### PR TITLE
fix(orb): un-truncate model + universal quality classifier (VTID-01994)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -951,11 +951,19 @@ setInterval(() => {
         duration_ms: Date.now() - s.createdAt.getTime(),
         turn_count: s.turn_count,
       }).catch(() => { });
-      // VTID-01959: voice self-healing dispatch (mode-gated; off by default)
+      // VTID-01959: voice self-healing dispatch (mode-gated for /report path).
+      // VTID-01994: pass session metrics so quality classifier can detect
+      // failures regardless of mode and route to investigator.
       dispatchVoiceFailureFireAndForget({
         sessionId: sid,
         tenantScope: s.identity?.tenant_id || 'global',
         metadata: { synthetic: (s as any).synthetic === true },
+        sessionMetrics: {
+          audio_in_chunks: s.audioInChunks,
+          audio_out_chunks: s.audioOutChunks,
+          duration_ms: Date.now() - s.createdAt.getTime(),
+          turn_count: s.turn_count,
+        },
       });
       s.active = false;
       liveSessions.delete(sid);
@@ -1038,11 +1046,18 @@ function terminateExistingSessionsForUser(userId: string, excludeSessionId?: str
       duration_ms: Date.now() - existingSession.createdAt.getTime(),
       turn_count: existingSession.turn_count,
     }).catch(() => {});
-    // VTID-01959: voice self-healing dispatch (mode-gated; off by default)
+    // VTID-01959: voice self-healing dispatch (mode-gated for /report path).
+    // VTID-01994: pass session metrics for mode-independent quality classifier.
     dispatchVoiceFailureFireAndForget({
       sessionId: sid,
       tenantScope: existingSession.identity?.tenant_id || 'global',
       metadata: { synthetic: (existingSession as any).synthetic === true },
+      sessionMetrics: {
+        audio_in_chunks: existingSession.audioInChunks,
+        audio_out_chunks: existingSession.audioOutChunks,
+        duration_ms: Date.now() - existingSession.createdAt.getTime(),
+        turn_count: existingSession.turn_count,
+      },
     });
   }
   return terminated;
@@ -5662,7 +5677,10 @@ VOICE STYLE: ${voiceStyle}
 ${roleSection}
 
 GENERAL BEHAVIOR:
-${voiceLiveConfig.general_behavior || '- Be warm, patient, and empathetic\n- Keep responses concise for voice interaction (2-3 sentences max)\n- Use natural conversational tone'}
+${voiceLiveConfig.general_behavior || `- Be warm, patient, and empathetic
+- Match response length to the question: a quick yes/no question gets a sentence; a substantive question ("how is my sleep trending?", "what should I focus on this week?", "tell me about X") gets a substantive answer (4-8 sentences). Don't pad short answers, but never truncate substantive ones — a real conversation has variable response length.
+- Use natural conversational tone, not bullet points
+- Speak in complete thoughts; avoid clipped one-liners that force the user to ask follow-ups they didn't intend`}
 
 GREETING RULES (CRITICAL):
 ${isReconnect
@@ -12128,11 +12146,20 @@ router.post('/live/session/stop', optionalAuth, async (req: AuthenticatedRequest
     user_turns: session.transcriptTurns.filter(t => t.role === 'user').length,
     model_turns: session.transcriptTurns.filter(t => t.role === 'assistant').length,
   });
-  // VTID-01959: voice self-healing dispatch (mode-gated; off by default)
+  // VTID-01959: voice self-healing dispatch (mode-gated for /report path).
+  // VTID-01994: pass session metrics for mode-independent quality classifier.
   dispatchVoiceFailureFireAndForget({
     sessionId: session_id,
     tenantScope: session.identity?.tenant_id || 'global',
     metadata: { synthetic: (session as any).synthetic === true },
+    sessionMetrics: {
+      audio_in_chunks: session.audioInChunks,
+      audio_out_chunks: session.audioOutChunks,
+      duration_ms: Date.now() - session.createdAt.getTime(),
+      turn_count: session.turn_count,
+      user_turns: session.transcriptTurns.filter(t => t.role === 'user').length,
+      model_turns: session.transcriptTurns.filter(t => t.role === 'assistant').length,
+    },
   });
 
   // VTID-01225: Fire-and-forget entity extraction from live session
@@ -14303,11 +14330,20 @@ function handleWsStopSession(clientSession: WsClientSession): void {
       user_turns: liveSession.transcriptTurns.filter(t => t.role === 'user').length,
       model_turns: liveSession.transcriptTurns.filter(t => t.role === 'assistant').length,
     }).catch(() => { });
