### PR TITLE
feat(self-healing): accept voice-error:// synthetic endpoints (VTID-01956)

### DIFF
--- a/services/gateway/src/routes/self-healing.ts
+++ b/services/gateway/src/routes/self-healing.ts
@@ -383,8 +383,15 @@ router.post('/report', async (req: Request, res: Response) => {
     knownEndpoints.add('/alive');
     knownEndpoints.add('/api/v1/self-healing/health');
 
+    // Voice synthetic endpoints (voice-error://<class>) are accepted by the
+    // self-healing pipeline so the Voice→SelfHealing Adapter can dispatch
+    // ORB voice failures through the same diagnose/inject/dispatch chain.
+    // Subsequent PRs add the adapter, deterministic specs, and synthetic probe.
+    const VOICE_SYNTHETIC_ENDPOINT = /^voice-error:\/\/[a-z._-]+$/;
+
     for (const failure of downServices) {
-      if (!knownEndpoints.has(failure.endpoint)) {
+      const isVoiceSynthetic = VOICE_SYNTHETIC_ENDPOINT.test(failure.endpoint);
+      if (!isVoiceSynthetic && !knownEndpoints.has(failure.endpoint)) {
         console.log(`[self-healing] Rejecting unknown endpoint: ${failure.endpoint}`);
         details.push({
           service: failure.name,

--- a/services/gateway/src/routes/voice-lab.ts
+++ b/services/gateway/src/routes/voice-lab.ts
@@ -139,7 +139,9 @@ async function queryVoiceLabEvents(
     }
 
     // VTID filter: VTID-01218A (legacy voice-lab) + VTID-01155 (orb-live emitter)
-    params.push(`vtid=in.("VTID-01218A","VTID-01155")`);
+    // + VTID-VOICE-HEALING (autonomous self-healing loop events: dispatched,
+    // verdict, rollback, suppressed, spec_memory.blocked, investigation.completed)
+    params.push(`vtid=in.("VTID-01218A","VTID-01155","VTID-VOICE-HEALING")`);
 
     // Ordering and pagination
     params.push('order=created_at.desc');

--- a/services/gateway/src/services/self-healing-injector-service.ts
+++ b/services/gateway/src/services/self-healing-injector-service.ts
@@ -56,7 +56,13 @@ export async function injectIntoAutopilotPipeline(
   }
 
   try {
-    const autoApproved = diagnosis.confidence >= 0.8;
+    // Voice synthetic endpoints auto-approve regardless of confidence.
+    // The safety net for voice rows is the synthetic Voice Probe + auto-rollback
+    // + Spec Memory Gate (PR #4 + PR #3), not human approval.
+    const isVoiceSyntheticSource =
+      typeof diagnosis.endpoint === 'string' &&
+      diagnosis.endpoint.startsWith('voice-error://');
+    const autoApproved = isVoiceSyntheticSource || diagnosis.confidence >= 0.8;
 
     // Step 1: Update the existing VTID entry — transition allocated → pending
     const updateResp = await fetch(

--- a/services/gateway/src/services/self-healing-reconciler.ts
+++ b/services/gateway/src/services/self-healing-reconciler.ts
@@ -90,6 +90,17 @@ async function fetchStaleRows(thresholdMs: number): Promise<StaleRow[]> {
 async function probeEndpoint(
   endpoint: string,
 ): Promise<{ healthy: boolean; http_status: number | null }> {
+  // Voice synthetic endpoints (voice-error://<class>) have no HTTP path —
+  // they're a routing convention so the Voice→SelfHealing Adapter can flow
+  // through the same dedup/diagnose/inject pipeline. Verification for voice
+  // rows happens via the Synthetic Voice Probe (programmatic SSE session
+  // against /api/v1/orb/live/session/start with semantic-token check),
+  // which lands in PR #4. For now we report voice rows as not-healthy so
+  // the reconciler keeps them in the queue and does not falsely transition
+  // them to recovered_externally.
+  if (endpoint.startsWith('voice-error://')) {
+    return { healthy: false, http_status: null };
+  }
   try {
     const res = await fetch(`${GATEWAY_URL}${endpoint}`, {
       signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),


### PR DESCRIPTION
PR #0 of 9 in the autonomous ORB voice self-healing loop. Four integration edits to the existing self-healing pipeline so it accepts voice failures via synthetic voice-error://<class> endpoints. **No behavior change for non-voice paths.** Pure scaffolding.

Plan: .claude/plans/the-biggest-issues-and-fizzy-wozniak.md (approved 2026-04-25).

## Changes
- routes/self-healing.ts: /report allowlist accepts ^voice-error://[a-z._-]+$
- services/self-healing-injector-service.ts: voice synthetic rows auto-approve regardless of confidence (safety net is probe + rollback + Spec Memory Gate)
- services/self-healing-reconciler.ts: probeEndpoint short-circuits voice synthetic endpoints (no HTTP path; voice probe lands in PR #4)
- routes/voice-lab.ts: VTID query filter expanded to include VTID-VOICE-HEALING

## Test plan
- [x] TypeScript build passes (npm run build in services/gateway)
- [ ] Post-deploy: existing self-healing flows continue to work
- [ ] Post-deploy: synthetic POST to /report with endpoint voice-error://voice.config_missing is accepted

Generated with Claude Code