### PR TITLE
feat(proactive-guide): Phase C — pattern extractor for user routines (VTID-01936)

### DIFF
--- a/services/gateway/src/services/guide/awareness-context.ts
+++ b/services/gateway/src/services/guide/awareness-context.ts
@@ -26,6 +26,7 @@ import { describeTimeSince, fetchLastSessionInfo, type LastInteraction } from '.
 import { getFeatureIntroductions } from './feature-introductions';
 import { getRecentSessionSummaries } from './session-summaries';
 import { getAdaptationStatus } from './adaptation-applier';
+import { getUserRoutines } from './pattern-extractor';
 import type {
   UserAwareness,
   TenureStage,
@@ -77,6 +78,7 @@ export async function getAwarenessContext(
     featureIntros,
     priorSummaries,
     adaptationStatus,
+    userRoutines,
   ] = await Promise.all([
     safeGatherUserContext(userId, tenantId, supabase),
     fetchLastSessionInfo(userId).catch(() => null),
@@ -85,6 +87,7 @@ export async function getAwarenessContext(
     getFeatureIntroductions(userId).catch(() => []),
     getRecentSessionSummaries(userId, 3).catch(() => []),
     getAdaptationStatus(userId).catch(() => null),
+    getUserRoutines(userId, 8).catch(() => []),
   ]);
 
   const tenure = buildTenure(userContext);
@@ -109,7 +112,12 @@ export async function getAwarenessContext(
       ended_at: s.ended_at,
     })),
     adaptation_plans: adaptationStatus,
-    routines: null,
+    routines: (userRoutines || []).map((r) => ({
+      routine_kind: r.routine_kind,
+      title: r.title,
+      summary: r.summary,
+      confidence: r.confidence,
+    })),
     tastes_preferences: null,
   };
 
@@ -314,7 +322,7 @@ function skeletalAwareness(): UserAwareness {
     feature_introductions: [],
     prior_session_themes: [],
     adaptation_plans: null,
-    routines: null,
+    routines: [],
     tastes_preferences: null,
   };
 }

--- a/services/gateway/src/services/guide/guide-telemetry.ts
+++ b/services/gateway/src/services/guide/guide-telemetry.ts
@@ -23,7 +23,9 @@ export type GuideEventType =
   // Phase F — VTID-01933 conversation continuity
   | 'guide.session_summary.recorded'
   // Phase E — VTID-01935 D43 adaptation applier
