### PR TITLE
feat(autopilot): self-improvement substrate — outcomes + tightened triage

### DIFF
--- a/services/gateway/src/routes/dev-autopilot.ts
+++ b/services/gateway/src/routes/dev-autopilot.ts
@@ -19,6 +19,7 @@ import { bridgeFailureToSelfHealing, FailureStage } from '../services/dev-autopi
 import { writeAutopilotFailure } from '../services/dev-autopilot-self-heal-log';
 import { dryRunPreflight, RiskClass } from '../services/dev-autopilot-safety';
 import { emitOasisEvent } from '../services/oasis-event-service';
+import { recordOutcome } from '../services/dev-autopilot-outcomes';
 import { requireAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
 
 const router = Router();
@@ -803,7 +804,11 @@ router.post('/findings/:id/continue-planning', requireDevRole, async (req: Reque
 // POST /findings/:id/reject and batch variant
 // =============================================================================
 
-async function rejectById(supa: SupaConfig, id: string): Promise<{ ok: boolean; error?: string }> {
+async function rejectById(
+  supa: SupaConfig,
+  id: string,
+  approver_user_id?: string | null,
+): Promise<{ ok: boolean; error?: string }> {
   const r = await supaPatch(supa, `/rest/v1/autopilot_recommendations?id=eq.${id}&source_type=in.(dev_autopilot,dev_autopilot_impact)`, {
     status: 'rejected',
     updated_at: new Date().toISOString(),
@@ -817,6 +822,14 @@ async function rejectById(supa: SupaConfig, id: string): Promise<{ ok: boolean; 
       message: `Finding ${id} rejected`,
       payload: { finding_id: id },
     });
+    // Outcomes substrate: human said no. The future autonomy-graduation
+    // policy reads these rows to identify scanners whose findings get
+    // rejected often (signal that the scanner's signal:noise is bad).
+    await recordOutcome({
+      finding_id: id,
+      decision: 'rejected',
+      approver_user_id: approver_user_id || null,
+    });
   }
   return r;
 }
@@ -824,7 +837,8 @@ async function rejectById(supa: SupaConfig, id: string): Promise<{ ok: boolean; 
 router.post('/findings/:id/reject', requireDevRole, async (req: Request, res: Response) => {
   const supa = getSupabase();
   if (!supa) return res.status(500).json({ ok: false, error: 'Supabase not configured' });
-  const r = await rejectById(supa, req.params.id);
+  const userId = (req as AuthenticatedRequest).identity?.user_id;
+  const r = await rejectById(supa, req.params.id, userId);
   return res.status(r.ok ? 200 : 500).json(r.ok ? { ok: true } : { ok: false, error: r.error });
 });
 
@@ -835,7 +849,8 @@ router.post('/findings/batch-reject', requireDevRole, async (req: Request, res: 
   if (!Array.isArray(ids) || ids.length === 0) {
     return res.status(400).json({ ok: false, error: 'ids[] required' });
   }
-  const results = await Promise.all(ids.map(id => rejectById(supa, id).then(r => ({ id, ...r }))));
+  const userId = (req as AuthenticatedRequest).identity?.user_id;
+  const results = await Promise.all(ids.map(id => rejectById(supa, id, userId).then(r => ({ id, ...r }))));
   const rejected = results.filter(r => r.ok).map(r => r.id);
   const failed = results.filter(r => !r.ok).map(r => ({ id: r.id, reason: r.error }));
   return res.json({ ok: true, rejected, failed });

--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -39,6 +39,7 @@ import {
 import { extractFilePaths, generatePlanVersion } from './dev-autopilot-planning';
 import { isWorkerQueueEnabled, isWorkerOwnsPrEnabled, runWorkerTask, reclaimStuckWorkerTasks, reclaimStuckPendingWorkerTasks, type WorkerAttemptFailure } from './dev-autopilot-worker-queue';
 import { writeAutopilotFailure } from './dev-autopilot-self-heal-log';
+import { recordOutcome, recordExecOutcome } from './dev-autopilot-outcomes';
 
 const LOG_PREFIX = '[dev-autopilot-execute]';
 const EXEC_VTID = 'VTID-DEV-AUTOPILOT';
@@ -417,6 +418,15 @@ export async function approveAutoExecute(input: ApprovalInput): Promise<Approval
       plan_version: plan.version,
       execute_after: executeAfter.toISOString(),
     },
+  });
+
+  // Outcomes substrate: one row per decision. approved_by present → human
+  // approval; absent → auto-exec via autoApproveTick. exec_outcome is
+  // backfilled later when the worker reports completion/failure.
+  await recordOutcome({
+    finding_id: input.finding_id,
+    decision: input.approved_by ? 'approved' : 'auto_exec',
+    approver_user_id: input.approved_by || null,
   });
 
   return {
@@ -1105,6 +1115,28 @@ async function patchExecution(
     headers: { Prefer: 'return=minimal' },
     body: JSON.stringify({ ...fields, updated_at: new Date().toISOString() }),
   });
+  // Outcomes substrate: when an execution reaches a terminal state, look up
+  // its finding_id and backfill the open outcome row. Centralizing here
+  // covers all 9+ patch-to-terminal call sites without per-site changes.
+  if (r.ok && (fields.status === 'completed' || fields.status === 'failed')) {
+    void (async () => {
+      try {
+        const lookupR = await supa<Array<{ finding_id: string }>>(
+          s,
+          `/rest/v1/dev_autopilot_executions?id=eq.${id}&select=finding_id&limit=1`,
+        );
+        const finding_id = lookupR.ok && lookupR.data?.[0]?.finding_id;
+        if (finding_id) {
+          await recordExecOutcome(
+            finding_id,
+            fields.status === 'completed' ? 'success' : 'failure',
+          );
+        }
+      } catch (err) {
+        console.warn(`${LOG_PREFIX} outcome backfill error for ${id.slice(0, 8)}:`, err);
+      }
+    })();
+  }
   return { ok: r.ok, error: r.error };
 }
 

--- a/services/gateway/src/services/dev-autopilot-outcomes.ts
+++ b/services/gateway/src/services/dev-autopilot-outcomes.ts
@@ -1,0 +1,179 @@
+/**
+ * Dev Autopilot Outcomes — write-through to the substrate that records
+ * every approve / auto-exec / reject / dismiss decision and the eventual
+ * execution outcome.
+ *
+ * The dev_autopilot_outcomes table is the data substrate the future
+ * autonomy-graduation policy reads to decide which scanners earn a higher
+ * autonomy level (e.g., "scanner X had 50 consecutive successful auto_exec
+ * outcomes — promote it to full_auto"). For now we just *record*; the
+ * policy that *acts* on these rows is a follow-up.
+ *
+ * Failures here are logged and swallowed — never break the user-facing
+ * action because the substrate write failed.
+ */
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
+const LOG_PREFIX = '[dev-autopilot-outcomes]';
+
+export type OutcomeDecision = 'auto_exec' | 'approved' | 'rejected' | 'dismissed' | 'demoted';
+export type ExecOutcome = 'success' | 'failure' | 'rolled_back' | 'timeout';
+
+interface SupaConfig {
+  url: string;
+  key: string;
+}
+
+function getSupa(): SupaConfig | null {
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) return null;
+  return { url: SUPABASE_URL, key: SUPABASE_SERVICE_ROLE };
+}
+
+interface FindingShape {
+  source_type: 'dev_autopilot' | 'dev_autopilot_impact';
+  risk_class: string | null;
+  impact_score: number | null;
+  effort_score: number | null;
+  spec_snapshot: { scanner?: string } | null;
+}
+
+async function fetchFinding(supa: SupaConfig, findingId: string): Promise<FindingShape | null> {
+  try {
+    const r = await fetch(
+      `${supa.url}/rest/v1/autopilot_recommendations` +
+        `?id=eq.${findingId}` +
+        `&select=source_type,risk_class,impact_score,effort_score,spec_snapshot` +
+        `&limit=1`,
+      { headers: { apikey: supa.key, Authorization: `Bearer ${supa.key}` } },
+    );
+    if (!r.ok) return null;
+    const rows = (await r.json()) as FindingShape[];
+    return rows[0] || null;
+  } catch {
+    return null;
+  }
+}
+
+export interface RecordOutcomeInput {
+  finding_id: string;
+  decision: OutcomeDecision;
+  approver_user_id?: string | null;
+  vtid?: string | null;
+  human_modified_plan?: boolean;
+  reason?: string | null;
+  metadata?: Record<string, unknown>;
+}
+
+/**
+ * Insert a new outcome row at the moment of decision. Idempotent in spirit:
+ * a finding can have multiple outcome rows over its lifetime (e.g., an
+ * auto_exec that fails → demoted → eventually approved by a human). Each
+ * row represents one decision.
+ */
+export async function recordOutcome(input: RecordOutcomeInput): Promise<void> {
+  const supa = getSupa();
+  if (!supa) return;
+
+  const finding = await fetchFinding(supa, input.finding_id);
+  if (!finding) {
+    // Finding gone or not a dev row — silently skip. Outcomes are dev-only.
+    return;
+  }
+  if (finding.source_type !== 'dev_autopilot' && finding.source_type !== 'dev_autopilot_impact') {
+    return;
+  }
+
+  const scanner_name = (finding.spec_snapshot?.scanner as string) || 'unknown';
+
+  try {
+    const r = await fetch(`${supa.url}/rest/v1/dev_autopilot_outcomes`, {
+      method: 'POST',
+      headers: {
+        apikey: supa.key,
+        Authorization: `Bearer ${supa.key}`,
+        'Content-Type': 'application/json',
+        Prefer: 'return=minimal',
+      },
+      body: JSON.stringify({
+        finding_id: input.finding_id,
+        scanner_name,
+        source_type: finding.source_type,
+        risk_class: finding.risk_class,
+        impact_score: finding.impact_score,
+        effort_score: finding.effort_score,
+        decision: input.decision,
+        approver_user_id: input.approver_user_id ?? null,
+        vtid: input.vtid ?? null,
+        human_modified_plan: input.human_modified_plan ?? false,
+        reason: input.reason ?? null,
+        metadata: input.metadata ?? {},
+      }),
+    });
+    if (!r.ok) {
+      const body = await r.text();
+      console.warn(`${LOG_PREFIX} insert failed (${r.status}): ${body.slice(0, 200)}`);
+    }
+  } catch (err) {
+    console.warn(`${LOG_PREFIX} insert error:`, err);
+  }
+}
+
+/**
+ * Backfill the exec_outcome on the most recent outcome row for a finding
+ * after the worker reports completion/failure. There is normally a single
+ * "open" outcome row per finding (the most recent decision='approved' or
+ * 'auto_exec' with exec_outcome IS NULL); this updates that one.
+ *
+ * If no open outcome row exists (e.g., finding was approved before this
+ * substrate shipped, or the approval-time write failed), this is a no-op —
+ * we don't fabricate history.
+ */
+export async function recordExecOutcome(
+  finding_id: string,
+  exec_outcome: ExecOutcome,
+  vtid?: string | null,
+): Promise<void> {
+  const supa = getSupa();
+  if (!supa) return;
+
+  // Find the latest open outcome row for this finding.
+  const findUrl =
+    `${supa.url}/rest/v1/dev_autopilot_outcomes` +
+    `?finding_id=eq.${finding_id}` +
+    `&decision=in.(approved,auto_exec)` +
+    `&exec_outcome=is.null` +
+    `&order=created_at.desc&limit=1` +
+    `&select=id`;
+
+  try {
+    const findR = await fetch(findUrl, {
+      headers: { apikey: supa.key, Authorization: `Bearer ${supa.key}` },
+    });
+    if (!findR.ok) return;
+    const rows = (await findR.json()) as Array<{ id: string }>;
+    const target = rows[0];
+    if (!target) return;
+
+    const patchR = await fetch(`${supa.url}/rest/v1/dev_autopilot_outcomes?id=eq.${target.id}`, {
+      method: 'PATCH',
+      headers: {
+        apikey: supa.key,
+        Authorization: `Bearer ${supa.key}`,
+        'Content-Type': 'application/json',
+        Prefer: 'return=minimal',
+      },
+      body: JSON.stringify({
+        exec_outcome,
+        exec_completed_at: new Date().toISOString(),
+        ...(vtid ? { vtid } : {}),
+      }),
+    });
+    if (!patchR.ok) {
+      const body = await patchR.text();
+      console.warn(`${LOG_PREFIX} backfill failed (${patchR.status}): ${body.slice(0, 200)}`);
+    }
+  } catch (err) {
+    console.warn(`${LOG_PREFIX} backfill error:`, err);
+  }
+}

--- a/services/gateway/src/services/dev-autopilot-synthesis.ts
+++ b/services/gateway/src/services/dev-autopilot-synthesis.ts
@@ -211,11 +211,16 @@ function scoreSignal(signal: DevAutopilotSignal): {
   const impact = SEVERITY_IMPACT[signal.severity];
   const effort = TYPE_EFFORT[signal.type];
   const risk = TYPE_RISK_CLASS[signal.type];
+  // Conservative triage: only low-risk findings with non-trivial impact
+  // bypass the human-approval queue. Medium-risk signals (todo, missing_tests,
+  // rls_gap, schema_drift, product_gap, ...) always require human review.
+  // The dispatcher does a final destructive-op grep on the plan content
+  // before actually executing, so this rule is the first of two gates.
   return {
     impact_score: impact,
     effort_score: effort,
     risk_class: risk,
-    auto_exec_eligible: risk !== 'high',
+    auto_exec_eligible: risk === 'low' && impact >= 5,
   };
 }
 

--- a/supabase/migrations/20260427100000_BOOTSTRAP_autopilot_realign_substrate.sql
+++ b/supabase/migrations/20260427100000_BOOTSTRAP_autopilot_realign_substrate.sql
@@ -1,0 +1,124 @@
+-- =============================================================================
+-- Autopilot Realign Phase 2 — substrate for the self-improving loop
+-- =============================================================================
+-- Three additive changes that together close the autonomy loop:
+--
+-- 1. dev_autopilot_outcomes table — every approve/auto-exec/reject/dismiss
+--    decision lands here, plus the eventual exec outcome. This is the data
+--    substrate a future autonomy-graduation policy reads to decide which
+--    scanners get promoted to higher autonomy levels.
+--
+-- 2. Tighten existing dev_autopilot rows to match the conservative triage
+--    rule that ships in the same release: auto_exec_eligible=TRUE only when
+--    risk_class='low' AND impact_score>=5. Anything that doesn't pass flips
+--    back to FALSE so it lands in the Pending Approvals popup, which is the
+--    correct place to ask a human.
+--
+-- 3. No new status values — Phase 1 reused existing 'new' and the new
+--    auto_exec_eligible boolean as the "needs approval vs auto-exec" axis.
+--    Status stays the existing ladder for backward compatibility.
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- 1. dev_autopilot_outcomes — substrate for self-improvement
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.dev_autopilot_outcomes (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  finding_id UUID NOT NULL REFERENCES public.autopilot_recommendations(id) ON DELETE CASCADE,
+  scanner_name TEXT NOT NULL,
+  source_type TEXT NOT NULL CHECK (source_type IN ('dev_autopilot', 'dev_autopilot_impact')),
+  risk_class TEXT,
+  impact_score INTEGER,
+  effort_score INTEGER,
+
+  -- The decision: how this finding left the queue.
+  --   auto_exec — dispatcher picked it up because auto_exec_eligible=true
+  --   approved  — human approved via the Pending Approvals popup
+  --   rejected  — human rejected
+  --   dismissed — human dismissed (snooze counts as transient, not an outcome)
+  --   demoted   — dispatcher refused to auto-exec (e.g., destructive plan
+  --               markers found at the last gate); flipped to FALSE and
+  --               returned to the popup
+  decision TEXT NOT NULL CHECK (decision IN ('auto_exec','approved','rejected','dismissed','demoted')),
+
+  -- Set when a human is the approver/rejecter; NULL for auto_exec/demoted.
+  approver_user_id UUID,
+
+  -- VTID + execution outcome — set after approveAutoExecute() returns and the
+  -- worker actually runs. exec_outcome remains NULL until the worker reports.
+  vtid TEXT,
+  exec_outcome TEXT CHECK (exec_outcome IN ('success','failure','rolled_back','timeout')),
+  exec_completed_at TIMESTAMPTZ,
+
+  -- Did the human edit the plan before approving? Tracks how often the AI's
+  -- proposal needs human polish — important signal for autonomy graduation.
+  human_modified_plan BOOLEAN DEFAULT FALSE,
+
+  -- Free-text reason: rejection reason from human, or demotion reason from
+  -- dispatcher (e.g., "DROP TABLE found in plan"). NULL otherwise.
+  reason TEXT,
+
+  metadata JSONB DEFAULT '{}',
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_dev_autopilot_outcomes_finding
+  ON public.dev_autopilot_outcomes (finding_id, created_at DESC);
+
+CREATE INDEX IF NOT EXISTS idx_dev_autopilot_outcomes_scanner
+  ON public.dev_autopilot_outcomes (scanner_name, decision, created_at DESC);
+
+-- Used by the future graduation policy: "scanner X had N consecutive
+-- successful auto_exec outcomes in the last window".
+CREATE INDEX IF NOT EXISTS idx_dev_autopilot_outcomes_scanner_success
+  ON public.dev_autopilot_outcomes (scanner_name, exec_outcome, created_at DESC)
+  WHERE decision = 'auto_exec';
+
+ALTER TABLE public.dev_autopilot_outcomes ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS dev_autopilot_outcomes_service_role ON public.dev_autopilot_outcomes;
+CREATE POLICY dev_autopilot_outcomes_service_role
+  ON public.dev_autopilot_outcomes FOR ALL
+  TO service_role
+  USING (true) WITH CHECK (true);
+
+DROP POLICY IF EXISTS dev_autopilot_outcomes_authenticated_read ON public.dev_autopilot_outcomes;
+CREATE POLICY dev_autopilot_outcomes_authenticated_read
+  ON public.dev_autopilot_outcomes FOR SELECT
+  TO authenticated
+  USING (true);
+
+GRANT SELECT, INSERT, UPDATE ON public.dev_autopilot_outcomes TO service_role;
+GRANT SELECT ON public.dev_autopilot_outcomes TO authenticated;
+
+COMMENT ON TABLE public.dev_autopilot_outcomes IS
+  'BOOTSTRAP-AUTOPILOT-REALIGN: per-decision substrate for the dev autopilot self-improvement loop. One row per approve/auto-exec/reject/dismiss/demote decision; exec_outcome backfills when the worker reports.';
+
+-- -----------------------------------------------------------------------------
+-- 2. Tighten existing rows to match conservative triage rule
+-- -----------------------------------------------------------------------------
+-- Rule: auto_exec_eligible = (risk_class='low' AND impact_score >= 5).
+-- The application code is being updated to use the same rule at synthesis
+-- time. This UPDATE backfills existing rows so the popup gets the benefit
+-- immediately rather than only for newly-scanned findings.
+--
+-- Rows that PREVIOUSLY had auto_exec_eligible=TRUE but no longer pass the
+-- new rule flip back to FALSE — they will reappear in the Pending Approvals
+-- popup, which is the correct place to ask a human. This is intentional:
+-- the prior rule (risk!='high') was too loose and the user explicitly chose
+-- the conservative path.
+
+UPDATE public.autopilot_recommendations
+SET auto_exec_eligible = (
+      risk_class = 'low'
+      AND COALESCE(impact_score, 0) >= 5
+    ),
+    updated_at = NOW()
+WHERE source_type IN ('dev_autopilot', 'dev_autopilot_impact')
+  AND status = 'new';
+
+-- -----------------------------------------------------------------------------
+-- Done
+-- -----------------------------------------------------------------------------


### PR DESCRIPTION
## Summary

Phase 2 of the Autopilot UI realignment (Phase 1 was #956). Three additive pieces that close the autonomy feedback loop without enabling auto-execution of medium-risk findings.

### 1. Tighter synthesis triage rule

`services/gateway/src/services/dev-autopilot-synthesis.ts` — changed `auto_exec_eligible` from `(risk !== 'high')` to `(risk === 'low' AND impact_score >= 5)`.

The previous rule treated medium-risk signals (`todo`, `missing_tests`, `rls_gap`, `schema_drift`, `product_gap`, ...) as auto-exec candidates. The user explicitly chose the conservative path. The downstream `autoApproveTick()` + safety gate are unchanged — this just narrows what the popup considers "auto-exec eligible" so medium-risk findings correctly land in **Pending Approvals**.

### 2. `dev_autopilot_outcomes` table

`supabase/migrations/20260427100000_BOOTSTRAP_autopilot_realign_substrate.sql`

One row per decision: `approved` / `auto_exec` / `rejected` / `dismissed` / `demoted`. `exec_outcome` backfills when the worker reports completion. Indexed for the future autonomy-graduation policy ("scanner X had N consecutive successful `auto_exec` outcomes — promote it"). This release only WRITES; the policy that READS is a follow-up, by design — we want ~2 weeks of real outcome history before we let a policy act on it.

Migration also backfills existing rows under the new triage rule so the popup gets the benefit immediately rather than only for newly-scanned findings.

### 3. Outcomes write-through

- `dev-autopilot-outcomes.ts` (new) — fire-and-forget helpers.
- `approveAutoExecute()` success → `recordOutcome(decision: 'approved' if human else 'auto_exec')`.
- `rejectById()` (single + batch) → `recordOutcome(decision: 'rejected', approver_user_id from JWT)`.
- `patchExecution()` to a terminal status → `recordExecOutcome()` backfills the open outcome row's `exec_outcome`. Centralized here so the 9+ terminal-transition call sites get the substrate update for free.

All write-through is fire-and-forget — substrate failures never break the user-facing action.

## Plan reference

`/.claude/plans/1-look-at-the-optimized-gem.md` (Layers 2 + 5).

**Discovery during implementation:** the dispatcher I had planned (Layer 2c) already exists as `autoApproveTick()` in `dev-autopilot-execute.ts:1589`, wired in `startBackgroundExecutor()`. It's gated by `dev_autopilot_config.auto_approve_enabled` (default false) + scanner allowlist. Phase 2 didn't need to build it — only to align the synthesis rule with it and add the outcomes substrate.

Phase 2 PR-B (frontend status pills + per-card status badges + batch approval UX) follows.

## Test plan

- [ ] Migration applies cleanly via `RUN-MIGRATION.yml`.
- [ ] After deploy, popup count drops further as the backfill flips `auto_exec_eligible=false` for medium-risk rows that previously passed the looser rule.
- [ ] Approve a finding manually from the popup → row appears in `dev_autopilot_outcomes` with `decision='approved'`, `approver_user_id=<my UUID>`, `exec_outcome IS NULL`.
- [ ] Wait for the worker to complete that execution → same outcome row's `exec_outcome` backfills to `'success'` (or `'failure'`), `exec_completed_at` populated.
- [ ] Reject a finding → outcome row with `decision='rejected'`, `approver_user_id=<me>`.
- [ ] Run a scanner → newly-emitted medium-risk findings have `auto_exec_eligible=false` (they land in popup, not auto-exec); newly-emitted low-risk findings with `impact_score>=5` have `auto_exec_eligible=true`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)