### PR TITLE
DEV-AUTOPILOT: Refactor admin-notifications auth to use requireAdmin

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -12,48 +12,18 @@
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/auth';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIFICATIONS';
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
+router.use(requireAdmin);
 
 // ── POST /compose — Send notification to user(s) ────────────
 
 router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
+  const userEmail = (req as any).user?.email || 'unknown';
 
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
@@ -148,7 +118,7 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      console.log(`[${VTID}] Composed notification for 1 user by ${userEmail}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +131,7 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${userEmail}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -177,9 +147,6 @@ router.post('/compose', async (req: Request, res: Response) => {
 // ── GET /sent — Admin notification log ──────────────────────
 
 router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -224,9 +191,6 @@ router.get('/sent', async (req: Request, res: Response) => {
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
 router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,140 @@
+import request from 'supertest';
+import express from 'express';
+import adminNotificationsRouter from '../../src/routes/admin-notifications';
+import * as supabaseLib from '../../src/lib/supabase';
+import * as notificationService from '../../src/services/notification-service';
+
+jest.mock('../../src/middleware/auth', () => ({
+  requireAdmin: jest.fn((req, res, next) => {
+    req.user = { id: 'admin-id', email: 'admin@test.com' };
+    next();
+  }),
+}));
+
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn(),
+}));
+
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn(),
+  notifyUsersAsync: jest.fn(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/admin/notifications', adminNotificationsRouter);
+
+describe('Admin Notifications API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('POST /compose', () => {
+    it('should return 400 if title or body is missing', async () => {
+      (supabaseLib.getSupabase as jest.Mock).mockReturnValue({});
+      const res = await request(app).post('/admin/notifications/compose').send({});
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('INVALID_INPUT');
+    });
+
+    it('should successfully dispatch notification to specific users', async () => {
+      const mockSupabase = {};
+      (supabaseLib.getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+      (notificationService.notifyUser as jest.Mock).mockResolvedValue(true);
+
+      const res = await request(app).post('/admin/notifications/compose').send({
+        recipient_ids: ['user-1'],
+        title: 'Hello',
+        body: 'World',
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body.sent_to).toBe(1);
+      expect(notificationService.notifyUser).toHaveBeenCalledWith(
+        'user-1',
+        '',
+        'welcome_to_vitana',
+        expect.any(Object),
+        mockSupabase
+      );
+    });
+
+    it('should return 500 if supabase is unavailable', async () => {
+      (supabaseLib.getSupabase as jest.Mock).mockReturnValue(null);
+      const res = await request(app).post('/admin/notifications/compose').send({
+        recipient_ids: ['user-1'],
+        title: 'Hello',
+        body: 'World',
+      });
+      expect(res.status).toBe(500);
+      expect(res.body.error).toBe('SUPABASE_UNAVAILABLE');
+    });
+  });
+
+  describe('GET /sent', () => {
+    it('should fetch sent notifications', async () => {
+      const mockSelect = jest.fn().mockReturnThis();
+      const mockGte = jest.fn().mockReturnThis();
+      const mockOrder = jest.fn().mockReturnThis();
+      const mockRange = jest.fn().mockResolvedValue({
+        data: [{ id: 'notif-1' }],
+        count: 1,
+        error: null,
+      });
+
+      const mockSupabase = {
+        from: jest.fn().mockReturnValue({
+          select: mockSelect,
+          gte: mockGte,
+          order: mockOrder,
+          range: mockRange,
+        }),
+      };
+
+      (supabaseLib.getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+
+      const res = await request(app).get('/admin/notifications/sent');
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.total).toBe(1);
+    });
+  });
+
+  describe('GET /preferences/stats', () => {
+    it('should fetch preference stats', async () => {
+      const mockSupabase = {
+        from: jest.fn((table) => {
+          if (table === 'user_notification_preferences') {
+            return {
+              select: jest.fn().mockResolvedValue({
+                data: [{ push_enabled: true }, { push_enabled: false }],
+                error: null,
+              }),
+            };
+          }
+          if (table === 'user_notifications') {
+            return {
+              select: jest.fn().mockReturnThis(),
+              gte: jest.fn().mockImplementation(() => {
+                const chain = {
+                  not: jest.fn().mockResolvedValue({ count: 3 }),
+                };
+                (chain as any).then = (resolve: any) => resolve({ count: 10 });
+                return chain;
+              }),
+            };
+          }
+          return { select: jest.fn() };
+        }),
+      };
+
+      (supabaseLib.getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+
+      const res = await request(app).get('/admin/notifications/preferences/stats');
+      expect(res.status).toBe(200);
+      expect(res.body.stats.total_users_with_prefs).toBe(2);
+      expect(res.body.delivery.total_sent_30d).toBe(10);
+      expect(res.body.delivery.total_read_30d).toBe(3);
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses missing authentication in `services/gateway/src/routes/admin-notifications.ts` flagged by `route-auth-scanner-v1`. 

### Changes
- Replaced the inline `verifyExafyAdmin` authentication helper with the shared `requireAdmin` middleware across all endpoints in the router.
- Removed custom bearer token and Supabase auth client fetching specific to this router.
- Updated `POST /compose` logic to use `req.user.email` supplied by the shared middleware instead of parsing it from the custom helper.
- Added comprehensive unit tests in `services/gateway/test/routes/admin-notifications.test.ts` to cover the refactored endpoints and mock the shared middleware.

This brings the file in line with standard project auth patterns and will clear the vulnerability scan findings.