### PR TITLE
feat(autopilot): testing strategy reset + auto-approve + feedback loop

### DIFF
--- a/scripts/ci/dev-autopilot-scan.mjs
+++ b/scripts/ci/dev-autopilot-scan.mjs
@@ -33,6 +33,17 @@ const REPO_ROOT = process.cwd();
 const LARGE_FILE_THRESHOLD = 1000;
 const TODO_PATTERN = /\b(TODO|FIXME|HACK|XXX)\b[:\s]?([^\n]*)/;
 
+// missing-tests-scanner-v1 quality filters. Recent scans produced ~338
+// findings; ~60-80 of those were files that don't warrant unit tests
+// (types/constants/config modules, thin re-exports, barrels). These
+// filters target the noise without touching files that genuinely need
+// coverage. All are env-overridable so ops can tune without a redeploy.
+const MISSING_TESTS_MIN_LOC = Number.parseInt(process.env.MISSING_TESTS_MIN_LOC || '50', 10);
+const MISSING_TESTS_FILENAME_DENYLIST = new Set(
+  (process.env.MISSING_TESTS_FILENAME_DENYLIST ||
+    'types,constants,config,defaults,registry,index').split(',').map(s => s.trim()).filter(Boolean),
+);
+
 // Only walk these roots — keeps the scan bounded and skips node_modules / dist
 const SCAN_ROOTS = [
   'services/gateway/src',
@@ -168,12 +179,21 @@ function scanMissingTests(files) {
     if (!TEST_PAIR_ROOTS.some((root) => rel.startsWith(root + '/'))) continue;
     const ext = path.extname(file);
     if (!SOURCE_EXTS.has(ext)) continue;
+    if (ext === '.d.ts' || file.endsWith('.d.ts')) continue;
     const base = path.basename(file, ext);
     // Skip files that ARE tests
     if (/\.(test|spec)$/.test(base)) continue;
-    // Skip barrel / type-only files
-    if (base === 'index' || base === 'types') continue;
+    // Filename denylist — broadens the earlier index/types skip to cover
+    // config/constants/defaults/registry modules that are pure data.
+    if (MISSING_TESTS_FILENAME_DENYLIST.has(base)) continue;
     if (testsByStem.has(base)) continue;
+
+    // Size + pure-export filters require reading the file. Only pay the
+    // cost once we know it's a candidate.
+    const lines = readLines(file);
+    if (!lines) continue;
+    if (lines.length < MISSING_TESTS_MIN_LOC) continue;
+    if (isPureExportModule(lines)) continue;
 
     signals.push({
       type: 'missing_tests',
@@ -183,6 +203,173 @@ function scanMissingTests(files) {
       message: `${rel} has no matching ${base}.test.ts`,
       suggested_action: `Add a unit or integration test file named ${base}.test.ts that covers the public surface of ${rel}.`,
       scanner: 'missing-tests-scanner-v1',
+      raw: { file_loc: lines.length },
+    });
+  }
+  return signals;
+}
+
+/**
+ * True when a file's only top-level statements are imports, `export …`
+ * re-exports, or pure type/interface declarations — nothing that produces
+ * runtime behaviour worth unit-testing. Runs line-by-line rather than with
+ * a full AST so we stay zero-dep.
+ */
+function isPureExportModule(lines) {
+  let inBlockComment = false;
+  let braceDepth = 0;
+  let sawExecutable = false;
+  for (let raw of lines) {
+    let line = raw;
+    if (inBlockComment) {
+      const end = line.indexOf('*/');
+      if (end < 0) continue;
+      line = line.slice(end + 2);
+      inBlockComment = false;
+    }
+    // Strip trailing line comments and inline block comments.
+    line = line.replace(/\/\*[\s\S]*?\*\//g, '');
+    const blockStart = line.indexOf('/*');
+    if (blockStart >= 0 && line.indexOf('*/', blockStart) < 0) {
+      line = line.slice(0, blockStart);
+      inBlockComment = true;
+    }
+    line = line.replace(/\/\/.*$/, '').trim();
+    if (!line) continue;
+    // Track brace depth so bodies of type/interface blocks don't trip us.
+    if (braceDepth > 0) {
+      braceDepth += (line.match(/\{/g) || []).length;
+      braceDepth -= (line.match(/\}/g) || []).length;
+      if (braceDepth < 0) braceDepth = 0;
+      continue;
+    }
+    if (/^import\s/.test(line)) continue;
+    if (/^export\s+\*(\s|$)/.test(line)) continue;
+    if (/^export\s+\{/.test(line)) continue;
+    if (/^export\s+type\b/.test(line)) {
+      braceDepth += (line.match(/\{/g) || []).length;
+      braceDepth -= (line.match(/\}/g) || []).length;
+      if (braceDepth < 0) braceDepth = 0;
+      continue;
+    }
+    if (/^export\s+interface\b/.test(line) || /^export\s+enum\b/.test(line)) {
+      braceDepth += (line.match(/\{/g) || []).length;
+      braceDepth -= (line.match(/\}/g) || []).length;
+      if (braceDepth < 0) braceDepth = 0;
+      continue;
+    }
+    // Anything else (function, class, const expression, top-level call) counts
+    // as executable — unit tests could plausibly cover it.
+    sawExecutable = true;
+    break;
+  }
+  return !sawExecutable;
+}
+
+// =============================================================================
+// Scanner: safety_gap
+// =============================================================================
+
+/**
+ * Infrastructure-class test gaps — routes without integration coverage,
+ * migrations without RLS assertions, governance toggles without tests.
+ * These have bitten production more often than line-coverage gaps, so
+ * they emit at medium severity and higher impact.
+ *
+ * Each item is a static inventory entry; we check the repo state once
+ * per scan and emit a finding when the expected guard file is absent.
+ * Adding a new gap here is cheap and doesn't need LLM help.
+ */
+function scanSafetyGaps() {
+  const signals = [];
+  const gaps = [
+    {
+      key: 'approvals-integration',
+      title: 'Approvals route integration test missing',
+      source_file: 'services/gateway/src/routes/approvals.ts',
+      test_file: 'services/gateway/test/approvals.test.ts',
+      description: 'Integration test covering /api/v1/approvals auth + happy path + rejection path.',
+    },
+    {
+      key: 'autopilot-integration',
+      title: 'Autopilot route integration test missing',
+      source_file: 'services/gateway/src/routes/autopilot.ts',
+      test_file: 'services/gateway/test/autopilot.test.ts',
+      description: 'Integration test covering /api/v1/autopilot list + auto-approve gating.',
+    },
+    {
+      key: 'route-guard',
+      title: 'Route-guard startup test missing',
+      source_file: 'services/gateway/src/index.ts',
+      test_file: 'services/gateway/test/route-guard.test.ts',
+      description: 'Startup test that asserts no duplicate route registrations across the gateway.',
+    },
+    {
+      key: 'admin-auth-coverage',
+      title: 'Admin route auth-middleware coverage missing',
+      source_file: 'services/gateway/src/routes/admin',
+      test_file: 'services/gateway/test/admin-auth.test.ts',
+      description: 'Test that every handler under routes/admin/ + routes/tenant-admin/ rejects non-admin sessions.',
+    },
+    {
+      key: 'schema-vs-migrations',
+      title: 'Schema-vs-migrations validator missing',
+      source_file: 'services/gateway/src',
+      test_file: 'services/gateway/test/schema-vs-migrations.test.ts',
+      description: 'Test that greps every from(...).select(...) in the gateway and asserts every column exists in the latest supabase/migrations SQL.',
+    },
+    {
+      key: 'rls-write-guard',
+      title: 'RLS-write-deny assertion test missing',
+      source_file: 'supabase/migrations',
+      test_file: 'services/gateway/test/rls-write-deny.test.ts',
+      description: 'Test that hits each write-target table with the anon key and asserts RLS rejects the write.',
+    },
+    {
+      key: 'oasis-event-emission',
+      title: 'OASIS event emission contract test missing',
+      source_file: 'services/gateway/src/routes',
+      test_file: 'services/gateway/test/oasis-emission.test.ts',
+      description: 'Contract test: every state-mutating route handler emits a documented OASIS event from services/gateway/src/types/cicd.ts.',
+    },
+    {
+      key: 'governance-gates',
+      title: 'Governance kill-switch test missing',
+      source_file: 'services/gateway/src/services',
+      test_file: 'services/gateway/test/governance-gates.test.ts',
+      description: 'Test that EXECUTION_DISARMED and AUTOPILOT_LOOP_ENABLED, when flipped, actually block the executor/approve paths.',
+    },
+    {
+      key: 'deploy-smoke',
+      title: 'Post-deploy smoke step missing in EXEC-DEPLOY',
+      source_file: '.github/workflows/EXEC-DEPLOY.yml',
+      test_file: '.github/workflows/EXEC-DEPLOY.yml',
+      description: 'EXEC-DEPLOY should curl /alive and /api/v1/vtid/list post-deploy and hard-fail on non-JSON 200.',
+    },
+    {
+      key: 'e2e-playwright-autopilot',
+      title: 'Playwright smoke for task/approval/execution missing',
+      source_file: 'e2e/command-hub/roles/developer',
+      test_file: 'e2e/command-hub/roles/developer/autopilot-flow.spec.ts',
+      description: 'e2e spec that creates a task, approves a finding, and watches one execution through to merge.',
+    },
+  ];
+
+  for (const gap of gaps) {
+    const rel = gap.test_file;
+    const abs = path.join(REPO_ROOT, rel);
+    // Only emit when the expected guard file is absent. Stale-coverage
+    // detection is a follow-up — start simple, catch the binary gap.
+    if (fs.existsSync(abs)) continue;
+    signals.push({
+      type: 'safety_gap',
+      severity: 'medium',
+      file_path: gap.source_file,
+      line_number: 1,
+      message: gap.title,
+      suggested_action: `Add ${rel}. ${gap.description}`,
+      scanner: 'safety-gap-scanner-v1',
+      raw: { gap_key: gap.key, expected_test_file: rel },
     });
   }
   return signals;
@@ -211,9 +398,10 @@ async function main() {
   const todos = scanTodos(allFiles);
   const largeFiles = scanLargeFiles(allFiles);
   const missingTests = scanMissingTests(allFiles);
-  const signals = [...todos, ...largeFiles, ...missingTests];
+  const safetyGaps = scanSafetyGaps();
+  const signals = [...todos, ...largeFiles, ...missingTests, ...safetyGaps];
 
-  console.log(`[dev-autopilot-scan] signals: todo=${todos.length} large_file=${largeFiles.length} missing_tests=${missingTests.length} total=${signals.length}`);
+  console.log(`[dev-autopilot-scan] signals: todo=${todos.length} large_file=${largeFiles.length} missing_tests=${missingTests.length} safety_gap=${safetyGaps.length} total=${signals.length}`);
 
   // Persist signals.json next to the script so the workflow can attach it
   // as an artifact if needed.

--- a/services/autopilot-worker/src/index.ts
+++ b/services/autopilot-worker/src/index.ts
@@ -95,6 +95,26 @@ function log(msg: string, ...rest: unknown[]): void {
   console.log(`${ts} ${LOG_PREFIX} ${msg}`, ...rest);
 }
 
+/**
+ * A single validation failure, captured per attempt in the validation retry
+ * loop. The gateway's prompt-gap feedback loop (C4 in the autopilot-tripart
+ * plan) turns these into rows in dev_autopilot_prompt_learnings so future
+ * plan/execute prompts can include a "lessons from prior attempts" block.
+ *
+ * pattern_key is a short, normalized signature that groups similar failures:
+ *   - tsc: extract the first `TSxxxx` code + a slug of the short-form
+ *     message, e.g. "TS2307:cannot-find-module".
+ *   - jest: the first failing test's message, slugged.
+ *   - parse/apply: bucket by the kind of parse failure, e.g.
+ *     "parse:missing-PR_TITLE".
+ */
+interface AttemptFailure {
+  attempt: number;
+  stage: 'parse' | 'apply' | 'tsc' | 'jest';
+  pattern_key: string;
+  example_message: string;
+}
+
 interface ValidatedExecuteResult {
   ok: boolean;
   text?: string;
@@ -107,6 +127,43 @@ interface ValidatedExecuteResult {
   error?: string;
   attempts: number;
   validation_elapsed_ms: number;
+  /** Per-attempt failure signatures — included on both success (when some
+   * attempts failed before one passed) and failure. The gateway upserts
+   * these into dev_autopilot_prompt_learnings. */
+  attempt_failures?: AttemptFailure[];
+}
+
+function slug(msg: string): string {
+  return msg
+    .toLowerCase()
+    .replace(/["'`]/g, '')
+    .replace(/[^a-z0-9]+/g, '-')
+    .replace(/^-+|-+$/g, '')
+    .slice(0, 60);
+}
+
+/**
+ * Derive a normalized pattern_key from a tsc error. Typical error:
+ *   "services/gateway/src/routes/foo.test.ts(12,3): error TS2307: Cannot find module '../bar'"
+ * Output:
+ *   "TS2307:cannot-find-module"
+ */
+function tscPatternKey(msg: string): string {
+  const codeM = msg.match(/TS(\d+)/);
+  const code = codeM ? `TS${codeM[1]}` : 'TS';
+  // Short-form of the human message — take the tail after `: error TSxxxx:`.
+  const tail = msg.split(/error\s+TS\d+:\s*/).pop() || msg;
+  return `${code}:${slug(tail) || 'unknown'}`;
+}
+
+function jestPatternKey(msg: string): string {
+  // jest failure messages are long — keep the first clause only.
+  const firstLine = msg.split('\n').map(l => l.trim()).filter(Boolean)[0] || msg;
+  return `jest:${slug(firstLine) || 'failure'}`;
+}
+
+function parsePatternKey(msg: string): string {
+  return `parse:${slug(msg) || 'unknown'}`;
 }
 
 /**
@@ -130,6 +187,7 @@ async function runExecuteWithValidation(
   let lastOutput: string | undefined;
   let lastError = 'no attempts ran';
   let validationElapsedTotal = 0;
+  const attemptFailures: AttemptFailure[] = [];
 
   // Reset the clone once up front so we start from a known clean state.
   const fr = await fetchAndReset(VALIDATION_BASE_BRANCH);
@@ -164,6 +222,12 @@ async function runExecuteWithValidation(
     if ('error' in parsed) {
       lastError = `parse: ${parsed.error}`;
       log(`  attempt ${attempt + 1} parse failed: ${parsed.error}`);
+      attemptFailures.push({
+        attempt: attempt + 1,
+        stage: 'parse',
+        pattern_key: parsePatternKey(parsed.error),
+        example_message: parsed.error.slice(0, 500),
+      });
       currentPrompt = buildRetryPrompt(basePrompt, claudeResult.text, [parsed.error], attempt);
       continue;
     }
@@ -174,6 +238,12 @@ async function runExecuteWithValidation(
     if (!applied.ok || !applied.paths) {
       lastError = `apply: ${applied.error}`;
       log(`  attempt ${attempt + 1} apply failed: ${applied.error}`);
+      attemptFailures.push({
+        attempt: attempt + 1,
+        stage: 'apply',
+        pattern_key: `apply:${slug(applied.error || 'failed') || 'failed'}`,
+        example_message: (applied.error || 'apply failed').slice(0, 500),
+      });
       currentPrompt = buildRetryPrompt(basePrompt, claudeResult.text, [applied.error || 'apply failed'], attempt);
       continue;
     }
@@ -185,6 +255,13 @@ async function runExecuteWithValidation(
       const errCount = (tsc.relevantErrors || []).length;
       lastError = tsc.error || `${errCount} tsc error(s) in changed files`;
       log(`  attempt ${attempt + 1} FAILED tsc in ${Math.round(tsc.elapsedMs / 1000)}s — ${errCount} relevant error(s)`);
+      const first = (tsc.relevantErrors && tsc.relevantErrors[0]) || tsc.error || 'tsc failed';
+      attemptFailures.push({
+        attempt: attempt + 1,
+        stage: 'tsc',
+        pattern_key: tscPatternKey(first),
+        example_message: first.slice(0, 500),
+      });
       currentPrompt = buildRetryPrompt(
         basePrompt,
         claudeResult.text,
@@ -214,6 +291,7 @@ async function runExecuteWithValidation(
         usage: claudeResult.usage,
         attempts: attempt + 1,
         validation_elapsed_ms: validationElapsedTotal,
+        attempt_failures: attemptFailures.length > 0 ? attemptFailures : undefined,
       };
     }
 
@@ -232,12 +310,20 @@ async function runExecuteWithValidation(
         usage: claudeResult.usage,
         attempts: attempt + 1,
         validation_elapsed_ms: validationElapsedTotal,
+        attempt_failures: attemptFailures.length > 0 ? attemptFailures : undefined,
       };
     }
 
     const failCount = (jest.failures || []).length;
     lastError = jest.error || `${jest.testsFailed}/${jest.testsRun} jest test(s) failed`;
     log(`  attempt ${attempt + 1} FAILED jest in ${Math.round(jest.elapsedMs / 1000)}s — ${failCount} failure(s) (${jest.testsPassed}/${jest.testsRun} passed)`);
+    const firstJest = (jest.failures && jest.failures[0]) || jest.error || 'jest failed';
+    attemptFailures.push({
+      attempt: attempt + 1,
+      stage: 'jest',
+      pattern_key: jestPatternKey(firstJest),
+      example_message: firstJest.slice(0, 500),
+    });
     // Feed the jest failures back to Claude — labeling them so it knows
     // these are runtime assertion errors, not type errors.
     const jestErrorBlock = jest.failures && jest.failures.length > 0
@@ -256,6 +342,7 @@ async function runExecuteWithValidation(
     attempts: VALIDATION_MAX_ATTEMPTS,
     error: `validation exhausted ${VALIDATION_MAX_ATTEMPTS} attempts: ${lastError}`,
     validation_elapsed_ms: validationElapsedTotal,
+    attempt_failures: attemptFailures.length > 0 ? attemptFailures : undefined,
   };
 }
 
@@ -349,7 +436,13 @@ async function handleTask(wid: string): Promise<void> {
 
     if (!result.ok || !result.text) {
       log(`  task ${row.id.slice(0, 8)} failed after ${elapsed}s (${result.attempts} attempt${result.attempts === 1 ? '' : 's'}): ${result.error}`);
-      await failTask(row.id, result.error || 'claude returned no text');
+      await failTask(row.id, result.error || 'claude returned no text', {
+        worker_id: wid,
+        attempts: result.attempts,
+        validated: shouldValidate,
+        validation_elapsed_ms: result.validation_elapsed_ms,
+        attempt_failures: result.attempt_failures,
+      });
       return;
     }
 
@@ -371,7 +464,13 @@ async function handleTask(wid: string): Promise<void> {
       const pub = await publishToGitHub(result.files, result.pr_title, result.pr_body, branch, baseBranch, vtidLike);
       if (!pub.ok) {
         log(`  PR publish FAILED for ${row.id.slice(0, 8)}: ${pub.error}`);
-        await failTask(row.id, `publish PR: ${pub.error}`);
+        await failTask(row.id, `publish PR: ${pub.error}`, {
+          worker_id: wid,
+          attempts: result.attempts,
+          validated: shouldValidate,
+          validation_elapsed_ms: result.validation_elapsed_ms,
+          attempt_failures: result.attempt_failures,
+        });
         return;
       }
       log(`  PR opened: ${pub.pr_url}`);
@@ -383,6 +482,7 @@ async function handleTask(wid: string): Promise<void> {
           attempts: result.attempts,
           validated: shouldValidate,
           validation_elapsed_ms: result.validation_elapsed_ms,
+          attempt_failures: result.attempt_failures,
           // Fields the gateway watches for to advance execution row → 'ci'
           worker_owns_pr: true,
           pr_url: pub.pr_url,
@@ -401,6 +501,7 @@ async function handleTask(wid: string): Promise<void> {
         attempts: result.attempts,
         validated: shouldValidate,
         validation_elapsed_ms: result.validation_elapsed_ms,
+        attempt_failures: result.attempt_failures,
       },
     });
   } catch (err) {

--- a/services/autopilot-worker/src/queue.ts
+++ b/services/autopilot-worker/src/queue.ts
@@ -132,17 +132,26 @@ export async function completeTask(
   return { ok: r.ok, error: r.error };
 }
 
-export async function failTask(rowId: string, error: string): Promise<{ ok: boolean; error?: string }> {
+export async function failTask(
+  rowId: string,
+  error: string,
+  extra?: Record<string, unknown>,
+): Promise<{ ok: boolean; error?: string }> {
+  // Even on failure, write diagnostic context (attempt_failures, worker_id,
+  // etc.) into output_payload so the gateway's prompt-gap feedback loop
+  // can pick up the pattern. error_message stays the primary failure
+  // signal the watcher/bridge reads.
+  const body: Record<string, unknown> = {
+    status: 'failed',
+    error_message: error.slice(0, 4000),
+    completed_at: new Date().toISOString(),
+  };
+  if (extra && Object.keys(extra).length > 0) {
+    body.output_payload = extra;
+  }
   const r = await supa(
     `/rest/v1/dev_autopilot_worker_queue?id=eq.${rowId}`,
-    {
-      method: 'PATCH',
-      body: JSON.stringify({
-        status: 'failed',
-        error_message: error.slice(0, 4000),
-        completed_at: new Date().toISOString(),
-      }),
-    },
+    { method: 'PATCH', body: JSON.stringify(body) },
   );
   return { ok: r.ok, error: r.error };
 }

--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -37,7 +37,7 @@ import {
   SafetyDecision,
 } from './dev-autopilot-safety';
 import { extractFilePaths } from './dev-autopilot-planning';
-import { isWorkerQueueEnabled, isWorkerOwnsPrEnabled, runWorkerTask, reclaimStuckWorkerTasks } from './dev-autopilot-worker-queue';
+import { isWorkerQueueEnabled, isWorkerOwnsPrEnabled, runWorkerTask, reclaimStuckWorkerTasks, type WorkerAttemptFailure } from './dev-autopilot-worker-queue';
 
 const LOG_PREFIX = '[dev-autopilot-execute]';
 const EXEC_VTID = 'VTID-DEV-AUTOPILOT';
@@ -160,12 +160,100 @@ interface ConfigRow {
   max_auto_fix_depth: number;
   allow_scope: string[];
   deny_scope: string[];
+  // Auto-approve gate (defaults to disabled — opt-in per environment).
+  auto_approve_enabled?: boolean;
+  auto_approve_max_effort?: number;
+  auto_approve_risk_classes?: string[];
+  auto_approve_scanners?: string[];
 }
 
 async function loadConfig(s: SupaConfig): Promise<ConfigRow | null> {
   const r = await supa<ConfigRow[]>(s, `/rest/v1/dev_autopilot_config?id=eq.1&limit=1`);
   if (!r.ok || !r.data || r.data.length === 0) return null;
   return r.data[0];
+}
+
+/**
+ * Upsert worker validation failures into dev_autopilot_prompt_learnings.
+ * Scoped by the finding's scanner so retrieval can target lessons from the
+ * same scanner class (e.g. only pull missing-tests lessons for missing-tests
+ * findings).
+ *
+ * The scanner is looked up once from the finding's spec_snapshot. A null
+ * scanner is allowed (legacy rows without a scanner field still write, just
+ * with scanner IS NULL) — the ON CONFLICT index treats (pattern_type,
+ * pattern_key, NULL) as a distinct bucket.
+ */
+async function persistAttemptFailures(
+  s: SupaConfig,
+  failures: WorkerAttemptFailure[],
+  ctx: { finding_id: string; execution_id?: string },
+): Promise<void> {
+  // Look up the finding's scanner once.
+  const findingR = await supa<Array<{ spec_snapshot: { scanner?: string } | null }>>(
+    s,
+    `/rest/v1/autopilot_recommendations?id=eq.${ctx.finding_id}&select=spec_snapshot&limit=1`,
+  );
+  const scanner: string | null = findingR.ok && findingR.data && findingR.data[0]?.spec_snapshot?.scanner
+    ? String(findingR.data[0].spec_snapshot.scanner)
+    : null;
+
+  const now = new Date().toISOString();
+  for (const f of failures) {
+    const pattern_type = f.stage === 'tsc'
+      ? 'tsc_error'
+      : f.stage === 'jest'
+        ? 'jest_failure'
+        : f.stage === 'parse' || f.stage === 'apply'
+          ? 'parse_error'
+          : 'validation_other';
+    const body = {
+      pattern_type,
+      pattern_key: f.pattern_key.slice(0, 200),
+      example_message: (f.example_message || '').slice(0, 500),
+      scanner,
+      finding_id: ctx.finding_id,
+      execution_id: ctx.execution_id || null,
+      last_seen_at: now,
+    };
+    // PostgREST upsert: merge-duplicates against the UNIQUE
+    // (pattern_type, pattern_key, scanner) index. frequency stays at the
+    // default (1) on conflict; the aggregator counts by rows, not by the
+    // column, so an undercount of duplicates is acceptable.
+    await supa(s,
+      `/rest/v1/dev_autopilot_prompt_learnings?on_conflict=pattern_type,pattern_key,scanner`,
+      {
+        method: 'POST',
+        headers: { Prefer: 'resolution=merge-duplicates,return=minimal' },
+        body: JSON.stringify(body),
+      },
+    );
+  }
+}
+
+/**
+ * Load up to 5 recent validation lessons for a scanner. Used by the
+ * execution prompt builder so Claude's output avoids repeating known
+ * traps. Best-effort — returns [] on any DB issue so execute flow never
+ * blocks on this.
+ */
+async function loadExecutionLessons(
+  s: SupaConfig,
+  scanner: string,
+): Promise<ExecutionLesson[]> {
+  const since = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString();
+  try {
+    const r = await supa<ExecutionLesson[]>(
+      s,
+      `/rest/v1/dev_autopilot_prompt_learnings?scanner=eq.${encodeURIComponent(scanner)}`
+      + `&last_seen_at=gte.${since}`
+      + `&order=last_seen_at.desc&limit=5`
+      + `&select=pattern_type,pattern_key,example_message,mitigation_note`,
+    );
+    return r.ok && Array.isArray(r.data) ? r.data : [];
+  } catch {
+    return [];
+  }
 }
 
 async function countApprovedToday(s: SupaConfig): Promise<number> {
@@ -543,12 +631,20 @@ const parseExecutionJson = parseExecutionOutput;
 
 interface FileCtx { path: string; exists: boolean; content?: string; sha?: string }
 
+interface ExecutionLesson {
+  pattern_type: string;
+  pattern_key: string;
+  example_message: string;
+  mitigation_note: string | null;
+}
+
 function buildExecutionPrompt(
   findingId: string,
   planVersion: number,
   planMarkdown: string,
   fileCtx: FileCtx[],
   branch: string,
+  lessons?: ExecutionLesson[],
 ): string {
   const lines: string[] = [];
   lines.push(
@@ -564,6 +660,28 @@ function buildExecutionPrompt(
     planMarkdown.slice(0, 60_000),
     ``,
   );
+  // Inject recent validation-failure patterns scoped to the same scanner so
+  // Claude's output avoids repeating known traps (wrong import paths,
+  // jest shape mistakes, parse errors). Best-effort — missing lessons are
+  // a no-op, the base prompt is unchanged.
+  if (lessons && lessons.length > 0) {
+    lines.push(
+      `## Lessons from prior attempts`,
+      ``,
+      `These validation failures occurred on similar recent plans. Do NOT`,
+      `repeat them:`,
+      ``,
+    );
+    for (const l of lessons) {
+      const header = l.mitigation_note && l.mitigation_note.trim().length > 0
+        ? l.mitigation_note.trim()
+        : `${l.pattern_type}: ${l.pattern_key}`;
+      lines.push(`- **${header}**`);
+      const example = (l.example_message || '').trim().split('\n')[0].slice(0, 240);
+      if (example) lines.push(`  Example: ${example}`);
+    }
+    lines.push(``);
+  }
   if (fileCtx.length > 0) {
     lines.push(
       `## Current state of each file the plan touches`,
@@ -740,6 +858,18 @@ async function runExecutionSession(
     fileCtx.push({ path: p, exists: got.exists, content: got.content, sha: got.sha });
   }
 
+  // Pull prior-attempt lessons for the finding's scanner so Claude avoids
+  // repeating known traps. Best-effort — no rows / failed query just skips
+  // the optional prompt section.
+  const findingMetaR = await supa<Array<{ spec_snapshot: { scanner?: string } | null }>>(
+    s,
+    `/rest/v1/autopilot_recommendations?id=eq.${exec.finding_id}&select=spec_snapshot&limit=1`,
+  );
+  const findingScanner: string | null = findingMetaR.ok && findingMetaR.data && findingMetaR.data[0]?.spec_snapshot?.scanner
+    ? String(findingMetaR.data[0].spec_snapshot.scanner)
+    : null;
+  const lessons = findingScanner ? await loadExecutionLessons(s, findingScanner) : [];
+
   // 2. Ask Claude to produce the new file contents. Routes through the
   // worker queue when DEV_AUTOPILOT_USE_WORKER=true (Claude subscription);
   // otherwise hits the Messages API directly (pay-per-token).
@@ -750,12 +880,12 @@ async function runExecutionSession(
   // sequence in a single long-lived process, sidestepping the Cloud Run
   // recycle-mid-flight problem that kept stranding executions.
   const ownsPr = isWorkerQueueEnabled() && isWorkerOwnsPrEnabled();
-  const prompt = buildExecutionPrompt(exec.finding_id, exec.plan_version, plan.plan_markdown, fileCtx, branch);
+  const prompt = buildExecutionPrompt(exec.finding_id, exec.plan_version, plan.plan_markdown, fileCtx, branch, lessons);
   const startedAt = Date.now();
   // Widen the inline type so both call shapes satisfy the union we destructure
   // below (worker-queue path may carry pr_url/pr_number/branch from the
   // worker-owned-PR mode; direct Messages API never does).
-  const llm: { ok: boolean; text?: string; usage?: { input_tokens?: number; output_tokens?: number }; error?: string; pr_url?: string; pr_number?: number; branch?: string } =
+  const llm: { ok: boolean; text?: string; usage?: { input_tokens?: number; output_tokens?: number }; error?: string; pr_url?: string; pr_number?: number; branch?: string; attempt_failures?: WorkerAttemptFailure[] } =
     isWorkerQueueEnabled()
       ? await runWorkerTask(
           {
@@ -775,6 +905,20 @@ async function runExecutionSession(
         )
       : await callMessagesApi(prompt);
   const elapsed = Math.round((Date.now() - startedAt) / 1000);
+
+  // Prompt-gap feedback loop: the worker reports per-attempt validation
+  // failures via output_payload.attempt_failures. Upsert each into
+  // dev_autopilot_prompt_learnings so future plan/execute prompts can
+  // reference them. Best-effort — a learnings-persist failure must not
+  // block the execution outcome. Runs even on LLM failure so we capture
+  // exhausted-validation cases too.
+  if (llm.attempt_failures && llm.attempt_failures.length > 0) {
+    await persistAttemptFailures(s, llm.attempt_failures, {
+      finding_id: exec.finding_id,
+      execution_id: executionId,
+    }).catch(err => console.error(`${LOG_PREFIX} persist learnings error:`, err));
+  }
+
   if (!llm.ok || !llm.text) {
     return { ok: false, error: `LLM call failed after ${elapsed}s: ${llm.error || 'unknown'}`, session_id: sessionId, branch };
   }
@@ -1045,6 +1189,123 @@ export async function backgroundExecutorTick(): Promise<void> {
   }
 }
 
+/**
+ * Auto-approve tick — picks eligible `status='new'` findings and calls
+ * approveAutoExecute on their behalf. Runs alongside backgroundExecutorTick.
+ *
+ * Eligibility is gated by dev_autopilot_config:
+ *   - auto_approve_enabled must be true (default false, opt-in per env).
+ *   - kill_switch must be false (same gate as manual approval).
+ *   - finding's risk_class must be in auto_approve_risk_classes.
+ *   - finding's effort_score must be <= auto_approve_max_effort.
+ *   - finding's scanner must be in auto_approve_scanners.
+ *   - A plan version must already exist (approveAutoExecute enforces this
+ *     too; we filter here to avoid calling approveAutoExecute on findings
+ *     that would just error).
+ *
+ * Budget / concurrency caps are respected up-front so we don't burn through
+ * the daily budget in a single burst. The per-tick cap (5) is deliberate:
+ * it prevents a backlog flush if auto-approve is freshly enabled.
+ *
+ * The safety gate (evaluateSafetyGate inside approveAutoExecute) still runs
+ * on every finding — this function only automates the "click Approve" step.
+ */
+export async function autoApproveTick(): Promise<void> {
+  const s = getSupabase();
+  if (!s) return;
+
+  const cfg = await loadConfig(s);
+  if (!cfg) return;
+  if (cfg.kill_switch) return;
+  if (!cfg.auto_approve_enabled) return;
+
+  const riskClasses = (cfg.auto_approve_risk_classes && cfg.auto_approve_risk_classes.length > 0)
+    ? cfg.auto_approve_risk_classes
+    : ['low', 'medium'];
+  const scanners = (cfg.auto_approve_scanners && cfg.auto_approve_scanners.length > 0)
+    ? cfg.auto_approve_scanners
+    : [];
+  if (scanners.length === 0) return; // no scanner opted-in — nothing to pick
+  const maxEffort = cfg.auto_approve_max_effort ?? 5;
+
+  const approvedToday = await countApprovedToday(s);
+  const running = await countRunningExecutions(s);
+  const budgetSlots = Math.max(0, cfg.daily_budget - approvedToday);
+  const concurrencySlots = Math.max(0, cfg.concurrency_cap - running);
+  // Cap per-tick to avoid bursts when auto-approve is flipped on after a
+  // backlog has accumulated.
+  const PER_TICK_CAP = 5;
+  const slots = Math.min(budgetSlots, concurrencySlots, PER_TICK_CAP);
+  if (slots === 0) return;
+
+  // PostgREST in.(...) expects comma-separated values; quote strings for
+  // safety. scanners/riskClasses come from the config row (operator-controlled),
+  // but still encode to avoid breaking on stray punctuation.
+  const riskList = riskClasses.map(r => `"${encodeURIComponent(r)}"`).join(',');
+  const scannerList = scanners.map(r => `"${encodeURIComponent(r)}"`).join(',');
+  const findingsR = await supa<Array<{
+    id: string;
+    risk_class: 'low' | 'medium' | 'high' | null;
+    effort_score: number | null;
+    impact_score: number | null;
+    spec_snapshot: { scanner?: string } | null;
+  }>>(
+    s,
+    `/rest/v1/autopilot_recommendations?source_type=eq.dev_autopilot&status=eq.new`
+      + `&risk_class=in.(${riskList})`
+      + `&effort_score=lte.${maxEffort}`
+      + `&spec_snapshot->>scanner=in.(${scannerList})`
+      + `&order=impact_score.desc.nullslast,created_at.asc&limit=${slots * 2}`
+      + `&select=id,risk_class,effort_score,impact_score,spec_snapshot`,
+  );
+  if (!findingsR.ok || !findingsR.data || findingsR.data.length === 0) return;
+
+  let approved = 0;
+  for (const f of findingsR.data) {
+    if (approved >= slots) break;
+
+    // Only approve findings that already have a plan. approveAutoExecute
+    // will error otherwise; short-circuit with a cheap HEAD-style lookup.
+    const planR = await supa<Array<{ version: number }>>(
+      s,
+      `/rest/v1/dev_autopilot_plan_versions?finding_id=eq.${f.id}&select=version&order=version.desc&limit=1`,
+    );
+    if (!planR.ok || !planR.data || planR.data.length === 0) continue;
+
+    const result = await approveAutoExecute({ finding_id: f.id, approved_by: 'auto' });
+    if (!result.ok || !result.execution) {
+      // A safety-gate rejection here is EXPECTED for findings that cite
+      // files outside allow_scope — just log and move on. The operator
+      // will still see those findings in the queue with status='new'.
+      console.log(`${LOG_PREFIX} auto-approve skipped ${f.id.slice(0, 8)}: ${result.error || 'safety gate'}`);
+      continue;
+    }
+
+    approved++;
+    await emitOasisEvent({
+      vtid: EXEC_VTID,
+      type: 'dev_autopilot.execution.auto_approved',
+      source: 'dev-autopilot',
+      status: 'info',
+      message: `Auto-approved execution ${result.execution.id.slice(0, 8)} for finding ${f.id.slice(0, 8)}`,
+      payload: {
+        finding_id: f.id,
+        execution_id: result.execution.id,
+        trigger: {
+          risk_class: f.risk_class,
+          effort_score: f.effort_score,
+          impact_score: f.impact_score,
+          scanner: f.spec_snapshot?.scanner ?? null,
+        },
+      },
+    });
+  }
+
+  if (approved > 0) {
+    console.log(`${LOG_PREFIX} auto-approved ${approved} finding(s) this tick`);
+  }
+}
+
 let backgroundTickerStarted = false;
 export function startBackgroundExecutor(): void {
   if (backgroundTickerStarted) return;
@@ -1053,6 +1314,9 @@ export function startBackgroundExecutor(): void {
   setInterval(() => {
     backgroundExecutorTick().catch((err) => {
       console.error(`${LOG_PREFIX} tick error:`, err);
+    });
+    autoApproveTick().catch((err) => {
+      console.error(`${LOG_PREFIX} auto-approve tick error:`, err);
     });
   }, BACKGROUND_TICK_MS);
 }

--- a/services/gateway/src/services/dev-autopilot-planning.ts
+++ b/services/gateway/src/services/dev-autopilot-planning.ts
@@ -279,6 +279,67 @@ async function supaRequest<T>(
 }
 
 // =============================================================================
+// Prompt-gap feedback — pull recent validation failures for the same scanner
+// so plan prompts can warn Claude off known traps.
+// =============================================================================
+
+export interface PromptLesson {
+  pattern_type: string;
+  pattern_key: string;
+  example_message: string;
+  mitigation_note: string | null;
+  last_seen_at: string;
+}
+
+/**
+ * Load up to `limit` recent validation failures for a given scanner. Best-
+ * effort — a DB hiccup here must not block plan generation, so we swallow
+ * errors and return an empty list.
+ */
+export async function loadRecentLessons(
+  supa: SupaConfig,
+  scanner: string | null | undefined,
+  limit = 5,
+): Promise<PromptLesson[]> {
+  if (!scanner) return [];
+  const since = new Date(Date.now() - 14 * 24 * 60 * 60 * 1000).toISOString();
+  try {
+    const r = await supaRequest<PromptLesson[]>(
+      supa,
+      `/rest/v1/dev_autopilot_prompt_learnings?scanner=eq.${encodeURIComponent(scanner)}`
+      + `&last_seen_at=gte.${since}`
+      + `&order=last_seen_at.desc&limit=${limit}`
+      + `&select=pattern_type,pattern_key,example_message,mitigation_note,last_seen_at`,
+    );
+    return r.ok && Array.isArray(r.data) ? r.data : [];
+  } catch {
+    return [];
+  }
+}
+
+function formatLessonsBlock(lessons: PromptLesson[]): string {
+  if (!lessons || lessons.length === 0) return '';
+  const lines: string[] = [
+    ``,
+    `## Lessons from prior attempts on findings from this scanner`,
+    ``,
+    `These validation failures have surfaced recently on similar findings.`,
+    `Avoid repeating them in this plan.`,
+    ``,
+  ];
+  for (const l of lessons) {
+    const header = l.mitigation_note && l.mitigation_note.trim().length > 0
+      ? l.mitigation_note.trim()
+      : `${l.pattern_type}: ${l.pattern_key}`;
+    lines.push(`- **${header}**`);
+    const example = (l.example_message || '').trim().split('\n')[0].slice(0, 240);
+    if (example) lines.push(`  Example: ${example}`);
+  }
+  lines.push(``);
+  return lines.join('\n');
+}
+
+// =============================================================================
 // Prompt builder
 // =============================================================================
 
@@ -287,6 +348,7 @@ export function buildPlanningPrompt(
   previousPlan?: string,
   feedbackNote?: string,
   scope?: { allow?: string[]; deny?: string[] },
+  lessons?: PromptLesson[],
 ): string {
   const snap = finding.spec_snapshot || {};
   const lines: string[] = [];
@@ -309,6 +371,11 @@ export function buildPlanningPrompt(
     `- **Suggested action:** ${snap.suggested_action || '(none)'}`,
     ``,
   );
+
+  // Prompt-gap feedback loop — inject recent validation failures scoped to
+  // this scanner so Claude doesn't repeat known traps.
+  const lessonsBlock = formatLessonsBlock(lessons || []);
+  if (lessonsBlock) lines.push(lessonsBlock);
 
   if (previousPlan && feedbackNote) {
     lines.push(
@@ -515,6 +582,7 @@ async function runPlanningSession(
   previousPlan: string | undefined,
   feedbackNote: string | undefined,
   scope?: { allow?: string[]; deny?: string[] },
+  supa?: SupaConfig,
 ): Promise<{ ok: boolean; plan_markdown?: string; session_id?: string; error?: string }> {
   const sessionId = `plan_${randomUUID().slice(0, 12)}`;
 
@@ -526,6 +594,12 @@ async function runPlanningSession(
       session_id: sessionId,
     };
   }
+
+  // Pull recent validation lessons for this scanner so Claude can avoid
+  // known traps. Best-effort — never blocks plan generation.
+  const lessons = supa
+    ? await loadRecentLessons(supa, finding.spec_snapshot?.scanner)
+    : [];
 
   const startedAt = Date.now();
   const filePath = finding.spec_snapshot?.file_path;
@@ -554,7 +628,7 @@ async function runPlanningSession(
     fileSection = `\n\n## Referenced file\n\n> No file_path recorded on this finding. Produce the plan from the finding metadata alone.\n`;
   }
 
-  const prompt = buildPlanningPrompt(finding, previousPlan, feedbackNote, scope) + fileSection;
+  const prompt = buildPlanningPrompt(finding, previousPlan, feedbackNote, scope, lessons) + fileSection;
 
   // Route through the local worker queue when enabled, so the LLM call draws
   // on the Claude subscription instead of the pay-per-token API key. Falls
@@ -645,7 +719,7 @@ export async function generatePlanVersion(
   }
 
   // 4. Run the planning session
-  const session = await runPlanningSession(finding, previousPlan, opts.feedback_note, scope);
+  const session = await runPlanningSession(finding, previousPlan, opts.feedback_note, scope, supa);
   if (!session.ok || !session.plan_markdown) {
     await emitOasisEvent({
       vtid: PLAN_VTID,

--- a/services/gateway/src/services/dev-autopilot-synthesis.ts
+++ b/services/gateway/src/services/dev-autopilot-synthesis.ts
@@ -30,7 +30,8 @@ export type SignalType =
   | 'missing_docs'
   | 'circular_dep'
   | 'unused_dep'
-  | 'cognitive_complexity';
+  | 'cognitive_complexity'
+  | 'safety_gap';
 
 export type Severity = 'low' | 'medium' | 'high';
 
@@ -147,6 +148,9 @@ const TYPE_EFFORT: Record<SignalType, number> = {
   duplication: 5,
   cognitive_complexity: 6,
   large_file: 7,
+  // safety_gap items are infra-scoped integration tests — usually
+  // ~half a day of work per gap.
+  safety_gap: 6,
 };
 
 /** Risk class for auto-exec eligibility — dead_code, unused_dep, missing_docs
@@ -162,6 +166,7 @@ const TYPE_RISK_CLASS: Record<SignalType, 'low' | 'medium' | 'high'> = {
   duplication: 'medium',
   cognitive_complexity: 'medium',
   large_file: 'high',
+  safety_gap: 'medium',
 };
 
 function scoreSignal(signal: DevAutopilotSignal): {
@@ -193,6 +198,7 @@ function titleForSignal(signal: DevAutopilotSignal): string {
     case 'missing_docs':  return `Add missing docs for ${base}`;
     case 'circular_dep':  return `Break circular dependency via ${base}`;
     case 'cognitive_complexity': return `Reduce cognitive complexity in ${base}`;
+    case 'safety_gap':    return signal.message.slice(0, 80);
     default:              return signal.message.substring(0, 80);
   }
 }
@@ -329,6 +335,11 @@ export async function ingestScan(input: ScanInput): Promise<ScanResult> {
           line_number: signal.line_number,
           suggested_action: signal.suggested_action,
           scanner: signal.scanner,
+          // Propagate scanner-specific metadata (file_loc for missing_tests,
+          // gap_key/expected_test_file for safety_gap, etc.) into the
+          // snapshot so downstream consumers (bulk-archive SQL, auto-approve
+          // filter) can read them without a separate lookup.
+          ...(signal.raw || {}),
         },
       }),
     });

--- a/services/gateway/src/services/dev-autopilot-worker-queue.ts
+++ b/services/gateway/src/services/dev-autopilot-worker-queue.ts
@@ -79,6 +79,13 @@ export interface WorkerTaskInput {
   vtid_like?: string;
 }
 
+export interface WorkerAttemptFailure {
+  attempt: number;
+  stage: 'parse' | 'apply' | 'tsc' | 'jest';
+  pattern_key: string;
+  example_message: string;
+}
+
 export interface WorkerTaskResult {
   ok: boolean;
   text?: string;
@@ -88,6 +95,11 @@ export interface WorkerTaskResult {
   pr_url?: string;
   pr_number?: number;
   branch?: string;
+  /** Per-attempt validation failures from the worker's retry loop. Populated
+   * on both success (when earlier attempts failed) and final failure. The
+   * prompt-gap feedback loop in dev-autopilot-execute.ts upserts these into
+   * dev_autopilot_prompt_learnings. */
+  attempt_failures?: WorkerAttemptFailure[];
   error?: string;
   queue_row_id?: string;
 }
@@ -161,6 +173,7 @@ export async function waitForWorkerTask(
         pr_number?: number;
         branch?: string;
         worker_owns_pr?: boolean;
+        attempt_failures?: WorkerAttemptFailure[];
       } | null;
       error_message: string | null;
     }>>(
@@ -192,6 +205,7 @@ export async function waitForWorkerTask(
         pr_url: op.pr_url,
         pr_number: op.pr_number,
         branch: op.branch,
+        attempt_failures: op.attempt_failures,
         queue_row_id: rowId,
       };
     }
@@ -199,6 +213,7 @@ export async function waitForWorkerTask(
       return {
         ok: false,
         error: row.error_message || 'worker reported failure with no message',
+        attempt_failures: row.output_payload?.attempt_failures,
         queue_row_id: rowId,
       };
     }

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -582,6 +582,7 @@ export type CicdEventType =
   | 'dev_autopilot.finding.rejected'
   | 'dev_autopilot.finding.snoozed'
   | 'dev_autopilot.execution.approved'
+  | 'dev_autopilot.execution.auto_approved'
   | 'dev_autopilot.execution.cancelled'
   | 'dev_autopilot.execution.running'
   | 'dev_autopilot.execution.pr_opened'

--- a/supabase/migrations/20260423150000_BOOTSTRAP_archive_false_positive_findings.sql
+++ b/supabase/migrations/20260423150000_BOOTSTRAP_archive_false_positive_findings.sql
@@ -1,0 +1,48 @@
+-- =============================================================================
+-- Dev Autopilot — one-shot archive of scanner false-positive findings
+-- =============================================================================
+-- The missing-tests-scanner-v1 ran for months with no quality filters. It
+-- produced ~338 "Add missing tests for X" findings, ~60-80 of which target
+-- files that don't warrant unit tests: types.ts, constants.ts, config.ts,
+-- defaults.ts, registry.ts, barrel index.ts re-exports, and very small
+-- files that are too thin to cover meaningfully.
+--
+-- The scanner was tightened in the same PR as this migration (scripts/ci/
+-- dev-autopilot-scan.mjs). This statement retroactively archives the rows
+-- that the tightened scanner would no longer emit, so operators don't have
+-- to wait for the scanner to re-run before the queue clears.
+--
+-- Safe because:
+--   - Only touches status='new' rows (nothing in execute/merge flight).
+--   - Bounded to source_type='dev_autopilot' with scanner='missing-tests-scanner-v1'.
+--   - Writes the reason into spec_snapshot.archived_reason so the audit
+--     trail survives in the JSONB blob.
+--
+-- Uses the existing 'auto_archived' status value established by the parent
+-- dev_autopilot schema migration (20260416100000).
+-- =============================================================================
+
+UPDATE autopilot_recommendations
+SET
+  status = 'auto_archived',
+  spec_snapshot = jsonb_set(
+    COALESCE(spec_snapshot, '{}'::jsonb),
+    '{archived_reason}',
+    to_jsonb('scanner-false-positive (size/pattern/pure-export filter, 2026-04-23)'::text)
+  ),
+  auto_archive_at = NOW(),
+  updated_at = NOW()
+WHERE source_type = 'dev_autopilot'
+  AND status = 'new'
+  AND spec_snapshot ->> 'scanner' = 'missing-tests-scanner-v1'
+  AND (
+    -- Filename denylist: types/constants/config/defaults/registry/index modules.
+    spec_snapshot ->> 'file_path' ~ '/(types|constants|config|defaults|registry|index)\.ts$'
+    -- Size floor: anything shorter than the new MISSING_TESTS_MIN_LOC default.
+    -- file_loc is written by the updated scanner; older rows won't have it
+    -- and will fall through to the filename filter above.
+    OR (
+      spec_snapshot ? 'file_loc'
+      AND (spec_snapshot ->> 'file_loc')::int < 50
+    )
+  );

--- a/supabase/migrations/20260423150500_BOOTSTRAP_dev_autopilot_auto_approve.sql
+++ b/supabase/migrations/20260423150500_BOOTSTRAP_dev_autopilot_auto_approve.sql
@@ -1,0 +1,27 @@
+-- =============================================================================
+-- Dev Autopilot — auto-approve threshold columns
+-- =============================================================================
+-- The auto-merge pipeline (scan → plan → approve → cool → execute → CI →
+-- merge → deploy) now runs end-to-end, but a human still has to click
+-- Approve on each finding. These columns let operators opt-in to
+-- unattended approval for low-risk, low-effort findings from trusted
+-- scanners, while keeping the default behaviour identical (enabled=false).
+--
+-- The safety gate (evaluateSafetyGate) still runs on every auto-approved
+-- finding — auto_approve only removes the human click, it does not bypass
+-- allow_scope, deny_scope, or the file-count cap.
+--
+-- Rollout plan:
+--   1. Deploy gateway with autoApproveTick() wired in but no-op (enabled=false).
+--   2. Manually flip auto_approve_enabled=true in Supabase Studio.
+--   3. Watch OASIS for dev_autopilot.execution.auto_approved events.
+--   4. If misbehaves, flip back — no code change needed.
+-- =============================================================================
+
+ALTER TABLE public.dev_autopilot_config
+  ADD COLUMN IF NOT EXISTS auto_approve_enabled    BOOLEAN   NOT NULL DEFAULT FALSE,
+  ADD COLUMN IF NOT EXISTS auto_approve_max_effort INTEGER   NOT NULL DEFAULT 5,
+  ADD COLUMN IF NOT EXISTS auto_approve_risk_classes TEXT[]  NOT NULL
+    DEFAULT ARRAY['low','medium']::text[],
+  ADD COLUMN IF NOT EXISTS auto_approve_scanners   TEXT[]    NOT NULL
+    DEFAULT ARRAY['missing-tests-scanner-v1','safety-gap-scanner-v1']::text[];

--- a/supabase/migrations/20260423151000_BOOTSTRAP_dev_autopilot_prompt_learnings.sql
+++ b/supabase/migrations/20260423151000_BOOTSTRAP_dev_autopilot_prompt_learnings.sql
@@ -1,0 +1,60 @@
+-- =============================================================================
+-- Dev Autopilot — prompt-gap feedback loop (learnings table)
+-- =============================================================================
+-- When the worker's pre-PR validation fails (tsc red, jest red, parse
+-- error) we currently throw the signal away once the retry budget is
+-- exhausted. That means future plan/execute prompts keep repeating the
+-- same class of mistake (wrong relative-import depth, picking `tests/`
+-- over `test/`, referencing a module that doesn't exist, etc.).
+--
+-- This table gives us a place to record those failures and, at the next
+-- planning/execution, inject a short "lessons from prior attempts" block
+-- into the prompt so the autopilot can learn from its own mistakes.
+--
+-- Writes happen from services/gateway/src/services/dev-autopilot-execute.ts
+-- after each runWorkerTask() returns. Reads happen from
+-- services/gateway/src/services/dev-autopilot-planning.ts +
+-- dev-autopilot-execute.ts when building the next prompt.
+--
+-- No RLS policies beyond ENABLE — the gateway reads/writes via the
+-- SUPABASE_SERVICE_ROLE key which bypasses RLS anyway.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.dev_autopilot_prompt_learnings (
+  id              UUID        PRIMARY KEY DEFAULT gen_random_uuid(),
+  pattern_type    TEXT        NOT NULL
+    CHECK (pattern_type IN ('tsc_error','jest_failure','parse_error','out_of_scope','validation_other')),
+  -- Normalized signature — shape depends on pattern_type. Examples:
+  --   tsc_error:       'TS2307:cannot-find-module'
+  --   jest_failure:    'jest:expect-toBe-mismatch'
+  --   parse_error:     'parse:missing-PR_TITLE'
+  pattern_key     TEXT        NOT NULL,
+  -- First 500 chars of an actual occurrence, so a human reviewer can
+  -- tell if the auto-derived pattern_key captured the real signal.
+  example_message TEXT        NOT NULL,
+  -- Source finding's scanner, used to scope retrieval (e.g. only pull
+  -- missing-tests-scanner-v1 lessons when planning a missing-tests finding).
+  scanner         TEXT,
+  finding_id      UUID,
+  execution_id    UUID,
+  frequency       INTEGER     NOT NULL DEFAULT 1,
+  -- Human-authored upgrade of the auto-derived pattern_key. When present,
+  -- the prompt injector prefers this over the raw example_message.
+  mitigation_note TEXT,
+  first_seen_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  last_seen_at    TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  UNIQUE (pattern_type, pattern_key, scanner)
+);
+
+CREATE INDEX IF NOT EXISTS idx_dev_autopilot_prompt_learnings_recent
+  ON public.dev_autopilot_prompt_learnings (last_seen_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_dev_autopilot_prompt_learnings_by_scanner
+  ON public.dev_autopilot_prompt_learnings (scanner, last_seen_at DESC)
+  WHERE scanner IS NOT NULL;
+
+ALTER TABLE public.dev_autopilot_prompt_learnings ENABLE ROW LEVEL SECURITY;
+
+-- Service role is the only writer (gateway). No other policies needed —
+-- anon/authenticated roles have zero access by default on an RLS-enabled
+-- table without policies.


### PR DESCRIPTION
## Summary

Three interacting threads landed as one PR (full plan: `/home/dstev/.claude/plans/the-autopilot-identified-that-jazzy-rossum.md`).

### Part A — Testing strategy reset
- `missing-tests-scanner-v1` gains size (`< MISSING_TESTS_MIN_LOC` default 50 LOC), filename-denylist (`types|constants|config|defaults|registry|index|*.d.ts`), and pure-export filters.
- New `safety-gap-scanner-v1` flags infrastructure-class gaps (route guards, admin-auth coverage, RLS-deny assertions, OASIS-emission contract, governance toggles, deploy smoke, e2e) — one finding per gap, emits 8 on current repo state.
- One-shot migration retroactively archives stored false-positive findings so operators don't have to wait for the scanner cycle.
- `SignalType` extended with `safety_gap`; synthesis propagates scanner-specific `raw` fields (`file_loc`, `gap_key`) into `spec_snapshot`.

### Part B — `auto_approve_threshold`
- 4 new `dev_autopilot_config` columns (`auto_approve_enabled`, `auto_approve_max_effort`, `auto_approve_risk_classes`, `auto_approve_scanners`). All default-safe: `enabled=false`, enabling is a single Supabase Studio row flip.
- `autoApproveTick()` runs alongside `backgroundExecutorTick()`, respects `kill_switch`, `daily_budget`, `concurrency_cap`; per-tick cap of 5 to prevent bursts when freshly enabled.
- New `dev_autopilot.execution.auto_approved` event type.
- Safety gate still runs on every auto-approved finding — this only automates the click.

### Part C — Prompt-gap feedback loop
- New `dev_autopilot_prompt_learnings` table keyed by `(pattern_type, pattern_key, scanner)`.
- Worker tracks `AttemptFailure[]` across the validation retry loop (parse/apply/tsc/jest) with normalized `pattern_key` signatures (`TS2307:cannot-find-module`, `jest:expect-tobe-mismatch`, etc.), emits via `output_payload` on both `completeTask` and new `failTask(extra)` paths.
- Gateway persists learnings via PostgREST upsert — best-effort, no blocking.
- `buildPlanningPrompt` + `buildExecutionPrompt` gain optional `lessons?` parameter that injects a "Lessons from prior attempts" block scoped to the finding's scanner.

## Files touched

11 files: scanner (`scripts/ci/dev-autopilot-scan.mjs`), worker (`services/autopilot-worker/src/{index,queue}.ts`), gateway services (`dev-autopilot-execute.ts`, `dev-autopilot-planning.ts`, `dev-autopilot-synthesis.ts`, `dev-autopilot-worker-queue.ts`), event union (`types/cicd.ts`), three new migrations.

## Test plan

- [x] gateway `tsc --noEmit` — clean (only pre-existing `@anthropic-ai/sdk`/`openai` module errors unrelated to this PR)
- [x] worker `tsc --noEmit` — clean
- [x] `jest dev-autopilot-(execute|planning)` — 30/30 passing
- [x] scanner dry-run produced `todo=32 large_file=50 missing_tests=332 safety_gap=8 total=422`
- [ ] Apply migration `20260423151000_BOOTSTRAP_dev_autopilot_prompt_learnings.sql` via `RUN-MIGRATION.yml` → table exists
- [ ] Apply migration `20260423150500_BOOTSTRAP_dev_autopilot_auto_approve.sql` → 4 new columns on `dev_autopilot_config`, all default-safe
- [ ] Apply migration `20260423150000_BOOTSTRAP_archive_false_positive_findings.sql` → false-positive rows go to `status='auto_archived'`
- [ ] Merge + EXEC-DEPLOY → gateway boots with autoApproveTick registered (default disabled, no behaviour change)
- [ ] Flip `auto_approve_enabled=true` for one tick, verify `dev_autopilot.execution.auto_approved` OASIS event
- [ ] Force a worker validation failure, verify a row appears in `dev_autopilot_prompt_learnings`
- [ ] Re-approve the SAME finding, verify plan prompt contains the `## Lessons from prior attempts` block

## What this does NOT change

Worker-owned PR creation (#853), watcher auto-merge (#833), validation retry loop (#826, #846), plan→approve→cool→execute→merge state machine. All three parts are purely additive — existing flows unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)