### PR TITLE
feat(self-healing): wire real-time failure triggers from E2E + ORB + hourly checks

### DIFF
--- a/.github/workflows/DAILY-STATUS-UPDATE.yml
+++ b/.github/workflows/DAILY-STATUS-UPDATE.yml
@@ -1,7 +1,8 @@
-name: Daily Status Update
+name: Hourly Status Check
 on:
   schedule:
-    - cron: '0 8 * * *'
+    # Run every hour at :00 (was daily at 08:00 — too slow for self-healing)
+    - cron: '0 * * * *'
   workflow_dispatch:
 
 jobs:

--- a/.github/workflows/E2E-ORB-MONITOR.yml
+++ b/.github/workflows/E2E-ORB-MONITOR.yml
@@ -51,6 +51,35 @@ jobs:
           TEST_USER_EMAIL: ${{ secrets.TEST_USER_EMAIL }}
           TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
 
+      - name: Report failure to self-healing
+        if: failure()
+        env:
+          GATEWAY_URL: https://gateway-q74ibpv6ia-uc.a.run.app
+          SERVICE_TOKEN: ${{ secrets.GATEWAY_SERVICE_TOKEN }}
+        run: |
+          if [ -z "$SERVICE_TOKEN" ]; then
+            echo "::warning::GATEWAY_SERVICE_TOKEN not set — self-healing report skipped"
+            exit 0
+          fi
+          ENDPOINT="/api/v1/orb/health"
+          curl -sS -X POST "$GATEWAY_URL/api/v1/self-healing/report" \
+            -H "Authorization: Bearer $SERVICE_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "timestamp": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'",
+              "total": 1,
+              "live": 0,
+              "services": [{
+                "name": "orb-widget-${{ matrix.screen }}",
+                "endpoint": "'"$ENDPOINT"'",
+                "status": "down",
+                "http_status": 0,
+                "response_body": "E2E ORB Widget test failed for ${{ matrix.screen }} screen (project: ${{ matrix.project }})",
+                "response_time_ms": 0,
+                "error_message": "Playwright test ${{ matrix.spec }} failed — ORB widget not loading or not functional"
+              }]
+            }' || echo "::warning::Self-healing report POST failed (non-fatal)"
+
       - name: Upload test results on failure
         uses: actions/upload-artifact@v4
         if: failure()

--- a/.github/workflows/E2E-TEST-RUN.yml
+++ b/.github/workflows/E2E-TEST-RUN.yml
@@ -78,6 +78,36 @@ jobs:
           TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
           LOVABLE_SUPABASE_SERVICE_ROLE: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlubWtodndkY3V5aG54a2dmdnNiIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc1NTg2NjYzNywiZXhwIjoyMDcxNDQyNjM3fQ.P4bD2YrbzgvDqM4APVxk_5LzetSTsYx-fAp5GOX4n2M
 
+      - name: Report failure to self-healing
+        if: failure()
+        env:
+          GATEWAY_URL: https://gateway-q74ibpv6ia-uc.a.run.app
+          SERVICE_TOKEN: ${{ secrets.GATEWAY_SERVICE_TOKEN }}
+        run: |
+          if [ -z "$SERVICE_TOKEN" ]; then
+            echo "::warning::GATEWAY_SERVICE_TOKEN not set — self-healing report skipped"
+            exit 0
+          fi
+          # Determine which projects failed from the input
+          PROJECTS="${{ github.event_name == 'repository_dispatch' && github.event.client_payload.projects || inputs.projects }}"
+          curl -sS -X POST "$GATEWAY_URL/api/v1/self-healing/report" \
+            -H "Authorization: Bearer $SERVICE_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d '{
+              "timestamp": "'"$(date -u +%Y-%m-%dT%H:%M:%SZ)"'",
+              "total": 1,
+              "live": 0,
+              "services": [{
+                "name": "e2e-test-run",
+                "endpoint": "/api/v1/e2e/health",
+                "status": "down",
+                "http_status": 0,
+                "response_body": "E2E tests failed for projects: '"$PROJECTS"'",
+                "response_time_ms": 0,
+                "error_message": "Playwright E2E test suite failed — user-facing flows are broken"
+              }]
+            }' || echo "::warning::Self-healing report POST failed (non-fatal)"
+
       - name: Upload test results on failure
         uses: actions/upload-artifact@v4
         if: failure()


### PR DESCRIPTION
## Summary
- **ORB Widget Monitor** (every 15 min): now POSTs to `/self-healing/report` on failure — ORB crashes trigger self-healing in real time
- **E2E Test Run**: now POSTs to `/self-healing/report` on failure — broken user flows trigger self-healing
- **Daily Status → Hourly Status**: cron changed from `0 8 * * *` to `0 * * * *` — 89-endpoint sweep runs every hour

## Why
Self-healing only activated 4 times (April 3-4) because the ONLY trigger was `collect-status.py` running once daily. ORB errors and E2E failures were detected but never fed to self-healing. This PR closes that gap.

## Test plan
- [ ] Merge → ORB Monitor runs at next :00/:15/:30/:45 — if ORB test fails, self-healing/report gets called
- [ ] Verify `GATEWAY_SERVICE_TOKEN` secret exists (confirmed: set 2026-04-03)
- [ ] Check gateway logs for `self-healing.report.received` OASIS events after first hourly run
- [ ] If ORB test passes, no report is sent (if: failure() gate)

🤖 Generated with [Claude Code](https://claude.com/claude-code)