### PR TITLE
fix(og): lookup profile by user_id (not just id) in public OG route

### DIFF
--- a/services/gateway/src/routes/public-profile-og.ts
+++ b/services/gateway/src/routes/public-profile-og.ts
@@ -38,14 +38,16 @@ router.get('/profile/:id', async (req: Request, res: Response) => {
     return;
   }
 
+  // Accept either a UUID (matches profiles.user_id which is what useProfileShare
+  // puts in the URL, with profiles.id as a secondary match) or a handle.
   const query = supabase
     .from('profiles')
     .select(
-      'id, handle, display_name, first_name, last_name, longevity_archetype, bio, avatar_url, cover_url',
+      'id, user_id, handle, display_name, first_name, last_name, longevity_archetype, bio, avatar_url, cover_url',
     );
 
   const { data, error } = await (isUuid
-    ? query.eq('id', raw).maybeSingle()
+    ? query.or(`user_id.eq.${raw},id.eq.${raw}`).maybeSingle()
     : query.eq('handle', raw.toLowerCase()).maybeSingle());
 
   if (error) {


### PR DESCRIPTION
## Problem

PR #797 wired up `/api/v1/public/profile/:id` and the Cloudflare worker, but Facebook's sharing debugger still shows **Response Code: 404** for `https://e.vitanaland.com/profiles/c7d3260d-8311-4a0b-ab1c-53928a37caec`.

Root cause: the frontend's `useProfileShare.getShareUrl()` builds `/profiles/${profile.id}`, and in this app `profile.id` is actually the **user_id** (not `profiles.id`, the primary key). My first pass in #797 queried `.eq('id', raw)` and got no match → 404 → worker returned 404 to the crawler → WhatsApp rendered the generic site card.

## Fix

Switch the UUID lookup to match either `profiles.user_id` **or** `profiles.id`:

```ts
query.or(`user_id.eq.${raw},id.eq.${raw}`).maybeSingle()
```

Handle lookup is unchanged. Nothing else touched.

BOOTSTRAP-ACCOUNT-PILL

## Test plan
- [ ] Merge → AUTO-DEPLOY → EXEC-DEPLOY lands the gateway.
- [ ] Re-run Facebook debugger on the same URL → **Scrape Again** → expect `og:title`, `og:description`, `og:image` populated (Response Code 200, not 404).
- [ ] Share to a fresh WhatsApp chat → rich card with display name, @handle, archetype, avatar.

https://claude.ai/code/session_018xRvjcLocE5c52Rusqjinq