### PR TITLE
feat(privacy+find-partner): E5 visibility scaffold + E6 surface params (VTID-02607)

### DIFF
--- a/services/gateway/src/lib/account-visibility.ts
+++ b/services/gateway/src/lib/account-visibility.ts
@@ -1,0 +1,201 @@
+/**
+ * E5 — server-side enforcement of profiles.account_visibility.
+ *
+ * The jsonb column was introduced in vitana-v1 migration
+ * 20260421000000_add_account_profile_fields.sql with a 3-tier model
+ * (private | connections | public) keyed by camelCase field names.
+ * Today the visibility filter runs only client-side; this module is the
+ * server-side mirror used by gateway routes that proxy profile data.
+ *
+ * Used together with the SQL helpers introduced in
+ * 20260507000100_account_visibility_helper_fns.sql:
+ *   - public.get_viewer_relationship(viewer, subject) → 'self' | 'connection' | 'stranger'
+ *   - public.can_read_profile_field(subject, viewer, field_key, default_tier) → bool
+ *
+ * The frontend mirror (DEFAULT_ACCOUNT_VISIBILITY in src/types/profile.ts)
+ * MUST stay in sync with FIELD_DEFAULTS below — this is the price of
+ * defense-in-depth (frontend filter for UX, server filter for safety).
+ */
+
+import { getSupabase } from './supabase';
+
+export type FieldVisibility = 'private' | 'connections' | 'public';
+export type ViewerRelationship = 'self' | 'connection' | 'stranger';
+
+/**
+ * Canonical defaults per visibility key. Mirrors the frontend
+ * DEFAULT_ACCOUNT_VISIBILITY map. Sub-fields use dot notation.
+ *
+ * Defaults err on the side of privacy for sensitive fields (age,
+ * gender, partner preferences, contact info). Public defaults are only
+ * applied to fields whose exposure is intrinsic to community discovery
+ * (display_name, avatar, member_since, etc.).
+ */
+export const FIELD_DEFAULTS: Record<string, FieldVisibility> = {
+  // ── Existing keys (from 20260421000000) ──
+  firstName: 'private',
+  lastName: 'private',
+  dateOfBirth: 'private',
+  gender: 'private',
+  maritalStatus: 'private',
+  email: 'private',
+  phone: 'private',
+  address: 'private',
+  country: 'connections',
+  city: 'connections',
+  memberSince: 'public',
+  accountType: 'public',
+  verificationStatus: 'public',
+  handle: 'public',
+  avatarUrl: 'public',
+  longevityArchetype: 'public',
+
+  // ── E5 additions for new profile sections ──
+  dancePreferences: 'public',
+  'dancePreferences.varieties': 'public',
+  'dancePreferences.level': 'public',
+  'dancePreferences.lookingFor': 'public',
+
+  // Partner-finding section is private by default. Sub-fields stay
+  // private even if the section flips to public — user must opt-in
+  // each sub-field individually for the highest-stakes data.
+  partnerPreferences: 'private',
+  'partnerPreferences.ageRange': 'private',
+  'partnerPreferences.gender': 'private',
+  'partnerPreferences.relationshipIntent': 'private',
+  'partnerPreferences.locationRadius': 'connections',
+
+  // Service offerings are public by default (hiding defeats the purpose).
+  serviceOfferings: 'public',
+  'serviceOfferings.priceRange': 'public',
+
+  // "My posts" section visibility on the public profile page. Each
+  // user_intents row already has its own per-row visibility column from
+  // P2-A; this controls whether the SECTION even renders to non-owners.
+  myPosts: 'public',
+  'myPosts.commercial': 'public',
+  // Hardcoded — partner_seek posts NEVER surface in the public My Posts
+  // list regardless of toggle. They follow the mutual-reveal protocol.
+  'myPosts.partnerSeek': 'private',
+
+  // Coarse age-band exposure (e.g. "30s") that lets a user be
+  // discoverable without exposing exact age. Three modes are encoded
+  // separately by the frontend: 'none' (don't show), 'band' (exposes
+  // band only — corresponds to derivedAgeBand=public), 'exact' (exposes
+  // band AND exact age — corresponds to dateOfBirth=public).
+  derivedAgeBand: 'connections',
+};
+
+/**
+ * Keys that are NEVER user-toggleable. Writes to these keys via the
+ * visibility PATCH endpoint must be rejected.
+ */
+export const HARDCODED_KEYS = new Set<string>(['myPosts.partnerSeek']);
+
+/**
+ * Resolve viewer-vs-subject relationship via the SQL helper.
+ * Returns 'stranger' on any DB error to fail closed.
+ */
+export async function getViewerRelationship(
+  viewerUserId: string | null,
+  subjectUserId: string,
+): Promise<ViewerRelationship> {
+  if (!viewerUserId) return 'stranger';
+  if (viewerUserId === subjectUserId) return 'self';
+
+  const supabase = getSupabase();
+  if (!supabase) return 'stranger';
+
+  const { data, error } = await supabase.rpc('get_viewer_relationship', {
+    p_viewer: viewerUserId,
+    p_subject: subjectUserId,
+  });
+
+  if (error) {
+    console.warn('[account-visibility] get_viewer_relationship failed', error);
+    return 'stranger';
+  }
+  return (data === 'self' || data === 'connection') ? data : 'stranger';
+}
+
+/**
+ * Resolve the effective tier for a field given a subject's
+ * account_visibility map (raw jsonb from profiles row).
+ */
+export function effectiveTier(
+  visibilityMap: Record<string, FieldVisibility> | null | undefined,
+  fieldKey: string,
+): FieldVisibility {
+  const explicit = visibilityMap?.[fieldKey];
+  if (explicit === 'private' || explicit === 'connections' || explicit === 'public') {
+    return explicit;
+  }
+  return FIELD_DEFAULTS[fieldKey] ?? 'private';
+}
+
+/**
+ * Returns true iff the viewer is allowed to see fieldKey on subject.
+ * Tier ladder: public > connections > private. Self always wins.
+ */
+export function canRead(
+  visibilityMap: Record<string, FieldVisibility> | null | undefined,
+  fieldKey: string,
+  relationship: ViewerRelationship,
+): boolean {
+  if (relationship === 'self') return true;
+  const tier = effectiveTier(visibilityMap, fieldKey);
+  if (tier === 'public') return true;
+  if (tier === 'connections' && relationship === 'connection') return true;
+  return false;
+}
+
+/**
+ * Strip fields the viewer cannot see. Object spread, never mutates input.
+ *
+ * The fieldMap argument maps response-shape keys → visibility keys.
+ * Example for a member-card row:
+ *   {
+ *     age:        'dateOfBirth',
+ *     ageBand:    'derivedAgeBand',
+ *     gender:     'gender',
+ *     city:       'city',
+ *   }
+ *
+ * Any fieldMap value that resolves to a hidden tier sets the
+ * corresponding shape key to null in the returned shallow copy.
+ */
+export function applyAccountVisibility<T extends Record<string, any>>(
+  payload: T,
+  visibilityMap: Record<string, FieldVisibility> | null | undefined,
+  relationship: ViewerRelationship,
+  fieldMap: Record<string, string>,
+): T {
+  if (relationship === 'self') return payload;
+  const out: Record<string, any> = { ...payload };
+  for (const [shapeKey, visibilityKey] of Object.entries(fieldMap)) {
+    if (!canRead(visibilityMap, visibilityKey, relationship)) {
+      out[shapeKey] = null;
+    }
+  }
+  return out as T;
+}
+
+/**
+ * Validate a (field_key, tier) pair for the PATCH endpoint.
+ * Rejects unknown keys (visibility-key squatting) and hardcoded keys.
+ */
+export function validateVisibilityPatch(
+  fieldKey: string,
+  tier: string,
+): { ok: true } | { ok: false; reason: string } {
+  if (HARDCODED_KEYS.has(fieldKey)) {
+    return { ok: false, reason: `field_${fieldKey}_is_hardcoded` };
+  }
+  if (!(fieldKey in FIELD_DEFAULTS)) {
+    return { ok: false, reason: `unknown_field_${fieldKey}` };
+  }
+  if (tier !== 'private' && tier !== 'connections' && tier !== 'public') {
+    return { ok: false, reason: `invalid_tier_${tier}` };
+  }
+  return { ok: true };
+}

