### PR TITLE
feat(proactive-guide): Phase E — D43 adaptation applier skeleton (VTID-01935)

### DIFF
--- a/services/gateway/src/services/guide/adaptation-applier.ts
+++ b/services/gateway/src/services/guide/adaptation-applier.ts
@@ -1,0 +1,179 @@
+/**
+ * Companion Phase E — D43 Adaptation Plan Applier (VTID-01935)
+ *
+ * Reads APPROVED rows from `adaptation_plans` (written by the existing
+ * D43 longitudinal-adaptation-engine when it detects user-state drift)
+ * and translates them into per-user `user_journey_overrides` rows that
+ * journey-calendar-mapper consumes on next recompute.
+ *
+ * STATUS — DATA DEPENDENCY:
+ * The existing d43-longitudinal-adaptation-engine.ts detects drift and is
+ * intended to write `adaptation_plans` for human approval, but no
+ * `adaptation_plans` table currently exists in supabase/migrations and
+ * grep finds no INSERT into such a table from D43. This applier is the
+ * receiving half of a loop whose sender hasn't been wired up yet.
+ *
+ * What this module ships:
+ *   - applyApprovedPlans(userId): reads adaptation_plans (gracefully returns
+ *     {applied: 0, reason: 'no_plans_table'} if missing) and writes
+ *     user_journey_overrides rows
+ *   - getAdaptationStatus(userId): for awareness — returns { pending, applied }
+ *
+ * When D43 starts persisting plans (separate VTID), this module is already
+ * wired and just needs the table to exist. Until then, awareness.adaptation_plans
+ * stays null and the brain has nothing to reference.
+ */
+
+import { getSupabase } from '../../lib/supabase';
+import { emitGuideTelemetry } from './guide-telemetry';
+
+const LOG_PREFIX = '[Guide:adaptation-applier]';
+
+export interface AdaptationStatus {
+  pending_plans: number;
+  applied_plans: number;
+  last_applied_at: string | null;
+}
+
+export interface ApplyResult {
+  applied: number;
+  reason?: 'success' | 'no_plans_table' | 'no_pending_plans' | 'storage_unavailable' | string;
+  details?: string[];
+}
+
+/**
+ * Read approved (or auto-applicable) D43 adaptation plans and translate each
+ * into a user_journey_overrides row. Idempotent — re-running on the same
+ * approved plan does not double-apply.
+ *
+ * Returns a structured result so a caller can decide whether to surface the
+ * applied changes to the user ("I noticed you haven't been doing X — I've
+ * shifted your journey to favor Y instead").
+ */
+export async function applyApprovedPlans(userId: string): Promise<ApplyResult> {
+  const supabase = getSupabase();
+  if (!supabase) return { applied: 0, reason: 'storage_unavailable' };
+
+  // Try to read approved plans. If the table doesn't exist, supabase returns
+  // an error like "relation 'adaptation_plans' does not exist" — handle gracefully.
+  const { data: plans, error } = await supabase
+    .from('adaptation_plans')
+    .select('id, user_id, plan_type, plan_payload, approved_at, applied_at')
+    .eq('user_id', userId)
+    .not('approved_at', 'is', null)
+    .is('applied_at', null)
+    .limit(20);
+
+  if (error) {
+    if (
+      String(error.message || '').toLowerCase().includes('relation') &&
+      String(error.message || '').toLowerCase().includes('does not exist')
+    ) {
+      return { applied: 0, reason: 'no_plans_table' };
+    }
+    console.warn(`${LOG_PREFIX} read adaptation_plans failed:`, error.message);
+    return { applied: 0, reason: error.message };
+  }
+
+  if (!plans || plans.length === 0) {
+    return { applied: 0, reason: 'no_pending_plans' };
+  }
+
+  let appliedCount = 0;
+  const detailLines: string[] = [];
+  for (const plan of plans as Array<{
+    id: string;
+    user_id: string;
+    plan_type: string;
+    plan_payload: any;
+    approved_at: string;
+    applied_at: string | null;
+  }>) {
+    try {
+      // Translate plan_payload into journey_overrides shape. Plan shape isn't
+      // fully nailed down (D43 doesn't write yet), so we accept any jsonb and
+      // pass it through under an 'adaptation' key. journey-calendar-mapper
+      // will need to interpret it (out of scope here).
+      const waveId = plan.plan_payload?.wave_id || `adaptation_${plan.plan_type}`;
+
+      const { error: upsertErr } = await supabase.from('user_journey_overrides').upsert(
+        {
+          user_id: plan.user_id,
+          wave_id: waveId,
+          overrides: { adaptation: plan.plan_payload, plan_id: plan.id },
+          source: 'd43_adaptation',
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'user_id,wave_id' },
+      );
+
+      if (upsertErr) {
+        console.warn(`${LOG_PREFIX} override upsert failed for plan ${plan.id}:`, upsertErr.message);
+        continue;
+      }
+
+      // Mark plan as applied
+      await supabase
+        .from('adaptation_plans')
+        .update({ applied_at: new Date().toISOString() })
+        .eq('id', plan.id);
+
+      appliedCount += 1;
+      detailLines.push(`applied plan_type=${plan.plan_type} → wave_id=${waveId}`);
+    } catch (err: any) {
+      console.warn(`${LOG_PREFIX} apply error:`, err?.message);
+    }
+  }
+
+  if (appliedCount > 0) {
+    emitGuideTelemetry('guide.adaptation.applied', {
+      user_id: userId,
+      applied_count: appliedCount,
+      details: detailLines.slice(0, 5),
+    }).catch(() => {});
+    console.log(`${LOG_PREFIX} applied ${appliedCount} plans for user ${userId.substring(0, 8)}`);
+  }
+
+  return { applied: appliedCount, reason: 'success', details: detailLines };
+}
+
+/**
+ * Best-effort awareness signal — counts pending vs applied D43 plans.
+ * Returns null counts when the table doesn't exist (no D43 plan-writer wired yet).
+ */
+export async function getAdaptationStatus(userId: string): Promise<AdaptationStatus | null> {
+  const supabase = getSupabase();
+  if (!supabase) return null;
+
+  // Pending (approved but not applied)
+  const pendingRes = await supabase
+    .from('adaptation_plans')
+    .select('id', { count: 'exact', head: true })
+    .eq('user_id', userId)
+    .not('approved_at', 'is', null)
+    .is('applied_at', null);
+
+  if (pendingRes.error) {
+    if (
+      String(pendingRes.error.message || '').toLowerCase().includes('relation') &&
+      String(pendingRes.error.message || '').toLowerCase().includes('does not exist')
+    ) {
+      return null;
+    }
+  }
+
+  // Applied (most recent)
+  const appliedRes = await supabase
+    .from('adaptation_plans')
+    .select('id, applied_at', { count: 'exact' })
+    .eq('user_id', userId)
+    .not('applied_at', 'is', null)
+    .order('applied_at', { ascending: false })
+    .limit(1);
+
+  return {
+    pending_plans: pendingRes.count ?? 0,
+    applied_plans: appliedRes.count ?? 0,
+    last_applied_at: appliedRes.data?.[0]?.applied_at ?? null,
+  };
+}

