### PR TITLE
feat(admin-kb): admin System KB endpoint (BOOTSTRAP-VITANA-ADMIN-SYSTEM-KB)

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -287,6 +287,9 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const tenantAssistantSpeechesRouter = require('./routes/tenant-admin/assistant-speeches').default;
   // Batch 1.B2: Tenant Knowledge Base — per-tenant KB docs, opt-outs, search
   const tenantKnowledgeRouter = require('./routes/tenant-admin/knowledge').default;
+  // Admin System KB — exafy_admin-only view of system-wide knowledge_docs
+  // (where the Book of the Vitana Index and other vitana_system docs live).
+  const adminSystemKbRouter = require('./routes/admin-system-kb').default;
   // Overview Dashboard — KPI summary, at-risk, activity, alerts
   const tenantOverviewRouter = require('./routes/tenant-admin/overview').default;
   // BOOTSTRAP-ADMIN-KPI-AA: Admin KPI surface (real-time snapshot + history)
@@ -758,6 +761,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   mountRouterSync(app, '/api/v1/admin/tenants/:tenantId/assistant', tenantAssistantConfigRouter, { owner: 'tenant-assistant-config' });
   // Batch 1.B2: Tenant Knowledge Base — per-tenant KB docs, search, opt-outs
   mountRouterSync(app, '/api/v1/admin/tenants/:tenantId/kb', tenantKnowledgeRouter, { owner: 'tenant-knowledge' });
+  // Admin System KB — exafy_admin-only view of system-wide knowledge_docs
+  mountRouterSync(app, '/api/v1/admin/system-kb', adminSystemKbRouter, { owner: 'admin-system-kb' });
   // Overview Dashboard — KPI summary, at-risk, activity, alerts
   mountRouterSync(app, '/api/v1/admin/tenants/:tenantId/overview', tenantOverviewRouter, { owner: 'tenant-overview' });
   // BOOTSTRAP-ADMIN-KPI-AA: Admin KPI surface

--- a/services/gateway/src/routes/admin-system-kb.ts
+++ b/services/gateway/src/routes/admin-system-kb.ts
@@ -1,0 +1,109 @@
+/**
+ * Admin System KB — platform-admin-only view of the system-wide knowledge_docs
+ * table (not the tenant-scoped kb_documents table used by the existing
+ * /admin/tenants/:tenantId/kb UI).
+ *
+ * This is where the Book of the Vitana Index and other vitana_system docs
+ * live. Admin reads them here; the retrieval-router also reads this table
+ * at priority 100 for Assistant grounding.
+ *
+ * Endpoints:
+ *   GET  /api/v1/admin/system-kb/docs
+ *        Query params:
+ *          path_prefix  — optional, filter by leading path (e.g., 'kb/vitana-system/index-book/')
+ *          tag          — optional, filter by single tag
+ *          q            — optional, full-text search
+ *        Returns list of {id, title, path, tags, word_count, created_at, updated_at}
+ *   GET  /api/v1/admin/system-kb/docs/:id
+ *        Returns {id, title, path, content, tags, source_type, created_at, updated_at}
+ *
+ * Auth: requireAuth + requireExafyAdmin (platform admin only — these are
+ * system docs, not per-tenant).
+ */
+
+import { Router, Response } from 'express';
+import { requireAuth, requireExafyAdmin, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
+import { getSupabase } from '../lib/supabase';
+
+const router = Router();
+
+router.use(requireAuth);
+router.use(requireExafyAdmin);
+
+// GET /docs — list knowledge_docs rows with optional filters
+router.get('/docs', async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+  }
+
+  const pathPrefix = (req.query.path_prefix as string | undefined)?.trim();
+  const tag = (req.query.tag as string | undefined)?.trim();
+  const q = (req.query.q as string | undefined)?.trim();
+
+  try {
+    let query = supabase
+      .from('knowledge_docs')
+      .select('id, title, path, tags, word_count, source_type, created_at, updated_at')
+      .order('path', { ascending: true });
+
+    if (pathPrefix) {
+      query = query.like('path', `${pathPrefix}%`);
+    }
+    if (tag) {
+      query = query.contains('tags', [tag]);
+    }
+    if (q) {
+      // Full-text on title + content via tsvector if available; fall back to ilike.
+      query = query.or(`title.ilike.%${q}%,path.ilike.%${q}%`);
+    }
+
+    const { data, error } = await query.limit(500);
+    if (error) {
+      console.error('[admin-system-kb] list error:', error.message);
+      return res.status(400).json({ ok: false, error: error.message });
+    }
+    return res.status(200).json({ ok: true, documents: data ?? [] });
+  } catch (err: any) {
+    return res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+// GET /docs/:id — full content
+router.get('/docs/:id', async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+  }
+  const id = req.params.id;
+  try {
+    const { data, error } = await supabase
+      .from('knowledge_docs')
+      .select('id, title, path, content, tags, source_type, word_count, created_at, updated_at')
+      .eq('id', id)
+      .maybeSingle();
+    if (error) {
+      return res.status(400).json({ ok: false, error: error.message });
+    }
+    if (!data) {
+      return res.status(404).json({ ok: false, error: 'NOT_FOUND' });
+    }
+    return res.status(200).json({ ok: true, document: data });
+  } catch (err: any) {
+    return res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+// GET / — router health
+router.get('/', (_req, res: Response) => {
+  res.status(200).json({
+    ok: true,
+    service: 'admin-system-kb',
+    endpoints: [
+      'GET /api/v1/admin/system-kb/docs?path_prefix&tag&q',
+      'GET /api/v1/admin/system-kb/docs/:id',
+    ],
+  });
+});
+
+export default router;


### PR DESCRIPTION
Exafy-admin-only route surfacing the system-wide knowledge_docs table (where the Book of the Vitana Index lives). Separate from the existing tenant-scoped /admin/tenants/:tenantId/kb. Paired with vitana-v1 PR.