### PR TITLE
feat(feedback): specialist intake + handoff bridge (VTID-02603)

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -184,6 +184,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const diaryRouter = require('./routes/diary').default;
   // VTID-02047: Unified Feedback Pipeline - bug reports, support, claims, account
   const feedbackRouter = require('./routes/feedback').default;
+  // VTID-02603: Feedback intake & specialist handoff bridge
+  const feedbackIntakeRouter = require('./routes/feedback-intake').default;
   // VTID-01114: Domain & Topic Routing Engine (D22) - intelligence traffic control
   const domainRoutingRouter = require('./routes/domain-routing').default;
   // VTID-01119: User Preference & Constraint Modeling Engine
@@ -888,6 +890,9 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   // Mounted under /tickets because /api/v1/feedback is already the VTID-01121
   // feedback-correction router (different concept, same word).
   mountRouterSync(app, '/api/v1/feedback/tickets', feedbackRouter, { owner: 'feedback-tickets' });
+
+  // VTID-02603: Feedback intake & specialist handoff bridge
+  mountRouterSync(app, '/api/v1/feedback/intake', feedbackIntakeRouter, { owner: 'feedback-intake' });
 
   // VTID-01114: Domain & Topic Routing Engine (D22) - intelligence traffic control layer
   mountRouterSync(app, '/api/v1/routing', domainRoutingRouter, { owner: 'domain-routing' });

