### PR TITLE
VTID-02409: Assistant Speeches admin — backend (registry, service, routes, schema)

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -273,6 +273,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const { acceptRouter: invitationAcceptRouter } = require('./routes/tenant-admin/invitations');
   // Batch 1.B2: Tenant Assistant Config — per-tenant AI personality overrides
   const tenantAssistantConfigRouter = require('./routes/tenant-admin/assistant-config').default;
+  // Phase 1: Tenant Assistant Speeches — per-tenant overrides for named speeches
+  const tenantAssistantSpeechesRouter = require('./routes/tenant-admin/assistant-speeches').default;
   // Batch 1.B2: Tenant Knowledge Base — per-tenant KB docs, opt-outs, search
   const tenantKnowledgeRouter = require('./routes/tenant-admin/knowledge').default;
   // Overview Dashboard — KPI summary, at-risk, activity, alerts
@@ -708,6 +710,10 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   // Batch 1.B1: Tenant Invitations — per-tenant invite/accept flow
   mountRouterSync(app, '/api/v1/admin/tenants/:tenantId/invitations', tenantInvitationsRouter, { owner: 'tenant-invitations' });
   mountRouterSync(app, '/api/v1/admin/invitations', invitationAcceptRouter, { owner: 'invitation-accept' });
+  // Phase 1: Tenant Assistant Speeches — per-tenant overrides for named speeches
+  // (Mounted BEFORE the assistant-config router so the more-specific /assistant/speeches
+  // prefix is matched first and not swallowed by assistant-config's /:surfaceKey handler.)
+  mountRouterSync(app, '/api/v1/admin/tenants/:tenantId/assistant/speeches', tenantAssistantSpeechesRouter, { owner: 'tenant-assistant-speeches' });
   // Batch 1.B2: Tenant Assistant Config — per-tenant AI personality overrides
   mountRouterSync(app, '/api/v1/admin/tenants/:tenantId/assistant', tenantAssistantConfigRouter, { owner: 'tenant-assistant-config' });
   // Batch 1.B2: Tenant Knowledge Base — per-tenant KB docs, search, opt-outs

