### PR TITLE
fix(autopilot): prefer proposed_files for feedback findings (VTID-02693)

### DIFF
--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -350,13 +350,22 @@ export async function approveAutoExecute(input: ApprovalInput): Promise<Approval
   // file_outside_allow_scope rule forever. Re-extracting here makes the fix
   // retroactive for every existing plan without a regeneration pass.
   const freshFiles = extractFilePaths(plan.plan_markdown);
-  let files = freshFiles.length > 0
-    ? freshFiles
-    : (plan.files_referenced || []).map(String);
-  // VTID-02687: same fallback as runExecutionSession — for feedback-bridged
-  // findings, use the bridge-validated spec_snapshot.proposed_files when
-  // both the markdown extraction and stored column are empty. Required for
-  // stale plan_versions inserted before VTID-02680.
+  // VTID-02693: for feedback findings, ALWAYS prefer the stored
+  // files_referenced (= bridge's pre-validated proposed_files) over
+  // freshFiles. The planner's plan_markdown sometimes lists only the
+  // source file and omits the co-located test file in its "Files to
+  // modify" section even though Devon's spec has both — that misses the
+  // tests_missing safety check. proposed_files is the authoritative list
+  // because the bridge already validated it against allow_scope.
+  const isFeedbackFinding = rec.source_type === 'dev_autopilot'
+    && typeof rec.source_ref === 'string'
+    && rec.source_ref.startsWith('feedback_ticket:');
+  let files = isFeedbackFinding && (plan.files_referenced || []).length > 0
+    ? (plan.files_referenced || []).map(String)
+    : (freshFiles.length > 0 ? freshFiles : (plan.files_referenced || []).map(String));
+  // VTID-02687: fallback for stale plan_versions where neither
+  // freshFiles nor files_referenced has anything — read proposed_files
+  // off the recommendation directly.
   if (files.length === 0) {
     const proposed = (rec.spec_snapshot as { proposed_files?: unknown })?.proposed_files;
     if (Array.isArray(proposed)) {


### PR DESCRIPTION
## Summary
- Feedback-lane finding's `proposed_files` is the authoritative file scope (already validated by the bridge against allow_scope, and includes the co-located test file when Devon's spec listed it).
- `approveAutoExecute` was reading the planner's `plan_markdown` extraction first and falling back to stored `files_referenced` only when extraction was empty. Result: `tests_missing` fired on FB-040 because the planner's markdown listed only the source file even though `proposed_files` had both source + test.
- For feedback findings, always prefer stored `files_referenced` over `freshFiles` from the planner's markdown.

## Why this is safe
- Only changes ordering of two existing sources we already trust.
- Non-feedback findings keep the original behavior (markdown first).
- Same fallback to `spec_snapshot.proposed_files` if both lists empty.

## Test plan
- [x] gateway build green
- [ ] FB-2026-05-000040 /activate succeeds end-to-end after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)