### PR TITLE
fix(pgrst): force reload account-fields schema (triple-notify)

### DIFF
--- a/.github/workflows/APPLY-ACCOUNT-MIGRATION.yml
+++ b/.github/workflows/APPLY-ACCOUNT-MIGRATION.yml
@@ -26,9 +26,32 @@ jobs:
           psql "$SUPABASE_DB_URL" -f "supabase/migrations/20260421000000_add_account_profile_fields.sql"
           echo "Migration applied"
 
-      - name: Reload PostgREST schema cache
+      - name: Reload PostgREST schema cache (triple-signal + verify)
         env:
           SUPABASE_DB_URL: ${{ secrets.SUPABASE_DB_URL }}
         run: |
-          psql "$SUPABASE_DB_URL" -c "NOTIFY pgrst, 'reload schema';"
-          echo "Schema cache reload signal sent"
+          # Single NOTIFY sometimes no-ops on hosted Supabase when the
+          # listener connection is momentarily gone. Mirror the pattern
+          # from supabase/migrations/20260416140000_vtid_02000_pgrst_reload.sql.
+          psql "$SUPABASE_DB_URL" <<'SQL'
+          NOTIFY pgrst, 'reload config';
+          NOTIFY pgrst, 'reload schema';
+          SELECT pg_notify('pgrst', 'reload schema');
+
+          -- Small wait, then re-notify for belt-and-braces.
+          SELECT pg_sleep(3);
+          NOTIFY pgrst, 'reload schema';
+
+          -- Verify server-side visibility of the new profiles columns.
+          SELECT column_name, data_type
+            FROM information_schema.columns
+           WHERE table_schema = 'public'
+             AND table_name   = 'profiles'
+             AND column_name IN (
+               'account_visibility','first_name','last_name','gender',
+               'marital_status','address','country','city','account_type',
+               'verification_status'
+             )
+           ORDER BY column_name;
+          SQL
+          echo "Schema reload signals sent; column verification printed above"


### PR DESCRIPTION
## Problem

On a real mobile client, tapping the visibility chip on the Account card shows a red toast:

> Could not update visibility — Could not find the 'account_visibility' column of 'profiles' in the schema cache

The initial `APPLY-ACCOUNT-MIGRATION` run (run `24713486287`) reported `success`, but PostgREST is still serving its pre-migration in-memory schema. On hosted Supabase, a single `NOTIFY pgrst, 'reload schema'` sometimes no-ops when the listener connection is momentarily disconnected.

## Precedent

The repo already has `supabase/migrations/20260416140000_vtid_02000_pgrst_reload.sql` — a migration authored specifically to recover from this same stale-schema state using **three** reload signals.

## Fix

Extend the reload step in `APPLY-ACCOUNT-MIGRATION.yml` to mirror that pattern:
- `NOTIFY pgrst, 'reload config'`
- `NOTIFY pgrst, 'reload schema'`
- `SELECT pg_notify('pgrst', 'reload schema')`
- `pg_sleep(3)` then re-notify (belt-and-braces)
- Verification `SELECT` against `information_schema.columns` so the workflow log confirms server-side visibility of all 10 new columns.

Self-path-filter trigger retriggers the workflow on merge. Migration itself is idempotent (`ADD COLUMN IF NOT EXISTS`), so the re-run is safe.

BOOTSTRAP-ACCOUNT-PILL

## Test plan
- [ ] Merge → workflow auto-runs → `completed | success`.
- [ ] Workflow log's verification SELECT lists all 10 columns (`account_visibility`, `first_name`, `last_name`, `gender`, `marital_status`, `address`, `country`, `city`, `account_type`, `verification_status`).
- [ ] On mobile, reload MAXINA → Profile → **Account** pill → tap a visibility chip — cycles Private → Connections → Public with **no red toast**.
- [ ] Pencil → edit drawer → save a value → persists after reload.

https://claude.ai/code/session_018xRvjcLocE5c52Rusqjinq