### PR TITLE
feat: history-aware timeline projector + ORB user context profiler

### DIFF
--- a/services/gateway/src/routes/diary.ts
+++ b/services/gateway/src/routes/diary.ts
@@ -21,6 +21,7 @@ import { z } from 'zod';
 import { randomUUID } from 'crypto';
 import { createUserSupabaseClient } from '../lib/supabase-user';
 import { emitOasisEvent } from '../services/oasis-event-service';
+import { writeTimelineRow } from '../services/timeline-projector';
 // VTID-01225: Cognee entity extraction from diary entries
 import { cogneeExtractorClient } from '../services/cognee-extractor-client';
 
@@ -724,6 +725,26 @@ router.post('/entry', async (req: Request, res: Response) => {
         extraction_result: extractionResult
       }
     );
+
+    // BOOTSTRAP-HISTORY-AWARE-TIMELINE: direct write to timeline
+    // (emitDiaryEvent omits actor_id, so the tail-projector would drop this).
+    if (jwtUserId) {
+      writeTimelineRow({
+        user_id: jwtUserId,
+        activity_type: 'diary.create',
+        activity_data: {
+          entry_id: memoryId,
+          template_type: entry.template_type,
+          entry_type: entryType,
+          category_key: categoryKey,
+          has_mood: !!entry.mood,
+          has_energy: !!entry.energy_level,
+        },
+        context_data: { surface: 'diary' },
+        dedupe_key: `diary:${memoryId}`,
+        source: 'projector:diary',
+      }).catch(() => {});
+    }
 
     console.log(`[VTID-01097] Diary entry created: ${memoryId} (${entry.template_type})`);
 

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -46,6 +46,7 @@ import { randomUUID } from 'crypto';
 import { TextToSpeechClient, protos } from '@google-cloud/text-to-speech';
 import { processWithGemini, setThreadIdentity } from '../services/gemini-operator';
 import { emitOasisEvent } from '../services/oasis-event-service';
+import { getUserContextSummary } from '../services/user-context-profiler';
 import { notifyUserAsync } from '../services/notification-service';
 // VTID-01225: Cognee Entity Extraction Integration
 import { cogneeExtractorClient, type CogneeExtractionRequest } from '../services/cognee-extractor-client';
@@ -5979,13 +5980,14 @@ setInterval(cleanupExpiredConversations, 5 * 60 * 1000);
 /**
  * VTID-0135: Emit orb.session.started event
  */
