### PR TITLE
fix(orb): Vitana IDENTITY LOCK + specialist language directive + phrase coverage (v2c, VTID-02670)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1476,6 +1476,27 @@ function buildTranscriptSection(
   return lines.join('\n');
 }
 
+// Build the explicit language directive for specialist personaSystemOverride.
+// Without this, Devon/Sage/Atlas/Mira default to whatever language their DB
+// system_prompt is written in (English) regardless of session.lang.
+// Symptom: German user is talking to Vitana in German, swaps to Devon, and
+// Devon greets in English. Fixed by appending this directive at every swap.
+function buildSpecialistLanguageDirective(lang: string | undefined): string {
+  const languageNames: Record<string, string> = {
+    en: 'English', de: 'German', fr: 'French', es: 'Spanish',
+    ar: 'Arabic', zh: 'Chinese', ru: 'Russian', sr: 'Serbian',
+  };
+  const name = languageNames[lang || 'en'] || 'English';
+  return [
+    '[LANGUAGE LOCK]',
+    `Respond ONLY in ${name}. Match the user's language exactly.`,
+    'Do NOT switch to English. Do NOT mix languages.',
+    'Your greeting, your synthesis, your auto-return question — all in',
+    `${name}. The user has been speaking ${name} with Vitana already;`,
+    'continue in the same language without acknowledging the switch.',
+  ].join('\n');
+}
+
 // Build the input for Gate A by concatenating the user's last 3 raw utterances.
 // The LLM-curated `summary` argument to report_to_specialist is lossy — it can
 // rephrase "how does X work?" into "user is asking about X feature", which
