### PR TITLE
fix(events): eliminate LOVABLE_SUPABASE naming, use platform Supabase

### DIFF
--- a/.github/workflows/E2E-TEST-RUN.yml
+++ b/.github/workflows/E2E-TEST-RUN.yml
@@ -76,7 +76,7 @@ jobs:
           COMMUNITY_URL: ${{ github.event_name == 'repository_dispatch' && github.event.client_payload.community_url || inputs.community_url || 'https://vitanaland.com' }}
           TEST_USER_EMAIL: ${{ secrets.TEST_USER_EMAIL }}
           TEST_USER_PASSWORD: ${{ secrets.TEST_USER_PASSWORD }}
-          LOVABLE_SUPABASE_SERVICE_ROLE: ${{ secrets.LOVABLE_SUPABASE_SERVICE_ROLE }}
+          SUPABASE_SERVICE_ROLE: ${{ secrets.SUPABASE_SERVICE_ROLE }}
 
       - name: Report failure to self-healing
         if: failure()

--- a/.github/workflows/EXEC-DEPLOY.yml
+++ b/.github/workflows/EXEC-DEPLOY.yml
@@ -304,10 +304,7 @@ jobs:
             SECRETS_ARGS+=(--remove-secrets=APPILIX_APP_KEY)
             # Incident Triage Agent — Claude Managed Agents API key
             EXTRA_ENV_ARGS+=(--update-env-vars=ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }})
-            # VTID-01270A: Lovable Supabase connection for events/community data
-            # Secrets not in GCP Secret Manager — use GitHub Secrets as plain env vars
-            EXTRA_ENV_ARGS+=(--update-env-vars=LOVABLE_SUPABASE_URL=${{ secrets.LOVABLE_SUPABASE_URL }})
-            EXTRA_ENV_ARGS+=(--update-env-vars=LOVABLE_SUPABASE_SERVICE_ROLE=${{ secrets.LOVABLE_SUPABASE_SERVICE_ROLE }})
+            # VTID-01270A: Events/community data now uses platform SUPABASE_URL/SUPABASE_SERVICE_ROLE (already bound as GCP secrets above)
           fi
 
           # VTID-01225: Cognee extractor — internal ingress, Gemini LLM via API key
@@ -365,17 +362,15 @@ jobs:
             fi
           fi
 
-          # Pre-deploy: remove stale plain env vars that are migrating to secret refs.
-          # Cloud Run cannot --remove-env-vars and --update-secrets for the same key
-          # in a single deploy command, so we clean up first.
+          # Pre-deploy: remove stale env vars and secret refs from previous revisions.
           if [ "$CLOUD_RUN_SERVICE" = "gateway" ]; then
             echo "Cleaning stale env vars and secret refs before deploy..."
-            # Remove stale secret refs (LOVABLE_SUPABASE was never created in GCP SM)
+            # Remove retired LOVABLE_SUPABASE_* env vars (events now use platform SUPABASE_URL)
             gcloud run services update "$CLOUD_RUN_SERVICE" \
               --region=us-central1 \
               --project=lovable-vitana-vers1 \
-              --remove-secrets=LOVABLE_SUPABASE_URL,LOVABLE_SUPABASE_SERVICE_ROLE \
-              --quiet 2>/dev/null || echo "No stale secret refs to remove (already clean)"
+              --remove-env-vars=LOVABLE_SUPABASE_URL,LOVABLE_SUPABASE_SERVICE_ROLE \
+              --quiet 2>/dev/null || echo "No stale LOVABLE env vars to remove (already clean)"
           fi
 
           # Build deploy args

--- a/e2e/global-setup.ts
+++ b/e2e/global-setup.ts
@@ -10,12 +10,12 @@ const TEST_PASSWORD = process.env.TEST_USER_PASSWORD || 'VitanaE2eTest2026!';
  * - Creates user if not exists (provision_platform_user trigger handles app_users + user_tenants)
  * - Updates password + app_metadata if user already exists
  * - Sets exafy_admin: true so the user can switch to any role
