### PR TITLE
fix(deploy): DEV_AUTOPILOT_USE_WORKER=false on gateway — Vertex direct (VTID-02500b)

### DIFF
--- a/.github/workflows/EXEC-DEPLOY.yml
+++ b/.github/workflows/EXEC-DEPLOY.yml
@@ -315,8 +315,19 @@ jobs:
             # instead of the direct Messages API, so they draw on the Claude
             # Pro/Max subscription via the worker's `claude -p` subprocess
             # rather than on the pay-per-token API credit balance.
-            # Flip to false (or delete this line) to fall back to direct API calls.
-            EXTRA_ENV_ARGS+=(--update-env-vars=DEV_AUTOPILOT_USE_WORKER=true)
+            # 2026-04-29 (VTID-02500b): flipped to false. The active LLM
+            # routing policy v7 routes the `worker` stage to Vertex AI /
+            # gemini-3-pro-preview, so the local worker is no longer the
+            # cheaper path — and the worker queue's max_concurrent=1 was
+            # the bottleneck (every batch of N tasks queued for ~12 min
+            # apiece, hitting the 720s gateway timeout). Plus the worker
+            # process running on the developer's machine doesn't have
+            # GITHUB_SAFE_MERGE_TOKEN, so PR-publish failed there. With
+            # this flag off, the gateway's runExecutionSession runs in-
+            # process: LLM via Vertex direct, PR via the gateway's own
+            # GITHUB_SAFE_MERGE_TOKEN secret, concurrency limited only by
+            # dev_autopilot_config.concurrency_cap.
+            EXTRA_ENV_ARGS+=(--update-env-vars=DEV_AUTOPILOT_USE_WORKER=false)
             # Worker-owned PR creation: after the worker validates Claude's
             # output it ALSO creates the branch + writes files + opens the
             # PR itself, then writes pr_url back to the queue. This avoids


### PR DESCRIPTION
## Summary

Follow-up to #1069. The active LLM routing policy v7 routes the worker stage to Vertex AI / gemini-3-pro-preview, but the deployed gateway was still routing through the worker queue (env var set in #818). With the queue in path:

1. The local autopilot-worker (max_concurrent=1) became a bottleneck for every batch — 9 tasks queued for ~12 min apiece, hitting the gateway 720s per-task timeout.
2. The worker process running on the developer machine was missing GITHUB_SAFE_MERGE_TOKEN, so even when the LLM call succeeded (~3 min via Vertex through worker), PR-publish failed with: `create branch: base branch lookup: GITHUB_SAFE_MERGE_TOKEN not set on worker`.

Flipping to false runs everything in the gateway in-process: LLM via Vertex direct (GCP IAM, no API key), PR via gateway's own GITHUB_SAFE_MERGE_TOKEN secret, concurrency limited only by `dev_autopilot_config.concurrency_cap` (currently 4).

## Loop fix from #1069 already verified

While this issue was happening I watched the live execution stream. Of 9 enqueued executions earlier today:
- Some failed at the worker-token step, classified as `environmental_blocker`, marked `failed_escalated`. **Zero SELF-HEAL retry VTIDs spawned.**
- The bridge short-circuit + reconciler companion check from #1069 caught every env-blocker correctly.

This PR removes the failure source itself.

VTID: VTID-02500b

## Test plan

- [ ] Merge → EXEC-DEPLOY redeploys gateway with `DEV_AUTOPILOT_USE_WORKER=false`
- [ ] /alive returns 200
- [ ] Re-enqueue dev_autopilot executions → executor calls Vertex direct, gateway opens PR
- [ ] First PR appears in the repo within ~3-5 min of executor pickup
- [ ] No SELF-HEAL retry VTIDs in vtid_ledger

🤖 Generated with [Claude Code](https://claude.com/claude-code)