### PR TITLE
fix(visual-verify): drop overly-broad 'still pending' check (VTID-02695)

### DIFF
--- a/e2e/ci-visual-verify.ts
+++ b/e2e/ci-visual-verify.ts
@@ -33,7 +33,11 @@ const PAGES_TO_VERIFY = [
     name: 'self-healing',
     path: '/command-hub/infrastructure/self-healing/',
     mustContain: ['Self-Healing System'],
-    mustNotContain: ['still pending'],
+    // VTID-02695: 'still pending' was too broad — the page legitimately shows
+    // pending items (that's its job). Was failing every deploy on a normal
+    // operating condition. If a regression check is needed here, gate on a
+    // specific count threshold or a stuck-state indicator, not generic copy.
+    mustNotContain: [],
   },
   {
     name: 'services-health',


### PR DESCRIPTION
Single-line fix: removes overly-broad 'still pending' from forbidden text. Self-healing page legitimately shows pending items; the check has been false-failing every deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)