### PR TITLE
DEV-AUTOPILOT: Refactor admin-notifications to use shared requireAdmin auth

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -12,49 +12,18 @@
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/auth';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIFICATIONS';
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
+// Apply shared admin auth middleware to all routes
+router.use(requireAdmin);
 
 // ── POST /compose — Send notification to user(s) ────────────
 
 router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -138,6 +107,7 @@ router.post('/compose', async (req: Request, res: Response) => {
 
     // Determine effective tenant_id for dispatching
     const effectiveTenantId = tenant_id || (recipient_ids?.length === 1 ? undefined : undefined);
+    const adminEmail = (req as any).user?.email || 'unknown';
 
     // For single recipients, use synchronous dispatch for immediate feedback
     if (targetUserIds.length === 1) {
@@ -148,7 +118,7 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      console.log(`[${VTID}] Composed notification for 1 user by ${adminEmail}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +131,7 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${adminEmail}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -177,9 +147,6 @@ router.post('/compose', async (req: Request, res: Response) => {
 // ── GET /sent — Admin notification log ──────────────────────
 
 router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -224,9 +191,6 @@ router.get('/sent', async (req: Request, res: Response) => {
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
 router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,130 @@
+import request from 'supertest';
+import express, { Request, Response, NextFunction } from 'express';
+import adminNotificationsRouter from '../../src/routes/admin-notifications';
+import { getSupabase } from '../../src/lib/supabase';
+import { notifyUser, notifyUsersAsync } from '../../src/services/notification-service';
+
+jest.mock('../../src/middleware/auth', () => ({
+  requireAdmin: jest.fn((req: Request, res: Response, next: NextFunction) => {
+    (req as any).user = { id: 'admin-id', email: 'admin@test.com' };
+    next();
+  }),
+}));
+
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn(),
+}));
+
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn(),
+  notifyUsersAsync: jest.fn(),
+}));
+
+const createChainable = (resolveValue: any) => {
+  const chain: any = Promise.resolve(resolveValue);
+  chain.select = jest.fn().mockReturnValue(chain);
+  chain.eq = jest.fn().mockReturnValue(chain);
+  chain.gte = jest.fn().mockReturnValue(chain);
+  chain.order = jest.fn().mockReturnValue(chain);
+  chain.range = jest.fn().mockReturnValue(chain);
+  chain.or = jest.fn().mockReturnValue(chain);
+  chain.not = jest.fn().mockReturnValue(chain);
+  return chain;
+};
+
+describe('Admin Notifications Routes', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    (getSupabase as jest.Mock).mockReturnValue({
+      from: jest.fn().mockReturnValue(createChainable({ data: [], error: null }))
+    });
+
+    app = express();
+    app.use(express.json());
+    app.use('/admin/notifications', adminNotificationsRouter);
+  });
+
+  describe('POST /compose', () => {
+    it('returns 400 if title or body is missing', async () => {
+      const res = await request(app).post('/admin/notifications/compose').send({ recipient_ids: ['user-1'] });
+      expect(res.status).toBe(400);
+    });
+
+    it('returns 400 if no recipient criteria provided', async () => {
+      const res = await request(app).post('/admin/notifications/compose').send({ title: 'Hello', body: 'World' });
+      expect(res.status).toBe(400);
+    });
+
+    it('sends notification to specific users', async () => {
+      (notifyUser as jest.Mock).mockResolvedValue({ id: 'notif-1' });
+
+      const res = await request(app).post('/admin/notifications/compose').send({
+        title: 'Hello', body: 'World', recipient_ids: ['user-1']
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(notifyUser).toHaveBeenCalled();
+    });
+
+    it('sends to multiple recipients async', async () => {
+      const res = await request(app).post('/admin/notifications/compose').send({
+        title: 'Hello', body: 'World', recipient_ids: ['user-1', 'user-2']
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(notifyUsersAsync).toHaveBeenCalled();
+    });
+  });
+
+  describe('GET /sent', () => {
+    it('returns sent notifications', async () => {
+      (getSupabase as jest.Mock).mockReturnValue({
+        from: jest.fn().mockReturnValue(createChainable({
+          data: [{ id: 'notif-1', title: 'Hello' }],
+          count: 1,
+          error: null
+        }))
+      });
+
+      const res = await request(app).get('/admin/notifications/sent');
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveLength(1);
+    });
+
+    it('handles supabase error', async () => {
+      (getSupabase as jest.Mock).mockReturnValue({
+        from: jest.fn().mockReturnValue(createChainable({
+          data: null,
+          count: 0,
+          error: { message: 'Database error' }
+        }))
+      });
+
+      const res = await request(app).get('/admin/notifications/sent');
+      expect(res.status).toBe(500);
+    });
+  });
+
+  describe('GET /preferences/stats', () => {
+    it('returns preference statistics', async () => {
+      (getSupabase as jest.Mock).mockReturnValue({
+        from: jest.fn().mockImplementation((table) => {
+          if (table === 'user_notification_preferences') {
+            return createChainable({ data: [{ push_enabled: true }], error: null });
+          }
+          return createChainable({ count: 10, error: null });
+        })
+      });
+
+      const res = await request(app).get('/admin/notifications/preferences/stats');
+      expect(res.status).toBe(200);
+      expect(res.body.stats.total_users_with_prefs).toBe(1);
+      expect(res.body.delivery.total_sent_30d).toBe(10);
+    });
+  });
+});


### PR DESCRIPTION
**Context & Plan**
The route auth scanner flagged `admin-notifications.ts` for lacking standard authentication. It previously used a bespoke `verifyExafyAdmin` inline method. This PR refactors the file to use the shared `requireAdmin` middleware, bringing the auth path into alignment with the rest of the protected routes and reducing maintenance overhead. 

**Changes**
1. **`services/gateway/src/routes/admin-notifications.ts`**
   - Removed `getBearerToken` and `verifyExafyAdmin` helper functions.
   - Removed `createUserSupabaseClient` logic.
   - Added `router.use(requireAdmin)` to enforce the admin check via our shared middleware.
   - Removed per-route auth invocations and updated the logging to use `req.user.email`.
2. **`services/gateway/test/routes/admin-notifications.test.ts`**
   - Created test suite to mock the standard `requireAdmin` middleware instead of the old inline functionality.
   - Validated logic routing across `POST /compose`, `GET /sent`, and `GET /preferences/stats`.