### PR TITLE
feat(vitana-id): Release B gateway — voice messaging + canonical-ID dual-write (VTID-01967)

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -267,6 +267,10 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const notificationsRouter = require('./routes/notifications').default;
   // Chat — User-to-user direct messaging
   const chatRouter = require('./routes/chat').default;
+  // VTID-01967: Vitana ID — voice resolver, admin lookup, onboarding pick
+  const usersResolveRouter = require('./routes/users-resolve').default;
+  const adminUsersLookupRouter = require('./routes/admin-users-lookup').default;
+  const usersVitanaIdRouter = require('./routes/users-vitana-id').default;
   // Admin: Signup Funnel Tracking & Outreach
   const adminSignupsRouter = require('./routes/admin-signups').default;
   // Admin: Notification Compose & Tracking
@@ -740,6 +744,13 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
 
   // Chat — User-to-user direct messaging
   mountRouterSync(app, '/api/v1/chat', chatRouter, { owner: 'chat' });
+
+  // VTID-01967: Vitana ID resolver + onboarding pick + admin lookup.
+  // Mounted under /api/v1/users so /resolve and /me/vitana-id/* are siblings;
+  // admin lookup is at /api/v1/admin (gated by exafy_admin role).
+  mountRouterSync(app, '/api/v1/users', usersResolveRouter, { owner: 'users-resolve' });
+  mountRouterSync(app, '/api/v1/users', usersVitanaIdRouter, { owner: 'users-vitana-id' });
+  mountRouterSync(app, '/api/v1/admin', adminUsersLookupRouter, { owner: 'admin-users-lookup' });
 
   // Admin: Signup Funnel Tracking & Outreach
   mountRouterSync(app, '/api/v1/admin/signups', adminSignupsRouter, { owner: 'admin-signups' });

--- a/services/gateway/src/middleware/auth-supabase-jwt.ts
+++ b/services/gateway/src/middleware/auth-supabase-jwt.ts
@@ -30,6 +30,63 @@ export interface SupabaseIdentity {
   aud: string | null;       // Audience claim
   exp: number | null;       // Expiration timestamp
   iat: number | null;       // Issued at timestamp
+  // VTID-01967: Canonical Vitana ID — attached after JWT verify via cached
+  // lookup against app_users (mirrored from profiles by Release A trigger).
+  // Null-tolerant: undefined if the lookup hasn't run yet or the user has no
+  // app_users row yet. Callers must never block on this.
+  vitana_id?: string | null;
+}
+
+// VTID-01967: In-process cache for vitana_id lookup. Keyed by user_id, 5min TTL.
+// Avoids hammering app_users on every authenticated request. Cleared lazily
+// when entries are read after expiration.
+const VITANA_ID_CACHE_TTL_MS = 5 * 60 * 1000;
+const vitanaIdCache = new Map<string, { vitana_id: string | null; expires_at: number }>();
+
+/**
+ * VTID-01967: Resolve vitana_id for a user, with in-process caching.
+ * Returns null if not found / not yet mirrored — callers must be null-tolerant.
+ * Public so callers (oasis-event-service, voice-message-guard) can resolve
+ * the ID for a user_id outside the request lifecycle.
+ */
+export async function resolveVitanaId(userId: string): Promise<string | null> {
+  if (!userId) return null;
+
+  const cached = vitanaIdCache.get(userId);
+  if (cached && cached.expires_at > Date.now()) {
+    return cached.vitana_id;
+  }
+
+  try {
+    const supabase = getSupabase();
+    if (!supabase) return null;
+
+    const { data } = await supabase
+      .from('app_users')
+      .select('vitana_id')
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    const vitanaId = (data && (data as any).vitana_id) || null;
+    vitanaIdCache.set(userId, {
+      vitana_id: vitanaId,
+      expires_at: Date.now() + VITANA_ID_CACHE_TTL_MS,
+    });
+    return vitanaId;
+  } catch {
+    // Null-tolerant: never block auth on this lookup. If the column doesn't
+    // exist yet (Release A migrations not applied), the catch swallows.
+    return null;
+  }
+}
+
+/**
+ * VTID-01967: Invalidate cached vitana_id for a user. Call this from the
+ * /vitana-id/confirm endpoint after the user picks a different ID, so the
+ * next authenticated request reads the new value.
+ */
+export function invalidateVitanaIdCache(userId: string): void {
+  vitanaIdCache.delete(userId);
 }
 
 /**
@@ -175,6 +232,10 @@ export async function requireAuth(
     upsertActiveDay(result.identity.user_id).catch(() => {});
   }
 
+  // VTID-01967: Resolve vitana_id (cached, null-tolerant). Downstream code
+  // reads req.identity.vitana_id directly; on cache hit this is ~0ms.
+  req.identity.vitana_id = await resolveVitanaId(result.identity.user_id);
+
   next();
 }
 
@@ -198,6 +259,8 @@ export async function optionalAuth(
       if (result.identity.user_id) {
         upsertActiveDay(result.identity.user_id).catch(() => {});
       }
+      // VTID-01967: vitana_id resolution
+      req.identity.vitana_id = await resolveVitanaId(result.identity.user_id);
     }
   }
 
@@ -338,6 +401,9 @@ export async function requireAuthWithTenant(
     upsertActiveDay(result.identity.user_id).catch(() => {});
   }
 
+  // VTID-01967: vitana_id resolution
+  req.identity.vitana_id = await resolveVitanaId(result.identity.user_id);
+
   // If tenant_id missing from JWT, resolve from user_tenants table
   if (!req.identity.tenant_id) {
     const supabase = getSupabase();
@@ -420,6 +486,9 @@ export async function requireAdminAuth(
   if (result.identity.user_id) {
     upsertActiveDay(result.identity.user_id).catch(() => {});
   }
+
+  // VTID-01967: vitana_id resolution
+  req.identity.vitana_id = await resolveVitanaId(result.identity.user_id);
 
   // Then, require exafy_admin
   if (!req.identity.exafy_admin) {

--- a/services/gateway/src/routes/admin-users-lookup.ts
+++ b/services/gateway/src/routes/admin-users-lookup.ts
@@ -1,0 +1,61 @@
+/**
+ * VTID-01967: GET /api/v1/admin/users/lookup
+ *
+ * Admin support tooling — global (cross-tenant) Vitana ID lookup. Voice
+ * Lab, OASIS event panels, and Command Hub user-detail screens use this
+ * to jump from "@alex3700" to a user's full profile + tenant + recent
+ * activity without joining DBs by hand.
+ *
+ * Query: ?token=<vitana_id_or_handle_or_name>&limit=<n>
+ * Auth:  exafy_admin = true (gateway role check; SQL function trusts the
+ *        p_global flag forwarded from this route).
+ */
+
+import { Router, Request, Response } from 'express';
+import {
+  requireAdminAuth,
+  AuthenticatedRequest,
+} from '../middleware/auth-supabase-jwt';
+import { createClient } from '@supabase/supabase-js';
+
+const router = Router();
+
+function getSupabase() {
+  return createClient(
+    process.env.SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE!
+  );
+}
+
+router.get('/users/lookup', requireAdminAuth, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const token = (req.query.token as string | undefined)?.trim();
+  const limitParam = req.query.limit;
+  if (!token) {
+    return res.status(400).json({ ok: false, error: 'token query parameter is required' });
+  }
+
+  const limitInt = Math.min(Math.max(Number(limitParam) || 10, 1), 50);
+
+  const supabase = getSupabase();
+  const { data, error } = await supabase.rpc('resolve_recipient_candidates', {
+    p_actor: identity.user_id,
+    p_token: token,
+    p_limit: limitInt,
+    p_global: true, // admin-only: cross-tenant search
+  });
+
+  if (error) {
+    console.error('[VTID-01967] admin/users/lookup RPC error:', error);
+    return res.status(500).json({ ok: false, error: error.message });
+  }
+
+  return res.json({
+    ok: true,
+    candidates: data || [],
+  });
+});
+
+export default router;

