### PR TITLE
feat(admin-autopilot): tenant-scoped config + admin API (VTID-AP-ADMIN)

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -228,6 +228,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const { acceptRouter: invitationAcceptRouter } = require('./routes/tenant-admin/invitations');
   // VTID-NAV-02: Admin Navigator — DB-backed catalog CRUD, simulate, coverage, telemetry
   const adminNavigatorRouter = require('./routes/admin-navigator').default;
+  // VTID-AP-ADMIN: Tenant-scoped Autopilot admin — settings, bindings, runs, recommendations
+  const adminAutopilotRouter = require('./routes/admin-autopilot').default;
   // VTID-NAV-02: Navigator catalog DB cache warmer (runs at boot)
   const { warmNavCatalogCache } = require('./lib/nav-catalog-db');
   // Voice Feedback — Test user bug reports & UX improvement suggestions
@@ -579,6 +581,9 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
 
   // VTID-NAV-02: Admin Navigator — catalog/simulate/coverage/telemetry
   mountRouterSync(app, '/api/v1/admin/navigator', adminNavigatorRouter, { owner: 'admin-navigator' });
+
+  // VTID-AP-ADMIN: Autopilot admin — settings, bindings, catalog, runs, recommendations
+  mountRouterSync(app, '/api/v1/admin/autopilot', adminAutopilotRouter, { owner: 'admin-autopilot' });
 
   // VTID-01250: Autopilot Automations Engine — AP-XXXX registry, executor, wallet, sharing
   mountRouterSync(app, '/api/v1/automations', automationsRouter, { owner: 'automations' });

