### PR TITLE
feat(dev-autopilot): live DB schema context for the planner + anti-hallucination rules (VTID-02640)

### DIFF
--- a/services/gateway/src/services/dev-autopilot-planning.ts
+++ b/services/gateway/src/services/dev-autopilot-planning.ts
@@ -33,6 +33,11 @@ import { emitOasisEvent } from './oasis-event-service';
 import { renderPlanHtml } from './dev-autopilot-html';
 import { isWorkerQueueEnabled, runWorkerTask } from './dev-autopilot-worker-queue';
 import { writeAutopilotFailure, isWorkerBinaryMissing } from './dev-autopilot-self-heal-log';
+import {
+  extractTableNames,
+  loadSchemaSnippets,
+  formatSchemaBlock,
+} from './dev-autopilot-schema-context';
 
 const LOG_PREFIX = '[dev-autopilot-planning]';
 const PLAN_VTID = 'VTID-DEV-AUTOPILOT';
@@ -346,6 +351,7 @@ export function buildPlanningPrompt(
   feedbackNote?: string,
   scope?: { allow?: string[]; deny?: string[] },
   lessons?: PromptLesson[],
+  schemaBlock?: string,
 ): string {
   const snap = finding.spec_snapshot || {};
   const lines: string[] = [];
@@ -366,6 +372,41 @@ export function buildPlanningPrompt(
     `- **File:** ${snap.file_path || '(unspecified)'}${snap.line_number ? `:${snap.line_number}` : ''}`,
     `- **Scanner:** ${snap.scanner || '(unknown)'}`,
     `- **Suggested action:** ${snap.suggested_action || '(none)'}`,
+    ``,
+  );
+
+  // VTID-02640: live DB schema for any tables referenced in the flagged
+  // file. Inserted EARLY in the prompt so column-name hallucinations
+  // (e.g. PR #1091's wrong vitana_id -> vuid rename) are short-circuited
+  // before the LLM starts thinking about edits. Empty string is a no-op.
+  if (schemaBlock) lines.push(schemaBlock);
+
+  // VTID-02640: hard rules to suppress the most damaging classes of
+  // hallucination we've seen ship in PRs: migration modifications and
+  // unverified column renames. These rules supplement (not replace) the
+  // safety gate's allow/deny scope check + the deny_scope on migrations.
+  lines.push(
+    `## Critical anti-hallucination rules (read before producing the plan)`,
+    ``,
+    `1. **Never modify any file under \`supabase/migrations/\`.** Migrations`,
+    `   are append-only after they are applied. If schema needs to change,`,
+    `   add a NEW dated migration file (\`supabase/migrations/YYYYMMDDHHMMSS_<purpose>.sql\`)`,
+    `   and put the new file in Files-to-modify. Modifying an applied`,
+    `   migration is the failure mode behind closed PR #1086.`,
+    ``,
+    `2. **Never propose a column rename, table rename, or schema-drift fix`,
+    `   without verifying the columns in the Live DB schema section above`,
+    `   (or in an attached migration file).** If a column you want to`,
+    `   reference does not appear in the schema section, treat it as`,
+    `   "may not exist" and write the plan to investigate, not to rename.`,
+    `   Closed PR #1091 proposed renaming \`vitana_id\` -> \`vuid\` because`,
+    `   the planner inferred from filename patterns alone — \`vuid\` does`,
+    `   not exist; the canonical column is \`vitana_id\`.`,
+    ``,
+    `3. **Files-to-modify must match the diff your executor will produce.**`,
+    `   Do not list files for "the developer to verify" — those go in`,
+    `   Out-of-scope. The executor writes exactly the listed files; if a`,
+    `   file is not listed, no edits are made to it.`,
     ``,
   );
 
@@ -601,10 +642,12 @@ async function runPlanningSession(
   const startedAt = Date.now();
   const filePath = finding.spec_snapshot?.file_path;
   let fileSection = '';
+  let fileContent: string | null = null;
 
   if (filePath) {
     const fileR = await fetchFileFromGitHub(filePath);
     if (fileR.ok && typeof fileR.content === 'string') {
+      fileContent = fileR.content;
       fileSection =
         `\n\n## Referenced file\n\n` +
         buildFileContext(fileR.content, finding.spec_snapshot?.line_number, filePath) +
@@ -625,7 +668,28 @@ async function runPlanningSession(
     fileSection = `\n\n## Referenced file\n\n> No file_path recorded on this finding. Produce the plan from the finding metadata alone.\n`;
   }
 
-  const prompt = buildPlanningPrompt(finding, previousPlan, feedbackNote, scope, lessons) + fileSection;
+  // VTID-02640: pre-fetch live schema for tables referenced in the file.
+  // Best-effort — fetch failure or missing supa just means the planner runs
+  // without schema context, same as before.
+  let schemaBlock = '';
+  if (supa && fileContent) {
+    try {
+      const tables = extractTableNames(fileContent);
+      if (tables.length > 0) {
+        const rows = await loadSchemaSnippets(supa, tables);
+        schemaBlock = formatSchemaBlock(rows);
+        if (rows.length > 0) {
+          console.log(
+            `${LOG_PREFIX} schema context: ${rows.length} cols across ${tables.length} tables for ${finding.id}`,
+          );
+        }
+      }
+    } catch (err) {
+      console.warn(`${LOG_PREFIX} schema-context fetch threw for ${finding.id}:`, err);
+    }
+  }
+
+  const prompt = buildPlanningPrompt(finding, previousPlan, feedbackNote, scope, lessons, schemaBlock) + fileSection;
 
   // Route through the local worker queue when enabled, so the LLM call draws
   // on the Claude subscription instead of the pay-per-token API key. Falls

--- a/services/gateway/src/services/dev-autopilot-schema-context.ts
+++ b/services/gateway/src/services/dev-autopilot-schema-context.ts
@@ -1,0 +1,188 @@
+/**
+ * Dev Autopilot — live DB schema context for the planner (VTID-02640).
+ *
+ * The planner LLM was hallucinating column names (most visibly in PR #1091
+ * which proposed renaming `vitana_id` -> `vuid` across all auth code; the
+ * `vuid` column does not exist). The model had no visibility into the live
+ * schema and was inferring renames from filename patterns.
+ *
+ * This module fixes that by:
+ *   1. Extracting table names referenced in the flagged file's content
+ *      (`.from('x')`, `.rpc('y')`, SQL FROM/JOIN/UPDATE/INSERT INTO).
+ *   2. Pre-fetching the schema for those tables via the new RPC
+ *      `dev_autopilot_get_table_schema(p_tables text[])`.
+ *   3. Formatting a markdown block the planner prompt can include verbatim.
+ *
+ * The fetch is cached in-process for SCHEMA_CACHE_TTL_MS so the planner
+ * doesn't hit the DB on every plan generation, and the full pipeline is
+ * best-effort: a fetch failure logs a warning and the planner runs without
+ * schema context — never blocks plan generation.
+ */
+
+const LOG_PREFIX = '[dev-autopilot-schema-context]';
+
+export interface SupaConfig { url: string; key: string; }
+
+export interface SchemaColumn {
+  table_name: string;
+  column_name: string;
+  data_type: string;
+  is_nullable: string;
+  column_default: string | null;
+  ordinal_position: number;
+}
+
+const SCHEMA_CACHE_TTL_MS = 60_000;
+
+const cache = new Map<string, { rows: SchemaColumn[]; expires_at: number }>();
+
+/**
+ * Detect public-schema table names referenced in a TS / JS file body.
+ *
+ * Patterns covered:
+ *   - .from('x') / .from("x")          (Supabase JS / Postgres-style)
+ *   - .rpc('x')  / .rpc("x")
+ *   - 'rest/v1/x' inside a URL string  (PostgREST direct calls)
+ *   - SELECT/UPDATE/DELETE/INSERT INTO/FROM/JOIN <name>  (raw SQL strings)
+ *
+ * Names are filtered to the snake_case [a-z][a-z0-9_]+ shape we use for
+ * tables, capped at 64 chars (Postgres limit), and de-duplicated. Unknown
+ * names are still returned — the RPC will simply skip them server-side.
+ */
+export function extractTableNames(content: string): string[] {
+  if (!content) return [];
+  const found = new Set<string>();
+
+  const tableShape = /^[a-z][a-z0-9_]{0,63}$/;
+
+  const patterns: RegExp[] = [
+    // Supabase JS .from('x') / .from("x") — name followed by ANY of
+    // ) , ' " ` ; whitespace so we match both .from('x') and .from('x', opts).
+    /\.from\(\s*['"`]([a-z][a-z0-9_]{0,63})['"`]/g,
+    // Supabase JS .rpc('x'[, args])
+    /\.rpc\(\s*['"`]([a-z][a-z0-9_]{0,63})['"`]/g,
+    // PostgREST URL: /rest/v1/<table>?... or /rest/v1/<table>
+    /\/rest\/v1\/([a-z][a-z0-9_]{0,63})(?:[?\s'"`/]|$)/g,
+    // Raw SQL keywords. Word boundaries on both sides so we don't pick up
+    // partial tokens; case-insensitive for SQL fragments inside `` literals.
+    /\b(?:FROM|JOIN|UPDATE|INTO)\s+(?:public\.)?([a-z][a-z0-9_]{0,63})\b/gi,
+  ];
+
+  for (const re of patterns) {
+    for (const m of content.matchAll(re)) {
+      const name = (m[1] || '').toLowerCase();
+      if (name && tableShape.test(name)) {
+        found.add(name);
+      }
+    }
+  }
+
+  // Drop SQL keywords that occasionally pass the regex (e.g. "FROM SELECT ...").
+  const sqlKeywords = new Set([
+    'select', 'where', 'and', 'or', 'as', 'on', 'using', 'natural',
+    'inner', 'outer', 'left', 'right', 'full', 'cross', 'lateral',
+    'limit', 'offset', 'order', 'group', 'having', 'union', 'all',
+    'distinct', 'returning',
+  ]);
+  for (const kw of sqlKeywords) found.delete(kw);
+
+  return Array.from(found);
+}
+
+/**
+ * Fetch column metadata for the given tables. Cached per-table set
+ * (hashed by sorted-comma-joined name list) for SCHEMA_CACHE_TTL_MS.
+ */
+export async function loadSchemaSnippets(
+  supa: SupaConfig,
+  tables: string[],
+): Promise<SchemaColumn[]> {
+  if (!tables || tables.length === 0) return [];
+  const sorted = Array.from(new Set(tables)).sort();
+  const cacheKey = sorted.join(',');
+
+  const cached = cache.get(cacheKey);
+  if (cached && cached.expires_at > Date.now()) {
+    return cached.rows;
+  }
+
+  try {
+    const res = await fetch(`${supa.url}/rest/v1/rpc/dev_autopilot_get_table_schema`, {
+      method: 'POST',
+      headers: {
+        apikey: supa.key,
+        Authorization: `Bearer ${supa.key}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({ p_tables: sorted }),
+    });
+    if (!res.ok) {
+      console.warn(`${LOG_PREFIX} schema RPC failed (${res.status}) for tables=${cacheKey}`);
+      return [];
+    }
+    const rows = (await res.json()) as SchemaColumn[];
+    if (!Array.isArray(rows)) return [];
+    cache.set(cacheKey, { rows, expires_at: Date.now() + SCHEMA_CACHE_TTL_MS });
+    return rows;
+  } catch (err) {
+    console.warn(`${LOG_PREFIX} schema fetch threw for tables=${cacheKey}:`, err);
+    return [];
+  }
+}
+
+/**
+ * Render the schema rows as a markdown block the planner prompt can drop
+ * in verbatim. Returns an empty string when there's nothing to render so
+ * the caller can do `prompt += formatSchemaBlock(rows)` unconditionally.
+ *
+ * Format:
+ *   ## Live DB schema (read-only) — verify column names against this
+ *
+ *   ### app_users
+ *   | column | type | nullable | default |
+ *   | ... |
+ */
+export function formatSchemaBlock(rows: SchemaColumn[]): string {
+  if (!rows || rows.length === 0) return '';
+
+  const byTable = new Map<string, SchemaColumn[]>();
+  for (const row of rows) {
+    const list = byTable.get(row.table_name) || [];
+    list.push(row);
+    byTable.set(row.table_name, list);
+  }
+
+  const lines: string[] = [
+    ``,
+    `## Live DB schema (read-only) — verify column names against this before citing them`,
+    ``,
+    `Source: \`information_schema.columns\` (\`public\` schema), fetched at plan-generation time.`,
+    `If you cite a column name that is NOT in this section, you are probably hallucinating.`,
+    `If a table you need is missing here, do not invent its columns — note the gap in the plan instead.`,
+    ``,
+  ];
+
+  const tableNames = Array.from(byTable.keys()).sort();
+  for (const table of tableNames) {
+    const cols = byTable.get(table) || [];
+    lines.push(`### ${table}`);
+    lines.push(``);
+    lines.push(`| column | type | nullable | default |`);
+    lines.push(`| --- | --- | --- | --- |`);
+    for (const col of cols.sort((a, b) => a.ordinal_position - b.ordinal_position)) {
+      const def = col.column_default ? '`' + col.column_default.replace(/\|/g, '\\|') + '`' : '';
+      lines.push(`| \`${col.column_name}\` | \`${col.data_type}\` | ${col.is_nullable} | ${def} |`);
+    }
+    lines.push(``);
+  }
+
+  return lines.join('\n');
+}
+
+/**
+ * Test-only hook: clear the in-process cache so unit tests start fresh.
+ * Not exported for production use.
+ */
+export function _resetSchemaCacheForTests(): void {
+  cache.clear();
+}

--- a/services/gateway/test/dev-autopilot-schema-context.test.ts
+++ b/services/gateway/test/dev-autopilot-schema-context.test.ts
@@ -1,0 +1,236 @@
+/**
+ * VTID-02640 — Tests for the planner's live-schema context module.
+ *
+ * Three units under test:
+ *   1. extractTableNames    — regex-based table-name detection
+ *   2. loadSchemaSnippets   — RPC fetch + per-table-set in-process cache
+ *   3. formatSchemaBlock    — markdown rendering for the prompt
+ *
+ * Plus an integration check that buildPlanningPrompt includes the schema
+ * block + the new anti-hallucination rules.
+ */
+
+import {
+  extractTableNames,
+  loadSchemaSnippets,
+  formatSchemaBlock,
+  _resetSchemaCacheForTests,
+  type SchemaColumn,
+} from '../src/services/dev-autopilot-schema-context';
+import { buildPlanningPrompt } from '../src/services/dev-autopilot-planning';
+
+const SUPA = { url: 'https://test.supabase.co', key: 'test_key' };
+const ORIGINAL_FETCH = global.fetch;
+
+function mockResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(body),
+    json: async () => body,
+  } as unknown as Response;
+}
+
+describe('extractTableNames', () => {
+  it('detects Supabase JS .from() calls', () => {
+    const code = `
+      const { data } = await supabase.from('app_users').select('*');
+      await supabase.from("memory_facts").insert({ ... });
+    `;
+    const out = extractTableNames(code);
+    expect(out).toEqual(expect.arrayContaining(['app_users', 'memory_facts']));
+  });
+
+  it('detects .rpc() calls', () => {
+    const code = `await supabase.rpc('write_fact', { ... });`;
+    expect(extractTableNames(code)).toEqual(['write_fact']);
+  });
+
+  it('detects PostgREST URL paths /rest/v1/<table>', () => {
+    const code = "fetch(`${supa.url}/rest/v1/oasis_events?topic=eq.foo`)";
+    expect(extractTableNames(code)).toEqual(expect.arrayContaining(['oasis_events']));
+  });
+
+  it('detects raw SQL FROM/JOIN/UPDATE/INSERT INTO', () => {
+    const sql = `
+      SELECT * FROM tenants t
+      JOIN user_tenants ut ON ut.tenant_id = t.tenant_id
+      INSERT INTO memory_items (...) VALUES (...);
+      UPDATE app_users SET vitana_id = $1;
+    `;
+    const out = extractTableNames(sql);
+    expect(out).toEqual(
+      expect.arrayContaining(['tenants', 'user_tenants', 'memory_items', 'app_users']),
+    );
+  });
+
+  it('strips public. prefix on raw SQL', () => {
+    expect(extractTableNames('SELECT * FROM public.dev_autopilot_runs'))
+      .toEqual(['dev_autopilot_runs']);
+  });
+
+  it('drops SQL keywords that match the regex by accident', () => {
+    // "FROM SELECT" should NOT yield "select" as a table name.
+    const out = extractTableNames('SELECT a FROM (SELECT b FROM x) y');
+    expect(out).toContain('x');
+    expect(out).not.toContain('select');
+  });
+
+  it('returns empty for content with no table references', () => {
+    expect(extractTableNames('console.log("hi");')).toEqual([]);
+  });
+
+  it('returns empty for empty input', () => {
+    expect(extractTableNames('')).toEqual([]);
+  });
+
+  it('deduplicates repeated names', () => {
+    const out = extractTableNames(`
+      .from('tenants')
+      .from('tenants')
+      FROM tenants
+    `);
+    expect(out).toEqual(['tenants']);
+  });
+});
+
+describe('loadSchemaSnippets', () => {
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    _resetSchemaCacheForTests();
+    fetchMock = jest.fn();
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  afterAll(() => {
+    global.fetch = ORIGINAL_FETCH;
+  });
+
+  const sampleRows: SchemaColumn[] = [
+    {
+      table_name: 'app_users',
+      column_name: 'user_id',
+      data_type: 'uuid',
+      is_nullable: 'NO',
+      column_default: 'gen_random_uuid()',
+      ordinal_position: 1,
+    },
+    {
+      table_name: 'app_users',
+      column_name: 'vitana_id',
+      data_type: 'text',
+      is_nullable: 'YES',
+      column_default: null,
+      ordinal_position: 2,
+    },
+  ];
+
+  it('returns [] for empty table list (no fetch)', async () => {
+    const out = await loadSchemaSnippets(SUPA, []);
+    expect(out).toEqual([]);
+    expect(fetchMock).not.toHaveBeenCalled();
+  });
+
+  it('calls the RPC with the sorted, deduped table list', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(sampleRows));
+    await loadSchemaSnippets(SUPA, ['memory_facts', 'app_users', 'app_users']);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+    const call = fetchMock.mock.calls[0];
+    expect(call[0]).toBe('https://test.supabase.co/rest/v1/rpc/dev_autopilot_get_table_schema');
+    const body = JSON.parse(call[1].body);
+    expect(body.p_tables).toEqual(['app_users', 'memory_facts']);
+  });
+
+  it('caches results across repeated calls with the same table set', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse(sampleRows));
+    const a = await loadSchemaSnippets(SUPA, ['app_users']);
+    const b = await loadSchemaSnippets(SUPA, ['app_users']);
+    expect(a).toEqual(b);
+    expect(fetchMock).toHaveBeenCalledTimes(1);
+  });
+
+  it('returns [] gracefully when the RPC errors', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse({ error: 'boom' }, 500));
+    const out = await loadSchemaSnippets(SUPA, ['x']);
+    expect(out).toEqual([]);
+  });
+
+  it('returns [] when fetch throws', async () => {
+    fetchMock.mockRejectedValueOnce(new Error('network down'));
+    const out = await loadSchemaSnippets(SUPA, ['x']);
+    expect(out).toEqual([]);
+  });
+});
+
+describe('formatSchemaBlock', () => {
+  it('returns empty string for empty rows (so callers can concat unconditionally)', () => {
+    expect(formatSchemaBlock([])).toBe('');
+  });
+
+  it('renders one section per table with column rows in ordinal order', () => {
+    const rows: SchemaColumn[] = [
+      { table_name: 'tenants', column_name: 'tenant_id', data_type: 'uuid', is_nullable: 'NO', column_default: null, ordinal_position: 1 },
+      { table_name: 'app_users', column_name: 'vitana_id', data_type: 'text', is_nullable: 'YES', column_default: null, ordinal_position: 2 },
+      { table_name: 'app_users', column_name: 'user_id', data_type: 'uuid', is_nullable: 'NO', column_default: null, ordinal_position: 1 },
+    ];
+    const md = formatSchemaBlock(rows);
+    // Tables sorted alphabetically.
+    expect(md.indexOf('### app_users')).toBeLessThan(md.indexOf('### tenants'));
+    // Within app_users, user_id (pos 1) comes before vitana_id (pos 2).
+    const usersBlock = md.slice(md.indexOf('### app_users'), md.indexOf('### tenants'));
+    expect(usersBlock.indexOf('`user_id`')).toBeLessThan(usersBlock.indexOf('`vitana_id`'));
+    // Includes the canonical column name we want the LLM to use.
+    expect(md).toContain('`vitana_id`');
+    // Includes the anti-hallucination header.
+    expect(md).toMatch(/Live DB schema/);
+    expect(md).toMatch(/probably hallucinating/);
+  });
+});
+
+describe('buildPlanningPrompt — VTID-02640 schema-context wiring', () => {
+  const finding = {
+    id: 'f-1',
+    title: 'Test',
+    summary: 'sum',
+    domain: 'dev',
+    risk_class: 'low' as const,
+    spec_snapshot: { file_path: 'services/gateway/src/x.ts' },
+  };
+
+  it('omits the schema-section HEADER when no schemaBlock is provided', () => {
+    const out = buildPlanningPrompt(finding);
+    // Match only the section header (anchored). The anti-hallucination
+    // block intentionally references "Live DB schema section above" in
+    // prose, so a loose regex would fire even with no schema attached.
+    expect(out).not.toMatch(/^## Live DB schema \(read-only\)/m);
+  });
+
+  it('includes the schema block verbatim when provided', () => {
+    const block = '## Live DB schema (read-only) — verify column names against this before citing them\n\n### foo';
+    const out = buildPlanningPrompt(finding, undefined, undefined, undefined, undefined, block);
+    expect(out).toContain(block);
+  });
+
+  it('always includes the anti-hallucination rules block', () => {
+    const out = buildPlanningPrompt(finding);
+    expect(out).toMatch(/Critical anti-hallucination rules/);
+    expect(out).toMatch(/Never modify any file under .supabase\/migrations\//);
+    expect(out).toMatch(/Never propose a column rename/);
+    expect(out).toContain('PR #1086');
+    expect(out).toContain('PR #1091');
+  });
+
+  it('puts schema context BEFORE the Output-format section so the LLM reads it first', () => {
+    // The runPlan caller appends the file section AFTER buildPlanningPrompt's
+    // output; we verify the schema block lands inside the prompt body and
+    // before the Output-format trigger (the planner's Files-to-modify cue).
+    const block = '## Live DB schema (read-only) — verify column names against this before citing them\n\n### bar';
+    const out = buildPlanningPrompt(finding, undefined, undefined, undefined, undefined, block);
+    const blockIdx = out.indexOf(block);
+    const outputIdx = out.indexOf('## Output format');
+    expect(blockIdx).toBeGreaterThan(-1);
+    expect(outputIdx).toBeGreaterThan(-1);
+    expect(blockIdx).toBeLessThan(outputIdx);
+  });
+});

--- a/supabase/migrations/20260501010000_VTID_02640_dev_autopilot_get_table_schema.sql
+++ b/supabase/migrations/20260501010000_VTID_02640_dev_autopilot_get_table_schema.sql
@@ -1,0 +1,72 @@
+-- =============================================================================
+-- VTID-02640: dev_autopilot_get_table_schema RPC
+-- =============================================================================
+-- Dev Autopilot's planner has been hallucinating column names — most
+-- visibly in the closed PR #1091 which proposed renaming `vitana_id`
+-- across all auth code to `vuid` (the `vuid` column does not exist; the
+-- canonical column is `vitana_id`, used in 40+ places). The LLM had no
+-- visibility into the live schema and inferred the rename from filename
+-- patterns alone.
+--
+-- This RPC is the substrate for the planner-prompt schema-context
+-- injection (gateway change in this same VTID): the planner detects
+-- table names referenced in the flagged file and pre-fetches their
+-- column lists so the LLM can verify any column it cites against the
+-- actual schema instead of guessing.
+--
+-- The function is intentionally narrow (public schema only, columns
+-- only) — it is NOT a general-purpose introspection API. RPC, SECURITY
+-- DEFINER, restricted to service_role, only callable with an explicit
+-- table-name allowlist. Cached in-process by the gateway for 60s to keep
+-- planning latency low.
+-- =============================================================================
+
+\set ON_ERROR_STOP on
+
+BEGIN;
+
+CREATE OR REPLACE FUNCTION public.dev_autopilot_get_table_schema(p_tables TEXT[])
+RETURNS TABLE (
+  table_name     TEXT,
+  column_name    TEXT,
+  data_type      TEXT,
+  is_nullable    TEXT,
+  column_default TEXT,
+  ordinal_position INT
+)
+LANGUAGE sql
+STABLE
+SECURITY DEFINER
+SET search_path = public, pg_catalog
+AS $$
+  SELECT
+    c.table_name::TEXT,
+    c.column_name::TEXT,
+    c.data_type::TEXT,
+    c.is_nullable::TEXT,
+    c.column_default::TEXT,
+    c.ordinal_position::INT
+  FROM information_schema.columns c
+  WHERE c.table_schema = 'public'
+    AND c.table_name = ANY(p_tables)
+  ORDER BY c.table_name, c.ordinal_position;
+$$;
+
+REVOKE ALL ON FUNCTION public.dev_autopilot_get_table_schema(TEXT[]) FROM PUBLIC;
+GRANT EXECUTE ON FUNCTION public.dev_autopilot_get_table_schema(TEXT[]) TO service_role;
+
+-- Smoke test: the planner always asks for at least one table; verify the
+-- function returns rows for a known core table without erroring.
+DO $$
+DECLARE
+  v_count INTEGER;
+BEGIN
+  SELECT count(*) INTO v_count
+    FROM public.dev_autopilot_get_table_schema(ARRAY['app_users']);
+  IF v_count = 0 THEN
+    RAISE EXCEPTION 'VTID-02640 sanity: dev_autopilot_get_table_schema returned 0 columns for app_users — schema lookup likely broken';
+  END IF;
+  RAISE NOTICE 'VTID-02640 applied: dev_autopilot_get_table_schema(app_users) returned % columns', v_count;
+END $$;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Fix #2 of 3 for the dev-autopilot duplicate-PR root causes (containment in #1132, Fix #1 in #1137 + #1139).

## Why

The planner LLM was hallucinating column names — most visibly in closed PR #1091 which proposed renaming \`vitana_id\` → \`vuid\` across all auth code. The \`vuid\` column does not exist; the canonical column is \`vitana_id\`, used in 40+ places. The model had no visibility into the live schema and was inferring renames from filename patterns.

PR #1086 (modifying an applied migration) and PR #1102 (dead-code placeholder) shared the same shape: the planner was running blind on schema/intent and the LLM wandered.

## Changes

### Migration — \`20260501010000_VTID_02640_dev_autopilot_get_table_schema.sql\`
New RPC \`public.dev_autopilot_get_table_schema(p_tables text[])\` returning columns from \`information_schema.columns\` for the named tables in the \`public\` schema. \`SECURITY DEFINER\`, restricted to \`service_role\`. Wrapped in BEGIN..COMMIT with ON_ERROR_STOP and an apply-time smoke test against \`app_users\`.

### New module — \`services/gateway/src/services/dev-autopilot-schema-context.ts\`
- \`extractTableNames(content)\` — regex detection of:
  - Supabase JS \`.from('x')\` / \`.from("x")\` / \`.rpc('y'[, args])\`
  - PostgREST URL paths \`/rest/v1/<table>\`
  - Raw SQL \`FROM\` / \`JOIN\` / \`UPDATE\` / \`INSERT INTO\` (case-insensitive, supports \`public.<table>\` prefix)
  - SQL keyword filter, deduplication, snake_case shape filter
- \`loadSchemaSnippets(supa, tables)\` — RPC fetch with **60s in-process cache** (sorted-comma key). Best-effort — on RPC failure returns \`[]\` so plan generation never blocks on schema.
- \`formatSchemaBlock(rows)\` — markdown table-per-table, anti-hallucination header.

### Planner prompt hardening — \`services/gateway/src/services/dev-autopilot-planning.ts\`
- \`runPlan\` now extracts table names from the fetched file content, pre-fetches their schemas, and passes the rendered block to \`buildPlanningPrompt\`.
- \`buildPlanningPrompt\` injects the schema block early and ALWAYS includes a "Critical anti-hallucination rules" section with three rules:
  1. **Never modify any file under \`supabase/migrations/\`** (PR #1086 root cause).
  2. **Never propose a column rename without verifying in the schema section above** (PR #1091 root cause).
  3. **Files-to-modify must match the diff your executor will produce** — don't list files for "the developer to verify".

### Test — \`services/gateway/test/dev-autopilot-schema-context.test.ts\` (20 cases)
- Table-name extraction: Supabase JS, PostgREST URLs, raw SQL, \`public.\` prefix stripping, SQL keyword filter, dedup, empty input.
- RPC fetch: empty input no-op, sorted-deduped table list, 60s caching, error fallbacks (HTTP 500, fetch throws).
- Markdown formatting: empty input, sorted tables, ordinal-position-ordered columns, anti-hallucination header.
- Prompt-builder integration: omits schema header when no block provided, includes block verbatim, anti-hallucination block always present, schema block lands BEFORE Output-format trigger.

## Verification plan

1. Merge PR.
2. Dispatch \`RUN-MIGRATION.yml\` with \`migration_file=supabase/migrations/20260501010000_VTID_02640_dev_autopilot_get_table_schema.sql\` — grep logs for \`ROLLBACK\` and the \`VTID-02640 applied\` NOTICE.
3. EXEC-DEPLOY → wait for gateway revision.
4. Tail \`[dev-autopilot-planning]\` logs for \`schema context: N cols across M tables for FINDING_ID\` lines on next plan generation (proves the wire-up).

## Test plan

- [ ] CI green
- [ ] Gateway typecheck passes
- [ ] Migration applies cleanly
- [ ] Gateway deploys
- [ ] Plan generation produces a prompt with the live schema block (manual smoke after re-enabling auto_approve)

🤖 Generated with [Claude Code](https://claude.com/claude-code)