### PR TITLE
feat(autopilot): impact rules — diff-aware PR scan + registry (DEV-COMHU-0212)

### DIFF
--- a/.github/workflows/DEV-AUTOPILOT-IMPACT.yml
+++ b/.github/workflows/DEV-AUTOPILOT-IMPACT.yml
@@ -1,0 +1,152 @@
+name: Dev Autopilot Impact Scan
+
+# Diff-aware scan that runs on every PR (and on manual dispatch for local
+# testing). Reads the PR's base...HEAD diff, runs every rule in
+# scripts/ci/impact-rules/, and posts an auto-updating PR comment with the
+# aggregated findings. Blocker-severity rules fail the job; warnings are
+# surfaced but do not block.
+#
+# Companion to the baseline scanner (DEV-AUTOPILOT.yml, twice-daily cron).
+# The two together answer different questions:
+#   - DEV-AUTOPILOT.yml     : what gaps exist in the repo today?
+#   - DEV-AUTOPILOT-IMPACT  : does this PR introduce new gaps or conflicts?
+
+on:
+  pull_request:
+    # Run on any PR targeting main — the rules self-filter by touched path.
+    branches: [main]
+    types: [opened, synchronize, reopened, ready_for_review]
+  workflow_dispatch:
+    inputs:
+      base_ref:
+        description: "Override the base ref for diff (e.g. 'origin/main'). Default: auto."
+        required: false
+        default: ""
+      dry_run:
+        description: "If true, do not fail the job on blocker findings."
+        required: false
+        default: "false"
+
+permissions:
+  contents: read
+  pull-requests: write # for the PR-comment step
+
+concurrency:
+  group: impact-scan-${{ github.event.pull_request.number || github.ref }}
+  cancel-in-progress: true
+
+jobs:
+  scan:
+    runs-on: ubuntu-latest
+    env:
+      IMPACT_SCAN_DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
+      IMPACT_SCAN_BASE: ${{ github.event.inputs.base_ref || format('origin/{0}', github.event.pull_request.base.ref || 'main') }}
+    steps:
+      - name: Checkout (full history for diff)
+        uses: actions/checkout@v4
+        with:
+          fetch-depth: 0 # need history for base...HEAD diff
+
+      - name: Setup Node
+        uses: actions/setup-node@v4
+        with:
+          node-version: "22"
+
+      - name: Run impact scan
+        id: scan
+        # Continue even on blocker — we want to post the comment before failing.
+        continue-on-error: true
+        run: node scripts/ci/dev-autopilot-impact-scan.mjs
+
+      - name: Build PR comment body
+        id: comment
+        run: |
+          # shellcheck disable=SC2016
+          python3 <<'PY' > comment.md
+          import json, os
+          try:
+              with open('dev-autopilot-impact-findings.json') as fh:
+                  data = json.load(fh)
+          except FileNotFoundError:
+              print('<!-- impact-scan -->')
+              print('### Dev Autopilot — Impact Scan')
+              print()
+              print('Could not read findings file. Check the job log.')
+              raise SystemExit
+
+          counts = data.get('counts', {})
+          findings = data.get('findings', [])
+          blocker = counts.get('blocker', 0)
+          warning = counts.get('warning', 0)
+          info = counts.get('info', 0)
+
+          print('<!-- impact-scan -->')
+          print('### Dev Autopilot — Impact Scan')
+          print()
+          if not findings:
+              print('No impact findings — PR touches no paths that trigger a companion/conflict/semantic rule.')
+              print()
+              print('_Impact rules run on every PR. See **Command Hub → Autopilot → Impact Rules** for the active ruleset._')
+              raise SystemExit
+
+          emoji = '🟥' if blocker else ('🟨' if warning else '🟦')
+          print(f'{emoji} **blocker: {blocker} · warning: {warning} · info: {info}**')
+          print()
+
+          for f in findings:
+              sev = f.get('severity', 'info')
+              pill = {'blocker': '🟥 blocker', 'warning': '🟨 warning', 'info': '🟦 info'}.get(sev, sev)
+              rule = f.get('rule', '(unknown)')
+              msg = f.get('message', '')
+              act = f.get('suggested_action', '')
+              fp = f.get('file_path') or ''
+              ln = f.get('line_number')
+              loc = fp + (f':{ln}' if ln else '') if fp else ''
+              print(f'<details><summary>{pill} · <code>{rule}</code>{" · " + loc if loc else ""}</summary>')
+              print()
+              print(f'{msg}')
+              print()
+              if act:
+                  print(f'**Fix:** {act}')
+              print()
+              print('</details>')
+              print()
+
+          print('---')
+          print('_Rules live in [`scripts/ci/impact-rules/`](scripts/ci/impact-rules) · registry at **Command Hub → Autopilot → Impact Rules**_')
+          PY
+
+      - name: Post or update PR comment
+        if: github.event.pull_request.number != null
+        env:
+          GH_TOKEN: ${{ secrets.GITHUB_TOKEN }}
+          PR_NUMBER: ${{ github.event.pull_request.number }}
+          REPO: ${{ github.repository }}
+        run: |
+          set -e
+          # Find an existing comment with our marker.
+          EXISTING=$(gh api "repos/$REPO/issues/$PR_NUMBER/comments?per_page=100" \
+            --jq '.[] | select(.body | contains("<!-- impact-scan -->")) | .id' | head -n1)
+          BODY_JSON=$(jq -Rs '{body: .}' < comment.md)
+          if [ -n "$EXISTING" ]; then
+            echo "Updating comment $EXISTING"
+            gh api -X PATCH "repos/$REPO/issues/comments/$EXISTING" --input - <<< "$BODY_JSON"
+          else
+            echo "Creating new comment"
+            gh api -X POST "repos/$REPO/issues/$PR_NUMBER/comments" --input - <<< "$BODY_JSON"
+          fi
+
+      - name: Upload findings artifact
+        if: always()
+        uses: actions/upload-artifact@v4
+        with:
+          name: dev-autopilot-impact-findings
+          path: dev-autopilot-impact-findings.json
+          retention-days: 14
+          if-no-files-found: warn
+
+      - name: Fail if blocker findings (respecting dry_run)
+        if: ${{ env.IMPACT_SCAN_DRY_RUN != 'true' && steps.scan.outcome == 'failure' }}
+        run: |
+          echo "Impact scan reported blocker findings. See the PR comment or the uploaded artifact."
+          exit 1

--- a/dev-autopilot-impact-findings.json
+++ b/dev-autopilot-impact-findings.json
@@ -1,0 +1,10 @@
+{
+  "findings": [],
+  "counts": {
+    "blocker": 0,
+    "warning": 0,
+    "info": 0
+  },
+  "base": "origin/main",
+  "head": "HEAD"
+}

--- a/scripts/ci/dev-autopilot-impact-scan.mjs
+++ b/scripts/ci/dev-autopilot-impact-scan.mjs
@@ -1,0 +1,149 @@
+#!/usr/bin/env node
+/**
+ * Dev Autopilot — Impact Scan driver.
+ *
+ * Runs at PR-time (on pull_request events via .github/workflows/DEV-AUTOPILOT-IMPACT.yml)
+ * and on manual dispatch. Reads the PR's git diff (base...HEAD), classifies
+ * every changed file, runs every enabled rule in scripts/ci/impact-rules/
+ * against the diff, and writes the aggregated findings to a JSON file the
+ * workflow then posts as an auto-updating PR comment.
+ *
+ * Env:
+ *   GITHUB_BASE_REF     PR base ref, e.g. 'main'. CI fills this.
+ *   IMPACT_SCAN_BASE    Override base ref (useful for local dry runs).
+ *                       Defaults to 'origin/main' if GITHUB_BASE_REF unset.
+ *   IMPACT_SCAN_DRY_RUN If 'true', print findings to stdout and exit 0
+ *                       regardless of severity.
+ *   IMPACT_RULE_ALLOWLIST  comma-separated rule ids; default: all enabled
+ *   IMPACT_RULE_DENYLIST   comma-separated rule ids; default: empty
+ *
+ * Exit code:
+ *   0 — no blocker findings (warnings may exist)
+ *   1 — at least one blocker finding, OR the scanner itself threw
+ *
+ * Output:
+ *   dev-autopilot-impact-findings.json (alongside the signals.json from the
+ *   baseline scanner) with shape:
+ *     { findings: ImpactFinding[], counts: { blocker, warning, info } }
+ */
+
+import { execFileSync } from 'node:child_process';
+import fs from 'node:fs';
+import path from 'node:path';
+import { groupByCategory } from './impact-rules/_shared.mjs';
+import { IMPACT_RULES } from './impact-rules/registry.mjs';
+
+const REPO_ROOT = process.cwd();
+const DRY_RUN = (process.env.IMPACT_SCAN_DRY_RUN || '').toLowerCase() === 'true';
+const baseRef = process.env.IMPACT_SCAN_BASE
+  || (process.env.GITHUB_BASE_REF ? `origin/${process.env.GITHUB_BASE_REF}` : 'origin/main');
+const allowlist = new Set((process.env.IMPACT_RULE_ALLOWLIST || '').split(',').map(s => s.trim()).filter(Boolean));
+const denylist  = new Set((process.env.IMPACT_RULE_DENYLIST  || '').split(',').map(s => s.trim()).filter(Boolean));
+
+function git(args) {
+  return execFileSync('git', args, { encoding: 'utf8', cwd: REPO_ROOT, maxBuffer: 64 * 1024 * 1024 });
+}
+
+function resolveBase() {
+  // Try the raw baseRef; if that fails, fall back to HEAD~1.
+  try {
+    git(['rev-parse', '--verify', baseRef]);
+    return baseRef;
+  } catch { /* fall through */ }
+  try {
+    git(['rev-parse', '--verify', 'HEAD~1']);
+    console.warn(`[impact-scan] base ref ${baseRef} unresolved — falling back to HEAD~1`);
+    return 'HEAD~1';
+  } catch {
+    console.warn(`[impact-scan] could not resolve any base ref — empty diff`);
+    return null;
+  }
+}
+
+function loadRuleModules() {
+  const out = new Map();
+  const dir = path.join(REPO_ROOT, 'scripts', 'ci', 'impact-rules');
+  const files = fs.readdirSync(dir).filter(f => f.endsWith('.mjs') && !f.startsWith('_') && f !== 'registry.mjs');
+  return Promise.all(files.map(async f => {
+    try {
+      const mod = await import(`./impact-rules/${f}`);
+      if (mod && mod.meta && typeof mod.check === 'function') {
+        out.set(mod.meta.rule, mod);
+      }
+    } catch (err) {
+      console.warn(`[impact-scan] failed to load ${f}: ${err.message}`);
+    }
+  })).then(() => out);
+}
+
+function isRuleEnabled(ruleId) {
+  if (denylist.has(ruleId)) return false;
+  if (allowlist.size > 0 && !allowlist.has(ruleId)) return false;
+  const entry = IMPACT_RULES.find(r => r.rule === ruleId);
+  return entry ? entry.enabled : true;
+}
+
+async function main() {
+  const base = resolveBase();
+  let diff = '';
+  let changedFiles = [];
+  if (base) {
+    try { diff = git(['diff', '--unified=3', `${base}...HEAD`]); }
+    catch (err) { console.warn(`[impact-scan] git diff failed: ${err.message}`); }
+    try {
+      const raw = git(['diff', '--name-status', `${base}...HEAD`]);
+      changedFiles = raw.trim().split('\n').filter(Boolean).map(line => {
+        const [status, ...rest] = line.split('\t');
+        return { status: status.charAt(0), path: rest.join('\t') };
+      });
+    } catch (err) { console.warn(`[impact-scan] name-status failed: ${err.message}`); }
+  }
+  const byCategory = groupByCategory(changedFiles);
+  console.log(`[impact-scan] base=${base || '(none)'} changed=${changedFiles.length}`);
+
+  const rules = await loadRuleModules();
+  const ctx = { diff, changedFiles, byCategory, repoRoot: REPO_ROOT, baseRef: base };
+  const findings = [];
+  for (const entry of IMPACT_RULES) {
+    if (!isRuleEnabled(entry.rule)) continue;
+    const mod = rules.get(entry.rule);
+    if (!mod) {
+      console.warn(`[impact-scan] registry lists '${entry.rule}' but no module loaded — skipping`);
+      continue;
+    }
+    try {
+      const out = await mod.check(ctx);
+      if (Array.isArray(out)) {
+        for (const f of out) {
+          findings.push({ ...f, category: entry.category, rule_title: entry.rule });
+        }
+      }
+    } catch (err) {
+      console.warn(`[impact-scan] rule '${entry.rule}' threw: ${err.message}`);
+    }
+  }
+
+  const counts = { blocker: 0, warning: 0, info: 0 };
+  for (const f of findings) {
+    if (f.severity === 'blocker') counts.blocker++;
+    else if (f.severity === 'warning') counts.warning++;
+    else counts.info++;
+  }
+
+  const outPath = path.join(REPO_ROOT, 'dev-autopilot-impact-findings.json');
+  fs.writeFileSync(outPath, JSON.stringify({ findings, counts, base, head: 'HEAD' }, null, 2));
+
+  console.log(`[impact-scan] findings: blocker=${counts.blocker} warning=${counts.warning} info=${counts.info} total=${findings.length}`);
+  console.log(`[impact-scan] wrote ${outPath}`);
+
+  if (DRY_RUN) return;
+  if (counts.blocker > 0) {
+    console.error(`[impact-scan] FAILING: ${counts.blocker} blocker finding(s). See ${outPath} for details.`);
+    process.exit(1);
+  }
+}
+
+main().catch(err => {
+  console.error(`[impact-scan] unhandled error:`, err);
+  process.exit(1);
+});

