### PR TITLE
VTID-01942: Mobile intent/universal-link URLs for YouTube Music

### DIFF
--- a/services/gateway/src/connectors/productivity/google.ts
+++ b/services/gateway/src/connectors/productivity/google.ts
@@ -179,25 +179,32 @@ const googleConnector: Connector = {
         const hit = await youtubeSearchFirst(query, token);
         if (!hit) return { ok: false, error: `No YouTube result found for "${query}"` };
 
-        // YouTube Music on mobile is an Android App Link for music.youtube.com,
-        // so the same URL opens the native app (already signed in → Premium,
-        // no ads). On desktop or when the app isn't installed, the browser
-        // opens music.youtube.com. Append &authuser=<email> so if the user
-        // has multiple Google accounts in Chrome, the right one is picked —
-        // which is what makes Premium playback work in the browser too.
+        // Three URL variants so the widget picks the right one per platform.
+        // Key insight: a mobile WebView (Appilix, Chrome Custom Tab, etc.)
+        // will happily *load* https://music.youtube.com inside itself,
+        // covering Vitana with a raw web player that isn't signed in. An
+        // intent:// URL with the YouTube Music package forces Android to
+        // hand off to the native app — already signed in with Premium.
         const params = new URLSearchParams({ v: hit.videoId });
-        if (_ctx.provider_username) {
-          params.set('authuser', _ctx.provider_username);
-        }
-        const url = `https://music.youtube.com/watch?${params.toString()}`;
+        if (_ctx.provider_username) params.set('authuser', _ctx.provider_username);
+        const webUrl = `https://music.youtube.com/watch?${params.toString()}`;
+        const androidIntent =
+          `intent://music.youtube.com/watch?v=${encodeURIComponent(hit.videoId)}` +
+          `#Intent;scheme=https;package=com.google.android.apps.youtube.music;` +
+          `S.browser_fallback_url=${encodeURIComponent(webUrl)};end`;
+        // youtubemusic:// is the iOS URL scheme the YouTube Music app
+        // registers — triggers the native app if installed.
+        const iosScheme = `youtubemusic://watch?v=${encodeURIComponent(hit.videoId)}`;
 
         return {
           ok: true,
           external_id: hit.videoId,
-          url,
+          url: webUrl,
           raw: {
             action: 'open_url',
-            url,
+            url: webUrl,
+            android_intent: androidIntent,
+            ios_scheme: iosScheme,
             title: hit.title,
             channel: hit.channel,
             thumbnail: hit.thumbnail,

--- a/services/gateway/src/frontend/command-hub/orb-widget.js
+++ b/services/gateway/src/frontend/command-hub/orb-widget.js
@@ -1007,14 +1007,43 @@
             console.warn('[VTOrb] orb_directive open_url received without url — ignoring');
             break;
           }
-          console.log('[VTOrb] orb_directive open_url: ' + (msg.title || msg.url) + (msg.source ? ' (' + msg.source + ')' : ''));
+
+          // VTID-01942: pick the right URL per platform. On mobile we want
+          // the native app (intent:// on Android, custom scheme on iOS) so
+          // YouTube Music / Spotify / etc. open as real apps instead of
+          // covering Vitana with an in-WebView web player.
+          var _ua = (typeof navigator !== 'undefined' && navigator.userAgent) ? navigator.userAgent : '';
+          var _isAndroid = /android/i.test(_ua);
+          var _isIOS = /iphone|ipad|ipod/i.test(_ua);
+          var _target = msg.url;
+          var _kind = 'web';
+          if (_isAndroid && msg.android_intent) {
+            _target = msg.android_intent;
+            _kind = 'android_intent';
+          } else if (_isIOS && msg.ios_scheme) {
+            _target = msg.ios_scheme;
+            _kind = 'ios_scheme';
+          }
+          console.log('[VTOrb] orb_directive open_url [' + _kind + ']: ' + (msg.title || _target) + (msg.source ? ' (' + msg.source + ')' : ''));
+
+          // Intent URLs + custom schemes must use location.href — the OS
+          // intercepts them, and window.open on them returns null without
+          // actually dispatching on some WebViews. For https URLs, prefer
+          // a new tab so Vitana stays visible in the original tab on desktop.
+          if (_kind !== 'web') {
+            try {
+              window.location.href = _target;
+            } catch (_e) {
+              console.error('[VTOrb] intent/scheme open failed, falling back to web:', _e);
+              try { window.open(msg.url, '_blank', 'noopener,noreferrer'); } catch (_e2) { /* give up */ }
+            }
+            break;
+          }
           try {
-            var _opened = window.open(msg.url, '_blank', 'noopener,noreferrer');
+            var _opened = window.open(_target, '_blank', 'noopener,noreferrer');
             if (!_opened) {
-              // Pop-up blocked — fall back to same-tab navigation so the
-              // user at least reaches the player instead of getting nothing.
               console.warn('[VTOrb] window.open blocked, falling back to location.href');
-              window.location.href = msg.url;
+              window.location.href = _target;
             }
           } catch (_e) {
             console.error('[VTOrb] open_url failed:', _e);

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -3089,10 +3089,20 @@ async function executeLiveApiToolInner(
         const suggestDefault: boolean = Boolean(disp.suggest_default);
         const preferenceSetMethod: string | undefined = disp.preference_set_method;
 
+        // VTID-01942: pass through per-platform URL variants so the widget
+        // can hand off to the native app on iOS/Android instead of loading
+        // the web player inside the WebView (which covers Vitana and shows
+        // ads). See orb-widget.js handling of directive='open_url'.
+        const rawRec = (disp.raw ?? {}) as Record<string, unknown>;
+        const androidIntent = typeof rawRec.android_intent === 'string' ? rawRec.android_intent : undefined;
+        const iosScheme = typeof rawRec.ios_scheme === 'string' ? rawRec.ios_scheme : undefined;
+
         const directive = {
           type: 'orb_directive',
           directive: 'open_url',
           url: disp.url,
+          android_intent: androidIntent,
+          ios_scheme: iosScheme,
           title,
           channel,
           source,


### PR DESCRIPTION
music.play now returns android_intent + ios_scheme variants; widget picks the right one per platform so mobile hands off to the native YT Music app (Premium, no ads).