### PR TITLE
fix(events): retry allocator on duplicate-key errors (VTID-02032)

### DIFF
--- a/services/gateway/src/routes/events.ts
+++ b/services/gateway/src/routes/events.ts
@@ -130,24 +130,41 @@ router.post("/api/v1/events/ingest", async (req: Request, res: Response) => {
       (body.status === 'warning' || body.status === 'error');
     if (isRoutineBreach) {
       try {
-        // Allocate VTID via canonical RPC.
-        const allocResp = await fetch(`${supabaseUrl}/rest/v1/rpc/allocate_global_vtid`, {
-          method: 'POST',
-          headers: {
-            'Content-Type': 'application/json',
-            apikey: svcKey,
-            Authorization: `Bearer ${svcKey}`,
-          },
-          body: JSON.stringify({
-            p_source: body.source,
-            p_layer: 'DEV',
-            p_module: 'COMHU',
-          }),
-        });
-        if (allocResp.ok) {
-          const alloc = (await allocResp.json()) as Array<{ vtid?: string }>;
-          selfHealingVtid =
-            Array.isArray(alloc) && alloc[0]?.vtid ? alloc[0].vtid : null;
+        // Allocate VTID via canonical RPC. The allocator's `global_vtid_seq`
+        // can fall behind reality if other paths insert VTIDs without the
+        // sequence — manifests as duplicate-key 23505 errors. Retry up to
+        // 20 times so the sequence catches up to the next free slot.
+        for (let attempt = 0; attempt < 20 && !selfHealingVtid; attempt++) {
+          const allocResp = await fetch(`${supabaseUrl}/rest/v1/rpc/allocate_global_vtid`, {
+            method: 'POST',
+            headers: {
+              'Content-Type': 'application/json',
+              apikey: svcKey,
+              Authorization: `Bearer ${svcKey}`,
+            },
+            body: JSON.stringify({
+              p_source: body.source,
+              p_layer: 'DEV',
+              p_module: 'COMHU',
+            }),
+          });
+          if (allocResp.ok) {
+            const alloc = (await allocResp.json()) as Array<{ vtid?: string }>;
+            selfHealingVtid =
+              Array.isArray(alloc) && alloc[0]?.vtid ? alloc[0].vtid : null;
+            break;
+          }
+          // Read body to know if it's a duplicate-key conflict (retryable)
+          const errText = await allocResp.text();
+          if (allocResp.status === 409 || errText.includes('"code":"23505"')) {
+            // sequence advanced by 1 on the failed call; loop and try again
+            continue;
+          }
+          // Other error — give up, log
+          console.warn(
+            `[events.ingest] allocator failed (${allocResp.status}): ${errText.slice(0, 200)}`
+          );
+          break;
         }
 
         if (selfHealingVtid) {


### PR DESCRIPTION
## Problem

`POST /api/v1/events/ingest` auto-routes routine breaches by allocating a VTID and writing a `self_healing_log` row. The `allocate_global_vtid` RPC was returning PostgreSQL error 23505 (unique constraint violation) because `global_vtid_seq` is behind the highest existing VTID — multiple other paths have inserted VTIDs without going through the sequence.

Without retry, the auto-route silently fails (`self_healing_vtid` stays null, log row never written, self-healing never activates).

## Fix

Loop the allocator up to 20 times on 23505 errors. Each call advances the sequence by 1 regardless of insert outcome, so retries converge on the next free slot.

## Verification

```
curl -X POST .../api/v1/events/ingest \
  -d '{"vtid":"SYSTEM","type":"smoke","source":"routine.smoke","status":"warning","message":"smoke","payload":{}}'
```

Expected (post-deploy):
```
{ "ok":true, "event_id":"...", "self_healing_vtid":"VTID-...", "self_healing_log_id":"..." }
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)