### PR TITLE
DEV-AUTOPILOT: Enforce auth middleware on telemetry write endpoints

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,32 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+// Middleware to require authentication for write operations
+export const requireAuthenticatedUser = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      return res.status(401).json({ error: "Unauthorized", detail: "Missing or invalid Authorization header" });
+    }
+    
+    const token = authHeader.split(" ")[1];
+    const { data, error } = await supabase.auth.getUser(token);
+    
+    if (error || !data?.user) {
+      return res.status(401).json({ error: "Unauthorized", detail: "Invalid session token" });
+    }
+    
+    next();
+  } catch (err: any) {
+    console.error("❌ Auth middleware error:", err);
+    return res.status(500).json({ error: "Internal server error", detail: "Authentication check failed" });
+  }
+};
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +49,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +169,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,146 @@
+import express from "express";
+import request from "supertest";
+import { router } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+// Mock the supabase client for auth verification
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn()
+    }
+  }
+}));
+
+// Mock global fetch for OASIS database inserts
+global.fetch = jest.fn();
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1/telemetry", router);
+
+describe("Telemetry Routes Auth Enforcement", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SUPABASE_SERVICE_ROLE = "test-service-key";
+    process.env.SUPABASE_URL = "http://test-supabase-url.com";
+  });
+
+  describe("POST /api/v1/telemetry/event", () => {
+    const validPayload = {
+      vtid: "VTID-TEST",
+      layer: "test-layer",
+      module: "test-module",
+      source: "test-source",
+      kind: "test.event",
+      status: "success",
+      title: "Test Event"
+    };
+
+    it("should return 401 if Authorization header is missing", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validPayload);
+      
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should return 401 if session token is invalid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: new Error("Invalid token")
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validPayload);
+      
+      expect(res.status).toBe(401);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("invalid-token");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should return 202 if session token is valid and insert succeeds", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "test-user-id" } },
+        error: null
+      });
+
+      // Mock the OASIS db insert successful response
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({})
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send(validPayload);
+      
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("valid-token");
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    const validBatchPayload = [{
+      vtid: "VTID-TEST-1",
+      layer: "test-layer",
+      module: "test-module",
+      source: "test-source",
+      kind: "test.event.1",
+      status: "success",
+      title: "Test Event 1"
+    }];
+
+    it("should return 401 if Authorization header is missing", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send(validBatchPayload);
+      
+      expect(res.status).toBe(401);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should return 401 if session token is invalid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: new Error("Invalid token")
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer bad-token")
+        .send(validBatchPayload);
+      
+      expect(res.status).toBe(401);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should return 202 if session token is valid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "test-user-id" } },
+        error: null
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ([{}])
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer good-token")
+        .send(validBatchPayload);
+      
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
**Fixes RLS Gap in `oasis_events` Table (Application Layer)**

This PR adds application-level authentication checks to the telemetry API routes (`/api/v1/telemetry/event` and `/batch`) that write to the `oasis_events` table. 

As flagged by `rls-policy-scanner-v1`, `oasis_events` lacks RLS policies blocking unauthenticated access. While the final fix requires a database migration to enable RLS directly, this PR secures the API pathway immediately by ensuring only authenticated requests with a valid Supabase session token can push telemetry events.

Changes:
- Added `requireAuthenticatedUser` middleware using `supabase.auth.getUser()`.
- Applied middleware to POST `/event` and POST `/batch`.
- Added unit tests validating HTTP 401 on missing/invalid tokens and HTTP 202 on successful authentication.

*Note for Operators: Please run the corresponding database-level RLS migration manually as outlined in the issue.*