### PR TITLE
feat(dev-autopilot): plan-vs-diff coverage validator (VTID-02641)

### DIFF
--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -571,6 +571,65 @@ export function extractDeletions(markdown: string): string[] {
 }
 
 // =============================================================================
+// VTID-02641: plan-vs-diff coverage validator
+// =============================================================================
+
+/**
+ * Minimum fraction of the plan's files the executor diff must touch before
+ * we consider the diff "honest." Below this, the executor wandered off the
+ * plan and we'd rather fail loudly than ship dead code.
+ *
+ * 0.6 picked deliberately:
+ *   - 5/5  -> 1.00  pass
+ *   - 4/5  -> 0.80  pass
+ *   - 3/5  -> 0.60  pass (skip-test-file class)
+ *   - 2/5  -> 0.40  fail
+ *   - 1/4  -> 0.25  fail (PR #1102: 4-file plan, 1-file diff)
+ */
+const PLAN_DIFF_COVERAGE_THRESHOLD = 0.6;
+
+export interface PlanDiffCoverage {
+  ok: boolean;
+  coverage: number;
+  planCount: number;
+  coveredCount: number;
+  missing: string[];
+}
+
+/**
+ * Pure function: given the plan's files_referenced and the executor diff's
+ * file paths, decide whether enough of the plan was actually written.
+ *
+ * Returns ok=true when:
+ *   - the plan listed 0 files (nothing to validate; defer to the existing
+ *     "executor emitted zero files" check upstream); or
+ *   - covered/plan >= threshold.
+ *
+ * Otherwise returns ok=false with the missing-file list so the caller can
+ * surface a useful error to self-healing.
+ */
+export function validatePlanDiffCoverage(
+  planFiles: string[],
+  diffFiles: string[],
+  threshold: number = PLAN_DIFF_COVERAGE_THRESHOLD,
+): PlanDiffCoverage {
+  if (!planFiles || planFiles.length === 0) {
+    return { ok: true, coverage: 1, planCount: 0, coveredCount: 0, missing: [] };
+  }
+  const diffSet = new Set(diffFiles);
+  const covered = planFiles.filter(p => diffSet.has(p));
+  const missing = planFiles.filter(p => !diffSet.has(p));
+  const coverage = covered.length / planFiles.length;
+  return {
+    ok: coverage >= threshold,
+    coverage,
+    planCount: planFiles.length,
+    coveredCount: covered.length,
+    missing,
+  };
+}
+
+// =============================================================================
 // Cancel (during cooldown only)
 // =============================================================================
 
@@ -1093,7 +1152,7 @@ async function runExecutionSession(
     return { ok: false, error: `LLM output parse: ${parsed.error}`, session_id: sessionId, branch };
   }
 
