### PR TITLE
DEV-AUTOPILOT: Enforce auth on telemetry write routes to prevent unauthorized OASIS events

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,7 +1,8 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
 
@@ -24,9 +25,41 @@ const TelemetryEventSchema = z.object({
 
 type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
+// Authentication middleware for telemetry write operations
+const requireAuth = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      res.status(401).json({
+        error: "Unauthorized",
+        detail: "Missing or invalid Authorization header",
+      });
+      return;
+    }
+
+    const token = authHeader.substring(7); // Remove "Bearer "
+    const { data, error } = await supabase.auth.getUser(token);
+
+    if (error || !data?.user) {
+      res.status(401).json({
+        error: "Unauthorized",
+        detail: "Invalid session token",
+      });
+      return;
+    }
+
+    next();
+  } catch (err: any) {
+    res.status(500).json({
+      error: "Internal server error",
+      detail: err.message,
+    });
+  }
+};
+
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +179,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,117 @@
+import request from "supertest";
+import express from "express";
+import { router as telemetryRouter } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1/telemetry", telemetryRouter);
+
+describe("Telemetry API Auth Enforcement", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const validEventPayload = {
+    vtid: "VT-123",
+    layer: "core",
+    module: "test",
+    source: "test-runner",
+    kind: "system.info",
+    status: "success",
+    title: "Test Event",
+  };
+
+  describe("POST /api/v1/telemetry/event", () => {
+    it("should return 401 when Authorization header is missing", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validEventPayload);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+    });
+
+    it("should return 401 when session token is invalid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: null },
+        error: new Error("Invalid token"),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid-jwt-token")
+        .send(validEventPayload);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+    });
+
+    it("should pass auth and proceed when session token is valid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-jwt-token")
+        .send(validEventPayload);
+
+      // It reaches the internal logic which throws 500 because SUPABASE_URL isn't set in tests
+      expect(res.status).toBe(500);
+      expect(res.body.error).toBe("Gateway misconfigured");
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    const validBatchPayload = [validEventPayload];
+
+    it("should return 401 when Authorization header is missing", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send(validBatchPayload);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+    });
+
+    it("should return 401 when session token is invalid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: null },
+        error: new Error("Invalid token"),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer invalid-jwt-token")
+        .send(validBatchPayload);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+    });
+
+    it("should pass auth and proceed when session token is valid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-jwt-token")
+        .send(validBatchPayload);
+
+      expect(res.status).toBe(500);
+      expect(res.body.error).toBe("Gateway misconfigured");
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses the RLS policy gap flagged on the `oasis_events` table by enforcing application-level authentication on the telemetry routes that write to it (`POST /api/v1/telemetry/event` and `POST /api/v1/telemetry/batch`).

### Changes
- Implemented `requireAuth` middleware using `supabase.auth.getUser(token)` to validate incoming `Authorization: Bearer <token>` headers.
- Applied the middleware to the `/event` and `/batch` telemetry routes in `services/gateway/src/routes/telemetry.ts` to block unauthenticated inserts.
- Added corresponding unit tests in `services/gateway/test/routes/telemetry.test.ts` to assert that unauthorized requests fail with HTTP 401 and authenticated ones successfully reach the route handler.

**Note to Operator:** The database-level RLS enablement and policy migration for `oasis_events` still needs to be manually created and applied as per the out-of-scope instructions in the plan.