### PR TITLE
Claude/align oasis cicd 2 bpq i

### DIFF
--- a/services/gateway/src/routes/operator.ts
+++ b/services/gateway/src/routes/operator.ts
@@ -916,26 +916,13 @@ router.post('/repair/vtid-0540', async (req: Request, res: Response) => {
     } else {
       // Step 2: Create VTID-0540 entry
       const vtid0540Entry = {
-        id: randomUUID(),
         vtid: 'VTID-0540',
-        task_family: 'DEV',
-        task_module: 'GW',
+        title: 'Gemini Vertex ADC Health Gate Fix',
+        summary: 'Updated assistant routes health check to verify Vertex AI configuration. Retroactively registered by VTID-0541.',
         layer: 'DEV',
         module: 'GW',
-        title: 'Gemini Vertex ADC Health Gate Fix',
-        description_md: 'Updated assistant routes health check to verify Vertex AI configuration instead of GOOGLE_GEMINI_API_KEY. Retroactively registered by VTID-0541.',
         status: 'deployed',
-        tenant: 'vitana',
-        is_test: false,
-        metadata: {
-          created_by: 'system.repair',
-          repair_vtid: 'VTID-0541',
-          result: 'deployed',
-          layer: 'DEV',
-          note: 'Retroactively registered by VTID-0541'
-        },
-        created_at: '2025-12-15T10:00:00.000Z',
-        updated_at: timestamp
+        metadata: { repair_vtid: 'VTID-0541', note: 'Retroactively registered' }
       };
 
       const insertResp = await fetch(`${SUPABASE_URL}/rest/v1/vtid_ledger`, {


### PR DESCRIPTION
## 🎯 VTID Reference

**VTID:** `DEV-XXXX-NNNN` _(replace with actual VTID)_

**Layer:** _(e.g., CICDL, APIL, AGTL, UIUX)_

**Priority:** _(P0, P1, P2, P3)_

---

## 📋 Summary

_Brief description of what this PR accomplishes._

---

## ✅ Changes

- [ ] Item 1
- [ ] Item 2
- [ ] Item 3

---

## 🧪 Testing

_How was this tested?_

- [ ] Manual testing completed
- [ ] Automated tests added/updated
- [ ] Verified in staging/dev environment

---

## 📝 Phase 2B Naming Compliance Checklist

**All items must be checked before merging:**

### GitHub Actions
- [ ] All workflow files use **UPPERCASE** names (e.g., `DEPLOY-GATEWAY.yml`, not `deploy-gateway.yml`)
- [ ] All workflows include `run-name` with VTID
- [ ] No lowercase workflow names present

### File Names
- [ ] All new files follow **kebab-case** convention (e.g., `my-service.ts`, not `myService.ts` or `my_service.ts`)
- [ ] Directory names use **kebab-case**
- [ ] No files violate naming canon

### Code Standards
- [ ] VTID constants are in **UPPERCASE** (e.g., `const VTID = 'DEV-CICDL-0031'`)
- [ ] Event types/kinds use **snake_case** (e.g., `workflow_run`, `task.init`)
- [ ] Status values use **lowercase** (e.g., `success`, `failure`, `in_progress`)

### Cloud Run Deployments
- [ ] All Cloud Run services include required labels:
  - `vtid`: Full VTID (e.g., `DEV-CICDL-0031`)
  - `vt_layer`: Layer code (e.g., `CICDL`)
  - `vt_module`: Module name (e.g., `GATEWAY`)
- [ ] Deploy scripts use `ensure-vtid.sh` guard

### Documentation
- [ ] VTID mentioned in commit messages
- [ ] Phase 2B compliance verified
- [ ] No non-compliant files introduced

---

## 🔗 Links

- **VTID Tracker:** [Link if applicable]
- **Related PRs:** [List related PRs]
- **Documentation:** [Link to docs]

---

## 🚨 Breaking Changes

_List any breaking changes, or write "None"_

---

## 📸 Screenshots (if applicable)

_Add screenshots or recordings demonstrating the changes_

---

## 👀 Reviewers

@[username] - Required review

---

## 📌 Additional Notes

_Any other context or information for reviewers_
