### PR TITLE
fix(events): route routine breaches through full self-healing pipeline (VTID-02032)

### DIFF
--- a/services/gateway/src/routes/events.ts
+++ b/services/gateway/src/routes/events.ts
@@ -115,106 +115,63 @@ router.post("/api/v1/events/ingest", async (req: Request, res: Response) => {
 
     console.log(`✅ Event ingested: ${eventId} - ${body.vtid}/${body.type}`);
 
-    // VTID-02032: Auto-route routine-emitted breaches into self-healing.
-    // When a daily routine ingests an event with source=routine.* AND
-    // status=warning|critical, that's a detected breach. Write a
-    // self_healing_log row so the existing reconciler + self-healing-triage
-    // routine pick it up and dispatch the fix. Closes the autonomy loop:
-    // routine detects → event ingests → self-healing activates → triage
-    // approves (confidence 0.5) → worker dispatched.
-    let selfHealingVtid: string | null = null;
-    let selfHealingLogId: string | null = null;
+    // VTID-02032: Auto-route routine-emitted breaches through the FULL
+    // self-healing pipeline (LLM diagnosis + auto-fix-or-escalate). When a
+    // daily routine ingests an event with source=routine.* AND
+    // status=warning|error, that's a detected breach. Calling
+    // processFailingService runs the same flow real health-probe failures
+    // take: dedup/circuit-breaker → beginDiagnosis (allocates VTID + LLM
+    // generates a fix spec) → auto-apply if confidence ≥ threshold OR deep
+    // triage → escalate. Without this, rows just sat in self_healing_log
+    // with no spec and the reconciler escalated them after 1h.
+    let selfHealingResult: {
+      action?: string;
+      vtid?: string;
+      reason?: string;
+    } = {};
     const isRoutineBreach =
       typeof body.source === 'string' &&
       body.source.startsWith('routine.') &&
       (body.status === 'warning' || body.status === 'error');
     if (isRoutineBreach) {
       try {
-        // Allocate VTID via canonical RPC. The allocator's `global_vtid_seq`
-        // can fall behind reality if other paths insert VTIDs without the
-        // sequence — manifests as duplicate-key 23505 errors. Retry up to
-        // 20 times so the sequence catches up to the next free slot.
-        for (let attempt = 0; attempt < 20 && !selfHealingVtid; attempt++) {
-          const allocResp = await fetch(`${supabaseUrl}/rest/v1/rpc/allocate_global_vtid`, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              apikey: svcKey,
-              Authorization: `Bearer ${svcKey}`,
-            },
-            body: JSON.stringify({
-              p_source: body.source,
-              p_layer: 'DEV',
-              p_module: 'COMHU',
-            }),
-          });
-          if (allocResp.ok) {
-            const alloc = (await allocResp.json()) as Array<{ vtid?: string }>;
-            selfHealingVtid =
-              Array.isArray(alloc) && alloc[0]?.vtid ? alloc[0].vtid : null;
-            break;
-          }
-          // Read body to know if it's a duplicate-key conflict (retryable)
-          const errText = await allocResp.text();
-          if (allocResp.status === 409 || errText.includes('"code":"23505"')) {
-            // sequence advanced by 1 on the failed call; loop and try again
-            continue;
-          }
-          // Other error — give up, log
-          console.warn(
-            `[events.ingest] allocator failed (${allocResp.status}): ${errText.slice(0, 200)}`
+        const safeTopic = (body.type || 'unknown').replace(/[^a-zA-Z0-9._-]/g, '_');
+        const safeRoutine = body.source
+          .replace(/^routine\./, '')
+          .replace(/[^a-zA-Z0-9._-]/g, '_');
+        const syntheticEndpoint = `routine-incident://${safeRoutine}/${safeTopic}`;
+
+        // Lazy-load processFailingService + getAutonomyLevel from
+        // self-healing.ts to avoid a module-load cycle (events.ts is loaded
+        // earlier than self-healing.ts in some boot paths).
+        const selfHealingMod = require('./self-healing');
+        const { processFailingService, getAutonomyLevel } = selfHealingMod;
+        const AutonomyLevels = require('../types/self-healing').AutonomyLevel;
+        if (typeof processFailingService === 'function' && typeof getAutonomyLevel === 'function') {
+          const autonomyLevel = await getAutonomyLevel();
+          const synthetic = {
+            name: body.source,
+            endpoint: syntheticEndpoint,
+            status: 'down' as const,
+            http_status: null,
+            response_body: '',
+            response_time_ms: 0,
+            error_message: `${body.message} | payload=${JSON.stringify(body.payload ?? {}).slice(0, 1500)}`,
+          };
+          const result = await processFailingService(synthetic, autonomyLevel);
+          selfHealingResult = result;
+          console.log(
+            `[events.ingest] Routine breach → processFailingService: action=${result.action} vtid=${result.vtid ?? 'none'}`
           );
-          break;
-        }
-
-        if (selfHealingVtid) {
-          // Synthetic endpoint pattern matches ROUTINE_SYNTHETIC_ENDPOINT in
-          // self-healing.ts so /report would accept it too if invoked.
-          const safeTopic = (body.type || 'unknown').replace(/[^a-zA-Z0-9._-]/g, '_');
-          const safeRoutine = body.source.replace(/^routine\./, '').replace(/[^a-zA-Z0-9._-]/g, '_');
-          const syntheticEndpoint = `routine-incident://${safeRoutine}/${safeTopic}`;
-
-          const logResp = await fetch(`${supabaseUrl}/rest/v1/self_healing_log`, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              apikey: svcKey,
-              Authorization: `Bearer ${svcKey}`,
-              Prefer: 'return=representation',
-            },
-            body: JSON.stringify({
-              vtid: selfHealingVtid,
-              endpoint: syntheticEndpoint,
-              failure_class: body.source,
-              confidence: 0.5,
-              diagnosis: {
-                source: 'routine.events.ingest.auto-route',
-                routine_source: body.source,
-                topic: body.type,
-                severity: body.status,
-                message: body.message,
-                payload: body.payload || {},
-                oasis_event_id: insertedEvent.id,
-                routed_at: new Date().toISOString(),
-              },
-              outcome: 'pending',
-              attempt_number: 1,
-              blast_radius: body.status === 'error' ? 'critical' : 'contained',
-            }),
-          });
-          if (logResp.ok) {
-            const logData = (await logResp.json()) as Array<{ id?: string }>;
-            selfHealingLogId =
-              Array.isArray(logData) && logData[0]?.id ? logData[0].id : null;
-            console.log(
-              `[events.ingest] Auto-routed routine breach → self_healing_log ${selfHealingLogId} (${selfHealingVtid})`
-            );
-          }
+        } else {
+          console.warn(
+            '[events.ingest] processFailingService not exported — falling back to OASIS-only ingest'
+          );
         }
       } catch (autoRouteErr: any) {
         // Best-effort; don't fail the OASIS event ingest if self-healing routing fails.
         console.warn(
-          `[events.ingest] Self-healing auto-route failed (non-fatal): ${autoRouteErr.message}`
+          `[events.ingest] Self-healing pipeline failed (non-fatal): ${autoRouteErr.message}`
         );
       }
     }
