### PR TITLE
feat(dev-autopilot): worker-owned PR creation — survive Cloud Run recycles

### DIFF
--- a/.github/workflows/EXEC-DEPLOY.yml
+++ b/.github/workflows/EXEC-DEPLOY.yml
@@ -311,6 +311,14 @@ jobs:
             # rather than on the pay-per-token API credit balance.
             # Flip to false (or delete this line) to fall back to direct API calls.
             EXTRA_ENV_ARGS+=(--update-env-vars=DEV_AUTOPILOT_USE_WORKER=true)
+            # Worker-owned PR creation: after the worker validates Claude's
+            # output it ALSO creates the branch + writes files + opens the
+            # PR itself, then writes pr_url back to the queue. This avoids
+            # the Cloud Run recycle-mid-flight failure that kept stranding
+            # executions in 'running' (gateway-side runExecutionSession was
+            # a fire-and-forget promise that died when the container scaled
+            # down between worker-finishes and gateway-writes-PR).
+            EXTRA_ENV_ARGS+=(--update-env-vars=AUTOPILOT_WORKER_OWNS_PR=true)
             # BOOTSTRAP-DEV-AUTOPILOT-WATCHER-LIVE: flip the CI / merge /
             # deploy watchers out of DRY_RUN mode. Queries GitHub for real
             # check runs, auto-merges (squash) when all checks pass and

