### PR TITLE
DEV-AUTOPILOT: Add paramLimit middleware to mitigate path-to-regexp ReDoS

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,22 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const params = req.params || {};
+    const keys = Object.keys(params);
+
+    if (keys.length > maxParams) {
+      res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    for (const key of keys) {
+      if (params[key] && params[key].length > maxLength) {
+        res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,12 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:projectId', (req: Request, res: Response) => {
+  res.status(200).json({ projectId: req.params.projectId });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,12 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:id', (req: Request, res: Response) => {
+  res.status(200).json({ id: req.params.id, message: 'User retrieved' });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,51 @@
+import express from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - paramLimit middleware', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    
+    app.get('/resource/:a/:b/:c/:d/:e/:f', limitPathParams(), (req, res) => {
+      res.status(200).send('OK');
+    });
+
+    app.get('/long/:a', limitPathParams(), (req, res) => {
+      res.status(200).send('OK');
+    });
+
+    app.get('/valid/:a/:b', limitPathParams(), (req, res) => {
+      res.status(200).send('OK');
+    });
+  });
+
+  it('should return 400 when >5 params', async () => {
+    const res = await request(app).get('/resource/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'Too many path parameters or parameter too long' });
+  });
+
+  it('should return 400 when param >200 chars', async () => {
+    const longParam = 'a'.repeat(201);
+    const res = await request(app).get(`/long/${longParam}`);
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ error: 'Too many path parameters or parameter too long' });
+  });
+
+  it('should pass valid request with <=5 params', async () => {
+    const res = await request(app).get('/valid/hello/world');
+    expect(res.status).toBe(200);
+  });
+
+  it('integration test: response time for potentially malicious request should be < 500ms', async () => {
+    const start = Date.now();
+    const res = await request(app).get('/resource/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+    
+    expect(res.status).toBe(400);
+    // Ensures short response time against potential CPU exhaustion
+    expect(duration).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
Fixes ReDoS vulnerability via `path-to-regexp` versions < 0.1.13.
Because dependency updates to `package.json` are outside the scope of this update, we are adding server-side validation middleware to limit the number and length of path parameters. This restricts consecutive parameters and the length of each value to prevent catastrophic backtracking.

**Plan Summary**:
1. Created `limitPathParams` middleware to reject requests with >5 path parameters or parameters >200 chars.
2. Added middleware to `userRoutes.ts` and `projectRoutes.ts` via `router.use()`. Note: Apply this middleware manually to any other route files in `services/gateway/src/routes/` containing path parameters.
3. Created unit and integration tests to verify the limiting behavior and response time (< 500ms).

**Files touched**:
- `services/gateway/src/routes/middleware/paramLimit.ts`
- `services/gateway/src/routes/v1/userRoutes.ts`
- `services/gateway/src/routes/v1/projectRoutes.ts`
- `services/gateway/test/cve-mitigation.test.ts`