### PR TITLE
fix(notif): route chat push via Appilix-only so taps deep-link into app

### DIFF
--- a/services/gateway/src/routes/chat.ts
+++ b/services/gateway/src/routes/chat.ts
@@ -111,6 +111,10 @@ router.post('/send', requireAuth, requireTenant, async (req: Request, res: Respo
     // BOOTSTRAP-NOTIF-CATEGORIES: Use /inbox?thread=<sender_id> so the Messages
     // page deep-links into the conversation. The legacy `/messages/<id>` URL
     // was redirected to `/inbox` by App.tsx, stripping the thread parameter.
+    // `&context=global` ensures the Messages page selects the global chat
+    // context on mount so the thread auto-opens regardless of the recipient's
+    // current context preference (otherwise a `tenant`-context user lands on
+    // /inbox without the thread being selected).
     notifyUserAsync(
       receiver_id,
       identity.tenant_id!,
@@ -124,7 +128,7 @@ router.post('/send', requireAuth, requireTenant, async (req: Request, res: Respo
           sender_name: senderName,
           message_id: data.id,
           thread_id: identity.user_id,
-          url: `/inbox?thread=${identity.user_id}`,
+          url: `/inbox?thread=${identity.user_id}&context=global`,
         },
       },
       supabase,

--- a/services/gateway/src/services/notification-service.ts
+++ b/services/gateway/src/services/notification-service.ts
@@ -524,15 +524,32 @@ export async function notifyUser(
   // Only send ONE push per user to avoid duplicate notifications.
   // FCM covers desktop Chrome + mobile Chrome; Appilix covers Maxina app
   // users who have no FCM tokens registered.
+  //
+  // Exception: chat-category notifications go Appilix-only on users who
+  // have the mobile app installed. The reason is deep-linking — when the
+  // user taps a chat push, they should land directly in the conversation
+  // inside the Maxina app (where they're already signed in). FCM web push
+  // opens the link in the user's browser, which is a different session
+  // from the app and forces the user through `/maxina` sign-in. iOS
+  // Universal Links + Android App Links can only fire when the OS
+  // delivers the URL to the app, which Appilix push does and FCM web push
+  // doesn't. Trade-off: a desktop-browser-only user with no Appilix app
+  // installed will not see a chat browser pop-up; they'll still see the
+  // in-app red dot + bell when they next open the app.
+  const isChatCategory = meta.category === 'chat';
   let pushed = 0;
   let appilixSent = false;
   if (shouldSendPush) {
-    // Try FCM first (delivers to all registered device tokens)
-    pushed = await sendPushToUser(userId, tenantId, payload, supabase);
-
-    // Appilix native push only if no FCM tokens delivered
-    if (pushed === 0) {
+    if (isChatCategory) {
       appilixSent = await sendAppilixPush(userId, payload);
+    } else {
+      // Try FCM first (delivers to all registered device tokens)
+      pushed = await sendPushToUser(userId, tenantId, payload, supabase);
+
+      // Appilix native push only if no FCM tokens delivered
+      if (pushed === 0) {
+        appilixSent = await sendAppilixPush(userId, payload);
+      }
     }
   }
 


### PR DESCRIPTION
## Summary

Tapping a chat push notification on a phone where the user is already signed into the Maxina Appilix app currently lands on the **Maxina sign-in screen** instead of the conversation. Same UX bug class as the shorts redirection we just fixed, but the cause is the **push transport**, not the URL.

## Root cause

`notifyUser()` prefers FCM (web push) over Appilix native push and only falls back to Appilix when no FCM tokens are registered. Users who have ever clicked "Allow notifications" in Chrome have FCM tokens, so chat pushes fire as **web push notifications**. Tapping a web push opens the URL in the user's browser — a **separate session** from the Appilix app's WebView. With no session there, AuthGuard intercepts and redirects to `/maxina?redirectTo=/inbox?thread=<sender_id>`.

iOS Universal Links + Android App Links only fire when the OS delivers the URL to the **app**, which Appilix push does and FCM web push doesn't.

(Shorts share-link taps work because they originate from a system tap on the link itself — WhatsApp message → OS app-link handoff → Maxina app — not from a push.)

## Fix

1. **`notification-service.ts`** — when `meta.category === 'chat'`, skip the FCM path entirely and send only via Appilix. Trade-off: a desktop-browser-only user with no Maxina app installed will not see a chat browser pop-up; they still get the in-app red dot + bell when they open the app, and the inapp `user_notifications` row is still written exactly as before.
2. **`chat.ts`** — append `&context=global` to the deep-link URL so the Messages page selects the global chat context on mount and the thread auto-opens. Without it, a `tenant`-context user lands on /inbox without the thread being selected.

Other categories (events, profile follows, system, etc.) still go through FCM-first → Appilix-fallback unchanged.

## Test plan

- [ ] Send a chat message to a user with the Maxina app installed + browser notifications enabled. Recipient receives a single push, taps it, opens directly in the app on the conversation. **No sign-in screen.**
- [ ] Same test on a user with only the Maxina app (no FCM tokens). Receives Appilix push, taps, lands on conversation.
- [ ] Send a non-chat notification (e.g., new follower). Still arrives via FCM web push for browser users, Appilix for app-only users.
- [ ] Confirm in-app red dot + bell + toast still fire for chat messages on users currently using the web app (inapp write path is unchanged).

---
_Generated by [Claude Code](https://claude.ai/code/session_01AHwc6XR89bXLgqUtxzEWGy)_