### PR TITLE
DEV-AUTOPILOT: Add system-controls API endpoint for DYK tour flag

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,21 @@
+import { Router, Request, Response } from 'express';
+import { getSystemControl } from '../services/system-controls';
+
+const router = Router();
+
+router.get('/:key', async (req: Request, res: Response) => {
+  try {
+    const { key } = req.params;
+    const control = await getSystemControl(key);
+
+    if (!control) {
+      return res.status(404).json({ error: 'System control not found' });
+    }
+
+    return res.status(200).json(control);
+  } catch (error) {
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router;

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,23 @@
+import { supabase } from '../lib/supabase';
+import { SystemControl } from '../types/system-controls';
+
+export async function getSystemControl(key: string): Promise<SystemControl | null> {
+  const { data, error } = await supabase
+    .from('system_controls')
+    .select('*')
+    .eq('key', key)
+    .single();
+
+  if (error) {
+    if (error.code === 'PGRST116') {
+      return null;
+    }
+    return null;
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  return data as SystemControl;
+}

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at?: string;
+  updated_by?: string;
+  reason?: string;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,45 @@
+import request from 'supertest';
+import express from 'express';
+import systemControlsRouter from '../../src/routes/system-controls';
+import { getSystemControl } from '../../src/services/system-controls';
+
+jest.mock('../../src/services/system-controls');
+
+const app = express();
+app.use(express.json());
+app.use('/api/system-controls', systemControlsRouter);
+
+describe('GET /api/system-controls/:key', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 200 and the control if found', async () => {
+    const mockControl = { key: 'vitana_did_you_know_enabled', enabled: true };
+    (getSystemControl as jest.Mock).mockResolvedValue(mockControl);
+
+    const response = await request(app).get('/api/system-controls/vitana_did_you_know_enabled');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockControl);
+    expect(getSystemControl).toHaveBeenCalledWith('vitana_did_you_know_enabled');
+  });
+
+  it('returns 404 if control not found', async () => {
+    (getSystemControl as jest.Mock).mockResolvedValue(null);
+
+    const response = await request(app).get('/api/system-controls/missing_key');
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'System control not found' });
+  });
+
+  it('returns 500 on service error', async () => {
+    (getSystemControl as jest.Mock).mockRejectedValue(new Error('DB Error'));
+
+    const response = await request(app).get('/api/system-controls/error_key');
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: 'Internal server error' });
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,52 @@
+import { getSystemControl } from '../src/services/system-controls';
+import { supabase } from '../src/lib/supabase';
+
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+describe('getSystemControl', () => {
+  let selectMock: jest.Mock;
+  let eqMock: jest.Mock;
+  let singleMock: jest.Mock;
+
+  beforeEach(() => {
+    singleMock = jest.fn();
+    eqMock = jest.fn().mockReturnValue({ single: singleMock });
+    selectMock = jest.fn().mockReturnValue({ eq: eqMock });
+
+    (supabase.from as jest.Mock).mockReturnValue({ select: selectMock });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns system control if found', async () => {
+    const mockData = { key: 'vitana_did_you_know_enabled', enabled: true };
+    singleMock.mockResolvedValue({ data: mockData, error: null });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+    
+    expect(supabase.from).toHaveBeenCalledWith('system_controls');
+    expect(selectMock).toHaveBeenCalledWith('*');
+    expect(eqMock).toHaveBeenCalledWith('key', 'vitana_did_you_know_enabled');
+    expect(result).toEqual(mockData);
+  });
+
+  it('returns null if not found (PGRST116)', async () => {
+    singleMock.mockResolvedValue({ data: null, error: { code: 'PGRST116' } });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+    expect(result).toBeNull();
+  });
+
+  it('returns null on other errors', async () => {
+    singleMock.mockResolvedValue({ data: null, error: { message: 'Some error' } });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
This PR adds the gateway API components required to expose system control flags to the frontend, specifically supporting the `vitana_did_you_know_enabled` flag toggled in migration `20260425100000_BOOTSTRAP_dyk_flag_on.sql`.

It introduces:
- A `SystemControl` type definition.
- A service layer to fetch system controls dynamically from the `system_controls` Supabase table.
- An Express route exposing `GET /api/system-controls/:key`.
- Accompanying unit tests for both the service and the route.

**Note for Operator:** The original plan indicated an update to the frontend application (`services/gateway/src/frontend/command-hub/...`) to query this new endpoint on mount and conditionally render the "Did You Know?" tour. Because the specific frontend file path was unknown and thus not locked, the frontend modification was omitted from this PR. Please follow up by integrating the API call into the relevant command-hub React component or state store.