### PR TITLE
fix(voice): Gchat ping for any non-stay_and_patch track (VTID-02030 follow-up)

### DIFF
--- a/services/gateway/src/services/voice-architecture-investigator.ts
+++ b/services/gateway/src/services/voice-architecture-investigator.ts
@@ -770,19 +770,15 @@ export async function spawnInvestigator(input: InvestigatorInput): Promise<Inves
     /* best-effort emit */
   }
 
-  // VTID-02030: ping ops via Gchat for architectural recommendations only —
-  // tracks like stay_and_patch keep running through the auto-loop, but
-  // tracks that require a human team (replace_vendor / redesign_pipeline /
-  // "Redesign & Replace" / patch_around) need a supervisor to read & act.
-  // Reuses the same notifyGChat() helper used by existing self-healing pings.
-  const ARCHITECTURAL_TRACKS = new Set([
-    'replace_vendor',
-    'redesign_pipeline',
-    'redesign_replace',
-    'Redesign & Replace',
-    'patch_around',
-  ]);
-  if (ARCHITECTURAL_TRACKS.has(report.recommendation.track)) {
+  // VTID-02030: ping ops via Gchat for any recommendation that ISN'T
+  // stay_and_patch. The auto-loop only handles stay_and_patch autonomously
+  // (it flows through Accept & Execute); anything else (patch_around,
+  // replace_vendor, redesign_pipeline, "Architectural", "Redesign & Replace",
+  // or any unexpected free-text track the LLM returns) needs a supervisor.
+  // Inverting the rule means a non-conforming track defaults to "page the
+  // human" rather than "stay quiet" — fail-loud is the safer default.
+  const STAY_AND_PATCH_TRACKS = new Set(['stay_and_patch']);
+  if (!STAY_AND_PATCH_TRACKS.has(report.recommendation.track)) {
     try {
       const { notifyGChat } = await import('./self-healing-snapshot-service');
       const summary = (report.recommendation.summary || '').slice(0, 280);


### PR DESCRIPTION
## Summary

Live verification of VTID-02030 revealed the LLM does not reliably emit the spec'd enum values for \`recommendation.track\`. A re-run of the investigator produced \`track=\"Architectural\"\` which fell outside the original allowlist and silently no-op'd. That is exactly the fail-quiet failure mode the user explicitly asked us to avoid.

Inverting the rule: **ping for any track that isn't \`stay_and_patch\`**.

## Why

\`stay_and_patch\` is the only track the auto-loop is designed to close autonomously (via Accept & Execute or deterministic fix-spec). Anything else — \`patch_around\`, \`replace_vendor\`, \`redesign_pipeline\`, \`Redesign & Replace\`, \`Architectural\`, or any free-text the LLM invents — represents a decision a human team must make. Defaulting to *page the human* on unknown tracks is the safer behavior than the inverse.

The OASIS event still fires regardless of track; only the Gchat ping gates on this rule.

## Touched files

- \`services/gateway/src/services/voice-architecture-investigator.ts\` — 6-line change replacing the allowlist with an inverted check.

## Test plan

- [x] Typecheck clean
- [ ] After deploy: re-run investigator on \`voice.model_under_responds\` → confirm Gchat ping arrives this time

🤖 Generated with [Claude Code](https://claude.com/claude-code)