### PR TITLE
chore(autopilot): pause auto-approve + arm kill_switch (BOOTSTRAP-CONTAIN-DEV-AUTOPILOT)

### DIFF
--- a/supabase/migrations/20260430120000_BOOTSTRAP_pause_dev_autopilot_auto_approve.sql
+++ b/supabase/migrations/20260430120000_BOOTSTRAP_pause_dev_autopilot_auto_approve.sql
@@ -1,0 +1,60 @@
+-- =============================================================================
+-- Containment: pause Dev Autopilot auto-approve + arm kill switch
+-- =============================================================================
+-- We discovered Dev Autopilot has been generating low-quality, duplicate, and
+-- in some cases dangerous PRs (modified an applied migration, proposed wrong
+-- column rename `vitana_id` -> `vuid`, opened 6 identical middleware refactor
+-- PRs against the same finding).
+--
+-- Root causes (to be fixed in follow-up PRs):
+--   1. No "finding -> completed" state transition after PR merges, so
+--      autoApproveTick() re-approves the same finding and opens N PRs.
+--   2. Planner prompt has zero live DB schema context -> hallucinated columns.
+--   3. No plan-vs-diff validator -> dead-code placeholders shipped as PRs.
+--
+-- Until the fixes land, this migration disarms the autopilot:
+--   * auto_approve_enabled = FALSE  -> autoApproveTick() becomes a no-op
+--   * kill_switch          = TRUE   -> belt-and-suspenders panic flag
+--
+-- Reversal: re-run a follow-up migration that flips both back, OR call the
+-- existing POST /api/v1/dev-autopilot/config/kill-switch endpoint with
+-- {"armed": false} once the fixes are deployed.
+-- =============================================================================
+
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+UPDATE public.dev_autopilot_config
+   SET auto_approve_enabled = FALSE,
+       kill_switch          = TRUE,
+       updated_at           = NOW()
+ WHERE id = 1;
+
+DO $$
+DECLARE
+  v_auto_approve BOOLEAN;
+  v_kill_switch  BOOLEAN;
+BEGIN
+  SELECT auto_approve_enabled, kill_switch
+    INTO v_auto_approve, v_kill_switch
+    FROM public.dev_autopilot_config
+   WHERE id = 1;
+
+  IF v_auto_approve IS NULL THEN
+    RAISE EXCEPTION 'dev_autopilot_config row id=1 not found - migration aborted';
+  END IF;
+
+  IF v_auto_approve <> FALSE THEN
+    RAISE EXCEPTION 'auto_approve_enabled did not flip to FALSE (got %)', v_auto_approve;
+  END IF;
+
+  IF v_kill_switch <> TRUE THEN
+    RAISE EXCEPTION 'kill_switch did not flip to TRUE (got %)', v_kill_switch;
+  END IF;
+
+  RAISE NOTICE 'Containment applied: auto_approve_enabled=%, kill_switch=%',
+               v_auto_approve, v_kill_switch;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
## Summary

**Containment-only migration.** Pauses Dev Autopilot's auto-approve loop and arms the kill switch while we ship root-cause fixes.

## Why now

We just had to close ~20 Dev Autopilot PRs in a single sweep. Of those, **4 were dangerous**:

| PR | Issue |
|----|-------|
| #1086 | Modified an already-applied migration (\`20251209000000_add_task_stage.sql\`) |
| #1091 | Hallucinated column rename \`vitana_id\` → \`vuid\` (would break auth) |
| #1093 | "Fixed" \`oasis_events_v1.event_type\` queries that don't exist on main |
| #1102 | Shipped dead-code placeholder (\`safety-gap.ts\`, never imported) |

And **6 identical** \`admin-notification-categories\` middleware-refactor PRs all targeted the same finding.

## Root causes (to be fixed in follow-up PRs)

1. **No \`finding → completed\` state transition.** After a PR merges, the \`autopilot_recommendations\` row stays \`status='new'\`, so \`autoApproveTick()\` re-approves the same finding on the next pass and opens N PRs.
2. **Planner has zero live-schema context.** LLM hallucinates column names, queries non-existent views, modifies migrations.
3. **No plan-vs-diff validator.** Plan claims to touch 4 files; executor ships 1 placeholder; PR opens anyway.

## What this PR does

\`\`\`sql
UPDATE public.dev_autopilot_config
   SET auto_approve_enabled = FALSE,
       kill_switch          = TRUE,
       updated_at           = NOW()
 WHERE id = 1;
\`\`\`

- \`auto_approve_enabled = FALSE\` → \`autoApproveTick()\` short-circuits at \`services/gateway/src/services/dev-autopilot-execute.ts:1716\`.
- \`kill_switch = TRUE\` → belt-and-suspenders panic flag.
- Wrapped in \`BEGIN; ... COMMIT;\` with \`ON_ERROR_STOP\` and a \`DO \$\$\` verifier so we don't get the silent \`ROLLBACK\` problem.

**SQL-only PR — no gateway code touched, exempt from VTID HARD GATE.**

## How to apply

After merge, dispatch \`RUN-MIGRATION.yml\` with:
\`\`\`
migration_file = supabase/migrations/20260430120000_BOOTSTRAP_pause_dev_autopilot_auto_approve.sql
\`\`\`

## Reversal

Once Fix PRs ship and deploy, either:
- Re-run a follow-up migration that flips both back, OR
- \`POST /api/v1/dev-autopilot/config/kill-switch {"armed": false}\` (existing endpoint at \`services/gateway/src/routes/dev-autopilot.ts:1056\`).

## Test plan

- [ ] Merge PR
- [ ] Dispatch RUN-MIGRATION.yml manually
- [ ] Grep run logs for \`ROLLBACK\` and \`Containment applied:\` NOTICE
- [ ] Confirm \`GET /api/v1/dev-autopilot/config\` returns \`auto_approve_enabled: false\`, \`kill_switch: true\`
- [ ] Watch OASIS for absence of \`dev_autopilot.execution.auto_approved\` events going forward

🤖 Generated with [Claude Code](https://claude.com/claude-code)