### PR TITLE
feat(llm): provider routing facade — phase A (BOOTSTRAP-LLM-ROUTER)

### DIFF
--- a/services/gateway/src/constants/llm-defaults.ts
+++ b/services/gateway/src/constants/llm-defaults.ts
@@ -1,25 +1,49 @@
 /**
- * VTID-01208: LLM Safe Defaults Constants
+ * VTID-01208 + BOOTSTRAP-LLM-ROUTER: LLM Safe Defaults Constants
  *
- * These are the hardcoded safe defaults for LLM routing.
- * Used when:
+ * Hardcoded safe defaults for LLM routing. Used when:
  * - "Reset to Recommended" is clicked
  * - Database is unavailable
  * - Policy validation fails
  *
- * IMPORTANT: These defaults cannot be changed via UI.
- * Changes require code review and deployment.
+ * BOOTSTRAP-LLM-ROUTER (2026-04-26): defaults are now flagship-only — every
+ * primary and every fallback is its provider's strongest available model.
+ * Operator can step down via the Command Hub dropdown but the system never
+ * silently picks a weaker option.
+ *
+ * Stages extended from {planner|worker|validator|operator|memory} to also
+ * include {triage|vision|classifier} so per-call-site routing maps cleanly
+ * onto the JSONB policy doc. Providers extended from {anthropic|vertex|openai}
+ * to also include {deepseek|claude_subscription}.
  */
 
 /**
  * LLM Stage types
  */
-export type LLMStage = 'planner' | 'worker' | 'validator' | 'operator' | 'memory';
+export type LLMStage =
+  | 'planner'
+  | 'worker'
+  | 'validator'
+  | 'operator'
+  | 'memory'
+  | 'triage'
+  | 'vision'
+  | 'classifier';
 
 /**
  * LLM Provider types
+ *
+ * `claude_subscription` is the free pseudo-provider that delegates to the
+ * local autopilot-worker daemon (`runWorkerTask`) which executes via the
+ * user's Claude Pro/Max plan. It only makes sense for the `worker` and
+ * `planner` stages — the dropdown should hide it elsewhere.
  */
-export type LLMProvider = 'anthropic' | 'vertex' | 'openai';
+export type LLMProvider =
+  | 'anthropic'
+  | 'vertex'
+  | 'openai'
+  | 'deepseek'
+  | 'claude_subscription';
 
 /**
  * Stage routing configuration
@@ -27,8 +51,8 @@ export type LLMProvider = 'anthropic' | 'vertex' | 'openai';
 export interface StageRoutingConfig {
   primary_provider: LLMProvider;
   primary_model: string;
-  fallback_provider: LLMProvider;
-  fallback_model: string;
+  fallback_provider: LLMProvider | null;
+  fallback_model: string | null;
 }
 
 /**
@@ -40,48 +64,65 @@ export interface LLMRoutingPolicy {
   validator: StageRoutingConfig;
   operator: StageRoutingConfig;
   memory: StageRoutingConfig;
+  triage: StageRoutingConfig;
+  vision: StageRoutingConfig;
+  classifier: StageRoutingConfig;
 }
 
 /**
- * Safe defaults for LLM routing policy
+ * Flagship-only safe defaults per the BOOTSTRAP-LLM-ROUTER plan.
  *
- * Rationale:
- * - Planner: Claude 3.5 Sonnet - Best reasoning for task decomposition
- * - Worker: Gemini 1.5 Flash - Cost-efficient execution
- * - Validator: Claude 3.5 Sonnet - Strict rule-following for governance
- * - Operator: Gemini 2.5 Pro - Multimodal conversational capability
- * - Memory: Claude 3.5 Sonnet - Fact extraction accuracy
+ * Every primary AND every fallback is the strongest model the provider
+ * exposes. No mid-tier defaults seeded anywhere.
  */
 export const LLM_SAFE_DEFAULTS: LLMRoutingPolicy = {
   planner: {
-    primary_provider: 'anthropic',
-    primary_model: 'claude-3-5-sonnet-20241022',
-    fallback_provider: 'vertex',
-    fallback_model: 'gemini-1.5-pro',
+    primary_provider: 'vertex',
+    primary_model: 'gemini-3.1-pro',
+    fallback_provider: 'anthropic',
+    fallback_model: 'claude-opus-4-7',
   },
   worker: {
-    primary_provider: 'vertex',
-    primary_model: 'gemini-1.5-flash',
+    primary_provider: 'claude_subscription',
+    primary_model: 'claude-opus-4-7',
     fallback_provider: 'vertex',
-    fallback_model: 'gemini-1.5-pro',
+    fallback_model: 'gemini-3.1-pro',
   },
   validator: {
-    primary_provider: 'anthropic',
-    primary_model: 'claude-3-5-sonnet-20241022',
-    fallback_provider: 'vertex',
-    fallback_model: 'gemini-1.5-pro',
+    primary_provider: 'vertex',
+    primary_model: 'gemini-3.1-pro',
+    fallback_provider: 'anthropic',
+    fallback_model: 'claude-opus-4-7',
   },
   operator: {
     primary_provider: 'vertex',
-    primary_model: 'gemini-2.5-pro',
+    primary_model: 'gemini-3.1-pro',
     fallback_provider: 'anthropic',
-    fallback_model: 'claude-3-5-sonnet-20241022',
+    fallback_model: 'claude-opus-4-7',
   },
   memory: {
-    primary_provider: 'anthropic',
-    primary_model: 'claude-3-5-sonnet-20241022',
+    primary_provider: 'vertex',
+    primary_model: 'gemini-3.1-pro',
+    fallback_provider: 'deepseek',
+    fallback_model: 'deepseek-reasoner',
+  },
+  triage: {
+    primary_provider: 'vertex',
+    primary_model: 'gemini-3.1-pro',
+    fallback_provider: 'anthropic',
+    fallback_model: 'claude-opus-4-7',
+  },
+  vision: {
+    primary_provider: 'vertex',
+    primary_model: 'gemini-3.1-pro',
+    fallback_provider: 'anthropic',
+    fallback_model: 'claude-opus-4-7',
+  },
+  classifier: {
+    primary_provider: 'deepseek',
+    primary_model: 'deepseek-reasoner',
     fallback_provider: 'vertex',
-    fallback_model: 'gemini-1.5-flash',
+    fallback_model: 'gemini-3.1-pro',
   },
 };
 
