### PR TITLE
fix(ops): tighten Action Required — 24h + cap 20 + filter dev_autopilot.* (VTID-02031b)

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -28874,6 +28874,7 @@ async function fetchActionRequired(silentRefresh) {
             state.actionRequired.items = Array.isArray(body.items) ? body.items : [];
             state.actionRequired.countTotal = Number(body.count_total || 0);
             state.actionRequired.countCritical = Number(body.count_critical || 0);
+            state.actionRequired.itemsReturned = Number(body.items_returned || state.actionRequired.items.length);
         }
     } catch (err) {
         state.actionRequired.error = (err && err.message) ? err.message : String(err);
@@ -28957,6 +28958,16 @@ function renderActionRequiredPanel() {
         ar.items.forEach(function (item) {
             list.appendChild(renderActionRequiredCard(item));
         });
+        // VTID-02031b: when the backend capped the list, surface the residual
+        // count so the supervisor knows there's more if they want to drill in.
+        var returned = ar.itemsReturned || ar.items.length;
+        if (ar.countTotal > returned) {
+            var moreLine = document.createElement('div');
+            moreLine.style.cssText = 'padding:0.45rem 0.55rem;font-size:0.74rem;color:rgba(229,231,235,0.65);text-align:center;font-style:italic;';
+            moreLine.textContent = 'Showing top ' + returned + ' of ' + ar.countTotal +
+                ' open items — see Self-Healing screen for the full list';
+            list.appendChild(moreLine);
+        }
         wrapper.appendChild(list);
     }
 

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -12,7 +12,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260427-vtid-02020-contextual-recovery"></script>
-  <script src="/command-hub/app.js?v=20260429-vtid-02031-action-required"></script>
+  <script src="/command-hub/app.js?v=20260429-vtid-02031b-action-required-cap"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
 </body>

--- a/services/gateway/src/routes/ops-action-required.ts
+++ b/services/gateway/src/routes/ops-action-required.ts
@@ -22,7 +22,21 @@ import { Router, Request, Response } from 'express';
 
 const router = Router();
 
-const ITEM_LOOKBACK_HOURS = 72; // window for self-heal escalations
+// VTID-02031b: tightened to 24h lookback so the panel surfaces only fresh
+// items needing supervisor action. Older escalations live in the dedicated
+// Self-Healing screen.
+const ITEM_LOOKBACK_HOURS = 24;
+// Cap the total list so the panel never dominates the Overview view.
+// Sorted by severity desc → detected_at desc, so critical-and-fresh wins.
+const MAX_ITEMS = 20;
+// VTID-02031b: dev-autopilot self-heals have their own dedicated dashboard
+// (Autopilot Developer + Self-Healing History) — surfacing them here too
+// just creates a duplicate signal. The panel is for *unique* human-action
+// items. Filter out endpoints that begin with these prefixes.
+const SELF_HEAL_ENDPOINT_BLOCKLIST = [
+  'dev_autopilot.',
+  'autopilot.', // generic autopilot.* heals also routine
+];
 
 function getSupabaseConfig(): { url: string; key: string } | null {
   const url = process.env.SUPABASE_URL;
@@ -143,25 +157,30 @@ async function fetchSelfHealEscalations(
       created_at: string;
       diagnosis: any;
     }>;
-    return rows.map((row) => {
-      const reason =
-        row.diagnosis?.reason ??
-        row.diagnosis?.tombstone_reason ??
-        row.outcome;
-      return {
-        id: `self-heal:${row.vtid}`,
-        severity: row.outcome === 'rolled_back' ? 'critical' : ('warning' as 'critical' | 'warning'),
-        category: 'self-heal',
-        title: `Self-healing ${row.outcome}: ${row.endpoint}`,
-        summary:
-          `VTID ${row.vtid} (${row.failure_class ?? 'unknown class'}) — ${reason}.` +
-          ` Endpoint still requires manual investigation.`,
-        detected_at: row.created_at,
-        deeplink: `/command-hub/autonomy/self-healing/?vtid=${encodeURIComponent(row.vtid)}`,
-        source_table: 'self_healing_log',
-        source_id: row.vtid,
-      };
-    });
+    return rows
+      .filter((row) => {
+        const ep = row.endpoint || '';
+        return !SELF_HEAL_ENDPOINT_BLOCKLIST.some((prefix) => ep.startsWith(prefix));
+      })
+      .map((row) => {
+        const reason =
+          row.diagnosis?.reason ??
+          row.diagnosis?.tombstone_reason ??
+          row.outcome;
+        return {
+          id: `self-heal:${row.vtid}`,
+          severity: row.outcome === 'rolled_back' ? 'critical' : ('warning' as 'critical' | 'warning'),
+          category: 'self-heal',
+          title: `Self-healing ${row.outcome}: ${row.endpoint}`,
+          summary:
+            `VTID ${row.vtid} (${row.failure_class ?? 'unknown class'}) — ${reason}.` +
+            ` Endpoint still requires manual investigation.`,
+          detected_at: row.created_at,
+          deeplink: `/command-hub/autonomy/self-healing/?vtid=${encodeURIComponent(row.vtid)}`,
+          source_table: 'self_healing_log',
+          source_id: row.vtid,
+        };
+      });
   } catch {
     return [];
   }
@@ -180,18 +199,29 @@ router.get('/', async (_req: Request, res: Response) => {
     fetchSelfHealEscalations(config),
   ]);
 
-  // Concatenate and sort by detected_at desc (most recent first).
-  const items: ActionItem[] = [...quarantines, ...reports, ...escalations].sort(
-    (a, b) => (a.detected_at < b.detected_at ? 1 : -1),
+  // Sort: critical first, then by detected_at desc within each severity.
+  const all: ActionItem[] = [...quarantines, ...reports, ...escalations].sort(
+    (a, b) => {
+      if (a.severity !== b.severity) {
+        return a.severity === 'critical' ? -1 : 1;
+      }
+      return a.detected_at < b.detected_at ? 1 : -1;
+    },
   );
 
-  const count_critical = items.filter((i) => i.severity === 'critical').length;
+  const count_total = all.length;
+  const count_critical = all.filter((i) => i.severity === 'critical').length;
+  // VTID-02031b: cap surfaced items so the panel never dominates the view.
+  // Total count + critical count are still reported truthfully so the
+  // operator knows there's more if they want to drill in.
+  const items = all.slice(0, MAX_ITEMS);
 
   return res.json({
     ok: true,
     generated_at: new Date().toISOString(),
-    count_total: items.length,
+    count_total,
     count_critical,
+    items_returned: items.length,
     items,
   });
 });


### PR DESCRIPTION
## Summary

VTID-02031 deployed but surfaced **111 items** because the 72h lookback included every \`dev_autopilot.*\` escalation from the last three days. Most of those are routine and have their own dashboard — they made the panel unusable.

Three changes:

1. **24h lookback** instead of 72h.
2. **Cap at top 20** items, sorted critical-first then recency-desc. \`count_total\` + \`count_critical\` still reported truthfully.
3. **Filter \`dev_autopilot.*\` / \`autopilot.*\`** self-heal endpoints — they have a dedicated dashboard.

Frontend shows \"Showing top N of M — see Self-Healing screen for the full list\" when truncated.

## Touched files

- \`services/gateway/src/routes/ops-action-required.ts\` — constants + filter + sort + cap
- \`services/gateway/src/frontend/command-hub/app.js\` — capture items_returned + truncation hint
- \`services/gateway/src/frontend/command-hub/index.html\` — cache-buster

## Test plan

- [x] Typecheck clean
- [ ] After deploy: \`curl /api/v1/ops/action-required\` → expect ~5-10 items, count_total drops, dev-autopilot rows gone
- [ ] Reload Overview → panel shows tight list with truncation hint if applicable

🤖 Generated with [Claude Code](https://claude.com/claude-code)