### PR TITLE
VTID-02401: VAEA Phase 1 — observe-mode (listener + classifier + matcher + shadow drafts)

### DIFF
--- a/services/vaea/Dockerfile
+++ b/services/vaea/Dockerfile
@@ -14,7 +14,7 @@ RUN npm prune --production
 FROM node:20-alpine AS production
 
 LABEL maintainer="Vitana Platform"
-LABEL vtid="VTID-02400"
+LABEL vtid="VTID-02401"
 LABEL component="vaea-economic-actor"
 
 RUN addgroup -g 1001 -S nodejs && \
@@ -34,6 +34,8 @@ ENV NODE_ENV=production
 ENV PORT=8080
 ENV VAEA_ENABLED=false
 ENV VAEA_AUTO_EXECUTE_ENABLED=false
+ENV VAEA_PHASE_1_OBSERVE_ENABLED=false
+ENV VAEA_OBSERVE_INTERVAL_MS=300000
 
 EXPOSE 8080
 

--- a/services/vaea/manifest.json
+++ b/services/vaea/manifest.json
@@ -1,8 +1,8 @@
 {
   "name": "vaea",
-  "vtid": "VTID-02400",
-  "version": "0.1.0",
-  "description": "Vitana Autonomous Economic Actor — machine-to-machine referral agent. Phase 0 scaffold.",
+  "vtid": "VTID-02401",
+  "version": "0.2.0",
+  "description": "Vitana Autonomous Economic Actor — Phase 1 observe-mode (detect buying intent, match catalog, shadow drafts; no posting).",
   "layer": "PLATFORM",
   "module": "VAEA",
   "type": "service",
@@ -31,7 +31,9 @@
       "LOG_LEVEL",
       "VAEA_ENABLED",
       "VAEA_AUTO_EXECUTE_ENABLED",
-      "VAEA_MESH_BOUNDED_NETWORK"
+      "VAEA_MESH_BOUNDED_NETWORK",
+      "VAEA_PHASE_1_OBSERVE_ENABLED",
+      "VAEA_OBSERVE_INTERVAL_MS"
     ]
   },
   "resources": {
@@ -47,8 +49,9 @@
   },
   "governance": {
     "respect_execution_gate": true,
-    "phase": 0,
-    "loops_enabled": false,
+    "phase": 1,
+    "loops_enabled": true,
+    "loops_default_off": true,
     "auto_execute_default": false
   }
 }

