### PR TITLE
fix(orb-calendar): use user timezone instead of server UTC

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -2478,6 +2478,7 @@ async function executeLiveApiToolInner(
         const query = (args.query as string) || '';
         const role = session.active_role || 'community';
         const userId = session.identity.user_id;
+        const userTz = session.clientContext?.timezone || 'UTC';
 
         try {
           const { getUserTodayEvents, getUserUpcomingEvents, getCalendarGaps } = await import('../services/calendar-service');
@@ -2491,9 +2492,9 @@ async function executeLiveApiToolInner(
           let formatted = '';
 
           if (todayEvents.length > 0) {
-            formatted += 'Today\'s schedule:\n';
+            formatted += `Today's schedule (times in ${userTz}):\n`;
             for (const ev of todayEvents) {
-              const time = new Date(ev.start_time).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true });
+              const time = new Date(ev.start_time).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true, timeZone: userTz });
               formatted += `- ${time}: ${ev.title} (${ev.event_type})\n`;
             }
             formatted += '\n';
@@ -2502,20 +2503,20 @@ async function executeLiveApiToolInner(
           }
 
           if (upcomingEvents.length > 0) {
-            formatted += 'Upcoming (next 7 days):\n';
+            formatted += `Upcoming (next 7 days, times in ${userTz}):\n`;
             for (const ev of upcomingEvents.slice(0, 5)) {
-              const date = new Date(ev.start_time).toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
-              const time = new Date(ev.start_time).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true });
+              const date = new Date(ev.start_time).toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', timeZone: userTz });
+              const time = new Date(ev.start_time).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true, timeZone: userTz });
               formatted += `- ${date} ${time}: ${ev.title} (${ev.event_type})\n`;
             }
             formatted += '\n';
           }
 
           if (gaps.length > 0) {
-            formatted += 'Free time today:\n';
+            formatted += `Free time today (in ${userTz}):\n`;
             for (const gap of gaps.slice(0, 3)) {
-              const start = new Date(gap.start).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true });
-              const end = new Date(gap.end).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true });
+              const start = new Date(gap.start).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true, timeZone: userTz });
+              const end = new Date(gap.end).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true, timeZone: userTz });
               formatted += `- ${start}\u2013${end} (${gap.duration_minutes} min free)\n`;
             }
           }
@@ -2612,12 +2613,15 @@ async function executeLiveApiToolInner(
             },
           }).catch(() => {});
 
+          const userTz = session.clientContext?.timezone || 'UTC';
           const startFormatted = new Date(eventStart).toLocaleString('en-US', {
             weekday: 'short', month: 'short', day: 'numeric',
             hour: '2-digit', minute: '2-digit', hour12: true,
+            timeZone: userTz,
           });
           const endFormatted = new Date(effectiveEndTime).toLocaleTimeString('en-US', {
             hour: '2-digit', minute: '2-digit', hour12: true,
+            timeZone: userTz,
           });
 
           let result = `Event created successfully!\n- Title: ${event.title}\n- When: ${startFormatted} – ${endFormatted}`;
@@ -5750,9 +5754,10 @@ Operating mode:
  * VTID-01186: Now accepts optional identity parameter to use authenticated user's memory.
  */
 async function generateMemoryEnhancedSystemInstruction(
-  session: { tenant: string; role: string; route?: string; selectedId?: string },
+  session: { tenant: string; role: string; route?: string; selectedId?: string; userTimezone?: string },
   identity?: MemoryIdentity | null
 ): Promise<{ instruction: string; memoryContext: OrbMemoryContext | null; contextBundle?: ContextBundle }> {
+  const userTz = session.userTimezone || 'UTC';
   // VTID-01186: Determine effective identity (authenticated or DEV_IDENTITY fallback)
   const effectiveIdentity: MemoryIdentity = identity && identity.user_id && identity.tenant_id
     ? identity
@@ -5812,12 +5817,12 @@ async function generateMemoryEnhancedSystemInstruction(
         getCalendarGaps(effectiveIdentity.user_id, calRole, new Date()),
       ]);
 