@@ -90,19 +131,33 @@ export const LLM_SAFE_DEFAULTS: LLMRoutingPolicy = {
  * Used for cost estimation in telemetry
  */
 export const MODEL_COSTS: Record<string, { input: number; output: number }> = {
-  // Anthropic
+  // Anthropic — flagship + mid + light
+  'claude-opus-4-7': { input: 15.00, output: 75.00 },
+  'claude-sonnet-4-6': { input: 3.00, output: 15.00 },
+  'claude-haiku-4-5': { input: 0.80, output: 4.00 },
   'claude-3-5-sonnet-20241022': { input: 3.00, output: 15.00 },
   'claude-3-opus-20240229': { input: 15.00, output: 75.00 },
   'claude-3-haiku-20240307': { input: 0.25, output: 1.25 },
 
-  // Google Vertex AI
+  // Google Vertex AI — flagship + mid + light
+  'gemini-3.1-pro': { input: 1.25, output: 5.00 },        // pricing TBD by Google; using 2.5 Pro rate as best estimate
+  'gemini-3-pro-preview': { input: 1.25, output: 5.00 },  // legacy alias retained for back-compat
   'gemini-2.5-pro': { input: 1.25, output: 5.00 },
+  'gemini-2.5-flash': { input: 0.075, output: 0.30 },
   'gemini-1.5-pro': { input: 1.25, output: 5.00 },
   'gemini-1.5-flash': { input: 0.075, output: 0.30 },
 
-  // OpenAI (future support)
+  // OpenAI — flagship + mid + light
+  'gpt-5': { input: 5.00, output: 15.00 },                // pricing TBD by OpenAI; using gpt-4o rate as best estimate
   'gpt-4o': { input: 5.00, output: 15.00 },
   'gpt-4o-mini': { input: 0.15, output: 0.60 },
+
+  // DeepSeek — flagship + mid
+  'deepseek-reasoner': { input: 0.55, output: 2.19 },     // R1 published rates
+  'deepseek-chat': { input: 0.14, output: 0.28 },         // V3 published rates
+
+  // claude_subscription pseudo-provider — billed via Claude Pro/Max plan, not per-token
+  'claude-subscription': { input: 0, output: 0 },
 };
 
 /**
@@ -127,22 +182,53 @@ export function estimateCost(
 /**
  * Valid stages for routing
  */
-export const VALID_STAGES: LLMStage[] = ['planner', 'worker', 'validator', 'operator', 'memory'];
+export const VALID_STAGES: LLMStage[] = [
+  'planner',
+  'worker',
+  'validator',
+  'operator',
+  'memory',
+  'triage',
+  'vision',
+  'classifier',
+];
 
 /**
  * Valid providers
  */
-export const VALID_PROVIDERS: LLMProvider[] = ['anthropic', 'vertex', 'openai'];
+export const VALID_PROVIDERS: LLMProvider[] = [
+  'anthropic',
+  'vertex',
+  'openai',
+  'deepseek',
+  'claude_subscription',
+];
+
+/**
+ * Per-provider flagship — looked up by the Command Hub dropdown so flipping
+ * providers always lands on the strongest model from the new provider, never
+ * on a mid-tier or light option.
+ */
+export const PROVIDER_FLAGSHIPS: Record<LLMProvider, string> = {
+  anthropic: 'claude-opus-4-7',
+  vertex: 'gemini-3.1-pro',
+  openai: 'gpt-5',
+  deepseek: 'deepseek-reasoner',
+  claude_subscription: 'claude-opus-4-7',
+};
 
 /**
  * Recommended models per stage (for UI warnings)
  */
 export const RECOMMENDED_MODELS: Record<LLMStage, string[]> = {
-  planner: ['claude-3-5-sonnet-20241022', 'claude-3-opus-20240229'],
-  worker: ['gemini-1.5-flash', 'gemini-1.5-pro', 'claude-3-haiku-20240307'],
-  validator: ['claude-3-5-sonnet-20241022'],
-  operator: ['gemini-2.5-pro', 'gemini-1.5-pro'],
-  memory: ['claude-3-5-sonnet-20241022', 'claude-3-haiku-20240307'],
+  planner: ['gemini-3.1-pro', 'claude-opus-4-7', 'gpt-5'],
+  worker: ['claude-opus-4-7', 'gemini-3.1-pro', 'gpt-5'],
+  validator: ['gemini-3.1-pro', 'claude-opus-4-7'],
+  operator: ['gemini-3.1-pro', 'claude-opus-4-7'],
+  memory: ['gemini-3.1-pro', 'deepseek-reasoner', 'claude-opus-4-7'],
+  triage: ['gemini-3.1-pro', 'claude-opus-4-7', 'deepseek-reasoner'],
+  vision: ['gemini-3.1-pro', 'claude-opus-4-7'],
+  classifier: ['deepseek-reasoner', 'gemini-3.1-pro', 'gpt-5'],
 };
 
 /**
@@ -157,6 +243,14 @@ export function isRecommendedModel(stage: LLMStage, model: string): boolean {
  */
 export function getStageDefaults(stage: LLMStage): StageRoutingConfig {
   return LLM_SAFE_DEFAULTS[stage];
+}
+
+/**
+ * Get the flagship model id for a provider (used by Command Hub dropdown
+ * auto-select when the operator switches providers).
+ */
+export function getProviderFlagship(provider: LLMProvider): string {
+  return PROVIDER_FLAGSHIPS[provider];
 }
 
 export default LLM_SAFE_DEFAULTS;

--- a/services/gateway/src/routes/llm.ts
+++ b/services/gateway/src/routes/llm.ts
@@ -28,19 +28,33 @@ const router = Router();
 // Validation Schemas
 // =============================================================================
 
+// BOOTSTRAP-LLM-ROUTER: extended provider list (added deepseek + claude_subscription)
+// and made fallback nullable so a stage can be configured with no fallback.
+const ProviderEnum = z.enum([
+  'anthropic',
+  'vertex',
+  'openai',
+  'deepseek',
+  'claude_subscription',
+] as const);
+
 const StageConfigSchema = z.object({
-  primary_provider: z.enum(['anthropic', 'vertex', 'openai'] as const),
+  primary_provider: ProviderEnum,
   primary_model: z.string().min(1),
-  fallback_provider: z.enum(['anthropic', 'vertex', 'openai'] as const),
-  fallback_model: z.string().min(1),
+  fallback_provider: ProviderEnum.nullable(),
+  fallback_model: z.string().min(1).nullable(),
 });
 
+// BOOTSTRAP-LLM-ROUTER: extended schema with triage/vision/classifier stages.
 const PolicySchema = z.object({
   planner: StageConfigSchema,
   worker: StageConfigSchema,
   validator: StageConfigSchema,
   operator: StageConfigSchema,
   memory: StageConfigSchema,
+  triage: StageConfigSchema,
+  vision: StageConfigSchema,
+  classifier: StageConfigSchema,
 });
 
 const UpdatePolicySchema = z.object({
@@ -54,7 +68,16 @@ const ResetPolicySchema = z.object({
 
 const TelemetryQuerySchema = z.object({
   vtid: z.string().optional(),
-  stage: z.enum(['planner', 'worker', 'validator', 'operator', 'memory'] as const).optional(),
+  stage: z.enum([
+    'planner',
+    'worker',
+    'validator',
+    'operator',
+    'memory',
+    'triage',
+    'vision',
+    'classifier',
+  ] as const).optional(),
   provider: z.string().optional(),
   model: z.string().optional(),
   service: z.string().optional(),

--- a/services/gateway/src/services/llm-router.ts
+++ b/services/gateway/src/services/llm-router.ts
@@ -1,0 +1,585 @@
+/**
+ * BOOTSTRAP-LLM-ROUTER: Provider-agnostic LLM call dispatcher.
+ *
+ * Why this exists:
+ *   Every LLM call site in the gateway used to hard-code Anthropic. As we
+ *   scale 10-50× into autonomous operation, the per-call API cost becomes
+ *   prohibitive. This router reads the active `llm_routing_policy.policy[stage]`
+ *   row and dispatches to the configured provider — Anthropic, OpenAI,
+ *   Vertex (Google), DeepSeek, or claude_subscription (free, via worker queue).
+ *
+ *   Operators flip providers via the Command Hub dropdown without code edits.
+ *   Defaults are FLAGSHIP-ONLY: every primary and fallback in LLM_SAFE_DEFAULTS
+ *   is the strongest model the provider exposes. Stepping down to a mid-tier
+ *   model is opt-in per stage, never automatic.
+ *
+ * Architecture:
+ *   callViaRouter(stage, prompt, opts)
+ *     ├─ load policy[stage] (cached 30s)
+ *     ├─ call adapter[primary_provider].call(prompt, primary_model)
+ *     │   ├─ on success → completeLLMCall + return {ok:true, text, usage, ...}
+ *     │   └─ on failure → if fallback set, call adapter[fallback_provider]
+ *     │                   → record fallback_used=true in telemetry
+ *     └─ never throws — always returns {ok, text? | error?}
+ *
+ *   Adapters live inline in this file (small, no shared state) rather than
+ *   one-file-per-provider. Each adapter implements `call(prompt, model)
+ *   → Promise<AdapterResult>`. Adding a sixth provider is a new entry in
+ *   the ADAPTERS map plus an env var read.
+ *
+ * Reuses (do NOT reimplement):
+ *   - getActivePolicy() from llm-routing-policy-service.ts
+ *   - startLLMCall / completeLLMCall / failLLMCall from llm-telemetry-service.ts
+ *   - LLM_SAFE_DEFAULTS / estimateCost from constants/llm-defaults.ts
+ */
+
+import { getActivePolicy } from './llm-routing-policy-service';
+import { startLLMCall, completeLLMCall, failLLMCall } from './llm-telemetry-service';
+import {
+  LLM_SAFE_DEFAULTS,
+  type LLMRoutingPolicy,
+  type LLMStage,
+  type LLMProvider,
+  type StageRoutingConfig,
+} from '../constants/llm-defaults';
+
+const LOG_PREFIX = '[llm-router]';
+
+// =============================================================================
+// Public types
+// =============================================================================
+
+export interface LLMUsage {
+  inputTokens: number;
+  outputTokens: number;
+}
+
+export interface LLMRouterOpts {
+  /** VTID for telemetry correlation. Optional — falls back to VTID-LLM-ROUTER. */
+  vtid?: string | null;
+  /** Service that originated the call (e.g. 'triage-agent'). Logged in OASIS. */
+  service: string;
+  /** Allow fallback adapter on primary failure. Defaults true. */
+  allowFallback?: boolean;
+  /** Override max output tokens. Adapter may clamp to its own limit. */
+  maxTokens?: number;
+  /** Optional system prompt prepended to the user prompt. */
+  systemPrompt?: string;
+  /** Optional structured input for vision: base64 image + mime type. */
+  image?: { base64: string; mimeType: string };
+}
+
+export interface LLMRouterResult {
+  ok: boolean;
+  text?: string;
+  usage?: LLMUsage;
+  provider?: LLMProvider;
+  model?: string;
+  fallbackUsed?: boolean;
+  error?: string;
+}
+
+interface AdapterCallArgs {
+  prompt: string;
+  model: string;
+  systemPrompt?: string;
+  maxTokens?: number;
+  image?: { base64: string; mimeType: string };
+}
+
+interface AdapterResult {
+  ok: boolean;
+  text?: string;
+  usage?: LLMUsage;
+  error?: string;
+}
+
+interface ProviderAdapter {
+  /** Execute a prompt against the provider's API. Must not throw. */
+  call(args: AdapterCallArgs): Promise<AdapterResult>;
+  /** True if this provider has the env credentials it needs to run. */
+  isAvailable(): boolean;
+}
+
+// =============================================================================
+// Policy cache (30s TTL — same provider keeps serving across short bursts
+// without re-reading the policy table for every call)
+// =============================================================================
+
+const POLICY_CACHE_TTL_MS = 30_000;
+let cachedPolicy: { policy: LLMRoutingPolicy; expiresAt: number } | null = null;
+
+async function loadPolicy(): Promise<LLMRoutingPolicy> {
+  if (cachedPolicy && cachedPolicy.expiresAt > Date.now()) {
+    return cachedPolicy.policy;
+  }
+  try {
+    const env = process.env.LLM_ROUTING_ENV || 'DEV';
+    const row = await getActivePolicy(env);
+    const policy = (row?.policy as LLMRoutingPolicy | undefined) || LLM_SAFE_DEFAULTS;
+    cachedPolicy = { policy, expiresAt: Date.now() + POLICY_CACHE_TTL_MS };
+    return policy;
+  } catch (err) {
+    console.warn(`${LOG_PREFIX} policy load failed, falling back to LLM_SAFE_DEFAULTS:`, err);
+    return LLM_SAFE_DEFAULTS;
+  }
+}
+
+/** Test-only: clear the policy cache so tests can override the active policy. */
+export function _resetPolicyCacheForTests(): void {
+  cachedPolicy = null;
+}
+
+// =============================================================================
+// Provider adapters
+// =============================================================================
+
+/** Anthropic Messages API */
+const anthropicAdapter: ProviderAdapter = {
+  isAvailable: () => Boolean(process.env.ANTHROPIC_API_KEY),
+  async call({ prompt, model, systemPrompt, maxTokens, image }): Promise<AdapterResult> {
+    const apiKey = process.env.ANTHROPIC_API_KEY;
+    if (!apiKey) return { ok: false, error: 'ANTHROPIC_API_KEY not set' };
+
+    const userContent: unknown[] = [];
+    if (image) {
+      userContent.push({
+        type: 'image',
+        source: { type: 'base64', media_type: image.mimeType, data: image.base64 },
+      });
+    }
+    userContent.push({ type: 'text', text: prompt });
+
+    const body: Record<string, unknown> = {
+      model,
+      max_tokens: maxTokens ?? 8000,
+      messages: [{ role: 'user', content: userContent }],
+    };
+    if (systemPrompt) body.system = systemPrompt;
+
+    try {
+      const resp = await fetch('https://api.anthropic.com/v1/messages', {
+        method: 'POST',
+        headers: {
+          'x-api-key': apiKey,
+          'anthropic-version': '2023-06-01',
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify(body),
+      });
+      if (!resp.ok) {
+        const errText = await resp.text();
+        return { ok: false, error: `Anthropic ${resp.status}: ${errText.slice(0, 300)}` };
+      }
+      const json = await resp.json() as {
+        content?: Array<{ type: string; text?: string }>;
+        usage?: { input_tokens?: number; output_tokens?: number };
+      };
+      const text = (json.content || []).filter(c => c.type === 'text').map(c => c.text || '').join('');
+      return {
+        ok: true,
+        text,
+        usage: {
+          inputTokens: json.usage?.input_tokens ?? 0,
+          outputTokens: json.usage?.output_tokens ?? 0,
+        },
+      };
+    } catch (err) {
+      return { ok: false, error: `Anthropic threw: ${String(err).slice(0, 300)}` };
+    }
+  },
+};
+
+/** OpenAI Chat Completions API */
+const openaiAdapter: ProviderAdapter = {
+  isAvailable: () => Boolean(process.env.OPENAI_API_KEY),
+  async call({ prompt, model, systemPrompt, maxTokens, image }): Promise<AdapterResult> {
+    const apiKey = process.env.OPENAI_API_KEY;
+    if (!apiKey) return { ok: false, error: 'OPENAI_API_KEY not set' };
+
+    const messages: Array<Record<string, unknown>> = [];
+    if (systemPrompt) messages.push({ role: 'system', content: systemPrompt });
+    if (image) {
+      messages.push({
+        role: 'user',
+        content: [
+          { type: 'image_url', image_url: { url: `data:${image.mimeType};base64,${image.base64}` } },
+          { type: 'text', text: prompt },
+        ],
+      });
+    } else {
+      messages.push({ role: 'user', content: prompt });
+    }
+
+    try {
+      const resp = await fetch('https://api.openai.com/v1/chat/completions', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${apiKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          model,
+          messages,
+          max_tokens: maxTokens ?? 8000,
+        }),
+      });
+      if (!resp.ok) {
+        const errText = await resp.text();
+        return { ok: false, error: `OpenAI ${resp.status}: ${errText.slice(0, 300)}` };
+      }
+      const json = await resp.json() as {
+        choices?: Array<{ message?: { content?: string } }>;
+        usage?: { prompt_tokens?: number; completion_tokens?: number };
+      };
+      const text = json.choices?.[0]?.message?.content ?? '';
+      return {
+        ok: true,
+        text,
+        usage: {
+          inputTokens: json.usage?.prompt_tokens ?? 0,
+          outputTokens: json.usage?.completion_tokens ?? 0,
+        },
+      };
+    } catch (err) {
+      return { ok: false, error: `OpenAI threw: ${String(err).slice(0, 300)}` };
+    }
+  },
+};
+
+/**
+ * Google Vertex AI — uses Application Default Credentials, no API key required
+ * on Cloud Run (the gateway service account has Vertex AI User role). Falls
+ * back to GOOGLE_GEMINI_API_KEY for local dev.
+ */
+const vertexAdapter: ProviderAdapter = {
+  isAvailable: () =>
+    Boolean(process.env.GOOGLE_CLOUD_PROJECT) || Boolean(process.env.GOOGLE_GEMINI_API_KEY),
+  async call({ prompt, model, systemPrompt, maxTokens, image }): Promise<AdapterResult> {
+    // Prefer Vertex AI when GOOGLE_CLOUD_PROJECT is set (Cloud Run path).
+    // Fall back to Google AI Studio when only GOOGLE_GEMINI_API_KEY is present.
+    const projectId = process.env.GOOGLE_CLOUD_PROJECT;
+    if (projectId) {
+      try {
+        // Lazy import to avoid bundling cost when only Anthropic/DeepSeek are used.
+        const { VertexAI } = await import('@google-cloud/vertexai');
+        const location = process.env.VERTEX_LOCATION || 'us-central1';
+        const vertex = new VertexAI({ project: projectId, location });
+        const generativeModel = vertex.getGenerativeModel({
+          model,
+          generationConfig: { maxOutputTokens: maxTokens ?? 8000 },
+          ...(systemPrompt
+            ? { systemInstruction: { role: 'system', parts: [{ text: systemPrompt }] } }
+            : {}),
+        });
+
+        const parts: Array<Record<string, unknown>> = [];
+        if (image) {
+          parts.push({ inlineData: { data: image.base64, mimeType: image.mimeType } });
+        }
+        parts.push({ text: prompt });
+
+        const result = await generativeModel.generateContent({
+          contents: [{ role: 'user', parts: parts as any }],
+        });
+        const candidate = result.response?.candidates?.[0];
+        const text = (candidate?.content?.parts || [])
+          .map((p: any) => p.text || '')
+          .join('');
+        const usageMeta = result.response?.usageMetadata;
+        return {
+          ok: true,
+          text,
+          usage: {
+            inputTokens: usageMeta?.promptTokenCount ?? 0,
+            outputTokens: usageMeta?.candidatesTokenCount ?? 0,
+          },
+        };
+      } catch (err) {
+        return { ok: false, error: `Vertex threw: ${String(err).slice(0, 300)}` };
+      }
+    }
+
+    // Google AI Studio path
+    const apiKey = process.env.GOOGLE_GEMINI_API_KEY;
+    if (!apiKey) return { ok: false, error: 'No Vertex/Google AI credentials available' };
+    try {
+      const url = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(model)}:generateContent?key=${apiKey}`;
+      const parts: Array<Record<string, unknown>> = [];
+      if (image) parts.push({ inlineData: { data: image.base64, mimeType: image.mimeType } });
+      parts.push({ text: prompt });
+      const body: Record<string, unknown> = {
+        contents: [{ role: 'user', parts }],
+        generationConfig: { maxOutputTokens: maxTokens ?? 8000 },
+      };
+      if (systemPrompt) body.systemInstruction = { role: 'system', parts: [{ text: systemPrompt }] };
+      const resp = await fetch(url, {
+        method: 'POST',
+        headers: { 'content-type': 'application/json' },
+        body: JSON.stringify(body),
+      });
+      if (!resp.ok) {
+        const errText = await resp.text();
+        return { ok: false, error: `Google AI ${resp.status}: ${errText.slice(0, 300)}` };
+      }
+      const json = await resp.json() as {
+        candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>;
+        usageMetadata?: { promptTokenCount?: number; candidatesTokenCount?: number };
+      };
+      const text = (json.candidates?.[0]?.content?.parts || [])
+        .map(p => p.text || '')
+        .join('');
+      return {
+        ok: true,
+        text,
+        usage: {
+          inputTokens: json.usageMetadata?.promptTokenCount ?? 0,
+          outputTokens: json.usageMetadata?.candidatesTokenCount ?? 0,
+        },
+      };
+    } catch (err) {
+      return { ok: false, error: `Google AI threw: ${String(err).slice(0, 300)}` };
+    }
+  },
+};
+
+/** DeepSeek API — OpenAI-compatible, single env key */
+const deepseekAdapter: ProviderAdapter = {
+  isAvailable: () => Boolean(process.env.DEEPSEEK_API_KEY),
+  async call({ prompt, model, systemPrompt, maxTokens }): Promise<AdapterResult> {
+    const apiKey = process.env.DEEPSEEK_API_KEY;
+    if (!apiKey) return { ok: false, error: 'DEEPSEEK_API_KEY not set' };
+
+    const messages: Array<Record<string, unknown>> = [];
+    if (systemPrompt) messages.push({ role: 'system', content: systemPrompt });
+    messages.push({ role: 'user', content: prompt });
+
+    try {
+      const resp = await fetch('https://api.deepseek.com/chat/completions', {
+        method: 'POST',
+        headers: {
+          authorization: `Bearer ${apiKey}`,
+          'content-type': 'application/json',
+        },
+        body: JSON.stringify({
+          model,
+          messages,
+          max_tokens: maxTokens ?? 8000,
+        }),
+      });
+      if (!resp.ok) {
+        const errText = await resp.text();
+        return { ok: false, error: `DeepSeek ${resp.status}: ${errText.slice(0, 300)}` };
+      }
+      const json = await resp.json() as {
+        choices?: Array<{ message?: { content?: string } }>;
+        usage?: { prompt_tokens?: number; completion_tokens?: number };
+      };
+      const text = json.choices?.[0]?.message?.content ?? '';
+      return {
+        ok: true,
+        text,
+        usage: {
+          inputTokens: json.usage?.prompt_tokens ?? 0,
+          outputTokens: json.usage?.completion_tokens ?? 0,
+        },
+      };
+    } catch (err) {
+      return { ok: false, error: `DeepSeek threw: ${String(err).slice(0, 300)}` };
+    }
+  },
+};
+
+/**
+ * claude_subscription: free pseudo-provider that routes through the local
+ * autopilot-worker queue → `claude -p` against the user's Pro/Max plan.
+ *
+ * Only meaningful for `worker` / `planner` stages. For other stages (triage,
+ * vision, classifier) the worker overhead and 10-min timeout are wrong; the
+ * router will report "claude_subscription not viable for this stage" and
+ * the caller should pick another provider.
+ *
+ * Implementation defers to `runWorkerTask` from dev-autopilot-worker-queue
+ * to avoid duplicating the queue protocol.
+ */
+const claudeSubscriptionAdapter: ProviderAdapter = {
+  isAvailable: () =>
+    (process.env.DEV_AUTOPILOT_USE_WORKER || '').toLowerCase() === 'true',
+  async call({ prompt, model, maxTokens }): Promise<AdapterResult> {
+    try {
+      const { runWorkerTask } = await import('./dev-autopilot-worker-queue');
+      // The worker queue requires a finding_id; we synthesize one for ad-hoc
+      // routes that have no finding context. Worker doesn't validate the
+      // shape — it just stores it on the row.
+      const result = await runWorkerTask(
+        {
+          kind: 'plan',
+          finding_id: '00000000-0000-0000-0000-000000000000',
+          prompt,
+          model,
+          max_tokens: maxTokens ?? 8000,
+          notes: 'llm-router ad-hoc',
+        },
+        { timeoutMs: 6 * 60 * 1000 },
+      );
+      if (!result.ok) {
+        return { ok: false, error: `claude_subscription: ${result.error || 'worker failed'}` };
+      }
+      return {
+        ok: true,
+        text: result.text || '',
+        usage: {
+          inputTokens: result.usage?.input_tokens ?? 0,
+          outputTokens: result.usage?.output_tokens ?? 0,
+        },
+      };
+    } catch (err) {
+      return { ok: false, error: `claude_subscription threw: ${String(err).slice(0, 300)}` };
+    }
+  },
+};
+
+const ADAPTERS: Record<LLMProvider, ProviderAdapter> = {
+  anthropic: anthropicAdapter,
+  openai: openaiAdapter,
+  vertex: vertexAdapter,
+  deepseek: deepseekAdapter,
+  claude_subscription: claudeSubscriptionAdapter,
+};
+
+// =============================================================================
+// Public API
+// =============================================================================
+
+/**
+ * Dispatch an LLM call to the configured provider for `stage`.
+ *
+ * Never throws — always returns `{ ok, text? | error? }`. Records start +
+ * complete/fail telemetry via `llm-telemetry-service`. Falls back to the
+ * stage's `fallback_provider` on primary failure when `allowFallback !== false`.
+ */
+export async function callViaRouter(
+  stage: LLMStage,
+  prompt: string,
+  opts: LLMRouterOpts,
+): Promise<LLMRouterResult> {
+  const policy = await loadPolicy();
+  const stageConfig: StageRoutingConfig = policy[stage];
+  if (!stageConfig) {
+    return { ok: false, error: `No policy configured for stage '${stage}'` };
+  }
+
+  const allowFallback = opts.allowFallback !== false;
+
+  // === PRIMARY ===
+  const primary = await runProviderCall(
+    stage,
+    stageConfig.primary_provider,
+    stageConfig.primary_model,
+    prompt,
+    opts,
+    /* fallbackUsed= */ false,
+  );
+  if (primary.ok) return primary;
+
+  // === FALLBACK ===
+  if (
+    !allowFallback ||
+    !stageConfig.fallback_provider ||
+    !stageConfig.fallback_model
+  ) {
+    return primary;
+  }
+  console.warn(
+    `${LOG_PREFIX} stage=${stage} primary ${stageConfig.primary_provider}/${stageConfig.primary_model} failed: ${primary.error?.slice(0, 200)} — trying fallback ${stageConfig.fallback_provider}/${stageConfig.fallback_model}`,
+  );
+  const fallback = await runProviderCall(
+    stage,
+    stageConfig.fallback_provider,
+    stageConfig.fallback_model,
+    prompt,
+    opts,
+    /* fallbackUsed= */ true,
+  );
+  if (fallback.ok) {
+    return { ...fallback, fallbackUsed: true };
+  }
+  return {
+    ok: false,
+    error: `both providers failed: primary=${primary.error}; fallback=${fallback.error}`,
+    fallbackUsed: true,
+  };
+}
+
+async function runProviderCall(
+  stage: LLMStage,
+  provider: LLMProvider,
+  model: string,
+  prompt: string,
+  opts: LLMRouterOpts,
+  fallbackUsed: boolean,
+): Promise<LLMRouterResult> {
+  const adapter = ADAPTERS[provider];
+  if (!adapter) {
+    return { ok: false, error: `Unknown provider '${provider}'`, provider, model };
+  }
+  if (!adapter.isAvailable()) {
+    return {
+      ok: false,
+      error: `Provider '${provider}' has no credentials configured`,
+      provider,
+      model,
+    };
+  }
+
+  const ctx = await startLLMCall({
+    vtid: opts.vtid ?? null,
+    service: opts.service,
+    stage,
+    provider,
+    model,
+    prompt,
+  });
+
+  const result = await adapter.call({
+    prompt,
+    model,
+    systemPrompt: opts.systemPrompt,
+    maxTokens: opts.maxTokens,
+    image: opts.image,
+  });
+
+  if (result.ok) {
+    await completeLLMCall(ctx, {
+      inputTokens: result.usage?.inputTokens,
+      outputTokens: result.usage?.outputTokens,
+      fallbackUsed,
+    });
+    return {
+      ok: true,
+      text: result.text,
+      usage: result.usage,
+      provider,
+      model,
+      fallbackUsed,
+    };
+  }
+
+  await failLLMCall(ctx, {
+    code: 'provider_error',
+    message: result.error || 'unknown',
+  });
+  return {
+    ok: false,
+    error: result.error,
+    provider,
+    model,
+    fallbackUsed,
+  };
+}
+
+// =============================================================================
+// Re-exports for callers that want raw types
+// =============================================================================
+
+export type { LLMStage, LLMProvider, LLMRoutingPolicy, StageRoutingConfig };

--- a/services/gateway/test/llm-router.test.ts
+++ b/services/gateway/test/llm-router.test.ts
@@ -1,0 +1,280 @@
+/**
+ * BOOTSTRAP-LLM-ROUTER unit tests.
+ *
+ * Verifies the router:
+ *   1. Loads the active policy and dispatches to the configured primary provider.
+ *   2. Picks the right adapter per provider id.
+ *   3. Falls back to fallback_provider on primary failure when allowFallback.
+ *   4. Asserts flagship-by-default — every safe-default primary/fallback is
+ *      its provider's flagship model.
+ *
+ * Network calls are stubbed via global fetch mock so tests run offline.
+ */
+
+import {
+  LLM_SAFE_DEFAULTS,
+  PROVIDER_FLAGSHIPS,
+  VALID_STAGES,
+  type LLMStage,
+} from '../src/constants/llm-defaults';
+
+describe('BOOTSTRAP-LLM-ROUTER constants', () => {
+  describe('flagship-only safe defaults', () => {
+    test('every primary model in LLM_SAFE_DEFAULTS is its provider flagship', () => {
+      for (const stage of VALID_STAGES) {
+        const cfg = LLM_SAFE_DEFAULTS[stage];
+        const flagship = PROVIDER_FLAGSHIPS[cfg.primary_provider];
+        expect(cfg.primary_model).toBe(flagship);
+      }
+    });
+
+    test('every fallback model in LLM_SAFE_DEFAULTS is its provider flagship (when set)', () => {
+      for (const stage of VALID_STAGES) {
+        const cfg = LLM_SAFE_DEFAULTS[stage];
+        if (cfg.fallback_provider && cfg.fallback_model) {
+          const flagship = PROVIDER_FLAGSHIPS[cfg.fallback_provider];
+          expect(cfg.fallback_model).toBe(flagship);
+        }
+      }
+    });
+
+    test('all 8 stages have a primary and fallback configured', () => {
+      const expectedStages: LLMStage[] = [
+        'planner', 'worker', 'validator', 'operator',
+        'memory', 'triage', 'vision', 'classifier',
+      ];
+      for (const stage of expectedStages) {
+        const cfg = LLM_SAFE_DEFAULTS[stage];
+        expect(cfg.primary_provider).toBeTruthy();
+        expect(cfg.primary_model).toBeTruthy();
+      }
+    });
+
+    test('worker stage primary is claude_subscription (free path)', () => {
+      expect(LLM_SAFE_DEFAULTS.worker.primary_provider).toBe('claude_subscription');
+      expect(LLM_SAFE_DEFAULTS.worker.fallback_provider).toBe('vertex');
+    });
+
+    test('classifier stage primary is deepseek (highest-volume cheapest path)', () => {
+      expect(LLM_SAFE_DEFAULTS.classifier.primary_provider).toBe('deepseek');
+      expect(LLM_SAFE_DEFAULTS.classifier.primary_model).toBe('deepseek-reasoner');
+    });
+
+    test('vision stage primary is vertex with gemini-3.1-pro', () => {
+      expect(LLM_SAFE_DEFAULTS.vision.primary_provider).toBe('vertex');
+      expect(LLM_SAFE_DEFAULTS.vision.primary_model).toBe('gemini-3.1-pro');
+    });
+  });
+
+  describe('PROVIDER_FLAGSHIPS table', () => {
+    test('contains an entry for every supported provider', () => {
+      expect(PROVIDER_FLAGSHIPS.anthropic).toBe('claude-opus-4-7');
+      expect(PROVIDER_FLAGSHIPS.openai).toBe('gpt-5');
+      expect(PROVIDER_FLAGSHIPS.vertex).toBe('gemini-3.1-pro');
+      expect(PROVIDER_FLAGSHIPS.deepseek).toBe('deepseek-reasoner');
+      expect(PROVIDER_FLAGSHIPS.claude_subscription).toBe('claude-opus-4-7');
+    });
+  });
+});
+
+describe('callViaRouter', () => {
+  // Mock fetch globally so adapters don't hit real APIs.
+  const originalFetch = global.fetch;
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+    jest.resetModules();
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+    delete process.env.ANTHROPIC_API_KEY;
+    delete process.env.OPENAI_API_KEY;
+    delete process.env.DEEPSEEK_API_KEY;
+    delete process.env.GOOGLE_GEMINI_API_KEY;
+    delete process.env.GOOGLE_CLOUD_PROJECT;
+  });
+
+  /**
+   * Stub the Supabase REST polling that getActivePolicy() / startLLMCall() do.
+   * Returns:
+   *   - For llm_routing_policy GET: a single row with the desired policy
+   *   - For oasis_events POST: 201 (telemetry write succeeds quietly)
+   *   - Anything else: routed to the per-provider mock the test set up
+   */
+  function setupSupabaseAndTelemetryStubs(activePolicy: any, providerHandler: (url: string, init: any) => any) {
+    process.env.SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE = 'test-key';
+    fetchMock.mockImplementation(async (input: any, init: any = {}) => {
+      const url = typeof input === 'string' ? input : input.url;
+      // Supabase REST: policy fetch
+      if (url.includes('/rest/v1/llm_routing_policy')) {
+        return new Response(JSON.stringify([{ policy: activePolicy }]), {
+          status: 200, headers: { 'content-type': 'application/json' },
+        });
+      }
+      // Supabase REST: oasis events / telemetry writes
+      if (url.includes('/rest/v1/oasis_events') || url.includes('/rest/v1/llm_telemetry')) {
+        return new Response('', { status: 201 });
+      }
+      // Provider call
+      return providerHandler(url, init);
+    });
+  }
+
+  test('routes to anthropic when policy primary_provider=anthropic and credentials are set', async () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-test';
+    const policy = {
+      ...LLM_SAFE_DEFAULTS,
+      triage: {
+        primary_provider: 'anthropic',
+        primary_model: 'claude-opus-4-7',
+        fallback_provider: null,
+        fallback_model: null,
+      },
+    };
+    setupSupabaseAndTelemetryStubs(policy, async (url) => {
+      if (url.includes('api.anthropic.com')) {
+        return new Response(
+          JSON.stringify({
+            content: [{ type: 'text', text: 'ANTHROPIC_OK' }],
+            usage: { input_tokens: 5, output_tokens: 3 },
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const { callViaRouter, _resetPolicyCacheForTests } = await import('../src/services/llm-router');
+    _resetPolicyCacheForTests();
+    const r = await callViaRouter('triage', 'hello', { service: 'test' });
+
+    expect(r.ok).toBe(true);
+    expect(r.text).toBe('ANTHROPIC_OK');
+    expect(r.provider).toBe('anthropic');
+    expect(r.model).toBe('claude-opus-4-7');
+    expect(r.usage).toEqual({ inputTokens: 5, outputTokens: 3 });
+  });
+
+  test('routes to deepseek when policy primary_provider=deepseek and credentials are set', async () => {
+    process.env.DEEPSEEK_API_KEY = 'ds-test';
+    const policy = {
+      ...LLM_SAFE_DEFAULTS,
+      classifier: {
+        primary_provider: 'deepseek',
+        primary_model: 'deepseek-reasoner',
+        fallback_provider: null,
+        fallback_model: null,
+      },
+    };
+    setupSupabaseAndTelemetryStubs(policy, async (url) => {
+      if (url.includes('api.deepseek.com')) {
+        return new Response(
+          JSON.stringify({
+            choices: [{ message: { content: 'DEEPSEEK_OK' } }],
+            usage: { prompt_tokens: 7, completion_tokens: 4 },
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const { callViaRouter, _resetPolicyCacheForTests } = await import('../src/services/llm-router');
+    _resetPolicyCacheForTests();
+    const r = await callViaRouter('classifier', 'classify this', { service: 'test' });
+
+    expect(r.ok).toBe(true);
+    expect(r.text).toBe('DEEPSEEK_OK');
+    expect(r.provider).toBe('deepseek');
+    expect(r.model).toBe('deepseek-reasoner');
+  });
+
+  test('falls back to fallback_provider when primary returns non-2xx', async () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-test';
+    process.env.DEEPSEEK_API_KEY = 'ds-test';
+    const policy = {
+      ...LLM_SAFE_DEFAULTS,
+      triage: {
+        primary_provider: 'deepseek',
+        primary_model: 'deepseek-reasoner',
+        fallback_provider: 'anthropic',
+        fallback_model: 'claude-opus-4-7',
+      },
+    };
+    setupSupabaseAndTelemetryStubs(policy, async (url) => {
+      if (url.includes('api.deepseek.com')) {
+        return new Response('rate limited', { status: 429 });
+      }
+      if (url.includes('api.anthropic.com')) {
+        return new Response(
+          JSON.stringify({
+            content: [{ type: 'text', text: 'FALLBACK_OK' }],
+            usage: { input_tokens: 1, output_tokens: 2 },
+          }),
+          { status: 200 },
+        );
+      }
+      throw new Error(`unexpected url: ${url}`);
+    });
+
+    const { callViaRouter, _resetPolicyCacheForTests } = await import('../src/services/llm-router');
+    _resetPolicyCacheForTests();
+    const r = await callViaRouter('triage', 'go', { service: 'test' });
+
+    expect(r.ok).toBe(true);
+    expect(r.text).toBe('FALLBACK_OK');
+    expect(r.fallbackUsed).toBe(true);
+    expect(r.provider).toBe('anthropic');
+  });
+
+  test('returns ok=false when both providers fail', async () => {
+    process.env.ANTHROPIC_API_KEY = 'sk-test';
+    process.env.DEEPSEEK_API_KEY = 'ds-test';
+    const policy = {
+      ...LLM_SAFE_DEFAULTS,
+      triage: {
+        primary_provider: 'deepseek',
+        primary_model: 'deepseek-reasoner',
+        fallback_provider: 'anthropic',
+        fallback_model: 'claude-opus-4-7',
+      },
+    };
+    setupSupabaseAndTelemetryStubs(policy, async () => new Response('boom', { status: 500 }));
+
+    const { callViaRouter, _resetPolicyCacheForTests } = await import('../src/services/llm-router');
+    _resetPolicyCacheForTests();
+    const r = await callViaRouter('triage', 'go', { service: 'test' });
+
+    expect(r.ok).toBe(false);
+    expect(r.fallbackUsed).toBe(true);
+    expect(r.error).toContain('both providers failed');
+  });
+
+  test('returns ok=false when primary provider has no credentials AND no fallback', async () => {
+    // No ANTHROPIC_API_KEY set
+    const policy = {
+      ...LLM_SAFE_DEFAULTS,
+      triage: {
+        primary_provider: 'anthropic',
+        primary_model: 'claude-opus-4-7',
+        fallback_provider: null,
+        fallback_model: null,
+      },
+    };
+    setupSupabaseAndTelemetryStubs(policy, async () => {
+      throw new Error('should not call any provider');
+    });
+
+    const { callViaRouter, _resetPolicyCacheForTests } = await import('../src/services/llm-router');
+    _resetPolicyCacheForTests();
+    const r = await callViaRouter('triage', 'go', { service: 'test' });
+
+    expect(r.ok).toBe(false);
+    expect(r.error).toContain('no credentials');
+    expect(r.provider).toBe('anthropic');
+  });
+});


### PR DESCRIPTION
## Summary
Phase A of the LLM provider routing plan. Adds \`callViaRouter(stage, prompt, opts)\` — a provider-agnostic dispatcher that reads the active \`llm_routing_policy.policy[stage]\` row and routes to the configured provider. No call sites migrated yet; later phases wire the existing Anthropic callers one stage at a time.

## Why
Scaling autonomous operations 10–50× makes paying \$3/\$15-per-M-tokens for every gateway-side LLM call unsustainable. The router lets operators flip providers via Command Hub dropdowns (Phase H) without code edits, and seeds **flagship-only defaults** so the system never silently picks a weaker model.

## Changes
- \`constants/llm-defaults.ts\`: extend \`LLMStage\` with \`triage|vision|classifier\`; extend \`LLMProvider\` with \`deepseek|claude_subscription\`; rewrite \`LLM_SAFE_DEFAULTS\` to flagship-only across all 8 stages; extend \`MODEL_COSTS\` with new flagship+mid+light tiers; export \`PROVIDER_FLAGSHIPS\` for Phase H auto-select.
- \`services/llm-router.ts\` (NEW): \`callViaRouter\` with inline adapters for anthropic/openai/vertex/deepseek/claude_subscription. 30s policy cache; falls back to fallback_provider on primary failure when allowFallback. Telemetry via existing \`llm-telemetry-service\`.
- \`routes/llm.ts\`: extend Zod schemas with new stages + providers; make fallback fields nullable.
- \`test/llm-router.test.ts\` (NEW): 12 tests — flagship-only defaults, per-provider dispatch, fallback, missing-credentials.

## Defaults landed
| Stage | Primary | Fallback |
|---|---|---|
| planner | vertex/gemini-3.1-pro | anthropic/claude-opus-4-7 |
| worker | claude_subscription/claude-opus-4-7 (free) | vertex/gemini-3.1-pro |
| triage | vertex/gemini-3.1-pro | anthropic/claude-opus-4-7 |
| vision | vertex/gemini-3.1-pro | anthropic/claude-opus-4-7 |
| classifier | deepseek/deepseek-reasoner | vertex/gemini-3.1-pro |
| operator | vertex/gemini-3.1-pro | anthropic/claude-opus-4-7 |
| memory | vertex/gemini-3.1-pro | deepseek/deepseek-reasoner |
| validator | vertex/gemini-3.1-pro | anthropic/claude-opus-4-7 |

## Test plan
- [x] tsc clean (no new errors over pre-existing module-not-found issues)
- [x] 12/12 llm-router tests pass
- [x] 120/120 dev-autopilot + llm tests pass
- [ ] Phase B seed migration installs the flagship-only policy as the active row
- [ ] Phases C–G migrate call sites