### PR TITLE
fix(orb-resolver): force tool binding + relaxed threshold for chat peers (VTID-02647)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -2343,16 +2343,33 @@ function buildLiveApiTools(
           name: 'resolve_recipient',
           description: [
             'Resolve a spoken recipient name or Vitana ID to a real user.',
-            'Call this FIRST any time the user says "send a message to X",',
-            '"text X", "share this with X", "tell X that ...", "invite X",',
-            'or any other phrase where X is meant to be another Vitana user.',
+            '',
+            'YOU MUST CALL THIS before any reply about whether a person',
+            'exists — including saying you can\'t find them. The ONLY way',
+            'to honestly tell the user "I can\'t find that person" is to',
+            'receive an empty candidates array from this tool. Without',
+            'calling, you have no contact list to consult and you will',
+            'hallucinate. Do not infer absence from your own knowledge.',
+            '',
+            'Trigger phrases (call this on ALL of them):',
+            '  - "send a message to X" / "text X" / "tell X that ..."',
+            '  - "share this with X" / "invite X" / "introduce me to X"',
+            '  - "is X here?" / "do we have someone called X?"',
+            '',
+            'Spoken_name handling for hint phrases:',
+            '  - User says "Maria, I think it\'s maria6": pass spoken_name="maria6"',
+            '    first (the Vitana ID is the strongest signal). If empty,',
+            '    retry with spoken_name="maria".',
+            '  - User says "@alex3700": pass spoken_name="alex3700" (the',
+            '    resolver strips leading @).',
+            '  - User says "Daniela": pass spoken_name="Daniela".',
             '',
             'Returns ranked candidates. Each has:',
             '  - user_id (opaque UUID — pass to send_chat_message / share_link)',
             '  - vitana_id (speakable, e.g. "alex3700" — read this to the user)',
             '  - display_name (their full name)',
-            '  - score (0.00-1.10; 1.0 = exact vitana_id match)',
-            '  - reason ("vitana_id_exact" | "legacy_handle" | "fuzzy_name")',
+            '  - score (0.00-1.25; 1.0 = exact vitana_id match)',
+            '  - reason ("vitana_id_exact" | "legacy_handle" | "fuzzy_name" | "fuzzy_chat_peer")',
             '',
             'Also returns top_confidence and ambiguous (boolean).',
             '',
@@ -9909,6 +9926,23 @@ async function generateMemoryEnhancedSystemInstruction(
   // Load text_chat personality config
   const textChatConfig = getPersonalityConfigSync('text_chat') as Record<string, any>;
 
+  // Hard contract for tool-bound flows the LLM keeps skipping. Empirically
+  // Gemini Live sometimes answers "I can't find that user" without ever
+  // calling resolve_recipient — especially when the spoken phrase contains
+  // a hint like "I think it's maria6". This block makes the binding
+  // explicit at the system-instruction level (tool description alone wasn't
+  // enough). Same pattern for navigation.
+  const MESSAGING_CONTRACT = `
+
+## MESSAGING & SHARING CONTRACT (NON-NEGOTIABLE)
+
+If the user mentions sending a message, sharing a link, texting, inviting, or telling someone something, you MUST:
+1. Call resolve_recipient(spoken_name) BEFORE saying anything about whether the recipient exists. The ONLY way to honestly say "I can't find that user" is to receive an empty candidates array from resolve_recipient. Do not infer absence from your own context — you do not have the user's contact list.
+2. If the spoken phrase contains a name AND a Vitana ID hint ("Maria, I think it's maria6"), pass the Vitana ID hint as spoken_name first; if that returns 0 candidates, retry with the name.
+3. After resolve_recipient returns, follow the readback contract from the tool description (read back, await explicit confirmation, then send_chat_message).
+
+If the user asks to be shown a screen, list, or detail page, call navigate_to_screen — never claim a page doesn't exist without trying. The frontend handles routing; you handle the call.`;
+
   // Base instruction WITHOUT memory claims (used when memory is unavailable)
   // VTID-01225-READ-FIX: Always append memory_facts if available
   const baseInstructionNoMemory = `${textChatConfig.base_identity_no_memory || 'You are VITANA ORB, a voice-first multimodal assistant.'}
@@ -9920,7 +9954,7 @@ Context:
 - selectedId: ${session.selectedId || 'none'}
 
 Operating mode:
-${textChatConfig.operating_mode || '- Voice conversation is primary.\n- Always listening while ORB overlay is open.\n- Read-only: do not mutate system state.\n- Be concise, contextual, and helpful.'}${memoryFactsSection ? `\n- You have PERSISTENT MEMORY - you remember users across sessions.${memoryFactsSection}` : ''}${calendarSection}`;
+${textChatConfig.operating_mode || '- Voice conversation is primary.\n- Always listening while ORB overlay is open.\n- Read-only: do not mutate system state.\n- Be concise, contextual, and helpful.'}${memoryFactsSection ? `\n- You have PERSISTENT MEMORY - you remember users across sessions.${memoryFactsSection}` : ''}${calendarSection}${MESSAGING_CONTRACT}`;
 
   // Base instruction WITH memory claims (used when memory IS available)
   const baseInstructionWithMemory = `${textChatConfig.base_identity_with_memory || 'You are VITANA ORB, a voice-first multimodal assistant with persistent memory.'}
@@ -9934,7 +9968,7 @@ Context:
 Operating mode:
 ${textChatConfig.operating_mode || '- Voice conversation is primary.\n- Always listening while ORB overlay is open.\n- Read-only: do not mutate system state.\n- Be concise, contextual, and helpful.'}
 - You have PERSISTENT MEMORY - you remember users across sessions.
-- NEVER claim you cannot remember or that your memory resets.${memoryFactsSection}${calendarSection}`;
+- NEVER claim you cannot remember or that your memory resets.${memoryFactsSection}${calendarSection}${MESSAGING_CONTRACT}`;
 
   // VTID-01153: Try memory-indexer first (Mem0 OSS)
   // VTID-01186: Use effective identity for memory lookups

--- a/supabase/migrations/20260507000300_resolver_chat_peer_promotion.sql
+++ b/supabase/migrations/20260507000300_resolver_chat_peer_promotion.sql
@@ -1,0 +1,190 @@
+-- Resolver fix: promote frequent chat partners into the candidate set
+-- even when the spoken token doesn't trigram-match strongly.
+--
+-- Symptom: voice user said "send a message to Maria Maksina, I think
+-- it's maria6" — first attempt failed ("can't find that user"), retry
+-- succeeded. Root cause was twofold:
+--
+--   1. Gemini Live didn't always call resolve_recipient (fixed in
+--      gateway/orb-live.ts, paired PR).
+--   2. The SQL only surfaced candidates with trigram similarity > 0.4.
+--      ASR mishears + foreign names regularly fall below that line, so
+--      a frequent chat partner could be invisible. The +0.15 chat boost
+--      only applied AFTER a name match — never enough to pull a
+--      candidate INTO the result set.
+--
+-- This migration relaxes the trigram threshold to 0.15 for users the
+-- actor has chatted with in the last 200 chat_messages. The base score
+-- is also lowered (0.45 instead of 0.55) so chat-peer matches don't
+-- outrank exact name matches, and the existing +0.15 chat boost still
+-- applies on top — making frequent peers consistently surface as
+-- candidates without crowding out better matches.
+--
+-- Worst-case behavior: when ASR is decent ("maria maksina" → similarity
+-- ~0.95), the existing 0.4-threshold path still applies and the chat
+-- peer gets the higher 0.55 + 0.30*sim baseline, not the 0.45 path.
+-- The relaxed path only kicks in when the regular path would have
+-- failed to return them.
+
+CREATE OR REPLACE FUNCTION public.resolve_recipient_candidates(
+  p_actor  uuid,
+  p_token  text,
+  p_limit  int  DEFAULT 5,
+  p_global boolean DEFAULT false
+) RETURNS TABLE (
+  user_id      uuid,
+  vitana_id    text,
+  display_name text,
+  avatar_url   text,
+  score        numeric,
+  reason       text
+)
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_token        text;
+  v_actor_tenant uuid;
+BEGIN
+  -- 1. Normalize the spoken token: strip leading '@', lowercase, unaccent.
+  v_token := lower(public.unaccent(coalesce(p_token, '')));
+  v_token := ltrim(v_token, '@');
+  v_token := trim(v_token);
+
+  IF v_token = '' THEN
+    RETURN;
+  END IF;
+
+  -- 2. Tenant scoping (unchanged).
+  IF NOT p_global THEN
+    SELECT (au.raw_app_meta_data ->> 'active_tenant_id')::uuid
+      INTO v_actor_tenant
+      FROM auth.users au
+     WHERE au.id = p_actor;
+
+    IF v_actor_tenant IS NULL THEN
+      SELECT m.tenant_id INTO v_actor_tenant
+        FROM public.memberships m
+       WHERE m.user_id = p_actor
+         AND m.status = 'active'
+       ORDER BY m.created_at ASC
+       LIMIT 1;
+    END IF;
+
+    IF v_actor_tenant IS NULL THEN
+      RETURN;
+    END IF;
+  END IF;
+
+  -- 3. Build candidates and rank.
+  RETURN QUERY
+  -- Pre-compute the actor's recent chat-peer set ONCE, used both for
+  -- the relaxed-threshold inclusion AND for the +0.15 score boost.
+  WITH chat_peers AS (
+    SELECT DISTINCT peer
+      FROM (
+        SELECT cm.sender_id   AS peer FROM public.chat_messages cm
+         WHERE cm.receiver_id = p_actor
+         ORDER BY cm.created_at DESC LIMIT 200
+        UNION ALL
+        SELECT cm.receiver_id AS peer FROM public.chat_messages cm
+         WHERE cm.sender_id   = p_actor
+         ORDER BY cm.created_at DESC LIMIT 200
+      ) recent
+     WHERE peer IS NOT NULL
+  ),
+  base AS (
+    SELECT
+      p.user_id,
+      p.vitana_id,
+      p.display_name,
+      p.avatar_url,
+      EXISTS (SELECT 1 FROM chat_peers cp WHERE cp.peer = p.user_id) AS is_chat_peer,
+      similarity(lower(public.unaccent(coalesce(p.display_name, ''))), v_token) AS sim,
+      CASE
+        WHEN p.vitana_id = v_token THEN 1.00::numeric
+        WHEN EXISTS (
+          SELECT 1 FROM public.handle_aliases ha
+           WHERE ha.user_id = p.user_id
+             AND ha.old_handle = v_token
+        ) THEN 0.92::numeric
+        WHEN similarity(lower(public.unaccent(coalesce(p.display_name, ''))), v_token) > 0.4
+          THEN (0.55 + similarity(lower(public.unaccent(coalesce(p.display_name, ''))), v_token) * 0.30)::numeric
+        -- NEW: relaxed threshold for chat peers — surfaces foreign-name
+        -- ASR slips that the regular 0.4 threshold would drop. Baseline
+        -- 0.45 keeps these below exact / alias / strong-fuzzy matches.
+        WHEN EXISTS (SELECT 1 FROM chat_peers cp WHERE cp.peer = p.user_id)
+         AND similarity(lower(public.unaccent(coalesce(p.display_name, ''))), v_token) > 0.15
+          THEN (0.45 + similarity(lower(public.unaccent(coalesce(p.display_name, ''))), v_token) * 0.30)::numeric
+        ELSE 0.00::numeric
+      END AS base_score,
+      CASE
+        WHEN p.vitana_id = v_token THEN 'vitana_id_exact'
+        WHEN EXISTS (
+          SELECT 1 FROM public.handle_aliases ha
+           WHERE ha.user_id = p.user_id
+             AND ha.old_handle = v_token
+        ) THEN 'legacy_handle'
+        WHEN similarity(lower(public.unaccent(coalesce(p.display_name, ''))), v_token) > 0.4
+          THEN 'fuzzy_name'
+        WHEN EXISTS (SELECT 1 FROM chat_peers cp WHERE cp.peer = p.user_id)
+         AND similarity(lower(public.unaccent(coalesce(p.display_name, ''))), v_token) > 0.15
+          THEN 'fuzzy_chat_peer'
+        ELSE 'none'
+      END AS base_reason
+    FROM public.profiles p
+    WHERE p.user_id <> p_actor
+      AND (
+        p_global = true
+        OR EXISTS (
+          SELECT 1 FROM public.memberships m
+           WHERE m.user_id = p.user_id
+             AND m.tenant_id = v_actor_tenant
+             AND m.status = 'active'
+        )
+      )
+  ),
+  scored AS (
+    SELECT
+      b.user_id,
+      b.vitana_id,
+      b.display_name,
+      b.avatar_url,
+      b.base_score
+        -- Phonetic boost (unchanged).
+        + CASE
+            WHEN b.base_reason IN ('fuzzy_name', 'fuzzy_chat_peer', 'none')
+             AND b.display_name IS NOT NULL
+             AND length(v_token) >= 3
+             AND metaphone(lower(public.unaccent(split_part(b.display_name, ' ', 1))), 6)
+               = metaphone(v_token, 6)
+            THEN 0.10
+            ELSE 0
+          END
+        -- Recent chat partner boost (unchanged).
+        + CASE
+            WHEN b.is_chat_peer THEN 0.15
+            ELSE 0
+          END
+        AS score,
+      b.base_reason AS reason
+    FROM base b
+    WHERE b.base_score > 0
+  )
+  SELECT
+    s.user_id,
+    s.vitana_id,
+    s.display_name,
+    s.avatar_url,
+    s.score,
+    s.reason
+  FROM scored s
+  ORDER BY s.score DESC, s.display_name ASC
+  LIMIT GREATEST(coalesce(p_limit, 5), 1);
+END;
+$$;
+
+COMMENT ON FUNCTION public.resolve_recipient_candidates(uuid, text, int, boolean) IS
+  'Voice-resolver primitive. Given a spoken-name token, returns ranked candidates. Tenant-scoped when p_global=false. Relaxed trigram threshold (0.15 vs 0.4) for users in the actor''s recent chat-peer set so frequent contacts surface even with ASR slips.';


### PR DESCRIPTION
## Summary

Two fixes for the voice resolver bug where the same query non-deterministically returned "can't find" then "found her" on retry.

**1. Tool binding** (`orb-live.ts`)
- New "MESSAGING & SHARING CONTRACT" block injected into both base system instructions. Forces resolve_recipient invocation as a precondition to any reply about whether a recipient exists. Empty candidates is the only honest path to "can't find."
- Tool description rewritten with explicit hint-handling examples: *"Maria, I think it's maria6"* → pass `spoken_name="maria6"` first, retry with `"maria"` if empty.

**2. SQL resolver** (`20260507000300_resolver_chat_peer_promotion.sql`)
- Pre-computes the actor's recent chat-peer set in a single CTE (reused for both inclusion and the existing +0.15 boost).
- New base-score arm: profiles in `chat_peers` with similarity > 0.15 (relaxed from 0.4) score `0.45 + sim*0.30` with reason `fuzzy_chat_peer`. Pulls frequent contacts into the candidate set even with heavy ASR slips.
- Non-chat matches still require similarity > 0.4 — randoms don't pollute.

## Pairs with

[exafyltd/vitana-v1#TBD](https://github.com/exafyltd/vitana-v1) — same migration mirrored so `RUN-MIGRATION.yml` can apply it from this repo.

## Test plan

- [ ] `npx tsc --noEmit` passes
- [ ] After deploy: Voice "send a message to Maria Maksina" — ORB calls resolve_recipient on the FIRST attempt, no "can't find" hallucination
- [ ] After migration: `SELECT * FROM resolve_recipient_candidates('<actor>', 'maria', 5, false)` returns frequent chat partners named Maria even if their name doesn't trigram-match "maria" strongly
- [ ] Non-chat random query still respects strict 0.4 threshold (random user with name "Marsha" does NOT surface for "maria")

🤖 Generated with [Claude Code](https://claude.com/claude-code)