--- a/services/gateway/src/routes/feedback-intake.ts
+++ b/services/gateway/src/routes/feedback-intake.ts
@@ -1,0 +1,340 @@
+/**
+ * VTID-02603: Unified Feedback Pipeline — intake & handoff bridge
+ * Parent plan PR 3-5 bundle.
+ *
+ * Endpoints (mounted under /api/v1/feedback/intake):
+ * - POST /handoff-detect      — given a user opener, return the matching
+ *                               specialist (Devon/Sage/Atlas/Mira) or null
+ *                               for "stay with Vitana".
+ * - POST /start               — create a feedback_tickets row in
+ *                               'interviewing' status, log the Vitana →
+ *                               specialist handoff event, return persona +
+ *                               ticket_id so the frontend can swap voice.
+ * - POST /turn                — append one user/assistant turn to the
+ *                               in-flight ticket's intake_messages.
+ * - POST /complete            — flip status to 'triaged', set
+ *                               structured_fields, log wrap-back handoff.
+ *
+ * The voice channel swap happens in the frontend (vitana-v1) — this gateway
+ * code is the data plane: detection, ticket lifecycle, handoff events.
+ */
+
+import { Router, Request, Response } from 'express';
+import { z } from 'zod';
+import { createUserSupabaseClient } from '../lib/supabase-user';
+import { emitOasisEvent } from '../services/oasis-event-service';
+import { resolveVitanaId } from '../middleware/auth-supabase-jwt';
+
+const router = Router();
+const VTID = 'VTID-02603';
+
+const KIND_BY_AGENT: Record<string, string> = {
+  devon: 'bug',
+  sage: 'support_question',
+  atlas: 'marketplace_claim',
+  mira: 'account_issue',
+};
+
+function getBearerToken(req: Request): string | null {
+  const h = req.headers.authorization;
+  return h && h.startsWith('Bearer ') ? h.slice(7) : null;
+}
+
+function decodeJwtSub(token: string): string | null {
+  try {
+    return JSON.parse(Buffer.from(token.split('.')[1], 'base64').toString()).sub ?? null;
+  } catch { return null; }
+}
+
+// ---------------------------------------------------------------------------
+// POST /handoff-detect
+// ---------------------------------------------------------------------------
+
+const DetectSchema = z.object({
+  text: z.string().min(1).max(2000),
+  conversation_id: z.string().max(120).optional(),
+});
+
+router.post('/handoff-detect', async (req: Request, res: Response) => {
+  const token = getBearerToken(req);
+  if (!token) return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+
+  const v = DetectSchema.safeParse(req.body);
+  if (!v.success) return res.status(400).json({ ok: false, error: 'VALIDATION_FAILED' });
+
+  const supabase = createUserSupabaseClient(token);
+  const { data, error } = await supabase.rpc('pick_specialist_for_text', { p_text: v.data.text });
+
+  if (error) {
+    console.error(`[${VTID}] pick_specialist RPC error:`, error.message);
+    return res.status(502).json({ ok: false, error: 'RPC_FAILED', details: error.message });
+  }
+
+  const row = Array.isArray(data) ? data[0] : data;
+  if (!row || !row.persona_key) {
+    return res.json({ ok: true, handoff: false, persona_key: 'vitana' });
+  }
+  return res.json({
+    ok: true,
+    handoff: true,
+    persona_key: row.persona_key,
+    matched_keyword: row.matched_keyword,
+    score: row.score,
+    confidence: row.confidence,
+    suggested_kind: KIND_BY_AGENT[row.persona_key] ?? null,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /start
+// ---------------------------------------------------------------------------
+
+const StartSchema = z.object({
+  conversation_id: z.string().max(120).optional(),
+  to_persona: z.enum(['devon', 'sage', 'atlas', 'mira']),
+  detected_intent: z.string().max(500).optional(),
+  matched_keyword: z.string().max(200).optional(),
+  confidence: z.number().min(0).max(1).optional(),
+  initial_user_text: z.string().min(1).max(10_000),
+  screen_path: z.string().max(500).optional(),
+  app_version: z.string().max(64).optional(),
+  device_meta: z.record(z.unknown()).optional(),
+});
+
+router.post('/start', async (req: Request, res: Response) => {
+  const token = getBearerToken(req);
+  if (!token) return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+  const userId = decodeJwtSub(token);
+  if (!userId) return res.status(401).json({ ok: false, error: 'INVALID_TOKEN' });
+
+  const v = StartSchema.safeParse(req.body);
+  if (!v.success) {
+    return res.status(400).json({ ok: false, error: 'VALIDATION_FAILED',
+      details: v.error.errors.map(e => `${e.path.join('.')}: ${e.message}`).join(', ') });
+  }
+  const body = v.data;
+  const vitanaId = await resolveVitanaId(userId);
+  const supabase = createUserSupabaseClient(token);
+
+  const initialMessages = [
+    { agent: 'vitana', role: 'user' as const, content: body.initial_user_text, ts: new Date().toISOString() },
+  ];
+
+  // Create ticket in 'interviewing' state
+  const { data: ticket, error: insErr } = await supabase
+    .from('feedback_tickets')
+    .insert({
+      user_id: userId,
+      vitana_id: vitanaId,
+      kind: KIND_BY_AGENT[body.to_persona] ?? 'feedback',
+      status: 'interviewing',
+      raw_transcript: body.initial_user_text,
+      intake_messages: initialMessages,
+      structured_fields: {},
+      screen_path: body.screen_path ?? null,
+      app_version: body.app_version ?? null,
+      device_meta: body.device_meta ?? null,
+    })
+    .select('id, ticket_number, kind, status')
+    .single();
+
+  if (insErr) {
+    console.error(`[${VTID}] ticket insert failed:`, insErr.message);
+    return res.status(502).json({ ok: false, error: 'INSERT_FAILED', details: insErr.message });
+  }
+
+  // Log handoff event (service role via REST; user RLS only allows SELECT)
+  await fetch(`${process.env.SUPABASE_URL}/rest/v1/feedback_handoff_events`, {
+    method: 'POST',
+    headers: {
+      'Content-Type': 'application/json',
+      apikey: process.env.SUPABASE_SERVICE_ROLE!,
+      Authorization: `Bearer ${process.env.SUPABASE_SERVICE_ROLE!}`,
+    },
+    body: JSON.stringify({
+      conversation_id: body.conversation_id ?? null,
+      ticket_id: ticket.id,
+      user_id: userId,
+      vitana_id: vitanaId,
+      from_agent: 'vitana',
+      to_agent: body.to_persona,
+      reason: 'off_domain_intent',
+      detected_intent: body.detected_intent ?? null,
+      matched_keyword: body.matched_keyword ?? null,
+      confidence: body.confidence ?? null,
+    }),
+  }).catch(err => console.warn(`[${VTID}] handoff event write failed:`, err?.message));
+
+  // Fetch the persona for the frontend
+  const { data: persona } = await supabase
+    .from('agent_personas')
+    .select('key, display_name, role, voice_id, system_prompt, intake_schema_ref, max_questions, max_duration_seconds')
+    .eq('key', body.to_persona)
+    .maybeSingle();
+
+  emitOasisEvent({
+    vtid: VTID,
+    type: 'feedback.handoff.started' as any,
+    source: 'feedback-intake-gateway',
+    status: 'info',
+    message: `Vitana handed off to ${body.to_persona} for ticket ${ticket.ticket_number}`,
+    payload: {
+      ticket_id: ticket.id,
+      ticket_number: ticket.ticket_number,
+      to_persona: body.to_persona,
+      kind: ticket.kind,
+      matched_keyword: body.matched_keyword ?? null,
+      confidence: body.confidence ?? null,
+    },
+    actor_id: userId,
+    actor_role: 'user',
+    surface: 'orb',
+    vitana_id: vitanaId ?? undefined,
+  }).catch(err => console.warn(`[${VTID}] OASIS emit failed:`, err?.message));
+
+  return res.status(201).json({
+    ok: true,
+    ticket_id: ticket.id,
+    ticket_number: ticket.ticket_number,
+    persona,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// POST /turn
+// ---------------------------------------------------------------------------
+
+const TurnSchema = z.object({
+  ticket_id: z.string().uuid(),
+  agent: z.string().max(32),
+  role: z.enum(['user', 'assistant']),
+  content: z.string().min(1).max(10_000),
+});
+
+router.post('/turn', async (req: Request, res: Response) => {
+  const token = getBearerToken(req);
+  if (!token) return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+
+  const v = TurnSchema.safeParse(req.body);
+  if (!v.success) return res.status(400).json({ ok: false, error: 'VALIDATION_FAILED' });
+  const body = v.data;
+  const supabase = createUserSupabaseClient(token);
+
+  // Read current intake_messages (RLS = own ticket only)
+  const { data: existing, error: readErr } = await supabase
+    .from('feedback_tickets')
+    .select('id, intake_messages, status')
+    .eq('id', body.ticket_id)
+    .maybeSingle();
+
+  if (readErr || !existing) {
+    return res.status(404).json({ ok: false, error: 'TICKET_NOT_FOUND' });
+  }
+  if (!['interviewing', 'needs_more_info'].includes(existing.status)) {
+    return res.status(409).json({ ok: false, error: 'TICKET_NOT_INTERVIEWING', status: existing.status });
+  }
+
+  const messages = Array.isArray(existing.intake_messages) ? existing.intake_messages : [];
+  messages.push({ ...body, ts: new Date().toISOString() });
+
+  const { error: upErr } = await supabase
+    .from('feedback_tickets')
+    .update({ intake_messages: messages })
+    .eq('id', body.ticket_id);
+
+  if (upErr) {
+    return res.status(502).json({ ok: false, error: 'UPDATE_FAILED', details: upErr.message });
+  }
+  return res.json({ ok: true, turn_count: messages.length });
+});
+
+// ---------------------------------------------------------------------------
+// POST /complete
+// ---------------------------------------------------------------------------
+
+const CompleteSchema = z.object({
+  ticket_id: z.string().uuid(),
+  structured_fields: z.record(z.unknown()),
+  raw_transcript: z.string().max(20_000).optional(),
+  conversation_id: z.string().max(120).optional(),
+  resolver_persona: z.enum(['devon', 'sage', 'atlas', 'mira']).optional(),
+});
+
+router.post('/complete', async (req: Request, res: Response) => {
+  const token = getBearerToken(req);
+  if (!token) return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+  const userId = decodeJwtSub(token);
+  if (!userId) return res.status(401).json({ ok: false, error: 'INVALID_TOKEN' });
+
+  const v = CompleteSchema.safeParse(req.body);
+  if (!v.success) return res.status(400).json({ ok: false, error: 'VALIDATION_FAILED' });
+  const body = v.data;
+  const supabase = createUserSupabaseClient(token);
+
+  const { data: updated, error: upErr } = await supabase
+    .from('feedback_tickets')
+    .update({
+      status: 'triaged',
+      structured_fields: body.structured_fields,
+      raw_transcript: body.raw_transcript ?? undefined,
+      interviewed_at: new Date().toISOString(),
+      triaged_at: new Date().toISOString(),
+      resolver_agent: body.resolver_persona ?? null,
+    })
+    .eq('id', body.ticket_id)
+    .select('id, ticket_number, status, kind, vitana_id')
+    .single();
+
+  if (upErr || !updated) {
+    return res.status(502).json({ ok: false, error: 'UPDATE_FAILED', details: upErr?.message });
+  }
+
+  // Wrap-back handoff event: specialist → vitana
+  if (body.resolver_persona) {
+    await fetch(`${process.env.SUPABASE_URL}/rest/v1/feedback_handoff_events`, {
+      method: 'POST',
+      headers: {
+        'Content-Type': 'application/json',
+        apikey: process.env.SUPABASE_SERVICE_ROLE!,
+        Authorization: `Bearer ${process.env.SUPABASE_SERVICE_ROLE!}`,
+      },
+      body: JSON.stringify({
+        conversation_id: body.conversation_id ?? null,
+        ticket_id: updated.id,
+        user_id: userId,
+        vitana_id: updated.vitana_id,
+        from_agent: body.resolver_persona,
+        to_agent: 'vitana',
+        reason: 'wrap_back',
+      }),
+    }).catch(err => console.warn(`[${VTID}] wrap-back handoff write failed:`, err?.message));
+  }
+
+  emitOasisEvent({
+    vtid: VTID,
+    type: 'feedback.handoff.completed' as any,
+    source: 'feedback-intake-gateway',
+    status: 'info',
+    message: `Intake completed for ticket ${updated.ticket_number}`,
+    payload: {
+      ticket_id: updated.id,
+      ticket_number: updated.ticket_number,
+      kind: updated.kind,
+      resolver_persona: body.resolver_persona ?? null,
+      structured_fields_keys: Object.keys(body.structured_fields),
+    },
+    actor_id: userId,
+    actor_role: 'user',
+    surface: 'orb',
+    vitana_id: updated.vitana_id ?? undefined,
+  }).catch(err => console.warn(`[${VTID}] OASIS emit failed:`, err?.message));
+
+  return res.json({
+    ok: true,
+    ticket_id: updated.id,
+    ticket_number: updated.ticket_number,
+    status: updated.status,
+  });
+});
+
+export default router;

--- a/supabase/migrations/20260429100000_vtid_02603_feedback_handoff.sql
+++ b/supabase/migrations/20260429100000_vtid_02603_feedback_handoff.sql
@@ -1,0 +1,170 @@
+-- VTID-02603: Unified Feedback Pipeline — handoff events + persona prompts
+-- Parent plan PR 3-5 bundle: persona prompts + handoff bridge + specialists live.
+--
+-- Adds:
+--   1. feedback_handoff_events — every Vitana → specialist channel swap
+--   2. Concrete v1 system prompts for the 5 personas
+--   3. agent_personas.status flips to 'active' for all specialists
+--   4. handoff_keywords expanded with per-language patterns
+--   5. New RPC `pick_specialist_for_text(text)` returns the best persona
+--      key by keyword match, used by /feedback/intake/handoff-detect.
+
+-- ===========================================================================
+-- 1. feedback_handoff_events
+-- ===========================================================================
+-- One row per channel swap. Powers Live Handoffs Monitor (Phase 5 PR 20)
+-- AND post-hoc training data for routing accuracy. Conversation_id is the
+-- ORB session id; ticket_id links to the feedback_tickets row that captures
+-- the user's claim.
+
+CREATE TABLE IF NOT EXISTS public.feedback_handoff_events (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  conversation_id TEXT,
+  ticket_id UUID REFERENCES public.feedback_tickets(id) ON DELETE SET NULL,
+  user_id UUID,
+  vitana_id TEXT,
+  from_agent TEXT NOT NULL,                  -- persona key
+  to_agent TEXT NOT NULL,                    -- persona key
+  reason TEXT NOT NULL                       -- 'off_domain_intent' | 'cross_specialist'
+                                             -- | 'wrap_back' | 'manual_override'
+    CHECK (reason IN ('off_domain_intent','cross_specialist','wrap_back','manual_override','escalation')),
+  detected_intent TEXT,
+  matched_keyword TEXT,
+  confidence REAL,
+  ts TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS idx_handoff_events_ticket ON public.feedback_handoff_events (ticket_id);
+CREATE INDEX IF NOT EXISTS idx_handoff_events_conv ON public.feedback_handoff_events (conversation_id, ts);
+CREATE INDEX IF NOT EXISTS idx_handoff_events_recent ON public.feedback_handoff_events (ts DESC);
+
+ALTER TABLE public.feedback_handoff_events ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS handoff_events_select_own ON public.feedback_handoff_events;
+CREATE POLICY handoff_events_select_own ON public.feedback_handoff_events
+  FOR SELECT TO authenticated USING (user_id = auth.uid());
+DROP POLICY IF EXISTS handoff_events_service ON public.feedback_handoff_events;
+CREATE POLICY handoff_events_service ON public.feedback_handoff_events
+  FOR ALL TO service_role USING (TRUE) WITH CHECK (TRUE);
+GRANT SELECT ON public.feedback_handoff_events TO authenticated;
+
+-- ===========================================================================
+-- 2. v1 system prompts + activate specialists
+-- ===========================================================================
+-- Short, role-only prompts (per locked decision: role + voice, no backstory).
+-- Each specialist's prompt drives its intake schema interview style.
+
+UPDATE public.agent_personas SET system_prompt = $$
+You are Vitana — longevity coach, matchmaker, community brain. You are warm,
+curious, encouraging. When a user mentions a problem outside your domain
+(bugs, support questions, refunds, account issues, marketplace claims), you
+say a short bridge sentence and the channel swaps to the right colleague:
+- Devon for bugs / UX issues
+- Sage for support questions / how-to
+- Atlas for refunds / payments / marketplace claims
+- Mira for login / account / profile / data issues
+Bridge sentence template: "Let me bring in {name}, who handles the {domain}
+side. One moment." Stay in your domain — never debug code, never process
+refunds, never reset passwords. After the colleague finishes, welcome the
+user back to the longevity conversation.
+$$, status = 'active', version = version + 1, updated_at = NOW()
+WHERE key = 'vitana';
+
+UPDATE public.agent_personas SET system_prompt = $$
+You are Devon — Vitana's tech support colleague. You handle bug reports and
+UX issues. You are calm, technical, focused. Greet the user with: "Hi, Devon
+here — Vitana said you ran into an issue. Walk me through what happened."
+Ask up to 6 questions to fill: what_happened, expected, actual,
+repro_steps[], when_first_seen, frequency, screen, last_action_before. Stop
+when you have enough. Confirm a written summary back to the user. Tell them:
+"I've logged this. The team will follow up via this channel when it's
+fixed." Never promise a fix timeline. Never debug code in front of the user.
+$$, status = 'active', version = version + 1, updated_at = NOW()
+WHERE key = 'devon';
+
+UPDATE public.agent_personas SET system_prompt = $$
+You are Sage — Vitana's customer support colleague. You handle how-to
+questions, navigation help, and knowledge lookups. You are patient,
+supportive, and prefer to answer in-call rather than file tickets. Greet
+with: "Hi, Sage here. What can I help you find?" If you can answer from the
+knowledge base, do — keep it conversational. Only file a ticket if you
+genuinely can't resolve live. Cite which doc you used. Confirm understanding
+before ending the call. Hand back to Vitana when done.
+$$, status = 'active', version = version + 1, updated_at = NOW()
+WHERE key = 'sage';
+
+UPDATE public.agent_personas SET system_prompt = $$
+You are Atlas — Vitana's finance colleague. You handle refunds, payments,
+and marketplace claims. You are professional, precise, neutral. Greet with:
+"Hi, Atlas here. Let's sort this out. What's the issue with your order or
+payment?" Ask up to 6 questions to fill: order_id, counterparty_vitana_id,
+claim_type, evidence_urls, desired_outcome (refund/replace/mediate),
+amount_involved. Confirm the resolution that will be drafted. Never approve
+refunds or release funds yourself — a human reviews every action. Tell the
+user: "Resolution drafted, a human will action it in the next business day.
+You'll hear back from me here."
+$$, status = 'active', version = version + 1, updated_at = NOW()
+WHERE key = 'atlas';
+
+UPDATE public.agent_personas SET system_prompt = $$
+You are Mira — Vitana's account support colleague. You handle login, role,
+profile, data, and registration issues. You are calm and authoritative.
+Greet with: "Hi, Mira here. Let's get your account sorted. What's not
+working?" Ask up to 6 questions to fill: category (login/role/data/payment),
+account_email, what_is_wrong, desired_outcome. Never reset a password or
+change a role yourself — a human runbook approves every operation. Tell the
+user: "Logged. A human will action this and you'll hear back via this
+channel."
+$$, status = 'active', version = version + 1, updated_at = NOW()
+WHERE key = 'mira';
+
+-- ===========================================================================
+-- 3. pick_specialist_for_text RPC — keyword-based intent router
+-- ===========================================================================
+-- Lightweight v1 router. Scores each non-Vitana persona by counting how many
+-- of its handoff_keywords appear in the input text. Returns the best match
+-- (highest score) plus the specific keyword that matched, so the caller can
+-- log it for routing accuracy review. Confidence = matches / total_keywords.
+-- Returns NULL when nothing scores above zero — caller falls back to Vitana.
+
+CREATE OR REPLACE FUNCTION public.pick_specialist_for_text(p_text TEXT)
+RETURNS TABLE (persona_key TEXT, matched_keyword TEXT, score INT, confidence REAL)
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_lower TEXT := lower(coalesce(p_text, ''));
+BEGIN
+  RETURN QUERY
+  WITH per_keyword AS (
+    SELECT
+      ap.key AS persona_key,
+      kw AS matched_keyword,
+      array_length(ap.handoff_keywords, 1) AS total_keywords
+    FROM public.agent_personas ap
+    CROSS JOIN LATERAL unnest(ap.handoff_keywords) AS kw
+    WHERE ap.key <> 'vitana'
+      AND ap.status = 'active'
+      AND v_lower LIKE '%' || lower(kw) || '%'
+  ),
+  scored AS (
+    SELECT
+      persona_key,
+      count(*)::INT AS score,
+      max(total_keywords) AS total_keywords,
+      (array_agg(matched_keyword ORDER BY length(matched_keyword) DESC))[1] AS matched_keyword
+    FROM per_keyword
+    GROUP BY persona_key
+  )
+  SELECT
+    s.persona_key,
+    s.matched_keyword,
+    s.score,
+    (s.score::REAL / GREATEST(s.total_keywords, 1)::REAL) AS confidence
+  FROM scored s
+  ORDER BY s.score DESC, length(s.matched_keyword) DESC
+  LIMIT 1;
+END;
+$$;
+
+GRANT EXECUTE ON FUNCTION public.pick_specialist_for_text(TEXT) TO authenticated, service_role;


### PR DESCRIPTION
## Summary

Parent plan PRs 3-5 bundled. Data plane for the Vitana → specialist handoff that the frontend will trigger when a user mentions an off-domain topic.

- Migration: `feedback_handoff_events` + concrete v1 system prompts for all 5 personas + activate Devon/Sage/Atlas/Mira (currently `draft`)
- New RPC: `pick_specialist_for_text(text)` — keyword-based intent router. Scores each non-Vitana persona by `handoff_keywords` matches, returns top match + matched_keyword + confidence
- New routes at `/api/v1/feedback/intake/*`:
  - `POST /handoff-detect` — opener → which specialist?
  - `POST /start` — create ticket in `interviewing`, log handoff event, return persona for the frontend voice swap
  - `POST /turn` — append intake turn
  - `POST /complete` — flip to `triaged` + log wrap-back

## What's deferred

- Frontend orb voice channel swap (separate PR, vitana-v1)
- LLM-based intent classification (keyword router is the v1 baseline)

## Test plan

- [ ] Migration applies clean
- [ ] `select status from agent_personas` shows all 5 active with non-null `system_prompt`
- [ ] `select pick_specialist_for_text('the diary screen crashed')` returns devon
- [ ] `select pick_specialist_for_text('how do I find my profile')` returns sage
- [ ] `select pick_specialist_for_text('refund my order')` returns atlas
- [ ] `select pick_specialist_for_text('I love the new design')` returns nothing (stay with Vitana)
- [ ] curl POST /handoff-detect with bug text → handoff=true persona_key=devon
- [ ] curl POST /start → ticket row in `interviewing` status + handoff event row

🤖 Generated with [Claude Code](https://claude.com/claude-code)