--- a/services/autopilot-worker/src/github.ts
+++ b/services/autopilot-worker/src/github.ts
@@ -1,0 +1,191 @@
+/**
+ * GitHub REST API client for the worker — branch creation, file writes, PR
+ * opening. Mirror of the helpers that previously lived on the gateway in
+ * services/gateway/src/services/dev-autopilot-execute.ts.
+ *
+ * Why this lives in the worker now
+ * --------------------------------
+ * The gateway version sat inside `runExecutionSession` which ran on Cloud
+ * Run as a fire-and-forget background promise. Cloud Run recycles
+ * containers every few minutes and routinely killed the gateway mid-write,
+ * leaving execution rows stuck in 'running' (we shipped a watchdog for
+ * that, but stuck rows never produced a merged PR).
+ *
+ * The worker process is long-lived on the developer workstation (or a VM)
+ * and doesn't get recycled mid-task. Moving these calls here means the
+ * "claude → validate → branch → write → PR" sequence runs in a single
+ * process from start to finish.
+ *
+ * Auth: GITHUB_SAFE_MERGE_TOKEN (or DEV_AUTOPILOT_GITHUB_TOKEN /
+ * GITHUB_TOKEN as fallbacks). Same precedence the gateway used.
+ */
+
+const LOG_PREFIX = '[autopilot-worker/github]';
+
+const GITHUB_OWNER = process.env.AUTOPILOT_WORKER_GITHUB_OWNER || 'exafyltd';
+const GITHUB_REPO = process.env.AUTOPILOT_WORKER_GITHUB_REPO || 'vitana-platform';
+
+function getToken(): string {
+  return process.env.GITHUB_SAFE_MERGE_TOKEN
+      || process.env.DEV_AUTOPILOT_GITHUB_TOKEN
+      || process.env.GITHUB_TOKEN
+      || '';
+}
+
+interface ApiResult<T> {
+  ok: boolean;
+  status: number;
+  data?: T;
+  error?: string;
+}
+
+async function api<T>(
+  path: string,
+  init: { method?: string; body?: unknown; accept?: string } = {},
+): Promise<ApiResult<T>> {
+  const token = getToken();
+  if (!token) {
+    return { ok: false, status: 0, error: 'GITHUB_SAFE_MERGE_TOKEN not set on worker — can\'t talk to GitHub' };
+  }
+  try {
+    const res = await fetch(`https://api.github.com${path}`, {
+      method: init.method || 'GET',
+      headers: {
+        Authorization: `Bearer ${token}`,
+        Accept: init.accept || 'application/vnd.github+json',
+        'Content-Type': 'application/json',
+        'User-Agent': 'vitana-autopilot-worker',
+        'X-GitHub-Api-Version': '2022-11-28',
+      },
+      body: init.body != null ? JSON.stringify(init.body) : undefined,
+    });
+    if (!res.ok) {
+      const body = (await res.text()).slice(0, 500);
+      return { ok: false, status: res.status, error: `${res.status}: ${body}` };
+    }
+    if (res.status === 204) return { ok: true, status: 204 };
+    const data = (await res.json()) as T;
+    return { ok: true, status: res.status, data };
+  } catch (err) {
+    return { ok: false, status: 0, error: String(err) };
+  }
+}
+
+function encodePath(path: string): string {
+  return path.replace(/^\/+/, '').split('/').map(encodeURIComponent).join('/');
+}
+
+/** Look up a file's current sha + content on a given ref. Returns
+ * { exists: false } cleanly on 404 (the file doesn't exist yet). */
+export async function fetchFileContent(
+  path: string,
+  ref: string,
+): Promise<{ exists: boolean; content?: string; sha?: string; error?: string }> {
+  const r = await api<{ content: string; encoding: string; sha: string }>(
+    `/repos/${GITHUB_OWNER}/${GITHUB_REPO}/contents/${encodePath(path)}?ref=${encodeURIComponent(ref)}`,
+  );
+  if (!r.ok) {
+    if (r.status === 404) return { exists: false };
+    return { exists: false, error: r.error };
+  }
+  if (!r.data) return { exists: false };
+  const decoded = Buffer.from(r.data.content || '', (r.data.encoding as BufferEncoding) || 'base64').toString('utf-8');
+  return { exists: true, content: decoded, sha: r.data.sha };
+}
+
+/** Get the head sha of a branch. */
+export async function getBranchSha(branch: string): Promise<{ ok: boolean; sha?: string; error?: string }> {
+  const r = await api<{ object: { sha: string } }>(
+    `/repos/${GITHUB_OWNER}/${GITHUB_REPO}/git/ref/heads/${encodeURIComponent(branch)}`,
+  );
+  if (!r.ok || !r.data) return { ok: false, error: r.error || 'ref lookup failed' };
+  return { ok: true, sha: r.data.object.sha };
+}
+
+/** Create a branch from baseBranch's HEAD. If `branch` already exists
+ * (from a prior failed run on the same execution id), delete it first so we
+ * write a clean tree. Safe because these branches are always
+ * `dev-autopilot/...` prefixed. */
+export async function createBranch(
+  branch: string,
+  baseBranch: string,
+): Promise<{ ok: boolean; error?: string }> {
+  const base = await getBranchSha(baseBranch);
+  if (!base.ok || !base.sha) return { ok: false, error: `base branch lookup: ${base.error}` };
+
+  const existing = await getBranchSha(branch);
+  if (existing.ok) {
+    const del = await api(
+      `/repos/${GITHUB_OWNER}/${GITHUB_REPO}/git/refs/heads/${encodeURIComponent(branch)}`,
+      { method: 'DELETE' },
+    );
+    if (!del.ok) return { ok: false, error: `could not delete stale branch ${branch}: ${del.error}` };
+  }
+
+  const create = await api(
+    `/repos/${GITHUB_OWNER}/${GITHUB_REPO}/git/refs`,
+    { method: 'POST', body: { ref: `refs/heads/${branch}`, sha: base.sha } },
+  );
+  if (!create.ok) return { ok: false, error: `create branch ${branch}: ${create.error}` };
+  return { ok: true };
+}
+
+/** Create or update a file on a branch. Pass existingSha when modifying an
+ * existing file (GitHub requires it for atomic update). */
+export async function putFileToBranch(
+  branch: string,
+  path: string,
+  content: string,
+  message: string,
+  existingSha?: string,
+): Promise<{ ok: boolean; error?: string }> {
+  const base64 = Buffer.from(content, 'utf-8').toString('base64');
+  const body: Record<string, unknown> = { message, content: base64, branch };
+  if (existingSha) body.sha = existingSha;
+  const r = await api(
+    `/repos/${GITHUB_OWNER}/${GITHUB_REPO}/contents/${encodePath(path)}`,
+    { method: 'PUT', body },
+  );
+  if (!r.ok) return { ok: false, error: r.error };
+  return { ok: true };
+}
+
+export async function deleteFileOnBranch(
+  branch: string,
+  path: string,
+  message: string,
+  sha: string,
+): Promise<{ ok: boolean; error?: string }> {
+  const r = await api(
+    `/repos/${GITHUB_OWNER}/${GITHUB_REPO}/contents/${encodePath(path)}`,
+    { method: 'DELETE', body: { message, sha, branch } },
+  );
+  if (!r.ok) return { ok: false, error: r.error };
+  return { ok: true };
+}
+
+export async function openPullRequest(
+  branch: string,
+  baseBranch: string,
+  title: string,
+  body: string,
+): Promise<{ ok: boolean; url?: string; number?: number; error?: string }> {
+  const r = await api<{ html_url: string; number: number }>(
+    `/repos/${GITHUB_OWNER}/${GITHUB_REPO}/pulls`,
+    {
+      method: 'POST',
+      body: {
+        title: title.slice(0, 240),
+        head: branch,
+        base: baseBranch,
+        body,
+        maintainer_can_modify: true,
+        draft: false,
+      },
+    },
+  );
+  if (!r.ok || !r.data) return { ok: false, error: r.error };
+  return { ok: true, url: r.data.html_url, number: r.data.number };
+}
+
+export { LOG_PREFIX, GITHUB_OWNER, GITHUB_REPO };

