### PR TITLE
feat(history): track music plays and surface [CONTENT_PLAYED] in voice profile

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -47,6 +47,7 @@ import { TextToSpeechClient, protos } from '@google-cloud/text-to-speech';
 import { processWithGemini, setThreadIdentity } from '../services/gemini-operator';
 import { emitOasisEvent } from '../services/oasis-event-service';
 import { getUserContextSummary } from '../services/user-context-profiler';
+import { writeTimelineRow } from '../services/timeline-projector';
 import { notifyUserAsync } from '../services/notification-service';
 // VTID-01225: Cognee Entity Extraction Integration
 import { cogneeExtractorClient, type CogneeExtractionRequest } from '../services/cognee-extractor-client';
@@ -3263,6 +3264,27 @@ async function executeLiveApiToolInner(
         }
 
         console.log(`[VTID-01942] play_music: "${query}" → ${title}${channel ? ' — ' + channel : ''} via ${source} (${routingReason ?? 'n/a'}${suggestDefault ? ', suggest_default' : ''})`);
+
+        // BOOTSTRAP-HISTORY-AWARE-TIMELINE: record the play on the user
+        // timeline so the profiler picks it up in [RECENT] + [ACTIVITY_14D].
+        // Without this, the voice ORB has no memory of the songs the user
+        // just asked it to play — the whole point of the content-awareness ask.
+        writeTimelineRow({
+          user_id: lens.user_id,
+          activity_type: 'media.music.play',
+          activity_data: {
+            query,
+            title,
+            channel,
+            source,
+            routing_reason: routingReason,
+            url: disp.url,
+          },
+          context_data: { surface: 'orb' },
+          dedupe_key: `media:music:${source}:${title}:${Math.floor(Date.now() / 60_000)}`,
+          source: 'projector:orb',
+        }).catch(() => {});
+
         return { success: true, result: `${baseAck}${tail}` };
       }
 

--- a/services/gateway/src/services/user-context-profiler.ts
+++ b/services/gateway/src/services/user-context-profiler.ts
@@ -88,9 +88,28 @@ function relativeTime(iso: string): string {
   return `${weeks}w ago`;
 }
 
-function summarizeActivity(type: string): string {
+function summarizeActivity(type: string, data?: Record<string, unknown> | null): string {
   const [prefix, ...rest] = type.split('.');
   const suffix = rest.join('.');
+
+  // BOOTSTRAP-HISTORY-AWARE-TIMELINE: media consumption gets rich labels
+  // that include the actual title so the voice ORB can name-drop the song /
+  // podcast the user played, instead of just saying "played media".
+  if (type === 'media.music.play') {
+    const title = data?.title || data?.query || 'music';
+    const channel = data?.channel ? ` by ${data.channel}` : '';
+    const src = data?.source ? ` on ${formatMediaSource(String(data.source))}` : '';
+    return `played "${title}"${channel}${src}`;
+  }
+  if (type === 'media.podcast.play') {
+    const title = data?.title || data?.query || 'a podcast';
+    return `listened to "${title}"`;
+  }
+  if (type === 'media.shorts.play' || type === 'media.video.play') {
+    const title = data?.title || 'a short';
+    return `watched "${title}"`;
+  }
+
   const map: Record<string, string> = {
     'orb.session.start': 'started voice session',
     'orb.session.stop': 'ended voice session',
@@ -232,6 +251,7 @@ const HIGH_SIGNAL_PREFIXES = [
   'community.',
   'wallet.',
   'memory.',
+  'media.',              // songs, podcasts, shorts, videos
   'orb.session.',
   'task.',
   'calendar.',
@@ -240,8 +260,42 @@ const HIGH_SIGNAL_PREFIXES = [
   'profile.update',
 ];
 
+function formatMediaSource(source: string): string {
+  const map: Record<string, string> = {
+    youtube_music: 'YouTube Music',
+    spotify: 'Spotify',
+    apple_music: 'Apple Music',
+    vitana_hub: 'the Vitana Media Hub',
+  };
+  return map[source] || source;
+}
+
 function isHighSignal(type: string): boolean {
   return HIGH_SIGNAL_PREFIXES.some(p => type === p || type.startsWith(p));
+}
+
+/**
+ * Dedicated content-consumption section. Makes songs / podcasts / shorts the
+ * user played impossible for the voice ORB to miss — they get their own block,
+ * separate from the generic [RECENT] list. Listed newest first with the title.
+ */
+function buildContentSection(activities: ActivityRow[]): string {
+  const media = activities.filter(a => a.activity_type.startsWith('media.'));
+  if (!media.length) return '';
+
+  const seenTitles = new Set<string>();
+  const lines: string[] = [];
+  for (const a of media) {
+    const title = (a.activity_data?.title || a.activity_data?.query || '').toString();
+    const dedupeKey = `${a.activity_type}:${title}`;
+    if (seenTitles.has(dedupeKey)) continue;
+    seenTitles.add(dedupeKey);
+    lines.push(`- ${summarizeActivity(a.activity_type, a.activity_data)} (${relativeTime(a.created_at)})`);
+    if (lines.length >= 8) break;
+  }
+
+  if (!lines.length) return '';
+  return `[CONTENT_PLAYED]\n${lines.join('\n')}`;
 }
 
 function buildRecentSection(activities: ActivityRow[]): string {
@@ -258,7 +312,7 @@ function buildRecentSection(activities: ActivityRow[]): string {
     const key = `${a.activity_type}:${dataKey || relativeTime(a.created_at)}`;
     if (seen.has(key)) continue;
     seen.add(key);
-    lines.push(`- ${summarizeActivity(a.activity_type)} (${relativeTime(a.created_at)})`);
+    lines.push(`- ${summarizeActivity(a.activity_type, a.activity_data)} (${relativeTime(a.created_at)})`);
     if (lines.length >= 8) break;
   }
 
@@ -302,6 +356,7 @@ function buildActivitySummarySection(activities: ActivityRow[]): string {
     community: 'community interactions',
     wallet: 'wallet actions',
     memory: 'memory updates',
+    media: 'content plays',
     orb: 'voice sessions',
     task: 'task actions',
     calendar: 'calendar changes',
@@ -436,6 +491,7 @@ export async function getUserContextSummary(
     buildRoutinesSection(routines, activities),
     buildPreferencesSection(prefs),
     buildHealthSection(activities, vitana),
+    buildContentSection(activities),
     buildFactsSection(factsResult.ok ? factsResult.facts : []),
     buildRecentSection(activities),
   ].filter(Boolean);


### PR DESCRIPTION
User pointed out: content consumption is the most important preference signal, but the voice ORB's play_music tool wasn't writing to the user timeline, so after playing a song the assistant had no memory of it.

Fix: after the music.play capability resolves a track, log a media.music.play row to user_activity_log with query + title + channel + source (youtube_music / spotify / apple_music / vitana_hub) + url. Fire-and-forget, 1-minute dedupe.

Profiler updates: media.* is now high-signal; new [CONTENT_PLAYED] section emits lines like 'played "Shout" by Tears for Fears on Spotify (4m ago)'; [ACTIVITY_14D] counts media plays alongside diary / calendar / community; summarizeActivity labels songs with title + channel + human source name.

Groundwork for media.podcast.play + media.shorts.play is in — the profiler already handles them, just waiting on matching ORB tools. Frontend hooks in vitana-v1 for web music / shorts / video player instrumentation are a separate follow-up.

Generated with Claude Code