### PR TITLE
feat(autopilot): wire impact findings into autopilot_recommendations queue

### DIFF
--- a/.github/workflows/DEV-AUTOPILOT-IMPACT.yml
+++ b/.github/workflows/DEV-AUTOPILOT-IMPACT.yml
@@ -16,6 +16,12 @@ on:
     # Run on any PR targeting main — the rules self-filter by touched path.
     branches: [main]
     types: [opened, synchronize, reopened, ready_for_review]
+  push:
+    # Also run on push to main so findings from merged PRs get INGESTED
+    # into autopilot_recommendations (dev_autopilot_impact source_type).
+    # PR-scoped runs only post a comment; push-to-main runs persist findings
+    # so the Developer Autopilot view can surface + auto-fix them.
+    branches: [main]
   workflow_dispatch:
     inputs:
       base_ref:
@@ -32,15 +38,25 @@ permissions:
   pull-requests: write # for the PR-comment step
 
 concurrency:
-  group: impact-scan-${{ github.event.pull_request.number || github.ref }}
-  cancel-in-progress: true
+  # PR events: group per-PR so synchronize cancels the prior run.
+  # Push events: queue so each merge commit's findings get ingested.
+  group: impact-scan-${{ github.event.pull_request.number || github.sha }}
+  cancel-in-progress: ${{ github.event_name == 'pull_request' }}
 
 jobs:
   scan:
     runs-on: ubuntu-latest
     env:
       IMPACT_SCAN_DRY_RUN: ${{ github.event.inputs.dry_run || 'false' }}
-      IMPACT_SCAN_BASE: ${{ github.event.inputs.base_ref || format('origin/{0}', github.event.pull_request.base.ref || 'main') }}
+      # Base ref per event type:
+      #   pull_request  → origin/<pr.base.ref>
+      #   push (main)   → HEAD~1 (compare merge commit to its parent)
+      #   workflow_dispatch → user override OR origin/main
+      IMPACT_SCAN_BASE: >-
+        ${{ github.event.inputs.base_ref
+          || (github.event_name == 'pull_request' && format('origin/{0}', github.event.pull_request.base.ref))
+          || (github.event_name == 'push' && 'HEAD~1')
+          || 'origin/main' }}
     steps:
       - name: Checkout (full history for diff)
         uses: actions/checkout@v4
@@ -54,9 +70,49 @@ jobs:
 
       - name: Run impact scan
         id: scan
-        # Continue even on blocker — we want to post the comment before failing.
+        # Continue even on blocker — we want to post the comment + ingest first,
+        # then fail the check.
         continue-on-error: true
         run: node scripts/ci/dev-autopilot-impact-scan.mjs
+
+      # Ingest step: only on push to main. Persists non-info findings into
+      # autopilot_recommendations (source_type='dev_autopilot_impact') so the
+      # Developer Autopilot view can activate them one by one.
+      - name: Ingest impact findings into Developer Autopilot queue
+        if: github.event_name == 'push' && github.ref == 'refs/heads/main'
+        env:
+          GATEWAY_URL: https://gateway-q74ibpv6ia-uc.a.run.app
+          DEV_AUTOPILOT_SCAN_TOKEN: ${{ secrets.DEV_AUTOPILOT_SCAN_TOKEN }}
+        run: |
+          if [ ! -f dev-autopilot-impact-findings.json ]; then
+            echo "No findings file to ingest — skipping."
+            exit 0
+          fi
+          # Build the ingest payload from the driver's output.
+          python3 <<'PY' > ingest-payload.json
+          import json
+          with open('dev-autopilot-impact-findings.json') as fh:
+              data = json.load(fh)
+          payload = {
+              'findings': data.get('findings', []),
+              'metadata': {
+                  'github_sha': '${{ github.sha }}',
+                  'github_ref': '${{ github.ref }}',
+                  'github_run_id': '${{ github.run_id }}',
+                  'event_name': '${{ github.event_name }}',
+              },
+          }
+          with open('ingest-payload.json', 'w') as fh:
+              json.dump(payload, fh)
+          PY
+          curl -sS -o ingest-response.json -w "status=%{http_code}\n" \
+            -X POST "$GATEWAY_URL/api/v1/dev-autopilot/impact-ingest" \
+            -H "Content-Type: application/json" \
+            -H "X-DevAutopilot-Scan-Token: $DEV_AUTOPILOT_SCAN_TOKEN" \
+            --data-binary @ingest-payload.json
+          echo "Ingest response:"
+          cat ingest-response.json
+          echo
 
       - name: Build PR comment body
         id: comment
