### PR TITLE
fix(dev-autopilot): delimiter output format instead of JSON (executor stopped dying on source-code escapes)

### DIFF
--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -489,29 +489,50 @@ interface ExecutionLlmOutput {
   pr_body: string;
 }
 
-function parseExecutionJson(raw: string): ExecutionLlmOutput | { error: string } {
-  // Strip any fenced-code-block wrapper the model may have added despite the
-  // instruction. Also strip any leading narration before the opening brace.
-  let text = raw.trim();
-  const fenced = text.match(/```(?:json)?\s*([\s\S]*?)\s*```/);
-  if (fenced) text = fenced[1].trim();
-  // Otherwise, take from the first '{' to the last matching '}'
-  const start = text.indexOf('{');
-  const end = text.lastIndexOf('}');
-  if (start < 0 || end < 0 || end <= start) {
-    return { error: 'No JSON object found in model output' };
+// Delimiter-based format. Before: we asked the model to emit JSON with source
+// code inside string values. That forced correct escaping of every quote,
+// backslash, and newline across thousands of characters of TypeScript. In
+// practice the model occasionally emitted unescaped characters that broke
+// JSON.parse with errors like "SyntaxError: Expected ',' or ']' after array
+// element in JSON at position 46866" (execution 265fbf0f). Source code
+// inside verbatim delimiter blocks sidesteps all of that.
+function parseExecutionOutput(raw: string): ExecutionLlmOutput | { error: string } {
+  const text = raw.trim();
+
+  // pr_title: single line
+  const titleMatch = text.match(/<<<PR_TITLE>>>\s*([\s\S]*?)\s*<<<END>>>/);
+  if (!titleMatch) return { error: 'Missing <<<PR_TITLE>>>…<<<END>>> block' };
+  const pr_title = titleMatch[1].trim();
+
+  // pr_body: multi-line markdown
+  const bodyMatch = text.match(/<<<PR_BODY>>>\s*([\s\S]*?)\s*<<<END>>>/);
+  if (!bodyMatch) return { error: 'Missing <<<PR_BODY>>>…<<<END>>> block' };
+  const pr_body = bodyMatch[1];
+
+  // files: each block wraps raw content. Match header, then consume until the
+  // NEAREST matching <<<END>>> that's followed by a recognised boundary
+  // (another <<<FILE…>>> header, end of text, or whitespace to EOF).
+  // Using non-greedy match is fine for clean files, but source may contain
+  // "<<<END>>>" as a literal string; guard by requiring it at start of line.
+  const fileRe = /<<<FILE\s+(create|modify|delete)\s+([^\s>]+)\s*>>>\s*\r?\n([\s\S]*?)\r?\n<<<END>>>/g;
+  const files: ExecutionLlmOutput['files'] = [];
+  let m: RegExpExecArray | null;
+  while ((m = fileRe.exec(text)) !== null) {
+    const action = m[1] as 'create' | 'modify' | 'delete';
+    const path = m[2].trim();
+    const content = action === 'delete' ? undefined : m[3];
+    files.push({ path, action, content });
   }
-  const candidate = text.slice(start, end + 1);
-  try {
-    const parsed = JSON.parse(candidate);
-    if (!parsed || !Array.isArray(parsed.files)) {
-      return { error: 'Parsed JSON missing files[]' };
-    }
-    return parsed as ExecutionLlmOutput;
-  } catch (err) {
-    return { error: `JSON parse failed: ${String(err).slice(0, 200)}` };
+  if (files.length === 0) {
+    return { error: 'No <<<FILE …>>>…<<<END>>> blocks found' };
   }
+
+  return { files, pr_title, pr_body };
 }
+
+// Back-compat export name for existing tests / callers. Now points to the
+// new delimiter parser.
+const parseExecutionJson = parseExecutionOutput;
 
 interface FileCtx { path: string; exists: boolean; content?: string; sha?: string }
 
@@ -561,34 +582,47 @@ function buildExecutionPrompt(
     }
   }
   lines.push(
-    `## Output format`,
+    `## Output format — delimiter blocks, NOT JSON`,
     ``,
-    `Return a single JSON object (and nothing else) with this exact shape:`,
+    `Emit output in this exact shape (and nothing else, no surrounding prose or`,
+    `fences). File contents go VERBATIM between the markers — no escaping, no`,
+    `quoting, newlines are literal:`,
     ``,
-    '```json',
-    '{',
-    '  "files": [',
-    '    {',
-    '      "path": "services/gateway/src/routes/example.test.ts",',
-    '      "action": "create",',
-    '      "content": "…full file contents as a JSON string…"',
-    '    }',
-    '  ],',
-    '  "pr_title": "Short descriptive PR title (<=70 chars)",',
-    '  "pr_body": "Markdown body explaining what the PR does and why, suitable for a GitHub PR description."',
-    '}',
-    '```',
+    `<<<PR_TITLE>>>`,
+    `DEV-AUTOPILOT: short descriptive title (<=70 chars)`,
+    `<<<END>>>`,
+    ``,
+    `<<<PR_BODY>>>`,
+    `Markdown body that describes what this PR does and why. Can span many lines.`,
+    `Reference the finding; summarise the plan; list the files touched.`,
+    `<<<END>>>`,
+    ``,
+    `<<<FILE create services/gateway/src/routes/example.test.ts>>>`,
+    `// full file contents go here, verbatim`,
+    `import { foo } from 'bar';`,
+    ``,
+    `describe('example', () => {`,
+    `  it('works', () => {`,
+    `    expect(1).toBe(1);`,
+    `  });`,
+    `});`,
+    `<<<END>>>`,
     ``,
     `Rules:`,
-    `- Allowed actions: "create", "modify", "delete". For "delete" omit "content".`,
-    `- Only emit file paths that appear in the plan's Files-to-modify list. Do not`,
-    `  sneak in unrelated files.`,
-    `- "content" must be the complete file — the executor writes it verbatim.`,
-    `- Escape newlines and quotes correctly in the JSON string. Use \\n for newlines.`,
-    `- pr_title should reference the finding: e.g. "DEV-AUTOPILOT: add tests for …".`,
-    `- pr_body should summarise the plan + list the files changed.`,
+    `- Allowed actions in the FILE header: "create", "modify", "delete". For`,
+    `  "delete" emit the header + immediately <<<END>>> with no content in`,
+    `  between.`,
+    `- Emit one <<<FILE …>>>…<<<END>>> block per file in the plan's`,
+    `  Files-to-modify list. Do not emit files outside that list.`,
+    `- File content is written verbatim — do NOT wrap it in Markdown code`,
+    `  fences, do NOT escape quotes, do NOT use \\n; just write the actual`,
+    `  characters.`,
+    `- Never emit the literal string "<<<END>>>" inside a file's content;`,
+    `  it terminates the block. In the extremely rare case you need to, split`,
+    `  the string across lines or concatenation.`,
+    `- Produce all PR_TITLE, PR_BODY, and FILE blocks in a single response.`,
     ``,
-    `Produce the JSON now.`,
+    `Start now.`,
   );
   return lines.join('\n');
 }

--- a/services/gateway/test/dev-autopilot-execute.test.ts
+++ b/services/gateway/test/dev-autopilot-execute.test.ts
@@ -49,56 +49,100 @@ describe('extractDeletions', () => {
   });
 });
 
