### PR TITLE
fix(og): use avatar_url (not cover_url) as profile preview image

### DIFF
--- a/cloudflare/vitanaland-og-proxy/worker.js
+++ b/cloudflare/vitanaland-og-proxy/worker.js
@@ -98,19 +98,17 @@ async function renderProfileOg(id, canonicalUrl, destinationUrl) {
     .replace(/\s+/g, ' ')
     .trim()
     .slice(0, 200);
-  // cover_url is landscape-friendly; avatar_url is square (auto-fits on
-  // WhatsApp/Telegram but below some crawlers' 1200x630 preference, which
-  // is why DEFAULT_IMAGE is a landscape hero). HEAD-check each candidate
-  // so crawlers never see a broken URL — see pickUsableImage().
-  const picked = await pickUsableImage(
-    [p.cover_url, p.avatar_url],
-    DEFAULT_IMAGE,
-  );
+  // Preview tracks the current profile picture (avatar_url). cover_url is
+  // intentionally NOT in the candidate list: there is no user-facing UI to
+  // update it, so legacy rows drift out of sync with the in-app avatar and
+  // produce surprising previews (e.g. an unrelated old photo for a user
+  // whose current avatar is a headshot). Fall through to the branded
+  // DEFAULT_IMAGE hero when avatar_url is missing or not crawler-fetchable.
+  const picked = await pickUsableImage([p.avatar_url], DEFAULT_IMAGE);
   const image = picked.url;
   const imageType = picked.contentType;
-  // Landscape when we ended up on cover_url or the default hero;
-  // a validated avatar_url stays 512×512.
-  const isLandscape = image === p.cover_url || image === DEFAULT_IMAGE;
+  // avatar_url is square (512×512); DEFAULT_IMAGE is landscape (1200×630).
+  const isLandscape = image === DEFAULT_IMAGE;
 
   const html = `<!DOCTYPE html>
 <html lang="en">


### PR DESCRIPTION
## Summary
- In `cloudflare/vitanaland-og-proxy/worker.js` `renderProfileOg()`, drop `cover_url` from the OG image candidate list. Preview now tracks `avatar_url` only, falling through to `DEFAULT_IMAGE`.
- `og:image:width/height` are now `512×512` for a valid avatar and `1200×630` for the default hero. No change to event or product paths.

### Why

Dragan Alexander's profile shares as an unrelated old landscape photo on WhatsApp, while his in-app avatar is a completely different headshot. The worker was preferring `cover_url` over `avatar_url`, but there is no user-facing UI to update `cover_url` — so any profile row that ever received a value there (from a legacy flow, seed, or migration) is stuck with that image forever, decoupled from what the user sees and edits in the app.

Since "the preview should reflect the current profile picture" and the current profile picture is `avatar_url`, we source it from that column only. The HEAD-check safety net from PR #827 still applies and falls through to the branded hero if the avatar is missing or isn't crawler-fetchable.

### Test plan
- [ ] After auto-deploy, share Dragan Alexander's profile with a cache-busting query (`?v=3`) on WhatsApp. Preview should now show his actual current avatar (headshot), not the old landscape photo.
- [ ] Daniela's profile should still render an image — now sourced from her `avatar_url` rather than `cover_url`.
- [ ] Previously-broken profiles (`@jovanabizz`, `@mariia-maksina`) continue to fall through to the `covers/vitana-og-default.jpg` hero.
- [ ] `curl -A "WhatsApp/2.23" https://e.vitanaland.com/profiles/{id} | grep og:image` returns an avatar URL or the default image — never a `cover_url`.

Follow-up to PR #827.