### PR TITLE
fix(matchmaker): D14 de-dup intents + navigate_to_screen voice tool

### DIFF
--- a/services/gateway/src/routes/intents.ts
+++ b/services/gateway/src/routes/intents.ts
@@ -121,6 +121,79 @@ router.post('/', requireAuth, requireTenant, async (req: Request, res: Response)
     return res.status(400).json({ ok: false, error: 'scope must be 20-1500 chars' });
   }
 
+  // VTID-DANCE-D14 — De-duplication. If this user already has a recent
+  // open intent of the same kind + same category that looks the same,
+  // return the existing intent rather than creating a duplicate. This
+  // prevents users from looking like spammers when they ask the same
+  // thing twice via voice. Window: last 24 hours, same intent_kind,
+  // same category, status='open', AND case-folded title matches OR
+  // scope is a near-substring.
+  {
+    const supabase = getSupabase();
+    const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
+    const { data: existing } = await supabase
+      .from('user_intents')
+      .select('intent_id, requester_vitana_id, title, scope, kind_payload')
+      .eq('requester_user_id', identity.user_id)
+      .eq('intent_kind', intentKind)
+      .eq('status', 'open')
+      .gte('created_at', since)
+      .limit(20);
+
+    const norm = (s: string | null) => (s ?? '').toLowerCase().replace(/\s+/g, ' ').trim();
+    const sameCategory = (a: string | null, b: string | null) => {
+      if (a === b) return true;
+      if (a == null || b == null) return false;
+      // Same root (dance.*, home_services.*, sport.*, etc.)
+      return a.split('.')[0] === b.split('.')[0];
+    };
+    const newTitle = norm(title);
+    const newScope = norm(scope);
+
+    const dup = (existing as any[] ?? []).find((r) => {
+      const rTitle = norm(r.title);
+      const rScope = norm(r.scope);
+      if (!sameCategory(r.kind_payload?.category ?? null, category) && !sameCategory(category, category)) {
+        // No category info on existing row; rely on text similarity below.
+      }
+      // Title overlap: identical normalised, OR one is a near-substring of the other.
+      if (rTitle && newTitle && (rTitle === newTitle || rTitle.includes(newTitle) || newTitle.includes(rTitle))) {
+        return true;
+      }
+      // Scope substring match (>=80% of either side).
+      if (rScope && newScope) {
+        const minLen = Math.min(rScope.length, newScope.length);
+        if (minLen > 30 && (rScope.includes(newScope.slice(0, Math.floor(newScope.length * 0.8))) ||
+                            newScope.includes(rScope.slice(0, Math.floor(rScope.length * 0.8))))) {
+          return true;
+        }
+      }
+      return false;
+    });
+
+    if (dup) {
+      await emitOasisEvent({
+        vtid: 'VTID-DANCE-D14',
+        type: 'voice.message.sent',
+        source: 'intents-route',
+        status: 'info',
+        message: `De-dup blocked duplicate intent post (kind=${intentKind})`,
+        payload: { intent_kind: intentKind, existing_intent_id: dup.intent_id, requester_vitana_id: identity.vitana_id },
+        actor_id: identity.user_id,
+        actor_role: 'user',
+        surface: 'api',
+        vitana_id: identity.vitana_id ?? undefined,
+      });
+      return res.status(200).json({
+        ok: true,
+        deduplicated: true,
+        intent_id: dup.intent_id,
+        requester_vitana_id: dup.requester_vitana_id,
+        message: 'You already posted a similar request in the last 24 hours. Returning the existing post — refine it (different time, location, or style) if you want a new one.',
+      });
+    }
+  }
+
   // Content filter.
   const cf = checkIntentContent({ kind: intentKind, title, scope });
   if (!cf.ok) {

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -2400,6 +2400,16 @@ function buildLiveApiTools(mode: 'anonymous' | 'authenticated' = 'authenticated'
             '"I posted your request — you\'re the first one looking for this in our community right now.',
             ' I\'ll let you know the moment someone matches. Your post is also visible on the board so',
             ' anyone can see it."',
+            '',
+            'DEDUP BEHAVIOR: if the user asks the same thing twice in a session ("looking for a dance partner"',
+            'after they already posted that), the server returns deduplicated:true with the existing intent_id.',
+            'When you see deduplicated:true, do NOT post again. Tell the user: "You already posted this',
+            'earlier today. Refine it (different time, location, or style) if you want a new one — or open',
+            'the existing post and I can show you who responded." Then call list_my_intents OR navigate_to_screen',
+            'with target=my_intents so they can SEE their existing post.',
+            '',
+            'NEVER repeat-post the same generic ask. If the user repeats verbatim, treat it as "show me my',
+            'existing post" — call list_my_intents and surface what they already have.',
           ].join('\n'),
           parameters: {
             type: 'object',
@@ -2493,6 +2503,50 @@ function buildLiveApiTools(mode: 'anonymous' | 'authenticated' = 'authenticated'
               confirmed: { type: 'boolean' },
             },
             required: ['intent_id', 'recipient_vitana_ids'],
+          },
+        },
+        // VTID-DANCE-D14 — voice navigation. ORB returns a relative URL
+        // the frontend listens for and routes to. Use whenever the user
+        // says "show me my posts", "open the dance board", "where can I
+        // see this", "take me to the members list", etc.
+        {
+          name: 'navigate_to_screen',
+          description: [
+            'Return a navigation target (relative URL) for the frontend to route to.',
+            'Use whenever the user asks to be shown a screen, list, or detail page —',
+            '"show me my posts", "open the dance board", "where can I see this", "take me to members".',
+            '',
+            'Available targets:',
+            "  my_intents               → /intents/mine (my own posts list)",
+            "  intent_board             → /intents/board (all community posts, kind tabs)",
+            "  intent_board_dance       → /intents/board?filter=dance (dance tab pre-selected)",
+            "  open_asks                → /comm/open-asks (community-wide unmatched posts)",
+            "  members                  → /comm/members (community members directory)",
+            "  intent_match_detail      → /intents/match/<match_id> (a specific match)",
+            "  intent_post_public       → /p/<intent_id> (public viewer for a specific post)",
+            "  edit_dance_preferences   → /profile/edit?drawer=dance",
+            "  events_meetups           → /comm/events-meetups",
+            "  community_feed           → /comm/feed",
+            '',
+            'After calling, ORB should ALSO say a short voice cue ("Opening your posts now") so',
+            'the user knows the screen change is intentional. The frontend handles the actual route push.',
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              target: {
+                type: 'string',
+                enum: [
+                  'my_intents','intent_board','intent_board_dance',
+                  'open_asks','members',
+                  'intent_match_detail','intent_post_public',
+                  'edit_dance_preferences','events_meetups','community_feed',
+                ],
+              },
+              intent_id: { type: 'string', description: 'For intent_post_public target.' },
+              match_id: { type: 'string', description: 'For intent_match_detail target.' },
+            },
+            required: ['target'],
           },
         },
         // VTID-DANCE-D11.B — pre-post candidate scan.
