### PR TITLE
fix(self-healing): /history returns raw rows, no endpoint allow-list (VTID-01986)

### DIFF
--- a/services/gateway/src/routes/self-healing.ts
+++ b/services/gateway/src/routes/self-healing.ts
@@ -603,21 +603,7 @@ router.get('/history', async (req: Request, res: Response) => {
       return res.status(500).json({ ok: false, error: 'Failed to query history' });
     }
 
-    const raw = (await resp.json()) as any[];
-    // Filter out phantom/test endpoints that aren't in the gateway route map.
-    // Synthetic `autopilot.*` identifiers (from dev-autopilot self-heal-log writes)
-    // are NOT route URLs — they're stage tags ("autopilot.scan_ingest",
-    // "autopilot.worker_queue.plan", "autopilot.plan_gen"). Pass them through
-    // unconditionally so the Self-Healing screen surfaces autopilot failures
-    // alongside route-class failures.
-    const known = new Set(Object.keys(ENDPOINT_FILE_MAP));
-    known.add('/alive');
-    known.add('/api/v1/self-healing/health');
-    const items = raw.filter((r: any) =>
-      !r.endpoint
-      || known.has(r.endpoint)
-      || (typeof r.endpoint === 'string' && r.endpoint.startsWith('autopilot.'))
-    );
+    const items = (await resp.json()) as any[];
     const countHeader = resp.headers.get('content-range');
     const total = countHeader ? parseInt(countHeader.split('/')[1] || '0', 10) : items.length;
 


### PR DESCRIPTION
## Summary
- The `/api/v1/self-healing/history` route post-filters rows by an endpoint allow-list (URL paths in `ENDPOINT_FILE_MAP` + strings starting with `autopilot.`). The dev-autopilot triage path writes file-path endpoints (`services/gateway/...`, `supabase/migrations/...`) and `dev_autopilot.*` stage tags, so every row from that pipeline was being dropped.
- With the frontend asking for `limit=20` and the most-recent 20 rows all originating from that pipeline, the Self-Healing screen rendered **"No self-healing history yet"** while the underlying table held 218 rows growing every ~10 minutes.
- Returns the raw query result. The screen now reflects what the system is actually doing.

## Why now
User noticed the screen was empty and asked whether self-healing had been shut down. It hasn't — `Status: ACTIVE`, `Mode: AUTO-FIX SIMPLE`, log table at 218 rows. The filter was the only thing hiding it.

## Test plan
- [x] `tsc --noEmit` clean
- [ ] EXEC-DEPLOY succeeds + smoke tests pass
- [ ] After deploy, hit `/api/v1/self-healing/history?limit=20` and confirm dev-autopilot rows appear
- [ ] Command Hub → Autonomy → Self Healing shows history

🤖 Generated with [Claude Code](https://claude.com/claude-code)