### PR TITLE
fix(orb): pin gateway to a single Cloud Run instance (VTID-02037)

### DIFF
--- a/.github/workflows/EXEC-DEPLOY.yml
+++ b/.github/workflows/EXEC-DEPLOY.yml
@@ -456,16 +456,19 @@ jobs:
             DEPLOY_ARGS+=(--service-account=86804897789-compute@developer.gserviceaccount.com)
           fi
 
-          # VTID-02036: REVERTED VTID-02034 --session-affinity. Cloud Run's
-          # session-affinity cookie (GAESA) is set with SameSite=Lax by
-          # default, which browsers refuse to send on cross-origin
-          # requests (vitanaland.com → gateway). The flag created the
-          # cookie but no browser ever forwarded it, so no actual
-          # affinity was achieved. Worse, pairing this with
-          # withCredentials:true on the SSE EventSource appeared to
-          # break SSE entirely on iOS Safari / Appilix WebView. Reverting
-          # to restore working SSE; cross-instance 404s on /stream/send
-          # come back but at least the orb works.
+          # VTID-02037: pin gateway to a single instance so ORB voice
+          # sessions (held in an in-memory liveSessions Map) are never
+          # split across instances. Cookie-based affinity (VTID-02034)
+          # didn't work cross-origin because Cloud Run's session-affinity
+          # cookie defaults to SameSite=Lax. Sticking the gateway at
+          # max-instances=1 is a temporary brake until a shared session
+          # store (Supabase/Redis) lands. Other gateway endpoints lose
+          # horizontal scaling but the current test load fits one
+          # instance comfortably.
+          if [ "$CLOUD_RUN_SERVICE" = "gateway" ]; then
+            DEPLOY_ARGS+=(--max-instances=1)
+            DEPLOY_ARGS+=(--min-instances=1)
+          fi
 
 
           gcloud run deploy "$CLOUD_RUN_SERVICE" \


### PR DESCRIPTION
## Why

Console logs from user retest after VTID-02036 revert show the original cross-instance bug back exactly:

\`\`\`
[VTOrb] Audio send failed: HTTP 404
[VTOrb] _announceDisconnect: reason=network
[VTOrb] _resetAndReconnect: forcing full session restart
[VTOrb] SSE connected
... loop ...
\`\`\`

ORB audio POSTs round-robin across Cloud Run instances; ~50% land on an instance without the in-memory session map entry → 404 → widget fires \"internet issues\" → restart loop.

Cookie-based session affinity (VTID-02034) didn't work cross-origin because Cloud Run's GAESA cookie is SameSite=Lax by default and browsers refuse to forward it cross-origin from vitanaland.com.

## What this PR does

Pin the gateway to **one Cloud Run instance** via \`--max-instances=1 --min-instances=1\`. No multi-instance routing, no cross-instance 404s.

## Trade-off

Gateway loses horizontal scaling for ALL endpoints, not just ORB. Current test user count fits comfortably on one instance. **Revisit when a shared session store (Supabase/Redis) ships.**

## Touched files

- \`.github/workflows/EXEC-DEPLOY.yml\` — gateway-only \`--max-instances=1 --min-instances=1\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)