### PR TITLE
feat(orb): teach-before-redirect — intent classifier + explain_feature + how-to KB

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -2041,6 +2041,57 @@ function buildLiveApiTools(mode: 'anonymous' | 'authenticated' = 'authenticated'
             required: ['question'],
           },
         },
+        // ─── BOOTSTRAP-TEACH-BEFORE-REDIRECT — explanation-first dispatch ───
+        {
+          name: 'explain_feature',
+          description: [
+            'Return the canonical voice-friendly explanation of a Vitana feature',
+            'or how-to topic (manual hydration logging, Daily Diary dictation,',
+            'connecting trackers, what Autopilot is, how to improve the Index,',
+            'etc.). Returns summary + ordered steps + a redirect offer the',
+            'user can accept by saying yes.',
+            '',
+            'CALL THIS WHEN the user shows TEACH-INTENT phrasing — examples:',
+            '  - "Explain X" / "Erkläre mir X"',
+            '  - "Tell me about X" / "Tell me how X works"',
+            '  - "Show me how to <verb>" (NOT "show me the <noun>")',
+            '  - "How does X work" / "Wie funktioniert X"',
+            '  - "How do I <action>" / "How can I use X" (TEACH-THEN-NAV — speak',
+            '     a brief explanation, then offer redirect)',
+            '  - "I don\'t understand X" / "Ich verstehe X nicht"',
+            '  - "I\'m new to this" / "Ich bin neu hier"',
+            '',
+            'DO NOT CALL when the user clearly wants navigation:',
+            '  - "Open <thing>" / "Öffne <thing>"',
+            '  - "Go to <thing>" / "Take me to <thing>"',
+            '  - "Show me the <screen|page|section>" / "Zeig mir den Bildschirm"',
+            '  - "I want to see the <thing>"',
+            'Those are NAVIGATE-ONLY — call the navigation tool instead.',
+            '',
+            'Speak the returned summary_voice_<lang> verbatim, then read each',
+            'item of steps_voice_<lang> in order. End with the redirect_offer_<lang>.',
+            'Only call the navigation tool with redirect_route AFTER the user',
+            'confirms (yes / ja / open it / do it).',
+            '',
+            'If found=false, fall back to search_knowledge against the',
+            'kb/vitana-system/how-to/ corpus.',
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              topic: {
+                type: 'string',
+                description: 'The user\'s natural-language topic, verbatim. Used for canonical-topic resolution.',
+              },
+              mode: {
+                type: 'string',
+                enum: ['teach_only', 'teach_then_nav'],
+                description: 'Bucket per the intent classifier. teach_only = read FULL steps, no redirect. teach_then_nav = read concise steps + redirect_offer at end.',
+              },
+            },
+            required: ['topic'],
+          },
+        },
       ],
     },
     // VTID-GOOGLE-SEARCH: Native Google Search grounding. Gemini calls
@@ -4053,6 +4104,53 @@ async function executeLiveApiToolInner(
         }
       }
 
