### PR TITLE
feat(self-healing): surface successful auto-fixes to the screen (VTID-02001)

### DIFF
--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -38,7 +38,7 @@ import {
 } from './dev-autopilot-safety';
 import { extractFilePaths, generatePlanVersion } from './dev-autopilot-planning';
 import { isWorkerQueueEnabled, isWorkerOwnsPrEnabled, runWorkerTask, reclaimStuckWorkerTasks, reclaimStuckPendingWorkerTasks, type WorkerAttemptFailure } from './dev-autopilot-worker-queue';
-import { writeAutopilotFailure } from './dev-autopilot-self-heal-log';
+import { writeAutopilotFailure, writeAutopilotSuccess } from './dev-autopilot-self-heal-log';
 import { recordOutcome, recordExecOutcome } from './dev-autopilot-outcomes';
 
 const LOG_PREFIX = '[dev-autopilot-execute]';
@@ -1134,6 +1134,75 @@ async function patchExecution(
         }
       } catch (err) {
         console.warn(`${LOG_PREFIX} outcome backfill error for ${id.slice(0, 8)}:`, err);
+      }
+    })();
+  }
+
+  // VTID-02001: surface successful auto-fixes to the Self-Healing screen.
+  // self_healing_log was a failure-only log; without this the screen shows
+  // 100% escalation and the user can't tell autonomy is actually closing
+  // findings. We record `fixed` for `completed` and `rolled_back` for
+  // `reverted`. `failed_escalated` is already covered by the bridge writer
+  // and `failed`/`cancelled` aren't healing outcomes worth surfacing as
+  // distinct rows.
+  if (
+    r.ok &&
+    (fields.status === 'completed' || fields.status === 'reverted')
+  ) {
+    void (async () => {
+      try {
+        const lookupR = await supa<
+          Array<{
+            finding_id: string;
+            plan_version: number | null;
+            pr_url: string | null;
+            completed_at: string | null;
+            created_at: string | null;
+          }>
+        >(
+          s,
+          `/rest/v1/dev_autopilot_executions?id=eq.${id}` +
+            `&select=finding_id,plan_version,pr_url,completed_at,created_at&limit=1`,
+        );
+        const exec = lookupR.ok ? lookupR.data?.[0] : null;
+        if (!exec) return;
+
+        let endpoint = `autopilot.execute`;
+        if (exec.finding_id) {
+          const fR = await supa<Array<{ spec_snapshot: { file_path?: string } | null }>>(
+            s,
+            `/rest/v1/autopilot_recommendations?id=eq.${exec.finding_id}&select=spec_snapshot&limit=1`,
+          );
+          const fp = fR.ok && fR.data?.[0]?.spec_snapshot?.file_path;
+          if (fp) endpoint = String(fp);
+        }
+
+        const outcome: 'fixed' | 'rolled_back' =
+          fields.status === 'completed' ? 'fixed' : 'rolled_back';
+
+        await writeAutopilotSuccess(s, {
+          vtid: `VTID-DA-${id.slice(0, 8)}`,
+          endpoint,
+          outcome,
+          diagnosis: {
+            summary:
+              outcome === 'fixed'
+                ? `Auto-fix applied via ${exec.pr_url || 'PR'} (plan v${exec.plan_version ?? '?'})`
+                : `Auto-fix reverted via ${exec.pr_url || 'PR'} (plan v${exec.plan_version ?? '?'}) — verifier or watchdog rolled back`,
+            execution_id: id,
+            finding_id: exec.finding_id,
+            plan_version: exec.plan_version ?? null,
+            pr_url: exec.pr_url ?? null,
+            completed_at: exec.completed_at ?? null,
+          },
+          createdAtIso: exec.created_at || undefined,
+          resolvedAtIso: exec.completed_at || undefined,
+        });
+      } catch (err) {
+        console.warn(
+          `${LOG_PREFIX} self_healing_log success-write error for ${id.slice(0, 8)}:`,
+          err,
+        );
       }
     })();
   }

--- a/services/gateway/src/services/dev-autopilot-self-heal-log.ts
+++ b/services/gateway/src/services/dev-autopilot-self-heal-log.ts
@@ -136,6 +136,109 @@ export async function writeAutopilotFailure(
   }
 }
 
