### PR TITLE
DEV-AUTOPILOT: Refactor admin notification categories auth to middleware

### DIFF
--- a/services/gateway/src/routes/admin-notification-categories.ts
+++ b/services/gateway/src/routes/admin-notification-categories.ts
@@ -11,10 +11,10 @@
  * - POST   /:id/test      — Send test notification to admin
  *
  * Security:
- * - All endpoints require Bearer token + exafy_admin
+ * - All endpoints are protected by the `requireExafyAdmin` middleware.
  */
 
-import { Router, Request, Response } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { createClient } from '@supabase/supabase-js';
 import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, NotificationPayload } from '../services/notification-service';
@@ -33,7 +33,7 @@ function getSupabase() {
   );
 }
 
-// ── Auth Helper ─────────────────────────────────────────────
+// ── Auth Middleware ──────────────────────────────────────────
 
 function getBearerToken(req: Request): string | null {
   const authHeader = req.headers.authorization;
@@ -41,28 +41,30 @@ function getBearerToken(req: Request): string | null {
   return authHeader.slice(7);
 }
 
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
+async function requireExafyAdmin(req: Request, res: Response, next: NextFunction) {
   const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
+  if (!token) return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
 
   try {
     const userClient = createUserSupabaseClient(token);
     const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
+    if (authError || !authData?.user) return res.status(401).json({ ok: false, error: 'INVALID_TOKEN' });
 
     const appMetadata = authData.user.app_metadata || {};
     if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
+      return res.status(403).json({ ok: false, error: 'FORBIDDEN' });
     }
 
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
+    // Attach user info to request for downstream handlers
+    (req as any).authUser = { user_id: authData.user.id, email: authData.user.email || 'unknown' };
+    next();
   } catch (err: any) {
     console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
+    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
   }
 }
+
+router.use(requireExafyAdmin);
 
 // ── Slug helper ─────────────────────────────────────────────
 
