### PR TITLE
DEV-AUTOPILOT: Refactor admin-notifications router to use standard auth

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -7,54 +7,23 @@
  * - GET  /preferences/stats — Aggregate opt-in/out rates per category
  *
  * Security:
- * - All endpoints require Bearer token + exafy_admin
+ * - All endpoints require Bearer token + exafy_admin (via requireAdmin middleware)
  */
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/auth';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIFICATIONS';
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
+// Apply standard admin auth middleware to all routes in this file
+router.use(requireAdmin);
 
 // ── POST /compose — Send notification to user(s) ────────────
 
 router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -148,7 +117,7 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      console.log(`[${VTID}] Composed notification for 1 user by ${(req as any).user?.email || 'admin'}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +130,7 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${(req as any).user?.email || 'admin'}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -177,9 +146,6 @@ router.post('/compose', async (req: Request, res: Response) => {
 // ── GET /sent — Admin notification log ──────────────────────
 
 router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -224,9 +190,6 @@ router.get('/sent', async (req: Request, res: Response) => {
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
 router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,151 @@
+import request from 'supertest';
+import express from 'express';
+import { getSupabase } from '../../src/lib/supabase';
+import { notifyUser, notifyUsersAsync } from '../../src/services/notification-service';
+import adminNotificationsRouter from '../../src/routes/admin-notifications';
+
+// Mock the standard admin auth middleware
+jest.mock('../../src/middleware/auth', () => ({
+  requireAdmin: jest.fn((req, _res, next) => {
+    // Populate user object to simulate authorized admin state
+    req.user = { id: 'admin-id', email: 'admin@test.com' };
+    next();
+  })
+}));
+
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn()
+}));
+
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn(),
+  notifyUsersAsync: jest.fn()
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/admin/notifications', adminNotificationsRouter);
+
+describe('Admin Notifications Router', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('POST /compose', () => {
+    it('should return 400 if title and body are missing', async () => {
+      const res = await request(app).post('/admin/notifications/compose').send({
+        recipient_ids: ['user-1']
+      });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('INVALID_INPUT');
+    });
+
+    it('should compose notification for a single user synchronously', async () => {
+      const mockSupabase = {};
+      (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+      (notifyUser as jest.Mock).mockResolvedValue({ success: true });
+
+      const res = await request(app).post('/admin/notifications/compose').send({
+        title: 'Test Title',
+        body: 'Test Body',
+        recipient_ids: ['user-1']
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.sent_to).toBe(1);
+      expect(notifyUser).toHaveBeenCalledWith(
+        'user-1',
+        '',
+        'welcome_to_vitana',
+        { title: 'Test Title', body: 'Test Body', data: undefined },
+        mockSupabase
+      );
+    });
+
+    it('should use notifyUsersAsync for multiple recipients', async () => {
+      const mockSupabase = {};
+      (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+
+      const res = await request(app).post('/admin/notifications/compose').send({
+        title: 'Test Title',
+        body: 'Test Body',
+        recipient_ids: ['user-1', 'user-2']
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body.sent_to).toBe(2);
+      expect(notifyUsersAsync).toHaveBeenCalledWith(
+        ['user-1', 'user-2'],
+        '',
+        'welcome_to_vitana',
+        { title: 'Test Title', body: 'Test Body', data: undefined },
+        mockSupabase
+      );
+    });
+  });
+
+  describe('GET /sent', () => {
+    it('should return sent notifications properly mapped from Supabase', async () => {
+      const mockQuery = {
+        select: jest.fn().mockReturnThis(),
+        gte: jest.fn().mockReturnThis(),
+        order: jest.fn().mockReturnThis(),
+        range: jest.fn().mockResolvedValue({ data: [{ id: 1, title: 'Sent' }], count: 1, error: null })
+      };
+      const mockSupabase = {
+        from: jest.fn().mockReturnValue(mockQuery)
+      };
+      (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+
+      const res = await request(app).get('/admin/notifications/sent?limit=10&offset=0');
+      
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.data).toEqual([{ id: 1, title: 'Sent' }]);
+      expect(res.body.total).toBe(1);
+    });
+  });
+
+  describe('GET /preferences/stats', () => {
+    it('should aggregate push notification stats', async () => {
+      const mockSupabase = {
+        from: jest.fn().mockImplementation((table) => {
+          if (table === 'user_notification_preferences') {
+            return {
+              select: jest.fn().mockResolvedValue({
+                data: [
+                  { push_enabled: true, dnd_enabled: false },
+                  { push_enabled: false, dnd_enabled: true }
+                ],
+                error: null
+              })
+            };
+          }
+          if (table === 'user_notifications') {
+            const mQuery = {
+              select: jest.fn().mockReturnThis(),
+              gte: jest.fn().mockReturnThis(),
+              not: jest.fn().mockResolvedValue({ count: 1 }), // readCount mock
+              then: jest.fn((resolve) => resolve({ count: 2 })) // notificationCount mock
+            };
+            return mQuery;
+          }
+          return { select: jest.fn().mockReturnThis() };
+        })
+      };
+      (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+
+      const res = await request(app).get('/admin/notifications/preferences/stats');
+      
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.stats.total_users_with_prefs).toBe(2);
+      expect(res.body.stats.push_enabled).toBe(1);
+      expect(res.body.stats.push_disabled).toBe(1);
+      expect(res.body.delivery.total_sent_30d).toBe(2);
+      expect(res.body.delivery.total_read_30d).toBe(1);
+      expect(res.body.delivery.read_rate).toBe(50);
+    });
+  });
+});


### PR DESCRIPTION
**Summary:**
This PR addresses the security finding from `route-auth-scanner-v1` which flagged `admin-notifications.ts` for lacking standard middleware authentication. 

**Changes:**
1. Removed the inline `verifyExafyAdmin` and `getBearerToken` helper functions in `services/gateway/src/routes/admin-notifications.ts`.
2. Applied the shared `requireAdmin` middleware from `../middleware/auth` to the router (`router.use(requireAdmin)`).
3. Replaced per-handler inline auth checks and replaced `authResult.email` log references with `(req as any).user?.email`.
4. Created `services/gateway/test/routes/admin-notifications.test.ts` to mock the shared middleware and cover basic behavior across endpoints.

**Files modified:**
- `services/gateway/src/routes/admin-notifications.ts`
- `services/gateway/test/routes/admin-notifications.test.ts` (created)