--- a/scripts/ci/impact-rules/_shared.mjs
+++ b/scripts/ci/impact-rules/_shared.mjs
@@ -1,0 +1,111 @@
+/**
+ * Shared helpers for Dev Autopilot impact rules.
+ *
+ * Impact rules are **diff-aware**: they get the PR's git diff (between base
+ * and HEAD) as input and look for companion/conflict/pattern issues.
+ *
+ * Rule module contract:
+ *   export const meta = {
+ *     rule: 'kebab-case-id',         // unique, matches dev_autopilot_impact_rules.rule
+ *     title: 'Short human title',
+ *     description: 'What the rule checks, in one paragraph.',
+ *     category: 'companion' | 'conflict' | 'semantic',
+ *     severity: 'blocker' | 'warning' | 'info',
+ *     enabled: true | false,
+ *   };
+ *   export async function check(ctx) -> ImpactFinding[];
+ *
+ * ctx shape:
+ *   {
+ *     diff:          string,           // full unified diff (git diff --unified=3 base...HEAD)
+ *     changedFiles:  ChangedFile[],    // [{ path, status: 'A'|'M'|'D' }]
+ *     byCategory:    Record<Category, string[]>, // classified paths
+ *     repoRoot:      string,           // absolute path
+ *     baseRef:       string,           // e.g. 'origin/main'
+ *   }
+ *
+ * ImpactFinding shape:
+ *   {
+ *     rule:         string,           // meta.rule
+ *     severity:     'blocker' | 'warning' | 'info',
+ *     file_path:    string | null,    // closest file the finding is about, for context
+ *     line_number:  number | null,
+ *     message:      string,           // short, actionable
+ *     suggested_action: string,       // what to do
+ *     raw?:         Record<string, unknown>,
+ *   }
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const FILE_CATEGORIES = [
+  'migrations', 'routes', 'services', 'scanners', 'impactRules',
+  'tests', 'workflows', 'types', 'frontend', 'docs', 'config',
+  'worker', 'other',
+];
+
+export function classifyPath(p) {
+  if (/^supabase\/migrations\//.test(p)) return 'migrations';
+  if (/^scripts\/ci\/scanners\//.test(p)) return 'scanners';
+  if (/^scripts\/ci\/impact-rules\//.test(p)) return 'impactRules';
+  if (/^\.github\/workflows\//.test(p)) return 'workflows';
+  if (/^services\/gateway\/src\/frontend\//.test(p)) return 'frontend';
+  if (/^services\/gateway\/src\/routes\//.test(p)) return 'routes';
+  if (/^services\/gateway\/src\/services\//.test(p)) return 'services';
+  if (/^services\/gateway\/src\/types\//.test(p)) return 'types';
+  if (/^services\/gateway\/(test|tests)\//.test(p)) return 'tests';
+  if (/^services\/autopilot-worker\//.test(p)) return 'worker';
+  if (/\.test\.(ts|tsx|js|mjs)$/.test(p) || /\.spec\.(ts|tsx|js|mjs)$/.test(p)) return 'tests';
+  if (/\.(md|mdx)$/.test(p)) return 'docs';
+  if (/\.(yml|yaml|json|toml|env)$/.test(p)) return 'config';
+  return 'other';
+}
+
+export function groupByCategory(changedFiles) {
+  const out = Object.fromEntries(FILE_CATEGORIES.map(c => [c, []]));
+  for (const f of changedFiles) {
+    out[classifyPath(f.path)].push(f.path);
+  }
+  return out;
+}
+
+export function readFileSafe(p) {
+  try { return fs.readFileSync(p, 'utf8'); }
+  catch { return null; }
+}
+
+export function readFileAtRepo(repoRoot, rel) {
+  return readFileSafe(path.join(repoRoot, rel));
+}
+
+/**
+ * Return lines that were ADDED in the diff (prefixed with `+`, excluding
+ * the `+++` file header). Useful for rules that want to check what's new,
+ * not what moved.
+ */
+export function extractAddedLines(diff, matchPathRegex) {
+  const lines = diff.split('\n');
+  const out = [];
+  let currentFile = null;
+  let inAddedBlock = false;
+  for (const line of lines) {
+    if (line.startsWith('diff --git ')) {
+      const m = /b\/(.+)$/.exec(line);
+      currentFile = m ? m[1] : null;
+      continue;
+    }
+    if (line.startsWith('+++')) continue;
+    if (line.startsWith('---')) continue;
+    if (!currentFile) continue;
+    if (matchPathRegex && !matchPathRegex.test(currentFile)) continue;
+    if (line.startsWith('+')) {
+      out.push({ file: currentFile, text: line.slice(1) });
+    }
+  }
+  return out;
+}
+
+export function fileExists(repoRoot, rel) {
+  return fs.existsSync(path.join(repoRoot, rel));
+}

