### PR TITLE
DEV-AUTOPILOT: Add paramLimit middleware to mitigate path-to-regexp ReDoS

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,36 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  // Use RegExp only for validation, avoiding the vulnerable path-to-regexp matching.
+  // This regex matches any single path segment that exceeds maxLength.
+  const longSegmentRegex = new RegExp(`[^/]{${maxLength + 1},}`);
+
+  return (req: Request, res: Response, next: NextFunction) => {
+    // 1. Validate raw path to defend against ReDoS before Express path-to-regexp
+    // executes. This is crucial for when the middleware is applied via router.use()
+    const pathString = req.path || '';
+    if (longSegmentRegex.test(pathString)) {
+      res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    // 2. Parse req.params and count keys as an explicit post-match defense layer
+    const params = req.params || {};
+    const keys = Object.keys(params);
+
+    if (keys.length > maxParams) {
+      res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    for (const key of keys) {
+      const val = params[key];
+      if (typeof val === 'string' && val.length > maxLength) {
+        res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,17 @@
+import { Router } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply param limit middleware to mitigate path-to-regexp ReDoS
+router.use(limitPathParams());
+
+router.get('/:projectId', (req, res) => {
+  res.json({ id: req.params.projectId, type: 'project' });
+});
+
+router.get('/:projectId/members/:memberId', (req, res) => {
+  res.json({ projectId: req.params.projectId, memberId: req.params.memberId });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,17 @@
+import { Router } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply param limit middleware to mitigate path-to-regexp ReDoS
+router.use(limitPathParams());
+
+router.get('/:userId', (req, res) => {
+  res.json({ id: req.params.userId, type: 'user' });
+});
+
+router.get('/:userId/profile', (req, res) => {
+  res.json({ id: req.params.userId, type: 'profile' });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,58 @@
+import express from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - limitPathParams', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = express();
+    
+    // Mount as route-specific middleware to test req.params limit explicitly
+    app.get('/resource/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req, res) => {
+      res.status(200).json({ success: true });
+    });
+
+    app.get('/valid/:a/:b', limitPathParams(5, 200), (req, res) => {
+      res.status(200).json({ success: true });
+    });
+
+    // Mount globally to test integration and ReDoS prevention before route matching
+    app.use(limitPathParams(5, 200));
+    app.get('/integration/:a/:b/:c/:d/:e/:f?', (req, res) => {
+      res.status(200).json({ success: true });
+    });
+  });
+
+  it('Test 3: Valid request with 2 params passes successfully', async () => {
+    const response = await request(app).get('/valid/param1/param2');
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+  });
+
+  it('Test 1: Confirms 400 when >5 params are passed in route match', async () => {
+    const response = await request(app).get('/resource/1/2/3/4/5/6');
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('Test 2: Confirms 400 when a parameter is long (>200 chars)', async () => {
+    const longParam = 'x'.repeat(201);
+    const response = await request(app).get(`/valid/1/${longParam}`);
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('Integration test: prevents ReDoS by returning 400 in <500ms', async () => {
+    const start = Date.now();
+    // A pathological request designed to trigger ReDoS in path-to-regexp
+    // via a segment that exceeds the mitigation limits
+    const pathologicalValue = 'A'.repeat(500);
+    const response = await request(app).get(`/integration/1/2/3/4/5/${pathologicalValue}`);
+    const duration = Date.now() - start;
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
**Context & Plan Summary:**
A ReDoS vulnerability in `path-to-regexp` (<0.1.13) exposes the Gateway service to potential CPU exhaustion via crafted request paths that trigger catastrophic backtracking. Because direct `package.json` updates are out of scope for this change, we are implementing a server-side mitigation via a custom Express middleware (`limitPathParams`). 

The middleware validates the raw request path (using a safe regular expression) to block excessively long segments before they reach the vulnerable `path-to-regexp` router engine. It also explicitly parses `req.params` and limits the total parameter count and lengths for defense-in-depth on route-specific applications. The middleware has been applied to `userRoutes.ts` and `projectRoutes.ts` as a baseline.

**Files touched:**
- `services/gateway/src/routes/middleware/paramLimit.ts`
- `services/gateway/src/routes/v1/userRoutes.ts`
- `services/gateway/src/routes/v1/projectRoutes.ts`
- `services/gateway/test/cve-mitigation.test.ts`

**Note to operator:** 
The plan requires applying the `limitPathParams` middleware to *all* route files in `services/gateway/src/routes/` containing path parameters. As an autopilot agent, my modifications are restricted to the locked target file list. Please ensure that `router.use(limitPathParams())` is applied to any remaining relevant route files in the gateway service not included in this PR.