### PR TITLE
feat(llm): phases C+F+G via tool-use router (BOOTSTRAP-LLM-ROUTER-CFG)

### DIFF
--- a/services/gateway/src/routes/triage-agent.ts
+++ b/services/gateway/src/routes/triage-agent.ts
@@ -120,6 +120,51 @@ interface InvestigateRequest {
   };
 }
 
+// =============================================================================
+// BOOTSTRAP-LLM-ROUTER (Phase C): provider-aware /investigate
+//
+// When llm_routing_policy.policy.triage.primary_provider === 'anthropic', the
+// route falls through to the existing Managed Agents flow (multi-step session
+// with repo mount + custom tool dispatch + SSE streaming). For every other
+// provider (vertex, openai, deepseek), we do a single-shot LLM call via the
+// router and stash the result in an in-memory cache keyed by a synthetic
+// session_id (`router-<uuid>`). The /stream handler below detects the
+// `router-` prefix and serves the cached result as a single SSE event.
+//
+// Anthropic users see the same progressive UI as today. Non-anthropic users
+// get the result without per-token streaming but the UI still renders it via
+// the same EventSource handlers.
+// =============================================================================
+
+import { randomUUID } from 'crypto';
+import { getActivePolicy } from '../services/llm-routing-policy-service';
+
+interface CachedRouterTriageResult {
+  orb_session_id: string;
+  text: string;
+  provider: string;
+  model: string;
+  createdAt: number;
+}
+const ROUTER_CACHE_TTL_MS = 10 * 60 * 1000;
+const routerTriageCache = new Map<string, CachedRouterTriageResult>();
+function pruneRouterTriageCache() {
+  const cutoff = Date.now() - ROUTER_CACHE_TTL_MS;
+  for (const [k, v] of routerTriageCache) {
+    if (v.createdAt < cutoff) routerTriageCache.delete(k);
+  }
+}
+
+async function getTriagePrimaryProvider(): Promise<string> {
+  try {
+    const row = await getActivePolicy('DEV');
+    const policy = row?.policy as { triage?: { primary_provider?: string } } | undefined;
+    return policy?.triage?.primary_provider || 'anthropic';
+  } catch {
+    return 'anthropic';
+  }
+}
+
 triageAgentRouter.post('/investigate', async (req: Request, res: Response) => {
   try {
     const body = req.body as InvestigateRequest;
@@ -128,10 +173,79 @@ triageAgentRouter.post('/investigate', async (req: Request, res: Response) => {
       return res.status(400).json({ ok: false, error: 'session_id is required' });
     }
 
+    pruneRouterTriageCache();
+
+    // Read policy: if triage stage is NOT anthropic, dispatch through the
+    // router and short-circuit. Anthropic falls through to Managed Agents.
+    const triageProvider = await getTriagePrimaryProvider();
+    if (triageProvider !== 'anthropic') {
+      const flagsList = body.flags.length > 0
+        ? body.flags.map((f: string) => `  - ${f}`).join('\n')
+        : '  (no diagnostic flags)';
+      const prompt = [
+        `Investigate this ORB voice session.`,
+        ``,
+        `## Session: ${body.session_id}`,
+        ``,
+        `## Diagnostic Flags`,
+        flagsList,
+        ``,
+        `## Metrics`,
+        `- Duration: ${body.metrics.duration_ms ? Math.round(body.metrics.duration_ms / 1000) + 's' : 'unknown'}`,
+        `- Audio in chunks: ${body.metrics.audio_in_chunks ?? 'unknown'}`,
+        `- Audio out chunks: ${body.metrics.audio_out_chunks ?? 'unknown'}`,
+        `- Turns: ${body.metrics.turn_count ?? 'unknown'}`,
+        `- Errors: ${body.metrics.error_count ?? 'unknown'}`,
+        `- Interrupts: ${body.metrics.interrupted_count ?? 'unknown'}`,
+        ``,
+        `## Summary`,
+        body.diagnostic_summary || 'No summary provided.',
+        ``,
+        `## OASIS events for session ${body.session_id} (last 100)`,
+        await queryOasisEvents(body.session_id, 100),
+        ``,
+        `Produce a structured triage report with: severity, root cause hypothesis, affected component, evidence (bulleted list), recommended fix, and confidence (low|medium|high).`,
+      ].join('\n');
+
+      const { callViaRouter } = await import('../services/llm-router');
+      const r = await callViaRouter('triage', prompt, {
+        service: 'triage-agent-investigate',
+        maxTokens: 4000,
+      });
+
+      const synthSessionId = `router-${randomUUID()}`;
+      if (r.ok && r.text) {
+        routerTriageCache.set(synthSessionId, {
+          orb_session_id: body.session_id,
+          text: r.text,
+          provider: r.provider || triageProvider,
+          model: r.model || '',
+          createdAt: Date.now(),
+        });
+      } else {
+        routerTriageCache.set(synthSessionId, {
+          orb_session_id: body.session_id,
+          text: `Triage failed via ${r.provider || triageProvider}: ${r.error || 'unknown error'}`,
+          provider: r.provider || triageProvider,
+          model: r.model || '',
+          createdAt: Date.now(),
+        });
+      }
+      return res.status(200).json({
+        ok: true,
+        session_id: synthSessionId,
+        orb_session_id: body.session_id,
+        stream_url: `/api/v1/agents/triage/${synthSessionId}/stream`,
+        provider: r.provider || triageProvider,
+        model: r.model || '',
+      });
+    }
+
+    // === Anthropic Managed Agents path (unchanged) ===
     if (!ANTHROPIC_API_KEY) {
       return res.status(503).json({
         ok: false,
-        error: 'Incident triage is not configured — ANTHROPIC_API_KEY is not set on this gateway instance.',
+        error: 'Triage policy points to Anthropic but ANTHROPIC_API_KEY is not set. Pick a different provider in Command Hub → LLM Providers → triage.',
       });
     }
 
@@ -237,16 +351,46 @@ triageAgentRouter.post('/investigate', async (req: Request, res: Response) => {
 triageAgentRouter.get('/:sessionId/stream', async (req: Request, res: Response) => {
   const { sessionId } = req.params;
 
-  if (!ANTHROPIC_API_KEY) {
-    return res.status(503).json({ ok: false, error: 'ANTHROPIC_API_KEY not set' });
-  }
-
-  // Set up SSE headers
+  // Set up SSE headers up front — same shape for both router and Anthropic paths.
   res.setHeader('Content-Type', 'text/event-stream');
   res.setHeader('Cache-Control', 'no-cache');
   res.setHeader('Connection', 'keep-alive');
   res.setHeader('X-Accel-Buffering', 'no');
   res.flushHeaders();
+
+  // BOOTSTRAP-LLM-ROUTER (Phase C): synthetic session_ids prefixed `router-`
+  // were produced by /investigate when the active triage policy is non-anthropic.
+  // Serve the cached one-shot result as a single agent.message event.
+  if (sessionId.startsWith('router-')) {
+    pruneRouterTriageCache();
+    const cached = routerTriageCache.get(sessionId);
+    const sendSSE = (event: string, data: unknown) => {
+      res.write(`event: ${event}\ndata: ${JSON.stringify(data)}\n\n`);
+    };
+    if (!cached) {
+      sendSSE('error', { error: 'Router triage result expired or not found. Re-run /investigate.' });
+      sendSSE('session.complete', { reason: 'cache_miss' });
+      res.end();
+      return;
+    }
+    sendSSE('agent.message', {
+      id: sessionId + '-msg',
+      content: [{ type: 'text', text: cached.text }],
+      provider: cached.provider,
+      model: cached.model,
+    });
+    sendSSE('session.complete', {
+      reason: 'completed',
+      provider: cached.provider,
+      model: cached.model,
+    });
+    res.end();
+    return;
+  }
+
+  if (!ANTHROPIC_API_KEY) {
+    return res.status(503).json({ ok: false, error: 'ANTHROPIC_API_KEY not set' });
+  }
 
   console.log(`${LOG_PREFIX} Stream opened for session ${sessionId}`);
 

--- a/services/gateway/src/services/anthropic-vision-client.ts
+++ b/services/gateway/src/services/anthropic-vision-client.ts
@@ -18,27 +18,18 @@
  *    throw a typed error and the caller surfaces it to the client.
  */
 
-import Anthropic from '@anthropic-ai/sdk';
+// BOOTSTRAP-LLM-ROUTER (Phase F): vision now goes through callViaRouter
+// instead of the @anthropic-ai/sdk client. The model identifier is whatever
+// the active llm_routing_policy.policy.vision row picks; the constant below
+// is only used as a label for log lines if the router doesn't surface one.
 import { SHORTS_TAG_IDS, SHORTS_TAG_SET } from '../constants/shorts-tags';
 
-const VISION_MODEL = 'claude-sonnet-4-6';
+const VISION_MODEL = 'router-managed';
 const CALL_TIMEOUT_MS = 20_000;
 const MAX_TITLE_CHARS = 80;
 const MAX_DESCRIPTION_CHARS = 300;
 const MAX_TAGS = 5;
 const FALLBACK_CATEGORY = 'wellness';
-
-let client: Anthropic | null = null;
-
-function getClient(): Anthropic {
-  if (client) return client;
-  const apiKey = process.env.ANTHROPIC_API_KEY;
-  if (!apiKey) {
-    throw new VisionClientError('MISSING_API_KEY', 'ANTHROPIC_API_KEY is not configured');
-  }
-  client = new Anthropic({ apiKey });
-  return client;
-}
 
 export type KeyframeInput = {
   position_ratio: number;
@@ -176,78 +167,92 @@ export type AnalyzeResult = ShortMetadata & {
 };
 
 export async function analyzeShortFrames(input: AnalyzeInput): Promise<AnalyzeResult> {
-  const anthropic = getClient();
+  // BOOTSTRAP-LLM-ROUTER (Phase F): vision now goes through the provider
+  // router. The router reads llm_routing_policy.policy.vision and picks
+  // among Anthropic / OpenAI / Vertex (Google). DeepSeek is not a vision
+  // provider so the router will return ok=false if the operator picks it
+  // for the vision stage — caller falls through to the fallback provider.
+  const { callViaRouter } = await import('./llm-router');
 
   const safeFilename = String(input.filename ?? '').slice(0, 100).replace(/["\\]/g, '');
   const durationLabel = Number.isFinite(input.durationSeconds)
     ? `${Math.round(input.durationSeconds * 10) / 10}s`
     : 'unknown';
 
-  const imageBlocks = input.frames.map((f) => {
+  const images = input.frames.map((f) => {
     const { mediaType, base64 } = parseDataUrl(f.data_url);
-    return {
-      type: 'image' as const,
-      source: { type: 'base64' as const, media_type: mediaType, data: base64 },
-    };
+    return { base64, mimeType: mediaType };
   });
 
-  const userContent = [
-    {
-      type: 'text' as const,
-      text: `Duration: ${durationLabel}. Filename: "${safeFilename}". Analyze these ${imageBlocks.length} keyframes and emit metadata via the tool.`,
-    },
-    ...imageBlocks,
-  ];
+  const userText =
+    `Duration: ${durationLabel}. Filename: "${safeFilename}". Analyze these ${images.length} keyframes and emit metadata via the tool.`;
 
   const startedAt = Date.now();
-  let response;
-  try {
-    response = await anthropic.messages.create(
-      {
-        model: VISION_MODEL,
-        max_tokens: 1024,
-        system: [
-          {
-            type: 'text',
-            text: SYSTEM_PROMPT,
-            cache_control: { type: 'ephemeral' },
+  const r = await callViaRouter('vision', userText, {
+    service: 'anthropic-vision-client',
+    systemPrompt: SYSTEM_PROMPT,
+    maxTokens: 1024,
+    images,
+    tools: [{
+      name: 'emit_short_metadata',
+      description: 'Emit auto-generated metadata for a Shorts video based on keyframes.',
+      inputSchema: {
+        type: 'object',
+        properties: {
+          title: {
+            type: 'string',
+            maxLength: MAX_TITLE_CHARS,
+            description: 'Punchy, human-friendly title, <= 80 chars, no emoji, no hashtags.',
           },
-        ],
-        tools: buildTool(),
-        tool_choice: { type: 'tool', name: 'emit_short_metadata' },
-        messages: [{ role: 'user', content: userContent }],
+          description: {
+            type: 'string',
+            maxLength: MAX_DESCRIPTION_CHARS,
+            description: 'One or two neutral sentences describing visible content.',
+          },
+          category: {
+            type: 'string',
+            enum: [...SHORTS_TAG_IDS],
+            description: 'Best-fit single category from the allowed list.',
+          },
+          tags: {
+            type: 'array',
+            items: { type: 'string', enum: [...SHORTS_TAG_IDS] },
+            minItems: 1,
+            maxItems: MAX_TAGS,
+            uniqueItems: true,
+            description: 'Between 1 and 5 tags from the allowed list.',
+          },
+        },
+        required: ['title', 'description', 'category', 'tags'],
       },
-      { timeout: CALL_TIMEOUT_MS },
-    );
-  } catch (err: any) {
-    const latencyMs = Date.now() - startedAt;
-    const status = err?.status ?? err?.response?.status;
-    const msg = err?.message ?? String(err);
-    // Rule 19: log provider, model, latency for AI calls.
-    console.warn(
-      `[shorts-auto-metadata] provider=anthropic model=${VISION_MODEL} latency_ms=${latencyMs} status=${status ?? 'n/a'} error=${msg}`,
-    );
-    if (err?.name === 'APIConnectionTimeoutError' || /timeout/i.test(msg)) {
-      throw new VisionClientError('TIMEOUT', `Vision call timed out after ${CALL_TIMEOUT_MS}ms`);
-    }
-    if (status === 429) {
-      throw new VisionClientError('RATE_LIMIT', 'Anthropic rate limit exceeded');
-    }
-    throw new VisionClientError('LLM_ERROR', msg);
-  }
+    }],
+    forceTool: 0,
+  });
 
   const latencyMs = Date.now() - startedAt;
-  const toolUseBlock = response.content.find(
-    (b) => b.type === 'tool_use' && b.name === 'emit_short_metadata',
-  );
-  if (!toolUseBlock || toolUseBlock.type !== 'tool_use') {
+  const provider = r.provider || 'unknown';
+  const model = r.model || VISION_MODEL;
+
+  if (!r.ok) {
     console.warn(
-      `[shorts-auto-metadata] provider=anthropic model=${VISION_MODEL} latency_ms=${latencyMs} stop_reason=${response.stop_reason} no_tool_use=true`,
+      `[shorts-auto-metadata] provider=${provider} model=${model} latency_ms=${latencyMs} error=${r.error}`,
+    );
+    if (r.error && /timeout/i.test(r.error)) {
+      throw new VisionClientError('TIMEOUT', `Vision call timed out after ${CALL_TIMEOUT_MS}ms`);
+    }
+    if (r.error && /\b429\b/.test(r.error)) {
+      throw new VisionClientError('RATE_LIMIT', `${provider} rate limit exceeded`);
+    }
+    throw new VisionClientError('LLM_ERROR', r.error || 'router returned ok=false');
+  }
+  if (!r.toolCall || r.toolCall.name !== 'emit_short_metadata') {
+    console.warn(
+      `[shorts-auto-metadata] provider=${provider} model=${model} latency_ms=${latencyMs} no_tool_use=true`,
     );
     throw new VisionClientError('EMPTY_OUTPUT', 'Model returned no emit_short_metadata call');
   }
 
-  const raw = toolUseBlock.input as Record<string, unknown>;
+  const raw = r.toolCall.arguments;
   const title = sanitizeTitle(raw.title);
   const description = sanitizeDescription(raw.description);
   const category = sanitizeCategory(raw.category);
@@ -259,16 +264,15 @@ export async function analyzeShortFrames(input: AnalyzeInput): Promise<AnalyzeRe
   }
 
   const usage = {
-    input_tokens: response.usage.input_tokens ?? 0,
-    output_tokens: response.usage.output_tokens ?? 0,
-    cache_read_input_tokens: (response.usage as any).cache_read_input_tokens ?? 0,
-    cache_creation_input_tokens: (response.usage as any).cache_creation_input_tokens ?? 0,
+    input_tokens: r.usage?.inputTokens ?? 0,
+    output_tokens: r.usage?.outputTokens ?? 0,
+    cache_read_input_tokens: 0,
+    cache_creation_input_tokens: 0,
   };
 
   console.log(
-    `[shorts-auto-metadata] provider=anthropic model=${VISION_MODEL} latency_ms=${latencyMs} ` +
-      `input_tokens=${usage.input_tokens} output_tokens=${usage.output_tokens} ` +
-      `cache_read=${usage.cache_read_input_tokens} cache_write=${usage.cache_creation_input_tokens}`,
+    `[shorts-auto-metadata] provider=${provider} model=${model} latency_ms=${latencyMs} ` +
+      `input_tokens=${usage.input_tokens} output_tokens=${usage.output_tokens}`,
   );
 
   return {
@@ -276,7 +280,7 @@ export async function analyzeShortFrames(input: AnalyzeInput): Promise<AnalyzeRe
     description,
     category,
     tags,
-    model: VISION_MODEL,
+    model,
     latencyMs,
     usage,
   };

--- a/services/gateway/src/services/llm-router.ts
+++ b/services/gateway/src/services/llm-router.ts
@@ -54,6 +54,27 @@ export interface LLMUsage {
   outputTokens: number;
 }
 
+/**
+ * Tool definition for function calling. Provider-neutral — the adapter
+ * translates to each provider's wire format (Anthropic `tools`, OpenAI
+ * `tools` + `tool_choice`, Vertex `function_declarations`, DeepSeek
+ * (OpenAI-compatible)). The router enforces tool_choice='required' on
+ * the named tool so the model emits the structured call instead of free
+ * text.
+ */
+export interface LLMRouterTool {
+  name: string;
+  description: string;
+  /** JSON Schema describing the tool's input. */
+  inputSchema: Record<string, unknown>;
+}
+
+/** Optional inputs for image / vision / multiple images per call. */
+export interface LLMRouterImage {
+  base64: string;
+  mimeType: string;
+}
+
 export interface LLMRouterOpts {
   /** VTID for telemetry correlation. Optional — falls back to VTID-LLM-ROUTER. */
   vtid?: string | null;
@@ -65,13 +86,37 @@ export interface LLMRouterOpts {
   maxTokens?: number;
   /** Optional system prompt prepended to the user prompt. */
   systemPrompt?: string;
-  /** Optional structured input for vision: base64 image + mime type. */
-  image?: { base64: string; mimeType: string };
+  /** Single image input (back-compat). Use `images` for multi-image. */
+  image?: LLMRouterImage;
+  /** Multi-image input — Vertex / Anthropic / OpenAI all accept ordered images
+   *  attached as parts on the user message. */
+  images?: LLMRouterImage[];
+  /**
+   * Tools the model may call. When set with `forceTool`, the router asks the
+   * provider to emit a tool call deterministically and returns it in
+   * `LLMRouterResult.toolCall`. Used by vision (structured metadata) and
+   * triage (multi-step investigation).
+   */
+  tools?: LLMRouterTool[];
+  /**
+   * Force the model to invoke `tools[forceTool].name` and return the parsed
+   * arguments instead of free text. Index into `tools` array.
+   */
+  forceTool?: number;
+}
+
+/** Returned when `forceTool` is set and the model emitted a tool call. */
+export interface LLMRouterToolCall {
+  name: string;
+  /** Already-parsed JSON arguments. Adapters parse the provider-specific shape. */
+  arguments: Record<string, unknown>;
 }
 
 export interface LLMRouterResult {
   ok: boolean;
   text?: string;
+  /** Populated when `forceTool` was set and the model emitted a structured call. */
+  toolCall?: LLMRouterToolCall;
   usage?: LLMUsage;
   provider?: LLMProvider;
   model?: string;
@@ -84,12 +129,16 @@ interface AdapterCallArgs {
   model: string;
   systemPrompt?: string;
   maxTokens?: number;
-  image?: { base64: string; mimeType: string };
+  image?: LLMRouterImage;
+  images?: LLMRouterImage[];
+  tools?: LLMRouterTool[];
+  forceTool?: number;
 }
 
 interface AdapterResult {
   ok: boolean;
   text?: string;
+  toolCall?: LLMRouterToolCall;
   usage?: LLMUsage;
   error?: string;
 }
@@ -134,18 +183,21 @@ export function _resetPolicyCacheForTests(): void {
 // Provider adapters
 // =============================================================================
 
-/** Anthropic Messages API */
+/** Anthropic Messages API — supports text, multi-image, and tool_use. */
 const anthropicAdapter: ProviderAdapter = {
   isAvailable: () => Boolean(process.env.ANTHROPIC_API_KEY),
-  async call({ prompt, model, systemPrompt, maxTokens, image }): Promise<AdapterResult> {
+  async call({ prompt, model, systemPrompt, maxTokens, image, images, tools, forceTool }): Promise<AdapterResult> {
     const apiKey = process.env.ANTHROPIC_API_KEY;
     if (!apiKey) return { ok: false, error: 'ANTHROPIC_API_KEY not set' };
 
     const userContent: unknown[] = [];
-    if (image) {
+    const allImages: LLMRouterImage[] = [];
+    if (images && images.length > 0) allImages.push(...images);
+    if (image) allImages.push(image);
+    for (const img of allImages) {
       userContent.push({
         type: 'image',
-        source: { type: 'base64', media_type: image.mimeType, data: image.base64 },
+        source: { type: 'base64', media_type: img.mimeType, data: img.base64 },
       });
     }
     userContent.push({ type: 'text', text: prompt });
@@ -156,6 +208,16 @@ const anthropicAdapter: ProviderAdapter = {
       messages: [{ role: 'user', content: userContent }],
     };
     if (systemPrompt) body.system = systemPrompt;
+    if (tools && tools.length > 0) {
+      body.tools = tools.map(t => ({
+        name: t.name,
+        description: t.description,
+        input_schema: t.inputSchema,
+      }));
+      if (typeof forceTool === 'number' && tools[forceTool]) {
+        body.tool_choice = { type: 'tool', name: tools[forceTool].name };
+      }
+    }
 
     try {
       const resp = await fetch('https://api.anthropic.com/v1/messages', {
@@ -172,13 +234,18 @@ const anthropicAdapter: ProviderAdapter = {
         return { ok: false, error: `Anthropic ${resp.status}: ${errText.slice(0, 300)}` };
       }
       const json = await resp.json() as {
-        content?: Array<{ type: string; text?: string }>;
+        content?: Array<{ type: string; text?: string; name?: string; input?: Record<string, unknown> }>;
         usage?: { input_tokens?: number; output_tokens?: number };
       };
       const text = (json.content || []).filter(c => c.type === 'text').map(c => c.text || '').join('');
+      const toolBlock = (json.content || []).find(c => c.type === 'tool_use');
+      const toolCall = toolBlock && toolBlock.name && toolBlock.input
+        ? { name: toolBlock.name, arguments: toolBlock.input }
+        : undefined;
       return {
         ok: true,
         text,
+        toolCall,
         usage: {
           inputTokens: json.usage?.input_tokens ?? 0,
           outputTokens: json.usage?.output_tokens ?? 0,
@@ -190,25 +257,43 @@ const anthropicAdapter: ProviderAdapter = {
   },
 };
 
-/** OpenAI Chat Completions API */
+/** OpenAI Chat Completions API — supports text, multi-image, and function calling. */
 const openaiAdapter: ProviderAdapter = {
   isAvailable: () => Boolean(process.env.OPENAI_API_KEY),
-  async call({ prompt, model, systemPrompt, maxTokens, image }): Promise<AdapterResult> {
+  async call({ prompt, model, systemPrompt, maxTokens, image, images, tools, forceTool }): Promise<AdapterResult> {
     const apiKey = process.env.OPENAI_API_KEY;
     if (!apiKey) return { ok: false, error: 'OPENAI_API_KEY not set' };
 
     const messages: Array<Record<string, unknown>> = [];
     if (systemPrompt) messages.push({ role: 'system', content: systemPrompt });
-    if (image) {
-      messages.push({
-        role: 'user',
-        content: [
-          { type: 'image_url', image_url: { url: `data:${image.mimeType};base64,${image.base64}` } },
-          { type: 'text', text: prompt },
-        ],
-      });
+
+    const allImages: LLMRouterImage[] = [];
+    if (images && images.length > 0) allImages.push(...images);
+    if (image) allImages.push(image);
+    if (allImages.length > 0) {
+      const content: Array<Record<string, unknown>> = [];
+      for (const img of allImages) {
+        content.push({ type: 'image_url', image_url: { url: `data:${img.mimeType};base64,${img.base64}` } });
+      }
+      content.push({ type: 'text', text: prompt });
+      messages.push({ role: 'user', content });
     } else {
       messages.push({ role: 'user', content: prompt });
+    }
+
+    const body: Record<string, unknown> = {
+      model,
+      messages,
+      max_tokens: maxTokens ?? 8000,
+    };
+    if (tools && tools.length > 0) {
+      body.tools = tools.map(t => ({
+        type: 'function',
+        function: { name: t.name, description: t.description, parameters: t.inputSchema },
+      }));
+      if (typeof forceTool === 'number' && tools[forceTool]) {
+        body.tool_choice = { type: 'function', function: { name: tools[forceTool].name } };
+      }
     }
 
     try {
@@ -218,24 +303,36 @@ const openaiAdapter: ProviderAdapter = {
           authorization: `Bearer ${apiKey}`,
           'content-type': 'application/json',
         },
-        body: JSON.stringify({
-          model,
-          messages,
-          max_tokens: maxTokens ?? 8000,
-        }),
+        body: JSON.stringify(body),
       });
       if (!resp.ok) {
         const errText = await resp.text();
         return { ok: false, error: `OpenAI ${resp.status}: ${errText.slice(0, 300)}` };
       }
       const json = await resp.json() as {
-        choices?: Array<{ message?: { content?: string } }>;
+        choices?: Array<{
+          message?: {
+            content?: string;
+            tool_calls?: Array<{ function?: { name?: string; arguments?: string } }>;
+          };
+        }>;
         usage?: { prompt_tokens?: number; completion_tokens?: number };
       };
-      const text = json.choices?.[0]?.message?.content ?? '';
+      const msg = json.choices?.[0]?.message;
+      const text = msg?.content ?? '';
+      let toolCall: LLMRouterToolCall | undefined;
+      const tc = msg?.tool_calls?.[0];
+      if (tc?.function?.name && tc.function.arguments) {
+        try {
+          toolCall = { name: tc.function.name, arguments: JSON.parse(tc.function.arguments) };
+        } catch {
+          // Tool call not JSON-parseable — leave undefined; caller falls back to text.
+        }
+      }
       return {
         ok: true,
         text,
+        toolCall,
         usage: {
           inputTokens: json.usage?.prompt_tokens ?? 0,
           outputTokens: json.usage?.completion_tokens ?? 0,
@@ -250,32 +347,52 @@ const openaiAdapter: ProviderAdapter = {
 /**
  * Google Vertex AI — uses Application Default Credentials, no API key required
  * on Cloud Run (the gateway service account has Vertex AI User role). Falls
- * back to GOOGLE_GEMINI_API_KEY for local dev.
+ * back to GOOGLE_GEMINI_API_KEY for local dev. Supports text, multi-image,
+ * and function calling.
  */
 const vertexAdapter: ProviderAdapter = {
   isAvailable: () =>
     Boolean(process.env.GOOGLE_CLOUD_PROJECT) || Boolean(process.env.GOOGLE_GEMINI_API_KEY),
-  async call({ prompt, model, systemPrompt, maxTokens, image }): Promise<AdapterResult> {
+  async call({ prompt, model, systemPrompt, maxTokens, image, images, tools, forceTool }): Promise<AdapterResult> {
+    const allImages: LLMRouterImage[] = [];
+    if (images && images.length > 0) allImages.push(...images);
+    if (image) allImages.push(image);
+
+    const fnDecls = tools && tools.length > 0
+      ? tools.map(t => ({ name: t.name, description: t.description, parameters: t.inputSchema }))
+      : undefined;
+
     // Prefer Vertex AI when GOOGLE_CLOUD_PROJECT is set (Cloud Run path).
     // Fall back to Google AI Studio when only GOOGLE_GEMINI_API_KEY is present.
     const projectId = process.env.GOOGLE_CLOUD_PROJECT;
     if (projectId) {
       try {
-        // Lazy import to avoid bundling cost when only Anthropic/DeepSeek are used.
         const { VertexAI } = await import('@google-cloud/vertexai');
         const location = process.env.VERTEX_LOCATION || 'us-central1';
         const vertex = new VertexAI({ project: projectId, location });
-        const generativeModel = vertex.getGenerativeModel({
+        const modelInit: Record<string, unknown> = {
           model,
           generationConfig: { maxOutputTokens: maxTokens ?? 8000 },
-          ...(systemPrompt
-            ? { systemInstruction: { role: 'system', parts: [{ text: systemPrompt }] } }
-            : {}),
-        });
+        };
+        if (systemPrompt) {
+          modelInit.systemInstruction = { role: 'system', parts: [{ text: systemPrompt }] };
+        }
+        if (fnDecls) {
+          modelInit.tools = [{ functionDeclarations: fnDecls }];
+          if (typeof forceTool === 'number' && tools && tools[forceTool]) {
+            modelInit.toolConfig = {
+              functionCallingConfig: {
+                mode: 'ANY',
+                allowedFunctionNames: [tools[forceTool].name],
+              },
+            };
+          }
+        }
+        const generativeModel = vertex.getGenerativeModel(modelInit as any);
 
         const parts: Array<Record<string, unknown>> = [];
-        if (image) {
-          parts.push({ inlineData: { data: image.base64, mimeType: image.mimeType } });
+        for (const img of allImages) {
+          parts.push({ inlineData: { data: img.base64, mimeType: img.mimeType } });
         }
         parts.push({ text: prompt });
 
@@ -283,13 +400,17 @@ const vertexAdapter: ProviderAdapter = {
           contents: [{ role: 'user', parts: parts as any }],
         });
         const candidate = result.response?.candidates?.[0];
-        const text = (candidate?.content?.parts || [])
-          .map((p: any) => p.text || '')
-          .join('');
+        const candidateParts = (candidate?.content?.parts || []) as Array<{ text?: string; functionCall?: { name?: string; args?: Record<string, unknown> } }>;
+        const text = candidateParts.map(p => p.text || '').join('');
+        const fnPart = candidateParts.find(p => !!p.functionCall);
+        const toolCall = fnPart?.functionCall?.name && fnPart.functionCall.args
+          ? { name: fnPart.functionCall.name, arguments: fnPart.functionCall.args }
+          : undefined;
         const usageMeta = result.response?.usageMetadata;
         return {
           ok: true,
           text,
+          toolCall,
           usage: {
             inputTokens: usageMeta?.promptTokenCount ?? 0,
             outputTokens: usageMeta?.candidatesTokenCount ?? 0,
@@ -306,13 +427,26 @@ const vertexAdapter: ProviderAdapter = {
     try {
       const url = `https://generativelanguage.googleapis.com/v1beta/models/${encodeURIComponent(model)}:generateContent?key=${apiKey}`;
       const parts: Array<Record<string, unknown>> = [];
-      if (image) parts.push({ inlineData: { data: image.base64, mimeType: image.mimeType } });
+      for (const img of allImages) {
+        parts.push({ inlineData: { data: img.base64, mimeType: img.mimeType } });
+      }
       parts.push({ text: prompt });
       const body: Record<string, unknown> = {
         contents: [{ role: 'user', parts }],
         generationConfig: { maxOutputTokens: maxTokens ?? 8000 },
       };
       if (systemPrompt) body.systemInstruction = { role: 'system', parts: [{ text: systemPrompt }] };
+      if (fnDecls) {
+        body.tools = [{ functionDeclarations: fnDecls }];
+        if (typeof forceTool === 'number' && tools && tools[forceTool]) {
+          body.toolConfig = {
+            functionCallingConfig: {
+              mode: 'ANY',
+              allowedFunctionNames: [tools[forceTool].name],
+            },
+          };
+        }
+      }
       const resp = await fetch(url, {
         method: 'POST',
         headers: { 'content-type': 'application/json' },
@@ -323,15 +457,19 @@ const vertexAdapter: ProviderAdapter = {
         return { ok: false, error: `Google AI ${resp.status}: ${errText.slice(0, 300)}` };
       }
       const json = await resp.json() as {
-        candidates?: Array<{ content?: { parts?: Array<{ text?: string }> } }>;
+        candidates?: Array<{ content?: { parts?: Array<{ text?: string; functionCall?: { name?: string; args?: Record<string, unknown> } }> } }>;
         usageMetadata?: { promptTokenCount?: number; candidatesTokenCount?: number };
       };
-      const text = (json.candidates?.[0]?.content?.parts || [])
-        .map(p => p.text || '')
-        .join('');
+      const candidateParts = json.candidates?.[0]?.content?.parts || [];
+      const text = candidateParts.map(p => p.text || '').join('');
+      const fnPart = candidateParts.find(p => !!p.functionCall);
+      const toolCall = fnPart?.functionCall?.name && fnPart.functionCall.args
+        ? { name: fnPart.functionCall.name, arguments: fnPart.functionCall.args }
+        : undefined;
       return {
         ok: true,
         text,
+        toolCall,
         usage: {
           inputTokens: json.usageMetadata?.promptTokenCount ?? 0,
           outputTokens: json.usageMetadata?.candidatesTokenCount ?? 0,
@@ -343,16 +481,44 @@ const vertexAdapter: ProviderAdapter = {
   },
 };
 
-/** DeepSeek API — OpenAI-compatible, single env key */
+/**
+ * DeepSeek API — OpenAI-compatible. Supports text + function calling but
+ * NOT vision (DeepSeek hasn't shipped a multimodal model). When images are
+ * passed they're ignored and only the text prompt is sent; the router's
+ * fallback chain is responsible for routing vision calls to a different
+ * provider via the `vision` stage policy.
+ */
 const deepseekAdapter: ProviderAdapter = {
   isAvailable: () => Boolean(process.env.DEEPSEEK_API_KEY),
-  async call({ prompt, model, systemPrompt, maxTokens }): Promise<AdapterResult> {
+  async call({ prompt, model, systemPrompt, maxTokens, image, images, tools, forceTool }): Promise<AdapterResult> {
     const apiKey = process.env.DEEPSEEK_API_KEY;
     if (!apiKey) return { ok: false, error: 'DEEPSEEK_API_KEY not set' };
+
+    if (image || (images && images.length > 0)) {
+      return {
+        ok: false,
+        error: 'DeepSeek does not support vision input — route vision calls to a different provider',
+      };
+    }
 
     const messages: Array<Record<string, unknown>> = [];
     if (systemPrompt) messages.push({ role: 'system', content: systemPrompt });
     messages.push({ role: 'user', content: prompt });
+
+    const body: Record<string, unknown> = {
+      model,
+      messages,
+      max_tokens: maxTokens ?? 8000,
+    };
+    if (tools && tools.length > 0) {
+      body.tools = tools.map(t => ({
+        type: 'function',
+        function: { name: t.name, description: t.description, parameters: t.inputSchema },
+      }));
+      if (typeof forceTool === 'number' && tools[forceTool]) {
+        body.tool_choice = { type: 'function', function: { name: tools[forceTool].name } };
+      }
+    }
 
     try {
       const resp = await fetch('https://api.deepseek.com/chat/completions', {
@@ -361,24 +527,36 @@ const deepseekAdapter: ProviderAdapter = {
           authorization: `Bearer ${apiKey}`,
           'content-type': 'application/json',
         },
-        body: JSON.stringify({
-          model,
-          messages,
-          max_tokens: maxTokens ?? 8000,
-        }),
+        body: JSON.stringify(body),
       });
       if (!resp.ok) {
         const errText = await resp.text();
         return { ok: false, error: `DeepSeek ${resp.status}: ${errText.slice(0, 300)}` };
       }
       const json = await resp.json() as {
-        choices?: Array<{ message?: { content?: string } }>;
+        choices?: Array<{
+          message?: {
+            content?: string;
+            tool_calls?: Array<{ function?: { name?: string; arguments?: string } }>;
+          };
+        }>;
         usage?: { prompt_tokens?: number; completion_tokens?: number };
       };
-      const text = json.choices?.[0]?.message?.content ?? '';
+      const msg = json.choices?.[0]?.message;
+      const text = msg?.content ?? '';
+      let toolCall: LLMRouterToolCall | undefined;
+      const tc = msg?.tool_calls?.[0];
+      if (tc?.function?.name && tc.function.arguments) {
+        try {
+          toolCall = { name: tc.function.name, arguments: JSON.parse(tc.function.arguments) };
+        } catch {
+          // Tool call not JSON-parseable — leave undefined.
+        }
+      }
       return {
         ok: true,
         text,
+        toolCall,
         usage: {
           inputTokens: json.usage?.prompt_tokens ?? 0,
           outputTokens: json.usage?.completion_tokens ?? 0,
@@ -547,6 +725,9 @@ async function runProviderCall(
     systemPrompt: opts.systemPrompt,
     maxTokens: opts.maxTokens,
     image: opts.image,
+    images: opts.images,
+    tools: opts.tools,
+    forceTool: opts.forceTool,
   });
 
   if (result.ok) {
@@ -558,6 +739,7 @@ async function runProviderCall(
     return {
       ok: true,
       text: result.text,
+      toolCall: result.toolCall,
       usage: result.usage,
       provider,
       model,

--- a/services/gateway/src/services/self-healing-triage-service.ts
+++ b/services/gateway/src/services/self-healing-triage-service.ts
@@ -304,137 +304,78 @@ function parseTriageReport(
 // Main entry point: spawnTriageAgent
 // =============================================================================
 
+/**
+ * BOOTSTRAP-LLM-ROUTER (Phase C): triage now goes through the provider
+ * router. The router reads llm_routing_policy.policy.triage and dispatches
+ * to the configured provider (Vertex / Anthropic / OpenAI / DeepSeek).
+ *
+ * Architectural change vs the prior Managed Agents flow: instead of giving
+ * the model a `query_oasis_events` tool that fires mid-session, we
+ * pre-fetch the OASIS events for the failure session up front and attach
+ * them to the prompt. This is lossless for the diagnosis path (the agent
+ * always called the tool with the same session_id from `input.diagnosis`)
+ * and works across every provider — no Managed Agents dependency.
+ *
+ * The repo-mount feature is dropped — for the diagnosis use case the model
+ * doesn't need to read code on demand; failure context + recent events is
+ * sufficient. If a stage genuinely needs repo browsing in future, that's a
+ * separate router extension.
+ */
 export async function spawnTriageAgent(input: TriageInput): Promise<TriageResult> {
-  if (!ANTHROPIC_API_KEY) {
-    console.warn(`${LOG_PREFIX} ANTHROPIC_API_KEY not set — skipping triage`);
-    return { ok: false, error: 'ANTHROPIC_API_KEY not set' };
-  }
-
   const startTime = Date.now();
-  console.log(`${LOG_PREFIX} Spawning triage agent for ${input.vtid} (mode=${input.mode})`);
+  console.log(`${LOG_PREFIX} Triage for ${input.vtid} (mode=${input.mode})`);
 
-  // 1. Create session with repo mounted
-  const sessionResult = await anthropicRequest<any>('/v1/sessions', {
-    method: 'POST',
-    body: {
-      agent: { type: 'agent', id: AGENT_ID, version: 1 },
-      environment_id: ENVIRONMENT_ID,
-      title: `Self-healing triage: ${input.vtid} (${input.mode})`,
-      resources: [
-        {
-          type: 'github_repository',
-          url: 'https://github.com/exafyltd/vitana-platform',
-          authorization_token: process.env.GITHUB_SAFE_MERGE_TOKEN || '',
-          mount_path: '/workspace/repo',
-          checkout: { type: 'branch', name: 'main' },
-        },
-      ],
-    },
-  });
-
-  if (!sessionResult.ok || !sessionResult.data) {
-    console.error(`${LOG_PREFIX} Session creation failed:`, sessionResult.error);
-    return { ok: false, error: `Session creation failed: ${sessionResult.error}` };
-  }
-
-  const sessionId = sessionResult.data.id;
-  console.log(`${LOG_PREFIX} Session created: ${sessionId}`);
-
-  // 2. Send the investigation prompt
-  const prompt = buildPrompt(input);
-  await anthropicRequest(`/v1/sessions/${sessionId}/events`, {
-    method: 'POST',
-    body: {
-      events: [
-        { type: 'user.message', content: [{ type: 'text', text: prompt }] },
-      ],
-    },
-  });
-
-  // 3. Poll events until done, handling custom tools along the way
-  let done = false;
-  const seenIds = new Set<string>();
-  const textParts: string[] = [];
-  const deadline = Date.now() + SESSION_TIMEOUT_MS;
-
-  while (!done && Date.now() < deadline) {
-    const eventsResult = await anthropicRequest<any>(
-      `/v1/sessions/${sessionId}/events`
-    );
-
-    if (!eventsResult.ok || !eventsResult.data) {
-      console.error(`${LOG_PREFIX} Events poll failed:`, eventsResult.error);
-      break;
-    }
-
-    const events = eventsResult.data.data || [];
-
-    for (const event of events) {
-      if (seenIds.has(event.id)) continue;
-      seenIds.add(event.id);
-
-      switch (event.type) {
-        case 'agent.message':
-          if (event.content) {
-            for (const block of event.content) {
-              if (block.type === 'text') {
-                textParts.push(block.text);
-              }
-            }
-          }
-          break;
-
-        case 'agent.custom_tool_use':
-          if (event.tool_name === 'query_oasis_events') {
-            const result = await queryOasisEvents(
-              event.input?.session_id || '',
-              event.input?.limit || 100
-            );
-            await anthropicRequest(`/v1/sessions/${sessionId}/events`, {
-              method: 'POST',
-              body: {
-                events: [
-                  {
-                    type: 'user.custom_tool_result',
-                    custom_tool_use_id: event.id,
-                    content: [{ type: 'text', text: result }],
-                  },
-                ],
-              },
-            });
-          }
-          break;
-
-        case 'session.status_idle': {
-          const stopReason = event.stop_reason?.type;
-          if (stopReason !== 'requires_action') {
-            done = true;
-          }
-          break;
-        }
-
-        case 'session.status_terminated':
-          done = true;
-          break;
-      }
-    }
-
-    if (!done && events.length === 0) {
-      await new Promise((resolve) => setTimeout(resolve, 2000));
+  // 1. Pre-fetch OASIS events keyed off any session_id mentioned in the
+  //    diagnosis. The original Managed Agents path did this lazily via a
+  //    custom tool; we just pull them upfront and inline.
+  const sessionIdHint = (input.diagnosis as Record<string, unknown> | undefined)?.session_id
+    || (input.diagnosis as Record<string, unknown> | undefined)?.sessionId
+    || '';
+  let oasisEventsBlock = '';
+  if (typeof sessionIdHint === 'string' && sessionIdHint) {
+    try {
+      const eventsJson = await queryOasisEvents(sessionIdHint, 50);
+      oasisEventsBlock = `\n### OASIS events for session ${sessionIdHint} (most recent 50):\n${eventsJson}\n`;
+    } catch (err) {
+      console.warn(`${LOG_PREFIX} OASIS prefetch failed:`, err);
     }
   }
+
+  // 2. Build the prompt — same per-mode template as before, plus the
+  //    pre-fetched events if any.
+  const prompt = buildPrompt(input) + oasisEventsBlock;
+
+  // 3. Single-shot call via router. Provider chosen by llm_routing_policy.
+  //    `pseudoSessionId` is just a correlation id for the parser — there is
+  //    no real session.
+  const pseudoSessionId = `triage-${input.vtid}-${Date.now()}`;
+  const r = await (async () => {
+    const { callViaRouter } = await import('./llm-router');
+    return callViaRouter('triage', prompt, {
+      vtid: input.vtid,
+      service: 'self-healing-triage',
+      systemPrompt: 'You are a self-healing triage agent. Investigate the failure and produce a structured report with: Severity, Root Cause Hypothesis, Affected Component, Evidence (bulleted list), Recommended Fix, Confidence (low|medium|high). Use plain markdown headings (## Severity, ## Root Cause Hypothesis, etc.).',
+      maxTokens: 4000,
+      allowFallback: true,
+    });
+  })();
 
   const elapsedMs = Date.now() - startTime;
-  const rawOutput = textParts.join('\n');
 
-  if (!rawOutput) {
-    console.warn(`${LOG_PREFIX} Agent produced no text output for ${input.vtid}`);
-    return { ok: false, error: 'Agent produced no output' };
+  if (!r.ok) {
+    console.warn(`${LOG_PREFIX} Triage router call failed for ${input.vtid}: ${r.error}`);
+    return { ok: false, error: r.error || 'router returned ok=false' };
   }
 
-  const report = parseTriageReport(rawOutput, sessionId, input.mode, elapsedMs);
+  const rawOutput = r.text || '';
+  if (!rawOutput) {
+    console.warn(`${LOG_PREFIX} Triage produced no text for ${input.vtid}`);
+    return { ok: false, error: 'Triage produced no output' };
+  }
+
+  const report = parseTriageReport(rawOutput, pseudoSessionId, input.mode, elapsedMs);
   console.log(
-    `${LOG_PREFIX} Triage complete for ${input.vtid}: confidence=${report.confidence} (${report.confidence_numeric}), elapsed=${elapsedMs}ms`
+    `${LOG_PREFIX} Triage complete for ${input.vtid}: provider=${r.provider} model=${r.model} confidence=${report.confidence} (${report.confidence_numeric}) elapsed=${elapsedMs}ms`
   );
 
   return { ok: true, report };

--- a/services/gateway/src/services/voice-architecture-investigator.ts
+++ b/services/gateway/src/services/voice-architecture-investigator.ts
@@ -492,27 +492,43 @@ const RESPONSE_SCHEMA = {
   ],
 };
 
+/**
+ * BOOTSTRAP-LLM-ROUTER (Phase G): the investigator now routes through the
+ * provider router instead of calling Vertex directly. Operator picks the
+ * provider per `classifier` stage from the Command Hub dropdown. We use
+ * the router's tool-use mode (forceTool) to get structured output across
+ * any provider — Anthropic, OpenAI, Vertex/Gemini, DeepSeek all support
+ * function calling. The report shape is unchanged; we just parse from
+ * `toolCall.arguments` instead of from a JSON-mode text response.
+ */
 async function callVertexInvestigator(prompt: string): Promise<InvestigatorReport | null> {
-  if (!vertexAI) return null;
   try {
-    const model = vertexAI.getGenerativeModel({
-      model: INVESTIGATOR_MODEL,
-      generationConfig: {
-        temperature: 0.4,
-        topP: 0.95,
-        maxOutputTokens: 8192,
-        responseMimeType: 'application/json',
-        responseSchema: RESPONSE_SCHEMA as any,
-      },
+    const { callViaRouter } = await import('./llm-router');
+    const r = await callViaRouter('classifier', prompt, {
+      service: 'voice-architecture-investigator',
+      maxTokens: 8192,
+      tools: [{
+        name: 'emit_investigator_report',
+        description: 'Emit the structured investigator report. Always invoke this tool with a complete report rather than replying in plain text.',
+        inputSchema: RESPONSE_SCHEMA as Record<string, unknown>,
+      }],
+      forceTool: 0,
     });
-    const r = await model.generateContent({
-      contents: [{ role: 'user', parts: [{ text: prompt }] }],
-    });
-    const text = r.response?.candidates?.[0]?.content?.parts?.[0]?.text;
-    if (!text) return null;
-    return JSON.parse(text) as InvestigatorReport;
+    if (!r.ok) {
+      console.warn(`[voice-architecture-investigator] router call failed: ${r.error}`);
+      return null;
+    }
+    if (r.toolCall && r.toolCall.name === 'emit_investigator_report') {
+      return r.toolCall.arguments as unknown as InvestigatorReport;
+    }
+    // Some providers may return JSON in the text body when forceTool isn't
+    // honored. Try to parse as a fallback so we don't lose the call.
+    if (r.text) {
+      try { return JSON.parse(r.text) as InvestigatorReport; } catch { /* fall through */ }
+    }
+    return null;
   } catch (err: any) {
-    console.warn(`[voice-architecture-investigator] Vertex call failed: ${err.message}`);
+    console.warn(`[voice-architecture-investigator] router threw: ${err?.message ?? err}`);
     return null;
   }
 }


### PR DESCRIPTION
Closes the Anthropic-direct call sites in triage, vision, and classifier. Operators now control which provider runs each stage from the Command Hub dropdowns shipped in #959, with full tool-use + image + multi-image support across all four providers + claude_subscription.