--- a/scripts/ci/impact-rules/duplicate-route-registration.mjs
+++ b/scripts/ci/impact-rules/duplicate-route-registration.mjs
@@ -1,0 +1,98 @@
+/**
+ * duplicate-route-registration
+ *
+ * Walk every route handler in the PR's HEAD state (not just the diff) and
+ * flag any (HTTP method, full path) that appears in two or more files.
+ * Duplicate registrations cause Express's "which handler wins" behavior to
+ * be version-dependent — a silent correctness bug.
+ *
+ * Full-path resolution:
+ *   - Each file under services/gateway/src/routes/<name>.ts is typically
+ *     mounted at some sub-prefix in services/gateway/src/index.ts via
+ *     app.use('/api/v1/<name>', <name>Router).
+ *   - We don't attempt to recover that mount prefix; we compare routes
+ *     as `<file_stem> METHOD <path_arg>` tuples, which is sufficient:
+ *     if two different route files both register `GET /` that's a
+ *     mount-side collision; if one file registers `POST /foo` twice
+ *     that's an intra-file collision — both are bugs.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { readFileAtRepo } from './_shared.mjs';
+
+export const meta = {
+  rule: 'duplicate-route-registration',
+  category: 'conflict',
+  severity: 'blocker',
+};
+
+const HANDLER_RE = /router\.(get|post|put|patch|delete)\s*\(\s*[`'"]([^`'"]+)[`'"]/g;
+
+function collectRoutes(repoRoot, rel) {
+  const src = readFileAtRepo(repoRoot, rel);
+  if (!src) return [];
+  const out = [];
+  let m;
+  HANDLER_RE.lastIndex = 0;
+  while ((m = HANDLER_RE.exec(src)) !== null) {
+    const method = m[1].toUpperCase();
+    const routePath = m[2];
+    const line = src.slice(0, m.index).split('\n').length;
+    out.push({ method, path: routePath, file: rel, line });
+  }
+  return out;
+}
+
+export async function check({ changedFiles, repoRoot }) {
+  const routesDir = path.join(repoRoot, 'services', 'gateway', 'src', 'routes');
+  if (!fs.existsSync(routesDir)) return [];
+
+  // Walk the full routes directory in HEAD state.
+  const handlers = [];
+  const stack = [routesDir];
+  while (stack.length > 0) {
+    const cur = stack.pop();
+    let entries = [];
+    try { entries = fs.readdirSync(cur, { withFileTypes: true }); }
+    catch { continue; }
+    for (const e of entries) {
+      const full = path.join(cur, e.name);
+      if (e.isDirectory()) { stack.push(full); continue; }
+      if (!/\.(ts|tsx)$/.test(e.name)) continue;
+      if (/\.(test|spec)\.(ts|tsx)$/.test(e.name)) continue;
+      const rel = path.relative(repoRoot, full).split(path.sep).join('/');
+      handlers.push(...collectRoutes(repoRoot, rel));
+    }
+  }
+
+  // Group by file-stem + method + path — stem captures the likely mount prefix.
+  const byKey = new Map();
+  for (const h of handlers) {
+    const stem = path.basename(h.file, path.extname(h.file));
+    const key = `${stem}|${h.method}|${h.path}`;
+    if (!byKey.has(key)) byKey.set(key, []);
+    byKey.get(key).push(h);
+  }
+
+  // Only report collisions that the current PR may have caused or aggravated:
+  // at least one duplicate must be in a file touched by this PR.
+  const changedSet = new Set(changedFiles.map(f => f.path));
+  const findings = [];
+  for (const [key, hs] of byKey) {
+    if (hs.length < 2) continue;
+    const prTouched = hs.some(h => changedSet.has(h.file));
+    if (!prTouched) continue;
+    const [, method, routePath] = key.split('|');
+    findings.push({
+      rule: meta.rule,
+      severity: meta.severity,
+      file_path: hs[0].file,
+      line_number: hs[0].line,
+      message: `${method} ${routePath} is registered in multiple locations: ${hs.map(h => `${h.file}:${h.line}`).join(' and ')}.`,
+      suggested_action: `Keep exactly one registration of this (method, path) pair. Either remove the duplicate or rename one of them to a distinct route.`,
+      raw: { method, path: routePath, registrations: hs },
+    });
+  }
+  return findings;
+}

--- a/scripts/ci/impact-rules/duplicate-table-name.mjs
+++ b/scripts/ci/impact-rules/duplicate-table-name.mjs
@@ -1,0 +1,102 @@
+/**
+ * duplicate-table-name
+ *
+ * A migration added in this PR doing CREATE TABLE foo fails at psql time
+ * if foo already exists from a prior migration. psql errors are reported
+ * by RUN-MIGRATION.yml AFTER merge — catching it at PR time is cheaper.
+ *
+ * Logic:
+ *   - For each added migration in the PR, extract CREATE TABLE names.
+ *   - For each name, grep the baseline (all OTHER migrations, plus the
+ *     SAME migration at pre-PR state) for a prior CREATE TABLE of that name
+ *     without a paired DROP TABLE later.
+ *
+ * The migration-ordering guard (separate rule, future) will cover the
+ * subtler case of CREATE TABLE IF NOT EXISTS with a diverging column list.
+ */
+
+import fs from 'node:fs';
+import path from 'node:path';
+import { readFileAtRepo } from './_shared.mjs';
+
+export const meta = {
+  rule: 'duplicate-table-name',
+  category: 'conflict',
+  severity: 'blocker',
+};
+
+function extractCreateTables(sql) {
+  const out = [];
+  if (!sql) return out;
+  const re = /CREATE\s+TABLE\s+(?:IF\s+NOT\s+EXISTS\s+)?(?:public\.)?([a-z_][a-z0-9_]*)/gi;
+  let m;
+  while ((m = re.exec(sql)) !== null) {
+    out.push({ name: m[1].toLowerCase(), hasIfNotExists: /IF\s+NOT\s+EXISTS/i.test(m[0]) });
+  }
+  return out;
+}
+
+function extractDropTables(sql) {
+  const out = new Set();
+  if (!sql) return out;
+  const re = /DROP\s+TABLE\s+(?:IF\s+EXISTS\s+)?(?:public\.)?([a-z_][a-z0-9_]*)/gi;
+  let m;
+  while ((m = re.exec(sql)) !== null) out.add(m[1].toLowerCase());
+  return out;
+}
+
+export async function check({ changedFiles, repoRoot }) {
+  const addedMigrations = changedFiles.filter(f =>
+    f.status === 'A' && /^supabase\/migrations\/.+\.sql$/.test(f.path)
+  );
+  if (addedMigrations.length === 0) return [];
+
+  const migrationsDir = path.join(repoRoot, 'supabase', 'migrations');
+  if (!fs.existsSync(migrationsDir)) return [];
+
+  // Build a set of existing live tables (name -> oldestMigrationFile).
+  // We include ALL migrations currently on disk, which in the CI worktree
+  // includes the PR's own adds — we need to exclude those so we compare
+  // against the pre-PR state.
+  const addedSet = new Set(addedMigrations.map(f => path.basename(f.path)));
+  const existingCreates = new Map();   // name -> first migration
+  const existingDrops = new Map();     // name -> count of drops
+
+  const allFiles = fs.readdirSync(migrationsDir).filter(f => f.endsWith('.sql')).sort();
+  for (const f of allFiles) {
+    if (addedSet.has(f)) continue;
+    const sql = fs.readFileSync(path.join(migrationsDir, f), 'utf8');
+    for (const c of extractCreateTables(sql)) {
+      if (!existingCreates.has(c.name)) existingCreates.set(c.name, f);
+    }
+    const drops = extractDropTables(sql);
+    for (const d of drops) existingDrops.set(d, (existingDrops.get(d) || 0) + 1);
+  }
+
+  // Prune tables that were dropped and never re-created after the drop.
+  for (const [name] of existingCreates) {
+    if (existingDrops.has(name)) existingCreates.delete(name);
+  }
+
+  const findings = [];
+  for (const m of addedMigrations) {
+    const sql = readFileAtRepo(repoRoot, m.path);
+    if (!sql) continue;
+    const creates = extractCreateTables(sql);
+    for (const c of creates) {
+      if (c.hasIfNotExists) continue; // idempotent — psql won't error
+      if (existingCreates.has(c.name)) {
+        findings.push({
+          rule: meta.rule,
+          severity: meta.severity,
+          file_path: m.path,
+          line_number: null,
+          message: `${m.path} creates table \`${c.name}\`, but \`${c.name}\` was already created by ${existingCreates.get(c.name)}. psql will error at migration time.`,
+          suggested_action: `Either (a) use CREATE TABLE IF NOT EXISTS if the intent is idempotent, (b) use ALTER TABLE to modify the existing table, or (c) rename the new table to avoid the collision.`,
+          raw: { table_name: c.name, existing_migration: existingCreates.get(c.name) },
+        });
+      }
+    }
+  }
+  return findings;
+}

