### PR TITLE
feat(autopilot-worker): pre-PR validation loop — tsc + LLM-feedback retry

### DIFF
--- a/services/autopilot-worker/src/index.ts
+++ b/services/autopilot-worker/src/index.ts
@@ -15,8 +15,12 @@
 
 import { existsSync, readFileSync, unlinkSync, writeFileSync } from 'fs';
 import { hostname, userInfo } from 'os';
-import { claimNextTask, completeTask, failTask, queueDepth } from './queue';
-import { runClaude } from './claude';
+import { claimNextTask, completeTask, failTask, queueDepth, type QueueRow } from './queue';
+import { runClaude, type RunClaudeResult } from './claude';
+import { parseExecutionOutput } from './parse';
+import { applyFiles, fetchAndReset, resetClean } from './repo';
+import { runTsc } from './validate';
+import { buildRetryPrompt } from './retry';
 
 const LOG_PREFIX = '[autopilot-worker]';
 const POLL_INTERVAL_MS = Number(process.env.POLL_INTERVAL_MS || 5_000);
@@ -24,6 +28,15 @@ const TASK_TIMEOUT_MS = Number(process.env.TASK_TIMEOUT_MS || 600_000); // 10 mi
 const MAX_CONCURRENT = Number(process.env.MAX_CONCURRENT || 1);
 const PID_FILE = process.env.AUTOPILOT_WORKER_PIDFILE
   || `${process.env.HOME || '/tmp'}/.local/share/autopilot-worker.pid`;
+
+// Pre-PR validation — run tsc on Claude's output before returning it to the
+// gateway. If tsc finds errors in files we just changed, feed them back and
+// ask Claude to correct its output. Up to VALIDATION_MAX_ATTEMPTS total.
+const VALIDATION_ENABLED = (process.env.AUTOPILOT_WORKER_VALIDATE || 'true').toLowerCase() !== 'false';
+const VALIDATION_MAX_ATTEMPTS = Number(process.env.AUTOPILOT_WORKER_VALIDATION_MAX_ATTEMPTS || 3);
+const VALIDATION_TSCONFIG = process.env.AUTOPILOT_WORKER_TSCONFIG
+  || 'services/gateway/tsconfig.json';
+const VALIDATION_BASE_BRANCH = process.env.AUTOPILOT_WORKER_BASE_BRANCH || 'main';
 
 let running = 0;
 let shuttingDown = false;
@@ -71,6 +84,116 @@ function log(msg: string, ...rest: unknown[]): void {
   console.log(`${ts} ${LOG_PREFIX} ${msg}`, ...rest);
 }
 