@@ -76,9 +78,6 @@ function toSlug(name: string): string {
 // ── GET / — List all categories ─────────────────────────────
 
 router.get('/', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   const { type, tenant_id, include_inactive } = req.query;
 
@@ -120,9 +119,6 @@ router.get('/', async (req: Request, res: Response) => {
 // ── GET /:id — Get single category ─────────────────────────
 
 router.get('/:id', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   const { data, error } = await supabase
     .from('notification_categories')
@@ -140,9 +136,6 @@ router.get('/:id', async (req: Request, res: Response) => {
 // ── POST / — Create category ───────────────────────────────
 
 router.post('/', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   const {
     type,
@@ -181,7 +174,7 @@ router.post('/', async (req: Request, res: Response) => {
     default_enabled: default_enabled ?? true,
     mapped_types: mapped_types || [],
     tenant_id: tenant_id || null,
-    created_by: authResult.user_id,
+    created_by: (req as any).authUser.user_id,
   };
 
   const { data, error } = await supabase
@@ -198,16 +191,13 @@ router.post('/', async (req: Request, res: Response) => {
     return res.status(500).json({ ok: false, error: error.message });
   }
 
-  console.log(`[${VTID}] Created category "${slug}" (${type}) by ${authResult.email}`);
+  console.log(`[${VTID}] Created category "${slug}" (${type}) by ${(req as any).authUser.email}`);
   return res.status(201).json({ ok: true, data });
 });
 
 // ── PATCH /:id — Update category ────────────────────────────
 
 router.patch('/:id', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   const allowedFields = ['display_name', 'description', 'icon', 'sort_order', 'is_active', 'default_enabled', 'mapped_types'];
   const updateData: Record<string, any> = { updated_at: new Date().toISOString() };
@@ -238,16 +228,13 @@ router.patch('/:id', async (req: Request, res: Response) => {
     return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
   }
 
-  console.log(`[${VTID}] Updated category "${data.slug}" by ${authResult.email}`);
+  console.log(`[${VTID}] Updated category "${data.slug}" by ${(req as any).authUser.email}`);
   return res.json({ ok: true, data });
 });
 
 // ── DELETE /:id — Soft-delete (set is_active=false) ─────────
 
 router.delete('/:id', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   const { data, error } = await supabase
     .from('notification_categories')
@@ -264,16 +251,13 @@ router.delete('/:id', async (req: Request, res: Response) => {
     return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
   }
 
-  console.log(`[${VTID}] Soft-deleted category "${data.slug}" by ${authResult.email}`);
+  console.log(`[${VTID}] Soft-deleted category "${data.slug}" by ${(req as any).authUser.email}`);
   return res.json({ ok: true, data });
 });
 
 // ── POST /:id/test — Send test notification to admin ────────
 
 router.post('/:id/test', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
 
   // Get the category
@@ -300,15 +284,15 @@ router.post('/:id/test', async (req: Request, res: Response) => {
   const { data: tenantRow } = await supabase
     .from('user_tenants')
     .select('tenant_id')
-    .eq('user_id', authResult.user_id)
+    .eq('user_id', (req as any).authUser.user_id)
     .limit(1)
     .single();
 
   const tenantId = tenantRow?.tenant_id || '00000000-0000-0000-0000-000000000000';
 
   try {
-    const result = await notifyUser(authResult.user_id, tenantId, testType, payload, supabase);
-    console.log(`[${VTID}] Test notification sent for category "${category.slug}" by ${authResult.email}`);
+    const result = await notifyUser((req as any).authUser.user_id, tenantId, testType, payload, supabase);
+    console.log(`[${VTID}] Test notification sent for category "${category.slug}" by ${(req as any).authUser.email}`);
     return res.json({ ok: true, result });
   } catch (err: any) {
     console.error(`[${VTID}] POST /:id/test error:`, err.message);

--- a/services/gateway/test/routes/admin-notification-categories.test.ts
+++ b/services/gateway/test/routes/admin-notification-categories.test.ts
@@ -1,0 +1,120 @@
+import request from 'supertest';
+import express, { Router } from 'express';
+import { createClient } from '@supabase/supabase-js';
+
+// Mock external modules
+jest.mock('../../src/lib/supabase-user', () => ({
+  createUserSupabaseClient: jest.fn(),
+}));
+
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn(),
+  NotificationPayload: jest.fn(),
+}));
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(),
+}));
+
+// Import the router (must be after mocks)
+const routerModule = require('../../src/routes/admin-notification-categories').default;
+
+describe('Admin Notification Categories - Auth Middleware', () => {
+  let app: express.Express;
+  let mockSupabaseClient: any;
+  let mockCreateUserClient: jest.Mock;
+
+  beforeAll(() => {
+    // Create a minimal express app with just the router
+    app = express();
+    app.use(express.json());
+    app.use('/', routerModule);
+
+    // Setup createClient mock
+    mockSupabaseClient = {
+      from: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({ data: null, error: null }),
+      insert: jest.fn().mockReturnThis(),
+      update: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      or: jest.fn().mockReturnThis(),
+      is: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+    };
+    (createClient as jest.Mock).mockReturnValue(mockSupabaseClient);
+
+    mockCreateUserClient = require('../../src/lib/supabase-user').createUserSupabaseClient as jest.Mock;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  test('should return 401 if no Bearer token is provided', async () => {
+    const res = await request(app).get('/');
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ ok: false, error: 'UNAUTHENTICATED' });
+  });
+
+  test('should return 403 if token is valid but user is not exafy_admin', async () => {
+    const fakeUserClient = {
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: { user: { id: 'user-123', email: 'user@test.com', app_metadata: { exafy_admin: false } } },
+          error: null,
+        }),
+      },
+    };
+    mockCreateUserClient.mockReturnValue(fakeUserClient);
+
+    const res = await request(app)
+      .get('/')
+      .set('Authorization', 'Bearer fake-token');
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ ok: false, error: 'FORBIDDEN' });
+  });
+
+  test('should pass middleware and reach handler when admin token is valid', async () => {
+    const fakeUserClient = {
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: { user: { id: 'admin-1', email: 'admin@test.com', app_metadata: { exafy_admin: true } } },
+          error: null,
+        }),
+      },
+    };
+    mockCreateUserClient.mockReturnValue(fakeUserClient);
+
+    // Mock getSupabase to return data for the GET / handler
+    const mockFrom = jest.fn().mockReturnThis();
+    const mockSelect = jest.fn().mockReturnThis();
+    const mockOrder = jest.fn().mockReturnThis();
+    const mockEq = jest.fn().mockReturnThis();
+    const mockOr = jest.fn().mockReturnThis();
+    const mockIs = jest.fn().mockReturnThis();
+    const mockLimit = jest.fn().mockReturnThis();
+    const mockSingle = jest.fn().mockResolvedValue({ data: null, error: null });
+
+    mockSupabaseClient.from = mockFrom;
+    mockSupabaseClient.select = mockSelect;
+    mockSupabaseClient.order = mockOrder;
+    mockSupabaseClient.eq = mockEq;
+    mockSupabaseClient.or = mockOr;
+    mockSupabaseClient.is = mockIs;
+    mockSupabaseClient.limit = mockLimit;
+    mockSupabaseClient.single = mockSingle;
+
+    // For GET / we need the query to resolve with an empty list
+    mockSelect.mockResolvedValue({ data: [], error: null });
+
+    const res = await request(app)
+      .get('/')
+      .set('Authorization', 'Bearer valid-admin-token');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.data).toEqual({ chat: [], calendar: [], community: [] });
+    expect(res.body.total).toBe(0);
+  });
+});


### PR DESCRIPTION
## Summary

This PR refactors `admin-notification-categories.ts` to replace per‑handler `verifyExafyAdmin` calls with a single `router.use(requireExafyAdmin)` middleware. This eliminates auth duplication, aligns with the repository’s standard middleware pattern, and fixes the scanner’s `missing_auth` finding.

**Changes made:**
- **`services/gateway/src/routes/admin-notification-categories.ts`**
  - Added `NextFunction` import.
  - Created `requireExafyAdmin` middleware (extracts Bearer token, validates via Supabase, checks `exafy_admin` app_metadata, attaches `authUser` to request)
  - Registered middleware immediately after router creation.
  - Removed the `verifyExafyAdmin` helper function.
  - Updated all handlers to use `req.authUser` instead of `authResult`.
  - Updated the Security section comment.
- **`services/gateway/test/routes/admin-notification-categories.test.ts`** (new)
  - Test suite covering:
    - No token → 401
    - Valid token without `exafy_admin` → 403
    - Valid admin token → 200 (with mocked DB)
  - Uses `supertest` and mocks for Supabase and notification service.

## Testing
- Existing route tests (if any) should still pass.
- New test file verifies middleware behaviour end‑to‑end.
- Manual smoke test: `GET /` without token returns 401; with token returns 200.

## Files touched
- `services/gateway/src/routes/admin-notification-categories.ts` (modified)
- `services/gateway/test/routes/admin-notification-categories.test.ts` (created)