@@ -4162,9 +4183,11 @@ async function executeLiveApiToolInner(
             const userContextSection = await fetchSpecialistContextSection(session.identity?.user_id);
             const behavioralRule = buildPersonaBehavioralRule(target);
             const transcriptSection = buildTranscriptSection(session.transcriptTurns, currentPersona, target);
+            const languageDirective = buildSpecialistLanguageDirective(session.lang);
             (session as any).specialistContextSection = userContextSection;
             (session as any).lastTranscriptSection = transcriptSection;
             (session as any).personaSystemOverride = personaPrompt +
+              `\n\n${languageDirective}` +
               (userContextSection ? `\n\n${userContextSection}` : '') +
               (transcriptSection ? `\n\n${transcriptSection}` : '') +
               `\n\n${behavioralRule}` +
@@ -4423,12 +4446,14 @@ async function executeLiveApiToolInner(
                 const userContextSection = await fetchSpecialistContextSection(session.identity?.user_id);
                 const behavioralRule = buildPersonaBehavioralRule(swapTo);
                 const transcriptSection = buildTranscriptSection(session.transcriptTurns, 'vitana', swapTo);
+                const languageDirective = buildSpecialistLanguageDirective(session.lang);
                 // Cache for Vitana's prompt builder on the eventual swap-back.
                 (session as any).specialistContextSection = userContextSection;
                 (session as any).lastTranscriptSection = transcriptSection;
                 // Loop guard counter
                 (session as any).swapCount = (((session as any).swapCount as number | undefined) ?? 0) + 1;
                 (session as any).personaSystemOverride = personaPrompt +
+                  `\n\n${languageDirective}` +
                   (userContextSection ? `\n\n${userContextSection}` : '') +
                   (transcriptSection ? `\n\n${transcriptSection}` : '') +
                   `\n\n${behavioralRule}` +
@@ -7439,9 +7464,37 @@ Do NOT substitute an internal UUID under any circumstance.
 
 `;
 
-  let instruction = `${roleHeader}${vitanaIdHeader}${voiceLiveConfig.base_identity || 'You are Vitana, an AI health companion assistant powered by Gemini Live.'}
+  // Forwarding v2c: prepend IDENTITY LOCK to Vitana's prompt. The lock
+  // exists in the DB (agent_personas.system_prompt) but Vitana's prompt is
+  // built fresh in this function and never reads that DB row, so without
+  // this block she has no identity protection. Symptom: after swap-back
+  // from a specialist, the model would absorb the specialist's recent
+  // utterances ("Hi I'm Devon") and continue speaking as them in her voice.
+  const VITANA_IDENTITY_LOCK = `=== IDENTITY LOCK ===
+YOU ARE Vitana.
+Your role is the user's life companion and instruction manual.
 
-LANGUAGE: Respond ONLY in ${languageNames[lang] || 'English'}.
+You speak EXCLUSIVELY as Vitana. You NEVER:
+  - introduce yourself as another persona ("Hi, this is Devon" — only Devon ever says that)
+  - continue another persona's sentence as if it were your own
+  - mimic another persona's tone, signature phrases, or voice
+  - acknowledge another persona's words as if YOU said them
+  - name yourself as anyone other than Vitana
+
+The conversation transcript may show OTHER personas (Devon, Sage, Atlas, Mira)
+speaking earlier. Those were them, not you. Read those lines as third-party
+context only. Your next utterance is exclusively as Vitana, in your voice,
+with your identity.
+
+If you ever notice yourself drifting toward another persona's identity,
+stop and re-anchor: "I'm Vitana." Then continue.
+=== END IDENTITY LOCK ===
+
+`;
+
+  let instruction = `${roleHeader}${vitanaIdHeader}${VITANA_IDENTITY_LOCK}${voiceLiveConfig.base_identity || 'You are Vitana, an AI health companion assistant powered by Gemini Live.'}
+
+LANGUAGE: Respond ONLY in ${languageNames[lang] || 'English'}. Do NOT mix languages, do NOT switch to English, regardless of what other personas in the transcript said in other languages.
 
 VOICE STYLE: ${voiceStyle}
 

--- a/supabase/migrations/20260502120000_forwarding_v2c_coverage.sql
+++ b/supabase/migrations/20260502120000_forwarding_v2c_coverage.sql
@@ -1,0 +1,154 @@
+-- Forwarding v2c — coverage gaps for German + missing English phrasings
+--
+-- Test failures from /tmp/forwarding-test-suite.sh exposed three coverage gaps:
+--   3.3 "I want a refund" → not in forward_request_phrases (only "I need a refund")
+--   3.7 "ich habe einen Fehler" → German bug-report phrasings missing
+--   3.5/3.6 German concrete-problem phrasings pass Gate A but no specialist
+--          matches (Atlas/Mira have no German topic keywords).
+--
+-- This migration extends forward_request_phrases on Vitana AND extends
+-- handoff_keywords on Atlas + Mira (German equivalents). Idempotent via
+-- DISTINCT lower-case dedupe.
+
+-- 1. Vitana: extend forward_request_phrases
+DO $$
+DECLARE
+  v_existing TEXT[];
+  v_to_add TEXT[] := ARRAY[
+    -- English: refund / claim variants the v1 seed missed
+    'i want a refund', 'i would like a refund', 'i request a refund',
+    'i want my money back', 'request a refund',
+    -- English: bug variants
+    'i have an error', 'something is broken',
+    -- German: bug variants
+    'ich habe einen fehler', 'es ist ein fehler aufgetreten',
+    'es funktioniert nicht', 'etwas stimmt nicht',
+    'ich möchte einen fehler melden', 'ich will einen fehler melden',
+    -- German: refund variants
+    'ich will meine geld zurück', 'ich möchte mein geld zurück',
+    'ich möchte eine rückerstattung', 'ich will eine rückerstattung',
+    -- German: account variants
+    'ich kann mich nicht einloggen', 'login geht nicht',
+    'ich komme nicht in mein konto', 'mein passwort funktioniert nicht'
+  ]::TEXT[];
+  v_merged TEXT[];
+BEGIN
+  SELECT forward_request_phrases INTO v_existing
+  FROM public.agent_personas
+  WHERE key = 'vitana';
+
+  SELECT array_agg(DISTINCT phrase ORDER BY phrase)
+  INTO v_merged
+  FROM (
+    SELECT lower(p) AS phrase FROM unnest(coalesce(v_existing, ARRAY[]::TEXT[])) p
+    UNION
+    SELECT lower(p) FROM unnest(v_to_add) p
+  ) t;
+
+  UPDATE public.agent_personas
+  SET forward_request_phrases = v_merged,
+      version = version + 1,
+      updated_at = NOW()
+  WHERE key = 'vitana';
+END $$;
+
+-- 2. Atlas: extend handoff_keywords with German finance terms
+DO $$
+DECLARE
+  v_existing TEXT[];
+  v_to_add TEXT[] := ARRAY[
+    -- German finance / marketplace
+    'rückerstattung', 'erstattung', 'geld zurück', 'rechnung',
+    'zahlung', 'zurückzahlung', 'reklamation', 'beschwerde',
+    'falsche bestellung', 'falsche lieferung', 'nicht erhalten',
+    'beschädigt', 'preis', 'überzahlt', 'streitfall',
+    -- English augment
+    'reimbursement', 'cashback', 'overcharge', 'fraudulent charge'
+  ]::TEXT[];
+  v_merged TEXT[];
+BEGIN
+  SELECT handoff_keywords INTO v_existing
+  FROM public.agent_personas
+  WHERE key = 'atlas';
+
+  SELECT array_agg(DISTINCT kw ORDER BY kw)
+  INTO v_merged
+  FROM (
+    SELECT lower(p) AS kw FROM unnest(coalesce(v_existing, ARRAY[]::TEXT[])) p
+    UNION
+    SELECT lower(p) FROM unnest(v_to_add) p
+  ) t;
+
+  UPDATE public.agent_personas
+  SET handoff_keywords = v_merged,
+      version = version + 1,
+      updated_at = NOW()
+  WHERE key = 'atlas';
+END $$;
+
+-- 3. Mira: extend handoff_keywords with German account terms
+DO $$
+DECLARE
+  v_existing TEXT[];
+  v_to_add TEXT[] := ARRAY[
+    'gesperrt', 'einloggen', 'login', 'anmelden', 'passwort',
+    'konto', 'profil', 'email', 'e-mail', 'registrierung',
+    'verifizieren', 'rolle', 'berechtigung', 'ausgesperrt',
+    'kann nicht zugreifen'
+  ]::TEXT[];
+  v_merged TEXT[];
+BEGIN
+  SELECT handoff_keywords INTO v_existing
+  FROM public.agent_personas
+  WHERE key = 'mira';
+
+  SELECT array_agg(DISTINCT kw ORDER BY kw)
+  INTO v_merged
+  FROM (
+    SELECT lower(p) AS kw FROM unnest(coalesce(v_existing, ARRAY[]::TEXT[])) p
+    UNION
+    SELECT lower(p) FROM unnest(v_to_add) p
+  ) t;
+
+  UPDATE public.agent_personas
+  SET handoff_keywords = v_merged,
+      version = version + 1,
+      updated_at = NOW()
+  WHERE key = 'mira';
+END $$;
+
+-- 4. Devon: extend handoff_keywords with German bug terms
+DO $$
+DECLARE
+  v_existing TEXT[];
+  v_to_add TEXT[] := ARRAY[
+    'fehler', 'absturz', 'abgestürzt', 'eingefroren', 'hängt',
+    'stürzt ab', 'funktioniert nicht', 'kaputt', 'glitch',
+    'bildschirm', 'schaltfläche', 'knopf'
+  ]::TEXT[];
+  v_merged TEXT[];
+BEGIN
+  SELECT handoff_keywords INTO v_existing
+  FROM public.agent_personas
+  WHERE key = 'devon';
+
+  SELECT array_agg(DISTINCT kw ORDER BY kw)
+  INTO v_merged
+  FROM (
+    SELECT lower(p) AS kw FROM unnest(coalesce(v_existing, ARRAY[]::TEXT[])) p
+    UNION
+    SELECT lower(p) FROM unnest(v_to_add) p
+  ) t;
+
+  UPDATE public.agent_personas
+  SET handoff_keywords = v_merged,
+      version = version + 1,
+      updated_at = NOW()
+  WHERE key = 'devon';
+END $$;
+
+-- 5. Re-enable Sage if she was disabled by a manual toggle (so tests have a
+-- known starting state). Idempotent: only resets when status='disabled'.
+UPDATE public.agent_personas
+SET status = 'active', version = version + 1, updated_at = NOW()
+WHERE key = 'sage' AND status = 'disabled';


### PR DESCRIPTION
Test suite at /tmp/forwarding-test-suite.sh ran against production: 45/50 PASS, 5 FAIL. Failures grouped into three root causes:

1. **Vitana lacks IDENTITY LOCK at runtime** — buildLiveSystemInstruction never reads agent_personas.system_prompt. After swap-back, model absorbs Devon's recent lines and continues as Devon in Vitana's voice. **Fix:** prepend Vitana-specific IDENTITY LOCK block in buildLiveSystemInstruction.

2. **Specialist personaSystemOverride has no language directive** — Devon defaults to English on German session. **Fix:** new buildSpecialistLanguageDirective(lang) helper, prepended to override at both swap sites.

3. **Phrase coverage gaps** — "I want a refund" / German Atlas+Mira+Devon keywords missing. **Fix:** idempotent SQL migration extends forward_request_phrases + handoff_keywords for all 4 specialists.

Also re-enables Sage if she was left disabled by manual toggle (test-state cleanup).

VTID: VTID-02670.