### PR TITLE
feat: add notification category management system

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -221,6 +221,10 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const adminSignupsRouter = require('./routes/admin-signups').default;
   // Admin: Notification Compose & Tracking
   const adminNotificationsRouter = require('./routes/admin-notifications').default;
+  // Admin: Notification Category Management (CRUD + Test)
+  const adminNotificationCategoriesRouter = require('./routes/admin-notification-categories').default;
+  // User: Notification Category Preferences (toggle categories on/off)
+  const userCategoryPreferencesRouter = require('./routes/user-category-preferences').default;
   // Admin: User Management & Role Distribution
   const adminUsersRouter = require('./routes/admin-users').default;
   // Admin: Tenant Management
@@ -610,6 +614,12 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
 
   // Admin: Notification Compose & Tracking
   mountRouterSync(app, '/api/v1/admin/notifications', adminNotificationsRouter, { owner: 'admin-notifications' });
+
+  // Admin: Notification Category Management
+  mountRouterSync(app, '/api/v1/admin/notification-categories', adminNotificationCategoriesRouter, { owner: 'admin-notification-categories' });
+
+  // User: Notification Category Preferences
+  mountRouterSync(app, '/api/v1/notifications/category-preferences', userCategoryPreferencesRouter, { owner: 'user-category-preferences' });
 
   // Admin: User Management & Role Distribution
   mountRouterSync(app, '/api/v1/admin/users', adminUsersRouter, { owner: 'admin-users' });

