### PR TITLE
DEV-AUTOPILOT: Secure telemetry routes with API-level auth middleware

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,7 +1,8 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
 
@@ -24,9 +25,48 @@ const TelemetryEventSchema = z.object({
 
 type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
+/**
+ * Middleware to enforce authentication on routes that modify oasis_events.
+ * Verifies the Supabase session token from the Authorization header.
+ */
+const requireAuthenticatedUser = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const authHeader = req.headers.authorization;
+    let token: string | undefined;
+
+    if (authHeader && authHeader.startsWith("Bearer ")) {
+      token = authHeader.split(" ")[1];
+    }
+
+    if (!token) {
+      return res.status(401).json({
+        error: "Unauthorized",
+        detail: "Missing or invalid Authorization header",
+      });
+    }
+
+    const { data, error } = await supabase.auth.getUser(token);
+
+    if (error || !data?.user) {
+      return res.status(401).json({
+        error: "Unauthorized",
+        detail: "Invalid session token",
+      });
+    }
+
+    next();
+  } catch (e: any) {
+    console.error("❌ Auth middleware error:", e);
+    return res.status(500).json({
+      error: "Internal server error",
+      detail: "Auth verification failed",
+    });
+  }
+};
+
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +186,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,116 @@
+import request from "supertest";
+import express from "express";
+import { router } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+// Mock the Supabase client
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+// Mock the global fetch object
+const mockFetch = jest.fn();
+global.fetch = mockFetch as any;
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1/telemetry", router);
+
+describe("Telemetry Routes Authentication", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SUPABASE_SERVICE_ROLE = "test-service-key";
+    process.env.SUPABASE_URL = "http://localhost:8000";
+  });
+
+  const validEvent = {
+    vtid: "VT-123",
+    layer: "test-layer",
+    module: "test-module",
+    source: "test-source",
+    kind: "test.event",
+    status: "success",
+    title: "Test Event",
+  };
+
+  describe("POST /api/v1/telemetry/event", () => {
+    it("should return 401 when no token is provided", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validEvent);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+    });
+
+    it("should return 401 when an invalid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: new Error("Invalid token"),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid_token")
+        .send(validEvent);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+    });
+
+    it("should return 202 when a valid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid_token")
+        .send(validEvent);
+
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    it("should return 401 when no token is provided", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send([validEvent]);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+    });
+
+    it("should return 202 when a valid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid_token")
+        .send([validEvent]);
+
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
**Context & Issue:**
The `rls-policy-scanner-v1` flagged `oasis_events` for missing Row-Level Security (RLS) policies, allowing unauthenticated writes at the database level. While the long-term fix requires a manual database migration to enable RLS (out of scope for automated execution), this PR introduces an immediate API-level mitigation.

**Changes:**
1. Adds `requireAuthenticatedUser` middleware in `services/gateway/src/routes/telemetry.ts`.
2. This middleware extracts the Supabase session token from the `Authorization: Bearer <token>` header, verifies it via `supabase.auth.getUser()`, and rejects unauthenticated requests with a `401 Unauthorized` status.
3. Applies the middleware to the telemetry ingestion routes (`POST /event` and `POST /batch`) that write to the `oasis_events` table.
4. Adds full unit test coverage for the new authentication enforcement in `services/gateway/test/routes/telemetry.test.ts`.

**Follow-up:**
An operator must manually create and apply the database migration enabling RLS and enforcing `INSERT` restrictions to authenticated users for `oasis_events`.