### PR TITLE
DEV-AUTOPILOT: Refactor admin-notifications to use shared auth middleware

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -12,49 +12,17 @@
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/auth';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIFICATIONS';
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
+router.use(requireAdmin);
 
 // ── POST /compose — Send notification to user(s) ────────────
 
 router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -139,6 +107,8 @@ router.post('/compose', async (req: Request, res: Response) => {
     // Determine effective tenant_id for dispatching
     const effectiveTenantId = tenant_id || (recipient_ids?.length === 1 ? undefined : undefined);
 
+    const adminEmail = (req as any).user?.email || 'unknown';
+
     // For single recipients, use synchronous dispatch for immediate feedback
     if (targetUserIds.length === 1) {
       const result = await notifyUser(
@@ -148,7 +118,7 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      console.log(`[${VTID}] Composed notification for 1 user by ${adminEmail}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +131,7 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${adminEmail}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -177,9 +147,6 @@ router.post('/compose', async (req: Request, res: Response) => {
 // ── GET /sent — Admin notification log ──────────────────────
 
 router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -224,9 +191,6 @@ router.get('/sent', async (req: Request, res: Response) => {
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
 router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,158 @@
+import request from 'supertest';
+import express, { Request, Response, NextFunction } from 'express';
+import adminNotificationsRouter from '../../src/routes/admin-notifications';
+import { getSupabase } from '../../src/lib/supabase';
+import { notifyUser, notifyUsersAsync } from '../../src/services/notification-service';
+
+// Mock dependencies
+jest.mock('../../src/middleware/auth', () => ({
+  requireAdmin: jest.fn((req: Request, res: Response, next: NextFunction) => {
+    (req as any).user = { id: 'admin-id', email: 'admin@test.com' };
+    next();
+  })
+}));
+
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn()
+}));
+
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn(),
+  notifyUsersAsync: jest.fn()
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/admin/notifications', adminNotificationsRouter);
+
+describe('Admin Notifications API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('POST /compose', () => {
+    it('should return 400 if title or body is missing', async () => {
+      (getSupabase as jest.Mock).mockReturnValue({}); // Mock supabase
+      
+      const response = await request(app)
+        .post('/admin/notifications/compose')
+        .send({
+          recipient_ids: ['user-1']
+        });
+      
+      expect(response.status).toBe(400);
+      expect(response.body.message).toBe('title and body are required');
+    });
+
+    it('should return 400 if no recipients specified', async () => {
+      (getSupabase as jest.Mock).mockReturnValue({});
+      
+      const response = await request(app)
+        .post('/admin/notifications/compose')
+        .send({
+          title: 'Hello',
+          body: 'World'
+        });
+      
+      expect(response.status).toBe(400);
+      expect(response.body.message).toBe('Must specify recipient_ids, recipient_role, or send_to_all');
+    });
+
+    it('should send notification to a single user synchronously', async () => {
+      (getSupabase as jest.Mock).mockReturnValue({});
+      (notifyUser as jest.Mock).mockResolvedValue({ success: true });
+
+      const response = await request(app)
+        .post('/admin/notifications/compose')
+        .send({
+          recipient_ids: ['user-1'],
+          title: 'Hello',
+          body: 'World'
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body.sent_to).toBe(1);
+      expect(notifyUser).toHaveBeenCalledWith(
+        'user-1',
+        '',
+        'welcome_to_vitana',
+        expect.objectContaining({ title: 'Hello', body: 'World' }),
+        expect.any(Object)
+      );
+    });
+
+    it('should send notifications asynchronously to multiple users', async () => {
+      (getSupabase as jest.Mock).mockReturnValue({});
+      
+      const response = await request(app)
+        .post('/admin/notifications/compose')
+        .send({
+          recipient_ids: ['user-1', 'user-2'],
+          title: 'Hello',
+          body: 'World'
+        });
+
+      expect(response.status).toBe(200);
+      expect(response.body.sent_to).toBe(2);
+      expect(notifyUsersAsync).toHaveBeenCalledWith(
+        ['user-1', 'user-2'],
+        '',
+        'welcome_to_vitana',
+        expect.objectContaining({ title: 'Hello', body: 'World' }),
+        expect.any(Object)
+      );
+    });
+  });
+
+  describe('GET /sent', () => {
+    it('should return paginated sent notifications', async () => {
+      const mockQuery = Promise.resolve({ data: [{ id: 1 }], count: 1, error: null });
+      (mockQuery as any).select = jest.fn().mockReturnValue(mockQuery);
+      (mockQuery as any).gte = jest.fn().mockReturnValue(mockQuery);
+      (mockQuery as any).order = jest.fn().mockReturnValue(mockQuery);
+      (mockQuery as any).range = jest.fn().mockReturnValue(mockQuery);
+
+      const mockSupabase = {
+        from: jest.fn().mockReturnValue(mockQuery)
+      };
+      (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+
+      const response = await request(app).get('/admin/notifications/sent?limit=10&offset=0');
+
+      expect(response.status).toBe(200);
+      expect(response.body.data).toHaveLength(1);
+      expect(response.body.total).toBe(1);
+    });
+  });
+
+  describe('GET /preferences/stats', () => {
+    it('should return preferences stats and delivery metrics', async () => {
+      const mockSupabase = {
+        from: jest.fn((table: string) => {
+          if (table === 'user_notification_preferences') {
+            const mockPref = Promise.resolve({ data: [{ push_enabled: true }], error: null });
+            (mockPref as any).select = jest.fn().mockReturnValue(mockPref);
+            (mockPref as any).eq = jest.fn().mockReturnValue(mockPref);
+            return mockPref;
+          } else if (table === 'user_notifications') {
+            const query = Promise.resolve({ count: 5, data: [], error: null });
+            (query as any).select = jest.fn().mockReturnValue(query);
+            (query as any).gte = jest.fn().mockReturnValue(query);
+            (query as any).not = jest.fn().mockReturnValue(Promise.resolve({ count: 3, error: null }));
+            return query;
+          }
+        })
+      };
+
+      (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+
+      const response = await request(app).get('/admin/notifications/preferences/stats');
+
+      expect(response.status).toBe(200);
+      expect(response.body.stats.push_enabled).toBe(1);
+      expect(response.body.delivery.total_sent_30d).toBe(5);
+      expect(response.body.delivery.total_read_30d).toBe(3);
+      expect(response.body.delivery.read_rate).toBe(60); // (3 / 5) * 100
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses findings from `route-auth-scanner-v1` regarding `admin-notifications.ts` missing standard authentication.

Changes:
- Removed inline `verifyExafyAdmin` and `getBearerToken` helper functions.
- Imported and applied the shared `requireAdmin` middleware from `../middleware/auth` to protect the entire `admin-notifications` router.
- Updated route handlers to access `req.user.email` instead of local auth results for logging.
- Created `admin-notifications.test.ts` to cover core endpoints (`POST /compose`, `GET /sent`, `GET /preferences/stats`) by mocking the `requireAdmin` middleware and database/service functions.

These changes ensure unified auth behaviour and remove redundant manual token checks.