### PR TITLE
feat(admin): KPI awareness surface foundation (Phase AA)

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -285,6 +285,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const tenantKnowledgeRouter = require('./routes/tenant-admin/knowledge').default;
   // Overview Dashboard — KPI summary, at-risk, activity, alerts
   const tenantOverviewRouter = require('./routes/tenant-admin/overview').default;
+  // BOOTSTRAP-ADMIN-KPI-AA: Admin KPI surface (real-time snapshot + history)
+  const tenantKpisRouter = require('./routes/tenant-admin/kpis').default;
   // Settings — tenant profile, branding, feature flags, integrations
   const tenantSettingsRouter = require('./routes/tenant-admin/settings').default;
   // Audit & Compliance — admin action audit log, access log
@@ -746,6 +748,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   mountRouterSync(app, '/api/v1/admin/tenants/:tenantId/kb', tenantKnowledgeRouter, { owner: 'tenant-knowledge' });
   // Overview Dashboard — KPI summary, at-risk, activity, alerts
   mountRouterSync(app, '/api/v1/admin/tenants/:tenantId/overview', tenantOverviewRouter, { owner: 'tenant-overview' });
+  // BOOTSTRAP-ADMIN-KPI-AA: Admin KPI surface
+  mountRouterSync(app, '/api/v1/admin/tenants/:tenantId/kpis', tenantKpisRouter, { owner: 'tenant-kpis' });
   // Settings — tenant profile, branding, feature flags
   mountRouterSync(app, '/api/v1/admin/tenants/:tenantId/settings', tenantSettingsRouter, { owner: 'tenant-settings' });
   // Audit & Compliance — admin action audit log
@@ -998,6 +1002,19 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
         }
       } catch (error) {
         console.warn('⚠️ Self-healing reconciler initialization failed (non-fatal):', error);
+      }
+
+      // BOOTSTRAP-ADMIN-KPI-AA: Admin Awareness Worker (5-min KPI refresh per tenant)
+      try {
+        const adminKpiEnabled = process.env.ADMIN_KPI_WORKER_ENABLED !== 'false';
+        if (adminKpiEnabled) {
+          const { startAdminAwarenessWorker } = require('./services/admin-awareness-worker');
+          startAdminAwarenessWorker();
+        } else {
+          console.log('⏸️ Admin awareness worker disabled (ADMIN_KPI_WORKER_ENABLED=false)');
+        }
+      } catch (error) {
+        console.warn('⚠️ Admin awareness worker initialization failed (non-fatal):', error);
       }
 
       // Dev Autopilot background executor (cooling→running→ci loop).

