### PR TITLE
VTID-01942: Append ?authuser=<email> to music.youtube.com URL

### DIFF
--- a/services/gateway/src/connectors/productivity/google.ts
+++ b/services/gateway/src/connectors/productivity/google.ts
@@ -178,9 +178,19 @@ const googleConnector: Connector = {
         if (!query) return { ok: false, error: 'music.play: "query" arg is required' };
         const hit = await youtubeSearchFirst(query, token);
         if (!hit) return { ok: false, error: `No YouTube result found for "${query}"` };
-        // YouTube Music on mobile is an App Link for music.youtube.com, so the
-        // same URL opens the app on Android and the web player on desktop.
-        const url = `https://music.youtube.com/watch?v=${encodeURIComponent(hit.videoId)}`;
+
+        // YouTube Music on mobile is an Android App Link for music.youtube.com,
+        // so the same URL opens the native app (already signed in → Premium,
+        // no ads). On desktop or when the app isn't installed, the browser
+        // opens music.youtube.com. Append &authuser=<email> so if the user
+        // has multiple Google accounts in Chrome, the right one is picked —
+        // which is what makes Premium playback work in the browser too.
+        const params = new URLSearchParams({ v: hit.videoId });
+        if (_ctx.provider_username) {
+          params.set('authuser', _ctx.provider_username);
+        }
+        const url = `https://music.youtube.com/watch?${params.toString()}`;
+
         return {
           ok: true,
           external_id: hit.videoId,
@@ -193,6 +203,7 @@ const googleConnector: Connector = {
             thumbnail: hit.thumbnail,
             source: 'youtube_music',
             query,
+            authuser: _ctx.provider_username ?? null,
           },
         };
       }

--- a/services/gateway/src/connectors/runtime/dispatcher.ts
+++ b/services/gateway/src/connectors/runtime/dispatcher.ts
@@ -48,10 +48,17 @@ async function loadConnection(
   supabase: SupabaseClient,
   userId: string,
   connectorId: string,
-): Promise<{ id: string; access_token: string; refresh_token: string | null; token_expires_at: string | null } | null> {
+): Promise<{
+  id: string;
+  access_token: string;
+  refresh_token: string | null;
+  token_expires_at: string | null;
+  provider_user_id: string | null;
+  provider_username: string | null;
+} | null> {
   const { data } = await supabase
     .from('social_connections')
-    .select('id, access_token, refresh_token, token_expires_at')
+    .select('id, access_token, refresh_token, token_expires_at, provider_user_id, provider_username')
     .eq('user_id', userId)
     .eq('provider', connectorId)
     .eq('is_active', true)
@@ -62,6 +69,8 @@ async function loadConnection(
     access_token: data.access_token,
     refresh_token: data.refresh_token ?? null,
     token_expires_at: data.token_expires_at ?? null,
+    provider_user_id: data.provider_user_id ?? null,
+    provider_username: data.provider_username ?? null,
   };
 }
 
@@ -153,6 +162,8 @@ export async function dispatchAction(
   let tokens: TokenPair;
   let refreshed = false;
   let storedId: string | undefined;
+  let providerUserId: string | undefined;
+  let providerUsername: string | undefined;
 
   if (connector.auth_type === 'none') {
     tokens = { access_token: '' };
@@ -172,6 +183,8 @@ export async function dispatchAction(
     tokens = refreshResult.tokens;
     refreshed = refreshResult.refreshed;
     storedId = stored.id;
+    providerUserId = stored.provider_user_id ?? undefined;
+    providerUsername = stored.provider_username ?? undefined;
   }
 
   const request: ActionRequest = {
@@ -182,7 +195,13 @@ export async function dispatchAction(
 
   try {
     const result = await connector.performAction(
-      { tenant_id: ctx.tenantId, user_id: ctx.userId, user_connection_id: storedId },
+      {
+        tenant_id: ctx.tenantId,
+        user_id: ctx.userId,
+        user_connection_id: storedId,
+        provider_user_id: providerUserId,
+        provider_username: providerUsername,
+      },
       tokens,
       request,
     );

--- a/services/gateway/src/connectors/types.ts
+++ b/services/gateway/src/connectors/types.ts
@@ -77,6 +77,14 @@ export interface ConnectorContext {
   tenant_id: string;
   user_id: string;
   user_connection_id?: string;
+  /**
+   * VTID-01942: provider-side identity pulled from social_connections when
+   * the dispatcher loaded the user's row. Used for URL decoration (e.g.
+   * music.youtube.com?authuser=<email>) so browser playback picks the
+   * signed-in account instead of anonymous.
+   */
+  provider_user_id?: string;
+  provider_username?: string;
 }
 
 export interface OAuthExchangeResult {


### PR DESCRIPTION
Carries provider_username from social_connections → ConnectorContext → Google connector so the music.youtube.com playback URL pins the right Google account. Restores Premium playback when the browser has multiple Google sessions.