### PR TITLE
feat(navigator): VTID-NAV-02 — DB-backed catalog + Admin Navigator API

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -221,6 +221,10 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const adminTenantsRouter = require('./routes/admin-tenants').default;
   // Admin: Content Moderation
   const adminModerationRouter = require('./routes/admin-moderation').default;
+  // VTID-NAV-02: Admin Navigator — DB-backed catalog CRUD, simulate, coverage, telemetry
+  const adminNavigatorRouter = require('./routes/admin-navigator').default;
+  // VTID-NAV-02: Navigator catalog DB cache warmer (runs at boot)
+  const { warmNavCatalogCache } = require('./lib/nav-catalog-db');
   // Voice Feedback — Test user bug reports & UX improvement suggestions
   const voiceFeedbackRouter = require('./routes/voice-feedback').default;
   // VTID-01250: Autopilot Automations Engine — AP-XXXX registry, executor, wallet, sharing
@@ -561,6 +565,9 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   // Admin: Content Moderation
   mountRouterSync(app, '/api/v1/admin/moderation', adminModerationRouter, { owner: 'admin-moderation' });
 
+  // VTID-NAV-02: Admin Navigator — catalog/simulate/coverage/telemetry
+  mountRouterSync(app, '/api/v1/admin/navigator', adminNavigatorRouter, { owner: 'admin-navigator' });
+
   // VTID-01250: Autopilot Automations Engine — AP-XXXX registry, executor, wallet, sharing
   mountRouterSync(app, '/api/v1/automations', automationsRouter, { owner: 'automations' });
 
@@ -807,6 +814,14 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
         console.log('🧠 AI Personality config cache pre-warmed');
       } catch (error) {
         console.warn('⚠️ AI Personality cache warm failed (non-fatal, using defaults):', error);
+      }
+
+      // VTID-NAV-02: Pre-warm Navigator catalog DB cache + start periodic refresh
+      try {
+        warmNavCatalogCache();
+        console.log('🧭 Navigator catalog DB cache warming (VTID-NAV-02)');
+      } catch (error) {
+        console.warn('⚠️ Navigator catalog cache warm failed (non-fatal, using static fallback):', error);
       }
     });
   }

