### PR TITLE
fix(memory): timestamps in user timezone, CET default (VTID-02019)

### DIFF
--- a/services/gateway/src/routes/conversation.ts
+++ b/services/gateway/src/routes/conversation.ts
@@ -325,7 +325,18 @@ router.post('/turn', async (req: Request, res: Response) => {
 
     // VTID-DEV-ASSIST: Set thread identity with role for tool-level role enforcement
     // VTID-01967: include vitana_id so downstream tools see the canonical handle.
-    setThreadIdentity(thread.thread_id, { tenant_id, user_id, role, vitana_id: vitanaId });
+    // VTID-02019: include user_timezone so recall_conversation_at_time resolves
+    // free-text time hints in the user's local time (falls back to Europe/Berlin
+    // when undefined).
+    const reqUserTz =
+      (req.body?.ui_context?.metadata?.timezone as string | undefined) || undefined;
+    setThreadIdentity(thread.thread_id, {
+      tenant_id,
+      user_id,
+      role,
+      vitana_id: vitanaId,
+      user_timezone: reqUserTz,
+    });
 
     // Create context lens for memory access
     const lens: ContextLens = createContextLens(tenant_id, user_id, {

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -9847,11 +9847,22 @@ router.post('/chat', optionalAuth, async (req: AuthenticatedRequest, res: Respon
     // so downstream tools and any prompt that reads the thread identity can
     // surface the @handle without re-querying.
     if (identity.tenant_id && identity.user_id) {
+      // VTID-02019: forward user_timezone so recall_conversation_at_time resolves
+      // time hints in the caller's local tz. Live ORB session has clientContext
+      // with tz from IP geolocation; this /chat route falls back to whatever the
+      // body supplies. Either way, undefined → Europe/Berlin downstream.
+      const liveSession = sessions.get(orbSessionId) as any;
+      const orbUserTz =
+        liveSession?.clientContext?.timezone ||
+        (body as any)?.timezone ||
+        (body as any)?.user_timezone ||
+        undefined;
       setThreadIdentity(threadId, {
         tenant_id: identity.tenant_id,
         user_id: identity.user_id,
         role: identity.active_role || undefined,
         vitana_id: req.identity?.vitana_id ?? null,
+        user_timezone: orbUserTz,
       });
     }
 

--- a/services/gateway/src/services/conversation-client.ts
+++ b/services/gateway/src/services/conversation-client.ts
@@ -308,11 +308,12 @@ export async function processConversationTurn(
       try {
         const { getAwarenessContext } = await import('./guide/awareness-context');
         const { formatAwarenessForPrompt } = await import('./guide/awareness-prompt');
-        // VTID-01990: thread the user's timezone (if the surface supplied
-        // one via ui_context.metadata.timezone) into awareness so the
-        // sessions-today bucketing is local-day correct. UTC fallback.
-        const userTz =
-          (input.ui_context?.metadata?.timezone as string | undefined) || 'UTC';
+        // VTID-01990 + VTID-02019: thread the user's timezone (if the surface
+        // supplied one via ui_context.metadata.timezone) into awareness so
+        // session bucketing is local-day correct AND HH:MM renders in the
+        // user's local time. When the surface passes nothing, awareness
+        // resolves to Europe/Berlin (system default for our launch market).
+        const userTz = input.ui_context?.metadata?.timezone as string | undefined;
         const awareness = await getAwarenessContext(input.user_id, input.tenant_id, userTz);
         awarenessBlock = formatAwarenessForPrompt(awareness, { compact: true });
       } catch (e: any) {

--- a/services/gateway/src/services/guide/awareness-context.ts
+++ b/services/gateway/src/services/guide/awareness-context.ts
@@ -25,6 +25,7 @@ import { DEFAULT_WAVE_CONFIG } from '../wave-defaults';
 import { describeTimeSince, fetchLastSessionInfo, type LastInteraction } from './temporal-bucket';
 import { getFeatureIntroductions } from './feature-introductions';
 import { getRecentSessionSummaries, getSessionsTodayAndYesterday } from './session-summaries';
+import { resolveUserTimezone } from './user-timezone';
 import { getAdaptationStatus } from './adaptation-applier';
 import { getUserRoutines } from './pattern-extractor';
 import { countActiveUsageDays } from './active-usage';
@@ -61,11 +62,17 @@ const cache = new Map<string, CacheEntry>();
 export async function getAwarenessContext(
   userId: string,
   tenantId: string,
-  userTz: string = 'UTC',
+  userTz?: string,
 ): Promise<UserAwareness> {
+  // VTID-02019: resolve the user's timezone up-front. If the caller didn't
+  // pass one (or passed 'UTC' as a gateway-internal fallback), we substitute
+  // the system default (Europe/Berlin). The resolved tz is both used for the
+  // today/yesterday bucketing query AND attached to the returned awareness
+  // object so prompt formatters render HH:MM in the user's local time.
+  const resolvedTz = resolveUserTimezone(userTz);
   // Cache key includes tz so a tz-agnostic caller and a tz-aware caller don't
   // share a stale today/yesterday split.
-  const cacheKey = `${tenantId}::${userId}::${userTz}`;
+  const cacheKey = `${tenantId}::${userId}::${resolvedTz}`;
   const cached = cache.get(cacheKey);
   if (cached && cached.expires_at > Date.now()) {
     return cached.awareness;
@@ -99,7 +106,7 @@ export async function getAwarenessContext(
     getAdaptationStatus(userId).catch(() => null),
     getUserRoutines(userId, 8).catch(() => []),
     countActiveUsageDays(userId).catch(() => 0),
-    getSessionsTodayAndYesterday(userId, userTz).catch(() => ({ today: [], yesterday_last: null })),
+    getSessionsTodayAndYesterday(userId, resolvedTz).catch(() => ({ today: [], yesterday_last: null })),
   ]);
 
   const tenure = buildTenure(userContext, activeUsageDays);
@@ -150,6 +157,7 @@ export async function getAwarenessContext(
           ended_at: sessionsTodayAndYesterday.yesterday_last.ended_at,
         }
       : null,
+    user_timezone: resolvedTz,
   };
 
   cache.set(cacheKey, { awareness, expires_at: Date.now() + CACHE_TTL_MS });
@@ -363,5 +371,6 @@ function skeletalAwareness(): UserAwareness {
     tastes_preferences: null,
     sessions_today: { count: 0, entries: [] },
     last_session_yesterday: null,
+    user_timezone: resolveUserTimezone(undefined),
   };
 }

--- a/services/gateway/src/services/guide/awareness-prompt.ts
+++ b/services/gateway/src/services/guide/awareness-prompt.ts
@@ -9,6 +9,7 @@
  */
 
 import type { UserAwareness } from './types';
+import { formatLocalHHMM } from './user-timezone';
 
 export interface AwarenessPromptOpts {
   compact?: boolean; // omit section headers, one-line dense form
@@ -100,6 +101,7 @@ function renderSessionsTrackingBlock(awareness: UserAwareness): string {
   const yesterday = awareness.last_session_yesterday;
   if ((!today || today.count === 0) && !yesterday) return '';
 
+  const tz = awareness.user_timezone;
   const out: string[] = [];
 
   if (today && today.count > 0) {
@@ -107,7 +109,7 @@ function renderSessionsTrackingBlock(awareness: UserAwareness): string {
     // Up to 4 most recent today entries, oldest first so the trail reads chronologically
     const entries = today.entries.slice(-4);
     for (const e of entries) {
-      const hhmm = formatLocalHHMM(e.ended_at);
+      const hhmm = formatLocalHHMM(e.ended_at, tz);
       const themes = (e.themes || []).slice(0, 3).join(', ');
       const summary = truncateSummary(e.summary || '', 240);
       const channelTag = e.channel === 'voice' ? 'voice' : 'text';
@@ -116,7 +118,7 @@ function renderSessionsTrackingBlock(awareness: UserAwareness): string {
   }
 
   if (yesterday) {
-    const hhmm = formatLocalHHMM(yesterday.ended_at);
+    const hhmm = formatLocalHHMM(yesterday.ended_at, tz);
     const themes = (yesterday.themes || []).slice(0, 3).join(', ');
     const summary = truncateSummary(yesterday.summary || '', 240);
     out.push(`Yesterday's last session ${hhmm}${themes ? ` themes: ${themes}` : ''} — ${summary}`);
@@ -124,6 +126,7 @@ function renderSessionsTrackingBlock(awareness: UserAwareness): string {
 
   if (out.length > 0) {
     out.push(
+      `(All session times are local to the user — ${tz}. Always quote times in this timezone, never UTC.)`,
       'When the user references a past conversation by time ("we talked yesterday morning..."), call recall_conversation_at_time to fetch the actual turns. Do not invent details from these summaries alone.',
     );
   }
@@ -135,20 +138,6 @@ function ordinal(n: number): string {
   const s = ['th', 'st', 'nd', 'rd'];
   const v = n % 100;
   return `${n}${s[(v - 20) % 10] || s[v] || s[0]}`;
-}
-
-function formatLocalHHMM(iso: string): string {
-  // ISO timestamp -> HH:MM in UTC. The brain's user_timezone-aware formatter
-  // would be richer, but the awareness block is read by both compact and
-  // verbose paths and we don't want to thread tz here. UTC is acceptable —
-  // the times are still ordered correctly and "around 2pm" is fine.
-  try {
-    const d = new Date(iso);
-    if (isNaN(d.getTime())) return iso.slice(11, 16);
-    return d.toISOString().slice(11, 16);
-  } catch {
-    return iso.slice(11, 16);
-  }
 }
 
 function truncateSummary(s: string, max: number): string {

--- a/services/gateway/src/services/guide/session-summaries.ts
+++ b/services/gateway/src/services/guide/session-summaries.ts
@@ -248,7 +248,9 @@ async function fetchTodayWindow(userId: string, userTz: string): Promise<TodayWi
         apikey: SUPABASE_SERVICE_ROLE,
         Authorization: `Bearer ${SUPABASE_SERVICE_ROLE}`,
       },
-      body: JSON.stringify({ p_user_id: userId, p_user_tz: userTz || 'UTC' }),
+      // VTID-02019: caller is responsible for resolving tz; we pass it through
+      // verbatim so the RPC bounds match what the prompt formatter renders.
+      body: JSON.stringify({ p_user_id: userId, p_user_tz: userTz }),
     });
     if (!res.ok) return null;
     const arr = (await res.json()) as TodayWindow[];
@@ -275,14 +277,18 @@ export interface SessionsTodayAndYesterday {
  */
 export async function getSessionsTodayAndYesterday(
   userId: string,
-  userTz: string = 'UTC',
+  userTz?: string,
 ): Promise<SessionsTodayAndYesterday> {
   const empty: SessionsTodayAndYesterday = { today: [], yesterday_last: null };
 
   const supabase = getSupabase();
   if (!supabase) return empty;
 
-  const window = await fetchTodayWindow(userId, userTz);
+  // VTID-02019: lazy import so the type module stays free of side effects
+  const { resolveUserTimezone } = await import('./user-timezone');
+  const tz = resolveUserTimezone(userTz);
+
+  const window = await fetchTodayWindow(userId, tz);
   if (!window) return empty;
 
   // Pull a small range covering both yesterday and today; bucket in JS.

--- a/services/gateway/src/services/guide/types.ts
+++ b/services/gateway/src/services/guide/types.ts
@@ -105,6 +105,12 @@ export interface UserAwareness {
     ended_at: string;
   } | null;
 
+  // VTID-02019 — IANA tz used for any user-facing timestamp rendering
+  // (HH:MM, "this morning"/"yesterday afternoon" buckets, etc.). Resolved by
+  // resolveUserTimezone() — if the surface didn't supply one, this is the
+  // system default (Europe/Berlin) so prompts never show UTC clock values.
+  user_timezone: string;
+
   // Phase E — D43 adaptation status (VTID-01935)
   // Null when adaptation_plans table doesn't exist yet (D43 doesn't write
   // there yet). When populated, shows pending vs applied plans.

--- a/services/gateway/src/services/guide/user-timezone.ts
+++ b/services/gateway/src/services/guide/user-timezone.ts
@@ -1,0 +1,77 @@
+/**
+ * VTID-02019: User-timezone helpers.
+ *
+ * Vitana renders timestamps to humans, not to the gateway's runtime. Whenever
+ * we put a clock value (HH:MM, "this morning", "yesterday afternoon") in
+ * front of the user, it must be in their local timezone — not the Cloud Run
+ * region's tz, not UTC.
+ *
+ * The 10k+ users we expect on launch are in Central European Time. So when a
+ * surface doesn't explicitly tell us the user's tz (or tells us 'UTC' as a
+ * gateway-internal fallback), we resolve to Europe/Berlin instead of UTC.
+ *
+ * Set DEFAULT_USER_TIMEZONE env var to override the system default for a
+ * different launch market.
+ */
+
+export const DEFAULT_USER_TIMEZONE: string =
+  process.env.DEFAULT_USER_TIMEZONE && process.env.DEFAULT_USER_TIMEZONE.trim().length > 0
+    ? process.env.DEFAULT_USER_TIMEZONE
+    : 'Europe/Berlin';
+
+/**
+ * Normalize a user-supplied timezone for human-facing rendering.
+ *
+ * Rules:
+ *   - Valid IANA tz (e.g. "Europe/Berlin", "America/New_York") → use it.
+ *   - 'UTC' / null / undefined / empty → treat as "unknown" and use the
+ *     system default (Europe/Berlin). UTC is what the gateway falls back to
+ *     when a surface doesn't pass a real timezone, so we re-route it.
+ */
+export function resolveUserTimezone(provided: string | null | undefined): string {
+  if (!provided) return DEFAULT_USER_TIMEZONE;
+  const trimmed = provided.trim();
+  if (trimmed.length === 0) return DEFAULT_USER_TIMEZONE;
+  if (trimmed.toUpperCase() === 'UTC') return DEFAULT_USER_TIMEZONE;
+  return trimmed;
+}
+
+/**
+ * Render an ISO instant as "HH:MM" in the user's local timezone (24-hour).
+ * Falls back to a UTC slice if Intl rejects the tz.
+ */
+export function formatLocalHHMM(iso: string, userTz?: string | null): string {
+  const tz = resolveUserTimezone(userTz);
+  try {
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return iso.slice(11, 16);
+    return new Intl.DateTimeFormat('en-GB', {
+      timeZone: tz,
+      hour: '2-digit',
+      minute: '2-digit',
+      hour12: false,
+    }).format(d);
+  } catch {
+    return iso.slice(11, 16);
+  }
+}
+
+/**
+ * Render an ISO instant as "YYYY-MM-DD" in the user's local timezone.
+ */
+export function formatLocalDate(iso: string, userTz?: string | null): string {
+  const tz = resolveUserTimezone(userTz);
+  try {
+    const d = new Date(iso);
+    if (isNaN(d.getTime())) return iso.slice(0, 10);
+    // en-CA gives YYYY-MM-DD with - separators
+    return new Intl.DateTimeFormat('en-CA', {
+      timeZone: tz,
+      year: 'numeric',
+      month: '2-digit',
+      day: '2-digit',
+    }).format(d);
+  } catch {
+    return iso.slice(0, 10);
+  }
+}

--- a/services/gateway/src/services/tool-recall-conversation.ts
+++ b/services/gateway/src/services/tool-recall-conversation.ts
@@ -14,6 +14,8 @@
  * Read-only. Safe by construction — RPC scopes by user_id internally.
  */
 
+import { resolveUserTimezone } from './guide/user-timezone';
+
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
 
@@ -53,17 +55,22 @@ export interface RecallToolResult {
  */
 export function resolveTimeHint(
   hint: string,
-  userTz: string = 'UTC',
+  userTz?: string,
   now: Date = new Date(),
 ): { since: Date; until: Date; label: string } | null {
   const raw = hint.trim().toLowerCase();
   if (!raw) return null;
 
+  // VTID-02019: 'UTC' or unspecified means "we don't know the user's tz" —
+  // resolve to the system default (Europe/Berlin). 10k+ users are CET so
+  // when they say "yesterday morning" they mean CET morning.
+  const tz = resolveUserTimezone(userTz);
+
   // Buckets in the user's local day. Anchored to local midnight.
   // Computed in UTC against a virtual local-midnight.
-  const tzNow = localDayParts(now, userTz);
+  const tzNow = localDayParts(now, tz);
 
-  const todayStartUTC = utcInstantOfLocalMidnight(tzNow.localYear, tzNow.localMonth, tzNow.localDay, userTz);
+  const todayStartUTC = utcInstantOfLocalMidnight(tzNow.localYear, tzNow.localMonth, tzNow.localDay, tz);
   const oneDay = 24 * 3600 * 1000;
 
   type TimeBucket = { startHour: number; endHour: number; label: string };
@@ -240,7 +247,10 @@ export async function executeRecallConversationAtTime(
     return { ok: false, error: 'storage_unavailable' };
   }
 
-  const tz = context.user_timezone || 'UTC';
+  // VTID-02019: pass through whatever tz the executor placed on the thread
+  // identity; resolveTimeHint() will substitute Europe/Berlin if it's UTC or
+  // missing.
+  const tz = context.user_timezone;
   const window = resolveTimeHint(args.time_hint, tz);
   if (!window) {
     return { ok: false, error: 'ambiguous_time' };

--- a/services/gateway/src/services/vitana-brain.ts
+++ b/services/gateway/src/services/vitana-brain.ts
@@ -506,9 +506,12 @@ export async function buildProactiveGuideBlock(input: {
   const guideRole = mapRoleForGuide(input.role);
 
   // Compute the unified awareness picture ONCE — every downstream signal flows from it
+  // VTID-02019: pass the user's tz through so HH:MM in the awareness block
+  // renders local. If the surface didn't supply one, awareness resolves to
+  // Europe/Berlin (system default).
   let awareness: UserAwareness | null = null;
   try {
-    awareness = await getAwarenessContext(input.user_id, input.tenant_id, input.user_timezone || 'UTC');
+    awareness = await getAwarenessContext(input.user_id, input.tenant_id, input.user_timezone);
   } catch (err: any) {
     console.warn(`${LOG_PREFIX} getAwarenessContext failed:`, err?.message);
   }
@@ -1184,13 +1187,29 @@ function buildAwarenessBlock(awareness: UserAwareness | null): string {
 
   // VTID-01990 — cross-surface conversation tracking. Surfaces "this is your
   // Nth session today" + per-session timestamps + yesterday's last session
-  // so Vitana feels persistent across sessions. When the user references a
-  // past time ("we talked yesterday morning..."), the recall_conversation_at_time
-  // tool resolves the window and fetches actual turns; this block tells the
-  // brain that recall is possible.
+  // so Vitana feels persistent across sessions.
+  // VTID-02019 — all timestamps rendered in awareness.user_timezone (default
+  // Europe/Berlin), never UTC. Anytime Vitana quotes a clock value to the
+  // user it must be in the user's local time.
   const sessionsToday = awareness.sessions_today;
   const yesterdayLast = awareness.last_session_yesterday;
   if ((sessionsToday && sessionsToday.count > 0) || yesterdayLast) {
+    const tz = awareness.user_timezone;
+    const fmtHHMM = (iso: string): string => {
+      try {
+        const d = new Date(iso);
+        if (isNaN(d.getTime())) return iso.slice(11, 16);
+        return new Intl.DateTimeFormat('en-GB', {
+          timeZone: tz,
+          hour: '2-digit',
+          minute: '2-digit',
+          hour12: false,
+        }).format(d);
+      } catch {
+        return iso.slice(11, 16);
+      }
+    };
+
     if (sessionsToday && sessionsToday.count > 0) {
       const n = sessionsToday.count + 1;
       const suffix = (() => {
@@ -1202,14 +1221,14 @@ function buildAwarenessBlock(awareness: UserAwareness | null): string {
       lines.push(`Sessions today: ${sessionsToday.count} prior (this is the ${n}${suffix}).`);
       const entries = sessionsToday.entries.slice(-4);
       for (const e of entries) {
-        const hhmm = e.ended_at.slice(11, 16);
+        const hhmm = fmtHHMM(e.ended_at);
         const themes = (e.themes || []).slice(0, 3).join(', ');
         const summary = e.summary && e.summary.length > 240 ? e.summary.slice(0, 239) + '…' : e.summary || '';
         lines.push(`  - ${hhmm} (${e.channel})${themes ? ` themes: ${themes}` : ''} — ${summary}`);
       }
     }
     if (yesterdayLast) {
-      const hhmm = yesterdayLast.ended_at.slice(11, 16);
+      const hhmm = fmtHHMM(yesterdayLast.ended_at);
       const themes = (yesterdayLast.themes || []).slice(0, 3).join(', ');
       const summary =
         yesterdayLast.summary && yesterdayLast.summary.length > 240
@@ -1218,6 +1237,7 @@ function buildAwarenessBlock(awareness: UserAwareness | null): string {
       lines.push(`Yesterday's last session ${hhmm}${themes ? ` themes: ${themes}` : ''} — ${summary}`);
     }
     lines.push(
+      `(All session times are local to the user — ${tz}. Always quote times in this timezone, never UTC.)`,
       'When the user references a past conversation by time ("we talked yesterday morning...", "earlier today we discussed..."), call recall_conversation_at_time to fetch the actual turns. Do not invent details from these summaries alone.',
     );
   }

--- a/services/gateway/test/dyk-tour.test.ts
+++ b/services/gateway/test/dyk-tour.test.ts
@@ -57,6 +57,7 @@ function makeAwareness(overrides: Partial<UserAwareness> = {}): UserAwareness {
     tastes_preferences: null,
     sessions_today: { count: 0, entries: [] },
     last_session_yesterday: null,
+    user_timezone: 'Europe/Berlin',
   };
   return {
     ...base,


### PR DESCRIPTION
## Summary

When the user asked Vitana "when did we have that conversation?", Vitana answered with UTC time — 2h off for Central European users (1h in winter). Vitana should never quote a timestamp in the gateway's timezone; it's always the user's local time.

## Fix

- New `services/gateway/src/services/guide/user-timezone.ts` with `DEFAULT_USER_TIMEZONE` env var (defaults to `Europe/Berlin` since 10k+ users are CET).
- `UserAwareness` gains `user_timezone: string` — populated by awareness-context with the resolved tz so prompt formatters never need to re-thread it.
- `awareness-prompt.ts` + `vitana-brain.ts` (voice formatter) now render HH:MM via `Intl.DateTimeFormat` in `awareness.user_timezone`. Both append a reminder line: *"all session times are local to the user — <tz>. Always quote times in this timezone, never UTC."*
- `tool-recall-conversation.ts`: free-text time hints ("yesterday morning") resolve in the user's tz — not UTC.
- `conversation.ts` + `orb-live.ts` forward the user's tz onto thread identity so recall tool sees it at execution.

To switch markets later, set `DEFAULT_USER_TIMEZONE=America/New_York` (or whatever) on Cloud Run; no code change needed.

## Test plan

- [x] tsc --noEmit clean
- [ ] Apply env var if needed (defaults inline so a vanilla deploy is fine)
- [ ] Re-seed dragan1's dance-matchmaker thread, force closer
- [ ] Send a turn asking "when did we talk about the dance matchmaker?" — verify Vitana quotes **04:42 CEST** (not 02:42 UTC)

🤖 Generated with [Claude Code](https://claude.com/claude-code)