### PR TITLE
fix(orb): stop navigating on informational/comparative questions

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -3011,27 +3011,41 @@ eine deiner wichtigsten Aufgaben. Du hast zwei Werkzeuge:
     automatisch weiter. Du musst keine Bildschirmnamen oder IDs kennen —
     gib einfach die Frage weiter.
 
-WANN navigate() AUFRUFEN:
+WANN navigate() AUFRUFEN — NUR BEI EINDEUTIGER NAVIGATIONS-ABSICHT:
 
-Rufe navigate() auf wenn der Nutzer irgendwohin GEHEN möchte, ein Feature
-FINDEN will, LERNEN möchte wie etwas funktioniert, oder irgendeinen
-Bildschirm, eine Seite, einen Bereich oder eine Funktion der App erwähnt —
-auch indirekt. Beispiele:
+Rufe navigate() NUR auf wenn der Nutzer tatsächlich IRGENDWOHIN GEHEN
+möchte — also ein klares Handlungsverb benutzt ("öffne", "zeig",
+"bring mich zu", "geh zu", "ich will sehen", "wo finde ich", "wo sind").
+Beispiele:
    • "öffne mein Profil" → rufe navigate auf
    • "öffne mein Wallet" → rufe navigate auf
    • "wo sind die Podcasts" → rufe navigate auf
+   • "bring mich zu meinen Gesundheitsdaten" → rufe navigate auf
    • "ich möchte ein Business aufbauen" → rufe navigate auf
    • "zeig mir meine Gesundheitsdaten" → rufe navigate auf
-   • "öffne meinen Posteingang" → rufe navigate auf
-   • "wie verfolge ich meine Biologie?" → rufe navigate auf
 
-Im Zweifel rufe navigate() auf. Es ist billig, schnell und gibt immer
-etwas Nützliches zurück. Wenn du es nicht aufrufst und der Nutzer
-navigieren wollte, bleibt er stumm wartend im Hörmodus hängen.
-
-Der EINZIGE Fall in dem du navigate() NICHT aufrufen solltest:
+WANN navigate() **NICHT** AUFRUFEN — INFORMATIONS-Fragen beantworte
+gesprächig, OHNE zu navigieren. Der Nutzer kann Bildschirme erwähnen
+ohne dorthin zu wollen:
+   • "Was ist der Unterschied zwischen X und Y?" → VERGLEICH, erklären
+   • "Was ist X?" / "Was macht X?" → DEFINITION, erklären
+   • "Wofür ist X gut?" / "Warum gibt es X?" → ERKLÄRUNG
+   • "Wie funktioniert X?" → ERKLÄRUNG (außer Nutzer sagt "bring mich dorthin")
+   • "Erkläre mir X" / "Sag mir etwas über X" → ERKLÄRUNG
+   • "Ist X dasselbe wie Y?" → VERGLEICH, erklären
    • Reiner Smalltalk ("wie geht es dir", "danke")
-   • Schnelle Faktenfragen ohne Bildschirm-Bezug ("was ist Longevity?")
+   • Allgemeine Faktenfragen ("was ist Longevity?")
+
+FAUSTREGEL — das Verb entscheidet:
+   • "öffne / zeig / bring mich zu / geh zu / wo sind X" = Navigation ✓
+   • "was ist / was macht / Unterschied / erkläre / wie funktioniert /
+     wofür / warum" = Erklärung (KEINE Navigation) ✗
+
+Bei ECHTER Unsicherheit OB navigieren oder erklären: stelle EINE kurze
+Rückfrage ("Soll ich dich dorthin bringen oder es dir kurz erklären?")
+bevor du navigate() aufrufst. Reflexartiges Navigieren stört mehr als
+es hilft — eine falsche Navigation zwingt den Nutzer zurück und
+unterbricht sein Gespräch.
 
 WAS DU VON navigate() ZURÜCKBEKOMMST:
    • GUIDANCE: eine hilfreiche Erklärung die du dem Nutzer vorsprechen
@@ -3066,26 +3080,40 @@ your most important jobs. You have two tools:
     knowledge base for guidance, and redirects the user automatically.
     You do not need to know screen names or IDs — just pass the question.
 
