### PR TITLE
fix(autopilot): TypeScript errors in patchExecution finding-completion (VTID-02639 hotfix)

### DIFF
--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -1243,9 +1243,10 @@ async function patchExecution(
           s,
           `/rest/v1/dev_autopilot_executions?id=eq.${id}&select=finding_id,pr_url,pr_number&limit=1`,
         );
-        const exec = lookupR.ok && lookupR.data?.[0];
-        const finding_id = exec?.finding_id;
-        if (!finding_id) return;
+        if (!lookupR.ok) return;
+        const exec = lookupR.data?.[0];
+        if (!exec || !exec.finding_id) return;
+        const finding_id = exec.finding_id;
 
         await recordExecOutcome(
           finding_id,
@@ -1264,8 +1265,8 @@ async function patchExecution(
             headers: { Prefer: 'return=minimal' },
             body: JSON.stringify({
               status: 'completed',
-              merged_pr_url: exec?.pr_url ?? null,
-              merged_pr_number: exec?.pr_number ?? null,
+              merged_pr_url: exec.pr_url ?? null,
+              merged_pr_number: exec.pr_number ?? null,
               completed_at: new Date().toISOString(),
             }),
           },
@@ -1277,12 +1278,12 @@ async function patchExecution(
             source: 'dev-autopilot',
             status: 'success',
             message: `Finding ${finding_id.slice(0, 8)} completed via execution ${id.slice(0, 8)}`
-              + (exec?.pr_number ? ` (PR #${exec.pr_number})` : ''),
+              + (exec.pr_number ? ` (PR #${exec.pr_number})` : ''),
             payload: {
               finding_id,
               execution_id: id,
-              pr_url: exec?.pr_url ?? null,
-              pr_number: exec?.pr_number ?? null,
+              pr_url: exec.pr_url ?? null,
+              pr_number: exec.pr_number ?? null,
             },
           });
         } else {

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -596,6 +596,7 @@ export type CicdEventType =
   | 'dev_autopilot.plan.version_added'
   | 'dev_autopilot.finding.rejected'
   | 'dev_autopilot.finding.snoozed'
+  | 'dev_autopilot.finding.completed'
   | 'dev_autopilot.execution.approved'
   | 'dev_autopilot.execution.auto_approved'
   | 'dev_autopilot.execution.bridged'


### PR DESCRIPTION
## Summary

Hotfix for two compile errors in PR #1137 that have been blocking Cloud Run builds + EXEC-DEPLOY for the gateway since 2026-05-01 08:30 UTC. PR #1140's deploy ate the same failure mode (built at the broken SHA).

## CI failure on main

\`\`\`
src/services/dev-autopilot-execute.ts(1247,34): error TS2339: Property 'finding_id' does not exist on type 'false | { ... }'.
src/services/dev-autopilot-execute.ts(1276,13): error TS2820: Type '"dev_autopilot.finding.completed"' is not assignable to type 'CicdEventType'.
... (8 errors total — all variants of the same two issues)
\`\`\`

## Why local typecheck missed it

\`npm run typecheck\` (\`tsc --noEmit\`) was green. \`npm run build\` (the path CI uses) is what surfaces the strict-narrowing violation. Going forward I'll run \`npm run build\` before pushing, not just typecheck.

## Fix

### \`services/gateway/src/services/dev-autopilot-execute.ts\`
Replace the narrowing-resistant idiom:
\`\`\`ts
const exec = lookupR.ok && lookupR.data?.[0];   // false | {...} — TS can't narrow
const finding_id = exec?.finding_id;
\`\`\`
with explicit guards:
\`\`\`ts
if (!lookupR.ok) return;
const exec = lookupR.data?.[0];
if (!exec || !exec.finding_id) return;
const finding_id = exec.finding_id;
\`\`\`
Then drop the \`exec?.\` optional chains everywhere inside the guard.

### \`services/gateway/src/types/cicd.ts\`
Add the missing event type:
\`\`\`diff
   | 'dev_autopilot.finding.rejected'
   | 'dev_autopilot.finding.snoozed'
+  | 'dev_autopilot.finding.completed'
\`\`\`

## Verification

\`npm run build\` exits 0 in the worktree.

## Test plan

- [ ] CI green (\`validate\` / \`Build gateway\` job)
- [ ] EXEC-DEPLOY succeeds at the new SHA
- [ ] Gateway revision serves and \`/alive\` returns 200

🤖 Generated with [Claude Code](https://claude.com/claude-code)