### PR TITLE
fix(autopilot): break SELF-HEAL retry loop + Vertex Gemini routing + activation 409 fix (VTID-02500)

### DIFF
--- a/services/gateway/src/routes/autopilot-recommendations.ts
+++ b/services/gateway/src/routes/autopilot-recommendations.ts
@@ -1081,6 +1081,44 @@ router.post('/:id/activate', async (req: Request, res: Response) => {
       }
     }
 
+    // Bridge dev_autopilot* activations into the executor (cooldown skipped).
+    // Without this, "Activate" only writes the vtid_ledger row and the card
+    // sits in IN PROGRESS forever — there is no other code path that picks
+    // up vtid_ledger rows for these findings. The reaper tick in
+    // dev-autopilot-execute.ts catches any failures from this fire-and-forget
+    // call. Fire-and-forget on purpose so a slow LLM plan generation doesn't
+    // block the activate response.
+    if (!response.already_activated && response.vtid) {
+      try {
+        const supabaseUrl = process.env.SUPABASE_URL;
+        const svcKey = process.env.SUPABASE_SERVICE_ROLE;
+        if (supabaseUrl && svcKey) {
+          const srcResp = await fetch(
+            `${supabaseUrl}/rest/v1/autopilot_recommendations?id=eq.${id}&select=source_type&limit=1`,
+            { headers: { apikey: svcKey, Authorization: `Bearer ${svcKey}` } }
+          );
+          const srcRows = srcResp.ok ? await srcResp.json() as Array<{ source_type: string }> : [];
+          const srcType = srcRows[0]?.source_type;
+          if (srcType === 'dev_autopilot' || srcType === 'dev_autopilot_impact') {
+            const { bridgeActivationToExecution } = await import('../services/dev-autopilot-execute');
+            bridgeActivationToExecution(id, userId || null)
+              .then((br) => {
+                if (br.ok) {
+                  console.log(`${LOG_PREFIX} Bridged ${id.slice(0, 8)} → execution ${br.execution_id?.slice(0, 8) || '?'} (${br.skipped || 'enqueued'})`);
+                } else {
+                  console.warn(`${LOG_PREFIX} Bridge failed for ${id.slice(0, 8)}: ${br.error}`);
+                }
+              })
+              .catch((bridgeErr: any) => {
+                console.error(`${LOG_PREFIX} Bridge error for ${id.slice(0, 8)}: ${bridgeErr.message}`);
+              });
+          }
+        }
+      } catch (bridgeErr: any) {
+        console.error(`${LOG_PREFIX} Bridge dispatch error (non-fatal):`, bridgeErr.message);
+      }
+    }
+
     return res.status(200).json({
       ...response,
       vtid_ref: 'VTID-01180',

--- a/services/gateway/src/routes/board-adapter.ts
+++ b/services/gateway/src/routes/board-adapter.ts
@@ -155,6 +155,17 @@ router.get('/', cors(corsOptions), async (req: Request, res: Response) => {
     });
 
     // VTID-01058: Post-fetch filter: exclude rows with deleted/voided/cancelled status or metadata flags
+    // 2026-04-28 incident: also drop stale 'allocated' shell rows. The VTID
+    // allocator (operator-service.ts:1005) creates a placeholder row with
+    // title='Allocated - Pending Title' as the first leg of a 2-step
+    // allocate→update sequence, which normally completes in <1 second. When
+    // the second leg crashes (operator service died, supabase write race,
+    // self-heal triage path that doesn't fill in the title), the shell sits
+    // forever and pollutes the SCHEDULED column with phantom entries that
+    // can never be acted on. Anything still in 'allocated' for >5 minutes is
+    // an orphan — hide it.
+    const ALLOCATED_GRACE_MS = 5 * 60 * 1000;
+    const now = Date.now();
     const vtidRows = vtidRowsRaw.filter((row: any) => {
       const status = (row.status || '').toLowerCase();
       const isDeleted = status === 'deleted' || status === 'voided' || status === 'cancelled';
@@ -166,6 +177,15 @@ router.get('/', cors(corsOptions), async (req: Request, res: Response) => {
       if (isDeleted || hasDeletedAt || hasVoidedAt || metaDeleted) {
         console.log(`[VTID-01058] Filtering out ${row.vtid}: status=${status}, deleted_at=${row.deleted_at}, voided_at=${row.voided_at}`);
         return false;
+      }
+      if (status === 'allocated') {
+        const createdAt = row.created_at ? new Date(row.created_at).getTime() : 0;
+        const ageMs = now - createdAt;
+        const placeholderTitle = !row.title || row.title === 'Allocated - Pending Title' || row.title === 'Pending Title';
+        if (placeholderTitle && ageMs > ALLOCATED_GRACE_MS) {
+          console.log(`[allocated-orphan] Hiding ${row.vtid}: stale shell, age=${Math.round(ageMs / 60000)}min`);
+          return false;
+        }
       }
       return true;
     });

--- a/services/gateway/src/services/dev-autopilot-bridge.ts
+++ b/services/gateway/src/services/dev-autopilot-bridge.ts
@@ -31,6 +31,7 @@ import {
   TriageMode,
 } from './self-healing-triage-service';
 import { emitOasisEvent } from './oasis-event-service';
+import { isEnvironmentalBlocker } from './dev-autopilot-self-heal-log';
 
 const LOG_PREFIX = '[dev-autopilot-bridge]';
 const BRIDGE_VTID = 'VTID-DEV-AUTOPILOT';
@@ -114,6 +115,7 @@ export type BridgeOutcome =
   | 'self_heal_injected'
   | 'escalated'
   | 'already_bridged'
+  | 'env_blocker'
   | 'revert_failed'
   | 'triage_failed'
   | 'no_execution'
@@ -346,6 +348,68 @@ export async function bridgeFailureToSelfHealing(input: BridgeInput): Promise<Br
       outcome: 'already_bridged',
       execution_id: exec.id,
       self_healing_vtid: exec.self_healing_vtid || undefined,
+    };
+  }
+
+  // ENV-ERROR SHORT-CIRCUIT (2026-04-28 incident): when the failure is
+  // environmental (binary missing, OOM, network, container recycle), running
+  // triage produces a useless report ("install the binary") and the
+  // reconciler then spawns a SELF-HEAL retry VTID per failure. The retry
+  // execution hits the same blocker → infinite loop of stuck in_progress
+  // rows on the operator's Tasks board.
+  //
+  // Skip triage entirely. Mark the execution failed_escalated, write a
+  // self_healing_log entry classified `environmental_blocker` so the
+  // reconciler also short-circuits (see self-healing-reconciler.ts), and
+  // emit an OASIS event so an operator sees the infrastructure problem
+  // instead of a wall of phantom retries.
+  if (isEnvironmentalBlocker(input.error)) {
+    console.warn(`${LOG_PREFIX} environmental blocker for ${exec.id.slice(0, 8)}: ${input.error?.slice(0, 120)} — skipping triage + retry`);
+    await supa(s, `/rest/v1/dev_autopilot_executions?id=eq.${exec.id}`, {
+      method: 'PATCH',
+      headers: { Prefer: 'return=minimal' },
+      body: JSON.stringify({
+        status: 'failed_escalated',
+        failure_stage: input.failure_stage,
+        failure_event_id: input.failure_event_id || null,
+        metadata: {
+          ...(exec.metadata || {}),
+          bridge_outcome: 'env_blocker_skip_triage',
+          bridge_stage: input.failure_stage,
+          env_error: input.error,
+        },
+        completed_at: new Date().toISOString(),
+      }),
+    });
+    await writeSelfHealingLogEntry(s, {
+      execution_id: exec.id,
+      vtid: `VTID-DA-${exec.id.slice(0, 8)}`,
+      endpoint: `dev_autopilot.execution.${input.failure_stage}`,
+      failure_class: 'environmental_blocker',
+      confidence: 1.0,
+      diagnosis: {
+        summary: `Environmental blocker — triage + retry skipped to prevent SELF-HEAL retry loop. Fix the host environment, not the code.`,
+        execution_id: exec.id,
+        finding_id: exec.finding_id,
+        stage: input.failure_stage,
+        error: input.error,
+      },
+      outcome: 'escalated',
+      attempt_number: (exec.auto_fix_depth || 0) + 1,
+    });
+    await emitOasisEvent({
+      vtid: BRIDGE_VTID,
+      type: 'dev_autopilot.execution.escalated',
+      source: 'dev-autopilot-bridge',
+      status: 'error',
+      message: `Execution ${exec.id.slice(0, 8)} env blocker — operator action needed (no autonomous retry)`,
+      payload: { execution_id: exec.id, stage: input.failure_stage, error: input.error, env_blocker: true },
+    });
+    return {
+      ok: false,
+      outcome: 'env_blocker',
+      execution_id: exec.id,
+      error: input.error,
     };
   }
 

--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -445,6 +445,103 @@ export async function approveAutoExecute(input: ApprovalInput): Promise<Approval
   };
 }
 
