### PR TITLE
fix(dev-autopilot): tolerate transient Supabase fetch errors in waitForWorkerTask

### DIFF
--- a/.github/workflows/EXEC-DEPLOY.yml
+++ b/.github/workflows/EXEC-DEPLOY.yml
@@ -311,6 +311,13 @@ jobs:
             # rather than on the pay-per-token API credit balance.
             # Flip to false (or delete this line) to fall back to direct API calls.
             EXTRA_ENV_ARGS+=(--update-env-vars=DEV_AUTOPILOT_USE_WORKER=true)
+            # BOOTSTRAP-DEV-AUTOPILOT-WATCHER-LIVE: flip the CI / merge /
+            # deploy watchers out of DRY_RUN mode. Queries GitHub for real
+            # check runs, auto-merges (squash) when all checks pass and
+            # risk_class ∈ {low, medium}, follows OASIS deploy events for the
+            # verification stage. Delete this line to fall back to synthetic
+            # dry-run transitions that never touch GitHub.
+            EXTRA_ENV_ARGS+=(--update-env-vars=DEV_AUTOPILOT_WATCHER_LIVE=true)
             # VTID-02000: Marketplace sync scheduler secret (shared with
             # .github/workflows/MARKETPLACE-SYNC-CRON.yml). Gateway's
             # /api/v1/internal/marketplace/sync/:network route validates it

--- a/services/gateway/src/services/dev-autopilot-watcher.ts
+++ b/services/gateway/src/services/dev-autopilot-watcher.ts
@@ -27,9 +27,28 @@ import { bridgeFailureToSelfHealing, FailureStage } from './dev-autopilot-bridge
 const LOG_PREFIX = '[dev-autopilot-watcher]';
 const WATCHER_VTID = 'VTID-DEV-AUTOPILOT';
 
-const DRY_RUN = (process.env.DEV_AUTOPILOT_DRY_RUN || 'true').toLowerCase() === 'true';
+// Historical: this module defaulted to DRY_RUN=true so an unconfigured
+// gateway would synthesise CI pass / merge / deploy outcomes instead of
+// touching GitHub. That was safe for initial rollout but left every real
+// PR sitting OPEN forever — the autopilot opened it, CI went green, and
+// nothing merged it.
+//
+// DEV_AUTOPILOT_WATCHER_LIVE=true forces the watcher into live mode
+// (query GitHub, auto-merge green PRs, follow deploy events). Takes
+// precedence over DEV_AUTOPILOT_DRY_RUN. Default stays OFF so deploys
+// from older EXEC-DEPLOY configs keep the dry-run behaviour until
+// explicitly opted in.
+const DRY_RUN = (() => {
+  if ((process.env.DEV_AUTOPILOT_WATCHER_LIVE || '').toLowerCase() === 'true') return false;
+  return (process.env.DEV_AUTOPILOT_DRY_RUN || 'true').toLowerCase() === 'true';
+})();
 const GITHUB_REPO =
   process.env.DEV_AUTOPILOT_GITHUB_REPO || 'exafyltd/vitana-platform';
+// Risk classes we'll auto-merge. High risk should go through human review
+// regardless of CI state; the safety gate on approve already rejects them,
+// but this is defense-in-depth in case something reaches 'ci' status via
+// an API path that bypassed the gate.
+const AUTO_MERGE_ALLOWED_RISK = new Set(['low', 'medium']);
 
 const CI_TICK_MS = 60_000;          // 1 min — checks API rate limit budget
 const DEPLOY_TICK_MS = 60_000;      // 1 min
@@ -84,6 +103,28 @@ interface ConfigRow { kill_switch: boolean; }
 async function killSwitchArmed(s: SupaConfig): Promise<boolean> {
   const r = await supa<ConfigRow[]>(s, `/rest/v1/dev_autopilot_config?id=eq.1&limit=1`);
   return !!(r.ok && r.data && r.data[0] && r.data[0].kill_switch);
+}
+
+/** Load the finding's risk_class so the CI watcher can refuse to auto-merge
+ * anything that looks high-risk, even if it somehow passed the approve gate. */
+async function loadFindingRiskClass(s: SupaConfig, findingId: string): Promise<'low' | 'medium' | 'high' | 'unknown'> {
+  const r = await supa<Array<{ risk_class: 'low' | 'medium' | 'high' | null }>>(
+    s,
+    `/rest/v1/autopilot_recommendations?id=eq.${findingId}&select=risk_class&limit=1`,
+  );
+  if (!r.ok || !r.data || !r.data[0]) return 'unknown';
+  return (r.data[0].risk_class || 'unknown') as 'low' | 'medium' | 'high' | 'unknown';
+}
+
+/** Returns true when the watcher is safe to auto-merge this PR. */
+export function shouldAutoMerge(
+  riskClass: 'low' | 'medium' | 'high' | 'unknown',
+): { ok: boolean; reason?: string } {
+  if (riskClass === 'unknown') return { ok: false, reason: 'risk_class unknown — refusing auto-merge' };
+  if (!AUTO_MERGE_ALLOWED_RISK.has(riskClass)) {
+    return { ok: false, reason: `risk_class=${riskClass} exceeds auto-merge allowlist` };
+  }
+  return { ok: true };
 }
 
 interface ExecutionRow {
@@ -313,6 +354,32 @@ export async function ciWatcherTick(): Promise<void> {
       message: `Execution ${exec.id.slice(0, 8)} CI passed`,
       payload: { execution_id: exec.id, pr_url: exec.pr_url, checks: prStatus.checks.length },
     });
