### PR TITLE
VTID-01042: Unified Language Selector for ORB STT + TTS

### DIFF
--- a/scripts/ci/command-hub-ownership-guard.js
+++ b/scripts/ci/command-hub-ownership-guard.js
@@ -49,7 +49,9 @@ const PROTECTED_PATH = 'services/gateway/src/frontend/command-hub/';
 //             Branch pattern: add-conversation-summary (for claude/add-conversation-summary-* branches)
 // VTID-01041: Editable Scheduled Card Title + Title Capture on ORB Create + Success Confirmation
 //             Branch pattern: editable-scheduled-card-title (for claude/editable-scheduled-card-title-* branches)
-const ALLOWED_VTID_PATTERN = /DEV-COMHU-\d+|VTID-0302|VTID-0539|VTID-0541|VTID-0542|VTID-0600|VTID-0601|VTID-01001|VTID-01002|VTID-01003|VTID-01005|VTID-01006|VTID-01009|VTID-01010|VTID-01012|VTID-01013|VTID-01014|VTID-01015|VTID-01016|VTID-01017|VTID-01019|VTID-01021|VTID-01022|VTID-01025|VTID-01027|VTID-01028|VTID-01030|VTID-01034|VTID-0135|VTID-01037|VTID-01038|VTID-01039|VTID-01041|global-vtid-allocator|vtid-ledger-visibility|add-conversation-summary|editable-scheduled-card-title/i;
+// VTID-01042: Unified Language Selector for ORB STT + TTS (coupled language setting)
+//             Branch pattern: unified-language-selector (for claude/unified-language-selector-* branches)
+const ALLOWED_VTID_PATTERN = /DEV-COMHU-\d+|VTID-0302|VTID-0539|VTID-0541|VTID-0542|VTID-0600|VTID-0601|VTID-01001|VTID-01002|VTID-01003|VTID-01005|VTID-01006|VTID-01009|VTID-01010|VTID-01012|VTID-01013|VTID-01014|VTID-01015|VTID-01016|VTID-01017|VTID-01019|VTID-01021|VTID-01022|VTID-01025|VTID-01027|VTID-01028|VTID-01030|VTID-01034|VTID-0135|VTID-01037|VTID-01038|VTID-01039|VTID-01041|VTID-01042|global-vtid-allocator|vtid-ledger-visibility|add-conversation-summary|editable-scheduled-card-title|unified-language-selector/i;
 
 function getChangedFiles() {
   try {

--- a/services/gateway/dist/frontend/command-hub/styles.css
+++ b/services/gateway/dist/frontend/command-hub/styles.css
@@ -4818,33 +4818,47 @@ body {
   opacity: 0.7;
 }
 
-/* VTID-01038: Voice Settings Row */
-.orb-voice-settings {
+/* VTID-01042: Unified Language Settings (replaces VTID-01038 Voice Settings) */
+.orb-lang-settings {
   position: absolute;
   bottom: 140px;
   left: 50%;
   transform: translateX(-50%);
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 12px;
-  padding: 8px 16px;
+  gap: 8px;
+  padding: 12px 16px;
   background: rgba(30, 40, 55, 0.8);
   border-radius: 8px;
   border: 1px solid var(--color-border);
 }
 
-.orb-voice-label {
+.orb-lang-label-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  width: 100%;
+}
+
+.orb-lang-label {
   font-size: 0.75rem;
-  font-weight: 500;
-  color: var(--color-text-secondary);
+  font-weight: 600;
+  color: var(--color-text-primary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
-.orb-voice-select {
-  min-width: 180px;
+.orb-lang-helper {
+  font-size: 0.7rem;
+  color: var(--color-text-secondary);
+  font-style: italic;
+}
+
+.orb-lang-select {
+  min-width: 200px;
   max-width: 280px;
-  padding: 6px 10px;
+  padding: 8px 12px;
   font-size: 0.875rem;
   color: var(--color-text-primary);
   background: var(--color-bg);
@@ -4854,38 +4868,23 @@ body {
   transition: border-color 0.2s ease;
 }
 
-.orb-voice-select:hover {
+.orb-lang-select:hover {
   border-color: var(--color-text-secondary);
 }
 
-.orb-voice-select:focus {
+.orb-lang-select:focus {
   outline: none;
   border-color: var(--color-primary);
 }
 
-.orb-voice-preview {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: var(--color-text-primary);
-  background: var(--color-bg);
-  border: 1px solid var(--color-border);
+.orb-lang-warning {
+  font-size: 0.75rem;
+  color: var(--color-warning, #f0a500);
+  text-align: center;
+  padding: 4px 8px;
+  background: rgba(240, 165, 0, 0.1);
   border-radius: 4px;
-  cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease;
-}
-
-.orb-voice-preview:hover {
-  background: rgba(255, 255, 255, 0.05);
-  border-color: var(--color-text-secondary);
-}
-
-.orb-voice-preview svg {
-  width: 16px;
-  height: 16px;
+  max-width: 280px;
 }
 
 /* Chat button in overlay - hidden per design, chat accessed via control */

--- a/services/gateway/src/frontend/command-hub/styles.css
+++ b/services/gateway/src/frontend/command-hub/styles.css
@@ -4818,33 +4818,47 @@ body {
   opacity: 0.7;
 }
 
-/* VTID-01038: Voice Settings Row */
-.orb-voice-settings {
+/* VTID-01042: Unified Language Settings (replaces VTID-01038 Voice Settings) */
+.orb-lang-settings {
   position: absolute;
   bottom: 140px;
   left: 50%;
   transform: translateX(-50%);
   display: flex;
+  flex-direction: column;
   align-items: center;
-  gap: 12px;
-  padding: 8px 16px;
+  gap: 8px;
+  padding: 12px 16px;
   background: rgba(30, 40, 55, 0.8);
   border-radius: 8px;
   border: 1px solid var(--color-border);
 }
 
-.orb-voice-label {
+.orb-lang-label-row {
+  display: flex;
+  align-items: baseline;
+  gap: 8px;
+  width: 100%;
+}
+
+.orb-lang-label {
   font-size: 0.75rem;
-  font-weight: 500;
-  color: var(--color-text-secondary);
+  font-weight: 600;
+  color: var(--color-text-primary);
   text-transform: uppercase;
   letter-spacing: 0.5px;
 }
 
-.orb-voice-select {
-  min-width: 180px;
+.orb-lang-helper {
+  font-size: 0.7rem;
+  color: var(--color-text-secondary);
+  font-style: italic;
+}
+
+.orb-lang-select {
+  min-width: 200px;
   max-width: 280px;
-  padding: 6px 10px;
+  padding: 8px 12px;
   font-size: 0.875rem;
   color: var(--color-text-primary);
   background: var(--color-bg);
@@ -4854,38 +4868,23 @@ body {
   transition: border-color 0.2s ease;
 }
 
-.orb-voice-select:hover {
+.orb-lang-select:hover {
   border-color: var(--color-text-secondary);
 }
 
-.orb-voice-select:focus {
+.orb-lang-select:focus {
   outline: none;
   border-color: var(--color-primary);
 }
 
-.orb-voice-preview {
-  display: flex;
-  align-items: center;
-  gap: 6px;
-  padding: 6px 12px;
-  font-size: 0.875rem;
-  font-weight: 500;
-  color: var(--color-text-primary);
-  background: var(--color-bg);
-  border: 1px solid var(--color-border);
+.orb-lang-warning {
+  font-size: 0.75rem;
+  color: var(--color-warning, #f0a500);
+  text-align: center;
+  padding: 4px 8px;
+  background: rgba(240, 165, 0, 0.1);
   border-radius: 4px;
-  cursor: pointer;
-  transition: background 0.2s ease, border-color 0.2s ease;
-}
-
-.orb-voice-preview:hover {
-  background: rgba(255, 255, 255, 0.05);
-  border-color: var(--color-text-secondary);
-}
-
-.orb-voice-preview svg {
-  width: 16px;
-  height: 16px;
+  max-width: 280px;
 }
 
 /* Chat button in overlay - hidden per design, chat accessed via control */


### PR DESCRIPTION
Replace misleading TTS-only voice dropdown with single Language selector that couples Speech Recognition (STT) and Voice Output (TTS) together.

Changes:
- Add unified Language dropdown with 6 supported languages: English (US), German, French, Spanish, Arabic, Chinese
- STT locale updates immediately when language changes
- TTS voice auto-selects best matching voice using quality scoring: exact locale match > language prefix match > quality indicators
- Persist settings via orb_lang (single source of truth) with backward-compatible keys (orb_stt_lang, orb_tts_lang, orb_tts_voice_uri)
- Migrate legacy orb_tts_voice key to new unified system
- Add fallback to English (US) with warning when language unsupported
- Display warning when no matching voice available on device
- Update CSS from .orb-voice-* to .orb-lang-* classes

Removes:
- Voice-only dropdown that implied TTS without STT coupling
- Preview button (voice picker hidden per spec)

## 🎯 VTID Reference

**VTID:** `DEV-XXXX-NNNN` _(replace with actual VTID)_

**Layer:** _(e.g., CICDL, APIL, AGTL, UIUX)_

**Priority:** _(P0, P1, P2, P3)_

---

## 📋 Summary

_Brief description of what this PR accomplishes._

---

## ✅ Changes

- [ ] Item 1
- [ ] Item 2
- [ ] Item 3

---

## 🧪 Testing

_How was this tested?_

- [ ] Manual testing completed
- [ ] Automated tests added/updated
- [ ] Verified in staging/dev environment

---

## 📝 Phase 2B Naming Compliance Checklist

**All items must be checked before merging:**

### GitHub Actions
- [ ] All workflow files use **UPPERCASE** names (e.g., `DEPLOY-GATEWAY.yml`, not `deploy-gateway.yml`)
- [ ] All workflows include `run-name` with VTID
- [ ] No lowercase workflow names present

### File Names
- [ ] All new files follow **kebab-case** convention (e.g., `my-service.ts`, not `myService.ts` or `my_service.ts`)
- [ ] Directory names use **kebab-case**
- [ ] No files violate naming canon

### Code Standards
- [ ] VTID constants are in **UPPERCASE** (e.g., `const VTID = 'DEV-CICDL-0031'`)
- [ ] Event types/kinds use **snake_case** (e.g., `workflow_run`, `task.init`)
- [ ] Status values use **lowercase** (e.g., `success`, `failure`, `in_progress`)

### Cloud Run Deployments
- [ ] All Cloud Run services include required labels:
  - `vtid`: Full VTID (e.g., `DEV-CICDL-0031`)
  - `vt_layer`: Layer code (e.g., `CICDL`)
  - `vt_module`: Module name (e.g., `GATEWAY`)
- [ ] Deploy scripts use `ensure-vtid.sh` guard

### Documentation
- [ ] VTID mentioned in commit messages
- [ ] Phase 2B compliance verified
- [ ] No non-compliant files introduced

---

## 🔗 Links

- **VTID Tracker:** [Link if applicable]
- **Related PRs:** [List related PRs]
- **Documentation:** [Link to docs]

---

## 🚨 Breaking Changes

_List any breaking changes, or write "None"_

---

## 📸 Screenshots (if applicable)

_Add screenshots or recordings demonstrating the changes_

---

## 👀 Reviewers

@[username] - Required review

---

## 📌 Additional Notes

_Any other context or information for reviewers_
