### PR TITLE
feat(feedback): kill-switch bypass for feedback lane (VTID-02676)

### DIFF
--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -295,11 +295,12 @@ export async function approveAutoExecute(input: ApprovalInput): Promise<Approval
     id: string;
     risk_class: 'low' | 'medium' | 'high' | null;
     source_type: string;
+    source_ref: string | null;
     spec_snapshot: Record<string, unknown>;
     status: string;
   }>>(
     s,
-    `/rest/v1/autopilot_recommendations?id=eq.${input.finding_id}&select=id,risk_class,source_type,spec_snapshot,status&limit=1`,
+    `/rest/v1/autopilot_recommendations?id=eq.${input.finding_id}&select=id,risk_class,source_type,source_ref,spec_snapshot,status&limit=1`,
   );
   if (!recR.ok || !recR.data) return { ok: false, error: recR.error || 'finding lookup failed' };
   const rec = recR.data[0];
@@ -358,6 +359,12 @@ export async function approveAutoExecute(input: ApprovalInput): Promise<Approval
     files_to_modify: files,
     files_to_delete: deletions,
   };
+  // VTID-02676: feedback-bridged findings bypass the kill_switch only.
+  // All other gate rules still apply.
+  const isFeedbackLane = rec.source_type === 'dev_autopilot'
+    && typeof rec.source_ref === 'string'
+    && rec.source_ref.startsWith('feedback_ticket:');
+
   const safetyCtx: SafetyContext = {
     config: {
       kill_switch: cfg.kill_switch,
@@ -369,6 +376,7 @@ export async function approveAutoExecute(input: ApprovalInput): Promise<Approval
     },
     approved_today: approvedToday,
     auto_fix_depth: 0,
+    is_feedback_lane: isFeedbackLane,
   };
   const decision = evaluateSafetyGate(safetyPlan, safetyCtx);
   if (!decision.ok) {

--- a/services/gateway/src/services/dev-autopilot-safety.ts
+++ b/services/gateway/src/services/dev-autopilot-safety.ts
@@ -44,6 +44,19 @@ export interface SafetyContext {
   approved_today: number;
   /** For self-heal children: depth of the proposed execution (0 for root). */
   auto_fix_depth: number;
+  /**
+   * VTID-02676: when this context represents a feedback-bridged finding
+   * (source_type=dev_autopilot AND source_ref LIKE 'feedback_ticket:%'),
+   * the global kill_switch is BYPASSED. Every other rule (allow_scope,
+   * deny_scope, tests_missing, daily_budget, max_auto_fix_depth, risk
+   * class) still applies. Justification: the feedback lane has three
+   * independent guardrails the kill_switch was originally meant to
+   * compensate for — Devon's codebase-aware system prompt, bridge
+   * pre-flight scope check, and planner LOCKED file list. The kill
+   * switch stays armed for non-feedback lanes (where the unfixed
+   * plan-vs-diff validator gap still applies).
+   */
+  is_feedback_lane?: boolean;
 }
 
 export interface SafetyPlan {
@@ -151,8 +164,13 @@ export function isTestFile(path: string): boolean {
 export function evaluateSafetyGate(plan: SafetyPlan, ctx: SafetyContext): SafetyDecision {
   const violations: SafetyViolation[] = [];
 
-  // 1. Kill switch
-  if (ctx.config.kill_switch) {
+  // 1. Kill switch — VTID-02676: feedback lane bypasses this single rule.
+  //    The kill switch was originally armed to contain a planner-
+  //    hallucination + duplicate-PR class of incidents that don't apply
+  //    to feedback-bridged findings (Devon prompt + bridge pre-flight +
+  //    planner LOCKED file list are the dedicated guardrails). All other
+  //    gate rules below still apply to feedback lane.
+  if (ctx.config.kill_switch && !ctx.is_feedback_lane) {
     violations.push({
       code: 'kill_switch_engaged',
       message: 'Dev Autopilot kill switch is armed. Disarm it before approving new executions.',


### PR DESCRIPTION
Kill switch bypass for feedback-bridged findings only. All other gate rules still apply. Non-feedback lanes stay paused. Closes the last blocker on user contract: ONE click on Activate.