### PR TITLE
feat: Vitana Awareness diagnostic endpoint + Command Hub test panel

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -2746,7 +2746,8 @@ const NAVIGATION_CONFIG = [
             { "key": "integration-tests", "path": "/command-hub/testing-qa/integration-tests/" },
             { "key": "validator-tests", "path": "/command-hub/testing-qa/validator-tests/" },
             { "key": "e2e", "path": "/command-hub/testing-qa/e2e/" },
-            { "key": "ci-reports", "path": "/command-hub/testing-qa/ci-reports/" }
+            { "key": "ci-reports", "path": "/command-hub/testing-qa/ci-reports/" },
+            { "key": "vitana-awareness", "path": "/command-hub/testing-qa/vitana-awareness/" }
         ]
     },
     {
@@ -6115,6 +6116,8 @@ function renderModuleContent(moduleKey, tab) {
         container.appendChild(renderTestingE2eView());
     } else if (moduleKey === 'testing-qa' && tab === 'ci-reports') {
         container.appendChild(renderTestingCiReportsView());
+    } else if (moduleKey === 'testing-qa' && tab === 'vitana-awareness') {
+        container.appendChild(renderVitanaAwarenessTestView());
 
     // ──── Admin: Analytics ────
     } else if (moduleKey === 'admin' && tab === 'analytics') {
@@ -39456,6 +39459,204 @@ function renderAutopilotGrowthView() {
         topCard.appendChild(empty);
     }
     container.appendChild(topCard);
+
+    return container;
+}
+
+// =============================================================================
+// BOOTSTRAP-HISTORY-AWARE-TIMELINE — Vitana Awareness Test
+// =============================================================================
+// Calls GET /api/v1/orb/debug/awareness with the current operator's session
+// and renders pass/fail indicators for every context block the voice ORB
+// would inject: identity, memory, recent turns, user context profile, and
+// the final assembled contextInstruction. Designed as a reusable diagnostic
+// for the "Vitana doesn't know about my activity" failure mode.
+// =============================================================================
+function renderVitanaAwarenessTestView() {
+    var container = document.createElement('div');
+    container.style.padding = '1.5rem';
+    container.innerHTML = '<h2>Vitana Awareness Test</h2>' +
+        '<p class="section-subtitle">What does the voice ORB actually know before responding? This calls the same bootstrap path a voice session uses and shows every context block that would be injected into the Gemini Live system_instruction.</p>';
+
+    // Info card
+    var info = document.createElement('div');
+    info.className = 'databases-arch-note';
+    info.innerHTML = '<h3>What this tests</h3><ul>' +
+        '<li><strong>Identity</strong> — is the JWT verifying and resolving to a real user_id + tenant_id?</li>' +
+        '<li><strong>Memory items</strong> — what personal memory loads for this user?</li>' +
+        '<li><strong>Recent turns</strong> — what prior ORB user utterances are fetched?</li>' +
+        '<li><strong>User Context Profile</strong> — the deterministic summary of recent activity, routines, preferences.</li>' +
+        '<li><strong>Context instruction</strong> — the final string injected into the Gemini Live prompt.</li>' +
+        '</ul><p style="margin:.5rem 0 0;font-size:.8rem;color:var(--color-text-secondary);">If all checks are green but voice ORB still seems unaware, the issue is downstream of this test (Gemini model attention, anonymous fallback at widget, etc).</p>';
+    container.appendChild(info);
+
+    // Controls row
+    var controls = document.createElement('div');
+    controls.style.cssText = 'display:flex;gap:.5rem;align-items:center;margin:1rem 0;flex-wrap:wrap;';
+
+    var userInput = document.createElement('input');
+    userInput.type = 'text';
+    userInput.placeholder = 'Optional user_id (service-role only) — leave blank to test as yourself';
+    userInput.style.cssText = 'flex:1 1 320px;min-width:280px;padding:.5rem;background:var(--color-bg-elevated);border:1px solid var(--color-border);border-radius:6px;color:var(--color-text);';
+    controls.appendChild(userInput);
+
+    var runBtn = document.createElement('button');
+    runBtn.className = 'task-spec-pipeline-btn task-spec-pipeline-btn-generate';
+    runBtn.textContent = 'Run Awareness Test';
+    controls.appendChild(runBtn);
+
+    var copyBtn = document.createElement('button');
+    copyBtn.className = 'task-spec-pipeline-btn';
+    copyBtn.textContent = 'Copy JSON';
+    copyBtn.style.display = 'none';
+    controls.appendChild(copyBtn);
+
+    container.appendChild(controls);
+
+    var results = document.createElement('div');
+    results.style.cssText = 'margin-top:1rem;';
+    container.appendChild(results);
+
+    var lastPayload = null;
+
+    function renderChecks(data) {
+        var box = document.createElement('div');
+        box.style.cssText = 'display:grid;grid-template-columns:repeat(auto-fit,minmax(220px,1fr));gap:.5rem;margin-bottom:1rem;';
+        var c = data.checks || {};
+        var items = [
+            ['Identity resolved', c.identity_ok, data.identity && data.identity.user_id ? ('user=' + String(data.identity.user_id).slice(0, 8) + '\u2026 tenant=' + String(data.identity.tenant_id || '').slice(0, 8) + '\u2026') : 'anonymous'],
+            ['Context injected', c.context_injected, (data.context_instruction && data.context_instruction.char_count) + ' chars'],
+            ['Memory items', c.memory_ok, (data.memory && data.memory.item_count) + ' items'],
+            ['Recent ORB turns', c.turns_ok, (data.recent_turns && data.recent_turns.count) + ' turns'],
+            ['Profile summary', c.profile_ok, (data.profile && data.profile.char_count) + ' chars'],
+            ['Awareness overall', c.awareness_ok, c.awareness_ok ? 'ready' : 'degraded'],
+        ];
+        items.forEach(function (row) {
+            var tile = document.createElement('div');
+            var ok = !!row[1];
+            tile.style.cssText = 'padding:.75rem;border-radius:8px;border:1px solid ' +
+                (ok ? 'rgba(34,197,94,0.4)' : 'rgba(239,68,68,0.4)') +
+                ';background:' + (ok ? 'rgba(34,197,94,0.08)' : 'rgba(239,68,68,0.08)') + ';';
+            tile.innerHTML = '<div style="font-size:.75rem;color:var(--color-text-secondary);">' + row[0] + '</div>' +
+                '<div style="font-weight:600;margin-top:.25rem;">' + (ok ? '\u2705' : '\u274c') + ' ' +
+                String(row[2] || '').replace(/</g, '&lt;') + '</div>';
+            box.appendChild(tile);
+        });
+        return box;
+    }
+
+    function renderSection(title, bodyText, meta) {
+        var card = document.createElement('div');
+        card.style.cssText = 'margin-bottom:1rem;padding:1rem;border:1px solid var(--color-border);border-radius:8px;background:var(--color-bg-elevated);';
+        var h = document.createElement('h4');
+        h.style.cssText = 'margin:0 0 .25rem;font-size:.9rem;';
+        h.textContent = title;
+        card.appendChild(h);
+        if (meta) {
+            var m = document.createElement('div');
+            m.style.cssText = 'font-size:.75rem;color:var(--color-text-secondary);margin-bottom:.5rem;';
+            m.textContent = meta;
+            card.appendChild(m);
+        }
+        var pre = document.createElement('pre');
+        pre.style.cssText = 'margin:0;padding:.75rem;background:var(--color-bg);border-radius:6px;overflow:auto;max-height:300px;font-size:.75rem;white-space:pre-wrap;word-break:break-word;';
+        pre.textContent = bodyText || '(empty)';
+        card.appendChild(pre);
+        return card;
+    }
+
+    function renderList(title, arr) {
+        var card = document.createElement('div');
+        card.style.cssText = 'margin-bottom:1rem;padding:1rem;border:1px solid var(--color-border);border-radius:8px;background:var(--color-bg-elevated);';
+        var h = document.createElement('h4');
+        h.style.cssText = 'margin:0 0 .5rem;font-size:.9rem;';
+        h.textContent = title + ' (' + (arr ? arr.length : 0) + ')';
+        card.appendChild(h);
+        if (!arr || !arr.length) {
+            var p = document.createElement('div');
+            p.style.cssText = 'font-size:.8rem;color:var(--color-text-secondary);';
+            p.textContent = '(none)';
+            card.appendChild(p);
+            return card;
+        }
+        arr.forEach(function (s) {
+            var li = document.createElement('div');
+            li.style.cssText = 'padding:.35rem .5rem;background:var(--color-bg);border-radius:4px;margin-bottom:.25rem;font-size:.75rem;white-space:pre-wrap;';
+            li.textContent = s;
+            card.appendChild(li);
+        });
+        return card;
+    }
+
+    function renderResult(data) {
+        results.innerHTML = '';
+        lastPayload = data;
+        copyBtn.style.display = '';
+
+        results.appendChild(renderChecks(data));
+
+        if (data.warnings && data.warnings.length) {
+            var warnCard = document.createElement('div');
+            warnCard.style.cssText = 'padding:.75rem 1rem;background:rgba(234,179,8,0.1);border:1px solid rgba(234,179,8,0.35);border-radius:8px;margin-bottom:1rem;';
+            warnCard.innerHTML = '<strong style="font-size:.85rem;">Warnings</strong>';
+            var ul = document.createElement('ul');
+            ul.style.cssText = 'margin:.5rem 0 0;padding-left:1.25rem;font-size:.8rem;';
+            data.warnings.forEach(function (w) {
+                var li = document.createElement('li'); li.textContent = w; ul.appendChild(li);
+            });
+            warnCard.appendChild(ul);
+            results.appendChild(warnCard);
+        }
+
+        results.appendChild(renderSection(
+            'User Context Profile (summary injected into voice prompt)',
+            data.profile && data.profile.summary ? data.profile.summary : '',
+            'version=' + (data.profile ? data.profile.version : 0) +
+            ' cached=' + (data.profile ? data.profile.cached : false) +
+            ' sections=[' + ((data.profile && data.profile.sections) || []).join(', ') + ']'
+        ));
+
+        results.appendChild(renderList('Memory items (preview)', (data.memory && data.memory.preview) || []));
+        results.appendChild(renderList('Recent ORB turns (preview)', (data.recent_turns && data.recent_turns.preview) || []));
+
+        results.appendChild(renderSection(
+            'Context instruction — what Gemini Live would see',
+            data.context_instruction ? (data.context_instruction.preview + (data.context_instruction.truncated ? '\n\n[\u2026truncated for display\u2026]' : '')) : '',
+            (data.context_instruction ? data.context_instruction.char_count : 0) + ' chars total'
+        ));
+    }
+
+    function runTest() {
+        results.innerHTML = '<div class="placeholder-content">Running awareness check\u2026</div>';
+        var userId = userInput.value.trim();
+        var url = '/api/v1/orb/debug/awareness' + (userId ? ('?user_id=' + encodeURIComponent(userId)) : '');
+        fetch(url, { method: 'GET', headers: buildContextHeaders({ 'Accept': 'application/json' }) })
+            .then(function (r) { return r.json(); })
+            .then(function (data) {
+                if (!data || data.ok === false) {
+                    results.innerHTML = '<div class="error-text" style="padding:1rem;">Error: ' + ((data && data.error) || 'unknown') + '</div>';
+                    return;
+                }
+                renderResult(data);
+            })
+            .catch(function (err) {
+                results.innerHTML = '<div class="error-text" style="padding:1rem;">Request failed: ' + (err && err.message ? err.message : err) + '</div>';
+            });
+    }
+
+    runBtn.onclick = runTest;
+    copyBtn.onclick = function () {
+        if (lastPayload) {
+            try {
+                navigator.clipboard.writeText(JSON.stringify(lastPayload, null, 2));
+                copyBtn.textContent = 'Copied!';
+                setTimeout(function () { copyBtn.textContent = 'Copy JSON'; }, 1500);
+            } catch (e) { /* ignore */ }
+        }
+    };
+
+    // Auto-run on load so operators see the baseline immediately.
+    setTimeout(runTest, 50);
 
     return container;
 }

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -8422,6 +8422,230 @@ router.get('/session/:orb_session_id', (req: Request, res: Response) => {
  *   "timestamp": "ISO"
  * }
  */
+/**
+ * BOOTSTRAP-HISTORY-AWARE-TIMELINE: GET /debug/awareness
+ *
+ * Returns EXACTLY what the voice ORB would know about the authenticated user
+ * at session-start time. Use this to diagnose "Vitana doesn't know about my
+ * activity" reports.
+ *
+ * Auth:
+ *   - Bearer <user_jwt>  → returns that user's awareness snapshot.
+ *   - No auth             → returns diagnostic with identity_ok=false so the
+ *                           caller can see the widget is falling into the
+ *                           anonymous path (the most common cause).
+ *   - Service role + ?user_id=UUID (admin path) → look up any user.
+ *
+ * Response shape is stable so the Command Hub "Vitana Awareness" test panel
+ * can render it.
+ */
+router.get('/debug/awareness', optionalAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const startedAt = Date.now();
+  const checks: Record<string, boolean> = {};
+  const warnings: string[] = [];
+
+  try {
+    // 1. Resolve effective identity -----------------------------------------
+    const authHeader = req.headers.authorization;
+    const hasBearer = !!authHeader && authHeader.startsWith('Bearer ');
+    const jwtVerified = !!(req.identity && req.identity.user_id);
+
+    const explicitUserId = (req.query.user_id as string | undefined) || undefined;
+    const serviceRoleKey = req.get('x-service-role-key');
+    const isServiceRoleCaller = !!serviceRoleKey &&
+      (serviceRoleKey === process.env.SUPABASE_SERVICE_ROLE ||
+       serviceRoleKey === process.env.SUPABASE_SERVICE_ROLE_KEY);
+
+    let identity: SupabaseIdentity | null = null;
+    let isAnonymous = true;
+
+    if (hasBearer && !jwtVerified) {
+      warnings.push('Bearer token provided but JWT failed verification — voice ORB would 401 this client.');
+    }
+
+    if (jwtVerified) {
+      identity = {
+        user_id: req.identity!.user_id,
+        tenant_id: req.identity!.tenant_id,
+        email: req.identity!.email ?? null,
+        role: req.identity!.role ?? null,
+        exafy_admin: req.identity!.exafy_admin ?? false,
+        aud: req.identity!.aud ?? null,
+        exp: req.identity!.exp ?? null,
+        iat: req.identity!.iat ?? null,
+      } as SupabaseIdentity;
+      isAnonymous = false;
+    } else if (explicitUserId && isServiceRoleCaller) {
+      // Service-role admin lookup: resolve tenant for the target user.
+      const supabaseUrl = process.env.SUPABASE_URL;
+      const supabaseKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+      if (supabaseUrl && supabaseKey) {
+        try {
+          const { createClient } = await import('@supabase/supabase-js');
+          const admin = createClient(supabaseUrl, supabaseKey, { auth: { autoRefreshToken: false, persistSession: false } });
+          const { data: tenantRow } = await admin
+            .from('user_tenants')
+            .select('tenant_id')
+            .eq('user_id', explicitUserId)
+            .limit(1)
+            .maybeSingle();
+          if (tenantRow?.tenant_id) {
+            identity = {
+              user_id: explicitUserId,
+              tenant_id: tenantRow.tenant_id,
+              email: null,
+              role: 'authenticated',
+              exafy_admin: false,
+              aud: 'authenticated',
+              exp: null,
+              iat: null,
+            } as SupabaseIdentity;
+            isAnonymous = false;
+          } else {
+            warnings.push(`No user_tenants row for user_id=${explicitUserId}`);
+          }
+        } catch (err: any) {
+          warnings.push(`Admin lookup failed: ${err.message}`);
+        }
+      }
+    } else if (explicitUserId && !isServiceRoleCaller) {
+      warnings.push('user_id query param ignored — service-role key required for admin lookups.');
+    }
+
+    checks.identity_ok = !isAnonymous && !!identity;
+
+    if (!checks.identity_ok || !identity) {
+      return res.status(200).json({
+        ok: true,
+        scenario: 'anonymous',
+        identity: { user_id: '', tenant_id: '', role: 'anonymous', is_anonymous: true },
+        memory: { item_count: 0, preview: [] },
+        recent_turns: { count: 0, preview: [] },
+        profile: { char_count: 0, summary: '', version: 0, cached: false, sections: [] },
+        vitana_index: null,
+        context_instruction: { char_count: 0, preview: '', truncated: false },
+        checks: {
+          identity_ok: false,
+          memory_ok: false,
+          turns_ok: false,
+          profile_ok: false,
+          context_injected: false,
+          awareness_ok: false,
+        },
+        warnings: [
+          'Anonymous call: the voice ORB would skip all personal context for this session.',
+          ...(hasBearer && !jwtVerified ? ['The widget is sending a Bearer token that fails verification — check token freshness.'] : []),
+          ...(hasBearer ? [] : ['No Authorization header — if the user is signed in, the widget is not forwarding the Supabase access token.']),
+          ...warnings,
+        ],
+        elapsed_ms: Date.now() - startedAt,
+      });
+    }
+
+    // 2. Invoke the SAME bootstrap path the voice ORB uses ------------------
+    const debugSessionId = `debug-awareness-${Date.now()}`;
+    const bootstrapResult = await buildBootstrapContextPack(identity, debugSessionId);
+
+    const contextInstruction = bootstrapResult.contextInstruction || '';
+    checks.context_injected = contextInstruction.length > 0;
+
+    // 3. Also fetch profiler separately so the panel can show it distinctly -
+    const tenantIdOrUndefined = identity.tenant_id ?? undefined;
+    const profileResult = await getUserContextSummary(identity.user_id, { tenantId: tenantIdOrUndefined })
+      .catch((err: any) => {
+        warnings.push(`Profiler error: ${err?.message || 'unknown'}`);
+        return { summary: '', version: 0, cached: false, warnings: [] as string[] };
+      });
+
+    if (!identity.tenant_id) {
+      warnings.push('Identity has no tenant_id — memory and profile queries may be scoped incorrectly.');
+    }
+
+    // 4. Inspect the memory path ------------------------------------------
+    const memoryContext = identity.tenant_id
+      ? await fetchMemoryContextWithIdentity(
+          { user_id: identity.user_id, tenant_id: identity.tenant_id },
+          LIVE_CONTEXT_CONFIG.MAX_MEMORY_ITEMS
+        ).catch(() => null as any)
+      : null;
+
+    const recentTurns = identity.tenant_id
+      ? await fetchRecentOrbUserTurns(
+          { user_id: identity.user_id, tenant_id: identity.tenant_id },
+          3
+        ).catch(() => [] as any[])
+      : [];
+
+    const memoryItems = memoryContext?.items || [];
+    checks.memory_ok = memoryItems.length > 0;
+    checks.turns_ok = recentTurns.length > 0;
+
+    const profileSections = (profileResult.summary || '')
+      .split(/\n{2,}/)
+      .map(s => s.split('\n')[0].trim())
+      .filter(s => s.startsWith('['));
+    checks.profile_ok = profileResult.summary.length > 0;
+
+    checks.awareness_ok =
+      checks.identity_ok && checks.context_injected &&
+      (checks.memory_ok || checks.profile_ok || checks.turns_ok);
+
+    return res.status(200).json({
+      ok: true,
+      scenario: isAnonymous ? 'anonymous' : 'authenticated',
+      identity: {
+        user_id: identity.user_id,
+        tenant_id: identity.tenant_id,
+        role: identity.role,
+        email: identity.email,
+        is_anonymous: false,
+      },
+      memory: {
+        item_count: memoryItems.length,
+        preview: memoryItems.slice(0, 5).map((i: any) =>
+          (i.content || '').toString().slice(0, 120)
+        ),
+      },
+      recent_turns: {
+        count: recentTurns.length,
+        preview: recentTurns.slice(0, 3).map((t: any) =>
+          (t.text || t.content || '').toString().slice(0, 120)
+        ),
+      },
+      profile: {
+        char_count: profileResult.summary.length,
+        summary: profileResult.summary,
+        version: profileResult.version,
+        cached: profileResult.cached,
+        sections: profileSections,
+      },
+      context_instruction: {
+        char_count: contextInstruction.length,
+        preview: contextInstruction.slice(0, 4000),
+        truncated: contextInstruction.length > 4000,
+      },
+      checks: {
+        identity_ok: checks.identity_ok,
+        memory_ok: checks.memory_ok,
+        turns_ok: checks.turns_ok,
+        profile_ok: checks.profile_ok,
+        context_injected: checks.context_injected,
+        awareness_ok: checks.awareness_ok,
+      },
+      warnings,
+      elapsed_ms: Date.now() - startedAt,
+    });
+  } catch (err: any) {
+    console.error('[Awareness] debug endpoint error:', err?.message);
+    return res.status(500).json({
+      ok: false,
+      error: err?.message || 'awareness debug failed',
+      warnings,
+      elapsed_ms: Date.now() - startedAt,
+    });
+  }
+});
+
 router.get('/debug/memory', async (_req: Request, res: Response) => {
   // Dev-sandbox gate: return 404 in non-dev environments
   if (!isDevSandbox()) {


### PR DESCRIPTION
Reusable test + diagnostic for the Vitana voice ORB awareness path.

GET /api/v1/orb/debug/awareness invokes the same buildBootstrapContextPack that voice sessions use and returns every context block that would reach Gemini Live — identity, memory, recent turns, profile summary, full context_instruction. Supports Bearer-auth caller OR service-role admin lookup via ?user_id.

Command Hub > Testing & QA now has a 'Vitana Awareness' tab that auto-runs the test and shows pass/fail tiles for each check. Use it whenever a user says 'ORB doesn't know my activity' — if tiles are red, we know exactly which block broke (identity, memory, profile, or context wiring).

Generated with Claude Code