### PR TITLE
fix(autopilot): trust GitHub mergeable_state for CI gate (VTID-02694)

### DIFF
--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -350,13 +350,22 @@ export async function approveAutoExecute(input: ApprovalInput): Promise<Approval
   // file_outside_allow_scope rule forever. Re-extracting here makes the fix
   // retroactive for every existing plan without a regeneration pass.
   const freshFiles = extractFilePaths(plan.plan_markdown);
-  let files = freshFiles.length > 0
-    ? freshFiles
-    : (plan.files_referenced || []).map(String);
-  // VTID-02687: same fallback as runExecutionSession — for feedback-bridged
-  // findings, use the bridge-validated spec_snapshot.proposed_files when
-  // both the markdown extraction and stored column are empty. Required for
-  // stale plan_versions inserted before VTID-02680.
+  // VTID-02693: for feedback findings, ALWAYS prefer the stored
+  // files_referenced (= bridge's pre-validated proposed_files) over
+  // freshFiles. The planner's plan_markdown sometimes lists only the
+  // source file and omits the co-located test file in its "Files to
+  // modify" section even though Devon's spec has both — that misses the
+  // tests_missing safety check. proposed_files is the authoritative list
+  // because the bridge already validated it against allow_scope.
+  const isFeedbackFinding = rec.source_type === 'dev_autopilot'
+    && typeof rec.source_ref === 'string'
+    && rec.source_ref.startsWith('feedback_ticket:');
+  let files = isFeedbackFinding && (plan.files_referenced || []).length > 0
+    ? (plan.files_referenced || []).map(String)
+    : (freshFiles.length > 0 ? freshFiles : (plan.files_referenced || []).map(String));
+  // VTID-02687: fallback for stale plan_versions where neither
+  // freshFiles nor files_referenced has anything — read proposed_files
+  // off the recommendation directly.
   if (files.length === 0) {
     const proposed = (rec.spec_snapshot as { proposed_files?: unknown })?.proposed_files;
     if (Array.isArray(proposed)) {

--- a/services/gateway/src/services/dev-autopilot-watcher.ts
+++ b/services/gateway/src/services/dev-autopilot-watcher.ts
@@ -328,31 +328,57 @@ export async function ciWatcherTick(): Promise<void> {
     const analysis = analyzeCiStatus(prStatus.checks || []);
     if (analysis.state === 'pending') continue;
 
-    if (analysis.state === 'failing') {
+    // VTID-02694: trust GitHub's mergeable_state (which reflects branch
+    // protection rules) instead of failing on any red check. Otherwise
+    // the autopilot blocks on pre-existing-broken non-required checks
+    // that humans merge through every day. mergeable_state values:
+    //   'clean'    — required checks pass, no conflicts → merge OK
+    //   'unstable' — required checks pass, some non-required fail → merge OK
+    //   'blocked'  — required check failed OR review missing → fail
+    //   'dirty'    — merge conflicts → fail
+    //   'unknown' / 'has_hooks' / 'behind' — still settling → wait
+    const mState = (prStatus as { pr?: { mergeable_state?: string } }).pr?.mergeable_state;
+    if (mState === 'unknown' || mState === 'has_hooks' || mState === 'behind' || !mState) {
+      continue;
+    }
+
+    if (mState === 'dirty' || mState === 'blocked') {
       await transitionStatus(s, exec.id, 'ci', 'failed', {
-        metadata: { ...(exec.metadata || {}), failed_checks: analysis.failedNames },
+        metadata: {
+          ...(exec.metadata || {}),
+          failed_checks: analysis.failedNames,
+          mergeable_state: mState,
+        },
       });
       await emitOasisEvent({
         vtid: WATCHER_VTID,
         type: 'dev_autopilot.execution.ci_failed',
         source: 'dev-autopilot-watcher',
         status: 'error',
-        message: `Execution ${exec.id.slice(0, 8)} CI failed: ${analysis.failedNames.join(', ')}`,
-        payload: { execution_id: exec.id, pr_url: exec.pr_url, failed_checks: analysis.failedNames },
+        message: `Execution ${exec.id.slice(0, 8)} CI failed (mergeable_state=${mState}): ${analysis.failedNames.join(', ') || 'no failing check names'}`,
+        payload: { execution_id: exec.id, pr_url: exec.pr_url, failed_checks: analysis.failedNames, mergeable_state: mState },
       });
-      await bridgeFailure(exec.id, 'ci', `failing checks: ${analysis.failedNames.join(', ')}`);
+      await bridgeFailure(exec.id, 'ci', `mergeable_state=${mState}: ${analysis.failedNames.join(', ')}`);
       continue;
     }
 
-    // Passing → merge
+    // mState === 'clean' or 'unstable' → branch protection permits merge.
+    // 'unstable' means some non-required checks failed; we surface their
+    // names in the event payload but do not block the merge.
     await transitionStatus(s, exec.id, 'ci', 'merging');
     await emitOasisEvent({
       vtid: WATCHER_VTID,
       type: 'dev_autopilot.execution.ci_passed',
       source: 'dev-autopilot-watcher',
       status: 'success',
-      message: `Execution ${exec.id.slice(0, 8)} CI passed`,
-      payload: { execution_id: exec.id, pr_url: exec.pr_url, checks: prStatus.checks.length },
+      message: `Execution ${exec.id.slice(0, 8)} CI passed (mergeable_state=${mState})`,
+      payload: {
+        execution_id: exec.id,
+        pr_url: exec.pr_url,
+        checks: prStatus.checks.length,
+        mergeable_state: mState,
+        non_blocking_failures: analysis.failedNames,
+      },
     });
 
     // Defense-in-depth: check risk class one more time before auto-merging.


### PR DESCRIPTION
## Summary
- Autopilot CI watcher was blocking on ANY red check via `analyzeCiStatus` → `state='failing'`. Result: it failed PR #1230 (FB-040 smoke test) because `OASIS Persistence CI / Gateway Service Tests` is broken on main (and has been red on every recent main commit). Humans merge through it because branch protection marks the PR `mergeable_state='unstable'`.
- For a truly autonomous pipeline, autopilot must honor the same merge gate humans use: GitHub's `mergeable_state`.

## Logic
- `clean` / `unstable` → branch protection permits merge → proceed.
- `blocked` / `dirty` → fail.
- `unknown` / `has_hooks` / `behind` → wait.
- Non-required failures (the `unstable` path) still surface in the OASIS event payload as `non_blocking_failures`.

## Test plan
- [x] gateway build green
- [ ] Re-run FB-040 after deploy → PR #1230's pattern (red OASIS Persistence CI but otherwise green) should now merge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)