### PR TITLE
feat(profile-prefs+orb): cross-user filtered prefs + voice expectation copy + navigate targets (VTID-02633)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -2652,6 +2652,11 @@ function buildLiveApiTools(
             "  intent_match_detail      → /intents/match/<match_id> (a specific match)",
             "  intent_post_public       → /p/<intent_id> (public viewer for a specific post)",
             "  edit_dance_preferences   → /profile/edit?drawer=dance",
+            "  edit_partner_preferences → /me/profile?drawer=partner (private-by-default partner-finding prefs)",
+            "  edit_service_offerings   → /me/profile?drawer=offerings (services I offer)",
+            "  privacy_settings         → /profile/me/privacy (per-section visibility toggles)",
+            "  profile_with_match       → /u/<vitana_id>?match_intent=<intent_id> (matched user's profile with the matched post anchored)",
+            "  discover_marketplace     → /discover/marketplace (commercial intents)",
             "  events_meetups           → /comm/events-meetups",
             "  community_feed           → /comm/feed",
             '',
@@ -2672,12 +2677,15 @@ function buildLiveApiTools(
                   'find_partner','find_partner_matches','find_partner_board','find_partner_posts',
                   'my_intents','intent_board','intent_board_dance',
                   'open_asks','members',
-                  'intent_match_detail','intent_post_public',
-                  'edit_dance_preferences','events_meetups','community_feed',
+                  'intent_match_detail','intent_post_public','profile_with_match',
+                  'edit_dance_preferences','edit_partner_preferences','edit_service_offerings',
+                  'privacy_settings','discover_marketplace',
+                  'events_meetups','community_feed',
                 ],
               },
-              intent_id: { type: 'string', description: 'For intent_post_public target.' },
+              intent_id: { type: 'string', description: 'For intent_post_public + profile_with_match (the matched intent_id).' },
               match_id: { type: 'string', description: 'For intent_match_detail target.' },
+              vitana_id: { type: 'string', description: 'For profile_with_match — the counterparty\'s vitana_id (without leading @).' },
             },
             required: ['target'],
           },