-  | 'guide.adaptation.applied';
+  | 'guide.adaptation.applied'
+  // Phase C — VTID-01936 pattern extraction
+  | 'guide.patterns.extracted';
 
 export async function emitGuideTelemetry(
   type: GuideEventType,

--- a/services/gateway/src/services/guide/index.ts
+++ b/services/gateway/src/services/guide/index.ts
@@ -36,6 +36,13 @@ export {
   type ApplyResult as AdaptationApplyResult,
 } from './adaptation-applier';
 export {
+  extractPatternsForUser,
+  getUserRoutines,
+  type RoutineKind,
+  type RoutineRow,
+  type ExtractResult as PatternExtractResult,
+} from './pattern-extractor';
+export {
   describeTimeSince,
   fetchLastSessionInfo,
   deriveMotivationSignal,

--- a/services/gateway/src/services/guide/pattern-extractor.ts
+++ b/services/gateway/src/services/guide/pattern-extractor.ts
@@ -1,0 +1,253 @@
+/**
+ * Companion Phase C — Pattern Extractor (VTID-01936)
+ *
+ * Reads the last 30 days of completed calendar_events per user, extracts
+ * routine/rhythm signals, and writes user_routines rows. Brain reads these
+ * to weave naturally ("I noticed you usually do diary on Sundays — want
+ * to keep that rhythm?").
+ *
+ * Designed to be triggered:
+ *   - Manually (POST /api/v1/guide/pattern-extract — separate route, future)
+ *   - Nightly (via existing scheduler.ts pattern — separate VTID to wire cron)
+ *   - On-demand (e.g., after a major calendar update)
+ *
+ * STATUS: function is fully implemented + idempotent. Cron wiring is
+ * deferred — for now the function is exposed and can be invoked manually
+ * or by a future scheduled job.
+ */
+
+import { getSupabase } from '../../lib/supabase';
+import { emitGuideTelemetry } from './guide-telemetry';
+
+const LOG_PREFIX = '[Guide:pattern-extractor]';
+const MIN_EVIDENCE = 3; // need at least 3 occurrences before claiming a pattern
+const LOOKBACK_DAYS = 30;
+const MIN_CONFIDENCE = 0.4;
+
+export type RoutineKind =
+  | 'time_of_day_preference'
+  | 'day_of_week_rhythm'
+  | 'category_affinity'
+  | 'wave_velocity'
+  | 'completion_streak';
+
+export interface RoutineRow {
+  routine_kind: RoutineKind;
+  routine_key: string;
+  title: string;
+  summary: string;
+  evidence_count: number;
+  confidence: number;
+  metadata: Record<string, unknown>;
+  first_observed: string;
+  last_observed: string;
+}
+
+export interface ExtractResult {
+  user_id: string;
+  routines_written: number;
+  routines: RoutineRow[];
+  events_examined: number;
+}
+
+/**
+ * Read the user's recent routine patterns. Read-only; for awareness consumption.
+ */
+export async function getUserRoutines(userId: string, limit: number = 8): Promise<RoutineRow[]> {
+  const supabase = getSupabase();
+  if (!supabase) return [];
+
+  const { data, error } = await supabase
+    .from('user_routines')
+    .select('routine_kind, routine_key, title, summary, evidence_count, confidence, metadata, first_observed, last_observed')
+    .eq('user_id', userId)
+    .gte('confidence', MIN_CONFIDENCE)
+    .order('confidence', { ascending: false })
+    .limit(limit);
+
+  if (error) {
+    console.warn(`${LOG_PREFIX} read failed:`, error.message);
+    return [];
+  }
+  return (data || []) as RoutineRow[];
+}
+
+/**
+ * Extract patterns from the last 30 days of calendar_events for a user
+ * and upsert them into user_routines. Idempotent — re-running on the same
+ * data updates the same rows (UNIQUE on user_id + routine_kind + routine_key).
+ *
+ * Pattern types (MVP):
+ *   - time_of_day_preference: % of completed events in morning/afternoon/evening
+ *   - day_of_week_rhythm:    days where >40% of events happen
+ *   - category_affinity:    wellness_tags appearing on >25% of completed events
+ *
+ * Returns the routines that were derived. Returns empty if insufficient data
+ * (we never write low-confidence noise).
+ */
+export async function extractPatternsForUser(userId: string): Promise<ExtractResult> {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return { user_id: userId, routines_written: 0, routines: [], events_examined: 0 };
+  }
+
+  const sinceIso = new Date(Date.now() - LOOKBACK_DAYS * 86400000).toISOString();
+
+  const { data: events, error } = await supabase
+    .from('calendar_events')
+    .select('id, start_time, completion_status, status, event_type, wellness_tags, time_slot')
+    .eq('user_id', userId)
+    .gte('start_time', sinceIso);
+
+  if (error || !events) {
+    console.warn(`${LOG_PREFIX} fetch events failed for ${userId.substring(0, 8)}:`, error?.message);
+    return { user_id: userId, routines_written: 0, routines: [], events_examined: 0 };
+  }
+
+  type EvShape = {
+    id: string;
+    start_time: string;
+    completion_status: string | null;
+    status: string;
+    event_type: string;
+    wellness_tags: string[] | null;
+    time_slot: string | null;
+  };
+
+  const evList = (events as EvShape[]).filter((e) => e.start_time);
+  const completed = evList.filter(
+    (e) => e.completion_status === 'completed' || e.status === 'completed',
+  );
+
+  const eventsExamined = evList.length;
+
+  // Insufficient data → don't write noise
+  if (completed.length < MIN_EVIDENCE) {
+    console.log(
+      `${LOG_PREFIX} insufficient completed events for ${userId.substring(0, 8)} (${completed.length} < ${MIN_EVIDENCE}) — skipping`,
+    );
+    return { user_id: userId, routines_written: 0, routines: [], events_examined: eventsExamined };
+  }
+
+  const routines: RoutineRow[] = [];
+  const now = new Date().toISOString();
+
+  // Time-of-day preference (morning <12, afternoon 12-18, evening >=18, by start_time hour UTC)
+  const todBuckets = { morning: 0, afternoon: 0, evening: 0 };
+  for (const ev of completed) {
+    const h = new Date(ev.start_time).getUTCHours();
+    if (h < 12) todBuckets.morning += 1;
+    else if (h < 18) todBuckets.afternoon += 1;
+    else todBuckets.evening += 1;
+  }
+  const todTotal = completed.length;
+  for (const [tod, count] of Object.entries(todBuckets) as Array<['morning' | 'afternoon' | 'evening', number]>) {
+    const pct = count / todTotal;
+    if (pct >= 0.5 && count >= MIN_EVIDENCE) {
+      routines.push({
+        routine_kind: 'time_of_day_preference',
+        routine_key: `tod:${tod}`,
+        title: `${tod} preference`,
+        summary: `${Math.round(pct * 100)}% of completed activities happen in the ${tod}`,
+        evidence_count: count,
+        confidence: Math.min(0.95, 0.4 + pct / 2),
+        metadata: { time_of_day: tod, total_evidence: todTotal },
+        first_observed: now,
+        last_observed: now,
+      });
+    }
+  }
+
+  // Day-of-week rhythm
+  const dowCounts: Record<number, number> = { 0: 0, 1: 0, 2: 0, 3: 0, 4: 0, 5: 0, 6: 0 };
+  for (const ev of completed) {
+    const d = new Date(ev.start_time).getUTCDay();
+    dowCounts[d] += 1;
+  }
+  const dowTotal = completed.length;
+  const dowNames = ['Sunday', 'Monday', 'Tuesday', 'Wednesday', 'Thursday', 'Friday', 'Saturday'];
+  for (const [d, count] of Object.entries(dowCounts)) {
+    const pct = count / dowTotal;
+    if (pct >= 0.25 && count >= MIN_EVIDENCE) {
+      const name = dowNames[Number(d)];
+      routines.push({
+        routine_kind: 'day_of_week_rhythm',
+        routine_key: `dow:${d}`,
+        title: `${name} rhythm`,
+        summary: `~${Math.round(pct * 100)}% of activity happens on ${name}`,
+        evidence_count: count,
+        confidence: Math.min(0.95, 0.35 + pct),
+        metadata: { day_of_week: name, dow_index: Number(d) },
+        first_observed: now,
+        last_observed: now,
+      });
+    }
+  }
+
+  // Category affinity (wellness_tags)
+  const tagCounts: Record<string, number> = {};
+  for (const ev of completed) {
+    if (Array.isArray(ev.wellness_tags)) {
+      for (const tag of ev.wellness_tags) {
+        if (typeof tag === 'string' && tag.trim()) {
+          tagCounts[tag] = (tagCounts[tag] || 0) + 1;
+        }
+      }
+    }
+  }
+  for (const [tag, count] of Object.entries(tagCounts)) {
+    const pct = count / completed.length;
+    if (pct >= 0.25 && count >= MIN_EVIDENCE) {
+      routines.push({
+        routine_kind: 'category_affinity',
+        routine_key: `tag:${tag}`,
+        title: `${tag} affinity`,
+        summary: `engages with "${tag}" activities ${Math.round(pct * 100)}% of the time`,
+        evidence_count: count,
+        confidence: Math.min(0.95, 0.4 + pct),
+        metadata: { tag },
+        first_observed: now,
+        last_observed: now,
+      });
+    }
+  }
+
+  // Persist (upsert) — idempotent on (user_id, routine_kind, routine_key)
+  let written = 0;
+  for (const r of routines) {
+    const { error: upsertErr } = await supabase.from('user_routines').upsert(
+      {
+        user_id: userId,
+        routine_kind: r.routine_kind,
+        routine_key: r.routine_key,
+        title: r.title,
+        summary: r.summary,
+        evidence_count: r.evidence_count,
+        confidence: r.confidence,
+        metadata: r.metadata,
+        last_observed: r.last_observed,
+        updated_at: r.last_observed,
+      },
+      { onConflict: 'user_id,routine_kind,routine_key' },
+    );
+    if (upsertErr) {
+      console.warn(`${LOG_PREFIX} upsert ${r.routine_kind}:${r.routine_key} failed:`, upsertErr.message);
+      continue;
+    }
+    written += 1;
+  }
+
+  if (written > 0) {
+    emitGuideTelemetry('guide.patterns.extracted', {
+      user_id: userId,
+      routines_written: written,
+      events_examined: eventsExamined,
+      kinds: Array.from(new Set(routines.map((r) => r.routine_kind))),
+    }).catch(() => {});
+    console.log(
+      `${LOG_PREFIX} extracted ${written} routines for user ${userId.substring(0, 8)} from ${eventsExamined} events`,
+    );
+  }
+
+  return { user_id: userId, routines_written: written, routines, events_examined: eventsExamined };
+}

--- a/services/gateway/src/services/guide/types.ts
+++ b/services/gateway/src/services/guide/types.ts
@@ -86,8 +86,15 @@ export interface UserAwareness {
     last_applied_at: string | null;
   } | null;
 
-  // Reserved for future companion pillars (null until those phases ship)
-  routines: null;
+  // Phase C — user routines from pattern-extractor (VTID-01936)
+  routines: Array<{
+    routine_kind: string;
+    title: string;
+    summary: string;
+    confidence: number;
+  }>;
+
+  // Reserved for future (null until then)
   tastes_preferences: null;
 }
 

