### PR TITLE
feat(memory): Phase 5c — legacy backfill + relationship_edges mirror trigger (VTID-02007)

### DIFF
--- a/supabase/migrations/20260428100000_vtid_02007_phase_5c_legacy_backfill.sql
+++ b/supabase/migrations/20260428100000_vtid_02007_phase_5c_legacy_backfill.sql
@@ -1,0 +1,293 @@
+-- VTID-02007 / Phase 5c — legacy backfill of memory_items / memory_facts /
+-- relationship_edges into the new bi-temporal mem_* tables introduced
+-- in Phase 5a (VTID-02003).
+--
+-- After this migration, Tier 2 reads can serve the FULL historical
+-- corpus, not just rows written after the dual-writer flipped on
+-- (Phase 5b / VTID-02005).
+--
+-- Sizes at write time:
+--   memory_items:       2867 rows  →  mem_episodes
+--   memory_facts:       4797 rows  →  mem_facts
+--   relationship_edges:    3 rows  →  mem_graph_edges
+--
+-- All idempotent: re-running this migration is a no-op because the
+-- backfill INSERTs use NOT EXISTS / source_event_id de-duplication.
+
+BEGIN;
+
+-- ============================================================================
+-- 0. mem_graph_edges.user_id → make nullable (relationship_edges has no
+--    direct user_id; we derive from source_id when source_type='person'
+--    or 'user', else NULL).
+-- ============================================================================
+
+ALTER TABLE public.mem_graph_edges
+  ALTER COLUMN user_id DROP NOT NULL;
+
+-- ============================================================================
+-- 1. memory_items → mem_episodes (preserve embeddings)
+-- ============================================================================
+
+DO $backfill_episodes$
+DECLARE
+  v_inserted bigint;
+BEGIN
+  WITH inserted AS (
+    INSERT INTO public.mem_episodes (
+      tenant_id, user_id,
+      conversation_id,
+      kind, content, content_json, importance,
+      category_key, source, workspace_scope, active_role,
+      visibility_scope, origin_service, vtid,
+      embedding, embedding_model, embedding_updated_at,
+      occurred_at, valid_from, asserted_at,
+      actor_id, confidence, source_event_id,
+      policy_version, source_engine, classification
+    )
+    SELECT
+      mi.tenant_id, mi.user_id,
+      mi.conversation_id,
+      'utterance'::text AS kind,
+      mi.content,
+      mi.content_json,
+      LEAST(GREATEST(COALESCE(mi.importance, 30), 0), 100) AS importance,
+      mi.category_key, mi.source, mi.workspace_scope, mi.active_role,
+      COALESCE(mi.visibility_scope, 'private') AS visibility_scope,
+      mi.origin_service, mi.vtid,
+      mi.embedding, mi.embedding_model, mi.embedding_updated_at,
+      mi.occurred_at,
+      COALESCE(mi.occurred_at, mi.created_at) AS valid_from,
+      COALESCE(mi.created_at, now()) AS asserted_at,
+      CASE
+        WHEN (mi.content_json->>'direction') = 'assistant' THEN 'assistant'
+        ELSE 'user'
+      END AS actor_id,
+      COALESCE(mi.provenance_confidence, 1.0) AS confidence,
+      mi.id::text AS source_event_id,
+      'mem-2026.04' AS policy_version,
+      COALESCE(mi.source_engine, mi.source, 'legacy_backfill_phase_5c') AS source_engine,
+      '{}'::jsonb AS classification
+    FROM public.memory_items mi
+    WHERE NOT EXISTS (
+      SELECT 1 FROM public.mem_episodes me
+      WHERE me.source_event_id = mi.id::text
+    )
+    RETURNING 1
+  )
+  SELECT count(*) INTO v_inserted FROM inserted;
+  RAISE NOTICE 'STEP 1 — backfilled % rows from memory_items into mem_episodes', v_inserted;
+END
+$backfill_episodes$;
+
+-- ============================================================================
+-- 2. memory_facts → mem_facts
+--    Bi-temporal mapping:
+--      mf.superseded_at  →  mft.valid_to
+--      mf.extracted_at   →  mft.valid_from / asserted_at
+--    The partial unique index on mem_facts (tenant, user, entity, fact_key)
+--    WHERE valid_to IS NULL is preserved because at most one row per
+--    (tenant, user, entity, fact_key) has superseded_at NULL in memory_facts.
+-- ============================================================================
+
+DO $backfill_facts$
+DECLARE
+  v_inserted bigint;
+BEGIN
+  WITH inserted AS (
+    INSERT INTO public.mem_facts (
+      tenant_id, user_id, entity, fact_key, fact_value, fact_value_type,
+      embedding, embedding_model, embedding_updated_at,
+      valid_from, valid_to, asserted_at,
+      actor_id, confidence, source_event_id,
+      policy_version, source_engine, classification,
+      extracted_at, vtid
+    )
+    SELECT
+      mf.tenant_id, mf.user_id,
+      COALESCE(mf.entity, 'self') AS entity,
+      mf.fact_key, mf.fact_value,
+      COALESCE(mf.fact_value_type, 'text') AS fact_value_type,
+      mf.embedding, mf.embedding_model, mf.embedding_updated_at,
+      mf.extracted_at AS valid_from,
+      mf.superseded_at AS valid_to,
+      mf.extracted_at AS asserted_at,
+      COALESCE(mf.provenance_source, 'user_stated') AS actor_id,
+      COALESCE(mf.provenance_confidence, 1.0) AS confidence,
+      mf.id::text AS source_event_id,
+      'mem-2026.04' AS policy_version,
+      'legacy_backfill_phase_5c' AS source_engine,
+      '{}'::jsonb AS classification,
+      mf.extracted_at, mf.vtid
+    FROM public.memory_facts mf
+    WHERE NOT EXISTS (
+      SELECT 1 FROM public.mem_facts mft
+      WHERE mft.source_event_id = mf.id::text
+    )
+    -- Skip rows that would conflict with an already-mirrored ACTIVE fact
+    -- (Phase 5b dual-writer or earlier backfill run). The unique partial
+    -- index would reject these anyway; filter explicitly to keep the
+    -- migration log clean.
+    AND NOT (
+      mf.superseded_at IS NULL
+      AND EXISTS (
+        SELECT 1 FROM public.mem_facts mft
+        WHERE mft.tenant_id = mf.tenant_id
+          AND mft.user_id   = mf.user_id
+          AND mft.entity    = COALESCE(mf.entity, 'self')
+          AND mft.fact_key  = mf.fact_key
+          AND mft.valid_to IS NULL
+      )
+    )
+    RETURNING 1
+  )
+  SELECT count(*) INTO v_inserted FROM inserted;
+  RAISE NOTICE 'STEP 2 — backfilled % rows from memory_facts into mem_facts', v_inserted;
+END
+$backfill_facts$;
+
+-- ============================================================================
+-- 3. relationship_edges → mem_graph_edges
+-- ============================================================================
+
+DO $backfill_edges$
+DECLARE
+  v_inserted bigint;
+BEGIN
+  WITH inserted AS (
+    INSERT INTO public.mem_graph_edges (
+      tenant_id, user_id,
+      source_type, source_id, target_type, target_id,
+      edge_type, strength, metadata,
+      last_interaction_at, valid_from, asserted_at,
+      actor_id, confidence, source_event_id,
+      policy_version, source_engine
+    )
+    SELECT
+      re.tenant_id,
+      -- Derive user_id where source/target is a person or user; else NULL
+      CASE
+        WHEN re.source_type IN ('user','person') THEN re.source_id
+        WHEN re.target_type IN ('user','person') THEN re.target_id
+        ELSE NULL
+      END AS user_id,
+      re.source_type, re.source_id, re.target_type, re.target_id,
+      re.edge_type,
+      COALESCE(re.strength, 0.5) AS strength,
+      COALESCE(re.metadata, '{}'::jsonb) AS metadata,
+      re.last_interaction_at,
+      COALESCE(re.created_at, now()) AS valid_from,
+      COALESCE(re.created_at, now()) AS asserted_at,
+      'legacy_backfill' AS actor_id,
+      1.0 AS confidence,
+      re.id::text AS source_event_id,
+      'mem-2026.04' AS policy_version,
+      'legacy_backfill_phase_5c' AS source_engine
+    FROM public.relationship_edges re
+    WHERE NOT EXISTS (
+      SELECT 1 FROM public.mem_graph_edges mge
+      WHERE mge.source_event_id = re.id::text
+    )
+    RETURNING 1
+  )
+  SELECT count(*) INTO v_inserted FROM inserted;
+  RAISE NOTICE 'STEP 3 — backfilled % rows from relationship_edges into mem_graph_edges', v_inserted;
+END
+$backfill_edges$;
+
+-- ============================================================================
+-- 4. Trigger on relationship_edges → auto-mirror future INSERTs to
+--    mem_graph_edges. This replaces the per-call-site dual-writer wiring
+--    that was deferred from Phase 5b (5+ writer files would need touching).
+-- ============================================================================
+
+CREATE OR REPLACE FUNCTION public.mirror_relationship_edge_to_tier2()
+RETURNS trigger
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $trg$
+DECLARE
+  v_user_id uuid;
+BEGIN
+  -- Skip if the gate flag is off
+  IF NOT EXISTS (
+    SELECT 1 FROM public.system_controls
+    WHERE key = 'mem_tier2_dual_write_enabled' AND enabled = true
+  ) THEN
+    RETURN NEW;
+  END IF;
+
+  -- Derive user_id where possible (matches the backfill logic above)
+  v_user_id := CASE
+    WHEN NEW.source_type IN ('user','person') THEN NEW.source_id
+    WHEN NEW.target_type IN ('user','person') THEN NEW.target_id
+    ELSE NULL
+  END;
+
+  BEGIN
+    INSERT INTO public.mem_graph_edges (
+      tenant_id, user_id,
+      source_type, source_id, target_type, target_id,
+      edge_type, strength, metadata,
+      last_interaction_at, valid_from, asserted_at,
+      actor_id, confidence, source_event_id,
+      policy_version, source_engine
+    ) VALUES (
+      NEW.tenant_id, v_user_id,
+      NEW.source_type, NEW.source_id, NEW.target_type, NEW.target_id,
+      NEW.edge_type,
+      COALESCE(NEW.strength, 0.5),
+      COALESCE(NEW.metadata, '{}'::jsonb),
+      NEW.last_interaction_at,
+      COALESCE(NEW.created_at, now()),
+      COALESCE(NEW.created_at, now()),
+      'trigger:relationship_edges_mirror',
+      1.0,
+      NEW.id::text,
+      'mem-2026.04',
+      'relationship_edges_mirror'
+    );
+  EXCEPTION WHEN OTHERS THEN
+    -- Trigger MUST NOT break the primary write. Park the failure in the
+    -- DLQ and continue.
+    INSERT INTO public.memory_write_dlq (
+      tenant_id, user_id, stream, payload, provenance,
+      error_class, error_message, attempt_count, next_retry_at
+    ) VALUES (
+      NEW.tenant_id, v_user_id, 'mem_graph_edges',
+      to_jsonb(NEW),
+      jsonb_build_object('actor_id', 'trigger:relationship_edges_mirror', 'policy_version', 'mem-2026.04'),
+      SQLSTATE,
+      LEFT(SQLERRM, 1000),
+      0,
+      now() + interval '60 seconds'
+    );
+  END;
+
+  RETURN NEW;
+END
+$trg$;
+
+DROP TRIGGER IF EXISTS mirror_relationship_edge_to_tier2_trg ON public.relationship_edges;
+CREATE TRIGGER mirror_relationship_edge_to_tier2_trg
+  AFTER INSERT ON public.relationship_edges
+  FOR EACH ROW
+  EXECUTE FUNCTION public.mirror_relationship_edge_to_tier2();
+
+COMMENT ON FUNCTION public.mirror_relationship_edge_to_tier2 IS
+  'VTID-02007 Phase 5c — auto-mirror relationship_edges INSERTs into mem_graph_edges. Gated by system_controls.mem_tier2_dual_write_enabled. Fire-and-forget — failures land in memory_write_dlq.';
+
+-- ============================================================================
+-- 5. Final reconciliation report
+-- ============================================================================
+
+SELECT 'mem_episodes count'    AS report, COUNT(*) AS total FROM public.mem_episodes
+UNION ALL
+SELECT 'mem_facts count'                , COUNT(*)         FROM public.mem_facts
+UNION ALL
+SELECT 'mem_graph_edges count'          , COUNT(*)         FROM public.mem_graph_edges
+UNION ALL
+SELECT 'memory_write_dlq unresolved'    , COUNT(*)         FROM public.memory_write_dlq WHERE resolved_at IS NULL;
+
+COMMIT;


### PR DESCRIPTION
Backfills ~2867 memory_items + ~4797 memory_facts + 3 relationship_edges into the bi-temporal mem_* tables. Adds AFTER INSERT trigger on relationship_edges that auto-mirrors future writes (replaces the per-call-site wiring deferred from Phase 5b).

All one transaction, idempotent via source_event_id. Gated by the existing `mem_tier2_dual_write_enabled` system_controls flag.