### PR TITLE
fix(autopilot): autoApproveTick UUID type mismatch (BOOTSTRAP-AUTO-APPROVE-FIX)

### DIFF
--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -1648,7 +1648,14 @@ export async function autoApproveTick(): Promise<void> {
     );
     if (!planR.ok || !planR.data || planR.data.length === 0) continue;
 
-    const result = await approveAutoExecute({ finding_id: f.id, approved_by: 'auto' });
+    // Pass undefined so the INSERT writes approved_by=NULL.
+    // Earlier code passed the string literal 'auto', but approved_by is a
+    // UUID column — Postgres rejected every autonomous approval with
+    // "invalid input syntax for type uuid". Net: auto-approve has been
+    // silently no-op since the feature shipped. NULL is a valid sentinel
+    // for "approved by the system" — the OASIS event below is the audit
+    // trail for non-human approvals.
+    const result = await approveAutoExecute({ finding_id: f.id });
     if (!result.ok || !result.execution) {
       // A safety-gate rejection here is EXPECTED for findings that cite
       // files outside allow_scope — just log and move on. The operator
@@ -1720,7 +1727,14 @@ export async function autoApproveTick(): Promise<void> {
             continue;
           }
 
-          const result = await approveAutoExecute({ finding_id: f.id, approved_by: 'auto' });
+          // Pass undefined so the INSERT writes approved_by=NULL.
+    // Earlier code passed the string literal 'auto', but approved_by is a
+    // UUID column — Postgres rejected every autonomous approval with
+    // "invalid input syntax for type uuid". Net: auto-approve has been
+    // silently no-op since the feature shipped. NULL is a valid sentinel
+    // for "approved by the system" — the OASIS event below is the audit
+    // trail for non-human approvals.
+    const result = await approveAutoExecute({ finding_id: f.id });
           if (!result.ok || !result.execution) {
             console.log(`${LOG_PREFIX} auto-approve (impact) skipped ${f.id.slice(0, 8)}: ${result.error || 'safety gate'}`);
             continue;


### PR DESCRIPTION
## Bug
`approveAutoExecute({ approved_by: 'auto' })` triggered Postgres error 22P02 (invalid input syntax for type uuid) on every autonomous approval since the feature shipped — auto-approve has been silently no-op the entire time.

## Discovery
Surfaced while running v1 self-improving end-to-end: `auto_approve_enabled=true`, `daily_budget=10`, eligible findings with plans, all gates open, yet zero `dev_autopilot_executions` rows appeared. The autoApproveTick was logging "auto-approve skipped: execution insert failed: 400: ... uuid" silently and moving on.

## Fix
Pass `undefined` so the INSERT writes `approved_by=NULL`. The OASIS event `dev_autopilot.execution.auto_approved` is the audit trail for non-human approvals.

Two call sites updated (regular auto-approve + impact-finding auto-approve).

## Test plan
- [x] tsc clean
- [ ] Post-deploy: auto-approve tick approves the eligible finding 80aca9f4 within 30s