--- a/services/gateway/src/routes/auth.ts
+++ b/services/gateway/src/routes/auth.ts
@@ -431,16 +431,24 @@ router.get('/me', requireAuth, async (req: AuthenticatedRequest, res: Response) 
   );
 
   // VTID-01186: Fetch profile and memberships from database
-  let profile: { display_name?: string; avatar_url?: string; bio?: string } = {};
+  // VTID-01967: also expose vitana_id (from app_users mirror) and vitana_id_locked (from profiles).
+  let profile: {
+    display_name?: string;
+    avatar_url?: string;
+    bio?: string;
+    vitana_id?: string;
+    vitana_id_locked?: boolean;
+  } = {};
   let memberships: Array<{ tenant_id: string; role: string; is_primary: boolean }> = [];
 
   const supabase = getSupabase();
   if (supabase && identity.user_id) {
     try {
-      // Fetch user profile from app_users
+      // Fetch user profile from app_users — vitana_id is mirrored here by the
+      // Release A trigger profiles_vitana_id_mirror_trigger.
       const { data: profileData, error: profileError } = await supabase
         .from('app_users')
-        .select('display_name, avatar_url, bio')
+        .select('display_name, avatar_url, bio, vitana_id')
         .eq('user_id', identity.user_id)
         .single();
 
@@ -449,7 +457,28 @@ router.get('/me', requireAuth, async (req: AuthenticatedRequest, res: Response) 
           display_name: profileData.display_name || undefined,
           avatar_url: profileData.avatar_url || undefined,
           bio: profileData.bio || undefined,
+          vitana_id: (profileData as any).vitana_id || undefined,
         };
+      }
+
+      // VTID-01967: vitana_id_locked lives only on profiles (not mirrored).
+      // Parallel fetch — null-tolerant (column may not exist before Release A).
+      try {
+        const { data: lockData } = await supabase
+          .from('profiles')
+          .select('vitana_id_locked, vitana_id')
+          .eq('user_id', identity.user_id)
+          .maybeSingle();
+        if (lockData) {
+          profile.vitana_id_locked = (lockData as any).vitana_id_locked === true;
+          // Profiles is the source of truth; if app_users mirror is stale (or
+          // not yet provisioned), prefer profiles.vitana_id.
+          if (!profile.vitana_id && (lockData as any).vitana_id) {
+            profile.vitana_id = (lockData as any).vitana_id;
+          }
+        }
+      } catch (_lockErr) {
+        // Silent — profiles.vitana_id_locked may not exist on this env yet.
       }
 
       // VTID-01230-FIX: Match /auth/login fallback chain for avatar_url.

--- a/services/gateway/src/routes/chat.ts
+++ b/services/gateway/src/routes/chat.ts
@@ -13,6 +13,7 @@ import { Router, Request, Response } from 'express';
 import {
   requireAuth,
   requireTenant,
+  resolveVitanaId,
   AuthenticatedRequest,
 } from '../middleware/auth-supabase-jwt';
 import { createClient } from '@supabase/supabase-js';
@@ -48,6 +49,17 @@ router.post('/send', requireAuth, requireTenant, async (req: Request, res: Respo
   }
 
   const supabase = getSupabase();
+
+  // VTID-01967: denormalize sender + receiver vitana_id at insert time so
+  // support engineers and voice tooling can quote @<id> without joining
+  // profiles. Both lookups are cached. Null-tolerant: if either user has
+  // no vitana_id (pre-Release-A signup, or app_users not yet provisioned),
+  // the column stays NULL and downstream code falls back to display_name.
+  const [sender_vitana_id, receiver_vitana_id] = await Promise.all([
+    identity.vitana_id ? Promise.resolve(identity.vitana_id) : resolveVitanaId(identity.user_id),
+    resolveVitanaId(receiver_id),
+  ]);
+
   const { data, error } = await supabase
     .from('chat_messages')
     .insert({
@@ -55,6 +67,8 @@ router.post('/send', requireAuth, requireTenant, async (req: Request, res: Respo
       sender_id: identity.user_id,
       receiver_id,
       content: content.trim(),
+      ...(sender_vitana_id && { sender_vitana_id }),
+      ...(receiver_vitana_id && { receiver_vitana_id }),
     })
     .select()
     .single();

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -2109,6 +2109,136 @@ function buildLiveApiTools(mode: 'anonymous' | 'authenticated' = 'authenticated'
             required: ['topic'],
           },
         },
+        // ─── VTID-01967 — Vitana ID voice messaging ───
+        // Three tools that let the user say "send a message to alex3700"
+        // or "share this link with maria2307" and have ORB resolve the
+        // recipient, confirm verbally, and send. These tools enforce a
+        // strict confirmation contract: ALWAYS resolve first, ALWAYS
+        // read back, ONLY send on explicit verbal confirmation.
+        {
+          name: 'resolve_recipient',
+          description: [
+            'Resolve a spoken recipient name or Vitana ID to a real user.',
+            'Call this FIRST any time the user says "send a message to X",',
+            '"text X", "share this with X", "tell X that ...", "invite X",',
+            'or any other phrase where X is meant to be another Vitana user.',
+            '',
+            'Returns ranked candidates. Each has:',
+            '  - user_id (opaque UUID — pass to send_chat_message / share_link)',
+            '  - vitana_id (speakable, e.g. "alex3700" — read this to the user)',
+            '  - display_name (their full name)',
+            '  - score (0.00-1.10; 1.0 = exact vitana_id match)',
+            '  - reason ("vitana_id_exact" | "legacy_handle" | "fuzzy_name")',
+            '',
+            'Also returns top_confidence and ambiguous (boolean).',
+            '',
+            'BEHAVIOR:',
+            '  1. If candidates is empty: tell the user you couldn\'t find',
+            '     anyone matching that name and ask them to repeat or spell',
+            '     the Vitana ID.',
+            '  2. If ambiguous=false AND top_confidence >= 0.85 AND only ONE',
+            '     candidate: silently pick candidates[0] and proceed to step 4.',
+            '  3. If ambiguous=true OR multiple candidates: read up to 3',
+            '     options to the user — "I see {N} matches: @<vid1>',
+            '     ({display_name1}), @<vid2> ({display_name2}). Which one?"',
+            '     Wait for them to pick by Vitana ID, by name, or by',
+            '     position ("the first one", "Daniela Müller").',
+            '  4. After a recipient is chosen, NEVER call send_chat_message',
+            '     or share_link directly — first read the message back to',
+            '     the user verbatim and ask "say send to confirm or cancel',
+            '     to stop". Only on explicit confirmation, call the send',
+            '     tool.',
+            '',
+            'NEVER resolve to the user\'s own ID — the resolver excludes self.',
+            'NEVER skip this step before sending; the send tools assume a',
+            'pre-resolved user_id from this call.',
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              spoken_name: {
+                type: 'string',
+                description: 'The recipient name / Vitana ID exactly as the user said it. Examples: "Daniela", "alex3700", "@alex3700", "Branislav". Strip leading @ if present (the resolver normalizes).',
+              },
+              limit: {
+                type: 'integer',
+                description: 'Maximum candidates to return (default 5). Keep low for voice — 3 is plenty.',
+              },
+            },
+            required: ['spoken_name'],
+          },
+        },
+        {
+          name: 'send_chat_message',
+          description: [
+            'Send a direct message to another Vitana user. ONLY call this',
+            'after resolve_recipient has returned a candidate AND the user',
+            'has verbally confirmed both the recipient AND the message body',
+            '(e.g. "yes send it", "send", "confirm", "ja schick es").',
+            '',
+            'NEVER call this without resolve_recipient first.',
+            'NEVER auto-fire on "I want to message X" — always read back and wait.',
+            '',
+            'After a successful send, acknowledge briefly: "Sent to @<vid>."',
+            'If the response says rate_limited, tell the user: "I can\'t send',
+            'any more messages this session — please open the app to continue."',
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              recipient_user_id: {
+                type: 'string',
+                description: 'Opaque user_id from resolve_recipient candidates[i].user_id. Never derive this any other way.',
+              },
+              recipient_label: {
+                type: 'string',
+                description: 'The vitana_id of the recipient, used in the OASIS audit trail and acknowledgement (e.g. "alex3700"). Pass candidates[i].vitana_id verbatim.',
+              },
+              body: {
+                type: 'string',
+                description: 'The message body, exactly as the user dictated it. Do not rephrase or summarize.',
+              },
+            },
+            required: ['recipient_user_id', 'recipient_label', 'body'],
+          },
+        },
+        {
+          name: 'share_link',
+          description: [
+            'Share a link with another Vitana user as a chat message with a',
+            'link-card preview. Same confirmation contract as send_chat_message:',
+            'ALWAYS resolve_recipient first, ALWAYS read back the link target',
+            'and recipient, ONLY send on explicit confirmation.',
+            '',
+            'Use this when the user says "share this with X", "send the page',
+            'to X", "invite X to this", or similar. If the user is on a',
+            'specific screen, call get_current_screen first to learn the',
+            'target_url and target_kind ("event", "post", "profile", etc.),',
+            'then read both back to the user before sending.',
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              recipient_user_id: {
+                type: 'string',
+                description: 'Opaque user_id from resolve_recipient candidates[i].user_id.',
+              },
+              recipient_label: {
+                type: 'string',
+                description: 'Recipient vitana_id (e.g. "alex3700").',
+              },
+              target_url: {
+                type: 'string',
+                description: 'Full URL of the resource to share (e.g. https://vitanaland.com/events/abc).',
+              },
+              target_kind: {
+                type: 'string',
+                description: 'What is being shared. Examples: "event", "meetup", "post", "profile", "product", "campaign", "page".',
+              },
+            },
+            required: ['recipient_user_id', 'recipient_label', 'target_url', 'target_kind'],
+          },
+        },
       ],
     },
     // VTID-GOOGLE-SEARCH: Native Google Search grounding. Gemini calls
