### PR TITLE
fix(dev-autopilot): flip findings to 'completed' on PR-merge + dedup guard (VTID-02639)

### DIFF
--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -296,9 +296,10 @@ export async function approveAutoExecute(input: ApprovalInput): Promise<Approval
     risk_class: 'low' | 'medium' | 'high' | null;
     source_type: string;
     spec_snapshot: Record<string, unknown>;
+    status: string;
   }>>(
     s,
-    `/rest/v1/autopilot_recommendations?id=eq.${input.finding_id}&select=id,risk_class,source_type,spec_snapshot&limit=1`,
+    `/rest/v1/autopilot_recommendations?id=eq.${input.finding_id}&select=id,risk_class,source_type,spec_snapshot,status&limit=1`,
   );
   if (!recR.ok || !recR.data) return { ok: false, error: recR.error || 'finding lookup failed' };
   const rec = recR.data[0];
@@ -307,6 +308,20 @@ export async function approveAutoExecute(input: ApprovalInput): Promise<Approval
   // same plan→approve→execute path. Reject anything else (community, system).
   if (rec.source_type !== 'dev_autopilot' && rec.source_type !== 'dev_autopilot_impact') {
     return { ok: false, error: `not a dev_autopilot finding (source_type=${rec.source_type})` };
+  }
+  // VTID-02639 defense-in-depth: refuse to re-approve a finding that has
+  // already shipped (status='completed') or been manually closed
+  // (status='rejected'/'snoozed'/'activated'). autoApproveTick() now filters
+  // by status='new' upstream, but a manual call here could still hit a
+  // stale finding_id. Without this guard, the same finding can produce N
+  // duplicate PRs — exactly the failure mode that forced the 2026-04-30
+  // sweep (6 identical admin-notification-categories middleware refactors
+  // closed in one batch).
+  if (rec.status !== 'new') {
+    return {
+      ok: false,
+      error: `finding status is '${rec.status}' — only 'new' findings can be approved`,
+    };
   }
 
   // 2. Load latest plan version
