### PR TITLE
feat(routines): Tier A — voice-lab triage + draft-PR babysitter + agents heartbeat (VTID-02004)

### DIFF
--- a/routines/agents-heartbeat.md
+++ b/routines/agents-heartbeat.md
@@ -1,0 +1,96 @@
+# Routine: agents-heartbeat
+
+**Schedule:** `30 5 * * *` (daily 05:30 UTC, scheduler jitter pads to ~05:38)
+**Catalog row:** `routines.name = 'agents-heartbeat'`
+**OASIS VTID for emitted events:** `VTID-02004`
+
+## Autonomy contract
+
+Calls `/api/v1/agents/registry`, derives the live status of every agent (the registry decays heartbeat freshness at read time), and **emits an OASIS event** (`topic = agents.registry.degraded`) listing any agent that is not `healthy`. Self-healing already watches that topic and will spawn an investigation per affected service.
+
+Silent-agent-death is otherwise the single class of failure we cannot detect quickly. This routine closes that gap without adding any human queue.
+
+| Catalog state | Meaning |
+|---|---|
+| 🟢 `success` | All registered agents are healthy. Nothing to do. |
+| 🟡 `partial` | One or more agents degraded/down → OASIS event emitted → self-healing now investigating. |
+| 🔴 `failure` | Routine itself errored (registry endpoint down, gateway 5xx). |
+
+## Required environment
+
+- `GATEWAY_URL` = `https://gateway-q74ibpv6ia-uc.a.run.app`
+- `ROUTINE_INGEST_TOKEN` (embedded)
+
+## Steps
+
+### 1. Open the run record
+
+```
+POST $GATEWAY_URL/api/v1/routines/agents-heartbeat/runs
+H: X-Routine-Token: $ROUTINE_INGEST_TOKEN
+B: { "trigger": "cron" }
+→ { ok: true, run: { id: "<run_id>" } }
+```
+
+### 2. Read the registry
+
+```
+GET $GATEWAY_URL/api/v1/agents/registry
+→ {
+  ok: true,
+  counts: { total, by_tier:{service,embedded,scheduled}, by_status:{healthy,degraded,down,unknown}, ... },
+  agents: [ { agent_id, display_name, tier, status, derived_status, last_heartbeat_at, heartbeat_age_ms, ... } ]
+}
+```
+
+### 3. Filter for problems
+
+A "problem agent" is any row where `derived_status !== 'healthy'`. Two known caveats baked into the registry:
+- `tier === 'embedded'` agents do not heartbeat individually — they live or die with the gateway. Skip them when computing problems (the gateway's own /alive covers them).
+- `tier === 'scheduled'` agents have a 6h/24h decay window; they're allowed to be quieter than service-tier.
+
+So `problems = agents.filter(a => a.tier !== 'embedded' && a.derived_status !== 'healthy')`.
+
+### 4. If problems detected — emit OASIS event
+
+```
+POST $GATEWAY_URL/api/v1/events/ingest
+B: {
+  "vtid": "VTID-02004",
+  "type": "agents.registry.degraded",
+  "source": "routine.agents-heartbeat",
+  "status": "warning",
+  "message": "N agent(s) not healthy: <comma-separated agent_ids>",
+  "payload": {
+    "problems": [ { agent_id, tier, derived_status, last_heartbeat_at, heartbeat_age_ms, last_error } ],
+    "totals": { total, by_status }
+  }
+}
+```
+
+### 5. Close the run
+
+`PATCH $GATEWAY_URL/api/v1/routines/agents-heartbeat/runs/{run_id}` with `X-Routine-Token`.
+
+| Outcome | status | summary |
+|---|---|---|
+| Zero problems | `success` | `"✅ All N agents healthy across service / embedded / scheduled tiers"` |
+| Problems detected | `partial` | `"⚠️ N agents not healthy: <ids>. OASIS event emitted, self-healing notified."` |
+| Registry endpoint down | `failure` | `"❌ Could not read /api/v1/agents/registry — see error"` |
+
+`findings`:
+```json
+{
+  "agents_total": <int>,
+  "agents_problem": <int>,
+  "by_status": { "healthy": <int>, "degraded": <int>, "down": <int>, "unknown": <int> },
+  "problems": [ { "agent_id", "tier", "derived_status", "last_heartbeat_at", "heartbeat_age_ms" } ],
+  "oasis_event_id": "<uuid or null>"
+}
+```
+
+## Hard rules
+
+- Skip `tier === 'embedded'` agents when computing problems (they don't heartbeat).
+- Never restart, redeploy, or otherwise touch the agents — that's self-healing's job. The routine only emits the event.
+- Plain `curl` only. Wall-clock cap 2 minutes — this should be fast.

--- a/routines/draft-pr-babysitter.md
+++ b/routines/draft-pr-babysitter.md
@@ -1,0 +1,90 @@
+# Routine: draft-pr-babysitter
+
+**Schedule:** `0 5 * * *` (daily 05:00 UTC, scheduler jitter pads to ~05:08)
+**Catalog row:** `routines.name = 'draft-pr-babysitter'`
+**OASIS VTID for emitted events:** `VTID-02004`
+
+## Autonomy contract
+
+Sweeps every open draft PR across `exafyltd/vitana-platform` and `exafyltd/vitana-v1`. For each one:
+- If the branch is behind `main` → **auto-rebase** via `gh pr update-branch` (or post a one-line "needs rebase" comment if the auto-rebase fails).
+- If CI is failing → post a single comment summarising which check failed and a link to the run.
+- If the PR has been draft for >5 days with no commits → label `decide` so it surfaces on the user's review queue.
+
+| Catalog state | Meaning |
+|---|---|
+| 🟢 `success` | All draft PRs are healthy (CI green, fresh, on top of main). Routine took zero actions. |
+| 🟡 `partial` | Routine took at least one action (rebase / comment / label). Audit log in `findings.actions[]`. |
+| 🔴 `failure` | Routine itself errored (GitHub API down, gh auth broken). |
+
+## Required environment
+
+- `GATEWAY_URL` = `https://gateway-q74ibpv6ia-uc.a.run.app`
+- `ROUTINE_INGEST_TOKEN` (embedded)
+- `GITHUB_TOKEN` — provided by the CCR sandbox automatically for the cloned repo. If `gh auth status` fails inside the sandbox, set `status='failure'` and abort.
+
+## Steps
+
+### 1. Open the run record
+
+```
+POST $GATEWAY_URL/api/v1/routines/draft-pr-babysitter/runs
+H: X-Routine-Token: $ROUTINE_INGEST_TOKEN
+B: { "trigger": "cron" }
+→ { ok: true, run: { id: "<run_id>" } }
+```
+
+### 2. Enumerate draft PRs
+
+```
+gh pr list --repo exafyltd/vitana-platform --state open --draft --limit 50 --json number,title,headRefName,updatedAt,createdAt,baseRefName,mergeStateStatus
+gh pr list --repo exafyltd/vitana-v1     --state open --draft --limit 50 --json number,title,headRefName,updatedAt,createdAt,baseRefName,mergeStateStatus
+```
+
+### 3. For each draft PR, decide the action
+
+For each PR `p`:
+
+a. **If `p.mergeStateStatus === "BEHIND"`**: try `gh pr update-branch <p.number> --repo <repo>`. If success → record action `rebased`. If failure → post comment `"⚠️ Cannot auto-rebase (conflicts likely). Please rebase manually."` and record action `rebase_failed_commented`.
+
+b. **CI status**: `gh pr checks <p.number> --repo <repo> --json name,bucket`. If any check has `bucket=failure`: check whether we already commented within the last 24h (`gh pr view <p.number> --comments --json comments`). If not → post a single comment listing failed check names and record action `ci_failure_commented`.
+
+c. **Stale draft (no commits in >5 days)**: if `p.updatedAt < now - 5d` → check labels. If not already labeled `decide` → `gh pr edit <p.number> --repo <repo> --add-label decide` and record action `labeled_decide`.
+
+If a PR has no triggering condition: skip it (no action recorded).
+
+### 4. Close the run
+
+`PATCH $GATEWAY_URL/api/v1/routines/draft-pr-babysitter/runs/{run_id}` with `X-Routine-Token`.
+
+| Outcome | status | summary |
+|---|---|---|
+| `actions.length === 0` | `success` | `"✅ N draft PRs across both repos are all healthy"` |
+| `actions.length > 0` | `partial` | `"⚠️ Took A actions on N draft PRs: <kind summary>"` |
+| `gh` or GitHub API down | `failure` | `"❌ GitHub API unreachable — see error"` |
+
+`findings`:
+```json
+{
+  "drafts_inspected": <int>,
+  "actions": [
+    { "repo", "pr_number", "title", "action": "rebased|rebase_failed_commented|ci_failure_commented|labeled_decide", "detail" }
+  ],
+  "skipped": <int>
+}
+```
+
+## Hard rules
+
+- Auto-rebase is allowed and expected for behind-main draft PRs. Posting comments and applying labels is also allowed — it is autonomous maintenance, not human-review work.
+- One comment max per PR per 24h to avoid noise — check existing comments before posting.
+- Never close, merge, or reopen a PR. Never push commits other than the rebase.
+- Plain `gh` CLI + `curl` only. Wall-clock cap 5 minutes.
+
+## Why this is autonomy and not "manual work"
+
+The user does not read the audit log row by row. They look at the catalog tile:
+- 🟢 → no thought needed.
+- 🟡 → "the routine cleaned up X PRs for me" — they may glance at `findings.actions` once a week to spot trends, but no per-row decision required.
+
+The `decide` label routes a stuck PR to the user's existing review queue surface, which is *their* workflow choice, not new manual work.

--- a/routines/voice-lab-triage.md
+++ b/routines/voice-lab-triage.md
@@ -1,0 +1,92 @@
+# Routine: voice-lab-triage
+
+**Schedule:** `30 4 * * *` (daily 04:30 UTC, scheduler jitter pads to ~04:38)
+**Catalog row:** `routines.name = 'voice-lab-triage'`
+**OASIS VTID for emitted events:** `VTID-01155` (canonical voice VTID)
+
+## Autonomy contract
+
+Reads the last 24h of ORB Live sessions, clusters error patterns vs the 7-day baseline, and **emits an OASIS event** (`topic = voice.live.regression.daily_triage`) when a regression is detected so the existing voice self-healing loop picks it up. **No briefs for human review.**
+
+| Catalog state | Meaning |
+|---|---|
+| 🟢 `success` | No regression, error rate within baseline. Nothing to do. |
+| 🟡 `partial` | Regression detected → OASIS event emitted → self-healing now investigating. |
+| 🔴 `failure` | Routine itself errored (voice-lab API down, gateway 5xx, etc.). |
+
+## Required environment
+
+- `GATEWAY_URL` = `https://gateway-q74ibpv6ia-uc.a.run.app`
+- `ROUTINE_INGEST_TOKEN` (embedded in the routine prompt)
+
+## Steps
+
+### 1. Open the run record
+
+```
+POST $GATEWAY_URL/api/v1/routines/voice-lab-triage/runs
+H: X-Routine-Token: $ROUTINE_INGEST_TOKEN
+B: { "trigger": "cron" }
+→ { ok: true, run: { id: "<run_id>" } }
+```
+
+### 2. Fetch yesterday + the 7-day baseline
+
+```
+# Yesterday (last 24h)
+GET $GATEWAY_URL/api/v1/voice-lab/live/sessions?status=ended&since_hours=24
+→ { sessions: [ { session_id, started_at, ended_at, error_count, error_codes, platform, ... } ] }
+
+# Baseline (8d to 1d ago — the prior 7-day window, NOT including yesterday)
+GET $GATEWAY_URL/api/v1/voice-lab/live/sessions?status=ended&since_hours=192&until_hours=24
+```
+
+### 3. Cluster + compare
+
+For yesterday and baseline, compute:
+- `total_sessions`
+- `error_sessions` (sessions with `error_count > 0`)
+- `error_rate = error_sessions / total_sessions`
+- `top_error_codes` (count by error_code, top 5)
+- `novel_error_codes` (codes in yesterday NOT seen in baseline)
+
+A **regression** is any of:
+- `error_rate_yesterday > error_rate_baseline * 1.5` AND `error_sessions_yesterday >= 3`
+- `novel_error_codes.length > 0` AND that novel code appeared in `>= 3` yesterday sessions
+- `total_sessions_yesterday < total_sessions_baseline_avg * 0.3` (collapse — voice barely used, possible outage)
+
+### 4. If regression detected — emit OASIS event
+
+```
+POST $GATEWAY_URL/api/v1/events/ingest
+B: {
+  "vtid": "VTID-01155",
+  "type": "voice.live.regression.daily_triage",
+  "source": "routine.voice-lab-triage",
+  "status": "warning",
+  "message": "Voice regression detected: <one-line summary>",
+  "payload": {
+    "yesterday": { "total_sessions", "error_sessions", "error_rate", "top_error_codes", "novel_error_codes" },
+    "baseline":  { "total_sessions", "error_sessions", "error_rate", "top_error_codes" },
+    "regression_kind": "error_rate_spike" | "novel_error_codes" | "session_collapse"
+  }
+}
+```
+
+### 5. Close the run
+
+`PATCH $GATEWAY_URL/api/v1/routines/voice-lab-triage/runs/{run_id}` with `X-Routine-Token`.
+
+| Outcome | status | summary |
+|---|---|---|
+| No regression | `success` | `"✅ Voice healthy: X sessions, Y errors, error rate Z% (within baseline)"` |
+| Regression detected | `partial` | `"⚠️ Voice regression: <kind>. OASIS event emitted, self-healing notified."` |
+| Voice-lab API down | `failure` | `"❌ Could not read voice-lab/live/sessions — see error."` |
+
+`findings` = the comparison object plus `oasis_event_id` if one was emitted.
+
+## Hard rules
+
+- Never produce briefs. The findings JSON is forensics — green tile means no further reading needed.
+- Always end with PATCH (success / partial / failure). Never leave a run in `running`.
+- Plain `curl` only. Wall-clock cap 5 minutes.

--- a/supabase/migrations/20260427180000_vtid_02004_routines_tier_a.sql
+++ b/supabase/migrations/20260427180000_vtid_02004_routines_tier_a.sql
@@ -1,0 +1,25 @@
+-- =============================================================================
+-- VTID-02004 — Tier A daily routines: voice-lab triage, draft-PR babysitter,
+-- agents heartbeat. Seeds catalog only — the remote agents are created
+-- separately via /schedule (RemoteTrigger) once this row exists.
+--
+-- All three follow the autonomy contract from
+-- feedback_routines_no_human_briefs.md:
+--   green pass OR self-heal handoff via OASIS event ingest, never briefs.
+-- =============================================================================
+
+INSERT INTO routines (name, display_name, description, cron_schedule)
+VALUES
+  ('voice-lab-triage',
+   'Voice Lab Daily Triage',
+   'Reads the last 24h of ORB Live sessions, clusters error patterns vs the 7-day baseline, and emits an OASIS event (topic voice.live.regression.daily_triage) when a regression is detected so the existing voice self-healing loop picks it up. Green when no regression, yellow when self-healing has been notified.',
+   '30 4 * * *'),
+  ('draft-pr-babysitter',
+   'Draft PR Babysitter',
+   'Sweeps open draft PRs across exafyltd/vitana-platform and exafyltd/vitana-v1. Auto-rebases anything behind main, posts a one-line CI status comment, labels PRs that have been draft >5 days. Green when every draft PR is healthy, yellow when the routine took action.',
+   '0 5 * * *'),
+  ('agents-heartbeat',
+   'Agents Registry Heartbeat',
+   'Calls /api/v1/agents/registry, flags any of the registered agents whose derived status is degraded or down, and emits an OASIS event (topic agents.registry.degraded) so self-healing can investigate. Green when all agents are healthy, yellow when self-healing has been notified.',
+   '30 5 * * *')
+ON CONFLICT (name) DO NOTHING;


### PR DESCRIPTION
## Summary

Bundles **routines #2–#4** of the daily-routines plan ([`.claude/plans/let-s-make-a-plan-witty-naur.md`](.claude/plans/let-s-make-a-plan-witty-naur.md)). All three follow the autonomy contract from `feedback_routines_no_human_briefs.md`: **green pass or self-heal handoff via OASIS event ingest, never briefs for human review.**

| # | Name | Cron (UTC) | Behaviour on issue |
|---|---|---|---|
| 2 | `voice-lab-triage` | `30 4 * * *` | Emits OASIS `voice.live.regression.daily_triage` → existing voice self-healing loop |
| 3 | `draft-pr-babysitter` | `0 5 * * *` | Auto-rebase / single CI-failure comment / `decide` label on stale drafts |
| 4 | `agents-heartbeat` | `30 5 * * *` | Emits OASIS `agents.registry.degraded` → self-healing investigates |

Each catalog tile shows:
- 🟢 `success` → routine ran, nothing detected
- 🟡 `partial` → routine took an action / emitted an incident
- 🔴 `failure` → routine itself errored

## What this PR contains

- `supabase/migrations/20260427180000_vtid_02004_routines_tier_a.sql` — data-only INSERT INTO routines for the three new catalog rows
- `routines/voice-lab-triage.md` — spec + autonomy contract
- `routines/draft-pr-babysitter.md` — spec + autonomy contract
- `routines/agents-heartbeat.md` — spec + autonomy contract

## What this PR does NOT contain

The remote agents themselves are created via `RemoteTrigger.create` once this merges and the migration is applied. Each routine spec embeds the full prompt logic — the RemoteTrigger payload pulls from there.

## Test plan

- [ ] Apply the migration via `RUN-MIGRATION.yml`.
- [ ] `curl https://gateway-q74ibpv6ia-uc.a.run.app/api/v1/routines` returns 4 catalog rows (1 existing + 3 new), each with `last_run_status: null`.
- [ ] Open Command Hub → Routines → Catalog: see four tiles, three with "Never run".
- [ ] Create the three remote routines via `RemoteTrigger.create`.
- [ ] Manual `run` each one; verify the catalog tile flips to `success` (or `partial` if a real issue is detected today).
- [ ] Confirm each routine's `findings` JSON is an audit log, NOT a brief queue.

🤖 Generated with [Claude Code](https://claude.com/claude-code)