### PR TITLE
fix(triage-agent): drop invalid after_id query param on event poll (BOOTSTRAP-TRIAGE-STREAM)

### DIFF
--- a/services/gateway/src/routes/triage-agent.ts
+++ b/services/gateway/src/routes/triage-agent.ts
@@ -258,14 +258,19 @@ triageAgentRouter.get('/:sessionId/stream', async (req: Request, res: Response) 
   try {
     // Poll events from the Managed Agents session and forward to the browser.
     // Also handle custom tool calls (query_oasis_events).
+    //
+    // The Anthropic events list endpoint does NOT support an after-cursor
+    // query param — valid params are `limit`, `order`, `page` (per
+    // managed-agents-2026-04-01). We fetch up to the page max each poll and
+    // dedupe by event ID via `seenIds`. A triage session is expected to
+    // produce well under 1000 events, so a single page is sufficient. If we
+    // ever hit the cap, switch to cursor pagination via `page`.
     let done = false;
-    let lastEventId: string | undefined;
     const seenIds = new Set<string>();
 
     while (!done) {
-      // Fetch events
       const eventsResult = await anthropicRequest<any>(
-        `/v1/sessions/${sessionId}/events${lastEventId ? `?after_id=${lastEventId}` : ''}`
+        `/v1/sessions/${sessionId}/events?limit=1000&order=asc`,
       );
 
       if (!eventsResult.ok || !eventsResult.data) {
@@ -278,7 +283,6 @@ triageAgentRouter.get('/:sessionId/stream', async (req: Request, res: Response) 
       for (const event of events) {
         if (seenIds.has(event.id)) continue;
         seenIds.add(event.id);
-        lastEventId = event.id;
 
         // Forward relevant events to the browser
         switch (event.type) {


### PR DESCRIPTION
## Summary

The Voice Triage Agent's SSE proxy was polling the Anthropic Managed Agents events endpoint with `?after_id=<id>`, which is **not a valid query parameter** under `managed-agents-2026-04-01`. The first poll succeeded (no after_id yet); the second poll returned:

```
400 Unknown query parameter 'after_id'. Valid parameters: limit, order, page.
```

The agent itself was working — calling the `query_oasis_events` custom tool and starting to read source files in the mounted repo — but the proxy aborted the stream before any `agent.message` events could reach the browser. The smoke test on `POST /investigate` passed because session creation isn't affected, but the actual streaming was broken end-to-end.

## How it was discovered

Running the agent against a real Voice Lab session (`live-e9249f7b-…`, ai=0 / ao=28 / dur=2.5s) and watching the SSE output. The agent successfully called the custom tool with the right input; the gateway returned the 400 from Anthropic on the next poll cycle.

## Fix

Drop the after-cursor entirely. The Anthropic events list endpoint supports `limit` + `order` + `page` only — it has no after-id semantics. We fetch up to the page maximum each poll and rely on the existing `seenIds: Set<string>` dedupe. A triage session is expected to stay well under 1000 events; if we ever hit the cap, switch to cursor pagination via `page`.

## Test plan

- [x] TypeScript typecheck passes
- [ ] Post-deploy: re-run `POST /api/v1/agents/triage/investigate` against a real session, consume the SSE stream end-to-end, confirm we get `agent.message` events through to a final triage report

## Memory

Updates `project_incident_triage_agent.md`: the shipped feature was present in code but non-functional in production until this fix. End-to-end smoke test now expected to produce a complete report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)