### PR TITLE
DEV-AUTOPILOT: Expose system controls endpoint for DYK feature

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,22 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { getSystemControl } from '../services/system-controls';
+
+const router = Router();
+
+router.get('/:key', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { key } = req.params;
+    const control = await getSystemControl(key);
+
+    if (!control) {
+      res.status(404).json({ error: 'System control not found' });
+      return;
+    }
+
+    res.status(200).json(control);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,20 @@
+import { supabase } from '../lib/supabase';
+import { SystemControl } from '../types/system-controls';
+
+export async function getSystemControl(key: string): Promise<SystemControl | null> {
+  const { data, error } = await supabase
+    .from('system_controls')
+    .select('*')
+    .eq('key', key)
+    .single();
+
+  if (error) {
+    if (error.code === 'PGRST116') {
+      // Not found
+      return null;
+    }
+    throw new Error(`Failed to fetch system control: ${error.message}`);
+  }
+
+  return data as SystemControl;
+}

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at?: string;
+  updated_by?: string;
+  reason?: string;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,53 @@
+import request from 'supertest';
+import express from 'express';
+import systemControlsRouter from '../../src/routes/system-controls';
+import * as systemControlsService from '../../src/services/system-controls';
+
+jest.mock('../../src/services/system-controls');
+
+const app = express();
+app.use(express.json());
+app.use('/api/system-controls', systemControlsRouter);
+
+// basic error handler
+app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
+  res.status(500).json({ error: err.message });
+});
+
+describe('System Controls Routes', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('GET /api/system-controls/:key returns 200 and data if found', async () => {
+    const mockData = {
+      key: 'vitana_did_you_know_enabled',
+      enabled: true
+    };
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(mockData);
+
+    const response = await request(app).get('/api/system-controls/vitana_did_you_know_enabled');
+    
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockData);
+    expect(systemControlsService.getSystemControl).toHaveBeenCalledWith('vitana_did_you_know_enabled');
+  });
+
+  it('GET /api/system-controls/:key returns 404 if not found', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(null);
+
+    const response = await request(app).get('/api/system-controls/missing_key');
+    
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'System control not found' });
+  });
+
+  it('GET /api/system-controls/:key returns 500 on service error', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockRejectedValue(new Error('Internal error'));
+
+    const response = await request(app).get('/api/system-controls/some_key');
+    
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: 'Internal error' });
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,53 @@
+import { getSystemControl } from '../src/services/system-controls';
+import { supabase } from '../src/lib/supabase';
+
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+describe('System Controls Service', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns a system control if found', async () => {
+    const mockData = {
+      key: 'vitana_did_you_know_enabled',
+      enabled: true,
+    };
+
+    const singleMock = jest.fn().mockResolvedValue({ data: mockData, error: null });
+    const eqMock = jest.fn().mockReturnValue({ single: singleMock });
+    const selectMock = jest.fn().mockReturnValue({ eq: eqMock });
+    (supabase.from as jest.Mock).mockReturnValue({ select: selectMock });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+
+    expect(supabase.from).toHaveBeenCalledWith('system_controls');
+    expect(selectMock).toHaveBeenCalledWith('*');
+    expect(eqMock).toHaveBeenCalledWith('key', 'vitana_did_you_know_enabled');
+    expect(singleMock).toHaveBeenCalled();
+    expect(result).toEqual(mockData);
+  });
+
+  it('returns null if not found (PGRST116)', async () => {
+    const singleMock = jest.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } });
+    const eqMock = jest.fn().mockReturnValue({ single: singleMock });
+    const selectMock = jest.fn().mockReturnValue({ eq: eqMock });
+    (supabase.from as jest.Mock).mockReturnValue({ select: selectMock });
+
+    const result = await getSystemControl('missing_key');
+    expect(result).toBeNull();
+  });
+
+  it('throws on other errors', async () => {
+    const singleMock = jest.fn().mockResolvedValue({ data: null, error: { message: 'Database error' } });
+    const eqMock = jest.fn().mockReturnValue({ single: singleMock });
+    const selectMock = jest.fn().mockReturnValue({ eq: eqMock });
+    (supabase.from as jest.Mock).mockReturnValue({ select: selectMock });
+
+    await expect(getSystemControl('missing_key')).rejects.toThrow('Failed to fetch system control: Database error');
+  });
+});


### PR DESCRIPTION
This PR exposes the `system_controls` table via a new Gateway API route (`GET /api/system-controls/:key`). This allows frontend consumers (like command-hub) to check whether feature flags such as `vitana_did_you_know_enabled` are active.

### Plan execution
- Added `SystemControl` type definition.
- Created `getSystemControl` service to query Supabase using the backend client.
- Implemented an express route returning the control status, or 404 if not found.
- Added comprehensive unit and route integration tests.

### Missing files for operator followup
- As constrained by the locked file list, the actual route registration in the main express app (e.g. `services/gateway/src/app.ts` or `index.ts`) was not modified. An operator needs to mount `systemControlsRouter` at `/api/system-controls`.
- The frontend (command-hub) integration, as planned, has not been updated yet. An operator must update the corresponding React/Redux components to query this new endpoint on startup and conditionally render the "Did You Know?" tour.