### PR TITLE
feat(marketplace): Rakuten + Awin providers (VTID-01938)

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -11228,11 +11228,19 @@ function renderAdminMarketplaceShopCreateForm() {
     function input(id, spec) {
         var row = document.createElement('div');
         row.style.marginBottom = '0.5rem';
-        row.innerHTML = '<label style="display:block;font-size:0.8rem;margin-bottom:0.25rem;">'
+        var labelHtml = '<label style="display:block;font-size:0.8rem;margin-bottom:0.25rem;">'
             + escapeHtml(spec.label) + (spec.required ? ' <span style="color:var(--danger)">*</span>' : '')
-            + '</label>'
-            + '<input id="' + id + '" type="' + (spec.type === 'password' ? 'password' : (spec.type === 'number' ? 'number' : 'text')) + '" '
-            + 'placeholder="' + escapeHtml(spec.placeholder || '') + '" class="admin-input" style="width:100%;padding:0.5rem;" />'
+            + '</label>';
+        var fieldHtml;
+        if (spec.type === 'textarea') {
+            fieldHtml = '<textarea id="' + id + '" rows="4" placeholder="' + escapeHtml(spec.placeholder || '')
+                + '" class="admin-input" style="width:100%;padding:0.5rem;font-family:monospace;font-size:0.85rem;"></textarea>';
+        } else {
+            var type = spec.type === 'password' ? 'password' : (spec.type === 'number' ? 'number' : 'text');
+            fieldHtml = '<input id="' + id + '" type="' + type + '" placeholder="' + escapeHtml(spec.placeholder || '')
+                + '" class="admin-input" style="width:100%;padding:0.5rem;" />';
+        }
+        row.innerHTML = labelHtml + fieldHtml
             + (spec.help ? '<small class="admin-detail-note">' + escapeHtml(spec.help) + '</small>' : '');
         return row;
     }
@@ -11312,6 +11320,11 @@ function renderAdminMarketplaceShopCreateForm() {
                 var n = Number(v);
                 if (!Number.isFinite(n)) { missing.push(entry.spec.label + ' (must be a number)'); continue; }
                 config[entry.spec.key] = n;
+            } else if (entry.spec.type === 'textarea') {
+                // Textareas often carry JSON — try to parse; if it fails, store as string
+                // and let the server-side validateConfig catch malformed JSON.
+                try { config[entry.spec.key] = JSON.parse(v); }
+                catch (_e) { config[entry.spec.key] = v; }
             } else {
                 config[entry.spec.key] = v;
             }

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -12,7 +12,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260328-aura"></script>
-  <script src="/command-hub/app.js?v=20260419-scroll-module-wrapper"></script>
+  <script src="/command-hub/app.js?v=20260419-vtid01938-textarea-field"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js"></script>
 </body>

--- a/services/gateway/src/services/marketplace-sync/awin-sync.ts
+++ b/services/gateway/src/services/marketplace-sync/awin-sync.ts
@@ -1,0 +1,338 @@
+/**
+ * VTID-01938: Awin product data feed sync.
+ *
+ * https://wiki.awin.com/index.php/Product_Feeds — Awin distributes catalogs
+ * via per-advertiser "product data feeds" that can be downloaded in JSON
+ * with selectable columns. We pull one feed per advertiser we're joined to.
+ *
+ * EU-strongest network (~25k advertisers), useful when Vitana expands to
+ * European retailers that aren't on CJ/Rakuten.
+ *
+ * Config shape (JSON in marketplace_sources_config.config):
+ *   {
+ *     "api_key": "...",                       // Publisher API key
+ *     "publisher_id": "123456",               // Publisher SID
+ *     "feeds": [
+ *       { "feed_id": "1234", "advertiser_id": "5678", "advertiser_name": "Acme Vitamins" }
+ *     ],
+ *     "merchant_country": "GB",
+ *     "max_products_per_feed": 500
+ *   }
+ *
+ * Auth: the api_key is stamped into the feed URL path
+ *   https://productdata.awin.com/datafeed/download/apikey/{key}/...
+ */
+
+import {
+  startSyncRun,
+  finishSyncRun,
+  upsertMerchant,
+  upsertProducts,
+  type ProductUpsert,
+} from './shared';
+import { inferSupplementAttributes } from './supplement-inference';
+import { getSupabase } from '../../lib/supabase';
+
+interface AwinFeedRef {
+  feed_id: string;
+  advertiser_id: string;
+  advertiser_name?: string;
+}
+
+interface AwinSourceConfig {
+  api_key: string;
+  publisher_id: string;
+  feeds: AwinFeedRef[];
+  merchant_country?: string;
+  max_products_per_feed?: number;
+}
+
+async function loadSourceConfigs(): Promise<AwinSourceConfig[]> {
+  const supabase = getSupabase();
+  if (!supabase) return [];
+  const { data } = await supabase
+    .from('marketplace_sources_config')
+    .select('config')
+    .eq('source_network', 'awin')
+    .eq('is_active', true);
+  if (!data?.length) return [];
+  return data
+    .map((r) => r.config as AwinSourceConfig)
+    .filter((c) => c && c.api_key && c.publisher_id && Array.isArray(c.feeds) && c.feeds.length > 0);
+}
+
+// ==================== Feed fetch ====================
+
+// Column list we care about — Awin supports >100 columns but we only need these.
+const FEED_COLUMNS = [
+  'aw_deep_link',
+  'aw_product_id',
+  'merchant_product_id',
+  'product_name',
+  'description',
+  'product_short_description',
+  'merchant_name',
+  'merchant_id',
+  'merchant_category',
+  'category_name',
+  'brand_name',
+  'merchant_image_url',
+  'aw_image_url',
+  'search_price',
+  'rrp_price',
+  'currency',
+  'ean',
+  'upc',
+  'product_gtin',
+  'in_stock',
+  'stock_status',
+  'language',
+  'keywords',
+  'specifications',
+  'condition',
+  'delivery_restrictions',
+].join(',');
+
+interface AwinFeedItem {
+  aw_deep_link?: string;
+  aw_product_id?: string;
+  merchant_product_id?: string;
+  product_name?: string;
+  description?: string;
+  product_short_description?: string;
+  merchant_name?: string;
+  merchant_id?: string;
+  merchant_category?: string;
+  category_name?: string;
+  brand_name?: string;
+  merchant_image_url?: string;
+  aw_image_url?: string;
+  search_price?: string;
+  rrp_price?: string;
+  currency?: string;
+  ean?: string;
+  upc?: string;
+  product_gtin?: string;
+  in_stock?: string;
+  stock_status?: string;
+  keywords?: string;
+  specifications?: string;
+  delivery_restrictions?: string;
+}
+
+async function fetchAwinFeed(
+  cfg: AwinSourceConfig,
+  feed: AwinFeedRef
+): Promise<AwinFeedItem[]> {
+  const url =
+    `https://productdata.awin.com/datafeed/download/apikey/${encodeURIComponent(cfg.api_key)}` +
+    `/language/any/fid/${encodeURIComponent(feed.feed_id)}/bandwidth/low` +
+    `/sid/${encodeURIComponent(cfg.publisher_id)}/mid/${encodeURIComponent(feed.advertiser_id)}` +
+    `/columns/${FEED_COLUMNS}/format/json`;
+
+  const resp = await fetch(url, { headers: { Accept: 'application/json' } });
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => '(no body)');
+    throw new Error(`Awin feed ${feed.feed_id} HTTP ${resp.status} ${text.slice(0, 300)}`);
+  }
+  const data = (await resp.json()) as AwinFeedItem[] | { products?: AwinFeedItem[] };
+  if (Array.isArray(data)) return data;
+  return data.products ?? [];
+}
+
+// ==================== Normalization ====================
+
+function parseCents(amountStr: string | undefined): number | null {
+  if (!amountStr) return null;
+  const n = parseFloat(amountStr.replace(/[^0-9.]/g, ''));
+  return Number.isNaN(n) ? null : Math.round(n * 100);
+}
+
+function parseStock(item: AwinFeedItem): ProductUpsert['availability'] {
+  const s = (item.stock_status ?? item.in_stock ?? '').toLowerCase();
+  if (s.includes('out')) return 'out_of_stock';
+  if (s.includes('preorder') || s.includes('pre-order')) return 'preorder';
+  if (s.includes('discontinued')) return 'discontinued';
+  if (item.in_stock === '1' || s === 'in stock' || s === 'yes' || s === 'true') return 'in_stock';
+  return 'unknown';
+}
+
+function normalizeAwinItem(
+  item: AwinFeedItem,
+  feed: AwinFeedRef,
+  merchantId: string,
+  country?: string
+): ProductUpsert | null {
+  const id = item.aw_product_id ?? item.merchant_product_id;
+  if (!id) return null;
+  const title = item.product_name;
+  if (!title) return null;
+
+  const priceCents = parseCents(item.search_price);
+  if (priceCents === null) return null;
+  const currency = (item.currency ?? 'EUR').toUpperCase();
+  const rrp = parseCents(item.rrp_price);
+  const compareCents = rrp && rrp > priceCents ? rrp : undefined;
+
+  const gtin = item.product_gtin ?? item.ean ?? item.upc;
+  const description = item.product_short_description ?? item.description;
+  const images: string[] = [];
+  if (item.aw_image_url) images.push(item.aw_image_url);
+  if (item.merchant_image_url && item.merchant_image_url !== item.aw_image_url) {
+    images.push(item.merchant_image_url);
+  }
+
+  const topic_keys: string[] = [];
+  if (item.keywords) {
+    for (const k of item.keywords.split(/[,;]/)) {
+      const s = k.trim().toLowerCase();
+      if (s) topic_keys.push(s);
+    }
+  }
+
+  const inferText = [title, description, item.merchant_category, item.category_name, item.specifications, item.keywords]
+    .filter(Boolean).join(' ');
+  const inferred = inferSupplementAttributes(inferText);
+
+  // delivery_restrictions contains ISO country codes the merchant WILL NOT ship to — invert for ships_to_countries if needed.
+  // For now we skip this (requires global country list); leave null.
+
+  return {
+    merchant_id: merchantId,
+    source_network: 'awin',
+    source_product_id: String(id),
+    gtin,
+    sku: item.merchant_product_id,
+    title,
+    description,
+    description_long: item.description,
+    brand: item.brand_name,
+    category: item.merchant_category ?? item.category_name,
+    subcategory: item.category_name,
+    topic_keys: topic_keys.slice(0, 20),
+    price_cents: priceCents,
+    currency,
+    compare_at_price_cents: compareCents,
+    images,
+    affiliate_url: item.aw_deep_link ?? '',
+    availability: parseStock(item),
+    origin_country: country,
+    health_goals: inferred.health_goals,
+    dietary_tags: inferred.dietary_tags,
+    ingredients_primary: inferred.ingredients_primary,
+    form: inferred.form,
+    certifications: inferred.certifications,
+    raw: item as unknown as Record<string, unknown>,
+  };
+}
+
+// ==================== Per-feed sync ====================
+
+async function syncOneFeed(
+  cfg: AwinSourceConfig,
+  feed: AwinFeedRef
+): Promise<{ inserted: number; updated: number; skipped: number; errors: number; fetched: number; error_sample: unknown[] }> {
+  const merchantId = await upsertMerchant({
+    source_network: 'awin',
+    source_merchant_id: feed.advertiser_id,
+    name: feed.advertiser_name ?? `Awin Advertiser ${feed.advertiser_id}`,
+    affiliate_network: 'awin',
+    merchant_country: cfg.merchant_country,
+    quality_score: 65,
+    customs_risk: 'unknown',
+  });
+  if (!merchantId) {
+    return { inserted: 0, updated: 0, skipped: 0, errors: 1, fetched: 0, error_sample: [{ feed_id: feed.feed_id, error: 'merchant upsert failed' }] };
+  }
+
+  let items: AwinFeedItem[];
+  try {
+    items = await fetchAwinFeed(cfg, feed);
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    return { inserted: 0, updated: 0, skipped: 0, errors: 1, fetched: 0, error_sample: [{ feed_id: feed.feed_id, error: message }] };
+  }
+
+  const max = cfg.max_products_per_feed ?? 500;
+  const limited = items.slice(0, max);
+
+  const normalized = limited
+    .map((i) => normalizeAwinItem(i, feed, merchantId, cfg.merchant_country))
+    .filter((p): p is ProductUpsert => p !== null);
+
+  if (normalized.length === 0) {
+    return { inserted: 0, updated: 0, skipped: 0, errors: 0, fetched: items.length, error_sample: [] };
+  }
+
+  const r = await upsertProducts(normalized, 'awin');
+  return {
+    inserted: r.inserted,
+    updated: r.updated,
+    skipped: r.skipped_unchanged,
+    errors: r.errors.length,
+    fetched: items.length,
+    error_sample: r.errors.slice(0, 5),
+  };
+}
+
+// ==================== Entry point ====================
+
+export interface AwinSyncResult {
+  ok: boolean;
+  totals: { inserted: number; updated: number; skipped: number; errors: number; fetched: number };
+  feeds_synced: number;
+  duration_ms: number;
+  per_feed: Array<{ feed_id: string; advertiser_id: string; inserted: number; updated: number; skipped: number; errors: number }>;
+  error?: string;
+}
+
+export async function runAwinSync(triggered_by = 'scheduler'): Promise<AwinSyncResult> {
+  const startTime = Date.now();
+  const configs = await loadSourceConfigs();
+  if (configs.length === 0) {
+    console.log('[awin-sync] no feeds configured — skipping');
+    return {
+      ok: true,
+      totals: { inserted: 0, updated: 0, skipped: 0, errors: 0, fetched: 0 },
+      feeds_synced: 0,
+      per_feed: [],
+      duration_ms: Date.now() - startTime,
+    };
+  }
+
+  const totals = { inserted: 0, updated: 0, skipped: 0, errors: 0, fetched: 0 };
+  const per_feed: AwinSyncResult['per_feed'] = [];
+  const errorSample: unknown[] = [];
+  let feedCount = 0;
+
+  for (const cfg of configs) {
+    const run = await startSyncRun('awin', triggered_by);
+    for (const feed of cfg.feeds) {
+      feedCount++;
+      const stats = await syncOneFeed(cfg, feed);
+      per_feed.push({
+        feed_id: feed.feed_id,
+        advertiser_id: feed.advertiser_id,
+        inserted: stats.inserted,
+        updated: stats.updated,
+        skipped: stats.skipped,
+        errors: stats.errors,
+      });
+      totals.inserted += stats.inserted;
+      totals.updated += stats.updated;
+      totals.skipped += stats.skipped;
+      totals.errors += stats.errors;
+      totals.fetched += stats.fetched;
+      if (stats.error_sample.length) errorSample.push(...stats.error_sample);
+    }
+    if (run) await finishSyncRun(run, { ...totals, error_sample: errorSample.slice(0, 10) });
+  }
+
+  const duration_ms = Date.now() - startTime;
+  console.log(
+    `[awin-sync] done in ${duration_ms}ms — fetched ${totals.fetched}, ` +
+    `${totals.inserted}+ ${totals.updated}~ ${totals.skipped}= ${totals.errors}! across ${feedCount} feeds`
+  );
+
+  return { ok: totals.errors === 0, totals, feeds_synced: feedCount, per_feed, duration_ms };
+}

