### PR TITLE
feat(orb): teach Vitana Assistant to handle Vitana Index questions

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -4274,7 +4274,11 @@ ${profileSummary}
   - [ACTIVITY_14D]     → one-line counted summary of the last 14 days.
   - [ROUTINES]         → time-of-day / rhythm patterns.
   - [PREFERENCES]      → explicit + inferred preferences (music genre, food, etc.).
-  - [HEALTH]           → Vitana Index + biomarker/supplement activity.
+  - [HEALTH]           → Vitana Index (total + tier + 6 pillars + 7-day trend +
+                          weakest pillar + 90-day goal gap), recent biomarker
+                          uploads, supplements. The Vitana Index is the user's
+                          health-progress score (0–999, 6 pillars × 200) — it
+                          is THE single number that measures their journey.
   - [CONTENT_PLAYED]   → songs, podcasts, shorts, videos this user played
                           (ANY DEVICE — desktop, mobile, Appilix WebView — the
                           timeline is server-side and shared across devices).
@@ -4338,7 +4342,57 @@ was habe ich heute gemacht / what music did I play":**
 
 7. Weave the answer naturally — do not recite section headers or bracket
    tags. The user should hear a warm conversational sentence, not a dump of
-   structured data.`;
+   structured data.
+
+**VITANA INDEX QUESTIONS — special treatment** (BOOTSTRAP-ORB-INDEX-AWARENESS):
+
+When the user asks anything about THEIR Vitana Index, score, tier, pillars,
+or how to improve / level up — examples:
+  - "What is my Vitana Index?" / "Was ist mein Vitana Index?"
+  - "What's my score / tier?"
+  - "How can I improve my index?" / "Wie kann ich meinen Index verbessern?"
+  - "What's holding me back?" / "Welche Säule ist am schwächsten?"
+  - "Make me a plan to improve" / "Mach mir einen Plan"
+
+Apply these rules:
+
+A. ALWAYS quote the [HEALTH] block first. Lead with the number + tier and,
+   if a 7-day trend is present, mention the direction. Example (de):
+     ✓ "Du bist aktuell bei 612 — Tier 'Good'. In den letzten sieben Tagen
+        ist er um acht Punkte gestiegen — du bewegst dich in die richtige
+        Richtung."
+     ✗ "I don't know your Vitana Index" (the number IS in [HEALTH] above)
+     ✗ "I don't have access to your health data" (you do — quote [HEALTH])
+
+B. For "how can I improve / what's holding me back / which pillar is
+   lowest" — name the WEAKEST pillar from [HEALTH] explicitly. If a list of
+   recommended actions is present in the profile, name 2–3 of them
+   conversationally. Example (en):
+     ✓ "Mental is your lowest pillar at 95 out of 200. The actions that
+        would lift it most are a daily ten-minute meditation and a long
+        walk twice a week."
+
+C. For "make me a plan / schedule it / add to my calendar" — if a planning
+   tool exists for the Index (e.g. a future create_index_improvement_plan
+   tool), call it. If not, propose a small concrete plan in voice and offer
+   to add the events one by one via the existing create_calendar_event tool.
+   Always confirm what was scheduled in voice ("I added three movement
+   sessions this week and two mindfulness blocks across next week").
+
+D. Generic "what IS the Vitana Index" / "how does it work" (no "my") —
+   these are platform-explanation questions. Use the Knowledge Hub via
+   search_knowledge — there are dedicated docs explaining the 6 pillars,
+   tiers, and how completions move the score. Do NOT confuse this with
+   the personal-data path above; "MY index" needs personal data, "THE index"
+   needs the KB doc.
+
+E. NEVER cite the Index number from memory_facts or general memory. The
+   [HEALTH] block is fresher and authoritative. memory_facts may contain a
+   stale number from days ago — never quote it.
+
+F. The Vitana Index is the user's KEY progress measure across the 90-day
+   journey. Treat it with the same priority as their name or birthday — if
+   they ask, you ALWAYS answer. The journey IS the route to lift it.`;
     }
   }
 

--- a/services/gateway/src/services/retrieval-router.ts
+++ b/services/gateway/src/services/retrieval-router.ts
@@ -95,6 +95,39 @@ const ROUTING_RULES: RoutingRule[] = [
     rationale: 'Vitana system questions prioritize Knowledge Hub for accurate documentation',
   },
 
