### PR TITLE
fix(orb): wire recall_conversation_at_time into voice + community role (VTID-02052)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -3273,6 +3273,43 @@ async function executeLiveApiToolInner(
 
   try {
     switch (toolName) {
+      case 'recall_conversation_at_time': {
+        // VTID-02052: voice/Live-API path for the recall tool. Without this case,
+        // an iPhone user asking "when did we talk about X" hits the default
+        // "Unknown tool" branch and the upstream Live API WS closes — the
+        // user sees "internet issues" on the device.
+        try {
+          const { executeRecallConversationAtTime } = await import(
+            '../services/tool-recall-conversation'
+          );
+          const recall = await executeRecallConversationAtTime(
+            args as { time_hint: string; topic_hint?: string },
+            {
+              user_id: session.identity.user_id,
+              user_timezone:
+                (session as any)?.clientContext?.timezone || undefined,
+            },
+          );
+          // The Live API expects a JSON string; cap to keep the function
+          // response payload safely under the 4 KB stall threshold.
+          const payload = JSON.stringify(recall);
+          const MAX = 4000;
+          const result = payload.length > MAX ? payload.slice(0, MAX) + '...(truncated)' : payload;
+          return {
+            success: !!recall.ok,
+            result: recall.ok ? result : '',
+            error: recall.ok ? undefined : recall.error || 'recall_failed',
+          };
+        } catch (err: any) {
+          console.error('[VTID-02052] recall_conversation_at_time failed:', err?.message);
+          return {
+            success: false,
+            result: '',
+            error: err?.message || 'recall_exception',
+          };
+        }
+      }
+
       case 'search_memory': {
         const query = (args.query as string) || '';
         const categories = args.categories as string[] | undefined;

--- a/services/gateway/src/services/tool-registry.ts
+++ b/services/gateway/src/services/tool-registry.ts
@@ -209,7 +209,13 @@ const TOOL_REGISTRY: Map<string, ToolDefinition> = new Map([
         },
         required: ['time_hint'],
       },
-      allowed_roles: ['operator', 'admin', 'developer', 'user', 'system'],
+      // VTID-02052: Recall is a basic memory primitive — every authenticated
+      // surface needs it, including community/mobile. Without 'community' here,
+      // mobile (which is force-pinned to community role) gets the awareness
+      // prompt advisory but no tool declaration → Gemini Live emits a call
+      // for a tool that isn't declared → upstream WS closes → frontend shows
+      // "internet issues".
+      allowed_roles: ['operator', 'admin', 'developer', 'user', 'system', 'community'],
       enabled: true,
       category: 'memory',
       vtid: 'VTID-01990',


### PR DESCRIPTION
## Bug

iPhone Appilix WebView disconnects ("internet issues" screen) the moment a user asks **"when did we talk about X"**. Every other voice question works fine.

## Root cause — two-layer block on mobile/voice

1. `tool-registry.ts` allowed_roles excluded `community` — but mobile sessions are force-pinned to `community` role (see memory note 'Mobile is community-only, always'). So `getGeminiToolDefinitions('community')` returned nothing for this tool — Gemini Live never saw the function declaration. Yet the awareness prompt still tells the model *"call recall_conversation_at_time when the user references a past time"*. Gemini emits a call for an undeclared tool → upstream Live API closes the WS → frontend shows "internet issues".

2. Even if the tool had been declared, `orb-live`'s `executeLiveApiToolInner` had no case for it — voice would hit the default `Unknown tool` branch.

## Fix

- `tool-registry.ts` — added `community` to `allowed_roles`. Recall is a basic memory primitive, every authenticated surface needs it.
- `orb-live.ts` — added a `case 'recall_conversation_at_time'` that delegates to the same `executeRecallConversationAtTime` handler the text path uses, forwarding the voice session's `clientContext.timezone`. Result JSON capped at 4 KB to stay under the Live API function_response stall threshold (same pattern as search_memory).

## Test plan

- [x] tsc --noEmit clean
- [ ] Deploy
- [ ] iPhone: ask Vitana "when did we talk about the dance matchmaker?" → should answer with summary + time, NOT disconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)