### PR TITLE
fix(VTID-0529-C): add runtime debug endpoint for bundle verification

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -1,5 +1,6 @@
 ﻿import express from 'express';
 import path from 'path';
+import fs from 'fs';
 import boardAdapter from "./routes/board-adapter";
 import { commandhub } from "./routes/commandhub";
 import cors from 'cors';
@@ -66,6 +67,61 @@ app.get('/debug/vtid-0524', (_req, res) => {
   });
 });
 
+// VTID-0529-C: Diagnostic endpoint to verify Command Hub bundle at runtime
+app.get('/debug/vtid-0529', (_req, res) => {
+  const staticPath = path.join(__dirname, 'frontend/command-hub');
+  let files: string[] = [];
+  let appJsPreview = '';
+  let stylesPreview = '';
+  let error = '';
+
+  try {
+    if (fs.existsSync(staticPath)) {
+      files = fs.readdirSync(staticPath);
+
+      // Read first 5 lines of app.js to check fingerprint
+      const appJsPath = path.join(staticPath, 'app.js');
+      if (fs.existsSync(appJsPath)) {
+        const content = fs.readFileSync(appJsPath, 'utf-8');
+        appJsPreview = content.split('\n').slice(0, 5).join('\n');
+      }
+
+      // Check styles.css for fingerprint CSS
+      const stylesPath = path.join(staticPath, 'styles.css');
+      if (fs.existsSync(stylesPath)) {
+        const content = fs.readFileSync(stylesPath, 'utf-8');
+        const lines = content.split('\n');
+        const idx = lines.findIndex(l => l.includes('VTID-0529'));
+        if (idx >= 0) {
+          stylesPreview = lines.slice(idx, idx + 3).join('\n');
+        } else {
+          stylesPreview = 'VTID-0529 fingerprint CSS NOT FOUND';
+        }
+      }
+    } else {
+      error = 'Static path does not exist!';
+    }
+  } catch (e: any) {
+    error = e.message;
+  }
+
+  res.json({
+    ok: !error,
+    vtid: 'VTID-0529-C',
+    description: 'Command Hub Bundle Verification',
+    runtime: {
+      __dirname,
+      staticPath,
+      staticPathExists: fs.existsSync(staticPath),
+      files,
+      appJsPreview,
+      stylesPreview
+    },
+    error: error || undefined,
+    timestamp: new Date().toISOString()
+  });
+});
+
 // Mount routes
 app.use('/api/v1/governance', governanceRouter); // DEV-GOVBE-0106: Governance endpoints
 app.use('/api/v1/vtid', vtidRouter);
@@ -90,17 +146,24 @@ app.use("/", tasksRouter);
 app.use(eventsApiRouter);
 app.use(eventsRouter);
 app.use(oasisTasksRouter); // OASIS Tasks API
+
+// VTID-0529-C: Static files MUST be served BEFORE the router
+// Otherwise, router's catch-all /* intercepts static file requests
+// and next() doesn't properly reach express.static mounted at the same path.
+const staticPath = path.join(__dirname, 'frontend/command-hub');
+app.use('/command-hub', express.static(staticPath, {
+  // Disable caching during debugging - remove in production if needed
+  etag: false,
+  lastModified: false,
+  setHeaders: (res) => {
+    res.setHeader('Cache-Control', 'no-cache, no-store, must-revalidate');
+  }
+}));
+
+// Command Hub router handles HTML routes and API (after static files)
 app.use('/command-hub', commandHubRouter);
 app.use(sseService.router);
 app.use('/api/v1/board', boardAdapter); // Board adapter for v1 API
-
-// VTID-0529-B: Single source of truth for Command Hub SPA.
-// Build must write to dist/frontend/command-hub.
-// At runtime, /command-hub/ is served from path.join(__dirname, 'frontend/command-hub')
-// which resolves to dist/frontend/command-hub/ after TypeScript compilation.
-// The bundle fingerprint "VTID-0529-B – LIVE BUNDLE" banner and console log must be visible after deploy.
-const staticPath = path.join(__dirname, 'frontend/command-hub');
-app.use('/command-hub', express.static(staticPath));
 
 // Start server
 if (process.env.NODE_ENV === 'test') {


### PR DESCRIPTION
Add /debug/vtid-0529 endpoint that reveals at runtime:
- __dirname value
- Computed static path
- Whether the path exists
- Files in the directory
- First 5 lines of app.js (to verify fingerprint)
- VTID-0529 CSS fingerprint presence

CRITICAL FIX: Move express.static BEFORE commandHubRouter
- Previously: router's /* catch-all intercepted static file requests
- router called next() but it didn't reach express.static properly
- Now: static files served directly, router only handles HTML routes

Also added cache-busting headers to force browser to reload assets.

## 🎯 VTID Reference

**VTID:** `DEV-XXXX-NNNN` _(replace with actual VTID)_

**Layer:** _(e.g., CICDL, APIL, AGTL, UIUX)_

**Priority:** _(P0, P1, P2, P3)_

---

## 📋 Summary

_Brief description of what this PR accomplishes._

---

## ✅ Changes

- [ ] Item 1
- [ ] Item 2
- [ ] Item 3

---

## 🧪 Testing

_How was this tested?_

- [ ] Manual testing completed
- [ ] Automated tests added/updated
- [ ] Verified in staging/dev environment

---

## 📝 Phase 2B Naming Compliance Checklist

**All items must be checked before merging:**

### GitHub Actions
- [ ] All workflow files use **UPPERCASE** names (e.g., `DEPLOY-GATEWAY.yml`, not `deploy-gateway.yml`)
- [ ] All workflows include `run-name` with VTID
- [ ] No lowercase workflow names present

### File Names
- [ ] All new files follow **kebab-case** convention (e.g., `my-service.ts`, not `myService.ts` or `my_service.ts`)
- [ ] Directory names use **kebab-case**
- [ ] No files violate naming canon

### Code Standards
- [ ] VTID constants are in **UPPERCASE** (e.g., `const VTID = 'DEV-CICDL-0031'`)
- [ ] Event types/kinds use **snake_case** (e.g., `workflow_run`, `task.init`)
- [ ] Status values use **lowercase** (e.g., `success`, `failure`, `in_progress`)

### Cloud Run Deployments
- [ ] All Cloud Run services include required labels:
  - `vtid`: Full VTID (e.g., `DEV-CICDL-0031`)
  - `vt_layer`: Layer code (e.g., `CICDL`)
  - `vt_module`: Module name (e.g., `GATEWAY`)
- [ ] Deploy scripts use `ensure-vtid.sh` guard

### Documentation
- [ ] VTID mentioned in commit messages
- [ ] Phase 2B compliance verified
- [ ] No non-compliant files introduced

---

## 🔗 Links

- **VTID Tracker:** [Link if applicable]
- **Related PRs:** [List related PRs]
- **Documentation:** [Link to docs]

---

## 🚨 Breaking Changes

_List any breaking changes, or write "None"_

---

## 📸 Screenshots (if applicable)

_Add screenshots or recordings demonstrating the changes_

---

## 👀 Reviewers

@[username] - Required review

---

## 📌 Additional Notes

_Any other context or information for reviewers_
