### PR TITLE
feat(routines): Tier C-1 — ORB audio smoke + Cloud Run/frontend health (VTID-02017)

### DIFF
--- a/routines/cloud-run-frontend-health.md
+++ b/routines/cloud-run-frontend-health.md
@@ -1,0 +1,68 @@
+# Routine: cloud-run-frontend-health
+
+**Schedule:** `30 8 * * *` (daily 08:30 UTC)
+**Catalog row:** `routines.name = 'cloud-run-frontend-health'`
+**OASIS VTID for emitted events:** `VTID-02017`
+
+## Autonomy contract
+
+Daily smoke of the Cloud Run gateway and the community-app preview URL. Catches silent deploy failures and CDN propagation issues that wouldn't trigger any other routine. **No briefs.**
+
+| Catalog state | Meaning |
+|---|---|
+| 🟢 `success` | All three URLs return 2xx and the gateway `/alive` payload looks healthy. |
+| 🟡 `partial` | At least one URL not 2xx → OASIS event emitted. |
+| 🔴 `failure` | Routine itself errored (network unreachable from sandbox). |
+
+## Required environment
+
+- `GATEWAY_URL`, `ROUTINE_INGEST_TOKEN`
+
+## Steps
+
+### 1. Open run
+`POST $GATEWAY_URL/api/v1/routines/cloud-run-frontend-health/runs`.
+
+### 2. Probe three surfaces
+
+| URL | Acceptance |
+|---|---|
+| `https://gateway-q74ibpv6ia-uc.a.run.app/alive` | 200 + body contains `"ok"` or `"alive"` |
+| `https://community-app-q74ibpv6ia-uc.a.run.app/` | 200 + content-type starts with `text/html` |
+| `https://gateway-q74ibpv6ia-uc.a.run.app/api/v1/routines` | 200 + `body.ok === true` (proves the routines stack itself is live) |
+
+For each one capture: http_code, content_type, body length, latency_ms.
+
+### 3. Compute breach list
+
+```
+breach_kinds = []
+for each surface:
+  if http_code is not 2xx: breach_kinds.push('<surface_name>_unreachable_' + http_code)
+  if expected body shape mismatch: breach_kinds.push('<surface_name>_body_unexpected')
+```
+
+### 4. Emit OASIS event (only on breach)
+
+```
+POST $GATEWAY_URL/api/v1/events/ingest
+B: { vtid:"VTID-02017", type:"cloud_run.health.degraded",
+     source:"routine.cloud-run-frontend-health", status:"warning",
+     message:"<breach_kinds>", payload:{ surfaces: [ { name, http_code, latency_ms } ], breach_kinds } }
+```
+
+### 5. Close run
+
+| Outcome | status | summary |
+|---|---|---|
+| All 2xx | `success` | `"✅ All 3 surfaces healthy: gateway + community-app + routines API"` |
+| Breach | `partial` | `"⚠️ Cloud Run breach: <breach_kinds>. OASIS event emitted, self-healing notified."` |
+| Network error before any probe | `failure` | `"❌ Routine sandbox cannot reach internet — see error"` |
+
+`findings = { surfaces: [ { name, url, http_code, latency_ms, content_type, body_snippet } ], breach_kinds, oasis_event_id }`
+
+## Hard rules
+
+- Plain `curl` only.
+- Wall-clock cap 1 minute.
+- No briefs.