+// =============================================================================
+// Bridge: operator-driven activation → execution row
+// =============================================================================
+//
+// When a user clicks "Activate" on a dev_autopilot* recommendation in the
+// Command Hub Autopilot popup, the activate route writes a vtid_ledger row
+// and kicks this bridge fire-and-forget. We:
+//   1. Generate a plan if none exists yet (dev_autopilot findings always
+//      have one eventually via lazyPlanTick, but the operator just said
+//      "go" — don't make them wait for the next 30s tick).
+//   2. Skip if an in-flight execution already exists (idempotent — a
+//      double-click or the reaper tick won't double-enqueue).
+//   3. Call approveAutoExecute + immediately patch execute_after to NOW
+//      so the next backgroundExecutorTick picks it up without a cooldown
+//      wait. The cooldown exists to give the operator a chance to cancel
+//      auto-approved findings; an explicit Activate click already IS the
+//      operator's go-ahead.
+//
+// Returns a discriminated result so the caller can log success/failure but
+// the activate-route response itself isn't gated on this — it's all
+// fire-and-forget. The reaper tick later catches any failures here and
+// retries them.
+export async function bridgeActivationToExecution(
+  findingId: string,
+  approvedBy: string | null = null,
+): Promise<{ ok: boolean; execution_id?: string; error?: string; skipped?: string }> {
+  const s = getSupabase();
+  if (!s) return { ok: false, error: 'Supabase not configured' };
+
+  // 1. Verify this is a dev_autopilot* finding (the activate route only
+  //    bridges those — community recs don't go through the executor).
+  const recR = await supa<Array<{ id: string; source_type: string; status: string }>>(
+    s,
+    `/rest/v1/autopilot_recommendations?id=eq.${findingId}&select=id,source_type,status&limit=1`,
+  );
+  if (!recR.ok || !recR.data || !recR.data[0]) {
+    return { ok: false, error: 'finding lookup failed' };
+  }
+  const rec = recR.data[0];
+  if (rec.source_type !== 'dev_autopilot' && rec.source_type !== 'dev_autopilot_impact') {
+    return { ok: false, skipped: `source_type=${rec.source_type} not bridgeable` };
+  }
+
+  // 2. Skip if any in-flight execution already exists for this finding.
+  //    Statuses we consider in-flight: cooling, running, ci, merging,
+  //    deploying, verifying. Terminal states (completed, failed, *) are fine
+  //    to re-enqueue from — but only the reaper does that, never this path
+  //    (operator activation should be a no-op on re-click).
+  const inflightR = await supa<Array<{ id: string; status: string }>>(
+    s,
+    `/rest/v1/dev_autopilot_executions?finding_id=eq.${findingId}` +
+    `&status=in.(cooling,running,ci,merging,deploying,verifying)` +
+    `&select=id,status&limit=1`,
+  );
+  if (inflightR.ok && inflightR.data && inflightR.data[0]) {
+    return { ok: true, execution_id: inflightR.data[0].id, skipped: `existing ${inflightR.data[0].status} execution` };
+  }
+
+  // 3. Generate plan if none exists. lazyPlanTick would do this within 30s
+  //    but the operator clicked Activate — we owe them a faster path.
+  const planR = await supa<Array<{ version: number }>>(
+    s,
+    `/rest/v1/dev_autopilot_plan_versions?finding_id=eq.${findingId}&select=version&limit=1`,
+  );
+  if (!planR.ok || !planR.data || planR.data.length === 0) {
+    const planResult = await generatePlanVersion(findingId);
+    if (!planResult.ok) {
+      return { ok: false, error: `plan generation failed: ${planResult.error}` };
+    }
+  }
+
+  // 4. Approve. approveAutoExecute creates the execution row with
+  //    execute_after = now + cooldown_minutes; we immediately patch
+  //    execute_after back to now so the next tick claims it.
+  const approval = await approveAutoExecute({ finding_id: findingId, approved_by: approvedBy || undefined });
+  if (!approval.ok || !approval.execution) {
+    return { ok: false, error: approval.error || 'approval failed' };
+  }
+  const execId = approval.execution.id;
+  await supa(s, `/rest/v1/dev_autopilot_executions?id=eq.${execId}`, {
+    method: 'PATCH',
+    headers: { Prefer: 'return=minimal' },
+    body: JSON.stringify({ execute_after: new Date().toISOString() }),
+  });
+
+  await emitOasisEvent({
+    vtid: EXEC_VTID,
+    type: 'dev_autopilot.execution.bridged',
+    source: 'dev-autopilot',
+    status: 'info',
+    message: `Operator activation bridged finding ${findingId.slice(0, 8)} → execution ${execId.slice(0, 8)} (cooldown skipped)`,
+    payload: { execution_id: execId, finding_id: findingId, approved_by: approvedBy, source: 'operator_activate' },
+  });
+
+  return { ok: true, execution_id: execId };
+}
+
 /** Extract "delete" intent from the plan markdown — best-effort heuristic.
  *  Looks for bullet lines like "- delete services/.../foo.ts" in the Files
  *  section. Used by the safety gate to allow dead-code deletions without a
@@ -1955,6 +2052,118 @@ export async function lazyPlanTick(): Promise<void> {
   }
 }
 
+// =============================================================================
+// Activation reaper — recover dev_autopilot* recs activated but never executed
+// =============================================================================
+//
+// Operator clicks Activate → vtid_ledger row goes to IN_PROGRESS, the bridge
+// fires fire-and-forget, the user moves on. If the bridge call crashed (Cloud
+// Run container recycle, Supabase blip, Anthropic 5xx during plan
+// generation), the recommendation is left "activated" but no execution row
+// exists. The vtid_ledger card sits in IN PROGRESS forever — exactly what
+// the user reported (cards stuck for 2+ weeks).
+//
+// This tick scans for activated dev_autopilot* recs where:
+//   - autopilot_recommendations.status = 'activated'
+//   - source_type IN (dev_autopilot, dev_autopilot_impact)
+//   - activated_at < now - GRACE
+//   - no dev_autopilot_executions row exists for this finding (any status)
+// and re-runs the bridge for them. GRACE keeps the reaper from racing the
+// initial fire-and-forget bridge call from the activate route.
+const REAPER_GRACE_MS = 5 * 60 * 1000; // 5 min — well past plan-gen latency
+
+async function activationReaperTick(): Promise<void> {
+  const s = getSupabase();
+  if (!s) return;
+
+  const cfg = await loadConfig(s);
+  if (!cfg || cfg.kill_switch) return;
+
+  const cutoff = new Date(Date.now() - REAPER_GRACE_MS).toISOString();
+  // Pull a small batch — we want to recover steadily, not flood the LLM
+  // budget with weeks of accumulated activations on the first tick.
+  const orphanedR = await supa<Array<{ id: string; activated_vtid: string | null; activated_at: string }>>(
+    s,
+    `/rest/v1/autopilot_recommendations?source_type=in.(dev_autopilot,dev_autopilot_impact)` +
+    `&status=eq.activated&activated_at=lt.${cutoff}` +
+    `&select=id,activated_vtid,activated_at&order=activated_at.asc&limit=5`,
+  );
+  if (!orphanedR.ok || !orphanedR.data || orphanedR.data.length === 0) return;
+
+  for (const orphan of orphanedR.data) {
+    // Confirm no execution row exists (any status — a completed exec means
+    // the work was done and we shouldn't redo it; a failed/archived exec
+    // means self-heal has already had its turn).
+    const execR = await supa<Array<{ id: string }>>(
+      s,
+      `/rest/v1/dev_autopilot_executions?finding_id=eq.${orphan.id}&select=id&limit=1`,
+    );
+    if (execR.ok && execR.data && execR.data.length > 0) continue;
+
+    console.log(`${LOG_PREFIX} reaper: recovering activated ${orphan.id.slice(0, 8)} (vtid=${orphan.activated_vtid}, age=${Math.round((Date.now() - new Date(orphan.activated_at).getTime()) / 60000)}m)`);
+    try {
+      const result = await bridgeActivationToExecution(orphan.id, null);
+      if (result.ok) {
+        await emitOasisEvent({
+          vtid: orphan.activated_vtid || EXEC_VTID,
+          type: 'dev_autopilot.execution.reaped',
+          source: 'dev-autopilot',
+          status: 'info',
+          message: `Reaper bridged orphaned activation ${orphan.id.slice(0, 8)} → execution ${result.execution_id?.slice(0, 8) || '?'}`,
+          payload: { finding_id: orphan.id, execution_id: result.execution_id, vtid: orphan.activated_vtid },
+        });
+      } else {
+        console.warn(`${LOG_PREFIX} reaper: bridge failed for ${orphan.id.slice(0, 8)}: ${result.error}`);
+      }
+    } catch (err) {
+      console.error(`${LOG_PREFIX} reaper: error on ${orphan.id.slice(0, 8)}:`, err);
+    }
+  }
+}
+
+// =============================================================================
+// Allocated-orphan reaper — tombstone stale "Allocated - Pending Title" shells
+// =============================================================================
+//
+// VTID-0542 allocator creates a placeholder row (status='allocated',
+// title='Allocated - Pending Title') as the first leg of a 2-step
+// allocate→update sequence. Normally the second leg lands within 1 second.
+// When it doesn't (caller crash, supabase write race, broken self-heal
+// triage path), the shell sits forever and pollutes the operator's Tasks
+// board. The board adapter hides these from view, but rows still accumulate
+// in the database. This tick promotes stale shells to status='deleted' so
+// they fall out of the ledger entirely.
+const ALLOCATED_REAPER_GRACE_MS = 10 * 60 * 1000; // 10 min — well past the
+// happy-path allocate→update latency, even on a slow Supabase day.
+
+async function allocatedOrphanReaperTick(): Promise<void> {
+  const s = getSupabase();
+  if (!s) return;
+
+  const cutoff = new Date(Date.now() - ALLOCATED_REAPER_GRACE_MS).toISOString();
+  const orphansR = await supa<Array<{ vtid: string; created_at: string; title: string | null }>>(
+    s,
+    `/rest/v1/vtid_ledger?status=eq.allocated&created_at=lt.${cutoff}` +
+    `&or=(title.is.null,title.eq.Allocated%20-%20Pending%20Title,title.eq.Pending%20Title)` +
+    `&select=vtid,created_at,title&limit=50`,
+  );
+  if (!orphansR.ok || !orphansR.data || orphansR.data.length === 0) return;
+
+  for (const orphan of orphansR.data) {
+    const ageMin = Math.round((Date.now() - new Date(orphan.created_at).getTime()) / 60_000);
+    console.log(`${LOG_PREFIX} reaper: tombstoning orphan ${orphan.vtid} (age=${ageMin}min, title='${orphan.title}')`);
+    await supa(s, `/rest/v1/vtid_ledger?vtid=eq.${orphan.vtid}&status=eq.allocated`, {
+      method: 'PATCH',
+      headers: { Prefer: 'return=minimal' },
+      body: JSON.stringify({
+        status: 'deleted',
+        delete_reason: `allocated-orphan-reaper: shell never received title (age=${ageMin}min)`,
+        updated_at: new Date().toISOString(),
+      }),
+    });
+  }
+}
+
 let backgroundTickerStarted = false;
 export function startBackgroundExecutor(): void {
   if (backgroundTickerStarted) return;
@@ -1969,6 +2178,12 @@ export function startBackgroundExecutor(): void {
     });
     lazyPlanTick().catch((err) => {
       console.error(`${LOG_PREFIX} lazy-plan tick error:`, err);
+    });
+    activationReaperTick().catch((err) => {
+      console.error(`${LOG_PREFIX} activation-reaper tick error:`, err);
+    });
+    allocatedOrphanReaperTick().catch((err) => {
+      console.error(`${LOG_PREFIX} allocated-orphan-reaper tick error:`, err);
     });
   }, BACKGROUND_TICK_MS);
 }

--- a/services/gateway/src/services/dev-autopilot-self-heal-log.ts
+++ b/services/gateway/src/services/dev-autopilot-self-heal-log.ts
@@ -244,8 +244,42 @@ export async function writeAutopilotSuccess(
  * generation: `failed to spawn ...claude... ENOENT`. When the worker can't
  * find the Claude Code binary, the gateway should fall back to direct
  * Messages API (when ANTHROPIC_API_KEY is set) instead of escalating.
+ *
+ * Patterns matched:
+ *  - "spawn ...claude... ENOENT" — Node's standard spawn ENOENT
+ *  - "Is Claude Code installed and on PATH" — autopilot-worker/src/claude.ts
+ *    appends this to every spawn error
+ *  - "failed to spawn ...antigravity-server" / ".../claude-code-2.x" —
+ *    when CLAUDE_CLI_PATH points at a stale Antigravity extension version
+ *    that no longer exists (the IDE updated to a newer minor version).
+ *    This was the 2026-04-28 outage: 2.1.114 → 2.1.121 left every dev_autopilot
+ *    execution failing in seconds and the reconciler created a SELF-HEAL retry
+ *    VTID per failure, looping forever.
  */
 export function isWorkerBinaryMissing(errorMessage: string | undefined | null): boolean {
   if (!errorMessage) return false;
-  return /spawn .*claude.*ENOENT|Is Claude Code installed and on PATH/i.test(errorMessage);
+  return /spawn .*claude.*ENOENT|Is Claude Code installed and on PATH|failed to spawn .*(?:antigravity-server|claude-code-\d|\.claude\/)/i.test(errorMessage);
+}
+
+/**
+ * Generic environmental-blocker detector. Anything that returns true here
+ * means the failure is NOT a code defect we can fix by re-running triage —
+ * it's the host environment (missing binary, OOM, disk full, network
+ * unreachable). The bridge + reconciler must short-circuit on these so we
+ * don't spawn SELF-HEAL retry VTIDs that the executor can't possibly run.
+ *
+ * Add new patterns here as new infrastructure failures show up. Anything
+ * that matches must NOT trigger triage agent calls — those cost money + tokens
+ * and produce useless reports ("the binary is missing, install it") which
+ * the system can't act on autonomously.
+ */
+export function isEnvironmentalBlocker(errorMessage: string | undefined | null): boolean {
+  if (!errorMessage) return false;
+  if (isWorkerBinaryMissing(errorMessage)) return true;
+  // 2026-04-29: also short-circuit on "worker-queue wait time" — the local
+  // autopilot-worker is single-threaded (max_concurrent=1), so if the queue
+  // backs up the gateway times out per-task at 720s before the worker even
+  // gets to run the LLM. That's a capacity problem, not a code defect; the
+  // triage agent can't fix it.
+  return /ENOSPC|out of memory|OOMKilled|ECONNREFUSED|ETIMEDOUT.*supabase|GITHUB_TOKEN.*not set|GITHUB_SAFE_MERGE_TOKEN.*not set|container recycled mid-execution|worker-queue wait time|worker queue.*timeout/i.test(errorMessage);
 }