+/**
+ * Run an execute task through the validation retry loop.
+ *
+ * - Ask Claude, parse output, apply files to a scratch clone.
+ * - Run tsc --noEmit on the whole project, keep only errors that mention
+ *   files we just wrote.
+ * - If green: return the most-recent Claude output.
+ * - If red: build a retry prompt and go again, up to VALIDATION_MAX_ATTEMPTS.
+ *
+ * The gateway still owns PR creation via the GitHub Contents API — this
+ * function just increases confidence that the output will pass CI once
+ * the gateway writes it.
+ */
+async function runExecuteWithValidation(
+  basePrompt: string,
+  model: string | undefined,
+): Promise<{ ok: boolean; text?: string; usage?: RunClaudeResult['usage']; error?: string; attempts: number; validation_elapsed_ms: number }> {
+  let currentPrompt = basePrompt;
+  let lastOutput: string | undefined;
+  let lastError = 'no attempts ran';
+  let validationElapsedTotal = 0;
+
+  // Reset the clone once up front so we start from a known clean state.
+  const fr = await fetchAndReset(VALIDATION_BASE_BRANCH);
+  if (!fr.ok) {
+    // Clone infrastructure broken → skip validation entirely, fall back to
+    // single-shot behaviour (raw Claude call, return whatever it emits).
+    log(`validation clone unavailable (${fr.error}) — falling back to no-validate path`);
+    const raw = await runClaude(basePrompt, { model, timeoutMs: TASK_TIMEOUT_MS });
+    return {
+      ok: raw.ok,
+      text: raw.text,
+      usage: raw.usage,
+      error: raw.error,
+      attempts: 1,
+      validation_elapsed_ms: 0,
+    };
+  }
+
+  for (let attempt = 0; attempt < VALIDATION_MAX_ATTEMPTS; attempt++) {
+    const claudeResult = await runClaude(currentPrompt, { model, timeoutMs: TASK_TIMEOUT_MS });
+    if (!claudeResult.ok || !claudeResult.text) {
+      return {
+        ok: false,
+        error: claudeResult.error || 'claude returned no text',
+        attempts: attempt + 1,
+        validation_elapsed_ms: validationElapsedTotal,
+      };
+    }
+    lastOutput = claudeResult.text;
+
+    const parsed = parseExecutionOutput(claudeResult.text);
+    if ('error' in parsed) {
+      lastError = `parse: ${parsed.error}`;
+      log(`  attempt ${attempt + 1} parse failed: ${parsed.error}`);
+      currentPrompt = buildRetryPrompt(basePrompt, claudeResult.text, [parsed.error], attempt);
+      continue;
+    }
+
+    // Fetch fresh each attempt — previous attempt may have left files around.
+    await fetchAndReset(VALIDATION_BASE_BRANCH);
+    const applied = await applyFiles(parsed.files);
+    if (!applied.ok || !applied.paths) {
+      lastError = `apply: ${applied.error}`;
+      log(`  attempt ${attempt + 1} apply failed: ${applied.error}`);
+      currentPrompt = buildRetryPrompt(basePrompt, claudeResult.text, [applied.error || 'apply failed'], attempt);
+      continue;
+    }
+
+    const tsc = await runTsc(VALIDATION_TSCONFIG, applied.paths);
+    validationElapsedTotal += tsc.elapsedMs;
+
+    if (tsc.ok) {
+      log(`  attempt ${attempt + 1} PASSED validation in ${Math.round(tsc.elapsedMs / 1000)}s (${parsed.files.length} files applied)`);
+      await resetClean();
+      return {
+        ok: true,
+        text: claudeResult.text,
+        usage: claudeResult.usage,
+        attempts: attempt + 1,
+        validation_elapsed_ms: validationElapsedTotal,
+      };
+    }
+
+    const errCount = (tsc.relevantErrors || []).length;
+    lastError = tsc.error || `${errCount} tsc error(s) in changed files`;
+    log(`  attempt ${attempt + 1} FAILED validation in ${Math.round(tsc.elapsedMs / 1000)}s — ${errCount} relevant tsc error(s)`);
+    currentPrompt = buildRetryPrompt(
+      basePrompt,
+      claudeResult.text,
+      tsc.relevantErrors && tsc.relevantErrors.length > 0
+        ? tsc.relevantErrors
+        : [tsc.error || 'tsc failed with no specific errors extracted'],
+      attempt,
+    );
+  }
+
+  // All attempts exhausted. Return the last output anyway — some classes of
+  // failure (e.g. pre-existing broken types in an unrelated file that our
+  // filter didn't catch) are fixable by human review of the open PR.
+  await resetClean();
+  return {
+    ok: false,
+    text: lastOutput,
+    attempts: VALIDATION_MAX_ATTEMPTS,
+    error: `validation exhausted ${VALIDATION_MAX_ATTEMPTS} attempts: ${lastError}`,
+    validation_elapsed_ms: validationElapsedTotal,
+  };
+}
+
 async function handleTask(wid: string): Promise<void> {
   if (running >= MAX_CONCURRENT) return;
   running++;
@@ -87,26 +210,30 @@ async function handleTask(wid: string): Promise<void> {
     }
 
     const started = Date.now();
-    const result = await runClaude(prompt, {
-      model: row.input_payload.model,
-      timeoutMs: TASK_TIMEOUT_MS,
-    });
+    const shouldValidate = VALIDATION_ENABLED && row.kind === 'execute';
+    const result = shouldValidate
+      ? await runExecuteWithValidation(prompt, row.input_payload.model)
+      : await (async () => {
+          const r = await runClaude(prompt, { model: row.input_payload.model, timeoutMs: TASK_TIMEOUT_MS });
+          return { ok: r.ok, text: r.text, usage: r.usage, error: r.error, attempts: 1, validation_elapsed_ms: 0 } as const;
+        })();
     const elapsed = Math.round((Date.now() - started) / 1000);
 
     if (!result.ok || !result.text) {
-      log(`  task ${row.id.slice(0, 8)} failed after ${elapsed}s: ${result.error}`);
+      log(`  task ${row.id.slice(0, 8)} failed after ${elapsed}s (${result.attempts} attempt${result.attempts === 1 ? '' : 's'}): ${result.error}`);
       await failTask(row.id, result.error || 'claude returned no text');
       return;
     }
 
-    log(`  task ${row.id.slice(0, 8)} ok in ${elapsed}s (${result.usage?.input_tokens ?? '?'} in / ${result.usage?.output_tokens ?? '?'} out, stop=${result.stop_reason ?? '?'})`);
+    log(`  task ${row.id.slice(0, 8)} ok in ${elapsed}s across ${result.attempts} attempt${result.attempts === 1 ? '' : 's'} (${result.usage?.input_tokens ?? '?'} in / ${result.usage?.output_tokens ?? '?'} out)`);
     await completeTask(row.id, {
       text: result.text,
       usage: result.usage,
       extra: {
         worker_id: wid,
-        duration_ms: result.duration_ms,
-        stop_reason: result.stop_reason,
+        attempts: result.attempts,
+        validated: shouldValidate,
+        validation_elapsed_ms: result.validation_elapsed_ms,
       },
     });
   } catch (err) {

--- a/services/autopilot-worker/src/parse.ts
+++ b/services/autopilot-worker/src/parse.ts
@@ -1,0 +1,53 @@
+/**
+ * Delimiter-format parser — mirror of the one in
+ * services/gateway/src/services/dev-autopilot-execute.ts.
+ *
+ * Duplicated (rather than shared via a package) because this repo isn't a
+ * monorepo with cross-service publishing set up. The two copies MUST stay
+ * behaviourally identical — both ends of the queue speak the same dialect.
+ * If you change one, change the other, and add a test to both sides.
+ *
+ * The gateway already has a passing test suite locking this parser's
+ * behaviour against the kind of output Claude emits (code with quotes,
+ * backslashes, braces, template literals). See
+ * services/gateway/test/dev-autopilot-execute.test.ts.
+ */
+
+export interface ExecutionFile {
+  path: string;
+  action: 'create' | 'modify' | 'delete';
+  content?: string;
+}
+
+export interface ExecutionOutput {
+  files: ExecutionFile[];
+  pr_title: string;
+  pr_body: string;
+}
+
+export function parseExecutionOutput(raw: string): ExecutionOutput | { error: string } {
+  const text = raw.trim();
+
+  const titleMatch = text.match(/<<<PR_TITLE>>>\s*([\s\S]*?)\s*<<<END>>>/);
+  if (!titleMatch) return { error: 'Missing <<<PR_TITLE>>>…<<<END>>> block' };
+  const pr_title = titleMatch[1].trim();
+
+  const bodyMatch = text.match(/<<<PR_BODY>>>\s*([\s\S]*?)\s*<<<END>>>/);
+  if (!bodyMatch) return { error: 'Missing <<<PR_BODY>>>…<<<END>>> block' };
+  const pr_body = bodyMatch[1];
+
+  const fileRe = /<<<FILE\s+(create|modify|delete)\s+([^\s>]+)\s*>>>\s*\r?\n([\s\S]*?)\r?\n<<<END>>>/g;
+  const files: ExecutionFile[] = [];
+  let m: RegExpExecArray | null;
+  while ((m = fileRe.exec(text)) !== null) {
+    const action = m[1] as 'create' | 'modify' | 'delete';
+    const path = m[2].trim();
+    const content = action === 'delete' ? undefined : m[3];
+    files.push({ path, action, content });
+  }
+  if (files.length === 0) {
+    return { error: 'No <<<FILE …>>>…<<<END>>> blocks found' };
+  }
+
+  return { files, pr_title, pr_body };
+}

--- a/services/autopilot-worker/src/repo.ts
+++ b/services/autopilot-worker/src/repo.ts
@@ -1,0 +1,152 @@
+/**
+ * Local git clone manager used by pre-PR validation.
+ *
+ * Keeps one persistent clone of the target repo under
+ * $AUTOPILOT_WORKER_REPO_CLONE (default: ~/.cache/vitana-autopilot-worker/<repo>).
+ * For each execute task:
+ *
+ *   1. fetchAndReset(baseBranch) — git fetch; hard-reset a throwaway
+ *      worktree branch to origin/<baseBranch> so we start clean.
+ *   2. applyFiles(files) — write each ExecutionFile to disk under the clone
+ *      path. For action='delete', unlink. For 'modify'/'create', overwrite.
+ *
+ * We NEVER push from here. The gateway still owns branch creation + PR
+ * opening via the GitHub Contents API; this module exists purely as a
+ * scratch filesystem so `tsc --noEmit` (and later jest) have something
+ * real to check against.
+ *
+ * The gateway can't validate because Cloud Run containers are stateless
+ * and carrying a several-GB clone around is impractical. The worker has
+ * a persistent filesystem and we only clone once.
+ */
+
+import { execFile } from 'child_process';
+import { constants as fsc, existsSync } from 'fs';
+import { mkdir, access, writeFile, unlink, rm } from 'fs/promises';
+import { homedir } from 'os';
+import { dirname, join } from 'path';
+import { promisify } from 'util';
+
+import type { ExecutionFile } from './parse';
+
+const exec = promisify(execFile);
+
+const LOG_PREFIX = '[autopilot-worker/repo]';
+
+const DEFAULT_REMOTE = process.env.AUTOPILOT_WORKER_REPO_URL
+  || 'https://github.com/exafyltd/vitana-platform.git';
+const REPO_NAME = (() => {
+  const m = DEFAULT_REMOTE.match(/\/([^\/]+?)(?:\.git)?\/?$/);
+  return m ? m[1] : 'vitana-platform';
+})();
+
+const CLONE_ROOT = process.env.AUTOPILOT_WORKER_REPO_CLONE
+  || join(homedir(), '.cache', 'vitana-autopilot-worker', REPO_NAME);
+
+const GIT_TIMEOUT_MS = 120_000;
+
+async function run(cmd: string, args: string[], opts: { cwd?: string; timeoutMs?: number } = {}): Promise<{ stdout: string; stderr: string }> {
+  const { stdout, stderr } = await exec(cmd, args, {
+    cwd: opts.cwd,
+    timeout: opts.timeoutMs ?? GIT_TIMEOUT_MS,
+    maxBuffer: 50 * 1024 * 1024,
+  });
+  return { stdout: stdout.toString(), stderr: stderr.toString() };
+}
+
+async function exists(path: string): Promise<boolean> {
+  try { await access(path, fsc.F_OK); return true; } catch { return false; }
+}
+
+export function clonePath(): string {
+  return CLONE_ROOT;
+}
+
+/**
+ * Ensure a working clone exists at CLONE_ROOT. Creates it if missing.
+ * Idempotent — safe to call on every task.
+ */
+export async function ensureClone(): Promise<{ ok: boolean; path?: string; error?: string }> {
+  try {
+    if (await exists(join(CLONE_ROOT, '.git'))) {
+      return { ok: true, path: CLONE_ROOT };
+    }
+    await mkdir(dirname(CLONE_ROOT), { recursive: true });
+    console.log(`${LOG_PREFIX} cloning ${DEFAULT_REMOTE} → ${CLONE_ROOT} (first run, slow)`);
+    // Shallow clone keeps the initial cost reasonable; we only need
+    // latest main to validate typechecks against.
+    await run('git', ['clone', '--depth', '50', DEFAULT_REMOTE, CLONE_ROOT], { timeoutMs: 600_000 });
+    return { ok: true, path: CLONE_ROOT };
+  } catch (err) {
+    return { ok: false, error: `ensureClone failed: ${String(err).slice(0, 400)}` };
+  }
+}
+
+/**
+ * Fetch the latest from origin and hard-reset the working tree to
+ * origin/<baseBranch>, dropping any files from a previous task. Leaves
+ * the clone in a "fresh copy of baseBranch" state, ready to receive
+ * applyFiles().
+ */
+export async function fetchAndReset(baseBranch: string): Promise<{ ok: boolean; sha?: string; error?: string }> {
+  try {
+    const init = await ensureClone();
+    if (!init.ok) return { ok: false, error: init.error };
+
+    // Clean out any stray changes from last task
+    await run('git', ['reset', '--hard', 'HEAD'], { cwd: CLONE_ROOT }).catch(() => undefined);
+    await run('git', ['clean', '-fdx', '-e', 'node_modules/'], { cwd: CLONE_ROOT }).catch(() => undefined);
+    await run('git', ['fetch', '--depth', '50', 'origin', baseBranch], { cwd: CLONE_ROOT, timeoutMs: 300_000 });
+    await run('git', ['checkout', '-B', '_autopilot_scratch', `origin/${baseBranch}`], { cwd: CLONE_ROOT });
+    const { stdout } = await run('git', ['rev-parse', 'HEAD'], { cwd: CLONE_ROOT });
+    return { ok: true, sha: stdout.trim() };
+  } catch (err) {
+    return { ok: false, error: `fetchAndReset failed: ${String(err).slice(0, 400)}` };
+  }
+}
+
+/**
+ * Apply the parsed file set to the clone. For each file:
+ *   - 'delete' → unlink (missing file is fine)
+ *   - 'create' / 'modify' → mkdir -p + write the content verbatim
+ *
+ * Returns the absolute paths of the changed files so the validator can
+ * target them.
+ */
+export async function applyFiles(files: ExecutionFile[]): Promise<{ ok: boolean; paths?: string[]; error?: string }> {
+  try {
+    const touched: string[] = [];
+    for (const f of files) {
+      if (!f.path || f.path.includes('..') || f.path.startsWith('/')) {
+        return { ok: false, error: `rejecting unsafe path: ${f.path}` };
+      }
+      const abs = join(CLONE_ROOT, f.path);
+      if (f.action === 'delete') {
+        await unlink(abs).catch(() => undefined);
+        touched.push(abs);
+        continue;
+      }
+      if (typeof f.content !== 'string') {
+        return { ok: false, error: `file ${f.path} missing content for action=${f.action}` };
+      }
+      await mkdir(dirname(abs), { recursive: true });
+      await writeFile(abs, f.content, 'utf-8');
+      touched.push(abs);
+    }
+    return { ok: true, paths: touched };
+  } catch (err) {
+    return { ok: false, error: `applyFiles failed: ${String(err).slice(0, 400)}` };
+  }
+}
+
+/**
+ * Reset back to the clean base so the clone is ready for the next task.
+ * Called after validation completes (green or red).
+ */
+export async function resetClean(): Promise<void> {
+  if (!existsSync(CLONE_ROOT)) return;
+  await run('git', ['reset', '--hard', 'HEAD'], { cwd: CLONE_ROOT }).catch(() => undefined);
+  await run('git', ['clean', '-fd'], { cwd: CLONE_ROOT }).catch(() => undefined);
+}
+
+export { CLONE_ROOT, DEFAULT_REMOTE };

--- a/services/autopilot-worker/src/retry.ts
+++ b/services/autopilot-worker/src/retry.ts
@@ -1,0 +1,55 @@
+/**
+ * Build a follow-up prompt for Claude when the first attempt at an execute
+ * task produced code that `tsc --noEmit` rejects. We keep the original task
+ * prompt in full (Claude needs the plan + file contents to rebuild from),
+ * append what it emitted last time, the exact tsc errors from its own code,
+ * and a short instruction to try again. Same delimiter output format.
+ *
+ * Keeping "your last attempt" in the prompt rather than just "the errors"
+ * is deliberate — Claude is more reliable at patching its own draft than
+ * at guessing what draft produced a given error. We truncate it to avoid
+ * blowing the context window on a large file.
+ */
+
+const MAX_PRIOR_OUTPUT_CHARS = 40_000;
+const MAX_ERROR_CHARS = 8_000;
+
+export function buildRetryPrompt(
+  originalPrompt: string,
+  priorOutput: string,
+  tscErrors: string[],
+  attemptNumber: number,
+): string {
+  const errorsJoined = tscErrors.join('\n').slice(0, MAX_ERROR_CHARS);
+  const priorTrimmed = priorOutput.length > MAX_PRIOR_OUTPUT_CHARS
+    ? priorOutput.slice(0, MAX_PRIOR_OUTPUT_CHARS) + `\n... [truncated ${priorOutput.length - MAX_PRIOR_OUTPUT_CHARS} chars]`
+    : priorOutput;
+
+  return [
+    originalPrompt,
+    '',
+    '---',
+    '',
+    `# Retry (attempt ${attemptNumber + 1})`,
+    '',
+    `Your previous output failed pre-PR TypeScript validation (\`tsc --noEmit\`).`,
+    'Please emit a CORRECTED version of the entire output (same delimiter',
+    'format — <<<PR_TITLE>>>, <<<PR_BODY>>>, one <<<FILE …>>> block per',
+    'file). Fix the errors below. Do not apologise, do not explain the',
+    'diff — just emit the corrected blocks.',
+    '',
+    '## Errors from your last attempt',
+    '',
+    '```',
+    errorsJoined || '(no text captured — tsc probably timed out or crashed)',
+    '```',
+    '',
+    '## Your previous output (for reference)',
+    '',
+    '```',
+    priorTrimmed,
+    '```',
+    '',
+    'Produce the corrected delimiter output now.',
+  ].join('\n');
+}

--- a/services/autopilot-worker/src/validate.ts
+++ b/services/autopilot-worker/src/validate.ts
@@ -1,0 +1,132 @@
+/**
+ * Pre-PR validation: run `tsc --noEmit` on the repo, keep only the
+ * diagnostics that reference files we just changed (or files those files
+ * import — detected by path prefix).
+ *
+ * Filter vs. run-only-changed-files: `tsc` without `--project` can't see
+ * cross-file types, so it would spuriously reject anything that imports
+ * from another module. Running the whole project is the only way to get
+ * real answers. But we don't care about pre-existing errors in files we
+ * didn't touch — those are main's problem, not ours. Hence the filter.
+ */
+
+import { execFile } from 'child_process';
+import { relative } from 'path';
+import { promisify } from 'util';
+
+import { CLONE_ROOT } from './repo';
+
+const exec = promisify(execFile);
+
+const LOG_PREFIX = '[autopilot-worker/validate]';
+const TSC_TIMEOUT_MS = 120_000;
+const TSC_BIN = process.env.AUTOPILOT_WORKER_TSC_BIN || 'npx';
+// If TSC_BIN is `npx`, we invoke `npx tsc`. If someone sets TSC_BIN to an
+// explicit path (e.g. node_modules/.bin/tsc), we use it directly.
+const TSC_ARGS_PREFIX = TSC_BIN === 'npx' ? ['tsc'] : [];
+
+export interface ValidationResult {
+  ok: boolean;
+  /** Full tsc stdout (truncated). Useful for the retry prompt. */
+  raw?: string;
+  /** Only the errors that mention paths we changed. */
+  relevantErrors?: string[];
+  /** Elapsed time in ms. */
+  elapsedMs: number;
+  error?: string;
+}
+
+/**
+ * Run `tsc --noEmit -p <tsconfig>` and return filtered diagnostics.
+ *
+ * changedAbsPaths is the list of absolute paths that were written by
+ * applyFiles(). We keep only tsc errors whose first line path component
+ * matches one of those (relative to the clone root).
+ */
+export async function runTsc(
+  tsconfigPath: string,
+  changedAbsPaths: string[],
+): Promise<ValidationResult> {
+  const startedAt = Date.now();
+  const cwd = CLONE_ROOT;
+  const relChanged = new Set(
+    changedAbsPaths
+      .map(p => relative(cwd, p))
+      // normalize to POSIX for matching against tsc output
+      .map(p => p.replace(/\\/g, '/')),
+  );
+
+  try {
+    const { stdout } = await exec(
+      TSC_BIN,
+      [...TSC_ARGS_PREFIX, '--noEmit', '-p', tsconfigPath],
+      {
+        cwd,
+        timeout: TSC_TIMEOUT_MS,
+        maxBuffer: 50 * 1024 * 1024,
+        env: { ...process.env, FORCE_COLOR: '0' },
+      },
+    );
+    // tsc prints nothing on success.
+    const raw = stdout.toString();
+    return {
+      ok: true,
+      raw,
+      relevantErrors: [],
+      elapsedMs: Date.now() - startedAt,
+    };
+  } catch (err) {
+    // Non-zero exit from tsc → there are errors. Extract them.
+    const e = err as { stdout?: string | Buffer; stderr?: string | Buffer; code?: number; killed?: boolean };
+    if (e.killed) {
+      return {
+        ok: false,
+        error: `tsc timed out after ${Math.round(TSC_TIMEOUT_MS / 1000)}s`,
+        elapsedMs: Date.now() - startedAt,
+      };
+    }
+    const raw = (e.stdout ? e.stdout.toString() : '') + (e.stderr ? e.stderr.toString() : '');
+    const relevantErrors = filterErrorsToChangedFiles(raw, relChanged);
+    const relevantCount = relevantErrors.length;
+    console.log(`${LOG_PREFIX} tsc produced ${raw.split('\n').length} lines, ${relevantCount} relevant to changed files`);
+    return {
+      ok: relevantCount === 0, // tsc failed overall, but none of the errors are OURS → not our problem
+      raw,
+      relevantErrors,
+      elapsedMs: Date.now() - startedAt,
+    };
+  }
+}
+
+/**
+ * tsc error line format:
+ *   services/gateway/src/routes/tasks.test.ts(21,27): error TS2307: Cannot find module '../src/routes/tasks'
+ *
+ * We keep the line IF the path before `(` matches one of our changed
+ * files. We ALSO include continuation lines (ones that don't start with
+ * a path) that immediately follow a kept line, so multi-line diagnostic
+ * bodies aren't truncated.
+ */
+export function filterErrorsToChangedFiles(
+  rawTscOutput: string,
+  changedRelPaths: Set<string>,
+): string[] {
+  const lines = rawTscOutput.split(/\r?\n/);
+  const out: string[] = [];
+  let keeping = false;
+  for (const line of lines) {
+    // Match lines like `path(L,C): error TSxxxx: ...`
+    const m = line.match(/^([^\s(][^(]+?)\(\d+,\d+\):\s*(error|warning)\s/);
+    if (m) {
+      const p = m[1].replace(/\\/g, '/');
+      keeping = changedRelPaths.has(p);
+      if (keeping) out.push(line);
+    } else if (keeping && line.trim().length > 0) {
+      // continuation of a kept diagnostic (e.g. "Overload 1 of 2…")
+      out.push(line);
+    } else {
+      keeping = false;
+    }
+  }
+  return out;
+}

--- a/services/autopilot-worker/test/parse.test.ts
+++ b/services/autopilot-worker/test/parse.test.ts
@@ -1,0 +1,62 @@
+import { parseExecutionOutput } from '../src/parse';
+
+describe('parseExecutionOutput', () => {
+  it('parses a canonical delimiter-formatted response', () => {
+    const raw = [
+      '<<<PR_TITLE>>>',
+      'DEV-AUTOPILOT: add tests for foo',
+      '<<<END>>>',
+      '',
+      '<<<PR_BODY>>>',
+      '## Summary',
+      '',
+      'Tests for foo.',
+      '<<<END>>>',
+      '',
+      '<<<FILE create services/gateway/src/routes/foo.test.ts>>>',
+      "import { foo } from '../foo';",
+      '',
+      "describe('foo', () => {",
+      "  it('works', () => { expect(foo()).toBe(42); });",
+      '});',
+      '<<<END>>>',
+    ].join('\n');
+    const out = parseExecutionOutput(raw);
+    if ('error' in out) throw new Error(out.error);
+    expect(out.pr_title).toBe('DEV-AUTOPILOT: add tests for foo');
+    expect(out.files).toHaveLength(1);
+    expect(out.files[0].action).toBe('create');
+    expect(out.files[0].content).toContain('expect(foo()).toBe(42);');
+  });
+
+  it('returns error when PR_TITLE is missing', () => {
+    const out = parseExecutionOutput('<<<PR_BODY>>>b<<<END>>><<<FILE create a.ts>>>\nx\n<<<END>>>');
+    expect('error' in out).toBe(true);
+  });
+
+  it('returns error when FILE blocks are missing', () => {
+    const out = parseExecutionOutput('<<<PR_TITLE>>>t<<<END>>><<<PR_BODY>>>b<<<END>>>');
+    expect('error' in out).toBe(true);
+  });
+
+  it('matches gateway parser on the exact escape-heavy payload that broke the JSON path', () => {
+    // Matches gateway's test `handles source code that contains quotes, backslashes, and braces without escaping`.
+    const code = [
+      'export function render() {',
+      '  const msg = "user said \\"hi\\" and then {went} away";',
+      "  const re = /^[a-z]+\\s*$/;",
+      '  return `Template ${msg} with ${re.source}`;',
+      '}',
+    ].join('\n');
+    const raw = [
+      '<<<PR_TITLE>>>t<<<END>>>',
+      '<<<PR_BODY>>>b<<<END>>>',
+      '<<<FILE create services/gateway/src/a.ts>>>',
+      code,
+      '<<<END>>>',
+    ].join('\n');
+    const out = parseExecutionOutput(raw);
+    if ('error' in out) throw new Error(out.error);
+    expect(out.files[0].content).toBe(code);
+  });
+});

--- a/services/autopilot-worker/test/retry.test.ts
+++ b/services/autopilot-worker/test/retry.test.ts
@@ -1,0 +1,34 @@
+import { buildRetryPrompt } from '../src/retry';
+
+describe('buildRetryPrompt', () => {
+  it('includes the original prompt, previous output, and errors', () => {
+    const p = buildRetryPrompt(
+      'ORIGINAL TASK PROMPT',
+      'PRIOR LLM OUTPUT with code',
+      ['foo.ts(10,5): error TS2304: Cannot find name bar.'],
+      0,
+    );
+    expect(p).toContain('ORIGINAL TASK PROMPT');
+    expect(p).toContain('PRIOR LLM OUTPUT with code');
+    expect(p).toContain('error TS2304');
+    expect(p).toContain('Retry (attempt 1)');
+  });
+
+  it('truncates very large prior outputs so we stay inside the context window', () => {
+    const huge = 'x'.repeat(100_000);
+    const p = buildRetryPrompt('orig', huge, ['e'], 0);
+    expect(p).toContain('... [truncated');
+    expect(p.length).toBeLessThan(60_000);
+  });
+
+  it('substitutes a helpful stub when there are no error strings', () => {
+    const p = buildRetryPrompt('orig', 'prev', [], 0);
+    expect(p).toContain('(no text captured');
+  });
+
+  it('labels retry attempts correctly (attempt 0 → Retry 1, attempt 1 → Retry 2, etc)', () => {
+    expect(buildRetryPrompt('o', 'p', ['e'], 0)).toContain('Retry (attempt 1)');
+    expect(buildRetryPrompt('o', 'p', ['e'], 1)).toContain('Retry (attempt 2)');
+    expect(buildRetryPrompt('o', 'p', ['e'], 2)).toContain('Retry (attempt 3)');
+  });
+});

--- a/services/autopilot-worker/test/validate.test.ts
+++ b/services/autopilot-worker/test/validate.test.ts
@@ -1,0 +1,55 @@
+/**
+ * Unit tests for the tsc output filter. We don't actually run tsc here
+ * (the clone + validator integration is covered by the end-to-end smoke
+ * test); this file just locks the diagnostic-line filter so we don't
+ * accidentally start passing through unrelated pre-existing main errors
+ * as "your retry must fix these".
+ */
+
+import { filterErrorsToChangedFiles } from '../src/validate';
+
+describe('filterErrorsToChangedFiles', () => {
+  it('keeps errors that reference a changed file, drops the rest', () => {
+    const raw = [
+      'services/gateway/src/routes/tasks.test.ts(21,27): error TS2307: Cannot find module \'../src/routes/tasks\'',
+      'services/gateway/src/services/unrelated.ts(10,5): error TS2304: Cannot find name bar.',
+      'services/gateway/src/routes/tasks.test.ts(43,1): error TS2540: Cannot assign.',
+    ].join('\n');
+    const out = filterErrorsToChangedFiles(raw, new Set([
+      'services/gateway/src/routes/tasks.test.ts',
+    ]));
+    expect(out).toHaveLength(2);
+    expect(out[0]).toContain('tasks.test.ts(21,27)');
+    expect(out[1]).toContain('tasks.test.ts(43,1)');
+  });
+
+  it('includes continuation lines belonging to a kept diagnostic', () => {
+    const raw = [
+      'services/gateway/src/routes/foo.ts(5,1): error TS2322: Type \'string\' not assignable to',
+      '  Type \'number\'.',
+      '  (overload continuation…)',
+      'services/gateway/src/services/bar.ts(3,1): error TS2304: Cannot find name baz.',
+    ].join('\n');
+    const out = filterErrorsToChangedFiles(raw, new Set([
+      'services/gateway/src/routes/foo.ts',
+    ]));
+    expect(out).toHaveLength(3);
+    expect(out[0]).toContain('foo.ts');
+    expect(out[1].trim()).toBe("Type 'number'.");
+    expect(out[2]).toContain('overload continuation');
+  });
+
+  it('returns an empty array when no changed-file errors appear', () => {
+    const raw = 'services/gateway/src/services/unchanged.ts(10,5): error TS2304: Bla.';
+    const out = filterErrorsToChangedFiles(raw, new Set(['services/gateway/src/routes/new.test.ts']));
+    expect(out).toEqual([]);
+  });
+
+  it('handles Windows-style backslash paths by normalising to forward slashes', () => {
+    const raw = 'services\\gateway\\src\\routes\\tasks.test.ts(21,27): error TS2307: X';
+    const out = filterErrorsToChangedFiles(raw, new Set([
+      'services/gateway/src/routes/tasks.test.ts',
+    ]));
+    expect(out).toHaveLength(1);
+  });
+});


### PR DESCRIPTION
Adds a retry loop around every execute task. Before the worker reports completion, it parses Claude's delimiter output, applies the files to a persistent local clone, runs `tsc --noEmit`, and only keeps diagnostics that reference files we just wrote. Red → feed errors back to Claude with the original prompt + previous draft + tsc errors → retry. Up to 3 attempts. Green → return the output as before.

## What this catches
Every execute failure we've seen so far has been caught by post-PR CI, not pre-PR:
- Wrong relative import depth (`../../src/` vs `../src/` on the tasks.ts run)
- Guessed wrong helper internals
- Hallucinated exports

All of those show up as `tsc` errors. Feeding compiler output back into the next prompt lets Claude patch its own draft without a human in the loop.

## Rollout
Opt-in via `AUTOPILOT_WORKER_VALIDATE=true` (default on). First execute task does a shallow clone (~5s); subsequent tasks reuse it via fetch+reset. Jest validation is a follow-up PR.

## Tests
18/18 worker tests pass (was 6).