### PR TITLE
DEV-AUTOPILOT: Enforce auth middleware for telemetry endpoints

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,46 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+// Middleware to enforce authentication
+const requireAuthenticatedUser = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      return res.status(401).json({
+        error: "Unauthorized",
+        detail: "Missing or invalid Authorization header",
+      });
+    }
+
+    const token = authHeader.split(" ")[1];
+    if (!token) {
+      return res.status(401).json({
+        error: "Unauthorized",
+        detail: "Missing token",
+      });
+    }
+
+    const { data, error } = await supabase.auth.getUser(token);
+    if (error || !data.user) {
+      return res.status(401).json({
+        error: "Unauthorized",
+        detail: "Invalid token",
+      });
+    }
+
+    next();
+  } catch (err) {
+    return res.status(401).json({
+      error: "Unauthorized",
+      detail: "Token verification failed",
+    });
+  }
+};
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +63,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +183,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,144 @@
+import request from "supertest";
+import express from "express";
+import { router as telemetryRouter } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn()
+    }
+  }
+}));
+
+// Mock devhub to prevent any side effects if it gets evaluated
+jest.mock("../../src/routes/devhub", () => ({
+  broadcastEvent: jest.fn()
+}), { virtual: true });
+
+describe("Telemetry Routes Authentication", () => {
+  let app: express.Express;
+  let originalFetch: typeof global.fetch;
+
+  beforeAll(() => {
+    originalFetch = global.fetch;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    app.use("/api/v1/telemetry", telemetryRouter);
+    
+    jest.clearAllMocks();
+    process.env.SUPABASE_URL = "http://localhost:8000";
+    process.env.SUPABASE_SERVICE_ROLE = "test-service-key";
+    
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+      text: async () => ""
+    });
+  });
+
+  const validEvent = {
+    vtid: "VTID-001",
+    layer: "core",
+    module: "test",
+    source: "test-runner",
+    kind: "event.test",
+    status: "success",
+    title: "Test Event"
+  };
+
+  describe("POST /api/v1/telemetry/event", () => {
+    it("should return 401 when no Authorization header is provided", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validEvent);
+      
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should return 401 when an invalid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: new Error("Invalid token")
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validEvent);
+      
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should proceed and return 202 when a valid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "test-user-id" } },
+        error: null
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send(validEvent);
+      
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    const validBatch = [validEvent];
+
+    it("should return 401 when no Authorization header is provided", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send(validBatch);
+      
+      expect(res.status).toBe(401);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should return 401 when an invalid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: new Error("Invalid token")
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validBatch);
+      
+      expect(res.status).toBe(401);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should proceed and return 202 when a valid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "test-user-id" } },
+        error: null
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-token")
+        .send(validBatch);
+      
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
Addresses a flagged `rls_gap` for the `oasis_events` table by introducing application-level authentication checks.

- Adds `requireAuthenticatedUser` middleware to `POST /event` and `POST /batch` inside `services/gateway/src/routes/telemetry.ts`.
- Validates the Supabase session token via `supabase.auth.getUser()`.
- Rejects unauthenticated telemetry write requests with `401 Unauthorized`.
- Adds unit tests in `services/gateway/test/routes/telemetry.test.ts` to assert auth failure and success branches.

Note: The database-level RLS migration for `oasis_events` must be added manually in `supabase/migrations/` to fully close the security issue at the DB layer, as file modifications within `supabase/migrations/` fall outside of automated execution scope.