### PR TITLE
feat(marketplace): provider registry refactor (VTID-01930)

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -10920,7 +10920,34 @@ function renderAdminContentModerationView() {
     return container;
 }
 
-// ==================== VTID-02000: Admin Marketplace Shops ====================
+// ==================== VTID-02000 / VTID-01930: Admin Marketplace Shops ====================
+
+// VTID-01930: Fetch the provider registry from the gateway. The registry
+// drives the network filter, the per-provider sync buttons, and the
+// schema-driven "Add shop" form — so adding Amazon/Rakuten/etc. requires
+// zero frontend changes.
+async function fetchAdminMarketplaceProviders() {
+    if (state.adminMpProviders && state.adminMpProviders.length) return state.adminMpProviders;
+    try {
+        var resp = await fetch('/api/v1/admin/marketplace/providers', {
+            method: 'GET', headers: buildContextHeaders(),
+        });
+        var json = await resp.json();
+        if (!resp.ok || !json.ok) throw new Error(json.error || ('HTTP ' + resp.status));
+        state.adminMpProviders = json.providers || [];
+        return state.adminMpProviders;
+    } catch (err) {
+        console.error('[VTID-01930] fetch providers failed:', err);
+        state.adminMpProviders = [];
+        return [];
+    }
+}
+
+function getAdminMpProvider(key) {
+    var list = state.adminMpProviders || [];
+    for (var i = 0; i < list.length; i++) if (list[i].key === key) return list[i];
+    return null;
+}
 
 async function fetchAdminMarketplaceShops() {
     state.adminMpShopsLoading = true;
@@ -11014,25 +11041,37 @@ async function triggerMarketplaceSync(network) {
 function renderAdminMarketplaceShopsView() {
     var container = document.createElement('div');
     container.className = 'admin-screen-container';
+    if (!state.adminMpProviders) {
+        fetchAdminMarketplaceProviders().then(function () { renderApp(); });
+    }
     if (!state.adminMpShopsFetched && !state.adminMpShopsLoading && !state.adminMpShopsError) {
         fetchAdminMarketplaceShops();
     }
 
+    var providers = state.adminMpProviders || [];
+    var providerNames = providers.map(function (p) { return p.display_name; }).join(' + ');
+
     var header = document.createElement('div');
     header.className = 'admin-screen-header';
     header.innerHTML = '<h2>Marketplace Shops</h2>' +
-        '<p class="admin-screen-subtitle">Shopify + CJ Affiliate sources that feed the Discover catalog. '
+        '<p class="admin-screen-subtitle">'
+      + escapeHtml(providerNames || 'Marketplace') + ' sources that feed the Discover catalog. '
       + 'Daily sync runs at 03:00 UTC; use the Sync buttons below to force-run.</p>';
     container.appendChild(header);
 
-    // Toolbar: filter + "Add shop" + "Sync all"
+    // Toolbar: filter + "Add shop" + per-provider Sync buttons (registry-driven)
     var toolbar = document.createElement('div');
     toolbar.className = 'admin-filters-row';
     toolbar.style.gap = '0.5rem';
 
     var networkFilter = document.createElement('select');
     networkFilter.className = 'admin-filter-select';
-    networkFilter.innerHTML = '<option value="">All networks</option><option value="shopify">Shopify</option><option value="cj">CJ Affiliate</option>';
+    var filterOptionsHtml = '<option value="">All networks</option>';
+    for (var pi = 0; pi < providers.length; pi++) {
+        var p = providers[pi];
+        filterOptionsHtml += '<option value="' + escapeHtml(p.key) + '">' + escapeHtml(p.display_name) + '</option>';
+    }
+    networkFilter.innerHTML = filterOptionsHtml;
     networkFilter.value = state.adminMpShopsNetworkFilter || '';
     networkFilter.onchange = function (e) {
         state.adminMpShopsNetworkFilter = e.target.value;
@@ -11049,17 +11088,15 @@ function renderAdminMarketplaceShopsView() {
     };
     toolbar.appendChild(addBtn);
 
-    var syncShopifyBtn = document.createElement('button');
-    syncShopifyBtn.className = 'btn btn-secondary btn-sm';
-    syncShopifyBtn.textContent = 'Sync Shopify now';
-    syncShopifyBtn.onclick = function () { triggerMarketplaceSync('shopify'); };
-    toolbar.appendChild(syncShopifyBtn);
-
-    var syncCjBtn = document.createElement('button');
-    syncCjBtn.className = 'btn btn-secondary btn-sm';
-    syncCjBtn.textContent = 'Sync CJ now';
-    syncCjBtn.onclick = function () { triggerMarketplaceSync('cj'); };
-    toolbar.appendChild(syncCjBtn);
+    for (var si = 0; si < providers.length; si++) {
+        (function (pk, pn) {
+            var b = document.createElement('button');
+            b.className = 'btn btn-secondary btn-sm';
+            b.textContent = 'Sync ' + pn + ' now';
+            b.onclick = function () { triggerMarketplaceSync(pk); };
+            toolbar.appendChild(b);
+        })(providers[si].key, providers[si].display_name);
+    }
 
     container.appendChild(toolbar);
 
@@ -11078,10 +11115,13 @@ function renderAdminMarketplaceShopsView() {
         listWrap.innerHTML = '<div class="admin-error">' + state.adminMpShopsError +
             '<br><button class="btn btn-secondary btn-sm" onclick="state.adminMpShopsError=null;fetchAdminMarketplaceShops();">Retry</button></div>';
     } else if (!state.adminMpShops || state.adminMpShops.length === 0) {
+        var onboardHint = providers.length
+            ? providers.map(function (p) { return p.display_name; }).join(' or ')
+            : 'marketplace';
         listWrap.innerHTML = '<div class="admin-empty-list" style="padding:3rem;text-align:center;">' +
             '<span style="font-size:2.5rem;display:block;margin-bottom:0.75rem;">&#128722;</span>' +
             '<p style="font-size:1.1rem;margin-bottom:0.5rem;">No marketplace sources configured yet</p>' +
-            '<p class="admin-detail-note">Click <strong>+ Add shop</strong> above to onboard the first Shopify merchant or CJ publisher account.</p>' +
+            '<p class="admin-detail-note">Click <strong>+ Add shop</strong> above to onboard the first ' + escapeHtml(onboardHint) + ' source.</p>' +
             '</div>';
     } else {
         var table = document.createElement('table');
@@ -11096,15 +11136,23 @@ function renderAdminMarketplaceShopsView() {
         state.adminMpShops.forEach(function (s) {
             var tr = document.createElement('tr');
             var cfg = s.config || {};
+            // Per-provider keyInfo: show the first required, non-secret config
+            // field's value. Works for any registered provider.
             var keyInfo = '';
-            if (s.source_network === 'shopify') {
-                keyInfo = cfg.domain ? cfg.domain : '<em>no domain</em>';
-            } else if (s.source_network === 'cj') {
-                keyInfo = cfg.advertiser_ids ? ('advertisers: ' + (cfg.advertiser_ids.length || '?'))
-                  : (cfg.keywords ? ('kw: ' + cfg.keywords) : '<em>no filter</em>');
-            } else {
-                keyInfo = JSON.stringify(cfg).slice(0, 60);
+            var providerDef = getAdminMpProvider(s.source_network);
+            if (providerDef && providerDef.config_schema) {
+                for (var ci = 0; ci < providerDef.config_schema.length; ci++) {
+                    var spec = providerDef.config_schema[ci];
+                    if (spec.type === 'password') continue;
+                    if (cfg[spec.key] !== undefined && cfg[spec.key] !== null && cfg[spec.key] !== '') {
+                        var raw = cfg[spec.key];
+                        var rendered = Array.isArray(raw) ? (raw.length + ' items') : String(raw).slice(0, 60);
+                        keyInfo = escapeHtml(spec.label.replace(/\s*\(optional\)\s*$/i, '') + ': ' + rendered);
+                        break;
+                    }
+                }
             }
+            if (!keyInfo) keyInfo = escapeHtml(JSON.stringify(cfg).slice(0, 60));
             tr.innerHTML = ''
                 + '<td><strong>' + escapeHtml(s.display_name || s.id) + '</strong>'
                 + (s.notes ? '<br><small class="admin-detail-note">' + escapeHtml(s.notes) + '</small>' : '')
@@ -11132,13 +11180,23 @@ function renderAdminMarketplaceShopsView() {
     return container;
 }
 
+// VTID-01930: Schema-driven "Add marketplace source" form. Every input is
+// generated from the provider's config_schema — adding Amazon/Rakuten/etc.
+// on the backend makes the corresponding form appear here automatically.
 function renderAdminMarketplaceShopCreateForm() {
     var wrap = document.createElement('div');
     wrap.className = 'admin-card';
     wrap.style.padding = '1rem';
     wrap.style.marginBottom = '1rem';
 
-    var network = state.adminMpShopsCreateNetwork || 'shopify';
+    var providers = state.adminMpProviders || [];
+    if (providers.length === 0) {
+        wrap.innerHTML = '<div class="admin-loading">Loading provider registry…</div>';
+        return wrap;
+    }
+    var network = state.adminMpShopsCreateNetwork || providers[0].key;
+    var providerDef = getAdminMpProvider(network) || providers[0];
+    network = providerDef.key;
 
     var h = document.createElement('h3');
     h.textContent = 'Add marketplace source';
@@ -11146,26 +11204,33 @@ function renderAdminMarketplaceShopCreateForm() {
 
     var note = document.createElement('p');
     note.className = 'admin-detail-note';
-    note.textContent = network === 'shopify'
-        ? 'For a Shopify shop, you need the Storefront access token (Admin → Apps → Develop apps → Configure Storefront API).'
-        : 'For CJ Affiliate, you need a publisher developer key + website id from https://developers.cj.com.';
+    note.textContent = providerDef.description || '';
     wrap.appendChild(note);
 
-    function input(id, label, placeholder, type) {
+    function input(id, spec) {
         var row = document.createElement('div');
         row.style.marginBottom = '0.5rem';
-        row.innerHTML = '<label style="display:block;font-size:0.8rem;margin-bottom:0.25rem;">' + label + '</label>'
-            + '<input id="' + id + '" type="' + (type || 'text') + '" placeholder="' + (placeholder || '') + '" class="admin-input" style="width:100%;padding:0.5rem;" />';
+        row.innerHTML = '<label style="display:block;font-size:0.8rem;margin-bottom:0.25rem;">'
+            + escapeHtml(spec.label) + (spec.required ? ' <span style="color:var(--danger)">*</span>' : '')
+            + '</label>'
+            + '<input id="' + id + '" type="' + (spec.type === 'password' ? 'password' : (spec.type === 'number' ? 'number' : 'text')) + '" '
+            + 'placeholder="' + escapeHtml(spec.placeholder || '') + '" class="admin-input" style="width:100%;padding:0.5rem;" />'
+            + (spec.help ? '<small class="admin-detail-note">' + escapeHtml(spec.help) + '</small>' : '');
         return row;
     }
 
-    // Network selector
+    // Network selector — populated from registry
     var netSel = document.createElement('select');
     netSel.className = 'admin-filter-select';
-    netSel.innerHTML = '<option value="shopify">Shopify</option><option value="cj">CJ Affiliate</option>';
+    var netOpts = '';
+    for (var i = 0; i < providers.length; i++) {
+        netOpts += '<option value="' + escapeHtml(providers[i].key) + '">' + escapeHtml(providers[i].display_name) + '</option>';
+    }
+    netSel.innerHTML = netOpts;
     netSel.value = network;
     netSel.onchange = function (e) {
         state.adminMpShopsCreateNetwork = e.target.value;
+        state.adminMpShopsCreateError = null;
         renderApp();
     };
     var netRow = document.createElement('div');
@@ -11174,19 +11239,28 @@ function renderAdminMarketplaceShopCreateForm() {
     netRow.appendChild(netSel);
     wrap.appendChild(netRow);
 
-    wrap.appendChild(input('mp-displayname', 'Display name', network === 'shopify' ? 'Acme Supplements' : 'CJ Publisher Vitana'));
-    wrap.appendChild(input('mp-country', 'Merchant country (ISO-2, optional)', 'DE'));
-    wrap.appendChild(input('mp-notes', 'Internal notes (optional)', 'Commission 12%, contact jane@acme.com'));
+    // Common fields
+    var displayNameRow = input('mp-displayname', {
+        label: 'Display name',
+        required: true,
+        placeholder: providerDef.display_name + ' source',
+        type: 'text',
+    });
+    wrap.appendChild(displayNameRow);
+    wrap.appendChild(input('mp-notes', {
+        label: 'Internal notes (optional)',
+        placeholder: 'Commission 12%, contact jane@acme.com',
+        type: 'text',
+    }));
 
-    if (network === 'shopify') {
-        wrap.appendChild(input('mp-sh-domain', 'Shopify domain', 'acme-supplements.myshopify.com'));
-        wrap.appendChild(input('mp-sh-token', 'Storefront access token', 'shpat_…', 'password'));
-        wrap.appendChild(input('mp-sh-affiliate', 'Affiliate URL template (optional)', 'https://{domain}/products/{handle}?ref=vitana'));
-    } else {
-        wrap.appendChild(input('mp-cj-key', 'CJ developer key', '', 'password'));
-        wrap.appendChild(input('mp-cj-website', 'CJ website id', '12345678'));
-        wrap.appendChild(input('mp-cj-advertisers', 'Advertiser IDs (comma-separated, optional)', '1234,5678'));
-        wrap.appendChild(input('mp-cj-keywords', 'Keyword filter (optional)', 'supplement,vitamin'));
+    // Provider-specific fields, generated from config_schema
+    var fieldInputIds = [];
+    var schema = providerDef.config_schema || [];
+    for (var si = 0; si < schema.length; si++) {
+        var spec = schema[si];
+        var id = 'mp-cfg-' + spec.key;
+        wrap.appendChild(input(id, spec));
+        fieldInputIds.push({ id: id, spec: spec });
     }
 
     if (state.adminMpShopsCreateError) {
@@ -11203,31 +11277,33 @@ function renderAdminMarketplaceShopCreateForm() {
     submitBtn.disabled = !!state.adminMpShopsCreating;
     submitBtn.onclick = function () {
         var displayName = (document.getElementById('mp-displayname') || {}).value || '';
-        var country = (document.getElementById('mp-country') || {}).value || '';
         var notes = (document.getElementById('mp-notes') || {}).value || '';
         var config = {};
-        if (network === 'shopify') {
-            var dom = (document.getElementById('mp-sh-domain') || {}).value || '';
-            var tok = (document.getElementById('mp-sh-token') || {}).value || '';
-            var aff = (document.getElementById('mp-sh-affiliate') || {}).value || '';
-            if (!dom || !tok) { state.adminMpShopsCreateError = 'Shopify requires domain + token'; renderApp(); return; }
-            config.domain = dom.trim();
-            config.storefront_access_token = tok.trim();
-            if (aff) config.affiliate_url_template = aff.trim();
-            if (country) config.merchant_country = country.trim().toUpperCase();
-        } else {
-            var key = (document.getElementById('mp-cj-key') || {}).value || '';
-            var wid = (document.getElementById('mp-cj-website') || {}).value || '';
-            var advs = (document.getElementById('mp-cj-advertisers') || {}).value || '';
-            var kws = (document.getElementById('mp-cj-keywords') || {}).value || '';
-            if (!key || !wid) { state.adminMpShopsCreateError = 'CJ requires developer key + website id'; renderApp(); return; }
-            config.developer_key = key.trim();
-            config.website_id = wid.trim();
-            if (advs.trim()) config.advertiser_ids = advs.split(',').map(function (x){return x.trim();}).filter(Boolean);
-            if (kws.trim()) config.keywords = kws.trim();
-            if (country) config.merchant_country = country.trim().toUpperCase();
+        var missing = [];
+        for (var fi = 0; fi < fieldInputIds.length; fi++) {
+            var entry = fieldInputIds[fi];
+            var el = document.getElementById(entry.id);
+            var v = (el && el.value != null) ? String(el.value).trim() : '';
+            if (!v) {
+                if (entry.spec.required) missing.push(entry.spec.label);
+                continue;
+            }
+            if (entry.spec.list) {
+                config[entry.spec.key] = v.split(',').map(function (x) { return x.trim(); }).filter(Boolean);
+            } else if (entry.spec.type === 'number') {
+                var n = Number(v);
+                if (!Number.isFinite(n)) { missing.push(entry.spec.label + ' (must be a number)'); continue; }
+                config[entry.spec.key] = n;
+            } else {
+                config[entry.spec.key] = v;
+            }
         }
-        if (!displayName) { state.adminMpShopsCreateError = 'display_name is required'; renderApp(); return; }
+        if (!displayName) missing.push('Display name');
+        if (missing.length) {
+            state.adminMpShopsCreateError = 'Required: ' + missing.join(', ');
+            renderApp();
+            return;
+        }
         submitAdminMarketplaceShopCreate({
             source_network: network,
             display_name: displayName.trim(),

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -12,7 +12,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260328-aura"></script>
-  <script src="/command-hub/app.js?v=20260419-upstream-timeout-fix"></script>
+  <script src="/command-hub/app.js?v=20260419-vtid01930-provider-registry"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js"></script>
 </body>

--- a/services/gateway/src/routes/admin-marketplace.ts
+++ b/services/gateway/src/routes/admin-marketplace.ts
@@ -282,6 +282,21 @@ router.patch('/geo-policy/:id', requireTenantAdmin, async (req: Request, res: Re
   res.json({ ok: true, policy: data });
 });
 
+// ==================== VTID-01930: Provider registry ====================
+
+// Drives the Command Hub "Add shop" dropdown + form. Adding a new provider
+// requires zero frontend changes — the form is generated from config_schema.
+router.get('/providers', requireTenantAdmin, async (_req: Request, res: Response) => {
+  const { listProviders } = await import('../services/marketplace-sync/providers');
+  const providers = listProviders().map((p) => ({
+    key: p.key,
+    display_name: p.displayName,
+    description: p.description,
+    config_schema: p.configSchema,
+  }));
+  res.json({ ok: true, providers });
+});
+
 // ==================== VTID-02200: Sources (Shopify + CJ + etc) ====================
 
 router.get('/sources', requireTenantAdmin, async (req: Request, res: Response) => {
@@ -304,6 +319,18 @@ router.post('/sources', requireTenantAdmin, async (req: Request, res: Response) 
   if (!payload.source_network || !payload.display_name || !payload.config) {
     return res.status(400).json({ ok: false, error: 'source_network, display_name, config required' });
   }
+  // VTID-01930: reject unknown providers + run provider-level validateConfig
+  const { getProvider } = await import('../services/marketplace-sync/providers');
+  const provider = getProvider(String(payload.source_network));
+  if (!provider) {
+    return res.status(400).json({ ok: false, error: `Unknown source_network: ${payload.source_network}` });
+  }
+  if (provider.validateConfig) {
+    const validation = provider.validateConfig(payload.config as Record<string, unknown>);
+    if (!validation.ok) {
+      return res.status(400).json({ ok: false, error: `Invalid ${provider.key} config: ${validation.error}` });
+    }
+  }
   payload.created_by = getUserId(req) ?? null;
   const { data, error } = await supabase.from('marketplace_sources_config').insert(payload).select().single();
   if (error) return res.status(500).json({ ok: false, error: error.message });
@@ -325,14 +352,20 @@ router.patch('/sources/:id', requireTenantAdmin, async (req: Request, res: Respo
 });
 
 // Manual sync trigger — runs in-process, returns the result once done.
+// Supported networks come from the provider registry.
 router.post('/sync/:network', requireTenantAdmin, async (req: Request, res: Response) => {
   const network = req.params.network;
-  if (!['shopify', 'cj'].includes(network)) {
-    return res.status(400).json({ ok: false, error: `Unsupported network: ${network}. Use shopify or cj.` });
+  const { providerKeys } = await import('../services/marketplace-sync/providers');
+  const supported = providerKeys();
+  if (!supported.includes(network)) {
+    return res.status(400).json({
+      ok: false,
+      error: `Unsupported network: ${network}. Use one of: ${supported.join(', ')}.`,
+    });
   }
   try {
     const { runMarketplaceSyncSource } = await import('../services/marketplace-sync');
-    const result = await runMarketplaceSyncSource(network as 'shopify' | 'cj', `admin:${getUserId(req) ?? 'unknown'}`);
+    const result = await runMarketplaceSyncSource(network, `admin:${getUserId(req) ?? 'unknown'}`);
     await emitAdminActivity(getTenantId(req), getUserId(req), 'marketplace_sync.triggered', { network, totals: result.totals });
     res.json({ ok: true, network, result });
   } catch (err: unknown) {

--- a/services/gateway/src/routes/internal-marketplace-sync.ts
+++ b/services/gateway/src/routes/internal-marketplace-sync.ts
@@ -1,5 +1,5 @@
 /**
- * VTID-02000: Internal sync trigger endpoint for the scheduler.
+ * VTID-02000 / VTID-01930: Internal sync trigger endpoint for the scheduler.
  *
  * Separate from /api/v1/admin/marketplace/sync which requires a tenant-admin
  * JWT — that's a dead-end for machine-to-machine cron. This endpoint is
@@ -9,6 +9,9 @@
  *   - .github/workflows/MARKETPLACE-SYNC-CRON.yml — daily at 03:00 UTC
  *   - Manual `curl -H 'X-Scheduler-Secret: $MARKETPLACE_SYNC_SECRET' ...`
  *     when an operator wants to force-run outside the schedule
+ *
+ * The supported networks come from the provider registry — adding Amazon,
+ * Rakuten, etc. requires no changes here.
  *
  * Any request without a matching X-Scheduler-Secret header returns 401.
  * If MARKETPLACE_SYNC_SECRET is not configured on the gateway, all requests
@@ -42,8 +45,14 @@ router.post('/sync/:network', async (req: Request, res: Response) => {
   }
 
   const network = req.params.network;
-  if (!['shopify', 'cj', 'all'].includes(network)) {
-    res.status(400).json({ ok: false, error: `Unsupported network: ${network}. Use shopify, cj, or all.` });
+  const { providerKeys } = await import('../services/marketplace-sync/providers');
+  const supported = providerKeys();
+
+  if (network !== 'all' && !supported.includes(network)) {
+    res.status(400).json({
+      ok: false,
+      error: `Unsupported network: ${network}. Use one of: ${['all', ...supported].join(', ')}.`,
+    });
     return;
   }
 
@@ -54,14 +63,15 @@ router.post('/sync/:network', async (req: Request, res: Response) => {
 
     if (network === 'all') {
       const result = await runAllMarketplaceSync(triggeredBy);
-      console.log(
-        `[marketplace-sync-scheduler] all done in ${Date.now() - startedAt}ms shopify=${JSON.stringify(result.shopify.totals)} cj=${JSON.stringify(result.cj.totals)}`,
-      );
+      const summary = Object.entries(result.providers)
+        .map(([k, v]) => `${k}=${JSON.stringify(v.totals)}`)
+        .join(' ');
+      console.log(`[marketplace-sync-scheduler] all done in ${Date.now() - startedAt}ms ${summary}`);
       res.json({ ok: true, network: 'all', duration_ms: Date.now() - startedAt, result });
       return;
     }
 
-    const result = await runMarketplaceSyncSource(network as 'shopify' | 'cj', triggeredBy);
+    const result = await runMarketplaceSyncSource(network, triggeredBy);
     console.log(`[marketplace-sync-scheduler] ${network} done in ${Date.now() - startedAt}ms`, result.totals);
     res.json({ ok: true, network, duration_ms: Date.now() - startedAt, result });
   } catch (err: unknown) {

--- a/services/gateway/src/services/marketplace-sync/index.ts
+++ b/services/gateway/src/services/marketplace-sync/index.ts
@@ -1,61 +1,68 @@
 /**
- * VTID-02200: Marketplace sync orchestrator.
+ * VTID-02200 / VTID-01930: Marketplace sync orchestrator.
  *
- * Single entry point that runs all enabled marketplace sources on schedule.
+ * Single entry point that iterates the provider registry (./providers).
+ * Adding a new source (Amazon, Rakuten, …) is a registry-only change —
+ * this file never needs to be touched.
  */
 
-import { runShopifySync, type ShopifySyncResult } from './shopify-sync';
-import { runCjSync, type CjSyncResult } from './cj-sync';
+import type { ProviderSyncResult } from './provider';
+import { getProvider, listProviders } from './providers';
+
+export type { ProviderSyncResult } from './provider';
 
 export interface MarketplaceSyncAllResult {
   ok: boolean;
-  shopify: ShopifySyncResult;
-  cj: CjSyncResult;
+  /** Per-provider result keyed by provider.key (e.g. 'shopify', 'cj'). */
+  providers: Record<string, ProviderSyncResult>;
   duration_ms: number;
+}
+
+function emptyFailure(message: string): ProviderSyncResult {
+  return {
+    ok: false,
+    totals: { inserted: 0, updated: 0, skipped: 0, errors: 1 },
+    duration_ms: 0,
+    error: message,
+  };
 }
 
 export async function runAllMarketplaceSync(triggered_by = 'scheduler'): Promise<MarketplaceSyncAllResult> {
   const startTime = Date.now();
   console.log('[marketplace-sync] run started — triggered_by=%s', triggered_by);
 
-  // Sequential is fine; each source is rate-limited on its own vendor side.
-  const shopify = await runShopifySync(triggered_by).catch((err: unknown) => {
-    const message = err instanceof Error ? err.message : String(err);
-    console.error('[marketplace-sync] shopify failed:', message);
-    return {
-      ok: false,
-      shops_synced: 0,
-      totals: { inserted: 0, updated: 0, skipped: 0, errors: 1 },
-      per_shop: [],
-      duration_ms: 0,
-    } as ShopifySyncResult;
-  });
+  const providers: Record<string, ProviderSyncResult> = {};
+  let allOk = true;
 
-  const cj = await runCjSync(triggered_by).catch((err: unknown) => {
-    const message = err instanceof Error ? err.message : String(err);
-    console.error('[marketplace-sync] cj failed:', message);
-    return {
-      ok: false,
-      totals: { inserted: 0, updated: 0, skipped: 0, errors: 1, fetched: 0 },
-      pages_fetched: 0,
-      advertisers_seen: 0,
-      duration_ms: 0,
-      error: message,
-    } as CjSyncResult;
-  });
+  // Sequential is fine; each provider rate-limits against its own vendor.
+  for (const p of listProviders()) {
+    const r = await p.runSync(triggered_by).catch((err: unknown) => {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`[marketplace-sync] ${p.key} failed:`, message);
+      return emptyFailure(message);
+    });
+    providers[p.key] = r;
+    if (!r.ok) allOk = false;
+  }
 
   const duration_ms = Date.now() - startTime;
-  console.log(`[marketplace-sync] run done in ${duration_ms}ms — shopify=${shopify.totals.inserted}+ cj=${cj.totals.inserted}+`);
+  const summary = Object.entries(providers)
+    .map(([k, v]) => `${k}=${v.totals.inserted}+`)
+    .join(' ');
+  console.log(`[marketplace-sync] run done in ${duration_ms}ms — ${summary}`);
 
-  return {
-    ok: shopify.ok && cj.ok,
-    shopify,
-    cj,
-    duration_ms,
-  };
+  return { ok: allOk, providers, duration_ms };
 }
 
-export async function runMarketplaceSyncSource(source: 'shopify' | 'cj', triggered_by: string) {
-  if (source === 'shopify') return runShopifySync(triggered_by);
-  return runCjSync(triggered_by);
+export async function runMarketplaceSyncSource(
+  source: string,
+  triggered_by: string
+): Promise<ProviderSyncResult> {
+  const provider = getProvider(source);
+  if (!provider) {
+    throw new Error(
+      `Unknown marketplace provider: ${source}. Supported: ${listProviders().map((p) => p.key).join(', ')}`
+    );
+  }
+  return provider.runSync(triggered_by);
 }

--- a/services/gateway/src/services/marketplace-sync/provider.ts
+++ b/services/gateway/src/services/marketplace-sync/provider.ts
@@ -1,0 +1,64 @@
+/**
+ * VTID-01930: Marketplace provider registry — extensibility layer.
+ *
+ * Adding a new catalog source (Amazon, Rakuten, Awin, Impact, …) should be:
+ *   1. Drop a file at ./providers/<name>.ts implementing MarketplaceProvider.
+ *   2. Register it in ./providers/index.ts.
+ *   3. Everything else (admin UI dropdown, scheduler, internal sync route,
+ *      tenant-admin trigger) picks it up automatically via this registry.
+ *
+ * The previous shopify/cj hardcoded if/else branches across the admin UI,
+ * the internal sync route, and the scheduler were the technical debt this
+ * module retires.
+ */
+
+export interface SyncTotals {
+  inserted: number;
+  updated: number;
+  skipped: number;
+  errors: number;
+}
+
+export interface ProviderSyncResult {
+  ok: boolean;
+  totals: SyncTotals;
+  duration_ms: number;
+  /** Optional provider-specific payload (per-shop breakdown, pages fetched, etc). */
+  details?: Record<string, unknown>;
+  error?: string;
+}
+
+/**
+ * A single field in a provider's "Add source" admin form.
+ * Drives the Command Hub dropdown + input form without any per-provider
+ * frontend wiring.
+ */
+export interface ConfigFieldSpec {
+  key: string;
+  label: string;
+  type: 'text' | 'password' | 'number' | 'textarea';
+  placeholder?: string;
+  required?: boolean;
+  help?: string;
+  /** If set, the field's value is parsed as a comma-separated list before save. */
+  list?: boolean;
+}
+
+export interface MarketplaceProvider {
+  /** Stable slug persisted on catalog rows — NEVER change after launch. */
+  key: string;
+  /** Human-readable name shown in admin UI. */
+  displayName: string;
+  /** One-line description shown beneath the dropdown in the Add-source form. */
+  description: string;
+  /** Drives the Add-source form. */
+  configSchema: ConfigFieldSpec[];
+  /**
+   * Optional pre-save sanity check. Return `{ ok: false, error }` to reject
+   * a proposed source config before it hits Supabase. Keep this cheap —
+   * structural checks only, not live-API probes.
+   */
+  validateConfig?(cfg: Record<string, unknown>): { ok: boolean; error?: string };
+  /** Run a full catalog sync for this provider. */
+  runSync(triggered_by: string): Promise<ProviderSyncResult>;
+}

--- a/services/gateway/src/services/marketplace-sync/providers/cj.ts
+++ b/services/gateway/src/services/marketplace-sync/providers/cj.ts
@@ -1,0 +1,70 @@
+/**
+ * VTID-01930: CJ Affiliate provider registration.
+ *
+ * The underlying sync logic lives in ../cj-sync.ts. This file is the
+ * provider-registry adapter.
+ */
+
+import type { MarketplaceProvider, ProviderSyncResult } from '../provider';
+import { runCjSync } from '../cj-sync';
+
+export const cjProvider: MarketplaceProvider = {
+  key: 'cj',
+  displayName: 'CJ Affiliate',
+  description:
+    'Commission Junction Product Search. One publisher account per environment; credentials come from developers.cj.com.',
+  configSchema: [
+    {
+      key: 'developer_key',
+      label: 'CJ developer key',
+      type: 'password',
+      required: true,
+    },
+    {
+      key: 'website_id',
+      label: 'CJ website id',
+      type: 'text',
+      placeholder: '12345678',
+      required: true,
+    },
+    {
+      key: 'advertiser_ids',
+      label: 'Advertiser IDs (comma-separated, optional)',
+      type: 'text',
+      placeholder: '1234,5678',
+      list: true,
+    },
+    {
+      key: 'keywords',
+      label: 'Keyword filter (optional)',
+      type: 'text',
+      placeholder: 'supplement,vitamin',
+    },
+    {
+      key: 'merchant_country',
+      label: 'Merchant country (ISO-2, optional)',
+      type: 'text',
+      placeholder: 'DE',
+    },
+  ],
+  validateConfig(cfg) {
+    if (!cfg || typeof cfg !== 'object') return { ok: false, error: 'config must be an object' };
+    if (!cfg.developer_key || typeof cfg.developer_key !== 'string') {
+      return { ok: false, error: 'developer_key is required' };
+    }
+    if (!cfg.website_id || (typeof cfg.website_id !== 'string' && typeof cfg.website_id !== 'number')) {
+      return { ok: false, error: 'website_id is required' };
+    }
+    return { ok: true };
+  },
+  async runSync(triggered_by: string): Promise<ProviderSyncResult> {
+    const r = await runCjSync(triggered_by);
+    return {
+      ok: r.ok,
+      totals: { inserted: r.totals.inserted, updated: r.totals.updated, skipped: r.totals.skipped, errors: r.totals.errors },
+      duration_ms: r.duration_ms,
+      details: { fetched: r.totals.fetched, pages_fetched: r.pages_fetched, advertisers_seen: r.advertisers_seen },
+      error: r.error,
+    };
+  },
+};

--- a/services/gateway/src/services/marketplace-sync/providers/index.ts
+++ b/services/gateway/src/services/marketplace-sync/providers/index.ts
@@ -1,0 +1,29 @@
+/**
+ * VTID-01930: Marketplace provider registry.
+ *
+ * Import this module wherever you need to iterate, look up, or list
+ * supported marketplace providers. Do NOT reach into individual provider
+ * files directly — go through the registry so adding a new provider stays
+ * a one-line change.
+ */
+
+import type { MarketplaceProvider } from '../provider';
+import { shopifyProvider } from './shopify';
+import { cjProvider } from './cj';
+
+/** Order here == display order in the admin UI dropdown. */
+const PROVIDERS: readonly MarketplaceProvider[] = [shopifyProvider, cjProvider];
+
+const BY_KEY = new Map<string, MarketplaceProvider>(PROVIDERS.map((p) => [p.key, p]));
+
+export function listProviders(): readonly MarketplaceProvider[] {
+  return PROVIDERS;
+}
+
+export function getProvider(key: string): MarketplaceProvider | undefined {
+  return BY_KEY.get(key);
+}
+
+export function providerKeys(): string[] {
+  return PROVIDERS.map((p) => p.key);
+}

--- a/services/gateway/src/services/marketplace-sync/providers/shopify.ts
+++ b/services/gateway/src/services/marketplace-sync/providers/shopify.ts
@@ -1,0 +1,62 @@
+/**
+ * VTID-01930: Shopify provider registration.
+ *
+ * The underlying sync logic lives in ../shopify-sync.ts. This file is the
+ * provider-registry adapter: config schema, display name, and the runSync
+ * binding.
+ */
+
+import type { MarketplaceProvider, ProviderSyncResult } from '../provider';
+import { runShopifySync } from '../shopify-sync';
+
+export const shopifyProvider: MarketplaceProvider = {
+  key: 'shopify',
+  displayName: 'Shopify',
+  description:
+    'Per-merchant Shopify stores. Read-only Storefront API — install the Vitana partner app on the shop, paste the Storefront access token.',
+  configSchema: [
+    {
+      key: 'domain',
+      label: 'Shopify domain',
+      type: 'text',
+      placeholder: 'acme-supplements.myshopify.com',
+      required: true,
+    },
+    {
+      key: 'storefront_access_token',
+      label: 'Storefront access token',
+      type: 'password',
+      placeholder: 'shpat_…',
+      required: true,
+    },
+    {
+      key: 'affiliate_url_template',
+      label: 'Affiliate URL template (optional)',
+      type: 'text',
+      placeholder: 'https://{domain}/products/{handle}?ref=vitana',
+    },
+    {
+      key: 'merchant_country',
+      label: 'Merchant country (ISO-2, optional)',
+      type: 'text',
+      placeholder: 'DE',
+    },
+  ],
+  validateConfig(cfg) {
+    if (!cfg || typeof cfg !== 'object') return { ok: false, error: 'config must be an object' };
+    if (!cfg.domain || typeof cfg.domain !== 'string') return { ok: false, error: 'domain is required' };
+    if (!cfg.storefront_access_token || typeof cfg.storefront_access_token !== 'string') {
+      return { ok: false, error: 'storefront_access_token is required' };
+    }
+    return { ok: true };
+  },
+  async runSync(triggered_by: string): Promise<ProviderSyncResult> {
+    const r = await runShopifySync(triggered_by);
+    return {
+      ok: r.ok,
+      totals: r.totals,
+      duration_ms: r.duration_ms,
+      details: { shops_synced: r.shops_synced, per_shop: r.per_shop },
+    };
+  },
+};

--- a/services/gateway/src/services/recommendation-engine/scheduler.ts
+++ b/services/gateway/src/services/recommendation-engine/scheduler.ts
@@ -181,16 +181,17 @@ async function runFullCodebaseScan(basePath: string): Promise<void> {
 // Community User Daily Regeneration
 // =============================================================================
 
-// VTID-02200: Daily marketplace catalog sync (Shopify + CJ + future Amazon/Awin)
+// VTID-02200 / VTID-01930: Daily marketplace catalog sync — iterates the provider registry.
 async function runMarketplaceSync(): Promise<void> {
   console.log(`${LOG_PREFIX} Running daily marketplace catalog sync...`);
   try {
     const { runAllMarketplaceSync } = await import('../marketplace-sync');
     const result = await runAllMarketplaceSync('scheduler');
     state.lastMarketplaceRun = new Date();
-    console.log(
-      `${LOG_PREFIX} Marketplace sync done: shopify=${result.shopify.totals.inserted}+ cj=${result.cj.totals.inserted}+ in ${result.duration_ms}ms`
-    );
+    const summary = Object.entries(result.providers)
+      .map(([k, v]) => `${k}=${v.totals.inserted}+`)
+      .join(' ');
+    console.log(`${LOG_PREFIX} Marketplace sync done: ${summary} in ${result.duration_ms}ms`);
   } catch (err: unknown) {
     const message = err instanceof Error ? err.message : String(err);
     console.error(`${LOG_PREFIX} Marketplace sync failed:`, message);


### PR DESCRIPTION
## Summary
Refactor Shopify/CJ hardcoded branching into a MarketplaceProvider registry so adding Amazon, Rakuten, Awin, Impact etc. becomes a one-file change. No behavior change for Shopify + CJ — underlying sync logic in shopify-sync.ts / cj-sync.ts is untouched; the new provider files are thin adapters.

## What changed
- New interface: services/gateway/src/services/marketplace-sync/provider.ts (MarketplaceProvider: key, displayName, description, configSchema, validateConfig, runSync).
- New registry: providers/{shopify,cj,index}.ts. Adding a source = drop providers/<name>.ts + register in providers/index.ts.
- Orchestrator (marketplace-sync/index.ts) iterates listProviders() instead of hardcoding shopify/cj.
- /api/v1/internal/marketplace/sync/:network and /api/v1/admin/marketplace/sync/:network validate against providerKeys().
- New endpoint GET /api/v1/admin/marketplace/providers returns display names + config schemas for the UI.
- Admin UI (Command Hub): network filter, per-provider Sync buttons, and the "Add shop" form are generated from the registry; form inputs come from each provider's config_schema.
- POST /api/v1/admin/marketplace/sources runs provider.validateConfig before Supabase insert.

## Unblocks
- PR #2 (Amazon PA-API v5): pure addition — drop providers/amazon.ts, register it, done.
- PR #3 (Rakuten + Awin): same pattern.

## Test plan
- [x] tsc --noEmit on gateway — clean
- [x] node --check app.js — clean
- [ ] Post-merge: curl /api/v1/admin/marketplace/providers returns shopify + cj
- [ ] Post-merge: existing Shopify + CJ syncs still work end-to-end
- [ ] Post-merge: Command Hub → Admin → Marketplace Shops renders with registry-driven dropdown + form

🤖 Generated with [Claude Code](https://claude.com/claude-code)