### PR TITLE
feat(og): rich profile share preview via gateway + cloudflare worker

### DIFF
--- a/cloudflare/vitanaland-og-proxy/worker.js
+++ b/cloudflare/vitanaland-og-proxy/worker.js
@@ -40,6 +40,83 @@ function formatPrice(cents, currency) {
 }
 
 /**
+ * Build an HTML page with OG meta tags for a profile. Served to crawlers only.
+ * Queries the gateway's public profile endpoint — no auth required.
+ */
+async function renderProfileOg(id, canonicalUrl, destinationUrl) {
+  const DEFAULT_IMAGE =
+    'https://inmkhvwdcuyhnxkgfvsb.supabase.co/storage/v1/object/public/default-images/vitana-og-default.jpg';
+
+  const resp = await fetch(
+    `${GATEWAY_URL}/api/v1/public/profile/${encodeURIComponent(id)}`,
+  );
+  if (!resp.ok) {
+    return new Response('Profile not found', { status: 404 });
+  }
+  const body = await resp.json();
+  const p = body && body.profile;
+  if (!p) return new Response('Profile not found', { status: 404 });
+
+  const composedName =
+    [p.first_name, p.last_name].filter(Boolean).join(' ').trim() ||
+    p.display_name ||
+    (p.handle ? `@${p.handle}` : 'MAXINA member');
+  const handlePart = p.handle ? `@${p.handle}` : '';
+  const archetype = p.longevity_archetype || p.bio || 'Longevity community member';
+  const title = `${composedName}${handlePart ? ` (${handlePart})` : ''} · MAXINA`;
+  const description = `${handlePart ? handlePart + ' · ' : ''}${archetype}. Tap to view on MAXINA.`
+    .replace(/\s+/g, ' ')
+    .trim()
+    .slice(0, 200);
+  // cover_url is landscape-friendly; avatar_url is square but auto-fits on
+  // WhatsApp / Telegram. Default to MAXINA hero when both are empty.
+  const image = p.cover_url || p.avatar_url || DEFAULT_IMAGE;
+  const isCover = !!p.cover_url;
+
+  const html = `<!DOCTYPE html>
+<html lang="en">
+<head>
+  <meta charset="utf-8">
+  <title>${escapeHtml(title)}</title>
+  <meta name="description" content="${escapeHtml(description)}">
+  <link rel="canonical" href="${escapeHtml(canonicalUrl)}">
+
+  <meta property="og:type" content="profile">
+  <meta property="og:site_name" content="MAXINA">
+  <meta property="og:title" content="${escapeHtml(title)}">
+  <meta property="og:description" content="${escapeHtml(description)}">
+  <meta property="og:url" content="${escapeHtml(canonicalUrl)}">
+  <meta property="og:image" content="${escapeHtml(image)}">
+  <meta property="og:image:alt" content="${escapeHtml(composedName)}">
+  <meta property="og:image:width" content="${isCover ? 1200 : 512}">
+  <meta property="og:image:height" content="${isCover ? 630 : 512}">
+  ${p.handle ? `<meta property="profile:username" content="${escapeHtml(p.handle)}">` : ''}
+  ${p.first_name ? `<meta property="profile:first_name" content="${escapeHtml(p.first_name)}">` : ''}
+  ${p.last_name ? `<meta property="profile:last_name" content="${escapeHtml(p.last_name)}">` : ''}
+
+  <meta name="twitter:card" content="summary_large_image">
+  <meta name="twitter:title" content="${escapeHtml(title)}">
+  <meta name="twitter:description" content="${escapeHtml(description)}">
+  <meta name="twitter:image" content="${escapeHtml(image)}">
+
+  <meta http-equiv="refresh" content="0;url=${escapeHtml(destinationUrl)}">
+</head>
+<body>
+  <h1>${escapeHtml(title)}</h1>
+  <p>${escapeHtml(description)}</p>
+  <p><a href="${escapeHtml(destinationUrl)}">Open on MAXINA</a></p>
+</body>
+</html>`;
+
+  return new Response(html, {
+    headers: {
+      'Content-Type': 'text/html; charset=utf-8',
+      'Cache-Control': 'public, max-age=300, s-maxage=300',
+    },
+  });
+}
+
+/**
  * Build an HTML page with OG meta tags for a product. Served to crawlers only.
  * Queries the gateway's public product endpoint — no auth required.
  */
