### PR TITLE
fix(ci): add PostgREST schema cache reload to RUN-MIGRATION

### DIFF
--- a/.github/workflows/RUN-MIGRATION.yml
+++ b/.github/workflows/RUN-MIGRATION.yml
@@ -21,3 +21,11 @@ jobs:
           echo "Applying migration: ${{ inputs.migration_file }}"
           psql "$SUPABASE_DB_URL" -f "${{ inputs.migration_file }}"
           echo "Migration applied successfully"
+
+      - name: Reload PostgREST schema cache
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+        run: |
+          echo "Reloading PostgREST schema cache..."
+          psql "$SUPABASE_DB_URL" -c "NOTIFY pgrst, 'reload schema';"
+          echo "Schema cache reload signal sent"


### PR DESCRIPTION
## Problem
After running a migration via RUN-MIGRATION.yml, PostgREST's schema cache stays stale. New tables aren't visible to the Supabase JS client until PostgREST reloads. This caused "Could not find the table 'public.tenant_autopilot_bindings' in the schema cache" errors on all Autopilot admin tabs except Recommendations.

## Root cause
RUN-MIGRATION applies SQL via a one-shot `psql` connection. PostgreSQL's `NOTIFY` only reaches listeners on active connections. Since `psql` opens its own connection and disconnects, PostgREST never gets the reload signal.

## Fix
Add a second step after migration that sends `NOTIFY pgrst, 'reload schema'` via `psql`. This tells PostgREST to refresh its internal schema cache so newly created tables/columns are immediately visible.

## Test plan
- [x] Workflow YAML is valid
- [ ] Next migration that creates new tables should be immediately queryable without manual Supabase Dashboard intervention

## Immediate action needed
Please also run this in the **Supabase Dashboard SQL Editor** right now to fix the current stale cache:
```sql
NOTIFY pgrst, 'reload schema';
```
This will make tenant_autopilot_bindings, tenant_autopilot_settings, and tenant_autopilot_runs visible immediately.

Generated with Claude Code