### PR TITLE
fix(self-healing): show autopilot.* failures on /history (BOOTSTRAP-HEAL-SCREEN-AUTOPILOT)

### DIFF
--- a/services/gateway/src/routes/self-healing.ts
+++ b/services/gateway/src/routes/self-healing.ts
@@ -604,11 +604,20 @@ router.get('/history', async (req: Request, res: Response) => {
     }
 
     const raw = (await resp.json()) as any[];
-    // Filter out phantom/test endpoints that aren't in the gateway route map
+    // Filter out phantom/test endpoints that aren't in the gateway route map.
+    // Synthetic `autopilot.*` identifiers (from dev-autopilot self-heal-log writes)
+    // are NOT route URLs — they're stage tags ("autopilot.scan_ingest",
+    // "autopilot.worker_queue.plan", "autopilot.plan_gen"). Pass them through
+    // unconditionally so the Self-Healing screen surfaces autopilot failures
+    // alongside route-class failures.
     const known = new Set(Object.keys(ENDPOINT_FILE_MAP));
     known.add('/alive');
     known.add('/api/v1/self-healing/health');
-    const items = raw.filter((r: any) => !r.endpoint || known.has(r.endpoint));
+    const items = raw.filter((r: any) =>
+      !r.endpoint
+      || known.has(r.endpoint)
+      || (typeof r.endpoint === 'string' && r.endpoint.startsWith('autopilot.'))
+    );
     const countHeader = resp.headers.get('content-range');
     const total = countHeader ? parseInt(countHeader.split('/')[1] || '0', 10) : items.length;
 


### PR DESCRIPTION
## The bug
Discovered while running end-to-end verification of PRs #905/#906/#911. The /api/v1/self-healing/history filter at services/gateway/src/routes/self-healing.ts:604 was dropping every row whose endpoint isn't in ENDPOINT_FILE_MAP. My new self-heal writes use synthetic stage tags (autopilot.scan_ingest, autopilot.worker_queue.plan, autopilot.plan_gen) — none of which are HTTP routes — so 100% of them were invisible on the Self-Healing screen.

## Fix
Pass through any endpoint starting with `autopilot.` alongside the existing route allowlist. Verified: a row with endpoint=`autopilot.scan_ingest` written via the same writeAutopilotFailure() call my routes use exists in self_healing_log right now and is being filtered out by the deployed code.

## Test plan
- [x] tsc clean for the changed file
- [ ] Post-deploy: row with `autopilot.scan_ingest` (id `a4300ced-179d-4ffa-b6c0-ff6cb623a58e`, written during e2e test) appears in /api/v1/self-healing/history within 1 day