### PR TITLE
fix(orb): exclude auth/public from Navigator for authenticated users (BOOTSTRAP-ORB-NAV-AUTH-LEAK)

### DIFF
--- a/services/gateway/src/lib/nav-catalog-db.ts
+++ b/services/gateway/src/lib/nav-catalog-db.ts
@@ -469,6 +469,9 @@ export function searchCatalogEntries(
     if (opts.category && entry.category !== opts.category) continue;
     if (opts.anonymous_only && !entry.anonymous_safe) continue;
     if (excluded.has(entry.route)) continue;
+    // Auth / public category entries are sign-in screens and marketing landers —
+    // never the right destination for an authenticated user.
+    if (opts.role && (entry.category === 'auth' || entry.category === 'public')) continue;
     // Surface scoping: authenticated callers may only see entries on their
     // surface. Anonymous callers skip the role gate — anonymous_safe carries
     // the access decision for them. See navigation-catalog.ts for the same

--- a/services/gateway/src/lib/navigation-catalog.ts
+++ b/services/gateway/src/lib/navigation-catalog.ts
@@ -166,6 +166,12 @@ export async function semanticSearchCatalog(
       if (!entry.embedding) continue;
       if (opts.anonymous_only && !entry.anonymous_safe) continue;
       if (excluded.has(entry.route)) continue;
+      // Auth / public category entries are sign-in screens and marketing
+      // landers — never the right destination for an authenticated user. The
+      // semantic scorer otherwise matches "open the screen with the connectors"
+      // to AUTH.GENERIC ("Generic sign-in and sign-up screen") on the word
+      // "screen" and leaks the user out to /auth.
+      if (opts.role && (entry.category === 'auth' || entry.category === 'public')) continue;
       // Surface scoping: authenticated callers may only see entries on their
       // surface. Anonymous callers skip the role gate — anonymous_safe carries
       // the access decision for them.
@@ -1676,6 +1682,10 @@ export function searchCatalog(
     if (opts.category && entry.category !== opts.category) continue;
     if (opts.anonymous_only && !entry.anonymous_safe) continue;
     if (excluded.has(entry.route)) continue;
+    // Auth / public category entries are sign-in screens and marketing landers —
+    // never the right destination for an authenticated user. See the matching
+    // guard in semanticSearchCatalog above for the motivating case.
+    if (opts.role && (entry.category === 'auth' || entry.category === 'public')) continue;
     // Surface scoping: authenticated callers may only see entries on their
     // surface. Anonymous callers skip the role gate — anonymous_safe carries
     // the access decision for them.


### PR DESCRIPTION
## Summary
Follow-up to #867, #871. Mobile community user saying "open the screen with the connectors" was still getting a 404. After the surface-role gate, the semantic scorer's next-best match was AUTH.GENERIC — its description "Generic sign-in and sign-up screen" literally contains the word "screen" and outscored everything else. AUTH.GENERIC's route is \`/auth\`, which exists only as \`/auth/confirmed\` in the community React Router → NotFound.

## Fix
- Exclude `category='auth'` and `category='public'` entries from all three scorers (`searchCatalog`, `semanticSearchCatalog`, `searchCatalogEntries`) whenever the caller passes a role. These are sign-in / marketing landers — never the right destination for an authenticated user.
- Paired frontend PR: exafyltd/vitana-v1#fix/auth-redirect-maxina — redirects `/auth` → `/maxina` as a belt-and-suspenders safety net.

## Local sim (community role, "open connectors screen")
| | Primary |
|---|---|
| before | AUTH.GENERIC @ `/auth` → 404 |
| after  | HOME.OVERVIEW @ `/home` → renders |

## Test plan
- [x] 121/121 jest navigator tests pass, tsc clean
- [ ] Post-deploy: mobile "open connectors screen" → lands on Home (or gets clarification), no 404

🤖 Generated with [Claude Code](https://claude.com/claude-code)