### PR TITLE
feat(orb): Vitana Index round 2 — rich profile + 3 action tools

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1890,6 +1890,108 @@ function buildLiveApiTools(mode: 'anonymous' | 'authenticated' = 'authenticated'
             required: ['question'],
           },
         },
+        // ─── BOOTSTRAP-ORB-INDEX-AWARENESS round 2 — Vitana Index tools ───
+        {
+          name: 'get_vitana_index',
+          description: [
+            'Return the user\'s current Vitana Index with full breakdown:',
+            'total score (0-999), tier, all 6 pillars, 7-day trend, weakest',
+            'pillar, 90-day goal gap.',
+            '',
+            'CALL THIS WHEN the user asks:',
+            '  - "What is my Vitana Index?" / "Was ist mein Vitana Index?"',
+            '  - "What\'s my score / tier?" / "Welchen Tier habe ich?"',
+            '  - "How am I doing?" / "Wie stehe ich?" (when health context is the topic)',
+            '',
+            'DO NOT CALL for generic "what IS the Vitana Index" (no "my") —',
+            'that\'s a platform explanation, use search_knowledge instead.',
+            '',
+            'The [HEALTH] block in the system prompt usually has the same info;',
+            'calling this tool gets the freshest snapshot and returns it in a',
+            'single structured object you can read aloud naturally.',
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {},
+          },
+        },
+        {
+          name: 'get_index_improvement_suggestions',
+          description: [
+            'Return 2-3 concrete actions the user can take to improve their',
+            'Vitana Index, ranked by predicted contribution. Each suggestion',
+            'includes a title, the pillar(s) it lifts, and a magnitude.',
+            '',
+            'CALL THIS WHEN the user asks:',
+            '  - "How can I improve my Index?" / "Wie verbessere ich meinen Index?"',
+            '  - "What\'s holding me back?" / "Was hält mich zurück?"',
+            '  - "What should I focus on?" / "Worauf soll ich mich konzentrieren?"',
+            '  - "Which pillar needs work?" / "Welche Säule brauche ich?"',
+            '',
+            'If the user names a pillar ("help me with Mental"), pass the',
+            'pillar argument. Otherwise omit it and the tool will target the',
+            'user\'s weakest pillar automatically.',
+            '',
+            'Speak the suggestions naturally — "a ten-minute morning meditation',
+            'would lift Mental by three points" — never read raw JSON.',
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              pillar: {
+                type: 'string',
+                enum: ['physical', 'mental', 'nutritional', 'social', 'environmental', 'prosperity'],
+                description: 'Optional pillar to focus on. Omit to target the weakest pillar automatically.',
+              },
+              limit: {
+                type: 'integer',
+                description: 'Max suggestions to return. Default 3.',
+              },
+            },
+          },
+        },
+        {
+          name: 'create_index_improvement_plan',
+          description: [
+            'Build a multi-event calendar plan that targets a weak pillar of',
+            'the user\'s Vitana Index, then write the events to their calendar',
+            'directly (autonomous — no per-event confirmation). Returns a',
+            'summary of what was scheduled for you to announce.',
+            '',
+            'CALL THIS WHEN the user asks:',
+            '  - "Make me a plan to improve my Index"',
+            '  - "Mach mir einen Plan für meinen Index"',
+            '  - "Schedule a routine for me" / "Plan mir eine Routine"',
+            '  - "Add things to my calendar to lift [pillar]"',
+            '',
+            'This is AUTONOMOUS by design — you do NOT need per-event',
+            'confirmation. Announce clearly in voice what you just scheduled',
+            '("I\'ve added three movement sessions this week and two',
+            'mindfulness blocks next week to lift your Mental pillar").',
+            '',
+            'If the user names a pillar, pass it. Otherwise the tool targets',
+            'the weakest pillar automatically. Days defaults to 14 (2 weeks),',
+            'actions_per_week defaults to 3.',
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              pillar: {
+                type: 'string',
+                enum: ['physical', 'mental', 'nutritional', 'social', 'environmental', 'prosperity'],
+                description: 'Optional pillar to focus on. Omit to target weakest automatically.',
+              },
+              days: {
+                type: 'integer',
+                description: 'How many days forward to schedule. Default 14.',
+              },
+              actions_per_week: {
+                type: 'integer',
+                description: 'Rough frequency. Default 3.',
+              },
+            },
+          },
+        },
       ],
     },
     // VTID-GOOGLE-SEARCH: Native Google Search grounding. Gemini calls
