### PR TITLE
fix(command-hub): stop orphaned Voice Lab auto-refresh causing sidebar flicker

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -15652,8 +15652,25 @@ function startVoiceLabAutoRefresh() {
     }
     console.log('[VTID-01218B] Starting auto-refresh (2s interval)');
     state.voiceLab.autoRefreshIntervalId = setInterval(function () {
-        if (state.voiceLab.activeSubTab === 'orb-live' && state.voiceLab.autoRefreshEnabled) {
+        // BOOTSTRAP-SIDEBAR-FLICKER-FIX: ORB Live is reachable from two paths
+        // (Diagnostics → Voice Lab AND Assistant → ORB Live). The Diagnostics
+        // path's renderVoiceLabView fires stopVoiceLabAutoRefresh when its
+        // activeSubTab changes, but the Assistant path doesn't — so the
+        // interval was orphaned and fetchVoiceLabSessionsSilent →
+        // updateVoiceLabSessionsTable → renderApp() fired every 2s on every
+        // other screen, resetting sidebar scroll and causing flicker.
+        //
+        // Now: only fetch when the ORB Live panel is actually in view. If
+        // not, self-cancel so we don't keep firing.
+        var onOrbLive =
+            (state.currentModuleKey === 'diagnostics' && state.currentTab === 'voice-lab'
+             && state.voiceLab.activeSubTab === 'orb-live')
+            || (state.currentModuleKey === 'assistant' && state.currentTab === 'orb-live');
+
+        if (onOrbLive && state.voiceLab.autoRefreshEnabled) {
             fetchVoiceLabSessionsSilent();
+        } else if (!onOrbLive) {
+            stopVoiceLabAutoRefresh();
         }
     }, 2000);
 }
@@ -15731,8 +15748,12 @@ function updateVoiceLabSessionsTable() {
 
     var tbody = document.querySelector('.voice-lab-sessions-table tbody');
     if (!tbody) {
-        // Table doesn't exist yet, do full render
-        renderApp();
+        // BOOTSTRAP-SIDEBAR-FLICKER-FIX: if the table isn't in the DOM we are
+        // NOT on the ORB Live panel — just bail. The previous behaviour of
+        // calling renderApp() here turned every orphaned interval tick into
+        // a full re-render (sidebar scroll reset, flicker). If the user is
+        // on the ORB Live panel and the table is genuinely still mounting,
+        // the next tick (2s later) will find it.
         return;
     }
 


### PR DESCRIPTION
User report after PR #816: sidebar can't scroll to bottom, jumps to top, flickers when changing sections.

Root cause: ORB Live is reachable from two paths now (Diagnostics → Voice Lab AND Assistant → ORB Live from #816). renderVoiceLabOrbLivePanel starts a 2s setInterval via startVoiceLabAutoRefresh. The legacy cleanup lived inside renderVoiceLabView (the Diagnostics wrapper) — only fires on that path. When users navigate away from Assistant → ORB Live, the interval stays alive, fires every 2s, and inside updateVoiceLabSessionsTable — when tbody isn't in DOM — calls renderApp() to 'do full render'. Result: full app re-render every 2s on every other screen, sidebar scroll resets each cycle, flicker.

Fix: startVoiceLabAutoRefresh's interval callback now checks the active route (module + tab) and self-cancels when the ORB Live panel isn't in view — covering both old and new paths. updateVoiceLabSessionsTable no longer calls renderApp() on missing tbody; it just bails. Next legitimate tick (2s later) finds the table if the user actually IS on the panel.

Pure frontend fix. No backend, no migrations, no state shape changes.

Generated with Claude Code