--- a/services/gateway/src/routes/community-members.ts
+++ b/services/gateway/src/routes/community-members.ts
@@ -38,6 +38,42 @@ interface MemberRow {
   dance_preview: { variety: string | null; level: string | null; role: string | null } | null;
 }
 
+/**
+ * E6 — Members count. Powers the Find a Partner "Members" sub-tab gate
+ * (visible only while community total ≤ 1000). Reuses the same
+ * is_visible filter as the list endpoint.
+ */
+router.get('/community/members/count', requireAuth, requireTenant, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(500).json({ ok: false, error: 'supabase_unavailable' });
+  }
+
+  const { data: hiddenRows } = await supabase
+    .from('global_community_profiles')
+    .select('user_id')
+    .eq('is_visible', false);
+  const hiddenIds = new Set<string>((hiddenRows || []).map((r: any) => String(r.user_id)));
+
+  const { count, error } = await supabase
+    .from('profiles')
+    .select('user_id', { count: 'exact', head: true })
+    .neq('user_id', identity.user_id);
+
+  if (error) {
+    console.error('[E6] community/members/count failed', error);
+    return res.status(500).json({ ok: false, error: error.message });
+  }
+
+  // The count above is the total profiles minus self. Subtract hidden ones.
+  // For small N this is fine; promote to a SQL-side view if it ever matters.
+  const total = Math.max(0, (count ?? 0) - hiddenIds.size);
+  return res.json({ ok: true, total });
+});
+
 router.get('/community/members', requireAuth, requireTenant, async (req: Request, res: Response) => {
   const { identity } = req as AuthenticatedRequest;
   if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });

--- a/services/gateway/src/routes/intent-board.ts
+++ b/services/gateway/src/routes/intent-board.ts
@@ -46,6 +46,15 @@ function defaultKindsForCompass(category: string | null): IntentKind[] {
   }
 }
 
+/**
+ * E6 — surface-aware redaction. When `surface=find_a_partner` is present,
+ * partner_seek rows are returned UNREDACTED (posting under Find a Partner
+ * is implicit consent for that surface). The default `/intents/board`
+ * surface keeps the existing redaction. Per-user `account_visibility`
+ * overrides still win for any field a subject has marked private (E5).
+ */
+type Surface = 'default' | 'find_a_partner';
+
 router.get('/', requireAuth, requireTenant, async (req: Request, res: Response) => {
   const { identity } = req as AuthenticatedRequest;
   if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
@@ -53,6 +62,22 @@ router.get('/', requireAuth, requireTenant, async (req: Request, res: Response) 
   const explicitKind = req.query.kind as string | undefined;
   const category = req.query.category as string | undefined;
   const limit = Math.min(Number(req.query.limit) || 30, 100);
+  const surface: Surface = req.query.surface === 'find_a_partner' ? 'find_a_partner' : 'default';
+
+  // Optional `categories` array (comma-separated). Each entry can be an
+  // exact match (`activity_seek`) or a prefix glob (`dance.*`, `fitness.*`).
+  const categoriesParam = req.query.categories as string | undefined;
+  const categoryPrefixes: string[] = [];
+  const categoryExacts: string[] = [];
+  if (categoriesParam) {
+    for (const raw of categoriesParam.split(',').map((s) => s.trim()).filter(Boolean)) {
+      if (raw.endsWith('.*')) {
+        categoryPrefixes.push(raw.slice(0, -1)); // 'dance.*' → 'dance.'
+      } else {
+        categoryExacts.push(raw);
+      }
+    }
+  }
 
   const compass = await getActiveCompassGoal(identity.user_id);
   const kinds = explicitKind
@@ -70,25 +95,31 @@ router.get('/', requireAuth, requireTenant, async (req: Request, res: Response) 
     .order('created_at', { ascending: false })
     .limit(limit);
 
-  // For partner_seek, only return rows whose visibility is mutual_reveal
-  // (they're the only kind allowed there) AND redact scope/title.
-  // For all other kinds, the visibility check is enforced by RLS on the
-  // user_intents table (only public rows surface to non-owners).
-  if (kinds.includes('partner_seek')) {
-    // Only allow partner_seek when explicitly requested via ?kind=partner_seek.
+  // For partner_seek on the default surface, only return rows when
+  // explicitly requested. On the find_a_partner surface, include
+  // partner_seek freely — posting there is implicit consent.
+  if (kinds.includes('partner_seek') && surface === 'default') {
     if (!explicitKind || explicitKind !== 'partner_seek') {
       q = q.neq('intent_kind', 'partner_seek');
     }
   }
 
-  if (category) q = q.eq('category', category);
+  if (category) {
+    q = q.eq('category', category);
+  } else if (categoryPrefixes.length > 0 || categoryExacts.length > 0) {
+    // Build an OR clause: exact matches OR prefix LIKEs.
+    const clauses: string[] = [];
+    for (const exact of categoryExacts) clauses.push(`category.eq.${exact}`);
+    for (const prefix of categoryPrefixes) clauses.push(`category.like.${prefix}%`);
+    q = q.or(clauses.join(','));
+  }
 
   const { data, error } = await q;
   if (error) return res.status(500).json({ ok: false, error: error.message });
 
-  // Redact partner_seek rows (no scope text on board, just kind + category).
+  // Redaction: default surface redacts partner_seek; find_a_partner does not.
   const result = (data ?? []).map((row: any) => {
-    if (row.intent_kind === 'partner_seek') {
+    if (row.intent_kind === 'partner_seek' && surface === 'default') {
       return {
         intent_id: row.intent_id,
         intent_kind: row.intent_kind,
@@ -106,6 +137,7 @@ router.get('/', requireAuth, requireTenant, async (req: Request, res: Response) 
     ok: true,
     compass: compass?.category ?? null,
     kinds_shown: kinds,
+    surface,
     intents: result,
   });
 });

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -2635,6 +2635,10 @@ function buildLiveApiTools(mode: 'anonymous' | 'authenticated' = 'authenticated'
             '"show me my posts", "open the dance board", "where can I see this", "take me to members".',
             '',
             'Available targets:',
+            "  find_partner             → /comm/find-partner (Find a Partner — unified dance + fitness destination, my matches by default)",
+            "  find_partner_matches     → /comm/find-partner?view=matches (only my matches)",
+            "  find_partner_board       → /comm/find-partner?view=board (community board, dance + fitness)",
+            "  find_partner_posts       → /comm/find-partner?view=posts (my dance/fitness wishes)",
             "  my_intents               → /intents/mine (my own posts list)",
             "  intent_board             → /intents/board (all community posts, kind tabs)",
             "  intent_board_dance       → /intents/board?filter=dance (dance tab pre-selected)",
@@ -2646,7 +2650,12 @@ function buildLiveApiTools(mode: 'anonymous' | 'authenticated' = 'authenticated'
             "  events_meetups           → /comm/events-meetups",
             "  community_feed           → /comm/feed",
             '',
-            'After calling, ORB should ALSO say a short voice cue ("Opening your posts now") so',
+            'PREFER find_partner_* over my_intents / intent_board / members for any dance- or fitness-partner request.',
+            'find_partner is the single destination that pulls dance + fitness matches into one ranked list, with',
+            'sub-tabs for board, my posts, and members. Use it when the user says: "show me my matches",',
+            '"who did you find for me", "who wants to dance", "find me a fitness buddy", "open Find a Partner".',
+            '',
+            'After calling, ORB should ALSO say a short voice cue ("Opening your matches") so',
             'the user knows the screen change is intentional. The frontend handles the actual route push.',
           ].join('\n'),
           parameters: {
@@ -2655,6 +2664,7 @@ function buildLiveApiTools(mode: 'anonymous' | 'authenticated' = 'authenticated'
               target: {
                 type: 'string',
                 enum: [
+                  'find_partner','find_partner_matches','find_partner_board','find_partner_posts',
                   'my_intents','intent_board','intent_board_dance',
                   'open_asks','members',
                   'intent_match_detail','intent_post_public',
@@ -5772,6 +5782,10 @@ async function executeLiveApiToolInner(
         let url = '';
         let title = '';
         switch (target) {
+          case 'find_partner':             url = '/comm/find-partner'; title = 'Find a Partner'; break;
+          case 'find_partner_matches':     url = '/comm/find-partner?view=matches'; title = 'My matches'; break;
+          case 'find_partner_board':       url = '/comm/find-partner?view=board'; title = 'Find a Partner — board'; break;
+          case 'find_partner_posts':       url = '/comm/find-partner?view=posts'; title = 'My dance & fitness wishes'; break;
           case 'my_intents':              url = '/intents/mine'; title = 'My posts'; break;
           case 'intent_board':             url = '/intents/board'; title = 'Community board'; break;
           case 'intent_board_dance':       url = '/intents/board?filter=dance'; title = 'Dance posts'; break;


### PR DESCRIPTION
## Summary

Pairs with vitana-v1 PR for the **Find a Partner** unified destination + privacy controls scaffold.

**E5 — privacy scaffold:**
- New `services/gateway/src/lib/account-visibility.ts` — `FIELD_DEFAULTS`, `applyAccountVisibility()`, `getViewerRelationship()`. Private-first for age, gender, partner_preferences. Mirrors the frontend `DEFAULT_ACCOUNT_VISIBILITY` map.
- `HARDCODED_KEYS` covers `myPosts.partnerSeek` (never user-toggleable; partner_seek follows mutual-reveal protocol).

**E6 — Find a Partner backend:**
- `intent-board`: `?surface=find_a_partner` skips partner_seek redaction; `?categories=dance.*,fitness.*` filters server-side via OR clause.
- `community-members`: `GET /api/v1/community/members/count` for the Members tab gate (visible only while community total ≤ 1000).
- `orb-live` `navigate_to_screen`: registers `find_partner`, `find_partner_matches`, `find_partner_board`, `find_partner_posts` so ORB can voice-route to the new sub-views.

Tool description tells Gemini to PREFER `find_partner_*` over `my_intents`/`intent_board`/`members` for any dance- or fitness-partner request.

## Plan reference

PART 5 phases E5 + E6 of the i-want-a-solution-streamed-patterson plan.

## Test plan

- [ ] `npx tsc --noEmit` in `services/gateway` — passes
- [ ] After deploy: `GET /api/v1/community/members/count` returns `{ ok, total }`
- [ ] After deploy: `GET /api/v1/intent-board?surface=find_a_partner&categories=dance.*,fitness.*` returns dance + fitness intents, partner_seek rows unredacted
- [ ] Speak to ORB "open Find a Partner" / "show me my matches" — frontend navigates (paired vitana-v1 PR handles route push)

🤖 Generated with [Claude Code](https://claude.com/claude-code)
