### PR TITLE
perf(orb): overlap context build with Gemini WS handshake (BOOTSTRAP-ORB-CRITICAL-PATH)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -741,6 +741,13 @@ interface GeminiLiveSession {
   // typically EventSource network blips, not long pauses, so rebuilding would
   // waste 400-1200 ms of Supabase/Gemini calls for zero user benefit.
   contextBootstrapBuiltAt?: number;
+  // BOOTSTRAP-ORB-CRITICAL-PATH: Resolves once the heavy context assembly
+  // (memory bootstrap, active role lookup, last-session info, admin briefing,
+  // stored-language lookup) has populated the fields above. Awaited inside
+  // connectToLiveAPI's ws.on('open') handler so the context build (800-1200ms)
+  // overlaps with the Google auth + WS handshake (500-1000ms) instead of
+  // serializing with /live/session/start's response.
+  contextReadyPromise?: Promise<void>;
   // VTID-01225: Transcript accumulation for Cognee extraction
   transcriptTurns: Array<{ role: 'user' | 'assistant'; text: string; timestamp: string }>;
   // VTID-01225: Buffer for accumulating output transcription chunks until turn completes
@@ -4694,8 +4701,25 @@ async function connectToLiveAPI(
     }, 15000); // 15 second timeout
 
     // Connection opened - send setup message
