### PR TITLE
feat(proactive-guide): Phase 0 + 0.5 — schema and voice opener with dismissal honor (BOOTSTRAP-PROACTIVE-GUIDE-P05)

### DIFF
--- a/services/gateway/src/services/guide/dismissal-tool.ts
+++ b/services/gateway/src/services/guide/dismissal-tool.ts
@@ -1,0 +1,216 @@
+/**
+ * Proactive Guide — Dismissal Tool
+ *
+ * Tool the LLM calls when it detects the user wants to back off:
+ *   - "skip it"          → dismiss the current candidate (silence 24h)
+ *   - "not today"        → pause all proactive until tomorrow 06:00
+ *   - "give me space"    → pause all 48h
+ *   - "not this week"    → pause all 7d
+ *   - "don't mention X"  → mute category permanently-ish (90d)
+ *   - "you can talk again" → clear all active pauses
+ *
+ * The LLM is responsible for detecting the intent — its language understanding
+ * is more flexible than any regex. The system prompt (Proactive Opener Rules
+ * + Silent Honor Rules) tells it when to call this tool and how to respond
+ * after calling (briefly, no apology, no "I'll stop now" speech).
+ */
+
+import { getSupabase } from '../../lib/supabase';
+import { ProactivePauseScope } from './types';
+import { emitGuideTelemetry } from './guide-telemetry';
+
+const LOG_PREFIX = '[Guide:dismissal-tool]';
+
+export const PAUSE_PROACTIVE_GUIDANCE_TOOL = {
+  name: 'pause_proactive_guidance',
+  description:
+    'Honor a user request to back off from proactive suggestions. ' +
+    'Call this when the user says "skip it", "not today", "give me space", ' +
+    '"not this week", "don\'t mention X again", "stop being proactive", ' +
+    'or any equivalent. Choose scope + duration that matches what they asked. ' +
+    'After calling, respond briefly (max one short acknowledgement like "got it") ' +
+    'and pivot naturally — do NOT apologize or make a thing of it.',
+  parameters: {
+    type: 'object',
+    properties: {
+      scope: {
+        type: 'string',
+        enum: ['all', 'category', 'nudge_key', 'channel'],
+        description:
+          '"all" = pause all proactive openers. ' +
+          '"category" = mute a domain (use scope_value, e.g., "business_hub", "calendar"). ' +
+          '"nudge_key" = dismiss the specific candidate just surfaced (use scope_value with the candidate\'s nudge_key). ' +
+          '"channel" = mute on a specific channel (scope_value="voice" or "text"). ' +
+          'Default: "all" if unsure.',
+      },
+      scope_value: {
+        type: 'string',
+        description:
+          'Required when scope is category, nudge_key, or channel. Omit for scope=all.',
+      },
+      duration_minutes: {
+        type: 'integer',
+        description:
+          'Pause duration in minutes. Examples: ' +
+          '"not today" → minutes until 06:00 next day (compute from now), ' +
+          '"give me space" → 2880 (48h), ' +
+          '"not this week" → 10080 (7d), ' +
+          '"don\'t mention X again" → 129600 (90d). ' +
+          'Default 1440 (24h) when uncertain.',
+      },
+      reason: {
+        type: 'string',
+        description: 'Short paraphrase of what the user said. Stored for transparency. Optional.',
+      },
+    },
+    required: ['scope'],
+  },
+};
+
+export const CLEAR_PROACTIVE_PAUSES_TOOL = {
+  name: 'clear_proactive_pauses',
+  description:
+    'Clear all active proactive pauses for the user. Call this when the user ' +
+    'explicitly invites you to be proactive again — "you can talk again", ' +
+    '"go ahead and suggest things", "ok resume". After calling, you may resume ' +
+    'normal proactive behavior, but do not immediately surface a backlog of suggestions.',
+  parameters: {
+    type: 'object',
+    properties: {},
+  },
+};
+
+export interface PauseToolInput {
+  scope: ProactivePauseScope;
+  scope_value?: string;
+  duration_minutes?: number;
+  reason?: string;
+}
+
+export interface PauseToolResult {
+  success: boolean;
+  paused_until?: string;
+  scope?: ProactivePauseScope;
+  scope_value?: string | null;
+  error?: string;
+}
+
+/**
+ * Execute the pause_proactive_guidance tool. Writes user_proactive_pause row.
+ */
+export async function executePauseProactiveGuidance(
+  args: PauseToolInput,
+  context: { user_id: string; channel: 'voice' | 'text' },
+): Promise<PauseToolResult> {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return { success: false, error: 'storage_unavailable' };
+  }
+
+  if (args.scope !== 'all' && !args.scope_value) {
+    return { success: false, error: 'scope_value_required' };
+  }
+
+  const durationMinutes = clampDuration(args.duration_minutes ?? 1440);
+  const pausedUntil = new Date(Date.now() + durationMinutes * 60 * 1000).toISOString();
+
+  const { data, error } = await supabase
+    .from('user_proactive_pause')
+    .insert({
+      user_id: context.user_id,
+      scope: args.scope,
+      scope_value: args.scope === 'all' ? null : (args.scope_value ?? null),
+      paused_from: new Date().toISOString(),
+      paused_until: pausedUntil,
+      reason: args.reason ?? null,
+      created_via: context.channel === 'voice' ? 'voice' : 'text',
+    })
+    .select()
+    .single();
+
+  if (error) {
+    console.error(`${LOG_PREFIX} insert failed:`, error.message);
+    return { success: false, error: error.message };
+  }
+
+  // Also write to user_nudge_state if scope=nudge_key so opener-mvp's
+  // silenced_until check honors it on next pickOpenerCandidate.
+  if (args.scope === 'nudge_key' && args.scope_value) {
+    await supabase
+      .from('user_nudge_state')
+      .upsert(
+        {
+          user_id: context.user_id,
+          nudge_key: args.scope_value,
+          dismissed_at: new Date().toISOString(),
+          silenced_until: pausedUntil,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'user_id,nudge_key' },
+      );
+  }
+
+  await emitGuideTelemetry('guide.dismissal.pause_created', {
+    user_id: context.user_id,
+    scope: args.scope,
+    scope_value: args.scope_value ?? null,
+    duration_minutes: durationMinutes,
+    paused_until: pausedUntil,
+    via: context.channel,
+  });
+
+  console.log(
+    `${LOG_PREFIX} pause created: scope=${args.scope} value=${args.scope_value ?? '-'} ` +
+    `until=${pausedUntil} for user=${context.user_id}`,
+  );
+
+  return {
+    success: true,
+    paused_until: pausedUntil,
+    scope: args.scope,
+    scope_value: data?.scope_value ?? null,
+  };
+}
+
+/**
+ * Execute the clear_proactive_pauses tool. Deletes all currently-active pauses
+ * for the user (does not touch already-expired rows — they stay as history).
+ */
+export async function executeClearProactivePauses(
+  context: { user_id: string },
+): Promise<{ success: boolean; cleared_count: number; error?: string }> {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return { success: false, cleared_count: 0, error: 'storage_unavailable' };
+  }
+
+  const nowIso = new Date().toISOString();
+  const { data, error } = await supabase
+    .from('user_proactive_pause')
+    .update({ paused_until: nowIso })
+    .eq('user_id', context.user_id)
+    .gt('paused_until', nowIso)
+    .select('id');
+
+  if (error) {
+    console.error(`${LOG_PREFIX} clear failed:`, error.message);
+    return { success: false, cleared_count: 0, error: error.message };
+  }
+
+  const count = data?.length ?? 0;
+
+  await emitGuideTelemetry('guide.dismissal.pause_cleared', {
+    user_id: context.user_id,
+    cleared_count: count,
+  });
+
+  console.log(`${LOG_PREFIX} cleared ${count} active pauses for user=${context.user_id}`);
+
+  return { success: true, cleared_count: count };
+}
+
+function clampDuration(minutes: number): number {
+  // Floor 1 minute, ceiling 1 year (don't let users accidentally lock proactive
+  // forever — settings UI in Phase 7 handles permanent disable explicitly).
+  return Math.max(1, Math.min(525_600, Math.floor(minutes)));
+}

