### PR TITLE
feat(autopilot): system-wide rollup at synthesis layer

### DIFF
--- a/scripts/ci/scanners/route-auth.mjs
+++ b/scripts/ci/scanners/route-auth.mjs
@@ -222,31 +222,11 @@ export async function run({ repoRoot }) {
 
   if (unauthedFiles.length === 0) return [];
 
-  // ROLLUP — when enough files share the same fix class, emit ONE finding
-  // that batches them. Operators fix the whole class in one PR instead of N.
-  if (unauthedFiles.length >= ROLLUP_THRESHOLD) {
-    const total = unauthedFiles.length;
-    const totalHandlers = unauthedFiles.reduce((s, f) => s + f.handlers.length, 0);
-    const preview = unauthedFiles.slice(0, 6).map(f => f.file).join(', ');
-    const moreNote = total > 6 ? ` (+${total - 6} more)` : '';
-    return [{
-      type: 'missing_auth',
-      severity: 'high',
-      file_path: unauthedFiles[0].file,
-      line_number: unauthedFiles[0].firstLine,
-      message: `${total} route files have handlers without auth middleware (${totalHandlers} handlers total). Files: ${preview}${moreNote}.`,
-      suggested_action: `Either (a) add an auth middleware to the mount call in services/gateway/src/index.ts (one line per router — covers all handlers in that file), OR (b) add \`router.use(requireAuth)\` (or the right variant — requireTenantAdmin, requireDevRole, etc.) at the top of each file. For intentionally public handlers, add \`// public-route\` on the line above. See raw.affected_files for the full list.`,
-      scanner: 'route-auth-scanner-v1',
-      raw: {
-        rollup: true,
-        total_files: total,
-        total_unauthed_handlers: totalHandlers,
-        affected_files: unauthedFiles.map(f => ({ file: f.file, handler_count: f.handlers.length, handlers: f.handlers })),
-      },
-    }];
-  }
-
-  // Under threshold — emit per-file findings.
+  // Per-file emission. Rollup is handled system-wide at the synthesis layer
+  // (services/gateway/src/services/dev-autopilot-synthesis.ts groupSignalsForRollup),
+  // so any cluster of ≥5 same-class signals collapses into one rollup
+  // finding automatically. Scanners stay simple; the queue rule lives in
+  // one place.
   return unauthedFiles.map(f => {
     const preview = f.handlers.slice(0, 5).map(h => `${h.method} ${h.route}`).join(', ');
     const moreNote = f.handlers.length > 5 ? ` (+${f.handlers.length - 5} more)` : '';

--- a/services/gateway/src/services/dev-autopilot-synthesis.ts
+++ b/services/gateway/src/services/dev-autopilot-synthesis.ts
@@ -254,6 +254,93 @@ function domainForPath(path: string): string {
 }
 
 // =============================================================================
+// System-wide rollup rule
+// =============================================================================
+// When a single scanner emits a cluster of N findings of the same
+// (signal_type, severity), the queue gets useless: an operator either
+// approves all N (N PRs of the same trivial fix) or none (queue ignored).
+// Either way it's friction.
+//
+// This is a system-level invariant: any cluster of ROLLUP_THRESHOLD or
+// more signals from the same (scanner, signal_type, severity) collapses
+// into ONE rollup finding before insert. Children land in
+// raw.affected_files; the planner + worker pipeline reads that and writes
+// one PR touching every file in the cluster.
+//
+// The rule lives here, in the synthesis layer, instead of in each scanner
+// — so adding scanner #14 inherits the behaviour automatically.
+const ROLLUP_THRESHOLD = Number.parseInt(process.env.AUTOPILOT_ROLLUP_THRESHOLD || '5', 10);
+
+interface RollupGroup {
+  scanner: string;
+  signal_type: SignalType;
+  severity: Severity;
+  signals: DevAutopilotSignal[];
+}
+
+function groupSignalsForRollup(signals: DevAutopilotSignal[]): {
+  passthrough: DevAutopilotSignal[];
+  rollups: RollupGroup[];
+} {
+  const groups = new Map<string, RollupGroup>();
+  for (const s of signals) {
+    const scanner = s.scanner || 'unknown';
+    const key = `${scanner}|${s.type}|${s.severity}`;
+    let g = groups.get(key);
+    if (!g) {
+      g = { scanner, signal_type: s.type, severity: s.severity, signals: [] };
+      groups.set(key, g);
+    }
+    g.signals.push(s);
+  }
+  const passthrough: DevAutopilotSignal[] = [];
+  const rollups: RollupGroup[] = [];
+  for (const g of groups.values()) {
+    if (g.signals.length >= ROLLUP_THRESHOLD) rollups.push(g);
+    else passthrough.push(...g.signals);
+  }
+  return { passthrough, rollups };
+}
+
+function buildRollupSignal(g: RollupGroup): DevAutopilotSignal {
+  // Sort children by file_path for stable fingerprinting + readable lists.
+  const sorted = [...g.signals].sort((a, b) => (a.file_path || '').localeCompare(b.file_path || ''));
+  const previewFiles = sorted.slice(0, 6).map(s => s.file_path).filter(Boolean);
+  const moreNote = sorted.length > 6 ? ` (+${sorted.length - 6} more)` : '';
+  const anchorFile = sorted[0]?.file_path || '(rollup)';
+  const anchorLine = sorted[0]?.line_number || 1;
+
+  // Combine the children's suggested actions when distinct, otherwise use
+  // the first one's text — most scanners emit identical suggestions per
+  // signal in a cluster, so dedup keeps the message tight.
+  const distinctActions = Array.from(new Set(sorted.map(s => s.suggested_action).filter(Boolean)));
+  const action = distinctActions.length === 1
+    ? distinctActions[0]
+    : `Apply the same fix class to every file in raw.affected_files (typically a one-line change per file). Children's suggestions: ${distinctActions.slice(0, 3).join(' | ')}${distinctActions.length > 3 ? ' …' : ''}`;
+
+  return {
+    type: g.signal_type,
+    severity: g.severity,
+    file_path: anchorFile,
+    line_number: anchorLine,
+    message: `[rollup] ${g.scanner} flagged ${sorted.length} files with the same fix class (${g.signal_type}). Files: ${previewFiles.join(', ')}${moreNote}.`,
+    suggested_action: action || 'See raw.affected_files for the per-file fix list.',
+    scanner: g.scanner,
+    raw: {
+      rollup: true,
+      total_files: sorted.length,
+      affected_files: sorted.map(s => ({
+        file_path: s.file_path,
+        line_number: s.line_number,
+        message: s.message,
+        suggested_action: s.suggested_action,
+        raw: s.raw || {},
+      })),
+    },
+  };
+}
+
+// =============================================================================
 // Core: ingest a scan — dedup + upsert findings
 // =============================================================================
 
@@ -289,7 +376,8 @@ export async function ingestScan(input: ScanInput): Promise<ScanResult> {
     payload: { run_id: runId, signal_count: input.signals.length, triggered_by: input.triggered_by },
   });
 
-  // 2. Persist raw signals (for audit + dedup traceability)
+  // 2. Persist raw signals (for audit + dedup traceability) — one row per
+  // RAW signal, before rollup. Audit always sees the full pre-collapse list.
   if (input.signals.length > 0) {
     const signalRows = input.signals.map(s => ({
       run_id: runId,
@@ -313,12 +401,30 @@ export async function ingestScan(input: ScanInput): Promise<ScanResult> {
     }
   }
 
+  // 2b. System-wide rollup. Group raw signals by (scanner, signal_type, severity);
+  // any cluster ≥ ROLLUP_THRESHOLD becomes one synthetic rollup signal that
+  // replaces the cluster in the dedup-and-upsert loop below. Small clusters
+  // pass through unchanged. The rollup signal carries the full child list in
+  // raw.affected_files for downstream planning.
+  const { passthrough, rollups } = groupSignalsForRollup(input.signals);
+  const effectiveSignals: DevAutopilotSignal[] = [
+    ...passthrough,
+    ...rollups.map(g => buildRollupSignal(g)),
+  ];
+  if (rollups.length > 0) {
+    console.log(
+      `${LOG_PREFIX} rollup applied: ${rollups.length} cluster(s) collapsed `
+      + `(${rollups.reduce((acc, g) => acc + g.signals.length, 0)} signals → ${rollups.length} rollup findings, `
+      + `threshold=${ROLLUP_THRESHOLD})`,
+    );
+  }
+
   // 3. Dedup + upsert findings
   let newCount = 0;
   let updatedCount = 0;
   const now = new Date().toISOString();
 
-  for (const signal of input.signals) {
+  for (const signal of effectiveSignals) {
     const fingerprint = fingerprintSignal(signal);
     // Lookup existing live finding with this fingerprint
     const existing = await supaRequest<FindingRow[]>(

--- a/supabase/migrations/20260424500000_BOOTSTRAP_archive_findings_pending_rollup.sql
+++ b/supabase/migrations/20260424500000_BOOTSTRAP_archive_findings_pending_rollup.sql
@@ -1,0 +1,57 @@
+-- =============================================================================
+-- Dev Autopilot — archive scattered findings ahead of synthesis-layer rollup
+-- =============================================================================
+-- The matching gateway PR adds a system-wide rollup rule to ingestScan():
+-- any cluster of ≥5 signals from the same (scanner, signal_type, severity)
+-- collapses into ONE rollup finding instead of N individual rows.
+--
+-- The existing queue contains many such clusters from earlier scans that
+-- predate the rule:
+--   schema-drift-scanner-v1     ~60 findings
+--   dead-code-scanner-v1       ~250 findings
+--   missing-tests-scanner-v1   ~340 findings
+--   stale-feature-flag-scanner-v1 ~12 findings
+--   ... and any future scanner that emits a noisy class
+--
+-- After this migration runs, the next scan cycle will re-ingest those
+-- scanners' signals and produce one rollup finding per cluster — instead
+-- of the operator clicking through hundreds of duplicates.
+--
+-- The archive is parameterized: archive any (scanner, signal_type, severity)
+-- group that has ≥5 status='new' rows. Generic, applies to current AND
+-- future scanner output. Same operators can re-run this query manually any
+-- time the queue gets cluttered (or we can wire it into the scanner runner
+-- as a periodic cleanup step in a follow-up).
+-- =============================================================================
+
+WITH noisy_clusters AS (
+  SELECT
+    spec_snapshot->>'scanner'      AS scanner_key,
+    COALESCE(spec_snapshot->>'signal_type', '')   AS signal_type_key,
+    risk_class
+  FROM autopilot_recommendations
+  WHERE source_type IN ('dev_autopilot', 'dev_autopilot_impact')
+    AND status = 'new'
+    AND spec_snapshot ? 'scanner'
+    -- Skip rows that already are rollups — they're the answer, not the noise.
+    AND COALESCE((spec_snapshot->>'rollup')::boolean, FALSE) IS NOT TRUE
+  GROUP BY 1, 2, 3
+  HAVING COUNT(*) >= 5
+)
+UPDATE autopilot_recommendations r
+SET
+  status = 'auto_archived',
+  spec_snapshot = jsonb_set(
+    COALESCE(r.spec_snapshot, '{}'::jsonb),
+    '{archived_reason}',
+    to_jsonb('queued ahead of synthesis-layer rollup (cluster ≥5 will re-emit as rollup on next scan, 2026-04-24)'::text)
+  ),
+  auto_archive_at = NOW(),
+  updated_at = NOW()
+FROM noisy_clusters n
+WHERE r.source_type IN ('dev_autopilot', 'dev_autopilot_impact')
+  AND r.status = 'new'
+  AND r.spec_snapshot->>'scanner' = n.scanner_key
+  AND COALESCE(r.spec_snapshot->>'signal_type', '') = n.signal_type_key
+  AND r.risk_class IS NOT DISTINCT FROM n.risk_class
+  AND COALESCE((r.spec_snapshot->>'rollup')::boolean, FALSE) IS NOT TRUE;


### PR DESCRIPTION
## Summary

The previous PR (#892) added rollup logic to the route-auth scanner. That was the wrong layer — every other scanner that emits a cluster of N similar findings (schema-drift, dead-code, missing-tests, etc.) was still flooding the queue and forcing N approvals per cluster.

This PR moves the rule to **the synthesis service** — the single point where every scanner's output flows into the queue. **One rule, one place, every scanner inherits it automatically.**

## What changes

**`services/gateway/src/services/dev-autopilot-synthesis.ts`**:
- New `groupSignalsForRollup(signals)` groups raw input by `(scanner, signal_type, severity)`.
- Any cluster ≥`AUTOPILOT_ROLLUP_THRESHOLD` (default 5, env-tunable) collapses into ONE synthetic rollup signal that replaces the cluster in the dedup-and-upsert loop.
- Children land in `raw.affected_files` — same shape the route-auth rollup used, so the existing planner + worker pipeline handles it without any downstream changes.
- Smaller clusters pass through unchanged.

**`scripts/ci/scanners/route-auth.mjs`**:
- Removes the per-scanner rollup added in #892. Synthesis owns rollup now; scanners stay simple and just emit raw per-file signals.

**`supabase/migrations/20260424500000_BOOTSTRAP_archive_findings_pending_rollup.sql`**:
- One-shot archive of every `(scanner, signal_type, severity)` cluster ≥5 currently in the queue.
- Generic — works against any scanner past or future. Re-runnable any time the queue gets cluttered.

## What this fixes

| Before | After |
|---|---|
| Scanner #14 ships → I have to remember to add rollup logic to that scanner | Scanner #14 ships → rollup applies automatically, zero rollup code in the scanner |
| Queue floods every time a scanner produces a cluster | Queue stays clean automatically; one rule does it |
| schema-drift = 60 findings, dead-code = 251, missing-tests = 340 | Each collapses to 1-3 rollup findings on the next scan |

## Test plan

- [x] gateway `tsc --noEmit` clean
- [x] `jest dev-autopilot-(execute|planning|synthesis)`: 43/43 passing
- [ ] Apply migration `20260424500000` — archives the existing scattered findings (schema-drift ~60, dead-code ~251, missing-tests ~340, stale-flag ~12, route-auth-already-rolled).
- [ ] Merge + EXEC-DEPLOY
- [ ] Trigger a manual scan run — verify scanner output produces same N raw signals, but the queue gains only 1 rollup row per cluster (count visible in /api/v1/dev-autopilot/scan response: `new_finding_count` should be ~1 per cluster).
- [ ] Open Developer Autopilot — queue should now show ~10-20 findings total (one per cluster + small standalone findings) instead of ~700.

## Why this is the right architecture

The user's stated goal is a self-improving + self-healing system. A self-improving system encodes invariants in ONE place where the type system / runtime carries the rule forward to every new caller. Per-scanner rollup violated that — every new scanner needed a rollup patch. Synthesis-layer rollup is the actual invariant.

🤖 Generated with [Claude Code](https://claude.com/claude-code)