### PR TITLE
fix(connectors): reuse /callback/google for YouTube OAuth (no GCP allowlist change)

### DIFF
--- a/services/gateway/src/routes/social-connect.ts
+++ b/services/gateway/src/routes/social-connect.ts
@@ -128,28 +128,40 @@ router.get('/connect/:provider', (req: Request, res: Response) => {
 
 // =============================================================================
 // GET /callback/:provider — OAuth callback (redirect from provider)
+//
+// NB: the :provider in the URL is what was registered in the OAuth client's
+// redirect-URI allowlist, which is not always the actual provider the user is
+// connecting. YouTube shares Google's OAuth client and rides on the
+// /callback/google URL (see callbackProviderFor). The real provider lives in
+// the state blob — parse that first, then dispatch.
 // =============================================================================
 router.get('/callback/:provider', async (req: Request, res: Response) => {
-  const provider = req.params.provider as SocialProvider;
+  const urlProvider = req.params.provider as SocialProvider;
   const { code, state, error: oauthError } = req.query;
-  const redirectPath = callbackRedirectPath(provider);
 
   if (oauthError) {
-    console.warn(`${LOG_PREFIX} OAuth error for ${provider}: ${oauthError}`);
-    return res.redirect(`${APP_URL}${redirectPath}?error=oauth_denied&provider=${provider}`);
+    const redirectPath = callbackRedirectPath(urlProvider);
+    console.warn(`${LOG_PREFIX} OAuth error for ${urlProvider}: ${oauthError}`);
+    return res.redirect(`${APP_URL}${redirectPath}?error=oauth_denied&provider=${urlProvider}`);
   }
 
   if (!code || !state) {
-    return res.redirect(`${APP_URL}${redirectPath}?error=missing_params&provider=${provider}`);
+    const redirectPath = callbackRedirectPath(urlProvider);
+    return res.redirect(`${APP_URL}${redirectPath}?error=missing_params&provider=${urlProvider}`);
   }
 
-  // Parse state to get userId and tenantId
+  // Parse state to get userId, tenantId and the real provider.
   const stateData = parseOAuthState(state as string);
   if (!stateData) {
-    return res.redirect(`${APP_URL}${redirectPath}?error=invalid_state&provider=${provider}`);
+    const redirectPath = callbackRedirectPath(urlProvider);
+    return res.redirect(`${APP_URL}${redirectPath}?error=invalid_state&provider=${urlProvider}`);
   }
 
-  console.log(`${LOG_PREFIX} Processing callback for ${provider}, user ${stateData.userId.slice(0, 8)}…`);
+  // From here on use the actual provider from state, not the URL path.
+  const provider = stateData.provider;
+  const redirectPath = callbackRedirectPath(provider);
+
+  console.log(`${LOG_PREFIX} Processing callback for ${provider} (url:${urlProvider}), user ${stateData.userId.slice(0, 8)}…`);
 
   // Exchange code for tokens
   const tokens = await exchangeCodeForTokens(provider, code as string);

--- a/services/gateway/src/services/social-connect-service.ts
+++ b/services/gateway/src/services/social-connect-service.ts
@@ -147,7 +147,7 @@ export function getOAuthUrl(
     return { url: '', error: `${config.name} is not configured. Missing ${config.clientIdEnv}.` };
   }
 
-  const callbackUrl = `${GATEWAY_URL}/api/v1/social-accounts/callback/${provider}`;
+  const callbackUrl = `${GATEWAY_URL}/api/v1/social-accounts/callback/${callbackProviderFor(provider)}`;
   const state = Buffer.from(JSON.stringify({ userId, tenantId, provider })).toString('base64url');
 
   const params = new URLSearchParams({
@@ -191,6 +191,22 @@ export function parseOAuthState(state: string): { userId: string; tenantId: stri
   }
 }
 
+/**
+ * Some providers share the same OAuth client as another provider and can
+ * reuse the sibling's callback URL. This avoids having to register a new
+ * redirect URI in the OAuth client's allowlist when splitting a bundled
+ * provider into a narrower one.
+ *
+ * YouTube rides on Google's OAuth client — returning 'google' here means the
+ * auth request, the token-exchange redirect_uri, and the browser-facing
+ * callback all hit /api/v1/social-accounts/callback/google. The real provider
+ * is then read back out of the state blob.
+ */
+export function callbackProviderFor(provider: SocialProvider): SocialProvider {
+  if (provider === 'youtube') return 'google';
+  return provider;
+}
+
 // =============================================================================
 // Token Exchange
 // =============================================================================
@@ -215,7 +231,8 @@ export async function exchangeCodeForTokens(
     return { access_token: '', error: `Missing OAuth credentials for ${config.name}` };
   }
 
-  const callbackUrl = `${GATEWAY_URL}/api/v1/social-accounts/callback/${provider}`;
+  // MUST match the redirect_uri used in the auth request.
+  const callbackUrl = `${GATEWAY_URL}/api/v1/social-accounts/callback/${callbackProviderFor(provider)}`;
 
   try {
     const body: Record<string, string> = {


### PR DESCRIPTION
## Summary

Follow-up to #831. Users reported the YouTube OAuth flow hangs right after picking a Google account. Root cause: the new `redirect_uri /api/v1/social-accounts/callback/youtube` isn't registered in the Google OAuth client's authorized redirect URIs list, and we don't currently have GCP console access to add it.

Workaround without any GCP change: route YouTube's OAuth through the already-allowlisted `/callback/google` path. Both providers use the same Google OAuth client under the hood, so they can share the redirect URI. The real provider is already encoded in the `state` blob, so the callback handler can dispatch correctly.

## Changes

- `services/gateway/src/services/social-connect-service.ts` — new `callbackProviderFor(provider)` helper: maps `youtube → google`, everyone else maps to themselves. `getOAuthUrl` and `exchangeCodeForTokens` both use it so the auth request's `redirect_uri` and the token-exchange `redirect_uri` match (Google rejects the token exchange if they don't).
- `services/gateway/src/routes/social-connect.ts` — the URL path `:provider` is now just the allowlist tag; the actual provider is read from `stateData.provider` and used for all downstream work (token exchange, profile fetch, DB storage, callback redirect path, `connected=...` query param).

Other providers (instagram/facebook/tiktok/linkedin/twitter) are unaffected — they each have their own OAuth clients with their own allowlisted callback URLs.

## Test plan

- [ ] Hit `GET /api/v1/social-accounts/connect/youtube` — response `auth_url` ends with `redirect_uri=...%2Fcallback%2Fgoogle` (google, not youtube) but its `state` decodes to `{..., "provider": "youtube"}`.
- [ ] Complete the flow on mobile: click Connect on YouTube in Music & Video → consent screen asks only for `youtube.readonly` + `userinfo.profile` → after Allow, land on `/settings/connected-apps?connected=youtube&username=...`.
- [ ] Existing Google connect flow still completes (smoke test `GET /api/v1/social-accounts/connect/google` → complete consent → `connected=google`).
- [ ] `social_connections` gets a `provider='youtube'` row after a successful YouTube connect.

https://claude.ai/code/session_016dtqLRd7XpCjQVLHzJaizP