### PR TITLE
DEV-AUTOPILOT: Secure telemetry writes with auth middleware

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,7 +1,8 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
 
@@ -24,9 +25,46 @@ const TelemetryEventSchema = z.object({
 
 type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
+/**
+ * Require valid Supabase authentication to proceed
+ */
+export const requireAuth = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    let token = "";
+    const authHeader = req.headers.authorization;
+
+    if (authHeader && authHeader.startsWith("Bearer ")) {
+      token = authHeader.substring(7); // Extract token after "Bearer "
+    } else if (req.headers.cookie) {
+      const cookies = req.headers.cookie.split(";").map((c) => c.trim());
+      const sbCookie = cookies.find((c) => c.startsWith("sb-access-token=") || c.includes("-auth-token="));
+      if (sbCookie) {
+        token = sbCookie.substring(sbCookie.indexOf("=") + 1);
+      }
+    }
+
+    if (!token) {
+      return res.status(401).json({ error: "Unauthorized", detail: "Missing authentication token" });
+    }
+
+    const { data, error } = await supabase.auth.getUser(token);
+
+    if (error || !data?.user) {
+      return res.status(401).json({ error: "Unauthorized", detail: "Invalid token" });
+    }
+
+    // Attach user information to request for downstream handlers if needed
+    (req as any).user = data.user;
+    next();
+  } catch (err: any) {
+    console.error("Auth middleware error:", err);
+    return res.status(500).json({ error: "Internal server error", detail: err.message });
+  }
+};
+
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +184,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,153 @@
+import request from "supertest";
+import express from "express";
+import { router } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+// Mock dependencies
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("../../src/routes/devhub", () => ({
+  broadcastEvent: jest.fn(),
+}), { virtual: true });
+
+// Mock global fetch
+global.fetch = jest.fn();
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1/telemetry", router);
+
+describe("Telemetry Routes Auth Enforcement", () => {
+  beforeAll(() => {
+    // Silence expected logs/errors during tests
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SUPABASE_SERVICE_ROLE = "mock-service-role";
+    process.env.SUPABASE_URL = "http://mock-supabase.local";
+  });
+
+  const validPayload = {
+    vtid: "VTID-123",
+    layer: "core",
+    module: "test",
+    source: "jest",
+    kind: "test.event",
+    status: "info",
+    title: "Test Event",
+  };
+
+  describe("POST /api/v1/telemetry/event", () => {
+    it("should return 401 if no authorization token is provided", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validPayload);
+      
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+    });
+
+    it("should return 401 if provided token is invalid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: null },
+        error: { message: "Invalid token" },
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validPayload);
+      
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+    });
+
+    it("should proceed (202 Accepted) if token is valid and DB insert succeeds", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send(validPayload);
+      
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    it("should return 401 if no authorization token is provided", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send([validPayload]);
+      
+      expect(res.status).toBe(401);
+    });
+
+    it("should return 401 if provided token is invalid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: null },
+        error: { message: "Invalid token" },
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer invalid-token")
+        .send([validPayload]);
+      
+      expect(res.status).toBe(401);
+    });
+
+    it("should proceed (202 Accepted) if token is valid and DB batch insert succeeds", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-token")
+        .send([validPayload]);
+      
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+
+  describe("GET /api/v1/telemetry/health", () => {
+    it("should remain publicly accessible", async () => {
+      const res = await request(app).get("/api/v1/telemetry/health");
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
**Context & Finding**
The scanner `rls-policy-scanner-v1` flagged a medium-risk security gap because `oasis_events` lacks RLS policies, meaning anyone with direct DB access can bypass application logic. While the strict database migration to enforce RLS will be applied manually by a developer (per constraints preventing automated migration edits), this PR addresses the application-layer vulnerability.

**Changes in this PR**
1. **Added `requireAuth` Middleware**: Telemetry endpoints that write to `oasis_events` now require a valid Supabase authentication token via the `Authorization` header or Supabase auth cookies.
2. **Applied Middleware to Routes**: Secured the `POST /api/v1/telemetry/event` and `POST /api/v1/telemetry/batch` endpoints.
3. **Unit Tests**: Added `telemetry.test.ts` to assert that unauthenticated requests receive a 401 Unauthorized response, while requests with a valid token successfully proceed to write.

**Operator Note**
Please execute the corresponding manual database migration to fully enable RLS and add policies restricting INSERT/UPDATE on the `oasis_events` table to `authenticated` users, mirroring the pattern in incident #845.