### PR TITLE
fix(triage-agent): custom_tool_use field is .name not .tool_name (BOOTSTRAP-TRIAGE-DISPATCH)

### DIFF
--- a/services/gateway/src/routes/triage-agent.ts
+++ b/services/gateway/src/routes/triage-agent.ts
@@ -311,14 +311,22 @@ triageAgentRouter.get('/:sessionId/stream', async (req: Request, res: Response) 
             break;
 
           case 'agent.custom_tool_use': {
-            // Handle query_oasis_events — execute with our Supabase creds
+            // The Anthropic event uses `name` (not `tool_name`); fall back to
+            // `tool_name` defensively in case a future API rev renames it.
+            const toolName: string | undefined = event.name || event.tool_name;
+
+            // Handle query_oasis_events — execute with our Supabase creds.
+            // Forward to the browser AND keep the legacy `tool_name` key in
+            // the SSE payload for backwards compat with the existing UI;
+            // also expose `name` so future UI code can match the API field.
             sendSSE('agent.custom_tool_use', {
               id: event.id,
-              tool_name: event.tool_name,
+              name: toolName,
+              tool_name: toolName,
               input: event.input,
             });
 
-            if (event.tool_name === 'query_oasis_events') {
+            if (toolName === 'query_oasis_events') {
               const oasisResult = await queryOasisEvents(
                 event.input?.session_id || '',
                 event.input?.limit || 100


### PR DESCRIPTION
## Summary

Second bug in the Voice Triage SSE proxy. After [#930](https://github.com/exafyltd/vitana-platform/pull/930) (the `after_id` fix) landed and deployed, the next end-to-end attempt got past the events-list 400 — but the Anthropic session got stuck in `stop_reason=requires_action` forever. The agent fired the custom tool, the gateway saw the event, but the dispatch branch never ran.

The raw event:
```json
{
  "type": "agent.custom_tool_use",
  "name": "query_oasis_events",        // field is `name`
  "id": "sevt_01577dCgfPXUR7Dhi7iJdaAQ",
  "input": { "session_id": "live-..." }
}
```

The route was checking `event.tool_name === 'query_oasis_events'` — always `undefined`, always false → no `user.custom_tool_result` event ever sent back → session deadlocked waiting on us.

## Fix

Read `event.name` (with `tool_name` as defensive fallback in case a future API rev adds it). Forward both keys to the browser SSE payload so the existing UI code reading `tool_name` keeps working AND future code can match the canonical API field directly.

## How it was discovered

Re-running the triage agent end-to-end against the same `live-e9249f7b-...` Voice Lab session post-#930 and inspecting the deadlocked session via `GET /v1/sessions/{id}/events`.

## Pattern note

Two consecutive bugs in this proxy strongly suggest the original smoke test was POST-only (session creation works fine without ever round-tripping a custom tool). Worth adding a minimal integration test that drives at least one full custom-tool round-trip — out of scope for this hotfix.

## Test plan

- [x] TypeScript typecheck passes
- [ ] Post-deploy: re-run the same investigation, expect the agent to receive the OASIS event tool result and produce a complete triage report

🤖 Generated with [Claude Code](https://claude.com/claude-code)