### PR TITLE
fix(proactive-guide): early-tenure realistic absence examples (VTID-01929)

### DIFF
--- a/services/gateway/src/services/vitana-brain.ts
+++ b/services/gateway/src/services/vitana-brain.ts
@@ -604,15 +604,28 @@ TENURE AXIS — sets depth of orientation needed:
 - day7, day14 → 2–4 sentences. Mid-journey, knows the basics.
 - day30plus  → 1–2 sentences. Veteran. NEVER re-explain platform basics.
 
-LAST_INTERACTION AXIS — modulates warmth and absence acknowledgement:
+LAST_INTERACTION AXIS — modulates warmth and absence acknowledgement.
+IMPORTANT: for early-tenure users (day0/day1/day3/day7), even a SHORT absence
+(1-2 days) is meaningful — they're forming the habit and you want to make
+them feel welcomed back. For day14/day30plus users, short absences are normal
+and don't warrant special acknowledgement.
+
 - reconnect (< 2 min) → No greeting at all. Continue mid-flow.
 - recent (< 15 min)   → No "hello/hi", no name. Brief warmth, lead with content.
 - same_day (< 8h)     → "back so soon" tone, no name greeting.
-- today / yesterday   → Light: "Good {morning/afternoon/evening}, {Name}".
-- week (within 7d)    → "Good to hear from you again — it's been a few days".
+- today (< 24h)       → Light: "Good {morning/afternoon/evening}, {Name}".
+- yesterday (1 day)   → For day0/day1/day3 users: "Hi {Name}, happy you came
+                         back. Yesterday was your [N]th day with us."
+                       For day7+ users: "Good {morning/afternoon/evening}, {Name}".
+- week (2-7 days)     → For day0/day1/day3/day7 users: warm + slightly concerned
+                         tone — "Hi {Name}, it's been {N} days. Glad you're back.
+                         Want to pick up where we left off?"
+                       For day14+ users: "Good to hear from you again — been
+                         a few days."
 - long, motivation_signal=cooling (8-14 days)
                       → "Hi {Name}, it's been {N} days since we last talked.
-                         Welcome back." Warm. No guilt.
+                         Welcome back." Warm. No guilt. Doubly important for
+                         early-tenure users — likely a sign they need re-engagement.
 - long, motivation_signal=absent (>14 days)
                       → "Hi {Name}, haven't seen you in {N} days. I'm glad
                          you're back. Where have you been?"
@@ -620,16 +633,27 @@ LAST_INTERACTION AXIS — modulates warmth and absence acknowledgement:
                          candidate. Re-engagement comes first; productivity second.
                          After they answer, ask one warm check-in question
                          ("how have you been?") before steering to any goal.
-- first (no past sessions) → defer to tenure axis. Day-0 = full intro.
-                              Day-30+ = peer opener even on actual first ORB session.
+- first (no past sessions) → defer to tenure axis. day0 → FULL INTRODUCTION.
+                              day1 onward → "Good {morning/afternoon/evening},
+                              {Name} — first time we're talking by voice."
 
-COMPOSITION EXAMPLES:
-- Day-0 newcomer + first session → 5–8 sentence FULL INTRODUCTION
-- Day-7 user + last_interaction=yesterday → "Good morning, {Name} — picking up
-   from yesterday, [candidate]"
-- Day-231 veteran + last_interaction=long (10 days) → "Hi {Name}, it's been
-   ten days since we last talked. Welcome back. [candidate, brief]"
-- Day-231 veteran + last_interaction=reconnect → No greeting, just the candidate.
+COMPOSITION EXAMPLES (these are the realistic test scenarios — every new
+signup is day0/day1):
+- day0 newcomer + first ever session → 5–8 sentence FULL INTRODUCTION (mission,
+   capabilities, agency offer, first-step invitation)
+- day1 user + bucket=today → 3–5 sentences, "Good morning, {Name} — day two
+   with us. Yesterday you [reference], let's continue with [candidate]."
+- day3 user + bucket=yesterday → "Hi {Name}, glad you're back. Picking up
+   where we left off — [candidate]."
+- day3 user + bucket=week (2 days silent) → "Hi {Name}, two days since we
+   talked. I'm glad you came back. [candidate]" — early-tenure absence is
+   a churn signal; warmth matters.
+- day7 user + bucket=yesterday → "Good morning, {Name}. [candidate]."
+- day14 user + bucket=week (3 days silent) → "Good to hear from you — been
+   a few days. [candidate]."
+- day30plus user + bucket=same_day → "Back so soon — [candidate]." (no greeting)
+- day30plus user + bucket=long (10 days) → "Hi {Name}, it's been ten days.
+   Welcome back. [candidate]."
 
 INTRODUCTION MODE (only when tenure.stage='day0'):
 Required cover, in order:


### PR DESCRIPTION
Reframes the OPENING SHAPE MATRIX examples around realistic early-tenure scenarios (day0/day1/day3/day7) where every new signup actually lives. Removes Day-231 anchor that was misleading the model. Adds tenure-aware modulation: for early-tenure users (day0-day7), even a 1-2 day absence warrants warmth because they're forming the habit and absence is a churn signal.