### PR TITLE
DEV-AUTOPILOT: Refactor auth in admin-notification-categories to use middleware

### DIFF
--- a/services/gateway/src/routes/admin-notification-categories.ts
+++ b/services/gateway/src/routes/admin-notification-categories.ts
@@ -11,10 +11,10 @@
  * - POST   /:id/test      — Send test notification to admin
  *
  * Security:
- * - All endpoints require Bearer token + exafy_admin
+ * - All endpoints are protected by the `requireExafyAdmin` middleware.
  */
 
-import { Router, Request, Response } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { createClient } from '@supabase/supabase-js';
 import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, NotificationPayload } from '../services/notification-service';
@@ -24,15 +24,6 @@ const VTID = 'ADMIN-NOTIF-CATEGORIES';
 
 const VALID_TYPES = ['chat', 'calendar', 'community'];
 
-// ── Supabase ────────────────────────────────────────────────
-
-function getSupabase() {
-  return createClient(
-    process.env.SUPABASE_URL!,
-    process.env.SUPABASE_SERVICE_ROLE!
-  );
-}
-
 // ── Auth Helper ─────────────────────────────────────────────
 
 function getBearerToken(req: Request): string | null {
@@ -41,27 +32,42 @@ function getBearerToken(req: Request): string | null {
   return authHeader.slice(7);
 }
 
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
+// ── Auth Middleware ─────────────────────────────────────────
+
+async function requireExafyAdmin(req: Request, res: Response, next: NextFunction) {
   const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
+  if (!token) return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
 
   try {
     const userClient = createUserSupabaseClient(token);
     const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
+    if (authError || !authData?.user) {
+      return res.status(401).json({ ok: false, error: 'INVALID_TOKEN' });
+    }
 
     const appMetadata = authData.user.app_metadata || {};
     if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
+      return res.status(403).json({ ok: false, error: 'FORBIDDEN' });
     }
 
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
+    // Attach user info to request for downstream handlers
+    (req as any).authUser = { user_id: authData.user.id, email: authData.user.email || 'unknown' };
+    next();
   } catch (err: any) {
     console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
+    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
   }
+}
+
+router.use(requireExafyAdmin);
+
+// ── Supabase ────────────────────────────────────────────────
+
+function getSupabase() {
+  return createClient(
+    process.env.SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE!
+  );
 }
 
 // ── Slug helper ─────────────────────────────────────────────
