### PR TITLE
fix(command-hub): sidebar scroll no longer snaps to active module on every re-render

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -2836,6 +2836,11 @@ const state = {
     currentModuleKey: 'command-hub', // Will be overwritten by router
     currentTab: 'tasks', // Will be overwritten by router
     sidebarCollapsed: false,
+    // BOOTSTRAP-SIDEBAR-SCROLL-FIX: last module we scrolled the sidebar to.
+    // renderApp calls scrollIntoView on the active nav item; gating on this
+    // ref prevents every re-render from snapping scroll back to the active
+    // item after the user manually scrolled elsewhere.
+    _lastScrolledActiveModule: null,
 
     // Tasks
     tasks: [],
@@ -5137,14 +5142,19 @@ function _renderAppCore() {
     restoreAllScrollPositions(savedScrollPositions);
     attachScrollListeners();
 
-    // Ensure the active sidebar nav item is visible after render.
-    // The sidebar .nav-section is rebuilt on every render, so we scroll the
-    // active item into view rather than trying to restore an exact offset
-    // that becomes stale across route changes.
+    // Ensure the active sidebar nav item is visible after a module change.
+    // BOOTSTRAP-SIDEBAR-SCROLL-FIX: previously this fired on every renderApp
+    // — so any poller tick / badge update / silent refresh yanked the sidebar
+    // scroll back to the active item a few ms after the user manually
+    // scrolled elsewhere. Now we only scroll-into-view when the active
+    // module actually changes. Sidebar scroll retention wins on every other
+    // render.
     requestAnimationFrame(function () {
+        if (state._lastScrolledActiveModule === state.currentModuleKey) return;
         var activeNav = document.querySelector('.nav-section .nav-item.active');
         if (activeNav) {
             activeNav.scrollIntoView({ block: 'nearest' });
+            state._lastScrolledActiveModule = state.currentModuleKey;
         }
     });
 }


### PR DESCRIPTION
Follow-up to #817. Voice-lab auto-refresh was one cause of frequent renderApp ticks. But even after that fix, every renderApp cycle still ended with a scrollIntoView on the active sidebar nav item — overriding the scroll-retention system. Any poller / badge update / silent refresh yanked the sidebar back to the active item.

Fix: gate the scrollIntoView on whether the active module actually changed. state._lastScrolledActiveModule tracks the last-scrolled module. When it matches state.currentModuleKey, skip scrollIntoView entirely — scroll retention wins unopposed. When the user clicks a new module, the gate fires once, brings the new active into view, updates the tracker.

Behaviour: first page load scrolls (baseline), clicking a new module scrolls (expected), poller ticks / silent refreshes / badge updates / collapse toggles / form edits no longer move the sidebar. ~6 line delta.

Generated with Claude Code