### PR TITLE
BOOTSTRAP-APPROVE-UX show approve failures inline (fixes invisible safety-gate rejection)

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -34541,6 +34541,10 @@ if (!state.devAutopilot) {
         // themselves cleanly via state instead of touching detached DOM after
         // showToast() (which re-renders and invalidates refs).
         actionInFlight: {},
+        // Per-finding last action error — shown inline in the plan block so
+        // safety-gate rejections (high risk, depth cap, etc.) don't only live
+        // in a fleeting toast that's easy to miss.
+        actionErrors: {},
     };
 }
 
@@ -35088,28 +35092,36 @@ function devAutopilotApproveOne(findingId) {
     var key = 'approve:' + findingId;
     if (devAutopilotInFlight(key)) return;
     devAutopilotMarkFlight(key, true);
+    delete state.devAutopilot.actionErrors[findingId];
     renderApp();
     devAutopilotApi('/findings/' + findingId + '/approve-auto-execute', 'POST', {}).then(function (data) {
         devAutopilotMarkFlight(key, false);
         if (data.ok) {
-            // Remove from queue, drop selection, prepend execution to live trace
             state.devAutopilot.queue = (state.devAutopilot.queue || []).filter(function (f) { return f.id !== findingId; });
             delete state.devAutopilot.selectedIds[findingId];
             delete state.devAutopilot.expandedIds[findingId];
+            delete state.devAutopilot.actionErrors[findingId];
             if (data.execution) {
                 state.devAutopilot.executions = [data.execution].concat(state.devAutopilot.executions || []);
             }
             showToast('Approved — execution cooling: ' + (data.execution && data.execution.id ? data.execution.id.slice(0, 8) : '?'), 'success');
         } else {
+            // Persist the error inline in the plan block — toasts are easy to miss.
             var msg = data.error || 'Approval failed';
-            if (data.decision && Array.isArray(data.decision.violations) && data.decision.violations.length) {
-                msg += ' (' + data.decision.violations.map(function (v) { return v.code; }).join(', ') + ')';
+            var violations = (data.decision && Array.isArray(data.decision.violations)) ? data.decision.violations : [];
+            state.devAutopilot.actionErrors[findingId] = { message: msg, violations: violations };
+            if (violations.length) {
+                msg += ' (' + violations.map(function (v) { return v.code; }).join(', ') + ')';
             }
             showToast(msg, 'error');
+            renderApp();
         }
     }).catch(function (err) {
         devAutopilotMarkFlight(key, false);
-        showToast('Network error: ' + (err.message || err), 'error');
+        var emsg = 'Network error: ' + (err.message || err);
+        state.devAutopilot.actionErrors[findingId] = { message: emsg, violations: [] };
+        showToast(emsg, 'error');
+        renderApp();
     });
 }
 
@@ -35340,6 +35352,34 @@ function renderDevAutopilotBatchBar() {
 }
 
 function renderDevAutopilotActions(findingId) {
+    var wrap = document.createElement('div');
+
+    // Inline error banner — persists until the next approve attempt so the
+    // supervisor isn't left wondering why nothing happened (especially for
+    // safety-gate rejections on high-risk findings).
+    var err = state.devAutopilot.actionErrors && state.devAutopilot.actionErrors[findingId];
+    if (err) {
+        var banner = document.createElement('div');
+        banner.style.cssText = 'margin-top: 10px; padding: 10px 12px; background: rgba(239,68,68,0.12); border: 1px solid rgba(239,68,68,0.35); border-radius: 4px; color: #ef4444; font-size: 13px; line-height: 1.45;';
+        var line1 = document.createElement('div');
+        line1.style.cssText = 'font-weight: 600; margin-bottom: 4px;';
+        line1.textContent = '✗ ' + err.message;
+        banner.appendChild(line1);
+        if (err.violations && err.violations.length) {
+            var vlist = document.createElement('div');
+            vlist.style.cssText = 'font-size: 12px; color: #fca5a5;';
+            vlist.textContent = 'Blocked by safety gate: ' + err.violations.map(function (v) {
+                return (v.code || 'unknown') + (v.detail ? ' — ' + JSON.stringify(v.detail) : '');
+            }).join(' · ');
+            banner.appendChild(vlist);
+            var hint = document.createElement('div');
+            hint.style.cssText = 'font-size: 11px; color: var(--text-secondary, #aaa); margin-top: 6px;';
+            hint.textContent = 'Tip: lower-risk findings (TODOs, missing tests) pass the gate by default. High-risk refactors require raising the risk cap in dev_autopilot_config.';
+            banner.appendChild(hint);
+        }
+        wrap.appendChild(banner);
+    }
+
     var row = document.createElement('div');
     row.style.cssText = 'display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-top: 12px; padding-top: 10px; border-top: 1px solid var(--border-color, rgba(255,255,255,0.06));';
 
@@ -35380,7 +35420,6 @@ function renderDevAutopilotActions(findingId) {
         }
     }, 'reject:' + findingId));
 
-    var wrap = document.createElement('div');
     wrap.appendChild(row);
 
     if (state.devAutopilot.continuePlanningId === findingId) {

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -12,7 +12,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260328-aura"></script>
-  <script src="/command-hub/app.js?v=20260418-exafy-admin-rbac"></script>
+  <script src="/command-hub/app.js?v=20260418-inline-action-errors"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js"></script>
 </body>

--- a/services/gateway/src/routes/discover-search.ts
+++ b/services/gateway/src/routes/discover-search.ts
@@ -457,4 +457,50 @@ router.get('/search', async (req: Request, res: Response) => {
   });
 });
 
