### PR TITLE
fix(ci): add OASIS_GATEWAY_URL to vitana-verification-engine deploy

### DIFF
--- a/.github/workflows/EXEC-DEPLOY.yml
+++ b/.github/workflows/EXEC-DEPLOY.yml
@@ -340,6 +340,14 @@ jobs:
             SECRETS_ARGS+=(--update-secrets=SUPABASE_SERVICE_ROLE=SUPABASE_SERVICE_ROLE:latest)
           fi
 
+          # VTID-01175: Vitana Verification Engine — needs gateway URL for agents registry heartbeat
+          if [ "$CLOUD_RUN_SERVICE" = "vitana-verification-engine" ]; then
+            GATEWAY_URL=$(gcloud run services describe gateway --region=us-central1 --format='value(status.url)' 2>/dev/null || echo "")
+            if [ -n "$GATEWAY_URL" ]; then
+              EXTRA_ENV_ARGS+=(--update-env-vars=OASIS_GATEWAY_URL=$GATEWAY_URL)
+            fi
+          fi
+
           # Build deploy args
           DEPLOY_ARGS=(
             --source="$SOURCE_PATH"


### PR DESCRIPTION
## Summary
Adds `OASIS_GATEWAY_URL` env var to the vitana-verification-engine deploy block in EXEC-DEPLOY.yml so the agents-registry self-registration heartbeat works.

## Test plan
- [ ] Deploy vitana-verification-engine → confirm it heartbeats and shows healthy in the registry

🤖 Generated with [Claude Code](https://claude.com/claude-code)