### PR TITLE
fix(gateway): scope admin-router requireAuth to actual admin paths (VTID-02032)

### DIFF
--- a/services/gateway/src/routes/admin-embeddings-backfill.ts
+++ b/services/gateway/src/routes/admin-embeddings-backfill.ts
@@ -31,8 +31,12 @@ import { emitOasisEvent } from '../services/oasis-event-service';
 
 const router = Router();
 
-router.use(requireAuth);
-router.use(requireExafyAdmin);
+// VTID-02032: Path-scoped auth — was `router.use(requireAuth)` which fired
+// for every /api/v1/* request because this router is mounted at /api/v1.
+// That intercepts unrelated public endpoints (events ingest, voice-lab, etc.)
+// and 401s them. Restrict to the actual admin paths.
+router.use('/admin/embeddings', requireAuth);
+router.use('/admin/embeddings', requireExafyAdmin);
 
 const VTID = 'VTID-01972';
 

--- a/services/gateway/src/routes/admin-memory-broker.ts
+++ b/services/gateway/src/routes/admin-memory-broker.ts
@@ -21,8 +21,12 @@ import {
 import { getMemoryContext, MemoryIntent, MemoryBlockKind } from '../services/memory-broker';
 
 const router = Router();
-router.use(requireAuth);
-router.use(requireExafyAdmin);
+// VTID-02032: Path-scoped auth — was `router.use(requireAuth)` which fired
+// for every /api/v1/* request because this router is mounted at /api/v1.
+// That intercepts unrelated public endpoints and 401s them. Restrict to
+// the actual admin paths.
+router.use('/admin/memory', requireAuth);
+router.use('/admin/memory', requireExafyAdmin);
 
 const VALID_INTENTS: MemoryIntent[] = [
   'recall_recent',

--- a/services/gateway/src/routes/events.ts
+++ b/services/gateway/src/routes/events.ts
@@ -115,9 +115,98 @@ router.post("/api/v1/events/ingest", async (req: Request, res: Response) => {
 
     console.log(`✅ Event ingested: ${eventId} - ${body.vtid}/${body.type}`);
 
+    // VTID-02032: Auto-route routine-emitted breaches into self-healing.
+    // When a daily routine ingests an event with source=routine.* AND
+    // status=warning|critical, that's a detected breach. Write a
+    // self_healing_log row so the existing reconciler + self-healing-triage
+    // routine pick it up and dispatch the fix. Closes the autonomy loop:
+    // routine detects → event ingests → self-healing activates → triage
+    // approves (confidence 0.5) → worker dispatched.
+    let selfHealingVtid: string | null = null;
+    let selfHealingLogId: string | null = null;
+    const isRoutineBreach =
+      typeof body.source === 'string' &&
+      body.source.startsWith('routine.') &&
+      (body.status === 'warning' || body.status === 'error');
+    if (isRoutineBreach) {
+      try {
+        // Allocate VTID via canonical RPC.
+        const allocResp = await fetch(`${supabaseUrl}/rest/v1/rpc/allocate_global_vtid`, {
+          method: 'POST',
+          headers: {
+            'Content-Type': 'application/json',
+            apikey: svcKey,
+            Authorization: `Bearer ${svcKey}`,
+          },
+          body: JSON.stringify({
+            p_source: body.source,
+            p_layer: 'DEV',
+            p_module: 'COMHU',
+          }),
+        });
+        if (allocResp.ok) {
+          const alloc = (await allocResp.json()) as Array<{ vtid?: string }>;
+          selfHealingVtid =
+            Array.isArray(alloc) && alloc[0]?.vtid ? alloc[0].vtid : null;
+        }
+
+        if (selfHealingVtid) {
+          // Synthetic endpoint pattern matches ROUTINE_SYNTHETIC_ENDPOINT in
+          // self-healing.ts so /report would accept it too if invoked.
+          const safeTopic = (body.type || 'unknown').replace(/[^a-zA-Z0-9._-]/g, '_');
+          const safeRoutine = body.source.replace(/^routine\./, '').replace(/[^a-zA-Z0-9._-]/g, '_');
+          const syntheticEndpoint = `routine-incident://${safeRoutine}/${safeTopic}`;
+
+          const logResp = await fetch(`${supabaseUrl}/rest/v1/self_healing_log`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              apikey: svcKey,
+              Authorization: `Bearer ${svcKey}`,
+              Prefer: 'return=representation',
+            },
+            body: JSON.stringify({
+              vtid: selfHealingVtid,
+              endpoint: syntheticEndpoint,
+              failure_class: body.source,
+              confidence: 0.5,
+              diagnosis: {
+                source: 'routine.events.ingest.auto-route',
+                routine_source: body.source,
+                topic: body.type,
+                severity: body.status,
+                message: body.message,
+                payload: body.payload || {},
+                oasis_event_id: insertedEvent.id,
+                routed_at: new Date().toISOString(),
+              },
+              outcome: 'pending',
+              attempt_number: 1,
+              blast_radius: body.status === 'error' ? 'critical' : 'contained',
+            }),
+          });
+          if (logResp.ok) {
+            const logData = (await logResp.json()) as Array<{ id?: string }>;
+            selfHealingLogId =
+              Array.isArray(logData) && logData[0]?.id ? logData[0].id : null;
+            console.log(
+              `[events.ingest] Auto-routed routine breach → self_healing_log ${selfHealingLogId} (${selfHealingVtid})`
+            );
+          }
+        }
+      } catch (autoRouteErr: any) {
+        // Best-effort; don't fail the OASIS event ingest if self-healing routing fails.
+        console.warn(
+          `[events.ingest] Self-healing auto-route failed (non-fatal): ${autoRouteErr.message}`
+        );
+      }
+    }
+
     return res.status(200).json({
       ok: true,
-      event_id: insertedEvent.id
+      event_id: insertedEvent.id,
+      self_healing_vtid: selfHealingVtid,
+      self_healing_log_id: selfHealingLogId,
     });
   } catch (e: any) {
     console.error("❌ Unexpected error:", e);


### PR DESCRIPTION
## Critical fix

The `admin-embeddings-backfill` and `admin-memory-broker` routers are both mounted at `/api/v1` (in `index.ts` lines 812 and 829) and had `router.use(requireAuth)` at the top.

In Express, that fires `requireAuth` for **every** request whose URL prefix matches `/api/v1` — including unrelated public endpoints (`/api/v1/events/ingest`, `/api/v1/self-healing/*`, `/api/v1/voice-lab/*`, etc.). When the request lacks a Bearer token, requireAuth returns 401 immediately, before Express ever reaches the actual handler in another router.

**Why this matters for the autonomy loop:** the 13 daily routines POST OASIS events to `/api/v1/events/ingest` with no auth — they relied on it being public. Since this regression, every routine's breach-emission has been silently 401ing, breaking the detection→self-healing wire-up entirely.

## Fix

Scope the requireAuth middleware to just the admin sub-paths:

```diff
- router.use(requireAuth);
- router.use(requireExafyAdmin);
+ router.use('/admin/embeddings', requireAuth);
+ router.use('/admin/embeddings', requireExafyAdmin);
```

Same pattern for `admin-memory-broker` (`/admin/memory`).

After this:
- `/api/v1/admin/embeddings/*` → still Bearer + exafy_admin gated (unchanged)
- `/api/v1/admin/memory/*` → same
- All other `/api/v1/*` paths → reach their actual handler (no spurious 401s)

## What this unblocks

- The v3 events.ts auto-route (this same PR) finally activates: routines emit OASIS events with `source: routine.*, status: warning` → gateway writes a `self_healing_log` row → self-healing-triage approves it → worker dispatched.
- All other public `/api/v1` endpoints that were silently 401ing.

## Test plan

- [x] Typecheck clean
- [ ] After deploy: `curl -X POST .../api/v1/events/ingest -d '{"vtid":"SYSTEM","type":"smoke","source":"routine.smoke","status":"warning","message":"smoke","payload":{}}'` returns `{ok:true, event_id, self_healing_vtid, self_healing_log_id}`
- [ ] `curl .../api/v1/admin/embeddings/backfill/status` (no Bearer) still returns 401 (auth still works for actual admin paths)
- [ ] `curl .../api/v1/voice-lab/live/sessions` works without Bearer (other public endpoints unblocked)

🤖 Generated with [Claude Code](https://claude.com/claude-code)