@@ -5788,6 +5796,7 @@ async function executeLiveApiToolInner(
         const target = String(args.target || '').trim();
         const intentId = args.intent_id ? String(args.intent_id).trim() : null;
         const matchId = args.match_id ? String(args.match_id).trim() : null;
+        const vitanaIdArg = args.vitana_id ? String(args.vitana_id).trim().replace(/^@/, '') : null;
         if (!target) return { success: false, result: '', error: 'target is required' };
 
         let url = '';
@@ -5808,7 +5817,22 @@ async function executeLiveApiToolInner(
           case 'intent_post_public':
             if (!intentId) return { success: false, result: '', error: 'intent_id is required for intent_post_public' };
             url = `/p/${encodeURIComponent(intentId)}`; title = 'Post detail'; break;
+          // E3 — profile-first match presentation. Lands on the matched
+          // user's PublicProfilePage with the matched post anchored.
+          case 'profile_with_match': {
+            if (!vitanaIdArg) return { success: false, result: '', error: 'vitana_id is required for profile_with_match' };
+            const params = new URLSearchParams();
+            if (intentId) params.set('match_intent', intentId);
+            const qs = params.toString();
+            url = `/u/${encodeURIComponent(vitanaIdArg)}${qs ? '?' + qs : ''}`;
+            title = 'Profile';
+            break;
+          }
           case 'edit_dance_preferences':   url = '/profile/edit?drawer=dance'; title = 'Dance preferences'; break;
+          case 'edit_partner_preferences': url = '/me/profile?drawer=partner'; title = 'Partner preferences'; break;
+          case 'edit_service_offerings':   url = '/me/profile?drawer=offerings'; title = 'Service offerings'; break;
+          case 'privacy_settings':         url = '/profile/me/privacy'; title = 'Privacy & Visibility'; break;
+          case 'discover_marketplace':     url = '/discover/marketplace'; title = 'Marketplace'; break;
           case 'events_meetups':           url = '/comm/events-meetups'; title = 'Events & meetups'; break;
           case 'community_feed':           url = '/comm/feed'; title = 'Community feed'; break;
           default:

--- a/services/gateway/src/routes/profile-prefs.ts
+++ b/services/gateway/src/routes/profile-prefs.ts
@@ -12,6 +12,11 @@ import { Router, Request, Response } from 'express';
 import { requireAuth, requireTenant, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
 import { getSupabase } from '../lib/supabase';
 import { emitOasisEvent } from '../services/oasis-event-service';
+import {
+  applyAccountVisibility,
+  getViewerRelationship,
+  type FieldVisibility,
+} from '../lib/account-visibility';
 
 const router = Router();
 
@@ -163,6 +168,94 @@ router.get('/profiles/me/prefs', requireAuth, requireTenant, async (req: Request
     partner_preferences: (data as any)?.partner_preferences ?? {},
     service_offerings: (data as any)?.service_offerings ?? {},
     account_visibility: (data as any)?.account_visibility ?? {},
+  });
+});
+
+/**
+ * E5 server-side filter: cross-user GET that returns the SUBJECT's prefs
+ * filtered through their account_visibility map and the viewer's
+ * relationship. Self-reads return the full payload.
+ */
+router.get('/profiles/:vitana_id/prefs', requireAuth, requireTenant, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const rawVid = String(req.params.vitana_id || '').replace(/^@/, '').toLowerCase().trim();
+  if (!rawVid) return res.status(400).json({ ok: false, error: 'vitana_id_required' });
+
+  const supabase = getSupabase();
+  if (!supabase) return res.status(500).json({ ok: false, error: 'supabase_unavailable' });
+
+  const { data: subject, error } = await supabase
+    .from('profiles')
+    .select('user_id, partner_preferences, service_offerings, account_visibility')
+    .eq('vitana_id', rawVid)
+    .maybeSingle();
+
+  if (error) return res.status(500).json({ ok: false, error: error.message });
+  if (!subject) return res.status(404).json({ ok: false, error: 'profile_not_found' });
+
+  const subjectUserId = (subject as any).user_id as string;
+  const visMap = ((subject as any).account_visibility ?? {}) as Record<string, FieldVisibility>;
+  const partnerPrefs = ((subject as any).partner_preferences ?? {}) as Record<string, any>;
+  const serviceOfferings = ((subject as any).service_offerings ?? {}) as Record<string, any>;
+
+  const relationship = await getViewerRelationship(identity.user_id, subjectUserId);
+
+  // Section gates first.
+  const partnerSectionAllowed =
+    relationship === 'self' ||
+    visMap['partnerPreferences'] === 'public' ||
+    (visMap['partnerPreferences'] === 'connections' && relationship === 'connection');
+
+  const serviceSectionAllowed =
+    relationship === 'self' ||
+    // service_offerings defaults to 'public'.
+    visMap['serviceOfferings'] !== 'private' &&
+      !(visMap['serviceOfferings'] === 'connections' && relationship === 'stranger');
+
+  // Sub-field-level redaction inside an allowed partner section.
+  const partnerFiltered = partnerSectionAllowed
+    ? applyAccountVisibility(
+        partnerPrefs,
+        visMap,
+        relationship,
+        {
+          age_range: 'partnerPreferences.ageRange',
+          gender_pref: 'partnerPreferences.gender',
+          relationship_intent: 'partnerPreferences.relationshipIntent',
+          location_label: 'partnerPreferences.locationRadius',
+          max_radius_km: 'partnerPreferences.locationRadius',
+          // unknown key → falls back to private default → stripped for non-self.
+          deal_breakers: 'partnerPreferences.dealBreakers__self_only',
+        }
+      )
+    : {};
+
+  // Service offerings: hide priceRange when its tier blocks the viewer.
+  let serviceFiltered: Record<string, any> = {};
+  if (serviceSectionAllowed) {
+    const showPrice =
+      relationship === 'self' ||
+      visMap['serviceOfferings.priceRange'] === 'public' ||
+      (visMap['serviceOfferings.priceRange'] === 'connections' && relationship === 'connection') ||
+      visMap['serviceOfferings.priceRange'] === undefined; // default public
+    const offers = Array.isArray(serviceOfferings.offers) ? serviceOfferings.offers : [];
+    serviceFiltered = {
+      offers: offers.map((o: any) =>
+        showPrice
+          ? o
+          : { ...o, price_min_cents: null, price_max_cents: null, currency: null }
+      ),
+    };
+  }
+
+  return res.json({
+    ok: true,
+    vitana_id: rawVid,
+    relationship,
+    partner_preferences: partnerFiltered,
+    service_offerings: serviceFiltered,
   });
 });
 

