### PR TITLE
fix(orb): revert beep length, fix actual cut by playing beep before mic capture (VTID-02035b)

### DIFF
--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -11,7 +11,7 @@
   <!-- VTID-01216: Intelligence Panel containers -->
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
-  <script src="/command-hub/orb-widget.js?v=20260501-vtid-02035-mobile-beep-chime"></script>
+  <script src="/command-hub/orb-widget.js?v=20260501-vtid-02035b-revert-length-fix-cut"></script>
   <script src="/command-hub/app.js?v=20260429-dev-6h-session-v2"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>

--- a/services/gateway/src/frontend/command-hub/orb-widget.js
+++ b/services/gateway/src/frontend/command-hub/orb-widget.js
@@ -418,27 +418,20 @@
   function _playChime(ctx) {
     if (!ctx || ctx.state === 'closed') return;
     try {
-      // VTID-02035: same mobile-clipping issue as _playReadyBeep — original
-      // chime had two 150-200ms segments back-to-back with steep ramps that
-      // mobile speakers truncated. Stretched to ~700ms total with longer
-      // sustain on each note and a small lead-in delay so the audio
-      // pipeline is warm before envelope start.
-      var now = ctx.currentTime + 0.02;
+      var now = ctx.currentTime;
       var g = ctx.createGain();
       g.connect(ctx.destination);
-      // Note 1 envelope (C5)
       g.gain.setValueAtTime(0, now);
-      g.gain.linearRampToValueAtTime(0.15, now + 0.05);
+      g.gain.linearRampToValueAtTime(0.15, now + 0.02);
+      g.gain.setValueAtTime(0.15, now + 0.08);
+      g.gain.linearRampToValueAtTime(0.0, now + 0.15);
+      g.gain.linearRampToValueAtTime(0.15, now + 0.15);
       g.gain.setValueAtTime(0.15, now + 0.25);
-      g.gain.linearRampToValueAtTime(0.0, now + 0.30);
-      // Note 2 envelope (E5)
-      g.gain.linearRampToValueAtTime(0.15, now + 0.35);
-      g.gain.setValueAtTime(0.15, now + 0.60);
-      g.gain.linearRampToValueAtTime(0.0, now + 0.68);
+      g.gain.linearRampToValueAtTime(0.0, now + 0.40);
       var o1 = ctx.createOscillator(); o1.type = 'sine'; o1.frequency.setValueAtTime(523.25, now);
-      o1.connect(g); o1.start(now); o1.stop(now + 0.30);
-      var o2 = ctx.createOscillator(); o2.type = 'sine'; o2.frequency.setValueAtTime(659.25, now + 0.30);
-      o2.connect(g); o2.start(now + 0.30); o2.stop(now + 0.70);
+      o1.connect(g); o1.start(now); o1.stop(now + 0.15);
+      var o2 = ctx.createOscillator(); o2.type = 'sine'; o2.frequency.setValueAtTime(659.25, now + 0.15);
+      o2.connect(g); o2.start(now + 0.15); o2.stop(now + 0.40);
     } catch (e) { /* ignore */ }
   }
 
@@ -446,26 +439,14 @@
     try {
       var ctx = _s.playbackCtx;
       if (!ctx || ctx.state === 'closed') return;
-      // VTID-02035: lengthen + add sustain so mobile speakers don't clip
-      // the beep. Original 0.2s total (audible ~130ms) was clipped on
-      // iOS / Appilix WebView — speaker buffer hadn't filled before the
-      // gain envelope already collapsed back to zero.
-      // New shape: 60ms ramp-in → 380ms sustain at 0.12 → 60ms ramp-out
-      // = 500ms total, ~440ms audible. Gives mobile audio pipeline time
-      // to fully render. Slightly higher peak gain (0.12 vs 0.1) so the
-      // envelope reaches audibility before the speaker stabilises.
-      // Schedule the start at ctx.currentTime + 0.02 to defer past any
-      // sub-frame hiccup at envelope start.
       var o = ctx.createOscillator();
       var g = ctx.createGain();
       o.connect(g); g.connect(ctx.destination);
       o.frequency.value = 800;
-      var t0 = ctx.currentTime + 0.02;
-      g.gain.setValueAtTime(0, t0);
-      g.gain.linearRampToValueAtTime(0.12, t0 + 0.06);
-      g.gain.setValueAtTime(0.12, t0 + 0.44);
-      g.gain.linearRampToValueAtTime(0, t0 + 0.50);
-      o.start(t0); o.stop(t0 + 0.52);
+      g.gain.setValueAtTime(0, ctx.currentTime);
+      g.gain.linearRampToValueAtTime(0.1, ctx.currentTime + 0.05);
+      g.gain.linearRampToValueAtTime(0, ctx.currentTime + 0.2);
+      o.start(ctx.currentTime); o.stop(ctx.currentTime + 0.2);
     } catch (e) { /* ignore */ }
   }
 