--- a/services/gateway/src/services/marketplace-sync/providers/awin.ts
+++ b/services/gateway/src/services/marketplace-sync/providers/awin.ts
@@ -1,0 +1,104 @@
+/**
+ * VTID-01938: Awin provider registration.
+ *
+ * EU-strongest affiliate network (~25k advertisers). Catalog is distributed
+ * as per-advertiser product data feeds — we configure one "feed entry" per
+ * advertiser we've joined.
+ *
+ * Sync logic: ../awin-sync.ts.
+ */
+
+import type { MarketplaceProvider, ProviderSyncResult } from '../provider';
+import { runAwinSync } from '../awin-sync';
+
+export const awinProvider: MarketplaceProvider = {
+  key: 'awin',
+  displayName: 'Awin',
+  description:
+    'Awin product data feeds. Configure one publisher account + a list of advertiser feeds you have access to. Strongest in the EU market; use in addition to CJ/Rakuten for broader retailer coverage.',
+  configSchema: [
+    {
+      key: 'api_key',
+      label: 'Awin publisher API key',
+      type: 'password',
+      required: true,
+      help: 'Publisher API key from My Account → API Credentials on awin.com.',
+    },
+    {
+      key: 'publisher_id',
+      label: 'Publisher ID (SID)',
+      type: 'text',
+      placeholder: '123456',
+      required: true,
+    },
+    {
+      key: 'feeds',
+      label: 'Feed refs (JSON array)',
+      type: 'textarea',
+      placeholder: '[{"feed_id":"1234","advertiser_id":"5678","advertiser_name":"Acme Vitamins"}]',
+      required: true,
+      help: 'JSON array of {feed_id, advertiser_id, advertiser_name?} objects — one per advertiser you have product-feed access to.',
+    },
+    {
+      key: 'max_products_per_feed',
+      label: 'Max products per feed (default 500)',
+      type: 'number',
+      placeholder: '500',
+    },
+    {
+      key: 'merchant_country',
+      label: 'Fallback merchant country (ISO-2, optional)',
+      type: 'text',
+      placeholder: 'GB',
+    },
+  ],
+  validateConfig(cfg) {
+    if (!cfg || typeof cfg !== 'object') return { ok: false, error: 'config must be an object' };
+    if (!cfg.api_key || typeof cfg.api_key !== 'string') return { ok: false, error: 'api_key is required' };
+    if (!cfg.publisher_id) return { ok: false, error: 'publisher_id is required' };
+
+    // feeds may come in as an array (direct JSON) or as a JSON-encoded string from the textarea.
+    let feeds = cfg.feeds;
+    if (typeof feeds === 'string') {
+      try {
+        feeds = JSON.parse(feeds);
+      } catch {
+        return { ok: false, error: 'feeds must be a JSON array' };
+      }
+    }
+    if (!Array.isArray(feeds) || feeds.length === 0) {
+      return { ok: false, error: 'feeds must be a non-empty array' };
+    }
+    for (const f of feeds as Array<Record<string, unknown>>) {
+      if (!f || typeof f !== 'object') return { ok: false, error: 'each feed must be an object' };
+      if (!f.feed_id || !f.advertiser_id) {
+        return { ok: false, error: 'each feed requires feed_id and advertiser_id' };
+      }
+    }
+    // Normalize back — the admin route will persist this.
+    cfg.feeds = feeds;
+
+    if (cfg.max_products_per_feed !== undefined) {
+      const n = Number(cfg.max_products_per_feed);
+      if (!Number.isFinite(n) || n < 1 || n > 10000) {
+        return { ok: false, error: 'max_products_per_feed must be between 1 and 10000' };
+      }
+    }
+    return { ok: true };
+  },
+  async runSync(triggered_by: string): Promise<ProviderSyncResult> {
+    const r = await runAwinSync(triggered_by);
+    return {
+      ok: r.ok,
+      totals: {
+        inserted: r.totals.inserted,
+        updated: r.totals.updated,
+        skipped: r.totals.skipped,
+        errors: r.totals.errors,
+      },
+      duration_ms: r.duration_ms,
+      details: { fetched: r.totals.fetched, feeds_synced: r.feeds_synced, per_feed: r.per_feed },
+      error: r.error,
+    };
+  },
+};