@@ -1215,22 +1230,70 @@ async function patchExecution(
   // Outcomes substrate: when an execution reaches a terminal state, look up
   // its finding_id and backfill the open outcome row. Centralizing here
   // covers all 9+ patch-to-terminal call sites without per-site changes.
+  // VTID-02639: also flip the finding to status='completed' on a SUCCESSFUL
+  // terminal transition + write the merged-PR backref. Without this, the
+  // finding stays status='new' forever, autoApproveTick() re-approves it on
+  // the next pass, and a fresh duplicate PR opens against the same source
+  // signal. (Failure backfills outcomes only — the finding stays 'new' so
+  // the operator/self-healer can decide what's next.)
   if (r.ok && (fields.status === 'completed' || fields.status === 'failed')) {
     void (async () => {
       try {
-        const lookupR = await supa<Array<{ finding_id: string }>>(
+        const lookupR = await supa<Array<{ finding_id: string; pr_url: string | null; pr_number: number | null }>>(
           s,
-          `/rest/v1/dev_autopilot_executions?id=eq.${id}&select=finding_id&limit=1`,
+          `/rest/v1/dev_autopilot_executions?id=eq.${id}&select=finding_id,pr_url,pr_number&limit=1`,
         );
-        const finding_id = lookupR.ok && lookupR.data?.[0]?.finding_id;
-        if (finding_id) {
-          await recordExecOutcome(
-            finding_id,
-            fields.status === 'completed' ? 'success' : 'failure',
+        const exec = lookupR.ok && lookupR.data?.[0];
+        const finding_id = exec?.finding_id;
+        if (!finding_id) return;
+
+        await recordExecOutcome(
+          finding_id,
+          fields.status === 'completed' ? 'success' : 'failure',
+        );
+
+        if (fields.status !== 'completed') return;
+
+        // Only flip findings that are still 'new' — preserves any human
+        // override (rejected/snoozed/activated) the operator may have set.
+        const findingPatchR = await supa(
+          s,
+          `/rest/v1/autopilot_recommendations?id=eq.${finding_id}&status=eq.new`,
+          {
+            method: 'PATCH',
+            headers: { Prefer: 'return=minimal' },
+            body: JSON.stringify({
+              status: 'completed',
+              merged_pr_url: exec?.pr_url ?? null,
+              merged_pr_number: exec?.pr_number ?? null,
+              completed_at: new Date().toISOString(),
+            }),
+          },
+        );
+        if (findingPatchR.ok) {
+          await emitOasisEvent({
+            vtid: EXEC_VTID,
+            type: 'dev_autopilot.finding.completed',
+            source: 'dev-autopilot',
+            status: 'success',
+            message: `Finding ${finding_id.slice(0, 8)} completed via execution ${id.slice(0, 8)}`
+              + (exec?.pr_number ? ` (PR #${exec.pr_number})` : ''),
+            payload: {
+              finding_id,
+              execution_id: id,
+              pr_url: exec?.pr_url ?? null,
+              pr_number: exec?.pr_number ?? null,
+            },
+          });
+        } else {
+          // Don't fail the patchExecution call — outcome bookkeeping is
+          // best-effort. Just log so the dashboards/SRE see the gap.
+          console.warn(
+            `${LOG_PREFIX} finding completion patch failed for ${finding_id.slice(0, 8)}: ${findingPatchR.error}`,
           );
         }
       } catch (err) {
-        console.warn(`${LOG_PREFIX} outcome backfill error for ${id.slice(0, 8)}:`, err);
+        console.warn(`${LOG_PREFIX} outcome / finding-completion backfill error for ${id.slice(0, 8)}:`, err);
       }
     })();
   }

--- a/services/gateway/test/dev-autopilot-finding-completion.test.ts
+++ b/services/gateway/test/dev-autopilot-finding-completion.test.ts
@@ -1,0 +1,142 @@
+/**
+ * VTID-02639 — Tests for the finding-completion guard inside approveAutoExecute.
+ *
+ * The guard rejects re-approval of any finding whose status is not 'new'.
+ * Without it, autoApproveTick() (which already filters by status='new'
+ * upstream) was the only thing preventing duplicate PRs against a single
+ * finding — and a manual call into approveAutoExecute could still race.
+ *
+ * The 2026-04-30 sweep had to close 6 identical
+ * "Refactor admin-notification-categories to use middleware" PRs that all
+ * targeted the same finding. This guard is the regression fence.
+ */
+
+import { approveAutoExecute } from '../src/services/dev-autopilot-execute';
+
+type FetchMock = jest.Mock<Promise<Response>, [RequestInfo | URL, RequestInit?]>;
+
+const ORIGINAL_FETCH = global.fetch;
+const ORIGINAL_SUPABASE_URL = process.env.SUPABASE_URL;
+const ORIGINAL_SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
+
+function mockResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(body),
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe('approveAutoExecute — VTID-02639 finding-completion guard', () => {
+  let fetchMock: FetchMock;
+
+  beforeAll(() => {
+    process.env.SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE = 'test_service_role_key';
+  });
+
+  afterAll(() => {
+    if (ORIGINAL_SUPABASE_URL === undefined) delete process.env.SUPABASE_URL;
+    else process.env.SUPABASE_URL = ORIGINAL_SUPABASE_URL;
+    if (ORIGINAL_SUPABASE_SERVICE_ROLE === undefined) delete process.env.SUPABASE_SERVICE_ROLE;
+    else process.env.SUPABASE_SERVICE_ROLE = ORIGINAL_SUPABASE_SERVICE_ROLE;
+    global.fetch = ORIGINAL_FETCH;
+  });
+
+  beforeEach(() => {
+    fetchMock = jest.fn() as FetchMock;
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  it('rejects a finding whose status is "completed"', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse([{
+      id: 'f-1',
+      risk_class: 'low',
+      source_type: 'dev_autopilot',
+      spec_snapshot: {},
+      status: 'completed',
+    }]));
+
+    const result = await approveAutoExecute({ finding_id: 'f-1' });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/status is 'completed'/);
+    expect(result.error).toMatch(/only 'new'/);
+    // Should short-circuit BEFORE loading plan/config — only one fetch.
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a finding whose status is "rejected"', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse([{
+      id: 'f-2',
+      risk_class: 'medium',
+      source_type: 'dev_autopilot_impact',
+      spec_snapshot: { rule: 'companion-test-missing' },
+      status: 'rejected',
+    }]));
+
+    const result = await approveAutoExecute({ finding_id: 'f-2' });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/status is 'rejected'/);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('rejects a finding whose status is "snoozed"', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse([{
+      id: 'f-3',
+      risk_class: 'low',
+      source_type: 'dev_autopilot',
+      spec_snapshot: {},
+      status: 'snoozed',
+    }]));
+
+    const result = await approveAutoExecute({ finding_id: 'f-3' });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/status is 'snoozed'/);
+  });
+
+  it('rejects a finding whose status is "activated"', async () => {
+    // 'activated' means the finding has already been turned into a VTID by
+    // a different code path. Re-approving it through the autopilot would
+    // double-track the same work.
+    fetchMock.mockResolvedValueOnce(mockResponse([{
+      id: 'f-4',
+      risk_class: 'low',
+      source_type: 'dev_autopilot',
+      spec_snapshot: {},
+      status: 'activated',
+    }]));
+
+    const result = await approveAutoExecute({ finding_id: 'f-4' });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/status is 'activated'/);
+  });
+
+  it('progresses past the status guard for status="new" findings', async () => {
+    // Stubs the finding lookup but not the rest of the pipeline. The
+    // assertion is that we get past the status guard — any subsequent
+    // error (plan missing, supabase 500, etc.) is fine, just not the
+    // finding-completion error string.
+    fetchMock.mockResolvedValueOnce(mockResponse([{
+      id: 'f-5',
+      risk_class: 'low',
+      source_type: 'dev_autopilot',
+      spec_snapshot: {},
+      status: 'new',
+    }]));
+    // Plan-version lookup → empty (so we error with "plan version required",
+    // proving we got past the status check).
+    fetchMock.mockResolvedValueOnce(mockResponse([]));
+
+    const result = await approveAutoExecute({ finding_id: 'f-5' });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).not.toMatch(/status is/);
+    expect(result.error).toMatch(/plan version required/);
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+});

