### PR TITLE
VTID-02200: Phase 2 — Shopify + CJ marketplace sync

### DIFF
--- a/services/gateway/src/routes/admin-marketplace.ts
+++ b/services/gateway/src/routes/admin-marketplace.ts
@@ -282,6 +282,65 @@ router.patch('/geo-policy/:id', requireTenantAdmin, async (req: Request, res: Re
   res.json({ ok: true, policy: data });
 });
 
+// ==================== VTID-02200: Sources (Shopify + CJ + etc) ====================
+
+router.get('/sources', requireTenantAdmin, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+  const { source_network } = req.query;
+  let q = supabase.from('marketplace_sources_config').select('*').order('created_at', { ascending: false });
+  if (source_network) q = q.eq('source_network', String(source_network));
+  const { data, error } = await q;
+  if (error) return res.status(500).json({ ok: false, error: error.message });
+  res.json({ ok: true, sources: data ?? [] });
+});
+
+router.post('/sources', requireTenantAdmin, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+  const allowed = ['source_network', 'display_name', 'config', 'tenant_id', 'is_active', 'notes'];
+  const payload: Record<string, unknown> = {};
+  for (const k of allowed) if (k in req.body) payload[k] = req.body[k];
+  if (!payload.source_network || !payload.display_name || !payload.config) {
+    return res.status(400).json({ ok: false, error: 'source_network, display_name, config required' });
+  }
+  payload.created_by = getUserId(req) ?? null;
+  const { data, error } = await supabase.from('marketplace_sources_config').insert(payload).select().single();
+  if (error) return res.status(500).json({ ok: false, error: error.message });
+  await emitAdminActivity(getTenantId(req), getUserId(req), 'marketplace_source.created', { source_id: data.id, source_network: data.source_network });
+  res.json({ ok: true, source: data });
+});
+
+router.patch('/sources/:id', requireTenantAdmin, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+  const allowed = ['display_name', 'config', 'is_active', 'notes'];
+  const patch: Record<string, unknown> = {};
+  for (const k of allowed) if (k in req.body) patch[k] = req.body[k];
+  if (Object.keys(patch).length === 0) return res.status(400).json({ ok: false, error: 'No allowed fields to update' });
+  const { data, error } = await supabase.from('marketplace_sources_config').update(patch).eq('id', req.params.id).select().single();
+  if (error) return res.status(500).json({ ok: false, error: error.message });
+  await emitAdminActivity(getTenantId(req), getUserId(req), 'marketplace_source.updated', { source_id: req.params.id, patch });
+  res.json({ ok: true, source: data });
+});
+
+// Manual sync trigger — runs in-process, returns the result once done.
+router.post('/sync/:network', requireTenantAdmin, async (req: Request, res: Response) => {
+  const network = req.params.network;
+  if (!['shopify', 'cj'].includes(network)) {
+    return res.status(400).json({ ok: false, error: `Unsupported network: ${network}. Use shopify or cj.` });
+  }
+  try {
+    const { runMarketplaceSyncSource } = await import('../services/marketplace-sync');
+    const result = await runMarketplaceSyncSource(network as 'shopify' | 'cj', `admin:${getUserId(req) ?? 'unknown'}`);
+    await emitAdminActivity(getTenantId(req), getUserId(req), 'marketplace_sync.triggered', { network, totals: result.totals });
+    res.json({ ok: true, network, result });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    res.status(500).json({ ok: false, error: message });
+  }
+});
+
 router.post('/geo-policy', requireTenantAdmin, async (req: Request, res: Response) => {
   const supabase = getSupabase();
   if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });

--- a/services/gateway/src/services/marketplace-sync/cj-sync.ts
+++ b/services/gateway/src/services/marketplace-sync/cj-sync.ts
@@ -1,0 +1,282 @@
+/**
+ * VTID-02200: CJ Affiliate (Commission Junction) Product Search sync.
+ *
+ * https://developers.cj.com/ — Product Search API v2.
+ * Uses a single publisher account per environment. Configure:
+ *   CJ_DEVELOPER_KEY           — Bearer token
+ *   CJ_WEBSITE_ID              — publisher website ID (e.g. 12345678)
+ *   CJ_ADVERTISER_IDS          — comma-separated advertiser IDs (optional filter)
+ *   CJ_KEYWORDS                — comma-separated keyword filters (optional)
+ *   CJ_PRODUCT_LIMIT           — max products per run (default 1000)
+ *
+ * Deep-link pattern for CJ affiliate URLs:
+ *   https://www.anrdoezrs.net/links/{websiteId}/type/dlg/sid/{click_id}/{encoded_target_url}
+ * The click_id is stamped at click-redirect time by our own /r/:product_id
+ * handler (from Phase 0), so during sync we store the merchant's target URL
+ * as `affiliate_url` and let /r/:product_id build the CJ deep-link.
+ */
+
+import { getSupabase } from '../../lib/supabase';
+import {
+  startSyncRun,
+  finishSyncRun,
+  upsertMerchant,
+  upsertProducts,
+  deriveRegionGroup,
+  type ProductUpsert,
+} from './shared';
+
+function cjCreds(): { developer_key: string; website_id: string } | null {
+  const developer_key = process.env.CJ_DEVELOPER_KEY;
+  const website_id = process.env.CJ_WEBSITE_ID;
+  if (!developer_key || !website_id) return null;
+  return { developer_key, website_id };
+}
+
+// ==================== CJ Product Search API ====================
+
+interface CjProductRaw {
+  'ad-id'?: string;
+  'catalog-id'?: string;
+  'advertiser-id'?: string;
+  'advertiser-name'?: string;
+  'buy-url'?: string;
+  'currency'?: string;
+  'description'?: string;
+  'image-url'?: string;
+  'in-stock'?: string | boolean;
+  'manufacturer-name'?: string;
+  'manufacturer-sku'?: string;
+  'name'?: string;
+  'price'?: string;
+  'retail-price'?: string;
+  'sale-price'?: string;
+  'upc'?: string;
+  'isbn'?: string;
+  'ean'?: string;
+  'keywords'?: string;
+  'advertiser-category'?: string;
+  'third-party-category'?: string;
+  'third-party-id'?: string;
+  'country-of-origin'?: string;
+}
+
+interface CjProductSearchResp {
+  products?: {
+    '@attributes'?: { 'total-matched'?: string; 'records-returned'?: string; 'page-number'?: string };
+    product?: CjProductRaw[] | CjProductRaw;
+  };
+}
+
+async function fetchCjPage(
+  creds: { developer_key: string; website_id: string },
+  opts: { keywords?: string; advertiserIds?: string; pageNumber: number; recordsPerPage?: number }
+): Promise<CjProductRaw[]> {
+  const qs = new URLSearchParams({
+    'website-id': creds.website_id,
+    'records-per-page': String(opts.recordsPerPage ?? 100),
+    'page-number': String(opts.pageNumber),
+    'serviceable-area': 'US,GB,DE,FR,IT,ES,NL,SE',
+  });
+  if (opts.keywords) qs.set('keywords', opts.keywords);
+  if (opts.advertiserIds) qs.set('advertiser-ids', opts.advertiserIds);
+
+  const url = `https://product-search.api.cj.com/v2/product-search?${qs.toString()}`;
+  const resp = await fetch(url, {
+    headers: { Authorization: `Bearer ${creds.developer_key}`, Accept: 'application/json' },
+  });
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => '(no body)');
+    throw new Error(`CJ ${resp.status} ${text}`);
+  }
+  const data = (await resp.json()) as CjProductSearchResp;
+  const products = data.products?.product;
+  if (!products) return [];
+  return Array.isArray(products) ? products : [products];
+}
+
+// ==================== Normalization ====================
+
+function parseCents(amountStr: string | undefined): number | null {
+  if (!amountStr) return null;
+  const cleaned = amountStr.replace(/[^0-9.]/g, '');
+  const n = parseFloat(cleaned);
+  if (Number.isNaN(n)) return null;
+  return Math.round(n * 100);
+}
+
+function boolish(v: string | boolean | undefined): boolean {
+  if (typeof v === 'boolean') return v;
+  if (typeof v === 'string') return v === 'yes' || v === 'true' || v === '1';
+  return true; // default to in-stock
+}
+
+function normalizeCjProduct(raw: CjProductRaw, merchantMap: Map<string, string>): ProductUpsert | null {
+  const adId = raw['ad-id'] ?? raw['catalog-id'];
+  if (!adId) return null;
+  const advertiserId = raw['advertiser-id'];
+  if (!advertiserId) return null;
+
+  const merchantId = merchantMap.get(advertiserId);
+  if (!merchantId) return null; // will be skipped at upsert; caller retries after merchant upsert
+
+  const priceCents = parseCents(raw['sale-price']) ?? parseCents(raw['price']) ?? parseCents(raw['retail-price']);
+  if (priceCents === null) return null;
+
+  const currency = (raw['currency'] ?? 'USD').toUpperCase();
+  const gtin = raw['ean'] ?? raw['isbn'] ?? raw['upc'];
+  const origin_country = raw['country-of-origin']?.toUpperCase();
+  const compareAt = parseCents(raw['retail-price']);
+
+  const images: string[] = [];
+  if (raw['image-url']) images.push(raw['image-url']);
+
+  const tags: string[] = [];
+  if (raw['keywords']) {
+    for (const k of raw['keywords'].split(',')) {
+      const clean = k.trim().toLowerCase();
+      if (clean) tags.push(clean);
+    }
+  }
+
+  return {
+    merchant_id: merchantId,
+    source_network: 'cj',
+    source_product_id: String(adId),
+    gtin,
+    sku: raw['manufacturer-sku'],
+    title: raw['name'] ?? 'Untitled product',
+    description: raw['description'],
+    brand: raw['manufacturer-name'],
+    category: raw['advertiser-category'] ?? raw['third-party-category'],
+    topic_keys: tags.slice(0, 20),
+    price_cents: priceCents,
+    currency,
+    compare_at_price_cents: compareAt && compareAt > priceCents ? compareAt : undefined,
+    images,
+    affiliate_url: raw['buy-url'] ?? '',
+    availability: boolish(raw['in-stock']) ? 'in_stock' : 'out_of_stock',
+    origin_country,
+    raw: raw as unknown as Record<string, unknown>,
+  };
+}
+
+// ==================== Merchant resolution ====================
+
+async function ensureCjMerchants(rawProducts: CjProductRaw[]): Promise<Map<string, string>> {
+  const supabase = getSupabase();
+  if (!supabase) return new Map();
+
+  // Gather unique advertisers from the batch
+  const advertisers = new Map<string, { name: string; country?: string }>();
+  for (const p of rawProducts) {
+    const id = p['advertiser-id'];
+    if (!id) continue;
+    if (advertisers.has(id)) continue;
+    advertisers.set(id, {
+      name: p['advertiser-name'] ?? `CJ Advertiser ${id}`,
+      country: p['country-of-origin']?.toUpperCase(),
+    });
+  }
+
+  const merchantMap = new Map<string, string>();
+  for (const [advertiserId, info] of advertisers) {
+    const merchantId = await upsertMerchant({
+      source_network: 'cj',
+      source_merchant_id: advertiserId,
+      name: info.name,
+      merchant_country: info.country,
+      affiliate_network: 'cj',
+      quality_score: 60,
+      customs_risk: 'unknown',
+    });
+    if (merchantId) merchantMap.set(advertiserId, merchantId);
+  }
+  return merchantMap;
+}
+
+// ==================== Entry point ====================
+
+export interface CjSyncResult {
+  ok: boolean;
+  totals: { inserted: number; updated: number; skipped: number; errors: number; fetched: number };
+  pages_fetched: number;
+  advertisers_seen: number;
+  duration_ms: number;
+  error?: string;
+}
+
+export async function runCjSync(triggered_by = 'scheduler'): Promise<CjSyncResult> {
+  const startTime = Date.now();
+  const creds = cjCreds();
+  if (!creds) {
+    console.log('[cj-sync] CJ_DEVELOPER_KEY / CJ_WEBSITE_ID not set — skipping');
+    return {
+      ok: true,
+      totals: { inserted: 0, updated: 0, skipped: 0, errors: 0, fetched: 0 },
+      pages_fetched: 0,
+      advertisers_seen: 0,
+      duration_ms: Date.now() - startTime,
+    };
+  }
+
+  const run = await startSyncRun('cj', triggered_by);
+  const maxProducts = parseInt(process.env.CJ_PRODUCT_LIMIT ?? '1000', 10);
+  const keywords = process.env.CJ_KEYWORDS;          // optional comma list
+  const advertiserIds = process.env.CJ_ADVERTISER_IDS; // optional comma list
+
+  const totals = { inserted: 0, updated: 0, skipped: 0, errors: 0, fetched: 0 };
+  const errorSample: unknown[] = [];
+  const advertisersSeen = new Set<string>();
+  let pageNumber = 1;
+
+  while (totals.fetched < maxProducts) {
+    let rawPage: CjProductRaw[];
+    try {
+      rawPage = await fetchCjPage(creds, {
+        keywords,
+        advertiserIds,
+        pageNumber,
+        recordsPerPage: 100,
+      });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      errorSample.push({ pageNumber, error: message });
+      totals.errors++;
+      break;
+    }
+    if (rawPage.length === 0) break;
+    totals.fetched += rawPage.length;
+
+    const merchantMap = await ensureCjMerchants(rawPage);
+    for (const id of merchantMap.keys()) advertisersSeen.add(id);
+
+    const normalized = rawPage
+      .map((r) => normalizeCjProduct(r, merchantMap))
+      .filter((p): p is ProductUpsert => p !== null);
+
+    if (normalized.length === 0) {
+      pageNumber++;
+      continue;
+    }
+
+    const result = await upsertProducts(normalized, 'cj');
+    totals.inserted += result.inserted;
+    totals.updated += result.updated;
+    totals.skipped += result.skipped_unchanged;
+    if (result.errors.length) {
+      totals.errors += result.errors.length;
+      errorSample.push(...result.errors.slice(0, 5));
+    }
+
+    if (rawPage.length < 100) break; // last page
+    pageNumber++;
+  }
+
+  if (run) await finishSyncRun(run, { ...totals, error_sample: errorSample });
+
+  const duration_ms = Date.now() - startTime;
+  console.log(`[cj-sync] done in ${duration_ms}ms — fetched ${totals.fetched}, ${totals.inserted}+ ${totals.updated}~ ${totals.skipped}= ${totals.errors}! across ${advertisersSeen.size} advertisers`);
+
+  return { ok: totals.errors === 0, totals, pages_fetched: pageNumber, advertisers_seen: advertisersSeen.size, duration_ms };
+}