@@ -156,6 +233,15 @@ export default {
       if (route.type === 'products') {
         const canonical = getRedirectUrl('products', route.identifier);
         return renderProductOg(route.identifier, canonical);
+      }
+
+      // Profiles: same pattern. Gateway has the profile row; we render the
+      // OG HTML here so WhatsApp/Telegram see rich meta. The og-profile
+      // Supabase function was never implemented — this supersedes that path.
+      if (route.type === 'profiles') {
+        const canonical = `https://e.vitanaland.com/profiles/${encodeURIComponent(route.identifier)}`;
+        const destination = getRedirectUrl('profiles', route.identifier);
+        return renderProfileOg(route.identifier, canonical, destination);
       }
 
       const ogUrl = getOgFunctionUrl(route.type, route.identifier);

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -126,6 +126,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const clickRedirectRouter = require('./routes/click-redirect').default;
   // VTID-02000: Discover search (query-driven, used by UI search bar + assistant tool)
   const discoverSearchRouter = require('./routes/discover-search').default;
+  // Public, auth-less profile lookup for OG/share previews (Cloudflare worker).
+  const publicProfileOgRouter = require('./routes/public-profile-og').default;
   // VTID-02000: Discover feed (lifecycle-aware default browse)
   const discoverFeedRouter = require('./routes/discover-feed').default;
   // VTID-02000: Maxina admin marketplace routes
@@ -637,6 +639,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   // VTID-02000: Discover search + feed (unified marketplace query surface)
   mountRouterSync(app, '/api/v1/discover', discoverSearchRouter, { owner: 'discover-search' });
   mountRouterSync(app, '/api/v1/discover', discoverFeedRouter, { owner: 'discover-feed' });
+  // Public, auth-less profile lookup for crawler OG previews
+  mountRouterSync(app, '/api/v1/public', publicProfileOgRouter, { owner: 'public-profile-og' });
   // VTID-02000: Maxina admin marketplace
   mountRouterSync(app, '/api/v1/admin/marketplace', adminMarketplaceRouter, { owner: 'admin-marketplace' });
   mountRouterSync(app, '/api/v1/internal/marketplace', internalMarketplaceSyncRouter, { owner: 'marketplace-sync' });

--- a/services/gateway/src/routes/public-profile-og.ts
+++ b/services/gateway/src/routes/public-profile-og.ts
@@ -1,0 +1,65 @@
+/**
+ * Public, auth-less profile lookup used to populate rich share previews
+ * (Open Graph / Twitter cards) on WhatsApp, Telegram, LinkedIn, etc.
+ *
+ * Consumed by the Cloudflare Worker at `e.vitanaland.com`
+ * (`cloudflare/vitanaland-og-proxy/worker.js` → `renderProfileOg`). The worker
+ * detects crawler User-Agents, hits this endpoint, and assembles the OG
+ * meta HTML inline — mirroring the product OG flow.
+ *
+ * Returns only display / identity fields that are already public on
+ * `/u/:handle`. No emails, no DOB, no contact info.
+ */
+import { Router, Request, Response } from 'express';
+import { getSupabase } from '../lib/supabase';
+
+const router = Router();
+
+const UUID_RE = /^[0-9a-fA-F]{8}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{4}-[0-9a-fA-F]{12}$/;
+const HANDLE_RE = /^[a-z0-9_]{1,64}$/;
+
+router.get('/profile/:id', async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    res.status(500).json({ ok: false, error: 'Supabase unavailable' });
+    return;
+  }
+
+  const raw = String(req.params.id ?? '').trim();
+  if (!raw) {
+    res.status(400).json({ ok: false, error: 'missing id' });
+    return;
+  }
+
+  const isUuid = UUID_RE.test(raw);
+  const isHandle = !isUuid && HANDLE_RE.test(raw.toLowerCase());
+  if (!isUuid && !isHandle) {
+    res.status(400).json({ ok: false, error: 'invalid id' });
+    return;
+  }
+
+  const query = supabase
+    .from('profiles')
+    .select(
+      'id, handle, display_name, first_name, last_name, longevity_archetype, bio, avatar_url, cover_url',
+    );
+
+  const { data, error } = await (isUuid
+    ? query.eq('id', raw).maybeSingle()
+    : query.eq('handle', raw.toLowerCase()).maybeSingle());
+
+  if (error) {
+    res.status(500).json({ ok: false, error: error.message });
+    return;
+  }
+  if (!data) {
+    res.status(404).json({ ok: false, error: 'profile not found' });
+    return;
+  }
+
+  // Cache-friendly: profile card contents change rarely.
+  res.setHeader('Cache-Control', 'public, max-age=300, s-maxage=300');
+  res.json({ ok: true, profile: data });
+});
+
+export default router;


