### PR TITLE
DEV-AUTOPILOT: Refactor admin-notifications to use shared requireAdmin middleware

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -12,48 +12,18 @@
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/auth';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIFICATIONS';
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
+router.use(requireAdmin);
 
 // ── POST /compose — Send notification to user(s) ────────────
 
 router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
+  const userEmail = (req as any).user?.email || 'unknown';
 
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
@@ -148,7 +118,7 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      console.log(`[${VTID}] Composed notification for 1 user by ${userEmail}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +131,7 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${userEmail}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -177,9 +147,6 @@ router.post('/compose', async (req: Request, res: Response) => {
 // ── GET /sent — Admin notification log ──────────────────────
 
 router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -224,9 +191,6 @@ router.get('/sent', async (req: Request, res: Response) => {
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
 router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,132 @@
+import request from 'supertest';
+import express from 'express';
+
+// Mock the requireAdmin middleware BEFORE importing the router
+jest.mock('../../src/middleware/auth', () => ({
+  requireAdmin: jest.fn((req, res, next) => {
+    req.user = { id: 'admin-id', email: 'admin@test.com' };
+    next();
+  })
+}));
+
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn()
+}));
+
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn(),
+  notifyUsersAsync: jest.fn()
+}));
+
+import adminNotificationsRouter from '../../src/routes/admin-notifications';
+import { getSupabase } from '../../src/lib/supabase';
+import { notifyUser, notifyUsersAsync } from '../../src/services/notification-service';
+
+const app = express();
+app.use(express.json());
+app.use('/admin-notifications', adminNotificationsRouter);
+
+describe('Admin Notifications Router', () => {
+  const mockGetSupabase = getSupabase as jest.Mock;
+  const mockNotifyUser = notifyUser as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const createChainableMock = (resolvedValue: any) => {
+    const chain: any = {
+      select: jest.fn(() => chain),
+      gte: jest.fn(() => chain),
+      eq: jest.fn(() => chain),
+      not: jest.fn(() => chain),
+      order: jest.fn(() => chain),
+      range: jest.fn(() => chain),
+      or: jest.fn(() => chain),
+      then: (resolve: any) => resolve(resolvedValue),
+    };
+    return chain;
+  };
+
+  describe('POST /compose', () => {
+    it('should send notification to a specific user', async () => {
+      const mockSupabase = {};
+      mockGetSupabase.mockReturnValue(mockSupabase);
+      mockNotifyUser.mockResolvedValue({ ok: true });
+
+      const res = await request(app)
+        .post('/admin-notifications/compose')
+        .send({
+          title: 'Test',
+          body: 'Test body',
+          recipient_ids: ['user-1']
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(mockNotifyUser).toHaveBeenCalledWith(
+        'user-1',
+        '',
+        'welcome_to_vitana',
+        { title: 'Test', body: 'Test body', data: undefined },
+        mockSupabase
+      );
+    });
+
+    it('should return 400 if title or body is missing', async () => {
+      const res = await request(app)
+        .post('/admin-notifications/compose')
+        .send({
+          recipient_ids: ['user-1']
+        });
+
+      expect(res.status).toBe(400);
+      expect(res.body.ok).toBe(false);
+      expect(res.body.message).toBe('title and body are required');
+    });
+  });
+
+  describe('GET /sent', () => {
+    it('should return a list of sent notifications', async () => {
+      const mockSupabase = {
+        from: jest.fn().mockReturnValue(createChainableMock({
+          data: [{ id: 1, title: 'Notification 1' }],
+          count: 1,
+          error: null
+        }))
+      };
+      mockGetSupabase.mockReturnValue(mockSupabase);
+
+      const res = await request(app).get('/admin-notifications/sent');
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.total).toBe(1);
+    });
+  });
+
+  describe('GET /preferences/stats', () => {
+    it('should return aggregate stats', async () => {
+      const mockSupabase = {
+        from: jest.fn((table: string) => {
+          if (table === 'user_notification_preferences') {
+            return createChainableMock({ data: [{ push_enabled: true }], error: null });
+          }
+          if (table === 'user_notifications') {
+            return createChainableMock({ count: 10, error: null });
+          }
+          return createChainableMock({});
+        })
+      };
+      mockGetSupabase.mockReturnValue(mockSupabase);
+
+      const res = await request(app).get('/admin-notifications/preferences/stats');
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.stats.total_users_with_prefs).toBe(1);
+      expect(res.body.delivery.total_sent_30d).toBe(10);
+    });
+  });
+});


### PR DESCRIPTION
**Context**
The scanner `route-auth-scanner-v1` flagged `admin-notifications.ts` as missing standard authentication, as it was using an inline `verifyExafyAdmin` helper instead of the project's standard auth middleware pattern.

**Changes**
- Removed inline `getBearerToken` and `verifyExafyAdmin` functions from `services/gateway/src/routes/admin-notifications.ts`.
- Replaced with the shared `requireAdmin` middleware applied globally to the router.
- Updated user identity references in logging from `authResult.email` to `req.user.email`.
- Created a new test file `services/gateway/test/routes/admin-notifications.test.ts` which mocks the `requireAdmin` middleware and ensures route behavior remains unchanged.

This addresses the security inconsistency while reducing maintenance overhead.

Files touched:
- `services/gateway/src/routes/admin-notifications.ts`
- `services/gateway/test/routes/admin-notifications.test.ts`