### PR TITLE
fix(spec): reconcile dev-screen-inventory with nav-config (BOOTSTRAP-DEV-SPEC-RECONCILE)

### DIFF
--- a/services/gateway/specs/dev-screen-inventory-v1.json
+++ b/services/gateway/specs/dev-screen-inventory-v1.json
@@ -20,7 +20,8 @@
     "models-evaluations",
     "testing-qa",
     "intelligence-memory-dev",
-    "docs"
+    "docs",
+    "feedback"
   ],
   "module_catalog": {
     "overview": [
@@ -169,11 +170,17 @@
       "database-schemas",
       "architecture",
       "workforce",
-      "system-knowledge"
+      "system-knowledge",
+      "specialists"
+    ],
+    "feedback": [
+      "inbox",
+      "handoffs",
+      "kpis"
     ]
   },
   "screen_inventory": {
-    "total_screens": 110,
+    "total_screens": 114,
     "total_entries": 289,
     "last_synced": "2026-04-25",
     "source": "auto-regen via services/gateway/scripts/regen-screens-catalog.mjs",


### PR DESCRIPTION
## Summary

Recent PRs (#1079/#1080 added Feedback module; an earlier PR added Specialists tab to Docs) updated `navigation-config.js` but did NOT update the canonical `dev-screen-inventory-v1.json` spec. CI's `Validate Dev frontend navigation spec` check enforces strict equality between the two — so every PR opened on top of main has been failing CI on a check that has nothing to do with the PR's actual changes.

Confirmed via dev autopilot: 6 PRs from 2 LLM providers (Vertex Gemini 3 Pro + DeepSeek-Reasoner) all failed at this exact check despite producing high-quality, scope-respecting code changes.

This unblocks every gateway PR merge.

## Changes

- `sidebar_navigation`: append `"feedback"` (now 20 entries)
- `module_catalog.docs`: append `"specialists"` (now 7 tabs)
- `module_catalog`: add `"feedback"` with `["inbox", "handoffs", "kpis"]`
- `screen_inventory.total_screens`: `110 → 114`

## Validation (local)

```
🔍 DEV-CICDL-0205: Validating Dev Frontend Navigation Spec...
✅ FRONTEND SPEC OK
   ├─ Modules: 20 (expected: 20)
   ├─ Screens: 114 (expected: 114)
   └─ Order: Canonical
```

🤖 Generated with [Claude Code](https://claude.com/claude-code)