--- a/services/gateway/src/services/marketplace-sync/index.ts
+++ b/services/gateway/src/services/marketplace-sync/index.ts
@@ -1,0 +1,61 @@
+/**
+ * VTID-02200: Marketplace sync orchestrator.
+ *
+ * Single entry point that runs all enabled marketplace sources on schedule.
+ */
+
+import { runShopifySync, type ShopifySyncResult } from './shopify-sync';
+import { runCjSync, type CjSyncResult } from './cj-sync';
+
+export interface MarketplaceSyncAllResult {
+  ok: boolean;
+  shopify: ShopifySyncResult;
+  cj: CjSyncResult;
+  duration_ms: number;
+}
+
+export async function runAllMarketplaceSync(triggered_by = 'scheduler'): Promise<MarketplaceSyncAllResult> {
+  const startTime = Date.now();
+  console.log('[marketplace-sync] run started — triggered_by=%s', triggered_by);
+
+  // Sequential is fine; each source is rate-limited on its own vendor side.
+  const shopify = await runShopifySync(triggered_by).catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('[marketplace-sync] shopify failed:', message);
+    return {
+      ok: false,
+      shops_synced: 0,
+      totals: { inserted: 0, updated: 0, skipped: 0, errors: 1 },
+      per_shop: [],
+      duration_ms: 0,
+    } as ShopifySyncResult;
+  });
+
+  const cj = await runCjSync(triggered_by).catch((err: unknown) => {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('[marketplace-sync] cj failed:', message);
+    return {
+      ok: false,
+      totals: { inserted: 0, updated: 0, skipped: 0, errors: 1, fetched: 0 },
+      pages_fetched: 0,
+      advertisers_seen: 0,
+      duration_ms: 0,
+      error: message,
+    } as CjSyncResult;
+  });
+
+  const duration_ms = Date.now() - startTime;
+  console.log(`[marketplace-sync] run done in ${duration_ms}ms — shopify=${shopify.totals.inserted}+ cj=${cj.totals.inserted}+`);
+
+  return {
+    ok: shopify.ok && cj.ok,
+    shopify,
+    cj,
+    duration_ms,
+  };
+}
+
+export async function runMarketplaceSyncSource(source: 'shopify' | 'cj', triggered_by: string) {
+  if (source === 'shopify') return runShopifySync(triggered_by);
+  return runCjSync(triggered_by);
+}

