### PR TITLE
fix(presence): fallback to user_tenants when me_context.tenant_id is null (BOOTSTRAP-PRESENCE-TENANT-FB)

### DIFF
--- a/services/gateway/src/routes/presence-did-you-know.ts
+++ b/services/gateway/src/routes/presence-did-you-know.ts
@@ -49,10 +49,23 @@ async function resolveIdentity(req: Request): Promise<{
     if (error || !data) {
       return { user_id: null, tenant_id: null, error: error?.message || 'no_context' };
     }
-    return {
-      user_id: data.user_id || data.id || null,
-      tenant_id: data.tenant_id || null,
-    };
+    const userId = data.user_id || data.id || null;
+    let tenantId = data.tenant_id || null;
+    // Fallback: me_context returns tenant_id=null for users whose
+    // app_metadata.active_tenant_id was never populated, even when a
+    // primary user_tenants row exists. Match the behavior of the
+    // gateway's requireAuthWithTenant middleware (auth-supabase-jwt.ts).
+    if (!tenantId && userId) {
+      const { data: tenantRow } = await supabase
+        .from('user_tenants')
+        .select('tenant_id')
+        .eq('user_id', userId)
+        .eq('is_primary', true)
+        .limit(1)
+        .maybeSingle();
+      tenantId = tenantRow?.tenant_id || null;
+    }
+    return { user_id: userId, tenant_id: tenantId };
   } catch (err: any) {
     return { user_id: null, tenant_id: null, error: err.message };
   }

--- a/services/gateway/src/routes/presence.ts
+++ b/services/gateway/src/routes/presence.ts
@@ -41,9 +41,25 @@ async function resolveIdentity(req: Request): Promise<{
     if (error || !data) {
       return { user_id: null, tenant_id: null, user_name: null, error: error?.message || 'no_context' };
     }
+    const userId = data.user_id || data.id || null;
+    let tenantId = data.tenant_id || null;
+    // Fallback: me_context returns tenant_id=null for users whose
+    // app_metadata.active_tenant_id was never populated, even when a
+    // primary user_tenants row exists. Match the behavior of the
+    // gateway's requireAuthWithTenant middleware (auth-supabase-jwt.ts).
+    if (!tenantId && userId) {
+      const { data: tenantRow } = await supabase
+        .from('user_tenants')
+        .select('tenant_id')
+        .eq('user_id', userId)
+        .eq('is_primary', true)
+        .limit(1)
+        .maybeSingle();
+      tenantId = tenantRow?.tenant_id || null;
+    }
     return {
-      user_id: data.user_id || data.id || null,
-      tenant_id: data.tenant_id || null,
+      user_id: userId,
+      tenant_id: tenantId,
       user_name: data.display_name || null,
     };
   } catch (err: any) {


### PR DESCRIPTION
## Summary

`/api/v1/presence/welcome`, `/priority`, and the new `/did-you-know` all use a local `resolveIdentity` helper that calls the `me_context` RPC and 401s if `tenant_id` is null. For users whose `app_metadata.active_tenant_id` was never populated, `me_context` returns `tenant_id: null` **even when a primary `user_tenants` row exists** — and the routes reject the request.

This is the exact pattern `requireAuthWithTenant` (the gateway's auth middleware) already handles: if the JWT has no tenant_id, look up `user_tenants` where `user_id = ? AND is_primary = true`. Apply the same fallback to `resolveIdentity` in both `presence.ts` and `presence-did-you-know.ts`.

## How it surfaced

The standard E2E test user `e2e-test@vitana.dev` (`a27552a3-…`) has this configuration — `user_tenants` row points to tenant `2e7528b8-472a-4356-88da-0280d4639cce` with `is_primary=true`, but `app_metadata` was never updated. Without this fix, none of the presence routes work for that user, blocking visual smoke tests of the DYK card on `/home` plus the existing Welcome Banner / Priority of Day banner.

## Test plan

- [x] TypeScript typecheck passes
- [ ] Post-deploy: curl `/api/v1/presence/did-you-know` as the test user → expect `should_show=true` with day-0 `vitana_index` tip (no longer `unauthorized`)
- [ ] Same for `/welcome` and `/priority`
- [ ] Playwright smoke: sign in as test user, screenshot `/home` desktop+mobile, expect `<DidYouKnowCard>` visible

## Follow-up (out of scope)

The two `resolveIdentity` helpers are duplicate; worth hoisting into a shared `lib/presence-identity.ts` so this fallback only lives in one place.

🤖 Generated with [Claude Code](https://claude.com/claude-code)