### PR TITLE
feat(awareness-registry): admin control panel for every voice ORB context signal

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -2595,7 +2595,8 @@ const NAVIGATION_CONFIG = [
             { "key": "identity-access", "path": "/command-hub/admin/identity-access/" },
             { "key": "marketplace-shops", "path": "/command-hub/admin/marketplace-shops/" },
             { "key": "marketplace-review", "path": "/command-hub/admin/marketplace-review/" },
-            { "key": "analytics", "path": "/command-hub/admin/analytics/" }
+            { "key": "analytics", "path": "/command-hub/admin/analytics/" },
+            { "key": "awareness", "path": "/command-hub/admin/awareness/" }
         ]
     },
     {
@@ -3632,6 +3633,23 @@ const state = {
     testingValidator: { runs: [], loading: false, error: null, fetched: false },
     // Testing & QA — Vitana Awareness (BOOTSTRAP-HISTORY-AWARE-TIMELINE)
     vitanaAwareness: { result: null, loading: false, error: null, lastRunAt: 0, userId: '' },
+    // Admin > Awareness Registry (BOOTSTRAP-AWARENESS-REGISTRY)
+    awarenessRegistry: {
+        manifest: [],
+        overrides: {},
+        resolved: {},
+        audit: [],
+        loading: false,
+        saving: false,
+        error: null,
+        loaded: false,
+        // local pending edits keyed by signal.key — { enabled, params }
+        pending: {},
+        // expanded tier names
+        expandedTiers: {},
+        previewLoading: false,
+        previewResult: null,
+    },
     // Testing & QA — Test Cycles
     testingCycles: { cycles: [], loading: false, error: null, fetched: false },
     // Testing & QA — ORB Monitor (GitHub Actions)
@@ -6111,6 +6129,8 @@ function renderModuleContent(moduleKey, tab) {
         container.appendChild(renderVitanaAwarenessTestView());
 
     // ──── Admin: Analytics ────
+    } else if (moduleKey === 'admin' && tab === 'awareness') {
+        container.appendChild(renderAdminAwarenessView());
     } else if (moduleKey === 'admin' && tab === 'analytics') {
         container.appendChild(renderAdminAnalyticsView());
 
@@ -39690,6 +39710,417 @@ function renderVitanaAwarenessTestView() {
         renderResult(state.vitanaAwareness.result);
     } else {
         results.innerHTML = '<div class="placeholder-content" style="padding:1rem;color:var(--color-text-secondary);">Click <strong>Run Awareness Test</strong> to check what the voice ORB knows right now.</div>';
+    }
+
+    return container;
+}
+
+// =============================================================================
+// BOOTSTRAP-AWARENESS-REGISTRY — Admin > Awareness control panel
+// =============================================================================
+// Collapsible tier groups, each with subcategories of toggleable signals.
+// Pending edits cached in state.awarenessRegistry.pending so re-renders don't
+// drop in-flight changes. "Save" button writes via /api/v1/awareness/config/bulk.
+// "Preview" calls /api/v1/orb/debug/awareness as the current operator.
+// =============================================================================
+
+var TIER_LABELS = {
+    identity: '1 — Identity',
+    memory: '2 — Memory',
+    activity: '3 — Activity',
+    content: '4 — Content Consumption',
+    social: '5 — Social Graph (Network & Connections)',
+    preferences: '6 — Preferences',
+    routines: '7 — Routines',
+    health: '8 — Health',
+    context: '9 — Session Context',
+    knowledge: '10 — Knowledge & System',
+    brain: '11 — Brain / Proactive',
+    overrides: '12 — Overrides (high-priority blocks)',
+};
+
+function awarenessFetchConfig() {
+    if (state.awarenessRegistry.loading) return;
+    state.awarenessRegistry.loading = true;
+    state.awarenessRegistry.error = null;
+    renderApp();
+    fetch('/api/v1/awareness/config', { method: 'GET', headers: buildContextHeaders({ 'Accept': 'application/json' }) })
+        .then(function (r) { return r.json(); })
+        .then(function (d) {
+            state.awarenessRegistry.loading = false;
+            if (!d || d.ok === false) {
+                state.awarenessRegistry.error = (d && d.error) || 'Failed to load';
+            } else {
+                state.awarenessRegistry.manifest = d.manifest || [];
+                state.awarenessRegistry.overrides = d.overrides || {};
+                state.awarenessRegistry.resolved = d.resolved || {};
+                state.awarenessRegistry.loaded = true;
+            }
+            renderApp();
+        })
+        .catch(function (err) {
+            state.awarenessRegistry.loading = false;
+            state.awarenessRegistry.error = (err && err.message) ? err.message : String(err);
+            renderApp();
+        });
+}
+
+function awarenessFetchAudit() {
+    fetch('/api/v1/awareness/audit?limit=20', { method: 'GET', headers: buildContextHeaders({ 'Accept': 'application/json' }) })
+        .then(function (r) { return r.json(); })
+        .then(function (d) {
+            if (d && d.ok && Array.isArray(d.entries)) {
+                state.awarenessRegistry.audit = d.entries;
+                renderApp();
+            }
+        })
+        .catch(function () { /* non-critical */ });
+}
+
+function awarenessSavePending() {
+    var pending = state.awarenessRegistry.pending || {};
+    var keys = Object.keys(pending);
+    if (!keys.length || state.awarenessRegistry.saving) return;
+    var changes = keys.map(function (k) {
+        return { key: k, enabled: !!pending[k].enabled, params: pending[k].params || {} };
+    });
+    state.awarenessRegistry.saving = true;
+    renderApp();
+    fetch('/api/v1/awareness/config/bulk', {
+        method: 'POST',
+        headers: buildContextHeaders({ 'Content-Type': 'application/json', 'Accept': 'application/json' }),
+        body: JSON.stringify({ changes: changes }),
+    })
+        .then(function (r) { return r.json(); })
+        .then(function (d) {
+            state.awarenessRegistry.saving = false;
+            if (!d || d.ok === false) {
+                state.awarenessRegistry.error = 'Save partially failed: ' + JSON.stringify(d && d.failures || []);
+            } else {
+                state.awarenessRegistry.pending = {};
+                state.awarenessRegistry.error = null;
+            }
+            renderApp();
+            // Re-fetch resolved state + audit.
+            awarenessFetchConfig();
+            awarenessFetchAudit();
+        })
+        .catch(function (err) {
+            state.awarenessRegistry.saving = false;
+            state.awarenessRegistry.error = (err && err.message) ? err.message : String(err);
+            renderApp();
+        });
+}
+
+function awarenessRunPreview() {
+    state.awarenessRegistry.previewLoading = true;
+    state.awarenessRegistry.previewResult = null;
+    renderApp();
+    fetch('/api/v1/orb/debug/awareness', { method: 'GET', headers: buildContextHeaders({ 'Accept': 'application/json' }) })
+        .then(function (r) { return r.json(); })
+        .then(function (d) {
+            state.awarenessRegistry.previewLoading = false;
+            state.awarenessRegistry.previewResult = d;
+            renderApp();
+        })
+        .catch(function (err) {
+            state.awarenessRegistry.previewLoading = false;
+            state.awarenessRegistry.previewResult = { ok: false, error: (err && err.message) ? err.message : String(err) };
+            renderApp();
+        });
+}
+
+function awarenessSignalEffective(signal) {
+    var pending = state.awarenessRegistry.pending[signal.key];
+    if (pending) return pending;
+    var resolved = state.awarenessRegistry.resolved[signal.key];
+    if (resolved) return { enabled: !!resolved.enabled, params: resolved.params || {} };
+    var defaultParams = {};
+    (signal.params || []).forEach(function (p) { defaultParams[p.key] = p.default; });
+    return { enabled: !!signal.default_on, params: defaultParams };
+}
+
+function awarenessUpdatePending(signal, patch) {
+    var current = awarenessSignalEffective(signal);
+    state.awarenessRegistry.pending[signal.key] = {
+        enabled: 'enabled' in patch ? !!patch.enabled : current.enabled,
+        params: patch.params ? Object.assign({}, current.params, patch.params) : current.params,
+    };
+    renderApp();
+}
+
+function renderAwarenessSignalRow(signal) {
+    var row = document.createElement('div');
+    row.style.cssText = 'display:flex;flex-direction:column;gap:.25rem;padding:.5rem .75rem;border-bottom:1px solid var(--color-border);';
+    if (signal.enforcement_status === 'pending') {
+        row.style.opacity = '0.55';
+    }
+
+    var top = document.createElement('div');
+    top.style.cssText = 'display:flex;align-items:center;gap:.75rem;';
+
+    var checkbox = document.createElement('input');
+    checkbox.type = 'checkbox';
+    var eff = awarenessSignalEffective(signal);
+    checkbox.checked = eff.enabled;
+    checkbox.disabled = !!signal.locked;
+    checkbox.onchange = function () {
+        awarenessUpdatePending(signal, { enabled: checkbox.checked });
+    };
+    top.appendChild(checkbox);
+
+    var label = document.createElement('div');
+    label.style.cssText = 'flex:1;display:flex;flex-direction:column;gap:.1rem;';
+    var labelLine = document.createElement('div');
+    labelLine.style.cssText = 'display:flex;align-items:center;gap:.4rem;';
+    var labelStrong = document.createElement('strong');
+    labelStrong.textContent = signal.label;
+    labelStrong.style.fontSize = '.85rem';
+    labelLine.appendChild(labelStrong);
+    if (signal.locked) {
+        var lockedBadge = document.createElement('span');
+        lockedBadge.textContent = '\uD83D\uDD12 locked';
+        lockedBadge.style.cssText = 'font-size:.65rem;color:var(--color-text-secondary);background:var(--color-bg);padding:.1rem .35rem;border-radius:4px;';
+        labelLine.appendChild(lockedBadge);
+    }
+    if (signal.enforcement_status === 'pending') {
+        var pendBadge = document.createElement('span');
+        pendBadge.textContent = 'enforcement pending';
+        pendBadge.style.cssText = 'font-size:.65rem;color:#a16207;background:rgba(234,179,8,.12);padding:.1rem .35rem;border-radius:4px;';
+        labelLine.appendChild(pendBadge);
+    }
+    var keyTag = document.createElement('code');
+    keyTag.textContent = signal.key;
+    keyTag.style.cssText = 'font-size:.6rem;color:var(--color-text-secondary);margin-left:auto;';
+    labelLine.appendChild(keyTag);
+    label.appendChild(labelLine);
+    var desc = document.createElement('div');
+    desc.style.cssText = 'font-size:.7rem;color:var(--color-text-secondary);';
+    desc.textContent = signal.description;
+    label.appendChild(desc);
+    top.appendChild(label);
+
+    row.appendChild(top);
+
+    if (signal.params && signal.params.length) {
+        var paramsRow = document.createElement('div');
+        paramsRow.style.cssText = 'display:flex;flex-wrap:wrap;gap:.5rem;padding-left:1.5rem;margin-top:.25rem;';
+        signal.params.forEach(function (p) {
+            var wrap = document.createElement('label');
+            wrap.style.cssText = 'display:flex;align-items:center;gap:.35rem;font-size:.7rem;color:var(--color-text-secondary);';
+            wrap.textContent = p.label + ':';
+            var input;
+            var currentVal = (eff.params && (p.key in eff.params)) ? eff.params[p.key] : p.default;
+            if (p.type === 'bool') {
+                input = document.createElement('input');
+                input.type = 'checkbox';
+                input.checked = !!currentVal;
+                input.onchange = function () {
+                    var patch = {}; patch[p.key] = input.checked;
+                    awarenessUpdatePending(signal, { params: patch });
+                };
+            } else if (p.type === 'enum') {
+                input = document.createElement('select');
+                input.style.cssText = 'padding:.15rem .35rem;background:var(--color-bg-elevated);border:1px solid var(--color-border);color:var(--color-text);border-radius:4px;font-size:.7rem;';
+                (p.options || []).forEach(function (opt) {
+                    var o = document.createElement('option'); o.value = opt; o.textContent = opt;
+                    if (String(currentVal) === String(opt)) o.selected = true;
+                    input.appendChild(o);
+                });
+                input.onchange = function () {
+                    var patch = {}; patch[p.key] = input.value;
+                    awarenessUpdatePending(signal, { params: patch });
+                };
+            } else {
+                input = document.createElement('input');
+                input.type = 'number';
+                input.value = currentVal;
+                if ('min' in p) input.min = String(p.min);
+                if ('max' in p) input.max = String(p.max);
+                if ('step' in p) input.step = String(p.step);
+                input.style.cssText = 'width:5rem;padding:.15rem .35rem;background:var(--color-bg-elevated);border:1px solid var(--color-border);color:var(--color-text);border-radius:4px;font-size:.7rem;';
+                input.onchange = function () {
+                    var v = p.type === 'float' ? parseFloat(input.value) : parseInt(input.value, 10);
+                    if (isNaN(v)) return;
+                    var patch = {}; patch[p.key] = v;
+                    awarenessUpdatePending(signal, { params: patch });
+                };
+            }
+            wrap.appendChild(input);
+            paramsRow.appendChild(wrap);
+        });
+        row.appendChild(paramsRow);
+    }
+
+    return row;
+}
+
+function renderAwarenessTier(tierKey, signals) {
+    var card = document.createElement('div');
+    card.style.cssText = 'border:1px solid var(--color-border);border-radius:8px;background:var(--color-bg-elevated);margin-bottom:.75rem;';
+
+    // Header
+    var header = document.createElement('div');
+    var enabledCount = signals.filter(function (s) { return awarenessSignalEffective(s).enabled; }).length;
+    header.style.cssText = 'display:flex;align-items:center;gap:.75rem;padding:.75rem 1rem;cursor:pointer;user-select:none;';
+    header.innerHTML = '<strong>' + (TIER_LABELS[tierKey] || tierKey) + '</strong>' +
+        '<span style="margin-left:auto;font-size:.75rem;color:var(--color-text-secondary);">' +
+        enabledCount + ' of ' + signals.length + ' enabled</span>';
+    var caret = document.createElement('span');
+    var expanded = !!state.awarenessRegistry.expandedTiers[tierKey];
+    caret.textContent = expanded ? '\u25BC' : '\u25B6';
+    caret.style.fontSize = '.7rem';
+    header.insertBefore(caret, header.firstChild);
+    header.onclick = function () {
+        state.awarenessRegistry.expandedTiers[tierKey] = !expanded;
+        renderApp();
+    };
+    card.appendChild(header);
+
+    if (!expanded) return card;
+
+    // Group by subcategory
+    var bySubcat = {};
+    signals.forEach(function (s) {
+        if (!bySubcat[s.subcategory]) bySubcat[s.subcategory] = [];
+        bySubcat[s.subcategory].push(s);
+    });
+
+    Object.keys(bySubcat).forEach(function (subcat) {
+        var subHeader = document.createElement('div');
+        subHeader.style.cssText = 'padding:.4rem 1rem;font-size:.75rem;font-weight:600;color:var(--color-text-secondary);background:var(--color-bg);border-top:1px solid var(--color-border);';
+        subHeader.textContent = subcat;
+        card.appendChild(subHeader);
+        bySubcat[subcat].forEach(function (s) { card.appendChild(renderAwarenessSignalRow(s)); });
+    });
+
+    return card;
+}
+
+function renderAwarenessPreviewDrawer() {
+    if (!state.awarenessRegistry.previewLoading && !state.awarenessRegistry.previewResult) return null;
+    var drawer = document.createElement('div');
+    drawer.style.cssText = 'margin-top:1rem;padding:1rem;border:1px solid var(--color-border);border-radius:8px;background:var(--color-bg-elevated);';
+    var title = document.createElement('h3');
+    title.textContent = 'Preview: what the voice ORB would receive';
+    title.style.cssText = 'margin:0 0 .5rem;font-size:.95rem;';
+    drawer.appendChild(title);
+    if (state.awarenessRegistry.previewLoading) {
+        var l = document.createElement('div'); l.className = 'placeholder-content'; l.textContent = 'Running preview\u2026';
+        drawer.appendChild(l);
+        return drawer;
+    }
+    var d = state.awarenessRegistry.previewResult || {};
+    if (d.ok === false) {
+        var e = document.createElement('div'); e.className = 'error-text'; e.textContent = 'Error: ' + (d.error || 'unknown');
+        drawer.appendChild(e);
+        return drawer;
+    }
+    var meta = document.createElement('div');
+    meta.style.cssText = 'font-size:.75rem;color:var(--color-text-secondary);margin-bottom:.5rem;';
+    meta.textContent = 'profile=' + ((d.profile && d.profile.char_count) || 0) + ' chars  •  context_instruction=' + ((d.context_instruction && d.context_instruction.char_count) || 0) + ' chars  •  scenario=' + (d.scenario || 'unknown');
+    drawer.appendChild(meta);
+    var pre = document.createElement('pre');
+    pre.style.cssText = 'margin:0;padding:.75rem;background:var(--color-bg);border-radius:6px;overflow:auto;max-height:340px;font-size:.7rem;white-space:pre-wrap;word-break:break-word;';
+    pre.textContent = (d.profile && d.profile.summary) || '(empty)';
+    drawer.appendChild(pre);
+    return drawer;
+}
+
+function renderAdminAwarenessView() {
+    var container = document.createElement('div');
+    container.style.padding = '1.5rem';
+    container.innerHTML = '<h2>Awareness Registry</h2>' +
+        '<p class="section-subtitle">Global control of every context signal the voice ORB and brain inject into the Gemini Live system_instruction. Exafy admins only. Changes apply to all tenants.</p>';
+
+    if (!state.awarenessRegistry.loaded && !state.awarenessRegistry.loading) {
+        awarenessFetchConfig();
+        awarenessFetchAudit();
+    }
+
+    if (state.awarenessRegistry.loading) {
+        var l = document.createElement('div'); l.className = 'placeholder-content'; l.textContent = 'Loading awareness manifest\u2026';
+        container.appendChild(l);
+        return container;
+    }
+    if (state.awarenessRegistry.error) {
+        var e = document.createElement('div'); e.className = 'error-text'; e.style.padding = '1rem';
+        e.textContent = 'Error: ' + state.awarenessRegistry.error + ' (this page requires exafy_admin)';
+        container.appendChild(e);
+        return container;
+    }
+
+    var manifest = state.awarenessRegistry.manifest || [];
+    if (!manifest.length) {
+        var empty = document.createElement('div'); empty.className = 'placeholder-content'; empty.textContent = 'Manifest empty.';
+        container.appendChild(empty);
+        return container;
+    }
+
+    // Toolbar
+    var toolbar = document.createElement('div');
+    toolbar.style.cssText = 'display:flex;gap:.5rem;align-items:center;margin-bottom:1rem;flex-wrap:wrap;';
+    var pendingCount = Object.keys(state.awarenessRegistry.pending || {}).length;
+    var saveBtn = document.createElement('button');
+    saveBtn.className = 'task-spec-pipeline-btn task-spec-pipeline-btn-generate';
+    saveBtn.textContent = state.awarenessRegistry.saving ? 'Saving\u2026' : ('Save Changes' + (pendingCount ? ' (' + pendingCount + ')' : ''));
+    saveBtn.disabled = pendingCount === 0 || state.awarenessRegistry.saving;
+    if (saveBtn.disabled) saveBtn.style.opacity = '0.5';
+    saveBtn.onclick = awarenessSavePending;
+    toolbar.appendChild(saveBtn);
+
+    var discardBtn = document.createElement('button');
+    discardBtn.className = 'task-spec-pipeline-btn';
+    discardBtn.textContent = 'Discard pending';
+    discardBtn.disabled = pendingCount === 0;
+    if (discardBtn.disabled) discardBtn.style.opacity = '0.5';
+    discardBtn.onclick = function () {
+        state.awarenessRegistry.pending = {};
+        renderApp();
+    };
+    toolbar.appendChild(discardBtn);
+
+    var previewBtn = document.createElement('button');
+    previewBtn.className = 'task-spec-pipeline-btn';
+    previewBtn.textContent = state.awarenessRegistry.previewLoading ? 'Previewing\u2026' : 'Run Preview';
+    previewBtn.onclick = awarenessRunPreview;
+    toolbar.appendChild(previewBtn);
+
+    container.appendChild(toolbar);
+
+    // Group manifest by tier
+    var byTier = {};
+    manifest.forEach(function (s) {
+        if (!byTier[s.tier]) byTier[s.tier] = [];
+        byTier[s.tier].push(s);
+    });
+
+    // Render in tier order
+    Object.keys(TIER_LABELS).forEach(function (tierKey) {
+        if (!byTier[tierKey]) return;
+        container.appendChild(renderAwarenessTier(tierKey, byTier[tierKey]));
+    });
+
+    var preview = renderAwarenessPreviewDrawer();
+    if (preview) container.appendChild(preview);
+
+    // Audit
+    if (state.awarenessRegistry.audit && state.awarenessRegistry.audit.length) {
+        var auditCard = document.createElement('div');
+        auditCard.style.cssText = 'margin-top:1.5rem;padding:1rem;border:1px solid var(--color-border);border-radius:8px;background:var(--color-bg-elevated);';
+        var auditTitle = document.createElement('h3');
+        auditTitle.textContent = 'Recent changes';
+        auditTitle.style.cssText = 'margin:0 0 .5rem;font-size:.95rem;';
+        auditCard.appendChild(auditTitle);
+        state.awarenessRegistry.audit.forEach(function (entry) {
+            var line = document.createElement('div');
+            line.style.cssText = 'font-size:.72rem;padding:.25rem 0;border-bottom:1px solid var(--color-border);';
+            var when = new Date(entry.changed_at).toLocaleString();
+            line.innerHTML = '<code style="color:var(--color-text-secondary);">' + when + '</code> &nbsp; <strong>' + entry.key + '</strong> ' +
+                (entry.prev_enabled === entry.new_enabled ? '(params changed)' : (entry.prev_enabled + ' \u2192 ' + entry.new_enabled));
+            auditCard.appendChild(line);
+        });
+        container.appendChild(auditCard);
     }
 
     return container;

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -85,6 +85,7 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const autopilotPromptsRouter = require('./routes/autopilot-prompts').default;
   const assistantRouter = require('./routes/assistant').default;
   const orbLiveRouter = require('./routes/orb-live').default;
+  const awarenessConfigRouter = require('./routes/awareness-config').default;
   // VTID-01222: WebSocket server initialization for ORB Live API
   const { initializeOrbWebSocket } = require('./routes/orb-live');
   // VTID-01218A: Voice LAB - ORB Live Observability API
@@ -557,6 +558,9 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
 
   // DEV-COMHU-2025-0014: ORB Multimodal v1 - Live Voice Session (Gemini API, SSE)
   mountRouterSync(app, '/api/v1/orb', orbLiveRouter, { owner: 'orb-live' });
+
+  // BOOTSTRAP-AWARENESS-REGISTRY: admin API for the Awareness Registry
+  mountRouterSync(app, '/api/v1/awareness', awarenessConfigRouter, { owner: 'awareness-registry' });
 
   // VTID-01218A: Voice LAB - ORB Live Observability API
   mountRouterSync(app, '/api/v1/voice-lab', voiceLabRouter, { owner: 'voice-lab' });

--- a/services/gateway/src/routes/awareness-config.ts
+++ b/services/gateway/src/routes/awareness-config.ts
@@ -1,0 +1,202 @@
+/**
+ * Awareness Config admin API — BOOTSTRAP-AWARENESS-REGISTRY
+ *
+ * GET  /api/v1/awareness/config         → manifest + overrides + resolved
+ * GET  /api/v1/awareness/audit          → last N changes
+ * POST /api/v1/awareness/config         → upsert one signal
+ * POST /api/v1/awareness/config/bulk    → upsert many in one call (for the
+ *                                          admin page Save button)
+ *
+ * All endpoints require exafy_admin via the requireAdminAuth middleware.
+ * Writes use service-role to bypass RLS and append a row to
+ * awareness_config_audit.
+ */
+
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { requireAdminAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
+import {
+  getAwarenessConfig,
+  invalidateAwarenessConfigCache,
+  getManifest,
+  getSignal,
+} from '../services/awareness-registry';
+
+const router = Router();
+
+function adminClient(): SupabaseClient | null {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+  if (!url || !key) return null;
+  return createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
+}
+
+// =============================================================================
+// GET /api/v1/awareness/config
+// =============================================================================
+router.get('/config', requireAdminAuth, async (_req: AuthenticatedRequest, res: Response) => {
+  try {
+    const snap = await getAwarenessConfig();
+    return res.status(200).json({
+      ok: true,
+      manifest: getManifest(),
+      overrides: snap.overrides,
+      resolved: snap.resolved,
+      built_at: snap.built_at,
+    });
+  } catch (err: any) {
+    console.error('[awareness-config] GET failed:', err?.message);
+    return res.status(500).json({ ok: false, error: err?.message || 'unknown' });
+  }
+});
+
+// =============================================================================
+// GET /api/v1/awareness/audit?limit=20
+// =============================================================================
+router.get('/audit', requireAdminAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const client = adminClient();
+  if (!client) return res.status(503).json({ ok: false, error: 'Supabase not configured' });
+
+  const limit = Math.min(Math.max(parseInt(String(req.query.limit ?? '20'), 10), 1), 100);
+
+  const { data, error } = await client
+    .from('awareness_config_audit')
+    .select('id, key, prev_enabled, new_enabled, prev_params, new_params, changed_by, changed_at')
+    .order('changed_at', { ascending: false })
+    .limit(limit);
+
+  if (error) {
+    return res.status(500).json({ ok: false, error: error.message });
+  }
+  return res.status(200).json({ ok: true, entries: data || [] });
+});
+
+// =============================================================================
+// POST /api/v1/awareness/config — upsert ONE
+// =============================================================================
+const SingleChangeSchema = z.object({
+  key: z.string().min(1),
+  enabled: z.boolean(),
+  params: z.record(z.unknown()).optional(),
+});
+
+router.post('/config', requireAdminAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const parsed = SingleChangeSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ ok: false, error: 'Invalid body', details: parsed.error.errors });
+  }
+  const { key, enabled, params } = parsed.data;
+
+  const sig = getSignal(key);
+  if (!sig) {
+    return res.status(404).json({ ok: false, error: `Unknown awareness signal: ${key}` });
+  }
+  if (sig.locked && !enabled) {
+    return res.status(400).json({
+      ok: false,
+      error: `Signal ${key} is locked and cannot be disabled`,
+    });
+  }
+
+  const result = await upsertOne(key, enabled, params || {}, req.identity!.user_id);
+  if (!result.ok) return res.status(500).json({ ok: false, error: result.error });
+
+  invalidateAwarenessConfigCache();
+  return res.status(200).json({ ok: true, key, enabled, params: result.new_params });
+});
+
+// =============================================================================
+// POST /api/v1/awareness/config/bulk — upsert many
+// =============================================================================
+const BulkBodySchema = z.object({
+  changes: z.array(SingleChangeSchema).min(1).max(500),
+});
+
+router.post('/config/bulk', requireAdminAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const parsed = BulkBodySchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ ok: false, error: 'Invalid body', details: parsed.error.errors });
+  }
+
+  const userId = req.identity!.user_id;
+  const failures: { key: string; error: string }[] = [];
+  const succeeded: { key: string; enabled: boolean }[] = [];
+
+  for (const change of parsed.data.changes) {
+    const sig = getSignal(change.key);
+    if (!sig) {
+      failures.push({ key: change.key, error: 'unknown signal' });
+      continue;
+    }
+    if (sig.locked && !change.enabled) {
+      failures.push({ key: change.key, error: 'locked — cannot disable' });
+      continue;
+    }
+    const r = await upsertOne(change.key, change.enabled, change.params || {}, userId);
+    if (r.ok) succeeded.push({ key: change.key, enabled: change.enabled });
+    else failures.push({ key: change.key, error: r.error || 'unknown' });
+  }
+
+  invalidateAwarenessConfigCache();
+  return res.status(200).json({
+    ok: failures.length === 0,
+    succeeded,
+    failures,
+  });
+});
+
+// =============================================================================
+// Helper: upsert a single key + write audit row
+// =============================================================================
+async function upsertOne(
+  key: string,
+  enabled: boolean,
+  params: Record<string, unknown>,
+  changedBy: string
+): Promise<{ ok: true; new_params: Record<string, unknown> } | { ok: false; error: string }> {
+  const client = adminClient();
+  if (!client) return { ok: false, error: 'Supabase not configured' };
+
+  // Read previous state for audit.
+  const { data: prevRow } = await client
+    .from('awareness_config')
+    .select('enabled, params')
+    .eq('key', key)
+    .maybeSingle();
+  const prevEnabled = prevRow?.enabled ?? null;
+  const prevParams = (prevRow?.params as Record<string, unknown>) ?? null;
+
+  const { error: upsertError } = await client
+    .from('awareness_config')
+    .upsert(
+      {
+        key,
+        enabled,
+        params,
+        updated_by: changedBy,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'key' }
+    );
+  if (upsertError) return { ok: false, error: upsertError.message };
+
+  // Audit row — best effort; don't fail the write if audit fails.
+  await client
+    .from('awareness_config_audit')
+    .insert({
+      key,
+      prev_enabled: prevEnabled,
+      new_enabled: enabled,
+      prev_params: prevParams,
+      new_params: params,
+      changed_by: changedBy,
+    })
+    .then(({ error }) => {
+      if (error) console.warn(`[awareness-config] audit insert failed: ${error.message}`);
+    });
+
+  return { ok: true, new_params: params };
+}
+
+export default router;

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -47,6 +47,7 @@ import { TextToSpeechClient, protos } from '@google-cloud/text-to-speech';
 import { processWithGemini, setThreadIdentity } from '../services/gemini-operator';
 import { emitOasisEvent } from '../services/oasis-event-service';
 import { getUserContextSummary } from '../services/user-context-profiler';
