### PR TITLE
feat(proactive-guide): introduction mode + forbidden-phrase override (VTID-01927)

### DIFF
--- a/services/gateway/src/services/guide/opener-mvp.ts
+++ b/services/gateway/src/services/guide/opener-mvp.ts
@@ -76,7 +76,13 @@ export async function pickOpenerCandidate(input: PickOpenerInput): Promise<Opene
     return { candidate: null, suppressed_by_pause: false };
   }
 
-  // Active goal (Life Compass) — frames every opener
+  // Active goal (Life Compass) — frames every opener.
+  // Auto-seeds the default longevity goal when the user has none, so every
+  // user always has a "starting focus" the system can reference. The user
+  // can change it any time (the LLM is briefed to honor "change my goals").
+  let goal: LifeCompassRow | null = null;
+  let goalIsSystemSeeded = false;
+
   const { data: compassRows } = await supabase
     .from('life_compass')
     .select('id, primary_goal, category')
@@ -85,8 +91,40 @@ export async function pickOpenerCandidate(input: PickOpenerInput): Promise<Opene
     .order('created_at', { ascending: false })
     .limit(1);
 
-  const goal: LifeCompassRow | null = compassRows && compassRows.length ? (compassRows[0] as LifeCompassRow) : null;
-  const goalLink = goal ? { primary_goal: goal.primary_goal, category: goal.category } : undefined;
+  if (compassRows && compassRows.length) {
+    goal = compassRows[0] as LifeCompassRow;
+  } else {
+    // Lazy seed — Vitana's default focus is the platform's mission itself:
+    // improve quality of life and extend lifespan. The user can swap this
+    // for any catalog goal anytime.
+    const { data: seeded, error: seedErr } = await supabase
+      .from('life_compass')
+      .insert({
+        user_id: input.user_id,
+        primary_goal: 'Improve quality of life and extend lifespan',
+        category: 'longevity',
+        is_active: true,
+        version: 1,
+      })
+      .select('id, primary_goal, category')
+      .single();
+
+    if (seedErr) {
+      console.warn(`${LOG_PREFIX} default-goal seed failed for user ${input.user_id}:`, seedErr.message);
+    } else if (seeded) {
+      goal = seeded as LifeCompassRow;
+      goalIsSystemSeeded = true;
+      console.log(`${LOG_PREFIX} seeded default longevity goal for user ${input.user_id}`);
+    }
+  }
+
+  const goalLink = goal
+    ? {
+        primary_goal: goal.primary_goal,
+        category: goal.category,
+        is_system_seeded: goalIsSystemSeeded,
+      }
+    : undefined;
 
   const nowIso = new Date().toISOString();
   const in24hIso = new Date(Date.now() + 24 * 60 * 60 * 1000).toISOString();

