### PR TITLE
fix(assistant): answer "what is my user ID?" with @handle, never the UUID (VTID-01967)

### DIFF
--- a/services/gateway/src/routes/conversation.ts
+++ b/services/gateway/src/routes/conversation.ts
@@ -54,6 +54,8 @@ import {
   logToolExecution,
 } from '../services/tool-registry';
 import { processWithGemini, setThreadIdentity } from '../services/gemini-operator';
+// VTID-01967: Resolve canonical Vitana ID handle for the prompt + tool-thread identity
+import { resolveVitanaId } from '../middleware/auth-supabase-jwt';
 // VTID-DEV-ASSIST: Developer assistant personality
 import { getPersonalityConfigSync } from '../services/ai-personality-service';
 // Memory auto-write for conversation turns
@@ -316,8 +318,14 @@ router.post('/turn', async (req: Request, res: Response) => {
     const thread = getOrCreateThread(input.thread_id, tenant_id, user_id, channel);
     thread.turn_count++;
 
+    // VTID-01967: Resolve canonical Vitana ID handle (cached, ~free on hit).
+    // Used both for tool-thread identity and for the system prompt below so
+    // the assistant can answer "what is my user ID?" with the @handle.
+    const vitanaId = await resolveVitanaId(user_id);
+
     // VTID-DEV-ASSIST: Set thread identity with role for tool-level role enforcement
-    setThreadIdentity(thread.thread_id, { tenant_id, user_id, role });
+    // VTID-01967: include vitana_id so downstream tools see the canonical handle.
+    setThreadIdentity(thread.thread_id, { tenant_id, user_id, role, vitana_id: vitanaId });
 
     // Create context lens for memory access
     const lens: ContextLens = createContextLens(tenant_id, user_id, {
@@ -402,7 +410,24 @@ ${devConfig.important_section || ''}`;
 - For Operator, you can be more detailed`;
       }
 
+      // VTID-01967: Authoritative Vitana ID block — pinned to the system
+      // prompt so the model answers identity questions with the @handle and
+      // never the internal UUID. Mirrors the orb-live header pattern.
+      const vitanaIdBlock = vitanaId
+        ? `\n=== AUTHORITATIVE USER VITANA ID ===
+The user's Vitana ID handle is: ${vitanaId}
+This is the ONLY identifier you may share when the user asks "what is my user ID",
+"what is my handle", "what is my Vitana ID", or "who am I". Do NOT speak the
+internal UUID under any circumstance — it is a private system identifier.
+=====================================\n`
+        : `\n=== AUTHORITATIVE USER VITANA ID ===
+No Vitana ID handle is provisioned for this session. If the user asks for their
+user ID, handle, or Vitana ID, tell them honestly that their handle hasn't been
+set up yet. Do NOT substitute an internal UUID.
+=====================================\n`;
+
       const systemInstruction = `${channel === 'developer_assistant' ? '' : 'You are Vitana, an intelligent assistant. Respond helpfully and accurately based on the context provided.\n'}${languageDirective}
+${vitanaIdBlock}
 ${contextForLLM}
 
 Current conversation channel: ${channel}

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -5617,6 +5617,11 @@ function buildLiveSystemInstruction(
   currentRoute?: string | null,
   recentRoutes?: string[] | null,
   clientContext?: ClientContext,
+  // VTID-01967: Canonical Vitana ID handle for this user (e.g. "@alex3700").
+  // When present, pinned at the top of the prompt as the ONLY identifier the
+  // model may emit when asked "what is my user ID?". Null/undefined for
+  // sessions where the handle hasn't been provisioned yet.
+  vitanaId?: string | null,
 ): string {
   const languageNames: Record<string, string> = {
     'en': 'English',
@@ -5668,7 +5673,29 @@ honestly that you do not see a role in this session.
 
 `;
 
-  let instruction = `${roleHeader}${voiceLiveConfig.base_identity || 'You are Vitana, an AI health companion assistant powered by Gemini Live.'}
+  // VTID-01967: Pin the canonical Vitana ID at the top of the prompt so the
+  // model can answer "what is my user ID?" / "what's my handle?" with the
+  // @-prefixed handle instead of hallucinating a UUID. Mirrors the role
+  // header pattern above so the directive isn't buried.
+  const vitanaIdHeader = vitanaId
+    ? `=== AUTHORITATIVE USER VITANA ID ===
+The user's Vitana ID handle is: ${vitanaId}
+This is the ONLY identifier you may share when the user asks "what is my user ID",
+"what is my handle", "what is my Vitana ID", or "who am I". Do NOT speak the
+internal UUID under any circumstance — it is a private system identifier.
+=====================================
+
+`
+    : `=== AUTHORITATIVE USER VITANA ID ===
+No Vitana ID handle is provisioned for this session. If the user asks "what is
+my user ID", "what is my handle", or "what is my Vitana ID", tell them honestly
+that their handle hasn't been set up yet and they can configure it in Settings.
+Do NOT substitute an internal UUID under any circumstance.
+=====================================
+
+`;
+
+  let instruction = `${roleHeader}${vitanaIdHeader}${voiceLiveConfig.base_identity || 'You are Vitana, an AI health companion assistant powered by Gemini Live.'}
 
 LANGUAGE: Respond ONLY in ${languageNames[lang] || 'English'}.
 
@@ -6700,6 +6727,9 @@ async function connectToLiveAPI(
                     session.current_route || null,
                     session.recent_routes || null,
                     session.clientContext || undefined,
+                    // VTID-01967: Canonical Vitana ID handle (already resolved
+                    // by optionalAuth → resolveVitanaId on session start).
+                    session.identity?.vitana_id ?? null,
                   )
             }]
           },
