### PR TITLE
fix(command-hub): register marketplace admin tabs in runtime config + spec

### DIFF
--- a/services/gateway/specs/dev-screen-inventory-v1.json
+++ b/services/gateway/specs/dev-screen-inventory-v1.json
@@ -34,6 +34,8 @@
       "tenants",
       "content-moderation",
       "identity-access",
+      "marketplace-shops",
+      "marketplace-review",
       "analytics"
     ],
     "operator": [
@@ -150,6 +152,6 @@
     ]
   },
   "screen_inventory": {
-    "total_screens": 93
+    "total_screens": 95
   }
 }

--- a/services/gateway/specs/dev_screen_inventory_v1.json
+++ b/services/gateway/specs/dev_screen_inventory_v1.json
@@ -34,6 +34,8 @@
       "tenants",
       "content-moderation",
       "identity-access",
+      "marketplace-shops",
+      "marketplace-review",
       "analytics"
     ],
     "operator": [
@@ -144,6 +146,6 @@
     ]
   },
   "screen_inventory": {
-    "total_screens": 87
+    "total_screens": 89
   }
 }

--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -2588,6 +2588,8 @@ const NAVIGATION_CONFIG = [
             { "key": "tenants", "path": "/command-hub/admin/tenants/" },
             { "key": "content-moderation", "path": "/command-hub/admin/content-moderation/" },
             { "key": "identity-access", "path": "/command-hub/admin/identity-access/" },
+            { "key": "marketplace-shops", "path": "/command-hub/admin/marketplace-shops/" },
+            { "key": "marketplace-review", "path": "/command-hub/admin/marketplace-review/" },
             { "key": "analytics", "path": "/command-hub/admin/analytics/" }
         ]
     },


### PR DESCRIPTION
User caught that PR #715's tabs never rendered — only navigation-config.js was edited, but Command Hub runtime uses a hardcoded NAVIGATION_CONFIG inside app.js (line 2570).

This PR adds the two tabs to the inline runtime config + updates both spec files so validate-dev-frontend-spec.mjs stays green.

Playwright-verified locally: the validator passes (17 modules / 95 screens). Will re-verify rendering after deploy.