### PR TITLE
DEV-AUTOPILOT: Add middleware to mitigate path-to-regexp ReDoS vulnerability

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,34 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // 1. Validate parsed req.params if they are already populated
+    if (req.params) {
+      const keys = Object.keys(req.params);
+      if (keys.length > maxParams) {
+        res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+
+      for (const key of keys) {
+        const val = req.params[key];
+        if (val && String(val).length > maxLength) {
+          res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+          return;
+        }
+      }
+    }
+    
+    // 2. Use RegExp only for raw validation avoiding path-to-regexp matching.
+    // This is a safety mechanism when the middleware is run before route parameter extraction.
+    if (req.path) {
+      const excessivelyLongSegment = new RegExp(`[^/]{${maxLength + 1},}`);
+      if (excessivelyLongSegment.test(req.path)) {
+        res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,21 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply ReDoS mitigation middleware
+router.use(limitPathParams());
+
+router.get('/:projectId', (req: Request, res: Response) => {
+  res.status(200).json({ projectId: req.params.projectId, message: 'Project details retrieved' });
+});
+
+router.get('/:projectId/tasks/:taskId', (req: Request, res: Response) => {
+  res.status(200).json({ 
+    projectId: req.params.projectId, 
+    taskId: req.params.taskId, 
+    message: 'Project task retrieved' 
+  });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,21 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply ReDoS mitigation middleware
+router.use(limitPathParams());
+
+router.get('/:id', (req: Request, res: Response) => {
+  res.status(200).json({ id: req.params.id, message: 'User profile retrieved' });
+});
+
+router.get('/:id/profile/:section', (req: Request, res: Response) => {
+  res.status(200).json({ 
+    id: req.params.id, 
+    section: req.params.section, 
+    message: 'User section retrieved' 
+  });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,69 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+import userRoutes from '../src/routes/v1/userRoutes';
+import projectRoutes from '../src/routes/v1/projectRoutes';
+
+describe('CVE Mitigation - path-to-regexp ReDoS', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    
+    // Mount standard routes to test real integration behaviour
+    app.use('/users', userRoutes);
+    app.use('/projects', projectRoutes);
+
+    // Mount an explicit test route to specifically test parameter counts
+    app.get('/test/many/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.status(200).json({ success: true });
+    });
+  });
+
+  it('should allow normal requests to user routes (passthrough)', async () => {
+    const response = await request(app).get('/users/123/profile/settings');
+    expect(response.status).toBe(200);
+    expect(response.body.id).toEqual('123');
+    expect(response.body.section).toEqual('settings');
+  });
+
+  it('should allow normal requests to project routes (passthrough)', async () => {
+    const response = await request(app).get('/projects/p-1/tasks/t-2');
+    expect(response.status).toBe(200);
+    expect(response.body.projectId).toEqual('p-1');
+    expect(response.body.taskId).toEqual('t-2');
+  });
+
+  it('should return 400 when exceeding 5 path parameters on specific matching routes', async () => {
+    const startTime = Date.now();
+    const response = await request(app).get('/test/many/1/2/3/4/5/6');
+    const duration = Date.now() - startTime;
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ error: 'Too many path parameters or parameter too long' });
+    expect(duration).toBeLessThan(500); // Ensures response is fast and halts processing
+  });
+
+  it('should return 400 when a path parameter exceeds 200 characters on integrated routes', async () => {
+    const longParam = 'x'.repeat(250);
+    const startTime = Date.now();
+    const response = await request(app).get(`/users/${longParam}`);
+    const duration = Date.now() - startTime;
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ error: 'Too many path parameters or parameter too long' });
+    expect(duration).toBeLessThan(500);
+  });
+
+  it('should reject pathological requests designed to trigger ReDoS rapidly (< 500ms)', async () => {
+    const longPathologicalParam = 'x'.repeat(250);
+    const startTime = Date.now();
+    // Sending excessively long malicious payloads
+    const response = await request(app).get(`/test/many/${longPathologicalParam}/b/c/d/e/f`);
+    const duration = Date.now() - startTime;
+
+    expect(response.status).toBe(400);
+    expect(duration).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
**Context & Issue:**
A Regular Expression Denial of Service (ReDoS) vulnerability exists in `path-to-regexp` versions `< 0.1.13` which is used transitively by `express` in our services. Attackers can submit HTTP requests with numerous or exceptionally long path parameters, causing catastrophic backtracking and CPU exhaustion during route matching.

**Mitigation:**
Since updating dependencies directly in `package.json` is outside the current authorized scope (to be addressed in a follow-up), this PR implements a server-side validation middleware in the gateway that proactively limits the number and length of path parameters.

**Changes:**
1. Created `services/gateway/src/routes/middleware/paramLimit.ts`: Parses route parameters and enforces limits (`maxParams=5`, `maxLength=200`). Employs a defensive RegExp scan on the raw path to act before routing triggers.
2. Updated `services/gateway/src/routes/v1/userRoutes.ts` to attach the new middleware.
3. Updated `services/gateway/src/routes/v1/projectRoutes.ts` to attach the new middleware.
4. Created `services/gateway/test/cve-mitigation.test.ts` to ensure the mitigation blocks out-of-bound inputs while gracefully permitting normal traffic.

*Note for Operators: Please ensure this middleware pattern is adopted in all other gateway routes that use dynamic path parameters.*