### PR TITLE
DEV-AUTOPILOT: Add paramLimit middleware to mitigate ReDoS CVE

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,31 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+/**
+ * Middleware to mitigate ReDoS vulnerabilities in path-to-regexp by limiting
+ * the number of path parameters and the maximum length of each parameter.
+ *
+ * @param maxParams Maximum number of path parameters allowed (default: 5)
+ * @param maxLength Maximum string length for each parameter (default: 200)
+ */
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (req.params) {
+      const keys = Object.keys(req.params);
+      
+      if (keys.length > maxParams) {
+        res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+
+      for (const key of keys) {
+        const value = req.params[key];
+        if (value && value.length > maxLength) {
+          res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+          return;
+        }
+      }
+    }
+    
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,13 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply middleware to limit path parameters to mitigate ReDoS
+router.use(limitPathParams());
+
+router.get('/:projectId', (req: Request, res: Response) => {
+  res.json({ projectId: req.params.projectId, name: 'Project' });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply middleware to limit path parameters to mitigate ReDoS
+router.use(limitPathParams());
+
+router.get('/:id', (req: Request, res: Response) => {
+  res.json({ id: req.params.id, name: 'User' });
+});
+
+router.get('/:id/settings/:settingId', (req: Request, res: Response) => {
+  res.json({ id: req.params.id, setting: req.params.settingId });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,56 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - ReDoS in path parameters', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    // Default limit is 5 params, max length 200
+    app.use(limitPathParams(5, 200));
+
+    app.get('/test/:a/:b/:c/:d/:e/:f', (req: Request, res: Response) => {
+      res.status(200).json({ success: true });
+    });
+
+    app.get('/test/:a', (req: Request, res: Response) => {
+      res.status(200).json({ success: true });
+    });
+
+    app.get('/test/:a/:b', (req: Request, res: Response) => {
+      res.status(200).json({ success: true });
+    });
+  });
+
+  it('should return 400 when there are more than 5 path parameters', async () => {
+    const start = Date.now();
+    const res = await request(app).get('/test/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(200); // Should reject quickly
+  });
+
+  it('should return 400 when a path parameter is too long', async () => {
+    const longString = 'a'.repeat(201);
+    const start = Date.now();
+    const res = await request(app).get(`/test/${longString}`);
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('should pass through when parameters are within limits', async () => {
+    const start = Date.now();
+    const res = await request(app).get('/test/1/2');
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(duration).toBeLessThan(200);
+  });
+});


### PR DESCRIPTION
This PR implements server-side validation middleware (`limitPathParams`) to mitigate a Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` versions < 0.1.13.

It limits the number of path parameters (max 5) and the length of each parameter value (max 200 characters) to prevent CPU exhaustion caused by catastrophic backtracking.

Files touched:
- `services/gateway/src/routes/middleware/paramLimit.ts` (new middleware)
- `services/gateway/src/routes/v1/userRoutes.ts` (applied middleware)
- `services/gateway/src/routes/v1/projectRoutes.ts` (applied middleware)
- `services/gateway/test/cve-mitigation.test.ts` (unit/integration tests)

Note: This is a mitigation strategy. The ultimate fix requires bumping `express` (or `path-to-regexp` directly) in `package.json` for both `services/oasis-projector` and `services/gateway` to a version where `path-to-regexp >= 0.1.13`. Operators will need to follow up with dependency updates in a separate PR. Also, additional route files with path parameters may require the middleware applied manually if they were not covered here.