### PR TITLE
feat(triage-agent): Voice Lab incident investigation via Claude Managed Agents

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -14255,6 +14255,134 @@ function renderVoiceLabSessionDrawer() {
             });
 
             drawerContent.appendChild(diagSection);
+
+            // "Investigate with Claude" button — triggers Managed Agents triage
+            var investigateBtn = document.createElement('button');
+            investigateBtn.className = 'btn btn-primary triage-investigate-btn';
+            investigateBtn.textContent = 'Investigate with Claude';
+            investigateBtn.onclick = function () {
+                investigateBtn.disabled = true;
+                investigateBtn.textContent = 'Starting investigation...';
+
+                // Collect diagnostic flags
+                var flagTexts = diagnostics.map(function (d) { return d.title; });
+
+                fetch('/api/v1/agents/triage/investigate', {
+                    method: 'POST',
+                    headers: Object.assign({ 'Content-Type': 'application/json' }, buildContextHeaders({})),
+                    body: JSON.stringify({
+                        session_id: state.voiceLab.selectedSession,
+                        diagnostic_summary: diagnostics.map(function (d) {
+                            return d.severity + ': ' + d.title + ' — ' + d.detail;
+                        }).join('\n'),
+                        flags: flagTexts,
+                        metrics: {
+                            duration_ms: details.duration_ms,
+                            audio_in_chunks: details.audio_in_chunks,
+                            audio_out_chunks: details.audio_out_chunks,
+                            turn_count: details.turn_count,
+                            error_count: details.error_count,
+                            interrupted_count: details.interrupted_count
+                        }
+                    })
+                }).then(function (r) { return r.json(); }).then(function (result) {
+                    if (!result.ok) {
+                        investigateBtn.textContent = 'Investigation failed';
+                        investigateBtn.disabled = false;
+                        showToast(result.error || 'Failed to start investigation', 'error');
+                        return;
+                    }
+                    investigateBtn.textContent = 'Investigation running...';
+
+                    // Create the streaming panel
+                    var panel = document.createElement('div');
+                    panel.className = 'triage-panel';
+                    panel.innerHTML = '<div class="triage-panel-header">Claude Investigation — ' +
+                        escapeHtml(state.voiceLab.selectedSession) + '</div>' +
+                        '<div class="triage-panel-body" id="triage-output"></div>';
+                    investigateBtn.parentNode.insertBefore(panel, investigateBtn.nextSibling);
+
+                    var outputEl = document.getElementById('triage-output');
+
+                    // Connect to the SSE stream
+                    var eventSource = new EventSource(result.stream_url);
+
+                    eventSource.addEventListener('agent.message', function (e) {
+                        var data = JSON.parse(e.data);
+                        if (data.content) {
+                            data.content.forEach(function (block) {
+                                if (block.type === 'text') {
+                                    var p = document.createElement('div');
+                                    p.className = 'triage-message';
+                                    p.textContent = block.text;
+                                    outputEl.appendChild(p);
+                                    outputEl.scrollTop = outputEl.scrollHeight;
+                                }
+                            });
+                        }
+                    });
+
+                    eventSource.addEventListener('agent.thinking', function (e) {
+                        var data = JSON.parse(e.data);
+                        var div = document.createElement('div');
+                        div.className = 'triage-thinking';
+                        div.textContent = '[thinking] ' + (data.thinking || '').substring(0, 200) + '...';
+                        outputEl.appendChild(div);
+                    });
+
+                    eventSource.addEventListener('agent.custom_tool_use', function (e) {
+                        var data = JSON.parse(e.data);
+                        var div = document.createElement('div');
+                        div.className = 'triage-tool-call';
+                        div.textContent = 'Calling: ' + data.tool_name + '(' + JSON.stringify(data.input || {}) + ')';
+                        outputEl.appendChild(div);
+                    });
+
+                    eventSource.addEventListener('agent.tool_use', function (e) {
+                        var data = JSON.parse(e.data);
+                        var div = document.createElement('div');
+                        div.className = 'triage-tool-call';
+                        div.textContent = 'Using: ' + (data.name || 'tool');
+                        outputEl.appendChild(div);
+                    });
+
+                    eventSource.addEventListener('session.idle', function () {
+                        investigateBtn.textContent = 'Investigation complete';
+                        eventSource.close();
+                    });
+
+                    eventSource.addEventListener('session.terminated', function () {
+                        investigateBtn.textContent = 'Investigation ended';
+                        eventSource.close();
+                    });
+
+                    eventSource.addEventListener('session.error', function (e) {
+                        var data = JSON.parse(e.data);
+                        var div = document.createElement('div');
+                        div.className = 'triage-error';
+                        div.textContent = 'Error: ' + (data.error || 'unknown');
+                        outputEl.appendChild(div);
+                    });
+
+                    eventSource.addEventListener('done', function () {
+                        investigateBtn.textContent = 'Investigation complete';
+                        investigateBtn.disabled = false;
+                        eventSource.close();
+                    });
+
+                    eventSource.onerror = function () {
+                        investigateBtn.textContent = 'Investigate with Claude';
+                        investigateBtn.disabled = false;
+                        eventSource.close();
+                    };
+                }).catch(function (err) {
+                    investigateBtn.textContent = 'Investigate with Claude';
+                    investigateBtn.disabled = false;
+                    showToast('Failed: ' + err.message, 'error');
+                });
+            };
+            diagSection.appendChild(investigateBtn);
+
         } else if (details.status === 'ended') {
             var healthySection = document.createElement('div');
             healthySection.className = 'session-diagnostics session-diagnostics-healthy';

--- a/services/gateway/src/frontend/command-hub/styles.css
+++ b/services/gateway/src/frontend/command-hub/styles.css
@@ -18782,3 +18782,84 @@ border-bottom: 1px solid var(--color-border, #333);
         padding: 1rem;
     }
 }
