### PR TITLE
DEV-AUTOPILOT: Refactor admin-notifications auth to use shared requireAdmin middleware

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -12,49 +12,18 @@
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/auth';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIFICATIONS';
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
+// Apply admin authentication to all routes in this router
+router.use(requireAdmin);
 
 // ── POST /compose — Send notification to user(s) ────────────
 
 router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -89,6 +58,8 @@ router.post('/compose', async (req: Request, res: Response) => {
     body,
     data: data ? Object.fromEntries(Object.entries(data).map(([k, v]) => [k, String(v)])) : undefined,
   };
+
+  const userEmail = (req as any).user?.email || 'unknown';
 
   try {
     let targetUserIds: string[] = [];
@@ -148,7 +119,7 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      console.log(`[${VTID}] Composed notification for 1 user by ${userEmail}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +132,7 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${userEmail}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -177,9 +148,6 @@ router.post('/compose', async (req: Request, res: Response) => {
 // ── GET /sent — Admin notification log ──────────────────────
 
 router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -224,9 +192,6 @@ router.get('/sent', async (req: Request, res: Response) => {
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
 router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,204 @@
+import request from 'supertest';
+import express from 'express';
+import adminNotificationsRouter from '../../src/routes/admin-notifications';
+import { getSupabase } from '../../src/lib/supabase';
+import { notifyUser, notifyUsersAsync } from '../../src/services/notification-service';
+
+jest.mock('../../src/middleware/auth', () => ({
+  requireAdmin: jest.fn((req, res, next) => {
+    req.user = { id: 'admin-id', email: 'admin@test.com' };
+    next();
+  })
+}));
+
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn()
+}));
+
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn(),
+  notifyUsersAsync: jest.fn()
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/admin/notifications', adminNotificationsRouter);
+
+describe('Admin Notifications API', () => {
+  let mockSupabase: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    mockSupabase = {
+      from: jest.fn(),
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      range: jest.fn().mockReturnThis(),
+      or: jest.fn().mockReturnThis(),
+      not: jest.fn().mockReturnThis(),
+    };
+
+    (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+  });
+
+  describe('POST /compose', () => {
+    it('should return 400 if title or body is missing', async () => {
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ title: 'Hello' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('INVALID_INPUT');
+    });
+
+    it('should return 400 if recipient criteria is missing', async () => {
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ title: 'Hello', body: 'World' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('INVALID_INPUT');
+    });
+
+    it('should send notification to a specific user', async () => {
+      (notifyUser as jest.Mock).mockResolvedValue({ id: 'notif-1' });
+
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({
+          title: 'Hello',
+          body: 'World',
+          recipient_ids: ['user-1']
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.sent_to).toBe(1);
+      expect(notifyUser).toHaveBeenCalledWith(
+        'user-1',
+        '',
+        'welcome_to_vitana',
+        expect.objectContaining({ title: 'Hello', body: 'World' }),
+        mockSupabase
+      );
+    });
+
+    it('should fetch users by role and send to them', async () => {
+      mockSupabase.from.mockImplementation(() => {
+        const chain: any = {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          then: (resolve: any) => resolve({ data: [{ user_id: 'user-2' }, { user_id: 'user-3' }], error: null })
+        };
+        return chain;
+      });
+
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({
+          title: 'Hello',
+          body: 'World',
+          recipient_role: 'creator',
+          tenant_id: 'tenant-1'
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.sent_to).toBe(2);
+      expect(notifyUsersAsync).toHaveBeenCalledWith(
+        ['user-2', 'user-3'],
+        'tenant-1',
+        'welcome_to_vitana',
+        expect.objectContaining({ title: 'Hello', body: 'World' }),
+        mockSupabase
+      );
+    });
+
+    it('should return 500 if Supabase is unavailable', async () => {
+      (getSupabase as jest.Mock).mockReturnValue(null);
+
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({
+          title: 'Hello',
+          body: 'World',
+          recipient_ids: ['user-1']
+        });
+
+      expect(res.status).toBe(500);
+      expect(res.body.error).toBe('SUPABASE_UNAVAILABLE');
+    });
+  });
+
+  describe('GET /sent', () => {
+    it('should return sent notifications', async () => {
+      mockSupabase.from.mockImplementation(() => {
+        const chain: any = {
+          select: jest.fn().mockReturnThis(),
+          gte: jest.fn().mockReturnThis(),
+          order: jest.fn().mockReturnThis(),
+          range: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          or: jest.fn().mockReturnThis(),
+          then: (resolve: any) => resolve({
+            data: [{ id: 'notif-1', title: 'Hello' }],
+            count: 1,
+            error: null
+          })
+        };
+        return chain;
+      });
+
+      const res = await request(app).get('/admin/notifications/sent?limit=10&offset=0');
+
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.total).toBe(1);
+    });
+  });
+
+  describe('GET /preferences/stats', () => {
+    it('should return preference statistics', async () => {
+      let callCount = 0;
+      mockSupabase.from.mockImplementation((table: string) => {
+        const chain: any = {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          gte: jest.fn().mockReturnThis(),
+          not: jest.fn().mockReturnThis(),
+        };
+
+        chain.then = (resolve: any) => {
+          if (table === 'user_notification_preferences') {
+            resolve({
+              data: [
+                { push_enabled: true, dnd_enabled: false },
+                { push_enabled: false, dnd_enabled: true }
+              ],
+              error: null
+            });
+          } else if (table === 'user_notifications') {
+            if (callCount === 0) {
+              callCount++;
+              resolve({ count: 10 });
+            } else {
+              resolve({ count: 5 });
+            }
+          }
+        };
+
+        return chain;
+      });
+
+      const res = await request(app).get('/admin/notifications/preferences/stats');
+
+      expect(res.status).toBe(200);
+      expect(res.body.stats.total_users_with_prefs).toBe(2);
+      expect(res.body.stats.push_enabled).toBe(1);
+      expect(res.body.stats.push_disabled).toBe(1);
+      expect(res.body.delivery.total_sent_30d).toBe(10);
+      expect(res.body.delivery.total_read_30d).toBe(5);
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses missing authentication flagged by `route-auth-scanner-v1` in `admin-notifications.ts`.

It refactors the route to rely on the standard `requireAdmin` middleware from `../middleware/auth` instead of the inline `verifyExafyAdmin` and `getBearerToken` custom logic. This reduces maintenance overhead and standardizes the admin authorization flow. 

**Changes:**
- Replaced custom inline auth handlers in `services/gateway/src/routes/admin-notifications.ts` with `router.use(requireAdmin)`.
- Updated `req.user` payload referencing within endpoints.
- Added comprehensive unit tests in `services/gateway/test/routes/admin-notifications.test.ts` to cover core route capabilities and the updated middleware mock.