### PR TITLE
VTID-01928: Debug tools - gateway log tail + google insert smoke test

### DIFF
--- a/.github/workflows/DEBUG-GATEWAY-LOGS.yml
+++ b/.github/workflows/DEBUG-GATEWAY-LOGS.yml
@@ -1,0 +1,39 @@
+name: Debug Gateway Logs
+on:
+  workflow_dispatch:
+    inputs:
+      filter:
+        description: "Log filter (grep-style)"
+        required: false
+        default: "SocialConnect"
+      minutes:
+        description: "How many minutes back to fetch"
+        required: false
+        default: "30"
+
+jobs:
+  tail:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - name: Auth to GCP
+        uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_WIF_SA_EMAIL }}
+
+      - name: Setup gcloud
+        uses: google-github-actions/setup-gcloud@v2
+
+      - name: Read recent gateway logs
+        run: |
+          SINCE=$(date -u -d "${{ inputs.minutes }} minutes ago" +%Y-%m-%dT%H:%M:%SZ)
+          echo "Fetching logs since $SINCE matching \"${{ inputs.filter }}\""
+          gcloud logging read \
+            "resource.type=cloud_run_revision AND resource.labels.service_name=gateway AND timestamp>=\"$SINCE\" AND textPayload:\"${{ inputs.filter }}\"" \
+            --project=lovable-vitana-vers1 \
+            --limit=200 \
+            --order=desc \
+            --format='value(timestamp,textPayload)'

--- a/supabase/migrations/20260419120000_vtid_01928_social_connections_google.sql
+++ b/supabase/migrations/20260419120000_vtid_01928_social_connections_google.sql
@@ -1,0 +1,40 @@
+-- VTID-01928: Allow `google` in social_connections.provider
+--
+-- The original CHECK constraint (VTID-01250) only permitted the six social
+-- providers (instagram/facebook/tiktok/youtube/linkedin/twitter). Google OAuth
+-- for Gmail / Calendar / Contacts / YouTube / YouTube Music reuses the same
+-- social-connect storage path but stores its token row under provider='google',
+-- so the CHECK needs to be widened.
+--
+-- Idempotent: looks up the existing constraint by name OR by predicate text,
+-- drops whichever is found, then re-adds the widened version.
+
+DO $$
+DECLARE
+  existing_name TEXT;
+BEGIN
+  SELECT conname
+    INTO existing_name
+    FROM pg_constraint
+   WHERE conrelid = 'public.social_connections'::regclass
+     AND contype  = 'c'
+     AND pg_get_constraintdef(oid) ILIKE '%provider%IN%'
+   LIMIT 1;
+
+  IF existing_name IS NOT NULL THEN
+    EXECUTE format(
+      'ALTER TABLE public.social_connections DROP CONSTRAINT %I',
+      existing_name
+    );
+  END IF;
+END $$;
+
+ALTER TABLE public.social_connections
+  ADD CONSTRAINT social_connections_provider_check
+  CHECK (provider IN (
+    'instagram', 'facebook', 'tiktok', 'youtube', 'linkedin', 'twitter',
+    'google'
+  ));
+
+COMMENT ON CONSTRAINT social_connections_provider_check ON public.social_connections
+  IS 'VTID-01928: adds google alongside the original six providers';

--- a/supabase/migrations/20260419130000_vtid_01928_test_google_insert.sql
+++ b/supabase/migrations/20260419130000_vtid_01928_test_google_insert.sql
@@ -1,0 +1,43 @@
+-- VTID-01928 TEST: verify a google-provider row can be stored.
+--
+-- This is a self-contained "migration" that inserts a synthetic social_connections
+-- row with provider='google', reads it back to prove it stuck, then deletes it.
+-- Any constraint failure aborts the transaction so RUN-MIGRATION.yml reports red.
+--
+-- Runs in a single DO block so the cleanup happens even on success.
+
+DO $$
+DECLARE
+  test_tenant_id UUID := gen_random_uuid();
+  test_user_id   UUID := gen_random_uuid();
+  inserted_id    UUID;
+  check_count    INT;
+BEGIN
+  INSERT INTO public.social_connections (
+    tenant_id, user_id, provider,
+    provider_user_id, provider_username, display_name,
+    access_token, refresh_token, token_expires_at,
+    scopes, profile_data,
+    enrichment_status, connected_at, is_active
+  ) VALUES (
+    test_tenant_id, test_user_id, 'google',
+    'test-sub-' || test_user_id::text, 'vtid01928-test@example.com', 'VTID-01928 Test',
+    'fake-access-token', 'fake-refresh-token', NOW() + INTERVAL '1 hour',
+    ARRAY['openid','email','profile','https://www.googleapis.com/auth/gmail.readonly'],
+    '{}'::jsonb,
+    'skipped', NOW(), true
+  )
+  RETURNING id INTO inserted_id;
+
+  SELECT COUNT(*) INTO check_count
+    FROM public.social_connections
+   WHERE id = inserted_id AND provider = 'google';
+
+  IF check_count <> 1 THEN
+    RAISE EXCEPTION 'Inserted google row not readable (count=%, id=%)', check_count, inserted_id;
+  END IF;
+
+  DELETE FROM public.social_connections WHERE id = inserted_id;
+
+  RAISE NOTICE 'VTID-01928 TEST PASSED: google-provider row inserted, read, and deleted (id=%)', inserted_id;
+END $$;


### PR DESCRIPTION
Adds DEBUG-GATEWAY-LOGS workflow to tail Cloud Run gateway logs on demand, and a SQL smoke test migration that inserts+reads+deletes a synthetic google-provider row in social_connections to verify the widened CHECK is actually accepting inserts.