### PR TITLE
fix(orb): iOS AudioContext unlock + pre_greeting_ms gauge

### DIFF
--- a/services/gateway/src/frontend/command-hub/orb-widget.js
+++ b/services/gateway/src/frontend/command-hub/orb-widget.js
@@ -451,11 +451,34 @@
     }
     var ctx = _s.playbackCtx;
 
-    // Resume if suspended (mobile)
+    // BOOTSTRAP-ORB-IOS-UNLOCK: if the context is suspended (common on iOS
+    // when audio arrives before the user has tapped, or after a route
+    // change), attempt resume. Previously the .catch was silent and chunks
+    // sat in the queue until _processQueue was called again. Now we log
+    // visibly, retry up to 3s, and emit an error if the context never
+    // unlocks so the client isn't left silent while UI says "listening".
     if (ctx.state === 'suspended') {
-      ctx.resume().then(function () { setTimeout(_processQueue, 50); }).catch(function () {});
+      if (!_s._resumeRetryStartedAt) _s._resumeRetryStartedAt = Date.now();
+      var elapsed = Date.now() - _s._resumeRetryStartedAt;
+      if (elapsed > 3000) {
+        console.error('[VTOrb] AudioContext failed to resume after 3s — audio will not play. State:', ctx.state);
+        _s._resumeRetryStartedAt = 0;
+        // Drop queued audio rather than leaving UI in a stuck state.
+        _s.audioQueue.length = 0;
+        return;
+      }
+      ctx.resume().then(function () {
+        _s._resumeRetryStartedAt = 0;
+        // Re-enter on next tick so any pending chunks drain.
+        setTimeout(_processQueue, 0);
+      }).catch(function (e) {
+        console.warn('[VTOrb] AudioContext resume rejected (elapsed=' + elapsed + 'ms):', e && e.message);
+        // Retry via the existing setTimeout cadence.
+        setTimeout(_processQueue, 50);
+      });
       return;
     }
+    _s._resumeRetryStartedAt = 0;
 
     var isFirstChunk = _s.scheduledSources.length === 0;
 
@@ -546,12 +569,28 @@
     _s.navigationPending = false;
     _s.signupClosing = false;
 
-    // Create playback AudioContext in user gesture (critical for mobile)
+    // BOOTSTRAP-ORB-IOS-UNLOCK: Create playback AudioContext inside the user
+    // gesture (critical for iOS — creating later or resuming later is
+    // unreliable across awaits). Also play a 1-sample silent buffer
+    // immediately: this is the canonical iOS unlock primitive. The chime
+    // below used to be the de-facto unlock but it fires *after* the fetch
+    // below on slower devices, losing the gesture window.
     if (!_s.playbackCtx || _s.playbackCtx.state === 'closed') {
       _s.playbackCtx = new (window.AudioContext || window.webkitAudioContext)();
     }
+    try {
+      var _silent = _s.playbackCtx.createBuffer(1, 1, 22050);
+      var _silentSrc = _s.playbackCtx.createBufferSource();
+      _silentSrc.buffer = _silent;
+      _silentSrc.connect(_s.playbackCtx.destination);
+      _silentSrc.start(0);
+    } catch (e) {
+      console.warn('[VTOrb] silent-buffer iOS unlock failed:', e && e.message);
+    }
     if (_s.playbackCtx.state === 'suspended') {
-      _s.playbackCtx.resume().catch(function () {});
+      _s.playbackCtx.resume().catch(function (e) {
+        console.warn('[VTOrb] playbackCtx resume rejected at session start:', e && e.message);
+      });
     }
 
     // Play activation chime immediately

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -4772,6 +4772,23 @@ async function connectToLiveAPI(
                   session.consecutiveToolCalls = 0;
                   console.log(`[VTID-VOICE-INIT] Model started speaking for session ${session.sessionId} — mic audio gated`);
                   emitDiag(session, 'model_start_speaking');
+                  // BOOTSTRAP-ORB-HOTFIX-1: If this is the greeting (no turns yet
+                  // and greeting was sent), emit the pre-greeting latency gauge
+                  // — baseline metric for Phase 1 latency work.
+                  if (session.greetingSent && session.turn_count === 0 && !session.audioOutChunks) {
+                    const preGreetingMs = Date.now() - session.createdAt.getTime();
+                    emitLiveSessionEvent('orb.live.greeting.delivered', {
+                      session_id: session.sessionId,
+                      user_id: session.identity?.user_id || 'anonymous',
+                      tenant_id: session.identity?.tenant_id || null,
+                      transport: session.clientWs ? 'websocket' : 'sse',
+                      pre_greeting_ms: preGreetingMs,
+                      lang: session.lang,
+                      is_anonymous: session.isAnonymous || false,
+                      reconnect_count: (session as any)._reconnectCount || 0,
+                    }).catch(() => { });
+                    console.log(`[BOOTSTRAP-ORB-HOTFIX-1] pre_greeting_ms=${preGreetingMs} for session ${session.sessionId}`);
+                  }
                 }
                 // VTID-WATCHDOG: Model is sending audio — restart watchdog.
                 // If audio stops mid-stream (no turn_complete), watchdog fires.