@@ -4164,6 +4294,198 @@ async function executeLiveApiToolInner(
           };
         } catch (err: any) {
           console.error('[explain_feature] error:', err?.message);
+          return { success: false, result: '', error: err?.message || 'unknown' };
+        }
+      }
+
+      // ─── VTID-01967 — Vitana ID voice messaging ───
+      case 'resolve_recipient': {
+        const spoken = String(args.spoken_name || '').trim();
+        const limit = Math.min(Math.max(Number(args.limit) || 5, 1), 10);
+        if (!spoken) {
+          return { success: false, result: '', error: 'spoken_name is required' };
+        }
+        try {
+          const { createClient } = await import('@supabase/supabase-js');
+          const supabase = createClient(
+            process.env.SUPABASE_URL!,
+            process.env.SUPABASE_SERVICE_ROLE!,
+          );
+          const { data, error } = await supabase.rpc('resolve_recipient_candidates', {
+            p_actor: session.identity.user_id,
+            p_token: spoken,
+            p_limit: limit,
+            p_global: false,
+          });
+          if (error) {
+            console.error('[VTID-01967] resolve_recipient RPC error:', error.message);
+            return { success: false, result: '', error: error.message };
+          }
+          const candidates = (data || []) as Array<{
+            user_id: string;
+            vitana_id: string | null;
+            display_name: string | null;
+            score: number;
+            reason: string;
+          }>;
+          const top_confidence = candidates.length > 0 ? Number(candidates[0].score) : 0;
+          const ambiguous =
+            candidates.length === 0 ||
+            top_confidence < 0.85 ||
+            (candidates.length > 1 && Number(candidates[1].score) / Math.max(top_confidence, 0.0001) > 0.85);
+          return {
+            success: true,
+            result: JSON.stringify({
+              candidates,
+              top_confidence,
+              ambiguous,
+            }),
+          };
+        } catch (err: any) {
+          console.error('[VTID-01967] resolve_recipient error:', err?.message);
+          return { success: false, result: '', error: err?.message || 'unknown' };
+        }
+      }
+
+      case 'send_chat_message': {
+        const recipientUserId = String(args.recipient_user_id || '').trim();
+        const recipientLabel = String(args.recipient_label || '').trim();
+        const body = String(args.body || '').trim();
+        if (!recipientUserId || !body) {
+          return { success: false, result: '', error: 'recipient_user_id and body are required' };
+        }
+        if (recipientUserId === session.identity.user_id) {
+          return { success: false, result: '', error: 'cannot message yourself' };
+        }
+        try {
+          const { checkVoiceSendQuota } = await import('../services/voice-message-guard');
+          const { resolveVitanaId } = await import('../middleware/auth-supabase-jwt');
+          const recipientVitanaId = await resolveVitanaId(recipientUserId);
+          const quota = await checkVoiceSendQuota({
+            session_id: session.sessionId,
+            actor_id: session.identity.user_id,
+            vitana_id: session.identity.vitana_id,
+            recipient_user_id: recipientUserId,
+            recipient_vitana_id: recipientVitanaId,
+            kind: 'message',
+            body_length: body.length,
+          });
+          if (!quota.allowed) {
+            return {
+              success: true,
+              result: JSON.stringify({ ok: false, rate_limited: true, reason: quota.reason }),
+            };
+          }
+          const { createClient } = await import('@supabase/supabase-js');
+          const supabase = createClient(
+            process.env.SUPABASE_URL!,
+            process.env.SUPABASE_SERVICE_ROLE!,
+          );
+          const senderVitanaId = session.identity.vitana_id || (await resolveVitanaId(session.identity.user_id));
+          const { error: insErr } = await supabase
+            .from('chat_messages')
+            .insert({
+              tenant_id: session.identity.tenant_id,
+              sender_id: session.identity.user_id,
+              receiver_id: recipientUserId,
+              content: body,
+              ...(senderVitanaId && { sender_vitana_id: senderVitanaId }),
+              ...(recipientVitanaId && { receiver_vitana_id: recipientVitanaId }),
+              metadata: {
+                source: 'voice',
+                session_id: session.sessionId,
+                recipient_label: recipientLabel || recipientVitanaId,
+              },
+            });
+          if (insErr) {
+            console.error('[VTID-01967] send_chat_message insert error:', insErr.message);
+            return { success: false, result: '', error: insErr.message };
+          }
+          return {
+            success: true,
+            result: JSON.stringify({
+              ok: true,
+              recipient_label: recipientLabel || recipientVitanaId || recipientUserId,
+              remaining: quota.remaining,
+            }),
+          };
+        } catch (err: any) {
+          console.error('[VTID-01967] send_chat_message error:', err?.message);
+          return { success: false, result: '', error: err?.message || 'unknown' };
+        }
+      }
+
+      case 'share_link': {
+        const recipientUserId = String(args.recipient_user_id || '').trim();
+        const recipientLabel = String(args.recipient_label || '').trim();
+        const targetUrl = String(args.target_url || '').trim();
+        const targetKind = String(args.target_kind || 'page').trim();
+        if (!recipientUserId || !targetUrl) {
+          return { success: false, result: '', error: 'recipient_user_id and target_url are required' };
+        }
+        if (recipientUserId === session.identity.user_id) {
+          return { success: false, result: '', error: 'cannot share with yourself' };
+        }
+        try {
+          const { checkVoiceSendQuota } = await import('../services/voice-message-guard');
+          const { resolveVitanaId } = await import('../middleware/auth-supabase-jwt');
+          const recipientVitanaId = await resolveVitanaId(recipientUserId);
+          const quota = await checkVoiceSendQuota({
+            session_id: session.sessionId,
+            actor_id: session.identity.user_id,
+            vitana_id: session.identity.vitana_id,
+            recipient_user_id: recipientUserId,
+            recipient_vitana_id: recipientVitanaId,
+            kind: 'share_link',
+            target_url: targetUrl,
+          });
+          if (!quota.allowed) {
+            return {
+              success: true,
+              result: JSON.stringify({ ok: false, rate_limited: true, reason: quota.reason }),
+            };
+          }
+          const { createClient } = await import('@supabase/supabase-js');
+          const supabase = createClient(
+            process.env.SUPABASE_URL!,
+            process.env.SUPABASE_SERVICE_ROLE!,
+          );
+          const senderVitanaId = session.identity.vitana_id || (await resolveVitanaId(session.identity.user_id));
+          const previewBody = `🔗 ${targetUrl}`;
+          const { error: insErr } = await supabase
+            .from('chat_messages')
+            .insert({
+              tenant_id: session.identity.tenant_id,
+              sender_id: session.identity.user_id,
+              receiver_id: recipientUserId,
+              content: previewBody,
+              message_type: 'link_share',
+              ...(senderVitanaId && { sender_vitana_id: senderVitanaId }),
+              ...(recipientVitanaId && { receiver_vitana_id: recipientVitanaId }),
+              metadata: {
+                source: 'voice',
+                session_id: session.sessionId,
+                kind: 'shared_link',
+                target_url: targetUrl,
+                target_kind: targetKind,
+                recipient_label: recipientLabel || recipientVitanaId,
+              },
+            });
+          if (insErr) {
+            console.error('[VTID-01967] share_link insert error:', insErr.message);
+            return { success: false, result: '', error: insErr.message };
+          }
+          return {
+            success: true,
+            result: JSON.stringify({
+              ok: true,
+              recipient_label: recipientLabel || recipientVitanaId || recipientUserId,
+              target_kind: targetKind,
+              remaining: quota.remaining,
+            }),
+          };
+        } catch (err: any) {
+          console.error('[VTID-01967] share_link error:', err?.message);
           return { success: false, result: '', error: err?.message || 'unknown' };
         }
       }

