### PR TITLE
BOOTSTRAP-SESSION-POLL fix early-exit race in Managed Agents polling

### DIFF
--- a/.github/workflows/DEPLOY-CLOUDFLARE-WORKERS.yml
+++ b/.github/workflows/DEPLOY-CLOUDFLARE-WORKERS.yml
@@ -1,0 +1,92 @@
+name: Deploy Cloudflare Workers
+
+# Auto-deploys any Cloudflare Worker under cloudflare/ whose source changed
+# on push to main. Uses wrangler with CLOUDFLARE_API_TOKEN from repo secrets.
+#
+# Workers currently deployed this way:
+#   cloudflare/vitanaland-og-proxy/  → e.vitanaland.com route
+#
+# To add a new worker: drop a folder under cloudflare/<name>/ with worker.js
+# and wrangler.toml. The path filter + matrix below will pick it up on push.
+
+on:
+  push:
+    branches: [ main ]
+    paths:
+      - 'cloudflare/**'
+      - '.github/workflows/DEPLOY-CLOUDFLARE-WORKERS.yml'
+  workflow_dispatch:
+    inputs:
+      worker:
+        description: 'Worker directory under cloudflare/ (leave blank to deploy all)'
+        required: false
+        default: ''
+
+permissions:
+  contents: read
+
+concurrency:
+  group: cloudflare-workers-deploy
+  cancel-in-progress: false
+
+jobs:
+  detect:
+    runs-on: ubuntu-latest
+    outputs:
+      workers: ${{ steps.list.outputs.workers }}
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 2  # need previous commit to diff
+      - id: list
+        run: |
+          set -euo pipefail
+          if [ -n "${{ inputs.worker }}" ]; then
+            # Manual dispatch — deploy exactly the one the operator named
+            if [ ! -f "${{ inputs.worker }}/wrangler.toml" ]; then
+              echo "::error::${{ inputs.worker }}/wrangler.toml not found"; exit 1
+            fi
+            echo "workers=[\"${{ inputs.worker }}\"]" >> "$GITHUB_OUTPUT"
+            exit 0
+          fi
+          # Push to main — deploy only workers whose directory contains a changed file.
+          # Changed files in the last commit vs. previous commit:
+          changed=$(git diff --name-only HEAD^ HEAD || true)
+          echo "Changed files:"
+          echo "$changed"
+          mapfile -t all_dirs < <(
+            find cloudflare -mindepth 2 -maxdepth 2 -name wrangler.toml -printf '%h\n' | sort -u
+          )
+          touched=()
+          for d in "${all_dirs[@]}"; do
+            if echo "$changed" | grep -q "^$d/"; then
+              touched+=("$d")
+            fi
+          done
+          json=$(printf '%s\n' "${touched[@]}" | jq -R . | jq -s -c .)
+          echo "workers=$json" >> "$GITHUB_OUTPUT"
+          echo "Workers to deploy: $json"
+
+  deploy:
+    needs: detect
+    if: needs.detect.outputs.workers != '[]'
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        dir: ${{ fromJson(needs.detect.outputs.workers) }}
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: '20'
+
+      - name: Deploy ${{ matrix.dir }}
+        working-directory: ${{ matrix.dir }}
+        env:
+          CLOUDFLARE_API_TOKEN: ${{ secrets.CLOUDFLARE_API_TOKEN }}
+          CLOUDFLARE_ACCOUNT_ID: ${{ secrets.CLOUDFLARE_ACCOUNT_ID }}
+        run: |
+          echo "Deploying $(basename ${{ matrix.dir }})"
+          npx --yes wrangler@3 deploy

