### PR TITLE
fix(ci): VTID-01984 — add auth to EXEC-DEPLOY terminal completion gate

### DIFF
--- a/.github/workflows/EXEC-DEPLOY.yml
+++ b/.github/workflows/EXEC-DEPLOY.yml
@@ -647,10 +647,21 @@ jobs:
 
           echo "Writing terminal completion for VTID: $VTID"
 
+          # VTID-01984: Fetch Supabase service token from GCP Secret Manager.
+          # gcloud WIF auth runs at workflow start so secrets are accessible here.
+          SUPABASE_SERVICE_ROLE=$(gcloud secrets versions access latest \
+            --secret=SUPABASE_SERVICE_ROLE \
+            --project=lovable-vitana-vers1 2>/dev/null || echo "")
+          if [ -z "$SUPABASE_SERVICE_ROLE" ]; then
+            echo "::error::VTID-01984: Cannot fetch SUPABASE_SERVICE_ROLE from Secret Manager — terminal gate cannot authenticate"
+            exit 1
+          fi
+
           # Step 1: Call terminal completion endpoint
           RESPONSE=$(curl -sS --max-time 30 -X POST "${GATEWAY_URL}/api/v1/oasis/tasks/${VTID}/complete" \
             -H "Content-Type: application/json" \
             -H "X-VTID: $VTID" \
+            -H "Authorization: Bearer $SUPABASE_SERVICE_ROLE" \
             -d '{"terminal_outcome":"success"}' 2>&1 || echo '{"ok":false,"error":"request_failed"}')
 
           echo "Terminal completion response: $RESPONSE"
@@ -762,9 +773,14 @@ jobs:
           # This resets the task to 'scheduled' for retry (if under max failure count)
           if [[ "$VTID" != BOOTSTRAP-* ]] && [ -n "$GATEWAY_URL" ]; then
             echo "VTID-01841: Calling completion endpoint to trigger retry-reset"
+            # VTID-01984: Fetch auth token for retry-reset call (same gate as terminal completion)
+            SUPABASE_SVC_ROLE_FAIL=$(gcloud secrets versions access latest \
+              --secret=SUPABASE_SERVICE_ROLE \
+              --project=lovable-vitana-vers1 2>/dev/null || echo "")
             RETRY_RESPONSE=$(curl -s -X POST "${GATEWAY_URL}/api/v1/oasis/tasks/${VTID}/complete" \
               -H "Content-Type: application/json" \
               -H "X-VTID: $VTID" \
+              -H "Authorization: Bearer $SUPABASE_SVC_ROLE_FAIL" \
               -d '{"terminal_outcome":"failed"}' 2>/dev/null || echo '{"ok":false}')
             echo "VTID-01841: Retry-reset response: $RETRY_RESPONSE"
           fi

--- a/supabase/migrations/20260427000002_vtid_01984_exec_deploy_terminal_gate_auth.sql
+++ b/supabase/migrations/20260427000002_vtid_01984_exec_deploy_terminal_gate_auth.sql
@@ -1,0 +1,63 @@
+-- Migration: 20260427000002_vtid_01984_exec_deploy_terminal_gate_auth.sql
+-- Purpose: Allocate VTID-01984 — Fix EXEC-DEPLOY OASIS Terminal Completion Gate auth
+-- Advances global_vtid_seq to 1984 so future allocations start at 1985+
+
+-- ============================================================================
+-- Step 1: Advance sequence past 1984 to prevent future conflict
+-- ============================================================================
+DO $$
+BEGIN
+  IF (SELECT last_value FROM global_vtid_seq) < 1984 THEN
+    PERFORM setval('global_vtid_seq', 1984);
+  END IF;
+END $$;
+
+-- ============================================================================
+-- Step 2: Insert VTID-01984 row with approved+in_progress governance state
+-- ============================================================================
+INSERT INTO vtid_ledger (
+  id,
+  vtid,
+  title,
+  status,
+  spec_status,
+  is_terminal,
+  terminal_outcome,
+  failure_count,
+  tenant,
+  layer,
+  module,
+  task_family,
+  task_type,
+  summary,
+  description,
+  is_test,
+  metadata,
+  created_at,
+  updated_at
+) VALUES (
+  gen_random_uuid()::TEXT,
+  'VTID-01984',
+  'Fix EXEC-DEPLOY OASIS Terminal Completion Gate auth',
+  'in_progress',
+  'approved',
+  false,
+  NULL,
+  0,
+  'vitana',
+  'INFRA',
+  'CICD',
+  'INFRA',
+  'CICD',
+  'Add Authorization: Bearer header (SUPABASE_SERVICE_ROLE from GCP Secret Manager) to terminal completion gate curl in EXEC-DEPLOY workflow. Gate was returning 401 UNAUTHENTICATED on every deploy.',
+  '',
+  false,
+  jsonb_build_object(
+    'source', 'migration',
+    'allocated_at', NOW()::TEXT,
+    'allocator_version', 'VTID-01984',
+    'purpose', 'Fix CI/CD terminal gate authentication — OASIS Hard Gate VTID-01080'
+  ),
+  NOW(),
+  NOW()
+) ON CONFLICT (vtid) DO NOTHING;