--- a/services/gateway/src/routes/users-resolve.ts
+++ b/services/gateway/src/routes/users-resolve.ts
@@ -1,0 +1,83 @@
+/**
+ * VTID-01967: POST /api/v1/users/resolve
+ *
+ * Voice-resolver primitive. Given a spoken-name token, returns ranked
+ * candidates from `resolve_recipient_candidates()` (peer-scoped to the
+ * actor's tenant). The ORB voice tool `resolve_recipient` calls this; the
+ * frontend MessageComposeModal also uses it as a typeahead source.
+ *
+ * Body: { token: string, limit?: number }
+ * Returns: { candidates, top_confidence, ambiguous }
+ *   ambiguous = top_confidence < 0.85 OR (second_score / top_score) > 0.85
+ */
+
+import { Router, Request, Response } from 'express';
+import {
+  requireAuth,
+  requireTenant,
+  AuthenticatedRequest,
+} from '../middleware/auth-supabase-jwt';
+import { createClient } from '@supabase/supabase-js';
+
+const router = Router();
+
+function getSupabase() {
+  return createClient(
+    process.env.SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE!
+  );
+}
+
+const AMBIGUITY_THRESHOLD = 0.85; // top score must clear this; otherwise ask user
+const TIE_RATIO_THRESHOLD = 0.85; // if second/first > this, it's a tie
+
+router.post('/resolve', requireAuth, requireTenant, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const { token, limit } = req.body ?? {};
+
+  if (!token || typeof token !== 'string' || token.trim().length === 0) {
+    return res.status(400).json({ ok: false, error: 'token is required' });
+  }
+
+  const limitInt = Math.min(Math.max(Number(limit) || 5, 1), 20);
+
+  const supabase = getSupabase();
+  const { data, error } = await supabase.rpc('resolve_recipient_candidates', {
+    p_actor: identity.user_id,
+    p_token: token,
+    p_limit: limitInt,
+    p_global: false,
+  });
+
+  if (error) {
+    console.error('[VTID-01967] users/resolve RPC error:', error);
+    return res.status(500).json({ ok: false, error: error.message });
+  }
+
+  const candidates = (data || []) as Array<{
+    user_id: string;
+    vitana_id: string | null;
+    display_name: string | null;
+    avatar_url: string | null;
+    score: number;
+    reason: string;
+  }>;
+
+  const top_confidence = candidates.length > 0 ? Number(candidates[0].score) : 0;
+  const ambiguous =
+    candidates.length === 0 ||
+    top_confidence < AMBIGUITY_THRESHOLD ||
+    (candidates.length > 1 &&
+      Number(candidates[1].score) / Math.max(top_confidence, 0.0001) > TIE_RATIO_THRESHOLD);
+
+  return res.json({
+    ok: true,
+    candidates,
+    top_confidence,
+    ambiguous,
+  });
+});
+
+export default router;