+      // ─── BOOTSTRAP-TEACH-BEFORE-REDIRECT — explanation-first dispatch ───
+      case 'explain_feature': {
+        try {
+          const { explainFeature } = await import('../services/explain-feature-service');
+          const topic = typeof args.topic === 'string' ? args.topic.trim() : '';
+          if (!topic) {
+            return { success: false, result: '', error: 'topic is required' };
+          }
+          const mode = args.mode === 'teach_only' || args.mode === 'teach_then_nav'
+            ? args.mode
+            : 'teach_then_nav';
+
+          const result = explainFeature(topic);
+          if (!result.found) {
+            return {
+              success: true,
+              result: JSON.stringify({
+                found: false,
+                reason: result.reason ?? 'no_pattern_match',
+                guidance: 'Voice should fall back to search_knowledge against the kb/vitana-system/how-to/ corpus.',
+              }),
+            };
+          }
+
+          return {
+            success: true,
+            result: JSON.stringify({
+              found: true,
+              mode,
+              topic_canonical: result.topic_canonical,
+              pillar_lift: result.pillar_lift,
+              summary_voice_en: result.summary_voice_en,
+              summary_voice_de: result.summary_voice_de,
+              steps_voice_en: result.steps_voice_en,
+              steps_voice_de: result.steps_voice_de,
+              redirect_route: result.redirect_route,
+              redirect_offer_en: result.redirect_offer_en,
+              redirect_offer_de: result.redirect_offer_de,
+              citation: result.citation,
+            }),
+          };
+        } catch (err: any) {
+          console.error('[explain_feature] error:', err?.message);
+          return { success: false, result: '', error: err?.message || 'unknown' };
+        }
+      }
+
       default:
         return {
           success: false,
@@ -4859,6 +4957,92 @@ was habe ich heute gemacht / what music did I play":**
 7. Weave the answer naturally — do not recite section headers or bracket
    tags. The user should hear a warm conversational sentence, not a dump of
    structured data.
+
+===== INTENT CLASSIFIER — RUN BEFORE ANY TOOL CALL (BOOTSTRAP-TEACH-BEFORE-REDIRECT) =====
+
+Every user turn that asks about a feature, screen, or topic must be
+classified into ONE of three buckets BEFORE you call any tool. Run the
+disambiguation tree in order — first match wins:
+
+1. Does the phrase contain "show me how" / "tell me how" / "how to" followed
+   by a verb-phrase?
+   → TEACH-ONLY.
+
+2. Does the phrase contain a navigation verb (open / öffne / go to / geh zu /
+   navigate / pull up / take me to / bring me to / bring mich zu)?
+   → NAVIGATE-ONLY.
+
+3. Does "show me" / "let me see" / "I want to see" / "where is" / "zeig mir" /
+   "ich will sehen" / "wo ist" come BEFORE a place-noun (the / a / my /
+   the <screen|page|section|tab|Diary|Health|Autopilot|Index|<feature-name>>)?
+   → NAVIGATE-ONLY.
+
+4. Does the phrase contain a teach phrase (explain / erkläre / tell me about /
+   what is X for / wofür ist X / how does X work / wie funktioniert X /
+   I don't understand / ich verstehe nicht / I'm new / ich bin neu /
+   teach me / what does X do)?
+   → TEACH-ONLY.
+
+5. Does the phrase contain "how do I <action>" / "how can I <action>" /
+   "where do I <action>" / "can I <action>" / "wie mache ich <action>" /
+   "wie kann ich <action>" / "wo trage ich <X> ein" / "kann ich <X>"?
+   → TEACH-THEN-NAV.
+
+6. Otherwise: business-as-usual (other rules govern).
+
+Then act per the bucket:
+
+  NAVIGATE-ONLY  → call the navigation tool (navigate_to / get_route /
+                   get_route_for_path). Announce in ONE sentence
+                   ("Opening Daily Diary now"). Do NOT speak an
+                   explanation. The user is asking to GO somewhere, not
+                   to LEARN.
+
+  TEACH-ONLY     → call explain_feature(topic, mode='teach_only'). Speak
+                   summary_voice_<lang> + ALL steps_voice_<lang> in order.
+                   Do NOT navigate. End your turn after the explanation —
+                   wait for the user's next prompt.
+
+  TEACH-THEN-NAV → call explain_feature(topic, mode='teach_then_nav').
+                   Speak summary_voice_<lang> + the first 2-3 steps. Then
+                   ask the redirect_offer_<lang> verbatim. Only call the
+                   navigation tool with redirect_route IF the user
+                   confirms ("ja" / "yes" / "open it" / "go" / "do it" /
+                   "tu das" / equivalent).
+
+Edge cases:
+  - "Show me" / "open" / "go" with NO object → ask
+    "Show you what — a screen, or how something works?" /
+    "Was soll ich dir zeigen — einen Bildschirm oder wie etwas funktioniert?"
+  - Composite ("open Diary AND tell me how to use it") → navigate FIRST,
+    then immediately speak the explanation.
+  - If explain_feature returns found=false, fall back to search_knowledge
+    against the kb/vitana-system/how-to/ namespace (teach modes) or
+    proceed with navigation as fallback (teach_then_nav after offer
+    confirmed).
+
+Worked-example truth table:
+
+  "Open the Daily Diary"                  → NAVIGATE-ONLY
+  "Show me the Health screen"             → NAVIGATE-ONLY (noun follows "show me")
+  "Show me how to log water"              → TEACH-ONLY (verb-phrase follows "show me how")
+  "Explain how the Index works"           → TEACH-ONLY
+  "I don't understand my pillars"         → TEACH-ONLY
+  "How does Autopilot work"               → TEACH-ONLY
+  "I'm new — what is Autopilot for"       → TEACH-ONLY (fullest explanation)
+  "How do I log my hydration?"            → TEACH-THEN-NAV
+  "Where do I log my sleep?"              → TEACH-THEN-NAV
+  "Can I log nutrition manually?"         → TEACH-THEN-NAV
+  "Open Diary and tell me how to use it"  → composite (NAV first, then TEACH)
+  "Show me" (alone, no object)            → ASK FOR CLARIFICATION
+
+NEVER silently navigate when the phrase is teach-only. NEVER refuse to
+navigate when the phrase is navigate-only. The classification result is
+the single source of truth for which tool you call.
+
+NEW-USER BIAS: When [HEALTH] contains "User profile maturity: NEW USER",
+default to the FULLEST explanation in TEACH-ONLY and TEACH-THEN-NAV
+buckets. Veteran users (no NEW USER tag) get the tighter version.
 
 **VITANA INDEX QUESTIONS — special treatment** (BOOTSTRAP-ORB-INDEX-AWARENESS-R4):
 

--- a/services/gateway/src/services/explain-feature-service.ts
+++ b/services/gateway/src/services/explain-feature-service.ts
@@ -1,0 +1,380 @@
+/**
+ * Explain-Feature Service (BOOTSTRAP-TEACH-BEFORE-REDIRECT Phase 1).
+ *
+ * The voice-runtime side of the "Teach before redirect" plan. Maps a
+ * free-text topic from the user's question to a canonical how-to entry
+ * and returns the structured payload voice consumes.
+ *
+ * Why a TS map instead of parsing markdown frontmatter at runtime:
+ *   - Deterministic, fast (~1ms vs DB query + parse).
+ *   - Type-safe — the override prompt's contract is enforced by the type.
+ *   - The accompanying KB docs (seeded by migration) are for users to
+ *     browse / cite via search_knowledge. The TS map is for voice runtime.
+ *   - Two surfaces for the same content is a feature, not a bug: KB is
+ *     long-form prose for tap-through reading; this service is the short
+ *     spoken instruction. Single underlying topic, two presentations.
+ *
+ * If a topic doesn't match any pattern, returns { found: false } and the
+ * override prompt instructs voice to fall back to search_knowledge.
+ */
+
+import type { PillarKey } from '../lib/vitana-pillars';
+
+export interface ExplainFeatureResult {
+  found: boolean;
+  topic_canonical?: string;
+  pillar_lift?: PillarKey;
+  summary_voice_en?: string;
+  summary_voice_de?: string;
+  steps_voice_en?: string[];
+  steps_voice_de?: string[];
+  redirect_route?: string;        // e.g. '/journal' or '/health'
+  redirect_offer_en?: string;
+  redirect_offer_de?: string;
+  citation?: string;              // KB doc path for tap-through
+  reason?: string;                // populated when found=false
+}
+
+interface TopicEntry {
+  canonical: string;
+  patterns: RegExp[];
+  pillar?: PillarKey;
+  summary_voice_en: string;
+  summary_voice_de: string;
+  steps_voice_en: string[];
+  steps_voice_de: string[];
+  redirect_route?: string;
+  redirect_offer_en: string;
+  redirect_offer_de: string;
+  citation: string;
+}
+
+/**
+ * The canonical how-to topic library. Order matters — the first matching
+ * entry wins. Put more-specific patterns above more-general ones.
+ *
+ * Companion KB docs (same canonical names, kb/vitana-system/how-to/<X>.md)
+ * are seeded via supabase/migrations/<timestamp>_how_to_kb_corpus.sql so
+ * search_knowledge can also surface long-form versions.
+ */
+const TOPIC_LIBRARY: readonly TopicEntry[] = [
+  // ─── Manual logging — per pillar ───
+  {
+    canonical: 'log_hydration_manually',
+    patterns: [
+      /\b(log|track|enter|record|dictate|input)\b.*\b(hydration|water|drink|fluid)\b/i,
+      /\b(hydration|water|drink|fluid)\b.*\b(log|track|enter|record|manually|by hand)\b/i,
+      /how (do|can) i (log|track|enter|record).*water/i,
+      /wie (kann|mache) ich.*wasser.*ein/i,
+      /\b(wasser|hydration|trinken)\b.*\b(eintragen|protokollieren|erfassen)\b/i,
+    ],
+    pillar: 'hydration',
+    summary_voice_en: "You log hydration by speaking into your Daily Diary. The system listens for phrases like 'I drank a glass of water' and turns them into a hydration entry that lifts your Hydration pillar.",
+    summary_voice_de: "Du protokollierst Hydration, indem du ins Daily Diary sprichst. Sätze wie 'Ich habe ein Glas Wasser getrunken' werden automatisch erfasst und heben deine Hydration-Säule.",
+    steps_voice_en: [
+      "First, open Daily Diary from the bottom navigation.",
+      "Tap the microphone button.",
+      "Say something natural, like 'I drank 500 millilitres of water this morning'.",
+      "Tap done. The system parses your sentence into a hydration log automatically.",
+      "Your Hydration pillar updates within a few minutes.",
+    ],
+    steps_voice_de: [
+      "Öffne zuerst Daily Diary in der unteren Navigation.",
+      "Tippe auf das Mikrofon-Symbol.",
+      "Sag etwas Natürliches wie 'Ich habe heute Morgen 500 Milliliter Wasser getrunken'.",
+      "Tippe auf Fertig. Das System wandelt deinen Satz automatisch in einen Hydration-Eintrag um.",
+      "Deine Hydration-Säule aktualisiert sich innerhalb weniger Minuten.",
+    ],
+    redirect_route: '/journal',
+    redirect_offer_en: "Want me to open Daily Diary so you can dictate it now?",
+    redirect_offer_de: "Soll ich dir Daily Diary öffnen, damit du es jetzt diktieren kannst?",
+    citation: 'kb/vitana-system/how-to/log-hydration-manually.md',
+  },
+  {
+    canonical: 'log_nutrition_manually',
+    patterns: [
+      /\b(log|track|enter|record|dictate|input)\b.*\b(nutrition|food|meal|eating|ate|breakfast|lunch|dinner)\b/i,
+      /\b(nutrition|food|meal|eating)\b.*\b(log|track|enter|record|manually|by hand)\b/i,
+      /how (do|can) i (log|track|enter|record).*(food|meal|nutrition)/i,
+      /wie (kann|mache) ich.*(essen|mahlzeit|ernährung).*ein/i,
+      /\b(essen|mahlzeit|ernährung|frühstück|mittag|abendessen)\b.*\b(eintragen|protokollieren|erfassen)\b/i,
+    ],
+    pillar: 'nutrition',
+    summary_voice_en: "You log meals by dictating into Daily Diary. Describe what you ate naturally and the system records it as a nutrition entry that feeds your Nutrition pillar.",
+    summary_voice_de: "Du protokollierst Mahlzeiten, indem du sie ins Daily Diary diktierst. Beschreibe natürlich, was du gegessen hast — der Eintrag fließt in deine Nutrition-Säule ein.",
+    steps_voice_en: [
+      "Open Daily Diary.",
+      "Tap the microphone.",
+      "Describe your meal naturally, like 'I had oatmeal with berries and a coffee for breakfast'.",
+      "Save the entry. The system parses it into a nutrition log.",
+      "Your Nutrition pillar updates within a few minutes.",
+    ],
+    steps_voice_de: [
+      "Öffne Daily Diary.",
+      "Tippe auf das Mikrofon.",
+      "Beschreibe deine Mahlzeit natürlich, zum Beispiel 'Ich hatte Haferflocken mit Beeren und einen Kaffee zum Frühstück'.",
+      "Speichere den Eintrag. Das System wandelt ihn in einen Nutrition-Eintrag um.",
+      "Deine Nutrition-Säule aktualisiert sich in wenigen Minuten.",
+    ],
+    redirect_route: '/journal',
+    redirect_offer_en: "Want me to open Daily Diary now?",
+    redirect_offer_de: "Soll ich dir Daily Diary jetzt öffnen?",
+    citation: 'kb/vitana-system/how-to/log-nutrition-manually.md',
+  },
+  {
+    canonical: 'log_exercise_manually',
+    patterns: [
+      /\b(log|track|enter|record|dictate|input)\b.*\b(exercise|workout|movement|walk|run|cardio|gym|training)\b/i,
+      /\b(exercise|workout|walk|run|gym)\b.*\b(log|track|enter|record|manually|by hand)\b/i,
+      /how (do|can) i (log|track|enter|record).*(exercise|workout|run|walk)/i,
+      /wie (kann|mache) ich.*(bewegung|sport|training|workout|laufen).*ein/i,
+      /\b(bewegung|sport|training|workout|laufen|gehen)\b.*\b(eintragen|protokollieren|erfassen)\b/i,
+    ],
+    pillar: 'exercise',
+    summary_voice_en: "You log workouts by dictating them into Daily Diary. Connecting a tracker like Apple Health is the richer path, but for one-off sessions or when no tracker is on, dictation works.",
+    summary_voice_de: "Du protokollierst Workouts, indem du sie ins Daily Diary diktierst. Ein Tracker wie Apple Health ist der detailliertere Weg, aber für einmalige Sessions reicht das Diktat.",
+    steps_voice_en: [
+      "Open Daily Diary.",
+      "Tap the microphone.",
+      "Describe what you did, like 'I walked 30 minutes this morning' or 'I did a 45-minute strength workout at the gym'.",
+      "Save. The system logs it for your Exercise pillar.",
+    ],
+    steps_voice_de: [
+      "Öffne Daily Diary.",
+      "Tippe auf das Mikrofon.",
+      "Beschreibe, was du gemacht hast, zum Beispiel 'Ich bin heute Morgen 30 Minuten gelaufen' oder 'Ich hatte ein 45-minütiges Krafttraining im Studio'.",
+      "Speichern. Das System protokolliert es für deine Exercise-Säule.",
+    ],
+    redirect_route: '/journal',
+    redirect_offer_en: "Want me to open Daily Diary now?",
+    redirect_offer_de: "Soll ich dir Daily Diary jetzt öffnen?",
+    citation: 'kb/vitana-system/how-to/log-exercise-manually.md',
+  },
+  {
+    canonical: 'log_sleep_manually',
+    patterns: [
+      /\b(log|track|enter|record|dictate|input)\b.*\b(sleep|bedtime|rest|recovery)\b/i,
+      /\b(sleep|bedtime|rest)\b.*\b(log|track|enter|record|manually|by hand)\b/i,
+      /how (do|can) i (log|track|enter|record).*sleep/i,
+      /wie (kann|mache) ich.*(schlaf|schlafen).*ein/i,
+      /\b(schlaf|schlafen|bettzeit)\b.*\b(eintragen|protokollieren|erfassen)\b/i,
+    ],
+    pillar: 'sleep',
+    summary_voice_en: "You log sleep by dictating into Daily Diary in the morning. A sleep tracker is more accurate, but a quick voice note works fine for the Sleep pillar baseline.",
+    summary_voice_de: "Du protokollierst Schlaf, indem du morgens ins Daily Diary sprichst. Ein Schlaf-Tracker ist genauer, aber eine kurze Sprachnotiz reicht für die Sleep-Säule.",
+    steps_voice_en: [
+      "In the morning, open Daily Diary.",
+      "Tap the microphone.",
+      "Say something like 'I slept from 11 PM to 6:30 AM, woke up rested'.",
+      "Save. The system records it for your Sleep pillar.",
+    ],
+    steps_voice_de: [
+      "Öffne Daily Diary morgens.",
+      "Tippe auf das Mikrofon.",
+      "Sag zum Beispiel 'Ich habe von 23 Uhr bis 6:30 Uhr geschlafen und bin ausgeruht aufgewacht'.",
+      "Speichern. Das System erfasst es für deine Sleep-Säule.",
+    ],
+    redirect_route: '/journal',
+    redirect_offer_en: "Want me to open Daily Diary now?",
+    redirect_offer_de: "Soll ich dir Daily Diary jetzt öffnen?",
+    citation: 'kb/vitana-system/how-to/log-sleep-manually.md',
+  },
+  {
+    canonical: 'log_mental_state_manually',
+    patterns: [
+      /\b(log|track|enter|record|dictate|input)\b.*\b(mental|mood|stress|feeling|emotion|journaling)\b/i,
+      /\b(mental|mood|stress|feeling)\b.*\b(log|track|enter|record|manually)\b/i,
+      /how (do|can) i (log|track|record).*(mood|stress|mental|feeling)/i,
+      /wie (kann|mache) ich.*(stimmung|gefühl|stress|mental).*ein/i,
+      /\b(stimmung|gefühl|stress|mental)\b.*\b(eintragen|protokollieren|erfassen)\b/i,
+    ],
+    pillar: 'mental',
+    summary_voice_en: "You log how you feel — mood, stress, what's on your mind — by dictating into Daily Diary. Even a sentence helps; the system extracts your mental state to feed the Mental pillar.",
+    summary_voice_de: "Du protokollierst, wie du dich fühlst — Stimmung, Stress, Gedanken — indem du ins Daily Diary diktierst. Schon ein Satz hilft; das System erfasst deinen Zustand für die Mental-Säule.",
+    steps_voice_en: [
+      "Open Daily Diary.",
+      "Tap the microphone.",
+      "Say what's on your mind, like 'feeling a bit stressed about the meeting today, took 10 minutes to meditate this morning'.",
+      "Save. The system records it for your Mental pillar.",
+    ],
+    steps_voice_de: [
+      "Öffne Daily Diary.",
+      "Tippe auf das Mikrofon.",
+      "Sag, was dir durch den Kopf geht, zum Beispiel 'Ich bin etwas gestresst wegen des Meetings heute, habe heute Morgen 10 Minuten meditiert'.",
+      "Speichern. Das System erfasst es für deine Mental-Säule.",
+    ],
+    redirect_route: '/journal',
+    redirect_offer_en: "Want me to open Daily Diary now?",
+    redirect_offer_de: "Soll ich dir Daily Diary jetzt öffnen?",
+    citation: 'kb/vitana-system/how-to/log-mental-state-manually.md',
+  },
+
+  // ─── Foundational how-tos ───
+  {
+    canonical: 'use_daily_diary_dictation',
+    patterns: [
+      /\b(how|what|tell me about).*(daily diary|diary|journal)\b/i,
+      /\b(daily diary|diary)\b.*\b(work|use|dictat|speak)\b/i,
+      /wie (funktioniert|nutze ich).*(daily diary|tagebuch)/i,
+      /\b(daily diary|tagebuch)\b.*\b(funktioniert|nutzen|diktieren)\b/i,
+    ],
+    summary_voice_en: "Daily Diary is the single voice-first surface for everything you can't measure with a sensor. You speak; the system parses your words into health entries (food, water, exercise, sleep, mood) and saves them as a personal log. It's the manual counterpart to your trackers.",
+    summary_voice_de: "Daily Diary ist die zentrale Sprachoberfläche für alles, was kein Sensor messen kann. Du sprichst; das System wandelt deine Worte in Gesundheitseinträge um — Essen, Wasser, Bewegung, Schlaf, Stimmung — und speichert sie als persönliches Protokoll.",
+    steps_voice_en: [
+      "Open Daily Diary from the bottom navigation.",
+      "Tap the microphone to start dictation.",
+      "Speak naturally — full sentences are fine. You can mention multiple things in one entry.",
+      "Tap done. The system saves your entry and feeds the relevant pillars of your Vitana Index.",
+      "You can dictate multiple times a day — morning, midday, evening — to keep your day captured.",
+    ],
+    steps_voice_de: [
+      "Öffne Daily Diary in der unteren Navigation.",
+      "Tippe auf das Mikrofon, um die Diktatfunktion zu starten.",
+      "Sprich natürlich — ganze Sätze sind in Ordnung. Du kannst mehrere Dinge in einem Eintrag erwähnen.",
+      "Tippe auf Fertig. Das System speichert deinen Eintrag und versorgt die passenden Säulen deines Vitana-Index.",
+      "Du kannst mehrmals am Tag diktieren — morgens, mittags, abends — um deinen Tag festzuhalten.",
+    ],
+    redirect_route: '/journal',
+    redirect_offer_en: "Want me to open Daily Diary so you can try it now?",
+    redirect_offer_de: "Soll ich dir Daily Diary öffnen, damit du es jetzt ausprobieren kannst?",
+    citation: 'kb/vitana-system/how-to/use-daily-diary-dictation.md',
+  },
+  {
+    canonical: 'connect_health_tracker',
+    patterns: [
+      /\b(connect|link|pair|integrate|set up|setup|sync)\b.*\b(tracker|wearable|apple health|google fit|oura|whoop|fitbit|garmin)\b/i,
+      /\b(tracker|wearable|apple health|oura|whoop|fitbit)\b.*\b(connect|link|pair|set up|setup|sync)\b/i,
+      /how (do|can) i (connect|link|sync).*(tracker|apple health|oura)/i,
+      /wie (kann|mache) ich.*(tracker|apple health|oura).*verbind/i,
+      /\b(verbinden|koppeln|einrichten)\b.*\b(tracker|wearable|apple health|oura|whoop)\b/i,
+    ],
+    summary_voice_en: "Connecting a health tracker is the richer alternative to manual logging — once paired, it feeds your Vitana pillars automatically every day. Today, manual integration entries are the path; native partner OAuth (Apple Health, Oura, Whoop) is on the roadmap and will be opt-in when ready.",
+    summary_voice_de: "Einen Health-Tracker zu verbinden ist die detailliertere Alternative zum manuellen Protokoll — einmal gekoppelt, versorgt er deine Vitana-Säulen automatisch täglich. Heute ist das über manuelle Integrations-Einträge möglich; native Partner-Anbindungen für Apple Health, Oura und Whoop kommen demnächst.",
+    steps_voice_en: [
+      "Open the Integrations section in your Settings.",
+      "Pick the tracker or app you want to connect.",
+      "Today, log a single integration entry that points the system at your data source.",
+      "When native OAuth ships for that partner, you'll get a one-tap connect flow — and your Index will start drawing from the live data.",
+    ],
+    steps_voice_de: [
+      "Öffne den Bereich Integrationen in den Einstellungen.",
+      "Wähle den Tracker oder die App, die du verbinden möchtest.",
+      "Heute legst du dafür einen manuellen Integrations-Eintrag an, der dem System deine Datenquelle nennt.",
+      "Sobald die native OAuth-Anbindung für den jeweiligen Partner kommt, gibt es einen 1-Klick-Verbindungs-Flow — dein Index zieht dann live Daten.",
+    ],
+    redirect_route: '/integrations',
+    redirect_offer_en: "Want me to open the Integrations section now?",
+    redirect_offer_de: "Soll ich dir den Integrations-Bereich jetzt öffnen?",
+    citation: 'kb/vitana-system/how-to/connect-health-tracker.md',
+  },
+  {
+    canonical: 'improve_your_vitana_index',
+    patterns: [
+      /how (do|can) i (improve|raise|lift|boost|grow).*(vitana )?(index|score)/i,
+      /\bimprove (my )?(vitana )?(index|score)\b/i,
+      /wie (kann|verbessere) ich (meinen )?(vitana )?(index|score)/i,
+      /\bverbess(er|ern)\b.*\b(vitana )?(index|score)\b/i,
+    ],
+    summary_voice_en: "Your Vitana Index moves when you do small daily things across the five pillars — Nutrition, Hydration, Exercise, Sleep, Mental — AND when you keep them in balance. The fastest lever is your weakest pillar; the second-fastest is logging consistently so the system has signal to score from.",
+    summary_voice_de: "Dein Vitana-Index bewegt sich, wenn du kleine tägliche Dinge über die fünf Säulen verteilst — Nutrition, Hydration, Exercise, Sleep, Mental — UND sie im Gleichgewicht hältst. Der schnellste Hebel ist deine schwächste Säule; der zweitschnellste ist konsequentes Protokollieren.",
+    steps_voice_en: [
+      "Check your Index Detail screen — find your weakest pillar.",
+      "Pick one small action for that pillar from the Autopilot suggestions, or dictate one entry into Daily Diary today.",
+      "Repeat tomorrow. Streaks of 7 days lift sub-scores noticeably.",
+      "Connect a tracker for one pillar — that's the biggest jump per setup minute.",
+      "Keep balance: it's better to do 4-out-of-5 pillars at a moderate level than to max one and ignore the rest. The balance factor dampens lopsided scores.",
+    ],
+    steps_voice_de: [
+      "Schau auf deinen Index-Detail-Screen — finde deine schwächste Säule.",
+      "Wähle eine kleine Aktion für diese Säule aus den Autopilot-Vorschlägen oder diktiere heute einen Eintrag ins Daily Diary.",
+      "Wiederhole es morgen. Streaks von 7 Tagen heben die Sub-Scores spürbar.",
+      "Verbinde einen Tracker für eine Säule — das ist der größte Sprung pro Einrichtungsminute.",
+      "Halte die Balance: 4 von 5 Säulen auf mittlerem Niveau ist besser als eine maximieren und den Rest ignorieren. Der Balance-Faktor dämpft einseitige Scores.",
+    ],
+    redirect_route: '/health/vitana-index',
+    redirect_offer_en: "Want me to open your Index Detail screen so you can see where to start?",
+    redirect_offer_de: "Soll ich dir den Index-Detail-Screen öffnen, damit du siehst, wo du anfangen kannst?",
+    citation: 'kb/vitana-system/how-to/improve-your-vitana-index.md',
+  },
+  {
+    canonical: 'what_is_autopilot',
+    patterns: [
+      /what (is|does) autopilot/i,
+      /how (does )?autopilot work/i,
+      /tell me about autopilot/i,
+      /(explain|teach me) autopilot/i,
+      /was (ist|macht) autopilot/i,
+      /wie funktioniert autopilot/i,
+      /erkläre.*autopilot/i,
+    ],
+    summary_voice_en: "Autopilot is the engine that watches your Vitana Index and suggests the next small action that would lift it the most. It ranks suggestions by which pillar needs the most help and how much each action would move you. You activate, you complete, you climb.",
+    summary_voice_de: "Autopilot ist die Engine, die deinen Vitana-Index beobachtet und die nächste kleine Aktion vorschlägt, die ihn am meisten hebt. Sie bewertet Vorschläge danach, welche Säule am meisten Hilfe braucht und wie stark jede Aktion dich bewegen würde.",
+    steps_voice_en: [
+      "Open Autopilot from the home screen — you see a ranked list of suggestions.",
+      "Each card shows which pillar it lifts (for example, Sleep +4) and roughly how long it takes.",
+      "Activate one. The system schedules a calendar event for it.",
+      "Complete the event. Your Index recomputes within minutes and the queue regenerates.",
+      "Don't try to clear the whole list — pick one or two each day, balanced across pillars.",
+    ],
+    steps_voice_de: [
+      "Öffne Autopilot vom Home-Screen — du siehst eine sortierte Liste von Vorschlägen.",
+      "Jede Karte zeigt, welche Säule sie hebt (zum Beispiel Schlaf +4) und ungefähr wie lange es dauert.",
+      "Aktiviere einen Vorschlag. Das System legt einen Kalender-Eintrag dafür an.",
+      "Schließe den Eintrag ab. Dein Index wird innerhalb weniger Minuten neu berechnet und die Liste regeneriert.",
+      "Versuche nicht, die ganze Liste abzuarbeiten — wähle ein bis zwei pro Tag, ausgewogen über die Säulen.",
+    ],
+    redirect_route: '/autopilot',
+    redirect_offer_en: "Want me to open Autopilot now so you can see your suggestions?",
+    redirect_offer_de: "Soll ich dir Autopilot jetzt öffnen, damit du deine Vorschläge siehst?",
+    citation: 'kb/vitana-system/how-to/what-is-autopilot.md',
+  },
+] as const;
+
+/**
+ * Resolve a free-text topic to a canonical how-to entry. Returns
+ * { found: false } when nothing matches — voice falls back to
+ * search_knowledge per the override block instructions.
+ */
+export function explainFeature(topicText: string): ExplainFeatureResult {
+  if (!topicText || typeof topicText !== 'string') {
+    return { found: false, reason: 'empty_topic' };
+  }
+  const text = topicText.trim();
+  for (const entry of TOPIC_LIBRARY) {
+    if (entry.patterns.some(re => re.test(text))) {
+      return {
+        found: true,
+        topic_canonical: entry.canonical,
+        pillar_lift: entry.pillar,
+        summary_voice_en: entry.summary_voice_en,
+        summary_voice_de: entry.summary_voice_de,
+        steps_voice_en: [...entry.steps_voice_en],
+        steps_voice_de: [...entry.steps_voice_de],
+        redirect_route: entry.redirect_route,
+        redirect_offer_en: entry.redirect_offer_en,
+        redirect_offer_de: entry.redirect_offer_de,
+        citation: entry.citation,
+      };
+    }
+  }
+  return { found: false, reason: 'no_pattern_match' };
+}
+
+/**
+ * Lightweight introspection — exposes the canonical topic list (without
+ * patterns) for diagnostics endpoints / Command Hub. Order matches
+ * resolution priority.
+ */
+export function listCanonicalTopics(): Array<{
+  canonical: string;
+  pillar?: PillarKey;
+  citation: string;
+  redirect_route?: string;
+}> {
+  return TOPIC_LIBRARY.map(t => ({
+    canonical: t.canonical,
+    pillar: t.pillar,
+    citation: t.citation,
+    redirect_route: t.redirect_route,
+  }));
+}

--- a/services/gateway/src/services/retrieval-router.ts
+++ b/services/gateway/src/services/retrieval-router.ts
@@ -95,6 +95,90 @@ const ROUTING_RULES: RoutingRule[] = [
     rationale: 'Vitana system questions prioritize Knowledge Hub for accurate documentation',
   },
 
+  // ===== Intent Classifier — Navigation vs Teaching =====
+  // BOOTSTRAP-TEACH-BEFORE-REDIRECT Phase 1. Three sibling rules sitting
+  // between vitana_system (100) and personal_index (95). They route to
+  // the how-to KB corpus with a `mode` hint downstream consumers (logs,
+  // explain_feature tool) read to decide whether to navigate, teach, or
+  // teach-then-redirect. Same target source; different rationale tags so
+  // misclassifications are auditable.
+
+  // NAV-ONLY — clear navigation phrasings. Voice opens the screen,
+  // does NOT explain. "Show me the X" only matches when X is a noun
+  // (screen / page / Diary / Health / etc.), NOT when followed by
+  // "how to <verb>" (which is teach-only).
+  {
+    name: 'nav_intent',
+    priority: 94,
+    patterns: [
+      /\b(open|öffne|mach\s+\w+\s+auf)\s+(the\s+|a\s+|den\s+|die\s+|das\s+)?[\w-]+/i,
+      /\b(go to|geh zu|navigate to|jump to|pull up|take me to|bring me to|bring mich zu)\s+/i,
+      /\b(show me|let me see|i want to see|zeig mir|ich will sehen)\s+(the|a|my|den|die|das|mein|meine)\s+(screen|page|section|tab|list|dashboard|bildschirm|seite|bereich|liste|diary|tagebuch|health|index|autopilot|kalender|calendar)/i,
+      /\bwhere is\s+(the|a|my)\s+\w+/i,
+      /\bwo ist\s+(der|die|das|mein|meine)\s+\w+/i,
+    ],
+    keywords: [
+      'open', 'go to', 'take me to', 'navigate', 'pull up',
+      'öffne', 'geh zu', 'mach auf', 'bring mich zu',
+      'show me the', 'i want to see the',
+      'zeig mir den', 'ich will den', 'wo ist der',
+    ],
+    primary_source: 'knowledge_hub',
+    secondary_sources: [],
+    rationale: 'INTENT=NAV — phrase is a clear navigation request. Voice should call the navigation tool, no explanation.',
+  },
+
+  // TEACH-ONLY — clear explanatory phrasings. Voice calls explain_feature,
+  // speaks summary + ALL steps, does NOT navigate. Includes the
+  // unambiguous "show me how <verb>" form (verb-phrase, not noun).
+  {
+    name: 'teach_intent',
+    priority: 93,
+    patterns: [
+      /\b(explain|erkläre|tell me about|teach me|what does\s+\w+\s+do|what is\s+.+\s+for|wofür ist|was bedeutet)\b/i,
+      /\b(how does|wie funktioniert)\s+(it|this|that|es|das|dies)\b/i,
+      /\b(show me how|tell me how|zeig mir wie)\s+(to|i can|ich)\b/i,
+      /\b(i don'?t (understand|get)|ich verstehe (das )?nicht)\b/i,
+      /\b(i'?m new|ich bin neu)\b/i,
+    ],
+    keywords: [
+      'explain', 'tell me about', 'teach me', 'what does', 'what is for',
+      'how does it work', 'how does this work',
+      'show me how to', 'tell me how to',
+      'i don\'t understand', 'i\'m new',
+      'erkläre mir', 'wie funktioniert', 'wofür ist', 'was bedeutet',
+      'zeig mir wie', 'ich verstehe nicht', 'ich bin neu',
+    ],
+    primary_source: 'knowledge_hub',
+    secondary_sources: [],
+    rationale: 'INTENT=TEACH — phrase asks for understanding. Voice should call explain_feature with mode=teach_only, speak full explanation, no redirect.',
+  },
+
+  // TEACH-THEN-NAV — ambiguous "how do I <action>" / "where do I <action>"
+  // phrasings. Voice teaches briefly, then offers redirect. Default for
+  // anything between pure-nav and pure-teach.
+  {
+    name: 'teach_then_nav_intent',
+    priority: 92,
+    patterns: [
+      /\b(how|wie)\s+(do|can|kann)\s+i\s+(log|track|enter|record|connect|set up|setup|use|find|wear|dictate|sync|link|input)/i,
+      /\b(wie|wo)\s+(mache|kann|trage|verbinde|finde|nutze)\s+ich\b/i,
+      /\b(where do i|wo trage ich|wo kann ich)\b/i,
+      /\b(can i|kann ich)\s+(log|track|enter|record|connect|verbinde|protokoll|eintrag)/i,
+      /\bwhat should i do to\b/i,
+    ],
+    keywords: [
+      'how do i log', 'how can i log', 'how do i track', 'how can i connect',
+      'where do i log', 'where do i find',
+      'can i log', 'can i enter', 'can i connect',
+      'wie mache ich', 'wie kann ich', 'wo trage ich', 'wo kann ich',
+      'kann ich protokollieren', 'kann ich eintragen', 'kann ich verbinden',
+    ],
+    primary_source: 'knowledge_hub',
+    secondary_sources: [],
+    rationale: 'INTENT=TEACH-THEN-NAV — phrase is action-shaped but ambiguous. Voice should call explain_feature with mode=teach_then_nav, speak brief explanation + redirect_offer, only navigate on confirmation.',
+  },
+
   // ===== Personal Vitana Index Questions → User Data First =====
   // BOOTSTRAP-ORB-INDEX-AWARENESS: when the user asks about THEIR Index,
   // tier, pillars, or how to improve THEIR score, route to user data

--- a/services/gateway/src/services/user-context-profiler.ts
+++ b/services/gateway/src/services/user-context-profiler.ts
@@ -806,6 +806,19 @@ function buildHealthSection(activities: ActivityRow[], vitanaResult: VitanaIndex
         lines.push(`- Model: ${vitana.model_version}${typeof vitana.confidence === 'number' ? `, confidence ${vitana.confidence.toFixed(2)}` : ''}.`);
       }
 
+      // BOOTSTRAP-TEACH-BEFORE-REDIRECT: NEW USER detection. A user whose
+      // Index is mostly baseline-only (no completion sub-scores yet, low
+      // confidence, baseline-survey-v2 model) is a first-timer who needs
+      // fuller explanations. Voice's intent classifier reads this hint
+      // and biases TEACH-ONLY / TEACH-THEN-NAV toward the longest steps.
+      const isBaselineOnlyModel = typeof vitana.model_version === 'string'
+        && vitana.model_version.includes('baseline-survey');
+      const lowConfidence = typeof vitana.confidence === 'number' && vitana.confidence < 0.5;
+      const noCompletionsYet = Object.values(vitana.subscores).every(s => !s || s.completions === 0);
+      if (isBaselineOnlyModel || (lowConfidence && noCompletionsYet)) {
+        lines.push('- User profile maturity: NEW USER (no completions yet, baseline-only score). When the user asks teach-intent questions, default to the FULLEST explanation + step list. Offer onboarding pointers warmly.');
+      }
+
       // G3: Life Compass — when set, surface the goal so voice can align
       // suggestions toward it. When missing, invite the user to set one.
       if (vitana.life_compass) {

--- a/supabase/migrations/20260425100000_how_to_kb_corpus.sql
+++ b/supabase/migrations/20260425100000_how_to_kb_corpus.sql
@@ -1,0 +1,385 @@
+-- =============================================================================
+-- How-To KB Corpus (BOOTSTRAP-TEACH-BEFORE-REDIRECT Phase 1)
+-- Date: 2026-04-25
+--
+-- Seeds 9 procedural how-to docs into the Knowledge Hub `vitana_system`
+-- namespace. These complement the conceptual Book of the Vitana Index:
+--   - Book chapters explain WHY (longevity, the five pillars, balance).
+--   - How-to docs explain HOW (which buttons, which order, expected outcome).
+--
+-- The voice runtime calls explain_feature() for the same topics; the KB
+-- docs are the long-form prose users can browse via search_knowledge or
+-- the Command Hub System Knowledge tab.
+--
+-- Idempotent via upsert_knowledge_doc() (upsert on path). Safe to re-run.
+-- =============================================================================
+
+BEGIN;
+
+-- ===========================================================================
+-- 1. Log hydration manually
+-- ===========================================================================
+
+SELECT public.upsert_knowledge_doc(
+  p_title := 'How to log hydration manually',
+  p_path  := 'kb/vitana-system/how-to/log-hydration-manually.md',
+  p_source_type := 'markdown',
+  p_tags  := ARRAY['vitana_system','how-to','procedural','hydration','daily-diary','manual-log'],
+  p_content := $CONTENT$
+# How to log hydration manually
+
+## What it is
+Recording how much you drink across the day so your Hydration pillar has signal to score from. The fastest manual path is voice dictation into Daily Diary.
+
+## Why it matters for your Index
+Hydration is one of five pillars (max 200 each). Without logged data, your Hydration sub-score "data" component sits at zero — even if you drink plenty, the system can't see it. A few daily voice notes change that immediately.
+
+## Steps
+1. Open Daily Diary from the bottom navigation.
+2. Tap the microphone button.
+3. Say something natural, like *"I drank 500 millilitres of water this morning"* or *"Just finished a big glass of water with lunch"*.
+4. Tap done. The system parses your sentence into a hydration entry automatically.
+5. Your Hydration pillar updates within a few minutes.
+
+## Expected outcome
+A new diary entry appears with the hydration amount the system extracted. Within a recompute cycle (minutes), your Hydration pillar's "data" sub-score reflects the new entry.
+
+## Pitfalls
+- Vague phrasing ("I drank some water") records the action but not the amount — being specific lifts the score more.
+- Logging in past dates doesn't count toward today's streak.
+- A connected smart bottle (HidrateSpark, Apple Health Water) is more accurate than dictation; dictation is the gap-filler.
+
+## Related
+- [Connect a health tracker](kb/vitana-system/how-to/connect-health-tracker.md)
+- [Use Daily Diary dictation](kb/vitana-system/how-to/use-daily-diary-dictation.md)
+- [Book — Hydration chapter](kb/vitana-system/index-book/02-hydration.md)
+$CONTENT$
+);
+
+-- ===========================================================================
+-- 2. Log nutrition manually
+-- ===========================================================================
+
+SELECT public.upsert_knowledge_doc(
+  p_title := 'How to log nutrition manually',
+  p_path  := 'kb/vitana-system/how-to/log-nutrition-manually.md',
+  p_source_type := 'markdown',
+  p_tags  := ARRAY['vitana_system','how-to','procedural','nutrition','daily-diary','manual-log'],
+  p_content := $CONTENT$
+# How to log nutrition manually
+
+## What it is
+Recording what you eat through Daily Diary dictation. The system parses your description into a nutrition entry that feeds your Nutrition pillar.
+
+## Why it matters for your Index
+Nutrition (max 200) is the single largest lever in your Vitana Index for most users. Even a quick description of your meals — without weighing or counting calories — gives the system enough signal to score consistency, balance, and macro variety.
+
+## Steps
+1. Open Daily Diary.
+2. Tap the microphone.
+3. Describe your meal naturally, like *"I had oatmeal with berries and a coffee for breakfast"* or *"Lunch was a chicken salad with olive oil and a piece of bread"*.
+4. Save the entry. The system parses it into a nutrition log.
+5. Your Nutrition pillar updates within a few minutes.
+
+## Expected outcome
+A diary entry with the meal contents appears. The Nutrition pillar's "data" sub-score reflects the entry on next recompute.
+
+## Pitfalls
+- Vague entries ("had food") log the action but contribute little to scoring — describe what you actually ate.
+- Logging multiple meals in one entry is fine — the system handles it. *"Breakfast was eggs, lunch was a sandwich, dinner was salmon and rice."*
+- A connected nutrition app (MyFitnessPal, Cronometer) is more precise; dictation is the daily backbone.
+
+## Related
+- [Connect a health tracker](kb/vitana-system/how-to/connect-health-tracker.md)
+- [Use Daily Diary dictation](kb/vitana-system/how-to/use-daily-diary-dictation.md)
+- [Book — Nutrition chapter](kb/vitana-system/index-book/01-nutrition.md)
+$CONTENT$
+);
+
+-- ===========================================================================
+-- 3. Log exercise manually
+-- ===========================================================================
+
+SELECT public.upsert_knowledge_doc(
+  p_title := 'How to log exercise manually',
+  p_path  := 'kb/vitana-system/how-to/log-exercise-manually.md',
+  p_source_type := 'markdown',
+  p_tags  := ARRAY['vitana_system','how-to','procedural','exercise','daily-diary','manual-log'],
+  p_content := $CONTENT$
+# How to log exercise manually
+
+## What it is
+Recording physical activity through Daily Diary dictation when no tracker is on (or for a one-off session). A connected wearable like Apple Health or Strava gives richer data, but dictation works.
+
+## Why it matters for your Index
+Exercise (max 200) covers movement, intensity, and recovery. Without signal, the pillar relies only on your survey baseline — which is a prior, not a verdict. Logging real sessions lifts your Exercise sub-scores meaningfully.
+
+## Steps
+1. Open Daily Diary.
+2. Tap the microphone.
+3. Describe what you did, like *"I walked 30 minutes this morning"* or *"I did a 45-minute strength workout at the gym, mostly upper body"*.
+4. Save. The system logs it for your Exercise pillar.
+
+## Expected outcome
+A diary entry with the activity description. Exercise pillar reflects it after recompute.
+
+## Pitfalls
+- Mention duration AND intensity if you can ("30 minutes brisk walk" beats "I walked").
+- Steps from a phone or wearable are the cleanest signal — dictation is the supplement.
+- Recovery counts too: *"Took a rest day, gentle 15-minute mobility"* is a valid entry.
+
+## Related
+- [Connect a health tracker](kb/vitana-system/how-to/connect-health-tracker.md)
+- [Use Daily Diary dictation](kb/vitana-system/how-to/use-daily-diary-dictation.md)
+- [Book — Exercise chapter](kb/vitana-system/index-book/03-exercise.md)
+$CONTENT$
+);
+
+-- ===========================================================================
+-- 4. Log sleep manually
+-- ===========================================================================
+
+SELECT public.upsert_knowledge_doc(
+  p_title := 'How to log sleep manually',
+  p_path  := 'kb/vitana-system/how-to/log-sleep-manually.md',
+  p_source_type := 'markdown',
+  p_tags  := ARRAY['vitana_system','how-to','procedural','sleep','daily-diary','manual-log'],
+  p_content := $CONTENT$
+# How to log sleep manually
+
+## What it is
+Recording how you slept by dictating into Daily Diary in the morning. A wearable (Oura, Whoop, Apple Watch) is more accurate, but a quick voice note feeds the Sleep pillar baseline.
+
+## Why it matters for your Index
+Sleep (max 200) is the recovery pillar — it disproportionately affects every other pillar. Even a one-line note about duration and how rested you feel gives the system signal.
+
+## Steps
+1. In the morning, open Daily Diary.
+2. Tap the microphone.
+3. Say something like *"I slept from 11 PM to 6:30 AM, woke up rested"* or *"Got about 6 hours, kept waking up"*.
+4. Save. The system records it for your Sleep pillar.
+
+## Expected outcome
+A diary entry with sleep duration and quality. Sleep pillar updates after recompute.
+
+## Pitfalls
+- Mention BOTH duration and quality — the system tracks them as separate signals.
+- Logging morning-of is more accurate than guessing later in the day.
+- A sleep tracker (Oura, Whoop, Apple Sleep) gives stage data that dictation can't — pair both if possible.
+
+## Related
+- [Connect a health tracker](kb/vitana-system/how-to/connect-health-tracker.md)
+- [Use Daily Diary dictation](kb/vitana-system/how-to/use-daily-diary-dictation.md)
+- [Book — Sleep chapter](kb/vitana-system/index-book/04-sleep.md)
+$CONTENT$
+);
+
+-- ===========================================================================
+-- 5. Log mental state manually
+-- ===========================================================================
+
+SELECT public.upsert_knowledge_doc(
+  p_title := 'How to log mental state manually',
+  p_path  := 'kb/vitana-system/how-to/log-mental-state-manually.md',
+  p_source_type := 'markdown',
+  p_tags  := ARRAY['vitana_system','how-to','procedural','mental','daily-diary','manual-log'],
+  p_content := $CONTENT$
+# How to log mental state manually
+
+## What it is
+Recording how you feel — mood, stress, what's on your mind — by dictating into Daily Diary. Even a sentence helps the system extract your mental state for the Mental pillar.
+
+## Why it matters for your Index
+Mental (max 200) covers stress, mood, mindfulness, and cognitive load. It's the hardest pillar to track from sensors alone — dictation is often the primary signal source.
+
+## Steps
+1. Open Daily Diary.
+2. Tap the microphone.
+3. Say what's on your mind, like *"feeling a bit stressed about the meeting today, took 10 minutes to meditate this morning"* or *"calm and clear, slept well"*.
+4. Save. The system records it for your Mental pillar.
+
+## Expected outcome
+A diary entry with extracted mental signals (mood, stress level, mindfulness mentions). Mental pillar reflects it on recompute.
+
+## Pitfalls
+- Honesty matters more than positivity — the Index isn't graded on cheerful tone.
+- Mention specific practices ("meditated 10 minutes", "journaled") — they count toward sub-scores.
+- A mood-tracking app or HRV tracker (Oura readiness) supplements dictation; both can run.
+
+## Related
+- [Use Daily Diary dictation](kb/vitana-system/how-to/use-daily-diary-dictation.md)
+- [Book — Mental chapter](kb/vitana-system/index-book/05-mental.md)
+$CONTENT$
+);
+
+-- ===========================================================================
+-- 6. Use Daily Diary dictation (the foundational how-to)
+-- ===========================================================================
+
+SELECT public.upsert_knowledge_doc(
+  p_title := 'How to use Daily Diary dictation',
+  p_path  := 'kb/vitana-system/how-to/use-daily-diary-dictation.md',
+  p_source_type := 'markdown',
+  p_tags  := ARRAY['vitana_system','how-to','procedural','daily-diary','dictation','foundational'],
+  p_content := $CONTENT$
+# How to use Daily Diary dictation
+
+## What it is
+Daily Diary is the single voice-first surface for everything you can't (or don't want to) measure with a sensor. You speak; the system parses your words into health entries — food, water, exercise, sleep, mood — and saves them as your personal log. It's the manual counterpart to your trackers.
+
+## Why it matters for your Index
+Four of the five Vitana pillars (Nutrition, Hydration, Exercise, Sleep, Mental) accept signal from dictation. For users without wearables — and for any signal a wearable can't capture (mood, stress, food quality) — Daily Diary is the primary input. **The system can only score what it knows about.**
+
+## Steps
+1. Open Daily Diary from the bottom navigation.
+2. Tap the microphone to start dictation.
+3. Speak naturally — full sentences are fine. You can mention multiple things in one entry: *"Slept 7 hours, had eggs and toast for breakfast, going for a walk after lunch."*
+4. Tap done. The system saves your entry and feeds the relevant pillars of your Vitana Index.
+5. You can dictate multiple times a day — morning, midday, evening — to keep your day captured.
+
+## Expected outcome
+Your diary fills with timestamped entries. Each entry contributes to the relevant pillar's "data" sub-score. The Index recomputes within minutes of each save.
+
+## Pitfalls
+- One long entry per day works, but multiple short entries throughout the day give richer signal.
+- The system parses on language, not punctuation — speak naturally, not in keywords.
+- Diary entries are private to you — they're never shared with the community.
+- If the parser misinterprets you, edit the entry to correct — your edits train future parsing.
+
+## Related
+- [Log hydration manually](kb/vitana-system/how-to/log-hydration-manually.md)
+- [Log nutrition manually](kb/vitana-system/how-to/log-nutrition-manually.md)
+- [Log exercise manually](kb/vitana-system/how-to/log-exercise-manually.md)
+- [Log sleep manually](kb/vitana-system/how-to/log-sleep-manually.md)
+- [Log mental state manually](kb/vitana-system/how-to/log-mental-state-manually.md)
+$CONTENT$
+);
+
+-- ===========================================================================
+-- 7. Connect a health tracker
+-- ===========================================================================
+
+SELECT public.upsert_knowledge_doc(
+  p_title := 'How to connect a health tracker',
+  p_path  := 'kb/vitana-system/how-to/connect-health-tracker.md',
+  p_source_type := 'markdown',
+  p_tags  := ARRAY['vitana_system','how-to','procedural','integrations','tracker','wearable'],
+  p_content := $CONTENT$
+# How to connect a health tracker
+
+## What it is
+Connecting a wearable, app, or sensor so it streams data into your Vitana Index automatically — instead of (or alongside) manual dictation. Once paired, your Vitana pillars draw from live data every day.
+
+## Why it matters for your Index
+A connected tracker gives your Index its richest signal. Every pillar accepts wearable data:
+- **Nutrition** — MyFitnessPal, Cronometer, biomarker labs.
+- **Hydration** — HidrateSpark, Apple Health Water.
+- **Exercise** — Apple Health, Google Fit, Strava, Whoop, Oura, Garmin.
+- **Sleep** — Oura, Whoop, Eight Sleep, Apple Sleep.
+- **Mental** — Apple Health Mindful Minutes, Calm, Headspace, mood-tracking apps.
+
+## Steps
+1. Open the Integrations section in your Settings.
+2. Pick the tracker or app you want to connect.
+3. Today, log a single integration entry that points the system at your data source.
+4. When native OAuth ships for that partner, you'll get a one-tap connect flow — and your Index will start drawing from the live data.
+
+## Expected outcome
+The integration appears as connected in your Settings. Each day, the relevant pillar's "data" sub-score and "streak" sub-score climb as data flows in.
+
+## Pitfalls
+- Connecting one tracker that covers multiple pillars (Apple Health, Google Fit) is a bigger jump than connecting five single-purpose apps.
+- Trackers don't replace Daily Diary — they supplement it. Mood, stress, meal quality still need words.
+- If a partner shows as `unavailable` in the catalog, native OAuth isn't ready yet — manual integration is the path until then.
+
+## Related
+- [Use Daily Diary dictation](kb/vitana-system/how-to/use-daily-diary-dictation.md)
+- [Improve your Vitana Index](kb/vitana-system/how-to/improve-your-vitana-index.md)
+$CONTENT$
+);
+
+-- ===========================================================================
+-- 8. Improve your Vitana Index
+-- ===========================================================================
+
+SELECT public.upsert_knowledge_doc(
+  p_title := 'How to improve your Vitana Index',
+  p_path  := 'kb/vitana-system/how-to/improve-your-vitana-index.md',
+  p_source_type := 'markdown',
+  p_tags  := ARRAY['vitana_system','how-to','procedural','vitana-index','improve'],
+  p_content := $CONTENT$
+# How to improve your Vitana Index
+
+## What it is
+Practical guidance on the fastest, most durable ways to lift your Vitana Index — what works, in what order, and why.
+
+## Why it matters
+Your Vitana Index moves when you do small daily things across the five pillars (Nutrition, Hydration, Exercise, Sleep, Mental) AND when you keep them in balance. The scoring formula has a balance factor that dampens lopsided practice — so maxing one pillar while ignoring the rest doesn't work.
+
+## Steps
+1. **Find your weakest pillar.** Open the Index Detail screen. The lowest bar is where every point of effort gives the biggest lift.
+2. **Pick one small action.** Either activate one Autopilot suggestion targeting that pillar, or dictate one entry into Daily Diary today.
+3. **Repeat tomorrow.** Streaks of 7 days lift sub-scores noticeably (from 0 to +15 streak bonus per pillar).
+4. **Connect a tracker for one pillar.** Apple Health is the broadest single connection — it covers Exercise, Sleep, and Hydration in one OAuth.
+5. **Keep balance.** It's better to do 4-out-of-5 pillars at a moderate level than to max one and ignore the rest. The balance factor multiplies your raw score by 0.7–1.0 based on the gap between your strongest and weakest pillars.
+
+## Expected outcome
+At a moderate engagement pace (3–4 small actions per week + Daily Diary entries), users typically see the Index climb 50–100 points over a 90-day window. *Really good* (600+) is the aspirational Day-90 target. *Elite* (800+) is months of sustained practice.
+
+## Pitfalls
+- Trying to max your strongest pillar feels productive but the balance factor caps the return — diversify.
+- Skipping Daily Diary on busy days breaks streaks. Even one short entry preserves the streak.
+- Don't compare to other users — different lives have different capacities. The Index measures *your* trajectory, not a leaderboard position.
+
+## Related
+- [What is Autopilot](kb/vitana-system/how-to/what-is-autopilot.md)
+- [Connect a health tracker](kb/vitana-system/how-to/connect-health-tracker.md)
+- [Book — Reading your number](kb/vitana-system/index-book/08-reading-your-number.md)
+- [Book — Balance](kb/vitana-system/index-book/06-balance.md)
+$CONTENT$
+);
+
+-- ===========================================================================
+-- 9. What is Autopilot
+-- ===========================================================================
+
+SELECT public.upsert_knowledge_doc(
+  p_title := 'What is Autopilot',
+  p_path  := 'kb/vitana-system/how-to/what-is-autopilot.md',
+  p_source_type := 'markdown',
+  p_tags  := ARRAY['vitana_system','how-to','procedural','autopilot','foundational'],
+  p_content := $CONTENT$
+# What is Autopilot
+
+## What it is
+Autopilot is the engine that watches your Vitana Index and suggests the next small action that would lift it the most. Each suggestion shows which pillar it targets and roughly how many points it would move you. You activate, you complete, you climb.
+
+## Why it matters for your Index
+Autopilot personalises the climb. Instead of guessing what to do, you get a ranked queue tuned to your current weakest pillar, your Life Compass goal, and what you've already done recently. The ranker dampens repeats and reinforces things you've shown engagement with.
+
+## Steps
+1. Open Autopilot from the home screen — you see a ranked list of suggestions, each tagged with the pillar it lifts (for example, *Sleep +4*) and an estimated time.
+2. Activate one. The system schedules a calendar event for it.
+3. Complete the event when the time comes (mark it done from the calendar or the Daily Diary).
+4. Your Index recomputes within minutes; the queue regenerates with the next best suggestion.
+5. Don't try to clear the whole list — pick one or two each day, balanced across pillars.
+
+## Expected outcome
+A short, always-fresh list of suggestions with pillar pills. Completing them moves your Index incrementally and updates the queue. Over weeks, the suggestions adapt to what you actually engage with vs. dismiss.
+
+## Pitfalls
+- More suggestions ≠ more progress. Quality > quantity. Two completed beats five activated-but-skipped.
+- Dismissing repeatedly trains the ranker to surface less of that domain — that's the feedback loop working as designed.
+- The queue refreshes after completions; if it looks stale, complete one to trigger regeneration.
+
+## Related
+- [Improve your Vitana Index](kb/vitana-system/how-to/improve-your-vitana-index.md)
+- [Use Daily Diary dictation](kb/vitana-system/how-to/use-daily-diary-dictation.md)
+$CONTENT$
+);
+
+COMMIT;
+
+-- Reload the PostgREST schema cache so the new knowledge_docs rows are
+-- immediately searchable via the API.
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary

Voice was acting navigator-first: phrases like "How do I log my hydration?" or "Explain the Vitana Index" silently redirected users to a screen instead of teaching them. First-time users especially need verbal explanation, not blind navigation.

This PR introduces a 3-bucket intent classifier that routes every ambiguous turn correctly, plus the \`explain_feature\` tool and how-to KB corpus that the teaching path needs.

### The three buckets (classified BEFORE any tool call)

| Bucket | Triggers | Voice action |
|---|---|---|
| **NAVIGATE-ONLY** | "open", "go to", "show me the <noun>", "where is <noun>" | Open screen, one-sentence announce, NO explanation |
| **TEACH-ONLY** | "explain", "how does X work", "show me how <verb>", "I'm new", "I don't understand" | Call \`explain_feature\` (mode=teach_only), speak summary + ALL steps, NO redirect |
| **TEACH-THEN-NAV** | "how do I <action>", "where do I <action>", "can I <action>" | Call \`explain_feature\` (mode=teach_then_nav), speak brief summary + 2-3 steps + offer redirect; only navigate on confirmation |

### What ships

- **explain-feature-service.ts** (new) — 9 canonical topics with EN+DE summary + ordered steps + redirect_route + redirect_offer + KB citation. Deterministic, ~1ms.
- **20260425100000_how_to_kb_corpus.sql** (new) — long-form versions of the 9 topics for KB browsing / search_knowledge fallback.
- **explain_feature ORB tool** (new) — wraps the service.
- **Override prompt** — new INTENT CLASSIFIER section with full disambiguation tree, bucket actions, edge cases, worked-example truth table.
- **Retrieval router** — 3 sibling rules (nav/teach/teach_then_nav) at priorities 94/93/92 with auditable rationale tags.
- **Profiler** — emits "User profile maturity: NEW USER" line so voice biases toward the fullest explanation for first-timers.

### Adjacent gap flagged in plan (not in this PR)

Does Daily Diary dictation actually flow into \`health_features_daily\` so the pillar "data" sub-scores climb? The teach layer here tells users this works; the data layer must follow. Recommend a separate audit of \`inline-fact-extractor.ts\` + cognee extractor.

### Test plan

| # | Phrase | Expected bucket | Expected voice |
|---|---|---|---|
| 1 | "Open Daily Diary" | NAV-ONLY | Opens, "Opening Daily Diary" |
| 2 | "Show me the Health screen" | NAV-ONLY | Navigates briefly |
| 3 | "Show me how to log water" | TEACH-ONLY | Full explanation, NO redirect |
| 4 | "Explain how the Index works" | TEACH-ONLY | Spoken explanation |
| 5 | "How does Autopilot work" | TEACH-ONLY | Full how-to, NO redirect |
| 6 | "How do I log my hydration?" | TEACH-THEN-NAV | Brief explanation + "Want me to open Daily Diary?" |
| 7 | "Where do I log my sleep?" | TEACH-THEN-NAV | Brief + offer |
| 8 | "I'm new — what is Autopilot for" | TEACH-ONLY | Fullest explanation (NEW USER bias) |
| 9 | "Show me" (alone) | clarify | "Show you what — a screen, or how something works?" |

🤖 Generated with [Claude Code](https://claude.com/claude-code)