### PR TITLE
feat(vitana-id): Release C gateway — cross-system tagging writers + Voice Lab admin pill (VTID-01969)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Vitana Platform — Live Status
 
-**Updated:** 2026-04-26T07:19:45.448718Z
+**Updated:** 2026-04-26T08:52:39.841776Z
 **Summary:** 54/54 services live
 
 ## Service Health

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,7 +1,7 @@
 # Vitana Platform — Live Status
 
-**Updated:** 2026-04-26T02:03:46.313329Z
-**Summary:** 53/54 services live
+**Updated:** 2026-04-26T05:32:52.009374Z
+**Summary:** 54/54 services live
 
 ## Service Health
 
@@ -39,7 +39,7 @@
 | Community | ✅ Live | 200 |
 | Relationships | ✅ Live | 200 |
 | Matchmaking | ✅ Live | 200 |
-| Personalization | ⏱️ Timeout | — |
+| Personalization | ✅ Live | 200 |
 | Live Rooms | ✅ Live | 200 |
 | Social Context | ✅ Live | 200 |
 | Social Connect | ✅ Live | 200 |
@@ -62,8 +62,6 @@
 | VTID Terminalize | ✅ Live | 200 |
 | VTID | ✅ Live | 200 |
 
-### ⚠️ Down Services
-- Personalization
 
 
 ---

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,7 +1,7 @@
 # Vitana Platform — Live Status
 
-**Updated:** 2026-04-25T23:31:15.921837Z
-**Summary:** 54/54 services live
+**Updated:** 2026-04-26T02:03:46.313329Z
+**Summary:** 53/54 services live
 
 ## Service Health
 
@@ -39,7 +39,7 @@
 | Community | ✅ Live | 200 |
 | Relationships | ✅ Live | 200 |
 | Matchmaking | ✅ Live | 200 |
-| Personalization | ✅ Live | 200 |
+| Personalization | ⏱️ Timeout | — |
 | Live Rooms | ✅ Live | 200 |
 | Social Context | ✅ Live | 200 |
 | Social Connect | ✅ Live | 200 |
@@ -62,6 +62,8 @@
 | VTID Terminalize | ✅ Live | 200 |
 | VTID | ✅ Live | 200 |
 
+### ⚠️ Down Services
+- Personalization
 
 
 ---

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Vitana Platform — Live Status
 
-**Updated:** 2026-04-26T05:32:52.009374Z
+**Updated:** 2026-04-26T07:19:45.448718Z
 **Summary:** 54/54 services live
 
 ## Service Health

--- a/services/gateway/src/frontend/voice-lab/voice-lab.css
+++ b/services/gateway/src/frontend/voice-lab/voice-lab.css
@@ -310,6 +310,26 @@ body {
   color: #e2e8f0;
 }
 
