### PR TITLE
fix(VTID-02100): temporarily disable Phase 1 wearable mounts to unblock deploy

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -134,12 +134,13 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   // VTID-02000: Wearables waitlist (Phase 0 stub — still works alongside Phase 1 connector flow)
   const wearablesWaitlistRouter = require('./routes/wearables-waitlist').default;
   // VTID-02100: Phase 1 — connector framework + wearable routes + webhook receiver
-  const wearablesRouter = require('./routes/wearables').default;
-  const connectorWebhooksRouter = require('./routes/connector-webhooks').default;
-  const { initializeAllConnectors } = require('./connectors');
-  initializeAllConnectors().catch((err: unknown) => {
-    console.error('[connectors] initialization error:', err);
-  });
+  // TEMPORARY: isolate boot crash — disabled until root-caused
+  // const wearablesRouter = require('./routes/wearables').default;
+  // const connectorWebhooksRouter = require('./routes/connector-webhooks').default;
+  // const { initializeAllConnectors } = require('./connectors');
+  // initializeAllConnectors().catch((err: unknown) => {
+  //   console.error('[connectors] initialization error:', err);
+  // });
   // VTID-01091: Locations Memory (Places + Habits + Meetups) + Discovery
   const locationsRouter = require('./routes/locations').default;
   const { discoveryRouter, locationPrefsRouter } = require('./routes/locations');
@@ -607,8 +608,9 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   mountRouterSync(app, '/api/v1/wearables/waitlist', wearablesWaitlistRouter, { owner: 'wearables-waitlist' });
 
   // VTID-02100: Phase 1 wearables routes + connector webhook receiver
-  mountRouterSync(app, '/api/v1/wearables', wearablesRouter, { owner: 'wearables' });
-  mountRouterSync(app, '/api/v1/connectors', connectorWebhooksRouter, { owner: 'connector-webhooks' });
+  // TEMPORARY: disabled until boot crash root-caused
+  // mountRouterSync(app, '/api/v1/wearables', wearablesRouter, { owner: 'wearables' });
+  // mountRouterSync(app, '/api/v1/connectors', connectorWebhooksRouter, { owner: 'connector-webhooks' });
 
   // VTID-01091: Locations Memory + Discovery + Preferences
   mountRouterSync(app, '/api/v1/locations', locationsRouter, { owner: 'locations' });


### PR DESCRIPTION
## Summary

PR #658 shipped correctly from a code perspective — tsc clean, Docker builds — but the Cloud Run revision fails to bind PORT within timeout. Two EXEC-DEPLOY rerun attempts both fail the same way.

Without Cloud Run log access, I can't see the runtime stack trace. Rolling forward with a minimal isolation patch: temporarily disable the mount of `/api/v1/wearables` + `/api/v1/connectors` routes and the `initializeAllConnectors()` fire-and-forget call. The route files remain in the codebase — just not wired into Express.

If this deploy succeeds → the crash is in one of the direct-imported modules (wearables.ts, connector-webhooks.ts, connectors/index.ts, connectors/wearable/terra.ts). Will bisect and restore.

If this deploy still fails → the crash is in an indirectly-imported module (recommendation-generator's wearable-analyzer import, context-pack-builder's user-health-context import, gemini-operator's new executor, tool-registry's new tool def, or the extended types). Further bisection needed.

## Status
- Schema migrations already applied (safe — they added tables, not breaking)
- VTID-02100 already registered in ledger
- This is a no-op schema change

Generated with [Claude Code](https://claude.com/claude-code)