### PR TITLE
DEV-AUTOPILOT: Enforce auth for telemetry routes modifying oasis_events

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,37 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+// Authentication middleware to secure oasis_events writes
+const requireAuth = async (req: Request, res: Response, next: NextFunction): Promise<any> => {
+  try {
+    let token: string | undefined;
+
+    const authHeader = req.headers.authorization;
+    if (authHeader && authHeader.startsWith("Bearer ")) {
+      token = authHeader.substring(7);
+    }
+
+    if (!token) {
+      return res.status(401).json({ error: "Unauthorized", detail: "Missing or invalid Authorization header" });
+    }
+
+    const { data, error } = await supabase.auth.getUser(token);
+
+    if (error || !data?.user) {
+      return res.status(401).json({ error: "Unauthorized", detail: "Invalid token" });
+    }
+
+    next();
+  } catch (err) {
+    console.error("Auth middleware error:", err);
+    return res.status(500).json({ error: "Internal server error during auth" });
+  }
+};
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +54,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +174,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,113 @@
+import request from "supertest";
+import express from "express";
+import { router } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+// Mock supabase client to intercept auth checks
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn()
+    }
+  }
+}));
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1/telemetry", router);
+
+describe("Telemetry Routes Authentication", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SUPABASE_URL = "http://localhost:8000";
+    process.env.SUPABASE_SERVICE_ROLE = "test-svc-key";
+    
+    // Mock global fetch for DB interactions
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+      text: async () => "ok"
+    });
+  });
+
+  const validPayload = {
+    vtid: "VT-123",
+    layer: "test-layer",
+    module: "test-module",
+    source: "test-source",
+    kind: "test.event",
+    status: "success",
+    title: "Test Event"
+  };
+
+  describe("POST /event", () => {
+    it("should return 401 when no token is provided", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validPayload);
+      
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+      expect(supabase.auth.getUser).not.toHaveBeenCalled();
+    });
+
+    it("should return 401 when invalid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: null },
+        error: { message: "Invalid token" }
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validPayload);
+      
+      expect(res.status).toBe(401);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("invalid-token");
+    });
+
+    it("should proceed and return 202 when valid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send(validPayload);
+      
+      expect(res.status).toBe(202);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("valid-token");
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+
+  describe("POST /batch", () => {
+    it("should return 401 when no token is provided", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send([validPayload]);
+      
+      expect(res.status).toBe(401);
+      expect(supabase.auth.getUser).not.toHaveBeenCalled();
+    });
+
+    it("should proceed and return 202 when valid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-token")
+        .send([validPayload]);
+      
+      expect(res.status).toBe(202);
+      expect(res.body).toHaveProperty("count", 1);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("valid-token");
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
**Context & Plan**
This PR addresses the `rls_gap` flagged by `rls-policy-scanner-v1` on the `oasis_events` table. Because modifying files under `supabase/migrations/` is out of scope for automated PR execution, this acts as the application-layer mitigation. 

We introduce an authentication middleware to the telemetry routes (`POST /event` and `POST /batch`) that write to `oasis_events`. The middleware enforces a valid Supabase session using `supabase.auth.getUser()`. If no valid token is present, it returns a 401 Unauthorized before proceeding to the service-role-backed database insert.

**Follow-up Action for Operator**: 
The database-level RLS migration must still be applied manually. You can execute:
```sql
ALTER TABLE public.oasis_events ENABLE ROW LEVEL SECURITY;
CREATE POLICY "allow_authenticated_insert" ON public.oasis_events FOR INSERT TO authenticated WITH CHECK (true);
CREATE POLICY "allow_authenticated_update" ON public.oasis_events FOR UPDATE TO authenticated USING (true);
REVOKE INSERT, UPDATE ON public.oasis_events FROM anon, public;
```