### PR TITLE
DEV-AUTOPILOT: Mitigate path-to-regexp ReDoS with paramLimit middleware

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,31 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // 1. Strict check on Express parsed req.params
+    const keys = Object.keys(req.params || {});
+    
+    if (keys.length > maxParams) {
+      res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    for (const key of keys) {
+      const value = req.params[key];
+      if (value && value.length > maxLength) {
+        res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    // 2. Validate the raw path segments using RegExp to avoid vulnerable path-to-regexp matching
+    // when middleware is mounted globally before params are fully populated.
+    const longSegmentRegex = new RegExp(`[^/]{${maxLength + 1},}`);
+    if (longSegmentRegex.test(req.path)) {
+      res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply paramLimit middleware to prevent ReDoS from excessive or long path parameters.
+// Note: Ensure this pattern is propagated to all route files with path parameters.
+router.use(limitPathParams());
+
+router.get('/:projectId', (req, res) => {
+  res.json({ projectId: req.params.projectId });
+});
+
+router.get('/:projectId/tasks/:taskId', (req, res) => {
+  res.json({ projectId: req.params.projectId, taskId: req.params.taskId });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,18 @@
+import { Router } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply paramLimit middleware to prevent ReDoS from excessive or long path parameters.
+// Note: Ensure this pattern is propagated to all route files with path parameters.
+router.use(limitPathParams());
+
+router.get('/:userId', (req, res) => {
+  res.json({ userId: req.params.userId });
+});
+
+router.get('/:userId/profile/:section', (req, res) => {
+  res.json({ userId: req.params.userId, section: req.params.section });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,65 @@
+import express from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - paramLimit Middleware', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    
+    // Mount middleware inside specific parameterized routes for precise req.params check testing
+    app.get('/resource/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req, res) => {
+      res.status(200).json({ success: true });
+    });
+    
+    app.get('/long/:id', limitPathParams(5, 200), (req, res) => {
+      res.status(200).json({ success: true });
+    });
+
+    app.get('/valid/:id/:subId', limitPathParams(5, 200), (req, res) => {
+      res.status(200).json({ success: true });
+    });
+
+    // Mount globally to test RegExp raw path length fallback
+    app.use(limitPathParams(5, 200));
+    app.get('/global-long/:id', (req, res) => {
+      res.status(200).json({ success: true });
+    });
+  });
+
+  it('returns 400 when more than 5 parameters are provided', async () => {
+    const res = await request(app).get('/resource/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'Too many path parameters or parameter too long' });
+  });
+
+  it('returns 400 when a parameter exceeds max length', async () => {
+    const longParam = 'a'.repeat(201);
+    const res = await request(app).get(`/long/${longParam}`);
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'Too many path parameters or parameter too long' });
+  });
+
+  it('returns 400 when a parameter exceeds max length (global regex fallback)', async () => {
+    const longParam = 'a'.repeat(201);
+    const res = await request(app).get(`/global-long/${longParam}`);
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'Too many path parameters or parameter too long' });
+  });
+
+  it('passes through when parameters are within limits', async () => {
+    const res = await request(app).get('/valid/1/2');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ success: true });
+  });
+
+  it('responds quickly to potentially malicious requests', async () => {
+    const start = Date.now();
+    const res = await request(app).get('/resource/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+    
+    expect(res.status).toBe(400);
+    expect(duration).toBeLessThan(200);
+  });
+});


### PR DESCRIPTION
This PR introduces the `paramLimit` middleware to protect the gateway from a Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` < 0.1.13.

Since direct dependency updates are handled in a separate process, this server-side validation limits the number of path parameters (default 5) and the maximum length of any path parameter (default 200). Requests exceeding these limits are immediately rejected with a `400 Bad Request`, mitigating the CPU exhaustion from catastrophic backtracking.

### Changes:
- **`paramLimit.ts`**: Implements the middleware to validate parameter counts and lengths, using safe RegExp assertions on the raw path as a fallback.
- **`userRoutes.ts` & `projectRoutes.ts`**: Mounts the middleware to demonstrate usage.
- **`cve-mitigation.test.ts`**: Contains unit and integration tests confirming validation constraints and fast rejection times (<200ms).

*Note to operator: The `paramLimit` middleware should be applied universally across all route files containing path parameters. This PR updates representative candidate files; ensure any remaining route configurations also import and apply this middleware.*