### PR TITLE
feat(knowledge): unified KB tree + Command Hub System Knowledge

### DIFF
--- a/.claude/plans/unified-knowledge-tree.md
+++ b/.claude/plans/unified-knowledge-tree.md
@@ -1,0 +1,91 @@
+---
+slug: unified-knowledge-tree
+title: Unified Knowledge Tree — organize Vitana docs across Command Hub & Tenant KB
+started: 2026-04-23
+branch: feat/unified-knowledge-tree (vitana-platform) + feat/unified-knowledge-tree-v1 (vitana-v1)
+---
+
+# Unified Knowledge Tree
+
+## Problem
+
+Three overlapping surfaces today:
+- **Command Hub Docs** (`/command-hub/docs/*`) — operator/developer system catalog (Screens, APIs, Schemas, Architecture, Workforce).
+- **Tenant Knowledge → Documents** (`/admin/knowledge/documents`) — baseline + tenant RAG docs (`kb_documents`).
+- **Tenant Knowledge → System KB** (`/admin/knowledge/system-kb`) — system-wide RAG (`knowledge_docs`), added in PR #852 as a parallel sibling tab.
+
+Two separate Knowledge tabs (Documents + System KB) that look the same but hit different tables confuses admins. No operator-facing view of what the Assistant knows about itself.
+
+## Two surfaces, clear scope
+
+| Surface | URL | Audience | Content class | Source |
+|---|---|---|---|---|
+| Command Hub Docs | `/command-hub/docs/*` | Exafy staff, operators, devs | **System catalog** (what the platform *is*) | Live registries + `knowledge_docs` (read-only) |
+| Tenant Knowledge | `/admin/knowledge/*` | Tenant admins (+ Exafy admins for system scope) | **Brain knowledge** (what the Assistant retrieves) | `knowledge_docs` + `kb_documents` |
+
+Do not merge them. Catalog ≠ knowledge. Cross-link instead.
+
+## Phases
+
+### Phase 1 — Tenant KB: Documents tab becomes a unified tree (vitana-v1 + vitana-platform)
+
+**Drop** the standalone `SystemKB.tsx` tab. Its view folds into Documents scope 1.
+
+**Tree (three scopes, auto-grouped)**:
+```
+📖 Vitana Platform        (knowledge_docs, namespace=vitana_system) — exafy-admin editable
+    └── auto-grouped by path hierarchy (kb/vitana-system/<area>/*)
+📚 Baseline Library       (kb_documents WHERE tenant_id IS NULL) — exafy-admin editable, tenant can opt out
+    └── auto-grouped by first topic tag
+🏢 Your Tenant Docs       (kb_documents WHERE tenant_id = current) — tenant-admin editable
+    └── auto-grouped by first topic tag
+```
+
+**New gateway endpoint**: `GET /api/v1/admin/tenants/:tenantId/kb/unified-tree`
+Returns `{ system: TreeNode[], baseline: TreeNode[], tenant: TreeNode[] }`. Each `TreeNode` is `{ id, title, path, source: 'system'|'baseline'|'tenant', status, topics[], lastUpdated, opted_out? }`.
+
+**UI**: tree (left) + viewer (right) + global search (scoped to this surface only — Q2 answer: "no", don't bleed into Command Hub registries).
+
+**Baseline-edit safeguard (Q3 answer: yes)**: when exafy admin edits a baseline or system doc, show a confirm modal: "This document is shared across all tenants. Changes apply immediately everywhere."
+
+**Files to touch**:
+- *vitana-v1*: `src/pages/admin/knowledge/Documents.tsx` (rewrite), delete `SystemKB.tsx`, `src/config/admin-navigation.ts` (remove system-kb tab entry), `src/hooks/useAdminKnowledge.ts` (+ new `useUnifiedKbTree`)
+- *vitana-platform*: `services/gateway/src/routes/tenant-admin/knowledge.ts` (new `/unified-tree` handler), possibly proxy to existing `admin-system-kb.ts` data
+
+### Phase 2 — Command Hub: System Knowledge tab (Q1 answer: yes)
+
+New sibling tab in Command Hub Docs, read-only mirror of `knowledge_docs` (`vitana_system` namespace). Reuses the same unified-tree endpoint filtered to the system scope.
+
+**Files to touch**:
+- `services/gateway/src/frontend/command-hub/app.js` — extend docs nav (`2786–2817`) and add `renderDocsSystemKnowledgeView` next to `renderDocsScreensView`
+
+### Phase 3 — Cross-links
+
+- Command Hub System Knowledge doc viewer → "Edit in tenant KB" link (exafy admins only) → `/admin/knowledge/documents?doc=<id>`.
+- Tenant KB Vitana Platform scope doc viewer → "View in Command Hub" link for exafy admins.
+
+### Phase 4 (parked) — Command Hub `/docs/screens/` network error
+
+Screens tab shows "Error: Network response was not ok" in the screenshot. Separate follow-up ticket — endpoint diagnosis needed. Not in this PR.
+
+## Open decisions (answered)
+
+1. System Knowledge tab in Command Hub? **Yes.**
+2. Global search crosses into Command Hub registries? **No.**
+3. Baseline/system edits show "affects all tenants" warning? **Yes.**
+
+## Rollout
+
+- Commit to feature branches in both repos.
+- Test locally (gateway build + vitana-v1 build + manual click-through).
+- Open PRs in both repos.
+- Merge vitana-platform first (endpoint must exist when UI ships).
+- Merge vitana-v1.
+- Verify on vitanaland.com (vitana-v1 → Cloud Run `community-app`) and on gateway Cloud Run URL.
+
+## Out of scope
+
+- No schema changes. Both tables exist.
+- No ingestion changes. Same upload paths.
+- No changes to Topics / Indexing / Search Test / Governance sibling tabs.
+- No redesign of Command Hub Docs sub-tabs other than adding System Knowledge.

--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -2790,7 +2790,8 @@ const NAVIGATION_CONFIG = [
             { "key": "api-inventory", "path": "/command-hub/docs/api-inventory/" },
             { "key": "database-schemas", "path": "/command-hub/docs/database-schemas/" },
             { "key": "architecture", "path": "/command-hub/docs/architecture/" },
-            { "key": "workforce", "path": "/command-hub/docs/workforce/" }
+            { "key": "workforce", "path": "/command-hub/docs/workforce/" },
+            { "key": "system-knowledge", "path": "/command-hub/docs/system-knowledge/" }
         ]
     }
 ];
