### PR TITLE
fix(autopilot-worker): npm install on first clone — validation was running blind

### DIFF
--- a/services/autopilot-worker/src/repo.ts
+++ b/services/autopilot-worker/src/repo.ts
@@ -63,19 +63,53 @@ export function clonePath(): string {
 }
 
 /**
- * Ensure a working clone exists at CLONE_ROOT. Creates it if missing.
- * Idempotent — safe to call on every task.
+ * Directories under the clone that need `npm ci` (or `npm install`) before
+ * tsc / jest validation can do anything useful — without node_modules
+ * present, tsc reports "Cannot find module 'express'" on every file and
+ * jest fails to load setup files.
+ *
+ * Override with AUTOPILOT_WORKER_INSTALL_DIRS=services/gateway,services/foo
+ * if you need to validate against more than one project.
+ */
+const INSTALL_DIRS = (process.env.AUTOPILOT_WORKER_INSTALL_DIRS || 'services/gateway')
+  .split(',').map(s => s.trim()).filter(Boolean);
+
+const NPM_INSTALL_TIMEOUT_MS = 10 * 60_000; // 10 min — first-run install can be slow
+
+/**
+ * Ensure a working clone exists at CLONE_ROOT. Creates it if missing,
+ * AND installs npm deps in the validation project dirs so tsc / jest
+ * have something to resolve against.
+ *
+ * Idempotent — safe to call on every task. Both checks (clone exists,
+ * node_modules exists) skip the slow path on subsequent calls.
  */
 export async function ensureClone(): Promise<{ ok: boolean; path?: string; error?: string }> {
   try {
-    if (await exists(join(CLONE_ROOT, '.git'))) {
-      return { ok: true, path: CLONE_ROOT };
+    if (!(await exists(join(CLONE_ROOT, '.git')))) {
+      await mkdir(dirname(CLONE_ROOT), { recursive: true });
+      console.log(`${LOG_PREFIX} cloning ${DEFAULT_REMOTE} → ${CLONE_ROOT} (first run, slow)`);
+      // Shallow clone keeps the initial cost reasonable; we only need
+      // latest main to validate typechecks against.
+      await run('git', ['clone', '--depth', '50', DEFAULT_REMOTE, CLONE_ROOT], { timeoutMs: 600_000 });
     }
-    await mkdir(dirname(CLONE_ROOT), { recursive: true });
-    console.log(`${LOG_PREFIX} cloning ${DEFAULT_REMOTE} → ${CLONE_ROOT} (first run, slow)`);
-    // Shallow clone keeps the initial cost reasonable; we only need
-    // latest main to validate typechecks against.
-    await run('git', ['clone', '--depth', '50', DEFAULT_REMOTE, CLONE_ROOT], { timeoutMs: 600_000 });
+
+    for (const dir of INSTALL_DIRS) {
+      const projectPath = join(CLONE_ROOT, dir);
+      const nodeModulesPath = join(projectPath, 'node_modules');
+      if (await exists(nodeModulesPath)) continue;
+      if (!(await exists(join(projectPath, 'package.json')))) {
+        console.warn(`${LOG_PREFIX} ${dir} has no package.json — skipping npm install`);
+        continue;
+      }
+      console.log(`${LOG_PREFIX} installing npm deps in ${dir} (first run, slow)`);
+      // Use `npm ci` when a lockfile exists (faster + reproducible),
+      // fall back to `npm install` otherwise.
+      const hasLock = await exists(join(projectPath, 'package-lock.json'));
+      const cmd = hasLock ? ['ci', '--no-audit', '--no-fund'] : ['install', '--no-audit', '--no-fund'];
+      await run('npm', cmd, { cwd: projectPath, timeoutMs: NPM_INSTALL_TIMEOUT_MS });
+    }
+
     return { ok: true, path: CLONE_ROOT };
   } catch (err) {
     return { ok: false, error: `ensureClone failed: ${String(err).slice(0, 400)}` };

--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -47,7 +47,13 @@ const ANTHROPIC_BASE = 'https://api.anthropic.com';
 // Messages API timeout — Cloud Run's request timeout is 300s; we run in a
 // background ticker so that's not the constraint. Still cap at 8 minutes so
 // a pathological stuck call doesn't hold a concurrency slot forever.
-const MESSAGES_TIMEOUT_MS = 480_000; // 8 min — generous for multi-file generation
+// 12 min. Was 8 min; bumped after PR #846 added jest validation in the
+// worker which can add 60-90s on the first attempt and ~5-15s on retries
+// — combined with up to 3 retry attempts and an initial npm-install on
+// a cold clone, the worker can legitimately hold a task for ~10 min on
+// a hard case. The execute path is background-ticker scoped, so there's
+// no Cloud Run request-wall constraint here.
+const MESSAGES_TIMEOUT_MS = 720_000; // 12 min
 const EXECUTION_MODEL = process.env.DEV_AUTOPILOT_EXECUTION_MODEL || 'claude-sonnet-4-6';
 // Upper bound for total output tokens. One plan may touch up to ~5 files;
 // ~3000 tokens/file is a generous budget. Sonnet 4.6 supports 16k out.


### PR DESCRIPTION
PR #846's jest validation was a no-op because the clone had no node_modules. Worker logged `FAILED jest in 1s — 0/0 passed` and looped through retries until the gateway's 480s wait fired. Fix: ensureClone() now installs npm deps in services/gateway (and any AUTOPILOT_WORKER_INSTALL_DIRS list) using `npm ci` when a lockfile exists. Only runs when node_modules missing, so first task pays ~60-180s, subsequent tasks 0s. Also bumps gateway's worker-queue wait timeout 480s → 720s to accommodate validated retries.