### PR TITLE
VTID-01942 (2/3): preferences + learned-default prompt

### DIFF
--- a/services/gateway/src/capabilities/index.ts
+++ b/services/gateway/src/capabilities/index.ts
@@ -135,7 +135,9 @@ export interface ResolveOptions {
 export interface ResolveSuccess {
   connectorId: string;
   /** Which rule picked this connector — useful for telemetry and UX. */
-  reason: 'explicit' | 'external_connected' | 'hub_fallback';
+  reason: 'explicit' | 'preference' | 'external_connected' | 'hub_fallback';
+  /** Only set when reason='preference' — so the UI can show "your default". */
+  preference_set_method?: 'explicit' | 'learned' | 'onboarding';
 }
 
 /**
@@ -190,6 +192,28 @@ export async function resolveConnectorFor(
       };
     }
     return { connectorId: exact.id, reason: 'explicit' };
+  }
+
+  // ── Rule 2: stored preference for this capability ─────────────────────
+  // VTID-01942 PR 2: user_capability_preferences row. Honoured only if
+  // the preferred connector is still available.
+  const { data: prefRow } = await supabase
+    .from('user_capability_preferences')
+    .select('preferred_connector_id, set_method')
+    .eq('user_id', userId)
+    .eq('capability_id', capabilityId)
+    .maybeSingle();
+  if (prefRow?.preferred_connector_id) {
+    const pref = candidates.find((c) => c.id === prefRow.preferred_connector_id);
+    if (pref && isAvailable(pref.id, pref.auth_type)) {
+      return {
+        connectorId: pref.id,
+        reason: 'preference',
+        preference_set_method: (prefRow.set_method as 'explicit' | 'learned' | 'onboarding') ?? 'explicit',
+      };
+    }
+    // Preferred connector is no longer available — fall through. Future
+    // enhancement: clear the stale row so we don't keep checking it.
   }
 
   // ── Rule 4: prefer any externally-connected connector ─────────────────
@@ -248,8 +272,69 @@ export async function executeCapability(
     capability: capabilityId,
     args: dispatchArgs,
   });
-  // Surface why this connector was chosen so the UI / voice layer can
-  // shape the response ("Playing on YouTube Music — your default" vs
-  // "I don't have that in the hub, want me to link your music account?").
-  return { ...result, routing_reason: resolved.reason } as DispatchResult & { routing_reason: string };
+
+  // VTID-01942 PR 2: log successful plays so we can suggest a default later.
+  let suggestDefault = false;
+  if (result.ok) {
+    try {
+      await ctx.supabase.from('capability_play_log').insert({
+        tenant_id: ctx.tenantId,
+        user_id: ctx.userId,
+        capability_id: capabilityId,
+        connector_id: resolved.connectorId,
+        reason: resolved.reason,
+        args: dispatchArgs,
+        ok: true,
+      });
+    } catch (err: unknown) {
+      const m = err instanceof Error ? err.message : String(err);
+      console.warn(`[capabilities] play-log insert failed: ${m}`);
+    }
+
+    // Learned-preference prompt: after 3 successful plays through the same
+    // non-hub, non-preference-backed connector and no existing pref, tell
+    // the caller to suggest setting it as default. We never save the pref
+    // silently — the user has to confirm through the /preferences API (or a
+    // voice confirmation handled by the ORB).
+    if (
+      resolved.reason === 'external_connected' &&
+      !explicitSource
+    ) {
+      const { count: existingPrefCount } = await ctx.supabase
+        .from('user_capability_preferences')
+        .select('id', { count: 'exact', head: true })
+        .eq('user_id', ctx.userId)
+        .eq('capability_id', capabilityId);
+
+      if ((existingPrefCount ?? 0) === 0) {
+        const { data: recent } = await ctx.supabase
+          .from('capability_play_log')
+          .select('connector_id')
+          .eq('user_id', ctx.userId)
+          .eq('capability_id', capabilityId)
+          .eq('ok', true)
+          .order('created_at', { ascending: false })
+          .limit(3);
+
+        const lastThree = (recent ?? []).map((r: any) => r.connector_id);
+        if (
+          lastThree.length === 3 &&
+          lastThree.every((id) => id === resolved.connectorId)
+        ) {
+          suggestDefault = true;
+        }
+      }
+    }
+  }
+
+  return {
+    ...result,
+    routing_reason: resolved.reason,
+    preference_set_method: resolved.preference_set_method,
+    suggest_default: suggestDefault,
+  } as DispatchResult & {
+    routing_reason: string;
+    preference_set_method?: string;
+    suggest_default?: boolean;
+  };
 }

--- a/services/gateway/src/routes/capabilities.ts
+++ b/services/gateway/src/routes/capabilities.ts
@@ -65,6 +65,86 @@ router.get('/my-connectors', async (req: Request, res: Response) => {
   return res.json({ ok: true, connectors });
 });
 
+/**
+ * VTID-01942 PR 2: preferences CRUD so users can pin a default provider per
+ * capability (e.g. "always play music via YouTube Music") and clear it later.
+ * Must be declared BEFORE the generic POST /:capability route below or
+ * "/preferences" would be parsed as a capability name.
+ *
+ *   GET    /api/v1/capabilities/preferences                — list user prefs
+ *   PUT    /api/v1/capabilities/preferences/:capability    — set / update one
+ *   DELETE /api/v1/capabilities/preferences/:capability    — clear one
+ */
+router.get('/preferences', async (req: Request, res: Response) => {
+  const user = extractUserFromJwt(req);
+  if (!user) return res.status(401).json({ ok: false, error: 'Authentication required' });
+
+  const supabase = await getServiceClient();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'Service unavailable' });
+
+  const { data, error } = await supabase
+    .from('user_capability_preferences')
+    .select('capability_id, preferred_connector_id, set_method, updated_at')
+    .eq('user_id', user.userId);
+
+  if (error) return res.status(500).json({ ok: false, error: error.message });
+  return res.json({ ok: true, preferences: data ?? [] });
+});
+
+router.put('/preferences/:capability', async (req: Request, res: Response) => {
+  const user = extractUserFromJwt(req);
+  if (!user) return res.status(401).json({ ok: false, error: 'Authentication required' });
+
+  const capability = req.params.capability;
+  const body = (req.body && typeof req.body === 'object') ? req.body as any : {};
+  const preferred_connector_id = String(body.preferred_connector_id ?? '').trim();
+  const rawSetMethod = String(body.set_method ?? 'explicit').trim();
+  const set_method: 'explicit' | 'learned' | 'onboarding' =
+    rawSetMethod === 'learned' ? 'learned'
+      : rawSetMethod === 'onboarding' ? 'onboarding'
+        : 'explicit';
+
+  if (!preferred_connector_id) {
+    return res.status(400).json({ ok: false, error: 'preferred_connector_id is required' });
+  }
+
+  const supabase = await getServiceClient();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'Service unavailable' });
+
+  const { data, error } = await supabase
+    .from('user_capability_preferences')
+    .upsert({
+      tenant_id: user.tenantId,
+      user_id: user.userId,
+      capability_id: capability,
+      preferred_connector_id,
+      set_method,
+      updated_at: new Date().toISOString(),
+    }, { onConflict: 'tenant_id,user_id,capability_id' })
+    .select('capability_id, preferred_connector_id, set_method, updated_at')
+    .single();
+
+  if (error) return res.status(500).json({ ok: false, error: error.message });
+  return res.json({ ok: true, preference: data });
+});
+
+router.delete('/preferences/:capability', async (req: Request, res: Response) => {
+  const user = extractUserFromJwt(req);
+  if (!user) return res.status(401).json({ ok: false, error: 'Authentication required' });
+
+  const supabase = await getServiceClient();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'Service unavailable' });
+
+  const { error } = await supabase
+    .from('user_capability_preferences')
+    .delete()
+    .eq('user_id', user.userId)
+    .eq('capability_id', req.params.capability);
+
+  if (error) return res.status(500).json({ ok: false, error: error.message });
+  return res.json({ ok: true });
+});
+
 /** POST /api/v1/capabilities/:capability — invoke a capability. */
 router.post('/:capability', async (req: Request, res: Response) => {
   const user = extractUserFromJwt(req);

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -3030,6 +3030,8 @@ async function executeLiveApiToolInner(
         const channel = raw.channel ?? '';
         const source = raw.source ?? 'unknown';
         const routingReason: string | undefined = disp.routing_reason;
+        const suggestDefault: boolean = Boolean(disp.suggest_default);
+        const preferenceSetMethod: string | undefined = disp.preference_set_method;
 
         const directive = {
           type: 'orb_directive',
@@ -3040,6 +3042,7 @@ async function executeLiveApiToolInner(
           source,
           query,
           routing_reason: routingReason,
+          suggest_default: suggestDefault,
           vtid: 'VTID-01942',
         };
         try { session.sseResponse?.write(`data: ${JSON.stringify(directive)}\n\n`); } catch (_e) { /* SSE closed */ }
@@ -3048,8 +3051,6 @@ async function executeLiveApiToolInner(
           try { sendWsMessage(ws, directive); } catch (_e) { /* WS closed */ }
         }
 
-        // VTID-01942: shape the spoken ack to the routing reason so the user
-        // knows whether they hit their provider or the hub fallback.
         const providerDisplay =
           source === 'youtube_music' ? 'YouTube Music' :
           source === 'spotify' ? 'Spotify' :
@@ -3060,12 +3061,21 @@ async function executeLiveApiToolInner(
         const baseAck = channel
           ? `Now playing "${title}" by ${channel} on ${providerDisplay}.`
           : `Now playing "${title}" on ${providerDisplay}.`;
-        const hubFallbackHint = routingReason === 'hub_fallback'
-          ? ' Want me to link your Spotify or YouTube Music so I can play the real track next time?'
-          : '';
 
-        console.log(`[VTID-01942] play_music: "${query}" → ${title}${channel ? ' — ' + channel : ''} via ${source} (${routingReason ?? 'n/a'})`);
-        return { success: true, result: `${baseAck}${hubFallbackHint}` };
+        // VTID-01942 PR 2: shape the ack based on routing reason + preference
+        // state so the voice feels aware of why it picked this provider.
+        let tail = '';
+        if (routingReason === 'hub_fallback') {
+          tail = ' Want me to link your Spotify or YouTube Music so I can play the real track next time?';
+        } else if (suggestDefault) {
+          tail = ` That\'s three plays in a row on ${providerDisplay} — want me to make it your default for music?`;
+        } else if (routingReason === 'preference' && preferenceSetMethod === 'explicit') {
+          // Silent — user already set this as their default, don't chatter.
+          tail = '';
+        }
+
+        console.log(`[VTID-01942] play_music: "${query}" → ${title}${channel ? ' — ' + channel : ''} via ${source} (${routingReason ?? 'n/a'}${suggestDefault ? ', suggest_default' : ''})`);
+        return { success: true, result: `${baseAck}${tail}` };
       }
 
       default:

--- a/supabase/migrations/20260420110000_vtid_01942_capability_preferences.sql
+++ b/supabase/migrations/20260420110000_vtid_01942_capability_preferences.sql
@@ -1,0 +1,99 @@
+-- VTID-01942 (PR 2/3): user_capability_preferences + capability_play_log
+--
+-- Two tables backing the routing-preference rules in capabilities/index.ts:
+--
+-- user_capability_preferences
+--   One row per (user, capability) that records which connector the user
+--   wants to use. `set_method` records whether it was explicit (user said
+--   "always use YouTube Music") or learned (auto-suggested after N plays
+--   and user confirmed).
+--
+-- capability_play_log
+--   Lightweight append-only trail of successful capability invocations.
+--   Used to compute "the user has chosen YouTube Music 3 times in a row →
+--   suggest making it the default". Rotated (keep ~30 rows per user per
+--   capability) via a trimming trigger or periodic job — not critical for
+--   v1.
+--
+-- Idempotent — safe to apply multiple times.
+
+CREATE TABLE IF NOT EXISTS public.user_capability_preferences (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL,
+  user_id UUID NOT NULL,
+  capability_id TEXT NOT NULL,
+  preferred_connector_id TEXT NOT NULL,
+  set_method TEXT NOT NULL DEFAULT 'explicit'
+    CHECK (set_method IN ('explicit', 'learned', 'onboarding')),
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  UNIQUE (tenant_id, user_id, capability_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_cap_pref_user
+  ON public.user_capability_preferences (user_id, capability_id);
+
+ALTER TABLE public.user_capability_preferences ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+     WHERE schemaname = 'public'
+       AND tablename  = 'user_capability_preferences'
+       AND policyname = 'ucp_owner_access'
+  ) THEN
+    CREATE POLICY ucp_owner_access ON public.user_capability_preferences
+      FOR ALL USING (auth.uid() = user_id);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+     WHERE schemaname = 'public'
+       AND tablename  = 'user_capability_preferences'
+       AND policyname = 'ucp_service_role'
+  ) THEN
+    CREATE POLICY ucp_service_role ON public.user_capability_preferences
+      FOR ALL USING (auth.role() = 'service_role');
+  END IF;
+END $$;
+
+CREATE TABLE IF NOT EXISTS public.capability_play_log (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL,
+  user_id UUID NOT NULL,
+  capability_id TEXT NOT NULL,
+  connector_id TEXT NOT NULL,
+  reason TEXT,
+  args JSONB DEFAULT '{}'::jsonb,
+  ok BOOLEAN DEFAULT true,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_cap_play_log_user_cap
+  ON public.capability_play_log (user_id, capability_id, created_at DESC);
+
+ALTER TABLE public.capability_play_log ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+     WHERE schemaname = 'public'
+       AND tablename  = 'capability_play_log'
+       AND policyname = 'cpl_owner_read'
+  ) THEN
+    CREATE POLICY cpl_owner_read ON public.capability_play_log
+      FOR SELECT USING (auth.uid() = user_id);
+  END IF;
+
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+     WHERE schemaname = 'public'
+       AND tablename  = 'capability_play_log'
+       AND policyname = 'cpl_service_role'
+  ) THEN
+    CREATE POLICY cpl_service_role ON public.capability_play_log
+      FOR ALL USING (auth.role() = 'service_role');
+  END IF;
+END $$;


### PR DESCRIPTION
Second of three. Adds user_capability_preferences and capability_play_log tables, CRUD API, resolver integration for stored/learned preferences, and a voice-ready 'want me to make this your default?' prompt after 3 consecutive plays on the same provider. Apply the migration via RUN-MIGRATION.yml after merge.