### PR TITLE
feat(autopilot): expose contribution_vector on recommendations API

### DIFF
--- a/services/gateway/src/routes/autopilot-recommendations.ts
+++ b/services/gateway/src/routes/autopilot-recommendations.ts
@@ -166,7 +166,7 @@ async function queryRecommendationsByRole(
     return { ok: false, error: 'Missing Supabase credentials' };
   }
 
-  const select = 'id,title,summary,domain,risk_level,impact_score,effort_score,status,activated_vtid,created_at,activated_at,time_estimate_seconds,source_ref';
+  const select = 'id,title,summary,domain,risk_level,impact_score,effort_score,status,activated_vtid,created_at,activated_at,time_estimate_seconds,source_ref,contribution_vector';
   const params = new URLSearchParams();
   params.set('select', select);
   params.set('status', `in.(${statuses.join(',')})`);
@@ -230,7 +230,7 @@ async function queryRecommendationsFallback(
     return { ok: false, error: 'Missing Supabase credentials' };
   }
 
-  const select = 'id,title,summary,domain,risk_level,impact_score,effort_score,status,activated_vtid,created_at,activated_at,time_estimate_seconds,source_ref,source_type,user_id';
+  const select = 'id,title,summary,domain,risk_level,impact_score,effort_score,status,activated_vtid,created_at,activated_at,time_estimate_seconds,source_ref,source_type,user_id,contribution_vector';
   const params = new URLSearchParams();
   params.set('select', select);
   params.set('status', `in.(${statuses.join(',')})`);


### PR DESCRIPTION
## Summary
- Phase B3 needs the frontend to render pillar-impact pills (\`[Sleep +4] [Mental +2]\`) on every Autopilot card.
- The \`autopilot_recommendations.contribution_vector\` JSONB column already exists and is populated by the BEFORE INSERT trigger from the step-4 migration, but the PostgREST \`select\` strings in this route didn't include it, so the field never reached the client.
- Adding \`contribution_vector\` to both select lists.

## Test plan
- \`curl GET /api/v1/autopilot/recommendations?role=community\` returns \`contribution_vector\` on each record
- Frontend PR exafyltd/vitana-v1#231 renders the pills

BOOTSTRAP-VITANA-INDEX-PHASE-BC

🤖 Generated with [Claude Code](https://claude.com/claude-code)