### PR TITLE
fix(spec): add feedback module to dev-screen-inventory-v1.json

### DIFF
--- a/services/gateway/specs/dev-screen-inventory-v1.json
+++ b/services/gateway/specs/dev-screen-inventory-v1.json
@@ -20,7 +20,8 @@
     "models-evaluations",
     "testing-qa",
     "intelligence-memory-dev",
-    "docs"
+    "docs",
+    "feedback"
   ],
   "module_catalog": {
     "overview": [
@@ -169,11 +170,17 @@
       "database-schemas",
       "architecture",
       "workforce",
-      "system-knowledge"
+      "system-knowledge",
+      "specialists"
+    ],
+    "feedback": [
+      "inbox",
+      "handoffs",
+      "kpis"
     ]
   },
   "screen_inventory": {
-    "total_screens": 110,
+    "total_screens": 114,
     "total_entries": 289,
     "last_synced": "2026-04-25",
     "source": "auto-regen via services/gateway/scripts/regen-screens-catalog.mjs",


### PR DESCRIPTION
## Summary

Recent feedback PRs (VTID-02047, VTID-02603, VTID-02604, VTID-02605) added a \`feedback\` module to \`navigation-config.js\` and an extra \`specialists\` tab under \`docs\` but **did not update the canonical screen inventory spec**. Result: Gateway Validation (Minimal CI) has been failing on every subsequent PR (caught by VTID-02031b).

## Changes

\`services/gateway/specs/dev-screen-inventory-v1.json\`:
- Add \`feedback\` to \`sidebar_navigation\` (19 → 20 modules)
- Add \`module_catalog.feedback\` = \`[inbox, handoffs, kpis]\`
- Add \`specialists\` to \`module_catalog.docs\`
- Bump \`total_screens\` 110 → 114

## Test plan

- [x] Local validator: \`node ./scripts/validate-dev-frontend-spec.mjs\` → \`FRONTEND SPEC OK · 20/20 modules · 114/114 screens\`
- [ ] Gateway Validation (Minimal CI) check passes on this PR

🤖 Generated with [Claude Code](https://claude.com/claude-code)