### PR TITLE
fix(orb): recognize YouTube connection for music.play (VTID-02673)

### DIFF
--- a/services/gateway/src/capabilities/index.ts
+++ b/services/gateway/src/capabilities/index.ts
@@ -122,6 +122,39 @@ export function getCapability(id: string): CapabilityDefinition | undefined {
   return CAPABILITIES.find((c) => c.id === id);
 }
 
+/**
+ * BOOTSTRAP-YT-MUSIC-ALIAS: connection-provider aliases per capability.
+ *
+ * A user who connects YouTube from Settings → Connected Apps gets a
+ * `social_connections` row with `provider='youtube'` (VTID-01928 — a
+ * dedicated narrow-scope provider that shares Google's OAuth client but
+ * only requests `youtube.readonly` so users aren't forced to grant
+ * Gmail + Calendar access just to play music).
+ *
+ * The `music.play` capability is declared only by the `google` connector,
+ * which naively looks for `provider='google'` rows. Without this alias
+ * the resolver would say "YouTube isn't connected" even though the user
+ * clearly just connected YouTube — the exact bug this fix targets.
+ *
+ * Returns the ordered list of `social_connections.provider` values that
+ * satisfy this connector for this capability. Order matters: the dispatcher
+ * loads the first active row it finds.
+ *
+ * For `google` + `music.play`, the narrower `youtube`-scoped token is
+ * preferred over the bundled `google` token — it's the scope that was
+ * specifically granted for YouTube, and both tokens are equally capable
+ * of calling the YouTube Data API v3 search endpoint used internally.
+ */
+export function storageProvidersFor(
+  connectorId: string,
+  capabilityId: string,
+): string[] {
+  if (connectorId === 'google' && capabilityId === 'music.play') {
+    return ['youtube', 'google'];
+  }
+  return [connectorId];
+}
+
 export interface ResolveOptions {
   /**
    * Explicit connector id extracted from the user's phrase (e.g. "on Spotify",
@@ -173,8 +206,10 @@ export async function resolveConnectorFor(
     .eq('user_id', userId)
     .eq('is_active', true);
   const activeIds = new Set((active ?? []).map((r) => r.provider));
-  const isAvailable = (cId: string, auth: string): boolean =>
-    auth === 'none' || activeIds.has(cId);
+  const isAvailable = (cId: string, auth: string): boolean => {
+    if (auth === 'none') return true;
+    return storageProvidersFor(cId, capabilityId).some((p) => activeIds.has(p));
+  };
 
   // ── Rule 1: explicit source from the user phrase ──────────────────────
   if (options.explicitSource) {
@@ -218,7 +253,7 @@ export async function resolveConnectorFor(
 
   // ── Rule 4: prefer any externally-connected connector ─────────────────
   const externalConnected = candidates.find(
-    (c) => c.auth_type !== 'none' && activeIds.has(c.id),
+    (c) => c.auth_type !== 'none' && isAvailable(c.id, c.auth_type),
   );
   if (externalConnected) {
     return { connectorId: externalConnected.id, reason: 'external_connected' };

--- a/services/gateway/src/connectors/runtime/dispatcher.ts
+++ b/services/gateway/src/connectors/runtime/dispatcher.ts
@@ -16,6 +16,7 @@
 import type { SupabaseClient } from '@supabase/supabase-js';
 import type { ActionRequest, ActionResult, Connector, TokenPair } from '../types';
 import { getConnector } from '../index';
+import { storageProvidersFor } from '../../capabilities';
 
 export interface DispatchContext {
   supabase: SupabaseClient;
@@ -43,11 +44,18 @@ const REFRESH_BUFFER_MS = 30_000;
  * Load the user's token row. Uses social_connections for now — every new
  * provider registered via the framework also writes here, so storage is
  * consistent across provider types until we migrate to user_connections.
+ *
+ * BOOTSTRAP-YT-MUSIC-ALIAS: `providers` is an ordered list of
+ * `social_connections.provider` values that satisfy the connector for
+ * the capability in flight. Supplied by `storageProvidersFor` in the
+ * capability layer — today it lets a YouTube-scoped token (provider='youtube')
+ * serve the `google` connector's `music.play` capability, without
+ * requiring the user to also grant the broader Gmail + Calendar scopes.
  */
 async function loadConnection(
   supabase: SupabaseClient,
   userId: string,
-  connectorId: string,
+  providers: string[],
 ): Promise<{
   id: string;
   access_token: string;
@@ -56,22 +64,26 @@ async function loadConnection(
   provider_user_id: string | null;
   provider_username: string | null;
 } | null> {
-  const { data } = await supabase
-    .from('social_connections')
-    .select('id, access_token, refresh_token, token_expires_at, provider_user_id, provider_username')
-    .eq('user_id', userId)
-    .eq('provider', connectorId)
-    .eq('is_active', true)
-    .maybeSingle();
-  if (!data || !data.access_token) return null;
-  return {
-    id: data.id,
-    access_token: data.access_token,
-    refresh_token: data.refresh_token ?? null,
-    token_expires_at: data.token_expires_at ?? null,
-    provider_user_id: data.provider_user_id ?? null,
-    provider_username: data.provider_username ?? null,
-  };
+  for (const provider of providers) {
+    const { data } = await supabase
+      .from('social_connections')
+      .select('id, access_token, refresh_token, token_expires_at, provider_user_id, provider_username')
+      .eq('user_id', userId)
+      .eq('provider', provider)
+      .eq('is_active', true)
+      .maybeSingle();
+    if (data?.access_token) {
+      return {
+        id: data.id,
+        access_token: data.access_token,
+        refresh_token: data.refresh_token ?? null,
+        token_expires_at: data.token_expires_at ?? null,
+        provider_user_id: data.provider_user_id ?? null,
+        provider_username: data.provider_username ?? null,
+      };
+    }
+  }
+  return null;
 }
 
 async function refreshIfExpired(
@@ -168,7 +180,8 @@ export async function dispatchAction(
   if (connector.auth_type === 'none') {
     tokens = { access_token: '' };
   } else {
-    const stored = await loadConnection(ctx.supabase, ctx.userId, opts.connectorId);
+    const providers = storageProvidersFor(opts.connectorId, opts.capability);
+    const stored = await loadConnection(ctx.supabase, ctx.userId, providers);
     if (!stored) {
       return {
         ok: false,


### PR DESCRIPTION
## Summary

- ORB voice said "YouTube isn't connected" when asked to play a song, even though the Connectors UI showed YouTube as green-connected.
- Root cause: YouTube connections are stored as `provider='youtube'` (VTID-01928 narrow scope), but the `music.play` capability is declared by the `google` connector — and the resolver checked for `provider='google'` only.
- Adds a per-capability provider alias (`storageProvidersFor`): for `google` + `music.play`, a `provider='youtube'` row satisfies the connector. Email / Calendar / Contacts still require the broader `google` connection.

This is a cherry-pick of `8712792f` (BOOTSTRAP-YT-MUSIC-ALIAS, 2026-04-24) which sat unmerged on `claude/fix-music-service-detection-fDqvk`.

VTID-02673 allocated for the EXEC-DEPLOY ledger gate.

## Test plan
- [x] `npm run build` clean in worktree
- [ ] Post-merge: EXEC-DEPLOY hits gateway successfully
- [ ] User-facing: log in with a `provider='youtube'` row + no `provider='google'` row, ask ORB to play any track, verify the YouTube Music URL is opened (no "not connected" message)
- [ ] Backend smoke: `POST /api/v1/capabilities/dispatch` with `capability: music.play` returns `disp.ok && disp.url`

🤖 Generated with [Claude Code](https://claude.com/claude-code)