--- a/services/gateway/src/routes/admin-notification-categories.ts
+++ b/services/gateway/src/routes/admin-notification-categories.ts
@@ -1,0 +1,318 @@
+/**
+ * Admin Notification Categories API — CRUD + Test
+ *
+ * Endpoints:
+ * - GET    /              — List all categories (supports ?type=chat&tenant_id=...)
+ * - GET    /:id           — Get single category
+ * - POST   /              — Create category
+ * - PATCH  /:id           — Update category
+ * - DELETE /:id           — Soft-delete (set is_active=false)
+ * - POST   /:id/test      — Send test notification to admin
+ *
+ * Security:
+ * - All endpoints require Bearer token + exafy_admin
+ */
+
+import { Router, Request, Response } from 'express';
+import { createClient } from '@supabase/supabase-js';
+import { createUserSupabaseClient } from '../lib/supabase-user';
+import { notifyUser, NotificationPayload } from '../services/notification-service';
+
+const router = Router();
+const VTID = 'ADMIN-NOTIF-CATEGORIES';
+
+const VALID_TYPES = ['chat', 'calendar', 'community'];
+
+// ── Supabase ────────────────────────────────────────────────
+
+function getSupabase() {
+  return createClient(
+    process.env.SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE!
+  );
+}
+
+// ── Auth Helper ─────────────────────────────────────────────
+
+function getBearerToken(req: Request): string | null {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
+  return authHeader.slice(7);
+}
+
+async function verifyExafyAdmin(
+  req: Request
+): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
+  const token = getBearerToken(req);
+  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
+
+  try {
+    const userClient = createUserSupabaseClient(token);
+    const { data: authData, error: authError } = await userClient.auth.getUser();
+    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
+
+    const appMetadata = authData.user.app_metadata || {};
+    if (appMetadata.exafy_admin !== true) {
+      return { ok: false, status: 403, error: 'FORBIDDEN' };
+    }
+
+    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
+  } catch (err: any) {
+    console.error(`[${VTID}] Auth error:`, err.message);
+    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
+  }
+}
+
+// ── Slug helper ─────────────────────────────────────────────
+
+function toSlug(name: string): string {
+  return name
+    .toLowerCase()
+    .replace(/[^a-z0-9]+/g, '_')
+    .replace(/^_|_$/g, '');
+}
+
+// ── GET / — List all categories ─────────────────────────────
+
+router.get('/', async (req: Request, res: Response) => {
+  const authResult = await verifyExafyAdmin(req);
+  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
+
+  const supabase = getSupabase();
+  const { type, tenant_id, include_inactive } = req.query;
+
+  let query = supabase
+    .from('notification_categories')
+    .select('*')
+    .order('type')
+    .order('sort_order', { ascending: true });
+
+  if (type && typeof type === 'string' && VALID_TYPES.includes(type)) {
+    query = query.eq('type', type);
+  }
+  if (tenant_id && typeof tenant_id === 'string') {
+    query = query.or(`tenant_id.eq.${tenant_id},tenant_id.is.null`);
+  } else {
+    query = query.is('tenant_id', null);
+  }
+  if (include_inactive !== 'true') {
+    query = query.eq('is_active', true);
+  }
+
+  const { data, error } = await query;
+  if (error) {
+    console.error(`[${VTID}] GET / error:`, error.message);
+    return res.status(500).json({ ok: false, error: error.message });
+  }
+
+  // Group by type
+  const grouped: Record<string, any[]> = { chat: [], calendar: [], community: [] };
+  for (const cat of data || []) {
+    if (grouped[cat.type]) {
+      grouped[cat.type].push(cat);
+    }
+  }
+
+  return res.json({ ok: true, data: grouped, total: (data || []).length });
+});
+
+// ── GET /:id — Get single category ─────────────────────────
+
+router.get('/:id', async (req: Request, res: Response) => {
+  const authResult = await verifyExafyAdmin(req);
+  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
+
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from('notification_categories')
+    .select('*')
+    .eq('id', req.params.id)
+    .single();
+
+  if (error || !data) {
+    return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
+  }
+
+  return res.json({ ok: true, data });
+});
+
+// ── POST / — Create category ───────────────────────────────
+
+router.post('/', async (req: Request, res: Response) => {
+  const authResult = await verifyExafyAdmin(req);
+  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
+
+  const supabase = getSupabase();
+  const {
+    type,
+    display_name,
+    slug: slugInput,
+    description,
+    icon,
+    sort_order,
+    default_enabled,
+    mapped_types,
+    tenant_id,
+  } = req.body;
+
+  // Validate required fields
+  if (!type || !display_name) {
+    return res.status(400).json({ ok: false, error: 'INVALID_INPUT', message: 'type and display_name are required' });
+  }
+  if (!VALID_TYPES.includes(type)) {
+    return res.status(400).json({ ok: false, error: 'INVALID_TYPE', message: `type must be one of: ${VALID_TYPES.join(', ')}` });
+  }
+
+  const slug = slugInput || toSlug(display_name);
+
+  // Validate mapped_types is an array
+  if (mapped_types && !Array.isArray(mapped_types)) {
+    return res.status(400).json({ ok: false, error: 'INVALID_INPUT', message: 'mapped_types must be an array' });
+  }
+
+  const insertData: Record<string, any> = {
+    type,
+    slug,
+    display_name,
+    description: description || null,
+    icon: icon || null,
+    sort_order: sort_order ?? 0,
+    default_enabled: default_enabled ?? true,
+    mapped_types: mapped_types || [],
+    tenant_id: tenant_id || null,
+    created_by: authResult.user_id,
+  };
+
+  const { data, error } = await supabase
+    .from('notification_categories')
+    .insert(insertData)
+    .select()
+    .single();
+
+  if (error) {
+    if (error.code === '23505') {
+      return res.status(409).json({ ok: false, error: 'SLUG_CONFLICT', message: `Category with slug "${slug}" already exists` });
+    }
+    console.error(`[${VTID}] POST / error:`, error.message);
+    return res.status(500).json({ ok: false, error: error.message });
+  }
+
+  console.log(`[${VTID}] Created category "${slug}" (${type}) by ${authResult.email}`);
+  return res.status(201).json({ ok: true, data });
+});
+
+// ── PATCH /:id — Update category ────────────────────────────
+
+router.patch('/:id', async (req: Request, res: Response) => {
+  const authResult = await verifyExafyAdmin(req);
+  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
+
+  const supabase = getSupabase();
+  const allowedFields = ['display_name', 'description', 'icon', 'sort_order', 'is_active', 'default_enabled', 'mapped_types'];
+  const updateData: Record<string, any> = { updated_at: new Date().toISOString() };
+
+  for (const field of allowedFields) {
+    if (req.body[field] !== undefined) {
+      updateData[field] = req.body[field];
+    }
+  }
+
+  // Validate type if provided (cannot change type)
+  if (req.body.type !== undefined) {
+    return res.status(400).json({ ok: false, error: 'INVALID_INPUT', message: 'Cannot change category type after creation' });
+  }
+
+  const { data, error } = await supabase
+    .from('notification_categories')
+    .update(updateData)
+    .eq('id', req.params.id)
+    .select()
+    .single();
+
+  if (error) {
+    console.error(`[${VTID}] PATCH /:id error:`, error.message);
+    return res.status(500).json({ ok: false, error: error.message });
+  }
+  if (!data) {
+    return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
+  }
+
+  console.log(`[${VTID}] Updated category "${data.slug}" by ${authResult.email}`);
+  return res.json({ ok: true, data });
+});
+
+// ── DELETE /:id — Soft-delete (set is_active=false) ─────────
+
+router.delete('/:id', async (req: Request, res: Response) => {
+  const authResult = await verifyExafyAdmin(req);
+  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
+
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from('notification_categories')
+    .update({ is_active: false, updated_at: new Date().toISOString() })
+    .eq('id', req.params.id)
+    .select()
+    .single();
+
+  if (error) {
+    console.error(`[${VTID}] DELETE /:id error:`, error.message);
+    return res.status(500).json({ ok: false, error: error.message });
+  }
+  if (!data) {
+    return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
+  }
+
+  console.log(`[${VTID}] Soft-deleted category "${data.slug}" by ${authResult.email}`);
+  return res.json({ ok: true, data });
+});
+
+// ── POST /:id/test — Send test notification to admin ────────
+
+router.post('/:id/test', async (req: Request, res: Response) => {
+  const authResult = await verifyExafyAdmin(req);
+  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
+
+  const supabase = getSupabase();
+
+  // Get the category
+  const { data: category, error: catError } = await supabase
+    .from('notification_categories')
+    .select('*')
+    .eq('id', req.params.id)
+    .single();
+
+  if (catError || !category) {
+    return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
+  }
+
+  const mappedTypes = category.mapped_types as string[];
+  const testType = mappedTypes.length > 0 ? mappedTypes[0] : 'welcome_to_vitana';
+
+  const payload: NotificationPayload = {
+    title: `Test: ${category.display_name}`,
+    body: `This is a test notification for the "${category.display_name}" category.`,
+    data: { test: 'true', category_id: category.id, category_slug: category.slug },
+  };
+
+  // Look up the admin's tenant_id from user_tenants
+  const { data: tenantRow } = await supabase
+    .from('user_tenants')
+    .select('tenant_id')
+    .eq('user_id', authResult.user_id)
+    .limit(1)
+    .single();
+
+  const tenantId = tenantRow?.tenant_id || '00000000-0000-0000-0000-000000000000';
+
+  try {
+    const result = await notifyUser(authResult.user_id, tenantId, testType, payload, supabase);
+    console.log(`[${VTID}] Test notification sent for category "${category.slug}" by ${authResult.email}`);
+    return res.json({ ok: true, result });
+  } catch (err: any) {
+    console.error(`[${VTID}] POST /:id/test error:`, err.message);
+    return res.status(500).json({ ok: false, error: 'SEND_FAILED' });
+  }
+});
+
+export default router;

