### PR TITLE
feat(vitana-index): Phase F v1 — five pillar agents framework (step 8)

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -291,6 +291,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   // Admin System KB — exafy_admin-only view of system-wide knowledge_docs
   // (where the Book of the Vitana Index and other vitana_system docs live).
   const adminSystemKbRouter = require('./routes/admin-system-kb').default;
+  // Phase F v1: 5 pillar agents (Nutrition/Hydration/Exercise/Sleep/Mental).
+  const pillarAgentsRouter = require('./routes/pillar-agents').default;
   // Overview Dashboard — KPI summary, at-risk, activity, alerts
   const tenantOverviewRouter = require('./routes/tenant-admin/overview').default;
   // BOOTSTRAP-ADMIN-KPI-AA: Admin KPI surface (real-time snapshot + history)
@@ -764,6 +766,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   mountRouterSync(app, '/api/v1/admin/tenants/:tenantId/kb', tenantKnowledgeRouter, { owner: 'tenant-knowledge' });
   // Admin System KB — exafy_admin-only view of system-wide knowledge_docs
   mountRouterSync(app, '/api/v1/admin/system-kb', adminSystemKbRouter, { owner: 'admin-system-kb' });
+  // Phase F v1: pillar agents framework
+  mountRouterSync(app, '/api/v1/pillar-agents', pillarAgentsRouter, { owner: 'pillar-agents' });
   // Overview Dashboard — KPI summary, at-risk, activity, alerts
   mountRouterSync(app, '/api/v1/admin/tenants/:tenantId/overview', tenantOverviewRouter, { owner: 'tenant-overview' });
   // BOOTSTRAP-ADMIN-KPI-AA: Admin KPI surface