--- a/services/gateway/src/routes/admin-autopilot.ts
+++ b/services/gateway/src/routes/admin-autopilot.ts
@@ -1,0 +1,670 @@
+/**
+ * VTID-AP-ADMIN: Tenant-scoped Autopilot administration routes.
+ *
+ * All endpoints gated by requireTenantAdmin — supports both exafy_admin
+ * (super-admin, all tenants) and tenant-admin (own tenant only).
+ *
+ * Mounted at /api/v1/admin/autopilot
+ */
+
+import { Router, Request, Response } from 'express';
+import { requireTenantAdmin } from '../middleware/require-tenant-admin';
+import { AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
+import { getSupabase } from '../lib/supabase';
+
+const router = Router();
+const VTID = 'VTID-AP-ADMIN';
+
+// ── Helpers ──────────────────────────────────────────────────────────────────
+
+function getTenantId(req: Request): string {
+  return (req as any).targetTenantId || (req as AuthenticatedRequest).identity?.tenant_id;
+}
+
+function getUserId(req: Request): string | undefined {
+  return (req as AuthenticatedRequest).identity?.user_id;
+}
+
+// ── Settings ─────────────────────────────────────────────────────────────────
+
+/**
+ * GET /settings
+ * Returns tenant autopilot settings (creates default row if none exists).
+ */
+router.get('/settings', requireTenantAdmin, async (req: Request, res: Response) => {
+  try {
+    const tenantId = getTenantId(req);
+    const supabase = getSupabase();
+    if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+
+    let { data, error } = await supabase
+      .from('tenant_autopilot_settings')
+      .select('*')
+      .eq('tenant_id', tenantId)
+      .maybeSingle();
+
+    if (error) throw error;
+
+    // Auto-provision defaults on first access
+    if (!data) {
+      const { data: created, error: createErr } = await supabase
+        .from('tenant_autopilot_settings')
+        .insert({ tenant_id: tenantId })
+        .select('*')
+        .single();
+      if (createErr) throw createErr;
+      data = created;
+    }
+
+    res.json({ ok: true, data });
+  } catch (err: any) {
+    console.error(`[${VTID}] GET /settings error:`, err.message);
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+/**
+ * PATCH /settings
+ * Update tenant autopilot settings.
+ */
+router.patch('/settings', requireTenantAdmin, async (req: Request, res: Response) => {
+  try {
+    const tenantId = getTenantId(req);
+    const userId = getUserId(req);
+    const supabase = getSupabase();
+    if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+
+    const allowed = [
+      'enabled', 'max_recommendations_per_day', 'max_activations_per_day',
+      'allowed_domains', 'allowed_risk_levels', 'auto_activate_threshold',
+      'recommendation_retention_days', 'generation_schedule',
+    ];
+    const updates: Record<string, unknown> = {};
+    for (const key of allowed) {
+      if (req.body[key] !== undefined) updates[key] = req.body[key];
+    }
+    if (Object.keys(updates).length === 0) {
+      return res.status(400).json({ ok: false, error: 'NO_CHANGES', message: 'No valid fields to update' });
+    }
+    updates.updated_by = userId;
+
+    // Ensure row exists first
+    const { data: existing } = await supabase
+      .from('tenant_autopilot_settings')
+      .select('id')
+      .eq('tenant_id', tenantId)
+      .maybeSingle();
+
+    if (!existing) {
+      // Create with overrides
+      const { data, error } = await supabase
+        .from('tenant_autopilot_settings')
+        .insert({ tenant_id: tenantId, ...updates })
+        .select('*')
+        .single();
+      if (error) throw error;
+      return res.json({ ok: true, data });
+    }
+
+    const { data, error } = await supabase
+      .from('tenant_autopilot_settings')
+      .update(updates)
+      .eq('tenant_id', tenantId)
+      .select('*')
+      .single();
+
+    if (error) throw error;
+    res.json({ ok: true, data });
+  } catch (err: any) {
+    console.error(`[${VTID}] PATCH /settings error:`, err.message);
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+// ── Bindings (Active Automations) ────────────────────────────────────────────
+
+/**
+ * GET /bindings
+ * List all automation bindings for the tenant.
+ */
+router.get('/bindings', requireTenantAdmin, async (req: Request, res: Response) => {
+  try {
+    const tenantId = getTenantId(req);
+    const supabase = getSupabase();
+    if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+
+    const { enabled } = req.query;
+    let query = supabase
+      .from('tenant_autopilot_bindings')
+      .select('*')
+      .eq('tenant_id', tenantId)
+      .order('automation_id', { ascending: true });
+
+    if (enabled === 'true') query = query.eq('enabled', true);
+    if (enabled === 'false') query = query.eq('enabled', false);
+
+    const { data, error } = await query;
+    if (error) throw error;
+
+    res.json({ ok: true, data: data || [] });
+  } catch (err: any) {
+    console.error(`[${VTID}] GET /bindings error:`, err.message);
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+/**
+ * POST /bindings
+ * Create or upsert a binding for a specific automation.
+ */
+router.post('/bindings', requireTenantAdmin, async (req: Request, res: Response) => {
+  try {
+    const tenantId = getTenantId(req);
+    const userId = getUserId(req);
+    const supabase = getSupabase();
+    if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+
+    const { automation_id, enabled, schedule, guardrails, role_allowances,
+            requires_approval, max_runs_per_day, max_runs_per_user_per_day } = req.body;
+
+    if (!automation_id) {
+      return res.status(400).json({ ok: false, error: 'MISSING_AUTOMATION_ID' });
+    }
+
+    const row = {
+      tenant_id: tenantId,
+      automation_id,
+      enabled: enabled ?? true,
+      schedule: schedule ?? null,
+      guardrails: guardrails ?? null,
+      role_allowances: role_allowances ?? ['admin'],
+      requires_approval: requires_approval ?? true,
+      max_runs_per_day: max_runs_per_day ?? null,
+      max_runs_per_user_per_day: max_runs_per_user_per_day ?? null,
+      updated_by: userId,
+    };
+
+    const { data, error } = await supabase
+      .from('tenant_autopilot_bindings')
+      .upsert(row, { onConflict: 'tenant_id,automation_id' })
+      .select('*')
+      .single();
+
+    if (error) throw error;
+    res.json({ ok: true, data });
+  } catch (err: any) {
+    console.error(`[${VTID}] POST /bindings error:`, err.message);
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+/**
+ * PATCH /bindings/:bindingId
+ * Update an existing binding.
+ */
+router.patch('/bindings/:bindingId', requireTenantAdmin, async (req: Request, res: Response) => {
+  try {
+    const tenantId = getTenantId(req);
+    const userId = getUserId(req);
+    const { bindingId } = req.params;
+    const supabase = getSupabase();
+    if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+
+    const allowed = [
+      'enabled', 'schedule', 'guardrails', 'role_allowances',
+      'requires_approval', 'max_runs_per_day', 'max_runs_per_user_per_day',
+    ];
+    const updates: Record<string, unknown> = {};
+    for (const key of allowed) {
+      if (req.body[key] !== undefined) updates[key] = req.body[key];
+    }
+    if (Object.keys(updates).length === 0) {
+      return res.status(400).json({ ok: false, error: 'NO_CHANGES' });
+    }
+    updates.updated_by = userId;
+
+    const { data, error } = await supabase
+      .from('tenant_autopilot_bindings')
+      .update(updates)
+      .eq('id', bindingId)
+      .eq('tenant_id', tenantId)
+      .select('*')
+      .single();
+
+    if (error) throw error;
+    if (!data) return res.status(404).json({ ok: false, error: 'NOT_FOUND' });
+    res.json({ ok: true, data });
+  } catch (err: any) {
+    console.error(`[${VTID}] PATCH /bindings/:bindingId error:`, err.message);
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+/**
+ * DELETE /bindings/:bindingId
+ * Remove a binding.
+ */
+router.delete('/bindings/:bindingId', requireTenantAdmin, async (req: Request, res: Response) => {
+  try {
+    const tenantId = getTenantId(req);
+    const { bindingId } = req.params;
+    const supabase = getSupabase();
+    if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+
+    const { error } = await supabase
+      .from('tenant_autopilot_bindings')
+      .delete()
+      .eq('id', bindingId)
+      .eq('tenant_id', tenantId);
+
+    if (error) throw error;
+    res.json({ ok: true });
+  } catch (err: any) {
+    console.error(`[${VTID}] DELETE /bindings/:bindingId error:`, err.message);
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+// ── Runs (Execution History) ─────────────────────────────────────────────────
+
+/**
+ * GET /runs
+ * List execution runs for the tenant (paginated, filterable).
+ */
+router.get('/runs', requireTenantAdmin, async (req: Request, res: Response) => {
+  try {
+    const tenantId = getTenantId(req);
+    const supabase = getSupabase();
+    if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+
+    const limit = Math.min(parseInt(req.query.limit as string) || 50, 200);
+    const offset = parseInt(req.query.offset as string) || 0;
+    const { status, automation_id } = req.query;
+
+    let query = supabase
+      .from('tenant_autopilot_runs')
+      .select('*', { count: 'exact' })
+      .eq('tenant_id', tenantId)
+      .order('started_at', { ascending: false })
+      .range(offset, offset + limit - 1);
+
+    if (status) query = query.eq('status', status);
+    if (automation_id) query = query.eq('automation_id', automation_id);
+
+    const { data, error, count } = await query;
+    if (error) throw error;
+
+    res.json({ ok: true, data: data || [], total: count || 0 });
+  } catch (err: any) {
+    console.error(`[${VTID}] GET /runs error:`, err.message);
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+/**
+ * GET /runs/stats
+ * Aggregate run statistics for the Growth tab.
+ */
+router.get('/runs/stats', requireTenantAdmin, async (req: Request, res: Response) => {
+  try {
+    const tenantId = getTenantId(req);
+    const supabase = getSupabase();
+    if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+
+    const days = parseInt(req.query.days as string) || 30;
+    const since = new Date(Date.now() - days * 86400000).toISOString();
+
+    const { data: runs, error } = await supabase
+      .from('tenant_autopilot_runs')
+      .select('status, duration_ms, started_at, automation_id')
+      .eq('tenant_id', tenantId)
+      .gte('started_at', since);
+
+    if (error) throw error;
+
+    const allRuns = runs || [];
+    const completed = allRuns.filter(r => r.status === 'completed');
+    const failed = allRuns.filter(r => r.status === 'failed');
+
+    // Time saved estimate: each completed automation saves ~15 min of manual work
+    const timeSavedMinutes = completed.length * 15;
+
+    // Per-automation breakdown
+    const byAutomation: Record<string, { total: number; completed: number; failed: number; avg_duration_ms: number }> = {};
+    for (const run of allRuns) {
+      if (!byAutomation[run.automation_id]) {
+        byAutomation[run.automation_id] = { total: 0, completed: 0, failed: 0, avg_duration_ms: 0 };
+      }
+      const entry = byAutomation[run.automation_id];
+      entry.total++;
+      if (run.status === 'completed') {
+        entry.completed++;
+        entry.avg_duration_ms += (run.duration_ms || 0);
+      }
+      if (run.status === 'failed') entry.failed++;
+    }
+    // Average duration
+    for (const key of Object.keys(byAutomation)) {
+      const entry = byAutomation[key];
+      if (entry.completed > 0) entry.avg_duration_ms = Math.round(entry.avg_duration_ms / entry.completed);
+    }
+
+    // Daily trend (runs per day)
+    const dailyTrend: Record<string, number> = {};
+    for (const run of allRuns) {
+      const day = run.started_at.slice(0, 10);
+      dailyTrend[day] = (dailyTrend[day] || 0) + 1;
+    }
+
+    res.json({
+      ok: true,
+      data: {
+        period_days: days,
+        total_runs: allRuns.length,
+        completed: completed.length,
+        failed: failed.length,
+        success_rate: allRuns.length > 0 ? Math.round((completed.length / allRuns.length) * 100) : 0,
+        time_saved_minutes: timeSavedMinutes,
+        by_automation: byAutomation,
+        daily_trend: Object.entries(dailyTrend)
+          .sort(([a], [b]) => a.localeCompare(b))
+          .map(([date, count]) => ({ date, count })),
+      },
+    });
+  } catch (err: any) {
+    console.error(`[${VTID}] GET /runs/stats error:`, err.message);
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+// ── Recommendations (tenant-filtered view) ───────────────────────────────────
+
+/**
+ * GET /recommendations
+ * Tenant-scoped recommendation list. Wraps the existing autopilot_recommendations
+ * table with tenant settings awareness (allowed domains, risk levels).
+ */
+router.get('/recommendations', requireTenantAdmin, async (req: Request, res: Response) => {
+  try {
+    const tenantId = getTenantId(req);
+    const supabase = getSupabase();
+    if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+
+    const limit = Math.min(parseInt(req.query.limit as string) || 50, 200);
+    const offset = parseInt(req.query.offset as string) || 0;
+    const { status, domain, risk_level } = req.query;
+
+    // Get tenant settings for filtering
+    const { data: settings } = await supabase
+      .from('tenant_autopilot_settings')
+      .select('allowed_domains, allowed_risk_levels, enabled')
+      .eq('tenant_id', tenantId)
+      .maybeSingle();
+
+    // If autopilot is disabled for this tenant, return empty
+    if (settings && !settings.enabled) {
+      return res.json({ ok: true, data: [], total: 0, autopilot_enabled: false });
+    }
+
+    const allowedDomains = settings?.allowed_domains || ['health', 'community', 'longevity', 'professional', 'general'];
+    const allowedRisks = settings?.allowed_risk_levels || ['low', 'medium'];
+
+    let query = supabase
+      .from('autopilot_recommendations')
+      .select('*', { count: 'exact' })
+      .in('domain', allowedDomains)
+      .in('risk_level', allowedRisks)
+      .order('impact_score', { ascending: false })
+      .order('created_at', { ascending: false })
+      .range(offset, offset + limit - 1);
+
+    // Exclude snoozed
+    query = query.or('snoozed_until.is.null,snoozed_until.lt.' + new Date().toISOString());
+
+    if (status) query = query.eq('status', status as string);
+    if (domain) query = query.eq('domain', domain as string);
+    if (risk_level) query = query.eq('risk_level', risk_level as string);
+
+    const { data, error, count } = await query;
+    if (error) throw error;
+
+    res.json({ ok: true, data: data || [], total: count || 0, autopilot_enabled: true });
+  } catch (err: any) {
+    console.error(`[${VTID}] GET /recommendations error:`, err.message);
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+/**
+ * GET /recommendations/summary
+ * Quick counts for the Recommendations tab header badges.
+ */
+router.get('/recommendations/summary', requireTenantAdmin, async (req: Request, res: Response) => {
+  try {
+    const tenantId = getTenantId(req);
+    const supabase = getSupabase();
+    if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+
+    const { data: settings } = await supabase
+      .from('tenant_autopilot_settings')
+      .select('allowed_domains, allowed_risk_levels, enabled')
+      .eq('tenant_id', tenantId)
+      .maybeSingle();
+
+    if (settings && !settings.enabled) {
+      return res.json({ ok: true, data: { new: 0, activated: 0, rejected: 0, snoozed: 0, total: 0 } });
+    }
+
+    const allowedDomains = settings?.allowed_domains || ['health', 'community', 'longevity', 'professional', 'general'];
+    const allowedRisks = settings?.allowed_risk_levels || ['low', 'medium'];
+
+    const { data, error } = await supabase
+      .from('autopilot_recommendations')
+      .select('status')
+      .in('domain', allowedDomains)
+      .in('risk_level', allowedRisks);
+
+    if (error) throw error;
+
+    const counts = { new: 0, activated: 0, rejected: 0, snoozed: 0, total: 0 };
+    for (const row of data || []) {
+      counts.total++;
+      if (row.status === 'new') counts.new++;
+      else if (row.status === 'activated') counts.activated++;
+      else if (row.status === 'rejected') counts.rejected++;
+      else if (row.status === 'snoozed') counts.snoozed++;
+    }
+
+    res.json({ ok: true, data: counts });
+  } catch (err: any) {
+    console.error(`[${VTID}] GET /recommendations/summary error:`, err.message);
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+// ── Catalog (available automations for the Automations tab) ──────────────────
+
+/**
+ * GET /catalog
+ * Returns the full AP automation catalog with the tenant's binding status overlaid.
+ * This is a JOIN of the static catalog with tenant_autopilot_bindings.
+ */
+router.get('/catalog', requireTenantAdmin, async (req: Request, res: Response) => {
+  try {
+    const tenantId = getTenantId(req);
+    const supabase = getSupabase();
+    if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+
+    // Get tenant bindings
+    const { data: bindings, error: bErr } = await supabase
+      .from('tenant_autopilot_bindings')
+      .select('*')
+      .eq('tenant_id', tenantId);
+
+    if (bErr) throw bErr;
+
+    // Static catalog of available automations
+    const catalog = getAutomationCatalog();
+    const bindingMap = new Map((bindings || []).map(b => [b.automation_id, b]));
+
+    const items = catalog.map(entry => ({
+      ...entry,
+      binding: bindingMap.get(entry.id) || null,
+      enabled: bindingMap.get(entry.id)?.enabled ?? false,
+    }));
+
+    res.json({ ok: true, data: items });
+  } catch (err: any) {
+    console.error(`[${VTID}] GET /catalog error:`, err.message);
+    res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+// ── Static automation catalog ────────────────────────────────────────────────
+
+interface AutomationCatalogEntry {
+  id: string;
+  name: string;
+  description: string;
+  category: string;
+  risk_level: 'low' | 'medium' | 'high';
+  default_schedule: string;
+  requires_approval_default: boolean;
+}
+
+function getAutomationCatalog(): AutomationCatalogEntry[] {
+  return [
+    // ── Community health ──
+    {
+      id: 'AP-COMMUNITY-WELCOME',
+      name: 'Welcome New Members',
+      description: 'Automatically send personalized welcome messages and onboarding suggestions to new community members.',
+      category: 'community',
+      risk_level: 'low',
+      default_schedule: 'on_event',
+      requires_approval_default: false,
+    },
+    {
+      id: 'AP-COMMUNITY-ENGAGEMENT',
+      name: 'Engagement Nudges',
+      description: 'Identify inactive members and send re-engagement prompts based on their interests and past activity.',
+      category: 'community',
+      risk_level: 'low',
+      default_schedule: 'daily',
+      requires_approval_default: false,
+    },
+    {
+      id: 'AP-COMMUNITY-MODERATION',
+      name: 'Content Moderation',
+      description: 'Flag potentially inappropriate content for review based on community guidelines.',
+      category: 'community',
+      risk_level: 'medium',
+      default_schedule: 'realtime',
+      requires_approval_default: true,
+    },
+    {
+      id: 'AP-COMMUNITY-MATCHMAKING',
+      name: 'Member Matchmaking',
+      description: 'Suggest connections between members with complementary interests and goals.',
+      category: 'community',
+      risk_level: 'low',
+      default_schedule: 'weekly',
+      requires_approval_default: false,
+    },
+    // ── Health & longevity ──
+    {
+      id: 'AP-HEALTH-INSIGHTS',
+      name: 'Health Insights Digest',
+      description: 'Generate personalized health insights based on member biology data and community trends.',
+      category: 'health',
+      risk_level: 'medium',
+      default_schedule: 'weekly',
+      requires_approval_default: true,
+    },
+    {
+      id: 'AP-HEALTH-REMINDERS',
+      name: 'Wellness Reminders',
+      description: 'Schedule and send personalized wellness check-in reminders to members.',
+      category: 'health',
+      risk_level: 'low',
+      default_schedule: 'daily',
+      requires_approval_default: false,
+    },
+    {
+      id: 'AP-LONGEVITY-TRENDS',
+      name: 'Longevity Trend Reports',
+      description: 'Compile and distribute community-wide longevity trend analyses.',
+      category: 'health',
+      risk_level: 'low',
+      default_schedule: 'monthly',
+      requires_approval_default: false,
+    },
+    // ── Content & events ──
+    {
+      id: 'AP-CONTENT-CURATION',
+      name: 'Content Curation',
+      description: 'Curate and recommend relevant content to members based on their interests and engagement patterns.',
+      category: 'professional',
+      risk_level: 'low',
+      default_schedule: 'daily',
+      requires_approval_default: false,
+    },
+    {
+      id: 'AP-EVENT-RECOMMENDATIONS',
+      name: 'Event Recommendations',
+      description: 'Suggest upcoming events to members based on location, interests, and attendance history.',
+      category: 'community',
+      risk_level: 'low',
+      default_schedule: 'daily',
+      requires_approval_default: false,
+    },
+    {
+      id: 'AP-EVENT-FOLLOWUP',
+      name: 'Post-Event Follow-up',
+      description: 'Send automated follow-up messages after events with feedback requests and connection suggestions.',
+      category: 'community',
+      risk_level: 'low',
+      default_schedule: 'on_event',
+      requires_approval_default: false,
+    },
+    // ── Intelligence & ops ──
+    {
+      id: 'AP-KNOWLEDGE-INDEXING',
+      name: 'Knowledge Base Indexing',
+      description: 'Periodically reindex community knowledge base and update embeddings for better search.',
+      category: 'general',
+      risk_level: 'low',
+      default_schedule: 'daily',
+      requires_approval_default: false,
+    },
+    {
+      id: 'AP-ANALYTICS-DIGEST',
+      name: 'Analytics Digest',
+      description: 'Generate weekly analytics summaries for tenant admins with key metrics and actionable insights.',
+      category: 'general',
+      risk_level: 'low',
+      default_schedule: 'weekly',
+      requires_approval_default: false,
+    },
+    {
+      id: 'AP-ANOMALY-DETECTION',
+      name: 'Anomaly Detection',
+      description: 'Monitor community metrics for unusual patterns and alert admins of potential issues.',
+      category: 'general',
+      risk_level: 'medium',
+      default_schedule: 'hourly',
+      requires_approval_default: true,
+    },
+    {
+      id: 'AP-DATA-CLEANUP',
+      name: 'Data Hygiene',
+      description: 'Identify and flag stale data, orphaned records, and data quality issues for admin review.',
+      category: 'general',
+      risk_level: 'high',
+      default_schedule: 'weekly',
+      requires_approval_default: true,
+    },
+  ];
+}
+
+export default router;

--- a/supabase/migrations/20260412100000_tenant_autopilot_config.sql
+++ b/supabase/migrations/20260412100000_tenant_autopilot_config.sql
@@ -1,0 +1,150 @@
+-- VTID-AP-ADMIN: Tenant-scoped autopilot configuration
+-- tenant_autopilot_settings: per-tenant global config (risk caps, domains, rate limits)
+-- tenant_autopilot_bindings: per-tenant activation of specific AP catalog entries
+--
+-- Depends on: tenants(id), app_users(user_id)
+-- Idempotent: safe to rerun (IF NOT EXISTS on all objects).
+
+BEGIN;
+
+-- ── tenant_autopilot_settings ────────────────────────────────────────────────
+-- One row per tenant. Controls what the autopilot is allowed to do.
+
+CREATE TABLE IF NOT EXISTS tenant_autopilot_settings (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id       UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  enabled         BOOLEAN NOT NULL DEFAULT true,
+
+  -- Rate limits
+  max_recommendations_per_day   INTEGER NOT NULL DEFAULT 20,
+  max_activations_per_day       INTEGER NOT NULL DEFAULT 10,
+
+  -- Domain & risk guardrails
+  allowed_domains       TEXT[] NOT NULL DEFAULT ARRAY['health','community','longevity','professional','general']::text[],
+  allowed_risk_levels   TEXT[] NOT NULL DEFAULT ARRAY['low','medium']::text[],
+
+  -- Auto-activation: recommendations above this confidence auto-execute
+  -- NULL = disabled (all require manual approval)
+  auto_activate_threshold  NUMERIC(3,2) CHECK (auto_activate_threshold IS NULL OR (auto_activate_threshold >= 0 AND auto_activate_threshold <= 1)),
+
+  -- Retention
+  recommendation_retention_days  INTEGER NOT NULL DEFAULT 30,
+
+  -- Scheduling
+  generation_schedule   JSONB NOT NULL DEFAULT '{"cron": "0 2 * * *", "timezone": "UTC"}'::jsonb,
+
+  -- Audit
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_by   UUID REFERENCES app_users(user_id),
+
+  CONSTRAINT uq_tenant_autopilot_settings UNIQUE (tenant_id)
+);
+
+-- ── tenant_autopilot_bindings ────────────────────────────────────────────────
+-- Each row enables a specific automation for a tenant, with per-binding overrides.
+
+CREATE TABLE IF NOT EXISTS tenant_autopilot_bindings (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id       UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  automation_id   TEXT NOT NULL,              -- AP-XXXX or source_type key
+  enabled         BOOLEAN NOT NULL DEFAULT true,
+
+  -- Schedule override (NULL = use global)
+  schedule        JSONB,
+
+  -- Per-binding guardrails (NULL = inherit from tenant_autopilot_settings)
+  guardrails      JSONB,
+
+  -- Which roles can trigger this automation
+  role_allowances TEXT[] NOT NULL DEFAULT ARRAY['admin']::text[],
+
+  -- Approval flow
+  requires_approval   BOOLEAN NOT NULL DEFAULT true,
+
+  -- Rate limits per binding
+  max_runs_per_day          INTEGER,
+  max_runs_per_user_per_day INTEGER,
+
+  -- Audit
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_by   UUID REFERENCES app_users(user_id),
+
+  CONSTRAINT uq_tenant_binding UNIQUE (tenant_id, automation_id)
+);
+
+-- ── tenant_autopilot_runs ────────────────────────────────────────────────────
+-- Execution log: every time an autopilot action runs for a tenant.
+
+CREATE TABLE IF NOT EXISTS tenant_autopilot_runs (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id       UUID NOT NULL REFERENCES tenants(id) ON DELETE CASCADE,
+  binding_id      UUID REFERENCES tenant_autopilot_bindings(id) ON DELETE SET NULL,
+  automation_id   TEXT NOT NULL,
+  triggered_by    UUID REFERENCES app_users(user_id),
+  trigger_type    TEXT NOT NULL DEFAULT 'manual',   -- manual | scheduled | auto_activate | webhook
+  status          TEXT NOT NULL DEFAULT 'running',  -- running | completed | failed | cancelled
+  started_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  completed_at    TIMESTAMPTZ,
+  duration_ms     INTEGER,
+  result          JSONB,
+  error_message   TEXT,
+
+  -- Link to VTID if one was created
+  activated_vtid  TEXT
+);
+
+-- ── Indexes ──────────────────────────────────────────────────────────────────
+
+CREATE INDEX IF NOT EXISTS idx_ap_settings_tenant ON tenant_autopilot_settings(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_ap_bindings_tenant ON tenant_autopilot_bindings(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_ap_bindings_automation ON tenant_autopilot_bindings(tenant_id, automation_id);
+CREATE INDEX IF NOT EXISTS idx_ap_runs_tenant ON tenant_autopilot_runs(tenant_id);
+CREATE INDEX IF NOT EXISTS idx_ap_runs_status ON tenant_autopilot_runs(tenant_id, status);
+CREATE INDEX IF NOT EXISTS idx_ap_runs_started ON tenant_autopilot_runs(tenant_id, started_at DESC);
+
+-- ── RLS ──────────────────────────────────────────────────────────────────────
+
+ALTER TABLE tenant_autopilot_settings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tenant_autopilot_bindings ENABLE ROW LEVEL SECURITY;
+ALTER TABLE tenant_autopilot_runs ENABLE ROW LEVEL SECURITY;
+
+-- Service role (gateway) gets full access
+CREATE POLICY IF NOT EXISTS "service_full_access_settings" ON tenant_autopilot_settings
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+CREATE POLICY IF NOT EXISTS "service_full_access_bindings" ON tenant_autopilot_bindings
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+CREATE POLICY IF NOT EXISTS "service_full_access_runs" ON tenant_autopilot_runs
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+-- Authenticated users: read-only on their own tenant (gateway handles writes via service role)
+CREATE POLICY IF NOT EXISTS "tenant_read_settings" ON tenant_autopilot_settings
+  FOR SELECT TO authenticated
+  USING (tenant_id IN (SELECT tenant_id FROM user_tenants WHERE user_id = auth.uid()));
+CREATE POLICY IF NOT EXISTS "tenant_read_bindings" ON tenant_autopilot_bindings
+  FOR SELECT TO authenticated
+  USING (tenant_id IN (SELECT tenant_id FROM user_tenants WHERE user_id = auth.uid()));
+CREATE POLICY IF NOT EXISTS "tenant_read_runs" ON tenant_autopilot_runs
+  FOR SELECT TO authenticated
+  USING (tenant_id IN (SELECT tenant_id FROM user_tenants WHERE user_id = auth.uid()));
+
+-- ── Updated-at trigger ──────────────────────────────────────────────────────
+
+CREATE OR REPLACE FUNCTION update_autopilot_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_ap_settings_updated ON tenant_autopilot_settings;
+CREATE TRIGGER trg_ap_settings_updated
+  BEFORE UPDATE ON tenant_autopilot_settings
+  FOR EACH ROW EXECUTE FUNCTION update_autopilot_updated_at();
+
+DROP TRIGGER IF EXISTS trg_ap_bindings_updated ON tenant_autopilot_bindings;
+CREATE TRIGGER trg_ap_bindings_updated
+  BEFORE UPDATE ON tenant_autopilot_bindings
+  FOR EACH ROW EXECUTE FUNCTION update_autopilot_updated_at();
+
+COMMIT;


### PR DESCRIPTION
## Summary
- New migration: `tenant_autopilot_settings`, `tenant_autopilot_bindings`, `tenant_autopilot_runs` tables with RLS + indexes
- New gateway route: `/api/v1/admin/autopilot/*` (11 endpoints) gated by `requireTenantAdmin`
- Auto-provisions default settings on first tenant access
- Static AP catalog with tenant binding overlay for the Automations tab
- Run stats aggregation for the Growth tab (success rate, time saved, daily trend)

## Endpoints
| Endpoint | Method | Purpose |
|---|---|---|
| /settings | GET | Get tenant settings (auto-provisions) |
| /settings | PATCH | Update settings |
| /bindings | GET | List automation bindings |
| /bindings | POST | Create/upsert binding |
| /bindings/:id | PATCH | Update binding |
| /bindings/:id | DELETE | Remove binding |
| /runs | GET | Paginated execution history |
| /runs/stats | GET | Aggregated stats for Growth tab |
| /catalog | GET | AP catalog + binding status |
| /recommendations | GET | Tenant-filtered recommendations |
| /recommendations/summary | GET | Status counts for badges |

## Test plan
- [x] `tsc --noEmit` clean
- [ ] Migration applies via RUN-MIGRATION
- [ ] Gateway boots with admin-autopilot routes registered
- [ ] Endpoints return 401 without auth, 200 with admin JWT

Generated with Claude Code