### PR TITLE
feat(autopilot): enable auto-approve for stale-feature-flag-scanner-v1

### DIFF
--- a/supabase/migrations/20260427121500_BOOTSTRAP_autopilot_enable_stale_flag.sql
+++ b/supabase/migrations/20260427121500_BOOTSTRAP_autopilot_enable_stale_flag.sql
@@ -1,0 +1,46 @@
+-- =============================================================================
+-- Autopilot — first scanner allowlisted for unattended auto-approve
+-- =============================================================================
+-- Operator decision (2026-04-27): start the autonomous loop with the
+-- safest single scanner. stale-feature-flag-scanner-v1 emits findings
+-- for feature flags that haven't been toggled in 90+ days — small blast
+-- radius, deterministic fix (delete a flag and its references).
+--
+-- Caps:
+--   daily_budget = 5      → at most 5 unattended executions/day across
+--                            ALL scanners (not per-scanner; this is the
+--                            existing cap, narrowed from 10).
+--   risk_classes = ['low'] → tightened from default ['low','medium'] so
+--                            a future scanner addition doesn't silently
+--                            broaden the gate.
+--   max_effort   = 5      → unchanged (already the default).
+--
+-- Rollback: re-run with auto_approve_enabled=FALSE OR clear the array.
+-- All progress is recorded in dev_autopilot_outcomes for audit.
+-- =============================================================================
+
+UPDATE public.dev_autopilot_config
+SET auto_approve_enabled    = TRUE,
+    auto_approve_scanners   = ARRAY['stale-feature-flag-scanner-v1']::text[],
+    auto_approve_risk_classes = ARRAY['low']::text[],
+    daily_budget            = 5,
+    updated_at              = NOW()
+WHERE id = 1;
+
+-- Audit row in oasis_events so the autonomy graduation policy + dashboards
+-- have a clear "moment" to anchor on.
+INSERT INTO public.oasis_events (vtid, type, topic, source, status, message, metadata)
+VALUES (
+  'BOOTSTRAP-AUTOPILOT-FIRST-SCANNER',
+  'dev_autopilot.config.auto_approve_enabled',
+  'dev_autopilot.config.auto_approve_enabled',
+  'autopilot-realign',
+  'success',
+  'Auto-approve enabled for stale-feature-flag-scanner-v1 (daily_budget=5, risk=low)',
+  jsonb_build_object(
+    'scanners', ARRAY['stale-feature-flag-scanner-v1'],
+    'risk_classes', ARRAY['low'],
+    'daily_budget', 5,
+    'enabled_at', NOW()
+  )
+);


### PR DESCRIPTION
## Summary

Operator decision (2026-04-27): flip on the autonomous loop with the safest single scanner — `stale-feature-flag-scanner-v1`. Tiny blast radius (deletes flags inactive for 90+ days), deterministic fix.

## What changes

```
auto_approve_enabled       = TRUE
auto_approve_scanners      = ['stale-feature-flag-scanner-v1']
auto_approve_risk_classes  = ['low']                ← tightened from ['low','medium']
daily_budget               = 5                       ← narrowed from default 10
```

The safety gate (`allow_scope`, `deny_scope`, file-count cap) still runs on every auto-approved finding — auto-approve only removes the human click. PR #963's outcomes substrate records every `decision='auto_exec'` row + later `exec_outcome` for audit.

Migration also writes one row to `oasis_events` with `vtid=BOOTSTRAP-AUTOPILOT-FIRST-SCANNER` as an anchor moment for dashboards + the future autonomy graduation policy.

## Rollback

```sql
UPDATE dev_autopilot_config SET auto_approve_enabled = FALSE WHERE id = 1;
```

Or via a follow-up migration. No code change needed.

## Test plan

- [ ] Apply via RUN-MIGRATION.yml → `auto_approve_enabled=TRUE` for `id=1` row.
- [ ] Within ~15 min (background tick), `dev_autopilot_outcomes` starts seeing rows with `decision='auto_exec'`, `scanner_name='stale-feature-flag-scanner-v1'`.
- [ ] Within ~30 min, the worker reports `exec_outcome` on the first row(s). Expected: `success`.
- [ ] After 24h, success rate ≥ 90% across the daily_budget of 5. If not, revert.
- [ ] AUTOPILOT pill badge in Command Hub remains stable or drops slightly (stale_flag findings now bypass the popup).

🤖 Generated with [Claude Code](https://claude.com/claude-code)