--- a/services/gateway/src/services/marketplace-sync/providers/index.ts
+++ b/services/gateway/src/services/marketplace-sync/providers/index.ts
@@ -11,9 +11,17 @@ import type { MarketplaceProvider } from '../provider';
 import { shopifyProvider } from './shopify';
 import { cjProvider } from './cj';
 import { amazonProvider } from './amazon';
+import { rakutenProvider } from './rakuten';
+import { awinProvider } from './awin';
 
 /** Order here == display order in the admin UI dropdown. */
-const PROVIDERS: readonly MarketplaceProvider[] = [shopifyProvider, cjProvider, amazonProvider];
+const PROVIDERS: readonly MarketplaceProvider[] = [
+  shopifyProvider,
+  cjProvider,
+  amazonProvider,
+  rakutenProvider,
+  awinProvider,
+];
 
 const BY_KEY = new Map<string, MarketplaceProvider>(PROVIDERS.map((p) => [p.key, p]));
 

--- a/services/gateway/src/services/marketplace-sync/providers/rakuten.ts
+++ b/services/gateway/src/services/marketplace-sync/providers/rakuten.ts
@@ -1,0 +1,83 @@
+/**
+ * VTID-01938: Rakuten Advertising provider registration.
+ *
+ * Complements CJ with a different advertiser mix (~1000 advertisers,
+ * Europe-stronger). Single publisher account, one bearer token — similar
+ * shape to CJ but different endpoint + response format.
+ *
+ * Sync logic: ../rakuten-sync.ts.
+ */
+
+import type { MarketplaceProvider, ProviderSyncResult } from '../provider';
+import { runRakutenSync } from '../rakuten-sync';
+
+export const rakutenProvider: MarketplaceProvider = {
+  key: 'rakuten',
+  displayName: 'Rakuten Advertising',
+  description:
+    'LinkShare / Rakuten Advertising Product Search API. One publisher account per environment; bearer token comes from the Rakuten Advertising dashboard.',
+  configSchema: [
+    {
+      key: 'bearer_token',
+      label: 'Rakuten bearer token',
+      type: 'password',
+      required: true,
+      help: 'Generated in the Rakuten Advertising dashboard under Tools → Keys.',
+    },
+    {
+      key: 'keywords',
+      label: 'Search keywords (comma-separated)',
+      type: 'text',
+      placeholder: 'supplement,vitamin,probiotic',
+      help: 'One Product Search call per keyword. Defaults to "supplement,vitamin".',
+    },
+    {
+      key: 'advertiser_ids',
+      label: 'Advertiser IDs / MIDs (comma-separated, optional)',
+      type: 'text',
+      placeholder: '12345,67890',
+      list: true,
+      help: 'Restrict to specific advertisers. Leave blank to query all your linked advertisers.',
+    },
+    {
+      key: 'max_pages',
+      label: 'Max pages per keyword (1-20)',
+      type: 'number',
+      placeholder: '10',
+    },
+    {
+      key: 'merchant_country',
+      label: 'Fallback merchant country (ISO-2, optional)',
+      type: 'text',
+      placeholder: 'US',
+    },
+  ],
+  validateConfig(cfg) {
+    if (!cfg || typeof cfg !== 'object') return { ok: false, error: 'config must be an object' };
+    if (!cfg.bearer_token || typeof cfg.bearer_token !== 'string') {
+      return { ok: false, error: 'bearer_token is required' };
+    }
+    if (cfg.max_pages !== undefined) {
+      const n = Number(cfg.max_pages);
+      if (!Number.isFinite(n) || n < 1 || n > 20) {
+        return { ok: false, error: 'max_pages must be between 1 and 20' };
+      }
+    }
+    return { ok: true };
+  },
+  async runSync(triggered_by: string): Promise<ProviderSyncResult> {
+    const r = await runRakutenSync(triggered_by);
+    return {
+      ok: r.ok,
+      totals: {
+        inserted: r.totals.inserted,
+        updated: r.totals.updated,
+        skipped: r.totals.skipped,
+        errors: r.totals.errors,
+      },
+      duration_ms: r.duration_ms,
+      details: { fetched: r.totals.fetched, pages_fetched: r.pages_fetched, advertisers_seen: r.advertisers_seen },
+      error: r.error,
+    };
+  },
+};

