### PR TITLE
chore(dyk): clear today's proactive touches for e2e test user (BOOTSTRAP-DYK-SMOKE)

### DIFF
--- a/supabase/migrations/20260426120000_clear_dyk_test_user_touches.sql
+++ b/supabase/migrations/20260426120000_clear_dyk_test_user_touches.sql
@@ -1,0 +1,5 @@
+-- BOOTSTRAP-DYK-SMOKE — clear today's proactive touches for the e2e test user
+-- so we can re-verify the DYK card renders end-to-end. One-off; safe to re-run.
+DELETE FROM public.user_proactive_touches
+WHERE user_id = 'a27552a3-0257-4305-8ed0-351a80fd3701'
+  AND sent_at >= date_trunc('day', NOW() AT TIME ZONE 'UTC');


### PR DESCRIPTION
One-off SQL to reset the per-user daily-cap state for the e2e test user so the DYK card can be visually verified end-to-end. Earlier curl smoke against `/presence/did-you-know` + `/priority` already consumed the balanced cap of 2 for today UTC (proves the pacer works) — but blocks the Playwright screenshot. Idempotent.