### PR TITLE
feat(reminders): SSE /stream endpoint for fire delivery (VTID-02601 PR-2 backend)

### DIFF
--- a/services/gateway/src/routes/reminders.ts
+++ b/services/gateway/src/routes/reminders.ts
@@ -7,6 +7,7 @@
  *   POST   /api/v1/reminders                  Create
  *   GET    /api/v1/reminders                  List (?status, ?include_fired, ?q, ?limit)
  *   GET    /api/v1/reminders/missed           Fired but not acked
+ *   GET    /api/v1/reminders/stream           SSE: pushes reminder.fire events with chime + voice
  *   GET    /api/v1/reminders/:id              Get one
  *   PATCH  /api/v1/reminders/:id              Edit
  *   POST   /api/v1/reminders/:id/snooze       Push next_fire_at by N minutes
@@ -14,8 +15,6 @@
  *   POST   /api/v1/reminders/:id/complete     Mark completed (user did the thing)
  *   DELETE /api/v1/reminders/:id              Soft-cancel (status='cancelled')
  *   DELETE /api/v1/reminders?mode=all         Soft-cancel all active reminders
- *
- * SSE stream and audio delivery wiring lands in PR-2.
  */
 
 import { Router, Request, Response } from 'express';
@@ -27,6 +26,7 @@ import {
   formatTimeForVoice,
   ReminderValidationError,
 } from '../services/reminders-service';
+import { getReminderChimePcmB64 } from '../services/reminder-chime';
 
 const router = Router();
 const LOG_PREFIX = '[Reminders]';
@@ -371,6 +371,95 @@ router.delete('/', async (req: Request, res: Response) => {
     console.error(`${LOG_PREFIX} DELETE / error:`, err.message);
     return res.status(500).json({ ok: false, error: 'Internal error' });
   }
+});
+
+// =============================================================================
+// GET /reminders/stream — Server-Sent Events for reminder fire delivery
+//
+// Auth: EventSource cannot send custom headers, so we accept ?user_id=X as
+// query param (server-role check). For production we'd swap this for a
+// signed short-TTL session token, but the same vector exists for /events.
+//
+// Polling cadence: 3s (matches /api/v1/events/stream pattern).
+// Heartbeat: 30s.
+// Payload on a fire: { type:'reminder.fire', reminder_id, action_text,
+//   spoken_message, chime_pcm_b64, voice_audio_b64, voice_lang, fired_at }
+// =============================================================================
+router.get('/stream', async (req: Request, res: Response) => {
+  const userId = getUserId(req);
+  if (!userId) {
+    return res.status(401).json({ ok: false, error: 'User ID required' });
+  }
+  const admin = getSupabase();
+  if (!admin) return res.status(503).json({ ok: false, error: 'Supabase not configured' });
+
+  res.setHeader('Content-Type', 'text/event-stream');
+  res.setHeader('Cache-Control', 'no-cache');
+  res.setHeader('Connection', 'keep-alive');
+  res.setHeader('X-Accel-Buffering', 'no');
+
+  res.write(
+    `event: connected\ndata: ${JSON.stringify({
+      status: 'connected',
+      timestamp: new Date().toISOString(),
+    })}\n\n`,
+  );
+
+  const seen = new Set<string>(); // dedup across reconnect-within-session
+  const chimeB64 = getReminderChimePcmB64();
+
+  const pollFires = async () => {
+    try {
+      const { data, error } = await admin
+        .from('reminders')
+        .select('*')
+        .eq('user_id', userId)
+        .eq('status', 'fired')
+        .is('acked_at', null)
+        .order('fired_at', { ascending: true })
+        .limit(20);
+      if (error) {
+        console.error('[Reminders SSE] poll error:', error.message);
+        return;
+      }
+      for (const row of data || []) {
+        if (seen.has(row.id)) continue;
+        seen.add(row.id);
+
+        const payload = {
+          type: 'reminder.fire',
+          reminder_id: row.id,
+          action_text: row.action_text,
+          spoken_message: row.spoken_message,
+          description: row.description,
+          chime_pcm_b64: chimeB64,
+          chime_mime: 'audio/pcm;rate=24000',
+          voice_audio_b64: row.tts_audio_b64,
+          voice_mime: 'audio/mp3',
+          voice_lang: row.tts_lang,
+          fired_at: row.fired_at,
+          next_fire_at: row.next_fire_at,
+        };
+        res.write(`id: ${row.id}\nevent: reminder-fire\ndata: ${JSON.stringify(payload)}\n\n`);
+      }
+    } catch (err: any) {
+      console.error('[Reminders SSE] poll exception:', err?.message);
+    }
+  };
+
+  await pollFires();
+  const pollInterval = setInterval(pollFires, 3000);
+  const heartbeatInterval = setInterval(() => {
+    res.write(`: heartbeat ${new Date().toISOString()}\n\n`);
+  }, 30000);
+
+  req.on('close', () => {
+    clearInterval(pollInterval);
+    clearInterval(heartbeatInterval);
+    try {
+      res.end();
+    } catch {}
+  });
 });
 
 // =============================================================================

