### PR TITLE
fix(orb): force community role on all mobile sessions (BOOTSTRAP-ORB-MOBILE-ROLE)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -9725,8 +9725,13 @@ router.post('/live/session/start', optionalAuth, async (req: AuthenticatedReques
               const { buildBrainSystemInstruction } = await import('../services/vitana-brain');
               // VTID-ROLE-CMD-HUB: Infer developer role from Command Hub route
               const bodyRoute = typeof (body as any).current_route === 'string' ? (body as any).current_route : '';
-              const brainRole = bodyRoute.startsWith('/command-hub') ? 'developer'
-                : ((bootstrapIdentity as any).active_role || 'community');
+              // BOOTSTRAP-ORB-MOBILE-ROLE: Mobile (Appilix WebView / phone browsers) is community-only.
+              // Even if DB role is admin/developer/professional, mobile sessions must greet as community.
+              const brainRole = clientContext.isMobile
+                ? 'community'
+                : bodyRoute.startsWith('/command-hub')
+                  ? 'developer'
+                  : ((bootstrapIdentity as any).active_role || 'community');
               const { instruction, contextPack: cp } = await buildBrainSystemInstruction({
                 user_id: bootstrapIdentity.user_id,
                 tenant_id: bootstrapIdentity.tenant_id || 'default',
@@ -9761,6 +9766,14 @@ router.post('/live/session/start', optionalAuth, async (req: AuthenticatedReques
     if (sseRoute.startsWith('/command-hub') && (!sseActiveRole || sseActiveRole === 'community')) {
       console.log(`[VTID-01225-ROLE] Overriding role to "developer" for Command Hub session (was: ${sseActiveRole || 'null'})`);
       sseActiveRole = 'developer';
+    }
+
+    // BOOTSTRAP-ORB-MOBILE-ROLE: Mobile (Appilix WebView / phone browsers) is community-only.
+    // Runs AFTER the Command Hub override so mobile always wins, even if someone routes
+    // an Appilix WebView to /command-hub. Matches the frontend guard in useRole.tsx.
+    if (clientContext.isMobile && sseActiveRole !== 'community') {
+      console.log(`[BOOTSTRAP-ORB-MOBILE-ROLE] Forcing role to "community" for mobile session (was: ${sseActiveRole || 'null'})`);
+      sseActiveRole = 'community';
     }
 
     contextInstruction = bootstrapResult.contextInstruction;


### PR DESCRIPTION
## Problem

Logged-in admin/developer/professional users were being greeted by the ORB voice assistant **with their admin role** on the Vitana mobile app (Appilix WebView on Android). The rule has been: **mobile = community role only**, regardless of the user's DB role. The frontend `useRole.tsx` already enforces this for UI gating, but the ORB greeting is built server-side in `orb-live.ts` and was not checking the client platform.

Reproduced by the user this morning (2026-04-22): desktop session is admin, mobile session greets as admin.

## Fix

`POST /live/session/start` in `services/gateway/src/routes/orb-live.ts` now forces the role to `community` when `clientContext.isMobile === true`, in two places:

1. **`brainRole` picker** (used when Vitana Brain is enabled for ORB) — mobile short-circuits to `'community'` before the Command Hub / DB role branch runs.
2. **`sseActiveRole` post-resolution** — placed **after** the existing Command Hub override so that mobile always wins, even if an Appilix WebView somehow navigates to `/command-hub`.

`clientContext.isMobile` is already populated via `parseUserAgent()` from the User-Agent header in `buildClientContext()` — no new signal from the frontend is required.

## Test plan

- [ ] After deploy: mobile session (Appilix WebView / phone browser) greeting uses community tone, no admin briefing
- [ ] Desktop admin session still gets admin greeting (no regression)
- [ ] Desktop at /command-hub still gets developer greeting (no regression)
- [ ] Gateway logs show [BOOTSTRAP-ORB-MOBILE-ROLE] override entry for mobile sessions where DB role differs from community

Generated with Claude Code