### PR TITLE
feat(routines): Tier C-2 — knowledge docs / push / migrations / DYK tour / spec memory gate (VTID-02018)

### DIFF
--- a/routines/dyk-tour-progress.md
+++ b/routines/dyk-tour-progress.md
@@ -1,0 +1,30 @@
+# Routine: dyk-tour-progress
+
+**Schedule:** `30 10 * * *` (daily 10:30 UTC)
+**Catalog row:** `routines.name = 'dyk-tour-progress'`
+**OASIS VTID for emitted events:** `VTID-02018`
+
+## Autonomy contract
+
+Daily snapshot of `dyk_user_active_days` distribution to track user progress through the 30-day Did You Know tour. Emits an OASIS event when no users have advanced past day 14 — signal that the tour is stuck. **No briefs.**
+
+| Catalog state | Meaning |
+|---|---|
+| 🟢 `success` | At least one user past day 14, distribution looks healthy. |
+| 🟡 `partial` | No users past day 14 → OASIS event emitted. |
+| 🔴 `failure` | Audit endpoint unreachable. |
+
+## Steps
+
+1. `POST $GATEWAY_URL/api/v1/routines/dyk-tour-progress/runs` (X-Routine-Token).
+2. `GET $GATEWAY_URL/api/v1/routines/audits/dyk-tour-progress` → `{ feature_pending, total_tracked, day_distribution: { "<n>": <count> }, max_day_seen }`.
+3. If `feature_pending === true`: PATCH `success`, summary `"✅ dyk_user_active_days not yet present — feature pending"`. STOP.
+4. If `total_tracked === 0`: PATCH `success`, summary `"✅ No DYK tour users yet — nothing to triage"`. STOP.
+5. Threshold: `breach = max_day_seen < 14 && total_tracked > 5` (a few real users but nobody past mid-tour).
+6. If breach: `POST /api/v1/events/ingest` topic `dyk.tour.coverage_drop`, vtid `VTID-02018`, payload `{ total_tracked, max_day_seen, day_distribution }`.
+7. PATCH:
+   - No breach: `success`, `"✅ DYK tour healthy: {total_tracked} users tracked, max day {max_day_seen}"`.
+   - Breach: `partial`, `"⚠️ DYK tour stuck: {total_tracked} users, max day {max_day_seen}. OASIS event emitted, self-healing notified."`.
+
+## Hard rules
+- Plain `curl`. Wall-clock cap 1 minute. No briefs.

--- a/routines/knowledge-docs-freshness.md
+++ b/routines/knowledge-docs-freshness.md
@@ -1,0 +1,30 @@
+# Routine: knowledge-docs-freshness
+
+**Schedule:** `0 9 * * *` (daily 09:00 UTC)
+**Catalog row:** `routines.name = 'knowledge-docs-freshness'`
+**OASIS VTID for emitted events:** `VTID-02018`
+
+## Autonomy contract
+
+Daily sweep of `knowledge_docs` for entries older than 180 days. Emits an OASIS event when stale-doc count crosses threshold so the existing docs-curation flow picks them up. **No briefs.**
+
+| Catalog state | Meaning |
+|---|---|
+| 🟢 `success` | Stale-doc count below threshold OR feature pending. |
+| 🟡 `partial` | Stale count above threshold → OASIS event emitted. |
+| 🔴 `failure` | Audit endpoint unreachable. |
+
+## Steps
+
+1. `POST $GATEWAY_URL/api/v1/routines/knowledge-docs-freshness/runs` (X-Routine-Token).
+2. `GET $GATEWAY_URL/api/v1/routines/audits/knowledge-docs-staleness?stale_after_days=180` → `{ feature_pending, total_docs, stale_count, sample_stalest[] }`.
+3. If `feature_pending === true`: PATCH `success`, summary `"✅ knowledge_docs table not yet present — feature pending"`. STOP.
+4. Threshold: `breach = stale_count > Math.max(20, total_docs * 0.10)`.
+5. If breach: `POST /api/v1/events/ingest` with topic `docs.staleness.detected`, vtid `VTID-02018`, payload `{ total_docs, stale_count, sample_stalest }`.
+6. PATCH:
+   - No breach: `success`, `"✅ Knowledge docs healthy: {stale_count}/{total_docs} stale"`.
+   - Breach: `partial`, `"⚠️ {stale_count} stale knowledge docs (>{threshold}). OASIS event emitted, self-healing notified."`.
+   - Audit endpoint down: `failure`.
+
+## Hard rules
+- Plain `curl`. Wall-clock cap 1 minute. No briefs.

