### PR TITLE
chore(status): only notify Chat when a health check fails

### DIFF
--- a/scripts/ci/collect-status.py
+++ b/scripts/ci/collect-status.py
@@ -2,7 +2,8 @@
 """
 VTID-01176: Cloud Run Status Collector
 Checks health of ALL canonical Cloud Run gateway services.
-Posts summary to Google Chat Command HUB space.
+Posts summary to Google Chat Command HUB space ONLY when one or more
+services are down (all-green runs are silent by design).
 """
 import os, requests, json
 from datetime import datetime
@@ -162,23 +163,24 @@ with open('docs/STATUS.md', 'w') as f:
     f.write(md)
 print(f'Updated docs/STATUS.md — {live_count}/{total} live')
 
-# ── Post to Google Chat ──
+# ── Post to Google Chat (only when one or more checks are failing) ──
+# Rationale: all-green pings create noise; we only want to hear from the
+# DevOps bot when something actually needs attention.
 webhook = os.getenv('WEBHOOK_URL', '')
 if webhook:
-    summary = f'*Vitana: {live_count}/{total} live*'
     if down_services:
+        summary = f'*Vitana: {live_count}/{total} live*'
         down_list = ', '.join(down_services[:10])
         if len(down_services) > 10:
             down_list += f' (+{len(down_services) - 10} more)'
         text = f'{summary}\n⚠️ Down: {down_list}'
+        try:
+            requests.post(webhook, json={'text': text}, timeout=10)
+            print('Posted to Chat (failures detected)')
+        except Exception as e:
+            print(f'Chat error: {e}')
     else:
-        text = f'{summary}\n✅ All systems operational'
-
-    try:
-        requests.post(webhook, json={'text': text}, timeout=10)
-        print('Posted to Chat')
-    except Exception as e:
-        print(f'Chat error: {e}')
+        print(f'All {total} services live — Chat notification suppressed (all-green rule)')
 
 # ── POST structured failure data to Gateway self-healing endpoint ──
 service_token = os.getenv('SERVICE_TOKEN', '')


### PR DESCRIPTION
## Summary
- Suppresses the all-green `Vitana: 54/54 live ✅ All systems operational` Google Chat pings.
- `scripts/ci/collect-status.py` now posts to the Command HUB Chat webhook **only when 1 or more of the tracked services is down / timeout / error**.
- `docs/STATUS.md` write and the self-healing `/api/v1/self-healing/report` POST are unchanged.

## Why
Status-only notifications were firing multiple times a day with nothing actionable. The new rule: silence on green, alert on red.

## Test plan
- [ ] Next scheduled run of `.github/workflows/DAILY-STATUS-UPDATE.yml` with all services live → no Chat post, workflow log shows `"All 54 services live — Chat notification suppressed (all-green rule)"`.
- [ ] Simulate a failure (e.g. temporarily break one health endpoint or run the script locally against a bogus `GATEWAY_URL`) → Chat post with `⚠️ Down: ...` is delivered.
- [ ] `docs/STATUS.md` still updates on every run.
- [ ] Self-healing report still POSTs when `down_services` is non-empty and `SERVICE_TOKEN` is set.