### PR TITLE
feat(vitana-id): v2 chronological sequence — gateway (VTID-01987)

### DIFF
--- a/services/gateway/src/routes/auth.ts
+++ b/services/gateway/src/routes/auth.ts
@@ -432,12 +432,14 @@ router.get('/me', requireAuth, async (req: AuthenticatedRequest, res: Response) 
 
   // VTID-01186: Fetch profile and memberships from database
   // VTID-01967: also expose vitana_id (from app_users mirror) and vitana_id_locked (from profiles).
+  // VTID-01987: also expose registration_seq (the user's chronological signup rank).
   let profile: {
     display_name?: string;
     avatar_url?: string;
     bio?: string;
     vitana_id?: string;
     vitana_id_locked?: boolean;
+    registration_seq?: number;
   } = {};
   let memberships: Array<{ tenant_id: string; role: string; is_primary: boolean }> = [];
 
@@ -461,24 +463,27 @@ router.get('/me', requireAuth, async (req: AuthenticatedRequest, res: Response) 
         };
       }
 
-      // VTID-01967: vitana_id_locked lives only on profiles (not mirrored).
-      // Parallel fetch — null-tolerant (column may not exist before Release A).
+      // VTID-01967 + VTID-01987: vitana_id_locked + registration_seq live only
+      // on profiles (not mirrored). Parallel fetch — null-tolerant (columns
+      // may not exist before Release A / v2 backfill).
       try {
         const { data: lockData } = await supabase
           .from('profiles')
-          .select('vitana_id_locked, vitana_id')
+          .select('vitana_id_locked, vitana_id, registration_seq')
           .eq('user_id', identity.user_id)
           .maybeSingle();
         if (lockData) {
           profile.vitana_id_locked = (lockData as any).vitana_id_locked === true;
-          // Profiles is the source of truth; if app_users mirror is stale (or
-          // not yet provisioned), prefer profiles.vitana_id.
           if (!profile.vitana_id && (lockData as any).vitana_id) {
             profile.vitana_id = (lockData as any).vitana_id;
           }
+          if (typeof (lockData as any).registration_seq === 'number') {
+            profile.registration_seq = (lockData as any).registration_seq;
+          }
         }
       } catch (_lockErr) {
-        // Silent — profiles.vitana_id_locked may not exist on this env yet.
+        // Silent — profiles.vitana_id_locked / registration_seq may not exist
+        // on this env yet.
       }
 
       // VTID-01230-FIX: Match /auth/login fallback chain for avatar_url.

--- a/services/gateway/src/routes/users-vitana-id.ts
+++ b/services/gateway/src/routes/users-vitana-id.ts
@@ -1,16 +1,20 @@
 /**
- * VTID-01967: Vitana ID onboarding pick endpoints.
+ * VTID-01967 + VTID-01987: Vitana ID onboarding pick endpoints.
  *
  *   GET  /api/v1/users/me/vitana-id/suggestion
- *        Returns 3 fresh suggestions from generate_vitana_id_suggestion().
+ *        Returns the user's current vitana_id + registration_seq + 3 base
+ *        alternatives. The seq is fixed (allocated at signup, the user's
+ *        registration rank); only the base portion is editable.
  *
- *   POST /api/v1/users/me/vitana-id/confirm   body: { vitana_id }
+ *   POST /api/v1/users/me/vitana-id/confirm   body: { base } | { vitana_id }
  *        ONE-SHOT — only callable when profiles.vitana_id_locked = false.
- *        On success: writes previous auto-generated value to handle_aliases,
- *        updates vitana_id (and the legacy handle mirror) to the new value,
- *        sets vitana_id_locked = true. After lock: 409 Conflict on every
- *        subsequent call. Mutability is permanent — there is intentionally
- *        no PATCH endpoint after this.
+ *        Accepts either { base } (v2, suffix is forced from registration_seq)
+ *        or { vitana_id } (legacy, accepted for one release with deprecation
+ *        warning) — the suffix part is enforced to match registration_seq
+ *        either way. On success: parks the previous auto-generated value in
+ *        handle_aliases, updates vitana_id (and the legacy handle mirror) to
+ *        the new value, sets vitana_id_locked = true. After lock: 409 on
+ *        every subsequent call.
  */
 
 import { Router, Request, Response } from 'express';
@@ -31,9 +35,24 @@ function getSupabase() {
   );
 }
 
