### PR TITLE
feat(voice): self-healing adapter + 5-tuple dedupe (VTID-01959)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -46,6 +46,7 @@ import { randomUUID } from 'crypto';
 import { TextToSpeechClient, protos } from '@google-cloud/text-to-speech';
 import { processWithGemini, setThreadIdentity } from '../services/gemini-operator';
 import { emitOasisEvent } from '../services/oasis-event-service';
+import { dispatchVoiceFailureFireAndForget } from '../services/voice-self-healing-adapter';
 import { fetchAdminBriefingBlock, isAdminRole } from '../services/admin-scanners/briefing';
 import { getUserContextSummary } from '../services/user-context-profiler';
 import { getAwarenessConfigSync } from '../services/awareness-registry';
@@ -942,6 +943,12 @@ setInterval(() => {
         duration_ms: Date.now() - s.createdAt.getTime(),
         turn_count: s.turn_count,
       }).catch(() => { });
+      // VTID-01959: voice self-healing dispatch (mode-gated; off by default)
+      dispatchVoiceFailureFireAndForget({
+        sessionId: sid,
+        tenantScope: s.identity?.tenant_id || 'global',
+        metadata: { synthetic: (s as any).synthetic === true },
+      });
       s.active = false;
       liveSessions.delete(sid);
       purged++;
@@ -1023,6 +1030,12 @@ function terminateExistingSessionsForUser(userId: string, excludeSessionId?: str
       duration_ms: Date.now() - existingSession.createdAt.getTime(),
       turn_count: existingSession.turn_count,
     }).catch(() => {});
+    // VTID-01959: voice self-healing dispatch (mode-gated; off by default)
+    dispatchVoiceFailureFireAndForget({
+      sessionId: sid,
+      tenantScope: existingSession.identity?.tenant_id || 'global',
+      metadata: { synthetic: (existingSession as any).synthetic === true },
+    });
   }
   return terminated;
 }
@@ -11093,6 +11106,12 @@ router.post('/live/session/stop', optionalAuth, async (req: AuthenticatedRequest
     user_turns: session.transcriptTurns.filter(t => t.role === 'user').length,
     model_turns: session.transcriptTurns.filter(t => t.role === 'assistant').length,
   });
+  // VTID-01959: voice self-healing dispatch (mode-gated; off by default)
+  dispatchVoiceFailureFireAndForget({
+    sessionId: session_id,
+    tenantScope: session.identity?.tenant_id || 'global',
+    metadata: { synthetic: (session as any).synthetic === true },
+  });
 
   // VTID-01225: Fire-and-forget entity extraction from live session
   // Use in-memory transcriptTurns (UNFILTERED full conversation) instead of memory_items
@@ -11419,6 +11438,13 @@ router.get('/live/stream', optionalAuth, async (req: AuthenticatedRequest, res: 
         error: err.message,
         vertex_project_id: VERTEX_PROJECT_ID || 'EMPTY',
       }, 'error').catch(() => {});
+      // VTID-01959: voice self-healing dispatch (mode-gated; off by default).
+      // Hooked here for the fast-fail path that may abort before session.stop.
+      dispatchVoiceFailureFireAndForget({
+        sessionId,
+        tenantScope: session.identity?.tenant_id || 'global',
+        metadata: { synthetic: (session as any).synthetic === true },
+      });
 
       // Notify client of connection failure
       if (session.sseResponse) {
@@ -11437,6 +11463,13 @@ router.get('/live/stream', optionalAuth, async (req: AuthenticatedRequest, res: 
       google_auth_ready: !!googleAuth,
       vertex_project_id: VERTEX_PROJECT_ID || 'EMPTY',
     }, 'error').catch(() => {});
+    // VTID-01959: voice self-healing dispatch (mode-gated; off by default).
+    // Hooked here for the fast-fail path that may abort before session.stop.
+    dispatchVoiceFailureFireAndForget({
+      sessionId,
+      tenantScope: session.identity?.tenant_id || 'global',
+      metadata: { synthetic: (session as any).synthetic === true },
+    });
   }
 
   // VTID-HEARTBEAT-FIX: Send actual data heartbeats, not SSE comments.