--- a/routines/migration-backlog.md
+++ b/routines/migration-backlog.md
@@ -1,0 +1,31 @@
+# Routine: migration-backlog
+
+**Schedule:** `0 10 * * *` (daily 10:00 UTC)
+**Catalog row:** `routines.name = 'migration-backlog'`
+**OASIS VTID for emitted events:** `VTID-02018`
+
+## Autonomy contract
+
+Compares `supabase/migrations/*.sql` files in the cloned repo against `schema_migrations` applied in Supabase (via gateway audit endpoint). Lists migrations on disk but never applied. Emits OASIS event when the gap exceeds 5 unapplied migrations. **No briefs.**
+
+| Catalog state | Meaning |
+|---|---|
+| 🟢 `success` | Backlog ≤ 5. |
+| 🟡 `partial` | Backlog > 5 → OASIS event emitted. |
+| 🔴 `failure` | Audit endpoint or repo file listing unreachable. |
+
+## Steps
+
+1. `POST $GATEWAY_URL/api/v1/routines/migration-backlog/runs` (X-Routine-Token).
+2. **List local migrations** — `ls supabase/migrations/*.sql` in the cloned repo. Each filename starts with a timestamp prefix (e.g. `20260427180000_vtid_02006_routines_tier_b.sql`). Extract just the `<ts>` prefix as the version.
+3. **List applied** — `GET $GATEWAY_URL/api/v1/routines/audits/migration-backlog` → `{ applied_count, applied_versions: [...], latest_applied }`.
+4. **Compute gap** — `unapplied = local_versions - applied_versions` (set difference). Sort by version ascending.
+5. Threshold: `breach = unapplied.length > 5`.
+6. If breach: `POST /api/v1/events/ingest` topic `migrations.backlog.detected`, vtid `VTID-02018`, payload `{ unapplied_count, unapplied_versions: unapplied.slice(0, 20), latest_local, latest_applied }`.
+7. PATCH:
+   - No breach: `success`, `"✅ Migration backlog clean: {unapplied.length} unapplied (≤5)"`.
+   - Breach: `partial`, `"⚠️ Migration backlog: {unapplied.length} unapplied. OASIS event emitted, self-healing notified."`.
+
+## Hard rules
+- Plain `curl` + `ls`. Wall-clock cap 1 minute. No briefs.
+- `unapplied` is "files on disk not in applied list" — this surfaces forward backlog only, not anything weird like applied-without-file.

--- a/routines/push-pipeline-probe.md
+++ b/routines/push-pipeline-probe.md
@@ -1,0 +1,36 @@
+# Routine: push-pipeline-probe
+
+**Schedule:** `30 9 * * *` (daily 09:30 UTC)
+**Catalog row:** `routines.name = 'push-pipeline-probe'`
+**OASIS VTID for emitted events:** `VTID-02018`
+
+## Autonomy contract
+
+Daily probe of the push notification stack: external Appilix API reachability + token counts via the gateway audit endpoint. Emits an OASIS event on any breach. **No briefs.**
+
+Background: Appilix push API has been down (522) since March 2026 per memory. This routine watches for recovery and for FCM regressions.
+
+| Catalog state | Meaning |
+|---|---|
+| 🟢 `success` | Appilix reachable AND mobile-token count steady or growing. |
+| 🟡 `partial` | Appilix down OR mobile tokens collapsing → OASIS event emitted. |
+| 🔴 `failure` | Audit endpoint unreachable. |
+
+## Steps
+
+1. `POST $GATEWAY_URL/api/v1/routines/push-pipeline-probe/runs` (X-Routine-Token).
+2. **Appilix reachability** — `curl -sS -o /dev/null -w '%{http_code}' --max-time 10 https://appilix.com/api/push-notification`. Capture `appilix_http_code`. If non-2xx (anything not 200/201/202), Appilix is still down.
+3. **Token counts** — `GET $GATEWAY_URL/api/v1/routines/audits/push-pipeline` → `{ feature_pending, total_tokens, web_tokens, mobile_tokens, new_tokens_last_24h }`.
+4. If `feature_pending === true`: PATCH `success`, summary `"✅ user_device_tokens not yet present — feature pending"`. STOP.
+5. Threshold:
+   - `breach_kinds = []`
+   - if `appilix_http_code` not in {200,201,202}: `breach_kinds.push('appilix_down_' + appilix_http_code)`
+   - if `total_tokens > 0 && new_tokens_last_24h === 0 && total_tokens > 100`: `breach_kinds.push('no_new_tokens_24h')`
+6. If `breach_kinds.length > 0`: `POST /api/v1/events/ingest` topic `push.pipeline.degraded`, vtid `VTID-02018`, payload `{ appilix_http_code, web_tokens, mobile_tokens, new_tokens_last_24h, breach_kinds }`.
+7. PATCH:
+   - No breach: `success`, `"✅ Push pipeline healthy: Appilix {appilix_http_code}, {mobile_tokens} mobile + {web_tokens} web tokens"`.
+   - Breach: `partial`, `"⚠️ Push breach: {breach_kinds}. OASIS event emitted, self-healing notified."`.
+
+## Hard rules
+- Plain `curl`. Wall-clock cap 1 minute. No briefs.
+- Treat the Appilix HTTP probe as best-effort; if `curl` itself times out, treat as 0 (unreachable) and mark `appilix_down_timeout`.

