### PR TITLE
feat(marketplace): Shopify sync augments with supplement-inference

### DIFF
--- a/services/gateway/src/services/marketplace-sync/shopify-sync.ts
+++ b/services/gateway/src/services/marketplace-sync/shopify-sync.ts
@@ -29,6 +29,7 @@ import {
   deriveRegionGroup,
   type ProductUpsert,
 } from './shared';
+import { inferSupplementAttributes } from './supplement-inference';
 
 interface ShopifyShopConfig {
   domain: string;
@@ -229,6 +230,20 @@ function normalizeShopifyProduct(
     if (tagsLower.includes(d) || tagsLower.includes(d.replace('-', ''))) dietaryTags.add(d);
   }
 
+  // Free-text inference over title + description + tags + productType.
+  // This augments (does not replace) the collection / tag mappings above.
+  // Ingredients / form / certifications have no prior source on Shopify today
+  // and come entirely from inference.
+  const inferText = [
+    node.title,
+    stripHtml(node.descriptionHtml) ?? '',
+    (node.tags ?? []).join(' '),
+    node.productType ?? '',
+  ].join(' ');
+  const inferred = inferSupplementAttributes(inferText);
+  for (const g of inferred.health_goals) healthGoals.add(g);
+  for (const d of inferred.dietary_tags) dietaryTags.add(d);
+
   const affiliateUrl = shop.affiliate_url_template
     ? shop.affiliate_url_template.replace('{handle}', node.handle)
     : node.onlineStoreUrl ?? `https://${shop.domain}/products/${node.handle}`;
@@ -256,6 +271,9 @@ function normalizeShopifyProduct(
     ships_to_regions: shop.ships_to_regions,
     health_goals: Array.from(healthGoals),
     dietary_tags: Array.from(dietaryTags),
+    ingredients_primary: inferred.ingredients_primary,
+    form: inferred.form,
+    certifications: inferred.certifications,
     raw: node as unknown as Record<string, unknown>,
   };
 }


### PR DESCRIPTION
Symmetric to CJ enrichment PR #685. Shopify sync now runs `inferSupplementAttributes` over title + description + tags + productType; results are unioned with the existing collection-based health_goals / dietary_tags so explicit merchant config still wins. Ingredients / form / certifications come entirely from inference since Shopify has no prior source for them.

Means merchants can onboard to Shopify without pre-configuring collection mappings — products land with reasonable tags out of the box.

content_hash already includes all inferred fields → next sync re-upserts every existing Shopify row with the enriched values. No data migration needed.