### PR TITLE
fix(deploy): quote GCHAT_COMMANDHUB_WEBHOOK secret — unblock all gateway deploys (BOOTSTRAP-DEPLOY-QUOTE-FIX)

### DIFF
--- a/.github/workflows/EXEC-DEPLOY.yml
+++ b/.github/workflows/EXEC-DEPLOY.yml
@@ -355,7 +355,12 @@ jobs:
             # VTID-02030d: Google Chat webhook for human-in-the-loop pings
             # (voice quarantine, architectural recommendations, etc.).
             # Same secret used by DAILY-STATUS-UPDATE.yml's existing pings.
-            EXTRA_ENV_ARGS+=(--update-env-vars=GCHAT_COMMANDHUB_WEBHOOK=${{ secrets.VITANA_CHAT_WEBHOOK }})
+            # Quoted because Google Chat webhook URLs always contain `&`
+            # between query params (?key=...&token=...) and an unquoted `&`
+            # inside `()` is a bash background-job token → syntax error
+            # before the run even starts. PR #1070 missed the quoting and
+            # broke every gateway deploy until this fix.
+            EXTRA_ENV_ARGS+=("--update-env-vars=GCHAT_COMMANDHUB_WEBHOOK=${{ secrets.VITANA_CHAT_WEBHOOK }}")
           fi
 
           # VTID-01225: Cognee extractor — internal ingress, Gemini LLM via API key


### PR DESCRIPTION
## Summary

PR #1070 added the GChat webhook env var unquoted:

\`\`\`
EXTRA_ENV_ARGS+=(--update-env-vars=GCHAT_COMMANDHUB_WEBHOOK=\${{ secrets.VITANA_CHAT_WEBHOOK }})
\`\`\`

Google Chat webhook URLs always contain \`&\` between query params (\`?key=...&token=...\`). Actions does direct text substitution, so the generated bash becomes:

\`\`\`
EXTRA_ENV_ARGS+=(--update-env-vars=GCHAT_COMMANDHUB_WEBHOOK=https://...?key=X&token=Y)
\`\`\`

The \`&\` inside \`()\` is a bash background-job token. Script fails syntax-check before deploy starts:

\`\`\`
line 126: syntax error near unexpected token '&'
Process completed with exit code 2
\`\`\`

This has blocked **every gateway EXEC-DEPLOY since PR #1070 merged at ~10:00 UTC today**, including the deploy of PR #1069 (autopilot loop fix + Vertex routing).

## Fix

Wrap the \`--update-env-vars=...\` argument in double quotes so the substituted URL is one bash token.

## Test plan

- [ ] Re-run EXEC-DEPLOY for gateway after merge → succeeds at the deploy step (no syntax error)
- [ ] Verify \`GCHAT_COMMANDHUB_WEBHOOK\` is set on the gateway Cloud Run service
- [ ] Confirm /alive returns 200 with new revision

VTID: BOOTSTRAP-DEPLOY-QUOTE-FIX (urgent infrastructure unblock)

🤖 Generated with [Claude Code](https://claude.com/claude-code)