### PR TITLE
DEV-AUTOPILOT: Enforce authentication for telemetry event writes

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,7 +1,8 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
 
@@ -24,9 +25,49 @@ const TelemetryEventSchema = z.object({
 
 type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
+// Middleware to enforce authentication for modifying telemetry
+const requireAuthenticatedUser = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    let token = "";
+    
+    const authHeader = req.headers.authorization;
+    if (authHeader && authHeader.startsWith("Bearer ")) {
+      token = authHeader.substring(7);
+    } else if (req.headers.cookie) {
+      const match = req.headers.cookie.match(/(?:^|;\s*)(?:sb-[a-z0-9]+-auth-token|supabase-auth-token)=([^;]+)/);
+      if (match) {
+        try {
+          const parsed = JSON.parse(decodeURIComponent(match[1]));
+          token = parsed.access_token || (Array.isArray(parsed) ? parsed[0] : match[1]);
+        } catch {
+          token = match[1];
+        }
+      }
+    }
+
+    if (!token) {
+      res.status(401).json({ error: "Unauthorized", detail: "Missing authentication token" });
+      return;
+    }
+
+    const { data, error } = await supabase.auth.getUser(token);
+
+    if (error || !data?.user) {
+      res.status(401).json({ error: "Unauthorized", detail: "Invalid token" });
+      return;
+    }
+
+    next();
+  } catch (e: any) {
+    console.error("❌ Auth middleware error:", e);
+    res.status(500).json({ error: "Internal server error", detail: e.message });
+    return;
+  }
+};
+
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +187,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,129 @@
+import request from "supertest";
+import express from "express";
+import { router as telemetryRouter } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+// Mock supabase client
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+// Mock stage-mapping to avoid dependencies and state issues
+jest.mock("../../src/lib/stage-mapping", () => ({
+  mapRawToStage: jest.fn().mockReturnValue("WORKER"),
+  normalizeStage: jest.fn().mockReturnValue("WORKER"),
+  isValidStage: jest.fn().mockReturnValue(true),
+  emptyStageCounters: jest.fn().mockReturnValue({ PLANNER: 0, WORKER: 0, VALIDATOR: 0, DEPLOY: 0 }),
+  VALID_STAGES: ["PLANNER", "WORKER", "VALIDATOR", "DEPLOY"],
+}));
+
+describe("Telemetry Routes Authentication", () => {
+  let app: express.Application;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use("/api/v1/telemetry", telemetryRouter);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SUPABASE_SERVICE_ROLE = "dummy-service-role";
+    process.env.SUPABASE_URL = "http://dummy-supabase-url";
+    global.fetch = jest.fn() as any;
+  });
+
+  const validEvent = {
+    vtid: "test-vtid",
+    layer: "core",
+    module: "test",
+    source: "test-source",
+    kind: "test.event",
+    status: "success",
+    title: "Test Event",
+  };
+
+  describe("POST /api/v1/telemetry/event", () => {
+    it("returns 401 when no token is provided", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validEvent);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("returns 401 when an invalid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: new Error("Invalid token"),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validEvent);
+
+      expect(res.status).toBe(401);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("invalid-token");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("returns 202 when a valid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send(validEvent);
+
+      expect(res.status).toBe(202);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("valid-token");
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    it("returns 401 when no token is provided", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send([validEvent]);
+
+      expect(res.status).toBe(401);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("returns 202 when a valid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-token")
+        .send([validEvent]);
+
+      expect(res.status).toBe(202);
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Addresses a flagged `rls_gap` for the `oasis_events` table by applying application-level authentication checks to telemetry write operations (`POST /event` and `POST /batch`). 

- Added `requireAuthenticatedUser` Express middleware to verify Supabase session tokens via `supabase.auth.getUser()`.
- Tokens are extracted from either the `Authorization` header (Bearer) or standard Supabase auth cookies.
- Unauthenticated requests are rejected with a `401 Unauthorized` before reaching the database logic.
- Included corresponding unit tests in `services/gateway/test/routes/telemetry.test.ts` to validate both valid and missing/invalid token paths.

*Note: The subsequent manual database migration applying RLS to the `oasis_events` table remains to be executed by a developer, as it falls outside this automated PR's allowed scope.*