### PR TITLE
fix(self-healing): unify into standard task execution pipeline

### DIFF
--- a/services/gateway/src/routes/self-healing.ts
+++ b/services/gateway/src/routes/self-healing.ts
@@ -263,44 +263,9 @@ async function processFailingService(
     return { action: 'escalated', vtid, reason: `Injection failed: ${injection.error}` };
   }
 
-  // For auto-approved tasks: directly dispatch to worker orchestrator
-  // with bounded retry (autopilot event loop is the backup, but a single
-  // transient 5xx / network blip used to leave rows pending until the
-  // reconciler tombstoned them).
-  if (diagnosis.confidence >= 0.8 && diagnosis.auto_fixable) {
-    const dispatch = await dispatchToWorkerWithRetry(
-      vtid,
-      `SELF-HEAL: ${diagnosis.service_name} — ${diagnosis.failure_class}`,
-      spec,
-    );
-    if (!dispatch.ok) {
-      console.error(`[self-healing] ${vtid} dispatch failed after retries: ${dispatch.lastError}`);
-      await emitOasisEvent({
-        type: 'self-healing.dispatch.failed',
-        vtid,
-        source: 'self-healing',
-        status: 'error',
-        message: `Worker orchestrator dispatch failed after retries: ${dispatch.lastError}`,
-        payload: {
-          last_error: dispatch.lastError,
-          confidence: diagnosis.confidence,
-          service: diagnosis.service_name,
-        },
-      });
-      // Real-time Gchat alert — autopilot couldn't dispatch, team needs
-      // to investigate or manually approve.
-      await notifyGChat(
-        `🚨 *Self-Healing Dispatch FAILED*\n` +
-        `Task: ${vtid}\n` +
-        `Service: ${diagnosis.service_name}\n` +
-        `Endpoint: ${diagnosis.endpoint}\n` +
-        `Confidence: ${(diagnosis.confidence * 100).toFixed(0)}%\n` +
-        `Error: ${dispatch.lastError}\n` +
-        `Autopilot exhausted retries. Reconciler will attempt redispatch within 1h.\n` +
-        `Act now: ${COMMAND_HUB_SH_URL}`,
-      );
-    }
-  }
+  // No direct dispatch — the injector emits autopilot.task.spec.created
+  // which the autopilot event loop picks up and dispatches through the
+  // standard pipeline (enforceSpecRequirement → worker-runner → completion).
 
   // Gchat notification ONLY when a human decision is required.
   // Auto-approved tasks run silently — the team sees them in the