--- a/routines/orb-audio-smoke.md
+++ b/routines/orb-audio-smoke.md
@@ -1,0 +1,61 @@
+# Routine: orb-audio-smoke
+
+**Schedule:** `0 8 * * *` (daily 08:00 UTC)
+**Catalog row:** `routines.name = 'orb-audio-smoke'`
+**OASIS VTID for emitted events:** `VTID-01155` (canonical voice VTID)
+
+## Autonomy contract
+
+Daily probe of `/api/v1/orb/health` to confirm Vertex AI Live API is wired up correctly. Same three checks the `EXEC-DEPLOY` hard-gate runs on every deploy — but daily and independent of any deploy event. **No briefs.**
+
+| Catalog state | Meaning |
+|---|---|
+| 🟢 `success` | All three checks pass: `gemini_live.enabled === true`, `vertex_project_id` non-empty, `google_auth_ready === true`. |
+| 🟡 `partial` | At least one check failed → OASIS event emitted, voice self-healing notified. |
+| 🔴 `failure` | `/api/v1/orb/health` itself unreachable. |
+
+## Required environment
+
+- `GATEWAY_URL`, `ROUTINE_INGEST_TOKEN`
+
+## Steps
+
+### 1. Open run
+`POST $GATEWAY_URL/api/v1/routines/orb-audio-smoke/runs`.
+
+### 2. Probe ORB health
+`GET $GATEWAY_URL/api/v1/orb/health`
+→ `{ ok, gemini_live: { enabled }, vertex_project_id, google_auth_ready, ... }`
+
+### 3. Three checks
+
+```
+breach_kinds = []
+if gemini_live.enabled !== true:           breach_kinds.push('gemini_live_disabled')
+if !vertex_project_id || vertex_project_id === '':  breach_kinds.push('vertex_project_id_missing')
+if google_auth_ready !== true:             breach_kinds.push('google_auth_not_ready')
+```
+
+### 4. Emit OASIS event (only on breach)
+
+```
+POST $GATEWAY_URL/api/v1/events/ingest
+B: { vtid:"VTID-01155", type:"orb.live.smoke.regression",
+     source:"routine.orb-audio-smoke", status:"warning",
+     message:"<breach kinds>", payload:{ checks: { gemini_live_enabled, vertex_project_id, google_auth_ready }, breach_kinds } }
+```
+
+### 5. Close run
+
+| Outcome | status | summary |
+|---|---|---|
+| All checks pass | `success` | `"✅ ORB audio pipeline healthy: gemini_live + vertex + google_auth all green"` |
+| Breach | `partial` | `"⚠️ ORB audio breach: <breach_kinds>. OASIS event emitted, self-healing notified."` |
+| Health endpoint down | `failure` | `"❌ /api/v1/orb/health unreachable — see error"` |
+
+`findings = { gemini_live_enabled, vertex_project_id, google_auth_ready, breach_kinds, oasis_event_id }`
+
+## Hard rules
+
+- Plain `curl` only. Wall-clock cap 1 minute.
+- No briefs.

--- a/supabase/migrations/20260428110000_vtid_02017_routines_tier_c_batch_1.sql
+++ b/supabase/migrations/20260428110000_vtid_02017_routines_tier_c_batch_1.sql
@@ -1,0 +1,19 @@
+-- =============================================================================
+-- VTID-02017 — Tier C-1 daily routines: ORB audio smoke + Cloud Run deploy/
+-- frontend health. No new gateway code; both reuse existing endpoints.
+--
+-- Both follow the autonomy contract from feedback_routines_no_human_briefs.md:
+--   green pass OR self-heal handoff via OASIS event ingest, never briefs.
+-- =============================================================================
+
+INSERT INTO routines (name, display_name, description, cron_schedule)
+VALUES
+  ('orb-audio-smoke',
+   'ORB Audio Smoke Test',
+   'Daily probe of /api/v1/orb/health to confirm Vertex AI Live API is wired up correctly (gemini_live.enabled, vertex_project_id, google_auth_ready). Same checks the EXEC-DEPLOY hard-gate runs on every deploy, but daily and independent. Emits OASIS event orb.live.smoke.regression on any failed check.',
+   '0 8 * * *'),
+  ('cloud-run-frontend-health',
+   'Cloud Run + Frontend Health',
+   'Daily curl of gateway /alive and community-app preview URL. Catches silent deploy failures and CDN propagation issues. Emits OASIS event cloud_run.health.degraded on any non-2xx response.',
+   '30 8 * * *')
+ON CONFLICT (name) DO NOTHING;


### PR DESCRIPTION
## Summary

Two daily routines, **no new gateway code** — both reuse existing endpoints.

| # | Name | Cron UTC | Probe | Issue → OASIS |
|---|---|---|---|---|
| 11 | `orb-audio-smoke` | `0 8 * * *` | `/api/v1/orb/health` (gemini_live.enabled / vertex_project_id / google_auth_ready) | `orb.live.smoke.regression` (VTID-01155) |
| 15 | `cloud-run-frontend-health` | `30 8 * * *` | `gateway /alive` + community-app preview URL + `/api/v1/routines` | `cloud_run.health.degraded` (VTID-02017) |

Same autonomy contract as the prior 8 routines: green tile = nothing for you. Yellow = self-healing already on it. Red = the routine itself broke.

## Files

- `supabase/migrations/20260428110000_vtid_02017_routines_tier_c_batch_1.sql` — INSERT INTO routines for the 2 catalog rows
- `routines/orb-audio-smoke.md` · `routines/cloud-run-frontend-health.md`

## Test plan

- [ ] Apply migration via `RUN-MIGRATION.yml`
- [ ] `curl https://gateway-q74ibpv6ia-uc.a.run.app/api/v1/routines` returns 10 catalog rows (8 existing + 2 new)
- [ ] Create 2 remote routines via `RemoteTrigger.create`
- [ ] Manual `run` each one; verify the catalog tile flips to `success` (or `partial` if a real issue is detected today)

🤖 Generated with [Claude Code](https://claude.com/claude-code)