@@ -6212,6 +6213,8 @@ function renderModuleContent(moduleKey, tab) {
         container.appendChild(renderDocsArchitectureView());
     } else if (moduleKey === 'docs' && tab === 'workforce') {
         container.appendChild(renderDocsWorkforceView());
+    } else if (moduleKey === 'docs' && tab === 'system-knowledge') {
+        container.appendChild(renderDocsSystemKnowledgeView());
 
     // ──── Autopilot tabs ────
     } else if (moduleKey === 'autopilot' && tab === 'registry') {
@@ -34064,6 +34067,311 @@ function renderDocsWorkforceView() {
         '<span style="padding:4px 12px;border-radius:4px;background:#22c55e;color:white;">Deploy</span><span style="color:var(--color-text-secondary);">-></span>' +
         '<span style="padding:4px 12px;border-radius:4px;background:#10b981;color:white;">Done</span></div>';
     container.appendChild(pipeline);
+    return container;
+}
+
+// ===========================================================================
+// Docs: System Knowledge — read-only mirror of knowledge_docs (vitana_system)
+// ===========================================================================
+//
+// Operator view of what the Vitana Assistant "knows about itself" (Book of the
+// Vitana Index + other vitana_system docs). Editing happens in the tenant-admin
+// Knowledge UI (Vitanaland → Admin → Knowledge → Documents, system scope).
+// Endpoint: GET /api/v1/admin/system-kb/docs  (exafy-admin only)
+
+function initSystemKbState() {
+    if (state.systemKb) return;
+    state.systemKb = {
+        docsLoading: false,
+        docsError: null,
+        docs: null,
+        filterPrefix: 'kb/vitana-system/index-book/',
+        searchQ: '',
+        selectedId: null,
+        selectedDocLoading: false,
+        selectedDoc: null,
+        selectedDocError: null,
+    };
+}
+
+async function fetchSystemKbDocs() {
+    initSystemKbState();
+    state.systemKb.docsLoading = true;
+    state.systemKb.docsError = null;
+    renderApp();
+
+    try {
+        const token = state.authToken;
+        const qs = new URLSearchParams();
+        if (state.systemKb.filterPrefix) qs.set('path_prefix', state.systemKb.filterPrefix);
+        if (state.systemKb.searchQ) qs.set('q', state.systemKb.searchQ);
+
+        const response = await fetch('/api/v1/admin/system-kb/docs?' + qs.toString(), {
+            headers: token ? { Authorization: 'Bearer ' + token } : {},
+        });
+        if (!response.ok) {
+            const data = await response.json().catch(() => ({}));
+            throw new Error(data.error || 'HTTP ' + response.status);
+        }
+        const json = await response.json();
+        state.systemKb.docs = json.documents || [];
+    } catch (err) {
+        console.error('[system-knowledge] list error:', err);
+        state.systemKb.docsError = err.message;
+        state.systemKb.docs = null;
+    } finally {
+        state.systemKb.docsLoading = false;
+        renderApp();
+    }
+}
+
+async function fetchSystemKbDoc(id) {
+    initSystemKbState();
+    state.systemKb.selectedId = id;
+    state.systemKb.selectedDoc = null;
+    state.systemKb.selectedDocLoading = true;
+    state.systemKb.selectedDocError = null;
+    renderApp();
+
+    try {
+        const token = state.authToken;
+        const response = await fetch('/api/v1/admin/system-kb/docs/' + encodeURIComponent(id), {
+            headers: token ? { Authorization: 'Bearer ' + token } : {},
+        });
+        if (!response.ok) {
+            const data = await response.json().catch(() => ({}));
+            throw new Error(data.error || 'HTTP ' + response.status);
+        }
+        const json = await response.json();
+        state.systemKb.selectedDoc = json.document;
+    } catch (err) {
+        console.error('[system-knowledge] detail error:', err);
+        state.systemKb.selectedDocError = err.message;
+    } finally {
+        state.systemKb.selectedDocLoading = false;
+        renderApp();
+    }
+}
+
+function renderDocsSystemKnowledgeView() {
+    initSystemKbState();
+
+    // Deep-link: ?doc=<id> preselects the doc after the list loads.
+    try {
+        var urlParams = new URLSearchParams(window.location.search);
+        var deepDocId = urlParams.get('doc');
+        if (deepDocId && state.systemKb.selectedId !== deepDocId) {
+            fetchSystemKbDoc(deepDocId);
+        }
+    } catch (_) { /* ignore */ }
+
+    var container = document.createElement('div');
+    container.className = 'docs-container';
+    container.style.padding = '1.5rem';
+
+    var title = document.createElement('h2');
+    title.textContent = 'System Knowledge';
+    container.appendChild(title);
+
+    var subtitle = document.createElement('p');
+    subtitle.className = 'section-subtitle';
+    subtitle.textContent =
+        'Read-only view of the system-wide knowledge_docs table that grounds the Vitana Assistant (retrieval-router priority 100). Edits happen in the tenant Knowledge admin → Documents → Vitana Platform scope.';
+    container.appendChild(subtitle);
+
+    // Filters
+    var toolbar = document.createElement('div');
+    toolbar.className = 'docs-toolbar';
+    toolbar.style.flexWrap = 'wrap';
+    toolbar.style.gap = '0.5rem';
+
+    var filters = [
+        { key: 'kb/vitana-system/index-book/', label: 'Book of the Vitana Index' },
+        { key: 'kb/vitana-system/', label: 'All vitana_system docs' },
+        { key: '', label: 'All system KB docs' },
+    ];
+    filters.forEach(function (f) {
+        var btn = document.createElement('button');
+        btn.className = state.systemKb.filterPrefix === f.key ? 'btn role-btn-active' : 'btn';
+        btn.textContent = f.label;
+        btn.onclick = function () {
+            state.systemKb.filterPrefix = f.key;
+            state.systemKb.selectedId = null;
+            state.systemKb.selectedDoc = null;
+            fetchSystemKbDocs();
+        };
+        toolbar.appendChild(btn);
+    });
+    container.appendChild(toolbar);
+
+    var searchRow = document.createElement('div');
+    searchRow.style.margin = '0.75rem 0';
+    var searchInput = document.createElement('input');
+    searchInput.type = 'search';
+    searchInput.placeholder = 'Search by title or path…';
+    searchInput.value = state.systemKb.searchQ;
+    searchInput.style.width = '100%';
+    searchInput.style.padding = '0.5rem 0.75rem';
+    searchInput.style.background = 'var(--bg-secondary, #1a1a1a)';
+    searchInput.style.border = '1px solid var(--border-color, #333)';
+    searchInput.style.color = 'var(--text-primary, #fff)';
+    searchInput.style.borderRadius = '6px';
+    var searchTimer = null;
+    searchInput.oninput = function (e) {
+        state.systemKb.searchQ = e.target.value;
+        if (searchTimer) clearTimeout(searchTimer);
+        searchTimer = setTimeout(fetchSystemKbDocs, 250);
+    };
+    searchRow.appendChild(searchInput);
+    container.appendChild(searchRow);
+
+    // Two-pane layout: list | viewer
+    var panes = document.createElement('div');
+    panes.style.display = 'grid';
+    panes.style.gridTemplateColumns = 'minmax(260px, 1fr) 2fr';
+    panes.style.gap = '1rem';
+    panes.style.marginTop = '1rem';
+
+    // Left: list
+    var listPane = document.createElement('div');
+    listPane.style.minWidth = '0';
+
+    if (state.systemKb.docs === null && !state.systemKb.docsLoading && !state.systemKb.docsError) {
+        fetchSystemKbDocs();
+    }
+
+    if (state.systemKb.docsLoading) {
+        listPane.innerHTML = '<div class="placeholder-content">Loading system KB…</div>';
+    } else if (state.systemKb.docsError) {
+        listPane.innerHTML =
+            '<div class="placeholder-content error-text">Error: ' +
+            escapeHtml(state.systemKb.docsError) +
+            '</div>';
+    } else if (!state.systemKb.docs || state.systemKb.docs.length === 0) {
+        listPane.innerHTML = '<div class="placeholder-content">No docs match this filter.</div>';
+    } else {
+        var ul = document.createElement('ul');
+        ul.style.listStyle = 'none';
+        ul.style.padding = '0';
+        ul.style.margin = '0';
+        ul.style.maxHeight = '65vh';
+        ul.style.overflowY = 'auto';
+        state.systemKb.docs.forEach(function (d) {
+            var li = document.createElement('li');
+            var btn = document.createElement('button');
+            btn.className = state.systemKb.selectedId === d.id ? 'btn role-btn-active' : 'btn';
+            btn.style.display = 'block';
+            btn.style.width = '100%';
+            btn.style.textAlign = 'left';
+            btn.style.marginBottom = '0.25rem';
+            btn.style.padding = '0.5rem 0.75rem';
+            btn.onclick = function () {
+                fetchSystemKbDoc(d.id);
+            };
+            var titleEl = document.createElement('div');
+            titleEl.textContent = d.title;
+            titleEl.style.fontWeight = '500';
+            btn.appendChild(titleEl);
+            var pathEl = document.createElement('div');
+            pathEl.textContent = d.path;
+            pathEl.style.fontSize = '0.75rem';
+            pathEl.style.opacity = '0.7';
+            pathEl.style.wordBreak = 'break-all';
+            pathEl.style.marginTop = '0.15rem';
+            btn.appendChild(pathEl);
+            li.appendChild(btn);
+            ul.appendChild(li);
+        });
+        listPane.appendChild(ul);
+    }
+    panes.appendChild(listPane);
+
+    // Right: viewer
+    var viewerPane = document.createElement('div');
+    viewerPane.style.minWidth = '0';
+    viewerPane.style.background = 'var(--bg-secondary, #1a1a1a)';
+    viewerPane.style.border = '1px solid var(--border-color, #333)';
+    viewerPane.style.borderRadius = '6px';
+    viewerPane.style.padding = '1rem';
+    viewerPane.style.maxHeight = '70vh';
+    viewerPane.style.overflowY = 'auto';
+
+    if (!state.systemKb.selectedId) {
+        viewerPane.innerHTML =
+            '<div class="placeholder-content">Pick a doc from the list to read it.</div>';
+    } else if (state.systemKb.selectedDocLoading) {
+        viewerPane.innerHTML = '<div class="placeholder-content">Loading…</div>';
+    } else if (state.systemKb.selectedDocError) {
+        viewerPane.innerHTML =
+            '<div class="placeholder-content error-text">Error: ' +
+            escapeHtml(state.systemKb.selectedDocError) +
+            '</div>';
+    } else if (state.systemKb.selectedDoc) {
+        var doc = state.systemKb.selectedDoc;
+        var headerRow = document.createElement('div');
+        headerRow.style.display = 'flex';
+        headerRow.style.alignItems = 'baseline';
+        headerRow.style.justifyContent = 'space-between';
+        headerRow.style.gap = '0.5rem';
+        var h = document.createElement('h3');
+        h.textContent = doc.title;
+        h.style.margin = '0 0 0.25rem 0';
+        headerRow.appendChild(h);
+        var editLink = document.createElement('a');
+        editLink.href =
+            'https://vitanaland.com/admin/knowledge/documents?scope=system&doc=' +
+            encodeURIComponent(doc.id);
+        editLink.target = '_blank';
+        editLink.rel = 'noopener noreferrer';
+        editLink.textContent = 'Edit in Vitanaland →';
+        editLink.style.fontSize = '0.75rem';
+        editLink.style.whiteSpace = 'nowrap';
+        headerRow.appendChild(editLink);
+        viewerPane.appendChild(headerRow);
+        var p = document.createElement('div');
+        p.textContent = doc.path;
+        p.style.fontSize = '0.75rem';
+        p.style.opacity = '0.7';
+        p.style.wordBreak = 'break-all';
+        viewerPane.appendChild(p);
+        if (doc.tags && doc.tags.length) {
+            var tagsEl = document.createElement('div');
+            tagsEl.style.margin = '0.5rem 0';
+            doc.tags.forEach(function (t) {
+                var tag = document.createElement('span');
+                tag.textContent = t;
+                tag.style.display = 'inline-block';
+                tag.style.fontSize = '0.7rem';
+                tag.style.padding = '0.15rem 0.4rem';
+                tag.style.marginRight = '0.25rem';
+                tag.style.background = 'var(--bg-tertiary, #222)';
+                tag.style.borderRadius = '3px';
+                tagsEl.appendChild(tag);
+            });
+            viewerPane.appendChild(tagsEl);
+        }
+        var pre = document.createElement('pre');
+        pre.textContent = doc.content || '';
+        pre.style.whiteSpace = 'pre-wrap';
+        pre.style.wordBreak = 'break-word';
+        pre.style.fontFamily = 'inherit';
+        pre.style.fontSize = '0.85rem';
+        pre.style.lineHeight = '1.5';
+        pre.style.marginTop = '0.5rem';
+        viewerPane.appendChild(pre);
+        var meta = document.createElement('div');
+        meta.style.fontSize = '0.7rem';
+        meta.style.opacity = '0.6';
+        meta.style.marginTop = '1rem';
+        meta.textContent =
+            (doc.word_count || 0) +
+            ' words · updated ' +
+            new Date(doc.updated_at).toLocaleString();
+        viewerPane.appendChild(meta);
+    }
+    panes.appendChild(viewerPane);
+
+    container.appendChild(panes);
     return container;
 }
 

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -12,7 +12,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260421-disconnect-alert"></script>
-  <script src="/command-hub/app.js?v=20260420-scroll-capture-late-approve-stack"></script>
+  <script src="/command-hub/app.js?v=20260423-unified-kb-system-knowledge"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
 </body>

--- a/services/gateway/src/routes/tenant-admin/knowledge.ts
+++ b/services/gateway/src/routes/tenant-admin/knowledge.ts
@@ -306,6 +306,171 @@ router.get('/search', requireTenantAdmin, async (req: AuthenticatedRequest, res:
   }
 });
 
