### PR TITLE
feat(orb): tenant-aware persona registry + ORB pass-through (VTID-02654)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -48,12 +48,21 @@ import { processWithGemini, setThreadIdentity } from '../services/gemini-operato
 import { emitOasisEvent } from '../services/oasis-event-service';
 // VTID-02651: persona registry — voice/greeting/handles_kinds all loaded
 // from agent_personas at runtime so any new specialist is a config insert.
+// VTID-02653 Phase 6: tenant-aware overlay variants. The runtime uses
+// these whenever session.identity.tenant_id is available so each tenant
+// gets their customised view of the team. Falls back to the platform
+// variants for sessions without tenant context (anonymous, ops surfaces).
 import {
   getPersonaVoice as registryGetPersonaVoice,
   getPersonaGreeting as registryGetPersonaGreeting,
   pickPersonaForKind as registryPickPersonaForKind,
   isValidPersona as registryIsValidPersona,
   listAllPersonaKeys as registryListAllPersonaKeys,
+  getPersonaVoiceForTenant as registryGetPersonaVoiceForTenant,
+  getPersonaGreetingForTenant as registryGetPersonaGreetingForTenant,
+  pickPersonaForKindForTenant as registryPickPersonaForKindForTenant,
+  isValidPersonaForTenant as registryIsValidPersonaForTenant,
+  listAllPersonaKeysForTenant as registryListAllPersonaKeysForTenant,
   RECEPTIONIST_KEY as RECEPTIONIST_PERSONA_KEY,
 } from '../services/persona-registry';
 import { dispatchVoiceFailureFireAndForget } from '../services/voice-self-healing-adapter';
