### PR TITLE
fix(orb): role-gate DB-backed catalog scorer (BOOTSTRAP-ORB-NAV-DB-ROLE-GATE)

### DIFF
--- a/services/gateway/src/lib/nav-catalog-db.ts
+++ b/services/gateway/src/lib/nav-catalog-db.ts
@@ -28,7 +28,7 @@
  */
 
 import type { NavCatalogEntry, LangCode, NavCategory } from './navigation-catalog';
-import { NAVIGATION_CATALOG, getContent } from './navigation-catalog';
+import { NAVIGATION_CATALOG, getContent, resolveEffectiveRoles } from './navigation-catalog';
 import { getSupabase } from './supabase';
 
 // =============================================================================
@@ -438,6 +438,7 @@ export interface ScorerOptions {
   category?: NavCategory;
   anonymous_only?: boolean;
   exclude_routes?: string[];
+  role?: string;
 }
 
 /**
@@ -468,6 +469,11 @@ export function searchCatalogEntries(
     if (opts.category && entry.category !== opts.category) continue;
     if (opts.anonymous_only && !entry.anonymous_safe) continue;
     if (excluded.has(entry.route)) continue;
+    // Surface scoping: authenticated callers may only see entries on their
+    // surface. Anonymous callers skip the role gate — anonymous_safe carries
+    // the access decision for them. See navigation-catalog.ts for the same
+    // gate on the static scorer (they must stay in sync).
+    if (opts.role && !resolveEffectiveRoles(entry).includes(opts.role)) continue;
 
     const content = getContent(entry, lang);
     const titleLower = content.title.toLowerCase();

--- a/services/gateway/src/services/navigator-consult.ts
+++ b/services/gateway/src/services/navigator-consult.ts
@@ -322,7 +322,11 @@ function scoreCatalogWithMemory(
           getCatalogForTenant(tenantId) as ReadonlyArray<NavCatalogEntry>,
           input.question,
           input.lang,
-          { anonymous_only: input.is_anonymous, exclude_routes: excludeRoutes }
+          {
+            anonymous_only: input.is_anonymous,
+            exclude_routes: excludeRoutes,
+            role: input.identity?.role || undefined,
+          }
         )
       : searchCatalog(input.question, input.lang, {
           anonymous_only: input.is_anonymous,


### PR DESCRIPTION
## Summary
Follow-up to #867. That PR closed the static-catalog and semantic code paths, but the production Navigator runs `searchCatalogEntries` against the tenant-scoped DB cache (`isNavCatalogLoaded() → true`) and that scorer never received a `role`. Result: mobile community user saying "open the screen with the connectors" still got `DEVHUB.INTEGRATIONS.MCP → /command-hub/...` and the community app 404'd.

## Changes
- `nav-catalog-db.ts`: `ScorerOptions` gains `role?`; `searchCatalogEntries` applies the same `resolveEffectiveRoles(entry)` surface gate `searchCatalog` uses.
- `navigator-consult.ts`: pass `role: input.identity?.role` to the DB scorer, not just to the static fallback.

## Verification (local scoring dump)
| Query | Role | Top match |
|---|---|---|
| "open connectors screen" | community | AUTH.GENERIC (9) — below MEDIUM → clarification |
| "open connectors screen" | developer | DEVHUB.INTEGRATIONS.MCP (Command Hub) |
| "open my health screen"  | community | HEALTH.OVERVIEW → /health |

## Test plan
- [x] 121/121 jest navigator tests pass, tsc clean
- [ ] Post-deploy: on mobile (community) say "open the screen with the connectors" → no 404, Vitana asks for clarification

🤖 Generated with [Claude Code](https://claude.com/claude-code)