### PR TITLE
fix(orb): Index voice polish + retired-pillar silent aliasing + template plan fallback (R4.1)

### DIFF
--- a/services/gateway/src/lib/vitana-pillars.ts
+++ b/services/gateway/src/lib/vitana-pillars.ts
@@ -102,8 +102,119 @@ export function tierForScore(total: number): TierBand {
   return t;
 }
 
-/** Aspirational "Really good" entry — used for default 90-day framing. */
+/** Aspirational "Really good" entry — the Day-90 milestone for most users. */
 export const REALLY_GOOD_THRESHOLD = 600;
+
+/**
+ * Stretch target — a second aspirational anchor deep inside the Elite band
+ * (800-999). Shown on the Index Detail goal card as the "stretch" goal.
+ * Reaching it takes months of sustained balanced practice, not a 90-day
+ * sprint. Voice references it when the user asks what 850 means.
+ */
+export const STRETCH_TARGET = 850;
+
+/**
+ * Project a Day-90 linear forecast from a 7-day trend.
+ *
+ *   projected = clamp(0, 999, total + trend_7d × days_remaining / 7)
+ *
+ * Matches the frontend trajectory card's simple linear model. If the
+ * trend is zero or history is missing, returns null — voice should fall
+ * back to aspirational framing rather than quote a phantom projection.
+ *
+ * @param total            current Index score
+ * @param trend7d          delta vs 7 days ago (positive = rising)
+ * @param daysSinceStart   whole days since user's first Index row / registration
+ */
+export function projectDay90(
+  total: number,
+  trend7d: number,
+  daysSinceStart: number,
+): number | null {
+  if (!Number.isFinite(total) || !Number.isFinite(trend7d)) return null;
+  const daysRemaining = Math.max(0, 90 - daysSinceStart);
+  if (daysRemaining === 0) return Math.max(0, Math.min(999, Math.round(total)));
+  const projected = total + (trend7d * daysRemaining) / 7;
+  return Math.max(0, Math.min(999, Math.round(projected)));
+}
+
+/**
+ * Pillar-specific action templates — the fallback library the voice plan
+ * tool uses when there are no matching autopilot_recommendations for the
+ * user's target pillar yet (new accounts, empty queue, or a pillar with
+ * no current rec mapping). Each entry is a standalone, self-directed
+ * block the user can complete without setup.
+ *
+ * Keep these ~30 minutes each and framed as invitations, not prescriptions.
+ * Duration and wellness_tags are sourced by the calendar plan tool.
+ */
+export interface PillarActionTemplate {
+  readonly title: string;
+  readonly description: string;
+}
+
+export const PILLAR_ACTION_TEMPLATES: Record<PillarKey, readonly PillarActionTemplate[]> = {
+  nutrition: [
+    { title: 'Meal planning block', description: '15 minutes to plan balanced meals for the next two days. Focus on one protein source and two colors of vegetables per meal.' },
+    { title: 'Mindful eating session', description: 'One slow, phone-free meal. Notice tastes, textures, fullness signals.' },
+    { title: 'Nutrition log review', description: '10 minutes to log recent meals and reflect on macro balance.' },
+  ],
+  hydration: [
+    { title: 'Hydration check-in', description: 'Review today\'s water intake target. Top up if behind. Keep a water bottle within reach.' },
+    { title: 'Electrolyte reset', description: 'Short hydration + electrolyte block — salt, lemon, or a sports-drink alternative. Especially after exercise or heat.' },
+    { title: 'Pre-sleep hydration window', description: 'Last drink at least 90 minutes before bed so sleep isn\'t interrupted. Set a gentle evening cue.' },
+  ],
+  exercise: [
+    { title: '30-minute movement block', description: 'Walk, cycle, or light workout. Any sustained movement that raises your heart rate for the full 30 minutes.' },
+    { title: 'Mobility + recovery', description: '15 minutes of gentle mobility: hips, shoulders, spine. Slow, deliberate. Not a workout — a reset.' },
+    { title: 'Structured workout session', description: 'Strength or cardio session of your choice. Intensity to taste. Complete, then log how it felt.' },
+  ],
+  sleep: [
+    { title: 'Wind-down block', description: '30 minutes before bed with dim lights, screens off, calm routine. Reading, stretching, breathwork — anything below-the-line arousal.' },
+    { title: 'Sleep check-in', description: 'Note bedtime and wake time. Review what shifted compared to the previous night. No judgement, just data.' },
+    { title: 'Consistent bedtime', description: 'Anchor a bedtime within 30 minutes of your target window. Regularity matters more than total duration.' },
+  ],
+  mental: [
+    { title: 'Meditation / breathwork', description: '10 minutes of guided breath practice. Box breathing, 4-7-8, or any app-led session. Settles the nervous system.' },
+    { title: 'Journal entry', description: '5–10 minutes of free-writing. One sentence about something that surprised you, one intention for tomorrow.' },
+    { title: 'Quiet walk (no input)', description: '15-minute walk with no podcast, no phone. Let the mind unclench. Notice what bubbles up.' },
+  ],
+} as const;
+
+/**
+ * Silent alias map from retired 6-pillar names to the closest canonical
+ * 5-pillar key. Used by ORB tool executors and the retrieval path so when
+ * the model (or the user) slips and says "Physical" / "Prosperity" / etc.,
+ * we route them to the right bucket without acknowledging the retired
+ * pillar name in voice.
+ *
+ * Mapping choices mirror the 5-pillar cleanup migration's data-repair
+ * COALESCE fallback (score_physical → score_exercise primary, with
+ * score_sleep as a secondary split). "Social / environmental / prosperity"
+ * all route to Mental as the closest quality-of-life anchor we actually
+ * measure in the five-pillar model.
+ */
+export const RETIRED_PILLAR_ALIASES: Record<string, PillarKey> = {
+  physical: 'exercise',
+  nutritional: 'nutrition',
+  social: 'mental',
+  environmental: 'mental',
+  prosperity: 'mental',
+};
+
+/**
+ * Resolve a raw pillar argument (possibly from the model) to a canonical
+ * PillarKey, or `undefined` if unknown. Lowercases, checks the retired
+ * alias map first, then the canonical set. Callers should fall back to
+ * the weakest pillar when this returns undefined.
+ */
+export function resolvePillarKey(raw: unknown): PillarKey | undefined {
+  if (typeof raw !== 'string') return undefined;
+  const k = raw.trim().toLowerCase();
+  if ((PILLAR_KEYS as readonly string[]).includes(k)) return k as PillarKey;
+  if (k in RETIRED_PILLAR_ALIASES) return RETIRED_PILLAR_ALIASES[k];
+  return undefined;
+}
 
 /**
  * Balance factor classification. Mirrors the compute RPC:

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -3722,18 +3722,18 @@ async function executeLiveApiToolInner(
       case 'get_index_improvement_suggestions': {
         try {
           const { fetchVitanaIndexForProfiler } = await import('../services/user-context-profiler');
-          const { PILLAR_KEYS } = await import('../lib/vitana-pillars');
+          const { resolvePillarKey } = await import('../lib/vitana-pillars');
           const { createClient } = await import('@supabase/supabase-js');
           const url = process.env.SUPABASE_URL;
           const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
           if (!url || !key) return { success: false, result: '', error: 'Supabase not configured' };
           const client = createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
 
-          // Resolve target pillar. Validate any passed value against the
-          // canonical 5-pillar set — if the model hallucinates an old name
-          // (physical, social, etc.) fall through to weakest-pillar logic.
-          const rawPillar = typeof args.pillar === 'string' ? args.pillar.toLowerCase() : undefined;
-          let pillar: string | undefined = rawPillar && (PILLAR_KEYS as readonly string[]).includes(rawPillar) ? rawPillar : undefined;
+          // Resolve target pillar. resolvePillarKey silently maps retired
+          // names (physical → exercise, prosperity → mental, etc.) so the
+          // voice path never acknowledges a 6-pillar term even if the
+          // model slips. If unknown or missing, fall back to weakest.
+          let pillar: string | undefined = resolvePillarKey(args.pillar);
           if (!pillar) {
             const snap = await fetchVitanaIndexForProfiler(client, lens.user_id);
             pillar = snap?.weakest_pillar.name;
@@ -3806,7 +3806,7 @@ async function executeLiveApiToolInner(
       case 'create_index_improvement_plan': {
         try {
           const { fetchVitanaIndexForProfiler } = await import('../services/user-context-profiler');
-          const { PILLAR_KEYS } = await import('../lib/vitana-pillars');
+          const { resolvePillarKey, PILLAR_TAGS, PILLAR_ACTION_TEMPLATES } = await import('../lib/vitana-pillars');
           const { createCalendarEvent } = await import('../services/calendar-service');
           const { createClient } = await import('@supabase/supabase-js');
           const url = process.env.SUPABASE_URL;
@@ -3814,8 +3814,10 @@ async function executeLiveApiToolInner(
           if (!url || !key) return { success: false, result: '', error: 'Supabase not configured' };
           const client = createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
 
-          const rawPillar = typeof args.pillar === 'string' ? args.pillar.toLowerCase() : undefined;
-          let pillar: string | undefined = rawPillar && (PILLAR_KEYS as readonly string[]).includes(rawPillar) ? rawPillar : undefined;
+          // resolvePillarKey silently maps retired 6-pillar names (Physical
+          // → Exercise, Prosperity → Mental, etc.) so voice never says the
+          // retired name back to the user.
+          let pillar: string | undefined = resolvePillarKey(args.pillar);
           if (!pillar) {
             const snap = await fetchVitanaIndexForProfiler(client, lens.user_id);
             pillar = snap?.weakest_pillar.name;
@@ -3830,7 +3832,8 @@ async function executeLiveApiToolInner(
           const days = typeof args.days === 'number' ? Math.min(90, Math.max(7, args.days)) : 14;
           const perWeek = typeof args.actions_per_week === 'number' ? Math.min(7, Math.max(1, args.actions_per_week)) : 3;
 
-          // Pull top recommendations for this pillar.
+          // Pull existing autopilot recommendations targeting this pillar.
+          // These are the first-choice source — personalised to the user.
           const { data } = await client
             .from('autopilot_recommendations')
             .select('id, title, action_description, contribution_vector, priority')
@@ -3849,58 +3852,82 @@ async function executeLiveApiToolInner(
             .filter((r: any) => r._lift > 0)
             .sort((a: any, b: any) => b._lift - a._lift);
 
-          if (ranked.length === 0) {
+          // Source pool for the plan: prefer matched autopilot recs, else
+          // fall back to the pillar's canonical template library. This
+          // fixes the R4 failure mode where the tool returned "no plan
+          // possible" whenever the autopilot queue was empty for a
+          // pillar — which is common on new accounts.
+          type PlanItem = {
+            title: string;
+            description: string;
+            source: 'autopilot' | 'template';
+            source_ref_id: string | null;
+          };
+          const source: PlanItem[] = ranked.length > 0
+            ? ranked.map((r: any): PlanItem => ({
+                title: r.title,
+                description: r.action_description || '',
+                source: 'autopilot',
+                source_ref_id: r.id,
+              }))
+            : (PILLAR_ACTION_TEMPLATES[pillar as keyof typeof PILLAR_ACTION_TEMPLATES] ?? []).map((t): PlanItem => ({
+                title: t.title,
+                description: t.description,
+                source: 'template',
+                source_ref_id: null,
+              }));
+
+          if (source.length === 0) {
             return {
               success: true,
-              result: `No pending autopilot recommendations target your ${pillar} pillar right now. Try again after completing a few existing ones — the engine regenerates.`,
+              result: `I can't find any actions for the ${pillar} pillar right now — neither pending autopilot suggestions nor templates. This is unexpected; please report.`,
             };
           }
 
-          // Schedule: `perWeek` actions per 7-day block, cycling through the
-          // top recommendations. Each event is placed at a reasonable time
-          // (10 AM local — widget TZ preserved via clientContext is out of
-          // scope for this tool; UTC is fine, calendar-service renders local).
           const weeks = Math.ceil(days / 7);
           const totalEvents = weeks * perWeek;
-          const scheduled: { title: string; start_time: string }[] = [];
+          const scheduled: { title: string; start_time: string; source: string }[] = [];
           const startOfToday = new Date();
           startOfToday.setHours(10, 0, 0, 0);
           startOfToday.setDate(startOfToday.getDate() + 1); // start tomorrow
 
+          // Pre-resolve the wellness tag bucket once (was previously re-
+          // imported inside the loop, which also caused extra overhead).
+          const tags = PILLAR_TAGS[pillar as keyof typeof PILLAR_TAGS];
+          const wellnessTags: string[] = tags ? [...tags] : [pillar!];
+
           for (let i = 0; i < totalEvents; i++) {
-            const rec = ranked[i % ranked.length];
+            const item = source[i % source.length];
             const eventDate = new Date(startOfToday);
-            // Spread events every 2-3 days.
             eventDate.setDate(eventDate.getDate() + Math.floor((i * 7) / perWeek));
             if (eventDate.getTime() > Date.now() + days * 24 * 60 * 60 * 1000) break;
             const startIso = eventDate.toISOString();
             const endIso = new Date(eventDate.getTime() + 30 * 60 * 1000).toISOString();
 
-            // Canonical 5-pillar wellness-tag map. Keep in sync with the
-            // source-of-truth at lib/vitana-pillars.ts (PILLAR_TAGS).
-            const { PILLAR_TAGS } = await import('../lib/vitana-pillars');
-            const tags = PILLAR_TAGS[pillar as keyof typeof PILLAR_TAGS];
-            const wellnessTags = tags ? [...tags] : [pillar!];
-
             try {
               const evt = await createCalendarEvent(lens.user_id, {
-                title: rec.title,
+                title: item.title,
                 start_time: startIso,
                 end_time: endIso,
-                description: `${rec.action_description || ''}\n\nPart of your Vitana Index improvement plan (target: ${pillar}).`.trim(),
+                description: `${item.description}\n\nPart of your Vitana Index improvement plan (target: ${pillar}).`.trim(),
                 event_type: 'health' as any,
                 status: 'confirmed',
                 priority: 'medium',
                 role_context: (session.active_role || 'community') as any,
                 source_type: 'assistant',
-                source_ref_type: 'autopilot_recommendation',
-                source_ref_id: rec.id,
+                source_ref_type: item.source === 'autopilot' ? 'autopilot_recommendation' : 'pillar_template',
+                source_ref_id: item.source_ref_id ?? undefined,
                 priority_score: 60,
                 wellness_tags: wellnessTags,
-                metadata: { created_via: 'orb_voice', plan: 'index_improvement', target_pillar: pillar },
+                metadata: {
+                  created_via: 'orb_voice',
+                  plan: 'index_improvement',
+                  target_pillar: pillar,
+                  plan_source: item.source,
+                },
                 is_recurring: false,
               });
-              if (evt) scheduled.push({ title: evt.title, start_time: evt.start_time });
+              if (evt) scheduled.push({ title: evt.title, start_time: evt.start_time, source: item.source });
             } catch (evErr: any) {
               console.warn(`[create_index_improvement_plan] event create failed: ${evErr?.message}`);
             }
@@ -3921,6 +3948,10 @@ async function executeLiveApiToolInner(
               days,
               actions_per_week: perWeek,
               scheduled_count: scheduled.length,
+              source_mix: {
+                autopilot: scheduled.filter(s => s.source === 'autopilot').length,
+                template: scheduled.filter(s => s.source === 'template').length,
+              },
               first_event: scheduled[0],
               last_event: scheduled[scheduled.length - 1],
               all_titles: scheduled.map(s => s.title),
@@ -4747,10 +4778,34 @@ Each pillar caps at 200; the total is score_total × balance_factor (0.7–1.0),
 capped at 999. Tier ladder: Starting 0-99 / Early 100-299 / Building 300-499 /
 Strong 500-599 / Really good 600-799 / Elite 800-999. "Really good" (600+) is
 the aspirational Day-90 framing — NOT a threshold the user is failing to meet.
+"850" is the stretch target shown on the goal card: deep inside Elite,
+months of sustained practice, NOT a 90-day goal.
 
-Do NOT name any other pillar (no "Physical", "Social", "Environmental",
-"Prosperity" — those are retired). If the user mentions one of those names,
-translate silently (e.g. their "Physical" maps to Exercise + Sleep).
+===== RETIRED-PILLAR HANDLING — NON-NEGOTIABLE =====
+The names "Physical", "Social", "Environmental", "Prosperity", "Nutritional"
+are RETIRED. They do not exist in the Vitana Index. If the user (or you)
+slips and uses one, you MUST silently translate to the canonical pillar
+and NEVER echo the retired name back in your reply. Silent means: act as
+if the canonical name is what the user said. Do NOT say "translating your
+'Physical' to...". Do NOT say "I'll help with your Physical pillar". Do
+NOT offer Physical as an option in a follow-up question. Just answer
+about the canonical pillar directly.
+
+Silent alias map:
+  Physical      → Exercise   (closest primary fit; Sleep is secondary)
+  Nutritional   → Nutrition  (rename)
+  Social        → Mental     (community/connection feeds Mental in the 5-pillar model)
+  Environmental → Mental     (ambient/context affects Mental in the 5-pillar model)
+  Prosperity    → Mental     (self-actualization feeds Mental in the 5-pillar model)
+
+Example — user says "Help me improve my Physical pillar":
+  ✗ WRONG: "I can help you improve your Physical pillar. Want me to?"
+  ✗ WRONG: "Physical translates to Exercise in the new model."
+  ✗ WRONG: "Your Physical pillar is at 80 of 200..."
+  ✓ RIGHT: "Your Exercise pillar is at 80 of 200 — [continue]."
+  ✓ RIGHT: (silently passes "exercise" to create_index_improvement_plan
+            and announces) "I've added three movement blocks for your
+            Exercise pillar over the next two weeks — [details]."
 
 When the user asks anything about THEIR Vitana Index, score, tier, pillars,
 or how to improve / level up — examples:
@@ -4826,6 +4881,29 @@ H. TIER FRAMING IS ASPIRATIONAL, NEVER GATING. Never say "you need to
      ✗ "You need 42 more points to hit Good."
      ✓ "You're 42 points from Really-good territory. Your current rhythm
         gets you there inside two months if you stay balanced."
+
+H1. TWO ANCHORS: 600 AND 850. The goal card on the Index Detail screen
+    shows both numbers. You must be able to explain each without confusing
+    them:
+      - 600 = Really-good MILESTONE. The Day-90 aspirational target for
+              most users — the threshold of the "thriving" zone.
+      - 850 = STRETCH target within Elite. Long-horizon. Takes months of
+              sustained balanced practice. NOT a 90-day goal.
+    When the user asks "what's 850?" answer directly:
+     ✓ "850 is the stretch target — it sits deep inside Elite. It's a
+        long-horizon marker, not a 90-day goal. Most people focus on 600
+        first."
+    Source both anchors from [HEALTH] ("Really-good milestone (600)" /
+    "Stretch target (850)") — don't invent numbers.
+
+H2. DAY-90 PROJECTION. When [HEALTH] includes a "Day-90 projection" line,
+    use it for "am I on track?" / "where will I be?" questions. Speak it
+    as the trajectory card does — "at this pace you land around X by Day
+    90 — <tier>":
+     ✓ "At this pace you land around 420 by Day 90 — Building tier. Small
+        bumps in your weakest pillar would push that higher."
+    If [HEALTH] has no projection line (no baseline yet, flat trend),
+    fall back to aspirational framing — don't invent a projection.
 
 I. NEVER cite the Index number from memory_facts or general memory. The
    [HEALTH] block is fresher and authoritative. memory_facts may contain a

--- a/services/gateway/src/services/user-context-profiler.ts
+++ b/services/gateway/src/services/user-context-profiler.ts
@@ -244,6 +244,8 @@ import {
   tierForScore,
   describeBalance,
   REALLY_GOOD_THRESHOLD,
+  STRETCH_TARGET,
+  projectDay90,
 } from '../lib/vitana-pillars';
 
 /**
@@ -274,6 +276,10 @@ export interface VitanaIndexSnapshot {
   history_7d: number[];                              // [oldest...latest], up to 7 entries
   goal_target: number;                               // 600 (Really good entry)
   points_to_really_good: number;                     // max(0, 600 - total); aspirational only
+  stretch_target: number;                            // 850 — aspirational stretch anchor (UI-aligned)
+  points_to_stretch: number;                         // max(0, 850 - total)
+  projected_day_90: number | null;                   // linear extrapolation of trend_7d onto Day 90; null if no baseline
+  projected_day_90_tier: string | null;              // forecast tier name for the projection
   last_computed: string;                             // ISO date
   model_version?: string;                            // e.g. 'v3-5pillar'
   confidence?: number;                               // 0-1, from the RPC
@@ -397,6 +403,32 @@ async function fetchVitanaIndex(client: SupabaseClient, userId: string): Promise
     }
   } catch { /* best-effort */ }
 