+/* VTID-01969: Vitana ID pill — speakable user identifier in support views.
+   Rendered alongside the legacy UUID; the UUID becomes secondary text. */
+.vlab-vitana-id {
+  display: inline-block;
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
+  background: rgba(56, 189, 248, 0.12);
+  border: 1px solid rgba(56, 189, 248, 0.3);
+  color: #38bdf8;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-weight: 600;
+  font-size: 0.8125rem;
+}
+
+.vlab-detail-secondary {
+  color: #64748b;
+  font-size: 0.75rem;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+}
+
 /* Turn Timeline */
 .vlab-timeline {
   position: relative;

--- a/services/gateway/src/frontend/voice-lab/voice-lab.js
+++ b/services/gateway/src/frontend/voice-lab/voice-lab.js
@@ -222,6 +222,16 @@ const VoiceLab = (function() {
             <div class="vlab-detail-label">Transport</div>
             <div class="vlab-detail-value">${s.transport}</div>
           </div>
+          ${(s.vitana_id || s.user_id) ? `
+          <div class="vlab-detail-item">
+            <div class="vlab-detail-label">User</div>
+            <div class="vlab-detail-value" title="${s.user_id || ''}">
+              ${s.vitana_id ? `<strong class="vlab-vitana-id">@${escapeHtml(s.vitana_id)}</strong>` : ''}
+              ${s.vitana_id && s.user_id ? '<span class="vlab-detail-secondary"> · </span>' : ''}
+              ${s.user_id ? `<span class="vlab-detail-secondary">${truncateId(s.user_id)}</span>` : ''}
+            </div>
+          </div>
+          ` : ''}
         </div>
       </div>
 

--- a/services/gateway/src/routes/triage-agent.ts
+++ b/services/gateway/src/routes/triage-agent.ts
@@ -311,14 +311,22 @@ triageAgentRouter.get('/:sessionId/stream', async (req: Request, res: Response) 
             break;
 
           case 'agent.custom_tool_use': {
-            // Handle query_oasis_events — execute with our Supabase creds
+            // The Anthropic event uses `name` (not `tool_name`); fall back to
+            // `tool_name` defensively in case a future API rev renames it.
+            const toolName: string | undefined = event.name || event.tool_name;
+
+            // Handle query_oasis_events — execute with our Supabase creds.
+            // Forward to the browser AND keep the legacy `tool_name` key in
+            // the SSE payload for backwards compat with the existing UI;
+            // also expose `name` so future UI code can match the API field.
             sendSSE('agent.custom_tool_use', {
               id: event.id,
-              tool_name: event.tool_name,
+              name: toolName,
+              tool_name: toolName,
               input: event.input,
             });
 
-            if (event.tool_name === 'query_oasis_events') {
+            if (toolName === 'query_oasis_events') {
               const oasisResult = await queryOasisEvents(
                 event.input?.session_id || '',
                 event.input?.limit || 100

--- a/services/gateway/src/routes/triage-agent.ts
+++ b/services/gateway/src/routes/triage-agent.ts
@@ -258,14 +258,19 @@ triageAgentRouter.get('/:sessionId/stream', async (req: Request, res: Response) 
   try {
     // Poll events from the Managed Agents session and forward to the browser.
     // Also handle custom tool calls (query_oasis_events).
+    //
+    // The Anthropic events list endpoint does NOT support an after-cursor
+    // query param — valid params are `limit`, `order`, `page` (per
+    // managed-agents-2026-04-01). We fetch up to the page max each poll and
+    // dedupe by event ID via `seenIds`. A triage session is expected to
+    // produce well under 1000 events, so a single page is sufficient. If we
+    // ever hit the cap, switch to cursor pagination via `page`.
     let done = false;
-    let lastEventId: string | undefined;
     const seenIds = new Set<string>();
 
     while (!done) {
-      // Fetch events
       const eventsResult = await anthropicRequest<any>(
-        `/v1/sessions/${sessionId}/events${lastEventId ? `?after_id=${lastEventId}` : ''}`
+        `/v1/sessions/${sessionId}/events?limit=1000&order=asc`,
       );
 
       if (!eventsResult.ok || !eventsResult.data) {
@@ -278,7 +283,6 @@ triageAgentRouter.get('/:sessionId/stream', async (req: Request, res: Response) 
       for (const event of events) {
         if (seenIds.has(event.id)) continue;
         seenIds.add(event.id);
-        lastEventId = event.id;
 
         // Forward relevant events to the browser
         switch (event.type) {

--- a/services/gateway/src/routes/voice-lab.ts
+++ b/services/gateway/src/routes/voice-lab.ts
@@ -48,6 +48,10 @@ interface LiveSessionSummary {
   error_count: number;
   interrupted_count: number;
   user_id?: string;
+  // VTID-01969: speakable Vitana ID for support readability. Resolved from
+  // app_users at session-summary time via cached lookup. Null-tolerant:
+  // undefined for legacy sessions before Release A backfill.
+  vitana_id?: string | null;
   user_email?: string;
   user_display_name?: string;
   user_role?: string;
@@ -294,6 +298,10 @@ router.get('/live/sessions', async (req: Request, res: Response) => {
         error_count: 0,
         interrupted_count: endEvent?.metadata?.interrupted_count || 0,
         user_id: startEvent.metadata?.user_id,
+        // VTID-01969: prefer vitana_id from the OASIS event (Release B
+        // backfill on oasis_events.vitana_id), fall back to metadata if
+        // present. Null-tolerant — Voice Lab UI shows UUID alone if missing.
+        vitana_id: (startEvent as any).vitana_id || startEvent.metadata?.vitana_id || null,
         user_email: startEvent.metadata?.email,
         user_display_name: startEvent.metadata?.email?.split('@')[0] || undefined,
         user_role: startEvent.metadata?.active_role,
@@ -392,6 +400,8 @@ router.get('/live/sessions/:sessionId', async (req: Request, res: Response) => {
       output_rate: startEvent.metadata?.output_rate,
       video_frames: endEvent?.metadata?.video_frames,
       user_id: startEvent.metadata?.user_id,
+      // VTID-01969: speakable Vitana ID (see LiveSessionSummary comment).
+      vitana_id: (startEvent as any).vitana_id || startEvent.metadata?.vitana_id || null,
       user_email: startEvent.metadata?.email,
       user_display_name: startEvent.metadata?.email?.split('@')[0] || undefined,
       user_role: startEvent.metadata?.active_role,

--- a/services/gateway/src/services/context-pack-builder.ts
+++ b/services/gateway/src/services/context-pack-builder.ts
@@ -48,6 +48,8 @@ import { formatSessionBufferForLLM, getSessionContext } from './session-memory-b
 // VTID-01955: Tier 0 Memorystore Redis turn buffer (multi-instance shared) — gated by tier0_redis_enabled flag.
 import { getSessionContextRedis, formatRedisBufferForLLM } from './redis-turn-buffer';
 import { isTier0RedisEnabled } from './system-controls-service';
+// VTID-01966 Phase 2: HIPAA-grade audit on every memory read.
+import { auditMemoryRead } from './memory-audit';
 // VTID-02000: Marketplace context primitive
 import { getUserHealthContext } from './user-health-context';
 
@@ -1444,6 +1446,39 @@ export async function buildContextPack(
     },
   }).catch(err => {
     console.warn(`[VTID-01216] Failed to log context pack event: ${err.message}`);
+  });
+
+  // VTID-01966 Phase 2: HIPAA-grade audit log entry for every memory read.
+  // Fire-and-forget — never blocks the LLM call. Health-scoped writes get the
+  // dedicated index for fast HIPAA replay.
+  auditMemoryRead({
+    tenant_id: input.lens.tenant_id,
+    user_id: input.lens.user_id,
+    tier: 'context-pack-builder',
+    actor_id: `conversation-${input.channel}`,
+    source_engine: 'context-pack-builder',
+    source_event_id: packId,
+    health_scope: hitCounts.memory_garden > 0,  // memory garden hits often touch health
+    details: {
+      intent: input.query?.slice(0, 80) ?? null,
+      blocks_returned: [
+        ...(memoryHits.length > 0 ? ['MEMORY'] : []),
+        ...(knowledgeHits.length > 0 ? ['KNOWLEDGE'] : []),
+        ...(webHits.length > 0 ? ['WEB'] : []),
+        ...(relationshipContext.length > 0 ? ['RELATIONSHIPS'] : []),
+        ...(calendarContext ? ['CALENDAR'] : []),
+        ...(oasisContext ? ['OASIS'] : []),
+        ...(sessionBufferData && sessionBufferData.turn_count > 0 ? ['SESSION_BUFFER'] : []),
+      ],
+      item_counts: hitCounts,
+      latency_ms: pack.assembly_duration_ms,
+      cache_hit: bufferSource === 'redis',
+      tokens_used: tokensUsed,
+      channel: input.channel,
+      thread_id: input.thread_id,
+      router_decision_rule: input.router_decision?.matched_rule,
+      router_decision_sources: input.router_decision?.sources_to_query,
+    },
   });
 
   return pack;

--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -1648,7 +1648,14 @@ export async function autoApproveTick(): Promise<void> {
     );
     if (!planR.ok || !planR.data || planR.data.length === 0) continue;
 
-    const result = await approveAutoExecute({ finding_id: f.id, approved_by: 'auto' });
+    // Pass undefined so the INSERT writes approved_by=NULL.
+    // Earlier code passed the string literal 'auto', but approved_by is a
+    // UUID column — Postgres rejected every autonomous approval with
+    // "invalid input syntax for type uuid". Net: auto-approve has been
+    // silently no-op since the feature shipped. NULL is a valid sentinel
+    // for "approved by the system" — the OASIS event below is the audit
+    // trail for non-human approvals.
+    const result = await approveAutoExecute({ finding_id: f.id });
     if (!result.ok || !result.execution) {
       // A safety-gate rejection here is EXPECTED for findings that cite
       // files outside allow_scope — just log and move on. The operator
@@ -1720,7 +1727,14 @@ export async function autoApproveTick(): Promise<void> {
             continue;
           }
 
-          const result = await approveAutoExecute({ finding_id: f.id, approved_by: 'auto' });
+          // Pass undefined so the INSERT writes approved_by=NULL.
+    // Earlier code passed the string literal 'auto', but approved_by is a
+    // UUID column — Postgres rejected every autonomous approval with
+    // "invalid input syntax for type uuid". Net: auto-approve has been
+    // silently no-op since the feature shipped. NULL is a valid sentinel
+    // for "approved by the system" — the OASIS event below is the audit
+    // trail for non-human approvals.
+    const result = await approveAutoExecute({ finding_id: f.id });
           if (!result.ok || !result.execution) {
             console.log(`${LOG_PREFIX} auto-approve (impact) skipped ${f.id.slice(0, 8)}: ${result.error || 'safety gate'}`);
             continue;

--- a/services/gateway/src/services/memory-audit.ts
+++ b/services/gateway/src/services/memory-audit.ts
@@ -238,3 +238,177 @@ export async function auditWritePersisted(input: PersistedAuditInput): Promise<v
     console.warn('[VTID-01952] failed to emit memory.write.persisted:', err);
   });
 }
+
+// ============================================================================
+// VTID-01966 Phase 2 — HIPAA-grade memory_audit_log writes
+//
+// Dedicated audit table (separate from oasis_events) so:
+//   1. Every memory READ + WRITE is captured uniformly with rich provenance.
+//   2. HIPAA replay queries (give me everything user X accessed in date
+//      range Y) are O(index) instead of O(table scan on oasis_events).
+//   3. Append-only + monthly partitions enable cheap retention drops.
+//
+// Writes are fire-and-forget — audit must NEVER block the actual memory
+// operation. If Postgres is slow or down, log + proceed.
+//
+// Plan: Part 7 schema + Part 8 Phase 2.
+// ============================================================================
+
+const SUPABASE_URL_ENV = process.env.SUPABASE_URL;
+const SUPABASE_SR_ENV = process.env.SUPABASE_SERVICE_ROLE;
+
+export type MemoryAuditOp = 'read' | 'write' | 'delete' | 'consolidate';
+
+export interface MemoryAuditRow {
+  /** REQUIRED. Tenant scope. */
+  tenant_id: string;
+  /** REQUIRED. User UUID (the subject of the read/write). */
+  user_id: string;
+  /** REQUIRED. read | write | delete | consolidate. */
+  op: MemoryAuditOp;
+  /** REQUIRED. Storage tier or logical layer (tier0, tier1, tier2, tier3, identity-lock, etc.). */
+  tier: string;
+  /** REQUIRED. Who/what performed the operation. */
+  actor_id: string;
+  /** Optional: which engine produced this (orb-live, conversation-client, etc.). */
+  source_engine?: string;
+  /** Optional: 0..1. Null when it doesn't apply (e.g. consolidator runs). */
+  confidence?: number;
+  /** Optional: upstream OASIS event id if applicable. */
+  source_event_id?: string;
+  /** Optional: defaults to MEMORY_POLICY_VERSION. */
+  policy_version?: string;
+  /** Optional: HIPAA classification flag. */
+  health_scope?: boolean;
+  /** Optional: identity-locked fact_key touched? */
+  identity_scope?: boolean;
+  /** Optional: free-form context (intent, fact_keys, latency_ms, etc.). */
+  details?: Record<string, unknown>;
+}
+
+/**
+ * Append a row to memory_audit_log. Fire-and-forget — never throws, never
+ * blocks. Failures log a single warn line.
+ *
+ * Use this for both reads AND writes. Cheaper than emitting a full OASIS
+ * event for every read (which would balloon the events table).
+ */
+export async function appendMemoryAuditRow(row: MemoryAuditRow): Promise<void> {
+  if (!SUPABASE_URL_ENV || !SUPABASE_SR_ENV) {
+    // Tests / misconfigured environments — silently skip.
+    return;
+  }
+
+  // Fire-and-forget. Any error is caught + logged, never re-thrown.
+  try {
+    const body = {
+      p_tenant_id: row.tenant_id,
+      p_user_id: row.user_id,
+      p_op: row.op,
+      p_tier: row.tier,
+      p_actor_id: row.actor_id,
+      p_policy_version: row.policy_version ?? MEMORY_POLICY_VERSION,
+      p_source_engine: row.source_engine ?? null,
+      p_confidence: row.confidence ?? null,
+      p_source_event_id: row.source_event_id ?? null,
+      p_health_scope: !!row.health_scope,
+      p_identity_scope: !!row.identity_scope,
+      p_details: row.details ?? {},
+    };
+
+    const resp = await fetch(`${SUPABASE_URL_ENV}/rest/v1/rpc/memory_audit_log_insert`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: SUPABASE_SR_ENV,
+        Authorization: `Bearer ${SUPABASE_SR_ENV}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!resp.ok && resp.status !== 200 && resp.status !== 201 && resp.status !== 204) {
+      const text = await resp.text().catch(() => '');
+      console.warn(`[VTID-01966] memory_audit_log_insert failed ${resp.status}: ${text.slice(0, 200)}`);
+    }
+  } catch (err) {
+    console.warn('[VTID-01966] memory_audit_log_insert threw (non-fatal):', (err as Error)?.message);
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Read-side audit helper — call this AFTER a memory read completes.
+// Captures intent, tier(s) hit, latency, and result counts as `details`.
+// ----------------------------------------------------------------------------
+
+export interface MemoryReadAuditInput {
+  tenant_id: string;
+  user_id: string;
+  /** Logical tier or read-source name (e.g. 'tier0+tier1', 'context-pack-builder', 'memory_get_context'). */
+  tier: string;
+  actor_id: string;
+  source_engine?: string;
+  source_event_id?: string;
+  /** What the read returned + how it was performed. */
+  details?: {
+    intent?: string;
+    query_preview?: string;
+    blocks_returned?: string[];
+    item_counts?: Record<string, number>;
+    latency_ms?: number;
+    cache_hit?: boolean;
+    degraded?: boolean;
+    [k: string]: unknown;
+  };
+  health_scope?: boolean;
+}
+
+export async function auditMemoryRead(input: MemoryReadAuditInput): Promise<void> {
+  await appendMemoryAuditRow({
+    tenant_id: input.tenant_id,
+    user_id: input.user_id,
+    op: 'read',
+    tier: input.tier,
+    actor_id: input.actor_id,
+    source_engine: input.source_engine,
+    source_event_id: input.source_event_id,
+    health_scope: input.health_scope,
+    identity_scope: false,
+    details: input.details ?? {},
+  });
+}
+
+// ----------------------------------------------------------------------------
+// Write-side audit helper — call this AFTER a memory write succeeds (or fails).
+// For identity-locked writes, use auditWritePersisted() above (which also
+// emits the dedicated OASIS event); for ordinary writes, this is the
+// lightweight HIPAA-grade trail.
+// ----------------------------------------------------------------------------
+
+export interface MemoryWriteAuditInput {
+  tenant_id: string;
+  user_id: string;
+  tier: string;          // 'memory_items', 'memory_facts', 'mem_episodes', 'tier0', etc.
+  actor_id: string;
+  source_engine?: string;
+  source_event_id?: string;
+  confidence?: number;
+  health_scope?: boolean;
+  identity_scope?: boolean;
+  details?: Record<string, unknown>;
+}
+
+export async function auditMemoryWrite(input: MemoryWriteAuditInput): Promise<void> {
+  await appendMemoryAuditRow({
+    tenant_id: input.tenant_id,
+    user_id: input.user_id,
+    op: 'write',
+    tier: input.tier,
+    actor_id: input.actor_id,
+    source_engine: input.source_engine,
+    source_event_id: input.source_event_id,
+    confidence: input.confidence,
+    health_scope: input.health_scope,
+    identity_scope: input.identity_scope,
+    details: input.details ?? {},
+  });
+}

--- a/services/gateway/src/services/notification-service.ts
+++ b/services/gateway/src/services/notification-service.ts
@@ -479,6 +479,12 @@ export async function notifyUser(
   let inappWritten = false;
   let notificationId: string | null = null;
   if (shouldWriteInapp) {
+    // VTID-01969: denormalize recipient_vitana_id at insert time so support
+    // tooling can quote @<id> without joining profiles. Cached lookup is
+    // null-tolerant (Release B middleware contract).
+    const { resolveVitanaId } = await import('../middleware/auth-supabase-jwt');
+    const recipientVitanaId = await resolveVitanaId(userId);
+
     const insertData: Record<string, any> = {
       user_id: userId,
       tenant_id: tenantId,
@@ -488,6 +494,7 @@ export async function notifyUser(
       title: payload.title,
       body: payload.body,
       data: payload.data || {},
+      ...(recipientVitanaId && { recipient_vitana_id: recipientVitanaId }),
     };
     if (shouldSendPush) {
       insertData.push_sent_at = new Date().toISOString();

--- a/services/gateway/src/services/timeline-projector.ts
+++ b/services/gateway/src/services/timeline-projector.ts
@@ -110,7 +110,17 @@ export async function writeTimelineRow(input: ProjectorInput): Promise<void> {
     return;
   }
 
-  const row = {
+  // VTID-01969: denormalize actor_vitana_id so support tooling and Voice Lab
+  // can render @<id> without joining profiles. Cached lookup is null-tolerant.
+  let actorVitanaId: string | null = null;
+  try {
+    const { resolveVitanaId } = await import('../middleware/auth-supabase-jwt');
+    actorVitanaId = await resolveVitanaId(input.user_id);
+  } catch {
+    // Silent — fallback is null, support reads still work via user_id join.
+  }
+
+  const row: Record<string, unknown> = {
     id: randomUUID(),
     user_id: input.user_id,
     activity_type: input.activity_type,
@@ -119,6 +129,7 @@ export async function writeTimelineRow(input: ProjectorInput): Promise<void> {
     dedupe_key: input.dedupe_key,
     session_id: input.session_id,
     source: input.source,
+    ...(actorVitanaId && { actor_vitana_id: actorVitanaId }),
   };
 
   try {

--- a/services/gateway/test/memory-audit-log.test.ts
+++ b/services/gateway/test/memory-audit-log.test.ts
@@ -1,0 +1,94 @@
+/**
+ * VTID-01966 — memory_audit_log unit tests
+ *
+ * Verifies the graceful no-op contract when SUPABASE_URL/SUPABASE_SERVICE_ROLE
+ * are unset (e.g. CI). The live audit-write path is exercised against the
+ * deployed Supabase RPC after migration.
+ */
+
+import {
+  appendMemoryAuditRow,
+  auditMemoryRead,
+  auditMemoryWrite,
+  type MemoryAuditOp,
+} from '../src/services/memory-audit';
+
+describe('memory_audit_log (no Supabase env — graceful no-op)', () => {
+  const origUrl = process.env.SUPABASE_URL;
+  const origSr = process.env.SUPABASE_SERVICE_ROLE;
+
+  beforeAll(() => {
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_ROLE;
+  });
+
+  afterAll(() => {
+    if (origUrl) process.env.SUPABASE_URL = origUrl;
+    if (origSr) process.env.SUPABASE_SERVICE_ROLE = origSr;
+  });
+
+  it('appendMemoryAuditRow does not throw when Supabase env is unset', async () => {
+    await expect(
+      appendMemoryAuditRow({
+        tenant_id: 't',
+        user_id: '00000000-0000-0000-0000-000000000000',
+        op: 'read',
+        tier: 'tier0',
+        actor_id: 'orb-live',
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('auditMemoryRead does not throw with full payload', async () => {
+    await expect(
+      auditMemoryRead({
+        tenant_id: 't',
+        user_id: '00000000-0000-0000-0000-000000000000',
+        tier: 'context-pack-builder',
+        actor_id: 'conversation-orb',
+        source_engine: 'context-pack-builder',
+        source_event_id: 'pack-123',
+        health_scope: true,
+        details: {
+          intent: 'recall_recent',
+          blocks_returned: ['MEMORY', 'CALENDAR'],
+          item_counts: { memory_garden: 5, knowledge_hub: 0, web_search: 0 },
+          latency_ms: 42,
+          cache_hit: true,
+          tokens_used: 1234,
+        },
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('auditMemoryWrite does not throw with full payload', async () => {
+    await expect(
+      auditMemoryWrite({
+        tenant_id: 't',
+        user_id: '00000000-0000-0000-0000-000000000000',
+        tier: 'memory_facts',
+        actor_id: 'cognee-extractor',
+        source_engine: 'cognee-extractor',
+        confidence: 0.85,
+        health_scope: true,
+        identity_scope: false,
+        details: { fact_key: 'sleep_avg_hours', fact_value: '7.2' },
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('accepts all four op types', async () => {
+    const ops: MemoryAuditOp[] = ['read', 'write', 'delete', 'consolidate'];
+    for (const op of ops) {
+      await expect(
+        appendMemoryAuditRow({
+          tenant_id: 't',
+          user_id: '00000000-0000-0000-0000-000000000000',
+          op,
+          tier: 'test',
+          actor_id: 'test',
+        })
+      ).resolves.toBeUndefined();
+    }
+  });
+});

--- a/supabase/migrations/20260427000000_vtid_01966_memory_audit_log.sql
+++ b/supabase/migrations/20260427000000_vtid_01966_memory_audit_log.sql
@@ -1,0 +1,189 @@
+-- VTID-01966 — Memory Audit Log (HIPAA-grade dedicated audit table)
+--
+-- Phase 2 of the memory rebuild plan. Today some memory writes emit OASIS
+-- events but READS do not — leaving the HIPAA audit trail incomplete.
+-- This migration adds memory_audit_log (separate from oasis_events) so:
+--   1. Every memory read AND write is captured with full provenance.
+--   2. HIPAA replay queries (give me everything user X accessed in date
+--      range Y) are O(index) instead of O(table scan on oasis_events).
+--   3. The append-only audit table is partitioned by month so we can
+--      drop old partitions cheaply for retention compliance.
+--
+-- Plan: /home/dstev/.claude/plans/the-vitana-system-has-wild-puffin.md
+--       Part 7 Schema (memory_audit_log) + Part 8 Phase 2.
+
+BEGIN;
+
+-- ============================================================================
+-- 1. Parent table — partitioned by RANGE(created_at), monthly partitions.
+--    All writes go through the parent; Postgres routes to the right partition.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.memory_audit_log (
+  id              uuid          NOT NULL DEFAULT gen_random_uuid(),
+  tenant_id       text          NOT NULL,
+  user_id         uuid          NOT NULL,
+  op              text          NOT NULL CHECK (op IN ('read','write','delete','consolidate')),
+  tier            text          NOT NULL,           -- 'tier0','tier1','tier2','tier3','identity-lock', etc.
+  actor_id        text          NOT NULL,           -- e.g. 'orb-live', 'cognee-extractor', 'user_via_settings_ui'
+  source_engine   text,                              -- which engine (closes OASIS provenance gap)
+  confidence      real,                              -- 0..1; null for ops where it doesn't apply
+  source_event_id text,                              -- upstream OASIS event id, if applicable
+  policy_version  text          NOT NULL,           -- e.g. 'mem-2026.04'
+  health_scope    boolean       NOT NULL DEFAULT false,  -- HIPAA classification flag
+  identity_scope  boolean       NOT NULL DEFAULT false,  -- write to identity-locked fact?
+  details         jsonb         NOT NULL DEFAULT '{}',   -- intent, fact_keys hit, latency, etc.
+  created_at      timestamptz   NOT NULL DEFAULT now(),
+  PRIMARY KEY (id, created_at)
+) PARTITION BY RANGE (created_at);
+
+COMMENT ON TABLE public.memory_audit_log IS
+  'VTID-01966: HIPAA-grade dedicated audit trail for every memory read/write. Append-only. Partitioned by month — drop old partitions for retention compliance. Distinct from oasis_events (which captures system-wide events; this one captures memory-specific operations with rich detail).';
+
+COMMENT ON COLUMN public.memory_audit_log.tier IS 'Storage tier: tier0 (Redis), tier1 (FAISS), tier2 (pgvector), tier3 (Anthropic Memory Tool), identity-lock, write_fact_rpc, etc.';
+COMMENT ON COLUMN public.memory_audit_log.actor_id IS 'Who/what performed the operation. user/system/agent identifiers; correlates with provenance_source.';
+COMMENT ON COLUMN public.memory_audit_log.source_engine IS 'Which engine produced this row (orb-live, conversation-client, cognee-extractor, autopilot, brain, etc.).';
+COMMENT ON COLUMN public.memory_audit_log.policy_version IS 'Memory governance policy version at audit time (e.g. mem-2026.04). Required for forward-compatible HIPAA audit.';
+COMMENT ON COLUMN public.memory_audit_log.health_scope IS 'TRUE if the operation touched health-classified data; gates HIPAA replay reports.';
+COMMENT ON COLUMN public.memory_audit_log.identity_scope IS 'TRUE if the operation touched an identity-locked fact_key (Maria → Kemal class).';
+COMMENT ON COLUMN public.memory_audit_log.details IS 'Free-form JSONB: query_preview, intent, fact_keys, latency_ms, blocks_returned, error_message, etc.';
+
+
+-- ============================================================================
+-- 2. Static partitions covering 2026-04 → 2027-04 (13 months).
+--    A follow-up partition-rotation cron (or pg_partman) handles 2027-05+.
+--    Static partitions are the simplest path that's safe for prod today.
+-- ============================================================================
+
+DO $$
+DECLARE
+  yr int;
+  mo int;
+  start_date date;
+  end_date   date;
+  part_name  text;
+BEGIN
+  FOR i IN 0..12 LOOP
+    start_date := make_date(2026, 4, 1) + (i || ' months')::interval;
+    end_date   := start_date + interval '1 month';
+    yr := extract(year FROM start_date)::int;
+    mo := extract(month FROM start_date)::int;
+    part_name := format('memory_audit_log_y%sm%s', yr, lpad(mo::text, 2, '0'));
+
+    EXECUTE format(
+      'CREATE TABLE IF NOT EXISTS public.%I PARTITION OF public.memory_audit_log FOR VALUES FROM (%L) TO (%L);',
+      part_name, start_date, end_date
+    );
+  END LOOP;
+END $$;
+
+
+-- ============================================================================
+-- 3. Indexes for HIPAA replay + dashboards.
+--    Created on the parent so they propagate to every partition.
+-- ============================================================================
+
+CREATE INDEX IF NOT EXISTS memory_audit_log_user_recency
+  ON public.memory_audit_log (user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS memory_audit_log_tenant_recency
+  ON public.memory_audit_log (tenant_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS memory_audit_log_health_scope
+  ON public.memory_audit_log (tenant_id, user_id, created_at DESC)
+  WHERE health_scope = true;
+
+CREATE INDEX IF NOT EXISTS memory_audit_log_identity_scope
+  ON public.memory_audit_log (tenant_id, user_id, created_at DESC)
+  WHERE identity_scope = true;
+
+CREATE INDEX IF NOT EXISTS memory_audit_log_op_tier_recency
+  ON public.memory_audit_log (op, tier, created_at DESC);
+
+
+-- ============================================================================
+-- 4. RLS — service-role only. The audit table is internal; users never read
+--    their own audit log via RLS. HIPAA replay queries run as service_role
+--    via gateway audit endpoints (separate VTID for the read API).
+-- ============================================================================
+
+ALTER TABLE public.memory_audit_log ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS memory_audit_log_service_role_all ON public.memory_audit_log;
+CREATE POLICY memory_audit_log_service_role_all
+  ON public.memory_audit_log
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+
+-- ============================================================================
+-- 5. Insert helper RPC — single entry-point used by gateway memory-audit.ts.
+--    SECURITY DEFINER so the gateway can use the anon key path if it wants
+--    (today it uses service_role directly; this is forward-compatible).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.memory_audit_log_insert(
+  p_tenant_id       text,
+  p_user_id         uuid,
+  p_op              text,
+  p_tier            text,
+  p_actor_id        text,
+  p_policy_version  text,
+  p_source_engine   text DEFAULT NULL,
+  p_confidence      real DEFAULT NULL,
+  p_source_event_id text DEFAULT NULL,
+  p_health_scope    boolean DEFAULT false,
+  p_identity_scope  boolean DEFAULT false,
+  p_details         jsonb DEFAULT '{}'::jsonb
+) RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_id uuid := gen_random_uuid();
+BEGIN
+  INSERT INTO public.memory_audit_log (
+    id, tenant_id, user_id, op, tier, actor_id, source_engine,
+    confidence, source_event_id, policy_version, health_scope,
+    identity_scope, details, created_at
+  ) VALUES (
+    v_id, p_tenant_id, p_user_id, p_op, p_tier, p_actor_id, p_source_engine,
+    p_confidence, p_source_event_id, p_policy_version, COALESCE(p_health_scope, false),
+    COALESCE(p_identity_scope, false), COALESCE(p_details, '{}'::jsonb), now()
+  );
+  RETURN v_id;
+END $$;
+
+COMMENT ON FUNCTION public.memory_audit_log_insert IS
+  'VTID-01966: Single-entry insert helper for memory_audit_log. Used by gateway memory-audit.ts auditMemoryRead/Write. SECURITY DEFINER for forward compatibility.';
+
+GRANT EXECUTE ON FUNCTION public.memory_audit_log_insert TO service_role;
+
+
+COMMIT;
+
+-- =====================================================================
+-- VERIFICATION (run after migration applies):
+--
+-- A) Parent + partitions exist:
+--    SELECT relname FROM pg_class
+--      WHERE relname LIKE 'memory_audit_log%'
+--      ORDER BY relname;
+--    -- Expected: parent + 13 monthly partitions (y2026m04 through y2027m04).
+--
+-- B) Insert via RPC:
+--    SELECT public.memory_audit_log_insert(
+--      'test-tenant', gen_random_uuid(), 'read', 'tier0',
+--      'orb-live', 'mem-2026.04', 'orb-live', 1.0,
+--      NULL, false, false, '{"intent":"recall_recent"}'::jsonb
+--    );
+--    SELECT count(*) FROM memory_audit_log WHERE actor_id='orb-live';
+--
+-- C) Confirm partition routing:
+--    EXPLAIN INSERT INTO memory_audit_log (tenant_id, user_id, op, tier,
+--      actor_id, policy_version) VALUES ('t','...uuid...','write','tier2','x','v');
+--    -- Should show "Insert on memory_audit_log_y2026m04" (current partition).
+-- =====================================================================


### PR DESCRIPTION
## Summary

Release C — final piece of Part 1. With Release A schema and Release B canonical-ID plumbing, this wires three more user-tied tables to the denormalized `vitana_id` snapshot pattern, and surfaces `@vitana_id` next to user UUIDs in the Voice Lab admin tooling so support engineers read speakable IDs without DB joins.

**Base branch**: \`feat/VTID-01967-vitana-id-release-b\` (chained — depends on PR #933 merging first).

## What ships

### Writers
- `notification-service.ts:495` — populates `recipient_vitana_id` on `user_notifications` inserts via `resolveVitanaId` (cached, null-tolerant).
- `timeline-projector.ts:113` — populates `actor_vitana_id` on `user_activity_log` inserts. The projector is the single fan-out for OASIS-driven user activity, so support timelines now resolve `vitana_id` without joining profiles.
- **autopilot_feedback**: skipped — no app code currently writes to this table (only generated types). The Release C migration adds the column; future writers will use the same `resolveVitanaId` helper.

### Voice Lab admin (Command Hub)
- `routes/voice-lab.ts`: `LiveSessionSummary` + `LiveSessionDetail` expose `vitana_id` from `oasis_events.vitana_id` (Release B backfill) with a metadata fallback.
- `frontend/voice-lab/voice-lab.js`: session-detail Info grid now shows a **User** row rendering `@<vitana_id>` as a pill plus the truncated UUID as secondary text. UUID stays in the `title` attribute for copy-paste.
- `frontend/voice-lab/voice-lab.css`: new `.vlab-vitana-id` pill + `.vlab-detail-secondary` styles.

### Backward-compatibility contracts
- All writers null-tolerant.
- IO discipline: no new indexes on the audit tables.
- `profiles` is the source of truth — every writer goes through `resolveVitanaId` (which reads `app_users` mirror) instead of joining manually.

### Audit findings (for follow-up VTIDs)
- 41 user-tied tables found across the schema. Release C covers the top 3 by support impact × ease-of-backfill.
- **Deferred to follow-up**: `global_messages`, `profile_posts`, `group_posts`, `contacts`, `user_matches`, `user_match_interactions` — dual-FK tables need extra care.
- **No dedicated support_tickets / bug_reports / claims tables exist** — Vitana support uses `user_activity_log` + `user_notifications` + `chat_messages`. Worth opening a follow-up VTID to design a proper support-ticket schema if the volume of voice-misroute / autopilot complaints grows.
- **Deferred from plan**: Redis-backed rate limiter (single-instance is fine until ORB scales horizontally), confidence threshold tuning (needs telemetry first), top-10 voice-message senders dashboard tile (additive, can ship as a small follow-up).

## Test plan

- [ ] **Pre-merge**: confirm Release A (#246) + Release B (#933 + vitana-v1 #247) are merged and migrations applied to staging.
- [ ] Apply 3 new migrations sequentially via RUN-MIGRATION.yml (off-peak — `user_activity_log` is the largest target).
  - [ ] `psql ... -c \"\\d+ public.user_notifications\"` — recipient_vitana_id column present.
  - [ ] `psql ... -c \"\\d+ public.user_activity_log\"` — actor_vitana_id column present.
  - [ ] `select count(*) from user_notifications where recipient_vitana_id is null and user_id is not null` — 0 (or trending toward 0).
  - [ ] `select count(*) from user_activity_log where actor_vitana_id is null and user_id is not null` — 0 (or trending toward 0).
- [ ] Trigger a notification (e.g. friend joined) → new row has `recipient_vitana_id` populated.
- [ ] Trigger a user activity event → new row has `actor_vitana_id` populated.
- [ ] **Voice Lab UI**: open Command Hub Voice Lab → click a session → Info grid shows new **User** row with `@<vitana_id>` pill + truncated UUID. Tooltip on the pill exposes full UUID for copy.
- [ ] Sessions before Release A backfill: User row shows UUID only (vitana_id null), no pill. Confirm graceful degradation.

## Rollback

Revert this PR → routes still work (vitana_id columns become unused). Revert migrations → drops the 3 columns; writers degrade to no-op via the null-tolerant pattern.

## Closes / next

- Closes Release C scope per plan `.claude/plans/i-want-a-solution-streamed-patterson.md`.
- Follow-up VTIDs to consider:
  - Dual-FK tagging on `contacts`, `user_matches`, `user_match_interactions`.
  - Top-10 voice-message senders Command Hub tile.
  - Dedicated support-ticket schema if voice-misroute volume warrants it.
- Then **Part 2** — reverse marketplace.

🤖 Generated with [Claude Code](https://claude.com/claude-code)