### PR TITLE
DEV-AUTOPILOT: Refactor admin-notifications auth to use requireAdmin

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -12,49 +12,17 @@
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/auth';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIFICATIONS';
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
+router.use(requireAdmin);
 
 // ── POST /compose — Send notification to user(s) ────────────
 
 router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -138,6 +106,7 @@ router.post('/compose', async (req: Request, res: Response) => {
 
     // Determine effective tenant_id for dispatching
     const effectiveTenantId = tenant_id || (recipient_ids?.length === 1 ? undefined : undefined);
+    const userEmail = (req as any).user?.email || 'admin';
 
     // For single recipients, use synchronous dispatch for immediate feedback
     if (targetUserIds.length === 1) {
@@ -148,7 +117,7 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      console.log(`[${VTID}] Composed notification for 1 user by ${userEmail}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +130,7 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${userEmail}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -177,9 +146,6 @@ router.post('/compose', async (req: Request, res: Response) => {
 // ── GET /sent — Admin notification log ──────────────────────
 
 router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -224,9 +190,6 @@ router.get('/sent', async (req: Request, res: Response) => {
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
 router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,135 @@
+import request from 'supertest';
+import express, { Request, Response, NextFunction } from 'express';
+import adminNotificationsRouter from '../../src/routes/admin-notifications';
+
+// Mock auth middleware
+jest.mock('../../src/middleware/auth', () => ({
+  requireAdmin: jest.fn((req: Request, res: Response, next: NextFunction) => {
+    (req as any).user = { id: 'admin-id', email: 'admin@test.com' };
+    next();
+  })
+}));
+
+// Mock variables for Supabase chain
+let mockResolveValues: any[] = [];
+
+const createMockChain = () => {
+  const chain: any = {
+    select: jest.fn(() => chain),
+    eq: jest.fn(() => chain),
+    gte: jest.fn(() => chain),
+    order: jest.fn(() => chain),
+    range: jest.fn(() => chain),
+    or: jest.fn(() => chain),
+    not: jest.fn(() => chain),
+    then: jest.fn((resolve) => {
+      const val = mockResolveValues.shift() || { data: [], error: null, count: 0 };
+      resolve(val);
+    })
+  };
+  return chain;
+};
+
+const mockSupabase = {
+  from: jest.fn(() => createMockChain())
+};
+
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn(() => mockSupabase)
+}));
+
+// Mock Notification Service
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn().mockResolvedValue({ success: true }),
+  notifyUsersAsync: jest.fn().mockResolvedValue(true)
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/admin-notifications', adminNotificationsRouter);
+
+describe('Admin Notifications Router', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockResolveValues = [];
+  });
+
+  describe('POST /compose', () => {
+    it('should return 400 if title or body are missing', async () => {
+      const res = await request(app)
+        .post('/admin-notifications/compose')
+        .send({ recipient_ids: ['user-1'] });
+      expect(res.status).toBe(400);
+      expect(res.body.message).toBe('title and body are required');
+    });
+
+    it('should send a notification to a single user', async () => {
+      mockResolveValues = [{ data: [], error: null }];
+      
+      const res = await request(app)
+        .post('/admin-notifications/compose')
+        .send({
+          recipient_ids: ['user-1'],
+          title: 'Test Title',
+          body: 'Test Body'
+        });
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.sent_to).toBe(1);
+    });
+
+    it('should send notifications to multiple users via role', async () => {
+      // Mock lookup response for role
+      mockResolveValues = [
+        { data: [{ user_id: 'user-1' }, { user_id: 'user-2' }], error: null }
+      ];
+      
+      const res = await request(app)
+        .post('/admin-notifications/compose')
+        .send({
+          recipient_role: 'community',
+          tenant_id: 'tenant-1',
+          title: 'Role Test',
+          body: 'Role Body'
+        });
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.sent_to).toBe(2);
+    });
+  });
+
+  describe('GET /sent', () => {
+    it('should fetch sent notifications', async () => {
+      mockResolveValues = [
+        { data: [{ id: 'notif-1', type: 'test' }], count: 1, error: null }
+      ];
+
+      const res = await request(app).get('/admin-notifications/sent?limit=10&offset=0');
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.total).toBe(1);
+    });
+  });
+
+  describe('GET /preferences/stats', () => {
+    it('should fetch preference statistics', async () => {
+      // 1. preferences query
+      // 2. notification count query
+      // 3. read count query
+      mockResolveValues = [
+        { data: [{ push_enabled: true }, { push_enabled: false }], error: null },
+        { count: 100, error: null },
+        { count: 45, error: null }
+      ];
+
+      const res = await request(app).get('/admin-notifications/preferences/stats');
+      expect(res.status).toBe(200);
+      expect(res.body.stats.total_users_with_prefs).toBe(2);
+      expect(res.body.stats.push_enabled).toBe(1);
+      expect(res.body.stats.push_disabled).toBe(1);
+      expect(res.body.delivery.total_sent_30d).toBe(100);
+      expect(res.body.delivery.total_read_30d).toBe(45);
+      expect(res.body.delivery.read_rate).toBe(45); // (45 / 100) * 100
+    });
+  });
+});


### PR DESCRIPTION
This pull request refactors the `admin-notifications.ts` route file to use the shared standard `requireAdmin` middleware instead of custom, inline authentication logic. This resolves missing authentication scanner flags while standardizing how admin identity is verified.

Changes included:
- Imported and applied `requireAdmin` middleware from `../middleware/auth` to the whole router.
- Removed the local `verifyExafyAdmin` and `getBearerToken` helper functions.
- Removed dependencies directly interfacing with user auth extraction (`createUserSupabaseClient`).
- Replaced custom auth results and console log formats to directly access `req.user.email`.
- Created `admin-notifications.test.ts` to implement unit testing with Jest for these newly structured endpoints.