### PR TITLE
fix(VTID-0527-B): stageTimeline always returns 4 entries

### DIFF
--- a/services/gateway/src/lib/stage-mapping.ts
+++ b/services/gateway/src/lib/stage-mapping.ts
@@ -140,9 +140,23 @@ export type StageStatus = 'PENDING' | 'RUNNING' | 'COMPLETED' | 'ERROR';
 export interface StageTimelineEntry {
   stage: TaskStage;
   status: StageStatus;
-  startedAt?: string;
-  completedAt?: string;
-  errorAt?: string;
+  startedAt?: string | null;
+  completedAt?: string | null;
+  errorAt?: string | null;
+}
+
+/**
+ * VTID-0527-B: Return default stage timeline with all stages PENDING.
+ * Used as fallback when no events are found.
+ */
+export function defaultStageTimeline(): StageTimelineEntry[] {
+  return VALID_STAGES.map((stage): StageTimelineEntry => ({
+    stage,
+    status: 'PENDING',
+    startedAt: null,
+    completedAt: null,
+    errorAt: null,
+  }));
 }
 
 /**


### PR DESCRIPTION
Ensures /api/v1/vtid/:vtid always returns a 4-entry stageTimeline and never null, with default PENDING stages and event-based overrides.