@@ -661,51 +626,6 @@ router.get('/pending-approval', async (req: Request, res: Response) => {
 });
 
 /**
- * Helper: dispatch a self-healing VTID to the worker orchestrator with
- * bounded retry. Used by both the auto-approved direct-dispatch path
- * (in runHealing) and the human-approve path below. Returns true on
- * success, false after maxAttempts failures.
- */
-async function dispatchToWorkerWithRetry(
-  vtid: string,
-  title: string,
-  spec: string,
-  maxAttempts = 3,
-): Promise<{ ok: boolean; lastError?: string }> {
-  const gatewayUrl = process.env.GATEWAY_URL || 'https://gateway-q74ibpv6ia-uc.a.run.app';
-  let lastError: string | undefined;
-
-  for (let attempt = 1; attempt <= maxAttempts; attempt++) {
-    try {
-      console.log(`[self-healing] ${vtid} dispatch attempt ${attempt}/${maxAttempts}`);
-      const resp = await fetch(`${gatewayUrl}/api/v1/worker/orchestrator/route`, {
-        method: 'POST',
-        headers: { 'Content-Type': 'application/json' },
-        body: JSON.stringify({
-          vtid,
-          title,
-          spec: spec.substring(0, 8000),
-          source: 'self-healing',
-          priority: 'critical',
-        }),
-      });
-
-      if (resp.ok) {
-        console.log(`[self-healing] ${vtid} dispatch ok on attempt ${attempt}`);
-        return { ok: true };
-      }
-      lastError = `HTTP ${resp.status}`;
-    } catch (err: any) {
-      lastError = err.message;
-    }
-    if (attempt < maxAttempts) {
-      await new Promise(r => setTimeout(r, 1000 * Math.pow(2, attempt - 1)));
-    }
-  }
-  return { ok: false, lastError };
-}
-
-/**
  * POST /approve — Human approves a sub-0.8 row from pending-approval.
  * Body: { id: number, operator?: string }
  *
@@ -766,22 +686,12 @@ router.post('/approve', async (req: Request, res: Response) => {
       body: JSON.stringify({ spec_status: 'approved', updated_at: new Date().toISOString() }),
     });
 
-    // 4. Dispatch with bounded retry
-    const dispatch = await dispatchToWorkerWithRetry(
-      vtid,
-      ledgerRow.title || `SELF-HEAL: ${vtid}`,
-      ledgerRow.summary || '',
-    );
-
-    // 5. Mark self_healing_log row as human-approved (regardless of dispatch outcome —
-    //    the OASIS event captures the dispatch failure separately)
+    // 4. Mark self_healing_log row as human-approved
     const newDiagnosis = {
       ...(logRow.diagnosis || {}),
       human_decision: 'approved',
       human_decision_at: new Date().toISOString(),
       human_decision_by: operator || 'command-hub',
-      human_dispatch_ok: dispatch.ok,
-      human_dispatch_error: dispatch.lastError,
     };
     await fetch(`${SUPABASE_URL}/rest/v1/self_healing_log?id=eq.${id}`, {
       method: 'PATCH',
@@ -789,37 +699,25 @@ router.post('/approve', async (req: Request, res: Response) => {
       body: JSON.stringify({ diagnosis: newDiagnosis }),
     });
 
-    // 6. Emit OASIS event
+    // 5. Emit execution_approved OASIS event — the autopilot event loop
+    // picks this up and dispatches through the standard pipeline (worker
+    // orchestrator → worker-runner), just like any other approved task.
+    // NO direct dispatch — same path as every other task.
     await emitOasisEvent({
-      type: dispatch.ok ? 'self-healing.approved' : 'self-healing.dispatch.failed',
+      type: 'vtid.lifecycle.execution_approved',
       vtid,
       source: 'self-healing',
-      status: dispatch.ok ? 'info' : 'error',
-      message: dispatch.ok
-        ? `Self-healing ${vtid} approved by ${operator || 'command-hub'} and dispatched`
-        : `Self-healing ${vtid} approved but dispatch failed: ${dispatch.lastError}`,
+      status: 'info',
+      message: `Self-healing ${vtid} approved by ${operator || 'command-hub'}`,
       payload: {
+        auto_approved: true,
+        source: 'self-healing',
         operator: operator || 'command-hub',
         confidence: logRow.confidence,
-        dispatch_ok: dispatch.ok,
-        dispatch_error: dispatch.lastError,
       },
     });
 
-    // Gchat notification ONLY on failure — a successful approve is a
-    // "done" state the operator who clicked the button already knows
-    // about. If the dispatch failed, manual retry is needed.
-    if (!dispatch.ok) {
-      await notifyGChat(
-        `🚨 *Self-Healing Approved but Dispatch FAILED*\n` +
-        `Task: ${vtid}\n` +
-        `Operator: ${operator || 'command-hub'}\n` +
-        `Error: ${dispatch.lastError}\n` +
-        `Manual retry needed: ${COMMAND_HUB_SH_URL}`,
-      );
-    }
-
-    return res.json({ ok: true, vtid, dispatched: dispatch.ok, error: dispatch.lastError });
+    return res.json({ ok: true, vtid });
   } catch (err: any) {
     return res.status(500).json({ ok: false, error: err.message });
   }

--- a/services/gateway/src/services/autopilot-controller.ts
+++ b/services/gateway/src/services/autopilot-controller.ts
@@ -43,6 +43,7 @@ import {
  */
 export type AutopilotState =
   | 'allocated'       // VTID allocated, not yet started
