### PR TITLE
feat: pre-flight safety gate at Autopilot Developer listing (VTID-01974)

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -37004,6 +37004,38 @@ function renderDevAutopilotActions(findingId) {
         wrap.appendChild(banner);
     }
 
+    // Pre-flight (VTID-01974): the /queue endpoint annotates each finding
+    // with auto_actionable + block_reason + block_message. When false, the
+    // executor literally cannot act — the safety gate would block any
+    // approve attempt — so we surface a manual-review callout up front and
+    // hide Approve & execute / Continue planning. Reject + Snooze stay
+    // available because the operator still needs to clear the row.
+    var queue = (state.devAutopilot && state.devAutopilot.queue) || [];
+    var finding = null;
+    for (var i = 0; i < queue.length; i++) {
+        if (queue[i] && queue[i].id === findingId) { finding = queue[i]; break; }
+    }
+    var autoActionable = !finding || finding.auto_actionable !== false;
+    if (!autoActionable) {
+        var manual = document.createElement('div');
+        manual.style.cssText = 'margin-top: 10px; padding: 10px 12px; background: rgba(234,179,8,0.10); border: 1px solid rgba(234,179,8,0.40); border-radius: 4px; color: #eab308; font-size: 13px; line-height: 1.45;';
+        var manualTitle = document.createElement('div');
+        manualTitle.style.cssText = 'font-weight: 600; margin-bottom: 4px;';
+        manualTitle.textContent = '⚑ Manual review required';
+        manual.appendChild(manualTitle);
+        var manualBody = document.createElement('div');
+        manualBody.style.cssText = 'font-size: 12px; color: #fde68a;';
+        manualBody.textContent = (finding && finding.block_message)
+            || 'This finding is outside the executor\'s allow-scope or above the auto-fix risk cap. Open a manual PR or Reject.';
+        manual.appendChild(manualBody);
+        var manualHint = document.createElement('div');
+        manualHint.style.cssText = 'font-size: 11px; color: var(--text-secondary, #aaa); margin-top: 6px;';
+        manualHint.textContent = 'Reason: ' + ((finding && finding.block_reason) || 'unknown')
+            + ' · Approve & execute hidden because the safety gate would block dispatch.';
+        manual.appendChild(manualHint);
+        wrap.appendChild(manual);
+    }
+
     var row = document.createElement('div');
     row.style.cssText = 'display: flex; gap: 8px; align-items: center; flex-wrap: wrap; margin-top: 12px; padding-top: 10px; border-top: 1px solid var(--border-color, rgba(255,255,255,0.06));';
 
@@ -37017,22 +37049,24 @@ function renderDevAutopilotActions(findingId) {
         return btn;
     }
 