--- a/services/gateway/src/routes/users-vitana-id.ts
+++ b/services/gateway/src/routes/users-vitana-id.ts
@@ -1,0 +1,252 @@
+/**
+ * VTID-01967: Vitana ID onboarding pick endpoints.
+ *
+ *   GET  /api/v1/users/me/vitana-id/suggestion
+ *        Returns 3 fresh suggestions from generate_vitana_id_suggestion().
+ *
+ *   POST /api/v1/users/me/vitana-id/confirm   body: { vitana_id }
+ *        ONE-SHOT — only callable when profiles.vitana_id_locked = false.
+ *        On success: writes previous auto-generated value to handle_aliases,
+ *        updates vitana_id (and the legacy handle mirror) to the new value,
+ *        sets vitana_id_locked = true. After lock: 409 Conflict on every
+ *        subsequent call. Mutability is permanent — there is intentionally
+ *        no PATCH endpoint after this.
+ */
+
+import { Router, Request, Response } from 'express';
+import {
+  requireAuth,
+  invalidateVitanaIdCache,
+  AuthenticatedRequest,
+} from '../middleware/auth-supabase-jwt';
+import { createClient } from '@supabase/supabase-js';
+import { emitOasisEvent } from '../services/oasis-event-service';
+
+const router = Router();
+
+function getSupabase() {
+  return createClient(
+    process.env.SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE!
+  );
+}
+
+const VITANA_ID_REGEX = /^[a-z][a-z0-9]{3,11}$/;
+const MIN_LETTERS = 2;
+const MIN_DIGITS = 2;
+
+// ── GET /me/vitana-id/suggestion ──────────────────────────────
+
+router.get('/me/vitana-id/suggestion', requireAuth, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const supabase = getSupabase();
+
+  // Fetch the user's display_name + email for the generator. (full_name in
+  // profiles is the user-friendly name; falls back to email prefix.)
+  const { data: profileRow } = await supabase
+    .from('profiles')
+    .select('display_name, full_name, email, vitana_id_locked')
+    .eq('user_id', identity.user_id)
+    .maybeSingle();
+
+  if (profileRow && (profileRow as any).vitana_id_locked) {
+    return res.status(409).json({
+      ok: false,
+      error: 'ALREADY_LOCKED',
+      message: 'Your Vitana ID is already set and cannot be changed.',
+    });
+  }
+
+  // Three suggestions — three independent RPC calls. Each gets its own
+  // random suffix internally, so the trio is naturally distinct.
+  const [s1, s2, s3] = await Promise.all([
+    supabase.rpc('generate_vitana_id_suggestion', {
+      p_display_name: profileRow?.display_name ?? null,
+      p_full_name: profileRow?.full_name ?? null,
+      p_email: profileRow?.email ?? identity.email ?? null,
+    }),
+    supabase.rpc('generate_vitana_id_suggestion', {
+      p_display_name: profileRow?.display_name ?? null,
+      p_full_name: profileRow?.full_name ?? null,
+      p_email: profileRow?.email ?? identity.email ?? null,
+    }),
+    supabase.rpc('generate_vitana_id_suggestion', {
+      p_display_name: profileRow?.display_name ?? null,
+      p_full_name: profileRow?.full_name ?? null,
+      p_email: profileRow?.email ?? identity.email ?? null,
+    }),
+  ]);
+
+  // Dedupe in case the random suffixes happened to collide.
+  const suggestions = Array.from(
+    new Set([s1.data, s2.data, s3.data].filter(Boolean))
+  );
+
+  return res.json({
+    ok: true,
+    suggestions,
+  });
+});
+
+// ── POST /me/vitana-id/confirm ────────────────────────────────
+
+router.post('/me/vitana-id/confirm', requireAuth, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const { vitana_id: requestedRaw } = req.body ?? {};
+
+  if (!requestedRaw || typeof requestedRaw !== 'string') {
+    return res.status(400).json({ ok: false, error: 'vitana_id is required' });
+  }
+
+  // Normalize: strip leading @, lowercase. Same rules as the resolver.
+  const requested = requestedRaw.trim().replace(/^@/, '').toLowerCase();
+
+  // Format check.
+  if (!VITANA_ID_REGEX.test(requested)) {
+    return res.status(400).json({
+      ok: false,
+      error: 'INVALID_FORMAT',
+      message: 'Vitana ID must start with a letter, then 3-11 lowercase letters or digits.',
+    });
+  }
+
+  // Composition check (≥2 letters AND ≥2 digits).
+  const letters = (requested.match(/[a-z]/g) || []).length;
+  const digits = (requested.match(/[0-9]/g) || []).length;
+  if (letters < MIN_LETTERS || digits < MIN_DIGITS) {
+    return res.status(400).json({
+      ok: false,
+      error: 'WEAK_COMPOSITION',
+      message: `Vitana ID needs at least ${MIN_LETTERS} letters and ${MIN_DIGITS} digits.`,
+    });
+  }
+
+  const supabase = getSupabase();
+
+  // Reserved-word check (single source of truth in vitana_id_reserved table).
+  const { data: reserved } = await supabase
+    .from('vitana_id_reserved')
+    .select('token')
+    .eq('token', requested)
+    .maybeSingle();
+  if (reserved) {
+    return res.status(400).json({
+      ok: false,
+      error: 'RESERVED_TOKEN',
+      message: 'That Vitana ID is reserved. Please choose another.',
+    });
+  }
+
+  // Read current row + lock state.
+  const { data: current, error: currentErr } = await supabase
+    .from('profiles')
+    .select('vitana_id, vitana_id_locked')
+    .eq('user_id', identity.user_id)
+    .maybeSingle();
+
+  if (currentErr || !current) {
+    return res.status(404).json({
+      ok: false,
+      error: 'PROFILE_NOT_FOUND',
+      message: 'Profile row not found.',
+    });
+  }
+
+  if ((current as any).vitana_id_locked) {
+    return res.status(409).json({
+      ok: false,
+      error: 'ALREADY_LOCKED',
+      message: 'Your Vitana ID is already set and cannot be changed.',
+    });
+  }
+
+  const previous = (current as any).vitana_id as string | null;
+
+  // Uniqueness pre-check (definitive check is the UNIQUE index on UPDATE).
+  if (previous !== requested) {
+    const { data: taken } = await supabase
+      .from('profiles')
+      .select('user_id')
+      .eq('vitana_id', requested)
+      .neq('user_id', identity.user_id)
+      .maybeSingle();
+    if (taken) {
+      return res.status(409).json({
+        ok: false,
+        error: 'TAKEN',
+        message: 'That Vitana ID is already taken. Please choose another.',
+      });
+    }
+
+    // Also check handle_aliases — collisions are protected here too so we
+    // never re-issue an ID that historically pointed to a different user.
+    const { data: aliasTaken } = await supabase
+      .from('handle_aliases')
+      .select('user_id')
+      .eq('old_handle', requested)
+      .neq('user_id', identity.user_id)
+      .maybeSingle();
+    if (aliasTaken) {
+      return res.status(409).json({
+        ok: false,
+        error: 'ALIAS_COLLISION',
+        message: 'That Vitana ID was previously used by another account. Please choose another.',
+      });
+    }
+
+    // Park the previous auto-generated value in handle_aliases so /profiles
+    // links and any in-flight references still resolve to this user.
+    if (previous) {
+      await supabase.from('handle_aliases').upsert(
+        { old_handle: previous, user_id: identity.user_id },
+        { onConflict: 'old_handle' }
+      );
+    }
+  }
+
+  // Update profiles. Mirror trigger fires -> app_users.vitana_id updates.
+  // handle column also mirrored to keep frontend reads consistent under
+  // the replace policy.
+  const { error: updateErr } = await supabase
+    .from('profiles')
+    .update({
+      vitana_id: requested,
+      handle: requested,
+      vitana_id_locked: true,
+    })
+    .eq('user_id', identity.user_id);
+
+  if (updateErr) {
+    console.error('[VTID-01967] vitana-id confirm update error:', updateErr);
+    return res.status(500).json({ ok: false, error: updateErr.message });
+  }
+
+  // Invalidate the in-process cache so the next request sees the new value.
+  invalidateVitanaIdCache(identity.user_id);
+
+  // Audit event — vitana_id is now the canonical user identifier.
+  await emitOasisEvent({
+    vtid: 'VTID-01967',
+    type: 'vitana_id.confirmed',
+    source: 'users-vitana-id',
+    status: 'success',
+    message: `User confirmed Vitana ID @${requested}${previous ? ` (was @${previous})` : ''}`,
+    payload: { previous, current: requested },
+    actor_id: identity.user_id,
+    actor_role: 'user',
+    surface: 'api',
+    vitana_id: requested,
+  });
+
+  return res.json({
+    ok: true,
+    vitana_id: requested,
+    vitana_id_locked: true,
+  });
+});
+
+export default router;