+
+/* ===========================================================================
+ * Incident Triage Agent — Voice Lab "Investigate with Claude" panel
+ * =========================================================================== */
+
+.triage-investigate-btn {
+  margin-top: 12px;
+  background: linear-gradient(135deg, rgba(217, 119, 87, 0.9), rgba(180, 80, 60, 0.9));
+  border: 1px solid rgba(217, 119, 87, 0.5);
+  color: #fff;
+  font-weight: 600;
+  padding: 8px 20px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.85rem;
+}
+
+.triage-investigate-btn:hover:not(:disabled) {
+  background: linear-gradient(135deg, rgba(230, 130, 100, 0.95), rgba(200, 90, 70, 0.95));
+}
+
+.triage-investigate-btn:disabled {
+  opacity: 0.7;
+  cursor: default;
+}
+
+.triage-panel {
+  margin-top: 16px;
+  background: rgba(17, 24, 39, 0.8);
+  border: 1px solid rgba(217, 119, 87, 0.3);
+  border-left: 3px solid rgba(217, 119, 87, 0.7);
+  border-radius: 8px;
+  overflow: hidden;
+}
+
+.triage-panel-header {
+  padding: 10px 16px;
+  background: rgba(217, 119, 87, 0.1);
+  font-weight: 600;
+  font-size: 0.85rem;
+  color: #f0a883;
+  border-bottom: 1px solid rgba(217, 119, 87, 0.2);
+}
+
+.triage-panel-body {
+  padding: 12px 16px;
+  max-height: 500px;
+  overflow-y: auto;
+  font-size: 0.82rem;
+  line-height: 1.5;
+  color: var(--color-text-primary);
+}
+
+.triage-message {
+  margin-bottom: 8px;
+  white-space: pre-wrap;
+  word-break: break-word;
+}
+
+.triage-thinking {
+  margin-bottom: 6px;
+  color: var(--color-text-secondary);
+  font-style: italic;
+  font-size: 0.78rem;
+}
+
+.triage-tool-call {
+  margin-bottom: 6px;
+  color: #93c5fd;
+  font-family: monospace;
+  font-size: 0.75rem;
+  padding: 4px 8px;
+  background: rgba(0, 0, 0, 0.2);
+  border-radius: 4px;
+}
+
+.triage-error {
+  margin-bottom: 6px;
+  color: #f87171;
+  font-weight: 600;
+}

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -186,6 +186,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const { workerOrchestratorRouter } = require('./routes/worker-orchestrator');
   // Agents Registry — single source of truth for every LLM-powered workload
   const { agentsRegistryRouter, bootstrapEmbeddedAgents } = require('./routes/agents-registry');
