### PR TITLE
feat(proactive-guide): Phase F — conversation continuity / session summaries (VTID-01933)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -5543,6 +5543,40 @@ async function emitOrbSessionEnded(orbSessionId: string, conversationId: string)
   }).catch(err => console.warn('[VTID-0135] Failed to emit orb.session.ended:', err.message));
 }
 
+/**
+ * VTID-01933 (Companion Phase F): Persist a short summary of the just-ended
+ * ORB session so the brain can weave it into the next session naturally.
+ * Best-effort — never blocks session teardown. Called from POST /end-session.
+ */
+async function recordSessionSummaryFromTranscript(
+  transcript: OrbSessionTranscript,
+): Promise<void> {
+  if (!transcript.user_id) return;
+  if (!transcript.turns || transcript.turns.length === 0) return;
+  try {
+    const { recordSessionSummary } = await import('../services/guide/session-summaries');
+    const turns = transcript.turns
+      .map((t) => ({
+        role: (t.role === 'user' ? 'user' : 'assistant') as 'user' | 'assistant',
+        text: String(t.text || '').trim(),
+      }))
+      .filter((t) => t.text.length > 0);
+    if (turns.length === 0) return;
+    const durationMs = transcript.started_at
+      ? Date.now() - new Date(transcript.started_at).getTime()
+      : null;
+    await recordSessionSummary({
+      user_id: transcript.user_id,
+      session_id: transcript.orb_session_id,
+      channel: 'voice',
+      transcript_turns: turns,
+      duration_ms: durationMs,
+    });
+  } catch (err: any) {
+    console.warn('[VTID-01933] recordSessionSummary failed:', err?.message);
+  }
+}
+
 // =============================================================================
 // Helpers
 // =============================================================================
@@ -7440,6 +7474,10 @@ router.post('/end-session', async (req: Request, res: Response) => {
     }).catch(err => console.warn('[VTID-01039] Failed to emit orb.session.summary:', err.message));
 
     console.log(`[VTID-01039] Session finalized: ${orb_session_id} (${transcript.summary.turns_count} turns, ${durationSec}s)`);