+  // Day-90 projection — mirrors the frontend trajectory card (linear from
+  // 7-day trend). Anchored at the user's first-ever Index row rather than
+  // today so "days remaining" is meaningful. If we can't compute a
+  // baseline day count (oldest row missing), fall back to using today as
+  // the reference — projection stays accurate when trend is flat.
+  let projected_day_90: number | null = null;
+  let projected_day_90_tier: string | null = null;
+  try {
+    const { data: firstRow } = await client
+      .from('vitana_index_scores')
+      .select('date')
+      .eq('user_id', userId)
+      .order('date', { ascending: true })
+      .limit(1)
+      .maybeSingle();
+    const firstDate = firstRow?.date as string | undefined;
+    const today = new Date();
+    const firstTs = firstDate ? Date.parse(firstDate) : today.getTime();
+    const daysSinceStart = Math.max(0, Math.floor((today.getTime() - firstTs) / (24 * 60 * 60 * 1000)));
+    const proj = projectDay90(total, trend_7d, daysSinceStart);
+    if (proj !== null) {
+      projected_day_90 = proj;
+      projected_day_90_tier = tierForScore(proj).name;
+    }
+  } catch { /* best-effort */ }
+
   return {
     state: 'ok',
     snapshot: {
@@ -414,6 +446,10 @@ async function fetchVitanaIndex(client: SupabaseClient, userId: string): Promise
       history_7d,
       goal_target: REALLY_GOOD_THRESHOLD,
       points_to_really_good: Math.max(0, REALLY_GOOD_THRESHOLD - total),
+      stretch_target: STRETCH_TARGET,
+      points_to_stretch: Math.max(0, STRETCH_TARGET - total),
+      projected_day_90,
+      projected_day_90_tier,
       last_computed: latest.date,
       model_version: latest.model_version ?? undefined,
       confidence: typeof latest.confidence === 'number' ? latest.confidence : undefined,
@@ -691,12 +727,27 @@ function buildHealthSection(activities: ActivityRow[], vitanaResult: VitanaIndex
 
       // Aspirational framing, NOT a gate. "Really good" starts at 600; we
       // surface the gap as progress signal, not as pass/fail.
+      // Aspirational anchors — match the Index Detail goal card (600
+      // milestone / 850 stretch). Two lines because users reference both
+      // numbers on screen and voice must be able to answer "what's 850?".
       if (vitana.points_to_really_good > 0) {
-        lines.push(`- Really-good band (600+) entry: ${vitana.points_to_really_good} points away. Keep building steadily — do not force the ceiling.`);
+        lines.push(`- Really-good milestone (600): ${vitana.points_to_really_good} points away. 90-day aspirational target for most users — do not frame as pass/fail.`);
       } else if (vitana.total >= 800) {
-        lines.push(`- Elite band (800+): sustained excellence territory. Maintenance, not acceleration.`);
+        lines.push(`- Really-good milestone (600): already inside, ${vitana.total - 600} points clear.`);
       } else {
-        lines.push(`- Really-good band (600+): already inside. The climb from here is slow and earned.`);
+        lines.push(`- Really-good milestone (600): already inside. The climb from here is slow and earned.`);
+      }
+      if (vitana.points_to_stretch > 0) {
+        lines.push(`- Stretch target (850): ${vitana.points_to_stretch} points away. Deep in the Elite band — months of sustained balanced practice, NOT a 90-day target. When asked "what is 850", explain it as a long-horizon anchor, not a near-term goal.`);
+      } else {
+        lines.push(`- Stretch target (850): already reached. Sustained excellence territory.`);
+      }
+
+      // Day-90 linear projection — matches the frontend trajectory card.
+      // Null when no baseline exists yet (first-day users); otherwise voice
+      // can say "at this pace you land around X by Day 90 — <tier>".
+      if (typeof vitana.projected_day_90 === 'number' && vitana.projected_day_90_tier) {
+        lines.push(`- Day-90 projection (linear from 7-day trend): ~${vitana.projected_day_90} (${vitana.projected_day_90_tier} tier). Mirror the trajectory card on /autopilot — use phrase "at this pace you land around X by Day 90".`);
       }
 
       if (vitana.last_movement) {


### PR DESCRIPTION
## Summary

Voice testing of R4 surfaced two bugs and two polish items. Bundling them all as R4.1.

### Polish

- **Day-90 projection** in [HEALTH] block ([profiler snapshot](services/gateway/src/services/user-context-profiler.ts)) + new override rule H2. Voice now says *\"at this pace you land around X by Day 90 — <tier>\"* matching the /autopilot trajectory card.
- **850 stretch target** — [HEALTH] emits both \"Really-good milestone (600)\" and \"Stretch target (850)\" lines so voice can explain each without improvising. New rule H1 teaches the model to distinguish a 90-day milestone from a long-horizon stretch.

### Bug fixes

- **Test 6 — \"couldn't create a sleep plan\"**: when the user's autopilot queue had no \`contribution_vector[sleep] > 0\` recs, \`create_index_improvement_plan\` returned a dead end. Added \`PILLAR_ACTION_TEMPLATES\` to [lib/vitana-pillars.ts](services/gateway/src/lib/vitana-pillars.ts) (3 self-contained templates per pillar) and wired the tool to fall through to templates when autopilot is empty. Calendar events tagged \`source_ref_type=pillar_template\` so personalised vs. starter plans stay distinguishable downstream.
- **Test 7 — voice echoed retired pillar name \"Physical\" back to the user**: defense in depth — added \`RETIRED_PILLAR_ALIASES\` + \`resolvePillarKey()\` helper to the lib, both ORB tools now silently alias (physical → exercise, prosperity/social/environmental → mental, nutritional → nutrition), and the override block gets a NON-NEGOTIABLE retired-pillar section with explicit DO/DON'T examples.

## Test plan

- [x] \`npm run typecheck\` clean
- [ ] Post-deploy: ask ORB \"Make me a plan to improve my sleep\" on account with no sleep autopilot recs → expect a 3-template Sleep plan written to calendar
- [ ] Post-deploy: ask ORB \"How is my Physical pillar?\" → expect silent answer about Exercise (no \"Physical\" in reply)
- [ ] Post-deploy: ask ORB \"Am I on track?\" → expect \"at this pace you land around X by Day 90\"
- [ ] Post-deploy: ask ORB \"What is 850?\" → expect stretch-target explanation

🤖 Generated with [Claude Code](https://claude.com/claude-code)