--- a/supabase/migrations/20260501000000_VTID_02639_autopilot_finding_completed_state.sql
+++ b/supabase/migrations/20260501000000_VTID_02639_autopilot_finding_completed_state.sql
@@ -1,0 +1,98 @@
+-- =============================================================================
+-- VTID-02639: autopilot_recommendations — add 'completed' status + PR backref
+-- =============================================================================
+-- Root cause: dev autopilot's autoApproveTick() filters findings by
+-- status='new'. After a successful execution merges a PR, the corresponding
+-- autopilot_recommendations row is never updated — so on the next tick it
+-- gets re-approved and a fresh PR is opened against the same finding. This
+-- is why the 2026-04-30 sweep had to close 6 identical
+-- "Refactor admin-notification-categories to use middleware" PRs that all
+-- targeted the same finding.
+--
+-- This migration:
+--   1. Extends the status CHECK constraint to allow 'completed'.
+--   2. Adds backref columns so we know which PR closed which finding:
+--        merged_pr_url    TEXT
+--        merged_pr_number INTEGER
+--        completed_at     TIMESTAMPTZ
+--   3. Adds a partial index for fast "what did we ship?" queries.
+--
+-- The gateway code change in dev-autopilot-execute.ts (this same VTID) is
+-- what actually flips the finding to 'completed' inside patchExecution() —
+-- the centralized chokepoint for execution-status updates. A defense-in-
+-- depth guard inside approveAutoExecute() refuses to re-approve any finding
+-- whose status is not 'new'.
+-- =============================================================================
+
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+-- 1. Extend the status enum.
+-- The existing constraint is:
+--   CHECK (status IN ('new', 'activated', 'rejected', 'snoozed'))
+-- Drop and re-create with 'completed' added.
+ALTER TABLE public.autopilot_recommendations
+  DROP CONSTRAINT IF EXISTS autopilot_recommendations_status_check;
+
+ALTER TABLE public.autopilot_recommendations
+  ADD CONSTRAINT autopilot_recommendations_status_check
+    CHECK (status IN ('new', 'activated', 'rejected', 'snoozed', 'completed'));
+
+-- 2. Backref columns. NULLable — populated only when the autopilot's
+--    execution loop successfully merges a PR for this finding.
+ALTER TABLE public.autopilot_recommendations
+  ADD COLUMN IF NOT EXISTS merged_pr_url    TEXT,
+  ADD COLUMN IF NOT EXISTS merged_pr_number INTEGER,
+  ADD COLUMN IF NOT EXISTS completed_at     TIMESTAMPTZ;
+
+-- 3. Partial index for "completed in the last N days" telemetry queries
+--    (Command Hub Autopilot dashboard, OASIS retention reports). Partial
+--    so we don't pay storage for the (much larger) population of 'new' rows.
+CREATE INDEX IF NOT EXISTS idx_autopilot_recommendations_completed_at
+  ON public.autopilot_recommendations (completed_at DESC NULLS LAST)
+  WHERE status = 'completed';
+
+-- 4. Verify the constraint and columns are in place. Reads from pg_catalog
+--    instead of an INSERT smoke test so we don't have to track NOT NULL /
+--    REFERENCES constraints that may evolve on this table.
+DO $$
+DECLARE
+  v_constraint_def TEXT;
+  v_url_col_count   INTEGER;
+  v_num_col_count   INTEGER;
+  v_at_col_count    INTEGER;
+BEGIN
+  SELECT pg_get_constraintdef(oid)
+    INTO v_constraint_def
+    FROM pg_constraint
+   WHERE conname = 'autopilot_recommendations_status_check'
+     AND conrelid = 'public.autopilot_recommendations'::regclass;
+
+  IF v_constraint_def IS NULL THEN
+    RAISE EXCEPTION 'autopilot_recommendations_status_check constraint missing after migration';
+  END IF;
+  IF position('completed' in v_constraint_def) = 0 THEN
+    RAISE EXCEPTION 'status CHECK constraint did not pick up completed: %', v_constraint_def;
+  END IF;
+
+  SELECT count(*) INTO v_url_col_count FROM information_schema.columns
+   WHERE table_schema = 'public' AND table_name = 'autopilot_recommendations'
+     AND column_name = 'merged_pr_url';
+  SELECT count(*) INTO v_num_col_count FROM information_schema.columns
+   WHERE table_schema = 'public' AND table_name = 'autopilot_recommendations'
+     AND column_name = 'merged_pr_number';
+  SELECT count(*) INTO v_at_col_count FROM information_schema.columns
+   WHERE table_schema = 'public' AND table_name = 'autopilot_recommendations'
+     AND column_name = 'completed_at';
+
+  IF v_url_col_count = 0 OR v_num_col_count = 0 OR v_at_col_count = 0 THEN
+    RAISE EXCEPTION 'backref columns missing: merged_pr_url=%, merged_pr_number=%, completed_at=%',
+                    v_url_col_count, v_num_col_count, v_at_col_count;
+  END IF;
+
+  RAISE NOTICE 'VTID-02639 applied: status enum extended (constraint=%), backref columns present',
+               v_constraint_def;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Fix #1 of 3 for the dev-autopilot duplicate-PR root causes (containment landed in #1132).

