### PR TITLE
fix(screens-regen): graceful fallback when vitana-v1 unreachable (DEV-COMHU-0414)

### DIFF
--- a/.github/workflows/REGEN-SCREENS-CATALOG.yml
+++ b/.github/workflows/REGEN-SCREENS-CATALOG.yml
@@ -37,12 +37,19 @@ jobs:
           fetch-depth: 0
 
       - name: Checkout vitana-v1 (read-only)
+        id: checkout_v1
+        continue-on-error: true
         uses: actions/checkout@v4
         with:
           repository: exafyltd/vitana-v1
           token: ${{ secrets.VITANA_V1_READ_TOKEN || secrets.GITHUB_TOKEN }}
           ref: main
           path: vitana-v1
+
+      - name: Note v1 checkout outcome
+        if: steps.checkout_v1.outcome != 'success'
+        run: |
+          echo "::warning::vitana-v1 checkout failed — VITANA_V1_READ_TOKEN secret likely missing. ADMIN rows will be preserved from existing spec; DEV side will still regenerate."
 
       - name: Setup Node.js
         uses: actions/setup-node@v4

--- a/services/gateway/scripts/regen-screens-catalog.mjs
+++ b/services/gateway/scripts/regen-screens-catalog.mjs
@@ -208,7 +208,16 @@ function extractObjectLiteralAfter(rawSrc, marker) {
 
 function loadAdm() {
   if (!fs.existsSync(ADMIN_NAV_TS)) {
-    bail(`vitana-v1 admin-navigation.ts not found at ${ADMIN_NAV_TS}. Set VITANA_V1_ROOT or check out exafyltd/vitana-v1 next to vitana-platform.`);
+    // Graceful fallback when vitana-v1 isn't reachable (no PAT configured,
+    // offline, etc): preserve whatever ADMIN rows are already in the spec
+    // so the DEV side can still regenerate without losing the ADM data.
+    console.warn(`⚠ vitana-v1 admin-navigation.ts not found at ${ADMIN_NAV_TS} — preserving existing ADMIN rows from spec.`);
+    if (!fs.existsSync(SPEC_PATH)) return [];
+    try {
+      const spec = JSON.parse(fs.readFileSync(SPEC_PATH, 'utf8'));
+      const existing = (spec.screen_inventory && spec.screen_inventory.screens) || [];
+      return existing.filter(s => s.role === 'ADMIN');
+    } catch { return []; }
   }
   const src = fs.readFileSync(ADMIN_NAV_TS, 'utf8');
   const arrLit = extractArrayLiteralAfter(src, 'export const ADMIN_SECTIONS');


### PR DESCRIPTION
Makes the auto-regen pipeline succeed end-to-end even before the cross-repo PAT secrets are provisioned. Falls back to preserving existing ADMIN rows when vitana-v1 isn't checked out; the DEV side still regenerates fully from app.js. Once the VITANA_V1_READ_TOKEN secret lands the ADM side promotes automatically — no code changes needed.