### PR TITLE
feat(reminders): FCM web push fallback for closed-app delivery (VTID-02601)

### DIFF
--- a/services/gateway/src/routes/scheduled-notifications.ts
+++ b/services/gateway/src/routes/scheduled-notifications.ts
@@ -856,6 +856,16 @@ router.post('/reminders-tick', async (_req: Request, res: Response) => {
             },
           });
         } catch {}
+
+        // VTID-02601 FCM fallback: 5s after fire, if SSE didn't ack the row,
+        // send an OS-level push notification so the user gets the reminder
+        // even if the app is closed / phone locked / WebView suspended.
+        // SSE wins for active clients (it acks within ~3s); FCM catches the
+        // rest. Best-effort, fully detached — does not block the tick.
+        scheduleReminderFcmFallback(supa, row).catch((e) =>
+          console.warn(`[reminders-tick] FCM fallback schedule failed for ${row.id}:`, e?.message),
+        );
+
         fired++;
       } catch (err: any) {
         console.error(`[reminders-tick] error firing ${row.id}:`, err?.message);
@@ -924,6 +934,87 @@ router.post('/reminders-sweeper', async (_req: Request, res: Response) => {
     return res.status(500).json({ ok: false, error: err?.message || 'internal' });
   }
 });
+
+// =============================================================================
+// VTID-02601 — scheduleReminderFcmFallback
+//
+// 5 seconds after a reminder is marked 'fired', re-check `acked_at`. If the
+// SSE listener already acked the row (because the app is open and the user
+// got the chime + voice + banner), skip — the user has been notified. If
+// not, send an FCM web push so the OS surfaces a notification. Also try
+// Appilix native push for the Maxina installed app (currently 522 per memory,
+// but worth retrying — fails silently if API is down).
+//
+// Detached from the request handler — Cloud Run keeps the function instance
+// alive long enough for the 5-second timer because the gateway has CPU
+// always-on (set in EXEC-DEPLOY). Worst case (instance scales to zero),
+// the FCM is dropped and the next tick poll picks it up via the existing
+// fired+unacked SSE flow.
+// =============================================================================
+async function scheduleReminderFcmFallback(
+  supa: any,
+  row: { id: string; user_id: string; tenant_id: string; action_text: string; spoken_message: string | null }
+): Promise<void> {
+  await new Promise((r) => setTimeout(r, 5000));
+
+  // Re-check acked_at — SSE may have already delivered + the user dismissed.
+  const { data: fresh } = await supa
+    .from('reminders')
+    .select('id, acked_at, delivery_via')
+    .eq('id', row.id)
+    .maybeSingle();
+  if (fresh?.acked_at) {
+    console.log(`[reminders-tick] FCM skip — already acked via ${fresh.delivery_via} (${row.id})`);
+    return;
+  }
+
+  const payload = {
+    title: '🔔 Reminder',
+    body: row.action_text,
+    data: {
+      type: 'reminder.fire',
+      reminder_id: row.id,
+      url: '/reminders',
+      spoken_message: row.spoken_message || '',
+    },
+  };
+
+  try {
+    const fcmSent = await sendPushToUser(row.user_id, row.tenant_id, payload, supa);
+    const appilixSent = await sendAppilixPush(row.user_id, payload);
+    console.log(`[reminders-tick] FCM fallback for ${row.id}: fcm=${fcmSent} appilix=${appilixSent}`);
+
+    // Mark delivery_via=fcm if we sent at least one push and the row is still
+    // unacked. The SSE flow may still race-deliver later — that's fine, the
+    // overlay's seen-set dedups so the user never sees the same fire twice.
+    if (fcmSent > 0 || appilixSent) {
+      await supa
+        .from('reminders')
+        .update({ delivery_via: 'fcm' })
+        .eq('id', row.id)
+        .is('acked_at', null);
+    }
+
+    try {
+      const { emitOasisEvent } = await import('../services/oasis-event-service');
+      await emitOasisEvent({
+        type: 'reminder.fcm_fallback' as any,
+        source: 'gateway',
+        vtid: 'VTID-REMINDER',
+        status: 'info',
+        message: `Reminder FCM fallback sent`,
+        payload: {
+          reminder_id: row.id,
+          user_id: row.user_id,
+          fcm_devices: fcmSent,
+          appilix_sent: !!appilixSent,
+        },
+      });
+    } catch {}
+  } catch (err: any) {
+    console.error(`[reminders-tick] FCM fallback error for ${row.id}:`, err?.message);
+  }
+}
 
 // =============================================================================
 // Health check


### PR DESCRIPTION
Closes the gap user reported: reminders only fire when the app is open. Now they also surface as OS notifications when the app is closed or the phone is locked.

## Behavior

- 5 seconds after a reminder is marked fired, re-check acked_at
- If SSE already acked (active client got the chime + banner) → skip FCM
- If unacked → send FCM web push to all the users registered tokens. Tap on the OS notification opens /reminders
- Also tries sendAppilixPush for the Maxina installed app (currently 522 per memory, best-effort)
- Records delivery_via=fcm on the row
- Emits reminder.fcm_fallback OASIS event

## Caveat (per memory)

- Chrome mobile browser → FCM web push works, OS notification arrives reliably
- Maxina installed app (Appilix WebView) → no Notification API in the WebView, FCM web push does not surface. The Appilix native push API has been 522 since mid-March. Real fix is V2 native bridge work.

For user dragan1: testing on Chrome mobile browser (not the Maxina app) will give the closed-app delivery they want today.

## Verified

- tsc clean
- Detached setTimeout is safe on Cloud Run because the gateway has CPU always-on; instance stays alive for the 5s timer.

🤖 Generated with [Claude Code](https://claude.com/claude-code)