### PR TITLE
fix(rls): vitana_index_scores user-only policy (BOOTSTRAP-VITANA-INDEX-RLS)

### DIFF
--- a/supabase/migrations/20260423080000_vitana_index_scores_schema_repair.sql
+++ b/supabase/migrations/20260423080000_vitana_index_scores_schema_repair.sql
@@ -1,0 +1,48 @@
+-- =============================================================================
+-- vitana_index_scores — schema repair: add the columns that
+-- 20251231000000_vtid_01103_health_compute_engine.sql intended to create but
+-- couldn't because the table was pre-created by the earlier VTID-01078 c1
+-- migration with `CREATE TABLE IF NOT EXISTS`.
+--
+-- Missing columns the current gateway code + RPC depend on:
+--   score_physical, score_nutritional, score_social, score_environmental,
+--   feature_inputs, confidence, metadata, updated_at
+--
+-- `score_prosperity` is added by the proactive-guide phase0 migration (already
+-- re-applied on 2026-04-23) — included here as IF NOT EXISTS to be safe.
+--
+-- `score_mental` already exists in both old and new schemas — same semantics.
+--
+-- Idempotent via IF NOT EXISTS. Safe to re-run.
+-- =============================================================================
+
+BEGIN;
+
+ALTER TABLE public.vitana_index_scores
+  ADD COLUMN IF NOT EXISTS score_physical INTEGER DEFAULT 0
+    CHECK (score_physical IS NULL OR (score_physical >= 0 AND score_physical <= 200)),
+  ADD COLUMN IF NOT EXISTS score_nutritional INTEGER DEFAULT 0
+    CHECK (score_nutritional IS NULL OR (score_nutritional >= 0 AND score_nutritional <= 200)),
+  ADD COLUMN IF NOT EXISTS score_social INTEGER DEFAULT 0
+    CHECK (score_social IS NULL OR (score_social >= 0 AND score_social <= 200)),
+  ADD COLUMN IF NOT EXISTS score_environmental INTEGER DEFAULT 0
+    CHECK (score_environmental IS NULL OR (score_environmental >= 0 AND score_environmental <= 200)),
+  ADD COLUMN IF NOT EXISTS score_prosperity SMALLINT DEFAULT 100
+    CHECK (score_prosperity IS NULL OR (score_prosperity >= 0 AND score_prosperity <= 200)),
+  ADD COLUMN IF NOT EXISTS feature_inputs JSONB DEFAULT '{}'::JSONB,
+  ADD COLUMN IF NOT EXISTS confidence NUMERIC DEFAULT 1.0,
+  ADD COLUMN IF NOT EXISTS metadata JSONB DEFAULT '{}'::JSONB,
+  ADD COLUMN IF NOT EXISTS updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW();
+
+COMMENT ON COLUMN public.vitana_index_scores.score_physical IS
+  'Physical pillar (0-200). Added 2026-04-23 schema repair.';
+COMMENT ON COLUMN public.vitana_index_scores.score_nutritional IS
+  'Nutritional pillar (0-200). Added 2026-04-23 schema repair (distinct from legacy score_nutrition).';
+COMMENT ON COLUMN public.vitana_index_scores.score_social IS
+  'Social pillar (0-200). Added 2026-04-23 schema repair.';
+COMMENT ON COLUMN public.vitana_index_scores.score_environmental IS
+  'Environmental pillar (0-200). Added 2026-04-23 schema repair.';
+COMMENT ON COLUMN public.vitana_index_scores.confidence IS
+  'Compute confidence 0.0-1.0. Added 2026-04-23 schema repair.';
+
+COMMIT;

--- a/supabase/migrations/20260423081500_vitana_index_scores_rls_simplify.sql
+++ b/supabase/migrations/20260423081500_vitana_index_scores_rls_simplify.sql
@@ -1,0 +1,38 @@
+-- =============================================================================
+-- vitana_index_scores — simplify RLS to user-only
+-- Date: 2026-04-23
+--
+-- The c1 migration (20251231000000_vtid_01078) created 4 separate policies
+-- (select/insert/update/delete) that check both tenant_id = current_tenant_id()
+-- AND user_id = current_user_id(). Supabase JWTs do not carry tenant_id claims
+-- by default, so current_tenant_id() returns NULL for browser-direct queries
+-- and rows are invisible to their own owner.
+--
+-- The c3 migration added a user-only policy, but the c1 policies were never
+-- dropped. Policies OR-combine, but if the c3 policy failed to apply, the
+-- strict c1 tenant-gated check is all that's left.
+--
+-- This migration:
+--   1. Drops the c1 tenant-gated policies (all 4)
+--   2. Drops any previous "user_policy" (idempotent re-creation)
+--   3. Creates a single FOR ALL user-scoped policy
+--
+-- Service-role writes (gateway admin client) still bypass RLS as they always
+-- have, so nothing server-side changes. This just makes the row visible to
+-- its actual owner when read via the anon key + user JWT.
+-- =============================================================================
+
+BEGIN;
+
+DROP POLICY IF EXISTS vitana_index_scores_select ON public.vitana_index_scores;
+DROP POLICY IF EXISTS vitana_index_scores_insert ON public.vitana_index_scores;
+DROP POLICY IF EXISTS vitana_index_scores_update ON public.vitana_index_scores;
+DROP POLICY IF EXISTS vitana_index_scores_delete ON public.vitana_index_scores;
+DROP POLICY IF EXISTS vitana_index_scores_user_policy ON public.vitana_index_scores;
+
+CREATE POLICY vitana_index_scores_user_policy ON public.vitana_index_scores
+  FOR ALL
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+COMMIT;


### PR DESCRIPTION
Drops the c1 tenant+user RLS policies on vitana_index_scores. Supabase JWTs don't carry tenant_id → current_tenant_id() returns NULL → users can't see their own rows. Replaces with user_id = auth.uid() FOR ALL policy. Also includes the column-repair migration (adds score_physical/score_nutritional/score_social/score_environmental/confidence/feature_inputs/metadata/updated_at).