### PR TITLE
fix(autopilot): autoApproveTick dedup vs in-flight executions (BOOTSTRAP-AUTO-APPROVE-DEDUP)

### DIFF
--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -1648,6 +1648,20 @@ export async function autoApproveTick(): Promise<void> {
     );
     if (!planR.ok || !planR.data || planR.data.length === 0) continue;
 
+    // Dedup: skip findings that already have a non-terminal execution.
+    // Without this, every tick approves a NEW execution row even though
+    // the prior one is still cooling/running — N concurrent executions
+    // for the same finding all racing the same plan. Discovered while
+    // running v1 autonomy: a single eligible finding produced 5 cooling
+    // executions in 3 minutes after auto-approve flipped on.
+    const inflightR = await supa<Array<{ id: string }>>(
+      s,
+      `/rest/v1/dev_autopilot_executions?finding_id=eq.${f.id}`
+      + `&status=in.(cooling,running,ci,merging,deploying,verifying)`
+      + `&select=id&limit=1`,
+    );
+    if (inflightR.ok && inflightR.data && inflightR.data.length > 0) continue;
+
     // Pass undefined so the INSERT writes approved_by=NULL.
     // Earlier code passed the string literal 'auto', but approved_by is a
     // UUID column — Postgres rejected every autonomous approval with


### PR DESCRIPTION
Without this, autoApproveTick approves the same finding once per tick (every 30s) until the budget caps, racing N executions of the same plan version against each other.

Discovered immediately after #934 fixed the silent UUID bug: auto-approve actually started working and produced 5 cooling executions of the same finding in 3 minutes.

Fix: skip findings with any execution row in cooling/running/ci/merging/deploying/verifying. Watchdog and bridge clear non-terminal rows on failure, so retries still happen organically.