--- a/services/gateway/src/services/marketplace-sync/rakuten-sync.ts
+++ b/services/gateway/src/services/marketplace-sync/rakuten-sync.ts
@@ -1,0 +1,298 @@
+/**
+ * VTID-01938: Rakuten Advertising (LinkShare) Product Search sync.
+ *
+ * https://developers.rakutenadvertising.com/ — Product Search API v1.
+ * Complements CJ with a different advertiser mix (~1000 advertisers,
+ * Europe-stronger than CJ).
+ *
+ * Auth: bearer token issued to the publisher account. Unlike CJ, the
+ * token is tied to the whole publisher account (not an advertiser) and
+ * can be rotated from the Rakuten dashboard.
+ *
+ * Config shape (JSON in marketplace_sources_config.config):
+ *   {
+ *     "bearer_token": "...",
+ *     "keywords": "supplement,vitamin,probiotic",
+ *     "advertiser_ids": ["12345","67890"],     // optional, filter to these
+ *     "merchant_country": "US",                 // fallback when feed lacks it
+ *     "max_pages": 10
+ *   }
+ *
+ * One source row per publisher account (there is usually only one).
+ */
+
+import {
+  startSyncRun,
+  finishSyncRun,
+  upsertMerchant,
+  upsertProducts,
+  type ProductUpsert,
+} from './shared';
+import { inferSupplementAttributes } from './supplement-inference';
+import { getSupabase } from '../../lib/supabase';
+
+interface RakutenSourceConfig {
+  bearer_token: string;
+  keywords?: string;
+  advertiser_ids?: string[] | string;
+  merchant_country?: string;
+  max_pages?: number;
+}
+
+async function loadSourceConfigs(): Promise<RakutenSourceConfig[]> {
+  const supabase = getSupabase();
+  if (!supabase) return [];
+  const { data } = await supabase
+    .from('marketplace_sources_config')
+    .select('config')
+    .eq('source_network', 'rakuten')
+    .eq('is_active', true);
+  if (!data?.length) return [];
+  return data.map((r) => r.config as RakutenSourceConfig).filter((c) => c && c.bearer_token);
+}
+
+// ==================== API ====================
+
+interface RakutenProductRaw {
+  mid?: string;
+  merchantname?: string;
+  linkid?: string;
+  createdon?: string;
+  sku?: string;
+  productname?: string;
+  category?: { primary?: string; secondary?: string };
+  price?: { '#text'?: string; '-currency'?: string } | string;
+  saleprice?: { '#text'?: string; '-currency'?: string } | string;
+  upccode?: string;
+  description?: { short?: string; long?: string };
+  keywords?: string;
+  linkurl?: string;
+  imageurl?: string;
+}
+
+interface RakutenResp {
+  result?: {
+    TotalMatches?: string;
+    TotalPages?: string;
+    PageNumber?: string;
+    item?: RakutenProductRaw[] | RakutenProductRaw;
+  };
+}
+
+async function fetchRakutenPage(
+  token: string,
+  opts: { keyword?: string; mids?: string; pageNumber: number; max?: number }
+): Promise<RakutenProductRaw[]> {
+  const qs = new URLSearchParams({
+    max: String(opts.max ?? 100),
+    pagenumber: String(opts.pageNumber),
+  });
+  if (opts.keyword) qs.set('keyword', opts.keyword);
+  if (opts.mids) qs.set('mid', opts.mids);
+
+  const url = `https://api.linksynergy.com/productsearch/1.0?${qs.toString()}`;
+  const resp = await fetch(url, {
+    headers: { Authorization: `Bearer ${token}`, Accept: 'application/json' },
+  });
+  if (!resp.ok) {
+    const text = await resp.text().catch(() => '(no body)');
+    throw new Error(`Rakuten ${resp.status} ${text.slice(0, 300)}`);
+  }
+  const data = (await resp.json()) as RakutenResp;
+  const items = data.result?.item;
+  if (!items) return [];
+  return Array.isArray(items) ? items : [items];
+}
+
+// ==================== Normalization ====================
+
+function extractPriceCents(
+  field: { '#text'?: string; '-currency'?: string } | string | undefined
+): { cents: number | null; currency: string } {
+  if (!field) return { cents: null, currency: 'USD' };
+  if (typeof field === 'string') {
+    const n = parseFloat(field.replace(/[^0-9.]/g, ''));
+    return { cents: Number.isNaN(n) ? null : Math.round(n * 100), currency: 'USD' };
+  }
+  const raw = field['#text'];
+  const currency = (field['-currency'] ?? 'USD').toUpperCase();
+  if (!raw) return { cents: null, currency };
+  const n = parseFloat(raw);
+  return { cents: Number.isNaN(n) ? null : Math.round(n * 100), currency };
+}
+
+function normalizeRakutenProduct(
+  raw: RakutenProductRaw,
+  merchantMap: Map<string, string>
+): ProductUpsert | null {
+  const productId = raw.linkid ?? raw.sku;
+  if (!productId) return null;
+  const mid = raw.mid;
+  if (!mid) return null;
+  const merchantId = merchantMap.get(mid);
+  if (!merchantId) return null;
+
+  const sale = extractPriceCents(raw.saleprice);
+  const list = extractPriceCents(raw.price);
+  const priceCents = sale.cents ?? list.cents;
+  if (priceCents === null) return null;
+  const currency = (sale.cents !== null ? sale.currency : list.currency) ?? 'USD';
+  const compareCents = sale.cents !== null && list.cents !== null && list.cents > sale.cents ? list.cents : undefined;
+
+  const shortDesc = raw.description?.short;
+  const longDesc = raw.description?.long;
+
+  const inferText = [raw.productname, shortDesc, longDesc, raw.keywords, raw.category?.primary, raw.category?.secondary]
+    .filter(Boolean).join(' ');
+  const inferred = inferSupplementAttributes(inferText);
+
+  const topic_keys: string[] = [];
+  if (raw.keywords) {
+    for (const k of raw.keywords.split(/[,;]/)) {
+      const s = k.trim().toLowerCase();
+      if (s) topic_keys.push(s);
+    }
+  }
+
+  return {
+    merchant_id: merchantId,
+    source_network: 'rakuten',
+    source_product_id: String(productId),
+    gtin: raw.upccode,
+    sku: raw.sku,
+    title: raw.productname ?? 'Untitled product',
+    description: shortDesc,
+    description_long: longDesc ?? shortDesc,
+    category: raw.category?.primary,
+    subcategory: raw.category?.secondary,
+    topic_keys: topic_keys.slice(0, 20),
+    price_cents: priceCents,
+    currency,
+    compare_at_price_cents: compareCents,
+    images: raw.imageurl ? [raw.imageurl] : [],
+    affiliate_url: raw.linkurl ?? '',
+    availability: 'in_stock', // Rakuten's search doesn't expose availability — assume in_stock
+    health_goals: inferred.health_goals,
+    dietary_tags: inferred.dietary_tags,
+    ingredients_primary: inferred.ingredients_primary,
+    form: inferred.form,
+    certifications: inferred.certifications,
+    raw: raw as unknown as Record<string, unknown>,
+  };
+}
+
+async function ensureMerchants(items: RakutenProductRaw[], country?: string): Promise<Map<string, string>> {
+  const byMid = new Map<string, { name: string }>();
+  for (const i of items) {
+    if (!i.mid) continue;
+    if (byMid.has(i.mid)) continue;
+    byMid.set(i.mid, { name: i.merchantname ?? `Rakuten Merchant ${i.mid}` });
+  }
+  const out = new Map<string, string>();
+  for (const [mid, info] of byMid) {
+    const id = await upsertMerchant({
+      source_network: 'rakuten',
+      source_merchant_id: mid,
+      name: info.name,
+      affiliate_network: 'rakuten',
+      merchant_country: country,
+      quality_score: 65,
+      customs_risk: 'unknown',
+    });
+    if (id) out.set(mid, id);
+  }
+  return out;
+}
+
+// ==================== Entry point ====================
+
+export interface RakutenSyncResult {
+  ok: boolean;
+  totals: { inserted: number; updated: number; skipped: number; errors: number; fetched: number };
+  pages_fetched: number;
+  advertisers_seen: number;
+  duration_ms: number;
+  error?: string;
+}
+
+export async function runRakutenSync(triggered_by = 'scheduler'): Promise<RakutenSyncResult> {
+  const startTime = Date.now();
+  const configs = await loadSourceConfigs();
+  if (configs.length === 0) {
+    console.log('[rakuten-sync] no publishers configured — skipping');
+    return {
+      ok: true,
+      totals: { inserted: 0, updated: 0, skipped: 0, errors: 0, fetched: 0 },
+      pages_fetched: 0,
+      advertisers_seen: 0,
+      duration_ms: Date.now() - startTime,
+    };
+  }
+
+  const totals = { inserted: 0, updated: 0, skipped: 0, errors: 0, fetched: 0 };
+  const errorSample: unknown[] = [];
+  const advertisersSeen = new Set<string>();
+  let totalPages = 0;
+
+  for (const cfg of configs) {
+    const run = await startSyncRun('rakuten', triggered_by);
+    const keywords = (cfg.keywords ?? 'supplement,vitamin')
+      .split(',').map((k) => k.trim()).filter(Boolean);
+    const mids = Array.isArray(cfg.advertiser_ids)
+      ? cfg.advertiser_ids.join('|')
+      : (typeof cfg.advertiser_ids === 'string' ? cfg.advertiser_ids : undefined);
+    const maxPages = Math.max(1, Math.min(cfg.max_pages ?? 10, 20));
+
+    for (const kw of keywords) {
+      for (let page = 1; page <= maxPages; page++) {
+        let items: RakutenProductRaw[];
+        try {
+          items = await fetchRakutenPage(cfg.bearer_token, { keyword: kw, mids, pageNumber: page, max: 100 });
+        } catch (err: unknown) {
+          const message = err instanceof Error ? err.message : String(err);
+          totals.errors++;
+          errorSample.push({ keyword: kw, page, error: message });
+          break;
+        }
+        totalPages++;
+        totals.fetched += items.length;
+        if (items.length === 0) break;
+
+        const merchantMap = await ensureMerchants(items, cfg.merchant_country);
+        for (const mid of merchantMap.keys()) advertisersSeen.add(mid);
+
+        const normalized = items
+          .map((r) => normalizeRakutenProduct(r, merchantMap))
+          .filter((p): p is ProductUpsert => p !== null);
+        if (normalized.length === 0) continue;
+
+        const r = await upsertProducts(normalized, 'rakuten');
+        totals.inserted += r.inserted;
+        totals.updated += r.updated;
+        totals.skipped += r.skipped_unchanged;
+        if (r.errors.length) {
+          totals.errors += r.errors.length;
+          errorSample.push(...r.errors.slice(0, 3));
+        }
+
+        if (items.length < 100) break; // last page for this keyword
+      }
+    }
+
+    if (run) await finishSyncRun(run, { ...totals, error_sample: errorSample.slice(0, 10) });
+  }
+
+  const duration_ms = Date.now() - startTime;
+  console.log(
+    `[rakuten-sync] done in ${duration_ms}ms — fetched ${totals.fetched}, ` +
+    `${totals.inserted}+ ${totals.updated}~ ${totals.skipped}= ${totals.errors}! across ${advertisersSeen.size} advertisers`
+  );
+
+  return {
+    ok: totals.errors === 0,
+    totals,
+    pages_fetched: totalPages,
+    advertisers_seen: advertisersSeen.size,
+    duration_ms,
+  };
+}


