### PR TITLE
feat(voice): Shadow Mode + decision log + mode flip endpoint (VTID-01964)

### DIFF
--- a/services/gateway/src/routes/voice-lab.ts
+++ b/services/gateway/src/routes/voice-lab.ts
@@ -18,6 +18,8 @@ import {
   getQuarantineState,
 } from '../services/voice-recurrence-sentinel';
 import { spawnInvestigator } from '../services/voice-architecture-investigator';
+import { setMode } from '../services/voice-shadow-mode';
+import { getVoiceSelfHealingMode } from '../services/voice-self-healing-adapter';
 
 const router = Router();
 
@@ -711,6 +713,34 @@ router.get('/healing/reports/:id', async (req: Request, res: Response) => {
   } catch (err: any) {
     return res.status(500).json({ ok: false, error: err.message });
   }
+});
+
+/**
+ * GET /api/v1/voice-lab/healing/mode (VTID-01964, PR #7)
+ *
+ * Returns the current voice self-healing mode (off / shadow / live).
+ * Forces a fresh read past the 30s in-memory cache.
+ */
+router.get('/healing/mode', async (_req: Request, res: Response) => {
+  const mode = await getVoiceSelfHealingMode(true);
+  return res.json({ ok: true, mode });
+});
+
+/**
+ * POST /api/v1/voice-lab/healing/mode (VTID-01964, PR #7)
+ *
+ * Flip system_config.voice_self_healing_mode. Body: { mode: 'off' | 'shadow' | 'live', vtid?: string }.
+ * Idempotent. Emits voice.healing.dispatched (mode flip event) for audit.
+ */
+router.post('/healing/mode', async (req: Request, res: Response) => {
+  const body = (req.body || {}) as Record<string, unknown>;
+  const next = body.mode;
+  const actorVtid = typeof body.vtid === 'string' ? body.vtid : 'VTID-VOICE-HEALING';
+  if (next !== 'off' && next !== 'shadow' && next !== 'live') {
+    return res.status(400).json({ ok: false, error: 'mode must be one of off|shadow|live' });
+  }
+  const r = await setMode(next, actorVtid);
+  return res.json(r);
 });
 
 /**

--- a/services/gateway/src/services/voice-self-healing-adapter.ts
+++ b/services/gateway/src/services/voice-self-healing-adapter.ts
@@ -31,6 +31,7 @@ import { lookupSpecMemory } from './voice-spec-memory';
 import { isDispatchAllowed } from './voice-recurrence-sentinel';
 import { emitOasisEvent } from './oasis-event-service';
 import { spawnInvestigator } from './voice-architecture-investigator';
+import { appendShadowLog } from './voice-shadow-mode';
 
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
@@ -236,7 +237,7 @@ async function postSelfHealingReport(
  * result describing what happened. Does not throw — all internal errors
  * are surfaced as `action: 'error'`.
  */
