### PR TITLE
feat(feedback): end-to-end dev autopilot bridge + reclassify (VTID-02665)

### DIFF
--- a/services/gateway/src/routes/tenant-specialists.ts
+++ b/services/gateway/src/routes/tenant-specialists.ts
@@ -871,6 +871,37 @@ router.post('/:tenantId/tickets/:id/activate', async (req: Request, res: Respons
     if (u) { newStatus = 'resolved'; action = 'resolved'; }
   }
 
+  // VTID-02665: dispatch bug / ux_issue tickets through the dev autopilot
+  // pipeline once they enter in_progress. The bridge inserts an
+  // autopilot_recommendations row and creates a dev_autopilot_executions
+  // row that backgroundExecutorTick will claim on its next pass (~30s).
+  // The ticket's spec_md becomes the executor's spec; supervisor_notes is
+  // packed into spec_snapshot.feedback for the planner to see.
+  let dispatchInfo: { recommendation_id?: string; execution_id?: string; skipped?: string; error?: string } | null = null;
+  if (newStatus === 'in_progress' && (t.kind === 'bug' || t.kind === 'ux_issue')) {
+    try {
+      // Re-fetch the ticket so we have the latest spec_md / supervisor_notes
+      // (an earlier /draft-spec call in the same supervisor session sets
+      // both — but loaded.ticket above was fetched before any patches).
+      const { data: fresh } = await supabase.from('feedback_tickets')
+        .select('id, ticket_number, kind, status, spec_md, supervisor_notes, raw_transcript, vitana_id, screen_path, app_version, linked_finding_id')
+        .eq('id', t.id).maybeSingle();
+      if (fresh) {
+        const { dispatchFeedbackTicket } = await import('../services/feedback-execution-bridge');
+        const r = await dispatchFeedbackTicket(fresh as any, userId);
+        dispatchInfo = {
+          recommendation_id: r.recommendation_id,
+          execution_id: r.execution_id,
+          skipped: r.skipped,
+          error: r.ok ? undefined : r.error,
+        };
+      }
+    } catch (err) {
+      console.warn(`[VTID-02665] dispatchFeedbackTicket failed for ${t.ticket_number}:`, err);
+      dispatchInfo = { error: err instanceof Error ? err.message : 'unknown' };
+    }
+  }
+
   // Audit + OASIS
   await supabase.from('agent_audit_log').insert({
     actor_user_id: userId,
@@ -895,7 +926,99 @@ router.post('/:tenantId/tickets/:id/activate', async (req: Request, res: Respons
     });
   } catch { /* non-blocking */ }
 
-  return res.json({ ok: true, ticket_id: t.id, ticket_number: t.ticket_number, from: t.status, to: newStatus, action });
+  return res.json({
+    ok: true,
+    ticket_id: t.id,
+    ticket_number: t.ticket_number,
+    from: t.status,
+    to: newStatus,
+    action,
+    dispatch: dispatchInfo,
+  });
+});
+
+// ---------------------------------------------------------------------------
+// PUT /:tenantId/tickets/:id/reclassify — VTID-02665
+// ---------------------------------------------------------------------------
+// Lets the supervisor fix a misclassified ticket (e.g. classifier picked
+// support_question but it's really a bug). Resets the ticket to a
+// pre-draft state so the new resolver can be picked up by /draft-spec.
+//
+// Body: { kind: 'bug'|'ux_issue'|'support_question'|'marketplace_claim'|
+//                'account_issue'|'feedback'|'feature_request' }
+// Effect:
+//   - Updates kind
+//   - Clears spec_md / draft_answer_md / resolution_md (the previous
+//     resolver's draft is no longer relevant)
+//   - Resets resolver_agent
+//   - Status → 'triaged' (so the drawer shows the Generate step again)
+//   - Refuses if the ticket is already linked to a dev autopilot finding
+//     (you can't reclassify an in-flight execution).
+const KIND_VALUES = ['bug','ux_issue','support_question','marketplace_claim','account_issue','feedback','feature_request'] as const;
+const ReclassifyBody = z.object({ kind: z.enum(KIND_VALUES) });
+
+router.put('/:tenantId/tickets/:id/reclassify', async (req: Request, res: Response) => {
+  const tenantId = req.params.tenantId;
+  const userId = await ensureTenantAdmin(req, res, tenantId);
+  if (!userId) return;
+  const v = ReclassifyBody.safeParse(req.body);
+  if (!v.success) return res.status(400).json({ ok: false, error: 'INVALID_BODY' });
+
+  const loaded = await loadTicketIfTenantOwned(req.params.id, tenantId);
+  if (!loaded) return res.status(404).json({ ok: false, error: 'NOT_FOUND_OR_NOT_IN_TENANT' });
+  const t = loaded.ticket as { id: string; ticket_number: string; kind: string; status: string; linked_finding_id: string | null; vitana_id: string | null };
+
+  if (t.linked_finding_id) {
+    return res.status(409).json({
+      ok: false,
+      error: 'ALREADY_DISPATCHED',
+      message: 'This ticket is already running through the dev autopilot. Reclassify is blocked once dispatched.',
+      finding_id: t.linked_finding_id,
+    });
+  }
+  if (t.kind === v.data.kind) {
+    return res.json({ ok: true, ticket_id: t.id, kind: t.kind, no_change: true });
+  }
+
+  const supabase = getServiceClient();
+  const { error: upErr } = await supabase
+    .from('feedback_tickets')
+    .update({
+      kind: v.data.kind,
+      status: 'triaged',
+      spec_md: null,
+      draft_answer_md: null,
+      resolution_md: null,
+      resolver_agent: null,
+    })
+    .eq('id', t.id);
+  if (upErr) return res.status(502).json({ ok: false, error: upErr.message });
+
+  await supabase.from('agent_audit_log').insert({
+    actor_user_id: userId,
+    tenant_id: tenantId,
+    persona_id: null,
+    action: 'tenant_persona_enable', // closest existing slot
+    after_state: { ticket_id: t.id, ticket_number: t.ticket_number, action: 'reclassify', from_kind: t.kind, to_kind: v.data.kind },
+  });
+
+  try {
+    const { emitOasisEvent } = await import('../services/oasis-event-service');
+    await emitOasisEvent({
+      vtid: 'VTID-02665',
+      type: 'feedback.ticket.status_changed' as any,
+      source: 'tenant-admin-reclassify',
+      status: 'info',
+      message: `Tenant ${tenantId} reclassified ${t.ticket_number}: ${t.kind} → ${v.data.kind}`,
+      payload: { ticket_id: t.id, ticket_number: t.ticket_number, from_kind: t.kind, to_kind: v.data.kind },
+      actor_id: userId,
+      actor_role: 'operator',
+      surface: 'operator',
+      vitana_id: (t.vitana_id as string) ?? undefined,
+    });
+  } catch { /* non-blocking */ }
+
+  return res.json({ ok: true, ticket_id: t.id, kind: v.data.kind, status: 'triaged' });
 });
 
 void VTID;

