### PR TITLE
VTID-01007: Fix VTID format validation to accept 5-digit VTIDs

### DIFF
--- a/services/gateway/src/routes/cicd.ts
+++ b/services/gateway/src/routes/cicd.ts
@@ -978,9 +978,10 @@ router.post('/approvals/:id/deny', async (req: Request, res: Response) => {
 
     const prNumber = parseInt(prMatch[1], 10);
 
-    // VTID-0604: Validate body.vtid strictly - NO fallback extraction
+    // VTID-0604 + VTID-01007: Validate body.vtid strictly - NO fallback extraction
+    // Updated to accept 4-5 digit VTIDs (canonical format is VTID-##### from VTID-01000+)
     let vtid = 'UNKNOWN';
-    if (typeof rawVtid === 'string' && /^VTID-\d{4}$/.test(rawVtid.trim())) {
+    if (typeof rawVtid === 'string' && /^VTID-\d{4,5}$/.test(rawVtid.trim())) {
       vtid = rawVtid.trim().toUpperCase();
     }
 

--- a/services/gateway/src/routes/vtid.ts
+++ b/services/gateway/src/routes/vtid.ts
@@ -731,13 +731,13 @@ router.get("/projection", async (req: Request, res: Response) => {
 router.get("/:vtid", async (req: Request, res: Response) => {
   try {
     const { vtid } = req.params;
-    // VTID-0527-C: Accept both formats:
-    // - Simple: VTID-0516, VTID-0527-B
+    // VTID-0527-C + VTID-01007: Accept both formats with 4-5 digit support:
+    // - Simple: VTID-0516, VTID-01006, VTID-0527-B
     // - Complex: DEV-ABC-0001-0002
-    const VTID_REGEX = /^(VTID-\d{4}(-[A-Za-z0-9]+)?|[A-Z]+-[A-Z0-9]+-\d{4}-\d{4})$/;
+    const VTID_REGEX = /^(VTID-\d{4,5}(-[A-Za-z0-9]+)?|[A-Z]+-[A-Z0-9]+-\d{4}-\d{4})$/;
     if (!VTID_REGEX.test(vtid)) {
-      console.log(`[VTID-0527-C] Invalid VTID format: ${vtid}`);
-      return res.status(400).json({ error: "invalid_format", vtid, expected: "VTID-#### or XXX-YYY-####-####" });
+      console.log(`[VTID-01007] Invalid VTID format: ${vtid}`);
+      return res.status(400).json({ error: "invalid_format", vtid, expected: "VTID-#### or VTID-##### or XXX-YYY-####-####" });
     }
     const { supabaseUrl, svcKey } = getSupabaseConfig();
 

--- a/services/gateway/src/services/gemini-operator.ts
+++ b/services/gateway/src/services/gemini-operator.ts
@@ -520,11 +520,12 @@ async function executeGetStatus(
   console.log(`[VTID-0536] get_status called for: ${args.vtid}`);
 
   // Step 1: Validate VTID format
-  const vtidRegex = /^(VTID-\d{4}(-[A-Za-z0-9]+)?|[A-Z]+-[A-Z0-9]+-\d{4}-\d{4})$/;
+  // VTID-01007: Accept 4-5 digit VTIDs (canonical format is VTID-##### from VTID-01000+)
+  const vtidRegex = /^(VTID-\d{4,5}(-[A-Za-z0-9]+)?|[A-Z]+-[A-Z0-9]+-\d{4}-\d{4})$/;
   if (!vtidRegex.test(args.vtid)) {
     return {
       ok: false,
-      error: `Invalid VTID format: ${args.vtid}. Expected format like VTID-0533 or DEV-COMHU-2024-0001`
+      error: `Invalid VTID format: ${args.vtid}. Expected format like VTID-0533, VTID-01006 or DEV-COMHU-2024-0001`
     };
   }
 
@@ -1115,13 +1116,14 @@ async function processLocalRouting(text: string, threadId: string): Promise<Gemi
   }
 
   // Detect status requests
+  // VTID-01007: Updated to match 4-5 digit VTIDs
   else if (
     lowerText.includes('status') ||
     lowerText.match(/what.*vtid/i) ||
-    lowerText.match(/vtid-\d{4}/i)
+    lowerText.match(/vtid-\d{4,5}/i)
   ) {
-    // Extract VTID
-    const vtidMatch = text.match(/VTID-\d{4}/i);
+    // Extract VTID (supports 4-5 digit formats)
+    const vtidMatch = text.match(/VTID-\d{4,5}/i);
     if (vtidMatch) {
       const result = await executeTool('autopilot_get_status', { vtid: vtidMatch[0].toUpperCase() }, threadId);
       toolResults.push({

--- a/services/gateway/src/types/operator-chat.ts
+++ b/services/gateway/src/types/operator-chat.ts
@@ -118,9 +118,10 @@ export interface OperatorChatEventPayload {
 // ==================== VTID Validation ====================
 
 /**
- * VTID format regex - matches patterns like VTID-0516, VTID-0527-B, DEV-ABC-0001-0002
+ * VTID format regex - matches patterns like VTID-0516, VTID-01006, VTID-0527-B, DEV-ABC-0001-0002
+ * VTID-01007: Updated to accept 4-5 digit VTIDs (canonical format is VTID-##### from VTID-01000+)
  */
-export const VTID_REGEX = /^(VTID-\d{4}(-[A-Za-z0-9]+)?|[A-Z]+-[A-Z0-9]+-\d{4}-\d{4})$/;
+export const VTID_REGEX = /^(VTID-\d{4,5}(-[A-Za-z0-9]+)?|[A-Z]+-[A-Z0-9]+-\d{4}-\d{4})$/;
 
 /**
  * Validate VTID format

--- a/services/oasis-projector/src/ledger-writer.ts
+++ b/services/oasis-projector/src/ledger-writer.ts
@@ -400,8 +400,9 @@ export class LedgerWriter {
     }
 
     // Check message for VTID pattern
+    // VTID-01007: Updated to match 4-5 digit VTIDs (canonical format is VTID-##### from VTID-01000+)
     if (event.message) {
-      const match = event.message.match(/VTID-\d{4}(-\d+)?/);
+      const match = event.message.match(/VTID-\d{4,5}(-\d+)?/);
       if (match) {
         return match[0];
       }
@@ -412,10 +413,11 @@ export class LedgerWriter {
 
   /**
    * Validate VTID format
+   * VTID-01007: Updated to accept 4-5 digit VTIDs (canonical format is VTID-##### from VTID-01000+)
    */
   private isValidVtid(vtid: string): boolean {
-    // Matches patterns like: VTID-0521, VTID-2025-0001, DEV-OASIS-0010
-    return /^[A-Z]+-[A-Z0-9]+-?\d+$/i.test(vtid) || /^VTID-\d{4}(-\d+)?$/i.test(vtid);
+    // Matches patterns like: VTID-0521, VTID-01006, VTID-2025-0001, DEV-OASIS-0010
+    return /^[A-Z]+-[A-Z0-9]+-?\d+$/i.test(vtid) || /^VTID-\d{4,5}(-\d+)?$/i.test(vtid);
   }
 
   /**


### PR DESCRIPTION
Update VTID validation regex patterns across the gateway and oasis-projector services to accept the new canonical 5-digit VTID format (VTID-##### starting from VTID-01000) while maintaining backwards compatibility with 4-digit VTIDs.

Files changed:
- services/gateway/src/routes/vtid.ts: Main VTID GET endpoint validation
- services/gateway/src/types/operator-chat.ts: Exported VTID_REGEX constant
- services/gateway/src/routes/cicd.ts: CICD approval denial endpoint
- services/gateway/src/services/gemini-operator.ts: Operator tool validation
- services/oasis-projector/src/ledger-writer.ts: Ledger VTID extraction/validation

Validation now accepts:
- VTID-01000 to VTID-99999 (5-digit, canonical format)
- VTID-0000 to VTID-9999 (4-digit, legacy format)
- DEV-XXX-####-#### (complex module formats)
- VTID-####-X suffixed variants

## 🎯 VTID Reference

**VTID:** `DEV-XXXX-NNNN` _(replace with actual VTID)_

**Layer:** _(e.g., CICDL, APIL, AGTL, UIUX)_

**Priority:** _(P0, P1, P2, P3)_

---

## 📋 Summary

_Brief description of what this PR accomplishes._

---

## ✅ Changes

- [ ] Item 1
- [ ] Item 2
- [ ] Item 3

---

## 🧪 Testing

_How was this tested?_

- [ ] Manual testing completed
- [ ] Automated tests added/updated
- [ ] Verified in staging/dev environment

---

## 📝 Phase 2B Naming Compliance Checklist

**All items must be checked before merging:**

### GitHub Actions
- [ ] All workflow files use **UPPERCASE** names (e.g., `DEPLOY-GATEWAY.yml`, not `deploy-gateway.yml`)
- [ ] All workflows include `run-name` with VTID
- [ ] No lowercase workflow names present

### File Names
- [ ] All new files follow **kebab-case** convention (e.g., `my-service.ts`, not `myService.ts` or `my_service.ts`)
- [ ] Directory names use **kebab-case**
- [ ] No files violate naming canon

### Code Standards
- [ ] VTID constants are in **UPPERCASE** (e.g., `const VTID = 'DEV-CICDL-0031'`)
- [ ] Event types/kinds use **snake_case** (e.g., `workflow_run`, `task.init`)
- [ ] Status values use **lowercase** (e.g., `success`, `failure`, `in_progress`)

### Cloud Run Deployments
- [ ] All Cloud Run services include required labels:
  - `vtid`: Full VTID (e.g., `DEV-CICDL-0031`)
  - `vt_layer`: Layer code (e.g., `CICDL`)
  - `vt_module`: Module name (e.g., `GATEWAY`)
- [ ] Deploy scripts use `ensure-vtid.sh` guard

### Documentation
- [ ] VTID mentioned in commit messages
- [ ] Phase 2B compliance verified
- [ ] No non-compliant files introduced

---

## 🔗 Links

- **VTID Tracker:** [Link if applicable]
- **Related PRs:** [List related PRs]
- **Documentation:** [Link to docs]

---

## 🚨 Breaking Changes

_List any breaking changes, or write "None"_

---

## 📸 Screenshots (if applicable)

_Add screenshots or recordings demonstrating the changes_

---

## 👀 Reviewers

@[username] - Required review

---

## 📌 Additional Notes

_Any other context or information for reviewers_
