### PR TITLE
fix(rls): Enable RLS on oasis_events to deny anonymous access

### DIFF
--- a/services/gateway/test/integration/rls-oasis-events.test.ts
+++ b/services/gateway/test/integration/rls-oasis-events.test.ts
@@ -1,0 +1,140 @@
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { v4 as uuidv4 } from 'uuid';
+import 'dotenv/config';
+
+// Set a longer timeout for integration tests that hit an external service
+jest.setTimeout(30000);
+
+describe('Integration: RLS on oasis_events table', () => {
+  let anonClient: SupabaseClient;
+  let serviceClient: SupabaseClient;
+
+  const SUPABASE_URL = process.env.SUPABASE_URL;
+  const SUPABASE_ANON_KEY = process.env.SUPABASE_ANON_KEY;
+  const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE_KEY;
+
+  if (!SUPABASE_URL || !SUPABASE_ANON_KEY || !SUPABASE_SERVICE_ROLE_KEY) {
+    throw new Error(
+      'SUPABASE_URL, SUPABASE_ANON_KEY, and SUPABASE_SERVICE_ROLE_KEY must be set in the environment for integration tests.',
+    );
+  }
+
+  beforeAll(() => {
+    anonClient = createClient(SUPABASE_URL, SUPABASE_ANON_KEY);
+    serviceClient = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE_KEY);
+  });
+
+  const testEventPayload = {
+    vtid: `vtid-rls-test-${uuidv4()}`,
+    kind: 'test.event',
+    status: 'running',
+    title: 'RLS Policy Test Event',
+  };
+
+  describe('as anonymous user (anon role)', () => {
+    it('should be denied from inserting into oasis_events', async () => {
+      const { data, error } = await anonClient
+        .from('oasis_events')
+        .insert(testEventPayload);
+
+      expect(data).toBeNull();
+      expect(error).not.toBeNull();
+      // PostgREST error code for RLS violation on insert/update
+      expect(error?.code).toBe('42501');
+      expect(error?.message).toContain(
+        'new row violates row-level security policy for table "oasis_events"',
+      );
+    });
+
+    it('should be denied from reading from oasis_events', async () => {
+      // First, ensure a record exists using the service client
+      const { data: insertedData, error: insertError } = await serviceClient
+        .from('oasis_events')
+        .insert(testEventPayload)
+        .select()
+        .single();
+
+      expect(insertError).toBeNull();
+      expect(insertedData).not.toBeNull();
+
+      // Now, try to read it as the anonymous user
+      const { data: selectData, error: selectError } = await anonClient
+        .from('oasis_events')
+        .select('*')
+        .eq('id', insertedData.id);
+
+      // A select that finds no rows due to RLS is not an error. It returns an empty array.
+      expect(selectError).toBeNull();
+      expect(selectData).toEqual([]);
+
+      // Cleanup the record with the service client
+      const { error: deleteError } = await serviceClient
+        .from('oasis_events')
+        .delete()
+        .eq('id', insertedData.id);
+
+      expect(deleteError).toBeNull();
+    });
+  });
+
+  describe('as privileged user (service_role)', () => {
+    it('should be able to perform CRUD operations on oasis_events', async () => {
+      const testId = uuidv4();
+      const eventData = {
+        id: testId,
+        vtid: `vtid-crud-test-${uuidv4()}`,
+        kind: 'crud.test',
+        title: 'CRUD Test',
+      };
+
+      // 1. INSERT
+      const { error: insertError } = await serviceClient
+        .from('oasis_events')
+        .insert(eventData);
+      expect(insertError).toBeNull();
+
+      // 2. SELECT
+      const { data: selectData, error: selectError } = await serviceClient
+        .from('oasis_events')
+        .select('*')
+        .eq('id', testId)
+        .single();
+
+      expect(selectError).toBeNull();
+      expect(selectData).not.toBeNull();
+      expect(selectData?.title).toBe('CRUD Test');
+
+      // 3. UPDATE
+      const { data: updateData, error: updateError } = await serviceClient
+        .from('oasis_events')
+        .update({ title: 'CRUD Test Updated' })
+        .eq('id', testId)
+        .select()
+        .single();
+
+      expect(updateError).toBeNull();
+      expect(updateData).not.toBeNull();
+      expect(updateData?.title).toBe('CRUD Test Updated');
+
+      // 4. DELETE
+      const { error: deleteError } = await serviceClient
+        .from('oasis_events')
+        .delete()
+        .eq('id', testId);
+      expect(deleteError).toBeNull();
+
+      // 5. VERIFY DELETE
+      const { data: verifyData, error: verifyError } = await serviceClient
+        .from('oasis_events')
+        .select('*')
+        .eq('id', testId)
+        .single();
+
+      expect(verifyData).toBeNull();
+      expect(verifyError).not.toBeNull(); // .single() causes an error on 0 rows
+      expect(verifyError?.message).toContain(
+        'JSON object requested, multiple (or no) rows returned',
+      );
+    });
+  });
+});

--- a/supabase/migrations/20251209000000_add_task_stage.sql
+++ b/supabase/migrations/20251209000000_add_task_stage.sql
@@ -35,6 +35,11 @@ CREATE TABLE IF NOT EXISTS public.oasis_events (
   task_stage    text
 );
 
+-- RLS Policy: Deny unauthenticated access
+ALTER TABLE public.oasis_events ENABLE ROW LEVEL SECURITY;
+CREATE POLICY "deny_unauthenticated" ON public.oasis_events
+  FOR ALL TO anon USING (false) WITH CHECK (false);
+
 -- Step 2: Add task_stage column if table existed but column doesn't
 -- (for existing Supabase instances where table was created manually)
 DO $$


### PR DESCRIPTION
This pull request addresses a security finding (`rls_gap`) by enabling Row Level Security (RLS) on the `public.oasis_events` table.

The `oasis_events` table is used by telemetry endpoints and could previously be accessed by any authenticated user, including those with an `anon` role, which poses a security risk.

### Changes

1.  **`supabase/migrations/20251209000000_add_task_stage.sql`**:
    *   RLS is enabled on the `oasis_events` table.
    *   A new policy `deny_unauthenticated` is added to block all `SELECT`, `INSERT`, `UPDATE`, and `DELETE` operations for the `anon` role.

2.  **`services/gateway/test/integration/rls-oasis-events.test.ts`** (new file):
    *   An integration test is added to verify the RLS policy.
    *   It confirms that a client with the `anon` key cannot read from or write to the `oasis_events` table.
    *   It also confirms that a client with the `service_role` key (used by backend services) can still perform all CRUD operations, ensuring no regression in functionality for the telemetry endpoints.

This change hardens the database security by enforcing the principle of least privilege, ensuring that unauthenticated and unauthorized requests are blocked at the database layer.