### PR TITLE
chore: bump app.js cache-bust to surface Autonomy Pulse + Trace tabs

### DIFF
--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -12,7 +12,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260328-aura"></script>
-  <script src="/command-hub/app.js?v=20260410-selfheal-timestamps"></script>
+  <script src="/command-hub/app.js?v=20260418-autonomy-pulse-trace"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js"></script>
 </body>


### PR DESCRIPTION
Version string was from April 10; PR-11 + PR-12 landed April 17-18. Browsers kept the stale cached app.js so the new tabs were invisible.