### PR TITLE
fix(integrations): /manual/log recomputes canonical Vitana Index

### DIFF
--- a/services/gateway/src/routes/integrations.ts
+++ b/services/gateway/src/routes/integrations.ts
@@ -226,8 +226,18 @@ router.post('/manual/log', requireAuth, async (req: AuthenticatedRequest, res: R
         updated_at: new Date().toISOString(),
       }, { onConflict: 'user_id,integration_id' });
 
-    // Re-run pillar agents so the connected_data sub-score reflects the new signal.
+    // Re-run pillar agents so the per-agent connected_data sub-score reflects the new signal.
     const orchestratorResult = await runPillarAgentsForUser(admin, userId, date);
+
+    // Recompute the canonical Index row so vitana_index_scores (and the header badge)
+    // picks up the new feature value. Agents write to vitana_pillar_agent_outputs;
+    // the main Index total lives in vitana_index_scores and is only refreshed by
+    // health_compute_vitana_index_for_user. Without this call the badge stays flat
+    // after a manual log even though the agents panel updates.
+    const { data: recomputedRow, error: recomputeErr } = await admin.rpc(
+      'health_compute_vitana_index_for_user',
+      { p_user_id: userId, p_date: date }
+    );
 
     return res.status(200).json({
       ok: true,
@@ -241,6 +251,9 @@ router.post('/manual/log', requireAuth, async (req: AuthenticatedRequest, res: R
           Object.entries(orchestratorResult.per_pillar).map(([k, v]) => [k, v?.subscores])
         ),
       },
+      index: recomputeErr
+        ? { ok: false, error: recomputeErr.message }
+        : { ok: true, row: recomputedRow },
     });
   } catch (err: any) {
     return res.status(500).json({ ok: false, error: err.message });


### PR DESCRIPTION
## Summary
- Step 9 verification surfaced a last-mile defect: manual data entries updated vitana_pillar_agent_outputs (Active Agents panel moved) but vitana_index_scores stayed flat, so the header badge did not reflect logged data.
- Root cause: POST /api/v1/integrations/manual/log only ran the pillar agents. The canonical Index total lives in vitana_index_scores and is refreshed only by the RPC health_compute_vitana_index_for_user.
- Fix: after the agents run, call health_compute_vitana_index_for_user(p_user_id, p_date) and return the recomputed row in the response so the frontend can invalidate ['vitana_index'] and the badge climbs in step with the data sub-score.

## Verification
- Deploy to Cloud Run via EXEC-DEPLOY.yml
- POST /api/v1/integrations/manual/log with {pillar:exercise, feature_key:wearable_steps, value:6000} then read vitana_index_scores for today — score_exercise and score_total climb in lockstep
- One entry per pillar → score_total climbs from 125 to ~200

BOOTSTRAP-VITANA-INTEGRATIONS-V1 (step 9 last-mile)

🤖 Generated with [Claude Code](https://claude.com/claude-code)