### PR TITLE
chore(initiative): flip V2 Initiative Engine flag ON for voice smoke (BOOTSTRAP-PROACTIVE-INITIATIVE)

### DIFF
--- a/supabase/migrations/20260428010000_initiative_flag_on.sql
+++ b/supabase/migrations/20260428010000_initiative_flag_on.sql
@@ -1,0 +1,17 @@
+-- BOOTSTRAP-PROACTIVE-INITIATIVE — flip V2 Initiative Engine flag ON.
+-- Mirrors the DYK flag-flip pattern from PR #896. Idempotent — re-running
+-- is a no-op.
+--
+-- Plan: .claude/plans/proactive-did-you-generic-sifakis.md (V2 §Rollout step 3).
+
+UPDATE public.system_controls
+SET enabled = TRUE,
+    updated_at = NOW(),
+    updated_by = 'BOOTSTRAP-PROACTIVE-INITIATIVE-SMOKE',
+    updated_by_role = 'system',
+    reason = 'V2 Proactive Initiative Engine: backend route + tool + brain block deployed (PR #1012). Enabling for voice smoke.'
+WHERE key = 'vitana_proactive_initiative_enabled';
+
+SELECT key, enabled, updated_at, reason
+FROM public.system_controls
+WHERE key = 'vitana_proactive_initiative_enabled';


### PR DESCRIPTION
One-shot SQL: `UPDATE system_controls SET enabled=TRUE WHERE key='vitana_proactive_initiative_enabled'`. Idempotent. Backend (PR #1012) is deployed and verified — flag default-FALSE was confirmed via `/api/v1/governance/controls`. Run via RUN-MIGRATION.yml after merge to start the initiative offer firing on ORB session start.