### PR TITLE
fix(orb): stopword generic UI nouns (BOOTSTRAP-ORB-NAV-UI-STOPWORDS)

### DIFF
--- a/services/gateway/src/lib/nav-catalog-db.ts
+++ b/services/gateway/src/lib/nav-catalog-db.ts
@@ -394,8 +394,14 @@ const SCORER_STOPWORDS = new Set<string>([
   'want', 'wants', 'wanted', 'need', 'needs', 'needed', 'like', 'likes', 'liked',
   'get', 'got', 'getting', 'take', 'taken', 'taking',
   'show', 'shows', 'showed', 'open', 'opens', 'opened', 'close', 'closed', 'go', 'goes', 'going', 'went',
-  // German navigation verbs
+  // Generic UI nouns — users say "open the X screen" meaning "open X". Kept
+  // in sync with navigation-catalog.ts::STOPWORDS.
+  'screen', 'screens', 'page', 'pages', 'section', 'sections',
+  'view', 'views', 'panel', 'panels', 'tab', 'tabs', 'window', 'windows',
+  // German navigation verbs + UI nouns
   'öffne', 'öffnen', 'öffnet', 'schließen', 'schließe',
+  'seite', 'seiten', 'bildschirm', 'bildschirme',
+  'ansicht', 'ansichten', 'bereich', 'bereiche', 'fenster',
   // German
   'ich', 'mich', 'mir', 'mein', 'meine', 'meinen', 'meinem', 'meiner', 'meines',
   'du', 'dich', 'dir', 'dein', 'deine', 'deinen',

--- a/services/gateway/src/lib/navigation-catalog.ts
+++ b/services/gateway/src/lib/navigation-catalog.ts
@@ -219,8 +219,18 @@ const STOPWORDS = new Set<string>([
   'want', 'wants', 'wanted', 'need', 'needs', 'needed', 'like', 'likes', 'liked',
   'get', 'got', 'getting', 'take', 'taken', 'taking',
   'show', 'shows', 'showed', 'open', 'opens', 'opened', 'close', 'closed', 'go', 'goes', 'going', 'went',
-  // German navigation verbs
+  // Generic UI nouns — users say "open the X screen" meaning "open X". Without
+  // these in stopwords, any entry whose when_to_visit mentions "screen" /
+  // "page" / "section" picks up a keyword hit on the generic word and the
+  // Navigator can't distinguish specific matches from noise (see "open
+  // connectors screen" silently matching HOME because its hint ends with
+  // "...or simply the home screen").
+  'screen', 'screens', 'page', 'pages', 'section', 'sections',
+  'view', 'views', 'panel', 'panels', 'tab', 'tabs', 'window', 'windows',
+  // German navigation verbs + UI nouns
   'öffne', 'öffnen', 'öffnet', 'schließen', 'schließe',
+  'seite', 'seiten', 'bildschirm', 'bildschirme',
+  'ansicht', 'ansichten', 'bereich', 'bereiche', 'fenster',
   // German
   'ich', 'mich', 'mir', 'mein', 'meine', 'meinen', 'meinem', 'meiner', 'meines',
   'du', 'dich', 'dir', 'dein', 'deine', 'deinen',


### PR DESCRIPTION
## Summary
"open the connectors screen" still cycled through Home / Calendar / Wallet on repeat after the semantic floor in #878. Each of those community pages' \`when_to_visit\` hints mentions "screen" as filler (e.g. HOME.OVERVIEW ends with "...or simply the home screen") — so the query's "screen" token scored a hit, kept keywordScore > 0, and bypassed the \`keywordScore === 0\` gate of the floor.

## Fix
Add generic UI nouns to STOPWORDS in both the static (`navigation-catalog.ts`) and DB-backed (`nav-catalog-db.ts`) scorers:
- EN: screen, page, section, view, panel, tab, window (+ plurals)
- DE: seite, bildschirm, ansicht, bereich, fenster (+ plurals)

Users say "open the X screen" meaning "open X" — the UI noun itself carries no content signal.

## Local sim (community role)
| Query | Result |
|---|---|
| "open connectors screen" | no keyword matches → clarification |
| "open the screen with the connectors" | no keyword matches → clarification |
| "open my health screen" | HEALTH.OVERVIEW @ /health (24) |
| "open my health page" | HEALTH.OVERVIEW @ /health (24) |

## Test plan
- [x] 121/121 jest tests pass
- [ ] Mobile: "open connectors screen" → clarification ask (no more cycling)
- [ ] Mobile: "open my health screen" → `/health`

🤖 Generated with [Claude Code](https://claude.com/claude-code)