-    row.appendChild(mkBtn('Approve & execute', '#22c55e', function () {
-        if (window.confirm('Approve and queue auto-execution? Cooldown ~10 min.')) {
-            devAutopilotApproveOne(findingId);
-        }
-    }, 'approve:' + findingId));
+    if (autoActionable) {
+        row.appendChild(mkBtn('Approve & execute', '#22c55e', function () {
+            if (window.confirm('Approve and queue auto-execution? Cooldown ~10 min.')) {
+                devAutopilotApproveOne(findingId);
+            }
+        }, 'approve:' + findingId));
 
-    row.appendChild(mkBtn(state.devAutopilot.continuePlanningId === findingId ? 'Cancel' : 'Continue planning…', '#3b82f6', function () {
-        if (state.devAutopilot.continuePlanningId === findingId) {
-            state.devAutopilot.continuePlanningId = null;
-            state.devAutopilot.continuePlanningDraft = '';
-        } else {
-            state.devAutopilot.continuePlanningId = findingId;
-            state.devAutopilot.continuePlanningDraft = '';
-        }
-        renderApp();
-    }, 'continue:' + findingId));
+        row.appendChild(mkBtn(state.devAutopilot.continuePlanningId === findingId ? 'Cancel' : 'Continue planning…', '#3b82f6', function () {
+            if (state.devAutopilot.continuePlanningId === findingId) {
+                state.devAutopilot.continuePlanningId = null;
+                state.devAutopilot.continuePlanningDraft = '';
+            } else {
+                state.devAutopilot.continuePlanningId = findingId;
+                state.devAutopilot.continuePlanningDraft = '';
+            }
+            renderApp();
+        }, 'continue:' + findingId));
+    }
 
     row.appendChild(mkBtn('Snooze 24h', '#eab308', function () {
         devAutopilotSnoozeOne(findingId, 24);

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -12,7 +12,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260421-disconnect-alert"></script>
-  <script src="/command-hub/app.js?v=20260425-dev-comhu-0414-autonomy-e2e"></script>
+  <script src="/command-hub/app.js?v=20260426-vtid-01974-preflight"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
 </body>

--- a/services/gateway/src/routes/dev-autopilot.ts
+++ b/services/gateway/src/routes/dev-autopilot.ts
@@ -17,6 +17,7 @@ import { generatePlanVersion } from '../services/dev-autopilot-planning';
 import { approveAutoExecute, cancelExecution } from '../services/dev-autopilot-execute';
 import { bridgeFailureToSelfHealing, FailureStage } from '../services/dev-autopilot-bridge';
 import { writeAutopilotFailure } from '../services/dev-autopilot-self-heal-log';
+import { dryRunPreflight, RiskClass } from '../services/dev-autopilot-safety';
 import { emitOasisEvent } from '../services/oasis-event-service';
 import { requireAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
 
@@ -635,7 +636,40 @@ router.get('/queue', requireDevRole, async (req: Request, res: Response) => {
   const path = `/rest/v1/autopilot_recommendations?${qs.toString()}`;
   const r = await supaGet<unknown[]>(supa, path);
   if (!r.ok) return res.status(500).json({ ok: false, error: r.error });
-  return res.json({ ok: true, findings: r.data || [] });
+
+  // Pre-flight the safety gate (VTID-01974). High-risk and out-of-allow-scope
+  // findings render as Approve & execute cards otherwise; the gate only fires
+  // post-approval, so the user faced dead-end buttons. Annotating each row
+  // with auto_actionable + block_reason + block_message lets the UI route
+  // un-actionable rows into a manual-review lane up front.
+  const cfgR = await supaGet<Array<{ allow_scope: string[]; deny_scope: string[] }>>(
+    supa,
+    `/rest/v1/dev_autopilot_config?id=eq.1&select=allow_scope,deny_scope&limit=1`,
+  );
+  const cfg = cfgR.ok && cfgR.data && cfgR.data[0]
+    ? cfgR.data[0]
+    : { allow_scope: [] as string[], deny_scope: [] as string[] };
+
+  const findings = (r.data as Array<Record<string, unknown>> | undefined) || [];
+  const annotated = findings.map((f) => {
+    const spec = (f.spec_snapshot as Record<string, unknown> | undefined) || {};
+    const filePath = typeof spec.file_path === 'string' ? spec.file_path : '';
+    const riskClass = (typeof f.risk_class === 'string' ? f.risk_class : 'medium') as RiskClass;
+    const pf = dryRunPreflight({
+      file_path: filePath,
+      risk_class: riskClass,
+      allow_scope: cfg.allow_scope || [],
+      deny_scope: cfg.deny_scope || [],
+    });
+    return {
+      ...f,
+      auto_actionable: pf.auto_actionable,
+      block_reason: pf.block_reason,
+      block_message: pf.block_message,
+    };
+  });
+
+  return res.json({ ok: true, findings: annotated });
 });
 
 // =============================================================================

--- a/services/gateway/src/services/dev-autopilot-safety.ts
+++ b/services/gateway/src/services/dev-autopilot-safety.ts
@@ -231,5 +231,100 @@ export function evaluateSafetyGate(plan: SafetyPlan, ctx: SafetyContext): Safety
   return { ok: violations.length === 0, violations };
 }
 
+// =============================================================================
+// Listing-time pre-flight (VTID-01974)
+// =============================================================================
+
+/**
+ * Lightweight gate dry-run for the findings listing endpoint.
+ *
+ * Why this exists: the full evaluateSafetyGate() needs a generated plan
+ * (files_to_modify, deletions, etc.) and runs *after* the user clicks
+ * Approve & execute. By then it's too late — the user already faced a
+ * dead-end button. This pre-flight runs at /queue listing time using only
+ * the scanner's spec_snapshot (file_path + risk_class), so the UI can
+ * route findings the executor cannot act on into a manual-review lane
+ * before rendering the Approve button.
+ *
+ * It checks the two violations that are decidable from scanner data
+ * alone:
+ *   - risk_class_too_high (plan-independent)
+ *   - file_outside_allow_scope on the scanner-reported file_path
+ *     (the LLM may add more files when planning, but if the seed file
+ *      is already out of scope, no plan can rescue it)
+ *
+ * It does NOT enumerate later-stage gates (tests_missing, daily_budget,
+ * kill_switch, max_auto_fix_depth) — those depend on plan output, current
+ * counters, or runtime config the executor reads at approval time and are
+ * better surfaced through the existing post-approval failure banner.
+ */
+export interface PreflightInput {
+  /** Scanner's reported file path. Pass an empty string if unknown — the
+   *  preflight will return auto_actionable=false with reason
+   *  'file_path_unknown' since we can't gate without it. */
+  file_path: string;
+  /** Risk class on the recommendation row. Defaults to 'medium' upstream
+   *  if missing (matching the gate). */
+  risk_class: RiskClass;
+  /** Allow- and deny-globs from dev_autopilot_config. */
+  allow_scope: string[];
+  deny_scope: string[];
+}
+
+export type PreflightBlockReason =
+  | 'risk_class_too_high'
+  | 'file_outside_allow_scope'
+  | 'file_in_deny_scope'
+  | 'file_path_unknown';
+
+export interface PreflightResult {
+  /** false → UI should hide Approve & execute, route to manual lane. */
+  auto_actionable: boolean;
+  /** First reason the preflight blocked, in stable priority order:
+   *    risk_class_too_high → file_outside_allow_scope → file_in_deny_scope.
+   *  Null when auto_actionable=true. */
+  block_reason: PreflightBlockReason | null;
+  /** Short human-readable explanation suitable for inline UI rendering. */
+  block_message: string | null;
+}
+
+export function dryRunPreflight(input: PreflightInput): PreflightResult {
+  if (input.risk_class === 'high') {
+    return {
+      auto_actionable: false,
+      block_reason: 'risk_class_too_high',
+      block_message:
+        'High-risk findings require a human-written PR. Auto-execution is gated off; use Reject + handle manually.',
+    };
+  }
+
+  if (!input.file_path) {
+    return {
+      auto_actionable: false,
+      block_reason: 'file_path_unknown',
+      block_message:
+        'Scanner did not record a target file_path; the executor cannot scope a fix automatically.',
+    };
+  }
+
+  if (matchesAnyGlob(input.file_path, input.deny_scope)) {
+    return {
+      auto_actionable: false,
+      block_reason: 'file_in_deny_scope',
+      block_message: `${input.file_path} is in the executor's deny-scope. Manual fix required.`,
+    };
+  }
+
+  if (!matchesAnyGlob(input.file_path, input.allow_scope)) {
+    return {
+      auto_actionable: false,
+      block_reason: 'file_outside_allow_scope',
+      block_message: `${input.file_path} is outside the executor's allow-scope. Manual fix required.`,
+    };
+  }
+
+  return { auto_actionable: true, block_reason: null, block_message: null };
+}
+
 // Intentional log tag for service boot tracing consistency
 export { LOG_PREFIX };


### PR DESCRIPTION
## Summary
The Autopilot Developer view rendered **Approve & execute** buttons on findings the executor could never act on (risk_class=high or file outside `allow_scope`). The safety gate only fired *after* the click, so the user faced a dead-end button + red banner. This pre-flights the gate at `/queue` listing time.

- New pure helper `dryRunPreflight(file_path, risk_class, allow_scope, deny_scope)` in `dev-autopilot-safety.ts` — decides the plan-independent violations (`risk_class_too_high`, `file_outside_allow_scope`, `file_in_deny_scope`, `file_path_unknown`).
- `GET /api/v1/dev-autopilot/queue` reads `dev_autopilot_config` once per request and annotates each finding with `auto_actionable` + `block_reason` + `block_message`.
- Command Hub Autopilot Developer card: when `auto_actionable=false`, hides **Approve & execute** + **Continue planning**, shows a yellow "Manual review required" callout with the reason. **Reject** + **Snooze** stay available.
- Bumped `app.js` cache-busting version.

**Tradeoff:** dry-run at list-time costs one config read per request + a glob match per finding (cheap, the gate is pure). Alternative — persisting `auto_actionable` via migration — would drift when scope config changes; dry-run always reflects current config.

## Test plan
- [ ] Pre-deploy: source grep confirms `dryRunPreflight` is exported and `auto_actionable` is wired into `/queue`.
- [ ] Post-deploy: `GET /api/v1/dev-autopilot/queue?status=new` returns `findings[].auto_actionable` boolean and `findings[].block_reason` string|null on each row.
- [ ] Post-deploy UI: Autopilot Developer view → high-risk or out-of-scope card shows yellow "Manual review required" callout, no green Approve & execute button, Reject + Snooze still visible.
- [ ] Post-deploy UI: low-risk in-scope card unchanged (Approve & execute / Continue planning / Snooze / Reject all visible).

🤖 Generated with [Claude Code](https://claude.com/claude-code)