### PR TITLE
fix(orb): raise forwarding watchdog 6s to 10s to stop reconnect storm

### DIFF
--- a/services/gateway/src/orb/upstream/constants.ts
+++ b/services/gateway/src/orb/upstream/constants.ts
@@ -71,7 +71,16 @@ export const TURN_RESPONSE_TIMEOUT_MS = 10_000;     // 10s after user speech
 // stalls in the 24 h window successfully recovered via transparent reconnect,
 // so faster detection just makes the recovery faster without raising the
 // false-positive rate.
-export const FORWARDING_ACK_TIMEOUT_MS = 6_000;
+//
+// BOOTSTRAP-ORB-WATCHDOG-RESTORE: Raised 6 s → 10 s after voice sessions
+// started flickering on/off with user reports "greeting and first question
+// break." Field diagnostics showed Vertex legitimately takes 8–9 s to respond
+// to the first user turn when system_instruction is ~15 K chars + 16 tools
+// (our current config with memory + profile + tools). 6 s was firing on every
+// real first question and triggering a reconnect storm. 10 s accommodates
+// normal first-turn latency while still cutting the original 15 s interruption
+// window by a third.
+export const FORWARDING_ACK_TIMEOUT_MS = 10_000;
 
 // =============================================================================
 // VTID-LOOPGUARD: Response loop prevention


### PR DESCRIPTION
Root cause: PR #769 cut FORWARDING_ACK_TIMEOUT_MS from 15s to 6s. With our current voice system_instruction (~15.8K chars + 16 tools) Gemini legitimately takes 8-9s to respond to the first user question. 6s watchdog fires on every real first turn, triggering a reconnect storm — users see the ORB flicker on/off.

Diagnostic: live-43adf2e0, live-0eecfaf2, live-a319cf73 all show turn_complete -> watchdog_fired in 8.0-9.6s, reason=forwarding_no_ack(6000ms), followed by upstream_ws_close + reconnect. Consistent pattern across 3 back-to-back user sessions.

Fix: raise to 10s. Still 33% faster than the original 15s envelope, but above the measured first-turn latency so normal questions reach Gemini. Does NOT touch TURN_RESPONSE_TIMEOUT_MS (10s) or GREETING_RESPONSE_TIMEOUT_MS (8s) — those are fine.

Generated with Claude Code