### PR TITLE
DEV-AUTOPILOT: Refactor admin-notifications routes to use requireAdmin

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -12,49 +12,18 @@
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/auth';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIFICATIONS';
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
+// Apply admin authentication to all routes in this router
+router.use(requireAdmin);
 
 // ── POST /compose — Send notification to user(s) ────────────
 
 router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -138,6 +107,7 @@ router.post('/compose', async (req: Request, res: Response) => {
 
     // Determine effective tenant_id for dispatching
     const effectiveTenantId = tenant_id || (recipient_ids?.length === 1 ? undefined : undefined);
+    const adminEmail = (req as any).user?.email || 'unknown';
 
     // For single recipients, use synchronous dispatch for immediate feedback
     if (targetUserIds.length === 1) {
@@ -148,7 +118,7 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      console.log(`[${VTID}] Composed notification for 1 user by ${adminEmail}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +131,7 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${adminEmail}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -177,9 +147,6 @@ router.post('/compose', async (req: Request, res: Response) => {
 // ── GET /sent — Admin notification log ──────────────────────
 
 router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -224,9 +191,6 @@ router.get('/sent', async (req: Request, res: Response) => {
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
 router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,116 @@
+import request from 'supertest';
+import express from 'express';
+import adminNotificationsRouter from '../../src/routes/admin-notifications';
+import { getSupabase } from '../../src/lib/supabase';
+import { notifyUser, notifyUsersAsync } from '../../src/services/notification-service';
+
+// Mock dependencies
+jest.mock('../../src/middleware/auth', () => ({
+  requireAdmin: jest.fn((req, res, next) => {
+    (req as any).user = { id: 'admin-id', email: 'admin@test.com' };
+    next();
+  }),
+}));
+
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn(),
+}));
+
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn(),
+  notifyUsersAsync: jest.fn(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/admin/notifications', adminNotificationsRouter);
+
+describe('Admin Notifications API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('POST /compose', () => {
+    it('should return 400 if title or body is missing', async () => {
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ recipient_ids: ['u1'] });
+      
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('INVALID_INPUT');
+    });
+
+    it('should compose notification for a single user', async () => {
+      (getSupabase as jest.Mock).mockReturnValue({});
+      (notifyUser as jest.Mock).mockResolvedValue({ success: true });
+
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ title: 'Hello', body: 'World', recipient_ids: ['u1'] });
+      
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(notifyUser).toHaveBeenCalledWith('u1', '', 'welcome_to_vitana', expect.any(Object), expect.any(Object));
+    });
+  });
+
+  describe('GET /sent', () => {
+    it('should return sent notifications', async () => {
+      const mockQuery = {
+        select: jest.fn().mockReturnThis(),
+        gte: jest.fn().mockReturnThis(),
+        order: jest.fn().mockReturnThis(),
+        range: jest.fn().mockResolvedValue({ data: [{ id: '1' }], count: 1 }),
+      };
+      
+      const mockSupabase = {
+        from: jest.fn().mockReturnValue(mockQuery),
+      };
+      (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+
+      const res = await request(app).get('/admin/notifications/sent');
+      
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.data.length).toBe(1);
+    });
+  });
+
+  describe('GET /preferences/stats', () => {
+    it('should return preference stats', async () => {
+      const mockSupabase = {
+        from: jest.fn().mockImplementation((table) => {
+          if (table === 'user_notification_preferences') {
+            const mockSelect = {
+              eq: jest.fn().mockReturnThis(),
+              then: jest.fn((cb) => cb({ data: [{ push_enabled: true }] }))
+            };
+            return {
+              select: jest.fn().mockReturnValue(mockSelect)
+            };
+          }
+          if (table === 'user_notifications') {
+            const queryChain: any = {
+              select: jest.fn().mockReturnThis(),
+              gte: jest.fn().mockReturnThis(),
+              not: jest.fn().mockReturnThis(),
+              then: jest.fn((cb) => cb({ count: 10 }))
+            };
+            queryChain.not = jest.fn().mockReturnValue({
+              then: jest.fn((cb: any) => cb({ count: 5 }))
+            });
+            return queryChain;
+          }
+        }),
+      };
+
+      (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+
+      const res = await request(app).get('/admin/notifications/preferences/stats');
+      
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.stats.push_enabled).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
**Context & Plan**
The `route-auth-scanner-v1` scanner flagged `admin-notifications.ts` for missing authentication. This was because it used inline custom authentication (`verifyExafyAdmin`) instead of the standard auth middleware pattern.

This PR addresses the issue by:
1. Importing and applying the standard `requireAdmin` middleware to the entire `admin-notifications` router.
2. Removing inline `verifyExafyAdmin` and `getBearerToken` helper functions.
3. Updating the handlers to rely on `req.user` populated by the middleware for identifying the admin during logging.
4. Providing matching unit tests to ensure that the mocked `requireAdmin` middleware allows standard behavior tests to pass cleanly.

**Files touched:**
- `services/gateway/src/routes/admin-notifications.ts`
- `services/gateway/test/routes/admin-notifications.test.ts`