--- a/services/gateway/src/routes/tenant-admin/assistant-speeches.ts
+++ b/services/gateway/src/routes/tenant-admin/assistant-speeches.ts
@@ -1,0 +1,121 @@
+/**
+ * Phase 1: Tenant Assistant Speeches API
+ *
+ * Mounted at /api/v1/admin/tenants/:tenantId/assistant/speeches
+ *
+ * Endpoints:
+ *   GET    /                  — List all registered speeches with effective text
+ *   GET    /:speechKey        — Single speech (default + tenant override)
+ *   PUT    /:speechKey        — Upsert tenant override { text }
+ *   DELETE /:speechKey        — Clear tenant override; returns effective (= default)
+ */
+
+import { Router, Response } from 'express';
+import { requireTenantAdmin } from '../../middleware/require-tenant-admin';
+import { AuthenticatedRequest } from '../../middleware/auth-supabase-jwt';
+import {
+  isValidSpeechKey,
+  SpeechKey,
+  getSpeech,
+  listSpeeches,
+  upsertTenantSpeech,
+  resetTenantSpeech,
+} from '../../services/assistant-speeches/service';
+
+const router = Router({ mergeParams: true });
+
+// GET / — list all speeches
+router.get('/', requireTenantAdmin, async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const tenantId = (req.params.tenantId as string) || (req as any).targetTenantId;
+    const speeches = await listSpeeches(tenantId);
+    return res.json({ speeches });
+  } catch (err: any) {
+    console.error('[ASSISTANT-SPEECHES] List error:', err.message);
+    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
+  }
+});
+
+// GET /:speechKey — single speech detail
+router.get('/:speechKey', requireTenantAdmin, async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const tenantId = (req.params.tenantId as string) || (req as any).targetTenantId;
+    const speechKey = req.params.speechKey;
+
+    if (!isValidSpeechKey(speechKey)) {
+      return res.status(400).json({ ok: false, error: 'INVALID_SPEECH_KEY' });
+    }
+
+    const speech = await getSpeech(speechKey as SpeechKey, tenantId);
+    if (!speech) {
+      return res.status(404).json({ ok: false, error: 'SPEECH_NOT_FOUND' });
+    }
+    return res.json(speech);
+  } catch (err: any) {
+    console.error('[ASSISTANT-SPEECHES] Get error:', err.message);
+    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
+  }
+});
+
+// PUT /:speechKey — upsert tenant override
+router.put('/:speechKey', requireTenantAdmin, async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const tenantId = (req.params.tenantId as string) || (req as any).targetTenantId;
+    const speechKey = req.params.speechKey;
+
+    if (!isValidSpeechKey(speechKey)) {
+      return res.status(400).json({ ok: false, error: 'INVALID_SPEECH_KEY' });
+    }
+
+    const { text } = req.body ?? {};
+    if (typeof text !== 'string' || !text.trim()) {
+      return res.status(400).json({ ok: false, error: 'EMPTY_TEXT' });
+    }
+
+    const result = await upsertTenantSpeech(
+      tenantId,
+      speechKey as SpeechKey,
+      text,
+      req.identity!.user_id
+    );
+
+    if (!result.ok || !result.speech) {
+      const status = result.error === 'EMPTY_TEXT' ? 400 : 500;
+      return res.status(status).json({ ok: false, error: result.error });
+    }
+
+    return res.json(result.speech);
+  } catch (err: any) {
+    console.error('[ASSISTANT-SPEECHES] Update error:', err.message);
+    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
+  }
+});
+
+// DELETE /:speechKey — clear tenant override
+router.delete('/:speechKey', requireTenantAdmin, async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const tenantId = (req.params.tenantId as string) || (req as any).targetTenantId;
+    const speechKey = req.params.speechKey;
+
+    if (!isValidSpeechKey(speechKey)) {
+      return res.status(400).json({ ok: false, error: 'INVALID_SPEECH_KEY' });
+    }
+
+    const result = await resetTenantSpeech(
+      tenantId,
+      speechKey as SpeechKey,
+      req.identity!.user_id
+    );
+
+    if (!result.ok || !result.speech) {
+      return res.status(500).json({ ok: false, error: result.error });
+    }
+
+    return res.json(result.speech);
+  } catch (err: any) {
+    console.error('[ASSISTANT-SPEECHES] Delete error:', err.message);
+    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
+  }
+});
+
+export default router;

