### PR TITLE
Auto-approve Bash/Edit/Write permissions in Claude Code

### DIFF
--- a/.claude/settings.json
+++ b/.claude/settings.json
@@ -2,6 +2,9 @@
   "env": {
     "CLAUDE_CODE_EXPERIMENTAL_AGENT_TEAMS": "1"
   },
+  "permissions": {
+    "allow": ["Bash(*)", "Edit", "Write", "Skill"]
+  },
   "hooks": {
     "PostToolUse": [
       {


### PR DESCRIPTION
## Summary
- Adds project-level `permissions.allow` to `.claude/settings.json` so Claude Code sessions stop prompting 100+ times for bash command approval
- Allows: `Bash(*)`, `Edit`, `Write`, `Skill`

## Test plan
- [x] Settings file is valid JSON
- [ ] Start a new Claude Code Web session and verify bash commands run without prompting

https://claude.ai/code/session_01TozAFxZcJhBVs91iQN1cLt