### PR TITLE
chore(guide): flip Did-You-Know tour flag ON for smoke test (BOOTSTRAP-DYK-TOUR)

### DIFF
--- a/supabase/migrations/20260425100000_BOOTSTRAP_dyk_flag_on.sql
+++ b/supabase/migrations/20260425100000_BOOTSTRAP_dyk_flag_on.sql
@@ -1,0 +1,11 @@
+-- BOOTSTRAP-DYK-TOUR — flip vitana_did_you_know_enabled ON
+-- 2026-04-25, after Phase 1a (gateway) + Phase 2 (vitana-v1) deploys.
+-- Idempotent: re-running is a no-op once enabled=TRUE.
+
+UPDATE public.system_controls
+SET enabled = TRUE,
+    updated_at = NOW(),
+    updated_by = 'BOOTSTRAP-DYK-TOUR-SMOKE',
+    updated_by_role = 'system',
+    reason = 'Phase 2 frontend deployed + backend verified. Enabling tour for smoke test.'
+WHERE key = 'vitana_did_you_know_enabled';


### PR DESCRIPTION
One-shot SQL to enable `vitana_did_you_know_enabled`. Idempotent — re-runs are no-ops.

Backend route + frontend card are both deployed and verified. This flips the gate so the next community user `/home` load within their first 30 usage-days shows the day-0 `vitana_index` tip.

Run via RUN-MIGRATION.yml after merge.