-      let calLines = '\n\n## Your Calendar Awareness\nYou have access to this user\'s calendar. This is part of your core memory. ALWAYS reference this when asked about schedule, calendar, events, or availability.\n';
+      let calLines = `\n\n## Your Calendar Awareness\nYou have access to this user's calendar. This is part of your core memory. ALWAYS reference this when asked about schedule, calendar, events, or availability.\nAll times below are in the user's local timezone (${userTz}). When speaking to the user, state these times verbatim — do NOT convert to UTC or another timezone.\n`;
 
       if (todayEvents.length > 0) {
-        calLines += '\nToday\'s schedule:\n';
+        calLines += `\nToday's schedule (${userTz}):\n`;
         for (const ev of todayEvents) {
-          const time = new Date(ev.start_time).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true });
+          const time = new Date(ev.start_time).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true, timeZone: userTz });
           calLines += `- ${time}: ${ev.title} (${ev.event_type})\n`;
         }
       } else {
@@ -5825,19 +5830,19 @@ async function generateMemoryEnhancedSystemInstruction(
       }
 
       if (upcomingEvents.length > 0) {
-        calLines += '\nUpcoming (next 7 days):\n';
+        calLines += `\nUpcoming (next 7 days, ${userTz}):\n`;
         for (const ev of upcomingEvents.slice(0, 5)) {
-          const date = new Date(ev.start_time).toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
-          const time = new Date(ev.start_time).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true });
+          const date = new Date(ev.start_time).toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', timeZone: userTz });
+          const time = new Date(ev.start_time).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true, timeZone: userTz });
           calLines += `- ${date} ${time}: ${ev.title}\n`;
         }
       }
 
       if (gaps.length > 0) {
-        calLines += '\nFree time today:\n';
+        calLines += `\nFree time today (${userTz}):\n`;
         for (const gap of gaps.slice(0, 3)) {
-          const start = new Date(gap.start).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true });
-          const end = new Date(gap.end).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true });
+          const start = new Date(gap.start).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true, timeZone: userTz });
+          const end = new Date(gap.end).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true, timeZone: userTz });
           calLines += `- ${start}\u2013${end} (${gap.duration_minutes} min free)\n`;
         }
       }
@@ -8560,6 +8565,7 @@ router.post('/live/session/start', optionalAuth, async (req: AuthenticatedReques
                 role: brainRole,
                 channel: 'orb',
                 thread_id: sessionId,
+                user_timezone: clientContext?.timezone,
               });
               console.log(`[VITANA-BRAIN] ORB context built in ${Date.now() - brainStart}ms (${instruction.length} chars)`);
               return { contextInstruction: instruction, contextPack: cp, latencyMs: Date.now() - brainStart };

--- a/services/gateway/src/services/context-pack-builder.ts
+++ b/services/gateway/src/services/context-pack-builder.ts
@@ -1417,7 +1417,8 @@ export async function buildContextPack(
 /**
  * Format Context Pack for LLM system instruction injection
  */
-export function formatContextPackForLLM(pack: ContextPack): string {
+export function formatContextPackForLLM(pack: ContextPack, opts?: { userTimezone?: string }): string {
+  const userTz = opts?.userTimezone || 'UTC';
   let context = '';
 
   // VTID-01230: Session buffer FIRST — highest priority, most recent context
@@ -1509,11 +1510,12 @@ export function formatContextPackForLLM(pack: ContextPack): string {
   if (pack.calendar_context) {
     const cal = pack.calendar_context;
     context += `<calendar_memory>\n`;
+    context += `All calendar times below are in the user's local timezone (${userTz}). When speaking to the user, state these times verbatim — do NOT convert to UTC or any other timezone.\n\n`;
 
     if (cal.today_events.length > 0) {
-      context += `Today's schedule:\n`;
+      context += `Today's schedule (${userTz}):\n`;
       for (const ev of cal.today_events) {
-        const time = new Date(ev.start_time).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true });
+        const time = new Date(ev.start_time).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true, timeZone: userTz });
         context += `- ${time}: ${ev.title} (${ev.event_type})\n`;
       }
       context += `\n`;
@@ -1522,20 +1524,20 @@ export function formatContextPackForLLM(pack: ContextPack): string {
     }
 
     if (cal.upcoming_events.length > 0) {
-      context += `Upcoming (next 7 days):\n`;
+      context += `Upcoming (next 7 days, ${userTz}):\n`;
       for (const ev of cal.upcoming_events.slice(0, 5)) {
-        const date = new Date(ev.start_time).toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
-        const time = new Date(ev.start_time).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true });
+        const date = new Date(ev.start_time).toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', timeZone: userTz });
+        const time = new Date(ev.start_time).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true, timeZone: userTz });
         context += `- ${date} ${time}: ${ev.title}\n`;
       }
       context += `\n`;
     }
 
     if (cal.gaps_today.length > 0) {
-      context += `Free time today:\n`;
+      context += `Free time today (${userTz}):\n`;
       for (const gap of cal.gaps_today.slice(0, 3)) {
-        const start = new Date(gap.start).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true });
-        const end = new Date(gap.end).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true });
+        const start = new Date(gap.start).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true, timeZone: userTz });
+        const end = new Date(gap.end).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true, timeZone: userTz });
         context += `- ${start}–${end} (${gap.duration_minutes} min free)\n`;
       }
       context += `\n`;