@@ -76,9 +82,6 @@ function toSlug(name: string): string {
 // ── GET / — List all categories ─────────────────────────────
 
 router.get('/', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   const { type, tenant_id, include_inactive } = req.query;
 
@@ -120,9 +123,6 @@ router.get('/', async (req: Request, res: Response) => {
 // ── GET /:id — Get single category ─────────────────────────
 
 router.get('/:id', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   const { data, error } = await supabase
     .from('notification_categories')
@@ -140,8 +140,7 @@ router.get('/:id', async (req: Request, res: Response) => {
 // ── POST / — Create category ───────────────────────────────
 
 router.post('/', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
+  const { authUser } = req as any;
 
   const supabase = getSupabase();
   const {
@@ -181,7 +180,7 @@ router.post('/', async (req: Request, res: Response) => {
     default_enabled: default_enabled ?? true,
     mapped_types: mapped_types || [],
     tenant_id: tenant_id || null,
-    created_by: authResult.user_id,
+    created_by: authUser.user_id,
   };
 
   const { data, error } = await supabase
@@ -198,15 +197,14 @@ router.post('/', async (req: Request, res: Response) => {
     return res.status(500).json({ ok: false, error: error.message });
   }
 
-  console.log(`[${VTID}] Created category "${slug}" (${type}) by ${authResult.email}`);
+  console.log(`[${VTID}] Created category "${slug}" (${type}) by ${authUser.email}`);
   return res.status(201).json({ ok: true, data });
 });
 
 // ── PATCH /:id — Update category ────────────────────────────
 
 router.patch('/:id', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
+  const { authUser } = req as any;
 
   const supabase = getSupabase();
   const allowedFields = ['display_name', 'description', 'icon', 'sort_order', 'is_active', 'default_enabled', 'mapped_types'];
@@ -238,15 +236,14 @@ router.patch('/:id', async (req: Request, res: Response) => {
     return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
   }
 
-  console.log(`[${VTID}] Updated category "${data.slug}" by ${authResult.email}`);
+  console.log(`[${VTID}] Updated category "${data.slug}" by ${authUser.email}`);
   return res.json({ ok: true, data });
 });
 
 // ── DELETE /:id — Soft-delete (set is_active=false) ─────────
 
 router.delete('/:id', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
+  const { authUser } = req as any;
 
   const supabase = getSupabase();
   const { data, error } = await supabase
@@ -264,15 +261,14 @@ router.delete('/:id', async (req: Request, res: Response) => {
     return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
   }
 
-  console.log(`[${VTID}] Soft-deleted category "${data.slug}" by ${authResult.email}`);
+  console.log(`[${VTID}] Soft-deleted category "${data.slug}" by ${authUser.email}`);
   return res.json({ ok: true, data });
 });
 
 // ── POST /:id/test — Send test notification to admin ────────
 
 router.post('/:id/test', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
+  const { authUser } = req as any;
 
   const supabase = getSupabase();
 
@@ -300,15 +296,15 @@ router.post('/:id/test', async (req: Request, res: Response) => {
   const { data: tenantRow } = await supabase
     .from('user_tenants')
     .select('tenant_id')
-    .eq('user_id', authResult.user_id)
+    .eq('user_id', authUser.user_id)
     .limit(1)
     .single();
 
   const tenantId = tenantRow?.tenant_id || '00000000-0000-0000-0000-000000000000';
 
   try {
-    const result = await notifyUser(authResult.user_id, tenantId, testType, payload, supabase);
-    console.log(`[${VTID}] Test notification sent for category "${category.slug}" by ${authResult.email}`);
+    const result = await notifyUser(authUser.user_id, tenantId, testType, payload, supabase);
+    console.log(`[${VTID}] Test notification sent for category "${category.slug}" by ${authUser.email}`);
     return res.json({ ok: true, result });
   } catch (err: any) {
     console.error(`[${VTID}] POST /:id/test error:`, err.message);

--- a/services/gateway/test/routes/admin-notification-categories.test.ts
+++ b/services/gateway/test/routes/admin-notification-categories.test.ts
@@ -1,0 +1,167 @@
+import request from 'supertest';
+import express from 'express';
+import router from '../../src/routes/admin-notification-categories';
+import { createUserSupabaseClient } from '../../src/lib/supabase-user';
+import { createClient } from '@supabase/supabase-js';
+
+// Mock dependencies
+jest.mock('../../src/lib/supabase-user');
+jest.mock('@supabase/supabase-js');
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn().mockResolvedValue({ ok: true }),
+}));
+
+
+const mockCreateUserSupabaseClient = createUserSupabaseClient as jest.Mock;
+const mockCreateSupabaseClient = createClient as jest.Mock;
+
+const app = express();
+app.use(express.json());
+app.use('/', router);
+
+describe('Admin Notification Categories Routes', () => {
+  let mockSupabase: any;
+  
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    // Default mock for the service role client
+    mockSupabase = {
+      from: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      insert: jest.fn().mockReturnThis(),
+      update: jest.fn().mockReturnThis(),
+      delete: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      or: jest.fn().mockReturnThis(),
+      is: jest.fn().mockReturnThis(),
+      limit: jest.fn().mockReturnThis(),
+      single: jest.fn().mockResolvedValue({ data: { id: '123' }, error: null }),
+    };
+    mockCreateSupabaseClient.mockReturnValue(mockSupabase);
+  });
+
+  // --- Auth Middleware Tests ---
+
+  it('should return 401 if no Authorization header is provided', async () => {
+    const response = await request(app).get('/');
+    expect(response.status).toBe(401);
+    expect(response.body.error).toBe('UNAUTHENTICATED');
+  });
+
+  it('should return 401 if the token is invalid', async () => {
+    mockCreateUserSupabaseClient.mockReturnValue({
+      auth: {
+        getUser: jest.fn().mockResolvedValue({ data: { user: null }, error: { message: 'Invalid token' } }),
+      },
+    });
+
+    const response = await request(app).get('/').set('Authorization', 'Bearer invalid-token');
+    expect(response.status).toBe(401);
+    expect(response.body.error).toBe('INVALID_TOKEN');
+  });
+
+  it('should return 403 if the user is not an exafy_admin', async () => {
+    mockCreateUserSupabaseClient.mockReturnValue({
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: {
+            user: {
+              id: 'user-123',
+              email: 'test@example.com',
+              app_metadata: { exafy_admin: false },
+            },
+          },
+          error: null,
+        }),
+      },
+    });
+
+    const response = await request(app).get('/').set('Authorization', 'Bearer valid-non-admin-token');
+    expect(response.status).toBe(403);
+    expect(response.body.error).toBe('FORBIDDEN');
+  });
+
+  it('should allow access if the user is an exafy_admin', async () => {
+    // Mock user client for auth
+    mockCreateUserSupabaseClient.mockReturnValue({
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: {
+            user: {
+              id: 'admin-123',
+              email: 'admin@example.com',
+              app_metadata: { exafy_admin: true },
+            },
+          },
+          error: null,
+        }),
+      },
+    });
+
+    // Mock service client for the handler logic
+    mockSupabase.select.mockResolvedValue({ data: [], error: null });
+
+    const response = await request(app).get('/').set('Authorization', 'Bearer valid-admin-token');
+    
+    expect(response.status).toBe(200);
+    expect(response.body.ok).toBe(true);
+    expect(response.body.data).toEqual({ chat: [], calendar: [], community: [] }); // Check handler response
+    expect(mockCreateUserSupabaseClient).toHaveBeenCalledWith('valid-admin-token');
+  });
+
+  // --- Example handler test to confirm passthrough ---
+
+  it('POST / should create a category for an admin user', async () => {
+     // Mock user client for auth
+    mockCreateUserSupabaseClient.mockReturnValue({
+      auth: {
+        getUser: jest.fn().mockResolvedValue({
+          data: {
+            user: {
+              id: 'admin-user-id',
+              email: 'admin@example.com',
+              app_metadata: { exafy_admin: true },
+            },
+          },
+          error: null,
+        }),
+      },
+    });
+
+    const newCategory = {
+      type: 'chat',
+      display_name: 'New Test Category',
+      description: 'A test category',
+    };
+
+    const createdCategory = {
+      ...newCategory,
+      id: 'new-id-123',
+      slug: 'new_test_category',
+      created_by: 'admin-user-id',
+      is_active: true,
+      sort_order: 0,
+      default_enabled: true,
+      mapped_types: [],
+      tenant_id: null,
+    };
+
+    mockSupabase.single.mockResolvedValue({ data: createdCategory, error: null });
+
+    const response = await request(app)
+      .post('/')
+      .set('Authorization', 'Bearer valid-admin-token')
+      .send(newCategory);
+
+    expect(response.status).toBe(201);
+    expect(response.body.ok).toBe(true);
+    expect(response.body.data).toMatchObject(newCategory);
+    expect(mockSupabase.insert).toHaveBeenCalledWith(expect.objectContaining({
+        ...newCategory,
+        slug: 'new_test_category',
+        created_by: 'admin-user-id' // confirms user is passed from middleware
+    }));
+  });
+});


### PR DESCRIPTION
This pull request refactors the authentication and authorization logic in the `admin-notification-categories` API endpoint.

**Problem:**
The previous implementation performed authorization checks inline within each route handler (e.g., `GET /`, `POST /`). This duplicated logic and was flagged by security scanners as `missing_auth` because it did not use a standard Express middleware pattern.

**Solution:**
1.  The inline auth logic from `verifyExafyAdmin` has been extracted into a dedicated Express middleware function, `requireExafyAdmin`.
2.  This middleware is now applied to all routes in the file using `router.use(requireExafyAdmin)`.
3.  The individual handlers have been simplified, removing the redundant auth checks. The authenticated user's information is now attached to the `req` object by the middleware.
4.  A new test suite (`admin-notification-categories.test.ts`) has been added to verify the middleware's behavior, ensuring it correctly handles unauthenticated, unauthorized, and authorized admin requests.

This change improves maintainability, reduces code duplication, and aligns the endpoint with repository best practices for authentication.

**Files Touched:**
- `services/gateway/src/routes/admin-notification-categories.ts`: Modified to use middleware for auth.
- `services/gateway/test/routes/admin-notification-categories.test.ts`: Created to test the new auth middleware and route functionality.