### PR TITLE
DEV-AUTOPILOT: Refactor admin notification categories to use standard requireAdmin

### DIFF
--- a/services/gateway/src/routes/admin-notification-categories.ts
+++ b/services/gateway/src/routes/admin-notification-categories.ts
@@ -11,12 +11,12 @@
  * - POST   /:id/test      — Send test notification to admin
  *
  * Security:
- * - All endpoints are protected by the `requireExafyAdmin` middleware.
+ * - All endpoints are protected by the `requireAdmin` middleware.
  */
 
-import { Router, Request, Response, NextFunction } from 'express';
+import { Router, Request, Response } from 'express';
 import { createClient } from '@supabase/supabase-js';
-import { createUserSupabaseClient } from '../lib/supabase-user';
+import { requireAdmin } from '../middleware/requireAdmin';
 import { notifyUser, NotificationPayload } from '../services/notification-service';
 
 const router = Router();
@@ -24,42 +24,7 @@ const VTID = 'ADMIN-NOTIF-CATEGORIES';
 
 const VALID_TYPES = ['chat', 'calendar', 'community'];
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-// ── Auth Middleware ─────────────────────────────────────────
-
-async function requireExafyAdmin(req: Request, res: Response, next: NextFunction) {
-  const token = getBearerToken(req);
-  if (!token) return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) {
-      return res.status(401).json({ ok: false, error: 'INVALID_TOKEN' });
-    }
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return res.status(403).json({ ok: false, error: 'FORBIDDEN' });
-    }
-
-    // Attach user info to request for downstream handlers
-    (req as any).authUser = { user_id: authData.user.id, email: authData.user.email || 'unknown' };
-    next();
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
-  }
-}
-
-router.use(requireExafyAdmin);
+router.use(requireAdmin);
 
 // ── Supabase ────────────────────────────────────────────────
 
