### PR TITLE
feat(og): add og-profile Supabase Edge Function for rich share previews

### DIFF
--- a/.github/workflows/DEPLOY-OG-PROFILE.yml
+++ b/.github/workflows/DEPLOY-OG-PROFILE.yml
@@ -1,0 +1,41 @@
+name: Deploy og-profile Edge Function
+
+# Deploys supabase/functions/og-profile via the Supabase CLI.
+# Requires a repo secret SUPABASE_ACCESS_TOKEN (create one at
+# https://supabase.com/dashboard/account/tokens, scope "All projects").
+# Project ref is the stable one used elsewhere in this repo.
+#
+# Triggers:
+#   - push to main when og-profile source or this workflow changes
+#   - manual dispatch (workflow_dispatch)
+
+on:
+  push:
+    branches: [main]
+    paths:
+      - 'supabase/functions/og-profile/**'
+      - '.github/workflows/DEPLOY-OG-PROFILE.yml'
+  workflow_dispatch:
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Install Supabase CLI
+        uses: supabase/setup-cli@v1
+        with:
+          version: latest
+
+      - name: Deploy og-profile
+        env:
+          SUPABASE_ACCESS_TOKEN: ${{ secrets.SUPABASE_ACCESS_TOKEN }}
+          SUPABASE_PROJECT_REF: inmkhvwdcuyhnxkgfvsb
+        run: |
+          if [ -z "$SUPABASE_ACCESS_TOKEN" ]; then
+            echo "::error::SUPABASE_ACCESS_TOKEN secret is missing — add it under Settings → Secrets → Actions."
+            exit 1
+          fi
+          supabase functions deploy og-profile --project-ref "$SUPABASE_PROJECT_REF"
+          echo "og-profile deployed to project $SUPABASE_PROJECT_REF"

