### PR TITLE
feat(intent-engine): P2-A gateway — voice-dictated intent registry + kind-aware matcher (VTID-01973)

### DIFF
--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Vitana Platform — Live Status
 
-**Updated:** 2026-04-26T07:19:45.448718Z
+**Updated:** 2026-04-26T08:52:39.841776Z
 **Summary:** 54/54 services live
 
 ## Service Health

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,7 +1,7 @@
 # Vitana Platform — Live Status
 
-**Updated:** 2026-04-26T02:03:46.313329Z
-**Summary:** 53/54 services live
+**Updated:** 2026-04-26T05:32:52.009374Z
+**Summary:** 54/54 services live
 
 ## Service Health
 
@@ -39,7 +39,7 @@
 | Community | ✅ Live | 200 |
 | Relationships | ✅ Live | 200 |
 | Matchmaking | ✅ Live | 200 |
-| Personalization | ⏱️ Timeout | — |
+| Personalization | ✅ Live | 200 |
 | Live Rooms | ✅ Live | 200 |
 | Social Context | ✅ Live | 200 |
 | Social Connect | ✅ Live | 200 |
@@ -62,8 +62,6 @@
 | VTID Terminalize | ✅ Live | 200 |
 | VTID | ✅ Live | 200 |
 
-### ⚠️ Down Services
-- Personalization
 
 
 ---

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Vitana Platform — Live Status
 
-**Updated:** 2026-04-26T08:52:39.841776Z
+**Updated:** 2026-04-26T09:47:35.595650Z
 **Summary:** 54/54 services live
 
 ## Service Health

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Vitana Platform — Live Status
 
-**Updated:** 2026-04-26T09:47:35.595650Z
+**Updated:** 2026-04-26T10:39:11.301182Z
 **Summary:** 54/54 services live
 
 ## Service Health

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,7 +1,7 @@
 # Vitana Platform — Live Status
 
-**Updated:** 2026-04-25T23:31:15.921837Z
-**Summary:** 54/54 services live
+**Updated:** 2026-04-26T02:03:46.313329Z
+**Summary:** 53/54 services live
 
 ## Service Health
 
@@ -39,7 +39,7 @@
 | Community | ✅ Live | 200 |
 | Relationships | ✅ Live | 200 |
 | Matchmaking | ✅ Live | 200 |
-| Personalization | ✅ Live | 200 |
+| Personalization | ⏱️ Timeout | — |
 | Live Rooms | ✅ Live | 200 |
 | Social Context | ✅ Live | 200 |
 | Social Connect | ✅ Live | 200 |
@@ -62,6 +62,8 @@
 | VTID Terminalize | ✅ Live | 200 |
 | VTID | ✅ Live | 200 |
 
+### ⚠️ Down Services
+- Personalization
 
 
 ---

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,6 +1,6 @@
 # Vitana Platform — Live Status
 
-**Updated:** 2026-04-26T05:32:52.009374Z
+**Updated:** 2026-04-26T07:19:45.448718Z
 **Summary:** 54/54 services live
 
 ## Service Health

--- a/services/gateway/src/frontend/voice-lab/voice-lab.css
+++ b/services/gateway/src/frontend/voice-lab/voice-lab.css
@@ -310,6 +310,26 @@ body {
   color: #e2e8f0;
 }
 
+/* VTID-01969: Vitana ID pill — speakable user identifier in support views.
+   Rendered alongside the legacy UUID; the UUID becomes secondary text. */
+.vlab-vitana-id {
+  display: inline-block;
+  padding: 0.125rem 0.5rem;
+  border-radius: 9999px;
+  background: rgba(56, 189, 248, 0.12);
+  border: 1px solid rgba(56, 189, 248, 0.3);
+  color: #38bdf8;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+  font-weight: 600;
+  font-size: 0.8125rem;
+}
+
+.vlab-detail-secondary {
+  color: #64748b;
+  font-size: 0.75rem;
+  font-family: ui-monospace, "SF Mono", Menlo, monospace;
+}
+
 /* Turn Timeline */
 .vlab-timeline {
   position: relative;

--- a/services/gateway/src/frontend/voice-lab/voice-lab.js
+++ b/services/gateway/src/frontend/voice-lab/voice-lab.js
@@ -222,6 +222,16 @@ const VoiceLab = (function() {
             <div class="vlab-detail-label">Transport</div>
             <div class="vlab-detail-value">${s.transport}</div>
           </div>
+          ${(s.vitana_id || s.user_id) ? `
+          <div class="vlab-detail-item">
+            <div class="vlab-detail-label">User</div>
+            <div class="vlab-detail-value" title="${s.user_id || ''}">
+              ${s.vitana_id ? `<strong class="vlab-vitana-id">@${escapeHtml(s.vitana_id)}</strong>` : ''}
+              ${s.vitana_id && s.user_id ? '<span class="vlab-detail-secondary"> · </span>' : ''}
+              ${s.user_id ? `<span class="vlab-detail-secondary">${truncateId(s.user_id)}</span>` : ''}
+            </div>
+          </div>
+          ` : ''}
         </div>
       </div>
 

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -267,6 +267,10 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const notificationsRouter = require('./routes/notifications').default;
   // Chat — User-to-user direct messaging
   const chatRouter = require('./routes/chat').default;
+  // VTID-01967: Vitana ID — voice resolver, admin lookup, onboarding pick
+  const usersResolveRouter = require('./routes/users-resolve').default;
+  const adminUsersLookupRouter = require('./routes/admin-users-lookup').default;
+  const usersVitanaIdRouter = require('./routes/users-vitana-id').default;
   // Admin: Signup Funnel Tracking & Outreach
   const adminSignupsRouter = require('./routes/admin-signups').default;
   // Admin: Notification Compose & Tracking
@@ -740,6 +744,13 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
 
   // Chat — User-to-user direct messaging
   mountRouterSync(app, '/api/v1/chat', chatRouter, { owner: 'chat' });
+
+  // VTID-01967: Vitana ID resolver + onboarding pick + admin lookup.
+  // Mounted under /api/v1/users so /resolve and /me/vitana-id/* are siblings;
+  // admin lookup is at /api/v1/admin (gated by exafy_admin role).
+  mountRouterSync(app, '/api/v1/users', usersResolveRouter, { owner: 'users-resolve' });
+  mountRouterSync(app, '/api/v1/users', usersVitanaIdRouter, { owner: 'users-vitana-id' });
+  mountRouterSync(app, '/api/v1/admin', adminUsersLookupRouter, { owner: 'admin-users-lookup' });
 
   // Admin: Signup Funnel Tracking & Outreach
   mountRouterSync(app, '/api/v1/admin/signups', adminSignupsRouter, { owner: 'admin-signups' });

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -271,6 +271,14 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const usersResolveRouter = require('./routes/users-resolve').default;
   const adminUsersLookupRouter = require('./routes/admin-users-lookup').default;
   const usersVitanaIdRouter = require('./routes/users-vitana-id').default;
+  // VTID-01973: Vitana Intent Engine (P2-A). Voice-dictated intent registry +
+  // kind-aware matcher. Behind FEATURE_INTENT_ENGINE_A — disabled by default.
+  const intentEngineEnabled = process.env.FEATURE_INTENT_ENGINE_A === 'true';
+  const intentsRouter = intentEngineEnabled ? require('./routes/intents').default : null;
+  const intentMatchesRouter = intentEngineEnabled ? require('./routes/intent-matches').default : null;
+  const intentBoardRouter = intentEngineEnabled ? require('./routes/intent-board').default : null;
+  const intentCategoriesRouter = intentEngineEnabled ? require('./routes/intent-categories').default : null;
+  const adminIntentEngineRouter = intentEngineEnabled ? require('./routes/admin-intent-engine').default : null;
   // Admin: Signup Funnel Tracking & Outreach
   const adminSignupsRouter = require('./routes/admin-signups').default;
   // Admin: Notification Compose & Tracking
@@ -751,6 +759,13 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   mountRouterSync(app, '/api/v1/users', usersResolveRouter, { owner: 'users-resolve' });
   mountRouterSync(app, '/api/v1/users', usersVitanaIdRouter, { owner: 'users-vitana-id' });
   mountRouterSync(app, '/api/v1/admin', adminUsersLookupRouter, { owner: 'admin-users-lookup' });
+
+  // VTID-01973: Vitana Intent Engine (P2-A) — gated by FEATURE_INTENT_ENGINE_A.
+  if (intentsRouter) mountRouterSync(app, '/api/v1/intents', intentsRouter, { owner: 'intents' });
+  if (intentMatchesRouter) mountRouterSync(app, '/api/v1/intent-matches', intentMatchesRouter, { owner: 'intent-matches' });
+  if (intentBoardRouter) mountRouterSync(app, '/api/v1/intent-board', intentBoardRouter, { owner: 'intent-board' });
+  if (intentCategoriesRouter) mountRouterSync(app, '/api/v1/intent-categories', intentCategoriesRouter, { owner: 'intent-categories' });
+  if (adminIntentEngineRouter) mountRouterSync(app, '/api/v1/admin/intent-engine', adminIntentEngineRouter, { owner: 'admin-intent-engine' });
 
   // Admin: Signup Funnel Tracking & Outreach
   mountRouterSync(app, '/api/v1/admin/signups', adminSignupsRouter, { owner: 'admin-signups' });

--- a/services/gateway/src/middleware/auth-supabase-jwt.ts
+++ b/services/gateway/src/middleware/auth-supabase-jwt.ts
@@ -30,6 +30,63 @@ export interface SupabaseIdentity {
   aud: string | null;       // Audience claim
   exp: number | null;       // Expiration timestamp
   iat: number | null;       // Issued at timestamp
+  // VTID-01967: Canonical Vitana ID — attached after JWT verify via cached
+  // lookup against app_users (mirrored from profiles by Release A trigger).
+  // Null-tolerant: undefined if the lookup hasn't run yet or the user has no
+  // app_users row yet. Callers must never block on this.
+  vitana_id?: string | null;
+}
+
+// VTID-01967: In-process cache for vitana_id lookup. Keyed by user_id, 5min TTL.
+// Avoids hammering app_users on every authenticated request. Cleared lazily
+// when entries are read after expiration.
+const VITANA_ID_CACHE_TTL_MS = 5 * 60 * 1000;
+const vitanaIdCache = new Map<string, { vitana_id: string | null; expires_at: number }>();
+
+/**
+ * VTID-01967: Resolve vitana_id for a user, with in-process caching.
+ * Returns null if not found / not yet mirrored — callers must be null-tolerant.
+ * Public so callers (oasis-event-service, voice-message-guard) can resolve
+ * the ID for a user_id outside the request lifecycle.
+ */
+export async function resolveVitanaId(userId: string): Promise<string | null> {
+  if (!userId) return null;
+
+  const cached = vitanaIdCache.get(userId);
+  if (cached && cached.expires_at > Date.now()) {
+    return cached.vitana_id;
+  }
+
+  try {
+    const supabase = getSupabase();
+    if (!supabase) return null;
+
+    const { data } = await supabase
+      .from('app_users')
+      .select('vitana_id')
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    const vitanaId = (data && (data as any).vitana_id) || null;
+    vitanaIdCache.set(userId, {
+      vitana_id: vitanaId,
+      expires_at: Date.now() + VITANA_ID_CACHE_TTL_MS,
+    });
+    return vitanaId;
+  } catch {
+    // Null-tolerant: never block auth on this lookup. If the column doesn't
+    // exist yet (Release A migrations not applied), the catch swallows.
+    return null;
+  }
+}
+
+/**
+ * VTID-01967: Invalidate cached vitana_id for a user. Call this from the
+ * /vitana-id/confirm endpoint after the user picks a different ID, so the
+ * next authenticated request reads the new value.
+ */
+export function invalidateVitanaIdCache(userId: string): void {
+  vitanaIdCache.delete(userId);
 }
 
 /**
@@ -175,6 +232,10 @@ export async function requireAuth(
     upsertActiveDay(result.identity.user_id).catch(() => {});
   }
 
+  // VTID-01967: Resolve vitana_id (cached, null-tolerant). Downstream code
+  // reads req.identity.vitana_id directly; on cache hit this is ~0ms.
+  req.identity.vitana_id = await resolveVitanaId(result.identity.user_id);
+
   next();
 }
 
@@ -198,6 +259,8 @@ export async function optionalAuth(
       if (result.identity.user_id) {
         upsertActiveDay(result.identity.user_id).catch(() => {});
       }
+      // VTID-01967: vitana_id resolution
+      req.identity.vitana_id = await resolveVitanaId(result.identity.user_id);
     }
   }
 
@@ -338,6 +401,9 @@ export async function requireAuthWithTenant(
     upsertActiveDay(result.identity.user_id).catch(() => {});
   }
 
+  // VTID-01967: vitana_id resolution
+  req.identity.vitana_id = await resolveVitanaId(result.identity.user_id);
+
   // If tenant_id missing from JWT, resolve from user_tenants table
   if (!req.identity.tenant_id) {
     const supabase = getSupabase();
@@ -420,6 +486,9 @@ export async function requireAdminAuth(
   if (result.identity.user_id) {
     upsertActiveDay(result.identity.user_id).catch(() => {});
   }
+
+  // VTID-01967: vitana_id resolution
+  req.identity.vitana_id = await resolveVitanaId(result.identity.user_id);
 
   // Then, require exafy_admin
   if (!req.identity.exafy_admin) {

--- a/services/gateway/src/routes/admin-intent-engine.ts
+++ b/services/gateway/src/routes/admin-intent-engine.ts
@@ -1,0 +1,99 @@
+/**
+ * VTID-01973: Admin Intent Engine (P2-A).
+ *
+ * exafy_admin only. Surface for moderation, manual recompute, archival.
+ * P2-A baseline:
+ *   GET   /api/v1/admin/intent-engine/intent/:id        — read any intent (bypasses visibility)
+ *   POST  /api/v1/admin/intent-engine/intent/:id/close  — force close
+ *   POST  /api/v1/admin/intent-engine/recompute         — body { intent_id? } — re-run compute (one or daily fan-out)
+ *   GET   /api/v1/admin/intent-engine/stats             — basic dashboard counts
+ */
+
+import { Router, Request, Response } from 'express';
+import { createClient } from '@supabase/supabase-js';
+import {
+  requireAdminAuth,
+  AuthenticatedRequest,
+} from '../middleware/auth-supabase-jwt';
+import { computeForIntent } from '../services/intent-matcher';
+
+const router = Router();
+
+function getSupabase() {
+  return createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE!);
+}
+
+router.get('/intent/:id', requireAdminAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from('user_intents')
+    .select('*')
+    .eq('intent_id', req.params.id)
+    .maybeSingle();
+  if (error) return res.status(500).json({ ok: false, error: error.message });
+  if (!data) return res.status(404).json({ ok: false, error: 'not_found' });
+  return res.json({ ok: true, intent: data });
+});
+
+router.post('/intent/:id/close', requireAdminAuth, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  const supabase = getSupabase();
+  const { error } = await supabase
+    .from('user_intents')
+    .update({ status: 'closed' })
+    .eq('intent_id', req.params.id);
+  if (error) return res.status(500).json({ ok: false, error: error.message });
+
+  await supabase.from('intent_events').insert({
+    intent_id: req.params.id,
+    actor_user_id: identity?.user_id,
+    actor_vitana_id: identity?.vitana_id ?? null,
+    event_type: 'admin.force_close',
+    payload: { reason: req.body?.reason ?? 'admin_action' },
+  });
+  return res.json({ ok: true });
+});
+
+router.post('/recompute', requireAdminAuth, async (req: Request, res: Response) => {
+  const intentId = req.body?.intent_id as string | undefined;
+  if (intentId) {
+    const inserted = await computeForIntent(intentId);
+    return res.json({ ok: true, mode: 'one', inserted });
+  }
+  const supabase = getSupabase();
+  const { data, error } = await supabase.rpc('compute_intent_matches_daily');
+  if (error) return res.status(500).json({ ok: false, error: error.message });
+  return res.json({ ok: true, mode: 'daily', result: data });
+});
+
+router.get('/stats', requireAdminAuth, async (_req: Request, res: Response) => {
+  const supabase = getSupabase();
+  const { count: totalIntents } = await supabase
+    .from('user_intents')
+    .select('*', { count: 'exact', head: true });
+  const { count: openIntents } = await supabase
+    .from('user_intents')
+    .select('*', { count: 'exact', head: true })
+    .eq('status', 'open');
+  const { count: totalMatches } = await supabase
+    .from('intent_matches')
+    .select('*', { count: 'exact', head: true });
+  const { count: stuckOpen } = await supabase
+    .from('user_intents')
+    .select('*', { count: 'exact', head: true })
+    .eq('status', 'open')
+    .eq('match_count', 0)
+    .lt('created_at', new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString());
+
+  return res.json({
+    ok: true,
+    stats: {
+      total_intents: totalIntents ?? 0,
+      open_intents: openIntents ?? 0,
+      total_matches: totalMatches ?? 0,
+      stuck_open_24h: stuckOpen ?? 0,
+    },
+  });
+});
+
+export default router;

--- a/services/gateway/src/routes/admin-users-lookup.ts
+++ b/services/gateway/src/routes/admin-users-lookup.ts
@@ -1,0 +1,61 @@
+/**
+ * VTID-01967: GET /api/v1/admin/users/lookup
+ *
+ * Admin support tooling — global (cross-tenant) Vitana ID lookup. Voice
+ * Lab, OASIS event panels, and Command Hub user-detail screens use this
+ * to jump from "@alex3700" to a user's full profile + tenant + recent
+ * activity without joining DBs by hand.
+ *
+ * Query: ?token=<vitana_id_or_handle_or_name>&limit=<n>
+ * Auth:  exafy_admin = true (gateway role check; SQL function trusts the
+ *        p_global flag forwarded from this route).
+ */
+
+import { Router, Request, Response } from 'express';
+import {
+  requireAdminAuth,
+  AuthenticatedRequest,
+} from '../middleware/auth-supabase-jwt';
+import { createClient } from '@supabase/supabase-js';
+
+const router = Router();
+
+function getSupabase() {
+  return createClient(
+    process.env.SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE!
+  );
+}
+
+router.get('/users/lookup', requireAdminAuth, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const token = (req.query.token as string | undefined)?.trim();
+  const limitParam = req.query.limit;
+  if (!token) {
+    return res.status(400).json({ ok: false, error: 'token query parameter is required' });
+  }
+
+  const limitInt = Math.min(Math.max(Number(limitParam) || 10, 1), 50);
+
+  const supabase = getSupabase();
+  const { data, error } = await supabase.rpc('resolve_recipient_candidates', {
+    p_actor: identity.user_id,
+    p_token: token,
+    p_limit: limitInt,
+    p_global: true, // admin-only: cross-tenant search
+  });
+
+  if (error) {
+    console.error('[VTID-01967] admin/users/lookup RPC error:', error);
+    return res.status(500).json({ ok: false, error: error.message });
+  }
+
+  return res.json({
+    ok: true,
+    candidates: data || [],
+  });
+});
+
+export default router;

--- a/services/gateway/src/routes/auth.ts
+++ b/services/gateway/src/routes/auth.ts
@@ -431,16 +431,24 @@ router.get('/me', requireAuth, async (req: AuthenticatedRequest, res: Response) 
   );
 
   // VTID-01186: Fetch profile and memberships from database