-async function emitOrbSessionStarted(orbSessionId: string, conversationId: string): Promise<void> {
+async function emitOrbSessionStarted(orbSessionId: string, conversationId: string, userId?: string): Promise<void> {
   await emitOasisEvent({
     vtid: 'VTID-0135',
     type: 'orb.session.started',
     source: 'command-hub',
     status: 'info',
     message: `ORB voice session started: ${orbSessionId}`,
+    ...(userId && { actor_id: userId, surface: 'orb' as const }),
     payload: {
       orb_session_id: orbSessionId,
       conversation_id: conversationId,
@@ -6045,13 +6047,14 @@ async function emitOrbTurnResponded(
 /**
  * VTID-0135: Emit orb.session.ended event
  */
-async function emitOrbSessionEnded(orbSessionId: string, conversationId: string): Promise<void> {
+async function emitOrbSessionEnded(orbSessionId: string, conversationId: string, userId?: string): Promise<void> {
   await emitOasisEvent({
     vtid: 'VTID-0135',
     type: 'orb.session.ended',
     source: 'command-hub',
     status: 'info',
     message: `ORB voice session ended: ${orbSessionId}`,
+    ...(userId && { actor_id: userId, surface: 'orb' as const }),
     payload: {
       orb_session_id: orbSessionId,
       conversation_id: conversationId,
@@ -6365,6 +6368,18 @@ async function generateMemoryEnhancedSystemInstruction(
     ? identity
     : { user_id: DEV_IDENTITY.USER_ID, tenant_id: DEV_IDENTITY.TENANT_ID, active_role: DEV_IDENTITY.ACTIVE_ROLE };
 
+  // BOOTSTRAP-HISTORY-AWARE-TIMELINE: Fetch user context profile in parallel with the rest.
+  // Flag-gated so we can disable per-tenant without redeploy.
+  const profilerEnabled = process.env.PROFILER_IN_ORB_INSTRUCTION !== 'false';
+  const userContextSummaryPromise = profilerEnabled && effectiveIdentity.user_id
+    ? getUserContextSummary(effectiveIdentity.user_id, { tenantId: effectiveIdentity.tenant_id })
+        .then(r => r.summary)
+        .catch(err => {
+          console.warn('[UserContextProfiler] non-fatal fetch error:', err?.message || err);
+          return '';
+        })
+    : Promise.resolve('');
+
   // VTID-01225-READ-FIX: Always fetch memory_facts directly via REST API.
   // This bypasses ALL pipeline complexity (Mem0, Context Assembly, Memory Bridge)
   // and guarantees structured facts are ALWAYS available in the system instruction.
@@ -6544,10 +6559,17 @@ ${textChatConfig.operating_mode || '- Voice conversation is primary.\n- Always l
       console.log(`[VTID-01112] Context assembly failed: ${contextResult.error}`);
       // Fallback to legacy memory bridge with identity-aware function
       const memoryContext = await fetchMemoryContextWithIdentity(effectiveIdentity);
+      const activitySummary = await userContextSummaryPromise;
       if (!memoryContext.ok || memoryContext.items.length === 0) {
+        if (activitySummary) {
+          return {
+            instruction: `${baseInstructionNoMemory}\n\n## USER CONTEXT PROFILE (recent activity & preferences)\n${activitySummary}\n`,
+            memoryContext
+          };
+        }
         return { instruction: baseInstructionNoMemory, memoryContext };
       }
-      const enhancedInstruction = buildMemoryEnhancedInstruction(baseInstructionWithMemory, memoryContext);
+      const enhancedInstruction = buildMemoryEnhancedInstruction(baseInstructionWithMemory, memoryContext, activitySummary);
       return { instruction: enhancedInstruction, memoryContext };
     }
 
@@ -6558,17 +6580,29 @@ ${textChatConfig.operating_mode || '- Voice conversation is primary.\n- Always l
       // VTID-01225-READ-FIX: Context assembly reads only memory_items.
       // When those are empty, try fetchMemoryContextWithIdentity() which also reads memory_facts.
       const factsMemoryContext = await fetchMemoryContextWithIdentity(effectiveIdentity);
+      const activitySummary = await userContextSummaryPromise;
       if (factsMemoryContext.ok && factsMemoryContext.items.length > 0) {
         console.log(`[VTID-01225-READ-FIX] memory_facts fallback found ${factsMemoryContext.items.length} items`);
-        const enhancedInstruction = buildMemoryEnhancedInstruction(baseInstructionWithMemory, factsMemoryContext);
+        const enhancedInstruction = buildMemoryEnhancedInstruction(baseInstructionWithMemory, factsMemoryContext, activitySummary);
         return { instruction: enhancedInstruction, memoryContext: factsMemoryContext, contextBundle: bundle };
       }
       console.log('[VTID-01112] No context items found for user (including memory_facts)');
+      if (activitySummary) {
+        return {
+          instruction: `${baseInstructionNoMemory}\n\n## USER CONTEXT PROFILE (recent activity & preferences)\n${activitySummary}\n`,
+          memoryContext: null,
+          contextBundle: bundle
+        };
+      }
       return { instruction: baseInstructionNoMemory, memoryContext: null, contextBundle: bundle };
     }
 
     // Format context bundle for prompt injection
     const contextForPrompt = formatContextForPrompt(bundle);
+    const activitySummary = await userContextSummaryPromise;
+    const activityBlock = activitySummary
+      ? `\n\n## USER CONTEXT PROFILE (recent activity, routines, preferences)\n${activitySummary}\n\n**Weave this naturally** — e.g. "I noticed you logged a diary entry this morning". Never recite the list verbatim.`
+      : '';
 
     // Build enhanced instruction with context bundle
     const enhancedInstruction = `${baseInstructionWithMemory}
@@ -6600,9 +6634,9 @@ You have access to PERSISTENT MEMORY that contains REAL information from previou
 
 ---
 ${contextForPrompt}
----
+---${activityBlock}
 
-You KNOW this user. You REMEMBER their name, their hometown, their family. USE the data above to answer questions. For any calculation, USE the run_code tool.`;
+You KNOW this user. You REMEMBER their name, their hometown, their family, and their recent life rhythm. USE the data above to answer questions. For any calculation, USE the run_code tool.`;
 
     console.log(`[VTID-01112] Context-enhanced instruction generated with ${bundle.traceability.total_items_included} items (bundle=${bundle.bundle_id})`);
 
@@ -6617,10 +6651,17 @@ You KNOW this user. You REMEMBER their name, their hometown, their family. USE t
     // Fallback to legacy memory bridge (identity-scoped)
     try {
       const memoryContext = await fetchMemoryContextWithIdentity(effectiveIdentity);
+      const activitySummary = await userContextSummaryPromise;
       if (!memoryContext.ok || memoryContext.items.length === 0) {
+        if (activitySummary) {
+          return {
+            instruction: `${baseInstructionNoMemory}\n\n## USER CONTEXT PROFILE (recent activity & preferences)\n${activitySummary}\n`,
+            memoryContext
+          };
+        }
         return { instruction: baseInstructionNoMemory, memoryContext };
       }
-      const enhancedInstruction = buildMemoryEnhancedInstruction(baseInstructionWithMemory, memoryContext);
+      const enhancedInstruction = buildMemoryEnhancedInstruction(baseInstructionWithMemory, memoryContext, activitySummary);
       return { instruction: enhancedInstruction, memoryContext };
     } catch {
       return { instruction: baseInstructionNoMemory, memoryContext: null };
@@ -7227,7 +7268,7 @@ router.post('/chat', optionalAuth, async (req: AuthenticatedRequest, res: Respon
     console.log(`[VTID-0135] Created new conversation: ${conversationId}`);
 
     // Emit session started event
-    await emitOrbSessionStarted(orbSessionId, conversationId);
+    await emitOrbSessionStarted(orbSessionId, conversationId, identity.user_id);
   }
 
   // VTID-01039: Append user turn to transcript (replaces per-turn OASIS event)

--- a/services/gateway/src/routes/recommendation-inbox.ts
+++ b/services/gateway/src/routes/recommendation-inbox.ts
@@ -286,6 +286,8 @@ router.post('/:id/accept', async (req: Request, res: Response) => {
       source: 'recommendation-inbox',
       status: 'info',
       message: `User accepted recommendation`,
+      actor_id: userId,
+      surface: 'command-hub',
       payload: {
         recommendation_id: id,
         user_id: userId,
@@ -381,6 +383,8 @@ router.post('/:id/dismiss', async (req: Request, res: Response) => {
       source: 'recommendation-inbox',
       status: 'info',
       message: `User dismissed recommendation`,
+      actor_id: userId,
+      surface: 'command-hub',
       payload: {
         recommendation_id: id,
         user_id: userId,
@@ -506,6 +510,8 @@ router.post('/:id/feedback', async (req: Request, res: Response) => {
       source: 'recommendation-inbox',
       status: 'info',
       message: `User submitted feedback (rating: ${rating})`,
+      actor_id: userId,
+      surface: 'command-hub',
       payload: {
         recommendation_id: id,
         user_id: userId,

--- a/services/gateway/src/services/oasis-event-service.ts
+++ b/services/gateway/src/services/oasis-event-service.ts
@@ -5,6 +5,7 @@
 
 import { randomUUID } from 'crypto';
 import { CicdEventType, CicdOasisEvent } from '../types/cicd';
+import { projectOasisEventToTimeline } from './timeline-projector';
 
 /**
  * VTID-01874: Infer task_stage from event type when not explicitly set.
@@ -84,6 +85,20 @@ export async function emitOasisEvent(event: CicdOasisEvent): Promise<{ ok: boole
     }
 
     console.log(`[OASIS Event] Emitted: ${event.type} for ${event.vtid} (${eventId})`);
+
+    // BOOTSTRAP-HISTORY-AWARE-TIMELINE: fan out to user timeline (fire-and-forget).
+    // Projector drops events without actor_id and topics that aren't user-facing.
+    projectOasisEventToTimeline({
+      topic: event.type,
+      actor_id: event.actor_id,
+      event_id: eventId,
+      status: event.status,
+      message: event.message,
+      payload: event.payload,
+      surface: event.surface,
+      conversation_turn_id: event.conversation_turn_id,
+    }).catch(err => console.warn(`[TimelineProjector] non-fatal: ${err instanceof Error ? err.message : 'unknown'}`));
+
     return { ok: true, event_id: eventId };
   } catch (error) {
     const errorMessage = error instanceof Error ? error.message : 'Unknown error';

--- a/services/gateway/src/services/orb-memory-bridge.ts
+++ b/services/gateway/src/services/orb-memory-bridge.ts
@@ -2026,10 +2026,14 @@ function truncateContent(content: string, maxLength: number): string {
  */
 export function buildMemoryEnhancedInstruction(
   baseInstruction: string,
-  memoryContext: OrbMemoryContext
+  memoryContext: OrbMemoryContext,
+  activitySummary?: string
 ): string {
-  // If no memory or error, return base instruction
+  // If no memory or error, still inject activity summary if we have one.
   if (!memoryContext.ok || memoryContext.items.length === 0) {
+    if (activitySummary && activitySummary.trim().length > 0) {
+      return `${baseInstruction}\n\n## USER CONTEXT PROFILE (recent activity & preferences)\n${activitySummary}\n`;
+    }
     return baseInstruction;
   }
 
@@ -2051,6 +2055,12 @@ export function buildMemoryEnhancedInstruction(
 
   // Inject memory context after the base instruction
   // VTID-01107 + VTID-01109: Strong instruction to USE memory and NEVER claim inability to remember
+  // BOOTSTRAP-HISTORY-AWARE-TIMELINE: append activity summary so the assistant
+  // is aware of recent actions, routines, and inferred preferences.
+  const activityBlock = activitySummary && activitySummary.trim().length > 0
+    ? `\n\n## USER CONTEXT PROFILE (recent activity, routines, preferences)\n${activitySummary}\n\n**Weave this naturally into responses** — e.g. "I noticed you logged a diary entry this morning" or "since you usually do X". Never recite the list verbatim.`
+    : '';
+
   const enhancedInstruction = `${baseInstruction}
 
 ## CRITICAL: You Have Persistent Memory About This User
@@ -2074,9 +2084,9 @@ ${quickReference}
 ---
 MEMORY CONTEXT (This is REAL data - USE IT when answering):
 ${memoryContext.formatted_context}
----
+---${activityBlock}
 
-You KNOW this user. You REMEMBER their name, their hometown, their family. Answer their questions using the memory above.`;
+You KNOW this user. You REMEMBER their name, their hometown, their family, and their recent life rhythm. Answer their questions using the memory and context above.`;
 
   return enhancedInstruction;
 }

--- a/services/gateway/src/services/timeline-projector.ts
+++ b/services/gateway/src/services/timeline-projector.ts
@@ -1,0 +1,221 @@
+/**
+ * Timeline Projector - BOOTSTRAP-HISTORY-AWARE-TIMELINE
+ *
+ * Fans user-observable backend events into `user_activity_log` so the
+ * /memory/timeline screen and the UserContextProfiler read a single source
+ * of truth. Writes are fire-and-forget — caller paths (emitOasisEvent,
+ * diary create, recommendation interaction) MUST NOT block on this.
+ *
+ * Design choices (see plan `we-were-always-talking-optimized-owl.md`):
+ *   - No new canonical table; `user_activity_log` already exists and is read
+ *     by the frontend timeline hook.
+ *   - No DB triggers; Supabase IO pressure history makes app-level fan-in safer.
+ *   - No queue/retry; oasis_events remains source of truth for backend events.
+ *   - Bumps `user_profiler_version` so the in-proc profiler cache invalidates
+ *     on new activity without TTL-only eviction.
+ */
+import { randomUUID } from 'crypto';
+
+const PROJECTOR_DISABLED = process.env.TIMELINE_PROJECTOR_ENABLED === 'false';
+
+interface ProjectorInput {
+  user_id: string;
+  activity_type: string;
+  activity_data?: Record<string, unknown>;
+  context_data?: Record<string, unknown>;
+  dedupe_key?: string;
+  source: string;
+  session_id?: string;
+}
+
+/**
+ * Map an OASIS event topic to a user-facing activity_type.
+ * Returns null for topics that don't belong on a user timeline
+ * (CICD, deploy, governance — those stay in oasis_events only).
+ *
+ * Kept in sync with the frontend `ACTIVITY_TYPE_CONFIG` in vitana-v1's
+ * useActivityHistory.ts by prefix; exact codes are preserved where the
+ * frontend has specific renderers, otherwise we pass the topic through
+ * and let the prefix-fallback handle rendering.
+ */
+export function mapOasisTopicToActivityType(topic: string): string | null {
+  if (!topic) return null;
+  const t = topic.toLowerCase();
+
+  // Autopilot lifecycle → autopilot.*
+  if (t.startsWith('autopilot.recommendation.')) {
+    if (t.endsWith('.accepted') || t.endsWith('.accept')) return 'autopilot.action.execute';
+    if (t.endsWith('.dismissed') || t.endsWith('.dismiss')) return 'autopilot.action.dismiss';
+    if (t.endsWith('.snoozed') || t.endsWith('.snooze')) return 'autopilot.action.snooze';
+    if (t.endsWith('.selected') || t.endsWith('.select')) return 'autopilot.action.select';
+    return 'autopilot.action.update';
+  }
+  if (t.startsWith('autopilot.')) return t;
+
+  // ORB session lifecycle
+  if (t === 'orb.session.started' || t === 'orb.live.session.start' || t === 'vtid.live.session.start') {
+    return 'orb.session.start';
+  }
+  if (t === 'orb.session.stopped' || t === 'orb.live.session.stop' || t === 'vtid.live.session.stop') {
+    return 'orb.session.stop';
+  }
+  if (t.startsWith('orb.') || t.startsWith('vtid.live.')) return t.replace('vtid.live.', 'orb.');
+
+  // Recommendation interactions
+  if (t.startsWith('recommendation.interaction.')) return t;
+  if (t.startsWith('recommendation.')) return t;
+
+  // Task lifecycle (user-owned tasks only — CICD vtid.* events are filtered below)
+  if (t === 'task.intake' || t === 'task.created') return 'task.create';
+  if (t === 'task.completed') return 'task.complete';
+  if (t === 'task.approved') return 'task.approve';
+  if (t === 'task.rejected') return 'task.reject';
+  if (t.startsWith('task.')) return t;
+
+  // Diary
+  if (t.startsWith('diary.')) return t;
+
+  // Memory
+  if (t === 'memory.promote' || t.startsWith('memory.')) return t;
+
+  // Community rooms / events
+  if (t.startsWith('community.room.')) return t.replace('community.room.', 'community.live.');
+  if (t.startsWith('community.event.')) return t;
+
+  // Health
+  if (t.startsWith('health.biomarker.')) return t;
+  if (t.startsWith('health.')) return t;
+
+  // Everything else — CICD, governance, deploy, worker, spec — NOT user timeline material
+  return null;
+}
+
+/**
+ * Write a single row to user_activity_log with idempotent dedupe.
+ * Fire-and-forget. Never throws; errors are logged but swallowed so
+ * user-facing code paths are never blocked.
+ */
+export async function writeTimelineRow(input: ProjectorInput): Promise<void> {
+  if (PROJECTOR_DISABLED) return;
+
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+  if (!supabaseUrl || !supabaseKey) return;
+
+  if (!input.user_id || !input.activity_type) return;
+
+  // Basic constraint guard so we don't trigger CHECK violations.
+  if (!/^[a-z][a-z0-9_]*(\.[a-z0-9_]+){1,3}$/.test(input.activity_type)) {
+    console.warn(`[TimelineProjector] invalid activity_type skipped: ${input.activity_type}`);
+    return;
+  }
+
+  const row = {
+    id: randomUUID(),
+    user_id: input.user_id,
+    activity_type: input.activity_type,
+    activity_data: input.activity_data || {},
+    context_data: input.context_data || {},
+    dedupe_key: input.dedupe_key,
+    session_id: input.session_id,
+    source: input.source,
+  };
+
+  try {
+    const response = await fetch(`${supabaseUrl}/rest/v1/user_activity_log`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: supabaseKey,
+        Authorization: `Bearer ${supabaseKey}`,
+        Prefer: 'resolution=ignore-duplicates,return=minimal',
+      },
+      body: JSON.stringify(row),
+    });
+
+    if (!response.ok && response.status !== 409) {
+      const errText = await response.text().catch(() => '');
+      // Silent for CHECK violations (23514) during the rollout window;
+      // loud for anything else.
+      if (!errText.includes('chk_activity_type')) {
+        console.warn(`[TimelineProjector] insert failed ${response.status}: ${errText.slice(0, 200)}`);
+      }
+      return;
+    }
+
+    // Bump profiler cache version. Best-effort; ignore failures.
+    bumpProfilerVersion(supabaseUrl, supabaseKey, input.user_id).catch(() => {});
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : 'unknown';
+    console.warn(`[TimelineProjector] network error: ${msg}`);
+  }
+}
+
+async function bumpProfilerVersion(supabaseUrl: string, supabaseKey: string, userId: string): Promise<void> {
+  try {
+    const rpc = await fetch(`${supabaseUrl}/rest/v1/rpc/bump_user_profiler_version`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: supabaseKey,
+        Authorization: `Bearer ${supabaseKey}`,
+      },
+      body: JSON.stringify({ p_user_id: userId }),
+    });
+    if (rpc.ok) return;
+  } catch {
+    // fallthrough
+  }
+
+  // RPC not available — upsert via PostgREST.
+  try {
+    await fetch(`${supabaseUrl}/rest/v1/user_profiler_version?on_conflict=user_id`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: supabaseKey,
+        Authorization: `Bearer ${supabaseKey}`,
+        Prefer: 'resolution=merge-duplicates,return=minimal',
+      },
+      body: JSON.stringify({ user_id: userId, updated_at: new Date().toISOString() }),
+    });
+  } catch {
+    // Best-effort — the profiler TTL will cover us.
+  }
+}
+
+/**
+ * Project an OASIS event onto the user timeline.
+ * Called by emitOasisEvent after a successful write. Never throws.
+ */
+export async function projectOasisEventToTimeline(params: {
+  topic: string;
+  actor_id?: string;
+  event_id?: string;
+  status?: string;
+  message?: string;
+  payload?: Record<string, unknown>;
+  surface?: string;
+  conversation_turn_id?: string;
+}): Promise<void> {
+  if (!params.actor_id) return; // CICD events without a user have no business on a user timeline
+  const activityType = mapOasisTopicToActivityType(params.topic);
+  if (!activityType) return;
+
+  await writeTimelineRow({
+    user_id: params.actor_id,
+    activity_type: activityType,
+    activity_data: {
+      message: params.message,
+      status: params.status,
+      ...(params.payload || {}),
+    },
+    context_data: {
+      surface: params.surface,
+      conversation_turn_id: params.conversation_turn_id,
+      original_topic: params.topic,
+    },
+    dedupe_key: params.event_id ? `oasis:${params.event_id}` : undefined,
+    source: 'projector:oasis_events',
+  });
+}

--- a/services/gateway/src/services/user-context-profiler.ts
+++ b/services/gateway/src/services/user-context-profiler.ts
@@ -1,0 +1,361 @@
+/**
+ * User Context Profiler - BOOTSTRAP-HISTORY-AWARE-TIMELINE Phase 3
+ *
+ * Deterministic, rules-based summary of what a user has been doing,
+ * what they seem to prefer, and what health/routine patterns they exhibit.
+ * The ORB injects this summary into the Gemini Live system prompt so
+ * voice-to-voice conversations are history-aware rather than amnesic.
+ *
+ * Inputs (read-only, service role):
+ *   - user_activity_log           last 14 days
+ *   - user_routines               VTID-01936 pattern-extracted rhythms
+ *   - memory_facts                via existing getCurrentFacts service
+ *   - user_preferences            explicit user preferences
+ *   - user_inferred_preferences   system-inferred preferences
+ *   - vitana_index_scores         latest health snapshot
+ *
+ * Output: a compact tagged prose block sized to a configurable char budget.
+ *
+ * No LLM calls — pattern counting is fast (<30ms warm) and debuggable.
+ * Upgrade path: swap internals behind the same signature if narratives
+ * prove insufficient.
+ *
+ * Cache: per-user in-proc Map with 10-min TTL, invalidated on profiler
+ * version bump (written by timeline-projector on new activity insert).
+ */
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { getCurrentFacts } from './memory-facts-service';
+
+const TTL_MS = 10 * 60 * 1000;
+const DEFAULT_WINDOW_DAYS = 14;
+const DEFAULT_MAX_CHARS = 2400;
+
+interface CacheEntry {
+  version: number;
+  summary: string;
+  expiresAt: number;
+}
+
+const cache = new Map<string, CacheEntry>();
+
+export interface GetProfileOptions {
+  maxChars?: number;
+  windowDays?: number;
+  tenantId?: string;
+}
+
+export interface UserContextProfile {
+  summary: string;
+  version: number;
+  cached: boolean;
+  warnings: string[];
+}
+
+function serviceClient(): SupabaseClient | null {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+  if (!url || !key) return null;
+  return createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
+}
+
+async function readProfilerVersion(client: SupabaseClient, userId: string): Promise<number> {
+  const { data } = await client
+    .from('user_profiler_version')
+    .select('version')
+    .eq('user_id', userId)
+    .maybeSingle();
+  return data?.version ?? 0;
+}
+
+function hourBucket(iso: string): 'morning' | 'midday' | 'afternoon' | 'evening' | 'night' {
+  const h = new Date(iso).getHours();
+  if (h >= 5 && h < 10) return 'morning';
+  if (h >= 10 && h < 13) return 'midday';
+  if (h >= 13 && h < 17) return 'afternoon';
+  if (h >= 17 && h < 22) return 'evening';
+  return 'night';
+}
+
+function relativeTime(iso: string): string {
+  const delta = Date.now() - new Date(iso).getTime();
+  const mins = Math.floor(delta / 60000);
+  if (mins < 60) return `${Math.max(1, mins)}m ago`;
+  const hours = Math.floor(mins / 60);
+  if (hours < 24) return `${hours}h ago`;
+  const days = Math.floor(hours / 24);
+  if (days < 7) return `${days}d ago`;
+  const weeks = Math.floor(days / 7);
+  return `${weeks}w ago`;
+}
+
+function summarizeActivity(type: string): string {
+  const [prefix, ...rest] = type.split('.');
+  const suffix = rest.join('.');
+  const map: Record<string, string> = {
+    'orb.session.start': 'started voice session',
+    'orb.session.stop': 'ended voice session',
+    'diary.create': 'logged a diary entry',
+    'diary.template.submitted': 'logged a diary entry',
+    'autopilot.action.execute': 'activated an autopilot recommendation',
+    'autopilot.action.dismiss': 'dismissed an autopilot recommendation',
+    'autopilot.action.snooze': 'snoozed an autopilot recommendation',
+    'task.complete': 'completed a task',
+    'task.create': 'created a task',
+    'memory.promote': 'promoted content to knowledge',
+    'health.biomarker.upload_pdf': 'uploaded lab results',
+    'health.biomarker.upload_manual': 'logged biomarker manually',
+    'health.biomarker.connect_device': 'connected a health device',
+    'health.supplement.add': 'added a supplement',
+    'community.live.join': 'joined a live room',
+    'community.event.join': 'joined a community event',
+    'community.group.join': 'joined a community group',
+    'community.follow': 'followed someone',
+    'discover.service.view': 'viewed a service',
+    'discover.service.bookmark': 'bookmarked a service',
+    'calendar.create': 'added a calendar event',
+    'wallet.transfer': 'made a wallet transfer',
+  };
+  if (map[type]) return map[type];
+  return `${prefix || 'activity'} ${suffix || ''}`.trim();
+}
+
+function truncate(str: string, max: number): string {
+  if (str.length <= max) return str;
+  return str.slice(0, Math.max(0, max - 1)).trimEnd() + '…';
+}
+
+interface ActivityRow {
+  activity_type: string;
+  activity_data: Record<string, unknown> | null;
+  created_at: string;
+}
+
+interface RoutineRow {
+  routine_kind: string;
+  title: string;
+  summary: string;
+  confidence: number;
+}
+
+interface PreferenceRow {
+  category: string;
+  preference_key: string;
+  preference_value: string | null;
+  source?: string;
+}
+
+async function fetchActivityLog(client: SupabaseClient, userId: string, sinceIso: string): Promise<ActivityRow[]> {
+  const { data, error } = await client
+    .from('user_activity_log')
+    .select('activity_type, activity_data, created_at')
+    .eq('user_id', userId)
+    .gte('created_at', sinceIso)
+    .order('created_at', { ascending: false })
+    .limit(400);
+  if (error) return [];
+  return (data || []) as ActivityRow[];
+}
+
+async function fetchRoutines(client: SupabaseClient, userId: string): Promise<RoutineRow[]> {
+  const { data, error } = await client
+    .from('user_routines')
+    .select('routine_kind, title, summary, confidence')
+    .eq('user_id', userId)
+    .gte('confidence', 0.5)
+    .order('confidence', { ascending: false })
+    .limit(8);
+  if (error) return [];
+  return (data || []) as RoutineRow[];
+}
+
+async function fetchPreferences(client: SupabaseClient, userId: string): Promise<PreferenceRow[]> {
+  const out: PreferenceRow[] = [];
+  const explicit = await client
+    .from('user_preferences')
+    .select('category, preference_key, preference_value')
+    .eq('user_id', userId)
+    .limit(20);
+  if (!explicit.error && explicit.data) {
+    for (const row of explicit.data as any[]) {
+      out.push({
+        category: row.category ?? 'preference',
+        preference_key: row.preference_key ?? row.key ?? '',
+        preference_value: row.preference_value ?? row.value ?? null,
+        source: 'explicit',
+      });
+    }
+  }
+  const inferred = await client
+    .from('user_inferred_preferences')
+    .select('category, preference_key, preference_value, confidence')
+    .eq('user_id', userId)
+    .order('confidence', { ascending: false })
+    .limit(15);
+  if (!inferred.error && inferred.data) {
+    for (const row of inferred.data as any[]) {
+      if ((row.confidence ?? 0) < 0.55) continue;
+      out.push({
+        category: row.category ?? 'preference',
+        preference_key: row.preference_key ?? row.key ?? '',
+        preference_value: row.preference_value ?? row.value ?? null,
+        source: 'inferred',
+      });
+    }
+  }
+  return out;
+}
+
+async function fetchVitanaIndex(client: SupabaseClient, userId: string): Promise<{ score: number; deltas?: Record<string, number> } | null> {
+  const { data, error } = await client
+    .from('vitana_index_scores')
+    .select('score, sub_scores, computed_at')
+    .eq('user_id', userId)
+    .order('computed_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (error || !data) return null;
+  return { score: Number(data.score) || 0, deltas: (data.sub_scores as Record<string, number>) || undefined };
+}
+
+function buildRecentSection(activities: ActivityRow[]): string {
+  const meaningful = activities.filter(a => !a.activity_type.startsWith('chat.'));
+  const top = meaningful.slice(0, 10);
+  if (!top.length) return '';
+  const lines = top.map(a => `- ${summarizeActivity(a.activity_type)} (${relativeTime(a.created_at)})`);
+  return `[RECENT]\n${lines.join('\n')}`;
+}
+
+function buildRoutinesSection(routines: RoutineRow[], activities: ActivityRow[]): string {
+  const lines: string[] = [];
+
+  // Prefer pre-extracted routines from VTID-01936 pattern extractor.
+  for (const r of routines.slice(0, 5)) {
+    lines.push(`- ${r.title}: ${r.summary}`);
+  }
+
+  // Fallback: derive a crude time-of-day preference from recent activity.
+  if (lines.length === 0 && activities.length >= 10) {
+    const buckets: Record<string, number> = {};
+    for (const a of activities) {
+      const b = hourBucket(a.created_at);
+      buckets[b] = (buckets[b] || 0) + 1;
+    }
+    const total = activities.length;
+    const [topBucket, topCount] = Object.entries(buckets).sort((a, b) => b[1] - a[1])[0] || [];
+    if (topBucket && topCount && topCount / total >= 0.4) {
+      lines.push(`- Most active in the ${topBucket} (${Math.round((topCount / total) * 100)}% of recent activity).`);
+    }
+  }
+
+  if (!lines.length) return '';
+  return `[ROUTINES]\n${lines.join('\n')}`;
+}
+
+function buildPreferencesSection(prefs: PreferenceRow[]): string {
+  if (!prefs.length) return '';
+  const deduped = new Map<string, PreferenceRow>();
+  for (const p of prefs) {
+    const key = `${p.category}:${p.preference_key}`;
+    if (!deduped.has(key)) deduped.set(key, p);
+  }
+  const lines = [...deduped.values()].slice(0, 8).map(p => {
+    const label = p.preference_key || p.category;
+    const value = p.preference_value ? `: ${p.preference_value}` : '';
+    const tag = p.source === 'inferred' ? ' (inferred)' : '';
+    return `- ${label}${value}${tag}`;
+  });
+  return `[PREFERENCES]\n${lines.join('\n')}`;
+}
+
+function buildHealthSection(activities: ActivityRow[], vitana: { score: number; deltas?: Record<string, number> } | null): string {
+  const lines: string[] = [];
+  const healthActivities = activities.filter(a => a.activity_type.startsWith('health.'));
+  if (healthActivities.length) {
+    const uploads = healthActivities.filter(a => a.activity_type.includes('upload') || a.activity_type.includes('connect')).length;
+    const supplements = healthActivities.filter(a => a.activity_type.startsWith('health.supplement.add')).length;
+    if (uploads) lines.push(`- ${uploads} health data upload${uploads === 1 ? '' : 's'} in the last 14 days.`);
+    if (supplements) lines.push(`- Added ${supplements} supplement${supplements === 1 ? '' : 's'} recently.`);
+  }
+  if (vitana && vitana.score > 0) {
+    lines.push(`- Latest Vitana Index: ${vitana.score.toFixed(1)}.`);
+  }
+  if (!lines.length) return '';
+  return `[HEALTH]\n${lines.join('\n')}`;
+}
+
+function buildFactsSection(facts: { fact_key: string; fact_value: string; provenance_confidence: number }[]): string {
+  if (!facts.length) return '';
+  const top = facts
+    .filter(f => f.provenance_confidence >= 0.7)
+    .slice(0, 6)
+    .map(f => `- ${f.fact_key.replace(/_/g, ' ')}: ${f.fact_value}`);
+  if (!top.length) return '';
+  return `[FACTS]\n${top.join('\n')}`;
+}
+
+export async function getUserContextSummary(
+  userId: string,
+  opts: GetProfileOptions = {}
+): Promise<UserContextProfile> {
+  const warnings: string[] = [];
+  if (!userId) {
+    return { summary: '', version: 0, cached: false, warnings: ['missing userId'] };
+  }
+
+  const client = serviceClient();
+  if (!client) {
+    return { summary: '', version: 0, cached: false, warnings: ['supabase not configured'] };
+  }
+
+  const maxChars = opts.maxChars ?? DEFAULT_MAX_CHARS;
+  const windowDays = opts.windowDays ?? DEFAULT_WINDOW_DAYS;
+  const now = Date.now();
+
+  const version = await readProfilerVersion(client, userId);
+
+  // Cache hit?
+  const hit = cache.get(userId);
+  if (hit && hit.version === version && hit.expiresAt > now) {
+    return { summary: hit.summary, version, cached: true, warnings };
+  }
+
+  const sinceIso = new Date(now - windowDays * 24 * 60 * 60 * 1000).toISOString();
+
+  const [activities, routines, prefs, vitana, factsResult] = await Promise.all([
+    fetchActivityLog(client, userId, sinceIso),
+    fetchRoutines(client, userId),
+    fetchPreferences(client, userId),
+    fetchVitanaIndex(client, userId),
+    opts.tenantId
+      ? getCurrentFacts({ tenant_id: opts.tenantId, user_id: userId })
+      : Promise.resolve({ ok: true, facts: [] as any[] }),
+  ]);
+
+  const sections = [
+    buildRoutinesSection(routines, activities),
+    buildPreferencesSection(prefs),
+    buildHealthSection(activities, vitana),
+    buildFactsSection(factsResult.ok ? factsResult.facts : []),
+    buildRecentSection(activities),
+  ].filter(Boolean);
+
+  const summary = truncate(sections.join('\n\n'), maxChars);
+
+  cache.set(userId, { version, summary, expiresAt: now + TTL_MS });
+
+  return { summary, version, cached: false, warnings };
+}
+
+/**
+ * Drop the profiler cache for a user. Exposed for tests and admin endpoints.
+ */
+export function invalidateUserContextCache(userId: string): void {
+  cache.delete(userId);
+}
+
+/**
+ * Clear the entire cache — useful on gateway restart hooks if needed.
+ */
+export function clearUserContextCache(): void {
+  cache.clear();
+}

--- a/supabase/migrations/20260420120000_BOOTSTRAP_history_aware_timeline.sql
+++ b/supabase/migrations/20260420120000_BOOTSTRAP_history_aware_timeline.sql
@@ -1,0 +1,97 @@
+-- =============================================================================
+-- BOOTSTRAP-HISTORY-AWARE-TIMELINE: Widen user_activity_log + profiler plumbing
+-- Date: 2026-04-20
+--
+-- Task 1 (timeline fix):
+--   - The existing CHECK constraint on user_activity_log.activity_type only
+--     allows 16 values, but the frontend hooks (useCommunityLogger,
+--     useHealthLogger, useActivityLogger, etc.) write 60+ types. All writes
+--     outside the 16 fail silently, so the timeline is missing most activity.
+--   - Replace the enum allowlist with a permissive regex so new types onboard
+--     without future migrations.
+--   - Add a `source` column so we can distinguish frontend writes from backend
+--     projections (Task 1 Phase 2).
+--   - Add a composite index (user_id, activity_type, created_at DESC) for the
+--     UserContextProfiler's grouped-by-prefix queries.
+--
+-- Task 2 (profiler plumbing):
+--   - Add a tiny `user_profiler_version` counter table. The tail-projector
+--     bumps this on every user activity insert; the profiler cache keys on
+--     (user_id, version) so it can invalidate cheaply without TTL-only eviction.
+--
+-- Rollback:
+--   ALTER TABLE public.user_activity_log DROP CONSTRAINT chk_activity_type;
+--   ALTER TABLE public.user_activity_log ADD CONSTRAINT chk_activity_type
+--     CHECK (activity_type IN (
+--       'chat.message',
+--       'memory.create', 'memory.update', 'memory.delete', 'memory.promote',
+--       'wallet.transfer', 'wallet.exchange',
+--       'discover.view', 'discover.like', 'discover.match',
+--       'calendar.create', 'calendar.update', 'calendar.respond'
+--     ));
+--   ALTER TABLE public.user_activity_log DROP COLUMN IF EXISTS source;
+--   DROP INDEX IF EXISTS public.idx_ual_user_type_created;
+--   DROP TABLE IF EXISTS public.user_profiler_version;
+-- =============================================================================
+
+BEGIN;
+
+-- 1. Widen the activity_type CHECK constraint ----------------------------------
+ALTER TABLE public.user_activity_log
+  DROP CONSTRAINT IF EXISTS chk_activity_type;
+
+ALTER TABLE public.user_activity_log
+  ADD CONSTRAINT chk_activity_type
+  CHECK (activity_type ~ '^[a-z][a-z0-9_]*(\.[a-z0-9_]+){1,3}$');
+
+-- 2. Add provenance column -----------------------------------------------------
+ALTER TABLE public.user_activity_log
+  ADD COLUMN IF NOT EXISTS source text NOT NULL DEFAULT 'frontend';
+
+COMMENT ON COLUMN public.user_activity_log.source IS
+  'Provenance: frontend | projector:oasis_events | projector:diary | projector:reco | projector:orb';
+
+-- 3. Profiler-friendly composite index -----------------------------------------
+CREATE INDEX IF NOT EXISTS idx_ual_user_type_created
+  ON public.user_activity_log (user_id, activity_type, created_at DESC);
+
+-- 4. Profiler cache version counter --------------------------------------------
+CREATE TABLE IF NOT EXISTS public.user_profiler_version (
+  user_id    uuid PRIMARY KEY REFERENCES auth.users(id) ON DELETE CASCADE,
+  version    bigint NOT NULL DEFAULT 1,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+ALTER TABLE public.user_profiler_version ENABLE ROW LEVEL SECURITY;
+
+-- Self-read policy; writes happen from service-role key in gateway
+CREATE POLICY "user_profiler_version_self_read"
+  ON public.user_profiler_version FOR SELECT
+  USING (auth.uid() = user_id);
+
+COMMENT ON TABLE public.user_profiler_version IS
+  'BOOTSTRAP-HISTORY-AWARE-TIMELINE: bumped by timeline-projector on user activity writes; read by UserContextProfiler to invalidate in-proc cache.';
+
+-- 5. Increment RPC (service-role caller bumps, frontend reads) -----------------
+CREATE OR REPLACE FUNCTION public.bump_user_profiler_version(p_user_id uuid)
+RETURNS bigint
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_version bigint;
+BEGIN
+  INSERT INTO public.user_profiler_version (user_id, version, updated_at)
+  VALUES (p_user_id, 1, now())
+  ON CONFLICT (user_id) DO UPDATE
+    SET version = public.user_profiler_version.version + 1,
+        updated_at = now()
+  RETURNING version INTO v_version;
+  RETURN v_version;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.bump_user_profiler_version(uuid) TO service_role;
+
+COMMIT;


### PR DESCRIPTION
Makes the Vitana Assistant history-aware. Pairs with vitana-v1 PR #167 (frontend auto-refresh + prefix fallback).

Plan: .claude/plans/we-were-always-talking-optimized-owl.md

## Timeline unlock (Phases 1+2)

Migration 20260420120000_BOOTSTRAP_history_aware_timeline.sql widens user_activity_log CHECK from a 16-value enum to a permissive regex; adds source column + composite index; adds user_profiler_version counter + bump_user_profiler_version RPC. Rollback preserved inline.

timeline-projector.ts tail-calls from inside emitOasisEvent. Maps user-facing OASIS topics (autopilot.*, orb.session.*, task.*, recommendation.*, community.*, health.*) to activity_type and writes to user_activity_log. CICD/deploy/governance topics dropped. Fire-and-forget, never blocks the caller.

Direct writeTimelineRow in diary /entry (emitDiaryEvent omits actor_id). actor_id propagated on recommendation accept/dismiss/feedback + ORB session start so the tail-projector picks them up.

## Brain history-awareness (Phase 3)

user-context-profiler.ts is a deterministic rules-based summary of recent activity (14d), routines (reuses VTID-01936 user_routines), preferences (explicit + inferred), health signals (Vitana Index), and top memory_facts. In-proc cache keyed on (user_id, profiler_version), 10-min TTL, bump-on-write invalidation. No LLM call.

orb-memory-bridge.buildMemoryEnhancedInstruction accepts optional activitySummary and renders it in a USER CONTEXT PROFILE block the LLM is instructed to weave naturally (not recite).

orb-live.generateMemoryEnhancedSystemInstruction fetches profiler in parallel with the memory pipeline; injects summary into all three buildMemoryEnhancedInstruction call sites plus the context-assembly path. Flag-gated via PROFILER_IN_ORB_INSTRUCTION (default on).

## Test plan

- Merge vitana-v1 #167
- Apply migration via RUN-MIGRATION.yml
- Deploy gateway (EXEC-DEPLOY with BOOTSTRAP-HISTORY-AWARE-TIMELINE marker)
- Open /memory/timeline, trigger autopilot accept -> row appears
- Create diary entry -> row appears
- Start ORB session -> orb.session.start row appears
- Ask ORB what have I been up to -> answers from profiler
- Set PROFILER_IN_ORB_INSTRUCTION=false -> reverts to dumb baseline

## Safety

Projector is fire-and-forget. No DB triggers. Migration rollback preserved. Profiler output routed through existing redaction.

Generated with Claude Code