@@ -13227,6 +13260,12 @@ function handleWsStopSession(clientSession: WsClientSession): void {
       user_turns: liveSession.transcriptTurns.filter(t => t.role === 'user').length,
       model_turns: liveSession.transcriptTurns.filter(t => t.role === 'assistant').length,
     }).catch(() => { });
+    // VTID-01959: voice self-healing dispatch (mode-gated; off by default)
+    dispatchVoiceFailureFireAndForget({
+      sessionId,
+      tenantScope: liveSession.identity?.tenant_id || 'global',
+      metadata: { synthetic: (liveSession as any).synthetic === true },
+    });
 
     liveSessions.delete(sessionId);
   }

--- a/services/gateway/src/services/voice-self-healing-adapter.ts
+++ b/services/gateway/src/services/voice-self-healing-adapter.ts
@@ -1,0 +1,315 @@
+/**
+ * Voice→SelfHealing Adapter (VTID-01959, PR #2)
+ *
+ * Bridges voice OASIS error events into the existing self-healing pipeline
+ * via the synthetic endpoint convention `voice-error://<class>` (allowlisted
+ * in PR #0). The adapter is fire-and-forget from orb-live.ts hot paths so
+ * voice session handling is never blocked by classification or HTTP work.
+ *
+ * Flow per call:
+ *   1. Filter synthetic probe sessions (metadata.synthetic === true).
+ *   2. Read mode flag (system_config.voice_self_healing_mode):
+ *        - off    → return early (this PR's default)
+ *        - shadow → classify + dedupe + log "would-dispatch", do NOT POST
+ *        - live   → classify + dedupe + POST to /api/v1/self-healing/report
+ *   3. Classify the session (voice-session-classifier).
+ *   4. 5-tuple Supabase dedupe — INSERT ON CONFLICT DO NOTHING on
+ *      (class, normalized_signature, gateway_revision, tenant_scope, hour_bucket).
+ *      Conflict = another instance/session in the same hour already dispatched
+ *      this signature, so skip.
+ *   5. Build ServiceStatus and POST to /report (mode=live only).
+ *
+ * Plan: .claude/plans/the-biggest-issues-and-fizzy-wozniak.md
+ */
+
+import {
+  classifyVoiceSession,
+  VoiceClassification,
+} from './voice-session-classifier';
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
+const GATEWAY_URL = process.env.GATEWAY_URL || 'https://gateway-q74ibpv6ia-uc.a.run.app';
+// Cloud Run sets K_REVISION; fall back to BUILD_INFO for local/dev.
+const GATEWAY_REVISION =
+  process.env.K_REVISION || process.env.BUILD_INFO || 'unknown';
+
+export type SelfHealingMode = 'off' | 'shadow' | 'live';
+
+const MODE_CACHE_TTL_MS = 30_000;
+let cachedMode: SelfHealingMode | null = null;
+let cachedModeAt = 0;
+
+/**
+ * Read `system_config.voice_self_healing_mode`. Default 'off' on any error
+ * (missing config row, Supabase unreachable, malformed value). Cached for
+ * 30s so the hot path doesn't read Supabase per emit.
+ */
+export async function getVoiceSelfHealingMode(force?: boolean): Promise<SelfHealingMode> {
+  const now = Date.now();
+  if (!force && cachedMode && now - cachedModeAt < MODE_CACHE_TTL_MS) {
+    return cachedMode;
+  }
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
+    cachedMode = 'off';
+    cachedModeAt = now;
+    return 'off';
+  }
+  try {
+    const res = await fetch(
+      `${SUPABASE_URL}/rest/v1/system_config?key=eq.voice_self_healing_mode&select=value&limit=1`,
+      {
+        headers: {
+          apikey: SUPABASE_SERVICE_ROLE,
+          Authorization: `Bearer ${SUPABASE_SERVICE_ROLE}`,
+        },
+      },
+    );
+    if (res.ok) {
+      const rows = (await res.json()) as Array<{ value?: string }>;
+      const v = rows[0]?.value;
+      if (v === 'off' || v === 'shadow' || v === 'live') {
+        cachedMode = v;
+        cachedModeAt = now;
+        return v;
+      }
+    }
+  } catch {
+    /* fall through to default */
+  }
+  cachedMode = 'off';
+  cachedModeAt = now;
+  return 'off';
+}
+
+/** Test helper — invalidate the mode cache. */
+export function _resetModeCacheForTests(): void {
+  cachedMode = null;
+  cachedModeAt = 0;
+}
+
+export interface DispatchOptions {
+  sessionId: string;
+  /** Optional tenant scope for dedupe. Defaults to 'global'. */
+  tenantScope?: string;
+  /**
+   * Session metadata. If `synthetic === true` the dispatch is suppressed
+   * (used by future Synthetic Voice Probe — PR #4).
+   */
+  metadata?: Record<string, unknown>;
+}
+
+export type DispatchAction =
+  | 'dispatched'
+  | 'shadow_logged'
+  | 'mode_off'
+  | 'synthetic_skipped'
+  | 'dedupe_hit'
+  | 'classifier_no_error'
+  | 'error';
+
+export interface DispatchResult {
+  action: DispatchAction;
+  class?: string;
+  normalized_signature?: string;
+  detail?: string;
+  http_status?: number;
+}
+
+function hourBucketIso(): string {
+  const d = new Date();
+  d.setUTCMinutes(0, 0, 0);
+  return d.toISOString();
+}
+
+interface DedupeReservation {
+  first: boolean;
+  error?: string;
+}
+
+async function tryReserveDedupe(
+  klass: string,
+  signature: string,
+  tenantScope: string,
+): Promise<DedupeReservation> {
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
+    return { first: false, error: 'no_supabase' };
+  }
+  const row = {
+    class: klass,
+    normalized_signature: signature,
+    gateway_revision: GATEWAY_REVISION,
+    tenant_scope: tenantScope,
+    hour_bucket: hourBucketIso(),
+  };
+  // ON CONFLICT DO NOTHING via Prefer: resolution=ignore-duplicates.
+  // Combined with return=representation, the response body length tells us
+  // whether the row was newly inserted (length 1) or already existed (0).
+  try {
+    const res = await fetch(
+      `${SUPABASE_URL}/rest/v1/voice_healing_dedupe`,
+      {
+        method: 'POST',
+        headers: {
+          apikey: SUPABASE_SERVICE_ROLE,
+          Authorization: `Bearer ${SUPABASE_SERVICE_ROLE}`,
+          'Content-Type': 'application/json',
+          Prefer: 'resolution=ignore-duplicates,return=representation',
+        },
+        body: JSON.stringify(row),
+      },
+    );
+    if (!res.ok) {
+      const txt = await res.text().catch(() => '');
+      return { first: false, error: `dedupe_${res.status}_${txt.slice(0, 80)}` };
+    }
+    const inserted = (await res.json()) as Array<unknown>;
+    return { first: Array.isArray(inserted) && inserted.length > 0 };
+  } catch (err: any) {
+    return { first: false, error: `dedupe_fetch: ${err?.message ?? 'unknown'}` };
+  }
+}
+
+interface ServiceStatusPayload {
+  name: string;
+  endpoint: string;
+  status: 'down';
+  http_status: number;
+  response_body: string;
+  response_time_ms: number;
+  error_message: string;
+}
+
+function buildServiceStatus(c: VoiceClassification): ServiceStatusPayload {
+  const evidence = JSON.stringify(c.evidence).slice(0, 4000);
+  const errorMessage =
+    c.evidence.stall_description ||
+    `${c.class} (signature: ${c.normalized_signature}, errors: ${c.evidence.error_count})`;
+  return {
+    name: 'orb-voice-pipeline',
+    endpoint: `voice-error://${c.class}`,
+    status: 'down',
+    http_status: 0,
+    response_body: evidence,
+    response_time_ms: 0,
+    error_message: errorMessage,
+  };
+}
+
+async function postSelfHealingReport(
+  c: VoiceClassification,
+): Promise<{ ok: boolean; status?: number; detail?: string }> {
+  const payload = {
+    timestamp: new Date().toISOString(),
+    total: 1,
+    live: 0,
+    services: [buildServiceStatus(c)],
+  };
+  try {
+    const res = await fetch(`${GATEWAY_URL}/api/v1/self-healing/report`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify(payload),
+      signal: AbortSignal.timeout(10_000),
+    });
+    if (!res.ok) {
+      const txt = await res.text().catch(() => '');
+      return { ok: false, status: res.status, detail: txt.slice(0, 200) };
+    }
+    return { ok: true, status: res.status };
+  } catch (err: any) {
+    return { ok: false, detail: err?.message ?? 'unknown' };
+  }
+}
+
+/**
+ * Classify the session and dispatch to self-healing if the (class,
+ * signature) hasn't been dispatched in this hour. Returns a structured
+ * result describing what happened. Does not throw — all internal errors
+ * are surfaced as `action: 'error'`.
+ */
+export async function dispatchVoiceFailure(
+  opts: DispatchOptions,
+): Promise<DispatchResult> {
+  if (opts.metadata?.synthetic === true) {
+    return { action: 'synthetic_skipped' };
+  }
+
+  const mode = await getVoiceSelfHealingMode();
+  if (mode === 'off') {
+    return { action: 'mode_off' };
+  }
+
+  let classification: VoiceClassification;
+  try {
+    classification = await classifyVoiceSession(opts.sessionId);
+  } catch (err: any) {
+    return { action: 'error', detail: `classify_failed: ${err?.message ?? 'unknown'}` };
+  }
+
+  // Healthy session (no error events, no stall) → don't dispatch. Note we
+  // still dispatch when class is voice.unknown but severity === 'error',
+  // because that means we observed errors we couldn't classify — investigator
+  // needs that signal.
+  if (classification.class === 'voice.unknown' && classification.severity !== 'error') {
+    return {
+      action: 'classifier_no_error',
+      class: classification.class,
+      normalized_signature: classification.normalized_signature,
+    };
+  }
+
+  const tenantScope = opts.tenantScope || 'global';
+  const dedup = await tryReserveDedupe(
+    classification.class,
+    classification.normalized_signature,
+    tenantScope,
+  );
+  if (!dedup.first) {
+    return {
+      action: 'dedupe_hit',
+      class: classification.class,
+      normalized_signature: classification.normalized_signature,
+      detail: dedup.error,
+    };
+  }
+
+  if (mode === 'shadow') {
+    return {
+      action: 'shadow_logged',
+      class: classification.class,
+      normalized_signature: classification.normalized_signature,
+    };
+  }
+
+  // mode === 'live'
+  const post = await postSelfHealingReport(classification);
+  if (!post.ok) {
+    return {
+      action: 'error',
+      class: classification.class,
+      normalized_signature: classification.normalized_signature,
+      http_status: post.status,
+      detail: `report_${post.status ?? 'fetch'}: ${post.detail ?? ''}`,
+    };
+  }
+  return {
+    action: 'dispatched',
+    class: classification.class,
+    normalized_signature: classification.normalized_signature,
+    http_status: post.status,
+  };
+}
+
+/**
+ * Fire-and-forget wrapper for orb-live.ts hot paths. Always returns
+ * synchronously; never throws. Internal errors are logged at warn level.
+ */
+export function dispatchVoiceFailureFireAndForget(opts: DispatchOptions): void {
+  dispatchVoiceFailure(opts).catch((err) => {
+    console.warn(
+      '[voice-self-healing-adapter] fire-and-forget dispatch failed:',
+      err?.message ?? err,
+    );
+  });
+}