--- a/services/gateway/src/services/self-healing-reconciler.ts
+++ b/services/gateway/src/services/self-healing-reconciler.ts
@@ -202,6 +202,7 @@ type EscalateReason =
   | 'recovered_externally'
   | 'stale_no_progress'
   | 'stale_agent_exhausted'
+  | 'environmental_blocker'
   | 'probe_verified'
   | 'probe_failed';
 
@@ -496,6 +497,19 @@ async function runReconcileCycle(thresholdMs: number): Promise<void> {
       // Before tombstoning, try a deep triage agent investigation — it may
       // produce a DIFFERENT approach that feeds a fresh self-healing cycle.
       const agentAttempts = Number((row.diagnosis || {} as any).triage_agent_attempts || 0);
+
+      // ENV-ERROR SHORT-CIRCUIT (2026-04-28 incident): when the failure class
+      // is `environmental_blocker` (binary missing, OOM, network, container
+      // recycle), the bridge already escalated and explicitly skipped triage
+      // because the agent can't fix infrastructure. Don't run another triage
+      // here — it would spawn a SELF-HEAL retry VTID via createFreshVtid…,
+      // and that VTID would just hit the same env blocker again on its next
+      // dispatch. Tombstone immediately instead.
+      if (row.failure_class === 'environmental_blocker') {
+        console.log(`${LOG_PREFIX} env-blocker for ${row.vtid}: skipping triage agent + spawn (operator must fix host)`);
+        await markEscalated(row, 'environmental_blocker', http_status);
+        continue;
+      }
 
       if (agentAttempts < MAX_TRIAGE_ATTEMPTS) {
         console.log(`${LOG_PREFIX} Spawning triage agent for ${row.vtid} (attempt ${agentAttempts + 1}/${MAX_TRIAGE_ATTEMPTS})`);

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -596,6 +596,8 @@ export type CicdEventType =
   | 'dev_autopilot.finding.snoozed'
   | 'dev_autopilot.execution.approved'
   | 'dev_autopilot.execution.auto_approved'
+  | 'dev_autopilot.execution.bridged'
+  | 'dev_autopilot.execution.reaped'
   | 'dev_autopilot.execution.cancelled'
   | 'dev_autopilot.execution.running'
   | 'dev_autopilot.execution.pr_opened'

--- a/supabase/migrations/20260428000000_activate_recommendation_in_progress.sql
+++ b/supabase/migrations/20260428000000_activate_recommendation_in_progress.sql
@@ -169,13 +169,19 @@ COMMENT ON FUNCTION activate_autopilot_recommendation IS
 DO $$
 DECLARE
   v_max BIGINT;
+  v_seq_last BIGINT;
 BEGIN
   SELECT COALESCE(MAX((REGEXP_MATCH(vtid, '^VTID-(\d+)$'))[1]::BIGINT), 0)
     INTO v_max
     FROM vtid_ledger
    WHERE vtid ~ '^VTID-\d+$';
+  -- Read the sequence's current value from the sequence relation rather than
+  -- currval(), which throws "is not yet defined in this session" when no
+  -- nextval() has been called yet in the migration's psql session.
+  SELECT last_value INTO v_seq_last FROM global_vtid_seq;
   -- Add a 100-row buffer so any manual VTIDs minted between this migration
   -- running and the first nextval() don't immediately re-collide.
-  PERFORM setval('global_vtid_seq', GREATEST(v_max + 100, currval('global_vtid_seq')));
-  RAISE NOTICE 'global_vtid_seq advanced to %, max ledger VTID was %', currval('global_vtid_seq'), v_max;
+  PERFORM setval('global_vtid_seq', GREATEST(v_max + 100, v_seq_last));
+  RAISE NOTICE 'global_vtid_seq advanced to %, max ledger VTID was %, prior seq last_value was %',
+    GREATEST(v_max + 100, v_seq_last), v_max, v_seq_last;
 END $$;

--- a/supabase/migrations/20260428000000_activate_recommendation_in_progress.sql
+++ b/supabase/migrations/20260428000000_activate_recommendation_in_progress.sql
@@ -1,0 +1,181 @@
+-- =============================================================================
+-- Fix: activate_autopilot_recommendation lands tasks in SCHEDULED column
+--      AND fails with 409 duplicate-key when the global VTID sequence has
+--      drifted behind manually-inserted high-numbered VTIDs
+--
+-- Symptom (Operations → Tasks board):
+--   1. User clicks "Activate" in the Autopilot popup. The new VTID card
+--      appears in the SCHEDULED column instead of IN PROGRESS.
+--   2. (2026-04-29) After cleanup of self-heal retry rows, every Activate
+--      click returned `409: duplicate key value violates unique constraint
+--      "vtid_ledger_vtid_unique"` for VTID-02055, VTID-02056, etc.
+--
+-- Root causes:
+--   1. The RPC inserts vtid_ledger.status = 'scheduled'. The Tasks board
+--      adapter in services/gateway/src/routes/tasks.ts maps that to the
+--      SCHEDULED column. Activation means "start now" — the row should land
+--      in IN_PROGRESS, not Scheduled limbo.
+--   2. global_vtid_seq is only one of several VTID generators. The VAEA
+--      project (VTID-02400-02409) inserted high-numbered VTIDs via its own
+--      migration without advancing the sequence; the self-healing reconciler
+--      generates VTIDs via MAX(vtid)+1 in createFreshVtidFromTriageReport
+--      which also ignores the sequence. Result: the sequence emits numbers
+--      (e.g. 2055) that already exist in vtid_ledger and the INSERT 409s.
+--
+-- Fixes:
+--   1. INSERT with status = 'in_progress' so the card renders in IN PROGRESS
+--      immediately. The route handler then enqueues execution
+--      (dev_autopilot_executions) for dev_autopilot* findings via the bridge
+--      added in the same change set.
+--   2. setval() the sequence above the current MAX(vtid_number) so the next
+--      nextval() can't collide. Done as a one-shot DO block at the bottom of
+--      this migration. Future drift is structurally prevented by this RPC
+--      now using a do/while loop that increments past any pre-existing VTID
+--      before INSERTing — so even a fresh manual VTID inserted between the
+--      sequence jump and the INSERT can't break activation.
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION activate_autopilot_recommendation(
+  p_recommendation_id UUID,
+  p_user_id UUID DEFAULT NULL
+)
+RETURNS JSONB
+LANGUAGE plpgsql
+SECURITY DEFINER
+AS $$
+DECLARE
+  v_rec RECORD;
+  v_vtid TEXT;
+  v_num BIGINT;
+  v_spec_snapshot JSONB;
+  v_checksum TEXT;
+  v_now TIMESTAMPTZ := NOW();
+BEGIN
+  SELECT * INTO v_rec
+  FROM autopilot_recommendations
+  WHERE id = p_recommendation_id
+  FOR UPDATE;
+
+  IF NOT FOUND THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'Recommendation not found');
+  END IF;
+
+  IF v_rec.status = 'activated' AND v_rec.activated_vtid IS NOT NULL THEN
+    RETURN jsonb_build_object(
+      'ok', true,
+      'vtid', v_rec.activated_vtid,
+      'already_activated', true,
+      'activated_at', v_rec.activated_at
+    );
+  END IF;
+
+  IF v_rec.status NOT IN ('new', 'snoozed') THEN
+    RETURN jsonb_build_object(
+      'ok', false,
+      'error', format('Cannot activate recommendation in status: %s', v_rec.status)
+    );
+  END IF;
+
+  -- Generate VTID. nextval() can collide with high-numbered VTIDs inserted
+  -- by other code paths (VAEA migrations, self-heal createFreshVtid, etc.)
+  -- that don't advance the sequence. Skip forward until we find a free slot.
+  -- Bounded loop to fail loudly if the table is somehow full.
+  FOR i IN 1..1000 LOOP
+    v_num := nextval('global_vtid_seq');
+    v_vtid := 'VTID-' || LPAD(v_num::TEXT, 5, '0');
+    EXIT WHEN NOT EXISTS (SELECT 1 FROM vtid_ledger WHERE vtid = v_vtid);
+  END LOOP;
+  IF EXISTS (SELECT 1 FROM vtid_ledger WHERE vtid = v_vtid) THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'VTID generator could not find a free slot in 1000 tries');
+  END IF;
+
+  v_spec_snapshot := jsonb_build_object(
+    'vtid_title', v_rec.title,
+    'goal', v_rec.summary,
+    'scope_in', ARRAY[v_rec.domain],
+    'scope_out', ARRAY[]::TEXT[],
+    'non_negotiables', ARRAY['Safety check required', 'User consent required'],
+    'files_expected', ARRAY[]::TEXT[],
+    'endpoints_expected', ARRAY[]::TEXT[],
+    'tests', ARRAY['Unit tests', 'Integration tests'],
+    'definition_of_done', ARRAY[
+      'Implementation complete',
+      'Tests passing',
+      'Documentation updated',
+      'Code reviewed'
+    ],
+    'source_recommendation_id', p_recommendation_id,
+    'domain', v_rec.domain,
+    'risk_level', v_rec.risk_level,
+    'impact_score', v_rec.impact_score,
+    'effort_score', v_rec.effort_score
+  );
+
+  v_checksum := encode(sha256(convert_to(v_spec_snapshot::text, 'UTF8')), 'hex');
+
+  UPDATE autopilot_recommendations
+  SET status = 'activated',
+      activated_vtid = v_vtid,
+      activated_at = v_now,
+      spec_snapshot = v_spec_snapshot,
+      spec_checksum = v_checksum,
+      updated_at = v_now
+  WHERE id = p_recommendation_id;
+
+  -- Status starts at 'in_progress' (was 'scheduled' before this migration)
+  -- so the Tasks board renders the card in the IN PROGRESS column the moment
+  -- the operator clicks Activate.
+  INSERT INTO vtid_ledger (
+    vtid,
+    title,
+    summary,
+    status,
+    layer,
+    module,
+    created_at,
+    updated_at
+  ) VALUES (
+    v_vtid,
+    v_rec.title,
+    v_rec.summary,
+    'in_progress',
+    'autopilot',
+    'recommendation',
+    v_now,
+    v_now
+  );
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'vtid', v_vtid,
+    'recommendation_id', p_recommendation_id,
+    'title', v_rec.title,
+    'status', 'activated',
+    'activated_at', v_now,
+    'spec_checksum', v_checksum
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION activate_autopilot_recommendation IS
+  'Activate recommendation - creates VTID + spec snapshot. Sets vtid_ledger.status=in_progress so the Tasks board renders the card in IN PROGRESS. Skips past existing VTIDs to handle sequence drift.';
+
+-- =============================================================================
+-- One-shot: realign global_vtid_seq above the highest VTID currently in the
+-- ledger so the next nextval() can't collide on the first try. The RPC's
+-- skip-forward loop above is the durable fix; this just spares us a wasted
+-- ~400 nextval() calls on the first activation post-deploy.
+-- =============================================================================
+DO $$
+DECLARE
+  v_max BIGINT;
+BEGIN
+  SELECT COALESCE(MAX((REGEXP_MATCH(vtid, '^VTID-(\d+)$'))[1]::BIGINT), 0)
+    INTO v_max
+    FROM vtid_ledger
+   WHERE vtid ~ '^VTID-\d+$';
+  -- Add a 100-row buffer so any manual VTIDs minted between this migration
+  -- running and the first nextval() don't immediately re-collide.
+  PERFORM setval('global_vtid_seq', GREATEST(v_max + 100, currval('global_vtid_seq')));
+  RAISE NOTICE 'global_vtid_seq advanced to %, max ledger VTID was %', currval('global_vtid_seq'), v_max;
+END $$;