--- a/services/gateway/src/services/reminder-chime.ts
+++ b/services/gateway/src/services/reminder-chime.ts
@@ -1,0 +1,54 @@
+/**
+ * VTID-02601 — Reminder chime PCM generator.
+ *
+ * 24kHz mono 16-bit PCM, 400ms two-tone bell (C5 → E5), pre-generated once
+ * at module load and cached. The same shape used by the ORB activation chime
+ * in orb-live.ts (we duplicate to avoid coupling reminder delivery to that
+ * module's lifecycle — refactor opportunity later).
+ */
+
+let cached: string | null = null;
+
+export function getReminderChimePcmB64(): string {
+  if (cached) return cached;
+
+  const sampleRate = 24000;
+  const duration = 0.40;
+  const totalSamples = Math.floor(sampleRate * duration);
+  const buffer = Buffer.alloc(totalSamples * 2);
+
+  const tone1Freq = 523.25; // C5
+  const tone2Freq = 659.25; // E5
+  const tone1End = 0.15;
+  const tone2Start = 0.15;
+  const amplitude = 4000;
+
+  for (let i = 0; i < totalSamples; i++) {
+    const t = i / sampleRate;
+    let sample = 0;
+
+    if (t < tone1End) {
+      let env = 1.0;
+      if (t < 0.02) env = t / 0.02;
+      else if (t > 0.08) env = (tone1End - t) / (tone1End - 0.08);
+      sample = Math.sin(2 * Math.PI * tone1Freq * t) * amplitude * env;
+    } else if (t >= tone2Start) {
+      const t2 = t - tone2Start;
+      const tone2Duration = duration - tone2Start;
+      let env = 1.0;
+      if (t2 < 0.02) env = t2 / 0.02;
+      else if (t2 > 0.10) env = (tone2Duration - t2) / (tone2Duration - 0.10);
+      sample = Math.sin(2 * Math.PI * tone2Freq * t) * amplitude * env;
+    }
+
+    const clamped = Math.max(-32768, Math.min(32767, Math.round(sample)));
+    buffer.writeInt16LE(clamped, i * 2);
+  }
+
+  cached = buffer.toString('base64');
+  console.log(`[reminder-chime] PCM generated: ${totalSamples} samples, ${buffer.length} bytes, ${cached.length} b64 chars`);
+  return cached;
+}
+
+// Pre-generate at module load
+getReminderChimePcmB64();


### PR DESCRIPTION
## Summary

Part 2 of the Reminder feature — backend SSE delivery surface.

- New `GET /api/v1/reminders/stream` Server-Sent Events endpoint pushes reminder.fire events to the connected client in real time
- Each event carries the chime PCM (cached, 24kHz two-tone bell) + pre-rendered TTS voice audio so the client just plays two buffers — no server-side synthesis on the critical path
- Polls reminders table every 3s for the user (mirrors existing /events/stream pattern). Dedups via SSE event id. Heartbeat every 30s. Cleanup on req.close.
- New `services/reminder-chime.ts` — self-contained chime PCM generator (cached at module load)

Frontend wiring (overlay + chime/voice playback + banner) lands in the vitana-v1 PR.

## Test plan

- [ ] curl `/api/v1/reminders/stream?user_id=<id>` and verify SSE handshake (`event: connected`)
- [ ] Create a reminder for 90s, watch the stream, verify `event: reminder-fire` arrives within 30s of fire time with chime + voice payloads
- [ ] Tab-close-during-fire — verify no zombie poll loops in gateway logs

🤖 Generated with [Claude Code](https://claude.com/claude-code)