### PR TITLE
fix(spec): add feedback.audit tab to dev-screen-inventory-v1.json

### DIFF
--- a/services/gateway/specs/dev-screen-inventory-v1.json
+++ b/services/gateway/specs/dev-screen-inventory-v1.json
@@ -176,11 +176,12 @@
     "feedback": [
       "inbox",
       "handoffs",
-      "kpis"
+      "kpis",
+      "audit"
     ]
   },
   "screen_inventory": {
-    "total_screens": 114,
+    "total_screens": 115,
     "total_entries": 289,
     "last_synced": "2026-04-27",
     "source": "auto-regen via services/gateway/scripts/regen-screens-catalog.mjs",


### PR DESCRIPTION
## Summary

Recent feedback PRs added an \`audit\` tab under the feedback module in \`navigation-config.js\` but didn't update the canonical screen-inventory spec. Gateway Validation (Minimal CI) has been failing on every PR that follows.

## Changes

\`services/gateway/specs/dev-screen-inventory-v1.json\`:
- \`module_catalog.feedback\`: + \`audit\` (3 → 4 tabs)
- \`total_screens\`: 114 → 115

## Test plan

- [x] Local validator: \`node ./scripts/validate-dev-frontend-spec.mjs\` → \`FRONTEND SPEC OK · 20/20 modules · 115/115 screens\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)