### PR TITLE
DEV-AUTOPILOT: Add system controls API endpoint for frontend feature flags

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,22 @@
+import { Router, Request, Response } from 'express';
+import { getSystemControl } from '../services/system-controls';
+
+const router = Router();
+
+router.get('/:key', async (req: Request, res: Response) => {
+  try {
+    const { key } = req.params;
+    const control = await getSystemControl(key);
+
+    if (!control) {
+      return res.status(404).json({ error: 'System control not found' });
+    }
+
+    return res.status(200).json(control);
+  } catch (error) {
+    console.error(`Error fetching system control for key ${req.params.key}:`, error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router;

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,20 @@
+import { supabase } from '../lib/supabase';
+import { SystemControl } from '../types/system-controls';
+
+export async function getSystemControl(key: string): Promise<SystemControl | null> {
+  const { data, error } = await supabase
+    .from('system_controls')
+    .select('*')
+    .eq('key', key)
+    .single();
+
+  if (error) {
+    if (error.code === 'PGRST116') {
+      // 0 rows returned
+      return null;
+    }
+    throw error;
+  }
+
+  return data as SystemControl;
+}

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at?: string;
+  updated_by?: string;
+  reason?: string;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,45 @@
+import request from 'supertest';
+import express from 'express';
+import systemControlsRouter from '../../src/routes/system-controls';
+import * as systemControlsService from '../../src/services/system-controls';
+
+jest.mock('../../src/services/system-controls');
+
+const app = express();
+app.use(express.json());
+app.use('/api/system-controls', systemControlsRouter);
+
+describe('GET /api/system-controls/:key', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return 200 and the control if found', async () => {
+    const mockControl = { key: 'vitana_did_you_know_enabled', enabled: true };
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(mockControl);
+
+    const response = await request(app).get('/api/system-controls/vitana_did_you_know_enabled');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockControl);
+    expect(systemControlsService.getSystemControl).toHaveBeenCalledWith('vitana_did_you_know_enabled');
+  });
+
+  it('should return 404 if the control is not found', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(null);
+
+    const response = await request(app).get('/api/system-controls/missing_flag');
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'System control not found' });
+  });
+
+  it('should return 500 if the service throws an error', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockRejectedValue(new Error('Test error'));
+
+    const response = await request(app).get('/api/system-controls/error_flag');
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: 'Internal server error' });
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,55 @@
+import { getSystemControl } from '../src/services/system-controls';
+import { supabase } from '../src/lib/supabase';
+
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+describe('System Controls Service', () => {
+  let selectMock: jest.Mock;
+  let eqMock: jest.Mock;
+  let singleMock: jest.Mock;
+
+  beforeEach(() => {
+    singleMock = jest.fn();
+    eqMock = jest.fn().mockReturnValue({ single: singleMock });
+    selectMock = jest.fn().mockReturnValue({ eq: eqMock });
+
+    (supabase.from as jest.Mock).mockReturnValue({
+      select: selectMock
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return a system control if found', async () => {
+    const mockControl = { key: 'vitana_did_you_know_enabled', enabled: true };
+    singleMock.mockResolvedValue({ data: mockControl, error: null });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+
+    expect(supabase.from).toHaveBeenCalledWith('system_controls');
+    expect(selectMock).toHaveBeenCalledWith('*');
+    expect(eqMock).toHaveBeenCalledWith('key', 'vitana_did_you_know_enabled');
+    expect(singleMock).toHaveBeenCalled();
+    expect(result).toEqual(mockControl);
+  });
+
+  it('should return null if not found (PGRST116)', async () => {
+    singleMock.mockResolvedValue({ data: null, error: { code: 'PGRST116' } });
+
+    const result = await getSystemControl('missing_flag');
+    expect(result).toBeNull();
+  });
+
+  it('should throw on other errors', async () => {
+    const dbError = new Error('Database connection failed');
+    singleMock.mockResolvedValue({ data: null, error: dbError });
+
+    await expect(getSystemControl('test_flag')).rejects.toThrow('Database connection failed');
+  });
+});


### PR DESCRIPTION
This PR implements the gateway API endpoints for the `system_controls` table, resolving the missing mechanism to read system flags (like `vitana_did_you_know_enabled`) on the frontend. 

**Changes Included:**
- Defined `SystemControl` typescript interface.
- Created `getSystemControl` service utilizing the Supabase client to fetch flags by key.
- Created `GET /api/system-controls/:key` Express route.
- Added comprehensive unit tests for both the service and the route.

**Operator Follow-up Required:**
The specific file to update in the frontend (`services/gateway/src/frontend/command-hub/...`) was omitted from this PR as the exact tour component location was undetermined. Please update the relevant `command-hub` file to fetch from `GET /api/system-controls/vitana_did_you_know_enabled` before deploying so that the Did You Know? tour logic is complete.