### PR TITLE
DEV-AUTOPILOT: Fix persona handoff greeting language fallback issue

### DIFF
--- a/services/gateway/src/services/persona-registry.ts
+++ b/services/gateway/src/services/persona-registry.ts
@@ -98,11 +98,23 @@ export async function getPersonaVoice(key: string): Promise<string> {
   return reg.get(key)?.voice_id ?? '';
 }
 
+function extractLocale(langOrCtx: any): string {
+  if (!langOrCtx) return 'en';
+  let raw = 'en';
+  if (typeof langOrCtx === 'string') {
+    raw = langOrCtx;
+  } else if (typeof langOrCtx === 'object') {
+    raw = langOrCtx.user?.locale || langOrCtx.session?.language || langOrCtx.language || langOrCtx.lang || 'en';
+  }
+  return typeof raw === 'string' ? raw.split('-')[0].toLowerCase() : 'en';
+}
+
 /**
  * Returns the persona's greeting in the requested language, falling
  * through `lang → 'en' → generic` so a missing language never hard-fails.
  */
-export async function getPersonaGreeting(key: string, lang: string): Promise<string> {
+export async function getPersonaGreeting(key: string, langOrCtx: any): Promise<string> {
+  const lang = extractLocale(langOrCtx);
   const reg = await loadPersonaRegistry();
   const p = reg.get(key);
   if (!p) return `Hi, ${key} here. How can I help?`;
@@ -281,9 +293,10 @@ export async function getPersonaVoiceForTenant(key: string, tenantId: string): P
  */
 export async function getPersonaGreetingForTenant(
   key: string,
-  lang: string,
+  langOrCtx: any,
   tenantId: string,
 ): Promise<string> {
+  const lang = extractLocale(langOrCtx);
   const reg = await loadPersonaRegistryForTenant(tenantId);
   const p = reg.get(key);
   if (!p) return `Hi, ${key} here. How can I help?`;


### PR DESCRIPTION
Fixes a bug where persona handoffs revert to English instead of the user's selected language. The registry previously expected a simple `lang` string, but caller contexts sometimes pass an entire session/context object. This caused the language to stringify to `"[object Object]"`, failing the localized greeting lookup and triggering the default English greeting.

This PR introduces an `extractLocale` helper that:
1. Safely checks if the `lang` argument is a string or an object.
2. Extracts the locale accurately from fields like `user.locale` or `session.language`.
3. Normalizes the locale format (e.g., `de-DE` → `de`) so dictionary template lookups succeed, maintaining the caller's language preference seamlessly when swapping voice agents.

Files touched:
- `services/gateway/src/services/persona-registry.ts`