### PR TITLE
feat(feedback): unified feedback pipeline foundation (VTID-02047)

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -180,6 +180,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const feedbackCorrectionRouter = require('./routes/feedback-correction').default;
   // VTID-01097: Diary Templates Gateway - guided diary templates
   const diaryRouter = require('./routes/diary').default;
+  // VTID-02047: Unified Feedback Pipeline - bug reports, support, claims, account
+  const feedbackRouter = require('./routes/feedback').default;
   // VTID-01114: Domain & Topic Routing Engine (D22) - intelligence traffic control
   const domainRoutingRouter = require('./routes/domain-routing').default;
   // VTID-01119: User Preference & Constraint Modeling Engine
@@ -878,6 +880,11 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
 
   // VTID-01097: Diary Templates - guided diary templates for memory quality
   mountRouterSync(app, '/api/v1/diary', diaryRouter, { owner: 'diary' });
+
+  // VTID-02047: Unified Feedback Pipeline - single inbox for user-originated signals
+  // Mounted under /tickets because /api/v1/feedback is already the VTID-01121
+  // feedback-correction router (different concept, same word).
+  mountRouterSync(app, '/api/v1/feedback/tickets', feedbackRouter, { owner: 'feedback-tickets' });
 
   // VTID-01114: Domain & Topic Routing Engine (D22) - intelligence traffic control layer
   mountRouterSync(app, '/api/v1/routing', domainRoutingRouter, { owner: 'domain-routing' });