@@ -140,7 +105,7 @@ router.get('/:id', async (req: Request, res: Response) => {
 // ── POST / — Create category ───────────────────────────────
 
 router.post('/', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const user = (req as any).user;
 
   const supabase = getSupabase();
   const {
@@ -180,7 +145,7 @@ router.post('/', async (req: Request, res: Response) => {
     default_enabled: default_enabled ?? true,
     mapped_types: mapped_types || [],
     tenant_id: tenant_id || null,
-    created_by: authUser.user_id,
+    created_by: user?.id,
   };
 
   const { data, error } = await supabase
@@ -197,14 +162,14 @@ router.post('/', async (req: Request, res: Response) => {
     return res.status(500).json({ ok: false, error: error.message });
   }
 
-  console.log(`[${VTID}] Created category "${slug}" (${type}) by ${authUser.email}`);
+  console.log(`[${VTID}] Created category "${slug}" (${type}) by ${user?.email ?? 'unknown'}`);
   return res.status(201).json({ ok: true, data });
 });
 
 // ── PATCH /:id — Update category ────────────────────────────
 
 router.patch('/:id', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const user = (req as any).user;
 
   const supabase = getSupabase();
   const allowedFields = ['display_name', 'description', 'icon', 'sort_order', 'is_active', 'default_enabled', 'mapped_types'];
@@ -236,14 +201,14 @@ router.patch('/:id', async (req: Request, res: Response) => {
     return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
   }
 
-  console.log(`[${VTID}] Updated category "${data.slug}" by ${authUser.email}`);
+  console.log(`[${VTID}] Updated category "${data.slug}" by ${user?.email ?? 'unknown'}`);
   return res.json({ ok: true, data });
 });
 
 // ── DELETE /:id — Soft-delete (set is_active=false) ─────────
 
 router.delete('/:id', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const user = (req as any).user;
 
   const supabase = getSupabase();
   const { data, error } = await supabase
@@ -261,14 +226,14 @@ router.delete('/:id', async (req: Request, res: Response) => {
     return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
   }
 
-  console.log(`[${VTID}] Soft-deleted category "${data.slug}" by ${authUser.email}`);
+  console.log(`[${VTID}] Soft-deleted category "${data.slug}" by ${user?.email ?? 'unknown'}`);
   return res.json({ ok: true, data });
 });
 
 // ── POST /:id/test — Send test notification to admin ────────
 
 router.post('/:id/test', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const user = (req as any).user;
 
   const supabase = getSupabase();
 
@@ -296,15 +261,15 @@ router.post('/:id/test', async (req: Request, res: Response) => {
   const { data: tenantRow } = await supabase
     .from('user_tenants')
     .select('tenant_id')
-    .eq('user_id', authUser.user_id)
+    .eq('user_id', user?.id)
     .limit(1)
     .single();
 
   const tenantId = tenantRow?.tenant_id || '00000000-0000-0000-0000-000000000000';
 
   try {
-    const result = await notifyUser(authUser.user_id, tenantId, testType, payload, supabase);
-    console.log(`[${VTID}] Test notification sent for category "${category.slug}" by ${authUser.email}`);
+    const result = await notifyUser(user?.id, tenantId, testType, payload, supabase);
+    console.log(`[${VTID}] Test notification sent for category "${category.slug}" by ${user?.email ?? 'unknown'}`);
     return res.json({ ok: true, result });
   } catch (err: any) {
     console.error(`[${VTID}] POST /:id/test error:`, err.message);

--- a/services/gateway/tests/admin-notification-categories.test.ts
+++ b/services/gateway/tests/admin-notification-categories.test.ts
@@ -1,0 +1,91 @@
+import request from 'supertest';
+import express from 'express';
+
+// Set up mock before importing the router to ensure it uses the mocked middleware
+jest.mock('../src/middleware/requireAdmin', () => ({
+  requireAdmin: jest.fn((req, res, next) => {
+    const authHeader = req.headers.authorization;
+    if (!authHeader) {
+      return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+    }
+    if (authHeader.includes('non-admin')) {
+      return res.status(403).json({ ok: false, error: 'FORBIDDEN' });
+    }
+    req.user = { id: 'admin-123', email: 'admin@example.com' };
+    next();
+  })
+}));
+
+const mockQueryObj: any = {
+  select: jest.fn().mockReturnThis(),
+  insert: jest.fn().mockReturnThis(),
+  update: jest.fn().mockReturnThis(),
+  eq: jest.fn().mockReturnThis(),
+  order: jest.fn().mockReturnThis(),
+  is: jest.fn().mockReturnThis(),
+  or: jest.fn().mockReturnThis(),
+  limit: jest.fn().mockReturnThis(),
+  single: jest.fn(),
+};
+mockQueryObj.then = jest.fn((resolve) => resolve({ data: [], error: null }));
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: jest.fn(() => mockQueryObj)
+  })
+}));
+
+import adminNotificationCategoriesRouter from '../src/routes/admin-notification-categories';
+
+const app = express();
+app.use(express.json());
+app.use('/admin-categories', adminNotificationCategoriesRouter);
+
+describe('Admin Notification Categories API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    
+    mockQueryObj.then.mockImplementation((resolve: any) => resolve({ data: [], error: null }));
+    mockQueryObj.single.mockResolvedValue({ 
+      data: { id: 'cat-123', slug: 'test_cat', type: 'chat' }, 
+      error: null 
+    });
+  });
+
+  it('rejects unauthenticated requests with 401', async () => {
+    const response = await request(app).get('/admin-categories');
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({ ok: false, error: 'UNAUTHENTICATED' });
+  });
+
+  it('rejects non-admin authenticated requests with 403', async () => {
+    const response = await request(app)
+      .get('/admin-categories')
+      .set('Authorization', 'Bearer non-admin-token');
+    
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({ ok: false, error: 'FORBIDDEN' });
+  });
+
+  it('allows admin requests and returns 200 on GET', async () => {
+    const response = await request(app)
+      .get('/admin-categories')
+      .set('Authorization', 'Bearer admin-token');
+    
+    expect(response.status).toBe(200);
+    expect(response.body.ok).toBe(true);
+  });
+
+  it('allows admin requests and returns 201 on POST', async () => {
+    const response = await request(app)
+      .post('/admin-categories')
+      .set('Authorization', 'Bearer admin-token')
+      .send({
+        type: 'chat',
+        display_name: 'Test Category'
+      });
+    
+    expect(response.status).toBe(201);
+    expect(response.body.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
**Context**
The `route-auth-scanner-v1` flagged this file for using a non-standard inline auth pattern instead of the shared middleware. This PR replaces the bespoke inline functions with `router.use(requireAdmin)` for consistent enforcement and scanner compliance.

**Changes**
- Added `import { requireAdmin } from '../middleware/requireAdmin';`
- Replaced the inline `requireExafyAdmin` and `getBearerToken` helpers with a top-level `router.use(requireAdmin)`.
- Replaced per-route accesses of `(req as any).authUser` with standard `(req as any).user` properties.
- Removed unused `createUserSupabaseClient` import.
- Added 3 test cases to `tests/admin-notification-categories.test.ts` to assert that 401 unauthenticated, 403 forbidden, and 200/201 successful paths behave as expected across the auth boundary.