### PR TITLE
fix(command-hub): health probe sends operator bearer (VTID-01982)

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -25363,9 +25363,15 @@ async function fetchServiceHealth(silentRefresh) {
     ];
 
     try {
+        // VTID-01982: send the operator's bearer token so health probes against
+        // routers gated by requireAuth/requireExafyAdmin (diary, automations,
+        // capacity, alignment, routing, situational, availability, mobility,
+        // user-prefs, taste, overload, mitigation, opportunities,
+        // vtid-terminalize) don't return 401 and trip a false "down" badge.
+        var probeHeaders = (typeof buildContextHeaders === 'function') ? buildContextHeaders({ 'Accept': 'application/json' }) : {};
         var results = await Promise.allSettled(healthEndpoints.map(function (ep) {
             var start = Date.now();
-            return fetchWT(ep.url, {}, 6000)
+            return fetchWT(ep.url, { headers: probeHeaders }, 6000)
                 .then(function (r) {
                     var latency = Date.now() - start;
                     var ok = r.ok;
@@ -27618,9 +27624,11 @@ async function fetchOverviewDashboard() {
                 { name: 'Autopilot', url: '/api/v1/autopilot/health' },
                 { name: 'Assistant', url: '/api/v1/assistant/health' }
             ];
+        // VTID-01982: pass the operator's bearer token to /health probes
+        var dashHeaders = (typeof buildContextHeaders === 'function') ? buildContextHeaders({ 'Accept': 'application/json' }) : {};
         healthCheckPromise = Promise.allSettled(healthEndpoints.map(function (ep) {
             var start = Date.now();
-            return fetchWT(ep.url)
+            return fetchWT(ep.url, { headers: dashHeaders })
                 .then(function (r) {
                     var latency = Date.now() - start;
                     var ok = r.ok;

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -12,7 +12,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260421-disconnect-alert"></script>
-  <script src="/command-hub/app.js?v=20260426-llm-router-ui"></script>
+  <script src="/command-hub/app.js?v=20260426-vtid-01982-health-probe-auth"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
 </body>


### PR DESCRIPTION
## Summary

The Service Health modal in the Command Hub was showing **14/54 services as "down"** even though the services themselves were running normally. Root cause: fetchServiceHealth() and fetchOverviewDashboard() probed every /health endpoint with no Authorization header.

Routers behind requireAuth + requireExafyAdmin (the platform-admin chain) responded 401 UNAUTHENTICATED, so the UI flagged them down. Self-healing didn't kick in because, server-side, those services were healthy — the gateway-side reconciler probes them with auth and gets 200.

Affected routers: diary, automations, capacity, alignment, routing, situational, availability, mobility, user-prefs, taste, overload, mitigation, opportunities, vtid-terminalize.

## Fix

Pass buildContextHeaders() to both probe sites so the logged-in operator's JWT (which already carries the exafy_admin claim for platform staff) travels with each request. Bump app.js?v= cache-bust to 20260426-vtid-01982-health-probe-auth.

## Test plan
- Hard-reload /command-hub/autonomy/autopilot-developer/ and confirm Service Health badge shows 54/0 instead of 40/14
- Open Service Health modal and verify diary, automations, capacity, alignment etc. now show green
- Confirm underlying services still return 200 to authenticated requests

🤖 Generated with [Claude Code](https://claude.com/claude-code)