### PR TITLE
DEV-AUTOPILOT: Extract locale safely for persona greeting lookup

### DIFF
--- a/services/gateway/src/services/persona-registry.ts
+++ b/services/gateway/src/services/persona-registry.ts
@@ -98,11 +98,22 @@ export async function getPersonaVoice(key: string): Promise<string> {
   return reg.get(key)?.voice_id ?? '';
 }
 
+function extractLocale(langOrCtx: any): string {
+  let locale = 'en';
+  if (typeof langOrCtx === 'string' && langOrCtx.trim()) {
+    locale = langOrCtx.trim();
+  } else if (langOrCtx && typeof langOrCtx === 'object') {
+    locale = langOrCtx.user?.locale || langOrCtx.session?.language || 'en';
+  }
+  return (locale || 'en').split('-')[0].toLowerCase();
+}
+
 /**
  * Returns the persona's greeting in the requested language, falling
  * through `lang → 'en' → generic` so a missing language never hard-fails.
  */
-export async function getPersonaGreeting(key: string, lang: string): Promise<string> {
+export async function getPersonaGreeting(key: string, langOrCtx: any): Promise<string> {
+  const lang = extractLocale(langOrCtx);
   const reg = await loadPersonaRegistry();
   const p = reg.get(key);
   if (!p) return `Hi, ${key} here. How can I help?`;
@@ -281,9 +292,10 @@ export async function getPersonaVoiceForTenant(key: string, tenantId: string): P
  */
 export async function getPersonaGreetingForTenant(
   key: string,
-  lang: string,
+  langOrCtx: any,
   tenantId: string,
 ): Promise<string> {
+  const lang = extractLocale(langOrCtx);
   const reg = await loadPersonaRegistryForTenant(tenantId);
   const p = reg.get(key);
   if (!p) return `Hi, ${key} here. How can I help?`;


### PR DESCRIPTION
Fixes an issue where persona handoffs default to English even when the user's configured language is different. This was happening because a session/context object was being passed instead of a primitive locale string, resulting in an `"[object Object]"` key lookup against the greeting dictionary.

Changes:
- Added a private helper `extractLocale` to `services/gateway/src/services/persona-registry.ts`.
- `extractLocale` falls back to `user.locale` or `session.language` if a context object is passed, and normalizes the output (e.g., `de-DE` → `de`).
- Updated `getPersonaGreeting` and `getPersonaGreetingForTenant` to use the helper and type `langOrCtx: any` to match the real-world caller behavior without breaking.