-const VITANA_ID_REGEX = /^[a-z][a-z0-9]{3,11}$/;
-const MIN_LETTERS = 2;
-const MIN_DIGITS = 2;
+// v2 format: <base><seq>. Total 4-16 chars. The base alone is 2-8 chars and
+// must match BASE_REGEX; the suffix is the user's registration_seq (digits).
+const VITANA_ID_REGEX_V2 = /^[a-z][a-z0-9]{3,15}$/;
+const BASE_REGEX = /^[a-z][a-z0-9]{1,7}$/;
+
+// Lightweight base normalizer — strips @ + non-base chars + lowercases. Returns
+// '' if the input has no usable base prefix.
+function normalizeBase(input: string): string {
+  return input.trim().replace(/^@/, '').toLowerCase().replace(/[^a-z0-9]/g, '');
+}
+
+// Split a vitana_id into { base, seq }. Returns null if it doesn't end in
+// digits (shouldn't happen post-v2, but the legacy format has digits too).
+function splitVitanaId(v: string): { base: string; seq: number } | null {
+  const m = v.match(/^([a-z][a-z0-9]*?)([0-9]+)$/);
+  if (!m) return null;
+  return { base: m[1], seq: parseInt(m[2], 10) };
+}
 
 // ── GET /me/vitana-id/suggestion ──────────────────────────────
 
@@ -43,11 +62,9 @@ router.get('/me/vitana-id/suggestion', requireAuth, async (req: Request, res: Re
 
   const supabase = getSupabase();
 
-  // Fetch the user's display_name + email for the generator. (full_name in
-  // profiles is the user-friendly name; falls back to email prefix.)
   const { data: profileRow } = await supabase
     .from('profiles')
-    .select('display_name, full_name, email, vitana_id_locked')
+    .select('display_name, full_name, email, vitana_id, vitana_id_locked, registration_seq')
     .eq('user_id', identity.user_id)
     .maybeSingle();
 
@@ -59,34 +76,49 @@ router.get('/me/vitana-id/suggestion', requireAuth, async (req: Request, res: Re
     });
   }
 
-  // Three suggestions — three independent RPC calls. Each gets its own
-  // random suffix internally, so the trio is naturally distinct.
-  const [s1, s2, s3] = await Promise.all([
-    supabase.rpc('generate_vitana_id_suggestion', {
-      p_display_name: profileRow?.display_name ?? null,
-      p_full_name: profileRow?.full_name ?? null,
-      p_email: profileRow?.email ?? identity.email ?? null,
-    }),
-    supabase.rpc('generate_vitana_id_suggestion', {
-      p_display_name: profileRow?.display_name ?? null,
-      p_full_name: profileRow?.full_name ?? null,
-      p_email: profileRow?.email ?? identity.email ?? null,
-    }),
-    supabase.rpc('generate_vitana_id_suggestion', {
-      p_display_name: profileRow?.display_name ?? null,
-      p_full_name: profileRow?.full_name ?? null,
-      p_email: profileRow?.email ?? identity.email ?? null,
-    }),
-  ]);
+  const current = (profileRow as any)?.vitana_id as string | undefined;
+  const seq = (profileRow as any)?.registration_seq as number | undefined;
 
-  // Dedupe in case the random suffixes happened to collide.
-  const suggestions = Array.from(
-    new Set([s1.data, s2.data, s3.data].filter(Boolean))
-  );
+  // Build 3 base alternatives from display_name / full_name / email-local.
+  // Truncate each to 8 chars. Dedupe + filter to BASE_REGEX-valid bases.
+  const sources: string[] = [
+    (profileRow as any)?.display_name ?? '',
+    (profileRow as any)?.full_name ?? '',
+    (((profileRow as any)?.email ?? identity.email ?? '') as string).split('@')[0] ?? '',
+  ];
+
+  const candidateBases = new Set<string>();
+  for (const src of sources) {
+    if (!src) continue;
+    const parts = src.split(/\s+/).filter(Boolean);
+    for (const part of parts) {
+      const norm = normalizeBase(part).replace(/^[0-9]+/, '');
+      if (norm.length >= 2) {
+        candidateBases.add(norm.slice(0, 8));
+      }
+    }
+  }
+
+  // Always include the current base as the first alternative.
+  const currentSplit = current ? splitVitanaId(current) : null;
+  const baseAlternatives: string[] = [];
+  if (currentSplit?.base) baseAlternatives.push(currentSplit.base);
+  for (const b of candidateBases) {
+    if (BASE_REGEX.test(b) && !baseAlternatives.includes(b)) {
+      baseAlternatives.push(b);
+    }
+    if (baseAlternatives.length >= 3) break;
+  }
 
   return res.json({
     ok: true,
-    suggestions,
+    data: {
+      current,
+      registration_seq: seq,
+      base_alternatives: baseAlternatives,
+    },
+    // Legacy field — keep filled for one release for backwards-compatible clients.
+    suggestions: current ? [current] : [],
   });
 });
 
