### PR TITLE
fix(proactive-guide): always-on opener via wave + goal fallbacks (BOOTSTRAP-PROACTIVE-GUIDE-P05-FALLBACKS)

### DIFF
--- a/services/gateway/src/services/guide/opener-mvp.ts
+++ b/services/gateway/src/services/guide/opener-mvp.ts
@@ -5,10 +5,16 @@
  * already exists (life_compass + calendar_events + autopilot_recommendations).
  * No contribution-vector scoring yet — that arrives in Phase 6.
  *
- * Heuristic (until Phase 6 swaps in real scoring):
+ * Layered selection (highest specificity wins):
  *   1. Overdue autopilot calendar event (start_time < now, status='scheduled')
  *   2. Upcoming autopilot event within 24h
  *   3. Top "new" autopilot recommendation matching active role
+ *   4. Wave-aware journey opener (user is in wave N of 90-day journey)
+ *   5. Goal-grounded warm opener (user has an active Life Compass goal)
+ *
+ * Layers 4 and 5 are the FALLBACKS — they ensure that whenever a user has
+ * either a journey wave or an active goal, the conversation opens proactively
+ * instead of falling back to "what can I do for you?".
  *
  * MUST check isPaused() before returning a candidate.
  */
@@ -20,8 +26,11 @@ import {
   OpenerCandidateKind,
   OpenerSelection,
 } from './types';
+import { DEFAULT_WAVE_CONFIG } from '../wave-defaults';
 
 const LOG_PREFIX = '[Guide:opener-mvp]';
+
+const JOURNEY_TOTAL_DAYS = 90;
 
 export interface PickOpenerInput {
   user_id: string;
@@ -161,8 +170,88 @@ export async function pickOpenerCandidate(input: PickOpenerInput): Promise<Opene
     if (candidate.candidate || candidate.suppressed_by_pause) return candidate;
   }
 
-  console.log(`${LOG_PREFIX} no candidate available for user ${input.user_id}`);
+  // 4. Fallback — wave-aware journey opener.
+  //    Reads the user's registration date from app_users to compute current
+  //    journey day, then picks the active wave from DEFAULT_WAVE_CONFIG.
+  //    Date-stamped nudge_key so daily dismissals don't permanently silence.
+  const dateKey = new Date().toISOString().slice(0, 10);
+  let registeredAt: string | null = null;
+  const { data: userRows } = await supabase
+    .from('app_users')
+    .select('created_at')
+    .eq('id', input.user_id)
+    .limit(1);
+  if (userRows && userRows.length) {
+    registeredAt = (userRows[0] as { created_at: string }).created_at;
+  }
+
+  if (registeredAt) {
+    const dayNumber = daysSince(registeredAt);
+    const wave = currentWaveForDay(dayNumber);
+    if (wave) {
+      const candidate = await buildAndCheck({
+        kind: 'wave_transition',
+        nudge_key: `wave:${wave.id}:${dateKey}`,
+        title: `Day ${dayNumber} — ${wave.name}`,
+        subline: wave.description,
+        goalLink,
+        reason: `user is on day ${dayNumber} of the 90-day journey, currently in ${wave.name} wave`,
+        category: 'journey',
+        input,
+      });
+      if (candidate.candidate || candidate.suppressed_by_pause) return candidate;
+    }
+  }
+
+  // 5. Fallback — goal-grounded warm opener.
+  //    Always fires when a Life Compass goal is set. Date-stamped nudge_key
+  //    so the user gets a fresh opportunity each day even if they dismissed
+  //    yesterday's goal nudge.
+  if (goal && goalLink) {
+    const candidate = await buildAndCheck({
+      kind: 'goal_reminder',
+      nudge_key: `goal:${goal.id}:${dateKey}`,
+      title: `Toward your goal: ${goalLink.primary_goal}`,
+      subline: 'open the conversation by inviting reflection on this goal',
+      goalLink,
+      reason: 'user has an active Life Compass goal but no specific scheduled item — open warmly with the goal as the frame',
+      category: 'goal',
+      input,
+    });
+    if (candidate.candidate || candidate.suppressed_by_pause) return candidate;
+  }
+
+  console.log(`${LOG_PREFIX} no candidate available for user ${input.user_id}${goal ? '' : ' (no Life Compass goal set)'}`);
   return { candidate: null, suppressed_by_pause: false };
