### PR TITLE
feat(autopilot-worker): pre-PR jest validation — catch test-logic bugs

### DIFF
--- a/services/autopilot-worker/src/index.ts
+++ b/services/autopilot-worker/src/index.ts
@@ -19,7 +19,9 @@ import { claimNextTask, completeTask, failTask, queueDepth, type QueueRow } from
 import { runClaude, type RunClaudeResult } from './claude';
 import { parseExecutionOutput } from './parse';
 import { applyFiles, fetchAndReset, resetClean } from './repo';
-import { runTsc } from './validate';
+import { runTsc, runJest } from './validate';
+import { join } from 'path';
+import { CLONE_ROOT } from './repo';
 import { buildRetryPrompt } from './retry';
 
 const LOG_PREFIX = '[autopilot-worker]';
@@ -37,6 +39,13 @@ const VALIDATION_MAX_ATTEMPTS = Number(process.env.AUTOPILOT_WORKER_VALIDATION_M
 const VALIDATION_TSCONFIG = process.env.AUTOPILOT_WORKER_TSCONFIG
   || 'services/gateway/tsconfig.json';
 const VALIDATION_BASE_BRANCH = process.env.AUTOPILOT_WORKER_BASE_BRANCH || 'main';
+// Directory containing the jest.config.js that owns the changed test files.
+// jest needs to be invoked from this directory so its `roots` resolve.
+const VALIDATION_JEST_PROJECT_DIR = process.env.AUTOPILOT_WORKER_JEST_PROJECT_DIR
+  || 'services/gateway';
+// jest can be slow + flaky for some tests. The worker can skip jest and rely
+// on tsc-only validation by setting AUTOPILOT_WORKER_RUN_JEST=false.
+const RUN_JEST = (process.env.AUTOPILOT_WORKER_RUN_JEST || 'true').toLowerCase() !== 'false';
 
 let running = 0;
 let shuttingDown = false;
@@ -156,8 +165,29 @@ async function runExecuteWithValidation(
     const tsc = await runTsc(VALIDATION_TSCONFIG, applied.paths);
     validationElapsedTotal += tsc.elapsedMs;
 
-    if (tsc.ok) {
-      log(`  attempt ${attempt + 1} PASSED validation in ${Math.round(tsc.elapsedMs / 1000)}s (${parsed.files.length} files applied)`);
+    if (!tsc.ok) {
+      const errCount = (tsc.relevantErrors || []).length;
+      lastError = tsc.error || `${errCount} tsc error(s) in changed files`;
+      log(`  attempt ${attempt + 1} FAILED tsc in ${Math.round(tsc.elapsedMs / 1000)}s — ${errCount} relevant error(s)`);
+      currentPrompt = buildRetryPrompt(
+        basePrompt,
+        claudeResult.text,
+        tsc.relevantErrors && tsc.relevantErrors.length > 0
+          ? tsc.relevantErrors
+          : [tsc.error || 'tsc failed with no specific errors extracted'],
+        attempt,
+      );
+      continue;
+    }
+
+    // tsc passed. Now run jest --findRelatedTests on the same paths so
+    // logic-level bugs (Claude's test asserts the wrong shape, mocks the
+    // wrong module, etc.) get caught before the gateway opens the PR.
+    // The class of bug we just hit on PR #844 (memory.test.ts compiled
+    // fine but its assertions failed at runtime) is exactly what this
+    // catches.
+    if (!RUN_JEST) {
+      log(`  attempt ${attempt + 1} PASSED tsc in ${Math.round(tsc.elapsedMs / 1000)}s (jest skipped)`);
       await resetClean();
       return {
         ok: true,
@@ -168,17 +198,30 @@ async function runExecuteWithValidation(
       };
     }
 
-    const errCount = (tsc.relevantErrors || []).length;
-    lastError = tsc.error || `${errCount} tsc error(s) in changed files`;
-    log(`  attempt ${attempt + 1} FAILED validation in ${Math.round(tsc.elapsedMs / 1000)}s — ${errCount} relevant tsc error(s)`);
-    currentPrompt = buildRetryPrompt(
-      basePrompt,
-      claudeResult.text,
-      tsc.relevantErrors && tsc.relevantErrors.length > 0
-        ? tsc.relevantErrors
-        : [tsc.error || 'tsc failed with no specific errors extracted'],
-      attempt,
-    );
+    const jest = await runJest(join(CLONE_ROOT, VALIDATION_JEST_PROJECT_DIR), applied.paths);
+    validationElapsedTotal += jest.elapsedMs;
+
+    if (jest.ok) {
+      log(`  attempt ${attempt + 1} PASSED tsc + jest (${jest.testsPassed}/${jest.testsRun} tests) in ${Math.round((tsc.elapsedMs + jest.elapsedMs) / 1000)}s`);
+      await resetClean();
+      return {
+        ok: true,
+        text: claudeResult.text,
+        usage: claudeResult.usage,
+        attempts: attempt + 1,
+        validation_elapsed_ms: validationElapsedTotal,
+      };
+    }
+
+    const failCount = (jest.failures || []).length;
+    lastError = jest.error || `${jest.testsFailed}/${jest.testsRun} jest test(s) failed`;
+    log(`  attempt ${attempt + 1} FAILED jest in ${Math.round(jest.elapsedMs / 1000)}s — ${failCount} failure(s) (${jest.testsPassed}/${jest.testsRun} passed)`);
+    // Feed the jest failures back to Claude — labeling them so it knows
+    // these are runtime assertion errors, not type errors.
+    const jestErrorBlock = jest.failures && jest.failures.length > 0
+      ? jest.failures.map(f => `[jest] ${f}`)
+      : [`[jest] ${jest.error || `${jest.testsFailed} test(s) failed (no specific failure messages extracted)`}`];
+    currentPrompt = buildRetryPrompt(basePrompt, claudeResult.text, jestErrorBlock, attempt);
   }
 
   // All attempts exhausted. Return the last output anyway — some classes of

--- a/services/autopilot-worker/src/validate.ts
+++ b/services/autopilot-worker/src/validate.ts
@@ -130,3 +130,176 @@ export function filterErrorsToChangedFiles(
   }
   return out;
 }
+
+// =============================================================================
+// jest validation — run `jest --findRelatedTests` on changed paths
+// =============================================================================
+
+const JEST_TIMEOUT_MS = 180_000; // 3 min — most route tests run in <30s; pad for cold ts-jest start
+const JEST_BIN = process.env.AUTOPILOT_WORKER_JEST_BIN || 'npx';
+const JEST_ARGS_PREFIX = JEST_BIN === 'npx' ? ['jest'] : [];
+
+export interface JestResult {
+  ok: boolean;
+  /** Truncated jest stdout — useful for the retry prompt. */
+  raw?: string;
+  /** Compact human-readable failure descriptions, one per failed assertion. */
+  failures?: string[];
+  /** Tests jest actually ran (so we can tell "no tests touched" from "all passed"). */
+  testsRun: number;
+  testsPassed: number;
+  testsFailed: number;
+  elapsedMs: number;
+  error?: string;
+}
+
+interface JestJsonReport {
+  numTotalTests?: number;
+  numPassedTests?: number;
+  numFailedTests?: number;
+  numPendingTests?: number;
+  testResults?: Array<{
+    name: string;
+    testResults?: Array<{
+      ancestorTitles?: string[];
+      title?: string;
+      status?: string;
+      failureMessages?: string[];
+    }>;
+  }>;
+}
+
+/**
+ * Run jest with --findRelatedTests over the changed files. Targets ONLY tests
+ * that exercise paths we touched, so we don't pay for the whole suite.
+ *
+ * paths: absolute paths returned by repo.applyFiles().
+ * jestProjectDir: absolute path of the directory containing jest.config.js
+ *                 (typically <CLONE_ROOT>/services/gateway).
+ */
+export async function runJest(
+  jestProjectDir: string,
+  changedAbsPaths: string[],
+): Promise<JestResult> {
+  const startedAt = Date.now();
+  if (changedAbsPaths.length === 0) {
+    return { ok: true, testsRun: 0, testsPassed: 0, testsFailed: 0, elapsedMs: 0, raw: '' };
+  }
+
+  // Pass paths relative to the jest project so jest's own resolver matches.
+  const relPaths = changedAbsPaths.map(p => relative(jestProjectDir, p).replace(/\\/g, '/'));
+  // Strip files outside the jest project (e.g. supabase/migrations changes
+  // cited in the same plan would confuse jest).
+  const inProject = relPaths.filter(p => !p.startsWith('..'));
+  if (inProject.length === 0) {
+    return { ok: true, testsRun: 0, testsPassed: 0, testsFailed: 0, elapsedMs: 0, raw: '(no files inside the jest project)' };
+  }
+
+  // --json gives us a structured report we can parse instead of guessing
+  // from terminal output. --passWithNoTests so a non-test file with no
+  // dependent tests doesn't trip on "no tests found".
+  const args = [
+    ...JEST_ARGS_PREFIX,
+    '--findRelatedTests',
+    ...inProject,
+    '--passWithNoTests',
+    '--json',
+    '--silent',
+    '--no-coverage',
+    '--testTimeout=30000',
+  ];
+
+  let stdout = '';
+  let stderr = '';
+  try {
+    const r = await exec(JEST_BIN, args, {
+      cwd: jestProjectDir,
+      timeout: JEST_TIMEOUT_MS,
+      maxBuffer: 50 * 1024 * 1024,
+      env: { ...process.env, FORCE_COLOR: '0', CI: 'true' },
+    });
+    stdout = r.stdout.toString();
+    stderr = r.stderr.toString();
+  } catch (err) {
+    const e = err as { stdout?: string | Buffer; stderr?: string | Buffer; code?: number; killed?: boolean };
+    if (e.killed) {
+      return {
+        ok: false,
+        error: `jest timed out after ${Math.round(JEST_TIMEOUT_MS / 1000)}s`,
+        testsRun: 0, testsPassed: 0, testsFailed: 0,
+        elapsedMs: Date.now() - startedAt,
+      };
+    }
+    stdout = e.stdout ? e.stdout.toString() : '';
+    stderr = e.stderr ? e.stderr.toString() : '';
+    // jest exits non-zero on failures — that's a normal "tests failed" state,
+    // we still want to parse stdout for the report.
+  }
+
+  const elapsedMs = Date.now() - startedAt;
+  const report = parseJestReport(stdout);
+  if (!report) {
+    // No parseable report — usually a config/setup error, not a test failure.
+    return {
+      ok: false,
+      raw: (stdout + stderr).slice(-4000),
+      error: 'jest produced no parseable JSON report (likely a setup error)',
+      testsRun: 0, testsPassed: 0, testsFailed: 0,
+      elapsedMs,
+    };
+  }
+
+  const failures = extractJestFailures(report);
+  const ok = failures.length === 0 && (report.numFailedTests || 0) === 0;
+  console.log(
+    `${LOG_PREFIX} jest ran ${report.numTotalTests || 0} test(s) in ${Math.round(elapsedMs / 1000)}s — ${report.numPassedTests || 0} passed, ${report.numFailedTests || 0} failed`,
+  );
+  return {
+    ok,
+    raw: stdout.slice(-8000),
+    failures,
+    testsRun: report.numTotalTests || 0,
+    testsPassed: report.numPassedTests || 0,
+    testsFailed: report.numFailedTests || 0,
+    elapsedMs,
+  };
+}
+
+/** Try to find a single JSON object in jest's stdout. Some setups print
+ * setup-loader messages BEFORE the report; we just hunt for the last
+ * top-level brace pair. */
+export function parseJestReport(stdout: string): JestJsonReport | null {
+  const start = stdout.indexOf('{');
+  const end = stdout.lastIndexOf('}');
+  if (start < 0 || end < 0 || end <= start) return null;
+  const slice = stdout.slice(start, end + 1);
+  try {
+    return JSON.parse(slice) as JestJsonReport;
+  } catch {
+    return null;
+  }
+}
+
+/** Pull "TestSuite > nested > describe — assertion message (first line)"
+ * for each failed test. Keeps the retry prompt small + actionable. */
+export function extractJestFailures(report: JestJsonReport): string[] {
+  const out: string[] = [];
+  for (const file of report.testResults || []) {
+    for (const t of file.testResults || []) {
+      if (t.status === 'failed') {
+        const fullName = [...(t.ancestorTitles || []), t.title || '(unnamed)'].join(' > ');
+        const firstFailure = (t.failureMessages || [])[0] || '(no failure message)';
+        // Take the first 5 lines of the failure — usually enough to see what
+        // assertion failed without dragging in full stack.
+        const concise = firstFailure
+          .split('\n')
+          .filter(l => l.trim().length > 0)
+          .slice(0, 5)
+          .map(l => `    ${l.replace(/\x1B\[[0-9;]*[A-Za-z]/g, '').trim()}`)
+          .join('\n');
+        out.push(`✗ ${fullName}\n${concise}`);
+      }
+    }
+  }
+  return out;
+}

--- a/services/autopilot-worker/test/validate.test.ts
+++ b/services/autopilot-worker/test/validate.test.ts
@@ -6,7 +6,7 @@
  * as "your retry must fix these".
  */
 
-import { filterErrorsToChangedFiles } from '../src/validate';
+import { filterErrorsToChangedFiles, parseJestReport, extractJestFailures } from '../src/validate';
 
 describe('filterErrorsToChangedFiles', () => {
   it('keeps errors that reference a changed file, drops the rest', () => {
@@ -51,5 +51,82 @@ describe('filterErrorsToChangedFiles', () => {
       'services/gateway/src/routes/tasks.test.ts',
     ]));
     expect(out).toHaveLength(1);
+  });
+});
+
+describe('parseJestReport', () => {
+  it('parses a clean json report', () => {
+    const report = {
+      numTotalTests: 3,
+      numPassedTests: 3,
+      numFailedTests: 0,
+      testResults: [{ name: 'foo.test.ts', testResults: [] }],
+    };
+    const out = parseJestReport(JSON.stringify(report));
+    expect(out).not.toBeNull();
+    expect(out!.numTotalTests).toBe(3);
+  });
+
+  it('strips leading non-JSON noise (setup loader logs etc.)', () => {
+    const report = { numTotalTests: 1, numPassedTests: 1, numFailedTests: 0, testResults: [] };
+    const stdout = '✅ Test setup loaded - fetch mocked, env vars set\n' + JSON.stringify(report);
+    const out = parseJestReport(stdout);
+    expect(out).not.toBeNull();
+    expect(out!.numTotalTests).toBe(1);
+  });
+
+  it('returns null when stdout has no parseable JSON', () => {
+    expect(parseJestReport('jest crashed: cannot find module')).toBeNull();
+  });
+});
+
+describe('extractJestFailures', () => {
+  it('returns empty array when no tests failed', () => {
+    const report = {
+      numTotalTests: 2, numPassedTests: 2, numFailedTests: 0,
+      testResults: [{
+        name: 'a.test.ts',
+        testResults: [
+          { ancestorTitles: ['Suite'], title: 'works', status: 'passed', failureMessages: [] },
+          { ancestorTitles: ['Suite'], title: 'also works', status: 'passed', failureMessages: [] },
+        ],
+      }],
+    };
+    expect(extractJestFailures(report)).toEqual([]);
+  });
+
+  it('extracts failure name + first 5 lines of failure message per failed test', () => {
+    const report = {
+      testResults: [{
+        name: 'memory.test.ts',
+        testResults: [
+          {
+            ancestorTitles: ['GET /api/v1/memory', 'when query missing'],
+            title: 'returns 400',
+            status: 'failed',
+            failureMessages: [
+              'Expected: 400\nReceived: 500\n  at line 42\n  at line 50\n  at line 60\n  at line 70\n  at line 80',
+            ],
+          },
+        ],
+      }],
+    };
+    const out = extractJestFailures(report);
+    expect(out).toHaveLength(1);
+    expect(out[0]).toContain('GET /api/v1/memory > when query missing > returns 400');
+    expect(out[0]).toContain('Expected: 400');
+    expect(out[0]).toContain('Received: 500');
+    // Should NOT include the 6th line (capped at 5)
+    expect(out[0]).not.toContain('at line 80');
+  });
+
+  it('handles multiple failed tests across multiple suites', () => {
+    const report = {
+      testResults: [
+        { name: 'a.test.ts', testResults: [{ ancestorTitles: ['A'], title: 'fails', status: 'failed', failureMessages: ['boom'] }] },
+        { name: 'b.test.ts', testResults: [{ ancestorTitles: ['B'], title: 'also fails', status: 'failed', failureMessages: ['bang'] }] },
+      ],
+    };
+    expect(extractJestFailures(report)).toHaveLength(2);
   });
 });


### PR DESCRIPTION
Adds `jest --findRelatedTests` after tsc passes. Catches the class of LLM bug PR #826's tsc-only validation misses: test files that compile fine but fail their own assertions at runtime (exact failure mode on PR #844's `memory.test.ts`). 24/24 worker tests pass. Knobs: `AUTOPILOT_WORKER_RUN_JEST=false` to skip; `AUTOPILOT_WORKER_JEST_PROJECT_DIR` to point at a different jest project.