### PR TITLE
fix(docs): specs route + system/baseline KB edit

### DIFF
--- a/services/gateway/Dockerfile
+++ b/services/gateway/Dockerfile
@@ -6,6 +6,7 @@ RUN npm install
 COPY BUILD_INFO ./
 COPY src ./src
 COPY config ./config
+COPY specs ./specs
 RUN npm run build
 
 FROM node:20-alpine
@@ -14,6 +15,7 @@ COPY package*.json ./
 RUN apk add --no-cache ffmpeg && npm install --production
 COPY --from=builder /app/dist ./dist
 COPY --from=builder /app/config ./config
+COPY --from=builder /app/specs ./specs
 COPY BUILD_INFO ./
 ENV NODE_ENV=production
 ENV PORT=8080

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -77,6 +77,7 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const governanceControlsRouter = require('./routes/governance-controls').default;
   const { oasisTasksRouter } = require('./routes/oasis-tasks');
   const { oasisVtidLedgerRouter } = require('./routes/oasis-vtid-ledger');
+  const oasisSpecsRouter = require('./routes/oasis-specs').default;
   const cicdRouter = require('./routes/cicd').default;
   const operatorRouter = require('./routes/operator').default;
   const { router: telemetryRouter } = require('./routes/telemetry');
@@ -865,6 +866,9 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
 
   // VTID-01020: VTID Ledger JSON endpoint
   mountRouterSync(app, '/', oasisVtidLedgerRouter, { owner: 'oasis-vtid-ledger' });
+
+  // BOOTSTRAP-DOCS-FOLLOWUPS: OASIS specs for Command Hub Docs UI
+  mountRouterSync(app, '/api/v1/oasis/specs', oasisSpecsRouter, { owner: 'oasis-specs' });
 
   // VTID-01169: Deploy → Ledger Terminalization (terminalize endpoint + repair job)
   mountRouterSync(app, '/', vtidTerminalizeRouter, { owner: 'vtid-terminalize' });

--- a/services/gateway/src/routes/admin-system-kb.ts
+++ b/services/gateway/src/routes/admin-system-kb.ts
@@ -94,6 +94,87 @@ router.get('/docs/:id', async (req: AuthenticatedRequest, res: Response) => {
   }
 });
 
