### PR TITLE
DEV-AUTOPILOT: Add API endpoint to fetch system controls by key

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,22 @@
+import { Router, Request, Response } from 'express';
+import { getSystemControl } from '../services/system-controls';
+
+const router = Router();
+
+router.get('/:key', async (req: Request, res: Response) => {
+  try {
+    const { key } = req.params;
+    const control = await getSystemControl(key);
+
+    if (!control) {
+      return res.status(404).json({ error: 'System control not found' });
+    }
+
+    return res.status(200).json(control);
+  } catch (error) {
+    console.error(`Error fetching system control ${req.params.key}:`, error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router;

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,20 @@
+import { supabase } from '../lib/supabase';
+import { SystemControl } from '../types/system-controls';
+
+export async function getSystemControl(key: string): Promise<SystemControl | null> {
+  const { data, error } = await supabase
+    .from('system_controls')
+    .select('*')
+    .eq('key', key)
+    .single();
+
+  if (error) {
+    if (error.code === 'PGRST116') {
+      // PGRST116 occurs when .single() returns exactly 0 rows
+      return null;
+    }
+    throw new Error(`Failed to fetch system control: ${error.message}`);
+  }
+
+  return data as SystemControl;
+}

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at?: string;
+  updated_by?: string;
+  reason?: string;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,45 @@
+import request from 'supertest';
+import express from 'express';
+import systemControlsRouter from '../../src/routes/system-controls';
+import * as systemControlsService from '../../src/services/system-controls';
+
+jest.mock('../../src/services/system-controls');
+
+const app = express();
+app.use(express.json());
+app.use('/api/system-controls', systemControlsRouter);
+
+describe('System Controls Routes', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('GET /api/system-controls/:key returns 200 and the control if found', async () => {
+    const mockControl = { key: 'vitana_did_you_know_enabled', enabled: true };
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(mockControl);
+
+    const response = await request(app).get('/api/system-controls/vitana_did_you_know_enabled');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockControl);
+    expect(systemControlsService.getSystemControl).toHaveBeenCalledWith('vitana_did_you_know_enabled');
+  });
+
+  it('GET /api/system-controls/:key returns 404 if control does not exist', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(null);
+
+    const response = await request(app).get('/api/system-controls/unknown_key');
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'System control not found' });
+  });
+
+  it('GET /api/system-controls/:key returns 500 on internal service error', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockRejectedValue(new Error('Test error'));
+
+    const response = await request(app).get('/api/system-controls/error_key');
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: 'Internal server error' });
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,53 @@
+import { getSystemControl } from '../src/services/system-controls';
+import { supabase } from '../src/lib/supabase';
+
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+describe('System Controls Service', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns a system control when found', async () => {
+    const mockData = { key: 'vitana_did_you_know_enabled', enabled: true };
+    const singleMock = jest.fn().mockResolvedValue({ data: mockData, error: null });
+    const eqMock = jest.fn().mockReturnValue({ single: singleMock });
+    const selectMock = jest.fn().mockReturnValue({ eq: eqMock });
+    (supabase.from as jest.Mock).mockReturnValue({ select: selectMock });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+
+    expect(supabase.from).toHaveBeenCalledWith('system_controls');
+    expect(selectMock).toHaveBeenCalledWith('*');
+    expect(eqMock).toHaveBeenCalledWith('key', 'vitana_did_you_know_enabled');
+    expect(singleMock).toHaveBeenCalled();
+    expect(result).toEqual(mockData);
+  });
+
+  it('returns null when control is not found (PGRST116 error)', async () => {
+    const singleMock = jest.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } });
+    const eqMock = jest.fn().mockReturnValue({ single: singleMock });
+    const selectMock = jest.fn().mockReturnValue({ eq: eqMock });
+    (supabase.from as jest.Mock).mockReturnValue({ select: selectMock });
+
+    const result = await getSystemControl('unknown_key');
+
+    expect(result).toBeNull();
+  });
+
+  it('throws an error on unexpected database errors', async () => {
+    const singleMock = jest.fn().mockResolvedValue({ 
+      data: null, 
+      error: { message: 'Database connection failed', code: 'XYZ' } 
+    });
+    const eqMock = jest.fn().mockReturnValue({ single: singleMock });
+    const selectMock = jest.fn().mockReturnValue({ eq: eqMock });
+    (supabase.from as jest.Mock).mockReturnValue({ select: selectMock });
+
+    await expect(getSystemControl('error_key')).rejects.toThrow('Failed to fetch system control: Database connection failed');
+  });
+});


### PR DESCRIPTION
This PR adds a Gateway API endpoint to query backend feature flags from the `system_controls` Supabase table. Specifically, this supports the `vitana_did_you_know_enabled` feature flag required by the "Did You Know?" tour.

## Changes
- Created `SystemControl` type definition.
- Added `getSystemControl` service logic integrating with the existing Supabase client to fetch a system control by its key.
- Created an Express route for `GET /api/system-controls/:key`.
- Added unit tests for both the service and the route.

## Missing Files for Operator Follow-up
The plan identified that we need to update the `command-hub` frontend to call `GET /api/system-controls/vitana_did_you_know_enabled` on mount and use it to conditionally render the tour. Since the exact path to the `command-hub` components managing the tour was unknown and not included in the locked file list, the frontend change was **omitted**. An operator will need to add the client-side fetch call in `command-hub` to complete this feature.