### PR TITLE
fix(orb): only Vitana files tickets — block specialists from calling report_to_specialist (VTID-02684)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -4463,6 +4463,27 @@ async function executeLiveApiToolInner(
           return { success: false, result: '', error: 'summary is required' };
         }
 
+        // v3b: ONLY Vitana files tickets. If a specialist calls this tool
+        // (which they can — it's in the shared tool registry), the gateway
+        // treats the call as a swap and resets personaFirstUtteranceDelivered
+        // → on next setup-message rebuild the model gets the FIRST TURN block
+        // again and re-greets ("Hi I'm Devon..."). User-reported regression:
+        // even after v3a, Devon greeted again because Devon himself called
+        // report_to_specialist mid-conversation to "file" the bug he'd just
+        // heard, and the swap logic reset his first-turn flag.
+        //
+        // Block: if the active persona is NOT Vitana, refuse this tool. The
+        // specialist's job is intake into the EXISTING ticket Vitana already
+        // filed — not file a fresh one.
+        const _activePersonaForReport = ((session as any).activePersona as string | undefined) || 'vitana';
+        if (_activePersonaForReport !== 'vitana' && _activePersonaForReport !== '') {
+          console.log(`[VTID-02684] report_to_specialist refused — caller is specialist '${_activePersonaForReport}', only vitana files tickets`);
+          return {
+            success: true,
+            result: `STAY_IN_INTAKE: You (${_activePersonaForReport}) are NOT allowed to file new tickets — only Vitana files. The user is already talking to YOU because Vitana has ALREADY filed the ticket for this issue. Your job is to continue the intake — gather details, write them into the existing ticket via your intake tools, then close with the standard close-question + goodbye flow. Do NOT call report_to_specialist again. Do NOT swap personas. Just respond to the user in your own language and continue the conversation from where it was.`,
+          };
+        }
+
         // v2e: server-side block on vague summaries. The LLM tool description
         // forbids placeholder summaries like "user wants to report a bug",
         // but we enforce server-side too. A vague summary causes the receiving


### PR DESCRIPTION
Real session log (live-08eaf2c0-..., 22:35-22:36 UTC) shows DEVON himself called report_to_specialist with a concrete summary at 22:36:38, which the gateway treated as a fresh swap and reset `personaFirstUtteranceDelivered`. The next transparent reconnect rebuilt the setup with the FIRST TURN block → Devon greeted again.

**Fix:** server-side guard at the top of report_to_specialist — refuses the call if the active persona is not Vitana. Returns STAY_IN_INTAKE telling the specialist 'Only Vitana files tickets; the user's already with you because the ticket is already filed; continue the intake, do not call this tool again, do not swap.'

After Vitana's initial swap to Devon, Devon can ONLY call switch_persona (and only to vitana per the hot-potato guard). The first-turn flag stays set, every reconnect during Devon's intake gets the MID-INTAKE block (v3a), no re-greeting.

VTID: VTID-02684.