### PR TITLE
feat(memory): conversation tracking with timestamps — full impl (VTID-01990)

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -1105,6 +1105,16 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
         console.warn('⚠️ Self-healing reconciler initialization failed (non-fatal):', error);
       }
 
+      // VTID-01990: Idle session closer — writes user_session_summaries rows
+      // for text-channel threads idle >= 4h. Voice already writes its own
+      // summaries on disconnect. Gated by IDLE_SESSION_CLOSER_ENABLED.
+      try {
+        const { startIdleSessionCloser } = require('./services/idle-session-closer');
+        startIdleSessionCloser();
+      } catch (error) {
+        console.warn('⚠️ Idle session closer initialization failed (non-fatal):', error);
+      }
+
       // VTID-01992: Async intent embedding worker. Polls for un-embedded
       // user_intents rows and backfills via Gemini. Acts as insurance
       // when inline is on; primary embedder when FEATURE_INTENT_EMBEDDING_ASYNC=true.

--- a/services/gateway/src/services/conversation-client.ts
+++ b/services/gateway/src/services/conversation-client.ts
@@ -308,7 +308,12 @@ export async function processConversationTurn(
       try {
         const { getAwarenessContext } = await import('./guide/awareness-context');
         const { formatAwarenessForPrompt } = await import('./guide/awareness-prompt');
-        const awareness = await getAwarenessContext(input.user_id, input.tenant_id);
+        // VTID-01990: thread the user's timezone (if the surface supplied
+        // one via ui_context.metadata.timezone) into awareness so the
+        // sessions-today bucketing is local-day correct. UTC fallback.
+        const userTz =
+          (input.ui_context?.metadata?.timezone as string | undefined) || 'UTC';
+        const awareness = await getAwarenessContext(input.user_id, input.tenant_id, userTz);
         awarenessBlock = formatAwarenessForPrompt(awareness, { compact: true });
       } catch (e: any) {
         console.warn('[conversation-client] awareness inject failed:', e?.message);

--- a/services/gateway/src/services/gemini-operator.ts
+++ b/services/gateway/src/services/gemini-operator.ts
@@ -62,10 +62,10 @@ const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
 
 // VTID-01270A: Thread-to-identity map for community/events tools
 // Populated by ORB chat handlers before calling processWithGemini
-const threadIdentityMap = new Map<string, { tenant_id: string; user_id: string; role?: string }>();
+const threadIdentityMap = new Map<string, { tenant_id: string; user_id: string; role?: string; user_timezone?: string }>();
 
 /** VTID-01270A: Set identity context for a thread (call before processWithGemini) */
-export function setThreadIdentity(threadId: string, identity: { tenant_id: string; user_id: string; role?: string }): void {
+export function setThreadIdentity(threadId: string, identity: { tenant_id: string; user_id: string; role?: string; user_timezone?: string }): void {
   threadIdentityMap.set(threadId, identity);
   // Auto-cleanup after 30 minutes
   setTimeout(() => threadIdentityMap.delete(threadId), 30 * 60 * 1000);
@@ -2648,6 +2648,32 @@ export async function executeTool(
       case 'get_wearable_metrics':
         result = await executeGetWearableMetrics(args as { days?: number }, threadId);
         break;
+
+      // VTID-01990: Time-anchored conversation recall.
+      // Resolves a user's free-text time reference ("yesterday morning",
+      // "earlier today", "letzten Montag") to a window and returns matching
+      // session summaries + actual conversation_messages turns + facts.
+      case 'recall_conversation_at_time': {
+        const recallIdentity = threadIdentityMap.get(threadId);
+        if (!recallIdentity?.user_id) {
+          result = { ok: false, error: 'Tool requires authenticated user context' };
+          break;
+        }
+        const { executeRecallConversationAtTime } = await import('./tool-recall-conversation');
+        const recallResult = await executeRecallConversationAtTime(
+          args as { time_hint: string; topic_hint?: string },
+          {
+            user_id: recallIdentity.user_id,
+            user_timezone: recallIdentity.user_timezone,
+          },
+        );
+        result = {
+          ok: recallResult.ok,
+          error: recallResult.error,
+          data: recallResult as unknown as Record<string, unknown>,
+        };
+        break;
+      }
 
       default:
         result = {

--- a/services/gateway/src/services/guide/awareness-context.ts
+++ b/services/gateway/src/services/guide/awareness-context.ts
@@ -24,7 +24,7 @@ import {
 import { DEFAULT_WAVE_CONFIG } from '../wave-defaults';
 import { describeTimeSince, fetchLastSessionInfo, type LastInteraction } from './temporal-bucket';
 import { getFeatureIntroductions } from './feature-introductions';
-import { getRecentSessionSummaries } from './session-summaries';
+import { getRecentSessionSummaries, getSessionsTodayAndYesterday } from './session-summaries';
 import { getAdaptationStatus } from './adaptation-applier';
 import { getUserRoutines } from './pattern-extractor';
 import { countActiveUsageDays } from './active-usage';
@@ -53,12 +53,19 @@ const cache = new Map<string, CacheEntry>();
  *
  * All sub-queries run in parallel. Any failing branch returns sensible defaults
  * rather than throwing — awareness is best-effort, brain must always get a result.
+ *
+ * VTID-01990: optional userTz threaded through to bucket today/yesterday session
+ * summaries in the user's local timezone. UTC fallback is safe for users whose
+ * surface didn't supply a timezone.
  */
 export async function getAwarenessContext(
   userId: string,
   tenantId: string,
+  userTz: string = 'UTC',
 ): Promise<UserAwareness> {
-  const cacheKey = `${tenantId}::${userId}`;
+  // Cache key includes tz so a tz-agnostic caller and a tz-aware caller don't
+  // share a stale today/yesterday split.
+  const cacheKey = `${tenantId}::${userId}::${userTz}`;
   const cached = cache.get(cacheKey);
   if (cached && cached.expires_at > Date.now()) {
     return cached.awareness;
@@ -81,6 +88,7 @@ export async function getAwarenessContext(
     adaptationStatus,
     userRoutines,
     activeUsageDays,
+    sessionsTodayAndYesterday,
   ] = await Promise.all([
     safeGatherUserContext(userId, tenantId, supabase),
     fetchLastSessionInfo(userId).catch(() => null),
@@ -91,6 +99,7 @@ export async function getAwarenessContext(
     getAdaptationStatus(userId).catch(() => null),
     getUserRoutines(userId, 8).catch(() => []),
     countActiveUsageDays(userId).catch(() => 0),
+    getSessionsTodayAndYesterday(userId, userTz).catch(() => ({ today: [], yesterday_last: null })),
   ]);
 
   const tenure = buildTenure(userContext, activeUsageDays);
@@ -122,6 +131,25 @@ export async function getAwarenessContext(
       confidence: r.confidence,
     })),
     tastes_preferences: null,
+    sessions_today: {
+      count: sessionsTodayAndYesterday.today.length,
+      entries: sessionsTodayAndYesterday.today.map((s) => ({
+        session_id: s.session_id,
+        channel: s.channel,
+        summary: s.summary,
+        themes: s.themes,
+        ended_at: s.ended_at,
+      })),
+    },
+    last_session_yesterday: sessionsTodayAndYesterday.yesterday_last
+      ? {
+          session_id: sessionsTodayAndYesterday.yesterday_last.session_id,
+          channel: sessionsTodayAndYesterday.yesterday_last.channel,
+          summary: sessionsTodayAndYesterday.yesterday_last.summary,
+          themes: sessionsTodayAndYesterday.yesterday_last.themes,
+          ended_at: sessionsTodayAndYesterday.yesterday_last.ended_at,
+        }
+      : null,
   };
 
   cache.set(cacheKey, { awareness, expires_at: Date.now() + CACHE_TTL_MS });
@@ -133,7 +161,11 @@ export async function getAwarenessContext(
  */
 export function clearAwarenessCache(userId?: string, tenantId?: string): void {
   if (userId && tenantId) {
-    cache.delete(`${tenantId}::${userId}`);
+    // Clear all tz-suffixed keys for this (tenant, user)
+    const prefix = `${tenantId}::${userId}::`;
+    for (const key of cache.keys()) {
+      if (key.startsWith(prefix)) cache.delete(key);
+    }
   } else {
     cache.clear();
   }
@@ -329,5 +361,7 @@ function skeletalAwareness(): UserAwareness {
     adaptation_plans: null,
     routines: [],
     tastes_preferences: null,
+    sessions_today: { count: 0, entries: [] },
+    last_session_yesterday: null,
   };
 }

--- a/services/gateway/src/services/guide/awareness-prompt.ts
+++ b/services/gateway/src/services/guide/awareness-prompt.ts
@@ -75,6 +75,15 @@ export function formatAwarenessForPrompt(
     }
   }
 
+  // VTID-01990 — cross-surface conversation tracking. Surfaces "this is your
+  // Nth session today, last at HH:MM" + a one-liner per prior session today
+  // and yesterday's last session. Lets Vitana feel persistent across
+  // sessions and lets users say "we talked yesterday morning about X" and
+  // have it actually work (the recall_conversation_at_time tool resolves the
+  // window; this block is what makes the assistant know it's possible).
+  const sessionsBlock = renderSessionsTrackingBlock(awareness);
+  if (sessionsBlock) lines.push(sessionsBlock);
+
   if (!compact) {
     lines.push(
       '',
@@ -84,4 +93,65 @@ export function formatAwarenessForPrompt(
   }
 
   return lines.join('\n');
+}
+
+function renderSessionsTrackingBlock(awareness: UserAwareness): string {
+  const today = awareness.sessions_today;
+  const yesterday = awareness.last_session_yesterday;
+  if ((!today || today.count === 0) && !yesterday) return '';
+
+  const out: string[] = [];
+
+  if (today && today.count > 0) {
+    out.push(`Sessions today: ${today.count} prior (this is the ${ordinal(today.count + 1)}).`);
+    // Up to 4 most recent today entries, oldest first so the trail reads chronologically
+    const entries = today.entries.slice(-4);
+    for (const e of entries) {
+      const hhmm = formatLocalHHMM(e.ended_at);
+      const themes = (e.themes || []).slice(0, 3).join(', ');
+      const summary = truncateSummary(e.summary || '', 240);
+      const channelTag = e.channel === 'voice' ? 'voice' : 'text';
+      out.push(`  - ${hhmm} (${channelTag})${themes ? ` themes: ${themes}` : ''} — ${summary}`);
+    }
+  }
+
+  if (yesterday) {
+    const hhmm = formatLocalHHMM(yesterday.ended_at);
+    const themes = (yesterday.themes || []).slice(0, 3).join(', ');
+    const summary = truncateSummary(yesterday.summary || '', 240);
+    out.push(`Yesterday's last session ${hhmm}${themes ? ` themes: ${themes}` : ''} — ${summary}`);
+  }
+
+  if (out.length > 0) {
+    out.push(
+      'When the user references a past conversation by time ("we talked yesterday morning..."), call recall_conversation_at_time to fetch the actual turns. Do not invent details from these summaries alone.',
+    );
+  }
+
+  return out.join('\n');
+}
+
+function ordinal(n: number): string {
+  const s = ['th', 'st', 'nd', 'rd'];
+  const v = n % 100;
+  return `${n}${s[(v - 20) % 10] || s[v] || s[0]}`;
+}
+
+function formatLocalHHMM(iso: string): string {
+  // ISO timestamp -> HH:MM in UTC. The brain's user_timezone-aware formatter
+  // would be richer, but the awareness block is read by both compact and
+  // verbose paths and we don't want to thread tz here. UTC is acceptable —
+  // the times are still ordered correctly and "around 2pm" is fine.
+  try {
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return iso.slice(11, 16);
+    return d.toISOString().slice(11, 16);
+  } catch {
+    return iso.slice(11, 16);
+  }
+}
+
+function truncateSummary(s: string, max: number): string {
+  if (s.length <= max) return s;
+  return s.slice(0, max - 1).trimEnd() + '…';
 }

--- a/services/gateway/src/services/guide/session-summaries.ts
+++ b/services/gateway/src/services/guide/session-summaries.ts
@@ -11,12 +11,48 @@
  * dedicated LLM call for richer summaries.
  */
 
+import { VertexAI } from '@google-cloud/vertexai';
 import { getSupabase } from '../../lib/supabase';
 import { emitGuideTelemetry } from './guide-telemetry';
 
 const LOG_PREFIX = '[Guide:session-summaries]';
 const MAX_SUMMARY_CHARS = 600;
 const RECENT_SUMMARIES_LIMIT = 3;
+
+// VTID-01990: Gemini Flash summarizer config
+const GOOGLE_GEMINI_API_KEY = process.env.GOOGLE_GEMINI_API_KEY;
+const VERTEX_PROJECT = process.env.GOOGLE_CLOUD_PROJECT || process.env.GCP_PROJECT || 'lovable-vitana-vers1';
+const VERTEX_LOCATION = process.env.VERTEX_LOCATION || 'us-central1';
+const SUMMARY_MODEL = 'gemini-2.0-flash';
+
+let summaryVertexAI: VertexAI | null = null;
+try {
+  if (VERTEX_PROJECT && VERTEX_LOCATION) {
+    summaryVertexAI = new VertexAI({ project: VERTEX_PROJECT, location: VERTEX_LOCATION });
+  }
+} catch (err: any) {
+  console.warn(`${LOG_PREFIX} Vertex AI init for summarization failed: ${err.message}`);
+}
+
+const SUMMARY_SYSTEM_PROMPT = `You write 1-2 sentence summaries of a conversation between a User and an AI assistant named Vitana.
+
+Goal: when the User opens Vitana again, your summary should let them say "remember when we talked about X yesterday morning?" and have it work — so capture the topic and the gist of what was discussed or decided, not pleasantries.
+
+Rules:
+- 1-2 sentences, max 280 chars total.
+- Refer to the user as "the user", never "you".
+- Lead with the topic. Skip greetings, sign-offs, "user said hello", etc.
+- If the user revealed a fact about themselves (their company, their goal, a name), include it concisely.
+- Do NOT invent details. Stick to what is in the transcript.
+- Plain prose. No markdown, no quotes, no JSON.
+
+Example input:
+User: My name is Dragan and I work for Exafy. We are building Vitana.
+Assistant: Nice to meet you Dragan. That is a fascinating project.
+User: Yeah, hoping to ship the autopilot loop next week.
+
+Example output:
+The user (Dragan, Exafy) shared that they are building Vitana and aim to ship the autopilot loop next week.`;
 
 export interface SessionSummary {
   session_id: string;
@@ -78,7 +114,13 @@ export async function recordSessionSummary(
     return { success: false, error: 'empty_transcript' };
   }
 
-  const summary = buildSummary(input.transcript_turns);
+  // VTID-01990: prefer Gemini Flash summary, fall back to heuristic on any failure
+  let summary = await summarizeWithGeminiFlash(input.transcript_turns);
+  let summarySource: 'llm' | 'heuristic' = 'llm';
+  if (!summary || summary.length === 0) {
+    summary = buildSummary(input.transcript_turns);
+    summarySource = 'heuristic';
+  }
   const themes = extractThemes(input.transcript_turns);
 
   const { error } = await supabase.from('user_session_summaries').upsert(
@@ -107,13 +149,170 @@ export async function recordSessionSummary(
     turn_count: input.transcript_turns.length,
     themes,
     summary_length: summary.length,
+    summary_source: summarySource,
   }).catch(() => {});
 
   console.log(
-    `${LOG_PREFIX} stored summary for user=${input.user_id.substring(0, 8)} session=${input.session_id.substring(0, 12)} themes=[${themes.join(',')}]`,
+    `${LOG_PREFIX} stored summary for user=${input.user_id.substring(0, 8)} session=${input.session_id.substring(0, 12)} themes=[${themes.join(',')}] source=${summarySource}`,
   );
 
   return { success: true, summary };
+}
+
+// =============================================================================
+// VTID-01990: Gemini Flash summarizer
+// =============================================================================
+
+/**
+ * Summarize a transcript with Gemini Flash. Returns null on any failure so
+ * the caller can fall back to the heuristic builder. Vertex AI primary,
+ * Gemini API key fallback — same pattern as inline-fact-extractor.
+ */
+export async function summarizeWithGeminiFlash(
+  turns: Array<{ role: 'user' | 'assistant'; text: string }>,
+): Promise<string | null> {
+  if (!turns || turns.length === 0) return null;
+
+  // Compact transcript, capped per-turn to keep token cost low
+  const transcript = turns
+    .map((t) => `${t.role === 'user' ? 'User' : 'Assistant'}: ${truncate(t.text.trim(), 400)}`)
+    .join('\n');
+
+  if (summaryVertexAI) {
+    try {
+      const model = summaryVertexAI.getGenerativeModel({
+        model: SUMMARY_MODEL,
+        generationConfig: { temperature: 0.2, maxOutputTokens: 200, topP: 0.8 },
+        systemInstruction: { role: 'system', parts: [{ text: SUMMARY_SYSTEM_PROMPT }] },
+      });
+      const response = await model.generateContent({
+        contents: [{ role: 'user', parts: [{ text: transcript }] }],
+      });
+      const candidate = response.response?.candidates?.[0];
+      const textPart = candidate?.content?.parts?.find((p: any) => 'text' in p);
+      const raw = textPart ? ((textPart as any).text || '').trim() : '';
+      if (raw.length > 0) return truncate(raw, MAX_SUMMARY_CHARS);
+    } catch (err: any) {
+      console.warn(`${LOG_PREFIX} Vertex summary failed: ${err.message}`);
+    }
+  }
+
+  if (GOOGLE_GEMINI_API_KEY) {
+    try {
+      const response = await fetch(
+        `https://generativelanguage.googleapis.com/v1beta/models/${SUMMARY_MODEL}:generateContent?key=${GOOGLE_GEMINI_API_KEY}`,
+        {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify({
+            contents: [{ parts: [{ text: transcript }] }],
+            systemInstruction: { parts: [{ text: SUMMARY_SYSTEM_PROMPT }] },
+            generationConfig: { temperature: 0.2, maxOutputTokens: 200 },
+          }),
+        },
+      );
+      if (response.ok) {
+        const data = (await response.json()) as any;
+        const raw = (data.candidates?.[0]?.content?.parts?.[0]?.text || '').trim();
+        if (raw.length > 0) return truncate(raw, MAX_SUMMARY_CHARS);
+      }
+    } catch (err: any) {
+      console.warn(`${LOG_PREFIX} Gemini API summary failed: ${err.message}`);
+    }
+  }
+
+  return null;
+}
+
+// =============================================================================
+// VTID-01990: today / yesterday bucketing for awareness
+// =============================================================================
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
+
+interface TodayWindow {
+  today_start_utc: string;
+  today_end_utc: string;
+  yesterday_start_utc: string;
+  yesterday_end_utc: string;
+}
+
+async function fetchTodayWindow(userId: string, userTz: string): Promise<TodayWindow | null> {
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) return null;
+  try {
+    const res = await fetch(`${SUPABASE_URL}/rest/v1/rpc/user_sessions_today_window`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: SUPABASE_SERVICE_ROLE,
+        Authorization: `Bearer ${SUPABASE_SERVICE_ROLE}`,
+      },
+      body: JSON.stringify({ p_user_id: userId, p_user_tz: userTz || 'UTC' }),
+    });
+    if (!res.ok) return null;
+    const arr = (await res.json()) as TodayWindow[];
+    return arr && arr.length > 0 ? arr[0] : null;
+  } catch (err: any) {
+    console.warn(`${LOG_PREFIX} fetchTodayWindow failed: ${err.message}`);
+    return null;
+  }
+}
+
+export interface SessionsTodayAndYesterday {
+  today: SessionSummary[];
+  yesterday_last: SessionSummary | null;
+}
+
+/**
+ * Cross-surface bucketing of recent session summaries into today and
+ * yesterday in the user's local timezone. Used by awareness-context to
+ * surface "this is your 3rd session today, last at 14:20" in the prompt.
+ *
+ * Returns the today list ordered ASC by ended_at (so the awareness prompt
+ * can render them in chronological order: "earlier today 09:14, then 11:30,
+ * then now"), and the most recent session that ended yesterday.
+ */
+export async function getSessionsTodayAndYesterday(
+  userId: string,
+  userTz: string = 'UTC',
+): Promise<SessionsTodayAndYesterday> {
+  const empty: SessionsTodayAndYesterday = { today: [], yesterday_last: null };
+
+  const supabase = getSupabase();
+  if (!supabase) return empty;
+
+  const window = await fetchTodayWindow(userId, userTz);
+  if (!window) return empty;
+
+  // Pull a small range covering both yesterday and today; bucket in JS.
+  const { data, error } = await supabase
+    .from('user_session_summaries')
+    .select('session_id, channel, summary, themes, turn_count, duration_ms, ended_at')
+    .eq('user_id', userId)
+    .gte('ended_at', window.yesterday_start_utc)
+    .lt('ended_at', window.today_end_utc)
+    .order('ended_at', { ascending: true });
+
+  if (error || !data) {
+    if (error) console.warn(`${LOG_PREFIX} getSessionsTodayAndYesterday read failed: ${error.message}`);
+    return empty;
+  }
+
+  const todayList: SessionSummary[] = [];
+  let yesterdayLast: SessionSummary | null = null;
+
+  for (const row of data as SessionSummary[]) {
+    const endedAt = row.ended_at;
+    if (endedAt >= window.today_start_utc && endedAt < window.today_end_utc) {
+      todayList.push(row);
+    } else if (endedAt >= window.yesterday_start_utc && endedAt < window.yesterday_end_utc) {
+      // last one wins (data is sorted ASC, so the newest yesterday row overwrites)
+      yesterdayLast = row;
+    }
+  }
+
+  return { today: todayList, yesterday_last: yesterdayLast };
 }
 
 // =============================================================================

--- a/services/gateway/src/services/guide/types.ts
+++ b/services/gateway/src/services/guide/types.ts
@@ -84,6 +84,27 @@ export interface UserAwareness {
     ended_at: string;
   }>;
 
+  // VTID-01990 — conversation tracking with timestamps. Cross-surface
+  // (voice + text + community + developer) — "this is the Nth session today,
+  // last at HH:MM" awareness so Vitana feels persistent across sessions.
+  sessions_today: {
+    count: number;
+    entries: Array<{
+      session_id: string;
+      channel: 'voice' | 'text';
+      summary: string;
+      themes: string[];
+      ended_at: string;
+    }>;
+  };
+  last_session_yesterday: {
+    session_id: string;
+    channel: 'voice' | 'text';
+    summary: string;
+    themes: string[];
+    ended_at: string;
+  } | null;
+
   // Phase E — D43 adaptation status (VTID-01935)
   // Null when adaptation_plans table doesn't exist yet (D43 doesn't write
   // there yet). When populated, shows pending vs applied plans.

--- a/services/gateway/src/services/idle-session-closer.ts
+++ b/services/gateway/src/services/idle-session-closer.ts
@@ -1,0 +1,262 @@
+/**
+ * VTID-01990: Idle Session Closer
+ *
+ * Background worker that finds text-channel threads idle for >= 4h and writes
+ * a session summary via recordSessionSummary (which itself calls Gemini Flash).
+ * Voice already writes its own summaries on disconnect from orb-live.ts; this
+ * closer handles the text-channel parity so the awareness builder sees text
+ * sessions in user_session_summaries too.
+ *
+ * Pattern mirrors self-healing-reconciler: setInterval, idempotent, swallows
+ * its own errors, no DB writes outside the canonical recordSessionSummary
+ * path. Runs every 5 minutes; closes threads whose last conversation_messages
+ * row is older than the configured idle threshold (default 4h, matching
+ * resolve_thread_id's default p_session_timeout_hours=4).
+ *
+ * Disabled when SUPABASE_URL / SUPABASE_SERVICE_ROLE missing, or when the
+ * IDLE_SESSION_CLOSER_ENABLED env var is explicitly 'false'.
+ */
+
+import { getSupabase } from '../lib/supabase';
+import { recordSessionSummary } from './guide/session-summaries';
+
+const LOG_PREFIX = '[VTID-01990:idle-session-closer]';
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
+
+const DEFAULT_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+const DEFAULT_IDLE_HOURS = 4; // matches resolve_thread_id's session timeout
+const MAX_THREADS_PER_CYCLE = 10;
+const MAX_TURNS_PER_SESSION = 50;
+
+let timer: NodeJS.Timeout | null = null;
+let running = false;
+let cycleInFlight = false;
+
+interface IdleThreadRow {
+  thread_id: string;
+  user_id: string;
+  tenant_id: string;
+  last_activity_at: string;
+  first_activity_at: string;
+  channel: string;
+  turn_count: number;
+}
+
+async function findIdleThreadsToSummarize(idleHours: number): Promise<IdleThreadRow[]> {
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) return [];
+
+  // PostgREST doesn't support GROUP BY + aggregates ergonomically — use the
+  // SQL endpoint pattern: a one-shot RPC would be cleaner, but we already
+  // have everything we need from the existing tables. Use a raw HTTP RPC
+  // call only if needed; for now, do a simpler approach: pull recent
+  // distinct threads from conversation_messages, then check each against
+  // user_session_summaries.
+  const cutoffIso = new Date(Date.now() - idleHours * 3600 * 1000).toISOString();
+  const supabase = getSupabase();
+  if (!supabase) return [];
+
+  // Step 1: list candidate text-channel threads with their newest activity.
+  // We grab a recent window so the closer doesn't scan the whole table.
+  const lookbackIso = new Date(Date.now() - 14 * 24 * 3600 * 1000).toISOString(); // last 14 days
+  const { data: msgs, error: msgErr } = await supabase
+    .from('conversation_messages')
+    .select('thread_id, user_id, tenant_id, channel, created_at')
+    .neq('channel', 'orb') // voice writes its own summaries via orb-live.ts
+    .gte('created_at', lookbackIso)
+    .order('created_at', { ascending: false })
+    .limit(2000);
+
+  if (msgErr) {
+    console.warn(`${LOG_PREFIX} message scan failed: ${msgErr.message}`);
+    return [];
+  }
+  if (!msgs || msgs.length === 0) return [];
+
+  // Reduce to (thread_id, user_id) -> { last_activity, first_activity, channel, turn_count }.
+  // The query is ordered DESC, so first occurrence per thread is the newest.
+  const byThread = new Map<
+    string,
+    { thread_id: string; user_id: string; tenant_id: string; channel: string; first: string; last: string; count: number }
+  >();
+  for (const row of msgs as Array<{
+    thread_id: string;
+    user_id: string;
+    tenant_id: string;
+    channel: string;
+    created_at: string;
+  }>) {
+    const key = row.thread_id;
+    const existing = byThread.get(key);
+    if (!existing) {
+      byThread.set(key, {
+        thread_id: row.thread_id,
+        user_id: row.user_id,
+        tenant_id: row.tenant_id,
+        channel: row.channel,
+        first: row.created_at,
+        last: row.created_at,
+        count: 1,
+      });
+    } else {
+      existing.count += 1;
+      // ascending oldest
+      if (row.created_at < existing.first) existing.first = row.created_at;
+      if (row.created_at > existing.last) existing.last = row.created_at;
+    }
+  }
+
+  // Filter to threads that are idle (last activity older than the cutoff)
+  const idle: IdleThreadRow[] = [];
+  for (const t of byThread.values()) {
+    if (t.last < cutoffIso) {
+      idle.push({
+        thread_id: t.thread_id,
+        user_id: t.user_id,
+        tenant_id: t.tenant_id,
+        last_activity_at: t.last,
+        first_activity_at: t.first,
+        channel: t.channel,
+        turn_count: t.count,
+      });
+    }
+  }
+  if (idle.length === 0) return [];
+
+  // Step 2: filter out threads that already have a summary
+  const sessionIds = idle.map((t) => t.thread_id);
+  const { data: existing, error: existingErr } = await supabase
+    .from('user_session_summaries')
+    .select('session_id, user_id')
+    .in('session_id', sessionIds);
+
+  if (existingErr) {
+    console.warn(`${LOG_PREFIX} existing-summary check failed: ${existingErr.message}`);
+    return [];
+  }
+  const existingKeys = new Set<string>();
+  for (const row of (existing || []) as Array<{ session_id: string; user_id: string }>) {
+    existingKeys.add(`${row.user_id}::${row.session_id}`);
+  }
+
+  const ready = idle.filter((t) => !existingKeys.has(`${t.user_id}::${t.thread_id}`));
+  // Sort newest-first so the most recently idle threads close first
+  ready.sort((a, b) => (a.last_activity_at < b.last_activity_at ? 1 : -1));
+  return ready.slice(0, MAX_THREADS_PER_CYCLE);
+}
+
+async function fetchTranscript(
+  threadId: string,
+): Promise<Array<{ role: 'user' | 'assistant'; text: string }>> {
+  const supabase = getSupabase();
+  if (!supabase) return [];
+
+  const { data, error } = await supabase
+    .from('conversation_messages')
+    .select('role, content, created_at')
+    .eq('thread_id', threadId)
+    .order('created_at', { ascending: true })
+    .limit(MAX_TURNS_PER_SESSION);
+
+  if (error || !data) {
+    if (error) console.warn(`${LOG_PREFIX} transcript fetch failed: ${error.message}`);
+    return [];
+  }
+
+  return (data as Array<{ role: string; content: string }>).map((m) => ({
+    role: (m.role === 'assistant' ? 'assistant' : 'user') as 'user' | 'assistant',
+    text: m.content || '',
+  }));
+}
+
+async function closeOne(thread: IdleThreadRow): Promise<void> {
+  const turns = await fetchTranscript(thread.thread_id);
+  if (turns.length === 0) {
+    console.log(`${LOG_PREFIX} thread ${thread.thread_id.slice(0, 12)} has no turns — skipping`);
+    return;
+  }
+
+  const durationMs =
+    new Date(thread.last_activity_at).getTime() - new Date(thread.first_activity_at).getTime();
+
+  const result = await recordSessionSummary({
+    user_id: thread.user_id,
+    session_id: thread.thread_id,
+    channel: 'text',
+    transcript_turns: turns,
+    duration_ms: durationMs > 0 ? durationMs : null,
+  });
+
+  if (!result.success) {
+    console.warn(
+      `${LOG_PREFIX} closeOne failed thread=${thread.thread_id.slice(0, 12)} error=${result.error}`,
+    );
+  } else {
+    console.log(
+      `${LOG_PREFIX} closed thread=${thread.thread_id.slice(0, 12)} user=${thread.user_id.slice(0, 8)} turns=${turns.length}`,
+    );
+  }
+}
+
+async function runCycle(idleHours: number): Promise<void> {
+  if (cycleInFlight) {
+    console.log(`${LOG_PREFIX} cycle already in flight — skipping`);
+    return;
+  }
+  cycleInFlight = true;
+  try {
+    const threads = await findIdleThreadsToSummarize(idleHours);
+    if (threads.length === 0) return;
+    console.log(`${LOG_PREFIX} closing ${threads.length} idle thread(s)`);
+    // Sequential to keep Gemini Flash QPS predictable; cycle is bounded.
+    for (const t of threads) {
+      try {
+        await closeOne(t);
+      } catch (err: any) {
+        console.warn(`${LOG_PREFIX} closeOne threw: ${err.message}`);
+      }
+    }
+  } catch (err: any) {
+    console.warn(`${LOG_PREFIX} cycle error: ${err.message}`);
+  } finally {
+    cycleInFlight = false;
+  }
+}
+
+export function startIdleSessionCloser(): void {
+  if (running) {
+    console.log(`${LOG_PREFIX} already running`);
+    return;
+  }
+  if ((process.env.IDLE_SESSION_CLOSER_ENABLED ?? 'true').toLowerCase() === 'false') {
+    console.log(`${LOG_PREFIX} disabled via IDLE_SESSION_CLOSER_ENABLED=false`);
+    return;
+  }
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
+    console.warn(`${LOG_PREFIX} Supabase credentials missing — closer not started`);
+    return;
+  }
+
+  const intervalMs = parseInt(
+    process.env.IDLE_SESSION_CLOSER_INTERVAL_MS || String(DEFAULT_INTERVAL_MS),
+    10,
+  );
+  const idleHours = parseInt(process.env.IDLE_SESSION_CLOSER_IDLE_HOURS || String(DEFAULT_IDLE_HOURS), 10);
+
+  running = true;
+  // First cycle 60s after boot so the gateway is warm
+  setTimeout(() => void runCycle(idleHours), 60_000);
+  timer = setInterval(() => void runCycle(idleHours), intervalMs);
+  console.log(
+    `🗂️  VTID-01990 idle-session-closer started (interval=${intervalMs}ms, idle_threshold=${idleHours}h)`,
+  );
+}
+
+export function stopIdleSessionCloser(): void {
+  if (timer) {
+    clearInterval(timer);
+    timer = null;
+  }
+  running = false;
+  console.log(`${LOG_PREFIX} stopped`);
+}

--- a/services/gateway/src/services/tool-recall-conversation.ts
+++ b/services/gateway/src/services/tool-recall-conversation.ts
@@ -1,0 +1,370 @@
+/**
+ * VTID-01990: recall_conversation_at_time tool handler
+ *
+ * When the user says something like "we talked yesterday morning about my
+ * company" or "earlier today we discussed sleep", Gemini emits a function
+ * call to this tool. The handler:
+ *
+ *   1. Parses the time hint into a [since, until] window in the user's
+ *      local timezone (DE + EN supported).
+ *   2. Calls the recall_at_time_range RPC for matched session summaries +
+ *      conversation_messages excerpts + memory_facts in that window.
+ *   3. Shapes the result for the LLM tool reply.
+ *
+ * Read-only. Safe by construction — RPC scopes by user_id internally.
+ */
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
+
+export interface RecallToolArgs {
+  time_hint: string;
+  topic_hint?: string;
+}
+
+export interface RecallToolResult {
+  ok: boolean;
+  error?: string;
+  resolved_window?: { since: string; until: string; label: string };
+  matched_session?: {
+    session_id: string;
+    channel: 'voice' | 'text';
+    ended_at: string;
+    summary: string;
+    themes: string[];
+  };
+  excerpts?: Array<{
+    role: 'user' | 'assistant';
+    channel: string;
+    content: string;
+    created_at: string;
+  }>;
+  related_facts?: Array<{
+    fact_key: string;
+    fact_value: string;
+    extracted_at: string;
+  }>;
+  neighbors?: Array<{ ended_at: string; summary: string; themes: string[] }>;
+}
+
+/**
+ * Resolve a free-text time hint to a UTC [since, until) window in the user's
+ * local timezone. Returns null when the hint can't be parsed.
+ */
+export function resolveTimeHint(
+  hint: string,
+  userTz: string = 'UTC',
+  now: Date = new Date(),
+): { since: Date; until: Date; label: string } | null {
+  const raw = hint.trim().toLowerCase();
+  if (!raw) return null;
+
+  // Buckets in the user's local day. Anchored to local midnight.
+  // Computed in UTC against a virtual local-midnight.
+  const tzNow = localDayParts(now, userTz);
+
+  const todayStartUTC = utcInstantOfLocalMidnight(tzNow.localYear, tzNow.localMonth, tzNow.localDay, userTz);
+  const oneDay = 24 * 3600 * 1000;
+
+  type TimeBucket = { startHour: number; endHour: number; label: string };
+  const buckets: Record<string, TimeBucket> = {
+    morning: { startHour: 5, endHour: 12, label: 'morning' },
+    noon: { startHour: 11, endHour: 14, label: 'noon' },
+    midday: { startHour: 11, endHour: 14, label: 'midday' },
+    afternoon: { startHour: 12, endHour: 18, label: 'afternoon' },
+    evening: { startHour: 17, endHour: 22, label: 'evening' },
+    tonight: { startHour: 17, endHour: 22, label: 'tonight' },
+    night: { startHour: 21, endHour: 29, label: 'night' }, // wraps past midnight
+    late: { startHour: 21, endHour: 29, label: 'late' },
+  };
+
+  // Locale dictionary — maps DE phrases into the same bucket keys
+  const dayOffsets: Array<{ rx: RegExp; offset: number; label: string }> = [
+    { rx: /\b(today|heute)\b/, offset: 0, label: 'today' },
+    { rx: /\b(yesterday|gestern)\b/, offset: -1, label: 'yesterday' },
+    { rx: /\b(day before yesterday|vorgestern)\b/, offset: -2, label: 'day-before-yesterday' },
+  ];
+  const bucketAliases: Array<{ rx: RegExp; key: keyof typeof buckets }> = [
+    { rx: /\b(morning|morgens|in der frueh|am morgen|heute morgen)\b/, key: 'morning' },
+    { rx: /\b(noon|mittag|mittags)\b/, key: 'noon' },
+    { rx: /\b(afternoon|nachmittag|nachmittags)\b/, key: 'afternoon' },
+    { rx: /\b(evening|abend|abends|tonight|heute abend)\b/, key: 'evening' },
+    { rx: /\b(night|nacht|nachts|late|spaet|spät|letzte nacht|last night)\b/, key: 'night' },
+  ];
+
+  // "N days ago" / "vor N Tagen"
+  const daysAgoMatch = raw.match(/\b(\d+)\s*(days?\s*ago|tagen?\s+her|tagen?)\b/);
+  if (daysAgoMatch) {
+    const n = parseInt(daysAgoMatch[1], 10);
+    if (Number.isFinite(n) && n >= 0 && n <= 30) {
+      const start = new Date(todayStartUTC.getTime() - n * oneDay);
+      const end = new Date(start.getTime() + oneDay);
+      return { since: start, until: end, label: `${n} days ago` };
+    }
+  }
+
+  // "last <weekday>" / "letzten <Wochentag>"
+  const weekdays: Array<[RegExp, number]> = [
+    [/\b(monday|montag)\b/, 1],
+    [/\b(tuesday|dienstag)\b/, 2],
+    [/\b(wednesday|mittwoch)\b/, 3],
+    [/\b(thursday|donnerstag)\b/, 4],
+    [/\b(friday|freitag)\b/, 5],
+    [/\b(saturday|samstag|sonnabend)\b/, 6],
+    [/\b(sunday|sonntag)\b/, 0],
+  ];
+  if (/\b(last|letzten?)\b/.test(raw) || /\bvergangenen\b/.test(raw)) {
+    for (const [rx, dow] of weekdays) {
+      if (rx.test(raw)) {
+        // Most recent past <dow>
+        const todayDow = new Date(todayStartUTC).getUTCDay();
+        let delta = todayDow - dow;
+        if (delta <= 0) delta += 7;
+        const start = new Date(todayStartUTC.getTime() - delta * oneDay);
+        const end = new Date(start.getTime() + oneDay);
+        return { since: start, until: end, label: `last ${dow}` };
+      }
+    }
+  }
+
+  // Day-anchored buckets (today/yesterday/etc + optional bucket)
+  let dayOffset: number | null = null;
+  let dayLabel = 'today';
+  for (const dy of dayOffsets) {
+    if (dy.rx.test(raw)) {
+      dayOffset = dy.offset;
+      dayLabel = dy.label;
+      break;
+    }
+  }
+  // Bucket may appear standalone ("morning" => today's morning)
+  let bucketKey: keyof typeof buckets | null = null;
+  for (const ba of bucketAliases) {
+    if (ba.rx.test(raw)) {
+      bucketKey = ba.key;
+      break;
+    }
+  }
+
+  if (dayOffset === null && bucketKey === null) {
+    return null; // Unparseable
+  }
+
+  const day = dayOffset ?? 0;
+  const dayStartUtc = new Date(todayStartUTC.getTime() + day * oneDay);
+
+  if (!bucketKey) {
+    // Whole day
+    return {
+      since: dayStartUtc,
+      until: new Date(dayStartUtc.getTime() + oneDay),
+      label: dayLabel,
+    };
+  }
+
+  const b = buckets[bucketKey];
+  // Bucket bounds expressed as offsets-from-local-midnight, then converted to UTC
+  const since = new Date(dayStartUtc.getTime() + b.startHour * 3600 * 1000);
+  const until = new Date(dayStartUtc.getTime() + b.endHour * 3600 * 1000);
+  return { since, until, label: `${dayLabel} ${b.label}` };
+}
+
+function localDayParts(now: Date, tz: string): { localYear: number; localMonth: number; localDay: number } {
+  try {
+    const fmt = new Intl.DateTimeFormat('en-CA', {
+      timeZone: tz,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    });
+    const parts = fmt.formatToParts(now).reduce<Record<string, string>>((acc, p) => {
+      if (p.type !== 'literal') acc[p.type] = p.value;
+      return acc;
+    }, {});
+    return {
+      localYear: parseInt(parts.year || '1970', 10),
+      localMonth: parseInt(parts.month || '1', 10),
+      localDay: parseInt(parts.day || '1', 10),
+    };
+  } catch {
+    return { localYear: now.getUTCFullYear(), localMonth: now.getUTCMonth() + 1, localDay: now.getUTCDate() };
+  }
+}
+
+function utcInstantOfLocalMidnight(year: number, month: number, day: number, tz: string): Date {
+  // Compute the UTC instant that is local-midnight in the given tz on the given date.
+  // Approach: build a UTC date, then shift by the tz offset at that instant.
+  const utcMidnight = Date.UTC(year, month - 1, day, 0, 0, 0, 0);
+  // Get the tz's offset at that approximate instant
+  try {
+    const fmt = new Intl.DateTimeFormat('en-CA', {
+      timeZone: tz,
+      hour12: false,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+      hour: '2-digit',
+      minute: '2-digit',
+      second: '2-digit',
+    });
+    const parts = fmt.formatToParts(new Date(utcMidnight)).reduce<Record<string, string>>((acc, p) => {
+      if (p.type !== 'literal') acc[p.type] = p.value;
+      return acc;
+    }, {});
+    const localAsUTC = Date.UTC(
+      parseInt(parts.year, 10),
+      parseInt(parts.month, 10) - 1,
+      parseInt(parts.day, 10),
+      parseInt(parts.hour, 10),
+      parseInt(parts.minute, 10),
+      parseInt(parts.second, 10),
+    );
+    const offset = localAsUTC - utcMidnight;
+    return new Date(utcMidnight - offset);
+  } catch {
+    return new Date(utcMidnight);
+  }
+}
+
+export async function executeRecallConversationAtTime(
+  args: RecallToolArgs,
+  context: { user_id: string; user_timezone?: string },
+): Promise<RecallToolResult> {
+  if (!args || typeof args.time_hint !== 'string' || args.time_hint.trim().length === 0) {
+    return { ok: false, error: 'missing_time_hint' };
+  }
+  if (!context.user_id) {
+    return { ok: false, error: 'missing_user_context' };
+  }
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
+    return { ok: false, error: 'storage_unavailable' };
+  }
+
+  const tz = context.user_timezone || 'UTC';
+  const window = resolveTimeHint(args.time_hint, tz);
+  if (!window) {
+    return { ok: false, error: 'ambiguous_time' };
+  }
+
+  // Cap window to avoid runaway scans (max 7 days)
+  const maxSpanMs = 7 * 24 * 3600 * 1000;
+  if (window.until.getTime() - window.since.getTime() > maxSpanMs) {
+    return { ok: false, error: 'window_too_wide' };
+  }
+
+  try {
+    const res = await fetch(`${SUPABASE_URL}/rest/v1/rpc/recall_at_time_range`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: SUPABASE_SERVICE_ROLE,
+        Authorization: `Bearer ${SUPABASE_SERVICE_ROLE}`,
+      },
+      body: JSON.stringify({
+        p_user_id: context.user_id,
+        p_since: window.since.toISOString(),
+        p_until: window.until.toISOString(),
+        p_topic_hint: args.topic_hint || null,
+      }),
+    });
+    if (!res.ok) {
+      return { ok: false, error: `rpc_${res.status}` };
+    }
+    const data = (await res.json()) as any;
+    if (!data || !data.ok) {
+      return { ok: false, error: data?.error || 'rpc_failed' };
+    }
+    const sessions = (data.sessions || []) as Array<any>;
+    const excerpts = (data.excerpts || []) as Array<any>;
+    const facts = (data.facts || []) as Array<any>;
+
+    const result: RecallToolResult = {
+      ok: true,
+      resolved_window: {
+        since: window.since.toISOString(),
+        until: window.until.toISOString(),
+        label: window.label,
+      },
+      excerpts: excerpts.map((e) => ({
+        role: e.role,
+        channel: e.channel,
+        content: e.content,
+        created_at: e.created_at,
+      })),
+      related_facts: facts.map((f) => ({
+        fact_key: f.fact_key,
+        fact_value: f.fact_value,
+        extracted_at: f.extracted_at,
+      })),
+    };
+
+    if (sessions.length > 0) {
+      const top = sessions[0];
+      result.matched_session = {
+        session_id: top.session_id,
+        channel: top.channel,
+        ended_at: top.ended_at,
+        summary: top.summary,
+        themes: top.themes || [],
+      };
+    } else if (excerpts.length === 0) {
+      // No session AND no turns in this window → tell the LLM there was no
+      // conversation, and offer the nearest neighbors so it can clarify.
+      const neighbors = await fetchNearestNeighbors(context.user_id, window.since);
+      return {
+        ok: false,
+        error: 'no_session_in_window',
+        resolved_window: {
+          since: window.since.toISOString(),
+          until: window.until.toISOString(),
+          label: window.label,
+        },
+        neighbors,
+      };
+    }
+    return result;
+  } catch (err: any) {
+    console.warn(`[VTID-01990:recall] RPC call failed: ${err.message}`);
+    return { ok: false, error: 'rpc_exception' };
+  }
+}
+
+async function fetchNearestNeighbors(
+  userId: string,
+  anchor: Date,
+): Promise<Array<{ ended_at: string; summary: string; themes: string[] }>> {
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) return [];
+  // Find one before and one after the anchor
+  try {
+    const before = await fetch(
+      `${SUPABASE_URL}/rest/v1/user_session_summaries?select=ended_at,summary,themes&user_id=eq.${userId}&ended_at=lt.${encodeURIComponent(anchor.toISOString())}&order=ended_at.desc&limit=1`,
+      {
+        headers: {
+          apikey: SUPABASE_SERVICE_ROLE,
+          Authorization: `Bearer ${SUPABASE_SERVICE_ROLE}`,
+        },
+      },
+    );
+    const after = await fetch(
+      `${SUPABASE_URL}/rest/v1/user_session_summaries?select=ended_at,summary,themes&user_id=eq.${userId}&ended_at=gte.${encodeURIComponent(anchor.toISOString())}&order=ended_at.asc&limit=1`,
+      {
+        headers: {
+          apikey: SUPABASE_SERVICE_ROLE,
+          Authorization: `Bearer ${SUPABASE_SERVICE_ROLE}`,
+        },
+      },
+    );
+    const out: Array<{ ended_at: string; summary: string; themes: string[] }> = [];
+    if (before.ok) {
+      const arr = (await before.json()) as any[];
+      if (arr && arr[0]) out.push({ ended_at: arr[0].ended_at, summary: arr[0].summary, themes: arr[0].themes || [] });
+    }
+    if (after.ok) {
+      const arr = (await after.json()) as any[];
+      if (arr && arr[0]) out.push({ ended_at: arr[0].ended_at, summary: arr[0].summary, themes: arr[0].themes || [] });
+    }
+    return out;
+  } catch {
+    return [];
+  }
+}

