### PR TITLE
feat(vitana-index): Phase F v2 step 9 — integrations framework + Manual Data Entry

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -293,6 +293,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const adminSystemKbRouter = require('./routes/admin-system-kb').default;
   // Phase F v1: 5 pillar agents (Nutrition/Hydration/Exercise/Sleep/Mental).
   const pillarAgentsRouter = require('./routes/pillar-agents').default;
+  // Phase F v2 step 9: per-user integrations + Manual Data Entry.
+  const integrationsRouter = require('./routes/integrations').default;
   // Overview Dashboard — KPI summary, at-risk, activity, alerts
   const tenantOverviewRouter = require('./routes/tenant-admin/overview').default;
   // BOOTSTRAP-ADMIN-KPI-AA: Admin KPI surface (real-time snapshot + history)
@@ -768,6 +770,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   mountRouterSync(app, '/api/v1/admin/system-kb', adminSystemKbRouter, { owner: 'admin-system-kb' });
   // Phase F v1: pillar agents framework
   mountRouterSync(app, '/api/v1/pillar-agents', pillarAgentsRouter, { owner: 'pillar-agents' });
+  // Phase F v2 step 9: per-user integrations (Manual Data Entry + catalog)
+  mountRouterSync(app, '/api/v1/integrations', integrationsRouter, { owner: 'integrations' });
   // Overview Dashboard — KPI summary, at-risk, activity, alerts
   mountRouterSync(app, '/api/v1/admin/tenants/:tenantId/overview', tenantOverviewRouter, { owner: 'tenant-overview' });
   // BOOTSTRAP-ADMIN-KPI-AA: Admin KPI surface

