### PR TITLE
DEV-AUTOPILOT: Refactor admin-notifications to use shared requireAdmin

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -12,48 +12,18 @@
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/auth';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIFICATIONS';
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
+router.use(requireAdmin);
 
 // ── POST /compose — Send notification to user(s) ────────────
 
 router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
+  const adminEmail = (req as any).user?.email || 'unknown';
 
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
@@ -148,7 +118,7 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      console.log(`[${VTID}] Composed notification for 1 user by ${adminEmail}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +131,7 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${adminEmail}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -177,9 +147,6 @@ router.post('/compose', async (req: Request, res: Response) => {
 // ── GET /sent — Admin notification log ──────────────────────
 
 router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -224,9 +191,6 @@ router.get('/sent', async (req: Request, res: Response) => {
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
 router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,173 @@
+import request from 'supertest';
+import express from 'express';
+import adminNotificationsRouter from '../../src/routes/admin-notifications';
+import { getSupabase } from '../../src/lib/supabase';
+import { notifyUser, notifyUsersAsync } from '../../src/services/notification-service';
+
+// Mock the auth middleware
+jest.mock('../../src/middleware/auth', () => ({
+  requireAdmin: jest.fn((req, res, next) => {
+    req.user = { id: 'admin-id', email: 'admin@test.com' };
+    next();
+  })
+}));
+
+// Mock Supabase
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn()
+}));
+
+// Mock Notification Service
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn(),
+  notifyUsersAsync: jest.fn()
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/admin-notifications', adminNotificationsRouter);
+
+describe('Admin Notifications Router', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('POST /compose', () => {
+    it('should require title and body', async () => {
+      const mockSupabase = {
+        from: jest.fn()
+      };
+      (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+
+      const response = await request(app)
+        .post('/admin-notifications/compose')
+        .send({
+          recipient_ids: ['user-1']
+        });
+
+      expect(response.status).toBe(400);
+      expect(response.body.ok).toBe(false);
+      expect(response.body.error).toBe('INVALID_INPUT');
+    });
+
+    it('should call notifyUser for a single recipient', async () => {
+      const mockSupabase = {
+        from: jest.fn()
+      };
+      (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+      (notifyUser as jest.Mock).mockResolvedValue({ success: true });
+
+      const response = await request(app)
+        .post('/admin-notifications/compose')
+        .send({
+          recipient_ids: ['user-1'],
+          title: 'Hello',
+          body: 'World'
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body.ok).toBe(true);
+      expect(notifyUser).toHaveBeenCalledWith(
+        'user-1',
+        '',
+        'welcome_to_vitana',
+        { title: 'Hello', body: 'World', data: undefined },
+        mockSupabase
+      );
+    });
+
+    it('should call notifyUsersAsync for multiple recipients', async () => {
+      const mockSupabase = {
+        from: jest.fn()
+      };
+      (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+
+      const response = await request(app)
+        .post('/admin-notifications/compose')
+        .send({
+          recipient_ids: ['user-1', 'user-2'],
+          title: 'Hello',
+          body: 'World'
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body.ok).toBe(true);
+      expect(notifyUsersAsync).toHaveBeenCalledWith(
+        ['user-1', 'user-2'],
+        '',
+        'welcome_to_vitana',
+        { title: 'Hello', body: 'World', data: undefined },
+        mockSupabase
+      );
+    });
+  });
+
+  describe('GET /sent', () => {
+    it('should fetch sent notifications', async () => {
+      const mockSelect = jest.fn().mockReturnThis();
+      const mockGte = jest.fn().mockReturnThis();
+      const mockOrder = jest.fn().mockReturnThis();
+      const mockRange = jest.fn().mockResolvedValue({
+        data: [{ id: 'notif-1' }],
+        count: 1,
+        error: null
+      });
+
+      const mockSupabase = {
+        from: jest.fn().mockReturnValue({
+          select: mockSelect,
+          gte: mockGte,
+          order: mockOrder,
+          range: mockRange
+        })
+      };
+
+      (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+
+      const response = await request(app).get('/admin-notifications/sent');
+
+      expect(response.status).toBe(200);
+      expect(response.body.ok).toBe(true);
+      expect(response.body.data).toHaveLength(1);
+      expect(mockSupabase.from).toHaveBeenCalledWith('user_notifications');
+    });
+  });
+
+  describe('GET /preferences/stats', () => {
+    it('should return preference stats', async () => {
+      const mockSupabase = {
+        from: jest.fn().mockImplementation((table) => {
+          if (table === 'user_notification_preferences') {
+            return {
+              select: jest.fn().mockResolvedValue({
+                data: [
+                  { push_enabled: true },
+                  { push_enabled: false }
+                ],
+                error: null
+              })
+            };
+          }
+          if (table === 'user_notifications') {
+            return {
+              select: jest.fn().mockReturnThis(),
+              gte: jest.fn().mockReturnValue(
+                Object.assign(Promise.resolve({ count: 10 }), {
+                  not: jest.fn().mockResolvedValue({ count: 5 })
+                })
+              )
+            };
+          }
+        })
+      };
+
+      (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+
+      const response = await request(app).get('/admin-notifications/preferences/stats');
+
+      expect(response.status).toBe(200);
+      expect(response.body.ok).toBe(true);
+      expect(response.body.stats.total_users_with_prefs).toBe(2);
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses the missing authentication finding flagged by the `route-auth-scanner-v1`.

- Replaced custom `verifyExafyAdmin` inline authentication with the standard shared `requireAdmin` middleware in `services/gateway/src/routes/admin-notifications.ts`.
- Removed local token parsing and custom supabase client initialization for auth.
- Standardized logging to use `req.user.email` set by `requireAdmin`.
- Added missing test suite for `admin-notifications.test.ts` to mock the middleware and cover the existing logic.