### PR TITLE
chore(ci): drop unused artifact uploads from workflows

### DIFF
--- a/.github/workflows/E2E-ORB-MONITOR.yml
+++ b/.github/workflows/E2E-ORB-MONITOR.yml
@@ -80,14 +80,5 @@ jobs:
               }]
             }' || echo "::warning::Self-healing report POST failed (non-fatal)"
 
-      - name: Upload test results on failure
-        uses: actions/upload-artifact@v4
-        if: failure()
-        continue-on-error: true
-        with:
-          name: orb-${{ matrix.screen }}-results-${{ github.run_id }}
-          path: |
-            e2e/test-results/
-            e2e/playwright-report/
-          retention-days: 2
-          overwrite: true
+      # Playwright trace/video artifact upload removed — never used for
+      # debugging. Re-add temporarily if investigating a specific failure.

--- a/.github/workflows/E2E-TEST-RUN.yml
+++ b/.github/workflows/E2E-TEST-RUN.yml
@@ -108,14 +108,5 @@ jobs:
               }]
             }' || echo "::warning::Self-healing report POST failed (non-fatal)"
 
-      - name: Upload test results on failure
-        uses: actions/upload-artifact@v4
-        if: failure()
-        continue-on-error: true
-        with:
-          name: e2e-results-${{ github.run_id }}
-          path: |
-            e2e/test-results/
-            e2e/playwright-report/
-          retention-days: 2
-          overwrite: true
+      # Playwright trace/video artifact upload removed — never used for
+      # debugging. Re-add temporarily if investigating a specific failure.

--- a/.github/workflows/EXEC-DEPLOY.yml
+++ b/.github/workflows/EXEC-DEPLOY.yml
@@ -514,16 +514,10 @@ jobs:
           mkdir -p "$SCREENSHOT_DIR"
           npx tsx ci-visual-verify.ts
 
-      - name: Upload Visual Verification Screenshots
-        uses: actions/upload-artifact@v4
-        if: always() && steps.visual_verify.outcome != 'skipped'
-        continue-on-error: true  # Artifact quota issues must not fail a successful deploy
-        with:
-          name: visual-verify-screenshots-${{ github.run_id }}
-          path: /tmp/visual-verify/
-          retention-days: 2
-          if-no-files-found: ignore
-          overwrite: true
+      # Screenshot artifact upload removed — never used for debugging and was
+      # the primary consumer of the private-repo artifact storage quota.
+      # Workflow logs show pass/fail and the exact failure message; re-add
+      # this step temporarily if a specific deploy ever needs deep debugging.
 
       # =========================================================================
       # VTID-0510: Record Software Version

--- a/.github/workflows/VISUAL-VERIFY-FRONTEND.yml
+++ b/.github/workflows/VISUAL-VERIFY-FRONTEND.yml
@@ -42,13 +42,5 @@ jobs:
           SCREENSHOT_DIR: /tmp/visual-verify-frontend
         run: npx tsx ci-visual-verify-frontend.ts
 
-      - name: Upload Screenshots
-        uses: actions/upload-artifact@v4
-        if: always()
-        continue-on-error: true
-        with:
-          name: frontend-visual-screenshots-${{ github.run_id }}
-          path: /tmp/visual-verify-frontend/
-          retention-days: 2
-          if-no-files-found: ignore
-          overwrite: true
+      # Screenshot artifact upload removed — never used for debugging.
+      # Re-add temporarily if investigating a specific failure.


### PR DESCRIPTION
## Summary
- User confirmed none of the CI artifacts have ever been opened to debug a failure.
- Playwright trace/video bundles (50 MB per failed run) were the primary consumer of the artifact storage quota that exhausted when the repo flipped from public to private.
- Removed `upload-artifact` steps from EXEC-DEPLOY, E2E-ORB-MONITOR, E2E-TEST-RUN, VISUAL-VERIFY-FRONTEND.
- Tests still run. Workflow logs still show pass/fail and error messages.

## Test plan
- [ ] Merge, re-run EXEC-DEPLOY, confirm it completes green and the "Upload …" steps are gone
- [ ] Confirm no new artifacts appear under repo Actions → Artifacts after a few runs