--- a/services/gateway/src/services/vitana-brain.ts
+++ b/services/gateway/src/services/vitana-brain.ts
@@ -279,6 +279,7 @@ export async function buildBrainSystemInstruction(input: {
   turn_number?: number;
   conversation_start?: string;
   display_name?: string;
+  user_timezone?: string;
 }): Promise<{ instruction: string; contextPack: ContextPack }> {
   const startTime = Date.now();
 
@@ -315,7 +316,7 @@ export async function buildBrainSystemInstruction(input: {
   };
 
   const contextPack = await buildContextPack(contextPackInput);
-  const contextForLLM = formatContextPackForLLM(contextPack);
+  const contextForLLM = formatContextPackForLLM(contextPack, { userTimezone: input.user_timezone });
 
   // Build personality-driven instruction
   const preferredLanguage = extractLanguageFromContextPack(contextPack);
@@ -398,9 +399,10 @@ export function buildBrainToolDefinitions(role: string): object[] {
 export async function executeBrainTool(
   toolName: string,
   args: Record<string, unknown>,
-  context: { user_id: string; tenant_id: string; role: string },
+  context: { user_id: string; tenant_id: string; role: string; user_timezone?: string },
 ): Promise<{ success: boolean; result: string; error?: string }> {
   const startTime = Date.now();
+  const userTz = context.user_timezone || 'UTC';
 
   try {
     switch (toolName) {
@@ -414,27 +416,27 @@ export async function executeBrainTool(
 
         let formatted = '';
         if (today.length > 0) {
-          formatted += 'Today\'s schedule:\n';
+          formatted += `Today's schedule (times in ${userTz}):\n`;
           for (const ev of today) {
-            const time = new Date(ev.start_time).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true });
+            const time = new Date(ev.start_time).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true, timeZone: userTz });
             formatted += `- ${time}: ${ev.title} (${ev.event_type})\n`;
           }
         } else {
           formatted += 'Today\'s schedule: No events scheduled.\n';
         }
         if (upcoming.length > 0) {
-          formatted += '\nUpcoming (next 7 days):\n';
+          formatted += `\nUpcoming (next 7 days, times in ${userTz}):\n`;
           for (const ev of upcoming.slice(0, 5)) {
-            const date = new Date(ev.start_time).toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric' });
-            const time = new Date(ev.start_time).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true });
+            const date = new Date(ev.start_time).toLocaleDateString('en-US', { weekday: 'short', month: 'short', day: 'numeric', timeZone: userTz });
+            const time = new Date(ev.start_time).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true, timeZone: userTz });
             formatted += `- ${date} ${time}: ${ev.title}\n`;
           }
         }
         if (gaps.length > 0) {
-          formatted += '\nFree time today:\n';
+          formatted += `\nFree time today (in ${userTz}):\n`;
           for (const gap of gaps.slice(0, 3)) {
-            const start = new Date(gap.start).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true });
-            const end = new Date(gap.end).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true });
+            const start = new Date(gap.start).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true, timeZone: userTz });
+            const end = new Date(gap.end).toLocaleTimeString('en-US', { hour: '2-digit', minute: '2-digit', hour12: true, timeZone: userTz });
             formatted += `- ${start}\u2013${end} (${gap.duration_minutes} min free)\n`;
           }
         }


### PR DESCRIPTION
## Summary
- ORB voice and calendar tools formatted event times without a `timeZone` option, so Node fell back to the server TZ (UTC on Cloud Run). A 16:00 CEST event stored as 14:00 UTC was spoken back as "2:00 PM" instead of "4:00 PM".
- Thread the user's timezone (already resolved via IP geolocation into `session.clientContext.timezone`) through every calendar formatting path: live tool handlers (`search_calendar`, `create_calendar_event`), the system-instruction calendar block, the brain's `formatContextPackForLLM`, and `executeBrainTool`.
- Label the calendar section with the explicit TZ and instruct the model to state times verbatim — no UTC conversion.

## Files
- `services/gateway/src/routes/orb-live.ts` — tool handlers + `generateMemoryEnhancedSystemInstruction` + SSE bootstrap call into `buildBrainSystemInstruction`
- `services/gateway/src/services/vitana-brain.ts` — `buildBrainSystemInstruction` + `executeBrainTool` accept `user_timezone`
- `services/gateway/src/services/context-pack-builder.ts` — `formatContextPackForLLM(pack, { userTimezone })` with TZ-aware calendar block

## Test plan
- [ ] `tsc --noEmit` passes (verified locally)
- [ ] After deploy, ask ORB "what's on my calendar today?" with a CEST user — times must match the user's local time
- [ ] Create an event via voice ("schedule yoga at 6 PM") — confirmation must echo 6:00 PM, not 4:00 PM

🤖 Generated with [Claude Code](https://claude.com/claude-code)