### PR TITLE
fix(llm-router): Vertex 404 fall-through to AI Studio for preview models (VTID-02689)

### DIFF
--- a/services/gateway/src/services/llm-router.ts
+++ b/services/gateway/src/services/llm-router.ts
@@ -417,7 +417,23 @@ const vertexAdapter: ProviderAdapter = {
           },
         };
       } catch (err) {
-        return { ok: false, error: `Vertex threw: ${String(err).slice(0, 300)}` };
+        const errStr = String(err);
+        // VTID-02689: fall through to AI Studio when Vertex doesn't have
+        // the model. Preview models like `gemini-3.1-pro-preview` are
+        // exposed via generativelanguage.googleapis.com (consumer/AI Studio
+        // endpoint) but not the Vertex v1 publisher catalog used by the
+        // @google-cloud/vertexai Node SDK. The Python google-genai SDK
+        // (used by livekit-plugins-google with vertexai=True) talks to a
+        // different Vertex endpoint that DOES expose the preview models.
+        // Until we migrate this adapter to @google/genai, AI Studio is the
+        // path that works for preview models.
+        if (errStr.match(/Publisher Model.*not found|404 Not Found|model.*not.*supported/i)
+          && process.env.GOOGLE_GEMINI_API_KEY) {
+          console.log(`[llm-router] Vertex returned 404 for model "${model}" — falling through to AI Studio`);
+          // fall through to AI Studio block below
+        } else {
+          return { ok: false, error: `Vertex threw: ${errStr.slice(0, 300)}` };
+        }
       }
     }
 

--- a/supabase/migrations/data-fixups/20260503000500_data_fixup_FB_000032_proposed_files.sql
+++ b/supabase/migrations/data-fixups/20260503000500_data_fixup_FB_000032_proposed_files.sql
@@ -1,0 +1,32 @@
+-- DATA FIXUP — VTID-02689
+--
+-- FB-2026-05-000032's autopilot_recommendations row (id cf6b0317-...)
+-- was created BEFORE VTID-02672 added spec_snapshot.proposed_files. The
+-- bridge's orphan-reuse path (VTID-02674) returns this stale finding on
+-- every retry, so spec_snapshot.proposed_files stays NULL forever and
+-- the executor's fallback (VTID-02687) has nothing to fall back to.
+--
+-- Devon's spec_md on the linked feedback_ticket lists the correct files
+-- in its "Files to touch" section. Backfill those into the recommendation
+-- so the next /activate retry can dispatch with valid files.
+
+UPDATE public.autopilot_recommendations
+SET spec_snapshot = jsonb_set(
+  COALESCE(spec_snapshot, '{}'::jsonb),
+  '{proposed_files}',
+  '["services/gateway/src/services/persona-registry.ts", "services/gateway/src/services/persona-registry.test.ts"]'::jsonb
+)
+WHERE source_ref = 'feedback_ticket:f85298f4-e1d1-48c8-bb10-faf7efc6d11c'
+  AND (spec_snapshot->'proposed_files' IS NULL
+       OR jsonb_typeof(spec_snapshot->'proposed_files') = 'null'
+       OR jsonb_array_length(COALESCE(spec_snapshot->'proposed_files', '[]'::jsonb)) = 0);
+
+-- Sanity check
+SELECT
+  id,
+  source_ref,
+  spec_snapshot->'proposed_files' AS proposed_files,
+  spec_snapshot->>'signal_type'   AS signal_type,
+  spec_snapshot->>'file_path'     AS file_path
+FROM public.autopilot_recommendations
+WHERE source_ref = 'feedback_ticket:f85298f4-e1d1-48c8-bb10-faf7efc6d11c';


### PR DESCRIPTION
gemini-3.1-pro-preview isn't in the Vertex v1 publisher catalog that the @google-cloud/vertexai Node SDK reads. Fall through to AI Studio (GOOGLE_GEMINI_API_KEY) when Vertex 404s. Plus data fixup to backfill spec_snapshot.proposed_files for FB-000032's orphan recommendation.