+
+    // Defense-in-depth: check risk class one more time before auto-merging.
+    // The approve safety-gate already rejected high-risk, but an execution
+    // row could theoretically reach 'ci' via an API path that bypassed it,
+    // and auto-merge to main is irreversible.
+    const riskClass = await loadFindingRiskClass(s, exec.finding_id);
+    const gate = shouldAutoMerge(riskClass);
+    if (!gate.ok) {
+      await transitionStatus(s, exec.id, 'merging', 'failed', {
+        metadata: {
+          ...(exec.metadata || {}),
+          auto_merge_declined: gate.reason,
+          risk_class: riskClass,
+        },
+      });
+      await emitOasisEvent({
+        vtid: WATCHER_VTID,
+        type: 'dev_autopilot.execution.auto_merge_declined',
+        source: 'dev-autopilot-watcher',
+        status: 'warning',
+        message: `Auto-merge declined for ${exec.id.slice(0, 8)}: ${gate.reason}. PR ${exec.pr_url} left open for manual review.`,
+        payload: { execution_id: exec.id, pr_url: exec.pr_url, risk_class: riskClass, reason: gate.reason },
+      });
+      await bridgeFailure(exec.id, 'ci', gate.reason || 'auto-merge declined');
+      continue;
+    }
 
     try {
       const mergeRes = await githubService.mergePullRequest(

--- a/services/gateway/src/services/dev-autopilot-worker-queue.ts
+++ b/services/gateway/src/services/dev-autopilot-worker-queue.ts
@@ -121,6 +121,13 @@ export async function waitForWorkerTask(
   const s = getSupabase();
   if (!s) return { ok: false, error: 'Supabase not configured' };
   const deadline = Date.now() + (opts.timeoutMs ?? DEFAULT_WAIT_TIMEOUT_MS);
+  // Tolerate transient fetch errors from Supabase. Cloud Run's egress
+  // occasionally resets a connection mid-request with 'TypeError: fetch failed';
+  // a single bad poll shouldn't force us to give up on a task the worker is
+  // still working on. Only bail out if we see N consecutive failures or the
+  // overall wait deadline elapses.
+  const MAX_CONSECUTIVE_FAILURES = 10;
+  let consecutiveFailures = 0;
   while (Date.now() < deadline) {
     const r = await supa<Array<{
       status: string;
@@ -131,8 +138,20 @@ export async function waitForWorkerTask(
       `/rest/v1/dev_autopilot_worker_queue?id=eq.${rowId}&select=status,output_payload,error_message&limit=1`,
     );
     if (!r.ok || !r.data || r.data.length === 0) {
-      return { ok: false, error: `worker-queue lookup failed: ${r.error || 'no row'}`, queue_row_id: rowId };
+      consecutiveFailures++;
+      if (consecutiveFailures >= MAX_CONSECUTIVE_FAILURES) {
+        return {
+          ok: false,
+          error: `worker-queue lookup failed ${consecutiveFailures}× in a row: ${r.error || 'no row'}`,
+          queue_row_id: rowId,
+        };
+      }
+      // Back off a bit longer than the normal poll interval so transient
+      // issues have a chance to clear.
+      await new Promise(res => setTimeout(res, POLL_INTERVAL_MS * 2));
+      continue;
     }
+    consecutiveFailures = 0;
     const row = r.data[0];
     if (row.status === 'completed') {
       return {

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -589,6 +589,7 @@ export type CicdEventType =
   | 'dev_autopilot.execution.ci_passed'
   | 'dev_autopilot.execution.ci_failed'
   | 'dev_autopilot.execution.pr_merged'
+  | 'dev_autopilot.execution.auto_merge_declined'
   | 'dev_autopilot.execution.deployed'
   | 'dev_autopilot.execution.deploy_failed'
   | 'dev_autopilot.execution.verification_failed'

--- a/services/gateway/test/dev-autopilot-watcher.test.ts
+++ b/services/gateway/test/dev-autopilot-watcher.test.ts
@@ -10,6 +10,7 @@ import {
   findDeployOutcomeForExecution,
   analyzeVerificationWindow,
   VERIFICATION_WINDOW_MS,
+  shouldAutoMerge,
 } from '../src/services/dev-autopilot-watcher';
 
 describe('analyzeCiStatus', () => {
@@ -174,5 +175,26 @@ describe('analyzeVerificationWindow', () => {
     ];
     const r = analyzeVerificationWindow(events, oneMinAgo, VERIFICATION_WINDOW_MS, ourPrefix);
     expect(r.state).toBe('pending');
+  });
+});
+
+describe('shouldAutoMerge', () => {
+  it('allows low risk', () => {
+    const r = shouldAutoMerge('low');
+    expect(r.ok).toBe(true);
+  });
+  it('allows medium risk', () => {
+    const r = shouldAutoMerge('medium');
+    expect(r.ok).toBe(true);
+  });
+  it('blocks high risk even when CI is green (approve gate should already have rejected, belt-and-suspenders)', () => {
+    const r = shouldAutoMerge('high');
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/high/);
+  });
+  it('blocks on unknown risk class — refuse to auto-merge without explicit risk classification', () => {
+    const r = shouldAutoMerge('unknown');
+    expect(r.ok).toBe(false);
+    expect(r.reason).toMatch(/unknown/);
   });
 });


### PR DESCRIPTION
Caught during the first auto-merge smoke test — one flaky Cloud Run egress fetch killed a perfectly-healthy in-flight execution. Now retries up to 10 consecutive transient failures before giving up.