### PR TITLE
DEV-AUTOPILOT: Refactor admin-notifications to use shared requireAdmin

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -12,49 +12,17 @@
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/auth';
 
 const router = Router();
+router.use(requireAdmin);
+
 const VTID = 'ADMIN-NOTIFICATIONS';
-
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
 
 // ── POST /compose — Send notification to user(s) ────────────
 
 router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -139,6 +107,8 @@ router.post('/compose', async (req: Request, res: Response) => {
     // Determine effective tenant_id for dispatching
     const effectiveTenantId = tenant_id || (recipient_ids?.length === 1 ? undefined : undefined);
 
+    const userEmail = (req as any).user?.email || 'unknown';
+
     // For single recipients, use synchronous dispatch for immediate feedback
     if (targetUserIds.length === 1) {
       const result = await notifyUser(
@@ -148,7 +118,7 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      console.log(`[${VTID}] Composed notification for 1 user by ${userEmail}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +131,7 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${userEmail}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -177,9 +147,6 @@ router.post('/compose', async (req: Request, res: Response) => {
 // ── GET /sent — Admin notification log ──────────────────────
 
 router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -224,9 +191,6 @@ router.get('/sent', async (req: Request, res: Response) => {
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
 router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,183 @@
+import request from 'supertest';
+import express from 'express';
+import adminNotificationsRouter from '../../src/routes/admin-notifications';
+import { getSupabase } from '../../src/lib/supabase';
+import { notifyUser, notifyUsersAsync } from '../../src/services/notification-service';
+
+// Mock dependencies
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn()
+}));
+
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn(),
+  notifyUsersAsync: jest.fn()
+}));
+
+jest.mock('../../src/middleware/auth', () => ({
+  requireAdmin: jest.fn((req, res, next) => {
+    req.user = { id: 'admin-id', email: 'admin@test.com' };
+    next();
+  })
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/admin/notifications', adminNotificationsRouter);
+
+describe('Admin Notifications Routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('POST /compose', () => {
+    it('returns 400 if title or body is missing', async () => {
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ recipient_ids: ['user1'] });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('INVALID_INPUT');
+    });
+
+    it('returns 400 if no recipients specified', async () => {
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ title: 'T', body: 'B' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('INVALID_INPUT');
+    });
+
+    it('returns 500 if Supabase is unavailable', async () => {
+      (getSupabase as jest.Mock).mockReturnValue(null);
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ title: 'T', body: 'B', recipient_ids: ['u1'] });
+      expect(res.status).toBe(500);
+      expect(res.body.error).toBe('SUPABASE_UNAVAILABLE');
+    });
+
+    it('successfully dispatches a notification to one user', async () => {
+      (getSupabase as jest.Mock).mockReturnValue({});
+      (notifyUser as jest.Mock).mockResolvedValue({ success: true });
+
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ title: 'T', body: 'B', recipient_ids: ['u1'] });
+      
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.sent_to).toBe(1);
+      expect(notifyUser).toHaveBeenCalledWith(
+        'u1',
+        '',
+        'welcome_to_vitana',
+        { title: 'T', body: 'B', data: undefined },
+        {}
+      );
+    });
+
+    it('successfully dispatches notifications to multiple users', async () => {
+      (getSupabase as jest.Mock).mockReturnValue({});
+      
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ title: 'T', body: 'B', recipient_ids: ['u1', 'u2'] });
+      
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.sent_to).toBe(2);
+      expect(notifyUsersAsync).toHaveBeenCalledWith(
+        ['u1', 'u2'],
+        '',
+        'welcome_to_vitana',
+        { title: 'T', body: 'B', data: undefined },
+        {}
+      );
+    });
+  });
+
+  describe('GET /sent', () => {
+    it('returns sent notifications', async () => {
+      const mockQuery = {
+        select: jest.fn().mockReturnThis(),
+        gte: jest.fn().mockReturnThis(),
+        order: jest.fn().mockReturnThis(),
+        range: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        or: jest.fn().mockReturnThis(),
+        then: jest.fn(cb => cb({ data: [{ id: 'n1' }], count: 1, error: null }))
+      };
+
+      (getSupabase as jest.Mock).mockReturnValue({
+        from: jest.fn().mockReturnValue(mockQuery)
+      });
+
+      const res = await request(app)
+        .get('/admin/notifications/sent')
+        .query({ type: 'test', user_id: 'u1', search: 'hello' });
+      
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.total).toBe(1);
+    });
+
+    it('handles query errors gracefully', async () => {
+      const mockQuery = {
+        select: jest.fn().mockReturnThis(),
+        gte: jest.fn().mockReturnThis(),
+        order: jest.fn().mockReturnThis(),
+        range: jest.fn().mockReturnThis(),
+        then: jest.fn(cb => cb({ data: null, count: null, error: { message: 'db error' } }))
+      };
+
+      (getSupabase as jest.Mock).mockReturnValue({
+        from: jest.fn().mockReturnValue(mockQuery)
+      });
+
+      const res = await request(app).get('/admin/notifications/sent');
+      expect(res.status).toBe(500);
+      expect(res.body.error).toBe('db error');
+    });
+  });
+
+  describe('GET /preferences/stats', () => {
+    it('returns valid preference stats', async () => {
+      (getSupabase as jest.Mock).mockReturnValue({
+        from: jest.fn((table) => {
+          if (table === 'user_notification_preferences') {
+            return {
+              select: jest.fn().mockReturnThis(),
+              eq: jest.fn().mockReturnThis(),
+              then: jest.fn(cb => cb({
+                data: [
+                  { push_enabled: true, dnd_enabled: false },
+                  { push_enabled: false, dnd_enabled: true }
+                ],
+                error: null
+              }))
+            };
+          }
+          if (table === 'user_notifications') {
+            return {
+              select: jest.fn().mockReturnThis(),
+              gte: jest.fn().mockReturnThis(),
+              not: jest.fn().mockReturnThis(),
+              then: jest.fn(cb => cb({ count: 10, error: null }))
+            };
+          }
+        })
+      });
+
+      const res = await request(app).get('/admin/notifications/preferences/stats').query({ tenant_id: 't1' });
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.stats.total_users_with_prefs).toBe(2);
+      expect(res.body.stats.push_enabled).toBe(1);
+      expect(res.body.stats.push_disabled).toBe(1);
+      expect(res.body.delivery.total_sent_30d).toBe(10);
+      expect(res.body.delivery.total_read_30d).toBe(10);
+      expect(res.body.delivery.read_rate).toBe(100);
+    });
+  });
+});


### PR DESCRIPTION
**Context**
The security scanner `route-auth-scanner-v1` flagged `services/gateway/src/routes/admin-notifications.ts` as using custom authentication rather than the standard middleware, creating inconsistencies across 95 files.

**Summary of Changes**
- Removed the inline `getBearerToken` and `verifyExafyAdmin` functions from `admin-notifications.ts`.
- Substituted inline custom checks with the shared `requireAdmin` middleware across all routes in the file via `router.use(requireAdmin)`.
- Updated logging to reference `req.user.email` dynamically instead of `authResult.email`.
- Created a new test suite specifically for `admin-notifications.ts` to maintain testing coverage under the newly applied shared middleware pattern.

**Touched Files**
- `services/gateway/src/routes/admin-notifications.ts`
- `services/gateway/test/routes/admin-notifications.test.ts`