+/**
+ * GET /unified-tree
+ * Returns a merged, auto-grouped tree of all three KB scopes:
+ *   - system   (knowledge_docs, namespace=vitana_system — Book of the Vitana Index + others)
+ *   - baseline (kb_documents WHERE tenant_id IS NULL, with per-tenant opt-out flag)
+ *   - tenant   (kb_documents WHERE tenant_id = :tenantId)
+ *
+ * Response shape:
+ *   {
+ *     ok: true,
+ *     tree: {
+ *       system:   [{ group: string, docs: Doc[] }, ...],
+ *       baseline: [{ group: string, docs: Doc[] }, ...],
+ *       tenant:   [{ group: string, docs: Doc[] }, ...]
+ *     }
+ *   }
+ *   Doc = { id, title, path, source, status, topics[], updated_at, is_opted_out? }
+ *
+ * Read-only for tenant admins; exafy admins get the same shape. Editing still
+ * flows through the existing per-scope endpoints:
+ *   - tenant  → PUT /documents/:id
+ *   - baseline→ (exafy admin only; not yet surfaced in this router)
+ *   - system  → /api/v1/admin/system-kb (exafy admin only)
+ */
+router.get('/unified-tree', requireTenantAdmin, async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const supabase = getSupabase();
+    if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+
+    const tenantId = req.params.tenantId || (req as any).targetTenantId;
+
+    const [optoutsRes, kbDocsRes, systemDocsRes] = await Promise.allSettled([
+      supabase
+        .from('tenant_kb_baseline_optouts')
+        .select('document_id')
+        .eq('tenant_id', tenantId),
+      supabase
+        .from('kb_documents')
+        .select('id, title, tenant_id, topics, status, created_at, updated_at')
+        .or(`tenant_id.eq.${tenantId},tenant_id.is.null`),
+      supabase
+        .from('knowledge_docs')
+        .select('id, title, path, tags, source_type, word_count, created_at, updated_at')
+        .order('path', { ascending: true })
+        .limit(500),
+    ]);
+
+    const optoutIds = new Set<string>();
+    if (optoutsRes.status === 'fulfilled' && optoutsRes.value.data) {
+      optoutsRes.value.data.forEach((o: any) => optoutIds.add(o.document_id));
+    }
+
+    const kbDocs: any[] =
+      kbDocsRes.status === 'fulfilled' && kbDocsRes.value.data ? kbDocsRes.value.data : [];
+    const systemDocs: any[] =
+      systemDocsRes.status === 'fulfilled' && systemDocsRes.value.data
+        ? systemDocsRes.value.data
+        : [];
+
+    // --- System scope ---
+    const systemFriendly: Record<string, string> = {
+      'index-book': 'Book of the Vitana Index',
+      vaea: 'VAEA',
+      agents: 'Agents',
+      assistant: 'Assistant',
+      autopilot: 'Autopilot',
+    };
+    const systemGroups: Record<string, any[]> = {};
+    for (const d of systemDocs) {
+      const parts = String(d.path || '').split('/').filter(Boolean);
+      // Expected: kb/vitana-system/<area>/<file>
+      const area = parts[2] || 'other';
+      const groupName = systemFriendly[area] ?? area.charAt(0).toUpperCase() + area.slice(1);
+      if (!systemGroups[groupName]) systemGroups[groupName] = [];
+      systemGroups[groupName].push({
+        id: d.id,
+        title: d.title,
+        path: d.path,
+        source: 'system' as const,
+        status: 'indexed' as const,
+        topics: d.tags || [],
+        updated_at: d.updated_at,
+      });
+    }
+    const systemTree = Object.entries(systemGroups)
+      .map(([group, docs]) => ({
+        group,
+        docs: docs.sort((a, b) => String(a.path).localeCompare(String(b.path))),
+      }))
+      .sort((a, b) => a.group.localeCompare(b.group));
+
+    // --- Baseline + Tenant scopes (both from kb_documents) ---
+    const baselineBuckets: Record<string, any[]> = {};
+    const tenantBuckets: Record<string, any[]> = {};
+    for (const d of kbDocs) {
+      const isBaseline = d.tenant_id === null;
+      const topic = (d.topics && d.topics[0]) || 'Uncategorized';
+      const group = topic.charAt(0).toUpperCase() + topic.slice(1);
+      const entry = {
+        id: d.id,
+        title: d.title,
+        path: null,
+        source: isBaseline ? 'baseline' : 'tenant',
+        status: d.status,
+        topics: d.topics || [],
+        updated_at: d.updated_at,
+        created_at: d.created_at,
+        ...(isBaseline ? { is_opted_out: optoutIds.has(d.id) } : {}),
+      };
+      const target = isBaseline ? baselineBuckets : tenantBuckets;
+      if (!target[group]) target[group] = [];
+      target[group].push(entry);
+    }
+    const toTree = (buckets: Record<string, any[]>) =>
+      Object.entries(buckets)
+        .map(([group, docs]) => ({
+          group,
+          docs: docs.sort((a, b) =>
+            String(b.updated_at || b.created_at || '').localeCompare(
+              String(a.updated_at || a.created_at || '')
+            )
+          ),
+        }))
+        .sort((a, b) => a.group.localeCompare(b.group));
+
+    return res.json({
+      ok: true,
+      tree: {
+        system: systemTree,
+        baseline: toTree(baselineBuckets),
+        tenant: toTree(tenantBuckets),
+      },
+    });
+  } catch (err: any) {
+    console.error(`[${VTID}] unified-tree error:`, err.message);
+    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
+  }
+});
+
+/**
+ * GET /system-docs/:id
+ * Read-only viewer for knowledge_docs content. Tenant admins can READ system
+ * docs so the unified-tree viewer works; editing stays on /api/v1/admin/system-kb.
+ */
+router.get('/system-docs/:id', requireTenantAdmin, async (req: AuthenticatedRequest, res: Response) => {
+  try {
+    const supabase = getSupabase();
+    if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+
+    const { id } = req.params;
+    const { data, error } = await supabase
+      .from('knowledge_docs')
+      .select('id, title, path, content, tags, source_type, word_count, created_at, updated_at')
+      .eq('id', id)
+      .maybeSingle();
+
+    if (error) return res.status(500).json({ ok: false, error: error.message });
+    if (!data) return res.status(404).json({ ok: false, error: 'NOT_FOUND' });
+
+    return res.json({ ok: true, document: data });
+  } catch (err: any) {
+    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
+  }
+});
+
 // GET /topics — distinct topics for this tenant
 router.get('/topics', requireTenantAdmin, async (req: AuthenticatedRequest, res: Response) => {
   try {


### PR DESCRIPTION
Gateway: new GET /api/v1/admin/tenants/:tenantId/kb/unified-tree endpoint merges knowledge_docs (system) + baseline kb_documents + tenant kb_documents into a three-scope grouped tree. Companion GET /kb/system-docs/:id gives tenant admins read-only viewer access to system docs.

Command Hub Docs: new System Knowledge sub-tab — read-only mirror of knowledge_docs (Book of the Vitana Index + vitana_system). Filter buttons, search, list + viewer. Deep-link via ?doc=<id>. Outbound 'Edit in Vitanaland →' cross-link.

Plan: .claude/plans/unified-knowledge-tree.md

Pair PR in vitana-v1 drops the standalone System KB tab and rewrites the Documents tab as a single unified tree.

🤖 Generated with Claude Code (https://claude.com/claude-code)