--- a/services/gateway/src/routes/user-category-preferences.ts
+++ b/services/gateway/src/routes/user-category-preferences.ts
@@ -1,0 +1,142 @@
+/**
+ * User Category Preferences API
+ *
+ * Endpoints:
+ * - GET /    — Get user's notification categories with preference state
+ * - PUT /:categoryId — Toggle a category on/off
+ *
+ * Security:
+ * - All endpoints require Bearer token (standard user auth)
+ */
+
+import { Router, Request, Response } from 'express';
+import {
+  requireAuth,
+  requireTenant,
+  AuthenticatedRequest,
+} from '../middleware/auth-supabase-jwt';
+import { createClient } from '@supabase/supabase-js';
+
+const router = Router();
+
+function getSupabase() {
+  return createClient(
+    process.env.SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE!
+  );
+}
+
+// ── GET / — Get categories with user preference state ───────
+
+router.get('/', requireAuth, requireTenant, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const supabase = getSupabase();
+
+  // Fetch all active categories (global + tenant-specific)
+  const { data: categories, error: catError } = await supabase
+    .from('notification_categories')
+    .select('id, type, slug, display_name, description, icon, sort_order, default_enabled')
+    .eq('is_active', true)
+    .or(`tenant_id.eq.${identity.tenant_id},tenant_id.is.null`)
+    .order('type')
+    .order('sort_order', { ascending: true });
+
+  if (catError) {
+    console.error('[USER-CAT-PREFS] GET / categories error:', catError.message);
+    return res.status(500).json({ ok: false, error: catError.message });
+  }
+
+  // Fetch user's existing preferences
+  const { data: userPrefs, error: prefError } = await supabase
+    .from('user_category_preferences')
+    .select('category_id, enabled')
+    .eq('user_id', identity.user_id)
+    .eq('tenant_id', identity.tenant_id);
+
+  if (prefError) {
+    console.error('[USER-CAT-PREFS] GET / preferences error:', prefError.message);
+    return res.status(500).json({ ok: false, error: prefError.message });
+  }
+
+  // Build a lookup map for user preferences
+  const prefMap = new Map<string, boolean>();
+  for (const pref of userPrefs || []) {
+    prefMap.set(pref.category_id, pref.enabled);
+  }
+
+  // Group categories by type, merging in the user's preference state
+  const grouped: Record<string, any[]> = { chat: [], calendar: [], community: [] };
+  for (const cat of categories || []) {
+    const userPref = prefMap.get(cat.id);
+    const enabled = userPref !== undefined ? userPref : cat.default_enabled;
+
+    const entry = {
+      id: cat.id,
+      slug: cat.slug,
+      display_name: cat.display_name,
+      description: cat.description,
+      icon: cat.icon,
+      enabled,
+    };
+
+    if (grouped[cat.type]) {
+      grouped[cat.type].push(entry);
+    }
+  }
+
+  return res.json({ ok: true, data: grouped });
+});
+
+// ── PUT /:categoryId — Toggle a category on/off ────────────
+
+router.put('/:categoryId', requireAuth, requireTenant, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const { enabled } = req.body;
+  if (typeof enabled !== 'boolean') {
+    return res.status(400).json({ ok: false, error: 'INVALID_INPUT', message: 'enabled must be a boolean' });
+  }
+
+  const supabase = getSupabase();
+  const categoryId = req.params.categoryId;
+
+  // Verify the category exists and is active
+  const { data: category, error: catError } = await supabase
+    .from('notification_categories')
+    .select('id')
+    .eq('id', categoryId)
+    .eq('is_active', true)
+    .single();
+
+  if (catError || !category) {
+    return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
+  }
+
+  // Upsert the user's preference
+  const { data, error } = await supabase
+    .from('user_category_preferences')
+    .upsert(
+      {
+        user_id: identity.user_id,
+        tenant_id: identity.tenant_id,
+        category_id: categoryId,
+        enabled,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'user_id,category_id' }
+    )
+    .select()
+    .single();
+
+  if (error) {
+    console.error('[USER-CAT-PREFS] PUT /:categoryId error:', error.message);
+    return res.status(500).json({ ok: false, error: error.message });
+  }
+
+  return res.json({ ok: true, data });
+});
+
+export default router;