--- a/services/gateway/src/routes/tenant-admin/kpis.ts
+++ b/services/gateway/src/routes/tenant-admin/kpis.ts
@@ -1,0 +1,117 @@
+/**
+ * BOOTSTRAP-ADMIN-KPI-AA: Admin KPI endpoints.
+ *
+ * Mounted at /api/v1/admin/tenants/:tenantId/kpis
+ *
+ *   GET  /           — current snapshot + 7-day history
+ *   GET  /current    — current snapshot only (lighter payload)
+ *   GET  /history    — historical daily snapshots (query ?days=30, default 7, max 90)
+ *   POST /refresh    — force recompute this tenant (dev/admin convenience)
+ *
+ * Reads from tenant_kpi_current + tenant_kpi_daily. The worker
+ * (services/admin-awareness-worker.ts) writes those tables every 5 min.
+ */
+import { Router, Response } from 'express';
+import { requireTenantAdmin } from '../../middleware/require-tenant-admin';
+import { AuthenticatedRequest } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { computeAndStoreForTenant } from '../../services/admin-awareness-worker';
+
+const router = Router({ mergeParams: true });
+const VTID = 'BOOTSTRAP-ADMIN-KPI-AA';
+
+router.get('/', requireTenantAdmin, async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+
+  const tenantId = req.params.tenantId || (req as any).targetTenantId;
+  if (!tenantId) return res.status(400).json({ ok: false, error: 'TENANT_ID_REQUIRED' });
+
+  try {
+    const sevenDaysAgo = new Date(Date.now() - 7 * 86400_000).toISOString().slice(0, 10);
+
+    const [currentResp, historyResp] = await Promise.all([
+      supabase
+        .from('tenant_kpi_current')
+        .select('tenant_id, generated_at, kpi, computation_duration_ms, source_version')
+        .eq('tenant_id', tenantId)
+        .maybeSingle(),
+      supabase
+        .from('tenant_kpi_daily')
+        .select('snapshot_date, kpi, computed_at')
+        .eq('tenant_id', tenantId)
+        .gte('snapshot_date', sevenDaysAgo)
+        .order('snapshot_date', { ascending: false }),
+    ]);
+
+    if (currentResp.error) {
+      console.warn(`[${VTID}] current query failed:`, currentResp.error.message);
+      return res.status(500).json({ ok: false, error: currentResp.error.message });
+    }
+    if (historyResp.error) {
+      console.warn(`[${VTID}] history query failed:`, historyResp.error.message);
+    }
+
+    return res.json({
+      ok: true,
+      tenant_id: tenantId,
+      current: currentResp.data ?? null,
+      history: historyResp.data ?? [],
+      generated_at: new Date().toISOString(),
+    });
+  } catch (err: any) {
+    console.error(`[${VTID}] root GET error:`, err.message);
+    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
+  }
+});
+
+router.get('/current', requireTenantAdmin, async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+  const tenantId = req.params.tenantId || (req as any).targetTenantId;
+  if (!tenantId) return res.status(400).json({ ok: false, error: 'TENANT_ID_REQUIRED' });
+
+  const { data, error } = await supabase
+    .from('tenant_kpi_current')
+    .select('tenant_id, generated_at, kpi, computation_duration_ms, source_version')
+    .eq('tenant_id', tenantId)
+    .maybeSingle();
+  if (error) return res.status(500).json({ ok: false, error: error.message });
+  return res.json({ ok: true, current: data ?? null });
+});
+
+router.get('/history', requireTenantAdmin, async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+  const tenantId = req.params.tenantId || (req as any).targetTenantId;
+  if (!tenantId) return res.status(400).json({ ok: false, error: 'TENANT_ID_REQUIRED' });
+
+  const daysRaw = Number(req.query.days ?? 7);
+  const days = Number.isFinite(daysRaw) ? Math.max(1, Math.min(90, Math.floor(daysRaw))) : 7;
+  const from = new Date(Date.now() - days * 86400_000).toISOString().slice(0, 10);
+
+  const { data, error } = await supabase
+    .from('tenant_kpi_daily')
+    .select('snapshot_date, kpi, computed_at')
+    .eq('tenant_id', tenantId)
+    .gte('snapshot_date', from)
+    .order('snapshot_date', { ascending: false });
+  if (error) return res.status(500).json({ ok: false, error: error.message });
+  return res.json({ ok: true, days, history: data ?? [] });
+});
+
+router.post('/refresh', requireTenantAdmin, async (req: AuthenticatedRequest, res: Response) => {
+  const tenantId = req.params.tenantId || (req as any).targetTenantId;
+  if (!tenantId) return res.status(400).json({ ok: false, error: 'TENANT_ID_REQUIRED' });
+
+  try {
+    const start = Date.now();
+    await computeAndStoreForTenant(tenantId);
+    return res.json({ ok: true, tenant_id: tenantId, duration_ms: Date.now() - start });
+  } catch (err: any) {
+    console.error(`[${VTID}] refresh error:`, err.message);
+    return res.status(500).json({ ok: false, error: err.message || 'REFRESH_FAILED' });
+  }
+});
+
+export default router;