-  let profile: { display_name?: string; avatar_url?: string; bio?: string } = {};
+  // VTID-01967: also expose vitana_id (from app_users mirror) and vitana_id_locked (from profiles).
+  let profile: {
+    display_name?: string;
+    avatar_url?: string;
+    bio?: string;
+    vitana_id?: string;
+    vitana_id_locked?: boolean;
+  } = {};
   let memberships: Array<{ tenant_id: string; role: string; is_primary: boolean }> = [];
 
   const supabase = getSupabase();
   if (supabase && identity.user_id) {
     try {
-      // Fetch user profile from app_users
+      // Fetch user profile from app_users — vitana_id is mirrored here by the
+      // Release A trigger profiles_vitana_id_mirror_trigger.
       const { data: profileData, error: profileError } = await supabase
         .from('app_users')
-        .select('display_name, avatar_url, bio')
+        .select('display_name, avatar_url, bio, vitana_id')
         .eq('user_id', identity.user_id)
         .single();
 
@@ -449,7 +457,28 @@ router.get('/me', requireAuth, async (req: AuthenticatedRequest, res: Response) 
           display_name: profileData.display_name || undefined,
           avatar_url: profileData.avatar_url || undefined,
           bio: profileData.bio || undefined,
+          vitana_id: (profileData as any).vitana_id || undefined,
         };
+      }
+
+      // VTID-01967: vitana_id_locked lives only on profiles (not mirrored).
+      // Parallel fetch — null-tolerant (column may not exist before Release A).
+      try {
+        const { data: lockData } = await supabase
+          .from('profiles')
+          .select('vitana_id_locked, vitana_id')
+          .eq('user_id', identity.user_id)
+          .maybeSingle();
+        if (lockData) {
+          profile.vitana_id_locked = (lockData as any).vitana_id_locked === true;
+          // Profiles is the source of truth; if app_users mirror is stale (or
+          // not yet provisioned), prefer profiles.vitana_id.
+          if (!profile.vitana_id && (lockData as any).vitana_id) {
+            profile.vitana_id = (lockData as any).vitana_id;
+          }
+        }
+      } catch (_lockErr) {
+        // Silent — profiles.vitana_id_locked may not exist on this env yet.
       }
 
       // VTID-01230-FIX: Match /auth/login fallback chain for avatar_url.

--- a/services/gateway/src/routes/chat.ts
+++ b/services/gateway/src/routes/chat.ts
@@ -13,6 +13,7 @@ import { Router, Request, Response } from 'express';
 import {
   requireAuth,
   requireTenant,
+  resolveVitanaId,
   AuthenticatedRequest,
 } from '../middleware/auth-supabase-jwt';
 import { createClient } from '@supabase/supabase-js';
@@ -48,6 +49,17 @@ router.post('/send', requireAuth, requireTenant, async (req: Request, res: Respo
   }
 
   const supabase = getSupabase();
+
+  // VTID-01967: denormalize sender + receiver vitana_id at insert time so
+  // support engineers and voice tooling can quote @<id> without joining
+  // profiles. Both lookups are cached. Null-tolerant: if either user has
+  // no vitana_id (pre-Release-A signup, or app_users not yet provisioned),
+  // the column stays NULL and downstream code falls back to display_name.
+  const [sender_vitana_id, receiver_vitana_id] = await Promise.all([
+    identity.vitana_id ? Promise.resolve(identity.vitana_id) : resolveVitanaId(identity.user_id),
+    resolveVitanaId(receiver_id),
+  ]);
+
   const { data, error } = await supabase
     .from('chat_messages')
     .insert({
@@ -55,6 +67,8 @@ router.post('/send', requireAuth, requireTenant, async (req: Request, res: Respo
       sender_id: identity.user_id,
       receiver_id,
       content: content.trim(),
+      ...(sender_vitana_id && { sender_vitana_id }),
+      ...(receiver_vitana_id && { receiver_vitana_id }),
     })
     .select()
     .single();

--- a/services/gateway/src/routes/intent-board.ts
+++ b/services/gateway/src/routes/intent-board.ts
@@ -1,0 +1,113 @@
+/**
+ * VTID-01973: Public-facing intent board (P2-A).
+ *
+ * Browse open intents in the actor's tenant, filtered by kind. Defaults
+ * shown depend on the user's active Life Compass goal — a compass-aware
+ * feed without requiring the client to specify a kind. mutual_reveal
+ * kinds are excluded by default; clients can opt in via ?kind=partner_seek
+ * but they'll see redacted cards.
+ *
+ *   GET /api/v1/intent-board?kind=...&category=...
+ */
+
+import { Router, Request, Response } from 'express';
+import { createClient } from '@supabase/supabase-js';
+import {
+  requireAuth,
+  requireTenant,
+  AuthenticatedRequest,
+} from '../middleware/auth-supabase-jwt';
+import { getActiveCompassGoal } from '../services/intent-compass-lens';
+import type { IntentKind } from '../services/intent-classifier';
+
+const router = Router();
+
+function getSupabase() {
+  return createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE!);
+}
+
+// Compass → preferred kinds (for the default feed). Mirrors intent_compass_boost
+// but returns a sorted list. mutual_reveal kinds are excluded from defaults.
+function defaultKindsForCompass(category: string | null): IntentKind[] {
+  switch (category) {
+    case 'earn_money':
+    case 'business':
+      return ['commercial_buy', 'commercial_sell', 'social_seek'];
+    case 'longevity':
+    case 'health':
+      return ['activity_seek', 'social_seek', 'commercial_buy'];
+    case 'family':
+    case 'community':
+      return ['mutual_aid', 'social_seek', 'activity_seek'];
+    case 'career_growth':
+      return ['social_seek', 'commercial_sell', 'commercial_buy'];
+    default:
+      return ['commercial_buy', 'commercial_sell', 'activity_seek', 'social_seek', 'mutual_aid'];
+  }
+}
+
+router.get('/', requireAuth, requireTenant, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const explicitKind = req.query.kind as string | undefined;
+  const category = req.query.category as string | undefined;
+  const limit = Math.min(Number(req.query.limit) || 30, 100);
+
+  const compass = await getActiveCompassGoal(identity.user_id);
+  const kinds = explicitKind
+    ? [explicitKind as IntentKind]
+    : defaultKindsForCompass(compass?.category ?? null);
+
+  const supabase = getSupabase();
+  let q = supabase
+    .from('user_intents')
+    .select('*')
+    .eq('tenant_id', identity.tenant_id)
+    .eq('status', 'open')
+    .in('intent_kind', kinds)
+    .neq('requester_user_id', identity.user_id)  // never show me my own intents on the board
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  // For partner_seek, only return rows whose visibility is mutual_reveal
+  // (they're the only kind allowed there) AND redact scope/title.
+  // For all other kinds, the visibility check is enforced by RLS on the
+  // user_intents table (only public rows surface to non-owners).
+  if (kinds.includes('partner_seek')) {
+    // Only allow partner_seek when explicitly requested via ?kind=partner_seek.
+    if (!explicitKind || explicitKind !== 'partner_seek') {
+      q = q.neq('intent_kind', 'partner_seek');
+    }
+  }
+
+  if (category) q = q.eq('category', category);
+
+  const { data, error } = await q;
+  if (error) return res.status(500).json({ ok: false, error: error.message });
+
+  // Redact partner_seek rows (no scope text on board, just kind + category).
+  const result = (data ?? []).map((row: any) => {
+    if (row.intent_kind === 'partner_seek') {
+      return {
+        intent_id: row.intent_id,
+        intent_kind: row.intent_kind,
+        category: row.category,
+        title: 'Partner-seek (redacted)',
+        scope: 'View redacted card and express interest to start the mutual-reveal protocol.',
+        kind_payload: { age_range: row.kind_payload?.age_range, location_label: row.kind_payload?.location_label },
+        created_at: row.created_at,
+      };
+    }
+    return row;
+  });
+
+  return res.json({
+    ok: true,
+    compass: compass?.category ?? null,
+    kinds_shown: kinds,
+    intents: result,
+  });
+});
+
+export default router;

--- a/services/gateway/src/routes/intent-categories.ts
+++ b/services/gateway/src/routes/intent-categories.ts
@@ -1,0 +1,43 @@
+/**
+ * VTID-01973: Intent categories (P2-A).
+ *
+ * GET /api/v1/intent-categories?kind=<intent_kind>
+ *
+ * Returns the per-kind taxonomy (tree, hierarchical via parent_key).
+ * Cached at edge for 24h via Cache-Control + ETag.
+ */
+
+import { Router, Request, Response } from 'express';
+import { createClient } from '@supabase/supabase-js';
+import { requireAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
+
+const router = Router();
+
+function getSupabase() {
+  return createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE!);
+}
+
+router.get('/', requireAuth, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const kind = req.query.kind as string | undefined;
+  const supabase = getSupabase();
+
+  let q = supabase
+    .from('intent_categories')
+    .select('kind_key, category_key, parent_key, label, sort_order, active')
+    .eq('active', true)
+    .order('kind_key', { ascending: true })
+    .order('sort_order', { ascending: true });
+
+  if (kind) q = q.eq('kind_key', kind);
+
+  const { data, error } = await q;
+  if (error) return res.status(500).json({ ok: false, error: error.message });
+
+  res.set('Cache-Control', 'public, max-age=86400');
+  return res.json({ ok: true, categories: data ?? [] });
+});
+
+export default router;

--- a/services/gateway/src/routes/intent-matches.ts
+++ b/services/gateway/src/routes/intent-matches.ts
@@ -1,0 +1,206 @@
+/**
+ * VTID-01973: Intent matches REST router (P2-A).
+ *
+ *   GET   /api/v1/intent-matches/incoming     — where I'm vitana_id_b
+ *   GET   /api/v1/intent-matches/outgoing     — where I'm vitana_id_a
+ *   POST  /api/v1/intent-matches/:id/state    — lifecycle transition
+ *   POST  /api/v1/intent-matches/:id/decline  — convenience
+ */
+
+import { Router, Request, Response } from 'express';
+import { createClient } from '@supabase/supabase-js';
+import {
+  requireAuth,
+  requireTenant,
+  AuthenticatedRequest,
+} from '../middleware/auth-supabase-jwt';
+import { redactMatchForReader, tryUnlockReveal } from '../services/intent-mutual-reveal';
+import { emitOasisEvent } from '../services/oasis-event-service';
+import type { MatchRow } from '../services/intent-matcher';
+
+const router = Router();
+
+function getSupabase() {
+  return createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE!);
+}
+
+const VALID_TRANSITIONS = new Set([
+  'viewed_by_a', 'viewed_by_b',
+  'responded_by_a', 'responded_by_b',
+  'mutual_interest', 'engaged', 'fulfilled', 'closed', 'declined',
+]);
+
+// ── GET /intent-matches/outgoing (I'm party A) ───────────────
+
+router.get('/outgoing', requireAuth, requireTenant, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const limit = Math.min(Number(req.query.limit) || 50, 200);
+  const supabase = getSupabase();
+
+  // Find intents owned by the reader, then their matches.
+  const { data: myIntents } = await supabase
+    .from('user_intents')
+    .select('intent_id')
+    .eq('requester_user_id', identity.user_id);
+  const myIds = (myIntents ?? []).map((r: any) => r.intent_id as string);
+  if (myIds.length === 0) return res.json({ ok: true, matches: [] });
+
+  const { data, error } = await supabase
+    .from('intent_matches')
+    .select('*')
+    .in('intent_a_id', myIds)
+    .order('score', { ascending: false })
+    .limit(limit);
+  if (error) return res.status(500).json({ ok: false, error: error.message });
+
+  const redacted = await Promise.all(((data ?? []) as MatchRow[]).map(m => redactMatchForReader(m, identity.user_id)));
+  return res.json({ ok: true, matches: redacted });
+});
+
+// ── GET /intent-matches/incoming (I'm party B) ───────────────
+
+router.get('/incoming', requireAuth, requireTenant, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const limit = Math.min(Number(req.query.limit) || 50, 200);
+  const supabase = getSupabase();
+
+  const { data: myIntents } = await supabase
+    .from('user_intents')
+    .select('intent_id')
+    .eq('requester_user_id', identity.user_id);
+  const myIds = (myIntents ?? []).map((r: any) => r.intent_id as string);
+  if (myIds.length === 0) return res.json({ ok: true, matches: [] });
+
+  const { data, error } = await supabase
+    .from('intent_matches')
+    .select('*')
+    .in('intent_b_id', myIds)
+    .order('score', { ascending: false })
+    .limit(limit);
+  if (error) return res.status(500).json({ ok: false, error: error.message });
+
+  const redacted = await Promise.all(((data ?? []) as MatchRow[]).map(m => redactMatchForReader(m, identity.user_id)));
+  return res.json({ ok: true, matches: redacted });
+});
+
+// ── POST /intent-matches/:id/state ───────────────────────────
+
+router.post('/:id/state', requireAuth, requireTenant, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const newState = String(req.body?.state ?? '');
+  if (!VALID_TRANSITIONS.has(newState)) {
+    return res.status(400).json({ ok: false, error: 'invalid_state', allowed: Array.from(VALID_TRANSITIONS) });
+  }
+
+  const supabase = getSupabase();
+  const { data: m } = await supabase
+    .from('intent_matches')
+    .select('match_id, intent_a_id, intent_b_id, state, vitana_id_a, vitana_id_b, kind_pairing')
+    .eq('match_id', req.params.id)
+    .maybeSingle();
+  if (!m) return res.status(404).json({ ok: false, error: 'not_found' });
+
+  // Authorize: reader must own intent_a OR intent_b.
+  const { data: aOwner } = await supabase
+    .from('user_intents').select('requester_user_id').eq('intent_id', (m as any).intent_a_id).maybeSingle();
+  const { data: bOwner } = (m as any).intent_b_id
+    ? await supabase.from('user_intents').select('requester_user_id').eq('intent_id', (m as any).intent_b_id).maybeSingle()
+    : { data: null as any };
+  const isA = aOwner && (aOwner as any).requester_user_id === identity.user_id;
+  const isB = bOwner && (bOwner as any).requester_user_id === identity.user_id;
+  if (!isA && !isB) return res.status(403).json({ ok: false, error: 'not_a_party' });
+
+  // Detect bilateral interest → mutual_interest.
+  let computedNextState = newState;
+  if ((newState === 'responded_by_a' && (m as any).state === 'responded_by_b')
+    || (newState === 'responded_by_b' && (m as any).state === 'responded_by_a')) {
+    computedNextState = 'mutual_interest';
+  }
+
+  const { error } = await supabase
+    .from('intent_matches')
+    .update({ state: computedNextState })
+    .eq('match_id', req.params.id);
+  if (error) return res.status(500).json({ ok: false, error: error.message });
+
+  // If transitioned to mutual_interest, try the reveal protocol.
+  if (computedNextState === 'mutual_interest') {
+    await tryUnlockReveal(req.params.id);
+  }
+
+  await emitOasisEvent({
+    vtid: 'VTID-01973',
+    type: 'voice.message.sent',
+    source: 'intent-matches-route',
+    status: 'info',
+    message: `Match state -> ${computedNextState}`,
+    payload: {
+      match_id: req.params.id,
+      from_state: (m as any).state,
+      to_state: computedNextState,
+      kind_pairing: (m as any).kind_pairing,
+      mutual_unlocked: computedNextState === 'mutual_interest',
+    },
+    actor_id: identity.user_id,
+    actor_role: 'user',
+    surface: 'api',
+    vitana_id: identity.vitana_id ?? undefined,
+  });
+
+  return res.json({ ok: true, state: computedNextState });
+});
+
+// ── POST /intent-matches/:id/decline ─────────────────────────
+
+router.post('/:id/decline', requireAuth, requireTenant, async (req: Request, res: Response) => {
+  // Convenience wrapper around state=declined. Inline the same authorize +
+  // update + audit dance rather than re-routing internally.
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const supabase = getSupabase();
+  const { data: m } = await supabase
+    .from('intent_matches')
+    .select('match_id, intent_a_id, intent_b_id, state, kind_pairing')
+    .eq('match_id', req.params.id)
+    .maybeSingle();
+  if (!m) return res.status(404).json({ ok: false, error: 'not_found' });
+
+  const { data: aOwner } = await supabase
+    .from('user_intents').select('requester_user_id').eq('intent_id', (m as any).intent_a_id).maybeSingle();
+  const { data: bOwner } = (m as any).intent_b_id
+    ? await supabase.from('user_intents').select('requester_user_id').eq('intent_id', (m as any).intent_b_id).maybeSingle()
+    : { data: null as any };
+  const isParty = (aOwner && (aOwner as any).requester_user_id === identity.user_id)
+                || (bOwner && (bOwner as any).requester_user_id === identity.user_id);
+  if (!isParty) return res.status(403).json({ ok: false, error: 'not_a_party' });
+
+  const { error } = await supabase
+    .from('intent_matches')
+    .update({ state: 'declined' })
+    .eq('match_id', req.params.id);
+  if (error) return res.status(500).json({ ok: false, error: error.message });
+
+  await emitOasisEvent({
+    vtid: 'VTID-01973',
+    type: 'voice.message.sent',
+    source: 'intent-matches-route',
+    status: 'info',
+    message: `Match declined`,
+    payload: { match_id: req.params.id, from_state: (m as any).state, kind_pairing: (m as any).kind_pairing },
+    actor_id: identity.user_id,
+    actor_role: 'user',
+    surface: 'api',
+    vitana_id: identity.vitana_id ?? undefined,
+  });
+
+  return res.json({ ok: true, state: 'declined' });
+});
+
+export default router;

--- a/services/gateway/src/routes/intents.ts
+++ b/services/gateway/src/routes/intents.ts
@@ -1,0 +1,331 @@
+/**
+ * VTID-01973: Intents REST router (P2-A).
+ *
+ * Single endpoint for posting any intent_kind. The classifier + extractor
+ * stack runs INSIDE post — clients can either:
+ *   (a) Provide structured fields directly (typed form path), or
+ *   (b) Provide just `utterance` and let the server classify + extract.
+ *
+ * No voice tools yet — those land in P2-B inside orb-live.ts. This route
+ * surface is what the voice tool will eventually call.
+ *
+ *   POST   /api/v1/intents                  — create
+ *   GET    /api/v1/intents                  — list mine (?kind, ?status)
+ *   GET    /api/v1/intents/:id              — read one (visibility-checked)
+ *   PATCH  /api/v1/intents/:id              — update (owner only)
+ *   POST   /api/v1/intents/:id/close        — close (owner only)
+ *   GET    /api/v1/intents/:id/matches      — top matches for this intent
+ */
+
+import { Router, Request, Response } from 'express';
+import { createClient } from '@supabase/supabase-js';
+import {
+  requireAuth,
+  requireTenant,
+  AuthenticatedRequest,
+} from '../middleware/auth-supabase-jwt';
+import { classifyIntentKind, type IntentKind } from '../services/intent-classifier';
+import { extractIntent } from '../services/intent-extractor';
+import { embedIntent } from '../services/intent-embedding';
+import { computeForIntent, surfaceTopMatches } from '../services/intent-matcher';
+import { checkIntentContent } from '../services/intent-content-filter';
+import { canPostIntent } from '../services/intent-throttle';
+import { gateCommercialBudget } from '../services/intent-tier-gate';
+import { redactMatchForReader } from '../services/intent-mutual-reveal';
+import { notifyMatchSurfaced } from '../services/intent-notifier';
+import { getActiveCompassGoal } from '../services/intent-compass-lens';
+import { emitOasisEvent } from '../services/oasis-event-service';
+
+const router = Router();
+
+function getSupabase() {
+  return createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE!);
+}
+
+const VALID_KINDS: IntentKind[] = [
+  'commercial_buy', 'commercial_sell', 'activity_seek',
+  'partner_seek', 'social_seek', 'mutual_aid',
+];
+
+// ── POST /intents ────────────────────────────────────────────
+
+router.post('/', requireAuth, requireTenant, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const body = req.body ?? {};
+  let intentKind: IntentKind | null = body.intent_kind ?? null;
+  let category: string | null = body.category ?? null;
+  let title: string | null = body.title ?? null;
+  let scope: string | null = body.scope ?? null;
+  let kindPayload: Record<string, unknown> = body.kind_payload ?? {};
+  let visibility: string | null = body.visibility ?? null;
+
+  // Path B: utterance-only — run classifier + extractor.
+  if (body.utterance && (!intentKind || !title || !scope)) {
+    const utterance = String(body.utterance);
+    if (!intentKind) {
+      const cls = await classifyIntentKind(utterance);
+      if (!cls.intent_kind || cls.confidence < 0.7) {
+        return res.status(400).json({
+          ok: false,
+          error: 'CLASSIFY_LOW_CONFIDENCE',
+          message: 'Could not confidently classify the utterance. Provide intent_kind explicitly or rephrase.',
+          classifier_confidence: cls.confidence,
+        });
+      }
+      intentKind = cls.intent_kind;
+    }
+    if (!title || !scope) {
+      const extract = await extractIntent(utterance, intentKind);
+      title = title ?? extract.title;
+      scope = scope ?? extract.scope;
+      category = category ?? extract.category;
+      kindPayload = { ...extract.kind_payload, ...kindPayload };
+      if (extract.missing_critical.length > 0 && extract.confidence < 0.8) {
+        return res.status(422).json({
+          ok: false,
+          error: 'EXTRACT_INCOMPLETE',
+          message: 'Single-shot extraction missed required fields. Provide them or fall back to slot-fill.',
+          missing_critical: extract.missing_critical,
+          extract_confidence: extract.confidence,
+        });
+      }
+    }
+  }
+
+  // Validation.
+  if (!intentKind || !VALID_KINDS.includes(intentKind)) {
+    return res.status(400).json({ ok: false, error: 'invalid intent_kind' });
+  }
+  if (!title || title.length < 3 || title.length > 140) {
+    return res.status(400).json({ ok: false, error: 'title must be 3-140 chars' });
+  }
+  if (!scope || scope.length < 20 || scope.length > 1500) {
+    return res.status(400).json({ ok: false, error: 'scope must be 20-1500 chars' });
+  }
+
+  // Content filter.
+  const cf = checkIntentContent({ kind: intentKind, title, scope });
+  if (!cf.ok) {
+    await emitOasisEvent({
+      vtid: 'VTID-01973',
+      type: 'voice.message.sent',
+      source: 'intents-route',
+      status: 'warning',
+      message: 'Intent post blocked by content filter',
+      payload: { reasons: cf.reasons, kind: intentKind },
+      actor_id: identity.user_id,
+      actor_role: 'user',
+      surface: 'api',
+      vitana_id: identity.vitana_id ?? undefined,
+    });
+    return res.status(422).json({ ok: false, error: 'CONTENT_FILTER_BLOCKED', reasons: cf.reasons });
+  }
+
+  // Throttle.
+  const budgetMax = (kindPayload?.budget_max ?? null) as number | null;
+  const throttle = await canPostIntent({
+    userId: identity.user_id,
+    kind: intentKind,
+    budgetMaxEur: typeof budgetMax === 'number' ? budgetMax : null,
+  });
+  if (!throttle.ok) {
+    return res.status(429).json({ ok: false, error: throttle.reason, message: throttle.detail });
+  }
+
+  // Tier gate (commercial only).
+  if ((intentKind === 'commercial_buy' || intentKind === 'commercial_sell') && typeof budgetMax === 'number') {
+    const gate = await gateCommercialBudget(identity.user_id, budgetMax);
+    if (!gate.ok) {
+      return res.status(403).json({ ok: false, error: 'TIER_REQUIRED', tier: gate.tier, required: gate.required, message: gate.reason });
+    }
+  }
+
+  // Snapshot the user's active compass at post time (for telemetry).
+  const compass = await getActiveCompassGoal(identity.user_id);
+
+  const supabase = getSupabase();
+  const { data: inserted, error: insErr } = await supabase
+    .from('user_intents')
+    .insert({
+      requester_user_id: identity.user_id,
+      tenant_id: identity.tenant_id,
+      intent_kind: intentKind,
+      category,
+      title,
+      scope,
+      kind_payload: kindPayload,
+      visibility: visibility ?? undefined,
+      compass_alignment_at_post: compass?.category ?? null,
+      status: 'open',
+    })
+    .select('intent_id, requester_vitana_id')
+    .single();
+
+  if (insErr || !inserted) {
+    console.error('[VTID-01973] intents POST insert failed', insErr);
+    return res.status(500).json({ ok: false, error: insErr?.message ?? 'insert_failed' });
+  }
+
+  // Embed (inline; P2-C moves to a worker).
+  const embedding = await embedIntent({ intent_kind: intentKind, category, title, scope, kind_payload: kindPayload });
+  if (embedding) {
+    await supabase.from('user_intents').update({ embedding: embedding as any }).eq('intent_id', (inserted as any).intent_id);
+  }
+
+  // Compute matches now (best-effort; daily recompute catches misses).
+  let matchCount = 0;
+  try {
+    matchCount = await computeForIntent((inserted as any).intent_id);
+    if (matchCount > 0) {
+      const top = await surfaceTopMatches((inserted as any).intent_id, 5);
+      // Audit each surfaced match (P2-A: no push — that's P2-B).
+      for (const m of top) {
+        await notifyMatchSurfaced({ match: m, kind: intentKind });
+      }
+    }
+  } catch (err: any) {
+    console.warn(`[VTID-01973] post-insert match compute failed: ${err.message}`);
+  }
+
+  await emitOasisEvent({
+    vtid: 'VTID-01973',
+    type: 'voice.message.sent',
+    source: 'intents-route',
+    status: 'success',
+    message: `Intent posted: ${intentKind}`,
+    payload: {
+      intent_id: (inserted as any).intent_id,
+      intent_kind: intentKind,
+      category,
+      match_count: matchCount,
+      compass_alignment_at_post: compass?.category ?? null,
+    },
+    actor_id: identity.user_id,
+    actor_role: 'user',
+    surface: 'api',
+    vitana_id: identity.vitana_id ?? undefined,
+  });
+
+  return res.status(201).json({
+    ok: true,
+    intent_id: (inserted as any).intent_id,
+    requester_vitana_id: (inserted as any).requester_vitana_id,
+    match_count: matchCount,
+  });
+});
+
+// ── GET /intents (mine) ──────────────────────────────────────
+
+router.get('/', requireAuth, requireTenant, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const kind = req.query.kind as string | undefined;
+  const status = req.query.status as string | undefined;
+  const limit = Math.min(Number(req.query.limit) || 20, 100);
+
+  const supabase = getSupabase();
+  let q = supabase
+    .from('user_intents')
+    .select('*')
+    .eq('requester_user_id', identity.user_id)
+    .order('created_at', { ascending: false })
+    .limit(limit);
+  if (kind) q = q.eq('intent_kind', kind);
+  if (status) q = q.eq('status', status);
+
+  const { data, error } = await q;
+  if (error) return res.status(500).json({ ok: false, error: error.message });
+  return res.json({ ok: true, intents: data ?? [] });
+});
+
+// ── GET /intents/:id ─────────────────────────────────────────
+
+router.get('/:id', requireAuth, requireTenant, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const supabase = getSupabase();
+  const { data: ok } = await supabase.rpc('can_read_intent', {
+    p_reader: identity.user_id,
+    p_intent_id: req.params.id,
+  });
+  if (!ok) return res.status(404).json({ ok: false, error: 'not_found' });
+
+  const { data, error } = await supabase
+    .from('user_intents')
+    .select('*')
+    .eq('intent_id', req.params.id)
+    .maybeSingle();
+  if (error) return res.status(500).json({ ok: false, error: error.message });
+  if (!data) return res.status(404).json({ ok: false, error: 'not_found' });
+  return res.json({ ok: true, intent: data });
+});
+
+// ── PATCH /intents/:id (owner only — partial update) ─────────
+
+router.patch('/:id', requireAuth, requireTenant, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const allowed = ['title', 'scope', 'kind_payload', 'category', 'status', 'visibility'];
+  const patch: Record<string, unknown> = {};
+  for (const k of allowed) {
+    if (req.body && k in req.body) patch[k] = req.body[k];
+  }
+  if (Object.keys(patch).length === 0) return res.status(400).json({ ok: false, error: 'no fields' });
+
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from('user_intents')
+    .update(patch as any)
+    .eq('intent_id', req.params.id)
+    .eq('requester_user_id', identity.user_id)
+    .select('*')
+    .maybeSingle();
+  if (error) return res.status(500).json({ ok: false, error: error.message });
+  if (!data) return res.status(404).json({ ok: false, error: 'not_found_or_not_owner' });
+  return res.json({ ok: true, intent: data });
+});
+
+// ── POST /intents/:id/close ──────────────────────────────────
+
+router.post('/:id/close', requireAuth, requireTenant, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from('user_intents')
+    .update({ status: 'closed' })
+    .eq('intent_id', req.params.id)
+    .eq('requester_user_id', identity.user_id)
+    .select('*')
+    .maybeSingle();
+  if (error) return res.status(500).json({ ok: false, error: error.message });
+  if (!data) return res.status(404).json({ ok: false, error: 'not_found_or_not_owner' });
+  return res.json({ ok: true, intent: data });
+});
+
+// ── GET /intents/:id/matches ─────────────────────────────────
+
+router.get('/:id/matches', requireAuth, requireTenant, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const supabase = getSupabase();
+  const { data: canRead } = await supabase.rpc('can_read_intent', {
+    p_reader: identity.user_id,
+    p_intent_id: req.params.id,
+  });
+  if (!canRead) return res.status(404).json({ ok: false, error: 'not_found' });
+
+  const matches = await surfaceTopMatches(req.params.id, Math.min(Number(req.query.limit) || 5, 20));
+  // Apply mutual-reveal redaction.
+  const redacted = await Promise.all(matches.map(m => redactMatchForReader(m, identity.user_id)));
+  return res.json({ ok: true, matches: redacted });
+});
+
+export default router;

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -2109,6 +2109,136 @@ function buildLiveApiTools(mode: 'anonymous' | 'authenticated' = 'authenticated'
             required: ['topic'],
           },
         },
