### PR TITLE
Refactor: Use middleware for auth in admin-notification-categories

### DIFF
--- a/services/gateway/src/routes/admin-notification-categories.ts
+++ b/services/gateway/src/routes/admin-notification-categories.ts
@@ -11,10 +11,10 @@
  * - POST   /:id/test      — Send test notification to admin
  *
  * Security:
- * - All endpoints require Bearer token + exafy_admin
+ * - All endpoints are protected by the `requireExafyAdmin` middleware.
  */
 
-import { Router, Request, Response } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { createClient } from '@supabase/supabase-js';
 import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, NotificationPayload } from '../services/notification-service';
@@ -33,7 +33,7 @@ function getSupabase() {
   );
 }
 
-// ── Auth Helper ─────────────────────────────────────────────
+// ── Auth Helper/Middleware ──────────────────────────────────
 
 function getBearerToken(req: Request): string | null {
   const authHeader = req.headers.authorization;
@@ -41,28 +41,36 @@ function getBearerToken(req: Request): string | null {
   return authHeader.slice(7);
 }
 
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
+async function requireExafyAdmin(req: Request, res: Response, next: NextFunction) {
   const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
+  if (!token) return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
 
   try {
     const userClient = createUserSupabaseClient(token);
     const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
+    if (authError || !authData?.user) {
+      return res.status(401).json({ ok: false, error: 'INVALID_TOKEN' });
+    }
 
     const appMetadata = authData.user.app_metadata || {};
     if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
+      return res.status(403).json({ ok: false, error: 'FORBIDDEN' });
     }
 
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
+    // Attach user info to request for downstream handlers
+    (req as any).authUser = {
+      user_id: authData.user.id,
+      email: authData.user.email || 'unknown',
+    };
+    next();
   } catch (err: any) {
     console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
+    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
   }
 }
+
+// Apply auth middleware to all routes in this file
+router.use(requireExafyAdmin);
 
 // ── Slug helper ─────────────────────────────────────────────
 
