### PR TITLE
fix(llm-router): swap fictional gemini-3.1-pro for gemini-2.5-pro (VTID-01992)

### DIFF
--- a/services/gateway/src/constants/llm-defaults.ts
+++ b/services/gateway/src/constants/llm-defaults.ts
@@ -78,7 +78,7 @@ export interface LLMRoutingPolicy {
 export const LLM_SAFE_DEFAULTS: LLMRoutingPolicy = {
   planner: {
     primary_provider: 'vertex',
-    primary_model: 'gemini-3.1-pro',
+    primary_model: 'gemini-2.5-pro',
     fallback_provider: 'anthropic',
     fallback_model: 'claude-opus-4-7',
   },
@@ -86,35 +86,35 @@ export const LLM_SAFE_DEFAULTS: LLMRoutingPolicy = {
     primary_provider: 'claude_subscription',
     primary_model: 'claude-opus-4-7',
     fallback_provider: 'vertex',
-    fallback_model: 'gemini-3.1-pro',
+    fallback_model: 'gemini-2.5-pro',
   },
   validator: {
     primary_provider: 'vertex',
-    primary_model: 'gemini-3.1-pro',
+    primary_model: 'gemini-2.5-pro',
     fallback_provider: 'anthropic',
     fallback_model: 'claude-opus-4-7',
   },
   operator: {
     primary_provider: 'vertex',
-    primary_model: 'gemini-3.1-pro',
+    primary_model: 'gemini-2.5-pro',
     fallback_provider: 'anthropic',
     fallback_model: 'claude-opus-4-7',
   },
   memory: {
     primary_provider: 'vertex',
-    primary_model: 'gemini-3.1-pro',
+    primary_model: 'gemini-2.5-pro',
     fallback_provider: 'deepseek',
     fallback_model: 'deepseek-reasoner',
   },
   triage: {
     primary_provider: 'vertex',
-    primary_model: 'gemini-3.1-pro',
+    primary_model: 'gemini-2.5-pro',
     fallback_provider: 'anthropic',
     fallback_model: 'claude-opus-4-7',
   },
   vision: {
     primary_provider: 'vertex',
-    primary_model: 'gemini-3.1-pro',
+    primary_model: 'gemini-2.5-pro',
     fallback_provider: 'anthropic',
     fallback_model: 'claude-opus-4-7',
   },
@@ -122,7 +122,7 @@ export const LLM_SAFE_DEFAULTS: LLMRoutingPolicy = {
     primary_provider: 'deepseek',
     primary_model: 'deepseek-reasoner',
     fallback_provider: 'vertex',
-    fallback_model: 'gemini-3.1-pro',
+    fallback_model: 'gemini-2.5-pro',
   },
 };
 
@@ -140,9 +140,8 @@ export const MODEL_COSTS: Record<string, { input: number; output: number }> = {
   'claude-3-haiku-20240307': { input: 0.25, output: 1.25 },
 
   // Google Vertex AI — flagship + mid + light
-  'gemini-3.1-pro': { input: 1.25, output: 5.00 },        // pricing TBD by Google; using 2.5 Pro rate as best estimate
-  'gemini-3-pro-preview': { input: 1.25, output: 5.00 },  // legacy alias retained for back-compat
   'gemini-2.5-pro': { input: 1.25, output: 5.00 },
+  'gemini-3-pro-preview': { input: 1.25, output: 5.00 },  // legacy alias retained for back-compat
   'gemini-2.5-flash': { input: 0.075, output: 0.30 },
   'gemini-1.5-pro': { input: 1.25, output: 5.00 },
   'gemini-1.5-flash': { input: 0.075, output: 0.30 },
@@ -211,7 +210,7 @@ export const VALID_PROVIDERS: LLMProvider[] = [
  */
 export const PROVIDER_FLAGSHIPS: Record<LLMProvider, string> = {
   anthropic: 'claude-opus-4-7',
-  vertex: 'gemini-3.1-pro',
+  vertex: 'gemini-2.5-pro',
   openai: 'gpt-5',
   deepseek: 'deepseek-reasoner',
   claude_subscription: 'claude-opus-4-7',
@@ -221,14 +220,14 @@ export const PROVIDER_FLAGSHIPS: Record<LLMProvider, string> = {
  * Recommended models per stage (for UI warnings)
  */
 export const RECOMMENDED_MODELS: Record<LLMStage, string[]> = {
-  planner: ['gemini-3.1-pro', 'claude-opus-4-7', 'gpt-5'],
-  worker: ['claude-opus-4-7', 'gemini-3.1-pro', 'gpt-5'],
-  validator: ['gemini-3.1-pro', 'claude-opus-4-7'],
-  operator: ['gemini-3.1-pro', 'claude-opus-4-7'],
-  memory: ['gemini-3.1-pro', 'deepseek-reasoner', 'claude-opus-4-7'],
-  triage: ['gemini-3.1-pro', 'claude-opus-4-7', 'deepseek-reasoner'],
-  vision: ['gemini-3.1-pro', 'claude-opus-4-7'],
-  classifier: ['deepseek-reasoner', 'gemini-3.1-pro', 'gpt-5'],
+  planner: ['gemini-2.5-pro', 'claude-opus-4-7', 'gpt-5'],
+  worker: ['claude-opus-4-7', 'gemini-2.5-pro', 'gpt-5'],
+  validator: ['gemini-2.5-pro', 'claude-opus-4-7'],
+  operator: ['gemini-2.5-pro', 'claude-opus-4-7'],
+  memory: ['gemini-2.5-pro', 'deepseek-reasoner', 'claude-opus-4-7'],
+  triage: ['gemini-2.5-pro', 'claude-opus-4-7', 'deepseek-reasoner'],
+  vision: ['gemini-2.5-pro', 'claude-opus-4-7'],
+  classifier: ['deepseek-reasoner', 'gemini-2.5-pro', 'gpt-5'],
 };
 
 /**

--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -803,7 +803,7 @@ function buildExecutionPrompt(
  * BOOTSTRAP-LLM-ROUTER (Phase E): execute direct-API call now goes through
  * the provider router. The router reads llm_routing_policy.policy.worker
  * and dispatches to the configured fallback provider (default Vertex /
- * gemini-3.1-pro with Anthropic / claude-opus-4-7 secondary fallback).
+ * gemini-2.5-pro with Anthropic / claude-opus-4-7 secondary fallback).
  *
  * This path only fires when the worker queue is unavailable (worker daemon
  * dead, binary missing) — the worker queue path at runExecutionSession()

--- a/services/gateway/src/services/dev-autopilot-planning.ts
+++ b/services/gateway/src/services/dev-autopilot-planning.ts
@@ -123,7 +123,7 @@ interface MessagesResponse {
 /**
  * BOOTSTRAP-LLM-ROUTER (Phase D): plan-gen direct-API call now goes through
  * the provider router. The router reads llm_routing_policy.policy.planner
- * and dispatches to the configured provider (default Vertex / gemini-3.1-pro
+ * and dispatches to the configured provider (default Vertex / gemini-2.5-pro
  * with Anthropic / claude-opus-4-7 fallback). Operators flip providers via
  * the Command Hub dropdown without code edits.
  *


### PR DESCRIPTION
## Summary
The self-healing planner has been logging 162 `dev_autopilot_plan_gen_failed` rows because Vertex returns **404 Not Found — Publisher Model `gemini-3.1-pro` was not found**. That model doesn't exist on Google. Anthropic fallback is also dead (credit balance — billing, separate). Result: every finding goes through the planner, fails, gets logged with `confidence: 0`, and escalates — the self-healing dispatcher has nothing to apply.

Replaces every `gemini-3.1-pro` reference in `services/gateway/src` with the canonical `gemini-2.5-pro` (per CLAUDE.md §8 and every other working call site like `gemini-operator.ts`, `voice-architecture-investigator.ts`). The Supabase `llm_routing_policy` v2 row will be updated in lockstep after merge so runtime config matches the new defaults.

## Existing escalated rows
The 162 historical `escalated` rows are not retried automatically. Future findings will produce real plans, real confidence scores, and the self-healing path will start closing them.

## Test plan
- [x] tsc --noEmit clean
- [ ] EXEC-DEPLOY succeeds + smoke tests pass
- [ ] Update llm_routing_policy v2 row in Supabase (`gemini-3.1-pro` → `gemini-2.5-pro`)
- [ ] Trigger a dev-autopilot scan and verify next plan-gen call returns ok=true (no new dev_autopilot_plan_gen_failed rows in the next ~10 min)

🤖 Generated with [Claude Code](https://claude.com/claude-code)