### PR TITLE
feat(marketplace): daily sync scheduler + internal trigger endpoint

### DIFF
--- a/.github/workflows/EXEC-DEPLOY.yml
+++ b/.github/workflows/EXEC-DEPLOY.yml
@@ -304,6 +304,11 @@ jobs:
             SECRETS_ARGS+=(--remove-secrets=APPILIX_APP_KEY)
             # Incident Triage Agent — Claude Managed Agents API key
             EXTRA_ENV_ARGS+=(--update-env-vars=ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }})
+            # VTID-02000: Marketplace sync scheduler secret (shared with
+            # .github/workflows/MARKETPLACE-SYNC-CRON.yml). Gateway's
+            # /api/v1/internal/marketplace/sync/:network route validates it
+            # with timingSafeEqual and returns 401 if it doesn't match.
+            EXTRA_ENV_ARGS+=(--update-env-vars=MARKETPLACE_SYNC_SECRET=${{ secrets.MARKETPLACE_SYNC_SECRET }})
             # VTID-01270A: Events/community data now uses platform SUPABASE_URL/SUPABASE_SERVICE_ROLE (already bound as GCP secrets above)
             # VTID-01928: Google OAuth for Gmail / Calendar / Contacts / YouTube connectors.
             # Client ID is public; secret lives in GSM as google-oauth-client-secret.

--- a/.github/workflows/MARKETPLACE-SYNC-CRON.yml
+++ b/.github/workflows/MARKETPLACE-SYNC-CRON.yml
@@ -1,0 +1,85 @@
+name: Marketplace Sync Cron
+
+# Runs the marketplace ingestion (Shopify + CJ) against every configured
+# merchant once a day. Calls the gateway's scheduler-authed endpoint so we
+# don't need a service-account JWT.
+#
+# Requires repo secrets:
+#   MARKETPLACE_SYNC_SECRET — shared secret also set on the gateway's
+#                             Cloud Run env. Rotate in both places.
+#   GATEWAY_URL             — full base URL, e.g.
+#                             https://gateway-q74ibpv6ia-uc.a.run.app
+#
+# Can be triggered manually via workflow_dispatch with optional `network`
+# input (shopify / cj / all). Default is `all`.
+
+on:
+  schedule:
+    # Daily at 03:00 UTC — low-traffic window. Adjust as needed.
+    - cron: '0 3 * * *'
+  workflow_dispatch:
+    inputs:
+      network:
+        description: 'Which source to sync (shopify / cj / all)'
+        required: false
+        default: 'all'
+        type: choice
+        options: [ all, shopify, cj ]
+
+permissions:
+  contents: read
+
+concurrency:
+  group: marketplace-sync
+  cancel-in-progress: false
+
+jobs:
+  sync:
+    runs-on: ubuntu-latest
+    timeout-minutes: 20
+    steps:
+      - name: Trigger sync
+        env:
+          GATEWAY_URL: ${{ secrets.GATEWAY_URL }}
+          SECRET: ${{ secrets.MARKETPLACE_SYNC_SECRET }}
+          NETWORK: ${{ inputs.network || 'all' }}
+        run: |
+          set -euo pipefail
+          if [ -z "${GATEWAY_URL:-}" ] || [ -z "${SECRET:-}" ]; then
+            echo "::error::GATEWAY_URL or MARKETPLACE_SYNC_SECRET secret missing"
+            exit 1
+          fi
+          echo "Triggering marketplace sync: network=$NETWORK"
+          RESP=$(curl -sS -o /tmp/sync-response.json -w "HTTP %{http_code}" \
+            -X POST "$GATEWAY_URL/api/v1/internal/marketplace/sync/$NETWORK" \
+            -H "X-Scheduler-Secret: $SECRET" \
+            -H 'Content-Type: application/json' \
+            --max-time 900 \
+            --retry 2 --retry-delay 30 \
+            -d '{}')
+          echo "$RESP"
+          cat /tmp/sync-response.json | jq . || cat /tmp/sync-response.json
+          # Fail if HTTP != 200 OR ok != true
+          if ! grep -q '"HTTP 200"' <<< "$RESP"; then
+            echo "::error::non-200 response"; exit 1
+          fi
+          OK=$(jq -r '.ok // false' /tmp/sync-response.json)
+          if [ "$OK" != "true" ]; then
+            echo "::error::sync returned ok=false"
+            exit 1
+          fi
+
+          # Surface totals so the workflow run page shows them at a glance
+          {
+            echo "## Marketplace sync — $NETWORK"
+            if [ "$NETWORK" = "all" ]; then
+              echo "### Shopify"
+              jq -r '.result.shopify.totals | to_entries | map("- \(.key): \(.value)") | join("\n")' /tmp/sync-response.json
+              echo "### CJ"
+              jq -r '.result.cj.totals | to_entries | map("- \(.key): \(.value)") | join("\n")' /tmp/sync-response.json
+            else
+              jq -r '.result.totals | to_entries | map("- \(.key): \(.value)") | join("\n")' /tmp/sync-response.json
+            fi
+            echo ""
+            echo "**Duration:** $(jq -r '.duration_ms' /tmp/sync-response.json)ms"
+          } >> "$GITHUB_STEP_SUMMARY"

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -129,6 +129,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const discoverFeedRouter = require('./routes/discover-feed').default;
   // VTID-02000: Maxina admin marketplace routes
   const adminMarketplaceRouter = require('./routes/admin-marketplace').default;
