### PR TITLE
fix(voice): static notifyGChat import + diagnostic endpoint (VTID-02030c)

### DIFF
--- a/services/gateway/src/routes/voice-lab.ts
+++ b/services/gateway/src/routes/voice-lab.ts
@@ -18,6 +18,7 @@ import {
   getQuarantineState,
 } from '../services/voice-recurrence-sentinel';
 import { spawnInvestigator } from '../services/voice-architecture-investigator';
+import { notifyGChat } from '../services/self-healing-snapshot-service';
 import { setMode } from '../services/voice-shadow-mode';
 import { getVoiceSelfHealingMode } from '../services/voice-self-healing-adapter';
 import {
@@ -1095,6 +1096,36 @@ router.get('/healing/reports/:id/execution', async (req: Request, res: Response)
 router.get('/healing/mode', async (_req: Request, res: Response) => {
   const mode = await getVoiceSelfHealingMode(true);
   return res.json({ ok: true, mode });
+});
+
+/**
+ * POST /api/v1/voice-lab/healing/gchat-ping-test (VTID-02030c)
+ *
+ * Diagnostic only. Sends a single test message via the same notifyGChat()
+ * helper used by quarantine + investigator pings. Reports whether the
+ * env var is set and whether the fetch actually fired. No side effects
+ * other than the message itself.
+ */
+router.post('/healing/gchat-ping-test', async (req: Request, res: Response) => {
+  const body = (req.body || {}) as Record<string, unknown>;
+  const note = typeof body.note === 'string' ? body.note : 'manual diagnostic';
+  const webhookSet = Boolean(process.env.GCHAT_COMMANDHUB_WEBHOOK);
+  const text =
+    `🔧 *Gchat ping diagnostic* (VTID-02030c)\n` +
+    `If you see this, the gateway → Gchat path works.\n` +
+    `Note: ${note}\n` +
+    `Time: ${new Date().toISOString()}`;
+  let sendError: string | null = null;
+  try {
+    await notifyGChat(text);
+  } catch (err: any) {
+    sendError = err?.message ?? String(err);
+  }
+  return res.json({
+    ok: sendError === null,
+    webhook_env_set: webhookSet,
+    send_error: sendError,
+  });
 });
 
 /**

--- a/services/gateway/src/services/voice-architecture-investigator.ts
+++ b/services/gateway/src/services/voice-architecture-investigator.ts
@@ -30,6 +30,7 @@ import { VertexAI } from '@google-cloud/vertexai';
 import { GoogleAuth } from 'google-auth-library';
 import { emitOasisEvent } from './oasis-event-service';
 import { getVoiceSpecHint } from './voice-spec-hints';
+import { notifyGChat } from './self-healing-snapshot-service';
 
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
@@ -779,20 +780,28 @@ export async function spawnInvestigator(input: InvestigatorInput): Promise<Inves
   // human" rather than "stay quiet" — fail-loud is the safer default.
   const STAY_AND_PATCH_TRACKS = new Set(['stay_and_patch']);
   if (!STAY_AND_PATCH_TRACKS.has(report.recommendation.track)) {
+    const summary = (report.recommendation.summary || '').slice(0, 280);
+    const message =
+      `🧠 *Voice — architectural action recommended*\n` +
+      `Class: \`${input.class}\`\n` +
+      `Track: *${report.recommendation.track}* ` +
+      `(confidence ${(report.recommendation.confidence * 100).toFixed(0)}%)\n` +
+      `Trigger: ${input.trigger_reason}\n` +
+      `${summary}\n` +
+      `Report ID: \`${reportId}\` — open Voice Lab → Healing tab to read & Accept & Execute`;
+    console.log(
+      `[voice-architecture-investigator] gchat-ping prep: track=${report.recommendation.track} ` +
+      `webhook_set=${Boolean(process.env.GCHAT_COMMANDHUB_WEBHOOK)}`,
+    );
     try {
-      const { notifyGChat } = await import('./self-healing-snapshot-service');
-      const summary = (report.recommendation.summary || '').slice(0, 280);
-      await notifyGChat(
-        `🧠 *Voice — architectural action recommended*\n` +
-        `Class: \`${input.class}\`\n` +
-        `Track: *${report.recommendation.track}* ` +
-        `(confidence ${(report.recommendation.confidence * 100).toFixed(0)}%)\n` +
-        `Trigger: ${input.trigger_reason}\n` +
-        `${summary}\n` +
-        `Report ID: \`${reportId}\` — open Voice Lab → Healing tab to read & Accept & Execute`,
+      await notifyGChat(message);
+      console.log(
+        `[voice-architecture-investigator] gchat-ping sent for class=${input.class} report=${reportId}`,
       );
-    } catch {
-      /* best-effort */
+    } catch (err: any) {
+      console.error(
+        `[voice-architecture-investigator] gchat-ping FAILED: ${err?.message ?? err}`,
+      );
     }
   }
 

