### PR TITLE
fix(deploy): wire VITANA_CHAT_WEBHOOK secret into gateway env (VTID-02030d)

### DIFF
--- a/.github/workflows/EXEC-DEPLOY.yml
+++ b/.github/workflows/EXEC-DEPLOY.yml
@@ -352,6 +352,10 @@ jobs:
             # VTID-01981: Routines ingest token — required by /api/v1/routines POST/PATCH
             # so daily Claude Code remote agents can authenticate without user JWTs.
             EXTRA_ENV_ARGS+=(--update-env-vars=ROUTINE_INGEST_TOKEN=${{ secrets.ROUTINE_INGEST_TOKEN }})
+            # VTID-02030d: Google Chat webhook for human-in-the-loop pings
+            # (voice quarantine, architectural recommendations, etc.).
+            # Same secret used by DAILY-STATUS-UPDATE.yml's existing pings.
+            EXTRA_ENV_ARGS+=(--update-env-vars=GCHAT_COMMANDHUB_WEBHOOK=${{ secrets.VITANA_CHAT_WEBHOOK }})
           fi
 
           # VTID-01225: Cognee extractor — internal ingress, Gemini LLM via API key


### PR DESCRIPTION
## Summary

Root cause of the missing Gchat ping found via VTID-02030c diagnostic endpoint: \`webhook_env_set: false\` on the deployed gateway. The code reads \`process.env.GCHAT_COMMANDHUB_WEBHOOK\` but EXEC-DEPLOY.yml never injected that variable into the Cloud Run service config.

The webhook URL **does** exist in the repo — it's the GitHub Actions secret \`VITANA_CHAT_WEBHOOK\`, used by \`.github/workflows/DAILY-STATUS-UPDATE.yml:20\` for the working daily-status pings to the same Gchat space. It was just never wired to the gateway.

This PR adds one line to EXEC-DEPLOY.yml's gateway-specific env block:

\`\`\`yaml
EXTRA_ENV_ARGS+=(--update-env-vars=GCHAT_COMMANDHUB_WEBHOOK=\${{ secrets.VITANA_CHAT_WEBHOOK }})
\`\`\`

## Touched files

- \`.github/workflows/EXEC-DEPLOY.yml\` — +4 lines (1 env-var line + 3 lines of context comment)

No code changes. After the next gateway deploy lands, all VTID-02030 paths (quarantine ping, architectural-recommendation ping, plus the diagnostic endpoint) start firing into the same Gchat space the daily-status pings use.

## Test plan

- [ ] After deploy: \`curl -X POST .../api/v1/voice-lab/healing/gchat-ping-test -d '{\"note\":\"verify\"}'\` should return \`{ok:true, webhook_env_set:true, send_error:null}\` AND a 🔧 message arrives in the Gchat space
- [ ] Re-run investigator on \`voice.model_under_responds\` → 🧠 ping for architectural recommendation arrives

🤖 Generated with [Claude Code](https://claude.com/claude-code)