### PR TITLE
fix(autopilot): include 'auto_archived' in extended status CHECK (VTID-02639 follow-up)

### DIFF
--- a/supabase/migrations/20260501000000_VTID_02639_autopilot_finding_completed_state.sql
+++ b/supabase/migrations/20260501000000_VTID_02639_autopilot_finding_completed_state.sql
@@ -29,15 +29,18 @@
 BEGIN;
 
 -- 1. Extend the status enum.
--- The existing constraint is:
---   CHECK (status IN ('new', 'activated', 'rejected', 'snoozed'))
--- Drop and re-create with 'completed' added.
+-- The CURRENT constraint (after 20260416100000_dev_autopilot.sql) is:
+--   CHECK (status IN ('new', 'activated', 'rejected', 'snoozed', 'auto_archived'))
+-- Drop and re-create with 'completed' added — keeping 'auto_archived' so we
+-- don't violate any existing rows. (First attempt of this migration dropped
+-- 'auto_archived' and failed with "check constraint violated by some row"
+-- against rows the autopilot's auto-archive sweep had already produced.)
 ALTER TABLE public.autopilot_recommendations
   DROP CONSTRAINT IF EXISTS autopilot_recommendations_status_check;
 
 ALTER TABLE public.autopilot_recommendations
   ADD CONSTRAINT autopilot_recommendations_status_check
-    CHECK (status IN ('new', 'activated', 'rejected', 'snoozed', 'completed'));
+    CHECK (status IN ('new', 'activated', 'rejected', 'snoozed', 'auto_archived', 'completed'));
 
 -- 2. Backref columns. NULLable — populated only when the autopilot's
 --    execution loop successfully merges a PR for this finding.


### PR DESCRIPTION
## Summary

Follow-up to PR #1137. The migration shipped there failed at apply time:

\`\`\`
ERROR: check constraint "autopilot_recommendations_status_check" of
relation "autopilot_recommendations" is violated by some row
\`\`\`

I authored the new CHECK clause from the **original** constraint in \`20260117120000_vtid_01180_autopilot_recommendations.sql\` (\`'new','activated','rejected','snoozed'\`), missing the fact that \`20260416100000_dev_autopilot.sql\` extended it with \`'auto_archived'\`. Production rows in that state violated my new constraint and Postgres rejected the ALTER.

## Fix

One-line edit in the same migration file:
- Was: \`CHECK (status IN ('new','activated','rejected','snoozed','completed'))\`
- Now: \`CHECK (status IN ('new','activated','rejected','snoozed','auto_archived','completed'))\`

Same filename re-runs cleanly because the failed first attempt was wrapped in \`BEGIN..COMMIT\` and rolled back fully — DB state is identical to before.

SQL-only — no gateway code, exempt from VTID HARD GATE.

## Apply

After merge, dispatch \`RUN-MIGRATION.yml\` with the same filename:
\`migration_file=supabase/migrations/20260501000000_VTID_02639_autopilot_finding_completed_state.sql\`

Grep run logs for \`ROLLBACK\` and the \`VTID-02639 applied:\` NOTICE.

## Test plan

- [ ] Merge
- [ ] RUN-MIGRATION succeeds (no ROLLBACK in logs, NOTICE present)
- [ ] \`SELECT pg_get_constraintdef(oid) FROM pg_constraint WHERE conname='autopilot_recommendations_status_check'\` shows all 6 values

🤖 Generated with [Claude Code](https://claude.com/claude-code)