### PR TITLE
BOOTSTRAP-ADMIN-GG: Tenant Health Index (daily 0-100 score + trend)

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -293,6 +293,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const tenantKpisRouter = require('./routes/tenant-admin/kpis').default;
   // BOOTSTRAP-ADMIN-BB-CC: Admin insights (scanner outputs + approve/reject)
   const tenantInsightsRouter = require('./routes/tenant-admin/insights').default;
+  // BOOTSTRAP-ADMIN-GG: Tenant Health Index (0-100 composite + trend)
+  const tenantHealthIndexRouter = require('./routes/tenant-admin/health-index').default;
   // Settings — tenant profile, branding, feature flags, integrations
   const tenantSettingsRouter = require('./routes/tenant-admin/settings').default;
   // Audit & Compliance — admin action audit log, access log
@@ -762,6 +764,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   mountRouterSync(app, '/api/v1/admin/tenants/:tenantId/kpis', tenantKpisRouter, { owner: 'tenant-kpis' });
   // BOOTSTRAP-ADMIN-BB-CC: Admin insights
   mountRouterSync(app, '/api/v1/admin/tenants/:tenantId/insights', tenantInsightsRouter, { owner: 'tenant-insights' });
+  // BOOTSTRAP-ADMIN-GG: Tenant Health Index
+  mountRouterSync(app, '/api/v1/admin/tenants/:tenantId/health-index', tenantHealthIndexRouter, { owner: 'tenant-health-index' });
   // Settings — tenant profile, branding, feature flags
   mountRouterSync(app, '/api/v1/admin/tenants/:tenantId/settings', tenantSettingsRouter, { owner: 'tenant-settings' });
   // Audit & Compliance — admin action audit log

--- a/services/gateway/src/routes/tenant-admin/health-index.ts
+++ b/services/gateway/src/routes/tenant-admin/health-index.ts
@@ -1,0 +1,107 @@
+/**
+ * BOOTSTRAP-ADMIN-GG: Tenant Health Index endpoints.
+ *
+ * Mounted at /api/v1/admin/tenants/:tenantId/health-index
+ *
+ *   GET  /           — current score + 30-day history trend
+ *   GET  /current    — latest score only
+ *   POST /refresh    — recompute on-demand (admin-facing convenience)
+ *
+ * Reads from tenant_health_index_daily. Writes happen via the admin
+ * awareness worker (storeTenantHealthIndex).
+ */
+import { Router, Response } from 'express';
+import { requireTenantAdmin } from '../../middleware/require-tenant-admin';
+import { AuthenticatedRequest } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { storeTenantHealthIndex } from '../../services/admin-health-index';
+
+const router = Router({ mergeParams: true });
+const VTID = 'BOOTSTRAP-ADMIN-GG';
+
+router.get('/', requireTenantAdmin, async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+  const tenantId = req.params.tenantId || (req as any).targetTenantId;
+  if (!tenantId) return res.status(400).json({ ok: false, error: 'TENANT_ID_REQUIRED' });
+
+  const daysParam = Number.parseInt((req.query.days as string) || '30', 10);
+  const days = Number.isFinite(daysParam) ? Math.max(7, Math.min(90, daysParam)) : 30;
+  const startDate = new Date(Date.now() - days * 86400_000).toISOString().slice(0, 10);
+
+  try {
+    const { data, error } = await supabase
+      .from('tenant_health_index_daily')
+      .select('snapshot_date, score, components, computed_at, source_version')
+      .eq('tenant_id', tenantId)
+      .gte('snapshot_date', startDate)
+      .order('snapshot_date', { ascending: false });
+    if (error) {
+      console.warn(`[${VTID}] history query failed: ${error.message}`);
+      return res.status(500).json({ ok: false, error: error.message });
+    }
+
+    const rows = data ?? [];
+    const current = rows[0] ?? null;
+    // Compute trend: mean of last 7 minus mean of previous 7
+    const last7 = rows.slice(0, 7);
+    const prev7 = rows.slice(7, 14);
+    const mean = (a: typeof rows) => (a.length ? Math.round(a.reduce((s, r) => s + r.score, 0) / a.length) : null);
+    const last7Mean = mean(last7);
+    const prev7Mean = mean(prev7);
+    const weekly_delta = last7Mean !== null && prev7Mean !== null ? last7Mean - prev7Mean : null;
+
+    return res.json({
+      ok: true,
+      tenant_id: tenantId,
+      current,
+      history: rows,
+      summary: {
+        last7_mean: last7Mean,
+        prior7_mean: prev7Mean,
+        weekly_delta,
+        days_of_data: rows.length,
+      },
+      generated_at: new Date().toISOString(),
+    });
+  } catch (err: any) {
+    console.warn(`[${VTID}] fetch failed: ${err?.message}`);
+    return res.status(500).json({ ok: false, error: err?.message || 'UNKNOWN' });
+  }
+});
+
+router.get('/current', requireTenantAdmin, async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+  const tenantId = req.params.tenantId || (req as any).targetTenantId;
+  if (!tenantId) return res.status(400).json({ ok: false, error: 'TENANT_ID_REQUIRED' });
+
+  const today = new Date().toISOString().slice(0, 10);
+  try {
+    const { data } = await supabase
+      .from('tenant_health_index_daily')
+      .select('snapshot_date, score, components, computed_at, source_version')
+      .eq('tenant_id', tenantId)
+      .lte('snapshot_date', today)
+      .order('snapshot_date', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    return res.json({ ok: true, tenant_id: tenantId, current: data ?? null });
+  } catch (err: any) {
+    return res.status(500).json({ ok: false, error: err?.message || 'UNKNOWN' });
+  }
+});
+
+router.post('/refresh', requireTenantAdmin, async (req: AuthenticatedRequest, res: Response) => {
+  const tenantId = req.params.tenantId || (req as any).targetTenantId;
+  if (!tenantId) return res.status(400).json({ ok: false, error: 'TENANT_ID_REQUIRED' });
+  try {
+    const result = await storeTenantHealthIndex(tenantId);
+    if (!result) return res.status(500).json({ ok: false, error: 'HEALTH_INDEX_COMPUTE_FAILED' });
+    return res.json({ ok: true, tenant_id: tenantId, ...result });
+  } catch (err: any) {
+    return res.status(500).json({ ok: false, error: err?.message || 'UNKNOWN' });
+  }
+});
+
+export default router;

