### PR TITLE
DEV-AUTOPILOT: Enforce authentication on telemetry write routes

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,33 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+// Auth middleware to enforce application-level checks for telemetry writes
+export async function requireAuthenticatedUser(req: Request, res: Response, next: NextFunction) {
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      return res.status(401).json({ error: "Unauthorized", detail: "Missing or invalid Authorization header" });
+    }
+
+    const token = authHeader.split(" ")[1];
+    const { data, error } = await supabase.auth.getUser(token);
+
+    if (error || !data?.user) {
+      return res.status(401).json({ error: "Unauthorized", detail: "Invalid session token" });
+    }
+
+    // User is authenticated, proceed
+    next();
+  } catch (e) {
+    console.error("❌ Auth middleware error:", e);
+    return res.status(500).json({ error: "Internal server error during authentication" });
+  }
+}
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +50,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +170,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,146 @@
+import express from 'express';
+import request from 'supertest';
+import { router } from '../../src/routes/telemetry';
+import { supabase } from '../../src/lib/supabase';
+
+jest.mock('../../src/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+// Mock devhub broadcasting to prevent unhandled requirements
+jest.mock('../../src/routes/devhub', () => ({
+  broadcastEvent: jest.fn(),
+}), { virtual: true });
+
+describe('Telemetry Routes Auth Enforcement', () => {
+  let app: express.Express;
+  const originalFetch = global.fetch;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api/v1/telemetry', router);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SUPABASE_URL = 'http://mock-supabase-url';
+    process.env.SUPABASE_SERVICE_ROLE = 'mock-service-role-key';
+
+    // Prevent network calls during tests
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+        text: () => Promise.resolve(''),
+      } as any)
+    );
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  const validEvent = {
+    vtid: "test-vtid",
+    layer: "test-layer",
+    module: "test-module",
+    source: "test-source",
+    kind: "test.event",
+    status: "success",
+    title: "Test Event"
+  };
+
+  describe('POST /event', () => {
+    it('returns 401 when no Authorization header is provided', async () => {
+      const res = await request(app)
+        .post('/api/v1/telemetry/event')
+        .send(validEvent);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe('Unauthorized');
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 when an invalid token is provided', async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: { message: 'Invalid token' }
+      });
+
+      const res = await request(app)
+        .post('/api/v1/telemetry/event')
+        .set('Authorization', 'Bearer invalid-token')
+        .send(validEvent);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe('Unauthorized');
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('returns 202 when a valid token is provided and persists the event', async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: 'user-123' } },
+        error: null
+      });
+
+      const res = await request(app)
+        .post('/api/v1/telemetry/event')
+        .set('Authorization', 'Bearer valid-token')
+        .send(validEvent);
+
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('POST /batch', () => {
+    it('returns 401 when no Authorization header is provided', async () => {
+      const res = await request(app)
+        .post('/api/v1/telemetry/batch')
+        .send([validEvent]);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe('Unauthorized');
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 when an invalid token is provided', async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: { message: 'Invalid token' }
+      });
+
+      const res = await request(app)
+        .post('/api/v1/telemetry/batch')
+        .set('Authorization', 'Bearer invalid-token')
+        .send([validEvent]);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe('Unauthorized');
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('returns 202 when a valid token is provided and persists the batch', async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: 'user-123' } },
+        error: null
+      });
+
+      const res = await request(app)
+        .post('/api/v1/telemetry/batch')
+        .set('Authorization', 'Bearer valid-token')
+        .send([validEvent]);
+
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.count).toBe(1);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
**Context & Finding:**
The `rls-policy-scanner-v1` flagged `supabase/migrations/20251209000000_add_task_stage.sql` as a medium-risk `rls_gap` because the `oasis_events` table does not have RLS enabled with a strict policy, exposing it to direct, unauthenticated SQL access.

**Action Taken:**
While the database-level RLS policy must be created manually to respect directory modification constraints, this PR secures the application layer. It introduces an Express middleware (`requireAuthenticatedUser`) in the telemetry API to extract Supabase tokens and reject unauthenticated telemetry events from being written to the database via API.

**Files Touched:**
- `services/gateway/src/routes/telemetry.ts`: Added auth middleware and bound it to `POST /event` and `POST /batch`.
- `services/gateway/test/routes/telemetry.test.ts`: Created unit tests verifying HTTP 401 returns for invalid or missing tokens, and HTTP 202 accepts for authenticated requests.

**Next Steps (Out of scope for this PR):**
- Create a manual database migration to enforce RLS locally at the Supabase layer:
```sql
ALTER TABLE public.oasis_events ENABLE ROW LEVEL SECURITY;
CREATE POLICY "allow_authenticated_insert" ON public.oasis_events FOR INSERT TO authenticated WITH CHECK (true);
CREATE POLICY "allow_authenticated_update" ON public.oasis_events FOR UPDATE TO authenticated USING (true);
REVOKE INSERT, UPDATE ON public.oasis_events FROM anon, public;
```