@@ -145,8 +201,8 @@ jobs:
           retention-days: 14
           if-no-files-found: warn
 
-      - name: Fail if blocker findings (respecting dry_run)
-        if: ${{ env.IMPACT_SCAN_DRY_RUN != 'true' && steps.scan.outcome == 'failure' }}
+      - name: Fail if blocker findings (PR only, respecting dry_run)
+        if: ${{ github.event_name == 'pull_request' && env.IMPACT_SCAN_DRY_RUN != 'true' && steps.scan.outcome == 'failure' }}
         run: |
           echo "Impact scan reported blocker findings. See the PR comment or the uploaded artifact."
           exit 1

--- a/services/gateway/src/routes/dev-autopilot.ts
+++ b/services/gateway/src/routes/dev-autopilot.ts
@@ -73,6 +73,25 @@ async function supaPatch(supa: SupaConfig, path: string, body: unknown): Promise
   }
 }
 
+async function supaPost(supa: SupaConfig, path: string, body: unknown): Promise<{ ok: boolean; error?: string }> {
+  try {
+    const res = await fetch(`${supa.url}${path}`, {
+      method: 'POST',
+      headers: {
+        apikey: supa.key,
+        Authorization: `Bearer ${supa.key}`,
+        'Content-Type': 'application/json',
+        Prefer: 'return=minimal',
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) return { ok: false, error: `${res.status}: ${await res.text()}` };
+    return { ok: true };
+  } catch (err) {
+    return { ok: false, error: String(err) };
+  }
+}
+
 // =============================================================================
 // Auth guard
 // =============================================================================
@@ -135,6 +154,145 @@ router.post('/scan', requireScanToken, async (req: Request, res: Response) => {
     return res.status(500).json({ ok: false, error: String(err) });
   }
 });
+
+// =============================================================================
+// POST /impact-ingest — diff-aware impact findings from PR-time scans
+// =============================================================================
+// Called by .github/workflows/DEV-AUTOPILOT-IMPACT.yml after the impact scan
+// completes on a push to main. Rows land in autopilot_recommendations with
+// source_type='dev_autopilot_impact' so they show up in the Developer
+// Autopilot view alongside baseline findings and can be auto-executed by
+// the same plan → approve → PR pipeline.
+//
+// Dedup: (source_type, signal_fingerprint) partial-unique index on status
+// IN ('new','snoozed') means re-ingesting the same finding bumps
+// seen_count instead of duplicating. Fingerprint = sha256 of
+// rule|file_path|message[:60] — stable across line-shift diffs.
+//
+// Skipped: findings with severity='info' (too noisy for the queue).
+
+router.post('/impact-ingest', requireScanToken, async (req: Request, res: Response) => {
+  const supa = getSupabase();
+  if (!supa) return res.status(500).json({ ok: false, error: 'Supabase not configured' });
+
+  const body = req.body as {
+    findings?: Array<{
+      rule: string;
+      category?: string;
+      severity: 'blocker' | 'warning' | 'info';
+      file_path?: string | null;
+      line_number?: number | null;
+      message: string;
+      suggested_action?: string;
+      raw?: Record<string, unknown>;
+    }>;
+    metadata?: Record<string, unknown>;
+  };
+  if (!body || !Array.isArray(body.findings)) {
+    return res.status(400).json({ ok: false, error: 'body must include findings[]' });
+  }
+
+  const { createHash } = await import('node:crypto');
+  const now = new Date().toISOString();
+  let newCount = 0;
+  let updatedCount = 0;
+  let skippedInfo = 0;
+
+  for (const f of body.findings) {
+    if (!f || !f.rule || !f.message) continue;
+    if (f.severity === 'info') { skippedInfo++; continue; }
+
+    const fingerprint = createHash('sha256')
+      .update(`${f.rule}|${f.file_path || ''}|${(f.message || '').slice(0, 60)}`)
+      .digest('hex')
+      .slice(0, 32);
+
+    // Lookup existing live finding with this fingerprint
+    const existing = await supaGet<Array<{ id: string; seen_count: number | null }>>(
+      supa,
+      `/rest/v1/autopilot_recommendations?source_type=eq.dev_autopilot_impact&signal_fingerprint=eq.${fingerprint}&status=in.(new,snoozed)&select=id,seen_count&limit=1`,
+    );
+    const hit = existing.ok && existing.data && existing.data[0];
+    if (hit) {
+      await supaPatch(supa, `/rest/v1/autopilot_recommendations?id=eq.${hit.id}`, {
+        seen_count: (hit.seen_count || 1) + 1,
+        last_seen_at: now,
+        updated_at: now,
+      });
+      updatedCount++;
+      continue;
+    }
+
+    // Scoring maps severity → risk class + impact score; effort is
+    // deliberately low because most impact findings are small companion
+    // changes the autopilot can handle in one short PR.
+    const riskClass = f.severity === 'blocker' ? 'high' : 'medium';
+    const impactScore = f.severity === 'blocker' ? 8 : 5;
+    const effortScore = 3;
+    const title = buildImpactTitle(f);
+    const domain = domainForImpactCategory(f.category || 'companion');
+
+    const inserted = await supaPost(supa, '/rest/v1/autopilot_recommendations', {
+      title,
+      summary: f.message,
+      domain,
+      risk_level: riskClass,
+      risk_class: riskClass,
+      impact_score: impactScore,
+      effort_score: effortScore,
+      status: 'new',
+      source_type: 'dev_autopilot_impact',
+      // Impact findings ship as auto-exec-eligible at blocker severity only —
+      // warnings are still reviewable but won't be picked up by auto-approve
+      // (which gates on the scanner allowlist, not this field).
+      auto_exec_eligible: f.severity === 'blocker',
+      signal_fingerprint: fingerprint,
+      first_seen_at: now,
+      last_seen_at: now,
+      seen_count: 1,
+      spec_snapshot: {
+        rule: f.rule,
+        category: f.category || 'companion',
+        severity: f.severity,
+        file_path: f.file_path || null,
+        line_number: f.line_number || null,
+        suggested_action: f.suggested_action || null,
+        scanner: `impact:${f.rule}`,
+        signal_type: 'impact_' + (f.category || 'companion'),
+        ...(f.raw || {}),
+        source_metadata: body.metadata || null,
+      },
+    });
+    if (inserted.ok) newCount++;
+  }
+
+  return res.json({
+    ok: true,
+    new_count: newCount,
+    updated_count: updatedCount,
+    skipped_info: skippedInfo,
+  });
+});
+
+function buildImpactTitle(f: {
+  rule: string;
+  file_path?: string | null;
+  severity: 'blocker' | 'warning' | 'info';
+}): string {
+  const base = f.file_path ? (f.file_path.split('/').pop() || f.file_path) : null;
+  const rulePretty = f.rule.replace(/-/g, ' ');
+  if (base) return `[${f.severity}] ${rulePretty} in ${base}`;
+  return `[${f.severity}] ${rulePretty}`;
+}
+
+function domainForImpactCategory(cat: string): string {
+  switch (cat) {
+    case 'conflict':   return 'architecture';
+    case 'semantic':   return 'routes';
+    case 'companion':  return 'services';
+    default:           return 'general';
+  }
+}
 
 // =============================================================================
 // GET /runs — last N runs
@@ -262,7 +420,14 @@ router.get('/queue', requireDevRole, async (req: Request, res: Response) => {
   if (!supa) return res.status(500).json({ ok: false, error: 'Supabase not configured' });
 
   const qs = new URLSearchParams();
-  qs.append('source_type', 'eq.dev_autopilot');
+  // Include both baseline Dev Autopilot findings and the diff-aware impact
+  // findings. Callers that want just one kind can pass ?kind=baseline or
+  // ?kind=impact; default shows both so the Developer Autopilot view can
+  // activate items from either source.
+  const kind = String(req.query.kind || 'all');
+  if (kind === 'baseline') qs.append('source_type', 'eq.dev_autopilot');
+  else if (kind === 'impact') qs.append('source_type', 'eq.dev_autopilot_impact');
+  else qs.append('source_type', 'in.(dev_autopilot,dev_autopilot_impact)');
   const status = String(req.query.status || 'new');
   qs.append('status', `eq.${status}`);
   if (req.query.risk)   qs.append('risk_class', `eq.${String(req.query.risk)}`);
@@ -344,7 +509,7 @@ router.post('/findings/:id/continue-planning', requireDevRole, async (req: Reque
 // =============================================================================
 
 async function rejectById(supa: SupaConfig, id: string): Promise<{ ok: boolean; error?: string }> {
-  const r = await supaPatch(supa, `/rest/v1/autopilot_recommendations?id=eq.${id}&source_type=eq.dev_autopilot`, {
+  const r = await supaPatch(supa, `/rest/v1/autopilot_recommendations?id=eq.${id}&source_type=in.(dev_autopilot,dev_autopilot_impact)`, {
     status: 'rejected',
     updated_at: new Date().toISOString(),
   });
@@ -391,7 +556,7 @@ async function snoozeById(
   hours: number,
 ): Promise<{ ok: boolean; error?: string }> {
   const until = new Date(Date.now() + hours * 3600 * 1000).toISOString();
-  const r = await supaPatch(supa, `/rest/v1/autopilot_recommendations?id=eq.${id}&source_type=eq.dev_autopilot`, {
+  const r = await supaPatch(supa, `/rest/v1/autopilot_recommendations?id=eq.${id}&source_type=in.(dev_autopilot,dev_autopilot_impact)`, {
     status: 'snoozed',
     snoozed_until: until,
     updated_at: new Date().toISOString(),

--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -295,7 +295,11 @@ export async function approveAutoExecute(input: ApprovalInput): Promise<Approval
   if (!recR.ok || !recR.data) return { ok: false, error: recR.error || 'finding lookup failed' };
   const rec = recR.data[0];
   if (!rec) return { ok: false, error: 'finding not found' };
-  if (rec.source_type !== 'dev_autopilot') return { ok: false, error: 'not a dev_autopilot finding' };
+  // Accept both baseline and impact-scan findings — both flow through the
+  // same plan→approve→execute path. Reject anything else (community, system).
+  if (rec.source_type !== 'dev_autopilot' && rec.source_type !== 'dev_autopilot_impact') {
+    return { ok: false, error: `not a dev_autopilot finding (source_type=${rec.source_type})` };
+  }
 
   // 2. Load latest plan version
   const planR = await supa<Array<{ version: number; files_referenced: string[]; plan_markdown: string }>>(

--- a/supabase/migrations/20260424200000_BOOTSTRAP_autopilot_recommendations_impact_source.sql
+++ b/supabase/migrations/20260424200000_BOOTSTRAP_autopilot_recommendations_impact_source.sql
@@ -1,0 +1,38 @@
+-- =============================================================================
+-- Dev Autopilot — allow source_type='dev_autopilot_impact' on recommendations
+-- =============================================================================
+-- The impact scanner (PR-time, diff-aware) emits findings that should live
+-- in the same queue as the baseline scanners, but tagged with their own
+-- source_type so the Developer Autopilot view can filter + style them
+-- differently. Their lifecycle is shorter than baseline findings:
+-- companion/conflict/semantic issues typically resolve in a single follow-up PR.
+--
+-- Current check (from 20260416100000_dev_autopilot.sql):
+--   CHECK (source_type IN ('community', 'dev_autopilot', 'system'))
+--
+-- After this migration:
+--   CHECK (source_type IN ('community', 'dev_autopilot', 'dev_autopilot_impact', 'system'))
+-- =============================================================================
+
+ALTER TABLE public.autopilot_recommendations
+  DROP CONSTRAINT IF EXISTS autopilot_recommendations_source_type_check;
+
+ALTER TABLE public.autopilot_recommendations
+  ADD CONSTRAINT autopilot_recommendations_source_type_check
+  CHECK (source_type IN ('community', 'dev_autopilot', 'dev_autopilot_impact', 'system'));
+
+-- Partial unique index for dedup — same fingerprint doesn't re-insert while
+-- a finding is still live (status=new or snoozed). Uses spec_snapshot->>'rule'
+-- + spec_snapshot->>'fingerprint' so re-scans bump seen_count via upsert.
+--
+-- Separate index from the baseline 20260416100000 uq_autopilot_dev_fingerprint_active
+-- so impact + baseline scanners can't collide on fingerprint.
+CREATE UNIQUE INDEX IF NOT EXISTS uq_autopilot_impact_fingerprint_active
+  ON public.autopilot_recommendations (source_type, signal_fingerprint)
+  WHERE source_type = 'dev_autopilot_impact'
+    AND signal_fingerprint IS NOT NULL
+    AND status IN ('new', 'snoozed');
+
+CREATE INDEX IF NOT EXISTS idx_autopilot_impact_queue
+  ON public.autopilot_recommendations (source_type, status, created_at DESC)
+  WHERE source_type = 'dev_autopilot_impact';


### PR DESCRIPTION
## Summary

Follow-up to #877. Impact-scan findings from merged PRs now persist into the autopilot queue as `source_type='dev_autopilot_impact'`, so the Developer Autopilot view at [/command-hub/autonomy/autopilot-developer/](https://gateway-q74ibpv6ia-uc.a.run.app/command-hub/autonomy/autopilot-developer/) surfaces them next to baseline findings. Operators can activate them one-by-one through the same plan → approve → PR pipeline.

## What ships

1. **Migration 20260424200000** — extends `autopilot_recommendations_source_type_check` to allow `'dev_autopilot_impact'` + partial-unique fingerprint index.
2. **POST /api/v1/dev-autopilot/impact-ingest** (scan-token authed) — upserts non-info-severity findings with sha256-fingerprint dedup.
3. **Queue + action endpoints** extended to accept `source_type IN (dev_autopilot, dev_autopilot_impact)`. New `?kind=baseline|impact|all` filter on `/queue`.
4. **`approveAutoExecute`** accepts `dev_autopilot_impact` so impact findings can be planned + executed through the validation + worker-owned PR pipeline.
5. **Workflow** now fires on push to main (in addition to PR events). Push runs: compute diff from `HEAD~1`, run the scan, POST to `/impact-ingest`. Blockers only fail the check on PR events — push never fails the workflow (PR was already merged; failing post-hoc would just look like a broken deploy).

## Scoring

| severity | risk_class | impact_score | auto_exec_eligible |
|---|---|---|---|
| blocker | high | 8 | true |
| warning | medium | 5 | false |
| info | — | — | **skipped (not queued)** |

All impact findings get `effort_score=3` — they tend to be small companion changes.

## Auto-approve gating

The `autoApproveTick` continues to pick **baseline findings only**. Impact findings stay manual-approval until you've validated the flow one-by-one. Once the queue pattern is trusted, a follow-up PR can add `dev_autopilot_impact` to the allowlist.

## Test plan

- [x] gateway `tsc --noEmit` clean (only pre-existing unrelated errors)
- [ ] Apply migration `20260424200000_BOOTSTRAP_autopilot_recommendations_impact_source.sql` via `RUN-MIGRATION.yml`
- [ ] Merge + EXEC-DEPLOY
- [ ] The push-to-main that merges *this* PR will itself trigger an impact scan → ingest meta-test; verify the gateway accepts POST `/impact-ingest` with 200 and no findings persist (this PR's own diff is clean)
- [ ] Verify `GET /api/v1/dev-autopilot/queue` now returns both source_types (default) and `?kind=impact` filters correctly
- [ ] After a subsequent PR with real impact findings merges, verify its findings show up in `/command-hub/autonomy/autopilot-developer/` with `[blocker]` / `[warning]` title prefixes
- [ ] Activate one impact finding via the Developer view, watch it generate a plan + auto-execute PR through the existing pipeline

## Rollout

1. Merge this PR.
2. Apply the migration.
3. Gateway redeploys automatically.
4. Next merge to main will trigger the first push-event impact scan, which will call the ingest endpoint. If that merge introduces any blocker or warning findings, they'll appear in the queue immediately.

🤖 Generated with [Claude Code](https://claude.com/claude-code)