--- a/services/gateway/src/services/guide/guide-telemetry.ts
+++ b/services/gateway/src/services/guide/guide-telemetry.ts
@@ -1,0 +1,40 @@
+/**
+ * Proactive Guide — OASIS telemetry helpers.
+ *
+ * Single emit() facade so all guide events use a consistent vtid + source +
+ * topic naming. Phase 0.5 starts with opener and dismissal events; later
+ * phases add scoring + learning telemetry.
+ */
+
+import { emitOasisEvent } from '../oasis-event-service';
+
+const VTID = 'PROACTIVE-GUIDE';
+const SOURCE = 'guide';
+
+export type GuideEventType =
+  | 'guide.opener.shown'
+  | 'guide.opener.suppressed_by_pause'
+  | 'guide.opener.no_candidate'
+  | 'guide.dismissal.pause_created'
+  | 'guide.dismissal.pause_cleared'
+  | 'guide.flag.disabled';
+
+export async function emitGuideTelemetry(
+  type: GuideEventType,
+  payload: Record<string, unknown>,
+  status: 'info' | 'success' | 'warning' | 'error' = 'info',
+): Promise<void> {
+  try {
+    await emitOasisEvent({
+      vtid: VTID,
+      type,
+      source: SOURCE,
+      status,
+      message: type,
+      payload,
+    });
+  } catch (err: any) {
+    // Telemetry must never break the guide — log and move on.
+    console.warn(`[Guide:telemetry] failed to emit ${type}:`, err?.message);
+  }
+}

--- a/services/gateway/src/services/guide/index.ts
+++ b/services/gateway/src/services/guide/index.ts
@@ -1,0 +1,22 @@
+/**
+ * Proactive Guide — barrel exports.
+ *
+ * Public surface for the guide module used by vitana-brain.ts and ORB voice.
+ */
+
+export { isPaused } from './pause-check';
+export { pickOpenerCandidate } from './opener-mvp';
+export {
+  PAUSE_PROACTIVE_GUIDANCE_TOOL,
+  CLEAR_PROACTIVE_PAUSES_TOOL,
+  executePauseProactiveGuidance,
+  executeClearProactivePauses,
+} from './dismissal-tool';
+export { emitGuideTelemetry } from './guide-telemetry';
+export {
+  type ProactivePause,
+  type ProactivePauseScope,
+  type OpenerCandidate,
+  type OpenerCandidateKind,
+  type OpenerSelection,
+} from './types';

