### PR TITLE
feat(autopilot-worker): PID file coordination for idempotent autostart

### DIFF
--- a/services/autopilot-worker/src/index.ts
+++ b/services/autopilot-worker/src/index.ts
@@ -13,6 +13,7 @@
  * `claude login`). The subprocess inherits the CLI's auth.
  */
 
+import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
 import { hostname, userInfo } from 'os';
 import { claimNextTask, completeTask, failTask, queueDepth } from './queue';
 import { runClaude } from './claude';
@@ -21,9 +22,45 @@ const LOG_PREFIX = '[autopilot-worker]';
 const POLL_INTERVAL_MS = Number(process.env.POLL_INTERVAL_MS || 5_000);
 const TASK_TIMEOUT_MS = Number(process.env.TASK_TIMEOUT_MS || 600_000); // 10 min
 const MAX_CONCURRENT = Number(process.env.MAX_CONCURRENT || 1);
+const PID_FILE = process.env.AUTOPILOT_WORKER_PIDFILE
+  || `${process.env.HOME || '/tmp'}/.local/share/autopilot-worker.pid`;
 
 let running = 0;
 let shuttingDown = false;
+
+/**
+ * Write our PID to PID_FILE. If a stale file exists pointing at a process
+ * that's no longer running, overwrite it. If it points at a LIVE process,
+ * exit — we don't want to run two workers simultaneously (Claude Code CLI
+ * is single-session per auth and two `claude -p` calls from the same host
+ * compete for the same stdio context).
+ */
+function claimPidFile(): void {
+  if (existsSync(PID_FILE)) {
+    try {
+      const other = parseInt(readFileSync(PID_FILE, 'utf-8').trim(), 10);
+      if (Number.isFinite(other) && other > 0 && other !== process.pid) {
+        try {
+          process.kill(other, 0); // probe — throws if not alive
+          console.error(`${LOG_PREFIX} another worker is already running (pid ${other} in ${PID_FILE}). Exiting.`);
+          process.exit(0);
+        } catch {
+          // stale — fall through to overwrite
+        }
+      }
+    } catch { /* unreadable — overwrite */ }
+  }
+  writeFileSync(PID_FILE, String(process.pid));
+}
+
+function releasePidFile(): void {
+  try {
+    if (existsSync(PID_FILE)) {
+      const n = parseInt(readFileSync(PID_FILE, 'utf-8').trim(), 10);
+      if (n === process.pid) unlinkSync(PID_FILE);
+    }
+  } catch { /* best effort */ }
+}
 
 function workerId(): string {
   return `${userInfo().username}@${hostname()}/pid${process.pid}`;
@@ -80,8 +117,9 @@ async function handleTask(wid: string): Promise<void> {
 }
 
 async function mainLoop(): Promise<void> {
+  claimPidFile();
   const wid = workerId();
-  log(`starting — worker_id=${wid} poll=${POLL_INTERVAL_MS}ms task_timeout=${TASK_TIMEOUT_MS}ms max_concurrent=${MAX_CONCURRENT}`);
+  log(`starting — worker_id=${wid} pid_file=${PID_FILE} poll=${POLL_INTERVAL_MS}ms task_timeout=${TASK_TIMEOUT_MS}ms max_concurrent=${MAX_CONCURRENT}`);
 
   const depth = await queueDepth();
   if ('error' in depth) {
@@ -101,12 +139,14 @@ async function mainLoop(): Promise<void> {
   log('shutdown complete');
 }
 
-// Graceful shutdown
+// Graceful shutdown — also release the PID file so a new worker can claim it.
+process.on('exit', releasePidFile);
 process.on('SIGINT', () => {
   log('SIGINT — draining before exit…');
   shuttingDown = true;
   const wait = setInterval(() => {
     if (running === 0) {
+      releasePidFile();
       clearInterval(wait);
       process.exit(0);
     }
@@ -117,6 +157,7 @@ process.on('SIGTERM', () => {
   shuttingDown = true;
   const wait = setInterval(() => {
     if (running === 0) {
+      releasePidFile();
       clearInterval(wait);
       process.exit(0);
     }


### PR DESCRIPTION
Worker writes `$$` to `$HOME/.local/share/autopilot-worker.pid` on start; exits cleanly if the file points at a live process. Release on SIGTERM/SIGINT/exit. Makes the systemd user unit + the .bashrc autostart shim safely coexist — neither can double-start a worker now, and .bashrc can detect liveness from the PID file instead of the flaky pgrep-on-cmdline pattern.