### PR TITLE
docs(schema): document Account tab profiles fields + visibility

### DIFF
--- a/DATABASE_SCHEMA.md
+++ b/DATABASE_SCHEMA.md
@@ -667,5 +667,34 @@ RLS: users see their own; service role full.
 
 ---
 
+### profiles
+**Purpose:** Canonical per-user profile — identity, contact, and account data surfaced in the MAXINA profile card (Identity | Social | Account pills).
+**Owned by:** Community app (`vitana-v1`), writes via Supabase client.
+**Migration:** `vitana-v1/supabase/migrations/20260421000000_add_account_profile_fields.sql`
+
+**Account tab — fields + per-field visibility:**
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `first_name` | TEXT | Basic Personal Information |
+| `last_name` | TEXT | Basic Personal Information |
+| `date_of_birth` | DATE | Pre-existing; exposed in Account tab |
+| `gender` | TEXT | free-form |
+| `marital_status` | TEXT | free-form |
+| `email` | TEXT | Pre-existing |
+| `phone` | TEXT | Pre-existing |
+| `address` | TEXT | Contact Information |
+| `country` | TEXT | Contact Information |
+| `city` | TEXT | Contact Information |
+| `account_type` | TEXT | e.g. `Community`, `Professional` |
+| `verification_status` | TEXT | CHECK (`unverified` \| `pending` \| `verified`) |
+| `account_visibility` | JSONB | Per-field visibility rule, key → `private` \| `connections` \| `public` |
+
+**Default `account_visibility`:** sensitive fields (names, DOB, contact) default to `private`; `country`/`city` default to `connections`; `member_since` / `account_type` / `verification_status` default to `public`.
+
+**Design principle:** Each field has BOTH a value and a visibility rule. Non-owners only see fields flagged `public`.
+
+---
+
 **Remember:** This file is the SINGLE SOURCE OF TRUTH for table names.
 When in doubt, CHECK HERE FIRST!


### PR DESCRIPTION
## Summary

Adds a `profiles` table section to the canonical `DATABASE_SCHEMA.md`, documenting the new columns introduced by vitana-v1's migration `20260421000000_add_account_profile_fields.sql`:

- `first_name`, `last_name`, `gender`, `marital_status`, `address`, `country`, `city`
- `account_type`, `verification_status` (CHECK: `unverified | pending | verified`)
- `account_visibility` JSONB — per-field visibility rule (`private | connections | public`)

Also captures the design principle for the Account pill on the profile card: **each field has both a value and a visibility rule**, with private-first defaults for sensitive fields.

## Why
Platform rule #24: _"Always update DATABASE_SCHEMA.md when schema changes."_

## Companion PR
- `exafyltd/vitana-v1#179` — actual schema migration + UI implementation.

## Test plan
- [ ] Skim the new `### profiles` section in `DATABASE_SCHEMA.md` — columns and defaults match the migration in `vitana-v1#179`.

https://claude.ai/code/session_018xRvjcLocE5c52Rusqjinq