### PR TITLE
DEV-COMHU-0207 Autonomy Pulse: unified supervisor feed (PR-11)

### DIFF
--- a/services/gateway/specs/dev-screen-inventory-v1.json
+++ b/services/gateway/specs/dev-screen-inventory-v1.json
@@ -49,6 +49,7 @@
       "events",
       "vtids",
       "approvals",
+      "autonomy-pulse",
       "dev-autopilot"
     ],
     "governance": [
@@ -148,6 +149,6 @@
     ]
   },
   "screen_inventory": {
-    "total_screens": 91
+    "total_screens": 92
   }
 }

--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -5852,6 +5852,9 @@ function renderModuleContent(moduleKey, tab) {
     } else if (moduleKey === 'command-hub' && tab === 'dev-autopilot') {
         // Dev Autopilot — self-improving queue (plan: .claude/plans/quirky-jumping-fairy.md)
         container.appendChild(renderDevAutopilotView());
+    } else if (moduleKey === 'command-hub' && tab === 'autonomy-pulse') {
+        // Autonomy Pulse — unified supervisor feed across self-healing + dev-autopilot
+        container.appendChild(renderAutonomyPulseView());
     } else if (moduleKey === 'oasis' && tab === 'events') {
         // VTID-0600: OASIS Events View
         container.appendChild(renderOasisEventsView());
@@ -35617,6 +35620,310 @@ function devAutopilotEscape(s) {
         .replace(/>/g, '&gt;')
         .replace(/"/g, '&quot;')
         .replace(/'/g, '&#39;');
+}
+
+// =============================================================================
+// Autonomy Pulse — unified supervisor feed (PR-11)
+// =============================================================================
+//
+// One scrollable feed across dev-autopilot findings, pending self-heal rows,
+// and active autonomous executions. Each card surfaces the available actions
+// for that row and cross-links to the canonical source tab (dev-autopilot
+// or infrastructure/self-healing). No new editing logic here — actions
+// delegate to the existing endpoints so we don't duplicate business logic.
+
+if (!state.autonomyPulse) {
+    state.autonomyPulse = {
+        fetched: false,
+        loading: false,
+        error: null,
+        items: [],
+        counts: null,
+        filter: 'all',
+        pollerId: null,
+        actionInFlight: {},
+    };
+}
+
+function fetchAutonomyPulse() {
+    state.autonomyPulse.loading = true;
+    var headers = buildContextHeaders({});
+    var filter = state.autonomyPulse.filter || 'all';
+    return fetch('/api/v1/autonomy/pulse?filter=' + encodeURIComponent(filter) + '&limit=100', { headers })
+        .then(function (r) { return r.json(); })
+        .then(function (data) {
+            state.autonomyPulse.loading = false;
+            if (data && data.ok) {
+                state.autonomyPulse.items = data.items || [];
+                state.autonomyPulse.counts = data.counts || null;
+                state.autonomyPulse.error = null;
+                state.autonomyPulse.fetched = true;
+            } else {
+                state.autonomyPulse.error = (data && data.error) || 'Unknown error';
+            }
+            renderApp();
+        })
+        .catch(function (err) {
+            state.autonomyPulse.loading = false;
+            state.autonomyPulse.error = err.message || String(err);
+            renderApp();
+        });
+}
+
+function renderAutonomyPulseView() {
+    var container = document.createElement('div');
+    container.style.cssText = 'padding: 16px;';
+
+    if (!state.autonomyPulse.fetched && !state.autonomyPulse.loading) fetchAutonomyPulse();
+
+    // 30s poller while the tab is active
+    if (!state.autonomyPulse.pollerId) {
+        state.autonomyPulse.pollerId = setInterval(function () {
+            if (state.activeTab === 'autonomy-pulse' && state.activeModule === 'command-hub') {
+                fetchAutonomyPulse();
+            }
+        }, 30000);
+    }
+
+    // Header
+    var header = document.createElement('div');
+    header.style.cssText = 'display: flex; justify-content: space-between; align-items: center; margin-bottom: 16px;';
+    var titleWrap = document.createElement('div');
+    var title = document.createElement('h2');
+    title.textContent = 'Autonomy Pulse';
+    title.style.cssText = 'margin: 0; font-size: 20px; color: var(--text-color, #fff);';
+    titleWrap.appendChild(title);
+    var subtitle = document.createElement('div');
+    subtitle.style.cssText = 'font-size: 12px; color: var(--text-secondary, #888); margin-top: 4px;';
+    subtitle.textContent = 'Every pending decision + in-flight autonomous action, in one feed';
+    titleWrap.appendChild(subtitle);
+    header.appendChild(titleWrap);
+    var refreshBtn = document.createElement('button');
+    refreshBtn.className = 'btn btn-secondary';
+    refreshBtn.textContent = state.autonomyPulse.loading ? 'Loading…' : 'Refresh';
+    refreshBtn.disabled = !!state.autonomyPulse.loading;
+    refreshBtn.style.cssText = 'padding: 6px 14px; font-size: 13px;';
+    refreshBtn.onclick = function () { fetchAutonomyPulse(); };
+    header.appendChild(refreshBtn);
+    container.appendChild(header);
+
+    if (state.autonomyPulse.error) {
+        var errorEl = document.createElement('div');
+        errorEl.style.cssText = 'padding: 12px; background: rgba(239,68,68,0.15); border: 1px solid rgba(239,68,68,0.3); border-radius: 4px; color: #ef4444; margin-bottom: 16px;';
+        errorEl.textContent = 'Error: ' + state.autonomyPulse.error;
+        container.appendChild(errorEl);
+    }
+
+    // Counts strip
+    var counts = state.autonomyPulse.counts || { total: 0, critical: 0, warning: 0, info: 0, findings: 0, heals: 0, executions: 0 };
+    var strip = document.createElement('div');
+    strip.style.cssText = 'display: flex; gap: 12px; margin-bottom: 12px; flex-wrap: wrap;';
+    var chips = [
+        { label: 'Total', value: counts.total, color: '#aaa' },
+        { label: 'Critical', value: counts.critical, color: '#ef4444' },
+        { label: 'Warning', value: counts.warning, color: '#eab308' },
+        { label: 'Info', value: counts.info, color: '#3b82f6' },
+        { label: 'Findings', value: counts.findings, color: '#a855f7' },
+        { label: 'Heals', value: counts.heals, color: '#f97316' },
+        { label: 'Executions', value: counts.executions, color: '#22c55e' },
+    ];
+    chips.forEach(function (c) {
+        var chip = document.createElement('div');
+        chip.style.cssText = 'padding: 8px 12px; background: var(--card-bg, rgba(255,255,255,0.04)); border: 1px solid var(--border-color, rgba(255,255,255,0.08)); border-radius: 6px; min-width: 90px;';
+        chip.innerHTML = '<div style="font-size: 11px; color: var(--text-secondary, #888); text-transform: uppercase;">' + c.label + '</div>' +
+            '<div style="font-size: 20px; font-weight: 600; color: ' + c.color + ';">' + (c.value || 0) + '</div>';
+        strip.appendChild(chip);
+    });
+    container.appendChild(strip);
+
+    // Filter toolbar
+    var toolbar = document.createElement('div');
+    toolbar.style.cssText = 'display: flex; gap: 8px; align-items: center; margin-bottom: 12px;';
+    var filterLabel = document.createElement('span');
+    filterLabel.style.cssText = 'font-size: 12px; color: var(--text-secondary, #888);';
+    filterLabel.textContent = 'Filter:';
+    toolbar.appendChild(filterLabel);
+    var filterOpts = [
+        { value: 'all', label: 'All' },
+        { value: 'findings', label: 'Dev Autopilot' },
+        { value: 'heals', label: 'Self-Healing' },
+        { value: 'executions', label: 'Executions' },
+    ];
+    filterOpts.forEach(function (o) {
+        var btn = document.createElement('button');
+        btn.textContent = o.label;
+        var active = state.autonomyPulse.filter === o.value;
+        btn.style.cssText = 'padding: 5px 12px; border-radius: 3px; font-size: 12px; cursor: pointer; border: 1px solid ' + (active ? '#3b82f6' : 'var(--border-color, rgba(255,255,255,0.15))') + '; background: ' + (active ? 'rgba(59,130,246,0.15)' : 'transparent') + '; color: ' + (active ? '#3b82f6' : 'var(--text-color, #fff)') + ';';
+        btn.onclick = function () {
+            state.autonomyPulse.filter = o.value;
+            fetchAutonomyPulse();
+        };
+        toolbar.appendChild(btn);
+    });
+    container.appendChild(toolbar);
+
+    // Feed
+    var feed = document.createElement('div');
+    feed.style.cssText = 'display: flex; flex-direction: column; gap: 10px;';
+    if ((state.autonomyPulse.items || []).length === 0) {
+        var empty = document.createElement('div');
+        empty.style.cssText = 'padding: 40px; text-align: center; color: var(--text-secondary, #888); background: var(--card-bg, rgba(255,255,255,0.03)); border: 1px dashed var(--border-color, rgba(255,255,255,0.12)); border-radius: 6px;';
+        empty.innerHTML = '<div style="font-size: 48px; margin-bottom: 12px;">✓</div><div>Nothing pending. The system is quiet.</div>';
+        feed.appendChild(empty);
+    } else {
+        state.autonomyPulse.items.forEach(function (item) {
+            feed.appendChild(renderAutonomyPulseCard(item));
+        });
+    }
+    container.appendChild(feed);
+    return container;
+}
+
+function renderAutonomyPulseCard(item) {
+    var card = document.createElement('div');
+    card.style.cssText = 'background: var(--card-bg, rgba(255,255,255,0.04)); border: 1px solid var(--border-color, rgba(255,255,255,0.1)); border-left: 3px solid ' + autonomyPulseSeverityColor(item.severity) + '; border-radius: 6px; padding: 12px 14px;';
+
+    var topRow = document.createElement('div');
+    topRow.style.cssText = 'display: flex; gap: 10px; align-items: center; flex-wrap: wrap; margin-bottom: 6px;';
+
+    var sourceBadge = document.createElement('span');
+    sourceBadge.style.cssText = 'padding: 2px 8px; border-radius: 3px; font-size: 10px; text-transform: uppercase; background: rgba(255,255,255,0.06); color: ' + autonomyPulseSourceColor(item.source) + ';';
+    sourceBadge.textContent = autonomyPulseSourceLabel(item.source);
+    topRow.appendChild(sourceBadge);
+
+    var titleEl = document.createElement('span');
+    titleEl.textContent = item.title;
+    titleEl.style.cssText = 'font-weight: 600; font-size: 14px; color: var(--text-color, #fff);';
+    topRow.appendChild(titleEl);
+
+    var ageEl = document.createElement('span');
+    ageEl.style.cssText = 'margin-left: auto; font-size: 11px; color: var(--text-secondary, #888);';
+    ageEl.textContent = (item.age_minutes < 60 ? item.age_minutes + 'm' : Math.round(item.age_minutes / 60) + 'h') + ' ago';
+    topRow.appendChild(ageEl);
+
+    card.appendChild(topRow);
+
+    if (item.description) {
+        var desc = document.createElement('div');
+        desc.textContent = item.description;
+        desc.style.cssText = 'font-size: 13px; color: var(--text-color, #ddd); line-height: 1.4; margin-bottom: 8px;';
+        card.appendChild(desc);
+    }
+
+    var actionRow = document.createElement('div');
+    actionRow.style.cssText = 'display: flex; gap: 6px; flex-wrap: wrap; margin-top: 8px; align-items: center;';
+
+    (item.actions || []).forEach(function (a) {
+        var btn = document.createElement('button');
+        var spec = autonomyPulseActionSpec(a);
+        btn.textContent = spec.label;
+        var inFlight = !!state.autonomyPulse.actionInFlight[item.id + ':' + a];
+        btn.disabled = inFlight;
+        btn.style.cssText = 'padding: 4px 10px; border-radius: 3px; font-size: 12px; cursor: ' + (inFlight ? 'wait' : 'pointer') + '; border: 1px solid ' + spec.color + '; background: transparent; color: ' + spec.color + '; opacity: ' + (inFlight ? '0.6' : '1') + ';';
+        btn.onclick = function () { autonomyPulseDoAction(item, a); };
+        actionRow.appendChild(btn);
+    });
+
+    if (item.source_url) {
+        var link = document.createElement('a');
+        link.textContent = 'Open in source →';
+        link.href = item.source_url;
+        link.style.cssText = 'margin-left: auto; font-size: 12px; color: var(--text-secondary, #aaa); text-decoration: none;';
+        actionRow.appendChild(link);
+    }
+
+    card.appendChild(actionRow);
+    return card;
+}
+
+function autonomyPulseSeverityColor(s) {
+    return s === 'critical' ? '#ef4444' : s === 'warning' ? '#eab308' : '#3b82f6';
+}
+function autonomyPulseSourceColor(s) {
+    return s === 'dev_autopilot_finding' ? '#a855f7' : s === 'self_healing' ? '#f97316' : '#22c55e';
+}
+function autonomyPulseSourceLabel(s) {
+    return s === 'dev_autopilot_finding' ? 'DEV AUTOPILOT' : s === 'self_healing' ? 'SELF-HEAL' : 'EXECUTION';
+}
+function autonomyPulseActionSpec(action) {
+    switch (action) {
+        case 'approve':        return { label: 'Approve & execute', color: '#22c55e' };
+        case 'reject':         return { label: 'Reject', color: '#ef4444' };
+        case 'snooze':         return { label: 'Snooze 24h', color: '#eab308' };
+        case 'view_plan':      return { label: 'View plan', color: '#3b82f6' };
+        case 'investigate':    return { label: 'Investigate', color: '#3b82f6' };
+        case 'apply_heal':     return { label: 'Apply heal', color: '#22c55e' };
+        case 'discard_heal':   return { label: 'Discard', color: '#ef4444' };
+        case 'cancel':         return { label: 'Cancel', color: '#ef4444' };
+        case 'view_trace':     return { label: 'View trace', color: '#3b82f6' };
+        default:               return { label: action, color: 'var(--text-secondary, #aaa)' };
+    }
+}
+
+function autonomyPulseDoAction(item, action) {
+    var key = item.id + ':' + action;
+    if (state.autonomyPulse.actionInFlight[key]) return;
+
+    // Navigation-only actions — just route to source
+    if (action === 'view_plan' || action === 'view_trace' || action === 'investigate') {
+        window.location.href = item.source_url;
+        return;
+    }
+
+    // All mutating actions route through the existing endpoints. Pulse doesn't
+    // duplicate business logic — it's a forwarder.
+    state.autonomyPulse.actionInFlight[key] = true;
+    renderApp();
+    var headers = buildContextHeaders({ 'Content-Type': 'application/json' });
+    var promise;
+    if (item.source === 'dev_autopilot_finding') {
+        var findingId = item.metadata.finding_id;
+        if (action === 'approve') {
+            promise = fetch('/api/v1/dev-autopilot/findings/' + findingId + '/approve-auto-execute', { method: 'POST', headers, body: '{}' });
+        } else if (action === 'reject') {
+            promise = fetch('/api/v1/dev-autopilot/findings/' + findingId + '/reject', { method: 'POST', headers, body: '{}' });
+        } else if (action === 'snooze') {
+            promise = fetch('/api/v1/dev-autopilot/findings/' + findingId + '/snooze', { method: 'POST', headers, body: JSON.stringify({ hours: 24 }) });
+        }
+    } else if (item.source === 'autonomous_execution') {
+        var execId = item.metadata.execution_id;
+        if (action === 'cancel') {
+            promise = fetch('/api/v1/dev-autopilot/executions/' + execId + '/cancel', { method: 'POST', headers, body: '{}' });
+        }
+    }
+    // self_healing apply_heal / discard_heal — Self-Healing endpoints live
+    // under /api/v1/self-healing; route there.
+    if (item.source === 'self_healing') {
+        var vtid = item.metadata.vtid;
+        if (action === 'apply_heal') {
+            promise = fetch('/api/v1/self-healing/approve', { method: 'POST', headers, body: JSON.stringify({ vtid: vtid }) });
+        } else if (action === 'discard_heal') {
+            promise = fetch('/api/v1/self-healing/reject', { method: 'POST', headers, body: JSON.stringify({ vtid: vtid }) });
+        }
+    }
+
+    if (!promise) {
+        delete state.autonomyPulse.actionInFlight[key];
+        showToast('Unsupported action: ' + action, 'error');
+        return;
+    }
+
+    promise
+        .then(function (r) { return r.json().catch(function () { return { ok: false, error: 'Bad JSON ' + r.status }; }); })
+        .then(function (data) {
+            delete state.autonomyPulse.actionInFlight[key];
+            if (data && data.ok) {
+                // Drop the item locally for snappy UX; poller will confirm.
+                state.autonomyPulse.items = (state.autonomyPulse.items || []).filter(function (i) { return i.id !== item.id; });
+                showToast(autonomyPulseActionSpec(action).label + ' ✓', 'success');
+            } else {
+                showToast((data && data.error) || 'Action failed', 'error');
+            }
+        })
+        .catch(function (err) {
+            delete state.autonomyPulse.actionInFlight[key];
+            showToast('Network error: ' + (err.message || err), 'error');
+        });
 }
 
 function renderSelfHealingView() {

--- a/services/gateway/src/frontend/command-hub/navigation-config.js
+++ b/services/gateway/src/frontend/command-hub/navigation-config.js
@@ -53,6 +53,7 @@ export const NAVIGATION_CONFIG = [
       { key: 'events', label: 'Events' },
       { key: 'vtids', label: 'VTIDs' },
       { key: 'approvals', label: 'Approvals' },
+      { key: 'autonomy-pulse', label: 'Autonomy Pulse' },
       { key: 'dev-autopilot', label: 'Dev Autopilot' }
     ]
   },

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -229,6 +229,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const autopilotRecommendationsRouter = require('./routes/autopilot-recommendations').default;
   // Dev Autopilot — self-improving loop (plan: .claude/plans/quirky-jumping-fairy.md)
   const devAutopilotRouter = require('./routes/dev-autopilot').default;
+  // Autonomy Pulse — unified supervisor feed across self-healing + dev-autopilot
+  const autonomyPulseRouter = require('./routes/autonomy-pulse').default;
   // VTID-01250: Social Connect (AP-1305/AP-1306)
   const socialConnectRouter = require('./routes/social-connect').default;
   // Intelligent Calendar — Phase 1: Backend Calendar API
@@ -512,6 +514,7 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
 
   // Dev Autopilot — self-improving loop (plan: .claude/plans/quirky-jumping-fairy.md)
   mountRouterSync(app, '/api/v1/dev-autopilot', devAutopilotRouter, { owner: 'dev-autopilot' });
+  mountRouterSync(app, '/api/v1/autonomy', autonomyPulseRouter, { owner: 'autonomy-pulse' });
 
   // VTID-01250: Social Connect — OAuth, profile enrichment, auto-share (AP-1305/AP-1306)
   mountRouterSync(app, '/api/v1/social-accounts', socialConnectRouter, { owner: 'social-connect' });

--- a/services/gateway/src/routes/autonomy-pulse.ts
+++ b/services/gateway/src/routes/autonomy-pulse.ts
@@ -1,0 +1,383 @@
+/**
+ * Autonomy Pulse — unified supervisor feed (PR-11)
+ *
+ * One endpoint that aggregates every pending decision and in-flight
+ * autonomous action across the self-healing pipeline and the dev-autopilot
+ * pipeline. Goal: a single pane of glass so the supervisor never has to
+ * correlate across GitHub, Cloud Run, Supabase, OASIS, Self-Healing, and
+ * Dev Autopilot screens separately.
+ *
+ * Feed item types:
+ *   - pending_finding      autopilot_recommendations (dev_autopilot, new) — needs approval
+ *   - pending_heal         self_healing_log (outcome=pending) — needs diagnosis review
+ *   - active_execution     dev_autopilot_executions (cooling|running|ci|merging|deploying|verifying)
+ *
+ * Each item carries a normalized shape with:
+ *   - id, source, title, description, severity, created_at, age_minutes
+ *   - actions: which verbs the UI can present (approve/reject/snooze/cancel/...)
+ *   - source_url: deep link back to the canonical source tab
+ *   - raw: the original row (minus heavy fields) for anyone who needs detail
+ */
+
+import { Router, Request, Response } from 'express';
+
+const router = Router();
+const LOG_PREFIX = '[autonomy-pulse]';
+
+// =============================================================================
+// Auth (aligned with dev-autopilot — developer role only)
+// =============================================================================
+
+function requireDevRole(req: Request, res: Response, next: () => void) {
+  const user = (req as unknown as { user?: { role?: string; roles?: string[] } }).user;
+  const roles: string[] = user?.roles || (user?.role ? [user.role] : []);
+  if (!roles.includes('developer') && !roles.includes('admin')) {
+    return res.status(403).json({ ok: false, error: 'Autonomy Pulse requires developer role' });
+  }
+  next();
+}
+
+// =============================================================================
+// Supabase
+// =============================================================================
+
+interface SupaConfig { url: string; key: string; }
+
+function getSupabase(): SupaConfig | null {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE;
+  if (!url || !key) return null;
+  return { url, key };
+}
+
+async function supaGet<T>(s: SupaConfig, path: string): Promise<{ ok: boolean; data?: T; error?: string }> {
+  try {
+    const res = await fetch(`${s.url}${path}`, {
+      headers: { apikey: s.key, Authorization: `Bearer ${s.key}` },
+    });
+    if (!res.ok) return { ok: false, error: `${res.status}: ${await res.text()}` };
+    return { ok: true, data: (await res.json()) as T };
+  } catch (err) {
+    return { ok: false, error: String(err) };
+  }
+}
+
+// =============================================================================
+// Types (normalized feed item)
+// =============================================================================
+
+export type PulseSource = 'dev_autopilot_finding' | 'self_healing' | 'autonomous_execution';
+export type PulseSeverity = 'critical' | 'warning' | 'info';
+export type PulseAction =
+  | 'approve'            // dev_autopilot finding → approve-auto-execute
+  | 'reject'             // dev_autopilot finding → reject
+  | 'snooze'             // dev_autopilot finding → snooze 24h
+  | 'view_plan'          // dev_autopilot finding → expand plan in dev-autopilot tab
+  | 'investigate'        // self_healing → open diagnosis
+  | 'apply_heal'         // self_healing → apply fix spec
+  | 'discard_heal'       // self_healing → mark won't-fix
+  | 'cancel'             // autonomous_execution → cancel during cooldown
+  | 'view_trace';        // autonomous_execution → open lineage
+
+export interface PulseItem {
+  id: string;                          // stable across reloads: `${source}:${row.id}`
+  source: PulseSource;
+  title: string;
+  description: string;
+  severity: PulseSeverity;
+  created_at: string;
+  age_minutes: number;
+  actions: PulseAction[];
+  source_url: string;                  // deep link to the canonical tab
+  metadata: Record<string, unknown>;
+}
+
+// =============================================================================
+// Row types per source
+// =============================================================================
+
+interface FindingRow {
+  id: string;
+  title: string | null;
+  summary: string | null;
+  risk_class: 'low' | 'medium' | 'high' | null;
+  impact_score: number | null;
+  effort_score: number | null;
+  auto_exec_eligible: boolean | null;
+  domain: string | null;
+  first_seen_at: string | null;
+  seen_count: number | null;
+  spec_snapshot: Record<string, unknown> | null;
+}
+
+interface HealRow {
+  id: string;
+  vtid: string;
+  endpoint: string;
+  failure_class: string;
+  created_at: string;
+  diagnosis: Record<string, unknown> | null;
+  attempt_number: number | null;
+}
+
+interface ExecRow {
+  id: string;
+  finding_id: string;
+  status: string;
+  pr_url: string | null;
+  pr_number: number | null;
+  branch: string | null;
+  execute_after: string | null;
+  auto_fix_depth: number | null;
+  self_healing_vtid: string | null;
+  created_at: string;
+  updated_at: string | null;
+}
+
+// =============================================================================
+// Normalizers
+// =============================================================================
+
+function ageMinutes(iso: string): number {
+  const ms = Date.now() - new Date(iso).getTime();
+  return Math.max(0, Math.round(ms / 60_000));
+}
+
+function severityFromRisk(risk: string | null, impact: number | null): PulseSeverity {
+  if (risk === 'high' || (impact && impact >= 8)) return 'critical';
+  if (risk === 'medium' || (impact && impact >= 5)) return 'warning';
+  return 'info';
+}
+
+function severityFromFailureClass(fc: string): PulseSeverity {
+  const critical = new Set(['timeout', '5xx', 'crash', 'oom']);
+  return critical.has(fc) ? 'critical' : 'warning';
+}
+
+function normalizeFinding(row: FindingRow): PulseItem {
+  const created = row.first_seen_at || new Date().toISOString();
+  return {
+    id: `dev_autopilot_finding:${row.id}`,
+    source: 'dev_autopilot_finding',
+    title: row.title || 'Untitled finding',
+    description: row.summary || '',
+    severity: severityFromRisk(row.risk_class, row.impact_score),
+    created_at: created,
+    age_minutes: ageMinutes(created),
+    actions: row.auto_exec_eligible
+      ? ['approve', 'view_plan', 'snooze', 'reject']
+      : ['view_plan', 'snooze', 'reject'],
+    source_url: `/command-hub/dev-autopilot?finding_id=${row.id}`,
+    metadata: {
+      finding_id: row.id,
+      risk_class: row.risk_class,
+      impact_score: row.impact_score,
+      effort_score: row.effort_score,
+      auto_exec_eligible: row.auto_exec_eligible,
+      domain: row.domain,
+      seen_count: row.seen_count,
+      file_path: (row.spec_snapshot as { file_path?: string })?.file_path,
+    },
+  };
+}
+
+function normalizeHeal(row: HealRow): PulseItem {
+  const confidence = Number((row.diagnosis || {}).confidence || 0);
+  const description = typeof (row.diagnosis || {}).summary === 'string'
+    ? ((row.diagnosis || {}).summary as string)
+    : `${row.failure_class} failure on ${row.endpoint}`;
+  return {
+    id: `self_healing:${row.id}`,
+    source: 'self_healing',
+    title: `Self-heal needed: ${row.endpoint}`,
+    description,
+    severity: severityFromFailureClass(row.failure_class),
+    created_at: row.created_at,
+    age_minutes: ageMinutes(row.created_at),
+    actions: confidence >= 0.8
+      ? ['apply_heal', 'investigate', 'discard_heal']
+      : ['investigate', 'apply_heal', 'discard_heal'],
+    source_url: `/command-hub/infrastructure/self-healing?vtid=${encodeURIComponent(row.vtid)}`,
+    metadata: {
+      vtid: row.vtid,
+      endpoint: row.endpoint,
+      failure_class: row.failure_class,
+      attempt_number: row.attempt_number,
+      confidence,
+    },
+  };
+}
+
+function normalizeExecution(row: ExecRow): PulseItem {
+  const created = row.updated_at || row.created_at;
+  const statusLabel: Record<string, string> = {
+    cooling: 'cooling down before execution',
+    running: 'agent is executing the plan',
+    ci: 'PR awaiting CI checks',
+    merging: 'merging approved PR',
+    deploying: 'gateway deploying',
+    verifying: 'post-deploy verification',
+  };
+  const label = statusLabel[row.status] || row.status;
+  const title = row.pr_url
+    ? `Execution ${row.id.slice(0, 8)} — ${label}`
+    : `Execution ${row.id.slice(0, 8)} — ${label}`;
+  return {
+    id: `autonomous_execution:${row.id}`,
+    source: 'autonomous_execution',
+    title,
+    description: row.pr_url ? `PR: ${row.pr_url}` : `Plan execution in progress`,
+    severity: (row.auto_fix_depth || 0) > 0 ? 'warning' : 'info',
+    created_at: created,
+    age_minutes: ageMinutes(created),
+    actions: row.status === 'cooling'
+      ? ['cancel', 'view_trace']
+      : ['view_trace'],
+    source_url: `/command-hub/dev-autopilot?execution_id=${row.id}`,
+    metadata: {
+      execution_id: row.id,
+      finding_id: row.finding_id,
+      status: row.status,
+      pr_url: row.pr_url,
+      pr_number: row.pr_number,
+      branch: row.branch,
+      execute_after: row.execute_after,
+      auto_fix_depth: row.auto_fix_depth,
+      self_healing_vtid: row.self_healing_vtid,
+    },
+  };
+}
+
+// =============================================================================
+// Data fetches (parallelizable)
+// =============================================================================
+
+async function fetchFindings(s: SupaConfig, limit: number): Promise<FindingRow[]> {
+  const r = await supaGet<FindingRow[]>(
+    s,
+    `/rest/v1/autopilot_recommendations?source_type=eq.dev_autopilot&status=eq.new` +
+    `&select=id,title,summary,risk_class,impact_score,effort_score,auto_exec_eligible,domain,first_seen_at,seen_count,spec_snapshot` +
+    `&order=impact_score.desc.nullslast,first_seen_at.desc&limit=${limit}`,
+  );
+  return r.ok && r.data ? r.data : [];
+}
+
+async function fetchHeals(s: SupaConfig, limit: number): Promise<HealRow[]> {
+  const r = await supaGet<HealRow[]>(
+    s,
+    `/rest/v1/self_healing_log?outcome=eq.pending` +
+    `&select=id,vtid,endpoint,failure_class,created_at,diagnosis,attempt_number` +
+    `&order=created_at.desc&limit=${limit}`,
+  );
+  return r.ok && r.data ? r.data : [];
+}
+
+async function fetchExecutions(s: SupaConfig, limit: number): Promise<ExecRow[]> {
+  const r = await supaGet<ExecRow[]>(
+    s,
+    `/rest/v1/dev_autopilot_executions?status=in.(cooling,running,ci,merging,deploying,verifying)` +
+    `&select=id,finding_id,status,pr_url,pr_number,branch,execute_after,auto_fix_depth,self_healing_vtid,created_at,updated_at` +
+    `&order=created_at.desc&limit=${limit}`,
+  );
+  return r.ok && r.data ? r.data : [];
+}
+
+// =============================================================================
+// Pure aggregator — unit-testable (no network)
+// =============================================================================
+
+export function aggregatePulse(
+  findings: FindingRow[],
+  heals: HealRow[],
+  executions: ExecRow[],
+): PulseItem[] {
+  const items = [
+    ...findings.map(normalizeFinding),
+    ...heals.map(normalizeHeal),
+    ...executions.map(normalizeExecution),
+  ];
+  // Sort: critical first, then newer first within same severity.
+  const sevRank: Record<PulseSeverity, number> = { critical: 0, warning: 1, info: 2 };
+  items.sort((a, b) => {
+    const s = sevRank[a.severity] - sevRank[b.severity];
+    if (s !== 0) return s;
+    return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+  });
+  return items;
+}
+
+// =============================================================================
+// Routes
+// =============================================================================
+
+router.get('/pulse', requireDevRole, async (req: Request, res: Response) => {
+  const supa = getSupabase();
+  if (!supa) return res.status(500).json({ ok: false, error: 'Supabase not configured' });
+
+  const perSourceLimit = Math.min(parseInt(String(req.query.limit || '50'), 10), 200);
+  const filter = String(req.query.filter || 'all') as 'all' | 'findings' | 'heals' | 'executions';
+
+  try {
+    const [findings, heals, executions] = await Promise.all([
+      filter === 'all' || filter === 'findings'
+        ? fetchFindings(supa, perSourceLimit)
+        : Promise.resolve<FindingRow[]>([]),
+      filter === 'all' || filter === 'heals'
+        ? fetchHeals(supa, perSourceLimit)
+        : Promise.resolve<HealRow[]>([]),
+      filter === 'all' || filter === 'executions'
+        ? fetchExecutions(supa, perSourceLimit)
+        : Promise.resolve<ExecRow[]>([]),
+    ]);
+
+    const items = aggregatePulse(findings, heals, executions);
+    return res.json({
+      ok: true,
+      items,
+      counts: {
+        findings: findings.length,
+        heals: heals.length,
+        executions: executions.length,
+        total: items.length,
+        critical: items.filter((i) => i.severity === 'critical').length,
+        warning: items.filter((i) => i.severity === 'warning').length,
+        info: items.filter((i) => i.severity === 'info').length,
+      },
+      generated_at: new Date().toISOString(),
+    });
+  } catch (err) {
+    console.error(`${LOG_PREFIX} pulse fetch failed:`, err);
+    return res.status(500).json({ ok: false, error: String(err) });
+  }
+});
+
+/** GET /pulse/counts — lightweight badge counter for Command Hub nav. */
+router.get('/pulse/counts', requireDevRole, async (_req: Request, res: Response) => {
+  const supa = getSupabase();
+  if (!supa) return res.status(500).json({ ok: false, error: 'Supabase not configured' });
+
+  try {
+    const [findings, heals, executions] = await Promise.all([
+      supaGet<Array<{ id: string }>>(supa, `/rest/v1/autopilot_recommendations?source_type=eq.dev_autopilot&status=eq.new&select=id&limit=1000`),
+      supaGet<Array<{ id: string }>>(supa, `/rest/v1/self_healing_log?outcome=eq.pending&select=id&limit=1000`),
+      supaGet<Array<{ id: string }>>(supa, `/rest/v1/dev_autopilot_executions?status=in.(cooling,running,ci,merging,deploying,verifying)&select=id&limit=1000`),
+    ]);
+
+    return res.json({
+      ok: true,
+      counts: {
+        findings: findings.data?.length || 0,
+        heals: heals.data?.length || 0,
+        executions: executions.data?.length || 0,
+        total:
+          (findings.data?.length || 0) +
+          (heals.data?.length || 0) +
+          (executions.data?.length || 0),
+      },
+    });
+  } catch (err) {
+    return res.status(500).json({ ok: false, error: String(err) });
+  }
+});
+
+export default router;

--- a/services/gateway/test/autonomy-pulse.test.ts
+++ b/services/gateway/test/autonomy-pulse.test.ts
@@ -1,0 +1,182 @@
+/**
+ * Tests for the Autonomy Pulse aggregator.
+ * Focuses on the pure sort/normalize logic — full HTTP flow is an integration test.
+ */
+
+import { aggregatePulse } from '../src/routes/autonomy-pulse';
+
+const nowIso = () => new Date().toISOString();
+const agoIso = (minutes: number) => new Date(Date.now() - minutes * 60_000).toISOString();
+
+describe('aggregatePulse', () => {
+  it('returns an empty list when all sources are empty', () => {
+    expect(aggregatePulse([], [], [])).toEqual([]);
+  });
+
+  it('normalizes a dev_autopilot finding into a pulse item with the right actions', () => {
+    const items = aggregatePulse(
+      [{
+        id: 'f-1',
+        title: 'Remove dead code in foo.ts',
+        summary: 'Unused export',
+        risk_class: 'low',
+        impact_score: 4,
+        effort_score: 2,
+        auto_exec_eligible: true,
+        domain: 'services',
+        first_seen_at: nowIso(),
+        seen_count: 1,
+        spec_snapshot: { file_path: 'services/gateway/src/services/foo.ts' },
+      }],
+      [],
+      [],
+    );
+    expect(items).toHaveLength(1);
+    expect(items[0].source).toBe('dev_autopilot_finding');
+    expect(items[0].actions).toEqual(['approve', 'view_plan', 'snooze', 'reject']);
+    expect(items[0].severity).toBe('info');
+    expect(items[0].metadata.file_path).toBe('services/gateway/src/services/foo.ts');
+  });
+
+  it('high-risk findings are marked critical and drop the approve action if not auto-exec-eligible', () => {
+    const items = aggregatePulse(
+      [{
+        id: 'f-2',
+        title: 'Refactor massive file',
+        summary: 'Over 2000 lines',
+        risk_class: 'high',
+        impact_score: 9,
+        effort_score: 8,
+        auto_exec_eligible: false,
+        domain: 'services',
+        first_seen_at: nowIso(),
+        seen_count: 1,
+        spec_snapshot: null,
+      }],
+      [],
+      [],
+    );
+    expect(items[0].severity).toBe('critical');
+    expect(items[0].actions).not.toContain('approve');
+    expect(items[0].actions).toContain('view_plan');
+  });
+
+  it('normalizes self_healing rows and extracts confidence from diagnosis', () => {
+    const items = aggregatePulse(
+      [],
+      [{
+        id: 'h-1',
+        vtid: 'VTID-01999',
+        endpoint: '/api/v1/orb/health',
+        failure_class: 'timeout',
+        created_at: agoIso(5),
+        diagnosis: { confidence: 0.9, summary: 'VERTEX_PROJECT_ID drift' },
+        attempt_number: 2,
+      }],
+      [],
+    );
+    expect(items[0].source).toBe('self_healing');
+    expect(items[0].severity).toBe('critical');            // timeout → critical
+    expect(items[0].actions[0]).toBe('apply_heal');        // confidence >= 0.8
+    expect(items[0].metadata.confidence).toBe(0.9);
+  });
+
+  it('low-confidence self_healing rows put investigate before apply_heal', () => {
+    const items = aggregatePulse(
+      [],
+      [{
+        id: 'h-2',
+        vtid: 'VTID-02000',
+        endpoint: '/api/v1/other',
+        failure_class: '4xx',
+        created_at: nowIso(),
+        diagnosis: { confidence: 0.5 },
+        attempt_number: 1,
+      }],
+      [],
+    );
+    expect(items[0].actions[0]).toBe('investigate');
+  });
+
+  it('normalizes active executions and only offers cancel during cooldown', () => {
+    const items = aggregatePulse(
+      [],
+      [],
+      [{
+        id: 'e-1',
+        finding_id: 'f-1',
+        status: 'cooling',
+        pr_url: null,
+        pr_number: null,
+        branch: 'dev-autopilot/abc',
+        execute_after: nowIso(),
+        auto_fix_depth: 0,
+        self_healing_vtid: null,
+        created_at: nowIso(),
+        updated_at: nowIso(),
+      }, {
+        id: 'e-2',
+        finding_id: 'f-2',
+        status: 'deploying',
+        pr_url: 'https://github.com/x/y/pull/42',
+        pr_number: 42,
+        branch: 'dev-autopilot/def',
+        execute_after: null,
+        auto_fix_depth: 1,
+        self_healing_vtid: 'VTID-DA-def12345',
+        created_at: nowIso(),
+        updated_at: nowIso(),
+      }],
+    );
+    expect(items).toHaveLength(2);
+    const cooling = items.find((i) => i.metadata.status === 'cooling')!;
+    const deploying = items.find((i) => i.metadata.status === 'deploying')!;
+    expect(cooling.actions).toContain('cancel');
+    expect(deploying.actions).not.toContain('cancel');
+    expect(deploying.severity).toBe('warning');            // self-heal child (depth>0) → warning
+  });
+
+  it('sorts items by severity then freshness', () => {
+    const items = aggregatePulse(
+      [{
+        id: 'f-old-critical',
+        title: 'high', summary: '',
+        risk_class: 'high', impact_score: 9, effort_score: 7,
+        auto_exec_eligible: false, domain: 'x',
+        first_seen_at: agoIso(120), seen_count: 1, spec_snapshot: null,
+      }, {
+        id: 'f-new-info',
+        title: 'low', summary: '',
+        risk_class: 'low', impact_score: 3, effort_score: 2,
+        auto_exec_eligible: true, domain: 'x',
+        first_seen_at: agoIso(1), seen_count: 1, spec_snapshot: null,
+      }, {
+        id: 'f-new-critical',
+        title: 'high recent', summary: '',
+        risk_class: 'high', impact_score: 9, effort_score: 7,
+        auto_exec_eligible: false, domain: 'x',
+        first_seen_at: agoIso(5), seen_count: 1, spec_snapshot: null,
+      }],
+      [], [],
+    );
+    // Critical first, within critical the newer one wins
+    expect(items[0].id).toContain('f-new-critical');
+    expect(items[1].id).toContain('f-old-critical');
+    expect(items[2].id).toContain('f-new-info');
+  });
+
+  it('computes age_minutes from created_at', () => {
+    const [item] = aggregatePulse(
+      [{
+        id: 'f-age',
+        title: 't', summary: '',
+        risk_class: 'low', impact_score: 3, effort_score: 2,
+        auto_exec_eligible: true, domain: 'x',
+        first_seen_at: agoIso(37), seen_count: 1, spec_snapshot: null,
+      }],
+      [], [],
+    );
+    expect(item.age_minutes).toBeGreaterThanOrEqual(36);
+    expect(item.age_minutes).toBeLessThanOrEqual(38);
+  });
+});


### PR DESCRIPTION
## Summary

Single pane of glass in Command Hub. Aggregates every pending decision and in-flight autonomous action across self-healing + dev-autopilot into one scrollable feed. Supervisor no longer bounces between 5 tabs + GitHub + Cloud Run to piece together status.

## Surface

- **GET /api/v1/autonomy/pulse?filter={all|findings|heals|executions}** — normalized PulseItem[]
- **GET /api/v1/autonomy/pulse/counts** — badge counter
- **/command-hub/autonomy-pulse** — new Command Hub tab

Each item carries id, source, title, description, severity (critical/warning/info), age_minutes, actions[], source_url, metadata. Severity blends risk_class + impact + failure_class + auto_fix_depth.

## Action forwarding (no duplicated logic)

- approve/reject/snooze → /api/v1/dev-autopilot/findings/:id/*
- cancel → /api/v1/dev-autopilot/executions/:id/cancel
- apply_heal/discard_heal → /api/v1/self-healing/approve|reject
- view_plan/view_trace/investigate → navigate to source_url

## Tests

- 8 new aggregator unit tests (empty, normalization, sort, action sets)
- Full dev-autopilot + pulse sweep: **100/100 passing**
- tsc --noEmit clean
- Frontend node --check clean
- Spec validator: 17 modules / 92 screens (up from 91, order canonical)

## Test plan

- [ ] Merge + auto-deploy (commit has BOOTSTRAP-AUTONOMY-PULSE prefix)
- [ ] Visit /command-hub/autonomy-pulse → counts strip populates, feed renders 300+ items (dev-autopilot findings are already live)
- [ ] Click "Approve & execute" on a low-risk finding → item drops from feed, shows in Dev Autopilot live trace as cooling
- [ ] Click "Open in source →" → navigates to canonical tab with deep-link
- [ ] Filter toolbar works across all 4 buckets

🤖 Generated with [Claude Code](https://claude.com/claude-code)