### PR TITLE
DEV-COMHU-2027: fix showToast infinite recursion in intelligence-panels.js

### DIFF
--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -14,6 +14,6 @@
   <script src="/command-hub/orb-widget.js?v=20260328-aura"></script>
   <script src="/command-hub/app.js?v=20260420-scroll-capture-late-approve-stack"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
-  <script src="/command-hub/intelligence-panels.js"></script>
+  <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
 </body>
 </html>

--- a/services/gateway/src/frontend/command-hub/intelligence-panels.js
+++ b/services/gateway/src/frontend/command-hub/intelligence-panels.js
@@ -584,7 +584,7 @@ function copyToClipboard(callIndex, field) {
   const text = JSON.stringify(data, null, 2);
 
   navigator.clipboard.writeText(text).then(() => {
-    showToast('Copied to clipboard');
+    intelShowToast('Copied to clipboard');
   }).catch(err => {
     console.error('Failed to copy:', err);
   });
@@ -661,17 +661,17 @@ async function fetchRecommendations() {
 function copyRecommendationCommands(recIndex) {
   const rec = IntelligenceState.recommendations[recIndex];
   if (!rec || !rec.suggested_commands || rec.suggested_commands.length === 0) {
-    showToast('No commands to copy');
+    intelShowToast('No commands to copy');
     return;
   }
 
   const text = rec.suggested_commands.join('\n');
 
   navigator.clipboard.writeText(text).then(() => {
-    showToast('Commands copied to clipboard');
+    intelShowToast('Commands copied to clipboard');
   }).catch(err => {
     console.error('[VTID-01221] Failed to copy commands:', err);
-    showToast('Failed to copy commands');
+    intelShowToast('Failed to copy commands');
   });
 }
 
@@ -754,11 +754,16 @@ function formatDate(dateStr) {
 }
 
 /**
- * Show a toast notification
+ * Show a toast notification — delegates to the app-level showToast if it's
+ * available on window. MUST be named `intelShowToast` (not `showToast`) so
+ * that its top-level `function` declaration does not shadow app.js's
+ * `showToast` in the global scope. (Top-level function declarations in
+ * sibling scripts bind the same global, and the last-loaded one wins —
+ * that caused every call to showToast anywhere in the app to recurse into
+ * this delegate and stack-overflow.)
  */
-function showToast(message) {
-  // Use existing toast system if available
-  if (typeof window.showToast === 'function') {
+function intelShowToast(message) {
+  if (typeof window.showToast === 'function' && window.showToast !== intelShowToast) {
     window.showToast(message);
   } else {
     console.log('[Intel Panel]', message);


### PR DESCRIPTION
## Root cause (traced via e2e run [24677151783](https://github.com/exafyltd/vitana-platform/actions/runs/24677151783))

Browser console stack from the e2e run:

\`\`\`
RangeError: Maximum call stack size exceeded
    at showToast (…/intelligence-panels.js:1:1)
    at showToast (…/intelligence-panels.js:1:1)
    at showToast (…/intelligence-panels.js:1:1)
    … ×(lots)
\`\`\`

\`intelligence-panels.js\` declared \`function showToast(message)\` at the top level. Top-level function declarations in sibling \`<script>\` tags all bind the same global object — whichever script loads last overwrites the earlier one. Since \`intelligence-panels.js\` loads **after** \`app.js\` in index.html, it silently replaced the real showToast globally.

The delegate body did:

\`\`\`js
function showToast(message) {
  if (typeof window.showToast === 'function') {
    window.showToast(message);   // <— calls itself, forever
  }
}
\`\`\`

After the overwrite \`window.showToast === intelShowToast\`, so every call to showToast anywhere in the app entered this loop → RangeError.

The user-visible symptom was **\"Approve & execute → Maximum call stack size exceeded\"**. The actual approval response from the server is clean:

\`\`\`json
{
  \"ok\": false,
  \"decision\": {
    \"ok\": false,
    \"violations\": [
      {\"code\": \"risk_class_too_high\", \"message\": \"...\"},
      {\"code\": \"file_outside_allow_scope\", \"message\": \"...\"}
    ]
  },
  \"error\": \"safety gate blocked approval\"
}
\`\`\`

That's a legitimate safety-gate rejection. The RangeError was purely a client-side render bug the user never saw the real reason for.

## Fix
- Rename the intel helper from \`showToast\` → \`intelShowToast\` so it cannot shadow the global
- Update all four internal call sites
- Add guard \`window.showToast !== intelShowToast\` so a future rename accident cannot reintroduce the recursion
- Preserve the delegate behavior: if the app-level \`showToast\` exists, call it; otherwise fall back to \`console.log\`

## Verification
- e2e spec \`dev-autopilot-plan-flow.spec.ts\` (on branch test/dev-autopilot-plan-e2e-DEV-COMHU-2026) already proves plan-gen + scroll-hold pass. Will rerun the same spec after this merges to confirm approve surfaces the real safety-gate rejection inline (\"Approval failed (risk_class_too_high, file_outside_allow_scope)\") instead of the RangeError.

🤖 Generated with [Claude Code](https://claude.com/claude-code)