### PR TITLE
feat(vitana-index): wire Index real end-to-end (Phase A + D)

### DIFF
--- a/services/gateway/src/routes/health.ts
+++ b/services/gateway/src/routes/health.ts
@@ -552,6 +552,8 @@ router.post('/recompute/daily', async (req: Request, res: Response) => {
         score_nutritional: indexResult.score_nutritional,
         score_social: indexResult.score_social,
         score_environmental: indexResult.score_environmental,
+        score_prosperity: indexResult.score_prosperity,
+        pillar_weights: indexResult.pillar_weights,
         model_version: indexResult.model_version,
         confidence: indexResult.confidence,
       },
@@ -636,6 +638,7 @@ router.get('/summary', async (req: Request, res: Response) => {
             score_nutritional: indexData.score_nutritional,
             score_social: indexData.score_social,
             score_environmental: indexData.score_environmental,
+            score_prosperity: indexData.score_prosperity,
             model_version: indexData.model_version,
             confidence: indexData.confidence,
           }
@@ -659,6 +662,134 @@ router.get('/summary', async (req: Request, res: Response) => {
 });
 
 /**
+ * POST /baseline-survey
+ *
+ * Seeds the Day-0 Vitana Index from a 3-question onboarding self-rating.
+ * Writes answers to vitana_index_baseline_survey, then seeds
+ * health_features_daily rows that the compute RPC will pick up, then
+ * triggers the compute pipeline for today.
+ *
+ * Request body:
+ *   { "physical": 1-5, "mental": 1-5, "nutritional": 1-5, "notes"?: string }
+ *
+ * Idempotent via UNIQUE(user_id) on vitana_index_baseline_survey — a second
+ * submission updates the existing row.
+ */
+router.post('/baseline-survey', async (req: Request, res: Response) => {
+  const token = getBearerToken(req);
+  if (!token) {
+    return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+  }
+
+  const { physical, mental, nutritional, notes } = req.body ?? {};
+  const ratings = { physical, mental, nutritional };
+  for (const [key, val] of Object.entries(ratings)) {
+    if (typeof val !== 'number' || val < 1 || val > 5 || !Number.isInteger(val)) {
+      return res.status(400).json({
+        ok: false,
+        error: 'INVALID_RATING',
+        message: `${key} must be an integer between 1 and 5`,
+      });
+    }
+  }
+
+  const today = new Date().toISOString().slice(0, 10);
+  const supabase = createUserSupabaseClient(token);
+
+  try {
+    const { data: ctx, error: ctxErr } = await supabase.rpc('me_context');
+    if (ctxErr || !ctx?.user_id || !ctx?.tenant_id) {
+      return res.status(401).json({ ok: false, error: 'NO_CONTEXT' });
+    }
+
+    const answers = { physical, mental, nutritional, notes: notes ?? null };
+    const { error: surveyErr } = await supabase
+      .from('vitana_index_baseline_survey')
+      .upsert({ user_id: ctx.user_id, answers, completed_at: new Date().toISOString() }, { onConflict: 'user_id' });
+
+    if (surveyErr) {
+      console.error(`[${VTID_C3}] baseline-survey upsert failed:`, surveyErr.message);
+      return res.status(400).json({ ok: false, error: surveyErr.message });
+    }
+
+    // Seed health_features_daily so the compute RPC has something to score.
+    // Scale 1-5 → heart_rate/stress/glucose proxies that hit the "good" band
+    // when the user rated themselves well.
+    const ratingToHeartRate = { 1: 95, 2: 88, 3: 75, 4: 70, 5: 65 } as const;
+    const ratingToStress = { 1: 85, 2: 65, 3: 45, 4: 25, 5: 15 } as const;
+    const ratingToGlucose = { 1: 130, 2: 115, 3: 95, 4: 85, 5: 80 } as const;
+
+    const features = [
+      { feature_key: 'wearable_heart_rate', feature_value: ratingToHeartRate[physical as 1|2|3|4|5], feature_unit: 'bpm' },
+      { feature_key: 'wearable_stress',     feature_value: ratingToStress[mental as 1|2|3|4|5],      feature_unit: 'pct' },
+      { feature_key: 'biomarker_glucose',   feature_value: ratingToGlucose[nutritional as 1|2|3|4|5], feature_unit: 'mg/dL' },
+    ];
+
+    for (const f of features) {
+      await supabase.from('health_features_daily').upsert({
+        tenant_id: ctx.tenant_id,
+        user_id: ctx.user_id,
+        date: today,
+        feature_key: f.feature_key,
+        feature_value: f.feature_value,
+        feature_unit: f.feature_unit,
+        sample_count: 1,
+        confidence: 0.5,
+      }, { onConflict: 'tenant_id,user_id,date,feature_key' });
+    }
+
+    // Compute the Index
+    const { data: indexResult, error: indexErr } = await supabase.rpc(
+      'health_compute_vitana_index',
+      { p_date: today, p_model_version: 'baseline-survey-v1' }
+    );
+
+    if (indexErr || !indexResult?.ok) {
+      console.error(`[${VTID_C3}] baseline compute failed:`, indexErr?.message || indexResult);
+      return res.status(400).json({ ok: false, error: 'COMPUTE_FAILED', detail: indexErr?.message });
+    }
+
+    await emitHealthComputeEvent(
+      'health.compute.baseline_survey',
+      'success',
+      `Baseline survey seeded Day-0 Index: ${indexResult.score_total}`,
+      { user_id: ctx.user_id, score_total: indexResult.score_total, answers }
+    );
+
+    return res.status(200).json({ ok: true, date: today, index: indexResult });
+  } catch (err: any) {
+    console.error(`[${VTID_C3}] POST /health/baseline-survey error:`, err.message);
+    return res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+/**
+ * GET /baseline-survey/status
+ *
+ * Returns { completed: bool } so the frontend can decide whether to show the
+ * baseline survey modal on first /health load.
+ */
+router.get('/baseline-survey/status', async (req: Request, res: Response) => {
+  const token = getBearerToken(req);
+  if (!token) {
+    return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+  }
+  try {
+    const supabase = createUserSupabaseClient(token);
+    const { data, error } = await supabase
+      .from('vitana_index_baseline_survey')
+      .select('completed_at')
+      .maybeSingle();
+    if (error) {
+      return res.status(400).json({ ok: false, error: error.message });
+    }
+    return res.status(200).json({ ok: true, completed: !!data, completed_at: data?.completed_at ?? null });
+  } catch (err: any) {
+    return res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+/**
  * GET /
  *
  * Health router status endpoint
@@ -674,6 +805,8 @@ router.get('/', (_req: Request, res: Response) => {
       'POST /api/v1/health/wearables/ingest',
       'POST /api/v1/health/recompute/daily',
       'GET /api/v1/health/summary?date=YYYY-MM-DD',
+      'POST /api/v1/health/baseline-survey',
+      'GET /api/v1/health/baseline-survey/status',
     ],
     timestamp: new Date().toISOString(),
   });

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -220,6 +220,7 @@ export type CicdEventType =
   | 'health.compute.vitana_index'
   | 'health.recommendations.refresh'
   | 'health.compute.error'
+  | 'health.compute.baseline_survey'
   // VTID-01105: Memory Write Events
   | 'memory.write'
   | 'memory.read'

--- a/supabase/migrations/20260422150000_vitana_index_prosperity_and_weights.sql
+++ b/supabase/migrations/20260422150000_vitana_index_prosperity_and_weights.sql
@@ -1,0 +1,242 @@
+-- =============================================================================
+-- Vitana Index — 6th pillar (Prosperity) + config-driven pillar weights
+-- Date: 2026-04-22
+-- Plan: .claude/plans/community-user-role-make-purring-pascal.md (Phase A1 + A2)
+--
+-- Brings the compute RPC in line with the 6-pillar architecture described in
+-- the Proactive Guide plan. Two changes:
+--   1. score_prosperity (column already exists, added 2026-04-18) is now
+--      written by health_compute_vitana_index() — baseline 100 until a real
+--      Prosperity signal source lands in Phase 1c of the Proactive Guide plan.
+--   2. vitana_index_config gains a pillar_weights jsonb column, default 1.0
+--      per pillar (backward-compatible). The RPC multiplies each pillar by
+--      its weight before summing.
+--
+-- Cap stays at 999 (existing scoring_tiers are calibrated against 0-999).
+-- Retiring the cap to 1200 is a later tier-recalibration task.
+-- =============================================================================
+
+BEGIN;
+
+-- -----------------------------------------------------------------------------
+-- 1. pillar_weights column on vitana_index_config
+-- -----------------------------------------------------------------------------
+ALTER TABLE public.vitana_index_config
+  ADD COLUMN IF NOT EXISTS pillar_weights jsonb NOT NULL DEFAULT
+    '{"physical":1.0,"mental":1.0,"nutritional":1.0,"social":1.0,"environmental":1.0,"prosperity":1.0}'::jsonb;
+
+COMMENT ON COLUMN public.vitana_index_config.pillar_weights IS
+  'Per-pillar multiplier applied by health_compute_vitana_index(). Default 1.0 per pillar = equal weighting (backward-compatible). Admin-tunable via Vitana Index Config UI. Accepted keys: physical, mental, nutritional, social, environmental, prosperity.';
+
+-- Backfill: ensure every existing config row has all 6 keys (merge default
+-- into whatever's there today).
+UPDATE public.vitana_index_config
+SET pillar_weights = '{"physical":1.0,"mental":1.0,"nutritional":1.0,"social":1.0,"environmental":1.0,"prosperity":1.0}'::jsonb || COALESCE(pillar_weights, '{}'::jsonb)
+WHERE pillar_weights IS NULL
+   OR NOT (pillar_weights ? 'physical'
+       AND pillar_weights ? 'mental'
+       AND pillar_weights ? 'nutritional'
+       AND pillar_weights ? 'social'
+       AND pillar_weights ? 'environmental'
+       AND pillar_weights ? 'prosperity');
+
+-- -----------------------------------------------------------------------------
+-- 2. health_compute_vitana_index() v2 — 6 pillars + weights
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.health_compute_vitana_index(
+    p_date DATE,
+    p_model_version TEXT DEFAULT 'v2'
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_user_id UUID;
+    v_tenant_id UUID;
+    v_feature_inputs JSONB := '{}'::JSONB;
+    v_score_physical INTEGER := 100;
+    v_score_mental INTEGER := 100;
+    v_score_nutritional INTEGER := 100;
+    v_score_social INTEGER := 100;
+    v_score_environmental INTEGER := 100;
+    v_score_prosperity INTEGER := 100;
+    v_score_total INTEGER := 0;
+    v_confidence NUMERIC := 1.0;
+    v_feature RECORD;
+    v_feature_count INTEGER := 0;
+    v_weights JSONB;
+    v_w_physical NUMERIC := 1.0;
+    v_w_mental NUMERIC := 1.0;
+    v_w_nutritional NUMERIC := 1.0;
+    v_w_social NUMERIC := 1.0;
+    v_w_environmental NUMERIC := 1.0;
+    v_w_prosperity NUMERIC := 1.0;
+BEGIN
+    -- Gate 1: authenticated user
+    v_user_id := auth.uid();
+    IF v_user_id IS NULL THEN
+        RETURN jsonb_build_object('ok', false, 'error', 'UNAUTHENTICATED');
+    END IF;
+
+    -- Gate 2: tenant context
+    v_tenant_id := public.current_tenant_id();
+    IF v_tenant_id IS NULL THEN
+        RETURN jsonb_build_object('ok', false, 'error', 'NO_TENANT');
+    END IF;
+
+    -- Collect feature inputs
+    FOR v_feature IN
+        SELECT feature_key, feature_value, confidence
+        FROM public.health_features_daily
+        WHERE user_id = v_user_id AND tenant_id = v_tenant_id AND date = p_date
+    LOOP
+        v_feature_inputs := v_feature_inputs || jsonb_build_object(v_feature.feature_key, v_feature.feature_value);
+        v_feature_count := v_feature_count + 1;
+    END LOOP;
+
+    -- Pillar 1: Physical (heart rate heuristic — unchanged from v1)
+    SELECT COALESCE(LEAST(200, GREATEST(0,
+        COALESCE((SELECT
+            CASE
+                WHEN feature_value BETWEEN 60 AND 100 THEN 180
+                WHEN feature_value BETWEEN 50 AND 110 THEN 150
+                ELSE 100
+            END
+        FROM public.health_features_daily
+        WHERE user_id = v_user_id AND tenant_id = v_tenant_id AND date = p_date
+          AND feature_key = 'wearable_heart_rate'), 100)
+    )), 100) INTO v_score_physical;
+
+    -- Pillar 2: Mental (stress heuristic — unchanged from v1)
+    SELECT COALESCE(LEAST(200, GREATEST(0,
+        COALESCE((SELECT
+            CASE
+                WHEN feature_value < 30 THEN 180
+                WHEN feature_value < 50 THEN 150
+                WHEN feature_value < 70 THEN 100
+                ELSE 50
+            END
+        FROM public.health_features_daily
+        WHERE user_id = v_user_id AND tenant_id = v_tenant_id AND date = p_date
+          AND feature_key = 'wearable_stress'), 100)
+    )), 100) INTO v_score_mental;
+
+    -- Pillar 3: Nutritional (glucose heuristic — unchanged from v1)
+    SELECT COALESCE(LEAST(200, GREATEST(0,
+        COALESCE((SELECT
+            CASE
+                WHEN feature_value BETWEEN 70 AND 100 THEN 180
+                WHEN feature_value BETWEEN 60 AND 125 THEN 150
+                ELSE 100
+            END
+        FROM public.health_features_daily
+        WHERE user_id = v_user_id AND tenant_id = v_tenant_id AND date = p_date
+          AND feature_key = 'biomarker_glucose'), 100)
+    )), 100) INTO v_score_nutritional;
+
+    -- Pillar 4: Social — baseline until Proactive Guide Phase 1a wires real signals
+    v_score_social := 100;
+
+    -- Pillar 5: Environmental — baseline until Proactive Guide Phase 1b
+    v_score_environmental := 100;
+
+    -- Pillar 6: Prosperity — baseline until Proactive Guide Phase 1c
+    v_score_prosperity := 100;
+
+    -- Read active config weights (default 1.0 each if no config or missing keys)
+    SELECT pillar_weights INTO v_weights
+    FROM public.vitana_index_config
+    WHERE is_active = TRUE
+    ORDER BY version DESC
+    LIMIT 1;
+
+    IF v_weights IS NOT NULL THEN
+        v_w_physical      := COALESCE((v_weights->>'physical')::NUMERIC, 1.0);
+        v_w_mental        := COALESCE((v_weights->>'mental')::NUMERIC, 1.0);
+        v_w_nutritional   := COALESCE((v_weights->>'nutritional')::NUMERIC, 1.0);
+        v_w_social        := COALESCE((v_weights->>'social')::NUMERIC, 1.0);
+        v_w_environmental := COALESCE((v_weights->>'environmental')::NUMERIC, 1.0);
+        v_w_prosperity    := COALESCE((v_weights->>'prosperity')::NUMERIC, 1.0);
+    END IF;
+
+    -- Total = sum of weighted pillars, clamped to [0, 999]
+    v_score_total := LEAST(999, GREATEST(0, ROUND(
+          (v_score_physical      * v_w_physical)
+        + (v_score_mental        * v_w_mental)
+        + (v_score_nutritional   * v_w_nutritional)
+        + (v_score_social        * v_w_social)
+        + (v_score_environmental * v_w_environmental)
+        + (v_score_prosperity    * v_w_prosperity)
+    )::INTEGER));
+
+    -- Confidence from feature availability
+    IF v_feature_count = 0 THEN
+        v_confidence := 0.1;
+    ELSIF v_feature_count < 3 THEN
+        v_confidence := 0.5;
+    ELSE
+        v_confidence := 0.9;
+    END IF;
+
+    -- Upsert
+    INSERT INTO public.vitana_index_scores (
+        tenant_id, user_id, date, score_total,
+        score_physical, score_mental, score_nutritional,
+        score_social, score_environmental, score_prosperity,
+        model_version, feature_inputs, confidence
+    ) VALUES (
+        v_tenant_id, v_user_id, p_date, v_score_total,
+        v_score_physical, v_score_mental, v_score_nutritional,
+        v_score_social, v_score_environmental, v_score_prosperity,
+        p_model_version, v_feature_inputs, v_confidence
+    )
+    ON CONFLICT (tenant_id, user_id, date) DO UPDATE SET
+        score_total = EXCLUDED.score_total,
+        score_physical = EXCLUDED.score_physical,
+        score_mental = EXCLUDED.score_mental,
+        score_nutritional = EXCLUDED.score_nutritional,
+        score_social = EXCLUDED.score_social,
+        score_environmental = EXCLUDED.score_environmental,
+        score_prosperity = EXCLUDED.score_prosperity,
+        model_version = EXCLUDED.model_version,
+        feature_inputs = EXCLUDED.feature_inputs,
+        confidence = EXCLUDED.confidence,
+        updated_at = NOW();
+
+    RETURN jsonb_build_object(
+        'ok', true,
+        'date', p_date,
+        'score_total', v_score_total,
+        'score_physical', v_score_physical,
+        'score_mental', v_score_mental,
+        'score_nutritional', v_score_nutritional,
+        'score_social', v_score_social,
+        'score_environmental', v_score_environmental,
+        'score_prosperity', v_score_prosperity,
+        'pillar_weights', jsonb_build_object(
+            'physical', v_w_physical,
+            'mental', v_w_mental,
+            'nutritional', v_w_nutritional,
+            'social', v_w_social,
+            'environmental', v_w_environmental,
+            'prosperity', v_w_prosperity
+        ),
+        'model_version', p_model_version,
+        'feature_count', v_feature_count,
+        'confidence', v_confidence,
+        'tenant_id', v_tenant_id,
+        'user_id', v_user_id
+    );
+END;
+$$;
+
+COMMIT;
+
+-- =============================================================================
+-- Rollback notes (manual):
+--   DROP FUNCTION health_compute_vitana_index(date, text);
+--   (then re-apply the original v1 RPC from 20251231000000_vtid_01103_health_compute_engine.sql)
+--   ALTER TABLE vitana_index_config DROP COLUMN pillar_weights;
+-- =============================================================================

--- a/supabase/migrations/20260422160000_vitana_index_kb_docs.sql
+++ b/supabase/migrations/20260422160000_vitana_index_kb_docs.sql
@@ -1,0 +1,368 @@
+-- =============================================================================
+-- Vitana Index onboarding — Knowledge Hub seed (vitana_system namespace)
+-- Date: 2026-04-22
+-- Plan: .claude/plans/community-user-role-make-purring-pascal.md (Phase D)
+--
+-- Seeds the user-facing documentation that ties the Vitana Index, the 90-day
+-- Maxina journey, the Calendar, and the Autopilot into one coherent story
+-- the Assistant can retrieve and quote when asked "how does my Index work?"
+-- or "how do I level up?". All docs are tagged `vitana_system` so they flow
+-- through the priority-100 retrieval rule in retrieval-router.ts.
+--
+-- Idempotent via upsert_knowledge_doc() — safe to re-run when docs are
+-- revised.
+-- =============================================================================
+
+-- ===========================================================================
+-- DOC 1 — Vitana Index explained (the anchor doc)
+-- ===========================================================================
+
+SELECT public.upsert_knowledge_doc(
+  p_title := 'Vitana Index — what it is and how it moves',
+  p_path  := 'kb/vitana-system/vitana-index-explained.md',
+  p_source_type := 'markdown',
+  p_tags  := ARRAY['vitana_system','vitana-index','longevity','onboarding','maxina'],
+  p_content := $CONTENT$
+# Vitana Index — what it is and how it moves
+
+Your Vitana Index is a single number between 0 and 999 that answers one
+question: **how well is today compounding into a longer, healthier,
+more fulfilling life?**
+
+The higher the number, the more your daily behaviour is aligned with
+longevity. The lower the number, the more the system has to suggest to
+lift you back on track. It is the one score you can keep in your eye
+across every screen in Maxina and Vitana.
+
+## The six pillars
+
+Your Index is the weighted sum of six pillars, each scored 0–200:
+
+1. **Physical** — Movement, heart rate, sleep and recovery signals.
+2. **Mental** — Stress, mindfulness, cognitive load and mood.
+3. **Nutritional** — Glucose, hydration, macro balance and meal timing.
+4. **Social** — Relationships, community engagement, connection quality.
+5. **Environmental** — Time outdoors, living-space quality, exposure.
+6. **Prosperity** — Business progress, marketplace activity, rewards.
+
+At launch, Physical / Mental / Nutritional read real data from your
+wearables and lab results. Social, Environmental and Prosperity start at
+a neutral baseline and will read their own signal sources as each feature
+area lands (Proactive Guide phase 1a–1c).
+
+## The tiers
+
+| Range | Tier | Meaning |
+|---|---|---|
+| 0–99 | Very Poor | Significant concerns across multiple pillars |
+| 100–299 | Poor | Below optimal — real room to grow |
+| 300–499 | Fair | Moderate well-being, mixed signals |
+| 500–699 | Improving | Good progress toward optimal |
+| 700–849 | Good | Strong well-being across most pillars |
+| 850–999 | Excellent | Exceptional optimisation |
+
+Your Maxina 90-day goal by default is **Good (600+)** — we aim to lift
+your Index into that band within your first 90 days.
+
+## Where you see it
+
+- **Every screen header** — the circle badge with your current number
+  (tap it for the full Index Detail Screen).
+- **Health section** — the full breakdown by pillar, with 7-day trend.
+- **My Journey (`/autopilot`)** — your trajectory across the 90-day
+  timeline, pillar-by-pillar.
+- **Autopilot popup** — each suggested action shows which pillars it
+  lifts and by how much.
+
+## How it moves
+
+Your Index recomputes daily and incrementally whenever you complete an
+action. Three things push it up:
+
+1. **Completing Autopilot actions** — each action declares a
+   contribution vector (e.g., a 30-minute walk = `Physical +3 Mental +1`).
+   When you mark it done on your calendar, that contribution lands.
+2. **Fresh data arriving** — wearable syncs, lab reports and community
+   signals update the pillar readings the Index is built from.
+3. **Habit consistency** — long streaks of a positive signal compound
+   faster than one-off spikes.
+
+Two things can hold it back:
+
+1. **Missing data** — if we can't read your wearable, Physical stays at
+   a conservative baseline. Connect devices to let the Index see you.
+2. **Declining pillar signals** — if your sleep or stress drifts, the
+   pillar will drift with it. The Proactive Guide notices and surfaces
+   an action that targets exactly that pillar.
+
+## The Day-0 baseline survey
+
+On your very first visit to the Health screen, Maxina asks three quick
+self-rating questions (physical, mental, nutritional). Those answers seed
+a confidence-0.5 baseline so you're never staring at an empty score. As
+your real data arrives over the following days, the baseline gives way
+to real signals.
+
+## How the Assistant uses your Index
+
+When you talk to Maxina, she always knows your current Index, your
+weakest pillar, and your 90-day trajectory. When you ask a question, she
+frames recommendations in terms of which pillar to lift next — not
+abstractly, but concretely: "Your Physical dropped 12 points this week —
+want me to put a 20-minute walk on tomorrow morning?"
+
+## Privacy
+
+Your Index is yours. It is never shared outside your tenant. Community
+aggregates (later phases) use only anonymous tier distributions and
+never reveal individual scores.
+$CONTENT$
+);
+
+
+-- ===========================================================================
+-- DOC 2 — 90-day journey and your Index
+-- ===========================================================================
+
+SELECT public.upsert_knowledge_doc(
+  p_title := '90-day Maxina journey — the route to a higher Index',
+  p_path  := 'kb/vitana-system/90-day-journey-and-your-index.md',
+  p_source_type := 'markdown',
+  p_tags  := ARRAY['vitana_system','vitana-index','90-day-journey','autopilot','calendar','maxina'],
+  p_content := $CONTENT$
+# 90-day Maxina journey — the route to a higher Index
+
+When you register for Vitana, Maxina pre-populates your calendar with
+roughly 30 wellness events spread across 90 days. This is your default
+Maxina journey. You can adapt it, speed it up, slow it down, or ignore
+parts — but the calendar is never empty.
+
+## Six waves
+
+The journey is organised in six waves, each targeting different pillars
+of your Vitana Index:
+
+1. **Wave 1: Getting Started (days 0–7)** — Onboarding basics. Complete
+   your profile, add a photo, explore your community, say hello to
+   Maxina, first diary entry, first health check, first matches. Lifts
+   **Onboarding / Social**.
+2. **Wave 2: Daily Anchors (days 1–14)** — Building habits. Daily diary,
+   matches check, join a group, first meetup, health scores review.
+   Lifts **Mental / Social**.
+3. **Wave 3: Deepening Connections (days 7–30)** — Relationships & goals.
+   Deepen a connection, set a health goal, invite a friend. Lifts
+   **Social / Mental**.
+4. **Wave 4: Health Intelligence (days 14–60)** — Expertise & streaks.
+   Share your knowledge, start a wellness streak, streak check-ins.
+   Lifts **Physical / Mental**.
+5. **Wave 5: Insight Moments (days 30–60)** — Content & live rooms.
+   Explore wellness content, join a live room, host a discussion.
+   Lifts **Mental / Social**.
+6. **Wave 6: Recommendations & Discovery (days 30–90)** — Marketplace &
+   mentoring. Mentor a newcomer, explore the marketplace, 60-day review,
+   90-day celebration. Lifts **Social / Prosperity**.
+
+## How the journey lifts your Index
+
+Each event in the journey carries wellness tags — `movement`,
+`mindfulness`, `social`, `health-check`, `nutrition`, `learning`,
+`community` — that map to pillar contributions. When you mark an event
+done, the calendar emits a completion signal and the next nightly
+recompute lifts the relevant pillars.
+
+The trajectory is visible on the **My Journey** screen: a line across
+the 90-day timeline showing your real Index scores so far, plus a simple
+projection for the remaining days based on your current rate.
+
+## Adaptivity — the calendar is alive
+
+- Skip a task → the smart rescheduler moves it to tomorrow (up to three
+  times, then it releases the slot).
+- Complete tasks faster → later waves can pull forward.
+- Health signal drops in a specific pillar → a weakness-driven event is
+  inserted (e.g., a 15-minute walk if Physical dips).
+- Natural-language change → "Move my yoga to 3pm" via the Assistant.
+
+## The 90-day goal
+
+By default, Maxina's target is to lift your Vitana Index into the
+**Good (600+)** tier by day 90. You can see your current gap on the
+Index Detail Screen. Individual Life Compass goals (Build Financial
+Freedom, Find Life Partner, Transform Health, Advance Career, Master
+New Skills) re-weight the pillars so the journey naturally emphasises
+what matters most to you — that surface lands in a later phase.
+$CONTENT$
+);
+
+
+-- ===========================================================================
+-- DOC 3 — Autopilot and your Index
+-- ===========================================================================
+
+SELECT public.upsert_knowledge_doc(
+  p_title := 'Autopilot — why items appear and how they lift your Index',
+  p_path  := 'kb/vitana-system/autopilot-and-your-index.md',
+  p_source_type := 'markdown',
+  p_tags  := ARRAY['vitana_system','vitana-index','autopilot','calendar','maxina'],
+  p_content := $CONTENT$
+# Autopilot — why items appear and how they lift your Index
+
+Autopilot is the engine that puts the right next action in front of you
+at the right moment. It sits behind the airplane icon in the header of
+every screen, and it behaves the same everywhere: a small badge counts
+the actions waiting for you, a tap opens the popup, and you choose
+which ones to run.
+
+## Where actions come from
+
+Autopilot pulls actions from several analyzers that watch your state:
+
+- **Community analyzer** — suggests social and community engagement
+  actions based on where you are in the 90-day journey.
+- **Personalization analyzer** — spots your weakest Index pillar and
+  suggests an action that lifts exactly that pillar.
+- **D43 drift engine** — notices when a habit you had going has slipped
+  and proposes a gentle restart.
+- **Journey mapper** — surfaces the next wave milestone at the right
+  moment in your 90 days.
+
+## Every action carries a contribution vector
+
+When Autopilot proposes an action, it includes a `contribution_vector`
+declaring how many points it expects to lift each pillar, e.g.:
+
+```
+{ "physical": 3, "mental": 1, "social": 0, ... }
+```
+
+This is visible on the action card as pill badges: `[Physical +3]
+[Mental +1]`. Over time, the index-delta learner (a later phase)
+compares declared contributions with observed Index movement and updates
+the priors — so the system learns what actually lifts your number.
+
+## From activation to calendar to Index
+
+When you activate an Autopilot action, three things happen in sequence:
+
+1. **Calendar event created.** A new entry appears on your calendar at
+   the next appropriate slot (morning / afternoon / evening matching
+   the action type and your history), tagged with the action's wellness
+   tags.
+2. **Reminder + nudge.** You get a reminder at the scheduled time. The
+   Assistant can help you move or reshape the event via natural
+   language ("Move my walk to 5pm").
+3. **Completion lifts the Index.** When you mark the event done, the
+   calendar emits a `calendar.event.completed` signal. The index-delta
+   emitter maps the event's wellness tags to pillar deltas and triggers
+   an incremental recompute. Your Index badge updates within seconds.
+
+## The Priority Action card
+
+On the Health screen, the Priority Action card always shows your
+weakest pillar and a recommendation whose contribution vector has a
+positive value on that pillar. It's the single-best thing you could do
+right now to raise your Index the fastest.
+
+## Respecting you
+
+You're always in control:
+
+- Dismiss an action → it's silenced for 24 hours (or longer if you set
+  the dismissal scope).
+- "Not today" → all proactive nudges pause until tomorrow.
+- "Don't mention X again" → that category is muted until you lift it.
+
+The dismissal-honor system is on by default and non-negotiable; the
+number of points an action could lift your Index never overrides your
+consent.
+$CONTENT$
+);
+
+
+-- ===========================================================================
+-- DOC 4 — Umbrella: how Maxina tracks your progress
+-- ===========================================================================
+
+SELECT public.upsert_knowledge_doc(
+  p_title := 'How Maxina tracks your progress — the full picture',
+  p_path  := 'kb/vitana-system/how-maxina-tracks-your-progress.md',
+  p_source_type := 'markdown',
+  p_tags  := ARRAY['vitana_system','vitana-index','90-day-journey','autopilot','calendar','life-compass','maxina','onboarding'],
+  p_content := $CONTENT$
+# How Maxina tracks your progress — the full picture
+
+Maxina's job is to improve your quality of life and help you live longer
+and more fulfilled. The way she tracks whether she's doing that is
+deliberately simple:
+
+- **One number** — your Vitana Index (0–999).
+- **One route** — your 90-day Maxina journey across 6 waves.
+- **One day-level plan** — your Calendar.
+- **One nudge engine** — Autopilot.
+- **One goal compass** — Life Compass (lands in a later phase).
+
+Everything else is in service of those five elements.
+
+## The loop
+
+```
+You register
+   ↓
+Maxina pre-populates 90-day calendar (≈30 events)
+   ↓
+First visit to Health → 3-question baseline survey → Day-0 Index
+   ↓
+Every day: Autopilot surfaces the next best action
+   ↓
+You activate → calendar event created
+   ↓
+You complete → completion signal emitted
+   ↓
+Index recomputes → pillar delta applied
+   ↓
+Trajectory visible on My Journey → assistant frames next suggestion
+   ↓
+Day 90 → celebration + reflection ("where did your Index start, where
+   did it end, which pillars moved most?")
+```
+
+## Why four surfaces, one system
+
+The Index is the **measurement**. The Journey is the **route**. The
+Calendar is the **day**. The Autopilot is the **nudge**. The Assistant
+is the **voice**.
+
+They are all looking at the same underlying data and the same active
+goal. When you ask Maxina "how am I doing?", she doesn't open a
+separate report — she reads the Index, cross-checks your calendar
+completion, notices the weakest pillar, and responds in terms of your
+goal.
+
+## Goals and Life Compass
+
+At launch, the default goal is: **reach the Good tier (600+) by day
+90**. In a later phase, the Life Compass modal lets you swap that for
+one of five presets (Build Financial Freedom, Find Life Partner,
+Transform Health, Advance Career, Master New Skills) or write your
+own. Changing the goal re-weights the pillars so the journey naturally
+emphasises what matters most — without ever letting Physical or Mental
+drop below a safety floor.
+
+## Privacy and control
+
+- Your Index and calendar history are scoped to you and your tenant.
+- You can dismiss or pause any proactive nudge; the system honours it
+  silently, without apology.
+- You can ask Maxina to "explain" anything — why an Autopilot item
+  appeared, why a pillar moved — and she will ground the answer in this
+  Knowledge Hub (the `vitana_system` namespace).
+- You can edit your goal any time. Historical Index values are never
+  rewritten when the goal changes — the past is the past.
+
+## If you're just starting
+
+Open the Health screen. Answer the three baseline questions. That's it
+— Maxina takes it from there. Every day after, the Autopilot popup is
+where the next action lives.
+$CONTENT$
+);


### PR DESCRIPTION
## Summary

- Extends `health_compute_vitana_index()` RPC to include 6th pillar (Prosperity) and apply config-driven `pillar_weights`. Default 1.0 per pillar keeps existing behaviour.
- New `POST /api/v1/health/baseline-survey` and `GET /api/v1/health/baseline-survey/status` endpoints seed the Day-0 Index from a 3-question self-rating.
- Seeds 4 Knowledge Hub docs in the `vitana_system` namespace (priority 100 via existing retrieval-router) so the Assistant can ground meta-questions like "how does my Index work?".

Plan: `.claude/plans/community-user-role-make-purring-pascal.md` (Phase A + D).

## Test plan

- [ ] Apply both migrations via `RUN-MIGRATION.yml` (prosperity + weights first, KB docs second).
- [ ] `POST /api/v1/health/recompute/daily` for test user — confirm JSON response now includes `score_prosperity` and `pillar_weights`.
- [ ] `POST /api/v1/health/baseline-survey` with `{"physical":3,"mental":3,"nutritional":3}` — confirm idempotent, Index row written, OASIS `health.compute.baseline_survey` event visible.
- [ ] In ORB voice or Operator: ask "how does the Vitana Index work?" — response should ground in `kb/vitana-system/vitana-index-explained.md`.

Frontend PR: exafyltd/vitana-v1 — branch feat/vitana-index-wiring-phase-a

🤖 Generated with [Claude Code](https://claude.com/claude-code)