### PR TITLE
feat(proactive-guide): auto-seed default longevity goal + voice goal-change handler (VTID-01927)

### DIFF
--- a/services/gateway/src/services/guide/opener-mvp.ts
+++ b/services/gateway/src/services/guide/opener-mvp.ts
@@ -76,7 +76,13 @@ export async function pickOpenerCandidate(input: PickOpenerInput): Promise<Opene
     return { candidate: null, suppressed_by_pause: false };
   }
 
-  // Active goal (Life Compass) — frames every opener
+  // Active goal (Life Compass) — frames every opener.
+  // Auto-seeds the default longevity goal when the user has none, so every
+  // user always has a "starting focus" the system can reference. The user
+  // can change it any time (the LLM is briefed to honor "change my goals").
+  let goal: LifeCompassRow | null = null;
+  let goalIsSystemSeeded = false;
+
   const { data: compassRows } = await supabase
     .from('life_compass')
     .select('id, primary_goal, category')
@@ -85,8 +91,40 @@ export async function pickOpenerCandidate(input: PickOpenerInput): Promise<Opene
     .order('created_at', { ascending: false })
     .limit(1);
 
-  const goal: LifeCompassRow | null = compassRows && compassRows.length ? (compassRows[0] as LifeCompassRow) : null;
-  const goalLink = goal ? { primary_goal: goal.primary_goal, category: goal.category } : undefined;
+  if (compassRows && compassRows.length) {
+    goal = compassRows[0] as LifeCompassRow;
+  } else {
+    // Lazy seed — Vitana's default focus is the platform's mission itself:
+    // improve quality of life and extend lifespan. The user can swap this
+    // for any catalog goal anytime.
+    const { data: seeded, error: seedErr } = await supabase
+      .from('life_compass')
+      .insert({
+        user_id: input.user_id,
+        primary_goal: 'Improve quality of life and extend lifespan',
+        category: 'longevity',
+        is_active: true,
+        version: 1,
+      })
+      .select('id, primary_goal, category')
+      .single();
+
+    if (seedErr) {
+      console.warn(`${LOG_PREFIX} default-goal seed failed for user ${input.user_id}:`, seedErr.message);
+    } else if (seeded) {
+      goal = seeded as LifeCompassRow;
+      goalIsSystemSeeded = true;
+      console.log(`${LOG_PREFIX} seeded default longevity goal for user ${input.user_id}`);
+    }
+  }
+
+  const goalLink = goal
+    ? {
+        primary_goal: goal.primary_goal,
+        category: goal.category,
+        is_system_seeded: goalIsSystemSeeded,
+      }
+    : undefined;
 
   const nowIso = new Date().toISOString();
   const in24hIso = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();

--- a/services/gateway/src/services/guide/types.ts
+++ b/services/gateway/src/services/guide/types.ts
@@ -38,6 +38,13 @@ export interface OpenerCandidate {
   goal_link?: {
     primary_goal: string;
     category: string;
+    /**
+     * True when this Life Compass goal was system-seeded (the default longevity
+     * goal applied to a new user who hasn't picked one). The brain prompt uses
+     * this to make the agency offer ("I set this for you, change anytime")
+     * explicit instead of implicit.
+     */
+    is_system_seeded?: boolean;
   };
   /** Shipping rationale for the LLM — why this was picked. Not shown to user verbatim. */
   reason: string;

--- a/services/gateway/src/services/vitana-brain.ts
+++ b/services/gateway/src/services/vitana-brain.ts
@@ -492,14 +492,29 @@ GRACEFUL RETURN:
 - After a pause expires, do not dump a backlog. At most ONE gentle check-in
   per session: "Welcome back — want to hear what I noticed, or pick up
   where you were?" If the user declines, stay quiet for the rest of the
-  session.`;
+  session.
+
+GOAL CHANGES:
+- If the user says "change my goals", "I want a different focus", "update
+  my goals", "pick a different goal" — confirm warmly and tell them the
+  exact path: "Open the Memory Hub and tap Life Compass — that's where
+  your goals live. Pick the focus that matters to you most right now."
+  Do NOT pretend you can navigate the app for them. The goal-change UI
+  is the Life Compass modal accessed via Memory Hub.
+- After they tell you they have changed their goal, you can ask them
+  what they picked (so you can frame the next conversation accordingly).`;
 
   if (!candidate) {
     return rulesBlock;
   }
 
   const goalLine = candidate.goal_link
-    ? `Toward the user's active Life Compass goal: "${candidate.goal_link.primary_goal}" (category: ${candidate.goal_link.category})`
+    ? candidate.goal_link.is_system_seeded
+      ? `User's active Life Compass goal (SYSTEM-SEEDED DEFAULT): "${candidate.goal_link.primary_goal}" (category: ${candidate.goal_link.category})\n` +
+        `IMPORTANT: this goal was set BY YOU automatically because the user has not picked one. ` +
+        `Frame your opener accordingly — explicitly mention you've set this default and the user can change it any time. ` +
+        `Example: "I've set your starting focus to improving quality of life and extending lifespan — that's the heart of Vitanaland's mission. You can change it any time by saying so, or in the Memory Hub. For now, here's something on my mind..."`
+      : `Toward the user's active Life Compass goal: "${candidate.goal_link.primary_goal}" (category: ${candidate.goal_link.category})`
     : 'No active Life Compass goal set — gently invite the user to pick one if natural.';
 
   const candidateBlock = `


### PR DESCRIPTION
Fixes the still-passive opener after the previous fallback fix. OASIS confirmed both fallback layers returned null because the test user (a) is past day 90 of the journey and (b) has no saved life_compass row. Adds lazy auto-seed of the default longevity goal so every user always has a starting focus + brain prompt now explicitly frames system-seeded goals with agency offer + voice handler for 'change my goals'.