### PR TITLE
fix(self-healing): Command Hub fetches now send Authorization header (VTID-01989)

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -36402,11 +36402,18 @@ function fetchSelfHealingData() {
     state.selfHealing.error = null;
     renderApp();
 
+    var shHeaders = buildContextHeaders();
+    function shFetchJson(url) {
+        return fetch(url, { headers: shHeaders }).then(function(r) {
+            if (!r.ok) throw new Error('HTTP ' + r.status + ' ' + url);
+            return r.json();
+        });
+    }
     Promise.all([
-        fetch('/api/v1/self-healing/config').then(function(r) { return r.json(); }),
-        fetch('/api/v1/self-healing/active').then(function(r) { return r.json(); }),
-        fetch('/api/v1/self-healing/history?limit=20').then(function(r) { return r.json(); }),
-        fetch('/api/v1/self-healing/pending-approval').then(function(r) { return r.json(); })
+        shFetchJson('/api/v1/self-healing/config'),
+        shFetchJson('/api/v1/self-healing/active'),
+        shFetchJson('/api/v1/self-healing/history?limit=20'),
+        shFetchJson('/api/v1/self-healing/pending-approval')
     ]).then(function(results) {
         state.selfHealing.config = results[0];
         state.selfHealing.active = (results[1] && results[1].tasks) || [];
@@ -38485,7 +38492,7 @@ function renderSelfHealingView() {
         killBtn.textContent = 'Processing...';
         fetch('/api/v1/self-healing/kill-switch', {
             method: 'POST',
-            headers: { 'Content-Type': 'application/json' },
+            headers: buildContextHeaders({ 'Content-Type': 'application/json' }),
             body: JSON.stringify({ action: action, operator: 'command-hub' })
         }).then(function(r) { return r.json(); }).then(function() {
             state.selfHealing.fetched = false;
@@ -38557,7 +38564,7 @@ function renderSelfHealingView() {
     levelSelect.onchange = function() {
         fetch('/api/v1/self-healing/config', {
             method: 'PATCH',
-            headers: { 'Content-Type': 'application/json' },
+            headers: buildContextHeaders({ 'Content-Type': 'application/json' }),
             body: JSON.stringify({ autonomy_level: parseInt(levelSelect.value), operator: 'command-hub' })
         }).then(function() {
             state.selfHealing.fetched = false;
@@ -38618,7 +38625,7 @@ function renderSelfHealingView() {
                 approveBtn.textContent = 'DISPATCHING…';
                 fetch('/api/v1/self-healing/approve', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: buildContextHeaders({ 'Content-Type': 'application/json' }),
                     body: JSON.stringify({ id: row.id, operator: 'command-hub' })
                 }).then(function(r) { return r.json(); }).then(function(result) {
                     state.selfHealing.fetched = false;
@@ -38646,7 +38653,7 @@ function renderSelfHealingView() {
                 rejectBtn.textContent = 'REJECTING…';
                 fetch('/api/v1/self-healing/reject', {
                     method: 'POST',
-                    headers: { 'Content-Type': 'application/json' },
+                    headers: buildContextHeaders({ 'Content-Type': 'application/json' }),
                     body: JSON.stringify({ id: row.id, operator: 'command-hub', reason: reason || '' })
                 }).then(function(r) { return r.json(); }).then(function(result) {
                     state.selfHealing.fetched = false;
@@ -38746,7 +38753,7 @@ function renderSelfHealingView() {
                 rejectBtn.className = 'infra-btn infra-btn--danger';
                 rejectBtn.textContent = 'REJECT';
                 rejectBtn.onclick = function() {
-                    fetch('/api/v1/self-healing/rollback/' + task.vtid, { method: 'POST' }).then(function() {
+                    fetch('/api/v1/self-healing/rollback/' + task.vtid, { method: 'POST', headers: buildContextHeaders() }).then(function() {
                         state.selfHealing.fetched = false;
                         fetchSelfHealingData();
                         showToast('Rejected ' + task.vtid, 'info');
@@ -38760,7 +38767,7 @@ function renderSelfHealingView() {
             rollbackBtn.textContent = 'ROLLBACK';
             rollbackBtn.onclick = function() {
                 if (!confirm('Rollback ' + task.vtid + '?')) return;
-                fetch('/api/v1/self-healing/rollback/' + task.vtid, { method: 'POST' }).then(function() {
+                fetch('/api/v1/self-healing/rollback/' + task.vtid, { method: 'POST', headers: buildContextHeaders() }).then(function() {
                     state.selfHealing.fetched = false;
                     fetchSelfHealingData();
                     showToast('Rollback requested for ' + task.vtid, 'warning');

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -12,7 +12,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260427-vtid-01988-mic-restart"></script>
-  <script src="/command-hub/app.js?v=20260426-vtid-01982-health-probe-auth"></script>
+  <script src="/command-hub/app.js?v=20260427-vtid-01989-self-healing-auth"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
 </body>


### PR DESCRIPTION
## Summary

The Self-Healing screen at `/command-hub/autonomy/self-healing/` looked alive but was actually logged out. The 8 `fetch()` calls in app.js (4 reads in `fetchSelfHealingData` + kill-switch + PATCH /config + approve + reject + 2 rollback) skipped `buildContextHeaders()`, so every request hit the gateway anonymously and got `401 UNAUTHENTICATED`. The `Promise.all` then treated the 401 JSON as success (no `r.ok` check), `config/active/history/pendingApproval` all resolved to `{ok:false,…}`, the items lookup fell back to `[]`, and the status bar rendered the hardcoded defaults at app.js:38219 (`autonomy_level=3` → `AUTO-FIX SIMPLE`). The screen reported `Status: ACTIVE`, `Mode: AUTO-FIX SIMPLE`, `0 Active Repairs`, `0 Awaiting Approval`, and `No self-healing history yet` — all of those are the *empty defaults*, not real data.

This is a sibling of VTID-01986 (which fixed the backend filter dropping all dev-autopilot rows). The data was finally reaching the API but the screen never saw it because it was never authenticated.

## Changes
- `services/gateway/src/frontend/command-hub/app.js` — every self-healing `fetch()` wrapped in `buildContextHeaders()`. New helper `shFetchJson()` throws on `!r.ok` so future auth/server errors surface as a visible "Error: ..." instead of silently rendering defaults (CLAUDE.md ALWAYS rule 10).
- `services/gateway/src/frontend/command-hub/index.html` — bumps `app.js?v=` cache-buster.

## Test plan
- [x] `tsc --noEmit` clean
- [ ] EXEC-DEPLOY succeeds + smoke tests pass
- [ ] Playwright as e2e-test (developer role) sees `state.selfHealing.history.length === 20` and the History table renders dev-autopilot rows.

🤖 Generated with [Claude Code](https://claude.com/claude-code)