### PR TITLE
fix(orb): handle reconnecting/reconnected events in command-hub widget

### DIFF
--- a/services/gateway/src/frontend/command-hub/orb-widget.js
+++ b/services/gateway/src/frontend/command-hub/orb-widget.js
@@ -898,6 +898,41 @@
         _setStatus('Error: ' + (msg.message || 'Unknown'));
         break;
 
+      case 'reconnecting':
+        // Backend is transparently reconnecting upstream (Vertex Live API).
+        // Flip UI off "Listening..." so the user stops talking into the void.
+        console.warn('[VTOrb] Upstream reconnecting — pausing UI');
+        clearTimeout(_s._listeningIdleTimer);
+        if (_s.voiceState === 'MUTED') {
+          // Keep the muted visual, but ensure unmute doesn't snap back to LISTENING.
+          _s.preMuteState = 'THINKING';
+        } else {
+          _s._preReconnectVoiceState = _s.voiceState;
+          _setOrbState('thinking');
+          _s.voiceState = 'THINKING';
+          _setStatus(
+            _cfg.lang.startsWith('de')
+              ? 'Verbindung wird wiederhergestellt, einen Moment...'
+              : 'Reconnecting, one moment...'
+          );
+          _updateUI();
+        }
+        break;
+
+      case 'reconnected':
+        // Reconnect succeeded. Don't snap straight to LISTENING here — a
+        // fresh turn_complete (or audio) will drive the next transition and
+        // the user gets the familiar ready-beep cue.
+        console.log('[VTOrb] Upstream reconnected');
+        if (_s.voiceState === 'THINKING' && _s._preReconnectVoiceState === 'LISTENING') {
+          _setOrbState('listening');
+          _s.voiceState = 'LISTENING';
+          _setStatus(_cfg.lang.startsWith('de') ? 'Ich höre zu...' : 'Listening...');
+          _updateUI();
+        }
+        _s._preReconnectVoiceState = null;
+        break;
+
       case 'connection_issue':
       case 'live_api_disconnected':
         // VTID-RECONNECT: Try auto-reconnect before giving up


### PR DESCRIPTION
## Summary

The gateway already emits `reconnecting` / `reconnected` SSE messages when the upstream Vertex Live API WS is torn down (session expiry or watchdog stall recovery), but the orb widget's SSE switch ignored them. The widget kept showing "Ich höre zu… / Listening…" while the upstream was disconnected, so users kept talking into the void.

- Add `reconnecting` case: flip the orb to THINKING, clear the listening-idle nudge, remember the pre-reconnect voiceState, and show "Reconnecting, one moment…" — respects MUTED by only steering `preMuteState`.
- Add `reconnected` case: if we were listening before, restore LISTENING; otherwise let the next `turn_complete`/`audio` drive the transition naturally (keeps the ready-beep cue).

**This only fixes the UX during reconnects — it does NOT address whatever is causing the upstream to disconnect so frequently. That's a separate investigation (check `watchdog_fired` reasons in recent gateway logs).**

Paired frontend change in `exafyltd/vitana-v1#154`.

## Test plan
- [ ] Simulate a watchdog-triggered reconnect: widget flips from "Listening…" to "Reconnecting, one moment…" and back to "Listening…" after `reconnected`.
- [ ] MUTED state stays muted during reconnect; `preMuteState` is updated so unmute restores to the correct state.
- [ ] `connection_issue` / `live_api_disconnected` still triggers the existing retry-and-give-up path (unchanged).

https://claude.ai/code/session_01KohzCHKC3RFdC2JuSjr9xV