### PR TITLE
feat(gateway): ffmpeg thumbnail extraction + backfill for shorts

### DIFF
--- a/services/gateway/Dockerfile
+++ b/services/gateway/Dockerfile
@@ -11,7 +11,7 @@ RUN npm run build
 FROM node:20-alpine
 WORKDIR /app
 COPY package*.json ./
-RUN npm install --production
+RUN apk add --no-cache ffmpeg && npm install --production
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/config ./config
 COPY BUILD_INFO ./

--- a/services/gateway/src/routes/media-hub.ts
+++ b/services/gateway/src/routes/media-hub.ts
@@ -14,11 +14,16 @@
  */
 import { Router, Request, Response } from 'express';
 import { z } from 'zod';
-import { requireAuth } from '../middleware/auth-supabase-jwt';
+import { requireAuth, requireAdminAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
 import {
   analyzeShortFrames,
   VisionClientError,
 } from '../services/anthropic-vision-client';
+import {
+  extractThumbnail,
+  extractStoragePath,
+  VideoExtractionError,
+} from '../services/video-thumbnail-service';
 
 const router = Router();
 
@@ -208,5 +213,178 @@ router.post('/shorts/auto-metadata', requireAuth, async (req: Request, res: Resp
     });
   }
 });
+
+// ── POST /shorts/extract-thumbnail ───────────────────────────────────────
+// Single-video thumbnail extraction. Called by vitana-v1's upload hook right
+// after the media_videos row is inserted. The caller must own the row.
+
+const ExtractThumbnailRequestSchema = z.object({
+  video_id: z.string().uuid(),
+  video_path: z.string().min(1).max(512),
+});
+
+function mapExtractionError(err: unknown): { status: number; code: string; message: string } {
+  if (err instanceof VideoExtractionError) {
+    const status = err.code === 'TIMEOUT' ? 504 : err.code === 'NO_VIDEO_STREAM' ? 422 : 500;
+    return { status, code: err.code, message: err.message };
+  }
+  const message = err instanceof Error ? err.message : 'Unknown error';
+  return { status: 500, code: 'INTERNAL', message };
+}
+
+router.post('/shorts/extract-thumbnail', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const validation = ExtractThumbnailRequestSchema.safeParse(req.body);
+  if (!validation.success) {
+    return res.status(400).json({
+      ok: false,
+      error: 'Invalid request body',
+      details: validation.error.issues,
+    });
+  }
+  const { video_id, video_path } = validation.data;
+  const userId = req.identity?.user_id;
+  if (!userId) {
+    return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+  }
+
+  const supabase = await getServiceClient();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'Service unavailable' });
+
+  const { data: row, error: fetchError } = await supabase
+    .from('media_videos')
+    .select('id, user_id, src_url')
+    .eq('id', video_id)
+    .maybeSingle();
+  if (fetchError) {
+    console.error(`[media-hub] POST /shorts/extract-thumbnail fetch error: ${fetchError.message}`);
+    return res.status(500).json({ ok: false, error: 'Database error', code: 'DB_FETCH_FAILED' });
+  }
+  if (!row) {
+    return res.status(404).json({ ok: false, error: 'Video not found', code: 'NOT_FOUND' });
+  }
+  if (row.user_id !== userId) {
+    return res.status(403).json({ ok: false, error: 'Not the video owner', code: 'FORBIDDEN' });
+  }
+
+  const started = Date.now();
+  try {
+    const extracted = await extractThumbnail(supabase, video_path);
+    const { error: patchError } = await supabase
+      .from('media_videos')
+      .update({
+        thumbnail_url: extracted.thumbnail_url,
+        duration_sec: extracted.duration_sec,
+        width: extracted.width,
+        height: extracted.height,
+      })
+      .eq('id', video_id);
+    if (patchError) {
+      console.error(`[media-hub] POST /shorts/extract-thumbnail patch error: ${patchError.message}`);
+      return res.status(500).json({ ok: false, error: 'Database error', code: 'DB_PATCH_FAILED' });
+    }
+
+    console.log(
+      `[media-hub] thumbnail extracted video_id=${video_id} user=${userId} latency_ms=${Date.now() - started}`,
+    );
+    return res.json({
+      ok: true,
+      thumbnail_url: extracted.thumbnail_url,
+      duration_sec: extracted.duration_sec,
+      width: extracted.width,
+      height: extracted.height,
+      latency_ms: Date.now() - started,
+    });
+  } catch (err) {
+    const mapped = mapExtractionError(err);
+    console.error(
+      `[media-hub] POST /shorts/extract-thumbnail failed video_id=${video_id} code=${mapped.code}: ${mapped.message}`,
+    );
+    return res.status(mapped.status).json({
+      ok: false,
+      error: 'Thumbnail extraction failed',
+      code: mapped.code,
+      details: mapped.message,
+    });
+  }
+});
+
+// ── POST /admin/backfill-video-thumbnails ────────────────────────────────
+// One-shot backfill for rows that landed with thumbnail_url=null. Admin only,
+// synchronous, paged at batch_size per call so a single invocation can't
+// exhaust the Cloud Run request window. Re-call until processed=0.
+
+const BackfillRequestSchema = z.object({
+  batch_size: z.number().int().min(1).max(25).optional(),
+});
+
+router.post(
+  '/admin/backfill-video-thumbnails',
+  requireAdminAuth,
+  async (req: AuthenticatedRequest, res: Response) => {
+    const validation = BackfillRequestSchema.safeParse(req.body ?? {});
+    if (!validation.success) {
+      return res.status(400).json({
+        ok: false,
+        error: 'Invalid request body',
+        details: validation.error.issues,
+      });
+    }
+    const batchSize = validation.data.batch_size ?? 10;
+
+    const supabase = await getServiceClient();
+    if (!supabase) return res.status(503).json({ ok: false, error: 'Service unavailable' });
+
+    const { data: rows, error: listError } = await supabase
+      .from('media_videos')
+      .select('id, src_url')
+      .is('thumbnail_url', null)
+      .not('src_url', 'is', null)
+      .limit(batchSize);
+    if (listError) {
+      return res.status(500).json({ ok: false, error: 'Database error', code: 'DB_LIST_FAILED', details: listError.message });
+    }
+    if (!rows || rows.length === 0) {
+      return res.json({ ok: true, processed: 0, succeeded: 0, failed: 0, errors: [] });
+    }
+
+    let succeeded = 0;
+    const errors: Array<{ id: string; code: string; message: string }> = [];
+    for (const row of rows) {
+      const videoPath = extractStoragePath(row.src_url as string, 'media') ?? row.src_url;
+      if (!videoPath) {
+        errors.push({ id: row.id as string, code: 'BAD_SRC_URL', message: 'Cannot derive storage path' });
+        continue;
+      }
+      try {
+        const extracted = await extractThumbnail(supabase, videoPath);
+        const { error: patchError } = await supabase
+          .from('media_videos')
+          .update({
+            thumbnail_url: extracted.thumbnail_url,
+            duration_sec: extracted.duration_sec,
+            width: extracted.width,
+            height: extracted.height,
+          })
+          .eq('id', row.id);
+        if (patchError) {
+          errors.push({ id: row.id as string, code: 'DB_PATCH_FAILED', message: patchError.message });
+          continue;
+        }
+        succeeded += 1;
+      } catch (err) {
+        const mapped = mapExtractionError(err);
+        errors.push({ id: row.id as string, code: mapped.code, message: mapped.message });
+      }
+    }
+
+    return res.json({
+      ok: true,
+      processed: rows.length,
+      succeeded,
+      failed: rows.length - succeeded,
+      errors,
+    });
+  },
+);
 
 export default router;

