### PR TITLE
BOOTSTRAP-ADMIN-EE: proactive admin briefings + urgent push

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -46,6 +46,7 @@ import { randomUUID } from 'crypto';
 import { TextToSpeechClient, protos } from '@google-cloud/text-to-speech';
 import { processWithGemini, setThreadIdentity } from '../services/gemini-operator';
 import { emitOasisEvent } from '../services/oasis-event-service';
+import { fetchAdminBriefingBlock, isAdminRole } from '../services/admin-scanners/briefing';
 import { getUserContextSummary } from '../services/user-context-profiler';
 import { getAwarenessConfigSync } from '../services/awareness-registry';
 import { writeTimelineRow } from '../services/timeline-projector';
@@ -9772,6 +9773,33 @@ router.post('/live/session/start', optionalAuth, async (req: AuthenticatedReques
     } else {
       console.log(`[VTID-01224] Context bootstrap complete for ${sessionId}: ${bootstrapResult.latencyMs}ms, chars=${contextInstruction?.length || 0}`);
     }
+
+    // BOOTSTRAP-ADMIN-EE: admin-role sessions get a proactive briefing of the
+    // top open admin_insights prepended to the greeting. Only fires for admin-ish
+    // roles and only when there's something to speak about.
+    if (isAdminRole(sseActiveRole) && bootstrapIdentity.tenant_id) {
+      try {
+        const briefing = await fetchAdminBriefingBlock(bootstrapIdentity.tenant_id, 3);
+        if (briefing) {
+          contextInstruction = contextInstruction
+            ? `${contextInstruction}\n\n${briefing}`
+            : briefing;
+          emitOasisEvent({
+            vtid: 'BOOTSTRAP-ADMIN-EE',
+            type: 'admin.briefing.injected',
+            source: 'orb-live',
+            status: 'info',
+            message: `Admin briefing injected into SSE session ${sessionId}`,
+            payload: { session_id: sessionId, tenant_id: bootstrapIdentity.tenant_id, role: sseActiveRole, chars: briefing.length },
+            actor_id: bootstrapIdentity.user_id,
+            actor_role: 'admin',
+            surface: 'orb',
+          }).catch(() => {});
+        }
+      } catch (err: any) {
+        console.warn(`[BOOTSTRAP-ADMIN-EE] SSE briefing fetch failed: ${err?.message}`);
+      }
+    }
   } else {
     contextBootstrapSkippedReason = 'no_identity';
     console.log(`[VTID-01224] Skipping context bootstrap for ${sessionId}: no identity`);
@@ -11500,6 +11528,31 @@ async function handleWsStartMessage(clientSession: WsClientSession, message: WsC
     contextPack = bootstrapResult.contextPack;
     contextBootstrapLatencyMs = bootstrapResult.latencyMs;
     contextBootstrapSkippedReason = bootstrapResult.skippedReason;
+
+    // BOOTSTRAP-ADMIN-EE: admin-role WS sessions get a proactive briefing too.
+    if (isAdminRole(activeRole) && effectiveBootstrapIdentity.tenant_id) {
+      try {
+        const briefing = await fetchAdminBriefingBlock(effectiveBootstrapIdentity.tenant_id, 3);
+        if (briefing) {
+          contextInstruction = contextInstruction
+            ? `${contextInstruction}\n\n${briefing}`
+            : briefing;
+          emitOasisEvent({
+            vtid: 'BOOTSTRAP-ADMIN-EE',
+            type: 'admin.briefing.injected',
+            source: 'orb-live-ws',
+            status: 'info',
+            message: `Admin briefing injected into WS session ${sessionId}`,
+            payload: { session_id: sessionId, tenant_id: effectiveBootstrapIdentity.tenant_id, role: activeRole, chars: briefing.length },
+            actor_id: effectiveBootstrapIdentity.user_id,
+            actor_role: 'admin',
+            surface: 'orb',
+          }).catch(() => {});
+        }
+      } catch (err: any) {
+        console.warn(`[BOOTSTRAP-ADMIN-EE] WS briefing fetch failed: ${err?.message}`);
+      }
+    }
 
     // VTID-01224: Emit OASIS telemetry for context bootstrap
     if (bootstrapResult.skippedReason) {

--- a/services/gateway/src/services/admin-scanners/briefing.ts
+++ b/services/gateway/src/services/admin-scanners/briefing.ts
@@ -1,0 +1,219 @@
+/**
+ * BOOTSTRAP-ADMIN-EE: Admin briefing module.
+ *
+ * Two responsibilities:
+ *   1. fetchAdminBriefingBlock(tenantId, limit)
+ *      → returns a markdown block of the top-N open insights, formatted so
+ *        Vitana voice can open the admin session with them.
+ *   2. notifyUnnotifiedUrgentInsights(tenantId)
+ *      → finds urgent insights not yet pushed, fires notifyUserAsync to every
+ *        tenant admin, and stamps urgent_notified_at.
+ *
+ * Called from:
+ *   - orb-live.ts buildBootstrapContextPack → (1), admin role only
+ *   - admin-scanners/index.ts runAllScannersForTenant → (2), every scan
+ */
+import { getSupabase } from '../../lib/supabase';
+import { notifyUserAsync } from '../notification-service';
+
+const LOG_PREFIX = '[admin-briefing]';
+
+// Severity → rank for ordering the briefing. Higher = surfaced first.
+const SEVERITY_RANK: Record<string, number> = {
+  urgent: 4,
+  action_needed: 3,
+  warning: 2,
+  info: 1,
+};
+
+const PRIVILEGED_ROLES = ['admin', 'exafy_admin', 'developer'];
+
+export function isAdminRole(role: string | null | undefined): boolean {
+  return !!role && PRIVILEGED_ROLES.includes(role);
+}
+
+interface InsightRow {
+  id: string;
+  scanner: string;
+  natural_key: string;
+  domain: string;
+  title: string;
+  description: string | null;
+  severity: string;
+  confidence_score: number | null;
+  recommended_action: Record<string, unknown> | null;
+}
+
+/**
+ * Returns a markdown block of the top-N open insights for this tenant,
+ * or null if there are none. The block is wrapped with a directive that
+ * Gemini should open the admin session by surfacing them.
+ */
+export async function fetchAdminBriefingBlock(
+  tenantId: string,
+  limit = 3,
+): Promise<string | null> {
+  const supabase = getSupabase();
+  if (!supabase) return null;
+
+  try {
+    // Fetch open insights excluding snoozed-until-future. Rank severity client-side
+    // since Postgres sorts the text alphabetically, not by our semantic order.
+    const { data, error } = await supabase
+      .from('admin_insights')
+      .select(
+        'id, scanner, natural_key, domain, title, description, severity, confidence_score, recommended_action, snoozed_until',
+      )
+      .eq('tenant_id', tenantId)
+      .eq('status', 'open')
+      .limit(20);
+    if (error) {
+      console.warn(`${LOG_PREFIX} fetch failed: ${error.message}`);
+      return null;
+    }
+    if (!data || data.length === 0) return null;
+
+    const now = Date.now();
+    const ranked = (data as (InsightRow & { snoozed_until: string | null })[])
+      .filter((r) => !r.snoozed_until || new Date(r.snoozed_until).getTime() <= now)
+      .map((r) => ({
+        row: r,
+        score:
+          (SEVERITY_RANK[r.severity] ?? 1) * 10 +
+          (typeof r.confidence_score === 'number' ? r.confidence_score : 0.5),
+      }))
+      .sort((a, b) => b.score - a.score)
+      .slice(0, limit);
+
+    if (ranked.length === 0) return null;
+
+    const lines = ranked.map((entry, idx) => {
+      const r = entry.row;
+      const pill = r.severity === 'urgent' ? '🔴'
+        : r.severity === 'action_needed' ? '🟠'
+        : r.severity === 'warning' ? '🟡'
+        : '⚪';
+      const n = idx + 1;
+      const desc = r.description ? r.description.split('\n')[0].slice(0, 220) : '';
+      return `${n}. ${pill} **[${r.domain}]** ${r.title}${desc ? `\n   ${desc}` : ''}`;
+    });
+
+    return [
+      '## ADMIN BRIEFING (active tenant signals — speak these on open)',
+      '',
+      `The supervisor just opened the orb. These are the top ${ranked.length} open insight${ranked.length > 1 ? 's' : ''} right now, ranked by severity × confidence. OPEN by briefly naming what needs attention — two short sentences each, ask which to tackle first. Do NOT do a generic greeting. Be direct, numeric, action-oriented.`,
+      '',
+      ...lines,
+      '',
+      'After the user picks one, stay on that insight until it is approved, rejected, snoozed, or handed off.',
+    ].join('\n');
+  } catch (err: any) {
+    console.warn(`${LOG_PREFIX} fetchAdminBriefingBlock error: ${err?.message}`);
+    return null;
+  }
+}
+
+/**
+ * Returns the user_ids of every admin-ish member of this tenant.
+ * Used to fan out urgent push notifications.
+ */
+async function getTenantAdminUserIds(tenantId: string): Promise<string[]> {
+  const supabase = getSupabase();
+  if (!supabase) return [];
+  try {
+    const { data, error } = await supabase
+      .from('user_tenants')
+      .select('user_id, active_role')
+      .eq('tenant_id', tenantId)
+      .in('active_role', PRIVILEGED_ROLES);
+    if (error) {
+      console.warn(`${LOG_PREFIX} getTenantAdminUserIds failed: ${error.message}`);
+      return [];
+    }
+    return (data ?? []).map((r: { user_id: string }) => r.user_id);
+  } catch (err: any) {
+    console.warn(`${LOG_PREFIX} getTenantAdminUserIds error: ${err?.message}`);
+    return [];
+  }
+}
+
+/**
+ * Find urgent open insights that have not been pushed yet, fire a push/in-app
+ * notification to every admin of this tenant, and stamp urgent_notified_at.
+ * Fire-and-forget; soft-fails per insight.
+ */
+export async function notifyUnnotifiedUrgentInsights(tenantId: string): Promise<number> {
+  const supabase = getSupabase();
+  if (!supabase) return 0;
+
+  try {
+    const { data, error } = await supabase
+      .from('admin_insights')
+      .select('id, title, description, domain, scanner, natural_key')
+      .eq('tenant_id', tenantId)
+      .eq('status', 'open')
+      .eq('severity', 'urgent')
+      .is('urgent_notified_at', null)
+      .limit(20);
+    if (error) {
+      console.warn(`${LOG_PREFIX} notify fetch failed: ${error.message}`);
+      return 0;
+    }
+    if (!data || data.length === 0) return 0;
+
+    const adminIds = await getTenantAdminUserIds(tenantId);
+    if (adminIds.length === 0) {
+      // Still mark notified so we don't re-query. If admins show up later
+      // they'll see the insight in the console; the first-push opportunity
+      // is only valuable for live admins.
+      const ids = data.map((r: { id: string }) => r.id);
+      await supabase
+        .from('admin_insights')
+        .update({ urgent_notified_at: new Date().toISOString() })
+        .in('id', ids);
+      return 0;
+    }
+
+    let notified = 0;
+    for (const insight of data as InsightRow[]) {
+      const title = `Urgent: ${insight.title.slice(0, 120)}`;
+      const body = (insight.description || '').split('\n')[0].slice(0, 200);
+      for (const userId of adminIds) {
+        try {
+          notifyUserAsync(
+            userId,
+            tenantId,
+            'admin_insight_urgent',
+            {
+              title,
+              body,
+              data: {
+                insight_id: insight.id,
+                scanner: insight.scanner,
+                natural_key: insight.natural_key,
+                domain: insight.domain,
+                link: `/command-hub/admin/insights/${insight.id}`,
+              },
+            },
+            supabase,
+          );
+          notified++;
+        } catch (err: any) {
+          console.warn(`${LOG_PREFIX} notify user=${userId.substring(0, 8)}... failed: ${err?.message}`);
+        }
+      }
+    }
+
+    // Stamp notified — use one UPDATE for all ids
+    const ids = data.map((r: { id: string }) => r.id);
+    await supabase
+      .from('admin_insights')
+      .update({ urgent_notified_at: new Date().toISOString() })
+      .in('id', ids);
+
+    return notified;
+  } catch (err: any) {
+    console.warn(`${LOG_PREFIX} notifyUnnotifiedUrgentInsights error: ${err?.message}`);
+    return 0;
+  }
+}

--- a/services/gateway/src/services/admin-scanners/index.ts
+++ b/services/gateway/src/services/admin-scanners/index.ts
@@ -12,6 +12,7 @@
  */
 import { getSupabase } from '../../lib/supabase';
 import type { AdminScanner, InsightDraft } from './types';
+import { notifyUnnotifiedUrgentInsights } from './briefing';
 import { systemHealthScanner } from './system-health';
 import { autopilotHealthScanner } from './autopilot-health';
 import { contentModerationScanner } from './content-moderation';
@@ -54,9 +55,10 @@ export async function runAllScannersForTenant(tenantId: string): Promise<{
   scanners_failed: number;
   insights_written: number;
   insights_resolved: number;
+  urgent_notified: number;
 }> {
   const supabase = getSupabase();
-  if (!supabase) return { scanners_run: 0, scanners_failed: 0, insights_written: 0, insights_resolved: 0 };
+  if (!supabase) return { scanners_run: 0, scanners_failed: 0, insights_written: 0, insights_resolved: 0, urgent_notified: 0 };
 
   let scannersRun = 0;
   let scannersFailed = 0;
@@ -132,5 +134,20 @@ export async function runAllScannersForTenant(tenantId: string): Promise<{
     }
   }
 
-  return { scanners_run: scannersRun, scanners_failed: scannersFailed, insights_written: insightsWritten, insights_resolved: insightsResolved };
+  // BOOTSTRAP-ADMIN-EE: after all scanners finish, push urgent insights to
+  // tenant admins. Fire-and-forget — soft-fails per user inside the helper.
+  let urgentNotified = 0;
+  try {
+    urgentNotified = await notifyUnnotifiedUrgentInsights(tenantId);
+  } catch (err: any) {
+    console.warn(`${LOG_PREFIX} urgent_notify tenant=${tenantId.substring(0, 8)}... threw: ${err?.message}`);
+  }
+
+  return {
+    scanners_run: scannersRun,
+    scanners_failed: scannersFailed,
+    insights_written: insightsWritten,
+    insights_resolved: insightsResolved,
+    urgent_notified: urgentNotified,
+  };
 }

--- a/services/gateway/src/services/notification-service.ts
+++ b/services/gateway/src/services/notification-service.ts
@@ -134,6 +134,9 @@ const TYPE_META: Record<string, TypeMeta> = {
   complete_your_profile:       { channel: 'inapp',          priority: 'p2', category: 'system' },
   onboarding_step_completed:   { channel: 'inapp',          priority: 'p3', category: 'system' },
   weekly_activity_summary:     { channel: 'push_and_inapp', priority: 'p2', category: 'system' },
+  // Admin Companion (BOOTSTRAP-ADMIN-EE)
+  admin_insight_urgent:        { channel: 'push_and_inapp', priority: 'p0', category: 'system' },
+  admin_insight_action_needed: { channel: 'inapp',          priority: 'p1', category: 'system' },
   // Wallet & Business (VTID-01250)
   wallet_credits_earned:       { channel: 'push_and_inapp', priority: 'p1', category: 'offer' },
   wallet_payout_received:      { channel: 'push_and_inapp', priority: 'p1', category: 'offer' },

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -505,6 +505,9 @@ export type CicdEventType =
   | 'admin.insight.rejected'
   | 'admin.insight.snoozed'
   | 'admin.insight.dismissed'
+  // BOOTSTRAP-ADMIN-EE: proactive briefings + urgent notifications
+  | 'admin.briefing.injected'
+  | 'admin.insight.urgent_notified'
   // VTID-DIAG: Pipeline diagnostics
   | 'orb.live.diag'
   // VTID-FALLBACK: Chat-TTS fallback events

--- a/supabase/migrations/20260422120000_BOOTSTRAP_admin_insights_notified_at.sql
+++ b/supabase/migrations/20260422120000_BOOTSTRAP_admin_insights_notified_at.sql
@@ -1,0 +1,20 @@
+-- =============================================================================
+-- BOOTSTRAP-ADMIN-EE: urgent_notified_at column on admin_insights
+--
+-- Phase EE needs to deliver push + in-app notifications to tenant admins
+-- the first time an insight becomes severity='urgent'. We track delivery
+-- with a timestamp column so re-scans don't re-notify for the same signal.
+--
+-- Idempotent migration: safe to run twice.
+-- =============================================================================
+
+ALTER TABLE public.admin_insights
+  ADD COLUMN IF NOT EXISTS urgent_notified_at TIMESTAMPTZ;
+
+COMMENT ON COLUMN public.admin_insights.urgent_notified_at IS
+  'BOOTSTRAP-ADMIN-EE: set to NOW() when we fire admin_insight_urgent notifications. NULL = not yet notified. Reset to NULL if an insight transitions out of severity=urgent and back.';
+
+-- Partial index for the post-scan query that finds un-notified urgent insights.
+CREATE INDEX IF NOT EXISTS admin_insights_urgent_unnotified_idx
+  ON public.admin_insights (tenant_id, created_at DESC)
+  WHERE status = 'open' AND severity = 'urgent' AND urgent_notified_at IS NULL;


### PR DESCRIPTION
## Summary

Phase EE of the Admin Companion plan. Two user-visible changes:

1. **Proactive briefing on orb-open** — admin/exafy_admin/developer sessions no longer hear a generic greeting. Instead Vitana opens with the top 3 open admin_insights (ranked severity × confidence), naming what needs attention and asking which to tackle first.

2. **Urgent push notifications** — insights at severity=urgent fire a p0 push_and_inapp notification to every admin of the tenant as soon as the scanner produces them. Once-only, tracked with new `admin_insights.urgent_notified_at` column.

## Files

- **Migration** `20260422120000_BOOTSTRAP_admin_insights_notified_at.sql` — ADD COLUMN urgent_notified_at + partial index. Run via RUN-MIGRATION.yml **after merge**.
- `services/admin-scanners/briefing.ts` (new) — `fetchAdminBriefingBlock`, `notifyUnnotifiedUrgentInsights`, `isAdminRole`.
- `services/admin-scanners/index.ts` — end-of-scan hook calls notifyUnnotifiedUrgentInsights, extended return type with urgent_notified.
- `services/notification-service.ts` — registers `admin_insight_urgent` (p0) + `admin_insight_action_needed` (p1).
- `routes/orb-live.ts` — SSE + WS session-start paths await fetchAdminBriefingBlock when role is admin-ish; appends to contextInstruction; emits `admin.briefing.injected`.
- `types/cicd.ts` — new event types.

## Cost

Admin sessions: +50-100ms briefing fetch (one indexed SELECT). Community sessions: zero change. Typecheck clean.

## Verification

- [x] Typecheck clean
- [ ] Run migration via RUN-MIGRATION.yml after merge
- [ ] Post-deploy: open admin orb, confirm briefing greeting
- [ ] Seed an urgent insight → confirm push notification delivered
- [ ] OASIS: `admin.briefing.injected` per admin session

🤖 Generated with [Claude Code](https://claude.com/claude-code)