-WHEN TO CALL navigate():
+WHEN TO CALL navigate() — ONLY ON CLEAR NAVIGATION INTENT:
 
-Call navigate() whenever the user wants to GO somewhere, FIND a feature,
-LEARN how to do something, or mentions any screen, page, section, or
-area of the app — even indirectly. Examples:
+Call navigate() ONLY when the user actually wants to GO somewhere — i.e.
+they used a clear action verb: "open", "show me", "take me to", "go to",
+"bring me to", "where is / where are", "I want to see". Examples:
    • "open my profile" → call navigate
    • "open my wallet" → call navigate
    • "where are the podcasts" → call navigate
+   • "take me to my health data" → call navigate
    • "I want to set up a business" → call navigate
    • "show me my health data" → call navigate
-   • "open my inbox" → call navigate
-   • "how do I track my biology?" → call navigate
 
-When in doubt, call navigate(). It is cheap, fast, and always returns
-something useful. Not calling it when the user wanted to go somewhere
-leaves them stuck in silence.
-
-The ONLY time you should NOT call navigate():
+DO **NOT** call navigate() on INFORMATIONAL questions — answer them
+conversationally without navigating. Users can reference screens
+without wanting to go to them:
+   • "What's the difference between X and Y?" → COMPARISON, explain
+   • "What is X?" / "What does X do?" → DEFINITION, explain
+   • "What is X for?" / "Why does X exist?" → EXPLANATION
+   • "How does X work?" → EXPLANATION (unless they explicitly say "take me there")
+   • "Tell me about X" / "Explain X to me" → EXPLANATION
+   • "Is X the same as Y?" → COMPARISON, explain
    • Pure small talk ("how are you", "thank you")
-   • Quick factual questions with no screen destination ("what is longevity?")
+   • General factual questions ("what is longevity?")
+
+RULE OF THUMB — the verb decides:
+   • "open / show / take me to / go to / where is X" → navigate ✓
+   • "what is / what does / difference / explain / how does / why /
+     what is X for" → explain, DO NOT navigate ✗
+
+If you are GENUINELY unsure whether the user wants navigation or an
+explanation: ask ONE short clarifying question ("Would you like me to
+take you there, or briefly explain it?") before calling navigate().
+Reflexive navigation is worse than a quick clarification — a wrong
+redirect forces the user to backtrack and breaks the conversation.
 
 WHAT YOU GET BACK from navigate():
    • GUIDANCE: a helpful explanation you should speak to the user. Describe


### PR DESCRIPTION
## Summary

When the user asked **"What's the difference between My Journey and User Profile?"**, the orb redirected them to one of the screens instead of answering. Root cause was in the navigator policy prompt (`buildNavigatorPolicySection` in `orb-live.ts`), which told Gemini:
- *"call navigate() whenever the user ... mentions any screen ... even indirectly"*
- *"when in doubt, call navigate()"*

A comparative question mentioning two screens matched those rules, so Gemini dispatched a redirect.

### Fix (prompt-only, no code changes)

Rewrote the policy to condition on the user's **verb**, not on whether a screen name appears:

| Verb family | Action |
|---|---|
| `open` / `show` / `take me to` / `go to` / `where is X` | **navigate** ✓ |
| `what is` / `difference` / `explain` / `how does` / `why` / `what is X for` | **explain — do NOT navigate** ✗ |
| Genuinely ambiguous | Ask ONE short clarifying question first |

Both the German and English branches now have explicit **negative examples** so the model has concrete patterns to match against — *"was ist der Unterschied zwischen X und Y?"*, *"what is X for?"*, *"tell me about X"*, etc.

## Test plan

- [ ] "Open my journey" → navigate to `/autopilot` (still works)
- [ ] "What's the difference between My Journey and User Profile?" → explained verbally, NO redirect
- [ ] "What is the wallet screen for?" → explained, NO redirect
- [ ] "How does the autopilot work?" → explained, NO redirect
- [ ] Ambiguous case → Vitana asks "Would you like me to take you there, or briefly explain it?"

🤖 Generated with [Claude Code](https://claude.com/claude-code)