### PR TITLE
DEV-AUTOPILOT: Refactor admin-notifications to use requireAdmin middleware

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -12,49 +12,18 @@
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/auth';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIFICATIONS';
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
+router.use(requireAdmin);
 
 // ── POST /compose — Send notification to user(s) ────────────
 
 router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
+  const user = (req as any).user;
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -148,7 +117,7 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      console.log(`[${VTID}] Composed notification for 1 user by ${user?.email || 'unknown'}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +130,7 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${user?.email || 'unknown'}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -177,9 +146,6 @@ router.post('/compose', async (req: Request, res: Response) => {
 // ── GET /sent — Admin notification log ──────────────────────
 
 router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -224,9 +190,6 @@ router.get('/sent', async (req: Request, res: Response) => {
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
 router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,150 @@
+import request from 'supertest';
+import express from 'express';
+import adminNotificationsRouter from '../../src/routes/admin-notifications';
+import { getSupabase } from '../../src/lib/supabase';
+import { notifyUser, notifyUsersAsync } from '../../src/services/notification-service';
+
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn(),
+}));
+
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn(),
+  notifyUsersAsync: jest.fn(),
+}));
+
+jest.mock('../../src/middleware/auth', () => ({
+  requireAdmin: jest.fn((req, res, next) => {
+    req.user = { id: 'admin-id', email: 'admin@test.com' };
+    next();
+  }),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/admin/notifications', adminNotificationsRouter);
+
+// Helper for Supabase query chaining
+const createMockQuery = (resolvesTo: any) => {
+  const query: any = Promise.resolve(resolvesTo);
+  const methods = ['select', 'eq', 'or', 'not', 'gte', 'order', 'range'];
+  methods.forEach(method => {
+    query[method] = jest.fn().mockReturnValue(query);
+  });
+  return query;
+};
+
+describe('Admin Notifications Router', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('POST /compose', () => {
+    it('should return 400 if title or body are missing', async () => {
+      (getSupabase as jest.Mock).mockReturnValue({});
+
+      const response = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ recipient_ids: ['user-1'] });
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe('INVALID_INPUT');
+    });
+
+    it('should send notification to a single user successfully', async () => {
+      (getSupabase as jest.Mock).mockReturnValue({});
+      (notifyUser as jest.Mock).mockResolvedValue({ id: 'notif-1' });
+
+      const response = await request(app)
+        .post('/admin/notifications/compose')
+        .send({
+          recipient_ids: ['user-1'],
+          title: 'Hello',
+          body: 'World',
+          type: 'test_type',
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body.ok).toBe(true);
+      expect(response.body.sent_to).toBe(1);
+    });
+
+    it('should send notification to multiple users successfully', async () => {
+      const mockQuery = createMockQuery({ data: [{ user_id: 'user-1' }, { user_id: 'user-2' }], error: null });
+      const mockSupabase = {
+        from: jest.fn().mockReturnValue(mockQuery),
+      };
+      (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+
+      const response = await request(app)
+        .post('/admin/notifications/compose')
+        .send({
+          recipient_role: 'member',
+          tenant_id: 'tenant-1',
+          title: 'Hello',
+          body: 'World',
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body.ok).toBe(true);
+      expect(response.body.sent_to).toBe(2);
+      expect(notifyUsersAsync).toHaveBeenCalled();
+    });
+  });
+
+  describe('GET /sent', () => {
+    it('should return sent notifications', async () => {
+      const mockQuery = createMockQuery({ data: [{ id: 'notif-1' }], error: null, count: 1 });
+      const mockSupabase = {
+        from: jest.fn().mockReturnValue(mockQuery),
+      };
+      (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+
+      const response = await request(app).get('/admin/notifications/sent');
+
+      expect(response.status).toBe(200);
+      expect(response.body.ok).toBe(true);
+      expect(response.body.data).toHaveLength(1);
+      expect(response.body.total).toBe(1);
+    });
+  });
+
+  describe('GET /preferences/stats', () => {
+    it('should return aggregate preference statistics', async () => {
+      let notifCallCount = 0;
+      
+      const mockSupabase = {
+        from: jest.fn((table) => {
+          if (table === 'user_notification_preferences') {
+            return createMockQuery({
+              data: [
+                { push_enabled: true, dnd_enabled: false },
+                { push_enabled: false, dnd_enabled: true },
+              ],
+              error: null,
+            });
+          }
+          if (table === 'user_notifications') {
+            notifCallCount++;
+            if (notifCallCount === 1) {
+              return createMockQuery({ count: 10 });
+            } else {
+              return createMockQuery({ count: 5 });
+            }
+          }
+          return createMockQuery({});
+        }),
+      };
+
+      (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+
+      const response = await request(app).get('/admin/notifications/preferences/stats');
+
+      expect(response.status).toBe(200);
+      expect(response.body.ok).toBe(true);
+      expect(response.body.stats.total_users_with_prefs).toBe(2);
+      expect(response.body.delivery.total_sent_30d).toBe(10);
+      expect(response.body.delivery.total_read_30d).toBe(5);
+    });
+  });
+});


### PR DESCRIPTION
This PR replaces inline custom auth logic (`verifyExafyAdmin`) in `admin-notifications.ts` with the project's standard `requireAdmin` middleware.

- Standardises authentication for admin notification routes.
- Removes redundant auth helper functions.
- Resolves the missing authentication flag generated by `route-auth-scanner-v1`.
- Adds tests to verify correct routing and mock behaviour under the new middleware.

Files modified/created:
- `services/gateway/src/routes/admin-notifications.ts`
- `services/gateway/test/routes/admin-notifications.test.ts`