### PR TITLE
feat(llm): wire DeepSeek API key + provider-health endpoint + dropdown gray-out (DEV-COMHU-0418)

### DIFF
--- a/.github/workflows/EXEC-DEPLOY.yml
+++ b/.github/workflows/EXEC-DEPLOY.yml
@@ -304,6 +304,11 @@ jobs:
             SECRETS_ARGS+=(--remove-secrets=APPILIX_APP_KEY)
             # Incident Triage Agent — Claude Managed Agents API key
             EXTRA_ENV_ARGS+=(--update-env-vars=ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }})
+            # BOOTSTRAP-LLM-ROUTER: DeepSeek provider key. Used when
+            # llm_routing_policy.policy[stage].primary_provider='deepseek'
+            # (or fallback). Without this set, the router's deepseekAdapter
+            # reports unavailable and falls through to the configured fallback.
+            EXTRA_ENV_ARGS+=(--update-env-vars=DEEPSEEK_API_KEY=${{ secrets.DEEPSEEK_API_KEY }})
             # BOOTSTRAP-DEV-AUTOPILOT-WORKER-QUEUE: route Dev Autopilot LLM
             # calls (plan + execute) through the local worker + Supabase queue
             # instead of the direct Messages API, so they draw on the Claude

--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -3668,6 +3668,11 @@ const state = {
       pending: null,          // operator-edited copy (only persisted on Save)
       providers: [],          // from /api/v1/llm/routing-policy
       models: [],             // from /api/v1/llm/routing-policy (with tier field)
+      // BOOTSTRAP-LLM-ROUTER-CFG: provider availability from /api/v1/llm/providers/health.
+      // Map of provider_key -> { available: bool, reason?: string }. Drives the
+      // dropdown gray-out so the UI never lists a provider that has no
+      // credentials configured on the gateway.
+      health: {},
       saving: false,
       saveError: null,
       lastSavedAt: null,
@@ -31359,21 +31364,34 @@ function fetchLlmRoutingPolicy() {
   state.llmRouting.loading = true;
   state.llmRouting.error = null;
   renderApp();
-  fetch('/api/v1/llm/routing-policy?environment=DEV', { credentials: 'include' })
-    .then(function (r) { return r.json(); })
-    .then(function (resp) {
+  // Fetch policy + provider health in parallel — health drives dropdown gray-out.
+  Promise.all([
+    fetch('/api/v1/llm/routing-policy?environment=DEV', { credentials: 'include' }).then(function (r) { return r.json(); }),
+    fetch('/api/v1/llm/providers/health', { credentials: 'include' })
+      .then(function (r) { return r.json(); })
+      .catch(function () { return { ok: false }; }),
+  ])
+    .then(function (results) {
+      var resp = results[0];
+      var healthResp = results[1];
       if (!resp || !resp.ok) throw new Error((resp && resp.error) || 'fetch failed');
       var data = resp.data || {};
       state.llmRouting.loading = false;
       state.llmRouting.fetched = true;
-      // Server may return policy nested in `data.policy.policy` (the row's `policy` JSONB field)
-      // or directly as `data.policy` (flat). Handle both.
       var policyRow = data.policy || null;
       var policyDoc = (policyRow && policyRow.policy) ? policyRow.policy : policyRow;
       state.llmRouting.policy = policyDoc;
       state.llmRouting.pending = JSON.parse(JSON.stringify(policyDoc || {}));
       state.llmRouting.providers = data.providers || [];
       state.llmRouting.models = data.models || [];
+      // Health: turn the array into a map keyed by provider key for O(1) lookup
+      var healthMap = {};
+      if (healthResp && healthResp.ok && Array.isArray(healthResp.data)) {
+        healthResp.data.forEach(function (h) {
+          healthMap[h.provider] = { available: !!h.available, reason: h.reason || null };
+        });
+      }
+      state.llmRouting.health = healthMap;
       renderApp();
     })
     .catch(function (err) {
@@ -31551,12 +31569,32 @@ function buildPickerCell(slotLabel, stageKey, slot, providers, stageCfg) {
   providers.forEach(function (p) {
     var opt = document.createElement('option');
     opt.value = p.provider_key;
-    opt.textContent = p.display_name || p.provider_key;
+    var label = p.display_name || p.provider_key;
+    // BOOTSTRAP-LLM-ROUTER-CFG: gray out + annotate providers without
+    // credentials configured on the gateway. Operator can still select them
+    // (in case they're about to set the secret), but the UI is honest about
+    // current availability.
+    var health = state.llmRouting.health[p.provider_key];
+    if (health && !health.available) {
+      opt.disabled = true;
+      label = label + ' (no API key)';
+      opt.title = health.reason || 'No credentials configured';
+    } else {
+      opt.title = '';
+    }
+    opt.textContent = label;
     providerSelect.appendChild(opt);
   });
 
   var currentProvider = stageCfg[slot + '_provider'];
   providerSelect.value = currentProvider || '';
+  // If the saved policy points at an unavailable provider, surface that on the
+  // select itself so the operator sees the warning even before opening the menu.
+  var currentHealth = currentProvider ? state.llmRouting.health[currentProvider] : null;
+  if (currentHealth && !currentHealth.available) {
+    providerSelect.style.cssText += 'border-color:#ff6b6b;color:#ff9f9f;';
+    providerSelect.title = currentHealth.reason || 'Provider has no credentials configured';
+  }
   col.appendChild(providerSelect);
 
   // Model <select>

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -12,7 +12,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260427-vtid-01988-mic-restart"></script>
-  <script src="/command-hub/app.js?v=20260427-vtid-01993-self-healing-pagination"></script>
+  <script src="/command-hub/app.js?v=20260427-deepseek-wired"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
 </body>

--- a/services/gateway/src/routes/llm.ts
+++ b/services/gateway/src/routes/llm.ts
@@ -19,7 +19,7 @@ import {
   getPolicyAuditHistory,
 } from '../services/llm-routing-policy-service';
 import { queryLLMTelemetry } from '../services/llm-telemetry-service';
-import { LLM_SAFE_DEFAULTS, VALID_STAGES, VALID_PROVIDERS } from '../constants/llm-defaults';
+import { LLM_SAFE_DEFAULTS, VALID_STAGES, VALID_PROVIDERS, type LLMProvider } from '../constants/llm-defaults';
 import { getSupabase } from '../lib/supabase';
 
 const router = Router();
@@ -353,6 +353,51 @@ router.get('/telemetry', async (req: Request, res: Response) => {
 // VTID-02403: Return static catalog of LLM providers + live user_connections_count
 // for AI-assistant providers (ChatGPT, Claude). Command Hub consumes this.
 // =============================================================================
+// =============================================================================
+// GET /api/v1/llm/providers/health
+//
+// BOOTSTRAP-LLM-ROUTER: report which router providers actually have credentials
+// configured on this gateway instance. The Command Hub dropdown reads this
+// and grays out unavailable providers + shows a tooltip, so the UI can never
+// again silently mislead by listing a provider that would fail at call time.
+// =============================================================================
+router.get('/providers/health', (_req: Request, res: Response) => {
+  const providers: Array<{ provider: LLMProvider; available: boolean; reason?: string }> = [
+    {
+      provider: 'anthropic',
+      available: Boolean(process.env.ANTHROPIC_API_KEY),
+      reason: process.env.ANTHROPIC_API_KEY ? undefined : 'ANTHROPIC_API_KEY not set on gateway',
+    },
+    {
+      provider: 'openai',
+      available: Boolean(process.env.OPENAI_API_KEY),
+      reason: process.env.OPENAI_API_KEY ? undefined : 'OPENAI_API_KEY not set on gateway',
+    },
+    {
+      provider: 'vertex',
+      available: Boolean(process.env.GOOGLE_CLOUD_PROJECT) || Boolean(process.env.GOOGLE_GEMINI_API_KEY),
+      reason:
+        process.env.GOOGLE_CLOUD_PROJECT || process.env.GOOGLE_GEMINI_API_KEY
+          ? undefined
+          : 'No Vertex/Google AI credentials',
+    },
+    {
+      provider: 'deepseek',
+      available: Boolean(process.env.DEEPSEEK_API_KEY),
+      reason: process.env.DEEPSEEK_API_KEY ? undefined : 'DEEPSEEK_API_KEY not set on gateway',
+    },
+    {
+      provider: 'claude_subscription',
+      available: (process.env.DEV_AUTOPILOT_USE_WORKER || '').toLowerCase() === 'true',
+      reason:
+        (process.env.DEV_AUTOPILOT_USE_WORKER || '').toLowerCase() === 'true'
+          ? undefined
+          : 'DEV_AUTOPILOT_USE_WORKER=true required (worker queue disabled)',
+    },
+  ];
+  res.json({ ok: true, data: providers });
+});
+
 router.get('/models', async (req: Request, res: Response) => {
   // Static catalog (mirrors prior front-end defaults so existing UI still works)
   const staticModels: Array<{


### PR DESCRIPTION
Stops the dropdown from misleading: lists DeepSeek as selectable now that the env var is wired, shows '(no API key)' next to OpenAI which still has no secret, paints a red border on the select if the saved policy already points at an unavailable provider.