### PR TITLE
feat(admin): insights table + system_health scanner (Phases BB#1 + CC)

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -289,6 +289,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const tenantOverviewRouter = require('./routes/tenant-admin/overview').default;
   // BOOTSTRAP-ADMIN-KPI-AA: Admin KPI surface (real-time snapshot + history)
   const tenantKpisRouter = require('./routes/tenant-admin/kpis').default;
+  // BOOTSTRAP-ADMIN-BB-CC: Admin insights (scanner outputs + approve/reject)
+  const tenantInsightsRouter = require('./routes/tenant-admin/insights').default;
   // Settings — tenant profile, branding, feature flags, integrations
   const tenantSettingsRouter = require('./routes/tenant-admin/settings').default;
   // Audit & Compliance — admin action audit log, access log
@@ -754,6 +756,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   mountRouterSync(app, '/api/v1/admin/tenants/:tenantId/overview', tenantOverviewRouter, { owner: 'tenant-overview' });
   // BOOTSTRAP-ADMIN-KPI-AA: Admin KPI surface
   mountRouterSync(app, '/api/v1/admin/tenants/:tenantId/kpis', tenantKpisRouter, { owner: 'tenant-kpis' });
+  // BOOTSTRAP-ADMIN-BB-CC: Admin insights
+  mountRouterSync(app, '/api/v1/admin/tenants/:tenantId/insights', tenantInsightsRouter, { owner: 'tenant-insights' });
   // Settings — tenant profile, branding, feature flags
   mountRouterSync(app, '/api/v1/admin/tenants/:tenantId/settings', tenantSettingsRouter, { owner: 'tenant-settings' });
   // Audit & Compliance — admin action audit log

--- a/services/gateway/src/routes/tenant-admin/insights.ts
+++ b/services/gateway/src/routes/tenant-admin/insights.ts
@@ -1,0 +1,212 @@
+/**
+ * BOOTSTRAP-ADMIN-BB-CC: Admin insights endpoints.
+ *
+ * Mounted at /api/v1/admin/tenants/:tenantId/insights
+ *
+ *   GET    /                     — list open + pending (default) insights
+ *                                   ?status=open|pending_approval|...|all (default open+pending)
+ *                                   ?domain=system_health|...  (filter)
+ *                                   ?severity=urgent|action_needed|warning|info
+ *                                   ?scanner=system_health
+ *                                   ?limit=50 (default 50, max 200)
+ *   GET    /:id                  — single insight (full context)
+ *   POST   /:id/approve          — approve (status → approved)
+ *   POST   /:id/reject           — reject (status → rejected)
+ *   POST   /:id/snooze           — snooze (status → snoozed, optional ?hours=N)
+ *   POST   /:id/dismiss          — dismiss (status → dismissed)
+ *
+ * The approve/reject/snooze/dismiss pattern mirrors routes/self-healing.ts
+ * (approve/reject) so the autopilot executor (Phase FF) will pick up
+ * status='approved' rows and dispatch them through the existing autopilot
+ * event loop.
+ */
+import { Router, Response } from 'express';
+import { requireTenantAdmin } from '../../middleware/require-tenant-admin';
+import { AuthenticatedRequest } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { emitOasisEvent } from '../../services/oasis-event-service';
+
+const router = Router({ mergeParams: true });
+const VTID = 'BOOTSTRAP-ADMIN-BB-CC';
+
+const SEVERITY_ORDER = ['urgent', 'action_needed', 'warning', 'info'] as const;
+
+function getTenantId(req: AuthenticatedRequest): string | null {
+  return req.params.tenantId || ((req as any).targetTenantId as string | undefined) || null;
+}
+
+function getActorId(req: AuthenticatedRequest): string | null {
+  return (req.identity?.user_id as string | undefined) ?? null;
+}
+
+router.get('/', requireTenantAdmin, async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+  const tenantId = getTenantId(req);
+  if (!tenantId) return res.status(400).json({ ok: false, error: 'TENANT_ID_REQUIRED' });
+
+  const statusParam = typeof req.query.status === 'string' ? req.query.status : '';
+  const domain = typeof req.query.domain === 'string' ? req.query.domain : null;
+  const severity = typeof req.query.severity === 'string' ? req.query.severity : null;
+  const scanner = typeof req.query.scanner === 'string' ? req.query.scanner : null;
+  const limitRaw = Number(req.query.limit ?? 50);
+  const limit = Number.isFinite(limitRaw) ? Math.max(1, Math.min(200, Math.floor(limitRaw))) : 50;
+
+  let query = supabase
+    .from('admin_insights')
+    .select('*')
+    .eq('tenant_id', tenantId)
+    .order('severity', { ascending: true })
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  if (statusParam === 'all') {
+    // no status filter
+  } else if (statusParam) {
+    query = query.eq('status', statusParam);
+  } else {
+    query = query.in('status', ['open', 'pending_approval']);
+  }
+  if (domain) query = query.eq('domain', domain);
+  if (severity) query = query.eq('severity', severity);
+  if (scanner) query = query.eq('scanner', scanner);
+
+  const { data, error } = await query;
+  if (error) {
+    console.warn(`[${VTID}] list failed: ${error.message}`);
+    return res.status(500).json({ ok: false, error: error.message });
+  }
+
+  // Re-sort by severity desc (urgent → info) — Supabase's order on a CHECK
+  // column is alphabetical, which doesn't match urgency. Do it client-side.
+  const rows = (data ?? []).slice().sort((a: any, b: any) => {
+    const ia = SEVERITY_ORDER.indexOf(a.severity);
+    const ib = SEVERITY_ORDER.indexOf(b.severity);
+    if (ia !== ib) return ia - ib;
+    return new Date(b.created_at).getTime() - new Date(a.created_at).getTime();
+  });
+
+  return res.json({ ok: true, count: rows.length, insights: rows });
+});
+
+router.get('/:id', requireTenantAdmin, async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+  const tenantId = getTenantId(req);
+  if (!tenantId) return res.status(400).json({ ok: false, error: 'TENANT_ID_REQUIRED' });
+
+  const { data, error } = await supabase
+    .from('admin_insights')
+    .select('*')
+    .eq('tenant_id', tenantId)
+    .eq('id', req.params.id)
+    .maybeSingle();
+  if (error) return res.status(500).json({ ok: false, error: error.message });
+  if (!data) return res.status(404).json({ ok: false, error: 'NOT_FOUND' });
+  return res.json({ ok: true, insight: data });
+});
+
+async function resolveInsight(
+  req: AuthenticatedRequest,
+  res: Response,
+  newStatus: 'approved' | 'rejected' | 'dismissed',
+  resolvedVia: 'orb' | 'console' | 'autopilot' = 'console',
+): Promise<Response> {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+  const tenantId = getTenantId(req);
+  if (!tenantId) return res.status(400).json({ ok: false, error: 'TENANT_ID_REQUIRED' });
+  const actorId = getActorId(req);
+
+  const { data, error } = await supabase
+    .from('admin_insights')
+    .update({
+      status: newStatus,
+      resolved_at: new Date().toISOString(),
+      resolved_by: actorId,
+      resolved_via: resolvedVia,
+    })
+    .eq('tenant_id', tenantId)
+    .eq('id', req.params.id)
+    .select()
+    .single();
+
+  if (error) {
+    console.warn(`[${VTID}] ${newStatus} failed: ${error.message}`);
+    return res.status(500).json({ ok: false, error: error.message });
+  }
+  if (!data) return res.status(404).json({ ok: false, error: 'NOT_FOUND' });
+
+  emitOasisEvent({
+    vtid: VTID,
+    type: `admin.insight.${newStatus}` as any,
+    source: 'gateway',
+    status: 'info',
+    message: `Admin insight ${newStatus}: ${data.title}`,
+    payload: {
+      insight_id: data.id,
+      tenant_id: tenantId,
+      scanner: data.scanner,
+      natural_key: data.natural_key,
+      severity: data.severity,
+      resolved_via: resolvedVia,
+    },
+    actor_id: actorId ?? undefined,
+  }).catch(() => {});
+
+  return res.json({ ok: true, insight: data });
+}
+
+router.post('/:id/approve', requireTenantAdmin, async (req: AuthenticatedRequest, res: Response) =>
+  resolveInsight(req, res, 'approved'),
+);
+
+router.post('/:id/reject', requireTenantAdmin, async (req: AuthenticatedRequest, res: Response) =>
+  resolveInsight(req, res, 'rejected'),
+);
+
+router.post('/:id/dismiss', requireTenantAdmin, async (req: AuthenticatedRequest, res: Response) =>
+  resolveInsight(req, res, 'dismissed'),
+);
+
+router.post('/:id/snooze', requireTenantAdmin, async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+  const tenantId = getTenantId(req);
+  if (!tenantId) return res.status(400).json({ ok: false, error: 'TENANT_ID_REQUIRED' });
+  const actorId = getActorId(req);
+
+  const hoursRaw = Number(req.body?.hours ?? req.query?.hours ?? 24);
+  const hours = Number.isFinite(hoursRaw) ? Math.max(1, Math.min(24 * 30, Math.floor(hoursRaw))) : 24;
+  const snoozedUntil = new Date(Date.now() + hours * 60 * 60 * 1000).toISOString();
+
+  const { data, error } = await supabase
+    .from('admin_insights')
+    .update({
+      status: 'snoozed',
+      snoozed_until: snoozedUntil,
+      resolved_by: actorId,
+      resolved_via: 'console',
+    })
+    .eq('tenant_id', tenantId)
+    .eq('id', req.params.id)
+    .select()
+    .single();
+
+  if (error) return res.status(500).json({ ok: false, error: error.message });
+  if (!data) return res.status(404).json({ ok: false, error: 'NOT_FOUND' });
+
+  emitOasisEvent({
+    vtid: VTID,
+    type: 'admin.insight.snoozed' as any,
+    source: 'gateway',
+    status: 'info',
+    message: `Admin insight snoozed for ${hours}h: ${data.title}`,
+    payload: { insight_id: data.id, tenant_id: tenantId, hours, snoozed_until: snoozedUntil },
+    actor_id: actorId ?? undefined,
+  }).catch(() => {});
+
+  return res.json({ ok: true, insight: data, snoozed_until: snoozedUntil });
+});
+
+export default router;