@@ -3542,6 +3644,254 @@ async function executeLiveApiToolInner(
         console.log(`[BOOTSTRAP-ORB-DELEGATION-ROUTE] consult_external_ai ok: provider=${outcome.result.providerId} model=${outcome.result.model} in=${outcome.result.usage.inputTokens} out=${outcome.result.usage.outputTokens} cost=$${outcome.result.usage.costUsd.toFixed(4)} latency=${outcome.result.latencyMs}ms`);
 
         return { success: true, result: voiceText };
+      }
+
+      // ─── BOOTSTRAP-ORB-INDEX-AWARENESS round 2 — Vitana Index tools ───
+      case 'get_vitana_index': {
+        try {
+          const { fetchVitanaIndexForProfiler } = await import('../services/user-context-profiler');
+          const { createClient } = await import('@supabase/supabase-js');
+          const url = process.env.SUPABASE_URL;
+          const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+          if (!url || !key) return { success: false, result: '', error: 'Supabase not configured' };
+          const client = createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
+          const snap = await fetchVitanaIndexForProfiler(client, lens.user_id);
+          if (!snap) {
+            return {
+              success: true,
+              result: 'I don\'t see a Vitana Index score yet — it looks like the baseline survey hasn\'t been completed. Want me to point you to the health screen so you can start?',
+            };
+          }
+          return {
+            success: true,
+            result: JSON.stringify({
+              total: snap.total,
+              tier: snap.tier,
+              pillars: snap.pillars,
+              weakest_pillar: snap.weakest_pillar,
+              strongest_pillar: snap.strongest_pillar,
+              trend_7d: snap.trend_7d,
+              goal_target: snap.goal_target,
+              goal_gap: snap.goal_gap,
+              last_computed: snap.last_computed,
+              last_movement: snap.last_movement,
+            }),
+          };
+        } catch (err: any) {
+          console.error('[get_vitana_index] error:', err?.message);
+          return { success: false, result: '', error: err?.message || 'unknown' };
+        }
+      }
+
+      case 'get_index_improvement_suggestions': {
+        try {
+          const { fetchVitanaIndexForProfiler } = await import('../services/user-context-profiler');
+          const { createClient } = await import('@supabase/supabase-js');
+          const url = process.env.SUPABASE_URL;
+          const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+          if (!url || !key) return { success: false, result: '', error: 'Supabase not configured' };
+          const client = createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
+
+          // Resolve target pillar: either user-specified or the weakest.
+          let pillar = typeof args.pillar === 'string' ? args.pillar : undefined;
+          if (!pillar) {
+            const snap = await fetchVitanaIndexForProfiler(client, lens.user_id);
+            pillar = snap?.weakest_pillar.name;
+          }
+          if (!pillar) {
+            return {
+              success: true,
+              result: 'I don\'t see Index data for this user yet, so I can\'t pick a target pillar. Complete the baseline survey first.',
+            };
+          }
+
+          const limit = typeof args.limit === 'number' ? Math.min(10, Math.max(1, args.limit)) : 3;
+
+          // Query autopilot_recommendations whose contribution_vector lifts the target pillar.
+          // We use a simple JSON path filter — rows where contribution_vector[pillar] > 0.
+          const { data, error } = await client
+            .from('autopilot_recommendations')
+            .select('id, title, action_description, contribution_vector, priority, status')
+            .eq('user_id', lens.user_id)
+            .in('status', ['pending', 'new', 'snoozed'])
+            .not('contribution_vector', 'is', null)
+            .order('priority', { ascending: false })
+            .limit(50);
+
+          if (error) {
+            return { success: false, result: '', error: `Could not fetch recommendations: ${error.message}` };
+          }
+
+          // Filter + rank by contribution_vector[pillar]
+          const ranked = (data || [])
+            .map((r: any) => {
+              const cv = r.contribution_vector as Record<string, number> | null;
+              const lift = cv && typeof cv[pillar!] === 'number' ? cv[pillar!] : 0;
+              return { ...r, _lift: lift };
+            })
+            .filter((r: any) => r._lift > 0)
+            .sort((a: any, b: any) => b._lift - a._lift)
+            .slice(0, limit);
+
+          if (ranked.length === 0) {
+            return {
+              success: true,
+              result: JSON.stringify({
+                pillar,
+                suggestions: [],
+                message: `No pending recommendations with a positive ${pillar} contribution right now. Completing ANY existing recommendation will trigger the Index engine to propose more.`,
+              }),
+            };
+          }
+
+          return {
+            success: true,
+            result: JSON.stringify({
+              pillar,
+              suggestions: ranked.map((r: any) => ({
+                id: r.id,
+                title: r.title,
+                action: r.action_description,
+                lift: r._lift,
+                contribution_vector: r.contribution_vector,
+              })),
+            }),
+          };
+        } catch (err: any) {
+          console.error('[get_index_improvement_suggestions] error:', err?.message);
+          return { success: false, result: '', error: err?.message || 'unknown' };
+        }
+      }
+
+      case 'create_index_improvement_plan': {
+        try {
+          const { fetchVitanaIndexForProfiler } = await import('../services/user-context-profiler');
+          const { createCalendarEvent } = await import('../services/calendar-service');
+          const { createClient } = await import('@supabase/supabase-js');
+          const url = process.env.SUPABASE_URL;
+          const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+          if (!url || !key) return { success: false, result: '', error: 'Supabase not configured' };
+          const client = createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
+
+          let pillar = typeof args.pillar === 'string' ? args.pillar : undefined;
+          if (!pillar) {
+            const snap = await fetchVitanaIndexForProfiler(client, lens.user_id);
+            pillar = snap?.weakest_pillar.name;
+          }
+          if (!pillar) {
+            return {
+              success: true,
+              result: 'I don\'t see Index data for this user yet, so I can\'t build a plan. Complete the baseline survey first.',
+            };
+          }
+
+          const days = typeof args.days === 'number' ? Math.min(90, Math.max(7, args.days)) : 14;
+          const perWeek = typeof args.actions_per_week === 'number' ? Math.min(7, Math.max(1, args.actions_per_week)) : 3;
+
+          // Pull top recommendations for this pillar.
+          const { data } = await client
+            .from('autopilot_recommendations')
+            .select('id, title, action_description, contribution_vector, priority')
+            .eq('user_id', lens.user_id)
+            .in('status', ['pending', 'new', 'snoozed'])
+            .not('contribution_vector', 'is', null)
+            .order('priority', { ascending: false })
+            .limit(50);
+
+          const ranked = (data || [])
+            .map((r: any) => {
+              const cv = r.contribution_vector as Record<string, number> | null;
+              const lift = cv && typeof cv[pillar!] === 'number' ? cv[pillar!] : 0;
+              return { ...r, _lift: lift };
+            })
+            .filter((r: any) => r._lift > 0)
+            .sort((a: any, b: any) => b._lift - a._lift);
+
+          if (ranked.length === 0) {
+            return {
+              success: true,
+              result: `No pending autopilot recommendations target your ${pillar} pillar right now. Try again after completing a few existing ones — the engine regenerates.`,
+            };
+          }
+
+          // Schedule: `perWeek` actions per 7-day block, cycling through the
+          // top recommendations. Each event is placed at a reasonable time
+          // (10 AM local — widget TZ preserved via clientContext is out of
+          // scope for this tool; UTC is fine, calendar-service renders local).
+          const weeks = Math.ceil(days / 7);
+          const totalEvents = weeks * perWeek;
+          const scheduled: { title: string; start_time: string }[] = [];
+          const startOfToday = new Date();
+          startOfToday.setHours(10, 0, 0, 0);
+          startOfToday.setDate(startOfToday.getDate() + 1); // start tomorrow
+
+          for (let i = 0; i < totalEvents; i++) {
+            const rec = ranked[i % ranked.length];
+            const eventDate = new Date(startOfToday);
+            // Spread events every 2-3 days.
+            eventDate.setDate(eventDate.getDate() + Math.floor((i * 7) / perWeek));
+            if (eventDate.getTime() > Date.now() + days * 24 * 60 * 60 * 1000) break;
+            const startIso = eventDate.toISOString();
+            const endIso = new Date(eventDate.getTime() + 30 * 60 * 1000).toISOString();
+
+            const pillarTagMap: Record<string, string[]> = {
+              physical: ['movement', 'exercise'],
+              mental: ['mindfulness', 'focus'],
+              nutritional: ['nutrition'],
+              social: ['community', 'social'],
+              environmental: ['environment'],
+              prosperity: ['growth'],
+            };
+            const wellnessTags = pillarTagMap[pillar!] || [pillar!];
+
+            try {
+              const evt = await createCalendarEvent(lens.user_id, {
+                title: rec.title,
+                start_time: startIso,
+                end_time: endIso,
+                description: `${rec.action_description || ''}\n\nPart of your Vitana Index improvement plan (target: ${pillar}).`.trim(),
+                event_type: 'health' as any,
+                status: 'confirmed',
+                priority: 'medium',
+                role_context: (session.active_role || 'community') as any,
+                source_type: 'assistant',
+                source_ref_type: 'autopilot_recommendation',
+                source_ref_id: rec.id,
+                priority_score: 60,
+                wellness_tags: wellnessTags,
+                metadata: { created_via: 'orb_voice', plan: 'index_improvement', target_pillar: pillar },
+                is_recurring: false,
+              });
+              if (evt) scheduled.push({ title: evt.title, start_time: evt.start_time });
+            } catch (evErr: any) {
+              console.warn(`[create_index_improvement_plan] event create failed: ${evErr?.message}`);
+            }
+          }
+
+          if (scheduled.length === 0) {
+            return {
+              success: false,
+              result: '',
+              error: 'No events could be scheduled (calendar write failed).',
+            };
+          }
+
+          return {
+            success: true,
+            result: JSON.stringify({
+              pillar,
+              days,
+              actions_per_week: perWeek,
+              scheduled_count: scheduled.length,
+              first_event: scheduled[0],
+              last_event: scheduled[scheduled.length - 1],
+              all_titles: scheduled.map(s => s.title),
+            }),
+          };
+        } catch (err: any) {
+          console.error('[create_index_improvement_plan] error:', err?.message);
+          return { success: false, result: '', error: err?.message || 'unknown' };
+        }
       }
 
       default:

