### PR TITLE
fix(orb): reject stale Bearer tokens on /live/session/start (BOOTSTRAP-ORB-AUTH-REJECT)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -8550,6 +8550,23 @@ router.post('/live/session/start', optionalAuth, async (req: AuthenticatedReques
     return res.status(403).json({ ok: false, error: 'Origin not allowed' });
   }
 
+  // VTID-AUTH-BACKEND-REJECT: If a Bearer token was provided but the JWT
+  // failed verification, reject with 401 so the client knows to re-auth.
+  // optionalAuth silently drops invalid tokens, which is fine for truly
+  // anonymous widget requests on public pages (no Authorization header),
+  // but lets stale authenticated sessions degrade into anonymous greetings —
+  // which is how logged-in users ended up hearing the first-time intro
+  // speech after their JWT expired in the background.
+  const authHeader = req.headers.authorization;
+  if (authHeader && authHeader.startsWith('Bearer ') && !req.identity) {
+    console.warn('[VTID-AUTH-BACKEND-REJECT] Bearer token provided but JWT failed verification — returning 401');
+    return res.status(401).json({
+      ok: false,
+      error: 'AUTH_TOKEN_INVALID',
+      message: 'Session expired or invalid — please re-authenticate',
+    });
+  }
+
   const body = req.body as LiveSessionStartRequest;
   const clientRequestedLang = body.lang; // may be undefined if client didn't specify
   console.log(`[LANG-PREF] Client requested lang: '${clientRequestedLang || 'NONE'}' (from POST body.lang)`);


### PR DESCRIPTION
## Summary
- `/live/session/start` kept `optionalAuth`, but now rejects with 401 `AUTH_TOKEN_INVALID` when a Bearer header is provided but the JWT fails verification
- Requests with no Authorization header still flow through as anonymous (public-page widget behavior unchanged)

## Why
The widget cached the authToken at init time. When the user backgrounded the app long enough for the JWT to expire, the widget re-used that stale token on the next session-start — and the backend silently treated the call as anonymous, so the user heard the first-time intro speech instead of being redirected to login. Paired with vitana-v1 PR #159 (frontend probes `/auth/me` and signs out on 401); this is defense-in-depth.

## Test plan
- [ ] Call `/live/session/start` with no Authorization header → still succeeds (anonymous)
- [ ] Call `/live/session/start` with a valid Bearer → succeeds (authenticated)
- [ ] Call `/live/session/start` with an expired/forged Bearer → now returns 401 `AUTH_TOKEN_INVALID`

\ud83e\udd16 Generated with [Claude Code](https://claude.com/claude-code)