--- a/services/gateway/src/services/admin-awareness-worker.ts
+++ b/services/gateway/src/services/admin-awareness-worker.ts
@@ -21,10 +21,11 @@
  * routes/tenant-admin/overview.ts — same tables, same Supabase client.
  */
 import { getSupabase } from '../lib/supabase';
+import { runAllScannersForTenant } from './admin-scanners';
 
 const LOG_PREFIX = '[admin-kpi]';
 const WORKER_TICK_MS = 5 * 60 * 1000; // 5 minutes
-const WORKER_VERSION = 'phase-AA.2026-04-21';
+const WORKER_VERSION = 'phase-BB-CC.2026-04-21';
 
 type KpiPayload = Record<string, unknown>;
 
@@ -233,5 +234,20 @@ export async function computeAndStoreForTenant(tenantId: string): Promise<void> 
     );
   if (dailyErr) {
     console.warn(`${LOG_PREFIX} upsert daily failed ${tenantId.substring(0, 8)}...: ${dailyErr.message}`);
+  }
+
+  // BOOTSTRAP-ADMIN-BB-CC: run domain scanners after KPI compute.
+  // Scanners soft-fail inside the runner; never propagates to break this tick.
+  try {
+    const scan = await runAllScannersForTenant(tenantId);
+    if (scan.scanners_run > 0 || scan.insights_written > 0 || scan.insights_resolved > 0) {
+      console.log(
+        `${LOG_PREFIX} scanners tenant=${tenantId.substring(0, 8)}... ` +
+          `ran=${scan.scanners_run} failed=${scan.scanners_failed} ` +
+          `written=${scan.insights_written} resolved=${scan.insights_resolved}`,
+      );
+    }
+  } catch (err: any) {
+    console.warn(`${LOG_PREFIX} scanner runner failed ${tenantId.substring(0, 8)}...: ${err?.message}`);
   }
 }