+// ─────────────────────────────────────────────────────────────────────────
+//  Success / rolled-back writer (VTID-02001)
+//
+//  self_healing_log used to be a failure-only log: writeAutopilotFailure
+//  was the only writer, so the Self-Healing screen showed escalations
+//  forever and never showed a single fix landing — even though
+//  dev_autopilot_executions had `completed` and `reverted` rows. This
+//  writer surfaces the success side of the pipeline.
+//
+//  Conventions:
+//    - vtid       = `VTID-DA-<exec-short>` (matches failure VTID format)
+//    - endpoint   = the finding's file_path (matches failure rows for that
+//                   finding so they sit together in the table)
+//    - failure_class = `auto_fix_applied` | `auto_fix_reverted` (kept in
+//                      the failure_class column because the schema reuses
+//                      it; the outcome column is the source of truth)
+//    - confidence = 1.0 for completed (the executor + verifier both
+//                   passed), 0.5 for reverted (the executor passed but
+//                   the verifier rolled it back)
+//    - outcome    = `fixed` | `rolled_back`
+// ─────────────────────────────────────────────────────────────────────────
+
+export interface AutopilotSuccessArgs {
+  /** `VTID-DA-<exec-short>` */
+  vtid: string;
+  /** Finding's file_path; falls back to `autopilot.execute` if unknown. */
+  endpoint: string;
+  /** 'fixed' for completed, 'rolled_back' for reverted. */
+  outcome: 'fixed' | 'rolled_back';
+  /** Structured diagnosis: include pr_url, plan_version, completed_at, etc. */
+  diagnosis: Record<string, unknown>;
+  /** Override the default confidence if needed. */
+  confidence?: number;
+  /** Override resolved_at (for backfill). Defaults to now(). */
+  resolvedAtIso?: string;
+  /** Override created_at (for backfill so timeline reflects when the fix
+   *  actually happened, not when we backfilled). */
+  createdAtIso?: string;
+}
+
+export async function writeAutopilotSuccess(
+  s: SupaConfig,
+  args: AutopilotSuccessArgs,
+): Promise<void> {
+  const failure_class =
+    args.outcome === 'fixed' ? 'auto_fix_applied' : 'auto_fix_reverted';
+  const confidence =
+    args.confidence ?? (args.outcome === 'fixed' ? 1.0 : 0.5);
+  try {
+    // Dedup: same vtid + endpoint + failure_class within DEDUP_WINDOW_MS.
+    // Success rows shouldn't repeat for the same execution — patchExecution
+    // can fire twice if a transient PostgREST retry happens — so the dedup
+    // saves us from double-counting.
+    const sinceIso = new Date(Date.now() - DEDUP_WINDOW_MS).toISOString();
+    const dedupQuery =
+      `?vtid=eq.${encodeURIComponent(args.vtid)}` +
+      `&endpoint=eq.${encodeURIComponent(args.endpoint)}` +
+      `&failure_class=eq.${encodeURIComponent(failure_class)}` +
+      `&created_at=gte.${encodeURIComponent(sinceIso)}` +
+      `&select=id&limit=1`;
+    const dedupRes = await fetch(`${s.url}/rest/v1/self_healing_log${dedupQuery}`, {
+      headers: { apikey: s.key, Authorization: `Bearer ${s.key}` },
+    });
+    if (dedupRes.ok) {
+      const existing = (await dedupRes.json()) as Array<{ id: string }>;
+      if (Array.isArray(existing) && existing.length > 0) {
+        return;
+      }
+    }
+
+    const body: Record<string, unknown> = {
+      vtid: args.vtid,
+      endpoint: args.endpoint,
+      failure_class,
+      confidence,
+      diagnosis: { stage: 'execute_run', ...args.diagnosis },
+      outcome: args.outcome,
+      attempt_number: 1,
+      resolved_at: args.resolvedAtIso || new Date().toISOString(),
+    };
+    if (args.createdAtIso) body.created_at = args.createdAtIso;
+
+    const res = await fetch(`${s.url}/rest/v1/self_healing_log`, {
+      method: 'POST',
+      headers: {
+        apikey: s.key,
+        Authorization: `Bearer ${s.key}`,
+        'Content-Type': 'application/json',
+        Prefer: 'return=minimal',
+      },
+      body: JSON.stringify(body),
+    });
+    if (!res.ok) {
+      const text = await res.text();
+      console.warn(
+        `${LOG_PREFIX} self_healing_log success POST failed (${res.status}): ${text.slice(0, 200)}`,
+      );
+    }
+  } catch (err) {
+    console.warn(`${LOG_PREFIX} self_healing_log success POST threw:`, err);
+  }
+}
+
 /**
  * Detect the worker spawn error pattern that's been silently failing plan
  * generation: `failed to spawn ...claude... ENOENT`. When the worker can't


### PR DESCRIPTION
## Summary
self_healing_log was a failure-only log. The Self-Healing screen showed 288 escalations and zero fixes — even though `dev_autopilot_executions` already has 5 `completed` + 4 `reverted` rows that never surfaced. From the user's seat the autonomy loop looked perpetually dead.

## Changes
- **`services/gateway/src/services/dev-autopilot-self-heal-log.ts`** — new `writeAutopilotSuccess(s, args)` writer. `failure_class = 'auto_fix_applied' | 'auto_fix_reverted'`, confidence `1.0` for fixed and `0.5` for rolled_back, outcome carried in the canonical column. Same dedup window as the failure writer.
- **`services/gateway/src/services/dev-autopilot-execute.ts`** — hooks into `patchExecution()`: `completed → fixed`, `reverted → rolled_back`. Looks up the finding's `file_path` from `autopilot_recommendations` so success rows sit in the same endpoint bucket as related failures.

## Frontend (no changes needed)
`outcomeIcons` already has `fixed='✅'` and `rolled_back='❌↩'`. `SH_RESOLVED_OUTCOMES` from VTID-01998 treats both as real resolutions, so the Resolved column shows accurate timestamps + duration.

## Backfill
The 9 historical terminal executions (5 completed + 4 reverted) are backfilled by a one-off script (`/tmp/backfill-self-healing-success.sh`) after the deploy lands. Cannot be done in-code without a migration; cleaner as a one-off.

## Test plan
- [x] tsc --noEmit clean
- [ ] EXEC-DEPLOY succeeds + smoke tests pass
- [ ] Backfill script writes 9 rows; Self-Healing screen shows 5 `✅ fixed` + 4 `❌↩ rolled_back` rows when filtered by class
- [ ] Future executions reaching `completed`/`reverted` produce a row within seconds of the patch

🤖 Generated with [Claude Code](https://claude.com/claude-code)