### PR TITLE
DEV-AUTOPILOT: Use standard requireAdmin middleware in admin-notifications

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -12,49 +12,17 @@
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/auth';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIFICATIONS';
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
+router.use(requireAdmin);
 
 // ── POST /compose — Send notification to user(s) ────────────
 
 router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -138,6 +106,7 @@ router.post('/compose', async (req: Request, res: Response) => {
 
     // Determine effective tenant_id for dispatching
     const effectiveTenantId = tenant_id || (recipient_ids?.length === 1 ? undefined : undefined);
+    const adminEmail = (req as any).user?.email || 'admin';
 
     // For single recipients, use synchronous dispatch for immediate feedback
     if (targetUserIds.length === 1) {
@@ -148,7 +117,7 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      console.log(`[${VTID}] Composed notification for 1 user by ${adminEmail}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +130,7 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${adminEmail}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -177,9 +146,6 @@ router.post('/compose', async (req: Request, res: Response) => {
 // ── GET /sent — Admin notification log ──────────────────────
 
 router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -224,9 +190,6 @@ router.get('/sent', async (req: Request, res: Response) => {
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
 router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,155 @@
+import request from 'supertest';
+import express from 'express';
+import adminNotificationsRouter from '../../src/routes/admin-notifications';
+import { getSupabase } from '../../src/lib/supabase';
+import { notifyUser, notifyUsersAsync } from '../../src/services/notification-service';
+
+jest.mock('../../src/middleware/auth', () => ({
+  requireAdmin: jest.fn((req, res, next) => {
+    req.user = { id: 'admin-id', email: 'admin@test.com' };
+    next();
+  })
+}));
+
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn()
+}));
+
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn(),
+  notifyUsersAsync: jest.fn()
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/admin/notifications', adminNotificationsRouter);
+
+describe('Admin Notifications API', () => {
+  const mockSupabase = {
+    from: jest.fn()
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+  });
+
+  describe('POST /compose', () => {
+    it('should validate required fields', async () => {
+      const response = await request(app)
+        .post('/admin/notifications/compose')
+        .send({});
+
+      expect(response.status).toBe(400);
+      expect(response.body.message).toBe('title and body are required');
+    });
+
+    it('should send notification to specific user IDs', async () => {
+      (notifyUser as jest.Mock).mockResolvedValue({ success: true });
+
+      const response = await request(app)
+        .post('/admin/notifications/compose')
+        .send({
+          title: 'Test Title',
+          body: 'Test Body',
+          recipient_ids: ['user-1']
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body.sent_to).toBe(1);
+      expect(notifyUser).toHaveBeenCalledWith(
+        'user-1',
+        '',
+        'welcome_to_vitana',
+        { title: 'Test Title', body: 'Test Body', data: undefined },
+        mockSupabase
+      );
+    });
+
+    it('should send notifications to all users with a role in a tenant', async () => {
+      const mockQuery: any = {
+        select: jest.fn().mockReturnThis()
+      };
+      mockQuery.eq = jest.fn().mockImplementation((field, value) => {
+        if (field === 'active_role') {
+          return Promise.resolve({ data: [{ user_id: 'user-2' }, { user_id: 'user-3' }] });
+        }
+        return mockQuery;
+      });
+
+      mockSupabase.from.mockReturnValue(mockQuery);
+
+      const response = await request(app)
+        .post('/admin/notifications/compose')
+        .send({
+          title: 'Role Test',
+          body: 'Role Body',
+          recipient_role: 'community',
+          tenant_id: 'tenant-1'
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body.sent_to).toBe(2);
+      expect(notifyUsersAsync).toHaveBeenCalledWith(
+        ['user-2', 'user-3'],
+        'tenant-1',
+        'welcome_to_vitana',
+        { title: 'Role Test', body: 'Role Body', data: undefined },
+        mockSupabase
+      );
+    });
+  });
+
+  describe('GET /sent', () => {
+    it('should return sent notifications', async () => {
+      const mockQuery = {
+        select: jest.fn().mockReturnThis(),
+        gte: jest.fn().mockReturnThis(),
+        order: jest.fn().mockReturnThis(),
+        range: jest.fn().mockResolvedValue({ data: [{ id: 'notif-1' }], count: 1 })
+      };
+      mockSupabase.from.mockReturnValue(mockQuery);
+
+      const response = await request(app)
+        .get('/admin/notifications/sent');
+
+      expect(response.status).toBe(200);
+      expect(response.body.data).toHaveLength(1);
+      expect(response.body.total).toBe(1);
+    });
+  });
+
+  describe('GET /preferences/stats', () => {
+    it('should return preference statistics', async () => {
+      const mockPrefsQuery = {
+        select: jest.fn().mockResolvedValue({ data: [{ push_enabled: true }, { push_enabled: false }] })
+      };
+
+      const mockGte = jest.fn().mockImplementation(() => {
+        const promise = Promise.resolve({ count: 50 });
+        (promise as any).not = jest.fn().mockResolvedValue({ count: 20 });
+        return promise;
+      });
+
+      const mockNotifsQuery = {
+        select: jest.fn().mockReturnThis(),
+        gte: mockGte
+      };
+
+      mockSupabase.from.mockImplementation((table) => {
+        if (table === 'user_notification_preferences') return mockPrefsQuery;
+        if (table === 'user_notifications') return mockNotifsQuery;
+      });
+
+      const response = await request(app)
+        .get('/admin/notifications/preferences/stats');
+
+      expect(response.status).toBe(200);
+      expect(response.body.ok).toBe(true);
+      expect(response.body.stats.total_users_with_prefs).toBe(2);
+      expect(response.body.delivery.total_sent_30d).toBe(50);
+      expect(response.body.delivery.total_read_30d).toBe(20);
+      expect(response.body.delivery.read_rate).toBe(40);
+    });
+  });
+});


### PR DESCRIPTION
**Summary:**
This PR replaces the custom inline authentication logic (`verifyExafyAdmin`) in `admin-notifications.ts` with the project's standard `requireAdmin` middleware. This resolves the missing authentication flagged by `route-auth-scanner-v1` and ensures consistent admin auth enforcement across routes.

**Changes:**
- Removed `getBearerToken` and `verifyExafyAdmin` functions from `admin-notifications.ts`.
- Inserted `router.use(requireAdmin)` to uniformly secure all endpoints.
- Replaced references to the local auth check with `req.user.email` (from the standard middleware payload) in log statements.
- Added comprehensive unit tests in `admin-notifications.test.ts` to mock the shared middleware and validate endpoint behavior.