--- a/services/gateway/src/services/matchmaker-agent.ts
+++ b/services/gateway/src/services/matchmaker-agent.ts
@@ -300,10 +300,31 @@ export async function runMatchmakerForIntent(intentId: string): Promise<Matchmak
     pool_size: poolSize,
     candidates: agentResponse.candidates,
     counter_questions: agentResponse.counter_questions,
-    voice_readback: agentResponse.voice_readback,
+    voice_readback: applyExpectationCopy(agentResponse.voice_readback, mode, poolSize),
     reasoning_summary: agentResponse.reasoning_summary,
     used_fallback: profileFallback.length > 0,
   };
+}
+
+/**
+ * E3 — time-bound expectation copy. Until 2026-09-01 we append a short
+ * honesty paragraph to the voice readback for solo/early modes so users
+ * understand match approximation reflects community size, not engine
+ * quality. Sunsets automatically — after 2026-09-01 the function
+ * returns the readback unchanged.
+ */
+const EXPECTATION_SUNSET = Date.parse('2026-09-01T00:00:00Z');
+const EXPECTATION_COPY =
+  " Quick note — our community is still growing. The more precise you are about style, time and location, the better your matches, but I'll find you something even with broad criteria. Match quality sharpens as more people join.";
+
+function applyExpectationCopy(readback: string, mode: 'solo' | 'early' | 'growth', poolSize: number): string {
+  if (!readback) return readback;
+  if (Date.now() >= EXPECTATION_SUNSET) return readback;
+  if (mode === 'growth' && poolSize >= 50) return readback;
+  // Don't double-append if the model already mentioned community size.
+  const lower = readback.toLowerCase();
+  if (lower.includes('community is still growing') || lower.includes('still growing')) return readback;
+  return readback.trimEnd() + EXPECTATION_COPY;
 }
 
 // ─── Context loaders ────────────────────────────────────────────


### PR DESCRIPTION
## Summary

Two related additions in one PR — both unblock the v1-side companion PR.

**E5 server-side filter** — new `GET /api/v1/profiles/:vitana_id/prefs` endpoint that returns the SUBJECT's `partner_preferences` + `service_offerings` filtered through their `account_visibility` map and the viewer's relationship (`self` / `connection` / `stranger`). Section-level gates first, then sub-field redaction (age, gender, relationship_intent, locationRadius). Deal-breakers always self-only. Service `priceRange` redacted per-row when blocked.

**E3 voice journey** — adds time-bound expectation copy and 5 new `navigate_to_screen` targets:
- `applyExpectationCopy()` appends an honesty paragraph to `voice_readback` for `solo` + `early` modes (poolSize < 50). Sunsets automatically on **2026-09-01** — no code change needed.
- New nav targets: `profile_with_match`, `edit_partner_preferences`, `edit_service_offerings`, `privacy_settings`, `discover_marketplace`. `profile_with_match` is the profile-first match presentation per the PART 5 plan.

## Pairs with

[exafyltd/vitana-v1#TBD](https://github.com/exafyltd/vitana-v1) — frontend wires the cross-user reads on the public profile sections, ships PrivacySettings + Marketplace + MyPostsSection, and adds the new navigate targets to `useVitanaOrbTools`.

## Test plan

- [ ] `npx tsc --noEmit` — passes
- [ ] After deploy: `GET /api/v1/profiles/<some-vid>/prefs` as a stranger returns `relationship: "stranger"` and an empty `partner_preferences` (default-private)
- [ ] Same call as the owner returns full `partner_preferences`
- [ ] Time-bound copy: `voice_readback` from a `solo` matchmaker run contains `"still growing"` while clock < 2026-09-01
- [ ] ORB voice: "open the marketplace" / "show me my matches" / "open her profile" each navigate correctly

🤖 Generated with [Claude Code](https://claude.com/claude-code)
