### PR TITLE
fix(ci): point orb-agent deploy at existing vitana-services AR repo (VTID-02686)

### DIFF
--- a/.github/workflows/DEPLOY-ORB-AGENT.yml
+++ b/.github/workflows/DEPLOY-ORB-AGENT.yml
@@ -39,7 +39,7 @@ env:
   GCP_PROJECT_ID: lovable-vitana-vers1
   GCP_REGION: us-central1
   SERVICE_NAME: vitana-orb-agent
-  IMAGE_REPO: us-central1-docker.pkg.dev/lovable-vitana-vers1/vitana/orb-agent
+  IMAGE_REPO: us-central1-docker.pkg.dev/lovable-vitana-vers1/vitana-services/orb-agent
 
 jobs:
   build-and-deploy:


### PR DESCRIPTION
AR repo 'vitana' doesn't exist; cognee-extractor and others use 'vitana-services'. One-line fix to IMAGE_REPO. VTID-02686.