### PR TITLE
fix(wearables): remove duplicate POST /waitlist route — unblocks gateway deploys

### DIFF
--- a/services/gateway/src/routes/wearables.ts
+++ b/services/gateway/src/routes/wearables.ts
@@ -233,29 +233,8 @@ router.get('/metrics', async (req: Request, res: Response) => {
   });
 });
 
-// ==================== POST /waitlist — Phase 0 compat (still works) ====================
-
-router.post('/waitlist', async (req: Request, res: Response) => {
-  const user = getUser(req);
-  if (!user) return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
-  const supabase = getSupabase();
-  if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
-  const tenantId = user.tenant_id ?? (await resolveTenantId(user.user_id));
-  if (!tenantId) return res.status(400).json({ ok: false, error: 'Tenant not found' });
-
-  const provider = typeof req.body?.provider === 'string' ? (req.body.provider as string) : null;
-  if (!provider) return res.status(400).json({ ok: false, error: 'provider required' });
-
-  const { data, error } = await supabase
-    .from('wearable_waitlist')
-    .upsert(
-      { user_id: user.user_id, tenant_id: tenantId, provider, notify_via: 'email' },
-      { onConflict: 'user_id,provider' }
-    )
-    .select('*')
-    .single();
-  if (error) return res.status(500).json({ ok: false, error: error.message });
-  res.json({ ok: true, waitlist_entry: data });
-});
+// POST /api/v1/wearables/waitlist is owned by routes/wearables-waitlist.ts
+// (mounted separately in index.ts). Kept there to avoid a duplicate-route
+// registration that blocks gateway startup.
 
 export default router;


### PR DESCRIPTION
## Summary

Gateway has been failing to start on every deploy since VTID-02100 Phase 1 landed. RouteGuard detected a duplicate registration of POST /api/v1/wearables/waitlist:

- routes/wearables-waitlist.ts (POST /, mounted at /api/v1/wearables/waitlist)
- routes/wearables.ts (POST /waitlist, mounted at /api/v1/wearables)

Every new revision fails its startup TCP probe, so traffic stays pinned on gateway-00292-hup (a pre-wearables build). That blocks every env-var and code change from going live — including the Dev Autopilot scan token I just tried to set.

## Fix

Remove the duplicate `router.post('/waitlist', ...)` from routes/wearables.ts. The Phase 0 router is the canonical owner per VTID-02100's own commit message ("Phase 0 stub still works alongside Phase 1 connector flow"). The 5 Phase 1 wearable routes (providers, connect/:connector, disconnect/:connector, connections, metrics) are untouched.

## Test plan

- [ ] tsc --noEmit clean (verified locally)
- [ ] Gateway Service Tests green on PR
- [ ] After merge + EXEC-DEPLOY: `curl -sS -o /dev/null -w "%{http_code}" https://gateway-q74ibpv6ia-uc.a.run.app/alive` → 200
- [ ] Confirm new revision is serving, not gateway-00292-hup

🤖 Generated with [Claude Code](https://claude.com/claude-code)