### PR TITLE
fix(orb): add connected_apps to navigate_to_screen enum (VTID-02675)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -3120,6 +3120,7 @@ function buildLiveApiTools(
             "  edit_partner_preferences → /me/profile?drawer=partner (private-by-default partner-finding prefs)",
             "  edit_service_offerings   → /me/profile?drawer=offerings (services I offer)",
             "  privacy_settings         → /profile/me/privacy (per-section visibility toggles)",
+            "  connected_apps           → /settings/connected-apps (link/unlink Google, YouTube, Spotify, Apple Music etc — use whenever the user needs to connect or reconnect a music/calendar/email service)",
             "  profile_with_match       → /u/<vitana_id>?match_intent=<intent_id> (matched user's profile with the matched post anchored)",
             "  discover_marketplace     → /discover/marketplace (commercial intents)",
             "  events_meetups           → /comm/events-meetups",
@@ -3144,7 +3145,7 @@ function buildLiveApiTools(
                   'open_asks','members',
                   'intent_match_detail','intent_post_public','profile_with_match',
                   'edit_dance_preferences','edit_partner_preferences','edit_service_offerings',
-                  'privacy_settings','discover_marketplace',
+                  'privacy_settings','connected_apps','discover_marketplace',
                   'events_meetups','community_feed',
                 ],
               },
@@ -6724,6 +6725,10 @@ async function executeLiveApiToolInner(
           case 'edit_partner_preferences': url = '/me/profile?drawer=partner'; title = 'Partner preferences'; break;
           case 'edit_service_offerings':   url = '/me/profile?drawer=offerings'; title = 'Service offerings'; break;
           case 'privacy_settings':         url = '/profile/me/privacy'; title = 'Privacy & Visibility'; break;
+          // VTID-02675: pairs with the play_music fallback at ~line 4801 which
+          // says "want me to take you to Connected Apps?". Without this case,
+          // the fuzzy resolver would land the user on a random Settings page.
+          case 'connected_apps':           url = '/settings/connected-apps'; title = 'Connected Apps'; break;
           case 'discover_marketplace':     url = '/discover/marketplace'; title = 'Marketplace'; break;
           case 'events_meetups':           url = '/comm/events-meetups'; title = 'Events & meetups'; break;
           case 'community_feed':           url = '/comm/feed'; title = 'Community feed'; break;


### PR DESCRIPTION
## Summary

- The `play_music` fallback at `orb-live.ts:4801` says "want me to take you to Connected Apps?" when no music service is connected.
- But `connected_apps` was never in the `navigate_to_screen` target enum. When the user said yes, Gemini called the tool with an unknown target → fuzzy resolver picked the nearest valid match (privacy_settings or discover_marketplace) → user landed on a random Settings page ("ridiculous new screen").
- This patch wires the existing `/settings/connected-apps` route (already mounted in `App.tsx:1057` of vitana-v1) to the voice tool. No frontend change required.

Pairs with #1197 (VTID-02673 / BOOTSTRAP-YT-MUSIC-ALIAS). Together they close the loop on the user's reported "play song" → "redirect me" bug:
- #1197 makes the YouTube green-check actually count for music.play.
- This PR ensures that when a fallback redirect IS needed, it lands on the correct screen.

## Test plan
- [x] `npm run build` clean
- [ ] Post-merge: EXEC-DEPLOY succeeds for gateway
- [ ] User-facing: ORB voice → "play obscure track" → ORB asks to redirect to Connected Apps → user says yes → lands on `/settings/connected-apps` (not `/profile/me/privacy` or `/discover/marketplace`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)