--- a/services/gateway/test/voice-self-healing-adapter.test.ts
+++ b/services/gateway/test/voice-self-healing-adapter.test.ts
@@ -1,0 +1,220 @@
+/**
+ * VTID-01959: Voice→SelfHealing Adapter Tests
+ *
+ * Verifies the dispatch state machine end-to-end with a mocked classifier
+ * and mocked Supabase/Gateway fetches:
+ *   - mode=off blocks dispatch
+ *   - synthetic flag blocks dispatch
+ *   - dedupe hit blocks dispatch
+ *   - mode=shadow logs but does NOT POST
+ *   - mode=live POSTs to /report with proper ServiceStatus shape
+ *   - classifier with no errors does not dispatch
+ */
+
+process.env.NODE_ENV = 'test';
+process.env.SUPABASE_URL = 'http://supabase.test';
+process.env.SUPABASE_SERVICE_ROLE = 'test-service-role';
+process.env.GATEWAY_URL = 'http://gateway.test';
+process.env.K_REVISION = 'test-rev-1';
+
+import {
+  dispatchVoiceFailure,
+  _resetModeCacheForTests,
+} from '../src/services/voice-self-healing-adapter';
+
+// Mock the classifier — adapter calls it during dispatch.
+const mockClassify = jest.fn();
+jest.mock('../src/services/voice-session-classifier', () => ({
+  classifyVoiceSession: (sessionId: string) => mockClassify(sessionId),
+}));
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as any;
+
+function jsonResp(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: 'OK',
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+function classification(overrides: Record<string, unknown> = {}) {
+  return {
+    class: 'voice.config_missing',
+    normalized_signature: 'vertex_project_id_empty',
+    severity: 'error',
+    evidence: {
+      session_id: 'test-session',
+      stall_description: 'config missing',
+      error_count: 1,
+      audio_in_chunks: 0,
+      audio_out_chunks: 0,
+    },
+    ...overrides,
+  };
+}
+
+beforeEach(() => {
+  mockFetch.mockReset();
+  mockClassify.mockReset();
+  _resetModeCacheForTests();
+});
+
+describe('VTID-01959: Voice→SelfHealing Adapter', () => {
+  test('mode=off → returns mode_off and does not classify or POST', async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('system_config')) return Promise.resolve(jsonResp([{ value: 'off' }]));
+      throw new Error('unexpected fetch: ' + url);
+    });
+    const r = await dispatchVoiceFailure({ sessionId: 's1' });
+    expect(r.action).toBe('mode_off');
+    expect(mockClassify).not.toHaveBeenCalled();
+  });
+
+  test('synthetic=true → returns synthetic_skipped and does not read mode', async () => {
+    const r = await dispatchVoiceFailure({
+      sessionId: 's2',
+      metadata: { synthetic: true },
+    });
+    expect(r.action).toBe('synthetic_skipped');
+    expect(mockFetch).not.toHaveBeenCalled();
+  });
+
+  test('mode missing config row defaults to off', async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('system_config')) return Promise.resolve(jsonResp([]));
+      throw new Error('unexpected fetch: ' + url);
+    });
+    const r = await dispatchVoiceFailure({ sessionId: 's3' });
+    expect(r.action).toBe('mode_off');
+  });
+
+  test('mode=live + healthy classifier (unknown/info) → classifier_no_error', async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('system_config')) return Promise.resolve(jsonResp([{ value: 'live' }]));
+      throw new Error('unexpected fetch: ' + url);
+    });
+    mockClassify.mockResolvedValue(
+      classification({ class: 'voice.unknown', severity: 'info' }),
+    );
+    const r = await dispatchVoiceFailure({ sessionId: 's4' });
+    expect(r.action).toBe('classifier_no_error');
+  });
+
+  test('mode=live + dedupe hit → dedupe_hit, no POST', async () => {
+    mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes('system_config')) return Promise.resolve(jsonResp([{ value: 'live' }]));
+      if (url.includes('voice_healing_dedupe')) {
+        // ON CONFLICT DO NOTHING — already-existing row returns []
+        return Promise.resolve(jsonResp([]));
+      }
+      if (url.includes('/api/v1/self-healing/report')) {
+        throw new Error('should not POST when dedupe hit');
+      }
+      throw new Error('unexpected fetch: ' + url);
+    });
+    mockClassify.mockResolvedValue(classification());
+    const r = await dispatchVoiceFailure({ sessionId: 's5' });
+    expect(r.action).toBe('dedupe_hit');
+    expect(r.class).toBe('voice.config_missing');
+  });
+
+  test('mode=shadow + first-time signature → shadow_logged, no POST', async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('system_config')) return Promise.resolve(jsonResp([{ value: 'shadow' }]));
+      if (url.includes('voice_healing_dedupe')) {
+        return Promise.resolve(jsonResp([{ class: 'voice.config_missing' }]));
+      }
+      if (url.includes('/api/v1/self-healing/report')) {
+        throw new Error('should not POST in shadow mode');
+      }
+      throw new Error('unexpected fetch: ' + url);
+    });
+    mockClassify.mockResolvedValue(classification());
+    const r = await dispatchVoiceFailure({ sessionId: 's6' });
+    expect(r.action).toBe('shadow_logged');
+    expect(r.class).toBe('voice.config_missing');
+  });
+
+  test('mode=live + first-time signature → dispatched + POSTs to /report with voice-error:// endpoint', async () => {
+    let capturedPostBody: any = null;
+    mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes('system_config')) return Promise.resolve(jsonResp([{ value: 'live' }]));
+      if (url.includes('voice_healing_dedupe')) {
+        return Promise.resolve(jsonResp([{ class: 'voice.config_missing' }]));
+      }
+      if (url.includes('/api/v1/self-healing/report')) {
+        capturedPostBody = JSON.parse((init?.body as string) || '{}');
+        return Promise.resolve(jsonResp({ ok: true, processed: 1 }));
+      }
+      throw new Error('unexpected fetch: ' + url);
+    });
+    mockClassify.mockResolvedValue(classification());
+    const r = await dispatchVoiceFailure({
+      sessionId: 's7',
+      tenantScope: 'tenant-abc',
+    });
+    expect(r.action).toBe('dispatched');
+    expect(r.class).toBe('voice.config_missing');
+    expect(capturedPostBody).not.toBeNull();
+    expect(capturedPostBody.services).toHaveLength(1);
+    expect(capturedPostBody.services[0].endpoint).toBe('voice-error://voice.config_missing');
+    expect(capturedPostBody.services[0].name).toBe('orb-voice-pipeline');
+    expect(capturedPostBody.services[0].status).toBe('down');
+  });
+
+  test('mode=live + /report 500 → action=error with detail', async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('system_config')) return Promise.resolve(jsonResp([{ value: 'live' }]));
+      if (url.includes('voice_healing_dedupe')) {
+        return Promise.resolve(jsonResp([{ class: 'voice.config_missing' }]));
+      }
+      if (url.includes('/api/v1/self-healing/report')) {
+        return Promise.resolve(jsonResp({ ok: false, error: 'internal' }, 500));
+      }
+      throw new Error('unexpected fetch: ' + url);
+    });
+    mockClassify.mockResolvedValue(classification());
+    const r = await dispatchVoiceFailure({ sessionId: 's8' });
+    expect(r.action).toBe('error');
+    expect(r.detail).toContain('report_500');
+  });
+
+  test('classifier throws → action=error with classify_failed', async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('system_config')) return Promise.resolve(jsonResp([{ value: 'live' }]));
+      throw new Error('unexpected fetch: ' + url);
+    });
+    mockClassify.mockRejectedValue(new Error('boom'));
+    const r = await dispatchVoiceFailure({ sessionId: 's9' });
+    expect(r.action).toBe('error');
+    expect(r.detail).toContain('classify_failed');
+  });
+
+  test('dedupe key includes class, signature, gateway_revision, tenant_scope, hour_bucket', async () => {
+    let capturedDedupeBody: any = null;
+    mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes('system_config')) return Promise.resolve(jsonResp([{ value: 'shadow' }]));
+      if (url.includes('voice_healing_dedupe')) {
+        capturedDedupeBody = JSON.parse((init?.body as string) || '{}');
+        return Promise.resolve(jsonResp([{ class: 'voice.model_stall' }]));
+      }
+      throw new Error('unexpected fetch: ' + url);
+    });
+    mockClassify.mockResolvedValue(
+      classification({ class: 'voice.model_stall', normalized_signature: 'mid_stream_stall' }),
+    );
+    await dispatchVoiceFailure({ sessionId: 's10', tenantScope: 'tenant-xyz' });
+    expect(capturedDedupeBody).toMatchObject({
+      class: 'voice.model_stall',
+      normalized_signature: 'mid_stream_stall',
+      gateway_revision: 'test-rev-1',
+      tenant_scope: 'tenant-xyz',
+    });
+    expect(typeof capturedDedupeBody.hour_bucket).toBe('string');
+    expect(capturedDedupeBody.hour_bucket).toMatch(/T\d\d:00:00/);
+  });
+});