--- a/services/vaea/package-lock.json
+++ b/services/vaea/package-lock.json
@@ -1,12 +1,12 @@
 {
   "name": "vaea",
-  "version": "0.1.0",
+  "version": "0.2.0",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "vaea",
-      "version": "0.1.0",
+      "version": "0.2.0",
       "dependencies": {
         "@supabase/supabase-js": "^2.39.0",
         "dotenv": "^16.3.1",

--- a/services/vaea/package.json
+++ b/services/vaea/package.json
@@ -1,7 +1,7 @@
 {
   "name": "vaea",
-  "version": "0.1.0",
-  "description": "VTID-02400: Vitana Autonomous Economic Actor — referral agent (Phase 0 scaffold)",
+  "version": "0.2.0",
+  "description": "VTID-02401: Vitana Autonomous Economic Actor — Phase 1 observe-mode (classifier + matcher + shadow drafts)",
   "main": "dist/index.js",
   "scripts": {
     "build": "tsc",

--- a/services/vaea/src/classifier/intent-classifier.ts
+++ b/services/vaea/src/classifier/intent-classifier.ts
@@ -1,0 +1,112 @@
+/**
+ * v0 heuristic classifier — zero LLM calls, zero external deps.
+ *
+ * Good enough to filter noise in Phase 1. Phase 2+ replaces with Brain-side
+ * semantic classification. Keep scoring axes identical so the swap is trivial.
+ */
+
+export interface ClassifierInput {
+  body: string;
+  author_external_id?: string;
+  already_has_reply?: boolean;
+  expertise_zones?: string[];
+}
+
+export interface ClassifierOutput {
+  is_purchase_intent: number;
+  topic_match: number;
+  urgency: number;
+  already_answered: number;
+  poster_fit: number;
+  combined_score: number;
+  extracted_topics: string[];
+  classifier_version: string;
+}
+
+const CLASSIFIER_VERSION = 'v0-heuristic';
+
+const PURCHASE_PHRASES = [
+  /\bwhere (?:can|do) (?:i|you) (?:buy|get|find|order)\b/i,
+  /\banyone (?:know|have) (?:a )?(?:good )?recommendation/i,
+  /\blooking for (?:a |an )?(?:good |reliable |trusted )?\w+/i,
+  /\bcan (?:anyone|someone) recommend\b/i,
+  /\bwhat\'?s the best\b/i,
+  /\bwhich (?:one )?should i\b/i,
+  /\bany (?:good )?(?:recommendations?|suggestions?)\b/i,
+  /\bi (?:need|want) to buy\b/i,
+  /\bhow much (?:does|is|for)\b/i,
+  /\bwhere to (?:get|buy|find)\b/i,
+];
+
+const URGENCY_PHRASES = [
+  /\burgent\b/i,
+  /\btoday\b/i,
+  /\btonight\b/i,
+  /\bthis week\b/i,
+  /\basap\b/i,
+  /\b(?:quickly|soon)\b/i,
+];
+
+export function classifyIntent(input: ClassifierInput): ClassifierOutput {
+  const body = input.body.trim();
+  const lower = body.toLowerCase();
+
+  const is_purchase_intent = score(PURCHASE_PHRASES.some((re) => re.test(body)) ? 0.9 : lower.includes('?') ? 0.25 : 0.05);
+  const urgency = score(URGENCY_PHRASES.some((re) => re.test(body)) ? 0.8 : 0.2);
+  const already_answered = score(input.already_has_reply ? 0.8 : 0.1);
+  const poster_fit = score(input.author_external_id ? 0.7 : 0.5);
+
+  const extracted_topics = extractTopics(body);
+  const zones = (input.expertise_zones || []).map((z) => z.toLowerCase());
+  const topic_match = zones.length === 0
+    ? score(0.5) // no expertise zones configured → neutral
+    : score(
+        extracted_topics.some((t) => zones.some((z) => t.includes(z) || z.includes(t)))
+          ? 0.85
+          : 0.15,
+      );
+
+  // Weighted combo — tweak in Phase 2 once we have outcome data.
+  const combined_score = score(
+    is_purchase_intent * 0.45 +
+      topic_match * 0.25 +
+      (1 - already_answered) * 0.15 +
+      poster_fit * 0.1 +
+      urgency * 0.05,
+  );
+
+  return {
+    is_purchase_intent,
+    topic_match,
+    urgency,
+    already_answered,
+    poster_fit,
+    combined_score,
+    extracted_topics,
+    classifier_version: CLASSIFIER_VERSION,
+  };
+}
+
+function score(v: number): number {
+  if (Number.isNaN(v)) return 0;
+  return Math.max(0, Math.min(1, Number(v.toFixed(2))));
+}
+
+const STOP_WORDS = new Set([
+  'the','a','an','and','or','but','if','then','is','are','was','were','be','been','being',
+  'have','has','had','do','does','did','i','you','he','she','it','we','they','me','him','her',
+  'us','them','my','your','his','its','our','their','this','that','these','those','there','here',
+  'of','to','in','on','for','with','at','by','from','as','about','into','like','through',
+  'where','what','which','who','how','why','when','can','could','would','should','will','may',
+  'any','some','good','best','buy','get','find','know','recommend','recommendation','looking',
+  'need','want','anyone','someone','people','thing','things',
+]);
+
+function extractTopics(body: string): string[] {
+  const tokens = body
+    .toLowerCase()
+    .replace(/[^a-z0-9\s-]/g, ' ')
+    .split(/\s+/)
+    .filter((t) => t.length >= 4 && !STOP_WORDS.has(t));
+  return Array.from(new Set(tokens)).slice(0, 8);
+}

--- a/services/vaea/src/composer/draft-composer.ts
+++ b/services/vaea/src/composer/draft-composer.ts
@@ -1,0 +1,48 @@
+import type { CatalogRow } from '../matcher/catalog-matcher';
+
+export interface ComposerInput {
+  question_body: string;
+  match: CatalogRow;
+  user_disclosure: string;
+  personal_voice_sample?: string;
+}
+
+export interface ComposerOutput {
+  reply_body: string;
+  includes_disclosure: boolean;
+  includes_non_affiliate_alt: boolean;
+  composer_version: string;
+}
+
+const COMPOSER_VERSION = 'v0-template';
+
+export function composeDraft(input: ComposerInput): ComposerOutput {
+  const { match, user_disclosure } = input;
+  const note = match.personal_note?.trim();
+  const title = match.title;
+  const url = match.affiliate_url;
+
+  const lead = note
+    ? note
+    : match.tier === 'own'
+      ? `${title} is something I put together for exactly this.`
+      : match.vetting_status === 'endorsed'
+        ? `I've tried ${title} and it holds up.`
+        : match.vetting_status === 'tried'
+          ? `I've used ${title} — worth a look.`
+          : `${title} is worth looking at.`;
+
+  const includeAlt = match.tier === 'affiliate_network';
+  const altLine = includeAlt
+    ? " If you'd rather skip the affiliate link, search the product name directly and buy from the retailer."
+    : '';
+
+  const reply_body = `${lead} Link: ${url}\n\n${user_disclosure}${altLine}`;
+
+  return {
+    reply_body,
+    includes_disclosure: true,
+    includes_non_affiliate_alt: includeAlt,
+    composer_version: COMPOSER_VERSION,
+  };
+}

--- a/services/vaea/src/index.ts
+++ b/services/vaea/src/index.ts
@@ -1,23 +1,24 @@
 /**
- * VTID-02400: Vitana Autonomous Economic Actor (VAEA) — Phase 0 scaffold.
+ * VTID-02400 / VTID-02401: Vitana Autonomous Economic Actor (VAEA).
  *
- * Machine-to-machine referral agent. Phase 0 ships:
- *   - service skeleton (Express + /alive + /metrics)
- *   - vaea_config + vaea_referral_catalog tables (via migration)
- *   - three-switch model (receive / give / make-money goal)
- *   - feature flags (VAEA_ENABLED, VAEA_AUTO_EXECUTE_ENABLED)
+ * Phase 0 shipped: service skeleton, config + catalog tables, three switches.
+ * Phase 1 (this): observe-mode loop — ingest messages from listener channels,
+ * classify buying intent, match against user's catalog, write shadow drafts.
  *
- * NO loops yet. Listeners, classifier, mesh broker, playbooks arrive in Phase 1+.
+ * Still no external posting. Still no mesh. Loop gated behind
+ * VAEA_PHASE_1_OBSERVE_ENABLED, which is itself gated behind VAEA_ENABLED.
  */
 
 import express, { Request, Response } from 'express';
 import { config as dotenvConfig } from 'dotenv';
 import { readFeatureFlags } from './lib/feature-flags';
 import { startAgentRegistration } from './lib/agents-registry-client';
+import { getSupabase } from './lib/supabase';
+import { runObservePass, getObserveMetrics } from './loops/observe';
 
 dotenvConfig();
 
-const VTID = 'VTID-02400';
+const VTID = 'VTID-02401';
 const PORT = parseInt(process.env.PORT || '8080', 10);
 
 const app = express();
@@ -25,6 +26,7 @@ app.use(express.json());
 
 const startedAt = new Date().toISOString();
 let stopAgentRegistration: (() => void) | null = null;
+let observeTimer: NodeJS.Timeout | null = null;
 
 app.get('/alive', (_req: Request, res: Response) => {
   const flags = readFeatureFlags();
@@ -32,9 +34,10 @@ app.get('/alive', (_req: Request, res: Response) => {
     status: 'healthy',
     vtid: VTID,
     service: 'vaea',
-    phase: 0,
+    phase: 1,
     started_at: startedAt,
     feature_flags: flags,
+    observe_metrics: getObserveMetrics(),
   });
 });
 
@@ -50,9 +53,9 @@ app.get('/metrics', (_req: Request, res: Response) => {
   res.json({
     vtid: VTID,
     service: 'vaea',
-    phase: 0,
-    loops_enabled: false,
+    phase: 1,
     feature_flags: readFeatureFlags(),
+    observe_metrics: getObserveMetrics(),
     environment: {
       supabase_url_set: Boolean(process.env.SUPABASE_URL),
       gateway_url: process.env.GATEWAY_URL || 'not set',
@@ -60,8 +63,49 @@ app.get('/metrics', (_req: Request, res: Response) => {
   });
 });
 
+app.post('/admin/observe/run-once', async (_req: Request, res: Response) => {
+  const flags = readFeatureFlags();
+  if (!flags.vaeaEnabled) {
+    res.status(423).json({ ok: false, error: 'VAEA_ENABLED=false' });
+    return;
+  }
+  try {
+    const m = await runObservePass(getSupabase());
+    res.json({ ok: true, metrics: m });
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    res.status(500).json({ ok: false, error: msg });
+  }
+});
+
+function startObserveLoop(): void {
+  const flags = readFeatureFlags();
+  if (!flags.vaeaEnabled || !flags.observeEnabled) {
+    console.log(`[${VTID}] Observe loop disabled (vaeaEnabled=${flags.vaeaEnabled}, observeEnabled=${flags.observeEnabled})`);
+    return;
+  }
+
+  const interval = Math.max(60_000, flags.observeIntervalMs);
+  console.log(`[${VTID}] Starting observe loop — interval ${interval}ms`);
+
+  const tick = async (): Promise<void> => {
+    try {
+      await runObservePass(getSupabase());
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[${VTID}] observe pass threw: ${msg}`);
+    }
+  };
+
+  void tick();
+  observeTimer = setInterval(() => {
+    void tick();
+  }, interval);
+  if (typeof observeTimer.unref === 'function') observeTimer.unref();
+}
+
 async function main(): Promise<void> {
-  console.log(`[${VTID}] VAEA Phase 0 scaffold starting...`);
+  console.log(`[${VTID}] VAEA Phase 1 starting...`);
   const flags = readFeatureFlags();
   console.log(`[${VTID}] Feature flags:`, flags);
 
@@ -81,19 +125,22 @@ async function main(): Promise<void> {
       gatewayUrl: process.env.GATEWAY_URL || '',
       agentId: 'vaea',
       displayName: 'Vitana Autonomous Economic Actor',
-      description: 'M2M referral agent — Phase 0 scaffold, no loops yet',
+      description: 'M2M referral agent — Phase 1 observe mode (detects, scores, drafts; no posting)',
       tier: 'service',
       role: 'economic-actor',
       sourcePath: 'services/vaea/',
       healthEndpoint: '/alive',
-      metadata: { vtid: VTID, phase: 0 },
+      metadata: { vtid: VTID, phase: 1 },
     });
   } catch (err) {
     console.warn(`[${VTID}] agents-registry self-registration failed (non-fatal):`, err);
   }
 
+  startObserveLoop();
+
   const shutdown = (signal: string): void => {
     console.log(`[${VTID}] Received ${signal}, shutting down...`);
+    if (observeTimer) clearInterval(observeTimer);
     if (stopAgentRegistration) {
       try { stopAgentRegistration(); } catch { /* best-effort */ }
     }

--- a/services/vaea/src/lib/feature-flags.ts
+++ b/services/vaea/src/lib/feature-flags.ts
@@ -2,6 +2,8 @@ export interface FeatureFlags {
   vaeaEnabled: boolean;
   vaeaAutoExecuteEnabled: boolean;
   meshBoundedNetwork: boolean;
+  observeEnabled: boolean;
+  observeIntervalMs: number;
 }
 
 export function readFeatureFlags(): FeatureFlags {
@@ -9,5 +11,7 @@ export function readFeatureFlags(): FeatureFlags {
     vaeaEnabled: process.env.VAEA_ENABLED === 'true',
     vaeaAutoExecuteEnabled: process.env.VAEA_AUTO_EXECUTE_ENABLED === 'true',
     meshBoundedNetwork: process.env.VAEA_MESH_BOUNDED_NETWORK !== 'false',
+    observeEnabled: process.env.VAEA_PHASE_1_OBSERVE_ENABLED === 'true',
+    observeIntervalMs: parseInt(process.env.VAEA_OBSERVE_INTERVAL_MS || '300000', 10),
   };
 }

--- a/services/vaea/src/listeners/index.ts
+++ b/services/vaea/src/listeners/index.ts
@@ -1,0 +1,16 @@
+import { MaxinaAdapter } from './maxina-adapter';
+import type { ListenerAdapter } from './types';
+
+const registry: Record<string, ListenerAdapter> = {
+  maxina: new MaxinaAdapter(),
+};
+
+export function getListenerAdapter(platform: string): ListenerAdapter | null {
+  return registry[platform] || null;
+}
+
+export function registerListenerAdapter(adapter: ListenerAdapter): void {
+  registry[adapter.platform] = adapter;
+}
+
+export type { ListenerAdapter, IncomingMessage, IngestResult, ListenerChannelRecord } from './types';

--- a/services/vaea/src/listeners/maxina-adapter.ts
+++ b/services/vaea/src/listeners/maxina-adapter.ts
@@ -1,0 +1,81 @@
+/**
+ * Maxina listener adapter — stub implementation.
+ *
+ * Maxina's technical shape (own app, Slack-alike, forum, etc.) is not yet
+ * finalized. This adapter uses a generic "polling REST endpoint" contract
+ * so we can flip to whatever Maxina ends up being without touching the
+ * observe loop. Config shape:
+ *
+ *   {
+ *     "endpoint": "https://maxina.example.com/api/channels/{channel_key}/messages",
+ *     "auth_header": "Bearer <token>",
+ *     "since_param": "since"
+ *   }
+ *
+ * Expected response: { messages: IncomingMessage[], next_cursor?: string }
+ * If the endpoint isn't set, the adapter returns an empty result — safe
+ * no-op that lets Phase 1 ship before Maxina's API exists.
+ */
+
+import fetch from 'node-fetch';
+import type { IngestResult, ListenerAdapter, ListenerChannelRecord, IncomingMessage } from './types';
+
+interface MaxinaConfig {
+  endpoint?: string;
+  auth_header?: string;
+  since_param?: string;
+  max_messages?: number;
+}
+
+export class MaxinaAdapter implements ListenerAdapter {
+  platform = 'maxina';
+
+  async ingest(channel: ListenerChannelRecord): Promise<IngestResult> {
+    const cfg = (channel.config || {}) as MaxinaConfig;
+
+    if (!cfg.endpoint) {
+      return { messages: [], next_cursor: channel.last_ingest_cursor };
+    }
+
+    const url = new URL(cfg.endpoint.replace('{channel_key}', encodeURIComponent(channel.channel_key)));
+    if (channel.last_ingest_cursor) {
+      url.searchParams.set(cfg.since_param || 'since', channel.last_ingest_cursor);
+    }
+    if (cfg.max_messages) {
+      url.searchParams.set('limit', String(cfg.max_messages));
+    }
+
+    const headers: Record<string, string> = { Accept: 'application/json' };
+    if (cfg.auth_header) headers['Authorization'] = cfg.auth_header;
+
+    const res = await fetch(url.toString(), { headers });
+    if (!res.ok) {
+      throw new Error(`maxina ingest ${res.status}: ${await res.text().catch(() => '')}`);
+    }
+
+    const body = (await res.json()) as { messages?: unknown[]; next_cursor?: string };
+    const messages: IncomingMessage[] = Array.isArray(body.messages)
+      ? body.messages.map(normalizeMessage).filter((m): m is IncomingMessage => m !== null)
+      : [];
+
+    return { messages, next_cursor: body.next_cursor ?? channel.last_ingest_cursor };
+  }
+}
+
+function normalizeMessage(raw: unknown): IncomingMessage | null {
+  if (!raw || typeof raw !== 'object') return null;
+  const r = raw as Record<string, unknown>;
+  const id = typeof r.id === 'string' ? r.id : typeof r.external_message_id === 'string' ? r.external_message_id : null;
+  const body = typeof r.body === 'string' ? r.body : typeof r.text === 'string' ? r.text : null;
+  if (!id || !body) return null;
+
+  return {
+    external_message_id: id,
+    platform: 'maxina',
+    author_handle: typeof r.author_handle === 'string' ? r.author_handle : typeof r.author === 'string' ? r.author : undefined,
+    author_external_id: typeof r.author_id === 'string' ? r.author_id : undefined,
+    body,
+    url: typeof r.url === 'string' ? r.url : undefined,
+    posted_at: typeof r.posted_at === 'string' ? r.posted_at : typeof r.created_at === 'string' ? r.created_at : undefined,
+  };
+}

--- a/services/vaea/src/listeners/types.ts
+++ b/services/vaea/src/listeners/types.ts
@@ -1,0 +1,30 @@
+export interface IncomingMessage {
+  external_message_id: string;
+  platform: string;
+  author_handle?: string;
+  author_external_id?: string;
+  body: string;
+  url?: string;
+  posted_at?: string;
+}
+
+export interface ListenerChannelRecord {
+  id: string;
+  tenant_id: string;
+  user_id: string;
+  platform: string;
+  channel_key: string;
+  config: Record<string, unknown>;
+  last_ingest_cursor: string | null;
+  dry_run: boolean;
+}
+
+export interface IngestResult {
+  messages: IncomingMessage[];
+  next_cursor?: string | null;
+}
+
+export interface ListenerAdapter {
+  platform: string;
+  ingest(channel: ListenerChannelRecord): Promise<IngestResult>;
+}

--- a/services/vaea/src/loops/observe.ts
+++ b/services/vaea/src/loops/observe.ts
@@ -1,0 +1,236 @@
+/**
+ * Observe loop — Phase 1.
+ *
+ * Pulls messages from each active listener channel, classifies them,
+ * writes detected questions to DB, and (if the score is high enough)
+ * matches against the user's catalog + composes a shadow draft.
+ *
+ * ZERO external posting. ZERO mesh. Drafts stay in `shadow` status until
+ * Phase 2 introduces one-tap approval.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getListenerAdapter, type ListenerChannelRecord, type IncomingMessage } from '../listeners';
+import { classifyIntent } from '../classifier/intent-classifier';
+import { matchCatalog } from '../matcher/catalog-matcher';
+import { composeDraft } from '../composer/draft-composer';
+
+const SCORE_THRESHOLD = 0.5;
+
+interface UserVaeaConfig {
+  user_id: string;
+  tenant_id: string;
+  give_recommendations: boolean;
+  expertise_zones: string[];
+  disclosure_text: string;
+  excluded_categories: string[];
+}
+
+interface LoopMetrics {
+  channels_scanned: number;
+  messages_ingested: number;
+  questions_scored: number;
+  drafts_created: number;
+  errors: number;
+  last_run_at: string | null;
+}
+
+const metrics: LoopMetrics = {
+  channels_scanned: 0,
+  messages_ingested: 0,
+  questions_scored: 0,
+  drafts_created: 0,
+  errors: 0,
+  last_run_at: null,
+};
+
+export function getObserveMetrics(): LoopMetrics {
+  return { ...metrics };
+}
+
+export async function runObservePass(supabase: SupabaseClient): Promise<LoopMetrics> {
+  metrics.last_run_at = new Date().toISOString();
+
+  const { data: channels, error } = await supabase
+    .from('vaea_listener_channels')
+    .select('id, tenant_id, user_id, platform, channel_key, config, last_ingest_cursor, dry_run')
+    .eq('active', true);
+
+  if (error) {
+    console.error('[vaea-observe] channel fetch failed:', error.message);
+    metrics.errors += 1;
+    return metrics;
+  }
+
+  for (const channel of (channels || []) as ListenerChannelRecord[]) {
+    metrics.channels_scanned += 1;
+    try {
+      await processChannel(supabase, channel);
+    } catch (err) {
+      metrics.errors += 1;
+      const msg = err instanceof Error ? err.message : String(err);
+      console.error(`[vaea-observe] channel ${channel.id} failed: ${msg}`);
+      await supabase
+        .from('vaea_listener_channels')
+        .update({ last_error: msg.slice(0, 500) })
+        .eq('id', channel.id);
+    }
+  }
+
+  return metrics;
+}
+
+async function processChannel(
+  supabase: SupabaseClient,
+  channel: ListenerChannelRecord,
+): Promise<void> {
+  const adapter = getListenerAdapter(channel.platform);
+  if (!adapter) {
+    console.warn(`[vaea-observe] no adapter for platform '${channel.platform}'`);
+    return;
+  }
+
+  const result = await adapter.ingest(channel);
+  if (result.messages.length === 0) {
+    await supabase
+      .from('vaea_listener_channels')
+      .update({ last_ingested_at: new Date().toISOString(), last_error: null })
+      .eq('id', channel.id);
+    return;
+  }
+
+  metrics.messages_ingested += result.messages.length;
+
+  const userConfig = await loadUserConfig(supabase, channel.tenant_id, channel.user_id);
+  if (!userConfig) {
+    console.warn(`[vaea-observe] no vaea_config for user ${channel.user_id}, skipping`);
+    return;
+  }
+
+  for (const msg of result.messages) {
+    await processMessage(supabase, channel, msg, userConfig);
+  }
+
+  await supabase
+    .from('vaea_listener_channels')
+    .update({
+      last_ingested_at: new Date().toISOString(),
+      last_ingest_cursor: result.next_cursor ?? channel.last_ingest_cursor,
+      last_error: null,
+    })
+    .eq('id', channel.id);
+}
+
+async function processMessage(
+  supabase: SupabaseClient,
+  channel: ListenerChannelRecord,
+  msg: IncomingMessage,
+  userConfig: UserVaeaConfig,
+): Promise<void> {
+  const scoring = classifyIntent({
+    body: msg.body,
+    author_external_id: msg.author_external_id,
+    expertise_zones: userConfig.expertise_zones,
+  });
+
+  metrics.questions_scored += 1;
+
+  const shouldDraft =
+    scoring.combined_score >= SCORE_THRESHOLD && userConfig.give_recommendations;
+
+  const { data: detected, error: detectErr } = await supabase
+    .from('vaea_detected_questions')
+    .insert({
+      tenant_id: channel.tenant_id,
+      user_id: channel.user_id,
+      channel_id: channel.id,
+      external_message_id: msg.external_message_id,
+      platform: msg.platform,
+      author_handle: msg.author_handle,
+      author_external_id: msg.author_external_id,
+      message_body: msg.body,
+      message_url: msg.url,
+      posted_at: msg.posted_at,
+      is_purchase_intent: scoring.is_purchase_intent,
+      topic_match: scoring.topic_match,
+      urgency: scoring.urgency,
+      already_answered: scoring.already_answered,
+      poster_fit: scoring.poster_fit,
+      combined_score: scoring.combined_score,
+      classifier_version: scoring.classifier_version,
+      extracted_topics: scoring.extracted_topics,
+      disposition: shouldDraft ? 'drafted' : 'below_threshold',
+      disposition_reason: shouldDraft
+        ? null
+        : !userConfig.give_recommendations
+          ? 'give_recommendations=false'
+          : `score ${scoring.combined_score} < threshold ${SCORE_THRESHOLD}`,
+    })
+    .select('id')
+    .single();
+
+  if (detectErr) {
+    if (detectErr.code === '23505') return; // duplicate external_message_id, already processed
+    throw new Error(`insert detected_question: ${detectErr.message}`);
+  }
+
+  if (!shouldDraft || !detected) return;
+
+  const matches = await matchCatalog(supabase, {
+    tenant_id: channel.tenant_id,
+    user_id: channel.user_id,
+    topics: scoring.extracted_topics,
+  });
+
+  if (matches.length === 0) {
+    await supabase
+      .from('vaea_detected_questions')
+      .update({ disposition: 'skipped', disposition_reason: 'no catalog match' })
+      .eq('id', detected.id);
+    return;
+  }
+
+  const top = matches[0];
+  const draft = composeDraft({
+    question_body: msg.body,
+    match: top.item,
+    user_disclosure: userConfig.disclosure_text,
+  });
+
+  const { error: draftErr } = await supabase.from('vaea_reply_drafts').insert({
+    tenant_id: channel.tenant_id,
+    user_id: channel.user_id,
+    detected_question_id: detected.id,
+    catalog_item_id: top.item.id,
+    reply_body: draft.reply_body,
+    reply_includes_disclosure: draft.includes_disclosure,
+    reply_includes_non_affiliate_alt: draft.includes_non_affiliate_alt,
+    match_reason: top.reason,
+    match_score: top.score,
+    match_tier: top.item.tier,
+    status: 'shadow',
+    composer_version: draft.composer_version,
+  });
+
+  if (draftErr) {
+    throw new Error(`insert reply_draft: ${draftErr.message}`);
+  }
+
+  metrics.drafts_created += 1;
+}
+
+async function loadUserConfig(
+  supabase: SupabaseClient,
+  tenant_id: string,
+  user_id: string,
+): Promise<UserVaeaConfig | null> {
+  const { data, error } = await supabase
+    .from('vaea_config')
+    .select('user_id, tenant_id, give_recommendations, expertise_zones, disclosure_text, excluded_categories')
+    .eq('tenant_id', tenant_id)
+    .eq('user_id', user_id)
+    .maybeSingle();
+
+  if (error || !data) return null;
+  return data as UserVaeaConfig;
+}

--- a/services/vaea/src/matcher/catalog-matcher.ts
+++ b/services/vaea/src/matcher/catalog-matcher.ts
@@ -1,0 +1,91 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export interface CatalogRow {
+  id: string;
+  tenant_id: string;
+  user_id: string;
+  tier: 'own' | 'vetted_partner' | 'affiliate_network';
+  category: string;
+  title: string;
+  description: string | null;
+  affiliate_url: string;
+  affiliate_network: string | null;
+  commission_percent: number | null;
+  personal_note: string | null;
+  vetting_status: 'unvetted' | 'tried' | 'endorsed';
+}
+
+export interface MatchInput {
+  tenant_id: string;
+  user_id: string;
+  topics: string[];
+}
+
+export interface MatchResult {
+  item: CatalogRow;
+  score: number;
+  reason: string;
+}
+
+const TIER_WEIGHT: Record<CatalogRow['tier'], number> = {
+  own: 1.0,
+  vetted_partner: 0.75,
+  affiliate_network: 0.5,
+};
+
+const VETTING_WEIGHT: Record<CatalogRow['vetting_status'], number> = {
+  endorsed: 1.0,
+  tried: 0.8,
+  unvetted: 0.5,
+};
+
+export async function matchCatalog(
+  supabase: SupabaseClient,
+  input: MatchInput,
+): Promise<MatchResult[]> {
+  const { data, error } = await supabase
+    .from('vaea_referral_catalog')
+    .select('id, tenant_id, user_id, tier, category, title, description, affiliate_url, affiliate_network, commission_percent, personal_note, vetting_status')
+    .eq('tenant_id', input.tenant_id)
+    .eq('user_id', input.user_id)
+    .eq('active', true);
+
+  if (error) {
+    throw new Error(`catalog fetch failed: ${error.message}`);
+  }
+
+  const rows = (data || []) as CatalogRow[];
+  if (rows.length === 0) return [];
+
+  const topicsLower = input.topics.map((t) => t.toLowerCase());
+
+  const scored: MatchResult[] = rows.map((item) => {
+    const haystack = [
+      item.category.toLowerCase(),
+      item.title.toLowerCase(),
+      (item.description || '').toLowerCase(),
+    ].join(' ');
+
+    let hits = 0;
+    const matchedTopics: string[] = [];
+    for (const t of topicsLower) {
+      if (haystack.includes(t)) {
+        hits += 1;
+        matchedTopics.push(t);
+      }
+    }
+    const topicScore = topicsLower.length === 0 ? 0 : Math.min(1, hits / Math.max(1, topicsLower.length));
+
+    const score = Number(
+      (topicScore * 0.6 + TIER_WEIGHT[item.tier] * 0.25 + VETTING_WEIGHT[item.vetting_status] * 0.15).toFixed(2),
+    );
+
+    const reason = hits > 0
+      ? `matched topics: ${matchedTopics.join(', ')} · tier=${item.tier} · vetting=${item.vetting_status}`
+      : `no topic overlap · tier=${item.tier} · vetting=${item.vetting_status}`;
+
+    return { item, score, reason };
+  });
+
+  return scored.filter((m) => m.score > 0.2).sort((a, b) => b.score - a.score);
+}

--- a/supabase/migrations/20260418040000_vtid_02401_vaea_phase1_observe.sql
+++ b/supabase/migrations/20260418040000_vtid_02401_vaea_phase1_observe.sql
@@ -1,0 +1,229 @@
+-- Migration: 20260418040000_vtid_02401_vaea_phase1_observe.sql
+-- Purpose: VTID-02401 VAEA Phase 1 — observe-mode foundation.
+--          Adds listener channels, detected questions, and reply drafts.
+--          Zero posting. Zero mesh. Classifier + matcher run, results land
+--          in DB for the Business Hub to surface (wiring comes later).
+
+-- ===========================================================================
+-- 1. VAEA_LISTENER_CHANNELS — per-user channel configs
+-- ===========================================================================
+
+CREATE TABLE IF NOT EXISTS public.vaea_listener_channels (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL,
+  user_id UUID NOT NULL,
+
+  platform TEXT NOT NULL                             -- 'maxina','slack','discord','telegram','reddit','custom'
+    CHECK (platform IN ('maxina','slack','discord','telegram','reddit','custom')),
+  channel_key TEXT NOT NULL,                         -- platform-specific channel ID
+  display_name TEXT,
+
+  -- Adapter config — polling URL, auth token ref, webhook path, etc.
+  config JSONB NOT NULL DEFAULT '{}'::jsonb,
+
+  -- Per-channel autonomy override (null = use vaea_config.autonomy_default)
+  autonomy TEXT
+    CHECK (autonomy IS NULL OR autonomy IN ('silent','draft_to_user','one_tap_approve','auto_post')),
+
+  -- Lifecycle
+  active BOOLEAN NOT NULL DEFAULT TRUE,
+  last_ingested_at TIMESTAMPTZ,
+  last_ingest_cursor TEXT,                           -- opaque cursor for resumable polling
+  last_error TEXT,
+
+  -- Dry-run shadow mode — classifier runs but drafts are marked shadow=true
+  dry_run BOOLEAN NOT NULL DEFAULT TRUE,
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  UNIQUE (tenant_id, user_id, platform, channel_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_vaea_channels_user_active
+  ON public.vaea_listener_channels (tenant_id, user_id, active)
+  WHERE active = TRUE;
+
+CREATE INDEX IF NOT EXISTS idx_vaea_channels_platform
+  ON public.vaea_listener_channels (platform, active)
+  WHERE active = TRUE;
+
+DROP TRIGGER IF EXISTS trg_vaea_channels_updated ON public.vaea_listener_channels;
+CREATE TRIGGER trg_vaea_channels_updated
+  BEFORE UPDATE ON public.vaea_listener_channels
+  FOR EACH ROW EXECUTE FUNCTION public.vaea_config_bump_updated();
+
+-- ===========================================================================
+-- 2. VAEA_DETECTED_QUESTIONS — audit trail of every message the classifier scored
+-- ===========================================================================
+
+CREATE TABLE IF NOT EXISTS public.vaea_detected_questions (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL,
+  user_id UUID NOT NULL,                             -- the user whose VAEA observed this
+  channel_id UUID NOT NULL REFERENCES public.vaea_listener_channels(id) ON DELETE CASCADE,
+
+  -- Source message
+  external_message_id TEXT NOT NULL,                 -- platform-native id (dedup key)
+  platform TEXT NOT NULL,
+  author_handle TEXT,
+  author_external_id TEXT,
+  message_body TEXT NOT NULL,
+  message_url TEXT,
+  posted_at TIMESTAMPTZ,
+
+  -- Classifier output (0.0 - 1.0 per axis)
+  is_purchase_intent NUMERIC(3,2),
+  topic_match NUMERIC(3,2),
+  urgency NUMERIC(3,2),
+  already_answered NUMERIC(3,2),
+  poster_fit NUMERIC(3,2),
+  combined_score NUMERIC(3,2),
+  classifier_version TEXT NOT NULL DEFAULT 'v0-heuristic',
+
+  -- Disposition
+  disposition TEXT NOT NULL DEFAULT 'scored'
+    CHECK (disposition IN ('scored','below_threshold','excluded','skipped','drafted','rejected_by_user')),
+  disposition_reason TEXT,
+
+  -- Keywords / topic extracted from message
+  extracted_topics TEXT[] NOT NULL DEFAULT '{}',
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+
+  UNIQUE (channel_id, external_message_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_vaea_detected_user_recent
+  ON public.vaea_detected_questions (tenant_id, user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_vaea_detected_disposition
+  ON public.vaea_detected_questions (user_id, disposition, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_vaea_detected_score
+  ON public.vaea_detected_questions (user_id, combined_score DESC)
+  WHERE disposition = 'drafted';
+
+-- ===========================================================================
+-- 3. VAEA_REPLY_DRAFTS — proposed replies awaiting approval (observe mode: never sent)
+-- ===========================================================================
+
+CREATE TABLE IF NOT EXISTS public.vaea_reply_drafts (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL,
+  user_id UUID NOT NULL,
+
+  detected_question_id UUID NOT NULL REFERENCES public.vaea_detected_questions(id) ON DELETE CASCADE,
+  catalog_item_id UUID REFERENCES public.vaea_referral_catalog(id) ON DELETE SET NULL,
+
+  -- Drafted reply (not sent — observe only)
+  reply_body TEXT NOT NULL,
+  reply_includes_disclosure BOOLEAN NOT NULL DEFAULT TRUE,
+  reply_includes_non_affiliate_alt BOOLEAN NOT NULL DEFAULT FALSE,
+
+  -- Match rationale
+  match_reason TEXT,                                 -- human-readable explanation
+  match_score NUMERIC(3,2),
+  match_tier TEXT                                    -- 'own' / 'vetted_partner' / 'affiliate_network'
+    CHECK (match_tier IS NULL OR match_tier IN ('own','vetted_partner','affiliate_network')),
+
+  -- Status — drafts in Phase 1 stay `shadow` (visible but un-actionable) until
+  -- Phase 2 introduces one-tap approval. `dismissed` means user rejected the draft.
+  status TEXT NOT NULL DEFAULT 'shadow'
+    CHECK (status IN ('shadow','pending_approval','approved','dismissed','expired')),
+
+  composer_version TEXT NOT NULL DEFAULT 'v0-template',
+
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  expires_at TIMESTAMPTZ NOT NULL DEFAULT (NOW() + INTERVAL '72 hours')
+);
+
+CREATE INDEX IF NOT EXISTS idx_vaea_drafts_user_status
+  ON public.vaea_reply_drafts (tenant_id, user_id, status, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_vaea_drafts_expiry
+  ON public.vaea_reply_drafts (expires_at)
+  WHERE status IN ('shadow','pending_approval');
+
+DROP TRIGGER IF EXISTS trg_vaea_drafts_updated ON public.vaea_reply_drafts;
+CREATE TRIGGER trg_vaea_drafts_updated
+  BEFORE UPDATE ON public.vaea_reply_drafts
+  FOR EACH ROW EXECUTE FUNCTION public.vaea_config_bump_updated();
+
+-- ===========================================================================
+-- 4. RLS + GRANTS
+-- ===========================================================================
+
+ALTER TABLE public.vaea_listener_channels ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS vaea_channels_own ON public.vaea_listener_channels;
+CREATE POLICY vaea_channels_own ON public.vaea_listener_channels
+  FOR ALL TO authenticated
+  USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+DROP POLICY IF EXISTS vaea_channels_service ON public.vaea_listener_channels;
+CREATE POLICY vaea_channels_service ON public.vaea_listener_channels
+  FOR ALL TO service_role USING (TRUE) WITH CHECK (TRUE);
+
+ALTER TABLE public.vaea_detected_questions ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS vaea_detected_select_own ON public.vaea_detected_questions;
+CREATE POLICY vaea_detected_select_own ON public.vaea_detected_questions
+  FOR SELECT TO authenticated USING (user_id = auth.uid());
+DROP POLICY IF EXISTS vaea_detected_service ON public.vaea_detected_questions;
+CREATE POLICY vaea_detected_service ON public.vaea_detected_questions
+  FOR ALL TO service_role USING (TRUE) WITH CHECK (TRUE);
+
+ALTER TABLE public.vaea_reply_drafts ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS vaea_drafts_select_own ON public.vaea_reply_drafts;
+CREATE POLICY vaea_drafts_select_own ON public.vaea_reply_drafts
+  FOR SELECT TO authenticated USING (user_id = auth.uid());
+DROP POLICY IF EXISTS vaea_drafts_update_own ON public.vaea_reply_drafts;
+CREATE POLICY vaea_drafts_update_own ON public.vaea_reply_drafts
+  FOR UPDATE TO authenticated USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+DROP POLICY IF EXISTS vaea_drafts_service ON public.vaea_reply_drafts;
+CREATE POLICY vaea_drafts_service ON public.vaea_reply_drafts
+  FOR ALL TO service_role USING (TRUE) WITH CHECK (TRUE);
+
+GRANT SELECT, INSERT, UPDATE, DELETE ON public.vaea_listener_channels TO authenticated;
+GRANT SELECT ON public.vaea_detected_questions TO authenticated;
+GRANT SELECT, UPDATE ON public.vaea_reply_drafts TO authenticated;
+
+-- ===========================================================================
+-- 5. VTID LEDGER
+-- ===========================================================================
+
+INSERT INTO public.vtid_ledger (
+  vtid, layer, module, status, title, description, summary, task_family,
+  task_type, assigned_to, metadata, created_at, updated_at
+) VALUES (
+  'VTID-02401', 'PLATFORM', 'VAEA', 'in_progress',
+  'VAEA Phase 1 — observe-mode listener + classifier + matcher',
+  'Ingests messages from listener channels, scores buying intent, matches against vaea_referral_catalog, writes drafts to DB. ZERO posting. ZERO mesh. Drafts stay in shadow status until Phase 2 introduces one-tap approval.',
+  'Observe-mode detection loop. Gated behind VAEA_PHASE_1_OBSERVE_ENABLED. Maxina adapter is the first concrete listener; framework is generic so other platforms plug in via vaea_listener_channels.config.',
+  'ECONOMIC_ACTOR',
+  'observe_mode',
+  'platform',
+  jsonb_build_object(
+    'phase', 1,
+    'mode', 'observe_only',
+    'posting', false,
+    'mesh', false,
+    'tables', jsonb_build_array(
+      'vaea_listener_channels',
+      'vaea_detected_questions',
+      'vaea_reply_drafts'
+    ),
+    'classifier', 'v0-heuristic',
+    'composer', 'v0-template',
+    'feature_flags', jsonb_build_array(
+      'VAEA_ENABLED',
+      'VAEA_PHASE_1_OBSERVE_ENABLED'
+    )
+  ),
+  NOW(), NOW()
+)
+ON CONFLICT (vtid) DO UPDATE SET
+  status = EXCLUDED.status,
+  description = EXCLUDED.description,
+  summary = EXCLUDED.summary,
+  metadata = EXCLUDED.metadata,
+  updated_at = NOW();


### PR DESCRIPTION
## Summary

Phase 1 of VAEA — the observe loop is alive. The service now ingests messages from listener channels, scores them for buying intent, matches against the user's `vaea_referral_catalog`, and writes **shadow drafts** to the DB. **Nothing is posted. Nothing talks to peers.** Drafts stay in `shadow` status until Phase 2 introduces one-tap approval.

## Pipeline

```
vaea_listener_channels   ← per-user, per-platform config (dry_run default)
      │
      ▼
listener adapter         ← Maxina stub (polling-based, configurable endpoint)
      │
      ▼
classifyIntent()         ← v0 heuristic, 5 scoring axes + extracted_topics
      │  combined_score >= 0.5 AND give_recommendations=true?
      ▼
matchCatalog()           ← topic overlap × tier × vetting_status
      │
      ▼
composeDraft()           ← template: personal_note + affiliate_url + disclosure
      │
      ▼
vaea_reply_drafts        ← status=shadow; never sent in Phase 1
```

Every message gets an audit row in `vaea_detected_questions` — even below-threshold ones — with `disposition` + `disposition_reason` so the Business Hub can eventually show **"here's what your VAEA saw and why it stayed quiet."**

## New tables (migration `20260418040000_vtid_02401_vaea_phase1_observe.sql`)

| Table | Purpose |
|---|---|
| `vaea_listener_channels` | per-user, per-platform (Maxina first) with opaque `config` JSON. `dry_run=true` default — classifier runs but drafts marked shadow. |
| `vaea_detected_questions` | full audit of every message scored, including the 5-axis classifier output, extracted topics, and disposition. |
| `vaea_reply_drafts` | composed replies with match reason, tier, score — status `shadow` in Phase 1, `pending_approval` / `approved` / `dismissed` / `expired` reserved for Phase 2. |

All three tables have tenant-isolated RLS + service-role escape hatch.

## Classifier (v0 heuristic)

5 scoring axes (all 0.0–1.0):
- `is_purchase_intent` — regex match on "where can I buy", "recommend", "looking for", etc.
- `topic_match` — extracted topics ∩ user's expertise_zones
- `urgency` — "urgent", "today", "asap", etc.
- `already_answered` — flag to demote threads with good replies already
- `poster_fit` — placeholder for veteran-vs-new-member signal (Phase 2)

Weighted `combined_score`. Version tag `v0-heuristic` so the swap to Brain-side semantic classification in Phase 2 is lossless.

## Matcher

Ranks catalog entries by: topic overlap (0.6) × tier weight (0.25) × vetting weight (0.15). Own products rank above vetted partners rank above affiliate networks. Threshold 0.2 to filter pure noise.

## Composer (v0 template)

Picks the top match, uses `personal_note` if the user wrote one, else a tier/vetting-aware fallback. Always appends `disclosure_text`. Affiliate-network items also include a non-affiliate alternative line (\"If you'd rather skip the affiliate link, search the product name directly\").

## Feature flags (stacked — ALL must be true)

- `VAEA_ENABLED=true` — master kill
- `VAEA_PHASE_1_OBSERVE_ENABLED=true` — loop gate
- user's `vaea_config.give_recommendations=true` — per-user opt-in

Dockerfile ships **all three OFF by default.** Observe loop interval configurable via `VAEA_OBSERVE_INTERVAL_MS` (min 60s, default 300s).

## New endpoints

- `GET /alive` — now includes `observe_metrics`
- `GET /metrics` — same, phase=1
- `POST /admin/observe/run-once` — manual trigger (returns 423 if `VAEA_ENABLED=false`)

## What's NOT in the box

- Business Hub read routes for detected-questions / drafts → Phase 1.5
- Brain-side semantic classifier → Phase 2
- One-tap approval + post-to-platform adapters → Phase 2
- Mesh broker (`vaea-mesh`) + peer negotiation → Phase 3
- Commission attribution → Phase 3

## Safety posture

- Observe loop is gated by THREE flags (service env × env × per-user config) — no single flip turns on autonomous action.
- `vaea_listener_channels.dry_run` defaults to `true` — new channels shadow-draft only.
- `vaea_reply_drafts.status` defaults to `shadow` — Phase 1 cannot produce a postable draft even by accident.
- Service still marked `deployable: false` in `config/service-path-map.json`.

## Test plan

- [x] TypeScript compiles (`npm run build` — 0 errors)
- [ ] Migration applies cleanly via `RUN-MIGRATION.yml` with `supabase/migrations/20260418040000_vtid_02401_vaea_phase1_observe.sql`
- [ ] After migration: verify all 3 new tables exist with RLS enabled
- [ ] After migration: verify `VTID-02401` present in `vtid_ledger`
- [ ] No deploy yet

## Follow-ups

1. Phase 1.5: Gateway read routes (`/api/v1/vaea/detected-questions`, `/api/v1/vaea/drafts`) + Business Hub panel
2. Phase 2 scaffold: `vaea-mesh` broker + mesh message tables + post-to-platform adapters
3. Brain integration for teaching / norm-setting flow

🤖 Generated with [Claude Code](https://claude.com/claude-code)