--- a/routines/spec-memory-quarantine.md
+++ b/routines/spec-memory-quarantine.md
@@ -1,0 +1,34 @@
+# Routine: spec-memory-quarantine
+
+**Schedule:** `0 11 * * *` (daily 11:00 UTC)
+**Catalog row:** `routines.name = 'spec-memory-quarantine'`
+**OASIS VTID for emitted events:** `VTID-02018`
+
+## Autonomy contract
+
+Reads `voice_healing_shadow_log` for `outcome=quarantined` entries via the gateway audit endpoint. Emits an OASIS event when quarantine grows >50% week-over-week or oldest entry exceeds 14 days. **No briefs.**
+
+This complements `self-healing-triage` (which clears the human-approval queue) by making sure the spec-quarantine bucket doesn't silently accumulate.
+
+| Catalog state | Meaning |
+|---|---|
+| 🟢 `success` | Quarantine count stable AND oldest within 14 days. |
+| 🟡 `partial` | Growing or stale → OASIS event emitted. |
+| 🔴 `failure` | Audit endpoint unreachable. |
+
+## Steps
+
+1. `POST $GATEWAY_URL/api/v1/routines/spec-memory-quarantine/runs` (X-Routine-Token).
+2. `GET $GATEWAY_URL/api/v1/routines/audits/spec-memory-quarantine` → `{ feature_pending, total_shadow_log, quarantined_now, quarantined_recent_7d, sample_oldest[] }`.
+3. If `feature_pending === true`: PATCH `success`, summary `"✅ voice_healing_shadow_log not yet present — feature pending"`. STOP.
+4. Threshold:
+   - `breach_kinds = []`
+   - `oldest = sample_oldest[0]?.created_at`. If `oldest` exists AND `(now - oldest) > 14 days`: `breach_kinds.push('quarantine_aged')`.
+   - If `quarantined_recent_7d > 0 && quarantined_now > quarantined_recent_7d * 1.5`: `breach_kinds.push('quarantine_growing')`.
+5. If `breach_kinds.length > 0`: `POST /api/v1/events/ingest` topic `voice_healing.quarantine.degraded`, vtid `VTID-02018`, payload `{ quarantined_now, quarantined_recent_7d, oldest, sample_oldest, breach_kinds }`.
+6. PATCH:
+   - No breach: `success`, `"✅ Spec memory gate healthy: {quarantined_now} quarantined, oldest within 14d"`.
+   - Breach: `partial`, `"⚠️ Spec memory gate: {breach_kinds}. OASIS event emitted, self-healing notified."`.
+
+## Hard rules
+- Plain `curl`. Wall-clock cap 1 minute. No briefs.

--- a/services/gateway/src/routes/routine-audits.ts
+++ b/services/gateway/src/routes/routine-audits.ts
@@ -345,3 +345,233 @@ routineAuditsRouter.get(
     }
   }
 );