--- a/services/gateway/src/services/assistant-speeches/registry.ts
+++ b/services/gateway/src/services/assistant-speeches/registry.ts
@@ -1,0 +1,91 @@
+/**
+ * Assistant Speeches Registry
+ *
+ * Phase 1: admin-editable registry of named assistant speeches.
+ * One object literal per speech — to add a new speech, append to SPEECH_REGISTRY.
+ *
+ * Phase 2 will migrate the real hardcoded copy from IntroExperience.tsx etc.
+ * For Phase 1, default_text is a placeholder.
+ */
+
+export type SpeechKey =
+  | 'pre_login_intro'
+  | 'post_login_onboarding'
+  | 'general_onboarding'
+  | 'proactive_guidance_character';
+
+export type SpeechJourneyStage = 'pre_login' | 'onboarding' | 'proactive';
+
+export interface SpeechRegistryEntry {
+  key: SpeechKey;
+  label: string;
+  description: string;
+  journey_stage: SpeechJourneyStage;
+  default_text: string;
+  /**
+   * True when the speech is delivered via a baked-in pre-recorded audio asset
+   * (e.g. the pre-login intro). The admin UI should show a warning that text
+   * edits will not affect the audio playback until Phase 2.
+   */
+  plays_prerecorded_audio?: boolean;
+}
+
+// =============================================================================
+// Registry
+// =============================================================================
+
+export const SPEECH_REGISTRY: SpeechRegistryEntry[] = [
+  {
+    key: 'pre_login_intro',
+    label: 'Pre-Login Intro',
+    description:
+      'First speech a visitor hears on the landing experience before signing in.',
+    journey_stage: 'pre_login',
+    default_text: '[Default pre-login intro speech — replace with copy]',
+    plays_prerecorded_audio: true,
+  },
+  {
+    key: 'post_login_onboarding',
+    label: 'Post-Login Onboarding',
+    description:
+      'Spoken immediately after a user signs in for the first time to welcome them.',
+    journey_stage: 'onboarding',
+    default_text: '[Default post-login onboarding speech — replace with copy]',
+  },
+  {
+    key: 'general_onboarding',
+    label: 'General Onboarding',
+    description:
+      'Generic onboarding guidance used during the broader first-run flow.',
+    journey_stage: 'onboarding',
+    default_text: '[Default general onboarding speech — replace with copy]',
+  },
+  {
+    key: 'proactive_guidance_character',
+    label: 'Proactive Guidance — Character',
+    description:
+      'In-app proactive nudge spoken by the assistant character to guide the user.',
+    journey_stage: 'proactive',
+    default_text:
+      '[Default proactive guidance character speech — replace with copy]',
+  },
+];
+
+export const SPEECH_KEYS: SpeechKey[] = SPEECH_REGISTRY.map((s) => s.key);
+
+const REGISTRY_BY_KEY: Record<SpeechKey, SpeechRegistryEntry> =
+  SPEECH_REGISTRY.reduce(
+    (acc, entry) => {
+      acc[entry.key] = entry;
+      return acc;
+    },
+    {} as Record<SpeechKey, SpeechRegistryEntry>
+  );
+
+export function getRegistryEntry(key: SpeechKey): SpeechRegistryEntry | null {
+  return REGISTRY_BY_KEY[key] ?? null;
+}
+
+export function isValidSpeechKey(key: string): key is SpeechKey {
+  return key in REGISTRY_BY_KEY;
+}

