### PR TITLE
VTID-01928: Google OAuth for Gmail/Calendar/Contacts/YouTube connectors (backend)

### DIFF
--- a/.github/workflows/EXEC-DEPLOY.yml
+++ b/.github/workflows/EXEC-DEPLOY.yml
@@ -305,6 +305,13 @@ jobs:
             # Incident Triage Agent — Claude Managed Agents API key
             EXTRA_ENV_ARGS+=(--update-env-vars=ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }})
             # VTID-01270A: Events/community data now uses platform SUPABASE_URL/SUPABASE_SERVICE_ROLE (already bound as GCP secrets above)
+            # VTID-01928: Google OAuth for Gmail / Calendar / Contacts / YouTube connectors.
+            # Client ID is public; secret lives in GSM as google-oauth-client-secret.
+            EXTRA_ENV_ARGS+=(--update-env-vars=GOOGLE_OAUTH_CLIENT_ID=86804897789-hej1ferhlfnjcjtn5hd899r07ssld7en.apps.googleusercontent.com)
+            SECRETS_ARGS+=(--update-secrets=GOOGLE_OAUTH_CLIENT_SECRET=google-oauth-client-secret:latest)
+            # Callback base URL (gateway) and post-OAuth redirect base (community-app).
+            EXTRA_ENV_ARGS+=(--update-env-vars=GATEWAY_PUBLIC_URL=https://gateway-q74ibpv6ia-uc.a.run.app)
+            EXTRA_ENV_ARGS+=(--update-env-vars=APP_URL=https://community-app-q74ibpv6ia-uc.a.run.app)
           fi
 
           # VTID-01225: Cognee extractor — internal ingress, Gemini LLM via API key

--- a/services/gateway/src/routes/social-connect.ts
+++ b/services/gateway/src/routes/social-connect.ts
@@ -41,6 +41,14 @@ const LOG_PREFIX = '[SocialConnect]';
 
 const APP_URL = process.env.APP_URL || 'https://vitana.app';
 
+// VTID-01928: OAuth callback redirect path per provider. Google connectors live
+// in /settings/connected-apps; legacy social providers keep the /settings/social
+// path so their existing flows (scrape-based import, share prefs UI) are unaffected.
+function callbackRedirectPath(provider: string): string {
+  if (provider === 'google') return '/settings/connected-apps';
+  return '/settings/social';
+}
+
 // Helper: get Supabase service client
 async function getServiceClient() {
   const url = process.env.SUPABASE_URL;
@@ -122,20 +130,21 @@ router.get('/connect/:provider', (req: Request, res: Response) => {
 router.get('/callback/:provider', async (req: Request, res: Response) => {
   const provider = req.params.provider as SocialProvider;
   const { code, state, error: oauthError } = req.query;
+  const redirectPath = callbackRedirectPath(provider);
 
   if (oauthError) {
     console.warn(`${LOG_PREFIX} OAuth error for ${provider}: ${oauthError}`);
-    return res.redirect(`${APP_URL}/settings/social?error=oauth_denied&provider=${provider}`);
+    return res.redirect(`${APP_URL}${redirectPath}?error=oauth_denied&provider=${provider}`);
   }
 
   if (!code || !state) {
-    return res.redirect(`${APP_URL}/settings/social?error=missing_params&provider=${provider}`);
+    return res.redirect(`${APP_URL}${redirectPath}?error=missing_params&provider=${provider}`);
   }
 
   // Parse state to get userId and tenantId
   const stateData = parseOAuthState(state as string);
   if (!stateData) {
-    return res.redirect(`${APP_URL}/settings/social?error=invalid_state&provider=${provider}`);
+    return res.redirect(`${APP_URL}${redirectPath}?error=invalid_state&provider=${provider}`);
   }
 
   console.log(`${LOG_PREFIX} Processing callback for ${provider}, user ${stateData.userId.slice(0, 8)}…`);
@@ -144,19 +153,19 @@ router.get('/callback/:provider', async (req: Request, res: Response) => {
   const tokens = await exchangeCodeForTokens(provider, code as string);
   if (!tokens.access_token) {
     console.error(`${LOG_PREFIX} Token exchange failed: ${tokens.error}`);
-    return res.redirect(`${APP_URL}/settings/social?error=token_exchange_failed&provider=${provider}`);
+    return res.redirect(`${APP_URL}${redirectPath}?error=token_exchange_failed&provider=${provider}`);
   }
 
   // Fetch social profile
   const profile = await fetchSocialProfile(provider, tokens.access_token);
   if (!profile) {
-    return res.redirect(`${APP_URL}/settings/social?error=profile_fetch_failed&provider=${provider}`);
+    return res.redirect(`${APP_URL}${redirectPath}?error=profile_fetch_failed&provider=${provider}`);
   }
 
   // Store connection
   const supabase = await getServiceClient();
   if (!supabase) {
-    return res.redirect(`${APP_URL}/settings/social?error=service_unavailable&provider=${provider}`);
+    return res.redirect(`${APP_URL}${redirectPath}?error=service_unavailable&provider=${provider}`);
   }
 
   const result = await storeSocialConnection(
@@ -164,11 +173,13 @@ router.get('/callback/:provider', async (req: Request, res: Response) => {
   );
 
   if (!result.ok) {
-    return res.redirect(`${APP_URL}/settings/social?error=store_failed&provider=${provider}`);
+    return res.redirect(`${APP_URL}${redirectPath}?error=store_failed&provider=${provider}`);
   }
 
-  // Trigger profile enrichment in the background
-  if (result.connection_id) {
+  // VTID-01928: Skip social enrichment for Google — it's a data-access connector,
+  // not a profile-scraping one. Social providers (Instagram/Facebook/TikTok/etc.)
+  // still run the enrichment pipeline for interest/topic extraction.
+  if (result.connection_id && provider !== 'google') {
     enrichProfileFromSocial(supabase, stateData.userId, stateData.tenantId, result.connection_id)
       .then(enrichResult => {
         console.log(`${LOG_PREFIX} Enrichment for ${provider}: ${enrichResult.enrichments.join(', ') || 'none'}`);
@@ -180,7 +191,7 @@ router.get('/callback/:provider', async (req: Request, res: Response) => {
 
   // Redirect back to settings with success
   return res.redirect(
-    `${APP_URL}/settings/social?connected=${provider}&username=${encodeURIComponent(profile.username)}`
+    `${APP_URL}${redirectPath}?connected=${provider}&username=${encodeURIComponent(profile.username)}`
   );
 });
 

--- a/services/gateway/src/services/social-connect-service.ts
+++ b/services/gateway/src/services/social-connect-service.ts
@@ -26,10 +26,17 @@ const GATEWAY_URL = process.env.GATEWAY_PUBLIC_URL || process.env.APP_URL || 'ht
 // Provider Configuration
 // =============================================================================
 
-export type SocialProvider = 'instagram' | 'facebook' | 'tiktok' | 'youtube' | 'linkedin' | 'twitter';
+// VTID-01928: `google` covers Gmail + Calendar + Contacts + YouTube data access.
+// Distinct from the `youtube` social-enrichment provider which shares the same
+// OAuth client but only requests the youtube.readonly scope and is surfaced in
+// the Social Media section, not Mail/Calendar/Music.
+export type SocialProvider =
+  | 'instagram' | 'facebook' | 'tiktok' | 'youtube' | 'linkedin' | 'twitter'
+  | 'google';
 
 export const SUPPORTED_PROVIDERS: SocialProvider[] = [
   'instagram', 'facebook', 'tiktok', 'youtube', 'linkedin', 'twitter',
+  'google',
 ];
 
 interface ProviderConfig {
@@ -97,6 +104,26 @@ const PROVIDER_CONFIGS: Record<SocialProvider, ProviderConfig> = {
     clientIdEnv: 'TWITTER_CLIENT_ID',
     clientSecretEnv: 'TWITTER_CLIENT_SECRET',
   },
+  // VTID-01928: Google covers Gmail, Google Calendar, Google Contacts (People API),
+  // YouTube data and YouTube Music. All routed through a single OAuth consent so
+  // the user grants once and every Google-based connector activates together.
+  google: {
+    name: 'Google',
+    authUrl: 'https://accounts.google.com/o/oauth2/v2/auth',
+    tokenUrl: 'https://oauth2.googleapis.com/token',
+    profileUrl: 'https://openidconnect.googleapis.com/v1/userinfo',
+    scopes: [
+      'openid',
+      'email',
+      'profile',
+      'https://www.googleapis.com/auth/gmail.readonly',
+      'https://www.googleapis.com/auth/calendar.readonly',
+      'https://www.googleapis.com/auth/contacts.readonly',
+      'https://www.googleapis.com/auth/youtube.readonly',
+    ],
+    clientIdEnv: 'GOOGLE_OAUTH_CLIENT_ID',
+    clientSecretEnv: 'GOOGLE_OAUTH_CLIENT_SECRET',
+  },
 };
 
 // =============================================================================
@@ -139,6 +166,13 @@ export function getOAuthUrl(
   if (provider === 'twitter') {
     params.set('code_challenge', 'challenge'); // PKCE simplified
     params.set('code_challenge_method', 'plain');
+  }
+  if (provider === 'google') {
+    // offline + consent so Google actually returns a refresh_token on every consent,
+    // not just the very first one — required for long-lived background access.
+    params.set('access_type', 'offline');
+    params.set('prompt', 'consent');
+    params.set('include_granted_scopes', 'true');
   }
 
   return { url: `${config.authUrl}?${params.toString()}` };
@@ -362,6 +396,23 @@ function normalizeProfile(provider: SocialProvider, data: any): SocialProfile {
         profile_url: '',
         bio: data.headline || '',
         location: data.locale ? `${data.locale.language}-${data.locale.country}` : '',
+        website: '',
+        followers_count: 0,
+        following_count: 0,
+        posts_count: 0,
+        interests: [],
+        raw: data,
+      };
+    case 'google':
+      // Google userinfo (OpenID Connect) returns sub/email/name/picture.
+      return {
+        provider_user_id: data.sub || '',
+        username: data.email || '',
+        display_name: data.name || data.email || '',
+        avatar_url: data.picture || '',
+        profile_url: '',
+        bio: '',
+        location: data.locale || '',
         website: '',
         followers_count: 0,
         following_count: 0,


### PR DESCRIPTION
## Summary

Adds Google OAuth to the gateway's social-connect framework, unlocking the five Google-backed connectors on the Connected Apps page (Gmail, Google Calendar, Google Contacts, YouTube, YouTube Music) through a single consent flow.

- New \`google\` provider config with 4 scope bundles plus openid/email/profile.
- Google-specific OAuth URL params (\`access_type=offline\`, \`prompt=consent\`, \`include_granted_scopes=true\`) so a real refresh_token is actually returned.
- userinfo-based profile normalization for the \`google\` provider.
- Callback redirect routed to \`/settings/connected-apps\` for google (existing providers keep \`/settings/social\`).
- \`EXEC-DEPLOY.yml\` now binds \`GOOGLE_OAUTH_CLIENT_ID\` (public), \`GOOGLE_OAUTH_CLIENT_SECRET\` from GSM, \`GATEWAY_PUBLIC_URL\` and \`APP_URL\`.

Pairs with vitana-v1 PR: wires the actual Connect buttons.

## Test plan

- [ ] After merge + deploy, curl \`GET /api/v1/social/connect/google\` with a real JWT returns \`{ ok: true, auth_url: \"https://accounts.google.com/…\" }\`.
- [ ] Completing OAuth lands the browser on \`/settings/connected-apps?connected=google&username=<email>\`.
- [ ] A row appears in \`social_connections\` with provider=google and a non-null refresh_token.
- [ ] Gmail, Google Calendar, Google Contacts, YouTube, YouTube Music all show Connected in the UI after a single consent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)