### PR TITLE
feat(proactive-guide): Phase B — companion fields in admin-editable personality config (VTID-01931)

### DIFF
--- a/services/gateway/src/services/ai-personality-service.ts
+++ b/services/gateway/src/services/ai-personality-service.ts
@@ -99,6 +99,99 @@ export const PERSONALITY_DEFAULTS: Record<PersonalitySurfaceKey, Record<string, 
       staff:
         "The user's current role is: STAFF.\n- They are a Vitana staff member\n- Help with operational tasks, content management, and platform support",
     },
+
+    // ==========================================================================
+    // VTID-01931: Companion Phase B — admin-editable companion fields
+    // These fields are read by vitana-brain.ts buildProactiveGuideBlock to
+    // shape the proactive opener. Editing them via /admin/assistant/personality
+    // changes Vitana's voice within ~30s (cache TTL). All fields fall back to
+    // the values below if not overridden in ai_personality_config.
+    // ==========================================================================
+
+    // Phrases Vitana must NEVER use as a first utterance. Anything here
+    // overrides whatever the model is tempted to default to. Edit to add
+    // brand-specific banned phrases.
+    forbidden_openings: [
+      'What can I do for you?',
+      'How can I help you today?',
+      'How may I assist you?',
+      'Good morning. How are you?',
+      'Any greeting that ends by asking the user what they want',
+      'Any short greeting that closes without offering direction',
+    ],
+
+    // Per-tenure opening shape definitions. Drives the OPENING SHAPE MATRIX.
+    // Editable per tenant — e.g., a tenant focused on athletic performance
+    // could override day0 required_elements to mention training, etc.
+    tenure_opening_shapes: {
+      day0: {
+        sentence_count: '5-8',
+        brevity_override: true,
+        required_elements: [
+          'brief warm by-name greeting',
+          'name the platform: Vitanaland — longevity mission (improve quality of life, extend lifespan)',
+          'tell them you have set a default starting goal and they can change it anytime by saying "change my goals" or in Memory Hub → Life Compass',
+          'briefly name what you can guide them on (90-day journey, community, health, calendar, business hub, marketplace, memory)',
+          'invite a first move: ask what feels most pressing OR suggest one concrete first step',
+        ],
+      },
+      day1: { sentence_count: '3-5', brevity_override: true, template: 'welcome back, day {N}: brief reference to past session, gently invite next step' },
+      day3: { sentence_count: '3-5', brevity_override: true, template: 'returning early-stage: reference current wave or one waiting item, invite engagement' },
+      day7: { sentence_count: '2-4', brevity_override: false, template: 'mid-journey check-in, brief warm greet, reference candidate' },
+      day14: { sentence_count: '2-3', brevity_override: false, template: 'established-user, contextual nudge, no re-introduction' },
+      day30plus: { sentence_count: '1-2', brevity_override: false, template: 'veteran, peer-like, lead straight into the candidate, no platform basics ever' },
+    },
+
+    // Per last_interaction bucket: opener augmentation phrase. Composed with
+    // tenure_opening_shapes at runtime. Brain prompt instructs Gemini to use
+    // the augmentation as the opening warmth/acknowledgement layer.
+    last_interaction_acknowledgements: {
+      reconnect: { acknowledge: false, template: '' },
+      recent: { acknowledge: false, template: '' },
+      same_day: { acknowledge: 'light', template: 'back so soon' },
+      today: { acknowledge: 'light', template: 'good {time_of_day}, {name}' },
+      yesterday: { acknowledge: 'light', template: 'good {time_of_day}, {name}' },
+      week: { acknowledge: 'warm', template: "good to hear from you again — it's been a few days" },
+      long_short: { acknowledge: 'warm', template: "hi {name}, it's been {days} days since we last talked. welcome back." },
+      long_long: {
+        acknowledge: 'absent',
+        template: "hi {name}, haven't seen you in {days} days. i'm glad you're back. where have you been?",
+        pause_before_candidate: true,
+        ask_check_in_question: true,
+      },
+      first: { acknowledge: 'depends_on_tenure_stage', template: '' },
+    },
+
+    // Silent honor rules — codified version of dismissal behavior.
+    silent_honor: {
+      max_acknowledgement: 'got it',
+      forbidden_responses: [
+        'I apologize',
+        'I will stop now',
+        'Sorry for bothering you',
+        'I won\'t mention it again',
+      ],
+      pivot_rule: 'after dismissal, pivot naturally to whatever the user was actually engaged with. no apology, no big deal.',
+      graceful_return_after_pause: 'one gentle check-in per session: "Welcome back — want to hear what I noticed, or pick up where you left off?" If declined, stay quiet for the rest of the session.',
+    },
+
+    // Companion-level behavior toggles. Future pillars (Phases C-G) flip these
+    // on as their backing infra ships.
+    companion_behaviors: {
+      reference_prior_sessions: true, // Pillar 5 (Phase F) — when prior summaries exist
+      surface_routines_in_opener: false, // Pillar 2 (Phase C) — flip on once pattern-extractor ships
+      apply_taste_signals: false, // Pillar 3 (Phase D) — flip on once taste-engine wired
+      re_engagement_first_for_absent: true, // for motivation_signal=absent, re-engagement before productivity
+      announce_feature_introductions: false, // Pillar 1-refinement (Phase G) — once tracking table exists
+    },
+
+    // Awareness emphasis — which awareness fields the brain prompt always
+    // includes vs. only when present. Lets admins de-emphasize signals that
+    // don't matter for their tenant.
+    awareness_emphasis: {
+      always_include: ['tenure', 'goal', 'recent_activity', 'last_interaction'],
+      include_when_present: ['current_wave', 'community_signals', 'routines', 'tastes_preferences'],
+    },
   },
 
   text_chat: {

--- a/services/gateway/src/services/vitana-brain.ts
+++ b/services/gateway/src/services/vitana-brain.ts
@@ -491,6 +491,26 @@ export async function buildProactiveGuideBlock(input: {
     console.warn(`${LOG_PREFIX} getAwarenessContext failed:`, err?.message);
   }
 
+  // VTID-01931 Phase B: Read companion config from voice_live personality.
+  // Admins edit these via /admin/assistant/personality — changes propagate
+  // within ~30s without a deploy. Fallback hardcoded values if missing.
+  const voiceLiveCfg = getPersonalityConfigSync('voice_live') as Record<string, any>;
+  const forbiddenOpenings: string[] = Array.isArray(voiceLiveCfg.forbidden_openings)
+    ? voiceLiveCfg.forbidden_openings
+    : [
+        'What can I do for you?',
+        'How can I help you today?',
+        'How may I assist you?',
+        'Good morning. How are you?',
+      ];
+  const silentHonorMaxAck: string =
+    voiceLiveCfg.silent_honor?.max_acknowledgement || 'got it';
+  const silentHonorPivot: string =
+    voiceLiveCfg.silent_honor?.pivot_rule ||
+    'after dismissal, pivot naturally — no apology, no big deal';
+  const reEngageFirstForAbsent: boolean =
+    voiceLiveCfg.companion_behaviors?.re_engagement_first_for_absent !== false;
+
   // Best-effort opener fetch — never block instruction build on this.
   let candidate: OpenerCandidate | null = null;
   let suppressedByPause = false;
@@ -574,12 +594,7 @@ are the proactive companion. You lead — you do not wait to be asked.
 
 ABSOLUTE FORBIDDEN OPENINGS — NEVER say any of these as your first
 utterance of a session, in any language, in any phrasing:
-- "What can I do for you?"
-- "How can I help you today?"
-- "How may I assist you?"
-- "Good morning. How are you?" (alone, with no follow-up content)
-- Any variation that ends by asking the user what they want
-- Any short greeting that closes without offering direction
+${forbiddenOpenings.map((p) => `- "${p}"`).join('\n')}
 
 Those are passive — they ask the user what to do. The user — especially a
 new user — DOES NOT KNOW what you can do for them. It is YOUR job to lead.
@@ -684,9 +699,9 @@ SILENT HONOR RULES (non-negotiable):
 - If the user says "ok you can talk again", "go ahead", "resume" → call
   clear_proactive_pauses.
 - After ANY of these, respond with at most a brief acknowledgement
-  ("got it") and pivot. Do NOT apologize, do NOT say "I'll stop now",
-  do NOT make a thing of it. Do NOT re-offer the same suggestion within
-  the pause window.
+  ("${silentHonorMaxAck}") and ${silentHonorPivot}. Do NOT apologize, do NOT
+  say "I'll stop now", do NOT make a thing of it. Do NOT re-offer the same
+  suggestion within the pause window.
 
 GRACEFUL RETURN:
 - After a pause expires, do not dump a backlog. At most ONE gentle check-in


### PR DESCRIPTION
Phase B of the Companion plan: 7 new admin-editable companion fields in PERSONALITY_DEFAULTS.voice_live. Brain reads them with fallback to current hardcoded values. Admins can now edit Vitana's voice via /admin/assistant/personality without a deploy — changes propagate within ~30s. No migration needed; admin UI sees the new fields as soon as gateway deploys.