### PR DESCRIPTION
## Summary
Adds Rakuten Advertising and Awin as MarketplaceProviders. Pure additions on top of the VTID-01930 registry — no changes to the orchestrator, scheduler, or sync routes. One small frontend addition: the form helper now renders `<textarea>` for config_schema entries with `type: 'textarea'` (Awin's feeds JSON needs it).

## What changed
- **rakuten-sync.ts / providers/rakuten.ts** — LinkSynergy Product Search API v1 (bearer token, JSON). Per-keyword pagination up to 20 × 100 items. Normalization mirrors CJ but handles Rakuten's field shape (nested price/saleprice, linkid/linkurl, nested category).
- **awin-sync.ts / providers/awin.ts** — per-advertiser product data feeds via `productdata.awin.com` with JSON + column selection (26 columns of the 100+ available). Config takes a list of `{feed_id, advertiser_id, advertiser_name?}` objects so a single publisher account can import multiple advertisers.
- **providers/index.ts** — two-line registration; registry now lists 5 providers.
- **app.js** — form helper handles `type:'textarea'` (monospace textarea); on submit, textarea values are `JSON.parse`'d so Awin's feeds array round-trips as structured data.
- **index.html** — cache-bust bumped.

## Ship-idle behavior
Both providers ship without credentials. Daily cron runs but skips them until an admin creates a source row via Command Hub → Admin → Marketplace Shops.

## Test plan
- [x] `tsc --noEmit` clean
- [x] `node --check app.js` clean
- [x] Registry smoke: all 5 providers load (`shopify`, `cj`, `amazon`, `rakuten`, `awin`)
- [x] Rakuten validator: bearer_token required, max_pages range check (1-20)
- [x] Awin validator: accepts feeds as array OR JSON string; rejects bad JSON, missing feed_id/advertiser_id, empty arrays
- [ ] Post-merge: `/api/v1/admin/marketplace/providers` lists all 5
- [ ] Post-merge: Add-shop form for Awin renders a textarea for feeds
- [ ] Live sync — deferred until credentials provisioned

🤖 Generated with [Claude Code](https://claude.com/claude-code)