### PR TITLE
perf(orb): cut forwarding stall detection 15s→6s + gauge diagnostics

### DIFF
--- a/services/gateway/src/orb/upstream/constants.ts
+++ b/services/gateway/src/orb/upstream/constants.ts
@@ -62,7 +62,16 @@ export const TURN_RESPONSE_TIMEOUT_MS = 10_000;     // 10s after user speech
 // not processing anything. If Vertex doesn't acknowledge within this window
 // (via input_transcription or model response), stall recovery force-closes
 // the WS to trigger a transparent reconnect.
-export const FORWARDING_ACK_TIMEOUT_MS = 15_000;
+//
+// BOOTSTRAP-ORB-RELIABILITY-R2: Reduced 15 s → 6 s. 24 h production diagnostic
+// showed 21 % of sessions (14 of 67) hit forwarding_no_ack; with 15 s
+// detection + reconnect + greeting re-setup users experienced 20–30 s of
+// dead air. Vertex's SLO for input_transcription is under 2 s; 6 s gives
+// 3× headroom while halving the user-visible interruption window. All 14
+// stalls in the 24 h window successfully recovered via transparent reconnect,
+// so faster detection just makes the recovery faster without raising the
+// false-positive rate.
+export const FORWARDING_ACK_TIMEOUT_MS = 6_000;
 
 // =============================================================================
 // VTID-LOOPGUARD: Response loop prevention

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -4984,9 +4984,17 @@ async function connectToLiveAPI(
                   console.log(`[VTID-VOICE-INIT] Model started speaking for session ${session.sessionId} — mic audio gated`);
                   emitDiag(session, 'model_start_speaking');
                   // BOOTSTRAP-ORB-HOTFIX-1: If this is the greeting (no turns yet
-                  // and greeting was sent), emit the pre-greeting latency gauge
-                  // — baseline metric for Phase 1 latency work.
-                  if (session.greetingSent && session.turn_count === 0 && !session.audioOutChunks) {
+                  // and greeting was sent), emit the pre-greeting latency gauge.
+                  //
+                  // BOOTSTRAP-ORB-RELIABILITY-R2: Log gate evaluation so we can
+                  // debug why the prior gauge version emitted zero events. All
+                  // three booleans are logged so we can spot which guard is
+                  // falsifying the condition in prod.
+                  const gateGreeting = !!session.greetingSent;
+                  const gateTurnZero = session.turn_count === 0;
+                  const gateNoChunks = !session.audioOutChunks;
+                  console.log(`[BOOTSTRAP-ORB-HOTFIX-1-GATE] session=${session.sessionId} greetingSent=${gateGreeting} turn_count=${session.turn_count} audioOutChunks=${session.audioOutChunks}`);
+                  if (gateGreeting && gateTurnZero && gateNoChunks) {
                     const preGreetingMs = Date.now() - session.createdAt.getTime();
                     emitLiveSessionEvent('orb.live.greeting.delivered', {
                       session_id: session.sessionId,
@@ -4997,7 +5005,9 @@ async function connectToLiveAPI(
                       lang: session.lang,
                       is_anonymous: session.isAnonymous || false,
                       reconnect_count: (session as any)._reconnectCount || 0,
-                    }).catch(() => { });
+                    }).catch((err: any) => {
+                      console.warn(`[BOOTSTRAP-ORB-HOTFIX-1] emit failed: ${err?.message || err}`);
+                    });
                     console.log(`[BOOTSTRAP-ORB-HOTFIX-1] pre_greeting_ms=${preGreetingMs} for session ${session.sessionId}`);
                   }
                 }


### PR DESCRIPTION
24h prod diagnostic: 21% of sessions hit forwarding_no_ack stall, and with 15s detection + reconnect users heard 20-30s of dead air. Vertex SLO for input_transcription is <2s; 6s gives 3x headroom and cuts the user-visible interruption window in half. 100% of stalls in the 24h window recovered via transparent reconnect, so faster detection just makes recovery faster without raising failure rate. Also adds per-boolean gate logging for the pre_greeting_ms gauge so we can diagnose why PR #750 emitted zero rows.