--- a/services/gateway/src/services/guide/awareness-context.ts
+++ b/services/gateway/src/services/guide/awareness-context.ts
@@ -25,6 +25,7 @@ import { DEFAULT_WAVE_CONFIG } from '../wave-defaults';
 import { describeTimeSince, fetchLastSessionInfo, type LastInteraction } from './temporal-bucket';
 import { getFeatureIntroductions } from './feature-introductions';
 import { getRecentSessionSummaries } from './session-summaries';
+import { getAdaptationStatus } from './adaptation-applier';
 import type {
   UserAwareness,
   TenureStage,
@@ -75,6 +76,7 @@ export async function getAwarenessContext(
     recentActivity,
     featureIntros,
     priorSummaries,
+    adaptationStatus,
   ] = await Promise.all([
     safeGatherUserContext(userId, tenantId, supabase),
     fetchLastSessionInfo(userId).catch(() => null),
@@ -82,6 +84,7 @@ export async function getAwarenessContext(
     fetchRecentActivitySummary(userId, supabase),
     getFeatureIntroductions(userId).catch(() => []),
     getRecentSessionSummaries(userId, 3).catch(() => []),
+    getAdaptationStatus(userId).catch(() => null),
   ]);
 
   const tenure = buildTenure(userContext);
@@ -105,9 +108,9 @@ export async function getAwarenessContext(
       themes: s.themes,
       ended_at: s.ended_at,
     })),
