### PR TITLE
BOOTSTRAP-RBAC-FIX dev routes verify JWT + check exafy_admin

### DIFF
--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -12,7 +12,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260328-aura"></script>
-  <script src="/command-hub/app.js?v=20260418-pulse-auth-freeze-fix"></script>
+  <script src="/command-hub/app.js?v=20260418-exafy-admin-rbac"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js"></script>
 </body>

--- a/services/gateway/src/routes/autonomy-pulse.ts
+++ b/services/gateway/src/routes/autonomy-pulse.ts
@@ -19,26 +19,34 @@
  *   - raw: the original row (minus heavy fields) for anyone who needs detail
  */
 
-import { Router, Request, Response } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
+import { requireAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
 
 const router = Router();
 const LOG_PREFIX = '[autonomy-pulse]';
 
 // =============================================================================
-// Auth (aligned with dev-autopilot — developer role only)
+// Auth — dev-only (requires app_metadata.exafy_admin === true)
 // =============================================================================
 
-function requireDevRole(req: Request, res: Response, next: () => void) {
-  // Matches dev-autopilot.ts — auth middleware populates req.user.role
-  // (singular). Accept internal gateway calls via X-Gateway-Internal too.
-  const user = (req as unknown as { user?: { role?: string } }).user;
-  const role = user?.role;
-  if (role === 'developer' || role === 'admin') return next();
+async function requireDevRole(req: Request, res: Response, next: NextFunction): Promise<void> {
   if (req.get('X-Gateway-Internal') === (process.env.GATEWAY_INTERNAL_TOKEN || '__dev__') &&
       process.env.GATEWAY_INTERNAL_TOKEN) {
     return next();
   }
-  return res.status(403).json({ ok: false, error: 'Autonomy Pulse requires developer role' });
+  let authFailed = false;
+  await requireAuth(req as AuthenticatedRequest, res, () => {
+    const identity = (req as AuthenticatedRequest).identity;
+    if (!identity) {
+      authFailed = true;
+      res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+      return;
+    }
+    if (identity.exafy_admin === true) return next();
+    authFailed = true;
+    res.status(403).json({ ok: false, error: 'Autonomy Pulse requires developer access (exafy_admin)' });
+  });
+  if (authFailed) return;
 }
 
 // =============================================================================

--- a/services/gateway/src/routes/autonomy-trace.ts
+++ b/services/gateway/src/routes/autonomy-trace.ts
@@ -24,26 +24,34 @@
  * approve → ci → deploy → verify → done timeline shows as one lane.
  */
 
-import { Router, Request, Response } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
+import { requireAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
 
 const router = Router();
 const LOG_PREFIX = '[autonomy-trace]';
 
 // =============================================================================
-// Auth (aligned with dev-autopilot + autonomy-pulse)
+// Auth — dev-only (requires app_metadata.exafy_admin === true)
 // =============================================================================
 
-function requireDevRole(req: Request, res: Response, next: () => void) {
-  // Matches dev-autopilot.ts — auth middleware populates req.user.role
-  // (singular). Accept internal gateway calls via X-Gateway-Internal too.
-  const user = (req as unknown as { user?: { role?: string } }).user;
-  const role = user?.role;
-  if (role === 'developer' || role === 'admin') return next();
+async function requireDevRole(req: Request, res: Response, next: NextFunction): Promise<void> {
   if (req.get('X-Gateway-Internal') === (process.env.GATEWAY_INTERNAL_TOKEN || '__dev__') &&
       process.env.GATEWAY_INTERNAL_TOKEN) {
     return next();
   }
-  return res.status(403).json({ ok: false, error: 'Autonomy Trace requires developer role' });
+  let authFailed = false;
+  await requireAuth(req as AuthenticatedRequest, res, () => {
+    const identity = (req as AuthenticatedRequest).identity;
+    if (!identity) {
+      authFailed = true;
+      res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+      return;
+    }
+    if (identity.exafy_admin === true) return next();
+    authFailed = true;
+    res.status(403).json({ ok: false, error: 'Autonomy Trace requires developer access (exafy_admin)' });
+  });
+  if (authFailed) return;
 }
 
 // =============================================================================

--- a/services/gateway/src/routes/dev-autopilot.ts
+++ b/services/gateway/src/routes/dev-autopilot.ts
@@ -11,12 +11,13 @@
  * GitHub Actions workflow).
  */
 
-import { Router, Request, Response } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { ingestScan, ScanInput } from '../services/dev-autopilot-synthesis';
 import { generatePlanVersion } from '../services/dev-autopilot-planning';
 import { approveAutoExecute, cancelExecution } from '../services/dev-autopilot-execute';
 import { bridgeFailureToSelfHealing, FailureStage } from '../services/dev-autopilot-bridge';
 import { emitOasisEvent } from '../services/oasis-event-service';
+import { requireAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
 
 const router = Router();
 
@@ -76,18 +77,29 @@ async function supaPatch(supa: SupaConfig, path: string, body: unknown): Promise
 // Auth guard
 // =============================================================================
 
-function requireDevRole(req: Request, res: Response, next: () => void) {
-  // Dev-assistant RBAC — reuse the populated req.user from upstream auth
-  // middleware if present. For the MVP we accept a service-role header too
-  // so local/internal callers (the watcher, the workflow) can hit the API.
-  const user = (req as unknown as { user?: { role?: string } }).user;
-  const role = user?.role;
-  if (role === 'developer' || role === 'admin') return next();
+/** Dev-only guard. Runs requireAuth (verifies Supabase JWT + populates
+ *  req.identity) then requires app_metadata.exafy_admin === true. The
+ *  Supabase JWT's `role` claim is always 'authenticated' for logged-in
+ *  users; dev access is granted via exafy_admin. Internal calls can
+ *  bypass via X-Gateway-Internal + GATEWAY_INTERNAL_TOKEN. */
+async function requireDevRole(req: Request, res: Response, next: NextFunction): Promise<void> {
   if (req.get('X-Gateway-Internal') === (process.env.GATEWAY_INTERNAL_TOKEN || '__dev__') &&
       process.env.GATEWAY_INTERNAL_TOKEN) {
     return next();
   }
-  return res.status(403).json({ ok: false, error: 'Dev Autopilot requires developer role' });
+  let authFailed = false;
+  await requireAuth(req as AuthenticatedRequest, res, () => {
+    const identity = (req as AuthenticatedRequest).identity;
+    if (!identity) {
+      authFailed = true;
+      res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+      return;
+    }
+    if (identity.exafy_admin === true) return next();
+    authFailed = true;
+    res.status(403).json({ ok: false, error: 'Dev Autopilot requires developer access (exafy_admin)' });
+  });
+  if (authFailed) return;
 }
 
 function requireScanToken(req: Request, res: Response, next: () => void) {


### PR DESCRIPTION
Dev Autopilot / Autonomy Pulse / Autonomy Trace have been silently 403-ing every logged-in user. The check read req.user.role === 'developer' but (1) no middleware populated req.user, and (2) Supabase JWT's role claim is always 'authenticated' — dev access comes from app_metadata.exafy_admin. Fix: chain requireAuth + check identity.exafy_admin across all three routes.