--- a/services/gateway/src/services/assistant-speeches/service.ts
+++ b/services/gateway/src/services/assistant-speeches/service.ts
@@ -1,0 +1,411 @@
+/**
+ * Assistant Speeches Service
+ *
+ * Phase 1: per-tenant overrides for the named assistant speeches in the
+ * registry. Mirrors the architecture of `ai-personality-service.ts`:
+ *   - Hardcoded defaults from `registry.ts`
+ *   - Supabase `tenant_assistant_speeches` table for tenant overrides
+ *   - 30-second in-memory cache for hot-path reads
+ *   - OASIS audit events on every write
+ *
+ * Effective text resolution: registry default ← tenant override.
+ * (No global DB layer in Phase 1 — speeches are either default or
+ * tenant-overridden.)
+ */
+import { emitOasisEvent } from '../oasis-event-service';
+import {
+  SPEECH_REGISTRY,
+  SPEECH_KEYS,
+  SpeechKey,
+  SpeechRegistryEntry,
+  getRegistryEntry,
+  isValidSpeechKey,
+} from './registry';
+
+// =============================================================================
+// Environment
+// =============================================================================
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export interface TenantSpeechOverride {
+  tenant_id: string;
+  speech_key: SpeechKey;
+  text: string;
+  updated_at: string;
+  updated_by: string | null;
+}
+
+export interface SpeechDto {
+  key: SpeechKey;
+  label: string;
+  description: string;
+  journey_stage: SpeechRegistryEntry['journey_stage'];
+  default_text: string;
+  current_text: string;
+  has_override: boolean;
+  plays_prerecorded_audio?: boolean;
+  updated_at?: string;
+  updated_by?: string;
+}
+
+// =============================================================================
+// Cache
+// =============================================================================
+
+const CACHE_TTL_MS = 30_000; // 30 seconds
+
+interface CacheEntry {
+  override: TenantSpeechOverride | null;
+  fetchedAt: number;
+}
+
+// Cache key: `${tenantId}:${speechKey}`
+const overrideCache = new Map<string, CacheEntry>();
+
+function cacheKey(tenantId: string, speechKey: SpeechKey): string {
+  return `${tenantId}:${speechKey}`;
+}
+
+function isCacheValid(entry: CacheEntry): boolean {
+  return Date.now() - entry.fetchedAt < CACHE_TTL_MS;
+}
+
+export function clearSpeechCache(tenantId?: string, speechKey?: SpeechKey): void {
+  if (tenantId && speechKey) {
+    overrideCache.delete(cacheKey(tenantId, speechKey));
+    return;
+  }
+  if (tenantId) {
+    for (const k of Array.from(overrideCache.keys())) {
+      if (k.startsWith(`${tenantId}:`)) overrideCache.delete(k);
+    }
+    return;
+  }
+  overrideCache.clear();
+}
+
+// =============================================================================
+// Internal helpers
+// =============================================================================
+
+function buildDto(
+  entry: SpeechRegistryEntry,
+  override: TenantSpeechOverride | null
+): SpeechDto {
+  const dto: SpeechDto = {
+    key: entry.key,
+    label: entry.label,
+    description: entry.description,
+    journey_stage: entry.journey_stage,
+    default_text: entry.default_text,
+    current_text: override?.text ?? entry.default_text,
+    has_override: !!override,
+  };
+  if (entry.plays_prerecorded_audio) {
+    dto.plays_prerecorded_audio = true;
+  }
+  if (override) {
+    dto.updated_at = override.updated_at;
+    if (override.updated_by) dto.updated_by = override.updated_by;
+  }
+  return dto;
+}
+
+async function fetchTenantOverride(
+  tenantId: string,
+  speechKey: SpeechKey
+): Promise<TenantSpeechOverride | null> {
+  // Cache
+  const cached = overrideCache.get(cacheKey(tenantId, speechKey));
+  if (cached && isCacheValid(cached)) {
+    return cached.override;
+  }
+
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
+    return null;
+  }
+
+  try {
+    const response = await fetch(
+      `${SUPABASE_URL}/rest/v1/tenant_assistant_speeches?tenant_id=eq.${encodeURIComponent(tenantId)}&speech_key=eq.${encodeURIComponent(speechKey)}&select=*`,
+      {
+        method: 'GET',
+        headers: {
+          'Content-Type': 'application/json',
+          apikey: SUPABASE_SERVICE_ROLE,
+          Authorization: `Bearer ${SUPABASE_SERVICE_ROLE}`,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      console.warn(
+        `[ASSISTANT-SPEECHES] Failed to fetch override for ${tenantId}/${speechKey}: ${response.status}`
+      );
+      return null;
+    }
+
+    const rows = (await response.json()) as TenantSpeechOverride[];
+    const override = rows.length > 0 ? rows[0] : null;
+    overrideCache.set(cacheKey(tenantId, speechKey), {
+      override,
+      fetchedAt: Date.now(),
+    });
+    return override;
+  } catch (error: any) {
+    console.error(
+      `[ASSISTANT-SPEECHES] Error fetching override for ${tenantId}/${speechKey}:`,
+      error
+    );
+    return null;
+  }
+}
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Get a single speech (default + tenant override merged) as a DTO.
+ */
+export async function getSpeech(
+  speechKey: SpeechKey,
+  tenantId: string
+): Promise<SpeechDto | null> {
+  const entry = getRegistryEntry(speechKey);
+  if (!entry) return null;
+  const override = await fetchTenantOverride(tenantId, speechKey);
+  return buildDto(entry, override);
+}
+
+/**
+ * List all registered speeches with effective text for the given tenant.
+ */
+export async function listSpeeches(tenantId: string): Promise<SpeechDto[]> {
+  const results: SpeechDto[] = [];
+  for (const entry of SPEECH_REGISTRY) {
+    const override = await fetchTenantOverride(tenantId, entry.key);
+    results.push(buildDto(entry, override));
+  }
+  return results;
+}
+
+/**
+ * Upsert a tenant override for a speech.
+ */
+export async function upsertTenantSpeech(
+  tenantId: string,
+  speechKey: SpeechKey,
+  text: string,
+  updatedBy: string
+): Promise<{ ok: boolean; speech?: SpeechDto; error?: string }> {
+  const entry = getRegistryEntry(speechKey);
+  if (!entry) return { ok: false, error: 'INVALID_SPEECH_KEY' };
+  if (!text || !text.trim()) return { ok: false, error: 'EMPTY_TEXT' };
+
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
+    return { ok: false, error: 'Supabase not configured' };
+  }
+
+  try {
+    const previous = await fetchTenantOverride(tenantId, speechKey);
+    const nowIso = new Date().toISOString();
+
+    const response = await fetch(
+      `${SUPABASE_URL}/rest/v1/tenant_assistant_speeches`,
+      {
+        method: 'POST',
+        headers: {
+          'Content-Type': 'application/json',
+          apikey: SUPABASE_SERVICE_ROLE,
+          Authorization: `Bearer ${SUPABASE_SERVICE_ROLE}`,
+          Prefer: 'resolution=merge-duplicates',
+        },
+        body: JSON.stringify({
+          tenant_id: tenantId,
+          speech_key: speechKey,
+          text,
+          updated_at: nowIso,
+          updated_by: updatedBy,
+        }),
+      }
+    );
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error(
+        `[ASSISTANT-SPEECHES] Failed to upsert ${tenantId}/${speechKey}: ${response.status} - ${errorText}`
+      );
+      return { ok: false, error: `DB error: ${response.status}` };
+    }
+
+    // Audit
+    await fetch(`${SUPABASE_URL}/rest/v1/assistant_speech_audit`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: SUPABASE_SERVICE_ROLE,
+        Authorization: `Bearer ${SUPABASE_SERVICE_ROLE}`,
+      },
+      body: JSON.stringify({
+        tenant_id: tenantId,
+        speech_key: speechKey,
+        from_text: previous?.text ?? entry.default_text,
+        to_text: text,
+        action: 'upsert',
+        updated_by: updatedBy,
+      }),
+    }).catch((err) =>
+      console.warn('[ASSISTANT-SPEECHES] Audit write failed:', err)
+    );
+
+    await emitOasisEvent({
+      vtid: 'ASSISTANT-SPEECHES',
+      type: 'assistant.speech.updated' as any,
+      source: 'assistant-speeches-service',
+      status: 'info',
+      message: `Assistant speech updated for ${speechKey} in tenant ${tenantId}`,
+      payload: {
+        tenant_id: tenantId,
+        speech_key: speechKey,
+        updated_by: updatedBy,
+      },
+    }).catch(() => {});
+
+    // Invalidate cache so next read sees the new override
+    clearSpeechCache(tenantId, speechKey);
+
+    const updated = await fetchTenantOverride(tenantId, speechKey);
+    const speech = buildDto(entry, updated);
+    console.log(
+      `[ASSISTANT-SPEECHES] Updated ${speechKey} for tenant ${tenantId} by ${updatedBy}`
+    );
+    return { ok: true, speech };
+  } catch (error: any) {
+    console.error(
+      `[ASSISTANT-SPEECHES] Error upserting ${tenantId}/${speechKey}:`,
+      error
+    );
+    return { ok: false, error: error.message };
+  }
+}
+
+/**
+ * Reset a tenant override (delete the row). The effective text reverts
+ * to the registry default. Returns the resulting effective speech DTO.
+ */
+export async function resetTenantSpeech(
+  tenantId: string,
+  speechKey: SpeechKey,
+  updatedBy: string
+): Promise<{ ok: boolean; speech?: SpeechDto; error?: string }> {
+  const entry = getRegistryEntry(speechKey);
+  if (!entry) return { ok: false, error: 'INVALID_SPEECH_KEY' };
+
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
+    return { ok: false, error: 'Supabase not configured' };
+  }
+
+  try {
+    const previous = await fetchTenantOverride(tenantId, speechKey);
+
+    const response = await fetch(
+      `${SUPABASE_URL}/rest/v1/tenant_assistant_speeches?tenant_id=eq.${encodeURIComponent(tenantId)}&speech_key=eq.${encodeURIComponent(speechKey)}`,
+      {
+        method: 'DELETE',
+        headers: {
+          'Content-Type': 'application/json',
+          apikey: SUPABASE_SERVICE_ROLE,
+          Authorization: `Bearer ${SUPABASE_SERVICE_ROLE}`,
+        },
+      }
+    );
+
+    if (!response.ok) {
+      const errorText = await response.text();
+      console.error(
+        `[ASSISTANT-SPEECHES] Failed to reset ${tenantId}/${speechKey}: ${response.status} - ${errorText}`
+      );
+      return { ok: false, error: `DB error: ${response.status}` };
+    }
+
+    // Audit
+    await fetch(`${SUPABASE_URL}/rest/v1/assistant_speech_audit`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: SUPABASE_SERVICE_ROLE,
+        Authorization: `Bearer ${SUPABASE_SERVICE_ROLE}`,
+      },
+      body: JSON.stringify({
+        tenant_id: tenantId,
+        speech_key: speechKey,
+        from_text: previous?.text ?? entry.default_text,
+        to_text: entry.default_text,
+        action: 'reset',
+        updated_by: updatedBy,
+      }),
+    }).catch((err) =>
+      console.warn('[ASSISTANT-SPEECHES] Audit write failed:', err)
+    );
+
+    await emitOasisEvent({
+      vtid: 'ASSISTANT-SPEECHES',
+      type: 'assistant.speech.reset' as any,
+      source: 'assistant-speeches-service',
+      status: 'info',
+      message: `Assistant speech reset to default for ${speechKey} in tenant ${tenantId}`,
+      payload: {
+        tenant_id: tenantId,
+        speech_key: speechKey,
+        updated_by: updatedBy,
+      },
+    }).catch(() => {});
+
+    clearSpeechCache(tenantId, speechKey);
+
+    // Effective is now the registry default
+    const speech = buildDto(entry, null);
+    console.log(
+      `[ASSISTANT-SPEECHES] Reset ${speechKey} for tenant ${tenantId} by ${updatedBy}`
+    );
+    return { ok: true, speech };
+  } catch (error: any) {
+    console.error(
+      `[ASSISTANT-SPEECHES] Error resetting ${tenantId}/${speechKey}:`,
+      error
+    );
+    return { ok: false, error: error.message };
+  }
+}
+
+/**
+ * Runtime helper for callers that just need the effective speech text.
+ * Returns the tenant override if present, otherwise the registry default.
+ * Returns null if the speech key is not in the registry.
+ */
+export async function getEffectiveSpeechText(
+  speechKey: SpeechKey,
+  tenantId: string | null
+): Promise<string | null> {
+  const entry = getRegistryEntry(speechKey);
+  if (!entry) return null;
+  if (!tenantId) return entry.default_text;
+  const override = await fetchTenantOverride(tenantId, speechKey);
+  return override?.text ?? entry.default_text;
+}
+
+// Re-exports for convenience
+export {
+  SPEECH_KEYS,
+  SPEECH_REGISTRY,
+  isValidSpeechKey,
+  getRegistryEntry,
+};
+export type { SpeechKey, SpeechRegistryEntry };

