### PR TITLE
feat(events): auto-route routine breaches into self-healing (VTID-02032 v3)

### DIFF
--- a/services/gateway/src/routes/events.ts
+++ b/services/gateway/src/routes/events.ts
@@ -115,9 +115,98 @@ router.post("/api/v1/events/ingest", async (req: Request, res: Response) => {
 
     console.log(`✅ Event ingested: ${eventId} - ${body.vtid}/${body.type}`);
 
+    // VTID-02032: Auto-route routine-emitted breaches into self-healing.
+    // When a daily routine ingests an event with source=routine.* AND
+    // status=warning|critical, that's a detected breach. Write a
+    // self_healing_log row so the existing reconciler + self-healing-triage
+    // routine pick it up and dispatch the fix. Closes the autonomy loop:
+    // routine detects → event ingests → self-healing activates → triage
+    // approves (confidence 0.5) → worker dispatched.
+    let selfHealingVtid: string | null = null;
+    let selfHealingLogId: string | null = null;
+    const isRoutineBreach =
+      typeof body.source === 'string' &&
+      body.source.startsWith('routine.') &&
+      (body.status === 'warning' || body.status === 'error');
+    if (isRoutineBreach) {
+      try {
+        // Allocate VTID via canonical RPC.
+        const allocResp = await fetch(`${supabaseUrl}/rest/v1/rpc/allocate_global_vtid`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            apikey: svcKey,
+            Authorization: `Bearer ${svcKey}`,
+          },
+          body: JSON.stringify({
+            p_source: body.source,
+            p_layer: 'DEV',
+            p_module: 'COMHU',
+          }),
+        });
+        if (allocResp.ok) {
+          const alloc = (await allocResp.json()) as Array<{ vtid?: string }>;
+          selfHealingVtid =
+            Array.isArray(alloc) && alloc[0]?.vtid ? alloc[0].vtid : null;
+        }
+
+        if (selfHealingVtid) {
+          // Synthetic endpoint pattern matches ROUTINE_SYNTHETIC_ENDPOINT in
+          // self-healing.ts so /report would accept it too if invoked.
+          const safeTopic = (body.type || 'unknown').replace(/[^a-zA-Z0-9._-]/g, '_');
+          const safeRoutine = body.source.replace(/^routine\./, '').replace(/[^a-zA-Z0-9._-]/g, '_');
+          const syntheticEndpoint = `routine-incident://${safeRoutine}/${safeTopic}`;
+
+          const logResp = await fetch(`${supabaseUrl}/rest/v1/self_healing_log`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              apikey: svcKey,
+              Authorization: `Bearer ${svcKey}`,
+              Prefer: 'return=representation',
+            },
+            body: JSON.stringify({
+              vtid: selfHealingVtid,
+              endpoint: syntheticEndpoint,
+              failure_class: body.source,
+              confidence: 0.5,
+              diagnosis: {
+                source: 'routine.events.ingest.auto-route',
+                routine_source: body.source,
+                topic: body.type,
+                severity: body.status,
+                message: body.message,
+                payload: body.payload || {},
+                oasis_event_id: insertedEvent.id,
+                routed_at: new Date().toISOString(),
+              },
+              outcome: 'pending',
+              attempt_number: 1,
+              blast_radius: body.status === 'error' ? 'critical' : 'contained',
+            }),
+          });
+          if (logResp.ok) {
+            const logData = (await logResp.json()) as Array<{ id?: string }>;
+            selfHealingLogId =
+              Array.isArray(logData) && logData[0]?.id ? logData[0].id : null;
+            console.log(
+              `[events.ingest] Auto-routed routine breach → self_healing_log ${selfHealingLogId} (${selfHealingVtid})`
+            );
+          }
+        }
+      } catch (autoRouteErr: any) {
+        // Best-effort; don't fail the OASIS event ingest if self-healing routing fails.
+        console.warn(
+          `[events.ingest] Self-healing auto-route failed (non-fatal): ${autoRouteErr.message}`
+        );
+      }
+    }
+
     return res.status(200).json({
       ok: true,
-      event_id: insertedEvent.id
+      event_id: insertedEvent.id,
+      self_healing_vtid: selfHealingVtid,
+      self_healing_log_id: selfHealingLogId,
     });
   } catch (e: any) {
     console.error("❌ Unexpected error:", e);


### PR DESCRIPTION
## Summary

Closes the autonomy loop **without touching any of the 13 routine prompts.**

When `POST /api/v1/events/ingest` receives an event with `source = routine.*` and `status = warning|error`, it now also writes a `self_healing_log` row (allocate VTID + insert) so the existing self-healing pipeline picks it up.

User instruction: *"as soon as we identify an error, a bug, or something that does not work the way it should, it is reported to the self-healing process so that it activates the self-healing process and that the system fixes the issue."*

## How the loop closes

1. Routine detects breach → calls `POST /api/v1/events/ingest` (already does this)
2. Gateway sees `source: "routine.<name>"` + `status: "warning"` → also writes `self_healing_log` row with `confidence=0.5, outcome=pending`
3. `self-healing-triage` daily routine's APPROVE heuristic (`attempt<=2 AND confidence>=0.5 AND not quarantined`) approves the row
4. `/api/v1/self-healing/approve` dispatches the fix via the worker
5. Reconciler also picks up the row via its 10-min sweep

No human in the loop. No new routine prompts.

## Test plan

- [x] Typecheck clean
- [ ] Deploy + smoke test:
  ```
  curl -X POST .../api/v1/events/ingest -d '{"vtid":"SYSTEM","type":"smoke.test","source":"routine.smoke","status":"warning","message":"smoke","payload":{}}'
  ```
  Expected response: `{ ok: true, event_id, self_healing_vtid: "VTID-...", self_healing_log_id }`
- [ ] Verify the row in `self_healing_log` exists with `confidence=0.5, outcome=pending`
- [ ] On next `self-healing-triage` cron tick, the row gets approved + dispatched

🤖 Generated with [Claude Code](https://claude.com/claude-code)