### PR TITLE
feat(voice): Gchat ping on quarantine + architectural recommendation (VTID-02030)

### DIFF
--- a/services/gateway/src/services/voice-architecture-investigator.ts
+++ b/services/gateway/src/services/voice-architecture-investigator.ts
@@ -770,6 +770,36 @@ export async function spawnInvestigator(input: InvestigatorInput): Promise<Inves
     /* best-effort emit */
   }
 
+  // VTID-02030: ping ops via Gchat for architectural recommendations only —
+  // tracks like stay_and_patch keep running through the auto-loop, but
+  // tracks that require a human team (replace_vendor / redesign_pipeline /
+  // "Redesign & Replace" / patch_around) need a supervisor to read & act.
+  // Reuses the same notifyGChat() helper used by existing self-healing pings.
+  const ARCHITECTURAL_TRACKS = new Set([
+    'replace_vendor',
+    'redesign_pipeline',
+    'redesign_replace',
+    'Redesign & Replace',
+    'patch_around',
+  ]);
+  if (ARCHITECTURAL_TRACKS.has(report.recommendation.track)) {
+    try {
+      const { notifyGChat } = await import('./self-healing-snapshot-service');
+      const summary = (report.recommendation.summary || '').slice(0, 280);
+      await notifyGChat(
+        `🧠 *Voice — architectural action recommended*\n` +
+        `Class: \`${input.class}\`\n` +
+        `Track: *${report.recommendation.track}* ` +
+        `(confidence ${(report.recommendation.confidence * 100).toFixed(0)}%)\n` +
+        `Trigger: ${input.trigger_reason}\n` +
+        `${summary}\n` +
+        `Report ID: \`${reportId}\` — open Voice Lab → Healing tab to read & Accept & Execute`,
+      );
+    } catch {
+      /* best-effort */
+    }
+  }
+
   return {
     ok: true,
     report_id: reportId,

--- a/services/gateway/src/services/voice-recurrence-sentinel.ts
+++ b/services/gateway/src/services/voice-recurrence-sentinel.ts
@@ -317,6 +317,24 @@ export async function evaluateAndQuarantine(
     /* best-effort */
   }
 
+  // VTID-02030: ping ops via Gchat — quarantine means the auto-loop has
+  // stopped and the supervisor should look. Reuses the same notifyGChat()
+  // helper that powers existing self-healing pings (54-health-check stream).
+  try {
+    const { notifyGChat } = await import('./self-healing-snapshot-service');
+    await notifyGChat(
+      `🛑 *Voice class quarantined*\n` +
+      `Class: \`${klass}\`\n` +
+      `Signature: \`${signature}\`\n` +
+      `Reason: *${reason}* ` +
+      `(burst_24h=${counts.burst_24h}, persistence_7d=${counts.persistence_7d}, failed_fix_7d=${counts.failed_fix_7d}` +
+      `${inProbation ? ', from_probation=true' : ''})\n` +
+      `Investigator spawned. No further auto-dispatch on this class until released.`,
+    );
+  } catch {
+    /* best-effort */
+  }
+
   // VTID-01963 (PR #6): spawn the Architecture Investigator. Fire-and-forget
   // so we don't block the reconciler tick on the Vertex call. The
   // investigator persists a report row and emits voice.healing.investigation.completed.


### PR DESCRIPTION
## Summary

Two pings to Gchat at the moments where the auto-loop **needs the supervisor**:

1. **Quarantine entered** (Sentinel) — auto-dispatch has stopped on the class until released. Supervisor should look at why.
2. **Architectural recommendation** (Investigator) — only when track ∈ {replace_vendor, redesign_pipeline, redesign_replace, \"Redesign & Replace\", patch_around}. These need a human team. \`stay_and_patch\` is *excluded* — it's meant to flow through the existing Accept & Execute auto-loop.

## How it works

Reuses \`notifyGChat()\` from \`services/self-healing-snapshot-service.ts\` — the same helper that already powers the 54-health-check pings the user is receiving today. No new env var. No new plumbing. Best-effort: if Gchat is unreachable, the OASIS event is still written so Voice Lab and the future Action Required panel still see it.

## Touched files

- \`services/gateway/src/services/voice-recurrence-sentinel.ts\` — +18 lines after existing \`voice.healing.dispatch.suppressed\` emit
- \`services/gateway/src/services/voice-architecture-investigator.ts\` — +30 lines after existing \`voice.healing.investigation.completed\` emit, gated to architectural tracks

No new tables, no new endpoints, no schema changes, no frontend changes.

## What you'll see

- *Quarantine* → \`🛑 *Voice class quarantined* Class: \`voice.X\` …\`
- *Architectural recommendation* → \`🧠 *Voice — architectural action recommended* Class: \`voice.X\` Track: *replace_vendor* (confidence 90%) …\`

\`stay_and_patch\` recommendations and ordinary dispatches stay quiet — by design.

## Test plan

- [x] Typecheck clean
- [ ] After deploy: force-quarantine a test class on staging → confirm Gchat ping arrives
- [ ] After deploy: trigger an investigator run on a quarantined class → confirm second ping (architectural track)
- [ ] Confirm \`stay_and_patch\` recommendations do **not** ping (regression)

## Follow-up

VTID-02031 will add an \"Action Required\" panel to the Command Hub Overview drawing from the same source (\`voice_healing_quarantine\` + open \`voice_architecture_reports\` with architectural tracks), so the supervisor has both push (Gchat) and pull (Overview).

🤖 Generated with [Claude Code](https://claude.com/claude-code)