### PR TITLE
feat(proactive-guide): Phase G — feature-introduction tracking (VTID-01932)

### DIFF
--- a/services/gateway/src/services/guide/awareness-context.ts
+++ b/services/gateway/src/services/guide/awareness-context.ts
@@ -23,6 +23,7 @@ import {
 } from '../recommendation-engine/analyzers/community-user-analyzer';
 import { DEFAULT_WAVE_CONFIG } from '../wave-defaults';
 import { describeTimeSince, fetchLastSessionInfo, type LastInteraction } from './temporal-bucket';
+import { getFeatureIntroductions } from './feature-introductions';
 import type {
   UserAwareness,
   TenureStage,
@@ -71,11 +72,13 @@ export async function getAwarenessContext(
     lastSessionInfo,
     goal,
     recentActivity,
+    featureIntros,
   ] = await Promise.all([
     safeGatherUserContext(userId, tenantId, supabase),
     fetchLastSessionInfo(userId).catch(() => null),
     fetchActiveGoal(userId, supabase),
     fetchRecentActivitySummary(userId, supabase),
+    getFeatureIntroductions(userId).catch(() => []),
   ]);
 
   const tenure = buildTenure(userContext);
@@ -92,6 +95,7 @@ export async function getAwarenessContext(
     community_signals,
     recent_activity: recentActivity,
     last_interaction,
+    feature_introductions: (featureIntros || []).map((f) => f.feature_key),
     routines: null,
     tastes_preferences: null,
     adaptation_plans: null,
@@ -296,6 +300,7 @@ function skeletalAwareness(): UserAwareness {
     },
     recent_activity: emptyRecentActivity(),
     last_interaction: describeTimeSince(null),
+    feature_introductions: [],
     routines: null,
     tastes_preferences: null,
     adaptation_plans: null,

--- a/services/gateway/src/services/guide/feature-introductions.ts
+++ b/services/gateway/src/services/guide/feature-introductions.ts
@@ -1,0 +1,133 @@
+/**
+ * Companion Phase G — Feature-Introduction Tracking (VTID-01932)
+ *
+ * Records which platform features Vitana has already explained to each user.
+ * Brain reads from getFeatureIntroductions() and instructs the LLM not to
+ * re-introduce features in the list. The LLM calls record_feature_introduction
+ * (Gemini tool) after explaining a feature, which writes a row.
+ *
+ * This stops Vitana from explaining "Life Compass" or "Vitana Index" every
+ * single session to a Day-30+ user who has heard the explanation already.
+ */
+
+import { getSupabase } from '../../lib/supabase';
+import { emitGuideTelemetry } from './guide-telemetry';
+
+const LOG_PREFIX = '[Guide:feature-introductions]';
+
+/**
+ * Canonical feature keys. The LLM is told which ones it can record.
+ * Adding a new key here makes it admin-discoverable but also requires
+ * the LLM to know about it (system prompt updated by Phase B config).
+ */
+export const KNOWN_FEATURE_KEYS = [
+  'life_compass',
+  'vitana_index',
+  'autopilot',
+  'memory_garden',
+  'calendar',
+  'business_hub',
+  'marketplace',
+  'journey_90day',
+  'voice_chat_basics',
+  'dismissal_phrases',
+  'goal_changing',
+  'navigator',
+  'community',
+] as const;
+
+export type FeatureKey = (typeof KNOWN_FEATURE_KEYS)[number] | string;
+
+export interface FeatureIntroduction {
+  feature_key: string;
+  introduced_at: string;
+  channel: 'voice' | 'text' | 'system';
+}
+
+/**
+ * Read all features Vitana has already introduced to this user.
+ * Returns empty array on any error (safe fallback — worst case Vitana
+ * re-introduces a feature, which is better than crashing).
+ */
+export async function getFeatureIntroductions(userId: string): Promise<FeatureIntroduction[]> {
+  const supabase = getSupabase();
+  if (!supabase) return [];
+
+  const { data, error } = await supabase
+    .from('user_feature_introductions')
+    .select('feature_key, introduced_at, channel')
+    .eq('user_id', userId)
+    .order('introduced_at', { ascending: false })
+    .limit(50);
+
+  if (error) {
+    console.warn(`${LOG_PREFIX} read failed:`, error.message);
+    return [];
+  }
+  return (data || []) as FeatureIntroduction[];
+}
+
+/**
+ * Record that Vitana has now explained a feature to this user.
+ * Idempotent — re-recording the same feature updates introduced_at.
+ */
+export async function recordFeatureIntroduction(
+  userId: string,
+  featureKey: string,
+  channel: 'voice' | 'text' | 'system' = 'voice',
+  context: Record<string, unknown> = {},
+): Promise<{ success: boolean; error?: string }> {
+  const supabase = getSupabase();
+  if (!supabase) return { success: false, error: 'storage_unavailable' };
+
+  const { error } = await supabase.from('user_feature_introductions').upsert(
+    {
+      user_id: userId,
+      feature_key: featureKey,
+      introduced_at: new Date().toISOString(),
+      channel,
+      context,
+    },
+    { onConflict: 'user_id,feature_key' },
+  );
+
+  if (error) {
+    console.warn(`${LOG_PREFIX} write failed for ${featureKey}:`, error.message);
+    return { success: false, error: error.message };
+  }
+
+  emitGuideTelemetry('guide.feature_introduction.recorded', {
+    user_id: userId,
+    feature_key: featureKey,
+    channel,
+  }).catch(() => {});
+
+  console.log(`${LOG_PREFIX} recorded ${featureKey} for user=${userId.substring(0, 8)}`);
+  return { success: true };
+}
+
+/**
+ * Gemini tool definition — the LLM calls this after explaining a feature.
+ * Brain registers this in buildBrainToolDefinitions and dispatches in
+ * executeBrainTool.
+ */
+export const RECORD_FEATURE_INTRODUCTION_TOOL = {
+  name: 'record_feature_introduction',
+  description:
+    'Record that you have just explained a platform feature to the user. ' +
+    'Call this immediately AFTER you finish explaining a feature so you do not ' +
+    'explain it again in future sessions. Only call when you have actually ' +
+    'covered what the feature does, not for passing mentions.',
+  parameters: {
+    type: 'object',
+    properties: {
+      feature_key: {
+        type: 'string',
+        enum: KNOWN_FEATURE_KEYS as unknown as string[],
+        description:
+          'The feature you just explained. Must be one of the canonical keys.',
+      },
+    },
+    required: ['feature_key'],
+  },
+};

--- a/services/gateway/src/services/guide/guide-telemetry.ts
+++ b/services/gateway/src/services/guide/guide-telemetry.ts
@@ -17,7 +17,9 @@ export type GuideEventType =
   | 'guide.opener.no_candidate'
   | 'guide.dismissal.pause_created'
   | 'guide.dismissal.pause_cleared'
-  | 'guide.flag.disabled';
+  | 'guide.flag.disabled'
+  // Phase G — VTID-01932
+  | 'guide.feature_introduction.recorded';
 
 export async function emitGuideTelemetry(
   type: GuideEventType,

--- a/services/gateway/src/services/guide/index.ts
+++ b/services/gateway/src/services/guide/index.ts
@@ -15,6 +15,14 @@ export {
 export { emitGuideTelemetry } from './guide-telemetry';
 export { getAwarenessContext, clearAwarenessCache } from './awareness-context';
 export {
+  getFeatureIntroductions,
+  recordFeatureIntroduction,
+  RECORD_FEATURE_INTRODUCTION_TOOL,
+  KNOWN_FEATURE_KEYS,
+  type FeatureIntroduction,
+  type FeatureKey,
+} from './feature-introductions';
+export {
   describeTimeSince,
   fetchLastSessionInfo,
   deriveMotivationSignal,

--- a/services/gateway/src/services/guide/types.ts
+++ b/services/gateway/src/services/guide/types.ts
@@ -66,6 +66,9 @@ export interface UserAwareness {
   recent_activity: RecentActivitySummary;
   last_interaction: LastInteraction | null;
 
+  // Phase G — feature-introduction tracking (VTID-01932)
+  feature_introductions: string[];
+
   // Reserved for future companion pillars (null until those phases ship)
   routines: null;
   tastes_preferences: null;

--- a/services/gateway/src/services/vitana-brain.ts
+++ b/services/gateway/src/services/vitana-brain.ts
@@ -39,12 +39,15 @@ import { getPersonalityConfigSync } from './ai-personality-service';
 import { emitOasisEvent } from './oasis-event-service';
 import { getSupabase } from '../lib/supabase';
 // Proactive Guide Phase 0.5 + Companion Awareness Phase A (VTID-01927)
+// + Phase B personality config (VTID-01931) + Phase G feature introductions (VTID-01932)
 import { getSystemControl } from './system-controls-service';
 import {
   pickOpenerCandidate,
   getAwarenessContext,
+  recordFeatureIntroduction,
   PAUSE_PROACTIVE_GUIDANCE_TOOL,
   CLEAR_PROACTIVE_PAUSES_TOOL,
+  RECORD_FEATURE_INTRODUCTION_TOOL,
   executePauseProactiveGuidance,
   executeClearProactivePauses,
   emitGuideTelemetry,
@@ -852,6 +855,17 @@ function buildAwarenessBlock(awareness: UserAwareness | null): string {
     lines.push(`Recent activity: ${raParts.join('; ')}`);
   }
 
+  // Phase G — feature introductions already given to this user
+  if (awareness.feature_introductions && awareness.feature_introductions.length > 0) {
+    lines.push(
+      `Features already introduced to this user (DO NOT re-explain): ${awareness.feature_introductions.join(', ')}. Reference them by name only. If the user asks about one explicitly, you may give a brief refresher.`,
+    );
+  } else if (awareness.feature_introductions) {
+    lines.push(
+      `Features already introduced: NONE. When you explain any platform feature (life_compass, vitana_index, autopilot, memory_garden, calendar, business_hub, marketplace, journey_90day, voice_chat_basics, dismissal_phrases, goal_changing, navigator, community), call the record_feature_introduction tool with the feature_key so we don't re-explain next session.`,
+    );
+  }
+
   lines.push('');
   lines.push('Use this awareness to personalize EVERY response — not just the opener.');
   lines.push('Reference these signals naturally when relevant ("your diary streak is at 5 days",');
@@ -893,6 +907,10 @@ export function buildBrainToolDefinitions(role: string): object[] {
     // Proactive Opener Rules are present (i.e., flag is on).
     PAUSE_PROACTIVE_GUIDANCE_TOOL,
     CLEAR_PROACTIVE_PAUSES_TOOL,
+    // Companion Phase G (VTID-01932) — feature-introduction tracking.
+    // The LLM calls this after explaining a feature so we know not to
+    // re-introduce it in future sessions.
+    RECORD_FEATURE_INTRODUCTION_TOOL,
   ];
 
   // Merge: registry tools + ORB tools (avoid duplicates)
@@ -997,6 +1015,20 @@ export async function executeBrainTool(
           success: true,
           result: `Cleared ${result.cleared_count} active pause${result.cleared_count === 1 ? '' : 's'}.`,
         };
+      }
+
+      // Companion Phase G — VTID-01932
+      case 'record_feature_introduction': {
+        const featureKey = String(args.feature_key || '').trim();
+        if (!featureKey) {
+          return { success: false, result: 'feature_key required', error: 'missing_feature_key' };
+        }
+        const channel: 'voice' | 'text' = 'voice';
+        const result = await recordFeatureIntroduction(context.user_id, featureKey, channel);
+        if (!result.success) {
+          return { success: false, result: `record failed: ${result.error}`, error: result.error };
+        }
+        return { success: true, result: `Recorded introduction of ${featureKey}.` };
       }
 
       default: {

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -596,6 +596,8 @@ export type CicdEventType =
   | 'guide.dismissal.pause_created'
   | 'guide.dismissal.pause_cleared'
   | 'guide.flag.disabled'
+  // COMPANION Phase G — feature-introduction tracking (VTID-01932)
+  | 'guide.feature_introduction.recorded'
   // VTID-01900: Longevity News Feed Events
   | 'news.feed.error'
   | 'news.feed.cycle_complete'

--- a/supabase/migrations/20260419100000_user_feature_introductions.sql
+++ b/supabase/migrations/20260419100000_user_feature_introductions.sql
@@ -1,0 +1,42 @@
+-- =============================================================================
+-- VTID-01932 (Companion Phase G): Feature-introduction tracking
+-- Date: 2026-04-19
+--
+-- Records which platform features Vitana has already introduced to each user.
+-- Brain reads this to avoid re-explaining features the user already knows about.
+-- LLM tool record_feature_introduction writes a row when Vitana explains a feature.
+--
+-- Examples of feature_key values:
+--   life_compass, vitana_index, autopilot, memory_garden, calendar,
+--   business_hub, marketplace, journey_90day, dismissal_phrases, voice_chat
+-- =============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS user_feature_introductions (
+  user_id        uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  feature_key    text NOT NULL,
+  introduced_at  timestamptz NOT NULL DEFAULT now(),
+  channel        text NOT NULL DEFAULT 'voice'
+    CHECK (channel IN ('voice', 'text', 'system')),
+  context        jsonb DEFAULT '{}'::jsonb,
+  PRIMARY KEY (user_id, feature_key)
+);
+
+ALTER TABLE user_feature_introductions ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "user_feature_introductions_self_rw"
+  ON user_feature_introductions FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE INDEX IF NOT EXISTS idx_user_feature_introductions_user
+  ON user_feature_introductions (user_id, introduced_at DESC);
+
+COMMENT ON TABLE user_feature_introductions IS
+  'VTID-01932 Companion Phase G — records which platform features Vitana has explained to each user. Brain reads to avoid re-introducing.';
+
+COMMENT ON COLUMN user_feature_introductions.feature_key IS
+  'Stable identifier for the feature: life_compass, vitana_index, autopilot, memory_garden, calendar, business_hub, marketplace, journey_90day, etc.';
+
+COMMIT;


### PR DESCRIPTION
Companion Phase G: stops Vitana from re-explaining 'Life Compass', 'Vitana Index', etc. to users who already heard the explanation. Ships new user_feature_introductions table (migration already applied), new feature-introductions service with Gemini tool, awareness now carries feature_introductions[], brain prompt instructs LLM to call record_feature_introduction after explaining anything.