### PR TITLE
DEV-AUTOPILOT: Enforce application-level auth on telemetry endpoints

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,32 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+// Middleware to enforce authentication
+const requireAuthenticatedUser = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      return res.status(401).json({ error: "Unauthorized", detail: "Missing or invalid authorization header" });
+    }
+    
+    const token = authHeader.split(" ")[1];
+    const { data, error } = await supabase.auth.getUser(token);
+    
+    if (error || !data?.user) {
+      return res.status(401).json({ error: "Unauthorized", detail: "Invalid session token" });
+    }
+    
+    return next();
+  } catch (err: any) {
+    console.error("❌ Auth middleware error:", err);
+    return res.status(500).json({ error: "Internal server error", detail: "Auth check failed" });
+  }
+};
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +49,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +169,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,145 @@
+import request from "supertest";
+import express from "express";
+import { router } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+// Mock supabase client
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+// Mock devhub broadcast to prevent side effects
+jest.mock("../../src/routes/devhub", () => ({
+  broadcastEvent: jest.fn(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1/telemetry", router);
+
+describe("Telemetry Routes Auth Enforcement", () => {
+  const originalEnv = process.env;
+  let fetchSpy: jest.SpyInstance;
+
+  beforeAll(() => {
+    process.env = {
+      ...originalEnv,
+      SUPABASE_URL: "https://mock-supabase.local",
+      SUPABASE_SERVICE_ROLE: "mock-service-role-key",
+    };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    fetchSpy = jest.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+      text: async () => (""),
+      status: 200
+    } as any);
+  });
+
+  afterEach(() => {
+    fetchSpy.mockRestore();
+  });
+
+  const validEventPayload = {
+    vtid: "VTID-TEST",
+    layer: "core",
+    module: "test",
+    source: "test-runner",
+    kind: "test.event",
+    status: "success",
+    title: "Test Event",
+  };
+
+  describe("POST /api/v1/telemetry/event", () => {
+    it("should return 401 if no Authorization header is provided", async () => {
+      const res = await request(app).post("/api/v1/telemetry/event").send(validEventPayload);
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("should return 401 if token is invalid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: new Error("Invalid session"),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer bad-token")
+        .send(validEventPayload);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("should proceed and return 202 if token is valid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send(validEventPayload);
+
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    const validBatchPayload = [validEventPayload];
+
+    it("should return 401 if no Authorization header is provided", async () => {
+      const res = await request(app).post("/api/v1/telemetry/batch").send(validBatchPayload);
+      expect(res.status).toBe(401);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("should return 401 if token is invalid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: new Error("Invalid session"),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer bad-token")
+        .send(validBatchPayload);
+
+      expect(res.status).toBe(401);
+      expect(fetchSpy).not.toHaveBeenCalled();
+    });
+
+    it("should proceed and return 202 if token is valid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-token")
+        .send(validBatchPayload);
+
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect(fetchSpy).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
**Summary:**
This PR adds application-level authentication checks to the `oasis_events` telemetry routes, closing a medium-risk RLS gap flagged by the `rls-policy-scanner-v1`. 

**Details:**
1. Created an Express middleware `requireAuthenticatedUser` in `telemetry.ts` that intercepts requests, checks the `Authorization` header against Supabase, and ensures `auth.uid()` is valid.
2. Applied the middleware to the `POST /event` and `POST /batch` endpoints, rejecting unauthenticated writes with HTTP 401.
3. Created a new unit test suite in `telemetry.test.ts` to verify 401 and success responses explicitly simulating both missing/invalid token errors and success passes. 

*Note for Operators:* The database-level RLS migration needs to be applied manually as a follow-up step via a new migration in `supabase/migrations/` (out-of-scope for automated execution).