### PR TITLE
DEV-AUTOPILOT: Add test to skip FIXME self-scan in dev-autopilot-scan.mjs

### DIFF
--- a/services/gateway/test/dev-autopilot-scan-self.test.ts
+++ b/services/gateway/test/dev-autopilot-scan-self.test.ts
@@ -1,0 +1,70 @@
+import fs from 'fs';
+import path from 'path';
+import os from 'os';
+
+// Helper mimicking the behavior from scripts/ci/dev-autopilot-scan.mjs
+function relFromRepoLocal(file: string, repoRoot: string) {
+  return path.relative(repoRoot, file).replace(/\\/g, '/');
+}
+
+// Duplicating the intended scanTodos logic inline as the script does not export it
+function scanTodosMock(files: string[], repoRoot: string) {
+  const signals: any[] = [];
+  const regex = /\b(TODO|FIXME|HACK|XXX)\b/g;
+
+  for (const file of files) {
+    const relPath = relFromRepoLocal(file, repoRoot);
+    
+    // The intended fix logic:
+    if (relPath === 'scripts/ci/dev-autopilot-scan.mjs') {
+      continue;
+    }
+
+    const content = fs.readFileSync(file, 'utf-8');
+    let match;
+    while ((match = regex.exec(content)) !== null) {
+      signals.push({
+        file_path: relPath,
+        message: `Found ${match[1]}`,
+      });
+    }
+  }
+  return signals;
+}
+
+describe('dev-autopilot-scan self-skip', () => {
+  let tempDir: string;
+
+  beforeEach(() => {
+    tempDir = fs.mkdtempSync(path.join(os.tmpdir(), 'dev-autopilot-scan-test-'));
+  });
+
+  afterEach(() => {
+    fs.rmSync(tempDir, { recursive: true, force: true });
+  });
+
+  it('should ignore the scanner script itself if it contains FIXME literal', () => {
+    // 1. Setup mock environment with the scanner file
+    const scannerFilePath = path.join(tempDir, 'scripts', 'ci', 'dev-autopilot-scan.mjs');
+    fs.mkdirSync(path.dirname(scannerFilePath), { recursive: true });
+    // Write a file that contains the FIXME string similar to the real file's severity ternary
+    fs.writeFileSync(scannerFilePath, 'const severity = true ? "FIXME" : "INFO";\n', 'utf-8');
+
+    // 2. Create another standard source file containing a FIXME to ensure general scanning works
+    const normalFilePath = path.join(tempDir, 'services', 'gateway', 'index.ts');
+    fs.mkdirSync(path.dirname(normalFilePath), { recursive: true });
+    fs.writeFileSync(normalFilePath, '// FIXME: this needs to be addressed\n', 'utf-8');
+
+    const files = [scannerFilePath, normalFilePath];
+    
+    // 3. Run the scan logic
+    const signals = scanTodosMock(files, tempDir);
+
+    // 4. Verify the correct signal generation
+    const normalSignals = signals.filter((s) => s.file_path === 'services/gateway/index.ts');
+    expect(normalSignals).toHaveLength(1);
+
+    const scannerSignals = signals.filter((s) => s.file_path === 'scripts/ci/dev-autopilot-scan.mjs');
+    expect(scannerSignals).toHaveLength(0); // Should be empty
+  });
+});


### PR DESCRIPTION
This PR introduces a unit test (`services/gateway/test/dev-autopilot-scan-self.test.ts`) that verifies the scanner's own file (`scripts/ci/dev-autopilot-scan.mjs`) is skipped during TODO/FIXME scanning. This prevents self-referential false positives caused by the literal string "FIXME" inside the scanner's severity ternary.

**Note to operator:**
The plan also requested modifying `scripts/ci/dev-autopilot-scan.mjs` to add the exclusion guard (`if (relFromRepoLocal(file) === 'scripts/ci/dev-autopilot-scan.mjs') continue;`). However, that file was excluded from the locked file list for this generation, so it could not be modified directly. Please follow up by adding the guard logic inside the `scanTodos` loop in `scripts/ci/dev-autopilot-scan.mjs`. The test has been written with a duplicated logic block inline, as suggested by the plan, to test the behavior of the fix independently.