### PR DESCRIPTION
## Summary

Closes the autopilot self-loop incident chain. Fixes four chained bugs at the source plus moves the worker LLM stage from local Claude-subscription path to Vertex AI / Gemini 3 Pro.

- **VTID sequence collision (409 on Activate):** RPC skip-loops past existing VTIDs; one-shot setval() realigns ahead of MAX(vtid).
- **Activated tasks landed in SCHEDULED:** RPC now inserts with status='in_progress'.
- **SELF-HEAL retry loop on env failures:** bridge + reconciler short-circuit on environmental_blocker failures (binary missing, OOM, network, container recycle, worker-queue wait). No triage agent. No child execution. No fresh SELF-HEAL VTID.
- **Orphan 'Allocated - Pending Title' shells:** board adapter hides them after 5min; new reaper tombstones after 10min.

Activation now bridges dev_autopilot* findings into the executor immediately, with reaper to recover crashed bridge calls.

**Companion runtime change** (already applied directly in Supabase, not in this PR): LLM routing policy v6→v7, flipping worker.primary from claude_subscription → vertex/gemini-3-pro-preview. Cloud Run GOOGLE_CLOUD_PROJECT covers Vertex IAM.

VTID: VTID-02500

## Test plan

- [ ] RUN-MIGRATION.yml: verify no ROLLBACK, currval('global_vtid_seq') > 2409
- [ ] EXEC-DEPLOY gateway, /alive returns 200 + new revision serving
- [ ] Click Activate on a dev_autopilot finding — lands in IN_PROGRESS, no 409
- [ ] Executor claims cooling row, opens PR via Vertex
- [ ] No SELF-HEAL retry VTIDs spawned after next run
- [ ] No 'Allocated - Pending Title' rows older than 5 min on board

🤖 Generated with [Claude Code](https://claude.com/claude-code)