### PR TITLE
fix(gateway): Correct schema drift in admin-navigator for oasis_events_v1

### DIFF
--- a/services/gateway/src/routes/admin-navigator.ts
+++ b/services/gateway/src/routes/admin-navigator.ts
@@ -578,8 +578,8 @@ router.get('/coverage', async (req: AuthenticatedRequest, res: Response) => {
     const since = new Date(Date.now() - 30 * 86400000).toISOString();
     const { data: events } = await supabase
       .from('oasis_events_v1')
-      .select('payload, type, created_at')
-      .like('type', 'orb.navigator.%')
+      .select('payload, event_type, created_at')
+      .like('event_type', 'orb.navigator.%')
       .gte('created_at', since)
       .limit(10000);
 
@@ -626,8 +626,8 @@ router.get('/telemetry', async (req: AuthenticatedRequest, res: Response) => {
   try {
     const { data: events, error } = await supabase
       .from('oasis_events_v1')
-      .select('type, payload, created_at')
-      .like('type', 'orb.navigator.%')
+      .select('payload, event_type, created_at')
+      .like('event_type', 'orb.navigator.%')
       .gte('created_at', since)
       .order('created_at', { ascending: false })
       .limit(5000);
@@ -639,7 +639,7 @@ router.get('/telemetry', async (req: AuthenticatedRequest, res: Response) => {
     const nearMisses: Array<{ utterance: string; picked: any; runner_up: any; delta: number }> = [];
 
     for (const ev of (events as any[]) || []) {
-      byType[ev.type] = (byType[ev.type] || 0) + 1;
+      byType[ev.event_type] = (byType[ev.event_type] || 0) + 1;
       const payload = (ev.payload || {}) as any;
       const picks: any[] = payload.top_picks || (payload.primary ? [payload.primary] : []);
       for (const p of picks) {


### PR DESCRIPTION
This pull request addresses a `schema_drift` violation in `services/gateway/src/routes/admin-navigator.ts` as flagged by the schema drift scanner. The `oasis_events_v1` table's `type` column was renamed to `event_type` in a recent migration, causing queries in this file to become outdated.

This change updates the `GET /coverage` and `GET /telemetry` endpoints to use the correct `event_type` column name in their `SELECT`, `LIKE`, and result processing logic. This restores the functionality of these admin endpoints without any change in their external behavior.

### Files Modified
- `services/gateway/src/routes/admin-navigator.ts`

This is part of a larger effort to fix 60 files affected by the same schema drift. This PR only addresses `admin-navigator.ts`.