--- a/services/gateway/src/services/marketplace-sync/shared.ts
+++ b/services/gateway/src/services/marketplace-sync/shared.ts
@@ -1,0 +1,299 @@
+/**
+ * VTID-02200: Marketplace sync shared helpers — DB upsert + run tracking.
+ *
+ * Each sync (Shopify, CJ, Amazon, ...) uses these to stamp provenance and
+ * write normalized rows. Runs bypass the HTTP /api/v1/catalog/ingest API
+ * since we're in the same process — direct Supabase service-role writes.
+ */
+
+import { createHash } from 'crypto';
+import { getSupabase } from '../../lib/supabase';
+
+export interface SyncRunHandle {
+  run_id: string;
+  source_network: string;
+  started_at: string;
+  triggered_by: string;
+}
+
+export async function startSyncRun(
+  source_network: string,
+  triggered_by = 'scheduler'
+): Promise<SyncRunHandle | null> {
+  const supabase = getSupabase();
+  if (!supabase) return null;
+  const { data, error } = await supabase
+    .from('catalog_sources')
+    .insert({ source_network, triggered_by })
+    .select('run_id, started_at, source_network, triggered_by')
+    .single();
+  if (error || !data) {
+    console.error('[marketplace-sync] failed to start run:', error?.message);
+    return null;
+  }
+  return {
+    run_id: data.run_id,
+    source_network: data.source_network,
+    started_at: data.started_at,
+    triggered_by: data.triggered_by,
+  };
+}
+
+export async function finishSyncRun(
+  handle: SyncRunHandle,
+  stats: { inserted: number; updated: number; skipped: number; errors: number; error_sample?: unknown[] }
+): Promise<void> {
+  const supabase = getSupabase();
+  if (!supabase) return;
+  await supabase
+    .from('catalog_sources')
+    .update({
+      finished_at: new Date().toISOString(),
+      products_inserted: stats.inserted,
+      products_updated: stats.updated,
+      products_skipped: stats.skipped,
+      errors: stats.errors,
+      error_sample: stats.error_sample ? stats.error_sample.slice(0, 10) : null,
+    })
+    .eq('run_id', handle.run_id);
+}
+
+// ==================== Merchant upsert ====================
+
+export interface MerchantUpsert {
+  source_network: string;
+  source_merchant_id: string;
+  name: string;
+  slug?: string;
+  storefront_url?: string;
+  merchant_country?: string;
+  ships_to_countries?: string[];
+  ships_to_regions?: string[];
+  currencies?: string[];
+  affiliate_network?: string;
+  commission_rate?: number;
+  quality_score?: number;
+  customs_risk?: 'low' | 'medium' | 'high' | 'unknown';
+}
+
+export async function upsertMerchant(m: MerchantUpsert): Promise<string | null> {
+  const supabase = getSupabase();
+  if (!supabase) return null;
+  const { data, error } = await supabase
+    .from('merchants')
+    .upsert(
+      {
+        source_network: m.source_network,
+        source_merchant_id: m.source_merchant_id,
+        name: m.name,
+        slug: m.slug ?? null,
+        storefront_url: m.storefront_url ?? null,
+        merchant_country: m.merchant_country ?? null,
+        ships_to_countries: m.ships_to_countries ?? null,
+        ships_to_regions: m.ships_to_regions ?? null,
+        currencies: m.currencies ?? [],
+        affiliate_network: m.affiliate_network ?? null,
+        commission_rate: m.commission_rate ?? null,
+        quality_score: m.quality_score ?? 50,
+        customs_risk: m.customs_risk ?? null,
+        is_active: true,
+      },
+      { onConflict: 'source_network,source_merchant_id' }
+    )
+    .select('id')
+    .single();
+  if (error || !data) {
+    console.error('[marketplace-sync] merchant upsert failed:', error?.message);
+    return null;
+  }
+  return data.id;
+}
+
+// ==================== Product upsert ====================
+
+export interface ProductUpsert {
+  merchant_id: string;
+  source_network: string;
+  source_product_id: string;
+  gtin?: string;
+  sku?: string;
+  asin?: string;
+  title: string;
+  description?: string;
+  brand?: string;
+  category?: string;
+  subcategory?: string;
+  topic_keys?: string[];
+  price_cents: number;
+  currency: string;
+  compare_at_price_cents?: number;
+  images?: string[];
+  affiliate_url: string;
+  availability?: 'in_stock' | 'out_of_stock' | 'preorder' | 'discontinued' | 'unknown';
+  rating?: number;
+  review_count?: number;
+  origin_country?: string;
+  ships_to_countries?: string[];
+  ships_to_regions?: string[];
+  health_goals?: string[];
+  dietary_tags?: string[];
+  form?: string;
+  certifications?: string[];
+  ingredients_primary?: string[];
+  contains_allergens?: string[];
+  raw?: Record<string, unknown>;
+}
+
+export function computeProductContentHash(p: ProductUpsert): string {
+  const canonical = {
+    title: p.title ?? '',
+    description: p.description ?? '',
+    brand: p.brand ?? '',
+    price_cents: p.price_cents,
+    currency: p.currency,
+    availability: p.availability ?? 'in_stock',
+    origin_country: p.origin_country ?? '',
+    ships_to_countries: [...(p.ships_to_countries ?? [])].sort(),
+    ships_to_regions: [...(p.ships_to_regions ?? [])].sort(),
+    affiliate_url: p.affiliate_url,
+    health_goals: [...(p.health_goals ?? [])].sort(),
+    dietary_tags: [...(p.dietary_tags ?? [])].sort(),
+    ingredients_primary: [...(p.ingredients_primary ?? [])].sort(),
+    images_count: (p.images ?? []).length,
+  };
+  return createHash('sha256').update(JSON.stringify(canonical)).digest('hex');
+}
+
+export interface UpsertProductsResult {
+  inserted: number;
+  updated: number;
+  skipped_unchanged: number;
+  errors: Array<{ source_product_id: string; error: string }>;
+}
+
+export async function upsertProducts(
+  products: ProductUpsert[],
+  source_network: string
+): Promise<UpsertProductsResult> {
+  const supabase = getSupabase();
+  const result: UpsertProductsResult = {
+    inserted: 0,
+    updated: 0,
+    skipped_unchanged: 0,
+    errors: [],
+  };
+  if (!supabase || products.length === 0) return result;
+
+  // Look up existing rows to detect insert vs update vs unchanged
+  const { data: existing } = await supabase
+    .from('products')
+    .select('source_product_id, content_hash')
+    .eq('source_network', source_network)
+    .in(
+      'source_product_id',
+      products.map((p) => p.source_product_id)
+    );
+  const existingMap = new Map((existing ?? []).map((e) => [e.source_product_id, e.content_hash]));
+
+  const now = new Date().toISOString();
+  const rows: Array<Record<string, unknown>> = [];
+
+  for (const p of products) {
+    const content_hash = computeProductContentHash(p);
+    const prevHash = existingMap.get(p.source_product_id);
+
+    if (prevHash === content_hash) {
+      result.skipped_unchanged++;
+      // Bump last_seen_at so stale-detection doesn't accidentally retire the row
+      rows.push({
+        source_network,
+        source_product_id: p.source_product_id,
+        merchant_id: p.merchant_id,
+        title: p.title,
+        affiliate_url: p.affiliate_url,
+        price_cents: p.price_cents,
+        currency: p.currency,
+        origin_country: p.origin_country ?? null,
+        last_seen_at: now,
+        content_hash,
+      });
+      continue;
+    }
+
+    rows.push({
+      merchant_id: p.merchant_id,
+      source_network,
+      source_product_id: p.source_product_id,
+      gtin: p.gtin ?? null,
+      sku: p.sku ?? null,
+      asin: p.asin ?? null,
+      title: p.title,
+      description: p.description ?? null,
+      brand: p.brand ?? null,
+      category: p.category ?? null,
+      subcategory: p.subcategory ?? null,
+      topic_keys: p.topic_keys ?? [],
+      price_cents: p.price_cents,
+      currency: p.currency,
+      compare_at_price_cents: p.compare_at_price_cents ?? null,
+      images: p.images ?? [],
+      affiliate_url: p.affiliate_url,
+      availability: p.availability ?? 'in_stock',
+      rating: p.rating ?? null,
+      review_count: p.review_count ?? null,
+      origin_country: p.origin_country ?? null,
+      ships_to_countries: p.ships_to_countries ?? null,
+      ships_to_regions: p.ships_to_regions ?? null,
+      health_goals: p.health_goals ?? [],
+      dietary_tags: p.dietary_tags ?? [],
+      form: p.form ?? null,
+      certifications: p.certifications ?? [],
+      ingredients_primary: p.ingredients_primary ?? [],
+      contains_allergens: p.contains_allergens ?? [],
+      raw: p.raw ?? null,
+      content_hash,
+      ingested_at: prevHash ? undefined : now,
+      last_seen_at: now,
+      is_active: true,
+    });
+  }
+
+  const { data: upserted, error } = await supabase
+    .from('products')
+    .upsert(rows, { onConflict: 'source_network,source_product_id' })
+    .select('source_product_id');
+
+  if (error) {
+    result.errors.push({ source_product_id: '(batch)', error: error.message });
+    return result;
+  }
+
+  // Classify each returned row as insert vs update based on whether we had an existing hash
+  for (const u of upserted ?? []) {
+    if (existingMap.has(u.source_product_id)) {
+      // Already counted as skipped_unchanged above OR it's an update
+      const stillUnchanged = rows.find(
+        (r) => r.source_product_id === u.source_product_id && r.content_hash === existingMap.get(u.source_product_id)
+      );
+      if (!stillUnchanged) result.updated++;
+    } else {
+      result.inserted++;
+    }
+  }
+  return result;
+}
+
+// ==================== Region derivation (client-side fallback) ====================
+
+export function deriveRegionGroup(country_code: string | undefined | null): string {
+  if (!country_code) return 'OTHER';
+  const c = country_code.toUpperCase();
+  const EU = ['AT', 'BE', 'BG', 'HR', 'CY', 'CZ', 'DK', 'EE', 'FI', 'FR', 'DE', 'GR', 'HU', 'IE', 'IT', 'LV', 'LT', 'LU', 'MT', 'NL', 'PL', 'PT', 'RO', 'SK', 'SI', 'ES', 'SE', 'NO', 'IS', 'CH', 'LI'];
+  if (EU.includes(c)) return 'EU';
+  if (c === 'GB' || c === 'UK') return 'UK';
+  if (c === 'US') return 'US';
+  if (c === 'CA') return 'CA';
+  if (c === 'CN' || c === 'HK' || c === 'MO') return 'APAC_CN';
+  if (['JP', 'KR', 'TW'].includes(c)) return 'APAC_JP_KR_TW';
+  return 'OTHER';
+}

