### PR TITLE
fix(autopilot): reject truncated + lying worker output (VTID-02652)

### DIFF
--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -840,6 +840,68 @@ function parseExecutionOutput(raw: string): ExecutionLlmOutput | { error: string
     return { error: 'No <<<FILE …>>>…<<<END>>> blocks found' };
   }
 
+  // VTID-02652 — Check 1: detect truncated output. Count every FILE header
+  // (regardless of whether it has a closing <<<END>>>) and compare to the
+  // count of complete blocks we consumed above. If the model started a
+  // FILE block and then ran out of MESSAGES_MAX_TOKENS before emitting
+  // <<<END>>>, the regex above silently skipped it and the worker would
+  // open a PR claiming changes that aren't in the diff. PR #1102 was the
+  // first observed example: PR_BODY listed 5 files, output truncated
+  // mid-second-file, parser returned 1 block, PR opened with placeholder
+  // code + a body that lied about wiring it up everywhere.
+  const headerRe = /<<<FILE\s+(?:create|modify|delete)\s+\S+\s*>>>/g;
+  const headerCount = (text.match(headerRe) || []).length;
+  if (headerCount !== files.length) {
+    return {
+      error:
+        `Truncated output: ${headerCount} <<<FILE …>>> headers found but only ${files.length} ` +
+        `closed blocks. The model likely hit its token budget mid-file. Reject this attempt — ` +
+        `the worker's PR-opener would otherwise file a PR whose body promises work the diff doesn't deliver.`,
+    };
+  }
+
+  // VTID-02652 — Check 2: PR_BODY-vs-FILE-blocks consistency. The body
+  // sometimes lists files in a bullet structure; if the model truncated
+  // FILE-block emission OR hallucinated wire-ups, the body promises more
+  // than was emitted. Heuristic: extract path-like tokens (containing '/'
+  // and ending in a known code/data extension) from the body, compare
+  // against the set of paths emitted in FILE blocks. If the body claims
+  // a path that no FILE block touches and we have at least 2 such orphan
+  // claims, reject — the autopilot has lied. We allow up to 1 orphan to
+  // tolerate prose like "similar to the pattern in services/foo.ts".
+  const bodyPathRe = /\b([\w./-]+\.(?:ts|tsx|js|jsx|sql|md|json|yml|yaml))\b/g;
+  const claimedPaths = new Set<string>();
+  let pm: RegExpExecArray | null;
+  while ((pm = bodyPathRe.exec(pr_body)) !== null) {
+    const candidate = pm[1];
+    // Skip pure filenames without a directory — too generic to attribute.
+    if (!candidate.includes('/')) continue;
+    claimedPaths.add(candidate);
+  }
+  const emittedPaths = new Set(files.map((f) => f.path));
+  const orphanClaims: string[] = [];
+  for (const claim of claimedPaths) {
+    // Match if any emitted path equals the claim OR ends with it (lets
+    // body shorthand like "approvals.ts" match "src/routes/approvals.ts"
+    // — except we filtered shorthand above by requiring '/').
+    let matched = false;
+    for (const emitted of emittedPaths) {
+      if (emitted === claim || emitted.endsWith(`/${claim}`) || claim.endsWith(`/${emitted}`)) {
+        matched = true;
+        break;
+      }
+    }
+    if (!matched) orphanClaims.push(claim);
+  }
+  if (orphanClaims.length >= 2) {
+    return {
+      error:
+        `PR_BODY claims work on ${orphanClaims.length} files that no FILE block emits: ` +
+        `${orphanClaims.slice(0, 5).join(', ')}. Either the model truncated mid-emission or ` +
+        `hallucinated the wire-up. Reject this attempt rather than opening a PR with a lying body.`,
+    };
+  }
+
   return { files, pr_title, pr_body };
 }
 

--- a/services/gateway/test/dev-autopilot-execute.test.ts
+++ b/services/gateway/test/dev-autopilot-execute.test.ts
@@ -145,6 +145,95 @@ describe('parseExecutionJson (delimiter format)', () => {
     const out = parseExecutionJson('no delimiters here at all');
     expect('error' in out).toBe(true);
   });
