### PR TITLE
DEV-AUTOPILOT: Refactor admin notification categories to use requireAdmin

### DIFF
--- a/services/gateway/src/routes/admin-notification-categories.ts
+++ b/services/gateway/src/routes/admin-notification-categories.ts
@@ -11,12 +11,12 @@
  * - POST   /:id/test      — Send test notification to admin
  *
  * Security:
- * - All endpoints are protected by the `requireExafyAdmin` middleware.
+ * - All endpoints are protected by the `requireAdmin` middleware.
  */
 
-import { Router, Request, Response, NextFunction } from 'express';
+import { Router, Request, Response } from 'express';
 import { createClient } from '@supabase/supabase-js';
-import { createUserSupabaseClient } from '../lib/supabase-user';
+import { requireAdmin } from '../middleware/requireAdmin';
 import { notifyUser, NotificationPayload } from '../services/notification-service';
 
 const router = Router();
@@ -24,42 +24,9 @@ const VTID = 'ADMIN-NOTIF-CATEGORIES';
 
 const VALID_TYPES = ['chat', 'calendar', 'community'];
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
 // ── Auth Middleware ─────────────────────────────────────────
 
-async function requireExafyAdmin(req: Request, res: Response, next: NextFunction) {
-  const token = getBearerToken(req);
-  if (!token) return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) {
-      return res.status(401).json({ ok: false, error: 'INVALID_TOKEN' });
-    }
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return res.status(403).json({ ok: false, error: 'FORBIDDEN' });
-    }
-
-    // Attach user info to request for downstream handlers
-    (req as any).authUser = { user_id: authData.user.id, email: authData.user.email || 'unknown' };
-    next();
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
-  }
-}
-
-router.use(requireExafyAdmin);
+router.use(requireAdmin);
 
 // ── Supabase ────────────────────────────────────────────────
 
