### PR TITLE
fix(orb): stop killing healthy WS during Vertex compute (VTID-01984)

### DIFF
--- a/services/gateway/src/orb/upstream/constants.ts
+++ b/services/gateway/src/orb/upstream/constants.ts
@@ -76,7 +76,24 @@ export const TURN_RESPONSE_TIMEOUT_MS = 10_000;     // 10s after user speech
 //     safe because "N seconds without Vertex response" then means "N seconds
 //     after last audio with Vertex still silent" which is the real stall
 //     condition. Until that ships, 15 s is the safest known-good value.
-export const FORWARDING_ACK_TIMEOUT_MS = 15_000;
+//   R5 (VTID-01984): production data (24h, 14/20 sessions BAD, 1 session
+//     53s of speech with 0 turns) showed 15 s was still destroying healthy
+//     sessions during legitimate first-turn inference. With 15K-char system
+//     instruction + 16 tools, Vertex first-turn latency is 8-12 s; add
+//     1.2 s VAD trigger time + audio chunking; 15 s is right on the edge
+//     and frequently fires inside Vertex's compute window — destroying the
+//     in-flight utterance via reconnect. Two changes:
+//       (1) The arm site now skips this watchdog entirely once Vertex has
+//           shown ANY sign of life this session (input_transcription /
+//           model_start_speaking / audio_out chunk). Native WS handlers
+//           still close on real connection failures; we don't need a 15 s
+//           heuristic to "detect" a Vertex pause between turns when the
+//           WS itself is healthy.
+//       (2) For genuine first-turn (vertexHasShownLife=false), bump from
+//           15 s to 45 s. Real Vertex stalls before any life signal are
+//           rare and 45 s won't make them invisible — but it will stop
+//           the false positives that were truncating greetings.
+export const FORWARDING_ACK_TIMEOUT_MS = 45_000;
 
 // =============================================================================
 // VTID-LOOPGUARD: Response loop prevention

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -810,6 +810,14 @@ interface GeminiLiveSession {
   // safe when the reason is 'forwarding_no_ack' — a model-response watchdog
   // must not be reset by user audio or we'd suppress legitimate stalls.
   responseWatchdogReason?: string;
+  // VTID-01984 (R5): true once Vertex has shown ANY sign of life on this
+  // session — first input_transcription, first model_start_speaking, or
+  // first audio_out chunk. The audio-forwarding paths skip the
+  // forwarding_no_ack watchdog entirely once this is true, because the
+  // upstream WS is demonstrably healthy and a 15-45 s "no ack" window is
+  // simply Vertex computing a response, not a stall. Native WS error /
+  // close handlers still catch real connection failures.
+  vertexHasShownLife?: boolean;
   // VTID-LOOPGUARD: Consecutive model turns without user speech.
   // Detects response loops where model keeps elaborating without being asked.
   consecutiveModelTurns: number;
@@ -7253,6 +7261,11 @@ async function connectToLiveAPI(
                   session.isModelSpeaking = true;
                   // VTID-TOOLGUARD: Model produced audio — reset tool call counter
                   session.consecutiveToolCalls = 0;
+                  // VTID-01984 (R5): Vertex has spoken — upstream WS is healthy.
+                  // Once true, the audio-forwarding paths skip arming the
+                  // forwarding_no_ack watchdog so we never kill a healthy
+                  // session in the middle of Vertex computing a follow-up turn.
+                  session.vertexHasShownLife = true;
                   console.log(`[VTID-VOICE-INIT] Model started speaking for session ${session.sessionId} — mic audio gated`);
                   emitDiag(session, 'model_start_speaking');
                   // BOOTSTRAP-ORB-HOTFIX-1: If this is the greeting (no turns yet
@@ -7330,6 +7343,12 @@ async function connectToLiveAPI(
               console.log(`[VTID-VOICE-INIT] Filtering greeting prompt from input transcription: "${inputTranscription.substring(0, 60)}..."`);
             } else {
               console.log(`[VTID-01219] Input transcription: ${inputTranscription}`);
+              // VTID-01984 (R5): Vertex's VAD fired and produced a transcription —
+              // upstream WS is demonstrably healthy. Mark life signal so subsequent
+              // user-audio chunks don't arm the forwarding_no_ack watchdog (which
+              // was destroying healthy sessions when first-turn inference exceeded
+              // 15 s). Real WS failures are still caught by native handlers.
+              session.vertexHasShownLife = true;
               emitDiag(session, 'input_transcription', { text_preview: inputTranscription.substring(0, 80) });
               if (session.sseResponse) {
                 session.sseResponse.write(`data: ${JSON.stringify({ type: 'input_transcript', text: inputTranscription })}\n\n`);
@@ -12647,10 +12666,22 @@ router.post('/live/stream/send', optionalAuth, async (req: AuthenticatedRequest,
           // model-response watchdog must NOT be reset by user audio or we'd
           // suppress legitimate mid-stream model stalls.
           if (!session.isModelSpeaking) {
-            const canSlide = !session.responseWatchdogTimer
-              || session.responseWatchdogReason === 'forwarding_no_ack';
-            if (canSlide) {
-              startResponseWatchdog(session, FORWARDING_ACK_TIMEOUT_MS, 'forwarding_no_ack');
+            // VTID-01984 (R5): once Vertex has shown life this session, the
+            // upstream WS is healthy by definition. A "no ack" window is just
+            // Vertex computing — not a stall. Skip arming the watchdog here.
+            // Native ws.onclose / ws.onerror still catch real connection failures.
+            // Periodically emit a watchdog_skipped diag so we can confirm in
+            // production how many sessions this saves.
+            if (session.vertexHasShownLife) {
+              if (session.audioInChunks % 200 === 0) {
+                emitDiag(session, 'watchdog_skipped', { reason: 'vertex_alive' });
+              }
+            } else {
+              const canSlide = !session.responseWatchdogTimer
+                || session.responseWatchdogReason === 'forwarding_no_ack';
+              if (canSlide) {
+                startResponseWatchdog(session, FORWARDING_ACK_TIMEOUT_MS, 'forwarding_no_ack');
+              }
             }
           }
           // VTID-DIAG: Periodic audio forward diagnostic (every 100 chunks)
@@ -14063,10 +14094,19 @@ async function handleWsAudioMessage(clientSession: WsClientSession, message: WsC
       // WS and SSE transports stay in lockstep until Phase 3 collapses
       // them onto one adapter.
       if (!liveSession.isModelSpeaking) {
-        const canSlide = !liveSession.responseWatchdogTimer
-          || liveSession.responseWatchdogReason === 'forwarding_no_ack';
-        if (canSlide) {
-          startResponseWatchdog(liveSession, FORWARDING_ACK_TIMEOUT_MS, 'forwarding_no_ack');
+        // VTID-01984 (R5): mirror of SSE-path gate — once Vertex has shown
+        // life, skip arming the forwarding_no_ack watchdog. Healthy WS does
+        // not need a 15-45 s heuristic to detect Vertex's compute window.
+        if (liveSession.vertexHasShownLife) {
+          if (liveSession.audioInChunks % 200 === 0) {
+            emitDiag(liveSession, 'watchdog_skipped', { reason: 'vertex_alive' });
+          }
+        } else {
+          const canSlide = !liveSession.responseWatchdogTimer
+            || liveSession.responseWatchdogReason === 'forwarding_no_ack';
+          if (canSlide) {
+            startResponseWatchdog(liveSession, FORWARDING_ACK_TIMEOUT_MS, 'forwarding_no_ack');
+          }
         }
       }
     } else {


### PR DESCRIPTION
**Production data (24h):** 14/20 ORB voice sessions had audio_in:audio_out ratio > 5x. Worst case: 53s of user speech, 585 audio_in chunks, 0 turns, ratio 117:1. This is the bug users have been complaining about for months.

**Root cause:** the forwarding_no_ack watchdog at FORWARDING_ACK_TIMEOUT_MS=15s fires INSIDE Vertex's compute window. With our 15K-char system instruction + 16 tools, first-turn inference is 8-12s. Add VAD trigger (1.2s) + audio chunking + network and 15s is right on the edge. When the timer fires, we force-close the upstream WS; the reconnect loses the in-flight utterance; Vertex never replies. Session ends with 0 turns.

The constants.ts comment itself documents two prior regressions (R2: 15→6s broke long utterances, R3: bumped back to 15s) and acknowledges 15s 'is the safest known-good value' but only with a sliding-watchdog assumption that turns out to still be too tight in production.

## Changes

- `constants.ts` — `FORWARDING_ACK_TIMEOUT_MS` 15s → 45s. For first-turn only; gives margin without making real stalls invisible.
- `orb-live.ts` — track `session.vertexHasShownLife` (true on first `model_start_speaking` OR `input_transcription`). Both audio-forwarding paths skip arming the `forwarding_no_ack` watchdog once true. Once Vertex has spoken once, the WS is healthy by definition. Native `ws.onclose` / `ws.onerror` still catch real failures.
- New `watchdog_skipped` diag (every 200 chunks) so we can measure saved sessions in prod.

## Test plan

- [x] TypeScript build passes.
- [ ] Post-deploy: check Voice Lab — sessions with `audio_in_chunks > 200` should now have `audio_out_chunks > 30` (no longer truncated).
- [ ] Post-deploy: check `oasis_events` for `watchdog_skipped` diag — should appear on any session with sustained user audio after Vertex's first response.
- [ ] Post-deploy 24h: re-run the ratio distribution. Expectation: BAD count drops from 14/20 to ≤3/20.

If the ratio doesn't improve significantly, the secondary failure mode is model-terseness (Vertex responds but says little) which is a separate fix at the prompt/model-config level. The self-healing loop infrastructure (PRs #913-927) is in place to catch and surface either pattern.

🤖 Generated with [Claude Code](https://claude.com/claude-code)