--- a/services/gateway/src/services/notification-service.ts
+++ b/services/gateway/src/services/notification-service.ts
@@ -288,6 +288,90 @@ export async function sendAppilixPush(
   }
 }
 
+// ── Dynamic Category Preference Check ────────────────────────
+// In-memory cache for notification_categories (avoids DB hit per notification)
+
+interface CategoryCacheEntry {
+  categoryId: string;
+  defaultEnabled: boolean;
+  isActive: boolean;
+}
+
+let categoryCache: Map<string, CategoryCacheEntry> | null = null;
+let categoryCacheExpiry = 0;
+const CATEGORY_CACHE_TTL_MS = 5 * 60 * 1000; // 5 minutes
+
+async function getCategoryCache(
+  supabase: SupabaseClient<any, any, any>
+): Promise<Map<string, CategoryCacheEntry>> {
+  if (categoryCache && Date.now() < categoryCacheExpiry) {
+    return categoryCache;
+  }
+
+  const { data, error } = await supabase
+    .from('notification_categories')
+    .select('id, mapped_types, default_enabled, is_active')
+    .eq('is_active', true);
+
+  const cache = new Map<string, CategoryCacheEntry>();
+  if (!error && data) {
+    for (const cat of data) {
+      const mappedTypes = (cat.mapped_types as string[]) || [];
+      for (const typeKey of mappedTypes) {
+        cache.set(typeKey, {
+          categoryId: cat.id,
+          defaultEnabled: cat.default_enabled,
+          isActive: cat.is_active,
+        });
+      }
+    }
+  }
+
+  categoryCache = cache;
+  categoryCacheExpiry = Date.now() + CATEGORY_CACHE_TTL_MS;
+  return cache;
+}
+
+/**
+ * Check dynamic category preference for a notification type.
+ * Returns { suppressed: false } if no category mapping exists or user has not disabled it.
+ * Returns { suppressed: true, reason: string } if user has disabled this category.
+ */
+async function checkDynamicCategoryPreference(
+  userId: string,
+  tenantId: string,
+  type: string,
+  supabase: SupabaseClient<any, any, any>
+): Promise<{ suppressed: boolean; reason?: string }> {
+  try {
+    const cache = await getCategoryCache(supabase);
+    const entry = cache.get(type);
+
+    // No mapping → pass through (unmapped types are never suppressed by the new system)
+    if (!entry) return { suppressed: false };
+
+    // Check user's preference for this category
+    const { data: userPref } = await supabase
+      .from('user_category_preferences')
+      .select('enabled')
+      .eq('user_id', userId)
+      .eq('category_id', entry.categoryId)
+      .maybeSingle();
+
+    const enabled = userPref ? userPref.enabled : entry.defaultEnabled;
+
+    if (!enabled) {
+      return { suppressed: true, reason: `category_${type}_disabled` };
+    }
+
+    return { suppressed: false };
+  } catch (err: any) {
+    // On error, don't suppress — fail open to avoid blocking notifications
+    console.error('[Notifications] Dynamic category check error:', err.message);
+    return { suppressed: false };
+  }
+}
+
 // ── Preference & DND Check ───────────────────────────────────
 
 interface UserPrefs {
@@ -359,11 +443,19 @@ export async function notifyUser(
       // push_and_inapp → inapp only (handled below by not sending push)
     }
 
-    // Category-specific gate
+    // Category-specific gate (legacy boolean columns)
     const prefCol = CATEGORY_PREF[meta.category];
     if (prefCol && prefCol !== 'push_enabled' && prefs[prefCol] === false) {
       return { pushed: 0, inapp: false, suppressed: `pref_${prefCol}_off` };
     }
+  }
+
+  // ── 1b. Check dynamic category preferences (new system) ──
+  const categoryCheckResult = await checkDynamicCategoryPreference(
+    userId, tenantId, type, supabase
+  );
+  if (categoryCheckResult.suppressed) {
+    return { pushed: 0, inapp: false, suppressed: categoryCheckResult.reason };
   }
 
   // ── 2. DND check (only blocks push, not inapp) ──────────