-describe('parseExecutionJson', () => {
-  it('parses a clean JSON object', () => {
-    const raw = JSON.stringify({
-      files: [{ path: 'a/b.ts', action: 'create', content: 'export {};' }],
-      pr_title: 'T',
-      pr_body: 'B',
-    });
-    const out = parseExecutionJson(raw);
-    if ('error' in out) throw new Error(`unexpected: ${out.error}`);
-    expect(out.files).toHaveLength(1);
-    expect(out.files[0].path).toBe('a/b.ts');
-    expect(out.pr_title).toBe('T');
-  });
-
-  it('strips ```json fences the model often adds', () => {
+describe('parseExecutionJson (delimiter format)', () => {
+  it('parses a complete delimiter-formatted response', () => {
     const raw = [
-      'Here you go:',
-      '```json',
-      JSON.stringify({
-        files: [{ path: 'x.ts', action: 'create', content: 'c' }],
-        pr_title: 't',
-        pr_body: 'b',
-      }),
-      '```',
+      '<<<PR_TITLE>>>',
+      'DEV-AUTOPILOT: add tests for foo',
+      '<<<END>>>',
+      '',
+      '<<<PR_BODY>>>',
+      '## Summary',
+      '',
+      'Adds Jest tests for the foo module.',
+      '<<<END>>>',
+      '',
+      '<<<FILE create services/gateway/src/routes/foo.test.ts>>>',
+      "import { foo } from '../foo';",
+      '',
+      "describe('foo', () => {",
+      "  it('does a thing', () => {",
+      '    expect(foo()).toBe(42);',
+      '  });',
+      '});',
+      '<<<END>>>',
     ].join('\n');
     const out = parseExecutionJson(raw);
     if ('error' in out) throw new Error(`unexpected: ${out.error}`);
-    expect(out.files[0].path).toBe('x.ts');
+    expect(out.pr_title).toBe('DEV-AUTOPILOT: add tests for foo');
+    expect(out.pr_body).toContain('Adds Jest tests');
+    expect(out.files).toHaveLength(1);
+    expect(out.files[0].path).toBe('services/gateway/src/routes/foo.test.ts');
+    expect(out.files[0].action).toBe('create');
+    expect(out.files[0].content).toContain("import { foo } from '../foo';");
+    expect(out.files[0].content).toContain('expect(foo()).toBe(42);');
   });
 
-  it('recovers JSON when the model adds leading narration before {', () => {
-    const raw = 'Sure. Here is the structured output you asked for: { "files": [{"path":"a.ts","action":"create","content":"x"}], "pr_title":"t", "pr_body":"b" }';
+  it('handles source code that contains quotes, backslashes, and braces without escaping', () => {
+    // The exact class of content that broke the old JSON parser.
+    const code = [
+      'export function render() {',
+      '  const msg = "user said \\"hi\\" and then {went} away";',
+      "  const re = /^[a-z]+\\s*$/;",
+      '  return `Template ${msg} with ${re.source}`;',
+      '}',
+    ].join('\n');
+    const raw = [
+      '<<<PR_TITLE>>>t<<<END>>>',
+      '<<<PR_BODY>>>b<<<END>>>',
+      '<<<FILE create services/gateway/src/a.ts>>>',
+      code,
+      '<<<END>>>',
+    ].join('\n');
     const out = parseExecutionJson(raw);
     if ('error' in out) throw new Error(`unexpected: ${out.error}`);
-    expect(out.files[0].path).toBe('a.ts');
+    expect(out.files[0].content).toBe(code);
   });
 
-  it('errors on malformed JSON', () => {
-    const out = parseExecutionJson('{"files": [oops');
-    expect('error' in out).toBe(true);
+  it('parses multiple file blocks with actions create + modify', () => {
+    const raw = [
+      '<<<PR_TITLE>>>t<<<END>>>',
+      '<<<PR_BODY>>>b<<<END>>>',
+      '<<<FILE create a/new.ts>>>',
+      'export const a = 1;',
+      '<<<END>>>',
+      '',
+      '<<<FILE modify a/existing.ts>>>',
+      'export const b = 2;',
+      '<<<END>>>',
+    ].join('\n');
+    const out = parseExecutionJson(raw);
+    if ('error' in out) throw new Error(`unexpected: ${out.error}`);
+    expect(out.files).toHaveLength(2);
+    expect(out.files.map(f => f.action)).toEqual(['create', 'modify']);
+    expect(out.files.map(f => f.path)).toEqual(['a/new.ts', 'a/existing.ts']);
   });
 
-  it('errors when JSON is missing files array', () => {
-    const raw = JSON.stringify({ pr_title: 't', pr_body: 'b' });
+  it('errors when PR_TITLE block is missing', () => {
+    const raw = '<<<PR_BODY>>>b<<<END>>><<<FILE create a.ts>>>\nx\n<<<END>>>';
     const out = parseExecutionJson(raw);
     expect('error' in out).toBe(true);
   });
 
-  it('errors when no JSON object is found', () => {
-    const out = parseExecutionJson('no braces here at all');
+  it('errors when PR_BODY block is missing', () => {
+    const raw = '<<<PR_TITLE>>>t<<<END>>><<<FILE create a.ts>>>\nx\n<<<END>>>';
+    const out = parseExecutionJson(raw);
+    expect('error' in out).toBe(true);
+  });
+
+  it('errors when no FILE blocks are emitted', () => {
+    const raw = '<<<PR_TITLE>>>t<<<END>>><<<PR_BODY>>>b<<<END>>>';
+    const out = parseExecutionJson(raw);
+    expect('error' in out).toBe(true);
+  });
+
+  it('errors for completely malformed input', () => {
+    const out = parseExecutionJson('no delimiters here at all');
     expect('error' in out).toBe(true);
   });
 });
@@ -135,12 +179,15 @@ describe('buildExecutionPrompt', () => {
     expect(p).toMatch(/does NOT exist/);
   });
 
-  it('specifies the JSON output contract so the parser can rely on it', () => {
+  it('specifies the delimiter output contract so the parser can rely on it', () => {
     const p = buildExecutionPrompt('f', 1, 'body', [], 'b');
-    expect(p).toMatch(/"files"/);
-    expect(p).toMatch(/"pr_title"/);
-    expect(p).toMatch(/"pr_body"/);
-    expect(p).toMatch(/"action": "create"/);
-    expect(p).toMatch(/Allowed actions: "create", "modify", "delete"/);
+    expect(p).toContain('<<<PR_TITLE>>>');
+    expect(p).toContain('<<<PR_BODY>>>');
+    expect(p).toMatch(/<<<FILE create /);
+    expect(p).toContain('<<<END>>>');
+    expect(p).toMatch(/Allowed actions in the FILE header: "create", "modify", "delete"/);
+    expect(p).toMatch(/verbatim/);
+    // Must explicitly tell the model NOT to use JSON (prevent regression).
+    expect(p).toMatch(/NOT JSON/);
   });
 });


### PR DESCRIPTION
Previous run failed at `LLM output parse: JSON parse failed: SyntaxError: Expected ',' or ']' after array element in JSON at position 46866` because we asked the model to emit source code inside JSON string values. Switched to verbatim delimiter blocks — no escaping required. See commit for details. 15/15 parser tests pass, including one that uses the exact backslash+brace+template-literal payload that broke the old JSON path.