@@ -3789,12 +3798,19 @@ async function executeLiveApiToolInner(
 
       case 'switch_persona': {
         const target = String(args.to || '').toLowerCase();
-        // VTID-02651: validate against the live persona registry rather than
-        // a hardcoded list. Adding a new specialist via INSERT into
-        // agent_personas makes them an immediate valid swap target.
-        const targetIsValid = await registryIsValidPersona(target);
+        // VTID-02651 + VTID-02653: validate against the persona registry.
+        // When the session has a tenant context, use the tenant-aware
+        // variant — that excludes personas the tenant has disabled, so
+        // the LLM cannot accidentally swap the user to a colleague who's
+        // turned off for their tenant.
+        const _swapTenantId = session.identity?.tenant_id;
+        const targetIsValid = _swapTenantId
+          ? await registryIsValidPersonaForTenant(target, _swapTenantId)
+          : await registryIsValidPersona(target);
         if (!targetIsValid) {
-          const valid = await registryListAllPersonaKeys();
+          const valid = _swapTenantId
+            ? await registryListAllPersonaKeysForTenant(_swapTenantId)
+            : await registryListAllPersonaKeys();
           return { success: false, result: '', error: `Invalid persona: ${target} (active personas: ${valid.join(', ')})` };
         }
         const currentPersona = ((session as any).activePersona as string) || 'vitana';
@@ -3841,8 +3857,15 @@ async function executeLiveApiToolInner(
             (session as any).personaSystemOverride = personaPrompt +
               `\n\n[CONVERSATION HANDOFF] You have just been brought into an existing voice call. The user explicitly asked to switch to you (no new ticket — they're navigating between colleagues). Greet briefly and ask how you can help.` +
               `\n\n[NAVIGATION TOOL] You have a switch_persona tool. Call it when the user wants to talk to someone else: "back to ${RECEPTIONIST_PERSONA_KEY} please", "zurück zur Rezeption", "talk to a different colleague instead", etc. Pass to='${RECEPTIONIST_PERSONA_KEY}' to hand back, or to=<persona_key> to swap to another active colleague (the available keys live in agent_personas). After calling, speak a one-line bridge then STOP.`;
-            (session as any).personaVoiceOverride = await registryGetPersonaVoice(target);
-            (session as any).personaForcedFirstMessage = await registryGetPersonaGreeting(target, session.lang || 'en');
+            // VTID-02653 Phase 6: tenant-aware voice + greeting lookup.
+            // Tenant custom_greeting_templates win over platform per-language
+            // greetings; tenant disable was already filtered above.
+            (session as any).personaVoiceOverride = _swapTenantId
+              ? await registryGetPersonaVoiceForTenant(target, _swapTenantId)
+              : await registryGetPersonaVoice(target);
+            (session as any).personaForcedFirstMessage = _swapTenantId
+              ? await registryGetPersonaGreetingForTenant(target, session.lang || 'en', _swapTenantId)
+              : await registryGetPersonaGreeting(target, session.lang || 'en');
             console.log(`[VTID-02047] switch_persona: ${currentPersona} → ${target} queued, voice=${(session as any).personaVoiceOverride}`);
           }
 
@@ -3884,16 +3907,28 @@ async function executeLiveApiToolInner(
           const url = process.env.SUPABASE_URL!;
           const key = process.env.SUPABASE_SERVICE_ROLE!;
 
-          // Resolve specialist via keyword router unless hinted explicitly
+          // Resolve specialist via keyword router unless hinted explicitly.
+          // VTID-02653 Phase 6: when the session has a tenant context, use
+          // the tenant-aware RPC pick_specialist_for_text_tenant which
+          // UNIONs platform handoff_keywords with the tenant's own routing
+          // keywords (and respects tenant disable). Falls back to the
+          // platform-only RPC when no tenant context (anonymous sessions).
           let pickedPersona = specialistHint;
           let matchedKeyword: string | null = null;
           let confidence: number | null = null;
+          const _reportTenantId = session.identity?.tenant_id;
           if (!pickedPersona) {
             try {
-              const rpcResp = await fetch(`${url}/rest/v1/rpc/pick_specialist_for_text`, {
+              const rpcName = _reportTenantId
+                ? 'pick_specialist_for_text_tenant'
+                : 'pick_specialist_for_text';
+              const rpcBody = _reportTenantId
+                ? { p_text: summary, p_tenant_id: _reportTenantId }
+                : { p_text: summary };
+              const rpcResp = await fetch(`${url}/rest/v1/rpc/${rpcName}`, {
                 method: 'POST',
                 headers: { 'Content-Type': 'application/json', apikey: key, Authorization: `Bearer ${key}` },
-                body: JSON.stringify({ p_text: summary }),
+                body: JSON.stringify(rpcBody),
               });
               const rpcJson = await rpcResp.json().catch(() => null);
               const row = Array.isArray(rpcJson) ? rpcJson[0] : rpcJson;
@@ -3905,12 +3940,13 @@ async function executeLiveApiToolInner(
             } catch { /* keep empty hint, fall through */ }
           }
           // VTID-02651: kind→persona mapping is data-driven from
-          // agent_personas.handles_kinds. Adding a new persona that handles
-          // a kind = updating that row's handles_kinds array; no code
-          // change needed. Falls back to '' (caller skips swap) if no
-          // active persona claims the kind.
+          // agent_personas.handles_kinds. VTID-02653: tenant variant skips
+          // personas the tenant has disabled. Falls back to '' (caller
+          // skips swap) if no active persona claims the kind.
           if (!pickedPersona) {
-            pickedPersona = (await registryPickPersonaForKind(kind)) ?? '';
+            pickedPersona = _reportTenantId
+              ? ((await registryPickPersonaForKindForTenant(kind, _reportTenantId)) ?? '')
+              : ((await registryPickPersonaForKind(kind)) ?? '');
           }
 
           const insertResp = await fetch(`${url}/rest/v1/feedback_tickets`, {
@@ -4025,9 +4061,14 @@ async function executeLiveApiToolInner(
                 (session as any).personaSystemOverride = personaPrompt +
                   `\n\n[CONVERSATION HANDOFF] You have just been brought into an existing voice call between the user and Vitana. The user already explained: "${summary}". Acknowledge this in your greeting — you do NOT need them to repeat themselves.` +
                   `\n\n[NAVIGATION TOOL] You have a switch_persona tool. Call it when the user wants to talk to someone else: "back to ${RECEPTIONIST_PERSONA_KEY}", "talk to a different colleague instead", etc. Pass to='${RECEPTIONIST_PERSONA_KEY}' to hand back, or to=<persona_key> to swap to another active colleague (active keys live in agent_personas). After calling, speak a one-line bridge then STOP.`;
-                (session as any).personaVoiceOverride = await registryGetPersonaVoice(swapTo);
-                (session as any).personaForcedFirstMessage = await registryGetPersonaGreeting(swapTo, session.lang || 'en');
-                console.log(`[VTID-02047] Persona swap queued: ${RECEPTIONIST_PERSONA_KEY} → ${swapTo}, voice=${(session as any).personaVoiceOverride}`);
+                // VTID-02653 Phase 6: tenant-aware voice + greeting.
+                (session as any).personaVoiceOverride = _reportTenantId
+                  ? await registryGetPersonaVoiceForTenant(swapTo, _reportTenantId)
+                  : await registryGetPersonaVoice(swapTo);
+                (session as any).personaForcedFirstMessage = _reportTenantId
+                  ? await registryGetPersonaGreetingForTenant(swapTo, session.lang || 'en', _reportTenantId)
+                  : await registryGetPersonaGreeting(swapTo, session.lang || 'en');
+                console.log(`[VTID-02047] Persona swap queued: ${RECEPTIONIST_PERSONA_KEY} → ${swapTo}, voice=${(session as any).personaVoiceOverride}, tenant=${_reportTenantId ?? 'none'}`);
 
                 // Notify the client UI so it can show "Talking to <Persona>"
                 const swapMsg = {
@@ -8035,7 +8076,11 @@ async function connectToLiveAPI(
       let _personaVoice = (session as any).personaVoiceOverride;
       if (!_personaVoice) {
         try {
-          const fromRegistry = await registryGetPersonaVoice(_persona);
+          // VTID-02653: tenant-aware lookup when session has tenant context.
+          const _setupTenantId = session.identity?.tenant_id;
+          const fromRegistry = _setupTenantId
+            ? await registryGetPersonaVoiceForTenant(_persona, _setupTenantId)
+            : await registryGetPersonaVoice(_persona);
           if (fromRegistry) _personaVoice = fromRegistry;
         } catch (e) {
           console.warn(`[VTID-02651] persona registry lookup failed for ${_persona}:`, e);

--- a/services/gateway/src/services/persona-registry.ts
+++ b/services/gateway/src/services/persona-registry.ts
@@ -159,3 +159,181 @@ export async function isValidPersona(key: string): Promise<boolean> {
   const reg = await loadPersonaRegistry();
   return reg.has(key);
 }
+
+// ===========================================================================
+// VTID-02653: Phase 6 — tenant overlay support.
+// ===========================================================================
+// Three-layer separation:
+//   Command Hub (BUILD)    → agent_personas + agent_tools + audit_log
+//   Tenant Admin (CUSTOMIZE) → agent_personas_tenant_overrides +
+//                              agent_kb_bindings_tenant +
+//                              agent_routing_keywords_tenant +
+//                              agent_third_party_connections (tenant_id=X)
+//   Community User (USE)   → loadPersonaRegistryForTenant() at runtime
+//
+// The tenant-aware loader merges platform defaults with the tenant's
+// overrides:
+//   - filter out personas where the tenant has set enabled=false
+//   - merge intake_schema_extras into a shadow field on the record
+//   - prefer custom_greeting_templates over platform greetings when present
+
+export interface TenantOverridesRecord {
+  tenant_id: string;
+  persona_id: string;
+  enabled: boolean;
+  intake_schema_extras: Record<string, unknown>;
+  custom_greeting_templates: Record<string, string>;
+}
+
+export interface TenantPersonaRecord extends PersonaRecord {
+  // Effective record after applying tenant overlay. Always has
+  // tenant_enabled (defaults to true if no override row exists).
+  tenant_enabled: boolean;
+  intake_schema_extras: Record<string, unknown>;
+}
+
+const tenantCache = new Map<string, { at: number; map: Map<string, TenantPersonaRecord> }>();
+
+async function loadTenantOverrides(tenantId: string): Promise<Map<string, TenantOverridesRecord>> {
+  const supabase = getServiceClient();
+  const { data, error } = await supabase
+    .from('agent_personas_tenant_overrides')
+    .select('tenant_id, persona_id, enabled, intake_schema_extras, custom_greeting_templates')
+    .eq('tenant_id', tenantId);
+  if (error) {
+    console.warn(`[persona-registry] tenant overrides load failed for ${tenantId}:`, error.message);
+    return new Map();
+  }
+  const map = new Map<string, TenantOverridesRecord>();
+  for (const row of data ?? []) {
+    const r = row as TenantOverridesRecord;
+    map.set(r.persona_id, r);
+  }
+  return map;
+}
+
+/**
+ * Tenant-aware variant of loadPersonaRegistry. Merges platform defaults
+ * with the tenant's overlay rows. Cached for 60s per tenant.
+ */
+export async function loadPersonaRegistryForTenant(
+  tenantId: string,
+  forceRefresh = false,
+): Promise<Map<string, TenantPersonaRecord>> {
+  if (!tenantId) {
+    // No tenant → return platform-only view, with tenant_enabled=true on all.
+    const platform = await loadPersonaRegistry(forceRefresh);
+    const merged = new Map<string, TenantPersonaRecord>();
+    for (const [k, p] of platform) {
+      merged.set(k, { ...p, tenant_enabled: true, intake_schema_extras: {} });
+    }
+    return merged;
+  }
+  const cached = tenantCache.get(tenantId);
+  if (!forceRefresh && cached && Date.now() - cached.at < CACHE_TTL_MS) {
+    return cached.map;
+  }
+  const [platform, overrides] = await Promise.all([
+    loadPersonaRegistry(forceRefresh),
+    loadTenantOverrides(tenantId),
+  ]);
+  const merged = new Map<string, TenantPersonaRecord>();
+  for (const [k, p] of platform) {
+    const ov = overrides.get(p.id);
+    const tenant_enabled = ov ? ov.enabled : true;
+    // Merge greeting templates: tenant custom wins over platform per-language
+    const greeting_templates =
+      ov?.custom_greeting_templates && Object.keys(ov.custom_greeting_templates).length > 0
+        ? { ...p.greeting_templates, ...ov.custom_greeting_templates }
+        : p.greeting_templates;
+    merged.set(k, {
+      ...p,
+      greeting_templates,
+      tenant_enabled,
+      intake_schema_extras: ov?.intake_schema_extras ?? {},
+    });
+  }
+  tenantCache.set(tenantId, { at: Date.now(), map: merged });
+  return merged;
+}
+
+export function clearTenantPersonaCache(tenantId?: string): void {
+  if (tenantId) tenantCache.delete(tenantId);
+  else tenantCache.clear();
+}
+
+/**
+ * Tenant-aware voice lookup. If the tenant disabled this persona (or the
+ * persona doesn't exist), returns ''. Custom voice overrides are NOT yet
+ * supported on the tenant overlay (deferred per Phase 6 plan); this just
+ * gates by tenant_enabled.
+ */
+export async function getPersonaVoiceForTenant(key: string, tenantId: string): Promise<string> {
+  const reg = await loadPersonaRegistryForTenant(tenantId);
+  const p = reg.get(key);
+  if (!p || !p.tenant_enabled) return '';
+  return p.voice_id ?? '';
+}
+
+/**
+ * Tenant-aware greeting lookup. Honors tenant custom_greeting_templates
+ * if set, otherwise falls back to platform greeting → English → generic.
+ */
+export async function getPersonaGreetingForTenant(
+  key: string,
+  lang: string,
+  tenantId: string,
+): Promise<string> {
+  const reg = await loadPersonaRegistryForTenant(tenantId);
+  const p = reg.get(key);
+  if (!p) return `Hi, ${key} here. How can I help?`;
+  const tpls = p.greeting_templates ?? {};
+  if (tpls[lang]) return tpls[lang];
+  if (tpls['en']) return tpls['en'];
+  return `Hi, ${p.display_name} here. How can I help?`;
+}
+
+/**
+ * Tenant-aware kind→persona resolver. Same shape as pickPersonaForKind
+ * but skips personas the tenant has disabled.
+ */
+export async function pickPersonaForKindForTenant(
+  kind: string,
+  tenantId: string,
+): Promise<string | null> {
+  if (!kind) return null;
+  const reg = await loadPersonaRegistryForTenant(tenantId);
+  for (const p of reg.values()) {
+    if (p.key === RECEPTIONIST_KEY) continue;
+    if (!p.tenant_enabled) continue;
+    if (Array.isArray(p.handles_kinds) && p.handles_kinds.includes(kind)) {
+      return p.key;
+    }
+  }
+  return null;
+}
+
+/**
+ * Tenant-aware persona validity. Returns false if the persona doesn't
+ * exist or is disabled for this tenant. Used by switch_persona to prevent
+ * the LLM from switching the user to a colleague their tenant disabled.
+ */
+export async function isValidPersonaForTenant(key: string, tenantId: string): Promise<boolean> {
+  const reg = await loadPersonaRegistryForTenant(tenantId);
+  const p = reg.get(key);
+  return !!p && p.tenant_enabled;
+}
+
+/**
+ * Tenant-aware persona keys list. Returns only personas enabled for the
+ * tenant. Used by switch_persona error messages and the runtime tool
+ * description hints.
+ */
+export async function listAllPersonaKeysForTenant(tenantId: string): Promise<string[]> {
+  const reg = await loadPersonaRegistryForTenant(tenantId);
+  const out: string[] = [];
+  for (const [k, p] of reg) {
+    if (p.tenant_enabled) out.push(k);
+  }
+  return out;
+}


### PR DESCRIPTION
Phase 6 PR 27. Runtime now honours the tenant overlay tables from #1151. Every voice/greeting/kind-routing/persona-validation site in orb-live.ts uses the tenant-aware variant when session.identity.tenant_id is set. Tenant disable filters propagate; tenant custom greeting templates win over platform per-language. report_to_specialist routes through pick_specialist_for_text_tenant RPC.

🤖 Generated with [Claude Code](https://claude.com/claude-code)