+
+// =============================================================================
+// VTID-02018 — Tier C-2 audit endpoints
+// =============================================================================
+
+// -----------------------------------------------------------------------------
+// GET /api/v1/routines/audits/knowledge-docs-staleness
+// Used by: knowledge-docs-freshness routine
+// -----------------------------------------------------------------------------
+
+routineAuditsRouter.get(
+  '/api/v1/routines/audits/knowledge-docs-staleness',
+  requireRoutineToken,
+  async (req: Request, res: Response) => {
+    try {
+      const staleAfterDays =
+        Math.min(parseInt(req.query.stale_after_days as string) || 180, 730);
+      const staleCutoff = new Date(Date.now() - staleAfterDays * 24 * 60 * 60 * 1000).toISOString();
+
+      const totalCount = await supaCount('/rest/v1/knowledge_docs');
+      // Stale = updated_at older than cutoff (or created_at if updated_at missing)
+      const staleCount = await supaCount(
+        `/rest/v1/knowledge_docs?updated_at=lt.${staleCutoff}`
+      );
+
+      // Sample of the stalest entries for the audit log
+      const sample = await supaFetch<Array<{
+        id: string;
+        title?: string;
+        path?: string;
+        updated_at?: string;
+        created_at?: string;
+      }>>(
+        `/rest/v1/knowledge_docs?updated_at=lt.${staleCutoff}` +
+          `&select=id,title,path,updated_at,created_at` +
+          `&order=updated_at.asc&limit=10`
+      );
+
+      // If the table doesn't exist totalCount will be null; surface that as `feature_pending`.
+      const featurePending = totalCount === null;
+
+      return res.json({
+        ok: true,
+        feature_pending: featurePending,
+        total_docs: totalCount ?? 0,
+        stale_count: staleCount ?? 0,
+        stale_after_days: staleAfterDays,
+        sample_stalest: sample ?? [],
+      });
+    } catch (e: any) {
+      console.error(`${LOG_PREFIX} knowledge-docs-staleness error:`, e);
+      return res.status(500).json({ ok: false, error: e.message });
+    }
+  }
+);
+
+// -----------------------------------------------------------------------------
+// GET /api/v1/routines/audits/push-pipeline
+// Used by: push-pipeline-probe routine
+// -----------------------------------------------------------------------------
+
+routineAuditsRouter.get(
+  '/api/v1/routines/audits/push-pipeline',
+  requireRoutineToken,
+  async (_req: Request, res: Response) => {
+    try {
+      const totalTokens = await supaCount('/rest/v1/user_device_tokens');
+      const webTokens = await supaCount(
+        '/rest/v1/user_device_tokens?platform=in.(web,chrome,firefox,safari)'
+      );
+      const mobileTokens = await supaCount(
+        '/rest/v1/user_device_tokens?platform=in.(android,ios,appilix)'
+      );
+      const recentTokens = await supaCount(
+        `/rest/v1/user_device_tokens?created_at=gte.${hoursAgoIso(24)}`
+      );
+
+      const featurePending = totalTokens === null;
+
+      return res.json({
+        ok: true,
+        feature_pending: featurePending,
+        total_tokens: totalTokens ?? 0,
+        web_tokens: webTokens ?? 0,
+        mobile_tokens: mobileTokens ?? 0,
+        new_tokens_last_24h: recentTokens ?? 0,
+      });
+    } catch (e: any) {
+      console.error(`${LOG_PREFIX} push-pipeline error:`, e);
+      return res.status(500).json({ ok: false, error: e.message });
+    }
+  }
+);
+
+// -----------------------------------------------------------------------------
+// GET /api/v1/routines/audits/migration-backlog
+// Used by: migration-backlog routine
+// -----------------------------------------------------------------------------
+
+routineAuditsRouter.get(
+  '/api/v1/routines/audits/migration-backlog',
+  requireRoutineToken,
+  async (_req: Request, res: Response) => {
+    try {
+      // Supabase stores applied migrations under schema=supabase_migrations,
+      // table=schema_migrations. Use the schema-qualified PostgREST header.
+      const url = process.env.SUPABASE_URL;
+      const key = process.env.SUPABASE_SERVICE_ROLE;
+      if (!url || !key) {
+        return res.status(503).json({ ok: false, error: 'Supabase env not configured' });
+      }
+      const resp = await fetch(
+        `${url}/rest/v1/schema_migrations?select=version,name,statements&limit=1000&order=version.desc`,
+        {
+          headers: {
+            apikey: key,
+            Authorization: `Bearer ${key}`,
+            'Accept-Profile': 'supabase_migrations',
+          },
+        }
+      );
+      let applied: Array<{ version: string; name?: string }> = [];
+      if (resp.ok) {
+        applied = (await resp.json()) as Array<{ version: string; name?: string }>;
+      }
+
+      return res.json({
+        ok: true,
+        applied_count: applied.length,
+        applied_versions: applied.map((m) => m.version),
+        latest_applied: applied[0]?.version ?? null,
+      });
+    } catch (e: any) {
+      console.error(`${LOG_PREFIX} migration-backlog error:`, e);
+      return res.status(500).json({ ok: false, error: e.message });
+    }
+  }
+);
+
+// -----------------------------------------------------------------------------
+// GET /api/v1/routines/audits/dyk-tour-progress
+// Used by: dyk-tour-progress routine
+// -----------------------------------------------------------------------------
+
+routineAuditsRouter.get(
+  '/api/v1/routines/audits/dyk-tour-progress',
+  requireRoutineToken,
+  async (_req: Request, res: Response) => {
+    try {
+      // dyk_user_active_days tracks per-user usage day counters.
+      // Some installs track tour state in a sibling table; we read what exists.
+      const totalTracked = await supaCount('/rest/v1/dyk_user_active_days');
+      // Distribution of active_day values (1..30) — pull a sample.
+      const sample = await supaFetch<Array<{ user_id?: string; active_day?: number }>>(
+        '/rest/v1/dyk_user_active_days?select=user_id,active_day&order=active_day.desc&limit=2000'
+      );
+      const dayDistribution: Record<number, number> = {};
+      let maxDay = 0;
+      for (const row of sample ?? []) {
+        const d = row.active_day ?? 0;
+        dayDistribution[d] = (dayDistribution[d] || 0) + 1;
+        if (d > maxDay) maxDay = d;
+      }
+
+      const featurePending = totalTracked === null;
+
+      return res.json({
+        ok: true,
+        feature_pending: featurePending,
+        total_tracked: totalTracked ?? 0,
+        day_distribution: dayDistribution,
+        max_day_seen: maxDay,
+        sample_size: sample?.length ?? 0,
+      });
+    } catch (e: any) {
+      console.error(`${LOG_PREFIX} dyk-tour-progress error:`, e);
+      return res.status(500).json({ ok: false, error: e.message });
+    }
+  }
+);
+
+// -----------------------------------------------------------------------------
+// GET /api/v1/routines/audits/spec-memory-quarantine
+// Used by: spec-memory-quarantine routine
+// -----------------------------------------------------------------------------
+
+routineAuditsRouter.get(
+  '/api/v1/routines/audits/spec-memory-quarantine',
+  requireRoutineToken,
+  async (_req: Request, res: Response) => {
+    try {
+      // The voice self-healing loop uses a shadow log; quarantined entries
+      // have outcome='quarantined' or status='quarantined'.
+      const totalShadow = await supaCount('/rest/v1/voice_healing_shadow_log');
+      const quarantinedNow = await supaCount(
+        '/rest/v1/voice_healing_shadow_log?outcome=eq.quarantined'
+      );
+      const quarantinedRecent = await supaCount(
+        `/rest/v1/voice_healing_shadow_log?outcome=eq.quarantined&created_at=gte.${hoursAgoIso(7 * 24)}`
+      );
+
+      // Sample the oldest quarantined entries for the audit log
+      const sample = await supaFetch<Array<{
+        id?: string;
+        endpoint?: string;
+        failure_class?: string;
+        outcome?: string;
+        created_at?: string;
+      }>>(
+        '/rest/v1/voice_healing_shadow_log?outcome=eq.quarantined' +
+          '&select=id,endpoint,failure_class,outcome,created_at' +
+          '&order=created_at.asc&limit=10'
+      );
+
+      const featurePending = totalShadow === null;
+
+      return res.json({
+        ok: true,
+        feature_pending: featurePending,
+        total_shadow_log: totalShadow ?? 0,
+        quarantined_now: quarantinedNow ?? 0,
+        quarantined_recent_7d: quarantinedRecent ?? 0,
+        sample_oldest: sample ?? [],
+      });
+    } catch (e: any) {
+      console.error(`${LOG_PREFIX} spec-memory-quarantine error:`, e);
+      return res.status(500).json({ ok: false, error: e.message });
+    }
+  }
+);