--- a/services/gateway/src/services/feedback-execution-bridge.ts
+++ b/services/gateway/src/services/feedback-execution-bridge.ts
@@ -1,0 +1,259 @@
+/**
+ * VTID-02665: Feedback Execution Bridge.
+ *
+ * Converts an activated bug / ux_issue feedback ticket into the existing
+ * dev autopilot pipeline:
+ *
+ *   feedback_ticket (kind=bug|ux_issue, status=in_progress, spec_md set)
+ *       │
+ *       ▼
+ *   INSERT autopilot_recommendations (source_type='dev_autopilot',
+ *       spec_snapshot=<ticket spec + supervisor notes>)
+ *       │
+ *       ▼
+ *   bridgeActivationToExecution(finding_id)
+ *       (generates plan + creates dev_autopilot_executions row +
+ *        sets execute_after = now so backgroundExecutorTick claims it)
+ *       │
+ *       ▼
+ *   Existing autopilot worker runs Claude Messages API with the spec
+ *   → makes the code changes → opens PR → CI → merge → EXEC-DEPLOY
+ *       │
+ *       ▼
+ *   feedback_tickets.linked_finding_id (this PR) +
+ *   feedback_tickets.linked_pr_url + linked_vtid (later, by reconciler)
+ *
+ * The supervisor's instructions (supervisor_notes) take priority over
+ * the user's report when the spec was generated upstream — VTID-02664.
+ * This service treats spec_md as the authoritative work item and just
+ * forwards it; supervisor_notes is included verbatim for the executor's
+ * Claude session as additional context.
+ */
+
+import { bridgeActivationToExecution } from './dev-autopilot-execute';
+
+const VTID = 'VTID-02665';
+
+interface FeedbackTicketRow {
+  id: string;
+  ticket_number: string | null;
+  kind: string;
+  status: string;
+  spec_md: string | null;
+  supervisor_notes: string | null;
+  raw_transcript: string | null;
+  vitana_id: string | null;
+  screen_path: string | null;
+  app_version: string | null;
+  linked_finding_id: string | null;
+}
+
+export interface BridgeResult {
+  ok: boolean;
+  recommendation_id?: string;
+  execution_id?: string;
+  skipped?: string;
+  error?: string;
+}
+
+interface SupaConfig {
+  url: string;
+  key: string;
+  headers: Record<string, string>;
+}
+
+function getSupabase(): SupaConfig | null {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE;
+  if (!url || !key) return null;
+  return {
+    url,
+    key,
+    headers: {
+      apikey: key,
+      Authorization: `Bearer ${key}`,
+      'Content-Type': 'application/json',
+    },
+  };
+}
+
+function shortenForTitle(s: string, max = 80): string {
+  const flat = s.replace(/\s+/g, ' ').trim();
+  if (flat.length <= max) return flat;
+  return flat.slice(0, max - 1) + '…';
+}
+
+// Pull a one-line problem statement from Devon's spec (which begins with
+// `# <ticket_number> — <one-line problem statement>`). Falls back to the
+// ticket's raw_transcript if the spec heading isn't present.
+function extractProblemHeadline(specMd: string | null, raw: string | null): string {
+  const md = (specMd ?? '').trim();
+  if (md) {
+    const firstLine = md.split('\n', 1)[0] ?? '';
+    const stripped = firstLine.replace(/^#\s*/, '').trim();
+    if (stripped) {
+      // Strip leading "FB-XXXX —" prefix Devon's template includes.
+      const withoutPrefix = stripped.replace(/^[A-Z0-9-]+\s*[—-]\s*/, '').trim();
+      if (withoutPrefix) return withoutPrefix;
+      return stripped;
+    }
+  }
+  if (raw && raw.trim()) return shortenForTitle(raw);
+  return 'Feedback ticket — no spec';
+}
+
+/**
+ * Dispatch a feedback ticket through the dev autopilot pipeline.
+ *
+ * Idempotent: if linked_finding_id is already set, the existing
+ * recommendation is returned (no new row, no duplicate execution). The
+ * downstream bridgeActivationToExecution is also idempotent on its own
+ * inflight check.
+ *
+ * Returns:
+ *   { ok: true, recommendation_id, execution_id }   on success / re-click
+ *   { ok: false, error }                            on failure
+ *   { ok: true, skipped: "<why>" }                  for non-bridgeable kinds
+ */
+export async function dispatchFeedbackTicket(
+  ticket: FeedbackTicketRow,
+  approvedBy?: string | null,
+): Promise<BridgeResult> {
+  const s = getSupabase();
+  if (!s) return { ok: false, error: 'Supabase not configured' };
+
+  // Only bug / ux_issue feed the dev autopilot. Other kinds get their own
+  // delivery paths (Sage answer, Atlas claim, Mira account) — handled
+  // elsewhere or in follow-up PRs. Refuse here cleanly so callers can log
+  // the skip without crashing.
+  if (ticket.kind !== 'bug' && ticket.kind !== 'ux_issue') {
+    return { ok: true, skipped: `kind=${ticket.kind} not dev_autopilot` };
+  }
+
+  const spec = (ticket.spec_md ?? '').trim();
+  if (!spec) {
+    return { ok: false, error: 'NO_SPEC — call /draft-spec before dispatch' };
+  }
+
+  // 1. Idempotency — if already linked, just look up the execution and
+  //    return. Operator can press Activate again on a still-running ticket
+  //    without duplicating.
+  if (ticket.linked_finding_id) {
+    const existingRecResp = await fetch(
+      `${s.url}/rest/v1/autopilot_recommendations?id=eq.${ticket.linked_finding_id}&select=id,status&limit=1`,
+      { headers: s.headers },
+    );
+    const existingRec = (await existingRecResp.json().catch(() => [])) as Array<{ id: string; status: string }>;
+    if (existingRec[0]) {
+      const execResp = await fetch(
+        `${s.url}/rest/v1/dev_autopilot_executions?finding_id=eq.${ticket.linked_finding_id}&select=id,status&order=created_at.desc&limit=1`,
+        { headers: s.headers },
+      );
+      const exec = (await execResp.json().catch(() => [])) as Array<{ id: string; status: string }>;
+      return {
+        ok: true,
+        recommendation_id: existingRec[0].id,
+        execution_id: exec[0]?.id,
+        skipped: 'already_linked',
+      };
+    }
+    // linked_finding_id is set but the recommendation row was deleted —
+    // fall through and create a new one. Don't block the dispatch.
+  }
+
+  // 2. Build the recommendation. spec_snapshot is the payload the autopilot
+  //    executor reads at run-time. We pack the spec and supervisor notes so
+  //    the Claude session has everything it needs.
+  const headline = extractProblemHeadline(ticket.spec_md, ticket.raw_transcript);
+  const title = `[${ticket.ticket_number ?? 'feedback'}] ${shortenForTitle(headline, 100)}`;
+  const summary = ticket.supervisor_notes
+    ? `${shortenForTitle(headline, 200)} — ${shortenForTitle(ticket.supervisor_notes, 280)}`
+    : shortenForTitle(headline, 480);
+  const now = new Date().toISOString();
+
+  const payload = {
+    title,
+    summary,
+    domain: 'feedback',
+    risk_level: 'medium',
+    risk_class: 'medium',
+    impact_score: 0.7,
+    effort_score: 0.5,
+    status: 'new',
+    source_type: 'dev_autopilot',
+    source_ref: `feedback_ticket:${ticket.id}`,
+    auto_exec_eligible: false,
+    signal_fingerprint: `feedback:${ticket.id}`,
+    first_seen_at: now,
+    last_seen_at: now,
+    seen_count: 1,
+    spec_snapshot: {
+      // Standard dev_autopilot fields the executor / planner expect.
+      signal_type: 'feedback_ticket',
+      file_path: null,
+      line_number: null,
+      suggested_action: spec,
+      scanner: 'feedback_pipeline',
+      // VTID-02665 extension — feedback-specific context. The autopilot
+      // planner will see this when generating the plan version.
+      feedback: {
+        ticket_id: ticket.id,
+        ticket_number: ticket.ticket_number,
+        kind: ticket.kind,
+        spec_md: spec,
+        supervisor_notes: ticket.supervisor_notes ?? null,
+        raw_transcript: ticket.raw_transcript ?? null,
+        screen_path: ticket.screen_path ?? null,
+        app_version: ticket.app_version ?? null,
+        reporter_vitana_id: ticket.vitana_id ?? null,
+      },
+    },
+  };
+
+  const insertResp = await fetch(
+    `${s.url}/rest/v1/autopilot_recommendations?select=id`,
+    {
+      method: 'POST',
+      headers: { ...s.headers, Prefer: 'return=representation' },
+      body: JSON.stringify(payload),
+    },
+  );
+  if (!insertResp.ok) {
+    const text = await insertResp.text().catch(() => '');
+    return { ok: false, error: `recommendation insert failed (${insertResp.status}): ${text.slice(0, 200)}` };
+  }
+  const rows = (await insertResp.json().catch(() => [])) as Array<{ id: string }>;
+  const findingId = rows[0]?.id;
+  if (!findingId) return { ok: false, error: 'recommendation insert returned no id' };
+
+  // 3. Backlink the ticket so re-Activate is a no-op.
+  await fetch(
+    `${s.url}/rest/v1/feedback_tickets?id=eq.${ticket.id}`,
+    {
+      method: 'PATCH',
+      headers: { ...s.headers, Prefer: 'return=minimal' },
+      body: JSON.stringify({ linked_finding_id: findingId }),
+    },
+  ).catch(() => { /* non-blocking; the next dispatch will idempotency-skip via the check above */ });
+
+  // 4. Bridge to execution. This generates the plan if missing, creates
+  //    the dev_autopilot_executions row, and sets execute_after=now so
+  //    the next backgroundExecutorTick claims it (~30s).
+  const bridge = await bridgeActivationToExecution(findingId, approvedBy ?? null);
+  if (!bridge.ok) {
+    // Don't unset linked_finding_id — the recommendation exists; the bridge
+    // just couldn't kick the execution. Operator can retry.
+    return {
+      ok: false,
+      recommendation_id: findingId,
+      error: `bridge failed: ${bridge.error ?? 'unknown'}`,
+    };
+  }
+
+  console.log(`[${VTID}] dispatched ${ticket.ticket_number} → finding=${findingId.slice(0, 8)} execution=${(bridge.execution_id ?? '').slice(0, 8)}`);
+  return {
+    ok: true,
+    recommendation_id: findingId,
+    execution_id: bridge.execution_id,
+  };
+}

--- a/supabase/migrations/20260501230000_vtid_02665_feedback_execution_bridge.sql
+++ b/supabase/migrations/20260501230000_vtid_02665_feedback_execution_bridge.sql
@@ -1,0 +1,22 @@
+-- VTID-02665: Feedback execution bridge.
+-- When a tenant admin Activates a bug/ux_issue ticket, the gateway now
+-- creates a row in autopilot_recommendations and bridges it to a
+-- dev_autopilot_executions row. We need a column on feedback_tickets
+-- to point at the resulting recommendation so the supervisor's drawer
+-- can show "dispatched to dev autopilot, execution ID xxx" and so we
+-- never accidentally dispatch the same ticket twice.
+
+ALTER TABLE public.feedback_tickets
+  ADD COLUMN IF NOT EXISTS linked_finding_id UUID
+    REFERENCES public.autopilot_recommendations(id)
+    ON DELETE SET NULL;
+
+CREATE INDEX IF NOT EXISTS idx_feedback_tickets_linked_finding_id
+  ON public.feedback_tickets (linked_finding_id)
+  WHERE linked_finding_id IS NOT NULL;
+
+COMMENT ON COLUMN public.feedback_tickets.linked_finding_id IS
+  'VTID-02665: when /activate dispatches a bug/ux_issue ticket through '
+  'the dev autopilot pipeline, the resulting autopilot_recommendations.id '
+  'is stored here. Single source of truth for "is this ticket already '
+  'dispatched?" — used to make Activate idempotent.';


### PR DESCRIPTION
## Summary
When a tenant admin Activates a bug/ux_issue ticket, the supervisors spec_md flows directly into the existing dev autopilot pipeline (recommendation → execution → Claude run → PR → CI → deploy).

- New service `feedback-execution-bridge.ts` dispatches the ticket as an `autopilot_recommendations` row of type `dev_autopilot`, then calls the existing `bridgeActivationToExecution`. Idempotent on `linked_finding_id`.
- `/activate` calls the bridge for bug/ux_issue when status flips to in_progress. Returns dispatch info for the UI.
- New `PUT /:tenantId/tickets/:id/reclassify` lets the supervisor fix wrong kind classifications.
- Migration adds `feedback_tickets.linked_finding_id` (FK to autopilot_recommendations).

Pairs with vitana-v1 PR for the dropdown + dispatch indicator UI.

## Test plan
- [x] `npm run build` clean.
- [ ] Apply migration via RUN-MIGRATION workflow.
- [ ] Generate spec on a bug ticket → Activate → response includes `dispatch.execution_id` → row appears in `dev_autopilot_executions` with status cooling/running.
- [ ] Re-Activate idempotent — returns existing execution_id, no duplicate row.
- [ ] Reclassify support_question → bug clears `draft_answer_md`, status → triaged.
- [ ] Reclassify is refused with `ALREADY_DISPATCHED` once `linked_finding_id` is set.