--- a/services/gateway/src/services/oasis-event-service.ts
+++ b/services/gateway/src/services/oasis-event-service.ts
@@ -6,6 +6,7 @@
 import { randomUUID } from 'crypto';
 import { CicdEventType, CicdOasisEvent } from '../types/cicd';
 import { projectOasisEventToTimeline } from './timeline-projector';
+import { resolveVitanaId } from '../middleware/auth-supabase-jwt';
 
 /**
  * VTID-01874: Infer task_stage from event type when not explicitly set.
@@ -43,6 +44,15 @@ export async function emitOasisEvent(event: CicdOasisEvent): Promise<{ ok: boole
   const eventId = randomUUID();
   const timestamp = new Date().toISOString();
 
+  // VTID-01967: Auto-resolve vitana_id from actor_id when caller didn't pass it.
+  // Cached in resolveVitanaId(), so this is ~0ms after first lookup per user.
+  // Null-tolerant: if the column doesn't exist or app_users hasn't been mirrored
+  // yet, the field stays undefined and the INSERT just omits it.
+  let vitanaId: string | null | undefined = event.vitana_id;
+  if (vitanaId === undefined && event.actor_id) {
+    vitanaId = await resolveVitanaId(event.actor_id);
+  }
+
   const payload: Record<string, unknown> = {
     id: eventId,
     created_at: timestamp,
@@ -64,6 +74,8 @@ export async function emitOasisEvent(event: CicdOasisEvent): Promise<{ ok: boole
     // VTID-01874: Explicit stage annotation for correct timeline mapping
     // Uses explicit task_stage if set, otherwise infers from event type
     ...((event.task_stage || inferTaskStageFromType(event.type)) ? { task_stage: event.task_stage || inferTaskStageFromType(event.type) } : {}),
+    // VTID-01967: Denormalized canonical Vitana ID for support / audit queries.
+    ...(vitanaId && { vitana_id: vitanaId }),
   };
 
   try {

--- a/services/gateway/src/services/voice-message-guard.ts
+++ b/services/gateway/src/services/voice-message-guard.ts
@@ -1,0 +1,150 @@
+/**
+ * VTID-01967: Voice-message rate limiter + audit hook for ORB voice tools.
+ *
+ * Per-session 5-send cap. In-memory Map keyed by ORB session id, sweeps
+ * automatically on read. Safe in single-instance deploys (current state);
+ * Release C migrates to Redis when ORB scales horizontally.
+ *
+ * Every send / rate-limit emits an OASIS event so support and Voice Lab
+ * dashboards can audit voice-initiated outreach without DB joins.
+ */
+
+import { emitOasisEvent } from './oasis-event-service';
+
+const SEND_CAP_PER_SESSION = 5;
+const SESSION_TTL_MS = 30 * 60 * 1000; // 30 min — matches typical ORB session
+
+interface SessionCounter {
+  count: number;
+  expires_at: number;
+}
+
+const sendCounters = new Map<string, SessionCounter>();
+
+function sweepExpired(): void {
+  const now = Date.now();
+  for (const [key, counter] of sendCounters.entries()) {
+    if (counter.expires_at <= now) {
+      sendCounters.delete(key);
+    }
+  }
+}
+
+/**
+ * Increment the per-session counter for a voice-initiated send. Returns
+ * { allowed: true } when the cap hasn't been hit, { allowed: false, reason }
+ * when it has. Emits OASIS audit events on every call.
+ */
+export async function checkVoiceSendQuota(args: {
+  session_id: string;
+  actor_id: string;
+  vitana_id: string | null | undefined;
+  recipient_user_id: string;
+  recipient_vitana_id: string | null | undefined;
+  kind: 'message' | 'share_link';
+  body_length?: number;
+  target_url?: string;
+}): Promise<{ allowed: boolean; reason?: string; remaining: number }> {
+  sweepExpired();
+
+  const existing = sendCounters.get(args.session_id);
+  const count = existing?.count ?? 0;
+
+  if (count >= SEND_CAP_PER_SESSION) {
+    await emitOasisEvent({
+      vtid: 'VTID-01967',
+      type: 'voice.message.rate_limited',
+      source: 'voice-message-guard',
+      status: 'warning',
+      message: `Voice send quota exceeded for session ${args.session_id} (${count}/${SEND_CAP_PER_SESSION})`,
+      payload: {
+        session_id: args.session_id,
+        recipient_user_id: args.recipient_user_id,
+        recipient_vitana_id: args.recipient_vitana_id,
+        kind: args.kind,
+        cap: SEND_CAP_PER_SESSION,
+      },
+      actor_id: args.actor_id,
+      actor_role: 'user',
+      surface: 'orb',
+      vitana_id: args.vitana_id ?? undefined,
+    });
+    return {
+      allowed: false,
+      reason: 'rate_limited',
+      remaining: 0,
+    };
+  }
+
+  sendCounters.set(args.session_id, {
+    count: count + 1,
+    expires_at: Date.now() + SESSION_TTL_MS,
+  });
+
+  await emitOasisEvent({
+    vtid: 'VTID-01967',
+    type: args.kind === 'share_link' ? 'voice.message.share_link_sent' : 'voice.message.sent',
+    source: 'voice-message-guard',
+    status: 'success',
+    message: `Voice ${args.kind === 'share_link' ? 'link share' : 'message'} sent to @${args.recipient_vitana_id ?? args.recipient_user_id}`,
+    payload: {
+      session_id: args.session_id,
+      recipient_user_id: args.recipient_user_id,
+      recipient_vitana_id: args.recipient_vitana_id,
+      kind: args.kind,
+      ...(args.body_length !== undefined && { body_length: args.body_length }),
+      ...(args.target_url && { target_url: args.target_url }),
+      send_index: count + 1,
+      cap: SEND_CAP_PER_SESSION,
+    },
+    actor_id: args.actor_id,
+    actor_role: 'user',
+    surface: 'orb',
+    vitana_id: args.vitana_id ?? undefined,
+  });
+
+  return {
+    allowed: true,
+    remaining: SEND_CAP_PER_SESSION - (count + 1),
+  };
+}
+
+/**
+ * Emit a misroute event when the user signals "you sent it to the wrong
+ * person" after a voice send. Used for ASR-confidence threshold tuning.
+ */
+export async function reportVoiceMisroute(args: {
+  session_id: string;
+  actor_id: string;
+  vitana_id: string | null | undefined;
+  intended_token: string;
+  resolved_user_id: string;
+  resolved_vitana_id: string | null | undefined;
+}): Promise<void> {
+  await emitOasisEvent({
+    vtid: 'VTID-01967',
+    type: 'voice.message.misroute',
+    source: 'voice-message-guard',
+    status: 'warning',
+    message: `Voice misroute reported by @${args.vitana_id ?? args.actor_id}: said "${args.intended_token}", resolved to @${args.resolved_vitana_id ?? args.resolved_user_id}`,
+    payload: {
+      session_id: args.session_id,
+      intended_token: args.intended_token,
+      resolved_user_id: args.resolved_user_id,
+      resolved_vitana_id: args.resolved_vitana_id,
+    },
+    actor_id: args.actor_id,
+    actor_role: 'user',
+    surface: 'orb',
+    vitana_id: args.vitana_id ?? undefined,
+  });
+}
+
+/**
+ * Reset the counter for a session — useful when an ORB session ends so
+ * the next session for the same user starts fresh. Otherwise sweeps occur
+ * on every check via TTL.
+ */
+export function resetSessionQuota(sessionId: string): void {
+  sendCounters.delete(sessionId);
+}

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -686,7 +686,13 @@ export type CicdEventType =
   // OAuth WebView fix Phase 5: background OAuth token refresher
   | 'oauth.token.refresh.succeeded'
   | 'oauth.token.refresh.failed'
