### PR TITLE
DEV-AUTOPILOT: Add system-controls API endpoint for feature flags

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,22 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { getSystemControl } from '../services/system-controls';
+
+const router = Router();
+
+router.get('/:key', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const { key } = req.params;
+    const control = await getSystemControl(key);
+
+    if (!control) {
+      res.status(404).json({ error: 'System control not found' });
+      return;
+    }
+
+    res.status(200).json(control);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,20 @@
+import { supabase } from '../lib/supabase';
+import { SystemControl } from '../types/system-controls';
+
+export async function getSystemControl(key: string): Promise<SystemControl | null> {
+  const { data, error } = await supabase
+    .from('system_controls')
+    .select('*')
+    .eq('key', key)
+    .single();
+
+  if (error) {
+    // PGRST116 indicates no rows returned for .single() query
+    if (error.code === 'PGRST116') {
+      return null;
+    }
+    throw error;
+  }
+
+  return data as SystemControl;
+}

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at?: string;
+  updated_by?: string;
+  reason?: string;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,53 @@
+import request from 'supertest';
+import express, { Request, Response, NextFunction } from 'express';
+import systemControlsRouter from '../../src/routes/system-controls';
+import { getSystemControl } from '../../src/services/system-controls';
+
+jest.mock('../../src/services/system-controls', () => ({
+  getSystemControl: jest.fn()
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/api/system-controls', systemControlsRouter);
+app.use((err: any, req: Request, res: Response, next: NextFunction) => {
+  res.status(500).json({ error: 'Internal server error' });
+});
+
+describe('System Controls Routes', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return 200 and the control if found', async () => {
+    const mockData = {
+      key: 'vitana_did_you_know_enabled',
+      enabled: true,
+    };
+    (getSystemControl as jest.Mock).mockResolvedValue(mockData);
+
+    const response = await request(app).get('/api/system-controls/vitana_did_you_know_enabled');
+    
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockData);
+    expect(getSystemControl).toHaveBeenCalledWith('vitana_did_you_know_enabled');
+  });
+
+  it('should return 404 if control is not found', async () => {
+    (getSystemControl as jest.Mock).mockResolvedValue(null);
+
+    const response = await request(app).get('/api/system-controls/unknown_key');
+    
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'System control not found' });
+  });
+
+  it('should return 500 if an error occurs', async () => {
+    (getSystemControl as jest.Mock).mockRejectedValue(new Error('Service Error'));
+
+    const response = await request(app).get('/api/system-controls/vitana_did_you_know_enabled');
+    
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: 'Internal server error' });
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,52 @@
+import { getSystemControl } from '../src/services/system-controls';
+import { supabase } from '../src/lib/supabase';
+
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+describe('System Controls Service', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return a system control when found', async () => {
+    const mockData = {
+      key: 'vitana_did_you_know_enabled',
+      enabled: true,
+      updated_at: '2023-01-01T00:00:00Z',
+    };
+
+    const mockSingle = jest.fn().mockResolvedValue({ data: mockData, error: null });
+    const mockEq = jest.fn().mockReturnValue({ single: mockSingle });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    (supabase.from as jest.Mock).mockReturnValue({ select: mockSelect });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+    expect(result).toEqual(mockData);
+    expect(supabase.from).toHaveBeenCalledWith('system_controls');
+    expect(mockSelect).toHaveBeenCalledWith('*');
+    expect(mockEq).toHaveBeenCalledWith('key', 'vitana_did_you_know_enabled');
+  });
+
+  it('should return null when not found (PGRST116)', async () => {
+    const mockSingle = jest.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } });
+    const mockEq = jest.fn().mockReturnValue({ single: mockSingle });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    (supabase.from as jest.Mock).mockReturnValue({ select: mockSelect });
+
+    const result = await getSystemControl('unknown_flag');
+    expect(result).toBeNull();
+  });
+
+  it('should throw on other errors', async () => {
+    const mockSingle = jest.fn().mockResolvedValue({ data: null, error: new Error('DB Error') });
+    const mockEq = jest.fn().mockReturnValue({ single: mockSingle });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    (supabase.from as jest.Mock).mockReturnValue({ select: mockSelect });
+
+    await expect(getSystemControl('vitana_did_you_know_enabled')).rejects.toThrow('DB Error');
+  });
+});


### PR DESCRIPTION
Adds API endpoints and services for fetching system controls. This allows clients (like the frontend command-hub) to dynamically check feature flags, such as the `vitana_did_you_know_enabled` flag introduced by a recent migration.

Files touched:
- `services/gateway/src/types/system-controls.ts`
- `services/gateway/src/services/system-controls.ts`
- `services/gateway/src/routes/system-controls.ts`
- `services/gateway/test/system-controls.test.ts`
- `services/gateway/test/routes/system-controls.test.ts`

**Note for operators:**
The frontend (command-hub) integration for consuming this new endpoint is not included in this PR due to locked scope constraints. Please follow up by locating the relevant `DidYouKnowTour` component in `services/gateway/src/frontend/command-hub/` and adding a fetch to `/api/system-controls/vitana_did_you_know_enabled` to conditionally render the tour based on the system control flag. Additionally, remember to mount the exported `systemControlsRouter` in the main Express application.