--- a/supabase/migrations/20260416000000_notification_categories.sql
+++ b/supabase/migrations/20260416000000_notification_categories.sql
@@ -1,0 +1,82 @@
+-- =============================================================================
+-- Notification Category Management — Dynamic Categories + User Preferences
+-- =============================================================================
+-- Adds admin-managed notification categories grouped by type (chat, calendar,
+-- community) and per-user toggle preferences for each category.
+-- Existing user_notification_preferences table is untouched (global push toggle
+-- and DND settings continue to live there).
+-- =============================================================================
+
+-- 1. Admin-managed notification categories
+CREATE TABLE IF NOT EXISTS notification_categories (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id       UUID,                        -- NULL = global (all tenants)
+  type            TEXT NOT NULL CHECK (type IN ('chat', 'calendar', 'community')),
+  slug            TEXT NOT NULL,                -- machine key, e.g. 'direct_messages'
+  display_name    TEXT NOT NULL,                -- human label, e.g. 'Direct Messages'
+  description     TEXT,                         -- brief explanation for settings UI
+  icon            TEXT,                         -- optional lucide icon name
+  sort_order      INTEGER NOT NULL DEFAULT 0,   -- display order within type
+  is_active       BOOLEAN NOT NULL DEFAULT true,
+  default_enabled BOOLEAN NOT NULL DEFAULT true, -- default for users without explicit preference
+  mapped_types    JSONB NOT NULL DEFAULT '[]',   -- array of TYPE_META keys this category covers
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_by      UUID
+);
+
+-- Unique slug per shared (global) categories
+CREATE UNIQUE INDEX notification_categories_slug_shared_uq
+  ON notification_categories (slug) WHERE tenant_id IS NULL;
+
+-- Unique slug per tenant-specific categories
+CREATE UNIQUE INDEX notification_categories_slug_tenant_uq
+  ON notification_categories (slug, tenant_id) WHERE tenant_id IS NOT NULL;
+
+-- Index for lookups by type
+CREATE INDEX idx_notification_categories_type
+  ON notification_categories (type, sort_order);
+
+-- Index for mapped_types containment queries (used by notification dispatch)
+CREATE INDEX idx_notification_categories_mapped_types
+  ON notification_categories USING gin (mapped_types);
+
+-- 2. Per-user toggle per category
+CREATE TABLE IF NOT EXISTS user_category_preferences (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id     UUID NOT NULL,
+  tenant_id   UUID NOT NULL,
+  category_id UUID NOT NULL REFERENCES notification_categories(id) ON DELETE CASCADE,
+  enabled     BOOLEAN NOT NULL DEFAULT true,
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE(user_id, category_id)
+);
+
+CREATE INDEX idx_user_category_preferences_user
+  ON user_category_preferences (user_id, tenant_id);
+
+-- 3. RLS Policies
+
+ALTER TABLE notification_categories ENABLE ROW LEVEL SECURITY;
+
+-- Service-role full access (admin API is the gatekeeper)
+CREATE POLICY "service_role_full_access_categories"
+  ON notification_categories FOR ALL
+  USING (true) WITH CHECK (true);
+
+-- Authenticated users can read active categories
+CREATE POLICY "authenticated_read_active_categories"
+  ON notification_categories FOR SELECT TO authenticated
+  USING (is_active = true);
+
+ALTER TABLE user_category_preferences ENABLE ROW LEVEL SECURITY;
+
+-- Users manage their own category preferences
+CREATE POLICY "users_manage_own_category_prefs"
+  ON user_category_preferences FOR ALL
+  USING (auth.uid() = user_id);
+
+-- Service-role full access for admin stats queries
+CREATE POLICY "service_role_full_access_category_prefs"
+  ON user_category_preferences FOR ALL
+  USING (true) WITH CHECK (true);