+// PUT /docs/:id — edit a knowledge_docs row (exafy admin only).
+// This is the system-scope edit path: changes apply immediately to the
+// Vitana Assistant's retrieval-router priority-100 grounding for every tenant.
+router.put('/docs/:id', async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+
+  const id = req.params.id;
+  const { title, content, tags } = req.body ?? {};
+  const updates: Record<string, unknown> = { updated_at: new Date().toISOString() };
+  if (typeof title === 'string') updates.title = title;
+  if (typeof content === 'string') {
+    updates.content = content;
+    updates.word_count = content.trim().split(/\s+/).filter(Boolean).length;
+  }
+  if (Array.isArray(tags)) updates.tags = tags;
+
+  if (Object.keys(updates).length === 1) {
+    return res.status(400).json({ ok: false, error: 'NO_FIELDS' });
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from('knowledge_docs')
+      .update(updates)
+      .eq('id', id)
+      .select('id, title, path, content, tags, word_count, source_type, created_at, updated_at')
+      .maybeSingle();
+    if (error) {
+      console.error('[admin-system-kb] update error:', error.message);
+      return res.status(400).json({ ok: false, error: error.message });
+    }
+    if (!data) return res.status(404).json({ ok: false, error: 'NOT_FOUND' });
+    console.log(
+      `[admin-system-kb] system doc ${id} edited by exafy_admin user ${req.identity?.user_id}`,
+    );
+    return res.status(200).json({ ok: true, document: data });
+  } catch (err: any) {
+    return res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+// PUT /baseline-docs/:id — edit a baseline kb_documents row (tenant_id IS NULL).
+// Exafy admin only. Changes apply to every tenant that hasn't opted out.
+router.put('/baseline-docs/:id', async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+
+  const id = req.params.id;
+  const { title, body, topics } = req.body ?? {};
+  const updates: Record<string, unknown> = { updated_at: new Date().toISOString() };
+  if (typeof title === 'string') updates.title = title;
+  if (typeof body === 'string') updates.body = body;
+  if (Array.isArray(topics)) updates.topics = topics;
+
+  if (Object.keys(updates).length === 1) {
+    return res.status(400).json({ ok: false, error: 'NO_FIELDS' });
+  }
+
+  try {
+    const { data, error } = await supabase
+      .from('kb_documents')
+      .update(updates)
+      .eq('id', id)
+      .is('tenant_id', null) // enforce baseline scope
+      .select('*')
+      .maybeSingle();
+    if (error) {
+      console.error('[admin-system-kb] baseline update error:', error.message);
+      return res.status(400).json({ ok: false, error: error.message });
+    }
+    if (!data) return res.status(404).json({ ok: false, error: 'NOT_FOUND_OR_NOT_BASELINE' });
+    console.log(
+      `[admin-system-kb] baseline doc ${id} edited by exafy_admin user ${req.identity?.user_id}`,
+    );
+    return res.status(200).json({ ok: true, document: data });
+  } catch (err: any) {
+    return res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
 // GET / — router health
 router.get('/', (_req, res: Response) => {
   res.status(200).json({
@@ -102,6 +183,8 @@ router.get('/', (_req, res: Response) => {
     endpoints: [
       'GET /api/v1/admin/system-kb/docs?path_prefix&tag&q',
       'GET /api/v1/admin/system-kb/docs/:id',
+      'PUT /api/v1/admin/system-kb/docs/:id',
+      'PUT /api/v1/admin/system-kb/baseline-docs/:id',
     ],
   });
 });

--- a/services/gateway/src/routes/oasis-specs.ts
+++ b/services/gateway/src/routes/oasis-specs.ts
@@ -1,0 +1,63 @@
+/**
+ * OASIS Specs — serves the static spec JSON files under `services/gateway/specs/`
+ * to the Command Hub docs UI. Before this router existed, the frontend call to
+ * `/api/v1/oasis/specs/dev-screen-inventory` returned HTML 404 because no
+ * backend handler was mounted, causing the "Error: Network response was not ok"
+ * banner on the Docs → Screens tab.
+ *
+ * Endpoints:
+ *   GET /api/v1/oasis/specs                          — list available specs
+ *   GET /api/v1/oasis/specs/dev-screen-inventory     — the dev screen inventory
+ *
+ * The spec is wrapped in `{ ok: true, data: <spec> }` to match the shape the
+ * frontend renderer (renderDocsScreensView → state.screenInventory) expects.
+ *
+ * No auth: these specs describe the platform surface and are already served to
+ * authenticated Command Hub users. Public read aligns with the other
+ * `/api/v1/oasis/*` operator endpoints that serve catalog-like data.
+ */
+
+import { Router, Request, Response } from 'express';
+import fs from 'fs';
+import path from 'path';
+
+const router = Router();
+
+// Whitelist of supported spec keys → filenames (relative to services/gateway/specs/).
+const SPEC_FILES: Record<string, string> = {
+  'dev-screen-inventory': 'dev-screen-inventory-v1.json',
+};
+
+function specsDir(): string {
+  // dist/routes/oasis-specs.js runs out of services/gateway/dist/; specs live
+  // in services/gateway/specs/ (two dirs up from dist/routes).
+  return path.resolve(__dirname, '..', '..', 'specs');
+}
+
+router.get('/', (_req: Request, res: Response) => {
+  return res.status(200).json({
+    ok: true,
+    data: {
+      available: Object.keys(SPEC_FILES),
+    },
+  });
+});
+
+router.get('/:specKey', (req: Request, res: Response) => {
+  const key = req.params.specKey;
+  const filename = SPEC_FILES[key];
+  if (!filename) {
+    return res.status(404).json({ ok: false, error: 'UNKNOWN_SPEC', key });
+  }
+  const fullPath = path.join(specsDir(), filename);
+  try {
+    const raw = fs.readFileSync(fullPath, 'utf-8');
+    const data = JSON.parse(raw);
+    return res.status(200).json({ ok: true, data });
+  } catch (err: any) {
+    console.error(`[oasis-specs] failed to read ${fullPath}:`, err.message);
+    return res.status(500).json({ ok: false, error: 'SPEC_READ_FAILED' });
+  }
+});
+
+export default router;


### PR DESCRIPTION
Two follow-ups to the unified-KB PR #859.

1. /command-hub/docs/screens returned 'Network response was not ok' because no backend served /api/v1/oasis/specs/dev-screen-inventory. This adds routes/oasis-specs.ts that serves whitelisted spec JSON from services/gateway/specs/ wrapped in {ok, data}. Dockerfile also updated to COPY specs/ into the image.

2. Adds exafy-admin edit endpoints for the unified-KB Documents tab:
  - PUT /api/v1/admin/system-kb/docs/:id  (edit knowledge_docs / system scope)
  - PUT /api/v1/admin/system-kb/baseline-docs/:id  (edit kb_documents WHERE tenant_id IS NULL)
Both gated by requireExafyAdmin. Baseline PUT enforces .is('tenant_id', null) to prevent accidental tenant mutations.

Pair PR in vitana-v1 adds the Edit buttons + inline form + AlertDialog warning ('affects all tenants immediately').

Test plan
- curl /api/v1/oasis/specs/dev-screen-inventory → expect 200 JSON (was HTML 404)
- Command Hub Docs → Screens tab loads rows (previously 'Network response was not ok')
- PUT system-kb/docs/:id as exafy admin → applies; as non-admin → 403
- PUT system-kb/baseline-docs/:id with a NON-baseline id → 404 NOT_FOUND_OR_NOT_BASELINE

🤖 Generated with Claude Code (https://claude.com/claude-code)