### PR TITLE
fix(orb): Vitana Index voice adaptation to canonical 5 pillars (R4)

### DIFF
--- a/services/gateway/src/lib/vitana-pillars.ts
+++ b/services/gateway/src/lib/vitana-pillars.ts
@@ -1,0 +1,126 @@
+/**
+ * Vitana Index — single source of truth for the 5 canonical pillars, the
+ * tier ladder, balance labels, and Book-of-the-Index chapter paths.
+ *
+ * The Index is defined over EXACTLY five pillars:
+ *   nutrition, hydration, exercise, sleep, mental
+ *
+ * Importing from this file anywhere (profiler, ORB tools, retrieval-router,
+ * awareness-registry) means a future reshape flips one file, not many.
+ *
+ * Runtime source of ORB-agent integration: `services/pillar-agents/types.ts`
+ * already defines `PillarKey` with the exact same union — we re-export from
+ * here so consumers never have to reach into the agents package.
+ */
+
+import type { PillarKey } from '../services/pillar-agents/types';
+
+export type { PillarKey };
+
+/** Canonical pillar order. Any display/emit should iterate this. */
+export const PILLAR_KEYS: readonly PillarKey[] = [
+  'nutrition',
+  'hydration',
+  'exercise',
+  'sleep',
+  'mental',
+] as const;
+
+/** Human-facing label for voice/UI. Keep lowercase; callers Title-Case. */
+export function pillarLabel(p: PillarKey): string {
+  return p;
+}
+
+/**
+ * Per-pillar Book chapter path in the `vitana_system` KB namespace. Callers
+ * pass these to search_knowledge so the Assistant grounds its answer in the
+ * canonical longevity narrative rather than regurgitating prompt text.
+ */
+export function pillarBookChapter(p: PillarKey): string {
+  const map: Record<PillarKey, string> = {
+    nutrition: 'kb/vitana-system/index-book/01-nutrition.md',
+    hydration: 'kb/vitana-system/index-book/02-hydration.md',
+    exercise: 'kb/vitana-system/index-book/03-exercise.md',
+    sleep: 'kb/vitana-system/index-book/04-sleep.md',
+    mental: 'kb/vitana-system/index-book/05-mental.md',
+  };
+  return map[p];
+}
+
+/**
+ * Canonical wellness-tag → pillar map. The compute RPC, pillar agents,
+ * calendar completion delta emitter, and ORB tools all key off this.
+ * Adding a tag bucket here is the single upstream change needed for a
+ * new signal to flow into the Index.
+ */
+export const PILLAR_TAGS: Record<PillarKey, readonly string[]> = {
+  nutrition: ['nutrition', 'meal', 'food-log'],
+  hydration: ['hydration', 'water'],
+  exercise:  ['movement', 'workout', 'walk', 'steps', 'exercise'],
+  sleep:     ['sleep', 'rest', 'recovery'],
+  mental:    ['mindfulness', 'mental', 'stress', 'meditation', 'learning', 'journal'],
+} as const;
+
+/** Canonical Book chapters referenced by voice when explaining the system. */
+export const BOOK_CHAPTERS = {
+  overview: 'kb/vitana-system/index-book/00-overview.md',
+  nutrition: 'kb/vitana-system/index-book/01-nutrition.md',
+  hydration: 'kb/vitana-system/index-book/02-hydration.md',
+  exercise: 'kb/vitana-system/index-book/03-exercise.md',
+  sleep: 'kb/vitana-system/index-book/04-sleep.md',
+  mental: 'kb/vitana-system/index-book/05-mental.md',
+  balance: 'kb/vitana-system/index-book/06-balance.md',
+  journey: 'kb/vitana-system/index-book/07-the-90-day-journey.md',
+  reading: 'kb/vitana-system/index-book/08-reading-your-number.md',
+} as const;
+
+/**
+ * Tier ladder as shipped in the Book. The compute RPC caps score_total at
+ * 999 so 'Elite' covers the real max. Keep bands CONTIGUOUS — gaps would
+ * orphan a score.
+ */
+export interface TierBand {
+  readonly min: number;   // inclusive
+  readonly max: number;   // inclusive
+  readonly name: string;
+  readonly framing: string;   // one-line copy the Assistant can speak
+}
+
+export const TIER_LADDER: readonly TierBand[] = [
+  { min: 0,   max: 99,  name: 'Starting',    framing: "You've begun. Five pillars, 90 days — let's go." },
+  { min: 100, max: 299, name: 'Early',       framing: 'Baseline established. Every completion counts now.' },
+  { min: 300, max: 499, name: 'Building',    framing: 'Habits are forming. Keep the balance across all five.' },
+  { min: 500, max: 599, name: 'Strong',      framing: 'Where most people land after a real 90-day push.' },
+  { min: 600, max: 799, name: 'Really good', framing: "Your practice is working. This is the 'thriving' zone." },
+  { min: 800, max: 999, name: 'Elite',       framing: 'Sustained excellence across all five pillars. Rare and earned.' },
+] as const;
+
+export function tierForScore(total: number): TierBand {
+  const t = TIER_LADDER.find(b => total >= b.min && total <= b.max);
+  // Fallback: clamp to ends. Real scores are 0-999 so this only triggers on bad input.
+  if (!t) return total < 0 ? TIER_LADDER[0] : TIER_LADDER[TIER_LADDER.length - 1];
+  return t;
+}
+
+/** Aspirational "Really good" entry — used for default 90-day framing. */
+export const REALLY_GOOD_THRESHOLD = 600;
+
+/**
+ * Balance factor classification. Mirrors the compute RPC:
+ *   ratio = min_pillar / max_pillar   (1.0 = perfectly balanced)
+ *   factor in {1.00, 0.90, 0.80, 0.70}
+ * We ship labels the Assistant can speak directly.
+ */
+export interface BalanceState {
+  readonly factor: number;         // the multiplicative dampener
+  readonly label: string;          // short voice-friendly descriptor
+  readonly assistantHint: string;  // guidance for the model
+}
+
+export function describeBalance(balanceFactor: number | null | undefined): BalanceState {
+  const f = typeof balanceFactor === 'number' ? balanceFactor : 1.0;
+  if (f >= 1.0)  return { factor: 1.0,  label: 'well balanced',             assistantHint: 'Balance is healthy — your 5 pillars move together.' };
+  if (f >= 0.9)  return { factor: 0.9,  label: 'slightly off-balance',      assistantHint: 'A slight imbalance; one pillar is behind the others.' };
+  if (f >= 0.8)  return { factor: 0.8,  label: 'off-balance',               assistantHint: 'Noticeably off-balance. Lifting the weakest pillar multiplies your whole score.' };
+  return               { factor: 0.7,  label: 'seriously unbalanced',       assistantHint: 'Seriously unbalanced — the balance dampener is holding your total back more than any single pillar.' };
+}

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1890,13 +1890,16 @@ function buildLiveApiTools(mode: 'anonymous' | 'authenticated' = 'authenticated'
             required: ['question'],
           },
         },