--- a/services/gateway/src/services/admin-scanners/index.ts
+++ b/services/gateway/src/services/admin-scanners/index.ts
@@ -1,0 +1,114 @@
+/**
+ * BOOTSTRAP-ADMIN-BB-CC: Admin scanner registry + runner.
+ *
+ * Each scanner self-registers here. The runner iterates registered scanners
+ * for each tenant and upserts their insight drafts into admin_insights
+ * keyed by (tenant_id, scanner, natural_key) so rescans dedup on the same
+ * signal.
+ *
+ * The runner is invoked from services/admin-awareness-worker.ts after KPI
+ * compute completes for a tenant. Soft-fails per scanner — a broken
+ * scanner never breaks the loop or the KPI tick.
+ */
+import { getSupabase } from '../../lib/supabase';
+import type { AdminScanner, InsightDraft } from './types';
+import { systemHealthScanner } from './system-health';
+
+const LOG_PREFIX = '[admin-scanners]';
+
+const REGISTRY: AdminScanner[] = [
+  systemHealthScanner,
+  // Phase BB follow-ups: autopilot_health, content_moderation, community,
+  // users_lifecycle, marketplace, navigator, knowledge, assistant,
+  // signups_funnel, settings_audit, compliance, notifications
+];
+
+export function listScanners(): AdminScanner[] {
+  return [...REGISTRY];
+}
+
+export async function runAllScannersForTenant(tenantId: string): Promise<{
+  scanners_run: number;
+  scanners_failed: number;
+  insights_written: number;
+  insights_resolved: number;
+}> {
+  const supabase = getSupabase();
+  if (!supabase) return { scanners_run: 0, scanners_failed: 0, insights_written: 0, insights_resolved: 0 };
+
+  let scannersRun = 0;
+  let scannersFailed = 0;
+  let insightsWritten = 0;
+  let insightsResolved = 0;
+
+  for (const scanner of REGISTRY) {
+    try {
+      const drafts = await scanner.scan(tenantId);
+      scannersRun++;
+
+      // Upsert each draft — unique (tenant_id, scanner, natural_key) handles dedup.
+      for (const draft of drafts) {
+        const { error } = await supabase.from('admin_insights').upsert(
+          {
+            tenant_id: tenantId,
+            scanner: scanner.id,
+            natural_key: draft.natural_key,
+            domain: draft.domain,
+            title: draft.title,
+            description: draft.description ?? null,
+            severity: draft.severity,
+            actionable: draft.actionable ?? false,
+            recommended_action: draft.recommended_action ?? null,
+            context: draft.context ?? {},
+            confidence_score: draft.confidence_score ?? null,
+            autonomy_level: draft.autonomy_level ?? 'observe_only',
+            // Only set status on insert. On conflict we leave existing
+            // status alone so approved/rejected/snoozed decisions stick
+            // across rescans.
+            status: 'open',
+          },
+          {
+            onConflict: 'tenant_id,scanner,natural_key',
+            ignoreDuplicates: false,
+          },
+        );
+        if (error) {
+          console.warn(`${LOG_PREFIX} upsert failed scanner=${scanner.id} key=${draft.natural_key}: ${error.message}`);
+        } else {
+          insightsWritten++;
+        }
+      }
+
+      // Auto-resolve: any open insight from THIS scanner not in the current
+      // draft set means the signal has cleared. Mark them resolved so the
+      // admin isn't shown stale actions.
+      const activeKeys = drafts.map((d) => d.natural_key);
+      if (activeKeys.length > 0) {
+        const { data: stale, error: staleErr } = await supabase
+          .from('admin_insights')
+          .update({ status: 'resolved', resolved_at: new Date().toISOString(), resolved_via: 'scanner_auto' })
+          .eq('tenant_id', tenantId)
+          .eq('scanner', scanner.id)
+          .eq('status', 'open')
+          .not('natural_key', 'in', `(${activeKeys.map((k) => `"${k.replace(/"/g, '\\"')}"`).join(',')})`)
+          .select('id');
+        if (!staleErr && stale) insightsResolved += stale.length;
+      } else {
+        // No drafts at all — resolve everything currently open from this scanner.
+        const { data: stale } = await supabase
+          .from('admin_insights')
+          .update({ status: 'resolved', resolved_at: new Date().toISOString(), resolved_via: 'scanner_auto' })
+          .eq('tenant_id', tenantId)
+          .eq('scanner', scanner.id)
+          .eq('status', 'open')
+          .select('id');
+        if (stale) insightsResolved += stale.length;
+      }
+    } catch (err: any) {
+      scannersFailed++;
+      console.warn(`${LOG_PREFIX} scanner=${scanner.id} tenant=${tenantId.substring(0, 8)}... threw: ${err?.message}`);
+    }
+  }
+
+  return { scanners_run: scannersRun, scanners_failed: scannersFailed, insights_written: insightsWritten, insights_resolved: insightsResolved };
+}

