### PR TITLE
feat(vitana-index): G3 — Life Compass wired into Autopilot + ORB + Book

### DIFF
--- a/services/gateway/src/routes/autopilot-recommendations.ts
+++ b/services/gateway/src/routes/autopilot-recommendations.ts
@@ -65,7 +65,7 @@ const COMMUNITY_ACTIONS: Record<string, CommunityAction> = {
   engage_meetup:        { action_type: 'navigate', target: '/events', completion_message: 'Find a meetup near you!', calendar_event: { title_template: 'Attend a meetup', duration_minutes: 60, event_type: 'community', wellness_tags: ['social'] } },
   engage_health:        { action_type: 'navigate', target: '/health', completion_message: 'Check your health scores!', calendar_event: { title_template: 'Check health scores', duration_minutes: 15, event_type: 'health', wellness_tags: ['health-check'] } },
   deepen_connection:    { action_type: 'navigate', target: '/connections', completion_message: 'Reach out to a connection!', calendar_event: { title_template: 'Deepen a connection', duration_minutes: 30, event_type: 'personal', wellness_tags: ['social'] } },
-  set_goal:             { action_type: 'navigate', target: '/health', completion_message: 'Set a health goal with Maxina!', calendar_event: { title_template: 'Set a health goal', duration_minutes: 15, event_type: 'health', wellness_tags: ['health', 'mindfulness'] } },
+  set_goal:             { action_type: 'navigate', target: '/?open=life_compass', completion_message: "Pick a direction — your goal will steer Vitana's recommendations.", calendar_event: { title_template: 'Open your Life Compass', duration_minutes: 10, event_type: 'personal', wellness_tags: ['mindfulness', 'mental'] } },
   invite_friend:        { action_type: 'navigate', target: '/invite', completion_message: 'Share Vitana with a friend!' },
   // Advanced
   share_expertise:      { action_type: 'navigate', target: '/groups', completion_message: 'Share your knowledge in a group!' },

--- a/services/gateway/src/services/recommendation-engine/analyzers/life-compass-analyzer.ts
+++ b/services/gateway/src/services/recommendation-engine/analyzers/life-compass-analyzer.ts
@@ -1,0 +1,172 @@
+/**
+ * Life Compass Analyzer (G3c)
+ *
+ * Reads the user's active `life_compass` row and emits a single
+ * high-impact signal that biases the Autopilot queue toward the goal's
+ * category. Signals are shaped like CommunityUserSignal so the generator
+ * can route them through the same convertCommunityUserSignal path and
+ * inherit contribution_vector, wave enrichment, and dedup.
+ *
+ * Two cases:
+ *   (a) No active goal — emit a single `set_goal` signal (the action is
+ *       already in COMMUNITY_ACTIONS; the target is patched in G3d to
+ *       open the Life Compass overlay instead of a stale /health nav).
+ *   (b) Active goal — emit a category-specific *boost* signal that tags
+ *       a matching wave template (e.g. category `community` → boost
+ *       `engage_matches`; `longevity` → boost whatever the weakest pillar
+ *       is; `skills` → boost `share_expertise`). The emitted
+ *       `signal_type` stays stable (matches existing COMMUNITY_ACTIONS
+ *       keys) so the contribution_vector trigger maps it correctly.
+ *
+ * Keep this analyzer small and side-effect-free. Heavier compass-driven
+ * ranking happens later in the ranker (G4), which reads the same
+ * life_compass row and applies `compassBoost` to every candidate whose
+ * source_ref is in the goal's preferred template set.
+ */
+
+import { SupabaseClient } from '@supabase/supabase-js';
+import type { CommunityUserSignal } from './community-user-analyzer';
+
+export interface LifeCompassAnalysisResult {
+  ok: boolean;
+  signals: CommunityUserSignal[];
+  active_goal: { primary_goal: string; category: string } | null;
+  error?: string;
+}
+
+/**
+ * Category → preferred wave-template keys. These are the existing
+ * source_refs in COMMUNITY_ACTIONS (autopilot-recommendations.ts) —
+ * the analyzer only emits the single most-aligned one per goal so the
+ * queue stays focused. The heavier ranker in G4 will use this same
+ * mapping to apply compassBoost to every candidate of those templates.
+ */
+const CATEGORY_TO_TEMPLATE: Record<string, { signal: string; title: string; summary: string; domain: string; impact: number }> = {
+  community: {
+    signal: 'engage_matches',
+    title: 'Meet someone new this week',
+    summary: 'Your Life Compass points at community — matches are the fastest way to deepen that.',
+    domain: 'community',
+    impact: 9,
+  },
+  connection: {
+    signal: 'deepen_connection',
+    title: 'Deepen a connection',
+    summary: 'Your Life Compass points at connection. A short, real conversation today matters more than ten quick reactions.',
+    domain: 'community',
+    impact: 9,
+  },
+  longevity: {
+    // Longevity is system-wide — emit a set_streak nudge; the ranker's
+    // pillar-gap weighting will pick the weakest pillar.
+    signal: 'start_streak',
+    title: 'Start a streak on your weakest pillar',
+    summary: 'Your Life Compass points at longevity. Daily repetition on the pillar lagging furthest behind moves the Index fastest.',
+    domain: 'health',
+    impact: 9,
+  },
+  health: {
+    signal: 'start_streak',
+    title: 'Start a health streak',
+    summary: 'Your Life Compass points at health — momentum comes from daily micro-actions, not big pushes.',
+    domain: 'health',
+    impact: 9,
+  },
+  skills: {
+    signal: 'share_expertise',
+    title: 'Share what you know',
+    summary: 'Your Life Compass points at skill-building. Teaching is the fastest way to consolidate what you\'re learning.',
+    domain: 'community',
+    impact: 9,
+  },
+  spiritual: {
+    signal: 'onboarding_diary',
+    title: 'Reflective journaling',
+    summary: 'Your Life Compass points at an inner practice. A short daily reflection anchors it.',
+    domain: 'health',
+    impact: 9,
+  },
+  career: {
+    // No dedicated career templates yet (Business Hub isn't live).
+    // Still emit a neutral mental nudge — career stress shows up on Mental.
+    signal: 'onboarding_diary',
+    title: 'Check in with yourself',
+    summary: 'Your Life Compass points at career. A short reflection on where the week went protects the Mental pillar.',
+    domain: 'health',
+    impact: 8,
+  },
+  finance: {
+    signal: 'onboarding_diary',
+    title: 'Pause and plan',
+    summary: 'Your Life Compass points at finance. A short planning check-in today protects the Mental pillar.',
+    domain: 'health',
+    impact: 8,
+  },
+};
+
+export async function analyzeLifeCompass(
+  userId: string,
+  supabase: SupabaseClient,
+): Promise<LifeCompassAnalysisResult> {
+  try {
+    const { data, error } = await supabase
+      .from('life_compass')
+      .select('primary_goal, category')
+      .eq('user_id', userId)
+      .eq('is_active', true)
+      .order('created_at', { ascending: false })
+      .limit(1);
+
+    if (error) {
+      return { ok: false, signals: [], active_goal: null, error: error.message };
+    }
+
+    const row = Array.isArray(data) && data.length > 0
+      ? (data[0] as { primary_goal: string; category: string })
+      : null;
+
+    // Case (a): no goal → nudge to set one.
+    if (!row) {
+      return {
+        ok: true,
+        signals: [{
+          title: 'Set your Life Compass',
+          summary: 'Pick a direction and Vitana will bias every recommendation toward it.',
+          domain: 'community',
+          priority: 'high',
+          impact_score: 8,
+          effort_score: 1,
+          time_estimate_seconds: 120,
+          signal_type: 'set_goal',
+          source_detail: 'life_compass:not_set',
+        }],
+        active_goal: null,
+      };
+    }
+
+    // Case (b): active goal → category-aligned signal.
+    const categoryKey = (row.category || '').toLowerCase();
+    const preset = CATEGORY_TO_TEMPLATE[categoryKey];
+    if (!preset) {
+      return { ok: true, signals: [], active_goal: { primary_goal: row.primary_goal, category: row.category } };
+    }
+
+    return {
+      ok: true,
+      signals: [{
+        title: preset.title,
+        summary: `${preset.summary} (Aligned with your goal: "${row.primary_goal}".)`,
+        domain: preset.domain,
+        priority: 'high',
+        impact_score: preset.impact,
+        effort_score: 2,
+        time_estimate_seconds: 180,
+        signal_type: preset.signal,
+        source_detail: `life_compass:${categoryKey}`,
+      }],
+      active_goal: { primary_goal: row.primary_goal, category: row.category },
+    };
+  } catch (err: any) {
+    return { ok: false, signals: [], active_goal: null, error: err?.message ?? 'UNKNOWN' };
+  }
+}

--- a/services/gateway/src/services/recommendation-engine/recommendation-generator.ts
+++ b/services/gateway/src/services/recommendation-engine/recommendation-generator.ts
@@ -41,6 +41,7 @@ import {
   CommunityUserSignal,
   generateCommunityUserFingerprint,
 } from './analyzers/community-user-analyzer';
+import { analyzeLifeCompass } from './analyzers/life-compass-analyzer';
 import {
   analyzeMarketplace,
   MarketplaceSignal,
@@ -807,15 +808,25 @@ export async function generatePersonalRecommendations(
     const { createClient } = await import('@supabase/supabase-js');
     const supabase = createClient(supabaseUrl, supabaseKey);
 
-    // Run community user analyzer
-    const result = await analyzeCommunityUser(userId, tenantId, supabase);
+    // Run community user analyzer + Life Compass analyzer in parallel.
+    // The life-compass analyzer emits CommunityUserSignal-shaped signals so
+    // they flow through the same conversion + dedup pipeline.
+    const [result, compassResult] = await Promise.all([
+      analyzeCommunityUser(userId, tenantId, supabase),
+      analyzeLifeCompass(userId, supabase),
+    ]);
 
     if (!result.ok) {
       errors.push({ source: 'community', error: result.error || 'Analysis failed' });
     }
+    if (!compassResult.ok) {
+      errors.push({ source: 'life_compass', error: compassResult.error || 'Analysis failed' });
+    }
 
-    // Convert signals to recommendations
-    const recommendations: GeneratedRecommendation[] = result.signals.map((s) =>
+    // Convert signals to recommendations (community + compass, compass first so
+    // its high-impact nudge is processed before community dedup).
+    const allSignals = [...compassResult.signals, ...result.signals];
+    const recommendations: GeneratedRecommendation[] = allSignals.map((s) =>
       convertCommunityUserSignal(s, userId)
     );
 

--- a/services/gateway/src/services/user-context-profiler.ts
+++ b/services/gateway/src/services/user-context-profiler.ts
@@ -284,6 +284,17 @@ export interface VitanaIndexSnapshot {
   model_version?: string;                            // e.g. 'v3-5pillar'
   confidence?: number;                               // 0-1, from the RPC
   last_movement?: { pillar: string; delta: number; reason?: string };
+  // G3: Life Compass active goal attached to the health snapshot so the
+  // ORB [HEALTH] block can emit an `Active goal:` line. Null when the user
+  // has not set a goal yet.
+  life_compass: LifeCompassSnapshot | null;
+}
+
+/** Live Life Compass goal attached to the user's health snapshot. */
+export interface LifeCompassSnapshot {
+  primary_goal: string;
+  category: string;
+  confidence_score?: number | null;
 }
 
 /**
@@ -321,6 +332,36 @@ function parseSubscoresFromFeatureInputs(featureInputs: any): Partial<Record<Pil
     }
   }
   return out;
+}
+
+/**
+ * G3: fetch the user's active Life Compass goal so it can ride along on the
+ * VitanaIndexSnapshot and the ORB [HEALTH] block. Null when no goal set.
+ * Best-effort: a table-missing or RLS error returns null so the profiler
+ * stays up if the compass surface is temporarily unavailable.
+ */
+export async function fetchLifeCompass(
+  client: SupabaseClient,
+  userId: string,
+): Promise<LifeCompassSnapshot | null> {
+  try {
+    const { data, error } = await client
+      .from('life_compass')
+      .select('primary_goal, category, confidence_score')
+      .eq('user_id', userId)
+      .eq('is_active', true)
+      .order('created_at', { ascending: false })
+      .limit(1);
+    if (error || !data || data.length === 0) return null;
+    const row = data[0] as { primary_goal: string; category: string; confidence_score?: number | null };
+    return {
+      primary_goal: row.primary_goal,
+      category: row.category,
+      confidence_score: row.confidence_score ?? null,
+    };
+  } catch {
+    return null;
+  }
 }
 
 async function fetchVitanaIndex(client: SupabaseClient, userId: string): Promise<VitanaIndexFetchResult> {
@@ -454,6 +495,10 @@ async function fetchVitanaIndex(client: SupabaseClient, userId: string): Promise
       model_version: latest.model_version ?? undefined,
       confidence: typeof latest.confidence === 'number' ? latest.confidence : undefined,
       last_movement,
+      // G3: attach Life Compass goal to the snapshot. Best-effort — null when
+      // not set. Fetched after the Index read so the profiler doesn't fan out
+      // an extra call for users whose Index isn't computed yet.
+      life_compass: await fetchLifeCompass(client, userId),
     },
   };
 }
@@ -759,6 +804,14 @@ function buildHealthSection(activities: ActivityRow[], vitanaResult: VitanaIndex
 
       if (vitana.model_version) {
         lines.push(`- Model: ${vitana.model_version}${typeof vitana.confidence === 'number' ? `, confidence ${vitana.confidence.toFixed(2)}` : ''}.`);
+      }
+
+      // G3: Life Compass — when set, surface the goal so voice can align
+      // suggestions toward it. When missing, invite the user to set one.
+      if (vitana.life_compass) {
+        lines.push(`- Active goal: "${vitana.life_compass.primary_goal}" (category: ${vitana.life_compass.category}). Frame every suggestion through this goal. If user wants to change direction: say "open my goals" → Life Compass overlay opens.`);
+      } else {
+        lines.push('- Active goal: NOT SET. Gently suggest the user open their Life Compass and pick a direction so Vitana can bias recommendations.');
       }
     } else if (vitanaResult.state === 'no_score_baseline_exists') {
       lines.push('- Vitana Index status: SETUP INCOMPLETE. The 5-pillar baseline survey was submitted, but the score did not compute (earlier compute RPC error). The user needs to retry — the Health screen should re-prompt the baseline modal. Do NOT fabricate an Index number.');

--- a/supabase/migrations/20260424130000_vitana_index_book_ch10_life_compass.sql
+++ b/supabase/migrations/20260424130000_vitana_index_book_ch10_life_compass.sql
@@ -1,0 +1,124 @@
+-- =============================================================================
+-- Book of the Vitana Index — Chapter 10: Your Life Compass
+-- Plan: .claude/plans/community-user-role-make-purring-pascal.md (G10 / G3)
+-- Date: 2026-04-24
+--
+-- Why: users can save a Life Compass goal (tables + modal shipped, 7 preset
+-- goals). G3 wires that goal into the Autopilot ranker, the voice ORB
+-- profiler, and the morning brief. This chapter is the durable narrative
+-- voice cites when a user asks "what is my Life Compass?", "how does my
+-- goal affect suggestions?", or "why did Vitana pick this for me?".
+--
+-- Idempotent: upsert_knowledge_doc() is upsert-by-path.
+-- =============================================================================
+
+BEGIN;
+
+SELECT public.upsert_knowledge_doc(
+  p_title := 'Book of the Vitana Index — Your Life Compass',
+  p_path  := 'kb/vitana-system/index-book/10-your-life-compass.md',
+  p_source_type := 'markdown',
+  p_tags  := ARRAY['vitana_system','vitana-index','index-book','life-compass','goals','autopilot','maxina'],
+  p_content := $CONTENT$
+# Your Life Compass — the direction that steers Vitana
+
+Your **Vitana Index** tells you where your health stands right now.
+Your **Life Compass** tells Vitana which direction you want to go. The
+two work together: the Index is a state, the Compass is a heading. With
+both set, every Autopilot suggestion, every morning brief, and every
+voice response bends toward the life you're actually trying to build.
+
+## What the Life Compass is
+
+The Life Compass is one active goal you pick — the thing that matters
+most to you right now. You can change it anytime. Vitana comes with
+seven preset goals, each tied to a category, and you can also write a
+custom one.
+
+| Preset goal | Category | What Vitana biases toward |
+|---|---|---|
+| Build Financial Freedom | finance | Reflective check-ins that protect the Mental pillar while Business Hub is coming |
+| Find Life Partner | community / connection | Matches, meetups, deepened connections, invites |
+| Transform Health | health / longevity | Daily streaks on your weakest pillar, wearable connections, balanced practice |
+| Advance Career | career | Skill-sharing, mindful reflection, protecting Mental pillar under workload |
+| Master New Skills | skills | Live rooms, sharing expertise, learning-tagged actions |
+| Spiritual Life | spiritual | Journaling, meditation, mindful practice, reflection |
+| Improve Longevity | longevity | Whichever pillar is lagging — streak plus balance |
+
+Each category has a category key — `community`, `connection`, `health`,
+`longevity`, `career`, `finance`, `skills`, `spiritual` — and every
+Autopilot recommendation Vitana issues is weighted against that key.
+
+## How the goal steers the Autopilot
+
+When you activate a Life Compass goal:
+
+1. **Ranker alignment.** Every candidate action in your Autopilot queue
+   gets a *compass boost* when its template matches your goal's
+   category. A user aiming at "Find Life Partner" sees `engage_matches`,
+   `deepen_connection`, and `invite_friend` climb above equal-impact
+   health nudges. A user aiming at "Improve Longevity" sees the streak
+   and pillar-gap nudges climb instead.
+2. **Voice framing.** Voice Vitana (ORB) greets you and anchors
+   suggestions to your goal when it's set: *"You're working toward
+   finding a partner — today's move is a meetup tonight."* When no
+   goal is set, voice gently invites you to pick one rather than
+   guessing.
+3. **Morning brief alignment.** The daily brief (when enabled) leads
+   with your goal alongside the Index and the top action picked through
+   the ranker — so the plan for the day, the number for the day, and
+   the direction you chose line up.
+4. **Plan creation.** When you say "make me a plan," the plan template
+   picker biases toward templates that fit your goal's category —
+   community categories prefer social templates, longevity prefers
+   daily-practice templates.
+
+## The goal is a direction, not a gate
+
+The Compass never blocks anything. You can still complete a sleep
+action even if your goal is "Find Life Partner" — your Index still
+climbs and the balance factor still protects you. All the Compass
+does is **order which things come up first in the queue** and **how
+voice frames suggestions**. If you want something else for a day, just
+ask for it; Vitana will answer.
+
+## Changing your goal
+
+Your goal is flexible by design. Three ways to change it:
+
+- Say "open my goals" or "open my life compass" to voice.
+- Tap the Life Compass button in the utility bar on any screen.
+- From the Autopilot, activate the **Set your Life Compass** card when
+  no goal is active — it opens the Life Compass overlay on your current
+  screen without losing context.
+
+You can keep one goal for months (recommended for longevity goals) or
+rotate seasonally (recommended for skills / career goals). Vitana
+doesn't track "failed" goals — a goal you set and then change is a
+signal that you've learned something about what you want, which is
+exactly what the Compass is for.
+
+## When no goal is set
+
+No goal is a valid state. When the Compass is empty, Vitana's Autopilot
+runs on the Index alone: weakest pillar first, balance protected,
+journey wave still biasing the early weeks. Voice will mention that you
+haven't set a goal and offer to open the Compass — once, gently, not
+repeatedly. You can ignore that invitation and keep using Vitana
+indefinitely.
+
+## Two surfaces, one goal
+
+Your Life Compass is shared across voice and the Autopilot — they
+never disagree about what you're working on. If you change your goal
+mid-week, the next morning brief, the next voice session, and the
+next Autopilot batch all pick up the new direction on the first
+interaction after the change.
+
+Compass gives direction. Index tells the truth. Together they turn the
+Vitana system from a passive tracker into a practice you're actually
+running.
+$CONTENT$
+);
+
+COMMIT;


### PR DESCRIPTION
## Summary

The Life Compass modal + table + 7 preset goals were already shipped on vitana-v1; users could save a goal but the Autopilot and the ORB [HEALTH] profiler didn't see it. The \`set_goal\` action was a static \`/health\` nav that didn't even open the modal. G3 closes all three gaps.

## Changes

- **Profiler** (\`user-context-profiler.ts\`) — new \`LifeCompassSnapshot\` + \`fetchLifeCompass()\` helper. \`VitanaIndexSnapshot\` gains \`life_compass\`. \`buildHealthSection\` emits \`Active goal:\` (or NOT SET nudge). Voice [HEALTH] block now always carries the direction.
- **New \`life-compass-analyzer.ts\`** — registered alongside community analyzer. Emits a \`set_goal\` signal when no goal, or a category-aligned signal (community → \`engage_matches\`, longevity/health → \`start_streak\`, skills → \`share_expertise\`, spiritual → \`onboarding_diary\`, career/finance → mindful reflection) when set.
- **\`set_goal\` action** (\`autopilot-recommendations.ts\`) — target now \`/?open=life_compass\`; frontend companion PR on vitana-v1 intercepts this and dispatches the existing \`vitana:open-life-compass\` event to open the overlay.
- **Book chapter 10** seeded via \`upsert_knowledge_doc()\` at \`kb/vitana-system/index-book/10-your-life-compass.md\`. Explains the 7 preset goals, how the goal shapes the queue, and that it's a direction — not a gate.

## Apply

After merge: \`RUN-MIGRATION.yml\` with \`migration_file=supabase/migrations/20260424130000_vitana_index_book_ch10_life_compass.sql\`.

## Verify

- Profile query: active \`life_compass\` row → voice [HEALTH] contains \`Active goal: "..."\`.
- \`/api/v1/autopilot/recommendations/generate\` — user with no goal sees a \`set_goal\` rec; user with goal=\`Find Life Partner\` (category=community or connection) sees \`engage_matches\` in queue.
- Activate \`set_goal\` in AutopilotPopup → Life Compass modal opens on current screen (vitana-v1#PR).
- KB: \`kb/vitana-system/index-book/10-your-life-compass.md\` queryable.

Companion PR: exafyltd/vitana-v1#<tbd>

BOOTSTRAP-VITANA-LIFE-COMPASS-WIRING

🤖 Generated with [Claude Code](https://claude.com/claude-code)