### PR TITLE
fix(og): validate profile image URL before emitting og:image

### DIFF
--- a/cloudflare/vitanaland-og-proxy/worker.js
+++ b/cloudflare/vitanaland-og-proxy/worker.js
@@ -40,6 +40,33 @@ function formatPrice(cents, currency) {
 }
 
 /**
+ * Walk a list of candidate image URLs and return the first one that
+ * responds 2xx with an image/* content-type. Falls through to the
+ * supplied default on any miss. Used to shield WhatsApp/Facebook et al.
+ * from legacy / broken rows in `profiles.avatar_url` — some pre-existing
+ * rows point at the no-longer-public `default-images` bucket, at expired
+ * signed URLs, or at third-party picture URLs that return non-image
+ * content to crawlers. Returns the detected content-type too so the
+ * caller can emit an accurate `og:image:type`.
+ */
+async function pickUsableImage(candidates, defaultImage) {
+  for (const url of candidates) {
+    if (!url || typeof url !== 'string') continue;
+    if (!/^https?:\/\//i.test(url)) continue;
+    try {
+      const r = await fetch(url, {
+        method: 'HEAD',
+        redirect: 'follow',
+        cf: { cacheTtl: 300, cacheEverything: true },
+      });
+      const ct = (r.headers.get('content-type') || '').toLowerCase();
+      if (r.ok && ct.startsWith('image/')) return { url, contentType: ct };
+    } catch { /* try next */ }
+  }
+  return { url: defaultImage, contentType: 'image/jpeg' };
+}
+
+/**
  * Build an HTML page with OG meta tags for a profile. Served to crawlers only.
  * Queries the gateway's public profile endpoint — no auth required.
  */
@@ -73,9 +100,17 @@ async function renderProfileOg(id, canonicalUrl, destinationUrl) {
     .slice(0, 200);
   // cover_url is landscape-friendly; avatar_url is square (auto-fits on
   // WhatsApp/Telegram but below some crawlers' 1200x630 preference, which
-  // is why DEFAULT_IMAGE is a landscape hero).
-  const image = p.cover_url || p.avatar_url || DEFAULT_IMAGE;
-  const isLandscape = !!p.cover_url || image === DEFAULT_IMAGE;
+  // is why DEFAULT_IMAGE is a landscape hero). HEAD-check each candidate
+  // so crawlers never see a broken URL — see pickUsableImage().
+  const picked = await pickUsableImage(
+    [p.cover_url, p.avatar_url],
+    DEFAULT_IMAGE,
+  );
+  const image = picked.url;
+  const imageType = picked.contentType;
+  // Landscape when we ended up on cover_url or the default hero;
+  // a validated avatar_url stays 512×512.
+  const isLandscape = image === p.cover_url || image === DEFAULT_IMAGE;
 
   const html = `<!DOCTYPE html>
 <html lang="en">
@@ -92,7 +127,7 @@ async function renderProfileOg(id, canonicalUrl, destinationUrl) {
   <meta property="og:url" content="${escapeHtml(canonicalUrl)}">
   <meta property="og:image" content="${escapeHtml(image)}">
   <meta property="og:image:secure_url" content="${escapeHtml(image)}">
-  <meta property="og:image:type" content="image/jpeg">
+  <meta property="og:image:type" content="${escapeHtml(imageType)}">
   <meta property="og:image:alt" content="${escapeHtml(composedName)}">
   <meta property="og:image:width" content="${isLandscape ? 1200 : 512}">
   <meta property="og:image:height" content="${isLandscape ? 630 : 512}">


### PR DESCRIPTION
## Summary
- Add `pickUsableImage()` helper in `cloudflare/vitanaland-og-proxy/worker.js` that HEAD-checks each candidate image URL (`cover_url` → `avatar_url` → `DEFAULT_IMAGE`) and falls through on non-2xx or non-image content-type. Caches the HEAD at the edge for 5 min (`cf.cacheTtl: 300`), matching the existing response cache.
- Emit the detected content-type as `og:image:type` instead of the hardcoded `image/jpeg`.
- Only `renderProfileOg()` changes; event/product paths untouched.

### Why

When sharing a profile link on WhatsApp, some profiles render the full rich preview (avatar + name + handle) and others render text-only. The gateway + worker chain is correct, but `profiles.avatar_url` has per-row data drift — legacy rows pointing at the no-longer-public `default-images` bucket, stale OAuth provider picture URLs (`lh3.googleusercontent.com` etc.) that sometimes return non-image content to crawlers, or expired signed URLs from older upload paths. The existing `cover_url || avatar_url || DEFAULT_IMAGE` fallback is purely truthiness-based, so a truthy-but-broken URL shadows the DEFAULT_IMAGE hero and WhatsApp drops the image.

### Test plan
- [ ] After merge + auto-deploy (`DEPLOY-CLOUDFLARE-WORKERS.yml`), paste `https://e.vitanaland.com/profiles/{id}?v=2` into WhatsApp for the previously-broken profiles (`@jovanabizz`, `@mariia-maksina`, `c7d3260d-…`). All three should render with an image — either the user's own avatar if it resolves, or the branded `covers/vitana-og-default.jpg` hero.
- [ ] `curl -A "WhatsApp/2.23" https://e.vitanaland.com/profiles/{broken-id} | grep og:image` → points at DEFAULT_IMAGE for previously-broken profiles; unchanged for profiles with working avatars.
- [ ] Latency: worst-case ~80–150ms added to a first crawler hit per URL, amortised to zero on repeat hits due to `cf.cacheTtl`.
- [ ] Existing working profiles (e.g. `@danigoespalma`) still show their own avatar.

### Follow-ups (not in this PR)
- Optional one-shot data cleanup: null out `profiles.avatar_url` values that don't HEAD-check as images. Separate PR; not urgent once this lands since the worker now recovers on its own.
- Spot-check that the `avatars` Supabase bucket is genuinely marked public (i.e. unauthenticated GETs are allowed). Needs admin access; no code change in this repo.

Relates to the client-side change already merged in [vitana-v1 #197](https://github.com/exafyltd/vitana-v1/pull/197).