### PR TITLE
DEV-AUTOPILOT: Add auth middleware to telemetry write endpoints

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,32 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+export const requireAuthenticatedUser = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      res.status(401).json({ error: "Unauthorized", detail: "Missing or invalid Authorization header" });
+      return;
+    }
+    
+    const token = authHeader.split(" ")[1];
+    const { data, error } = await supabase.auth.getUser(token);
+    
+    if (error || !data?.user) {
+      res.status(401).json({ error: "Unauthorized", detail: "Invalid session token" });
+      return;
+    }
+    
+    next();
+  } catch (e: any) {
+    res.status(500).json({ error: "Internal server error", detail: e.message });
+  }
+};
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +49,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +169,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,142 @@
+import express from "express";
+import request from "supertest";
+import { router } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+// Mock the supabase client
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+// Mock devhub to avoid SSE broadcast errors in tests
+jest.mock("../../src/routes/devhub", () => ({
+  broadcastEvent: jest.fn(),
+}), { virtual: true });
+
+// Mock fetch
+global.fetch = jest.fn() as jest.Mock;
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1/telemetry", router);
+
+describe("Telemetry Routes Auth Enforcement", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SUPABASE_SERVICE_ROLE = "test-key";
+    process.env.SUPABASE_URL = "http://test-url";
+  });
+
+  describe("POST /api/v1/telemetry/event", () => {
+    const validPayload = {
+      vtid: "123",
+      layer: "test-layer",
+      module: "test-module",
+      source: "test-source",
+      kind: "test-kind",
+      status: "success",
+      title: "test-title",
+    };
+
+    it("should return 401 if no Authorization header is provided", async () => {
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validPayload);
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe("Unauthorized");
+      expect(supabase.auth.getUser).not.toHaveBeenCalled();
+    });
+
+    it("should return 401 if Authorization header is invalid", async () => {
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "InvalidToken")
+        .send(validPayload);
+
+      expect(response.status).toBe(401);
+    });
+
+    it("should return 401 if supabase.auth.getUser returns error", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: new Error("Invalid token"),
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer bad-token")
+        .send(validPayload);
+
+      expect(response.status).toBe(401);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("bad-token");
+    });
+
+    it("should proceed and return 202 if user is authenticated", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "user-1" } },
+        error: null,
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send(validPayload);
+
+      expect(response.status).toBe(202);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("valid-token");
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    const validPayload = [
+      {
+        vtid: "123",
+        layer: "test-layer",
+        module: "test-module",
+        source: "test-source",
+        kind: "test-kind",
+        status: "success",
+        title: "test-title",
+      },
+    ];
+
+    it("should return 401 if no Authorization header is provided", async () => {
+      const response = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send(validPayload);
+
+      expect(response.status).toBe(401);
+    });
+
+    it("should proceed and return 202 if user is authenticated", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "user-1" } },
+        error: null,
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ([]),
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-token")
+        .send(validPayload);
+
+      expect(response.status).toBe(202);
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses the `rls_gap` flagged by `rls-policy-scanner-v1` for the `oasis_events` table. 

While the database-level RLS enablement will be handled via a manual migration, this PR adds the necessary application-level security by enforcing authentication on API routes that write to `oasis_events`.

- Added `requireAuthenticatedUser` middleware in `services/gateway/src/routes/telemetry.ts`.
- Extracts `Authorization: Bearer <token>` header and verifies it via `supabase.auth.getUser()`.
- Rejects unauthenticated requests with HTTP 401.
- Applied the middleware to `POST /event` and `POST /batch`.
- Added comprehensive unit tests in `services/gateway/test/routes/telemetry.test.ts` to ensure appropriate auth enforcement.