-  // 3. Validate: every emitted file path was in the plan's files_referenced
+  // 3a. Validate: every emitted file path was in the plan's files_referenced
   const allowedSet = new Set(planFiles);
   const outOfScope: string[] = [];
   for (const f of parsed.files) {
@@ -1109,6 +1168,29 @@ async function runExecutionSession(
   }
   if (parsed.files.length === 0) {
     return { ok: false, error: 'LLM emitted zero files', session_id: sessionId, branch };
+  }
+
+  // 3b. VTID-02641: validate the executor's diff covers ENOUGH of the plan.
+  // The existing 3a check only catches files in the diff that are NOT in
+  // the plan. It's silent when the diff covers a SUBSET of the plan — e.g.
+  // closed PR #1102 had a 4-file plan (approvals.ts, autopilot.ts,
+  // admin/index.ts, safety-gap.ts) but the diff only created the empty
+  // safety-gap.ts placeholder. The PR opened anyway as dead code.
+  // This check fails the execution when coverage falls below
+  // PLAN_DIFF_COVERAGE_THRESHOLD so the LLM-shipped-half-the-plan failure
+  // mode surfaces to self-healing instead of becoming a noisy PR.
+  const coverage = validatePlanDiffCoverage(planFiles, parsed.files.map(f => f.path));
+  if (!coverage.ok) {
+    return {
+      ok: false,
+      error:
+        `executor diff covers only ${Math.round(coverage.coverage * 100)}% of the plan's files `
+        + `(${coverage.coveredCount}/${coverage.planCount}). `
+        + `Missing: ${coverage.missing.slice(0, 5).join(', ')}`
+        + (coverage.missing.length > 5 ? `, +${coverage.missing.length - 5} more` : ''),
+      session_id: sessionId,
+      branch,
+    };
   }
   for (const f of parsed.files) {
     if (f.action !== 'delete' && (!f.content || f.content.length === 0)) {

--- a/services/gateway/test/dev-autopilot-plan-diff-coverage.test.ts
+++ b/services/gateway/test/dev-autopilot-plan-diff-coverage.test.ts
@@ -1,0 +1,118 @@
+/**
+ * VTID-02641 — Tests for the plan-vs-diff coverage validator.
+ *
+ * The 2026-04-30 PR sweep had to close PR #1102: a "safety-gap-scanner-v1"
+ * finding produced a plan that listed 4 files (approvals.ts, autopilot.ts,
+ * admin/index.ts, safety-gap.ts) but the executor only created the empty
+ * safety-gap.ts placeholder. The PR opened anyway as dead code.
+ *
+ * The existing 3a check inside runExecutionSession only catches the
+ * inverse — files in the diff that are NOT in the plan. It is silent when
+ * the diff covers a subset of the plan. This validator is the missing
+ * fence: fail when coverage < 60%.
+ */
+
+import { validatePlanDiffCoverage } from '../src/services/dev-autopilot-execute';
+
+describe('validatePlanDiffCoverage — VTID-02641', () => {
+  it('passes when the diff covers every file in the plan', () => {
+    const out = validatePlanDiffCoverage(
+      ['src/a.ts', 'src/b.ts', 'src/c.ts'],
+      ['src/a.ts', 'src/b.ts', 'src/c.ts'],
+    );
+    expect(out.ok).toBe(true);
+    expect(out.coverage).toBe(1);
+    expect(out.coveredCount).toBe(3);
+    expect(out.planCount).toBe(3);
+    expect(out.missing).toEqual([]);
+  });
+
+  it('passes at exactly the threshold (3/5 = 0.6)', () => {
+    const out = validatePlanDiffCoverage(
+      ['src/a.ts', 'src/b.ts', 'src/c.ts', 'src/d.ts', 'src/e.ts'],
+      ['src/a.ts', 'src/b.ts', 'src/c.ts'],
+    );
+    expect(out.ok).toBe(true);
+    expect(out.coverage).toBeCloseTo(0.6);
+    expect(out.missing).toEqual(['src/d.ts', 'src/e.ts']);
+  });
+
+  it('fails for the PR #1102 case: 4-file plan, 1-file diff (25% coverage)', () => {
+    const out = validatePlanDiffCoverage(
+      [
+        'services/gateway/src/routes/approvals.ts',
+        'services/gateway/src/routes/autopilot.ts',
+        'services/gateway/src/routes/admin/index.ts',
+        'services/gateway/src/services/safety-gap.ts',
+      ],
+      ['services/gateway/src/services/safety-gap.ts'],
+    );
+    expect(out.ok).toBe(false);
+    expect(out.coverage).toBeCloseTo(0.25);
+    expect(out.coveredCount).toBe(1);
+    expect(out.missing).toHaveLength(3);
+    expect(out.missing).toContain('services/gateway/src/routes/approvals.ts');
+  });
+
+  it('passes when 4/5 files covered (80%, the canonical "tests-only-skipped" case)', () => {
+    const out = validatePlanDiffCoverage(
+      ['src/a.ts', 'src/b.ts', 'src/c.ts', 'src/d.ts', 'src/d.test.ts'],
+      ['src/a.ts', 'src/b.ts', 'src/c.ts', 'src/d.ts'],
+    );
+    expect(out.ok).toBe(true);
+    expect(out.coverage).toBeCloseTo(0.8);
+  });
+
+  it('fails when 1/3 files covered (33%)', () => {
+    const out = validatePlanDiffCoverage(
+      ['src/a.ts', 'src/b.ts', 'src/c.ts'],
+      ['src/a.ts'],
+    );
+    expect(out.ok).toBe(false);
+    expect(out.coverage).toBeCloseTo(1 / 3);
+    expect(out.missing).toEqual(['src/b.ts', 'src/c.ts']);
+  });
+
+  it('fails when no diff files match the plan (0% coverage)', () => {
+    const out = validatePlanDiffCoverage(
+      ['src/a.ts', 'src/b.ts'],
+      ['src/x.ts'],
+    );
+    expect(out.ok).toBe(false);
+    expect(out.coverage).toBe(0);
+    expect(out.missing).toEqual(['src/a.ts', 'src/b.ts']);
+  });
+
+  it('passes for empty plan (defers to upstream "zero files" check)', () => {
+    const out = validatePlanDiffCoverage([], ['src/x.ts']);
+    expect(out.ok).toBe(true);
+    expect(out.planCount).toBe(0);
+  });
+
+  it('passes for empty plan + empty diff', () => {
+    const out = validatePlanDiffCoverage([], []);
+    expect(out.ok).toBe(true);
+  });
+
+  it('extra files in the diff (beyond the plan) do not affect coverage in either direction', () => {
+    // Out-of-scope files are caught by the existing 3a check, not this one.
+    // This validator only measures plan->diff coverage, not the reverse.
+    const out = validatePlanDiffCoverage(
+      ['src/a.ts', 'src/b.ts'],
+      ['src/a.ts', 'src/b.ts', 'src/extra.ts'],
+    );
+    expect(out.ok).toBe(true);
+    expect(out.coverage).toBe(1);
+  });
+
+  it('honors a custom threshold parameter', () => {
+    // Strict 100% threshold rejects the canonical 80% pass case.
+    const out = validatePlanDiffCoverage(
+      ['src/a.ts', 'src/b.ts', 'src/c.ts', 'src/d.ts', 'src/d.test.ts'],
+      ['src/a.ts', 'src/b.ts', 'src/c.ts', 'src/d.ts'],
+      1.0,
+    );
+    expect(out.ok).toBe(false);
+    expect(out.coverage).toBeCloseTo(0.8);
+  });
+});


### PR DESCRIPTION
## Summary

Fix #3 of 3 for the dev-autopilot duplicate-PR root causes.

(Containment in #1132, Fix #1 in #1137 + #1139 + #1144 hotfix, Fix #2 in #1141.)

## Why

Closed PR #1102 was a "safety-gap-scanner-v1" finding whose plan listed 4 files (\`approvals.ts\`, \`autopilot.ts\`, \`admin/index.ts\`, \`safety-gap.ts\`) but the executor only created the empty \`safety-gap.ts\` placeholder. The PR opened anyway as dead code.

The existing 3a check inside \`runExecutionSession\` only catches files in the **diff that are NOT in the plan** — it's silent when the diff covers a **subset** of the plan.

## Change

### \`services/gateway/src/services/dev-autopilot-execute.ts\`
New pure function next to \`extractDeletions\`:

\`\`\`ts
validatePlanDiffCoverage(planFiles, diffFiles, threshold = 0.6) -> {
  ok, coverage, planCount, coveredCount, missing
}
\`\`\`

Wired in as a 3b check after the existing 3a out-of-scope guard. When coverage falls below \`PLAN_DIFF_COVERAGE_THRESHOLD\` (0.6), the execution fails with:

> executor diff covers only 25% of the plan's files (1/4). Missing: services/gateway/src/routes/approvals.ts, services/gateway/src/routes/autopilot.ts, services/gateway/src/routes/admin/index.ts

The failure routes through the existing self-healing path — the operator sees WHY in the Self-Healing screen.

### Threshold rationale (0.6)

| Coverage | Result | Case |
| --- | --- | --- |
| 5/5 = 1.00 | pass | ideal |
| 4/5 = 0.80 | pass | "skipped the test file" |
| 3/5 = 0.60 | pass (boundary) | borderline |
| 2/5 = 0.40 | fail | half the plan |
| 1/4 = 0.25 | fail | **PR #1102 case** |

When the plan listed 0 files, the function returns \`ok=true\` and we defer to the existing "executor emitted zero files" check upstream.

### Test — \`services/gateway/test/dev-autopilot-plan-diff-coverage.test.ts\` (10 cases)
- Coverage math at the threshold boundary (0.6)
- The literal PR #1102 scenario
- 100% pass / 80% pass / 33% fail / 0% fail
- Empty plan + empty diff guards
- Custom-threshold parameter
- Out-of-scope diff files don't perturb the metric (3a's job, not 3b)

## Verification plan

1. Merge PR.
2. EXEC-DEPLOY → wait for gateway revision.
3. (Future, after auto-approve re-armed) tail \`[dev-autopilot]\` logs for any \`executor diff covers only N%\` lines on failed executions.

## Test plan

- [ ] CI green (\`validate\`, \`Build gateway\`)
- [ ] Gateway typecheck + build pass
- [ ] Gateway deploys
- [ ] No regressions in existing dev-autopilot tests

🤖 Generated with [Claude Code](https://claude.com/claude-code)