--- a/services/gateway/src/services/guide/opener-mvp.ts
+++ b/services/gateway/src/services/guide/opener-mvp.ts
@@ -1,0 +1,232 @@
+/**
+ * Proactive Guide — Phase 0.5 Opener MVP
+ *
+ * Picks ONE candidate for the proactive opener using only data that
+ * already exists (life_compass + calendar_events + autopilot_recommendations).
+ * No contribution-vector scoring yet — that arrives in Phase 6.
+ *
+ * Heuristic (until Phase 6 swaps in real scoring):
+ *   1. Overdue autopilot calendar event (start_time < now, status='scheduled')
+ *   2. Upcoming autopilot event within 24h
+ *   3. Top "new" autopilot recommendation matching active role
+ *
+ * MUST check isPaused() before returning a candidate.
+ */
+
+import { getSupabase } from '../../lib/supabase';
+import { isPaused } from './pause-check';
+import {
+  OpenerCandidate,
+  OpenerCandidateKind,
+  OpenerSelection,
+} from './types';
+
+const LOG_PREFIX = '[Guide:opener-mvp]';
+
+export interface PickOpenerInput {
+  user_id: string;
+  active_role: 'community' | 'developer' | 'admin';
+  channel: 'voice' | 'text';
+}
+
+interface LifeCompassRow {
+  id: string;
+  primary_goal: string;
+  category: string;
+}
+
+interface CalendarEventRow {
+  id: string;
+  title: string;
+  start_time: string;
+  duration_minutes: number | null;
+  event_type: string;
+  status: string;
+  source_ref: string | null;
+}
+
+interface AutopilotRecRow {
+  id: string;
+  title: string;
+  summary: string;
+  domain: string;
+  role_scope: string;
+  status: string;
+  user_id: string | null;
+  created_at: string;
+}
+
+/**
+ * Pick the single best opener candidate for this user right now.
+ * Honor any active pause silently.
+ */
+export async function pickOpenerCandidate(input: PickOpenerInput): Promise<OpenerSelection> {
+  const supabase = getSupabase();
+  if (!supabase) {
+    console.warn(`${LOG_PREFIX} no supabase — yielding`);
+    return { candidate: null, suppressed_by_pause: false };
+  }
+
+  // Active goal (Life Compass) — frames every opener
+  const { data: compassRows } = await supabase
+    .from('life_compass')
+    .select('id, primary_goal, category')
+    .eq('user_id', input.user_id)
+    .eq('is_active', true)
+    .order('created_at', { ascending: false })
+    .limit(1);
+
+  const goal: LifeCompassRow | null = compassRows && compassRows.length ? (compassRows[0] as LifeCompassRow) : null;
+  const goalLink = goal ? { primary_goal: goal.primary_goal, category: goal.category } : undefined;
+
+  const nowIso = new Date().toISOString();
+  const in24hIso = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();
+
+  // 1. Overdue autopilot events (highest priority candidate kind)
+  const { data: overdueRows } = await supabase
+    .from('calendar_events')
+    .select('id, title, start_time, duration_minutes, event_type, status, source_ref')
+    .eq('user_id', input.user_id)
+    .eq('event_type', 'autopilot')
+    .eq('status', 'scheduled')
+    .lt('start_time', nowIso)
+    .order('start_time', { ascending: false })
+    .limit(1);
+
+  if (overdueRows && overdueRows.length) {
+    const ev = overdueRows[0] as CalendarEventRow;
+    const candidate = await buildAndCheck({
+      kind: 'overdue_calendar',
+      nudge_key: `overdue_event:${ev.id}`,
+      title: ev.title,
+      subline: ev.duration_minutes ? `${ev.duration_minutes} min — from earlier` : 'from earlier',
+      goalLink,
+      reason: 'overdue autopilot calendar event from before now',
+      category: 'calendar',
+      input,
+    });
+    if (candidate.candidate || candidate.suppressed_by_pause) return candidate;
+  }
+
+  // 2. Upcoming within 24h
+  const { data: upcomingRows } = await supabase
+    .from('calendar_events')
+    .select('id, title, start_time, duration_minutes, event_type, status, source_ref')
+    .eq('user_id', input.user_id)
+    .eq('event_type', 'autopilot')
+    .eq('status', 'scheduled')
+    .gt('start_time', nowIso)
+    .lt('start_time', in24hIso)
+    .order('start_time', { ascending: true })
+    .limit(1);
+
+  if (upcomingRows && upcomingRows.length) {
+    const ev = upcomingRows[0] as CalendarEventRow;
+    const startsIn = describeTimeUntil(ev.start_time);
+    const candidate = await buildAndCheck({
+      kind: 'upcoming_calendar',
+      nudge_key: `upcoming_event:${ev.id}`,
+      title: ev.title,
+      subline: `coming up ${startsIn}${ev.duration_minutes ? ` · ${ev.duration_minutes} min` : ''}`,
+      goalLink,
+      reason: 'autopilot event scheduled within next 24h',
+      category: 'calendar',
+      input,
+    });
+    if (candidate.candidate || candidate.suppressed_by_pause) return candidate;
+  }
+
+  // 3. Top "new" autopilot recommendation matching role
+  const { data: recRows } = await supabase
+    .from('autopilot_recommendations')
+    .select('id, title, summary, domain, role_scope, status, user_id, created_at')
+    .eq('user_id', input.user_id)
+    .eq('status', 'new')
+    .in('role_scope', ['any', input.active_role])
+    .order('created_at', { ascending: false })
+    .limit(1);
+
+  if (recRows && recRows.length) {
+    const rec = recRows[0] as AutopilotRecRow;
+    const candidate = await buildAndCheck({
+      kind: 'autopilot_recommendation',
+      nudge_key: `recommendation:${rec.id}`,
+      title: rec.title,
+      subline: rec.summary?.slice(0, 80),
+      goalLink,
+      reason: `top new autopilot recommendation in domain "${rec.domain}"`,
+      category: rec.domain,
+      input,
+    });
+    if (candidate.candidate || candidate.suppressed_by_pause) return candidate;
+  }
+
+  console.log(`${LOG_PREFIX} no candidate available for user ${input.user_id}`);
+  return { candidate: null, suppressed_by_pause: false };
+}
+
+interface BuildAndCheckInput {
+  kind: OpenerCandidateKind;
+  nudge_key: string;
+  title: string;
+  subline?: string;
+  goalLink?: { primary_goal: string; category: string };
+  reason: string;
+  category: string;
+  input: PickOpenerInput;
+}
+
+/**
+ * Build a candidate and check pause + nudge_state silencing in one shot.
+ * Returns suppression info when blocked.
+ */
+async function buildAndCheck(b: BuildAndCheckInput): Promise<OpenerSelection> {
+  const candidate: OpenerCandidate = {
+    nudge_key: b.nudge_key,
+    kind: b.kind,
+    title: b.title,
+    subline: b.subline,
+    goal_link: b.goalLink,
+    reason: b.reason,
+    category: b.category,
+  };
+
+  const pause = await isPaused({
+    user_id: b.input.user_id,
+    channel: b.input.channel,
+    category: b.category,
+    nudge_key: b.nudge_key,
+  });
+  if (pause.paused) {
+    return { candidate: null, suppressed_by_pause: true, suppressing_pause: pause.pause };
+  }
+
+  const supabase = getSupabase();
+  if (supabase) {
+    const { data: nudgeRows } = await supabase
+      .from('user_nudge_state')
+      .select('silenced_until')
+      .eq('user_id', b.input.user_id)
+      .eq('nudge_key', b.nudge_key)
+      .limit(1);
+    if (nudgeRows && nudgeRows.length && nudgeRows[0].silenced_until) {
+      const silenced = new Date(nudgeRows[0].silenced_until).getTime();
+      if (silenced > Date.now()) {
+        return { candidate: null, suppressed_by_pause: false };
+      }
+    }
+  }
+
+  return { candidate, suppressed_by_pause: false };
+}
+
+function describeTimeUntil(iso: string): string {
+  const ms = new Date(iso).getTime() - Date.now();
+  if (ms <= 0) return 'now';
+  const minutes = Math.floor(ms / 60000);
+  if (minutes < 60) return `in ${minutes} min`;
+  const hours = Math.floor(minutes / 60);
+  if (hours < 24) return `in ${hours}h`;
+  const days = Math.floor(hours / 24);
+  return `in ${days}d`;
+}

