### PR TITLE
fix(orb-agent): set VERTEX_AI_LOCATION=global for gemini-3.1 preview (VTID-02691)

### DIFF
--- a/.github/workflows/DEPLOY-ORB-AGENT.yml
+++ b/.github/workflows/DEPLOY-ORB-AGENT.yml
@@ -91,7 +91,7 @@ jobs:
             --allow-unauthenticated \
             --labels=vtid=vtid-livekit-foundation,vt_layer=aicor,vt_module=voice \
             --update-secrets=LIVEKIT_URL=LIVEKIT_URL:latest,LIVEKIT_API_KEY=LIVEKIT_API_KEY:latest,LIVEKIT_API_SECRET=LIVEKIT_API_SECRET:latest \
-            --set-env-vars=GATEWAY_URL=https://gateway-q74ibpv6ia-uc.a.run.app,AGENT_LOG_LEVEL=INFO,AGENT_ENABLE_WORKER=1,GOOGLE_CLOUD_PROJECT=lovable-vitana-vers1
+            --set-env-vars=GATEWAY_URL=https://gateway-q74ibpv6ia-uc.a.run.app,AGENT_LOG_LEVEL=INFO,AGENT_ENABLE_WORKER=1,GOOGLE_CLOUD_PROJECT=lovable-vitana-vers1,VERTEX_AI_LOCATION=global
 
       - name: Smoke test — health endpoint
         run: |


### PR DESCRIPTION
Gemini 3.1 preview models are served only from the Vertex 'global' endpoint. Sending requests to us-central1 returns 404 → AgentSession crashed silently → no transcript on the LiveKit test page. One-line env-var fix.