### PR TITLE
fix(orb-voice): teach override prompt about [CONTENT_PLAYED] + cross-device rule

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -4260,16 +4260,40 @@ table at session start.
 
 ${profileSummary}
 
+**SECTION KEY — what each tag in the profile above means:**
+  - [ACTIVITY_14D]     → one-line counted summary of the last 14 days.
+  - [ROUTINES]         → time-of-day / rhythm patterns.
+  - [PREFERENCES]      → explicit + inferred preferences (music genre, food, etc.).
+  - [HEALTH]           → Vitana Index + biomarker/supplement activity.
+  - [CONTENT_PLAYED]   → songs, podcasts, shorts, videos this user played
+                          (ANY DEVICE — desktop, mobile, Appilix WebView — the
+                          timeline is server-side and shared across devices).
+  - [FACTS]            → verified facts about the user.
+  - [RECENT]           → last ~8 high-signal actions with relative times.
+
 **HARD RULES — when the user asks about their recent activity, history,
-routines, preferences, or ANY form of "what have I been doing / what did I do
-today / was habe ich heute gemacht":**
+routines, preferences, listening/viewing habits, or ANY form of "what have
+I been doing / what did I play / what did I listen to / was habe ich gespielt /
+was habe ich heute gemacht / what music did I play":**
 
 1. ANSWER FROM THE PROFILE ABOVE. Start from the [ACTIVITY_14D] one-line
-   summary and pull 2–3 concrete items from [RECENT] or [FACTS]. Example (de):
-     User: "Weißt du, was ich heute im Vitana-System gemacht habe?"
+   summary and pull 2–3 concrete items from [CONTENT_PLAYED] (for music /
+   podcasts / videos), [RECENT], or [FACTS]. Examples:
+
+     User (de): "Weißt du, welches Lied ich gerade gespielt habe?"
+     ✓ Good: "Ja, du hast vor ein paar Minuten ‚Shout' von Tears for Fears
+       auf YouTube Music gespielt."
+       (Quoted directly from [CONTENT_PLAYED].)
+
+     User (en): "What songs have I been listening to?"
+     ✓ Good: "Earlier today you played Shout by Tears for Fears on YouTube
+       Music, and a couple of hours ago Brzo Brzo by Nataša Bekvalac on
+       Spotify. Want me to keep going with that vibe?"
+
+     User (de): "Weißt du, was ich heute im Vitana-System gemacht habe?"
      ✓ Good: "Ja, in den letzten zwei Wochen hast du acht Kalendereinträge,
-       27 Entdeckungs-Interaktionen und einige Anmeldungen gemacht. Zuletzt
-       hast du Kalenderereignisse hinzugefügt — ich sehe drei in der letzten
+       27 Entdeckungs-Interaktionen und ein paar Songs gespielt. Zuletzt hast
+       du Kalenderereignisse hinzugefügt — ich sehe drei in der letzten
        Woche. Du bist am aktivsten nachmittags."
      ✗ BAD: "You are now in the event screen."
        (This is currentRoute, NOT activity history — wrong answer shape.)
@@ -4280,21 +4304,29 @@ today / was habe ich heute gemacht":**
    answer to activity questions. The current screen tells you WHERE the user
    is RIGHT NOW; activity history tells you WHAT THEY DID. Different questions.
 
-3. DO NOT call get_current_screen, search_memory, search_knowledge, or any
+3. CROSS-DEVICE: [CONTENT_PLAYED] and [RECENT] include plays / actions from
+   ALL of the user's devices — desktop browser, mobile browser, Maxina
+   Appilix WebView. If the user asks on their phone what they played on
+   desktop, the answer IS in the profile above because the timeline is
+   server-side. Don't say "I can't see what you did on another device."
+
+4. DO NOT call get_current_screen, search_memory, search_knowledge, or any
    other tool to answer history questions. The answer is already in the
    profile above. Tool calls here waste 2–5 seconds and return LESS than
    what's already on screen for you.
 
-4. If the user asks about a specific category ("did I add any calendar events?"
-   / "have I done anything with health lately?"), filter the [RECENT] lines
-   and [ACTIVITY_14D] counts by that category and answer from them.
+5. If the user asks about a specific category ("did I add any calendar events?"
+   / "have I done anything with health lately?" / "what podcasts did I
+   listen to?"), filter the matching section and answer from it. Music
+   questions → [CONTENT_PLAYED] first. Calendar → [RECENT] filtered for
+   calendar. Health → [HEALTH] + [RECENT] filtered for health.
 
-5. ONLY IF [ACTIVITY_14D], [RECENT] AND [FACTS] are ALL empty in the profile
-   above may you say "I don't see much activity yet in the system — have you
-   been using Vitana recently?" NEVER claim emptiness when the sections
-   contain data.
+6. ONLY IF [ACTIVITY_14D], [CONTENT_PLAYED], [RECENT] AND [FACTS] are ALL
+   empty in the profile above may you say "I don't see much activity yet
+   in the system — have you been using Vitana recently?" NEVER claim
+   emptiness when the sections contain data.
 
-6. Weave the answer naturally — do not recite section headers or bracket
+7. Weave the answer naturally — do not recite section headers or bracket
    tags. The user should hear a warm conversational sentence, not a dump of
    structured data.`;
     }


### PR DESCRIPTION
User played a song on desktop ORB, then asked on mobile ORB (same account) what they played — got 'I don't know'. Root cause: PR #788 added media.music.play writes + [CONTENT_PLAYED] section to the profile, but the ACTIVITY AWARENESS OVERRIDE prompt from #777 only told the model about [ACTIVITY_14D] / [RECENT] / [FACTS]. The model literally was never told [CONTENT_PLAYED] exists or what it means.

Fix: rewrite the override block to (1) open with a SECTION KEY explaining what every bracket tag means, calling out [CONTENT_PLAYED] as songs/podcasts/shorts/videos on ANY DEVICE; (2) widen trigger list to include 'what did I play / what music'; (3) add concrete [CONTENT_PLAYED] worked examples in German and English; (4) new rule #3 explicitly stating the timeline is server-side and aggregates plays across desktop / mobile / Maxina Appilix; (5) route music questions to [CONTENT_PLAYED] first; (6) include [CONTENT_PLAYED] in the all-empty check.

No data-layer changes — the profile already has the song row. This is the prompt plumbing that tells Gemini what to do with it.

Generated with Claude Code