--- a/services/gateway/src/services/video-thumbnail-service.ts
+++ b/services/gateway/src/services/video-thumbnail-service.ts
@@ -1,0 +1,214 @@
+/**
+ * BOOTSTRAP-SHORTS-THUMBNAIL: ffmpeg-based thumbnail extraction for shorts.
+ *
+ * Downloads a video from the Supabase `media` bucket, runs ffprobe to read
+ * dimensions/duration, runs ffmpeg to extract a single JPEG frame, uploads
+ * the thumbnail back to the same bucket, and returns a public URL + metadata
+ * ready to PATCH onto the media_videos row.
+ *
+ * Requires `ffmpeg` + `ffprobe` to be present on PATH (installed via the
+ * gateway Dockerfile's `apk add --no-cache ffmpeg`).
+ */
+import { spawn } from 'child_process';
+import { randomUUID } from 'crypto';
+import * as fs from 'fs/promises';
+import * as os from 'os';
+import * as path from 'path';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+export interface ExtractedVideoMetadata {
+  thumbnail_url: string;
+  duration_sec: number;
+  width: number;
+  height: number;
+}
+
+export class VideoExtractionError extends Error {
+  constructor(public code: string, message: string) {
+    super(message);
+    this.name = 'VideoExtractionError';
+  }
+}
+
+interface ProbeResult {
+  width: number;
+  height: number;
+  durationSec: number;
+}
+
+function runCommand(
+  cmd: string,
+  args: string[],
+  timeoutMs: number,
+): Promise<{ stdout: string; stderr: string; code: number }> {
+  return new Promise((resolve, reject) => {
+    const child = spawn(cmd, args, { stdio: ['ignore', 'pipe', 'pipe'] });
+    let stdout = '';
+    let stderr = '';
+    const timer = setTimeout(() => {
+      child.kill('SIGKILL');
+      reject(new VideoExtractionError('TIMEOUT', `${cmd} timed out after ${timeoutMs}ms`));
+    }, timeoutMs);
+
+    child.stdout.on('data', (d) => {
+      stdout += d.toString();
+    });
+    child.stderr.on('data', (d) => {
+      stderr += d.toString();
+    });
+    child.on('error', (err) => {
+      clearTimeout(timer);
+      reject(new VideoExtractionError('SPAWN_FAILED', `${cmd} failed to spawn: ${err.message}`));
+    });
+    child.on('close', (code) => {
+      clearTimeout(timer);
+      resolve({ stdout, stderr, code: code ?? -1 });
+    });
+  });
+}
+
+async function probeVideo(filePath: string): Promise<ProbeResult> {
+  const { stdout, stderr, code } = await runCommand(
+    'ffprobe',
+    [
+      '-v', 'error',
+      '-select_streams', 'v:0',
+      '-show_entries', 'stream=width,height,duration',
+      '-show_entries', 'format=duration',
+      '-of', 'json',
+      filePath,
+    ],
+    15_000,
+  );
+  if (code !== 0) {
+    throw new VideoExtractionError('PROBE_FAILED', `ffprobe exit ${code}: ${stderr.slice(0, 400)}`);
+  }
+
+  let parsed: any;
+  try {
+    parsed = JSON.parse(stdout);
+  } catch {
+    throw new VideoExtractionError('PROBE_PARSE_FAILED', 'ffprobe returned non-JSON output');
+  }
+
+  const stream = parsed.streams?.[0];
+  if (!stream || !stream.width || !stream.height) {
+    throw new VideoExtractionError('NO_VIDEO_STREAM', 'File has no decodable video stream');
+  }
+
+  const durationRaw = stream.duration || parsed.format?.duration || '0';
+  const durationSec = Math.max(0, Math.floor(parseFloat(String(durationRaw))));
+
+  return {
+    width: Number(stream.width),
+    height: Number(stream.height),
+    durationSec,
+  };
+}
+
+function thumbnailPathFor(videoPath: string): string {
+  return videoPath.replace(/\.[^./]+$/, '.jpg');
+}
+
+/**
+ * Downloads `videoPath` from the `media` bucket, extracts a thumbnail, uploads
+ * it back, and returns the new thumbnail's public URL + video metadata.
+ * Caller is responsible for patching media_videos.
+ */
+export async function extractThumbnail(
+  supabase: SupabaseClient,
+  videoPath: string,
+): Promise<ExtractedVideoMetadata> {
+  const workDir = await fs.mkdtemp(path.join(os.tmpdir(), 'short-thumb-'));
+  const videoExt = path.extname(videoPath) || '.mp4';
+  const localVideoPath = path.join(workDir, `src${videoExt}`);
+  const localThumbPath = path.join(workDir, `${randomUUID()}.jpg`);
+
+  try {
+    const { data: blob, error: downloadError } = await supabase.storage
+      .from('media')
+      .download(videoPath);
+    if (downloadError || !blob) {
+      throw new VideoExtractionError(
+        'DOWNLOAD_FAILED',
+        `Supabase storage download failed for ${videoPath}: ${downloadError?.message ?? 'no data'}`,
+      );
+    }
+    const bytes = Buffer.from(await blob.arrayBuffer());
+    await fs.writeFile(localVideoPath, bytes);
+
+    const probe = await probeVideo(localVideoPath);
+
+    const seekTime = probe.durationSec > 1 ? '00:00:01' : '00:00:00';
+    const ffmpegResult = await runCommand(
+      'ffmpeg',
+      [
+        '-y',
+        '-ss', seekTime,
+        '-i', localVideoPath,
+        '-vframes', '1',
+        '-q:v', '3',
+        localThumbPath,
+      ],
+      30_000,
+    );
+    if (ffmpegResult.code !== 0) {
+      throw new VideoExtractionError(
+        'FFMPEG_FAILED',
+        `ffmpeg exit ${ffmpegResult.code}: ${ffmpegResult.stderr.slice(0, 400)}`,
+      );
+    }
+
+    const thumbBytes = await fs.readFile(localThumbPath);
+    if (thumbBytes.byteLength === 0) {
+      throw new VideoExtractionError('EMPTY_THUMBNAIL', 'ffmpeg produced an empty JPEG');
+    }
+
+    const remoteThumbPath = thumbnailPathFor(videoPath);
+    const { error: uploadError } = await supabase.storage
+      .from('media')
+      .upload(remoteThumbPath, thumbBytes, {
+        contentType: 'image/jpeg',
+        upsert: true,
+        cacheControl: '3600',
+      });
+    if (uploadError) {
+      throw new VideoExtractionError(
+        'UPLOAD_FAILED',
+        `Supabase storage upload failed for ${remoteThumbPath}: ${uploadError.message}`,
+      );
+    }
+
+    const { data: publicUrlData } = supabase.storage.from('media').getPublicUrl(remoteThumbPath);
+    if (!publicUrlData?.publicUrl) {
+      throw new VideoExtractionError('NO_PUBLIC_URL', 'getPublicUrl returned empty');
+    }
+
+    return {
+      thumbnail_url: publicUrlData.publicUrl,
+      duration_sec: probe.durationSec,
+      width: probe.width,
+      height: probe.height,
+    };
+  } finally {
+    await fs.rm(workDir, { recursive: true, force: true }).catch(() => undefined);
+  }
+}
+
+/**
+ * Extracts the storage path (key within the bucket) from a Supabase public URL.
+ * Mirrors the vitana-v1 helper so the gateway can backfill rows whose src_url
+ * is a full public URL rather than a raw storage path.
+ */
+export function extractStoragePath(publicUrl: string, bucket: string): string | null {
+  if (!publicUrl) return null;
+  const marker = `/storage/v1/object/public/${bucket}/`;
+  const idx = publicUrl.indexOf(marker);
+  if (idx === -1) return null;
+  const raw = publicUrl.slice(idx + marker.length);
+  try {
+    return decodeURIComponent(raw);
+  } catch {
+    return raw;
+  }
+}