--- a/supabase/migrations/20260428120000_vtid_02018_routines_tier_c_batch_2.sql
+++ b/supabase/migrations/20260428120000_vtid_02018_routines_tier_c_batch_2.sql
@@ -1,0 +1,36 @@
+-- =============================================================================
+-- VTID-02018 — Tier C-2 daily routines: knowledge-docs-freshness, push-pipeline,
+-- migration-backlog, dyk-tour-progress, spec-memory-quarantine.
+-- Seeds catalog only — remote agents are created separately via /schedule.
+--
+-- All five follow the autonomy contract: green pass OR self-heal handoff via
+-- OASIS event ingest, never briefs.
+--
+-- Each routine reads pre-aggregated metrics from a new audit endpoint under
+-- /api/v1/routines/audits/* (X-Routine-Token gated; service role stays on
+-- the gateway, no DB credentials in the sandbox).
+-- =============================================================================
+
+INSERT INTO routines (name, display_name, description, cron_schedule)
+VALUES
+  ('knowledge-docs-freshness',
+   'Knowledge Docs Freshness',
+   'Daily sweep of knowledge_docs for entries older than 180 days. Emits OASIS event docs.staleness.detected when stale-doc count exceeds threshold so the existing docs-curation flow picks them up.',
+   '0 9 * * *'),
+  ('push-pipeline-probe',
+   'Push Notification Pipeline Probe',
+   'Daily probe of the push notification stack: external Appilix API reachability + user_device_tokens counts (web vs mobile). Emits OASIS event push.pipeline.degraded on any breach.',
+   '30 9 * * *'),
+  ('migration-backlog',
+   'Migration Backlog Audit',
+   'Compares the supabase/migrations/*.sql files in the cloned repo against schema_migrations applied in Supabase. Lists migrations that exist on disk but were never applied. Emits OASIS event migrations.backlog.detected when the gap exceeds 5 unapplied migrations.',
+   '0 10 * * *'),
+  ('dyk-tour-progress',
+   'Did You Know Tour Progress',
+   'Daily snapshot of dyk_user_active_days distribution. Tracks user progress through the 30-day tour. Emits OASIS event dyk.tour.coverage_drop when no users have advanced past day 14 — signals the tour is stuck.',
+   '30 10 * * *'),
+  ('spec-memory-quarantine',
+   'Spec Memory Gate Quarantine Sweep',
+   'Reads voice_healing_shadow_log for outcome=quarantined entries. Surfaces aged or growing quarantine. Emits OASIS event voice_healing.quarantine.degraded when count grows >50%/week or oldest entry exceeds 14 days.',
+   '0 11 * * *')
+ON CONFLICT (name) DO NOTHING;


### PR DESCRIPTION
## Summary

Bundles **routines #9, #10, #12, #13, #14** with five new audit endpoints. All on the autonomy contract: green tile = nothing for you. Yellow = self-healing already on it. Red = the routine itself broke. **No briefs.**

| # | Routine | Cron UTC | Audit endpoint | Issue → OASIS |
|---|---|---|---|---|
| 9 | `knowledge-docs-freshness` | `0 9 * * *` | `/audits/knowledge-docs-staleness` | `docs.staleness.detected` |
| 10 | `push-pipeline-probe` | `30 9 * * *` | `/audits/push-pipeline` + Appilix HTTP | `push.pipeline.degraded` |
| 12 | `migration-backlog` | `0 10 * * *` | `/audits/migration-backlog` + repo file list | `migrations.backlog.detected` |
| 13 | `dyk-tour-progress` | `30 10 * * *` | `/audits/dyk-tour-progress` | `dyk.tour.coverage_drop` |
| 14 | `spec-memory-quarantine` | `0 11 * * *` | `/audits/spec-memory-quarantine` | `voice_healing.quarantine.degraded` |

## Files

- `services/gateway/src/routes/routine-audits.ts` — extended with 5 new GET handlers
- `routines/{knowledge-docs-freshness,push-pipeline-probe,migration-backlog,dyk-tour-progress,spec-memory-quarantine}.md` — specs
- `supabase/migrations/20260428120000_vtid_02018_routines_tier_c_batch_2.sql` — INSERT INTO routines for the 5 catalog rows

## Resilience pattern

Each audit endpoint returns `feature_pending: true` when its source table doesn't exist (Supabase REST 404 / null count). The routine treats that as "feature not yet shipped" and exits `success` with that summary — so we don't get false-positive `failure` tiles when a feature ships later or hasn't shipped yet.

## Test plan

- [ ] `npm run typecheck` clean (verified locally — 0 new errors)
- [ ] Apply migration via `RUN-MIGRATION.yml`
- [ ] EXEC-DEPLOY gateway with VTID-02018
- [ ] `curl -H "X-Routine-Token: $TOKEN" .../api/v1/routines/audits/knowledge-docs-staleness?stale_after_days=180` returns counts
- [ ] Same smoke test for the other 4 audit endpoints
- [ ] Create 5 remote routines via `RemoteTrigger.create`
- [ ] Manual `run` each one; verify catalog tile flips to `success` (or `partial` if a real issue is detected today)
- [ ] All 15 catalog rows present after this lands

🤖 Generated with [Claude Code](https://claude.com/claude-code)