@@ -222,8 +179,9 @@ router.post("/api/v1/events/ingest", async (req: Request, res: Response) => {
     return res.status(200).json({
       ok: true,
       event_id: insertedEvent.id,
-      self_healing_vtid: selfHealingVtid,
-      self_healing_log_id: selfHealingLogId,
+      self_healing_action: selfHealingResult.action ?? null,
+      self_healing_vtid: selfHealingResult.vtid ?? null,
+      self_healing_reason: selfHealingResult.reason ?? null,
     });
   } catch (e: any) {
     console.error("❌ Unexpected error:", e);

--- a/services/gateway/src/routes/self-healing.ts
+++ b/services/gateway/src/routes/self-healing.ts
@@ -76,7 +76,9 @@ async function isSelfHealingEnabled(): Promise<boolean> {
   }
 }
 
-async function getAutonomyLevel(): Promise<AutonomyLevel> {
+// VTID-02032: Exported alongside processFailingService so the routines
+// bridge runs at the same autonomy level as the canonical /report path.
+export async function getAutonomyLevel(): Promise<AutonomyLevel> {
   if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) return AutonomyLevel.AUTO_FIX_SIMPLE;
   try {
     const resp = await fetch(
@@ -153,7 +155,12 @@ async function shouldBeginDiagnosis(endpoint: string): Promise<{ proceed: boolea
 // Process a single failing service through the pipeline
 // ═══════════════════════════════════════════════════════════════════
 
-async function processFailingService(
+// VTID-02032: Exported so the routines bridge can run a routine-detected
+// breach through the same LLM-diagnosis + auto-fix-or-escalate pipeline as
+// real health-probe failures. Without this, rows inserted directly into
+// self_healing_log have no spec and the reconciler escalates them after 1h
+// of no progress.
+export async function processFailingService(
   failure: ServiceStatus,
   autonomyLevel: AutonomyLevel,
 ): Promise<{ action: 'created' | 'skipped' | 'escalated' | 'disabled'; vtid?: string; reason?: string }> {


### PR DESCRIPTION
## Verified gap

Per simulation of the prior auto-route bridge (VTID-02032 v3): inserting `self_healing_log` rows directly skipped the LLM-diagnosis step. The reconciler picked up the rows, found no spec, and after 1h of no progress escalated them to `outcome=stale_no_progress`. The "closed loop" wasn't closing — issues were detected but never fixed.

Concrete evidence: VTID-02042 inserted at 14:48 → reconciled at 16:22 with `reconciled_reason: "stale_no_progress"`, no spec ever generated, no worker dispatched.

## Fix

Route routine breaches through `processFailingService` — the same function the canonical `/api/v1/self-healing/report` path calls. That runs:

1. dedup + circuit-breaker
2. `beginDiagnosis` (allocates VTID + LLM generates a fix spec)
3. auto-apply if confidence ≥ threshold (worker dispatch)
4. deep triage / escalate otherwise

Two changes:

- `self-healing.ts`: `export` keyword on `processFailingService` and `getAutonomyLevel`
- `events.ts`: when `source = routine.*` AND `status = warning|error`, construct a synthetic `ServiceStatus` and invoke `processFailingService`. Synthetic endpoint format `routine-incident://<routine>/<topic>` is already accepted by the `ROUTINE_SYNTHETIC_ENDPOINT` regex from PR #1047.

Response now exposes the pipeline outcome:
```
{ ok, event_id, self_healing_action, self_healing_vtid, self_healing_reason }
```

## Test plan

- [x] Typecheck clean
- [ ] Deploy + smoke test:
  ```
  curl -X POST .../api/v1/events/ingest \
    -d '{"vtid":"SYSTEM","type":"smoke","source":"routine.smoke","status":"warning","message":"smoke","payload":{}}'
  ```
  Expected: `{ ok: true, event_id, self_healing_action: "created"|"escalated", self_healing_vtid: "VTID-..." }`
- [ ] Verify the new self_healing_log row has `spec_hash` and `diagnosis.fix_*` populated by LLM diagnosis (vs the previous always-null spec_hash)
- [ ] If `action == "created"`: a worker dispatch should be visible in worker_orchestrator events

🤖 Generated with [Claude Code](https://claude.com/claude-code)