### PR DESCRIPTION
## Problem

Sharing a profile into WhatsApp today shows:
- Generic title "VITANA - Community"
- Generic description
- **No image**

The Cloudflare Worker at `e.vitanaland.com` already routes `/profiles/:id` crawler hits to a Supabase Edge Function called `og-profile` ([`worker.js:112`](https://github.com/exafyltd/vitana-platform/blob/main/cloudflare/vitanaland-og-proxy/worker.js#L112)) — but that function was **never implemented**. Fetch fails, WhatsApp falls back to the SPA's static index.html meta.

## Fix

Mirror the **product** OG flow exactly (`renderProductOg` already works the same way). No Supabase Edge Function needed — no new tokens / secrets.

### `services/gateway`
- **new** `routes/public-profile-og.ts` — `GET /profile/:id` (accepts UUID or handle). Uses the service-role supabase client, returns only public fields: `handle, display_name, first/last_name, longevity_archetype, bio, avatar_url, cover_url`. No email / DOB / contact info. 5-minute cache.
- Mount at `/api/v1/public` in `src/index.ts`.

### `cloudflare/vitanaland-og-proxy/worker.js`
- Add `renderProfileOg(id, canonicalUrl, destinationUrl)`:
  - `og:type=profile`, `og:site_name=MAXINA`
  - Title: "First Last (@handle) · MAXINA"
  - Description: "@handle · archetype. Tap to view on MAXINA."
  - `og:image` = `cover_url` → `avatar_url` → default MAXINA hero. Avatars bucket is already publicly readable.
  - `profile:username / first_name / last_name` when set.
- In the `fetch` handler, short-circuit `route.type === 'profiles'` to call the new renderer inline (same structural move as the existing `products` branch).

### `vitana-v1`
No changes. `useProfileShare.getShareUrl()` already emits `https://e.vitanaland.com/profiles/:id`.

## Deploy flow (no new secrets)
1. **Gateway** — `AUTO-DEPLOY` sees `services/gateway/**` changed + the `BOOTSTRAP-ACCOUNT-PILL` token in the commit message → dispatches `EXEC-DEPLOY` → Cloud Run `gateway` rolls out.
2. **Worker** — `DEPLOY-CLOUDFLARE-WORKERS` sees `cloudflare/**` changed → `wrangler deploy` ships the worker using existing `CLOUDFLARE_API_TOKEN` + `CLOUDFLARE_ACCOUNT_ID`.

Supersedes #795 (Supabase Edge Function approach — closed since it required a new `SUPABASE_ACCESS_TOKEN` secret).

BOOTSTRAP-ACCOUNT-PILL

## Test plan

After both workflows complete:

- [ ] `curl -s https://gateway-q74ibpv6ia-uc.a.run.app/api/v1/public/profile/<uuid>` returns `{ ok: true, profile: { ... } }` (JSON, not HTML 404).
- [ ] `curl -A "WhatsApp/2.0" -L "https://e.vitanaland.com/profiles/<uuid>" -o -` returns HTML containing `<meta property="og:title" content="... · MAXINA">` and `<meta property="og:image" content="...">`.
- [ ] On phone: share a profile into WhatsApp → preview shows display name, @handle, archetype, and the avatar/cover image.
- [ ] Paste the URL into https://developers.facebook.com/tools/debug/ — all four og: tags populated.

## Rollback
Single `git revert` on the merge commit. Cloud Run and the worker both re-deploy to previous state on next push.

https://claude.ai/code/session_018xRvjcLocE5c52Rusqjinq