### PR TITLE
feat(autopilot): align AUTOPILOT popup + badge with dev pending-approvals (DEV-COMHU-0415)

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -5351,60 +5351,28 @@ function renderHeader() {
                 user_id: state.meContext?.user_id || 'none',
                 tenant_id: state.meContext?.tenant_id || 'none',
             }));
-            const response = await fetch('/api/v1/autopilot/recommendations?status=new&limit=20', {
+            // Popup is the dev autopilot escalation inbox: scanner findings that
+            // need a human go/no-go decision. Same source as the badge counter
+            // and the "Pending Approval" filter in the Autopilot Developer tab.
+            const response = await fetch('/api/v1/dev-autopilot/pending-approvals?limit=200', {
                 headers: reqHeaders
             });
-            console.log('[VTID-01180] Response status:', response.status, response.statusText);
+            console.log('[autopilot-popup] Response status:', response.status, response.statusText);
             if (!response.ok) {
                 var errorBody = await response.text();
-                console.error('[VTID-01180] Non-OK response body:', errorBody);
-                throw new Error('Failed to fetch recommendations: ' + response.status);
+                console.error('[autopilot-popup] Non-OK response body:', errorBody);
+                throw new Error('Failed to fetch pending approvals: ' + response.status);
             }
             const data = await response.json();
-            console.log('[VTID-01180] Response data:', JSON.stringify({
+            console.log('[autopilot-popup] Response data:', JSON.stringify({
                 ok: data.ok,
                 count: data.count,
-                has_more: data.has_more,
                 recommendationsLength: (data.recommendations || []).length,
-                _debug: data._debug || 'none',
                 error: data.error || 'none',
             }));
             if (data.ok) {
                 state.autopilotRecommendations = data.recommendations || [];
                 state.autopilotRecommendationsCount = state.autopilotRecommendations.length;
-
-                // Auto-replenishment: if community role has 0 new recommendations,
-                // trigger generation of fresh personalized recommendations
-                if (state.autopilotRecommendations.length === 0 &&
-                    state.meContext?.active_role === 'community' &&
-                    state.meContext?.user_id &&
-                    !state._autopilotReplenishAttempted) {
-                    console.log('[VTID-01180] Zero recommendations for community user — triggering auto-replenishment');
-                    state._autopilotReplenishAttempted = true;
-                    try {
-                        var genResp = await fetch('/api/v1/autopilot/recommendations/generate-personal', {
-                            method: 'POST',
-                            headers: buildContextHeaders({ 'Content-Type': 'application/json' }),
-                            body: JSON.stringify({})
-                        });
-                        var genData = await genResp.json();
-                        console.log('[VTID-01180] Auto-replenishment result:', JSON.stringify(genData));
-                        if (genData.ok && genData.generated > 0) {
-                            // Re-fetch to show the new recommendations
-                            var refetchResp = await fetch('/api/v1/autopilot/recommendations?status=new&limit=20', {
-                                headers: buildContextHeaders({})
-                            });
-                            var refetchData = await refetchResp.json();
-                            if (refetchData.ok) {
-                                state.autopilotRecommendations = refetchData.recommendations || [];
-                                state.autopilotRecommendationsCount = state.autopilotRecommendations.length;
-                                console.log('[VTID-01180] After replenishment:', state.autopilotRecommendations.length, 'recommendations');
-                            }
-                        }
-                    } catch (genErr) {
-                        console.warn('[VTID-01180] Auto-replenishment failed:', genErr.message);
-                    }
-                }
             } else {
                 state.autopilotRecommendationsError = data.error || 'Unknown error';
             }
@@ -23748,10 +23716,20 @@ function renderAutopilotRecommendationsModal() {
     iconSpan.textContent = '\u{1F916}'; // Robot emoji
     titleRow.appendChild(iconSpan);
 
+    var titleStack = document.createElement('div');
+    titleStack.style.cssText = 'display: flex; flex-direction: column; gap: 2px;';
+
     var title = document.createElement('span');
-    title.textContent = 'Autopilot Recommendations';
+    title.textContent = 'Pending Approvals';
     title.style.cssText = 'font-size: 18px; font-weight: 600; color: var(--text-color, #fff);';
-    titleRow.appendChild(title);
+    titleStack.appendChild(title);
+
+    var subtitle = document.createElement('span');
+    subtitle.textContent = 'Scanner findings the autopilot needs you to greenlight.';
+    subtitle.style.cssText = 'font-size: 12px; color: var(--text-secondary, #888);';
+    titleStack.appendChild(subtitle);
+
+    titleRow.appendChild(titleStack);
 
     header.appendChild(titleRow);
 
@@ -23786,8 +23764,8 @@ function renderAutopilotRecommendationsModal() {
         var emptyDiv = document.createElement('div');
         emptyDiv.style.cssText = 'text-align: center; padding: 40px; color: var(--text-secondary, #888);';
         emptyDiv.innerHTML = '<div style="font-size: 48px; margin-bottom: 16px;">\u2705</div>';
-        emptyDiv.innerHTML += '<div style="font-size: 16px;">All caught up!</div>';
-        emptyDiv.innerHTML += '<div style="font-size: 14px; margin-top: 8px;">No new recommendations at this time.</div>';
+        emptyDiv.innerHTML += '<div style="font-size: 16px;">All caught up.</div>';
+        emptyDiv.innerHTML += '<div style="font-size: 14px; margin-top: 8px;">Autopilot is handling the rest.</div>';
         body.appendChild(emptyDiv);
     } else {
         // Render recommendations list
@@ -23806,7 +23784,7 @@ function renderAutopilotRecommendationsModal() {
 
     var countLabel = document.createElement('span');
     countLabel.style.cssText = 'color: var(--text-secondary, #888); font-size: 13px;';
-    countLabel.textContent = state.autopilotRecommendations.length + ' recommendation' + (state.autopilotRecommendations.length !== 1 ? 's' : '');
+    countLabel.textContent = state.autopilotRecommendations.length + ' awaiting your decision';
     footer.appendChild(countLabel);
 
     var closeFooterBtn = document.createElement('button');
@@ -23845,8 +23823,10 @@ function createRecommendationCard(rec) {
 
     var riskBadge = document.createElement('span');
     var riskColors = { low: '#22c55e', medium: '#eab308', high: '#f97316', critical: '#ef4444' };
-    riskBadge.style.cssText = 'font-size: 11px; color: ' + (riskColors[rec.risk_level] || '#888') + ';';
-    riskBadge.textContent = (rec.risk_level || 'low').toUpperCase() + ' RISK';
+    // dev_autopilot rows store severity in risk_class; community/system rows in risk_level.
+    var riskValue = rec.risk_level || rec.risk_class || 'low';
+    riskBadge.style.cssText = 'font-size: 11px; color: ' + (riskColors[riskValue] || '#888') + ';';
+    riskBadge.textContent = riskValue.toUpperCase() + ' RISK';
     topRow.appendChild(riskBadge);
 
     card.appendChild(topRow);
@@ -24001,7 +23981,7 @@ function createRecommendationCard(rec) {
  */
 async function fetchAutopilotRecommendationsCount() {
     try {
-        var response = await fetch('/api/v1/autopilot/recommendations/count', {
+        var response = await fetch('/api/v1/dev-autopilot/pending-approvals/count', {
             headers: buildContextHeaders({})
         });
         if (response.ok) {
@@ -24012,7 +23992,7 @@ async function fetchAutopilotRecommendationsCount() {
             }
         }
     } catch (err) {
-        console.warn('[VTID-01180] Could not fetch recommendations count:', err);
+        console.warn('[autopilot-popup] Could not fetch pending approvals count:', err);
     }
 }
 

--- a/services/gateway/src/routes/dev-autopilot.ts
+++ b/services/gateway/src/routes/dev-autopilot.ts
@@ -598,6 +598,81 @@ router.get('/auto-approve', requireDevRole, async (_req: Request, res: Response)
 });
 
 // =============================================================================
+// GET /pending-approvals — escalation inbox for the AUTOPILOT popup
+// =============================================================================
+// Single source of truth for the AUTOPILOT pill badge AND the popup body.
+// Returns dev_autopilot* findings that need a human go/no-go decision:
+// status='new' AND auto_exec_eligible=false (i.e., the triage step did NOT
+// mark this as low-risk-auto-exec). Snoozed rows are filtered out by the
+// snoozed_until check. Sorted riskiest-first.
+//
+// Once Phase 2 ships the auto-exec triage rule, low-risk findings flip to
+// auto_exec_eligible=true and the dispatcher executes them silently — those
+// disappear from this endpoint, which is exactly what makes the popup small
+// enough to be useful for batch decisions.
+
+const PENDING_APPROVALS_PREDICATE =
+  'source_type=in.(dev_autopilot,dev_autopilot_impact)' +
+  '&status=eq.new' +
+  // not.is.true covers both FALSE (default for new rows) and NULL (legacy rows
+  // pre-dating the column's existence) — anything not affirmatively auto-exec.
+  '&auto_exec_eligible=not.is.true' +
+  '&or=(snoozed_until.is.null,snoozed_until.lt.now())';
+
+const PENDING_APPROVALS_SELECT =
+  'id,title,summary,domain,risk_class,impact_score,effort_score,' +
+  'source_type,seen_count,last_seen_at,signal_fingerprint,spec_snapshot';
+
+router.get('/pending-approvals', requireDevRole, async (req: Request, res: Response) => {
+  const supa = getSupabase();
+  if (!supa) return res.status(500).json({ ok: false, error: 'Supabase not configured' });
+
+  const limit = Math.min(parseInt(String(req.query.limit || '200'), 10), 500);
+  const offset = Math.max(parseInt(String(req.query.offset || '0'), 10), 0);
+
+  // Sort riskiest-first then highest impact then most recent activity.
+  const order = 'order=risk_class.desc.nullslast,impact_score.desc.nullslast,last_seen_at.desc';
+  const path =
+    `/rest/v1/autopilot_recommendations?${PENDING_APPROVALS_PREDICATE}` +
+    `&select=${PENDING_APPROVALS_SELECT}&${order}&limit=${limit}&offset=${offset}`;
+
+  const r = await supaGet<unknown[]>(supa, path);
+  if (!r.ok) return res.status(500).json({ ok: false, error: r.error });
+  const recommendations = r.data || [];
+  return res.json({ ok: true, recommendations, count: recommendations.length });
+});
+
+router.get('/pending-approvals/count', requireDevRole, async (_req: Request, res: Response) => {
+  const supa = getSupabase();
+  if (!supa) return res.status(500).json({ ok: false, error: 'Supabase not configured' });
+
+  // PostgREST exact count: HEAD with Prefer: count=exact returns total in
+  // Content-Range. We use a tiny GET to sidestep adding a HEAD helper.
+  const path =
+    `/rest/v1/autopilot_recommendations?${PENDING_APPROVALS_PREDICATE}` +
+    `&select=id&limit=1`;
+
+  try {
+    const url = `${supa.url}${path}`;
+    const resp = await fetch(url, {
+      headers: {
+        apikey: supa.key,
+        Authorization: `Bearer ${supa.key}`,
+        Prefer: 'count=exact',
+      },
+    });
+    if (!resp.ok) {
+      return res.status(500).json({ ok: false, error: `${resp.status}: ${await resp.text()}` });
+    }
+    const range = resp.headers.get('content-range') || '';
+    const total = parseInt(range.split('/').pop() || '0', 10) || 0;
+    return res.json({ ok: true, count: total });
+  } catch (err) {
+    return res.status(500).json({ ok: false, error: String(err) });
+  }
+});
+
+// =============================================================================
 // GET /queue — queue with optional filters
 // =============================================================================
 


### PR DESCRIPTION
## Summary

Phase 1 of the Autopilot UI realignment — make the AUTOPILOT pill badge, the popup body, and the Autopilot Developer tab all reconcile to a single source of truth.

**Before**
- Header badge: `57` (from `/api/v1/autopilot/recommendations/count`, no role/source filter)
- Popup body: `19 recommendations` (from `/api/v1/autopilot/recommendations?status=new&limit=20`, role-filtered + deduped)
- Three endpoints, three filters, one popup. Numbers cannot reconcile.

**After**
- Header badge and popup both fetch `/api/v1/dev-autopilot/pending-approvals[/count]` — same SQL predicate.
- Popup retitled **"Pending Approvals"** with subtitle *"Scanner findings the autopilot needs you to greenlight."*
- Footer: *"X awaiting your decision"*. Empty state: *"All caught up — autopilot is handling the rest."*
- Community recommendations no longer mixed into the Command Hub popup (community app inbox unchanged).

The `auto_exec_eligible IS NOT TRUE` predicate already exists in the schema (column with DEFAULT FALSE), so this works today without any migration. Phase 2 will wire the triage rule that flips low-risk findings to TRUE so they get auto-executed and never land in the popup — that is what makes the popup shrink from "everything" to "just the things that need a human."

## Plan reference

`/.claude/plans/1-look-at-the-optimized-gem.md` (Layer 1).

Phase 2 (status filter pills, batch UX, triage rule, auto-exec dispatcher, outcomes substrate) ships in a follow-up PR.

## Test plan

- [ ] After deploy, header badge equals popup footer count: both come from the same predicate so they cannot disagree.
- [ ] Both equal `SELECT count(*) FROM autopilot_recommendations WHERE source_type IN ('dev_autopilot','dev_autopilot_impact') AND status='new' AND auto_exec_eligible IS NOT TRUE AND (snoozed_until IS NULL OR snoozed_until < now())` in Supabase.
- [ ] Popup shows risk badge correctly for dev rows (uses `risk_class` fallback for rows without `risk_level`).
- [ ] Per-card Activate / Snooze / Dismiss buttons on dev rows still create a VTID + spec via the existing `/api/v1/autopilot/recommendations/:id/*` endpoints (unchanged).
- [ ] Community user signing into the community app still sees their personalized recs in the inbox (legacy `/api/v1/autopilot/recommendations` endpoint untouched).
- [ ] Snoozing a popup row makes it disappear from the badge count and the popup body.

🤖 Generated with [Claude Code](https://claude.com/claude-code)