--- a/services/gateway/src/services/marketplace-sync/shopify-sync.ts
+++ b/services/gateway/src/services/marketplace-sync/shopify-sync.ts
@@ -1,0 +1,351 @@
+/**
+ * VTID-02200: Shopify Storefront GraphQL sync.
+ *
+ * Reads configured partner shops from the marketplace_sources_config table
+ * (or the SHOPIFY_SHOPS env var as a bootstrap), fetches public product
+ * catalogs via the Storefront API, normalizes, upserts.
+ *
+ * Storefront API is read-only, uses a per-shop "public access token"
+ * (shopify.dev/docs/api/storefront). No OAuth required for public catalogs.
+ *
+ * Config shape (JSON array in SHOPIFY_SHOPS env or marketplace_sources_config.config):
+ *   {
+ *     "domain": "acme.myshopify.com",
+ *     "storefront_access_token": "...",
+ *     "merchant_name": "ACME Wellness",
+ *     "merchant_country": "DE",
+ *     "ships_to_regions": ["EU","UK"],
+ *     "commission_rate": 0.10,
+ *     "affiliate_url_template": "https://acme.myshopify.com/products/{handle}?ref=vitana"
+ *   }
+ */
+
+import { getSupabase } from '../../lib/supabase';
+import {
+  startSyncRun,
+  finishSyncRun,
+  upsertMerchant,
+  upsertProducts,
+  deriveRegionGroup,
+  type ProductUpsert,
+} from './shared';
+
+interface ShopifyShopConfig {
+  domain: string;
+  storefront_access_token: string;
+  merchant_name: string;
+  merchant_country?: string;
+  ships_to_countries?: string[];
+  ships_to_regions?: string[];
+  commission_rate?: number;
+  quality_score?: number;
+  affiliate_url_template?: string;   // optional; defaults to product URL with ?ref=vitana
+  currency?: string;                  // override if needed; normally derived from product
+  health_goals_by_collection?: Record<string, string[]>; // optional collection → health_goals map
+  dietary_tags_by_collection?: Record<string, string[]>; // optional collection → dietary_tags map
+}
+
+const SHOPIFY_API_VERSION = '2024-10';
+
+async function loadShopConfigs(): Promise<ShopifyShopConfig[]> {
+  // 1. Check DB-managed configs
+  const supabase = getSupabase();
+  if (supabase) {
+    const { data } = await supabase
+      .from('marketplace_sources_config')
+      .select('config')
+      .eq('source_network', 'shopify')
+      .eq('is_active', true);
+    if (data && data.length > 0) {
+      return data
+        .map((r) => r.config as ShopifyShopConfig)
+        .filter((c) => c && c.domain && c.storefront_access_token && c.merchant_name);
+    }
+  }
+  // 2. Fall back to env var
+  const envRaw = process.env.SHOPIFY_SHOPS;
+  if (!envRaw) return [];
+  try {
+    const parsed = JSON.parse(envRaw);
+    if (Array.isArray(parsed)) return parsed as ShopifyShopConfig[];
+  } catch (err) {
+    console.warn('[shopify-sync] SHOPIFY_SHOPS env var is not valid JSON:', err);
+  }
+  return [];
+}
+
+// ==================== GraphQL query ====================
+
+const PRODUCTS_QUERY = `
+query Products($cursor: String) {
+  products(first: 50, after: $cursor) {
+    pageInfo { hasNextPage endCursor }
+    edges {
+      node {
+        id
+        handle
+        title
+        descriptionHtml
+        vendor
+        productType
+        tags
+        totalInventory
+        availableForSale
+        featuredImage { url altText }
+        images(first: 4) { edges { node { url altText } } }
+        priceRange {
+          minVariantPrice { amount currencyCode }
+          maxVariantPrice { amount currencyCode }
+        }
+        compareAtPriceRange {
+          minVariantPrice { amount currencyCode }
+        }
+        onlineStoreUrl
+        collections(first: 10) { edges { node { handle title } } }
+      }
+    }
+  }
+}
+`;
+
+interface ShopifyProductNode {
+  id: string;
+  handle: string;
+  title: string;
+  descriptionHtml?: string;
+  vendor?: string;
+  productType?: string;
+  tags?: string[];
+  availableForSale?: boolean;
+  totalInventory?: number;
+  featuredImage?: { url: string; altText?: string | null } | null;
+  images?: { edges: Array<{ node: { url: string; altText?: string | null } }> };
+  priceRange: { minVariantPrice: { amount: string; currencyCode: string }; maxVariantPrice: { amount: string; currencyCode: string } };
+  compareAtPriceRange?: { minVariantPrice: { amount: string; currencyCode: string } };
+  onlineStoreUrl?: string | null;
+  collections?: { edges: Array<{ node: { handle: string; title: string } }> };
+}
+
+interface ShopifyProductsResp {
+  data?: {
+    products: {
+      pageInfo: { hasNextPage: boolean; endCursor: string | null };
+      edges: Array<{ node: ShopifyProductNode }>;
+    };
+  };
+  errors?: Array<{ message: string }>;
+}
+
+async function fetchShopifyProducts(
+  shop: ShopifyShopConfig,
+  cursor: string | null = null
+): Promise<ShopifyProductsResp> {
+  const resp = await fetch(`https://${shop.domain}/api/${SHOPIFY_API_VERSION}/graphql.json`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      'X-Shopify-Storefront-Access-Token': shop.storefront_access_token,
+      Accept: 'application/json',
+    },
+    body: JSON.stringify({ query: PRODUCTS_QUERY, variables: { cursor } }),
+  });
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => '(no body)');
+    throw new Error(`Shopify ${shop.domain} HTTP ${resp.status} ${text}`);
+  }
+  return (await resp.json()) as ShopifyProductsResp;
+}
+
+function dollarsToCents(amountStr: string): number {
+  const n = parseFloat(amountStr);
+  if (Number.isNaN(n)) return 0;
+  return Math.round(n * 100);
+}
+
+function stripHtml(html: string | undefined): string | undefined {
+  if (!html) return undefined;
+  return html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim() || undefined;
+}
+
+function normalizeShopifyProduct(
+  node: ShopifyProductNode,
+  shop: ShopifyShopConfig,
+  merchantId: string
+): ProductUpsert {
+  const priceAmount = node.priceRange?.minVariantPrice?.amount ?? '0';
+  const currency = (node.priceRange?.minVariantPrice?.currencyCode ?? shop.currency ?? 'USD').toUpperCase();
+  const compareAt = node.compareAtPriceRange?.minVariantPrice?.amount;
+
+  const images: string[] = [];
+  if (node.featuredImage?.url) images.push(node.featuredImage.url);
+  for (const e of node.images?.edges ?? []) {
+    if (e.node.url && !images.includes(e.node.url)) images.push(e.node.url);
+  }
+
+  // Derive health_goals + dietary_tags from collections + tags
+  const healthGoals = new Set<string>();
+  const dietaryTags = new Set<string>();
+  const collectionHandles = (node.collections?.edges ?? []).map((e) => e.node.handle.toLowerCase());
+  for (const h of collectionHandles) {
+    if (shop.health_goals_by_collection?.[h]) {
+      for (const g of shop.health_goals_by_collection[h]) healthGoals.add(g);
+    }
+    if (shop.dietary_tags_by_collection?.[h]) {
+      for (const d of shop.dietary_tags_by_collection[h]) dietaryTags.add(d);
+    }
+  }
+  // Tag-based dietary inference (common Shopify conventions)
+  const tagsLower = (node.tags ?? []).map((t) => t.toLowerCase());
+  const DIETARY_TAGS = ['vegan', 'vegetarian', 'gluten-free', 'dairy-free', 'nut-free', 'soy-free', 'sugar-free', 'organic', 'non-gmo', 'halal', 'kosher', 'keto-friendly'];
+  for (const d of DIETARY_TAGS) {
+    if (tagsLower.includes(d) || tagsLower.includes(d.replace('-', ''))) dietaryTags.add(d);
+  }
+
+  const affiliateUrl = shop.affiliate_url_template
+    ? shop.affiliate_url_template.replace('{handle}', node.handle)
+    : node.onlineStoreUrl ?? `https://${shop.domain}/products/${node.handle}`;
+
+  return {
+    merchant_id: merchantId,
+    source_network: 'shopify',
+    source_product_id: node.id,
+    sku: node.handle,
+    title: node.title,
+    description: stripHtml(node.descriptionHtml),
+    brand: node.vendor,
+    category: 'supplements', // Phase 2 MVP assumption — admin can override in review queue
+    subcategory: node.productType,
+    topic_keys: node.tags ?? [],
+    price_cents: dollarsToCents(priceAmount),
+    currency,
+    compare_at_price_cents: compareAt ? dollarsToCents(compareAt) : undefined,
+    images,
+    affiliate_url: affiliateUrl,
+    availability: node.availableForSale === false || node.totalInventory === 0 ? 'out_of_stock' : 'in_stock',
+    origin_country: shop.merchant_country,
+    ships_to_countries: shop.ships_to_countries,
+    ships_to_regions: shop.ships_to_regions,
+    health_goals: Array.from(healthGoals),
+    dietary_tags: Array.from(dietaryTags),
+    raw: node as unknown as Record<string, unknown>,
+  };
+}
+
+// ==================== Per-shop sync ====================
+
+async function syncOneShop(shop: ShopifyShopConfig): Promise<{ inserted: number; updated: number; skipped: number; errors: number; error_sample: unknown[] }> {
+  const merchantId = await upsertMerchant({
+    source_network: 'shopify',
+    source_merchant_id: shop.domain,
+    name: shop.merchant_name,
+    slug: shop.domain.replace('.myshopify.com', ''),
+    storefront_url: `https://${shop.domain}`,
+    merchant_country: shop.merchant_country,
+    ships_to_countries: shop.ships_to_countries,
+    ships_to_regions: shop.ships_to_regions,
+    affiliate_network: 'shopify',
+    commission_rate: shop.commission_rate,
+    quality_score: shop.quality_score ?? 70,
+    customs_risk: shop.merchant_country ? 'low' : 'unknown',
+  });
+
+  if (!merchantId) {
+    return { inserted: 0, updated: 0, skipped: 0, errors: 1, error_sample: [{ shop: shop.domain, error: 'merchant upsert failed' }] };
+  }
+
+  // Derive ships_to_regions from ships_to_countries if missing
+  if (!shop.ships_to_regions && shop.ships_to_countries?.length) {
+    const regions = new Set(shop.ships_to_countries.map((c) => deriveRegionGroup(c)));
+    shop.ships_to_regions = Array.from(regions);
+  }
+
+  let totalInserted = 0;
+  let totalUpdated = 0;
+  let totalSkipped = 0;
+  const errors: unknown[] = [];
+  let cursor: string | null = null;
+  let pageCount = 0;
+
+  while (pageCount < 50) { // hard cap: 50 pages × 50 = 2500 products per shop per run
+    let resp: ShopifyProductsResp;
+    try {
+      resp = await fetchShopifyProducts(shop, cursor);
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      errors.push({ shop: shop.domain, cursor, error: message });
+      break;
+    }
+    if (resp.errors?.length) {
+      errors.push({ shop: shop.domain, cursor, errors: resp.errors });
+      break;
+    }
+    const edges = resp.data?.products.edges ?? [];
+    if (edges.length === 0) break;
+
+    const products = edges.map((e) => normalizeShopifyProduct(e.node, shop, merchantId));
+    const result = await upsertProducts(products, 'shopify');
+
+    totalInserted += result.inserted;
+    totalUpdated += result.updated;
+    totalSkipped += result.skipped_unchanged;
+    if (result.errors.length) errors.push(...result.errors);
+
+    const pageInfo = resp.data?.products.pageInfo;
+    if (!pageInfo?.hasNextPage || !pageInfo.endCursor) break;
+    cursor = pageInfo.endCursor;
+    pageCount++;
+  }
+
+  return { inserted: totalInserted, updated: totalUpdated, skipped: totalSkipped, errors: errors.length, error_sample: errors.slice(0, 10) };
+}
+
+// ==================== Entry point ====================
+
+export interface ShopifySyncResult {
+  ok: boolean;
+  shops_synced: number;
+  totals: { inserted: number; updated: number; skipped: number; errors: number };
+  per_shop: Array<{ domain: string; inserted: number; updated: number; skipped: number; errors: number }>;
+  duration_ms: number;
+}
+
+export async function runShopifySync(triggered_by = 'scheduler'): Promise<ShopifySyncResult> {
+  const startTime = Date.now();
+  const shops = await loadShopConfigs();
+  if (shops.length === 0) {
+    console.log('[shopify-sync] no shops configured — skipping');
+    return {
+      ok: true,
+      shops_synced: 0,
+      totals: { inserted: 0, updated: 0, skipped: 0, errors: 0 },
+      per_shop: [],
+      duration_ms: Date.now() - startTime,
+    };
+  }
+
+  const run = await startSyncRun('shopify', triggered_by);
+  const per_shop: ShopifySyncResult['per_shop'] = [];
+  const totals = { inserted: 0, updated: 0, skipped: 0, errors: 0 };
+
+  for (const shop of shops) {
+    const stats = await syncOneShop(shop);
+    per_shop.push({
+      domain: shop.domain,
+      inserted: stats.inserted,
+      updated: stats.updated,
+      skipped: stats.skipped,
+      errors: stats.errors,
+    });
+    totals.inserted += stats.inserted;
+    totals.updated += stats.updated;
+    totals.skipped += stats.skipped;
+    totals.errors += stats.errors;
+  }
+
+  if (run) await finishSyncRun(run, totals);
+
+  const duration_ms = Date.now() - startTime;
+  console.log(`[shopify-sync] done in ${duration_ms}ms — ${totals.inserted} inserted, ${totals.updated} updated, ${totals.skipped} skipped, ${totals.errors} errors across ${shops.length} shops`);
+
+  return { ok: totals.errors === 0, shops_synced: shops.length, totals, per_shop, duration_ms };
+}

