### PR TITLE
DEV-AUTOPILOT: Enforce authentication for telemetry events (oasis_events)

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,41 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+// Middleware to enforce authentication
+const requireAuthenticatedUser = async (req: Request, res: Response, next: NextFunction) => {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    res.status(401).json({
+      error: "Unauthorized",
+      detail: "Missing or invalid Authorization header",
+    });
+    return;
+  }
+
+  const token = authHeader.substring(7);
+  try {
+    const { data, error } = await supabase.auth.getUser(token);
+    if (error || !data?.user) {
+      res.status(401).json({
+        error: "Unauthorized",
+        detail: "Invalid or expired token",
+      });
+      return;
+    }
+    next();
+  } catch (e: any) {
+    res.status(401).json({
+      error: "Unauthorized",
+      detail: "Token verification failed",
+    });
+    return;
+  }
+};
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +58,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +178,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,101 @@
+import request from "supertest";
+import express from "express";
+import { router } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+// Mock the supabase client
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+// Mock the devhub broadcast to avoid errors related to dynamic requires
+jest.mock("../../src/routes/devhub", () => ({
+  broadcastEvent: jest.fn(),
+}), { virtual: true });
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1/telemetry", router);
+
+describe("Telemetry Routes Auth Enforcement", () => {
+  const validEvent = {
+    vtid: "VTID-123",
+    layer: "layer1",
+    module: "mod1",
+    source: "src1",
+    kind: "test.event",
+    status: "success",
+    title: "Test Event",
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    
+    // Mock global fetch for actual supabase rest call inside route handler
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+      text: async () => "",
+    });
+    
+    process.env.SUPABASE_URL = "http://localhost:8000";
+    process.env.SUPABASE_SERVICE_ROLE = "test-service-role-key";
+  });
+
+  describe("POST /api/v1/telemetry/event", () => {
+    it("returns 401 when no token is provided", async () => {
+      const res = await request(app).post("/api/v1/telemetry/event").send(validEvent);
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+    });
+
+    it("returns 401 when an invalid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({ data: { user: null }, error: { message: "Invalid token" } });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validEvent);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("invalid-token");
+    });
+
+    it("returns 202 when a valid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({ data: { user: { id: "user-123" } }, error: null });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send(validEvent);
+
+      expect(res.status).toBe(202);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("valid-token");
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    it("returns 401 when no token is provided", async () => {
+      const res = await request(app).post("/api/v1/telemetry/batch").send([validEvent]);
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+    });
+
+    it("returns 202 when a valid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({ data: { user: { id: "user-123" } }, error: null });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-token")
+        .send([validEvent]);
+
+      expect(res.status).toBe(202);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("valid-token");
+    });
+  });
+});


### PR DESCRIPTION
Fixes a medium-risk `rls_gap` flagged by `rls-policy-scanner-v1` on the `oasis_events` table writes. 
This PR enforces application-level authentication for the `POST /api/v1/telemetry/event` and `/batch` endpoints to prevent unauthenticated database writes prior to applying database-level RLS.

Plan executed:
1. Added `requireAuthenticatedUser` middleware to `services/gateway/src/routes/telemetry.ts` which uses `supabase.auth.getUser()` to validate session tokens.
2. Applied the middleware to the `/event` and `/batch` POST routes to ensure only authenticated users can insert records into `oasis_events`.
3. Created unit tests in `services/gateway/test/routes/telemetry.test.ts` mocking `getUser` and validating both authorized and unauthorized request behavior.

*Note: The corresponding RLS database migration for `oasis_events` must be manually applied by developers per automated environment rules.*