--- a/supabase/migrations/20260418060000_tenant_assistant_speeches.sql
+++ b/supabase/migrations/20260418060000_tenant_assistant_speeches.sql
@@ -1,0 +1,76 @@
+-- =============================================================================
+-- Phase 1: Per-tenant assistant speeches
+--
+-- Stores tenant-specific overrides for the named assistant speeches defined
+-- in services/gateway/src/services/assistant-speeches/registry.ts.
+-- The gateway resolves: registry default ← tenant override.
+--
+-- Mirrors the RLS pattern in 20260412200000_tenant_assistant_config.sql.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.tenant_assistant_speeches (
+    tenant_id   UUID NOT NULL REFERENCES public.tenants(id),
+    speech_key  TEXT NOT NULL,
+    text        TEXT NOT NULL,
+    updated_at  TIMESTAMPTZ NOT NULL DEFAULT now(),
+    updated_by  UUID,
+    PRIMARY KEY (tenant_id, speech_key)
+);
+
+CREATE INDEX IF NOT EXISTS idx_tenant_assistant_speeches_tenant
+    ON public.tenant_assistant_speeches (tenant_id);
+
+ALTER TABLE public.tenant_assistant_speeches ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "service_role_all" ON public.tenant_assistant_speeches
+    FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+CREATE POLICY "tenant_members_select" ON public.tenant_assistant_speeches
+    FOR SELECT TO authenticated
+    USING (
+        tenant_id = (
+            SELECT (raw_app_meta_data->>'active_tenant_id')::uuid
+            FROM auth.users WHERE id = auth.uid()
+        )
+    );
+
+COMMENT ON TABLE public.tenant_assistant_speeches IS
+    'Phase 1: per-tenant overrides for named assistant speeches (registry-backed).';
+
+-- =============================================================================
+-- Audit log for assistant speech changes (mirrors ai_personality_config_audit)
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.assistant_speech_audit (
+    id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+    tenant_id   UUID NOT NULL,
+    speech_key  TEXT NOT NULL,
+    from_text   TEXT,
+    to_text     TEXT,
+    action      TEXT NOT NULL,           -- 'upsert' | 'reset'
+    updated_by  UUID,
+    created_at  TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_assistant_speech_audit_tenant
+    ON public.assistant_speech_audit (tenant_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_assistant_speech_audit_key
+    ON public.assistant_speech_audit (speech_key, created_at DESC);
+
+ALTER TABLE public.assistant_speech_audit ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "service_role_all" ON public.assistant_speech_audit
+    FOR ALL TO service_role USING (true) WITH CHECK (true);
+
+CREATE POLICY "tenant_members_select" ON public.assistant_speech_audit
+    FOR SELECT TO authenticated
+    USING (
+        tenant_id = (
+            SELECT (raw_app_meta_data->>'active_tenant_id')::uuid
+            FROM auth.users WHERE id = auth.uid()
+        )
+    );
+
+COMMENT ON TABLE public.assistant_speech_audit IS
+    'Phase 1: audit trail of tenant assistant speech overrides (upsert/reset).';


### PR DESCRIPTION
## VTID-02409 — Assistant Speeches admin (Phase 1 backend)

Adds an admin-editable registry of named user-journey speeches so that the Assistant Personality admin can manage what Vitana says at distinct phases of the user journey (pre-login intro, post-login onboarding, general onboarding, proactive guidance character).

### Files
- `services/gateway/src/services/assistant-speeches/registry.ts` — typed `SpeechKey` enum + 4-entry registry; trivial to append new speeches.
- `services/gateway/src/services/assistant-speeches/service.ts` — `getSpeech`, `listSpeeches`, `upsertTenantSpeech`, `resetTenantSpeech`, `getEffectiveSpeechText`, 30s in-memory cache, OASIS audit events on writes (mirrors `ai-personality-service.ts` patterns).
- `services/gateway/src/routes/tenant-admin/assistant-speeches.ts` — Express router gated by `requireTenantAdmin`. `GET /`, `GET /:speechKey`, `PUT /:speechKey`, `DELETE /:speechKey`.
- `supabase/migrations/20260418060000_tenant_assistant_speeches.sql` — `tenant_assistant_speeches` (PK `(tenant_id, speech_key)`) + `assistant_speech_audit`, both with RLS matching `tenant_assistant_config` precedent.
- `services/gateway/src/index.ts` — mounts new router at `/api/v1/admin/tenants/:tenantId/assistant/speeches`. Mounted **before** assistant-config so its `/:surfaceKey` route doesn't intercept `/speeches`.

### Scope
Phase 1 only — admin storage + endpoints. Default speech text is placeholder; admins set real copy via the UI. Phase 2 will migrate the existing hardcoded copy in `IntroExperience.tsx`, `OnboardingWelcome.tsx`, and the proactive guidance engine to read from `getEffectiveSpeechText()`.

### Frontend PR
Companion PR on `exafyltd/vitana-v1` adds the Speeches sub-tab under `/admin/assistant`.

### Post-merge
- Verify EXEC-DEPLOY dispatches for `gateway` (CLAUDE.md §16).
- Apply Supabase migration `20260418060000_tenant_assistant_speeches.sql` against the dev database.