--- a/services/gateway/src/services/guide/pause-check.ts
+++ b/services/gateway/src/services/guide/pause-check.ts
@@ -1,0 +1,84 @@
+/**
+ * Proactive Guide — Pause Check
+ *
+ * Single authoritative function the opener pipeline calls before producing
+ * any proactive output. If any active row in user_proactive_pause covers
+ * the requested scope, the opener yields silently.
+ *
+ * The opener MUST call isPaused() before doing any LLM-bound work.
+ */
+
+import { getSupabase } from '../../lib/supabase';
+import { ProactivePause, ProactivePauseScope } from './types';
+
+const LOG_PREFIX = '[Guide:pause-check]';
+
+export interface PauseCheckInput {
+  user_id: string;
+  /** Channel the opener would render on. Used to honor channel-scoped pauses. */
+  channel?: 'voice' | 'text';
+  /** Category of the candidate — used to honor category-scoped pauses. */
+  category?: string;
+  /** Specific nudge_key — used to honor per-candidate dismissals. */
+  nudge_key?: string;
+}
+
+export interface PauseCheckResult {
+  paused: boolean;
+  pause?: ProactivePause;
+}
+
+/**
+ * Returns the first active pause that covers the requested scope, or null.
+ * "Active" = paused_until > now().
+ *
+ * Order of precedence (most specific first):
+ *   1. nudge_key match  (this exact candidate is dismissed)
+ *   2. category match   (this category is muted)
+ *   3. channel match    (this channel is muted)
+ *   4. all              (blanket pause)
+ */
+export async function isPaused(input: PauseCheckInput): Promise<PauseCheckResult> {
+  const supabase = getSupabase();
+  if (!supabase) {
+    console.warn(`${LOG_PREFIX} no supabase client — failing OPEN (no pause)`);
+    return { paused: false };
+  }
+
+  const nowIso = new Date().toISOString();
+
+  const { data, error } = await supabase
+    .from('user_proactive_pause')
+    .select('*')
+    .eq('user_id', input.user_id)
+    .gt('paused_until', nowIso)
+    .order('created_at', { ascending: false });
+
+  if (error) {
+    console.error(`${LOG_PREFIX} query failed:`, error.message);
+    return { paused: false };
+  }
+
+  if (!data || data.length === 0) {
+    return { paused: false };
+  }
+
+  const matchScopes: Array<{ scope: ProactivePauseScope; value: string | null }> = [];
+  if (input.nudge_key) matchScopes.push({ scope: 'nudge_key', value: input.nudge_key });
+  if (input.category)  matchScopes.push({ scope: 'category', value: input.category });
+  if (input.channel)   matchScopes.push({ scope: 'channel', value: input.channel });
+  matchScopes.push({ scope: 'all', value: null });
+
+  for (const target of matchScopes) {
+    const hit = data.find((row: ProactivePause) => {
+      if (row.scope !== target.scope) return false;
+      if (target.scope === 'all') return true;
+      return row.scope_value === target.value;
+    });
+    if (hit) {
+      return { paused: true, pause: hit as ProactivePause };
+    }
+  }
+
+  return { paused: false };
+}

--- a/services/gateway/src/services/guide/types.ts
+++ b/services/gateway/src/services/guide/types.ts
@@ -1,0 +1,55 @@
+/**
+ * Proactive Guide — Shared Types
+ *
+ * Types for the Phase 0.5 thin proactive opener and dismissal honor system.
+ * Plan: .claude/plans/lucent-stitching-sextant.md
+ */
+
+export type ProactivePauseScope = 'all' | 'category' | 'nudge_key' | 'channel';
+
+export interface ProactivePause {
+  id: string;
+  user_id: string;
+  scope: ProactivePauseScope;
+  scope_value: string | null;
+  paused_from: string;
+  paused_until: string;
+  reason: string | null;
+  created_via: 'voice' | 'text' | 'settings';
+  created_at: string;
+}
+
+export type OpenerCandidateKind =
+  | 'overdue_calendar'
+  | 'upcoming_calendar'
+  | 'autopilot_recommendation'
+  | 'wave_transition'
+  | 'goal_reminder';
+
+export interface OpenerCandidate {
+  /** Stable identifier used in user_nudge_state to prevent re-surfacing within silence window. */
+  nudge_key: string;
+  kind: OpenerCandidateKind;
+  /** What the LLM should reference. Short, concrete, in the user's language ideally. */
+  title: string;
+  /** Optional subline — duration, time, what it's for. */
+  subline?: string;
+  /** The Life Compass goal this candidate aligns with. Frames every opener. */
+  goal_link?: {
+    primary_goal: string;
+    category: string;
+  };
+  /** Shipping rationale for the LLM — why this was picked. Not shown to user verbatim. */
+  reason: string;
+  /** Optional category for category-mute checks. */
+  category?: string;
+}
+
+export interface OpenerSelection {
+  /** Null when there's no candidate OR an active pause covers the user. */
+  candidate: OpenerCandidate | null;
+  /** True if a pause caused suppression — useful for telemetry. */
+  suppressed_by_pause: boolean;
+  /** Set when suppressed_by_pause is true. */
+  suppressing_pause?: ProactivePause;
+}

--- a/services/gateway/src/services/vitana-brain.ts
+++ b/services/gateway/src/services/vitana-brain.ts
@@ -37,6 +37,17 @@ import { ContextLens, createContextLens } from '../types/context-lens';
 import { ConversationChannel, ContextPack } from '../types/conversation';
 import { getPersonalityConfigSync } from './ai-personality-service';
 import { emitOasisEvent } from './oasis-event-service';
+// Proactive Guide Phase 0.5
+import { getSystemControl } from './system-controls-service';
+import {
+  pickOpenerCandidate,
+  PAUSE_PROACTIVE_GUIDANCE_TOOL,
+  CLEAR_PROACTIVE_PAUSES_TOOL,
+  executePauseProactiveGuidance,
+  executeClearProactivePauses,
+  emitGuideTelemetry,
+  type OpenerCandidate,
+} from './guide';
 
 // =============================================================================
 // Types
