### PR TITLE
VTID-01005: Fix frontend to use OASIS-derived board endpoint

### DIFF
--- a/scripts/ci/command-hub-ownership-guard.js
+++ b/scripts/ci/command-hub-ownership-guard.js
@@ -24,7 +24,8 @@ const PROTECTED_PATH = 'services/gateway/src/frontend/command-hub/';
 //             Branch pattern: vtid-ledger-visibility (for claude/vtid-ledger-visibility-* branches)
 // VTID-01002: Global Dev UI Scroll Retention (polling-safe, permanent)
 // VTID-01003: Fix Create Task modal + add Task Spec field + drawer metadata formatting
-const ALLOWED_VTID_PATTERN = /DEV-COMHU-\d+|VTID-0302|VTID-0539|VTID-0541|VTID-0542|VTID-0600|VTID-0601|VTID-01001|VTID-01002|VTID-01003|global-vtid-allocator|vtid-ledger-visibility/i;
+// VTID-01005: Task Completion Authority & Board Sync (OASIS → Command Hub)
+const ALLOWED_VTID_PATTERN = /DEV-COMHU-\d+|VTID-0302|VTID-0539|VTID-0541|VTID-0542|VTID-0600|VTID-0601|VTID-01001|VTID-01002|VTID-01003|VTID-01005|global-vtid-allocator|vtid-ledger-visibility/i;
 
 function getChangedFiles() {
   try {


### PR DESCRIPTION
Root cause: Frontend was fetching from /api/v1/vtid/list (local ledger) instead of using the OASIS-derived /api/v1/commandhub/board endpoint.

Changes:
- fetchTasks() now calls /api/v1/commandhub/board for OASIS-derived data
- mapStatusToColumnWithOverride() prioritizes OASIS column over local status
- createTaskCard() uses is_terminal and terminal_outcome for status display
- Updated fingerprints to show "OASIS_EVENTS" and "Task Mgmt v2: OASIS"

Result: Board columns now derive from OASIS events (single source of truth). Tasks with terminal OASIS state will appear in COMPLETED column automatically.

## 🎯 VTID Reference

**VTID:** `DEV-XXXX-NNNN` _(replace with actual VTID)_

**Layer:** _(e.g., CICDL, APIL, AGTL, UIUX)_

**Priority:** _(P0, P1, P2, P3)_

---

## 📋 Summary

_Brief description of what this PR accomplishes._

---

## ✅ Changes

- [ ] Item 1
- [ ] Item 2
- [ ] Item 3

---

## 🧪 Testing

_How was this tested?_

- [ ] Manual testing completed
- [ ] Automated tests added/updated
- [ ] Verified in staging/dev environment

---

## 📝 Phase 2B Naming Compliance Checklist

**All items must be checked before merging:**

### GitHub Actions
- [ ] All workflow files use **UPPERCASE** names (e.g., `DEPLOY-GATEWAY.yml`, not `deploy-gateway.yml`)
- [ ] All workflows include `run-name` with VTID
- [ ] No lowercase workflow names present

### File Names
- [ ] All new files follow **kebab-case** convention (e.g., `my-service.ts`, not `myService.ts` or `my_service.ts`)
- [ ] Directory names use **kebab-case**
- [ ] No files violate naming canon

### Code Standards
- [ ] VTID constants are in **UPPERCASE** (e.g., `const VTID = 'DEV-CICDL-0031'`)
- [ ] Event types/kinds use **snake_case** (e.g., `workflow_run`, `task.init`)
- [ ] Status values use **lowercase** (e.g., `success`, `failure`, `in_progress`)

### Cloud Run Deployments
- [ ] All Cloud Run services include required labels:
  - `vtid`: Full VTID (e.g., `DEV-CICDL-0031`)
  - `vt_layer`: Layer code (e.g., `CICDL`)
  - `vt_module`: Module name (e.g., `GATEWAY`)
- [ ] Deploy scripts use `ensure-vtid.sh` guard

### Documentation
- [ ] VTID mentioned in commit messages
- [ ] Phase 2B compliance verified
- [ ] No non-compliant files introduced

---

## 🔗 Links

- **VTID Tracker:** [Link if applicable]
- **Related PRs:** [List related PRs]
- **Documentation:** [Link to docs]

---

## 🚨 Breaking Changes

_List any breaking changes, or write "None"_

---

## 📸 Screenshots (if applicable)

_Add screenshots or recordings demonstrating the changes_

---

## 👀 Reviewers

@[username] - Required review

---

## 📌 Additional Notes

_Any other context or information for reviewers_