--- a/services/gateway/src/services/admin-scanners/system-health.ts
+++ b/services/gateway/src/services/admin-scanners/system-health.ts
@@ -1,0 +1,180 @@
+/**
+ * BOOTSTRAP-ADMIN-BB-CC: system_health scanner — first scanner of Phase BB.
+ *
+ * Produces insights for:
+ *   - orb_stall_cluster — ≥ 3 orb.live.stall_detected in last 1 h
+ *   - error_spike       — OASIS error events exceed baseline in last 1 h
+ *   - deploy_failure    — recent cicd.deploy.failed event
+ *   - agent_heartbeat_stale — any service-tier agent last_heartbeat older than 5 min
+ *
+ * Everything is soft-failing — a bad query returns [] rather than breaking
+ * the scan loop. All signals are observe-only per the plan's observe-7-days
+ * policy; admin reviews and promotes to higher severity if signal is useful.
+ */
+import { getSupabase } from '../../lib/supabase';
+import type { AdminScanner, InsightDraft } from './types';
+
+const LOG_PREFIX = '[admin-scanner:system_health]';
+const ORB_STALL_CLUSTER_THRESHOLD = 3;
+const ERROR_SPIKE_THRESHOLD = 20;          // OASIS error events/hour above this = spike
+const AGENT_HEARTBEAT_STALE_MS = 5 * 60 * 1000;
+
+export const systemHealthScanner: AdminScanner = {
+  id: 'system_health',
+  domain: 'system_health',
+  label: 'System health',
+
+  async scan(tenantId: string): Promise<InsightDraft[]> {
+    const supabase = getSupabase();
+    if (!supabase) return [];
+
+    const insights: InsightDraft[] = [];
+    const now = Date.now();
+    const h1 = new Date(now - 60 * 60 * 1000).toISOString();
+    const d1 = new Date(now - 24 * 60 * 60 * 1000).toISOString();
+
+    // 1. Orb stall cluster — how many orb.live.stall_detected in the last 1h
+    try {
+      const { count, error } = await supabase
+        .from('oasis_events')
+        .select('id', { count: 'exact', head: true })
+        .eq('topic', 'orb.live.stall_detected')
+        .gte('created_at', h1);
+      if (!error && count !== null && count >= ORB_STALL_CLUSTER_THRESHOLD) {
+        insights.push({
+          natural_key: 'orb_stall_cluster_1h',
+          domain: 'system_health',
+          title: `Orb stall cluster: ${count} stalls in last hour`,
+          description:
+            `The forwarding watchdog fired ${count} times in the last hour. ` +
+            `Expected baseline is < ${ORB_STALL_CLUSTER_THRESHOLD} per hour.`,
+          severity: count >= ORB_STALL_CLUSTER_THRESHOLD * 3 ? 'urgent' : 'action_needed',
+          actionable: true,
+          recommended_action: {
+            type: 'investigate',
+            hint: 'Check Cloud Run logs for VTID-WATCHDOG; verify Vertex region latency.',
+          },
+          context: { stalls_last_hour: count, threshold: ORB_STALL_CLUSTER_THRESHOLD },
+          confidence_score: 0.9,
+          autonomy_level: 'observe_only',
+        });
+      }
+    } catch (err: any) {
+      console.warn(`${LOG_PREFIX} orb_stall_cluster failed: ${err?.message}`);
+    }
+
+    // 2. Error spike — OASIS events with status='error' in last 1h
+    try {
+      const { count, error } = await supabase
+        .from('oasis_events')
+        .select('id', { count: 'exact', head: true })
+        .eq('status', 'error')
+        .gte('created_at', h1);
+      if (!error && count !== null && count >= ERROR_SPIKE_THRESHOLD) {
+        insights.push({
+          natural_key: 'error_spike_1h',
+          domain: 'system_health',
+          title: `Error spike: ${count} OASIS errors in last hour`,
+          description: `${count} error-status events emitted in the last 60 min (baseline threshold ${ERROR_SPIKE_THRESHOLD}).`,
+          severity: count >= ERROR_SPIKE_THRESHOLD * 5 ? 'urgent' : 'action_needed',
+          actionable: true,
+          recommended_action: {
+            type: 'investigate',
+            hint: 'Group oasis_events by topic in the last hour to identify the hot source.',
+          },
+          context: { error_count_last_hour: count, threshold: ERROR_SPIKE_THRESHOLD },
+          confidence_score: 0.85,
+          autonomy_level: 'observe_only',
+        });
+      }
+    } catch (err: any) {
+      console.warn(`${LOG_PREFIX} error_spike failed: ${err?.message}`);
+    }
+
+    // 3. Deploy failure in last 24h
+    try {
+      const { data, error } = await supabase
+        .from('oasis_events')
+        .select('topic, created_at, message')
+        .in('topic', ['cicd.deploy.failed', 'deploy.gateway.failed'])
+        .gte('created_at', d1)
+        .order('created_at', { ascending: false })
+        .limit(5);
+      if (!error && data && data.length > 0) {
+        insights.push({
+          natural_key: `deploy_failure_${data[0].created_at}`,
+          domain: 'system_health',
+          title: `${data.length} deploy failure${data.length > 1 ? 's' : ''} in last 24h`,
+          description:
+            `Most recent: ${data[0].topic} at ${new Date(data[0].created_at).toISOString()}. ` +
+            (data[0].message ? `Message: ${String(data[0].message).slice(0, 200)}` : ''),
+          severity: 'warning',
+          actionable: true,
+          recommended_action: { type: 'review_deploy_logs', topic: data[0].topic },
+          context: { failures: data.length, most_recent: data[0] },
+          confidence_score: 0.95,
+          autonomy_level: 'observe_only',
+        });
+      }
+    } catch (err: any) {
+      console.warn(`${LOG_PREFIX} deploy_failure failed: ${err?.message}`);
+    }
+
+    // 4. Service-tier agent heartbeat stale
+    try {
+      const { data, error } = await supabase
+        .from('agents_registry')
+        .select('agent_id, name, tier, last_heartbeat_at')
+        .eq('tier', 'service')
+        .order('last_heartbeat_at', { ascending: true, nullsFirst: true })
+        .limit(20);
+      if (!error && data) {
+        const stale = data.filter((a: { last_heartbeat_at: string | null }) => {
+          if (!a.last_heartbeat_at) return true;
+          return Date.now() - new Date(a.last_heartbeat_at).getTime() > AGENT_HEARTBEAT_STALE_MS;
+        });
+        if (stale.length > 0) {
+          insights.push({
+            natural_key: 'agent_heartbeat_stale',
+            domain: 'system_health',
+            title: `${stale.length} service agent${stale.length > 1 ? 's' : ''} not reporting`,
+            description:
+              `Service-tier agents with last heartbeat > 5 min: ` +
+              stale.map((a: { agent_id: string }) => a.agent_id).slice(0, 5).join(', ') +
+              (stale.length > 5 ? ` (+${stale.length - 5} more)` : ''),
+            severity: stale.length >= 3 ? 'action_needed' : 'warning',
+            actionable: true,
+            recommended_action: {
+              type: 'check_agent',
+              agent_ids: stale.map((a: { agent_id: string }) => a.agent_id),
+            },
+            context: {
+              stale_count: stale.length,
+              agents: stale.map((a: { agent_id: string; name?: string; last_heartbeat_at: string | null }) => ({
+                agent_id: a.agent_id,
+                name: a.name,
+                last_heartbeat_at: a.last_heartbeat_at,
+              })),
+            },
+            confidence_score: 0.8,
+            autonomy_level: 'observe_only',
+          });
+        }
+      }
+    } catch (err: any) {
+      console.warn(`${LOG_PREFIX} agent_heartbeat failed: ${err?.message}`);
+    }
+
+    // NOTE: these signals are mostly *global* (OASIS + agents_registry aren't
+    // strictly tenant-scoped today). For Phase BB#1 we produce one copy per
+    // tenant — good enough for the observe-only period. A follow-up scanner
+    // phase will introduce tenant-scoped OASIS projection so each tenant only
+    // sees insights relevant to it. We tag `context.tenant_scope: 'global'`
+    // so the UI can disambiguate.
+    for (const insight of insights) {
+      insight.context = { ...(insight.context || {}), tenant_scope: 'global', scanned_tenant: tenantId };
+    }
+
+    return insights;
+  },
+};