### PR DESCRIPTION
## Summary

Rehomes shorts thumbnail extraction from a never-deployed (and never-deployable) Supabase Edge Function to the already-governed gateway Cloud Run service. Adds the ffmpeg binary to the runtime image and two new routes on `/api/v1/media-hub`.

- **Dockerfile** — `apk add --no-cache ffmpeg` in the runtime stage.
- **`POST /shorts/extract-thumbnail`** (`requireAuth`) — the upload flow calls this right after the `media_videos` insert. Verifies ownership, runs ffprobe + ffmpeg, uploads the JPEG back to the `media` bucket, PATCHes `thumbnail_url` / `duration_sec` / `width` / `height` onto the row. Typed error codes (`TIMEOUT`, `NO_VIDEO_STREAM`, `DOWNLOAD_FAILED`, `FFMPEG_FAILED`, …).
- **`POST /admin/backfill-video-thumbnails`** (`requireAdminAuth`) — one-shot backfill. Pages at `batch_size` (default 10, max 25), reuses the same extractor, returns per-row errors. Re-call until `processed=0`.
- **`services/gateway/src/services/video-thumbnail-service.ts`** — shared extraction helper. Temp dir in `os.tmpdir()`, cleaned up in `finally`. Hard timeouts on both ffprobe (15s) and ffmpeg (30s).

