### PR TITLE
ci(migration): apply account profile fields migration

### DIFF
--- a/.github/workflows/APPLY-ACCOUNT-MIGRATION.yml
+++ b/.github/workflows/APPLY-ACCOUNT-MIGRATION.yml
@@ -1,0 +1,34 @@
+name: Apply Account Profile Fields Migration
+
+# One-shot: applies supabase/migrations/20260421000000_add_account_profile_fields.sql.
+# Runs when this workflow itself is pushed to main, and is safe to re-run
+# (migration uses ADD COLUMN IF NOT EXISTS).
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - '.github/workflows/APPLY-ACCOUNT-MIGRATION.yml'
+  workflow_dispatch:
+
+jobs:
+  migrate:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Apply account-fields migration
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+        run: |
+          sudo apt-get install -y postgresql-client > /dev/null 2>&1
+          echo "Applying 20260421000000_add_account_profile_fields.sql"
+          psql "$SUPABASE_DB_URL" -f "supabase/migrations/20260421000000_add_account_profile_fields.sql"
+          echo "Migration applied"
+
+      - name: Reload PostgREST schema cache
+        env:
+          SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
+        run: |
+          psql "$SUPABASE_DB_URL" -c "NOTIFY pgrst, 'reload schema';"
+          echo "Schema cache reload signal sent"

--- a/DATABASE_SCHEMA.md
+++ b/DATABASE_SCHEMA.md
@@ -667,5 +667,34 @@ RLS: users see their own; service role full.
 
 ---
 
+### profiles
+**Purpose:** Canonical per-user profile — identity, contact, and account data surfaced in the MAXINA profile card (Identity | Social | Account pills).
+**Owned by:** Community app (`vitana-v1`), writes via Supabase client.
+**Migration:** `vitana-v1/supabase/migrations/20260421000000_add_account_profile_fields.sql`
+
+**Account tab — fields + per-field visibility:**
+
+| Column | Type | Notes |
+|--------|------|-------|
+| `first_name` | TEXT | Basic Personal Information |
+| `last_name` | TEXT | Basic Personal Information |
+| `date_of_birth` | DATE | Pre-existing; exposed in Account tab |
+| `gender` | TEXT | free-form |
+| `marital_status` | TEXT | free-form |
+| `email` | TEXT | Pre-existing |
+| `phone` | TEXT | Pre-existing |
+| `address` | TEXT | Contact Information |
+| `country` | TEXT | Contact Information |
+| `city` | TEXT | Contact Information |
+| `account_type` | TEXT | e.g. `Community`, `Professional` |
+| `verification_status` | TEXT | CHECK (`unverified` \| `pending` \| `verified`) |
+| `account_visibility` | JSONB | Per-field visibility rule, key → `private` \| `connections` \| `public` |
+
+**Default `account_visibility`:** sensitive fields (names, DOB, contact) default to `private`; `country`/`city` default to `connections`; `member_since` / `account_type` / `verification_status` default to `public`.
+
+**Design principle:** Each field has BOTH a value and a visibility rule. Non-owners only see fields flagged `public`.
+
+---
+
 **Remember:** This file is the SINGLE SOURCE OF TRUTH for table names.
 When in doubt, CHECK HERE FIRST!

--- a/supabase/migrations/20260421000000_add_account_profile_fields.sql
+++ b/supabase/migrations/20260421000000_add_account_profile_fields.sql
@@ -1,0 +1,40 @@
+-- Account tab — structured personal data + per-field visibility
+--
+-- The profile card now has a third pill, "Account", that stores fixed and
+-- editable personal data in one place. Each field has BOTH a value and a
+-- visibility rule (private / connections / public), stored in
+-- `account_visibility` as JSONB.
+--
+-- Existing columns reused: full_name, email, phone, date_of_birth, created_at
+-- New columns added below.
+
+ALTER TABLE public.profiles
+  ADD COLUMN IF NOT EXISTS first_name           TEXT,
+  ADD COLUMN IF NOT EXISTS last_name            TEXT,
+  ADD COLUMN IF NOT EXISTS gender               TEXT,
+  ADD COLUMN IF NOT EXISTS marital_status       TEXT,
+  ADD COLUMN IF NOT EXISTS address              TEXT,
+  ADD COLUMN IF NOT EXISTS country              TEXT,
+  ADD COLUMN IF NOT EXISTS city                 TEXT,
+  ADD COLUMN IF NOT EXISTS account_type         TEXT,
+  ADD COLUMN IF NOT EXISTS verification_status  TEXT
+    CHECK (verification_status IN ('unverified', 'pending', 'verified')),
+  ADD COLUMN IF NOT EXISTS account_visibility   JSONB
+    NOT NULL DEFAULT '{
+      "firstName": "private",
+      "lastName": "private",
+      "dateOfBirth": "private",
+      "gender": "private",
+      "maritalStatus": "private",
+      "email": "private",
+      "phone": "private",
+      "address": "private",
+      "country": "connections",
+      "city": "connections",
+      "memberSince": "public",
+      "accountType": "public",
+      "verificationStatus": "public"
+    }'::jsonb;
+
+COMMENT ON COLUMN public.profiles.account_visibility IS
+  'Per-field visibility for the Account tab. Keys map to UserProfile.account.* fields. Values: "private" | "connections" | "public". Defaults are private-first for sensitive fields.';


### PR DESCRIPTION
## Summary

One-shot workflow that applies the Account-pill migration introduced in `exafyltd/vitana-v1#179`. Follows the established `VTID-01900-MIGRATION.yml` pattern — auto-runs on push to main when the workflow file itself changes, and is safe to re-run (migration uses `ADD COLUMN IF NOT EXISTS`).

## Files
- `supabase/migrations/20260421000000_add_account_profile_fields.sql` — copy of the migration added in `exafyltd/vitana-v1#179`, brought into this repo so `psql -f` can reach it from the checkout.
- `.github/workflows/APPLY-ACCOUNT-MIGRATION.yml` — calls `psql` against `SUPABASE_DB_URL`, then sends `NOTIFY pgrst, 'reload schema'` so the UI's new fields become visible immediately.

## Migration effect (see `DATABASE_SCHEMA.md#profiles`)
Adds to `public.profiles`:
- `first_name`, `last_name`, `gender`, `marital_status`, `address`, `country`, `city`, `account_type`
- `verification_status` (CHECK `unverified | pending | verified`)
- `account_visibility` JSONB (private-first defaults)

BOOTSTRAP-ACCOUNT-PILL

## Test plan
- [ ] Merge this PR → workflow run "Apply Account Profile Fields Migration" succeeds on main.
- [ ] Verify the new columns exist on `profiles` (`\d public.profiles`) and `account_visibility` default JSON matches the migration.
- [ ] Open the MAXINA profile on mobile → Account pill → edit a field → reload → value persists.

https://claude.ai/code/session_018xRvjcLocE5c52Rusqjinq