@@ -1322,23 +1303,37 @@
               _waitForAudioEnd(); // Still playing — check again in 300ms
               return;
             }
-            // Start mic on first turn_complete (greeting done) — not before.
-            if (!_s.greetingComplete) {
-              _s.greetingComplete = true;
-              _startAudioCapture().catch(function (err) {
-                console.error('[VTOrb] Mic capture failed after greeting:', err);
-                _announceDisconnect('mic');
-              });
-            }
+            // VTID-02035b: play the ready beep BEFORE starting mic capture.
+            // On iOS / Appilix WebView, getUserMedia switches the audio
+            // session to the "voiceChat"/"playAndRecord" category, which
+            // ducks (or briefly cuts) any other audio playing through the
+            // shared playback context. The beep was getting clipped because
+            // _startAudioCapture() ran first and the audio-session switch
+            // happened during the beep envelope. Play the beep, give it
+            // ~250ms (its full audible window) to drain on the speaker,
+            // THEN start mic capture.
+            var _afterBeepStartMic = function () {
+              if (!_s.greetingComplete) {
+                _s.greetingComplete = true;
+                _startAudioCapture().catch(function (err) {
+                  console.error('[VTOrb] Mic capture failed after greeting:', err);
+                  _announceDisconnect('mic');
+                });
+              }
+            };
             if (_s.voiceState === 'MUTED') {
               // Muted — don't change visual state, but update what unmute restores to
               _s.preMuteState = 'LISTENING';
+              _afterBeepStartMic();
             } else {
               _setOrbState('listening');
               _s.voiceState = 'LISTENING';
               _setStatus(_cfg.lang.startsWith('de') ? 'Ich höre zu...' : 'Listening...');
               _playReadyBeep();
               _updateUI();
+              // The beep is 200ms; defer mic-arm by 250ms so the audio-session
+              // switch happens after the speaker has finished rendering it.
+              setTimeout(_afterBeepStartMic, 250);
 
               // VTID-NAV-IDLE: If the orb sits in LISTENING for 15 seconds
               // without the user speaking, nudge them. This catches the


### PR DESCRIPTION
## What broke

VTID-02035 misdiagnosed the user report. The user said the beep was **cut** (interrupted mid-playback), not too short. I extended the duration anyway, which made the beep ~2× longer and **annoying** without fixing the cut.

## Real root cause

In the turn_complete handler:

\`\`\`js
_startAudioCapture()   // mic capture armed (calls getUserMedia)
_playReadyBeep()       // beep plays AFTER
\`\`\`

On iOS / Appilix WebView, \`getUserMedia\` switches the audio session to \`voiceChat\` / \`playAndRecord\` category. That switch **ducks (or briefly cuts) audio playing through the shared playback context** — so the beep envelope was being clipped by an audio-session switch happening **during** the beep itself.

## Fix

1. Revert \`_playChime\` and \`_playReadyBeep\` to their original short durations.
2. **Play the beep first**, then defer \`_startAudioCapture()\` by 250ms (the beep's full audible window) via \`setTimeout\`. Audio-session switch now happens **after** the speaker has finished rendering the beep cleanly.

## Touched files

- \`services/gateway/src/frontend/command-hub/orb-widget.js\` — restore envelope shapes; reorder beep-then-mic with a 250ms deferral.
- \`services/gateway/src/frontend/command-hub/index.html\` — cache-buster bump.

🤖 Generated with [Claude Code](https://claude.com/claude-code)