--- a/services/gateway/src/services/admin-awareness-worker.ts
+++ b/services/gateway/src/services/admin-awareness-worker.ts
@@ -22,10 +22,11 @@
  */
 import { getSupabase } from '../lib/supabase';
 import { runAllScannersForTenant } from './admin-scanners';
+import { storeTenantHealthIndex } from './admin-health-index';
 
 const LOG_PREFIX = '[admin-kpi]';
 const WORKER_TICK_MS = 5 * 60 * 1000; // 5 minutes
-const WORKER_VERSION = 'phase-BB-CC.2026-04-21';
+const WORKER_VERSION = 'phase-BB-CC-GG.2026-04-22';
 
 type KpiPayload = Record<string, unknown>;
 
@@ -249,5 +250,21 @@ export async function computeAndStoreForTenant(tenantId: string): Promise<void> 
     }
   } catch (err: any) {
     console.warn(`${LOG_PREFIX} scanner runner failed ${tenantId.substring(0, 8)}...: ${err?.message}`);
+  }
+
+  // BOOTSTRAP-ADMIN-GG: compute + upsert tenant health index. Idempotent
+  // upsert by (tenant_id, snapshot_date=today), so the 5-min tick refreshes
+  // the score continuously but only a single row per day survives. Emits
+  // regression OASIS event when score drops > 10 points vs previous snapshot.
+  try {
+    const health = await storeTenantHealthIndex(tenantId);
+    if (health) {
+      console.log(
+        `${LOG_PREFIX} health-index tenant=${tenantId.substring(0, 8)}... ` +
+          `score=${health.score} components=${JSON.stringify(health.components)}`,
+      );
+    }
+  } catch (err: any) {
+    console.warn(`${LOG_PREFIX} health-index failed ${tenantId.substring(0, 8)}...: ${err?.message}`);
   }
 }

