### PR TITLE
Claude/fix governance catalog conflict 01 un bs3 lt519 u nv p vx ab s rj1

### DIFF
--- a/supabase/migrations/20251203000000_governance_catalog_init.sql
+++ b/supabase/migrations/20251203000000_governance_catalog_init.sql
@@ -1,8 +1,8 @@
 -- ============================================================
 -- GOVERNANCE CATALOG INITIALIZATION
--- VTID: VTID-0400, VTID-0402 (ON CONFLICT fix)
+-- VTID: VTID-0400, VTID-0402, VTID-0403 (constraint fix in separate migration)
 -- Purpose: Initialize governance catalog and seed rules from codebase
--- Fix: Changed partial unique index to proper UNIQUE constraint for ON CONFLICT
+-- Note: The rule_id UNIQUE constraint is now created by 20251207000000_fix_governance_rules_rule_id_constraint.sql
 -- ============================================================
 
 -- 1. Create governance_catalog table for versioned catalog metadata

--- a/supabase/migrations/20251207000000_fix_governance_rules_rule_id_constraint.sql
+++ b/supabase/migrations/20251207000000_fix_governance_rules_rule_id_constraint.sql
@@ -1,0 +1,56 @@
+-- ============================================================
+-- VTID-0403: Fix governance_rules.rule_id ON CONFLICT support
+-- ============================================================
+-- Problem: The 20251203000000_governance_catalog_init.sql migration uses
+-- ON CONFLICT (rule_id) but only a plain INDEX existed, not a UNIQUE constraint.
+-- PostgreSQL requires a UNIQUE constraint (or unique index) for ON CONFLICT.
+--
+-- This migration:
+-- 1. Drops the stale idx_rules_rule_id index if it exists
+-- 2. Adds a proper UNIQUE constraint on rule_id
+-- ============================================================
+
+DO $$
+BEGIN
+    -- Drop old index if it still exists
+    IF EXISTS (
+        SELECT 1 FROM pg_class c
+        JOIN pg_namespace n ON n.oid = c.relnamespace
+        WHERE c.relname = 'idx_rules_rule_id'
+          AND n.nspname = 'public'
+    ) THEN
+        DROP INDEX IF EXISTS idx_rules_rule_id;
+        RAISE NOTICE 'Dropped stale index idx_rules_rule_id';
+    END IF;
+
+    -- Add unique constraint on governance_rules.rule_id if not present
+    IF NOT EXISTS (
+        SELECT 1
+        FROM pg_constraint
+        WHERE conname = 'governance_rules_rule_id_key'
+          AND conrelid = 'governance_rules'::regclass
+    ) THEN
+        ALTER TABLE governance_rules
+            ADD CONSTRAINT governance_rules_rule_id_key UNIQUE (rule_id);
+        RAISE NOTICE 'Added UNIQUE constraint governance_rules_rule_id_key on rule_id';
+    ELSE
+        RAISE NOTICE 'Constraint governance_rules_rule_id_key already exists';
+    END IF;
+END $$;
+
+-- Log the fix to OASIS
+DO $$
+BEGIN
+    IF EXISTS (SELECT 1 FROM information_schema.tables WHERE table_name = 'oasis_events_v1') THEN
+        INSERT INTO oasis_events_v1 (tenant, service, vtid, topic, status, notes, metadata)
+        VALUES (
+            'SYSTEM',
+            'governance-catalog',
+            'VTID-0403',
+            'GOVERNANCE_RULE_ID_CONSTRAINT_FIXED',
+            'success',
+            'Fixed governance_rules.rule_id to have UNIQUE constraint for ON CONFLICT support',
+            '{"fix": "replaced plain index with UNIQUE constraint", "constraint_name": "governance_rules_rule_id_key"}'::jsonb
+        );
+    END IF;
+END $$;


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `DEV-XXXX-NNNN` _(replace with actual VTID)_

**Layer:** _(e.g., CICDL, APIL, AGTL, UIUX)_

**Priority:** _(P0, P1, P2, P3)_

---

## 📋 Summary

_Brief description of what this PR accomplishes._

---

## ✅ Changes

- [ ] Item 1
- [ ] Item 2
- [ ] Item 3

---

## 🧪 Testing

_How was this tested?_

- [ ] Manual testing completed
- [ ] Automated tests added/updated
- [ ] Verified in staging/dev environment

---

## 📝 Phase 2B Naming Compliance Checklist

**All items must be checked before merging:**

### GitHub Actions
- [ ] All workflow files use **UPPERCASE** names (e.g., `DEPLOY-GATEWAY.yml`, not `deploy-gateway.yml`)
- [ ] All workflows include `run-name` with VTID
- [ ] No lowercase workflow names present

### File Names
- [ ] All new files follow **kebab-case** convention (e.g., `my-service.ts`, not `myService.ts` or `my_service.ts`)
- [ ] Directory names use **kebab-case**
- [ ] No files violate naming canon

### Code Standards
- [ ] VTID constants are in **UPPERCASE** (e.g., `const VTID = 'DEV-CICDL-0031'`)
- [ ] Event types/kinds use **snake_case** (e.g., `workflow_run`, `task.init`)
- [ ] Status values use **lowercase** (e.g., `success`, `failure`, `in_progress`)

### Cloud Run Deployments
- [ ] All Cloud Run services include required labels:
  - `vtid`: Full VTID (e.g., `DEV-CICDL-0031`)
  - `vt_layer`: Layer code (e.g., `CICDL`)
  - `vt_module`: Module name (e.g., `GATEWAY`)
- [ ] Deploy scripts use `ensure-vtid.sh` guard

### Documentation
- [ ] VTID mentioned in commit messages
- [ ] Phase 2B compliance verified
- [ ] No non-compliant files introduced

---

## 🔗 Links

- **VTID Tracker:** [Link if applicable]
- **Related PRs:** [List related PRs]
- **Documentation:** [Link to docs]

---

## 🚨 Breaking Changes

_List any breaking changes, or write "None"_

---

## 📸 Screenshots (if applicable)

_Add screenshots or recordings demonstrating the changes_

---

## 👀 Reviewers

@[username] - Required review

---

## 📌 Additional Notes

_Any other context or information for reviewers_
