### PR TITLE
feat(feedback): Devon codebase context + auto-retry on hallucinations (VTID-02671)

### DIFF
--- a/services/gateway/src/services/feedback-execution-bridge.ts
+++ b/services/gateway/src/services/feedback-execution-bridge.ts
@@ -250,22 +250,80 @@ export async function dispatchFeedbackTicket(
     // fall through and create a new one. Don't block the dispatch.
   }
 
-  // 2. Pre-flight scope check (VTID-02669). Pull "Files to touch" from
-  //    Devon's spec, validate against allow_scope / deny_scope. If every
-  //    proposed file is denied or out-of-scope, refuse with a structured
-  //    violation BEFORE inserting the recommendation — saves a planner
-  //    round trip the safety gate would refuse anyway and gives the
-  //    supervisor a clear, actionable error.
-  const proposedFiles = parseFilesToTouchFromSpec(ticket.spec_md);
+  // 2. Pre-flight scope check + auto-retry (VTID-02671). Parse Devon's
+  //    "Files to touch" section and validate against allow_scope/deny_scope.
+  //    If the draft is bad, we silently re-call Devon with the violations
+  //    as feedback up to 2 times. The supervisor only sees a violation if
+  //    Devon still can't produce a valid spec after retries — at that
+  //    point a human edit is genuinely needed.
   const cfg = await loadSafetyConfig(s);
-  const flight = preflightFiles(proposedFiles, cfg);
+  const MAX_DRAFT_RETRIES = 2;
+  let proposedFiles = parseFilesToTouchFromSpec(ticket.spec_md);
+  let flight = preflightFiles(proposedFiles, cfg);
+
+  for (let attempt = 0; attempt < MAX_DRAFT_RETRIES; attempt++) {
+    const isBad = proposedFiles.length === 0 || flight.allowed.length === 0;
+    if (!isBad) break;
+
+    // Build feedback for Devon explaining what was wrong.
+    const reasons: string[] = [];
+    if (proposedFiles.length === 0) {
+      reasons.push('Your previous draft did not list any files in the "Files to touch" section. EVERY draft must include concrete file paths.');
+    }
+    if (flight.denied.length > 0) {
+      reasons.push(`These files are FORBIDDEN (deny-scope): ${flight.denied.join(', ')}. Pick allow-scoped equivalents instead.`);
+    }
+    if (flight.outside.length > 0) {
+      reasons.push(`These files are OUTSIDE the allow-scope (likely don't exist in this codebase): ${flight.outside.join(', ')}. Use ONLY paths starting with services/gateway/src/{routes,services,frontend/command-hub}/** or services/agents/**.`);
+    }
+    const retryFeedback = [
+      'AUTO-RETRY (your previous draft was rejected by the safety pre-flight)',
+      '====================================================================',
+      ...reasons,
+      '',
+      `Allow-scope: ${cfg.allow_scope.join(', ')}`,
+      `Deny-scope:  ${cfg.deny_scope.join(', ')}`,
+      '',
+      'Re-write the spec with VALID allow-scoped paths. Include at least one .test.ts file.',
+      '====================================================================',
+    ].join('\n');
+
+    console.log(`[${VTID}] auto-retry Devon (attempt ${attempt + 1}/${MAX_DRAFT_RETRIES}) for ${ticket.ticket_number}`);
+
+    try {
+      const { llmDraftDevonSpec } = await import('./feedback-llm-resolvers');
+      const r = await llmDraftDevonSpec(ticket as any, {
+        supervisorInstructions: ticket.supervisor_notes,
+        retryFeedback,
+      });
+      if (r.markdown && r.markdown.trim()) {
+        // Persist the new draft so the supervisor sees the corrected
+        // version when they reopen the drawer (and so subsequent runs
+        // start from the good draft).
+        await fetch(`${s.url}/rest/v1/feedback_tickets?id=eq.${ticket.id}`, {
+          method: 'PATCH',
+          headers: { ...s.headers, Prefer: 'return=minimal' },
+          body: JSON.stringify({ spec_md: r.markdown }),
+        }).catch(() => { /* non-blocking */ });
+        ticket.spec_md = r.markdown;
+        proposedFiles = parseFilesToTouchFromSpec(r.markdown);
+        flight = preflightFiles(proposedFiles, cfg);
+      }
+    } catch (err) {
+      console.warn(`[${VTID}] auto-retry failed:`, err);
+      break;
+    }
+  }
+
+  // After retries — if STILL bad, surface violations for the supervisor
+  // to take over manually.
   if (proposedFiles.length === 0) {
     return {
       ok: false,
       error: 'NO_FILES_IN_SPEC',
       violations: [{
         code: 'no_files_in_spec',
-        message: "Devon's spec didn't list any files to touch. Add a `## Files to touch` section with concrete paths, then Re-generate.",
+        message: "Devon couldn't propose concrete files even after auto-retry. Tighten Step 1 instructions with specific module names (e.g. services/gateway/src/services/persona-registry.ts).",
       }],
     };
   }
