### PR TITLE
DEV-AUTOPILOT: Refactor admin notification categories route to use shared requireAdmin

### DIFF
--- a/services/gateway/src/routes/admin-notification-categories.ts
+++ b/services/gateway/src/routes/admin-notification-categories.ts
@@ -11,12 +11,12 @@
  * - POST   /:id/test      — Send test notification to admin
  *
  * Security:
- * - All endpoints are protected by the `requireExafyAdmin` middleware.
+ * - All endpoints are protected by the `requireAdmin` middleware.
  */
 
 import { Router, Request, Response, NextFunction } from 'express';
 import { createClient } from '@supabase/supabase-js';
-import { createUserSupabaseClient } from '../lib/supabase-user';
+import { requireAdmin } from '../middleware/requireAdmin';
 import { notifyUser, NotificationPayload } from '../services/notification-service';
 
 const router = Router();
@@ -24,42 +24,9 @@ const VTID = 'ADMIN-NOTIF-CATEGORIES';
 
 const VALID_TYPES = ['chat', 'calendar', 'community'];
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
 // ── Auth Middleware ─────────────────────────────────────────
 
-async function requireExafyAdmin(req: Request, res: Response, next: NextFunction) {
-  const token = getBearerToken(req);
-  if (!token) return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) {
-      return res.status(401).json({ ok: false, error: 'INVALID_TOKEN' });
-    }
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return res.status(403).json({ ok: false, error: 'FORBIDDEN' });
-    }
-
-    // Attach user info to request for downstream handlers
-    (req as any).authUser = { user_id: authData.user.id, email: authData.user.email || 'unknown' };
-    next();
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
-  }
-}
-
-router.use(requireExafyAdmin);
+router.use(requireAdmin);
 
 // ── Supabase ────────────────────────────────────────────────
 
