### PR TITLE
DEV-AUTOPILOT: Refactor admin-notifications auth to use requireAdmin

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -7,54 +7,23 @@
  * - GET  /preferences/stats — Aggregate opt-in/out rates per category
  *
  * Security:
- * - All endpoints require Bearer token + exafy_admin
+ * - All endpoints require Bearer token + exafy_admin (via requireAdmin middleware)
  */
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/auth';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIFICATIONS';
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
+// Apply centralized admin authentication middleware
+router.use(requireAdmin);
 
 // ── POST /compose — Send notification to user(s) ────────────
 
 router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -138,6 +107,7 @@ router.post('/compose', async (req: Request, res: Response) => {
 
     // Determine effective tenant_id for dispatching
     const effectiveTenantId = tenant_id || (recipient_ids?.length === 1 ? undefined : undefined);
+    const adminEmail = (req as any).user?.email || 'unknown';
 
     // For single recipients, use synchronous dispatch for immediate feedback
     if (targetUserIds.length === 1) {
@@ -148,7 +118,7 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      console.log(`[${VTID}] Composed notification for 1 user by ${adminEmail}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +131,7 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${adminEmail}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -177,9 +147,6 @@ router.post('/compose', async (req: Request, res: Response) => {
 // ── GET /sent — Admin notification log ──────────────────────
 
 router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -224,9 +191,6 @@ router.get('/sent', async (req: Request, res: Response) => {
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
 router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,144 @@
+import request from 'supertest';
+import express from 'express';
+import adminNotificationsRouter from '../../src/routes/admin-notifications';
+import { getSupabase } from '../../src/lib/supabase';
+import { notifyUser, notifyUsersAsync } from '../../src/services/notification-service';
+
+// Mock dependencies
+jest.mock('../../src/middleware/auth', () => ({
+  requireAdmin: jest.fn((req, res, next) => {
+    req.user = { id: 'admin-id', email: 'admin@test.com' };
+    next();
+  }),
+}));
+
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn(),
+}));
+
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn().mockResolvedValue({ success: true }),
+  notifyUsersAsync: jest.fn(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/admin/notifications', adminNotificationsRouter);
+
+describe('Admin Notifications Router', () => {
+  let mockChain: any;
+  let mockData: any[];
+  let mockCount: number;
+  let mockError: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockData = [];
+    mockCount = 0;
+    mockError = null;
+
+    mockChain = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      or: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      range: jest.fn().mockReturnThis(),
+      not: jest.fn().mockReturnThis(),
+      then: jest.fn((cb) => cb({ data: mockData, error: mockError, count: mockCount })),
+    };
+
+    (getSupabase as jest.Mock).mockReturnValue({
+      from: jest.fn().mockReturnValue(mockChain),
+    });
+  });
+
+  describe('POST /compose', () => {
+    it('should return 400 if title or body is missing', async () => {
+      const res = await request(app).post('/admin/notifications/compose').send({
+        recipient_ids: ['u1']
+      });
+      expect(res.status).toBe(400);
+      expect(res.body.message).toMatch(/title and body are required/);
+    });
+
+    it('should return 400 if recipients are missing', async () => {
+      const res = await request(app).post('/admin/notifications/compose').send({
+        title: 'Hello',
+        body: 'World'
+      });
+      expect(res.status).toBe(400);
+      expect(res.body.message).toMatch(/Must specify recipient_ids, recipient_role, or send_to_all/);
+    });
+
+    it('should send single notification synchronously', async () => {
+      const res = await request(app).post('/admin/notifications/compose').send({
+        title: 'Hello',
+        body: 'World',
+        recipient_ids: ['u1']
+      });
+      expect(res.status).toBe(200);
+      expect(res.body.sent_to).toBe(1);
+      expect(notifyUser).toHaveBeenCalled();
+      expect(notifyUsersAsync).not.toHaveBeenCalled();
+    });
+
+    it('should send multiple notifications asynchronously', async () => {
+      const res = await request(app).post('/admin/notifications/compose').send({
+        title: 'Hello',
+        body: 'World',
+        recipient_ids: ['u1', 'u2']
+      });
+      expect(res.status).toBe(200);
+      expect(res.body.sent_to).toBe(2);
+      expect(notifyUsersAsync).toHaveBeenCalled();
+    });
+
+    it('should fetch users by role and send asynchronously', async () => {
+      mockData = [{ user_id: 'u3' }, { user_id: 'u4' }];
+      const res = await request(app).post('/admin/notifications/compose').send({
+        title: 'Role Alert',
+        body: 'For all admins',
+        recipient_role: 'admin',
+        tenant_id: 't1'
+      });
+      expect(res.status).toBe(200);
+      expect(res.body.sent_to).toBe(2);
+      expect(notifyUsersAsync).toHaveBeenCalled();
+    });
+  });
+
+  describe('GET /sent', () => {
+    it('should fetch sent notifications with pagination', async () => {
+      mockData = [{ id: 'n1', title: 'Test Alert' }];
+      mockCount = 1;
+      const res = await request(app).get('/admin/notifications/sent').query({ limit: 10, offset: 0 });
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.total).toBe(1);
+    });
+
+    it('should return 500 on database error', async () => {
+      mockError = new Error('Database down');
+      const res = await request(app).get('/admin/notifications/sent');
+      expect(res.status).toBe(500);
+      expect(res.body.error).toBe('Database down');
+    });
+  });
+
+  describe('GET /preferences/stats', () => {
+    it('should compute aggregate preference statistics', async () => {
+      mockData = [
+        { push_enabled: true, dnd_enabled: false },
+        { push_enabled: false, dnd_enabled: true }
+      ];
+      mockCount = 2;
+      const res = await request(app).get('/admin/notifications/preferences/stats');
+      expect(res.status).toBe(200);
+      expect(res.body.stats.total_users_with_prefs).toBe(2);
+      expect(res.body.stats.push_enabled).toBe(1);
+      expect(res.body.stats.push_disabled).toBe(1);
+      expect(res.body.stats.dnd_enabled).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses missing authentication flags raised by `route-auth-scanner-v1`. 
The `admin-notifications.ts` route file previously implemented an inline admin authentication function (`verifyExafyAdmin`). To standardise security across the application and satisfy the scanner, this PR refactors the file to use the shared `requireAdmin` middleware.

Changes:
- Removed custom `getBearerToken` and `verifyExafyAdmin` helper functions.
- Removed dependency on `createUserSupabaseClient`.
- Implemented `router.use(requireAdmin)` applying middleware globally to all endpoints within the router.
- Switched user identity lookups in `console.log` from `authResult.email` to `req.user.email`.
- Created comprehensive test suite in `admin-notifications.test.ts` mocking the `requireAdmin` middleware and asserting endpoint business logic.