+  // VTID-02000: Internal scheduler-authed sync trigger (shared secret, no user JWT)
+  const internalMarketplaceSyncRouter = require('./routes/internal-marketplace-sync').default;
   // VTID-02000: User limitations CRUD + impact counter
   const userLimitationsRouter = require('./routes/user-limitations').default;
   // VTID-02000: Wearables waitlist (Phase 0 stub — still works alongside Phase 1 connector flow)
@@ -621,6 +623,7 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   mountRouterSync(app, '/api/v1/discover', discoverFeedRouter, { owner: 'discover-feed' });
   // VTID-02000: Maxina admin marketplace
   mountRouterSync(app, '/api/v1/admin/marketplace', adminMarketplaceRouter, { owner: 'admin-marketplace' });
+  mountRouterSync(app, '/api/v1/internal/marketplace', internalMarketplaceSyncRouter, { owner: 'marketplace-sync' });
 
   // VTID-02000: User limitations + impact counter (user-facing /ecosystem/preferences)
   mountRouterSync(app, '/api/v1/user/limitations', userLimitationsRouter, { owner: 'user-limitations' });

--- a/services/gateway/src/routes/internal-marketplace-sync.ts
+++ b/services/gateway/src/routes/internal-marketplace-sync.ts
@@ -1,0 +1,74 @@
+/**
+ * VTID-02000: Internal sync trigger endpoint for the scheduler.
+ *
+ * Separate from /api/v1/admin/marketplace/sync which requires a tenant-admin
+ * JWT — that's a dead-end for machine-to-machine cron. This endpoint is
+ * authed by a shared secret header and has no user context.
+ *
+ * Used by:
+ *   - .github/workflows/MARKETPLACE-SYNC-CRON.yml — daily at 03:00 UTC
+ *   - Manual `curl -H 'X-Scheduler-Secret: $MARKETPLACE_SYNC_SECRET' ...`
+ *     when an operator wants to force-run outside the schedule
+ *
+ * Any request without a matching X-Scheduler-Secret header returns 401.
+ * If MARKETPLACE_SYNC_SECRET is not configured on the gateway, all requests
+ * return 500 (fail closed — never run sync without auth).
+ */
+
+import { Router, Request, Response } from 'express';
+import { timingSafeEqual } from 'crypto';
+
+const router = Router();
+
+function secretMatches(provided: string | undefined): boolean {
+  const configured = process.env.MARKETPLACE_SYNC_SECRET;
+  if (!configured || !provided) return false;
+  const a = Buffer.from(configured);
+  const b = Buffer.from(provided);
+  if (a.length !== b.length) return false;
+  return timingSafeEqual(a, b);
+}
+
+router.post('/sync/:network', async (req: Request, res: Response) => {
+  if (!process.env.MARKETPLACE_SYNC_SECRET) {
+    res.status(500).json({ ok: false, error: 'MARKETPLACE_SYNC_SECRET not configured on gateway' });
+    return;
+  }
+  const headerSecret = req.headers['x-scheduler-secret'];
+  const provided = Array.isArray(headerSecret) ? headerSecret[0] : headerSecret;
+  if (!secretMatches(provided)) {
+    res.status(401).json({ ok: false, error: 'invalid or missing X-Scheduler-Secret' });
+    return;
+  }
+
+  const network = req.params.network;
+  if (!['shopify', 'cj', 'all'].includes(network)) {
+    res.status(400).json({ ok: false, error: `Unsupported network: ${network}. Use shopify, cj, or all.` });
+    return;
+  }
+
+  try {
+    const { runMarketplaceSyncSource, runAllMarketplaceSync } = await import('../services/marketplace-sync');
+    const triggeredBy = 'scheduler';
+    const startedAt = Date.now();
+
+    if (network === 'all') {
+      const result = await runAllMarketplaceSync(triggeredBy);
+      console.log(
+        `[marketplace-sync-scheduler] all done in ${Date.now() - startedAt}ms shopify=${JSON.stringify(result.shopify.totals)} cj=${JSON.stringify(result.cj.totals)}`,
+      );
+      res.json({ ok: true, network: 'all', duration_ms: Date.now() - startedAt, result });
+      return;
+    }
+
+    const result = await runMarketplaceSyncSource(network as 'shopify' | 'cj', triggeredBy);
+    console.log(`[marketplace-sync-scheduler] ${network} done in ${Date.now() - startedAt}ms`, result.totals);
+    res.json({ ok: true, network, duration_ms: Date.now() - startedAt, result });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error('[marketplace-sync-scheduler] failed:', message);
+    res.status(500).json({ ok: false, error: message });
+  }
+});
+
+export default router;


### PR DESCRIPTION
Before: marketplace sync only runs via an admin-JWT endpoint. No automation.

New:
- `POST /api/v1/internal/marketplace/sync/:network` authed by `X-Scheduler-Secret` (timingSafeEqual, fail-closed if env unset)
- `.github/workflows/MARKETPLACE-SYNC-CRON.yml` — daily at 03:00 UTC, supports manual dispatch with network=shopify/cj/all, writes a run-summary with insert/update totals
- `EXEC-DEPLOY.yml` wires `MARKETPLACE_SYNC_SECRET` into Cloud Run on gateway deploy so GH secret + gateway env stay in sync

After merge: gateway redeploys with env → first scheduled run at 03:00 UTC. Can also trigger manually right after deploy to smoke-test.