--- a/services/gateway/src/services/recommendation-engine/scheduler.ts
+++ b/services/gateway/src/services/recommendation-engine/scheduler.ts
@@ -24,6 +24,8 @@ export interface SchedulerConfig {
   codebaseMinute: number;       // Default: 0
   communityHour: number;        // Default: 7 (7 AM UTC) — daily community user regeneration
   communityMinute: number;      // Default: 0
+  marketplaceHour: number;      // Default: 3 (3 AM UTC) — daily marketplace catalog sync
+  marketplaceMinute: number;    // Default: 0
 }
 
 export interface SchedulerState {
@@ -31,12 +33,15 @@ export interface SchedulerState {
   lastOasisRun?: Date;
   lastCodebaseRun?: Date;
   lastCommunityRun?: Date;
+  lastMarketplaceRun?: Date;
   nextOasisRun?: Date;
   nextCodebaseRun?: Date;
   nextCommunityRun?: Date;
+  nextMarketplaceRun?: Date;
   oasisIntervalId?: NodeJS.Timeout;
   codebaseIntervalId?: NodeJS.Timeout;
   communityIntervalId?: NodeJS.Timeout;
+  marketplaceIntervalId?: NodeJS.Timeout;
 }
 
 // =============================================================================
@@ -51,6 +56,8 @@ const DEFAULT_CONFIG: SchedulerConfig = {
   codebaseMinute: 0,
   communityHour: 7,
   communityMinute: 0,
+  marketplaceHour: 3,
+  marketplaceMinute: 0,
 };
 
 // =============================================================================
@@ -173,6 +180,22 @@ async function runFullCodebaseScan(basePath: string): Promise<void> {
 // =============================================================================
 // Community User Daily Regeneration
 // =============================================================================
+
+// VTID-02200: Daily marketplace catalog sync (Shopify + CJ + future Amazon/Awin)
+async function runMarketplaceSync(): Promise<void> {
+  console.log(`${LOG_PREFIX} Running daily marketplace catalog sync...`);
+  try {
+    const { runAllMarketplaceSync } = await import('../marketplace-sync');
+    const result = await runAllMarketplaceSync('scheduler');
+    state.lastMarketplaceRun = new Date();
+    console.log(
+      `${LOG_PREFIX} Marketplace sync done: shopify=${result.shopify.totals.inserted}+ cj=${result.cj.totals.inserted}+ in ${result.duration_ms}ms`
+    );
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`${LOG_PREFIX} Marketplace sync failed:`, message);
+  }
+}
 
 async function runCommunityUserRegeneration(): Promise<void> {
   console.log(`${LOG_PREFIX} Running daily community user recommendation regeneration...`);
@@ -486,10 +509,27 @@ export function startScheduler(config: Partial<SchedulerConfig> = {}): void {
 
   scheduleNextCommunityRun();
 
+  // VTID-02200: Schedule daily marketplace sync
+  const scheduleNextMarketplaceRun = () => {
+    const nextRun = getNextDailyRunTime(fullConfig.marketplaceHour, fullConfig.marketplaceMinute);
+    state.nextMarketplaceRun = nextRun;
+    const msUntilRun = getMillisecondsUntil(nextRun);
+    console.log(
+      `${LOG_PREFIX} Next marketplace sync scheduled for ${nextRun.toISOString()} (in ${Math.round(msUntilRun / 1000 / 60)} minutes)`
+    );
+    state.marketplaceIntervalId = setTimeout(() => {
+      runMarketplaceSync();
+      scheduleNextMarketplaceRun();
+    }, msUntilRun);
+  };
+
+  scheduleNextMarketplaceRun();
+
   console.log(`${LOG_PREFIX} Scheduler started`);
   console.log(`${LOG_PREFIX} - OASIS analysis: every ${fullConfig.oasisIntervalMs / 1000 / 60 / 60}h`);
   console.log(`${LOG_PREFIX} - Daily scan: ${fullConfig.codebaseHour}:${String(fullConfig.codebaseMinute).padStart(2, '0')} UTC`);
   console.log(`${LOG_PREFIX} - Community regen: ${fullConfig.communityHour}:${String(fullConfig.communityMinute).padStart(2, '0')} UTC`);
+  console.log(`${LOG_PREFIX} - Marketplace sync: ${fullConfig.marketplaceHour}:${String(fullConfig.marketplaceMinute).padStart(2, '0')} UTC`);
 }
 
 export function stopScheduler(): void {
@@ -503,6 +543,11 @@ export function stopScheduler(): void {
   if (state.oasisIntervalId) {
     clearInterval(state.oasisIntervalId);
     state.oasisIntervalId = undefined;
+  }
+
+  if (state.marketplaceIntervalId) {
+    clearTimeout(state.marketplaceIntervalId);
+    state.marketplaceIntervalId = undefined;
   }
 
   if (state.codebaseIntervalId) {

--- a/supabase/migrations/20260418000000_vtid_02200_marketplace_sources_config.sql
+++ b/supabase/migrations/20260418000000_vtid_02200_marketplace_sources_config.sql
@@ -1,0 +1,79 @@
+-- Migration: 20260418000000_vtid_02200_marketplace_sources_config.sql
+-- Purpose: VTID-02200 Phase 2 — admin-managed config for marketplace sync sources
+--          (Shopify stores, CJ advertiser allowlists, Amazon PA-API locales).
+--          Removes the need for SHOPIFY_SHOPS env JSON blobs.
+
+CREATE TABLE IF NOT EXISTS public.marketplace_sources_config (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID,                                  -- NULL = platform-wide
+  source_network TEXT NOT NULL
+    CHECK (source_network IN ('shopify','cj','amazon','awin','rakuten','manual')),
+  display_name TEXT NOT NULL,
+
+  /*
+   * Opaque JSON config per source_network. Shape examples:
+   *
+   * Shopify:
+   *   {
+   *     "domain": "acme.myshopify.com",
+   *     "storefront_access_token": "...",
+   *     "merchant_name": "ACME Wellness",
+   *     "merchant_country": "DE",
+   *     "ships_to_countries": ["DE","AT","CH","NL","FR","IT","ES","GB"],
+   *     "ships_to_regions": ["EU","UK"],
+   *     "commission_rate": 0.10,
+   *     "affiliate_url_template": "https://acme.myshopify.com/products/{handle}?ref=vitana",
+   *     "health_goals_by_collection": { "sleep": ["better-sleep"], "stress": ["stress-reduction"] },
+   *     "dietary_tags_by_collection": { "vegan": ["vegan"] }
+   *   }
+   *
+   * CJ:
+   *   {
+   *     "advertiser_ids": ["12345","67890"],
+   *     "keywords": ["magnesium","ashwagandha"],
+   *     "product_limit": 1000
+   *   }
+   *
+   * Amazon:
+   *   {
+   *     "locale": "de",
+   *     "associate_tag": "vitana-21",
+   *     "access_key": "...",
+   *     "secret_key": "...",
+   *     "keywords": ["magnesium"]
+   *   }
+   */
+  config JSONB NOT NULL,
+
+  is_active BOOLEAN NOT NULL DEFAULT TRUE,
+  last_sync_at TIMESTAMPTZ,
+  last_sync_status TEXT CHECK (last_sync_status IS NULL OR last_sync_status IN ('success','partial','failed')),
+  last_sync_stats JSONB,
+  notes TEXT,
+
+  created_by UUID,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_marketplace_sources_config_active
+  ON public.marketplace_sources_config (source_network, is_active);
+
+-- updated_at trigger
+CREATE OR REPLACE FUNCTION public.marketplace_sources_config_bump_updated()
+RETURNS TRIGGER LANGUAGE plpgsql AS $$
+BEGIN NEW.updated_at := NOW(); RETURN NEW; END;
+$$;
+DROP TRIGGER IF EXISTS trg_marketplace_sources_config_updated ON public.marketplace_sources_config;
+CREATE TRIGGER trg_marketplace_sources_config_updated
+  BEFORE UPDATE ON public.marketplace_sources_config
+  FOR EACH ROW EXECUTE FUNCTION public.marketplace_sources_config_bump_updated();
+
+-- RLS: admins only
+ALTER TABLE public.marketplace_sources_config ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS marketplace_sources_config_service ON public.marketplace_sources_config;
+CREATE POLICY marketplace_sources_config_service ON public.marketplace_sources_config
+  FOR ALL TO service_role USING (TRUE) WITH CHECK (TRUE);
+
+COMMENT ON TABLE public.marketplace_sources_config IS
+  'VTID-02200: Admin-managed config for marketplace sync sources (Shopify stores, CJ, Amazon, Awin, Rakuten). Replaces env-JSON bootstrap.';

--- a/supabase/migrations/20260418000100_vtid_02200_register_ledger.sql
+++ b/supabase/migrations/20260418000100_vtid_02200_register_ledger.sql
@@ -1,0 +1,27 @@
+-- Migration: 20260418000100_vtid_02200_register_ledger.sql
+-- Purpose: Register VTID-02200 in vtid_ledger so EXEC-DEPLOY VTID-0542 gate
+--          passes when Phase 2 merges.
+
+INSERT INTO public.vtid_ledger (
+  vtid, layer, module, status, title, description, summary, task_family,
+  task_type, assigned_to, metadata, created_at, updated_at
+)
+VALUES (
+  'VTID-02200',
+  'PLATFORM',
+  'MARKETPLACE',
+  'in_progress',
+  'Phase 2 — Multi-source marketplace sync (Shopify + CJ)',
+  'Phase 2 backend: Shopify Storefront GraphQL multi-shop sync, CJ Affiliate Product Search API, unified upsert to products table via content_hash deduplication, marketplace_sources_config table for admin-managed per-source config, daily 3 AM UTC scheduler hook, manual admin trigger route /api/v1/admin/marketplace/sync/:network.',
+  'Phase 2 marketplace sync: Shopify + CJ → products table.',
+  'PLATFORM',
+  'MARKETPLACE',
+  'claude-code',
+  jsonb_build_object('source','retroactive_migration','registered_at',NOW(),'phase',2),
+  NOW(),
+  NOW()
+)
+ON CONFLICT (vtid) DO UPDATE
+  SET updated_at = NOW(),
+      status = EXCLUDED.status,
+      description = EXCLUDED.description;


### PR DESCRIPTION
## Summary

Phase 2 backend — populates the `products` table from real affiliate sources.

### New service: `services/gateway/src/services/marketplace-sync/`

- **shared.ts** — run tracking (catalog_sources), merchant upsert, product upsert with content_hash deduplication, region derivation
- **shopify-sync.ts** — Storefront GraphQL paginated fetch across multiple partner shops
- **cj-sync.ts** — Commission Junction Product Search API v2
- **index.ts** — orchestrator

### Scheduler
Daily 3 AM UTC hook in `recommendation-engine/scheduler.ts`, sandwiched between the 2 AM codebase scan and 7 AM community regen.

### Admin endpoints (under `/api/v1/admin/marketplace`)
- `GET /sources` — list configured sources
- `POST /sources` — add Shopify store or CJ config
- `PATCH /sources/:id` — edit config
- `POST /sync/:network` — manual trigger (`shopify` | `cj`), returns totals inline

### Schema
- `marketplace_sources_config` — admin-managed per-source JSON config
- VTID-02200 registered in `vtid_ledger` (EXEC-DEPLOY gate)

### Env vars to activate (optional — inactive until set)
- **Shopify**: either `SHOPIFY_SHOPS` env JSON OR rows in `marketplace_sources_config`. Example config:
  ```json
  {
    "domain": "acme.myshopify.com",
    "storefront_access_token": "...",
    "merchant_name": "ACME Wellness",
    "merchant_country": "DE",
    "ships_to_regions": ["EU"],
    "commission_rate": 0.10
  }
  ```
- **CJ**: `CJ_DEVELOPER_KEY`, `CJ_WEBSITE_ID`, optional `CJ_ADVERTISER_IDS`, `CJ_KEYWORDS`, `CJ_PRODUCT_LIMIT` (default 1000)

### Test plan
- [ ] Apply migration `20260418000000_vtid_02200_marketplace_sources_config.sql`
- [ ] Apply migration `20260418000100_vtid_02200_register_ledger.sql`
- [ ] Deploy succeeds
- [ ] Without any env vars, `POST /api/v1/admin/marketplace/sync/shopify` returns `{ok:true, shops_synced:0}`
- [ ] Without CJ creds, `POST /api/v1/admin/marketplace/sync/cj` returns `{ok:true, totals:{fetched:0}}`
- [ ] With SHOPIFY_SHOPS env set to a real public store, the sync inserts products
- [ ] `GET /api/v1/discover/search` returns the newly synced products

Generated with [Claude Code](https://claude.com/claude-code)