### PR TITLE
feat(routines): bridge to self-healing pipeline (VTID-02032)

### DIFF
--- a/services/gateway/src/routes/routines.ts
+++ b/services/gateway/src/routes/routines.ts
@@ -413,3 +413,142 @@ routinesRouter.patch(
     }
   }
 );
+
+// =============================================================================
+// VTID-02032 — Routine → self-healing bridge
+// =============================================================================
+// When a routine detects a breach, calling this endpoint:
+//   1. Emits an OASIS event (audit trail)
+//   2. Forwards a synthetic HealthReport into POST /api/v1/self-healing/report
+//      so the existing self-healing pipeline (LLM diagnosis + auto-fix-or-
+//      escalate) actually runs on the breach.
+//
+// This closes the gap where routines emitted OASIS events with nothing
+// listening. The autonomy contract: every breach activates self-healing.
+
+const escalateSchema = z.object({
+  routine_name: z.string().min(1).max(64),
+  topic: z.string().min(1).max(128),
+  source_endpoint: z.string().min(1).max(512).optional(),
+  severity: z.enum(['warning', 'critical']).optional(),
+  message: z.string().max(2000),
+  payload: z.unknown().optional(),
+  vtid_for_event: z.string().optional(),
+});
+
+routinesRouter.post(
+  '/api/v1/routines/escalate-incident',
+  requireRoutineToken,
+  async (req: Request, res: Response) => {
+    try {
+      const parsed = escalateSchema.safeParse(req.body);
+      if (!parsed.success) {
+        return res
+          .status(400)
+          .json({ ok: false, error: 'Invalid body', details: parsed.error.flatten() });
+      }
+      const {
+        routine_name,
+        topic,
+        source_endpoint,
+        severity,
+        message,
+        payload,
+        vtid_for_event,
+      } = parsed.data;
+
+      // 1. Emit OASIS event (audit trail) — same shape as /api/v1/events/ingest.
+      const supabaseUrl = process.env.SUPABASE_URL;
+      const svcKey = process.env.SUPABASE_SERVICE_ROLE;
+      let oasisEventId: string | null = null;
+      if (supabaseUrl && svcKey) {
+        try {
+          const eventResp = await fetch(`${supabaseUrl}/rest/v1/oasis_events`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              apikey: svcKey,
+              Authorization: `Bearer ${svcKey}`,
+              Prefer: 'return=representation',
+            },
+            body: JSON.stringify({
+              vtid: vtid_for_event ?? 'SYSTEM',
+              topic,
+              service: `routine.${routine_name}`,
+              role: 'API',
+              model: 'routine-escalate-incident',
+              status: severity ?? 'warning',
+              message,
+              metadata: payload ?? {},
+              created_at: new Date().toISOString(),
+            }),
+          });
+          if (eventResp.ok) {
+            const data = (await eventResp.json()) as Array<{ id?: string }>;
+            oasisEventId = Array.isArray(data) && data[0]?.id ? data[0].id : null;
+          }
+        } catch (e) {
+          console.warn(`${LOG_PREFIX} oasis ingest failed (non-fatal):`, e);
+        }
+      }
+
+      // 2. Forward a synthetic HealthReport to /api/v1/self-healing/report so the
+      //    full pipeline (diagnose, allocate VTID, auto-fix or escalate) runs.
+      const syntheticEndpoint =
+        source_endpoint && source_endpoint.startsWith('/')
+          ? source_endpoint
+          : `routine-incident://${routine_name}/${topic.replace(/[^a-zA-Z0-9._-]/g, '_')}`;
+
+      const port = process.env.PORT || '8080';
+      const internalUrl = `http://localhost:${port}/api/v1/self-healing/report`;
+      const healthReport = {
+        timestamp: new Date().toISOString(),
+        total: 1,
+        live: 0,
+        services: [
+          {
+            name: `routine.${routine_name}`,
+            endpoint: syntheticEndpoint,
+            status: 'down',
+            http_status: null,
+            response_body: '',
+            response_time_ms: 0,
+            error_message: `${message} | payload=${JSON.stringify(payload ?? {}).slice(0, 1500)}`,
+          },
+        ],
+      };
+
+      let selfHealingResult: any = null;
+      let selfHealingError: string | null = null;
+      try {
+        const r = await fetch(internalUrl, {
+          method: 'POST',
+          headers: { 'Content-Type': 'application/json' },
+          body: JSON.stringify(healthReport),
+        });
+        const text = await r.text();
+        try {
+          selfHealingResult = text ? JSON.parse(text) : null;
+        } catch {
+          selfHealingResult = { raw: text.slice(0, 500) };
+        }
+        if (!r.ok) {
+          selfHealingError = `${r.status}: ${text.slice(0, 200)}`;
+        }
+      } catch (e: any) {
+        selfHealingError = e.message;
+      }
+
+      return res.status(200).json({
+        ok: true,
+        oasis_event_id: oasisEventId,
+        synthetic_endpoint: syntheticEndpoint,
+        self_healing: selfHealingResult,
+        self_healing_error: selfHealingError,
+      });
+    } catch (error: any) {
+      console.error(`${LOG_PREFIX} escalate-incident error:`, error);
+      return res.status(500).json({ ok: false, error: error.message });
+    }
+  }
+);