+import { getAwarenessConfigSync } from '../services/awareness-registry';
 import { writeTimelineRow } from '../services/timeline-projector';
 import { notifyUserAsync } from '../services/notification-service';
 // VTID-01225: Cognee Entity Extraction Integration
@@ -4208,6 +4209,13 @@ ${trimmedHistory}
     clientContext?.timeOfDay,
   );
 
+  // BOOTSTRAP-AWARENESS-REGISTRY: gate the override blocks below on admin
+  // toggles. Synchronous read of the cached config; if cache is cold we use
+  // manifest defaults (which are on for both overrides).
+  const awarenessCfg = getAwarenessConfigSync();
+  const includeProactiveOpener = awarenessCfg.isEnabled('overrides.proactive_opener');
+  const includeActivityAwareness = awarenessCfg.isEnabled('overrides.activity_awareness');
+
   // VTID-01927: PROACTIVE OPENER OVERRIDE — appended absolute LAST so it has
   // recency primacy in Gemini's attention. When the brain context (added later
   // by the Vitana Brain layer) includes a "Proactive Opener Candidate" or
@@ -4215,6 +4223,7 @@ ${trimmedHistory}
   // greeting policy + the generic baseline above. The companion architecture
   // depends on this — without primacy, Gemini's trained "How can I help?"
   // reflex wins.