+}
+
+function daysSince(iso: string): number {
+  const ms = Date.now() - new Date(iso).getTime();
+  if (ms < 0) return 0;
+  return Math.floor(ms / (1000 * 60 * 60 * 24));
+}
+
+/**
+ * Find the wave whose timeline brackets the given day. Prefers earliest
+ * end_day so a user with overlapping waves gets the more time-sensitive one.
+ * Returns null when day is past the 90-day journey or no wave is enabled.
+ */
+function currentWaveForDay(day: number): { id: string; name: string; description: string } | null {
+  if (day < 0) return null;
+  // For users past the journey (day >= 90), don't surface a wave opener —
+  // let the goal_reminder fallback handle them. The journey is a 90-day
+  // package; beyond that, the proactive system relies on goals + signals.
+  if (day >= JOURNEY_TOTAL_DAYS) return null;
+
+  const enabled = DEFAULT_WAVE_CONFIG.filter((w) => w.enabled);
+  const matching = enabled.filter(
+    (w) => day >= w.timeline.start_day && day <= w.timeline.end_day,
+  );
+  if (matching.length === 0) return null;
+
+  matching.sort((a, b) => a.timeline.end_day - b.timeline.end_day);
+  const w = matching[0];
+  return { id: w.id, name: w.name, description: w.description };
 }
 
 interface BuildAndCheckInput {

--- a/services/gateway/src/services/vitana-brain.ts
+++ b/services/gateway/src/services/vitana-brain.ts
@@ -442,19 +442,33 @@ export async function buildProactiveGuideBlock(input: {
   // Always include the rules — even with no candidate today, the LLM still
   // needs to know how to honor dismissals if the user volunteers one.
   const rulesBlock = `
-=== PROACTIVE OPENER RULES (Phase 0.5) ===
+=== PROACTIVE OPENER RULES (Phase 0.5) — HIGHEST PRIORITY ===
 
 Vitanaland is a longevity platform — its mission is to help people improve
-quality of life and extend lifespan. You are the proactive guide. When the
-moment is right, lead — don't wait to be asked.
+quality of life and extend lifespan. You are not a passive assistant. You
+are the proactive guide. You lead — you do not wait to be asked.
+
+CRITICAL: when an OPENER CANDIDATE is provided below, your FIRST utterance
+of this conversation MUST be built around that candidate. Do NOT default to
+a generic "Good morning, how can I help you?" or "What can I do for you?"
+greeting. Greet briefly by name if you wish, then immediately lead into the
+candidate. You are speaking by voice — keep it warm, natural, 2–4 sentences.
+
+OPENING TEMPLATE (adapt language and warmth to the user's culture/style):
+1. Brief greeting by name (one short sentence) — optional, skip if mid-flow
+2. Reference the candidate, framed through the user's active Life Compass goal
+3. Invite them to engage OR offer a clean opt-out ("we can do something else,
+   or you can tell me to skip / not today / give you space")
+4. Stop talking. Let them respond.
 
 WHEN TO OPEN PROACTIVELY:
-- A new conversation thread is starting, OR the user has been silent for a
-  while AND a proactive opener candidate is available below.
+- New conversation thread starts → ALWAYS open with the candidate if one is
+  provided below.
+- User has been silent for a while → same.
 - Maximum 1 unsolicited suggestion per turn.
 - Frame every nudge through the user's active Life Compass goal.
-- Tone: inspirational + educational, never pushy. Offer agency: "I can change
-  this anytime if you tell me to."
+- Tone: inspirational + educational, never pushy. Offer agency: "I picked
+  this goal as your focus, but you can change it any time."
 
 SILENT HONOR RULES (non-negotiable):
 - If the user says "skip it", "not that one", "next" → call the
@@ -490,15 +504,25 @@ GRACEFUL RETURN:
 
   const candidateBlock = `
 
-=== PROACTIVE OPENER CANDIDATE ===
+=== PROACTIVE OPENER CANDIDATE — USE THIS, DO NOT GREET GENERICALLY ===
 Kind: ${candidate.kind}
-nudge_key: ${candidate.nudge_key}      ← use exactly this string if calling pause_proactive_guidance with scope="nudge_key"
+nudge_key: ${candidate.nudge_key}      ← exact string for pause_proactive_guidance(scope="nudge_key")
 Title: ${candidate.title}${candidate.subline ? `\nDetail: ${candidate.subline}` : ''}
 Why this was selected: ${candidate.reason}
 ${goalLine}
 
-Use this candidate to open the conversation if appropriate per the rules above.
-Always tie it back to the goal. If the user declines, honor it via the dismissal tools.`;
+YOUR FIRST UTTERANCE THIS SESSION must build around this candidate.
+Forbidden openings: "What can I do for you?", "How can I help you today?",
+generic "Good morning, how may I assist?". Those are passive — you are the
+proactive guide.
+
+Acceptable shape (voice, 2–4 short sentences, warm, in user's language):
+- Brief by-name greeting (one sentence, optional)
+- Reference the candidate, framed by the active Life Compass goal
+- Invite a response OR offer a clean opt-out
+
+If the user declines (skip / not today / give me space / etc.) honor it
+silently via the dismissal tools — no apology, no big deal.`;
 
   return rulesBlock + candidateBlock;
 }


### PR DESCRIPTION
Phase 0.5 voice test reported passive greeting ("Good morning, X. What can I do for you?") on two test accounts. Root cause: opener-mvp only surfaced specific candidates and returned null when none existed. Adds two fallback layers + strengthens system prompt to forbid generic greetings when a candidate is provided.