### PR TITLE
feat(diary): VTID-01983 H.5 — diary streak detection + wallet reward

### DIFF
--- a/services/gateway/src/routes/memory.ts
+++ b/services/gateway/src/routes/memory.ts
@@ -1892,12 +1892,17 @@ router.post('/diary/sync-index', async (req: Request, res: Response) => {
       mental:    pillars_after.mental    - Number(before?.score_mental    ?? 0),
     } : null;
 
+    // H.5 — diary streak celebration (best-effort, non-blocking).
+    const { celebrateDiaryStreak } = await import('../services/diary-streak-celebrator');
+    const streak = await celebrateDiaryStreak(admin, userId, tenantId);
+
     return res.status(200).json({
       ok: true,
       entry_date: entryDate,
       health_features_written,
       pillars_after,
       index_delta,
+      streak,
     });
   } catch (err: any) {
     console.error('[VTID-01983] /diary/sync-index error:', err?.message ?? err);

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -4424,7 +4424,11 @@ async function executeLiveApiToolInner(
             mental:    pillars_after.mental    - Number(before?.score_mental    ?? 0),
           } : null;
 
-          console.log(`[save_diary_entry] user=${lens.user_id.slice(0, 8)} features=${health_features_written} delta_total=${index_delta?.total ?? 0}`);
+          // H.5 — diary streak celebration (best-effort, non-blocking).
+          const { celebrateDiaryStreak } = await import('../services/diary-streak-celebrator');
+          const streak = await celebrateDiaryStreak(admin, lens.user_id, tenantId);
+
+          console.log(`[save_diary_entry] user=${lens.user_id.slice(0, 8)} features=${health_features_written} delta_total=${index_delta?.total ?? 0} streak=${streak ? streak.tier_days : '-'}`);
 
           return {
             success: true,
@@ -4434,6 +4438,7 @@ async function executeLiveApiToolInner(
               health_features_written,
               pillars_after,
               index_delta,
+              streak,
             }),
           };
         } catch (err: any) {

--- a/services/gateway/src/services/diary-streak-celebrator.ts
+++ b/services/gateway/src/services/diary-streak-celebrator.ts
@@ -1,0 +1,137 @@
+/**
+ * Diary streak celebration helper (VTID-01983 / H.5).
+ *
+ * Reads `user_diary_streak`, detects transitions to 3 / 7 / 14 / 30
+ * days, credits a small wallet reward, and emits an OASIS event so
+ * downstream surfaces (morning brief, autopilot popup banner) can
+ * celebrate.
+ *
+ * Idempotency: only fires on the FIRST detection of a given streak tier
+ * (i.e. when transitioning from N-1 to N for N ∈ {3, 7, 14, 30}). The
+ * caller must call this AFTER the diary entry has been written so the
+ * streak length already reflects today's save.
+ *
+ * Reward tiers (mirror the autopilot onboarding pattern: 10 VTN base):
+ *   3-day streak  → 10 VTN
+ *   7-day streak  → 20 VTN
+ *  14-day streak  → 40 VTN
+ *  30-day streak  → 80 VTN
+ *
+ * Returns the celebration payload (or null when nothing fired) so the
+ * caller can include it in the response and surface it in the toast /
+ * voice reply.
+ */
+
+import { SupabaseClient } from '@supabase/supabase-js';
+import { emitOasisEvent } from './oasis-event-service';
+
+export interface StreakCelebration {
+  current_streak_days: number;
+  tier_days: number;        // the tier just reached: 3 / 7 / 14 / 30
+  wallet_credit: number;    // VTN credited
+  message: string;          // human-friendly celebration ("3-day diary streak — keep it!")
+}
+
+const STREAK_TIERS: ReadonlyArray<{ days: number; reward: number; message: string }> = [
+  { days: 3,  reward: 10, message: '3-day diary streak — keep it.' },
+  { days: 7,  reward: 20, message: '7-day diary streak — a real habit is forming.' },
+  { days: 14, reward: 40, message: '14-day diary streak — two solid weeks.' },
+  { days: 30, reward: 80, message: '30-day diary streak — this is your practice now.' },
+];
+
+/**
+ * Check the user's current diary streak. If today's save crossed into a
+ * tier (3, 7, 14, or 30 days), fire the wallet credit + OASIS event and
+ * return the celebration payload.
+ *
+ * Best-effort: any DB / event errors log + return null so the diary write
+ * is never blocked by the celebration path.
+ */
+export async function celebrateDiaryStreak(
+  admin: SupabaseClient,
+  userId: string,
+  tenantId: string,
+): Promise<StreakCelebration | null> {
+  try {
+    const { data: streakRow } = await admin
+      .from('user_diary_streak')
+      .select('current_streak_days, last_day')
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    const streak = Number((streakRow as any)?.current_streak_days ?? 0);
+    if (streak <= 0) return null;
+
+    // Only fire on EXACT transition to a tier — not every day at or above.
+    const tier = STREAK_TIERS.find(t => t.days === streak);
+    if (!tier) return null;
+
+    // Idempotency: dedup on (user_id, streak_days) via the OASIS event's
+    // payload — if a celebration event already exists for this streak
+    // length today, skip. Cheap dedup query (filter in last 25 hours so a
+    // single-day duplicate never re-fires).
+    const since = new Date(Date.now() - 25 * 60 * 60 * 1000).toISOString();
+    const { data: existing } = await admin
+      .from('oasis_events')
+      .select('id')
+      .eq('topic', 'diary.streak_celebrated')
+      .gte('created_at', since)
+      .filter('metadata->>user_id', 'eq', userId)
+      .filter('metadata->>streak_days', 'eq', String(tier.days))
+      .limit(1);
+    if (Array.isArray(existing) && existing.length > 0) {
+      // Already celebrated this tier today — skip the credit + event but
+      // still return the payload so voice/toast can mention it idly if
+      // they want. Caller can ignore it.
+      return null;
+    }
+
+    // Wallet credit — mirror the autopilot onboarding pattern.
+    try {
+      await admin.rpc('credit_wallet', {
+        p_tenant_id: tenantId,
+        p_user_id: userId,
+        p_amount: tier.reward,
+        p_type: 'reward',
+        p_source: 'diary_streak',
+        p_source_event_id: `diary_streak_${userId}_${tier.days}_${new Date().toISOString().slice(0, 10)}`,
+        p_description: `Diary ${tier.days}-day streak`,
+      });
+    } catch (walletErr: any) {
+      // credit_wallet is best-effort — wallet may dedup on
+      // p_source_event_id (idempotent) or be temporarily unavailable.
+      // Streak event still fires regardless.
+      console.warn(`[diary-streak] credit_wallet failed: ${walletErr?.message ?? walletErr}`);
+    }
+
+    // OASIS event so the morning brief + autopilot popup can pick it up.
+    try {
+      await emitOasisEvent({
+        vtid: 'VTID-01983',
+        type: 'diary.streak_celebrated' as any,
+        source: 'memory-diary',
+        status: 'success',
+        message: tier.message,
+        payload: {
+          user_id: userId,
+          tenant_id: tenantId,
+          streak_days: tier.days,
+          reward_vtn: tier.reward,
+        },
+      });
+    } catch (evErr: any) {
+      console.warn(`[diary-streak] oasis emit failed: ${evErr?.message ?? evErr}`);
+    }
+
+    console.log(`[diary-streak] user=${userId.slice(0, 8)} hit ${tier.days}-day streak +${tier.reward} VTN`);
+    return {
+      current_streak_days: streak,
+      tier_days: tier.days,
+      wallet_credit: tier.reward,
+      message: tier.message,
+    };
+  } catch (err: any) {
+    console.warn(`[diary-streak] check failed (non-fatal): ${err?.message ?? err}`);
+    return null;
+  }
+}

--- a/supabase/migrations/20260427090000_user_diary_streak_view.sql
+++ b/supabase/migrations/20260427090000_user_diary_streak_view.sql
@@ -1,0 +1,64 @@
+-- =============================================================================
+-- user_diary_streak — current consecutive-day streak for diary entries
+-- VTID-01983 (H.5)
+-- Date: 2026-04-27
+--
+-- Returns one row per user that has at least one diary_entries record,
+-- with the current streak ending today (or null if the most recent entry
+-- isn't from today/yesterday).
+--
+-- Used by the gateway's POST /memory/diary/sync-index endpoint and by the
+-- ORB save_diary_entry tool to detect streak transitions (3/7/14/30
+-- days) so a wallet reward + OASIS celebration event can fire.
+--
+-- Streak rule: consecutive calendar days with ≥ 1 diary_entries.created_at
+-- ending today. Yesterday-only (no entry today yet) returns the streak
+-- length; a gap of 2+ days breaks the streak (returns 0 / NULL).
+--
+-- Idempotent: CREATE OR REPLACE VIEW.
+-- =============================================================================
+
+BEGIN;
+
+CREATE OR REPLACE VIEW public.user_diary_streak AS
+WITH entry_days AS (
+  SELECT
+    user_id,
+    (created_at AT TIME ZONE 'UTC')::DATE AS entry_day
+  FROM public.diary_entries
+  GROUP BY 1, 2
+),
+ranked AS (
+  SELECT
+    user_id,
+    entry_day,
+    -- Group consecutive days by subtracting a row number from the date.
+    -- Days in the same streak share the same (entry_day - rn) value.
+    entry_day - (ROW_NUMBER() OVER (PARTITION BY user_id ORDER BY entry_day))::INTEGER AS streak_group
+  FROM entry_days
+),
+streaks AS (
+  SELECT
+    user_id,
+    streak_group,
+    COUNT(*) AS streak_days,
+    MAX(entry_day) AS last_day
+  FROM ranked
+  GROUP BY user_id, streak_group
+)
+SELECT
+  user_id,
+  streak_days::INTEGER AS current_streak_days,
+  last_day
+FROM streaks
+WHERE last_day >= (CURRENT_DATE - INTERVAL '1 day')::DATE
+ORDER BY user_id;
+
+COMMENT ON VIEW public.user_diary_streak IS
+  'VTID-01983: per-user current diary streak ending today (or yesterday). Used by /diary/sync-index + save_diary_entry voice tool to detect streak transitions and trigger wallet reward + OASIS celebration. Streak breaks with a 2+ day gap.';
+
+-- RLS: view inherits from diary_entries. Service role reads it from the
+-- gateway endpoints; users won't query it directly today.
+GRANT SELECT ON public.user_diary_streak TO authenticated, anon;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Final piece of the Phase H celebration loop. A single diary entry is good; three days in a row is the start of a habit. Until now the system had no concept of a diary streak.

## Changes

- **Migration \`20260427090000_user_diary_streak_view.sql\`** — new \`user_diary_streak\` view. Per-user current consecutive-day streak ending today (or yesterday). Standard row-number-minus-date streak pattern.
- **\`services/gateway/src/services/diary-streak-celebrator.ts\`** — \`celebrateDiaryStreak()\` reads the view, detects exact transitions to 3/7/14/30 days, credits a wallet reward (10/20/40/80 VTN, same pattern as autopilot onboarding), and emits OASIS event \`diary.streak_celebrated\`. Idempotent via OASIS dedup query.
- **\`memory.ts\` /diary/sync-index** + **\`orb-live.ts\` save_diary_entry executor** — both call \`celebrateDiaryStreak\` after Index recompute and include \`streak\` in the response.

## Apply

\`RUN-MIGRATION.yml\` with \`migration_file=supabase/migrations/20260427090000_user_diary_streak_view.sql\`.

## Verify

- Save diary entries on 3 consecutive days for a fresh user.
- 3rd day's \`/diary/sync-index\` response contains \`streak: { current_streak_days: 3, tier_days: 3, wallet_credit: 10, message: "3-day diary streak — keep it." }\`.
- \`oasis_events\` row with topic \`diary.streak_celebrated\` exists with \`metadata.streak_days: 3\`.
- Wallet credited 10 VTN.

VTID-01983

🤖 Generated with [Claude Code](https://claude.com/claude-code)