@@ -5397,6 +5451,58 @@ async function executeLiveApiToolInner(
           console.error('[VTID-DANCE-D10] share_intent_post error:', err?.message);
           return { success: false, result: '', error: err?.message || 'unknown' };
         }
+      }
+
+      // VTID-DANCE-D14 — frontend navigation tool. Returns a relative URL
+      // the client routes to. The frontend listens for navigate_to events
+      // emitted on the ORB session channel.
+      case 'navigate_to_screen': {
+        const target = String(args.target || '').trim();
+        const intentId = args.intent_id ? String(args.intent_id).trim() : null;
+        const matchId = args.match_id ? String(args.match_id).trim() : null;
+        if (!target) return { success: false, result: '', error: 'target is required' };
+
+        let url = '';
+        let title = '';
+        switch (target) {
+          case 'my_intents':              url = '/intents/mine'; title = 'My posts'; break;
+          case 'intent_board':             url = '/intents/board'; title = 'Community board'; break;
+          case 'intent_board_dance':       url = '/intents/board?filter=dance'; title = 'Dance posts'; break;
+          case 'open_asks':                url = '/comm/open-asks'; title = 'Open asks'; break;
+          case 'members':                  url = '/comm/members'; title = 'Community members'; break;
+          case 'intent_match_detail':
+            if (!matchId) return { success: false, result: '', error: 'match_id is required for intent_match_detail' };
+            url = `/intents/match/${encodeURIComponent(matchId)}`; title = 'Match detail'; break;
+          case 'intent_post_public':
+            if (!intentId) return { success: false, result: '', error: 'intent_id is required for intent_post_public' };
+            url = `/p/${encodeURIComponent(intentId)}`; title = 'Post detail'; break;
+          case 'edit_dance_preferences':   url = '/profile/edit?drawer=dance'; title = 'Dance preferences'; break;
+          case 'events_meetups':           url = '/comm/events-meetups'; title = 'Events & meetups'; break;
+          case 'community_feed':           url = '/comm/feed'; title = 'Community feed'; break;
+          default:
+            return { success: false, result: '', error: `Unknown target: ${target}` };
+        }
+
+        // Emit a session event so the frontend can listen + route.
+        try {
+          await emitOasisEvent({
+            vtid: 'VTID-DANCE-D14',
+            type: 'voice.message.sent',
+            source: 'orb-live',
+            status: 'info',
+            message: `Voice navigate_to_screen: ${target}`,
+            payload: { target, url, title, intent_id: intentId, match_id: matchId },
+            actor_id: session.identity?.user_id,
+            actor_role: 'user',
+            surface: 'orb',
+            vitana_id: session.identity?.vitana_id ?? undefined,
+          });
+        } catch { /* best-effort */ }
+
+        return {
+          success: true,
+          result: JSON.stringify({ ok: true, navigate_to: url, title }),
+        };
       }
 
       // VTID-DANCE-D11.B — pre-post candidate scan.


### PR DESCRIPTION
Stops duplicate posts within 24h (returns existing intent_id with deduplicated:true). Adds navigate_to_screen voice tool covering 10 screens. Pairs with vitana-v1 #d14-nav-client for browser routing. 🤖