### PR TITLE
DEV-AUTOPILOT: Enforce auth checks for telemetry writes to oasis_events

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,32 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+const requireAuthenticatedUser = async (req: Request, res: Response, next: NextFunction) => {
+  const authHeader = req.headers.authorization;
+  if (!authHeader) {
+    return res.status(401).json({ error: "Unauthorized", detail: "Missing Authorization header" });
+  }
+
+  const token = authHeader.replace(/^Bearer\s+/i, "").trim();
+  if (!token) {
+    return res.status(401).json({ error: "Unauthorized", detail: "Invalid Authorization header" });
+  }
+
+  try {
+    const { data, error } = await supabase.auth.getUser(token);
+    if (error || !data?.user) {
+      return res.status(401).json({ error: "Unauthorized", detail: error?.message || "Invalid token" });
+    }
+    next();
+  } catch (e: any) {
+    return res.status(500).json({ error: "Internal server error", detail: "Auth verification failed" });
+  }
+};
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +49,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +169,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,141 @@
+import request from "supertest";
+import express from "express";
+import { router } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("../../src/routes/devhub", () => ({
+  broadcastEvent: jest.fn(),
+}));
+
+// Mock global fetch for Supabase HTTP requests
+global.fetch = jest.fn() as jest.Mock;
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1/telemetry", router);
+
+describe("Telemetry Routes", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SUPABASE_URL = "http://localhost:8000";
+    process.env.SUPABASE_SERVICE_ROLE = "test-svc-key";
+  });
+
+  describe("POST /api/v1/telemetry/event", () => {
+    const validPayload = {
+      vtid: "VT-123",
+      layer: "app",
+      module: "test",
+      source: "tester",
+      kind: "test.event",
+      status: "success",
+      title: "Test Event",
+    };
+
+    it("should return 401 if no Authorization header is provided", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validPayload);
+      
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+      expect(res.body.detail).toBe("Missing Authorization header");
+    });
+
+    it("should return 401 if getUser returns an error", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: null },
+        error: { message: "Invalid token" },
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validPayload);
+      
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+      expect(res.body.detail).toBe("Invalid token");
+    });
+
+    it("should return 401 if token is empty after Bearer", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer ")
+        .send(validPayload);
+      
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+    });
+
+    it("should proceed and return 202 if user is authenticated", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send(validPayload);
+      
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    const validPayload = [{
+      vtid: "VT-123",
+      layer: "app",
+      module: "test",
+      source: "tester",
+      kind: "test.event",
+      status: "success",
+      title: "Test Event",
+    }];
+
+    it("should return 401 if no Authorization header is provided", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send(validPayload);
+      
+      expect(res.status).toBe(401);
+    });
+
+    it("should proceed and return 202 if user is authenticated", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-token")
+        .send(validPayload);
+      
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
**Context & Issue:**
The `oasis_events` table lacks Row-Level Security (RLS) enforcement, leaving it exposed to direct, unauthenticated SQL access, flagged by `rls-policy-scanner-v1`. Since the execution scope prohibits direct modification of `supabase/migrations/` files via the automation tool, we are applying the requisite application-level authentication gating as a precursor/complementary layer.

**Changes in this PR:**
1. Created an Express middleware (`requireAuthenticatedUser`) in `services/gateway/src/routes/telemetry.ts` that explicitly demands and validates a Supabase JWT from the `Authorization: Bearer <token>` header against `supabase.auth.getUser()`.
2. Applied this middleware to the `POST /event` and `POST /batch` endpoints to prevent any unauthenticated insertions.
3. Added unit tests in `services/gateway/test/routes/telemetry.test.ts` to ensure unauthenticated requests yield a `401 Unauthorized` and authenticated valid requests succeed.

**Developer Follow-up (Out of Scope):**
- You MUST manually create a new Supabase migration (e.g., `20251215000000_enable_rls_oasis_events.sql`) to strictly enable RLS on the `oasis_events` table and enforce INSERT/UPDATE for `authenticated` users only.