### PR TITLE
feat(vitana-index): calendar completion → Index recompute loop (step 4)

### DIFF
--- a/services/gateway/src/routes/calendar.ts
+++ b/services/gateway/src/routes/calendar.ts
@@ -13,6 +13,7 @@
 
 import { Router, Request, Response } from 'express';
 import { emitOasisEvent } from '../services/oasis-event-service';
+import { getSupabase } from '../lib/supabase';
 import {
   CreateCalendarEventSchema,
   UpdateCalendarEventSchema,
@@ -33,6 +34,93 @@ import {
   softDeleteEvent,
   toSummary,
 } from '../services/calendar-service';
+
+// Pillar keys — must match the 5 canonical Vitana pillars.
+const PILLAR_KEYS = ['nutrition', 'hydration', 'exercise', 'sleep', 'mental'] as const;
+type PillarKey = typeof PILLAR_KEYS[number];
+
+/**
+ * Read prior vitana_index_scores row, invoke the admin-callable recompute RPC,
+ * diff the results, emit an index.recomputed OASIS event, and return the new
+ * row + per_pillar_delta. Best-effort — errors are logged and swallowed so a
+ * failed recompute never blocks a successful calendar completion.
+ */
+async function recomputeVitanaIndexForUser(
+  userId: string,
+  eventMetadata: Record<string, unknown> = {},
+): Promise<{ new_index?: Record<string, number>; per_pillar_delta?: Record<PillarKey, number>; delta_total?: number } | null> {
+  const admin = getSupabase();
+  if (!admin) return null;
+  const today = new Date().toISOString().slice(0, 10);
+
+  try {
+    // Snapshot prior row (if any) so we can compute deltas.
+    const { data: priorRow } = await admin
+      .from('vitana_index_scores')
+      .select('score_total, score_nutrition, score_hydration, score_exercise, score_sleep, score_mental')
+      .eq('user_id', userId)
+      .eq('date', today)
+      .maybeSingle();
+
+    const { data: newResult, error: rpcErr } = await admin.rpc(
+      'health_compute_vitana_index_for_user',
+      { p_user_id: userId, p_date: today, p_model_version: 'v3-5pillar' },
+    );
+    if (rpcErr || !(newResult as any)?.ok) {
+      console.warn('[Calendar] recompute RPC failed:', rpcErr?.message || (newResult as any)?.error);
+      return null;
+    }
+    const n = newResult as any;
+
+    const prior = (priorRow as any) ?? {
+      score_total: 0, score_nutrition: 0, score_hydration: 0,
+      score_exercise: 0, score_sleep: 0, score_mental: 0,
+    };
+    const per_pillar_delta: Record<PillarKey, number> = {
+      nutrition: (n.score_nutrition ?? 0) - (prior.score_nutrition ?? 0),
+      hydration: (n.score_hydration ?? 0) - (prior.score_hydration ?? 0),
+      exercise:  (n.score_exercise  ?? 0) - (prior.score_exercise  ?? 0),
+      sleep:     (n.score_sleep     ?? 0) - (prior.score_sleep     ?? 0),
+      mental:    (n.score_mental    ?? 0) - (prior.score_mental    ?? 0),
+    };
+    const delta_total = (n.score_total ?? 0) - (prior.score_total ?? 0);
+
+    emitOasisEvent({
+      vtid: 'SYSTEM',
+      type: 'index.recomputed' as any,
+      source: 'calendar-api',
+      status: 'info',
+      message: `Vitana Index recomputed: ${prior.score_total ?? 0} → ${n.score_total} (Δ${delta_total >= 0 ? '+' : ''}${delta_total})`,
+      payload: {
+        user_id: userId,
+        date: today,
+        new_score_total: n.score_total,
+        prior_score_total: prior.score_total ?? 0,
+        delta_total,
+        per_pillar_delta,
+        subscores: n.subscores,
+        balance_factor: n.balance_factor,
+        trigger: eventMetadata,
+      },
+    }).catch(() => {});
+
+    return {
+      new_index: {
+        score_total: n.score_total,
+        score_nutrition: n.score_nutrition,
+        score_hydration: n.score_hydration,
+        score_exercise: n.score_exercise,
+        score_sleep: n.score_sleep,
+        score_mental: n.score_mental,
+      },
+      per_pillar_delta,
+      delta_total,
+    };
+  } catch (err: any) {
+    console.warn('[Calendar] recomputeVitanaIndexForUser error:', err.message);
+    return null;
+  }
+}
 
 const router = Router();
 const LOG_PREFIX = '[Calendar]';
@@ -313,10 +401,28 @@ router.post('/events/:id/complete', async (req: Request, res: Response) => {
         event_id: id,
         user_id: userId,
         completion_status: parsed.data.completion_status,
+        wellness_tags: event.wellness_tags ?? [],
+        event_type: event.event_type,
+        source_ref_type: event.source_type,
       },
     }).catch(() => {});
 