+
+    // VTID-01933 (Companion Phase F): persist summary for the brain to read
+    // on the user's next session. Fire-and-forget; never blocks teardown.
+    recordSessionSummaryFromTranscript(transcript).catch(() => {});
 
     // Send follow-up reminder notification if conversation had substance
     if (transcript.turns.length >= 4) {

--- a/services/gateway/src/services/guide/awareness-context.ts
+++ b/services/gateway/src/services/guide/awareness-context.ts
@@ -24,6 +24,7 @@ import {
 import { DEFAULT_WAVE_CONFIG } from '../wave-defaults';
 import { describeTimeSince, fetchLastSessionInfo, type LastInteraction } from './temporal-bucket';
 import { getFeatureIntroductions } from './feature-introductions';
+import { getRecentSessionSummaries } from './session-summaries';
 import type {
   UserAwareness,
   TenureStage,
@@ -73,12 +74,14 @@ export async function getAwarenessContext(
     goal,
     recentActivity,
     featureIntros,
+    priorSummaries,
   ] = await Promise.all([
     safeGatherUserContext(userId, tenantId, supabase),
     fetchLastSessionInfo(userId).catch(() => null),
     fetchActiveGoal(userId, supabase),
     fetchRecentActivitySummary(userId, supabase),
     getFeatureIntroductions(userId).catch(() => []),
+    getRecentSessionSummaries(userId, 3).catch(() => []),
   ]);
 
   const tenure = buildTenure(userContext);
@@ -96,10 +99,15 @@ export async function getAwarenessContext(
     recent_activity: recentActivity,
     last_interaction,
     feature_introductions: (featureIntros || []).map((f) => f.feature_key),
+    prior_session_themes: (priorSummaries || []).map((s) => ({
+      session_id: s.session_id,
+      summary: s.summary,
+      themes: s.themes,
+      ended_at: s.ended_at,
+    })),
     routines: null,
     tastes_preferences: null,
     adaptation_plans: null,
-    prior_session_themes: null,
   };
 
   cache.set(cacheKey, { awareness, expires_at: Date.now() + CACHE_TTL_MS });
@@ -301,9 +309,9 @@ function skeletalAwareness(): UserAwareness {
     recent_activity: emptyRecentActivity(),
     last_interaction: describeTimeSince(null),
     feature_introductions: [],
+    prior_session_themes: [],
     routines: null,
     tastes_preferences: null,
     adaptation_plans: null,
-    prior_session_themes: null,
   };
 }

--- a/services/gateway/src/services/guide/guide-telemetry.ts
+++ b/services/gateway/src/services/guide/guide-telemetry.ts
@@ -19,7 +19,9 @@ export type GuideEventType =
   | 'guide.dismissal.pause_cleared'
   | 'guide.flag.disabled'
   // Phase G — VTID-01932
-  | 'guide.feature_introduction.recorded';
+  | 'guide.feature_introduction.recorded'
+  // Phase F — VTID-01933 conversation continuity
+  | 'guide.session_summary.recorded';
 
 export async function emitGuideTelemetry(
   type: GuideEventType,

--- a/services/gateway/src/services/guide/index.ts
+++ b/services/gateway/src/services/guide/index.ts
@@ -23,6 +23,13 @@ export {
   type FeatureKey,
 } from './feature-introductions';
 export {
+  getRecentSessionSummaries,
+  recordSessionSummary,
+  formatSummariesForPrompt,
+  type SessionSummary,
+  type RecordSessionSummaryInput,
+} from './session-summaries';
+export {
   describeTimeSince,
   fetchLastSessionInfo,
   deriveMotivationSignal,

--- a/services/gateway/src/services/guide/session-summaries.ts
+++ b/services/gateway/src/services/guide/session-summaries.ts
@@ -1,0 +1,196 @@
+/**
+ * Companion Phase F — Conversation Continuity / Session Summaries (VTID-01933)
+ *
+ * Stores a short summary of each completed ORB session. Brain reads the last
+ * 1-3 summaries on the user's next session so Vitana can naturally weave in
+ * continuity ("last time we talked about your sleep — how did the wind-down
+ * ritual go?").
+ *
+ * MVP summary generation: takes the last N transcript turns and extracts
+ * the user's primary themes via simple heuristics. Future iteration: a
+ * dedicated LLM call for richer summaries.
+ */
+
+import { getSupabase } from '../../lib/supabase';
+import { emitGuideTelemetry } from './guide-telemetry';
+
+const LOG_PREFIX = '[Guide:session-summaries]';
+const MAX_SUMMARY_CHARS = 600;
+const RECENT_SUMMARIES_LIMIT = 3;
+
+export interface SessionSummary {
+  session_id: string;
+  channel: 'voice' | 'text';
+  summary: string;
+  themes: string[];
+  turn_count: number;
+  duration_ms: number | null;
+  ended_at: string;
+}
+
+export interface RecordSessionSummaryInput {
+  user_id: string;
+  session_id: string;
+  channel: 'voice' | 'text';
+  transcript_turns: Array<{ role: 'user' | 'assistant'; text: string }>;
+  duration_ms?: number | null;
+}
+
+/**
+ * Read the user's recent session summaries (most recent first).
+ * Returns empty array on any error — never throws.
+ */
+export async function getRecentSessionSummaries(
+  userId: string,
+  limit: number = RECENT_SUMMARIES_LIMIT,
+): Promise<SessionSummary[]> {
+  const supabase = getSupabase();
+  if (!supabase) return [];
+
+  const { data, error } = await supabase
+    .from('user_session_summaries')
+    .select('session_id, channel, summary, themes, turn_count, duration_ms, ended_at')
+    .eq('user_id', userId)
+    .order('ended_at', { ascending: false })
+    .limit(Math.max(1, Math.min(limit, 10)));
+
+  if (error) {
+    console.warn(`${LOG_PREFIX} read failed:`, error.message);
+    return [];
+  }
+  return (data || []) as SessionSummary[];
+}
+
+/**
+ * Build + persist a summary of a completed session.
+ * Idempotent — re-saving the same (user_id, session_id) updates the row.
+ *
+ * Best-effort: failures are swallowed so they never block session-end.
+ */
+export async function recordSessionSummary(
+  input: RecordSessionSummaryInput,
+): Promise<{ success: boolean; summary?: string; error?: string }> {
+  const supabase = getSupabase();
+  if (!supabase) return { success: false, error: 'storage_unavailable' };
+
+  // Skip empty sessions — nothing to summarize
+  if (!input.transcript_turns || input.transcript_turns.length === 0) {
+    return { success: false, error: 'empty_transcript' };
+  }
+
+  const summary = buildSummary(input.transcript_turns);
+  const themes = extractThemes(input.transcript_turns);
+
+  const { error } = await supabase.from('user_session_summaries').upsert(
+    {
+      user_id: input.user_id,
+      session_id: input.session_id,
+      channel: input.channel,
+      summary,
+      themes,
+      turn_count: input.transcript_turns.length,
+      duration_ms: input.duration_ms ?? null,
+      ended_at: new Date().toISOString(),
+    },
+    { onConflict: 'user_id,session_id' },
+  );
+
+  if (error) {
+    console.warn(`${LOG_PREFIX} write failed:`, error.message);
+    return { success: false, error: error.message };
+  }
+
+  emitGuideTelemetry('guide.session_summary.recorded', {
+    user_id: input.user_id,
+    session_id: input.session_id,
+    channel: input.channel,
+    turn_count: input.transcript_turns.length,
+    themes,
+    summary_length: summary.length,
+  }).catch(() => {});
+
+  console.log(
+    `${LOG_PREFIX} stored summary for user=${input.user_id.substring(0, 8)} session=${input.session_id.substring(0, 12)} themes=[${themes.join(',')}]`,
+  );
+
+  return { success: true, summary };
+}
+
+// =============================================================================
+// Summary builders (MVP — simple heuristics; future: LLM call)
+// =============================================================================
+
+/**
+ * Build a short prose summary from the transcript.
+ * MVP heuristic: take the user's first substantive utterance + the assistant's
+ * last substantive reply. Caps at 600 chars.
+ */
+function buildSummary(turns: Array<{ role: 'user' | 'assistant'; text: string }>): string {
+  const userTurns = turns.filter((t) => t.role === 'user' && t.text.trim().length > 6);
+  const assistantTurns = turns.filter((t) => t.role === 'assistant' && t.text.trim().length > 10);
+
+  const firstUser = userTurns[0]?.text.trim() ?? '';
+  const lastAssistant = assistantTurns[assistantTurns.length - 1]?.text.trim() ?? '';
+  const lastUser = userTurns[userTurns.length - 1]?.text.trim() ?? '';
+
+  const parts: string[] = [];
+  if (firstUser) parts.push(`User opened with: ${truncate(firstUser, 200)}`);
+  if (lastUser && lastUser !== firstUser) parts.push(`Last user message: ${truncate(lastUser, 150)}`);
+  if (lastAssistant) parts.push(`I closed with: ${truncate(lastAssistant, 200)}`);
+
+  const joined = parts.join('. ');
+  return truncate(joined, MAX_SUMMARY_CHARS) || 'Brief session — nothing notable to summarize.';
+}
+
+/**
+ * Extract simple topical theme tags from the transcript.
+ * MVP: keyword heuristics over the full transcript. Future: real NLP.
+ */
+function extractThemes(turns: Array<{ role: 'user' | 'assistant'; text: string }>): string[] {
+  const allText = turns.map((t) => t.text).join(' ').toLowerCase();
+  const themes = new Set<string>();
+  for (const [theme, patterns] of Object.entries(THEME_PATTERNS)) {
+    for (const pat of patterns) {
+      if (allText.includes(pat)) {
+        themes.add(theme);
+        break;
+      }
+    }
+  }
+  return Array.from(themes).slice(0, 8);
+}
+
+const THEME_PATTERNS: Record<string, string[]> = {
+  sleep: ['sleep', 'rest', 'tired', 'insomnia', 'wind down', 'bedtime', 'schlaf'],
+  stress: ['stress', 'anxious', 'anxiety', 'overwhelm', 'pressure', 'stresse'],
+  nutrition: ['food', 'eat', 'meal', 'diet', 'nutrition', 'hungry', 'essen'],
+  exercise: ['workout', 'exercise', 'gym', 'walk', 'run', 'training', 'sport'],
+  health: ['health', 'doctor', 'medication', 'symptom', 'pain', 'gesundheit'],
+  relationships: ['friend', 'family', 'partner', 'meet', 'social', 'beziehung'],
+  business: ['business', 'work', 'income', 'money', 'career', 'project', 'arbeit', 'geld'],
+  goals: ['goal', 'objective', 'plan', 'achieve', 'milestone', 'ziel'],
+  community: ['community', 'group', 'meetup', 'event', 'gemeinschaft'],
+  calendar: ['calendar', 'schedule', 'appointment', 'meeting', 'kalender', 'termin'],
+  diary: ['diary', 'journal', 'reflection', 'tagebuch'],
+  mood: ['feel', 'feeling', 'mood', 'emotion', 'happy', 'sad', 'gefühl'],
+};
+
+function truncate(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1).trimEnd() + '…';
+}
+
+/**
+ * Format a list of summaries for inclusion in the system prompt.
+ * Returns empty string when no summaries.
+ */
+export function formatSummariesForPrompt(summaries: SessionSummary[]): string {
+  if (!summaries || summaries.length === 0) return '';
+  const lines: string[] = ['Recent prior sessions (most recent first — weave naturally, do NOT recite):'];
+  for (const s of summaries) {
+    const when = new Date(s.ended_at).toISOString().slice(0, 10);
+    const themes = s.themes && s.themes.length > 0 ? ` [themes: ${s.themes.join(', ')}]` : '';
+    lines.push(`  - ${when}${themes}: ${s.summary}`);
+  }
+  return lines.join('\n');
+}

--- a/services/gateway/src/services/guide/types.ts
+++ b/services/gateway/src/services/guide/types.ts
@@ -69,11 +69,18 @@ export interface UserAwareness {
   // Phase G — feature-introduction tracking (VTID-01932)
   feature_introductions: string[];
 
+  // Phase F — conversation continuity / prior session summaries (VTID-01933)
+  prior_session_themes: Array<{
+    session_id: string;
+    summary: string;
+    themes: string[];
+    ended_at: string;
+  }>;
+
   // Reserved for future companion pillars (null until those phases ship)
   routines: null;
   tastes_preferences: null;
   adaptation_plans: null;
-  prior_session_themes: null;
 }
 
 // =============================================================================

--- a/services/gateway/src/services/vitana-brain.ts
+++ b/services/gateway/src/services/vitana-brain.ts
@@ -855,6 +855,31 @@ function buildAwarenessBlock(awareness: UserAwareness | null): string {
     lines.push(`Recent activity: ${raParts.join('; ')}`);
   }
 
+  // Phase F — prior session continuity. Brain weaves naturally rather than reciting.
+  if (awareness.prior_session_themes && awareness.prior_session_themes.length > 0) {
+    const recentSummary = awareness.prior_session_themes[0];
+    const recentDate = recentSummary.ended_at.slice(0, 10);
+    const themeList =
+      recentSummary.themes && recentSummary.themes.length > 0
+        ? ` (themes: ${recentSummary.themes.slice(0, 4).join(', ')})`
+        : '';
+    lines.push(
+      `Last session (${recentDate})${themeList}: ${recentSummary.summary}`,
+    );
+    if (awareness.prior_session_themes.length > 1) {
+      const olderThemes = new Set<string>();
+      for (const s of awareness.prior_session_themes.slice(1)) {
+        for (const t of s.themes) olderThemes.add(t);
+      }
+      if (olderThemes.size > 0) {
+        lines.push(`Earlier sessions touched: ${Array.from(olderThemes).slice(0, 6).join(', ')}.`);
+      }
+    }
+    lines.push(
+      'Weave one of these into the conversation when natural — never recite the summary verbatim. Examples: "last time we talked about your sleep — how did that wind-down ritual go?", "you mentioned the business hub yesterday — any progress?".',
+    );
+  }
+
   // Phase G — feature introductions already given to this user
   if (awareness.feature_introductions && awareness.feature_introductions.length > 0) {
     lines.push(

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -598,6 +598,8 @@ export type CicdEventType =
   | 'guide.flag.disabled'
   // COMPANION Phase G — feature-introduction tracking (VTID-01932)
   | 'guide.feature_introduction.recorded'
+  // COMPANION Phase F — conversation continuity (VTID-01933)
+  | 'guide.session_summary.recorded'
   // VTID-01900: Longevity News Feed Events
   | 'news.feed.error'
   | 'news.feed.cycle_complete'

--- a/supabase/migrations/20260419110000_user_session_summaries.sql
+++ b/supabase/migrations/20260419110000_user_session_summaries.sql
@@ -1,0 +1,44 @@
+-- =============================================================================
+-- VTID-01933 (Companion Phase F): Conversation continuity / session summaries
+-- Date: 2026-04-19
+--
+-- Stores a short summary of each completed ORB session per user. Brain reads
+-- the last 1-3 summaries on the next session so Vitana can naturally
+-- reference prior conversations ("last time we talked about your sleep —
+-- how did the wind-down ritual go?").
+--
+-- Phase F MVP: summary is built from the last few transcript turns + topic
+-- extraction. Future iteration may use a dedicated LLM call to summarize.
+-- =============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS user_session_summaries (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  session_id      text NOT NULL,
+  channel         text NOT NULL DEFAULT 'voice'
+    CHECK (channel IN ('voice', 'text')),
+  summary         text NOT NULL,                     -- short prose, 1-3 sentences
+  themes          text[] DEFAULT '{}',               -- topical tags ('sleep', 'business', etc.)
+  turn_count      int NOT NULL DEFAULT 0,
+  duration_ms     int,
+  ended_at        timestamptz NOT NULL DEFAULT now(),
+  created_at      timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id, session_id)
+);
+
+ALTER TABLE user_session_summaries ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "user_session_summaries_self_rw"
+  ON user_session_summaries FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE INDEX IF NOT EXISTS idx_user_session_summaries_user_recent
+  ON user_session_summaries (user_id, ended_at DESC);
+
+COMMENT ON TABLE user_session_summaries IS
+  'VTID-01933 Companion Phase F — short summary of each ORB session per user. Brain reads last 1-3 to weave continuity into next session.';
+
+COMMIT;


### PR DESCRIPTION
Companion Phase F: Vitana weaves last session's themes into next conversation. Ships user_session_summaries table (migration applied), session-summaries service, orb-live /end-session hook that records summaries, awareness carries prior_session_themes, brain prompt instructs natural weaving.