### PR TITLE
fix(worker-runner): accept 'scheduled' tasks in eligibility check

### DIFF
--- a/services/worker-runner/src/services/runner-service.ts
+++ b/services/worker-runner/src/services/runner-service.ts
@@ -200,8 +200,10 @@ export class WorkerRunner {
    * Check if a task is eligible for execution
    */
   private isTaskEligible(task: PendingTask): boolean {
-    // Must be in_progress status
-    if (task.status !== 'in_progress') {
+    // Must be in a claimable status — 'in_progress' (legacy) or 'scheduled'
+    // (self-healing injector sets 'scheduled'; claim_vtid_task transitions
+    // to 'in_progress' on claim)
+    if (task.status !== 'in_progress' && task.status !== 'scheduled') {
       return false;
     }
 


### PR DESCRIPTION
One-line fix: isTaskEligible now accepts scheduled status alongside in_progress. Without this, the worker sees self-healing tasks but never claims them.