### PR TITLE
fix(gateway): tsc compile error breaks every deploy (VTID-02639, DEV-COMHU-2628)

### DIFF
--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -1243,7 +1243,13 @@ async function patchExecution(
           s,
           `/rest/v1/dev_autopilot_executions?id=eq.${id}&select=finding_id,pr_url,pr_number&limit=1`,
         );
-        const exec = lookupR.ok && lookupR.data?.[0];
+        // VTID-02639 fix: TS narrows `lookupR.ok && lookupR.data?.[0]` to
+        // `false | { finding_id, pr_url, pr_number }`. Optional chaining
+        // (`?.`) does NOT short-circuit on `false`, only on null/undefined,
+        // so accessing `.finding_id` on a false value is a compile error.
+        // Coerce the boolean branch to undefined explicitly so TS sees
+        // `undefined | { … }` and the optional chain narrows correctly.
+        const exec = (lookupR.ok && lookupR.data?.[0]) || undefined;
         const finding_id = exec?.finding_id;
         if (!finding_id) return;
 


### PR DESCRIPTION
PR #1137 introduced a TypeScript error in dev-autopilot-execute.ts at line 1247 that has blocked every gateway deploy since 08:30 today.

`lookupR.ok && lookupR.data?.[0]` narrows to `false | { finding_id, pr_url, pr_number }`. Optional chaining only short-circuits on null/undefined, not on false, so `exec?.finding_id` is a compile error when exec is false.

Fix is a one-character coercion: `(lookupR.ok && lookupR.data?.[0]) || undefined`. TS now sees `undefined | { … }` and the optional chain works. Runtime behaviour unchanged.

This unblocks the gateway deploy pipeline for everyone, including PR #1140 which has been waiting to ship the Manuals tab inline render fix.

🤖 Generated with Claude Code