-    ws.on('open', () => {
+    ws.on('open', async () => {
       console.log(`[VTID-01219] Live API WebSocket connected for session ${session.sessionId}`);
+
+      // BOOTSTRAP-ORB-CRITICAL-PATH: If /live/session/start kicked off a
+      // background context-assembly promise (Brain/bootstrap + role + last
+      // session + admin briefing + stored lang), wait for it before building
+      // the setup message. The Google auth + WS handshake that just completed
+      // has typically overlapped with context build, so this await is near
+      // zero for authenticated sessions and a no-op for anonymous sessions.
+      const ctxPromise = (session as any).contextReadyPromise as Promise<void> | undefined;
+      if (ctxPromise) {
+        const awaitStart = Date.now();
+        try {
+          await ctxPromise;
+        } catch (e) {
+          // Promise's own .catch already logged; proceed with whatever session fields are populated.
+        }
+        console.log(`[BOOTSTRAP-ORB-CRITICAL-PATH] Awaited contextReadyPromise for ${Date.now() - awaitStart}ms before Gemini setup for session ${session.sessionId}`);
+      }
 
       // Send setup message with model and configuration
       // Vertex AI uses snake_case (unlike Google AI which uses camelCase)
@@ -9752,6 +9776,13 @@ router.post('/live/session/start', optionalAuth, async (req: AuthenticatedReques
   let sseActiveRole: string | null = null;
   // VTID-01224-FIX: Last session info for context-aware greeting
   let lastSessionInfo: { time: string; wasFailure: boolean } | null = null;
+  // BOOTSTRAP-ORB-CRITICAL-PATH: Promise resolving once context assembly has
+  // populated the session fields below. Attached to the session object and
+  // awaited by connectToLiveAPI's ws.on('open') handler, so context build
+  // overlaps with Google auth + Gemini WS handshake instead of blocking the
+  // /live/session/start response. Undefined for anonymous / no-identity
+  // sessions (nothing to build).
+  let contextReadyPromise: Promise<void> | undefined;
 
   if (isAnonymousSession) {
     // VTID-ANON: Anonymous session — skip ALL personal context.
@@ -9765,13 +9796,15 @@ router.post('/live/session/start', optionalAuth, async (req: AuthenticatedReques
     // VITANA-BRAIN: If ORB brain flag is enabled, use brain context assembly instead
     const { isVitanaBrainOrbEnabled } = await import('../services/system-controls-service');
     const useOrbBrain = await isVitanaBrainOrbEnabled();
+    const contextBuildStart = Date.now();
 
-    // BOOTSTRAP-ORB-PHASE1: Run bootstrap + role + sessionInfo + language
-    // preference all in parallel. Previously storedLang awaited serially
-    // before this block, adding ~100 ms to the critical path. Now it
-    // overlaps with the other queries so total latency is governed by the
-    // slowest one (bootstrap ~800-1200 ms).
-    const [bootstrapResult, fetchedSseRole, fetchedSessionInfo, storedLangResult] = await Promise.all([
+    // BOOTSTRAP-ORB-CRITICAL-PATH: Kick off bootstrap + role + sessionInfo +
+    // stored-language + admin briefing in parallel, WITHOUT awaiting. The
+    // resulting promise is stored on the session and awaited by
+    // connectToLiveAPI's ws.on('open') handler. Admin briefing is fetched
+    // speculatively (only needs tenant_id) and discarded if the resolved role
+    // turns out not to be admin-ish.
+    const bootstrapWork = Promise.all([
       useOrbBrain
         ? (async () => {
             const brainStart = Date.now();
@@ -9807,75 +9840,86 @@ router.post('/live/session/start', optionalAuth, async (req: AuthenticatedReques
         : resolveEffectiveRole(bootstrapIdentity.user_id, bootstrapIdentity.tenant_id || ''),
       fetchLastSessionInfo(bootstrapIdentity.user_id),
       storedLangPromise,
+      bootstrapIdentity.tenant_id
+        ? fetchAdminBriefingBlock(bootstrapIdentity.tenant_id, 3).catch((err) => {
+            console.warn(`[BOOTSTRAP-ADMIN-EE] SSE briefing fetch failed: ${err?.message}`);
+            return null;
+          })
+        : Promise.resolve(null),
     ]);
-    sseActiveRole = fetchedSseRole;
-    lastSessionInfo = fetchedSessionInfo;
-    if (storedLangResult && !clientRequestedLang) {
-      lang = storedLangResult;
-      console.log(`[LANG-PREF] No client lang — using stored preference: ${lang} for user=${bootstrapIdentity.user_id.substring(0, 8)}...`);
-    }
 
-    // VTID-ROLE-CMD-HUB: Command Hub is developer-only — override role
-    const sseRoute = typeof (body as any).current_route === 'string' ? (body as any).current_route : '';
-    if (sseRoute.startsWith('/command-hub') && (!sseActiveRole || sseActiveRole === 'community')) {
-      console.log(`[VTID-01225-ROLE] Overriding role to "developer" for Command Hub session (was: ${sseActiveRole || 'null'})`);
-      sseActiveRole = 'developer';
-    }
+    contextReadyPromise = bootstrapWork
+      .then(([bootstrapResult, fetchedSseRole, fetchedSessionInfo, storedLangResult, adminBriefing]) => {
+        // Resolve effective role (same overrides as before — kept in sync with the Brain path above).
+        let resolvedRole = fetchedSseRole;
+        const sseRoute = typeof (body as any).current_route === 'string' ? (body as any).current_route : '';
+        if (sseRoute.startsWith('/command-hub') && (!resolvedRole || resolvedRole === 'community')) {
+          console.log(`[VTID-01225-ROLE] Overriding role to "developer" for Command Hub session (was: ${resolvedRole || 'null'})`);
+          resolvedRole = 'developer';
+        }
+        if (clientContext.isMobile && resolvedRole !== 'community') {
+          console.log(`[BOOTSTRAP-ORB-MOBILE-ROLE] Forcing role to "community" for mobile session (was: ${resolvedRole || 'null'})`);
+          resolvedRole = 'community';
+        }
 
-    // BOOTSTRAP-ORB-MOBILE-ROLE: Mobile (Appilix WebView / phone browsers) is community-only.
-    // Runs AFTER the Command Hub override so mobile always wins, even if someone routes
-    // an Appilix WebView to /command-hub. Matches the frontend guard in useRole.tsx.
-    if (clientContext.isMobile && sseActiveRole !== 'community') {
-      console.log(`[BOOTSTRAP-ORB-MOBILE-ROLE] Forcing role to "community" for mobile session (was: ${sseActiveRole || 'null'})`);
-      sseActiveRole = 'community';
-    }
-
-    contextInstruction = bootstrapResult.contextInstruction;
-    contextPack = bootstrapResult.contextPack;
-    contextBootstrapLatencyMs = bootstrapResult.latencyMs;
-    contextBootstrapSkippedReason = bootstrapResult.skippedReason;
-
-    if (bootstrapResult.skippedReason) {
-      console.warn(`[VTID-01224] Context bootstrap skipped for ${sessionId}: ${bootstrapResult.skippedReason}`);
-    } else {
-      console.log(`[VTID-01224] Context bootstrap complete for ${sessionId}: ${bootstrapResult.latencyMs}ms, chars=${contextInstruction?.length || 0}`);
-    }
-
-    // BOOTSTRAP-ADMIN-EE: admin-role sessions get a proactive briefing of the
-    // top open admin_insights prepended to the greeting. Only fires for admin-ish
-    // roles and only when there's something to speak about.
-    if (isAdminRole(sseActiveRole) && bootstrapIdentity.tenant_id) {
-      try {
-        const briefing = await fetchAdminBriefingBlock(bootstrapIdentity.tenant_id, 3);
-        if (briefing) {
-          contextInstruction = contextInstruction
-            ? `${contextInstruction}\n\n${briefing}`
-            : briefing;
+        // Build final context instruction, optionally prepending the admin briefing.
+        let finalContext = bootstrapResult.contextInstruction || '';
+        if (isAdminRole(resolvedRole) && adminBriefing) {
+          finalContext = finalContext ? `${finalContext}\n\n${adminBriefing}` : adminBriefing;
           emitOasisEvent({
             vtid: 'BOOTSTRAP-ADMIN-EE',
             type: 'admin.briefing.injected',
             source: 'orb-live',
             status: 'info',
             message: `Admin briefing injected into SSE session ${sessionId}`,
-            payload: { session_id: sessionId, tenant_id: bootstrapIdentity.tenant_id, role: sseActiveRole, chars: briefing.length },
+            payload: { session_id: sessionId, tenant_id: bootstrapIdentity.tenant_id, role: resolvedRole, chars: adminBriefing.length },
             actor_id: bootstrapIdentity.user_id,
             actor_role: 'admin',
             surface: 'orb',
           }).catch(() => {});
         }
-      } catch (err: any) {
-        console.warn(`[BOOTSTRAP-ADMIN-EE] SSE briefing fetch failed: ${err?.message}`);
-      }
-    }
+
+        if (bootstrapResult.skippedReason) {
+          console.warn(`[VTID-01224] Context bootstrap skipped for ${sessionId}: ${bootstrapResult.skippedReason}`);
+        } else {
+          console.log(`[VTID-01224] Context bootstrap complete for ${sessionId}: ${bootstrapResult.latencyMs}ms, chars=${finalContext.length}`);
+        }
+
+        // Determine final lang (stored preference wins only if client didn't
+        // explicitly request one).
+        let finalLang = lang;
+        if (storedLangResult && !clientRequestedLang) {
+          finalLang = storedLangResult;
+          console.log(`[LANG-PREF] No client lang — using stored preference: ${finalLang} for user=${bootstrapIdentity.user_id.substring(0, 8)}...`);
+        }
+
+        // Patch the session (it has already been constructed with placeholders
+        // below this block). Mutations are safe because no consumer reads
+        // these fields before awaiting contextReadyPromise.
+        session.active_role = resolvedRole;
+        session.lastSessionInfo = fetchedSessionInfo;
+        session.contextInstruction = finalContext;
+        session.contextPack = bootstrapResult.contextPack;
+        session.contextBootstrapLatencyMs = bootstrapResult.latencyMs;
+        session.contextBootstrapSkippedReason = bootstrapResult.skippedReason;
+        session.contextBootstrapBuiltAt = Date.now();
+        if (finalLang !== session.lang) {
+          session.lang = finalLang;
+        }
+
+        // Persist language preference (non-blocking, after we know the final lang).
+        if (bootstrapIdentity.user_id && bootstrapIdentity.tenant_id) {
+          persistLanguagePreference(bootstrapIdentity.tenant_id, bootstrapIdentity.user_id, finalLang);
+        }
+
+        console.log(`[BOOTSTRAP-ORB-CRITICAL-PATH] Context ready for ${sessionId} in ${Date.now() - contextBuildStart}ms (role=${resolvedRole}, chars=${finalContext.length})`);
+      })
+      .catch((err) => {
+        console.warn(`[BOOTSTRAP-ORB-CRITICAL-PATH] Context build rejected for ${sessionId}, proceeding with empty context:`, err?.message || err);
+      });
   } else {
     contextBootstrapSkippedReason = 'no_identity';
     console.log(`[VTID-01224] Skipping context bootstrap for ${sessionId}: no identity`);
-  }
-
-  // BOOTSTRAP-ORB-PHASE1: persist language preference AFTER the final lang is
-  // determined (stored-lang lookup moved into the parallel block above).
-  if (bootstrapIdentity?.user_id && bootstrapIdentity?.tenant_id) {
-    persistLanguagePreference(bootstrapIdentity.tenant_id, bootstrapIdentity.user_id, lang);
   }
 
   // Create session object with identity and context attached
@@ -9894,11 +9938,16 @@ router.post('/live/session/start', optionalAuth, async (req: AuthenticatedReques
     audioOutChunks: 0,
     // VTID-01224: Context and identity
     turn_count: 0,
+    // BOOTSTRAP-ORB-CRITICAL-PATH: context/role/lastSessionInfo are populated
+    // asynchronously by contextReadyPromise (kicked off above). For anonymous
+    // / no-identity sessions the promise is undefined and these stay
+    // undefined, which all downstream consumers already tolerate.
     contextInstruction,
     contextPack,
     contextBootstrapLatencyMs,
     contextBootstrapSkippedReason,
     contextBootstrapBuiltAt: Date.now(),
+    contextReadyPromise,
     // VTID-01225: Transcript accumulation for Cognee extraction
     transcriptTurns: [],
     outputTranscriptBuffer: '',
@@ -9982,7 +10031,7 @@ router.post('/live/session/start', optionalAuth, async (req: AuthenticatedReques
     voice: getVoiceForLang(lang)
   });
 
-  console.log(`[VTID-ORBC] Live session created: ${sessionId} (user=${orbIdentity?.user_id || 'anonymous'}, tenant=${orbIdentity?.tenant_id || 'none'}, lang=${lang}, contextChars=${contextInstruction?.length || 0})`);
+  console.log(`[VTID-ORBC] Live session created: ${sessionId} (user=${orbIdentity?.user_id || 'anonymous'}, tenant=${orbIdentity?.tenant_id || 'none'}, lang=${lang}, contextDeferred=${!!contextReadyPromise})`);
 
   return res.status(200).json({
     ok: true,
@@ -9993,9 +10042,14 @@ router.post('/live/session/start', optionalAuth, async (req: AuthenticatedReques
       modalities: responseModalities,
       model: VERTEX_LIVE_MODEL,
       context_bootstrap: {
-        latency_ms: contextBootstrapLatencyMs,
-        context_chars: contextInstruction?.length || 0,
+        // BOOTSTRAP-ORB-CRITICAL-PATH: latency / char count are now known only
+        // after contextReadyPromise resolves (which happens during the Gemini
+        // WS handshake). Returning placeholders is intentional — clients use
+        // these for diagnostics only.
+        latency_ms: contextBootstrapLatencyMs ?? null,
+        context_chars: null,
         skipped_reason: contextBootstrapSkippedReason || null,
+        deferred: !!contextReadyPromise,
       }
     }
   });


### PR DESCRIPTION
## Problem

Every ORB voice session used to block for **4–7 seconds** between the user tapping the orb button and hearing the greeting. Two of those seconds were inside the gateway, serialized:

1. `POST /live/session/start` awaited Vitana Brain context assembly (800–1200ms), sequential admin briefing (100–300ms for admins), role resolution, last-session info, and stored-language lookup.
2. Only then did the client get `session_id` back, open the SSE stream, and trigger `connectToLiveAPI`, which runs Google auth + Gemini WebSocket handshake (500–1000ms).

Those two phases are independent — context build is DB work; auth+WS is network to Google. Nothing forces them to serialize.

## Fix

Move context assembly off the `/live/session/start` critical path and onto a session-attached promise that `connectToLiveAPI`'s `ws.on('open')` awaits before building the Gemini setup message.

### Changes, all in [services/gateway/src/routes/orb-live.ts](services/gateway/src/routes/orb-live.ts)

- **`GeminiLiveSession` gains `contextReadyPromise?: Promise<void>`** — resolves once the heavy work has populated `contextInstruction` / `active_role` / `lastSessionInfo` / `lang`.
- **`/live/session/start`** kicks off `Promise.all([brain-or-bootstrap, role, last-session, stored-lang, admin-briefing])` **without awaiting**. The `.then` applies role overrides (Command Hub → developer, mobile → community per PR #821), injects the admin briefing if the resolved role is admin-ish, and patches the fields onto `session`. The response now returns in ~100ms.
- **Admin briefing is fetched in parallel** (only needs `tenant_id`). Briefing is discarded if the resolved role turns out to be non-admin — one speculative DB call saves 100–300ms for admins.
- **`connectToLiveAPI`'s `ws.on('open')` becomes `async`** and awaits `session.contextReadyPromise` before constructing the setup message. For anonymous sessions (no promise) it's a no-op. By the time the WS opens (Google auth + handshake ~800–1500ms), context build (~800ms) is typically already done — await is near-zero.
- **Response `meta.context_bootstrap`** gains a `deferred: true` flag so clients know `latency_ms` / `context_chars` are no longer known at response time (diagnostic-only fields).

### Expected savings

- **~800ms** off end-to-end first-audio latency (the full context build now hides under the Google auth + WS handshake that was already happening).
- **Additional ~100–300ms** for admins from parallelizing the briefing fetch.
- Stacks with the frontend instant-greeting (PR #200 in vitana-v1): user hears a pre-recorded ~1.5s "I'm here, I'm listening" on tap, then the real Gemini greeting arrives ~3s later instead of ~5s.

## Risk analysis

- **Reconnects**: `contextReadyPromise` on a returning session has already resolved; await is immediate. No change to reconnect semantics.
- **Anonymous sessions**: `contextReadyPromise` is undefined; `ws.on('open')` skips the await. No change.
- **Error path**: promise `.catch` logs and leaves session fields undefined; the setup message falls back to empty context, matching prior behavior for context-bootstrap failures.
- **Race safety**: the `.then` callback runs as a microtask well after session construction finishes synchronously. Patching fields on `session` is safe; no consumer reads them before the `await` in `ws.on('open')`.
- **OASIS event** at session-start now emits with `active_role: null` (role is pending). The admin-briefing event still fires later with the resolved role. Accepting a null active_role on the session-start snapshot is intentional — the role is known within ~800ms and appears on subsequent per-turn events.

## Test plan

- [ ] Cloud Run logs show `[BOOTSTRAP-ORB-CRITICAL-PATH] Awaited contextReadyPromise for Xms before Gemini setup` with X typically <200ms
- [ ] End-to-end tap-to-first-audio measured on Android Chrome drops from ~5s → ~3s
- [ ] Desktop admin session still gets admin briefing injected (log `[BOOTSTRAP-ADMIN-EE] Admin briefing injected` still present)
- [ ] Mobile session still forced to community role (log `[BOOTSTRAP-ORB-MOBILE-ROLE]` still present)
- [ ] Command Hub session still elevated to developer role
- [ ] Reconnect path works: no double-context-build

Generated with Claude Code