### PR TITLE
DEV-AUTOPILOT: Enforce auth checks on telemetry event API writes

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,7 +1,8 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
 
@@ -24,9 +25,31 @@ const TelemetryEventSchema = z.object({
 
 type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
+// Middleware to verify Supabase session token
+const requireAuthenticatedUser = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    res.status(401).json({ error: "Unauthorized", detail: "Missing or invalid Authorization header" });
+    return;
+  }
+
+  const token = authHeader.split(" ")[1];
+  try {
+    const { data, error } = await supabase.auth.getUser(token);
+    if (error || !data?.user) {
+      res.status(401).json({ error: "Unauthorized", detail: "Invalid session token" });
+      return;
+    }
+    next();
+  } catch (err: any) {
+    res.status(401).json({ error: "Unauthorized", detail: "Failed to verify session" });
+    return;
+  }
+};
+
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +169,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,126 @@
+import request from 'supertest';
+import express from 'express';
+import { router } from '../../src/routes/telemetry';
+import { supabase } from '../../src/lib/supabase';
+
+jest.mock('../../src/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+// Mock dynamic require inside telemetry routes
+jest.mock('../../src/routes/devhub', () => ({
+  broadcastEvent: jest.fn(),
+}), { virtual: true });
+
+const app = express();
+app.use(express.json());
+app.use('/api/v1/telemetry', router);
+
+describe('Telemetry Routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SUPABASE_SERVICE_ROLE = 'mock-svc-key';
+    process.env.SUPABASE_URL = 'http://mock-supabase.local';
+    
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+      text: async () => 'OK'
+    });
+  });
+
+  describe('POST /api/v1/telemetry/event', () => {
+    const validPayload = {
+      vtid: 'VTID-1234',
+      layer: 'app',
+      module: 'auth',
+      source: 'web',
+      kind: 'auth.login',
+      status: 'success',
+      title: 'User logged in'
+    };
+
+    it('returns 401 if missing Authorization header', async () => {
+      const res = await request(app)
+        .post('/api/v1/telemetry/event')
+        .send(validPayload);
+      
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe('Unauthorized');
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 if token is invalid', async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: null },
+        error: new Error('Invalid token')
+      });
+
+      const res = await request(app)
+        .post('/api/v1/telemetry/event')
+        .set('Authorization', 'Bearer invalid-token')
+        .send(validPayload);
+      
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe('Unauthorized');
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('proceeds and returns 202 if token is valid', async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: 'user-123' } },
+        error: null
+      });
+
+      const res = await request(app)
+        .post('/api/v1/telemetry/event')
+        .set('Authorization', 'Bearer valid-token')
+        .send(validPayload);
+      
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('POST /api/v1/telemetry/batch', () => {
+    const validPayload = [{
+      vtid: 'VTID-1234',
+      layer: 'app',
+      module: 'auth',
+      source: 'web',
+      kind: 'auth.login',
+      status: 'success',
+      title: 'User logged in'
+    }];
+
+    it('returns 401 if missing Authorization header', async () => {
+      const res = await request(app)
+        .post('/api/v1/telemetry/batch')
+        .send(validPayload);
+      
+      expect(res.status).toBe(401);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('returns 202 if token is valid', async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: 'user-123' } },
+        error: null
+      });
+
+      const res = await request(app)
+        .post('/api/v1/telemetry/batch')
+        .set('Authorization', 'Bearer valid-token')
+        .send(validPayload);
+      
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses the medium‑risk RLS gap flagged by `rls-policy-scanner-v1` on the `oasis_events` table.
Because automated scope limits modifying database migrations directly, this plan adds **application‑level** authentication checks to the telemetry API routes that insert into `oasis_events`. 

Changes:
- Adds a `requireAuthenticatedUser` middleware to `services/gateway/src/routes/telemetry.ts` which uses `supabase.auth.getUser()`.
- Applies the new middleware to `POST /event` and `POST /batch`. Unauthenticated requests are now rejected with a `401 Unauthorized`.
- Adds unit tests in `services/gateway/test/routes/telemetry.test.ts` to verify the authentication flows.

**Note to Operator:** The database‑level RLS migration to enable RLS and add proper `INSERT`/`UPDATE` policies for `oasis_events` is out of scope for autopilot and must be manually applied.