--- a/services/gateway/src/services/admin-scanners/types.ts
+++ b/services/gateway/src/services/admin-scanners/types.ts
@@ -1,0 +1,61 @@
+/**
+ * BOOTSTRAP-ADMIN-BB-CC: Shared types for admin scanners.
+ *
+ * Each scanner is a module exporting `scan(tenantId)` that returns an array
+ * of insight drafts. The runner upserts them into admin_insights keyed by
+ * (tenant_id, scanner, natural_key) so repeat scans dedup on the same signal.
+ */
+
+export type InsightSeverity = 'info' | 'warning' | 'action_needed' | 'urgent';
+
+export type AutonomyLevel =
+  | 'observe_only'
+  | 'diagnose'
+  | 'spec_and_wait'
+  | 'auto_approve_simple'
+  | 'full_auto';
+
+/**
+ * Admin domains map to the tenant-admin sidebar sections in the plan
+ * (atomic-riding-badger.md Part B-1).
+ */
+export type AdminDomain =
+  | 'overview'
+  | 'users'
+  | 'community'
+  | 'knowledge'
+  | 'navigator'
+  | 'moderation'
+  | 'assistant'
+  | 'marketplace'
+  | 'autopilot'
+  | 'audit'
+  | 'settings'
+  | 'notifications'
+  | 'signups'
+  | 'system_health';
+
+export interface InsightDraft {
+  /** Stable per-signal key; scanner produces the same value on re-scan to dedup. */
+  natural_key: string;
+  domain: AdminDomain;
+  title: string;
+  description?: string;
+  severity: InsightSeverity;
+  actionable?: boolean;
+  recommended_action?: Record<string, unknown>;
+  context?: Record<string, unknown>;
+  confidence_score?: number; // 0-1
+  autonomy_level?: AutonomyLevel;
+}
+
+export interface AdminScanner {
+  /** Unique scanner id (lowercase, used as the scanner column value). */
+  id: string;
+  /** The admin domain this scanner reports to. */
+  domain: AdminDomain;
+  /** Human label for logs. */
+  label: string;
+  /** Scan one tenant. Never throws; returns [] on any internal failure. */
+  scan(tenantId: string): Promise<InsightDraft[]>;
+}

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -500,6 +500,11 @@ export type CicdEventType =
   // BOOTSTRAP-ORB-HOTFIX-1: pre-greeting latency gauge (time from session-start
   // request to first greeting audio chunk forwarded to client)
   | 'orb.live.greeting.delivered'