-  | 'oauth.token.refresh.tombstoned';
+  | 'oauth.token.refresh.tombstoned'
+  // VTID-01967: Vitana ID voice messaging
+  | 'voice.message.sent'
+  | 'voice.message.rate_limited'
+  | 'voice.message.misroute'
+  | 'voice.message.share_link_sent'
+  | 'vitana_id.confirmed';
 
 export interface CicdOasisEvent {
   vtid: string;
@@ -703,6 +709,10 @@ export interface CicdOasisEvent {
   conversation_turn_id?: string;
   // VTID-01874: Explicit stage annotation for correct timeline mapping
   task_stage?: 'PLANNER' | 'WORKER' | 'VALIDATOR' | 'DEPLOY';
+  // VTID-01967: Canonical Vitana ID denormalized for support / audit queries.
+  // Auto-resolved from actor_id if omitted by caller (cached lookup in
+  // emitOasisEvent). Null when the event has no human actor (system/cron).
+  vitana_id?: string | null;
 }
 
 // ==================== Allowed Services for Deploy ====================


### PR DESCRIPTION
## Summary

Release B of the **Vitana ID** initiative (VTID-01967). Wires the canonical Vitana ID into every authenticated request and adds the ORB voice-messaging contract. Depends on Release A (vitana-v1 #246) being merged + migrations applied first.

## What ships

### Middleware
- `auth-supabase-jwt.ts`: `SupabaseIdentity` gains `vitana_id?`, resolved via cached lookup against `app_users` (5min TTL, null-tolerant). Wired into `requireAuth`, `optionalAuth`, `requireAuthWithTenant`, `requireAdminAuth`. New helpers: `resolveVitanaId(userId)` and `invalidateVitanaIdCache(userId)`.

### Routes
- `auth.ts:425` /me: exposes `vitana_id` (from `app_users` mirror) and `vitana_id_locked` (from `profiles`). Backward-compat fallback for envs pre-Release-A.
- `chat.ts` /send: populates `sender_vitana_id` and `receiver_vitana_id` at insert time.
- New `routes/users-resolve.ts`: `POST /api/v1/users/resolve` — peer-scoped voice resolver via `resolve_recipient_candidates()` RPC.
- New `routes/admin-users-lookup.ts`: `GET /api/v1/admin/users/lookup` — global cross-tenant lookup, gated by `exafy_admin`.
- New `routes/users-vitana-id.ts`: `GET /me/vitana-id/suggestion` + `POST /confirm` (one-shot — 409 Conflict after lock).

### OASIS audit
- `services/oasis-event-service.ts`: `vitana_id` auto-resolves from `actor_id` when caller omits it, then is denormalized onto every event. New event types in `types/cicd.ts`: `voice.message.sent`, `voice.message.rate_limited`, `voice.message.misroute`, `voice.message.share_link_sent`, `vitana_id.confirmed`.

### ORB voice tools (`routes/orb-live.ts`)
- 3 new tool declarations: `resolve_recipient`, `send_chat_message`, `share_link`. Confirmation contract embedded in tool descriptions — always resolve first, always read back, only send on explicit verbal confirmation.
- 3 new dispatcher cases route through resolver RPC + `chat_messages` insert + voice-message-guard quota + OASIS audit.

### Voice send guard (`services/voice-message-guard.ts`, new)
- Per-session 5-send cap, in-memory Map keyed by ORB session id, 30min TTL, lazy sweep. Emits `voice.message.sent` / `voice.message.rate_limited` / `voice.message.misroute` via OASIS — every voice-initiated outreach visible in support tooling without DB joins.

### Backward-compatibility contracts (per plan)
- Identifier normalization (`@foo` ≡ `foo`) in resolver SQL.
- Self-resolution blocked at SQL + at orb-live dispatcher.
- All writers null-tolerant: `chat.ts`, `oasis-event-service`, /me — none fails when `vitana_id` is null during the brief Release-A→B window.
- `app_users.vitana_id` only updated by the Release A mirror trigger — app code never writes it directly.

## Test plan

- [ ] **Pre-merge**: confirm Release A (vitana-v1 #246) is merged + 9 migrations applied to staging. Without that, the new column reads return null and the resolver RPC errors out.
- [ ] Deploy gateway to dev. Curl smoke tests:
  - [ ] `curl -H \"Authorization: Bearer \$JWT\" \$GATEWAY/api/v1/auth/me | jq '.profile.vitana_id, .profile.vitana_id_locked'` — both populated.
  - [ ] `curl -X POST -H \"Authorization: Bearer \$JWT\" -H \"Content-Type: application/json\" -d '{\"token\":\"daniela\"}' \$GATEWAY/api/v1/users/resolve | jq '.candidates[0]'` — returns top candidate.
  - [ ] `curl -H \"Authorization: Bearer \$ADMIN_JWT\" \"\$GATEWAY/api/v1/admin/users/lookup?token=alex3700\"` — global match. 403 for non-admin.
  - [ ] `curl -H \"Authorization: Bearer \$JWT\" \$GATEWAY/api/v1/users/me/vitana-id/suggestion` — 3 suggestions.
  - [ ] `curl -X POST -d '{\"vitana_id\":\"alex3700\"}' \$GATEWAY/api/v1/users/me/vitana-id/confirm` — 200 with `vitana_id_locked: true`.
  - [ ] Same call again → 409 Conflict.
- [ ] **ORB voice end-to-end** (Cloud Run preview): open ORB, say *\"Send a message to alex3700: see you Monday\"* — expect resolve → readback → confirm → `chat_messages` row with both vitana_id columns populated.
- [ ] Ambiguity flow with multiple Danielas → ORB asks which.
- [ ] Trigger 6 sends in one session → 6th rejected with rate-limit voice. OASIS event emitted.
- [ ] Share-link flow: \"share this with alex3700\" → `chat_messages` row with `metadata.kind='shared_link'`.
- [ ] OASIS audit: `select vitana_id, count(*) from oasis_events where created_at > now() - interval '5 min' group by 1` — every recent row has vitana_id populated.

## Rollback

Each route is independent — revert this PR removes the routes and tools but leaves the schema (Release A) intact. The middleware change is null-tolerant so reverting doesn't break existing requests.

## Next

- **Release C**: enforcement (confidence threshold tuning), cross-system tagging audit (support tickets, bug reports, claim tables), Command Hub admin views, Redis-backed rate limiter.
- **Part 2**: reverse marketplace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)