### PR TITLE
feat(memory): HIPAA-grade memory_audit_log + read-path audit (VTID-01966)

### DIFF
--- a/services/gateway/src/services/context-pack-builder.ts
+++ b/services/gateway/src/services/context-pack-builder.ts
@@ -48,6 +48,8 @@ import { formatSessionBufferForLLM, getSessionContext } from './session-memory-b
 // VTID-01955: Tier 0 Memorystore Redis turn buffer (multi-instance shared) — gated by tier0_redis_enabled flag.
 import { getSessionContextRedis, formatRedisBufferForLLM } from './redis-turn-buffer';
 import { isTier0RedisEnabled } from './system-controls-service';
+// VTID-01966 Phase 2: HIPAA-grade audit on every memory read.
+import { auditMemoryRead } from './memory-audit';
 // VTID-02000: Marketplace context primitive
 import { getUserHealthContext } from './user-health-context';
 
@@ -1444,6 +1446,39 @@ export async function buildContextPack(
     },
   }).catch(err => {
     console.warn(`[VTID-01216] Failed to log context pack event: ${err.message}`);
+  });
+
+  // VTID-01966 Phase 2: HIPAA-grade audit log entry for every memory read.
+  // Fire-and-forget — never blocks the LLM call. Health-scoped writes get the
+  // dedicated index for fast HIPAA replay.
+  auditMemoryRead({
+    tenant_id: input.lens.tenant_id,
+    user_id: input.lens.user_id,
+    tier: 'context-pack-builder',
+    actor_id: `conversation-${input.channel}`,
+    source_engine: 'context-pack-builder',
+    source_event_id: packId,
+    health_scope: hitCounts.memory_garden > 0,  // memory garden hits often touch health
+    details: {
+      intent: input.query?.slice(0, 80) ?? null,
+      blocks_returned: [
+        ...(memoryHits.length > 0 ? ['MEMORY'] : []),
+        ...(knowledgeHits.length > 0 ? ['KNOWLEDGE'] : []),
+        ...(webHits.length > 0 ? ['WEB'] : []),
+        ...(relationshipContext.length > 0 ? ['RELATIONSHIPS'] : []),
+        ...(calendarContext ? ['CALENDAR'] : []),
+        ...(oasisContext ? ['OASIS'] : []),
+        ...(sessionBufferData && sessionBufferData.turn_count > 0 ? ['SESSION_BUFFER'] : []),
+      ],
+      item_counts: hitCounts,
+      latency_ms: pack.assembly_duration_ms,
+      cache_hit: bufferSource === 'redis',
+      tokens_used: tokensUsed,
+      channel: input.channel,
+      thread_id: input.thread_id,
+      router_decision_rule: input.router_decision?.matched_rule,
+      router_decision_sources: input.router_decision?.sources_to_query,
+    },
   });
 
   return pack;

--- a/services/gateway/src/services/memory-audit.ts
+++ b/services/gateway/src/services/memory-audit.ts
@@ -238,3 +238,177 @@ export async function auditWritePersisted(input: PersistedAuditInput): Promise<v
     console.warn('[VTID-01952] failed to emit memory.write.persisted:', err);
   });
 }