--- a/services/autopilot-worker/src/index.ts
+++ b/services/autopilot-worker/src/index.ts
@@ -23,6 +23,8 @@ import { runTsc, runJest } from './validate';
 import { join } from 'path';
 import { CLONE_ROOT } from './repo';
 import { buildRetryPrompt } from './retry';
+import { createBranch, putFileToBranch, deleteFileOnBranch, fetchFileContent, openPullRequest } from './github';
+import type { ExecutionFile } from './parse';
 
 const LOG_PREFIX = '[autopilot-worker]';
 const POLL_INTERVAL_MS = Number(process.env.POLL_INTERVAL_MS || 5_000);
@@ -93,6 +95,20 @@ function log(msg: string, ...rest: unknown[]): void {
   console.log(`${ts} ${LOG_PREFIX} ${msg}`, ...rest);
 }
 
+interface ValidatedExecuteResult {
+  ok: boolean;
+  text?: string;
+  /** Parsed files from the FINAL validated attempt. Caller can publish
+   * these directly to GitHub instead of re-parsing the text. */
+  files?: ExecutionFile[];
+  pr_title?: string;
+  pr_body?: string;
+  usage?: RunClaudeResult['usage'];
+  error?: string;
+  attempts: number;
+  validation_elapsed_ms: number;
+}
+
 /**
  * Run an execute task through the validation retry loop.
  *
@@ -102,14 +118,14 @@ function log(msg: string, ...rest: unknown[]): void {
  * - If green: return the most-recent Claude output.
  * - If red: build a retry prompt and go again, up to VALIDATION_MAX_ATTEMPTS.
  *
- * The gateway still owns PR creation via the GitHub Contents API — this
- * function just increases confidence that the output will pass CI once
- * the gateway writes it.
+ * Returns parsed files alongside the raw text — the caller can either hand
+ * the text back to the gateway (legacy path) or publish the files itself
+ * via the GitHub API (worker-owned-PR path).
  */
 async function runExecuteWithValidation(
   basePrompt: string,
   model: string | undefined,
-): Promise<{ ok: boolean; text?: string; usage?: RunClaudeResult['usage']; error?: string; attempts: number; validation_elapsed_ms: number }> {
+): Promise<ValidatedExecuteResult> {
   let currentPrompt = basePrompt;
   let lastOutput: string | undefined;
   let lastError = 'no attempts ran';
@@ -192,6 +208,9 @@ async function runExecuteWithValidation(
       return {
         ok: true,
         text: claudeResult.text,
+        files: parsed.files,
+        pr_title: parsed.pr_title,
+        pr_body: parsed.pr_body,
         usage: claudeResult.usage,
         attempts: attempt + 1,
         validation_elapsed_ms: validationElapsedTotal,
@@ -207,6 +226,9 @@ async function runExecuteWithValidation(
       return {
         ok: true,
         text: claudeResult.text,
+        files: parsed.files,
+        pr_title: parsed.pr_title,
+        pr_body: parsed.pr_body,
         usage: claudeResult.usage,
         attempts: attempt + 1,
         validation_elapsed_ms: validationElapsedTotal,
@@ -237,6 +259,69 @@ async function runExecuteWithValidation(
   };
 }
 
+/**
+ * Worker-owned PR creation. After validation succeeds the worker holds the
+ * canonical file contents in memory; instead of returning text to the gateway
+ * and asking it to write the files via the GitHub API (which kept dying when
+ * Cloud Run recycled the container mid-write), the worker publishes them
+ * itself in a single in-process sequence: branch → files → PR.
+ *
+ * Returns the PR url + number to write back to the queue row's output
+ * payload — the gateway picks those up and advances the execution state to
+ * 'ci' for the watcher to take over from there.
+ */
+async function publishToGitHub(
+  files: ExecutionFile[],
+  prTitle: string,
+  prBody: string,
+  branch: string,
+  baseBranch: string,
+  vtidLike: string,
+): Promise<{ ok: boolean; pr_url?: string; pr_number?: number; error?: string }> {
+  // Look up current shas for any "modify" / "delete" targets — GitHub's PUT
+  // and DELETE on /contents both require the existing blob sha.
+  const shaCache = new Map<string, string>();
+  for (const f of files) {
+    if (f.action === 'modify' || f.action === 'delete') {
+      const existing = await fetchFileContent(f.path, baseBranch);
+      if (existing.exists && existing.sha) {
+        shaCache.set(f.path, existing.sha);
+      }
+    }
+  }
+
+  const branchR = await createBranch(branch, baseBranch);
+  if (!branchR.ok) return { ok: false, error: `create branch: ${branchR.error}` };
+
+  for (const f of files) {
+    if (f.action === 'delete') {
+      const sha = shaCache.get(f.path);
+      if (!sha) {
+        log(`  publishToGitHub: skip delete for ${f.path} (not present on ${baseBranch})`);
+        continue;
+      }
+      const dr = await deleteFileOnBranch(branch, f.path, `${vtidLike}: delete ${f.path}`, sha);
+      if (!dr.ok) return { ok: false, error: `delete ${f.path}: ${dr.error}` };
+      continue;
+    }
+    if (typeof f.content !== 'string') {
+      return { ok: false, error: `file ${f.path} missing content for action=${f.action}` };
+    }
+    const wr = await putFileToBranch(
+      branch,
+      f.path,
+      f.content,
+      `${vtidLike}: ${f.action} ${f.path}`,
+      shaCache.get(f.path),
+    );
+    if (!wr.ok) return { ok: false, error: `write ${f.path}: ${wr.error}` };
+  }
+
+  const pr = await openPullRequest(branch, baseBranch, prTitle, prBody);
+  if (!pr.ok) return { ok: false, error: `open PR: ${pr.error}` };
+  return { ok: true, pr_url: pr.url, pr_number: pr.number };
+}
+
 async function handleTask(wid: string): Promise<void> {
   if (running >= MAX_CONCURRENT) return;
   running++;
@@ -254,11 +339,11 @@ async function handleTask(wid: string): Promise<void> {
 
     const started = Date.now();
     const shouldValidate = VALIDATION_ENABLED && row.kind === 'execute';
-    const result = shouldValidate
+    const result: ValidatedExecuteResult = shouldValidate
       ? await runExecuteWithValidation(prompt, row.input_payload.model)
       : await (async () => {
           const r = await runClaude(prompt, { model: row.input_payload.model, timeoutMs: TASK_TIMEOUT_MS });
-          return { ok: r.ok, text: r.text, usage: r.usage, error: r.error, attempts: 1, validation_elapsed_ms: 0 } as const;
+          return { ok: r.ok, text: r.text, usage: r.usage, error: r.error, attempts: 1, validation_elapsed_ms: 0 };
         })();
     const elapsed = Math.round((Date.now() - started) / 1000);
 
@@ -269,6 +354,45 @@ async function handleTask(wid: string): Promise<void> {
     }
 
     log(`  task ${row.id.slice(0, 8)} ok in ${elapsed}s across ${result.attempts} attempt${result.attempts === 1 ? '' : 's'} (${result.usage?.input_tokens ?? '?'} in / ${result.usage?.output_tokens ?? '?'} out)`);
+
+    // Worker-owned-PR path: when the gateway opted in by setting
+    // input_payload.worker_owns_pr=true, the worker creates the branch +
+    // writes files + opens the PR itself, then writes pr_url back to the
+    // queue row. This avoids the gateway / Cloud Run instability that kept
+    // killing fire-and-forget runExecutionSession promises.
+    const ownsPr = row.input_payload?.worker_owns_pr === true && row.kind === 'execute';
+    if (ownsPr && result.files && result.pr_title && result.pr_body) {
+      const branch = row.input_payload?.branch_name as string
+        || `dev-autopilot/${(row.execution_id || row.id).slice(0, 8)}`;
+      const baseBranch = (row.input_payload?.base_branch as string) || 'main';
+      const vtidLike = (row.input_payload?.vtid_like as string)
+        || `VTID-DA-${(row.execution_id || row.id).slice(0, 8)}`;
+      log(`  publishing PR for task ${row.id.slice(0, 8)}: branch=${branch} files=${result.files.length}`);
+      const pub = await publishToGitHub(result.files, result.pr_title, result.pr_body, branch, baseBranch, vtidLike);
+      if (!pub.ok) {
+        log(`  PR publish FAILED for ${row.id.slice(0, 8)}: ${pub.error}`);
+        await failTask(row.id, `publish PR: ${pub.error}`);
+        return;
+      }
+      log(`  PR opened: ${pub.pr_url}`);
+      await completeTask(row.id, {
+        text: result.text,
+        usage: result.usage,
+        extra: {
+          worker_id: wid,
+          attempts: result.attempts,
+          validated: shouldValidate,
+          validation_elapsed_ms: result.validation_elapsed_ms,
+          // Fields the gateway watches for to advance execution row → 'ci'
+          worker_owns_pr: true,
+          pr_url: pub.pr_url,
+          pr_number: pub.pr_number,
+          branch,
+        },
+      });
+      return;
+    }
+
     await completeTask(row.id, {
       text: result.text,
       usage: result.usage,

--- a/services/autopilot-worker/src/queue.ts
+++ b/services/autopilot-worker/src/queue.ts
@@ -26,6 +26,20 @@ export interface QueueRow {
     model?: string;
     max_tokens?: number;
     notes?: string;
+    /** Tells the worker to publish the validated files to GitHub itself
+     * (branch + commits + open PR) instead of returning text and letting
+     * the gateway do those steps. Set by the gateway when the
+     * worker-owned-PR feature flag is on. */
+    worker_owns_pr?: boolean;
+    /** Pre-computed branch name (gateway-side so it matches what the
+     * watcher / execution row recorded). Defaults to
+     * `dev-autopilot/<execId-prefix>` if absent. */
+    branch_name?: string;
+    /** Base branch to fork from. Defaults to 'main'. */
+    base_branch?: string;
+    /** Used in commit messages so the audit trail mentions the execution
+     * id (gateway also uses this for the safe-merge token's audit log). */
+    vtid_like?: string;
   };
   output_payload: Record<string, unknown> | null;
   error_message: string | null;

--- a/services/autopilot-worker/test/github.test.ts
+++ b/services/autopilot-worker/test/github.test.ts
@@ -1,0 +1,188 @@
+/**
+ * Tests for the worker's GitHub REST client. We mock global fetch so the
+ * tests don't actually talk to api.github.com — they verify URLs, methods,
+ * headers, body encoding (especially the base64 content for PUT /contents),
+ * and the error-recovery branches.
+ */
+
+import { fetchFileContent, getBranchSha, createBranch, putFileToBranch, deleteFileOnBranch, openPullRequest } from '../src/github';
+
+type FetchCall = { url: string; init: RequestInit };
+let calls: FetchCall[];
+let nextResponses: Array<{ status: number; body: unknown }>;
+const realFetch = global.fetch;
+
+beforeEach(() => {
+  calls = [];
+  nextResponses = [];
+  process.env.GITHUB_SAFE_MERGE_TOKEN = 'test-token';
+  // Re-implement fetch as a queue: each call pops the next response.
+  global.fetch = (async (url: string | URL | Request, init: RequestInit = {}) => {
+    calls.push({ url: String(url), init });
+    const next = nextResponses.shift();
+    if (!next) throw new Error(`unexpected fetch call to ${String(url)} — no mock response queued`);
+    const status = next.status;
+    // Per spec, 204 responses cannot have a body — the Response constructor
+    // will throw if you pass one.
+    if (status === 204) return new Response(null, { status });
+    const body = typeof next.body === 'string' ? next.body : JSON.stringify(next.body);
+    return new Response(body, { status });
+  }) as typeof fetch;
+});
+
+afterEach(() => { global.fetch = realFetch; });
+
+function queueResponse(status: number, body: unknown) {
+  nextResponses.push({ status, body });
+}
+
+describe('fetchFileContent', () => {
+  it('decodes base64 content + returns sha when file exists', async () => {
+    const content = 'export const x = 1;\n';
+    queueResponse(200, {
+      content: Buffer.from(content).toString('base64'),
+      encoding: 'base64',
+      sha: 'abc123',
+    });
+    const r = await fetchFileContent('services/gateway/src/foo.ts', 'main');
+    expect(r.exists).toBe(true);
+    expect(r.content).toBe(content);
+    expect(r.sha).toBe('abc123');
+    expect(calls[0].url).toContain('/contents/services/gateway/src/foo.ts');
+    expect(calls[0].url).toContain('ref=main');
+  });
+
+  it('returns exists:false on 404 (file not yet created)', async () => {
+    queueResponse(404, 'Not Found');
+    const r = await fetchFileContent('services/gateway/src/new.ts', 'main');
+    expect(r.exists).toBe(false);
+    expect(r.error).toBeUndefined();
+  });
+
+  it('surfaces error on non-404 failure', async () => {
+    queueResponse(500, 'oops');
+    const r = await fetchFileContent('a.ts', 'main');
+    expect(r.exists).toBe(false);
+    expect(r.error).toContain('500');
+  });
+
+  it('URL-encodes path segments', async () => {
+    queueResponse(200, { content: '', encoding: 'base64', sha: 'x' });
+    await fetchFileContent('services/gateway/src/with space.ts', 'main');
+    expect(calls[0].url).toContain('with%20space.ts');
+  });
+});
+
+describe('createBranch', () => {
+  it('looks up base sha, creates branch when target does not exist', async () => {
+    queueResponse(200, { object: { sha: 'base-sha-deadbeef' } }); // base lookup
+    queueResponse(404, 'Not Found');                               // target lookup → doesn't exist
+    queueResponse(201, { ref: 'refs/heads/test', object: { sha: 'base-sha-deadbeef' } });
+    const r = await createBranch('test', 'main');
+    expect(r.ok).toBe(true);
+    expect(calls).toHaveLength(3);
+    expect(calls[2].init.method).toBe('POST');
+    expect(JSON.parse(calls[2].init.body as string)).toEqual({
+      ref: 'refs/heads/test',
+      sha: 'base-sha-deadbeef',
+    });
+  });
+
+  it('deletes a stale branch + recreates when target already exists', async () => {
+    queueResponse(200, { object: { sha: 'base' } }); // base lookup
+    queueResponse(200, { object: { sha: 'stale' } }); // target exists
+    queueResponse(204, '');                            // DELETE
+    queueResponse(201, { ref: 'refs/heads/test', object: { sha: 'base' } }); // create
+    const r = await createBranch('test', 'main');
+    expect(r.ok).toBe(true);
+    expect(calls[2].init.method).toBe('DELETE');
+  });
+
+  it('errors clearly when base lookup fails', async () => {
+    queueResponse(404, 'Not Found');
+    const r = await createBranch('test', 'doesnt-exist');
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('base branch lookup');
+  });
+});
+
+describe('putFileToBranch', () => {
+  it('base64-encodes content and includes branch + message', async () => {
+    queueResponse(201, { content: { sha: 'new-sha' } });
+    const r = await putFileToBranch('test', 'a.ts', 'export {};\n', 'commit msg', undefined);
+    expect(r.ok).toBe(true);
+    const body = JSON.parse(calls[0].init.body as string);
+    expect(body.message).toBe('commit msg');
+    expect(body.branch).toBe('test');
+    expect(Buffer.from(body.content, 'base64').toString('utf-8')).toBe('export {};\n');
+    expect(body.sha).toBeUndefined();
+  });
+
+  it('passes existingSha when modifying a file', async () => {
+    queueResponse(200, { content: { sha: 'updated' } });
+    const r = await putFileToBranch('test', 'a.ts', 'new', 'msg', 'old-sha');
+    expect(r.ok).toBe(true);
+    const body = JSON.parse(calls[0].init.body as string);
+    expect(body.sha).toBe('old-sha');
+  });
+
+  it('surfaces error on 4xx/5xx', async () => {
+    queueResponse(409, 'conflict');
+    const r = await putFileToBranch('test', 'a.ts', 'x', 'msg');
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('409');
+  });
+});
+
+describe('deleteFileOnBranch', () => {
+  it('sends DELETE with sha', async () => {
+    queueResponse(200, { commit: { sha: 'x' } });
+    const r = await deleteFileOnBranch('test', 'old.ts', 'msg', 'old-sha');
+    expect(r.ok).toBe(true);
+    expect(calls[0].init.method).toBe('DELETE');
+    const body = JSON.parse(calls[0].init.body as string);
+    expect(body.sha).toBe('old-sha');
+    expect(body.branch).toBe('test');
+  });
+});
+
+describe('openPullRequest', () => {
+  it('returns the PR url + number on success', async () => {
+    queueResponse(201, { html_url: 'https://github.com/foo/bar/pull/42', number: 42 });
+    const r = await openPullRequest('test-branch', 'main', 'My PR', 'PR body markdown');
+    expect(r.ok).toBe(true);
+    expect(r.url).toBe('https://github.com/foo/bar/pull/42');
+    expect(r.number).toBe(42);
+    const body = JSON.parse(calls[0].init.body as string);
+    expect(body.head).toBe('test-branch');
+    expect(body.base).toBe('main');
+    expect(body.title).toBe('My PR');
+  });
+
+  it('clamps a very long title to 240 chars (GitHub limit)', async () => {
+    queueResponse(201, { html_url: 'x', number: 1 });
+    const longTitle = 'x'.repeat(500);
+    await openPullRequest('b', 'main', longTitle, 'body');
+    const body = JSON.parse(calls[0].init.body as string);
+    expect(body.title.length).toBe(240);
+  });
+
+  it('surfaces error on 422 (invalid request)', async () => {
+    queueResponse(422, 'no commits between branches');
+    const r = await openPullRequest('b', 'main', 't', 'b');
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('422');
+  });
+});
+
+describe('auth', () => {
+  it('refuses to make requests when no token is set', async () => {
+    delete process.env.GITHUB_SAFE_MERGE_TOKEN;
+    delete process.env.DEV_AUTOPILOT_GITHUB_TOKEN;
+    delete process.env.GITHUB_TOKEN;
+    const r = await fetchFileContent('a.ts', 'main');
+    expect(r.exists).toBe(false);
+    expect(r.error).toMatch(/GITHUB_SAFE_MERGE_TOKEN not set/);
+    expect(calls).toHaveLength(0); // never called fetch
+  });
+});

--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -37,7 +37,7 @@ import {
   SafetyDecision,
 } from './dev-autopilot-safety';
 import { extractFilePaths } from './dev-autopilot-planning';
-import { isWorkerQueueEnabled, runWorkerTask, reclaimStuckWorkerTasks } from './dev-autopilot-worker-queue';
+import { isWorkerQueueEnabled, isWorkerOwnsPrEnabled, runWorkerTask, reclaimStuckWorkerTasks } from './dev-autopilot-worker-queue';
 
 const LOG_PREFIX = '[dev-autopilot-execute]';
 const EXEC_VTID = 'VTID-DEV-AUTOPILOT';
@@ -743,27 +743,56 @@ async function runExecutionSession(
   // 2. Ask Claude to produce the new file contents. Routes through the
   // worker queue when DEV_AUTOPILOT_USE_WORKER=true (Claude subscription);
   // otherwise hits the Messages API directly (pay-per-token).
+  //
+  // When AUTOPILOT_WORKER_OWNS_PR=true, ALSO delegate the post-LLM work
+  // (parse output, create branch, write files, open PR) to the worker.
+  // The worker's local clone + GitHub token mean it can do the whole
+  // sequence in a single long-lived process, sidestepping the Cloud Run
+  // recycle-mid-flight problem that kept stranding executions.
+  const ownsPr = isWorkerQueueEnabled() && isWorkerOwnsPrEnabled();
   const prompt = buildExecutionPrompt(exec.finding_id, exec.plan_version, plan.plan_markdown, fileCtx, branch);
   const startedAt = Date.now();
-  const llm = isWorkerQueueEnabled()
-    ? await runWorkerTask(
-        {
-          kind: 'execute',
-          finding_id: exec.finding_id,
-          execution_id: executionId,
-          prompt,
-          model: EXECUTION_MODEL,
-          max_tokens: MESSAGES_MAX_TOKENS,
-          notes: `execute ${executionId.slice(0, 8)}`,
-        },
-        { timeoutMs: MESSAGES_TIMEOUT_MS },
-      )
-    : await callMessagesApi(prompt);
+  // Widen the inline type so both call shapes satisfy the union we destructure
+  // below (worker-queue path may carry pr_url/pr_number/branch from the
+  // worker-owned-PR mode; direct Messages API never does).
+  const llm: { ok: boolean; text?: string; usage?: { input_tokens?: number; output_tokens?: number }; error?: string; pr_url?: string; pr_number?: number; branch?: string } =
+    isWorkerQueueEnabled()
+      ? await runWorkerTask(
+          {
+            kind: 'execute',
+            finding_id: exec.finding_id,
+            execution_id: executionId,
+            prompt,
+            model: EXECUTION_MODEL,
+            max_tokens: MESSAGES_MAX_TOKENS,
+            notes: `execute ${executionId.slice(0, 8)}`,
+            worker_owns_pr: ownsPr,
+            branch_name: branch,
+            base_branch: GITHUB_BASE_BRANCH,
+            vtid_like: `VTID-DA-${executionId.slice(0, 8)}`,
+          },
+          { timeoutMs: MESSAGES_TIMEOUT_MS },
+        )
+      : await callMessagesApi(prompt);
   const elapsed = Math.round((Date.now() - startedAt) / 1000);
   if (!llm.ok || !llm.text) {
     return { ok: false, error: `LLM call failed after ${elapsed}s: ${llm.error || 'unknown'}`, session_id: sessionId, branch };
   }
   console.log(`${LOG_PREFIX} [${executionId.slice(0, 8)}] LLM returned in ${elapsed}s via ${isWorkerQueueEnabled() ? 'worker-queue' : 'messages-api'} (${llm.usage?.input_tokens || '?'} in / ${llm.usage?.output_tokens || '?'} out)`);
+
+  // Worker-owned-PR path: the worker already created the branch + wrote
+  // files + opened the PR. We just record what it did and hand control to
+  // the watcher.
+  if (ownsPr && llm.pr_url) {
+    console.log(`${LOG_PREFIX} [${executionId.slice(0, 8)}] worker published PR ${llm.pr_url} (${llm.branch || branch})`);
+    return {
+      ok: true,
+      pr_url: llm.pr_url,
+      pr_number: llm.pr_number,
+      branch: llm.branch || branch,
+      session_id: sessionId,
+    };
+  }
 
   const parsed = parseExecutionJson(llm.text);
   if ('error' in parsed) {

--- a/services/gateway/src/services/dev-autopilot-worker-queue.ts
+++ b/services/gateway/src/services/dev-autopilot-worker-queue.ts
@@ -68,18 +68,36 @@ export interface WorkerTaskInput {
   model?: string;
   max_tokens?: number;
   notes?: string;
+  /** Worker-owned-PR mode: after validation passes, the worker creates the
+   * branch + writes files + opens the PR itself, then writes pr_url back to
+   * output_payload. The gateway just reads it instead of doing GitHub work
+   * itself. Removes the "Cloud Run recycles us between worker-finishes and
+   * gateway-writes-PR" failure mode. */
+  worker_owns_pr?: boolean;
+  branch_name?: string;
+  base_branch?: string;
+  vtid_like?: string;
 }
 
 export interface WorkerTaskResult {
   ok: boolean;
   text?: string;
   usage?: { input_tokens?: number; output_tokens?: number };
+  /** Set when input.worker_owns_pr=true and the worker successfully published
+   * a PR. The gateway reads these instead of opening a PR itself. */
+  pr_url?: string;
+  pr_number?: number;
+  branch?: string;
   error?: string;
   queue_row_id?: string;
 }
 
 export function isWorkerQueueEnabled(): boolean {
   return (process.env.DEV_AUTOPILOT_USE_WORKER || '').toLowerCase() === 'true';
+}
+
+export function isWorkerOwnsPrEnabled(): boolean {
+  return (process.env.AUTOPILOT_WORKER_OWNS_PR || '').toLowerCase() === 'true';
 }
 
 /**
@@ -99,6 +117,10 @@ export async function enqueueWorkerTask(
       model: input.model || 'claude-sonnet-4-6',
       max_tokens: input.max_tokens ?? 16_000,
       notes: input.notes || null,
+      worker_owns_pr: input.worker_owns_pr === true,
+      branch_name: input.branch_name,
+      base_branch: input.base_branch,
+      vtid_like: input.vtid_like,
     },
     status: 'pending',
   };
@@ -131,7 +153,15 @@ export async function waitForWorkerTask(
   while (Date.now() < deadline) {
     const r = await supa<Array<{
       status: string;
-      output_payload: { text?: string; usage?: { input_tokens?: number; output_tokens?: number } } | null;
+      output_payload: {
+        text?: string;
+        usage?: { input_tokens?: number; output_tokens?: number };
+        // Set by the worker when it publishes the PR itself (worker_owns_pr).
+        pr_url?: string;
+        pr_number?: number;
+        branch?: string;
+        worker_owns_pr?: boolean;
+      } | null;
       error_message: string | null;
     }>>(
       s,
@@ -154,10 +184,14 @@ export async function waitForWorkerTask(
     consecutiveFailures = 0;
     const row = r.data[0];
     if (row.status === 'completed') {
+      const op = row.output_payload || {};
       return {
         ok: true,
-        text: row.output_payload?.text,
-        usage: row.output_payload?.usage,
+        text: op.text,
+        usage: op.usage,
+        pr_url: op.pr_url,
+        pr_number: op.pr_number,
+        branch: op.branch,
         queue_row_id: rowId,
       };
     }


### PR DESCRIPTION
Moves branch + file writes + PR open from the gateway (Cloud Run, recycled mid-flight, kept stranding executions in 'running') into the worker (long-lived process, has the validated files in memory, single in-process sequence). Feature-flagged via `AUTOPILOT_WORKER_OWNS_PR=true`. 39/39 worker tests pass. See commit message for full design + rollback path.