--- a/services/gateway/src/services/awareness-registry.ts
+++ b/services/gateway/src/services/awareness-registry.ts
@@ -266,9 +266,10 @@ const M: AwarenessSignal[] = [
   { key: 'health.enabled', tier: 'health', subcategory: 'Section render', label: '[HEALTH] block', description: 'Inject health summary section.', default_on: true, params: [
       { key: 'window_days', label: 'Window (days)', type: 'int', default: 14, min: 1, max: 90, step: 1 },
   ]},
-  { key: 'health.vitana_index.score',      tier: 'health', subcategory: 'Vitana Index (VTID-01103)', label: 'Index score',     description: 'Latest Vitana Index score.',         default_on: true },
-  { key: 'health.vitana_index.sub_scores', tier: 'health', subcategory: 'Vitana Index (VTID-01103)', label: 'Sub-scores',      description: 'Sleep / stress / movement breakdown.',default_on: true, enforcement_status: 'pending' },
-  { key: 'health.vitana_index.deltas',     tier: 'health', subcategory: 'Vitana Index (VTID-01103)', label: 'Index deltas',    description: 'Day-over-day changes.',              default_on: true, enforcement_status: 'pending' },
+  { key: 'health.vitana_index.score',       tier: 'health', subcategory: 'Vitana Index (VTID-01103)', label: 'Index score + tier',       description: 'Latest Vitana Index total (0-999) + tier band (Starting / Developing / Fair / Good / Great / Excellent).', default_on: true },
+  { key: 'health.vitana_index.sub_scores',  tier: 'health', subcategory: 'Vitana Index (VTID-01103)', label: '6 pillars breakdown',      description: 'Physical / Mental / Nutritional / Social / Environmental / Prosperity — each 0-200 — plus weakest and strongest pillar annotations.', default_on: true },
+  { key: 'health.vitana_index.deltas',      tier: 'health', subcategory: 'Vitana Index (VTID-01103)', label: 'Trend + last movement',    description: '7-day trend and most recent index.recomputed event (which pillar moved, by how much, what triggered it).', default_on: true },
+  { key: 'health.vitana_index.goal_gap',    tier: 'health', subcategory: 'Vitana Index (VTID-01103)', label: '90-day goal gap',          description: 'Difference between current score and the default Good-tier goal (600). Positive = points needed, negative = above target.', default_on: true },
   { key: 'health.biomarker.upload_count',  tier: 'health', subcategory: 'Biomarkers',                 label: 'Upload count',    description: 'Recent biomarker uploads (count).',  default_on: true },
   { key: 'health.biomarker.recent_tests',  tier: 'health', subcategory: 'Biomarkers',                 label: 'Recent tests',    description: 'Names of recent tests.',             default_on: true, enforcement_status: 'pending' },
   { key: 'health.supplement.add_count',    tier: 'health', subcategory: 'Supplements',                label: 'Adds count',      description: 'Recent supplement additions.',       default_on: true },

--- a/services/gateway/src/services/user-context-profiler.ts
+++ b/services/gateway/src/services/user-context-profiler.ts
@@ -225,17 +225,120 @@ async function fetchPreferences(client: SupabaseClient, userId: string): Promise
   return out;
 }
 