+  if (includeProactiveOpener)
   instruction += `\n\n## PROACTIVE OPENER OVERRIDE (HIGHEST PRIORITY — VTID-01927)
 
 When the brain context appended below contains either:
@@ -4250,7 +4259,7 @@ the policy above as normal.`;
     );
     const profileSummary = profileMatch ? profileMatch[0].trim() : '';
 
-    if (profileSummary && profileSummary.length > 100) {
+    if (includeActivityAwareness && profileSummary && profileSummary.length > 100) {
       instruction += `\n\n## ACTIVITY AWARENESS OVERRIDE (HIGHEST PRIORITY — BOOTSTRAP-HISTORY-AWARE-TIMELINE)
 
 This block REPLACES any instinct to say "I don't know what you've been doing"

--- a/services/gateway/src/services/awareness-registry.ts
+++ b/services/gateway/src/services/awareness-registry.ts
@@ -1,0 +1,461 @@
+/**
+ * Awareness Registry — BOOTSTRAP-AWARENESS-REGISTRY
+ *
+ * Single source of truth for every context signal the voice ORB / brain can
+ * inject into a Gemini Live system_instruction. Each entry declares its
+ * tier, subcategory, default state, and (optional) tunable parameters.
+ *
+ * The manifest below is the spec. Live overrides come from the
+ * `awareness_config` table (admin-controlled, exafy-admin only). The
+ * `getAwarenessConfig()` helper merges defaults with overrides and caches
+ * the merged view for 60s.
+ *
+ * Consumers (orb-live.ts, user-context-profiler.ts) ask:
+ *
+ *     const cfg = await getAwarenessConfig();
+ *     if (!cfg.isEnabled('content.music.enabled')) return '';
+ *     const maxItems = cfg.getParam('content.section.max_items', 8);
+ *
+ * v1 is GLOBAL — one config applies to every tenant. Per-tenant + per-user
+ * overrides are deferred to v2.
+ */
+
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type Tier =
+  | 'identity'
+  | 'memory'
+  | 'activity'
+  | 'content'
+  | 'social'
+  | 'preferences'
+  | 'routines'
+  | 'health'
+  | 'context'
+  | 'knowledge'
+  | 'brain'
+  | 'overrides';
+
+export interface ParamSpec {
+  key: string;
+  label: string;
+  type: 'int' | 'float' | 'bool' | 'string' | 'enum';
+  default: number | string | boolean;
+  min?: number;
+  max?: number;
+  step?: number;
+  options?: string[];
+  description?: string;
+}
+
+export interface AwarenessSignal {
+  key: string;                 // dot-notation, globally unique
+  tier: Tier;
+  subcategory: string;         // group within the tier
+  label: string;               // shown in admin UI
+  description: string;         // one-sentence what this signal does
+  default_on: boolean;
+  locked?: boolean;            // cannot be turned off (mandatory)
+  params?: ParamSpec[];        // optional tunable parameters
+  enforcement_status?: 'live' | 'pending'; // pending = manifest-only, no code gate yet
+}
+
+export interface ResolvedSignal {
+  enabled: boolean;
+  params: Record<string, unknown>;
+  source: 'override' | 'default';
+}
+
+export interface AwarenessConfigSnapshot {
+  /** Resolved (manifest defaults + DB overrides) keyed by signal.key */
+  resolved: Record<string, ResolvedSignal>;
+  /** Raw overrides from the table (only the keys with rows) */
+  overrides: Record<string, { enabled: boolean; params: Record<string, unknown> }>;
+  /** ISO timestamp when this snapshot was built */
+  built_at: string;
+  /** Helper: is this signal enabled? */
+  isEnabled(key: string): boolean;
+  /** Helper: get a param value with fallback */
+  getParam<T = unknown>(signalKey: string, paramKey: string, fallback: T): T;
+}
+
+// =============================================================================
+// MANIFEST — every awareness signal in the system, organized by tier
+// =============================================================================
+
+const M: AwarenessSignal[] = [
+  // ─── 1. IDENTITY (locked) ─────────────────────────────────────────────────
+  { key: 'identity.user_id',    tier: 'identity', subcategory: 'Authenticated user', label: 'User ID',     description: 'JWT sub claim resolved into the active user_id.',         default_on: true, locked: true },
+  { key: 'identity.tenant_id',  tier: 'identity', subcategory: 'Authenticated user', label: 'Tenant ID',   description: 'JWT app_metadata.active_tenant_id.',                       default_on: true, locked: true },
+  { key: 'identity.active_role',tier: 'identity', subcategory: 'Authenticated user', label: 'Active role', description: 'community / professional / staff / admin / dev.',          default_on: true, locked: true },
+  { key: 'identity.email',      tier: 'identity', subcategory: 'Authenticated user', label: 'Email',       description: 'Caller email from JWT (used for personalization).',        default_on: true },
+  { key: 'identity.surface',    tier: 'identity', subcategory: 'Session surface',    label: 'Surface',     description: 'orb / operator / command-hub / cicd / api.',               default_on: true, locked: true },
+  { key: 'identity.is_anonymous', tier: 'identity', subcategory: 'Session surface',  label: 'Anonymous flag', description: 'Emitted when no JWT — gates personal context entirely.', default_on: true, locked: true },
+
+  // ─── 2. MEMORY ───────────────────────────────────────────────────────────
+  { key: 'memory.items.enabled', tier: 'memory', subcategory: 'Memory Garden', label: 'Memory items', description: 'Inject ranked memory_items rows from the user\'s Memory Garden.', default_on: true, params: [
+      { key: 'max_age_hours', label: 'Max age (hours)', type: 'int', default: 168, min: 1, max: 8760, step: 1 },
+      { key: 'max_count',     label: 'Max items',       type: 'int', default: 50,  min: 1, max: 200,  step: 1 },
+  ]},
+  { key: 'memory.items.categories.personal_identity',     tier: 'memory', subcategory: 'Memory Garden categories', label: 'Personal identity',       description: 'Name, birthday, location facts.',                            default_on: true, locked: true },
+  { key: 'memory.items.categories.health_wellness',       tier: 'memory', subcategory: 'Memory Garden categories', label: 'Health & wellness',       description: 'Sleep, stress, biomarker mentions.',                         default_on: true },
+  { key: 'memory.items.categories.lifestyle_routines',    tier: 'memory', subcategory: 'Memory Garden categories', label: 'Lifestyle & routines',    description: 'Daily rhythms, schedule preferences.',                       default_on: true },
+  { key: 'memory.items.categories.network_relationships', tier: 'memory', subcategory: 'Memory Garden categories', label: 'Network & relationships', description: 'Family, friends, colleagues.',                                default_on: true },
+  { key: 'memory.items.categories.learning_knowledge',    tier: 'memory', subcategory: 'Memory Garden categories', label: 'Learning & knowledge',    description: 'Skills, education, reading.',                                default_on: true },
+  { key: 'memory.items.categories.business_projects',     tier: 'memory', subcategory: 'Memory Garden categories', label: 'Business & projects',     description: 'Active work / tasks.',                                       default_on: true },
+  { key: 'memory.items.categories.finance_assets',        tier: 'memory', subcategory: 'Memory Garden categories', label: 'Finance & assets',        description: 'Investments, products, services.',                            default_on: true },
+  { key: 'memory.items.categories.location_environment',  tier: 'memory', subcategory: 'Memory Garden categories', label: 'Location & environment',  description: 'Home city, travel patterns.',                                default_on: true },
+  { key: 'memory.items.categories.digital_footprint',     tier: 'memory', subcategory: 'Memory Garden categories', label: 'Digital footprint',       description: 'Online accounts, services used.',                            default_on: true },
+  { key: 'memory.items.categories.values_aspirations',    tier: 'memory', subcategory: 'Memory Garden categories', label: 'Values & aspirations',    description: 'Goals, motivations.',                                        default_on: true },
+  { key: 'memory.items.categories.autopilot_context',     tier: 'memory', subcategory: 'Memory Garden categories', label: 'Autopilot context',       description: 'Recommendations + auto actions context.',                    default_on: true },
+  { key: 'memory.items.categories.future_plans',          tier: 'memory', subcategory: 'Memory Garden categories', label: 'Future plans',            description: 'Upcoming milestones.',                                       default_on: true },
+  { key: 'memory.items.categories.uncategorized',         tier: 'memory', subcategory: 'Memory Garden categories', label: 'Uncategorized',           description: 'Conversation notes that did not match a category.',          default_on: true },
+
+  { key: 'memory.facts.enabled',       tier: 'memory', subcategory: 'Memory Facts (VTID-01192)', label: 'Memory facts',                description: 'Inject high-confidence memory_facts (name, birthday, etc.).',  default_on: true, locked: true, params: [
+      { key: 'min_confidence', label: 'Minimum confidence', type: 'float', default: 0.7, min: 0, max: 1, step: 0.05 },
+      { key: 'max_count',      label: 'Max facts in profile', type: 'int', default: 6, min: 1, max: 30, step: 1 },
+  ]},
+  { key: 'memory.facts.entity.self',     tier: 'memory', subcategory: 'Memory Facts (VTID-01192)', label: 'Self facts',     description: 'Facts about the user themselves.', default_on: true },
+  { key: 'memory.facts.entity.disclosed',tier: 'memory', subcategory: 'Memory Facts (VTID-01192)', label: 'Disclosed facts',description: 'Facts the user disclosed about others (family, partner, friends).', default_on: true },
+
+  { key: 'memory.recent_turns.enabled', tier: 'memory', subcategory: 'Recent ORB turns', label: 'Recent ORB turns', description: 'Last N raw user utterances — answers "what did I just say?".', default_on: true, params: [
+      { key: 'count', label: 'Turn count', type: 'int', default: 3, min: 1, max: 10, step: 1 },
+  ]},
+
+  { key: 'memory.relationships.nodes',   tier: 'memory', subcategory: 'Cognee relationship graph (VTID-01087)', label: 'Relationship nodes',   description: 'PERSON / LOCATION / ORG entities extracted from conversations.', default_on: true, enforcement_status: 'pending' },
+  { key: 'memory.relationships.edges',   tier: 'memory', subcategory: 'Cognee relationship graph (VTID-01087)', label: 'Relationship edges',   description: 'knows / works_for / attends / following relations.',              default_on: true, enforcement_status: 'pending' },
+  { key: 'memory.relationships.signals', tier: 'memory', subcategory: 'Cognee relationship graph (VTID-01087)', label: 'Relationship signals', description: 'Computed interaction signals from the graph.',                    default_on: true, enforcement_status: 'pending' },
+
+  // ─── 3. ACTIVITY ─────────────────────────────────────────────────────────
+  { key: 'activity.summary.enabled', tier: 'activity', subcategory: 'Counted summary', label: '[ACTIVITY_14D] block', description: 'One-line counted summary across the activity window.', default_on: true, params: [
+      { key: 'window_days', label: 'Window (days)', type: 'enum', default: 14, options: ['14','30','90'] },
+  ]},
+  { key: 'activity.recent.enabled', tier: 'activity', subcategory: 'Recent actions', label: '[RECENT] block', description: 'Listed recent high-signal actions with relative times.', default_on: true, params: [
+      { key: 'max_items',   label: 'Max items',     type: 'int', default: 8,  min: 1, max: 30,  step: 1 },
+      { key: 'window_days', label: 'Window (days)', type: 'int', default: 14, min: 1, max: 180, step: 1 },
+  ]},
+
+  { key: 'activity.include.diary',             tier: 'activity', subcategory: 'High-signal categories', label: 'Diary',                  description: 'Include diary.* events in [RECENT].',          default_on: true },
+  { key: 'activity.include.autopilot',         tier: 'activity', subcategory: 'High-signal categories', label: 'Autopilot',              description: 'Include autopilot.* events.',                  default_on: true },
+  { key: 'activity.include.recommendation',    tier: 'activity', subcategory: 'High-signal categories', label: 'Recommendation',         description: 'Include recommendation.* events.',             default_on: true },
+  { key: 'activity.include.task',              tier: 'activity', subcategory: 'High-signal categories', label: 'Task',                   description: 'Include task.* events.',                       default_on: true },
+  { key: 'activity.include.calendar',          tier: 'activity', subcategory: 'High-signal categories', label: 'Calendar',               description: 'Include calendar.* events.',                   default_on: true },
+  { key: 'activity.include.community',         tier: 'activity', subcategory: 'High-signal categories', label: 'Community',              description: 'Include community.* events (groups, events, live rooms).', default_on: true },
+  { key: 'activity.include.wallet',            tier: 'activity', subcategory: 'High-signal categories', label: 'Wallet',                 description: 'Include wallet.* events.',                     default_on: true },
+  { key: 'activity.include.memory',            tier: 'activity', subcategory: 'High-signal categories', label: 'Memory',                 description: 'Include memory.* events (create/update/promote).', default_on: true },
+  { key: 'activity.include.profile',           tier: 'activity', subcategory: 'High-signal categories', label: 'Profile',                description: 'Include profile.update events.',               default_on: true },
+  { key: 'activity.include.discover_bookmark', tier: 'activity', subcategory: 'High-signal categories', label: 'Discover: bookmarks',    description: 'Include discover.service.bookmark events.',    default_on: true },
+  { key: 'activity.include.discover_offer',    tier: 'activity', subcategory: 'High-signal categories', label: 'Discover: offer views',  description: 'Include discover.offer.view events.',          default_on: true },
+  { key: 'activity.include.media',             tier: 'activity', subcategory: 'High-signal categories', label: 'Media plays',            description: 'Include media.* (music, podcasts, shorts) events.', default_on: true },
+
+  { key: 'activity.nav.include_page_view',   tier: 'activity', subcategory: 'Navigation handling', label: 'Include page views in [RECENT]', description: 'Off by default — too noisy.',                          default_on: false },
+  { key: 'activity.nav.include_auth',        tier: 'activity', subcategory: 'Navigation handling', label: 'Include auth events in [RECENT]', description: 'Off by default — login/logout is rarely interesting.', default_on: false },
+  { key: 'activity.nav.collapsed_summary',   tier: 'activity', subcategory: 'Navigation handling', label: 'Collapsed nav summary',           description: 'Emit "76 navigation events, areas: X, Y, Z" in [RECENT].', default_on: true },
+
+  // ─── 4. CONTENT CONSUMPTION ──────────────────────────────────────────────
+  { key: 'content.music.enabled',         tier: 'content', subcategory: 'Music',           label: '[CONTENT_PLAYED] music',  description: 'Render songs the user played in [CONTENT_PLAYED].', default_on: true },
+  { key: 'content.music.include_query',   tier: 'content', subcategory: 'Music',           label: 'Include query',           description: 'What the user asked for ("play XYZ").', default_on: true },
+  { key: 'content.music.include_title',   tier: 'content', subcategory: 'Music',           label: 'Include title',           description: 'Resolved track title.',                  default_on: true },
+  { key: 'content.music.include_channel', tier: 'content', subcategory: 'Music',           label: 'Include artist/channel',  description: 'Artist or YouTube channel.',             default_on: true },
+  { key: 'content.music.include_source',  tier: 'content', subcategory: 'Music',           label: 'Include source',          description: 'YouTube Music / Spotify / Apple Music / Vitana Hub.', default_on: true },
+  { key: 'content.podcast.enabled',       tier: 'content', subcategory: 'Podcasts',        label: '[CONTENT_PLAYED] podcasts', description: 'Pending — ORB podcast tool not yet shipped.', default_on: true, enforcement_status: 'pending' },
+  { key: 'content.podcast.include_title', tier: 'content', subcategory: 'Podcasts',        label: 'Include podcast title',   description: 'Pending.', default_on: true, enforcement_status: 'pending' },
+  { key: 'content.shorts.enabled',        tier: 'content', subcategory: 'Shorts / video',  label: '[CONTENT_PLAYED] shorts', description: 'Pending — frontend instrumentation.', default_on: true, enforcement_status: 'pending' },
+  { key: 'content.video.enabled',         tier: 'content', subcategory: 'Shorts / video',  label: '[CONTENT_PLAYED] videos', description: 'Pending — frontend instrumentation.', default_on: true, enforcement_status: 'pending' },
+  { key: 'content.community.posts_read',     tier: 'content', subcategory: 'Community content', label: 'Posts read',     description: 'Pending — needs scroll/dwell tracking.', default_on: false, enforcement_status: 'pending' },
+  { key: 'content.community.articles_read',  tier: 'content', subcategory: 'Community content', label: 'Articles read',  description: 'Pending — needs read detection.',       default_on: false, enforcement_status: 'pending' },
+  { key: 'content.section.max_items',     tier: 'content', subcategory: 'Section render',  label: 'Max items',               description: 'Cap on [CONTENT_PLAYED] line count.', default_on: true, params: [
+      { key: 'value', label: 'Max items', type: 'int', default: 8, min: 1, max: 30, step: 1 },
+  ]},
+  { key: 'content.section.window_days',   tier: 'content', subcategory: 'Section render',  label: 'Window (days)',           description: 'How far back to look for content plays.', default_on: true, params: [
+      { key: 'value', label: 'Days', type: 'int', default: 14, min: 1, max: 90, step: 1 },
+  ]},
+
+  // ─── 5. SOCIAL GRAPH ─────────────────────────────────────────────────────
+  { key: 'social.section.enabled', tier: 'social', subcategory: 'Section render', label: '[NETWORK] block', description: 'Master toggle for the entire [NETWORK] section.', default_on: true, enforcement_status: 'pending', params: [
+      { key: 'max_chars',           label: 'Max chars in [NETWORK]', type: 'int',  default: 600, min: 100, max: 2000, step: 50 },
+      { key: 'anonymize_names',     label: 'Anonymize names (initials)',   type: 'bool', default: false },
+      { key: 'include_counts_only', label: 'Counts only (no names)',       type: 'bool', default: false },
+  ]},
+  { key: 'social.follows.enabled',          tier: 'social', subcategory: 'Follow graph', label: 'Follow stats',         description: 'Following / followers / mutuals counts + top N.', default_on: true, enforcement_status: 'pending', params: [
+      { key: 'outgoing_top_n',  label: 'Top N following', type: 'int', default: 5, min: 0, max: 20, step: 1 },
+      { key: 'followers_top_n', label: 'Top N followers', type: 'int', default: 5, min: 0, max: 20, step: 1 },
+      { key: 'mutuals_top_n',   label: 'Top N mutuals',   type: 'int', default: 5, min: 0, max: 20, step: 1 },
+  ]},
+  { key: 'social.follows.recently_added',   tier: 'social', subcategory: 'Follow graph', label: 'Recently added follows',   description: 'Last N follows (trend signal).',     default_on: true, enforcement_status: 'pending' },
+  { key: 'social.follows.recently_removed', tier: 'social', subcategory: 'Follow graph', label: 'Recently removed follows', description: 'Last N unfollows (dampening signal).',default_on: true, enforcement_status: 'pending' },
+
+  { key: 'social.dm.enabled', tier: 'social', subcategory: 'Direct messaging', label: 'DM partners', description: 'Top chat partners by message volume.', default_on: true, enforcement_status: 'pending', params: [
+      { key: 'top_partners_n',     label: 'Top N partners',  type: 'int', default: 5,  min: 1, max: 20, step: 1 },
+      { key: 'volume_window_days', label: 'Window (days)',  type: 'int', default: 30, min: 1, max: 180, step: 1 },
+  ]},
+  { key: 'social.dm.last_contacted',  tier: 'social', subcategory: 'Direct messaging', label: 'Last contacted',   description: 'Most recent DM recipient + relative time.', default_on: true, enforcement_status: 'pending' },
+  { key: 'social.dm.cadence_summary', tier: 'social', subcategory: 'Direct messaging', label: 'Cadence summary',  description: '"chats daily with X, weekly with Y".',      default_on: true, enforcement_status: 'pending' },
+
+  { key: 'social.groups.enabled',         tier: 'social', subcategory: 'Groups & spaces', label: 'Groups joined',      description: 'Top N groups the user is a member of.', default_on: true, enforcement_status: 'pending', params: [
+      { key: 'top_n', label: 'Top N groups', type: 'int', default: 5, min: 1, max: 20, step: 1 },
+  ]},
+  { key: 'social.groups.created_by_user', tier: 'social', subcategory: 'Groups & spaces', label: 'Groups created/hosted', description: 'Groups where the user is host.',        default_on: true, enforcement_status: 'pending' },
+
+  { key: 'social.live_rooms.enabled',       tier: 'social', subcategory: 'Live rooms & events', label: 'Live rooms attended', description: 'Recent live_room_attendance rows.', default_on: true, enforcement_status: 'pending', params: [
+      { key: 'recent_n', label: 'Recent N', type: 'int', default: 5, min: 1, max: 20, step: 1 },
+  ]},
+  { key: 'social.live_rooms.cohost_history',tier: 'social', subcategory: 'Live rooms & events', label: 'Co-host history',     description: 'Co-host invites accepted/declined.', default_on: true, enforcement_status: 'pending' },
+  { key: 'social.events.enabled',           tier: 'social', subcategory: 'Live rooms & events', label: 'Events RSVPd',        description: 'Events the user has RSVPd to.',      default_on: true, enforcement_status: 'pending', params: [
+      { key: 'top_n', label: 'Top N events', type: 'int', default: 5, min: 1, max: 20, step: 1 },
+  ]},
+
+  { key: 'social.profile_views.enabled',     tier: 'social', subcategory: 'Profile views', label: 'Profiles viewed', description: 'Recent community.profile.view events.', default_on: true, enforcement_status: 'pending', params: [
+      { key: 'recent_n', label: 'Recent N', type: 'int', default: 8, min: 1, max: 30, step: 1 },
+  ]},
+  { key: 'social.profile_views.role_pattern',tier: 'social', subcategory: 'Profile views', label: 'Role pattern',     description: '"mostly viewed: coaches / professionals / community".', default_on: true, enforcement_status: 'pending' },
+
+  { key: 'social.search.enabled',                tier: 'social', subcategory: 'Search intent (who is the user looking for)', label: 'Search intent',           description: 'Recent member-search queries.',      default_on: true, enforcement_status: 'pending', params: [
+      { key: 'recent_queries_n', label: 'Recent queries', type: 'int', default: 5, min: 1, max: 20, step: 1 },
+  ]},
+  { key: 'social.search.top_terms',              tier: 'social', subcategory: 'Search intent (who is the user looking for)', label: 'Top search terms',         description: '"coach", "nutritionist", "personal trainer".', default_on: true, enforcement_status: 'pending' },
+  { key: 'social.search.inferred_looking_for',   tier: 'social', subcategory: 'Search intent (who is the user looking for)', label: 'Inferred "looking for"',   description: '"Looking for: movement coaches, nutritionists".', default_on: true, enforcement_status: 'pending' },
+
+  { key: 'social.matches.enabled',             tier: 'social', subcategory: 'Matchmaking (people-matches)', label: 'People matches',           description: 'Recent matches_daily rows + accept/dismiss counts.', default_on: true, enforcement_status: 'pending', params: [
+      { key: 'recent_matches_n', label: 'Recent N', type: 'int', default: 5, min: 1, max: 20, step: 1 },
+  ]},
+  { key: 'social.matches.include_blocklist_signal', tier: 'social', subcategory: 'Matchmaking (people-matches)', label: 'Include blocklist signal', description: 'SENSITIVE — exposes who user blocked.',                default_on: false, locked: true, enforcement_status: 'pending' },
+  { key: 'social.matches.include_dampened',         tier: 'social', subcategory: 'Matchmaking (people-matches)', label: 'Include dampened',         description: 'user_dampening — 7-day "don\'t show again" entries.',  default_on: false, enforcement_status: 'pending' },
+
+  { key: 'social.topics.enabled', tier: 'social', subcategory: 'Topic affinity', label: 'Topic profile', description: 'user_topic_profile — top topics by score.', default_on: true, enforcement_status: 'pending', params: [
+      { key: 'top_n',     label: 'Top N',           type: 'int', default: 8,  min: 1, max: 30,  step: 1 },
+      { key: 'min_score', label: 'Minimum score',   type: 'int', default: 30, min: 0, max: 100, step: 5 },
+  ]},
+  { key: 'social.topics.source.system',   tier: 'social', subcategory: 'Topic affinity sources', label: 'System-derived topics',   description: 'Topics derived by the system.',                default_on: true, enforcement_status: 'pending' },
+  { key: 'social.topics.source.explicit', tier: 'social', subcategory: 'Topic affinity sources', label: 'Explicit topics',         description: 'User-stated topic preferences.',               default_on: true, enforcement_status: 'pending' },
+  { key: 'social.topics.source.feedback', tier: 'social', subcategory: 'Topic affinity sources', label: 'Feedback-derived topics', description: 'From match like/dismiss feedback.',           default_on: true, enforcement_status: 'pending' },
+  { key: 'social.topics.source.inferred', tier: 'social', subcategory: 'Topic affinity sources', label: 'Inferred topics',         description: 'Inferred from behavior.',                      default_on: true, enforcement_status: 'pending' },
+
+  { key: 'social.signals.enabled', tier: 'social', subcategory: 'Inferred social signals', label: 'Inferred signals', description: 'relationship_signals (close_to_X, leader_in_Y).', default_on: true, enforcement_status: 'pending', params: [
+      { key: 'min_confidence', label: 'Minimum confidence', type: 'float', default: 0.6, min: 0, max: 1, step: 0.05 },
+      { key: 'max_n',          label: 'Max signals',         type: 'int',   default: 6, min: 1, max: 20, step: 1 },
+  ]},
+
+  // ─── 6. PREFERENCES ──────────────────────────────────────────────────────
+  { key: 'preferences.explicit.enabled', tier: 'preferences', subcategory: 'Explicit preferences (user_preferences)', label: 'Explicit preferences', description: 'Inject [PREFERENCES] from user_preferences table.', default_on: true },
+  { key: 'preferences.inferred.enabled', tier: 'preferences', subcategory: 'Inferred preferences (user_inferred_preferences)', label: 'Inferred preferences', description: 'Inject from user_inferred_preferences table.', default_on: true, params: [
+      { key: 'min_confidence', label: 'Minimum confidence', type: 'float', default: 0.55, min: 0, max: 1, step: 0.05 },
+  ]},
+  { key: 'preferences.capability.music',    tier: 'preferences', subcategory: 'Capability defaults (VTID-01942)', label: 'Music default connector',    description: 'Whether to expose user\'s default music provider.',    default_on: true, enforcement_status: 'pending' },
+  { key: 'preferences.capability.email',    tier: 'preferences', subcategory: 'Capability defaults (VTID-01942)', label: 'Email default connector',    description: 'Whether to expose user\'s default email provider.',    default_on: true, enforcement_status: 'pending' },
+  { key: 'preferences.capability.calendar', tier: 'preferences', subcategory: 'Capability defaults (VTID-01942)', label: 'Calendar default connector', description: 'Whether to expose user\'s default calendar provider.', default_on: true, enforcement_status: 'pending' },
+  { key: 'preferences.dedupe_by_key',       tier: 'preferences', subcategory: 'Render', label: 'Dedupe by key', description: 'Collapse duplicate explicit + inferred entries.', default_on: true },
+
+  // ─── 7. ROUTINES ─────────────────────────────────────────────────────────
+  { key: 'routines.enabled', tier: 'routines', subcategory: 'Section render', label: '[ROUTINES] block', description: 'Inject pattern-extracted routines from user_routines (VTID-01936).', default_on: true, params: [
+      { key: 'min_confidence', label: 'Minimum confidence', type: 'float', default: 0.5, min: 0, max: 1, step: 0.05 },
+      { key: 'max_items',      label: 'Max items',           type: 'int',   default: 5, min: 1, max: 20, step: 1 },
+  ]},
+  { key: 'routines.kind.time_of_day_preference', tier: 'routines', subcategory: 'Routine kinds', label: 'Time-of-day preference', description: 'morning / afternoon / evening rhythms.',   default_on: true },
+  { key: 'routines.kind.day_of_week_rhythm',     tier: 'routines', subcategory: 'Routine kinds', label: 'Day-of-week rhythm',     description: '"diary on Sundays" type patterns.',         default_on: true },
+  { key: 'routines.kind.category_affinity',      tier: 'routines', subcategory: 'Routine kinds', label: 'Category affinity',      description: 'Higher engagement with specific categories.', default_on: true },
+  { key: 'routines.kind.wave_velocity',          tier: 'routines', subcategory: 'Routine kinds', label: 'Wave velocity',          description: '90-day wave progression speed.',             default_on: true },
+  { key: 'routines.kind.completion_streak',      tier: 'routines', subcategory: 'Routine kinds', label: 'Completion streak',      description: 'N-day streak in a category.',                 default_on: true },
+  { key: 'routines.fallback_time_of_day',        tier: 'routines', subcategory: 'Fallback', label: 'Compute time-of-day from activity', description: 'If no routines exist, derive from activity log.', default_on: true },
+
+  // ─── 8. HEALTH ───────────────────────────────────────────────────────────
+  { key: 'health.enabled', tier: 'health', subcategory: 'Section render', label: '[HEALTH] block', description: 'Inject health summary section.', default_on: true, params: [
+      { key: 'window_days', label: 'Window (days)', type: 'int', default: 14, min: 1, max: 90, step: 1 },
+  ]},
+  { key: 'health.vitana_index.score',      tier: 'health', subcategory: 'Vitana Index (VTID-01103)', label: 'Index score',     description: 'Latest Vitana Index score.',         default_on: true },
+  { key: 'health.vitana_index.sub_scores', tier: 'health', subcategory: 'Vitana Index (VTID-01103)', label: 'Sub-scores',      description: 'Sleep / stress / movement breakdown.',default_on: true, enforcement_status: 'pending' },
+  { key: 'health.vitana_index.deltas',     tier: 'health', subcategory: 'Vitana Index (VTID-01103)', label: 'Index deltas',    description: 'Day-over-day changes.',              default_on: true, enforcement_status: 'pending' },
+  { key: 'health.biomarker.upload_count',  tier: 'health', subcategory: 'Biomarkers',                 label: 'Upload count',    description: 'Recent biomarker uploads (count).',  default_on: true },
+  { key: 'health.biomarker.recent_tests',  tier: 'health', subcategory: 'Biomarkers',                 label: 'Recent tests',    description: 'Names of recent tests.',             default_on: true, enforcement_status: 'pending' },
+  { key: 'health.supplement.add_count',    tier: 'health', subcategory: 'Supplements',                label: 'Adds count',      description: 'Recent supplement additions.',       default_on: true },
+  { key: 'health.supplement.current_list', tier: 'health', subcategory: 'Supplements',                label: 'Current list',    description: 'Active supplements.',                default_on: true, enforcement_status: 'pending' },
+  { key: 'health.lab_report.upload_count', tier: 'health', subcategory: 'Lab reports',                label: 'Upload count',    description: 'Recent lab report uploads.',          default_on: true, enforcement_status: 'pending' },
+  { key: 'health.omics.upload_count',      tier: 'health', subcategory: 'Omics',                      label: 'Upload count',    description: 'Recent omics uploads.',              default_on: true, enforcement_status: 'pending' },
+
+  // ─── 9. SESSION CONTEXT ──────────────────────────────────────────────────
+  { key: 'context.current_route',  tier: 'context', subcategory: 'Navigation', label: 'currentRoute', description: 'URL path the user is on right now.', default_on: true },
+  { key: 'context.selected_id',    tier: 'context', subcategory: 'Navigation', label: 'selectedId',   description: 'Specific entity the user has open.',   default_on: true },
+  { key: 'context.recent_routes',  tier: 'context', subcategory: 'Navigation', label: 'recentRoutes', description: 'Last N pages visited this session.', default_on: true, params: [
+      { key: 'count', label: 'Routes count', type: 'int', default: 5, min: 1, max: 20, step: 1 },
+  ]},
+  { key: 'context.client.city',           tier: 'context', subcategory: 'Client context (IP + device)', label: 'City',          description: 'IP geo city.',          default_on: true },
+  { key: 'context.client.country',        tier: 'context', subcategory: 'Client context (IP + device)', label: 'Country',       description: 'IP geo country.',       default_on: true },
+  { key: 'context.client.timezone',       tier: 'context', subcategory: 'Client context (IP + device)', label: 'Timezone',      description: 'User timezone.',         default_on: true },
+  { key: 'context.client.time_of_day',    tier: 'context', subcategory: 'Client context (IP + device)', label: 'Time of day',   description: 'morning / midday / afternoon / evening / night.', default_on: true },
+  { key: 'context.client.device',         tier: 'context', subcategory: 'Client context (IP + device)', label: 'Device',        description: 'iOS / Android / Desktop / Appilix WebView.', default_on: true },
+  { key: 'context.client.browser',        tier: 'context', subcategory: 'Client context (IP + device)', label: 'Browser',       description: 'Browser identifier.',   default_on: true },
+  { key: 'context.client.accept_language',tier: 'context', subcategory: 'Client context (IP + device)', label: 'Accept-Language',description: 'Browser-preferred language.', default_on: true },
+  { key: 'context.last_session_info',     tier: 'context', subcategory: 'Session continuity',           label: 'Last session info', description: 'When the user was last in voice + whether it failed.', default_on: true },
+  { key: 'context.conversation_summary',  tier: 'context', subcategory: 'Session continuity',           label: 'Conversation summary', description: 'Returning-user bridge summary text.', default_on: true },
+  { key: 'context.conversation_history',  tier: 'context', subcategory: 'Session continuity',           label: 'Conversation history (reconnect)', description: 'Last N turns when reconnecting.', default_on: true, params: [
+      { key: 'max_turns', label: 'Max turns', type: 'int', default: 10, min: 1, max: 50, step: 1 },
+  ]},
+  { key: 'context.journey_stage',         tier: 'context', subcategory: 'Session continuity',           label: 'Journey stage', description: '90-day wave / wave_name / day_number.', default_on: true },
+
+  // ─── 10. KNOWLEDGE & SYSTEM ──────────────────────────────────────────────
+  { key: 'knowledge.hub.enabled', tier: 'knowledge', subcategory: 'Knowledge Hub (retrieval router)', label: 'Knowledge Hub', description: 'Master toggle for knowledge retrieval.', default_on: true, params: [
+      { key: 'max_items', label: 'Max items', type: 'int', default: 8, min: 1, max: 30, step: 1 },
+  ]},
+  { key: 'knowledge.ns.vitana_system',     tier: 'knowledge', subcategory: 'Namespaces (retrieval-router)', label: 'vitana_system (priority 100)',     description: 'Platform docs & how-to.', default_on: true, locked: true },
+  { key: 'knowledge.ns.personal_history',  tier: 'knowledge', subcategory: 'Namespaces (retrieval-router)', label: 'personal_history (priority 90)',   description: '"remember", "my name", "told you" routing.', default_on: true },
+  { key: 'knowledge.ns.health_personal',   tier: 'knowledge', subcategory: 'Namespaces (retrieval-router)', label: 'health_personal (priority 85)',     description: 'Personal health questions.', default_on: true },
+  { key: 'knowledge.ns.external_current',  tier: 'knowledge', subcategory: 'Namespaces (retrieval-router)', label: 'external_current (priority 80)',   description: 'News / weather / stock.', default_on: true },
+  { key: 'knowledge.ns.general_knowledge', tier: 'knowledge', subcategory: 'Namespaces (retrieval-router)', label: 'general_knowledge (priority 50)',   description: '"what is" / "how to".', default_on: true },
+  { key: 'knowledge.web_search.enabled',   tier: 'knowledge', subcategory: 'Web search', label: 'Google Search grounding', description: 'Route to google_search tool for current events.', default_on: true, params: [
+      { key: 'max_items', label: 'Max items', type: 'int', default: 6, min: 1, max: 20, step: 1 },
+  ]},
+  { key: 'knowledge.calendar.today_events',    tier: 'knowledge', subcategory: 'Calendar', label: "Today's events",      description: 'Inject today\'s calendar events.',        default_on: true },
+  { key: 'knowledge.calendar.upcoming_events', tier: 'knowledge', subcategory: 'Calendar', label: 'Upcoming events',     description: 'Inject upcoming events list.',            default_on: true },
+  { key: 'knowledge.calendar.free_slots',      tier: 'knowledge', subcategory: 'Calendar', label: 'Free time slots',     description: 'Inject free slots between meetings.',     default_on: true },
+
+  // ─── 11. BRAIN / PROACTIVE ───────────────────────────────────────────────
+  { key: 'brain.awareness.tenure',            tier: 'brain', subcategory: 'User Awareness block', label: 'Tenure stage',         description: 'day0 / early / returning.',          default_on: true, enforcement_status: 'pending' },
+  { key: 'brain.awareness.last_interaction',  tier: 'brain', subcategory: 'User Awareness block', label: 'Last interaction',     description: 'When user was last in any surface.',default_on: true, enforcement_status: 'pending' },
+  { key: 'brain.awareness.journey',           tier: 'brain', subcategory: 'User Awareness block', label: 'Journey wave',         description: 'Current 90-day wave.',              default_on: true, enforcement_status: 'pending' },
+  { key: 'brain.awareness.goal',              tier: 'brain', subcategory: 'User Awareness block', label: 'Active goal',          description: 'Active Life Compass goal.',         default_on: true, enforcement_status: 'pending' },
+  { key: 'brain.awareness.motivation_signal', tier: 'brain', subcategory: 'User Awareness block', label: 'Motivation signal',    description: 'absent / low / present.',           default_on: true, enforcement_status: 'pending' },
+  { key: 'brain.opener.enabled',              tier: 'brain', subcategory: 'Proactive opener',    label: 'Proactive opener',     description: 'Suggest opener from shape matrix.',  default_on: true, enforcement_status: 'pending' },
+  { key: 'brain.opener.forbidden_phrases',    tier: 'brain', subcategory: 'Proactive opener',    label: 'Forbidden openings',   description: '"What can I do for you?" override.',default_on: true, enforcement_status: 'pending' },
+  { key: 'brain.retrieval_router.enabled',    tier: 'brain', subcategory: 'Retrieval router',    label: 'Retrieval router',     description: 'Router-based retrieval rules.',     default_on: true, enforcement_status: 'pending' },
+
+  // ─── 12. OVERRIDES (high-priority, append-last blocks) ───────────────────
+  { key: 'overrides.proactive_opener',    tier: 'overrides', subcategory: 'High-priority overrides', label: 'PROACTIVE OPENER OVERRIDE', description: 'VTID-01927 — appended after temporal journey to override greeting reflexes.', default_on: true },
+  { key: 'overrides.activity_awareness',  tier: 'overrides', subcategory: 'High-priority overrides', label: 'ACTIVITY AWARENESS OVERRIDE', description: 'BOOTSTRAP-HISTORY-AWARE-TIMELINE — re-asserts USER CONTEXT PROFILE at end of prompt with hard rules.', default_on: true },
+  { key: 'overrides.navigator_policy',    tier: 'overrides', subcategory: 'High-priority overrides', label: 'Navigator policy',           description: 'Navigator tool routing rules section.', default_on: true, enforcement_status: 'pending' },
+  { key: 'overrides.temporal_journey',    tier: 'overrides', subcategory: 'High-priority overrides', label: 'Temporal + journey context', description: 'Time-of-day greeting + 90-day journey stage.', default_on: true, enforcement_status: 'pending' },
+];
+
+// =============================================================================
+// Public — manifest accessors
+// =============================================================================
+
+export function getManifest(): readonly AwarenessSignal[] {
+  return M;
+}
+
+export function getSignal(key: string): AwarenessSignal | undefined {
+  return M.find(s => s.key === key);
+}
+
+// =============================================================================
+// Config snapshot — merges manifest + DB overrides, cached
+// =============================================================================
+
+const CACHE_TTL_MS = 60_000;
+let cached: { snap: AwarenessConfigSnapshot; expiresAt: number } | null = null;
+let inflight: Promise<AwarenessConfigSnapshot> | null = null;
+
+function serviceClient(): SupabaseClient | null {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+  if (!url || !key) return null;
+  return createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
+}
+
+function buildSnapshot(overrides: Record<string, { enabled: boolean; params: Record<string, unknown> }>): AwarenessConfigSnapshot {
+  const resolved: Record<string, ResolvedSignal> = {};
+
+  for (const sig of M) {
+    const override = overrides[sig.key];
+    const defaultParams: Record<string, unknown> = {};
+    for (const p of sig.params || []) {
+      defaultParams[p.key] = p.default;
+    }
+    if (override) {
+      // Locked signals cannot be turned off — force enabled regardless of override.
+      const enabled = sig.locked ? sig.default_on : override.enabled;
+      resolved[sig.key] = {
+        enabled,
+        params: { ...defaultParams, ...(override.params || {}) },
+        source: 'override',
+      };
+    } else {
+      resolved[sig.key] = {
+        enabled: sig.default_on,
+        params: defaultParams,
+        source: 'default',
+      };
+    }
+  }
+
+  return {
+    resolved,
+    overrides,
+    built_at: new Date().toISOString(),
+    isEnabled(key: string): boolean {
+      const r = resolved[key];
+      if (r) return r.enabled;
+      // Unknown key → treat as enabled (don't break callers when manifest is ahead/behind).
+      console.warn(`[AwarenessRegistry] isEnabled called with unknown key: ${key}`);
+      return true;
+    },
+    getParam<T>(signalKey: string, paramKey: string, fallback: T): T {
+      const r = resolved[signalKey];
+      if (!r) return fallback;
+      const v = r.params[paramKey];
+      return (v === undefined || v === null) ? fallback : (v as T);
+    },
+  };
+}
+
+async function fetchOverrides(): Promise<Record<string, { enabled: boolean; params: Record<string, unknown> }>> {
+  const client = serviceClient();
+  if (!client) return {};
+  const { data, error } = await client
+    .from('awareness_config')
+    .select('key, enabled, params');
+  if (error) {
+    // table missing pre-migration is normal — log once and continue.
+    if (!/relation .*awareness_config.* does not exist/i.test(error.message)) {
+      console.warn(`[AwarenessRegistry] fetchOverrides failed: ${error.message}`);
+    }
+    return {};
+  }
+  const out: Record<string, { enabled: boolean; params: Record<string, unknown> }> = {};
+  for (const row of (data || []) as any[]) {
+    out[row.key] = { enabled: !!row.enabled, params: (row.params as Record<string, unknown>) || {} };
+  }
+  return out;
+}
+
+/**
+ * Returns the current effective awareness configuration. Cached for 60s.
+ */
+export async function getAwarenessConfig(): Promise<AwarenessConfigSnapshot> {
+  const now = Date.now();
+  if (cached && cached.expiresAt > now) return cached.snap;
+  if (inflight) return inflight;
+
+  inflight = (async () => {
+    try {
+      const overrides = await fetchOverrides();
+      const snap = buildSnapshot(overrides);
+      cached = { snap, expiresAt: Date.now() + CACHE_TTL_MS };
+      return snap;
+    } finally {
+      inflight = null;
+    }
+  })();
+  return inflight;
+}
+
+/**
+ * Drop the cache. Called by the admin write endpoint after a save so the next
+ * read sees fresh values immediately.
+ */
+export function invalidateAwarenessConfigCache(): void {
+  cached = null;
+}
+
+/**
+ * Synchronous helper for code paths where awaiting isn't possible. Returns
+ * a snapshot built from manifest defaults only when no cache is warm.
+ */
+export function getAwarenessConfigSync(): AwarenessConfigSnapshot {
+  if (cached && cached.expiresAt > Date.now()) return cached.snap;
+  return buildSnapshot({});
+}

--- a/services/gateway/src/services/user-context-profiler.ts
+++ b/services/gateway/src/services/user-context-profiler.ts
@@ -25,6 +25,7 @@
  */
 import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { getCurrentFacts } from './memory-facts-service';
+import { getAwarenessConfig } from './awareness-registry';
 
 const TTL_MS = 10 * 60 * 1000;
 const DEFAULT_WINDOW_DAYS = 14;
@@ -474,26 +475,57 @@ export async function getUserContextSummary(
     return { summary: hit.summary, version, cached: true, warnings };
   }
 
-  const sinceIso = new Date(now - windowDays * 24 * 60 * 60 * 1000).toISOString();
+  // BOOTSTRAP-AWARENESS-REGISTRY: load admin config (60s cache) so each
+  // section can be turned off / tuned globally without a redeploy.
+  const cfg = await getAwarenessConfig().catch(() => null);
+
+  // Effective window: registry param overrides opts.windowDays.
+  const effectiveWindowDays = cfg
+    ? Number(cfg.getParam('activity.recent.enabled', 'window_days', windowDays)) || windowDays
+    : windowDays;
+  const sinceIso = new Date(now - effectiveWindowDays * 24 * 60 * 60 * 1000).toISOString();
+
+  const fetchActivitiesIfWanted = (cfg && (
+    !cfg.isEnabled('activity.summary.enabled') &&
+    !cfg.isEnabled('activity.recent.enabled') &&
+    !cfg.isEnabled('content.music.enabled') &&
+    !cfg.isEnabled('health.enabled')))
+    ? Promise.resolve([] as ActivityRow[])
+    : fetchActivityLog(client, userId, sinceIso);
+
+  const fetchRoutinesIfWanted = (cfg && !cfg.isEnabled('routines.enabled'))
+    ? Promise.resolve([] as RoutineRow[])
+    : fetchRoutines(client, userId);
+
+  const fetchPrefsIfWanted = (cfg && !cfg.isEnabled('preferences.explicit.enabled') && !cfg.isEnabled('preferences.inferred.enabled'))
+    ? Promise.resolve([] as PreferenceRow[])
+    : fetchPreferences(client, userId);
+
+  const fetchVitanaIfWanted = (cfg && !cfg.isEnabled('health.enabled'))
+    ? Promise.resolve(null)
+    : fetchVitanaIndex(client, userId);
+
+  const fetchFactsIfWanted = (cfg && !cfg.isEnabled('memory.facts.enabled')) || !opts.tenantId
+    ? Promise.resolve({ ok: true, facts: [] as any[] })
+    : getCurrentFacts({ tenant_id: opts.tenantId, user_id: userId });
 
   const [activities, routines, prefs, vitana, factsResult] = await Promise.all([
-    fetchActivityLog(client, userId, sinceIso),
-    fetchRoutines(client, userId),
-    fetchPreferences(client, userId),
-    fetchVitanaIndex(client, userId),
-    opts.tenantId
-      ? getCurrentFacts({ tenant_id: opts.tenantId, user_id: userId })
-      : Promise.resolve({ ok: true, facts: [] as any[] }),
+    fetchActivitiesIfWanted,
+    fetchRoutinesIfWanted,
+    fetchPrefsIfWanted,
+    fetchVitanaIfWanted,
+    fetchFactsIfWanted,
   ]);
 
   const sections = [
-    buildActivitySummarySection(activities),
-    buildRoutinesSection(routines, activities),
-    buildPreferencesSection(prefs),
-    buildHealthSection(activities, vitana),
-    buildContentSection(activities),
-    buildFactsSection(factsResult.ok ? factsResult.facts : []),
-    buildRecentSection(activities),
+    (!cfg || cfg.isEnabled('activity.summary.enabled')) ? buildActivitySummarySection(activities) : '',
+    (!cfg || cfg.isEnabled('routines.enabled'))         ? buildRoutinesSection(routines, activities) : '',
+    (!cfg || cfg.isEnabled('preferences.explicit.enabled') || cfg.isEnabled('preferences.inferred.enabled'))
+      ? buildPreferencesSection(prefs) : '',
+    (!cfg || cfg.isEnabled('health.enabled'))           ? buildHealthSection(activities, vitana) : '',
+    (!cfg || cfg.isEnabled('content.music.enabled'))    ? buildContentSection(activities) : '',
+    (!cfg || cfg.isEnabled('memory.facts.enabled'))     ? buildFactsSection(factsResult.ok ? factsResult.facts : []) : '',
+    (!cfg || cfg.isEnabled('activity.recent.enabled'))  ? buildRecentSection(activities) : '',
   ].filter(Boolean);
 
   const summary = truncate(sections.join('\n\n'), maxChars);

--- a/supabase/migrations/20260421140000_BOOTSTRAP_awareness_registry.sql
+++ b/supabase/migrations/20260421140000_BOOTSTRAP_awareness_registry.sql
@@ -1,0 +1,74 @@
+-- =============================================================================
+-- BOOTSTRAP-AWARENESS-REGISTRY
+-- Date: 2026-04-21
+--
+-- Stores admin-controlled overrides for the Awareness Registry. Each row keys
+-- one signal in services/gateway/src/services/awareness-registry.ts manifest.
+-- Missing rows fall back to manifest defaults (`enabled: default_on`).
+--
+-- v1: GLOBAL config — one row per key, applies to every tenant.
+-- (Per-tenant + per-user overrides are deferred to v2.)
+--
+-- Access: read = exafy_admin only via RLS. Writes go through the gateway with
+-- service-role key, so no INSERT/UPDATE policies are needed for end users.
+--
+-- Rollback:
+--   DROP TABLE IF EXISTS public.awareness_config_audit;
+--   DROP TABLE IF EXISTS public.awareness_config;
+-- =============================================================================
+
+BEGIN;
+
+-- 1. Live config table -------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.awareness_config (
+  key        text        PRIMARY KEY,
+  enabled    boolean     NOT NULL,
+  params     jsonb       NOT NULL DEFAULT '{}'::jsonb,
+  updated_by uuid        REFERENCES auth.users(id) ON DELETE SET NULL,
+  updated_at timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.awareness_config IS
+  'BOOTSTRAP-AWARENESS-REGISTRY: per-signal admin overrides. Empty rows = manifest defaults apply.';
+
+-- 2. Audit log ---------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.awareness_config_audit (
+  id           bigserial PRIMARY KEY,
+  key          text        NOT NULL,
+  prev_enabled boolean,
+  new_enabled  boolean,
+  prev_params  jsonb,
+  new_params   jsonb,
+  changed_by   uuid        REFERENCES auth.users(id) ON DELETE SET NULL,
+  changed_at   timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_awareness_audit_changed_at
+  ON public.awareness_config_audit (changed_at DESC);
+
+COMMENT ON TABLE public.awareness_config_audit IS
+  'BOOTSTRAP-AWARENESS-REGISTRY: change history for awareness_config (who toggled what, when).';
+
+-- 3. RLS — exafy admins only -------------------------------------------------
+ALTER TABLE public.awareness_config ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.awareness_config_audit ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS awareness_config_admin_read ON public.awareness_config;
+CREATE POLICY awareness_config_admin_read
+  ON public.awareness_config FOR SELECT
+  USING (EXISTS (
+    SELECT 1 FROM public.app_users u
+    WHERE u.user_id = auth.uid() AND u.exafy_admin = true
+  ));
+
+DROP POLICY IF EXISTS awareness_audit_admin_read ON public.awareness_config_audit;
+CREATE POLICY awareness_audit_admin_read
+  ON public.awareness_config_audit FOR SELECT
+  USING (EXISTS (
+    SELECT 1 FROM public.app_users u
+    WHERE u.user_id = auth.uid() AND u.exafy_admin = true
+  ));
+
+-- Service role bypasses RLS entirely, so the gateway can write without policies.
+
+COMMIT;


### PR DESCRIPTION
Awareness Registry — admin control panel for every signal the voice ORB / brain injects into the Gemini Live system_instruction.

v1 scope (per approved plan we-were-always-talking-optimized-owl.md):
- Global config (no tenant column) — exafy_admin only.
- Manifest of ~155 signals across 12 tiers (identity / memory / activity / content / social / preferences / routines / health / context / knowledge / brain / overrides).
- Migration creates awareness_config + awareness_config_audit with RLS (read = exafy_admin).
- New service awareness-registry.ts with getAwarenessConfig() (60s cache) + getAwarenessConfigSync() for the prompt builder.
- New admin API /api/v1/awareness/{config, audit, config/bulk}.
- Enforcement: user-context-profiler skips sections + short-circuits data fetches based on toggles; orb-live gates the PROACTIVE OPENER and ACTIVITY AWARENESS overrides.
- Command Hub: Admin > Awareness page with 12 collapsible tiers, subcategories, checkbox + param inputs, Save (bulk upsert), Run Preview (uses existing /debug/awareness), Discard, Audit panel.

Out of scope (manifest entries marked enforcement_status='pending'): Social Graph [NETWORK] section build (~20 signals declared, buildNetworkSection follow-up PR), brain awareness wiring (Tier 11), memory category subcategory toggles (Tier 2).

Generated with Claude Code