### PR TITLE
fix(diag): surface gchat webhook HTTP status + url shape (VTID-02030f)

### DIFF
--- a/services/gateway/src/routes/voice-lab.ts
+++ b/services/gateway/src/routes/voice-lab.ts
@@ -1109,22 +1109,31 @@ router.get('/healing/mode', async (_req: Request, res: Response) => {
 router.post('/healing/gchat-ping-test', async (req: Request, res: Response) => {
   const body = (req.body || {}) as Record<string, unknown>;
   const note = typeof body.note === 'string' ? body.note : 'manual diagnostic';
-  const webhookSet = Boolean(process.env.GCHAT_COMMANDHUB_WEBHOOK);
+  const webhook = process.env.GCHAT_COMMANDHUB_WEBHOOK || '';
   const text =
-    `🔧 *Gchat ping diagnostic* (VTID-02030c)\n` +
+    `🔧 *Gchat ping diagnostic* (VTID-02030f)\n` +
     `If you see this, the gateway → Gchat path works.\n` +
     `Note: ${note}\n` +
     `Time: ${new Date().toISOString()}`;
-  let sendError: string | null = null;
-  try {
-    await notifyGChat(text);
-  } catch (err: any) {
-    sendError = err?.message ?? String(err);
+  const result = await notifyGChat(text);
+  // Capture useful diagnostics about the webhook URL itself without leaking
+  // its full value: domain, path prefix, query-keys present.
+  let url_host: string | null = null;
+  let url_path_prefix: string | null = null;
+  let query_keys: string[] = [];
+  if (webhook) {
+    try {
+      const u = new URL(webhook);
+      url_host = u.host;
+      url_path_prefix = u.pathname.split('/').slice(0, 4).join('/');
+      query_keys = Array.from(u.searchParams.keys()).sort();
+    } catch { /* malformed url */ }
   }
   return res.json({
-    ok: sendError === null,
-    webhook_env_set: webhookSet,
-    send_error: sendError,
+    ...result,
+    webhook_url_host: url_host,
+    webhook_url_path_prefix: url_path_prefix,
+    webhook_query_keys: query_keys,
   });
 });
 

--- a/services/gateway/src/services/self-healing-snapshot-service.ts
+++ b/services/gateway/src/services/self-healing-snapshot-service.ts
@@ -21,20 +21,38 @@ function supabaseHeaders(): Record<string, string> {
   };
 }
 
-export async function notifyGChat(message: string): Promise<void> {
+/**
+ * VTID-02030f: returns a structured result so callers (especially the
+ * diagnostic endpoint) can tell when fetch() resolved-but-the-message-
+ * never-arrived (401/403/404 from the webhook). Existing callers ignore
+ * the return value, so behavior for them is unchanged.
+ */
+export async function notifyGChat(
+  message: string,
+): Promise<{ ok: boolean; webhook_set: boolean; status?: number; body_excerpt?: string; error?: string }> {
   const webhook = process.env.GCHAT_COMMANDHUB_WEBHOOK;
   if (!webhook) {
     console.warn('[Self-Healing] GCHAT_COMMANDHUB_WEBHOOK not set, skipping notification');
-    return;
+    return { ok: false, webhook_set: false, error: 'webhook_not_set' };
   }
   try {
-    await fetch(webhook, {
+    const r = await fetch(webhook, {
       method: 'POST',
       headers: { 'Content-Type': 'application/json' },
       body: JSON.stringify({ text: message }),
     });
-  } catch (err) {
-    console.error('[Self-Healing] GChat notification failed:', err);
+    let body = '';
+    try { body = (await r.text()).slice(0, 400); } catch { /* ignore */ }
+    if (!r.ok) {
+      console.error(
+        `[Self-Healing] GChat webhook returned non-2xx: status=${r.status} body=${body}`,
+      );
+    }
+    return { ok: r.ok, webhook_set: true, status: r.status, body_excerpt: body };
+  } catch (err: any) {
+    const msg = err?.message ?? String(err);
+    console.error('[Self-Healing] GChat notification failed:', msg);
+    return { ok: false, webhook_set: true, error: msg };
   }
 }
 


### PR DESCRIPTION
## Summary

VTID-02030e diagnostic returned \`ok:true, webhook_env_set:true, send_error:null\` but the message never arrived. Root cause: \`notifyGChat()\` calls \`await fetch()\` and never inspects \`response.ok\`. Fetch resolves successfully even on 401/403/404, so a webhook that returns \"rejected\" looks identical to a webhook that delivered.

## Changes

1. \`notifyGChat()\` now returns \`{ok, webhook_set, status, body_excerpt, error}\` — existing callers ignore the return, no behavior change for them.
2. \`/healing/gchat-ping-test\` passes that through and adds \`webhook_url_host\`, \`webhook_url_path_prefix\`, \`webhook_query_keys\` so we can spot wrong-domain / missing-token / etc. without leaking the URL value.

## Test plan

After deploy, \`curl -X POST .../healing/gchat-ping-test\` will return the actual HTTP status and body excerpt. If it's a 4xx, the body excerpt explains why. If it's 200 but you still don't see the message, the URL-shape fields tell us whether the URL is even pointing at chat.googleapis.com.

🤖 Generated with [Claude Code](https://claude.com/claude-code)