+// ==================== GET /product/:id ====================
+//
+// Single-product fetch for the /discover/product/:id page.
+// Same row shape as /search items but with no match_score / match_reasons
+// (there's no query context to rank against — this is a direct lookup).
+// Applies the same hard-filter for is_active; hidden-by-limitations is NOT
+// enforced here so shared/deep-linked URLs still resolve (caller can choose
+// whether to surface warnings separately).
+router.get('/product/:id', async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    res.status(500).json({ ok: false, error: 'Supabase unavailable' });
+    return;
+  }
+  const id = String(req.params.id ?? '').trim();
+  if (!/^[0-9a-fA-F-]{36}$/.test(id)) {
+    res.status(400).json({ ok: false, error: 'invalid product id' });
+    return;
+  }
+  const { data, error } = await supabase
+    .from('products')
+    .select(
+      'id, title, description, description_long, brand, category, subcategory, price_cents, currency, compare_at_price_cents, images, affiliate_url, availability, rating, review_count, origin_country, origin_region, merchant_id, ingredients_primary, health_goals, dietary_tags, reward_preview, dosage, serving_size, servings_per_container, evidence_links, safety_notes'
+    )
+    .eq('id', id)
+    .eq('is_active', true)
+    .maybeSingle();
+
+  if (error) {
+    res.status(500).json({ ok: false, error: error.message });
+    return;
+  }
+  if (!data) {
+    res.status(404).json({ ok: false, error: 'product not found' });
+    return;
+  }
+
+  res.json({
+    ok: true,
+    product: {
+      ...data,
+      evidence_links: Array.isArray(data.evidence_links) ? data.evidence_links : [],
+    },
+  });
+});
+
 export default router;

--- a/services/gateway/src/services/dev-autopilot-bridge.ts
+++ b/services/gateway/src/services/dev-autopilot-bridge.ts
@@ -112,7 +112,13 @@ async function supa<T>(
       },
     });
     if (!res.ok) return { ok: false, status: res.status, error: `${res.status}: ${await res.text()}` };
-    if (res.status === 204) return { ok: true, status: 204 };
+    if (res.status === 204 || res.status === 201) {
+      const text = await res.text();
+      if (!text) return { ok: true, status: res.status };
+      try {
+        return { ok: true, status: res.status, data: JSON.parse(text) as T };
+      } catch { return { ok: true, status: res.status }; }
+    }
     const data = (await res.json()) as T;
     return { ok: true, status: res.status, data };
   } catch (err) {

--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -113,7 +113,13 @@ async function supa<T>(
       },
     });
     if (!res.ok) return { ok: false, status: res.status, error: `${res.status}: ${await res.text()}` };
-    if (res.status === 204) return { ok: true, status: 204 };
+    if (res.status === 204 || res.status === 201) {
+      const text = await res.text();
+      if (!text) return { ok: true, status: res.status };
+      try {
+        return { ok: true, status: res.status, data: JSON.parse(text) as T };
+      } catch { return { ok: true, status: res.status }; }
+    }
     const data = (await res.json()) as T;
     return { ok: true, status: res.status, data };
   } catch (err) {

--- a/services/gateway/src/services/dev-autopilot-planning.ts
+++ b/services/gateway/src/services/dev-autopilot-planning.ts
@@ -134,7 +134,14 @@ async function supaRequest<T>(
       },
     });
     if (!res.ok) return { ok: false, status: res.status, error: `${res.status}: ${await res.text()}` };
-    if (res.status === 204) return { ok: true, status: 204 };
+    if (res.status === 204 || res.status === 201) {
+      // Prefer: return=minimal produces 201 with an empty body — don't parse.
+      const text = await res.text();
+      if (!text) return { ok: true, status: res.status };
+      try {
+        return { ok: true, status: res.status, data: JSON.parse(text) as T };
+      } catch { return { ok: true, status: res.status }; }
+    }
     const data = (await res.json()) as T;
     return { ok: true, status: res.status, data };
   } catch (err) {

--- a/services/gateway/src/services/dev-autopilot-watcher.ts
+++ b/services/gateway/src/services/dev-autopilot-watcher.ts
@@ -67,7 +67,13 @@ async function supa<T>(
       },
     });
     if (!res.ok) return { ok: false, status: res.status, error: `${res.status}: ${await res.text()}` };
-    if (res.status === 204) return { ok: true, status: 204 };
+    if (res.status === 204 || res.status === 201) {
+      const text = await res.text();
+      if (!text) return { ok: true, status: res.status };
+      try {
+        return { ok: true, status: res.status, data: JSON.parse(text) as T };
+      } catch { return { ok: true, status: res.status }; }
+    }
     return { ok: true, status: res.status, data: (await res.json()) as T };
   } catch (err) {
     return { ok: false, status: 500, error: String(err) };


### PR DESCRIPTION
User reports 'spinning wheel, then nothing happens' when approving a HIGH RISK finding. Safety gate is correctly blocking it; the rejection was only in a toast. Now shows an inline red banner in the plan block with violation codes + hint about raising the cap.