### PR TITLE
feat(marketplace): Shopify sync preserves body_html as description_long

### DIFF
--- a/services/gateway/src/routes/discover-feed.ts
+++ b/services/gateway/src/routes/discover-feed.ts
@@ -102,7 +102,7 @@ router.get('/feed', async (req: Request, res: Response) => {
   let candidateQuery = supabase
     .from('products')
     .select(
-      'id, title, description, brand, category, subcategory, price_cents, currency, compare_at_price_cents, images, affiliate_url, availability, rating, review_count, origin_country, origin_region, merchant_id, ingredients_primary, health_goals, dietary_tags, reward_preview, contains_allergens, contraindicated_with_conditions, contraindicated_with_medications, ships_to_countries, ships_to_regions, excluded_from_regions, dosage, serving_size, servings_per_container, evidence_links, safety_notes'
+      'id, title, description, description_long, brand, category, subcategory, price_cents, currency, compare_at_price_cents, images, affiliate_url, availability, rating, review_count, origin_country, origin_region, merchant_id, ingredients_primary, health_goals, dietary_tags, reward_preview, contains_allergens, contraindicated_with_conditions, contraindicated_with_medications, ships_to_countries, ships_to_regions, excluded_from_regions, dosage, serving_size, servings_per_container, evidence_links, safety_notes'
     )
     .eq('is_active', true)
     .eq('availability', 'in_stock');

--- a/services/gateway/src/routes/discover-search.ts
+++ b/services/gateway/src/routes/discover-search.ts
@@ -210,7 +210,7 @@ router.get('/search', async (req: Request, res: Response) => {
   let query = supabase
     .from('products')
     .select(
-      'id, title, description, brand, category, subcategory, price_cents, currency, compare_at_price_cents, images, affiliate_url, availability, rating, review_count, origin_country, origin_region, merchant_id, ingredients_primary, health_goals, dietary_tags, reward_preview, contains_allergens, contraindicated_with_conditions, contraindicated_with_medications, ships_to_countries, ships_to_regions, excluded_from_regions, dosage, serving_size, servings_per_container, evidence_links, safety_notes',
+      'id, title, description, description_long, brand, category, subcategory, price_cents, currency, compare_at_price_cents, images, affiliate_url, availability, rating, review_count, origin_country, origin_region, merchant_id, ingredients_primary, health_goals, dietary_tags, reward_preview, contains_allergens, contraindicated_with_conditions, contraindicated_with_medications, ships_to_countries, ships_to_regions, excluded_from_regions, dosage, serving_size, servings_per_container, evidence_links, safety_notes',
       { count: 'exact' }
     )
     .eq('is_active', true);
@@ -385,6 +385,7 @@ router.get('/search', async (req: Request, res: Response) => {
       id: p.id,
       title: p.title,
       description: p.description,
+      description_long: (p as { description_long?: string | null }).description_long ?? null,
       brand: p.brand,
       category: p.category,
       subcategory: p.subcategory,

--- a/services/gateway/src/services/marketplace-sync/shared.ts
+++ b/services/gateway/src/services/marketplace-sync/shared.ts
@@ -120,6 +120,8 @@ export interface ProductUpsert {
   asin?: string;
   title: string;
   description?: string;
+  /** Multi-paragraph readable version of description (for the product-detail drawer). */
+  description_long?: string;
   brand?: string;
   category?: string;
   subcategory?: string;
@@ -148,6 +150,7 @@ export function computeProductContentHash(p: ProductUpsert): string {
   const canonical = {
     title: p.title ?? '',
     description: p.description ?? '',
+    description_long: p.description_long ?? '',
     brand: p.brand ?? '',
     price_cents: p.price_cents,
     currency: p.currency,
@@ -229,6 +232,7 @@ export async function upsertProducts(
       asin: p.asin ?? null,
       title: p.title,
       description: p.description ?? null,
+      description_long: p.description_long ?? null,
       brand: p.brand ?? null,
       category: p.category ?? null,
       subcategory: p.subcategory ?? null,

--- a/services/gateway/src/services/marketplace-sync/shopify-sync.ts
+++ b/services/gateway/src/services/marketplace-sync/shopify-sync.ts
@@ -167,6 +167,34 @@ function stripHtml(html: string | undefined): string | undefined {
   return html.replace(/<[^>]+>/g, ' ').replace(/\s+/g, ' ').trim() || undefined;
 }
 
+/**
+ * Convert Shopify descriptionHtml to readable multi-paragraph plain text.
+ * Preserves paragraph breaks from <p>, <br>, <div>, <li>; strips everything else.
+ * Used for the product-detail drawer's "About this product" section.
+ */
+function htmlToFormattedText(html: string | undefined): string | undefined {
+  if (!html) return undefined;
+  const withBreaks = html
+    // Treat closing block tags as a paragraph break
+    .replace(/<\/(p|div|section|article|h[1-6]|li|tr)>/gi, '\n\n')
+    // Treat <br> and <li> openings as a line break
+    .replace(/<br\s*\/?>/gi, '\n')
+    .replace(/<li[^>]*>/gi, '\n• ')
+    // Drop everything else
+    .replace(/<[^>]+>/g, '')
+    // Decode a few common entities
+    .replace(/&nbsp;/g, ' ')
+    .replace(/&amp;/g, '&')
+    .replace(/&lt;/g, '<')
+    .replace(/&gt;/g, '>')
+    .replace(/&quot;/g, '"')
+    .replace(/&#39;/g, "'");
+  // Normalise whitespace: collapse runs of spaces, trim each line, collapse 3+ blank lines
+  const lines = withBreaks.split('\n').map((l) => l.replace(/[ \t]+/g, ' ').trim());
+  const joined = lines.join('\n').replace(/\n{3,}/g, '\n\n').trim();
+  return joined || undefined;
+}
+
 function normalizeShopifyProduct(
   node: ShopifyProductNode,
   shop: ShopifyShopConfig,
@@ -212,6 +240,7 @@ function normalizeShopifyProduct(
     sku: node.handle,
     title: node.title,
     description: stripHtml(node.descriptionHtml),
+    description_long: htmlToFormattedText(node.descriptionHtml),
     brand: node.vendor,
     category: 'supplements', // Phase 2 MVP assumption — admin can override in review queue
     subcategory: node.productType,

--- a/supabase/migrations/20260418050000_vtid_02000_description_long.sql
+++ b/supabase/migrations/20260418050000_vtid_02000_description_long.sql
@@ -1,0 +1,22 @@
+-- VTID-02000: Add description_long column for the product-detail drawer.
+--
+-- The existing `description` field is the single-line, HTML-stripped version
+-- the marketplace sync has always written. It remains useful for card
+-- summaries and search snippets.
+--
+-- `description_long` is the multi-paragraph readable form used by the
+-- community-app drawer's "About this product" section. The Shopify sync
+-- (this PR) populates it from `descriptionHtml` via a paragraph-preserving
+-- strip. The CJ sync will populate it in a follow-up once the CJ enrichment
+-- PR lands. Existing rows without it fall back to `description` on render.
+
+BEGIN;
+
+ALTER TABLE public.products
+  ADD COLUMN IF NOT EXISTS description_long TEXT;
+
+COMMENT ON COLUMN public.products.description_long IS
+  'Multi-paragraph readable product description for the detail drawer. '
+  'Falls back to the short `description` field when null.';
+
+COMMIT;


### PR DESCRIPTION
## Summary
Adds `description_long` column to `products` and teaches the Shopify sync to populate it. Existing `description` stays as the HTML-stripped single-line version used for card summaries and search snippets.

## Why
Today the Shopify sync runs `descriptionHtml` through `stripHtml()`, which collapses the merchant's paragraph structure into a single-line blob. That blob is what the product-detail drawer (community-app PR #131) has been rendering as "About this product" — it reads like a run-on sentence. `description_long` keeps paragraph breaks and list bullets intact.

## Changes
- `20260418050000_vtid_02000_description_long.sql`: `ADD COLUMN description_long TEXT`
- `shopify-sync.ts`:
  - New `htmlToFormattedText()` — preserves `<p>` / `<br>` / `<li>` as line breaks, decodes common HTML entities, collapses whitespace, strips everything else
  - Upsert now writes both `description` (single-line strip, unchanged) and `description_long` (multi-paragraph)
- `shared.ts`: `ProductUpsert` gains `description_long`; `upsertProducts` writes it; `content_hash` includes it so resync triggers when merchant copy changes
- `discover-search` / `discover-feed`: SELECT + output includes `description_long` so the community-app drawer can render it

## Not included
- No backfill for demo_seed rows — their existing `description` is already a well-formatted 3-paragraph string from the prior backfill (PR #677), so leaving `description_long` null means the drawer transparently falls back. CJ sync enrichment is a separate follow-up.

## Apply order
1. Merge → gateway auto-redeploys, SELECTs new column which is still null for all existing rows (graceful).
2. Trigger `RUN-MIGRATION.yml` with `supabase/migrations/20260418050000_vtid_02000_description_long.sql`.
3. Next Shopify sync run populates `description_long` for real merchant products as they come in.

## Verify (after migration)
```bash
curl -s "https://gateway-q74ibpv6ia-uc.a.run.app/api/v1/discover/search?limit=3" \
  | jq '.items[] | {title, short: (.description | length), long: (.description_long // "" | length)}'
```