+  // Incident Triage Agent — Claude Managed Agents proxy for Voice Lab investigations
+  const { triageAgentRouter } = require('./routes/triage-agent');
   // VTID-01148: Approvals API v1 — Pending Queue + Count + Approve/Reject
   const approvalsRouter = require('./routes/approvals').default;
   // VTID-01169: Deploy → Ledger Terminalization (terminalize endpoint + repair job)
@@ -452,6 +454,9 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
 
   // Agents Registry — replaces the hardcoded subagents array with a real, queryable registry
   mountRouterSync(app, '/', agentsRegistryRouter, { owner: 'agents-registry' });
+
+  // Incident Triage Agent — Claude Managed Agents proxy for Voice Lab
+  mountRouterSync(app, '/api/v1/agents/triage', triageAgentRouter, { owner: 'triage-agent' });
 
   // VTID-0509 + VTID-0510: Operator Console & Version Tracking
   mountRouterSync(app, '/api/v1/operator', operatorRouter, { owner: 'operator' });

--- a/services/gateway/src/routes/triage-agent.ts
+++ b/services/gateway/src/routes/triage-agent.ts
@@ -1,0 +1,396 @@
+/**
+ * Incident Triage Agent — Claude Managed Agents proxy route
+ *
+ * Proxies Claude Managed Agents sessions to the Command Hub for Voice Lab
+ * incident investigation. The agent reads the vitana-platform repo, queries
+ * OASIS events via a custom tool (Supabase creds stay host-side), and streams
+ * its investigation back to the browser via SSE.
+ *
+ * Endpoints:
+ *   POST /api/v1/agents/triage/investigate  — create a session + send initial prompt
+ *   GET  /api/v1/agents/triage/:sessionId/stream — SSE proxy for agent events
+ *
+ * The Anthropic API key, agent ID, and environment ID are read from env vars:
+ *   ANTHROPIC_API_KEY, TRIAGE_AGENT_ID, TRIAGE_ENVIRONMENT_ID
+ */
+
+import { Router, Request, Response } from 'express';
+
+export const triageAgentRouter = Router();
+
+const LOG_PREFIX = '[triage-agent]';
+
+// Config from environment
+const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY || '';
+const AGENT_ID = process.env.TRIAGE_AGENT_ID || 'agent_011Ca1RTRZADaWdZsKAKjs3B';
+const ENVIRONMENT_ID = process.env.TRIAGE_ENVIRONMENT_ID || 'env_01VrvRRUWP91wiFQrmWaUcEh';
+const ANTHROPIC_BASE = 'https://api.anthropic.com';
+const BETA_HEADER = 'managed-agents-2026-04-01';
+
+// =============================================================================
+// Anthropic API helper
+// =============================================================================
+
+async function anthropicRequest<T>(
+  path: string,
+  options: { method?: string; body?: unknown } = {}
+): Promise<{ ok: boolean; data?: T; error?: string; status?: number }> {
+  if (!ANTHROPIC_API_KEY) {
+    return { ok: false, error: 'ANTHROPIC_API_KEY not set', status: 500 };
+  }
+
+  try {
+    const response = await fetch(`${ANTHROPIC_BASE}${path}`, {
+      method: options.method || 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': ANTHROPIC_API_KEY,
+        'anthropic-version': '2023-06-01',
+        'anthropic-beta': BETA_HEADER,
+      },
+      body: options.body ? JSON.stringify(options.body) : undefined,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return { ok: false, error: `${response.status}: ${errorText}`, status: response.status };
+    }
+
+    const data = (await response.json()) as T;
+    return { ok: true, data };
+  } catch (error) {
+    return { ok: false, error: String(error), status: 500 };
+  }
+}
+
+// =============================================================================
+// Supabase helper for custom tool (query_oasis_events)
+// =============================================================================
+
+async function queryOasisEvents(
+  sessionId: string,
+  limit: number = 100
+): Promise<{ ok: boolean; events?: unknown[]; error?: string }> {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE;
+
+  if (!supabaseUrl || !supabaseKey) {
+    return { ok: false, error: 'Missing Supabase credentials' };
+  }
+
+  try {
+    // Query OASIS events for this session ID — check both metadata.session_id
+    // and metadata.sessionId patterns (both exist in the codebase)
+    const response = await fetch(
+      `${supabaseUrl}/rest/v1/oasis_events?or=(metadata->>session_id.eq.${encodeURIComponent(sessionId)},metadata->>sessionId.eq.${encodeURIComponent(sessionId)})&order=created_at.asc&limit=${limit}&select=id,topic,vtid,status,message,metadata,created_at`,
+      {
+        headers: {
+          apikey: supabaseKey,
+          Authorization: `Bearer ${supabaseKey}`,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      return { ok: false, error: `Supabase ${response.status}: ${await response.text()}` };
+    }
+
+    const events = (await response.json()) as unknown[];
+    return { ok: true, events };
+  } catch (error) {
+    return { ok: false, error: String(error) };
+  }
+}
+
+// =============================================================================
+// POST /api/v1/agents/triage/investigate
+// =============================================================================
+
+interface InvestigateRequest {
+  session_id: string;
+  diagnostic_summary: string;
+  flags: string[];
+  metrics: {
+    duration_ms?: number;
+    audio_in_chunks?: number;
+    audio_out_chunks?: number;
+    turn_count?: number;
+    error_count?: number;
+    interrupted_count?: number;
+  };
+}
+
+triageAgentRouter.post('/investigate', async (req: Request, res: Response) => {
+  try {
+    const body = req.body as InvestigateRequest;
+
+    if (!body.session_id) {
+      return res.status(400).json({ ok: false, error: 'session_id is required' });
+    }
+
+    if (!ANTHROPIC_API_KEY) {
+      return res.status(503).json({
+        ok: false,
+        error: 'Incident triage is not configured — ANTHROPIC_API_KEY is not set on this gateway instance.',
+      });
+    }
+
+    console.log(`${LOG_PREFIX} Starting investigation for session ${body.session_id}`);
+
+    // 1. Create a Managed Agents session with the repo mounted
+    const sessionResult = await anthropicRequest<any>('/v1/sessions', {
+      method: 'POST',
+      body: {
+        agent: { type: 'agent', id: AGENT_ID, version: 1 },
+        environment_id: ENVIRONMENT_ID,
+        title: `Voice triage: ${body.session_id}`,
+        resources: [
+          {
+            type: 'github_repository',
+            url: 'https://github.com/exafyltd/vitana-platform',
+            authorization_token: process.env.GITHUB_SAFE_MERGE_TOKEN || '',
+            mount_path: '/workspace/repo',
+            checkout: { type: 'branch', name: 'main' },
+          },
+        ],
+      },
+    });
+
+    if (!sessionResult.ok || !sessionResult.data) {
+      console.error(`${LOG_PREFIX} Session creation failed:`, sessionResult.error);
+      return res.status(500).json({
+        ok: false,
+        error: 'Failed to create triage session',
+        detail: sessionResult.error,
+      });
+    }
+
+    const sessionId = sessionResult.data.id;
+    console.log(`${LOG_PREFIX} Session created: ${sessionId}`);
+
+    // 2. Build the investigation prompt from the diagnostic data
+    const flagsList = body.flags.length > 0
+      ? body.flags.map((f: string) => `  - ${f}`).join('\n')
+      : '  (no diagnostic flags)';
+
+    const prompt = [
+      `Investigate this ORB voice session that has diagnostic issues.`,
+      ``,
+      `## Session: ${body.session_id}`,
+      ``,
+      `## Diagnostic Flags`,
+      flagsList,
+      ``,
+      `## Metrics`,
+      `- Duration: ${body.metrics.duration_ms ? Math.round(body.metrics.duration_ms / 1000) + 's' : 'unknown'}`,
+      `- Audio in chunks: ${body.metrics.audio_in_chunks ?? 'unknown'}`,
+      `- Audio out chunks: ${body.metrics.audio_out_chunks ?? 'unknown'}`,
+      `- Turns: ${body.metrics.turn_count ?? 'unknown'}`,
+      `- Errors: ${body.metrics.error_count ?? 'unknown'}`,
+      `- Interrupts: ${body.metrics.interrupted_count ?? 'unknown'}`,
+      ``,
+      `## Summary`,
+      body.diagnostic_summary || 'No summary provided.',
+      ``,
+      `## Instructions`,
+      `1. Start by calling query_oasis_events with session_id="${body.session_id}" to get the raw event timeline`,
+      `2. Read the relevant source code in /workspace/repo/ based on what the events reveal`,
+      `3. Produce a structured triage report with root cause, severity, and recommended fix`,
+    ].join('\n');
+
+    // 3. Send the initial message
+    const sendResult = await anthropicRequest<any>(
+      `/v1/sessions/${sessionId}/events`,
+      {
+        method: 'POST',
+        body: {
+          events: [
+            {
+              type: 'user.message',
+              content: [{ type: 'text', text: prompt }],
+            },
+          ],
+        },
+      }
+    );
+
+    if (!sendResult.ok) {
+      console.error(`${LOG_PREFIX} Failed to send initial message:`, sendResult.error);
+    }
+
+    return res.status(200).json({
+      ok: true,
+      session_id: sessionId,
+      orb_session_id: body.session_id,
+      stream_url: `/api/v1/agents/triage/${sessionId}/stream`,
+    });
+  } catch (error: any) {
+    console.error(`${LOG_PREFIX} investigate error:`, error);
+    return res.status(500).json({ ok: false, error: error.message });
+  }
+});
+
+// =============================================================================
+// GET /api/v1/agents/triage/:sessionId/stream — SSE proxy
+// =============================================================================
+
+triageAgentRouter.get('/:sessionId/stream', async (req: Request, res: Response) => {
+  const { sessionId } = req.params;
+
+  if (!ANTHROPIC_API_KEY) {
+    return res.status(503).json({ ok: false, error: 'ANTHROPIC_API_KEY not set' });
+  }
+
+  // Set up SSE headers
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no');
+  res.flushHeaders();
+
+  console.log(`${LOG_PREFIX} Stream opened for session ${sessionId}`);
+
+  // Helper to send SSE events to the browser
+  const sendSSE = (event: string, data: unknown) => {
+    res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+  };
+
+  try {
+    // Poll events from the Managed Agents session and forward to the browser.
+    // Also handle custom tool calls (query_oasis_events).
+    let done = false;
+    let lastEventId: string | undefined;
+    const seenIds = new Set<string>();
+
+    while (!done) {
+      // Fetch events
+      const eventsResult = await anthropicRequest<any>(
+        `/v1/sessions/${sessionId}/events${lastEventId ? `?after_id=${lastEventId}` : ''}`
+      );
+
+      if (!eventsResult.ok || !eventsResult.data) {
+        sendSSE('error', { error: eventsResult.error });
+        break;
+      }
+
+      const events = eventsResult.data.data || [];
+
+      for (const event of events) {
+        if (seenIds.has(event.id)) continue;
+        seenIds.add(event.id);
+        lastEventId = event.id;
+
+        // Forward relevant events to the browser
+        switch (event.type) {
+          case 'agent.message':
+            sendSSE('agent.message', {
+              id: event.id,
+              content: event.content,
+            });
+            break;
+
+          case 'agent.thinking':
+            sendSSE('agent.thinking', {
+              id: event.id,
+              thinking: event.thinking,
+            });
+            break;
+
+          case 'agent.tool_use':
+          case 'agent.tool_result':
+            sendSSE(event.type, {
+              id: event.id,
+              name: event.name || event.tool_name,
+              input: event.input,
+              content: event.content,
+            });
+            break;
+
+          case 'agent.custom_tool_use': {
+            // Handle query_oasis_events — execute with our Supabase creds
+            sendSSE('agent.custom_tool_use', {
+              id: event.id,
+              tool_name: event.tool_name,
+              input: event.input,
+            });
+
+            if (event.tool_name === 'query_oasis_events') {
+              const oasisResult = await queryOasisEvents(
+                event.input?.session_id || '',
+                event.input?.limit || 100
+              );
+
+              const resultText = oasisResult.ok
+                ? JSON.stringify(oasisResult.events, null, 2)
+                : `Error querying OASIS events: ${oasisResult.error}`;
+
+              // Send the tool result back to the managed agent
+              await anthropicRequest(
+                `/v1/sessions/${sessionId}/events`,
+                {
+                  method: 'POST',
+                  body: {
+                    events: [
+                      {
+                        type: 'user.custom_tool_result',
+                        custom_tool_use_id: event.id,
+                        content: [{ type: 'text', text: resultText }],
+                      },
+                    ],
+                  },
+                }
+              );
+
+              sendSSE('tool_result_sent', {
+                tool_name: 'query_oasis_events',
+                event_count: oasisResult.ok ? (oasisResult.events?.length || 0) : 0,
+              });
+            }
+            break;
+          }
+
+          case 'session.status_idle': {
+            const stopReason = event.stop_reason?.type;
+            if (stopReason === 'requires_action') {
+              // Agent is waiting for our tool result — continue the loop
+              continue;
+            }
+            // end_turn or retries_exhausted — we're done
+            sendSSE('session.idle', { stop_reason: stopReason });
+            done = true;
+            break;
+          }
+
+          case 'session.status_terminated':
+            sendSSE('session.terminated', {});
+            done = true;
+            break;
+
+          case 'session.error':
+            sendSSE('session.error', {
+              error: event.error || event.message,
+            });
+            break;
+        }
+      }
+
+      // If no new events and not done, wait briefly before polling again
+      if (events.length === 0 && !done) {
+        await new Promise((resolve) => setTimeout(resolve, 1000));
+      }
+
+      // Check if client disconnected
+      if (req.socket.destroyed) {
+        console.log(`${LOG_PREFIX} Client disconnected from stream ${sessionId}`);
+        done = true;
+      }
+    }
+  } catch (error: any) {
+    console.error(`${LOG_PREFIX} Stream error for ${sessionId}:`, error);
+    sendSSE('error', { error: error.message });
+  } finally {
+    sendSSE('done', {});
+    res.end();
+    console.log(`${LOG_PREFIX} Stream closed for session ${sessionId}`);
+  }
+});


### PR DESCRIPTION
## Summary
First Claude Managed Agents feature. "Investigate with Claude" button in the Voice Lab session detail drawer — creates a managed session with the repo mounted, queries OASIS events via custom tool, streams the investigation report back via SSE.

## Setup (already done)
- Environment: `env_01VrvRRUWP91wiFQrmWaUcEh` (vitana-ops)
- Agent: `agent_011Ca1RTRZADaWdZsKAKjs3B` (Voice Triage Agent, claude-sonnet-4-6)

## Requires
- `ANTHROPIC_API_KEY` env var on the gateway Cloud Run service
- `GITHUB_SAFE_MERGE_TOKEN` (already set) for repo mounting

## Test plan
- [ ] Set ANTHROPIC_API_KEY on gateway Cloud Run
- [ ] Open Voice Lab, find a session with diagnostic flags
- [ ] Click "Investigate with Claude"
- [ ] Verify SSE stream renders agent messages, tool calls, and final triage report

🤖 Generated with [Claude Code](https://claude.com/claude-code)