### PR TITLE
feat(self-healing): wire Claude triage agent into self-healing feedback loop

### DIFF
--- a/services/gateway/src/routes/self-healing.ts
+++ b/services/gateway/src/routes/self-healing.ts
@@ -28,6 +28,7 @@ import {
   executeRollback,
   notifyGChat,
 } from '../services/self-healing-snapshot-service';
+import { spawnTriageAgent } from '../services/self-healing-triage-service';
 import {
   HealthReport,
   ServiceStatus,
@@ -190,17 +191,54 @@ async function processFailingService(
     return { action: 'created', vtid, reason: 'Diagnosed only (autonomy level 1)' };
   }
 
-  // If not auto-fixable and low confidence, escalate
+  // If not auto-fixable and low confidence, try deep triage before escalating
   if (!diagnosis.auto_fixable && diagnosis.confidence < 0.5) {
-    await notifyGChat(
-      `🚨 *Self-Healing Escalation*\n` +
-      `Task: ${vtid}\n` +
-      `Service: ${diagnosis.service_name}\n` +
-      `Confidence: ${(diagnosis.confidence * 100).toFixed(0)}% — too low for autonomous fix\n` +
-      `Root cause: ${diagnosis.root_cause.substring(0, 200)}\n` +
-      `Action required: Manual investigation needed`,
-    );
-    return { action: 'escalated', vtid, reason: `Low confidence (${(diagnosis.confidence * 100).toFixed(0)}%)` };
+    // Attempt deep triage with Claude Managed Agents — may upgrade confidence
+    const triageResult = await spawnTriageAgent({
+      mode: 'pre_fix',
+      vtid,
+      diagnosis: diagnosis as any,
+      failure,
+    });
+    if (triageResult.ok && triageResult.report) {
+      console.log(`[self-healing] ${vtid} deep triage: confidence ${(diagnosis.confidence * 100).toFixed(0)}% → ${(triageResult.report.confidence_numeric * 100).toFixed(0)}%`);
+      diagnosis.root_cause = triageResult.report.root_cause_hypothesis || diagnosis.root_cause;
+      diagnosis.confidence = triageResult.report.confidence_numeric;
+      diagnosis.auto_fixable = triageResult.report.confidence_numeric >= 0.8;
+      (diagnosis as any).triage_agent = triageResult.report;
+      // If triage upgraded confidence above 0.5, fall through to spec generation
+      // instead of escalating
+    }
+
+    // Still too low after triage — escalate with the agent's enriched context
+    if (diagnosis.confidence < 0.5) {
+      await notifyGChat(
+        `🚨 *Self-Healing Escalation*\n` +
+        `Task: ${vtid}\n` +
+        `Service: ${diagnosis.service_name}\n` +
+        `Confidence: ${(diagnosis.confidence * 100).toFixed(0)}%${(diagnosis as any).triage_agent ? ' (after deep triage)' : ''}\n` +
+        `Root cause: ${diagnosis.root_cause.substring(0, 200)}\n` +
+        `Action required: Manual investigation needed`,
+      );
+      return { action: 'escalated', vtid, reason: `Low confidence (${(diagnosis.confidence * 100).toFixed(0)}%)` };
+    }
+  }
+
+  // Mid-range confidence (0.5-0.79) — also try deep triage to potentially upgrade
+  if (diagnosis.confidence >= 0.5 && diagnosis.confidence < 0.8 && !(diagnosis as any).triage_agent) {
+    const triageResult = await spawnTriageAgent({
+      mode: 'pre_fix',
+      vtid,
+      diagnosis: diagnosis as any,
+      failure,
+    });
+    if (triageResult.ok && triageResult.report) {
+      console.log(`[self-healing] ${vtid} deep triage: confidence ${(diagnosis.confidence * 100).toFixed(0)}% → ${(triageResult.report.confidence_numeric * 100).toFixed(0)}%`);
+      diagnosis.root_cause = triageResult.report.root_cause_hypothesis || diagnosis.root_cause;
+      diagnosis.confidence = triageResult.report.confidence_numeric;
+      diagnosis.auto_fixable = triageResult.report.confidence_numeric >= 0.8;
+      (diagnosis as any).triage_agent = triageResult.report;
+    }
   }
 
   // Generate fix spec

--- a/services/gateway/src/services/self-healing-reconciler.ts
+++ b/services/gateway/src/services/self-healing-reconciler.ts
@@ -21,6 +21,11 @@
 
 import { emitOasisEvent } from './oasis-event-service';
 import { notifyGChat } from './self-healing-snapshot-service';
+import {
+  spawnTriageAgent,
+  createFreshVtidFromTriageReport,
+  MAX_TRIAGE_ATTEMPTS,
+} from './self-healing-triage-service';
 
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
@@ -288,9 +293,82 @@ async function runReconcileCycle(thresholdMs: number): Promise<void> {
         continue;
       }
 
-      // Path C: redispatch was capped, infeasible (no spec), or failed →
-      // tombstone as stale_no_progress so it leaves the pending list.
-      const ok = await markEscalated(row, 'stale_no_progress', http_status);
+      // Path C: redispatch was capped, infeasible, or failed.
+      // Before tombstoning, try a deep triage agent investigation — it may
+      // produce a DIFFERENT approach that feeds a fresh self-healing cycle.
+      const agentAttempts = Number((row.diagnosis || {} as any).triage_agent_attempts || 0);
+
+      if (agentAttempts < MAX_TRIAGE_ATTEMPTS) {
+        console.log(`${LOG_PREFIX} Spawning triage agent for ${row.vtid} (attempt ${agentAttempts + 1}/${MAX_TRIAGE_ATTEMPTS})`);
+        try {
+          const triageResult = await spawnTriageAgent({
+            mode: 'post_failure',
+            vtid: row.vtid,
+            original_diagnosis: row.diagnosis || undefined,
+            failure_class: row.failure_class,
+            endpoint: row.endpoint,
+            all_attempts: agentAttempts,
+            reconciler_history: {
+              redispatch_count: (row.diagnosis || {} as any).reconciler_redispatch_count,
+              age_hours: ageHours,
+              redispatch_status: redispatch.status,
+              redispatch_reason: redispatch.reason,
+            },
+          });
+
+          if (triageResult.ok && triageResult.report && triageResult.report.confidence_numeric >= 0.5) {
+            // Agent produced a viable new approach — create a fresh VTID
+            const newVtid = await createFreshVtidFromTriageReport(
+              row.vtid,
+              triageResult.report,
+              row.endpoint,
+            );
+
+            if (newVtid) {
+              // Update the original row to record the agent attempt
+              const updatedDiagnosis = {
+                ...(row.diagnosis || {}),
+                triage_agent_attempts: agentAttempts + 1,
+                triage_spawned_vtid: newVtid,
+                triage_report: triageResult.report,
+              };
+              await fetch(`${SUPABASE_URL}/rest/v1/self_healing_log?id=eq.${row.id}`, {
+                method: 'PATCH',
+                headers: { ...supabaseHeaders(), Prefer: 'return=minimal' },
+                body: JSON.stringify({ diagnosis: updatedDiagnosis }),
+              }).catch(() => {});
+
+              await emitOasisEvent({
+                vtid: row.vtid,
+                type: 'self-healing.triage.loop' as any,
+                source: 'self-healing-reconciler',
+                status: 'info',
+                message: `Triage agent produced new approach → spawned ${newVtid} (parent: ${row.vtid})`,
+                payload: {
+                  parent_vtid: row.vtid,
+                  child_vtid: newVtid,
+                  triage_confidence: triageResult.report.confidence,
+                  agent_attempt: agentAttempts + 1,
+                },
+                actor_role: 'system',
+                surface: 'system',
+              }).catch(() => {});
+
+              console.log(`${LOG_PREFIX} Triage loop: ${row.vtid} → ${newVtid} (confidence: ${triageResult.report.confidence})`);
+              // Mark original as escalated now that a child has taken over
+              await markEscalated(row, 'stale_no_progress', http_status);
+              continue;
+            }
+          }
+        } catch (triageErr) {
+          console.warn(`${LOG_PREFIX} Triage agent error for ${row.vtid}:`, triageErr);
+        }
+      }
+
+      // Tombstone: either agent budget exhausted or agent couldn't produce a viable approach
+      const tombstoneReason = agentAttempts >= MAX_TRIAGE_ATTEMPTS
+        ? 'stale_agent_exhausted' : 'stale_no_progress';
+      const ok = await markEscalated(row, tombstoneReason as any, http_status);
       if (!ok) continue;
       try {
         await emitOasisEvent({
@@ -298,15 +376,16 @@ async function runReconcileCycle(thresholdMs: number): Promise<void> {
           type: 'self-healing.reconciled',
           source: 'self-healing-reconciler',
           status: 'warning',
-          message: `Reconciler tombstoned ${row.vtid} as stale_no_progress (redispatch ${redispatch.status}: ${redispatch.reason || 'n/a'})`,
+          message: `Reconciler tombstoned ${row.vtid} as ${tombstoneReason}`,
           payload: {
             endpoint: row.endpoint,
             failure_class: row.failure_class,
-            reason: 'stale_no_progress',
+            reason: tombstoneReason,
             http_status,
             age_hours: Number(ageHours.toFixed(2)),
             redispatch_status: redispatch.status,
             redispatch_reason: redispatch.reason,
+            triage_agent_attempts: agentAttempts,
           },
           actor_role: 'system',
           surface: 'system',
@@ -314,14 +393,13 @@ async function runReconcileCycle(thresholdMs: number): Promise<void> {
       } catch (emitErr) {
         console.warn(`${LOG_PREFIX} Failed to emit OASIS event for ${row.vtid}:`, emitErr);
       }
-      // Real-time Gchat — this is a GIVE-UP signal, team must act.
       try {
         await notifyGChat(
-          `🚨 *Self-Healing GAVE UP — stale_no_progress*\n` +
+          `🚨 *Self-Healing GAVE UP — ${tombstoneReason}*\n` +
           `Task: ${row.vtid}\n` +
           `Endpoint: ${row.endpoint} (HTTP ${http_status ?? 'err'})\n` +
           `Age: ${ageHours.toFixed(1)}h\n` +
-          `Reason: Reconciler exhausted redispatch attempts (${redispatch.status}: ${redispatch.reason || 'n/a'}).\n` +
+          `Triage attempts: ${agentAttempts}/${MAX_TRIAGE_ATTEMPTS}\n` +
           `Endpoint still down. Manual investigation required.\n` +
           `Act now: ${COMMAND_HUB_SH_URL}`,
         );
@@ -329,7 +407,7 @@ async function runReconcileCycle(thresholdMs: number): Promise<void> {
         console.warn(`${LOG_PREFIX} Failed to send Gchat tombstone notification:`, notifyErr);
       }
       console.log(
-        `${LOG_PREFIX} Tombstoned ${row.vtid} as stale_no_progress (age=${ageHours.toFixed(1)}h, redispatch=${redispatch.status}/${redispatch.reason || 'n/a'})`,
+        `${LOG_PREFIX} Tombstoned ${row.vtid} as ${tombstoneReason} (age=${ageHours.toFixed(1)}h, triage_attempts=${agentAttempts})`,
       );
     }
   } catch (err) {

--- a/services/gateway/src/services/self-healing-triage-service.ts
+++ b/services/gateway/src/services/self-healing-triage-service.ts
@@ -1,0 +1,518 @@
+/**
+ * Self-Healing Triage Service
+ *
+ * Reusable synchronous wrapper around Claude Managed Agents that the
+ * self-healing pipeline calls at three points:
+ *
+ *   1. PRE-FIX:  low-confidence deterministic diagnosis → agent investigates
+ *                deeper → may upgrade confidence or enrich human context
+ *   2. POST-FAILURE: reconciler exhausted redispatches → agent analyzes the
+ *                full failure history → produces a revised diagnosis for a
+ *                fresh self-healing cycle
+ *   3. VERIFICATION_FAILURE: blast radius detected → agent reads pre/post
+ *                snapshots + applied diff → explains what went wrong
+ *
+ * The agent has access to:
+ *   - The vitana-platform repo (mounted at /workspace/repo)
+ *   - OASIS events via the `query_oasis_events` custom tool (Supabase creds host-side)
+ *   - E2E test results via the `query_test_results` custom tool (future)
+ *
+ * Shared Anthropic API helpers and config are imported from triage-agent.ts.
+ */
+
+const LOG_PREFIX = '[self-healing-triage]';
+
+// Config from environment (same as triage-agent.ts)
+const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY || '';
+const AGENT_ID = process.env.TRIAGE_AGENT_ID || 'agent_011Ca1RTRZADaWdZsKAKjs3B';
+const ENVIRONMENT_ID = process.env.TRIAGE_ENVIRONMENT_ID || 'env_01VrvRRUWP91wiFQrmWaUcEh';
+const ANTHROPIC_BASE = 'https://api.anthropic.com';
+const BETA_HEADER = 'managed-agents-2026-04-01';
+const MAX_TRIAGE_ATTEMPTS = 2;
+const SESSION_TIMEOUT_MS = 120_000; // 2 minutes max per triage session
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type TriageMode = 'pre_fix' | 'post_failure' | 'verification_failure';
+
+export interface TriageInput {
+  mode: TriageMode;
+  vtid: string;
+  // Pre-fix mode
+  diagnosis?: Record<string, unknown>;
+  failure?: { endpoint: string; name?: string; status?: string; error?: string };
+  // Post-failure mode
+  original_diagnosis?: Record<string, unknown>;
+  failure_class?: string;
+  endpoint?: string;
+  all_attempts?: number;
+  reconciler_history?: Record<string, unknown>;
+  // Verification failure mode
+  applied_spec?: string;
+  verification_result?: Record<string, unknown>;
+  pre_fix_snapshot?: unknown;
+  post_fix_snapshot?: unknown;
+  blast_radius?: unknown;
+}
+
+export interface TriageReport {
+  session_id: string;
+  severity: 'critical' | 'warning' | 'info';
+  root_cause_hypothesis: string;
+  affected_component: string;
+  evidence: string[];
+  recommended_fix: string;
+  confidence: 'high' | 'medium' | 'low';
+  confidence_numeric: number;
+  elapsed_ms: number;
+  mode: TriageMode;
+  raw_output: string;
+}
+
+export interface TriageResult {
+  ok: boolean;
+  report?: TriageReport;
+  error?: string;
+}
+
+// =============================================================================
+// Anthropic API helper (duplicated from triage-agent.ts to avoid circular dep)
+// =============================================================================
+
+async function anthropicRequest<T>(
+  path: string,
+  options: { method?: string; body?: unknown } = {}
+): Promise<{ ok: boolean; data?: T; error?: string }> {
+  if (!ANTHROPIC_API_KEY) {
+    return { ok: false, error: 'ANTHROPIC_API_KEY not set' };
+  }
+
+  try {
+    const response = await fetch(`${ANTHROPIC_BASE}${path}`, {
+      method: options.method || 'GET',
+      headers: {
+        'Content-Type': 'application/json',
+        'x-api-key': ANTHROPIC_API_KEY,
+        'anthropic-version': '2023-06-01',
+        'anthropic-beta': BETA_HEADER,
+      },
+      body: options.body ? JSON.stringify(options.body) : undefined,
+    });
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      return { ok: false, error: `${response.status}: ${errorText}` };
+    }
+
+    const data = (await response.json()) as T;
+    return { ok: true, data };
+  } catch (error) {
+    return { ok: false, error: String(error) };
+  }
+}
+
+// =============================================================================
+// OASIS events custom tool handler (same as triage-agent.ts)
+// =============================================================================
+
+async function queryOasisEvents(
+  sessionId: string,
+  limit: number = 100
+): Promise<string> {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE;
+
+  if (!supabaseUrl || !supabaseKey) {
+    return 'Error: Missing Supabase credentials';
+  }
+
+  try {
+    const response = await fetch(
+      `${supabaseUrl}/rest/v1/oasis_events?or=(metadata->>session_id.eq.${encodeURIComponent(sessionId)},metadata->>sessionId.eq.${encodeURIComponent(sessionId)})&order=created_at.asc&limit=${limit}&select=id,topic,vtid,status,message,metadata,created_at`,
+      {
+        headers: {
+          apikey: supabaseKey,
+          Authorization: `Bearer ${supabaseKey}`,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      return `Error: Supabase ${response.status}: ${await response.text()}`;
+    }
+
+    const events = await response.json();
+    return JSON.stringify(events, null, 2);
+  } catch (error) {
+    return `Error: ${String(error)}`;
+  }
+}
+
+// =============================================================================
+// Prompt builders per mode
+// =============================================================================
+
+function buildPrompt(input: TriageInput): string {
+  const lines: string[] = [];
+
+  switch (input.mode) {
+    case 'pre_fix':
+      lines.push(
+        `## Investigation Mode: PRE-FIX DEEP TRIAGE`,
+        ``,
+        `The deterministic self-healing classifier produced a diagnosis with`,
+        `insufficient confidence. Your job is to investigate deeper using`,
+        `source code and OASIS events, and either upgrade the confidence`,
+        `or provide richer context for human approval.`,
+        ``,
+        `### VTID: ${input.vtid}`,
+        `### Endpoint: ${input.failure?.endpoint || 'unknown'}`,
+        `### Service: ${input.failure?.name || 'unknown'}`,
+        `### Deterministic Diagnosis:`,
+        `${JSON.stringify(input.diagnosis, null, 2)}`,
+        ``,
+        `### Instructions`,
+        `1. Call query_oasis_events if the diagnosis mentions a session_id`,
+        `2. Read the relevant source code in /workspace/repo/ based on the failure class`,
+        `3. Produce your triage report with a confidence assessment`,
+      );
+      break;
+
+    case 'post_failure':
+      lines.push(
+        `## Investigation Mode: POST-FAILURE FEEDBACK LOOP`,
+        ``,
+        `A previous self-healing attempt for this endpoint FAILED. The`,
+        `reconciler exhausted its redispatch budget and the endpoint is`,
+        `still down. Your job is to analyze the FULL failure history,`,
+        `understand WHY the previous fix didn't work, and propose a`,
+        `DIFFERENT approach.`,
+        ``,
+        `### VTID: ${input.vtid}`,
+        `### Endpoint: ${input.endpoint || 'unknown'}`,
+        `### Failure Class: ${input.failure_class || 'unknown'}`,
+        `### Previous Attempts: ${input.all_attempts || 0}`,
+        `### Reconciler History:`,
+        `${JSON.stringify(input.reconciler_history, null, 2)}`,
+        `### Original Diagnosis:`,
+        `${JSON.stringify(input.original_diagnosis, null, 2)}`,
+        ``,
+        `### Instructions`,
+        `1. Read the source code that was targeted by the previous fix`,
+        `2. Understand why the previous approach failed`,
+        `3. Propose a DIFFERENT root cause and fix — do not repeat the same approach`,
+        `4. Your diagnosis will feed a FRESH self-healing cycle with a new VTID`,
+      );
+      break;
+
+    case 'verification_failure':
+      lines.push(
+        `## Investigation Mode: VERIFICATION FAILURE ANALYSIS`,
+        ``,
+        `A self-healing fix was applied but verification detected problems`,
+        `— either blast radius (newly broken endpoints) or the original`,
+        `endpoint is still down. The fix will be rolled back. Your job is`,
+        `to analyze what went wrong so the next attempt is better-informed.`,
+        ``,
+        `### VTID: ${input.vtid}`,
+        `### Applied Spec:`,
+        `${input.applied_spec || '(not available)'}`,
+        `### Verification Result:`,
+        `${JSON.stringify(input.verification_result, null, 2)}`,
+        `### Blast Radius:`,
+        `${JSON.stringify(input.blast_radius, null, 2)}`,
+        ``,
+        `### Instructions`,
+        `1. Read the code that was modified by the applied spec`,
+        `2. Analyze why the fix caused blast radius or failed verification`,
+        `3. Explain what went wrong and what the next attempt should do differently`,
+      );
+      break;
+  }
+
+  lines.push(
+    ``,
+    `## Output Format`,
+    `End your investigation with a structured report:`,
+    ``,
+    `### Triage Report`,
+    `- **Session ID**: (your managed session id)`,
+    `- **Severity**: critical / warning / info`,
+    `- **Root Cause Hypothesis**: 1-2 sentences`,
+    `- **Affected Component**: file path + function name`,
+    `- **Evidence**: bullet list`,
+    `- **Recommended Fix**: concrete next step`,
+    `- **Confidence**: high / medium / low`,
+  );
+
+  return lines.join('\n');
+}
+
+// =============================================================================
+// Report parser — extracts structured data from the agent's text output
+// =============================================================================
+
+function parseTriageReport(
+  rawText: string,
+  sessionId: string,
+  mode: TriageMode,
+  elapsedMs: number
+): TriageReport {
+  const extract = (label: string): string => {
+    const regex = new RegExp(`\\*\\*${label}\\*\\*:\\s*(.+?)(?=\\n\\*\\*|\\n###|$)`, 's');
+    const match = rawText.match(regex);
+    return match ? match[1].trim() : '';
+  };
+
+  const severityRaw = extract('Severity').toLowerCase();
+  const severity = (['critical', 'warning', 'info'].includes(severityRaw)
+    ? severityRaw
+    : 'warning') as 'critical' | 'warning' | 'info';
+
+  const confidenceRaw = extract('Confidence').toLowerCase();
+  const confidence = (['high', 'medium', 'low'].includes(confidenceRaw)
+    ? confidenceRaw
+    : 'low') as 'high' | 'medium' | 'low';
+
+  const confidenceNumeric =
+    confidence === 'high' ? 0.85 : confidence === 'medium' ? 0.65 : 0.4;
+
+  const evidenceRaw = extract('Evidence');
+  const evidence = evidenceRaw
+    .split('\n')
+    .map((line) => line.replace(/^[-*•]\s*/, '').trim())
+    .filter((line) => line.length > 0);
+
+  return {
+    session_id: sessionId,
+    severity,
+    root_cause_hypothesis: extract('Root Cause Hypothesis'),
+    affected_component: extract('Affected Component'),
+    evidence,
+    recommended_fix: extract('Recommended Fix'),
+    confidence,
+    confidence_numeric: confidenceNumeric,
+    elapsed_ms: elapsedMs,
+    mode,
+    raw_output: rawText,
+  };
+}
+
+// =============================================================================
+// Main entry point: spawnTriageAgent
+// =============================================================================
+
+export async function spawnTriageAgent(input: TriageInput): Promise<TriageResult> {
+  if (!ANTHROPIC_API_KEY) {
+    console.warn(`${LOG_PREFIX} ANTHROPIC_API_KEY not set — skipping triage`);
+    return { ok: false, error: 'ANTHROPIC_API_KEY not set' };
+  }
+
+  const startTime = Date.now();
+  console.log(`${LOG_PREFIX} Spawning triage agent for ${input.vtid} (mode=${input.mode})`);
+
+  // 1. Create session with repo mounted
+  const sessionResult = await anthropicRequest<any>('/v1/sessions', {
+    method: 'POST',
+    body: {
+      agent: { type: 'agent', id: AGENT_ID, version: 1 },
+      environment_id: ENVIRONMENT_ID,
+      title: `Self-healing triage: ${input.vtid} (${input.mode})`,
+      resources: [
+        {
+          type: 'github_repository',
+          url: 'https://github.com/exafyltd/vitana-platform',
+          authorization_token: process.env.GITHUB_SAFE_MERGE_TOKEN || '',
+          mount_path: '/workspace/repo',
+          checkout: { type: 'branch', name: 'main' },
+        },
+      ],
+    },
+  });
+
+  if (!sessionResult.ok || !sessionResult.data) {
+    console.error(`${LOG_PREFIX} Session creation failed:`, sessionResult.error);
+    return { ok: false, error: `Session creation failed: ${sessionResult.error}` };
+  }
+
+  const sessionId = sessionResult.data.id;
+  console.log(`${LOG_PREFIX} Session created: ${sessionId}`);
+
+  // 2. Send the investigation prompt
+  const prompt = buildPrompt(input);
+  await anthropicRequest(`/v1/sessions/${sessionId}/events`, {
+    method: 'POST',
+    body: {
+      events: [
+        { type: 'user.message', content: [{ type: 'text', text: prompt }] },
+      ],
+    },
+  });
+
+  // 3. Poll events until done, handling custom tools along the way
+  let done = false;
+  const seenIds = new Set<string>();
+  const textParts: string[] = [];
+  const deadline = Date.now() + SESSION_TIMEOUT_MS;
+
+  while (!done && Date.now() < deadline) {
+    const eventsResult = await anthropicRequest<any>(
+      `/v1/sessions/${sessionId}/events`
+    );
+
+    if (!eventsResult.ok || !eventsResult.data) {
+      console.error(`${LOG_PREFIX} Events poll failed:`, eventsResult.error);
+      break;
+    }
+
+    const events = eventsResult.data.data || [];
+
+    for (const event of events) {
+      if (seenIds.has(event.id)) continue;
+      seenIds.add(event.id);
+
+      switch (event.type) {
+        case 'agent.message':
+          if (event.content) {
+            for (const block of event.content) {
+              if (block.type === 'text') {
+                textParts.push(block.text);
+              }
+            }
+          }
+          break;
+
+        case 'agent.custom_tool_use':
+          if (event.tool_name === 'query_oasis_events') {
+            const result = await queryOasisEvents(
+              event.input?.session_id || '',
+              event.input?.limit || 100
+            );
+            await anthropicRequest(`/v1/sessions/${sessionId}/events`, {
+              method: 'POST',
+              body: {
+                events: [
+                  {
+                    type: 'user.custom_tool_result',
+                    custom_tool_use_id: event.id,
+                    content: [{ type: 'text', text: result }],
+                  },
+                ],
+              },
+            });
+          }
+          break;
+
+        case 'session.status_idle': {
+          const stopReason = event.stop_reason?.type;
+          if (stopReason !== 'requires_action') {
+            done = true;
+          }
+          break;
+        }
+
+        case 'session.status_terminated':
+          done = true;
+          break;
+      }
+    }
+
+    if (!done && events.length === 0) {
+      await new Promise((resolve) => setTimeout(resolve, 2000));
+    }
+  }
+
+  const elapsedMs = Date.now() - startTime;
+  const rawOutput = textParts.join('\n');
+
+  if (!rawOutput) {
+    console.warn(`${LOG_PREFIX} Agent produced no text output for ${input.vtid}`);
+    return { ok: false, error: 'Agent produced no output' };
+  }
+
+  const report = parseTriageReport(rawOutput, sessionId, input.mode, elapsedMs);
+  console.log(
+    `${LOG_PREFIX} Triage complete for ${input.vtid}: confidence=${report.confidence} (${report.confidence_numeric}), elapsed=${elapsedMs}ms`
+  );
+
+  return { ok: true, report };
+}
+
+// =============================================================================
+// Helper: create a fresh VTID from a triage report for the feedback loop
+// =============================================================================
+
+export async function createFreshVtidFromTriageReport(
+  parentVtid: string,
+  report: TriageReport,
+  endpoint: string,
+): Promise<string | null> {
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE;
+
+  if (!supabaseUrl || !supabaseKey) {
+    return null;
+  }
+
+  // Generate a new VTID by incrementing the latest
+  try {
+    const latestRes = await fetch(
+      `${supabaseUrl}/rest/v1/vtid_ledger?select=vtid&order=created_at.desc&limit=1`,
+      {
+        headers: {
+          apikey: supabaseKey,
+          Authorization: `Bearer ${supabaseKey}`,
+        },
+      }
+    );
+
+    if (!latestRes.ok) return null;
+    const latest = (await latestRes.json()) as Array<{ vtid: string }>;
+    const lastNum = latest.length > 0
+      ? parseInt(latest[0].vtid.replace('VTID-', ''), 10)
+      : 1900;
+    const newVtid = `VTID-${String(lastNum + 1).padStart(5, '0')}`;
+
+    // Insert the new VTID into the ledger
+    const insertRes = await fetch(`${supabaseUrl}/rest/v1/vtid_ledger`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: supabaseKey,
+        Authorization: `Bearer ${supabaseKey}`,
+        Prefer: 'return=representation',
+      },
+      body: JSON.stringify({
+        vtid: newVtid,
+        title: `SELF-HEAL (retry): ${report.root_cause_hypothesis.substring(0, 80)}`,
+        summary: report.recommended_fix,
+        status: 'in_progress',
+        layer: 'OPS',
+        module: 'SELF-HEAL',
+        metadata: {
+          source: 'self-healing-triage-loop',
+          parent_vtid: parentVtid,
+          triage_session_id: report.session_id,
+          triage_confidence: report.confidence,
+          triage_mode: report.mode,
+          endpoint,
+        },
+      }),
+    });
+
+    if (!insertRes.ok) {
+      console.error(`${LOG_PREFIX} Failed to create VTID: ${insertRes.status}`);
+      return null;
+    }
+
+    console.log(`${LOG_PREFIX} Created fresh VTID ${newVtid} (parent: ${parentVtid})`);
+    return newVtid;
+  } catch (error) {
+    console.error(`${LOG_PREFIX} createFreshVtid error:`, error);
+    return null;
+  }
+}
+
+export { MAX_TRIAGE_ATTEMPTS };


### PR DESCRIPTION
## Summary
The self-healing pipeline now spawns a Claude Managed Agents session at two points for deep code-based investigation:

1. **PRE-FIX**: when deterministic confidence < 0.8, the agent reads code + OASIS events and may upgrade confidence or enrich human approval context
2. **POST-FAILURE**: when the reconciler exhausts redispatch attempts, the agent analyzes the full failure history and proposes a DIFFERENT approach. If viable, a fresh VTID is created and fed back into the pipeline (max 2 loops)

This closes the feedback loop: the system now learns from its own failed attempts instead of tombstoning and giving up.

## New file
- `services/gateway/src/services/self-healing-triage-service.ts`: `spawnTriageAgent()` + `createFreshVtidFromTriageReport()`

## Test plan
- [ ] POST a simulated failure with < 0.5 confidence → verify triage agent spawns and may upgrade
- [ ] Create a stale pending row with exhausted redispatches → wait for reconciler → verify triage loop spawns fresh VTID
- [ ] Verify max 2 loops: after 2 agent attempts, row is tombstoned as stale_agent_exhausted

🤖 Generated with [Claude Code](https://claude.com/claude-code)