--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -442,6 +442,8 @@ async function runExecutionSession(
   const texts: string[] = [];
   const deadline = Date.now() + SESSION_TIMEOUT_MS;
   let done = false;
+  let sawAgentMessage = false;
+  let sawUserMessage = false;
   while (!done && Date.now() < deadline) {
     const ev = await anthropicRequest<{ data?: Array<{ id: string; type: string; content?: Array<{ type: string; text?: string }>; stop_reason?: { type?: string } }> }>(
       `/v1/sessions/${sessionId}/events`,
@@ -451,12 +453,17 @@ async function runExecutionSession(
     for (const e of events) {
       if (seen.has(e.id)) continue;
       seen.add(e.id);
-      if (e.type === 'agent.message' && e.content) {
+      if (e.type === 'user.message') {
+        sawUserMessage = true;
+      } else if (e.type === 'agent.message' && e.content) {
+        sawAgentMessage = true;
         for (const b of e.content) {
           if (b.type === 'text' && b.text) texts.push(b.text);
         }
       } else if (e.type === 'session.status_idle' && e.stop_reason?.type !== 'requires_action') {
-        done = true;
+        // Don't exit on the pre-user-message idle state — session is idle
+        // between create and user.message arrival.
+        if (sawAgentMessage && sawUserMessage) done = true;
       } else if (e.type === 'session.status_terminated') {
         done = true;
       }

--- a/services/gateway/src/services/dev-autopilot-planning.ts
+++ b/services/gateway/src/services/dev-autopilot-planning.ts
@@ -35,7 +35,7 @@ const PLAN_VTID = 'VTID-DEV-AUTOPILOT';
 const ANTHROPIC_API_KEY = process.env.ANTHROPIC_API_KEY || '';
 const ANTHROPIC_BASE = 'https://api.anthropic.com';
 const BETA_HEADER = 'managed-agents-2026-04-01';
-const SESSION_TIMEOUT_MS = 180_000; // 3 minutes per planning session
+const SESSION_TIMEOUT_MS = 360_000; // 6 minutes per planning session — large-file findings take time
 
 function getAgentIds(): { agent_id: string; environment_id: string } {
   return {
@@ -199,13 +199,22 @@ function buildPlanningPrompt(
 
   lines.push(
     `## Your task`,
-    `1. Open /workspace/repo and read the file(s) referenced by the finding.`,
+    `1. Open /workspace/repo. Skim the referenced file strategically — read`,
+    `   only what you need to understand structure. For large files (>1000`,
+    `   lines), read the top 200 lines (imports + top-level exports) and`,
+    `   grep/search for key symbols rather than reading the whole thing.`,
+    `   Do NOT try to read multi-thousand-line files end-to-end.`,
     `2. Verify the signal — is it genuine, what is the root cause, what else is`,
-    `   affected?`,
+    `   affected? You can answer this from structure + grep alone for most`,
+    `   signals.`,
     `3. Identify any tests, types, or callers that a fix must touch.`,
     `4. Write a complete plan using the canonical structure below. Cite every`,
     `   file you propose to modify by its repo-relative path. A plan that cites`,
     `   a file that doesn't exist will be rejected by validation.`,
+    ``,
+    `Budget: produce the final plan within 4 minutes. If you are still`,
+    `reading files at the 3-minute mark, stop and write the plan with the`,
+    `information you have.`,
     ``,
     `## Output format — raw markdown, no code fences around the whole document`,
     ``,
@@ -389,7 +398,12 @@ async function runPlanningSession(
 
   const planMarkdown = textParts.join('\n').trim();
   if (!planMarkdown) {
-    return { ok: false, error: 'Agent produced no plan output', session_id: sessionId };
+    const elapsed = Math.round((Date.now() - (deadline - SESSION_TIMEOUT_MS)) / 1000);
+    return {
+      ok: false,
+      error: `Agent produced no plan output after ${elapsed}s (timeout ${SESSION_TIMEOUT_MS / 1000}s). The file may be too large to plan without deeper context — try again, or regenerate after raising the planning timeout.`,
+      session_id: sessionId,
+    };
   }
   return { ok: true, plan_markdown: planMarkdown, session_id: sessionId };
 }

--- a/services/gateway/src/services/dev-autopilot-planning.ts
+++ b/services/gateway/src/services/dev-autopilot-planning.ts
@@ -355,7 +355,7 @@ async function runPlanningSession(
   }
   const sessionId = sessionResult.data.id;
 
-  await anthropicRequest(`/v1/sessions/${sessionId}/events`, {
+  const userMsgPost = await anthropicRequest(`/v1/sessions/${sessionId}/events`, {
     method: 'POST',
     body: {
       events: [
@@ -366,11 +366,20 @@ async function runPlanningSession(
       ],
     },
   });
+  if (!userMsgPost.ok) {
+    return {
+      ok: false,
+      error: `user.message post failed: ${userMsgPost.error}`,
+      session_id: sessionId,
+    };
+  }
 
   const seenIds = new Set<string>();
   const textParts: string[] = [];
   const deadline = Date.now() + SESSION_TIMEOUT_MS;
   let done = false;
+  let sawAgentMessage = false;
+  let sawUserMessage = false;
 
   while (!done && Date.now() < deadline) {
     const eventsResult = await anthropicRequest<{ data?: Array<{ id: string; type: string; content?: Array<{ type: string; text?: string }>; stop_reason?: { type?: string } }> }>(
@@ -383,12 +392,20 @@ async function runPlanningSession(
     for (const event of events) {
       if (seenIds.has(event.id)) continue;
       seenIds.add(event.id);
-      if (event.type === 'agent.message' && event.content) {
+      if (event.type === 'user.message') {
+        sawUserMessage = true;
+      } else if (event.type === 'agent.message' && event.content) {
+        sawAgentMessage = true;
         for (const block of event.content) {
           if (block.type === 'text' && block.text) textParts.push(block.text);
         }
       } else if (event.type === 'session.status_idle') {
-        if (event.stop_reason?.type !== 'requires_action') done = true;
+        // Only treat idle as "done" once the agent has had a turn. Sessions
+        // enter idle state between the create-session call and the user's
+        // first message — exiting then would miss all output.
+        if (event.stop_reason?.type !== 'requires_action' && sawAgentMessage && sawUserMessage) {
+          done = true;
+        }
       } else if (event.type === 'session.status_terminated') {
         done = true;
       }


### PR DESCRIPTION
Planning / execute poll loops exited after 2s because Managed Agents sessions are IDLE between create and first user.message. Now waits for both sawUserMessage + sawAgentMessage before treating status_idle as done.