### PR TITLE
DEV-AUTOPILOT: Add paramLimit middleware to mitigate Express ReDoS CVE

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,44 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // 1. Validate based on Express req.params (for when middleware runs inline/post-matching)
+    const keys = Object.keys(req.params || {});
+    
+    if (keys.length > maxParams) {
+      res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    for (const key of keys) {
+      const value = req.params[key];
+      if (typeof value === 'string' && value.length > maxLength) {
+        res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    // 2. Validate raw path to protect against ReDoS before route matching occurs.
+    // Uses RegExp only for safe extraction, avoiding vulnerable path-to-regexp backtracking.
+    const rawPath = req.path || '';
+    const segmentRegex = /[^/]+/g;
+    let match;
+    let segmentCount = 0;
+
+    while ((match = segmentRegex.exec(rawPath)) !== null) {
+      segmentCount++;
+      if (match[0].length > maxLength) {
+        res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    // Allow some extra segments for static base paths (e.g., /api/v1/resource)
+    if (segmentCount > maxParams + 5) {
+      res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,20 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply CVE mitigation middleware to limit path parameters
+router.use(limitPathParams());
+
+router.get('/:projectId', (req: Request, res: Response) => {
+  res.status(200).json({ project: req.params.projectId });
+});
+
+router.post('/:projectId/members/:memberId', (req: Request, res: Response) => {
+  res.status(200).json({ 
+    project: req.params.projectId, 
+    member: req.params.memberId 
+  });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply CVE mitigation middleware to limit path parameters
+router.use(limitPathParams());
+
+router.get('/:id', (req: Request, res: Response) => {
+  res.status(200).json({ user: req.params.id });
+});
+
+router.put('/:id', (req: Request, res: Response) => {
+  res.status(200).json({ updated: req.params.id });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,95 @@
+import express, { Request, Response, NextFunction } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE-202X Mitigation - paramLimit Middleware', () => {
+  describe('Unit Test', () => {
+    it('should call next() if params are within limits', () => {
+      const req = { params: { a: '1', b: '2' }, path: '/1/2' } as unknown as Request;
+      const res = {} as Response;
+      const next = jest.fn() as NextFunction;
+
+      const middleware = limitPathParams(5, 200);
+      middleware(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+    });
+
+    it('should return 400 if there are more than 5 params in req.params', () => {
+      const req = { 
+        params: { a: '1', b: '2', c: '3', d: '4', e: '5', f: '6' }, 
+        path: '/1/2/3/4/5/6' 
+      } as unknown as Request;
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn()
+      } as unknown as Response;
+      const next = jest.fn() as NextFunction;
+
+      const middleware = limitPathParams(5, 200);
+      middleware(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Too many path parameters or parameter too long' });
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Integration Test', () => {
+    let app: express.Application;
+
+    beforeEach(() => {
+      app = express();
+      
+      // Global application simulates router.use() prior to matched parameters
+      app.use(limitPathParams(5, 200));
+
+      // Inline application ensures req.params limits are strictly enforced on matched routes
+      app.get('/resource/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req, res) => {
+        res.status(200).json({ success: true });
+      });
+
+      app.get('/resource/:a', limitPathParams(5, 200), (req, res) => {
+        res.status(200).json({ success: true });
+      });
+
+      app.get('/valid/route', (req, res) => {
+        res.status(200).json({ success: true });
+      });
+    });
+
+    it('should return 400 quickly when >5 path parameters are passed (triggering limit)', async () => {
+      const start = Date.now();
+      const response = await request(app).get('/resource/1/2/3/4/5/6');
+      const duration = Date.now() - start;
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe('Too many path parameters or parameter too long');
+      // Assert short response time to prove absence of catastrophic backtracking hang
+      expect(duration).toBeLessThan(200); 
+    });
+
+    it('should return 400 quickly when a path segment triggers length limit', async () => {
+      const longParam = 'a'.repeat(201);
+      const start = Date.now();
+      const response = await request(app).get(`/resource/${longParam}`);
+      const duration = Date.now() - start;
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe('Too many path parameters or parameter too long');
+      expect(duration).toBeLessThan(200);
+    });
+
+    it('should pass normal request with <=5 parameters', async () => {
+      const response = await request(app).get('/resource/1');
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+    });
+
+    it('should pass normal request without path parameters', async () => {
+      const response = await request(app).get('/valid/route');
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
This PR introduces the `paramLimit` middleware to mitigate a Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (< 0.1.13) used by Express. Attackers can trigger catastrophic backtracking and CPU exhaustion by sending requests with excessive or overly long path parameters.

As dependency updates to `package.json` are handled separately, this PR implements server-side validation to reduce the attack surface. 

**Changes:**
1. Created `paramLimit.ts` middleware that validates both `req.params` (for inline/post-match use) and the raw `req.path` segments (to protect the Express router before the vulnerable regex execution happens).
2. Applied the middleware to `userRoutes.ts` and `projectRoutes.ts` to demonstrate usage.
3. Added extensive unit and integration tests under `test/cve-mitigation.test.ts` to ensure 400 rejection and fast response times (<200ms) during malicious payloads.

**Note for Operator:** 
- Due to restricted file access scope, `userRoutes.ts` and `projectRoutes.ts` were created/modified as reference implementations. Please ensure this middleware is applied to **all** actual route files in `services/gateway/src/routes/` that contain path parameters.
- Be sure to wire up any newly created example route files into the main Express application (`app.ts` / `server.ts`) if they did not exist previously.
- Remember to pursue the final `path-to-regexp` / `express` dependency update in a follow-up PR.