### PR TITLE
fix(orb): unwedge Vertex Live when tool-loop guard trips

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -4745,12 +4745,31 @@ async function connectToLiveAPI(
           const functionCalls = toolCall.function_calls || toolCall.functionCalls || [];
 
           // VTID-TOOLGUARD: If too many consecutive tool calls without audio,
-          // stop sending function_responses. This forces Gemini to respond
-          // to the user with whatever data it has already gathered.
+          // we break the loop by sending synthetic responses that instruct
+          // Gemini to answer with data already gathered. Previously we silently
+          // DROPPED the responses — but that left Gemini blocked waiting on
+          // function_responses that never arrived, producing zombie upstream
+          // sessions (no input_transcription, no audio) and ultimately
+          // `watchdog_fired` with reason `forwarding_no_ack`. Sending a
+          // synthetic response keeps the Live API protocol intact while still
+          // forcing the model out of the tool-call loop.
           if (session.consecutiveToolCalls > MAX_CONSECUTIVE_TOOL_CALLS) {
-            console.warn(`[VTID-TOOLGUARD] Tool call loop detected for session ${session.sessionId}: ${session.consecutiveToolCalls} consecutive calls (limit: ${MAX_CONSECUTIVE_TOOL_CALLS}). Dropping tool response to break loop.`);
+            console.warn(`[VTID-TOOLGUARD] Tool call loop detected for session ${session.sessionId}: ${session.consecutiveToolCalls} consecutive calls (limit: ${MAX_CONSECUTIVE_TOOL_CALLS}). Sending synthetic loop-break response.`);
             emitDiag(session, 'tool_loop_guard', { consecutive: session.consecutiveToolCalls, dropped_tools: toolNames });
-            // Skip tool execution — don't send function_response back to Gemini
+            emitLiveSessionEvent('orb.live.tool_loop_guard_activated', {
+              session_id: session.sessionId,
+              consecutive: session.consecutiveToolCalls,
+              tools: toolNames,
+              function_call_count: functionCalls.length,
+            }, 'warning').catch(() => { });
+            for (const fc of functionCalls) {
+              const callId = fc.id || randomUUID();
+              sendFunctionResponseToLiveAPI(ws, callId, fc.name, {
+                success: false,
+                result: '',
+                error: 'Tool loop guard: too many consecutive tool calls. Respond to the user now with the information already gathered from earlier tool results. Do not call any more tools in this turn.',
+              });
+            }
           } else {
             for (const fc of functionCalls) {
             const toolName = fc.name;
@@ -8465,9 +8484,9 @@ async function fetchLastSessionInfo(userId: string): Promise<{ time: string; was
  * VTID-01155: Helper to emit Live session events to OASIS
  */
 async function emitLiveSessionEvent(
-  eventType: 'vtid.live.session.start' | 'vtid.live.session.stop' | 'vtid.live.audio.in.chunk' | 'vtid.live.video.in.frame' | 'vtid.live.audio.out.chunk' | 'orb.live.config_missing' | 'orb.live.connection_failed' | 'orb.live.stall_detected' | 'orb.live.diag' | 'orb.live.fallback_used' | 'orb.live.fallback_error',
+  eventType: 'vtid.live.session.start' | 'vtid.live.session.stop' | 'vtid.live.audio.in.chunk' | 'vtid.live.video.in.frame' | 'vtid.live.audio.out.chunk' | 'orb.live.config_missing' | 'orb.live.connection_failed' | 'orb.live.stall_detected' | 'orb.live.diag' | 'orb.live.fallback_used' | 'orb.live.fallback_error' | 'orb.live.tool_loop_guard_activated',
   payload: Record<string, unknown>,
-  status: 'info' | 'error' = 'info'
+  status: 'info' | 'warning' | 'error' = 'info'
 ): Promise<void> {
   try {
     await emitOasisEvent({

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -495,6 +495,8 @@ export type CicdEventType =
   | 'orb.live.connection_failed'
   // VTID-WATCHDOG: ORB stall detection events
   | 'orb.live.stall_detected'
+  // VTID-TOOLGUARD: Tool loop guard activation
+  | 'orb.live.tool_loop_guard_activated'
   // VTID-DIAG: Pipeline diagnostics
   | 'orb.live.diag'
   // VTID-FALLBACK: Chat-TTS fallback events


### PR DESCRIPTION
## Summary

Root cause of frequent watchdog_fired / forwarding_no_ack disconnects on Vertex Live API.

When consecutiveToolCalls > MAX_CONSECUTIVE_TOOL_CALLS (5), we silently **dropped** the function_response. Per the Live API protocol, Gemini then blocks waiting for responses to function_calls it sent — the upstream WS stays OPEN but Vertex never emits input_transcription, audio, or text. 15s later the response watchdog fires with reason forwarding_no_ack and terminates the upstream. User experiences this as "the orb disconnects for no reason mid-conversation."

## Fix

On loop detection, send a **synthetic** function_response per function_call telling the model to respond with data already gathered. Keeps the protocol intact while still forcing the model out of the loop.

Also emits orb.live.tool_loop_guard_activated as a warning so we can correlate loop-guard trips with watchdog fires in production to confirm this was the dominant failure mode.

## Scope

- services/gateway/src/routes/orb-live.ts — replace silent drop with synthetic responses
- services/gateway/src/types/cicd.ts — register new OASIS event type

Unblocks the UX improvements shipped in #730 (reconnect honesty) + #731 (greeting latency).

VTID tag BOOTSTRAP-ORB-RELIABILITY on the merge commit will fire Auto-Deploy → EXEC-DEPLOY on the gateway.

## Test plan

- [x] TypeScript typecheck passes
- [ ] Post-deploy: verify orb.live.tool_loop_guard_activated events appear for sessions that previously stalled on forwarding_no_ack
- [ ] Post-deploy: measure drop in watchdog_fired events over 24h
- [ ] User smoke test on vitanaland.com

🤖 Generated with [Claude Code](https://claude.com/claude-code)