### PR TITLE
DEV-COMHU-0209 wire new tabs into inline NAVIGATION_CONFIG

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -2610,7 +2610,10 @@ const NAVIGATION_CONFIG = [
             { "key": "live-console", "path": "/command-hub/live-console/" },
             { "key": "events", "path": "/command-hub/events/" },
             { "key": "vtids", "path": "/command-hub/vtids/" },
-            { "key": "approvals", "path": "/command-hub/approvals/" }
+            { "key": "approvals", "path": "/command-hub/approvals/" },
+            { "key": "autonomy-pulse", "path": "/command-hub/autonomy-pulse/" },
+            { "key": "autonomy-trace", "path": "/command-hub/autonomy-trace/" },
+            { "key": "dev-autopilot", "path": "/command-hub/dev-autopilot/" }
         ]
     },
     {

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -12,7 +12,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260328-aura"></script>
-  <script src="/command-hub/app.js?v=20260418-autonomy-pulse-trace"></script>
+  <script src="/command-hub/app.js?v=20260418-nav-config-inline"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js"></script>
 </body>


### PR DESCRIPTION
The nav config read by the frontend is inline in app.js, not the separate navigation-config.js file. PR-4/PR-11/PR-12 edited the dead file. Fix: append 3 tab entries to the live inline config + bump cache-bust.