### PR TITLE
feat(guide): G9 — Index- and Compass-aware morning brief

### DIFF
--- a/services/gateway/src/services/guide/morning-brief-generator.ts
+++ b/services/gateway/src/services/guide/morning-brief-generator.ts
@@ -13,6 +13,10 @@ import { getAwarenessContext } from './awareness-context';
 import { resolvePriorityMessage } from './priority-rules';
 import { canSurfaceProactively } from './presence-pacer';
 import type { NotificationPayload } from '../notification-service';
+import { getSupabase } from '../../lib/supabase';
+import { fetchLifeCompass } from '../user-context-profiler';
+import { tierForScore, projectDay90 } from '../../lib/vitana-pillars';
+import { buildRankerContext, rankBatch } from '../recommendation-engine/ranking/index-pillar-weighter';
 
 export interface MorningBriefInput {
   user_id: string;
@@ -63,10 +67,91 @@ export async function buildMorningBrief(
     ? `${timeOfDay}, ${firstName}`
     : `${timeOfDay}`;
 
-  // Body = priority message; truncate for notification width
-  const body = priority.message.length > 140
-    ? priority.message.slice(0, 137) + '…'
-    : priority.message;
+  // G9: fetch Index + Compass + top ranked rec in parallel. Best-effort —
+  // any failure falls through to the legacy priority-message body so the
+  // brief never depends on the Index layer being up.
+  let indexSummary: { score: number; tier: string } | null = null;
+  let compassGoal: { primary_goal: string; category: string } | null = null;
+  let topAction: { title: string; source_ref: string | null } | null = null;
+  let day90Projection: { score: number; tier: string } | null = null;
+
+  try {
+    const supabase = getSupabase();
+    if (supabase) {
+      const [indexRow, firstRow, compass, rankerCtx] = await Promise.all([
+        supabase
+          .from('vitana_index_scores')
+          .select('score_total, date')
+          .eq('user_id', input.user_id)
+          .order('date', { ascending: false })
+          .limit(1)
+          .maybeSingle(),
+        supabase
+          .from('vitana_index_scores')
+          .select('date')
+          .eq('user_id', input.user_id)
+          .order('date', { ascending: true })
+          .limit(1)
+          .maybeSingle(),
+        fetchLifeCompass(supabase, input.user_id),
+        buildRankerContext(supabase, input.user_id),
+      ]);
+
+      const row = indexRow.data as { score_total?: number; date?: string } | null;
+      if (row && typeof row.score_total === 'number') {
+        const t = tierForScore(row.score_total);
+        indexSummary = { score: row.score_total, tier: t.name };
+
+        // Day-90 projection uses the same lib helper as the profiler + trajectory card.
+        const firstTs = firstRow.data?.date
+          ? Date.parse(firstRow.data.date as string)
+          : Date.now();
+        const days = Math.max(0, Math.floor((Date.now() - firstTs) / 86400000));
+        const proj = projectDay90(row.score_total, 0, days);
+        if (proj !== null) {
+          day90Projection = { score: proj, tier: tierForScore(proj).name };
+        }
+      }
+      if (compass) compassGoal = { primary_goal: compass.primary_goal, category: compass.category };
+
+      // Top ranked Autopilot rec using the shared ranker. This query runs
+      // for up to 10 recent community recs; rankBatch re-orders and the
+      // top is picked.
+      const { data: recs } = await supabase
+        .from('autopilot_recommendations')
+        .select('id, title, source_ref, impact_score, contribution_vector, domain, status')
+        .eq('user_id', input.user_id)
+        .eq('source_type', 'community')
+        .eq('status', 'new')
+        .order('impact_score', { ascending: false })
+        .limit(10);
+      if (recs && recs.length > 0) {
+        const ranked = rankBatch(recs as any, rankerCtx);
+        if (ranked.length > 0) {
+          const top = ranked[0].rec as { title?: string | null; source_ref?: string | null };
+          if (top.title) topAction = { title: String(top.title), source_ref: top.source_ref ?? null };
+        }
+      }
+    }
+  } catch (err: any) {
+    console.warn(`[MorningBrief] G9 enrichment failed (non-fatal): ${err?.message ?? err}`);
+  }
+
+  // Compose body. When the Index is set, lead with score + tier.
+  // Then top action (if ranker picked one). Then compass alignment.
+  // Fall back to priority message when we have nothing Index-y to say.
+  const parts: string[] = [];
+  if (indexSummary) parts.push(`Vitana ${indexSummary.score} (${indexSummary.tier})`);
+  if (topAction) parts.push(`Today's move: ${topAction.title}`);
+  if (compassGoal) parts.push(`Aligned with: ${compassGoal.primary_goal}`);
+
+  let body: string;
+  if (parts.length > 0) {
+    body = parts.join(' · ');
+  } else {
+    body = priority.message;
+  }
+  if (body.length > 140) body = body.slice(0, 137) + '…';
 
   return {
     title,
@@ -76,6 +161,17 @@ export async function buildMorningBrief(
       reason_tag: priority.reason_tag,
       variant: priority.variant,
       cta_url: priority.cta_url || '/',
+      // G9: structured payload for the frontend brief card (separate from
+      // the notification body). FCM data must be all strings; empty string
+      // when not present so the payload stays flat.
+      index_score_total: indexSummary ? String(indexSummary.score) : '',
+      index_tier: indexSummary?.tier ?? '',
+      projected_day_90: day90Projection ? String(day90Projection.score) : '',
+      projected_day_90_tier: day90Projection?.tier ?? '',
+      active_goal: compassGoal?.primary_goal ?? '',
+      active_goal_category: compassGoal?.category ?? '',
+      top_action_title: topAction?.title ?? '',
+      top_action_source_ref: topAction?.source_ref ?? '',
     },
     reason_tag: priority.reason_tag,
     variant: priority.variant,


### PR DESCRIPTION
## Summary

Final step of the 10-step plan. The morning brief (daily notification) was Index-blind and Compass-blind — it generated body copy from the priority-rules layer only. This PR wires it to the same ranker + Index + Life Compass helpers that now drive voice and Autopilot, so all three surfaces agree on the top pick and the user's direction.

## Changes

- \`services/gateway/src/services/guide/morning-brief-generator.ts\` — reads Vitana Index + Life Compass + top ranked rec in parallel (best-effort). Composes body as \`"Vitana <score> (<tier>) · Today's move: <title> · Aligned with: <goal>"\`. Falls back to legacy priority message when nothing is available.
- FCM \`data\` payload gains 8 new fields for richer frontend rendering of the brief card.
- Zero new dependencies — reuses \`fetchLifeCompass\`, \`tierForScore\`, \`projectDay90\` from the shared lib and \`buildRankerContext\` + \`rankBatch\` from the ranker module.

## Verify

- Call \`buildMorningBrief({ user_id, tenant_id })\` for a user with Index + active goal + queue → body contains \`Vitana 206 (Early) · Today's move: Attend a meetup · Aligned with: Find Life Partner\`.
- Same user without an active goal → body omits the Aligned-with tail.
- Same user with empty queue → body reads \`Vitana 206 (Early)\` only.
- User without an Index → falls back to legacy priority-rules message.

BOOTSTRAP-VITANA-MORNING-BRIEF-INDEX

🤖 Generated with [Claude Code](https://claude.com/claude-code)