### PR TITLE
refactor(gateway): Use middleware for admin auth on notification categories

### DIFF
--- a/services/gateway/src/routes/admin-notification-categories.ts
+++ b/services/gateway/src/routes/admin-notification-categories.ts
@@ -11,10 +11,10 @@
  * - POST   /:id/test      — Send test notification to admin
  *
  * Security:
- * - All endpoints require Bearer token + exafy_admin
+ * - All endpoints are protected by the `requireExafyAdmin` middleware.
  */
 
-import { Router, Request, Response } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { createClient } from '@supabase/supabase-js';
 import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, NotificationPayload } from '../services/notification-service';
@@ -24,16 +24,7 @@ const VTID = 'ADMIN-NOTIF-CATEGORIES';
 
 const VALID_TYPES = ['chat', 'calendar', 'community'];
 
-// ── Supabase ────────────────────────────────────────────────
-
-function getSupabase() {
-  return createClient(
-    process.env.SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE!
-  );
-}
-
-// ── Auth Helper ─────────────────────────────────────────────
+// ── Auth Helper for Middleware ──────────────────────────────
 
 function getBearerToken(req: Request): string | null {
   const authHeader = req.headers.authorization;
@@ -41,27 +32,35 @@ function getBearerToken(req: Request): string | null {
   return authHeader.slice(7);
 }
 
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
+// ── Auth Middleware ─────────────────────────────────────────
 
+async function requireExafyAdmin(req: Request, res: Response, next: NextFunction) {
+  const token = getBearerToken(req);
+  if (!token) return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
   try {
     const userClient = createUserSupabaseClient(token);
     const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
+    if (authError || !authData?.user) return res.status(401).json({ ok: false, error: 'INVALID_TOKEN' });
     const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
+    if (appMetadata.exafy_admin !== true) return res.status(403).json({ ok: false, error: 'FORBIDDEN' });
+    // Attach user info to request for downstream handlers
+    (req as any).authUser = { user_id: authData.user.id, email: authData.user.email };
+    next();
   } catch (err: any) {
     console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
+    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
   }
+}
+
+router.use(requireExafyAdmin);
+
+// ── Supabase ────────────────────────────────────────────────
+
+function getSupabase() {
+  return createClient(
+    process.env.SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE!
+  );
 }
 
 // ── Slug helper ─────────────────────────────────────────────
@@ -76,9 +75,6 @@ function toSlug(name: string): string {
 // ── GET / — List all categories ─────────────────────────────
 
 router.get('/', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   const { type, tenant_id, include_inactive } = req.query;
 
@@ -120,9 +116,6 @@ router.get('/', async (req: Request, res: Response) => {
 // ── GET /:id — Get single category ─────────────────────────
 
 router.get('/:id', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   const { data, error } = await supabase
     .from('notification_categories')
@@ -140,9 +133,6 @@ router.get('/:id', async (req: Request, res: Response) => {
 // ── POST / — Create category ───────────────────────────────
 
 router.post('/', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   const {
     type,
@@ -181,7 +171,7 @@ router.post('/', async (req: Request, res: Response) => {
     default_enabled: default_enabled ?? true,
     mapped_types: mapped_types || [],
     tenant_id: tenant_id || null,
-    created_by: authResult.user_id,
+    created_by: (req as any).authUser.user_id,
   };
 
   const { data, error } = await supabase
@@ -198,16 +188,13 @@ router.post('/', async (req: Request, res: Response) => {
     return res.status(500).json({ ok: false, error: error.message });
   }
 
-  console.log(`[${VTID}] Created category "${slug}" (${type}) by ${authResult.email}`);
+  console.log(`[${VTID}] Created category "${slug}" (${type}) by ${(req as any).authUser.email}`);
   return res.status(201).json({ ok: true, data });
 });
 
 // ── PATCH /:id — Update category ────────────────────────────
 
 router.patch('/:id', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   const allowedFields = ['display_name', 'description', 'icon', 'sort_order', 'is_active', 'default_enabled', 'mapped_types'];
   const updateData: Record<string, any> = { updated_at: new Date().toISOString() };
@@ -238,16 +225,13 @@ router.patch('/:id', async (req: Request, res: Response) => {
     return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
   }
 
-  console.log(`[${VTID}] Updated category "${data.slug}" by ${authResult.email}`);
+  console.log(`[${VTID}] Updated category "${data.slug}" by ${(req as any).authUser.email}`);
   return res.json({ ok: true, data });
 });
 
 // ── DELETE /:id — Soft-delete (set is_active=false) ─────────
 
 router.delete('/:id', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   const { data, error } = await supabase
     .from('notification_categories')
@@ -264,16 +248,13 @@ router.delete('/:id', async (req: Request, res: Response) => {
     return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
   }
 
-  console.log(`[${VTID}] Soft-deleted category "${data.slug}" by ${authResult.email}`);
+  console.log(`[${VTID}] Soft-deleted category "${data.slug}" by ${(req as any).authUser.email}`);
   return res.json({ ok: true, data });
 });
 
 // ── POST /:id/test — Send test notification to admin ────────
 
 router.post('/:id/test', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
 
   // Get the category
@@ -300,15 +281,15 @@ router.post('/:id/test', async (req: Request, res: Response) => {
   const { data: tenantRow } = await supabase
     .from('user_tenants')
     .select('tenant_id')
-    .eq('user_id', authResult.user_id)
+    .eq('user_id', (req as any).authUser.user_id)
     .limit(1)
     .single();
 
   const tenantId = tenantRow?.tenant_id || '00000000-0000-0000-0000-000000000000';
 
   try {
-    const result = await notifyUser(authResult.user_id, tenantId, testType, payload, supabase);
-    console.log(`[${VTID}] Test notification sent for category "${category.slug}" by ${authResult.email}`);
+    const result = await notifyUser((req as any).authUser.user_id, tenantId, testType, payload, supabase);
+    console.log(`[${VTID}] Test notification sent for category "${category.slug}" by ${(req as any).authUser.email}`);
     return res.json({ ok: true, result });
   } catch (err: any) {
     console.error(`[${VTID}] POST /:id/test error:`, err.message);

--- a/services/gateway/test/routes/admin-notification-categories.test.ts
+++ b/services/gateway/test/routes/admin-notification-categories.test.ts
@@ -1,0 +1,146 @@
+import request from 'supertest';
+import express from 'express';
+import router from '../../src/routes/admin-notification-categories';
+import { createUserSupabaseClient } from '../../src/lib/supabase-user';
+import { createClient } from '@supabase/supabase-js';
+
+// Mock dependencies
+jest.mock('../../src/lib/supabase-user');
+jest.mock('@supabase/supabase-js');
+jest.mock('../../src/services/notification-service');
+
+const mockedCreateUserSupabaseClient = createUserSupabaseClient as jest.Mock;
+const mockedCreateClient = createClient as jest.Mock;
+
+const app = express();
+app.use(express.json());
+app.use('/', router);
+
+describe('Admin Notification Categories API Auth', () => {
+  const mockSupabaseQuery = {
+    from: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    order: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    or: jest.fn().mockReturnThis(),
+    is: jest.fn().mockReturnThis(),
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockedCreateClient.mockReturnValue(mockSupabaseQuery);
+  });
+
+  it('should return 401 UNAUTHENTICATED for requests without a token', async () => {
+    const response = await request(app).get('/');
+    expect(response.status).toBe(401);
+    expect(response.body.error).toBe('UNAUTHENTICATED');
+  });
+
+  it('should return 401 INVALID_TOKEN for requests with a bad token', async () => {
+    mockedCreateUserSupabaseClient.mockReturnValue({
+      auth: {
+        getUser: jest.fn().mockResolvedValue({ data: { user: null }, error: { message: 'Invalid token' } }),
+      },
+    });
+
+    const response = await request(app)
+      .get('/')
+      .set('Authorization', 'Bearer INVALID_TOKEN');
+
+    expect(response.status).toBe(401);
+    expect(response.body.error).toBe('INVALID_TOKEN');
+  });
+
+  it('should return 403 FORBIDDEN for requests from a non-admin user', async () => {
+    mockedCreateUserSupabaseClient.mockReturnValue({
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: {
+            user: {
+              id: 'user-123',
+              email: 'user@example.com',
+              app_metadata: { exafy_admin: false },
+            },
+          },
+          error: null,
+        }),
+      },
+    });
+
+    const response = await request(app)
+      .get('/')
+      .set('Authorization', 'Bearer NON_ADMIN_TOKEN');
+
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe('FORBIDDEN');
+  });
+
+  it('should allow access for a valid admin user', async () => {
+    mockedCreateUserSupabaseClient.mockReturnValue({
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: {
+            user: {
+              id: 'admin-456',
+              email: 'admin@exafy.com',
+              app_metadata: { exafy_admin: true },
+            },
+          },
+          error: null,
+        }),
+      },
+    });
+
+    (mockSupabaseQuery.select as jest.Mock).mockResolvedValue({
+      data: [{ id: 1, type: 'chat', display_name: 'Test Category' }],
+      error: null,
+    });
+
+    const response = await request(app)
+      .get('/')
+      .set('Authorization', 'Bearer VALID_ADMIN_TOKEN');
+
+    expect(response.status).toBe(200);
+    expect(response.body.ok).toBe(true);
+    expect(response.body.data.chat[0].display_name).toBe('Test Category');
+  });
+
+  it('should pass authUser to downstream handlers on successful auth', async () => {
+    const adminUser = {
+      id: 'admin-789',
+      email: 'creator@exafy.com',
+      app_metadata: { exafy_admin: true },
+    };
+
+    mockedCreateUserSupabaseClient.mockReturnValue({
+      auth: {
+        getUser: jest.fn().mockResolvedValue({ data: { user: adminUser }, error: null }),
+      },
+    });
+
+    const mockInsert = jest.fn().mockReturnThis();
+    const mockSelect = jest.fn().mockResolvedValue({
+        data: { id: 'new-id', created_by: adminUser.id },
+        error: null,
+    });
+
+    mockedCreateClient.mockReturnValue({
+        from: jest.fn().mockReturnThis(),
+        insert: mockInsert,
+        select: mockSelect,
+        single: jest.fn().mockReturnThis()
+    });
+
+    await request(app)
+      .post('/')
+      .set('Authorization', 'Bearer VALID_ADMIN_TOKEN')
+      .send({ type: 'chat', display_name: 'New Category' });
+
+    expect(mockInsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        created_by: adminUser.id,
+      })
+    );
+  });
+});


### PR DESCRIPTION
This pull request refactors the authentication logic for the admin notification categories API (`/admin/notification-categories`).

**Problem:**
The existing implementation performed authentication checks (`verifyExafyAdmin`) inside each route handler. This duplicated logic and made the file susceptible to a `missing_auth` scanner finding, as it did not follow the standard Express middleware pattern. Any new route added to this file could have easily missed the auth check.

**Solution:**
- The inline authentication logic has been extracted into a dedicated Express middleware function, `requireExafyAdmin`.
- This middleware is now applied once to the entire router using `router.use(requireExafyAdmin)`.
- All individual auth checks have been removed from the route handlers, simplifying their implementation.
- A new test suite (`admin-notification-categories.test.ts`) has been added to verify the middleware's behavior, ensuring it correctly handles unauthenticated, unauthorized (non-admin), and authorized (admin) requests.

**Files Touched:**
- `services/gateway/src/routes/admin-notification-categories.ts`: Refactored to use middleware.
- `services/gateway/test/routes/admin-notification-categories.test.ts`: New test file for auth middleware.

This change improves code maintainability, reduces duplication, and aligns the route's security implementation with repository standards.