+
+  // VTID-02652: truncation + body-consistency guards
+  describe('VTID-02652 hallucination guards', () => {
+    it('rejects truncated output where a second FILE block has no closing END', () => {
+      // Mirrors PR #1102: model emits PR_BODY claiming work on multiple files,
+      // emits one complete FILE block, starts a second FILE block, then runs
+      // out of token budget — no closing <<<END>>>. Old parser silently
+      // returned 1 file. New parser must reject.
+      const raw = [
+        '<<<PR_TITLE>>>t<<<END>>>',
+        '<<<PR_BODY>>>',
+        'Adds the placeholder and wires it into approvals.ts and autopilot.ts.',
+        '<<<END>>>',
+        '',
+        '<<<FILE create services/gateway/src/services/safety-gap.ts>>>',
+        'export function checkSafetyGap() {}',
+        '<<<END>>>',
+        '',
+        // Second header opens but the model's response was cut off here —
+        // no <<<END>>> closes it.
+        '<<<FILE modify services/gateway/src/routes/approvals.ts>>>',
+        'import { checkSafetyGap } from "../services/safety-gap";',
+        '// ... output truncated here, no closing marker ever emitted',
+      ].join('\n');
+      const out = parseExecutionJson(raw);
+      expect('error' in out).toBe(true);
+      if ('error' in out) {
+        expect(out.error).toMatch(/Truncated output/);
+        expect(out.error).toMatch(/2 .*headers .*1 closed/);
+      }
+    });
+
+    it('rejects when PR_BODY claims work on >=2 files no FILE block touches', () => {
+      // Body promises five paths; only one is in the FILE blocks.
+      const raw = [
+        '<<<PR_TITLE>>>t<<<END>>>',
+        '<<<PR_BODY>>>',
+        'Wires checkSafetyGap into:',
+        '- `services/gateway/src/routes/approvals.ts`',
+        '- `services/gateway/src/routes/autopilot.ts`',
+        '- `services/gateway/src/routes/admin/index.ts`',
+        '- `services/gateway/src/routes/index.ts`',
+        '<<<END>>>',
+        '',
+        '<<<FILE create services/gateway/src/services/safety-gap.ts>>>',
+        'export function checkSafetyGap() {}',
+        '<<<END>>>',
+      ].join('\n');
+      const out = parseExecutionJson(raw);
+      expect('error' in out).toBe(true);
+      if ('error' in out) {
+        expect(out.error).toMatch(/PR_BODY claims work on/);
+      }
+    });
+
+    it('tolerates one orphan path mention in PR_BODY (prose / context references)', () => {
+      // Body references a related file by way of explanation — should NOT
+      // trip the consistency check at <2 orphans.
+      const raw = [
+        '<<<PR_TITLE>>>t<<<END>>>',
+        '<<<PR_BODY>>>',
+        'Mirrors the pattern already used in `services/gateway/src/routes/foo.ts`.',
+        '<<<END>>>',
+        '',
+        '<<<FILE create services/gateway/src/routes/bar.test.ts>>>',
+        'export const x = 1;',
+        '<<<END>>>',
+      ].join('\n');
+      const out = parseExecutionJson(raw);
+      expect('error' in out).toBe(false);
+    });
+
+    it('matches body-shorthand path against fully-qualified emitted path', () => {
+      // Body uses a multi-segment relative path, FILE block uses the full
+      // services/... path. The endsWith match should accept this.
+      const raw = [
+        '<<<PR_TITLE>>>t<<<END>>>',
+        '<<<PR_BODY>>>',
+        'Adds tests in `gateway/src/routes/foo.test.ts`.',
+        '<<<END>>>',
+        '',
+        '<<<FILE create services/gateway/src/routes/foo.test.ts>>>',
+        'describe("foo", () => {});',
+        '<<<END>>>',
+      ].join('\n');
+      const out = parseExecutionJson(raw);
+      expect('error' in out).toBe(false);
+    });
+  });
 });
 
 describe('buildExecutionPrompt', () => {


### PR DESCRIPTION
## Summary

Two surgical guards in `parseExecutionOutput()` to stop the autonomous loop from opening PRs whose body promises work the diff doesn't deliver.

## Background — PR #1102 evidence

The autopilot opened a PR whose body said it had:
1. created `services/gateway/src/services/safety-gap.ts`
2. wired `checkSafetyGap` into `approvals.ts`, `autopilot.ts`, `admin/index.ts`, and `index.ts`
3. added an integration test

The actual diff: a single 14-line placeholder file. Items 2 and 3 were hallucinated. The reviewer (human) closed it on 2026-04-30 with the comment *"Closing — adds an unused safety-gap.ts placeholder (no-op function not imported anywhere)."*

## Root cause

The worker's LLM hits `MESSAGES_MAX_TOKENS = 16000` mid-stream. Output order is **PR_TITLE → PR_BODY** (small) **→ first FILE block** (small, emitted with closing `<<<END>>>`) **→ second FILE block** (started, dumped TypeScript, ran out of tokens before `<<<END>>>`).

The `fileRe` regex requires `<<<END>>>` as a closing marker, so it silently skips the unclosed second block. `parseExecutionOutput()` returned 1 file and a body that claimed 5. The PR opener trusted it.

This is the failure mode behind ~80% of the "closed unmerged" autopilot PRs in the last 2 days.

## The fix

### Check 1 — orphan-header detection
Count `<<<FILE …>>>` headers in the raw text. Compare to closed-block count. Mismatch → reject. Catches mid-block truncation.

### Check 2 — PR_BODY-vs-FILE-blocks consistency
Extract path-like tokens from `PR_BODY` (anything containing `/` and ending in a known code/data extension). For each, check whether any emitted FILE block path equals or `endsWith` it. ≥2 orphans → reject. We tolerate **1** orphan to leave room for prose like *"mirrors the pattern in `services/foo.ts`"*.

Both checks return `{ error }` from `parseExecutionOutput()`; the worker's `runExecutionSession()` already routes parser errors to the failed-state + self-healing path, so the bad attempt never reaches the PR opener.

## Tests

4 new cases under `"VTID-02652 hallucination guards"`:
- rejects truncated output where a second FILE block has no closing END
- rejects when PR_BODY claims work on ≥2 files no FILE block touches
- tolerates one orphan path mention (prose / context refs)
- matches body-shorthand path against fully-qualified emitted path

All 11 parser tests pass. Verified with `npm run build` per the new memory rule (`tsc --noEmit` doesn't catch what `tsc` build mode catches).

## Test plan

- [ ] Existing autopilot PRs that already shipped behave the same — no regression on well-formed output.
- [ ] Next autopilot scan-cycle with multi-file findings either succeeds in full OR is rejected with one of the new error strings; no more PRs opened with hallucinated bodies.
- [ ] `dev_autopilot_outcomes` rows for rejected attempts get `exec_outcome='failure'` (existing path).

## Out of scope (deferred to follow-up)

- Bumping `MESSAGES_MAX_TOKENS` from 16K → 32K — better headroom but doesn't replace these checks.
- Switching modify-actions to diff/patch output — bigger architectural decision.
- Per-file LLM calls — much higher reliability but ~5× API cost.

🤖 Generated with [Claude Code](https://claude.com/claude-code)