@@ -327,9 +338,22 @@ export async function buildBrainSystemInstruction(input: {
     ? (ucConfig.orb_instruction || 'You are Vitana, an intelligent voice assistant. Keep responses concise and conversational for voice interaction.')
     : (ucConfig.operator_instruction || 'You are Vitana, an intelligent assistant. You can be detailed and use formatting when helpful.');
 
+  // -------------------------------------------------------------------------
+  // Proactive Guide Phase 0.5 — opener + dismissal honor rules
+  // Gated on `vitana_proactive_opener_enabled` (default FALSE).
+  // Always appends the Silent Honor Rules when guide is on so the LLM knows
+  // it has the dismissal tools and how to behave when called.
+  // -------------------------------------------------------------------------
+  const proactiveGuideBlock = await buildProactiveGuideBlock({
+    user_id: input.user_id,
+    role: input.role,
+    channel: input.channel,
+  });
+
   const instruction = `${baseInstruction}
 ${languageDirective}
 ${contextForLLM}
+${proactiveGuideBlock}
 
 Current conversation channel: ${input.channel}
 User's role: ${input.role}
@@ -339,9 +363,144 @@ ${ucConfig.common_instructions || '- Use the memory context to personalize respo
 - ${input.channel === 'orb' ? (ucConfig.instructions_orb || 'Keep responses brief and natural for voice') : (ucConfig.instructions_operator || 'You can use markdown formatting and be more detailed')}`;
 
   const latencyMs = Date.now() - startTime;
-  console.log(`${LOG_PREFIX} System instruction built in ${latencyMs}ms (${instruction.length} chars, ${contextPack.memory_hits?.length || 0} memory hits, calendar=${!!contextPack.calendar_context})`);
+  console.log(`${LOG_PREFIX} System instruction built in ${latencyMs}ms (${instruction.length} chars, ${contextPack.memory_hits?.length || 0} memory hits, calendar=${!!contextPack.calendar_context}, guide=${proactiveGuideBlock.length > 0 ? 'on' : 'off'})`);
 
   return { instruction, contextPack };
+}
+
+// =============================================================================
+// Proactive Guide system-prompt block (Phase 0.5)
+// =============================================================================
+
+/**
+ * Map an arbitrary role string to the three Guide roles.
+ * Defaults to 'community' for anything unrecognized.
+ */
+function mapRoleForGuide(role: string): 'community' | 'developer' | 'admin' {
+  const r = (role || '').toLowerCase();
+  if (r === 'developer' || r === 'dev') return 'developer';
+  if (r === 'admin' || r === 'super_admin' || r === 'superadmin') return 'admin';
+  return 'community';
+}
+
+/**
+ * Build the Proactive Guide block to append to the system instruction.
+ * Returns empty string when guide is disabled, so callers can concatenate freely.
+ */
+export async function buildProactiveGuideBlock(input: {
+  user_id: string;
+  role: string;
+  channel: ConversationChannel;
+}): Promise<string> {
+  const flag = await getSystemControl('vitana_proactive_opener_enabled').catch(() => null);
+  if (!flag || !flag.enabled) {
+    return '';
+  }
+
+  const channel: 'voice' | 'text' = input.channel === 'orb' ? 'voice' : 'text';
+  const guideRole = mapRoleForGuide(input.role);
+
+  // Best-effort opener fetch — never block instruction build on this.
+  let candidate: OpenerCandidate | null = null;
+  let suppressedByPause = false;
+  try {
+    const sel = await pickOpenerCandidate({
+      user_id: input.user_id,
+      active_role: guideRole,
+      channel,
+    });
+    candidate = sel.candidate;
+    suppressedByPause = sel.suppressed_by_pause;
+  } catch (err: any) {
+    console.warn(`${LOG_PREFIX} pickOpenerCandidate failed:`, err?.message);
+  }
+
+  // Telemetry — fire-and-forget
+  if (candidate) {
+    emitGuideTelemetry('guide.opener.shown', {
+      user_id: input.user_id,
+      channel,
+      role: guideRole,
+      nudge_key: candidate.nudge_key,
+      kind: candidate.kind,
+      goal: candidate.goal_link?.primary_goal ?? null,
+    }).catch(() => {});
+  } else if (suppressedByPause) {
+    emitGuideTelemetry('guide.opener.suppressed_by_pause', {
+      user_id: input.user_id,
+      channel,
+      role: guideRole,
+    }).catch(() => {});
+  } else {
+    emitGuideTelemetry('guide.opener.no_candidate', {
+      user_id: input.user_id,
+      channel,
+      role: guideRole,
+    }).catch(() => {});
+  }
+
+  // Always include the rules — even with no candidate today, the LLM still
+  // needs to know how to honor dismissals if the user volunteers one.
+  const rulesBlock = `
+=== PROACTIVE OPENER RULES (Phase 0.5) ===
+
+Vitanaland is a longevity platform — its mission is to help people improve
+quality of life and extend lifespan. You are the proactive guide. When the
+moment is right, lead — don't wait to be asked.
+
+WHEN TO OPEN PROACTIVELY:
+- A new conversation thread is starting, OR the user has been silent for a
+  while AND a proactive opener candidate is available below.
+- Maximum 1 unsolicited suggestion per turn.
+- Frame every nudge through the user's active Life Compass goal.
+- Tone: inspirational + educational, never pushy. Offer agency: "I can change
+  this anytime if you tell me to."
+
+SILENT HONOR RULES (non-negotiable):
+- If the user says "skip it", "not that one", "next" → call the
+  pause_proactive_guidance tool with scope="nudge_key" and the candidate's
+  nudge_key, duration_minutes=1440 (24h). Then pivot naturally.
+- If the user says "not today", "quiet today", "give me space" → call
+  pause_proactive_guidance with scope="all" and an appropriate
+  duration_minutes (until 06:00 next day, or 2880 for 48h).
+- If the user says "not this week", "ask me Monday" → scope="all",
+  duration_minutes matching what they asked.
+- If the user says "don't mention X again" → scope="category",
+  scope_value=the topic, duration_minutes=129600 (90d).
+- If the user says "ok you can talk again", "go ahead", "resume" → call
+  clear_proactive_pauses.
+- After ANY of these, respond with at most a brief acknowledgement
+  ("got it") and pivot. Do NOT apologize, do NOT say "I'll stop now",
+  do NOT make a thing of it. Do NOT re-offer the same suggestion within
+  the pause window.
+
+GRACEFUL RETURN:
+- After a pause expires, do not dump a backlog. At most ONE gentle check-in
+  per session: "Welcome back — want to hear what I noticed, or pick up
+  where you were?" If the user declines, stay quiet for the rest of the
+  session.`;
+
+  if (!candidate) {
+    return rulesBlock;
+  }
+
+  const goalLine = candidate.goal_link
+    ? `Toward the user's active Life Compass goal: "${candidate.goal_link.primary_goal}" (category: ${candidate.goal_link.category})`
+    : 'No active Life Compass goal set — gently invite the user to pick one if natural.';
+
+  const candidateBlock = `
+
+=== PROACTIVE OPENER CANDIDATE ===
+Kind: ${candidate.kind}
+nudge_key: ${candidate.nudge_key}      ← use exactly this string if calling pause_proactive_guidance with scope="nudge_key"
+Title: ${candidate.title}${candidate.subline ? `\nDetail: ${candidate.subline}` : ''}
+Why this was selected: ${candidate.reason}
+${goalLine}
+
+Use this candidate to open the conversation if appropriate per the rules above.
+Always tie it back to the goal. If the user declines, honor it via the dismissal tools.`;
+
+  return rulesBlock + candidateBlock;
 }
 
 // =============================================================================
@@ -372,6 +531,11 @@ export function buildBrainToolDefinitions(role: string): object[] {
         required: ['query'],
       },
     },