--- a/services/gateway/src/services/admin-awareness-worker.ts
+++ b/services/gateway/src/services/admin-awareness-worker.ts
@@ -1,0 +1,237 @@
+/**
+ * BOOTSTRAP-ADMIN-KPI-AA: Admin awareness worker.
+ *
+ * Computes ~20 KPIs per tenant every 5 minutes and writes them to:
+ *   - tenant_kpi_current (upsert; real-time)
+ *   - tenant_kpi_daily   (upsert on snapshot_date = today; historical)
+ *
+ * KPI families (Phase AA):
+ *   - users        (7 KPIs)
+ *   - community    (6 KPIs)
+ *   - autopilot    (5 KPIs)
+ *
+ * Follow-up phases add: knowledge, navigator, moderation, marketplace,
+ * assistant, system_health. The jsonb payload schema is extensible.
+ *
+ * The worker iterates every active tenant in public.tenants. Counts are
+ * compiled in parallel per tenant. Soft-fail on any per-KPI error — a bad
+ * query never kills the worker or the row; affected KPIs come back as null.
+ *
+ * Reuse: patterns mirror routes/admin-autopilot.ts:310+ and
+ * routes/tenant-admin/overview.ts — same tables, same Supabase client.
+ */
+import { getSupabase } from '../lib/supabase';
+
+const LOG_PREFIX = '[admin-kpi]';
+const WORKER_TICK_MS = 5 * 60 * 1000; // 5 minutes
+const WORKER_VERSION = 'phase-AA.2026-04-21';
+
+type KpiPayload = Record<string, unknown>;
+
+let workerHandle: ReturnType<typeof setInterval> | null = null;
+
+export function startAdminAwarenessWorker(): void {
+  if (workerHandle) {
+    console.log(`${LOG_PREFIX} worker already started`);
+    return;
+  }
+  console.log(`${LOG_PREFIX} starting; cadence=${WORKER_TICK_MS / 1000}s version=${WORKER_VERSION}`);
+
+  // First run slightly delayed so the gateway finishes booting first.
+  setTimeout(() => {
+    runTick().catch((err) => console.warn(`${LOG_PREFIX} first tick failed:`, err?.message));
+  }, 15_000);
+
+  workerHandle = setInterval(() => {
+    runTick().catch((err) => console.warn(`${LOG_PREFIX} tick failed:`, err?.message));
+  }, WORKER_TICK_MS);
+}
+
+export function stopAdminAwarenessWorker(): void {
+  if (workerHandle) {
+    clearInterval(workerHandle);
+    workerHandle = null;
+    console.log(`${LOG_PREFIX} worker stopped`);
+  }
+}
+
+/**
+ * Run one tick: list tenants, compute KPIs for each, upsert snapshots.
+ * Sequential per tenant (tenants count is small; parallelism gains are
+ * negligible vs DB connection pressure from 60+ sub-queries in flight).
+ */
+async function runTick(): Promise<void> {
+  const supabase = getSupabase();
+  if (!supabase) return;
+
+  const tenants = await listActiveTenants();
+  if (tenants.length === 0) return;
+
+  let ok = 0;
+  let failed = 0;
+  for (const tenantId of tenants) {
+    try {
+      await computeAndStoreForTenant(tenantId);
+      ok++;
+    } catch (err: any) {
+      failed++;
+      console.warn(`${LOG_PREFIX} tenant=${tenantId.substring(0, 8)}... failed: ${err?.message || err}`);
+    }
+  }
+  console.log(`${LOG_PREFIX} tick done ok=${ok} failed=${failed}`);
+}
+
+async function listActiveTenants(): Promise<string[]> {
+  const supabase = getSupabase();
+  if (!supabase) return [];
+  const { data, error } = await supabase.from('tenants').select('tenant_id, is_active');
+  if (error) {
+    console.warn(`${LOG_PREFIX} listActiveTenants failed: ${error.message}`);
+    return [];
+  }
+  return (data ?? [])
+    .filter((row: { is_active?: boolean | null }) => row.is_active !== false)
+    .map((row: { tenant_id: string }) => row.tenant_id);
+}
+
+export async function computeAndStoreForTenant(tenantId: string): Promise<void> {
+  const supabase = getSupabase();
+  if (!supabase) return;
+
+  const start = Date.now();
+  const kpi: KpiPayload = {};
+
+  // ---- Users family ----
+  try {
+    const now = new Date();
+    const d1 = new Date(now.getTime() - 1 * 86400_000).toISOString();
+    const d7 = new Date(now.getTime() - 7 * 86400_000).toISOString();
+    const d14 = new Date(now.getTime() - 14 * 86400_000).toISOString();
+    const d48h = new Date(now.getTime() + 2 * 86400_000).toISOString();
+
+    const [totalMembers, signups24h, signups7d, signupsPrior7d, invPending, invExpiring48h] = await Promise.all([
+      supabase.from('user_tenants').select('id', { count: 'exact', head: true }).eq('tenant_id', tenantId),
+      supabase.from('user_tenants').select('id', { count: 'exact', head: true }).eq('tenant_id', tenantId).gte('created_at', d1),
+      supabase.from('user_tenants').select('id', { count: 'exact', head: true }).eq('tenant_id', tenantId).gte('created_at', d7),
+      supabase.from('user_tenants').select('id', { count: 'exact', head: true }).eq('tenant_id', tenantId).gte('created_at', d14).lt('created_at', d7),
+      supabase.from('tenant_invitations').select('id', { count: 'exact', head: true }).eq('tenant_id', tenantId).is('accepted_at', null).is('revoked_at', null),
+      supabase.from('tenant_invitations').select('id', { count: 'exact', head: true }).eq('tenant_id', tenantId).is('accepted_at', null).is('revoked_at', null).lte('expires_at', d48h).gte('expires_at', now.toISOString()),
+    ]);
+
+    const s7 = signups7d.count ?? 0;
+    const sPrior = signupsPrior7d.count ?? 0;
+    const deltaPct = sPrior > 0 ? Math.round(((s7 - sPrior) / sPrior) * 100) : (s7 > 0 ? 100 : 0);
+
+    kpi.users = {
+      total_members: totalMembers.count ?? 0,
+      new_signups_24h: signups24h.count ?? 0,
+      new_signups_7d: s7,
+      new_signups_7d_prior: sPrior,
+      new_signups_7d_delta_pct: deltaPct,
+      invitations_pending: invPending.count ?? 0,
+      invitations_expiring_48h: invExpiring48h.count ?? 0,
+    };
+  } catch (err: any) {
+    console.warn(`${LOG_PREFIX} users family failed for ${tenantId.substring(0, 8)}...: ${err?.message}`);
+    kpi.users = { error: err?.message || 'unknown' };
+  }
+
+  // ---- Community family ----
+  try {
+    const now = new Date();
+    const nowIso = now.toISOString();
+    const in7d = new Date(now.getTime() + 7 * 86400_000).toISOString();
+    const in14d = new Date(now.getTime() + 14 * 86400_000).toISOString();
+    const d7 = new Date(now.getTime() - 7 * 86400_000).toISOString();
+
+    const [eventsThisWeek, eventsNextWeek, groupsTotal, liveRoomsActive, newMemberships7d] = await Promise.all([
+      supabase.from('global_community_events').select('id', { count: 'exact', head: true }).eq('tenant_id', tenantId).gte('start_time', nowIso).lt('start_time', in7d),
+      supabase.from('global_community_events').select('id', { count: 'exact', head: true }).eq('tenant_id', tenantId).gte('start_time', in7d).lt('start_time', in14d),
+      supabase.from('global_community_groups').select('id', { count: 'exact', head: true }).eq('tenant_id', tenantId),
+      supabase.from('live_rooms').select('id', { count: 'exact', head: true }).eq('tenant_id', tenantId).gte('ends_at', nowIso),
+      supabase.from('community_memberships').select('id', { count: 'exact', head: true }).eq('tenant_id', tenantId).gte('created_at', d7),
+    ]);
+
+    kpi.community = {
+      events_this_week: eventsThisWeek.count ?? 0,
+      events_next_week: eventsNextWeek.count ?? 0,
+      groups_total: groupsTotal.count ?? 0,
+      live_rooms_active: liveRoomsActive.count ?? 0,
+      new_memberships_7d: newMemberships7d.count ?? 0,
+    };
+  } catch (err: any) {
+    console.warn(`${LOG_PREFIX} community family failed for ${tenantId.substring(0, 8)}...: ${err?.message}`);
+    kpi.community = { error: err?.message || 'unknown' };
+  }
+
+  // ---- Autopilot family ----
+  try {
+    const now = new Date();
+    const d1 = new Date(now.getTime() - 86400_000).toISOString();
+    const d7 = new Date(now.getTime() - 7 * 86400_000).toISOString();
+
+    const [runs24h, runsCompleted7d, runsFailed7d, recsNew, recsActivated7d] = await Promise.all([
+      supabase.from('tenant_autopilot_runs').select('id', { count: 'exact', head: true }).eq('tenant_id', tenantId).gte('started_at', d1),
+      supabase.from('tenant_autopilot_runs').select('id', { count: 'exact', head: true }).eq('tenant_id', tenantId).gte('started_at', d7).eq('status', 'completed'),
+      supabase.from('tenant_autopilot_runs').select('id', { count: 'exact', head: true }).eq('tenant_id', tenantId).gte('started_at', d7).eq('status', 'failed'),
+      supabase.from('autopilot_recommendations').select('id', { count: 'exact', head: true }).eq('status', 'new'),
+      supabase.from('autopilot_recommendations').select('id', { count: 'exact', head: true }).eq('status', 'activated').gte('updated_at', d7),
+    ]);
+
+    const completed = runsCompleted7d.count ?? 0;
+    const failed = runsFailed7d.count ?? 0;
+    const total = completed + failed;
+    const successRate = total > 0 ? Math.round((completed / total) * 100) : null;
+
+    kpi.autopilot = {
+      runs_24h: runs24h.count ?? 0,
+      runs_completed_7d: completed,
+      runs_failed_7d: failed,
+      runs_success_rate_pct: successRate,
+      recommendations_new: recsNew.count ?? 0,
+      recommendations_activated_7d: recsActivated7d.count ?? 0,
+    };
+  } catch (err: any) {
+    console.warn(`${LOG_PREFIX} autopilot family failed for ${tenantId.substring(0, 8)}...: ${err?.message}`);
+    kpi.autopilot = { error: err?.message || 'unknown' };
+  }
+
+  const computationDurationMs = Date.now() - start;
+
+  // Upsert current snapshot
+  const { error: currentErr } = await supabase
+    .from('tenant_kpi_current')
+    .upsert(
+      {
+        tenant_id: tenantId,
+        generated_at: new Date().toISOString(),
+        kpi,
+        computation_duration_ms: computationDurationMs,
+        source_version: WORKER_VERSION,
+      },
+      { onConflict: 'tenant_id' },
+    );
+  if (currentErr) {
+    console.warn(`${LOG_PREFIX} upsert current failed ${tenantId.substring(0, 8)}...: ${currentErr.message}`);
+    return;
+  }
+
+  // Upsert today's daily snapshot
+  const todayDate = new Date().toISOString().slice(0, 10);
+  const { error: dailyErr } = await supabase
+    .from('tenant_kpi_daily')
+    .upsert(
+      {
+        tenant_id: tenantId,
+        snapshot_date: todayDate,
+        kpi,
+        computed_at: new Date().toISOString(),
+        computation_duration_ms: computationDurationMs,
+        source_version: WORKER_VERSION,
+      },
+      { onConflict: 'tenant_id,snapshot_date' },
+    );
+  if (dailyErr) {
+    console.warn(`${LOG_PREFIX} upsert daily failed ${tenantId.substring(0, 8)}...: ${dailyErr.message}`);
+  }
+}

