### PR TITLE
DEV-AUTOPILOT: Enforce auth on oasis_events telemetry writes

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,32 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+// Middleware to require authentication via Supabase
+const requireAuth = async (req: Request, res: Response, next: NextFunction) => {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    res.status(401).json({ error: "Unauthorized", detail: "Missing or invalid authorization header" });
+    return;
+  }
+
+  const token = authHeader.split(" ")[1];
+  try {
+    const { data, error } = await supabase.auth.getUser(token);
+    if (error || !data?.user) {
+      res.status(401).json({ error: "Unauthorized", detail: "Invalid session token" });
+      return;
+    }
+    next();
+  } catch (e: any) {
+    res.status(401).json({ error: "Unauthorized", detail: "Error verifying session" });
+    return;
+  }
+};
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +49,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +169,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,142 @@
+import express from "express";
+import request from "supertest";
+import { router } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+// Mock supabase
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+// Mock devhub to avoid runtime errors during require()
+jest.mock("../../src/routes/devhub", () => ({
+  broadcastEvent: jest.fn(),
+}), { virtual: true });
+
+// Mock fetch
+const mockFetch = jest.fn();
+global.fetch = mockFetch as any;
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1/telemetry", router);
+
+describe("Telemetry Routes Authentication", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SUPABASE_SERVICE_ROLE = "mock-service-role";
+    process.env.SUPABASE_URL = "http://mock-supabase-url";
+  });
+
+  describe("POST /api/v1/telemetry/event", () => {
+    const validPayload = {
+      vtid: "VTID-001",
+      layer: "app",
+      module: "auth",
+      source: "client",
+      kind: "login",
+      status: "success",
+      title: "User logged in",
+    };
+
+    it("should return 401 when no authorization header is provided", async () => {
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validPayload);
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe("Unauthorized");
+    });
+
+    it("should return 401 when authorization header is invalid", async () => {
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Invalid Token")
+        .send(validPayload);
+
+      expect(response.status).toBe(401);
+    });
+
+    it("should return 401 when Supabase getUser returns error", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: new Error("Invalid token"),
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validPayload);
+
+      expect(response.status).toBe(401);
+    });
+
+    it("should return 202 when user is authenticated", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send(validPayload);
+
+      expect(response.status).toBe(202);
+      expect(response.body.ok).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    const validPayload = [
+      {
+        vtid: "VTID-001",
+        layer: "app",
+        module: "auth",
+        source: "client",
+        kind: "login",
+        status: "success",
+        title: "User logged in",
+      }
+    ];
+
+    it("should return 401 when no authorization header is provided", async () => {
+      const response = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send(validPayload);
+
+      expect(response.status).toBe(401);
+    });
+
+    it("should return 202 when user is authenticated", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-token")
+        .send(validPayload);
+
+      expect(response.status).toBe(202);
+      expect(response.body.ok).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
This PR secures the telemetry endpoints that write to `oasis_events` by introducing application-level authentication checks, resolving the medium-risk RLS gap detected by `rls-policy-scanner-v1`.

### Changes:
- Added `requireAuth` middleware in `services/gateway/src/routes/telemetry.ts` which verifies Supabase session tokens via `supabase.auth.getUser()`.
- Applied the middleware to the `POST /event` and `POST /batch` endpoints to prevent unauthenticated telemetry inserts.
- Created `services/gateway/test/routes/telemetry.test.ts` to verify unauthorized requests are rejected and authorized requests proceed.

### Action Required: Database Migration (Out of Scope)
The automated executor cannot modify files in `supabase/migrations/`. A developer must manually create the following database migration (e.g., `supabase/migrations/20251215000000_enable_rls_oasis_events.sql`) to enable Row-Level Security on the database layer:

```sql
ALTER TABLE public.oasis_events ENABLE ROW LEVEL SECURITY;
CREATE POLICY "allow_authenticated_insert" ON public.oasis_events
 FOR INSERT TO authenticated WITH CHECK (true);
CREATE POLICY "allow_authenticated_update" ON public.oasis_events
 FOR UPDATE TO authenticated USING (true);
REVOKE INSERT, UPDATE ON public.oasis_events FROM anon, public;
```