### PR TITLE
DEV-CICDL-2025-0007 Fix allocator migration - add vtid_ledger table

### DIFF
--- a/supabase/migrations/20251219000000_vtid_0542_global_allocator.sql
+++ b/supabase/migrations/20251219000000_vtid_0542_global_allocator.sql
@@ -9,6 +9,44 @@
 -- 4. Returns allocated VTID info
 
 -- ===========================================================================
+-- Ensure vtid_ledger table exists (required for allocator function)
+-- ===========================================================================
+
+CREATE TABLE IF NOT EXISTS vtid_ledger (
+    id TEXT PRIMARY KEY DEFAULT gen_random_uuid()::TEXT,
+    vtid TEXT UNIQUE NOT NULL,
+    title TEXT NOT NULL DEFAULT '',
+    status TEXT NOT NULL DEFAULT 'scheduled',
+    tenant TEXT NOT NULL DEFAULT 'vitana',
+    layer TEXT,
+    module TEXT,
+    task_family TEXT,
+    task_type TEXT,
+    summary TEXT DEFAULT '',
+    description TEXT DEFAULT '',
+    is_test BOOLEAN DEFAULT false,
+    metadata JSONB DEFAULT '{}',
+    assigned_to TEXT,
+    parent_vtid TEXT,
+    created_at TIMESTAMPTZ DEFAULT NOW(),
+    updated_at TIMESTAMPTZ DEFAULT NOW()
+);
+
+-- Create indexes if they don't exist
+CREATE INDEX IF NOT EXISTS idx_vtid_ledger_vtid ON vtid_ledger(vtid);
+CREATE INDEX IF NOT EXISTS idx_vtid_ledger_status ON vtid_ledger(status);
+CREATE INDEX IF NOT EXISTS idx_vtid_ledger_created_at ON vtid_ledger(created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_vtid_ledger_tenant ON vtid_ledger(tenant);
+
+-- Grant permissions
+GRANT ALL ON vtid_ledger TO service_role;
+
+-- Enable RLS but allow service_role full access
+ALTER TABLE vtid_ledger ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS vtid_ledger_service_role_all ON vtid_ledger;
+CREATE POLICY vtid_ledger_service_role_all ON vtid_ledger FOR ALL TO service_role USING (true);
+
+-- ===========================================================================
 -- Ensure global VTID sequence exists (starts at 1000 for VTID-01000 format)
 -- ===========================================================================
 


### PR DESCRIPTION
Previous migration failed because vtid_ledger table didn't exist. Added CREATE TABLE IF NOT EXISTS with all required columns.

Also added:
- Indexes for common queries
- RLS policy for service_role access
- Proper permissions

This ensures the allocate_global_vtid function can be created since PostgreSQL validates table references during function creation.

## 🎯 VTID Reference

**VTID:** `DEV-XXXX-NNNN` _(replace with actual VTID)_

**Layer:** _(e.g., CICDL, APIL, AGTL, UIUX)_

**Priority:** _(P0, P1, P2, P3)_

---

## 📋 Summary

_Brief description of what this PR accomplishes._

---

## ✅ Changes

- [ ] Item 1
- [ ] Item 2
- [ ] Item 3

---

## 🧪 Testing

_How was this tested?_

- [ ] Manual testing completed
- [ ] Automated tests added/updated
- [ ] Verified in staging/dev environment

---

## 📝 Phase 2B Naming Compliance Checklist

**All items must be checked before merging:**

### GitHub Actions
- [ ] All workflow files use **UPPERCASE** names (e.g., `DEPLOY-GATEWAY.yml`, not `deploy-gateway.yml`)
- [ ] All workflows include `run-name` with VTID
- [ ] No lowercase workflow names present

### File Names
- [ ] All new files follow **kebab-case** convention (e.g., `my-service.ts`, not `myService.ts` or `my_service.ts`)
- [ ] Directory names use **kebab-case**
- [ ] No files violate naming canon

### Code Standards
- [ ] VTID constants are in **UPPERCASE** (e.g., `const VTID = 'DEV-CICDL-0031'`)
- [ ] Event types/kinds use **snake_case** (e.g., `workflow_run`, `task.init`)
- [ ] Status values use **lowercase** (e.g., `success`, `failure`, `in_progress`)

### Cloud Run Deployments
- [ ] All Cloud Run services include required labels:
  - `vtid`: Full VTID (e.g., `DEV-CICDL-0031`)
  - `vt_layer`: Layer code (e.g., `CICDL`)
  - `vt_module`: Module name (e.g., `GATEWAY`)
- [ ] Deploy scripts use `ensure-vtid.sh` guard

### Documentation
- [ ] VTID mentioned in commit messages
- [ ] Phase 2B compliance verified
- [ ] No non-compliant files introduced

---

## 🔗 Links

- **VTID Tracker:** [Link if applicable]
- **Related PRs:** [List related PRs]
- **Documentation:** [Link to docs]

---

## 🚨 Breaking Changes

_List any breaking changes, or write "None"_

---

## 📸 Screenshots (if applicable)

_Add screenshots or recordings demonstrating the changes_

---

## 👀 Reviewers

@[username] - Required review

---

## 📌 Additional Notes

_Any other context or information for reviewers_
