### PR TITLE
feat(proactive-guide): Phase H.2 — awareness-driven Priority of the Day (VTID-01947)

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -237,6 +237,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const vaeaRouter = require('./routes/vaea').default;
   // VTID-01180: Autopilot Recommendations API v1 (correct implementation)
   const autopilotRecommendationsRouter = require('./routes/autopilot-recommendations').default;
+  // VTID-01947: Companion Phase H — Proactive Presence routes
+  const presenceRouter = require('./routes/presence').default;
   // Dev Autopilot — self-improving loop (plan: .claude/plans/quirky-jumping-fairy.md)
   const devAutopilotRouter = require('./routes/dev-autopilot').default;
   // Autonomy Pulse — unified supervisor feed across self-healing + dev-autopilot
@@ -474,6 +476,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   mountRouterSync(app, '/api/v1/governance', governanceRouter, { owner: 'governance' });
   // VTID-01181: Governance Controls v1 - System Arming Panel (arm/disarm without redeploy)
   mountRouterSync(app, '/api/v1/governance/controls', governanceControlsRouter, { owner: 'governance-controls' });
+  // VTID-01947: Companion Phase H — Proactive Presence
+  mountRouterSync(app, '/api/v1/presence', presenceRouter, { owner: 'presence' });
   mountRouterSync(app, '/api/v1/vtid', vtidRouter, { owner: 'vtid' });
 
   // VTID-0516: Autonomous Safe-Merge Layer - CICD routes

--- a/services/gateway/src/routes/presence.ts
+++ b/services/gateway/src/routes/presence.ts
@@ -1,0 +1,132 @@
+/**
+ * Companion Phase H — Proactive Presence routes (VTID-01947)
+ *
+ * Mounted at /api/v1/presence. Surfaces awareness-driven content for
+ * non-voice UI moments: Priority of the Day, Welcome-Back Banner,
+ * Self-Awareness preview.
+ *
+ * Every endpoint here consults the pacer before returning content so
+ * dismissal-pauses and per-user cadence caps apply uniformly.
+ */
+
+import { Router, Request, Response } from 'express';
+import { createUserSupabaseClient } from '../lib/supabase-user';
+import {
+  getAwarenessContext,
+  canSurfaceProactively,
+  recordTouch,
+} from '../services/guide';
+import { resolvePriorityMessage } from '../services/guide/priority-rules';
+
+const router = Router();
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+async function resolveIdentity(req: Request): Promise<{
+  user_id: string | null;
+  tenant_id: string | null;
+  user_name: string | null;
+  error?: string;
+}> {
+  const auth = req.headers.authorization;
+  if (!auth || !auth.startsWith('Bearer ')) {
+    return { user_id: null, tenant_id: null, user_name: null, error: 'no_token' };
+  }
+  const token = auth.slice(7);
+  try {
+    const supabase = createUserSupabaseClient(token);
+    const { data, error } = await supabase.rpc('me_context');
+    if (error || !data) {
+      return { user_id: null, tenant_id: null, user_name: null, error: error?.message || 'no_context' };
+    }
+    return {
+      user_id: data.user_id || data.id || null,
+      tenant_id: data.tenant_id || null,
+      user_name: data.display_name || null,
+    };
+  } catch (err: any) {
+    return { user_id: null, tenant_id: null, user_name: null, error: err.message };
+  }
+}
+
+// =============================================================================
+// GET /priority — awareness-driven Priority of the Day
+// =============================================================================
+
+router.get('/priority', async (req: Request, res: Response) => {
+  const identity = await resolveIdentity(req);
+  if (!identity.user_id || !identity.tenant_id) {
+    return res.status(401).json({ ok: false, error: identity.error || 'unauthorized' });
+  }
+
+  // Pacer check — respects user_proactive_pause, per-surface caps, dismissals.
+  // bypass_daily_cap=true here because the priority card is ALWAYS visible
+  // on Home; it's not a "proactive touch" that consumes a daily slot. But
+  // we still respect active pauses (which suppress all proactivity).
+  const decision = await canSurfaceProactively(identity.user_id, 'priority_card', {
+    bypass_daily_cap: true,
+  });
+  if (!decision.allow && decision.reason === 'paused') {
+    return res.json({
+      ok: true,
+      suppressed: true,
+      reason: 'paused',
+      pause: decision.pause,
+    });
+  }
+
+  try {
+    const awareness = await getAwarenessContext(identity.user_id, identity.tenant_id);
+    const priority = resolvePriorityMessage({
+      awareness,
+      now: new Date(),
+      user_name: identity.user_name,
+    });
+
+    // Fire-and-forget telemetry touch (doesn't count toward daily cap because
+    // we bypassed it — but log for dashboard visibility).
+    recordTouch({
+      user_id: identity.user_id,
+      surface: 'priority_card',
+      reason_tag: priority.reason_tag,
+      metadata: { variant: priority.variant },
+    }).catch(() => {});
+
+    return res.json({
+      ok: true,
+      suppressed: false,
+      message: priority.message,
+      cta_url: priority.cta_url,
+      reason_tag: priority.reason_tag,
+      variant: priority.variant,
+    });
+  } catch (err: any) {
+    console.error('[presence/priority] error:', err?.message);
+    return res.status(500).json({ ok: false, error: err?.message || 'INTERNAL_ERROR' });
+  }
+});
+
+// =============================================================================
+// POST /priority/ack — user tapped the CTA (or dismissed)
+// =============================================================================
+
+router.post('/priority/ack', async (req: Request, res: Response) => {
+  const identity = await resolveIdentity(req);
+  if (!identity.user_id) {
+    return res.status(401).json({ ok: false, error: identity.error || 'unauthorized' });
+  }
+  const action = (req.body?.action === 'dismissed' ? 'dismissed' : 'acknowledged') as
+    | 'acknowledged'
+    | 'dismissed';
+  const { acknowledgeTouch } = await import('../services/guide');
+  await acknowledgeTouch({
+    user_id: identity.user_id,
+    surface: 'priority_card',
+    action,
+  });
+  return res.json({ ok: true });
+});
+
+export default router;