--- a/services/gateway/src/routes/integrations.ts
+++ b/services/gateway/src/routes/integrations.ts
@@ -1,0 +1,263 @@
+/**
+ * Integrations — per-user integration management + data ingestion.
+ *
+ * Mounted at /api/v1/integrations.
+ *
+ * Endpoints:
+ *   GET  /                      — list the authenticated user's integrations + their state
+ *   POST /:integration_id/connect    — mark an integration as connected
+ *   POST /:integration_id/disconnect — mark disconnected
+ *   POST /manual/log            — write a health data point (Manual Entry)
+ *                                 Body: { pillar, feature_key, value, unit?, date? }
+ *                                 After write, runs pillar agents for the user
+ *                                 so the connected_data sub-score reflects the
+ *                                 new signal within ~1s on the UI.
+ *
+ * RLS on user_integrations is owner-only (via auth.uid()); service-role
+ * admin client is used here so we can compose multi-step operations
+ * (write feature_row + run agents) in a single request.
+ */
+
+import { Router, Response } from 'express';
+import { requireAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
+import { getSupabase } from '../lib/supabase';
+import { runPillarAgentsForUser } from '../services/pillar-agents/orchestrator';
+
+const router = Router();
+
+// Every user automatically has the manual-entry integration available.
+const BUILTIN_MANUAL = {
+  integration_id: 'manual-entry',
+  status: 'connected',
+  display_name: 'Manual Data Entry',
+  description:
+    'Log data points directly from the Index Detail screen — water, exercise, sleep, meditation, meals.',
+};
+
+const VALID_PILLARS = ['nutrition', 'hydration', 'exercise', 'sleep', 'mental'] as const;
+type Pillar = typeof VALID_PILLARS[number];
+
+// Per-pillar allowed feature keys (matches base-agent.ts / compute RPC).
+const PILLAR_FEATURE_KEYS: Record<Pillar, string[]> = {
+  nutrition: ['biomarker_glucose', 'biomarker_hba1c', 'meal_log', 'macro_balance'],
+  hydration: ['water_intake', 'hydration_log'],
+  exercise:  ['wearable_heart_rate', 'wearable_steps', 'wearable_workout', 'vo2_max'],
+  sleep:     ['wearable_sleep_duration', 'wearable_sleep_efficiency', 'wearable_hrv', 'wearable_sleep_stages'],
+  mental:    ['wearable_stress', 'mood_entry', 'meditation_minutes', 'journal_entry'],
+};
+
+router.get('/', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const admin = getSupabase();
+  if (!admin) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+  const userId = req.identity?.user_id;
+  if (!userId) return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+
+  try {
+    const { data, error } = await admin
+      .from('user_integrations')
+      .select('integration_id, status, connected_at, disconnected_at, last_sync_at, last_error, metadata')
+      .eq('user_id', userId)
+      .order('integration_id', { ascending: true });
+    if (error) return res.status(400).json({ ok: false, error: error.message });
+
+    const rows = data ?? [];
+    const hasManual = rows.some(r => r.integration_id === 'manual-entry');
+    const integrations = hasManual
+      ? rows
+      : [
+          {
+            integration_id: BUILTIN_MANUAL.integration_id,
+            status: BUILTIN_MANUAL.status,
+            connected_at: new Date().toISOString(),
+            disconnected_at: null,
+            last_sync_at: null,
+            last_error: null,
+            metadata: { implicit: true, display_name: BUILTIN_MANUAL.display_name },
+          },
+          ...rows,
+        ];
+
+    return res.status(200).json({
+      ok: true,
+      user_id: userId,
+      integrations,
+      catalog: [
+        BUILTIN_MANUAL,
+        { integration_id: 'apple-health',  status: 'unavailable', display_name: 'Apple Health',  description: 'Requires a native mobile app (HealthKit). Roadmap.' },
+        { integration_id: 'oura',          status: 'unavailable', display_name: 'Oura Ring',     description: 'Requires native app or third-party aggregator. Roadmap.' },
+        { integration_id: 'whoop',         status: 'unavailable', display_name: 'Whoop',         description: 'Requires OAuth + aggregator. Roadmap.' },
+        { integration_id: 'myfitnesspal',  status: 'unavailable', display_name: 'MyFitnessPal',  description: 'Requires OAuth + export sync. Roadmap.' },
+        { integration_id: 'cronometer',    status: 'unavailable', display_name: 'Cronometer',    description: 'Requires OAuth + export sync. Roadmap.' },
+        { integration_id: 'calm',          status: 'unavailable', display_name: 'Calm',          description: 'Requires OAuth. Roadmap.' },
+        { integration_id: 'headspace',     status: 'unavailable', display_name: 'Headspace',     description: 'Requires OAuth. Roadmap.' },
+      ],
+    });
+  } catch (err: any) {
+    return res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+router.post('/:integration_id/connect', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const admin = getSupabase();
+  if (!admin) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+  const userId = req.identity?.user_id;
+  if (!userId) return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+  const integrationId = req.params.integration_id;
+
+  try {
+    const { data, error } = await admin
+      .from('user_integrations')
+      .upsert(
+        {
+          user_id: userId,
+          integration_id: integrationId,
+          status: 'connected',
+          connected_at: new Date().toISOString(),
+          disconnected_at: null,
+          last_error: null,
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'user_id,integration_id' }
+      )
+      .select()
+      .single();
+    if (error) return res.status(400).json({ ok: false, error: error.message });
+    return res.status(200).json({ ok: true, integration: data });
+  } catch (err: any) {
+    return res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+router.post('/:integration_id/disconnect', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const admin = getSupabase();
+  if (!admin) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+  const userId = req.identity?.user_id;
+  if (!userId) return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+  const integrationId = req.params.integration_id;
+
+  try {
+    const { data, error } = await admin
+      .from('user_integrations')
+      .upsert(
+        {
+          user_id: userId,
+          integration_id: integrationId,
+          status: 'disconnected',
+          disconnected_at: new Date().toISOString(),
+          updated_at: new Date().toISOString(),
+        },
+        { onConflict: 'user_id,integration_id' }
+      )
+      .select()
+      .single();
+    if (error) return res.status(400).json({ ok: false, error: error.message });
+    return res.status(200).json({ ok: true, integration: data });
+  } catch (err: any) {
+    return res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+router.post('/manual/log', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const admin = getSupabase();
+  if (!admin) return res.status(503).json({ ok: false, error: 'DB_UNAVAILABLE' });
+  const userId = req.identity?.user_id;
+  if (!userId) return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+
+  const body = req.body ?? {};
+  const pillar = (body.pillar as string | undefined)?.trim() as Pillar | undefined;
+  const featureKey = (body.feature_key as string | undefined)?.trim();
+  const value = Number(body.value);
+  const unit = (body.unit as string | undefined)?.trim() ?? null;
+  const date = (body.date as string | undefined)?.trim() || new Date().toISOString().slice(0, 10);
+
+  if (!pillar || !VALID_PILLARS.includes(pillar)) {
+    return res.status(400).json({ ok: false, error: 'INVALID_PILLAR', message: `pillar must be one of ${VALID_PILLARS.join(', ')}` });
+  }
+  if (!featureKey || !PILLAR_FEATURE_KEYS[pillar].includes(featureKey)) {
+    return res.status(400).json({
+      ok: false,
+      error: 'INVALID_FEATURE_KEY',
+      message: `feature_key for ${pillar} must be one of ${PILLAR_FEATURE_KEYS[pillar].join(', ')}`,
+    });
+  }
+  if (!Number.isFinite(value)) {
+    return res.status(400).json({ ok: false, error: 'INVALID_VALUE' });
+  }
+
+  try {
+    // Resolve tenant via user_tenants fallback (same pattern as baseline survey).
+    let tenantId: string | null = null;
+    const { data: tenantRow } = await admin
+      .from('user_tenants')
+      .select('tenant_id')
+      .eq('user_id', userId)
+      .limit(1)
+      .maybeSingle();
+    tenantId = (tenantRow?.tenant_id as string | undefined) ?? null;
+    const effectiveTenantId = tenantId ?? '00000000-0000-0000-0000-000000000000';
+
+    // Upsert the feature row.
+    const { error: featErr } = await admin
+      .from('health_features_daily')
+      .upsert({
+        tenant_id: effectiveTenantId,
+        user_id: userId,
+        date,
+        feature_key: featureKey,
+        feature_value: value,
+        feature_unit: unit,
+        sample_count: 1,
+        confidence: 0.8,
+      }, { onConflict: 'tenant_id,user_id,date,feature_key' });
+    if (featErr) {
+      return res.status(400).json({ ok: false, error: 'FEATURE_WRITE_FAILED', detail: featErr.message });
+    }
+
+    // Mark the manual-entry integration as connected + bump last_sync_at.
+    await admin
+      .from('user_integrations')
+      .upsert({
+        user_id: userId,
+        integration_id: 'manual-entry',
+        status: 'connected',
+        connected_at: new Date().toISOString(),
+        last_sync_at: new Date().toISOString(),
+        metadata: { source: 'manual_log' },
+        updated_at: new Date().toISOString(),
+      }, { onConflict: 'user_id,integration_id' });
+
+    // Re-run pillar agents so the connected_data sub-score reflects the new signal.
+    const orchestratorResult = await runPillarAgentsForUser(admin, userId, date);
+
+    return res.status(200).json({
+      ok: true,
+      pillar,
+      feature_key: featureKey,
+      date,
+      orchestrator: {
+        agents_run: orchestratorResult.agents_run,
+        agents_failed: orchestratorResult.agents_failed,
+        per_pillar_subscores: Object.fromEntries(
+          Object.entries(orchestratorResult.per_pillar).map(([k, v]) => [k, v?.subscores])
+        ),
+      },
+    });
+  } catch (err: any) {
+    return res.status(500).json({ ok: false, error: err.message });
+  }
+});
+
+router.get('/health', (_req, res: Response) => {
+  res.status(200).json({
+    ok: true,
+    service: 'integrations',
+    endpoints: [
+      'GET    /api/v1/integrations',
+      'POST   /api/v1/integrations/:integration_id/connect',
+      'POST   /api/v1/integrations/:integration_id/disconnect',
+      'POST   /api/v1/integrations/manual/log',
+    ],
+  });
+});
+
+export default router;

--- a/supabase/migrations/20260423200000_vitana_integrations_v1.sql
+++ b/supabase/migrations/20260423200000_vitana_integrations_v1.sql
@@ -1,0 +1,177 @@
+-- =============================================================================
+-- Vitana integrations — v1 framework + Manual Data Entry as the first source
+-- Date: 2026-04-23
+-- Plan: .claude/plans/community-user-role-make-purring-pascal.md (step 9, Phase F v2+)
+--
+-- Every user's integrations state lives in user_integrations. The first
+-- shipped integration is "manual-entry" — a direct UI path to write data
+-- points into health_features_daily per pillar. Its purpose:
+--   a) exercise the full Index pipeline end-to-end (user → features →
+--      pillar-agent connected_data sub-score → Index) without requiring
+--      a native mobile app
+--   b) serve as the canonical endpoint shape that future third-party
+--      integrations (Apple Health, Oura, Whoop, MyFitnessPal) plug into
+--      identically
+--
+-- Native HealthKit / wearable sync requires either a real iOS app or a
+-- third-party aggregator (Validic, Terra, Rook). Those are out of scope
+-- for the WebView-only app today and are captured as roadmap.
+--
+-- Idempotent: CREATE TABLE IF NOT EXISTS, ON CONFLICT DO UPDATE,
+-- upsert_knowledge_doc.
+-- =============================================================================
+
+BEGIN;
+
+-- -----------------------------------------------------------------------------
+-- 1. user_integrations — per-user state for each integration source.
+--
+-- There is one system-wide row in a separate catalog table (integrations)
+-- for each integration definition, but for v1 we keep things simple and
+-- let user_integrations rows reference an integration_id string directly
+-- (fk is logical, not enforced). Future migration can split into a proper
+-- catalog if the list grows.
+-- -----------------------------------------------------------------------------
+CREATE TABLE IF NOT EXISTS public.user_integrations (
+  id                uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id           uuid NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  integration_id    text NOT NULL,  -- e.g., 'manual-entry', 'apple-health', 'oura', 'whoop'
+  status            text NOT NULL DEFAULT 'connected'
+                    CHECK (status IN ('connected', 'disconnected', 'error', 'pending')),
+  connected_at      timestamptz NOT NULL DEFAULT now(),
+  disconnected_at   timestamptz,
+  last_sync_at      timestamptz,
+  last_error        text,
+  metadata          jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at        timestamptz NOT NULL DEFAULT now(),
+  updated_at        timestamptz NOT NULL DEFAULT now(),
+  CONSTRAINT user_integrations_unique UNIQUE (user_id, integration_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_integrations_user
+  ON public.user_integrations (user_id, status);
+CREATE INDEX IF NOT EXISTS idx_user_integrations_integration
+  ON public.user_integrations (integration_id, status);
+
+ALTER TABLE public.user_integrations ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS user_integrations_owner_all ON public.user_integrations;
+CREATE POLICY user_integrations_owner_all
+  ON public.user_integrations FOR ALL
+  USING (user_id = auth.uid())
+  WITH CHECK (user_id = auth.uid());
+
+COMMENT ON TABLE public.user_integrations IS
+  'Per-user state of each integration source (manual-entry, apple-health, oura, whoop, mfp, etc.). RLS: owner-only read/write; service_role bypasses for server-side ingestion.';
+
+-- -----------------------------------------------------------------------------
+-- 2. Ensure health_features_daily tolerates ad-hoc feature_key values that
+-- the Manual Entry integration might use. Our compute RPC already queries
+-- by ANY(ARRAY[...]) so unknown keys are ignored gracefully — no schema
+-- change needed. The UNIQUE (tenant_id, user_id, date, feature_key) gives
+-- upsert semantics per pillar per day.
+-- -----------------------------------------------------------------------------
+-- (no-op; declarative note only)
+
+-- -----------------------------------------------------------------------------
+-- 3. Book of the Vitana Index — chapter 11: Connecting data sources.
+-- -----------------------------------------------------------------------------
+SELECT public.upsert_knowledge_doc(
+  p_title := 'Book of the Vitana Index — Connecting data sources',
+  p_path  := 'kb/vitana-system/index-book/11-connecting-data-sources.md',
+  p_source_type := 'markdown',
+  p_tags  := ARRAY['vitana_system','vitana-index','index-book','integrations','data-sources','maxina'],
+  p_content := $CONTENT$
+# Connecting data sources
+
+Your Vitana Index is only as rich as the data it sees. The Connected
+Data sub-score on each pillar (max 40 per pillar) fills in when real
+signals flow into your account — wearables, food logs, lab results,
+meditation apps, and so on.
+
+Each pillar agent watches for its own pillar-specific feature keys. The
+more sources connect, the higher that pillar's `connected_data` bar
+climbs.
+
+## What's connected today
+
+### Manual Data Entry
+Connected for every user by default. Lets you log data points directly
+from the Index Detail Screen:
+
+- Water intake (Hydration)
+- Exercise minutes or workouts (Exercise)
+- Sleep hours (Sleep)
+- Meditation minutes (Mental)
+- Meal entries, glucose readings (Nutrition)
+
+Each log writes into `health_features_daily`. The pillar agents
+re-compute and the corresponding Connected Data segment on that pillar
+grows.
+
+## What's on the roadmap
+
+Integrations planned per pillar (from each agent's
+`integrations_planned` metadata in the Agents Registry):
+
+### Nutrition
+- Apple Health (Nutrition)
+- Google Fit (Nutrition)
+- MyFitnessPal
+- Cronometer
+- Lab-report OCR (HbA1c, lipid panels, vitamin D)
+- USDA FoodData + OpenFoodFacts (barcode lookup)
+
+### Hydration
+- HidrateSpark smart bottles
+- Apple Health (Water)
+- Google Fit (Hydration)
+- OpenWeatherMap (climate-adjusted daily targets)
+
+### Exercise
+- Apple Health, Google Fit
+- Strava, Whoop, Oura, Garmin Connect, Fitbit, Polar
+
+### Sleep
+- Oura, Whoop, Eight Sleep
+- Apple Sleep, Fitbit Sleep, Garmin Sleep
+
+### Mental
+- Calm, Headspace
+- Oura (readiness + HRV stress)
+- Apple Health (Mindful Minutes)
+
+## How an integration connects
+
+1. You tap **Connect** on the Connected Sources panel.
+2. You grant permission to the source (OAuth for third parties, or a
+   confirmation for manual entry).
+3. Vitana writes a row to `user_integrations` with status
+   `connected` and starts listening for data.
+4. As data arrives, the relevant pillar agent(s) ingest it and the
+   Connected Data segment of that pillar grows. The Balance chip keeps
+   your pillars honest.
+
+## Why native mobile matters for the big list
+
+Apple Health, Oura, Whoop and most wearables require native iOS or
+Android access to read your health data. The current Vitana app is a
+WebView wrapper which cannot read HealthKit. Two paths unlock them:
+
+1. **Native mobile app** — a real iOS/Android app with HealthKit /
+   Health Connect permissions. Biggest effort, most reliable.
+2. **Third-party aggregator** — Validic, Terra, Rook. You grant them
+   access once; they sync every wearable. Ships faster but adds a
+   partner dependency.
+
+Either path posts the same shape into Vitana's `/api/v1/integrations/:source/ingest`
+endpoint, so the backend doesn't change — only the source of the
+stream does.
+
+## See also
+- [Your five agents](kb/vitana-system/index-book/10-your-five-agents.md)
+- [Reading your number](kb/vitana-system/index-book/08-reading-your-number.md)
+$CONTENT$
+);
+
+COMMIT;


### PR DESCRIPTION
user_integrations table + /api/v1/integrations routes (list, connect/disconnect, manual/log). Manual Data Entry is the first shipped integration — writes to health_features_daily and re-runs the 5 pillar agents so connected_data sub-score moves within ~1s. KB chapter 11 explains the roadmap. Native Apple Health / wearable sync (native iOS or third-party aggregator like Validic/Terra/Rook) stays as roadmap in the chapter.