### PR TITLE
fix(orb): 'connectors' routes to /settings/connected-apps (BOOTSTRAP-ORB-NAV-CONNECTORS-KW)

### DIFF
--- a/services/gateway/src/lib/navigation-catalog.ts
+++ b/services/gateway/src/lib/navigation-catalog.ts
@@ -1290,8 +1290,8 @@ export const NAVIGATION_CATALOG: ReadonlyArray<NavCatalogEntry> = [
     screen_id: 'SETTINGS.CONNECTED_APPS', route: '/settings/connected-apps', category: 'settings',
     access: 'authenticated', anonymous_safe: false,
     i18n: {
-      en: { title: 'Connected Apps', description: 'Manage third-party app integrations connected to your account.', when_to_visit: 'When the user asks about connected apps, integrations, third-party connections, or linked services.' },
-      de: { title: 'Verbundene Apps', description: 'Verwalte Drittanbieter-App-Integrationen, die mit deinem Konto verbunden sind.', when_to_visit: 'Wenn der Nutzer nach verbundenen Apps, Integrationen, Drittanbieter-Verbindungen oder verknüpften Diensten fragt.' },
+      en: { title: 'Connectors & Connected Apps', description: 'Connectors to third-party apps and integrations linked to your account.', when_to_visit: 'When the user asks about connectors, a connector, connected apps, app integrations, third-party connections, linked services, or how to connect an external app.' },
+      de: { title: 'Konnektoren & Verbundene Apps', description: 'Konnektoren zu Drittanbieter-Apps und Integrationen, die mit deinem Konto verknüpft sind.', when_to_visit: 'Wenn der Nutzer nach Konnektoren, einem Konnektor, verbundenen Apps, App-Integrationen, Drittanbieter-Verbindungen, verknüpften Diensten oder dem Verbinden einer externen App fragt.' },
     },
   },
   {


### PR DESCRIPTION
## Summary
User: *"open the screen with connectors still opens events. I tried with different expressions, but connector or connectors it seems not to be in the navigator list!"*

They were right. The catalog entry for `/settings/connected-apps` was titled "Connected Apps" and described as "third-party app integrations" — the literal word **"connector" / "connectors"** appeared nowhere in its content. On the community surface this query had zero keyword hits, so the semantic scorer chose whatever was closest in embedding space (Events, Home, etc.).

## Fix
Add explicit "connectors" vocabulary to `SETTINGS.CONNECTED_APPS` (EN + DE):
- Title: "Connectors & Connected Apps" / "Konnektoren & Verbundene Apps"
- when_to_visit: "…connectors, a connector, connected apps, app integrations…"

## Local sim (community role)
| Query | Result |
|---|---|
| "open connectors screen" | SETTINGS.CONNECTED_APPS (24) → /settings/connected-apps |
| "connectors" | SETTINGS.CONNECTED_APPS (64) |
| "open my connectors" | SETTINGS.CONNECTED_APPS (24) |

## Test plan
- [x] 121/121 jest tests pass
- [ ] Mobile: "open connectors screen" → /settings/connected-apps

🤖 Generated with [Claude Code](https://claude.com/claude-code)