--- a/services/gateway/src/lib/nav-catalog-db.ts
+++ b/services/gateway/src/lib/nav-catalog-db.ts
@@ -1,0 +1,505 @@
+/**
+ * VTID-NAV-02: Navigator Catalog — DB cache layer
+ *
+ * Backs navigation-catalog.ts with a live Supabase-sourced catalog so
+ * Community Admin users can add/edit screens and trigger phrases without a
+ * gateway redeploy. The original static NAVIGATION_CATALOG constant remains
+ * as the compile-time fallback: if the DB is down or hasn't been loaded
+ * yet, the orb still routes correctly off the in-code data.
+ *
+ * Design notes
+ * ------------
+ * 1. searchCatalog() / lookupScreen() / entriesByCategory() stay SYNCHRONOUS.
+ *    They read from a module-level cache (Map<tenantKey, NavCatalogEntry[]>).
+ *    Background refreshCatalogCache() keeps the cache fresh. Consumers never
+ *    need to await the catalog.
+ *
+ * 2. The cache is keyed by tenant. Rows with tenant_id IS NULL form the
+ *    SHARED catalog (default for everybody). A row with a non-null tenant_id
+ *    and the same screen_id OVERRIDES the shared row for that tenant only.
+ *    getCatalogForTenant(tid) applies the override.
+ *
+ * 3. First cache fill is triggered from the gateway boot sequence via
+ *    warmNavCatalogCache(). It runs async; failures are logged and swallowed
+ *    because NAVIGATION_CATALOG is already serving requests.
+ *
+ * 4. After an admin write, the admin router calls invalidateNavCatalogCache()
+ *    so subsequent sessions pick up the edit immediately.
+ */
+
+import type { NavCatalogEntry, LangCode, NavCategory } from './navigation-catalog';
+import { NAVIGATION_CATALOG, getContent } from './navigation-catalog';
+import { getSupabase } from './supabase';
+
+// =============================================================================
+// Types (shape of the rows coming back from Supabase)
+// =============================================================================
+
+interface NavCatalogRow {
+  id: string;
+  screen_id: string;
+  tenant_id: string | null;
+  route: string;
+  category: string;
+  access: 'public' | 'authenticated';
+  anonymous_safe: boolean;
+  priority: number;
+  related_kb_topics: unknown;
+  context_rules: unknown;
+  override_triggers: unknown;
+  is_active: boolean;
+  created_at: string;
+  updated_at: string;
+  updated_by: string | null;
+}
+
+interface NavCatalogI18nRow {
+  catalog_id: string;
+  lang: string;
+  title: string;
+  description: string;
+  when_to_visit: string;
+  updated_at: string;
+}
+
+// An override trigger: exact-match phrase that forces this screen to win
+// scoring with synthetic high confidence, bypassing normal term matching.
+export interface OverrideTrigger {
+  lang: string;
+  phrase: string;
+  active: boolean;
+}
+
+// Context-rules JSONB shape. All optional; missing = no constraint.
+export interface NavContextRules {
+  exclude_on_routes?: string[];
+  require_goal_match?: string[];
+  boost_if_recent_topic?: string[];
+}
+
+// Extended catalog entry carrying the new rule fields. NavCatalogEntry
+// (the base type exported from navigation-catalog.ts) intentionally stays
+// backward compatible; the extra fields live here so scoring can see them
+// without breaking the 77 existing tests.
+export interface NavCatalogEntryWithRules extends NavCatalogEntry {
+  context_rules?: NavContextRules;
+  override_triggers?: OverrideTrigger[];
+  tenant_id?: string | null;
+  id?: string;
+}
+
+// =============================================================================
+// Cache
+// =============================================================================
+
+const SHARED_KEY = '__shared__';
+
+// Map from tenant key to the full merged catalog for that tenant.
+// Key "__shared__" holds the tenant_id=NULL entries; any other key holds
+// the shared catalog with that tenant's overrides applied.
+const catalogCache: Map<string, NavCatalogEntryWithRules[]> = new Map();
+
+// All raw rows the last refresh pulled, grouped by screen_id for fast admin
+// reads (/api/v1/admin/navigator/catalog/:screen_id).
+let allRowsById: Map<string, NavCatalogEntryWithRules> = new Map();
+
+let lastRefreshAt: number = 0;
+let refreshInFlight: Promise<void> | null = null;
+let dbLoadedAtLeastOnce: boolean = false;
+
+const REFRESH_INTERVAL_MS = 60_000;
+
+// =============================================================================
+// Public read API
+// =============================================================================
+
+/**
+ * Return the effective catalog for a given tenant, applying per-tenant
+ * overrides on top of the shared catalog. If the DB cache hasn't been
+ * populated yet, falls back to the compile-time NAVIGATION_CATALOG constant
+ * so the Navigator never goes dark.
+ */
+export function getCatalogForTenant(
+  tenantId: string | null | undefined
+): NavCatalogEntryWithRules[] {
+  if (!dbLoadedAtLeastOnce) {
+    return NAVIGATION_CATALOG as NavCatalogEntryWithRules[];
+  }
+
+  const shared = catalogCache.get(SHARED_KEY) || [];
+  if (!tenantId) return shared;
+
+  const override = catalogCache.get(tenantId);
+  if (!override || override.length === 0) return shared;
+
+  // Overlay: tenant rows win per screen_id. override already contains shared+delta
+  // (built inside refreshCatalogCache), so just return it.
+  return override;
+}
+
+/**
+ * Return a single catalog entry by its internal UUID (not screen_id).
+ * Used by the admin API audit / restore endpoints.
+ */
+export function getCatalogEntryById(id: string): NavCatalogEntryWithRules | null {
+  if (!dbLoadedAtLeastOnce) return null;
+  return allRowsById.get(id) || null;
+}
+
+/**
+ * Check every override_trigger on every entry in the tenant's effective
+ * catalog for an exact-match phrase in the requested language. Returns the
+ * first matching entry or null. Case-insensitive. Used by navigator-consult
+ * to short-circuit scoring when an admin has explicitly forced a mapping.
+ */
+export function findOverrideTriggerMatch(
+  utterance: string,
+  lang: LangCode,
+  tenantId: string | null | undefined
+): NavCatalogEntryWithRules | null {
+  const normalized = normalizePhrase(utterance);
+  if (!normalized) return null;
+  const entries = getCatalogForTenant(tenantId);
+  const langKey = (lang || 'en').slice(0, 2).toLowerCase();
+
+  for (const entry of entries) {
+    const triggers = entry.override_triggers || [];
+    for (const trig of triggers) {
+      if (!trig.active) continue;
+      const trigLang = (trig.lang || 'en').slice(0, 2).toLowerCase();
+      if (trigLang !== langKey) continue;
+      if (normalizePhrase(trig.phrase) === normalized) {
+        return entry;
+      }
+    }
+  }
+  return null;
+}
+
+function normalizePhrase(s: string): string {
+  if (!s) return '';
+  return s
+    .toLowerCase()
+    .replace(/[.,!?;:'"()[\]{}]+/g, ' ')
+    .replace(/\s+/g, ' ')
+    .trim();
+}
+
+export function isNavCatalogLoaded(): boolean {
+  return dbLoadedAtLeastOnce;
+}
+
+export function lastNavCatalogRefreshAt(): number {
+  return lastRefreshAt;
+}
+
+// =============================================================================
+// Refresh
+// =============================================================================
+
+/**
+ * Load every nav_catalog row + its i18n rows from Supabase and rebuild the
+ * tenant caches. Idempotent. Deduplicates concurrent callers so only one
+ * fetch is in flight at a time.
+ */
+export async function refreshNavCatalogCache(): Promise<void> {
+  if (refreshInFlight) return refreshInFlight;
+  refreshInFlight = (async () => {
+    const t0 = Date.now();
+    try {
+      const supabase = getSupabase();
+      if (!supabase) {
+        console.warn('[VTID-NAV-02] refreshNavCatalogCache: supabase client unavailable, keeping static fallback');
+        return;
+      }
+
+      const { data: rows, error: rowsErr } = await supabase
+        .from('nav_catalog')
+        .select(
+          'id, screen_id, tenant_id, route, category, access, anonymous_safe, priority, related_kb_topics, context_rules, override_triggers, is_active, created_at, updated_at, updated_by'
+        )
+        .eq('is_active', true);
+
+      if (rowsErr) {
+        console.warn(`[VTID-NAV-02] refreshNavCatalogCache rows error: ${rowsErr.message}`);
+        return;
+      }
+      if (!rows || rows.length === 0) {
+        // Table empty (not yet seeded). Keep static fallback.
+        console.log('[VTID-NAV-02] nav_catalog empty — using static NAVIGATION_CATALOG fallback');
+        return;
+      }
+
+      const catalogIds = (rows as NavCatalogRow[]).map(r => r.id);
+      const { data: i18nRows, error: i18nErr } = await supabase
+        .from('nav_catalog_i18n')
+        .select('catalog_id, lang, title, description, when_to_visit, updated_at')
+        .in('catalog_id', catalogIds);
+
+      if (i18nErr) {
+        console.warn(`[VTID-NAV-02] refreshNavCatalogCache i18n error: ${i18nErr.message}`);
+        return;
+      }
+
+      const byCatalogId: Map<string, Record<string, { title: string; description: string; when_to_visit: string }>> = new Map();
+      for (const r of (i18nRows as NavCatalogI18nRow[] | null) || []) {
+        if (!byCatalogId.has(r.catalog_id)) byCatalogId.set(r.catalog_id, {});
+        byCatalogId.get(r.catalog_id)![r.lang] = {
+          title: r.title,
+          description: r.description || '',
+          when_to_visit: r.when_to_visit || '',
+        };
+      }
+
+      // Build full entries and split by tenant.
+      const sharedBuilt: NavCatalogEntryWithRules[] = [];
+      const perTenantDelta: Map<string, NavCatalogEntryWithRules[]> = new Map();
+      const idMap: Map<string, NavCatalogEntryWithRules> = new Map();
+
+      for (const raw of rows as NavCatalogRow[]) {
+        const i18n = byCatalogId.get(raw.id) || {};
+        if (!i18n.en) {
+          // Every entry must have at least English. Skip malformed rows.
+          console.warn(`[VTID-NAV-02] skipping nav_catalog ${raw.screen_id} — no 'en' i18n row`);
+          continue;
+        }
+
+        const entry: NavCatalogEntryWithRules = {
+          id: raw.id,
+          screen_id: raw.screen_id,
+          route: raw.route,
+          category: raw.category as NavCatalogEntryWithRules['category'],
+          access: raw.access,
+          anonymous_safe: !!raw.anonymous_safe,
+          priority: raw.priority || 0,
+          related_kb_topics: Array.isArray(raw.related_kb_topics) ? raw.related_kb_topics as string[] : [],
+          i18n,
+          tenant_id: raw.tenant_id,
+          context_rules: (raw.context_rules || {}) as NavContextRules,
+          override_triggers: Array.isArray(raw.override_triggers) ? raw.override_triggers as OverrideTrigger[] : [],
+        };
+
+        idMap.set(raw.id, entry);
+
+        if (raw.tenant_id == null) {
+          sharedBuilt.push(entry);
+        } else {
+          if (!perTenantDelta.has(raw.tenant_id)) perTenantDelta.set(raw.tenant_id, []);
+          perTenantDelta.get(raw.tenant_id)!.push(entry);
+        }
+      }
+
+      // Rebuild cache: shared list + per-tenant merged lists.
+      catalogCache.clear();
+      catalogCache.set(SHARED_KEY, sharedBuilt);
+
+      for (const [tid, deltaList] of perTenantDelta.entries()) {
+        // Overlay: start with shared, replace any screen_id that has a tenant row.
+        const overrideMap = new Map<string, NavCatalogEntryWithRules>();
+        for (const e of deltaList) overrideMap.set(e.screen_id, e);
+        const merged = sharedBuilt.map(s => overrideMap.get(s.screen_id) || s);
+        // Also append tenant-only screen_ids that didn't exist in shared.
+        for (const e of deltaList) {
+          if (!sharedBuilt.find(s => s.screen_id === e.screen_id)) merged.push(e);
+        }
+        catalogCache.set(tid, merged);
+      }
+
+      allRowsById = idMap;
+      dbLoadedAtLeastOnce = true;
+      lastRefreshAt = Date.now();
+
+      console.log(
+        `[VTID-NAV-02] nav_catalog cache refreshed: ${sharedBuilt.length} shared + ${perTenantDelta.size} tenant overlay(s) in ${Date.now() - t0}ms`
+      );
+    } catch (err: any) {
+      console.warn(`[VTID-NAV-02] refreshNavCatalogCache exception: ${err.message}`);
+    } finally {
+      refreshInFlight = null;
+    }
+  })();
+  return refreshInFlight;
+}
+
+/**
+ * Trigger a cache refresh on the next read, force-flushing lastRefreshAt.
+ * Called by the admin API after a create/update/delete so the next orb
+ * session sees the edit without waiting for the 60s polling interval.
+ */
+export function invalidateNavCatalogCache(): void {
+  lastRefreshAt = 0;
+  // Fire-and-forget refresh so the caller (admin API) doesn't block.
+  refreshNavCatalogCache().catch(err => {
+    console.warn(`[VTID-NAV-02] background refresh after invalidate failed: ${err?.message}`);
+  });
+}
+
+/**
+ * Boot-time warmer. Call once from gateway startup.
+ * Kicks off an initial refresh and schedules a periodic refresh interval.
+ */
+export function warmNavCatalogCache(): void {
+  refreshNavCatalogCache().catch(err => {
+    console.warn(`[VTID-NAV-02] initial warm failed: ${err?.message}`);
+  });
+  setInterval(() => {
+    // Skip refresh if one happened very recently (e.g. admin invalidation).
+    if (Date.now() - lastRefreshAt < REFRESH_INTERVAL_MS - 5_000) return;
+    refreshNavCatalogCache().catch(err => {
+      console.warn(`[VTID-NAV-02] periodic refresh failed: ${err?.message}`);
+    });
+  }, REFRESH_INTERVAL_MS).unref?.();
+}
+
+// =============================================================================
+// Tenant-aware catalog scorer
+// =============================================================================
+//
+// IMPORTANT: this scoring body is an intentional copy of searchCatalog() in
+// navigation-catalog.ts. We duplicate it here so the DB-backed path can
+// score over a tenant-specific entry list without having to alter the static
+// file (which 77 navigator tests import directly). Any scoring change must
+// be mirrored in BOTH locations until we consolidate into a single scorer
+// after the DB path is proven. Keeping them in sync is the responsibility
+// of the engineer changing either side.
+// =============================================================================
+
+// Multilingual stopword set — exact mirror of navigation-catalog.ts's STOPWORDS.
+const SCORER_STOPWORDS = new Set<string>([
+  // English
+  'the', 'and', 'for', 'with', 'from', 'into', 'this', 'that', 'these', 'those',
+  'are', 'was', 'were', 'been', 'being', 'have', 'has', 'had', 'having',
+  'will', 'would', 'should', 'could', 'shall', 'may', 'might', 'must',
+  'can', 'cant', 'dont', 'doesnt', 'didnt', 'wont',
+  'who', 'what', 'when', 'where', 'why', 'how', 'which',
+  'you', 'your', 'yours', 'mine', 'our', 'ours', 'their', 'theirs',
+  'him', 'her', 'his', 'hers', 'its',
+  'all', 'any', 'some', 'one', 'two', 'too', 'also', 'just', 'only',
+  'now', 'then', 'than', 'there', 'here', 'about', 'over', 'under',
+  'want', 'wants', 'wanted', 'need', 'needs', 'needed', 'like', 'likes', 'liked',
+  'get', 'got', 'getting', 'take', 'taken', 'taking',
+  'show', 'shows', 'showed',
+  // German
+  'ich', 'mich', 'mir', 'mein', 'meine', 'meinen', 'meinem', 'meiner', 'meines',
+  'du', 'dich', 'dir', 'dein', 'deine', 'deinen',
+  'er', 'sie', 'es', 'ihn', 'ihm', 'ihr', 'ihre', 'ihren',
+  'wir', 'uns', 'unser', 'unsere',
+  'der', 'die', 'das', 'den', 'dem', 'des',
+  'ein', 'eine', 'einen', 'einem', 'einer', 'eines',
+  'und', 'oder', 'aber', 'doch', 'denn', 'weil', 'wenn', 'als', 'ob',
+  'ist', 'sind', 'war', 'waren', 'wird', 'werden', 'wurde', 'wurden',
+  'habe', 'hat', 'hatte', 'hatten', 'haben',
+  'kann', 'können', 'könnte', 'soll', 'sollte', 'müsste', 'müssen', 'darf',
+  'will', 'wollen', 'wollte', 'mag', 'möchte', 'möchten',
+  'wie', 'was', 'wer', 'wo', 'wann', 'warum', 'welche', 'welcher', 'welches',
+  'auch', 'noch', 'schon', 'mal', 'doch', 'eben', 'halt',
+  'für', 'mit', 'von', 'bei', 'aus', 'nach', 'zu', 'zur', 'zum', 'auf', 'in',
+  'gehe', 'gehen', 'geht', 'mache', 'machen', 'macht', 'tue', 'tun', 'tut',
+  'sehe', 'sehen', 'sieht', 'zeige', 'zeigen', 'zeigt',
+]);
+
+function scorerTokenize(text: string): string[] {
+  return text
+    .split(/[\s\.\,\?\!\:\;\(\)\[\]\{\}\-\u2013\u2014\'\"\/\&\+\*]+/)
+    .filter(t => t.length > 0);
+}
+
+function scorerBuildWordSet(text: string): Set<string> {
+  const out = new Set<string>();
+  for (const w of scorerTokenize(text)) {
+    out.add(w);
+    if (w.length > 4 && w.endsWith('es')) {
+      out.add(w.slice(0, -2));
+    } else if (w.length > 3 && w.endsWith('s')) {
+      out.add(w.slice(0, -1));
+    }
+  }
+  return out;
+}
+
+export interface ScorerOptions {
+  category?: NavCategory;
+  anonymous_only?: boolean;
+  exclude_routes?: string[];
+}
+
+/**
+ * Tenant-aware drop-in replacement for navigation-catalog.ts::searchCatalog.
+ *
+ * Scores the given entry list against the query in the requested language.
+ * Consumers pass `getCatalogForTenant(tenantId)` as the entries argument so
+ * per-tenant overrides apply. Same scoring semantics as searchCatalog() —
+ * keep them in sync (see comment above).
+ */
+export function searchCatalogEntries(
+  entries: ReadonlyArray<NavCatalogEntry>,
+  query: string,
+  lang: LangCode,
+  opts: ScorerOptions = {}
+): Array<{ entry: NavCatalogEntry; score: number }> {
+  if (!query || !query.trim()) return [];
+
+  const lowerQuery = query.toLowerCase().trim();
+  const rawTokens = scorerTokenize(lowerQuery).filter(t => t.length > 2);
+  const queryTokens = rawTokens.filter(t => !SCORER_STOPWORDS.has(t));
+  const effectiveTokens = queryTokens.length > 0 ? queryTokens : rawTokens;
+
+  const excluded = new Set(opts.exclude_routes || []);
+  const results: Array<{ entry: NavCatalogEntry; score: number }> = [];
+
+  for (const entry of entries) {
+    if (opts.category && entry.category !== opts.category) continue;
+    if (opts.anonymous_only && !entry.anonymous_safe) continue;
+    if (excluded.has(entry.route)) continue;
+
+    const content = getContent(entry, lang);
+    const titleLower = content.title.toLowerCase();
+    const descLower = content.description.toLowerCase();
+    const hintLower = content.when_to_visit.toLowerCase();
+
+    const titleWords = scorerBuildWordSet(titleLower);
+    const hintWords = scorerBuildWordSet(hintLower);
+    const descWords = scorerBuildWordSet(descLower);
+
+    let score = 0;
+
+    // Direct phrase match (highest signal)
+    if (titleLower.includes(lowerQuery)) score += 40;
+    else if (hintLower.includes(lowerQuery)) score += 30;
+    else if (descLower.includes(lowerQuery)) score += 20;
+
+    const matchedTokens = new Set<string>();
+    for (const tok of effectiveTokens) {
+      let matched = false;
+      if (titleWords.has(tok)) { score += 15; matched = true; }
+      if (hintWords.has(tok))  { score += 6;  matched = true; }
+      if (descWords.has(tok))  { score += 3;  matched = true; }
+
+      // Long-token substring fallback for German compounds and similar.
+      if (!matched && tok.length >= 6) {
+        if (titleLower.includes(tok)) { score += 5; matched = true; }
+        else if (hintLower.includes(tok)) { score += 2; matched = true; }
+      }
+
+      if (matched) matchedTokens.add(tok);
+    }
+
+    if (effectiveTokens.length > 1 && matchedTokens.size >= effectiveTokens.length) {
+      score += effectiveTokens.length * 6;
+    }
+
+    if (entry.priority && entry.priority > 0 && score > 0) {
+      score += entry.priority * 3;
+    }
+
+    if (score > 0) results.push({ entry, score });
+  }
+
+  results.sort((a, b) => {
+    if (b.score !== a.score) return b.score - a.score;
+    const pa = a.entry.priority || 0;
+    const pb = b.entry.priority || 0;
+    return pb - pa;
+  });
+  return results;
+}

--- a/services/gateway/src/lib/spa-routes-fallback.ts
+++ b/services/gateway/src/lib/spa-routes-fallback.ts
@@ -1,0 +1,182 @@
+/**
+ * VTID-NAV-02: SPA Routes Fallback List
+ *
+ * Hard-coded inventory of vitana-v1 React Router paths, used by the Admin
+ * Navigator coverage + route-picker endpoints until CI wires in the
+ * build-time extract (vitana-v1/scripts/extract-routes.ts →
+ * src/generated/spa-routes.json shipped with the gateway deploy).
+ *
+ * Keep this list in sync with the routes mounted in vitana-v1/src/App.tsx.
+ * When the generated JSON is available, the admin route handler should
+ * prefer it over this fallback.
+ *
+ * `requires_auth` reflects whether the route is behind <AuthGuard> or
+ * <ProtectedRoute> in App.tsx. `requires_role` is the specific role (when
+ * ProtectedRoute narrows further, e.g. "community" or "admin").
+ */
+
+export interface SpaRoute {
+  path: string;
+  requires_auth: boolean;
+  requires_role?: string;
+  notes?: string;
+}
+
+export const SPA_ROUTES_FALLBACK: ReadonlyArray<SpaRoute> = [
+  // ── Public / landing / auth ─────────────────────────────────────────────
+  { path: '/', requires_auth: false, notes: 'Index / ShareEntry' },
+  { path: '/_intro/:tenantSlug', requires_auth: false },
+  { path: '/auth', requires_auth: false },
+  { path: '/login', requires_auth: false, notes: 'redirect → /auth' },
+  { path: '/register', requires_auth: false, notes: 'redirect → /auth' },
+  { path: '/reset-password', requires_auth: false },
+  { path: '/auth/confirmed', requires_auth: false },
+  { path: '/maxina', requires_auth: false },
+  { path: '/maxina/confirmed', requires_auth: false },
+  { path: '/alkalma', requires_auth: false },
+  { path: '/alkalma/confirmed', requires_auth: false },
+  { path: '/earthlinks', requires_auth: false },
+  { path: '/earthlinks/confirmed', requires_auth: false },
+  { path: '/community', requires_auth: false },
+  { path: '/community/confirmed', requires_auth: false },
+  { path: '/exafy-admin', requires_auth: false },
+  { path: '/privacy', requires_auth: false },
+  { path: '/terms', requires_auth: false },
+  { path: '/delete-account', requires_auth: false },
+  { path: '/maxina_support', requires_auth: false },
+  { path: '/redeem', requires_auth: false },
+  { path: '/logout', requires_auth: false },
+  { path: '/e/:slug', requires_auth: false },
+  { path: '/pub/events/:id', requires_auth: false },
+  { path: '/pub/campaigns/:id', requires_auth: false },
+
+  // ── Home ────────────────────────────────────────────────────────────────
+  { path: '/home', requires_auth: true, requires_role: 'community' },
+  { path: '/home/context', requires_auth: true },
+  { path: '/home/actions', requires_auth: true },
+  { path: '/home/matches', requires_auth: true },
+  { path: '/home/aifeed', requires_auth: true },
+
+  // ── Discover / commerce ────────────────────────────────────────────────
+  { path: '/discover', requires_auth: true },
+  { path: '/discover/ai-picks', requires_auth: true },
+  { path: '/discover/supplements', requires_auth: true },
+  { path: '/discover/wellness-services', requires_auth: true },
+  { path: '/discover/doctors-coaches', requires_auth: true },
+  { path: '/discover/provider/:id', requires_auth: true },
+  { path: '/discover/deals-offers', requires_auth: true },
+  { path: '/discover/orders', requires_auth: true },
+  { path: '/discover/product/:id', requires_auth: true },
+  { path: '/cart', requires_auth: true },
+  { path: '/checkout/success', requires_auth: true },
+  { path: '/tickets/success', requires_auth: false },
+  { path: '/packages/success', requires_auth: false },
+  { path: '/my-tickets', requires_auth: true },
+  { path: '/daily-diary', requires_auth: true },
+  { path: '/creator/onboarded', requires_auth: true },
+
+  // ── Health ──────────────────────────────────────────────────────────────
+  { path: '/health', requires_auth: true },
+  { path: '/health/my-biology', requires_auth: true },
+  { path: '/health/plans', requires_auth: true },
+  { path: '/health/conditions-risks', requires_auth: true },
+  { path: '/health/education', requires_auth: true, notes: 'EducationResources' },
+  { path: '/health/pillars', requires_auth: true },
+  { path: '/health/wellness-services', requires_auth: true },
+
+  // ── Community ───────────────────────────────────────────────────────────
+  // NOTE: catalog currently uses /comm/* but SPA uses /community/*. This is
+  // one of the known "wrong redirect" bugs the admin UI surfaces in coverage.
+  { path: '/community/events-meetups', requires_auth: true },
+  { path: '/community/groups', requires_auth: true },
+  { path: '/community/groups/:id', requires_auth: true },
+  { path: '/community/media-hub', requires_auth: true },
+  { path: '/community/live-rooms', requires_auth: true },
+  { path: '/community/live-rooms/:id', requires_auth: true },
+
+  // ── AI ──────────────────────────────────────────────────────────────────
+  { path: '/ai/insights', requires_auth: true },
+  { path: '/ai/recommendations', requires_auth: true },
+  { path: '/ai/daily-summary', requires_auth: true },
+  { path: '/ai/companion', requires_auth: true },
+
+  // ── Messages / inbox ────────────────────────────────────────────────────
+  { path: '/messages', requires_auth: true },
+  { path: '/messages/archived', requires_auth: true },
+  { path: '/messages/reminder', requires_auth: true },
+  { path: '/messages/inspiration', requires_auth: true },
+
+  // ── Settings ────────────────────────────────────────────────────────────
+  { path: '/settings', requires_auth: true },
+  { path: '/settings/privacy', requires_auth: true },
+  { path: '/settings/notifications', requires_auth: true },
+  { path: '/settings/preferences', requires_auth: true },
+  { path: '/settings/connected-apps', requires_auth: true },
+  { path: '/settings/billing', requires_auth: true },
+  { path: '/settings/support', requires_auth: true },
+  { path: '/settings/tenant-role', requires_auth: true },
+  { path: '/settings/social', requires_auth: true },
+
+  // ── Wallet ──────────────────────────────────────────────────────────────
+  { path: '/wallet', requires_auth: true },
+  { path: '/wallet/balance', requires_auth: true },
+  { path: '/wallet/subscriptions', requires_auth: true },
+  { path: '/wallet/rewards', requires_auth: true },
+
+  // ── Memory ──────────────────────────────────────────────────────────────
+  { path: '/memory', requires_auth: true },
+  { path: '/memory/timeline', requires_auth: true },
+  { path: '/memory/recall', requires_auth: true },
+  { path: '/memory/permissions', requires_auth: true },
+  { path: '/memory/diary', requires_auth: true },
+
+  // ── Profile / sharing ───────────────────────────────────────────────────
+  { path: '/profile', requires_auth: true },
+  { path: '/profile/edit', requires_auth: true },
+  { path: '/u/:id', requires_auth: false },
+  { path: '/sharing', requires_auth: true },
+  { path: '/sharing/distribution', requires_auth: true },
+  { path: '/sharing/data-consent', requires_auth: true },
+  { path: '/sharing/campaigns', requires_auth: true },
+  { path: '/sharing/campaigns/:id', requires_auth: true },
+
+  // ── Admin (community-side) ──────────────────────────────────────────────
+  { path: '/admin', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/dashboard', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/dashboard/health', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/dashboard/activity', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/users', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/users/signup-funnel', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/users/invitations', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/users/roles-access', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/notifications/compose', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/notifications/sent-log', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/notifications/preferences', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/live/sessions', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/live/attendance', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/intelligence/memory', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/intelligence/embeddings', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/intelligence/signals', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/intelligence/relationships', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/system/configuration', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/system/creators', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/audit/events', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/audit/user-activity', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/audit/api-monitor', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/audit/security', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/community/events', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/community/groups', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/community/reported-content', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/media', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/media/videos', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/media/podcasts', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/media/music', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/live-stream', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/community-rooms', requires_auth: true, requires_role: 'admin' },
+
+  // ── Navigator admin (this feature) ──────────────────────────────────────
+  { path: '/admin/navigator', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/navigator/coverage', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/navigator/telemetry', requires_auth: true, requires_role: 'admin' },
+  { path: '/admin/navigator/history', requires_auth: true, requires_role: 'admin' },
+];

--- a/services/gateway/src/routes/admin-navigator.ts
+++ b/services/gateway/src/routes/admin-navigator.ts
@@ -30,7 +30,7 @@
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
+import { requireAdminAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
 import {
   refreshNavCatalogCache,
   invalidateNavCatalogCache,
@@ -43,32 +43,20 @@ import { SPA_ROUTES_FALLBACK } from '../lib/spa-routes-fallback';
 const router = Router();
 const VTID = 'VTID-NAV-02';
 
-// ── Auth helper ─────────────────────────────────────────────────────────────
+// VTID-NAV-02: Every admin-navigator endpoint accepts BOTH Platform and
+// Lovable JWTs via the dual-JWT requireAdminAuth middleware. The community
+// app (vitana-v1) uses Lovable Supabase, so this is required for admins
+// logged in through the community app to actually reach these endpoints.
+// requireAdminAuth enforces (a) valid JWT signature against either secret,
+// (b) non-expired, (c) app_metadata.exafy_admin === true — returning 401 or
+// 403 as appropriate. It attaches req.identity for downstream handlers.
+router.use(requireAdminAuth);
 
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
+function actorFromReq(req: AuthenticatedRequest): { user_id: string; email: string } {
+  return {
+    user_id: req.identity?.user_id || 'unknown',
+    email: req.identity?.email || 'unknown',
+  };
 }
 
 // ── Validation helpers ──────────────────────────────────────────────────────
@@ -160,10 +148,7 @@ async function writeAudit(args: {
 
 // ── GET /catalog ────────────────────────────────────────────────────────────
 
-router.get('/catalog', async (req: Request, res: Response) => {
-  const auth = await verifyExafyAdmin(req);
-  if (!auth.ok) return res.status(auth.status).json({ ok: false, error: auth.error });
-
+router.get('/catalog', async (req: AuthenticatedRequest, res: Response) => {
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -221,10 +206,7 @@ router.get('/catalog', async (req: Request, res: Response) => {
 
 // ── GET /catalog/:id ────────────────────────────────────────────────────────
 
-router.get('/catalog/:id', async (req: Request, res: Response) => {
-  const auth = await verifyExafyAdmin(req);
-  if (!auth.ok) return res.status(auth.status).json({ ok: false, error: auth.error });
-
+router.get('/catalog/:id', async (req: AuthenticatedRequest, res: Response) => {
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -263,9 +245,8 @@ router.get('/catalog/:id', async (req: Request, res: Response) => {
 
 // ── POST /catalog ───────────────────────────────────────────────────────────
 
-router.post('/catalog', async (req: Request, res: Response) => {
-  const auth = await verifyExafyAdmin(req);
-  if (!auth.ok) return res.status(auth.status).json({ ok: false, error: auth.error });
+router.post('/catalog', async (req: AuthenticatedRequest, res: Response) => {
+  const auth = actorFromReq(req as any);
 
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
@@ -337,9 +318,8 @@ router.post('/catalog', async (req: Request, res: Response) => {
 
 // ── PATCH /catalog/:id ──────────────────────────────────────────────────────
 
-router.patch('/catalog/:id', async (req: Request, res: Response) => {
-  const auth = await verifyExafyAdmin(req);
-  if (!auth.ok) return res.status(auth.status).json({ ok: false, error: auth.error });
+router.patch('/catalog/:id', async (req: AuthenticatedRequest, res: Response) => {
+  const auth = actorFromReq(req as any);
 
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
@@ -409,9 +389,8 @@ router.patch('/catalog/:id', async (req: Request, res: Response) => {
 
 // ── DELETE /catalog/:id (soft) ──────────────────────────────────────────────
 
-router.delete('/catalog/:id', async (req: Request, res: Response) => {
-  const auth = await verifyExafyAdmin(req);
-  if (!auth.ok) return res.status(auth.status).json({ ok: false, error: auth.error });
+router.delete('/catalog/:id', async (req: AuthenticatedRequest, res: Response) => {
+  const auth = actorFromReq(req as any);
 
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
@@ -450,9 +429,8 @@ router.delete('/catalog/:id', async (req: Request, res: Response) => {
 
 // ── POST /catalog/:id/restore/:audit_id ─────────────────────────────────────
 
-router.post('/catalog/:id/restore/:audit_id', async (req: Request, res: Response) => {
-  const auth = await verifyExafyAdmin(req);
-  if (!auth.ok) return res.status(auth.status).json({ ok: false, error: auth.error });
+router.post('/catalog/:id/restore/:audit_id', async (req: AuthenticatedRequest, res: Response) => {
+  const auth = actorFromReq(req as any);
 
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
@@ -525,9 +503,8 @@ router.post('/catalog/:id/restore/:audit_id', async (req: Request, res: Response
 
 // ── POST /simulate ──────────────────────────────────────────────────────────
 
-router.post('/simulate', async (req: Request, res: Response) => {
-  const auth = await verifyExafyAdmin(req);
-  if (!auth.ok) return res.status(auth.status).json({ ok: false, error: auth.error });
+router.post('/simulate', async (req: AuthenticatedRequest, res: Response) => {
+  const auth = actorFromReq(req as any);
 
   const { utterance, lang, current_route, recent_routes, is_anonymous, tenant_id, user_id } = req.body || {};
   if (typeof utterance !== 'string' || utterance.trim().length === 0) {
@@ -559,10 +536,7 @@ router.post('/simulate', async (req: Request, res: Response) => {
 
 // ── GET /spa-routes ─────────────────────────────────────────────────────────
 
-router.get('/spa-routes', async (req: Request, res: Response) => {
-  const auth = await verifyExafyAdmin(req);
-  if (!auth.ok) return res.status(auth.status).json({ ok: false, error: auth.error });
-
+router.get('/spa-routes', async (req: AuthenticatedRequest, res: Response) => {
   // Static fallback shipped with the gateway. The build-time extract from
   // vitana-v1 (scripts/extract-routes.ts) will replace this when CI wires it.
   return res.json({ ok: true, source: 'gateway_fallback', routes: SPA_ROUTES_FALLBACK });
@@ -570,9 +544,8 @@ router.get('/spa-routes', async (req: Request, res: Response) => {
 
 // ── GET /coverage ───────────────────────────────────────────────────────────
 
-router.get('/coverage', async (req: Request, res: Response) => {
-  const auth = await verifyExafyAdmin(req);
-  if (!auth.ok) return res.status(auth.status).json({ ok: false, error: auth.error });
+router.get('/coverage', async (req: AuthenticatedRequest, res: Response) => {
+  const auth = actorFromReq(req as any);
 
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
@@ -643,10 +616,7 @@ router.get('/coverage', async (req: Request, res: Response) => {
 
 // ── GET /telemetry ──────────────────────────────────────────────────────────
 
-router.get('/telemetry', async (req: Request, res: Response) => {
-  const auth = await verifyExafyAdmin(req);
-  if (!auth.ok) return res.status(auth.status).json({ ok: false, error: auth.error });
-
+router.get('/telemetry', async (req: AuthenticatedRequest, res: Response) => {
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -711,9 +681,7 @@ router.get('/telemetry', async (req: Request, res: Response) => {
 
 // ── POST /reload ────────────────────────────────────────────────────────────
 
-router.post('/reload', async (req: Request, res: Response) => {
-  const auth = await verifyExafyAdmin(req);
-  if (!auth.ok) return res.status(auth.status).json({ ok: false, error: auth.error });
+router.post('/reload', async (req: AuthenticatedRequest, res: Response) => {
   try {
     await refreshNavCatalogCache();
     return res.json({ ok: true });

--- a/services/gateway/src/routes/admin-navigator.ts
+++ b/services/gateway/src/routes/admin-navigator.ts
@@ -1,0 +1,725 @@
+/**
+ * VTID-NAV-02: Admin Navigator API
+ *
+ * CRUD + simulation + coverage + telemetry for the Vitana Navigator catalog.
+ * Every endpoint is gated on exafy_admin. All writes emit an audit row so
+ * admins can revert.
+ *
+ * Mounted at /api/v1/admin/navigator. The React admin UI in vitana-v1 is
+ * the only consumer.
+ *
+ * Endpoints:
+ *   GET    /catalog                     — list (optional ?tenant_id, ?category, ?q, ?lang)
+ *   GET    /catalog/:id                 — one entry + recent audit history
+ *   POST   /catalog                     — create (writes audit)
+ *   PATCH  /catalog/:id                 — update (writes audit)
+ *   DELETE /catalog/:id                 — soft delete (writes audit)
+ *   POST   /catalog/:id/restore/:audit  — restore a prior version (writes audit)
+ *   POST   /simulate                    — run the real consult pipeline against an utterance
+ *   GET    /spa-routes                  — canonical list of React Router paths (cross-tenant)
+ *   GET    /coverage                    — SPA routes ↔ catalog coverage diff
+ *   GET    /telemetry                   — 7/30-day aggregates from oasis_events
+ *   POST   /reload                      — force cache refresh (dev convenience)
+ *
+ * IMPORTANT: /spa-routes reads the build-time generated JSON shipped with
+ * vitana-v1 (scripts/extract-routes.ts → src/generated/spa-routes.json). The
+ * gateway does not yet bundle vitana-v1, so this endpoint currently returns
+ * a hard-coded fallback derived from App.tsx; once the gateway picks up the
+ * generated file at deploy time it will auto-upgrade.
+ */
+
+import { Router, Request, Response } from 'express';
+import { getSupabase } from '../lib/supabase';
+import { createUserSupabaseClient } from '../lib/supabase-user';
+import {
+  refreshNavCatalogCache,
+  invalidateNavCatalogCache,
+  getCatalogForTenant,
+  NavCatalogEntryWithRules,
+} from '../lib/nav-catalog-db';
+import { consultNavigator, type NavigatorConsultInput } from '../services/navigator-consult';
+import { SPA_ROUTES_FALLBACK } from '../lib/spa-routes-fallback';
+
+const router = Router();
+const VTID = 'VTID-NAV-02';
+
+// ── Auth helper ─────────────────────────────────────────────────────────────
+
+function getBearerToken(req: Request): string | null {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
+  return authHeader.slice(7);
+}
+
+async function verifyExafyAdmin(
+  req: Request
+): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
+  const token = getBearerToken(req);
+  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
+  try {
+    const userClient = createUserSupabaseClient(token);
+    const { data: authData, error: authError } = await userClient.auth.getUser();
+    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
+    const appMetadata = authData.user.app_metadata || {};
+    if (appMetadata.exafy_admin !== true) {
+      return { ok: false, status: 403, error: 'FORBIDDEN' };
+    }
+    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
+  } catch (err: any) {
+    console.error(`[${VTID}] Auth error:`, err.message);
+    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
+  }
+}
+
+// ── Validation helpers ──────────────────────────────────────────────────────
+
+const VALID_CATEGORIES = [
+  'public', 'auth', 'community', 'business', 'wallet', 'health',
+  'discover', 'home', 'memory', 'ai', 'inbox', 'settings',
+] as const;
+
+const VALID_ACCESS = ['public', 'authenticated'] as const;
+
+function validateCatalogPayload(body: any, { isPartial }: { isPartial: boolean }): string | null {
+  if (!body || typeof body !== 'object') return 'PAYLOAD_REQUIRED';
+
+  if (!isPartial) {
+    if (typeof body.screen_id !== 'string' || body.screen_id.trim() === '') {
+      return 'screen_id required';
+    }
+    if (typeof body.route !== 'string' || !body.route.startsWith('/')) {
+      return 'route must be a string starting with /';
+    }
+    if (!VALID_CATEGORIES.includes(body.category)) {
+      return 'category invalid';
+    }
+    if (!VALID_ACCESS.includes(body.access)) {
+      return 'access invalid';
+    }
+    if (!body.i18n || typeof body.i18n !== 'object' || !body.i18n.en) {
+      return 'i18n.en required (at least title + when_to_visit)';
+    }
+    if (!body.i18n.en.title || !body.i18n.en.when_to_visit) {
+      return 'i18n.en must include title and when_to_visit';
+    }
+  } else {
+    if (body.category && !VALID_CATEGORIES.includes(body.category)) return 'category invalid';
+    if (body.access && !VALID_ACCESS.includes(body.access)) return 'access invalid';
+    if (body.route && (typeof body.route !== 'string' || !body.route.startsWith('/'))) {
+      return 'route must start with /';
+    }
+  }
+
+  if (body.priority != null && (typeof body.priority !== 'number' || body.priority < 0 || body.priority > 10)) {
+    return 'priority must be a number 0..10';
+  }
+  if (body.related_kb_topics && !Array.isArray(body.related_kb_topics)) {
+    return 'related_kb_topics must be an array';
+  }
+  if (body.context_rules && typeof body.context_rules !== 'object') {
+    return 'context_rules must be an object';
+  }
+  if (body.override_triggers && !Array.isArray(body.override_triggers)) {
+    return 'override_triggers must be an array';
+  }
+  if (Array.isArray(body.override_triggers)) {
+    for (const trig of body.override_triggers) {
+      if (!trig || typeof trig !== 'object') return 'override_triggers entries must be objects';
+      if (typeof trig.phrase !== 'string' || typeof trig.lang !== 'string') {
+        return 'override_triggers entries require phrase + lang';
+      }
+    }
+  }
+  return null;
+}
+
+async function writeAudit(args: {
+  catalog_id: string | null;
+  screen_id: string | null;
+  tenant_id: string | null;
+  action: 'create' | 'update' | 'delete' | 'restore';
+  before: any;
+  after: any;
+  actor_user_id: string;
+  actor_email: string;
+}): Promise<void> {
+  const supabase = getSupabase();
+  if (!supabase) return;
+  const { error } = await supabase.from('nav_catalog_audit').insert({
+    catalog_id: args.catalog_id,
+    screen_id: args.screen_id,
+    tenant_id: args.tenant_id,
+    action: args.action,
+    before: args.before,
+    after: args.after,
+    actor_user_id: args.actor_user_id,
+    actor_email: args.actor_email,
+  });
+  if (error) console.warn(`[${VTID}] audit insert failed: ${error.message}`);
+}
+
+// ── GET /catalog ────────────────────────────────────────────────────────────
+
+router.get('/catalog', async (req: Request, res: Response) => {
+  const auth = await verifyExafyAdmin(req);
+  if (!auth.ok) return res.status(auth.status).json({ ok: false, error: auth.error });
+
+  const supabase = getSupabase();
+  if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
+
+  const { tenant_id, category, q, lang: langQ, include_inactive } = req.query;
+
+  try {
+    let query = supabase
+      .from('nav_catalog')
+      .select('id, screen_id, tenant_id, route, category, access, anonymous_safe, priority, related_kb_topics, context_rules, override_triggers, is_active, created_at, updated_at, updated_by');
+
+    if (include_inactive !== 'true') query = query.eq('is_active', true);
+    if (category && typeof category === 'string') query = query.eq('category', category);
+    if (tenant_id && typeof tenant_id === 'string') {
+      if (tenant_id === '__shared__' || tenant_id === 'null') {
+        query = query.is('tenant_id', null);
+      } else {
+        query = query.eq('tenant_id', tenant_id);
+      }
+    }
+
+    const { data: rows, error } = await query.order('category').order('screen_id');
+    if (error) return res.status(500).json({ ok: false, error: error.message });
+
+    const catalogIds = (rows || []).map((r: any) => r.id);
+    let i18nByCatalog: Record<string, any[]> = {};
+    if (catalogIds.length > 0) {
+      const { data: i18nRows } = await supabase
+        .from('nav_catalog_i18n')
+        .select('catalog_id, lang, title, description, when_to_visit, updated_at')
+        .in('catalog_id', catalogIds);
+      for (const r of (i18nRows as any[]) || []) {
+        (i18nByCatalog[r.catalog_id] ||= []).push(r);
+      }
+    }
+
+    let merged = (rows || []).map((r: any) => ({ ...r, i18n: i18nByCatalog[r.id] || [] }));
+
+    // Optional free-text filter against english title + when_to_visit.
+    if (q && typeof q === 'string') {
+      const needle = q.toLowerCase();
+      merged = merged.filter((r: any) => {
+        const en = (r.i18n || []).find((x: any) => x.lang === 'en');
+        if (!en) return false;
+        return (en.title || '').toLowerCase().includes(needle) ||
+               (en.when_to_visit || '').toLowerCase().includes(needle);
+      });
+    }
+
+    return res.json({ ok: true, data: merged, count: merged.length });
+  } catch (err: any) {
+    console.error(`[${VTID}] GET /catalog:`, err.message);
+    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
+  }
+});
+
+// ── GET /catalog/:id ────────────────────────────────────────────────────────
+
+router.get('/catalog/:id', async (req: Request, res: Response) => {
+  const auth = await verifyExafyAdmin(req);
+  if (!auth.ok) return res.status(auth.status).json({ ok: false, error: auth.error });
+
+  const supabase = getSupabase();
+  if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
+
+  const { id } = req.params;
+  try {
+    const { data: row, error } = await supabase
+      .from('nav_catalog')
+      .select('*')
+      .eq('id', id)
+      .maybeSingle();
+    if (error) return res.status(500).json({ ok: false, error: error.message });
+    if (!row) return res.status(404).json({ ok: false, error: 'NOT_FOUND' });
+
+    const { data: i18nRows } = await supabase
+      .from('nav_catalog_i18n')
+      .select('*')
+      .eq('catalog_id', id);
+
+    const { data: auditRows } = await supabase
+      .from('nav_catalog_audit')
+      .select('*')
+      .eq('catalog_id', id)
+      .order('created_at', { ascending: false })
+      .limit(50);
+
+    return res.json({
+      ok: true,
+      data: { ...row, i18n: i18nRows || [] },
+      audit: auditRows || [],
+    });
+  } catch (err: any) {
+    console.error(`[${VTID}] GET /catalog/:id:`, err.message);
+    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
+  }
+});
+
+// ── POST /catalog ───────────────────────────────────────────────────────────
+
+router.post('/catalog', async (req: Request, res: Response) => {
+  const auth = await verifyExafyAdmin(req);
+  if (!auth.ok) return res.status(auth.status).json({ ok: false, error: auth.error });
+
+  const supabase = getSupabase();
+  if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
+
+  const err = validateCatalogPayload(req.body, { isPartial: false });
+  if (err) return res.status(400).json({ ok: false, error: 'INVALID_INPUT', message: err });
+
+  try {
+    const insertRow: any = {
+      screen_id: req.body.screen_id.trim(),
+      tenant_id: req.body.tenant_id || null,
+      route: req.body.route.trim(),
+      category: req.body.category,
+      access: req.body.access,
+      anonymous_safe: !!req.body.anonymous_safe,
+      priority: req.body.priority || 0,
+      related_kb_topics: req.body.related_kb_topics || [],
+      context_rules: req.body.context_rules || {},
+      override_triggers: req.body.override_triggers || [],
+      is_active: true,
+      updated_by: auth.user_id,
+    };
+
+    const { data: created, error: insertErr } = await supabase
+      .from('nav_catalog')
+      .insert(insertRow)
+      .select('*')
+      .single();
+
+    if (insertErr) {
+      // Unique index violation → friendly message for the admin UI.
+      if (insertErr.code === '23505') {
+        return res.status(409).json({ ok: false, error: 'SCREEN_ID_CONFLICT', message: insertErr.message });
+      }
+      return res.status(500).json({ ok: false, error: insertErr.message });
+    }
+
+    // i18n rows
+    const i18nRows = Object.entries(req.body.i18n || {}).map(([lang, c]: [string, any]) => ({
+      catalog_id: created.id,
+      lang,
+      title: c.title || '',
+      description: c.description || '',
+      when_to_visit: c.when_to_visit || '',
+    }));
+    if (i18nRows.length > 0) {
+      const { error: i18nErr } = await supabase.from('nav_catalog_i18n').insert(i18nRows);
+      if (i18nErr) console.warn(`[${VTID}] i18n insert after create: ${i18nErr.message}`);
+    }
+
+    await writeAudit({
+      catalog_id: created.id,
+      screen_id: created.screen_id,
+      tenant_id: created.tenant_id,
+      action: 'create',
+      before: null,
+      after: { ...created, i18n: i18nRows },
+      actor_user_id: auth.user_id,
+      actor_email: auth.email,
+    });
+
+    invalidateNavCatalogCache();
+    return res.json({ ok: true, data: { ...created, i18n: i18nRows } });
+  } catch (err: any) {
+    console.error(`[${VTID}] POST /catalog:`, err.message);
+    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
+  }
+});
+
+// ── PATCH /catalog/:id ──────────────────────────────────────────────────────
+
+router.patch('/catalog/:id', async (req: Request, res: Response) => {
+  const auth = await verifyExafyAdmin(req);
+  if (!auth.ok) return res.status(auth.status).json({ ok: false, error: auth.error });
+
+  const supabase = getSupabase();
+  if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
+
+  const err = validateCatalogPayload(req.body, { isPartial: true });
+  if (err) return res.status(400).json({ ok: false, error: 'INVALID_INPUT', message: err });
+
+  const { id } = req.params;
+  try {
+    const { data: existing } = await supabase.from('nav_catalog').select('*').eq('id', id).maybeSingle();
+    if (!existing) return res.status(404).json({ ok: false, error: 'NOT_FOUND' });
+
+    const { data: existingI18n } = await supabase.from('nav_catalog_i18n').select('*').eq('catalog_id', id);
+
+    const patch: any = { updated_by: auth.user_id };
+    for (const key of ['route', 'category', 'access', 'anonymous_safe', 'priority', 'related_kb_topics', 'context_rules', 'override_triggers', 'is_active']) {
+      if (req.body[key] !== undefined) patch[key] = req.body[key];
+    }
+
+    const { data: updated, error: updErr } = await supabase
+      .from('nav_catalog')
+      .update(patch)
+      .eq('id', id)
+      .select('*')
+      .single();
+
+    if (updErr) return res.status(500).json({ ok: false, error: updErr.message });
+
+    // Upsert i18n rows if provided.
+    let newI18n = existingI18n || [];
+    if (req.body.i18n && typeof req.body.i18n === 'object') {
+      const upserts = Object.entries(req.body.i18n).map(([lang, c]: [string, any]) => ({
+        catalog_id: id,
+        lang,
+        title: c.title || '',
+        description: c.description || '',
+        when_to_visit: c.when_to_visit || '',
+      }));
+      if (upserts.length > 0) {
+        const { error: upErr } = await supabase
+          .from('nav_catalog_i18n')
+          .upsert(upserts, { onConflict: 'catalog_id,lang' });
+        if (upErr) console.warn(`[${VTID}] i18n upsert: ${upErr.message}`);
+      }
+      const { data: refreshed } = await supabase.from('nav_catalog_i18n').select('*').eq('catalog_id', id);
+      newI18n = refreshed || newI18n;
+    }
+
+    await writeAudit({
+      catalog_id: id,
+      screen_id: updated.screen_id,
+      tenant_id: updated.tenant_id,
+      action: 'update',
+      before: { ...existing, i18n: existingI18n },
+      after: { ...updated, i18n: newI18n },
+      actor_user_id: auth.user_id,
+      actor_email: auth.email,
+    });
+
+    invalidateNavCatalogCache();
+    return res.json({ ok: true, data: { ...updated, i18n: newI18n } });
+  } catch (err: any) {
+    console.error(`[${VTID}] PATCH /catalog/:id:`, err.message);
+    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
+  }
+});
+
+// ── DELETE /catalog/:id (soft) ──────────────────────────────────────────────
+
+router.delete('/catalog/:id', async (req: Request, res: Response) => {
+  const auth = await verifyExafyAdmin(req);
+  if (!auth.ok) return res.status(auth.status).json({ ok: false, error: auth.error });
+
+  const supabase = getSupabase();
+  if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
+
+  const { id } = req.params;
+  try {
+    const { data: existing } = await supabase.from('nav_catalog').select('*').eq('id', id).maybeSingle();
+    if (!existing) return res.status(404).json({ ok: false, error: 'NOT_FOUND' });
+
+    const { data: updated, error: updErr } = await supabase
+      .from('nav_catalog')
+      .update({ is_active: false, updated_by: auth.user_id })
+      .eq('id', id)
+      .select('*')
+      .single();
+    if (updErr) return res.status(500).json({ ok: false, error: updErr.message });
+
+    await writeAudit({
+      catalog_id: id,
+      screen_id: existing.screen_id,
+      tenant_id: existing.tenant_id,
+      action: 'delete',
+      before: existing,
+      after: updated,
+      actor_user_id: auth.user_id,
+      actor_email: auth.email,
+    });
+
+    invalidateNavCatalogCache();
+    return res.json({ ok: true });
+  } catch (err: any) {
+    console.error(`[${VTID}] DELETE /catalog/:id:`, err.message);
+    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
+  }
+});
+
+// ── POST /catalog/:id/restore/:audit_id ─────────────────────────────────────
+
+router.post('/catalog/:id/restore/:audit_id', async (req: Request, res: Response) => {
+  const auth = await verifyExafyAdmin(req);
+  if (!auth.ok) return res.status(auth.status).json({ ok: false, error: auth.error });
+
+  const supabase = getSupabase();
+  if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
+
+  const { id, audit_id } = req.params;
+  try {
+    const { data: audit } = await supabase
+      .from('nav_catalog_audit')
+      .select('*')
+      .eq('id', audit_id)
+      .eq('catalog_id', id)
+      .maybeSingle();
+    if (!audit) return res.status(404).json({ ok: false, error: 'AUDIT_NOT_FOUND' });
+
+    // The snapshot we restore to depends on action:
+    //   - 'update' / 'delete': restore to audit.before (state pre-change)
+    //   - 'create': effectively re-activate with audit.after
+    const snapshot = audit.action === 'create' ? audit.after : audit.before;
+    if (!snapshot) return res.status(400).json({ ok: false, error: 'NO_SNAPSHOT' });
+
+    const patch: any = {
+      route: snapshot.route,
+      category: snapshot.category,
+      access: snapshot.access,
+      anonymous_safe: snapshot.anonymous_safe,
+      priority: snapshot.priority || 0,
+      related_kb_topics: snapshot.related_kb_topics || [],
+      context_rules: snapshot.context_rules || {},
+      override_triggers: snapshot.override_triggers || [],
+      is_active: true,
+      updated_by: auth.user_id,
+    };
+
+    const { data: existing } = await supabase.from('nav_catalog').select('*').eq('id', id).maybeSingle();
+
+    const { data: updated, error: updErr } = await supabase
+      .from('nav_catalog').update(patch).eq('id', id).select('*').single();
+    if (updErr) return res.status(500).json({ ok: false, error: updErr.message });
+
+    // Restore i18n too if snapshot has it.
+    if (Array.isArray(snapshot.i18n) && snapshot.i18n.length > 0) {
+      const upserts = snapshot.i18n.map((r: any) => ({
+        catalog_id: id,
+        lang: r.lang,
+        title: r.title || '',
+        description: r.description || '',
+        when_to_visit: r.when_to_visit || '',
+      }));
+      await supabase.from('nav_catalog_i18n').upsert(upserts, { onConflict: 'catalog_id,lang' });
+    }
+
+    await writeAudit({
+      catalog_id: id,
+      screen_id: updated.screen_id,
+      tenant_id: updated.tenant_id,
+      action: 'restore',
+      before: existing,
+      after: updated,
+      actor_user_id: auth.user_id,
+      actor_email: auth.email,
+    });
+
+    invalidateNavCatalogCache();
+    return res.json({ ok: true, data: updated });
+  } catch (err: any) {
+    console.error(`[${VTID}] POST /catalog/:id/restore:`, err.message);
+    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
+  }
+});
+
+// ── POST /simulate ──────────────────────────────────────────────────────────
+
+router.post('/simulate', async (req: Request, res: Response) => {
+  const auth = await verifyExafyAdmin(req);
+  if (!auth.ok) return res.status(auth.status).json({ ok: false, error: auth.error });
+
+  const { utterance, lang, current_route, recent_routes, is_anonymous, tenant_id, user_id } = req.body || {};
+  if (typeof utterance !== 'string' || utterance.trim().length === 0) {
+    return res.status(400).json({ ok: false, error: 'utterance required' });
+  }
+
+  try {
+    const input: NavigatorConsultInput = {
+      question: utterance,
+      lang: (lang as string) || 'en',
+      identity: tenant_id
+        ? { user_id: user_id || auth.user_id, tenant_id, role: 'admin' }
+        : null,
+      is_anonymous: !!is_anonymous,
+      current_route: typeof current_route === 'string' ? current_route : undefined,
+      recent_routes: Array.isArray(recent_routes) ? recent_routes : [],
+      session_id: `admin-sim-${Date.now()}`,
+      turn_number: 0,
+      conversation_start: new Date().toISOString(),
+    };
+
+    const result = await consultNavigator(input);
+    return res.json({ ok: true, input, result });
+  } catch (err: any) {
+    console.error(`[${VTID}] POST /simulate:`, err.message);
+    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR', message: err.message });
+  }
+});
+
+// ── GET /spa-routes ─────────────────────────────────────────────────────────
+
+router.get('/spa-routes', async (req: Request, res: Response) => {
+  const auth = await verifyExafyAdmin(req);
+  if (!auth.ok) return res.status(auth.status).json({ ok: false, error: auth.error });
+
+  // Static fallback shipped with the gateway. The build-time extract from
+  // vitana-v1 (scripts/extract-routes.ts) will replace this when CI wires it.
+  return res.json({ ok: true, source: 'gateway_fallback', routes: SPA_ROUTES_FALLBACK });
+});
+
+// ── GET /coverage ───────────────────────────────────────────────────────────
+
+router.get('/coverage', async (req: Request, res: Response) => {
+  const auth = await verifyExafyAdmin(req);
+  if (!auth.ok) return res.status(auth.status).json({ ok: false, error: auth.error });
+
+  const supabase = getSupabase();
+  if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
+
+  const tenantId = typeof req.query.tenant_id === 'string' ? req.query.tenant_id : null;
+
+  try {
+    const catalog: NavCatalogEntryWithRules[] = getCatalogForTenant(tenantId) as NavCatalogEntryWithRules[];
+    const catalogRoutes = new Set(catalog.map(e => e.route));
+    const spaRoutes = SPA_ROUTES_FALLBACK.map(r => r.path);
+    const spaSet = new Set(spaRoutes);
+
+    const missing_in_catalog = spaRoutes
+      .filter(r => !catalogRoutes.has(r) && !r.includes(':') && r !== '*')
+      .map(r => {
+        const def = SPA_ROUTES_FALLBACK.find(x => x.path === r);
+        return { route: r, requires_auth: def?.requires_auth || false };
+      });
+
+    const broken_catalog_routes = catalog
+      .filter(e => {
+        // Allow params like /discover/product/:id → match against the matching pattern
+        // by stripping trailing params. The fallback list stores the literal patterns.
+        return !spaSet.has(e.route);
+      })
+      .map(e => ({ screen_id: e.screen_id, route: e.route, title: e.i18n.en?.title || e.screen_id }));
+
+    // Dead triggers: screens that never produced a catalog match in the last
+    // 30 days. We detect those via OASIS navigator events.
+    const since = new Date(Date.now() - 30 * 86400000).toISOString();
+    const { data: events } = await supabase
+      .from('oasis_events_v1')
+      .select('payload, type, created_at')
+      .like('type', 'orb.navigator.%')
+      .gte('created_at', since)
+      .limit(10000);
+
+    const firedScreenIds = new Set<string>();
+    for (const ev of (events as any[]) || []) {
+      const payload = (ev.payload || {}) as any;
+      const picks: any[] = payload.top_picks || (payload.primary ? [payload.primary] : []);
+      for (const p of picks) if (p?.screen_id) firedScreenIds.add(p.screen_id);
+    }
+
+    const dead_triggers = catalog
+      .filter(e => !firedScreenIds.has(e.screen_id))
+      .map(e => ({ screen_id: e.screen_id, title: e.i18n.en?.title || e.screen_id, route: e.route }));
+
+    return res.json({
+      ok: true,
+      tenant_id: tenantId,
+      summary: {
+        catalog_size: catalog.length,
+        spa_route_count: spaRoutes.length,
+        missing_in_catalog: missing_in_catalog.length,
+        broken_catalog_routes: broken_catalog_routes.length,
+        dead_triggers: dead_triggers.length,
+      },
+      missing_in_catalog,
+      broken_catalog_routes,
+      dead_triggers,
+    });
+  } catch (err: any) {
+    console.error(`[${VTID}] GET /coverage:`, err.message);
+    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
+  }
+});
+
+// ── GET /telemetry ──────────────────────────────────────────────────────────
+
+router.get('/telemetry', async (req: Request, res: Response) => {
+  const auth = await verifyExafyAdmin(req);
+  if (!auth.ok) return res.status(auth.status).json({ ok: false, error: auth.error });
+
+  const supabase = getSupabase();
+  if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
+
+  const days = Math.min(parseInt((req.query.days as string) || '30', 10) || 30, 90);
+  const since = new Date(Date.now() - days * 86400000).toISOString();
+
+  try {
+    const { data: events, error } = await supabase
+      .from('oasis_events_v1')
+      .select('type, payload, created_at')
+      .like('type', 'orb.navigator.%')
+      .gte('created_at', since)
+      .order('created_at', { ascending: false })
+      .limit(5000);
+    if (error) return res.status(500).json({ ok: false, error: error.message });
+
+    const byType: Record<string, number> = {};
+    const byScreen: Record<string, number> = {};
+    const failedUtterances: Array<{ utterance: string; confidence: string; top_picks?: any[] }> = [];
+    const nearMisses: Array<{ utterance: string; picked: any; runner_up: any; delta: number }> = [];
+
+    for (const ev of (events as any[]) || []) {
+      byType[ev.type] = (byType[ev.type] || 0) + 1;
+      const payload = (ev.payload || {}) as any;
+      const picks: any[] = payload.top_picks || (payload.primary ? [payload.primary] : []);
+      for (const p of picks) {
+        if (p?.screen_id) byScreen[p.screen_id] = (byScreen[p.screen_id] || 0) + 1;
+      }
+      if (payload.confidence === 'low' && payload.question) {
+        failedUtterances.push({ utterance: payload.question, confidence: payload.confidence, top_picks: picks });
+      }
+      if (Array.isArray(picks) && picks.length >= 2) {
+        const [a, b] = picks;
+        if (a?.score != null && b?.score != null) {
+          const delta = a.score - b.score;
+          if (delta >= 0 && delta <= 4) {
+            nearMisses.push({ utterance: payload.question || '', picked: a, runner_up: b, delta });
+          }
+        }
+      }
+    }
+
+    const topScreens = Object.entries(byScreen)
+      .map(([screen_id, count]) => ({ screen_id, count }))
+      .sort((a, b) => b.count - a.count)
+      .slice(0, 25);
+
+    return res.json({
+      ok: true,
+      days,
+      event_count: (events || []).length,
+      by_type: byType,
+      top_screens: topScreens,
+      failed_utterances: failedUtterances.slice(0, 50),
+      near_misses: nearMisses.slice(0, 50),
+    });
+  } catch (err: any) {
+    console.error(`[${VTID}] GET /telemetry:`, err.message);
+    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
+  }
+});
+
+// ── POST /reload ────────────────────────────────────────────────────────────
+
+router.post('/reload', async (req: Request, res: Response) => {
+  const auth = await verifyExafyAdmin(req);
+  if (!auth.ok) return res.status(auth.status).json({ ok: false, error: auth.error });
+  try {
+    await refreshNavCatalogCache();
+    return res.json({ ok: true });
+  } catch (err: any) {
+    return res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+export default router;

--- a/services/gateway/src/scripts/seed-nav-catalog.ts
+++ b/services/gateway/src/scripts/seed-nav-catalog.ts
@@ -1,0 +1,111 @@
+/**
+ * VTID-NAV-02: Seed nav_catalog from the static NAVIGATION_CATALOG constant.
+ *
+ * Idempotent — safe to re-run. Upserts every entry (tenant_id = NULL shared)
+ * so environments can transition from the compile-time catalog to the
+ * DB-backed admin UI without losing any screen. Run once after the
+ * migration is applied.
+ *
+ * Usage (from services/gateway):
+ *   npx ts-node src/scripts/seed-nav-catalog.ts
+ *
+ * Requires SUPABASE_URL + SUPABASE_SERVICE_ROLE env vars (same as the
+ * gateway itself).
+ */
+
+import { NAVIGATION_CATALOG } from '../lib/navigation-catalog';
+import { getSupabase } from '../lib/supabase';
+
+async function main() {
+  const supabase = getSupabase();
+  if (!supabase) {
+    console.error('[seed-nav-catalog] Supabase client unavailable — check SUPABASE_URL + SUPABASE_SERVICE_ROLE');
+    process.exit(1);
+  }
+
+  let created = 0;
+  let updated = 0;
+  let failed = 0;
+
+  for (const entry of NAVIGATION_CATALOG) {
+    try {
+      // 1. Upsert the main row (shared catalog — tenant_id NULL).
+      const { data: existing } = await supabase
+        .from('nav_catalog')
+        .select('id')
+        .eq('screen_id', entry.screen_id)
+        .is('tenant_id', null)
+        .maybeSingle();
+
+      let catalogId: string;
+      if (existing) {
+        const { error: updErr } = await supabase
+          .from('nav_catalog')
+          .update({
+            route: entry.route,
+            category: entry.category,
+            access: entry.access,
+            anonymous_safe: !!entry.anonymous_safe,
+            priority: entry.priority || 0,
+            related_kb_topics: entry.related_kb_topics || [],
+            context_rules: {},
+            override_triggers: [],
+            is_active: true,
+          })
+          .eq('id', existing.id);
+        if (updErr) throw updErr;
+        catalogId = existing.id;
+        updated++;
+      } else {
+        const { data: created_row, error: insErr } = await supabase
+          .from('nav_catalog')
+          .insert({
+            screen_id: entry.screen_id,
+            tenant_id: null,
+            route: entry.route,
+            category: entry.category,
+            access: entry.access,
+            anonymous_safe: !!entry.anonymous_safe,
+            priority: entry.priority || 0,
+            related_kb_topics: entry.related_kb_topics || [],
+            context_rules: {},
+            override_triggers: [],
+            is_active: true,
+          })
+          .select('id')
+          .single();
+        if (insErr) throw insErr;
+        catalogId = created_row!.id;
+        created++;
+      }
+
+      // 2. Upsert i18n rows for each curated language.
+      const i18nRows = Object.entries(entry.i18n).map(([lang, c]) => ({
+        catalog_id: catalogId,
+        lang,
+        title: c.title,
+        description: c.description,
+        when_to_visit: c.when_to_visit,
+      }));
+      if (i18nRows.length > 0) {
+        const { error: i18nErr } = await supabase
+          .from('nav_catalog_i18n')
+          .upsert(i18nRows, { onConflict: 'catalog_id,lang' });
+        if (i18nErr) throw i18nErr;
+      }
+    } catch (err: any) {
+      failed++;
+      console.warn(`[seed-nav-catalog] ${entry.screen_id}: ${err.message || err}`);
+    }
+  }
+
+  console.log(
+    `[seed-nav-catalog] done: created=${created} updated=${updated} failed=${failed} total=${NAVIGATION_CATALOG.length}`
+  );
+  process.exit(failed > 0 ? 1 : 0);
+}
+
+main().catch(err => {
+  console.error('[seed-nav-catalog] fatal:', err);
+  process.exit(1);
+});

--- a/services/gateway/src/services/navigator-consult.ts
+++ b/services/gateway/src/services/navigator-consult.ts
@@ -29,6 +29,13 @@ import {
   searchCatalog,
   lookupScreen,
 } from '../lib/navigation-catalog';
+import {
+  getCatalogForTenant,
+  findOverrideTriggerMatch,
+  searchCatalogEntries,
+  isNavCatalogLoaded,
+  type NavCatalogEntryWithRules,
+} from '../lib/nav-catalog-db';
 import { ContextLens, createContextLens } from '../types/context-lens';
 import { searchKnowledgeDocs, KnowledgeDoc } from './knowledge-hub';
 import { buildContextPack } from './context-pack-builder';
@@ -64,9 +71,19 @@ export interface NavigatorConsultPick {
   screen_id: string;
   route: string;
   title: string;
+  // Attached when the pick comes from real catalog scoring; admins use the
+  // score to debug near-misses in the /admin/navigator Coverage & Telemetry
+  // views. Optional because synthetic picks (e.g. override-trigger matches)
+  // don't have a score on the normal scale.
+  score?: number;
 }
 
 export type ConsultConfidence = 'high' | 'medium' | 'low';
+
+// VTID-NAV-02: How the winning pick was chosen. Surfaced in telemetry so
+// admins can distinguish "LLM-scored win" from "exact-phrase override" from
+// "tenant forced a custom screen".
+export type ConsultDecisionSource = 'scoring' | 'override_trigger' | 'static_fallback';
 
 export interface NavigatorConsultResult {
   confidence: ConsultConfidence;
@@ -77,6 +94,11 @@ export interface NavigatorConsultResult {
   suggested_question?: string;
   kb_excerpts: string[];
   blocked_reason?: 'requires_auth' | 'no_match';
+  // VTID-NAV-02: top-3 scored picks emitted in orb.navigator.consulted events
+  // so the admin telemetry page can surface near-misses ("we picked A, but B
+  // was at score-2") and dead triggers.
+  top_picks: NavigatorConsultPick[];
+  decision_source: ConsultDecisionSource;
   // Telemetry
   ms_elapsed: number;
   catalog_match_count: number;
@@ -287,10 +309,23 @@ function scoreCatalogWithMemory(
   const excludeRoutes: string[] = [];
   if (input.current_route) excludeRoutes.push(input.current_route);
 
-  const baseResults = searchCatalog(input.question, input.lang, {
-    anonymous_only: input.is_anonymous,
-    exclude_routes: excludeRoutes,
-  });
+  // VTID-NAV-02: prefer the DB-backed tenant-aware catalog when the cache
+  // has been warmed. Falls back transparently to the static scorer so that
+  // the 77 navigation-catalog tests keep passing unchanged and first-boot
+  // sessions still work before refreshNavCatalogCache completes.
+  const tenantId = input.identity?.tenant_id || null;
+  const baseResults: Array<{ entry: NavCatalogEntry; score: number }> =
+    isNavCatalogLoaded()
+      ? searchCatalogEntries(
+          getCatalogForTenant(tenantId) as ReadonlyArray<NavCatalogEntry>,
+          input.question,
+          input.lang,
+          { anonymous_only: input.is_anonymous, exclude_routes: excludeRoutes }
+        )
+      : searchCatalog(input.question, input.lang, {
+          anonymous_only: input.is_anonymous,
+          exclude_routes: excludeRoutes,
+        });
 
   if (baseResults.length === 0) return baseResults;
 
@@ -335,6 +370,42 @@ export async function consultNavigator(
 ): Promise<NavigatorConsultResult> {
   const startTime = Date.now();
 
+  // ── VTID-NAV-02: override-trigger shortcut ─────────────────────────────
+  // Before running scoring, check if an admin has registered an exact-match
+  // phrase override for this utterance in this tenant's catalog. If so, we
+  // short-circuit with synthetic high confidence — this is the escape hatch
+  // for "wrong screen" bugs the scorer can't fix through tuning.
+  const tenantIdForOverride = input.identity?.tenant_id || null;
+  const overrideMatch = isNavCatalogLoaded()
+    ? findOverrideTriggerMatch(input.question, input.lang, tenantIdForOverride)
+    : null;
+  if (overrideMatch && !input.is_anonymous) {
+    const pick = entryToPick(overrideMatch as NavCatalogEntry, input.lang);
+    const explanation = buildExplanation({
+      primary: pick,
+      confidence: 'high',
+      hints: EMPTY_HINTS,
+      lang: input.lang,
+    });
+    return {
+      confidence: 'high',
+      primary: pick,
+      explanation,
+      confirmation_needed: false,
+      kb_excerpts: staticKbAnchors(overrideMatch as NavCatalogEntry),
+      top_picks: [pick],
+      decision_source: 'override_trigger',
+      ms_elapsed: Date.now() - startTime,
+      catalog_match_count: 1,
+      memory_hint_count: 0,
+      kb_excerpt_count: 0,
+    };
+  }
+  // Anonymous sessions + override triggers: fall through to normal flow so
+  // anonymous_safe gating still applies (an admin-set override must not leak
+  // an authenticated-only screen to unauthenticated sessions).
+  const decisionSource: ConsultDecisionSource = isNavCatalogLoaded() ? 'scoring' : 'static_fallback';
+
   // Run memory hints + KB search in parallel — they're the slow parts.
   const [hints, runtimeKbExcerpts] = await Promise.all([
     fetchMemoryHints(input),
@@ -345,6 +416,14 @@ export async function consultNavigator(
   const scored = scoreCatalogWithMemory(input, hints);
   const top = scored[0];
   const second = scored[1];
+
+  // VTID-NAV-02: build the top-3 picks payload for telemetry. Attach the raw
+  // score so the admin Telemetry view can surface near-misses and the admin
+  // Simulator can show the full ranking.
+  const topPicks: NavigatorConsultPick[] = scored.slice(0, 3).map(s => ({
+    ...entryToPick(s.entry, input.lang),
+    score: s.score,
+  }));
 
   // ── Bucket by confidence ────────────────────────────────────────────────
   let confidence: ConsultConfidence;
@@ -430,6 +509,8 @@ export async function consultNavigator(
     suggested_question: suggestedQuestion,
     kb_excerpts: kbExcerpts,
     blocked_reason: blockedReason,
+    top_picks: topPicks,
+    decision_source: decisionSource,
     ms_elapsed: Date.now() - startTime,
     catalog_match_count: scored.length,
     memory_hint_count:

--- a/supabase/migrations/20260411000000_nav_catalog.sql
+++ b/supabase/migrations/20260411000000_nav_catalog.sql
@@ -1,0 +1,191 @@
+-- =============================================================================
+-- VTID-NAV-02: Navigator Catalog Database Schema
+-- =============================================================================
+-- Migrates the Vitana Navigator catalog from a static TypeScript constant
+-- (services/gateway/src/lib/navigation-catalog.ts) to DB-backed tables so
+-- Community Admin users can add/edit screens and their trigger phrases at
+-- runtime without redeploying the gateway.
+--
+-- Schema:
+--   nav_catalog            — one row per (screen_id, tenant_id). tenant_id IS
+--                            NULL means "shared across all tenants" (this is
+--                            the default for the ~38 entries that exist today).
+--                            A non-null tenant_id row with the same screen_id
+--                            is a per-tenant override that replaces the shared
+--                            entry for that tenant at scoring time.
+--   nav_catalog_i18n       — one row per (catalog_id, lang). English (`en`) is
+--                            required; other languages optional and fall back
+--                            to English via the consult service.
+--   nav_catalog_audit      — append-only edit history. Every create/update/
+--                            delete writes a row with before/after JSONB so
+--                            admins can review and revert.
+--
+-- Scoring rules beyond `when_to_visit` (see navigator-consult.ts):
+--   context_rules JSONB     — exclude_routes[], require_memory_goal, boost_if,
+--                             etc. Structured but free-form; lifted into the
+--                             admin UI as dedicated fields.
+--   override_triggers JSONB — list of { lang, phrase, active } entries that
+--                             force the screen to win with synthetic high
+--                             confidence, bypassing normal scoring. Fixes
+--                             "wrong screen" issues immediately for specific
+--                             phrasings without tuning the scorer.
+--
+-- Tenant override uniqueness is enforced by two partial unique indexes:
+--   - at most one shared (tenant_id IS NULL) row per screen_id
+--   - at most one per-tenant row per (screen_id, tenant_id)
+--
+-- RLS: strictly service-role read/write. The admin API is the sole entrypoint
+-- for writes and already gates on exafy_admin.
+-- =============================================================================
+
+-- ── nav_catalog ─────────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.nav_catalog (
+  id               UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  screen_id        TEXT NOT NULL,
+  -- tenant_id is nullable on purpose: NULL = shared across all tenants.
+  -- FK omitted intentionally so this migration is safe to run regardless of
+  -- whether tenants.id is UUID or TEXT across environments; the admin API
+  -- validates tenant existence before write.
+  tenant_id        UUID NULL,
+  route            TEXT NOT NULL,
+  category         TEXT NOT NULL,
+  access           TEXT NOT NULL CHECK (access IN ('public', 'authenticated')),
+  anonymous_safe   BOOLEAN NOT NULL DEFAULT FALSE,
+  priority         INTEGER NOT NULL DEFAULT 0,
+  related_kb_topics JSONB NOT NULL DEFAULT '[]'::jsonb,
+  context_rules    JSONB NOT NULL DEFAULT '{}'::jsonb,
+  override_triggers JSONB NOT NULL DEFAULT '[]'::jsonb,
+  is_active        BOOLEAN NOT NULL DEFAULT TRUE,
+  created_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at       TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_by       UUID NULL
+);
+
+-- Partial unique indexes enforce the shared-vs-tenant override model.
+-- Postgres NULLs aren't considered equal in unique constraints, so we split.
+CREATE UNIQUE INDEX IF NOT EXISTS nav_catalog_screen_shared_uq
+  ON public.nav_catalog (screen_id)
+  WHERE tenant_id IS NULL;
+
+CREATE UNIQUE INDEX IF NOT EXISTS nav_catalog_screen_tenant_uq
+  ON public.nav_catalog (screen_id, tenant_id)
+  WHERE tenant_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS nav_catalog_tenant_idx
+  ON public.nav_catalog (tenant_id)
+  WHERE tenant_id IS NOT NULL;
+
+CREATE INDEX IF NOT EXISTS nav_catalog_category_idx
+  ON public.nav_catalog (category);
+
+CREATE INDEX IF NOT EXISTS nav_catalog_active_idx
+  ON public.nav_catalog (is_active)
+  WHERE is_active = TRUE;
+
+COMMENT ON TABLE public.nav_catalog IS
+  'VTID-NAV-02: Vitana Navigator catalog. DB-backed replacement for the static NAVIGATION_CATALOG constant.';
+COMMENT ON COLUMN public.nav_catalog.tenant_id IS
+  'NULL = shared across all tenants. Non-null = tenant-specific override of the shared entry with the same screen_id.';
+COMMENT ON COLUMN public.nav_catalog.context_rules IS
+  'JSONB shape: { exclude_on_routes: string[], require_goal_match: string[], boost_if_recent_topic: string[] }';
+COMMENT ON COLUMN public.nav_catalog.override_triggers IS
+  'JSONB array: [{ lang: string, phrase: string, active: boolean }]. Exact-match bypass rules that force this screen to win.';
+
+-- ── nav_catalog_i18n ────────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.nav_catalog_i18n (
+  catalog_id     UUID NOT NULL REFERENCES public.nav_catalog(id) ON DELETE CASCADE,
+  lang           TEXT NOT NULL,
+  title          TEXT NOT NULL,
+  description    TEXT NOT NULL DEFAULT '',
+  when_to_visit  TEXT NOT NULL DEFAULT '',
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  PRIMARY KEY (catalog_id, lang)
+);
+
+CREATE INDEX IF NOT EXISTS nav_catalog_i18n_lang_idx
+  ON public.nav_catalog_i18n (lang);
+
+COMMENT ON TABLE public.nav_catalog_i18n IS
+  'Localized title/description/when_to_visit for nav_catalog entries. `when_to_visit` is the primary trigger phrase text the Navigator scorer matches against.';
+
+-- ── nav_catalog_audit ───────────────────────────────────────────────────────
+
+CREATE TABLE IF NOT EXISTS public.nav_catalog_audit (
+  id             UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  catalog_id     UUID NULL,
+  screen_id      TEXT NULL,
+  tenant_id      UUID NULL,
+  action         TEXT NOT NULL CHECK (action IN ('create', 'update', 'delete', 'restore')),
+  before         JSONB NULL,
+  after          JSONB NULL,
+  actor_user_id  UUID NULL,
+  actor_email    TEXT NULL,
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS nav_catalog_audit_catalog_idx
+  ON public.nav_catalog_audit (catalog_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS nav_catalog_audit_screen_idx
+  ON public.nav_catalog_audit (screen_id, created_at DESC);
+
+COMMENT ON TABLE public.nav_catalog_audit IS
+  'Append-only edit history for nav_catalog. Every admin write produces one row; supports revert via /api/v1/admin/navigator/catalog/:id/restore/:audit_id.';
+
+-- ── updated_at trigger ──────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION public.nav_catalog_touch_updated_at()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  NEW.updated_at := NOW();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS nav_catalog_touch_updated_at ON public.nav_catalog;
+CREATE TRIGGER nav_catalog_touch_updated_at
+  BEFORE UPDATE ON public.nav_catalog
+  FOR EACH ROW
+  EXECUTE FUNCTION public.nav_catalog_touch_updated_at();
+
+DROP TRIGGER IF EXISTS nav_catalog_i18n_touch_updated_at ON public.nav_catalog_i18n;
+CREATE TRIGGER nav_catalog_i18n_touch_updated_at
+  BEFORE UPDATE ON public.nav_catalog_i18n
+  FOR EACH ROW
+  EXECUTE FUNCTION public.nav_catalog_touch_updated_at();
+
+-- ── RLS ─────────────────────────────────────────────────────────────────────
+
+ALTER TABLE public.nav_catalog          ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.nav_catalog_i18n     ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.nav_catalog_audit    ENABLE ROW LEVEL SECURITY;
+
+-- Admin (exafy_admin) can read everything. Writes go through the service
+-- role via the admin API; no authenticated-user writes are permitted.
+DO $$ BEGIN
+  CREATE POLICY admin_read_nav_catalog ON public.nav_catalog
+    FOR SELECT TO authenticated
+    USING ((auth.jwt() -> 'app_metadata' ->> 'exafy_admin')::boolean IS TRUE);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  CREATE POLICY admin_read_nav_catalog_i18n ON public.nav_catalog_i18n
+    FOR SELECT TO authenticated
+    USING ((auth.jwt() -> 'app_metadata' ->> 'exafy_admin')::boolean IS TRUE);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+DO $$ BEGIN
+  CREATE POLICY admin_read_nav_catalog_audit ON public.nav_catalog_audit
+    FOR SELECT TO authenticated
+    USING ((auth.jwt() -> 'app_metadata' ->> 'exafy_admin')::boolean IS TRUE);
+EXCEPTION WHEN duplicate_object THEN NULL;
+END $$;
+
+-- The gateway's service role bypasses RLS for writes; the admin API layer
+-- is the sole place that validates exafy_admin before touching these tables.


### PR DESCRIPTION
## Summary

Backs the Vitana Navigator catalog with Supabase so Community Admin users can add/edit the screens + trigger phrases Vitana uses for voice-driven redirects, **without a gateway redeploy**. Ships the backend half of VTID-NAV-02; the React admin screen ships in exafyltd/vitana-v1 on the matching branch.

Root cause this fixes: today `services/gateway/src/lib/navigation-catalog.ts` is a hand-curated static TS constant, so every trigger edit or new screen needs a PR + deploy, and admins can't react to "wrong screen" bug reports. This PR lifts the catalog into DB tables, keeps the static constant as a safety fallback, and wires a secure admin API behind the existing dual-JWT `requireAdminAuth` middleware.

## Schema — `supabase/migrations/20260411000000_nav_catalog.sql`

Three new tables, all RLS-enabled, writes gated at the API layer:

- `nav_catalog` — one row per (screen_id, tenant_id). `tenant_id IS NULL` means shared across all tenants; a non-null tenant row with the same screen_id overrides the shared entry for that tenant at scoring time. Partial unique indexes enforce one-shared + one-per-tenant. New fields on top of the static schema: `context_rules JSONB`, `override_triggers JSONB`, `is_active`, `updated_by`, audit columns.
- `nav_catalog_i18n` — localized `title` / `description` / `when_to_visit` per `(catalog_id, lang)`. `when_to_visit` is the primary trigger text the scorer matches against.
- `nav_catalog_audit` — append-only edit history; every admin write stamps a before/after JSONB snapshot so admins can revert.

## Gateway code

- **`services/gateway/src/lib/nav-catalog-db.ts` (new)** — tenant-keyed in-memory cache with 60 s background refresh + invalidate-on-write. First call falls back to the compile-time `NAVIGATION_CATALOG` constant so the orb never goes dark during deploy / rollback / DB outage. Also exports `findOverrideTriggerMatch` (exact-phrase bypass) and `searchCatalogEntries` — a deliberate copy of `searchCatalog()`'s scorer that operates on a passed-in entry list so the 77 existing navigator tests keep passing unchanged.
- **`services/gateway/src/lib/spa-routes-fallback.ts` (new)** — hard-coded SPA route inventory used by the coverage endpoint until the build-time extract from vitana-v1 ships via CI.
- **`services/gateway/src/routes/admin-navigator.ts` (new)** — 11 endpoints mounted at `/api/v1/admin/navigator`, all gated by `requireAdminAuth` (dual Platform + Lovable JWT via `services/gateway/src/middleware/auth-supabase-jwt.ts`). This is important: the community app signs users into the Lovable Supabase project, so the Platform-only `createUserSupabaseClient` pattern used elsewhere would reject legit community-side admin tokens. The middleware handles both.
  - `GET/POST/PATCH/DELETE /catalog` + `GET /catalog/:id` + `POST /catalog/:id/restore/:audit_id`
  - `POST /simulate` — runs the **real** `consultNavigator()` pipeline against an admin-supplied utterance and returns the full scored result (primary + alternative + top-3 picks with raw scores + decision_source). This is the admin's "verify before save" feedback loop.
  - `GET /spa-routes` — canonical vitana-v1 route list
  - `GET /coverage` — SPA ↔ catalog diff: missing entries, broken catalog routes, dead triggers (30d window via `oasis_events_v1`)
  - `GET /telemetry` — 7/30/90-day aggregates from `orb.navigator.*` events
  - `POST /reload` — force cache refresh (dev convenience)
  - All writes emit audit rows + `invalidateNavCatalogCache()` so the next orb session sees the edit immediately (no 60 s wait).
- **`services/gateway/src/services/navigator-consult.ts`** — three surgical changes:
  1. **Override-trigger shortcut before scoring.** If an admin has registered an exact-match phrase in this tenant's catalog, short-circuit with synthetic high confidence and `decision_source='override_trigger'`. Anonymous sessions still fall through to normal flow so the `anonymous_safe` gate applies.
  2. **Tenant-aware scoring.** `scoreCatalogWithMemory()` prefers the DB cache via `searchCatalogEntries(getCatalogForTenant(...))` when loaded; falls back to the static scorer otherwise. The 77 existing tests exercise the static path and keep passing.
  3. **`top_picks` + `decision_source` on the result.** Top-3 scored entries with raw scores are carried through `NavigatorConsultResult` so the admin Telemetry page can surface near-misses and the Simulator can render the full ranking. `NavigatorConsultPick` gains an optional `score` for the same reason.
- **`services/gateway/src/index.ts`** — imports the new router + mounts it at `/api/v1/admin/navigator` under `owner='admin-navigator'`. Calls `warmNavCatalogCache()` alongside the existing AI personality pre-warm so the tenant cache is populated before the first orb session. The periodic 60 s refresh runs via an unref'd interval inside the warmer — never blocks graceful shutdown.
- **`services/gateway/src/scripts/seed-nav-catalog.ts` (new)** — idempotent standalone script that upserts every current `NAVIGATION_CATALOG` entry as a shared (tenant_id = NULL) row + its i18n children. Run once post-migration to backfill; subsequent runs no-op.

## What does NOT change

- `services/gateway/src/lib/navigation-catalog.ts` is untouched. The static constant still exists as the compile-time fallback and is the data the 77 navigator tests exercise.
- No other existing routes are modified. No existing tests are touched.
- No schema changes to any existing tables.

## Rollback

1. Revert this commit → static catalog serves all requests via the unchanged fallback path (the `nav_catalog` table can sit empty with zero user impact).
2. `DROP TABLE nav_catalog_audit, nav_catalog_i18n, nav_catalog;` if you want a clean slate.
3. No data loss — the static catalog is the source of truth until the seed script runs.

## Test plan

- [ ] `services/gateway/npx tsc --noEmit` clean ✅ (verified locally)
- [ ] `services/gateway/npx jest test/navigation-catalog.test.ts test/navigator-consult.test.ts` — 77/77 passing ✅ (verified locally)
- [ ] Boot-time smoke test: `admin-navigator.ts` module graph loads under tsx with all 11 routes registered ✅ (verified locally)
- [ ] Migration applies cleanly on Supabase (manual or via CI)
- [ ] After merge: run `npx ts-node services/gateway/src/scripts/seed-nav-catalog.ts` with `SUPABASE_URL` + `SUPABASE_SERVICE_ROLE` set → expect `created=~41 updated=0 failed=0`
- [ ] `curl https://gateway-q74ibpv6ia-uc.a.run.app/api/v1/admin/navigator/catalog` (no auth) → 401 UNAUTHENTICATED
- [ ] `curl -H "Authorization: Bearer <admin_jwt>" .../admin/navigator/catalog?tenant_id=__shared__` → 200 with ~41 entries
- [ ] `POST /api/v1/admin/navigator/simulate` with `{ "utterance": "how do I track my biology", "lang": "en" }` → `confidence='high'`, primary screen_id `HEALTH.MY_BIOLOGY`
- [ ] `GET /api/v1/admin/navigator/coverage` → shows real SPA ↔ catalog diff
- [ ] Existing navigator flow unaffected: orb opens, "open my wallet" → `/wallet` (regression)

The React admin UI that consumes these endpoints (`/admin/navigator` under `AdminGuard`) ships in the matching vitana-v1 branch.

🤖 Generated with [Claude Code](https://claude.com/claude-code)