### PR TITLE
DEV-CICDL-2025-0004 Clean EXEC-DEPLOY gateway allocator env injection

### DIFF
--- a/.github/workflows/EXEC-DEPLOY.yml
+++ b/.github/workflows/EXEC-DEPLOY.yml
@@ -241,35 +241,22 @@ jobs:
           esac
 
           echo "Deploying $CLOUD_RUN_SERVICE from $SOURCE_PATH"
-
-          # Source deploy (builds container from source)
+            # Source deploy (builds container from source)
             # VTID allocator enablement (gateway-only)
             EXTRA_ENV_ARGS=()
-            if [ \"$CLOUD_RUN_SERVICE\" = \"gateway\" ]; then
-              EXTRA_ENV_ARGS+=(--update-env-vars=\"VTID_ALLOCATOR_ENABLED=true\")
+            if [ "$CLOUD_RUN_SERVICE" = "gateway" ]; then
+              EXTRA_ENV_ARGS+=(--update-env-vars=VTID_ALLOCATOR_ENABLED=true)
             fi
 
-          # DEV-CICDL-2025-0003: Gateway-specific env var injection for VTID allocator
-          if [ "$CLOUD_RUN_SERVICE" = "gateway" ]; then
-            echo "Enabling VTID allocator env flag on gateway"
             gcloud run deploy "$CLOUD_RUN_SERVICE" \
               --source="$SOURCE_PATH" \
               --region=us-central1 \
               --project=lovable-vitana-vers1 \
               --allow-unauthenticated \
-              --update-env-vars="VTID_ALLOCATOR_ENABLED=true" \
+              "${EXTRA_ENV_ARGS[@]}" \
               --quiet
-          else
-            gcloud run deploy "$CLOUD_RUN_SERVICE" \
-              --source="$SOURCE_PATH" \
-              --region=us-central1 \
-              --project=lovable-vitana-vers1 \
-              --allow-unauthenticated \
-              \"${EXTRA_ENV_ARGS[@]}\" \
-              --quiet
-          fi
 
-          # Get service URL
+            # Get service URL
           URL=$(gcloud run services describe "$CLOUD_RUN_SERVICE" --region=us-central1 --format='value(status.url)')
           echo "service_url=$URL" >> $GITHUB_OUTPUT
           echo "cloud_run_service=$CLOUD_RUN_SERVICE" >> $GITHUB_OUTPUT


### PR DESCRIPTION
Replace broken/duplicated deploy logic with a single canonical gcloud deploy command that injects VTID_ALLOCATOR_ENABLED=true only for gateway.