+        // ─── VTID-01967 — Vitana ID voice messaging ───
+        // Three tools that let the user say "send a message to alex3700"
+        // or "share this link with maria2307" and have ORB resolve the
+        // recipient, confirm verbally, and send. These tools enforce a
+        // strict confirmation contract: ALWAYS resolve first, ALWAYS
+        // read back, ONLY send on explicit verbal confirmation.
+        {
+          name: 'resolve_recipient',
+          description: [
+            'Resolve a spoken recipient name or Vitana ID to a real user.',
+            'Call this FIRST any time the user says "send a message to X",',
+            '"text X", "share this with X", "tell X that ...", "invite X",',
+            'or any other phrase where X is meant to be another Vitana user.',
+            '',
+            'Returns ranked candidates. Each has:',
+            '  - user_id (opaque UUID — pass to send_chat_message / share_link)',
+            '  - vitana_id (speakable, e.g. "alex3700" — read this to the user)',
+            '  - display_name (their full name)',
+            '  - score (0.00-1.10; 1.0 = exact vitana_id match)',
+            '  - reason ("vitana_id_exact" | "legacy_handle" | "fuzzy_name")',
+            '',
+            'Also returns top_confidence and ambiguous (boolean).',
+            '',
+            'BEHAVIOR:',
+            '  1. If candidates is empty: tell the user you couldn\'t find',
+            '     anyone matching that name and ask them to repeat or spell',
+            '     the Vitana ID.',
+            '  2. If ambiguous=false AND top_confidence >= 0.85 AND only ONE',
+            '     candidate: silently pick candidates[0] and proceed to step 4.',
+            '  3. If ambiguous=true OR multiple candidates: read up to 3',
+            '     options to the user — "I see {N} matches: @<vid1>',
+            '     ({display_name1}), @<vid2> ({display_name2}). Which one?"',
+            '     Wait for them to pick by Vitana ID, by name, or by',
+            '     position ("the first one", "Daniela Müller").',
+            '  4. After a recipient is chosen, NEVER call send_chat_message',
+            '     or share_link directly — first read the message back to',
+            '     the user verbatim and ask "say send to confirm or cancel',
+            '     to stop". Only on explicit confirmation, call the send',
+            '     tool.',
+            '',
+            'NEVER resolve to the user\'s own ID — the resolver excludes self.',
+            'NEVER skip this step before sending; the send tools assume a',
+            'pre-resolved user_id from this call.',
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              spoken_name: {
+                type: 'string',
+                description: 'The recipient name / Vitana ID exactly as the user said it. Examples: "Daniela", "alex3700", "@alex3700", "Branislav". Strip leading @ if present (the resolver normalizes).',
+              },
+              limit: {
+                type: 'integer',
+                description: 'Maximum candidates to return (default 5). Keep low for voice — 3 is plenty.',
+              },
+            },
+            required: ['spoken_name'],
+          },
+        },
+        {
+          name: 'send_chat_message',
+          description: [
+            'Send a direct message to another Vitana user. ONLY call this',
+            'after resolve_recipient has returned a candidate AND the user',
+            'has verbally confirmed both the recipient AND the message body',
+            '(e.g. "yes send it", "send", "confirm", "ja schick es").',
+            '',
+            'NEVER call this without resolve_recipient first.',
+            'NEVER auto-fire on "I want to message X" — always read back and wait.',
+            '',
+            'After a successful send, acknowledge briefly: "Sent to @<vid>."',
+            'If the response says rate_limited, tell the user: "I can\'t send',
+            'any more messages this session — please open the app to continue."',
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              recipient_user_id: {
+                type: 'string',
+                description: 'Opaque user_id from resolve_recipient candidates[i].user_id. Never derive this any other way.',
+              },
+              recipient_label: {
+                type: 'string',
+                description: 'The vitana_id of the recipient, used in the OASIS audit trail and acknowledgement (e.g. "alex3700"). Pass candidates[i].vitana_id verbatim.',
+              },
+              body: {
+                type: 'string',
+                description: 'The message body, exactly as the user dictated it. Do not rephrase or summarize.',
+              },
+            },
+            required: ['recipient_user_id', 'recipient_label', 'body'],
+          },
+        },
+        {
+          name: 'share_link',
+          description: [
+            'Share a link with another Vitana user as a chat message with a',
+            'link-card preview. Same confirmation contract as send_chat_message:',
+            'ALWAYS resolve_recipient first, ALWAYS read back the link target',
+            'and recipient, ONLY send on explicit confirmation.',
+            '',
+            'Use this when the user says "share this with X", "send the page',
+            'to X", "invite X to this", or similar. If the user is on a',
+            'specific screen, call get_current_screen first to learn the',
+            'target_url and target_kind ("event", "post", "profile", etc.),',
+            'then read both back to the user before sending.',
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              recipient_user_id: {
+                type: 'string',
+                description: 'Opaque user_id from resolve_recipient candidates[i].user_id.',
+              },
+              recipient_label: {
+                type: 'string',
+                description: 'Recipient vitana_id (e.g. "alex3700").',
+              },
+              target_url: {
+                type: 'string',
+                description: 'Full URL of the resource to share (e.g. https://vitanaland.com/events/abc).',
+              },
+              target_kind: {
+                type: 'string',
+                description: 'What is being shared. Examples: "event", "meetup", "post", "profile", "product", "campaign", "page".',
+              },
+            },
+            required: ['recipient_user_id', 'recipient_label', 'target_url', 'target_kind'],
+          },
+        },
       ],
     },
     // VTID-GOOGLE-SEARCH: Native Google Search grounding. Gemini calls
@@ -4164,6 +4294,198 @@ async function executeLiveApiToolInner(
           };
         } catch (err: any) {
           console.error('[explain_feature] error:', err?.message);
+          return { success: false, result: '', error: err?.message || 'unknown' };
+        }
+      }
+
+      // ─── VTID-01967 — Vitana ID voice messaging ───
+      case 'resolve_recipient': {
+        const spoken = String(args.spoken_name || '').trim();
+        const limit = Math.min(Math.max(Number(args.limit) || 5, 1), 10);
+        if (!spoken) {
+          return { success: false, result: '', error: 'spoken_name is required' };
+        }
+        try {
+          const { createClient } = await import('@supabase/supabase-js');
+          const supabase = createClient(
+            process.env.SUPABASE_URL!,
+            process.env.SUPABASE_SERVICE_ROLE!,
+          );
+          const { data, error } = await supabase.rpc('resolve_recipient_candidates', {
+            p_actor: session.identity.user_id,
+            p_token: spoken,
+            p_limit: limit,
+            p_global: false,
+          });
+          if (error) {
+            console.error('[VTID-01967] resolve_recipient RPC error:', error.message);
+            return { success: false, result: '', error: error.message };
+          }
+          const candidates = (data || []) as Array<{
+            user_id: string;
+            vitana_id: string | null;
+            display_name: string | null;
+            score: number;
+            reason: string;
+          }>;
+          const top_confidence = candidates.length > 0 ? Number(candidates[0].score) : 0;
+          const ambiguous =
+            candidates.length === 0 ||
+            top_confidence < 0.85 ||
+            (candidates.length > 1 && Number(candidates[1].score) / Math.max(top_confidence, 0.0001) > 0.85);
+          return {
+            success: true,
+            result: JSON.stringify({
+              candidates,
+              top_confidence,
+              ambiguous,
+            }),
+          };
+        } catch (err: any) {
+          console.error('[VTID-01967] resolve_recipient error:', err?.message);
+          return { success: false, result: '', error: err?.message || 'unknown' };
+        }
+      }
+
+      case 'send_chat_message': {
+        const recipientUserId = String(args.recipient_user_id || '').trim();
+        const recipientLabel = String(args.recipient_label || '').trim();
+        const body = String(args.body || '').trim();
+        if (!recipientUserId || !body) {
+          return { success: false, result: '', error: 'recipient_user_id and body are required' };
+        }
+        if (recipientUserId === session.identity.user_id) {
+          return { success: false, result: '', error: 'cannot message yourself' };
+        }
+        try {
+          const { checkVoiceSendQuota } = await import('../services/voice-message-guard');
+          const { resolveVitanaId } = await import('../middleware/auth-supabase-jwt');
+          const recipientVitanaId = await resolveVitanaId(recipientUserId);
+          const quota = await checkVoiceSendQuota({
+            session_id: session.sessionId,
+            actor_id: session.identity.user_id,
+            vitana_id: session.identity.vitana_id,
+            recipient_user_id: recipientUserId,
+            recipient_vitana_id: recipientVitanaId,
+            kind: 'message',
+            body_length: body.length,
+          });
+          if (!quota.allowed) {
+            return {
+              success: true,
+              result: JSON.stringify({ ok: false, rate_limited: true, reason: quota.reason }),
+            };
+          }
+          const { createClient } = await import('@supabase/supabase-js');
+          const supabase = createClient(
+            process.env.SUPABASE_URL!,
+            process.env.SUPABASE_SERVICE_ROLE!,
+          );
+          const senderVitanaId = session.identity.vitana_id || (await resolveVitanaId(session.identity.user_id));
+          const { error: insErr } = await supabase
+            .from('chat_messages')
+            .insert({
+              tenant_id: session.identity.tenant_id,
+              sender_id: session.identity.user_id,
+              receiver_id: recipientUserId,
+              content: body,
+              ...(senderVitanaId && { sender_vitana_id: senderVitanaId }),
+              ...(recipientVitanaId && { receiver_vitana_id: recipientVitanaId }),
+              metadata: {
+                source: 'voice',
+                session_id: session.sessionId,
+                recipient_label: recipientLabel || recipientVitanaId,
+              },
+            });
+          if (insErr) {
+            console.error('[VTID-01967] send_chat_message insert error:', insErr.message);
+            return { success: false, result: '', error: insErr.message };
+          }
+          return {
+            success: true,
+            result: JSON.stringify({
+              ok: true,
+              recipient_label: recipientLabel || recipientVitanaId || recipientUserId,
+              remaining: quota.remaining,
+            }),
+          };
+        } catch (err: any) {
+          console.error('[VTID-01967] send_chat_message error:', err?.message);
+          return { success: false, result: '', error: err?.message || 'unknown' };
+        }
+      }
+
+      case 'share_link': {
+        const recipientUserId = String(args.recipient_user_id || '').trim();
+        const recipientLabel = String(args.recipient_label || '').trim();
+        const targetUrl = String(args.target_url || '').trim();
+        const targetKind = String(args.target_kind || 'page').trim();
+        if (!recipientUserId || !targetUrl) {
+          return { success: false, result: '', error: 'recipient_user_id and target_url are required' };
+        }
+        if (recipientUserId === session.identity.user_id) {
+          return { success: false, result: '', error: 'cannot share with yourself' };
+        }
+        try {
+          const { checkVoiceSendQuota } = await import('../services/voice-message-guard');
+          const { resolveVitanaId } = await import('../middleware/auth-supabase-jwt');
+          const recipientVitanaId = await resolveVitanaId(recipientUserId);
+          const quota = await checkVoiceSendQuota({
+            session_id: session.sessionId,
+            actor_id: session.identity.user_id,
+            vitana_id: session.identity.vitana_id,
+            recipient_user_id: recipientUserId,
+            recipient_vitana_id: recipientVitanaId,
+            kind: 'share_link',
+            target_url: targetUrl,
+          });
+          if (!quota.allowed) {
+            return {
+              success: true,
+              result: JSON.stringify({ ok: false, rate_limited: true, reason: quota.reason }),
+            };
+          }
+          const { createClient } = await import('@supabase/supabase-js');
+          const supabase = createClient(
+            process.env.SUPABASE_URL!,
+            process.env.SUPABASE_SERVICE_ROLE!,
+          );
+          const senderVitanaId = session.identity.vitana_id || (await resolveVitanaId(session.identity.user_id));
+          const previewBody = `🔗 ${targetUrl}`;
+          const { error: insErr } = await supabase
+            .from('chat_messages')
+            .insert({
+              tenant_id: session.identity.tenant_id,
+              sender_id: session.identity.user_id,
+              receiver_id: recipientUserId,
+              content: previewBody,
+              message_type: 'link_share',
+              ...(senderVitanaId && { sender_vitana_id: senderVitanaId }),
+              ...(recipientVitanaId && { receiver_vitana_id: recipientVitanaId }),
+              metadata: {
+                source: 'voice',
+                session_id: session.sessionId,
+                kind: 'shared_link',
+                target_url: targetUrl,
+                target_kind: targetKind,
+                recipient_label: recipientLabel || recipientVitanaId,
+              },
+            });
+          if (insErr) {
+            console.error('[VTID-01967] share_link insert error:', insErr.message);
+            return { success: false, result: '', error: insErr.message };
+          }
+          return {
+            success: true,
+            result: JSON.stringify({
+              ok: true,
+              recipient_label: recipientLabel || recipientVitanaId || recipientUserId,
+              target_kind: targetKind,
+              remaining: quota.remaining,
+            }),
+          };
+        } catch (err: any) {
+          console.error('[VTID-01967] share_link error:', err?.message);
           return { success: false, result: '', error: err?.message || 'unknown' };
         }
       }