--- a/services/gateway/src/services/voice-recurrence-sentinel.ts
+++ b/services/gateway/src/services/voice-recurrence-sentinel.ts
@@ -32,6 +32,7 @@
 
 import { emitOasisEvent } from './oasis-event-service';
 import { spawnInvestigator } from './voice-architecture-investigator';
+import { notifyGChat } from './self-healing-snapshot-service';
 
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
@@ -320,8 +321,11 @@ export async function evaluateAndQuarantine(
   // VTID-02030: ping ops via Gchat — quarantine means the auto-loop has
   // stopped and the supervisor should look. Reuses the same notifyGChat()
   // helper that powers existing self-healing pings (54-health-check stream).
+  console.log(
+    `[voice-recurrence-sentinel] gchat-ping prep: class=${klass} reason=${reason} ` +
+    `webhook_set=${Boolean(process.env.GCHAT_COMMANDHUB_WEBHOOK)}`,
+  );
   try {
-    const { notifyGChat } = await import('./self-healing-snapshot-service');
     await notifyGChat(
       `🛑 *Voice class quarantined*\n` +
       `Class: \`${klass}\`\n` +
@@ -331,8 +335,13 @@ export async function evaluateAndQuarantine(
       `${inProbation ? ', from_probation=true' : ''})\n` +
       `Investigator spawned. No further auto-dispatch on this class until released.`,
     );
-  } catch {
-    /* best-effort */
+    console.log(
+      `[voice-recurrence-sentinel] gchat-ping sent for class=${klass}`,
+    );
+  } catch (err: any) {
+    console.error(
+      `[voice-recurrence-sentinel] gchat-ping FAILED: ${err?.message ?? err}`,
+    );
   }
 
   // VTID-01963 (PR #6): spawn the Architecture Investigator. Fire-and-forget


### PR DESCRIPTION
## Summary

User reports the Gchat ping from VTID-02030/02030b never arrived even though the investigator returned \`track=redesign_pipeline\` (which the inverted filter would correctly flag for paging). Three small changes to surface the failure source:

1. **Static import** of \`notifyGChat\` in both \`voice-architecture-investigator.ts\` and \`voice-recurrence-sentinel.ts\` — removes dynamic-import as a possible silent failure mode.
2. **Explicit logging** around each \`notifyGChat\` call — Cloud Run logs will now show webhook-set / send-success / send-error so we can pinpoint which step breaks.
3. **Diagnostic endpoint** \`POST /api/v1/voice-lab/healing/gchat-ping-test\` returning \`{ok, webhook_env_set, send_error}\` — verifies the gateway → Gchat path independent of the investigator's LLM call.

## Touched files

- \`services/gateway/src/services/voice-architecture-investigator.ts\` — static import + log lines
- \`services/gateway/src/services/voice-recurrence-sentinel.ts\` — static import + log lines  
- \`services/gateway/src/routes/voice-lab.ts\` — new diagnostic endpoint

## Test plan

After deploy:
1. \`curl -X POST .../api/v1/voice-lab/healing/gchat-ping-test -d '{\"note\":\"verify\"}'\` → confirm ok=true and Gchat message arrives
2. If \`ok=false\` or \`webhook_env_set=false\`, that pinpoints the issue

🤖 Generated with [Claude Code](https://claude.com/claude-code)