--- a/supabase/migrations/20260421220000_BOOTSTRAP_admin_kpi_surface.sql
+++ b/supabase/migrations/20260421220000_BOOTSTRAP_admin_kpi_surface.sql
@@ -1,0 +1,93 @@
+-- BOOTSTRAP-ADMIN-KPI-AA: Unified KPI surface for the admin companion.
+--
+-- First layer (L1) of the 5-layer admin companion architecture documented
+-- in /home/dstev/.claude/plans/atomic-riding-badger.md Part B. Every scanner,
+-- insight, voice tool, and autopilot action above it reads from these tables.
+--
+-- Design:
+--   - tenant_kpi_current: real-time snapshot (one row per tenant, upserted)
+--   - tenant_kpi_daily: 90-day history (one row per tenant × date)
+--   - Both store KPIs as JSONB so the schema can grow (3 families in Phase AA,
+--     9 total in Phase BB) without requiring new migrations per family.
+--
+-- KPI families captured in Phase AA (≈ 20 KPIs): users, community, autopilot.
+-- Follow-up phases extend the jsonb payload — readers treat missing fields
+-- as null.
+--
+-- Retention: tenant_kpi_daily keeps 90 days (pg_cron job below). Current
+-- is always the latest — upsert replaces.
+
+\set ON_ERROR_STOP on
+
+CREATE TABLE IF NOT EXISTS public.tenant_kpi_current (
+  tenant_id UUID PRIMARY KEY,
+  generated_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  kpi JSONB NOT NULL DEFAULT '{}'::jsonb,
+  computation_duration_ms INTEGER,
+  source_version TEXT
+);
+
+COMMENT ON TABLE public.tenant_kpi_current IS
+  'BOOTSTRAP-ADMIN-KPI-AA: real-time KPI snapshot per tenant (refreshed every 5 min by admin-awareness-worker).';
+
+CREATE TABLE IF NOT EXISTS public.tenant_kpi_daily (
+  tenant_id UUID NOT NULL,
+  snapshot_date DATE NOT NULL,
+  kpi JSONB NOT NULL DEFAULT '{}'::jsonb,
+  computed_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  computation_duration_ms INTEGER,
+  source_version TEXT,
+  PRIMARY KEY (tenant_id, snapshot_date)
+);
+
+COMMENT ON TABLE public.tenant_kpi_daily IS
+  'BOOTSTRAP-ADMIN-KPI-AA: historical daily KPI snapshots per tenant (90-day retention).';
+
+CREATE INDEX IF NOT EXISTS tenant_kpi_daily_tenant_date_desc_idx
+  ON public.tenant_kpi_daily (tenant_id, snapshot_date DESC);
+
+-- RLS: tenant admins can read their own tenant's KPIs. Service role writes.
+ALTER TABLE public.tenant_kpi_current ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.tenant_kpi_daily   ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS tenant_kpi_current_self_read ON public.tenant_kpi_current;
+CREATE POLICY tenant_kpi_current_self_read ON public.tenant_kpi_current
+  FOR SELECT TO authenticated
+  USING (
+    tenant_id IN (
+      SELECT ut.tenant_id FROM public.user_tenants ut
+      WHERE ut.user_id = auth.uid() AND ut.active_role IN ('admin', 'developer', 'infra')
+    )
+  );
+
+DROP POLICY IF EXISTS tenant_kpi_daily_self_read ON public.tenant_kpi_daily;
+CREATE POLICY tenant_kpi_daily_self_read ON public.tenant_kpi_daily
+  FOR SELECT TO authenticated
+  USING (
+    tenant_id IN (
+      SELECT ut.tenant_id FROM public.user_tenants ut
+      WHERE ut.user_id = auth.uid() AND ut.active_role IN ('admin', 'developer', 'infra')
+    )
+  );
+
+DROP POLICY IF EXISTS tenant_kpi_current_service ON public.tenant_kpi_current;
+CREATE POLICY tenant_kpi_current_service ON public.tenant_kpi_current
+  FOR ALL TO service_role USING (TRUE) WITH CHECK (TRUE);
+
+DROP POLICY IF EXISTS tenant_kpi_daily_service ON public.tenant_kpi_daily;
+CREATE POLICY tenant_kpi_daily_service ON public.tenant_kpi_daily
+  FOR ALL TO service_role USING (TRUE) WITH CHECK (TRUE);
+
+-- 90-day retention (best-effort; silently skips if pg_cron missing)
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+    PERFORM cron.schedule(
+      'tenant-kpi-daily-retention',
+      '17 3 * * *',
+      $$DELETE FROM public.tenant_kpi_daily WHERE snapshot_date < (NOW() - INTERVAL '90 days')::date;$$
+    );
+  END IF;
+EXCEPTION WHEN OTHERS THEN
+  RAISE NOTICE 'pg_cron scheduling skipped: %', SQLERRM;
+END$$;


### PR DESCRIPTION
Phase AA of the Admin Companion plan. Ships the L1 foundation layer: two tables (tenant_kpi_current + tenant_kpi_daily), a 5-min background worker computing ~18 KPIs across users/community/autopilot families per tenant, and a GET /api/v1/admin/tenants/:tenantId/kpis endpoint family with current + history + refresh. Zero orb changes. Migration applies manually via RUN-MIGRATION workflow. Every future admin-companion phase (scanners, insights, voice tools, autopilot) reads from these tables.