-export async function dispatchVoiceFailure(
+async function _dispatchVoiceFailureCore(
   opts: DispatchOptions,
 ): Promise<DispatchResult> {
   if (opts.metadata?.synthetic === true) {
@@ -410,6 +411,42 @@ export async function dispatchVoiceFailure(
     normalized_signature: classification.normalized_signature,
     http_status: post.status,
   };
+}
+
+/**
+ * Public dispatch wrapper. Runs the core decision pipeline and then writes
+ * a row to voice_healing_shadow_log (PR #7) for the dashboard's
+ * would-dispatch vs actual-outcome comparison view. The log row is
+ * written for every action — dispatched, mode_off, sentinel_quarantined,
+ * spec_memory_blocked, dedupe_hit, etc. — so ops sees a complete decision
+ * timeline, not just the cases that reached /report.
+ */
+export async function dispatchVoiceFailure(
+  opts: DispatchOptions,
+): Promise<DispatchResult> {
+  const result = await _dispatchVoiceFailureCore(opts);
+
+  // Skip shadow log for synthetic probe sessions — they're not real voice
+  // traffic and would pollute the comparison view.
+  if (result.action === 'synthetic_skipped') {
+    return result;
+  }
+
+  // Best-effort log; never blocks the caller.
+  const mode = (cachedMode ?? 'off') as 'off' | 'shadow' | 'live';
+  appendShadowLog({
+    mode,
+    action: result.action,
+    class: result.class,
+    normalized_signature: result.normalized_signature,
+    detail: result.detail,
+    session_id: opts.sessionId,
+    tenant_scope: opts.tenantScope,
+  }).catch(() => {
+    /* swallow — logging is best-effort */
+  });
+
+  return result;
 }
 
 /**

--- a/services/gateway/src/services/voice-shadow-mode.ts
+++ b/services/gateway/src/services/voice-shadow-mode.ts
@@ -1,0 +1,173 @@
+/**
+ * Voice Shadow Mode (VTID-01964, PR #7)
+ *
+ * Shadow Mode runs the entire adapter pipeline (classifier, Sentinel gate,
+ * Spec Memory Gate, dedupe) but DOES NOT POST to /api/v1/self-healing/report.
+ * Every decision the adapter would have made is logged to
+ * voice_healing_shadow_log so PR #8's dashboard can compute the comparison
+ * view ops needs before flipping mode=live.
+ *
+ * This module exposes:
+ *   - appendShadowLog(record): append a decision row.
+ *   - setMode(mode, actorVtid): flip system_config.voice_self_healing_mode.
+ *
+ * The mode flip itself is idempotent — POSTing twice to set 'shadow' is safe.
+ * Ops uses this via POST /api/v1/voice-lab/healing/mode (PR #7 also adds
+ * that route).
+ *
+ * Plan: .claude/plans/the-biggest-issues-and-fizzy-wozniak.md
+ */
+
+import { emitOasisEvent } from './oasis-event-service';
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
+const GATEWAY_REVISION =
+  process.env.K_REVISION || process.env.BUILD_INFO || 'unknown';
+
+export type SelfHealingMode = 'off' | 'shadow' | 'live';
+
+export interface ShadowLogRecord {
+  mode: SelfHealingMode;
+  action: string;
+  class?: string | null;
+  normalized_signature?: string | null;
+  spec_hash?: string | null;
+  detail?: string | null;
+  session_id?: string | null;
+  tenant_scope?: string | null;
+}
+
+function supabaseHeaders(): Record<string, string> {
+  return {
+    apikey: SUPABASE_SERVICE_ROLE!,
+    Authorization: `Bearer ${SUPABASE_SERVICE_ROLE}`,
+    'Content-Type': 'application/json',
+  };
+}
+
+/**
+ * Append a decision row to voice_healing_shadow_log. Best-effort; never
+ * throws. Called by the adapter at the end of every dispatch attempt
+ * (regardless of action) when mode != 'off'.
+ */
+export async function appendShadowLog(record: ShadowLogRecord): Promise<boolean> {
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) return false;
+  try {
+    const res = await fetch(`${SUPABASE_URL}/rest/v1/voice_healing_shadow_log`, {
+      method: 'POST',
+      headers: { ...supabaseHeaders(), Prefer: 'return=minimal' },
+      body: JSON.stringify({
+        mode: record.mode,
+        action: record.action,
+        class: record.class ?? null,
+        normalized_signature: record.normalized_signature ?? null,
+        spec_hash: record.spec_hash ?? null,
+        detail: record.detail ?? null,
+        session_id: record.session_id ?? null,
+        tenant_scope: record.tenant_scope ?? null,
+        gateway_revision: GATEWAY_REVISION,
+      }),
+    });
+    return res.ok;
+  } catch {
+    return false;
+  }
+}
+
+export interface SetModeResult {
+  ok: boolean;
+  previous: SelfHealingMode | null;
+  new: SelfHealingMode;
+  error?: string;
+}
+
+const MODE_KEY = 'voice_self_healing_mode';
+
+async function readMode(): Promise<SelfHealingMode | null> {
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) return null;
+  try {
+    const res = await fetch(
+      `${SUPABASE_URL}/rest/v1/system_config?key=eq.${MODE_KEY}&select=value&limit=1`,
+      { headers: supabaseHeaders() },
+    );
+    if (!res.ok) return null;
+    const rows = (await res.json()) as Array<{ value?: string }>;
+    const v = rows[0]?.value;
+    if (v === 'off' || v === 'shadow' || v === 'live') return v;
+    return null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Flip system_config.voice_self_healing_mode. Idempotent — setting the
+ * current value is a no-op success. Emits an OASIS event for audit.
+ */
+export async function setMode(
+  next: SelfHealingMode,
+  actorVtid: string,
+): Promise<SetModeResult> {
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
+    return { ok: false, previous: null, new: next, error: 'no_supabase' };
+  }
+  if (next !== 'off' && next !== 'shadow' && next !== 'live') {
+    return { ok: false, previous: null, new: next, error: 'invalid_mode' };
+  }
+
+  const previous = await readMode();
+  if (previous === next) {
+    return { ok: true, previous, new: next };
+  }
+
+  // Upsert into system_config — assume the canonical schema is
+  // system_config(key TEXT PK, value TEXT, updated_at TIMESTAMPTZ).
+  try {
+    const res = await fetch(
+      `${SUPABASE_URL}/rest/v1/system_config?on_conflict=key`,
+      {
+        method: 'POST',
+        headers: {
+          ...supabaseHeaders(),
+          Prefer: 'resolution=merge-duplicates,return=minimal',
+        },
+        body: JSON.stringify({
+          key: MODE_KEY,
+          value: next,
+          updated_at: new Date().toISOString(),
+        }),
+      },
+    );
+    if (!res.ok) {
+      const text = await res.text().catch(() => '');
+      return {
+        ok: false,
+        previous,
+        new: next,
+        error: `upsert_${res.status}_${text.slice(0, 80)}`,
+      };
+    }
+  } catch (err: any) {
+    return { ok: false, previous, new: next, error: `upsert_fetch: ${err?.message ?? ''}` };
+  }
+
+  try {
+    await emitOasisEvent({
+      vtid: actorVtid,
+      type: 'voice.healing.dispatched',
+      source: 'voice-shadow-mode',
+      status: 'info',
+      message: `Voice self-healing mode flipped: ${previous ?? '(unset)'} → ${next}`,
+      payload: {
+        previous_mode: previous,
+        new_mode: next,
+        actor_vtid: actorVtid,
+      },
+    });
+  } catch {
+    /* best-effort */
+  }
+
+  return { ok: true, previous, new: next };
+}

--- a/services/gateway/test/voice-self-healing-adapter.test.ts
+++ b/services/gateway/test/voice-self-healing-adapter.test.ts
@@ -107,6 +107,10 @@ describe('VTID-01959: Voice→SelfHealing Adapter', () => {
   test('mode=live + dedupe hit → dedupe_hit, no POST', async () => {
     mockFetch.mockImplementation((url: string, init?: RequestInit) => {
       if (url.includes('system_config')) return Promise.resolve(jsonResp([{ value: 'live' }]));
+      if (url.includes('voice_healing_shadow_log')) {
+        // Best-effort log; return success
+        return Promise.resolve(jsonResp({}));
+      }
       if (url.includes('voice_healing_quarantine')) {
         // Default: no quarantine row → active (allowed)
         return Promise.resolve(jsonResp([]));
@@ -137,6 +141,10 @@ describe('VTID-01959: Voice→SelfHealing Adapter', () => {
   test('mode=shadow + first-time signature → shadow_logged, no POST', async () => {
     mockFetch.mockImplementation((url: string) => {
       if (url.includes('system_config')) return Promise.resolve(jsonResp([{ value: 'shadow' }]));
+      if (url.includes('voice_healing_shadow_log')) {
+        // Best-effort log; return success
+        return Promise.resolve(jsonResp({}));
+      }
       if (url.includes('voice_healing_quarantine')) {
         // Default: no quarantine row → active (allowed)
         return Promise.resolve(jsonResp([]));
@@ -167,6 +175,10 @@ describe('VTID-01959: Voice→SelfHealing Adapter', () => {
     let capturedPostBody: any = null;
     mockFetch.mockImplementation((url: string, init?: RequestInit) => {
       if (url.includes('system_config')) return Promise.resolve(jsonResp([{ value: 'live' }]));
+      if (url.includes('voice_healing_shadow_log')) {
+        // Best-effort log; return success
+        return Promise.resolve(jsonResp({}));
+      }
       if (url.includes('voice_healing_quarantine')) {
         // Default: no quarantine row → active (allowed)
         return Promise.resolve(jsonResp([]));
@@ -205,6 +217,10 @@ describe('VTID-01959: Voice→SelfHealing Adapter', () => {
   test('mode=live + /report 500 → action=error with detail', async () => {
     mockFetch.mockImplementation((url: string) => {
       if (url.includes('system_config')) return Promise.resolve(jsonResp([{ value: 'live' }]));
+      if (url.includes('voice_healing_shadow_log')) {
+        // Best-effort log; return success
+        return Promise.resolve(jsonResp({}));
+      }
       if (url.includes('voice_healing_quarantine')) {
         // Default: no quarantine row → active (allowed)
         return Promise.resolve(jsonResp([]));
@@ -246,6 +262,10 @@ describe('VTID-01959: Voice→SelfHealing Adapter', () => {
     let capturedDedupeBody: any = null;
     mockFetch.mockImplementation((url: string, init?: RequestInit) => {
       if (url.includes('system_config')) return Promise.resolve(jsonResp([{ value: 'shadow' }]));
+      if (url.includes('voice_healing_shadow_log')) {
+        // Best-effort log; return success
+        return Promise.resolve(jsonResp({}));
+      }
       if (url.includes('voice_healing_quarantine')) {
         // Default: no quarantine row → active (allowed)
         return Promise.resolve(jsonResp([]));

--- a/services/gateway/test/voice-shadow-mode.test.ts
+++ b/services/gateway/test/voice-shadow-mode.test.ts
@@ -1,0 +1,148 @@
+/**
+ * VTID-01964: Voice Shadow Mode Tests
+ *
+ * Verifies appendShadowLog writes to the right table with the right shape,
+ * and setMode handles idempotent flips + invalid input.
+ */
+
+process.env.NODE_ENV = 'test';
+process.env.SUPABASE_URL = 'http://supabase.test';
+process.env.SUPABASE_SERVICE_ROLE = 'test-service-role';
+
+import { appendShadowLog, setMode } from '../src/services/voice-shadow-mode';
+
+const mockFetch = jest.fn();
+global.fetch = mockFetch as any;
+
+function jsonResp(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    json: async () => body,
+    text: async () => JSON.stringify(body),
+  } as unknown as Response;
+}
+
+beforeEach(() => mockFetch.mockReset());
+
+describe('VTID-01964: Voice Shadow Mode — appendShadowLog', () => {
+  test('writes a row to voice_healing_shadow_log with full shape', async () => {
+    let captured: any = null;
+    mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes('voice_healing_shadow_log')) {
+        captured = JSON.parse((init?.body as string) || '{}');
+        return Promise.resolve(jsonResp({}));
+      }
+      throw new Error('unexpected: ' + url);
+    });
+    await appendShadowLog({
+      mode: 'shadow',
+      action: 'sentinel_quarantined',
+      class: 'voice.config_missing',
+      normalized_signature: 'vertex_project_id_empty',
+      detail: 'quarantined',
+      session_id: 'sess-123',
+      tenant_scope: 'global',
+    });
+    expect(captured).toMatchObject({
+      mode: 'shadow',
+      action: 'sentinel_quarantined',
+      class: 'voice.config_missing',
+      normalized_signature: 'vertex_project_id_empty',
+      detail: 'quarantined',
+      session_id: 'sess-123',
+      tenant_scope: 'global',
+    });
+    expect(captured.gateway_revision).toBeTruthy();
+  });
+
+  test('returns false on Supabase error but does not throw', async () => {
+    mockFetch.mockResolvedValue(jsonResp({}, 500));
+    const ok = await appendShadowLog({ mode: 'live', action: 'dispatched' });
+    expect(ok).toBe(false);
+  });
+
+  test('null fields propagate as null (not undefined)', async () => {
+    let captured: any = null;
+    mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes('voice_healing_shadow_log')) {
+        captured = JSON.parse((init?.body as string) || '{}');
+        return Promise.resolve(jsonResp({}));
+      }
+      throw new Error('unexpected: ' + url);
+    });
+    await appendShadowLog({ mode: 'off', action: 'mode_off' });
+    expect(captured.class).toBeNull();
+    expect(captured.normalized_signature).toBeNull();
+    expect(captured.session_id).toBeNull();
+  });
+});
+
+describe('VTID-01964: Voice Shadow Mode — setMode', () => {
+  test('flip off → shadow upserts system_config and emits OASIS event', async () => {
+    let upserted: any = null;
+    let emitted: any = null;
+    mockFetch.mockImplementation((url: string, init?: RequestInit) => {
+      if (url.includes('system_config?key')) {
+        return Promise.resolve(jsonResp([{ value: 'off' }]));
+      }
+      if (url.includes('system_config?on_conflict')) {
+        upserted = JSON.parse((init?.body as string) || '{}');
+        return Promise.resolve(jsonResp({}));
+      }
+      if (url.includes('oasis_events')) {
+        emitted = JSON.parse((init?.body as string) || '{}');
+        return Promise.resolve(jsonResp({ id: 'e' }));
+      }
+      throw new Error('unexpected: ' + url);
+    });
+    const r = await setMode('shadow', 'VTID-01964');
+    expect(r.ok).toBe(true);
+    expect(r.previous).toBe('off');
+    expect(r.new).toBe('shadow');
+    expect(upserted.value).toBe('shadow');
+    // emitOasisEvent maps payload→metadata in the Supabase row body.
+    const md = emitted.metadata ?? emitted.payload ?? {};
+    expect(md.new_mode).toBe('shadow');
+  });
+
+  test('idempotent: flipping to current value is a no-op success', async () => {
+    let upsertCalled = false;
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('system_config?key')) {
+        return Promise.resolve(jsonResp([{ value: 'shadow' }]));
+      }
+      if (url.includes('system_config?on_conflict')) {
+        upsertCalled = true;
+        return Promise.resolve(jsonResp({}));
+      }
+      throw new Error('unexpected: ' + url);
+    });
+    const r = await setMode('shadow', 'VTID-01964');
+    expect(r.ok).toBe(true);
+    expect(r.previous).toBe('shadow');
+    expect(r.new).toBe('shadow');
+    expect(upsertCalled).toBe(false);
+  });
+
+  test('invalid mode → ok=false with invalid_mode', async () => {
+    const r = await setMode('garbage' as any, 'VTID-01964');
+    expect(r.ok).toBe(false);
+    expect(r.error).toBe('invalid_mode');
+  });
+
+  test('upsert error → ok=false with detail', async () => {
+    mockFetch.mockImplementation((url: string) => {
+      if (url.includes('system_config?key')) {
+        return Promise.resolve(jsonResp([{ value: 'off' }]));
+      }
+      if (url.includes('system_config?on_conflict')) {
+        return Promise.resolve(jsonResp({ message: 'permission denied' }, 403));
+      }
+      throw new Error('unexpected: ' + url);
+    });
+    const r = await setMode('live', 'VTID-01964');
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('upsert_403');
+  });
+});

--- a/supabase/migrations/20260426000000_vtid_01964_voice_healing_shadow_log.sql
+++ b/supabase/migrations/20260426000000_vtid_01964_voice_healing_shadow_log.sql
@@ -1,0 +1,66 @@
+-- VTID-01964: Voice Self-Healing Shadow Mode decision log (PR #7)
+--
+-- Append-only log of every adapter decision (regardless of action/outcome).
+-- The Healing dashboard (PR #8) joins this against oasis_events to compute
+-- the would-dispatch vs actual-outcome comparison view that ops uses to
+-- validate Shadow Mode before flipping mode=live.
+--
+-- Plan: .claude/plans/the-biggest-issues-and-fizzy-wozniak.md (PR #7 of 9
+-- in the autonomous ORB voice self-healing loop).
+
+CREATE TABLE IF NOT EXISTS public.voice_healing_shadow_log (
+  id                    UUID         PRIMARY KEY DEFAULT gen_random_uuid(),
+  decided_at            TIMESTAMPTZ  NOT NULL DEFAULT NOW(),
+  mode                  TEXT         NOT NULL,
+  action                TEXT         NOT NULL,
+  class                 TEXT         NULL,
+  normalized_signature  TEXT         NULL,
+  spec_hash             TEXT         NULL,
+  detail                TEXT         NULL,
+  session_id            TEXT         NULL,
+  tenant_scope          TEXT         NULL,
+  gateway_revision      TEXT         NULL
+);
+
+ALTER TABLE public.voice_healing_shadow_log
+  DROP CONSTRAINT IF EXISTS voice_healing_shadow_log_mode_chk;
+
+ALTER TABLE public.voice_healing_shadow_log
+  ADD CONSTRAINT voice_healing_shadow_log_mode_chk
+  CHECK (mode IN ('off', 'shadow', 'live'));
+
+CREATE INDEX IF NOT EXISTS idx_voice_healing_shadow_log_decided_at
+  ON public.voice_healing_shadow_log (decided_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_voice_healing_shadow_log_class_decided_at
+  ON public.voice_healing_shadow_log (class, decided_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_voice_healing_shadow_log_session
+  ON public.voice_healing_shadow_log (session_id, decided_at DESC);
+
+COMMENT ON TABLE public.voice_healing_shadow_log IS
+  'VTID-01964 (PR #7): Voice Self-Healing Shadow Mode decision log. One row per adapter call regardless of action. Used by PR #8 dashboard to compute would-dispatch vs actual-outcome comparison.';
+
+-- 30-day retention is enough for the shadow comparison window. The
+-- aggregate metrics in the dashboard (success rate, time-to-fix, etc.)
+-- are derived counts, not row-level details.
+CREATE OR REPLACE FUNCTION public.voice_healing_shadow_log_prune()
+RETURNS void
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  DELETE FROM public.voice_healing_shadow_log
+   WHERE decided_at < NOW() - INTERVAL '30 days';
+END;
+$$;
+
+DO $$
+BEGIN
+  IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
+    PERFORM cron.schedule(
+      'voice-healing-shadow-log-prune',
+      '30 3 * * *',
+      $cron$SELECT public.voice_healing_shadow_log_prune()$cron$
+    );
+  END IF;
+END $$;


### PR DESCRIPTION
PR #7 of 9 in the autonomous ORB voice self-healing loop.

Shadow Mode runs the full adapter pipeline (classifier + Sentinel + Spec Memory + dedupe) but does NOT POST to /report. Every adapter decision is logged to voice_healing_shadow_log so PR #8's dashboard can compute the would-dispatch vs actual-outcome comparison view that ops needs before flipping mode=live.

Plan: .claude/plans/the-biggest-issues-and-fizzy-wozniak.md

## Changes

- supabase/migrations/20260426000000_vtid_01964_voice_healing_shadow_log.sql (new) — decision log table. **Apply via RUN-MIGRATION.yml after merge.**
- services/voice-shadow-mode.ts (new) — appendShadowLog (best-effort log) + setMode (idempotent flip with audit event).
- services/voice-self-healing-adapter.ts (edited) — public dispatchVoiceFailure now wraps core decision logic to write a shadow log row on exit (skipped for synthetic_skipped).
- routes/voice-lab.ts (edited) — GET /healing/mode + POST /healing/mode endpoints.
- test/voice-shadow-mode.test.ts (new) — 7 tests; total 114 voice unit tests passing.

## Test plan

- [x] TypeScript build passes.
- [x] 114 voice unit tests pass.
- [ ] Post-deploy: GET /healing/mode returns current mode (expected 'off' on first call).
- [ ] Post-deploy: POST /healing/mode { mode: 'shadow', vtid: 'VTID-01964' } flips system_config and emits the audit event. THEN watch for ≥48h before flipping to 'live' in PR #8.

🤖 Generated with [Claude Code](https://claude.com/claude-code)