### PR TITLE
ci: auto-deploy Cloudflare Workers on push to main

### DIFF
--- a/.github/workflows/DEPLOY-CLOUDFLARE-WORKERS.yml
+++ b/.github/workflows/DEPLOY-CLOUDFLARE-WORKERS.yml
@@ -1,0 +1,92 @@
+name: Deploy Cloudflare Workers
+
+# Auto-deploys any Cloudflare Worker under cloudflare/ whose source changed
+# on push to main. Uses wrangler with CLOUDFLARE_API_TOKEN from repo secrets.
+#
+# Workers currently deployed this way:
+#   cloudflare/vitanaland-og-proxy/  → e.vitanaland.com route
+#
+# To add a new worker: drop a folder under cloudflare/<name>/ with worker.js
+# and wrangler.toml. The path filter + matrix below will pick it up on push.
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'cloudflare/**'
+      - '.github/workflows/DEPLOY-CLOUDFLARE-WORKERS.yml'
+  workflow_dispatch:
+    inputs:
+      worker:
+        description: 'Worker directory under cloudflare/ (leave blank to deploy all)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cloudflare-workers-deploy
+  cancel-in-progress: false
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      workers: ${{ steps.list.outputs.workers }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # need previous commit to diff
+      - id: list
+        run: |
+          set -euo pipefail
+          if [ -n "${{ inputs.worker }}" ]; then
+            # Manual dispatch — deploy exactly the one the operator named
+            if [ ! -f "${{ inputs.worker }}/wrangler.toml" ]; then
+              echo "::error::${{ inputs.worker }}/wrangler.toml not found"; exit 1
+            fi
+            echo "workers=[\"${{ inputs.worker }}\"]" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Push to main — deploy only workers whose directory contains a changed file.
+          # Changed files in the last commit vs. previous commit:
+          changed=$(git diff --name-only HEAD^ HEAD || true)
+          echo "Changed files:"
+          echo "$changed"
+          mapfile -t all_dirs < <(
+            find cloudflare -mindepth 2 -maxdepth 2 -name wrangler.toml -printf '%h\n' | sort -u
+          )
+          touched=()
+          for d in "${all_dirs[@]}"; do
+            if echo "$changed" | grep -q "^$d/"; then
+              touched+=("$d")
+            fi
+          done
+          json=$(printf '%s\n' "${touched[@]}" | jq -R . | jq -s -c .)
+          echo "workers=$json" >> "$GITHUB_OUTPUT"
+          echo "Workers to deploy: $json"
+
+  deploy:
+    needs: detect
+    if: needs.detect.outputs.workers != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dir: ${{ fromJson(needs.detect.outputs.workers) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Deploy ${{ matrix.dir }}
+        working-directory: ${{ matrix.dir }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          echo "Deploying $(basename ${{ matrix.dir }})"
+          npx --yes wrangler@3 deploy


### PR DESCRIPTION
Previously workers were deployed manually via CF dashboard — meaning worker code changes could merge to main without the live worker updating (hit this on PR #694).

Workflow:
- Triggers on push to main when files under `cloudflare/` change
- Also `workflow_dispatch` with a single-worker override
- Detects which worker dirs actually changed in the last commit (no unnecessary redeploys)
- Runs `npx wrangler@3 deploy` per changed worker dir
- Uses `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID` from repo secrets (already set)

Any new `cloudflare/<name>/wrangler.toml` is auto-detected — no workflow edits needed to onboard new workers.