@@ -9703,8 +9733,16 @@ router.post('/chat', optionalAuth, async (req: AuthenticatedRequest, res: Respon
     const threadId = `orb-${orbSessionId}`;
 
     // VTID-01270A: Set thread identity for community/events tools in text chat path
+    // VTID-01967: include vitana_id (resolved by optionalAuth → resolveVitanaId)
+    // so downstream tools and any prompt that reads the thread identity can
+    // surface the @handle without re-querying.
     if (identity.tenant_id && identity.user_id) {
-      setThreadIdentity(threadId, { tenant_id: identity.tenant_id, user_id: identity.user_id, role: identity.active_role || undefined });
+      setThreadIdentity(threadId, {
+        tenant_id: identity.tenant_id,
+        user_id: identity.user_id,
+        role: identity.active_role || undefined,
+        vitana_id: req.identity?.vitana_id ?? null,
+      });
     }
 
     // VTID-01118: Get state engine and increment turn count

--- a/services/gateway/src/services/assistant-service.ts
+++ b/services/gateway/src/services/assistant-service.ts
@@ -64,8 +64,16 @@ const activeSessions = new Set<string>();
 function buildSystemPrompt(context: AssistantContext): string {
   const devConfig = getPersonalityConfigSync('dev_orb') as Record<string, any>;
 
-  return `${devConfig.base_identity || 'You are the Vitana Global Assistant, a helpful AI assistant for the Vitana development platform.'}
+  // VTID-01967: Authoritative Vitana ID directive — pinned so the assistant
+  // can answer identity questions with the @handle instead of leaking a UUID.
+  // The Dev ORB chat body doesn't currently carry an authenticated identity,
+  // so vitanaId may be undefined; we still emit the guardrail in that case.
+  const vitanaIdBlock = context.vitanaId
+    ? `\n## Authoritative User Vitana ID\nThe user's Vitana ID handle is: ${context.vitanaId}\nThis is the ONLY identifier you may share when the user asks "what is my user ID", "what is my handle", or "who am I". Do NOT speak the internal UUID under any circumstance.\n`
+    : `\n## Authoritative User Vitana ID\nNo Vitana ID handle is available for this session. If the user asks for their user ID, handle, or Vitana ID, tell them honestly that their handle isn't available in this context — do NOT substitute an internal UUID.\n`;
 
+  return `${devConfig.base_identity || 'You are the Vitana Global Assistant, a helpful AI assistant for the Vitana development platform.'}
+${vitanaIdBlock}
 ## Context
 - **Role**: ${context.role} (Developer context)
 - **Tenant**: ${context.tenant}

--- a/services/gateway/src/services/gemini-operator.ts
+++ b/services/gateway/src/services/gemini-operator.ts
@@ -62,10 +62,10 @@ const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
 
 // VTID-01270A: Thread-to-identity map for community/events tools
 // Populated by ORB chat handlers before calling processWithGemini
-const threadIdentityMap = new Map<string, { tenant_id: string; user_id: string; role?: string; user_timezone?: string }>();
+const threadIdentityMap = new Map<string, { tenant_id: string; user_id: string; role?: string; user_timezone?: string; vitana_id?: string | null }>();
 
 /** VTID-01270A: Set identity context for a thread (call before processWithGemini) */
-export function setThreadIdentity(threadId: string, identity: { tenant_id: string; user_id: string; role?: string; user_timezone?: string }): void {
+export function setThreadIdentity(threadId: string, identity: { tenant_id: string; user_id: string; role?: string; user_timezone?: string; vitana_id?: string | null }): void {
   threadIdentityMap.set(threadId, identity);
   // Auto-cleanup after 30 minutes
   setTimeout(() => threadIdentityMap.delete(threadId), 30 * 60 * 1000);

--- a/services/gateway/src/types/assistant.ts
+++ b/services/gateway/src/types/assistant.ts
@@ -55,4 +55,11 @@ export interface AssistantContext {
   tenant: string;
   route: string;
   selectedId: string;
+  /**
+   * VTID-01967: Canonical Vitana ID handle (e.g. "@alex3700"). Optional —
+   * Dev ORB body does not currently carry one, but downstream prompts use
+   * this when present so the assistant can answer "what is my user ID?"
+   * with the handle instead of leaking the internal UUID.
+   */
+  vitanaId?: string | null;
 }


### PR DESCRIPTION
## Summary

When a user asks the Vitana assistant "What is my user ID?", it currently replies with a UUID-style string — a hallucination, since none of the three LLM pipelines actually injects the user's identity into their system prompt. The canonical Vitana ID handle (e.g. `@alex3700`) shipped on 2026-04-26 (PRs #933 / vitana-v1#247) and is already attached to `SupabaseIdentity` by `auth-supabase-jwt.resolveVitanaId()`. This PR wires it through to every authenticated assistant pipeline as a pinned, authoritative prompt directive.

The directive instructs the model to share ONLY the `@handle` when asked for the user's user ID / handle / "who am I", and to **never** speak the internal UUID. When `vitana_id` is null (handle not yet provisioned), the model is told to say so honestly rather than substitute the UUID.

## Changes

- **ORB Live** (`services/gateway/src/routes/orb-live.ts`): `buildLiveSystemInstruction()` now takes an optional `vitanaId` param and emits an `=== AUTHORITATIVE USER VITANA ID ===` block, mirroring the existing role-header pattern, pinned at the top of the prompt. `session.identity.vitana_id` is forwarded at the authenticated call site. The text-chat path's `setThreadIdentity()` now carries `vitana_id` too.
- **Conversation API** (`services/gateway/src/routes/conversation.ts`): resolves `vitana_id` once via the shared cache (`resolveVitanaId`) and injects the same authoritative block into the system instruction. `setThreadIdentity` carries the handle for downstream tools.
- **Assistant Service / Dev ORB** (`services/gateway/src/services/assistant-service.ts`): emits the same directive; the Dev ORB body does not carry an authenticated identity today, so `vitanaId` is undefined and the prompt falls back to the "no handle available" branch — still prevents UUID leakage.
- **Shared types**: `setThreadIdentity()` (`gemini-operator.ts`) and `AssistantContext` (`types/assistant.ts`) now carry an optional `vitana_id` / `vitanaId` field.

No new tools, no new endpoints, no new DB queries — reuses the cached `resolveVitanaId()` from auth middleware. Static prompt injection over a tool round-trip because the handle is short, stable, and known at session start; a tool failure would fall back to exactly the hallucination we're fixing.

## Test plan

- [ ] **Auth probe** — \`curl -H \"Authorization: Bearer \$JWT\" \$GATEWAY/auth/me\` confirms \`vitana_id\` is present (already shipping, sanity check).
- [ ] **Conversation API** — \`POST /api/v1/conversation/turn { message: \"What is my user ID?\" }\` with a real JWT → reply contains \`@<handle>\`; assert reply does **not** match \`/[0-9a-f]{8}-[0-9a-f]{4}/i\`.
- [ ] **ORB Live Voice** — open a Live session with a JWT, ask "what is my user ID?" → transcribed reply contains the \`@handle\`. Then ask "what is my UUID?" → confirm refusal (no UUID echoed).
- [ ] **Dev ORB Assistant** — \`POST /assistant/chat { message: \"what is my Vitana handle?\" }\` with no identity → falls into the "no handle available" branch (no UUID leak).
- [ ] **Null handle fallback** — issue a token for a user with \`vitana_id IS NULL\` → all three pipelines reply "not provisioned yet" rather than emitting the UUID.
- [ ] **Tool-path regression** — confirm \`send_chat_message\` and \`share_link\` still receive \`session.identity.vitana_id\` (no behavior change expected; only the prompt path is new).
- [ ] Verify in-browser per the "test as the real user" memory rule, not just curl.

## Out of scope

- vitana-v1 frontend (no changes; entirely server-side).
- The legacy \`/orb/chat\` text path (\`generateSystemInstruction\`) — older path, can be patched in a follow-up if needed.
- Anonymous ORB sessions (no handle by design).
- A \`get_my_identity\` tool — rejected; static prompt injection is faster and more robust.

🤖 Generated with [Claude Code](https://claude.com/claude-code)