--- a/services/gateway/src/services/admin-health-index.ts
+++ b/services/gateway/src/services/admin-health-index.ts
@@ -1,0 +1,260 @@
+/**
+ * BOOTSTRAP-ADMIN-GG: Tenant Health Index computation.
+ *
+ * Computes a 0-100 composite health score per tenant from:
+ *   - tenant_kpi_current (engagement, community, autopilot families)
+ *   - admin_insights      (urgent + action_needed penalties)
+ *
+ * Components and weights (all normalised to 0-100):
+ *   engagement        30%
+ *   community         25%
+ *   autopilot         25%
+ *   insight_penalty   20%   (applied as a deduction from baseline 100)
+ *
+ * Soft-fails per component: if a family is missing or errored in KPIs,
+ * the component scores 60 ("neutral unknown") instead of blowing up.
+ */
+import { getSupabase } from '../lib/supabase';
+import { emitOasisEvent } from './oasis-event-service';
+
+const LOG_PREFIX = '[admin-health-index]';
+
+export const HEALTH_INDEX_VERSION = 'v1.2026-04-22';
+
+export interface HealthComponents {
+  engagement: number;
+  community: number;
+  autopilot: number;
+  insight_penalty: number;
+  urgent_insights: number;
+  action_needed_insights: number;
+}
+
+export interface HealthIndexResult {
+  score: number;
+  components: HealthComponents;
+}
+
+const WEIGHTS = {
+  engagement: 0.30,
+  community: 0.25,
+  autopilot: 0.25,
+  insight_penalty: 0.20,
+};
+
+function clamp(value: number, min = 0, max = 100): number {
+  return Math.max(min, Math.min(max, value));
+}
+
+function scoreEngagement(users: any): number {
+  if (!users || users.error) return 60;
+  const delta = typeof users.new_signups_7d_delta_pct === 'number'
+    ? users.new_signups_7d_delta_pct : 0;
+  const signups7d = typeof users.new_signups_7d === 'number' ? users.new_signups_7d : 0;
+  // Base: 60. Positive delta adds up to +40, negative subtracts. Volume gives a floor.
+  let score = 60;
+  if (delta >= 25) score += 30;
+  else if (delta >= 10) score += 15;
+  else if (delta >= -10) score += 0;
+  else if (delta >= -30) score -= 20;
+  else score -= 40;
+  // Volume nudge — a tenant with zero signups for a week scores lower regardless.
+  if (signups7d === 0) score -= 10;
+  else if (signups7d >= 10) score += 10;
+  return clamp(score);
+}
+
+function scoreCommunity(community: any): number {
+  if (!community || community.error) return 60;
+  const eventsThis = community.events_this_week ?? 0;
+  const eventsNext = community.events_next_week ?? 0;
+  const groups = community.groups_total ?? 0;
+  const newMembers = community.new_memberships_7d ?? 0;
+  let score = 50;
+  if (eventsThis >= 3) score += 15;
+  else if (eventsThis >= 1) score += 8;
+  else score -= 10;
+  if (eventsNext >= 1) score += 10;
+  if (groups >= 5) score += 10;
+  else if (groups >= 1) score += 5;
+  if (newMembers >= 5) score += 15;
+  else if (newMembers >= 1) score += 5;
+  return clamp(score);
+}
+
+function scoreAutopilot(autopilot: any): number {
+  if (!autopilot || autopilot.error) return 60;
+  const successRate: number | null = typeof autopilot.runs_success_rate_pct === 'number'
+    ? autopilot.runs_success_rate_pct : null;
+  const activations = autopilot.recommendations_activated_7d ?? 0;
+  const newRecs = autopilot.recommendations_new ?? 0;
+  // Base: tie to success rate when available; fall back to 70 when no runs yet.
+  let score = successRate !== null ? successRate : 70;
+  if (activations >= 3) score += 5;
+  if (newRecs >= 50) score -= 10; // deep queue of unacted recommendations
+  return clamp(score);
+}
+
+/**
+ * Compute how many open insights (urgent + action_needed) the tenant carries
+ * and convert that into a deduction applied to a baseline of 100.
+ * Each urgent costs 10 points, each action_needed costs 3, cap at 100.
+ */
+function scoreInsightPenalty(urgent: number, actionNeeded: number): { score: number } {
+  const deduction = Math.min(100, urgent * 10 + actionNeeded * 3);
+  return { score: clamp(100 - deduction) };
+}
+
+async function fetchOpenInsightCounts(tenantId: string): Promise<{ urgent: number; actionNeeded: number }> {
+  const supabase = getSupabase();
+  if (!supabase) return { urgent: 0, actionNeeded: 0 };
+  try {
+    const [{ count: urgent }, { count: actionNeeded }] = await Promise.all([
+      supabase
+        .from('admin_insights')
+        .select('id', { count: 'exact', head: true })
+        .eq('tenant_id', tenantId)
+        .eq('status', 'open')
+        .eq('severity', 'urgent'),
+      supabase
+        .from('admin_insights')
+        .select('id', { count: 'exact', head: true })
+        .eq('tenant_id', tenantId)
+        .eq('status', 'open')
+        .eq('severity', 'action_needed'),
+    ]);
+    return { urgent: urgent ?? 0, actionNeeded: actionNeeded ?? 0 };
+  } catch (err: any) {
+    console.warn(`${LOG_PREFIX} insight count failed: ${err?.message}`);
+    return { urgent: 0, actionNeeded: 0 };
+  }
+}
+
+export async function computeTenantHealthIndex(tenantId: string): Promise<HealthIndexResult | null> {
+  const supabase = getSupabase();
+  if (!supabase) return null;
+
+  try {
+    const [kpiRow, insightCounts] = await Promise.all([
+      supabase
+        .from('tenant_kpi_current')
+        .select('kpi')
+        .eq('tenant_id', tenantId)
+        .maybeSingle(),
+      fetchOpenInsightCounts(tenantId),
+    ]);
+
+    const kpi = (kpiRow.data?.kpi ?? {}) as Record<string, any>;
+    const engagement = scoreEngagement(kpi.users);
+    const community = scoreCommunity(kpi.community);
+    const autopilot = scoreAutopilot(kpi.autopilot);
+    const penalty = scoreInsightPenalty(insightCounts.urgent, insightCounts.actionNeeded);
+
+    const score = clamp(
+      Math.round(
+        engagement * WEIGHTS.engagement +
+          community * WEIGHTS.community +
+          autopilot * WEIGHTS.autopilot +
+          penalty.score * WEIGHTS.insight_penalty,
+      ),
+    );
+
+    return {
+      score,
+      components: {
+        engagement,
+        community,
+        autopilot,
+        insight_penalty: penalty.score,
+        urgent_insights: insightCounts.urgent,
+        action_needed_insights: insightCounts.actionNeeded,
+      },
+    };
+  } catch (err: any) {
+    console.warn(`${LOG_PREFIX} compute failed tenant=${tenantId.substring(0, 8)}...: ${err?.message}`);
+    return null;
+  }
+}
+
+/**
+ * Compute + upsert today's health index for this tenant. Emits OASIS events:
+ *   - tenant.health.computed                 (every run)
+ *   - tenant.health.regression_detected      (drop >10 points vs previous snapshot)
+ */
+export async function storeTenantHealthIndex(tenantId: string): Promise<HealthIndexResult | null> {
+  const supabase = getSupabase();
+  if (!supabase) return null;
+
+  const result = await computeTenantHealthIndex(tenantId);
+  if (!result) return null;
+
+  const today = new Date().toISOString().slice(0, 10); // YYYY-MM-DD
+
+  // Fetch previous snapshot for regression detection
+  let prevScore: number | null = null;
+  try {
+    const { data: prev } = await supabase
+      .from('tenant_health_index_daily')
+      .select('score, snapshot_date')
+      .eq('tenant_id', tenantId)
+      .lt('snapshot_date', today)
+      .order('snapshot_date', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (prev?.score !== null && prev?.score !== undefined) prevScore = prev.score;
+  } catch {
+    /* swallow — first snapshot */
+  }
+
+  const { error } = await supabase
+    .from('tenant_health_index_daily')
+    .upsert(
+      {
+        tenant_id: tenantId,
+        snapshot_date: today,
+        score: result.score,
+        components: result.components,
+        computed_at: new Date().toISOString(),
+        source_version: HEALTH_INDEX_VERSION,
+      },
+      { onConflict: 'tenant_id,snapshot_date' },
+    );
+  if (error) {
+    console.warn(`${LOG_PREFIX} upsert failed: ${error.message}`);
+    return result;
+  }
+
+  emitOasisEvent({
+    vtid: 'BOOTSTRAP-ADMIN-GG',
+    type: 'tenant.health.computed',
+    source: 'admin-awareness-worker',
+    status: 'info',
+    message: `Tenant health index computed: ${result.score}`,
+    payload: {
+      tenant_id: tenantId,
+      score: result.score,
+      prev_score: prevScore,
+      components: result.components,
+      snapshot_date: today,
+    },
+  }).catch(() => {});
+
+  if (prevScore !== null && result.score < prevScore - 10) {
+    emitOasisEvent({
+      vtid: 'BOOTSTRAP-ADMIN-GG',
+      type: 'tenant.health.regression_detected',
+      source: 'admin-awareness-worker',
+      status: 'warning',
+      message: `Tenant health index dropped ${prevScore - result.score} points (${prevScore} → ${result.score})`,
+      payload: {
+        tenant_id: tenantId,
+        prev_score: prevScore,
+        current_score: result.score,
+        delta: prevScore - result.score,
+        components: result.components,
+      },
+    }).catch(() => {});
+  }
+
+  return result;
+}

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -508,6 +508,10 @@ export type CicdEventType =
   // BOOTSTRAP-ADMIN-EE: proactive briefings + urgent notifications
   | 'admin.briefing.injected'
   | 'admin.insight.urgent_notified'
+  // BOOTSTRAP-ADMIN-GG: tenant health index
+  | 'tenant.health.computed'
+  | 'tenant.health.regression_detected'
+  | 'tenant.weekly.review.ready'
   // VTID-DIAG: Pipeline diagnostics
   | 'orb.live.diag'
   // VTID-FALLBACK: Chat-TTS fallback events

--- a/supabase/migrations/20260422130000_BOOTSTRAP_tenant_health_index.sql
+++ b/supabase/migrations/20260422130000_BOOTSTRAP_tenant_health_index.sql
@@ -1,0 +1,50 @@
+-- =============================================================================
+-- BOOTSTRAP-ADMIN-GG: Tenant Health Index
+--
+-- Daily composite health score 0-100 per tenant, computed from the KPI snapshot
+-- and open admin_insights. Stored once per (tenant, day) so weekly reviews +
+-- regression alerts can trend it over time.
+--
+-- Components (weights):
+--   engagement       30%  — signup velocity, delta vs prior week
+--   community        25%  — events scheduled, groups, new memberships
+--   autopilot        25%  — run success rate, activation flow
+--   insight_penalty  20%  — open urgent/action_needed insights subtract
+--
+-- Score = weighted average with insight penalty applied last.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.tenant_health_index_daily (
+  tenant_id      UUID NOT NULL,
+  snapshot_date  DATE NOT NULL,
+  score          INT NOT NULL CHECK (score >= 0 AND score <= 100),
+  components     JSONB NOT NULL DEFAULT '{}'::jsonb,
+  computed_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  source_version TEXT,
+  PRIMARY KEY (tenant_id, snapshot_date)
+);
+
+COMMENT ON TABLE public.tenant_health_index_daily IS
+  'BOOTSTRAP-ADMIN-GG: composite tenant health score 0-100 per day. Inputs: tenant_kpi_current + admin_insights. Output consumed by weekly review, regression alerts, admin dashboard.';
+
+CREATE INDEX IF NOT EXISTS tenant_health_index_daily_date_idx
+  ON public.tenant_health_index_daily (tenant_id, snapshot_date DESC);
+
+CREATE INDEX IF NOT EXISTS tenant_health_index_daily_computed_at_idx
+  ON public.tenant_health_index_daily (computed_at DESC);
+
+-- RLS: service-role only; admin routes read through gateway with tenant filter.
+ALTER TABLE public.tenant_health_index_daily ENABLE ROW LEVEL SECURITY;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (
+    SELECT 1 FROM pg_policies
+    WHERE schemaname = 'public'
+      AND tablename = 'tenant_health_index_daily'
+      AND policyname = 'service_role_all'
+  ) THEN
+    CREATE POLICY service_role_all ON public.tenant_health_index_daily
+      FOR ALL TO service_role USING (true) WITH CHECK (true);
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary

Phase GG. Computes a 0-100 composite tenant health score every 5 min (via admin-awareness-worker) and stores one snapshot per day for 90-day trend. Zero autonomous-execution risk — pure read-side computation.

## Components (normalised 0-100)

| Component | Weight | Inputs |
|---|---:|---|
| engagement | 30% | new_signups_7d_delta_pct, signup volume |
| community | 25% | events_this_week, events_next_week, groups, memberships |
| autopilot | 25% | runs_success_rate, activations, queue depth |
| insight_penalty | 20% | 100 − (10×urgent + 3×action_needed) |

Regression alert: score drop > 10 pts DoD emits `tenant.health.regression_detected`.

## Endpoints

- `GET /api/v1/admin/tenants/:tenantId/health-index` — current + 30d history + 7d mean trend
- `GET .../current` — latest only
- `POST .../refresh` — on-demand recompute

## Files

- Migration `20260422130000_BOOTSTRAP_tenant_health_index.sql` — run via RUN-MIGRATION after merge
- `services/admin-health-index.ts` (new)
- `services/admin-awareness-worker.ts` — wires storeTenantHealthIndex into tick
- `routes/tenant-admin/health-index.ts` (new) + mount
- `types/cicd.ts` — 3 new event types

## Verification

- [x] Typecheck clean
- [ ] Run migration post-merge
- [ ] Post-deploy: worker logs show `health-index tenant=… score=… components=…` per tick
- [ ] GET /health-index returns populated row once first tick lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)