--- a/services/gateway/src/routes/feedback.ts
+++ b/services/gateway/src/routes/feedback.ts
@@ -1,0 +1,245 @@
+/**
+ * VTID-02047: Unified Feedback Pipeline — ingestion endpoint (parent plan PR 1)
+ *
+ * Single inbox for user-originated signals: bug reports, support questions,
+ * marketplace claims, account issues, feature requests, freeform feedback.
+ *
+ * Public endpoints (router mounted at /api/v1/feedback/tickets):
+ * - POST /api/v1/feedback/tickets       — create a ticket from mobile capture
+ * - GET  /api/v1/feedback/tickets/mine  — list current user's tickets
+ *
+ * Mounted under /tickets because /api/v1/feedback is already taken by the
+ * VTID-01121 feedback-correction router (User Feedback, Correction & Trust
+ * Repair Engine — different concept, same word). The two co-exist via the
+ * sub-prefix.
+ *
+ * Plan: .claude/plans/unified-feedback-pipeline.md
+ *
+ * Voice intake (Phase 1 PR 3-5) and async classifier (PR 6) land in later PRs.
+ * This PR only ships the foundation: schema + ingestion + own-ticket read.
+ */
+
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+import { createUserSupabaseClient } from '../lib/supabase-user';
+import { emitOasisEvent } from '../services/oasis-event-service';
+import { resolveVitanaId } from '../middleware/auth-supabase-jwt';
+
+const router = Router();
+const VTID = 'VTID-02047';
+
+// =============================================================================
+// Schema
+// =============================================================================
+
+const FEEDBACK_KINDS = [
+  'bug',
+  'ux_issue',
+  'support_question',
+  'account_issue',
+  'marketplace_claim',
+  'feature_request',
+  'feedback',
+] as const;
+
+const CreateTicketSchema = z.object({
+  // The user (or their voice transcript) describes the issue here.
+  raw_text: z.string().min(1).max(10_000).optional(),
+  raw_transcript: z.string().min(1).max(20_000).optional(),
+
+  // Optional kind hint from the client. Classifier worker (PR 6) is the
+  // authoritative source — the hint just speeds up Phase 1 routing.
+  kind: z.enum(FEEDBACK_KINDS).optional(),
+
+  // Capture context
+  screen_path: z.string().max(500).optional(),
+  app_version: z.string().max(64).optional(),
+  device_meta: z.record(z.unknown()).optional(),
+  screenshot_url: z.string().url().max(2_000).optional(),
+
+  // For voice intake (Phase 1 PR 3+), the front-end can pass the per-turn
+  // transcript array. Schema is open so we don't churn this PR when voice
+  // ships. The classifier reads `intake_messages` if present.
+  intake_messages: z.array(z.object({
+    agent: z.string().max(32),
+    role: z.enum(['user', 'assistant']),
+    content: z.string().max(10_000),
+    ts: z.string().datetime().optional(),
+  })).max(60).optional(),
+
+  // Structured fields filled by the specialist intake agent during voice
+  // capture. Open shape per kind — see plan for kind-specific schemas.
+  structured_fields: z.record(z.unknown()).optional(),
+}).refine(
+  v => Boolean(v.raw_text) || Boolean(v.raw_transcript) || (v.intake_messages && v.intake_messages.length > 0),
+  { message: 'At least one of raw_text, raw_transcript, or intake_messages is required' }
+);
+
+const ListMineQuerySchema = z.object({
+  limit: z.coerce.number().int().min(1).max(100).optional().default(25),
+  cursor: z.string().datetime().optional(), // created_at lower bound for pagination
+});
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function getBearerToken(req: Request): string | null {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
+  return authHeader.slice(7);
+}
+
+function decodeJwtSub(token: string): string | null {
+  try {
+    const payload = JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString());
+    return typeof payload.sub === 'string' ? payload.sub : null;
+  } catch {
+    return null;
+  }
+}
+
+// =============================================================================
+// POST / — create a ticket  (public path: POST /api/v1/feedback/tickets)
+// =============================================================================
+
+router.post('/', async (req: Request, res: Response) => {
+  const token = getBearerToken(req);
+  if (!token) {
+    return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+  }
+
+  const userId = decodeJwtSub(token);
+  if (!userId) {
+    return res.status(401).json({ ok: false, error: 'INVALID_TOKEN' });
+  }
+
+  const validation = CreateTicketSchema.safeParse(req.body);
+  if (!validation.success) {
+    return res.status(400).json({
+      ok: false,
+      error: 'VALIDATION_FAILED',
+      details: validation.error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join(', '),
+    });
+  }
+
+  const body = validation.data;
+
+  const supabaseUrl = process.env.SUPABASE_URL;
+  const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
+  if (!supabaseUrl || !supabaseAnonKey) {
+    return res.status(503).json({ ok: false, error: 'GATEWAY_MISCONFIGURED' });
+  }
+
+  // Resolve vitana_id at insert time so triage queries don't need a join.
+  // Null-tolerant per resolveVitanaId() contract — store NULL if not yet mirrored.
+  const vitanaId = await resolveVitanaId(userId);
+
+  const supabase = createUserSupabaseClient(token);
+
+  const insertRow: Record<string, unknown> = {
+    user_id: userId,
+    vitana_id: vitanaId,
+    kind: body.kind ?? 'feedback',
+    status: body.intake_messages && body.intake_messages.length > 0 ? 'triaged' : 'new',
+    raw_transcript: body.raw_transcript ?? body.raw_text ?? null,
+    intake_messages: body.intake_messages ?? [],
+    structured_fields: body.structured_fields ?? {},
+    screenshot_url: body.screenshot_url ?? null,
+    screen_path: body.screen_path ?? null,
+    app_version: body.app_version ?? null,
+    device_meta: body.device_meta ?? null,
+  };
+
+  const { data, error } = await supabase
+    .from('feedback_tickets')
+    .insert(insertRow)
+    .select('id, ticket_number, status, kind, created_at')
+    .single();
+
+  if (error) {
+    console.error(`[${VTID}] insert feedback_ticket failed:`, error.message);
+    return res.status(502).json({ ok: false, error: 'INSERT_FAILED', details: error.message });
+  }
+
+  // Fire-and-forget OASIS event so the supervisor inbox + any future routine
+  // pick it up. Failure here must not block the user response.
+  emitOasisEvent({
+    vtid: VTID,
+    type: 'feedback.ticket.created' as any,
+    source: 'feedback-gateway',
+    status: 'info',
+    message: `Feedback ticket ${data.ticket_number} created (${data.kind})`,
+    payload: {
+      ticket_id: data.id,
+      ticket_number: data.ticket_number,
+      kind: data.kind,
+      status: data.status,
+      has_screenshot: Boolean(body.screenshot_url),
+      has_intake_messages: Boolean(body.intake_messages?.length),
+      screen_path: body.screen_path ?? null,
+      app_version: body.app_version ?? null,
+    },
+    actor_id: userId,
+    actor_role: 'user',
+    surface: 'api',
+    vitana_id: vitanaId ?? undefined,
+  }).catch(err => console.warn(`[${VTID}] OASIS emit failed:`, err?.message));
+
+  return res.status(201).json({
+    ok: true,
+    id: data.id,
+    ticket_number: data.ticket_number,
+    status: data.status,
+    kind: data.kind,
+    created_at: data.created_at,
+  });
+});
+
+// =============================================================================
+// GET /mine — list current user's tickets  (public: GET /api/v1/feedback/tickets/mine)
+// =============================================================================
+
+router.get('/mine', async (req: Request, res: Response) => {
+  const token = getBearerToken(req);
+  if (!token) {
+    return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+  }
+
+  const validation = ListMineQuerySchema.safeParse(req.query);
+  if (!validation.success) {
+    return res.status(400).json({
+      ok: false,
+      error: 'VALIDATION_FAILED',
+      details: validation.error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join(', '),
+    });
+  }
+  const { limit, cursor } = validation.data;
+
+  const supabase = createUserSupabaseClient(token);
+
+  let query = supabase
+    .from('feedback_tickets')
+    .select('id, ticket_number, kind, status, priority, surface, created_at, resolver_agent, resolved_at, user_confirmed_at')
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  if (cursor) {
+    query = query.lt('created_at', cursor);
+  }
+
+  const { data, error } = await query;
+
+  if (error) {
+    console.error(`[${VTID}] list mine failed:`, error.message);
+    return res.status(502).json({ ok: false, error: 'QUERY_FAILED', details: error.message });
+  }
+
+  return res.json({
+    ok: true,
+    tickets: data ?? [],
+    next_cursor: data && data.length === limit ? data[data.length - 1].created_at : null,
+  });
+});
+
+export default router;

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -698,7 +698,15 @@ export type CicdEventType =
   | 'voice.message.rate_limited'
   | 'voice.message.misroute'
   | 'voice.message.share_link_sent'