+  // BOOTSTRAP-ADMIN-BB-CC: admin insight lifecycle
+  | 'admin.insight.approved'
+  | 'admin.insight.rejected'
+  | 'admin.insight.snoozed'
+  | 'admin.insight.dismissed'
   // VTID-DIAG: Pipeline diagnostics
   | 'orb.live.diag'
   // VTID-FALLBACK: Chat-TTS fallback events

--- a/supabase/migrations/20260421250000_BOOTSTRAP_admin_insights.sql
+++ b/supabase/migrations/20260421250000_BOOTSTRAP_admin_insights.sql
@@ -1,0 +1,85 @@
+-- BOOTSTRAP-ADMIN-BB-CC: admin_insights table — the L3 recommendation layer
+-- of the admin companion (see atomic-riding-badger.md Part B-3).
+--
+-- One row per actionable signal produced by a scanner. Insights carry their
+-- own confidence, autonomy level, and recommended_action, mirroring the
+-- autopilot_recommendations + self-healing_log schema so the same
+-- approve/reject/snooze lifecycle can drive them.
+--
+-- Dedup: (tenant_id, scanner, natural_key) is unique — scanners upsert
+-- the same row when the same signal persists across scans. Closing a row
+-- sets status=resolved/dismissed and stops further upserts until the
+-- signal clears AND reappears later.
+
+\set ON_ERROR_STOP on
+
+CREATE TABLE IF NOT EXISTS public.admin_insights (
+  id                   UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id            UUID NOT NULL,
+  scanner              TEXT NOT NULL,
+  natural_key          TEXT NOT NULL,
+  domain               TEXT NOT NULL,
+  title                TEXT NOT NULL,
+  description          TEXT,
+  severity             TEXT NOT NULL CHECK (severity IN ('info','warning','action_needed','urgent')),
+  actionable           BOOLEAN NOT NULL DEFAULT FALSE,
+  recommended_action   JSONB,
+  context              JSONB NOT NULL DEFAULT '{}'::jsonb,
+  confidence_score     NUMERIC(3,2),
+  autonomy_level       TEXT NOT NULL DEFAULT 'observe_only'
+                         CHECK (autonomy_level IN ('observe_only','diagnose','spec_and_wait','auto_approve_simple','full_auto')),
+  status               TEXT NOT NULL DEFAULT 'open'
+                         CHECK (status IN ('open','pending_approval','approved','rejected','executed','snoozed','dismissed','resolved')),
+  snoozed_until        TIMESTAMPTZ,
+  created_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at           TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  resolved_at          TIMESTAMPTZ,
+  resolved_by          UUID,
+  resolved_via         TEXT,
+  CONSTRAINT admin_insights_dedup UNIQUE (tenant_id, scanner, natural_key)
+);
+
+COMMENT ON TABLE public.admin_insights IS
+  'BOOTSTRAP-ADMIN-BB-CC: L3 recommendation layer of the admin companion. Scanners upsert signals; admins approve/reject via orb or console; autopilot executes auto_approve_simple+ rows within guardrails.';
+
+CREATE INDEX IF NOT EXISTS admin_insights_tenant_open_severity_idx
+  ON public.admin_insights (tenant_id, status, severity DESC, created_at DESC)
+  WHERE status IN ('open','pending_approval');
+
+CREATE INDEX IF NOT EXISTS admin_insights_scanner_key_idx
+  ON public.admin_insights (tenant_id, scanner, natural_key);
+
+CREATE INDEX IF NOT EXISTS admin_insights_snoozed_idx
+  ON public.admin_insights (snoozed_until)
+  WHERE status = 'snoozed';
+
+-- updated_at auto-touch
+CREATE OR REPLACE FUNCTION public.touch_admin_insights_updated_at()
+RETURNS TRIGGER LANGUAGE plpgsql AS $fn$
+BEGIN
+  NEW.updated_at := NOW();
+  RETURN NEW;
+END
+$fn$;
+
+DROP TRIGGER IF EXISTS admin_insights_touch_updated_at ON public.admin_insights;
+CREATE TRIGGER admin_insights_touch_updated_at
+  BEFORE UPDATE ON public.admin_insights
+  FOR EACH ROW EXECUTE FUNCTION public.touch_admin_insights_updated_at();
+
+-- RLS
+ALTER TABLE public.admin_insights ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS admin_insights_self_read ON public.admin_insights;
+CREATE POLICY admin_insights_self_read ON public.admin_insights
+  FOR SELECT TO authenticated
+  USING (
+    tenant_id IN (
+      SELECT ut.tenant_id FROM public.user_tenants ut
+      WHERE ut.user_id = auth.uid() AND ut.active_role IN ('admin','developer','infra')
+    )
+  );
+
+DROP POLICY IF EXISTS admin_insights_service ON public.admin_insights;
+CREATE POLICY admin_insights_service ON public.admin_insights
+  FOR ALL TO service_role USING (TRUE) WITH CHECK (TRUE);


### PR DESCRIPTION
Phases BB#1 and CC of the Admin Companion plan. Migration admin_insights + scanner framework + first scanner (system_health) + insights REST endpoints. Wired into existing admin-awareness-worker — after KPI compute per tenant, scanners run and upsert insights with dedup. Approve/reject/snooze/dismiss follows the self-healing pattern. 13 OASIS event types extended. Migration applies manually.