@@ -96,55 +128,13 @@ router.post('/me/vitana-id/confirm', requireAuth, async (req: Request, res: Resp
   const { identity } = req as AuthenticatedRequest;
   if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
 
-  const { vitana_id: requestedRaw } = req.body ?? {};
-
-  if (!requestedRaw || typeof requestedRaw !== 'string') {
-    return res.status(400).json({ ok: false, error: 'vitana_id is required' });
-  }
-
-  // Normalize: strip leading @, lowercase. Same rules as the resolver.
-  const requested = requestedRaw.trim().replace(/^@/, '').toLowerCase();
-
-  // Format check.
-  if (!VITANA_ID_REGEX.test(requested)) {
-    return res.status(400).json({
-      ok: false,
-      error: 'INVALID_FORMAT',
-      message: 'Vitana ID must start with a letter, then 3-11 lowercase letters or digits.',
-    });
-  }
-
-  // Composition check (≥2 letters AND ≥2 digits).
-  const letters = (requested.match(/[a-z]/g) || []).length;
-  const digits = (requested.match(/[0-9]/g) || []).length;
-  if (letters < MIN_LETTERS || digits < MIN_DIGITS) {
-    return res.status(400).json({
-      ok: false,
-      error: 'WEAK_COMPOSITION',
-      message: `Vitana ID needs at least ${MIN_LETTERS} letters and ${MIN_DIGITS} digits.`,
-    });
-  }
-
+  const body = req.body ?? {};
   const supabase = getSupabase();
 
-  // Reserved-word check (single source of truth in vitana_id_reserved table).
-  const { data: reserved } = await supabase
-    .from('vitana_id_reserved')
-    .select('token')
-    .eq('token', requested)
-    .maybeSingle();
-  if (reserved) {
-    return res.status(400).json({
-      ok: false,
-      error: 'RESERVED_TOKEN',
-      message: 'That Vitana ID is reserved. Please choose another.',
-    });
-  }
-
-  // Read current row + lock state.
+  // Read current row + lock state + seq.
   const { data: current, error: currentErr } = await supabase
     .from('profiles')
-    .select('vitana_id, vitana_id_locked')
+    .select('vitana_id, vitana_id_locked, registration_seq')
     .eq('user_id', identity.user_id)
     .maybeSingle();
 
@@ -165,8 +155,92 @@ router.post('/me/vitana-id/confirm', requireAuth, async (req: Request, res: Resp
   }
 
   const previous = (current as any).vitana_id as string | null;
+  const seq = (current as any).registration_seq as number | null;
 
-  // Uniqueness pre-check (definitive check is the UNIQUE index on UPDATE).
+  if (!seq) {
+    // Defensive: any post-v2 user has registration_seq populated. If this
+    // fires for a real user it means the v2 backfill missed them.
+    return res.status(409).json({
+      ok: false,
+      error: 'NO_REGISTRATION_SEQ',
+      message: 'Your account is missing a registration sequence number. Please contact support.',
+    });
+  }
+
+  // Resolve the user's chosen base. Two accepted shapes:
+  //   { base: "alex" }            — v2 native
+  //   { vitana_id: "alex25" }     — legacy; suffix MUST equal registration_seq
+  let base: string;
+  if (typeof body.base === 'string') {
+    base = body.base.trim().replace(/^@/, '').toLowerCase();
+  } else if (typeof body.vitana_id === 'string') {
+    const requested = body.vitana_id.trim().replace(/^@/, '').toLowerCase();
+    if (!VITANA_ID_REGEX_V2.test(requested)) {
+      return res.status(400).json({
+        ok: false,
+        error: 'INVALID_FORMAT',
+        message: 'Vitana ID must start with a letter and be 4-16 lowercase letters or digits.',
+      });
+    }
+    const split = splitVitanaId(requested);
+    if (!split) {
+      return res.status(400).json({
+        ok: false,
+        error: 'INVALID_FORMAT',
+        message: 'Vitana ID must end in digits matching your registration number.',
+      });
+    }
+    if (split.seq !== seq) {
+      return res.status(400).json({
+        ok: false,
+        error: 'SUFFIX_LOCKED',
+        message: `Your Vitana ID suffix is locked to your registration number ${seq}. You can only change the name part.`,
+      });
+    }
+    base = split.base;
+  } else {
+    return res.status(400).json({
+      ok: false,
+      error: 'BASE_REQUIRED',
+      message: 'Provide a `base` (the name portion of your Vitana ID).',
+    });
+  }
+
+  // Validate base shape.
+  if (!BASE_REGEX.test(base)) {
+    return res.status(400).json({
+      ok: false,
+      error: 'INVALID_BASE',
+      message: 'Base must start with a letter and be 2-8 lowercase letters or digits.',
+    });
+  }
+
+  // Reserved-word check against the canonical reserved table.
+  const { data: reserved } = await supabase
+    .from('vitana_id_reserved')
+    .select('token')
+    .eq('token', base)
+    .maybeSingle();
+  if (reserved) {
+    return res.status(400).json({
+      ok: false,
+      error: 'RESERVED_TOKEN',
+      message: 'That name is reserved. Please choose another.',
+    });
+  }
+
+  const requested = `${base}${seq}`;
+
+  // Final format check (defense in depth — should always pass).
+  if (!VITANA_ID_REGEX_V2.test(requested)) {
+    return res.status(400).json({
+      ok: false,
+      error: 'INVALID_FORMAT',
+      message: 'Computed Vitana ID is invalid; pick a shorter base.',
+    });
+  }
+
+  // Uniqueness pre-check (definitive guard is the UNIQUE index on UPDATE).
   if (previous !== requested) {
     const { data: taken } = await supabase
       .from('profiles')
@@ -178,12 +252,10 @@ router.post('/me/vitana-id/confirm', requireAuth, async (req: Request, res: Resp
       return res.status(409).json({
         ok: false,
         error: 'TAKEN',
-        message: 'That Vitana ID is already taken. Please choose another.',
+        message: 'That Vitana ID is already taken. Try a different name.',
       });
     }
 
-    // Also check handle_aliases — collisions are protected here too so we
-    // never re-issue an ID that historically pointed to a different user.
     const { data: aliasTaken } = await supabase
       .from('handle_aliases')
       .select('user_id')
@@ -194,12 +266,10 @@ router.post('/me/vitana-id/confirm', requireAuth, async (req: Request, res: Resp
       return res.status(409).json({
         ok: false,
         error: 'ALIAS_COLLISION',
-        message: 'That Vitana ID was previously used by another account. Please choose another.',
+        message: 'That Vitana ID was previously used by another account. Try a different name.',
       });
     }
 
-    // Park the previous auto-generated value in handle_aliases so /profiles
-    // links and any in-flight references still resolve to this user.
     if (previous) {
       await supabase.from('handle_aliases').upsert(
         { old_handle: previous, user_id: identity.user_id },
@@ -208,9 +278,6 @@ router.post('/me/vitana-id/confirm', requireAuth, async (req: Request, res: Resp
     }
   }
 
-  // Update profiles. Mirror trigger fires -> app_users.vitana_id updates.
-  // handle column also mirrored to keep frontend reads consistent under
-  // the replace policy.
   const { error: updateErr } = await supabase
     .from('profiles')
     .update({
@@ -221,21 +288,19 @@ router.post('/me/vitana-id/confirm', requireAuth, async (req: Request, res: Resp
     .eq('user_id', identity.user_id);
 
   if (updateErr) {
-    console.error('[VTID-01967] vitana-id confirm update error:', updateErr);
+    console.error('[VTID-01987] vitana-id confirm update error:', updateErr);
     return res.status(500).json({ ok: false, error: updateErr.message });
   }
 
-  // Invalidate the in-process cache so the next request sees the new value.
   invalidateVitanaIdCache(identity.user_id);
 
-  // Audit event — vitana_id is now the canonical user identifier.
   await emitOasisEvent({
-    vtid: 'VTID-01967',
+    vtid: 'VTID-01987',
     type: 'vitana_id.confirmed',
     source: 'users-vitana-id',
     status: 'success',
     message: `User confirmed Vitana ID @${requested}${previous ? ` (was @${previous})` : ''}`,
-    payload: { previous, current: requested },
+    payload: { previous, current: requested, registration_seq: seq, base },
     actor_id: identity.user_id,
     actor_role: 'user',
     surface: 'api',
@@ -246,6 +311,7 @@ router.post('/me/vitana-id/confirm', requireAuth, async (req: Request, res: Resp
     ok: true,
     vitana_id: requested,
     vitana_id_locked: true,
+    registration_seq: seq,
   });
 });
 


### PR DESCRIPTION
## Summary
- Switches gateway `/users/me/vitana-id/{suggestion,confirm}` to v2 base-only edit flow; suffix is forced to `registration_seq`
- Exposes `registration_seq` on `/auth/me`
- Migrations land in vitana-v1 PR (paired); apply BEFORE merging this PR

## Why
Random 4-digit suffixes were ASR-unfriendly and told you nothing about the user. v2 makes user #N's ID end in N — speakable, quotable, registration-order discoverable.

## Test plan
- [ ] Apply 4 migrations via RUN-MIGRATION.yml
- [ ] Verify all 20 existing users now have vitana_id ending in 1..20
- [ ] Verify handle_aliases redirects work (/profiles/dragan2943 → /profiles/dragan1)
- [ ] Hit /api/v1/users/me/vitana-id/suggestion as a fresh signup, confirm returns base_alternatives + locked seq
- [ ] Hit /api/v1/users/me/vitana-id/confirm with { base: "alex" }, expect 200 and vitana_id=alex<seq>
- [ ] Voice flow: "send a message to dragan one" via ORB

🤖 Generated with [Claude Code](https://claude.com/claude-code)