### PR TITLE
feat(og-proxy): product share URLs get real OG tags via worker

### DIFF
--- a/cloudflare/vitanaland-og-proxy/worker.js
+++ b/cloudflare/vitanaland-og-proxy/worker.js
@@ -1,4 +1,5 @@
 const SUPABASE_FUNCTIONS = 'https://inmkhvwdcuyhnxkgfvsb.supabase.co/functions/v1';
+const GATEWAY_URL = 'https://gateway-q74ibpv6ia-uc.a.run.app';
 
 const CRAWLERS = ['whatsapp', 'facebookexternalhit', 'facebot',
   'twitterbot', 'linkedinbot', 'slackbot', 'telegrambot', 'discordbot'];
@@ -8,7 +9,7 @@ function isCrawler(ua) {
 }
 
 function parseRoute(pathname) {
-  const match = pathname.match(/^\/(events|profiles|rooms|matches)\/(.+)$/);
+  const match = pathname.match(/^\/(events|profiles|rooms|matches|products)\/(.+)$/);
   if (match) return { type: match[1], identifier: match[2] };
   // Handle /pub/events/{id} format
   const pubMatch = pathname.match(/^\/pub\/events\/(.+)$/);
@@ -17,6 +18,89 @@ function parseRoute(pathname) {
   const bare = pathname.replace(/^\//, '');
   if (bare) return { type: 'events', identifier: bare };
   return null;
+}
+
+function escapeHtml(s) {
+  return String(s).replace(/[&<>"']/g, c =>
+    ({ '&': '&amp;', '<': '&lt;', '>': '&gt;', '"': '&quot;', "'": '&#39;' }[c]));
+}
+
+function formatPrice(cents, currency) {
+  if (cents == null || !currency) return '';
+  try {
+    return new Intl.NumberFormat('en', {
+      style: 'currency',
+      currency: currency.toUpperCase(),
+      minimumFractionDigits: 0,
+      maximumFractionDigits: 2,
+    }).format(cents / 100);
+  } catch {
+    return `${(cents / 100).toFixed(2)} ${currency.toUpperCase()}`;
+  }
+}
+
+/**
+ * Build an HTML page with OG meta tags for a product. Served to crawlers only.
+ * Queries the gateway's public product endpoint — no auth required.
+ */
+async function renderProductOg(id, canonicalUrl) {
+  const resp = await fetch(`${GATEWAY_URL}/api/v1/discover/product/${encodeURIComponent(id)}`);
+  if (!resp.ok) {
+    return new Response('Product not found', { status: 404 });
+  }
+  const { product: p } = await resp.json();
+  if (!p) return new Response('Product not found', { status: 404 });
+
+  const title = `${p.title}${p.brand ? ` — ${p.brand}` : ''}`;
+  const priceLine = formatPrice(p.price_cents, p.currency);
+  const rawDesc = p.description || p.description_long || `${p.title} on Vitana`;
+  // Single-line, ~200 char description for OG description meta
+  const description = rawDesc.replace(/\s+/g, ' ').trim().slice(0, 200) +
+    (priceLine ? ` — ${priceLine}` : '');
+  const image = (Array.isArray(p.images) && p.images[0]) || '';
+
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>${escapeHtml(title)}</title>
+  <meta name="description" content="${escapeHtml(description)}">
+  <link rel="canonical" href="${escapeHtml(canonicalUrl)}">
+
+  <meta property="og:site_name" content="VITANA">
+  <meta property="og:type" content="product">
+  <meta property="og:title" content="${escapeHtml(title)}">
+  <meta property="og:description" content="${escapeHtml(description)}">
+  <meta property="og:url" content="${escapeHtml(canonicalUrl)}">
+  ${image ? `<meta property="og:image" content="${escapeHtml(image)}">
+  <meta property="og:image:width" content="1200">
+  <meta property="og:image:height" content="1200">
+  <meta property="og:image:alt" content="${escapeHtml(p.title)}">` : ''}
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="${escapeHtml(title)}">
+  <meta name="twitter:description" content="${escapeHtml(description)}">
+  ${image ? `<meta name="twitter:image" content="${escapeHtml(image)}">` : ''}
+
+  ${priceLine ? `<meta property="product:price:amount" content="${escapeHtml((p.price_cents / 100).toFixed(2))}">
+  <meta property="product:price:currency" content="${escapeHtml((p.currency || 'USD').toUpperCase())}">` : ''}
+  ${p.availability ? `<meta property="product:availability" content="${escapeHtml(p.availability)}">` : ''}
+  ${p.brand ? `<meta property="product:brand" content="${escapeHtml(p.brand)}">` : ''}
+</head>
+<body>
+  <h1>${escapeHtml(title)}</h1>
+  ${priceLine ? `<p><strong>${escapeHtml(priceLine)}</strong></p>` : ''}
+  <p>${escapeHtml(description)}</p>
+  <p><a href="${escapeHtml(canonicalUrl)}">View on Vitana</a></p>
+</body>
+</html>`;
+
+  return new Response(html, {
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'public, max-age=300, s-maxage=300',
+    },
+  });
 }
 
 function getOgFunctionUrl(type, identifier) {
@@ -30,6 +114,7 @@ function getOgFunctionUrl(type, identifier) {
       return `${SUPABASE_FUNCTIONS}/og-room?id=${encodeURIComponent(identifier)}`;
     case 'matches':
       return `${SUPABASE_FUNCTIONS}/og-match?id=${encodeURIComponent(identifier)}`;
+    // products handled inline below via renderProductOg() — no Supabase Function needed
     default:
       return null;
   }
@@ -49,6 +134,8 @@ function getRedirectUrl(type, identifier) {
       return `https://vitanaland.com/?share=room&id=${encodeURIComponent(identifier)}`;
     case 'matches':
       return `https://vitanaland.com/discover?m=${encodeURIComponent(identifier)}`;
+    case 'products':
+      return `https://vitanaland.com/discover/product/${encodeURIComponent(identifier)}`;
     default:
       return 'https://vitanaland.com';
   }
@@ -65,6 +152,12 @@ export default {
     }
 
     if (isCrawler(ua)) {
+      // Products: generate OG HTML inline from the gateway product endpoint.
+      if (route.type === 'products') {
+        const canonical = getRedirectUrl('products', route.identifier);
+        return renderProductOg(route.identifier, canonical);
+      }
+
       const ogUrl = getOgFunctionUrl(route.type, route.identifier);
       if (ogUrl) {
         const ogResp = await fetch(ogUrl, {

--- a/cloudflare/vitanaland-og-proxy/wrangler.toml
+++ b/cloudflare/vitanaland-og-proxy/wrangler.toml
@@ -1,0 +1,15 @@
+name = "vitanaland-og-proxy"
+main = "worker.js"
+compatibility_date = "2024-10-01"
+
+# Worker is currently deployed manually via the Cloudflare dashboard and bound
+# to the e.vitanaland.com route. Running `wrangler deploy` from this folder
+# after `wrangler login` will update the same worker in place.
+#
+# Route binding (configure in the Cloudflare dashboard for the Worker):
+#   e.vitanaland.com/*   →   vitanaland-og-proxy
+#
+# The worker reads:
+#   - Supabase Edge Functions at inmkhvwdcuyhnxkgfvsb.supabase.co  (events/profiles/rooms/matches OG)
+#   - Gateway at gateway-q74ibpv6ia-uc.a.run.app  (marketplace product OG, inline)
+# Both are constants in worker.js; no secrets required.


### PR DESCRIPTION
## Problem
Shared product links currently render without a preview image. The SPA injects OG meta tags client-side, but Slack/Twitter/iMessage/WhatsApp crawlers fetch the URL without executing JS — they only see the static \`index.html\`.

## Fix
Extend the existing \`vitanaland-og-proxy\` worker (e.vitanaland.com) with a \`/products/:id\` route:
- Crawler → fetch gateway \`/api/v1/discover/product/:id\` → render inline HTML with full \`og:title\` / \`og:description\` / \`og:image\` / \`twitter:*\` / \`product:price:*\` metadata
- Non-crawler → 302 to \`vitanaland.com/discover/product/:id\` (the SPA)

No Supabase Edge Function needed — OG HTML is rendered inline with a minimal string template.

Companion frontend change (vitana-v1 PR incoming) switches the product share button to use \`getShareUrl('product', id)\` → \`https://e.vitanaland.com/products/{id}\`.

## Deployment
The worker has no \`wrangler.toml\` today and is deployed manually. This PR adds one. After merge:
\`\`\`
cd cloudflare/vitanaland-og-proxy
wrangler login    # one-time
wrangler deploy
\`\`\`
The existing e.vitanaland.com route binding continues to point at the \`vitanaland-og-proxy\` worker — no CF dashboard change needed.

## Test
After deploy:
\`\`\`
curl -H 'User-Agent: Slackbot-LinkExpanding' https://e.vitanaland.com/products/bdd702dd-d908-46db-943b-24c5924f0b67
\`\`\`
should return HTML with \`<meta property="og:image" content="https://images.unsplash.com/...">\`.

curl without the Slackbot UA should return a 302 to \`https://vitanaland.com/discover/product/...\`.