### PR DESCRIPTION
## Root cause

The **OASIS Terminal Completion Gate (VTID-01080 HARD GATE)** has been failing with:

```json
{"ok":false,"error":"UNAUTHENTICATED","message":"Missing or invalid Authorization header. Expected: Bearer <token>"}
```

on every single deploy. The curl in the gate step called:

```bash
POST /api/v1/oasis/tasks/${VTID}/complete
  -H "Content-Type: application/json"
  -H "X-VTID: $VTID"
  # ← no Authorization header
```

The gateway's `requireAuth` middleware (auth-supabase-jwt.ts:197) requires a valid Supabase HS256 JWT in the `Authorization: Bearer` header. Without it, it short-circuits with 401 UNAUTHENTICATED. The exact error string `"Missing or invalid Authorization header. Expected: Bearer <token>"` is produced at line 207–208 of that file.

## Fix

Fetch `SUPABASE_SERVICE_ROLE` from GCP Secret Manager using `gcloud secrets versions access` (gcloud WIF auth already runs at workflow start, so the secret is accessible). Add `-H "Authorization: Bearer $SUPABASE_SERVICE_ROLE"` to:

1. **Success path** — `OASIS Terminal Completion Gate` step curl (the hard-fail gate)
2. **Failure path** — `Emit OASIS Deploy Failure Event` step retry-reset curl (VTID-01841)

The service_role JWT is signed with the project's JWT secret, so `requireAuth`'s `jose.jwtVerify()` accepts it. The complete handler ignores `req.identity`, so the service identity is fine for this call.

If `SUPABASE_SERVICE_ROLE` cannot be fetched from Secret Manager, the gate now fails loudly (non-silently) with a clear error message.

## VTID-01984 allocation

Migration `20260427000002_vtid_01984_exec_deploy_terminal_gate_auth.sql`:
- Advances `global_vtid_seq` to 1984 (next `allocate_global_vtid()` call returns 1985+)
- Inserts `VTID-01984` row with `spec_status=approved`, `status=in_progress`, `is_terminal=false`

> **Note:** Apply this migration via `RUN-MIGRATION.yml` **before** the first VTID-01984 deploy so the governance gate can find the ledger row.

## Test plan

- [ ] Merge this PR — AUTO-DEPLOY detects `VTID-01984` in commit message and dispatches EXEC-DEPLOY
- [ ] In EXEC-DEPLOY run: `OASIS Terminal Completion Gate` step completes with exit 0 (no more 401)
- [ ] `vtid_ledger` row for `VTID-01984` shows `is_terminal=true`, `terminal_outcome=success`, `status=completed`
- [ ] Subsequent deploys for any VTID also pass the gate (regression check)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

---
_Generated by [Claude Code](https://claude.ai/code/session_01QhEXCv5C93F38YSCYatnwD)_