+  // ===== Personal Vitana Index Questions → User Data First =====
+  // BOOTSTRAP-ORB-INDEX-AWARENESS: when the user asks about THEIR Index,
+  // tier, pillars, or how to improve THEIR score, route to user data
+  // (memory garden + autopilot recommendations) first, then to KB
+  // narrative. Generic "what IS the Vitana Index?" stays at vitana_system
+  // (priority 100) and goes to KB docs. Sits BETWEEN vitana_system (100)
+  // and personal_history (90) so it wins on "MY index" while leaving "the
+  // index" to the higher-priority KB route.
+  {
+    name: 'personal_index',
+    priority: 95,
+    patterns: [
+      /\bmy (vitana )?(index|score|tier|pillars?|s\u00e4ul[en]?)/i,
+      /\bmein(en|e)? (vitana )?(index|score|tier|s\u00e4ul[en]?)/i,
+      /how (do|can) i (improve|raise|lift|boost) (my )?(index|score|tier)/i,
+      /(verbess|improv|raise|lift|boost).*(meinen?|my)\s*(vitana )?(index|score|s\u00e4ul[en]?)/i,
+      /what(\u2019|')?s (holding me back|my weakest)/i,
+      /(make|build|set up|create)\s+(me\s+)?a?\s*plan.*(index|score|pillar|s\u00e4ule)/i,
+      /(plan|schedule).*(improve|verbess).*(index|score|tier|s\u00e4ule)/i,
+    ],
+    keywords: [
+      'my index', 'my vitana index', 'my score', 'my tier', 'my pillar', 'my pillars',
+      'mein index', 'mein vitana index', 'meinen index', 'meine s\u00e4ule',
+      'improve my index', 'raise my score', 'lift my index', 'boost my tier',
+      'verbessere meinen index', 'verbesser meinen score',
+      'weakest pillar', 'lowest pillar', 'schw\u00e4chste s\u00e4ule',
+      'plan to improve', 'plan zur verbesserung',
+    ],
+    primary_source: 'memory_garden',
+    secondary_sources: ['knowledge_hub'],
+    rationale: 'Personal Index questions need the live score + user-specific recommendations. Memory Garden first surfaces the [HEALTH] profile block (current score, pillars, weakest, trend, goal gap); KB docs supplement with explanation when asked.',
+  },
+
   // ===== Personal/Historical Questions → Memory Garden First =====
   {
     name: 'personal_history',


### PR DESCRIPTION
User report: asked ORB 'what is my Vitana Index?' — got 'I don't know'. Asked 'help me improve' — got 'I don't know how'. The Index is the key 90-day progress measure; the Assistant must always answer.

Two no-dependency wirings (data-side enrichment is gated on parallel plan community-user-role-make-purring-pascal Phase A landing).

1) ACTIVITY AWARENESS OVERRIDE block in buildLiveSystemInstruction gets a new 'VITANA INDEX QUESTIONS' section with six rules: always quote [HEALTH] first; for 'how can I improve' name the weakest pillar + 2-3 actions; for 'make me a plan' use the planning tool when shipped, otherwise propose in voice and use create_calendar_event; generic 'what IS the Vitana Index' (no 'my') goes to KB via search_knowledge; never quote the Index from memory_facts ([HEALTH] is fresher); treat the Index with the priority of name/birthday — always answer.

The SECTION KEY for [HEALTH] is expanded to explicitly name the Index as the user's single 90-day progress measure.

2) New retrieval-router rule 'personal_index', priority 95 (between vitana_system at 100 and personal_history at 90). EN + DE patterns/keywords for 'my index', 'mein index', 'improve my index', 'weakest pillar', 'make a plan'. primary_source: memory_garden ([HEALTH] block). secondary_sources: knowledge_hub. Generic 'what IS the Vitana Index' continues routing to vitana_system (priority 100) → KB doc.

What this PR does NOT do (deliberately gated on parallel plan): enrich buildHealthSection (needs real pillars), add three ORB tools (get_vitana_index / improvement_suggestions / improvement_plan), mark vitana_index sub-signals live in awareness-registry. All in PR #2 once Phase A lands.

Pure prompt + routing. No DB, no tables, no endpoints.

Generated with Claude Code