-    return res.json({ ok: true, data: event });
+    // Recompute the Vitana Index for this user (only if the event was
+    // actually completed — skips/partials don't yet feed the Index).
+    let indexDelta: Awaited<ReturnType<typeof recomputeVitanaIndexForUser>> = null;
+    if (parsed.data.completion_status === 'completed') {
+      indexDelta = await recomputeVitanaIndexForUser(userId, {
+        event_id: id,
+        wellness_tags: event.wellness_tags ?? [],
+        event_type: event.event_type,
+      });
+    }
+
+    return res.json({
+      ok: true,
+      data: event,
+      vitana_index: indexDelta,
+    });
   } catch (err: any) {
     console.error(`${LOG_PREFIX} POST /events/:id/complete error:`, err.message);
     return res.status(500).json({ ok: false, error: 'Internal error' });

--- a/supabase/migrations/20260423140000_vitana_index_compute_for_user.sql
+++ b/supabase/migrations/20260423140000_vitana_index_compute_for_user.sql
@@ -1,0 +1,311 @@
+-- =============================================================================
+-- Vitana Index — health_compute_vitana_index_for_user (BOOTSTRAP-VITANA-INDEX-FOR-USER)
+-- Date: 2026-04-23
+--
+-- Admin-callable sibling of health_compute_vitana_index() that accepts the
+-- user_id explicitly instead of reading auth.uid(). Needed so server-side
+-- code (e.g., the calendar completion loop) can trigger a recompute for a
+-- specific user without having to pass a user JWT.
+--
+-- Shares the same compute body as the main RPC (copy of v3). Kept in sync
+-- manually; we'll factor into a shared plpgsql function in a follow-up if
+-- divergence becomes a problem.
+--
+-- GRANT: service_role only. Anon + authenticated callers cannot invoke it.
+-- Idempotent: CREATE OR REPLACE FUNCTION + explicit GRANT/REVOKE.
+-- =============================================================================
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.health_compute_vitana_index_for_user(
+    p_user_id UUID,
+    p_date DATE,
+    p_model_version TEXT DEFAULT 'v3-5pillar'
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+    v_tenant_id UUID;
+
+    v_b_nutrition INTEGER := 10;
+    v_b_hydration INTEGER := 10;
+    v_b_exercise INTEGER := 10;
+    v_b_sleep INTEGER := 10;
+    v_b_mental INTEGER := 10;
+
+    v_ac_nutrition INTEGER := 0;
+    v_ac_hydration INTEGER := 0;
+    v_ac_exercise INTEGER := 0;
+    v_ac_sleep INTEGER := 0;
+    v_ac_mental INTEGER := 0;
+
+    v_cd_nutrition INTEGER := 0;
+    v_cd_hydration INTEGER := 0;
+    v_cd_exercise INTEGER := 0;
+    v_cd_sleep INTEGER := 0;
+    v_cd_mental INTEGER := 0;
+
+    v_sb_nutrition INTEGER := 0;
+    v_sb_hydration INTEGER := 0;
+    v_sb_exercise INTEGER := 0;
+    v_sb_sleep INTEGER := 0;
+    v_sb_mental INTEGER := 0;
+
+    v_score_nutrition INTEGER;
+    v_score_hydration INTEGER;
+    v_score_exercise INTEGER;
+    v_score_sleep INTEGER;
+    v_score_mental INTEGER;
+
+    v_raw_sum NUMERIC;
+    v_min_pillar INTEGER;
+    v_max_pillar INTEGER;
+    v_ratio NUMERIC;
+    v_balance_factor NUMERIC;
+    v_score_total INTEGER;
+
+    v_weights JSONB;
+    v_w_nutrition NUMERIC := 1.0;
+    v_w_hydration NUMERIC := 1.0;
+    v_w_exercise NUMERIC := 1.0;
+    v_w_sleep NUMERIC := 1.0;
+    v_w_mental NUMERIC := 1.0;
+
+    v_confidence NUMERIC := 0.3;
+    v_survey_answers JSONB;
+    v_ev RECORD;
+
+    v_nutrition_tags TEXT[] := ARRAY['nutrition','meal','food-log'];
+    v_hydration_tags TEXT[] := ARRAY['hydration','water'];
+    v_exercise_tags  TEXT[] := ARRAY['movement','workout','walk','steps','exercise'];
+    v_sleep_tags     TEXT[] := ARRAY['sleep','rest','recovery'];
+    v_mental_tags    TEXT[] := ARRAY['mindfulness','mental','stress','meditation','learning','journal'];
+
+    v_streak INTEGER;
+BEGIN
+    IF p_user_id IS NULL THEN
+        RETURN jsonb_build_object('ok', false, 'error', 'USER_ID_REQUIRED');
+    END IF;
+
+    -- Tenant resolution: use user_tenants lookup; fall back to zero-UUID.
+    SELECT tenant_id INTO v_tenant_id
+    FROM public.user_tenants
+    WHERE user_id = p_user_id
+    LIMIT 1;
+    IF v_tenant_id IS NULL THEN
+        v_tenant_id := '00000000-0000-0000-0000-000000000000'::UUID;
+    END IF;
+
+    -- Baseline
+    SELECT answers INTO v_survey_answers
+    FROM public.vitana_index_baseline_survey
+    WHERE user_id = p_user_id LIMIT 1;
+
+    IF v_survey_answers IS NOT NULL THEN
+        v_b_nutrition := CASE COALESCE((v_survey_answers->>'nutrition')::INTEGER, 0)
+            WHEN 1 THEN 10 WHEN 2 THEN 20 WHEN 3 THEN 25 WHEN 4 THEN 32 WHEN 5 THEN 40 ELSE 10 END;
+        v_b_hydration := CASE COALESCE((v_survey_answers->>'hydration')::INTEGER, 0)
+            WHEN 1 THEN 10 WHEN 2 THEN 20 WHEN 3 THEN 25 WHEN 4 THEN 32 WHEN 5 THEN 40 ELSE 10 END;
+        v_b_exercise := CASE COALESCE((v_survey_answers->>'exercise')::INTEGER, 0)
+            WHEN 1 THEN 10 WHEN 2 THEN 20 WHEN 3 THEN 25 WHEN 4 THEN 32 WHEN 5 THEN 40 ELSE 10 END;
+        v_b_sleep := CASE COALESCE((v_survey_answers->>'sleep')::INTEGER, 0)
+            WHEN 1 THEN 10 WHEN 2 THEN 20 WHEN 3 THEN 25 WHEN 4 THEN 32 WHEN 5 THEN 40 ELSE 10 END;
+        v_b_mental := CASE COALESCE((v_survey_answers->>'mental')::INTEGER, 0)
+            WHEN 1 THEN 10 WHEN 2 THEN 20 WHEN 3 THEN 25 WHEN 4 THEN 32 WHEN 5 THEN 40 ELSE 10 END;
+        v_confidence := 0.5;
+    END IF;
+
+    -- Action completions
+    FOR v_ev IN
+        SELECT wellness_tags
+        FROM public.calendar_events
+        WHERE user_id = p_user_id
+          AND completion_status = 'completed'
+          AND COALESCE(completed_at, end_time) >= (CURRENT_DATE - INTERVAL '30 days')
+    LOOP
+        IF v_ev.wellness_tags && v_nutrition_tags THEN v_ac_nutrition := v_ac_nutrition + 6; END IF;
+        IF v_ev.wellness_tags && v_hydration_tags THEN v_ac_hydration := v_ac_hydration + 6; END IF;
+        IF v_ev.wellness_tags && v_exercise_tags  THEN v_ac_exercise  := v_ac_exercise  + 6; END IF;
+        IF v_ev.wellness_tags && v_sleep_tags     THEN v_ac_sleep     := v_ac_sleep     + 6; END IF;
+        IF v_ev.wellness_tags && v_mental_tags    THEN v_ac_mental    := v_ac_mental    + 6; END IF;
+        IF NOT (v_ev.wellness_tags && v_nutrition_tags
+             OR v_ev.wellness_tags && v_hydration_tags
+             OR v_ev.wellness_tags && v_exercise_tags
+             OR v_ev.wellness_tags && v_sleep_tags
+             OR v_ev.wellness_tags && v_mental_tags)
+        THEN
+            v_ac_nutrition := v_ac_nutrition + 1;
+            v_ac_hydration := v_ac_hydration + 1;
+            v_ac_exercise  := v_ac_exercise  + 1;
+            v_ac_sleep     := v_ac_sleep     + 1;
+            v_ac_mental    := v_ac_mental    + 1;
+        END IF;
+    END LOOP;
+    v_ac_nutrition := LEAST(v_ac_nutrition, 80);
+    v_ac_hydration := LEAST(v_ac_hydration, 80);
+    v_ac_exercise  := LEAST(v_ac_exercise,  80);
+    v_ac_sleep     := LEAST(v_ac_sleep,     80);
+    v_ac_mental    := LEAST(v_ac_mental,    80);
+
+    -- Connected data
+    SELECT CASE WHEN COUNT(*) >= 11 THEN 40 WHEN COUNT(*) >= 4 THEN 25 WHEN COUNT(*) >= 1 THEN 15 ELSE 0 END
+    INTO v_cd_nutrition
+    FROM public.health_features_daily
+    WHERE user_id = p_user_id AND date >= (CURRENT_DATE - INTERVAL '7 days')
+      AND feature_key = ANY(ARRAY['biomarker_glucose','biomarker_hba1c','meal_log','macro_balance']);
+
+    SELECT CASE WHEN COUNT(*) >= 11 THEN 40 WHEN COUNT(*) >= 4 THEN 25 WHEN COUNT(*) >= 1 THEN 15 ELSE 0 END
+    INTO v_cd_hydration
+    FROM public.health_features_daily
+    WHERE user_id = p_user_id AND date >= (CURRENT_DATE - INTERVAL '7 days')
+      AND feature_key = ANY(ARRAY['water_intake','hydration_log']);
+
+    SELECT CASE WHEN COUNT(*) >= 11 THEN 40 WHEN COUNT(*) >= 4 THEN 25 WHEN COUNT(*) >= 1 THEN 15 ELSE 0 END
+    INTO v_cd_exercise
+    FROM public.health_features_daily
+    WHERE user_id = p_user_id AND date >= (CURRENT_DATE - INTERVAL '7 days')
+      AND feature_key = ANY(ARRAY['wearable_heart_rate','wearable_steps','wearable_workout','vo2_max']);
+
+    SELECT CASE WHEN COUNT(*) >= 11 THEN 40 WHEN COUNT(*) >= 4 THEN 25 WHEN COUNT(*) >= 1 THEN 15 ELSE 0 END
+    INTO v_cd_sleep
+    FROM public.health_features_daily
+    WHERE user_id = p_user_id AND date >= (CURRENT_DATE - INTERVAL '7 days')
+      AND feature_key = ANY(ARRAY['wearable_sleep_duration','wearable_sleep_efficiency','wearable_hrv','wearable_sleep_stages']);
+
+    SELECT CASE WHEN COUNT(*) >= 11 THEN 40 WHEN COUNT(*) >= 4 THEN 25 WHEN COUNT(*) >= 1 THEN 15 ELSE 0 END
+    INTO v_cd_mental
+    FROM public.health_features_daily
+    WHERE user_id = p_user_id AND date >= (CURRENT_DATE - INTERVAL '7 days')
+      AND feature_key = ANY(ARRAY['wearable_stress','mood_entry','meditation_minutes','journal_entry']);
+
+    -- Streak bonuses — reuses the existing helper.
+    v_streak := public.vitana_pillar_streak_days(p_user_id, 'nutrition');
+    v_sb_nutrition := CASE WHEN v_streak >= 30 THEN 40 WHEN v_streak >= 14 THEN 25 WHEN v_streak >= 7 THEN 15 ELSE 0 END;
+    v_streak := public.vitana_pillar_streak_days(p_user_id, 'hydration');
+    v_sb_hydration := CASE WHEN v_streak >= 30 THEN 40 WHEN v_streak >= 14 THEN 25 WHEN v_streak >= 7 THEN 15 ELSE 0 END;
+    v_streak := public.vitana_pillar_streak_days(p_user_id, 'exercise');
+    v_sb_exercise := CASE WHEN v_streak >= 30 THEN 40 WHEN v_streak >= 14 THEN 25 WHEN v_streak >= 7 THEN 15 ELSE 0 END;
+    v_streak := public.vitana_pillar_streak_days(p_user_id, 'sleep');
+    v_sb_sleep := CASE WHEN v_streak >= 30 THEN 40 WHEN v_streak >= 14 THEN 25 WHEN v_streak >= 7 THEN 15 ELSE 0 END;
+    v_streak := public.vitana_pillar_streak_days(p_user_id, 'mental');
+    v_sb_mental := CASE WHEN v_streak >= 30 THEN 40 WHEN v_streak >= 14 THEN 25 WHEN v_streak >= 7 THEN 15 ELSE 0 END;
+
+    -- Pillar totals + cap
+    v_score_nutrition := LEAST(200, v_b_nutrition + v_ac_nutrition + v_cd_nutrition + v_sb_nutrition);
+    v_score_hydration := LEAST(200, v_b_hydration + v_ac_hydration + v_cd_hydration + v_sb_hydration);
+    v_score_exercise  := LEAST(200, v_b_exercise  + v_ac_exercise  + v_cd_exercise  + v_sb_exercise);
+    v_score_sleep     := LEAST(200, v_b_sleep     + v_ac_sleep     + v_cd_sleep     + v_sb_sleep);
+    v_score_mental    := LEAST(200, v_b_mental    + v_ac_mental    + v_cd_mental    + v_sb_mental);
+
+    -- Weights
+    SELECT pillar_weights INTO v_weights
+    FROM public.vitana_index_config
+    WHERE is_active = TRUE ORDER BY version DESC LIMIT 1;
+    IF v_weights IS NOT NULL THEN
+        v_w_nutrition := COALESCE((v_weights->>'nutrition')::NUMERIC, 1.0);
+        v_w_hydration := COALESCE((v_weights->>'hydration')::NUMERIC, 1.0);
+        v_w_exercise  := COALESCE((v_weights->>'exercise')::NUMERIC,  1.0);
+        v_w_sleep     := COALESCE((v_weights->>'sleep')::NUMERIC,     1.0);
+        v_w_mental    := COALESCE((v_weights->>'mental')::NUMERIC,    1.0);
+    END IF;
+
+    v_raw_sum :=
+          v_score_nutrition * v_w_nutrition
+        + v_score_hydration * v_w_hydration
+        + v_score_exercise  * v_w_exercise
+        + v_score_sleep     * v_w_sleep
+        + v_score_mental    * v_w_mental;
+
+    v_min_pillar := LEAST(v_score_nutrition, v_score_hydration, v_score_exercise, v_score_sleep, v_score_mental);
+    v_max_pillar := GREATEST(v_score_nutrition, v_score_hydration, v_score_exercise, v_score_sleep, v_score_mental);
+    IF v_max_pillar > 0 THEN v_ratio := v_min_pillar::NUMERIC / v_max_pillar::NUMERIC; ELSE v_ratio := 1.0; END IF;
+    v_balance_factor := CASE
+        WHEN v_ratio >= 0.70 THEN 1.00
+        WHEN v_ratio >= 0.50 THEN 0.90
+        WHEN v_ratio >= 0.30 THEN 0.80
+        ELSE 0.70
+    END;
+    v_score_total := LEAST(999, GREATEST(0, ROUND(v_raw_sum * v_balance_factor)::INTEGER));
+
+    IF v_ac_nutrition + v_ac_hydration + v_ac_exercise + v_ac_sleep + v_ac_mental > 0 THEN
+        v_confidence := GREATEST(v_confidence, 0.7);
+    END IF;
+    IF v_cd_nutrition + v_cd_hydration + v_cd_exercise + v_cd_sleep + v_cd_mental > 0 THEN
+        v_confidence := GREATEST(v_confidence, 0.85);
+    END IF;
+
+    -- Upsert
+    INSERT INTO public.vitana_index_scores (
+        tenant_id, user_id, date, score_total,
+        score_nutrition, score_hydration, score_exercise, score_sleep, score_mental,
+        model_version, feature_inputs, confidence
+    ) VALUES (
+        v_tenant_id, p_user_id, p_date, v_score_total,
+        v_score_nutrition, v_score_hydration, v_score_exercise, v_score_sleep, v_score_mental,
+        p_model_version,
+        jsonb_build_object(
+            'source', 'compute_rpc_v3_for_user',
+            'balance_factor', v_balance_factor,
+            'ratio', v_ratio,
+            'raw_sum', v_raw_sum,
+            'subscores', jsonb_build_object(
+                'nutrition', jsonb_build_object('baseline', v_b_nutrition, 'completions', v_ac_nutrition, 'data', v_cd_nutrition, 'streak', v_sb_nutrition),
+                'hydration', jsonb_build_object('baseline', v_b_hydration, 'completions', v_ac_hydration, 'data', v_cd_hydration, 'streak', v_sb_hydration),
+                'exercise',  jsonb_build_object('baseline', v_b_exercise,  'completions', v_ac_exercise,  'data', v_cd_exercise,  'streak', v_sb_exercise),
+                'sleep',     jsonb_build_object('baseline', v_b_sleep,     'completions', v_ac_sleep,     'data', v_cd_sleep,     'streak', v_sb_sleep),
+                'mental',    jsonb_build_object('baseline', v_b_mental,    'completions', v_ac_mental,    'data', v_cd_mental,    'streak', v_sb_mental)
+            )
+        ),
+        v_confidence
+    )
+    ON CONFLICT (tenant_id, user_id, date) DO UPDATE SET
+        score_total = EXCLUDED.score_total,
+        score_nutrition = EXCLUDED.score_nutrition,
+        score_hydration = EXCLUDED.score_hydration,
+        score_exercise = EXCLUDED.score_exercise,
+        score_sleep = EXCLUDED.score_sleep,
+        score_mental = EXCLUDED.score_mental,
+        model_version = EXCLUDED.model_version,
+        feature_inputs = EXCLUDED.feature_inputs,
+        confidence = EXCLUDED.confidence,
+        updated_at = NOW();
+
+    RETURN jsonb_build_object(
+        'ok', true,
+        'date', p_date,
+        'user_id', p_user_id,
+        'score_total', v_score_total,
+        'score_nutrition', v_score_nutrition,
+        'score_hydration', v_score_hydration,
+        'score_exercise', v_score_exercise,
+        'score_sleep', v_score_sleep,
+        'score_mental', v_score_mental,
+        'balance_factor', v_balance_factor,
+        'subscores', jsonb_build_object(
+            'nutrition', jsonb_build_object('baseline', v_b_nutrition, 'completions', v_ac_nutrition, 'data', v_cd_nutrition, 'streak', v_sb_nutrition),
+            'hydration', jsonb_build_object('baseline', v_b_hydration, 'completions', v_ac_hydration, 'data', v_cd_hydration, 'streak', v_sb_hydration),
+            'exercise',  jsonb_build_object('baseline', v_b_exercise,  'completions', v_ac_exercise,  'data', v_cd_exercise,  'streak', v_sb_exercise),
+            'sleep',     jsonb_build_object('baseline', v_b_sleep,     'completions', v_ac_sleep,     'data', v_cd_sleep,     'streak', v_sb_sleep),
+            'mental',    jsonb_build_object('baseline', v_b_mental,    'completions', v_ac_mental,    'data', v_cd_mental,    'streak', v_sb_mental)
+        ),
+        'confidence', v_confidence,
+        'model_version', p_model_version
+    );
+END;
+$$;
+
+-- Service-role only — callers must use the admin Supabase client.
+REVOKE ALL ON FUNCTION public.health_compute_vitana_index_for_user(UUID, DATE, TEXT) FROM PUBLIC;
+REVOKE ALL ON FUNCTION public.health_compute_vitana_index_for_user(UUID, DATE, TEXT) FROM authenticated;
+REVOKE ALL ON FUNCTION public.health_compute_vitana_index_for_user(UUID, DATE, TEXT) FROM anon;
+GRANT EXECUTE ON FUNCTION public.health_compute_vitana_index_for_user(UUID, DATE, TEXT) TO service_role;
+
+COMMENT ON FUNCTION public.health_compute_vitana_index_for_user(UUID, DATE, TEXT) IS
+  'Service-role-only sibling of health_compute_vitana_index() that takes user_id as a parameter. Used by the calendar completion loop to trigger a recompute for a specific user without needing their JWT.';
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;

--- a/supabase/migrations/20260423150000_vitana_index_contribution_vector.sql
+++ b/supabase/migrations/20260423150000_vitana_index_contribution_vector.sql
@@ -1,0 +1,178 @@
+-- =============================================================================
+-- autopilot_recommendations.contribution_vector — auto-populate from source_ref
+-- Date: 2026-04-23
+-- Plan: .claude/plans/community-user-role-make-purring-pascal.md (step 4)
+--
+-- Populates the contribution_vector JSONB on every autopilot_recommendations
+-- insert using a single canonical map from source_ref (the signal_type) to
+-- 5-pillar delta. Mirrors the tag-map in health_compute_vitana_index() v3 so
+-- Autopilot activations and Calendar completions agree on what moves the
+-- Index.
+--
+-- Also backfills existing rows where contribution_vector IS NULL.
+--
+-- Idempotent: CREATE OR REPLACE FUNCTION, DROP TRIGGER IF EXISTS, UPDATE.
+-- =============================================================================
+
+BEGIN;
+
+-- -----------------------------------------------------------------------------
+-- Helper: source_ref → JSONB contribution_vector
+-- Returns {nutrition: n, hydration: n, exercise: n, sleep: n, mental: n}
+-- where n ≥ 0. Unknown source_refs return {} (NULL-equivalent).
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.vitana_contribution_vector_from_source_ref(p_source_ref TEXT)
+RETURNS JSONB
+LANGUAGE plpgsql
+IMMUTABLE
+AS $$
+DECLARE
+  v_nutrition INTEGER := 0;
+  v_hydration INTEGER := 0;
+  v_exercise  INTEGER := 0;
+  v_sleep     INTEGER := 0;
+  v_mental    INTEGER := 0;
+BEGIN
+  -- Mapping is derived from the wellness_tags on each COMMUNITY_ACTIONS entry
+  -- in autopilot-recommendations.ts. Kept in sync by convention.
+  CASE COALESCE(p_source_ref, '')
+    -- Weakness-driven
+    WHEN 'weakness_movement' THEN v_exercise := 6;
+    WHEN 'weakness_nutrition' THEN v_nutrition := 6;
+    WHEN 'weakness_sleep' THEN v_sleep := 6;
+    WHEN 'weakness_stress' THEN v_mental := 6;
+    WHEN 'weakness_social' THEN v_mental := 4; -- social → mental (community well-being)
+
+    -- Engagement
+    WHEN 'engage_health' THEN v_exercise := 2; -- health-check halo: small bumps everywhere below
+    WHEN 'engage_meetup' THEN v_mental := 4;
+    WHEN 'deepen_connection' THEN v_mental := 4;
+    WHEN 'set_goal' THEN v_mental := 4;
+    WHEN 'start_streak' THEN v_exercise := 4;
+
+    -- Mood-driven
+    WHEN 'mood_support' THEN v_mental := 6;
+    WHEN 'mood_energy' THEN v_exercise := 4;
+
+    -- Onboarding (small halo — +1 to all)
+    WHEN 'onboarding_profile' THEN
+      v_nutrition := 1; v_hydration := 1; v_exercise := 1; v_sleep := 1; v_mental := 1;
+    WHEN 'onboarding_avatar' THEN
+      v_nutrition := 1; v_hydration := 1; v_exercise := 1; v_sleep := 1; v_mental := 1;
+    WHEN 'onboarding_explore' THEN v_mental := 2;
+    WHEN 'onboarding_interests' THEN v_mental := 1;
+    WHEN 'onboarding_maxina' THEN v_mental := 2;
+    WHEN 'onboarding_diary', 'onboarding_diary_day0' THEN v_mental := 4;
+    WHEN 'onboarding_health' THEN v_exercise := 2;
+    WHEN 'onboarding_matches', 'onboarding_discover_matches', 'engage_matches' THEN v_mental := 2;
+    WHEN 'onboarding_group' THEN v_mental := 2;
+
+    -- Advanced
+    WHEN 'share_expertise' THEN v_mental := 2;
+    WHEN 'invite_friend' THEN v_mental := 2;
+
+    -- Streaks (small universal boost)
+    WHEN 'streak_celebration', 'streak_continue' THEN
+      v_nutrition := 1; v_hydration := 1; v_exercise := 1; v_sleep := 1; v_mental := 1;
+
+    ELSE
+      -- Unknown source_ref — return empty object so callers can distinguish
+      -- "no contribution mapped" from "explicit zero".
+      RETURN '{}'::JSONB;
+  END CASE;
+
+  RETURN jsonb_build_object(
+    'nutrition', v_nutrition,
+    'hydration', v_hydration,
+    'exercise',  v_exercise,
+    'sleep',     v_sleep,
+    'mental',    v_mental
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.vitana_contribution_vector_from_source_ref(TEXT) IS
+  'Maps an autopilot source_ref (signal_type) to a 5-pillar JSONB contribution vector. Keyed to the COMMUNITY_ACTIONS wellness_tags in autopilot-recommendations.ts and the tag map in health_compute_vitana_index() v3.';
+
+-- -----------------------------------------------------------------------------
+-- Trigger: on INSERT of autopilot_recommendations, populate contribution_vector
+-- from source_ref if the caller didn't provide one.
+-- -----------------------------------------------------------------------------
+CREATE OR REPLACE FUNCTION public.vitana_autopilot_contribution_vector_trigger()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.contribution_vector IS NULL OR NEW.contribution_vector = '{}'::JSONB THEN
+    NEW.contribution_vector := public.vitana_contribution_vector_from_source_ref(NEW.source_ref);
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_autopilot_recommendations_contribution_vector
+  ON public.autopilot_recommendations;
+
+CREATE TRIGGER trg_autopilot_recommendations_contribution_vector
+  BEFORE INSERT ON public.autopilot_recommendations
+  FOR EACH ROW
+  EXECUTE FUNCTION public.vitana_autopilot_contribution_vector_trigger();
+
+-- -----------------------------------------------------------------------------
+-- Backfill existing rows.
+-- -----------------------------------------------------------------------------
+UPDATE public.autopilot_recommendations
+SET contribution_vector = public.vitana_contribution_vector_from_source_ref(source_ref)
+WHERE contribution_vector IS NULL
+   OR contribution_vector = '{}'::JSONB;
+
+-- =============================================================================
+-- calendar_events.completion_status → trigger recompute
+-- When a row transitions to completion_status='completed', automatically
+-- invoke health_compute_vitana_index_for_user() for today. This guarantees
+-- the Index tracks completion regardless of which code path wrote the
+-- update (gateway /events/:id/complete, direct Supabase from the UI,
+-- background job, etc.).
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.vitana_trg_calendar_completion_recompute()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+BEGIN
+  -- Only react to transitions INTO 'completed' (new row or status change).
+  IF NEW.completion_status = 'completed'
+     AND (OLD.completion_status IS DISTINCT FROM 'completed')
+     AND NEW.user_id IS NOT NULL
+  THEN
+    BEGIN
+      PERFORM public.health_compute_vitana_index_for_user(
+        NEW.user_id,
+        CURRENT_DATE,
+        'v3-5pillar'
+      );
+    EXCEPTION WHEN OTHERS THEN
+      -- Never block a calendar update on a recompute failure.
+      RAISE WARNING 'vitana recompute on completion failed: %', SQLERRM;
+    END;
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_calendar_completion_recompute
+  ON public.calendar_events;
+
+CREATE TRIGGER trg_calendar_completion_recompute
+  AFTER UPDATE OF completion_status ON public.calendar_events
+  FOR EACH ROW
+  EXECUTE FUNCTION public.vitana_trg_calendar_completion_recompute();
+
+COMMENT ON FUNCTION public.vitana_trg_calendar_completion_recompute() IS
+  'AFTER UPDATE trigger on calendar_events.completion_status. When a row transitions to completed, invokes health_compute_vitana_index_for_user for today so the Vitana Index reflects the new completion regardless of which client wrote the update.';
+
+NOTIFY pgrst, 'reload schema';
+
+COMMIT;


### PR DESCRIPTION
Step 4 of the Vitana Index plan.

- New admin-callable RPC `health_compute_vitana_index_for_user(p_user_id, p_date, p_model_version)` (service_role only) — sibling of the main v3 compute RPC that takes user_id as a parameter instead of reading auth.uid(). Lets server-side code trigger recompute without a user JWT.

- New SQL helper `vitana_contribution_vector_from_source_ref(source_ref)` + BEFORE INSERT trigger on `autopilot_recommendations` that auto-populates `contribution_vector` from the signal_type. Backfills existing NULL rows.

- New AFTER UPDATE trigger on `calendar_events.completion_status` — when a row transitions to 'completed', fires `health_compute_vitana_index_for_user()` for today. Works for any completion path (gateway, direct Supabase from the UI, background jobs).

- Gateway POST /api/v1/calendar/events/:id/complete: after marking completed, invokes the admin recompute, diffs against the prior row, emits an `index.recomputed` OASIS event with `per_pillar_delta`, and returns `vitana_index` in the response. Best-effort — recompute failures don't block the completion.