--- a/supabase/migrations/20260425600000_vtid_01959_voice_healing_dedupe.sql
+++ b/supabase/migrations/20260425600000_vtid_01959_voice_healing_dedupe.sql
@@ -1,0 +1,57 @@
+-- VTID-01959: Voice Self-Healing dedupe table (PR #2)
+--
+-- 5-tuple primary key collapses simultaneous voice OASIS error events from
+-- multiple gateway instances + sessions + tenants into one self-healing
+-- dispatch per (class, normalized_signature) per gateway_revision per
+-- tenant_scope per hour bucket. INSERT ON CONFLICT DO NOTHING at the
+-- adapter is the dedupe primitive.
+--
+-- Plan: .claude/plans/the-biggest-issues-and-fizzy-wozniak.md (PR #2 of 9
+-- in the autonomous ORB voice self-healing loop).
+
+CREATE TABLE IF NOT EXISTS public.voice_healing_dedupe (
+  class                 TEXT        NOT NULL,
+  normalized_signature  TEXT        NOT NULL,
+  gateway_revision      TEXT        NOT NULL,
+  tenant_scope          TEXT        NOT NULL,
+  hour_bucket           TIMESTAMPTZ NOT NULL,
+  first_dispatched_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  vtid                  TEXT        NULL,
+  PRIMARY KEY (class, normalized_signature, gateway_revision, tenant_scope, hour_bucket)
+);
+
+CREATE INDEX IF NOT EXISTS idx_voice_healing_dedupe_first_dispatched_at
+  ON public.voice_healing_dedupe (first_dispatched_at);
+
+COMMENT ON TABLE public.voice_healing_dedupe IS
+  'VTID-01959 (PR #2): Voice Self-Healing Loop dedupe. 5-tuple PK collapses voice OASIS error events into one self-healing dispatch per (class, normalized_signature) per gateway_revision per tenant_scope per hour bucket.';
+
+-- Daily retention: drop dedupe rows older than 7 days. The dedupe key
+-- already includes hour_bucket so older rows have no purpose.
+CREATE OR REPLACE FUNCTION public.voice_healing_dedupe_prune()
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  DELETE FROM public.voice_healing_dedupe
+   WHERE first_dispatched_at < NOW() - INTERVAL '7 days';
+END;
+$$;
+
+COMMENT ON FUNCTION public.voice_healing_dedupe_prune() IS
+  'VTID-01959: Daily pg_cron job — drops voice_healing_dedupe rows older than 7 days. Scheduled at 03:15 UTC.';
+
+-- Schedule the prune via pg_cron. Idempotent: cron.schedule returns the
+-- existing job_id if a job with this name already exists. Wrapped in DO
+-- block so the migration succeeds even if pg_cron is not loaded in some
+-- environments (CI staging).
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+    PERFORM cron.schedule(
+      'voice-healing-dedupe-prune',
+      '15 3 * * *',
+      $cron$SELECT public.voice_healing_dedupe_prune()$cron$
+    );
+  END IF;
+END $$;


### PR DESCRIPTION
PR #2 of 9 in the autonomous ORB voice self-healing loop.

Wires the classifier (PR #1) into the existing self-healing pipeline (PR #0 allowlist) via the synthetic endpoint convention voice-error://<class>. Mode flag (system_config.voice_self_healing_mode) defaults to off — adapter is scaffolded but does nothing yet. Subsequent PRs flip mode through shadow then live.

Plan: .claude/plans/the-biggest-issues-and-fizzy-wozniak.md

## Changes

- supabase/migrations/20260425600000_vtid_01959_voice_healing_dedupe.sql (new): voice_healing_dedupe table with 5-tuple PK (class, normalized_signature, gateway_revision, tenant_scope, hour_bucket). Daily pg_cron prune. **Apply via RUN-MIGRATION.yml after merge.**
- services/voice-self-healing-adapter.ts (new): dispatch state machine — synthetic skip → mode read → classify → 5-tuple Supabase dedupe (INSERT ON CONFLICT DO NOTHING) → shadow log OR /api/v1/self-healing/report POST. Mode cached 30s. Never throws.
- routes/orb-live.ts (edited): 6 fire-and-forget hooks — 4 session.stop sites + 2 fast-fail sites (connection_failed, config_missing) that may abort before session.stop. Mode-off keeps them inert.
- test/voice-self-healing-adapter.test.ts (new): 10 tests covering all state-machine paths.

## Test plan

- [x] TypeScript build passes (npm run build).
- [x] 10 adapter unit tests pass (mocked classifier + Supabase + Gateway).
- [ ] Post-deploy: ORB voice sessions continue to work (mode=off — adapter is inert).
- [ ] After RUN-MIGRATION applies voice_healing_dedupe table: PR #3 can read/write it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)