- * - Skips gracefully if LOVABLE_SUPABASE_SERVICE_ROLE is not set (local dev fallback)
+ * - Skips gracefully if SUPABASE_SERVICE_ROLE is not set (local dev fallback)
  */
 export default async function globalSetup() {
-  const serviceRoleKey = process.env.LOVABLE_SUPABASE_SERVICE_ROLE;
+  const serviceRoleKey = process.env.SUPABASE_SERVICE_ROLE;
   if (!serviceRoleKey) {
-    console.log('[global-setup] LOVABLE_SUPABASE_SERVICE_ROLE not set — skipping test user provisioning');
+    console.log('[global-setup] SUPABASE_SERVICE_ROLE not set — skipping test user provisioning');
     return;
   }
 

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -2651,9 +2651,9 @@ async function executeLiveApiToolInner(
         const dateTo = (args.date_to as string) || '';
         const maxPrice = args.max_price !== undefined ? Number(args.max_price) : undefined;
 
-        // VTID-01270A: Events live in the Lovable Supabase (global_community_events table)
-        const LOVABLE_SUPABASE_URL = process.env.LOVABLE_SUPABASE_URL || '';
-        const LOVABLE_SUPABASE_KEY = process.env.LOVABLE_SUPABASE_SERVICE_ROLE || '';
+        // VTID-01270A: Events live in global_community_events table (platform Supabase)
+        const EVENTS_SUPABASE_URL = process.env.SUPABASE_URL || '';
+        const EVENTS_SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE || '';
         const PLATFORM_SUPABASE_URL = process.env.SUPABASE_URL;
         const PLATFORM_SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE;
 
@@ -2667,22 +2667,22 @@ async function executeLiveApiToolInner(
         // the 3s TOOL_TIMEOUT_MS.
         const fetchPromises: Promise<void>[] = [];
 
-        // Scoring engine results (populated by Lovable fetch)
+        // Scoring engine results (populated by events fetch)
         let scoredResult: ScoredEventResults | null = null;
 
-        // Primary: Fetch events from Lovable Supabase (global_community_events)
+        // Primary: Fetch events from platform Supabase (global_community_events)
         // VTID-01270A Scoring: Fetch broadly (no query ilike filter) so scoring engine
         // can rank ALL events — no event is pre-excluded at the DB level.
-        if (LOVABLE_SUPABASE_KEY && (typeFilter === 'meetup' || typeFilter === 'all')) {
+        if (EVENTS_SUPABASE_KEY && (typeFilter === 'meetup' || typeFilter === 'all')) {
           fetchPromises.push((async () => {
-            const lovableHeaders = {
+            const eventsHeaders = {
               'Content-Type': 'application/json',
-              apikey: LOVABLE_SUPABASE_KEY,
-              Authorization: `Bearer ${LOVABLE_SUPABASE_KEY}`,
+              apikey: EVENTS_SUPABASE_KEY,
+              Authorization: `Bearer ${EVENTS_SUPABASE_KEY}`,
             };
 
             const startTimeGte = dateFrom ? `${dateFrom}T00:00:00Z` : now;
-            let eventsUrl = `${LOVABLE_SUPABASE_URL}/rest/v1/global_community_events?select=id,title,description,start_time,end_time,location,virtual_link,slug,metadata&start_time=gte.${startTimeGte}&order=start_time.asc&limit=50`;
+            let eventsUrl = `${EVENTS_SUPABASE_URL}/rest/v1/global_community_events?select=id,title,description,start_time,end_time,location,virtual_link,slug,metadata&start_time=gte.${startTimeGte}&order=start_time.asc&limit=50`;
 
             if (dateTo) {
               eventsUrl += `&start_time=lte.${dateTo}T23:59:59Z`;
@@ -2692,10 +2692,10 @@ async function executeLiveApiToolInner(
             // Date range is the only hard constraint (true temporal boundary).
 
             try {
-              const resp = await fetch(eventsUrl, { method: 'GET', headers: lovableHeaders });
+              const resp = await fetch(eventsUrl, { method: 'GET', headers: eventsHeaders });
               if (resp.ok) {
                 const events = await resp.json() as EventRecord[];
-                console.log(`[VTID-01270A] search_events: ${events.length} raw results from Lovable Supabase`);
+                console.log(`[VTID-01270A] search_events: ${events.length} raw results from platform Supabase`);
 
                 // Fetch user's home_city for proximity boost
                 let userHomeCity: string | undefined;
@@ -2726,10 +2726,10 @@ async function executeLiveApiToolInner(
                 console.log(`[VTID-01270A] search_events scored: ${scoredResult.best.length} best, ${scoredResult.alternatives.length} alternatives, homeCity=${userHomeCity || 'none'}`);
               } else {
                 const body = await resp.text();
-                console.warn(`[VTID-01270A] Lovable events query failed: ${resp.status} — ${body.substring(0, 200)}`);
+                console.warn(`[VTID-01270A] events query failed: ${resp.status} — ${body.substring(0, 200)}`);
               }
             } catch (e: any) {
-              console.warn(`[VTID-01270A] Lovable events query error: ${e.message}`);
+              console.warn(`[VTID-01270A] events query error: ${e.message}`);
             }
           })());
         }

--- a/services/gateway/src/services/gemini-operator.ts
+++ b/services/gateway/src/services/gemini-operator.ts
@@ -2111,8 +2111,8 @@ async function executeCommunitySearchEvents(
 ): Promise<ToolExecutionResult> {
   const identity = threadIdentityMap.get(threadId);
 
-  const LOVABLE_SUPABASE_URL = process.env.LOVABLE_SUPABASE_URL || '';
-  const LOVABLE_SUPABASE_KEY = process.env.LOVABLE_SUPABASE_SERVICE_ROLE || '';
+  const EVENTS_SUPABASE_URL = process.env.SUPABASE_URL || '';
+  const EVENTS_SUPABASE_KEY = process.env.SUPABASE_SERVICE_ROLE || '';
 
   const query = args.query || '';
   const typeFilter = args.type_filter || 'all';
@@ -2124,21 +2124,21 @@ async function executeCommunitySearchEvents(
   const now = new Date().toISOString();
   const liveRoomResults: string[] = [];
 
-  // Scoring engine result (populated by Lovable fetch)
+  // Scoring engine result (populated by events fetch)
   let scoredResult: ScoredEventResults | null = null;
 
-  // Primary: Fetch events from Lovable Supabase (global_community_events)
+  // Primary: Fetch events from platform Supabase (global_community_events)
   // VTID-01270A Scoring: Fetch broadly (no query ilike filter) so scoring engine
   // can rank ALL events — no event is pre-excluded at the DB level.
-  if (LOVABLE_SUPABASE_KEY && (typeFilter === 'meetup' || typeFilter === 'all')) {
-    const lovableHeaders = {
+  if (EVENTS_SUPABASE_KEY && (typeFilter === 'meetup' || typeFilter === 'all')) {
+    const eventsHeaders = {
       'Content-Type': 'application/json',
-      apikey: LOVABLE_SUPABASE_KEY,
-      Authorization: `Bearer ${LOVABLE_SUPABASE_KEY}`,
+      apikey: EVENTS_SUPABASE_KEY,
+      Authorization: `Bearer ${EVENTS_SUPABASE_KEY}`,
     };
 
     const startTimeGte = dateFrom ? `${dateFrom}T00:00:00Z` : now;
-    let eventsUrl = `${LOVABLE_SUPABASE_URL}/rest/v1/global_community_events?select=id,title,description,start_time,end_time,location,virtual_link,slug,metadata&start_time=gte.${startTimeGte}&order=start_time.asc&limit=50`;
+    let eventsUrl = `${EVENTS_SUPABASE_URL}/rest/v1/global_community_events?select=id,title,description,start_time,end_time,location,virtual_link,slug,metadata&start_time=gte.${startTimeGte}&order=start_time.asc&limit=50`;
 
     if (dateTo) {
       eventsUrl += `&start_time=lte.${dateTo}T23:59:59Z`;
@@ -2150,7 +2150,7 @@ async function executeCommunitySearchEvents(
     try {
       const filterSummary = [query && `query="${query}"`, locationFilter && `loc="${locationFilter}"`, organizerFilter && `org="${organizerFilter}"`, dateFrom && `from=${dateFrom}`, dateTo && `to=${dateTo}`, maxPrice !== undefined && `maxPrice=${maxPrice}`].filter(Boolean).join(', ') || 'no filters';
       console.log(`[VTID-01270A] search_events (text): ${filterSummary}`);
-      const resp = await fetch(eventsUrl, { method: 'GET', headers: lovableHeaders });
+      const resp = await fetch(eventsUrl, { method: 'GET', headers: eventsHeaders });
       if (resp.ok) {
         const events = await resp.json() as EventRecord[];
         console.log(`[VTID-01270A] search_events (text): ${events.length} raw results`);
@@ -2184,10 +2184,10 @@ async function executeCommunitySearchEvents(
         console.log(`[VTID-01270A] search_events (text) scored: ${scoredResult.best.length} best, ${scoredResult.alternatives.length} alternatives, homeCity=${userHomeCity || 'none'}`);
       } else {
         const body = await resp.text();
-        console.warn(`[VTID-01270A] Lovable events query failed: ${resp.status} — ${body.substring(0, 200)}`);
+        console.warn(`[VTID-01270A] events query failed: ${resp.status} — ${body.substring(0, 200)}`);
       }
     } catch (e: any) {
-      console.warn(`[VTID-01270A] Lovable events query error: ${e.message}`);
+      console.warn(`[VTID-01270A] events query error: ${e.message}`);
     }
   }
 


### PR DESCRIPTION
## Summary
- **Root cause**: `LOVABLE_SUPABASE_URL` and `LOVABLE_SUPABASE_SERVICE_ROLE` GitHub Secrets were empty → every gateway deploy set these as empty env vars on Cloud Run → `search_events` tool silently skipped all event queries → ORB couldn't answer any event/meetup questions
- **Fix**: Both Supabase instances are the same DB (`inmkhvwdcuyhnxkgfvsb`). Rerouted `orb-live.ts` and `gemini-operator.ts` to use `SUPABASE_URL`/`SUPABASE_SERVICE_ROLE` (already deployed as GCP secrets). Removed all `LOVABLE_SUPABASE_*` naming from production code
- **Cleanup**: Deploy workflow now removes stale `LOVABLE_*` env vars from Cloud Run; e2e tests updated to use `SUPABASE_SERVICE_ROLE`

## Files changed
- `services/gateway/src/routes/orb-live.ts` — events fetch uses platform Supabase vars
- `services/gateway/src/services/gemini-operator.ts` — same
- `.github/workflows/EXEC-DEPLOY.yml` — removed LOVABLE env var injection, added cleanup of stale vars
- `.github/workflows/E2E-TEST-RUN.yml` — renamed env var
- `e2e/global-setup.ts` — renamed env var

## Test plan
- [ ] Deploy gateway via EXEC-DEPLOY
- [ ] Open ORB on mobile, ask "When is the next event?"
- [ ] Verify Cloud Run logs show `search_events: N raw results from platform Supabase` (non-zero)
- [ ] Verify no `LOVABLE_SUPABASE` env vars remain on Cloud Run revision

🤖 Generated with [Claude Code](https://claude.com/claude-code)