### PR TITLE
DEV-AUTOPILOT: Expose system controls via Gateway API

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,21 @@
+import { Router } from 'express';
+import { getSystemControl } from '../services/system-controls';
+
+const router = Router();
+
+router.get('/:key', async (req, res, next) => {
+  try {
+    const { key } = req.params;
+    const control = await getSystemControl(key);
+
+    if (!control) {
+      return res.status(404).json({ error: 'System control not found' });
+    }
+
+    return res.json(control);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,19 @@
+import { supabase } from '../lib/supabase';
+import { SystemControl } from '../types/system-controls';
+
+export async function getSystemControl(key: string): Promise<SystemControl | null> {
+  const { data, error } = await supabase
+    .from('system_controls')
+    .select('*')
+    .eq('key', key)
+    .single();
+
+  if (error) {
+    if (error.code === 'PGRST116') {
+      return null;
+    }
+    throw new Error(`Failed to fetch system control: ${error.message}`);
+  }
+
+  return data as SystemControl;
+}

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at?: string;
+  updated_by?: string;
+  reason?: string;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,50 @@
+import express from 'express';
+import request from 'supertest';
+import systemControlsRouter from '../../src/routes/system-controls';
+import * as systemControlsService from '../../src/services/system-controls';
+
+jest.mock('../../src/services/system-controls');
+
+describe('System Controls Routes', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    
+    app = express();
+    app.use(express.json());
+    app.use('/api/system-controls', systemControlsRouter);
+    app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
+      res.status(500).json({ error: err.message });
+    });
+  });
+
+  it('should return 200 and the control if found', async () => {
+    const mockControl = { key: 'test_flag', enabled: true };
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(mockControl);
+
+    const response = await request(app).get('/api/system-controls/test_flag');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockControl);
+    expect(systemControlsService.getSystemControl).toHaveBeenCalledWith('test_flag');
+  });
+
+  it('should return 404 if control is not found', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(null);
+
+    const response = await request(app).get('/api/system-controls/missing_flag');
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'System control not found' });
+  });
+
+  it('should pass errors to next middleware', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockRejectedValue(new Error('Internal failure'));
+
+    const response = await request(app).get('/api/system-controls/error_flag');
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: 'Internal failure' });
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,59 @@
+import { getSystemControl } from '../src/services/system-controls';
+import { supabase } from '../src/lib/supabase';
+
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+describe('System Controls Service', () => {
+  const mockSelect = jest.fn();
+  const mockEq = jest.fn();
+  const mockSingle = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (supabase.from as jest.Mock).mockReturnValue({
+      select: mockSelect
+    });
+    mockSelect.mockReturnValue({
+      eq: mockEq
+    });
+    mockEq.mockReturnValue({
+      single: mockSingle
+    });
+  });
+
+  it('should return a system control if found', async () => {
+    const mockData = { key: 'test_key', enabled: true };
+    mockSingle.mockResolvedValue({ data: mockData, error: null });
+
+    const result = await getSystemControl('test_key');
+
+    expect(supabase.from).toHaveBeenCalledWith('system_controls');
+    expect(mockSelect).toHaveBeenCalledWith('*');
+    expect(mockEq).toHaveBeenCalledWith('key', 'test_key');
+    expect(result).toEqual(mockData);
+  });
+
+  it('should return null if system control is not found', async () => {
+    mockSingle.mockResolvedValue({
+      data: null,
+      error: { code: 'PGRST116', message: 'Not found' }
+    });
+
+    const result = await getSystemControl('missing_key');
+
+    expect(result).toBeNull();
+  });
+
+  it('should throw an error on database failure', async () => {
+    mockSingle.mockResolvedValue({
+      data: null,
+      error: { code: 'OTHER_CODE', message: 'Database error' }
+    });
+
+    await expect(getSystemControl('error_key')).rejects.toThrow('Failed to fetch system control: Database error');
+  });
+});


### PR DESCRIPTION
This PR exposes the `system_controls` table through the Gateway API, adding a reusable endpoint to fetch a single system control flag by its key. 

This addresses the missing gateway code to read the `vitana_did_you_know_enabled` flag, which was flipped in the `20260425100000_BOOTSTRAP_dyk_flag_on.sql` migration. 

### Changes
* `services/gateway/src/types/system-controls.ts`: Added `SystemControl` type definition.
* `services/gateway/src/services/system-controls.ts`: Added service method to fetch a record by key via Supabase.
* `services/gateway/src/routes/system-controls.ts`: Added Express router `GET /:key` returning the record.
* `services/gateway/test/system-controls.test.ts`: Added unit tests for the service logic.
* `services/gateway/test/routes/system-controls.test.ts`: Added unit tests for the route.

**Note on Frontend Changes**:
The command-hub (frontend) modifications required to conditionally render the "Did You Know?" tour were intentionally excluded from this PR, as the frontend files are outside the allowed scope of this plan. An operator will need to follow up with a subsequent change to the `command-hub` codebase to consume `GET /api/system-controls/vitana_did_you_know_enabled`.