--- a/supabase/migrations/20260416000100_notification_categories_seed.sql
+++ b/supabase/migrations/20260416000100_notification_categories_seed.sql
@@ -1,0 +1,69 @@
+-- =============================================================================
+-- Seed Default Notification Categories
+-- =============================================================================
+-- Populates global (tenant_id = NULL) default categories across the three
+-- notification types: chat, calendar, community.
+-- Each category maps to existing TYPE_META keys from notification-service.ts.
+-- =============================================================================
+
+INSERT INTO notification_categories (tenant_id, type, slug, display_name, description, icon, sort_order, default_enabled, mapped_types)
+VALUES
+  -- ── Chat ──────────────────────────────────────────────────────────
+  (NULL, 'chat', 'direct_messages', 'Direct Messages',
+   'New messages from people and groups',
+   'MessageSquare', 0, true,
+   '["new_chat_message"]'::jsonb),
+
+  (NULL, 'chat', 'orb_messages', 'ORB Messages',
+   'Proactive messages and suggestions from your AI assistant',
+   'Sparkles', 1, true,
+   '["orb_proactive_message", "orb_suggestion"]'::jsonb),
+
+  (NULL, 'chat', 'followup_reminders', 'Follow-up Reminders',
+   'Reminders to continue conversations',
+   'Clock', 2, true,
+   '["conversation_followup_reminder"]'::jsonb),
+
+  -- ── Calendar ──────────────────────────────────────────────────────
+  (NULL, 'calendar', 'event_reminders', 'Event Reminders',
+   'Upcoming events and meetups starting soon',
+   'CalendarClock', 0, true,
+   '["upcoming_event_today", "meetup_starting_soon", "meetup_starting_now"]'::jsonb),
+
+  (NULL, 'calendar', 'morning_briefing', 'Morning Briefing',
+   'Your daily morning summary and schedule',
+   'Sun', 1, true,
+   '["morning_briefing_ready"]'::jsonb),
+
+  (NULL, 'calendar', 'weekly_digest', 'Weekly Digest',
+   'Weekly community digest and activity summary',
+   'Newspaper', 2, true,
+   '["weekly_community_digest", "weekly_activity_summary"]'::jsonb),
+
+  (NULL, 'calendar', 'rsvp_updates', 'RSVP Updates',
+   'Confirmations and updates about your RSVPs',
+   'CheckCircle', 3, true,
+   '["meetup_rsvp_confirmed", "someone_rsvpd_your_meetup"]'::jsonb),
+
+  -- ── Community ─────────────────────────────────────────────────────
+  (NULL, 'community', 'group_activity', 'Group Activity',
+   'Activity in your groups — joins, milestones, invitations',
+   'Users', 0, true,
+   '["someone_joined_your_group", "group_activity_update", "group_milestone_reached", "new_member_in_group", "group_recommended", "group_invitation_received"]'::jsonb),
+
+  (NULL, 'community', 'meetups', 'Meetups',
+   'Recommended meetups and meetup updates',
+   'MapPin', 1, true,
+   '["meetup_recommended", "meetup_cancelled", "new_meetup_in_group"]'::jsonb),
+
+  (NULL, 'community', 'live_rooms', 'Live Rooms',
+   'Live room starting, invites, summaries, and recordings',
+   'Radio', 2, true,
+   '["live_room_starting", "someone_joined_live_room", "live_room_ended_summary", "live_room_highlight_added", "live_room_invite", "live_room_recording_ready"]'::jsonb),
+
+  (NULL, 'community', 'connections_social', 'Connections & Social',
+   'New matches, connections, and social activity',
+   'Heart', 3, true,
+   '["new_connection_formed", "relationship_strength_increased", "new_daily_matches", "person_match_suggested", "match_accepted_by_other", "your_match_accepted", "someone_wants_to_connect", "people_near_you"]'::jsonb)
+
+ON CONFLICT DO NOTHING;


### PR DESCRIPTION
## Summary

- **Database**: Two new tables (`notification_categories` + `user_category_preferences`) with 11 seeded default categories across Chat (3), Calendar (4), Community (4)
- **Admin API**: CRUD at `/api/v1/admin/notification-categories` with Send Test endpoint per category
- **User API**: GET/PUT at `/api/v1/notifications/category-preferences` for dynamic category toggles
- **Dispatch integration**: `notifyUser()` now checks dynamic category preferences (5-min cached) alongside legacy boolean preferences for backward compatibility

## Test plan

- [ ] Run migrations on Supabase, verify `notification_categories` has 11 seeded rows
- [ ] `GET /api/v1/admin/notification-categories` returns categories grouped by type
- [ ] `POST /api/v1/admin/notification-categories/:id/test` sends test push to admin
- [ ] `GET /api/v1/notifications/category-preferences` returns categories with default `enabled` values
- [ ] `PUT /api/v1/notifications/category-preferences/:id` toggles a category
- [ ] Disable a category, trigger a mapped notification type, verify suppressed

https://claude.ai/code/session_01XGFwQaxGMc3L971fMdT1vT