### PR TITLE
DEV-AUTOPILOT: Mitigate path-to-regexp ReDoS via param limit middleware

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,22 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const keys = Object.keys(req.params || {});
+    
+    if (keys.length > maxParams) {
+      res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+    
+    for (const key of keys) {
+      const value = req.params[key];
+      if (typeof value === 'string' && value.length > maxLength) {
+        res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+    
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply paramLimit middleware to mitigate path-to-regexp ReDoS vulnerability
+router.use(limitPathParams());
+
+router.get('/:projectId', (req: Request, res: Response) => {
+  res.status(200).json({ id: req.params.projectId, name: 'Sample Project' });
+});
+
+router.post('/:projectId/resources', (req: Request, res: Response) => {
+  res.status(201).json({ projectId: req.params.projectId, created: true });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply paramLimit middleware to mitigate path-to-regexp ReDoS vulnerability
+router.use(limitPathParams());
+
+router.get('/:userId', (req: Request, res: Response) => {
+  res.status(200).json({ id: req.params.userId, name: 'Sample User' });
+});
+
+router.put('/:userId', (req: Request, res: Response) => {
+  res.status(200).json({ id: req.params.userId, updated: true });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,77 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation: limitPathParams middleware', () => {
+  let app: express.Application;
+
+  beforeAll(() => {
+    app = express();
+
+    // Test 1 route
+    app.get(
+      '/multi/:a/:b/:c/:d/:e/:f',
+      limitPathParams(5, 200),
+      (req: Request, res: Response) => {
+        res.status(200).json({ success: true });
+      }
+    );
+
+    // Test 2 route
+    app.get(
+      '/long/:a',
+      limitPathParams(5, 200),
+      (req: Request, res: Response) => {
+        res.status(200).json({ success: true });
+      }
+    );
+
+    // Test 3 route
+    app.get(
+      '/valid/:a/:b',
+      limitPathParams(5, 200),
+      (req: Request, res: Response) => {
+        res.status(200).json({ success: true });
+      }
+    );
+
+    // Integration test specific route
+    app.get(
+      '/redos/:a/:b/:c/:d/:e/:f?',
+      limitPathParams(5, 200),
+      (req: Request, res: Response) => {
+        res.status(200).json({ success: true });
+      }
+    );
+  });
+
+  it('Test 1: should return 400 when >5 params are provided', async () => {
+    const res = await request(app).get('/multi/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('Test 2: should return 400 when param >200 chars', async () => {
+    const longParam = 'a'.repeat(201);
+    const res = await request(app).get(`/long/${longParam}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('Test 3: should pass valid request with 2 params', async () => {
+    const res = await request(app).get('/valid/hello/world');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('Integration test: should reject ReDoS vector quickly (< 500ms)', async () => {
+    const start = Date.now();
+    // Pathological payload simulating an attack
+    const pathologicalValue = 'a'.repeat(300);
+    const res = await request(app).get(`/redos/1/2/3/4/5/${pathologicalValue}`);
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(duration).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
This PR implements a server-side validation middleware in the gateway to mitigate a Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (versions < 0.1.13). 

Because direct dependency updates are outside the allowed modification scope for this specific plan, this change:
- Introduces `paramLimit` middleware to enforce thresholds on path parameter count (`<= 5`) and length (`<= 200`).
- Applies the middleware to `userRoutes.ts` and `projectRoutes.ts` to reduce the attack surface.
- Adds comprehensive unit and integration tests asserting that requests exceeding boundaries are rejected quickly with a `400 Bad Request`.

**Note:** Any newly added route files with path parameters should ensure they also apply this middleware until the underlying `express` and `path-to-regexp` dependencies can be updated in `package.json`.

Files modified:
- `services/gateway/src/routes/middleware/paramLimit.ts`
- `services/gateway/src/routes/v1/userRoutes.ts`
- `services/gateway/src/routes/v1/projectRoutes.ts`
- `services/gateway/test/cve-mitigation.test.ts`