### PR TITLE
fix: Self-Healing approve handler + duplicate-row dedup (VTID-01971)

### DIFF
--- a/services/gateway/src/routes/self-healing.ts
+++ b/services/gateway/src/routes/self-healing.ts
@@ -648,9 +648,14 @@ router.get('/pending-approval', async (req: Request, res: Response) => {
 
     const limit = Math.min(parseInt(req.query.limit as string) || 100, 200);
 
+    // dev_autopilot_self_heal_in_progress is written by dev-autopilot-bridge
+    // when it AUTO-spawns a child execution to retry. Outcome is 'pending'
+    // because the retry is in flight, but no human input is requested or
+    // useful — those rows belong on the Active Repairs view, not here.
     const resp = await fetch(
       `${SUPABASE_URL}/rest/v1/self_healing_log?` +
         `outcome=eq.pending&confidence=lt.0.8` +
+        `&failure_class=neq.dev_autopilot_self_heal_in_progress` +
         `&select=id,vtid,endpoint,failure_class,confidence,diagnosis,created_at,attempt_number` +
         `&order=created_at.desc&limit=${limit}`,
       { headers: supabaseHeaders() },
@@ -711,29 +716,38 @@ router.post('/approve', async (req: Request, res: Response) => {
     const logRow = logBody[0];
     const vtid = logRow.vtid;
 
-    // 2. Read the vtid_ledger row to get title + spec
-    const ledgerResp = await fetch(
-      `${SUPABASE_URL}/rest/v1/vtid_ledger?vtid=eq.${vtid}&select=vtid,title,summary&limit=1`,
-      { headers: supabaseHeaders() },
-    );
-    if (!ledgerResp.ok) {
-      const errText = await ledgerResp.text().catch(() => '');
-      return res.status(500).json({ ok: false, error: `vtid_ledger query failed: ${errText.slice(0, 200)}` });
-    }
-    const ledgerBody = await ledgerResp.json();
-    if (!Array.isArray(ledgerBody) || ledgerBody.length === 0) {
-      return res.status(404).json({ ok: false, error: `vtid_ledger row ${vtid} not found` });
-    }
-    const ledgerRow = ledgerBody[0];
+    // Real ledger VTIDs match `VTID-<digits>`. Dev-autopilot synthetic
+    // correlation IDs (`VTID-DA-<exec>`, `VTID-DA-FIND-<finding>`) have
+    // no vtid_ledger row by design — see dev-autopilot-self-heal-log.ts.
+    // For those, the standard execution_approved → autopilot event loop
+    // path can't dispatch (no ledger row to read), so we mark the log
+    // row approved and emit a self-healing.approved signal instead.
+    const isLedgerVtid = /^VTID-\d+$/.test(vtid);
 
-    // 3. Mark spec approved in vtid_ledger
-    await fetch(`${SUPABASE_URL}/rest/v1/vtid_ledger?vtid=eq.${vtid}`, {
-      method: 'PATCH',
-      headers: supabaseHeaders(),
-      body: JSON.stringify({ spec_status: 'approved', updated_at: new Date().toISOString() }),
-    });
+    if (isLedgerVtid) {
+      // 2. Read the vtid_ledger row to confirm it exists.
+      const ledgerResp = await fetch(
+        `${SUPABASE_URL}/rest/v1/vtid_ledger?vtid=eq.${vtid}&select=vtid,title,summary&limit=1`,
+        { headers: supabaseHeaders() },
+      );
+      if (!ledgerResp.ok) {
+        const errText = await ledgerResp.text().catch(() => '');
+        return res.status(500).json({ ok: false, error: `vtid_ledger query failed: ${errText.slice(0, 200)}` });
+      }
+      const ledgerBody = await ledgerResp.json();
+      if (!Array.isArray(ledgerBody) || ledgerBody.length === 0) {
+        return res.status(404).json({ ok: false, error: `vtid_ledger row ${vtid} not found` });
+      }
 
-    // 4. Mark self_healing_log row as human-approved
+      // 3. Mark spec approved in vtid_ledger.
+      await fetch(`${SUPABASE_URL}/rest/v1/vtid_ledger?vtid=eq.${vtid}`, {
+        method: 'PATCH',
+        headers: supabaseHeaders(),
+        body: JSON.stringify({ spec_status: 'approved', updated_at: new Date().toISOString() }),
+      });
+    }
+
+    // 4. Mark self_healing_log row as human-approved.
     const newDiagnosis = {
       ...(logRow.diagnosis || {}),
       human_decision: 'approved',
@@ -746,12 +760,14 @@ router.post('/approve', async (req: Request, res: Response) => {
       body: JSON.stringify({ diagnosis: newDiagnosis }),
     });
 
-    // 5. Emit execution_approved OASIS event — the autopilot event loop
-    // picks this up and dispatches through the standard pipeline (worker
-    // orchestrator → worker-runner), just like any other approved task.
-    // NO direct dispatch — same path as every other task.
+    // 5. Emit the appropriate approval event.
+    //   - Ledger VTIDs: vtid.lifecycle.execution_approved so the autopilot
+    //     event loop dispatches through the standard worker pipeline.
+    //   - Synthetic VTIDs: self-healing.approved as a record-only signal
+    //     (the dev-autopilot bridge owns the real retry path; this just
+    //     clears the row from the human queue and leaves an audit trail).
     await emitOasisEvent({
-      type: 'vtid.lifecycle.execution_approved',
+      type: isLedgerVtid ? 'vtid.lifecycle.execution_approved' : 'self-healing.approved',
       vtid,
       source: 'self-healing',
       status: 'info',
@@ -761,6 +777,7 @@ router.post('/approve', async (req: Request, res: Response) => {
         source: 'self-healing',
         operator: operator || 'command-hub',
         confidence: logRow.confidence,
+        synthetic_vtid: !isLedgerVtid,
       },
     });
 

--- a/services/gateway/src/services/dev-autopilot-self-heal-log.ts
+++ b/services/gateway/src/services/dev-autopilot-self-heal-log.ts
@@ -60,14 +60,25 @@ export interface AutopilotFailureArgs {
   attempt_number?: number;
 }
 
+/** Time window for the writer-level idempotency check. Same vtid+endpoint+
+ *  failure_class within this window is treated as a duplicate and skipped.
+ *  Sized to comfortably swallow ticker-loop spam (lazyPlanTick fires every
+ *  ~30s, multiple Cloud Run instances each run their own ticker) without
+ *  hiding a genuine new occurrence after the underlying problem returns. */
+const DEDUP_WINDOW_MS = 10 * 60 * 1000;
+
 /**
  * Best-effort write — caller must NOT block on the result. A failure to
  * write to self_healing_log is logged but never propagates because that
  * would mask the original autopilot failure that needed surfacing.
  *
- * Idempotency: not enforced — duplicate writes get duplicate rows. If
- * a stage runs in a tick loop and may double-fire, the caller should
- * dedupe with its own short-window check before calling here.
+ * Idempotency: enforced at the writer (VTID-01971). Before each INSERT we
+ * GET self_healing_log filtered by (vtid, endpoint, failure_class) within
+ * the last DEDUP_WINDOW_MS; if a row exists, the write is skipped. Stops
+ * tick-loop spam (lazyPlanTick re-firing the same plan_gen failure every
+ * ~30s × N Cloud Run instances) from flooding the Self-Healing UI with
+ * dozens of identical rows. Retries that legitimately need a separate row
+ * should pass a stage-discriminating endpoint or distinct failure_class.
  */
 export async function writeAutopilotFailure(
   s: SupaConfig,
@@ -77,6 +88,26 @@ export async function writeAutopilotFailure(
   const confidence = args.confidence ?? 0;
   const attempt = args.attempt_number ?? 1;
   try {
+    const sinceIso = new Date(Date.now() - DEDUP_WINDOW_MS).toISOString();
+    const dedupQuery =
+      `?vtid=eq.${encodeURIComponent(args.vtid)}` +
+      `&endpoint=eq.${encodeURIComponent(args.endpoint)}` +
+      `&failure_class=eq.${encodeURIComponent(args.failure_class)}` +
+      `&created_at=gte.${encodeURIComponent(sinceIso)}` +
+      `&select=id&limit=1`;
+    const dedupRes = await fetch(`${s.url}/rest/v1/self_healing_log${dedupQuery}`, {
+      headers: {
+        apikey: s.key,
+        Authorization: `Bearer ${s.key}`,
+      },
+    });
+    if (dedupRes.ok) {
+      const existing = (await dedupRes.json()) as Array<{ id: string }>;
+      if (Array.isArray(existing) && existing.length > 0) {
+        return;
+      }
+    }
+
     const res = await fetch(`${s.url}/rest/v1/self_healing_log`, {
       method: 'POST',
       headers: {


### PR DESCRIPTION
## Summary
Three Self-Healing UI bugs that surfaced together when a dev-autopilot row hit \"Awaiting Human Approval\":

- **`/approve` 404'd on synthetic VTIDs.** `VTID-DA-*` correlation IDs are not in `vtid_ledger`; the handler now skips the ledger lookup for them and emits `self-healing.approved` instead of `vtid.lifecycle.execution_approved`.
- **In-flight auto-retries leaked into the human queue.** `dev_autopilot_self_heal_in_progress` rows (written by the bridge with `outcome=pending` to surface an auto-retry) now excluded from `/pending-approval`.
- **`self_healing_log` flooded with duplicates.** `writeAutopilotFailure` disclaimed idempotency; `lazyPlanTick` re-fired the same `plan_gen` failure every ~30s × N Cloud Run instances. Now: pre-INSERT 10-minute dedup on `(vtid, endpoint, failure_class)`, using the existing `idx_self_healing_vtid`.

## Test plan
- [ ] Pre-deploy: source grep confirms `isLedgerVtid` and `failure_class=neq.dev_autopilot_self_heal_in_progress` are present.
- [ ] Post-deploy: POST `/api/v1/self-healing/approve` with a row whose `vtid` starts `VTID-DA-` returns 200 — not 404.
- [ ] Post-deploy: GET `/api/v1/self-healing/pending-approval` no longer returns rows with `failure_class=dev_autopilot_self_heal_in_progress`.
- [ ] Post-deploy: trigger a plan_gen failure and confirm only one `self_healing_log` row is created within a 10-minute window for the same triple.

🤖 Generated with [Claude Code](https://claude.com/claude-code)