### PR TITLE
Remove hardcoded secrets from workflows and source code

### DIFF
--- a/.github/workflows/E2E-TEST-RUN.yml
+++ b/.github/workflows/E2E-TEST-RUN.yml
@@ -76,7 +76,7 @@ jobs:
           COMMUNITY_URL: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.community_url || inputs.community_url || 'https://vitanaland.com' }}
           TEST_USER_EMAIL: ${{ secrets.TEST_USER_EMAIL }}
           TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
-          LOVABLE_SUPABASE_SERVICE_ROLE: eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlubWtodndkY3V5aG54a2dmdnNiIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc1NTg2NjYzNywiZXhwIjoyMDcxNDQyNjM3fQ.P4bD2YrbzgvDqM4APVxk_5LzetSTsYx-fAp5GOX4n2M
+          LOVABLE_SUPABASE_SERVICE_ROLE: ${{ secrets.LOVABLE_SUPABASE_SERVICE_ROLE }}
 
       - name: Report failure to self-healing
         if: failure()

--- a/.github/workflows/EXEC-DEPLOY.yml
+++ b/.github/workflows/EXEC-DEPLOY.yml
@@ -298,13 +298,13 @@ jobs:
             SECRETS_ARGS+=(--update-secrets=SUPABASE_JWT_SECRET=SUPABASE_JWT_SECRET:latest)
             SECRETS_ARGS+=(--update-secrets=SUPABASE_ANON_KEY=SUPABASE_ANON_KEY:latest)
             # Appilix native push (Maxina Android app)
-            EXTRA_ENV_ARGS+=(--update-env-vars=APPILIX_API_KEY=u9p6gt2iqnbrod7kmshy)
-            EXTRA_ENV_ARGS+=(--update-env-vars=APPILIX_APP_KEY=8kwa81zf6ye64b0j42unyk7j9wgbr3u35pfidvn9)
+            SECRETS_ARGS+=(--update-secrets=APPILIX_API_KEY=APPILIX_API_KEY:latest)
+            SECRETS_ARGS+=(--update-secrets=APPILIX_APP_KEY=APPILIX_APP_KEY:latest)
             # Incident Triage Agent — Claude Managed Agents API key
             EXTRA_ENV_ARGS+=(--update-env-vars=ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }})
             # VTID-01270A: Lovable Supabase connection for events/community data
-            EXTRA_ENV_ARGS+=(--update-env-vars=LOVABLE_SUPABASE_URL=https://inmkhvwdcuyhnxkgfvsb.supabase.co)
-            EXTRA_ENV_ARGS+=(--update-env-vars=LOVABLE_SUPABASE_SERVICE_ROLE=eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlubWtodndkY3V5aG54a2dmdnNiIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc1NTg2NjYzNywiZXhwIjoyMDcxNDQyNjM3fQ.P4bD2YrbzgvDqM4APVxk_5LzetSTsYx-fAp5GOX4n2M)
+            SECRETS_ARGS+=(--update-secrets=LOVABLE_SUPABASE_URL=LOVABLE_SUPABASE_URL:latest)
+            SECRETS_ARGS+=(--update-secrets=LOVABLE_SUPABASE_SERVICE_ROLE=LOVABLE_SUPABASE_SERVICE_ROLE:latest)
           fi
 
           # VTID-01225: Cognee extractor — internal ingress, Gemini LLM via API key

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -2247,8 +2247,8 @@ async function executeLiveApiToolInner(
         const maxPrice = args.max_price !== undefined ? Number(args.max_price) : undefined;
 
         // VTID-01270A: Events live in the Lovable Supabase (global_community_events table)
-        const LOVABLE_SUPABASE_URL = process.env.LOVABLE_SUPABASE_URL || 'https://inmkhvwdcuyhnxkgfvsb.supabase.co';
-        const LOVABLE_SUPABASE_KEY = process.env.LOVABLE_SUPABASE_SERVICE_ROLE || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlubWtodndkY3V5aG54a2dmdnNiIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc1NTg2NjYzNywiZXhwIjoyMDcxNDQyNjM3fQ.P4bD2YrbzgvDqM4APVxk_5LzetSTsYx-fAp5GOX4n2M';
+        const LOVABLE_SUPABASE_URL = process.env.LOVABLE_SUPABASE_URL || '';
+        const LOVABLE_SUPABASE_KEY = process.env.LOVABLE_SUPABASE_SERVICE_ROLE || '';
         const PLATFORM_SUPABASE_URL = process.env.SUPABASE_URL;
         const PLATFORM_SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE;
 

--- a/services/gateway/src/services/gemini-operator.ts
+++ b/services/gateway/src/services/gemini-operator.ts
@@ -2111,8 +2111,8 @@ async function executeCommunitySearchEvents(
 ): Promise<ToolExecutionResult> {
   const identity = threadIdentityMap.get(threadId);
 
-  const LOVABLE_SUPABASE_URL = process.env.LOVABLE_SUPABASE_URL || 'https://inmkhvwdcuyhnxkgfvsb.supabase.co';
-  const LOVABLE_SUPABASE_KEY = process.env.LOVABLE_SUPABASE_SERVICE_ROLE || 'eyJhbGciOiJIUzI1NiIsInR5cCI6IkpXVCJ9.eyJpc3MiOiJzdXBhYmFzZSIsInJlZiI6ImlubWtodndkY3V5aG54a2dmdnNiIiwicm9sZSI6InNlcnZpY2Vfcm9sZSIsImlhdCI6MTc1NTg2NjYzNywiZXhwIjoyMDcxNDQyNjM3fQ.P4bD2YrbzgvDqM4APVxk_5LzetSTsYx-fAp5GOX4n2M';
+  const LOVABLE_SUPABASE_URL = process.env.LOVABLE_SUPABASE_URL || '';
+  const LOVABLE_SUPABASE_KEY = process.env.LOVABLE_SUPABASE_SERVICE_ROLE || '';
 
   const query = args.query || '';
   const typeFilter = args.type_filter || 'all';


### PR DESCRIPTION
## Summary
- Move LOVABLE_SUPABASE_SERVICE_ROLE, APPILIX_API_KEY, and APPILIX_APP_KEY from hardcoded values to GCP Secret Manager references in EXEC-DEPLOY.yml
- Reference `${{ secrets.LOVABLE_SUPABASE_SERVICE_ROLE }}` in E2E-TEST-RUN.yml instead of hardcoded JWT
- Remove hardcoded fallback service role key from gemini-operator.ts and orb-live.ts

These credentials were exposed while the repo was public. After merge, the following manual steps are required:
1. Create GCP secrets: `LOVABLE_SUPABASE_SERVICE_ROLE`, `LOVABLE_SUPABASE_URL`, `APPILIX_API_KEY`, `APPILIX_APP_KEY`
2. Add GitHub Actions secret: `LOVABLE_SUPABASE_SERVICE_ROLE`
3. Rotate the Lovable Supabase JWT secret via Supabase dashboard
4. Redeploy gateway to pick up new secret references

## Test plan
- [ ] Verify GCP secrets are created before merging
- [ ] Verify GitHub Actions secret is set
- [ ] After merge, trigger a deploy and confirm gateway starts with secrets from GCP Secret Manager
- [ ] Run E2E tests to confirm they pick up the secret from GitHub Actions

https://claude.ai/code/session_018QUvN8fewJqcW3diCaHUzj