--- a/services/gateway/src/services/guide/types.ts
+++ b/services/gateway/src/services/guide/types.ts
@@ -38,6 +38,13 @@ export interface OpenerCandidate {
   goal_link?: {
     primary_goal: string;
     category: string;
+    /**
+     * True when this Life Compass goal was system-seeded (the default longevity
+     * goal applied to a new user who hasn't picked one). The brain prompt uses
+     * this to make the agency offer ("I set this for you, change anytime")
+     * explicit instead of implicit.
+     */
+    is_system_seeded?: boolean;
   };
   /** Shipping rationale for the LLM — why this was picked. Not shown to user verbatim. */
   reason: string;

--- a/services/gateway/src/services/vitana-brain.ts
+++ b/services/gateway/src/services/vitana-brain.ts
@@ -350,17 +350,21 @@ export async function buildBrainSystemInstruction(input: {
     channel: input.channel,
   });
 
+  // PROMPT ORDER MATTERS: the proactive guide block goes LAST so it has
+  // recency primacy in Gemini's attention. Putting it before the brevity
+  // rule caused Gemini to default to "What can I do for you?" on the first
+  // utterance because the brevity rule reinforced its trained habit.
   const instruction = `${baseInstruction}
 ${languageDirective}
 ${contextForLLM}
-${proactiveGuideBlock}
 
 Current conversation channel: ${input.channel}
 User's role: ${input.role}
 
-Instructions:
+General instructions (DEFAULT — overridden by Proactive Guide Rules below):
 ${ucConfig.common_instructions || '- Use the memory context to personalize responses\n- Use knowledge context for Vitana-specific questions\n- Be helpful and accurate'}
-- ${input.channel === 'orb' ? (ucConfig.instructions_orb || 'Keep responses brief and natural for voice') : (ucConfig.instructions_operator || 'You can use markdown formatting and be more detailed')}`;
+- ${input.channel === 'orb' ? (ucConfig.instructions_orb || 'Keep responses brief and natural for voice') : (ucConfig.instructions_operator || 'You can use markdown formatting and be more detailed')}
+${proactiveGuideBlock}`;
 
   const latencyMs = Date.now() - startTime;
   console.log(`${LOG_PREFIX} System instruction built in ${latencyMs}ms (${instruction.length} chars, ${contextPack.memory_hits?.length || 0} memory hits, calendar=${!!contextPack.calendar_context}, guide=${proactiveGuideBlock.length > 0 ? 'on' : 'off'})`);
@@ -439,36 +443,65 @@ export async function buildProactiveGuideBlock(input: {
     }).catch(() => {});
   }
 
+  const introductionMode = !!candidate?.goal_link?.is_system_seeded;
+
   // Always include the rules — even with no candidate today, the LLM still
   // needs to know how to honor dismissals if the user volunteers one.
   const rulesBlock = `
-=== PROACTIVE OPENER RULES (Phase 0.5) — HIGHEST PRIORITY ===
+=== PROACTIVE GUIDE RULES (HIGHEST PRIORITY — OVERRIDES "brief / concise" RULE ABOVE) ===
+
+These rules override anything above about being concise or brief. The
+brevity guidance is the DEFAULT. Proactive opening + introduction +
+goal-setting conversations are EXCEPTIONS where you must elaborate,
+introduce, and present — not be terse.
 
 Vitanaland is a longevity platform — its mission is to help people improve
 quality of life and extend lifespan. You are not a passive assistant. You
 are the proactive guide. You lead — you do not wait to be asked.
 
-CRITICAL: when an OPENER CANDIDATE is provided below, your FIRST utterance
-of this conversation MUST be built around that candidate. Do NOT default to
-a generic "Good morning, how can I help you?" or "What can I do for you?"
-greeting. Greet briefly by name if you wish, then immediately lead into the
-candidate. You are speaking by voice — keep it warm, natural, 2–4 sentences.
+ABSOLUTE FORBIDDEN OPENINGS — NEVER say any of these as your first
+utterance of a session, in any language, in any phrasing:
+- "What can I do for you?"
+- "How can I help you today?"
+- "How may I assist you?"
+- "Good morning. How are you?" (alone, with no follow-up content)
+- Any variation that ends by asking the user what they want
+- Any short greeting that closes without offering direction
 
-OPENING TEMPLATE (adapt language and warmth to the user's culture/style):
-1. Brief greeting by name (one short sentence) — optional, skip if mid-flow
-2. Reference the candidate, framed through the user's active Life Compass goal
-3. Invite them to engage OR offer a clean opt-out ("we can do something else,
-   or you can tell me to skip / not today / give you space")
-4. Stop talking. Let them respond.
+Those are passive — they ask the user what to do. The user — especially a
+new user — DOES NOT KNOW what you can do for them. It is YOUR job to lead.
 
 WHEN TO OPEN PROACTIVELY:
-- New conversation thread starts → ALWAYS open with the candidate if one is
-  provided below.
-- User has been silent for a while → same.
+- New conversation thread → ALWAYS open with the candidate below.
+- User silent > 6h → same.
 - Maximum 1 unsolicited suggestion per turn.
 - Frame every nudge through the user's active Life Compass goal.
-- Tone: inspirational + educational, never pushy. Offer agency: "I picked
-  this goal as your focus, but you can change it any time."
+- Tone: warm, inspirational, educational — never pushy.
+
+OPENING SHAPE (REGULAR MODE — when introduction mode is OFF):
+- 2–4 sentences total
+- Brief by-name greeting (optional)
+- Reference the candidate, frame by the goal
+- Invite engagement or offer clean opt-out
+- Stop talking; let the user respond
+
+OPENING SHAPE (INTRODUCTION MODE — see flag in candidate block below):
+- 4–8 sentences, may take ~30 seconds. Brevity rule does NOT apply.
+- This is the user's first impression of who you are and what you do.
+- Required cover (in order):
+  1. Brief warm by-name greeting
+  2. Tell them: this is Vitanaland — a longevity platform whose mission is
+     to improve quality of life and extend lifespan
+  3. Tell them you have automatically set their starting focus to that
+     mission goal, AND that they can change it whenever they want by
+     saying "change my goals" or in the Memory Hub → Life Compass
+  4. Briefly name what you can guide them on (their 90-day journey,
+     community, health, calendar, business hub, marketplace, memory)
+  5. Invite a first move — ask what feels most pressing right now OR
+     suggest one concrete first step they can take today
+- After this introduction, in subsequent turns, return to brief voice
+  responses unless the topic itself requires elaboration (goal-setting,
+  capability questions, complex decisions).
 
 SILENT HONOR RULES (non-negotiable):
 - If the user says "skip it", "not that one", "next" → call the
@@ -517,24 +550,23 @@ GOAL CHANGES:
       : `Toward the user's active Life Compass goal: "${candidate.goal_link.primary_goal}" (category: ${candidate.goal_link.category})`
     : 'No active Life Compass goal set — gently invite the user to pick one if natural.';
 
+  const modeBanner = introductionMode
+    ? '*** INTRODUCTION MODE: ON — use the 4-8 sentence opening shape with all 5 required elements above ***'
+    : '*** INTRODUCTION MODE: OFF — use the 2-4 sentence regular opening shape above ***';
+
   const candidateBlock = `
 
-=== PROACTIVE OPENER CANDIDATE — USE THIS, DO NOT GREET GENERICALLY ===
+=== PROACTIVE OPENER CANDIDATE — YOUR FIRST UTTERANCE MUST BUILD AROUND THIS ===
+${modeBanner}
 Kind: ${candidate.kind}
 nudge_key: ${candidate.nudge_key}      ← exact string for pause_proactive_guidance(scope="nudge_key")
 Title: ${candidate.title}${candidate.subline ? `\nDetail: ${candidate.subline}` : ''}
 Why this was selected: ${candidate.reason}
 ${goalLine}
 
-YOUR FIRST UTTERANCE THIS SESSION must build around this candidate.
-Forbidden openings: "What can I do for you?", "How can I help you today?",
-generic "Good morning, how may I assist?". Those are passive — you are the
-proactive guide.
-
-Acceptable shape (voice, 2–4 short sentences, warm, in user's language):
-- Brief by-name greeting (one sentence, optional)
-- Reference the candidate, framed by the active Life Compass goal
-- Invite a response OR offer a clean opt-out
+DO NOT default to your trained "Good morning, how can I help?" reflex.
+That is on the FORBIDDEN OPENINGS list above. Lead with the candidate.
+Use the opening shape that matches the mode banner above.
 
 If the user declines (skip / not today / give me space / etc.) honor it
 silently via the dismissal tools — no apology, no big deal.`;

--- a/services/gateway/src/services/vitana-brain.ts
+++ b/services/gateway/src/services/vitana-brain.ts
@@ -492,14 +492,29 @@ GRACEFUL RETURN:
 - After a pause expires, do not dump a backlog. At most ONE gentle check-in
   per session: "Welcome back — want to hear what I noticed, or pick up
   where you were?" If the user declines, stay quiet for the rest of the
-  session.`;
+  session.
+
+GOAL CHANGES:
+- If the user says "change my goals", "I want a different focus", "update
+  my goals", "pick a different goal" — confirm warmly and tell them the
+  exact path: "Open the Memory Hub and tap Life Compass — that's where
+  your goals live. Pick the focus that matters to you most right now."
+  Do NOT pretend you can navigate the app for them. The goal-change UI
+  is the Life Compass modal accessed via Memory Hub.
+- After they tell you they have changed their goal, you can ask them
+  what they picked (so you can frame the next conversation accordingly).`;
 
   if (!candidate) {
     return rulesBlock;
   }
 
   const goalLine = candidate.goal_link
-    ? `Toward the user's active Life Compass goal: "${candidate.goal_link.primary_goal}" (category: ${candidate.goal_link.category})`
+    ? candidate.goal_link.is_system_seeded
+      ? `User's active Life Compass goal (SYSTEM-SEEDED DEFAULT): "${candidate.goal_link.primary_goal}" (category: ${candidate.goal_link.category})\n` +
+        `IMPORTANT: this goal was set BY YOU automatically because the user has not picked one. ` +
+        `Frame your opener accordingly — explicitly mention you've set this default and the user can change it any time. ` +
+        `Example: "I've set your starting focus to improving quality of life and extending lifespan — that's the heart of Vitanaland's mission. You can change it any time by saying so, or in the Memory Hub. For now, here's something on my mind..."`
+      : `Toward the user's active Life Compass goal: "${candidate.goal_link.primary_goal}" (category: ${candidate.goal_link.category})`
     : 'No active Life Compass goal set — gently invite the user to pick one if natural.';
 
   const candidateBlock = `


### PR DESCRIPTION
Test reported opener still passive despite lazy-seed working (OASIS confirmed guide.opener.shown fired). Root cause: prompt order — proactive block was sandwiched between two brevity rules, Gemini's trained 'How can I help?' won. This PR moves the proactive block to absolute END of system prompt for recency primacy, adds explicit forbidden-phrase list, and adds Introduction Mode that overrides brevity for first-time-user openers (4-8 sentences covering greeting, mission, agency offer, capabilities, first-step invitation).