--- a/services/gateway/src/routes/self-healing.ts
+++ b/services/gateway/src/routes/self-healing.ts
@@ -648,9 +648,14 @@ router.get('/pending-approval', async (req: Request, res: Response) => {
 
     const limit = Math.min(parseInt(req.query.limit as string) || 100, 200);
 
+    // dev_autopilot_self_heal_in_progress is written by dev-autopilot-bridge
+    // when it AUTO-spawns a child execution to retry. Outcome is 'pending'
+    // because the retry is in flight, but no human input is requested or
+    // useful — those rows belong on the Active Repairs view, not here.
     const resp = await fetch(
       `${SUPABASE_URL}/rest/v1/self_healing_log?` +
         `outcome=eq.pending&confidence=lt.0.8` +
+        `&failure_class=neq.dev_autopilot_self_heal_in_progress` +
         `&select=id,vtid,endpoint,failure_class,confidence,diagnosis,created_at,attempt_number` +
         `&order=created_at.desc&limit=${limit}`,
       { headers: supabaseHeaders() },
@@ -711,29 +716,38 @@ router.post('/approve', async (req: Request, res: Response) => {
     const logRow = logBody[0];
     const vtid = logRow.vtid;
 
-    // 2. Read the vtid_ledger row to get title + spec
-    const ledgerResp = await fetch(
-      `${SUPABASE_URL}/rest/v1/vtid_ledger?vtid=eq.${vtid}&select=vtid,title,summary&limit=1`,
-      { headers: supabaseHeaders() },
-    );
-    if (!ledgerResp.ok) {
-      const errText = await ledgerResp.text().catch(() => '');
-      return res.status(500).json({ ok: false, error: `vtid_ledger query failed: ${errText.slice(0, 200)}` });
-    }
-    const ledgerBody = await ledgerResp.json();
-    if (!Array.isArray(ledgerBody) || ledgerBody.length === 0) {
-      return res.status(404).json({ ok: false, error: `vtid_ledger row ${vtid} not found` });
-    }
-    const ledgerRow = ledgerBody[0];
+    // Real ledger VTIDs match `VTID-<digits>`. Dev-autopilot synthetic
+    // correlation IDs (`VTID-DA-<exec>`, `VTID-DA-FIND-<finding>`) have
+    // no vtid_ledger row by design — see dev-autopilot-self-heal-log.ts.
+    // For those, the standard execution_approved → autopilot event loop
+    // path can't dispatch (no ledger row to read), so we mark the log
+    // row approved and emit a self-healing.approved signal instead.
+    const isLedgerVtid = /^VTID-\d+$/.test(vtid);
 
-    // 3. Mark spec approved in vtid_ledger
-    await fetch(`${SUPABASE_URL}/rest/v1/vtid_ledger?vtid=eq.${vtid}`, {
-      method: 'PATCH',
-      headers: supabaseHeaders(),
-      body: JSON.stringify({ spec_status: 'approved', updated_at: new Date().toISOString() }),
-    });
+    if (isLedgerVtid) {
+      // 2. Read the vtid_ledger row to confirm it exists.
+      const ledgerResp = await fetch(
+        `${SUPABASE_URL}/rest/v1/vtid_ledger?vtid=eq.${vtid}&select=vtid,title,summary&limit=1`,
+        { headers: supabaseHeaders() },
+      );
+      if (!ledgerResp.ok) {
+        const errText = await ledgerResp.text().catch(() => '');
+        return res.status(500).json({ ok: false, error: `vtid_ledger query failed: ${errText.slice(0, 200)}` });
+      }
+      const ledgerBody = await ledgerResp.json();
+      if (!Array.isArray(ledgerBody) || ledgerBody.length === 0) {
+        return res.status(404).json({ ok: false, error: `vtid_ledger row ${vtid} not found` });
+      }
 
-    // 4. Mark self_healing_log row as human-approved
+      // 3. Mark spec approved in vtid_ledger.
+      await fetch(`${SUPABASE_URL}/rest/v1/vtid_ledger?vtid=eq.${vtid}`, {
+        method: 'PATCH',
+        headers: supabaseHeaders(),
+        body: JSON.stringify({ spec_status: 'approved', updated_at: new Date().toISOString() }),
+      });
+    }
+
+    // 4. Mark self_healing_log row as human-approved.
     const newDiagnosis = {
       ...(logRow.diagnosis || {}),
       human_decision: 'approved',
@@ -746,12 +760,14 @@ router.post('/approve', async (req: Request, res: Response) => {
       body: JSON.stringify({ diagnosis: newDiagnosis }),
     });
 
-    // 5. Emit execution_approved OASIS event — the autopilot event loop
-    // picks this up and dispatches through the standard pipeline (worker
-    // orchestrator → worker-runner), just like any other approved task.
-    // NO direct dispatch — same path as every other task.
+    // 5. Emit the appropriate approval event.
+    //   - Ledger VTIDs: vtid.lifecycle.execution_approved so the autopilot
+    //     event loop dispatches through the standard worker pipeline.
+    //   - Synthetic VTIDs: self-healing.approved as a record-only signal
+    //     (the dev-autopilot bridge owns the real retry path; this just
+    //     clears the row from the human queue and leaves an audit trail).
     await emitOasisEvent({
-      type: 'vtid.lifecycle.execution_approved',
+      type: isLedgerVtid ? 'vtid.lifecycle.execution_approved' : 'self-healing.approved',
       vtid,
       source: 'self-healing',
       status: 'info',
@@ -761,6 +777,7 @@ router.post('/approve', async (req: Request, res: Response) => {
         source: 'self-healing',
         operator: operator || 'command-hub',
         confidence: logRow.confidence,
+        synthetic_vtid: !isLedgerVtid,
       },
     });
 

--- a/services/gateway/src/routes/triage-agent.ts
+++ b/services/gateway/src/routes/triage-agent.ts
@@ -311,14 +311,22 @@ triageAgentRouter.get('/:sessionId/stream', async (req: Request, res: Response) 
             break;
 
           case 'agent.custom_tool_use': {
-            // Handle query_oasis_events — execute with our Supabase creds
+            // The Anthropic event uses `name` (not `tool_name`); fall back to
+            // `tool_name` defensively in case a future API rev renames it.
+            const toolName: string | undefined = event.name || event.tool_name;
+
+            // Handle query_oasis_events — execute with our Supabase creds.
+            // Forward to the browser AND keep the legacy `tool_name` key in
+            // the SSE payload for backwards compat with the existing UI;
+            // also expose `name` so future UI code can match the API field.
             sendSSE('agent.custom_tool_use', {
               id: event.id,
-              tool_name: event.tool_name,
+              name: toolName,
+              tool_name: toolName,
               input: event.input,
             });
 
-            if (event.tool_name === 'query_oasis_events') {
+            if (toolName === 'query_oasis_events') {
               const oasisResult = await queryOasisEvents(
                 event.input?.session_id || '',
                 event.input?.limit || 100

--- a/services/gateway/src/routes/triage-agent.ts
+++ b/services/gateway/src/routes/triage-agent.ts
@@ -258,14 +258,19 @@ triageAgentRouter.get('/:sessionId/stream', async (req: Request, res: Response) 
   try {
     // Poll events from the Managed Agents session and forward to the browser.
     // Also handle custom tool calls (query_oasis_events).
+    //
+    // The Anthropic events list endpoint does NOT support an after-cursor
+    // query param — valid params are `limit`, `order`, `page` (per
+    // managed-agents-2026-04-01). We fetch up to the page max each poll and
+    // dedupe by event ID via `seenIds`. A triage session is expected to
+    // produce well under 1000 events, so a single page is sufficient. If we
+    // ever hit the cap, switch to cursor pagination via `page`.
     let done = false;
-    let lastEventId: string | undefined;
     const seenIds = new Set<string>();
 
     while (!done) {
-      // Fetch events
       const eventsResult = await anthropicRequest<any>(
-        `/v1/sessions/${sessionId}/events${lastEventId ? `?after_id=${lastEventId}` : ''}`
+        `/v1/sessions/${sessionId}/events?limit=1000&order=asc`,
       );
 
       if (!eventsResult.ok || !eventsResult.data) {
@@ -278,7 +283,6 @@ triageAgentRouter.get('/:sessionId/stream', async (req: Request, res: Response) 
       for (const event of events) {
         if (seenIds.has(event.id)) continue;
         seenIds.add(event.id);
-        lastEventId = event.id;
 
         // Forward relevant events to the browser
         switch (event.type) {

--- a/services/gateway/src/routes/users-resolve.ts
+++ b/services/gateway/src/routes/users-resolve.ts
@@ -1,0 +1,83 @@
+/**
+ * VTID-01967: POST /api/v1/users/resolve
+ *
+ * Voice-resolver primitive. Given a spoken-name token, returns ranked
+ * candidates from `resolve_recipient_candidates()` (peer-scoped to the
+ * actor's tenant). The ORB voice tool `resolve_recipient` calls this; the
+ * frontend MessageComposeModal also uses it as a typeahead source.
+ *
+ * Body: { token: string, limit?: number }
+ * Returns: { candidates, top_confidence, ambiguous }
+ *   ambiguous = top_confidence < 0.85 OR (second_score / top_score) > 0.85
+ */
+
+import { Router, Request, Response } from 'express';
+import {
+  requireAuth,
+  requireTenant,
+  AuthenticatedRequest,
+} from '../middleware/auth-supabase-jwt';
+import { createClient } from '@supabase/supabase-js';
+
+const router = Router();
+
+function getSupabase() {
+  return createClient(
+    process.env.SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE!
+  );
+}
+
+const AMBIGUITY_THRESHOLD = 0.85; // top score must clear this; otherwise ask user
+const TIE_RATIO_THRESHOLD = 0.85; // if second/first > this, it's a tie
+
+router.post('/resolve', requireAuth, requireTenant, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const { token, limit } = req.body ?? {};
+
+  if (!token || typeof token !== 'string' || token.trim().length === 0) {
+    return res.status(400).json({ ok: false, error: 'token is required' });
+  }
+
+  const limitInt = Math.min(Math.max(Number(limit) || 5, 1), 20);
+
+  const supabase = getSupabase();
+  const { data, error } = await supabase.rpc('resolve_recipient_candidates', {
+    p_actor: identity.user_id,
+    p_token: token,
+    p_limit: limitInt,
+    p_global: false,
+  });
+
+  if (error) {
+    console.error('[VTID-01967] users/resolve RPC error:', error);
+    return res.status(500).json({ ok: false, error: error.message });
+  }
+
+  const candidates = (data || []) as Array<{
+    user_id: string;
+    vitana_id: string | null;
+    display_name: string | null;
+    avatar_url: string | null;
+    score: number;
+    reason: string;
+  }>;
+
+  const top_confidence = candidates.length > 0 ? Number(candidates[0].score) : 0;
+  const ambiguous =
+    candidates.length === 0 ||
+    top_confidence < AMBIGUITY_THRESHOLD ||
+    (candidates.length > 1 &&
+      Number(candidates[1].score) / Math.max(top_confidence, 0.0001) > TIE_RATIO_THRESHOLD);
+
+  return res.json({
+    ok: true,
+    candidates,
+    top_confidence,
+    ambiguous,
+  });
+});
+
+export default router;

--- a/services/gateway/src/routes/users-vitana-id.ts
+++ b/services/gateway/src/routes/users-vitana-id.ts
@@ -1,0 +1,252 @@
+/**
+ * VTID-01967: Vitana ID onboarding pick endpoints.
+ *
+ *   GET  /api/v1/users/me/vitana-id/suggestion
+ *        Returns 3 fresh suggestions from generate_vitana_id_suggestion().
+ *
+ *   POST /api/v1/users/me/vitana-id/confirm   body: { vitana_id }
+ *        ONE-SHOT — only callable when profiles.vitana_id_locked = false.
+ *        On success: writes previous auto-generated value to handle_aliases,
+ *        updates vitana_id (and the legacy handle mirror) to the new value,
+ *        sets vitana_id_locked = true. After lock: 409 Conflict on every
+ *        subsequent call. Mutability is permanent — there is intentionally
+ *        no PATCH endpoint after this.
+ */
+
+import { Router, Request, Response } from 'express';
+import {
+  requireAuth,
+  invalidateVitanaIdCache,
+  AuthenticatedRequest,
+} from '../middleware/auth-supabase-jwt';
+import { createClient } from '@supabase/supabase-js';
+import { emitOasisEvent } from '../services/oasis-event-service';
+
+const router = Router();
+
+function getSupabase() {
+  return createClient(
+    process.env.SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE!
+  );
+}
+
+const VITANA_ID_REGEX = /^[a-z][a-z0-9]{3,11}$/;
+const MIN_LETTERS = 2;
+const MIN_DIGITS = 2;
+
+// ── GET /me/vitana-id/suggestion ──────────────────────────────
+
+router.get('/me/vitana-id/suggestion', requireAuth, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const supabase = getSupabase();
+
+  // Fetch the user's display_name + email for the generator. (full_name in
+  // profiles is the user-friendly name; falls back to email prefix.)
+  const { data: profileRow } = await supabase
+    .from('profiles')
+    .select('display_name, full_name, email, vitana_id_locked')
+    .eq('user_id', identity.user_id)
+    .maybeSingle();
+
+  if (profileRow && (profileRow as any).vitana_id_locked) {
+    return res.status(409).json({
+      ok: false,
+      error: 'ALREADY_LOCKED',
+      message: 'Your Vitana ID is already set and cannot be changed.',
+    });
+  }
+
+  // Three suggestions — three independent RPC calls. Each gets its own
+  // random suffix internally, so the trio is naturally distinct.
+  const [s1, s2, s3] = await Promise.all([
+    supabase.rpc('generate_vitana_id_suggestion', {
+      p_display_name: profileRow?.display_name ?? null,
+      p_full_name: profileRow?.full_name ?? null,
+      p_email: profileRow?.email ?? identity.email ?? null,
+    }),
+    supabase.rpc('generate_vitana_id_suggestion', {
+      p_display_name: profileRow?.display_name ?? null,
+      p_full_name: profileRow?.full_name ?? null,
+      p_email: profileRow?.email ?? identity.email ?? null,
+    }),
+    supabase.rpc('generate_vitana_id_suggestion', {
+      p_display_name: profileRow?.display_name ?? null,
+      p_full_name: profileRow?.full_name ?? null,
+      p_email: profileRow?.email ?? identity.email ?? null,
+    }),
+  ]);
+
+  // Dedupe in case the random suffixes happened to collide.
+  const suggestions = Array.from(
+    new Set([s1.data, s2.data, s3.data].filter(Boolean))
+  );
+
+  return res.json({
+    ok: true,
+    suggestions,
+  });
+});
+
+// ── POST /me/vitana-id/confirm ────────────────────────────────
+
+router.post('/me/vitana-id/confirm', requireAuth, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const { vitana_id: requestedRaw } = req.body ?? {};
+
+  if (!requestedRaw || typeof requestedRaw !== 'string') {
+    return res.status(400).json({ ok: false, error: 'vitana_id is required' });
+  }
+
+  // Normalize: strip leading @, lowercase. Same rules as the resolver.
+  const requested = requestedRaw.trim().replace(/^@/, '').toLowerCase();
+
+  // Format check.
+  if (!VITANA_ID_REGEX.test(requested)) {
+    return res.status(400).json({
+      ok: false,
+      error: 'INVALID_FORMAT',
+      message: 'Vitana ID must start with a letter, then 3-11 lowercase letters or digits.',
+    });
+  }
+
+  // Composition check (≥2 letters AND ≥2 digits).
+  const letters = (requested.match(/[a-z]/g) || []).length;
+  const digits = (requested.match(/[0-9]/g) || []).length;
+  if (letters < MIN_LETTERS || digits < MIN_DIGITS) {
+    return res.status(400).json({
+      ok: false,
+      error: 'WEAK_COMPOSITION',
+      message: `Vitana ID needs at least ${MIN_LETTERS} letters and ${MIN_DIGITS} digits.`,
+    });
+  }
+
+  const supabase = getSupabase();
+
+  // Reserved-word check (single source of truth in vitana_id_reserved table).
+  const { data: reserved } = await supabase
+    .from('vitana_id_reserved')
+    .select('token')
+    .eq('token', requested)
+    .maybeSingle();
+  if (reserved) {
+    return res.status(400).json({
+      ok: false,
+      error: 'RESERVED_TOKEN',
+      message: 'That Vitana ID is reserved. Please choose another.',
+    });
+  }
+
+  // Read current row + lock state.
+  const { data: current, error: currentErr } = await supabase
+    .from('profiles')
+    .select('vitana_id, vitana_id_locked')
+    .eq('user_id', identity.user_id)
+    .maybeSingle();
+
+  if (currentErr || !current) {
+    return res.status(404).json({
+      ok: false,
+      error: 'PROFILE_NOT_FOUND',
+      message: 'Profile row not found.',
+    });
+  }
+
+  if ((current as any).vitana_id_locked) {
+    return res.status(409).json({
+      ok: false,
+      error: 'ALREADY_LOCKED',
+      message: 'Your Vitana ID is already set and cannot be changed.',
+    });
+  }
+
+  const previous = (current as any).vitana_id as string | null;
+
+  // Uniqueness pre-check (definitive check is the UNIQUE index on UPDATE).
+  if (previous !== requested) {
+    const { data: taken } = await supabase
+      .from('profiles')
+      .select('user_id')
+      .eq('vitana_id', requested)
+      .neq('user_id', identity.user_id)
+      .maybeSingle();
+    if (taken) {
+      return res.status(409).json({
+        ok: false,
+        error: 'TAKEN',
+        message: 'That Vitana ID is already taken. Please choose another.',
+      });
+    }
+
+    // Also check handle_aliases — collisions are protected here too so we
+    // never re-issue an ID that historically pointed to a different user.
+    const { data: aliasTaken } = await supabase
+      .from('handle_aliases')
+      .select('user_id')
+      .eq('old_handle', requested)
+      .neq('user_id', identity.user_id)
+      .maybeSingle();
+    if (aliasTaken) {
+      return res.status(409).json({
+        ok: false,
+        error: 'ALIAS_COLLISION',
+        message: 'That Vitana ID was previously used by another account. Please choose another.',
+      });
+    }
+
+    // Park the previous auto-generated value in handle_aliases so /profiles
+    // links and any in-flight references still resolve to this user.
+    if (previous) {
+      await supabase.from('handle_aliases').upsert(
+        { old_handle: previous, user_id: identity.user_id },
+        { onConflict: 'old_handle' }
+      );
+    }
+  }
+
+  // Update profiles. Mirror trigger fires -> app_users.vitana_id updates.
+  // handle column also mirrored to keep frontend reads consistent under
+  // the replace policy.
+  const { error: updateErr } = await supabase
+    .from('profiles')
+    .update({
+      vitana_id: requested,
+      handle: requested,
+      vitana_id_locked: true,
+    })
+    .eq('user_id', identity.user_id);
+
+  if (updateErr) {
+    console.error('[VTID-01967] vitana-id confirm update error:', updateErr);
+    return res.status(500).json({ ok: false, error: updateErr.message });
+  }
+
+  // Invalidate the in-process cache so the next request sees the new value.
+  invalidateVitanaIdCache(identity.user_id);
+
+  // Audit event — vitana_id is now the canonical user identifier.
+  await emitOasisEvent({
+    vtid: 'VTID-01967',
+    type: 'vitana_id.confirmed',
+    source: 'users-vitana-id',
+    status: 'success',
+    message: `User confirmed Vitana ID @${requested}${previous ? ` (was @${previous})` : ''}`,
+    payload: { previous, current: requested },
+    actor_id: identity.user_id,
+    actor_role: 'user',
+    surface: 'api',
+    vitana_id: requested,
+  });
+
+  return res.json({
+    ok: true,
+    vitana_id: requested,
+    vitana_id_locked: true,
+  });
+});
+
+export default router;

--- a/services/gateway/src/routes/voice-lab.ts
+++ b/services/gateway/src/routes/voice-lab.ts
@@ -48,6 +48,10 @@ interface LiveSessionSummary {
   error_count: number;
   interrupted_count: number;
   user_id?: string;
+  // VTID-01969: speakable Vitana ID for support readability. Resolved from
+  // app_users at session-summary time via cached lookup. Null-tolerant:
+  // undefined for legacy sessions before Release A backfill.
+  vitana_id?: string | null;
   user_email?: string;
   user_display_name?: string;
   user_role?: string;
@@ -294,6 +298,10 @@ router.get('/live/sessions', async (req: Request, res: Response) => {
         error_count: 0,
         interrupted_count: endEvent?.metadata?.interrupted_count || 0,
         user_id: startEvent.metadata?.user_id,
+        // VTID-01969: prefer vitana_id from the OASIS event (Release B
+        // backfill on oasis_events.vitana_id), fall back to metadata if
+        // present. Null-tolerant — Voice Lab UI shows UUID alone if missing.
+        vitana_id: (startEvent as any).vitana_id || startEvent.metadata?.vitana_id || null,
         user_email: startEvent.metadata?.email,
         user_display_name: startEvent.metadata?.email?.split('@')[0] || undefined,
         user_role: startEvent.metadata?.active_role,
@@ -392,6 +400,8 @@ router.get('/live/sessions/:sessionId', async (req: Request, res: Response) => {
       output_rate: startEvent.metadata?.output_rate,
       video_frames: endEvent?.metadata?.video_frames,
       user_id: startEvent.metadata?.user_id,
+      // VTID-01969: speakable Vitana ID (see LiveSessionSummary comment).
+      vitana_id: (startEvent as any).vitana_id || startEvent.metadata?.vitana_id || null,
       user_email: startEvent.metadata?.email,
       user_display_name: startEvent.metadata?.email?.split('@')[0] || undefined,
       user_role: startEvent.metadata?.active_role,

--- a/services/gateway/src/services/context-pack-builder.ts
+++ b/services/gateway/src/services/context-pack-builder.ts
@@ -48,6 +48,8 @@ import { formatSessionBufferForLLM, getSessionContext } from './session-memory-b
 // VTID-01955: Tier 0 Memorystore Redis turn buffer (multi-instance shared) — gated by tier0_redis_enabled flag.
 import { getSessionContextRedis, formatRedisBufferForLLM } from './redis-turn-buffer';
 import { isTier0RedisEnabled } from './system-controls-service';
+// VTID-01966 Phase 2: HIPAA-grade audit on every memory read.
+import { auditMemoryRead } from './memory-audit';
 // VTID-02000: Marketplace context primitive
 import { getUserHealthContext } from './user-health-context';
 
@@ -1444,6 +1446,39 @@ export async function buildContextPack(
     },
   }).catch(err => {
     console.warn(`[VTID-01216] Failed to log context pack event: ${err.message}`);
+  });
+
+  // VTID-01966 Phase 2: HIPAA-grade audit log entry for every memory read.
+  // Fire-and-forget — never blocks the LLM call. Health-scoped writes get the
+  // dedicated index for fast HIPAA replay.
+  auditMemoryRead({
+    tenant_id: input.lens.tenant_id,
+    user_id: input.lens.user_id,
+    tier: 'context-pack-builder',
+    actor_id: `conversation-${input.channel}`,
+    source_engine: 'context-pack-builder',
+    source_event_id: packId,
+    health_scope: hitCounts.memory_garden > 0,  // memory garden hits often touch health
+    details: {
+      intent: input.query?.slice(0, 80) ?? null,
+      blocks_returned: [
+        ...(memoryHits.length > 0 ? ['MEMORY'] : []),
+        ...(knowledgeHits.length > 0 ? ['KNOWLEDGE'] : []),
+        ...(webHits.length > 0 ? ['WEB'] : []),
+        ...(relationshipContext.length > 0 ? ['RELATIONSHIPS'] : []),
+        ...(calendarContext ? ['CALENDAR'] : []),
+        ...(oasisContext ? ['OASIS'] : []),
+        ...(sessionBufferData && sessionBufferData.turn_count > 0 ? ['SESSION_BUFFER'] : []),
+      ],
+      item_counts: hitCounts,
+      latency_ms: pack.assembly_duration_ms,
+      cache_hit: bufferSource === 'redis',
+      tokens_used: tokensUsed,
+      channel: input.channel,
+      thread_id: input.thread_id,
+      router_decision_rule: input.router_decision?.matched_rule,
+      router_decision_sources: input.router_decision?.sources_to_query,
+    },
   });
 
   return pack;

--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -1648,7 +1648,14 @@ export async function autoApproveTick(): Promise<void> {
     );
     if (!planR.ok || !planR.data || planR.data.length === 0) continue;
 
-    const result = await approveAutoExecute({ finding_id: f.id, approved_by: 'auto' });
+    // Pass undefined so the INSERT writes approved_by=NULL.
+    // Earlier code passed the string literal 'auto', but approved_by is a
+    // UUID column — Postgres rejected every autonomous approval with
+    // "invalid input syntax for type uuid". Net: auto-approve has been
+    // silently no-op since the feature shipped. NULL is a valid sentinel
+    // for "approved by the system" — the OASIS event below is the audit
+    // trail for non-human approvals.
+    const result = await approveAutoExecute({ finding_id: f.id });
     if (!result.ok || !result.execution) {
       // A safety-gate rejection here is EXPECTED for findings that cite
       // files outside allow_scope — just log and move on. The operator
@@ -1720,7 +1727,14 @@ export async function autoApproveTick(): Promise<void> {
             continue;
           }
 
-          const result = await approveAutoExecute({ finding_id: f.id, approved_by: 'auto' });
+          // Pass undefined so the INSERT writes approved_by=NULL.
+    // Earlier code passed the string literal 'auto', but approved_by is a
+    // UUID column — Postgres rejected every autonomous approval with
+    // "invalid input syntax for type uuid". Net: auto-approve has been
+    // silently no-op since the feature shipped. NULL is a valid sentinel
+    // for "approved by the system" — the OASIS event below is the audit
+    // trail for non-human approvals.
+    const result = await approveAutoExecute({ finding_id: f.id });
           if (!result.ok || !result.execution) {
             console.log(`${LOG_PREFIX} auto-approve (impact) skipped ${f.id.slice(0, 8)}: ${result.error || 'safety gate'}`);
             continue;

--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -1648,6 +1648,20 @@ export async function autoApproveTick(): Promise<void> {
     );
     if (!planR.ok || !planR.data || planR.data.length === 0) continue;
 
+    // Dedup: skip findings that already have a non-terminal execution.
+    // Without this, every tick approves a NEW execution row even though
+    // the prior one is still cooling/running — N concurrent executions
+    // for the same finding all racing the same plan. Discovered while
+    // running v1 autonomy: a single eligible finding produced 5 cooling
+    // executions in 3 minutes after auto-approve flipped on.
+    const inflightR = await supa<Array<{ id: string }>>(
+      s,
+      `/rest/v1/dev_autopilot_executions?finding_id=eq.${f.id}`
+      + `&status=in.(cooling,running,ci,merging,deploying,verifying)`
+      + `&select=id&limit=1`,
+    );
+    if (inflightR.ok && inflightR.data && inflightR.data.length > 0) continue;
+
     // Pass undefined so the INSERT writes approved_by=NULL.
     // Earlier code passed the string literal 'auto', but approved_by is a
     // UUID column — Postgres rejected every autonomous approval with

--- a/services/gateway/src/services/dev-autopilot-self-heal-log.ts
+++ b/services/gateway/src/services/dev-autopilot-self-heal-log.ts
@@ -60,14 +60,25 @@ export interface AutopilotFailureArgs {
   attempt_number?: number;
 }
 
+/** Time window for the writer-level idempotency check. Same vtid+endpoint+
+ *  failure_class within this window is treated as a duplicate and skipped.
+ *  Sized to comfortably swallow ticker-loop spam (lazyPlanTick fires every
+ *  ~30s, multiple Cloud Run instances each run their own ticker) without
+ *  hiding a genuine new occurrence after the underlying problem returns. */
+const DEDUP_WINDOW_MS = 10 * 60 * 1000;
+
 /**
  * Best-effort write — caller must NOT block on the result. A failure to
  * write to self_healing_log is logged but never propagates because that
  * would mask the original autopilot failure that needed surfacing.
  *
- * Idempotency: not enforced — duplicate writes get duplicate rows. If
- * a stage runs in a tick loop and may double-fire, the caller should
- * dedupe with its own short-window check before calling here.
+ * Idempotency: enforced at the writer (VTID-01971). Before each INSERT we
+ * GET self_healing_log filtered by (vtid, endpoint, failure_class) within
+ * the last DEDUP_WINDOW_MS; if a row exists, the write is skipped. Stops
+ * tick-loop spam (lazyPlanTick re-firing the same plan_gen failure every
+ * ~30s × N Cloud Run instances) from flooding the Self-Healing UI with
+ * dozens of identical rows. Retries that legitimately need a separate row
+ * should pass a stage-discriminating endpoint or distinct failure_class.
  */
 export async function writeAutopilotFailure(
   s: SupaConfig,
@@ -77,6 +88,26 @@ export async function writeAutopilotFailure(
   const confidence = args.confidence ?? 0;
   const attempt = args.attempt_number ?? 1;
   try {
+    const sinceIso = new Date(Date.now() - DEDUP_WINDOW_MS).toISOString();
+    const dedupQuery =
+      `?vtid=eq.${encodeURIComponent(args.vtid)}` +
+      `&endpoint=eq.${encodeURIComponent(args.endpoint)}` +
+      `&failure_class=eq.${encodeURIComponent(args.failure_class)}` +
+      `&created_at=gte.${encodeURIComponent(sinceIso)}` +
+      `&select=id&limit=1`;
+    const dedupRes = await fetch(`${s.url}/rest/v1/self_healing_log${dedupQuery}`, {
+      headers: {
+        apikey: s.key,
+        Authorization: `Bearer ${s.key}`,
+      },
+    });
+    if (dedupRes.ok) {
+      const existing = (await dedupRes.json()) as Array<{ id: string }>;
+      if (Array.isArray(existing) && existing.length > 0) {
+        return;
+      }
+    }
+
     const res = await fetch(`${s.url}/rest/v1/self_healing_log`, {
       method: 'POST',
       headers: {

--- a/services/gateway/src/services/embedding-cache.ts
+++ b/services/gateway/src/services/embedding-cache.ts
@@ -1,0 +1,110 @@
+/**
+ * VTID-01970 — Embedding Cache (sha256(text) → vector LRU)
+ *
+ * In-process LRU cache that eliminates redundant embedding API calls
+ * (OpenAI text-embedding-3-small ~50ms+$, Gemini ~80ms+$). Identical
+ * text strings are extremely common in our retrieval paths:
+ *   - retrieval-router classifies the same query phrasing repeatedly
+ *   - context-pack-builder embeds the same memory items multiple times
+ *   - autopilot ranker re-embeds the same recommendation titles
+ *
+ * Cache key = SHA-256 of normalized text. Bounded LRU (default 5000
+ * entries) so we don't grow unbounded across long-lived processes.
+ *
+ * Plan: Part 8 Phase 3 (Tier 1).
+ */
+
+import { createHash } from 'crypto';
+
+const MAX_ENTRIES = 5000;
+
+interface CacheEntry {
+  vector: number[];
+  model: string;
+  dimensions: number;
+  cached_at: number;
+}
+
+// Map preserves insertion order; we treat that as LRU by deleting + re-inserting on access.
+const cache = new Map<string, CacheEntry>();
+let hits = 0;
+let misses = 0;
+let evictions = 0;
+
+function keyFor(text: string): string {
+  // Normalize: collapse whitespace, lowercase, trim. Hash to bound key size.
+  const normalized = text.replace(/\s+/g, ' ').trim().toLowerCase();
+  return createHash('sha256').update(normalized).digest('hex');
+}
+
+/**
+ * Look up an embedding by text. Updates LRU position on hit.
+ * Returns null on miss — callers must compute then call set().
+ */
+export function getCachedEmbedding(text: string): CacheEntry | null {
+  if (!text) return null;
+  const k = keyFor(text);
+  const entry = cache.get(k);
+  if (!entry) {
+    misses += 1;
+    return null;
+  }
+  // LRU: re-insert to move to most-recent.
+  cache.delete(k);
+  cache.set(k, entry);
+  hits += 1;
+  return entry;
+}
+
+/**
+ * Store an embedding for a text. Evicts oldest entry on overflow.
+ */
+export function setCachedEmbedding(
+  text: string,
+  vector: number[],
+  model: string,
+  dimensions: number
+): void {
+  if (!text || !Array.isArray(vector) || vector.length === 0) return;
+  const k = keyFor(text);
+  if (cache.has(k)) {
+    cache.delete(k);
+  } else if (cache.size >= MAX_ENTRIES) {
+    // Evict oldest (first-inserted).
+    const oldest = cache.keys().next().value as string | undefined;
+    if (oldest) {
+      cache.delete(oldest);
+      evictions += 1;
+    }
+  }
+  cache.set(k, { vector, model, dimensions, cached_at: Date.now() });
+}
+
+export function getCacheStats(): {
+  size: number;
+  max: number;
+  hits: number;
+  misses: number;
+  evictions: number;
+  hit_rate: number;
+} {
+  const total = hits + misses;
+  return {
+    size: cache.size,
+    max: MAX_ENTRIES,
+    hits,
+    misses,
+    evictions,
+    hit_rate: total > 0 ? hits / total : 0,
+  };
+}
+
+export function clearEmbeddingCache(): void {
+  cache.clear();
+  hits = 0;
+  misses = 0;
+  evictions = 0;
+}
+
+// Test-only export
+export const EMBEDDING_CACHE_MAX_FOR_TEST = MAX_ENTRIES;

--- a/services/gateway/src/services/embedding-service.ts
+++ b/services/gateway/src/services/embedding-service.ts
@@ -11,6 +11,8 @@
  */
 
 import { emitOasisEvent } from './oasis-event-service';
+// VTID-01970 Tier 1: in-process LRU cache for embeddings (sha256(text)→vector)
+import { getCachedEmbedding, setCachedEmbedding, getCacheStats } from './embedding-cache';
 
 // =============================================================================
 // Configuration
@@ -302,11 +304,27 @@ async function generateGeminiEmbedding(text: string): Promise<EmbeddingResponse>
  * @returns Embedding vector (1536 dimensions)
  */
 export async function generateEmbedding(text: string): Promise<EmbeddingResponse> {
+  // VTID-01970 Tier 1 hot cache — return cached vector when available
+  // (eliminates the OpenAI/Gemini round-trip + cost for identical inputs).
+  const cached = getCachedEmbedding(text);
+  if (cached) {
+    return {
+      ok: true,
+      embedding: cached.vector,
+      model: cached.model,
+      dimensions: cached.dimensions,
+      latency_ms: 0,  // hot-cache hit
+    };
+  }
+
   // Try OpenAI first
   const openaiResult = await generateOpenAIEmbedding(text);
 
   if (openaiResult.ok) {
     console.log(`[${VTID}] Embedding generated (OpenAI): ${openaiResult.dimensions}d, ${openaiResult.latency_ms}ms`);
+    if (openaiResult.embedding && openaiResult.dimensions && openaiResult.model) {
+      setCachedEmbedding(text, openaiResult.embedding, openaiResult.model, openaiResult.dimensions);
+    }
     return openaiResult;
   }
 
@@ -316,6 +334,9 @@ export async function generateEmbedding(text: string): Promise<EmbeddingResponse
 
   if (geminiResult.ok) {
     console.log(`[${VTID}] Embedding generated (Gemini): ${geminiResult.dimensions}d, ${geminiResult.latency_ms}ms`);
+    if (geminiResult.embedding && geminiResult.dimensions && geminiResult.model) {
+      setCachedEmbedding(text, geminiResult.embedding, geminiResult.model, geminiResult.dimensions);
+    }
 
     // Emit OASIS event for fallback
     await emitOasisEvent({

--- a/services/gateway/src/services/intent-classifier.ts
+++ b/services/gateway/src/services/intent-classifier.ts
@@ -1,0 +1,143 @@
+/**
+ * VTID-01973: Intent kind classifier for the Vitana Intent Engine (P2-A).
+ *
+ * First-stage Gemini call that maps a free-form utterance to one of the
+ * registered intent_kinds + a confidence score. The dispatcher hands off
+ * to the kind-specific extractor only when confidence ≥ 0.7; below that,
+ * ORB asks a clarifying question.
+ *
+ * Mirrors the inline-fact-extractor pattern: Vertex AI primary, Gemini API
+ * fallback, temperature 0.1 for deterministic classification, low token
+ * budget. JSON-mode output.
+ */
+
+import { VertexAI } from '@google-cloud/vertexai';
+
+const GOOGLE_GEMINI_API_KEY = process.env.GOOGLE_GEMINI_API_KEY;
+const VERTEX_PROJECT = process.env.GOOGLE_CLOUD_PROJECT || process.env.GCP_PROJECT || 'lovable-vitana-vers1';
+const VERTEX_LOCATION = process.env.VERTEX_LOCATION || 'us-central1';
+const CLASSIFY_MODEL = 'gemini-2.0-flash';
+
+let vertexAI: VertexAI | null = null;
+try {
+  if (VERTEX_PROJECT && VERTEX_LOCATION) {
+    vertexAI = new VertexAI({ project: VERTEX_PROJECT, location: VERTEX_LOCATION });
+  }
+} catch {
+  vertexAI = null;
+}
+
+export type IntentKind =
+  | 'commercial_buy'
+  | 'commercial_sell'
+  | 'activity_seek'
+  | 'partner_seek'
+  | 'social_seek'
+  | 'mutual_aid';
+
+export interface IntentClassification {
+  intent_kind: IntentKind | null;
+  confidence: number; // 0-1
+  reasoning?: string;
+}
+
+const CLASSIFIER_SYSTEM_PROMPT = `You classify user utterances for the Vitana Intent Engine into one of six kinds. Return ONLY a JSON object, no prose:
+
+{ "intent_kind": "<one of: commercial_buy, commercial_sell, activity_seek, partner_seek, social_seek, mutual_aid, NONE>",
+  "confidence": <0.0-1.0>,
+  "reasoning": "<short>" }
+
+Definitions:
+- commercial_buy   = user wants to PURCHASE a service or product. ("I need a contractor", "I want to buy a road bike", "looking to hire a tutor")
+- commercial_sell  = user wants to SELL a service or product. ("I'm offering tutoring", "I want to sell my bike", "I provide kitchen renovations")
+- activity_seek    = user wants a partner for a recreational activity. ("looking for someone to play tennis", "anyone hiking Saturday?", "Mitspieler für Schach gesucht")
+- partner_seek     = user wants a romantic life partner. ("looking for a life partner", "I want to find a girlfriend", "Partner fürs Leben")
+- social_seek      = user wants a coffee chat / mentorship / networking conversation, NOT romantic. ("looking for a mentor", "want to chat with a Series A founder", "coffee chat anyone?")
+- mutual_aid       = user is lending/borrowing/giving/receiving without commercial transaction. ("I can lend my drill", "anyone got a sewing machine I can borrow?", "free moving help")
+- NONE             = utterance is not a marketplace/match intent (small talk, factual question, etc.).
+
+Rules:
+- Bias to NONE when ambiguous; the dispatcher will ask a clarifying question.
+- Confidence reflects how clear the kind is, NOT how complete the slots are.
+- Languages supported: English, German.
+
+Examples:
+"I need a kitchen contractor" -> {"intent_kind":"commercial_buy","confidence":0.95,"reasoning":"clear hire intent"}
+"Ich biete Übersetzungen" -> {"intent_kind":"commercial_sell","confidence":0.9,"reasoning":"offering services in DE"}
+"Anyone want to play tennis Tuesday?" -> {"intent_kind":"activity_seek","confidence":0.95,"reasoning":"recreational partner"}
+"I'd like to find a girlfriend" -> {"intent_kind":"partner_seek","confidence":0.95,"reasoning":"romantic partner"}
+"Looking for a mentor in fintech" -> {"intent_kind":"social_seek","confidence":0.9,"reasoning":"mentorship not romantic"}
+"I can lend my drill if anyone needs" -> {"intent_kind":"mutual_aid","confidence":0.9,"reasoning":"free lending"}
+"What's the weather?" -> {"intent_kind":"NONE","confidence":0.1,"reasoning":"factual question"}`;
+
+function parseClassifierResponse(raw: string): IntentClassification {
+  // Strip code fences if Gemini added them.
+  const cleaned = raw.trim().replace(/^```(?:json)?/i, '').replace(/```$/, '').trim();
+  try {
+    const parsed = JSON.parse(cleaned);
+    const kind = String(parsed.intent_kind || '').toLowerCase();
+    const validKinds = ['commercial_buy', 'commercial_sell', 'activity_seek', 'partner_seek', 'social_seek', 'mutual_aid'];
+    return {
+      intent_kind: validKinds.includes(kind) ? (kind as IntentKind) : null,
+      confidence: typeof parsed.confidence === 'number' ? Math.max(0, Math.min(1, parsed.confidence)) : 0,
+      reasoning: typeof parsed.reasoning === 'string' ? parsed.reasoning.slice(0, 200) : undefined,
+    };
+  } catch {
+    return { intent_kind: null, confidence: 0 };
+  }
+}
+
+export async function classifyIntentKind(utterance: string): Promise<IntentClassification> {
+  const trimmed = (utterance || '').trim();
+  if (!trimmed) return { intent_kind: null, confidence: 0 };
+
+  // Try Vertex AI first.
+  if (vertexAI) {
+    try {
+      const model = vertexAI.getGenerativeModel({
+        model: CLASSIFY_MODEL,
+        generationConfig: { temperature: 0.1, maxOutputTokens: 200, topP: 0.8 },
+        systemInstruction: { role: 'system', parts: [{ text: CLASSIFIER_SYSTEM_PROMPT }] },
+      });
+      const response = await model.generateContent({
+        contents: [{ role: 'user', parts: [{ text: trimmed }] }],
+      });
+      const textPart = response.response?.candidates?.[0]?.content?.parts?.find((p: any) => 'text' in p);
+      const raw = textPart ? (textPart as any).text : '';
+      if (raw) {
+        const parsed = parseClassifierResponse(raw);
+        if (parsed.intent_kind || parsed.confidence > 0) return parsed;
+      }
+    } catch (err: any) {
+      console.warn(`[VTID-01973] Vertex classifier failed: ${err.message}`);
+    }
+  }
+
+  // Gemini API fallback.
+  if (GOOGLE_GEMINI_API_KEY) {
+    try {
+      const response = await fetch(
+        `https://generativelanguage.googleapis.com/v1beta/models/${CLASSIFY_MODEL}:generateContent?key=${GOOGLE_GEMINI_API_KEY}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            contents: [{ parts: [{ text: trimmed }] }],
+            systemInstruction: { parts: [{ text: CLASSIFIER_SYSTEM_PROMPT }] },
+            generationConfig: { temperature: 0.1, maxOutputTokens: 200 },
+          }),
+        }
+      );
+      if (response.ok) {
+        const data = await response.json() as any;
+        const raw = data.candidates?.[0]?.content?.parts?.[0]?.text || '';
+        return parseClassifierResponse(raw);
+      }
+    } catch (err: any) {
+      console.warn(`[VTID-01973] Gemini API classifier failed: ${err.message}`);
+    }
+  }
+
+  // No backend available — return null kind so callers fall back to clarification.
+  return { intent_kind: null, confidence: 0 };
+}

--- a/services/gateway/src/services/intent-compass-lens.ts
+++ b/services/gateway/src/services/intent-compass-lens.ts
@@ -1,0 +1,106 @@
+/**
+ * VTID-01973: Life Compass alignment helper (P2-A).
+ *
+ * Reads the existing life_compass table (G3 of vitana_autopilot_index_compass_loop)
+ * and the new intent_compass_boost mapping. Used by:
+ *   - The matcher: to flip compass_aligned=true on intent_matches rows.
+ *   - The notifier: to prioritise surfacing of aligned matches.
+ *   - The proactive prompt branch in orb-live.ts (P2-B): to phrase the
+ *     prompt in a compass-aware way ("This fits your longevity focus...").
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import type { IntentKind } from './intent-classifier';
+
+const SUPABASE_URL = process.env.SUPABASE_URL!;
+const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE!;
+
+function getSupabase() {
+  return createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
+}
+
+export interface CompassGoal {
+  user_id: string;
+  category: string | null;       // e.g. 'longevity', 'earn_money', 'life_partner'
+  primary_goal: string | null;   // user-friendly text
+  alignment_score: number;
+  confidence_score: number;
+}
+
+// In-process cache: 5-min TTL, keyed by user_id. Goals don't change often.
+const COMPASS_TTL_MS = 5 * 60 * 1000;
+const compassCache = new Map<string, { goal: CompassGoal | null; expires_at: number }>();
+
+export async function getActiveCompassGoal(userId: string): Promise<CompassGoal | null> {
+  if (!userId) return null;
+
+  const cached = compassCache.get(userId);
+  if (cached && cached.expires_at > Date.now()) return cached.goal;
+
+  try {
+    const supabase = getSupabase();
+    const { data } = await supabase
+      .from('life_compass')
+      .select('user_id, category, primary_goal, alignment_score, confidence_score')
+      .eq('user_id', userId)
+      .eq('is_active', true)
+      .maybeSingle();
+
+    const goal = (data as CompassGoal | null) ?? null;
+    compassCache.set(userId, { goal, expires_at: Date.now() + COMPASS_TTL_MS });
+    return goal;
+  } catch (err: any) {
+    console.warn(`[VTID-01973] getActiveCompassGoal failed: ${err.message}`);
+    return null;
+  }
+}
+
+/**
+ * Given a kind_pairing and both parties' active compass categories, return
+ * the boost weight for this match. Null/0 means no alignment boost.
+ *
+ * Reads intent_compass_boost (seeded in migration 7/9). Both sides must
+ * have an aligned compass for the bonus to apply.
+ */
+export async function compassAlignmentBonus(
+  kindPairing: string,
+  dictatorCategory: string | null,
+  counterpartyCategory: string | null,
+): Promise<number> {
+  if (!dictatorCategory || !counterpartyCategory) return 0;
+  // The boost is per (compass_category, intent_kind). For pairings, we
+  // check whether EITHER party's compass aligns with the OTHER party's
+  // intent_kind. Conservative: require both sides aligned.
+  const [kindA, kindB] = kindPairing.split('::') as [IntentKind, IntentKind];
+  if (!kindA || !kindB) return 0;
+
+  try {
+    const supabase = getSupabase();
+    const { data } = await supabase
+      .from('intent_compass_boost')
+      .select('compass_category, intent_kind, boost_weight')
+      .in('compass_category', [dictatorCategory, counterpartyCategory])
+      .in('intent_kind', [kindA, kindB]);
+
+    if (!data || (data as any[]).length === 0) return 0;
+
+    // Both sides must have at least one boost row covering them.
+    const aBoost = (data as any[]).find(
+      (r) => r.compass_category === dictatorCategory && r.intent_kind === kindA,
+    );
+    const bBoost = (data as any[]).find(
+      (r) => r.compass_category === counterpartyCategory && r.intent_kind === kindB,
+    );
+    if (!aBoost || !bBoost) return 0;
+
+    // Use the smaller of the two boosts so neither side dominates.
+    return Math.min(Number(aBoost.boost_weight) || 0, Number(bBoost.boost_weight) || 0);
+  } catch (err: any) {
+    console.warn(`[VTID-01973] compassAlignmentBonus failed: ${err.message}`);
+    return 0;
+  }
+}
+
+export function invalidateCompassCache(userId: string): void {
+  compassCache.delete(userId);
+}

--- a/services/gateway/src/services/intent-content-filter.ts
+++ b/services/gateway/src/services/intent-content-filter.ts
@@ -1,0 +1,65 @@
+/**
+ * VTID-01973: Content filter (P2-A stub).
+ *
+ * Regex-based profanity + obvious-PII (phone, email, IBAN) detector.
+ * Stricter rules for partner_seek and social_seek where PII leaks are
+ * higher-stakes. P2-C swaps this for a real moderation service.
+ */
+
+import type { IntentKind } from './intent-classifier';
+
+interface CheckResult {
+  ok: boolean;
+  reasons: string[];
+}
+
+const PROFANITY = [
+  // English
+  /\b(f[*u]ck|sh[*i]t|c[*u]nt|b[*i]tch|asshole|dick|pussy)\b/i,
+  // German
+  /\b(scheiße|arschloch|fotze|wichser)\b/i,
+];
+
+const PII_EMAIL = /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/i;
+const PII_PHONE = /\b\+?\d[\d\s\-]{7,}\d\b/;
+const PII_IBAN = /\b[A-Z]{2}\d{2}[A-Z0-9]{10,30}\b/;
+
+function detectPII(text: string): string[] {
+  const found: string[] = [];
+  if (PII_EMAIL.test(text)) found.push('email');
+  if (PII_PHONE.test(text)) found.push('phone');
+  if (PII_IBAN.test(text)) found.push('iban');
+  return found;
+}
+
+function detectProfanity(text: string): boolean {
+  return PROFANITY.some((rx) => rx.test(text));
+}
+
+export function checkIntentContent(args: {
+  kind: IntentKind;
+  title: string;
+  scope: string;
+}): CheckResult {
+  const reasons: string[] = [];
+  const blob = `${args.title} ${args.scope}`;
+
+  // Profanity is always blocked.
+  if (detectProfanity(blob)) reasons.push('profanity');
+
+  const piiFound = detectPII(blob);
+  if (piiFound.length > 0) {
+    // partner_seek and social_seek: PII = hard reject (high-stakes privacy).
+    if (args.kind === 'partner_seek' || args.kind === 'social_seek') {
+      reasons.push(...piiFound.map((p) => `pii_${p}_blocked_strict`));
+    } else {
+      // Commercial / activity / mutual_aid: warn but allow — users sometimes
+      // legitimately want to share contact info for a paid job. Log it though.
+      reasons.push(...piiFound.map((p) => `pii_${p}_warning`));
+    }
+  }
+
+  // Hard rejects: profanity OR strict PII.
+  const hardReject = reasons.some((r) => r === 'profanity' || r.endsWith('_blocked_strict'));
+  return { ok: !hardReject, reasons };
+}

--- a/services/gateway/src/services/intent-embedding.ts
+++ b/services/gateway/src/services/intent-embedding.ts
@@ -1,0 +1,62 @@
+/**
+ * VTID-01973: Intent embedding helper (P2-A).
+ *
+ * Wraps the existing embedding-service.ts. Concatenates kind + category
+ * + title + scope + key kind_payload fields into one text blob, then
+ * embeds with the canonical 768-dim model. P2-A inlines on insert; P2-C
+ * promotes to a NOTIFY-driven worker if write rate climbs.
+ */
+
+import { generateEmbedding, EMBEDDING_DIMENSIONS } from './embedding-service';
+import type { IntentKind } from './intent-classifier';
+
+interface IntentForEmbedding {
+  intent_kind: IntentKind;
+  category: string | null;
+  title: string;
+  scope: string;
+  kind_payload: Record<string, unknown>;
+}
+
+/**
+ * Build a deterministic text blob from an intent. The kind-payload fields
+ * we include are the ones most discriminative for similarity (activity
+ * name, topic, object_or_skill). Budget/age/time numbers are NOT included
+ * — those are exact-overlap fields handled by the SQL match function.
+ */
+function intentToEmbeddingText(intent: IntentForEmbedding): string {
+  const parts: string[] = [
+    `kind:${intent.intent_kind}`,
+    intent.category ? `category:${intent.category}` : '',
+    intent.title || '',
+    intent.scope || '',
+  ];
+
+  // Pull a few kind-specific discriminators.
+  const p = intent.kind_payload || {};
+  if (typeof p.activity === 'string') parts.push(`activity:${p.activity}`);
+  if (typeof p.topic === 'string') parts.push(`topic:${p.topic}`);
+  if (typeof p.object_or_skill === 'string') parts.push(`item:${p.object_or_skill}`);
+  if (Array.isArray(p.skill_keywords)) parts.push(`skills:${p.skill_keywords.join(',')}`);
+  if (Array.isArray(p.must_haves)) parts.push(`must_haves:${p.must_haves.join(',')}`);
+
+  return parts.filter(Boolean).join(' | ');
+}
+
+export async function embedIntent(intent: IntentForEmbedding): Promise<number[] | null> {
+  const text = intentToEmbeddingText(intent);
+  if (!text) return null;
+  try {
+    const result = await generateEmbedding(text);
+    if (result?.embedding && result.embedding.length === EMBEDDING_DIMENSIONS) {
+      return result.embedding;
+    }
+    if (result?.embedding) {
+      console.warn(`[VTID-01973] Embedding dim mismatch: got ${result.embedding.length}, expected ${EMBEDDING_DIMENSIONS}`);
+    }
+    return null;
+  } catch (err: any) {
+    console.warn(`[VTID-01973] embedIntent failed: ${err.message}`);
+    return null;
+  }
+}

--- a/services/gateway/src/services/intent-extractor.ts
+++ b/services/gateway/src/services/intent-extractor.ts
@@ -1,0 +1,204 @@
+/**
+ * VTID-01973: Per-kind intent extractor (P2-A).
+ *
+ * Strategy pattern over five Gemini-driven extractors. After
+ * intent-classifier.ts identifies the kind, this module produces the
+ * kind-specific structured payload (kind_payload JSONB on user_intents).
+ *
+ * Same Vertex+Gemini fallback pattern as inline-fact-extractor.ts. JSON
+ * mode, temp 0.1, low token budget.
+ *
+ * Returns { fields, confidence, missing_critical } so the dispatcher knows
+ * whether to fire single-shot or fall back to multi-turn slot-fill.
+ */
+
+import { VertexAI } from '@google-cloud/vertexai';
+import type { IntentKind } from './intent-classifier';
+
+const GOOGLE_GEMINI_API_KEY = process.env.GOOGLE_GEMINI_API_KEY;
+const VERTEX_PROJECT = process.env.GOOGLE_CLOUD_PROJECT || process.env.GCP_PROJECT || 'lovable-vitana-vers1';
+const VERTEX_LOCATION = process.env.VERTEX_LOCATION || 'us-central1';
+const EXTRACT_MODEL = 'gemini-2.0-flash';
+
+let vertexAI: VertexAI | null = null;
+try {
+  if (VERTEX_PROJECT && VERTEX_LOCATION) {
+    vertexAI = new VertexAI({ project: VERTEX_PROJECT, location: VERTEX_LOCATION });
+  }
+} catch {
+  vertexAI = null;
+}
+
+export interface ExtractedIntent {
+  intent_kind: IntentKind;
+  category: string | null;
+  title: string | null;
+  scope: string | null;
+  kind_payload: Record<string, unknown>;
+  confidence: number; // 0-1
+  missing_critical: string[];
+}
+
+const CRITICAL_FIELDS_BY_KIND: Record<IntentKind, string[]> = {
+  commercial_buy: ['title', 'scope'],
+  commercial_sell: ['title', 'scope'],
+  activity_seek: ['title', 'scope', 'kind_payload.activity'],
+  partner_seek: ['title', 'scope'],
+  social_seek: ['title', 'scope', 'kind_payload.topic'],
+  mutual_aid: ['title', 'scope', 'kind_payload.direction', 'kind_payload.object_or_skill'],
+};
+
+const SYSTEM_PROMPT_BY_KIND: Record<IntentKind, string> = {
+  commercial_buy: `Extract a commercial_buy intent. Return JSON only:
+{ "category": "<one of: home_services.refurbishment, home_services.electrician, home_services.plumbing, home_services.cleaning, pro_services.legal, pro_services.accounting, pro_services.translation, wellness.coaching, wellness.nutrition, travel.itinerary_planning, travel.local_guide, local.errands, local.delivery, local.handyman, digital.web_dev, digital.design, digital.marketing, education.tutoring, education.language, events.catering, events.photography, events.music, OR null if unclear>",
+  "title": "<short headline ≤140 chars>",
+  "scope": "<longer description 20-1500 chars, in user's words>",
+  "kind_payload": { "budget_min": <number or null>, "budget_max": <number or null>, "currency": "<ISO 4217, default EUR>", "location_mode": "<remote|on_site|hybrid|null>", "location_label": "<city or null>", "urgency": "<asap|this_week|flexible|null>", "due_date": "<ISO date or null>" },
+  "confidence": <0-1>
+}
+Leave fields null when unclear. Confidence reflects extraction certainty, not slot completeness.`,
+  commercial_sell: `Extract a commercial_sell intent. Return JSON only:
+{ "category": "<same enum as commercial_buy or null>",
+  "title": "<headline ≤140>",
+  "scope": "<description 20-1500 chars>",
+  "kind_payload": { "price_floor": <number or null>, "price_ceiling": <number or null>, "currency": "<ISO 4217, default EUR>", "pricing_model": "<hourly|per_project|per_unit|quote_on_request|null>", "location_served": "<city or region label or null>", "skill_keywords": [<array of strings>], "availability": "<active|paused|null>" },
+  "confidence": <0-1>
+}`,
+  activity_seek: `Extract an activity_seek intent. Return JSON only:
+{ "category": "<one of: sport.tennis, sport.running, sport.hiking, sport.cycling, sport.yoga, sport.gym, creative.music, creative.painting, learning.language, learning.book_club, OR null>",
+  "title": "<headline ≤140>",
+  "scope": "<description 20-1500>",
+  "kind_payload": { "activity": "<canonical activity name>", "time_windows": [<array of strings like 'tue 18:00-20:00'>], "location_label": "<city/area or null>", "group_size_pref": "<1on1|small_group|large_group|null>", "skill_level": "<beginner|intermediate|advanced|null>" },
+  "confidence": <0-1>
+}`,
+  partner_seek: `Extract a partner_seek intent. Return JSON only — be PII-light and respect privacy:
+{ "category": "<life_partner|dating|companionship|null>",
+  "title": "<short tasteful headline ≤140>",
+  "scope": "<description 20-1500, NO last names, NO phone numbers, NO emails>",
+  "kind_payload": { "age_range": [<min int>,<max int>] or null, "gender_preference": "<string or null>", "location_radius_km": <number or null>, "life_stage": "<single|divorced|widowed|null>", "must_haves": [<short tags>], "deal_breakers": [<short tags>] },
+  "confidence": <0-1>
+}`,
+  social_seek: `Extract a social_seek intent (mentorship/networking/coffee chat — NOT romantic). Return JSON only:
+{ "category": "<mentorship|networking|coffee_chat|peer_support|null>",
+  "title": "<headline ≤140>",
+  "scope": "<description 20-1500>",
+  "kind_payload": { "topic": "<canonical topic e.g. 'fintech-fundraising'>", "time_windows": [<strings>], "location_label": "<city or 'remote'>", "format_pref": "<in_person|video|either|null>" },
+  "confidence": <0-1>
+}`,
+  mutual_aid: `Extract a mutual_aid intent. Return JSON only:
+{ "category": "<lend|borrow|gift|receive|help_me>",
+  "title": "<headline ≤140>",
+  "scope": "<description 20-1500>",
+  "kind_payload": { "direction": "<lend|borrow|give|receive|help_me>", "object_or_skill": "<short noun phrase>", "duration_estimate": "<short string or null>", "location_label": "<city/area>" },
+  "confidence": <0-1>
+}`,
+};
+
+function parseExtractorResponse(raw: string, kind: IntentKind): ExtractedIntent {
+  const cleaned = raw.trim().replace(/^```(?:json)?/i, '').replace(/```$/, '').trim();
+  let parsed: any;
+  try {
+    parsed = JSON.parse(cleaned);
+  } catch {
+    return {
+      intent_kind: kind,
+      category: null,
+      title: null,
+      scope: null,
+      kind_payload: {},
+      confidence: 0,
+      missing_critical: CRITICAL_FIELDS_BY_KIND[kind],
+    };
+  }
+
+  const result: ExtractedIntent = {
+    intent_kind: kind,
+    category: typeof parsed.category === 'string' && parsed.category ? parsed.category : null,
+    title: typeof parsed.title === 'string' && parsed.title ? parsed.title.slice(0, 140) : null,
+    scope: typeof parsed.scope === 'string' && parsed.scope ? parsed.scope.slice(0, 1500) : null,
+    kind_payload: typeof parsed.kind_payload === 'object' && parsed.kind_payload ? parsed.kind_payload : {},
+    confidence: typeof parsed.confidence === 'number' ? Math.max(0, Math.min(1, parsed.confidence)) : 0,
+    missing_critical: [],
+  };
+
+  // Compute missing_critical from CRITICAL_FIELDS_BY_KIND.
+  for (const path of CRITICAL_FIELDS_BY_KIND[kind]) {
+    if (path === 'title' && !result.title) result.missing_critical.push('title');
+    else if (path === 'scope' && !result.scope) result.missing_critical.push('scope');
+    else if (path.startsWith('kind_payload.')) {
+      const key = path.slice('kind_payload.'.length);
+      if (!result.kind_payload[key]) result.missing_critical.push(path);
+    }
+  }
+
+  return result;
+}
+
+export async function extractIntent(utterance: string, kind: IntentKind): Promise<ExtractedIntent> {
+  const trimmed = (utterance || '').trim();
+  if (!trimmed) {
+    return {
+      intent_kind: kind,
+      category: null,
+      title: null,
+      scope: null,
+      kind_payload: {},
+      confidence: 0,
+      missing_critical: CRITICAL_FIELDS_BY_KIND[kind],
+    };
+  }
+
+  const systemPrompt = SYSTEM_PROMPT_BY_KIND[kind];
+
+  if (vertexAI) {
+    try {
+      const model = vertexAI.getGenerativeModel({
+        model: EXTRACT_MODEL,
+        generationConfig: { temperature: 0.1, maxOutputTokens: 800, topP: 0.8 },
+        systemInstruction: { role: 'system', parts: [{ text: systemPrompt }] },
+      });
+      const response = await model.generateContent({
+        contents: [{ role: 'user', parts: [{ text: trimmed }] }],
+      });
+      const textPart = response.response?.candidates?.[0]?.content?.parts?.find((p: any) => 'text' in p);
+      const raw = textPart ? (textPart as any).text : '';
+      if (raw) return parseExtractorResponse(raw, kind);
+    } catch (err: any) {
+      console.warn(`[VTID-01973] Vertex extractor failed (kind=${kind}): ${err.message}`);
+    }
+  }
+
+  if (GOOGLE_GEMINI_API_KEY) {
+    try {
+      const response = await fetch(
+        `https://generativelanguage.googleapis.com/v1beta/models/${EXTRACT_MODEL}:generateContent?key=${GOOGLE_GEMINI_API_KEY}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            contents: [{ parts: [{ text: trimmed }] }],
+            systemInstruction: { parts: [{ text: systemPrompt }] },
+            generationConfig: { temperature: 0.1, maxOutputTokens: 800 },
+          }),
+        }
+      );
+      if (response.ok) {
+        const data = await response.json() as any;
+        const raw = data.candidates?.[0]?.content?.parts?.[0]?.text || '';
+        return parseExtractorResponse(raw, kind);
+      }
+    } catch (err: any) {
+      console.warn(`[VTID-01973] Gemini API extractor failed (kind=${kind}): ${err.message}`);
+    }
+  }
+
+  return {
+    intent_kind: kind,
+    category: null,
+    title: null,
+    scope: null,
+    kind_payload: {},
+    confidence: 0,
+    missing_critical: CRITICAL_FIELDS_BY_KIND[kind],
+  };
+}

--- a/services/gateway/src/services/intent-matcher.ts
+++ b/services/gateway/src/services/intent-matcher.ts
@@ -1,0 +1,125 @@
+/**
+ * VTID-01973: Intent matcher (P2-A).
+ *
+ * Wraps the SQL function compute_intent_matches() and federates against
+ * the existing affiliate products catalog (VTID-02000) for commercial_buy
+ * intents. Federation runs in TS, not SQL, to keep the products domain
+ * cleanly separated from user_intents.
+ *
+ * Public surface:
+ *   computeForIntent(intentId)       — runs SQL fn + federation, returns count
+ *   surfaceTopMatches(intentId, n)   — returns the top-N rows, sorted, with redaction applied
+ */
+
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.SUPABASE_URL!;
+const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE!;
+
+function getSupabase() {
+  return createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
+}
+
+export interface MatchRow {
+  match_id: string;
+  intent_a_id: string;
+  intent_b_id: string | null;
+  vitana_id_a: string | null;
+  vitana_id_b: string | null;
+  external_target_kind: string | null;
+  external_target_id: string | null;
+  kind_pairing: string;
+  score: number;
+  match_reasons: Record<string, unknown>;
+  compass_aligned: boolean;
+  state: string;
+  created_at: string;
+}
+
+/**
+ * Compute matches for a freshly-posted intent. Returns the number of new
+ * intent_matches rows inserted. Optionally federates commercial_buy against
+ * the affiliate products catalog.
+ */
+export async function computeForIntent(intentId: string): Promise<number> {
+  const supabase = getSupabase();
+
+  // 1. Run the kind-aware SQL fn for user-vs-user pairings.
+  const { data, error } = await supabase.rpc('compute_intent_matches', {
+    p_intent_id: intentId,
+    p_top_n: 5,
+  });
+
+  if (error) {
+    console.warn(`[VTID-01973] compute_intent_matches RPC failed: ${error.message}`);
+    return 0;
+  }
+
+  const userMatchesCount = typeof data === 'number' ? data : (data as any)?.[0] ?? 0;
+
+  // 2. For commercial_buy, also federate against affiliate products.
+  // P2-A keeps this minimal: same-tenant, category-mapped products with
+  // a baseline score of 0.55. P2-B adds proper semantic-over-products.
+  try {
+    const { data: src } = await supabase
+      .from('user_intents')
+      .select('intent_kind, category, requester_vitana_id')
+      .eq('intent_id', intentId)
+      .maybeSingle();
+
+    if (src && (src as any).intent_kind === 'commercial_buy' && (src as any).category) {
+      // Map intent category to product category and pull top 3.
+      // For P2-A we just look for products whose category column shares the
+      // first hierarchy segment (e.g. wellness.coaching → wellness).
+      const parentCategory = ((src as any).category as string).split('.')[0];
+      const { data: products } = await supabase
+        .from('products')
+        .select('id, name, category')
+        .eq('category', parentCategory)
+        .limit(3);
+
+      if (Array.isArray(products) && products.length > 0) {
+        const rows = products.map((p: any, idx: number) => ({
+          intent_a_id: intentId,
+          intent_b_id: null,
+          vitana_id_a: (src as any).requester_vitana_id,
+          vitana_id_b: null,
+          external_target_kind: 'product',
+          external_target_id: p.id,
+          kind_pairing: 'commercial_buy::product',
+          score: 0.55 - idx * 0.05,
+          match_reasons: { source: 'affiliate_catalog', category_match: true },
+          compass_aligned: false,
+          state: 'new',
+        }));
+        await supabase.from('intent_matches').insert(rows as any);
+      }
+    }
+  } catch (err: any) {
+    // Federation is best-effort; never block the user-vs-user path.
+    console.warn(`[VTID-01973] product federation failed: ${err.message}`);
+  }
+
+  return userMatchesCount || 0;
+}
+
+/**
+ * Get the top-N matches for an intent, sorted by score. Caller is
+ * responsible for redacting vitana_id_b on partner_seek pre-reveal rows
+ * via intent-mutual-reveal.ts (route-layer concern).
+ */
+export async function surfaceTopMatches(intentId: string, n: number = 5): Promise<MatchRow[]> {
+  const supabase = getSupabase();
+  const { data, error } = await supabase
+    .from('intent_matches')
+    .select('*')
+    .eq('intent_a_id', intentId)
+    .order('score', { ascending: false })
+    .limit(n);
+
+  if (error) {
+    console.warn(`[VTID-01973] surfaceTopMatches failed: ${error.message}`);
+    return [];
+  }
+  return (data || []) as MatchRow[];
+}

--- a/services/gateway/src/services/intent-mutual-reveal.ts
+++ b/services/gateway/src/services/intent-mutual-reveal.ts
@@ -1,0 +1,137 @@
+/**
+ * VTID-01973: Mutual-reveal protocol (P2-A surface).
+ *
+ * For partner_seek (and any future kind with requires_mutual_reveal=true):
+ * vitana_id_b on intent_matches rows is REDACTED in API responses until
+ * BOTH parties have explicitly expressed interest, at which point
+ * mutual_reveal_unlocked_at is set and both vitana_ids surface.
+ *
+ * P2-A provides:
+ *   - redactMatchForReader(match, readerUserId)  — applied at the route layer
+ *     to nullify counterparty vitana_id while pre-reveal.
+ *   - tryUnlockReveal(matchId)  — called by intent-matches.ts state-transition
+ *     handler. If both sides have expressed interest, set unlocked_at and
+ *     emit OASIS event.
+ *
+ * The DB-level helper intent_match_should_redact() (migration 8/9)
+ * complements this for support tooling that bypasses the gateway.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { emitOasisEvent } from './oasis-event-service';
+import type { MatchRow } from './intent-matcher';
+
+const SUPABASE_URL = process.env.SUPABASE_URL!;
+const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE!;
+
+function getSupabase() {
+  return createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
+}
+
+const MUTUAL_REVEAL_KINDS = new Set(['partner_seek']);
+
+export interface RedactedMatch extends Omit<MatchRow, 'vitana_id_a' | 'vitana_id_b'> {
+  vitana_id_a: string | null;
+  vitana_id_b: string | null;
+  redacted: boolean;
+}
+
+/**
+ * Given a match and a reader's user_id, decide whether to redact the
+ * counterparty vitana_id. Returns a copy of the match with redaction
+ * applied. Never mutates the input.
+ */
+export async function redactMatchForReader(
+  match: MatchRow,
+  readerUserId: string,
+): Promise<RedactedMatch> {
+  const kindA = match.kind_pairing.split('::')[0];
+  const kindB = match.kind_pairing.split('::')[1];
+  const involvesMutualReveal =
+    MUTUAL_REVEAL_KINDS.has(kindA) || MUTUAL_REVEAL_KINDS.has(kindB);
+
+  if (!involvesMutualReveal) {
+    return { ...match, redacted: false };
+  }
+
+  // Already unlocked: no redaction.
+  // (We check via a fresh read of the unlock timestamp because the cached
+  // match passed in might be stale.)
+  const supabase = getSupabase();
+  const { data: fresh } = await supabase
+    .from('intent_matches')
+    .select('mutual_reveal_unlocked_at, intent_a_id, intent_b_id')
+    .eq('match_id', match.match_id)
+    .maybeSingle();
+  const unlocked = fresh && (fresh as any).mutual_reveal_unlocked_at !== null;
+
+  if (unlocked) return { ...match, redacted: false };
+
+  // Pre-reveal: figure out which side the reader is on, hide the other vitana_id.
+  const { data: aOwner } = await supabase
+    .from('user_intents')
+    .select('requester_user_id')
+    .eq('intent_id', match.intent_a_id)
+    .maybeSingle();
+  const isReaderA = aOwner && (aOwner as any).requester_user_id === readerUserId;
+
+  return {
+    ...match,
+    vitana_id_a: isReaderA ? match.vitana_id_a : null,
+    vitana_id_b: isReaderA ? null : match.vitana_id_b,
+    redacted: true,
+  };
+}
+
+/**
+ * Called when a state transitions to provider_responded / requester_engaged.
+ * If BOTH sides have engaged, set mutual_reveal_unlocked_at and emit audit.
+ */
+export async function tryUnlockReveal(matchId: string): Promise<boolean> {
+  const supabase = getSupabase();
+  const { data: m } = await supabase
+    .from('intent_matches')
+    .select('match_id, kind_pairing, state, mutual_reveal_unlocked_at, vitana_id_a, vitana_id_b')
+    .eq('match_id', matchId)
+    .maybeSingle();
+
+  if (!m) return false;
+  if ((m as any).mutual_reveal_unlocked_at) return true;
+
+  const kindA = (m as any).kind_pairing.split('::')[0];
+  const kindB = (m as any).kind_pairing.split('::')[1];
+  if (!MUTUAL_REVEAL_KINDS.has(kindA) && !MUTUAL_REVEAL_KINDS.has(kindB)) return false;
+
+  // Both sides must have responded: state in mutual_interest signals both
+  // engaged. The state transition path in intent-matches.ts is the source
+  // of truth — any time it sets mutual_interest we call this.
+  if ((m as any).state !== 'mutual_interest') return false;
+
+  const { error } = await supabase
+    .from('intent_matches')
+    .update({ mutual_reveal_unlocked_at: new Date().toISOString() })
+    .eq('match_id', matchId);
+
+  if (error) {
+    console.warn(`[VTID-01973] tryUnlockReveal update failed: ${error.message}`);
+    return false;
+  }
+
+  await emitOasisEvent({
+    vtid: 'VTID-01973',
+    type: 'voice.message.sent', // P2-B introduces 'intent_partner_reciprocal_revealed'
+    source: 'intent-mutual-reveal',
+    status: 'success',
+    message: `Mutual reveal unlocked for match ${matchId}`,
+    payload: {
+      match_id: matchId,
+      vitana_id_a: (m as any).vitana_id_a,
+      vitana_id_b: (m as any).vitana_id_b,
+      protocol: 'partner_seek_reciprocal',
+    },
+    surface: 'api',
+    vitana_id: (m as any).vitana_id_a ?? undefined,
+  });
+
+  return true;
+}

--- a/services/gateway/src/services/intent-notifier.ts
+++ b/services/gateway/src/services/intent-notifier.ts
@@ -1,0 +1,42 @@
+/**
+ * VTID-01973: Intent notifier (P2-A stub).
+ *
+ * P2-A baseline: emit OASIS audit event only — no push notifications yet.
+ * P2-B wires this to the FCM/Appilix push pipeline via notification-service.ts
+ * with per-kind frequency caps in Redis. P2-A keeps the surface stable so
+ * the intents route can call it without conditional code.
+ */
+
+import { emitOasisEvent } from './oasis-event-service';
+import type { MatchRow } from './intent-matcher';
+
+interface NotifyArgs {
+  match: MatchRow;
+  kind: string;
+}
+
+/**
+ * Audit-only notification for P2-A. Emits an OASIS event so the dashboard
+ * can count surfaced matches; no user-facing push.
+ */
+export async function notifyMatchSurfaced(args: NotifyArgs): Promise<void> {
+  await emitOasisEvent({
+    vtid: 'VTID-01973',
+    type: 'voice.message.sent', // P2-A reuses an existing audit type; P2-B introduces 'intent_match_found_for_dictator' etc.
+    source: 'intent-notifier',
+    status: 'info',
+    message: `Intent match surfaced: ${args.match.kind_pairing} score=${args.match.score}`,
+    payload: {
+      match_id: args.match.match_id,
+      intent_a_id: args.match.intent_a_id,
+      intent_b_id: args.match.intent_b_id,
+      score: args.match.score,
+      compass_aligned: args.match.compass_aligned,
+      // P2-A: no push side-effect.
+      pushed: false,
+    },
+    actor_id: undefined,
+    surface: 'api',
+    vitana_id: args.match.vitana_id_a ?? undefined,
+  });
+}

--- a/services/gateway/src/services/intent-throttle.ts
+++ b/services/gateway/src/services/intent-throttle.ts
@@ -1,0 +1,98 @@
+/**
+ * VTID-01973: Throttle (P2-A).
+ *
+ * Per-user posting caps to deter spam and bound new-account abuse:
+ *   - Account < 7 days old: 1 open intent across all kinds, max budget €500.
+ *   - Mature accounts: 5 open intents per kind, 3 posts per kind per 24h.
+ *
+ * Cap is opinionated for P2-A; real tuning happens once P2-B telemetry
+ * arrives.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import type { IntentKind } from './intent-classifier';
+
+const SUPABASE_URL = process.env.SUPABASE_URL!;
+const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE!;
+
+function getSupabase() {
+  return createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
+}
+
+interface ThrottleResult {
+  ok: boolean;
+  reason?: 'new_account_cap' | 'open_intent_cap' | 'daily_post_cap' | 'budget_cap';
+  detail?: string;
+}
+
+const NEW_ACCOUNT_DAYS = 7;
+const NEW_ACCOUNT_MAX_OPEN = 1;
+const NEW_ACCOUNT_MAX_BUDGET_EUR = 500;
+const MATURE_MAX_OPEN_PER_KIND = 5;
+const MATURE_MAX_POSTS_PER_KIND_PER_24H = 3;
+
+export async function canPostIntent(args: {
+  userId: string;
+  kind: IntentKind;
+  budgetMaxEur: number | null;
+}): Promise<ThrottleResult> {
+  const supabase = getSupabase();
+
+  // 1. Account age — read auth.users.created_at via app_users (already keyed by user_id).
+  const { data: appUser } = await supabase
+    .from('app_users')
+    .select('created_at')
+    .eq('user_id', args.userId)
+    .maybeSingle();
+
+  const accountCreatedAt = appUser?.created_at ? new Date(appUser.created_at as string) : new Date();
+  const accountAgeDays = (Date.now() - accountCreatedAt.getTime()) / (1000 * 60 * 60 * 24);
+  const isNewAccount = accountAgeDays < NEW_ACCOUNT_DAYS;
+
+  // 2. Open intent count.
+  const { count: openCount } = await supabase
+    .from('user_intents')
+    .select('*', { count: 'exact', head: true })
+    .eq('requester_user_id', args.userId)
+    .in('status', ['open', 'matched', 'engaged']);
+
+  if (isNewAccount && (openCount ?? 0) >= NEW_ACCOUNT_MAX_OPEN) {
+    return { ok: false, reason: 'new_account_cap', detail: `New accounts (<${NEW_ACCOUNT_DAYS}d) limited to ${NEW_ACCOUNT_MAX_OPEN} open intent.` };
+  }
+
+  // Per-kind open cap (mature accounts).
+  if (!isNewAccount) {
+    const { count: openKindCount } = await supabase
+      .from('user_intents')
+      .select('*', { count: 'exact', head: true })
+      .eq('requester_user_id', args.userId)
+      .eq('intent_kind', args.kind)
+      .in('status', ['open', 'matched', 'engaged']);
+
+    if ((openKindCount ?? 0) >= MATURE_MAX_OPEN_PER_KIND) {
+      return { ok: false, reason: 'open_intent_cap', detail: `Limit of ${MATURE_MAX_OPEN_PER_KIND} open ${args.kind} intents.` };
+    }
+  }
+
+  // 3. New-account budget cap (commercial only).
+  if (isNewAccount && (args.kind === 'commercial_buy' || args.kind === 'commercial_sell')) {
+    if (args.budgetMaxEur !== null && args.budgetMaxEur > NEW_ACCOUNT_MAX_BUDGET_EUR) {
+      return { ok: false, reason: 'budget_cap', detail: `New accounts capped at €${NEW_ACCOUNT_MAX_BUDGET_EUR}.` };
+    }
+  }
+
+  // 4. Daily post cap per kind (mature).
+  const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+  const { count: dayCount } = await supabase
+    .from('user_intents')
+    .select('*', { count: 'exact', head: true })
+    .eq('requester_user_id', args.userId)
+    .eq('intent_kind', args.kind)
+    .gte('created_at', since);
+
+  if (!isNewAccount && (dayCount ?? 0) >= MATURE_MAX_POSTS_PER_KIND_PER_24H) {
+    return { ok: false, reason: 'daily_post_cap', detail: `Max ${MATURE_MAX_POSTS_PER_KIND_PER_24H} ${args.kind} posts per 24h.` };
+  }
+
+  return { ok: true };
+}

--- a/services/gateway/src/services/intent-tier-gate.ts
+++ b/services/gateway/src/services/intent-tier-gate.ts
@@ -1,0 +1,96 @@
+/**
+ * VTID-01973: Trust-tier gate (P2-A baseline).
+ *
+ * For commercial bids the user's vitana_id must clear a tier threshold:
+ *   - Bid up to €200          → community_verified (3-vouch).
+ *   - Bid up to €2000         → pro_verified (KYC-light).
+ *   - Bid > €2000             → id_verified (govt ID).
+ *
+ * For partner_seek: only id_verified profiles unlock the mutual-reveal
+ * vitana_id at the end of the protocol; community_verified can express
+ * interest but reveal is held until tier upgrade.
+ *
+ * P2-A reads tier from a soft default: profiles that have completed Part 1
+ * onboarding (vitana_id_locked=true) are treated as community_verified;
+ * pro_verified / id_verified gating is the P2-B/C concern. The function
+ * returns the tier so callers can branch.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+
+const SUPABASE_URL = process.env.SUPABASE_URL!;
+const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE!;
+
+function getSupabase() {
+  return createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
+}
+
+export type TrustTier = 'unverified' | 'community_verified' | 'pro_verified' | 'id_verified';
+
+const TIER_RANK: Record<TrustTier, number> = {
+  unverified: 0,
+  community_verified: 1,
+  pro_verified: 2,
+  id_verified: 3,
+};
+
+interface GateResult {
+  ok: boolean;
+  tier: TrustTier;
+  required?: TrustTier;
+  reason?: string;
+}
+
+/**
+ * Get the current tier for a user. P2-A baseline: vitana_id_locked=true
+ * → community_verified. Future migrations add pro_verified and
+ * id_verified mappings (manual review queues) — those callers will start
+ * returning higher tiers without changing this signature.
+ */
+export async function getTrustTier(userId: string): Promise<TrustTier> {
+  if (!userId) return 'unverified';
+  try {
+    const supabase = getSupabase();
+    const { data } = await supabase
+      .from('profiles')
+      .select('vitana_id_locked')
+      .eq('user_id', userId)
+      .maybeSingle();
+    if (data && (data as any).vitana_id_locked === true) return 'community_verified';
+    return 'unverified';
+  } catch (err: any) {
+    console.warn(`[VTID-01973] getTrustTier failed: ${err.message}`);
+    return 'unverified';
+  }
+}
+
+export async function gateCommercialBudget(userId: string, budgetMaxEur: number): Promise<GateResult> {
+  const tier = await getTrustTier(userId);
+  let required: TrustTier = 'community_verified';
+  if (budgetMaxEur > 2000) required = 'pro_verified';
+  if (budgetMaxEur > 10000) required = 'id_verified';
+
+  if (TIER_RANK[tier] < TIER_RANK[required]) {
+    return {
+      ok: false,
+      tier,
+      required,
+      reason: `Budget €${budgetMaxEur} requires ${required}; you are ${tier}.`,
+    };
+  }
+  return { ok: true, tier };
+}
+
+export async function gatePartnerReveal(userId: string): Promise<GateResult> {
+  const tier = await getTrustTier(userId);
+  const required: TrustTier = 'id_verified';
+  if (TIER_RANK[tier] < TIER_RANK[required]) {
+    return {
+      ok: false,
+      tier,
+      required,
+      reason: `Partner-seek vitana_id reveal requires ${required}; you are ${tier}.`,
+    };
+  }
+  return { ok: true, tier };
+}

--- a/services/gateway/src/services/memory-audit.ts
+++ b/services/gateway/src/services/memory-audit.ts
@@ -238,3 +238,177 @@ export async function auditWritePersisted(input: PersistedAuditInput): Promise<v
     console.warn('[VTID-01952] failed to emit memory.write.persisted:', err);
   });
 }
+
+// ============================================================================
+// VTID-01966 Phase 2 — HIPAA-grade memory_audit_log writes
+//
+// Dedicated audit table (separate from oasis_events) so:
+//   1. Every memory READ + WRITE is captured uniformly with rich provenance.
+//   2. HIPAA replay queries (give me everything user X accessed in date
+//      range Y) are O(index) instead of O(table scan on oasis_events).
+//   3. Append-only + monthly partitions enable cheap retention drops.
+//
+// Writes are fire-and-forget — audit must NEVER block the actual memory
+// operation. If Postgres is slow or down, log + proceed.
+//
+// Plan: Part 7 schema + Part 8 Phase 2.
+// ============================================================================
+
+const SUPABASE_URL_ENV = process.env.SUPABASE_URL;
+const SUPABASE_SR_ENV = process.env.SUPABASE_SERVICE_ROLE;
+
+export type MemoryAuditOp = 'read' | 'write' | 'delete' | 'consolidate';
+
+export interface MemoryAuditRow {
+  /** REQUIRED. Tenant scope. */
+  tenant_id: string;
+  /** REQUIRED. User UUID (the subject of the read/write). */
+  user_id: string;
+  /** REQUIRED. read | write | delete | consolidate. */
+  op: MemoryAuditOp;
+  /** REQUIRED. Storage tier or logical layer (tier0, tier1, tier2, tier3, identity-lock, etc.). */
+  tier: string;
+  /** REQUIRED. Who/what performed the operation. */
+  actor_id: string;
+  /** Optional: which engine produced this (orb-live, conversation-client, etc.). */
+  source_engine?: string;
+  /** Optional: 0..1. Null when it doesn't apply (e.g. consolidator runs). */
+  confidence?: number;
+  /** Optional: upstream OASIS event id if applicable. */
+  source_event_id?: string;
+  /** Optional: defaults to MEMORY_POLICY_VERSION. */
+  policy_version?: string;
+  /** Optional: HIPAA classification flag. */
+  health_scope?: boolean;
+  /** Optional: identity-locked fact_key touched? */
+  identity_scope?: boolean;
+  /** Optional: free-form context (intent, fact_keys, latency_ms, etc.). */
+  details?: Record<string, unknown>;
+}
+
+/**
+ * Append a row to memory_audit_log. Fire-and-forget — never throws, never
+ * blocks. Failures log a single warn line.
+ *
+ * Use this for both reads AND writes. Cheaper than emitting a full OASIS
+ * event for every read (which would balloon the events table).
+ */
+export async function appendMemoryAuditRow(row: MemoryAuditRow): Promise<void> {
+  if (!SUPABASE_URL_ENV || !SUPABASE_SR_ENV) {
+    // Tests / misconfigured environments — silently skip.
+    return;
+  }
+
+  // Fire-and-forget. Any error is caught + logged, never re-thrown.
+  try {
+    const body = {
+      p_tenant_id: row.tenant_id,
+      p_user_id: row.user_id,
+      p_op: row.op,
+      p_tier: row.tier,
+      p_actor_id: row.actor_id,
+      p_policy_version: row.policy_version ?? MEMORY_POLICY_VERSION,
+      p_source_engine: row.source_engine ?? null,
+      p_confidence: row.confidence ?? null,
+      p_source_event_id: row.source_event_id ?? null,
+      p_health_scope: !!row.health_scope,
+      p_identity_scope: !!row.identity_scope,
+      p_details: row.details ?? {},
+    };
+
+    const resp = await fetch(`${SUPABASE_URL_ENV}/rest/v1/rpc/memory_audit_log_insert`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: SUPABASE_SR_ENV,
+        Authorization: `Bearer ${SUPABASE_SR_ENV}`,
+      },
+      body: JSON.stringify(body),
+    });
+
+    if (!resp.ok && resp.status !== 200 && resp.status !== 201 && resp.status !== 204) {
+      const text = await resp.text().catch(() => '');
+      console.warn(`[VTID-01966] memory_audit_log_insert failed ${resp.status}: ${text.slice(0, 200)}`);
+    }
+  } catch (err) {
+    console.warn('[VTID-01966] memory_audit_log_insert threw (non-fatal):', (err as Error)?.message);
+  }
+}
+
+// ----------------------------------------------------------------------------
+// Read-side audit helper — call this AFTER a memory read completes.
+// Captures intent, tier(s) hit, latency, and result counts as `details`.
+// ----------------------------------------------------------------------------
+
+export interface MemoryReadAuditInput {
+  tenant_id: string;
+  user_id: string;
+  /** Logical tier or read-source name (e.g. 'tier0+tier1', 'context-pack-builder', 'memory_get_context'). */
+  tier: string;
+  actor_id: string;
+  source_engine?: string;
+  source_event_id?: string;
+  /** What the read returned + how it was performed. */
+  details?: {
+    intent?: string;
+    query_preview?: string;
+    blocks_returned?: string[];
+    item_counts?: Record<string, number>;
+    latency_ms?: number;
+    cache_hit?: boolean;
+    degraded?: boolean;
+    [k: string]: unknown;
+  };
+  health_scope?: boolean;
+}
+
+export async function auditMemoryRead(input: MemoryReadAuditInput): Promise<void> {
+  await appendMemoryAuditRow({
+    tenant_id: input.tenant_id,
+    user_id: input.user_id,
+    op: 'read',
+    tier: input.tier,
+    actor_id: input.actor_id,
+    source_engine: input.source_engine,
+    source_event_id: input.source_event_id,
+    health_scope: input.health_scope,
+    identity_scope: false,
+    details: input.details ?? {},
+  });
+}
+
+// ----------------------------------------------------------------------------
+// Write-side audit helper — call this AFTER a memory write succeeds (or fails).
+// For identity-locked writes, use auditWritePersisted() above (which also
+// emits the dedicated OASIS event); for ordinary writes, this is the
+// lightweight HIPAA-grade trail.
+// ----------------------------------------------------------------------------
+
+export interface MemoryWriteAuditInput {
+  tenant_id: string;
+  user_id: string;
+  tier: string;          // 'memory_items', 'memory_facts', 'mem_episodes', 'tier0', etc.
+  actor_id: string;
+  source_engine?: string;
+  source_event_id?: string;
+  confidence?: number;
+  health_scope?: boolean;
+  identity_scope?: boolean;
+  details?: Record<string, unknown>;
+}
+
+export async function auditMemoryWrite(input: MemoryWriteAuditInput): Promise<void> {
+  await appendMemoryAuditRow({
+    tenant_id: input.tenant_id,
+    user_id: input.user_id,
+    op: 'write',
+    tier: input.tier,
+    actor_id: input.actor_id,
+    source_engine: input.source_engine,
+    source_event_id: input.source_event_id,
+    confidence: input.confidence,
+    health_scope: input.health_scope,
+    identity_scope: input.identity_scope,
+    details: input.details ?? {},
+  });
+}

--- a/services/gateway/src/services/notification-service.ts
+++ b/services/gateway/src/services/notification-service.ts
@@ -479,6 +479,12 @@ export async function notifyUser(
   let inappWritten = false;
   let notificationId: string | null = null;
   if (shouldWriteInapp) {
+    // VTID-01969: denormalize recipient_vitana_id at insert time so support
+    // tooling can quote @<id> without joining profiles. Cached lookup is
+    // null-tolerant (Release B middleware contract).
+    const { resolveVitanaId } = await import('../middleware/auth-supabase-jwt');
+    const recipientVitanaId = await resolveVitanaId(userId);
+
     const insertData: Record<string, any> = {
       user_id: userId,
       tenant_id: tenantId,
@@ -488,6 +494,7 @@ export async function notifyUser(
       title: payload.title,
       body: payload.body,
       data: payload.data || {},
+      ...(recipientVitanaId && { recipient_vitana_id: recipientVitanaId }),
     };
     if (shouldSendPush) {
       insertData.push_sent_at = new Date().toISOString();

--- a/services/gateway/src/services/oasis-event-service.ts
+++ b/services/gateway/src/services/oasis-event-service.ts
@@ -6,6 +6,7 @@
 import { randomUUID } from 'crypto';
 import { CicdEventType, CicdOasisEvent } from '../types/cicd';
 import { projectOasisEventToTimeline } from './timeline-projector';
+import { resolveVitanaId } from '../middleware/auth-supabase-jwt';
 
 /**
  * VTID-01874: Infer task_stage from event type when not explicitly set.
@@ -43,6 +44,15 @@ export async function emitOasisEvent(event: CicdOasisEvent): Promise<{ ok: boole
   const eventId = randomUUID();
   const timestamp = new Date().toISOString();
 
+  // VTID-01967: Auto-resolve vitana_id from actor_id when caller didn't pass it.
+  // Cached in resolveVitanaId(), so this is ~0ms after first lookup per user.
+  // Null-tolerant: if the column doesn't exist or app_users hasn't been mirrored
+  // yet, the field stays undefined and the INSERT just omits it.
+  let vitanaId: string | null | undefined = event.vitana_id;
+  if (vitanaId === undefined && event.actor_id) {
+    vitanaId = await resolveVitanaId(event.actor_id);
+  }
+
   const payload: Record<string, unknown> = {
     id: eventId,
     created_at: timestamp,
@@ -64,6 +74,8 @@ export async function emitOasisEvent(event: CicdOasisEvent): Promise<{ ok: boole
     // VTID-01874: Explicit stage annotation for correct timeline mapping
     // Uses explicit task_stage if set, otherwise infers from event type
     ...((event.task_stage || inferTaskStageFromType(event.type)) ? { task_stage: event.task_stage || inferTaskStageFromType(event.type) } : {}),
+    // VTID-01967: Denormalized canonical Vitana ID for support / audit queries.
+    ...(vitanaId && { vitana_id: vitanaId }),
   };
 
   try {

--- a/services/gateway/src/services/timeline-projector.ts
+++ b/services/gateway/src/services/timeline-projector.ts
@@ -110,7 +110,17 @@ export async function writeTimelineRow(input: ProjectorInput): Promise<void> {
     return;
   }
 
-  const row = {
+  // VTID-01969: denormalize actor_vitana_id so support tooling and Voice Lab
+  // can render @<id> without joining profiles. Cached lookup is null-tolerant.
+  let actorVitanaId: string | null = null;
+  try {
+    const { resolveVitanaId } = await import('../middleware/auth-supabase-jwt');
+    actorVitanaId = await resolveVitanaId(input.user_id);
+  } catch {
+    // Silent — fallback is null, support reads still work via user_id join.
+  }
+
+  const row: Record<string, unknown> = {
     id: randomUUID(),
     user_id: input.user_id,
     activity_type: input.activity_type,
@@ -119,6 +129,7 @@ export async function writeTimelineRow(input: ProjectorInput): Promise<void> {
     dedupe_key: input.dedupe_key,
     session_id: input.session_id,
     source: input.source,
+    ...(actorVitanaId && { actor_vitana_id: actorVitanaId }),
   };
 
   try {

--- a/services/gateway/src/services/voice-message-guard.ts
+++ b/services/gateway/src/services/voice-message-guard.ts
@@ -1,0 +1,150 @@
+/**
+ * VTID-01967: Voice-message rate limiter + audit hook for ORB voice tools.
+ *
+ * Per-session 5-send cap. In-memory Map keyed by ORB session id, sweeps
+ * automatically on read. Safe in single-instance deploys (current state);
+ * Release C migrates to Redis when ORB scales horizontally.
+ *
+ * Every send / rate-limit emits an OASIS event so support and Voice Lab
+ * dashboards can audit voice-initiated outreach without DB joins.
+ */
+
+import { emitOasisEvent } from './oasis-event-service';
+
+const SEND_CAP_PER_SESSION = 5;
+const SESSION_TTL_MS = 30 * 60 * 1000; // 30 min — matches typical ORB session
+
+interface SessionCounter {
+  count: number;
+  expires_at: number;
+}
+
+const sendCounters = new Map<string, SessionCounter>();
+
+function sweepExpired(): void {
+  const now = Date.now();
+  for (const [key, counter] of sendCounters.entries()) {
+    if (counter.expires_at <= now) {
+      sendCounters.delete(key);
+    }
+  }
+}
+
+/**
+ * Increment the per-session counter for a voice-initiated send. Returns
+ * { allowed: true } when the cap hasn't been hit, { allowed: false, reason }
+ * when it has. Emits OASIS audit events on every call.
+ */
+export async function checkVoiceSendQuota(args: {
+  session_id: string;
+  actor_id: string;
+  vitana_id: string | null | undefined;
+  recipient_user_id: string;
+  recipient_vitana_id: string | null | undefined;
+  kind: 'message' | 'share_link';
+  body_length?: number;
+  target_url?: string;
+}): Promise<{ allowed: boolean; reason?: string; remaining: number }> {
+  sweepExpired();
+
+  const existing = sendCounters.get(args.session_id);
+  const count = existing?.count ?? 0;
+
+  if (count >= SEND_CAP_PER_SESSION) {
+    await emitOasisEvent({
+      vtid: 'VTID-01967',
+      type: 'voice.message.rate_limited',
+      source: 'voice-message-guard',
+      status: 'warning',
+      message: `Voice send quota exceeded for session ${args.session_id} (${count}/${SEND_CAP_PER_SESSION})`,
+      payload: {
+        session_id: args.session_id,
+        recipient_user_id: args.recipient_user_id,
+        recipient_vitana_id: args.recipient_vitana_id,
+        kind: args.kind,
+        cap: SEND_CAP_PER_SESSION,
+      },
+      actor_id: args.actor_id,
+      actor_role: 'user',
+      surface: 'orb',
+      vitana_id: args.vitana_id ?? undefined,
+    });
+    return {
+      allowed: false,
+      reason: 'rate_limited',
+      remaining: 0,
+    };
+  }
+
+  sendCounters.set(args.session_id, {
+    count: count + 1,
+    expires_at: Date.now() + SESSION_TTL_MS,
+  });
+
+  await emitOasisEvent({
+    vtid: 'VTID-01967',
+    type: args.kind === 'share_link' ? 'voice.message.share_link_sent' : 'voice.message.sent',
+    source: 'voice-message-guard',
+    status: 'success',
+    message: `Voice ${args.kind === 'share_link' ? 'link share' : 'message'} sent to @${args.recipient_vitana_id ?? args.recipient_user_id}`,
+    payload: {
+      session_id: args.session_id,
+      recipient_user_id: args.recipient_user_id,
+      recipient_vitana_id: args.recipient_vitana_id,
+      kind: args.kind,
+      ...(args.body_length !== undefined && { body_length: args.body_length }),
+      ...(args.target_url && { target_url: args.target_url }),
+      send_index: count + 1,
+      cap: SEND_CAP_PER_SESSION,
+    },
+    actor_id: args.actor_id,
+    actor_role: 'user',
+    surface: 'orb',
+    vitana_id: args.vitana_id ?? undefined,
+  });
+
+  return {
+    allowed: true,
+    remaining: SEND_CAP_PER_SESSION - (count + 1),
+  };
+}
+
+/**
+ * Emit a misroute event when the user signals "you sent it to the wrong
+ * person" after a voice send. Used for ASR-confidence threshold tuning.
+ */
+export async function reportVoiceMisroute(args: {
+  session_id: string;
+  actor_id: string;
+  vitana_id: string | null | undefined;
+  intended_token: string;
+  resolved_user_id: string;
+  resolved_vitana_id: string | null | undefined;
+}): Promise<void> {
+  await emitOasisEvent({
+    vtid: 'VTID-01967',
+    type: 'voice.message.misroute',
+    source: 'voice-message-guard',
+    status: 'warning',
+    message: `Voice misroute reported by @${args.vitana_id ?? args.actor_id}: said "${args.intended_token}", resolved to @${args.resolved_vitana_id ?? args.resolved_user_id}`,
+    payload: {
+      session_id: args.session_id,
+      intended_token: args.intended_token,
+      resolved_user_id: args.resolved_user_id,
+      resolved_vitana_id: args.resolved_vitana_id,
+    },
+    actor_id: args.actor_id,
+    actor_role: 'user',
+    surface: 'orb',
+    vitana_id: args.vitana_id ?? undefined,
+  });
+}
+
+/**
+ * Reset the counter for a session — useful when an ORB session ends so
+ * the next session for the same user starts fresh. Otherwise sweeps occur
+ * on every check via TTL.
+ */
+export function resetSessionQuota(sessionId: string): void {
+  sendCounters.delete(sessionId);
+}

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -686,7 +686,13 @@ export type CicdEventType =
   // OAuth WebView fix Phase 5: background OAuth token refresher
   | 'oauth.token.refresh.succeeded'
   | 'oauth.token.refresh.failed'
-  | 'oauth.token.refresh.tombstoned';
+  | 'oauth.token.refresh.tombstoned'
+  // VTID-01967: Vitana ID voice messaging
+  | 'voice.message.sent'
+  | 'voice.message.rate_limited'
+  | 'voice.message.misroute'
+  | 'voice.message.share_link_sent'
+  | 'vitana_id.confirmed';
 
 export interface CicdOasisEvent {
   vtid: string;
@@ -703,6 +709,10 @@ export interface CicdOasisEvent {
   conversation_turn_id?: string;
   // VTID-01874: Explicit stage annotation for correct timeline mapping
   task_stage?: 'PLANNER' | 'WORKER' | 'VALIDATOR' | 'DEPLOY';
+  // VTID-01967: Canonical Vitana ID denormalized for support / audit queries.
+  // Auto-resolved from actor_id if omitted by caller (cached lookup in
+  // emitOasisEvent). Null when the event has no human actor (system/cron).
+  vitana_id?: string | null;
 }
 
 // ==================== Allowed Services for Deploy ====================

--- a/services/gateway/test/embedding-cache.test.ts
+++ b/services/gateway/test/embedding-cache.test.ts
@@ -1,0 +1,92 @@
+/**
+ * VTID-01970 — embedding-cache LRU unit tests
+ */
+
+import {
+  getCachedEmbedding,
+  setCachedEmbedding,
+  getCacheStats,
+  clearEmbeddingCache,
+  EMBEDDING_CACHE_MAX_FOR_TEST,
+} from '../src/services/embedding-cache';
+
+describe('embedding-cache (sha256→vector LRU)', () => {
+  beforeEach(() => {
+    clearEmbeddingCache();
+  });
+
+  it('returns null on miss', () => {
+    expect(getCachedEmbedding('hello world')).toBeNull();
+    const stats = getCacheStats();
+    expect(stats.misses).toBe(1);
+    expect(stats.hits).toBe(0);
+  });
+
+  it('round-trips set then get', () => {
+    const v = [0.1, 0.2, 0.3];
+    setCachedEmbedding('hello world', v, 'text-embedding-3-small', 3);
+    const hit = getCachedEmbedding('hello world');
+    expect(hit?.vector).toEqual(v);
+    expect(hit?.model).toBe('text-embedding-3-small');
+    expect(hit?.dimensions).toBe(3);
+    expect(getCacheStats().hits).toBe(1);
+  });
+
+  it('normalizes whitespace + case for the cache key', () => {
+    const v = [0.5, 0.5, 0.5];
+    setCachedEmbedding('Hello   World', v, 'm', 3);
+    expect(getCachedEmbedding('hello world')?.vector).toEqual(v);
+    expect(getCachedEmbedding('HELLO WORLD')?.vector).toEqual(v);
+    expect(getCachedEmbedding('  hello  world  ')?.vector).toEqual(v);
+  });
+
+  it('updates LRU position on access (recently used stays)', () => {
+    setCachedEmbedding('a', [1], 'm', 1);
+    setCachedEmbedding('b', [2], 'm', 1);
+    // Access 'a' so it becomes most-recent.
+    getCachedEmbedding('a');
+    setCachedEmbedding('c', [3], 'm', 1);
+    // All three should still fit under the limit (5000), so all retrievable.
+    expect(getCachedEmbedding('a')?.vector).toEqual([1]);
+    expect(getCachedEmbedding('b')?.vector).toEqual([2]);
+    expect(getCachedEmbedding('c')?.vector).toEqual([3]);
+  });
+
+  it('evicts oldest when at capacity', () => {
+    // We can't fill 5000 in a unit test cheaply, so verify the eviction
+    // semantics by inserting at-capacity from a wrapper test with a smaller
+    // cache. The constant is exposed for documentation; behavior is asserted
+    // by the LRU logic above. Here we just verify the constant is sane.
+    expect(EMBEDDING_CACHE_MAX_FOR_TEST).toBeGreaterThan(0);
+    expect(EMBEDDING_CACHE_MAX_FOR_TEST).toBeLessThanOrEqual(50000);
+  });
+
+  it('ignores empty/invalid inputs', () => {
+    setCachedEmbedding('', [1], 'm', 1);  // empty text
+    expect(getCachedEmbedding('')).toBeNull();
+
+    setCachedEmbedding('a', [], 'm', 0);  // empty vector
+    expect(getCachedEmbedding('a')).toBeNull();
+  });
+
+  it('hit_rate climbs with hits', () => {
+    setCachedEmbedding('repeat me', [9], 'm', 1);
+    for (let i = 0; i < 10; i++) {
+      getCachedEmbedding('repeat me');
+    }
+    const stats = getCacheStats();
+    expect(stats.hits).toBe(10);
+    expect(stats.misses).toBe(0);
+    expect(stats.hit_rate).toBe(1);
+  });
+
+  it('clearEmbeddingCache resets state', () => {
+    setCachedEmbedding('a', [1], 'm', 1);
+    getCachedEmbedding('a');
+    clearEmbeddingCache();
+    const stats = getCacheStats();
+    expect(stats.size).toBe(0);
+    expect(stats.hits).toBe(0);
+    expect(stats.misses).toBe(0);
+  });
+});

--- a/services/gateway/test/memory-audit-log.test.ts
+++ b/services/gateway/test/memory-audit-log.test.ts
@@ -1,0 +1,94 @@
+/**
+ * VTID-01966 — memory_audit_log unit tests
+ *
+ * Verifies the graceful no-op contract when SUPABASE_URL/SUPABASE_SERVICE_ROLE
+ * are unset (e.g. CI). The live audit-write path is exercised against the
+ * deployed Supabase RPC after migration.
+ */
+
+import {
+  appendMemoryAuditRow,
+  auditMemoryRead,
+  auditMemoryWrite,
+  type MemoryAuditOp,
+} from '../src/services/memory-audit';
+
+describe('memory_audit_log (no Supabase env — graceful no-op)', () => {
+  const origUrl = process.env.SUPABASE_URL;
+  const origSr = process.env.SUPABASE_SERVICE_ROLE;
+
+  beforeAll(() => {
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_ROLE;
+  });
+
+  afterAll(() => {
+    if (origUrl) process.env.SUPABASE_URL = origUrl;
+    if (origSr) process.env.SUPABASE_SERVICE_ROLE = origSr;
+  });
+
+  it('appendMemoryAuditRow does not throw when Supabase env is unset', async () => {
+    await expect(
+      appendMemoryAuditRow({
+        tenant_id: 't',
+        user_id: '00000000-0000-0000-0000-000000000000',
+        op: 'read',
+        tier: 'tier0',
+        actor_id: 'orb-live',
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('auditMemoryRead does not throw with full payload', async () => {
+    await expect(
+      auditMemoryRead({
+        tenant_id: 't',
+        user_id: '00000000-0000-0000-0000-000000000000',
+        tier: 'context-pack-builder',
+        actor_id: 'conversation-orb',
+        source_engine: 'context-pack-builder',
+        source_event_id: 'pack-123',
+        health_scope: true,
+        details: {
+          intent: 'recall_recent',
+          blocks_returned: ['MEMORY', 'CALENDAR'],
+          item_counts: { memory_garden: 5, knowledge_hub: 0, web_search: 0 },
+          latency_ms: 42,
+          cache_hit: true,
+          tokens_used: 1234,
+        },
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('auditMemoryWrite does not throw with full payload', async () => {
+    await expect(
+      auditMemoryWrite({
+        tenant_id: 't',
+        user_id: '00000000-0000-0000-0000-000000000000',
+        tier: 'memory_facts',
+        actor_id: 'cognee-extractor',
+        source_engine: 'cognee-extractor',
+        confidence: 0.85,
+        health_scope: true,
+        identity_scope: false,
+        details: { fact_key: 'sleep_avg_hours', fact_value: '7.2' },
+      })
+    ).resolves.toBeUndefined();
+  });
+
+  it('accepts all four op types', async () => {
+    const ops: MemoryAuditOp[] = ['read', 'write', 'delete', 'consolidate'];
+    for (const op of ops) {
+      await expect(
+        appendMemoryAuditRow({
+          tenant_id: 't',
+          user_id: '00000000-0000-0000-0000-000000000000',
+          op,
+          tier: 'test',
+          actor_id: 'test',
+        })
+      ).resolves.toBeUndefined();
+    }
+  });
+});

--- a/supabase/migrations/20260427000000_vtid_01966_memory_audit_log.sql
+++ b/supabase/migrations/20260427000000_vtid_01966_memory_audit_log.sql
@@ -1,0 +1,189 @@
+-- VTID-01966 — Memory Audit Log (HIPAA-grade dedicated audit table)
+--
+-- Phase 2 of the memory rebuild plan. Today some memory writes emit OASIS
+-- events but READS do not — leaving the HIPAA audit trail incomplete.
+-- This migration adds memory_audit_log (separate from oasis_events) so:
+--   1. Every memory read AND write is captured with full provenance.
+--   2. HIPAA replay queries (give me everything user X accessed in date
+--      range Y) are O(index) instead of O(table scan on oasis_events).
+--   3. The append-only audit table is partitioned by month so we can
+--      drop old partitions cheaply for retention compliance.
+--
+-- Plan: /home/dstev/.claude/plans/the-vitana-system-has-wild-puffin.md
+--       Part 7 Schema (memory_audit_log) + Part 8 Phase 2.
+
+BEGIN;
+
+-- ============================================================================
+-- 1. Parent table — partitioned by RANGE(created_at), monthly partitions.
+--    All writes go through the parent; Postgres routes to the right partition.
+-- ============================================================================
+
+CREATE TABLE IF NOT EXISTS public.memory_audit_log (
+  id              uuid          NOT NULL DEFAULT gen_random_uuid(),
+  tenant_id       text          NOT NULL,
+  user_id         uuid          NOT NULL,
+  op              text          NOT NULL CHECK (op IN ('read','write','delete','consolidate')),
+  tier            text          NOT NULL,           -- 'tier0','tier1','tier2','tier3','identity-lock', etc.
+  actor_id        text          NOT NULL,           -- e.g. 'orb-live', 'cognee-extractor', 'user_via_settings_ui'
+  source_engine   text,                              -- which engine (closes OASIS provenance gap)
+  confidence      real,                              -- 0..1; null for ops where it doesn't apply
+  source_event_id text,                              -- upstream OASIS event id, if applicable
+  policy_version  text          NOT NULL,           -- e.g. 'mem-2026.04'
+  health_scope    boolean       NOT NULL DEFAULT false,  -- HIPAA classification flag
+  identity_scope  boolean       NOT NULL DEFAULT false,  -- write to identity-locked fact?
+  details         jsonb         NOT NULL DEFAULT '{}',   -- intent, fact_keys hit, latency, etc.
+  created_at      timestamptz   NOT NULL DEFAULT now(),
+  PRIMARY KEY (id, created_at)
+) PARTITION BY RANGE (created_at);
+
+COMMENT ON TABLE public.memory_audit_log IS
+  'VTID-01966: HIPAA-grade dedicated audit trail for every memory read/write. Append-only. Partitioned by month — drop old partitions for retention compliance. Distinct from oasis_events (which captures system-wide events; this one captures memory-specific operations with rich detail).';
+
+COMMENT ON COLUMN public.memory_audit_log.tier IS 'Storage tier: tier0 (Redis), tier1 (FAISS), tier2 (pgvector), tier3 (Anthropic Memory Tool), identity-lock, write_fact_rpc, etc.';
+COMMENT ON COLUMN public.memory_audit_log.actor_id IS 'Who/what performed the operation. user/system/agent identifiers; correlates with provenance_source.';
+COMMENT ON COLUMN public.memory_audit_log.source_engine IS 'Which engine produced this row (orb-live, conversation-client, cognee-extractor, autopilot, brain, etc.).';
+COMMENT ON COLUMN public.memory_audit_log.policy_version IS 'Memory governance policy version at audit time (e.g. mem-2026.04). Required for forward-compatible HIPAA audit.';
+COMMENT ON COLUMN public.memory_audit_log.health_scope IS 'TRUE if the operation touched health-classified data; gates HIPAA replay reports.';
+COMMENT ON COLUMN public.memory_audit_log.identity_scope IS 'TRUE if the operation touched an identity-locked fact_key (Maria → Kemal class).';
+COMMENT ON COLUMN public.memory_audit_log.details IS 'Free-form JSONB: query_preview, intent, fact_keys, latency_ms, blocks_returned, error_message, etc.';
+
+
+-- ============================================================================
+-- 2. Static partitions covering 2026-04 → 2027-04 (13 months).
+--    A follow-up partition-rotation cron (or pg_partman) handles 2027-05+.
+--    Static partitions are the simplest path that's safe for prod today.
+-- ============================================================================
+
+DO $$
+DECLARE
+  yr int;
+  mo int;
+  start_date date;
+  end_date   date;
+  part_name  text;
+BEGIN
+  FOR i IN 0..12 LOOP
+    start_date := make_date(2026, 4, 1) + (i || ' months')::interval;
+    end_date   := start_date + interval '1 month';
+    yr := extract(year FROM start_date)::int;
+    mo := extract(month FROM start_date)::int;
+    part_name := format('memory_audit_log_y%sm%s', yr, lpad(mo::text, 2, '0'));
+
+    EXECUTE format(
+      'CREATE TABLE IF NOT EXISTS public.%I PARTITION OF public.memory_audit_log FOR VALUES FROM (%L) TO (%L);',
+      part_name, start_date, end_date
+    );
+  END LOOP;
+END $$;
+
+
+-- ============================================================================
+-- 3. Indexes for HIPAA replay + dashboards.
+--    Created on the parent so they propagate to every partition.
+-- ============================================================================
+
+CREATE INDEX IF NOT EXISTS memory_audit_log_user_recency
+  ON public.memory_audit_log (user_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS memory_audit_log_tenant_recency
+  ON public.memory_audit_log (tenant_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS memory_audit_log_health_scope
+  ON public.memory_audit_log (tenant_id, user_id, created_at DESC)
+  WHERE health_scope = true;
+
+CREATE INDEX IF NOT EXISTS memory_audit_log_identity_scope
+  ON public.memory_audit_log (tenant_id, user_id, created_at DESC)
+  WHERE identity_scope = true;
+
+CREATE INDEX IF NOT EXISTS memory_audit_log_op_tier_recency
+  ON public.memory_audit_log (op, tier, created_at DESC);
+
+
+-- ============================================================================
+-- 4. RLS — service-role only. The audit table is internal; users never read
+--    their own audit log via RLS. HIPAA replay queries run as service_role
+--    via gateway audit endpoints (separate VTID for the read API).
+-- ============================================================================
+
+ALTER TABLE public.memory_audit_log ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS memory_audit_log_service_role_all ON public.memory_audit_log;
+CREATE POLICY memory_audit_log_service_role_all
+  ON public.memory_audit_log
+  FOR ALL
+  TO service_role
+  USING (true)
+  WITH CHECK (true);
+
+
+-- ============================================================================
+-- 5. Insert helper RPC — single entry-point used by gateway memory-audit.ts.
+--    SECURITY DEFINER so the gateway can use the anon key path if it wants
+--    (today it uses service_role directly; this is forward-compatible).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.memory_audit_log_insert(
+  p_tenant_id       text,
+  p_user_id         uuid,
+  p_op              text,
+  p_tier            text,
+  p_actor_id        text,
+  p_policy_version  text,
+  p_source_engine   text DEFAULT NULL,
+  p_confidence      real DEFAULT NULL,
+  p_source_event_id text DEFAULT NULL,
+  p_health_scope    boolean DEFAULT false,
+  p_identity_scope  boolean DEFAULT false,
+  p_details         jsonb DEFAULT '{}'::jsonb
+) RETURNS uuid
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_id uuid := gen_random_uuid();
+BEGIN
+  INSERT INTO public.memory_audit_log (
+    id, tenant_id, user_id, op, tier, actor_id, source_engine,
+    confidence, source_event_id, policy_version, health_scope,
+    identity_scope, details, created_at
+  ) VALUES (
+    v_id, p_tenant_id, p_user_id, p_op, p_tier, p_actor_id, p_source_engine,
+    p_confidence, p_source_event_id, p_policy_version, COALESCE(p_health_scope, false),
+    COALESCE(p_identity_scope, false), COALESCE(p_details, '{}'::jsonb), now()
+  );
+  RETURN v_id;
+END $$;
+
+COMMENT ON FUNCTION public.memory_audit_log_insert IS
+  'VTID-01966: Single-entry insert helper for memory_audit_log. Used by gateway memory-audit.ts auditMemoryRead/Write. SECURITY DEFINER for forward compatibility.';
+
+GRANT EXECUTE ON FUNCTION public.memory_audit_log_insert TO service_role;
+
+
+COMMIT;
+
+-- =====================================================================
+-- VERIFICATION (run after migration applies):
+--
+-- A) Parent + partitions exist:
+--    SELECT relname FROM pg_class
+--      WHERE relname LIKE 'memory_audit_log%'
+--      ORDER BY relname;
+--    -- Expected: parent + 13 monthly partitions (y2026m04 through y2027m04).
+--
+-- B) Insert via RPC:
+--    SELECT public.memory_audit_log_insert(
+--      'test-tenant', gen_random_uuid(), 'read', 'tier0',
+--      'orb-live', 'mem-2026.04', 'orb-live', 1.0,
+--      NULL, false, false, '{"intent":"recall_recent"}'::jsonb
+--    );
+--    SELECT count(*) FROM memory_audit_log WHERE actor_id='orb-live';
+--
+-- C) Confirm partition routing:
+--    EXPLAIN INSERT INTO memory_audit_log (tenant_id, user_id, op, tier,
+--      actor_id, policy_version) VALUES ('t','...uuid...','write','tier2','x','v');
+--    -- Should show "Insert on memory_audit_log_y2026m04" (current partition).
+-- =====================================================================


### PR DESCRIPTION
## Summary

Part 2 — Release A (P2-A). Reframes the original "Reverse Marketplace" as a unified **Voice-Dictated Intent Engine** spanning six intent kinds. All ride the same plumbing, discriminated by \`intent_kind\` + Life Compass goal; every match is a \`vitana_id ↔ vitana_id\` join (the Part 1 spine the user explicitly asked for).

**Behind \`FEATURE_INTENT_ENGINE_A\` — disabled by default. No voice tools, no UI yet.** Pure data plane; voice tools + Business Hub UI land in P2-B.

**Base branch**: \`feat/VTID-01969-vitana-id-release-c\` (chained — depends on PR #935 + Release A/B migrations applied).

## What ships

### 11 services (10 new + the existing chain + 5 routes)

| Service | Purpose |
|---|---|
| \`intent-classifier.ts\` | Vertex/Gemini call (temp 0.1 JSON) maps utterance → \`{intent_kind, confidence}\`. 0.7 confidence floor. |
| \`intent-extractor.ts\` | Strategy pattern over 5 per-kind extractors. Returns \`{fields, confidence, missing_critical}\`. |
| \`intent-matcher.ts\` | Wraps \`compute_intent_matches()\` RPC + federates \`commercial_buy\` against affiliate \`products\` catalog (read-only). |
| \`intent-embedding.ts\` | 768-dim embedding via existing \`embedding-service.ts\`. |
| \`intent-compass-lens.ts\` | Reads \`life_compass.is_active=true\` + \`intent_compass_boost\` lookup; returns 0.0-0.10 alignment bonus. 5min cache. |
| \`intent-content-filter.ts\` | Regex profanity + PII (email/phone/IBAN). Stricter for partner_seek/social_seek. |
| \`intent-throttle.ts\` | New-account caps + mature daily caps per kind. |
| \`intent-tier-gate.ts\` | Part 1 trust-tier gate. P2-A baseline: \`vitana_id_locked=true\` → \`community_verified\`. |
| \`intent-notifier.ts\` | P2-A audit-only stub (OASIS event on every surfaced match). Real per-kind 3/24h push cap lands in P2-B. |
| \`intent-mutual-reveal.ts\` | partner_seek protocol enforcer. Redacts \`vitana_id_b\` from API payloads until \`mutual_reveal_unlocked_at IS NOT NULL\`. |

### 5 routes (mounted behind FEATURE_INTENT_ENGINE_A)
- \`POST/GET/PATCH /api/v1/intents\` + \`/:id/close\` + \`/:id/matches\` — single endpoint for all intent kinds. Accepts structured fields OR \`utterance\` (server runs classifier + extractor).
- \`/api/v1/intent-matches/{incoming,outgoing,:id/state,:id/decline}\` — bilateral \`responded_by_a/b\` auto-promotes to \`mutual_interest\`, kicks reveal protocol.
- \`/api/v1/intent-board\` — compass-aware default feed; partner_seek gated behind explicit opt-in + redacted.
- \`/api/v1/intent-categories\` — per-kind taxonomy, Cache-Control 24h.
- \`/api/v1/admin/intent-engine/{intent/:id, recompute, stats}\` — exafy_admin only; stuck-open-24h panel.

### vitana_id = the spine
- \`user_intents.requester_vitana_id\` (denormalised via trigger from \`profiles.vitana_id\` Part 1 Release A).
- \`intent_matches.vitana_id_a\` + \`vitana_id_b\` (denormalised at insert via the matcher).
- Every OASIS event tagged with \`vitana_id\` via the Release B oasis-event-service auto-resolve.
- Support tooling, voice notifications, Command Hub admin views all quote \`@<id>\` without joining profiles.

### Life Compass = the lens
- New \`intent_compass_boost\` table (seeded with the boost matrix: earn_money/business → commercial+social_seek; longevity/health → activity_seek; family/community → mutual_aid; etc.).
- New \`intent_compass_alignment\` view joins each intent with the user's active life_compass goal.
- Match score gets \`+0.10\` when both parties' compass categories are in the boost matrix.
- \`intent-board.ts\` shows kind defaults based on the reader's active compass goal (\"earn money\" sees commercial; \"longevity\" sees activity).

## Test plan

- [ ] Pre-merge: confirm Release A (#246) + Release B (#933 + #247) + Release C (#935 + #249) merged + migrations applied to staging.
- [ ] Apply 9 P2-A migrations sequentially via \`RUN-MIGRATION.yml\`.
- [ ] \`SELECT count(*) FROM intent_kinds\` → 6.
- [ ] \`SELECT count(*) FROM intent_compatibility\` → 6.
- [ ] \`SELECT count(*) FROM intent_categories WHERE kind_key='commercial_buy'\` → 30.
- [ ] Set \`FEATURE_INTENT_ENGINE_A=true\` in dev gateway env, redeploy.
- [ ] Smoke each kind via curl:
  ```bash
  # commercial_buy via utterance path
  curl -X POST $GW/api/v1/intents -H \"Authorization: Bearer \$JWT\" -H \"Content-Type: application/json\" \\
       -d '{\"utterance\":\"I need an electrician in Vienna for a kitchen rewiring, 600 to 1200 euros, this week\"}'
  # → 201 with intent_id + classifier resolved commercial_buy + extractor filled scope/budget/location.

  # activity_seek via structured fields
  curl -X POST $GW/api/v1/intents -d '{\"intent_kind\":\"activity_seek\",\"category\":\"sport.tennis\",\"title\":\"Tennis partner Tuesday\",\"scope\":\"...\",\"kind_payload\":{\"activity\":\"tennis\",\"time_windows\":[\"tue 18:00-20:00\"],\"location_label\":\"Vienna 1010\",\"skill_level\":\"intermediate\"}}'

  # partner_seek
  curl -X POST $GW/api/v1/intents -d '{\"intent_kind\":\"partner_seek\",\"category\":\"life_partner\",\"title\":\"Looking for life partner\",\"scope\":\"...\",\"kind_payload\":{\"age_range\":[35,42],\"location_radius_km\":25}}'

  # Verify mutual-reveal redaction:
  curl $GW/api/v1/intent-matches/outgoing
  # → vitana_id_b is null on partner_seek matches until both parties express interest.
  ```
- [ ] Compass-aware feed: switch user's active compass to \"longevity\" and confirm \`/api/v1/intent-board\` shows activity_seek matches first.
- [ ] Affiliate federation: post a commercial_buy in a category that maps to existing products → \`/intents/:id/matches\` includes \`external_target_kind=product\` rows alongside user-vs-user.

## Rollback

\`FEATURE_INTENT_ENGINE_A=false\` removes all routes from the mounted surface (gating happens at boot). Migrations are additive — drop the 4 new tables (\`user_intents\`, \`intent_matches\`, \`intent_events\`, \`intent_compass_boost\`) + 1 view + 9 functions to fully reverse. \`profiles\` and existing tables are untouched.

## Next

- **P2-B**: ORB voice tool \`post_intent\`, kind-aware proactive prompts, Business Hub Opportunities + My Listings tabs, community IntentBoard, push notifications with per-kind 3/24h caps, mutual-reveal UI, compass-change resurface job.
- **P2-C**: embedding worker (NOTIFY-driven), prod content moderation, dispute flow, KPI tile, archival, monetization columns (still gated off).

🤖 Generated with [Claude Code](https://claude.com/claude-code)