## Why

The 2026-04-30 sweep had to close 6 identical \`admin-notification-categories\` middleware-refactor PRs that all targeted **the same finding**.

Root cause: \`autopilot_recommendations.status\` stayed \`'new'\` forever after the autopilot's execution loop merged a PR. \`autoApproveTick()\` filters by \`status='new'\` and the in-flight execution check was the only dedup, so once a prior execution completed cleanly the same finding became eligible again — fresh PR opens on the next tick.

## Changes

### Migration — \`20260501000000_VTID_02639_autopilot_finding_completed_state.sql\`
- Extends \`status\` CHECK to allow \`'completed'\` (was: \`'new', 'activated', 'rejected', 'snoozed'\`).
- Adds 3 backref columns: \`merged_pr_url TEXT\`, \`merged_pr_number INTEGER\`, \`completed_at TIMESTAMPTZ\`.
- Partial index \`idx_autopilot_recommendations_completed_at\` for completion telemetry.
- Wrapped in \`BEGIN ... COMMIT\` with \`ON_ERROR_STOP\` and a \`DO $$\` verifier (reads \`pg_constraint\` + \`information_schema\` — no INSERT smoke test).

### Code — \`services/gateway/src/services/dev-autopilot-execute.ts\`
- **\`patchExecution()\` chokepoint** (line ~1233 area): when an execution transitions to \`status='completed'\` (the SUCCESSFUL terminal state — verifying → completed via OASIS event or \`/alive\` probe), the side-effect IIFE now ALSO:
  - Looks up the execution's \`pr_url\` + \`pr_number\` (already stored on the row).
  - Updates the finding row: \`status='completed', merged_pr_url, merged_pr_number, completed_at=NOW()\`.
  - Filtered by \`status=eq.new\` so we don't trample a manual \`rejected\`/\`snoozed\`/\`activated\` decision.
  - Emits OASIS event \`dev_autopilot.finding.completed\`.
  - **Failures stay 'new'** — self-healing keeps retrying instead of marking complete.
- **\`approveAutoExecute()\` defense-in-depth** (line ~310 area): rejects any finding whose status is not \`'new'\`, with an explicit error naming the offending status. autoApproveTick() filters \`status='new'\` upstream, but a manual call into approveAutoExecute could still race; this is the regression fence.
- SELECT in step 1 extended to fetch \`status\` (was: \`id, risk_class, source_type, spec_snapshot\`).

### Test — \`services/gateway/test/dev-autopilot-finding-completion.test.ts\`
5 cases (all passing locally), \`fetch\` mocked:
- \`completed\` finding → reject + only one fetch (short-circuit before plan lookup).
- \`rejected\` / \`snoozed\` / \`activated\` → reject.
- \`new\` finding → progresses past the guard (errors later for missing plan).

## Verification plan

1. Merge PR.
2. Dispatch \`RUN-MIGRATION.yml\` with \`migration_file=supabase/migrations/20260501000000_VTID_02639_autopilot_finding_completed_state.sql\`.
3. Grep run logs for \`ROLLBACK\` and the success NOTICE \`VTID-02639 applied\`.
4. EXEC-DEPLOY → wait for gateway revision.
5. Manually verify on Command Hub Autopilot screen: any historic completed finding from the 2026-04-30 batch should show as \`status='completed'\` with \`merged_pr_url\` once a fresh execution runs against it. (Backfill of historic completed findings is out of scope; rely on going-forward correctness.)
6. \`auto_approve_enabled\` stays FALSE until Fix #2 + Fix #3 also ship.

## Test plan

- [ ] CI green
- [ ] Gateway typecheck passes
- [ ] Migration applies cleanly (no ROLLBACK)
- [ ] Gateway deploys, \`/alive\` returns 200
- [ ] (Future) when auto-approve is re-enabled, watch OASIS for \`dev_autopilot.finding.completed\` events and absence of duplicate PRs against the same finding

🤖 Generated with [Claude Code](https://claude.com/claude-code)