### PR TITLE
fix(command-hub): Databases info-card typography + section-header + arch-note (DEV-COMHU-0210)

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -34730,7 +34730,7 @@ function renderDatabasesSupabaseView() {
 
     connectionCards.forEach(function (info) {
         var card = document.createElement('div');
-        card.className = 'infra-service-card';
+        card.className = 'infra-service-card databases-info';
 
         var cardTitle = document.createElement('div');
         cardTitle.className = 'infra-service-card-title';
@@ -34860,7 +34860,7 @@ function renderDatabasesVectorsView() {
 
     statusCards.forEach(function (info) {
         var card = document.createElement('div');
-        card.className = 'infra-service-card';
+        card.className = 'infra-service-card databases-info';
 
         var cardTitle = document.createElement('div');
         cardTitle.className = 'infra-service-card-title';
@@ -34904,7 +34904,7 @@ function renderDatabasesVectorsView() {
 
         embedStats.forEach(function (s) {
             var card = document.createElement('div');
-            card.className = 'infra-service-card';
+            card.className = 'infra-service-card databases-info';
             var ct = document.createElement('div');
             ct.className = 'infra-service-card-title';
             ct.textContent = s.title;
@@ -34997,7 +34997,7 @@ function renderDatabasesCacheView() {
 
     cacheStrategies.forEach(function (info) {
         var card = document.createElement('div');
-        card.className = 'infra-service-card';
+        card.className = 'infra-service-card databases-info';
 
         var cardTitle = document.createElement('div');
         cardTitle.className = 'infra-service-card-title';
@@ -35082,7 +35082,7 @@ function renderDatabasesAnalyticsView() {
 
     countCards.forEach(function (info) {
         var card = document.createElement('div');
-        card.className = 'infra-service-card';
+        card.className = 'infra-service-card databases-info';
 
         var cardTitle = document.createElement('div');
         cardTitle.className = 'infra-service-card-title';
@@ -35163,7 +35163,7 @@ function renderDatabasesClustersView() {
 
     clusterConfig.forEach(function (info) {
         var card = document.createElement('div');
-        card.className = 'infra-service-card';
+        card.className = 'infra-service-card databases-info';
 
         var cardTitle = document.createElement('div');
         cardTitle.className = 'infra-service-card-title';

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -4,7 +4,7 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Vitana Command Hub</title>
-  <link rel="stylesheet" href="/command-hub/styles.css?v=20260419-vtid02403" />
+  <link rel="stylesheet" href="/command-hub/styles.css?v=20260423-dev-comhu-0210-databases" />
 </head>
 <body>
   <div id="root"></div>
@@ -12,7 +12,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260421-disconnect-alert"></script>
-  <script src="/command-hub/app.js?v=20260423-unified-kb-system-knowledge"></script>
+  <script src="/command-hub/app.js?v=20260423-dev-comhu-0210-databases"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
 </body>

--- a/services/gateway/src/frontend/command-hub/styles.css
+++ b/services/gateway/src/frontend/command-hub/styles.css
@@ -16791,6 +16791,84 @@ border-bottom: 1px solid var(--color-border, #333);
 .service-info .service-detail { font-size: 0.75rem; color: var(--color-text-secondary); }
 .service-info .service-latency { font-size: 0.75rem; color: var(--color-text-secondary); }
 
+/* ── Stacked info card variant (Databases module) ──
+   Overrides the default flex-row layout of .infra-service-card so the
+   title / value / detail stack vertically with proper typography. */
+.infra-service-card.databases-info {
+  flex-direction: column;
+  align-items: flex-start;
+  gap: 0.25rem;
+}
+.infra-service-card-title {
+  font-size: 0.75rem;
+  color: var(--color-text-secondary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+}
+.infra-service-card-value {
+  font-size: 1.25rem;
+  font-weight: 700;
+  color: var(--color-text-primary);
+  line-height: 1.2;
+}
+.infra-service-card-detail {
+  font-size: 0.75rem;
+  color: var(--color-text-secondary);
+  line-height: 1.4;
+  margin-top: 0.25rem;
+}
+
+/* ── Generic section header (used by Databases + other modules that do
+   not opt into the `.infra-section-header` variant below) ── */
+.section-header {
+  margin-bottom: 1.5rem;
+}
+.section-header h2 {
+  font-size: 1.25rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  margin: 0 0 0.25rem 0;
+}
+
+/* ── Databases module: tables section + architecture note block ── */
+.databases-tables-section,
+.databases-stats-section {
+  margin-top: 1.5rem;
+}
+.databases-tables-section h3,
+.databases-stats-section h3 {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0 0 0.75rem 0;
+}
+.databases-arch-note {
+  background: var(--color-sidebar-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+  margin-top: 1.5rem;
+}
+.databases-arch-note h3 {
+  font-size: 0.9rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+  text-transform: uppercase;
+  letter-spacing: 0.05em;
+  margin: 0 0 0.5rem 0;
+}
+.databases-arch-note ul {
+  margin: 0;
+  padding-left: 1.25rem;
+  color: var(--color-text-secondary);
+  font-size: 0.85rem;
+  line-height: 1.6;
+}
+.databases-arch-note li { margin-bottom: 0.25rem; }
+.databases-arch-note li strong { color: var(--color-text-primary); }
+
 /* ═══════════════════════════════════════════════════════════════
    INFRASTRUCTURE MODULE — Redesigned Layout
    ═══════════════════════════════════════════════════════════════ */


### PR DESCRIPTION
The five Databases views (Supabase, Vectors, Cache, Analytics, Clusters) at app.js:34396-34880 referenced CSS classes with no rules attached, resulting in broken typography. This adds the missing CSS rules (reuse-only — no new tokens, no new classes) and a `.databases-info` modifier on `.infra-service-card` to make the title/value/detail stack properly.

## What was broken

- `.infra-service-card-title` / `-value` / `-detail` had 40+ references across the 5 views but **zero CSS rules** — every card rendered all three fields at the same default browser font-size with no hierarchy.
- `.section-header` was used on every view, undefined — `<h2>` used browser default.
- `.infra-service-card` is a flex-row component (built for service-health lines with status dot + name + latency) — the Databases views used it as a stacked block, fighting the parent's `display: flex; align-items: center`.

## What this PR does

- Adds `.infra-service-card.databases-info` modifier → `flex-direction: column; align-items: flex-start; gap: 0.25rem`.
- Adds typography for `.infra-service-card-title` (0.75rem uppercase secondary), `-value` (1.25rem weight 700 primary), `-detail` (0.75rem secondary).
- Adds `.section-header` + `h2` typography (1.25rem 600 primary) so every Databases view gets a proper title.
- Adds `.databases-arch-note`, `.databases-tables-section`, `.databases-stats-section` styling.
- One-line JS change on all 6 database card sites: `infra-service-card` → `infra-service-card databases-info` (line 38321 elsewhere untouched).
- Bumps styles.css + app.js `?v=` cache-bust.

## Test plan

- Deploy Gateway; visit `/command-hub/databases/supabase/`, `/databases/vectors/`, `/databases/cache/`, `/databases/analytics/`, `/databases/clusters/`.
- Verify each card stacks title (uppercase, small, muted) → value (large, bold) → detail (small, muted).
- Verify section header renders as a proper H2 with subtitle underneath.
- Verify Cache + Analytics architecture notes are in a bordered panel.

🤖 Generated with [Claude Code](https://claude.com/claude-code)