## Why

`f783325` on the vitana-v1 side wired the upload hook at a Supabase Edge Function that (a) has no deploy path in this org and (b) runs on Deno Deploy, which has no ffmpeg binaries. Two shorts that landed today have `thumbnail_url = null` as a result. The companion vitana-v1 PR (e615198) repoints the client at this endpoint.

## Rollout

1. Merge this PR first — `BOOTSTRAP-SHORTS-THUMBNAIL` in the commit body triggers AUTO-DEPLOY → EXEC-DEPLOY.
2. Verify `/alive` + that `POST /api/v1/media-hub/shorts/extract-thumbnail` returns `application/json` (401 without auth is expected and means the route exists).
3. Run the backfill once against the 2 known orphans.
4. Then merge the companion vitana-v1 PR.

## Test plan

- [ ] Docker build succeeds and `which ffmpeg` returns `/usr/bin/ffmpeg` in the runtime image
- [ ] `POST /shorts/extract-thumbnail` without Bearer token → 401 JSON
- [ ] `POST /shorts/extract-thumbnail` with a non-owner token → 403 JSON
- [ ] Happy path upload on vitana-v1 dev → row lands with null thumbnail, gateway populates it within ~5-10s, `['shorts']` invalidation re-renders the card
- [ ] Audio-only `.mp4` upload → row persists with null thumbnail, server logs `NO_VIDEO_STREAM`
- [ ] `POST /admin/backfill-video-thumbnails` populates both legacy orphan rows

https://claude.ai/code/session_01Rtzk3FJJw6xGWjoC5Yt55K