### PR TITLE
DEV-AUTOPILOT: Expose system controls API endpoint for feature flags

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,27 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { getSystemControl } from '../services/system-controls';
+
+const router = Router();
+
+router.get('/:key', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { key } = req.params;
+    
+    // Safety check ensuring we only process string keys
+    if (!key || typeof key !== 'string') {
+      return res.status(400).json({ error: 'Invalid system control key' });
+    }
+
+    const control = await getSystemControl(key);
+
+    if (!control) {
+      return res.status(404).json({ error: 'System control not found' });
+    }
+
+    return res.json(control);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,26 @@
+import { supabase } from '../lib/supabase';
+import { SystemControl } from '../types/system-controls';
+
+/**
+ * Fetches a single system control flag by its key.
+ * Returns null if the control does not exist.
+ *
+ * @param key The unique key of the system control (e.g., 'vitana_did_you_know_enabled')
+ */
+export async function getSystemControl(key: string): Promise<SystemControl | null> {
+  const { data, error } = await supabase
+    .from('system_controls')
+    .select('*')
+    .eq('key', key)
+    .single();
+
+  if (error) {
+    // PGRST116 is the PostgREST error code for "JSON object requested, multiple (or no) rows returned"
+    if (error.code === 'PGRST116') {
+      return null;
+    }
+    throw new Error(`Failed to fetch system control: ${error.message}`);
+  }
+
+  return data as SystemControl;
+}

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at?: string;
+  updated_by?: string;
+  reason?: string;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,51 @@
+import request from 'supertest';
+import express, { Request, Response, NextFunction } from 'express';
+import systemControlsRouter from '../../src/routes/system-controls';
+import * as systemControlsService from '../../src/services/system-controls';
+
+jest.mock('../../src/services/system-controls');
+
+const app = express();
+app.use(express.json());
+app.use('/api/system-controls', systemControlsRouter);
+
+// Global error handler for catching next(error)
+app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
+  res.status(500).json({ error: err.message });
+});
+
+describe('GET /api/system-controls/:key', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return 200 and the control object if found', async () => {
+    const mockControl = { key: 'vitana_did_you_know_enabled', enabled: true };
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(mockControl);
+
+    const response = await request(app).get('/api/system-controls/vitana_did_you_know_enabled');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockControl);
+    expect(systemControlsService.getSystemControl).toHaveBeenCalledWith('vitana_did_you_know_enabled');
+  });
+
+  it('should return 404 if control is not found', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(null);
+
+    const response = await request(app).get('/api/system-controls/missing_key');
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'System control not found' });
+    expect(systemControlsService.getSystemControl).toHaveBeenCalledWith('missing_key');
+  });
+
+  it('should handle errors thrown by the service and yield 500', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockRejectedValue(new Error('Service failure'));
+
+    const response = await request(app).get('/api/system-controls/some_key');
+    
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: 'Service failure' });
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,60 @@
+import { getSystemControl } from '../src/services/system-controls';
+import { supabase } from '../src/lib/supabase';
+
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+describe('System Controls Service', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return a system control if found', async () => {
+    const mockData = { key: 'vitana_did_you_know_enabled', enabled: true };
+    const singleMock = jest.fn().mockResolvedValue({ data: mockData, error: null });
+    const eqMock = jest.fn().mockReturnValue({ single: singleMock });
+    const selectMock = jest.fn().mockReturnValue({ eq: eqMock });
+    
+    (supabase.from as jest.Mock).mockReturnValue({ select: selectMock });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+    
+    expect(supabase.from).toHaveBeenCalledWith('system_controls');
+    expect(selectMock).toHaveBeenCalledWith('*');
+    expect(eqMock).toHaveBeenCalledWith('key', 'vitana_did_you_know_enabled');
+    expect(result).toEqual(mockData);
+  });
+
+  it('should return null if not found (PGRST116)', async () => {
+    const singleMock = jest.fn().mockResolvedValue({ 
+      data: null, 
+      error: { code: 'PGRST116', message: 'Not found' } 
+    });
+    const eqMock = jest.fn().mockReturnValue({ single: singleMock });
+    const selectMock = jest.fn().mockReturnValue({ eq: eqMock });
+    
+    (supabase.from as jest.Mock).mockReturnValue({ select: selectMock });
+
+    const result = await getSystemControl('missing_flag');
+    
+    expect(result).toBeNull();
+  });
+
+  it('should throw an error for other supabase errors', async () => {
+    const singleMock = jest.fn().mockResolvedValue({ 
+      data: null, 
+      error: { code: '500', message: 'Internal Server Error' } 
+    });
+    const eqMock = jest.fn().mockReturnValue({ single: singleMock });
+    const selectMock = jest.fn().mockReturnValue({ eq: eqMock });
+    
+    (supabase.from as jest.Mock).mockReturnValue({ select: selectMock });
+
+    await expect(getSystemControl('some_flag')).rejects.toThrow(
+      'Failed to fetch system control: Internal Server Error'
+    );
+  });
+});


### PR DESCRIPTION
This PR adds the necessary Gateway backend changes to expose `system_controls` (specifically the `vitana_did_you_know_enabled` flag) to the frontend.

### Changes
- Defines `SystemControl` types.
- Implements `getSystemControl` service to query the `system_controls` table using the Supabase client.
- Exposes `GET /api/system-controls/:key` endpoint.
- Adds comprehensive unit tests for both the service and the route.

### Notes for Operator
As stated in the plan's constraints, the exact frontend file modifying the command-hub to use this new endpoint could not be determined or securely targeted yet (the exact path to `DidYouKnowTour.tsx` or similar is missing). **Please follow up** by locating the command-hub component responsible for the "Did You Know" tour and adding the fetch call to `/api/system-controls/vitana_did_you_know_enabled` on mount, as this PR purely implements the required backend portion to adhere strictly to the locked file scope.