--- a/services/gateway/src/routes/self-healing.ts
+++ b/services/gateway/src/routes/self-healing.ts
@@ -388,10 +388,15 @@ router.post('/report', async (req: Request, res: Response) => {
     // ORB voice failures through the same diagnose/inject/dispatch chain.
     // Subsequent PRs add the adapter, deterministic specs, and synthetic probe.
     const VOICE_SYNTHETIC_ENDPOINT = /^voice-error:\/\/[a-z._-]+$/;
+    // VTID-02032: Routine incidents — synthetic endpoint pattern for breaches detected
+    // by the daily routines, so the self-healing pipeline picks them up via the same
+    // diagnose/spec/dispatch chain that handles voice-synthetic errors.
+    const ROUTINE_SYNTHETIC_ENDPOINT = /^routine-incident:\/\/[a-zA-Z0-9._-]+\/[a-zA-Z0-9._-]+$/;
 
     for (const failure of downServices) {
       const isVoiceSynthetic = VOICE_SYNTHETIC_ENDPOINT.test(failure.endpoint);
-      if (!isVoiceSynthetic && !knownEndpoints.has(failure.endpoint)) {
+      const isRoutineSynthetic = ROUTINE_SYNTHETIC_ENDPOINT.test(failure.endpoint);
+      if (!isVoiceSynthetic && !isRoutineSynthetic && !knownEndpoints.has(failure.endpoint)) {
         console.log(`[self-healing] Rejecting unknown endpoint: ${failure.endpoint}`);
         details.push({
           service: failure.name,


### PR DESCRIPTION
## Summary

Closes the autonomy gap where routines emitted OASIS events but **nothing was listening**. With this PR, every routine breach reliably activates the existing self-healing pipeline (LLM diagnosis → spec generation → worker dispatch or escalation).

User instruction: *"as soon as we identify an error, a bug, or something that does not work the way it should, it is reported to the self-healing process so that it activates the self-healing process and that the system fixes the issue."*

## Two minimal additions

### 1. `self-healing.ts` — accept routine-synthetic endpoints
Mirrors the existing `VOICE_SYNTHETIC_ENDPOINT` regex. `/api/v1/self-healing/report` now accepts endpoints matching `routine-incident://<routine_name>/<topic>` without requiring them to exist in the gateway's static route map.

### 2. `routines.ts` — `POST /api/v1/routines/escalate-incident`
X-Routine-Token gated. Routine-friendly payload:
```json
{
  "routine_name": "supabase-io-audit",
  "topic": "database.io_pressure.daily_audit",
  "source_endpoint": "/api/v1/routines/audits/io-pressure",  // optional
  "severity": "warning",
  "message": "Retention drift: 12,430 stale info-events older than 7d",
  "payload": { "retention_drift_count": 12430, "today_count": 19620, "baseline_avg_per_day": 9108, "breach_kinds": ["retention_drift"] }
}
```
Action:
1. Inserts an `oasis_events` row (audit trail, same shape as `/events/ingest`).
2. Constructs a synthetic `HealthReport` and POSTs internally to `/api/v1/self-healing/report` so the full pipeline runs: dedup + circuit-breaker → diagnosis → allocate VTID → auto-fix-or-escalate-or-deep-triage.

Returns `{ ok, oasis_event_id, synthetic_endpoint, self_healing: { ok, processed, vtids_created, details: [...] } }`.

## Routine prompt updates (post-deploy, separately via RemoteTrigger.update)

Each of the 13 routines that detect breaches will be updated to call `escalate-incident` when their threshold check fires. Routines that take action directly (`self-healing-triage`, `draft-pr-babysitter`) don't need this.

## Test plan

- [x] `npm run typecheck` clean (0 new errors in routines.ts + self-healing.ts)
- [ ] Apply nothing (no migration in this PR)
- [ ] EXEC-DEPLOY gateway with VTID-02032
- [ ] `curl -H "X-Routine-Token: $TOKEN" -X POST .../api/v1/routines/escalate-incident -d '{"routine_name":"smoke","topic":"smoke.test","message":"end-to-end smoke","payload":{}}'` returns `self_healing.ok=true` and a `vtids_created` count
- [ ] A new self_healing_log row exists for `routine-incident://smoke/smoke.test`
- [ ] Update one routine (start with `agents-heartbeat`) to use `escalate-incident`; verify a real cron-triggered breach lands in self_healing_log

🤖 Generated with [Claude Code](https://claude.com/claude-code)