### PR TITLE
fix(ci): bootstrap workflow uses GCP_SA_KEY for secret-manager admin

### DIFF
--- a/.github/workflows/BOOTSTRAP-LIVEKIT-SECRETS.yml
+++ b/.github/workflows/BOOTSTRAP-LIVEKIT-SECRETS.yml
@@ -29,11 +29,10 @@ jobs:
     steps:
       - uses: actions/checkout@v4
 
-      - name: Authenticate to GCP
+      - name: Authenticate to GCP (SA key — needs secretmanager.admin)
         uses: google-github-actions/auth@v2
         with:
-          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
-          service_account: ${{ secrets.GCP_WIF_SA_EMAIL }}
+          credentials_json: ${{ secrets.GCP_SA_KEY }}
 
       - uses: google-github-actions/setup-gcloud@v2
 


### PR DESCRIPTION
WIF SA lacks secretmanager.secrets.create. Use GCP_SA_KEY (full JSON SA key, broader perms) for the bootstrap workflow only.