--- a/services/gateway/src/services/guide/priority-rules.ts
+++ b/services/gateway/src/services/guide/priority-rules.ts
@@ -1,0 +1,133 @@
+/**
+ * Companion Phase H.2 — Priority of the Day rule engine (VTID-01947)
+ *
+ * Pure function: given awareness state, returns the most relevant priority
+ * for today — the copy the Home banner shows. Rules are ordered; first
+ * match wins. Falls back to a generic time-of-day message when no
+ * awareness-driven rule matches.
+ *
+ * Consumed by /api/v1/presence/priority endpoint and (future) the
+ * WelcomeBackBanner.
+ */
+
+import type { UserAwareness } from './types';
+
+export interface PriorityMessage {
+  message: string;
+  cta_url: string | null;
+  reason_tag: string;
+  variant: 'urgent' | 'warm' | 'engage' | 'inform';
+}
+
+export interface PriorityRulesInput {
+  awareness: UserAwareness;
+  now?: Date;
+  user_name?: string | null;
+}
+
+/**
+ * Resolve the single most relevant priority for today. Rules ordered by
+ * importance: cooling/absent re-engagement first, then weakness signals,
+ * then journey nudges, then goal-aware prompts, then generic fallback.
+ */
+export function resolvePriorityMessage(input: PriorityRulesInput): PriorityMessage {
+  const { awareness, user_name } = input;
+  const firstName = (user_name || '').split(' ')[0] || '';
+
+  // Rule 1 — absence re-engagement (highest priority)
+  const motiv = awareness.last_interaction?.motivation_signal;
+  if (motiv === 'absent' || motiv === 'cooling') {
+    const days = awareness.last_interaction?.days_since_last ?? 0;
+    const streak = awareness.community_signals?.diary_streak_days ?? 0;
+    if (streak > 0) {
+      return {
+        message: `${firstName ? firstName + ', ' : ''}welcome back. Your diary streak paused at ${streak} days — want to pick it up?`,
+        cta_url: '/memory?tab=diary',
+        reason_tag: `absence:${days}d+streak`,
+        variant: 'warm',
+      };
+    }
+    return {
+      message: `${firstName ? firstName + ', ' : ''}it's been ${days} day${days === 1 ? '' : 's'} — glad you're back.`,
+      cta_url: null,
+      reason_tag: `absence:${days}d`,
+      variant: 'warm',
+    };
+  }
+
+  // Rule 2 — overdue calendar items take precedence over weakness
+  const overdue = awareness.recent_activity?.overdue_calendar_count ?? 0;
+  if (overdue > 0) {
+    return {
+      message: `${overdue} journey activit${overdue === 1 ? 'y is' : 'ies are'} waiting from earlier. Want to tackle ${overdue === 1 ? 'it' : 'one'} now?`,
+      cta_url: '/autopilot',
+      reason_tag: `overdue:${overdue}`,
+      variant: 'urgent',
+    };
+  }
+
+  // Rule 3 — goal-aware prompts
+  const goal = awareness.goal;
+  if (goal?.category === 'prosperity' || /financial|business|income|freedom/i.test(goal?.primary_goal || '')) {
+    const activated = awareness.recent_activity?.activated_recs_last_7d ?? 0;
+    if (activated === 0) {
+      return {
+        message: 'Your goal points at building freedom. One Business Hub check-in could move it today.',
+        cta_url: '/business',
+        reason_tag: 'goal:prosperity:idle',
+        variant: 'engage',
+      };
+    }
+  }
+
+  // Rule 4 — Day-0/Day-1 welcome — explain next step
+  if (awareness.tenure?.stage === 'day0' || awareness.tenure?.stage === 'day1') {
+    const wave = awareness.journey?.current_wave;
+    if (wave) {
+      return {
+        message: `You're in "${wave.name}" — ${wave.description}. Want a 2-minute walkthrough?`,
+        cta_url: '/autopilot',
+        reason_tag: `tenure:${awareness.tenure.stage}:wave:${wave.id}`,
+        variant: 'engage',
+      };
+    }
+    return {
+      message: 'Welcome to your longevity journey. Let me show you what we can do together.',
+      cta_url: '/autopilot',
+      reason_tag: `tenure:${awareness.tenure.stage}:no_wave`,
+      variant: 'engage',
+    };
+  }
+
+  // Rule 5 — pending autopilot recs
+  const openRecs = awareness.recent_activity?.open_autopilot_recs ?? 0;
+  if (openRecs > 0) {
+    return {
+      message: `${openRecs} Autopilot action${openRecs === 1 ? '' : 's'} ready for you. Worth a look?`,
+      cta_url: '/autopilot',
+      reason_tag: `open_recs:${openRecs}`,
+      variant: 'inform',
+    };
+  }
+
+  // Rule 6 — mid-journey engagement
+  const wave = awareness.journey?.current_wave;
+  if (wave && awareness.journey?.day_in_journey != null) {
+    return {
+      message: `Day ${awareness.journey.day_in_journey} of your journey, in ${wave.name}. Keep going.`,
+      cta_url: '/autopilot',
+      reason_tag: `journey:${wave.id}:day${awareness.journey.day_in_journey}`,
+      variant: 'inform',
+    };
+  }
+
+  // Rule 7 — generic fallback (time-of-day) — matches legacy banner behavior
+  const hour = (input.now ?? new Date()).getHours();
+  const tod = hour < 12 ? 'morning' : hour < 18 ? 'afternoon' : 'evening';
+  return {
+    message: `Good ${tod}${firstName ? ', ' + firstName : ''}. Ready when you are.`,
+    cta_url: null,
+    reason_tag: 'fallback:time_of_day',
+    variant: 'inform',
+  };
+}


### PR DESCRIPTION
Home Priority of the Day banner now reads from UserAwareness instead of static time+role. 7 rules, first match wins (absence re-engagement → overdue → goal → early-tenure → open recs → journey → fallback). Pacer-gated. New /api/v1/presence/priority + /ack endpoints. Pure rules function testable in isolation. Frontend integration follows in vitana-v1.