### PR TITLE
DEV-AUTOPILOT: Refactor admin-notifications to use requireAdmin middleware

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -12,49 +12,17 @@
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/auth';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIFICATIONS';
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
+router.use(requireAdmin);
 
 // ── POST /compose — Send notification to user(s) ────────────
 
 router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -148,7 +116,8 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      const userEmail = (req as any).user?.email || 'unknown';
+      console.log(`[${VTID}] Composed notification for 1 user by ${userEmail}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +130,8 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    const userEmail = (req as any).user?.email || 'unknown';
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${userEmail}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -177,9 +147,6 @@ router.post('/compose', async (req: Request, res: Response) => {
 // ── GET /sent — Admin notification log ──────────────────────
 
 router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -224,9 +191,6 @@ router.get('/sent', async (req: Request, res: Response) => {
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
 router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,118 @@
+import request from 'supertest';
+import express from 'express';
+import adminNotificationsRouter from '../../src/routes/admin-notifications';
+import { getSupabase } from '../../src/lib/supabase';
+import { notifyUser, notifyUsersAsync } from '../../src/services/notification-service';
+
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn(),
+}));
+
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn(),
+  notifyUsersAsync: jest.fn(),
+}));
+
+jest.mock('../../src/middleware/auth', () => ({
+  requireAdmin: jest.fn((req, res, next) => {
+    req.user = { id: 'admin-id', email: 'admin@test.com' };
+    next();
+  }),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/admin/notifications', adminNotificationsRouter);
+
+describe('Admin Notifications Route', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('POST /compose', () => {
+    it('should compose a notification for a single user', async () => {
+      const mockSupabase = {
+        from: jest.fn(),
+      };
+      (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+      (notifyUser as jest.Mock).mockResolvedValue({ id: 'notif-id' });
+
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({
+          title: 'Test',
+          body: 'Test Body',
+          recipient_ids: ['user-1'],
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(notifyUser).toHaveBeenCalledWith(
+        'user-1',
+        '',
+        'welcome_to_vitana',
+        { title: 'Test', body: 'Test Body', data: undefined },
+        mockSupabase
+      );
+    });
+
+    it('should require title and body', async () => {
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({
+          recipient_ids: ['user-1'],
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('INVALID_INPUT');
+    });
+  });
+
+  describe('GET /sent', () => {
+    it('should return sent notifications', async () => {
+      const mockSupabase = {
+        from: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        gte: jest.fn().mockReturnThis(),
+        order: jest.fn().mockReturnThis(),
+        range: jest.fn().mockResolvedValue({ data: [{ id: 'notif-1' }], error: null, count: 1 }),
+      };
+      (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+
+      const res = await request(app).get('/admin/notifications/sent');
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.data).toHaveLength(1);
+    });
+  });
+
+  describe('GET /preferences/stats', () => {
+    it('should return preference stats', async () => {
+      (getSupabase as jest.Mock).mockReturnValue({
+        from: jest.fn((table) => {
+          const chain: any = {
+            select: jest.fn().mockReturnThis(),
+            eq: jest.fn().mockReturnThis(),
+            gte: jest.fn().mockReturnThis(),
+            not: jest.fn().mockReturnThis(),
+          };
+          chain.then = function (cb: any) {
+            if (table === 'user_notification_preferences') {
+              return Promise.resolve({ data: [{ push_enabled: true }], error: null }).then(cb);
+            }
+            return Promise.resolve({ count: 10, error: null }).then(cb);
+          };
+          return chain;
+        })
+      });
+
+      const res = await request(app).get('/admin/notifications/preferences/stats');
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.stats.total_users_with_prefs).toBe(1);
+      expect(res.body.delivery.total_sent_30d).toBe(10);
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses missing authentication findings flagged by `route-auth-scanner-v1`. 

Instead of relying on inline custom authentication functions (`getBearerToken` and `verifyExafyAdmin`), the `admin-notifications.ts` route now implements the standard shared `requireAdmin` middleware. 

**Changes included:**
- Removed inline `verifyExafyAdmin` and token extraction logic.
- Applied `router.use(requireAdmin)` for consistent, centrally managed auth.
- Updated user identity references for logging to use `req.user.email` attached by middleware.
- Created unit tests (`admin-notifications.test.ts`) that mock the new middleware and verify endpoint behaviors.

**Files touched:**
- `services/gateway/src/routes/admin-notifications.ts`
- `services/gateway/test/routes/admin-notifications.test.ts`