+    adaptation_plans: adaptationStatus,
     routines: null,
     tastes_preferences: null,
-    adaptation_plans: null,
   };
 
   cache.set(cacheKey, { awareness, expires_at: Date.now() + CACHE_TTL_MS });
@@ -310,8 +313,8 @@ function skeletalAwareness(): UserAwareness {
     last_interaction: describeTimeSince(null),
     feature_introductions: [],
     prior_session_themes: [],
+    adaptation_plans: null,
     routines: null,
     tastes_preferences: null,
-    adaptation_plans: null,
   };
 }

--- a/services/gateway/src/services/guide/guide-telemetry.ts
+++ b/services/gateway/src/services/guide/guide-telemetry.ts
@@ -21,7 +21,9 @@ export type GuideEventType =
   // Phase G — VTID-01932
   | 'guide.feature_introduction.recorded'
   // Phase F — VTID-01933 conversation continuity
-  | 'guide.session_summary.recorded';
+  | 'guide.session_summary.recorded'
+  // Phase E — VTID-01935 D43 adaptation applier
+  | 'guide.adaptation.applied';
 
 export async function emitGuideTelemetry(
   type: GuideEventType,

--- a/services/gateway/src/services/guide/index.ts
+++ b/services/gateway/src/services/guide/index.ts
@@ -30,6 +30,12 @@ export {
   type RecordSessionSummaryInput,
 } from './session-summaries';
 export {
+  applyApprovedPlans,
+  getAdaptationStatus,
+  type AdaptationStatus,
+  type ApplyResult as AdaptationApplyResult,
+} from './adaptation-applier';
+export {
   describeTimeSince,
   fetchLastSessionInfo,
   deriveMotivationSignal,

--- a/services/gateway/src/services/guide/types.ts
+++ b/services/gateway/src/services/guide/types.ts
@@ -77,10 +77,18 @@ export interface UserAwareness {
     ended_at: string;
   }>;
 
+  // Phase E — D43 adaptation status (VTID-01935)
+  // Null when adaptation_plans table doesn't exist yet (D43 doesn't write
+  // there yet). When populated, shows pending vs applied plans.
+  adaptation_plans: {
+    pending_plans: number;
+    applied_plans: number;
+    last_applied_at: string | null;
+  } | null;
+
   // Reserved for future companion pillars (null until those phases ship)
   routines: null;
   tastes_preferences: null;
-  adaptation_plans: null;
 }
 
 // =============================================================================

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -600,6 +600,8 @@ export type CicdEventType =
   | 'guide.feature_introduction.recorded'
   // COMPANION Phase F — conversation continuity (VTID-01933)
   | 'guide.session_summary.recorded'
+  // COMPANION Phase E — D43 adaptation applier (VTID-01935)
+  | 'guide.adaptation.applied'
   // VTID-01900: Longevity News Feed Events
   | 'news.feed.error'
   | 'news.feed.cycle_complete'


### PR DESCRIPTION
Phase E receiver for D43 adaptation loop. Reads approved adaptation_plans (when D43 starts persisting them) and translates each into user_journey_overrides. Handles missing-table case gracefully — adaptation_plans schema is D43's responsibility (separate VTID). Awareness now carries adaptation_plans status.