--- a/supabase/functions/og-profile/index.ts
+++ b/supabase/functions/og-profile/index.ts
@@ -1,0 +1,211 @@
+import { createClient } from 'https://esm.sh/@supabase/supabase-js@2.56.0';
+
+const corsHeaders = {
+  'Access-Control-Allow-Origin': '*',
+  'Access-Control-Allow-Headers': 'authorization, x-client-info, apikey, content-type',
+};
+
+function isCrawler(userAgent: string): boolean {
+  const crawlers = [
+    'WhatsApp', 'facebookexternalhit', 'Facebot', 'Twitterbot',
+    'LinkedInBot', 'Slackbot', 'TelegramBot', 'SkypeUriPreview',
+    'Discordbot', 'redditbot',
+  ];
+  return crawlers.some((crawler) => userAgent.includes(crawler));
+}
+
+function sanitizeText(text: string | null | undefined, max = 160): string {
+  if (!text) return '';
+  return text
+    .replace(/<[^>]*>/g, '')
+    .replace(/[\r\n]+/g, ' ')
+    .replace(/“|”/g, '"')
+    .replace(/‘|’/g, "'")
+    .replace(/`/g, "'")
+    .replace(/&/g, '&amp;')
+    .replace(/"/g, '&quot;')
+    .replace(/</g, '&lt;')
+    .replace(/>/g, '&gt;')
+    .trim()
+    .substring(0, max);
+}
+
+const DEFAULT_IMAGE =
+  'https://inmkhvwdcuyhnxkgfvsb.supabase.co/storage/v1/object/public/default-images/vitana-og-default.jpg';
+
+interface ProfileRow {
+  id: string;
+  handle: string | null;
+  display_name: string | null;
+  first_name: string | null;
+  last_name: string | null;
+  longevity_archetype: string | null;
+  bio: string | null;
+  avatar_url: string | null;
+  cover_url: string | null;
+}
+
+function fallbackHTML(): string {
+  const homeUrl = 'https://vitanaland.com';
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>MAXINA - Longevity Community</title>
+  <meta property="og:type" content="website" />
+  <meta property="og:site_name" content="MAXINA" />
+  <meta property="og:title" content="MAXINA - Longevity Community" />
+  <meta property="og:description" content="Join MAXINA to connect with the longevity community." />
+  <meta property="og:image" content="${DEFAULT_IMAGE}" />
+  <meta property="og:image:type" content="image/jpeg" />
+  <meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />
+  <meta property="og:url" content="${homeUrl}" />
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta http-equiv="refresh" content="0;url=${homeUrl}">
+</head>
+<body><p>Redirecting to MAXINA…</p><a href="${homeUrl}">Click here</a></body>
+</html>`;
+}
+
+function buildProfileHTML(
+  profile: ProfileRow,
+  canonicalUrl: string,
+  destinationUrl: string,
+): string {
+  const composedName =
+    [profile.first_name, profile.last_name].filter(Boolean).join(' ').trim() ||
+    profile.display_name ||
+    (profile.handle ? `@${profile.handle}` : 'MAXINA member');
+
+  const handlePart = profile.handle ? `@${profile.handle}` : '';
+  const archetype = profile.longevity_archetype || profile.bio || 'Longevity community member';
+
+  const title = sanitizeText(`${composedName}${handlePart ? ` (${handlePart})` : ''} · MAXINA`, 80);
+  const description = sanitizeText(
+    `${handlePart ? handlePart + ' · ' : ''}${archetype}. Tap to view on MAXINA.`,
+    200,
+  );
+
+  // cover_url is landscape-friendly; avatar_url works too (WhatsApp/Telegram
+  // auto-fit square images). Fall back to the default MAXINA OG image.
+  const image = profile.cover_url || profile.avatar_url || DEFAULT_IMAGE;
+
+  return `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="UTF-8">
+  <meta name="viewport" content="width=device-width, initial-scale=1.0">
+  <title>${title}</title>
+  <meta name="description" content="${description}" />
+
+  <meta property="og:type" content="profile" />
+  <meta property="og:site_name" content="MAXINA" />
+  <meta property="og:title" content="${title}" />
+  <meta property="og:description" content="${description}" />
+  <meta property="og:image" content="${image}" />
+  <meta property="og:image:alt" content="${sanitizeText(composedName, 80)}" />
+  ${profile.cover_url
+    ? `<meta property="og:image:width" content="1200" />
+  <meta property="og:image:height" content="630" />`
+    : `<meta property="og:image:width" content="512" />
+  <meta property="og:image:height" content="512" />`}
+  <meta property="og:url" content="${canonicalUrl}" />
+  ${profile.handle ? `<meta property="profile:username" content="${sanitizeText(profile.handle, 80)}" />` : ''}
+  ${profile.first_name ? `<meta property="profile:first_name" content="${sanitizeText(profile.first_name, 80)}" />` : ''}
+  ${profile.last_name ? `<meta property="profile:last_name" content="${sanitizeText(profile.last_name, 80)}" />` : ''}
+
+  <meta name="twitter:card" content="summary_large_image" />
+  <meta name="twitter:title" content="${title}" />
+  <meta name="twitter:description" content="${description}" />
+  <meta name="twitter:image" content="${image}" />
+
+  <link rel="canonical" href="${canonicalUrl}" />
+  <meta http-equiv="refresh" content="0;url=${destinationUrl}" />
+</head>
+<body>
+  <h1>${title}</h1>
+  <p>${description}</p>
+  <p><a href="${destinationUrl}">Open on MAXINA</a></p>
+</body>
+</html>`;
+}
+
+Deno.serve(async (req) => {
+  if (req.method === 'OPTIONS') {
+    return new Response(null, { headers: corsHeaders });
+  }
+
+  try {
+    const url = new URL(req.url);
+    const profileId = url.searchParams.get('id');
+    const userAgent = req.headers.get('user-agent') || '';
+
+    console.log('og-profile request:', {
+      profileId,
+      isCrawler: isCrawler(userAgent),
+    });
+
+    if (!profileId) {
+      return new Response(fallbackHTML(), {
+        headers: { ...corsHeaders, 'Content-Type': 'text/html; charset=utf-8' },
+      });
+    }
+
+    const supabaseUrl = Deno.env.get('SUPABASE_URL')!;
+    const supabaseKey = Deno.env.get('SUPABASE_SERVICE_ROLE_KEY')!;
+    const supabase = createClient(supabaseUrl, supabaseKey);
+
+    // Accept either the profiles.id UUID (current share URL format)
+    // or a handle (future-proofing for pretty URLs).
+    const isUUID =
+      /^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(
+        profileId,
+      );
+
+    const query = supabase
+      .from('profiles')
+      .select(
+        'id, handle, display_name, first_name, last_name, longevity_archetype, bio, avatar_url, cover_url',
+      );
+    const { data, error } = await (isUUID
+      ? query.eq('id', profileId).maybeSingle()
+      : query.eq('handle', profileId).maybeSingle());
+
+    if (error || !data) {
+      console.warn('og-profile: not found', { profileId, err: error?.message });
+      return new Response(fallbackHTML(), {
+        headers: { ...corsHeaders, 'Content-Type': 'text/html; charset=utf-8' },
+      });
+    }
+
+    const profile = data as ProfileRow;
+    const canonicalUrl = `https://e.vitanaland.com/profiles/${profile.id}`;
+    const destinationUrl = `https://vitanaland.com/?share=profile&id=${profile.id}`;
+
+    if (isCrawler(userAgent)) {
+      return new Response(
+        buildProfileHTML(profile, canonicalUrl, destinationUrl),
+        {
+          headers: {
+            ...corsHeaders,
+            'Content-Type': 'text/html; charset=utf-8',
+            'Cache-Control': 'public, max-age=3600',
+          },
+        },
+      );
+    }
+
+    // Non-crawler hitting the edge function directly: bounce them on.
+    return new Response(null, {
+      status: 302,
+      headers: { ...corsHeaders, Location: destinationUrl },
+    });
+  } catch (err) {
+    console.error('og-profile error:', err);
+    return new Response(fallbackHTML(), {
+      headers: { ...corsHeaders, 'Content-Type': 'text/html; charset=utf-8' },
+    });
+  }
+});


### PR DESCRIPTION
## Problem

Sharing a profile link on WhatsApp today shows:
- Generic title "VITANA - Community"
- Generic description
- **No image**

The Cloudflare Worker at `e.vitanaland.com` already routes crawler hits for `/profiles/:id` to a Supabase Edge Function at `og-profile` ([worker.js:112](https://github.com/exafyltd/vitana-platform/blob/main/cloudflare/vitanaland-og-proxy/worker.js#L112)) — but **that function has never existed**. So the worker's fetch fails, and WhatsApp falls back to the SPA's static `index.html` meta tags.

## Fix

Add `supabase/functions/og-profile/index.ts`, modelled on the existing `og-match` function:

- Detect the crawler User-Agent (WhatsApp, Telegram, LinkedIn, Slack, etc.). Non-crawlers get a 302 straight to the app.
- Accept either `profiles.id` UUID (current share URL shape) or a handle (future pretty URLs).
- Query `profiles` for display name / first / last name / handle / archetype / bio / avatar_url / cover_url.
- Emit rich OG + Twitter meta:
  - `og:type=profile`, `og:site_name=MAXINA`
  - Title = `First Last (@handle) · MAXINA`
  - Description = `@handle · archetype. Tap to view on MAXINA.`
  - `og:image` = `cover_url` → `avatar_url` → default MAXINA hero. The `avatars` bucket is already publicly readable, so URLs render without auth.
  - `profile:username` / `profile:first_name` / `profile:last_name` when available.

Plus `.github/workflows/DEPLOY-OG-PROFILE.yml` — deploys via the Supabase CLI on push-to-main (path-filtered) and on manual dispatch.

BOOTSTRAP-ACCOUNT-PILL

## One-time setup needed before the workflow can run

The deploy workflow needs a repo secret **`SUPABASE_ACCESS_TOKEN`**:

1. Go to https://supabase.com/dashboard/account/tokens
2. "Generate new token", name it `gha-edge-functions`, scope "All projects", copy it.
3. In GitHub: Settings → Secrets and variables → Actions → New repository secret → name `SUPABASE_ACCESS_TOKEN`, paste the value.

After that, merging this PR will auto-deploy the function. The workflow also supports manual dispatch for re-deploys.

## Test plan
- [ ] Add the secret → merge → watch `DEPLOY-OG-PROFILE.yml` complete green.
- [ ] From a real phone, share a profile to WhatsApp. Preview should now show the display name, handle, archetype, and the avatar / cover image instead of the generic community card.
- [ ] Sanity curl from a crawler UA:
  ```bash
  curl -A "WhatsApp/2.0" -L "https://e.vitanaland.com/profiles/<your-profile-id>"
  ```
  Response should be HTML containing `<meta property="og:title" content="... · MAXINA"`.

https://claude.ai/code/session_018xRvjcLocE5c52Rusqjinq