### PR TITLE
fix(deploy): quote GCHAT webhook URL to escape '&' (VTID-02030e)

### DIFF
--- a/.github/workflows/EXEC-DEPLOY.yml
+++ b/.github/workflows/EXEC-DEPLOY.yml
@@ -352,10 +352,12 @@ jobs:
             # VTID-01981: Routines ingest token — required by /api/v1/routines POST/PATCH
             # so daily Claude Code remote agents can authenticate without user JWTs.
             EXTRA_ENV_ARGS+=(--update-env-vars=ROUTINE_INGEST_TOKEN=${{ secrets.ROUTINE_INGEST_TOKEN }})
-            # VTID-02030d: Google Chat webhook for human-in-the-loop pings
+            # VTID-02030d/e: Google Chat webhook for human-in-the-loop pings
             # (voice quarantine, architectural recommendations, etc.).
             # Same secret used by DAILY-STATUS-UPDATE.yml's existing pings.
-            EXTRA_ENV_ARGS+=(--update-env-vars=GCHAT_COMMANDHUB_WEBHOOK=${{ secrets.VITANA_CHAT_WEBHOOK }})
+            # Quoted because the webhook URL contains '&' (key=...&token=...)
+            # which bash would otherwise read as a background-process token.
+            EXTRA_ENV_ARGS+=("--update-env-vars=GCHAT_COMMANDHUB_WEBHOOK=${{ secrets.VITANA_CHAT_WEBHOOK }}")
           fi
 
           # VTID-01225: Cognee extractor — internal ingress, Gemini LLM via API key


### PR DESCRIPTION
## Summary

PR #1070 (VTID-02030d) added the gateway-side webhook env-var line but the gateway deploy failed at the \`Deploy to Cloud Run\` step:

\`\`\`
syntax error near unexpected token '&'
\`\`\`

Root cause: the webhook URL is \`https://chat.googleapis.com/v1/spaces/.../messages?key=X&token=Y\` and the unquoted ampersand was interpreted by bash as a background-process token. Wrapping the array element in double quotes makes the whole URL one literal argument.

## Touched files

- \`.github/workflows/EXEC-DEPLOY.yml\` — wrap one EXTRA_ENV_ARGS array entry in quotes (+2 / -2)

## Test plan

- [ ] After deploy: \`curl -X POST .../api/v1/voice-lab/healing/gchat-ping-test\` returns \`{ok:true, webhook_env_set:true}\` AND a 🔧 message arrives in Vitana Ops Gchat space

🤖 Generated with [Claude Code](https://claude.com/claude-code)