+  | 'scheduled'       // Ready for worker pickup (e.g. self-healing injected tasks)
   | 'in_progress'     // Work dispatched to worker
   | 'building'        // Worker actively building
   | 'pr_created'      // PR created, awaiting CI
@@ -392,7 +393,8 @@ export async function verifySpecIntegrity(vtid: string): Promise<boolean> {
  * VTID-01208: Added recovery transition from failed → completed for terminalization success
  */
 const VALID_TRANSITIONS: Record<AutopilotState, AutopilotState[]> = {
-  'allocated': ['in_progress', 'failed', 'completed'],
+  'allocated': ['in_progress', 'scheduled', 'failed', 'completed'],
+  'scheduled': ['in_progress', 'failed', 'completed'],
   'in_progress': ['building', 'failed', 'completed'],
   'building': ['pr_created', 'failed', 'completed'],
   'pr_created': ['reviewing', 'failed', 'completed'],
@@ -896,6 +898,7 @@ export function getAutopilotStatus(): {
 
   const runsByState: Record<AutopilotState, number> = {
     allocated: 0,
+    scheduled: 0,
     in_progress: 0,
     building: 0,
     pr_created: 0,

--- a/services/gateway/src/services/autopilot-event-mapper.ts
+++ b/services/gateway/src/services/autopilot-event-mapper.ts
@@ -90,6 +90,7 @@ export interface MappingResult {
 
 const STATE_ORDER: Record<AutopilotState, number> = {
   'allocated': 0,
+  'scheduled': 0,  // Same level as allocated — ready for pickup
   'in_progress': 1,
   'building': 2,
   'pr_created': 3,
@@ -158,7 +159,7 @@ export const EVENT_MAPPING_RULES: EventMappingRule[] = [
       'self-healing.task.injected',             // Self-healing pipeline injected task
       'autopilot.task.spec.created',            // Also fires on spec creation (shared trigger)
     ],
-    fromStates: ['allocated'],
+    fromStates: ['allocated', 'scheduled'],
     toState: 'in_progress',
     triggerAction: 'dispatch',
     condition: (event) => {
@@ -178,7 +179,7 @@ export const EVENT_MAPPING_RULES: EventMappingRule[] = [
       'vtid.lifecycle.execution_approved',  // VTID-01194: NEW - Explicit human approval
       'vtid.lifecycle.in_progress',         // VTID-01194: Status-based trigger
     ],
-    fromStates: ['allocated'],
+    fromStates: ['allocated', 'scheduled'],
     toState: 'in_progress',
     triggerAction: 'dispatch',
     description: 'VTID-01194: Human approved execution - dispatch to worker',

--- a/services/gateway/src/services/self-healing-injector-service.ts
+++ b/services/gateway/src/services/self-healing-injector-service.ts
@@ -70,7 +70,7 @@ export async function injectIntoAutopilotPipeline(
           summary: spec.substring(0, 2000),
           layer: 'INFRA',
           module: mapServiceToModule(diagnosis.service_name),
-          status: 'allocated',  // must stay 'allocated' for autopilot event loop to pick up
+          status: 'scheduled',  // 'scheduled' is what worker-runner polls for and the standard pipeline expects
           spec_status: autoApproved ? 'approved' : 'validated',  // approved = auto-exec, validated = awaiting human
           assigned_to: 'autopilot',
           metadata: {

--- a/services/gateway/src/services/self-healing-spec-service.ts
+++ b/services/gateway/src/services/self-healing-spec-service.ts
@@ -12,6 +12,7 @@ import { GoogleAuth } from 'google-auth-library';
 import { Diagnosis, FailureClass } from '../types/self-healing';
 import { emitOasisEvent } from './oasis-event-service';
 import { runFullQualityCheck } from './spec-quality-agent';
+import { createVtidSpec } from './vtid-spec-service';
 
 const VERTEX_PROJECT = process.env.GOOGLE_CLOUD_PROJECT || process.env.GCP_PROJECT || 'lovable-vitana-vers1';
 const SUPABASE_URL = process.env.SUPABASE_URL;
@@ -584,6 +585,39 @@ export async function generateAndStoreFixSpec(
 
   await storeSpec(diagnosis.vtid, spec, specHash, qualityScore, supabaseUrl, svcKey);
   await updateLedgerSpecStatus(diagnosis.vtid, supabaseUrl, svcKey);
+
+  // Persist to vtid_specs — the authoritative spec table that the working
+  // execution pipeline (enforceSpecRequirement → autopilot event loop →
+  // worker-runner) reads from. Without this row, governance blocks execution.
+  try {
+    const vtidSpecResult = await createVtidSpec({
+      vtid: diagnosis.vtid,
+      title: `SELF-HEAL: ${diagnosis.service_name} — ${diagnosis.failure_class}`,
+      spec_text: spec,
+      primary_domain: 'INFRA',
+      system_surface: diagnosis.files_to_modify,
+      layer: 'INFRA',
+      module: 'GATEWAY',
+      execution_mode: 'Autonomous',
+      creativity: 'FORBIDDEN',
+      target_paths: diagnosis.files_to_modify,
+      acceptance_criteria: [`Endpoint ${diagnosis.endpoint} returns HTTP 200`],
+      created_by: 'self-healing',
+      metadata: {
+        source: 'self-healing',
+        failure_class: diagnosis.failure_class,
+        confidence: diagnosis.confidence,
+        spec_hash: specHash,
+      },
+    });
+    if (!vtidSpecResult.ok) {
+      console.warn(`[SelfHealingSpec] createVtidSpec failed for ${diagnosis.vtid}: ${vtidSpecResult.error}`);
+    } else {
+      console.log(`[SelfHealingSpec] Spec persisted to vtid_specs for ${diagnosis.vtid}`);
+    }
+  } catch (err: any) {
+    console.warn(`[SelfHealingSpec] createVtidSpec threw for ${diagnosis.vtid}: ${err.message}`);
+  }
 
   await emitOasisEvent({
     vtid: diagnosis.vtid,

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -193,6 +193,7 @@ export type CicdEventType =
   // VTID-01005: Terminal Lifecycle Events (MANDATORY for governance compliance)
   | 'vtid.lifecycle.completed'
   | 'vtid.lifecycle.failed'
+  | 'vtid.lifecycle.execution_approved'
   // VTID-01018: Operator Action Lifecycle Events (MANDATORY for hard contract)
   | 'operator.action.started'
   | 'operator.action.completed'


### PR DESCRIPTION
## Summary
- Self-healing tasks were stuck at WORKER:PENDING because they bypassed the standard pipeline
- **Root cause**: 4 disconnects between self-healing and the working execution pipeline
- **Fix**: Delete the parallel dispatch path, plug into the ONE pipeline that works

## Changes (-120 lines, +57 lines)
1. **Spec persisted to `vtid_specs`** via `createVtidSpec()` — governance enforcement now passes
2. **Status `allocated` → `scheduled`** — worker-runner can now see and claim the task
3. **`dispatchToWorkerWithRetry()` DELETED** — autopilot event loop handles dispatch
4. **`/approve` emits OASIS event** instead of direct dispatch
5. **`scheduled` added to AutopilotState** + event mapper fromStates

## After this PR
Self-healing tasks follow the same path as every other task:
detect → diagnose → spec (vtid_specs) → OASIS event → event loop → worker orchestrator → worker-runner → completion

## Test plan
- [ ] Trigger ORB Monitor → self-healing fires → check vtid_specs has a row
- [ ] Check vtid_ledger shows `status=scheduled`, `spec_status=approved`
- [ ] Verify autopilot event loop picks up the task (OASIS event emitted)
- [ ] Verify worker-runner claims and begins execution
- [ ] Grep for `dispatchToWorkerWithRetry` → zero results

🤖 Generated with [Claude Code](https://claude.com/claude-code)