-    // VTID-01959: voice self-healing dispatch (mode-gated; off by default)
+    // VTID-01959: voice self-healing dispatch (mode-gated for /report path).
+    // VTID-01994: pass session metrics for mode-independent quality classifier.
     dispatchVoiceFailureFireAndForget({
       sessionId,
       tenantScope: liveSession.identity?.tenant_id || 'global',
       metadata: { synthetic: (liveSession as any).synthetic === true },
+      sessionMetrics: {
+        audio_in_chunks: liveSession.audioInChunks,
+        audio_out_chunks: liveSession.audioOutChunks,
+        duration_ms: Date.now() - liveSession.createdAt.getTime(),
+        turn_count: liveSession.turn_count,
+        user_turns: liveSession.transcriptTurns.filter(t => t.role === 'user').length,
+        model_turns: liveSession.transcriptTurns.filter(t => t.role === 'assistant').length,
+      },
     });
 
     liveSessions.delete(sessionId);

--- a/services/gateway/src/services/voice-architecture-investigator.ts
+++ b/services/gateway/src/services/voice-architecture-investigator.ts
@@ -75,6 +75,7 @@ const ALTERNATIVE_ARCHITECTURES_REFERENCE = `
 export type InvestigatorTriggerReason =
   | 'sentinel_quarantine'
   | 'spec_memory_blocked'
+  | 'quality_failure'
   | 'manual';
 
 export interface InvestigatorInput {

--- a/services/gateway/src/services/voice-failure-taxonomy.ts
+++ b/services/gateway/src/services/voice-failure-taxonomy.ts
@@ -13,7 +13,10 @@
  * See plan: .claude/plans/the-biggest-issues-and-fizzy-wozniak.md
  */
 
-export const SIGNATURE_VERSION = 'v1';
+// Bumped to v2 (VTID-01994) — added 3 quality classes derived from
+// session-stop metadata (no error events required). Bumping invalidates
+// prior spec_memory entries which is the safe transition.
+export const SIGNATURE_VERSION = 'v2';
 
 export const VOICE_FAILURE_CLASSES = [
   'voice.config_missing',
@@ -26,6 +29,13 @@ export const VOICE_FAILURE_CLASSES = [
   'voice.tool_loop',
   'voice.audio_one_way',
   'voice.permission_denied',
+  // VTID-01994: quality failures detectable from session-stop metadata
+  // alone, without any error event. Catches the dominant production
+  // failure mode (model under-responds, terse replies, no engagement)
+  // that the explicit-error-event classifier misses entirely.
+  'voice.model_under_responds',
+  'voice.no_engagement',
+  'voice.low_turn_progression',
   'voice.unknown',
 ] as const;
 
@@ -70,6 +80,13 @@ export const CLASS_SEVERITY: Record<VoiceFailureClass, number> = {
   'voice.session_leak': 40,
   'voice.tool_loop': 30,
   'voice.audio_one_way': 20,
+  // VTID-01994: quality classes — between unknown and tool_loop. They're
+  // dispatch-worthy but rank below explicit-error classes because explicit
+  // errors usually have a known fix; quality classes generally route to
+  // the Architecture Investigator for prompt/model-config-level analysis.
+  'voice.model_under_responds': 25,
+  'voice.no_engagement': 22,
+  'voice.low_turn_progression': 18,
   'voice.unknown': 0,
 };
 
@@ -195,5 +212,89 @@ export function detectAudioOneWay(input: {
   if (input.audio_in_chunks > 0 && input.audio_out_chunks === 0) {
     return { class: 'voice.audio_one_way', normalized_signature: 'audio_one_way_post_chime' };
   }
+  return null;
+}
+
+// =============================================================================
+// VTID-01994: Quality classifier — detects failures from session-stop metrics
+// alone, no error events required. Catches the dominant production failure
+// mode the explicit-error-event classifier misses: sessions that complete
+// "successfully" (reason=normal, ws closed cleanly) but the user clearly had
+// a broken experience (model under-responds, terse replies, never engaged).
+// =============================================================================
+
+export interface SessionStopMetrics {
+  audio_in_chunks: number;
+  audio_out_chunks: number;
+  duration_ms: number;
+  turn_count: number;
+  user_turns?: number;
+  model_turns?: number;
+}
+
+/** Bucket a numeric value to keep signatures stable across small variations. */
+function bucketRatio(ratio: number): string {
+  if (ratio >= 100) return 'r100plus';
+  if (ratio >= 20) return 'r20to100';
+  if (ratio >= 10) return 'r10to20';
+  if (ratio >= 5) return 'r5to10';
+  return 'rUnder5';
+}
+
+/**
+ * Classify a session as a quality failure based on session-stop metadata.
+ * Returns null when session looks healthy. Pure function — no I/O, no
+ * dependencies. Adapter passes the metrics straight from the
+ * vtid.live.session.stop emit payload.
+ *
+ * Thresholds:
+ *   voice.no_engagement         turn_count==0 AND duration_ms>30s AND audio_in>=20
+ *                               (user spoke but model never started speaking)
+ *   voice.model_under_responds  audio_in>=100 AND audio_out/audio_in<0.15 AND turn_count>=1
+ *                               (real conversation but model under-responded)
+ *   voice.low_turn_progression  duration_ms>60s AND turn_count<3 AND audio_in>=50
+ *                               (long session that never developed)
+ */
+export function classifyQualityFromSessionStop(
+  metrics: SessionStopMetrics,
+): ClassifierOutput | null {
+  const ai = metrics.audio_in_chunks || 0;
+  const ao = metrics.audio_out_chunks || 0;
+  const dur = metrics.duration_ms || 0;
+  const turns = metrics.turn_count || 0;
+
+  // Skip sessions that are too short or had no real input — they're not
+  // meaningfully broken, just not real conversations (mic permission test,
+  // page abandoned, etc.).
+  if (ai < 20 && turns < 1) return null;
+
+  // 1. No engagement: user spoke but model never started a turn.
+  if (turns === 0 && dur > 30_000 && ai >= 20) {
+    return {
+      class: 'voice.no_engagement',
+      normalized_signature: ai >= 100 ? 'no_engagement_user_active' : 'no_engagement_brief',
+    };
+  }
+
+  // 2. Model under-responds: real turn cycle but model produced very little.
+  if (turns >= 1 && ai >= 100) {
+    const ratio = ao > 0 ? ai / ao : ai;
+    if (ratio >= 5) {
+      return {
+        class: 'voice.model_under_responds',
+        normalized_signature: `model_under_responds_${bucketRatio(ratio)}`,
+      };
+    }
+  }
+
+  // 3. Low turn progression: long session, few turns. Conversation didn't
+  // develop. Catches "user struggling to engage" patterns the others miss.
+  if (dur > 60_000 && turns < 3 && ai >= 50) {
+    return {
+      class: 'voice.low_turn_progression',
+      normalized_signature: turns === 0 ? 'low_turn_zero' : 'low_turn_one_or_two',
+    };
+  }
+
   return null;
 }

--- a/services/gateway/src/services/voice-self-healing-adapter.ts
+++ b/services/gateway/src/services/voice-self-healing-adapter.ts
@@ -28,10 +28,11 @@ import {
 } from './voice-session-classifier';
 import { getVoiceSpecHint } from './voice-spec-hints';
 import { lookupSpecMemory } from './voice-spec-memory';
-import { isDispatchAllowed } from './voice-recurrence-sentinel';
+import { isDispatchAllowed, appendVerdict, evaluateAndQuarantine } from './voice-recurrence-sentinel';
 import { emitOasisEvent } from './oasis-event-service';
 import { spawnInvestigator } from './voice-architecture-investigator';
 import { appendShadowLog } from './voice-shadow-mode';
+import { classifyQualityFromSessionStop } from './voice-failure-taxonomy';
 
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
@@ -103,6 +104,20 @@ export interface DispatchOptions {
    * (used by future Synthetic Voice Probe — PR #4).
    */
   metadata?: Record<string, unknown>;
+  /**
+   * VTID-01994: session-end metrics for quality classification. Supplied
+   * by the orb-live.ts session-stop hooks. When present, the adapter runs
+   * the quality classifier (no error events required) and routes detected
+   * quality failures to the Architecture Investigator regardless of mode.
+   */
+  sessionMetrics?: {
+    audio_in_chunks?: number;
+    audio_out_chunks?: number;
+    duration_ms?: number;
+    turn_count?: number;
+    user_turns?: number;
+    model_turns?: number;
+  };
 }
 
 export type DispatchAction =
@@ -115,6 +130,7 @@ export type DispatchAction =
   | 'spec_memory_blocked'
   | 'sentinel_quarantined'
   | 'sentinel_probation_capped'
+  | 'quality_failure_classified'
   | 'error';
 
 export interface DispatchResult {
@@ -237,6 +253,110 @@ async function postSelfHealingReport(
  * result describing what happened. Does not throw — all internal errors
  * are surfaced as `action: 'error'`.
  */
+/**
+ * VTID-01994: Handle a quality failure detected from session-stop metrics.
+ *
+ * Quality failures don't have explicit error events — they're patterns
+ * inferred from audio_in:audio_out ratios, turn counts, durations. The
+ * fix is usually at the prompt or model-config layer, not the pipeline
+ * layer, so we route directly to the Architecture Investigator instead
+ * of the deterministic-spec path.
+ *
+ * Rate limiting:
+ *   - Sentinel quarantine check: if (class, signature) is quarantined,
+ *     skip investigator (record suppressed verdict only).
+ *   - Sentinel auto-quarantines after 5 dispatches/24h via the burst
+ *     threshold, so worst-case investigator spawns are bounded.
+ *
+ * Independent of the mode flag — quality failures always investigate.
+ */
+async function handleQualityFailure(
+  qc: { class: string; normalized_signature: string },
+  opts: DispatchOptions,
+): Promise<DispatchResult> {
+  // Always append a verdict to the history table — Sentinel reads this
+  // for threshold evaluation. Treat quality failures as 'rollback' verdicts
+  // (the model didn't deliver a usable response, equivalent to a fix
+  // that didn't hold).
+  await appendVerdict({
+    class: qc.class,
+    normalized_signature: qc.normalized_signature,
+    verdict: 'rollback',
+    vtid: null,
+  }).catch(() => { /* best-effort */ });
+
+  // Sentinel gate: if already quarantined, don't spawn another investigator.
+  const decision = await isDispatchAllowed(qc.class, qc.normalized_signature);
+  if (!decision.allowed) {
+    try {
+      await emitOasisEvent({
+        vtid: 'VTID-VOICE-HEALING',
+        type: 'voice.healing.dispatch.suppressed',
+        source: 'voice-self-healing-adapter',
+        status: 'warning',
+        message: `Quality failure suppressed by Sentinel: ${qc.class} (${decision.reason})`,
+        payload: {
+          class: qc.class,
+          normalized_signature: qc.normalized_signature,
+          reason: decision.reason,
+          session_id: opts.sessionId,
+          trigger: 'quality_failure',
+        },
+      });
+    } catch { /* best-effort */ }
+    return {
+      action: 'sentinel_quarantined',
+      class: qc.class,
+      normalized_signature: qc.normalized_signature,
+      detail: `quality:${decision.reason}`,
+    };
+  }
+
+  // Evaluate thresholds — may quarantine if rate is too high.
+  const quarantineReason = await evaluateAndQuarantine(qc.class, qc.normalized_signature);
+
+  // Spawn the Architecture Investigator (fire-and-forget so we don't block
+  // the orb-live.ts session-stop hook). Investigator output is a report
+  // only; never auto-executes.
+  spawnInvestigator({
+    class: qc.class,
+    normalized_signature: qc.normalized_signature,
+    trigger_reason: 'quality_failure',
+    notes: `Quality failure detected from session metrics: audio_in=${opts.sessionMetrics?.audio_in_chunks ?? '?'}, audio_out=${opts.sessionMetrics?.audio_out_chunks ?? '?'}, turns=${opts.sessionMetrics?.turn_count ?? '?'}, duration_ms=${opts.sessionMetrics?.duration_ms ?? '?'}.${quarantineReason ? ' (Sentinel just quarantined this signature.)' : ''}`,
+  }).catch((err) => {
+    console.warn('[voice-self-healing-adapter] quality investigator spawn failed:', err?.message ?? err);
+  });
+
+  // Emit a clear telemetry event so it's visible in the panel.
+  try {
+    await emitOasisEvent({
+      vtid: 'VTID-VOICE-HEALING',
+      type: 'voice.healing.dispatched',
+      source: 'voice-self-healing-adapter',
+      status: 'warning',
+      message: `Quality failure detected: ${qc.class}. Investigator spawned (mode-independent).`,
+      payload: {
+        class: qc.class,
+        normalized_signature: qc.normalized_signature,
+        trigger: 'quality_failure',
+        session_id: opts.sessionId,
+        audio_in_chunks: opts.sessionMetrics?.audio_in_chunks,
+        audio_out_chunks: opts.sessionMetrics?.audio_out_chunks,
+        turn_count: opts.sessionMetrics?.turn_count,
+        duration_ms: opts.sessionMetrics?.duration_ms,
+        sentinel_quarantined_now: !!quarantineReason,
+      },
+    });
+  } catch { /* best-effort */ }
+
+  return {
+    action: 'quality_failure_classified',
+    class: qc.class,
+    normalized_signature: qc.normalized_signature,
+    detail: quarantineReason ? `quarantined:${quarantineReason}` : 'investigator_spawned',
+  };
+}
+
 async function _dispatchVoiceFailureCore(
   opts: DispatchOptions,
 ): Promise<DispatchResult> {
@@ -244,9 +364,30 @@ async function _dispatchVoiceFailureCore(
     return { action: 'synthetic_skipped' };
   }
 
+  // VTID-01994: Quality classifier — runs BEFORE the mode check so quality
+  // failures (model under-responds, no engagement, low turn progression)
+  // always trigger the Architecture Investigator regardless of mode. Mode
+  // continues to gate the actual /report dispatch path that can change code;
+  // investigator output is read-only and always allowed because the user
+  // explicitly asked for visibility on every broken session.
+  let qualityResult: DispatchResult | null = null;
+  if (opts.sessionMetrics) {
+    const qc = classifyQualityFromSessionStop({
+      audio_in_chunks: opts.sessionMetrics.audio_in_chunks ?? 0,
+      audio_out_chunks: opts.sessionMetrics.audio_out_chunks ?? 0,
+      duration_ms: opts.sessionMetrics.duration_ms ?? 0,
+      turn_count: opts.sessionMetrics.turn_count ?? 0,
+      user_turns: opts.sessionMetrics.user_turns,
+      model_turns: opts.sessionMetrics.model_turns,
+    });
+    if (qc) {
+      qualityResult = await handleQualityFailure(qc, opts);
+    }
+  }
+
   const mode = await getVoiceSelfHealingMode();
   if (mode === 'off') {
-    return { action: 'mode_off' };
+    return qualityResult ?? { action: 'mode_off' };
   }
 
   let classification: VoiceClassification;

--- a/services/gateway/test/voice-failure-taxonomy.test.ts
+++ b/services/gateway/test/voice-failure-taxonomy.test.ts
@@ -27,8 +27,8 @@ describe('VTID-01958: Voice Failure Taxonomy', () => {
       expect(SIGNATURE_VERSION.length).toBeGreaterThan(0);
     });
 
-    test('VOICE_FAILURE_CLASSES contains all 11 expected classes', () => {
-      expect(VOICE_FAILURE_CLASSES).toHaveLength(11);
+    test('VOICE_FAILURE_CLASSES contains all 14 expected classes (incl. VTID-01994 quality classes)', () => {
+      expect(VOICE_FAILURE_CLASSES).toHaveLength(14);
       const expected = [
         'voice.config_missing',
         'voice.config_fallback_active',
@@ -40,6 +40,9 @@ describe('VTID-01958: Voice Failure Taxonomy', () => {
         'voice.tool_loop',
         'voice.audio_one_way',
         'voice.permission_denied',
+        'voice.model_under_responds',
+        'voice.no_engagement',
+        'voice.low_turn_progression',
         'voice.unknown',
       ];
       for (const c of expected) {
@@ -356,6 +359,83 @@ describe('VTID-01958: Voice Failure Taxonomy', () => {
       expect(
         detectAudioOneWay({ audio_in_chunks: 0, audio_out_chunks: 0, stall_type: null }),
       ).toBeNull();
+    });
+  });
+
+  describe('VTID-01994: classifyQualityFromSessionStop', () => {
+    const { classifyQualityFromSessionStop } = require('../src/services/voice-failure-taxonomy');
+
+    test('the worst-case session (585:5:1) → voice.model_under_responds with high-ratio bucket', () => {
+      const r = classifyQualityFromSessionStop({
+        audio_in_chunks: 585,
+        audio_out_chunks: 5,
+        duration_ms: 93700,
+        turn_count: 1,
+      });
+      expect(r?.class).toBe('voice.model_under_responds');
+      expect(r?.normalized_signature).toBe('model_under_responds_r100plus');
+    });
+
+    test('the 945:46 session → voice.model_under_responds with mid-ratio bucket', () => {
+      const r = classifyQualityFromSessionStop({
+        audio_in_chunks: 945,
+        audio_out_chunks: 46,
+        duration_ms: 80000,
+        turn_count: 5,
+      });
+      expect(r?.class).toBe('voice.model_under_responds');
+      expect(r?.normalized_signature).toBe('model_under_responds_r20to100');
+    });
+
+    test('user spoke but model never started turn → voice.no_engagement', () => {
+      const r = classifyQualityFromSessionStop({
+        audio_in_chunks: 200,
+        audio_out_chunks: 5,
+        duration_ms: 60000,
+        turn_count: 0,
+      });
+      expect(r?.class).toBe('voice.no_engagement');
+      expect(r?.normalized_signature).toBe('no_engagement_user_active');
+    });
+
+    test('long session, few turns → voice.low_turn_progression', () => {
+      const r = classifyQualityFromSessionStop({
+        audio_in_chunks: 80,
+        audio_out_chunks: 30,
+        duration_ms: 120000,
+        turn_count: 1,
+      });
+      expect(r?.class).toBe('voice.low_turn_progression');
+    });
+
+    test('healthy ratio session → null (no quality failure)', () => {
+      const r = classifyQualityFromSessionStop({
+        audio_in_chunks: 200,
+        audio_out_chunks: 100,
+        duration_ms: 60000,
+        turn_count: 5,
+      });
+      expect(r).toBeNull();
+    });
+
+    test('very brief session (mic test) → null (not a real conversation)', () => {
+      const r = classifyQualityFromSessionStop({
+        audio_in_chunks: 5,
+        audio_out_chunks: 50,
+        duration_ms: 4000,
+        turn_count: 0,
+      });
+      expect(r).toBeNull();
+    });
+
+    test('healthy short conversation → null', () => {
+      const r = classifyQualityFromSessionStop({
+        audio_in_chunks: 100,
+        audio_out_chunks: 60,
+        duration_ms: 25000,
+        turn_count: 3,
+      });
+      expect(r).toBeNull();
     });
   });
 });

--- a/services/gateway/test/voice-healing-summary.test.ts
+++ b/services/gateway/test/voice-healing-summary.test.ts
@@ -38,7 +38,7 @@ describe('VTID-01965: Healing Summary', () => {
       throw new Error('unexpected: ' + url);
     });
     const s = await buildHealingSummary();
-    expect(s.per_class.length).toBe(11);
+    expect(s.per_class.length).toBe(14);
     for (const c of s.per_class) {
       expect(c.dispatch_count_24h).toBe(0);
       expect(c.fix_success_rate_7d).toBeNull();

--- a/supabase/migrations/20260427100000_vtid_01994_voice_quality_failure_trigger.sql
+++ b/supabase/migrations/20260427100000_vtid_01994_voice_quality_failure_trigger.sql
@@ -1,0 +1,20 @@
+-- VTID-01994: Allow 'quality_failure' as trigger_reason for Architecture
+-- Investigator reports. Quality failures are detected from session-stop
+-- metrics (audio_in:audio_out ratio, turn count, duration) — no error
+-- events required. They route directly to the investigator because the
+-- root cause is usually at the prompt / model-config layer, not the
+-- pipeline layer.
+--
+-- Plan: .claude/plans/the-biggest-issues-and-fizzy-wozniak.md
+
+ALTER TABLE public.voice_architecture_reports
+  DROP CONSTRAINT IF EXISTS voice_architecture_reports_trigger_reason_chk;
+
+ALTER TABLE public.voice_architecture_reports
+  ADD CONSTRAINT voice_architecture_reports_trigger_reason_chk
+  CHECK (trigger_reason IN (
+    'sentinel_quarantine',
+    'spec_memory_blocked',
+    'quality_failure',
+    'manual'
+  ));


### PR DESCRIPTION
Two changes:

## 1. Prompt fix — direct cause of model_under_responds

`orb-live.ts` default general_behavior was `'- Keep responses concise for voice interaction (2-3 sentences max)'`. Production data showed terse responses across the board (e.g. 945:46 audio_in:audio_out ratio). Replaced with length guidance that scales to the question.

## 2. Universal quality classifier

Per user request: every broken session must trigger self-healing automatically, regardless of user/UI/role. Added 3 quality classes detectable from session-stop metadata alone (no error events required):
- `voice.model_under_responds` (audio_in≥100, ratio ≥5, turn_count≥1)
- `voice.no_engagement` (turn_count=0, duration>30s)
- `voice.low_turn_progression` (duration>60s, turn_count<3)

The quality path runs **before** the mode check so it works even when mode=off. Mode still gates the actual /report dispatch (which can change code); investigator path is mode-independent because reports are read-only. Sentinel + Spec Memory still rate-limit (≤5 investigator spawns per (class, signature) per 24h).

## Test plan

- [x] TypeScript build passes
- [x] 129 voice unit tests pass (+7 new for classifyQualityFromSessionStop)
- [ ] Post-deploy: try a real ORB session — model should give substantive answers (not 2-3 sentences)
- [ ] Post-deploy: check Voice panel — broken sessions now append to voice_healing_history with quality classes; investigator reports show up in voice_architecture_reports
- [ ] Apply migration: `supabase/migrations/20260427100000_vtid_01994_voice_quality_failure_trigger.sql` extends the CHECK constraint to allow trigger_reason='quality_failure'

🤖 Generated with [Claude Code](https://claude.com/claude-code)