@@ -76,9 +84,6 @@ function toSlug(name: string): string {
 // ── GET / — List all categories ─────────────────────────────
 
 router.get('/', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   const { type, tenant_id, include_inactive } = req.query;
 
@@ -120,9 +125,6 @@ router.get('/', async (req: Request, res: Response) => {
 // ── GET /:id — Get single category ─────────────────────────
 
 router.get('/:id', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   const { data, error } = await supabase
     .from('notification_categories')
@@ -140,9 +142,7 @@ router.get('/:id', async (req: Request, res: Response) => {
 // ── POST / — Create category ───────────────────────────────
 
 router.post('/', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
+  const { authUser } = req as any;
   const supabase = getSupabase();
   const {
     type,
@@ -181,7 +181,7 @@ router.post('/', async (req: Request, res: Response) => {
     default_enabled: default_enabled ?? true,
     mapped_types: mapped_types || [],
     tenant_id: tenant_id || null,
-    created_by: authResult.user_id,
+    created_by: authUser.user_id,
   };
 
   const { data, error } = await supabase
@@ -198,16 +198,14 @@ router.post('/', async (req: Request, res: Response) => {
     return res.status(500).json({ ok: false, error: error.message });
   }
 
-  console.log(`[${VTID}] Created category "${slug}" (${type}) by ${authResult.email}`);
+  console.log(`[${VTID}] Created category "${slug}" (${type}) by ${authUser.email}`);
   return res.status(201).json({ ok: true, data });
 });
 
 // ── PATCH /:id — Update category ────────────────────────────
 
 router.patch('/:id', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
+  const { authUser } = req as any;
   const supabase = getSupabase();
   const allowedFields = ['display_name', 'description', 'icon', 'sort_order', 'is_active', 'default_enabled', 'mapped_types'];
   const updateData: Record<string, any> = { updated_at: new Date().toISOString() };
@@ -238,16 +236,14 @@ router.patch('/:id', async (req: Request, res: Response) => {
     return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
   }
 
-  console.log(`[${VTID}] Updated category "${data.slug}" by ${authResult.email}`);
+  console.log(`[${VTID}] Updated category "${data.slug}" by ${authUser.email}`);
   return res.json({ ok: true, data });
 });
 
 // ── DELETE /:id — Soft-delete (set is_active=false) ─────────
 
 router.delete('/:id', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
+  const { authUser } = req as any;
   const supabase = getSupabase();
   const { data, error } = await supabase
     .from('notification_categories')
@@ -264,16 +260,14 @@ router.delete('/:id', async (req: Request, res: Response) => {
     return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
   }
 
-  console.log(`[${VTID}] Soft-deleted category "${data.slug}" by ${authResult.email}`);
+  console.log(`[${VTID}] Soft-deleted category "${data.slug}" by ${authUser.email}`);
   return res.json({ ok: true, data });
 });
 
 // ── POST /:id/test — Send test notification to admin ────────
 
 router.post('/:id/test', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
+  const { authUser } = req as any;
   const supabase = getSupabase();
 
   // Get the category
@@ -300,15 +294,15 @@ router.post('/:id/test', async (req: Request, res: Response) => {
   const { data: tenantRow } = await supabase
     .from('user_tenants')
     .select('tenant_id')
-    .eq('user_id', authResult.user_id)
+    .eq('user_id', authUser.user_id)
     .limit(1)
     .single();
 
   const tenantId = tenantRow?.tenant_id || '00000000-0000-0000-0000-000000000000';
 
   try {
-    const result = await notifyUser(authResult.user_id, tenantId, testType, payload, supabase);
-    console.log(`[${VTID}] Test notification sent for category "${category.slug}" by ${authResult.email}`);
+    const result = await notifyUser(authUser.user_id, tenantId, testType, payload, supabase);
+    console.log(`[${VTID}] Test notification sent for category "${category.slug}" by ${authUser.email}`);
     return res.json({ ok: true, result });
   } catch (err: any) {
     console.error(`[${VTID}] POST /:id/test error:`, err.message);

--- a/services/gateway/test/routes/admin-notification-categories.test.ts
+++ b/services/gateway/test/routes/admin-notification-categories.test.ts
@@ -1,0 +1,161 @@
+import express from 'express';
+import request from 'supertest';
+import { createClient } from '@supabase/supabase-js';
+import { createUserSupabaseClient } from '../../src/lib/supabase-user';
+import adminNotificationCategoriesRouter from '../../src/routes/admin-notification-categories';
+import { notifyUser } from '../../src/services/notification-service';
+
+// Mock dependencies
+jest.mock('@supabase/supabase-js');
+jest.mock('../../src/lib/supabase-user');
+jest.mock('../../src/services/notification-service');
+
+const mockedCreateUserSupabaseClient = createUserSupabaseClient as jest.Mock;
+const mockedCreateSupabaseClient = createClient as jest.Mock;
+const mockedNotifyUser = notifyUser as jest.Mock;
+
+const app = express();
+app.use(express.json());
+// Mount the router at a specific path for testing
+app.use('/', adminNotificationCategoriesRouter);
+
+describe('Admin Notification Categories Routes', () => {
+  let mockDbClient: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Default mock for the service role Supabase client
+    mockDbClient = {
+      from: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      insert: jest.fn().mockReturnThis(),
+      update: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      or: jest.fn().mockReturnThis(),
+      is: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({ data: {}, error: null }),
+    };
+    mockedCreateSupabaseClient.mockReturnValue(mockDbClient);
+  });
+
+  describe('Auth Middleware', () => {
+    it('should return 401 Unauthorized if no token is provided', async () => {
+      const response = await request(app).get('/');
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({ ok: false, error: 'UNAUTHENTICATED' });
+    });
+
+    it('should return 401 Unauthorized for an invalid token', async () => {
+      mockedCreateUserSupabaseClient.mockReturnValue({
+        auth: {
+          getUser: jest.fn().mockResolvedValue({ data: { user: null }, error: { message: 'invalid token' } }),
+        },
+      });
+
+      const response = await request(app).get('/').set('Authorization', 'Bearer invalid-token');
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({ ok: false, error: 'INVALID_TOKEN' });
+    });
+
+    it('should return 403 Forbidden for a non-admin user', async () => {
+      mockedCreateUserSupabaseClient.mockReturnValue({
+        auth: {
+          getUser: jest.fn().mockResolvedValue({
+            data: {
+              user: {
+                id: 'user-123',
+                email: 'user@test.com',
+                app_metadata: { exafy_admin: false },
+              },
+            },
+            error: null,
+          }),
+        },
+      });
+
+      const response = await request(app).get('/').set('Authorization', 'Bearer non-admin-token');
+      expect(response.status).toBe(403);
+      expect(response.body).toEqual({ ok: false, error: 'FORBIDDEN' });
+    });
+
+    it('should pass through to the handler for an admin user', async () => {
+      // Mock auth for an admin user
+      mockedCreateUserSupabaseClient.mockReturnValue({
+        auth: {
+          getUser: jest.fn().mockResolvedValue({
+            data: {
+              user: {
+                id: 'admin-456',
+                email: 'admin@test.com',
+                app_metadata: { exafy_admin: true },
+              },
+            },
+            error: null,
+          }),
+        },
+      });
+
+      // Mock the database response for the GET / handler
+      const mockCategories = [{ id: 'cat-1', type: 'chat', display_name: 'Chat Notifications' }];
+      (mockDbClient.select as jest.Mock).mockResolvedValue({ data: mockCategories, error: null });
+
+      const response = await request(app).get('/').set('Authorization', 'Bearer admin-token');
+      expect(response.status).toBe(200);
+      expect(response.body.ok).toBe(true);
+      expect(response.body.data.chat).toEqual(mockCategories);
+      expect(mockedCreateUserSupabaseClient).toHaveBeenCalledWith('admin-token');
+    });
+  });
+
+  describe('CRUD operations (with admin auth)', () => {
+    beforeEach(() => {
+      // Set up admin auth for all tests in this block
+      mockedCreateUserSupabaseClient.mockReturnValue({
+        auth: {
+          getUser: jest.fn().mockResolvedValue({
+            data: {
+              user: {
+                id: 'admin-456',
+                email: 'admin@test.com',
+                app_metadata: { exafy_admin: true },
+              },
+            },
+            error: null,
+          }),
+        },
+      });
+    });
+
+    it('POST /:id/test should send a notification and use authUser', async () => {
+      const mockCategory = {
+        id: 'cat-test-1',
+        slug: 'test-category',
+        display_name: 'Test Category',
+        mapped_types: ['test_event'],
+      };
+      // Mock DB calls in order: 1. get category, 2. get tenant
+      (mockDbClient.single as jest.Mock)
+        .mockResolvedValueOnce({ data: mockCategory, error: null })
+        .mockResolvedValueOnce({ data: { tenant_id: 'tenant-123' }, error: null });
+
+      mockedNotifyUser.mockResolvedValue({ success: true, message: 'sent' });
+
+      const response = await request(app)
+        .post('/cat-test-1/test')
+        .set('Authorization', 'Bearer admin-token');
+
+      expect(response.status).toBe(200);
+      expect(response.body).toEqual({ ok: true, result: { success: true, message: 'sent' } });
+      expect(mockedNotifyUser).toHaveBeenCalledWith(
+        'admin-456', // user_id from authUser
+        'tenant-123', // tenant_id from lookup
+        'test_event', // type from category
+        expect.any(Object), // payload
+        expect.any(Object)  // supabase client
+      );
+    });
+  });
+});


### PR DESCRIPTION
This PR refactors the `admin-notification-categories` API to use a standard Express middleware pattern for authentication, addressing a `missing_auth` scanner finding.

### Problem
Previously, authentication and authorization (`verifyExafyAdmin`) were checked inline within each route handler. This approach led to code duplication and was brittle, as new endpoints could easily forget to include the check.

### Solution
1.  **Created `requireExafyAdmin` Middleware**: The logic from `verifyExafyAdmin` was extracted into a proper Express middleware function.
    - On auth failure, it sends a `401`/`403` response and terminates the request.
    - On success, it attaches user information to the request object (`req.authUser`) and calls `next()`.
2.  **Applied Middleware**: The new middleware is applied to all routes in the file using `router.use(requireExafyAdmin)`.
3.  **Simplified Handlers**: All individual calls to `verifyExafyAdmin` were removed from the route handlers, making them cleaner and more focused on their business logic.
4.  **Added Tests**: A new test file (`admin-notification-categories.test.ts`) has been created to verify the middleware's behavior. It includes tests for:
    - Unauthorized requests (no token).
    - Forbidden requests (valid token, but not an admin).
    - Successful requests (valid admin token).

This change improves code maintainability and aligns the route with repository best practices for authentication.

### Files Modified
- `services/gateway/src/routes/admin-notification-categories.ts`
- `services/gateway/test/routes/admin-notification-categories.test.ts` (new)