### PR TITLE
feat(voice): cross-cutting visibility — voice exec → self_healing_log + task.injected (VTID-02029)

### DIFF
--- a/services/gateway/src/routes/voice-lab.ts
+++ b/services/gateway/src/routes/voice-lab.ts
@@ -929,6 +929,68 @@ router.post('/healing/reports/:id/execute', async (req: Request, res: Response) 
         continue;
       }
       executedVtids.push(newVtid);
+
+      // VTID-02029: cross-cutting visibility. Insert into self_healing_log
+      // and emit self-healing.task.injected so this VTID appears in the
+      // existing Self-Healing History list and Autonomy Trace timeline
+      // alongside dev-autopilot self-heals — operator doesn't have to
+      // know about a separate voice silo.
+      const recommendation = report.report?.recommendation || {};
+      const recConfidence =
+        typeof recommendation.confidence === 'number' ? recommendation.confidence : 0.5;
+      const shlogEndpoint = `voice-error://${reportClass}`;
+      fetch(`${config.url}/rest/v1/self_healing_log`, {
+        method: 'POST',
+        headers: {
+          apikey: config.key,
+          Authorization: `Bearer ${config.key}`,
+          'Content-Type': 'application/json',
+          Prefer: 'return=minimal',
+        },
+        body: JSON.stringify({
+          vtid: newVtid,
+          endpoint: shlogEndpoint,
+          failure_class: reportClass,
+          confidence: recConfidence,
+          diagnosis: {
+            source: 'voice-investigator-execute',
+            source_report_id: reportId,
+            normalized_signature: reportSig,
+            recommendation_track: recommendation.track || null,
+            step_index: i,
+            step_total: steps.length,
+            step_text: step.slice(0, 500),
+          },
+          outcome: 'pending',
+          blast_radius: 'none',
+          attempt_number: 1,
+        }),
+      }).catch(() => { /* best-effort */ });
+
+      // Emit self-healing.task.injected so Autonomy Trace + downstream
+      // listeners see the same event the canonical injector emits.
+      try {
+        const { emitOasisEvent } = await import('../services/oasis-event-service');
+        await emitOasisEvent({
+          vtid: newVtid,
+          type: 'self-healing.task.injected',
+          source: 'voice-investigator-execute',
+          status: 'info',
+          message: `Voice investigator step ${i + 1}/${steps.length} injected: ${title.slice(0, 100)}`,
+          payload: {
+            service: 'orb-voice',
+            endpoint: shlogEndpoint,
+            failure_class: reportClass,
+            confidence: recConfidence,
+            source_report_id: reportId,
+            normalized_signature: reportSig,
+            step_index: i,
+            step_total: steps.length,
+            recommendation_track: recommendation.track || null,
+            auto_approved: true,
+          },
+        });
+      } catch { /* best-effort */ }
     } catch (err: any) {
       failures.push({ step: step.slice(0, 80), error: err?.message ?? 'unknown' });
     }


### PR DESCRIPTION
## Summary

Voice investigator's **Accept & Execute** path created vtid_ledger rows but did NOT write to self_healing_log or emit self-healing.task.injected. Voice self-healing work was therefore invisible in the existing Self-Healing History list and Autonomy Trace timeline — operator saw a silo.

This PR adds two best-effort writes inside the existing for-loop in POST /healing/reports/:id/execute, right after each VTID is allocated and the ledger row is populated:

1. **self_healing_log INSERT** — matching canonical shape from self-healing-injector-service.ts. Endpoint encoded as voice-error://<class> so dashboards recognize the source.
2. **self-healing.task.injected OASIS event** — same shape the canonical injector emits, so Autonomy Trace renders it on the timeline.

Both writes are best-effort (don't fail execution if they error) — vtid_ledger row remains the source of truth.

## Why

User feedback: "Why is none of this visible in the self-help list? Why is it not visually traceable? Why don't you wire the screens into each other?" The voice loop already worked end-to-end, but operator had to switch tabs to follow it. After this PR, every voice investigator step shows up in the same screens that show every other self-heal.

## Touched files

- services/gateway/src/routes/voice-lab.ts — only file changed; +62 lines inside the existing execute loop.

No frontend changes. No new tables, no new endpoints, no new env vars.

## Test plan

- [x] Typecheck clean
- [ ] After deploy: trigger voice investigator on staging → press Accept & Execute → reload Self-Healing screen → confirm rows appear under Self-Healing History with endpoint=voice-error://voice.<class>
- [ ] Confirm Autonomy Trace timeline shows self-healing.task.injected events for the new VTIDs

## Backfill (post-merge)

Four pre-existing voice VTIDs in vtid_ledger (created before this fix) will not retroactively appear in History without one-shot SQL backfill. Will run via supabase MCP after deploy lands.

🤖 Generated with [Claude Code](https://claude.com/claude-code)