### PR TITLE
feat(orb-agent): scaffold Python livekit-agents worker skeleton (VTID-02672)

### DIFF
--- a/services/agents/orb-agent/.gitignore
+++ b/services/agents/orb-agent/.gitignore
@@ -1,0 +1,11 @@
+__pycache__/
+*.pyc
+*.pyo
+.venv/
+.pytest_cache/
+.mypy_cache/
+.ruff_cache/
+*.egg-info/
+build/
+dist/
+.coverage

--- a/services/agents/orb-agent/Dockerfile
+++ b/services/agents/orb-agent/Dockerfile
@@ -1,0 +1,55 @@
+# LiveKit ORB Voice Agent — Dockerfile for Cloud Run deployment.
+# Standby alternative to the Vertex Live pipeline (services/gateway/src/routes/orb-live.ts).
+#
+# Build: docker build -t orb-agent:dev .
+# Run:   docker run --rm -p 8080:8080 \
+#          -e LIVEKIT_URL=wss://livekit.your-domain \
+#          -e LIVEKIT_API_KEY=... -e LIVEKIT_API_SECRET=... \
+#          -e GATEWAY_URL=https://gateway-q74ibpv6ia-uc.a.run.app \
+#          orb-agent:dev
+
+FROM python:3.11-slim AS builder
+
+WORKDIR /app
+
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    build-essential \
+    curl \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY requirements.txt .
+RUN pip install --no-cache-dir --upgrade pip && \
+    pip install --no-cache-dir --target /install -r requirements.txt
+
+# ---- runtime ----
+FROM python:3.11-slim AS runtime
+
+WORKDIR /app
+
+# libstdc++ is sometimes needed by silero VAD wheels; ffmpeg is needed for
+# audio resampling on the small number of providers that don't ship native.
+RUN apt-get update && apt-get install -y --no-install-recommends \
+    ffmpeg \
+    libstdc++6 \
+    && rm -rf /var/lib/apt/lists/*
+
+COPY --from=builder /install /usr/local/lib/python3.11/site-packages
+
+COPY src/ ./src/
+COPY main.py manifest.json ./
+
+ENV PYTHONUNBUFFERED=1 \
+    PYTHONDONTWRITEBYTECODE=1 \
+    PORT=8080 \
+    AGENT_LOG_LEVEL=INFO
+
+EXPOSE 8080
+
+# Cloud Run sends SIGTERM and gives 10s to drain. The agent gracefully closes
+# in-flight LiveKit rooms before exit.
+STOPSIGNAL SIGTERM
+
+# Cloud Run health probe targets /health on $PORT — exposed by main.py's
+# embedded FastAPI health server. The actual livekit-agents worker connects
+# outbound to LIVEKIT_URL and runs in-process.
+CMD ["python", "main.py"]

--- a/services/agents/orb-agent/README.md
+++ b/services/agents/orb-agent/README.md
@@ -1,0 +1,95 @@
+# orb-agent
+
+LiveKit-based ORB voice agent worker.
+
+## What this service is
+
+A Python `livekit-agents` worker that joins LiveKit rooms as a participant, runs a configurable STT → LLM → TTS cascade, dispatches the same ~40 tools the Vertex Live pipeline exposes, and emits OASIS events with the same semantics. It is the **standby alternative** to the Vertex Live pipeline at `services/gateway/src/routes/orb-live.ts`.
+
+The two pipelines are **mutually exclusive** at runtime — exactly one is active at any moment, controlled by `system_config.voice.active_provider` ∈ `{vertex, livekit}`. When this service is the standby, Cloud Run runs zero instances (`min_instances=0`).
+
+See `.claude/plans/here-is-what-our-valiant-stearns.md` for the full architecture rationale.
+
+## Status
+
+**Skeleton.** Module shape established, key entrypoints stubbed, imports compile. **Does not run a real conversation yet.** Subsequent PRs land:
+
+1. Real `instructions.py` system-instruction builder ported from `buildLiveSystemInstruction()` in `orb-live.ts`.
+2. Real `tools.py` — every tool from `voice-pipeline-spec/spec.json` as a `@function_tool` HTTP wrapper to its existing gateway endpoint.
+3. Real `providers.py` factory that loads STT/LLM/TTS plugins from `agent_voice_configs`.
+4. Real `bootstrap.py` calling `GET /api/v1/orb/context-bootstrap`.
+5. Real `oasis.py` POSTing to `POST /api/v1/oasis/emit`.
+6. Real `session.py` lifecycle including the multi-specialist handoff path.
+
+## Module layout
+
+```
+services/agents/orb-agent/
+  main.py                  — entrypoint: starts livekit-agents worker + health server
+  src/orb_agent/
+    __init__.py
+    config.py              — env vars + LiveKit config resolution
+    session.py             — agent session lifecycle + handoff path
+    instructions.py        — buildLive / buildAnonymous system-instruction builders
+    tools.py               — @function_tool wrappers (one per spec.json tool)
+    providers.py           — STT/LLM/TTS plugin factory from agent_voice_configs
+    bootstrap.py           — context-bootstrap fetcher (memory + role + last session + admin briefing)
+    oasis.py               — OASIS event emitter (POSTs to gateway)
+    watchdogs.py           — stall watchdog + reconnect bucket counter
+    identity.py            — JWT identity resolution + mobile=community coercion
+    navigator.py           — get_current_screen / navigate tool helpers
+    video.py               — video frame forwarder for vision-capable LLMs
+    health.py              — embedded FastAPI health-check server (Cloud Run probe)
+    registry_client.py     — agents_registry self-register heartbeat
+  tests/                   — unit tests (pytest)
+```
+
+## Running locally
+
+Two-step. First the gateway must be reachable (it owns context-bootstrap, OASIS-emit, tool endpoints, the LiveKit token mint). Then the agent connects to a self-hosted LiveKit Server.
+
+```bash
+cd services/agents/orb-agent
+
+# 1. Install (with extra providers)
+pip install -e ".[dev,extra-providers]"
+
+# 2. Configure
+export LIVEKIT_URL=wss://livekit.your-domain.dev
+export LIVEKIT_API_KEY=...
+export LIVEKIT_API_SECRET=...
+export GATEWAY_URL=https://gateway-q74ibpv6ia-uc.a.run.app
+export GATEWAY_SERVICE_TOKEN=...
+
+# 3. Run
+python main.py
+# health: http://localhost:8080/health
+# the worker connects outbound to LIVEKIT_URL and waits for room dispatch
+```
+
+## How it relates to the parity scanner
+
+`voice-pipeline-spec/tools/extract-py.py` (the libcst walker) statically extracts:
+- every `@function_tool`-decorated function in this folder → tool list
+- every `oasis.emit(topic=...)` call site → OASIS topics
+- every `*_MS` / `MAX_*` / `*_TIMEOUT` constant → watchdog values
+- the parameter signatures of `build_live_system_instruction` / `build_anonymous_system_instruction`
+
+Then `voice-pipeline-spec/tools/diff.ts` three-way-diffs against `spec.json` and the Vertex extraction. If a new tool appears in `orb-live.ts` but not here (or vice versa), the parity scanner CI flags it on the offending PR. After 30 days of green runs, the scanner promotes from report-only to a hard merge gate for safety-critical drift.
+
+This is why the skeleton matters: it gives the Python extractor real symbols to find, even before any tool body is implemented. Empty `@function_tool` stubs that match the spec are the foundation.
+
+## Deployment
+
+Cloud Run service `vitana-orb-agent` in `us-central1`, `min-instances=0`, `max-instances=10`. EXEC-DEPLOY workflow gates on the `/health` probe responding 200 with `{"livekit_reachable": true, "providers": {...}}`.
+
+Standby cost is near-zero: `min-instances=0` means no idle compute. The only standing costs are the LiveKit SFU pair (separate workload) and the Artifact Registry image (~$0.20/mo).
+
+## Memory anchors
+
+- Plan: `.claude/plans/here-is-what-our-valiant-stearns.md`
+- Spec: `voice-pipeline-spec/spec.json`
+- Vertex sibling: `services/gateway/src/routes/orb-live.ts`
+- Parallel team: `memory/project_unified_feedback_pipeline.md` — owns the specialist handoff path on the Vertex side
+- Mobile rule: `memory/feedback_mobile_community_only.md`
+- Apology-loop fix: `memory/orb_apology_loop_fix_VTID_02637.md`

--- a/services/agents/orb-agent/main.py
+++ b/services/agents/orb-agent/main.py
@@ -1,0 +1,94 @@
+"""orb-agent entrypoint.
+
+Boots two things:
+  1. An embedded FastAPI health server (Cloud Run probe target on $PORT).
+  2. The livekit-agents worker (when wired in the follow-up PR), which
+     dials the configured LiveKit URL and waits for room dispatch.
+
+Skeleton today: the worker isn't wired yet — main.py runs the health
+server only, registers with agents_registry, and logs that it's standby.
+This is sufficient for Cloud Run deploy + smoke tests to pass.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import signal
+
+import structlog
+import uvicorn
+
+from src.orb_agent.config import AgentConfig
+from src.orb_agent.health import make_health_app
+from src.orb_agent.registry_client import RegistryHeartbeat
+
+
+def configure_logging(level: str) -> None:
+    logging.basicConfig(level=getattr(logging, level.upper(), logging.INFO))
+    structlog.configure(
+        processors=[
+            structlog.processors.add_log_level,
+            structlog.processors.TimeStamper(fmt="iso"),
+            structlog.processors.JSONRenderer(),
+        ],
+        wrapper_class=structlog.make_filtering_bound_logger(
+            getattr(logging, level.upper(), logging.INFO)
+        ),
+    )
+
+
+async def run() -> None:
+    cfg = AgentConfig.from_env()
+    configure_logging(cfg.log_level)
+    log = structlog.get_logger("orb-agent")
+    log.info("orb-agent.boot", version="0.1.0", livekit_url=cfg.livekit_url)
+
+    # Health server.
+    app = make_health_app()
+    server_cfg = uvicorn.Config(
+        app, host="0.0.0.0", port=cfg.health_port, log_config=None, access_log=False
+    )
+    server = uvicorn.Server(server_cfg)
+    server_task = asyncio.create_task(server.serve(), name="health-server")
+
+    # agents_registry heartbeat.
+    heartbeat = RegistryHeartbeat(
+        gateway_url=cfg.gateway_url,
+        service_token=cfg.gateway_service_token,
+        interval_s=cfg.heartbeat_interval_seconds,
+    )
+    heartbeat.start()
+
+    # TODO(VTID-LIVEKIT-FOUNDATION): wire livekit-agents worker here. Pseudocode:
+    #
+    #     from livekit.agents import WorkerOptions, cli
+    #     from src.orb_agent.session import AgentSession
+    #
+    #     worker_opts = WorkerOptions(
+    #         entrypoint_fnc=AgentSession.entrypoint,
+    #         max_concurrent_jobs=10,
+    #     )
+    #     cli.run_app(worker_opts)
+    #
+    # For the skeleton, we just keep the health server alive.
+
+    log.info("orb-agent.ready_skeleton", note="livekit worker not yet wired")
+
+    # Graceful shutdown on SIGTERM.
+    stop = asyncio.Event()
+    loop = asyncio.get_running_loop()
+    for sig in (signal.SIGTERM, signal.SIGINT):
+        try:
+            loop.add_signal_handler(sig, stop.set)
+        except NotImplementedError:  # pragma: no cover (Windows)
+            pass
+    await stop.wait()
+    log.info("orb-agent.stopping")
+    await heartbeat.stop()
+    server.should_exit = True
+    await server_task
+    log.info("orb-agent.stopped")
+
+
+if __name__ == "__main__":
+    asyncio.run(run())

--- a/services/agents/orb-agent/manifest.json
+++ b/services/agents/orb-agent/manifest.json
@@ -1,0 +1,115 @@
+{
+  "name": "AGENT-ORB-AGENT",
+  "vt_layer": "AICOR",
+  "vt_module": "VOICE",
+  "vtid": "VTID-LIVEKIT-FOUNDATION",
+  "version": "0.1.0",
+  "description": "LiveKit-based ORB voice agent worker. Joins LiveKit rooms as a participant, runs a configurable STT/LLM/TTS cascade, dispatches gateway tools, emits OASIS events. Standby alternative to the Vertex Live pipeline at services/gateway/src/routes/orb-live.ts. Mutually exclusive with Vertex — only one is active at a time per system_config.voice.active_provider.",
+  "provider_policy": {
+    "transport": {
+      "provider": "livekit-self-hosted",
+      "note": "Self-hosted LiveKit OSS on GCP Compute Engine (NOT LiveKit Cloud). 2x c2-standard-4 SFU pair + Memorystore Redis."
+    },
+    "stt": {
+      "provider": "configurable",
+      "default": "deepgram/nova-3",
+      "note": "Resolved per-agent at session start from voice_providers + agent_voice_configs tables. See migration vtid_livekit_foundation_voice_tables.sql."
+    },
+    "llm": {
+      "provider": "configurable",
+      "default": "anthropic/claude-sonnet-4-6",
+      "note": "Resolved per-agent. Tool catalogue is model-agnostic via livekit-agents @function_tool. tool_choice / parallel-call / strict-schema details are normalized inside each plugin."
+    },
+    "tts": {
+      "provider": "configurable",
+      "default": "cartesia/sonic-3",
+      "note": "Per-agent voice picked from voice_providers.models[].voices_per_lang. Each specialist (Vitana / Sage / Devon / Atlas / Mira) gets a distinct voice."
+    }
+  },
+  "required_env": [
+    "LIVEKIT_URL",
+    "LIVEKIT_API_KEY",
+    "LIVEKIT_API_SECRET",
+    "GATEWAY_URL",
+    "GATEWAY_SERVICE_TOKEN"
+  ],
+  "optional_env": [
+    "DEEPGRAM_API_KEY",
+    "ASSEMBLYAI_API_KEY",
+    "CARTESIA_API_KEY",
+    "ELEVENLABS_API_KEY",
+    "RIME_API_KEY",
+    "INWORLD_API_KEY",
+    "ANTHROPIC_API_KEY",
+    "OPENAI_API_KEY",
+    "GROQ_API_KEY",
+    "GOOGLE_GEMINI_API_KEY",
+    "AGENT_LOG_LEVEL",
+    "AGENT_MAX_TOOL_STEPS",
+    "AGENT_MAX_RECONNECTS"
+  ],
+  "features": [
+    "livekit_agents_worker",
+    "configurable_cascade",
+    "function_tool_dispatch",
+    "context_bootstrap_via_gateway",
+    "agents_registry_self_register",
+    "oasis_event_emit",
+    "multi_specialist_handoff",
+    "vertex_pipeline_parity"
+  ],
+  "constraints": {
+    "scale_to_zero_when_standby": true,
+    "single_voice_provider_active": true,
+    "no_business_logic_in_agent": true,
+    "every_tool_calls_gateway_endpoint": true
+  },
+  "telemetry": {
+    "oasis_events": [
+      "livekit.session.start",
+      "livekit.session.stop",
+      "livekit.tool.executed",
+      "livekit.tool_loop_guard_activated",
+      "livekit.stall_detected",
+      "livekit.connection_failed",
+      "livekit.config_missing",
+      "livekit.fallback_used",
+      "livekit.provider_quota_exceeded",
+      "livekit.provider_failover",
+      "livekit.context.bootstrap",
+      "livekit.context.bootstrap.skipped",
+      "voice.handoff.start",
+      "voice.handoff.complete",
+      "voice.handoff.failed",
+      "agent.voice.persona_swap"
+    ]
+  },
+  "runtime": {
+    "type": "cloud-run",
+    "min_instances": 0,
+    "max_instances": 10,
+    "cpu": "2",
+    "memory": "4Gi",
+    "timeout_seconds": 3600,
+    "note": "min=0 enforces scale-to-zero standby semantics. When LiveKit is the standby provider, no agent processes spawn. Cold-start cost ~1-2s on first room join after flip."
+  },
+  "registry": {
+    "agent_id": "orb-agent",
+    "tier": "service",
+    "role": "voice",
+    "emit_heartbeat": true,
+    "heartbeat_interval_seconds": 60
+  },
+  "dependencies": {
+    "vtid_01155": "orb_live_vertex_pipeline (sibling)",
+    "vtid_01225": "cognee_extractor (transcript ingest)",
+    "voice_pipeline_spec": "voice-pipeline-spec/spec.json (parity contract)",
+    "gateway_endpoints": [
+      "GET /api/v1/orb/context-bootstrap",
+      "POST /api/v1/orb/livekit/token",
+      "POST /api/v1/oasis/emit",
+      "POST /api/v1/agents/registry/heartbeat"
+    ]
+  },
+  "design_doc": ".claude/plans/here-is-what-our-valiant-stearns.md"
+}

--- a/services/agents/orb-agent/package.json
+++ b/services/agents/orb-agent/package.json
@@ -1,0 +1,12 @@
+{
+  "name": "@vitana/orb-agent",
+  "version": "0.1.0",
+  "private": true,
+  "scripts": {
+    "dev": "python main.py",
+    "start": "python main.py",
+    "test": "pytest",
+    "lint": "ruff check .",
+    "typecheck": "mypy src"
+  }
+}

--- a/services/agents/orb-agent/pyproject.toml
+++ b/services/agents/orb-agent/pyproject.toml
@@ -1,0 +1,67 @@
+[project]
+name = "orb-agent"
+version = "0.1.0"
+description = "LiveKit-based ORB voice agent worker. Standby alternative to the Vertex Live pipeline."
+requires-python = ">=3.11"
+readme = "README.md"
+license = { text = "Proprietary" }
+
+dependencies = [
+    "livekit-agents>=0.12.0",
+    "livekit-plugins-deepgram>=0.6.0",
+    "livekit-plugins-anthropic>=0.2.0",
+    "livekit-plugins-cartesia>=0.4.0",
+    "livekit-plugins-silero>=0.7.0",
+    "fastapi>=0.110.0",
+    "uvicorn[standard]>=0.27.0",
+    "httpx>=0.27.0",
+    "pydantic>=2.6.0",
+    "structlog>=24.1.0",
+    "PyJWT>=2.8.0",
+]
+
+[project.optional-dependencies]
+dev = [
+    "pytest>=8.0.0",
+    "pytest-asyncio>=0.23.0",
+    "pytest-mock>=3.12.0",
+    "ruff>=0.4.0",
+    "mypy>=1.10.0",
+    "libcst>=1.4.0",
+]
+extra-providers = [
+    "livekit-plugins-assemblyai>=0.2.0",
+    "livekit-plugins-elevenlabs>=0.7.0",
+    "livekit-plugins-rime>=0.4.0",
+    "livekit-plugins-inworld>=0.1.0",
+    "livekit-plugins-openai>=0.10.0",
+    "livekit-plugins-google>=0.8.0",
+    "livekit-plugins-groq>=0.1.0",
+    "livekit-plugins-azure>=0.5.0",
+]
+
+[build-system]
+requires = ["setuptools>=68", "wheel"]
+build-backend = "setuptools.build_meta"
+
+[tool.setuptools.packages.find]
+where = ["src"]
+
+[tool.ruff]
+line-length = 100
+target-version = "py311"
+
+[tool.ruff.lint]
+select = ["E", "F", "I", "N", "W", "UP", "B", "ASYNC"]
+ignore = ["E501"]
+
+[tool.mypy]
+python_version = "3.11"
+strict = true
+warn_return_any = true
+warn_unused_configs = true
+ignore_missing_imports = true
+
+[tool.pytest.ini_options]
+asyncio_mode = "auto"
+testpaths = ["tests"]

--- a/services/agents/orb-agent/requirements.txt
+++ b/services/agents/orb-agent/requirements.txt
@@ -1,0 +1,13 @@
+# Cloud Run-compatible requirements list (mirrors pyproject.toml [project.dependencies]).
+# Kept in sync manually until we move the deploy pipeline to uv/poetry.
+livekit-agents>=0.12.0
+livekit-plugins-deepgram>=0.6.0
+livekit-plugins-anthropic>=0.2.0
+livekit-plugins-cartesia>=0.4.0
+livekit-plugins-silero>=0.7.0
+fastapi>=0.110.0
+uvicorn[standard]>=0.27.0
+httpx>=0.27.0
+pydantic>=2.6.0
+structlog>=24.1.0
+PyJWT>=2.8.0

--- a/services/agents/orb-agent/service.yaml
+++ b/services/agents/orb-agent/service.yaml
@@ -1,0 +1,92 @@
+# VTID-LIVEKIT-FOUNDATION: ORB LiveKit Voice Agent
+# Cloud Run Service Configuration
+#
+# Deploy with:
+#   gcloud run services replace service.yaml --region=us-central1
+#
+# Or via the EXEC-DEPLOY GitHub Actions workflow once it's extended in PR #8.
+
+apiVersion: serving.knative.dev/v1
+kind: Service
+metadata:
+  name: vitana-orb-agent
+  labels:
+    vtid: vtid-livekit-foundation
+    vt_layer: aicor
+    vt_module: voice
+    cloud.googleapis.com/location: us-central1
+  annotations:
+    run.googleapis.com/description: "LiveKit-based ORB voice agent worker (standby alternative to Vertex Live)"
+    run.googleapis.com/ingress: internal-and-cloud-load-balancing
+    run.googleapis.com/launch-stage: BETA
+spec:
+  template:
+    metadata:
+      annotations:
+        # Scale-to-zero is critical: when LiveKit is the standby provider,
+        # zero instances run, costing zero compute. Cold-start on flip is
+        # ~1-2s on first room join.
+        autoscaling.knative.dev/minScale: "0"
+        autoscaling.knative.dev/maxScale: "10"
+
+        # CPU is not throttled when processing voice (latency-sensitive).
+        run.googleapis.com/cpu-throttling: "false"
+
+        # Startup CPU boost for faster cold starts.
+        run.googleapis.com/startup-cpu-boost: "true"
+
+        # Long-lived voice sessions; allow up to 1 hour per request.
+        run.googleapis.com/timeout-seconds: "3600"
+
+      labels:
+        vtid: vtid-livekit-foundation
+
+    spec:
+      containerConcurrency: 25
+      timeoutSeconds: 3600
+
+      containers:
+        - name: orb-agent
+          image: REPLACE_AT_DEPLOY_TIME
+          ports:
+            - containerPort: 8080
+          resources:
+            limits:
+              cpu: "2"
+              memory: "4Gi"
+          env:
+            # Required env (sourced from Secret Manager at deploy time).
+            - name: LIVEKIT_URL
+              valueFrom:
+                secretKeyRef: { name: LIVEKIT_URL, key: latest }
+            - name: LIVEKIT_API_KEY
+              valueFrom:
+                secretKeyRef: { name: LIVEKIT_API_KEY, key: latest }
+            - name: LIVEKIT_API_SECRET
+              valueFrom:
+                secretKeyRef: { name: LIVEKIT_API_SECRET, key: latest }
+            - name: GATEWAY_URL
+              value: "https://gateway-q74ibpv6ia-uc.a.run.app"
+            - name: GATEWAY_SERVICE_TOKEN
+              valueFrom:
+                secretKeyRef: { name: GATEWAY_SERVICE_TOKEN, key: latest }
+            # Optional provider keys — only needed for the providers that
+            # are actually configured in agent_voice_configs. Missing keys
+            # surface in /health.providers.* as false.
+            - name: ANTHROPIC_API_KEY
+              valueFrom:
+                secretKeyRef: { name: ANTHROPIC_API_KEY, key: latest, optional: true }
+            - name: DEEPGRAM_API_KEY
+              valueFrom:
+                secretKeyRef: { name: DEEPGRAM_API_KEY, key: latest, optional: true }
+            - name: CARTESIA_API_KEY
+              valueFrom:
+                secretKeyRef: { name: CARTESIA_API_KEY, key: latest, optional: true }
+            - name: ELEVENLABS_API_KEY
+              valueFrom:
+                secretKeyRef: { name: ELEVENLABS_API_KEY, key: latest, optional: true }
+            - name: ASSEMBLYAI_API_KEY
+              valueFrom:
+                secretKeyRef: { name: ASSEMBLYAI_API_KEY, key: latest, optional: true }
+            - name: AGENT_LOG_LEVEL
+              value: "INFO"

--- a/services/agents/orb-agent/src/orb_agent/bootstrap.py
+++ b/services/agents/orb-agent/src/orb_agent/bootstrap.py
@@ -1,0 +1,98 @@
+"""Context-bootstrap fetcher.
+
+Calls GET /api/v1/orb/context-bootstrap on the gateway, which returns the
+exact same payload the Vertex SSE path builds inline — memory garden + role +
+last session info + admin briefing + (NEW) the agent's agent_voice_configs row.
+
+Mirrors the `await contextReadyPromise` pattern in orb-live.ts:
+the agent does not start the LLM session until context is ready or a 5 s
+timeout fires (degraded mode).
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+CONTEXT_BOOTSTRAP_TIMEOUT_S = 5.0
+
+
+@dataclass
+class BootstrapResult:
+    """Payload returned by the gateway's context-bootstrap endpoint."""
+
+    bootstrap_context: str
+    active_role: str | None
+    conversation_summary: str | None
+    last_turns: str | None
+    last_session_info: dict[str, Any] | None
+    current_route: str | None
+    recent_routes: list[str]
+    client_context: dict[str, Any]
+    vitana_id: str | None
+    voice_config: dict[str, Any] | None  # agent_voice_configs row
+    is_degraded: bool = False
+
+
+class ContextBootstrap:
+    def __init__(self, gateway_url: str, service_token: str) -> None:
+        self._endpoint = gateway_url.rstrip("/") + "/api/v1/orb/context-bootstrap"
+        self._headers = {"Authorization": f"Bearer {service_token}"}
+        self._client = httpx.AsyncClient(timeout=CONTEXT_BOOTSTRAP_TIMEOUT_S)
+
+    async def fetch(
+        self,
+        *,
+        user_jwt: str,
+        agent_id: str = "vitana",
+        is_reconnect: bool = False,
+        last_n_turns: int = 0,
+    ) -> BootstrapResult:
+        params: dict[str, str | int | bool] = {
+            "agent_id": agent_id,
+            "is_reconnect": is_reconnect,
+            "last_n_turns": last_n_turns,
+        }
+        try:
+            r = await self._client.get(
+                self._endpoint,
+                params=params,
+                headers={**self._headers, "X-User-JWT": user_jwt},
+            )
+            r.raise_for_status()
+            data: dict[str, Any] = r.json()
+            return BootstrapResult(
+                bootstrap_context=data.get("bootstrap_context", ""),
+                active_role=data.get("active_role"),
+                conversation_summary=data.get("conversation_summary"),
+                last_turns=data.get("last_turns"),
+                last_session_info=data.get("last_session_info"),
+                current_route=data.get("current_route"),
+                recent_routes=data.get("recent_routes", []),
+                client_context=data.get("client_context", {}),
+                vitana_id=data.get("vitana_id"),
+                voice_config=data.get("voice_config"),
+                is_degraded=False,
+            )
+        except (httpx.TimeoutException, httpx.HTTPError) as exc:
+            logger.warning("context-bootstrap fetch failed: %s — entering degraded mode", exc)
+            return BootstrapResult(
+                bootstrap_context="",
+                active_role=None,
+                conversation_summary=None,
+                last_turns=None,
+                last_session_info=None,
+                current_route=None,
+                recent_routes=[],
+                client_context={},
+                vitana_id=None,
+                voice_config=None,
+                is_degraded=True,
+            )
+
+    async def aclose(self) -> None:
+        await self._client.aclose()

--- a/services/agents/orb-agent/src/orb_agent/config.py
+++ b/services/agents/orb-agent/src/orb_agent/config.py
@@ -1,0 +1,46 @@
+"""Environment-variable resolution + LiveKit / Gateway configuration."""
+from __future__ import annotations
+
+import os
+from dataclasses import dataclass
+
+
+@dataclass(frozen=True)
+class AgentConfig:
+    """Resolved configuration for the orb-agent process."""
+
+    livekit_url: str
+    livekit_api_key: str
+    livekit_api_secret: str
+    gateway_url: str
+    gateway_service_token: str
+    log_level: str = "INFO"
+    max_tool_steps: int = 5
+    max_reconnects: int = 10
+    health_port: int = 8080
+    heartbeat_interval_seconds: int = 60
+
+    @classmethod
+    def from_env(cls) -> "AgentConfig":
+        return cls(
+            livekit_url=_required("LIVEKIT_URL"),
+            livekit_api_key=_required("LIVEKIT_API_KEY"),
+            livekit_api_secret=_required("LIVEKIT_API_SECRET"),
+            gateway_url=_required("GATEWAY_URL"),
+            gateway_service_token=_required("GATEWAY_SERVICE_TOKEN"),
+            log_level=os.getenv("AGENT_LOG_LEVEL", "INFO"),
+            max_tool_steps=int(os.getenv("AGENT_MAX_TOOL_STEPS", "5")),
+            max_reconnects=int(os.getenv("AGENT_MAX_RECONNECTS", "10")),
+            health_port=int(os.getenv("PORT", "8080")),
+            heartbeat_interval_seconds=int(os.getenv("AGENT_HEARTBEAT_S", "60")),
+        )
+
+
+def _required(name: str) -> str:
+    value = os.getenv(name)
+    if not value:
+        raise RuntimeError(
+            f"Missing required environment variable {name}. "
+            "See services/agents/orb-agent/manifest.json for the full required-env list."
+        )
+    return value

--- a/services/agents/orb-agent/src/orb_agent/health.py
+++ b/services/agents/orb-agent/src/orb_agent/health.py
@@ -1,0 +1,51 @@
+"""Embedded FastAPI health server — Cloud Run probe target.
+
+Returns 200 with a structured payload that EXEC-DEPLOY's smoke test asserts
+against. Mirrors the contract documented in
+.claude/plans/here-is-what-our-valiant-stearns.md /api/v1/orb/livekit/health
+on the gateway side.
+"""
+from __future__ import annotations
+
+import logging
+import os
+from typing import Any
+
+from fastapi import FastAPI
+
+logger = logging.getLogger(__name__)
+
+
+def make_health_app() -> FastAPI:
+    app = FastAPI(title="orb-agent-health", version="0.1.0")
+
+    @app.get("/health")
+    async def health() -> dict[str, Any]:
+        return {
+            "ok": True,
+            "service": "orb-agent",
+            "vtid": "VTID-LIVEKIT-FOUNDATION",
+            "version": "0.1.0",
+            "livekit": {
+                "url_configured": bool(os.getenv("LIVEKIT_URL")),
+                "api_key_configured": bool(os.getenv("LIVEKIT_API_KEY")),
+            },
+            "providers": {
+                # Each true if the corresponding API key is set; false otherwise.
+                # Real reachability probe is the responsibility of the
+                # /voice-providers/:id/test endpoint on the gateway.
+                "anthropic_configured": bool(os.getenv("ANTHROPIC_API_KEY")),
+                "openai_configured": bool(os.getenv("OPENAI_API_KEY")),
+                "deepgram_configured": bool(os.getenv("DEEPGRAM_API_KEY")),
+                "assemblyai_configured": bool(os.getenv("ASSEMBLYAI_API_KEY")),
+                "cartesia_configured": bool(os.getenv("CARTESIA_API_KEY")),
+                "elevenlabs_configured": bool(os.getenv("ELEVENLABS_API_KEY")),
+            },
+            "active_provider_hint": os.getenv("VOICE_ACTIVE_PROVIDER", "vertex"),
+        }
+
+    @app.get("/alive")
+    async def alive() -> dict[str, bool]:
+        return {"ok": True}
+
+    return app

--- a/services/agents/orb-agent/src/orb_agent/identity.py
+++ b/services/agents/orb-agent/src/orb_agent/identity.py
@@ -1,0 +1,80 @@
+"""JWT identity resolution + the mobile=community-role coercion (defense-in-depth).
+
+Per memory/feedback_mobile_community_only.md: phone / WebView sessions MUST
+resolve to community role regardless of the DB role, on every role-reading
+path. The gateway enforces this in token mint, but we re-check here as a
+second line of defense — the agent worker never trusts a "developer" role
+on a mobile session.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any
+
+import jwt as pyjwt
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass(frozen=True)
+class Identity:
+    user_id: str
+    tenant_id: str
+    role: str
+    lang: str
+    vitana_id: str | None
+    is_mobile: bool
+    is_anonymous: bool
+
+
+def resolve_identity_from_room_metadata(
+    metadata: dict[str, Any],
+    *,
+    user_jwt: str | None = None,
+) -> Identity:
+    """Resolve identity from LiveKit room metadata + optional decoded JWT.
+
+    Room metadata is set by the gateway's /api/v1/orb/livekit/token endpoint,
+    which already coerces role for mobile/WebView clients. The agent never
+    re-decodes the JWT for auth (gateway is the auth source of truth) — but
+    we DO re-check the mobile coercion here as defense-in-depth.
+    """
+    user_id = str(metadata.get("user_id", "anon"))
+    tenant_id = str(metadata.get("tenant_id", ""))
+    db_role = str(metadata.get("role", "community"))
+    lang = str(metadata.get("lang", "en"))
+    vitana_id = metadata.get("vitana_id")
+    is_mobile = bool(metadata.get("is_mobile", False))
+    is_anonymous = bool(metadata.get("is_anonymous", False))
+
+    # Mobile-community coercion (defense-in-depth, mirrors
+    # feedback_mobile_community_only.md and orb-live.ts BOOTSTRAP-ORB-ROLE-SYNC-2)
+    role = "community" if is_mobile else db_role
+
+    if is_mobile and db_role != "community":
+        logger.warning(
+            "Mobile session for user_id=%s had db_role=%s — coerced to 'community' (defense-in-depth).",
+            user_id,
+            db_role,
+        )
+
+    return Identity(
+        user_id=user_id,
+        tenant_id=tenant_id,
+        role=role,
+        lang=lang,
+        vitana_id=str(vitana_id) if vitana_id else None,
+        is_mobile=is_mobile,
+        is_anonymous=is_anonymous,
+    )
+
+
+def decode_jwt_unsafe(token: str) -> dict[str, Any]:
+    """Decode a JWT without verifying — used only for inspection in tests.
+
+    Production code path NEVER trusts a JWT decoded by this agent for auth
+    decisions. The gateway has already authenticated and the agent reads
+    pre-resolved identity from room metadata.
+    """
+    return pyjwt.decode(token, options={"verify_signature": False})

--- a/services/agents/orb-agent/src/orb_agent/instructions.py
+++ b/services/agents/orb-agent/src/orb_agent/instructions.py
@@ -1,0 +1,107 @@
+"""System instruction builders — Python ports of buildLiveSystemInstruction
+and buildAnonymousSystemInstruction from orb-live.ts.
+
+The parameter SIGNATURES of these two functions are part of the parity
+contract (voice-pipeline-spec/spec.json -> system_instruction_params).
+The libcst extractor walks both function definitions and extracts the
+parameter list. The parity scanner fails CI if either signature drifts
+from the canonical spec.
+
+THE RENDERED PROMPT TEMPLATE IS NOT PART OF THE PARITY CONTRACT — only
+the parameter list is. Each implementation owns its own prompt template
+and the system-instruction golden-file test catches template drift on a
+fixed input separately.
+
+Skeleton today: returns minimal placeholder strings. Full implementation
+lands in a follow-up PR that ports the actual ~5–15 KB prompt from
+buildLiveSystemInstruction in orb-live.ts:6938+.
+"""
+from __future__ import annotations
+
+from dataclasses import dataclass
+from typing import Any
+
+
+@dataclass(frozen=True)
+class LastSessionInfo:
+    """Same shape as the TS-side `lastSessionInfo` parameter."""
+
+    time: str
+    was_failure: bool
+
+
+def build_live_system_instruction(
+    lang: str,
+    voice_style: str,
+    bootstrap_context: str | None = None,
+    active_role: str | None = None,
+    conversation_summary: str | None = None,
+    conversation_history: str | None = None,
+    is_reconnect: bool = False,
+    last_session_info: LastSessionInfo | None = None,
+    current_route: str | None = None,
+    recent_routes: list[str] | None = None,
+    client_context: dict[str, Any] | None = None,
+    vitana_id: str | None = None,
+) -> str:
+    """Authenticated session system prompt builder.
+
+    Parameter list mirrors orb-live.ts:6938 exactly. **Must stay in sync** —
+    the parity scanner fails CI if the names diverge.
+    """
+    parts: list[str] = []
+    if vitana_id:
+        parts.append(f"Canonical user handle: {vitana_id}.")
+    if active_role:
+        parts.append(f"Active role: {active_role}.")
+    if is_reconnect:
+        parts.append("This is a transparent reconnect — do not greet the user again.")
+    if last_session_info:
+        parts.append(f"Last session ended at {last_session_info.time}.")
+    if bootstrap_context:
+        parts.append(bootstrap_context)
+    if conversation_summary:
+        parts.append(f"Earlier-conversation summary: {conversation_summary}")
+    if conversation_history:
+        parts.append(f"Recent turns:\n{conversation_history}")
+    if current_route:
+        parts.append(f"User is on screen: {current_route}.")
+    if recent_routes:
+        parts.append(f"Recent screens: {', '.join(recent_routes)}.")
+    if client_context:
+        parts.append(f"Client context: {client_context}.")
+    parts.append(f"Speak in {lang}, voice style: {voice_style}.")
+    parts.append(
+        "TODO(VTID-LIVEKIT-FOUNDATION): port the full prompt from "
+        "buildLiveSystemInstruction at services/gateway/src/routes/orb-live.ts:6938. "
+        "This skeleton output is intentionally minimal so the agent worker can boot."
+    )
+    return "\n\n".join(parts)
+
+
+def build_anonymous_system_instruction(
+    lang: str,
+    voice_style: str,
+    ctx: dict[str, Any] | None = None,
+    conversation_history: str | None = None,
+    is_reconnect: bool = False,
+) -> str:
+    """Unauthenticated (no JWT) session system prompt builder.
+
+    Parameter list mirrors orb-live.ts:7783 exactly.
+    """
+    parts: list[str] = [
+        f"You are Vitana — speaking with an unauthenticated visitor in {lang} ({voice_style}).",
+        "You may help with general navigation but cannot access personal memory or tools.",
+    ]
+    if is_reconnect:
+        parts.append("Transparent reconnect — do not greet again.")
+    if ctx:
+        parts.append(f"Client context: {ctx}.")
+    if conversation_history:
+        parts.append(f"Recent turns:\n{conversation_history}")
+    parts.append(
+        "TODO(VTID-LIVEKIT-FOUNDATION): port the full prompt from "
+        "buildAnonymousSystemInstruction at services/gateway/src/routes/orb-live.ts:7783."
+    )
+    return "\n\n".join(parts)

--- a/services/agents/orb-agent/src/orb_agent/navigator.py
+++ b/services/agents/orb-agent/src/orb_agent/navigator.py
@@ -1,0 +1,51 @@
+"""Navigator surface scoping helpers.
+
+Per memory/feedback_navigator_surface_scoping.md: the ORB Navigator must
+scope to the active surface — vitanaland → community, /admin/* → admin,
+/command-hub/* → developer. Never cross surfaces.
+
+This module exposes:
+  - classify_surface(route) — derive surface from a path
+  - assert_route_in_surface(route, current_surface) — raises ValueError on
+    cross-surface, used by the navigate tool wrapper to reject bad routes.
+
+The actual `navigate` and `get_current_screen` @function_tools live in
+tools.py and call into these helpers.
+"""
+from __future__ import annotations
+
+from typing import Literal
+
+Surface = Literal["community", "admin", "developer", "unknown"]
+
+
+def classify_surface(route: str) -> Surface:
+    """Map a path to its surface."""
+    r = route.strip()
+    if r.startswith("/admin"):
+        return "admin"
+    if r.startswith("/command-hub"):
+        return "developer"
+    if r.startswith("/comm") or r.startswith("/health") or r.startswith("/intents") or r == "/":
+        return "community"
+    if r.startswith("/discover") or r.startswith("/profile") or r.startswith("/wallet"):
+        return "community"
+    return "unknown"
+
+
+def assert_route_in_surface(route: str, current_surface: Surface) -> None:
+    """Raise ValueError if `route` is in a different surface than the user is in.
+
+    Called by the navigate @function_tool. The error message is returned to
+    the LLM so it can apologize naturally instead of producing a broken
+    cross-surface redirect.
+    """
+    target_surface = classify_surface(route)
+    if target_surface == "unknown":
+        # Unknown is not a violation — let the gateway decide.
+        return
+    if target_surface != current_surface:
+        raise ValueError(
+            f"Cross-surface navigation rejected: cannot route to {target_surface} surface "
+            f"(route={route}) from {current_surface} surface."
+        )

--- a/services/agents/orb-agent/src/orb_agent/oasis.py
+++ b/services/agents/orb-agent/src/orb_agent/oasis.py
@@ -1,0 +1,67 @@
+"""OASIS event emitter — POSTs to the gateway's /api/v1/oasis/emit endpoint.
+
+Topic naming follows the parity contract in voice-pipeline-spec/spec.json.
+The libcst extractor walks every `oasis.emit(topic=...)` call site and feeds
+it to the parity scanner — so use string literals, not f-strings or
+variables, for the topic argument when you want it visible to the scanner.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+
+class OasisEmitter:
+    """Thin async client that POSTs OASIS events to the gateway."""
+
+    def __init__(self, gateway_url: str, service_token: str, *, timeout_s: float = 5.0) -> None:
+        self._endpoint = gateway_url.rstrip("/") + "/api/v1/oasis/emit"
+        self._headers = {
+            "Authorization": f"Bearer {service_token}",
+            "Content-Type": "application/json",
+        }
+        self._client = httpx.AsyncClient(timeout=timeout_s)
+
+    async def emit(
+        self,
+        *,
+        topic: str,
+        payload: dict[str, Any] | None = None,
+        vtid: str | None = None,
+    ) -> None:
+        """Fire-and-log emit. Errors are logged, never raised — telemetry must
+        never break the voice path."""
+        body = {"topic": topic, "payload": payload or {}, "vtid": vtid}
+        try:
+            r = await self._client.post(self._endpoint, json=body, headers=self._headers)
+            if r.status_code >= 400:
+                logger.warning("oasis emit failed: topic=%s status=%s", topic, r.status_code)
+        except Exception as exc:
+            logger.warning("oasis emit exception: topic=%s err=%s", topic, exc)
+
+    async def aclose(self) -> None:
+        await self._client.aclose()
+
+
+# Common topic constants — keep these as module-level string literals so the
+# libcst extractor can walk them. Topics not in this list are also valid;
+# this list is just for readability / IDE autocomplete.
+TOPIC_SESSION_START = "livekit.session.start"
+TOPIC_SESSION_STOP = "livekit.session.stop"
+TOPIC_TOOL_EXECUTED = "livekit.tool.executed"
+TOPIC_TOOL_LOOP_GUARD = "livekit.tool_loop_guard_activated"
+TOPIC_STALL_DETECTED = "livekit.stall_detected"
+TOPIC_CONNECTION_FAILED = "livekit.connection_failed"
+TOPIC_CONFIG_MISSING = "livekit.config_missing"
+TOPIC_PROVIDER_QUOTA_EXCEEDED = "livekit.provider_quota_exceeded"
+TOPIC_PROVIDER_FAILOVER = "livekit.provider_failover"
+TOPIC_CONTEXT_BOOTSTRAP = "livekit.context.bootstrap"
+TOPIC_CONTEXT_BOOTSTRAP_SKIPPED = "livekit.context.bootstrap.skipped"
+TOPIC_HANDOFF_START = "voice.handoff.start"
+TOPIC_HANDOFF_COMPLETE = "voice.handoff.complete"
+TOPIC_HANDOFF_FAILED = "voice.handoff.failed"
+TOPIC_PERSONA_SWAP = "agent.voice.persona_swap"

--- a/services/agents/orb-agent/src/orb_agent/providers.py
+++ b/services/agents/orb-agent/src/orb_agent/providers.py
@@ -1,0 +1,118 @@
+"""STT/LLM/TTS plugin factory.
+
+Reads an `agent_voice_configs` row (joined into the context-bootstrap
+payload) and instantiates the configured trio. Plugins not selected are
+imported but not instantiated — keeps memory footprint low. Adding a
+provider is one entry in `_REGISTRY` plus a seed row in `voice_providers`.
+
+Live behavior is gated on the actual livekit-agents plugin packages being
+present at runtime. The skeleton uses lazy imports + a NotImplementedError
+fallback so the agent boots even if optional plugins aren't installed.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+from typing import Any, Protocol
+
+logger = logging.getLogger(__name__)
+
+
+class _STTPlugin(Protocol):
+    """Anything livekit-agents recognizes as an STT — see livekit.agents.stt.STT."""
+
+    pass
+
+
+class _LLMPlugin(Protocol):
+    pass
+
+
+class _TTSPlugin(Protocol):
+    pass
+
+
+@dataclass
+class ResolvedCascade:
+    stt: _STTPlugin | None
+    llm: _LLMPlugin | None
+    tts: _TTSPlugin | None
+    notes: list[str]
+
+
+def build_cascade(voice_config: dict[str, Any] | None) -> ResolvedCascade:
+    """Instantiate the STT/LLM/TTS plugins per the agent_voice_configs row.
+
+    voice_config shape (matches PR #3 migration):
+      {
+        "stt_provider": "deepgram", "stt_model": "nova-3", "stt_options": {...},
+        "llm_provider": "anthropic", "llm_model": "claude-sonnet-4-6", "llm_options": {...},
+        "tts_provider": "cartesia", "tts_model": "sonic-3", "tts_options": {...}
+      }
+    """
+    if voice_config is None:
+        logger.warning("build_cascade: no voice_config provided, returning empty cascade")
+        return ResolvedCascade(stt=None, llm=None, tts=None, notes=["no voice_config"])
+
+    notes: list[str] = []
+    stt = _build_stt(voice_config.get("stt_provider"), voice_config.get("stt_model"), voice_config.get("stt_options", {}), notes)
+    llm = _build_llm(voice_config.get("llm_provider"), voice_config.get("llm_model"), voice_config.get("llm_options", {}), notes)
+    tts = _build_tts(voice_config.get("tts_provider"), voice_config.get("tts_model"), voice_config.get("tts_options", {}), notes)
+    return ResolvedCascade(stt=stt, llm=llm, tts=tts, notes=notes)
+
+
+def _build_stt(provider: str | None, model: str | None, options: dict[str, Any], notes: list[str]) -> _STTPlugin | None:
+    if provider == "deepgram":
+        try:
+            from livekit.plugins import deepgram  # type: ignore[import-not-found]
+            return deepgram.STT(model=model or "nova-3", **options)
+        except ImportError:
+            notes.append(f"STT provider 'deepgram' requested but livekit-plugins-deepgram not installed")
+            return None
+    if provider == "assemblyai":
+        try:
+            from livekit.plugins import assemblyai  # type: ignore[import-not-found]
+            return assemblyai.STT(**options)
+        except ImportError:
+            notes.append(f"STT provider 'assemblyai' requested but livekit-plugins-assemblyai not installed")
+            return None
+    notes.append(f"unknown or unsupported STT provider: {provider}")
+    return None
+
+
+def _build_llm(provider: str | None, model: str | None, options: dict[str, Any], notes: list[str]) -> _LLMPlugin | None:
+    if provider == "anthropic":
+        try:
+            from livekit.plugins import anthropic  # type: ignore[import-not-found]
+            return anthropic.LLM(model=model or "claude-sonnet-4-6", **options)
+        except ImportError:
+            notes.append("LLM provider 'anthropic' requested but livekit-plugins-anthropic not installed")
+            return None
+    if provider == "openai":
+        try:
+            from livekit.plugins import openai  # type: ignore[import-not-found]
+            return openai.LLM(model=model or "gpt-4o", **options)
+        except ImportError:
+            notes.append("LLM provider 'openai' requested but livekit-plugins-openai not installed")
+            return None
+    notes.append(f"unknown or unsupported LLM provider: {provider}")
+    return None
+
+
+def _build_tts(provider: str | None, model: str | None, options: dict[str, Any], notes: list[str]) -> _TTSPlugin | None:
+    if provider == "cartesia":
+        try:
+            from livekit.plugins import cartesia  # type: ignore[import-not-found]
+            return cartesia.TTS(model=model or "sonic-3", **options)
+        except ImportError:
+            notes.append("TTS provider 'cartesia' requested but livekit-plugins-cartesia not installed")
+            return None
+    if provider == "elevenlabs":
+        try:
+            from livekit.plugins import elevenlabs  # type: ignore[import-not-found]
+            return elevenlabs.TTS(model=model or "eleven_turbo_v2_5", **options)
+        except ImportError:
+            notes.append("TTS provider 'elevenlabs' requested but livekit-plugins-elevenlabs not installed")
+            return None
+    notes.append(f"unknown or unsupported TTS provider: {provider}")
+    return None

--- a/services/agents/orb-agent/src/orb_agent/registry_client.py
+++ b/services/agents/orb-agent/src/orb_agent/registry_client.py
@@ -1,0 +1,95 @@
+"""agents_registry self-register heartbeat client.
+
+Posts to POST /api/v1/agents/registry/heartbeat every 60 s so the gateway's
+agents_registry table reflects this service's status. The agent_id used
+here MUST match the seed row added by the eventual migration that adds
+'orb-agent' to agents_registry.
+
+Mirrors the inline pattern in services/agents/cognee-extractor/main.py:474
+and the future shared helper at services/agents/shared/agents_registry_client.py.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from typing import Any
+
+import httpx
+
+logger = logging.getLogger(__name__)
+
+AGENT_ID = "orb-agent"
+DISPLAY_NAME = "ORB LiveKit Agent"
+DESCRIPTION = (
+    "LiveKit-based ORB voice agent worker — standby alternative to the Vertex Live "
+    "pipeline (services/gateway/src/routes/orb-live.ts). Joins LiveKit rooms as a "
+    "participant and runs a configurable STT/LLM/TTS cascade."
+)
+TIER = "service"
+ROLE = "voice"
+SOURCE_PATH = "services/agents/orb-agent/"
+
+
+class RegistryHeartbeat:
+    """Background async task that posts heartbeats."""
+
+    def __init__(
+        self,
+        gateway_url: str,
+        service_token: str,
+        *,
+        interval_s: int = 60,
+        timeout_s: float = 5.0,
+    ) -> None:
+        self._endpoint = gateway_url.rstrip("/") + "/api/v1/agents/registry/heartbeat"
+        self._headers = {
+            "Authorization": f"Bearer {service_token}",
+            "Content-Type": "application/json",
+        }
+        self._interval_s = interval_s
+        self._timeout_s = timeout_s
+        self._task: asyncio.Task[None] | None = None
+        self._stop = asyncio.Event()
+
+    def start(self) -> None:
+        if self._task is None:
+            self._task = asyncio.create_task(self._loop())
+
+    async def stop(self) -> None:
+        self._stop.set()
+        if self._task is not None:
+            await self._task
+            self._task = None
+
+    async def _loop(self) -> None:
+        async with httpx.AsyncClient(timeout=self._timeout_s) as client:
+            while not self._stop.is_set():
+                try:
+                    await self._post(client, status="healthy")
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("agents_registry heartbeat failed: %s", exc)
+                try:
+                    await asyncio.wait_for(self._stop.wait(), timeout=self._interval_s)
+                except TimeoutError:
+                    pass
+
+    async def _post(self, client: httpx.AsyncClient, status: str = "healthy") -> None:
+        payload: dict[str, Any] = {
+            "agent_id": AGENT_ID,
+            "display_name": DISPLAY_NAME,
+            "description": DESCRIPTION,
+            "tier": TIER,
+            "role": ROLE,
+            "source_path": SOURCE_PATH,
+            "status": status,
+            "metadata": {
+                "language": "python",
+                "framework": "livekit-agents",
+                "vtid": "VTID-LIVEKIT-FOUNDATION",
+            },
+        }
+        r = await client.post(self._endpoint, json=payload, headers=self._headers)
+        if r.status_code >= 400:
+            logger.warning(
+                "agents_registry heartbeat returned %s: %s", r.status_code, r.text[:200]
+            )

--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -1,0 +1,204 @@
+"""Agent session lifecycle.
+
+Owns: agent joins room → fetch context-bootstrap → build system instruction
+→ instantiate STT/LLM/TTS via providers.py → start the livekit-agents
+VoicePipelineAgent → on every model turn, call transcript-append on the
+gateway → on session end, call /session/finalize.
+
+Also owns the **persona-swap path** (multi-specialist handoff) — when the
+LLM calls report_to_specialist or the gateway pushes a switch message:
+
+  1. Emit voice.handoff.start
+  2. Play bridge cue in *current* voice
+  3. Fetch new agent's voice config + system prompt via context-bootstrap
+  4. Swap LLM + TTS plugin instances in-place (STT keeps running)
+  5. Update room metadata (active_specialist=new_id)
+  6. Emit voice.handoff.complete
+
+Skeleton today: structural scaffolding + lifecycle hooks. Real
+livekit-agents wiring lands in a follow-up PR.
+"""
+from __future__ import annotations
+
+import logging
+from dataclasses import dataclass
+
+from .bootstrap import BootstrapResult, ContextBootstrap
+from .config import AgentConfig
+from .identity import Identity
+from .instructions import build_anonymous_system_instruction, build_live_system_instruction
+from .oasis import (
+    TOPIC_HANDOFF_COMPLETE,
+    TOPIC_HANDOFF_START,
+    TOPIC_PERSONA_SWAP,
+    TOPIC_SESSION_START,
+    TOPIC_SESSION_STOP,
+    OasisEmitter,
+)
+from .providers import ResolvedCascade, build_cascade
+from .watchdogs import ReconnectBucket
+
+logger = logging.getLogger(__name__)
+
+
+@dataclass
+class SessionContext:
+    """Per-session mutable state."""
+
+    orb_session_id: str
+    identity: Identity
+    bootstrap: BootstrapResult
+    cascade: ResolvedCascade
+    active_agent_id: str
+    reconnect_bucket: ReconnectBucket
+
+
+class AgentSession:
+    """Owns one user voice session end-to-end."""
+
+    def __init__(self, cfg: AgentConfig, oasis: OasisEmitter, ctx_fetcher: ContextBootstrap) -> None:
+        self._cfg = cfg
+        self._oasis = oasis
+        self._ctx_fetcher = ctx_fetcher
+
+    async def start(self, *, room_metadata: dict, user_jwt: str) -> SessionContext:
+        """Bootstrap a session for the user identified by `room_metadata`.
+
+        TODO(VTID-LIVEKIT-FOUNDATION): wire this into the livekit-agents
+        worker entrypoint. For now this is a structural placeholder that
+        future PRs flesh out.
+        """
+        from .identity import resolve_identity_from_room_metadata  # local import for testability
+
+        identity = resolve_identity_from_room_metadata(room_metadata, user_jwt=user_jwt)
+        agent_id = str(room_metadata.get("agent_id", "vitana"))
+
+        bootstrap = await self._ctx_fetcher.fetch(
+            user_jwt=user_jwt, agent_id=agent_id, is_reconnect=False, last_n_turns=0
+        )
+        cascade = build_cascade(bootstrap.voice_config)
+
+        # System instruction selected based on whether identity is anonymous.
+        if identity.is_anonymous:
+            sys_prompt = build_anonymous_system_instruction(
+                lang=identity.lang, voice_style="warm", ctx=bootstrap.client_context
+            )
+        else:
+            sys_prompt = build_live_system_instruction(
+                lang=identity.lang,
+                voice_style="warm",
+                bootstrap_context=bootstrap.bootstrap_context,
+                active_role=bootstrap.active_role or identity.role,
+                conversation_summary=bootstrap.conversation_summary,
+                conversation_history=bootstrap.last_turns,
+                is_reconnect=False,
+                last_session_info=None,
+                current_route=bootstrap.current_route,
+                recent_routes=bootstrap.recent_routes,
+                client_context=bootstrap.client_context,
+                vitana_id=bootstrap.vitana_id or identity.vitana_id,
+            )
+
+        await self._oasis.emit(
+            topic=TOPIC_SESSION_START,
+            payload={
+                "user_id": identity.user_id,
+                "tenant_id": identity.tenant_id,
+                "agent_id": agent_id,
+                "lang": identity.lang,
+                "is_mobile": identity.is_mobile,
+                "stt": bootstrap.voice_config.get("stt_provider") if bootstrap.voice_config else None,
+                "llm": bootstrap.voice_config.get("llm_provider") if bootstrap.voice_config else None,
+                "tts": bootstrap.voice_config.get("tts_provider") if bootstrap.voice_config else None,
+            },
+        )
+
+        # TODO(VTID-LIVEKIT-FOUNDATION): instantiate livekit.agents.VoicePipelineAgent
+        # with sys_prompt + cascade.{stt,llm,tts} + tools from tools.py.
+        logger.info(
+            "AgentSession started (skeleton): user=%s agent=%s sys_prompt_len=%d cascade_notes=%s",
+            identity.user_id,
+            agent_id,
+            len(sys_prompt),
+            cascade.notes,
+        )
+
+        return SessionContext(
+            orb_session_id=str(room_metadata.get("orb_session_id", "")),
+            identity=identity,
+            bootstrap=bootstrap,
+            cascade=cascade,
+            active_agent_id=agent_id,
+            reconnect_bucket=ReconnectBucket(),
+        )
+
+    async def handoff_to_specialist(
+        self,
+        *,
+        ctx: SessionContext,
+        target_agent_id: str,
+        reason: str,
+        context_summary: str,
+    ) -> SessionContext:
+        """Persona-swap path. Mid-session, swap LLM + TTS for the new specialist;
+        STT and the room remain. Bridge cue plays in the CURRENT voice before swap.
+        """
+        await self._oasis.emit(
+            topic=TOPIC_HANDOFF_START,
+            payload={
+                "from_agent_id": ctx.active_agent_id,
+                "to_agent_id": target_agent_id,
+                "reason": reason,
+                "context_summary": context_summary,
+                "user_id": ctx.identity.user_id,
+            },
+        )
+
+        # TODO(VTID-LIVEKIT-FOUNDATION): play bridge cue via current TTS,
+        # then re-fetch context-bootstrap with new agent_id, swap llm + tts
+        # plugins, update room metadata.
+
+        new_bootstrap = await self._ctx_fetcher.fetch(
+            user_jwt="",  # will be re-resolved from room metadata in real impl
+            agent_id=target_agent_id,
+            is_reconnect=True,
+            last_n_turns=10,
+        )
+        new_cascade = build_cascade(new_bootstrap.voice_config)
+
+        await self._oasis.emit(
+            topic=TOPIC_PERSONA_SWAP,
+            payload={
+                "room_id": ctx.orb_session_id,
+                "agent_id": target_agent_id,
+                "tts_provider": (new_bootstrap.voice_config or {}).get("tts_provider"),
+                "tts_model": (new_bootstrap.voice_config or {}).get("tts_model"),
+            },
+        )
+        await self._oasis.emit(
+            topic=TOPIC_HANDOFF_COMPLETE,
+            payload={
+                "from_agent_id": ctx.active_agent_id,
+                "to_agent_id": target_agent_id,
+                "latency_ms": 0,  # TODO: measure real swap latency
+            },
+        )
+
+        return SessionContext(
+            orb_session_id=ctx.orb_session_id,
+            identity=ctx.identity,
+            bootstrap=new_bootstrap,
+            cascade=new_cascade,
+            active_agent_id=target_agent_id,
+            reconnect_bucket=ctx.reconnect_bucket,
+        )
+
+    async def stop(self, ctx: SessionContext) -> None:
+        await self._oasis.emit(
+            topic=TOPIC_SESSION_STOP,
+            payload={
+                "user_id": ctx.identity.user_id,
+                "agent_id": ctx.active_agent_id,
+                "orb_session_id": ctx.orb_session_id,
+            },
+        )

--- a/services/agents/orb-agent/src/orb_agent/tools.py
+++ b/services/agents/orb-agent/src/orb_agent/tools.py
@@ -1,0 +1,436 @@
+"""Tool catalogue.
+
+Every tool in voice-pipeline-spec/spec.json.tools is exposed here as a
+`@function_tool`-decorated async Python function — all 40 of them. Each is
+a thin wrapper that calls the equivalent gateway HTTP endpoint and
+serializes the result to a string for the LLM.
+
+NOTHING in this file re-implements business logic. Every function is a
+single httpx.post / httpx.get call against the gateway, plus arg validation
+via Pydantic where appropriate. The gateway is the source of truth for tool
+behaviour; the agent only marshals the call.
+
+The libcst extractor in voice-pipeline-spec/tools/extract-py.py walks every
+@function_tool decorator here and feeds the names into the parity scanner.
+Tool names MUST match voice-pipeline-spec/spec.json.tools[].name exactly,
+or the parity scanner CI flags drift.
+
+Skeleton today: all 40 tool stubs raise NotImplementedError("VTID-LIVEKIT-FOUNDATION").
+A follow-up PR fills each in by calling the listed gateway endpoint.
+"""
+from __future__ import annotations
+
+import logging
+from typing import Any
+
+# livekit-agents plumbing — the runtime decorator is `@function_tool` from
+# `livekit.agents.llm.tool_context`. We import it lazily so unit tests on
+# this module don't need the full livekit stack.
+try:
+    from livekit.agents.llm import function_tool  # type: ignore[import-not-found]
+except ImportError:  # pragma: no cover
+
+    def function_tool(*args: Any, **kwargs: Any):  # type: ignore[no-redef]
+        """Fallback decorator when livekit-agents isn't installed (e.g. in unit tests)."""
+
+        def _wrap(fn: Any) -> Any:
+            return fn
+
+        if args and callable(args[0]):
+            return args[0]
+        return _wrap
+
+
+logger = logging.getLogger(__name__)
+
+NOT_IMPL = "NotImplementedError(VTID-LIVEKIT-FOUNDATION): tool stub — see services/agents/orb-agent/src/orb_agent/tools.py"
+
+
+# ---------------------------------------------------------------------------
+# Memory / Knowledge / Recall
+# ---------------------------------------------------------------------------
+
+
+@function_tool
+async def search_memory(query: str, limit: int = 5) -> str:
+    """Search the user's personal memory garden for entries matching `query`.
+
+    Args:
+        query: Free-text search phrase.
+        limit: Max number of entries to return (1..20).
+    """
+    raise NotImplementedError(NOT_IMPL)
+
+
+@function_tool
+async def search_knowledge(query: str) -> str:
+    """Search the Vitana Knowledge Hub (longevity, platform docs).
+
+    Args:
+        query: Free-text search phrase.
+    """
+    raise NotImplementedError(NOT_IMPL)
+
+
+@function_tool
+async def search_web(query: str) -> str:
+    """Web search via the configured external-search provider.
+
+    Args:
+        query: Free-text web search phrase.
+    """
+    raise NotImplementedError(NOT_IMPL)
+
+
+@function_tool
+async def recall_conversation_at_time(when: str) -> str:
+    """Recall what the user discussed at a given time (VTID-02052).
+
+    Args:
+        when: Natural-language time anchor, e.g. "yesterday morning", "two days ago".
+    """
+    raise NotImplementedError(NOT_IMPL)
+
+
+# ---------------------------------------------------------------------------
+# Persona / Handoff
+# ---------------------------------------------------------------------------
+
+
+@function_tool
+async def switch_persona(persona: str) -> str:
+    """Switch within-Vitana voice/style persona (NOT specialist handoff).
+
+    Args:
+        persona: Target persona name (e.g. "warm", "concise", "playful").
+    """
+    raise NotImplementedError(NOT_IMPL)
+
+
+@function_tool
+async def report_to_specialist(specialist: str, reason: str, context_summary: str) -> str:
+    """Hand off to a specialist (Sage / Devon / Atlas / Mira / Vitana).
+
+    Triggers the persona-swap flow in session.py. Each specialist has its own
+    voice configured in agent_voice_configs.
+
+    Args:
+        specialist: One of: 'sage' | 'devon' | 'atlas' | 'mira' | 'vitana'.
+        reason: Why the user is being handed off.
+        context_summary: Short summary the specialist needs to pick up the conversation.
+    """
+    raise NotImplementedError(NOT_IMPL)
+
+
+# ---------------------------------------------------------------------------
+# Calendar / Schedule
+# ---------------------------------------------------------------------------
+
+
+@function_tool
+async def search_calendar(query: str, days_ahead: int = 14) -> str:
+    """Search the user's calendar for upcoming events matching `query`."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+@function_tool
+async def create_calendar_event(title: str, when_iso: str, duration_min: int = 60) -> str:
+    """Create a calendar event."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+@function_tool
+async def add_to_calendar(title: str, when_iso: str) -> str:
+    """Add an event to the user's calendar (VTID-01943)."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+@function_tool
+async def get_schedule(date_iso: str | None = None) -> str:
+    """Return the user's schedule for a given date (defaults to today)."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+# ---------------------------------------------------------------------------
+# Community / Events / Recommendations
+# ---------------------------------------------------------------------------
+
+
+@function_tool
+async def search_events(query: str) -> str:
+    """Search community events / meetups (VTID-01270A)."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+@function_tool
+async def search_community(query: str) -> str:
+    """Search community groups / channels (VTID-01270A)."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+@function_tool
+async def get_recommendations() -> str:
+    """Return current Autopilot recommendations for the user (VTID-01180)."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+# ---------------------------------------------------------------------------
+# Music / Capability preferences
+# ---------------------------------------------------------------------------
+
+
+@function_tool
+async def play_music(query: str, provider: str | None = None) -> str:
+    """Play music via Spotify / Apple Music / Google / Vitana Hub (VTID-01941)."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+@function_tool
+async def set_capability_preference(capability: str, provider: str) -> str:
+    """Set the default provider for a capability (VTID-01942)."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+# ---------------------------------------------------------------------------
+# Email / Contacts
+# ---------------------------------------------------------------------------
+
+
+@function_tool
+async def read_email() -> str:
+    """Read the user's recent unread emails (VTID-01943)."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+@function_tool
+async def find_contact(query: str) -> str:
+    """Find a contact in the user's contact book (VTID-01943)."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+# ---------------------------------------------------------------------------
+# External AI bridge
+# ---------------------------------------------------------------------------
+
+
+@function_tool
+async def consult_external_ai(prompt: str, provider: str | None = None) -> str:
+    """Forward a prompt to the user's connected external AI account (ChatGPT / Claude / Gemini)."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+# ---------------------------------------------------------------------------
+# Vitana Index
+# ---------------------------------------------------------------------------
+
+
+@function_tool
+async def get_vitana_index() -> str:
+    """Return the user's current Vitana Index score + per-pillar breakdown (VTID-01983)."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+@function_tool
+async def get_index_improvement_suggestions() -> str:
+    """Return suggested actions that would lift the user's Vitana Index (VTID-01983)."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+@function_tool
+async def create_index_improvement_plan(target_pillar: str) -> str:
+    """Create a multi-step plan to improve a specific pillar (VTID-01983)."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+# ---------------------------------------------------------------------------
+# Diary
+# ---------------------------------------------------------------------------
+
+
+@function_tool
+async def save_diary_entry(text: str) -> str:
+    """Save a diary entry. Triggers Vitana Index recompute via /memory/diary/sync-index (VTID-01983)."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+# ---------------------------------------------------------------------------
+# Reminders
+# ---------------------------------------------------------------------------
+
+
+@function_tool
+async def set_reminder(text: str, when_iso: str) -> str:
+    """Set a reminder (VTID-02601)."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+@function_tool
+async def find_reminders(query: str | None = None) -> str:
+    """List the user's active reminders (VTID-02601)."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+@function_tool
+async def delete_reminder(reminder_id: str) -> str:
+    """Delete a reminder (VTID-02601)."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+# ---------------------------------------------------------------------------
+# Pillar agents / Feature explanations
+# ---------------------------------------------------------------------------
+
+
+@function_tool
+async def ask_pillar_agent(pillar: str, question: str) -> str:
+    """Ask a specific pillar agent (Nutrition / Hydration / Exercise / Sleep / Mental)."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+@function_tool
+async def explain_feature(feature: str) -> str:
+    """Explain a Vitana feature in plain language."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+# ---------------------------------------------------------------------------
+# Messaging (3-step send_message flow)
+# ---------------------------------------------------------------------------
+
+
+@function_tool
+async def resolve_recipient(name: str) -> str:
+    """Step 1 of 3-step send-message flow: resolve a name to candidates."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+@function_tool
+async def send_chat_message(recipient_id: str, body: str) -> str:
+    """Step 3: send the message after the user confirms the recipient."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+# ---------------------------------------------------------------------------
+# Autopilot recommendations
+# ---------------------------------------------------------------------------
+
+
+@function_tool
+async def activate_recommendation(recommendation_id: str) -> str:
+    """Activate an Autopilot recommendation (VTID-01180)."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+# ---------------------------------------------------------------------------
+# Sharing
+# ---------------------------------------------------------------------------
+
+
+@function_tool
+async def share_link(url: str, with_recipient: str | None = None) -> str:
+    """Share a link, optionally with a contact."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+# ---------------------------------------------------------------------------
+# Vitana Intent Engine (VTID-01975 / VTID-01976)
+# ---------------------------------------------------------------------------
+
+
+@function_tool
+async def post_intent(kind: str, body: str) -> str:
+    """Post an intent (commercial_buy / sell, activity_seek, partner_seek, social_seek, mutual_aid) (VTID-01975)."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+@function_tool
+async def view_intent_matches() -> str:
+    """View match candidates for the user's open intents (VTID-01976)."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+@function_tool
+async def list_my_intents() -> str:
+    """List the user's open and historical intents."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+@function_tool
+async def respond_to_match(match_id: str, response: str) -> str:
+    """Respond to a match candidate (VTID-01976)."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+@function_tool
+async def mark_intent_fulfilled(intent_id: str) -> str:
+    """Mark an intent as fulfilled."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+@function_tool
+async def share_intent_post(intent_id: str, with_recipient: str) -> str:
+    """Share an intent post with a contact."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+@function_tool
+async def scan_existing_matches() -> str:
+    """Scan for matches across all open intents."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+@function_tool
+async def get_matchmaker_result(intent_id: str) -> str:
+    """Get the matchmaker's current result for a specific intent."""
+    raise NotImplementedError(NOT_IMPL)
+
+
+# ---------------------------------------------------------------------------
+# Navigation
+# ---------------------------------------------------------------------------
+
+
+@function_tool
+async def navigate_to_screen(target: str) -> str:
+    """Navigate the user to a named screen.
+
+    Cross-surface navigation (e.g. community user trying to go to /admin)
+    is rejected with an LLM-visible error per
+    memory/feedback_navigator_surface_scoping.md.
+
+    Args:
+        target: Named screen identifier from the spec's navigation registry.
+    """
+    raise NotImplementedError(NOT_IMPL)
+
+
+# ---------------------------------------------------------------------------
+# Catalogue export — used by tests + libcst smoke
+# ---------------------------------------------------------------------------
+
+
+def all_tool_names() -> list[str]:
+    """Returns the names of every @function_tool in this module.
+
+    Used by tests/test_tools.py to assert the tool list matches
+    voice-pipeline-spec/spec.json. Update when adding/removing a tool.
+    """
+    return [
+        "search_memory", "search_knowledge", "search_web", "recall_conversation_at_time",
+        "switch_persona", "report_to_specialist",
+        "search_calendar", "create_calendar_event", "add_to_calendar", "get_schedule",
+        "search_events", "search_community", "get_recommendations",
+        "play_music", "set_capability_preference",
+        "read_email", "find_contact",
+        "consult_external_ai",
+        "get_vitana_index", "get_index_improvement_suggestions", "create_index_improvement_plan",
+        "save_diary_entry",
+        "set_reminder", "find_reminders", "delete_reminder",
+        "ask_pillar_agent", "explain_feature",
+        "resolve_recipient", "send_chat_message",
+        "activate_recommendation",
+        "share_link",
+        "post_intent", "view_intent_matches", "list_my_intents", "respond_to_match",
+        "mark_intent_fulfilled", "share_intent_post", "scan_existing_matches", "get_matchmaker_result",
+        "navigate_to_screen",
+    ]

--- a/services/agents/orb-agent/src/orb_agent/video.py
+++ b/services/agents/orb-agent/src/orb_agent/video.py
@@ -1,0 +1,50 @@
+"""Video frame forwarder for vision-capable LLMs.
+
+Mirrors orb-live.ts:12793 (`vtid.live.video.in.frame` emission). When the
+configured LLM provider supports vision (Gemini, GPT-4o), forward LiveKit
+video tracks at 1 FPS as JPEG 768x768 to the LLM. When the provider doesn't,
+drop frames gracefully and emit a one-time warning.
+
+Skeleton today: API surface only.
+"""
+from __future__ import annotations
+
+import logging
+
+logger = logging.getLogger(__name__)
+
+
+VISION_CAPABLE_LLM_PROVIDERS = frozenset({
+    "google_llm",       # gemini-2.5-flash, gemini-2.5-pro
+    "openai",           # gpt-4o, gpt-4o-mini, gpt-4.1
+})
+
+VIDEO_TARGET_FPS = 1
+VIDEO_TARGET_RESOLUTION = (768, 768)
+VIDEO_TARGET_FORMAT = "JPEG"
+
+
+def llm_supports_vision(provider: str) -> bool:
+    return provider in VISION_CAPABLE_LLM_PROVIDERS
+
+
+class VideoFrameForwarder:
+    """Wraps a LiveKit video track and ships frames into the LLM context.
+
+    TODO(VTID-LIVEKIT-FOUNDATION): wire to a real LiveKit video track in the
+    follow-up implementation PR.
+    """
+
+    def __init__(self, llm_provider: str) -> None:
+        self._enabled = llm_supports_vision(llm_provider)
+        self._frames_dropped = 0
+        if not self._enabled:
+            logger.info(
+                "VideoFrameForwarder disabled — LLM provider '%s' does not support vision. "
+                "Frames will be dropped silently.",
+                llm_provider,
+            )
+
+    @property
+    def enabled(self) -> bool:
+        return self._enabled

--- a/services/agents/orb-agent/src/orb_agent/watchdogs.py
+++ b/services/agents/orb-agent/src/orb_agent/watchdogs.py
@@ -1,0 +1,92 @@
+"""Stall watchdog + reconnect-bucket counter.
+
+Mirrors VTID-WATCHDOG (orb-live.ts:7320) and VTID-STREAM-RECONNECT
+(orb-live.ts:9280). The tool-loop guard is **NOT** custom-coded here — we
+use livekit-agents' built-in `AgentSession(max_tool_steps=N)` which
+auto-enforces tool_choice='none' at the threshold.
+
+Constants below are walked by the parity scanner — names match
+voice-pipeline-spec/spec.json.watchdogs.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+from dataclasses import dataclass
+
+logger = logging.getLogger(__name__)
+
+# Parity-spec watchdogs (names mirror voice-pipeline-spec/spec.json)
+SESSION_TIMEOUT_MS = 30 * 60 * 1000  # 30 min
+MAX_SESSION_AGE_MS = 30 * 60 * 1000  # 30 min — same as SESSION_TIMEOUT_MS
+CONVERSATION_TIMEOUT_MS = 24 * 60 * 60 * 1000  # 24 h
+TRANSCRIPT_RETENTION_MS = 60 * 60 * 1000  # 1 h
+IP_GEO_CACHE_TTL_MS = 60 * 60 * 1000  # 1 h
+MAX_CONNECTIONS_PER_IP = 5
+MAX_RECONNECTS = 10
+MAX_TOOL_RESPONSE_CHARS = 4000
+MAX_HISTORY_CHARS = 4000
+EXTRACTION_THROTTLE_MS = 60_000
+BOOTSTRAP_REBUILD_MIN_AGE_MS = 60_000
+
+# Stall watchdog: model has produced no audio output for this long → reconnect.
+STALL_THRESHOLD_MS = 8000
+
+
+@dataclass
+class ReconnectBucket:
+    """Tracks reconnect attempts within a session. Caps at MAX_RECONNECTS."""
+
+    count: int = 0
+
+    def record_attempt(self) -> bool:
+        """Returns True if reconnect is allowed, False if cap reached."""
+        if self.count >= MAX_RECONNECTS:
+            return False
+        self.count += 1
+        return True
+
+
+class StallWatchdog:
+    """Async watchdog that fires a callback if no `feed()` arrives within
+    `threshold_ms` of the last one. Reset on every `feed()`."""
+
+    def __init__(self, threshold_ms: int = STALL_THRESHOLD_MS) -> None:
+        self._threshold_s = threshold_ms / 1000.0
+        self._task: asyncio.Task[None] | None = None
+        self._fed = asyncio.Event()
+        self._cb: callable | None = None  # type: ignore[type-arg]
+        self._stopped = False
+
+    def start(self, on_stall: callable) -> None:  # type: ignore[type-arg]
+        self._cb = on_stall
+        self._stopped = False
+        self._task = asyncio.create_task(self._loop())
+
+    def feed(self) -> None:
+        self._fed.set()
+
+    async def stop(self) -> None:
+        self._stopped = True
+        if self._task:
+            self._task.cancel()
+            try:
+                await self._task
+            except asyncio.CancelledError:
+                pass
+
+    async def _loop(self) -> None:
+        while not self._stopped:
+            self._fed.clear()
+            try:
+                await asyncio.wait_for(self._fed.wait(), timeout=self._threshold_s)
+            except TimeoutError:
+                logger.warning("StallWatchdog fired (no feed in %ss)", self._threshold_s)
+                if self._cb is not None:
+                    try:
+                        await self._cb()
+                    except Exception as exc:  # noqa: BLE001
+                        logger.exception("StallWatchdog callback failed: %s", exc)
+                # After firing, wait for the next feed before re-arming, to
+                # avoid a tight loop if the callback can't unblock immediately.
+                await self._fed.wait()

--- a/services/agents/orb-agent/tests/test_smoke.py
+++ b/services/agents/orb-agent/tests/test_smoke.py
@@ -1,0 +1,119 @@
+"""Smoke tests: each module imports cleanly and exposes the expected surface."""
+from __future__ import annotations
+
+
+def test_config_imports() -> None:
+    from src.orb_agent.config import AgentConfig
+
+    assert AgentConfig is not None
+
+
+def test_oasis_imports() -> None:
+    from src.orb_agent.oasis import (
+        TOPIC_HANDOFF_COMPLETE,
+        TOPIC_HANDOFF_START,
+        TOPIC_PERSONA_SWAP,
+        TOPIC_SESSION_START,
+        TOPIC_SESSION_STOP,
+        OasisEmitter,
+    )
+
+    assert OasisEmitter is not None
+    # Topic strings must be the canonical literals from the parity spec.
+    assert TOPIC_SESSION_START == "livekit.session.start"
+    assert TOPIC_SESSION_STOP == "livekit.session.stop"
+    assert TOPIC_HANDOFF_START == "voice.handoff.start"
+    assert TOPIC_HANDOFF_COMPLETE == "voice.handoff.complete"
+    assert TOPIC_PERSONA_SWAP == "agent.voice.persona_swap"
+
+
+def test_instructions_signatures() -> None:
+    """The signatures of build_live / build_anonymous match the parity spec."""
+    import inspect
+
+    from src.orb_agent.instructions import (
+        build_anonymous_system_instruction,
+        build_live_system_instruction,
+    )
+
+    auth_params = list(inspect.signature(build_live_system_instruction).parameters.keys())
+    anon_params = list(inspect.signature(build_anonymous_system_instruction).parameters.keys())
+
+    expected_auth = [
+        "lang",
+        "voice_style",
+        "bootstrap_context",
+        "active_role",
+        "conversation_summary",
+        "conversation_history",
+        "is_reconnect",
+        "last_session_info",
+        "current_route",
+        "recent_routes",
+        "client_context",
+        "vitana_id",
+    ]
+    expected_anon = ["lang", "voice_style", "ctx", "conversation_history", "is_reconnect"]
+
+    assert auth_params == expected_auth, f"build_live signature drift: {auth_params}"
+    assert anon_params == expected_anon, f"build_anonymous signature drift: {anon_params}"
+
+
+def test_navigator_surface_classification() -> None:
+    from src.orb_agent.navigator import classify_surface
+
+    assert classify_surface("/admin/feedback/specialists") == "admin"
+    assert classify_surface("/command-hub/diagnostics") == "developer"
+    assert classify_surface("/comm/find-partner") == "community"
+    assert classify_surface("/discover/marketplace") == "community"
+    assert classify_surface("/some/random") == "unknown"
+
+
+def test_navigator_cross_surface_blocked() -> None:
+    import pytest
+
+    from src.orb_agent.navigator import assert_route_in_surface
+
+    # Crossing community → admin must raise.
+    with pytest.raises(ValueError):
+        assert_route_in_surface("/admin/feedback/specialists", "community")
+    # Same-surface is fine.
+    assert_route_in_surface("/comm/find-partner", "community")
+
+
+def test_identity_mobile_coercion() -> None:
+    """Mobile session with developer DB role must coerce to community."""
+    from src.orb_agent.identity import resolve_identity_from_room_metadata
+
+    ident = resolve_identity_from_room_metadata({
+        "user_id": "u1",
+        "tenant_id": "t1",
+        "role": "developer",
+        "lang": "en",
+        "is_mobile": True,
+    })
+    assert ident.role == "community", "mobile must coerce to community"
+
+    ident_desktop = resolve_identity_from_room_metadata({
+        "user_id": "u2",
+        "tenant_id": "t1",
+        "role": "developer",
+        "lang": "en",
+        "is_mobile": False,
+    })
+    assert ident_desktop.role == "developer"
+
+
+def test_health_app_returns_ok() -> None:
+    from fastapi.testclient import TestClient
+
+    from src.orb_agent.health import make_health_app
+
+    app = make_health_app()
+    client = TestClient(app)
+    r = client.get("/health")
+    assert r.status_code == 200
+    body = r.json()
+    assert body["ok"] is True
+    assert body["service"] == "orb-agent"
+    assert "providers" in body

--- a/services/agents/orb-agent/tests/test_tools_catalogue.py
+++ b/services/agents/orb-agent/tests/test_tools_catalogue.py
@@ -1,0 +1,46 @@
+"""Tests that the tool catalogue matches voice-pipeline-spec/spec.json.
+
+This is the parity contract enforced from the Python side. The CI parity
+scanner does the static AST walk; these tests do the dynamic-import check.
+Both should agree.
+"""
+from __future__ import annotations
+
+import json
+from pathlib import Path
+
+import pytest
+
+
+REPO_ROOT = Path(__file__).resolve().parents[3]
+SPEC = REPO_ROOT / "voice-pipeline-spec" / "spec.json"
+
+
+def _load_spec_tools() -> set[str]:
+    if not SPEC.exists():
+        pytest.skip(f"spec.json not found at {SPEC} (run from a checkout that includes voice-pipeline-spec/)")
+    with SPEC.open() as f:
+        spec = json.load(f)
+    return {t["name"] for t in spec["tools"]}
+
+
+def test_all_tool_names_exported() -> None:
+    """tools.all_tool_names() must equal spec.json's tool list."""
+    from src.orb_agent.tools import all_tool_names
+
+    spec_tools = _load_spec_tools()
+    skeleton_tools = set(all_tool_names())
+    missing_in_skeleton = spec_tools - skeleton_tools
+    extra_in_skeleton = skeleton_tools - spec_tools
+    assert not missing_in_skeleton, f"spec declares tools not in skeleton: {missing_in_skeleton}"
+    assert not extra_in_skeleton, f"skeleton has tools not in spec: {extra_in_skeleton}"
+
+
+def test_tool_decorators_present() -> None:
+    """Every tool name must resolve to a callable in tools module."""
+    import src.orb_agent.tools as tools_mod
+    from src.orb_agent.tools import all_tool_names
+
+    for name in all_tool_names():
+        fn = getattr(tools_mod, name, None)
+        assert callable(fn), f"tool {name!r} not exported as callable in tools.py"


### PR DESCRIPTION
## Summary

Adds `services/agents/orb-agent/` — the Python `livekit-agents` worker that will become the standby alternative to the Vertex Live pipeline at `services/gateway/src/routes/orb-live.ts`.

**Skeleton only.** Module shape established, key entrypoints stubbed, imports compile, syntax-checked. Does not run a real conversation yet.

## Why this matters for the parity scanner (#1150)

`voice-pipeline-spec/tools/extract-py.py` walks this folder and:
- finds every `@function_tool` decorator → tool list
- finds every `oasis.emit(topic=...)` call → OASIS topics
- finds every `*_MS` / `MAX_*` / `*_TIMEOUT` constant → watchdog values
- reads `build_live_system_instruction` / `build_anonymous_system_instruction` parameter signatures

Until this skeleton lands, the libcst extractor returns empty and the parity scanner can't compare both sides. With this PR the LiveKit side has **40 tools, 15 OASIS topics, 11 watchdogs, both system-instruction signatures** — all matching `voice-pipeline-spec/spec.json`.

## What's in this PR

\`\`\`
services/agents/orb-agent/
  Dockerfile              multi-stage Python 3.11-slim, Cloud Run ready
  pyproject.toml          modern Python project + dev/extra deps
  requirements.txt        Cloud-Run-compatible deps list
  service.yaml            Cloud Run config (min=0 scale-to-zero)
  manifest.json           VTID metadata + OASIS topics + runtime
  package.json            monorepo tooling consistency
  README.md
  main.py                 entrypoint: health server + heartbeat
  src/orb_agent/
    config.py, health.py, registry_client.py, oasis.py, bootstrap.py,
    instructions.py, tools.py, providers.py, session.py,
    identity.py, navigator.py, video.py, watchdogs.py
  tests/
    test_smoke.py             — imports, signatures, mobile coercion, navigator scoping
    test_tools_catalogue.py   — tool list matches spec.json
\`\`\`

## What still needs to land

- Real `instructions.py` prompt port from `buildLiveSystemInstruction` (orb-live.ts:6938+, ~5–15 KB role-aware prompt).
- Real `tools.py` bodies — each replaces `NotImplementedError` with a thin `httpx` call to the existing gateway endpoint.
- Wire `main.py` to launch the actual `livekit-agents` worker (uses `livekit.agents.cli.run_app`).
- Migration adding `voice_providers` / `agent_voice_configs` tables (PR #3 in the queue).
- Gateway `/api/v1/orb/context-bootstrap` and `/api/v1/orb/livekit/token` endpoints (PR #4).

## Local sanity

\`\`\`
$ for f in main.py src/orb_agent/*.py tests/*.py; do \\
    python3 -c "import ast; ast.parse(open('$f').read())" && echo "ok $f"; \\
  done
→ all 18 files parse clean.
\`\`\`

(WSL doesn't have pip; full `pytest` will run in CI on this PR.)

## VTID

To allocate at merge.

## Test plan

- [ ] CI: parity scanner runs and finds the 40 tools / 15 topics / 11 watchdogs in the new Python folder
- [ ] CI: pytest runs `tests/test_smoke.py` and `tests/test_tools_catalogue.py` green
- [ ] CI: docker build of `services/agents/orb-agent/Dockerfile` succeeds
- [ ] No regression on existing services (`services/agents/cognee-extractor/`, etc.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)