--- a/scripts/ci/impact-rules/migration-requires-code-touch.mjs
+++ b/scripts/ci/impact-rules/migration-requires-code-touch.mjs
@@ -1,0 +1,59 @@
+/**
+ * migration-requires-code-touch
+ *
+ * A new supabase/migrations/*.sql file that doesn't coincide with any
+ * change under services/gateway/src (or services/autopilot-worker/src)
+ * is often a red flag:
+ *   - Schema drift: table/column added but nothing reads/writes it.
+ *   - Forgotten rollout: the code that USES the new schema lives in another
+ *     unmerged PR.
+ *
+ * Warning-level: there are legit cases (pure-RLS migration, data backfill,
+ * index tweak) that don't touch code. A human reviewer can dismiss.
+ *
+ * Exclusions:
+ *   - BOOTSTRAP-prefixed migrations that are known to be schema-only
+ *     (index, RLS, retention cleanup) can add a `// impact-allow-solo-migration`
+ *     comment anywhere in the SQL to opt out.
+ */
+
+import { readFileAtRepo } from './_shared.mjs';
+
+export const meta = {
+  rule: 'migration-requires-code-touch',
+  category: 'companion',
+  severity: 'warning',
+};
+
+export async function check({ changedFiles, repoRoot }) {
+  const addedMigrations = changedFiles.filter(f =>
+    f.status === 'A' && /^supabase\/migrations\/.+\.sql$/.test(f.path)
+  );
+  if (addedMigrations.length === 0) return [];
+
+  const codeTouched = changedFiles.some(f =>
+    (f.status === 'A' || f.status === 'M')
+    && (/^services\/gateway\/src\//.test(f.path)
+        || /^services\/autopilot-worker\/src\//.test(f.path))
+  );
+  if (codeTouched) return [];
+
+  // Check for opt-out sentinel in each migration.
+  const relevant = [];
+  for (const m of addedMigrations) {
+    const sql = readFileAtRepo(repoRoot, m.path);
+    if (sql && /impact-allow-solo-migration/i.test(sql)) continue;
+    relevant.push(m.path);
+  }
+  if (relevant.length === 0) return [];
+
+  return [{
+    rule: meta.rule,
+    severity: meta.severity,
+    file_path: relevant[0],
+    line_number: null,
+    message: `${relevant.length} migration(s) added with no gateway/worker code change: ${relevant.join(', ')}.`,
+    suggested_action: `Confirm the schema change is already usable by existing code, or land the code change in the same PR. To silence this intentionally (pure-RLS / index / backfill / retention), add the comment \`-- impact-allow-solo-migration\` anywhere in the migration SQL.`,
+    raw: { migrations: relevant },
+  }];
+}

--- a/scripts/ci/impact-rules/new-env-var-requires-workflow-binding.mjs
+++ b/scripts/ci/impact-rules/new-env-var-requires-workflow-binding.mjs
@@ -1,0 +1,108 @@
+/**
+ * new-env-var-requires-workflow-binding
+ *
+ * When a diff ADDS a `process.env.X` reference (not just reads an existing
+ * var in a line that got moved), X should exist in at least one of:
+ *   - .github/workflows/*.yml (env: or secrets:)
+ *   - .env.example / .env.template
+ *   - services/<svc>/.env.example
+ *   - any Cloud Run deploy config (EXEC-DEPLOY.yml args)
+ *
+ * Otherwise the var reads as undefined in production and the code path
+ * silently no-ops. This has happened repeatedly (GCP_PROJECT_ID incident,
+ * Appilix push config incident, etc.).
+ */
+
+import { extractAddedLines, readFileSafe } from './_shared.mjs';
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const meta = {
+  rule: 'new-env-var-requires-workflow-binding',
+  category: 'companion',
+  severity: 'warning',
+};
+
+const ENV_VAR_RE = /process\.env\.([A-Z][A-Z0-9_]+)/g;
+
+// Vars everyone knows are set by the platform — skip these.
+const ALWAYS_BOUND = new Set([
+  'NODE_ENV', 'PORT', 'HOME', 'PATH', 'PWD', 'USER', 'TZ', 'LANG',
+  'NODE_VERSION', 'HOSTNAME',
+  // GitHub Actions built-ins
+  'GITHUB_SHA', 'GITHUB_REF', 'GITHUB_REPOSITORY', 'GITHUB_RUN_ID',
+  'GITHUB_ACTOR', 'GITHUB_WORKFLOW', 'GITHUB_EVENT_NAME', 'GITHUB_EVENT_PATH',
+  'GITHUB_HEAD_REF', 'GITHUB_BASE_REF', 'GITHUB_REF_NAME',
+  'CI', 'RUNNER_OS', 'RUNNER_NAME',
+  // Cloud Run built-ins
+  'K_SERVICE', 'K_REVISION', 'K_CONFIGURATION', 'GOOGLE_CLOUD_PROJECT',
+  // Optional operator knobs with sensible defaults — safe to read as undefined.
+  'IMPACT_RULE_ALLOWLIST', 'IMPACT_RULE_DENYLIST', 'IMPACT_SCAN_BASE', 'IMPACT_SCAN_DRY_RUN',
+  'SCANNER_ALLOWLIST', 'SCANNER_DENYLIST',
+  'MISSING_TESTS_MIN_LOC', 'MISSING_TESTS_FILENAME_DENYLIST',
+  'STALE_FLAG_DAYS', 'PRODUCT_GAP_INTERVAL_HOURS',
+]);
+
+function collectConfigFiles(repoRoot) {
+  const texts = [];
+  const roots = [
+    '.github/workflows',
+    'services/gateway',
+    'services/autopilot-worker',
+    'services/oasis-operator',
+    'services/oasis-projector',
+  ];
+  for (const root of roots) {
+    const abs = path.join(repoRoot, root);
+    if (!fs.existsSync(abs)) continue;
+    const stack = [abs];
+    while (stack.length > 0) {
+      const cur = stack.pop();
+      let entries = [];
+      try { entries = fs.readdirSync(cur, { withFileTypes: true }); }
+      catch { continue; }
+      for (const e of entries) {
+        if (e.name === 'node_modules' || e.name === 'dist' || e.name === '.git') continue;
+        const full = path.join(cur, e.name);
+        if (e.isDirectory()) { stack.push(full); continue; }
+        if (/\.(yml|yaml|json|sh)$/.test(e.name) || /\.env(\.example|\.template)?$/.test(e.name)) {
+          const t = readFileSafe(full);
+          if (t) texts.push(t);
+        }
+      }
+    }
+  }
+  return texts.join('\n');
+}
+
+export async function check({ diff, repoRoot }) {
+  // Only check added lines in source files (not config/test files).
+  const added = extractAddedLines(diff, /\.(ts|tsx|mjs|js)$/);
+  const newVars = new Set();
+  for (const l of added) {
+    if (/\/(test|tests|__tests__|__mocks__|fixtures)\//.test(l.file)) continue;
+    if (/\.(test|spec)\.(ts|tsx|mjs|js)$/.test(l.file)) continue;
+    let m;
+    ENV_VAR_RE.lastIndex = 0;
+    while ((m = ENV_VAR_RE.exec(l.text)) !== null) {
+      const v = m[1];
+      if (ALWAYS_BOUND.has(v)) continue;
+      newVars.add(v);
+    }
+  }
+  if (newVars.size === 0) return [];
+
+  const configText = collectConfigFiles(repoRoot);
+  const missing = [...newVars].filter(v => !new RegExp(`\\b${v}\\b`).test(configText));
+  if (missing.length === 0) return [];
+
+  return [{
+    rule: meta.rule,
+    severity: meta.severity,
+    file_path: null,
+    line_number: null,
+    message: `${missing.length} new process.env reference(s) with no binding in any workflow / deploy config / .env.example: ${missing.join(', ')}.`,
+    suggested_action: `For each var, either (a) bind it in the relevant deploy workflow (e.g. EXEC-DEPLOY.yml service env), (b) add it to the service's .env.example with a documented default, or (c) if it's truly optional, add a defensive \`process.env.X ?? 'default'\` at the call site.`,
+    raw: { missing_env_vars: missing },
+  }];
+}

--- a/scripts/ci/impact-rules/new-impact-rule-needs-seed-migration.mjs
+++ b/scripts/ci/impact-rules/new-impact-rule-needs-seed-migration.mjs
@@ -1,0 +1,43 @@
+/**
+ * new-impact-rule-needs-seed-migration
+ *
+ * Mirror of new-scanner-needs-seed-migration but for impact rules. A new
+ * file under scripts/ci/impact-rules/ should come with a seed migration row.
+ */
+
+export const meta = {
+  rule: 'new-impact-rule-needs-seed-migration',
+  category: 'companion',
+  severity: 'warning',
+};
+
+const SKIP_PATHS = new Set([
+  'scripts/ci/impact-rules/_shared.mjs',
+  'scripts/ci/impact-rules/registry.mjs',
+]);
+
+export async function check({ changedFiles }) {
+  const newRules = changedFiles.filter(f =>
+    f.status === 'A'
+    && /^scripts\/ci\/impact-rules\/.+\.mjs$/.test(f.path)
+    && !SKIP_PATHS.has(f.path)
+    && !f.path.startsWith('scripts/ci/impact-rules/_')
+  );
+  if (newRules.length === 0) return [];
+
+  const migrationTouched = changedFiles.some(f =>
+    (f.status === 'A' || f.status === 'M')
+    && /^supabase\/migrations\/.+\.sql$/.test(f.path)
+  );
+  if (migrationTouched) return [];
+
+  return [{
+    rule: meta.rule,
+    severity: meta.severity,
+    file_path: newRules[0].path,
+    line_number: null,
+    message: `New impact rule file(s) added [${newRules.map(r => r.path).join(', ')}] but no supabase/migrations/*.sql was updated to seed the dev_autopilot_impact_rules row.`,
+    suggested_action: `Append a migration that inserts the new rule(s) into dev_autopilot_impact_rules with matching metadata. Pattern: follow the initial dev_autopilot_impact_rules migration's INSERT ... ON CONFLICT DO UPDATE shape.`,
+    raw: { new_rules: newRules.map(r => r.path) },
+  }];
+}

--- a/scripts/ci/impact-rules/new-mutation-without-oasis-emit.mjs
+++ b/scripts/ci/impact-rules/new-mutation-without-oasis-emit.mjs
@@ -1,0 +1,114 @@
+/**
+ * new-mutation-without-oasis-emit
+ *
+ * CLAUDE.md invariant: "Always emit OASIS events for real state transitions."
+ * This rule flags newly-added state-mutating handlers (POST/PUT/PATCH/DELETE)
+ * in route files that do not call emitOasisEvent within the handler body.
+ *
+ * Logic:
+ *   - Find route files touched by the PR.
+ *   - Parse each such file's HEAD state; for every router.METHOD(path, ...)
+ *     handler where METHOD ∈ {post,put,patch,delete}, extract the handler
+ *     body block (between the first `=>` or `function () {` and its matching
+ *     closing brace).
+ *   - If the handler body doesn't contain emitOasisEvent, AND the handler's
+ *     opening `router.METHOD(` line appears in the diff as an added line,
+ *     flag it.
+ *
+ * Opt-out: add `// impact-allow-no-oasis` anywhere in the handler body.
+ */
+
+import { extractAddedLines, readFileAtRepo } from './_shared.mjs';
+import fs from 'node:fs';
+import path from 'node:path';
+
+export const meta = {
+  rule: 'new-mutation-without-oasis-emit',
+  category: 'semantic',
+  severity: 'warning',
+};
+
+const MUTATION_METHODS = new Set(['post', 'put', 'patch', 'delete']);
+
+function extractHandlerBody(src, callStart) {
+  // Walk forward from `router.METHOD(` to the matching `)`, then find the
+  // last `=>` or `function()` marker before it, capture the body between
+  // the opening `{` and its matching `}`.
+  const openParen = src.indexOf('(', callStart);
+  if (openParen < 0) return null;
+  let depth = 1;
+  let i = openParen + 1;
+  while (i < src.length && depth > 0) {
+    const c = src[i];
+    if (c === '(' || c === '[' || c === '{') depth++;
+    else if (c === ')' || c === ']' || c === '}') depth--;
+    else if (c === '"' || c === "'" || c === '`') {
+      const q = c; i++;
+      while (i < src.length && src[i] !== q) { if (src[i] === '\\') i++; i++; }
+    }
+    if (depth === 0) break;
+    i++;
+  }
+  const callEnd = i;
+  // Extract the argument region, find the LAST handler function.
+  const args = src.slice(openParen + 1, callEnd);
+  // The handler is the last arg — find the last `=>` and grab until the end.
+  const arrow = args.lastIndexOf('=>');
+  if (arrow >= 0) return args.slice(arrow + 2);
+  const fnKeyword = args.lastIndexOf('function');
+  if (fnKeyword >= 0) return args.slice(fnKeyword);
+  return args;
+}
+
+export async function check({ diff, repoRoot }) {
+  const added = extractAddedLines(diff, /^services\/gateway\/src\/routes\/.+\.(ts|tsx)$/);
+  // Group the added lines by file and mark which files saw an added
+  // router.METHOD(... where METHOD is a mutation.
+  const byFile = new Map();
+  for (const l of added) {
+    for (const method of MUTATION_METHODS) {
+      const re = new RegExp(`^\\s*router\\.${method}\\s*\\(`);
+      if (re.test(l.text)) {
+        if (!byFile.has(l.file)) byFile.set(l.file, []);
+        byFile.get(l.file).push({ method: method.toUpperCase(), text: l.text });
+      }
+    }
+  }
+  if (byFile.size === 0) return [];
+
+  const findings = [];
+  for (const [file, mutations] of byFile) {
+    // Read the HEAD file so we can inspect handler bodies.
+    const src = readFileAtRepo(repoRoot, file);
+    if (!src) continue;
+
+    for (const m of mutations) {
+      // Find the position of this added handler in the HEAD source.
+      const methodRe = new RegExp(`router\\.${m.method.toLowerCase()}\\s*\\([^)]*`, 'g');
+      let match;
+      while ((match = methodRe.exec(src)) !== null) {
+        // Match the first handler whose argument starts similarly to the added line.
+        const addedPathMatch = /[`'"]([^`'"]+)[`'"]/.exec(m.text);
+        const expectPath = addedPathMatch ? addedPathMatch[1] : null;
+        const thisPath = /[`'"]([^`'"]+)[`'"]/.exec(match[0])?.[1] || null;
+        if (expectPath && thisPath && expectPath !== thisPath) continue;
+        const body = extractHandlerBody(src, match.index);
+        if (!body) continue;
+        if (/\/\/\s*impact-allow-no-oasis/i.test(body)) break;
+        if (/\bemitOasisEvent\s*\(/.test(body)) break;
+        const lineNumber = src.slice(0, match.index).split('\n').length;
+        findings.push({
+          rule: meta.rule,
+          severity: meta.severity,
+          file_path: file,
+          line_number: lineNumber,
+          message: `${file}:${lineNumber} added ${m.method} handler for \`${thisPath || '?'}\` but the handler body does not call emitOasisEvent.`,
+          suggested_action: `Add an emitOasisEvent call inside the handler to record the state transition, or add \`// impact-allow-no-oasis\` inside the handler body if the operation truly has no state change worth recording (rare for mutations).`,
+          raw: { method: m.method, route: thisPath },
+        });
+        break;
+      }
+    }
+  }
+  return findings;
+}

--- a/scripts/ci/impact-rules/new-oasis-event-requires-union.mjs
+++ b/scripts/ci/impact-rules/new-oasis-event-requires-union.mjs
@@ -1,0 +1,76 @@
+/**
+ * new-oasis-event-requires-union
+ *
+ * emitOasisEvent({ type: 'foo.bar' }) with a type string not in the
+ * OasisEventType union in services/gateway/src/types/cicd.ts will be
+ * rejected by TypeScript at build time IF caller types it explicitly,
+ * but plenty of call sites pass anonymous objects that slip through.
+ *
+ * This rule extracts literal `type: 'x.y.z'` assignments from added
+ * emitOasisEvent calls, then asserts the string appears somewhere in the
+ * OasisEventType union on disk.
+ *
+ * Noise control:
+ *   - Only triggers when the PR diff ADDS a new type literal.
+ *   - Skips types containing template literal markers (`${...}`).
+ *   - Skips tests (under /test/ or /__tests__/).
+ */
+
+import { extractAddedLines, readFileAtRepo } from './_shared.mjs';
+
+export const meta = {
+  rule: 'new-oasis-event-requires-union',
+  category: 'companion',
+  severity: 'blocker',
+};
+
+const EVENT_TYPE_RE = /emitOasisEvent\s*\(\s*\{[^}]*\btype\s*:\s*['"`]([a-z0-9_.-]+)['"`]/gi;
+const CICD_TYPES_PATH = 'services/gateway/src/types/cicd.ts';
+
+export async function check({ diff, repoRoot }) {
+  const addedLines = extractAddedLines(diff, /\.(ts|tsx|mjs|js)$/);
+  const newTypes = new Set();
+  for (const l of addedLines) {
+    if (/\/(test|tests|__tests__|__mocks__)\//.test(l.file)) continue;
+    // The impact-rules files themselves document the patterns they match —
+    // skip them so a rule that references `emitOasisEvent({ type: 'foo.bar' })`
+    // as an example in a docstring doesn't trigger itself.
+    if (/^scripts\/ci\/impact-rules\//.test(l.file)) continue;
+    if (/^scripts\/ci\/scanners\//.test(l.file)) continue;
+    // Also skip lines that are clearly inside comments.
+    if (/^\s*(\*|\/\/|\*\/|\/\*)/.test(l.text)) continue;
+    let m;
+    EVENT_TYPE_RE.lastIndex = 0;
+    while ((m = EVENT_TYPE_RE.exec(l.text)) !== null) {
+      newTypes.add(m[1]);
+    }
+  }
+  if (newTypes.size === 0) return [];
+
+  const cicdSrc = readFileAtRepo(repoRoot, CICD_TYPES_PATH);
+  if (!cicdSrc) {
+    // Can't verify — emit a soft warning rather than a blocker.
+    return [{
+      rule: meta.rule,
+      severity: 'warning',
+      file_path: CICD_TYPES_PATH,
+      line_number: null,
+      message: `Could not read ${CICD_TYPES_PATH} to verify event-type union. Verify manually that [${[...newTypes].join(', ')}] are listed.`,
+      suggested_action: `Ensure each new event-type string literal appears in the OasisEventType union in ${CICD_TYPES_PATH}.`,
+      raw: { new_event_types: [...newTypes] },
+    }];
+  }
+
+  const missing = [...newTypes].filter(t => !cicdSrc.includes(`'${t}'`) && !cicdSrc.includes(`"${t}"`));
+  if (missing.length === 0) return [];
+
+  return missing.map(t => ({
+    rule: meta.rule,
+    severity: meta.severity,
+    file_path: CICD_TYPES_PATH,
+    line_number: null,
+    message: `emitOasisEvent uses type '${t}' but '${t}' is not declared in the OasisEventType union at ${CICD_TYPES_PATH}.`,
+    suggested_action: `Add \`| '${t}'\` to the OasisEventType union in ${CICD_TYPES_PATH}. Runtime handlers that filter on this type will otherwise silently drop the event.`,
+    raw: { event_type: t },
+  }));
+}

--- a/scripts/ci/impact-rules/new-route-needs-test.mjs
+++ b/scripts/ci/impact-rules/new-route-needs-test.mjs
@@ -1,0 +1,60 @@
+/**
+ * new-route-needs-test
+ *
+ * A new file under services/gateway/src/routes/ should come with a sibling
+ * test under services/gateway/test/. The baseline missing-tests-scanner
+ * catches this in cron, but at PR-time we catch it before the debt is born.
+ *
+ * Exclusions:
+ *   - Files that import nothing and export nothing (trivial routes — rare
+ *     but exist — opt-out via `// impact-allow-no-test` on first line).
+ *   - Files under 50 LOC skip (mirrors the missing-tests-scanner threshold).
+ */
+
+import path from 'node:path';
+import { readFileAtRepo } from './_shared.mjs';
+
+export const meta = {
+  rule: 'new-route-needs-test',
+  category: 'companion',
+  severity: 'warning',
+};
+
+export async function check({ changedFiles, repoRoot }) {
+  const newRoutes = changedFiles.filter(f =>
+    f.status === 'A'
+    && /^services\/gateway\/src\/routes\/.+\.(ts|tsx)$/.test(f.path)
+    && !/\.(test|spec)\.(ts|tsx)$/.test(f.path)
+    && !f.path.endsWith('.d.ts')
+  );
+  if (newRoutes.length === 0) return [];
+
+  const findings = [];
+  for (const r of newRoutes) {
+    const src = readFileAtRepo(repoRoot, r.path);
+    if (!src) continue;
+    if (/^\s*\/\/\s*impact-allow-no-test/.test(src)) continue;
+    if (src.split('\n').length < 50) continue;
+    // Derive the expected test file name.
+    const base = path.basename(r.path, path.extname(r.path));
+    const testCandidates = [
+      `services/gateway/test/${base}.test.ts`,
+      `services/gateway/tests/${base}.test.ts`,
+      `services/gateway/test/routes/${base}.test.ts`,
+    ];
+    const hasTest = changedFiles.some(f =>
+      (f.status === 'A' || f.status === 'M') && testCandidates.includes(f.path)
+    );
+    if (hasTest) continue;
+    findings.push({
+      rule: meta.rule,
+      severity: meta.severity,
+      file_path: r.path,
+      line_number: null,
+      message: `${r.path} is a new route file but no companion test was added.`,
+      suggested_action: `Add ${testCandidates[0]} covering the route's auth + happy-path + error-path. To opt out (rare), add \`// impact-allow-no-test\` as the first line of the route file.`,
+      raw: { route_file: r.path, expected_test_files: testCandidates },
+    });
+  }
+  return findings;
+}

--- a/scripts/ci/impact-rules/new-route-without-auth-middleware.mjs
+++ b/scripts/ci/impact-rules/new-route-without-auth-middleware.mjs
@@ -1,0 +1,66 @@
+/**
+ * new-route-without-auth-middleware
+ *
+ * Diff-aware version of route-auth-scanner-v1: checks ONLY the new handlers
+ * added in this PR, not the baseline. Prevents regressions without
+ * re-flagging long-standing gaps.
+ *
+ * Heuristic: a handler added in this PR (`router.METHOD(...)` appearing in
+ * the diff as an added line) that doesn't reference any known auth
+ * middleware in its argument chain. File-level `router.use(requireXxx)`
+ * at the top of the file is honored, matching the baseline scanner's
+ * semantics.
+ */
+
+import { extractAddedLines, readFileAtRepo } from './_shared.mjs';
+
+export const meta = {
+  rule: 'new-route-without-auth-middleware',
+  category: 'semantic',
+  severity: 'warning',
+};
+
+const AUTH_NAMES = [
+  'requireAuth', 'requireAdmin', 'requireDevRole', 'requirePlatformAdmin',
+  'optionalAuth', 'requireTenant', 'requireAuthOptional', 'requireServiceRole',
+  'requireApiKey', 'requireScanToken',
+];
+const ROUTE_PREFIX_RE = /^\s*router\.(get|post|put|patch|delete)\s*\(/;
+
+export async function check({ diff, repoRoot }) {
+  const added = extractAddedLines(diff, /^services\/gateway\/src\/routes\/.+\.(ts|tsx)$/);
+  const byFile = new Map();
+  for (const l of added) {
+    if (!ROUTE_PREFIX_RE.test(l.text)) continue;
+    if (!byFile.has(l.file)) byFile.set(l.file, []);
+    byFile.get(l.file).push(l.text);
+  }
+  if (byFile.size === 0) return [];
+
+  const findings = [];
+  for (const [file, lines] of byFile) {
+    const src = readFileAtRepo(repoRoot, file);
+    if (!src) continue;
+    // File-level auth short-circuit — mirrors baseline scanner.
+    const fileLevelAuth = new RegExp(`router\\.use\\(\\s*(?:${AUTH_NAMES.join('|')})\\b`).test(src);
+    if (fileLevelAuth) continue;
+    // Line-level: added handler that DOES include an auth name is fine.
+    const authRe = new RegExp(`\\b(?:${AUTH_NAMES.join('|')})\\b`);
+    const unauthedLines = lines.filter(t => !authRe.test(t));
+    if (unauthedLines.length === 0) continue;
+    // Public-route sentinel on the added line itself
+    const trulyUnauth = unauthedLines.filter(t => !/\/\/\s*public[-\s]?route\b/i.test(t));
+    if (trulyUnauth.length === 0) continue;
+
+    findings.push({
+      rule: meta.rule,
+      severity: meta.severity,
+      file_path: file,
+      line_number: null,
+      message: `${file} has ${trulyUnauth.length} newly-added handler(s) without auth middleware and no file-level router.use(requireXxx).`,
+      suggested_action: `For each new handler, either wrap with requireAuth / requireAdmin / requireDevRole / requireTenant, apply \`router.use(requireXxx)\` at the top of the file, or add \`// public-route\` above the line if the handler is intentionally anonymous.`,
+      raw: { handler_count: trulyUnauth.length },
+    });
+  }
+  return findings;
+}

--- a/scripts/ci/impact-rules/new-scanner-needs-seed-migration.mjs
+++ b/scripts/ci/impact-rules/new-scanner-needs-seed-migration.mjs
@@ -1,0 +1,50 @@
+/**
+ * new-scanner-needs-seed-migration
+ *
+ * If a new scanner module was added under scripts/ci/scanners/ (excluding
+ * the shared helpers and the registry itself), the PR should also include
+ * a migration under supabase/migrations/ that inserts the row into
+ * dev_autopilot_scanners.
+ *
+ * Coarse check — we don't parse the migration's SQL, just assert that at
+ * least one migration under supabase/migrations/ was added in the same PR.
+ * The 20260424000000 migration's ON CONFLICT DO UPDATE means operators can
+ * re-apply it with the new row appended.
+ */
+
+export const meta = {
+  rule: 'new-scanner-needs-seed-migration',
+  category: 'companion',
+  severity: 'warning',
+};
+
+const SKIP_PATHS = new Set([
+  'scripts/ci/scanners/_shared.mjs',
+  'scripts/ci/scanners/registry.mjs',
+]);
+
+export async function check({ changedFiles }) {
+  const newScanners = changedFiles.filter(f =>
+    f.status === 'A'
+    && /^scripts\/ci\/scanners\/.+\.mjs$/.test(f.path)
+    && !SKIP_PATHS.has(f.path)
+    && !f.path.startsWith('scripts/ci/scanners/_')
+  );
+  if (newScanners.length === 0) return [];
+
+  const migrationTouched = changedFiles.some(f =>
+    (f.status === 'A' || f.status === 'M')
+    && /^supabase\/migrations\/.+\.sql$/.test(f.path)
+  );
+  if (migrationTouched) return [];
+
+  return [{
+    rule: meta.rule,
+    severity: meta.severity,
+    file_path: newScanners[0].path,
+    line_number: null,
+    message: `New scanner file(s) added [${newScanners.map(s => s.path).join(', ')}] but no supabase/migrations/*.sql was updated to seed the dev_autopilot_scanners row.`,
+    suggested_action: `Append a migration that inserts the new scanner(s) into dev_autopilot_scanners with matching metadata (title, description, signal_type, category, maturity, severity, risk_class). Pattern: follow 20260424000000_BOOTSTRAP_dev_autopilot_scanners_registry.sql.`,
+    raw: { new_scanners: newScanners.map(s => s.path) },
+  }];
+}

--- a/scripts/ci/impact-rules/new-signal-type-requires-registry.mjs
+++ b/scripts/ci/impact-rules/new-signal-type-requires-registry.mjs
@@ -1,0 +1,50 @@
+/**
+ * new-signal-type-requires-registry
+ *
+ * Guards the invariant: if services/gateway/src/services/dev-autopilot-synthesis.ts
+ * gained a new value in its SignalType union, scripts/ci/scanners/registry.mjs
+ * must ALSO have been updated with the scanner that emits it — otherwise
+ * scans work but the Command Hub Scanners tab shows an orphan.
+ *
+ * Heuristic:
+ *   - Extract all `| 'foo'` lines added to the diff in dev-autopilot-synthesis.ts.
+ *   - For each added union value, check that scripts/ci/scanners/registry.mjs
+ *     was ALSO touched in this PR.
+ *   - (Coarse: we don't try to verify the exact scanner row exists — the
+ *     'new-scanner-needs-seed-migration' rule covers the DB side.)
+ */
+
+import { extractAddedLines } from './_shared.mjs';
+
+export const meta = {
+  rule: 'new-signal-type-requires-registry',
+  category: 'companion',
+  severity: 'blocker',
+};
+
+export async function check({ diff, changedFiles }) {
+  const synthTouched = changedFiles.some(f => f.path === 'services/gateway/src/services/dev-autopilot-synthesis.ts');
+  if (!synthTouched) return [];
+
+  // Added union values: lines matching `  | 'foo'`
+  const added = extractAddedLines(diff, /services\/gateway\/src\/services\/dev-autopilot-synthesis\.ts$/);
+  const newTypes = [];
+  for (const l of added) {
+    const m = /^\s*\|\s*'([a-z_][a-z0-9_]*)'/.exec(l.text);
+    if (m) newTypes.push(m[1]);
+  }
+  if (newTypes.length === 0) return [];
+
+  const registryTouched = changedFiles.some(f => f.path === 'scripts/ci/scanners/registry.mjs');
+  if (registryTouched) return [];
+
+  return [{
+    rule: meta.rule,
+    severity: meta.severity,
+    file_path: 'services/gateway/src/services/dev-autopilot-synthesis.ts',
+    line_number: null,
+    message: `New SignalType value(s) [${newTypes.join(', ')}] added, but scripts/ci/scanners/registry.mjs was not updated. Scanner registry and synthesis types must evolve together.`,
+    suggested_action: `Add corresponding entries to SCANNERS in scripts/ci/scanners/registry.mjs — one per new signal_type — so the Command Hub registry reflects the new detector(s).`,
+    raw: { new_signal_types: newTypes },
+  }];
+}

--- a/scripts/ci/impact-rules/registry.mjs
+++ b/scripts/ci/impact-rules/registry.mjs
@@ -1,0 +1,125 @@
+/**
+ * Dev Autopilot — impact rule registry.
+ *
+ * Source of truth for:
+ *   - scripts/ci/dev-autopilot-impact-scan.mjs (the driver iterates this list)
+ *   - supabase/migrations/*_dev_autopilot_impact_rules.sql (seed rows match)
+ *   - services/gateway/src/routes/dev-autopilot.ts GET /impact-rules
+ *
+ * Categories:
+ *   - companion — "if X changed, Y should change too" (missing companions)
+ *   - conflict  — "this PR contradicts or duplicates existing state"
+ *   - semantic  — "new code should match how the rest of the system does it"
+ *
+ * Severity:
+ *   - blocker  — fails the PR check; merge should not happen without resolution
+ *   - warning  — posts comment, does NOT fail the check
+ *   - info     — observational, surfaces for review but doesn't gate
+ *
+ * Adding a new rule:
+ *   1. Create scripts/ci/impact-rules/<name>.mjs with meta + check() exports.
+ *   2. Add an entry here.
+ *   3. Append a seed row to the next migration.
+ */
+
+export const IMPACT_RULES = [
+  // ── companion rules ──────────────────────────────────────────────────────
+  {
+    rule: 'new-signal-type-requires-registry',
+    title: 'New SignalType needs a scanner registry entry',
+    description: 'When a new value is added to the SignalType union in services/gateway/src/services/dev-autopilot-synthesis.ts, scripts/ci/scanners/registry.mjs must declare the scanner that emits it. Without the registry entry, scan output for that type lands in the queue but the Command Hub Scanners tab can\'t show it.',
+    category: 'companion',
+    severity: 'blocker',
+    enabled: true,
+  },
+  {
+    rule: 'new-scanner-needs-seed-migration',
+    title: 'New scanner file needs a DB seed migration',
+    description: 'Adding a file under scripts/ci/scanners/ without a corresponding INSERT into dev_autopilot_scanners means the scanner runs but the Command Hub registry table doesn\'t know about it — it shows up as an orphan.',
+    category: 'companion',
+    severity: 'warning',
+    enabled: true,
+  },
+  {
+    rule: 'new-impact-rule-needs-seed-migration',
+    title: 'New impact rule file needs a DB seed migration',
+    description: 'Adding a file under scripts/ci/impact-rules/ without a corresponding INSERT into dev_autopilot_impact_rules means the rule fires but the Command Hub Impact Rules tab doesn\'t reflect it.',
+    category: 'companion',
+    severity: 'warning',
+    enabled: true,
+  },
+  {
+    rule: 'new-oasis-event-requires-union',
+    title: 'emitOasisEvent({ type: \'X\' }) must have X in the OasisEventType union',
+    description: 'Calls to emitOasisEvent with a type string that isn\'t in services/gateway/src/types/cicd.ts OasisEventType union will be rejected at runtime. This rule extracts new event-type strings from the diff and asserts they exist in the union.',
+    category: 'companion',
+    severity: 'blocker',
+    enabled: true,
+  },
+  {
+    rule: 'migration-requires-code-touch',
+    title: 'Migration added without any gateway code change',
+    description: 'A new supabase/migrations/*.sql file that doesn\'t coincide with any change under services/gateway/src is often a sign of schema drift — the new column/table/policy exists in the DB but nothing in the code uses it yet.',
+    category: 'companion',
+    severity: 'warning',
+    enabled: true,
+  },
+  {
+    rule: 'new-env-var-requires-workflow-binding',
+    title: 'New process.env.X without a binding in .github/workflows',
+    description: 'A new process.env.X reference in source code should be explicitly bound in at least one of .github/workflows/*.yml, .env.example, or the Cloud Run deploy config. Unbound env vars read as undefined in production.',
+    category: 'companion',
+    severity: 'warning',
+    enabled: true,
+  },
+  {
+    rule: 'new-route-needs-test',
+    title: 'New gateway route without a sibling test',
+    description: 'A new file under services/gateway/src/routes/ without a matching *.test.ts under services/gateway/test/ means the route ships untested. The baseline missing-tests-scanner would catch this eventually, but the impact-scan catches it at PR time, which is cheaper to fix.',
+    category: 'companion',
+    severity: 'warning',
+    enabled: true,
+  },
+
+  // ── conflict rules ───────────────────────────────────────────────────────
+  {
+    rule: 'duplicate-route-registration',
+    title: 'New route path collides with an existing registration',
+    description: 'A new router.METHOD(path, ...) whose (method, full_path) already exists in another route file at main. Duplicate registrations cause the handler that wins to be Express-version-dependent — don\'t ship one.',
+    category: 'conflict',
+    severity: 'blocker',
+    enabled: true,
+  },
+  {
+    rule: 'duplicate-table-name',
+    title: 'New CREATE TABLE matches an existing table name',
+    description: 'A migration that does CREATE TABLE foo where foo already exists at main will fail at psql time. This catches it before merge rather than at migration-dispatch time.',
+    category: 'conflict',
+    severity: 'blocker',
+    enabled: true,
+  },
+
+  // ── semantic rules ───────────────────────────────────────────────────────
+  {
+    rule: 'new-route-without-auth-middleware',
+    title: 'New gateway route without auth middleware',
+    description: 'New state-mutating handler (POST/PUT/PATCH/DELETE) in a route file that has no file-level router.use(requireAuth) OR per-handler auth. Mirrors the baseline route-auth-scanner but scoped to the diff, so mistakes get flagged before merge.',
+    category: 'semantic',
+    severity: 'warning',
+    enabled: true,
+  },
+  {
+    rule: 'new-mutation-without-oasis-emit',
+    title: 'New state-mutating route without an emitOasisEvent call',
+    description: 'CLAUDE.md invariant: "Always emit OASIS events for real state transitions." New POST/PUT/PATCH/DELETE handlers that never call emitOasisEvent break the observability contract — Self-Heal and audit can\'t see the state change.',
+    category: 'semantic',
+    severity: 'warning',
+    enabled: true,
+  },
+];
+
+export function byRule() {
+  const map = new Map();
+  for (const r of IMPACT_RULES) map.set(r.rule, r);
+  return map;
+}

--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -2676,6 +2676,7 @@ const NAVIGATION_CONFIG = [
         "tabs": [
             { "key": "registry", "path": "/command-hub/autopilot/registry/" },
             { "key": "scanners", "path": "/command-hub/autopilot/scanners/" },
+            { "key": "impact-rules", "path": "/command-hub/autopilot/impact-rules/" },
             { "key": "runs", "path": "/command-hub/autopilot/runs/" },
             { "key": "live", "path": "/command-hub/autopilot/live/" },
             { "key": "engine", "path": "/command-hub/autopilot/engine/" },
@@ -6222,6 +6223,8 @@ function renderModuleContent(moduleKey, tab) {
         container.appendChild(renderAutopilotRegistryView());
     } else if (moduleKey === 'autopilot' && tab === 'scanners') {
         container.appendChild(renderAutopilotScannersView());
+    } else if (moduleKey === 'autopilot' && tab === 'impact-rules') {
+        container.appendChild(renderAutopilotImpactRulesView());
     } else if (moduleKey === 'autopilot' && tab === 'runs') {
         container.appendChild(renderAutopilotRunsView());
     } else if (moduleKey === 'autopilot' && tab === 'live') {
@@ -38916,6 +38919,7 @@ if (!state.autopilot) {
     state.autopilot = {
         registry: { loading: false, data: null, summary: null, filters: { domain: '', status: '', trigger: '', search: '' } },
         scanners: { loading: false, data: null, filter: { category: '', maturity: '' } },
+        impactRules: { loading: false, data: null, filter: { category: '', severity: '' } },
         runs: { loading: false, data: null, filters: { automation_id: '', status: '', limit: 50 } },
         live: { loading: false, activeRuns: null, recentRuns: null, engineStatus: null },
         engine: { loading: false, loopStatus: null, cronJobs: null },
@@ -39469,6 +39473,166 @@ function renderAutopilotScannersView() {
         container.appendChild(section);
     });
 
+    return container;
+}
+
+// ── Impact Rules view ────────────────────────────────────────
+// Surfaces GET /api/v1/dev-autopilot/impact-rules. Diff-aware rules that run
+// on every PR — companion checks, conflict detectors, and semantic patterns.
+// See scripts/ci/impact-rules/registry.mjs for the code source of truth.
+
+async function fetchAutopilotImpactRules() {
+    var s = state.autopilot.impactRules;
+    if (s.loading) return;
+    s.loading = true;
+    renderApp();
+    try {
+        var res = await fetch('/api/v1/dev-autopilot/impact-rules', { headers: buildContextHeaders({}) });
+        if (res.ok) {
+            var data = await res.json();
+            s.data = (data && Array.isArray(data.rules)) ? data.rules : [];
+        } else {
+            console.error('[Autopilot] fetchImpactRules failed:', res.status);
+            s.data = [];
+        }
+    } catch (err) {
+        console.error('[Autopilot] fetchImpactRules error:', err);
+        s.data = [];
+    } finally {
+        s.loading = false;
+        renderApp();
+    }
+}
+
+function renderAutopilotImpactRulesView() {
+    var container = document.createElement('div');
+    container.style.padding = '1.5rem';
+
+    var title = document.createElement('h2');
+    title.textContent = 'Impact Rules';
+    container.appendChild(title);
+    var subtitle = document.createElement('p');
+    subtitle.className = 'section-subtitle';
+    subtitle.textContent = 'Diff-aware rules that run on every PR. They catch companion updates that got missed, conflicts with existing state, and new code that doesn’t match established patterns — before merge, not after.';
+    container.appendChild(subtitle);
+
+    var s = state.autopilot.impactRules;
+    if (!s.data && !s.loading) {
+        setTimeout(function () { fetchAutopilotImpactRules(); }, 0);
+    }
+    if (s.loading) {
+        var loader = document.createElement('div');
+        loader.className = 'loading-indicator';
+        loader.textContent = 'Loading impact rules...';
+        container.appendChild(loader);
+        return container;
+    }
+    if (!s.data) return container;
+
+    var total = s.data.length;
+    var enabled = s.data.filter(function (r) { return r.enabled; }).length;
+    var blocker = s.data.filter(function (r) { return r.severity === 'blocker'; }).length;
+    var warning = s.data.filter(function (r) { return r.severity === 'warning'; }).length;
+
+    var summaryRow = document.createElement('div');
+    summaryRow.style.cssText = 'display:flex;gap:1rem;flex-wrap:wrap;margin-bottom:1.5rem;';
+    summaryRow.appendChild(createSummaryCard('Rules', total, '#fff'));
+    summaryRow.appendChild(createSummaryCard('Enabled', enabled, '#4caf50'));
+    summaryRow.appendChild(createSummaryCard('Blockers', blocker, '#f44336'));
+    summaryRow.appendChild(createSummaryCard('Warnings', warning, '#ffb74d'));
+    container.appendChild(summaryRow);
+
+    var filter = s.filter;
+    var filtersRow = document.createElement('div');
+    filtersRow.style.cssText = 'display:flex;gap:0.75rem;flex-wrap:wrap;margin-bottom:1rem;align-items:center;';
+    var categories = [''].concat(Array.from(new Set(s.data.map(function (r) { return r.category; }))).sort());
+    var catSelect = document.createElement('select');
+    catSelect.style.cssText = 'padding:6px 10px;border-radius:6px;background:#1a1a2e;color:#ccc;border:1px solid #333;font-size:0.85rem;';
+    catSelect.innerHTML = categories.map(function (c) {
+        var label = c === '' ? 'All categories' : c;
+        return '<option value="' + c + '"' + (filter.category === c ? ' selected' : '') + '>' + label + '</option>';
+    }).join('');
+    catSelect.onchange = function () { filter.category = this.value; renderApp(); };
+    filtersRow.appendChild(catSelect);
+
+    var severities = ['', 'blocker', 'warning', 'info'];
+    var sevSelect = document.createElement('select');
+    sevSelect.style.cssText = 'padding:6px 10px;border-radius:6px;background:#1a1a2e;color:#ccc;border:1px solid #333;font-size:0.85rem;';
+    sevSelect.innerHTML = severities.map(function (m) {
+        var label = m === '' ? 'Any severity' : m;
+        return '<option value="' + m + '"' + (filter.severity === m ? ' selected' : '') + '>' + label + '</option>';
+    }).join('');
+    sevSelect.onchange = function () { filter.severity = this.value; renderApp(); };
+    filtersRow.appendChild(sevSelect);
+
+    var refreshBtn = document.createElement('button');
+    refreshBtn.textContent = 'Refresh';
+    refreshBtn.style.cssText = 'padding:6px 14px;border-radius:6px;background:#333;color:#ccc;border:1px solid #444;cursor:pointer;font-size:0.85rem;';
+    refreshBtn.onclick = function () { state.autopilot.impactRules.data = null; fetchAutopilotImpactRules(); };
+    filtersRow.appendChild(refreshBtn);
+    container.appendChild(filtersRow);
+
+    var rows = s.data.filter(function (r) {
+        if (filter.category && r.category !== filter.category) return false;
+        if (filter.severity && r.severity !== filter.severity) return false;
+        return true;
+    });
+    var byCat = {};
+    rows.forEach(function (r) { (byCat[r.category] = byCat[r.category] || []).push(r); });
+    var catOrder = ['conflict', 'companion', 'semantic'];
+    var seenCats = Object.keys(byCat).sort(function (a, b) {
+        return catOrder.indexOf(a) - catOrder.indexOf(b);
+    });
+
+    seenCats.forEach(function (cat) {
+        var section = document.createElement('section');
+        section.style.cssText = 'margin-bottom:1.5rem;';
+        var h3 = document.createElement('h3');
+        h3.textContent = cat.toUpperCase() + ' (' + byCat[cat].length + ')';
+        h3.style.cssText = 'color:#888;font-size:0.8rem;letter-spacing:0.08em;margin:0 0 0.5rem 0;';
+        section.appendChild(h3);
+
+        byCat[cat].forEach(function (r) {
+            var card = document.createElement('div');
+            card.style.cssText = 'background:#13131f;border:1px solid ' + (r.enabled ? '#333' : '#555') + ';border-radius:8px;padding:12px 16px;margin-bottom:0.5rem;' + (r.enabled ? '' : 'opacity:0.55;');
+
+            var header = document.createElement('div');
+            header.style.cssText = 'display:flex;justify-content:space-between;align-items:center;gap:1rem;flex-wrap:wrap;';
+            var left = document.createElement('div');
+            left.style.cssText = 'display:flex;align-items:center;gap:0.75rem;flex-wrap:wrap;';
+            var name = document.createElement('strong');
+            name.textContent = r.title;
+            name.style.cssText = 'color:#e5e5e5;';
+            left.appendChild(name);
+            var id = document.createElement('code');
+            id.textContent = r.rule;
+            id.style.cssText = 'color:#888;font-size:0.8rem;';
+            left.appendChild(id);
+            var sevBadge = document.createElement('span');
+            sevBadge.textContent = r.severity;
+            var sevColor = r.severity === 'blocker' ? '#f44336' : r.severity === 'warning' ? '#ffb74d' : '#60a5fa';
+            sevBadge.style.cssText = 'background:' + sevColor + '20;color:' + sevColor + ';border:1px solid ' + sevColor + '60;padding:2px 8px;border-radius:999px;font-size:0.72rem;';
+            left.appendChild(sevBadge);
+            header.appendChild(left);
+
+            var right = document.createElement('div');
+            right.style.cssText = 'display:flex;gap:0.75rem;align-items:center;font-size:0.82rem;color:#aaa;';
+            var enabledPill = document.createElement('span');
+            enabledPill.textContent = r.enabled ? 'enabled' : 'disabled';
+            enabledPill.style.cssText = 'background:' + (r.enabled ? '#4caf5020' : '#66666620') + ';color:' + (r.enabled ? '#4caf50' : '#888') + ';border:1px solid ' + (r.enabled ? '#4caf5050' : '#66666650') + ';padding:2px 8px;border-radius:999px;font-size:0.72rem;';
+            right.appendChild(enabledPill);
+            header.appendChild(right);
+            card.appendChild(header);
+
+            var desc = document.createElement('p');
+            desc.textContent = r.description;
+            desc.style.cssText = 'margin:0.4rem 0 0 0;color:#bbb;font-size:0.82rem;line-height:1.4;';
+            card.appendChild(desc);
+
+            section.appendChild(card);
+        });
+        container.appendChild(section);
+    });
     return container;
 }
 

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -12,7 +12,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260421-disconnect-alert"></script>
-  <script src="/command-hub/app.js?v=20260424-scanner-registry"></script>
+  <script src="/command-hub/app.js?v=20260424-impact-rules"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
 </body>

--- a/services/gateway/src/routes/dev-autopilot.ts
+++ b/services/gateway/src/routes/dev-autopilot.ts
@@ -230,6 +230,30 @@ router.get('/scanners', requireDevRole, async (_req: Request, res: Response) => 
 });
 
 // =============================================================================
+// GET /impact-rules — diff-aware rule registry
+// =============================================================================
+
+router.get('/impact-rules', requireDevRole, async (_req: Request, res: Response) => {
+  const supa = getSupabase();
+  if (!supa) return res.status(500).json({ ok: false, error: 'Supabase not configured' });
+
+  const r = await supaGet<Array<{
+    rule: string;
+    title: string;
+    description: string;
+    category: string;
+    severity: string;
+    enabled: boolean;
+    docs_url: string | null;
+    created_at: string;
+    updated_at: string;
+  }>>(supa, `/rest/v1/dev_autopilot_impact_rules?order=category.asc,rule.asc`);
+  if (!r.ok) return res.status(500).json({ ok: false, error: r.error });
+
+  return res.json({ ok: true, rules: r.data, count: (r.data || []).length });
+});
+
+// =============================================================================
 // GET /queue — queue with optional filters
 // =============================================================================
 

--- a/supabase/migrations/20260424100000_BOOTSTRAP_dev_autopilot_impact_rules.sql
+++ b/supabase/migrations/20260424100000_BOOTSTRAP_dev_autopilot_impact_rules.sql
@@ -1,0 +1,95 @@
+-- =============================================================================
+-- Dev Autopilot — impact rule registry
+-- =============================================================================
+-- DB-side source of truth for the diff-aware rules that run on every PR
+-- (scripts/ci/impact-rules/*.mjs, driven by scripts/ci/dev-autopilot-impact-scan.mjs).
+--
+-- Same pattern as dev_autopilot_scanners: the code file
+-- scripts/ci/impact-rules/registry.mjs is the authoritative list; this
+-- table is seeded from it so the Command Hub can show the inventory with
+-- operator-controlled enabled/disabled state.
+--
+-- Join pattern (Command Hub GET /impact-rules):
+--   SELECT r.* FROM dev_autopilot_impact_rules r ORDER BY category, rule;
+--
+-- Categories:
+--   - companion : "if X changed, Y should change too"
+--   - conflict  : "this PR contradicts or duplicates existing state"
+--   - semantic  : "new code should match how the rest of the system does it"
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.dev_autopilot_impact_rules (
+  rule              TEXT        PRIMARY KEY,
+  title             TEXT        NOT NULL,
+  description       TEXT        NOT NULL,
+  category          TEXT        NOT NULL
+    CHECK (category IN ('companion','conflict','semantic')),
+  severity          TEXT        NOT NULL DEFAULT 'warning'
+    CHECK (severity IN ('blocker','warning','info')),
+  enabled           BOOLEAN     NOT NULL DEFAULT TRUE,
+  docs_url          TEXT,
+  created_at        TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at        TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_dev_autopilot_impact_rules_category
+  ON public.dev_autopilot_impact_rules (category, enabled);
+
+ALTER TABLE public.dev_autopilot_impact_rules ENABLE ROW LEVEL SECURITY;
+-- Service role reads/writes. No policies needed.
+
+-- Seed the initial 11 rules. Re-runnable via ON CONFLICT DO UPDATE.
+INSERT INTO public.dev_autopilot_impact_rules
+  (rule, title, description, category, severity, enabled)
+VALUES
+  ('new-signal-type-requires-registry',
+   'New SignalType needs a scanner registry entry',
+   'When a new value is added to the SignalType union in services/gateway/src/services/dev-autopilot-synthesis.ts, scripts/ci/scanners/registry.mjs must declare the scanner that emits it. Without the registry entry, scan output for that type lands in the queue but the Command Hub Scanners tab cannot show it.',
+   'companion', 'blocker', TRUE),
+  ('new-scanner-needs-seed-migration',
+   'New scanner file needs a DB seed migration',
+   'Adding a file under scripts/ci/scanners/ without a corresponding INSERT into dev_autopilot_scanners means the scanner runs but the Command Hub registry table does not know about it — it shows up as an orphan.',
+   'companion', 'warning', TRUE),
+  ('new-impact-rule-needs-seed-migration',
+   'New impact rule file needs a DB seed migration',
+   'Adding a file under scripts/ci/impact-rules/ without a corresponding INSERT into dev_autopilot_impact_rules means the rule fires but the Command Hub Impact Rules tab does not reflect it.',
+   'companion', 'warning', TRUE),
+  ('new-oasis-event-requires-union',
+   'emitOasisEvent({ type: X }) must have X in the OasisEventType union',
+   'Calls to emitOasisEvent with a type string that is not in services/gateway/src/types/cicd.ts OasisEventType union are rejected by handlers that filter on the union. This rule extracts new event-type strings from the diff and asserts they exist in the union.',
+   'companion', 'blocker', TRUE),
+  ('migration-requires-code-touch',
+   'Migration added without any gateway code change',
+   'A new supabase/migrations/*.sql file that does not coincide with any change under services/gateway/src is often a sign of schema drift — the new column/table/policy exists in the DB but nothing in the code uses it yet. Opt-out via `-- impact-allow-solo-migration` comment inside the SQL.',
+   'companion', 'warning', TRUE),
+  ('new-env-var-requires-workflow-binding',
+   'New process.env.X without a binding in any workflow / .env.example',
+   'A new process.env.X reference in source code should be explicitly bound in at least one of .github/workflows/*.yml, .env.example, or the Cloud Run deploy config. Unbound env vars read as undefined in production and silently no-op the code path.',
+   'companion', 'warning', TRUE),
+  ('new-route-needs-test',
+   'New gateway route without a sibling test',
+   'A new file under services/gateway/src/routes/ without a matching *.test.ts under services/gateway/test/ means the route ships untested. The baseline missing-tests-scanner catches this eventually; catching it at PR time is cheaper to fix. Opt-out via `// impact-allow-no-test` as first line.',
+   'companion', 'warning', TRUE),
+  ('duplicate-route-registration',
+   'New route path collides with an existing registration',
+   'A new router.METHOD(path, ...) whose (method, path) already exists in another route file is a silent correctness bug: which handler wins depends on Express version and registration order. Blocks the PR.',
+   'conflict', 'blocker', TRUE),
+  ('duplicate-table-name',
+   'New CREATE TABLE matches an existing table name',
+   'A migration that runs CREATE TABLE foo where foo already exists at main will fail at psql time. Catches it before merge so migration dispatch does not trip. Use CREATE TABLE IF NOT EXISTS if intent is idempotent, ALTER TABLE for column changes, or rename to avoid collision.',
+   'conflict', 'blocker', TRUE),
+  ('new-route-without-auth-middleware',
+   'New gateway route without auth middleware',
+   'New handler in a route file that has no file-level router.use(requireAuth) AND no per-handler auth call. Mirrors the baseline route-auth-scanner but scoped to diff, so mistakes get flagged before merge. Opt-out via `// public-route` above the handler.',
+   'semantic', 'warning', TRUE),
+  ('new-mutation-without-oasis-emit',
+   'New state-mutating route without an emitOasisEvent call',
+   'CLAUDE.md invariant: "Always emit OASIS events for real state transitions." New POST/PUT/PATCH/DELETE handlers that never call emitOasisEvent break observability — Self-Heal and audit cannot see the state change. Opt-out via `// impact-allow-no-oasis` inside the handler body.',
+   'semantic', 'warning', TRUE)
+ON CONFLICT (rule) DO UPDATE SET
+  title       = EXCLUDED.title,
+  description = EXCLUDED.description,
+  category    = EXCLUDED.category,
+  severity    = EXCLUDED.severity,
+  -- Preserve operator-set `enabled`.
+  updated_at  = NOW();


### PR DESCRIPTION
## Summary

Adds a **second analyzer surface** next to the baseline scanners: an **Impact Scan** that runs on every pull request and checks the PR's git diff for three things the existing scanners can't see:

1. **Companion updates missing** — if you changed X, did Y need to change too?
2. **Conflicts with existing state** — does this PR contradict or duplicate what's already there?
3. **Pattern deviations** — does new code match how the rest of the system does it?

The two analyzer surfaces answer different questions:

| | Scanners (DEV-AUTOPILOT.yml) | Impact Rules (this PR) |
|---|---|---|
| Trigger | cron 2×/day | pull_request event |
| Input | whole repo | git diff base...HEAD |
| Output | `autopilot_recommendations` | PR comment + artifact |
| Effect | queue fills over time | blocks/warns at merge |

## Seed rules (11 total)

**companion** (if X changes, Y should too):
- `new-signal-type-requires-registry` 🟥 blocker
- `new-scanner-needs-seed-migration` 🟨 warning
- `new-impact-rule-needs-seed-migration` 🟨 warning
- `new-oasis-event-requires-union` 🟥 blocker
- `migration-requires-code-touch` 🟨 warning
- `new-env-var-requires-workflow-binding` 🟨 warning
- `new-route-needs-test` 🟨 warning

**conflict** (PR contradicts existing state):
- `duplicate-route-registration` 🟥 blocker
- `duplicate-table-name` 🟥 blocker

**semantic** (new code should match patterns):
- `new-route-without-auth-middleware` 🟨 warning
- `new-mutation-without-oasis-emit` 🟨 warning

Each rule has an opt-out sentinel for legit edge cases (e.g. `// impact-allow-no-test`, `// public-route`, `-- impact-allow-solo-migration`).

## Registry surface

Same pattern as the scanner registry:
- Code source of truth: [scripts/ci/impact-rules/registry.mjs](scripts/ci/impact-rules/registry.mjs)
- DB table: `dev_autopilot_impact_rules` (seeded from code)
- API: `GET /api/v1/dev-autopilot/impact-rules` (requireDevRole)
- UI: **Command Hub → Autopilot → Impact Rules** — new tab grouped by category with severity badges

## How the PR comment works

The workflow posts an auto-updating PR comment (hidden `<!-- impact-scan -->` marker). On subsequent pushes, the existing comment is PATCHed rather than spamming new ones. Blockers fail the job; warnings surface without blocking. Findings artifact uploaded for 14 days.

## Dogfooding results

This PR was itself scanned against its own base (HEAD~1) with the final build: **0 findings** after fixing two initial false positives that the scanner caught on the draft commit:
- `new-oasis-event-requires-union` was matching example strings in its OWN source file — fixed by skipping `scripts/ci/impact-rules/` and `scripts/ci/scanners/` from that rule's scan.
- `new-env-var-requires-workflow-binding` flagged `IMPACT_RULE_ALLOWLIST` / `IMPACT_RULE_DENYLIST` (optional knobs) — added them + other optional knobs to `ALWAYS_BOUND`.

## Test plan

- [x] gateway `tsc --noEmit` — clean
- [x] Local dry-run (`IMPACT_SCAN_BASE=HEAD~1 node scripts/ci/dev-autopilot-impact-scan.mjs`) — 0 findings on this PR's own diff
- [ ] Apply migration `20260424100000_BOOTSTRAP_dev_autopilot_impact_rules.sql` via `RUN-MIGRATION.yml`
- [ ] Merge + EXEC-DEPLOY
- [ ] Verify `GET /api/v1/dev-autopilot/impact-rules` returns 11 rules
- [ ] Open Command Hub → Autopilot → Impact Rules, verify tab renders
- [ ] Verify the `DEV-AUTOPILOT-IMPACT` workflow attached to THIS PR runs and posts a comment (meta-verification — the workflow lands in the same PR it runs against)

## Follow-up

Separate PR: wire impact findings into `autopilot_recommendations` with `source_type='dev_autopilot_impact'` so the autopilot can auto-fix companion-change omissions in a follow-up PR. This one just ships the detection surface.

🤖 Generated with [Claude Code](https://claude.com/claude-code)