### PR TITLE
DEV-AUTOPILOT: Refactor admin notification categories auth to middleware

### DIFF
--- a/services/gateway/src/routes/admin-notification-categories.ts
+++ b/services/gateway/src/routes/admin-notification-categories.ts
@@ -11,10 +11,10 @@
  * - POST   /:id/test      — Send test notification to admin
  *
  * Security:
- * - All endpoints require Bearer token + exafy_admin
+ * - All endpoints are protected by the `requireExafyAdmin` middleware.
  */
 
-import { Router, Request, Response } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { createClient } from '@supabase/supabase-js';
 import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, NotificationPayload } from '../services/notification-service';
@@ -33,7 +33,7 @@ function getSupabase() {
   );
 }
 
-// ── Auth Helper ─────────────────────────────────────────────
+// ── Auth Middleware ─────────────────────────────────────────
 
 function getBearerToken(req: Request): string | null {
   const authHeader = req.headers.authorization;
@@ -41,28 +41,24 @@ function getBearerToken(req: Request): string | null {
   return authHeader.slice(7);
 }
 
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
+async function requireExafyAdmin(req: Request, res: Response, next: NextFunction) {
   const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
+  if (!token) return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
   try {
     const userClient = createUserSupabaseClient(token);
     const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
+    if (authError || !authData?.user) return res.status(401).json({ ok: false, error: 'INVALID_TOKEN' });
     const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
+    if (appMetadata.exafy_admin !== true) return res.status(403).json({ ok: false, error: 'FORBIDDEN' });
+    (req as any).authUser = { user_id: authData.user.id, email: authData.user.email };
+    next();
   } catch (err: any) {
     console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
+    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
   }
 }
+
+router.use(requireExafyAdmin);
 
 // ── Slug helper ─────────────────────────────────────────────
 
@@ -76,9 +72,6 @@ function toSlug(name: string): string {
 // ── GET / — List all categories ─────────────────────────────
 
 router.get('/', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   const { type, tenant_id, include_inactive } = req.query;
 
@@ -120,9 +113,6 @@ router.get('/', async (req: Request, res: Response) => {
 // ── GET /:id — Get single category ─────────────────────────
 
 router.get('/:id', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   const { data, error } = await supabase
     .from('notification_categories')
@@ -140,9 +130,6 @@ router.get('/:id', async (req: Request, res: Response) => {
 // ── POST / — Create category ───────────────────────────────
 
 router.post('/', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   const {
     type,
@@ -181,7 +168,7 @@ router.post('/', async (req: Request, res: Response) => {
     default_enabled: default_enabled ?? true,
     mapped_types: mapped_types || [],
     tenant_id: tenant_id || null,
-    created_by: authResult.user_id,
+    created_by: (req as any).authUser.user_id,
   };
 
   const { data, error } = await supabase
@@ -198,16 +185,13 @@ router.post('/', async (req: Request, res: Response) => {
     return res.status(500).json({ ok: false, error: error.message });
   }
 
-  console.log(`[${VTID}] Created category "${slug}" (${type}) by ${authResult.email}`);
+  console.log(`[${VTID}] Created category "${slug}" (${type}) by ${(req as any).authUser.email}`);
   return res.status(201).json({ ok: true, data });
 });
 
 // ── PATCH /:id — Update category ────────────────────────────
 
 router.patch('/:id', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   const allowedFields = ['display_name', 'description', 'icon', 'sort_order', 'is_active', 'default_enabled', 'mapped_types'];
   const updateData: Record<string, any> = { updated_at: new Date().toISOString() };
@@ -238,16 +222,13 @@ router.patch('/:id', async (req: Request, res: Response) => {
     return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
   }
 
-  console.log(`[${VTID}] Updated category "${data.slug}" by ${authResult.email}`);
+  console.log(`[${VTID}] Updated category "${data.slug}" by ${(req as any).authUser.email}`);
   return res.json({ ok: true, data });
 });
 
 // ── DELETE /:id — Soft-delete (set is_active=false) ─────────
 
 router.delete('/:id', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   const { data, error } = await supabase
     .from('notification_categories')
@@ -264,16 +245,13 @@ router.delete('/:id', async (req: Request, res: Response) => {
     return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
   }
 
-  console.log(`[${VTID}] Soft-deleted category "${data.slug}" by ${authResult.email}`);
+  console.log(`[${VTID}] Soft-deleted category "${data.slug}" by ${(req as any).authUser.email}`);
   return res.json({ ok: true, data });
 });
 
 // ── POST /:id/test — Send test notification to admin ────────
 
 router.post('/:id/test', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
 
   // Get the category
@@ -300,15 +278,15 @@ router.post('/:id/test', async (req: Request, res: Response) => {
   const { data: tenantRow } = await supabase
     .from('user_tenants')
     .select('tenant_id')
-    .eq('user_id', authResult.user_id)
+    .eq('user_id', (req as any).authUser.user_id)
     .limit(1)
     .single();
 
   const tenantId = tenantRow?.tenant_id || '00000000-0000-0000-0000-000000000000';
 
   try {
-    const result = await notifyUser(authResult.user_id, tenantId, testType, payload, supabase);
-    console.log(`[${VTID}] Test notification sent for category "${category.slug}" by ${authResult.email}`);
+    const result = await notifyUser((req as any).authUser.user_id, tenantId, testType, payload, supabase);
+    console.log(`[${VTID}] Test notification sent for category "${category.slug}" by ${(req as any).authUser.email}`);
     return res.json({ ok: true, result });
   } catch (err: any) {
     console.error(`[${VTID}] POST /:id/test error:`, err.message);

--- a/services/gateway/test/routes/admin-notification-categories.test.ts
+++ b/services/gateway/test/routes/admin-notification-categories.test.ts
@@ -1,0 +1,161 @@
+/**
+ * Tests for admin-notification-categories routes (auth middleware)
+ */
+
+import request from 'supertest';
+import express from 'express';
+
+// Mocks must be set up before importing the module under test
+jest.mock('../../src/lib/supabase-user', () => ({
+  createUserSupabaseClient: jest.fn(),
+}));
+
+jest.mock('@supabase/supabase-js', () => {
+  const mockFrom = jest.fn().mockReturnThis();
+  const mockSelect = jest.fn().mockReturnThis();
+  const mockOrder = jest.fn().mockReturnThis();
+  const mockEq = jest.fn().mockReturnThis();
+  const mockOr = jest.fn().mockReturnThis();
+  const mockIs = jest.fn().mockReturnThis();
+  const mockSingle = jest.fn().mockReturnThis();
+  const mockInsert = jest.fn().mockReturnThis();
+  const mockUpdate = jest.fn().mockReturnThis();
+  const mockLimit = jest.fn().mockReturnThis();
+  const mockThen = (callback: any) => callback({ data: [], error: null });
+  const mockQuery = {
+    from: mockFrom,
+    select: mockSelect,
+    order: mockOrder,
+    eq: mockEq,
+    or: mockOr,
+    is: mockIs,
+    single: mockSingle,
+    insert: mockInsert,
+    update: mockUpdate,
+    limit: mockLimit,
+    then: mockThen,
+  };
+  return {
+    createClient: jest.fn(() => ({
+      from: () => mockQuery,
+      auth: {
+        getUser: jest.fn(),
+      },
+    })),
+  };
+});
+
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn().mockResolvedValue({ ok: true }),
+}));
+
+import router from '../../src/routes/admin-notification-categories';
+import { createUserSupabaseClient } from '../../src/lib/supabase-user';
+
+const mockedCreateUserSupabaseClient = createUserSupabaseClient as jest.Mock;
+const app = express();
+app.use(express.json());
+app.use('/', router);
+
+describe('Admin Notification Categories — auth middleware', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return 401 when no Bearer token is provided', async () => {
+    const res = await request(app).get('/');
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ ok: false, error: 'UNAUTHENTICATED' });
+  });
+
+  it('should return 401 when token is invalid', async () => {
+    const mockClient = {
+      auth: {
+        getUser: jest.fn().mockResolvedValue({ data: { user: null }, error: new Error('invalid token') }),
+      },
+    };
+    mockedCreateUserSupabaseClient.mockReturnValue(mockClient);
+
+    const res = await request(app)
+      .get('/')
+      .set('Authorization', 'Bearer some-invalid-token');
+
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ ok: false, error: 'INVALID_TOKEN' });
+  });
+
+  it('should return 403 when user is not exafy_admin', async () => {
+    const mockClient = {
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: {
+            user: {
+              id: 'user-123',
+              email: 'user@example.com',
+              app_metadata: { exafy_admin: false },
+            },
+          },
+          error: null,
+        }),
+      },
+    };
+    mockedCreateUserSupabaseClient.mockReturnValue(mockClient);
+
+    const res = await request(app)
+      .get('/')
+      .set('Authorization', 'Bearer some-valid-nonadmin-token');
+
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ ok: false, error: 'FORBIDDEN' });
+  });
+
+  it('should pass middleware and return 200 for valid admin token (GET /)', async () => {
+    const mockQuery = jest.fn();
+    const mockSelect = jest.fn();
+    const mockOrder = jest.fn();
+    const mockEq = jest.fn();
+    const mockOr = jest.fn();
+    const mockIs = jest.fn();
+    const mockFrom = jest.fn(() => ({
+      select: mockSelect,
+      order: mockOrder,
+      eq: mockEq,
+      or: mockOr,
+      is: mockIs,
+    }));
+    const mockClient = {
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: {
+            user: {
+              id: 'admin-1',
+              email: 'admin@vitana.se',
+              app_metadata: { exafy_admin: true },
+            },
+          },
+          error: null,
+        }),
+      },
+    };
+    mockedCreateUserSupabaseClient.mockReturnValue(mockClient);
+
+    // mock the getSupabase() calls inside the handler: we already mocked @supabase/supabase-js createClient
+    // The mock returns a chain that ends with .then. We need the GET / handler to resolve successfully.
+    // We'll set up the mock chain to return an empty array.
+    const { createClient } = require('@supabase/supabase-js');
+    const fakeSupabaseClient = createClient();
+
+    // Override the chain to return data on the final call
+    // The actual handler uses await query, which calls .then under the hood.
+    // Our mock's .then returns { data: [], error: null } by default, so it should work.
+    // No additional setup needed.
+
+    const res = await request(app)
+      .get('/')
+      .set('Authorization', 'Bearer valid-admin-token');
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.data).toBeDefined();
+  });
+});


### PR DESCRIPTION
This PR addresses the `missing_auth` scanner finding in `admin-notification-categories.ts`. Previously every route handler duplicated the admin verification logic via the `verifyExafyAdmin` helper. This change introduces a single Express middleware `requireExafyAdmin` applied via `router.use()`, eliminating duplication and ensuring new routes automatically inherit authentication.

Changes:
- `services/gateway/src/routes/admin-notification-categories.ts` – extracted auth into middleware, removed per-handler checks, updated security comment.
- `services/gateway/test/routes/admin-notification-categories.test.ts` – new test suite verifying 401/403/200 behaviour with mocked auth and supabase.

No other files touched. Existing CRUD functionality is preserved.