-  | 'vitana_id.confirmed';
+  | 'vitana_id.confirmed'
+  // VTID-02047: Unified Feedback Pipeline events
+  | 'feedback.ticket.created'
+  | 'feedback.ticket.status_changed'
+  | 'feedback.ticket.triaged'
+  | 'feedback.ticket.resolved'
+  | 'feedback.ticket.user_confirmed'
+  | 'feedback.handoff.started'
+  | 'feedback.handoff.completed';
 
 export interface CicdOasisEvent {
   vtid: string;

--- a/supabase/migrations/20260428200000_vtid_02047_unified_feedback_pipeline_init.sql
+++ b/supabase/migrations/20260428200000_vtid_02047_unified_feedback_pipeline_init.sql
@@ -1,0 +1,236 @@
+-- VTID-02047: Unified Feedback Pipeline — schema foundation (parent plan PR 1)
+--
+-- Creates the two backbone tables:
+--   1. agent_personas — 5 voiced specialist agents (Vitana + Devon + Sage + Atlas + Mira)
+--   2. feedback_tickets — single inbox for all user-originated signals
+--
+-- Plan: .claude/plans/unified-feedback-pipeline.md (PR 1)
+-- Phase 5 management UI: .claude/plans/1-same-provider-as-greedy-hopcroft.md
+
+-- ===========================================================================
+-- 1. agent_personas — voiced specialist registry
+-- ===========================================================================
+-- Each row is a named persona the user hears (Vitana receptionist + 4
+-- specialists). v1 ships with 5 seeded rows; later PRs add the version
+-- history, tool bindings, KB bindings, and 3rd-party connection tables.
+
+CREATE TABLE IF NOT EXISTS public.agent_personas (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  key TEXT UNIQUE NOT NULL                    -- 'vitana' | 'devon' | 'sage' | 'atlas' | 'mira'
+    CHECK (key ~ '^[a-z][a-z0-9_]{1,31}$'),
+  display_name TEXT NOT NULL,
+  role TEXT NOT NULL,                         -- short label, no backstory (per locked decision)
+  voice_id TEXT,                              -- Gemini Live voice id; same provider as ORB
+  voice_sample_url TEXT,
+  system_prompt TEXT NOT NULL DEFAULT '',
+  intake_schema_ref TEXT,                     -- references structured_fields schema by kind
+  handles_kinds TEXT[] NOT NULL DEFAULT '{}', -- e.g. ['bug','ux_issue']
+  handoff_keywords TEXT[] NOT NULL DEFAULT '{}',
+  max_questions INT NOT NULL DEFAULT 6 CHECK (max_questions BETWEEN 1 AND 20),
+  max_duration_seconds INT NOT NULL DEFAULT 240 CHECK (max_duration_seconds BETWEEN 30 AND 1800),
+  status TEXT NOT NULL DEFAULT 'draft'
+    CHECK (status IN ('active','draft','disabled')),
+  version INT NOT NULL DEFAULT 1,
+  updated_by UUID,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_agent_personas_status ON public.agent_personas (status);
+
+-- ===========================================================================
+-- 2. feedback_tickets — single inbox for all user signals
+-- ===========================================================================
+-- One row per user submission. Discriminator is `kind`. Status ladder is
+-- documented in the parent plan (new → interviewing → triaged → spec_pending
+-- → spec_ready → answer_pending → answer_ready → approved → in_progress →
+-- resolved → user_confirmed, with branches duplicate / rejected / wont_fix /
+-- needs_more_info).
+
+CREATE TABLE IF NOT EXISTS public.feedback_tickets (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id UUID NOT NULL,                      -- auth.users.id of the reporter
+  vitana_id TEXT,                             -- canonical id; resolved at insert time
+  ticket_number TEXT UNIQUE,                  -- user-facing FB-YYYY-MM-NNNNNN; assigned by trigger
+  kind TEXT NOT NULL DEFAULT 'feedback'
+    CHECK (kind IN (
+      'bug','ux_issue','support_question','account_issue',
+      'marketplace_claim','feature_request','feedback'
+    )),
+  status TEXT NOT NULL DEFAULT 'new'
+    CHECK (status IN (
+      'new','interviewing','triaged',
+      'spec_pending','spec_ready',
+      'answer_pending','answer_ready',
+      'approved','in_progress','resolved','user_confirmed',
+      'duplicate','rejected','wont_fix','needs_more_info','reopened'
+    )),
+  priority TEXT NOT NULL DEFAULT 'p2'
+    CHECK (priority IN ('p0','p1','p2','p3')),
+  surface TEXT,                               -- 'community' | 'admin' | 'command-hub' | 'mobile-only' | 'marketplace' | 'infrastructure'
+  suggested_component TEXT,
+
+  -- Capture
+  raw_transcript TEXT,
+  intake_messages JSONB NOT NULL DEFAULT '[]'::jsonb,   -- [{agent, role, content, ts}]
+  structured_fields JSONB NOT NULL DEFAULT '{}'::jsonb, -- kind-specific schema
+  screenshot_url TEXT,
+  screen_path TEXT,
+  app_version TEXT,
+  device_meta JSONB,
+  session_oasis_refs JSONB,                  -- last N OASIS events, captured at intake
+
+  -- Classification + dedupe (filled async by classifier worker)
+  embedding vector(1536),
+  duplicate_of UUID REFERENCES public.feedback_tickets(id) ON DELETE SET NULL,
+  similar_ticket_ids UUID[] NOT NULL DEFAULT '{}',
+  classifier_meta JSONB,
+
+  -- Resolution
+  spec_md TEXT,
+  draft_answer_md TEXT,
+  resolution_md TEXT,
+  linked_vtid TEXT,
+  linked_pr_url TEXT,
+  linked_kb_doc_id UUID,
+  auto_resolved BOOLEAN NOT NULL DEFAULT FALSE,
+  resolver_agent TEXT,                       -- which persona key owned the resolution
+
+  -- Lifecycle
+  created_at TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  interviewed_at TIMESTAMPTZ,
+  triaged_at TIMESTAMPTZ,
+  resolved_at TIMESTAMPTZ,
+  user_confirmed_at TIMESTAMPTZ,
+  sla_due_at TIMESTAMPTZ,
+
+  -- Supervisor
+  assigned_to UUID,
+  supervisor_notes TEXT,
+  review_label JSONB                         -- post-hoc training labels
+);
+
+CREATE INDEX IF NOT EXISTS idx_feedback_tickets_user_created
+  ON public.feedback_tickets (user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_feedback_tickets_vitana_id
+  ON public.feedback_tickets (vitana_id) WHERE vitana_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_feedback_tickets_status_kind
+  ON public.feedback_tickets (status, kind);
+CREATE INDEX IF NOT EXISTS idx_feedback_tickets_priority_status
+  ON public.feedback_tickets (priority, status) WHERE status NOT IN ('resolved','user_confirmed','rejected','wont_fix','duplicate');
+CREATE INDEX IF NOT EXISTS idx_feedback_tickets_duplicate_of
+  ON public.feedback_tickets (duplicate_of) WHERE duplicate_of IS NOT NULL;
+CREATE INDEX IF NOT EXISTS idx_feedback_tickets_resolver_agent
+  ON public.feedback_tickets (resolver_agent) WHERE resolver_agent IS NOT NULL;
+
+-- ===========================================================================
+-- 3. ticket_number assignment trigger
+-- ===========================================================================
+-- Format: FB-YYYY-MM-NNNNNN (zero-padded sequential within month).
+-- Sequence is global, not per-month — simpler, still readable.
+
+CREATE SEQUENCE IF NOT EXISTS public.feedback_ticket_seq;
+
+CREATE OR REPLACE FUNCTION public.assign_feedback_ticket_number()
+RETURNS TRIGGER
+LANGUAGE plpgsql
+AS $$
+BEGIN
+  IF NEW.ticket_number IS NULL THEN
+    NEW.ticket_number := 'FB-' ||
+      to_char(COALESCE(NEW.created_at, NOW()), 'YYYY-MM') || '-' ||
+      lpad(nextval('public.feedback_ticket_seq')::text, 6, '0');
+  END IF;
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS feedback_tickets_assign_number ON public.feedback_tickets;
+CREATE TRIGGER feedback_tickets_assign_number
+  BEFORE INSERT ON public.feedback_tickets
+  FOR EACH ROW
+  EXECUTE FUNCTION public.assign_feedback_ticket_number();
+
+-- ===========================================================================
+-- 4. RLS — agent_personas
+-- ===========================================================================
+-- All authenticated users may read non-disabled personas (UI shows the team
+-- to community users on first handoff). Only service_role writes.
+
+ALTER TABLE public.agent_personas ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS agent_personas_select ON public.agent_personas;
+CREATE POLICY agent_personas_select ON public.agent_personas
+  FOR SELECT TO authenticated USING (status <> 'disabled');
+
+DROP POLICY IF EXISTS agent_personas_service ON public.agent_personas;
+CREATE POLICY agent_personas_service ON public.agent_personas
+  FOR ALL TO service_role USING (TRUE) WITH CHECK (TRUE);
+
+GRANT SELECT ON public.agent_personas TO authenticated;
+
+-- ===========================================================================
+-- 5. RLS — feedback_tickets
+-- ===========================================================================
+-- A user may read and create their own tickets (community capture surface).
+-- They may NOT update (status moves are server-side). Service role does
+-- everything; supervisor reads happen through service-role endpoints.
+
+ALTER TABLE public.feedback_tickets ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS feedback_tickets_select_own ON public.feedback_tickets;
+CREATE POLICY feedback_tickets_select_own ON public.feedback_tickets
+  FOR SELECT TO authenticated USING (user_id = auth.uid());
+
+DROP POLICY IF EXISTS feedback_tickets_insert_own ON public.feedback_tickets;
+CREATE POLICY feedback_tickets_insert_own ON public.feedback_tickets
+  FOR INSERT TO authenticated WITH CHECK (user_id = auth.uid());
+
+DROP POLICY IF EXISTS feedback_tickets_service ON public.feedback_tickets;
+CREATE POLICY feedback_tickets_service ON public.feedback_tickets
+  FOR ALL TO service_role USING (TRUE) WITH CHECK (TRUE);
+
+GRANT SELECT, INSERT ON public.feedback_tickets TO authenticated;
+GRANT USAGE ON SEQUENCE public.feedback_ticket_seq TO authenticated;
+
+-- ===========================================================================
+-- 6. Seed personas — Vitana + Devon + Sage + Atlas + Mira
+-- ===========================================================================
+-- Voice IDs left NULL until Phase 5 PR 16 wires the Gemini Live voice picker.
+-- system_prompt left as a placeholder; persona editor (PR 16) will fill these
+-- via UI with version history. handles_kinds + handoff_keywords are the
+-- minimum viable routing config for Phase 1.
+
+INSERT INTO public.agent_personas (key, display_name, role, handles_kinds, handoff_keywords, status)
+VALUES
+  ('vitana', 'Vitana',
+   'Longevity coach, matchmaker, community brain — and receptionist for everything off-domain.',
+   ARRAY['feedback','feature_request'],
+   ARRAY['report','tell','feedback','suggest']::TEXT[],
+   'active'),
+  ('devon', 'Devon',
+   'Tech support — bugs, crashes, UX issues. Logs the report and hands to the fix pipeline.',
+   ARRAY['bug','ux_issue'],
+   ARRAY['bug','broken','crashed','crash','error','glitch','frozen','freeze',
+         'doesn''t work','does not work','not working','app won''t','won''t load',
+         'screen','button','ui','ux']::TEXT[],
+   'draft'),
+  ('sage', 'Sage',
+   'Customer support — how-to questions, navigation help, knowledge lookups. Often resolves live in-call.',
+   ARRAY['support_question'],
+   ARRAY['how do i','how to','where is','where do i','what is','can i',
+         'help','question','don''t understand','confused']::TEXT[],
+   'draft'),
+  ('atlas', 'Atlas',
+   'Finance — refunds, payments, marketplace claims and disputes.',
+   ARRAY['marketplace_claim'],
+   ARRAY['refund','payment','charge','order','didn''t arrive','did not arrive',
+         'wrong item','damaged','seller','dispute','money','price','overcharge']::TEXT[],
+   'draft'),
+  ('mira', 'Mira',
+   'Account — login, role, profile, registration, data corrections.',
+   ARRAY['account_issue'],
+   ARRAY['login','log in','sign in','password','account','profile','email',
+         'registration','verify','role','permission','locked out','can''t access']::TEXT[],
+   'draft')
+ON CONFLICT (key) DO NOTHING;


### PR DESCRIPTION
## Summary

Parent plan PR 1 of the unified feedback pipeline. Adds the schema + ingestion endpoint that everything else (voice intake, classifier, supervisor inbox, resolver agents, KPI page) builds on.

- New tables: `agent_personas` (seeded with Vitana, Devon, Sage, Atlas, Mira) and `feedback_tickets` (kind discriminator, status ladder, intake_messages, structured_fields, embedding for later dedupe). Ticket numbers `FB-YYYY-MM-NNNNNN` via trigger. RLS: users read+create own only; service_role for everything else.
- New routes:
  - `POST /api/v1/feedback/tickets` — create a ticket from mobile capture (text or voice transcript or already-completed intake)
  - `GET  /api/v1/feedback/tickets/mine` — list current user's tickets
  - Mounted under `/tickets` because `/api/v1/feedback` is already taken by the VTID-01121 feedback-correction router.
- New OASIS event types: `feedback.ticket.{created,status_changed,triaged,resolved,user_confirmed}` + `feedback.handoff.{started,completed}` (handoff events used by Phase 5 PR 20 Live Handoffs Monitor).

Plans:
- Runtime (PRs 1-14): `.claude/plans/unified-feedback-pipeline.md`
- Management UI (PRs 15-25): `.claude/plans/1-same-provider-as-greedy-hopcroft.md`

## What this PR does NOT do

- No mobile capture UI yet (lands in parent PR 2).
- No voice intake / Vitana handoff (parent PR 3-5).
- No classifier worker (parent PR 6).
- No Command Hub Feedback Inbox UI (parent PR 7).

## Test plan

- [ ] Run RUN-MIGRATION workflow with this migration file, verify no ROLLBACK in logs
- [ ] After gateway deploys: POST a ticket, verify 201 with FB-YYYY-MM-NNNNNN number
- [ ] GET /mine lists the ticket
- [ ] vitana_id resolved on the row
- [ ] feedback.ticket.created OASIS event with VTID-02047 visible

🤖 Generated with [Claude Code](https://claude.com/claude-code)