--- a/services/gateway/src/services/vitana-brain.ts
+++ b/services/gateway/src/services/vitana-brain.ts
@@ -864,6 +864,17 @@ function buildAwarenessBlock(awareness: UserAwareness | null): string {
     lines.push(`Recent activity: ${raParts.join('; ')}`);
   }
 
+  // Phase C — learned routines from pattern-extractor. Brain weaves naturally.
+  if (awareness.routines && awareness.routines.length > 0) {
+    const top = awareness.routines.slice(0, 4);
+    const routineLines = top.map((r) => `  - ${r.title}: ${r.summary} (confidence ${(r.confidence * 100).toFixed(0)}%)`);
+    lines.push('Known routines (from past 30 days of completed activities):');
+    lines.push(...routineLines);
+    lines.push(
+      'Routine rule: reference routines naturally when relevant — e.g. "you usually do this in the morning, want to keep that?" — and respect them when suggesting new items. Never list them in bulk.',
+    );
+  }
+
   // Phase F — prior session continuity. Brain weaves naturally rather than reciting.
   if (awareness.prior_session_themes && awareness.prior_session_themes.length > 0) {
     const recentSummary = awareness.prior_session_themes[0];

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -602,6 +602,8 @@ export type CicdEventType =
   | 'guide.session_summary.recorded'
   // COMPANION Phase E — D43 adaptation applier (VTID-01935)
   | 'guide.adaptation.applied'
+  // COMPANION Phase C — pattern extractor (VTID-01936)
+  | 'guide.patterns.extracted'
   // VTID-01900: Longevity News Feed Events
   | 'news.feed.error'
   | 'news.feed.cycle_complete'

--- a/supabase/migrations/20260419120000_user_routines.sql
+++ b/supabase/migrations/20260419120000_user_routines.sql
@@ -1,0 +1,61 @@
+-- =============================================================================
+-- VTID-01936 (Companion Phase C): User routines extracted from calendar_events
+-- Date: 2026-04-19
+--
+-- Stores routine/rhythm patterns the pattern-extractor derives from each
+-- user's calendar_events history. Brain reads these to mention naturally
+-- ("I noticed you usually do diary on Sundays — want to keep that rhythm?").
+--
+-- Why a NEW table instead of extending memory_garden_nodes:
+-- The existing memory_garden_nodes table has TWO conflicting CREATE TABLE
+-- migrations (vtid_01085 + vtid_01082) with different node_type CHECK
+-- constraints. Reusing it would risk constraint violations. user_routines
+-- is a clean surface for Phase C — pattern-extractor writes here exclusively.
+--
+-- routine_kind values:
+--   time_of_day_preference  — user prefers morning/afternoon/evening for X
+--   day_of_week_rhythm      — user reliably does X on Mondays/etc
+--   category_affinity       — user engages with category Y much more than Z
+--   wave_velocity           — user moves through 90-day waves faster/slower than median
+--   completion_streak       — user has N-day completion streak in category
+-- =============================================================================
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS user_routines (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  routine_kind    text NOT NULL
+    CHECK (routine_kind IN (
+      'time_of_day_preference',
+      'day_of_week_rhythm',
+      'category_affinity',
+      'wave_velocity',
+      'completion_streak'
+    )),
+  routine_key     text NOT NULL,                     -- stable per (user, kind)
+  title           text NOT NULL,                     -- "morning preference"
+  summary         text NOT NULL,                     -- "you do 80% of activities before 10am"
+  evidence_count  int NOT NULL DEFAULT 1,
+  confidence      numeric NOT NULL DEFAULT 0.5 CHECK (confidence >= 0 AND confidence <= 1),
+  metadata        jsonb DEFAULT '{}'::jsonb,
+  first_observed  timestamptz NOT NULL DEFAULT now(),
+  last_observed   timestamptz NOT NULL DEFAULT now(),
+  updated_at      timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (user_id, routine_kind, routine_key)
+);
+
+ALTER TABLE user_routines ENABLE ROW LEVEL SECURITY;
+
+CREATE POLICY "user_routines_self_rw"
+  ON user_routines FOR ALL
+  USING (auth.uid() = user_id)
+  WITH CHECK (auth.uid() = user_id);
+
+CREATE INDEX IF NOT EXISTS idx_user_routines_user_kind
+  ON user_routines (user_id, routine_kind, confidence DESC);
+
+COMMENT ON TABLE user_routines IS
+  'VTID-01936 Companion Phase C — routine patterns extracted from calendar_events. Brain reads to weave naturally ("you usually X on Y day").';
+
+COMMIT;


### PR DESCRIPTION
Final Companion phase. Extracts time-of-day / day-of-week / category affinity patterns from 30 days of calendar_events, writes user_routines, awareness reads them, brain weaves naturally ('you usually do this in the morning'). New user_routines table (avoids memory_garden_nodes schema conflict). Nightly cron deferred — function is exposed for manual/scheduled invocation.