+    // Proactive Guide Phase 0.5 — dismissal honor tools.
+    // Always available; the LLM only calls them when the system prompt's
+    // Proactive Opener Rules are present (i.e., flag is on).
+    PAUSE_PROACTIVE_GUIDANCE_TOOL,
+    CLEAR_PROACTIVE_PAUSES_TOOL,
   ];
 
   // Merge: registry tools + ORB tools (avoid duplicates)
@@ -443,6 +607,39 @@ export async function executeBrainTool(
 
         console.log(`${LOG_PREFIX} search_calendar: ${today.length} today, ${upcoming.length} upcoming, ${gaps.length} gaps (${Date.now() - startTime}ms)`);
         return { success: true, result: formatted || 'Your calendar is currently empty.' };
+      }
+
+      // Proactive Guide Phase 0.5 — dismissal honor tools
+      case 'pause_proactive_guidance': {
+        const channel: 'voice' | 'text' = 'voice'; // brain executor is currently used by ORB
+        const result = await executePauseProactiveGuidance(
+          {
+            scope: (args.scope as any) || 'all',
+            scope_value: args.scope_value as string | undefined,
+            duration_minutes: args.duration_minutes as number | undefined,
+            reason: args.reason as string | undefined,
+          },
+          { user_id: context.user_id, channel },
+        );
+        if (!result.success) {
+          return { success: false, result: `pause failed: ${result.error}`, error: result.error };
+        }
+        const until = new Date(result.paused_until!);
+        return {
+          success: true,
+          result: `Paused (scope=${result.scope}${result.scope_value ? `:${result.scope_value}` : ''}) until ${until.toISOString()}.`,
+        };
+      }
+
+      case 'clear_proactive_pauses': {
+        const result = await executeClearProactivePauses({ user_id: context.user_id });
+        if (!result.success) {
+          return { success: false, result: `clear failed: ${result.error}`, error: result.error };
+        }
+        return {
+          success: true,
+          result: `Cleared ${result.cleared_count} active pause${result.cleared_count === 1 ? '' : 's'}.`,
+        };
       }
 
       default: {

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -589,6 +589,13 @@ export type CicdEventType =
   | 'brain.turn.error'
   | 'brain.context.assembled'
   | 'brain.tool.executed'
+  // PROACTIVE-GUIDE: Phase 0.5 opener + dismissal honor events
+  | 'guide.opener.shown'
+  | 'guide.opener.suppressed_by_pause'
+  | 'guide.opener.no_candidate'
+  | 'guide.dismissal.pause_created'
+  | 'guide.dismissal.pause_cleared'
+  | 'guide.flag.disabled'
   // VTID-01900: Longevity News Feed Events
   | 'news.feed.error'
   | 'news.feed.cycle_complete'

--- a/supabase/migrations/20260418000000_proactive_guide_phase0.sql
+++ b/supabase/migrations/20260418000000_proactive_guide_phase0.sql
@@ -1,0 +1,302 @@
+-- =============================================================================
+-- Proactive Guide — Phase 0 schema foundation
+-- Date: 2026-04-18
+-- Plan: .claude/plans/lucent-stitching-sextant.md
+--
+-- Adds the schema primitives the Proactive Guide needs before any behavioral
+-- code ships:
+--   1. role_scope + contribution_vector on autopilot_recommendations
+--   2. user_active_role — single source of truth for multi-role users
+--   3. user_journey_overrides — per-user wave customization (Phase 8 Loop 3)
+--   4. score_prosperity — 6th pillar on vitana_index_scores
+--   5. vitana_index_baseline_survey — onboarding self-report → Day-0 Index
+--   6. user_nudge_state — per-nudge rate-limiting + silencing
+--   7. user_proactive_pause — the "back off" layer (candidate/session/time/topic)
+--   8. system_controls flags for Phase 0.5 through Phase 9
+--
+-- Dismissal honor is a foundational principle (not a feature). The
+-- user_proactive_pause table + flags land here so no proactive code can ship
+-- without the respect layer wired.
+-- =============================================================================
+
+BEGIN;
+
+-- -----------------------------------------------------------------------------
+-- 1. autopilot_recommendations: role scoping + Index contribution vectors
+-- -----------------------------------------------------------------------------
+ALTER TABLE autopilot_recommendations
+  ADD COLUMN IF NOT EXISTS role_scope text NOT NULL DEFAULT 'any'
+    CHECK (role_scope IN ('community','developer','admin','any'));
+
+ALTER TABLE autopilot_recommendations
+  ADD COLUMN IF NOT EXISTS contribution_vector jsonb;
+
+CREATE INDEX IF NOT EXISTS idx_autopilot_recommendations_role_scope
+  ON autopilot_recommendations (role_scope, status)
+  WHERE status = 'new';
+
+COMMENT ON COLUMN autopilot_recommendations.role_scope IS
+  'community | developer | admin | any — clamps candidate to a role context. Default "any" preserves pre-Phase-0 behavior.';
+
+COMMENT ON COLUMN autopilot_recommendations.contribution_vector IS
+  'Declared Vitana Index contribution: {physical,mental,nutritional,social,environmental,prosperity, horizon, confidence, cost, goal_link}. Nullable until Phase 3. Used by Guide Engine scorer.';
+
+-- -----------------------------------------------------------------------------
+-- 2. user_active_role — SSOT for multi-role users. Role switch invalidates
+--    Autopilot popup cache and forces context pack rebuild on next turn.
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS user_active_role (
+  user_id    uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  role       text NOT NULL DEFAULT 'community'
+    CHECK (role IN ('community','developer','admin')),
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE user_active_role ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "user_active_role_self_rw"
+  ON user_active_role FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+COMMENT ON TABLE user_active_role IS
+  'Single source of truth for a user''s currently-selected role. Changed via UI role selector or conversational intent. Triggers cache invalidation in Guide Engine.';
+
+-- -----------------------------------------------------------------------------
+-- 3. user_journey_overrides — per-user wave customization from D43 adaptation
+--    plans (Phase 8 Loop 3) or manual edits.
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS user_journey_overrides (
+  id         uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id    uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  wave_id    text NOT NULL,
+  overrides  jsonb NOT NULL DEFAULT '{}'::jsonb,
+  source     text NOT NULL DEFAULT 'manual'
+    CHECK (source IN ('manual','d43_adaptation','admin')),
+  created_at timestamptz NOT NULL DEFAULT now(),
+  updated_at timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id, wave_id)
+);
+
+ALTER TABLE user_journey_overrides ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "user_journey_overrides_self_rw"
+  ON user_journey_overrides FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE INDEX IF NOT EXISTS idx_user_journey_overrides_user_wave
+  ON user_journey_overrides (user_id, wave_id);
+
+COMMENT ON TABLE user_journey_overrides IS
+  'Per-user wave customization read by journey-calendar-mapper on recompute. Source "d43_adaptation" means written by Phase 8 Loop 3 applier from approved adaptation_plans.';
+
+-- -----------------------------------------------------------------------------
+-- 4. Prosperity pillar on vitana_index_scores (6th pillar)
+--    Max Index rescales from 999 (5 pillars × 200 - 1) to 1200 (6 × 200).
+--    Default 100 = neutral until Phase 1c wires real signals.
+-- -----------------------------------------------------------------------------
+ALTER TABLE vitana_index_scores
+  ADD COLUMN IF NOT EXISTS score_prosperity smallint NOT NULL DEFAULT 100
+    CHECK (score_prosperity BETWEEN 0 AND 200);
+
+COMMENT ON COLUMN vitana_index_scores.score_prosperity IS
+  '6th Vitana Index pillar — Business Hub progress + marketplace earnings + reward accumulation. Hardcoded 100 until index_prosperity_pillar_enabled flag flips in Phase 1c.';
+
+-- -----------------------------------------------------------------------------
+-- 5. vitana_index_baseline_survey — onboarding self-report answers that seed
+--    the user's Day-0 Index (Phase 2 of the plan).
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS vitana_index_baseline_survey (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       uuid NOT NULL UNIQUE REFERENCES auth.users(id) ON DELETE CASCADE,
+  answers       jsonb NOT NULL,
+  completed_at  timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE vitana_index_baseline_survey ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "vitana_index_baseline_survey_self_rw"
+  ON vitana_index_baseline_survey FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+COMMENT ON TABLE vitana_index_baseline_survey IS
+  'Onboarding survey answers seeded into Day-0 Index at registration. Phase 2 bootstrap. Self-reported → low confidence, replaced by real signals over time.';
+
+-- -----------------------------------------------------------------------------
+-- 6. user_nudge_state — per-nudge rate-limiting and silencing.
+--    Used by Guide Engine to respect "skip it", prevent re-surfacing dismissed
+--    candidates, and track per-candidate acceptance rates.
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS user_nudge_state (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  nudge_key       text NOT NULL,
+  last_shown_at   timestamptz,
+  dismissed_at    timestamptz,
+  silenced_until  timestamptz,
+  show_count      int NOT NULL DEFAULT 0,
+  accept_count    int NOT NULL DEFAULT 0,
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id, nudge_key)
+);
+
+ALTER TABLE user_nudge_state ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "user_nudge_state_self_rw"
+  ON user_nudge_state FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE INDEX IF NOT EXISTS idx_user_nudge_state_silenced
+  ON user_nudge_state (user_id, silenced_until)
+  WHERE silenced_until IS NOT NULL;
+
+COMMENT ON TABLE user_nudge_state IS
+  'Per-candidate rate-limiting + dismissal state. "skip it" writes silenced_until = now + 24h. Accept/show counts feed Phase 8 Loop 4 learner.';
+
+-- -----------------------------------------------------------------------------
+-- 7. user_proactive_pause — dismissal honor system.
+--
+--    Scopes:
+--      all          — blanket pause across all proactive openers
+--      category     — mute a domain (e.g., scope_value = 'business_hub')
+--      nudge_key    — mute a specific candidate type
+--      channel      — mute on voice only or text only (scope_value = 'voice'|'text')
+--
+--    Voice trigger phrases map to rows here via Phase 0.5
+--    dismissal-intent detector. Settings UI (Phase 7) also writes here.
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS user_proactive_pause (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id       uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  scope         text NOT NULL
+    CHECK (scope IN ('all','category','nudge_key','channel')),
+  scope_value   text,
+  paused_from   timestamptz NOT NULL DEFAULT now(),
+  paused_until  timestamptz NOT NULL,
+  reason        text,
+  created_via   text NOT NULL DEFAULT 'voice'
+    CHECK (created_via IN ('voice','text','settings')),
+  created_at    timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT user_proactive_pause_value_required
+    CHECK (scope = 'all' OR scope_value IS NOT NULL)
+);
+
+ALTER TABLE user_proactive_pause ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "user_proactive_pause_self_rw"
+  ON user_proactive_pause FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+-- Index on (user_id, paused_until) — query filters paused_until > now() at
+-- read time; cannot use a partial WHERE clause here because now() is not
+-- IMMUTABLE (Postgres rejects it in partial-index predicates).
+CREATE INDEX IF NOT EXISTS idx_user_proactive_pause_user_until
+  ON user_proactive_pause (user_id, paused_until);
+
+CREATE INDEX IF NOT EXISTS idx_user_proactive_pause_scope
+  ON user_proactive_pause (user_id, scope, scope_value, paused_until);
+
+COMMENT ON TABLE user_proactive_pause IS
+  'The "back off" layer. Guide Engine MUST check this before emitting any proactive opener. Expired pauses remain as history; app only reads rows with paused_until > now().';
+
+-- -----------------------------------------------------------------------------
+-- 8. Feature flags — system_controls
+--    All proactive behavior gated. Dismissal honor defaults ENABLED so no
+--    proactive code can ship without the respect layer active.
+-- -----------------------------------------------------------------------------
+
+INSERT INTO system_controls (key, enabled, scope, reason, expires_at, updated_by, updated_by_role, updated_at)
+VALUES
+  -- Phase 0.5 — thin proactive opener
+  ('vitana_proactive_opener_enabled', FALSE,
+   '{"environment": "dev-sandbox"}'::jsonb,
+   'Phase 0.5 — thin proactive opener in ORB voice + Assistant. Reads life_compass + calendar_events + autopilot_recommendations.',
+   NULL, 'migration', 'system', NOW()),
+
+  -- Dismissal honor — DEFAULT ON. Proactive never ships without respect.
+  ('vitana_proactive_dismissal_honor_enabled', TRUE,
+   '{"environment": "dev-sandbox"}'::jsonb,
+   'Respects "skip it", "not today", "give me space", etc. Writes to user_proactive_pause / user_nudge_state. Non-negotiable — ON from Phase 0.',
+   NULL, 'migration', 'system', NOW()),
+
+  -- Phase 1 — Index backbone completion
+  ('index_social_pillar_enabled', FALSE,
+   '{"environment": "dev-sandbox"}'::jsonb,
+   'Phase 1a — compute Social pillar from relationship_nodes + community engagement (currently hardcoded 100).',
+   NULL, 'migration', 'system', NOW()),
+
+  ('index_environmental_pillar_enabled', FALSE,
+   '{"environment": "dev-sandbox"}'::jsonb,
+   'Phase 1b — compute Environmental pillar from health_features_daily + self-reported fields.',
+   NULL, 'migration', 'system', NOW()),
+
+  ('index_prosperity_pillar_enabled', FALSE,
+   '{"environment": "dev-sandbox"}'::jsonb,
+   'Phase 1c — compute Prosperity pillar from Business Hub + marketplace.commerce events + rewards.',
+   NULL, 'migration', 'system', NOW()),
+
+  ('index_weights_applied_enabled', FALSE,
+   '{"environment": "dev-sandbox"}'::jsonb,
+   'Phase 1d — health_compute_vitana_index() RPC multiplies pillars by vitana_index_config.algorithm_weights (currently ignored).',
+   NULL, 'migration', 'system', NOW()),
+
+  -- Phase 6 — Guide Engine
+  ('vitana_guide_shadow', FALSE,
+   '{"environment": "dev-sandbox"}'::jsonb,
+   'Phase 6 pre-live — Guide Engine runs in log-only mode for quality review. No user-visible output.',
+   NULL, 'migration', 'system', NOW()),
+
+  ('vitana_guide_enabled', FALSE,
+   '{"environment": "dev-sandbox"}'::jsonb,
+   'Phase 6 — full Guide Engine: contribution-vector scoring, role_agenda in context pack, opener dispatch.',
+   NULL, 'migration', 'system', NOW()),
+
+  ('vitana_brain_role_agenda_enabled', FALSE,
+   '{"environment": "dev-sandbox"}'::jsonb,
+   'Phase 6 — inject role_agenda + active_goal blocks into context-pack-builder output.',
+   NULL, 'migration', 'system', NOW()),
+
+  ('agenda_analyzer_community_enabled', FALSE,
+   '{"environment": "dev-sandbox"}'::jsonb,
+   'Phase 6 — community-journey-analyzer writing to autopilot_recommendations with role_scope=community.',
+   NULL, 'migration', 'system', NOW()),
+
+  -- Phase 9 — role analyzers
+  ('agenda_analyzer_developer_enabled', FALSE,
+   '{"environment": "dev-sandbox"}'::jsonb,
+   'Phase 9 — developer-agenda-analyzer (VTIDs, CI-CD, agents_registry, self-healing queue).',
+   NULL, 'migration', 'system', NOW()),
+
+  ('agenda_analyzer_admin_enabled', FALSE,
+   '{"environment": "dev-sandbox"}'::jsonb,
+   'Phase 9 — admin-agenda-analyzer (governance, policy reviews, tenant health).',
+   NULL, 'migration', 'system', NOW())
+ON CONFLICT (key) DO NOTHING;
+
+COMMIT;
+
+-- =============================================================================
+-- Rollback notes (manual — Supabase migrations do not auto-reverse):
+--   DROP TABLE user_proactive_pause, user_nudge_state,
+--              vitana_index_baseline_survey, user_journey_overrides,
+--              user_active_role;
+--   ALTER TABLE vitana_index_scores DROP COLUMN score_prosperity;
+--   ALTER TABLE autopilot_recommendations
+--     DROP COLUMN contribution_vector, DROP COLUMN role_scope;
+--   DELETE FROM system_controls WHERE key IN (
+--     'vitana_proactive_opener_enabled',
+--     'vitana_proactive_dismissal_honor_enabled',
+--     'index_social_pillar_enabled','index_environmental_pillar_enabled',
+--     'index_prosperity_pillar_enabled','index_weights_applied_enabled',
+--     'vitana_guide_shadow','vitana_guide_enabled',
+--     'vitana_brain_role_agenda_enabled',
+--     'agenda_analyzer_community_enabled',
+--     'agenda_analyzer_developer_enabled',
+--     'agenda_analyzer_admin_enabled'
+--   );
+-- =============================================================================


### PR DESCRIPTION
## Summary
Lays the schema foundation and ships the first voice-testable proactive slice for the Proactive Guide system.

**Phase 0 — Schema** (already applied to dev-sandbox via RUN-MIGRATION.yml run 24623413535):
- `autopilot_recommendations`: `role_scope` + `contribution_vector`
- `vitana_index_scores`: `score_prosperity` (6th pillar)
- New tables: `user_active_role`, `user_journey_overrides`, `vitana_index_baseline_survey`, `user_nudge_state`, `user_proactive_pause`
- `system_controls` flags including `vitana_proactive_dismissal_honor_enabled=TRUE`

**Phase 0.5 — Opener + Dismissal Honor**:
- New `services/gateway/src/services/guide/` module
- Brain integration: opener candidate appended to system prompt when flag on
- Two Gemini tools: `pause_proactive_guidance` + `clear_proactive_pauses`
- Silent Honor Rules baked into system prompt

**Behavior gate**: `vitana_proactive_opener_enabled` (default FALSE). Code ships dark; flag flip enables.

## Test plan
- [x] Migration applied to dev-sandbox
- [ ] EXEC-DEPLOY dispatched after merge
- [ ] Flip `vitana_proactive_opener_enabled` on for test user
- [ ] ORB voice opens proactively with goal-framed suggestion
- [ ] "skip it" / "not today" / "you can talk again" all honored cleanly
- [ ] OASIS events visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)