--- a/services/gateway/src/routes/pillar-agents.ts
+++ b/services/gateway/src/routes/pillar-agents.ts
@@ -1,0 +1,116 @@
+/**
+ * Pillar Agents — admin + self routes.
+ *
+ * Mounted at /api/v1/pillar-agents.
+ *
+ * Endpoints:
+ *   GET  /health             — router liveness + list of registered agents
+ *   POST /run                — run all 5 agents for the authenticated user
+ *                              (or for any user if caller is exafy_admin)
+ *                              Body: { user_id?: string, date?: string }
+ *   GET  /outputs            — self read-only: list the caller's recent
+ *                              per-pillar agent outputs (auth required)
+ */
+
+import { Router, Response } from 'express';
+import { requireAuth, requireExafyAdmin, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
+import { getSupabase } from '../lib/supabase';
+import { runPillarAgentsForUser, buildAllAgents } from '../services/pillar-agents/orchestrator';
+
+const router = Router();
+
+router.get('/health', (_req, res: Response) => {
+  const supabase = getSupabase();
+  const agents = supabase ? buildAllAgents(supabase).map(a => ({
+    agent_id: a.agentId,
+    pillar: a.pillar,
+    version: a.version,
+    display_name: a.displayName,
+  })) : [];
+  res.status(200).json({
+    ok: true,
+    service: 'pillar-agents',
+    agent_count: agents.length,
+    agents,
+  });
+});
+
+router.post('/run', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+  }
+
+  const selfId = req.identity?.user_id;
+  if (!selfId) {
+    return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+  }
+
+  const requestedUser = (req.body?.user_id as string | undefined)?.trim();
+  const date = (req.body?.date as string | undefined)?.trim()
+    || new Date().toISOString().slice(0, 10);
+
+  // Users can only run for themselves; exafy admins can run for any user.
+  let targetUser = selfId;
+  if (requestedUser && requestedUser !== selfId) {
+    if (!req.identity?.exafy_admin) {
+      return res.status(403).json({ ok: false, error: 'FORBIDDEN' });
+    }
+    targetUser = requestedUser;
+  }
+
+  try {
+    const result = await runPillarAgentsForUser(supabase, targetUser, date);
+    return res.status(200).json(result);
+  } catch (err: any) {
+    return res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+router.get('/outputs', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+  }
+  const userId = req.identity?.user_id;
+  if (!userId) {
+    return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+  }
+  const date = (req.query.date as string | undefined)?.trim()
+    || new Date().toISOString().slice(0, 10);
+
+  try {
+    const { data, error } = await supabase
+      .from('vitana_pillar_agent_outputs')
+      .select('pillar, date, subscore_baseline, subscore_completions, subscore_data, subscore_streak, agent_version, computed_at, outputs_jsonb')
+      .eq('user_id', userId)
+      .eq('date', date)
+      .order('pillar', { ascending: true });
+    if (error) {
+      return res.status(400).json({ ok: false, error: error.message });
+    }
+    return res.status(200).json({ ok: true, user_id: userId, date, outputs: data ?? [] });
+  } catch (err: any) {
+    return res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+// Admin-only: run for any user, and inspect recent outputs across users.
+router.get('/admin/outputs', requireAuth, requireExafyAdmin, async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+  const limit = Math.min(100, Number(req.query.limit ?? 20));
+  try {
+    const { data, error } = await supabase
+      .from('vitana_pillar_agent_outputs')
+      .select('user_id, pillar, date, subscore_baseline, subscore_completions, subscore_data, subscore_streak, agent_version, computed_at')
+      .order('computed_at', { ascending: false })
+      .limit(limit);
+    if (error) return res.status(400).json({ ok: false, error: error.message });
+    return res.status(200).json({ ok: true, outputs: data ?? [] });
+  } catch (err: any) {
+    return res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+export default router;

--- a/services/gateway/src/services/pillar-agents/base-agent.ts
+++ b/services/gateway/src/services/pillar-agents/base-agent.ts
@@ -1,0 +1,127 @@
+/**
+ * Shared helpers for pillar agents. v1 keeps the math identical to the
+ * compute RPC so switching to agent outputs is a drop-in change.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { PillarKey, PillarSubscores } from './types';
+
+const BASELINE_CURVE: Record<1|2|3|4|5, number> = { 1: 10, 2: 20, 3: 25, 4: 32, 5: 40 };
+
+const PILLAR_TAGS: Record<PillarKey, string[]> = {
+  nutrition: ['nutrition', 'meal', 'food-log'],
+  hydration: ['hydration', 'water'],
+  exercise:  ['movement', 'workout', 'walk', 'steps', 'exercise'],
+  sleep:     ['sleep', 'rest', 'recovery'],
+  mental:    ['mindfulness', 'mental', 'stress', 'meditation', 'learning', 'journal'],
+};
+
+const PILLAR_FEATURE_KEYS: Record<PillarKey, string[]> = {
+  nutrition: ['biomarker_glucose', 'biomarker_hba1c', 'meal_log', 'macro_balance'],
+  hydration: ['water_intake', 'hydration_log'],
+  exercise:  ['wearable_heart_rate', 'wearable_steps', 'wearable_workout', 'vo2_max'],
+  sleep:     ['wearable_sleep_duration', 'wearable_sleep_efficiency', 'wearable_hrv', 'wearable_sleep_stages'],
+  mental:    ['wearable_stress', 'mood_entry', 'meditation_minutes', 'journal_entry'],
+};
+
+/** Baseline sub-score (max 40) from the user's baseline survey answers. */
+export async function computeBaselineSubscore(
+  admin: SupabaseClient,
+  userId: string,
+  pillar: PillarKey,
+): Promise<number> {
+  const { data } = await admin
+    .from('vitana_index_baseline_survey')
+    .select('answers')
+    .eq('user_id', userId)
+    .maybeSingle();
+  const answer = (data?.answers as any)?.[pillar];
+  const rating = Number.isInteger(answer) && answer >= 1 && answer <= 5
+    ? (answer as 1|2|3|4|5)
+    : null;
+  return rating ? BASELINE_CURVE[rating] : 10;
+}
+
+/** Completions sub-score (max 80) from last 30d completed calendar events
+ * whose wellness_tags match this pillar's tag bucket. Each match = +6. */
+export async function computeCompletionsSubscore(
+  admin: SupabaseClient,
+  userId: string,
+  pillar: PillarKey,
+): Promise<number> {
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - 30);
+  const cutoffIso = cutoff.toISOString().slice(0, 10);
+
+  const { data } = await admin
+    .from('calendar_events')
+    .select('wellness_tags, completed_at, end_time')
+    .eq('user_id', userId)
+    .eq('completion_status', 'completed')
+    .gte('completed_at', cutoffIso);
+
+  const tags = new Set(PILLAR_TAGS[pillar]);
+  let score = 0;
+  for (const row of data ?? []) {
+    const rowTags = (row.wellness_tags as string[] | null) ?? [];
+    if (rowTags.some(t => tags.has(t))) score += 6;
+  }
+  return Math.min(score, 80);
+}
+
+/** Connected-data sub-score (max 40) based on count of pillar-relevant
+ * feature rows in the last 7 days. */
+export async function computeDataSubscore(
+  admin: SupabaseClient,
+  userId: string,
+  pillar: PillarKey,
+): Promise<number> {
+  const cutoff = new Date();
+  cutoff.setDate(cutoff.getDate() - 7);
+  const cutoffIso = cutoff.toISOString().slice(0, 10);
+
+  const { count } = await admin
+    .from('health_features_daily')
+    .select('id', { count: 'exact', head: true })
+    .eq('user_id', userId)
+    .gte('date', cutoffIso)
+    .in('feature_key', PILLAR_FEATURE_KEYS[pillar]);
+
+  const n = count ?? 0;
+  if (n >= 11) return 40;
+  if (n >= 4)  return 25;
+  if (n >= 1)  return 15;
+  return 0;
+}
+
+/** Streak bonus (max 40) — mirrors the vitana_pillar_streak_days() SQL
+ * helper so agent output matches the RPC. */
+export async function computeStreakSubscore(
+  admin: SupabaseClient,
+  userId: string,
+  pillar: PillarKey,
+): Promise<number> {
+  const { data } = await admin.rpc('vitana_pillar_streak_days', {
+    p_user_id: userId,
+    p_pillar_key: pillar,
+  });
+  const days = Number(data ?? 0);
+  if (days >= 30) return 40;
+  if (days >= 14) return 25;
+  if (days >= 7)  return 15;
+  return 0;
+}
+
+export async function computeAllSubscoresForPillar(
+  admin: SupabaseClient,
+  userId: string,
+  pillar: PillarKey,
+): Promise<PillarSubscores> {
+  const [baseline, completions, data, streak] = await Promise.all([
+    computeBaselineSubscore(admin, userId, pillar),
+    computeCompletionsSubscore(admin, userId, pillar),
+    computeDataSubscore(admin, userId, pillar),
+    computeStreakSubscore(admin, userId, pillar),
+  ]);
+  return { baseline, completions, data, streak };
+}

--- a/services/gateway/src/services/pillar-agents/exercise/index.ts
+++ b/services/gateway/src/services/pillar-agents/exercise/index.ts
@@ -1,0 +1,28 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { PillarAgent, PillarAgentOutput } from '../types';
+import { computeAllSubscoresForPillar } from '../base-agent';
+
+/**
+ * Exercise pillar agent (v1).
+ *
+ * v1: mirrors the compute RPC math for Exercise.
+ * v2+: Apple Health, Google Fit, Strava, Whoop, Oura, Garmin Connect,
+ *      Fitbit, Polar. VO2-max estimation. Zone-2 vs. HIIT detection.
+ */
+export function createExerciseAgent(admin: SupabaseClient): PillarAgent {
+  return {
+    pillar: 'exercise',
+    agentId: 'pillar-exercise-agent',
+    displayName: 'Pillar Agent — Exercise',
+    version: 'v1',
+    async computePillarSubscores(userId: string, _date: string): Promise<PillarAgentOutput> {
+      const subscores = await computeAllSubscoresForPillar(admin, userId, 'exercise');
+      return {
+        pillar: 'exercise',
+        subscores,
+        metadata: { source: 'v1', integrations_connected: [] },
+        agent_version: 'v1',
+      };
+    },
+  };
+}

--- a/services/gateway/src/services/pillar-agents/hydration/index.ts
+++ b/services/gateway/src/services/pillar-agents/hydration/index.ts
@@ -1,0 +1,28 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { PillarAgent, PillarAgentOutput } from '../types';
+import { computeAllSubscoresForPillar } from '../base-agent';
+
+/**
+ * Hydration pillar agent (v1).
+ *
+ * v1: mirrors the compute RPC math for Hydration.
+ * v2+: HidrateSpark bottles, Apple Health (Water), Google Fit (Hydration),
+ *      climate-adjusted daily targets via OpenWeatherMap.
+ */
+export function createHydrationAgent(admin: SupabaseClient): PillarAgent {
+  return {
+    pillar: 'hydration',
+    agentId: 'pillar-hydration-agent',
+    displayName: 'Pillar Agent — Hydration',
+    version: 'v1',
+    async computePillarSubscores(userId: string, _date: string): Promise<PillarAgentOutput> {
+      const subscores = await computeAllSubscoresForPillar(admin, userId, 'hydration');
+      return {
+        pillar: 'hydration',
+        subscores,
+        metadata: { source: 'v1', integrations_connected: [] },
+        agent_version: 'v1',
+      };
+    },
+  };
+}

--- a/services/gateway/src/services/pillar-agents/mental/index.ts
+++ b/services/gateway/src/services/pillar-agents/mental/index.ts
@@ -1,0 +1,28 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { PillarAgent, PillarAgentOutput } from '../types';
+import { computeAllSubscoresForPillar } from '../base-agent';
+
+/**
+ * Mental pillar agent (v1).
+ *
+ * v1: mirrors the compute RPC math for Mental.
+ * v2+: journal LLM analysis, HRV stress signals, Calm / Headspace logs,
+ *      Apple Health Mindful Minutes, mood-tracking apps.
+ */
+export function createMentalAgent(admin: SupabaseClient): PillarAgent {
+  return {
+    pillar: 'mental',
+    agentId: 'pillar-mental-agent',
+    displayName: 'Pillar Agent — Mental',
+    version: 'v1',
+    async computePillarSubscores(userId: string, _date: string): Promise<PillarAgentOutput> {
+      const subscores = await computeAllSubscoresForPillar(admin, userId, 'mental');
+      return {
+        pillar: 'mental',
+        subscores,
+        metadata: { source: 'v1', integrations_connected: [] },
+        agent_version: 'v1',
+      };
+    },
+  };
+}

--- a/services/gateway/src/services/pillar-agents/nutrition/index.ts
+++ b/services/gateway/src/services/pillar-agents/nutrition/index.ts
@@ -1,0 +1,28 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { PillarAgent, PillarAgentOutput } from '../types';
+import { computeAllSubscoresForPillar } from '../base-agent';
+
+/**
+ * Nutrition pillar agent (v1).
+ *
+ * v1: mirrors the compute RPC math for Nutrition.
+ * v2+: parse meal photos (LLM vision), import MyFitnessPal/Cronometer,
+ *      read biomarker labs (HbA1c, lipid panels), CGM glucose trends.
+ */
+export function createNutritionAgent(admin: SupabaseClient): PillarAgent {
+  return {
+    pillar: 'nutrition',
+    agentId: 'pillar-nutrition-agent',
+    displayName: 'Pillar Agent — Nutrition',
+    version: 'v1',
+    async computePillarSubscores(userId: string, _date: string): Promise<PillarAgentOutput> {
+      const subscores = await computeAllSubscoresForPillar(admin, userId, 'nutrition');
+      return {
+        pillar: 'nutrition',
+        subscores,
+        metadata: { source: 'v1', integrations_connected: [] },
+        agent_version: 'v1',
+      };
+    },
+  };
+}

--- a/services/gateway/src/services/pillar-agents/orchestrator.ts
+++ b/services/gateway/src/services/pillar-agents/orchestrator.ts
@@ -1,0 +1,119 @@
+/**
+ * Pillar Agent Orchestrator (Phase F v1).
+ *
+ * Runs all 5 pillar agents in parallel for a given user/date, writes their
+ * outputs to `vitana_pillar_agent_outputs`, and updates each agent's
+ * heartbeat in `agents_registry`. Never blocks the calling code — agent
+ * failures are logged and swallowed per-agent.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { OrchestratorRunResult, PillarAgent, PillarAgentOutput, PillarKey } from './types';
+import { createNutritionAgent } from './nutrition';
+import { createHydrationAgent } from './hydration';
+import { createExerciseAgent } from './exercise';
+import { createSleepAgent } from './sleep';
+import { createMentalAgent } from './mental';
+
+export function buildAllAgents(admin: SupabaseClient): PillarAgent[] {
+  return [
+    createNutritionAgent(admin),
+    createHydrationAgent(admin),
+    createExerciseAgent(admin),
+    createSleepAgent(admin),
+    createMentalAgent(admin),
+  ];
+}
+
+async function persistOutput(
+  admin: SupabaseClient,
+  userId: string,
+  date: string,
+  output: PillarAgentOutput,
+): Promise<void> {
+  const { error } = await admin
+    .from('vitana_pillar_agent_outputs')
+    .upsert({
+      user_id: userId,
+      pillar: output.pillar,
+      date,
+      outputs_jsonb: output.metadata,
+      subscore_baseline:    output.subscores.baseline,
+      subscore_completions: output.subscores.completions,
+      subscore_data:        output.subscores.data,
+      subscore_streak:      output.subscores.streak,
+      agent_version: output.agent_version,
+      computed_at: new Date().toISOString(),
+    }, { onConflict: 'user_id,pillar,date' });
+
+  if (error) {
+    throw new Error(`vitana_pillar_agent_outputs upsert failed: ${error.message}`);
+  }
+}
+
+async function heartbeat(
+  admin: SupabaseClient,
+  agentId: string,
+  ok: boolean,
+  errorMessage?: string,
+): Promise<void> {
+  try {
+    await admin
+      .from('agents_registry')
+      .update({
+        status: ok ? 'healthy' : 'degraded',
+        last_heartbeat_at: new Date().toISOString(),
+        last_error: ok ? null : (errorMessage ?? null),
+        updated_at: new Date().toISOString(),
+      })
+      .eq('agent_id', agentId);
+  } catch {
+    // Heartbeat failures are never fatal.
+  }
+}
+
+export async function runPillarAgentsForUser(
+  admin: SupabaseClient,
+  userId: string,
+  date: string,
+): Promise<OrchestratorRunResult> {
+  const t0 = Date.now();
+  const agents = buildAllAgents(admin);
+
+  const results = await Promise.allSettled(agents.map(async (agent) => {
+    const output = await agent.computePillarSubscores(userId, date);
+    await persistOutput(admin, userId, date, output);
+    await heartbeat(admin, agent.agentId, true);
+    return { agent, output };
+  }));
+
+  const per_pillar: Partial<Record<PillarKey, PillarAgentOutput>> = {};
+  const errors: Array<{ pillar: PillarKey; message: string }> = [];
+  let agents_run = 0;
+  let agents_failed = 0;
+
+  for (let i = 0; i < results.length; i++) {
+    const r = results[i];
+    const agent = agents[i];
+    if (r.status === 'fulfilled') {
+      per_pillar[agent.pillar] = r.value.output;
+      agents_run++;
+    } else {
+      const message = r.reason instanceof Error ? r.reason.message : String(r.reason);
+      errors.push({ pillar: agent.pillar, message });
+      await heartbeat(admin, agent.agentId, false, message);
+      agents_failed++;
+    }
+  }
+
+  return {
+    ok: agents_failed === 0,
+    user_id: userId,
+    date,
+    agents_run,
+    agents_failed,
+    per_pillar,
+    errors,
+    duration_ms: Date.now() - t0,
+  };
+}

--- a/services/gateway/src/services/pillar-agents/sleep/index.ts
+++ b/services/gateway/src/services/pillar-agents/sleep/index.ts
@@ -1,0 +1,28 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type { PillarAgent, PillarAgentOutput } from '../types';
+import { computeAllSubscoresForPillar } from '../base-agent';
+
+/**
+ * Sleep pillar agent (v1).
+ *
+ * v1: mirrors the compute RPC math for Sleep.
+ * v2+: Oura, Whoop, Eight Sleep, Apple Sleep, Fitbit Sleep, Garmin Sleep.
+ *      Personalised sleep-hygiene review, bedtime planner.
+ */
+export function createSleepAgent(admin: SupabaseClient): PillarAgent {
+  return {
+    pillar: 'sleep',
+    agentId: 'pillar-sleep-agent',
+    displayName: 'Pillar Agent — Sleep',
+    version: 'v1',
+    async computePillarSubscores(userId: string, _date: string): Promise<PillarAgentOutput> {
+      const subscores = await computeAllSubscoresForPillar(admin, userId, 'sleep');
+      return {
+        pillar: 'sleep',
+        subscores,
+        metadata: { source: 'v1', integrations_connected: [] },
+        agent_version: 'v1',
+      };
+    },
+  };
+}

--- a/services/gateway/src/services/pillar-agents/types.ts
+++ b/services/gateway/src/services/pillar-agents/types.ts
@@ -1,0 +1,55 @@
+/**
+ * Pillar Agent framework types (Phase F v1).
+ *
+ * One agent per Vitana pillar. Each implements `computePillarSubscores`
+ * and writes to `vitana_pillar_agent_outputs` via the orchestrator.
+ * v1 agents mirror the compute RPC's math for their pillar; v2+ replaces
+ * each agent's internals with external integrations.
+ */
+
+export type PillarKey = 'nutrition' | 'hydration' | 'exercise' | 'sleep' | 'mental';
+
+export interface PillarSubscores {
+  /** Max 40 — from vitana_index_baseline_survey.answers. */
+  baseline: number;
+  /** Max 80 — completed calendar events tagged for this pillar in last 30d. */
+  completions: number;
+  /** Max 40 — recent health_features_daily rows relevant to this pillar. */
+  data: number;
+  /** Max 40 — consecutive days with signal for this pillar. */
+  streak: number;
+}
+
+export interface PillarAgentOutput {
+  pillar: PillarKey;
+  subscores: PillarSubscores;
+  /** Free-form agent-specific payload (signals, narratives, suggested nudges). */
+  metadata: Record<string, unknown>;
+  /** Agent version ("v1", "v2", …). Written to DB for observability. */
+  agent_version: string;
+}
+
+export interface PillarAgent {
+  readonly pillar: PillarKey;
+  readonly agentId: string;         // e.g., 'pillar-nutrition-agent'
+  readonly displayName: string;
+  readonly version: string;
+
+  /**
+   * Compute this pillar's sub-scores for the given user/date using whatever
+   * data sources the agent has access to. v1 implementations read directly
+   * from vitana_index_baseline_survey / calendar_events / health_features_daily.
+   */
+  computePillarSubscores(userId: string, date: string): Promise<PillarAgentOutput>;
+}
+
+export interface OrchestratorRunResult {
+  ok: boolean;
+  user_id: string;
+  date: string;
+  agents_run: number;
+  agents_failed: number;
+  per_pillar: Partial<Record<PillarKey, PillarAgentOutput>>;
+  errors: Array<{ pillar: PillarKey; message: string }>;
+  duration_ms: number;
+}

--- a/supabase/migrations/20260423190000_vitana_pillar_agents_v1.sql
+++ b/supabase/migrations/20260423190000_vitana_pillar_agents_v1.sql
@@ -1,0 +1,238 @@
+-- =============================================================================
+-- Vitana pillar agents — v1 framework (BOOTSTRAP-VITANA-PILLAR-AGENTS-V1)
+-- Date: 2026-04-23
+-- Plan: .claude/plans/community-user-role-make-purring-pascal.md (step 8, Phase F v1)
+--
+-- First cut of the 5-pillar-agent architecture. One agent per pillar —
+-- Nutrition, Hydration, Exercise, Sleep, Mental — registered as 'embedded'
+-- agents in agents_registry. Each agent writes its per-user, per-day
+-- sub-score breakdown into vitana_pillar_agent_outputs for observability
+-- and to enable future compute-RPC swap (Phase F v2+).
+--
+-- v1 agents just mirror the compute RPC's sub-score math for their pillar,
+-- wrapped in a module. The framework + registration is what matters — v2+
+-- replaces each agent's internals with external integrations (Apple Health,
+-- Oura, Whoop, food-log apps, etc.) and LLM enrichment.
+--
+-- Idempotent: CREATE TABLE IF NOT EXISTS, ON CONFLICT DO UPDATE, upsert_knowledge_doc.
+-- =============================================================================
+
+BEGIN;
+
+-- -----------------------------------------------------------------------------
+-- 1. vitana_pillar_agent_outputs — per-user, per-day, per-pillar agent output.
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.vitana_pillar_agent_outputs (
+  id              uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id         uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  pillar          text NOT NULL CHECK (pillar IN ('nutrition','hydration','exercise','sleep','mental')),
+  date            date NOT NULL,
+  -- Agent output payload: sub-score breakdown + any extras the agent wants
+  -- to expose (signals, narratives, suggested actions). Always JSONB so
+  -- agents can evolve without schema changes.
+  outputs_jsonb   jsonb NOT NULL DEFAULT '{}'::jsonb,
+  -- Computed sub-scores for fast lookup by the RPC.
+  subscore_baseline    smallint DEFAULT 0 CHECK (subscore_baseline    BETWEEN 0 AND 40),
+  subscore_completions smallint DEFAULT 0 CHECK (subscore_completions BETWEEN 0 AND 80),
+  subscore_data        smallint DEFAULT 0 CHECK (subscore_data        BETWEEN 0 AND 40),
+  subscore_streak      smallint DEFAULT 0 CHECK (subscore_streak      BETWEEN 0 AND 40),
+  agent_version   text NOT NULL DEFAULT 'v1',
+  computed_at     timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT vitana_pillar_agent_outputs_unique UNIQUE (user_id, pillar, date)
+);
+
+CREATE INDEX IF NOT EXISTS idx_vitana_pillar_agent_outputs_user_date
+  ON public.vitana_pillar_agent_outputs (user_id, date DESC);
+CREATE INDEX IF NOT EXISTS idx_vitana_pillar_agent_outputs_pillar_date
+  ON public.vitana_pillar_agent_outputs (pillar, date DESC);
+
+ALTER TABLE public.vitana_pillar_agent_outputs ENABLE ROW LEVEL SECURITY;
+
+-- Users can see their own outputs (useful for debug/transparency on the
+-- Index Detail screen if we ever surface them).
+DROP POLICY IF EXISTS vitana_pillar_agent_outputs_owner_read ON public.vitana_pillar_agent_outputs;
+CREATE POLICY vitana_pillar_agent_outputs_owner_read
+  ON public.vitana_pillar_agent_outputs FOR SELECT
+  USING (user_id = auth.uid());
+
+COMMENT ON TABLE public.vitana_pillar_agent_outputs IS
+  'Per-user, per-day, per-pillar output from the 5 Vitana pillar agents. Owned by the agent framework (services/gateway/src/services/pillar-agents/). RLS: users read their own rows; service_role writes.';
+
+-- -----------------------------------------------------------------------------
+-- 2. Register the 5 pillar agents in agents_registry.
+-- -----------------------------------------------------------------------------
+INSERT INTO public.agents_registry
+  (agent_id, display_name, description, tier, role, llm_provider, llm_model,
+   source_path, health_endpoint, metadata)
+VALUES
+  ('pillar-nutrition-agent',
+   'Pillar Agent — Nutrition',
+   'Observes the Nutrition pillar: meal logs, macro balance, biomarkers (glucose, HbA1c, lipids). Writes per-day sub-score breakdown to vitana_pillar_agent_outputs. v1 mirrors the compute RPC math; v2+ adds external integrations (MyFitnessPal, Cronometer, Apple Health Nutrition, lab-report OCR).',
+   'embedded', 'pillar-scoring', 'none', NULL,
+   'services/gateway/src/services/pillar-agents/nutrition/', '/api/v1/pillar-agents/health',
+   jsonb_build_object(
+     'pillar', 'nutrition',
+     'version', 'v1',
+     'integrations_planned', jsonb_build_array('MyFitnessPal','Cronometer','Apple Health (Nutrition)','Google Fit (Nutrition)','USDA FoodData','OpenFoodFacts','lab-report OCR')
+   )),
+  ('pillar-hydration-agent',
+   'Pillar Agent — Hydration',
+   'Observes the Hydration pillar: water intake, activity- and climate-adjusted targets. Writes per-day sub-score breakdown to vitana_pillar_agent_outputs. v1 mirrors the compute RPC; v2+ adds smart-bottle + health-app integrations.',
+   'embedded', 'pillar-scoring', 'none', NULL,
+   'services/gateway/src/services/pillar-agents/hydration/', '/api/v1/pillar-agents/health',
+   jsonb_build_object(
+     'pillar', 'hydration',
+     'version', 'v1',
+     'integrations_planned', jsonb_build_array('HidrateSpark','Apple Health (Water)','Google Fit (Hydration)','OpenWeatherMap')
+   )),
+  ('pillar-exercise-agent',
+   'Pillar Agent — Exercise',
+   'Observes the Exercise pillar: movement, heart rate, workouts, recovery signals. Writes per-day sub-score breakdown to vitana_pillar_agent_outputs. v1 mirrors the compute RPC; v2+ ingests wearable data (Apple Health, Google Fit, Strava, Whoop, Oura, Garmin, Fitbit, Polar).',
+   'embedded', 'pillar-scoring', 'none', NULL,
+   'services/gateway/src/services/pillar-agents/exercise/', '/api/v1/pillar-agents/health',
+   jsonb_build_object(
+     'pillar', 'exercise',
+     'version', 'v1',
+     'integrations_planned', jsonb_build_array('Apple Health','Google Fit','Strava','Whoop','Oura','Garmin Connect','Fitbit','Polar')
+   )),
+  ('pillar-sleep-agent',
+   'Pillar Agent — Sleep',
+   'Observes the Sleep pillar: duration, stages, HRV, circadian alignment. Writes per-day sub-score breakdown to vitana_pillar_agent_outputs. v1 mirrors the compute RPC; v2+ reads wearable sleep data.',
+   'embedded', 'pillar-scoring', 'none', NULL,
+   'services/gateway/src/services/pillar-agents/sleep/', '/api/v1/pillar-agents/health',
+   jsonb_build_object(
+     'pillar', 'sleep',
+     'version', 'v1',
+     'integrations_planned', jsonb_build_array('Oura','Whoop','Eight Sleep','Apple Sleep','Fitbit Sleep','Garmin Sleep')
+   )),
+  ('pillar-mental-agent',
+   'Pillar Agent — Mental',
+   'Observes the Mental pillar: stress, mood, mindfulness, cognitive load. Writes per-day sub-score breakdown to vitana_pillar_agent_outputs. v1 mirrors the compute RPC; v2+ integrates journaling, HRV stress analysis, meditation apps.',
+   'embedded', 'pillar-scoring', 'none', NULL,
+   'services/gateway/src/services/pillar-agents/mental/', '/api/v1/pillar-agents/health',
+   jsonb_build_object(
+     'pillar', 'mental',
+     'version', 'v1',
+     'integrations_planned', jsonb_build_array('Calm','Headspace','Oura (readiness)','Apple Health (Mindful Minutes)','mood-tracking apps')
+   ))
+ON CONFLICT (agent_id) DO UPDATE SET
+  display_name = EXCLUDED.display_name,
+  description = EXCLUDED.description,
+  source_path = EXCLUDED.source_path,
+  health_endpoint = EXCLUDED.health_endpoint,
+  metadata = EXCLUDED.metadata,
+  updated_at = now();
+
+-- -----------------------------------------------------------------------------
+-- 3. Book of the Vitana Index — chapter 10: Your five agents.
+-- -----------------------------------------------------------------------------
+SELECT public.upsert_knowledge_doc(
+  p_title := 'Book of the Vitana Index — Your five agents',
+  p_path  := 'kb/vitana-system/index-book/10-your-five-agents.md',
+  p_source_type := 'markdown',
+  p_tags  := ARRAY['vitana_system','vitana-index','index-book','agents','pillar-agents','maxina'],
+  p_content := $CONTENT$
+# Your five agents
+
+Five specialised agents watch your Vitana Index on your behalf — one per
+pillar. They run inside the Vitana platform and keep your pillar
+scores honest, live, and rising as you engage with the 90-day journey.
+
+## The five
+
+| Agent | Pillar it owns |
+|---|---|
+| **Pillar Agent — Nutrition** | Nutrition |
+| **Pillar Agent — Hydration** | Hydration |
+| **Pillar Agent — Exercise** | Exercise |
+| **Pillar Agent — Sleep** | Sleep |
+| **Pillar Agent — Mental** | Mental |
+
+Each agent is an independent software module — visible in the admin
+"Agents Registry" dashboard with a live heartbeat — that does one
+thing well for its pillar. Over time, each agent grows its toolbelt
+(see "Integrations" below).
+
+## What each agent does today (v1)
+
+- Computes its pillar's four sub-scores (baseline / completions /
+  connected data / streak) from the data already in your Vitana
+  account.
+- Writes a per-day output record so you can see the sub-score breakdown
+  on the Index Detail Screen.
+- Heartbeats into the agent registry so the admin dashboard can monitor
+  health.
+
+In v1, the agents mirror the compute engine's math. The value of the
+framework is that future work — LLM enrichment, third-party
+integrations, personalised coaching per pillar — plugs in behind the
+agent boundary without changing the rest of the system.
+
+## What each agent will do next (v2 and beyond)
+
+Each agent has a planned integration roadmap. See the Agent Registry
+metadata (`integrations_planned`) for the canonical list.
+
+**Pillar Agent — Nutrition**
+- MyFitnessPal, Cronometer (food log imports)
+- Apple Health / Google Fit (Nutrition)
+- USDA FoodData + OpenFoodFacts (barcode / ingredient lookup)
+- Lab-report OCR (HbA1c, lipid panels, vitamin D)
+- LLM meal-photo analysis
+
+**Pillar Agent — Hydration**
+- HidrateSpark (smart bottles)
+- Apple Health (Water) / Google Fit (Hydration)
+- OpenWeatherMap (climate-adjusted daily targets)
+
+**Pillar Agent — Exercise**
+- Apple Health, Google Fit
+- Strava, Whoop, Oura, Garmin Connect, Fitbit, Polar
+- VO2-max estimation, zone-2 vs. HIIT detection
+
+**Pillar Agent — Sleep**
+- Oura, Whoop, Eight Sleep
+- Apple Sleep, Fitbit Sleep, Garmin Sleep
+- Personalised sleep-hygiene review
+
+**Pillar Agent — Mental**
+- Calm, Headspace (meditation logs)
+- Oura (readiness + HRV stress signals)
+- Apple Health (Mindful Minutes)
+- LLM journal analysis (with consent)
+
+## How to see them
+
+- Admin: **Agents Registry** page (`/admin` → Agents). Filter by tier
+  = `embedded` and role = `pillar-scoring` to see all five.
+- User: **Index Detail Screen** (`/health/vitana-index`) — a small
+  "Active agents" panel shows which pillars are being watched and
+  which integrations are currently connected for your account.
+
+## Connecting an integration (future)
+
+When you link a supported third-party app (e.g., Apple Health), the
+corresponding pillar agent begins to read that data source and its
+`connected_data` sub-score on that pillar fills in. You grant access
+per integration, per agent — nothing happens without your opt-in.
+
+## Why agents, not one big engine
+
+Splitting the work into five specialised agents has three effects:
+
+1. **Honest per-pillar signals.** The Exercise agent doesn't try to
+   also score Sleep. Each pillar's data world is distinct; the model
+   that serves one pillar well is not automatically right for another.
+2. **Independent evolution.** The Nutrition agent can ship an LLM
+   meal-photo parser without touching the Sleep or Mental agents.
+   Third-party integrations land as small, safe drops per agent.
+3. **Clear responsibility when something breaks.** If your Exercise
+   score isn't moving, one agent is the place to look — not a
+   monolithic compute engine.
+
+The Vitana Index is the integration of five agents, not a single
+mind. That matches how real health works.
+$CONTENT$
+);
+
+COMMIT;


### PR DESCRIPTION
First cut of the 5-pillar-agent architecture. One agent per Vitana pillar. Framework + agent boundary live; v1 agents mirror the compute RPC math; v2+ replaces each agent's internals with external integrations per pillar, independently.