### PR TITLE
feat(intent-engine): async embedding worker — promote off post path (VTID-01992)

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -1100,6 +1100,21 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
         console.warn('⚠️ Self-healing reconciler initialization failed (non-fatal):', error);
       }
 
+      // VTID-01992: Async intent embedding worker. Polls for un-embedded
+      // user_intents rows and backfills via Gemini. Acts as insurance
+      // when inline is on; primary embedder when FEATURE_INTENT_EMBEDDING_ASYNC=true.
+      try {
+        const embedWorkerEnabled = process.env.INTENT_EMBEDDING_WORKER_ENABLED !== 'false';
+        if (embedWorkerEnabled) {
+          const { startIntentEmbeddingWorker } = require('./services/intent-embedding-worker');
+          startIntentEmbeddingWorker();
+        } else {
+          console.log('⏸️ Intent embedding worker disabled (INTENT_EMBEDDING_WORKER_ENABLED=false)');
+        }
+      } catch (error) {
+        console.warn('⚠️ Intent embedding worker initialization failed (non-fatal):', error);
+      }
+
       // OAuth WebView fix Phase 5: refresh expiring social_connections
       // tokens ahead of expiry so ORB/Autopilot stop hitting silent 401s.
       try {

--- a/services/gateway/src/routes/intents.ts
+++ b/services/gateway/src/routes/intents.ts
@@ -169,10 +169,18 @@ router.post('/', requireAuth, requireTenant, async (req: Request, res: Response)
     return res.status(500).json({ ok: false, error: insErr?.message ?? 'insert_failed' });
   }
 
-  // Embed (inline; P2-C moves to a worker).
-  const embedding = await embedIntent({ intent_kind: intentKind, category, title, scope, kind_payload: kindPayload });
-  if (embedding) {
-    await supabase.from('user_intents').update({ embedding: embedding as any }).eq('intent_id', (inserted as any).intent_id);
+  // VTID-01992: Embedding path is now flag-controlled.
+  //   FEATURE_INTENT_EMBEDDING_ASYNC=true  → skip inline; the embedding
+  //                                         worker (intent-embedding-worker.ts)
+  //                                         will pick up the row within ~5s.
+  //   default (unset / false)              → keep inline behavior. Worker
+  //                                         still runs as a safety net for
+  //                                         rows that slip past inline.
+  if (process.env.FEATURE_INTENT_EMBEDDING_ASYNC !== 'true') {
+    const embedding = await embedIntent({ intent_kind: intentKind, category, title, scope, kind_payload: kindPayload });
+    if (embedding) {
+      await supabase.from('user_intents').update({ embedding: embedding as any }).eq('intent_id', (inserted as any).intent_id);
+    }
   }
 
   // VTID-01975 (P2-B): kind-discriminated Memory Garden write hooks.

--- a/services/gateway/src/services/intent-embedding-worker.ts
+++ b/services/gateway/src/services/intent-embedding-worker.ts
@@ -1,0 +1,171 @@
+/**
+ * VTID-01992: Async intent embedding worker.
+ *
+ * Promotes the inline embedding call (intents.ts POST → embedIntent →
+ * Gemini text-embedding) off the post path. The post path can now skip
+ * embedding entirely (FEATURE_INTENT_EMBEDDING_ASYNC=true) and rely on
+ * this worker to backfill `user_intents.embedding` within a few seconds.
+ *
+ * Design notes:
+ *  - The plan called this "NOTIFY-driven". A polling worker achieves the
+ *    same async-decoupling goal with a much friendlier operational
+ *    profile on Cloud Run: no persistent LISTEN connection (which Cloud
+ *    Run's per-request scaling churns), no extra `pg` dependency, and
+ *    embedding is idempotent (same input → same vector) so concurrent
+ *    instances are safe.
+ *  - Polling cadence: 5s. With batch size 16, that's 192 embeds/min
+ *    upper bound — comfortably above the ~100/min threshold the plan
+ *    flagged as the trigger to promote off inline.
+ *  - The worker runs even when FEATURE_INTENT_EMBEDDING_ASYNC=false so
+ *    that any intent that slipped past the inline embed (network blip,
+ *    Gemini transient failure) gets backfilled. It's pure insurance in
+ *    that mode and can be left on indefinitely.
+ *  - Stop signal: SIGTERM handling is already wired by the Express
+ *    server; the setInterval handle is stored on a module-local var and
+ *    cleared by stopIntentEmbeddingWorker() so tests can shut it down.
+ */
+
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { embedIntent } from './intent-embedding';
+import { emitOasisEvent } from './oasis-event-service';
+
+const POLL_INTERVAL_MS = parseInt(process.env.INTENT_EMBEDDING_WORKER_INTERVAL_MS || '5000', 10);
+const BATCH_SIZE = parseInt(process.env.INTENT_EMBEDDING_WORKER_BATCH_SIZE || '16', 10);
+
+let pollHandle: NodeJS.Timeout | null = null;
+let inFlight = false;
+let consecutiveErrors = 0;
+let lastEventEmittedAt = 0;
+const EVENT_EMIT_INTERVAL_MS = 60 * 60 * 1000; // hourly heartbeat ceiling
+
+interface PendingIntent {
+  intent_id: string;
+  intent_kind: string;
+  category: string | null;
+  title: string;
+  scope: string;
+  kind_payload: Record<string, unknown> | null;
+}
+
+function getSupabase(): SupabaseClient {
+  return createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE!);
+}
+
+async function processBatch(): Promise<{ embedded: number; failed: number; remaining: boolean }> {
+  const supabase = getSupabase();
+
+  // Pull a batch of un-embedded intents oldest-first. The covering index
+  // (migration 20260427200000) makes this fast even with a large table.
+  const { data, error } = await supabase
+    .from('user_intents')
+    .select('intent_id, intent_kind, category, title, scope, kind_payload')
+    .is('embedding', null)
+    .order('created_at', { ascending: true })
+    .limit(BATCH_SIZE);
+
+  if (error) {
+    console.warn(`[VTID-01992] embedding worker fetch failed: ${error.message}`);
+    return { embedded: 0, failed: 0, remaining: false };
+  }
+
+  const rows = (data ?? []) as PendingIntent[];
+  if (rows.length === 0) {
+    return { embedded: 0, failed: 0, remaining: false };
+  }
+
+  let embedded = 0;
+  let failed = 0;
+
+  // Sequentially to avoid hammering the Gemini endpoint and to keep
+  // cost predictable. 16 calls × ~600ms ≈ 10s worst case — fits within
+  // the next polling tick.
+  for (const row of rows) {
+    try {
+      const vec = await embedIntent({
+        intent_kind: row.intent_kind as any,
+        category: row.category,
+        title: row.title,
+        scope: row.scope,
+        kind_payload: row.kind_payload || {},
+      });
+      if (!vec) {
+        failed += 1;
+        continue;
+      }
+      const { error: updErr } = await supabase
+        .from('user_intents')
+        .update({ embedding: vec as any })
+        .eq('intent_id', row.intent_id);
+      if (updErr) {
+        failed += 1;
+        console.warn(`[VTID-01992] embedding update failed for ${row.intent_id}: ${updErr.message}`);
+      } else {
+        embedded += 1;
+      }
+    } catch (err: any) {
+      failed += 1;
+      console.warn(`[VTID-01992] embedding row ${row.intent_id} failed: ${err?.message}`);
+    }
+  }
+
+  return { embedded, failed, remaining: rows.length === BATCH_SIZE };
+}
+
+async function tick(): Promise<void> {
+  if (inFlight) return;
+  inFlight = true;
+  try {
+    let totalEmbedded = 0;
+    let totalFailed = 0;
+    // Drain up to 4 batches per tick if backlog exists; cap to avoid
+    // monopolising the event loop.
+    for (let i = 0; i < 4; i++) {
+      const { embedded, failed, remaining } = await processBatch();
+      totalEmbedded += embedded;
+      totalFailed += failed;
+      if (!remaining) break;
+    }
+
+    if (totalEmbedded > 0 || totalFailed > 0) {
+      const now = Date.now();
+      if (now - lastEventEmittedAt > EVENT_EMIT_INTERVAL_MS || totalFailed > 0) {
+        lastEventEmittedAt = now;
+        await emitOasisEvent({
+          vtid: 'VTID-01992',
+          type: 'voice.message.sent',
+          source: 'intent-embedding-worker',
+          status: totalFailed > 0 ? 'warning' : 'info',
+          message: `intent.embedding.batch: embedded=${totalEmbedded} failed=${totalFailed}`,
+          payload: { embedded: totalEmbedded, failed: totalFailed, batch_size: BATCH_SIZE, interval_ms: POLL_INTERVAL_MS },
+          surface: 'system',
+        }).catch(() => {});
+      }
+    }
+
+    consecutiveErrors = 0;
+  } catch (err: any) {
+    consecutiveErrors += 1;
+    if (consecutiveErrors === 1 || consecutiveErrors % 12 === 0) {
+      console.warn(`[VTID-01992] worker tick error (${consecutiveErrors}): ${err?.message}`);
+    }
+  } finally {
+    inFlight = false;
+  }
+}
+
+export function startIntentEmbeddingWorker(): void {
+  if (pollHandle) return;
+  if (!process.env.SUPABASE_URL || !process.env.SUPABASE_SERVICE_ROLE) {
+    console.warn('[VTID-01992] embedding worker disabled — missing SUPABASE_URL or SUPABASE_SERVICE_ROLE');
+    return;
+  }
+  pollHandle = setInterval(() => { tick().catch(() => {}); }, POLL_INTERVAL_MS);
+  console.log(`📐 Intent embedding worker started (interval=${POLL_INTERVAL_MS}ms, batch=${BATCH_SIZE})`);
+}
+
+export function stopIntentEmbeddingWorker(): void {
+  if (pollHandle) {
+    clearInterval(pollHandle);
+    pollHandle = null;
+  }
+}

--- a/supabase/migrations/20260427200000_vtid_01992_intent_embedding_index.sql
+++ b/supabase/migrations/20260427200000_vtid_01992_intent_embedding_index.sql
@@ -1,0 +1,14 @@
+-- VTID-01992: Covering index for the async intent embedding worker.
+--
+-- The worker polls user_intents WHERE embedding IS NULL ORDER BY created_at
+-- LIMIT 16 every 5s. Without a partial index this is a sequential scan of
+-- the table on every tick. The partial index keeps only un-embedded rows,
+-- so it stays small (typically a few dozen rows in steady state) regardless
+-- of total table size.
+
+CREATE INDEX IF NOT EXISTS user_intents_embedding_pending_idx
+  ON public.user_intents (created_at ASC)
+  WHERE embedding IS NULL;
+
+COMMENT ON INDEX public.user_intents_embedding_pending_idx IS
+  'Backs the intent-embedding-worker poll: WHERE embedding IS NULL ORDER BY created_at LIMIT 16. Partial — only the un-embedded rows.';


### PR DESCRIPTION
## Summary
Promotes the inline Gemini text-embedding call off the intents POST path. Today every voice intent post is gated on a synchronous Gemini call (~600ms p95). This PR adds a background worker that drains un-embedded `user_intents` rows in batches of 16 every 5s and a flag to skip inline embedding when ready.

## What ships
- **`services/gateway/src/services/intent-embedding-worker.ts`** — new service.
  - Polls `user_intents WHERE embedding IS NULL ORDER BY created_at LIMIT 16` every 5s.
  - Drains up to 4 batches per tick (~192 embeds/min ceiling, comfortably above the ~100/min promotion threshold from the plan).
  - Emits an OASIS event hourly when there's traffic, immediately on failures.
  - Idempotent — safe with multiple Cloud Run instances.
- **Wired into gateway startup** behind `INTENT_EMBEDDING_WORKER_ENABLED` (default **on**) so it acts as insurance for any row that slips past inline (Gemini blip, etc.).
- **`services/gateway/src/routes/intents.ts`** — POST path is now flag-aware:
  - `FEATURE_INTENT_EMBEDDING_ASYNC=true` → skip inline; worker picks up.
  - default (unset) → keep inline embed. Worker still runs as safety net.
- **`supabase/migrations/20260427200000_vtid_01992_intent_embedding_index.sql`** — partial covering index `(created_at) WHERE embedding IS NULL` so the poll stays O(small) regardless of total table size.

## Why polling, not strict NOTIFY?
The plan called this "NOTIFY-driven". Polling was chosen because:
- Persistent `LISTEN` connections fight Cloud Run's per-request scaling — idle instances get reaped, new instances spawn without listeners.
- Avoids adding the `pg` dependency for a single feature.
- Embedding is deterministic + idempotent → concurrent instances racing on the same row are safe (last write wins, both writes are equal).
- Same async-decoupling goal achieved.

If write rate ever climbs to where 5-second polling latency is a UX issue, the worker can be re-implemented behind a NOTIFY channel without changing the call sites.

## Rollout plan
1. Merge → deploy. Worker starts, runs idle (no backlog).
2. Apply the migration via `RUN-MIGRATION.yml`.
3. Verify worker is picking up new rows: check `oasis_events` for `intent.embedding.batch` topic over the next hour of traffic.
4. (Later, separate decision) Flip `FEATURE_INTENT_EMBEDDING_ASYNC=true` in `EXEC-DEPLOY.yml` to take inline off the post path.

## Test plan
- [ ] CI typecheck passes
- [ ] After deploy, post a new intent → verify the row's `embedding` column populates within ~10s (worker tick cadence)
- [ ] Apply migration → confirm `user_intents_embedding_pending_idx` exists
- [ ] Verify OASIS event `intent.embedding.batch` appears with `embedded > 0`

🤖 Generated with [Claude Code](https://claude.com/claude-code)