### PR TITLE
feat(agents-registry): wire self-registration into worker-runner + vitana-orchestrator

### DIFF
--- a/services/agents/vitana-orchestrator/server.py
+++ b/services/agents/vitana-orchestrator/server.py
@@ -10,12 +10,14 @@ results that the orchestrator uses to make decisions. OASIS remains the sole
 authority for terminal task status.
 """
 
+import asyncio
 import logging
 import os
 from datetime import datetime
 from pathlib import Path
 from typing import Any, Dict, List, Optional
 
+import httpx
 from fastapi import FastAPI, HTTPException
 from pydantic import BaseModel, Field
 
@@ -50,6 +52,75 @@ config = StageGateConfig(
     git_sha=os.getenv("GIT_SHA", "unknown"),
 )
 stage_gate = VerificationStageGate(config)
+
+
+# =============================================================================
+# Agents Registry self-registration (inlined — shared module not in Docker
+# build context, see services/agents/shared/agents_registry_client.py)
+# =============================================================================
+
+_AGENT_REG_TASK: Optional[asyncio.Task] = None  # type: ignore[type-arg]
+
+
+async def _agent_hb(gw: str, payload: Dict[str, Any]) -> bool:
+    try:
+        async with httpx.AsyncClient(timeout=5.0) as c:
+            r = await c.post(f"{gw}/api/v1/agents/registry/heartbeat", json=payload)
+            if r.status_code >= 400:
+                logger.warning("[agents-registry] heartbeat failed: %d %s", r.status_code, r.text[:200])
+                return False
+            return True
+    except Exception as e:  # noqa: BLE001
+        logger.warning("[agents-registry] heartbeat threw: %s", e)
+        return False
+
+
+async def _agent_hb_loop(gw: str) -> None:
+    p = {"agent_id": "vitana-orchestrator", "status": "healthy"}
+    while True:
+        try:
+            await asyncio.sleep(60)
+            await _agent_hb(gw, p)
+        except asyncio.CancelledError:
+            raise
+        except Exception:  # noqa: BLE001
+            pass
+
+
+@app.on_event("startup")
+async def _reg_startup() -> None:
+    global _AGENT_REG_TASK
+    gw = os.getenv("GATEWAY_URL") or os.getenv("OASIS_GATEWAY_URL")
+    if not gw:
+        logger.warning("[agents-registry] No GATEWAY_URL — self-registration disabled")
+        return
+    await _agent_hb(gw, {
+        "agent_id": "vitana-orchestrator", "status": "healthy",
+        "display_name": "Vitana Verification Engine",
+        "description": "Verification stage gate (VTID-01175). Verifies worker output before task completion.",
+        "tier": "service", "role": "verification",
+        "llm_provider": "claude", "llm_model": "claude-3-5-sonnet-20241022",
+        "source_path": "services/agents/vitana-orchestrator/",
+        "health_endpoint": "/health",
+        "metadata": {"vtid": __vtid__, "version": __version__, "fallback_provider": "gemini"},
+    })
+    logger.info("[agents-registry] Registered vitana-orchestrator")
+    _AGENT_REG_TASK = asyncio.create_task(_agent_hb_loop(gw))
+
+
+@app.on_event("shutdown")
+async def _reg_shutdown() -> None:
+    global _AGENT_REG_TASK
+    if _AGENT_REG_TASK:
+        _AGENT_REG_TASK.cancel()
+        try:
+            await _AGENT_REG_TASK
+        except asyncio.CancelledError:
+            pass
+        _AGENT_REG_TASK = None
+    gw = os.getenv("GATEWAY_URL") or os.getenv("OASIS_GATEWAY_URL")
+    if gw:
+        await _agent_hb(gw, {"agent_id": "vitana-orchestrator", "status": "down"})
 
 
 # --- Request/Response Models ---

--- a/services/worker-runner/src/index.ts
+++ b/services/worker-runner/src/index.ts
@@ -15,6 +15,7 @@
 import express, { Request, Response } from 'express';
 import { config as dotenvConfig } from 'dotenv';
 import { WorkerRunner, createRunnerFromEnv } from './services/runner-service';
+import { startAgentRegistration } from './lib/agents-registry-client';
 
 // Load environment variables
 dotenvConfig();
@@ -28,6 +29,7 @@ app.use(express.json());
 
 // Runner instance
 let runner: WorkerRunner | null = null;
+let stopAgentRegistration: (() => void) | null = null;
 
 // =============================================================================
 // Health Check Endpoints
@@ -192,9 +194,32 @@ async function main(): Promise<void> {
   console.log(`[${VTID}] Worker Runner Execution Plane started successfully`);
   console.log(`[${VTID}] Polling for tasks every ${process.env.POLL_INTERVAL_MS || '5000'}ms`);
 
+  // Self-register with the agents registry (fire-and-forget, non-blocking)
+  try {
+    stopAgentRegistration = startAgentRegistration({
+      gatewayUrl: process.env.GATEWAY_URL || '',
+      agentId: 'worker-runner',
+      displayName: 'Worker Runner',
+      description: 'Autonomous VTID execution plane (VTID-01200). Polls, claims, executes via LLM, terminalizes.',
+      tier: 'service',
+      role: 'executor',
+      llmProvider: 'gemini',
+      llmModel: process.env.VERTEX_MODEL || 'gemini-3.1-pro-preview',
+      sourcePath: 'services/worker-runner/',
+      healthEndpoint: '/alive',
+      metadata: { vtid: VTID },
+    });
+  } catch (err) {
+    console.warn(`[${VTID}] Agents registry self-registration failed (non-fatal):`, err);
+  }
+
   // Graceful shutdown handlers
   const shutdown = async (signal: string): Promise<void> => {
     console.log(`[${VTID}] Received ${signal}, shutting down...`);
+
+    if (stopAgentRegistration) {
+      try { stopAgentRegistration(); } catch { /* best-effort */ }
+    }
 
     if (runner) {
       await runner.stop();


### PR DESCRIPTION
## Summary
- worker-runner heartbeats to agents registry every 60s via the TS helper
- vitana-orchestrator heartbeats via inlined FastAPI startup/shutdown hooks
- After deploy, both flip from unknown (white) to healthy (green) in Command Hub

## Test plan
- [ ] Deploy worker-runner + vitana-orchestrator
- [ ] Verify both show healthy in `/command-hub/agents/registered-agents/`

🤖 Generated with [Claude Code](https://claude.com/claude-code)