### PR TITLE
fix(ci): guard artifact uploads so quota exhaustion cannot fail deploys

### DIFF
--- a/.github/workflows/E2E-ORB-MONITOR.yml
+++ b/.github/workflows/E2E-ORB-MONITOR.yml
@@ -83,9 +83,11 @@ jobs:
       - name: Upload test results on failure
         uses: actions/upload-artifact@v4
         if: failure()
+        continue-on-error: true
         with:
-          name: orb-${{ matrix.screen }}-results
+          name: orb-${{ matrix.screen }}-results-${{ github.run_id }}
           path: |
             e2e/test-results/
             e2e/playwright-report/
-          retention-days: 7
+          retention-days: 2
+          overwrite: true

--- a/.github/workflows/E2E-TEST-RUN.yml
+++ b/.github/workflows/E2E-TEST-RUN.yml
@@ -111,9 +111,11 @@ jobs:
       - name: Upload test results on failure
         uses: actions/upload-artifact@v4
         if: failure()
+        continue-on-error: true
         with:
           name: e2e-results-${{ github.run_id }}
           path: |
             e2e/test-results/
             e2e/playwright-report/
-          retention-days: 7
+          retention-days: 2
+          overwrite: true

--- a/.github/workflows/EXEC-DEPLOY.yml
+++ b/.github/workflows/EXEC-DEPLOY.yml
@@ -517,11 +517,13 @@ jobs:
       - name: Upload Visual Verification Screenshots
         uses: actions/upload-artifact@v4
         if: always() && steps.visual_verify.outcome != 'skipped'
+        continue-on-error: true  # Artifact quota issues must not fail a successful deploy
         with:
-          name: visual-verify-screenshots
+          name: visual-verify-screenshots-${{ github.run_id }}
           path: /tmp/visual-verify/
-          retention-days: 7
+          retention-days: 2
           if-no-files-found: ignore
+          overwrite: true
 
       # =========================================================================
       # VTID-0510: Record Software Version

--- a/.github/workflows/VISUAL-VERIFY-FRONTEND.yml
+++ b/.github/workflows/VISUAL-VERIFY-FRONTEND.yml
@@ -47,7 +47,8 @@ jobs:
         if: always()
         continue-on-error: true
         with:
-          name: frontend-visual-screenshots
+          name: frontend-visual-screenshots-${{ github.run_id }}
           path: /tmp/visual-verify-frontend/
-          retention-days: 7
+          retention-days: 2
           if-no-files-found: ignore
+          overwrite: true


### PR DESCRIPTION
## Summary
- Deploys were failing because `upload-artifact@v4` hit the repo's artifact storage quota (397 artifacts / 17.4 GiB). Deploy + smoke tests + visual verification all passed; only the debug artifact upload killed the run.
- Added `continue-on-error: true` to artifact upload steps in EXEC-DEPLOY, E2E-ORB-MONITOR, and E2E-TEST-RUN so a debug-artifact failure can never block a successful deploy.
- Cut retention from 7 → 2 days across EXEC-DEPLOY, E2E-ORB-MONITOR, E2E-TEST-RUN, VISUAL-VERIFY-FRONTEND.
- Added `${{ github.run_id }}` suffix + `overwrite: true` to avoid name collisions.
- Purged 259 non-expired artifacts from the repo to free quota immediately.

## Context
Every EXEC-DEPLOY run on 2026-04-15 failed at the `Upload Visual Verification Screenshots` step with `Failed to CreateArtifact: Artifact storage quota has been hit`. The gateway itself was deploying fine, but the workflow exited non-zero, which then triggered retry-reset → failure_count=6 → VTID rejection.

Separately: the most recent 10-second failure was GitHub billing (`recent account payments have failed or your spending limit needs to be increased`) — that requires action in repo Settings → Billing and is not addressed by this PR.

## Test plan
- [ ] Merge, then run EXEC-DEPLOY manually with a valid VTID and confirm the workflow completes green
- [ ] Confirm the visual-verify-screenshots artifact is still produced (check run artifacts panel)
- [ ] Re-check artifact storage quota after 6–12 hours (GitHub recalc window)