### PR TITLE
DEV-AUTOPILOT: Expose system controls via Gateway API

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,22 @@
+import { Router, Request, Response } from 'express';
+import { getSystemControl } from '../services/system-controls';
+
+const router = Router();
+
+router.get('/:key', async (req: Request, res: Response) => {
+  try {
+    const { key } = req.params;
+    const control = await getSystemControl(key);
+
+    if (!control) {
+      return res.status(404).json({ error: 'System control not found' });
+    }
+
+    return res.json(control);
+  } catch (error) {
+    console.error(`Error fetching system control for key ${req.params.key}:`, error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router;

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,20 @@
+import { supabase } from '../lib/supabase';
+import { SystemControl } from '../types/system-controls';
+
+export async function getSystemControl(key: string): Promise<SystemControl | null> {
+  const { data, error } = await supabase
+    .from('system_controls')
+    .select('*')
+    .eq('key', key)
+    .single();
+
+  if (error) {
+    // PGRST116 is Supabase's code for "no rows returned" when using .single()
+    if (error.code === 'PGRST116') {
+      return null;
+    }
+    throw error;
+  }
+
+  return data as SystemControl;
+}

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at?: string;
+  updated_by?: string;
+  reason?: string;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,47 @@
+import express from 'express';
+import request from 'supertest';
+import systemControlsRouter from '../../src/routes/system-controls';
+import { getSystemControl } from '../../src/services/system-controls';
+
+jest.mock('../../src/services/system-controls');
+
+const app = express();
+app.use(express.json());
+app.use('/api/system-controls', systemControlsRouter);
+
+describe('System Controls Routes', () => {
+  const mockedGetSystemControl = getSystemControl as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return 200 and the control data if found', async () => {
+    const mockData = { key: 'vitana_did_you_know_enabled', enabled: true };
+    mockedGetSystemControl.mockResolvedValue(mockData);
+
+    const response = await request(app).get('/api/system-controls/vitana_did_you_know_enabled');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockData);
+    expect(mockedGetSystemControl).toHaveBeenCalledWith('vitana_did_you_know_enabled');
+  });
+
+  it('should return 404 if control not found', async () => {
+    mockedGetSystemControl.mockResolvedValue(null);
+
+    const response = await request(app).get('/api/system-controls/non_existent');
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'System control not found' });
+  });
+
+  it('should return 500 on service error', async () => {
+    mockedGetSystemControl.mockRejectedValue(new Error('Internal database error'));
+
+    const response = await request(app).get('/api/system-controls/error_key');
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: 'Internal server error' });
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,66 @@
+import { getSystemControl } from '../src/services/system-controls';
+import { supabase } from '../src/lib/supabase';
+
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+describe('System Controls Service', () => {
+  const mockSupabase = supabase as jest.Mocked<typeof supabase>;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return a system control when found', async () => {
+    const mockData = { key: 'vitana_did_you_know_enabled', enabled: true };
+    const selectMock = jest.fn().mockReturnThis();
+    const eqMock = jest.fn().mockReturnThis();
+    const singleMock = jest.fn().mockResolvedValue({ data: mockData, error: null });
+
+    mockSupabase.from.mockReturnValue({
+      select: selectMock,
+      eq: eqMock,
+      single: singleMock,
+    } as any);
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('system_controls');
+    expect(selectMock).toHaveBeenCalledWith('*');
+    expect(eqMock).toHaveBeenCalledWith('key', 'vitana_did_you_know_enabled');
+    expect(singleMock).toHaveBeenCalled();
+    expect(result).toEqual(mockData);
+  });
+
+  it('should return null when not found (PGRST116)', async () => {
+    const selectMock = jest.fn().mockReturnThis();
+    const eqMock = jest.fn().mockReturnThis();
+    const singleMock = jest.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } });
+
+    mockSupabase.from.mockReturnValue({
+      select: selectMock,
+      eq: eqMock,
+      single: singleMock,
+    } as any);
+
+    const result = await getSystemControl('non_existent');
+    expect(result).toBeNull();
+  });
+
+  it('should throw on unexpected database errors', async () => {
+    const selectMock = jest.fn().mockReturnThis();
+    const eqMock = jest.fn().mockReturnThis();
+    const singleMock = jest.fn().mockResolvedValue({ data: null, error: { code: 'OTHER', message: 'DB Error' } });
+
+    mockSupabase.from.mockReturnValue({
+      select: selectMock,
+      eq: eqMock,
+      single: singleMock,
+    } as any);
+
+    await expect(getSystemControl('error_key')).rejects.toEqual({ code: 'OTHER', message: 'DB Error' });
+  });
+});


### PR DESCRIPTION
This PR introduces a new endpoint to the Gateway API for querying system control flags, specifically to support the `vitana_did_you_know_enabled` flag targeted by a recent database migration. 

**Changes included:**
- `services/gateway/src/types/system-controls.ts`: Types for the system control record.
- `services/gateway/src/services/system-controls.ts`: Service to fetch a single system control from Supabase by key.
- `services/gateway/src/routes/system-controls.ts`: Express router exposing `GET /api/system-controls/:key`.
- Accompanying unit tests for both the service and the route.

**Operator Follow-up:**
*Missing File Note:* The original plan intended to update the frontend (command-hub) to consume this new endpoint and conditionally render the "Did You Know?" tour. However, the exact frontend file path was unknown and thus excluded from the locked plan. An operator will need to follow up with a frontend commit to trigger the `fetch('/api/system-controls/vitana_did_you_know_enabled')` call inside the `command-hub` app.