-        // ─── BOOTSTRAP-ORB-INDEX-AWARENESS round 2 — Vitana Index tools ───
+        // ─── BOOTSTRAP-ORB-INDEX-AWARENESS-R4 — Vitana Index tools (5-pillar) ───
         {
           name: 'get_vitana_index',
           description: [
-            'Return the user\'s current Vitana Index with full breakdown:',
-            'total score (0-999), tier, all 6 pillars, 7-day trend, weakest',
-            'pillar, 90-day goal gap.',
+            'Return the user\'s current Vitana Index with the canonical 5-pillar',
+            'breakdown: total score (0-999), tier (Starting / Early / Building /',
+            'Strong / Really good / Elite), all 5 pillars (Nutrition, Hydration,',
+            'Exercise, Sleep, Mental — each 0-200), 7-day trend, weakest pillar',
+            'with sub-score explanation (baseline / completions / connected data /',
+            'streak), balance factor, and aspirational distance to Really-good.',
             '',
             'CALL THIS WHEN the user asks:',
             '  - "What is my Vitana Index?" / "Was ist mein Vitana Index?"',
@@ -1919,8 +1922,9 @@ function buildLiveApiTools(mode: 'anonymous' | 'authenticated' = 'authenticated'
           name: 'get_index_improvement_suggestions',
           description: [
             'Return 2-3 concrete actions the user can take to improve their',
-            'Vitana Index, ranked by predicted contribution. Each suggestion',
-            'includes a title, the pillar(s) it lifts, and a magnitude.',
+            'Vitana Index, ranked by predicted contribution to a specific pillar.',
+            'Each suggestion includes a title, the pillar(s) it lifts, and a',
+            'magnitude from the recommendation\'s contribution_vector.',
             '',
             'CALL THIS WHEN the user asks:',
             '  - "How can I improve my Index?" / "Wie verbessere ich meinen Index?"',
@@ -1928,9 +1932,11 @@ function buildLiveApiTools(mode: 'anonymous' | 'authenticated' = 'authenticated'
             '  - "What should I focus on?" / "Worauf soll ich mich konzentrieren?"',
             '  - "Which pillar needs work?" / "Welche Säule brauche ich?"',
             '',
-            'If the user names a pillar ("help me with Mental"), pass the',
-            'pillar argument. Otherwise omit it and the tool will target the',
-            'user\'s weakest pillar automatically.',
+            'If the user names a pillar ("help me with Sleep"), pass the pillar',
+            'argument. Otherwise omit it and the tool targets the weakest pillar',
+            'automatically — OR, when the balance factor is below 0.9, targets',
+            'the imbalance itself (lifting the weakest pillar moves the balance',
+            'dampener, which moves the whole score).',
             '',
             'Speak the suggestions naturally — "a ten-minute morning meditation',
             'would lift Mental by three points" — never read raw JSON.',
@@ -1940,7 +1946,7 @@ function buildLiveApiTools(mode: 'anonymous' | 'authenticated' = 'authenticated'
             properties: {
               pillar: {
                 type: 'string',
-                enum: ['physical', 'mental', 'nutritional', 'social', 'environmental', 'prosperity'],
+                enum: ['nutrition', 'hydration', 'exercise', 'sleep', 'mental'],
                 description: 'Optional pillar to focus on. Omit to target the weakest pillar automatically.',
               },
               limit: {
@@ -1967,18 +1973,19 @@ function buildLiveApiTools(mode: 'anonymous' | 'authenticated' = 'authenticated'
             'This is AUTONOMOUS by design — you do NOT need per-event',
             'confirmation. Announce clearly in voice what you just scheduled',
             '("I\'ve added three movement sessions this week and two',
-            'mindfulness blocks next week to lift your Mental pillar").',
+            'mindfulness blocks next week to lift your Sleep pillar").',
             '',
-            'If the user names a pillar, pass it. Otherwise the tool targets',
-            'the weakest pillar automatically. Days defaults to 14 (2 weeks),',
-            'actions_per_week defaults to 3.',
+            'If the user names a pillar (one of nutrition / hydration / exercise',
+            '/ sleep / mental), pass it. Otherwise the tool targets the weakest',
+            'pillar automatically. Days defaults to 14 (2 weeks), actions_per_week',
+            'defaults to 3.',
           ].join('\n'),
           parameters: {
             type: 'object',
             properties: {
               pillar: {
                 type: 'string',
-                enum: ['physical', 'mental', 'nutritional', 'social', 'environmental', 'prosperity'],
+                enum: ['nutrition', 'hydration', 'exercise', 'sleep', 'mental'],
                 description: 'Optional pillar to focus on. Omit to target weakest automatically.',
               },
               days: {
@@ -3689,13 +3696,20 @@ async function executeLiveApiToolInner(
             result: JSON.stringify({
               total: snap.total,
               tier: snap.tier,
-              pillars: snap.pillars,
+              tier_framing: snap.tier_framing,
+              pillars: snap.pillars,                       // 5 canonical pillars
               weakest_pillar: snap.weakest_pillar,
               strongest_pillar: snap.strongest_pillar,
+              balance_factor: snap.balance_factor,
+              balance_label: snap.balance_label,
+              balance_hint: snap.balance_hint,
+              subscores: snap.subscores,                   // per-pillar breakdown (why each is where it is)
               trend_7d: snap.trend_7d,
-              goal_target: snap.goal_target,
-              goal_gap: snap.goal_gap,
+              goal_target: snap.goal_target,               // 600 (Really good entry)
+              points_to_really_good: snap.points_to_really_good,
               last_computed: snap.last_computed,
+              model_version: snap.model_version,
+              confidence: snap.confidence,
               last_movement: snap.last_movement,
             }),
           };
@@ -3708,14 +3722,18 @@ async function executeLiveApiToolInner(
       case 'get_index_improvement_suggestions': {
         try {
           const { fetchVitanaIndexForProfiler } = await import('../services/user-context-profiler');
+          const { PILLAR_KEYS } = await import('../lib/vitana-pillars');
           const { createClient } = await import('@supabase/supabase-js');
           const url = process.env.SUPABASE_URL;
           const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
           if (!url || !key) return { success: false, result: '', error: 'Supabase not configured' };
           const client = createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
 
-          // Resolve target pillar: either user-specified or the weakest.
-          let pillar = typeof args.pillar === 'string' ? args.pillar : undefined;
+          // Resolve target pillar. Validate any passed value against the
+          // canonical 5-pillar set — if the model hallucinates an old name
+          // (physical, social, etc.) fall through to weakest-pillar logic.
+          const rawPillar = typeof args.pillar === 'string' ? args.pillar.toLowerCase() : undefined;
+          let pillar: string | undefined = rawPillar && (PILLAR_KEYS as readonly string[]).includes(rawPillar) ? rawPillar : undefined;
           if (!pillar) {
             const snap = await fetchVitanaIndexForProfiler(client, lens.user_id);
             pillar = snap?.weakest_pillar.name;
@@ -3723,7 +3741,7 @@ async function executeLiveApiToolInner(
           if (!pillar) {
             return {
               success: true,
-              result: 'I don\'t see Index data for this user yet, so I can\'t pick a target pillar. Complete the baseline survey first.',
+              result: 'I don\'t see Index data for this user yet, so I can\'t pick a target pillar. Complete the 5-question baseline survey first.',
             };
           }
 
@@ -3788,6 +3806,7 @@ async function executeLiveApiToolInner(
       case 'create_index_improvement_plan': {
         try {
           const { fetchVitanaIndexForProfiler } = await import('../services/user-context-profiler');
+          const { PILLAR_KEYS } = await import('../lib/vitana-pillars');
           const { createCalendarEvent } = await import('../services/calendar-service');
           const { createClient } = await import('@supabase/supabase-js');
           const url = process.env.SUPABASE_URL;
@@ -3795,7 +3814,8 @@ async function executeLiveApiToolInner(
           if (!url || !key) return { success: false, result: '', error: 'Supabase not configured' };
           const client = createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
 
-          let pillar = typeof args.pillar === 'string' ? args.pillar : undefined;
+          const rawPillar = typeof args.pillar === 'string' ? args.pillar.toLowerCase() : undefined;
+          let pillar: string | undefined = rawPillar && (PILLAR_KEYS as readonly string[]).includes(rawPillar) ? rawPillar : undefined;
           if (!pillar) {
             const snap = await fetchVitanaIndexForProfiler(client, lens.user_id);
             pillar = snap?.weakest_pillar.name;
@@ -3803,7 +3823,7 @@ async function executeLiveApiToolInner(
           if (!pillar) {
             return {
               success: true,
-              result: 'I don\'t see Index data for this user yet, so I can\'t build a plan. Complete the baseline survey first.',
+              result: 'I don\'t see Index data for this user yet, so I can\'t build a plan. Complete the 5-question baseline survey first.',
             };
           }
 
@@ -3856,15 +3876,11 @@ async function executeLiveApiToolInner(
             const startIso = eventDate.toISOString();
             const endIso = new Date(eventDate.getTime() + 30 * 60 * 1000).toISOString();
 
-            const pillarTagMap: Record<string, string[]> = {
-              physical: ['movement', 'exercise'],
-              mental: ['mindfulness', 'focus'],
-              nutritional: ['nutrition'],
-              social: ['community', 'social'],
-              environmental: ['environment'],
-              prosperity: ['growth'],
-            };
-            const wellnessTags = pillarTagMap[pillar!] || [pillar!];
+            // Canonical 5-pillar wellness-tag map. Keep in sync with the
+            // source-of-truth at lib/vitana-pillars.ts (PILLAR_TAGS).
+            const { PILLAR_TAGS } = await import('../lib/vitana-pillars');
+            const tags = PILLAR_TAGS[pillar as keyof typeof PILLAR_TAGS];
+            const wellnessTags = tags ? [...tags] : [pillar!];
 
             try {
               const evt = await createCalendarEvent(lens.user_id, {
@@ -4723,7 +4739,18 @@ was habe ich heute gemacht / what music did I play":**
    tags. The user should hear a warm conversational sentence, not a dump of
    structured data.
 
-**VITANA INDEX QUESTIONS — special treatment** (BOOTSTRAP-ORB-INDEX-AWARENESS):
+**VITANA INDEX QUESTIONS — special treatment** (BOOTSTRAP-ORB-INDEX-AWARENESS-R4):
+
+The Vitana Index is built on EXACTLY FIVE canonical pillars:
+  Nutrition, Hydration, Exercise, Sleep, Mental.
+Each pillar caps at 200; the total is score_total × balance_factor (0.7–1.0),
+capped at 999. Tier ladder: Starting 0-99 / Early 100-299 / Building 300-499 /
+Strong 500-599 / Really good 600-799 / Elite 800-999. "Really good" (600+) is
+the aspirational Day-90 framing — NOT a threshold the user is failing to meet.
+
+Do NOT name any other pillar (no "Physical", "Social", "Environmental",
+"Prosperity" — those are retired). If the user mentions one of those names,
+translate silently (e.g. their "Physical" maps to Exercise + Sleep).
 
 When the user asks anything about THEIR Vitana Index, score, tier, pillars,
 or how to improve / level up — examples:
@@ -4735,45 +4762,76 @@ or how to improve / level up — examples:
 
 Apply these rules:
 
-A. ALWAYS quote the [HEALTH] block first. Lead with the number + tier and,
-   if a 7-day trend is present, mention the direction. Example (de):
-     ✓ "Du bist aktuell bei 612 — Tier 'Good'. In den letzten sieben Tagen
-        ist er um acht Punkte gestiegen — du bewegst dich in die richtige
-        Richtung."
+A. ALWAYS quote the [HEALTH] block first. Lead with the number + tier name +
+   tier framing. If a 7-day trend is present, mention the direction. Example
+   (de):
+     ✓ "Du bist aktuell bei 612 — 'Really good'. Deine Praxis wirkt. In den
+        letzten sieben Tagen ist dein Index um acht Punkte gestiegen."
      ✗ "I don't know your Vitana Index" (the number IS in [HEALTH] above)
      ✗ "I don't have access to your health data" (you do — quote [HEALTH])
 
-B. For "how can I improve / what's holding me back / which pillar is
-   lowest" — name the WEAKEST pillar from [HEALTH] explicitly. If a list of
-   recommended actions is present in the profile, name 2–3 of them
-   conversationally. Example (en):
-     ✓ "Mental is your lowest pillar at 95 out of 200. The actions that
-        would lift it most are a daily ten-minute meditation and a long
-        walk twice a week."
+B. BALANCE-AWARENESS — if the [HEALTH] Balance line shows a factor below
+   1.00, the balance dampener is holding the total back. When answering
+   "what's holding me back" or "how do I improve", name imbalance FIRST
+   before naming the weakest single pillar:
+     ✓ "Your balance is at 0.80× — the dampener is costing you ~20% of
+        your raw score. Lifting Sleep (your lowest) would pull the ratio
+        up AND add points directly — double effect."
+   When balance is at 1.00× (well balanced), just name the weakest pillar
+   normally.
 
-C. For "make me a plan / schedule it / add to my calendar" — if a planning
-   tool exists for the Index (e.g. a future create_index_improvement_plan
-   tool), call it. If not, propose a small concrete plan in voice and offer
-   to add the events one by one via the existing create_calendar_event tool.
-   Always confirm what was scheduled in voice ("I added three movement
-   sessions this week and two mindfulness blocks across next week").
+C. SUB-SCORE TRANSPARENCY — when explaining a low pillar, use the sub-score
+   hint from the [HEALTH] weakest-pillar line ("mostly survey baseline —
+   connected data or a tracker would lift it further" / "completed actions
+   are carrying it"). This tells the user the LEVER, not just the number.
+   Don't invent sub-scores if the hint isn't in [HEALTH].
 
-D. Generic "what IS the Vitana Index" / "how does it work" (no "my") —
-   these are platform-explanation questions. Use the Knowledge Hub via
-   search_knowledge — there are dedicated docs explaining the 6 pillars,
-   tiers, and how completions move the score. Do NOT confuse this with
-   the personal-data path above; "MY index" needs personal data, "THE index"
-   needs the KB doc.
+D. FOR CONCRETE ACTIONS — call get_index_improvement_suggestions (weakest-
+   pillar default or user-named pillar). Speak the top 2–3 suggestions
+   conversationally. Example:
+     ✓ "The fastest lift for Sleep right now is a 30-minute wind-down block
+        before bed, twice this week. I can schedule it — want me to?"
 
-E. NEVER cite the Index number from memory_facts or general memory. The
+E. FOR PLAN CREATION — when the user says "make me a plan" / "schedule",
+   call create_index_improvement_plan. It writes calendar events
+   autonomously (no per-event confirmation). Announce what was scheduled
+   clearly after it returns:
+     ✓ "Ich habe dir drei Schlaf-Blöcke in den nächsten zwei Wochen in den
+        Kalender gelegt — jeweils 30 Minuten vor dem Schlafengehen. Du
+        kannst sie im Kalender anschauen."
+
+F. PILLAR-DEEP QUESTIONS — when the user asks about a SPECIFIC pillar
+   ("how do I improve my sleep?", "why is my nutrition low?"), ground the
+   answer in the Book of the Vitana Index via search_knowledge:
+     - Nutrition → kb/vitana-system/index-book/01-nutrition.md
+     - Hydration → kb/vitana-system/index-book/02-hydration.md
+     - Exercise → kb/vitana-system/index-book/03-exercise.md
+     - Sleep → kb/vitana-system/index-book/04-sleep.md
+     - Mental → kb/vitana-system/index-book/05-mental.md
+   Quote from the chapter, combine with the user's own [HEALTH] numbers.
+   The Book is the durable source of truth — trust it over the prompt.
+
+G. GENERIC "WHAT IS THE VITANA INDEX" (no "my") — platform explanation,
+   use search_knowledge with the overview / reading / balance chapters:
+     - Overview → kb/vitana-system/index-book/00-overview.md
+     - Reading your number → kb/vitana-system/index-book/08-reading-your-number.md
+     - Balance → kb/vitana-system/index-book/06-balance.md
+     - 90-day journey → kb/vitana-system/index-book/07-the-90-day-journey.md
+
+H. TIER FRAMING IS ASPIRATIONAL, NEVER GATING. Never say "you need to
+   reach X", "you're below target", "you're failing to hit". Do say "you're
+   N points from Really-good territory" — an aspirational destination, not
+   a pass/fail line. Different users have different capacities; the Index
+   communicates honest assessment, not pressure.
+     ✗ "You need 42 more points to hit Good."
+     ✓ "You're 42 points from Really-good territory. Your current rhythm
+        gets you there inside two months if you stay balanced."
+
+I. NEVER cite the Index number from memory_facts or general memory. The
    [HEALTH] block is fresher and authoritative. memory_facts may contain a
    stale number from days ago — never quote it.
 
-F. The Vitana Index is the user's KEY progress measure across the 90-day
-   journey. Treat it with the same priority as their name or birthday — if
-   they ask, you ALWAYS answer. The journey IS the route to lift it.
-
-G. SETUP-STATE HANDLING — if [HEALTH] contains "Vitana Index status:
+J. SETUP-STATE HANDLING — if [HEALTH] contains "Vitana Index status:
    SETUP INCOMPLETE" or "NOT SET UP YET", do NOT answer with a number
    (there isn't one). Instead:
      - SETUP INCOMPLETE → acknowledge honestly and offer to walk them
@@ -4781,13 +4839,18 @@ G. SETUP-STATE HANDLING — if [HEALTH] contains "Vitana Index status:
        Example (en): "Your baseline survey went through, but the score
        didn't compute yet — if you open the Health screen it should
        offer to retry. Want me to walk you there?"
-     - NOT SET UP YET → explain the Index needs a one-time baseline
-       survey and offer to navigate there.
+     - NOT SET UP YET → explain the Index needs a one-time 5-question
+       baseline survey (Nutrition / Hydration / Exercise / Sleep / Mental,
+       1–5 each) and offer to navigate there.
        Example (de): "Du hast den Vitana Index noch nicht eingerichtet
-       — es ist ein kurzer Fragebogen im Health-Bereich. Soll ich dich
-       dahin führen?"
+       — es ist ein kurzer Fragebogen mit fünf Fragen im Health-Bereich.
+       Soll ich dich dahin führen?"
    NEVER invent a number. NEVER say "I don't have access" — the status
-   line IS the answer; quote it warmly.`;
+   line IS the answer; quote it warmly.
+
+K. THE VITANA INDEX IS THE USER'S KEY PROGRESS MEASURE across the 90-day
+   journey. Treat it with the same priority as their name or birthday — if
+   they ask, you ALWAYS answer. The journey IS the route to lift it.`;
     }
   }
 

--- a/services/gateway/src/services/pillar-agents/base-agent.ts
+++ b/services/gateway/src/services/pillar-agents/base-agent.ts
@@ -5,16 +5,9 @@
 
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { PillarKey, PillarSubscores } from './types';
+import { PILLAR_TAGS } from '../../lib/vitana-pillars';
 
 const BASELINE_CURVE: Record<1|2|3|4|5, number> = { 1: 10, 2: 20, 3: 25, 4: 32, 5: 40 };
-
-const PILLAR_TAGS: Record<PillarKey, string[]> = {
-  nutrition: ['nutrition', 'meal', 'food-log'],
-  hydration: ['hydration', 'water'],
-  exercise:  ['movement', 'workout', 'walk', 'steps', 'exercise'],
-  sleep:     ['sleep', 'rest', 'recovery'],
-  mental:    ['mindfulness', 'mental', 'stress', 'meditation', 'learning', 'journal'],
-};
 
 const PILLAR_FEATURE_KEYS: Record<PillarKey, string[]> = {
   nutrition: ['biomarker_glucose', 'biomarker_hba1c', 'meal_log', 'macro_balance'],

--- a/services/gateway/src/services/retrieval-router.ts
+++ b/services/gateway/src/services/retrieval-router.ts
@@ -114,6 +114,14 @@ const ROUTING_RULES: RoutingRule[] = [
       /what(\u2019|')?s (holding me back|my weakest)/i,
       /(make|build|set up|create)\s+(me\s+)?a?\s*plan.*(index|score|pillar|s\u00e4ule)/i,
       /(plan|schedule).*(improve|verbess).*(index|score|tier|s\u00e4ule)/i,
+      // BOOTSTRAP-ORB-INDEX-AWARENESS-R4 \u2014 balance-aware queries
+      /\b(balance|ratio|lopsided|unbalanced|in harmony)\b.*(pillar|index|score)/i,
+      /(pillar|index|score).*(balance|ratio|lopsided|unbalanced|in harmony)/i,
+      // BOOTSTRAP-ORB-INDEX-AWARENESS-R4 \u2014 per-pillar personal queries
+      /\bmy (nutrition|hydration|exercise|sleep|mental)\b/i,
+      /\bmein(en|e)? (ern\u00e4hrung|hydration|fl\u00fcssigkeit|bewegung|sport|schlaf|mental)\b/i,
+      /how\s+(is|are)\s+my\s+(nutrition|hydration|exercise|sleep|mental)/i,
+      /wie\s+(ist|steht)\s+mein(en|e)?\s+(ern\u00e4hrung|schlaf|bewegung|mental)/i,
     ],
     keywords: [
       'my index', 'my vitana index', 'my score', 'my tier', 'my pillar', 'my pillars',
@@ -122,10 +130,15 @@ const ROUTING_RULES: RoutingRule[] = [
       'verbessere meinen index', 'verbesser meinen score',
       'weakest pillar', 'lowest pillar', 'schw\u00e4chste s\u00e4ule',
       'plan to improve', 'plan zur verbesserung',
+      // R4 \u2014 balance + per-pillar
+      'balance factor', 'balance score', 'pillar balance', 'lopsided', 'in harmony',
+      'my nutrition', 'my hydration', 'my exercise', 'my sleep', 'my mental',
+      'meine ern\u00e4hrung', 'meine hydration', 'mein schlaf', 'meine bewegung', 'mein mental',
+      'how is my sleep', 'how is my nutrition',
     ],
     primary_source: 'memory_garden',
     secondary_sources: ['knowledge_hub'],
-    rationale: 'Personal Index questions need the live score + user-specific recommendations. Memory Garden first surfaces the [HEALTH] profile block (current score, pillars, weakest, trend, goal gap); KB docs supplement with explanation when asked.',
+    rationale: 'Personal Index questions need the live score + user-specific recommendations. Memory Garden first surfaces the [HEALTH] profile block (5-pillar score, balance factor, weakest pillar with sub-score hint, trend, tier framing); Knowledge Hub supplements with the Book-of-the-Index chapters for per-pillar deep questions.',
   },
 
   // ===== Personal/Historical Questions → Memory Garden First =====

--- a/services/gateway/src/services/user-context-profiler.ts
+++ b/services/gateway/src/services/user-context-profiler.ts
@@ -226,51 +226,58 @@ async function fetchPreferences(client: SupabaseClient, userId: string): Promise
 }
 
 // =============================================================================
-// Vitana Index (BOOTSTRAP-ORB-INDEX-AWARENESS round 2)
+// Vitana Index — canonical 5-pillar model (BOOTSTRAP-ORB-INDEX-AWARENESS-R4)
 // =============================================================================
-// Real schema, confirmed against migrations:
-//   vitana_index_scores: (tenant_id, user_id, date, score_total,
-//                         score_physical, score_mental, score_nutritional,
-//                         score_social, score_environmental, score_prosperity)
-// Tier bands (derived deterministically from score_total, matches the
-// platform's published bands):
-//   Starting   0-299
-//   Developing 300-499
-//   Fair       500-599
-//   Good       600-749
-//   Great      750-899
-//   Excellent  900-999
-// Default 90-day journey goal: Good (600+).
+// Pillars: nutrition, hydration, exercise, sleep, mental  (each 0-200)
+// Schema (post 5pillar-cleanup migration 20260423110000):
+//   vitana_index_scores: tenant_id, user_id, date, score_total,
+//     score_nutrition, score_hydration, score_exercise, score_sleep, score_mental,
+//     model_version, feature_inputs JSONB (balance_factor, ratio, raw_sum, subscores),
+//     confidence, updated_at
+// Tier ladder + balance state: see services/gateway/src/lib/vitana-pillars.ts.
+// Default 90-day framing: aspirational, not a gate — "Really good" at 600+.
 // =============================================================================
 
-export interface VitanaIndexSnapshot {
-  total: number;
-  tier: string;
-  pillars: {
-    physical: number;
-    mental: number;
-    nutritional: number;
-    social: number;
-    environmental: number;
-    prosperity: number;
-  };
-  weakest_pillar: { name: string; score: number };
-  strongest_pillar: { name: string; score: number };
-  trend_7d: number;          // delta vs 7 days ago (0 if no earlier row)
-  history_7d: number[];      // [oldest, ..., latest] up to 7 entries
-  goal_target: number;       // 90-day default
-  goal_gap: number;          // target - total (positive = still needed, negative = over)
-  last_computed: string;     // ISO date
-  last_movement?: { pillar: string; delta: number; reason?: string }; // most recent index.recomputed event
+import {
+  PILLAR_KEYS,
+  type PillarKey,
+  tierForScore,
+  describeBalance,
+  REALLY_GOOD_THRESHOLD,
+} from '../lib/vitana-pillars';
+
+/**
+ * Sub-score breakdown per pillar. Matches the v3 compute RPC output shape
+ * in feature_inputs.subscores. All four components are caps, not live
+ * values — the RPC clamps each. We expose them so voice can explain WHY
+ * a pillar is low ("mostly baseline — connect a tracker to climb").
+ */
+export interface PillarSubscores {
+  baseline: number;     // 0-40, from vitana_index_baseline_survey
+  completions: number;  // 0-80, from calendar_events completions × tag map
+  data: number;         // 0-40, from health_features_daily
+  streak: number;       // 0-40, consecutive-day streak for the pillar
 }
 
-function scoreTier(total: number): string {
-  if (total >= 900) return 'Excellent';
-  if (total >= 750) return 'Great';
-  if (total >= 600) return 'Good';
-  if (total >= 500) return 'Fair';
-  if (total >= 300) return 'Developing';
-  return 'Starting';
+export interface VitanaIndexSnapshot {
+  total: number;                                     // 0-999
+  tier: string;                                      // Starting / Early / ... / Elite
+  tier_framing: string;                              // one-line voice-friendly description
+  pillars: Record<PillarKey, number>;                // each 0-200
+  weakest_pillar: { name: PillarKey; score: number };
+  strongest_pillar: { name: PillarKey; score: number };
+  balance_factor: number;                            // 0.7-1.0, from feature_inputs
+  balance_label: string;                             // 'well balanced' / 'off-balance' / ...
+  balance_hint: string;                              // assistant-facing guidance
+  subscores: Partial<Record<PillarKey, PillarSubscores>>;  // per-pillar if available
+  trend_7d: number;                                  // delta vs 7 days ago
+  history_7d: number[];                              // [oldest...latest], up to 7 entries
+  goal_target: number;                               // 600 (Really good entry)
+  points_to_really_good: number;                     // max(0, 600 - total); aspirational only
+  last_computed: string;                             // ISO date
+  model_version?: string;                            // e.g. 'v3-5pillar'
+  confidence?: number;                               // 0-1, from the RPC
+  last_movement?: { pillar: string; delta: number; reason?: string };
 }
 
 /**
@@ -288,12 +295,34 @@ export type VitanaIndexFetchResult =
   | { state: 'no_score_baseline_exists' }     // survey done, compute failed (#839 state)
   | { state: 'not_set_up' };                   // neither row exists
 
+const INDEX_SELECT_COLUMNS =
+  'date, score_total, score_nutrition, score_hydration, score_exercise, score_sleep, score_mental, model_version, feature_inputs, confidence';
+
+function parseSubscoresFromFeatureInputs(featureInputs: any): Partial<Record<PillarKey, PillarSubscores>> {
+  const out: Partial<Record<PillarKey, PillarSubscores>> = {};
+  if (!featureInputs || typeof featureInputs !== 'object') return out;
+  const s = featureInputs.subscores;
+  if (!s || typeof s !== 'object') return out;
+  for (const pillar of PILLAR_KEYS) {
+    const raw = s[pillar];
+    if (raw && typeof raw === 'object') {
+      out[pillar] = {
+        baseline: Number(raw.baseline) || 0,
+        completions: Number(raw.completions) || 0,
+        data: Number(raw.data) || 0,
+        streak: Number(raw.streak) || 0,
+      };
+    }
+  }
+  return out;
+}
+
 async function fetchVitanaIndex(client: SupabaseClient, userId: string): Promise<VitanaIndexFetchResult> {
   // 1) Try last 7 days first (for trend math).
   const sinceIso = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString().slice(0, 10);
   const { data: recentData, error: recentErr } = await client
     .from('vitana_index_scores')
-    .select('date, score_total, score_physical, score_mental, score_nutritional, score_social, score_environmental, score_prosperity')
+    .select(INDEX_SELECT_COLUMNS)
     .eq('user_id', userId)
     .gte('date', sinceIso)
     .order('date', { ascending: true })
@@ -307,7 +336,7 @@ async function fetchVitanaIndex(client: SupabaseClient, userId: string): Promise
     //    we still want to report what they have instead of saying nothing.
     const { data: latestData } = await client
       .from('vitana_index_scores')
-      .select('date, score_total, score_physical, score_mental, score_nutritional, score_social, score_environmental, score_prosperity')
+      .select(INDEX_SELECT_COLUMNS)
       .eq('user_id', userId)
       .order('date', { ascending: false })
       .limit(1);
@@ -315,8 +344,8 @@ async function fetchVitanaIndex(client: SupabaseClient, userId: string): Promise
   }
 
   if (!rows || rows.length === 0) {
-    // 3) No score row at all. Detect intermediate state (baseline done, compute failed).
-    //    Matches BOOTSTRAP-VITANA-INDEX-STATUS (#839): survey row can exist without a score.
+    // 3) No score row at all. Distinguish "compute failed after baseline" from
+    //    "never set up" so voice can redirect honestly (BOOTSTRAP-VITANA-INDEX-STATUS #839).
     const { data: surveyData } = await client
       .from('vitana_index_baseline_survey')
       .select('user_id')
@@ -331,19 +360,24 @@ async function fetchVitanaIndex(client: SupabaseClient, userId: string): Promise
   const earliest = rows[0];
   const history_7d = rows.map(r => Number(r.score_total) || 0);
   const total = Number(latest.score_total) || 0;
-  const pillars = {
-    physical: Number(latest.score_physical) || 0,
-    mental: Number(latest.score_mental) || 0,
-    nutritional: Number(latest.score_nutritional) || 0,
-    social: Number(latest.score_social) || 0,
-    environmental: Number(latest.score_environmental) || 0,
-    prosperity: Number(latest.score_prosperity) || 0,
+  const pillars: Record<PillarKey, number> = {
+    nutrition: Number(latest.score_nutrition) || 0,
+    hydration: Number(latest.score_hydration) || 0,
+    exercise:  Number(latest.score_exercise)  || 0,
+    sleep:     Number(latest.score_sleep)     || 0,
+    mental:    Number(latest.score_mental)    || 0,
   };
-  const pillarEntries = Object.entries(pillars) as [keyof typeof pillars, number][];
+  const pillarEntries = PILLAR_KEYS.map(k => [k, pillars[k]] as [PillarKey, number]);
   pillarEntries.sort((a, b) => a[1] - b[1]);
   const weakest_pillar = { name: pillarEntries[0][0], score: pillarEntries[0][1] };
   const strongest_pillar = { name: pillarEntries[pillarEntries.length - 1][0], score: pillarEntries[pillarEntries.length - 1][1] };
   const trend_7d = rows.length >= 2 ? total - (Number(earliest.score_total) || 0) : 0;
+
+  const featureInputs = (latest.feature_inputs as any) || {};
+  const balanceFactor = typeof featureInputs.balance_factor === 'number' ? featureInputs.balance_factor : 1.0;
+  const balance = describeBalance(balanceFactor);
+  const subscores = parseSubscoresFromFeatureInputs(featureInputs);
+  const tier = tierForScore(total);
 
   let last_movement: VitanaIndexSnapshot['last_movement'] | undefined;
   try {
@@ -367,15 +401,22 @@ async function fetchVitanaIndex(client: SupabaseClient, userId: string): Promise
     state: 'ok',
     snapshot: {
       total,
-      tier: scoreTier(total),
+      tier: tier.name,
+      tier_framing: tier.framing,
       pillars,
       weakest_pillar,
       strongest_pillar,
+      balance_factor: balanceFactor,
+      balance_label: balance.label,
+      balance_hint: balance.assistantHint,
+      subscores,
       trend_7d,
       history_7d,
-      goal_target: 600,
-      goal_gap: 600 - total,
+      goal_target: REALLY_GOOD_THRESHOLD,
+      points_to_really_good: Math.max(0, REALLY_GOOD_THRESHOLD - total),
       last_computed: latest.date,
+      model_version: latest.model_version ?? undefined,
+      confidence: typeof latest.confidence === 'number' ? latest.confidence : undefined,
       last_movement,
     },
   };
@@ -583,13 +624,46 @@ function formatPillarName(name: string): string {
   return name.charAt(0).toUpperCase() + name.slice(1);
 }
 
+/**
+ * Pick the dominant sub-score category for a pillar so voice can explain
+ * WHY the pillar sits where it does ("mostly baseline — connect a tracker
+ * to climb", "strong streak — keep going").
+ */
+function dominantSubscoreHint(sub: PillarSubscores | undefined): string | null {
+  if (!sub) return null;
+  const parts: Array<[string, number]> = [
+    ['baseline', sub.baseline],
+    ['completions', sub.completions],
+    ['data', sub.data],
+    ['streak', sub.streak],
+  ];
+  const total = parts.reduce((a, [, n]) => a + n, 0);
+  if (total <= 0) return 'no signal yet';
+  parts.sort((a, b) => b[1] - a[1]);
+  const [top, topVal] = parts[0];
+  const share = topVal / total;
+  if (top === 'baseline' && share >= 0.6) {
+    return 'mostly survey baseline — connected data or a tracker would lift it further';
+  }
+  if (top === 'completions' && share >= 0.4) {
+    return 'completed actions are carrying it — keep the rhythm';
+  }
+  if (top === 'data' && share >= 0.4) {
+    return 'connected data is feeding it — real signal';
+  }
+  if (top === 'streak' && share >= 0.3) {
+    return 'streak is doing the work — the day-over-day consistency compounds';
+  }
+  return null;
+}
+
 function buildHealthSection(activities: ActivityRow[], vitanaResult: VitanaIndexFetchResult | null): string {
   const lines: string[] = [];
 
   // Vitana Index — ALWAYS emit something so the voice model has a quotable
-  // line. Three paths: real score, baseline-but-compute-failed, not set up.
-  // BOOTSTRAP-ORB-INDEX-AWARENESS-R3: silence was the old bug — an empty
-  // section meant the Assistant had no number AND no guidance.
+  // line. Three states: `ok`, `no_score_baseline_exists`, `not_set_up`.
+  // R3 established the never-silent property; R4 carries it over to the
+  // 5-pillar model with balance + sub-score transparency.
   if (vitanaResult) {
     if (vitanaResult.state === 'ok') {
       const vitana = vitanaResult.snapshot;
@@ -598,25 +672,31 @@ function buildHealthSection(activities: ActivityRow[], vitanaResult: VitanaIndex
         : vitana.trend_7d < 0
           ? `trending down ${vitana.trend_7d} over 7 days`
           : 'stable over 7 days';
-      lines.push(`- Vitana Index: ${vitana.total} / 999 (${vitana.tier} tier), ${trendStr}.`);
+      lines.push(`- Vitana Index: ${vitana.total} / 999 (${vitana.tier} tier — ${vitana.tier_framing}); ${trendStr}.`);
 
       const p = vitana.pillars;
-      const pillarLines = [
-        `Physical ${p.physical}/200`,
-        `Mental ${p.mental}/200`,
-        `Nutritional ${p.nutritional}/200`,
-        `Social ${p.social}/200`,
-        `Environmental ${p.environmental}/200`,
-        `Prosperity ${p.prosperity}/200`,
-      ];
-      lines.push(`- Pillars: ${pillarLines.join(', ')}.`);
-      lines.push(`- Weakest pillar: ${formatPillarName(vitana.weakest_pillar.name)} (${vitana.weakest_pillar.score}/200) — this is where improvements move the Index most.`);
+      const pillarLines = PILLAR_KEYS.map(k => `${formatPillarName(k)} ${p[k]}/200`);
+      lines.push(`- Pillars (5 canonical, max 200 each): ${pillarLines.join(', ')}.`);
+
+      // Weakest/strongest with sub-score explanation so voice can name the lever.
+      const weakestSub = dominantSubscoreHint(vitana.subscores[vitana.weakest_pillar.name]);
+      const weakestSuffix = weakestSub ? ` — ${weakestSub}` : '';
+      lines.push(`- Weakest pillar: ${formatPillarName(vitana.weakest_pillar.name)} (${vitana.weakest_pillar.score}/200)${weakestSuffix}.`);
       lines.push(`- Strongest pillar: ${formatPillarName(vitana.strongest_pillar.name)} (${vitana.strongest_pillar.score}/200).`);
 
-      if (vitana.goal_gap > 0) {
-        lines.push(`- 90-day goal: reach Good tier (${vitana.goal_target}). Currently ${vitana.goal_gap} points below target.`);
+      // Balance factor — a first-class signal. The RPC applies it as a
+      // multiplicative dampener, so when the factor is < 1.0 the dampener
+      // is suppressing the total more than the weakest single pillar does.
+      lines.push(`- Balance: ${vitana.balance_factor.toFixed(2)}× (${vitana.balance_label}) — ${vitana.balance_hint}`);
+
+      // Aspirational framing, NOT a gate. "Really good" starts at 600; we
+      // surface the gap as progress signal, not as pass/fail.
+      if (vitana.points_to_really_good > 0) {
+        lines.push(`- Really-good band (600+) entry: ${vitana.points_to_really_good} points away. Keep building steadily — do not force the ceiling.`);
+      } else if (vitana.total >= 800) {
+        lines.push(`- Elite band (800+): sustained excellence territory. Maintenance, not acceleration.`);
       } else {
-        lines.push(`- 90-day goal: reach Good tier (${vitana.goal_target}). Already ${Math.abs(vitana.goal_gap)} points above target — keep the momentum.`);
+        lines.push(`- Really-good band (600+): already inside. The climb from here is slow and earned.`);
       }
 
       if (vitana.last_movement) {
@@ -625,13 +705,14 @@ function buildHealthSection(activities: ActivityRow[], vitanaResult: VitanaIndex
         const reason = m.reason ? ` from "${m.reason}"` : '';
         lines.push(`- Last movement: ${sign}${m.delta} ${formatPillarName(m.pillar)}${reason}.`);
       }
+
+      if (vitana.model_version) {
+        lines.push(`- Model: ${vitana.model_version}${typeof vitana.confidence === 'number' ? `, confidence ${vitana.confidence.toFixed(2)}` : ''}.`);
+      }
     } else if (vitanaResult.state === 'no_score_baseline_exists') {
-      // BOOTSTRAP-VITANA-INDEX-STATUS (#839): baseline survey row exists
-      // but vitana_index_scores has no row (compute RPC failed earlier).
-      // Tell the model so it can guide the user to retry.
-      lines.push('- Vitana Index status: SETUP INCOMPLETE. The baseline survey was submitted, but the score did not compute (earlier compute RPC error). The user needs to retry — the Health screen should re-prompt the baseline modal. Do NOT fabricate an Index number.');
+      lines.push('- Vitana Index status: SETUP INCOMPLETE. The 5-pillar baseline survey was submitted, but the score did not compute (earlier compute RPC error). The user needs to retry — the Health screen should re-prompt the baseline modal. Do NOT fabricate an Index number.');
     } else if (vitanaResult.state === 'not_set_up') {
-      lines.push('- Vitana Index status: NOT SET UP YET. The user has not completed the baseline survey. Direct them to the Health screen to take it — that is the ONLY way the Index gets a first value. Do NOT fabricate an Index number.');
+      lines.push('- Vitana Index status: NOT SET UP YET. The user has not completed the 5-question baseline survey (Nutrition / Hydration / Exercise / Sleep / Mental). Direct them to the Health screen — that survey is the only way the Index gets its first value. Do NOT fabricate an Index number.');
     }
   }
 


### PR DESCRIPTION
## Summary

Phase E+F of the Index reshape landed in PRs #855–#866 — `vitana_index_scores` is now 5-pillar (Nutrition/Hydration/Exercise/Sleep/Mental), `feature_inputs` carries `balance_factor` + per-pillar sub-score breakdown, and the Book of the Vitana Index is seeded as 9 KB chapters. **My R3 (PR #840) was built on the retired 6-pillar shape and is currently SELECTing columns that have been dropped** — voice ORB falls into the "no data" branch on every request. This PR brings the voice path to the final shape.

### Durability-first design (long-term solution)

- **New `lib/vitana-pillars.ts`** is the single source of truth for pillar keys, tier ladder, balance labels, wellness-tag map, and Book chapter URLs. Profiler, ORB tools, retrieval-router, and pillar-agents all import from here; `pillar-agents/base-agent.ts` is deduplicated to read `PILLAR_TAGS` from the lib. **Future pillar reshapes flip one file.**
- **Profiler snapshot** is now `Record<PillarKey, number>` + balance + sub-scores, so further iterations don't re-type the snapshot. `INDEX_SELECT_COLUMNS` centralised.
- **`buildHealthSection`** emits Balance line + aspirational distance-to-Really-good + weakest-pillar sub-score hint + tier+framing from the lib's `TIER_LADDER`.
- **ORB tool enums** swapped to canonical 5 pillars, runtime-validated against `PILLAR_KEYS`. Hard-coded `pillarTagMap` replaced with the canonical `PILLAR_TAGS` import.
- **`get_vitana_index`** tool now returns `balance_factor`, `balance_hint`, `subscores`, `points_to_really_good`.
- **Override block (VITANA INDEX QUESTIONS)** rewritten as rules A–K with balance-awareness (B), sub-score transparency (C), Book-grounded per-pillar deep answers (F), aspirational framing rule (H), setup-state rule J preserved from R3.
- **Retrieval router `personal_index`** rule gets balance + per-pillar patterns (\"how is my sleep?\" / \"mein Schlaf\").

### What's preserved from R3
- State envelope (`ok | no_score_baseline_exists | not_set_up`) — the \"never silent\" property is orthogonal to pillar shape.
- Rule J (setup-state honest redirect) — same applies regardless of pillar count.

## Test plan
- [x] \`npm run typecheck\` clean
- [ ] Post-deploy: user \`0adc6ff6-acb0-4dca-99d0-295211a40e3e\` asks voice ORB \"Was ist mein Vitana Index?\" — expects 5-pillar quote + balance line + tier framing
- [ ] User asks \"how is my sleep?\" — expects grounded answer from index-book/04-sleep.md
- [ ] User in \`not_set_up\` → 5-question baseline redirect
- [ ] User in \`no_score_baseline_exists\` → setup-incomplete redirect
- [ ] User with low balance (< 0.9) → Assistant names imbalance as primary lever

🤖 Generated with [Claude Code](https://claude.com/claude-code)