### PR TITLE
fix(VTID-0538-D): Fix Gateway build artifact to include knowledge routes

### DIFF
--- a/services/gateway/package.json
+++ b/services/gateway/package.json
@@ -5,6 +5,7 @@
   "main": "dist/index.js",
   "scripts": {
     "dev": "tsx watch src/index.ts",
+    "prebuild": "rm -rf dist",
     "build": "tsc && npm run copy-frontend",
     "copy-frontend": "mkdir -p dist/frontend/command-hub && cp -r src/frontend/command-hub/* dist/frontend/command-hub/",
     "start": "node dist/index.js",

--- a/services/gateway/src/routes/assistant.ts
+++ b/services/gateway/src/routes/assistant.ts
@@ -434,7 +434,12 @@ router.get('/health', (_req: Request, res: Response) => {
     ok: true,
     service: 'assistant-core',
     vtids: ['VTID-0150-B', 'VTID-0151', 'VTID-0538'],
+    buildFix: 'VTID-0538-D',
     capabilities: ['chat', 'live-session', 'frame-processing', 'audio-processing', 'knowledge-search'],
+    knowledgeRoutes: {
+      search: '/knowledge/search',
+      health: '/knowledge/health'
+    },
     gemini_configured: !!process.env.GOOGLE_GEMINI_API_KEY,
     timestamp: new Date().toISOString()
   });


### PR DESCRIPTION
Root cause: Build script lacked cleanup step, allowing stale compiled JS files to persist and shadow updated assistant routes.

Changes:
- Add prebuild script (rm -rf dist) to ensure clean build output
- Add /debug/vtid-0538-routes diagnostic endpoint for runtime verification
- Update assistant health endpoint with build verification info

This ensures knowledge routes at /api/v1/assistant/knowledge/* are included in deployed Gateway container.

## 🎯 VTID Reference

**VTID:** `DEV-XXXX-NNNN` _(replace with actual VTID)_

**Layer:** _(e.g., CICDL, APIL, AGTL, UIUX)_

**Priority:** _(P0, P1, P2, P3)_

---

## 📋 Summary

_Brief description of what this PR accomplishes._

---

## ✅ Changes

- [ ] Item 1
- [ ] Item 2
- [ ] Item 3

---

## 🧪 Testing

_How was this tested?_

- [ ] Manual testing completed
- [ ] Automated tests added/updated
- [ ] Verified in staging/dev environment

---

## 📝 Phase 2B Naming Compliance Checklist

**All items must be checked before merging:**

### GitHub Actions
- [ ] All workflow files use **UPPERCASE** names (e.g., `DEPLOY-GATEWAY.yml`, not `deploy-gateway.yml`)
- [ ] All workflows include `run-name` with VTID
- [ ] No lowercase workflow names present

### File Names
- [ ] All new files follow **kebab-case** convention (e.g., `my-service.ts`, not `myService.ts` or `my_service.ts`)
- [ ] Directory names use **kebab-case**
- [ ] No files violate naming canon

### Code Standards
- [ ] VTID constants are in **UPPERCASE** (e.g., `const VTID = 'DEV-CICDL-0031'`)
- [ ] Event types/kinds use **snake_case** (e.g., `workflow_run`, `task.init`)
- [ ] Status values use **lowercase** (e.g., `success`, `failure`, `in_progress`)

### Cloud Run Deployments
- [ ] All Cloud Run services include required labels:
  - `vtid`: Full VTID (e.g., `DEV-CICDL-0031`)
  - `vt_layer`: Layer code (e.g., `CICDL`)
  - `vt_module`: Module name (e.g., `GATEWAY`)
- [ ] Deploy scripts use `ensure-vtid.sh` guard

### Documentation
- [ ] VTID mentioned in commit messages
- [ ] Phase 2B compliance verified
- [ ] No non-compliant files introduced

---

## 🔗 Links

- **VTID Tracker:** [Link if applicable]
- **Related PRs:** [List related PRs]
- **Documentation:** [Link to docs]

---

## 🚨 Breaking Changes

_List any breaking changes, or write "None"_

---

## 📸 Screenshots (if applicable)

_Add screenshots or recordings demonstrating the changes_

---

## 👀 Reviewers

@[username] - Required review

---

## 📌 Additional Notes

_Any other context or information for reviewers_
