### PR TITLE
DEV-AUTOPILOT: Enforce auth for telemetry write endpoints

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,36 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+// Middleware to enforce Supabase session validity
+const requireAuthenticatedUser = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      return res.status(401).json({ error: "Unauthorized", detail: "Missing or invalid Authorization header" });
+    }
+
+    const token = authHeader.substring(7).trim();
+    if (!token) {
+      return res.status(401).json({ error: "Unauthorized", detail: "Missing token" });
+    }
+
+    const { data, error } = await supabase.auth.getUser(token);
+    
+    if (error || !data.user) {
+      return res.status(401).json({ error: "Unauthorized", detail: error?.message || "Invalid token" });
+    }
+
+    next();
+  } catch (err: any) {
+    console.error("Auth middleware error:", err);
+    return res.status(500).json({ error: "Internal server error", detail: "Authentication check failed" });
+  }
+};
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +53,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +173,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,131 @@
+import express from "express";
+import request from "supertest";
+import { router } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+// Mock Supabase
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+describe("Telemetry Routes Auth Enforcement", () => {
+  let app: express.Application;
+  let fetchSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    process.env.SUPABASE_SERVICE_ROLE = "test-svc-key";
+    process.env.SUPABASE_URL = "http://localhost:8000";
+    
+    // Mock global fetch to prevent actual network calls during tests
+    fetchSpy = jest.spyOn(global, "fetch").mockImplementation();
+
+    app = express();
+    app.use(express.json());
+    app.use("/api/v1/telemetry", router);
+  });
+
+  afterAll(() => {
+    fetchSpy.mockRestore();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const validPayload = {
+    vtid: "VTID-123",
+    layer: "app",
+    module: "test",
+    source: "test",
+    kind: "test.event",
+    status: "success",
+    title: "Test Event",
+  };
+
+  describe("POST /api/v1/telemetry/event", () => {
+    it("should return 401 when Authorization header is missing", async () => {
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validPayload);
+      
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe("Unauthorized");
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("should return 401 when Supabase token is invalid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: { message: "Invalid JWT" },
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validPayload);
+      
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe("Unauthorized");
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("should proceed and return 202 when token is valid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+      } as any);
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send(validPayload);
+      
+      expect(response.status).toBe(202);
+      expect(response.body.ok).toBe(true);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    const validBatch = [validPayload];
+
+    it("should return 401 when Authorization header is missing", async () => {
+      const response = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send(validBatch);
+      
+      expect(response.status).toBe(401);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("should return 202 when token is valid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      fetchSpy.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+      } as any);
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-token")
+        .send(validBatch);
+      
+      expect(response.status).toBe(202);
+      expect(response.body.ok).toBe(true);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
**Summary:**
This PR closes the `rls_gap` identified for `oasis_events` writes via telemetry endpoints. It adds application-level enforcement of Supabase authentication via the `Authorization: Bearer <token>` header for both `POST /event` and `POST /batch`. 

**Details:**
- **Added `requireAuthenticatedUser` middleware** to `services/gateway/src/routes/telemetry.ts`.
- Validates token against Supabase using `supabase.auth.getUser()`.
- Unauthenticated requests are blocked with a `401 Unauthorized`.
- Applied exclusively to mutation endpoints (`/event`, `/batch`), keeping `/snapshot` and `/health` accessible.
- Created `services/gateway/test/routes/telemetry.test.ts` to assert that correct responses are returned for authenticated vs unauthenticated scenarios.

**Out of scope:**
As requested, database migrations enabling actual RLS and row policies for `oasis_events` are omitted. Those must be executed manually by the operator.