### PR TITLE
feat(og-proxy): route /shorts/&lt;id&gt; through new og-short Supabase function

### DIFF
--- a/cloudflare/vitanaland-og-proxy/worker.js
+++ b/cloudflare/vitanaland-og-proxy/worker.js
@@ -9,7 +9,7 @@ function isCrawler(ua) {
 }
 
 function parseRoute(pathname) {
-  const match = pathname.match(/^\/(events|profiles|rooms|matches|products)\/(.+)$/);
+  const match = pathname.match(/^\/(events|profiles|rooms|matches|products|shorts)\/(.+)$/);
   if (match) return { type: match[1], identifier: match[2] };
   // Handle /pub/events/{id} format
   const pubMatch = pathname.match(/^\/pub\/events\/(.+)$/);
@@ -231,6 +231,8 @@ function getOgFunctionUrl(type, identifier) {
       return `${SUPABASE_FUNCTIONS}/og-room?id=${encodeURIComponent(identifier)}`;
     case 'matches':
       return `${SUPABASE_FUNCTIONS}/og-match?id=${encodeURIComponent(identifier)}`;
+    case 'shorts':
+      return `${SUPABASE_FUNCTIONS}/og-short?id=${encodeURIComponent(identifier)}`;
     // products handled inline below via renderProductOg() — no Supabase Function needed
     default:
       return null;
@@ -253,6 +255,8 @@ function getRedirectUrl(type, identifier) {
       return `https://vitanaland.com/discover?m=${encodeURIComponent(identifier)}`;
     case 'products':
       return `https://vitanaland.com/discover/product/${encodeURIComponent(identifier)}`;
+    case 'shorts':
+      return `https://vitanaland.com/comm/media-hub?short=${encodeURIComponent(identifier)}`;
     default:
       return 'https://vitanaland.com';
   }


### PR DESCRIPTION
## Summary

Routes `/shorts/<id>` on `e.vitanaland.com` through the new `og-short` Supabase Edge Function (lives in the `vitana-v1` repo) so shared Short links unfurl with a rich preview (thumbnail + title + creator). Crawlers get the OG HTML; humans 302 to `vitanaland.com/comm/media-hub?short=<id>`, where the frontend auto-opens that short.

This mirrors the existing events/rooms/matches delegation pattern in `worker.js` — no new auth, no new envs, no inline rendering.

Companion PR (frontend + edge function): exafyltd/vitana-v1#TBD on branch `claude/fix-shorts-share-button-w4Bde`.

## Deploy order — IMPORTANT

Out of order = broken share links in flight.

1. Deploy `og-short` Supabase function from `vitana-v1` first.
2. Merge this PR, then `wrangler deploy` from `cloudflare/vitanaland-og-proxy/`.
3. Smoke-test (test plan below).
4. Merge the `vitana-v1` PR.

## Test plan

After deploy:

- [ ] `curl -s -A "WhatsApp/2.0" "https://e.vitanaland.com/shorts/<published-short-id>" | grep -E 'og:title|og:image|og:description'` returns the short's metadata.
- [ ] `curl -sI -A "Mozilla/5.0" "https://e.vitanaland.com/shorts/<id>"` returns 302 to `https://vitanaland.com/comm/media-hub?short=<id>`.
- [ ] `curl -s "https://e.vitanaland.com/shorts/<bogus-uuid>"` returns the generic fallback (no 5xx).
- [ ] Regression: events/profiles/products/rooms/matches still unfurl correctly.

https://claude.ai/code/session_01QzJF9RoNoBVoLPHwFRhJXP

---
_Generated by [Claude Code](https://claude.ai/code/session_01QzJF9RoNoBVoLPHwFRhJXP)_