@@ -140,7 +107,9 @@ router.get('/:id', async (req: Request, res: Response) => {
 // ── POST / — Create category ───────────────────────────────
 
 router.post('/', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const user = (req as any).user;
+  const userId = user?.id;
+  const userEmail = user?.email ?? 'unknown';
 
   const supabase = getSupabase();
   const {
@@ -180,7 +149,7 @@ router.post('/', async (req: Request, res: Response) => {
     default_enabled: default_enabled ?? true,
     mapped_types: mapped_types || [],
     tenant_id: tenant_id || null,
-    created_by: authUser.user_id,
+    created_by: userId,
   };
 
   const { data, error } = await supabase
@@ -197,14 +166,15 @@ router.post('/', async (req: Request, res: Response) => {
     return res.status(500).json({ ok: false, error: error.message });
   }
 
-  console.log(`[${VTID}] Created category "${slug}" (${type}) by ${authUser.email}`);
+  console.log(`[${VTID}] Created category "${slug}" (${type}) by ${userEmail}`);
   return res.status(201).json({ ok: true, data });
 });
 
 // ── PATCH /:id — Update category ────────────────────────────
 
 router.patch('/:id', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const user = (req as any).user;
+  const userEmail = user?.email ?? 'unknown';
 
   const supabase = getSupabase();
   const allowedFields = ['display_name', 'description', 'icon', 'sort_order', 'is_active', 'default_enabled', 'mapped_types'];
@@ -236,14 +206,15 @@ router.patch('/:id', async (req: Request, res: Response) => {
     return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
   }
 
-  console.log(`[${VTID}] Updated category "${data.slug}" by ${authUser.email}`);
+  console.log(`[${VTID}] Updated category "${data.slug}" by ${userEmail}`);
   return res.json({ ok: true, data });
 });
 
 // ── DELETE /:id — Soft-delete (set is_active=false) ─────────
 
 router.delete('/:id', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const user = (req as any).user;
+  const userEmail = user?.email ?? 'unknown';
 
   const supabase = getSupabase();
   const { data, error } = await supabase
@@ -261,14 +232,16 @@ router.delete('/:id', async (req: Request, res: Response) => {
     return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
   }
 
-  console.log(`[${VTID}] Soft-deleted category "${data.slug}" by ${authUser.email}`);
+  console.log(`[${VTID}] Soft-deleted category "${data.slug}" by ${userEmail}`);
   return res.json({ ok: true, data });
 });
 
 // ── POST /:id/test — Send test notification to admin ────────
 
 router.post('/:id/test', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const user = (req as any).user;
+  const userId = user?.id;
+  const userEmail = user?.email ?? 'unknown';
 
   const supabase = getSupabase();
 
@@ -296,15 +269,15 @@ router.post('/:id/test', async (req: Request, res: Response) => {
   const { data: tenantRow } = await supabase
     .from('user_tenants')
     .select('tenant_id')
-    .eq('user_id', authUser.user_id)
+    .eq('user_id', userId)
     .limit(1)
     .single();
 
   const tenantId = tenantRow?.tenant_id || '00000000-0000-0000-0000-000000000000';
 
   try {
-    const result = await notifyUser(authUser.user_id, tenantId, testType, payload, supabase);
-    console.log(`[${VTID}] Test notification sent for category "${category.slug}" by ${authUser.email}`);
+    const result = await notifyUser(userId, tenantId, testType, payload, supabase);
+    console.log(`[${VTID}] Test notification sent for category "${category.slug}" by ${userEmail}`);
     return res.json({ ok: true, result });
   } catch (err: any) {
     console.error(`[${VTID}] POST /:id/test error:`, err.message);

--- a/services/gateway/tests/admin-notification-categories.test.ts
+++ b/services/gateway/tests/admin-notification-categories.test.ts
@@ -1,0 +1,100 @@
+import request from 'supertest';
+import express from 'express';
+import adminNotificationCategoriesRouter from '../src/routes/admin-notification-categories';
+import { requireAdmin } from '../src/middleware/requireAdmin';
+
+// Mock the requireAdmin middleware to simulate the auth boundary
+jest.mock('../src/middleware/requireAdmin', () => ({
+  requireAdmin: jest.fn((req, res, next) => {
+    const authHeader = req.headers.authorization;
+    if (!authHeader) {
+      return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+    }
+    if (authHeader === 'Bearer nonadmin') {
+      return res.status(403).json({ ok: false, error: 'FORBIDDEN' });
+    }
+    if (authHeader === 'Bearer admin') {
+      (req as any).user = { id: 'admin-123', email: 'admin@example.com' };
+      return next();
+    }
+    return res.status(401).json({ ok: false, error: 'INVALID_TOKEN' });
+  })
+}));
+
+// Mock Supabase Query Builder
+const mockQuery = {
+  select: jest.fn().mockReturnThis(),
+  insert: jest.fn().mockReturnThis(),
+  update: jest.fn().mockReturnThis(),
+  delete: jest.fn().mockReturnThis(),
+  eq: jest.fn().mockReturnThis(),
+  or: jest.fn().mockReturnThis(),
+  is: jest.fn().mockReturnThis(),
+  order: jest.fn().mockReturnThis(),
+  single: jest.fn().mockReturnThis(),
+  limit: jest.fn().mockReturnThis(),
+  then: jest.fn((resolve) => resolve({ data: [], error: null }))
+};
+
+const mockSupabase = {
+  from: jest.fn(() => mockQuery)
+};
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => mockSupabase)
+}));
+
+jest.mock('../src/services/notification-service', () => ({
+  notifyUser: jest.fn().mockResolvedValue({ success: true })
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/admin/notification-categories', adminNotificationCategoriesRouter);
+
+describe('Admin Notification Categories Auth Boundary', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 401 UNAUTHENTICATED when no token is provided', async () => {
+    const res = await request(app).get('/admin/notification-categories');
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('UNAUTHENTICATED');
+  });
+
+  it('returns 403 FORBIDDEN when authenticated user is not an admin', async () => {
+    const res = await request(app)
+      .get('/admin/notification-categories')
+      .set('Authorization', 'Bearer nonadmin');
+    
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('FORBIDDEN');
+  });
+
+  it('returns 200 OK when authenticated as admin (GET)', async () => {
+    mockQuery.then.mockImplementationOnce((resolve) => resolve({ data: [], error: null }));
+
+    const res = await request(app)
+      .get('/admin/notification-categories')
+      .set('Authorization', 'Bearer admin');
+    
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('returns 201 Created when authenticated as admin (POST)', async () => {
+    mockQuery.then.mockImplementationOnce((resolve) => resolve({ data: { id: 'cat-1', slug: 'test' }, error: null }));
+
+    const res = await request(app)
+      .post('/admin/notification-categories')
+      .set('Authorization', 'Bearer admin')
+      .send({
+        type: 'chat',
+        display_name: 'Test Category'
+      });
+    
+    expect(res.status).toBe(201);
+    expect(res.body.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
This PR resolves the `route-auth-scanner-v1` finding on `admin-notification-categories.ts`.

**Changes:**
- Removed the inline `requireExafyAdmin` auth middleware and `getBearerToken` helper.
- Implemented standard declarative `router.use(requireAdmin)` at the route level.
- Updated route handlers to retrieve the authenticated user from `req.user` instead of `req.authUser`.
- Maintained exact functional parity with existing Supabase queries, response contracts, and payloads.
- Created `admin-notification-categories.test.ts` to assert the 401/403/200 auth boundaries explicitly.

**Files modified:**
- `services/gateway/src/routes/admin-notification-categories.ts`
- `services/gateway/tests/admin-notification-categories.test.ts`