--- a/services/gateway/src/services/tool-registry.ts
+++ b/services/gateway/src/services/tool-registry.ts
@@ -187,6 +187,34 @@ const TOOL_REGISTRY: Map<string, ToolDefinition> = new Map([
       vtid: 'VTID-01085',
     },
   ],
+  [
+    'recall_conversation_at_time',
+    {
+      name: 'recall_conversation_at_time',
+      description:
+        'Retrieve a past conversation by time reference. Call this when the user mentions a past conversation by time — e.g. "we talked yesterday morning about my company", "earlier today we discussed sleep", "last Tuesday afternoon you said...". Resolves the time hint to a window in the user\'s local timezone and returns the matching session summary, the actual conversation turns, and any facts extracted in that window. Use the returned excerpts to quote what was actually said — do not paraphrase from the summary alone.',
+      parameters_schema: {
+        type: 'object',
+        properties: {
+          time_hint: {
+            type: 'string',
+            description:
+              'Free-text time reference exactly as the user phrased it. Examples: "yesterday morning", "this morning", "last Tuesday afternoon", "2 days ago", "yesterday", "tonight". German also supported: "gestern morgen", "heute abend", "letzten Montag", "vor 3 Tagen".',
+          },
+          topic_hint: {
+            type: 'string',
+            description:
+              'Optional topic the user mentioned, used to disambiguate when multiple sessions match the time window. Examples: "my company", "sleep", "weight goal".',
+          },
+        },
+        required: ['time_hint'],
+      },
+      allowed_roles: ['operator', 'admin', 'developer', 'user', 'system'],
+      enabled: true,
+      category: 'memory',
+      vtid: 'VTID-01990',
+    },
+  ],
 
   // ===== System Tools =====
   [
@@ -1092,7 +1120,7 @@ export async function runToolHealthChecks(): Promise<ToolHealthResponse> {
   const supabaseAvailable = !!SUPABASE_URL && !!SUPABASE_SERVICE_ROLE;
 
   // Update health for Supabase-dependent tools
-  const supabaseTools = ['autopilot_create_task', 'autopilot_get_status', 'autopilot_list_recent_tasks', 'knowledge_search', 'memory_write', 'memory_search', 'discover_oasis_tasks', 'dev_list_tasks', 'dev_get_task_detail', 'dev_generate_spec', 'dev_get_spec', 'dev_validate_spec', 'dev_quality_check', 'dev_approve_spec', 'dev_list_approvals', 'dev_approval_count', 'dev_approve_item', 'dev_reject_item', 'dev_query_oasis_events'];
+  const supabaseTools = ['autopilot_create_task', 'autopilot_get_status', 'autopilot_list_recent_tasks', 'knowledge_search', 'memory_write', 'memory_search', 'recall_conversation_at_time', 'discover_oasis_tasks', 'dev_list_tasks', 'dev_get_task_detail', 'dev_generate_spec', 'dev_get_spec', 'dev_validate_spec', 'dev_quality_check', 'dev_approve_spec', 'dev_list_approvals', 'dev_approval_count', 'dev_approve_item', 'dev_reject_item', 'dev_query_oasis_events'];
   for (const toolName of supabaseTools) {
     updateToolHealth(
       toolName,

--- a/services/gateway/src/services/vitana-brain.ts
+++ b/services/gateway/src/services/vitana-brain.ts
@@ -359,6 +359,7 @@ export async function buildBrainSystemInstruction(input: {
       tenant_id: input.tenant_id,
       role: input.role,
       channel: input.channel,
+      user_timezone: input.user_timezone,
     }),
     buildIdentityGuardrailBlock({ user_id: input.user_id, tenant_id: input.tenant_id }),
   ]);
@@ -491,6 +492,8 @@ export async function buildProactiveGuideBlock(input: {
   tenant_id: string;
   role: string;
   channel: ConversationChannel;
+  /** VTID-01990: optional IANA tz so awareness today/yesterday bucketing is local-day correct */
+  user_timezone?: string;
 }): Promise<string> {
   const flag = await getSystemControl('vitana_proactive_opener_enabled').catch(() => null);
   if (!flag || !flag.enabled) {
@@ -503,7 +506,7 @@ export async function buildProactiveGuideBlock(input: {
   // Compute the unified awareness picture ONCE — every downstream signal flows from it
   let awareness: UserAwareness | null = null;
   try {
-    awareness = await getAwarenessContext(input.user_id, input.tenant_id);
+    awareness = await getAwarenessContext(input.user_id, input.tenant_id, input.user_timezone || 'UTC');
   } catch (err: any) {
     console.warn(`${LOG_PREFIX} getAwarenessContext failed:`, err?.message);
   }
@@ -1018,6 +1021,46 @@ function buildAwarenessBlock(awareness: UserAwareness | null): string {
     }
     lines.push(
       'Weave one of these into the conversation when natural — never recite the summary verbatim. Examples: "last time we talked about your sleep — how did that wind-down ritual go?", "you mentioned the business hub yesterday — any progress?".',
+    );
+  }
+
+  // VTID-01990 — cross-surface conversation tracking. Surfaces "this is your
+  // Nth session today" + per-session timestamps + yesterday's last session
+  // so Vitana feels persistent across sessions. When the user references a
+  // past time ("we talked yesterday morning..."), the recall_conversation_at_time
+  // tool resolves the window and fetches actual turns; this block tells the
+  // brain that recall is possible.
+  const sessionsToday = awareness.sessions_today;
+  const yesterdayLast = awareness.last_session_yesterday;
+  if ((sessionsToday && sessionsToday.count > 0) || yesterdayLast) {
+    if (sessionsToday && sessionsToday.count > 0) {
+      const n = sessionsToday.count + 1;
+      const suffix = (() => {
+        const v = n % 100;
+        if (v >= 11 && v <= 13) return 'th';
+        const last = n % 10;
+        return last === 1 ? 'st' : last === 2 ? 'nd' : last === 3 ? 'rd' : 'th';
+      })();
+      lines.push(`Sessions today: ${sessionsToday.count} prior (this is the ${n}${suffix}).`);
+      const entries = sessionsToday.entries.slice(-4);
+      for (const e of entries) {
+        const hhmm = e.ended_at.slice(11, 16);
+        const themes = (e.themes || []).slice(0, 3).join(', ');
+        const summary = e.summary && e.summary.length > 240 ? e.summary.slice(0, 239) + '…' : e.summary || '';
+        lines.push(`  - ${hhmm} (${e.channel})${themes ? ` themes: ${themes}` : ''} — ${summary}`);
+      }
+    }
+    if (yesterdayLast) {
+      const hhmm = yesterdayLast.ended_at.slice(11, 16);
+      const themes = (yesterdayLast.themes || []).slice(0, 3).join(', ');
+      const summary =
+        yesterdayLast.summary && yesterdayLast.summary.length > 240
+          ? yesterdayLast.summary.slice(0, 239) + '…'
+          : yesterdayLast.summary || '';
+      lines.push(`Yesterday's last session ${hhmm}${themes ? ` themes: ${themes}` : ''} — ${summary}`);
+    }
+    lines.push(
+      'When the user references a past conversation by time ("we talked yesterday morning...", "earlier today we discussed..."), call recall_conversation_at_time to fetch the actual turns. Do not invent details from these summaries alone.',
     );
   }
 

--- a/services/gateway/test/dyk-tour.test.ts
+++ b/services/gateway/test/dyk-tour.test.ts
@@ -55,6 +55,8 @@ function makeAwareness(overrides: Partial<UserAwareness> = {}): UserAwareness {
     adaptation_plans: null,
     routines: [],
     tastes_preferences: null,
+    sessions_today: { count: 0, entries: [] },
+    last_session_yesterday: null,
   };
   return {
     ...base,


### PR DESCRIPTION
## Summary

End-to-end implementation of cross-surface conversation tracking. Migration RPCs landed in #1002; this PR wires the gateway up to use them. Default-on.

## What this gives Vitana

1. **"This is your 3rd session today, last at 14:20"** — surfaced in every system prompt (text + voice + community + developer). Counts pool across all surfaces per the user's "one Vitana" choice.

2. **Yesterday's last session injected** — *"yesterday 18:47, themes: business, identity — User shared they work for Exafy, building Vitana"*.

3. **recall_conversation_at_time tool** — when the user says *"we talked yesterday morning about X, don't you remember?"*, Gemini calls it. The handler resolves the hint to a window in the user's local timezone (DE + EN parsing), then calls the recall_at_time_range RPC for the matched session summary + actual conversation_messages turns + memory_facts in the window. LLM then quotes what was actually said.

## Components

- **types.ts** — UserAwareness gains sessions_today + last_session_yesterday
- **session-summaries.ts** —
  - summarizeWithGeminiFlash (Vertex primary, API key fallback)
  - recordSessionSummary now LLM-summarizes by default, heuristic fallback
  - getSessionsTodayAndYesterday bucketed via user_sessions_today_window RPC
- **awareness-context.ts** — userTz threaded through; new fields fetched in the existing Promise.all
- **awareness-prompt.ts** — renders "Sessions today: N" block with hh:mm + themes + summary
- **vitana-brain.ts** — passes user_timezone into awareness; richer voice formatter weaves the same block
- **conversation-client.ts** — passes ui_context.metadata.timezone to awareness
- **idle-session-closer.ts** *(new)* — setInterval worker, closes text threads idle ≥ 4h via recordSessionSummary. Voice already self-closes on disconnect
- **tool-recall-conversation.ts** *(new)* — time-hint parser (yesterday morning, last Tuesday afternoon, 2 days ago, gestern abend, etc.) + recall_at_time_range RPC caller
- **tool-registry.ts** — recall_conversation_at_time registered with role-gating
- **gemini-operator.ts** — executeTool dispatch for the new tool

## Behavior toggles (all default-on)

- IDLE_SESSION_CLOSER_ENABLED — closer worker
- IDLE_SESSION_CLOSER_INTERVAL_MS (default 5min)
- IDLE_SESSION_CLOSER_IDLE_HOURS (default 4h, matches resolve_thread_id timeout)
- PRESENCE_CHAT_AWARENESS_ENABLED — text-channel awareness inject (pre-existing)

## Plan

`~/.claude/plans/yes-make-a-plan-adaptive-dragon.md`

## Test plan

- [x] tsc --noEmit passes
- [ ] Deploy gateway via EXEC-DEPLOY
- [ ] Open conversation, send a message, force-close via running closer cycle, verify user_session_summaries row written with channel='text' and an LLM summary
- [ ] Open new conversation, verify system instruction contains "Sessions today" or "Yesterday's last session"
- [ ] Voice conversation: say "yesterday morning we discussed X" — expect Gemini to call recall_conversation_at_time and quote the actual turns

🤖 Generated with [Claude Code](https://claude.com/claude-code)