@@ -274,14 +332,14 @@ export async function dispatchFeedbackTicket(
     if (flight.denied.length > 0) {
       violations.push({
         code: 'file_in_deny_scope',
-        message: `Every proposed file is in the dev autopilot deny-scope: ${flight.denied.join(', ')}. Revise your instructions to scope the fix to allowed paths (gateway routes/services/frontend, agents). Files like orb-live.ts, supabase/migrations/**, and .github/workflows/** are intentionally excluded.`,
+        message: `Devon kept proposing forbidden files even after auto-retry: ${flight.denied.join(', ')}. The fix likely requires touching deny-scoped code (e.g. orb-live.ts) — that's intentionally human-only. Edit Step 1 to point Devon at an allow-scoped wrapper instead.`,
         detail: { denied: flight.denied, deny_scope: cfg.deny_scope },
       });
     }
     if (flight.outside.length > 0) {
       violations.push({
         code: 'file_outside_allow_scope',
-        message: `Files outside the allow-scope: ${flight.outside.join(', ')}. Allow scope: ${cfg.allow_scope.join(', ')}.`,
+        message: `Devon kept hallucinating non-existent paths after auto-retry: ${flight.outside.join(', ')}. Edit Step 1 with explicit module names.`,
         detail: { outside: flight.outside, allow_scope: cfg.allow_scope },
       });
     }

--- a/services/gateway/src/services/feedback-llm-resolvers.ts
+++ b/services/gateway/src/services/feedback-llm-resolvers.ts
@@ -154,33 +154,89 @@ export async function llmDraftSageAnswer(t: FeedbackTicketSnapshot, opts: DraftO
 
 const DEVON_SYSTEM = `You are Devon, the Vitana tech-support specialist. Your job is to write a one-page bug-fix spec for the engineering team based on a user's report.
 
-Output a markdown document with EXACTLY these sections in this order, no others:
+CODEBASE FACTS (authoritative — do not deviate):
+- This is the Vitana monorepo, TypeScript + Node only. There is NO Python anywhere. NEVER propose .py files.
+- All gateway code lives under \`services/gateway/src/\`:
+  • Routes (HTTP endpoints):     \`services/gateway/src/routes/*.ts\`
+  • Business services + helpers: \`services/gateway/src/services/*.ts\`
+  • Command Hub frontend:        \`services/gateway/src/frontend/command-hub/*.{js,html,css}\`
+  • Migrations (DB schema):      \`supabase/migrations/*.sql\` (NEVER touch in autopilot)
+- Agent code:                    \`services/agents/*\`
+- Tests:                         co-located \`*.test.ts\` next to source, or \`services/gateway/test/*.test.ts\`
+
+ALLOW-SCOPE (autopilot can edit these):
+  services/gateway/src/routes/**
+  services/gateway/src/services/**
+  services/gateway/src/frontend/command-hub/**
+  services/agents/**
+
+DENY-SCOPE (autopilot is FORBIDDEN here — propose alternatives in the allow-scope):
+  supabase/migrations/**     ← schema work is human-only
+  **/auth*                   ← auth code requires manual review
+  **/orb-live.ts             ← live voice runtime is too sensitive for autopilot
+  .github/workflows/**       ← CI config human-only
+  **/.env*                   ← secrets
+
+KEY MODULES (use these when the bug touches them):
+- Voice + persona handoff:       \`services/gateway/src/services/persona-registry.ts\`
+                                 (orb-live.ts is denied — adapt the registry instead)
+- Feedback pipeline:             \`services/gateway/src/services/feedback-execution-bridge.ts\`,
+                                 \`services/gateway/src/services/feedback-llm-resolvers.ts\`,
+                                 \`services/gateway/src/routes/tenant-specialists.ts\`
+- Dev autopilot:                 \`services/gateway/src/services/dev-autopilot-execute.ts\`,
+                                 \`services/gateway/src/services/dev-autopilot-safety.ts\`
+- Memory:                        \`services/gateway/src/services/orb-memory-bridge.ts\`,
+                                 \`services/gateway/src/services/cognee-extractor-client.ts\`
+- Retrieval / RAG:               \`services/gateway/src/services/retrieval-router.ts\`
+- Vitana Index:                  \`services/agents/vitana-orchestrator/*\`
+- Command Hub UI:                \`services/gateway/src/frontend/command-hub/app.js\`
+
+REQUIRED SECTIONS (output markdown with EXACTLY these in order):
 
 # <ticket_number> — <one-line problem statement>
 
 ## Root cause hypothesis
-A short paragraph naming what code is most likely at fault. If insufficient evidence, write a hypothesis explicitly labelled "best-guess".
+Short paragraph naming what code is most likely at fault, referenced by an
+allow-scope file. If insufficient evidence, label it "best-guess".
 
 ## Repro steps
-A numbered list. Use the user's words where possible. If steps weren't given, propose the most likely flow.
+Numbered list. Use the user's words where possible.
 
 ## Expected vs actual
 Two short paragraphs.
 
 ## Files to touch (best guess)
-A bullet list of likely files / modules. Mark uncertain ones with "(probably)".
+A bullet list of CONCRETE file paths from the allow-scope only. EVERY entry
+must be a real path that starts with one of the allow-scope prefixes.
+- DO NOT propose paths in the deny-scope (orb-live.ts, supabase/migrations,
+  auth, .github, .env).
+- DO NOT propose paths that don't exist in the codebase. If you're unsure
+  whether a file exists, prefer a known module (persona-registry.ts etc.).
+- INCLUDE at least one test file. Test files end in \`.test.ts\` or \`.spec.ts\`
+  and live next to the source or under \`services/gateway/test/\`. Without a
+  test file the autopilot safety gate REFUSES to run the spec.
 
 ## Risk + rollback
 One short paragraph: blast radius, which feature flag if any, how to revert.
 
 ## Test plan
-Bulleted checklist for verification.
+Bulleted checklist a human can verify.
 
-Style: terse, factual, engineering English. No marketing copy. No reassurance to the user. Sign off with "— Devon".`;
+Style: terse, factual, engineering English. No marketing copy. No reassurance
+to the user. Sign off with "— Devon".`;
 
-export async function llmDraftDevonSpec(t: FeedbackTicketSnapshot, opts: DraftOptions = {}): Promise<{ markdown: string; provider: 'llm' | 'fallback' }> {
+export async function llmDraftDevonSpec(
+  t: FeedbackTicketSnapshot,
+  opts: DraftOptions & { retryFeedback?: string } = {},
+): Promise<{ markdown: string; provider: 'llm' | 'fallback' }> {
   const base = `Ticket ${t.ticket_number ?? '(pending)'} (kind=${t.kind}):\n\n${summarizeIntake(t)}\n\nWrite the spec now.`;
-  const userPrompt = withSupervisorDirective(base, opts.supervisorInstructions);
+  const withDirective = withSupervisorDirective(base, opts.supervisorInstructions);
+  // VTID-02671: when the bridge auto-retries because pre-flight rejected
+  // the previous draft, append the rejection feedback so Devon corrects
+  // himself without supervisor intervention.
+  const userPrompt = opts.retryFeedback
+    ? `${opts.retryFeedback}\n\n---\n\n${withDirective}`
+    : withDirective;
   const r = await callRouter(DEVON_SYSTEM, userPrompt, t.ticket_number);
   if (!r.ok || !r.text) return { markdown: fallbackPlaceholder('devon', t), provider: 'fallback' };
   return { markdown: r.text.trim() + '\n', provider: 'llm' };


### PR DESCRIPTION
Devon now knows the codebase (TypeScript/Node, real module paths, allow + deny scope baked in). Bridge silently auto-retries up to 2 times when pre-flight rejects the draft, so the supervisor never has to typo-correct hallucinated paths. Persists the corrected draft to spec_md.