-async function fetchVitanaIndex(client: SupabaseClient, userId: string): Promise<{ score: number; deltas?: Record<string, number> } | null> {
+// =============================================================================
+// Vitana Index (BOOTSTRAP-ORB-INDEX-AWARENESS round 2)
+// =============================================================================
+// Real schema, confirmed against migrations:
+//   vitana_index_scores: (tenant_id, user_id, date, score_total,
+//                         score_physical, score_mental, score_nutritional,
+//                         score_social, score_environmental, score_prosperity)
+// Tier bands (derived deterministically from score_total, matches the
+// platform's published bands):
+//   Starting   0-299
+//   Developing 300-499
+//   Fair       500-599
+//   Good       600-749
+//   Great      750-899
+//   Excellent  900-999
+// Default 90-day journey goal: Good (600+).
+// =============================================================================
+
+export interface VitanaIndexSnapshot {
+  total: number;
+  tier: string;
+  pillars: {
+    physical: number;
+    mental: number;
+    nutritional: number;
+    social: number;
+    environmental: number;
+    prosperity: number;
+  };
+  weakest_pillar: { name: string; score: number };
+  strongest_pillar: { name: string; score: number };
+  trend_7d: number;          // delta vs 7 days ago (0 if no earlier row)
+  history_7d: number[];      // [oldest, ..., latest] up to 7 entries
+  goal_target: number;       // 90-day default
+  goal_gap: number;          // target - total (positive = still needed, negative = over)
+  last_computed: string;     // ISO date
+  last_movement?: { pillar: string; delta: number; reason?: string }; // most recent index.recomputed event
+}
+
+function scoreTier(total: number): string {
+  if (total >= 900) return 'Excellent';
+  if (total >= 750) return 'Great';
+  if (total >= 600) return 'Good';
+  if (total >= 500) return 'Fair';
+  if (total >= 300) return 'Developing';
+  return 'Starting';
+}
+
+async function fetchVitanaIndex(client: SupabaseClient, userId: string): Promise<VitanaIndexSnapshot | null> {
+  // Pull last 7 days so we can compute trend + sparkline.
+  const sinceIso = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
   const { data, error } = await client
     .from('vitana_index_scores')
-    .select('score, sub_scores, computed_at')
+    .select('date, score_total, score_physical, score_mental, score_nutritional, score_social, score_environmental, score_prosperity')
     .eq('user_id', userId)
-    .order('computed_at', { ascending: false })
-    .limit(1)
-    .maybeSingle();
-  if (error || !data) return null;
-  return { score: Number(data.score) || 0, deltas: (data.sub_scores as Record<string, number>) || undefined };
+    .gte('date', sinceIso)
+    .order('date', { ascending: true })
+    .limit(14);
+  if (error || !data || data.length === 0) return null;
+
+  const rows = data as any[];
+  const latest = rows[rows.length - 1];
+  const earliest = rows[0];
+  const history_7d = rows.map(r => Number(r.score_total) || 0);
+  const total = Number(latest.score_total) || 0;
+  const pillars = {
+    physical: Number(latest.score_physical) || 0,
+    mental: Number(latest.score_mental) || 0,
+    nutritional: Number(latest.score_nutritional) || 0,
+    social: Number(latest.score_social) || 0,
+    environmental: Number(latest.score_environmental) || 0,
+    prosperity: Number(latest.score_prosperity) || 0,
+  };
+  const pillarEntries = Object.entries(pillars) as [keyof typeof pillars, number][];
+  pillarEntries.sort((a, b) => a[1] - b[1]);
+  const weakest_pillar = { name: pillarEntries[0][0], score: pillarEntries[0][1] };
+  const strongest_pillar = { name: pillarEntries[pillarEntries.length - 1][0], score: pillarEntries[pillarEntries.length - 1][1] };
+  const trend_7d = rows.length >= 2 ? total - (Number(earliest.score_total) || 0) : 0;
+
+  // Last movement event — optional, best-effort.
+  let last_movement: VitanaIndexSnapshot['last_movement'] | undefined;
+  try {
+    const { data: evt } = await client
+      .from('oasis_events')
+      .select('topic, payload, created_at')
+      .eq('actor_id', userId)
+      .eq('topic', 'index.recomputed')
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (evt) {
+      const p = (evt.payload as any) || {};
+      const delta = Number(p.total_delta ?? p.delta ?? 0);
+      const reason = p.reason ?? p.source ?? p.action_title;
+      if (delta !== 0) last_movement = { pillar: p.pillar ?? 'unknown', delta, reason };
+    }
+  } catch { /* best-effort */ }
+
+  return {
+    total,
+    tier: scoreTier(total),
+    pillars,
+    weakest_pillar,
+    strongest_pillar,
+    trend_7d,
+    history_7d,
+    goal_target: 600,
+    goal_gap: 600 - total,
+    last_computed: latest.date,
+    last_movement,
+  };
 }
+
+export { fetchVitanaIndex as fetchVitanaIndexForProfiler };
 
 /**
  * Collapse noisy nav events (page.view, auth.*) into a counted summary and
@@ -423,8 +526,54 @@ function buildPreferencesSection(prefs: PreferenceRow[]): string {
   return `[PREFERENCES]\n${lines.join('\n')}`;
 }
 
-function buildHealthSection(activities: ActivityRow[], vitana: { score: number; deltas?: Record<string, number> } | null): string {
+function formatPillarName(name: string): string {
+  return name.charAt(0).toUpperCase() + name.slice(1);
+}
+
+function buildHealthSection(activities: ActivityRow[], vitana: VitanaIndexSnapshot | null): string {
   const lines: string[] = [];
+
+  // Vitana Index — the user's KEY 90-day progress measure. Always rendered
+  // first when available.
+  if (vitana && vitana.total > 0) {
+    const trendStr = vitana.trend_7d > 0
+      ? `trending up +${vitana.trend_7d} over 7 days`
+      : vitana.trend_7d < 0
+        ? `trending down ${vitana.trend_7d} over 7 days`
+        : 'stable over 7 days';
+    lines.push(`- Vitana Index: ${vitana.total} / 999 (${vitana.tier} tier), ${trendStr}.`);
+
+    // Pillar breakdown, weakest marked explicitly so the model can name it.
+    const p = vitana.pillars;
+    const pillarLines = [
+      `Physical ${p.physical}/200`,
+      `Mental ${p.mental}/200`,
+      `Nutritional ${p.nutritional}/200`,
+      `Social ${p.social}/200`,
+      `Environmental ${p.environmental}/200`,
+      `Prosperity ${p.prosperity}/200`,
+    ];
+    lines.push(`- Pillars: ${pillarLines.join(', ')}.`);
+    lines.push(`- Weakest pillar: ${formatPillarName(vitana.weakest_pillar.name)} (${vitana.weakest_pillar.score}/200) — this is where improvements move the Index most.`);
+    lines.push(`- Strongest pillar: ${formatPillarName(vitana.strongest_pillar.name)} (${vitana.strongest_pillar.score}/200).`);
+
+    // Goal gap — default 90-day goal is Good (600+).
+    if (vitana.goal_gap > 0) {
+      lines.push(`- 90-day goal: reach Good tier (${vitana.goal_target}). Currently ${vitana.goal_gap} points below target.`);
+    } else {
+      lines.push(`- 90-day goal: reach Good tier (${vitana.goal_target}). Already ${Math.abs(vitana.goal_gap)} points above target — keep the momentum.`);
+    }
+
+    // Most recent movement, if any.
+    if (vitana.last_movement) {
+      const m = vitana.last_movement;
+      const sign = m.delta > 0 ? '+' : '';
+      const reason = m.reason ? ` from "${m.reason}"` : '';
+      lines.push(`- Last movement: ${sign}${m.delta} ${formatPillarName(m.pillar)}${reason}.`);
+    }
+  }
+
+  // Rest of health signals — biomarkers + supplements.
   const healthActivities = activities.filter(a => a.activity_type.startsWith('health.'));
   if (healthActivities.length) {
     const uploads = healthActivities.filter(a => a.activity_type.includes('upload') || a.activity_type.includes('connect')).length;
@@ -432,9 +581,7 @@ function buildHealthSection(activities: ActivityRow[], vitana: { score: number; 
     if (uploads) lines.push(`- ${uploads} health data upload${uploads === 1 ? '' : 's'} in the last 14 days.`);
     if (supplements) lines.push(`- Added ${supplements} supplement${supplements === 1 ? '' : 's'} recently.`);
   }
-  if (vitana && vitana.score > 0) {
-    lines.push(`- Latest Vitana Index: ${vitana.score.toFixed(1)}.`);
-  }
+
   if (!lines.length) return '';
   return `[HEALTH]\n${lines.join('\n')}`;
 }


### PR DESCRIPTION
Round 2 completes the Vitana Index ↔ Assistant wiring. Round 1 (#822) gave the rules + routing; this adds the data + the hands. Builds on parallel plan Phase A+D (#823) which made the Index real and seeded the KB docs.

1) user-context-profiler.ts — fetchVitanaIndex fully rewritten. Previous version queried columns that never existed (score / sub_scores / computed_at); real schema is score_total / score_physical / ... / score_prosperity / date. Now returns a structured snapshot with total + tier + 6 pillars + weakest/strongest + 7-day trend + goal gap + most recent index.recomputed movement.

buildHealthSection rewritten to render the full breakdown instead of one line. Gives the voice model an unambiguous statement of score + tier + trend + pillars + weakest + goal status + last movement.

2) Three new ORB tools:
- get_vitana_index — fresh snapshot JSON (use when [HEALTH] might be stale)
- get_index_improvement_suggestions(pillar?, limit=3) — ranks pending autopilot_recommendations by contribution_vector[pillar], targets weakest pillar by default
- create_index_improvement_plan(pillar?, days=14, actions_per_week=3) — AUTONOMOUS calendar plan builder. Cycles top recs for the target pillar, writes calendar events spaced every 2-3 days with correct wellness_tags so Phase B's completion loop credits the right pillar. Per user call, no per-event confirmation — announces what was scheduled.

3) awareness-registry.ts — flipped health.vitana_index.sub_scores and .deltas from pending to live, added goal_gap, updated labels/descriptions to reflect the enriched HEALTH section.

End-to-end behaviour after deploy:
- 'What is my Vitana Index?' → answers from [HEALTH] with number + tier + trend
- 'How can I improve?' → calls get_index_improvement_suggestions, speaks 2-3 ranked actions
- 'Make me a plan' → calls create_index_improvement_plan, writes calendar events, announces plan
- Mark event complete → Phase B's index.recomputed fires → next ORB turn shows updated number

No migrations. No new tables. Reuses createCalendarEvent, autopilot_recommendations.contribution_vector, vitana_index_scores.

Generated with Claude Code