### PR TITLE
fix(self-healing): reconciler must terminalize vtid_ledger + raise circuit breaker

### DIFF
--- a/services/gateway/src/routes/self-healing.ts
+++ b/services/gateway/src/routes/self-healing.ts
@@ -130,7 +130,10 @@ async function shouldBeginDiagnosis(endpoint: string): Promise<{ proceed: boolea
     if (countResp.ok) {
       const countHeader = countResp.headers.get('content-range');
       const total = countHeader ? parseInt(countHeader.split('/')[1] || '0', 10) : 0;
-      if (total >= 2) {
+      // Circuit breaker cap: allow up to 5 attempts per endpoint per 24h.
+      // Raised from 2 to 5 to accommodate the triage agent feedback loop
+      // which may create 2-3 fresh VTIDs per original failure.
+      if (total >= 5) {
         return {
           proceed: false,
           reason: `Circuit breaker: ${total} attempts in 24h for ${endpoint}`,

--- a/services/gateway/src/services/self-healing-reconciler.ts
+++ b/services/gateway/src/services/self-healing-reconciler.ts
@@ -184,7 +184,7 @@ async function attemptRedispatch(
 
 async function markEscalated(
   row: StaleRow,
-  reason: 'recovered_externally' | 'stale_no_progress',
+  reason: 'recovered_externally' | 'stale_no_progress' | 'stale_agent_exhausted',
   httpStatus: number | null,
 ): Promise<boolean> {
   if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) return false;
@@ -195,6 +195,8 @@ async function markEscalated(
     reconciled_reason: reason,
     reconciled_probe_http_status: httpStatus,
   };
+
+  // 1. Update self_healing_log
   const res = await fetch(
     `${SUPABASE_URL}/rest/v1/self_healing_log?id=eq.${row.id}`,
     {
@@ -207,6 +209,26 @@ async function markEscalated(
       }),
     },
   );
+
+  // 2. ALSO terminalize the vtid_ledger row so the dedup check stops
+  //    seeing this VTID as "active". Without this, the ledger stays at
+  //    status=allocated and blocks new self-healing VTIDs for the same
+  //    endpoint forever.
+  const terminalStatus = reason === 'recovered_externally' ? 'completed' : 'failed';
+  await fetch(
+    `${SUPABASE_URL}/rest/v1/vtid_ledger?vtid=eq.${encodeURIComponent(row.vtid)}`,
+    {
+      method: 'PATCH',
+      headers: { ...supabaseHeaders(), Prefer: 'return=minimal' },
+      body: JSON.stringify({
+        status: terminalStatus,
+        updated_at: now,
+      }),
+    },
+  ).catch((err) => {
+    console.warn(`${LOG_PREFIX} Failed to terminalize ledger for ${row.vtid}: ${err.message}`);
+  });
+
   if (!res.ok) {
     const text = await res.text().catch(() => '');
     console.warn(


### PR DESCRIPTION
## Summary
Two bugs causing the self-healing pipeline to get permanently stuck after the reconciler runs:

1. `markEscalated()` updated `self_healing_log.outcome` but NOT `vtid_ledger.status` — dead VTIDs stayed "active" forever, blocking all new self-healing entries for the same endpoint via the dedup check
2. Circuit breaker cap was 2 per endpoint per 24h, too low for the triage agent feedback loop. Raised to 5.

## Root cause of current stuck state
E2E ORB tests failing repeatedly → self-healing created VTID-01905/01906 → reconciler probed `/api/v1/orb/health` (healthy) → marked `recovered_externally` in `self_healing_log` → but `vtid_ledger` stayed at `allocated` → dedup blocks forever → tests keep failing, self-healing never fires again

## Test plan
- [ ] Deploy gateway
- [ ] Terminalize stuck VTID-01905/01906 in the ledger
- [ ] Trigger E2E-ORB-MONITOR → verify new VTIDs are created

🤖 Generated with [Claude Code](https://claude.com/claude-code)