@@ -8644,7 +8661,7 @@ async function fetchLastSessionInfo(userId: string): Promise<{ time: string; was
  * VTID-01155: Helper to emit Live session events to OASIS
  */
 async function emitLiveSessionEvent(
-  eventType: 'vtid.live.session.start' | 'vtid.live.session.stop' | 'vtid.live.audio.in.chunk' | 'vtid.live.video.in.frame' | 'vtid.live.audio.out.chunk' | 'orb.live.config_missing' | 'orb.live.connection_failed' | 'orb.live.stall_detected' | 'orb.live.diag' | 'orb.live.fallback_used' | 'orb.live.fallback_error' | 'orb.live.tool_loop_guard_activated',
+  eventType: 'vtid.live.session.start' | 'vtid.live.session.stop' | 'vtid.live.audio.in.chunk' | 'vtid.live.video.in.frame' | 'vtid.live.audio.out.chunk' | 'orb.live.config_missing' | 'orb.live.connection_failed' | 'orb.live.stall_detected' | 'orb.live.diag' | 'orb.live.fallback_used' | 'orb.live.fallback_error' | 'orb.live.tool_loop_guard_activated' | 'orb.live.greeting.delivered',
   payload: Record<string, unknown>,
   status: 'info' | 'warning' | 'error' = 'info'
 ): Promise<void> {

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -497,6 +497,9 @@ export type CicdEventType =
   | 'orb.live.stall_detected'
   // VTID-TOOLGUARD: Tool loop guard activation
   | 'orb.live.tool_loop_guard_activated'
+  // BOOTSTRAP-ORB-HOTFIX-1: pre-greeting latency gauge (time from session-start
+  // request to first greeting audio chunk forwarded to client)
+  | 'orb.live.greeting.delivered'
   // VTID-DIAG: Pipeline diagnostics
   | 'orb.live.diag'
   // VTID-FALLBACK: Chat-TTS fallback events


### PR DESCRIPTION
## Summary

Phase 0 hotfixes from the approved orb refactor plan (`/.claude/plans/atomic-riding-badger.md`). Bundles 0a (command-hub iOS unlock) + 0e (pre-greeting latency gauge). Companion PR to [exafyltd/vitana-v1#165](https://github.com/exafyltd/vitana-v1/pull/165) which fixes the same iOS unlock in `OrbVoiceClient.ts`.

Phase 0b (WS reconnect parity) and Phase 0c (turn_complete on SSE) verified already in place (`attemptTransparentReconnect` is transport-agnostic; SSE emits turn_complete at `orb-live.ts:4731`) — no code change needed.

## 0a · command-hub orb-widget.js iOS unlock

- Play 1-sample silent buffer in the user-gesture handler at session start. This is the canonical iOS unlock primitive — creating the `AudioContext` isn't enough on iOS Safari; playback inside the gesture is required.
- `_processQueue()` no longer silently drops chunks when the context is suspended. Adds a 3 s cumulative resume-retry budget with visible logging. After 3 s without resuming, the queue is cleared and an error is logged so the client isn't stuck in a "UI says listening but nothing plays" state.
- Surfaces previously-swallowed `resume()` rejections so iOS Safari permanent-rejection can be diagnosed vs transient suspends.

## 0e · pre_greeting_ms OASIS gauge

- New event type `orb.live.greeting.delivered`, emitted once per session when the first audio chunk of the greeting turn is forwarded to the client.
- Field: `pre_greeting_ms = Date.now() - session.createdAt` — the full server-side envelope from session-start request to first audio chunk leaving the gateway.
- Baseline metric for Phase 1 latency work (Vertex WS pre-warm pool, awareness cache, combined identity query). Without this gauge the Phase 1 PRs have no before/after to point to.

## Scope

- `services/gateway/src/frontend/command-hub/orb-widget.js` — widget iOS unlock
- `services/gateway/src/routes/orb-live.ts` — greeting latency emission + typed union
- `services/gateway/src/types/cicd.ts` — register `orb.live.greeting.delivered`

VTID tag `BOOTSTRAP-ORB-IOS-UNLOCK` on the squash commit fires Auto-Deploy → EXEC-DEPLOY on the gateway.

## Test plan

- [x] `npm run typecheck` passes
- [ ] Post-deploy, Voice Lab: `orb.live.greeting.delivered` events visible, P50 `pre_greeting_ms` matches user-perceived 4-5 s (baseline)
- [ ] iPhone (Appilix WebView + Safari): user can tap orb and hear greeting within 3 s
- [ ] Android (no regression): greeting still plays
- [ ] `[VTOrb] AudioContext resume rejected` logs appear in browser console if a user hits the iOS failure path, enabling field diagnostics

🤖 Generated with [Claude Code](https://claude.com/claude-code)