### PR TITLE
feat(auth): 6-hour idle session for developer role (BOOTSTRAP-DEV-6H-SESSION)

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -930,7 +930,11 @@ async function doLogin(email, password) {
         // Store refresh token for later use
         if (data.refresh_token) {
             localStorage.setItem('vitana.refreshToken', data.refresh_token);
+            // BOOTSTRAP-DEV-6H-SESSION: keep in state for silent-refresh path
+            state.refreshToken = data.refresh_token;
         }
+        // Reset activity clock at login so the 6h idle window starts fresh.
+        state.lastActivityAt = Date.now();
 
         // VTID-01196: Store login email as fallback for profile display
         // This ensures we can show user info even if /auth/me fails
@@ -1202,6 +1206,7 @@ function renderAuthGate() {
 function doLogout() {
     // Clear auth state
     state.authToken = null;
+    state.refreshToken = null; // BOOTSTRAP-DEV-6H-SESSION
     state.authIdentity = null;
     state.meContext = null;
     state.loginUserEmail = null; // VTID-01196: Clear login email fallback
@@ -2978,6 +2983,13 @@ const state = {
     meContextError: null,
     // Auth token for API calls (set via dev-auth or Supabase session)
     authToken: localStorage.getItem('vitana.authToken') || null,
+
+    // BOOTSTRAP-DEV-6H-SESSION: refresh token + activity tracking for 6h
+    // extended sessions (developer role only). Non-developer roles continue
+    // to log out at JWT expiry (~1h) per current security posture.
+    refreshToken: localStorage.getItem('vitana.refreshToken') || null,
+    lastActivityAt: Date.now(),
+    refreshingToken: false,
 
     // VTID-01171: Auth Identity from /api/v1/auth/me
     // Contains user identity (email, user_id), profile (display_name, avatar_url), memberships
@@ -34090,31 +34102,113 @@ document.addEventListener('DOMContentLoaded', async () => {
             fetchAutopilotRecommendationsCount()
         ]).catch(err => console.error('Data Fetch Error:', err));
 
-        // VTID-AUTH-GUARD: Active session health monitor.
-        // The JWT in state.authToken can expire while the user is idle.
-        // Without this, the user stays on the Command Hub looking logged in
-        // but every action will 401. Poll every 30s by decoding the JWT exp
-        // claim — if expired, force logout to show the auth gate.
-        // Also check immediately when the tab/WebView returns to foreground.
-        function checkTokenExpiry() {
+        // VTID-AUTH-GUARD + BOOTSTRAP-DEV-6H-SESSION: Active session health monitor.
+        //
+        // Baseline (all roles): JWT expires (~1h for Supabase) → doLogout().
+        //
+        // Developer override: if active_role === 'developer', silently refresh
+        // the access token via /api/v1/auth/refresh whenever it's within 5 min
+        // of expiry, so the developer stays signed in while working. Only log
+        // out after 6 hours of true user inactivity (no mousedown/keydown/
+        // scroll/touchstart) OR when refresh fails (e.g. refresh token revoked
+        // server-side). This is scoped to developer only — community, admin,
+        // staff, professional, patient keep the stricter 1h hard expiry.
+        var DEV_IDLE_LOGOUT_MS = 6 * 60 * 60 * 1000;  // 6 hours
+        var TOKEN_REFRESH_LEAD_MS = 5 * 60 * 1000;     // refresh if <5m left
+
+        function isDeveloperSession() {
+            return (state.meContext && state.meContext.active_role === 'developer');
+        }
+
+        function markActivity() { state.lastActivityAt = Date.now(); }
+        ['mousedown', 'keydown', 'scroll', 'touchstart'].forEach(function (evt) {
+            document.addEventListener(evt, markActivity, { passive: true, capture: true });
+        });
+
+        async function refreshAccessToken() {
+            if (state.refreshingToken) return false;
+            if (!state.refreshToken) return false;
+            state.refreshingToken = true;
+            try {
+                var resp = await fetch('/api/v1/auth/refresh', {
+                    method: 'POST',
+                    headers: { 'Content-Type': 'application/json' },
+                    body: JSON.stringify({ refresh_token: state.refreshToken })
+                });
+                var data = await resp.json();
+                if (!resp.ok || !data.ok || !data.access_token) {
+                    console.warn('[DEV-6H-SESSION] refresh failed:', data && (data.message || data.error));
+                    return false;
+                }
+                state.authToken = data.access_token;
+                localStorage.setItem('vitana.authToken', data.access_token);
+                if (data.refresh_token) {
+                    state.refreshToken = data.refresh_token;
+                    localStorage.setItem('vitana.refreshToken', data.refresh_token);
+                }
+                if (window.VitanaOrb && typeof window.VitanaOrb.setAuth === 'function') {
+                    window.VitanaOrb.setAuth(data.access_token);
+                }
+                console.log('[DEV-6H-SESSION] access token refreshed silently');
+                return true;
+            } catch (err) {
+                console.warn('[DEV-6H-SESSION] refresh threw:', err && err.message);
+                return false;
+            } finally {
+                state.refreshingToken = false;
+            }
+        }
+
+        async function checkTokenExpiry() {
             if (!state.authToken) return;
+            var payload;
             try {
                 var parts = state.authToken.split('.');
                 if (parts.length !== 3) return;
-                var payload = JSON.parse(atob(parts[1]));
-                if (payload.exp && payload.exp * 1000 < Date.now()) {
-                    console.warn('[VTID-AUTH-GUARD] JWT expired — logging out');
+                payload = JSON.parse(atob(parts[1]));
+            } catch (e) {
+                console.warn('[VTID-AUTH-GUARD] Cannot parse JWT — logging out');
+                doLogout();
+                return;
+            }
+
+            var expMs = (payload && payload.exp) ? payload.exp * 1000 : 0;
+            var now = Date.now();
+
+            if (isDeveloperSession()) {
+                // Developer: enforce 6h idle logout FIRST — if idle for 6h,
+                // don't bother refreshing, just sign out.
+                var idleMs = now - (state.lastActivityAt || now);
+                if (idleMs >= DEV_IDLE_LOGOUT_MS) {
+                    console.warn('[DEV-6H-SESSION] idle ' + Math.round(idleMs / 60000) + 'm — logging out');
+                    doLogout();
+                    return;
+                }
+                // Token fresh enough — nothing to do.
+                if (expMs && expMs - now > TOKEN_REFRESH_LEAD_MS) return;
+                // Token expired or near expiry — try silent refresh.
+                var refreshed = await refreshAccessToken();
+                if (!refreshed) {
+                    console.warn('[DEV-6H-SESSION] cannot refresh — logging out');
                     doLogout();
                 }
-            } catch (e) {
-                // Malformed token — force logout
-                console.warn('[VTID-AUTH-GUARD] Cannot parse JWT — logging out');
+                return;
+            }
+
+            // Non-developer roles: keep the existing strict behavior.
+            if (expMs && expMs < now) {
+                console.warn('[VTID-AUTH-GUARD] JWT expired — logging out');
                 doLogout();
             }
         }
+
         setInterval(checkTokenExpiry, 30000);
         document.addEventListener('visibilitychange', function () {
-            if (document.visibilityState === 'visible') checkTokenExpiry();
+            if (document.visibilityState === 'visible') {
+                // Returning to the tab counts as activity for developers.
+                if (isDeveloperSession()) markActivity();
+                checkTokenExpiry();
+            }
         });
 
         // Initialize unified VitanaOrb widget (voice overlay handled by orb-widget.js)

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -12,7 +12,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260328-aura"></script>
-  <script src="/command-hub/app.js?v=20260419-vtid01938-textarea-field"></script>
+  <script src="/command-hub/app.js?v=20260420-dev-6h-session"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js"></script>
 </body>

--- a/services/gateway/src/routes/auth.ts
+++ b/services/gateway/src/routes/auth.ts
@@ -296,6 +296,93 @@ router.post('/login', async (req: Request, res: Response) => {
 });
 
 /**
+ * BOOTSTRAP-DEV-6H-SESSION: POST /refresh
+ *
+ * Exchange a Supabase refresh_token for a fresh access_token + refresh_token.
+ * Proxies to Supabase GoTrue `/token?grant_type=refresh_token`. Does NOT
+ * require an Authorization header — the refresh token IS the credential.
+ *
+ * Body:
+ *   { "refresh_token": "..." }
+ *
+ * Success (200):
+ *   { "ok": true, "access_token", "refresh_token", "expires_in", "token_type" }
+ *
+ * Failure (401):
+ *   { "ok": false, "error": "INVALID_REFRESH_TOKEN", "message": "..." }
+ */
+router.post('/refresh', async (req: Request, res: Response) => {
+  const { refresh_token } = req.body || {};
+
+  if (!refresh_token || typeof refresh_token !== 'string') {
+    return res.status(400).json({
+      ok: false,
+      error: 'INVALID_INPUT',
+      message: 'refresh_token is required',
+    });
+  }
+
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
+
+  if (!supabaseUrl || !supabaseAnonKey) {
+    console.error('[BOOTSTRAP-DEV-6H-SESSION] POST /auth/refresh - Missing Supabase config');
+    return res.status(500).json({
+      ok: false,
+      error: 'INTERNAL_ERROR',
+      message: 'Supabase configuration not available',
+    });
+  }
+
+  try {
+    const authResponse = await fetch(`${supabaseUrl}/auth/v1/token?grant_type=refresh_token`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        'apikey': supabaseAnonKey,
+      },
+      body: JSON.stringify({ refresh_token }),
+    });
+
+    const authData = await authResponse.json() as {
+      access_token?: string;
+      refresh_token?: string;
+      expires_in?: number;
+      token_type?: string;
+      error?: string;
+      error_description?: string;
+      msg?: string;
+    };
+
+    if (!authResponse.ok || !authData.access_token) {
+      console.warn(
+        `[BOOTSTRAP-DEV-6H-SESSION] POST /auth/refresh - failed: ${authData.error || authData.msg || authResponse.status}`
+      );
+      return res.status(401).json({
+        ok: false,
+        error: 'INVALID_REFRESH_TOKEN',
+        message: authData.error_description || authData.msg || 'Refresh token is invalid or expired',
+      });
+    }
+
+    return res.status(200).json({
+      ok: true,
+      access_token: authData.access_token,
+      refresh_token: authData.refresh_token,
+      expires_in: authData.expires_in,
+      token_type: authData.token_type || 'bearer',
+    });
+  } catch (err: any) {
+    console.error('[BOOTSTRAP-DEV-6H-SESSION] POST /auth/refresh - Exception:', err.message);
+    return res.status(500).json({
+      ok: false,
+      error: 'INTERNAL_ERROR',
+      message: 'Token refresh service error',
+    });
+  }
+});
+
+/**
  * GET /me
  *
  * Returns the authenticated user's identity, profile, and memberships.


### PR DESCRIPTION
## Summary
- Developer-role sessions now survive past the 1h Supabase JWT expiry: silent token refresh keeps them alive while the user is active, and logout fires only after 6 hours of true inactivity.
- Non-developer roles (community, admin, staff, professional, patient) keep the existing strict logout-on-expiry behavior.
- Adds `POST /api/v1/auth/refresh` gateway endpoint proxying Supabase's `grant_type=refresh_token`.

## Changes
- `services/gateway/src/routes/auth.ts` — new `/refresh` endpoint
- `services/gateway/src/frontend/command-hub/app.js` — activity tracker, refresh loop, role-gated logout logic
- `services/gateway/src/frontend/command-hub/index.html` — bump `app.js?v=` cache-buster

## Test plan
- [ ] `EXEC-DEPLOY` completes and the gateway revision bumps
- [ ] `curl -X POST /api/v1/auth/refresh` with no body → 400 INVALID_INPUT JSON (not HTML 404)
- [ ] `curl -X POST /api/v1/auth/refresh -d '{"refresh_token":"bogus"}'` → 401 INVALID_REFRESH_TOKEN JSON
- [ ] Log into Command Hub as developer, leave for >1h, interact → stay logged in (token silently rotates)
- [ ] Log into Command Hub as non-developer, leave for >1h → get logged out at JWT expiry as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)