### PR TITLE
DEV-AUTOPILOT: Support request objects for locale in persona greetings

### DIFF
--- a/services/gateway/src/services/persona-registry.ts
+++ b/services/gateway/src/services/persona-registry.ts
@@ -98,16 +98,30 @@ export async function getPersonaVoice(key: string): Promise<string> {
   return reg.get(key)?.voice_id ?? '';
 }
 
+function extractLocale(langOrCtx: any): string {
+  let locale = 'en';
+  if (typeof langOrCtx === 'string') {
+    locale = langOrCtx;
+  } else if (langOrCtx && typeof langOrCtx === 'object') {
+    locale = langOrCtx.user?.locale || langOrCtx.session?.language || 'en';
+  }
+  if (typeof locale !== 'string') {
+    locale = 'en';
+  }
+  return locale.split('-')[0].toLowerCase();
+}
+
 /**
  * Returns the persona's greeting in the requested language, falling
  * through `lang → 'en' → generic` so a missing language never hard-fails.
  */
-export async function getPersonaGreeting(key: string, lang: string): Promise<string> {
+export async function getPersonaGreeting(key: string, lang: any): Promise<string> {
+  const locale = extractLocale(lang);
   const reg = await loadPersonaRegistry();
   const p = reg.get(key);
   if (!p) return `Hi, ${key} here. How can I help?`;
   const tpls = p.greeting_templates ?? {};
-  if (tpls[lang]) return tpls[lang];
+  if (tpls[locale]) return tpls[locale];
   if (tpls['en']) return tpls['en'];
   // Last-resort generic — covers the "operator just inserted a new persona
   // and forgot to fill greeting_templates" case so the swap never sounds
@@ -281,14 +295,15 @@ export async function getPersonaVoiceForTenant(key: string, tenantId: string): P
  */
 export async function getPersonaGreetingForTenant(
   key: string,
-  lang: string,
+  lang: any,
   tenantId: string,
 ): Promise<string> {
+  const locale = extractLocale(lang);
   const reg = await loadPersonaRegistryForTenant(tenantId);
   const p = reg.get(key);
   if (!p) return `Hi, ${key} here. How can I help?`;
   const tpls = p.greeting_templates ?? {};
-  if (tpls[lang]) return tpls[lang];
+  if (tpls[locale]) return tpls[locale];
   if (tpls['en']) return tpls['en'];
   return `Hi, ${p.display_name} here. How can I help?`;
 }


### PR DESCRIPTION
**Context & Issue:**
During persona handoffs, the voice agent erroneously switches to English even when the user's language is configured otherwise (e.g., German). The root cause is that the caller is passing a context/session object instead of a simple locale string to the greeting lookup. Consequently, `[object Object]` is used as the language key, triggering the default English greeting fallback. Because the system prompt anchors the interaction via the greeting, the LLM continues the entire conversation in English.

**Resolution Plan:**
- Introduce a private helper `extractLocale` in `persona-registry.ts` to normalize language inputs by intelligently inspecting both primitive strings and potential session/context objects.
- Modify `getPersonaGreeting` and `getPersonaGreetingForTenant` to leverage `extractLocale` (and update the type of `lang` to `any` to prevent type mismatches).
- Standardize the extracted locale (e.g., converting `de-DE` into `de`) so that `greeting_templates` dict lookups reliably match the correct template.

**Files modified:**
- `services/gateway/src/services/persona-registry.ts`