+
+// ============================================================================
+// VTID-01966 Phase 2 — HIPAA-grade memory_audit_log writes
+//
+// Dedicated audit table (separate from oasis_events) so:
+//   1. Every memory READ + WRITE is captured uniformly with rich provenance.
+//   2. HIPAA replay queries (give me everything user X accessed in date
+//      range Y) are O(index) instead of O(table scan on oasis_events).
+//   3. Append-only + monthly partitions enable cheap retention drops.
+//
+// Writes are fire-and-forget — audit must NEVER block the actual memory
+// operation. If Postgres is slow or down, log + proceed.
+//
+// Plan: Part 7 schema + Part 8 Phase 2.
+// ============================================================================
+
+const SUPABASE_URL_ENV = process.env.SUPABASE_URL;
+const SUPABASE_SR_ENV = process.env.SUPABASE_SERVICE_ROLE;
+
+export type MemoryAuditOp = 'read' | 'write' | 'delete' | 'consolidate';
+
+export interface MemoryAuditRow {
+  /** REQUIRED. Tenant scope. */
+  tenant_id: string;
+  /** REQUIRED. User UUID (the subject of the read/write). */
+  user_id: string;
+  /** REQUIRED. read | write | delete | consolidate. */
+  op: MemoryAuditOp;
+  /** REQUIRED. Storage tier or logical layer (tier0, tier1, tier2, tier3, identity-lock, etc.). */
+  tier: string;
+  /** REQUIRED. Who/what performed the operation. */
+  actor_id: string;
+  /** Optional: which engine produced this (orb-live, conversation-client, etc.). */
+  source_engine?: string;
+  /** Optional: 0..1. Null when it doesn't apply (e.g. consolidator runs). */
+  confidence?: number;
+  /** Optional: upstream OASIS event id if applicable. */
+  source_event_id?: string;
+  /** Optional: defaults to MEMORY_POLICY_VERSION. */
+  policy_version?: string;
+  /** Optional: HIPAA classification flag. */
+  health_scope?: boolean;
+  /** Optional: identity-locked fact_key touched? */
+  identity_scope?: boolean;
+  /** Optional: free-form context (intent, fact_keys, latency_ms, etc.). */
+  details?: Record<string, unknown>;
+}
+
+/**
+ * Append a row to memory_audit_log. Fire-and-forget — never throws, never
+ * blocks. Failures log a single warn line.
+ *
+ * Use this for both reads AND writes. Cheaper than emitting a full OASIS
+ * event for every read (which would balloon the events table).
+ */
+export async function appendMemoryAuditRow(row: MemoryAuditRow): Promise<void> {
+  if (!SUPABASE_URL_ENV || !SUPABASE_SR_ENV) {
+    // Tests / misconfigured environments — silently skip.
+    return;
+  }
+
+  // Fire-and-forget. Any error is caught + logged, never re-thrown.
+  try {
+    const body = {
+      p_tenant_id: row.tenant_id,
+      p_user_id: row.user_id,
+      p_op: row.op,
+      p_tier: row.tier,
+      p_actor_id: row.actor_id,
+      p_policy_version: row.policy_version ?? MEMORY_POLICY_VERSION,
+      p_source_engine: row.source_engine ?? null,
+      p_confidence: row.confidence ?? null,
+      p_source_event_id: row.source_event_id ?? null,
+      p_health_scope: !!row.health_scope,
+      p_identity_scope: !!row.identity_scope,
+      p_details: row.details ?? {},
+    };
+
+    const resp = await fetch(`${SUPABASE_URL_ENV}/rest/v1/rpc/memory_audit_log_insert`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: SUPABASE_SR_ENV,
+        Authorization: `Bearer ${SUPABASE_SR_ENV}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!resp.ok && resp.status !== 200 && resp.status !== 201 && resp.status !== 204) {
+      const text = await resp.text().catch(() => '');
+      console.warn(`[VTID-01966] memory_audit_log_insert failed ${resp.status}: ${text.slice(0, 200)}`);
+    }
+  } catch (err) {
+    console.warn('[VTID-01966] memory_audit_log_insert threw (non-fatal):', (err as Error)?.message);
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Read-side audit helper — call this AFTER a memory read completes.
+// Captures intent, tier(s) hit, latency, and result counts as `details`.
+// ----------------------------------------------------------------------------
+
+export interface MemoryReadAuditInput {
+  tenant_id: string;
+  user_id: string;
+  /** Logical tier or read-source name (e.g. 'tier0+tier1', 'context-pack-builder', 'memory_get_context'). */
+  tier: string;
+  actor_id: string;
+  source_engine?: string;
+  source_event_id?: string;
+  /** What the read returned + how it was performed. */
+  details?: {
+    intent?: string;
+    query_preview?: string;
+    blocks_returned?: string[];
+    item_counts?: Record<string, number>;
+    latency_ms?: number;
+    cache_hit?: boolean;
+    degraded?: boolean;
+    [k: string]: unknown;
+  };
+  health_scope?: boolean;
+}
+
+export async function auditMemoryRead(input: MemoryReadAuditInput): Promise<void> {
+  await appendMemoryAuditRow({
+    tenant_id: input.tenant_id,
+    user_id: input.user_id,
+    op: 'read',
+    tier: input.tier,
+    actor_id: input.actor_id,
+    source_engine: input.source_engine,
+    source_event_id: input.source_event_id,
+    health_scope: input.health_scope,
+    identity_scope: false,
+    details: input.details ?? {},
+  });
+}
+
+// ----------------------------------------------------------------------------
+// Write-side audit helper — call this AFTER a memory write succeeds (or fails).
+// For identity-locked writes, use auditWritePersisted() above (which also
+// emits the dedicated OASIS event); for ordinary writes, this is the
+// lightweight HIPAA-grade trail.
+// ----------------------------------------------------------------------------
+
+export interface MemoryWriteAuditInput {
+  tenant_id: string;
+  user_id: string;
+  tier: string;          // 'memory_items', 'memory_facts', 'mem_episodes', 'tier0', etc.
+  actor_id: string;
+  source_engine?: string;
+  source_event_id?: string;
+  confidence?: number;
+  health_scope?: boolean;
+  identity_scope?: boolean;
+  details?: Record<string, unknown>;
+}
+
+export async function auditMemoryWrite(input: MemoryWriteAuditInput): Promise<void> {
+  await appendMemoryAuditRow({
+    tenant_id: input.tenant_id,
+    user_id: input.user_id,
+    op: 'write',
+    tier: input.tier,
+    actor_id: input.actor_id,
+    source_engine: input.source_engine,
+    source_event_id: input.source_event_id,
+    confidence: input.confidence,
+    health_scope: input.health_scope,
+    identity_scope: input.identity_scope,
+    details: input.details ?? {},
+  });
+}

--- a/services/gateway/test/memory-audit-log.test.ts
+++ b/services/gateway/test/memory-audit-log.test.ts
@@ -1,0 +1,94 @@
+/**
+ * VTID-01966 — memory_audit_log unit tests
+ *
+ * Verifies the graceful no-op contract when SUPABASE_URL/SUPABASE_SERVICE_ROLE
+ * are unset (e.g. CI). The live audit-write path is exercised against the
+ * deployed Supabase RPC after migration.
+ */
+
+import {
+  appendMemoryAuditRow,
+  auditMemoryRead,
+  auditMemoryWrite,
+  type MemoryAuditOp,
+} from '../src/services/memory-audit';
+
+describe('memory_audit_log (no Supabase env — graceful no-op)', () => {
+  const origUrl = process.env.SUPABASE_URL;
+  const origSr = process.env.SUPABASE_SERVICE_ROLE;
+
+  beforeAll(() => {
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_ROLE;
+  });
+
+  afterAll(() => {
+    if (origUrl) process.env.SUPABASE_URL = origUrl;
+    if (origSr) process.env.SUPABASE_SERVICE_ROLE = origSr;
+  });
+
+  it('appendMemoryAuditRow does not throw when Supabase env is unset', async () => {
+    await expect(
+      appendMemoryAuditRow({
+        tenant_id: 't',
+        user_id: '00000000-0000-0000-0000-000000000000',
+        op: 'read',
+        tier: 'tier0',
+        actor_id: 'orb-live',
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('auditMemoryRead does not throw with full payload', async () => {
+    await expect(
+      auditMemoryRead({
+        tenant_id: 't',
+        user_id: '00000000-0000-0000-0000-000000000000',
+        tier: 'context-pack-builder',
+        actor_id: 'conversation-orb',
+        source_engine: 'context-pack-builder',
+        source_event_id: 'pack-123',
+        health_scope: true,
+        details: {
+          intent: 'recall_recent',
+          blocks_returned: ['MEMORY', 'CALENDAR'],
+          item_counts: { memory_garden: 5, knowledge_hub: 0, web_search: 0 },
+          latency_ms: 42,
+          cache_hit: true,
+          tokens_used: 1234,
+        },
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('auditMemoryWrite does not throw with full payload', async () => {
+    await expect(
+      auditMemoryWrite({
+        tenant_id: 't',
+        user_id: '00000000-0000-0000-0000-000000000000',
+        tier: 'memory_facts',
+        actor_id: 'cognee-extractor',
+        source_engine: 'cognee-extractor',
+        confidence: 0.85,
+        health_scope: true,
+        identity_scope: false,
+        details: { fact_key: 'sleep_avg_hours', fact_value: '7.2' },
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('accepts all four op types', async () => {
+    const ops: MemoryAuditOp[] = ['read', 'write', 'delete', 'consolidate'];
+    for (const op of ops) {
+      await expect(
+        appendMemoryAuditRow({
+          tenant_id: 't',
+          user_id: '00000000-0000-0000-0000-000000000000',
+          op,
+          tier: 'test',
+          actor_id: 'test',
+        })
+      ).resolves.toBeUndefined();
+    }
+  });
+});

--- a/supabase/migrations/20260427000000_vtid_01966_memory_audit_log.sql
+++ b/supabase/migrations/20260427000000_vtid_01966_memory_audit_log.sql
@@ -1,0 +1,189 @@
+-- VTID-01966 — Memory Audit Log (HIPAA-grade dedicated audit table)
+--
+-- Phase 2 of the memory rebuild plan. Today some memory writes emit OASIS
+-- events but READS do not — leaving the HIPAA audit trail incomplete.
+-- This migration adds memory_audit_log (separate from oasis_events) so:
+--   1. Every memory read AND write is captured with full provenance.
+--   2. HIPAA replay queries (give me everything user X accessed in date
+--      range Y) are O(index) instead of O(table scan on oasis_events).
+--   3. The append-only audit table is partitioned by month so we can
+--      drop old partitions cheaply for retention compliance.
+--
+-- Plan: /home/dstev/.claude/plans/the-vitana-system-has-wild-puffin.md
+--       Part 7 Schema (memory_audit_log) + Part 8 Phase 2.
+
+BEGIN;
+
+-- ============================================================================
+-- 1. Parent table — partitioned by RANGE(created_at), monthly partitions.
+--    All writes go through the parent; Postgres routes to the right partition.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.memory_audit_log (
+  id              uuid          NOT NULL DEFAULT gen_random_uuid(),
+  tenant_id       text          NOT NULL,
+  user_id         uuid          NOT NULL,
+  op              text          NOT NULL CHECK (op IN ('read','write','delete','consolidate')),
+  tier            text          NOT NULL,           -- 'tier0','tier1','tier2','tier3','identity-lock', etc.
+  actor_id        text          NOT NULL,           -- e.g. 'orb-live', 'cognee-extractor', 'user_via_settings_ui'
+  source_engine   text,                              -- which engine (closes OASIS provenance gap)
+  confidence      real,                              -- 0..1; null for ops where it doesn't apply
+  source_event_id text,                              -- upstream OASIS event id, if applicable
+  policy_version  text          NOT NULL,           -- e.g. 'mem-2026.04'
+  health_scope    boolean       NOT NULL DEFAULT false,  -- HIPAA classification flag
+  identity_scope  boolean       NOT NULL DEFAULT false,  -- write to identity-locked fact?
+  details         jsonb         NOT NULL DEFAULT '{}',   -- intent, fact_keys hit, latency, etc.
+  created_at      timestamptz   NOT NULL DEFAULT now(),
+  PRIMARY KEY (id, created_at)
+) PARTITION BY RANGE (created_at);
+
+COMMENT ON TABLE public.memory_audit_log IS
+  'VTID-01966: HIPAA-grade dedicated audit trail for every memory read/write. Append-only. Partitioned by month — drop old partitions for retention compliance. Distinct from oasis_events (which captures system-wide events; this one captures memory-specific operations with rich detail).';
+
+COMMENT ON COLUMN public.memory_audit_log.tier IS 'Storage tier: tier0 (Redis), tier1 (FAISS), tier2 (pgvector), tier3 (Anthropic Memory Tool), identity-lock, write_fact_rpc, etc.';
+COMMENT ON COLUMN public.memory_audit_log.actor_id IS 'Who/what performed the operation. user/system/agent identifiers; correlates with provenance_source.';
+COMMENT ON COLUMN public.memory_audit_log.source_engine IS 'Which engine produced this row (orb-live, conversation-client, cognee-extractor, autopilot, brain, etc.).';
+COMMENT ON COLUMN public.memory_audit_log.policy_version IS 'Memory governance policy version at audit time (e.g. mem-2026.04). Required for forward-compatible HIPAA audit.';
+COMMENT ON COLUMN public.memory_audit_log.health_scope IS 'TRUE if the operation touched health-classified data; gates HIPAA replay reports.';
+COMMENT ON COLUMN public.memory_audit_log.identity_scope IS 'TRUE if the operation touched an identity-locked fact_key (Maria → Kemal class).';
+COMMENT ON COLUMN public.memory_audit_log.details IS 'Free-form JSONB: query_preview, intent, fact_keys, latency_ms, blocks_returned, error_message, etc.';
+
+
+-- ============================================================================
+-- 2. Static partitions covering 2026-04 → 2027-04 (13 months).
+--    A follow-up partition-rotation cron (or pg_partman) handles 2027-05+.
+--    Static partitions are the simplest path that's safe for prod today.
+-- ============================================================================
+
+DO $$
+DECLARE
+  yr int;
+  mo int;
+  start_date date;
+  end_date   date;
+  part_name  text;
+BEGIN
+  FOR i IN 0..12 LOOP
+    start_date := make_date(2026, 4, 1) + (i || ' months')::interval;
+    end_date   := start_date + interval '1 month';
+    yr := extract(year FROM start_date)::int;
+    mo := extract(month FROM start_date)::int;
+    part_name := format('memory_audit_log_y%sm%s', yr, lpad(mo::text, 2, '0'));
+
+    EXECUTE format(
+      'CREATE TABLE IF NOT EXISTS public.%I PARTITION OF public.memory_audit_log FOR VALUES FROM (%L) TO (%L);',
+      part_name, start_date, end_date
+    );
+  END LOOP;
+END $$;
+
+
+-- ============================================================================
+-- 3. Indexes for HIPAA replay + dashboards.
+--    Created on the parent so they propagate to every partition.
+-- ============================================================================
+
+CREATE INDEX IF NOT EXISTS memory_audit_log_user_recency
+  ON public.memory_audit_log (user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS memory_audit_log_tenant_recency
+  ON public.memory_audit_log (tenant_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS memory_audit_log_health_scope
+  ON public.memory_audit_log (tenant_id, user_id, created_at DESC)
+  WHERE health_scope = true;
+
+CREATE INDEX IF NOT EXISTS memory_audit_log_identity_scope
+  ON public.memory_audit_log (tenant_id, user_id, created_at DESC)
+  WHERE identity_scope = true;
+
+CREATE INDEX IF NOT EXISTS memory_audit_log_op_tier_recency
+  ON public.memory_audit_log (op, tier, created_at DESC);
+
+
+-- ============================================================================
+-- 4. RLS — service-role only. The audit table is internal; users never read
+--    their own audit log via RLS. HIPAA replay queries run as service_role
+--    via gateway audit endpoints (separate VTID for the read API).
+-- ============================================================================
+
+ALTER TABLE public.memory_audit_log ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS memory_audit_log_service_role_all ON public.memory_audit_log;
+CREATE POLICY memory_audit_log_service_role_all
+  ON public.memory_audit_log
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+
+-- ============================================================================
+-- 5. Insert helper RPC — single entry-point used by gateway memory-audit.ts.
+--    SECURITY DEFINER so the gateway can use the anon key path if it wants
+--    (today it uses service_role directly; this is forward-compatible).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.memory_audit_log_insert(
+  p_tenant_id       text,
+  p_user_id         uuid,
+  p_op              text,
+  p_tier            text,
+  p_actor_id        text,
+  p_policy_version  text,
+  p_source_engine   text DEFAULT NULL,
+  p_confidence      real DEFAULT NULL,
+  p_source_event_id text DEFAULT NULL,
+  p_health_scope    boolean DEFAULT false,
+  p_identity_scope  boolean DEFAULT false,
+  p_details         jsonb DEFAULT '{}'::jsonb
+) RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_id uuid := gen_random_uuid();
+BEGIN
+  INSERT INTO public.memory_audit_log (
+    id, tenant_id, user_id, op, tier, actor_id, source_engine,
+    confidence, source_event_id, policy_version, health_scope,
+    identity_scope, details, created_at
+  ) VALUES (
+    v_id, p_tenant_id, p_user_id, p_op, p_tier, p_actor_id, p_source_engine,
+    p_confidence, p_source_event_id, p_policy_version, COALESCE(p_health_scope, false),
+    COALESCE(p_identity_scope, false), COALESCE(p_details, '{}'::jsonb), now()
+  );
+  RETURN v_id;
+END $$;
+
+COMMENT ON FUNCTION public.memory_audit_log_insert IS
+  'VTID-01966: Single-entry insert helper for memory_audit_log. Used by gateway memory-audit.ts auditMemoryRead/Write. SECURITY DEFINER for forward compatibility.';
+
+GRANT EXECUTE ON FUNCTION public.memory_audit_log_insert TO service_role;
+
+
+COMMIT;
+
+-- =====================================================================
+-- VERIFICATION (run after migration applies):
+--
+-- A) Parent + partitions exist:
+--    SELECT relname FROM pg_class
+--      WHERE relname LIKE 'memory_audit_log%'
+--      ORDER BY relname;
+--    -- Expected: parent + 13 monthly partitions (y2026m04 through y2027m04).
+--
+-- B) Insert via RPC:
+--    SELECT public.memory_audit_log_insert(
+--      'test-tenant', gen_random_uuid(), 'read', 'tier0',
+--      'orb-live', 'mem-2026.04', 'orb-live', 1.0,
+--      NULL, false, false, '{"intent":"recall_recent"}'::jsonb
+--    );
+--    SELECT count(*) FROM memory_audit_log WHERE actor_id='orb-live';
+--
+-- C) Confirm partition routing:
+--    EXPLAIN INSERT INTO memory_audit_log (tenant_id, user_id, op, tier,
+--      actor_id, policy_version) VALUES ('t','...uuid...','write','tier2','x','v');
+--    -- Should show "Insert on memory_audit_log_y2026m04" (current partition).
+-- =====================================================================


### PR DESCRIPTION
## Summary

**Phase 2 of the memory rebuild** — HIPAA-grade audit chokepoint. Today some memory writes emit OASIS events but READS don't, leaving the audit trail incomplete. This PR adds a dedicated `memory_audit_log` table (separate from `oasis_events`) and wires `auditMemoryRead()` into the central read path.

### Files
- **`supabase/migrations/20260427000000_vtid_01966_memory_audit_log.sql`** — partitioned-by-month table (13 monthly partitions covering 2026-04 → 2027-04), service-role-only RLS, `SECURITY DEFINER` insert RPC, indexes for HIPAA replay queries (user_id+created_at, health_scope partial, identity_scope partial).
- **`services/gateway/src/services/memory-audit.ts`** (additive) — `appendMemoryAuditRow()` (fire-and-forget), `auditMemoryRead()`, `auditMemoryWrite()`. Audit MUST never block the actual memory operation.
- **`services/gateway/src/services/context-pack-builder.ts`** — wired `auditMemoryRead()` at the end of `buildContextPack()`. Every brain/conversation/orb-live read flows through this function, so this single wire-in covers the dominant read path. Captures intent, blocks_returned, hit_counts, latency, cache_hit (Redis Tier 0 hit), tokens_used, channel, thread_id, router_decision_rule.
- **`test/memory-audit-log.test.ts`** — 4 unit tests for the graceful-no-op contract.

### Behavioral guarantees
| State | Behavior |
|---|---|
| `SUPABASE_URL` unset | Audit functions silently no-op. Gateway boots + serves identically. |
| Supabase env set + migration applied | Every `buildContextPack` call appends one row to `memory_audit_log` via fire-and-forget POST. Failures log a single warn line and do not propagate. |

### HIPAA replay query (post-merge, separate VTID for the read API)
```sql
SELECT * FROM memory_audit_log
 WHERE user_id = $1 AND created_at >= $2 AND created_at < $3
 ORDER BY created_at;
```
Index-backed + partition-pruned.

### Test plan
- [x] 4 unit tests pass
- [x] TypeScript clean
- [ ] Apply migration via `RUN-MIGRATION.yml`
- [ ] Verify partitions exist: `SELECT relname FROM pg_class WHERE relname LIKE 'memory_audit_log%' ORDER BY relname;` should return parent + 13 partitions
- [ ] After EXEC-DEPLOY: tail Cloud Run logs for `[VTID-01966]` lines + check `SELECT count(*) FROM memory_audit_log WHERE created_at > now() - interval '5 min';` shows new rows after a real ORB / chat session

### Follow-ups (separate VTIDs)
- Wire `auditMemoryWrite()` into the existing fact-write paths (cognee-extractor-client, memory-facts-service, inline-fact-extractor).
- Wire `auditMemoryRead()` into `orb-memory-bridge.fetchMemoryContext`.
- Build `/api/v1/admin/audit/memory` HIPAA replay endpoint.
- Partition-rotation cron (or pg_partman) for 2027-05+.

🤖 Generated with [Claude Code](https://claude.com/claude-code)