@@ -140,7 +107,9 @@ router.get('/:id', async (req: Request, res: Response) => {
 // ── POST / — Create category ───────────────────────────────
 
 router.post('/', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const user = (req as any).user;
+  const userId = user?.id;
+  const userEmail = user?.email ?? 'unknown';
 
   const supabase = getSupabase();
   const {
@@ -180,7 +149,7 @@ router.post('/', async (req: Request, res: Response) => {
     default_enabled: default_enabled ?? true,
     mapped_types: mapped_types || [],
     tenant_id: tenant_id || null,
-    created_by: authUser.user_id,
+    created_by: userId,
   };
 
   const { data, error } = await supabase
@@ -197,14 +166,15 @@ router.post('/', async (req: Request, res: Response) => {
     return res.status(500).json({ ok: false, error: error.message });
   }
 
-  console.log(`[${VTID}] Created category "${slug}" (${type}) by ${authUser.email}`);
+  console.log(`[${VTID}] Created category "${slug}" (${type}) by ${userEmail}`);
   return res.status(201).json({ ok: true, data });
 });
 
 // ── PATCH /:id — Update category ────────────────────────────
 
 router.patch('/:id', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const user = (req as any).user;
+  const userEmail = user?.email ?? 'unknown';
 
   const supabase = getSupabase();
   const allowedFields = ['display_name', 'description', 'icon', 'sort_order', 'is_active', 'default_enabled', 'mapped_types'];
@@ -236,14 +206,15 @@ router.patch('/:id', async (req: Request, res: Response) => {
     return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
   }
 
-  console.log(`[${VTID}] Updated category "${data.slug}" by ${authUser.email}`);
+  console.log(`[${VTID}] Updated category "${data.slug}" by ${userEmail}`);
   return res.json({ ok: true, data });
 });
 
 // ── DELETE /:id — Soft-delete (set is_active=false) ─────────
 
 router.delete('/:id', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const user = (req as any).user;
+  const userEmail = user?.email ?? 'unknown';
 
   const supabase = getSupabase();
   const { data, error } = await supabase
@@ -261,14 +232,16 @@ router.delete('/:id', async (req: Request, res: Response) => {
     return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
   }
 
-  console.log(`[${VTID}] Soft-deleted category "${data.slug}" by ${authUser.email}`);
+  console.log(`[${VTID}] Soft-deleted category "${data.slug}" by ${userEmail}`);
   return res.json({ ok: true, data });
 });
 
 // ── POST /:id/test — Send test notification to admin ────────
 
 router.post('/:id/test', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const user = (req as any).user;
+  const userId = user?.id;
+  const userEmail = user?.email ?? 'unknown';
 
   const supabase = getSupabase();
 
@@ -296,15 +269,15 @@ router.post('/:id/test', async (req: Request, res: Response) => {
   const { data: tenantRow } = await supabase
     .from('user_tenants')
     .select('tenant_id')
-    .eq('user_id', authUser.user_id)
+    .eq('user_id', userId)
     .limit(1)
     .single();
 
   const tenantId = tenantRow?.tenant_id || '00000000-0000-0000-0000-000000000000';
 
   try {
-    const result = await notifyUser(authUser.user_id, tenantId, testType, payload, supabase);
-    console.log(`[${VTID}] Test notification sent for category "${category.slug}" by ${authUser.email}`);
+    const result = await notifyUser(userId, tenantId, testType, payload, supabase);
+    console.log(`[${VTID}] Test notification sent for category "${category.slug}" by ${userEmail}`);
     return res.json({ ok: true, result });
   } catch (err: any) {
     console.error(`[${VTID}] POST /:id/test error:`, err.message);

--- a/services/gateway/tests/admin-notification-categories.test.ts
+++ b/services/gateway/tests/admin-notification-categories.test.ts
@@ -1,0 +1,87 @@
+import request from 'supertest';
+import express, { Request, Response, NextFunction } from 'express';
+import router from '../src/routes/admin-notification-categories';
+
+// Mock the requireAdmin middleware to test the auth boundaries
+jest.mock('../src/middleware/requireAdmin', () => ({
+  requireAdmin: jest.fn((req: Request, res: Response, next: NextFunction) => {
+    const auth = req.headers.authorization;
+    if (!auth) {
+      return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+    }
+    if (auth === 'Bearer non-admin') {
+      return res.status(403).json({ ok: false, error: 'FORBIDDEN' });
+    }
+    // Valid admin
+    (req as any).user = { id: 'admin-123', email: 'admin@example.com' };
+    next();
+  })
+}));
+
+// Mock Supabase to avoid real DB calls during testing
+jest.mock('@supabase/supabase-js', () => {
+  const mockQuery = {
+    select: jest.fn().mockReturnThis(),
+    order: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    or: jest.fn().mockReturnThis(),
+    is: jest.fn().mockReturnThis(),
+    single: jest.fn().mockResolvedValue({ data: { id: '1', type: 'chat', slug: 'test' }, error: null }),
+    insert: jest.fn().mockReturnThis(),
+    update: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    then: jest.fn((resolve) => resolve({ data: [{ id: '1', type: 'chat' }], error: null })),
+  };
+
+  return {
+    createClient: jest.fn(() => ({
+      from: jest.fn(() => mockQuery)
+    }))
+  };
+});
+
+// Mock notification service
+jest.mock('../src/services/notification-service', () => ({
+  notifyUser: jest.fn().mockResolvedValue({ success: true })
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/admin/notification-categories', router);
+
+describe('Admin Notification Categories Auth Boundary', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return 401 for unauthenticated request (GET)', async () => {
+    const res = await request(app).get('/admin/notification-categories');
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ ok: false, error: 'UNAUTHENTICATED' });
+  });
+
+  it('should return 403 for authenticated non-admin (GET)', async () => {
+    const res = await request(app)
+      .get('/admin/notification-categories')
+      .set('Authorization', 'Bearer non-admin');
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ ok: false, error: 'FORBIDDEN' });
+  });
+
+  it('should return 200 for authenticated admin (GET)', async () => {
+    const res = await request(app)
+      .get('/admin/notification-categories')
+      .set('Authorization', 'Bearer valid-admin');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('should return 201 for authenticated admin (POST)', async () => {
+    const res = await request(app)
+      .post('/admin/notification-categories')
+      .set('Authorization', 'Bearer valid-admin')
+      .send({ type: 'chat', display_name: 'Test Chat' });
+    expect(res.status).toBe(201);
+    expect(res.body.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
**Context & Plan**
The `route-auth-scanner-v1` flagged `admin-notification-categories.ts` for using an inline authentication helper rather than the standard shared middleware. This PR standardizes the auth enforcement by replacing `verifyExafyAdmin` / `getBearerToken` with a single declarative `router.use(requireAdmin)` call.

**Changes**
1. **`services/gateway/src/routes/admin-notification-categories.ts`**:
   - Replaced custom inline auth implementations with `import { requireAdmin } from '../middleware/requireAdmin'`.
   - Updated all route handlers to read standard `req.user.id` and `req.user.email` instead of the legacy `req.authUser` structure.
   - Removed unused `createUserSupabaseClient` and `NextFunction` imports.
2. **`services/gateway/tests/admin-notification-categories.test.ts`**:
   - Added automated tests to assert the auth boundaries: unauthenticated (401), authenticated non-admin (403), and authenticated admin (200/201).