### PR TITLE
DEV-AUTOPILOT: Mitigate path-to-regexp ReDoS via paramLimit middleware

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,43 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // 1. Validate `req.params` explicitly
+    // Filter out undefined values that Express might inject for missing optional params
+    const keys = Object.keys(req.params || {}).filter(k => req.params[k] !== undefined);
+    
+    if (keys.length > maxParams) {
+      res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    for (const key of keys) {
+      const val = req.params[key];
+      if (typeof val === 'string' && val.length > maxLength) {
+        res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    // 2. Validate `req.path` using RegExp to protect downstream routing from ReDoS.
+    // This catches oversized parameters and excessive depth before express runs vulnerable 
+    // `path-to-regexp` iterations, which is essential if mounted via router.use().
+    const path = req.path || '';
+    const segments = path.match(/[^/]+/g) || [];
+    
+    // Add a safe buffer for static segments in the path, limiting total traversal depth.
+    if (segments.length > maxParams + 10) { 
+      res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    for (const segment of segments) {
+      if (segment.length > maxLength) {
+        res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply paramLimit middleware to prevent ReDoS on path-to-regexp
+router.use(limitPathParams());
+
+router.get('/:projectId', (req, res) => {
+  res.json({ id: req.params.projectId });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,13 @@
+import { Router } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply paramLimit middleware to prevent ReDoS on path-to-regexp
+router.use(limitPathParams());
+
+router.get('/:userId', (req, res) => {
+  res.json({ id: req.params.userId });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,64 @@
+import express from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE-2024-XXXX Mitigation: limitPathParams middleware', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    
+    // Valid route within limits
+    app.get('/resource/:a/:b', limitPathParams(5, 200), (req, res) => {
+      res.status(200).json({ success: true });
+    });
+
+    // Vulnerable-style route requiring 6 params to trigger rejection directly on req.params
+    app.get('/resource/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req, res) => {
+      res.status(200).json({ success: true });
+    });
+
+    // Vulnerable-style route for extremely long parameter values
+    app.get('/long/:a', limitPathParams(5, 200), (req, res) => {
+      res.status(200).json({ success: true });
+    });
+    
+    // Global router to test raw path string fallback that prevents ReDoS from unmounted layers
+    app.use('/api', limitPathParams(5, 200));
+    app.get('/api/test', (req, res) => {
+      res.status(200).json({ success: true });
+    });
+  });
+
+  it('should return 400 when >5 path parameters are provided', async () => {
+    const res = await request(app).get('/resource/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('should return 400 when a path parameter exceeds 200 characters', async () => {
+    const longParam = 'A'.repeat(205);
+    const res = await request(app).get(`/long/${longParam}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('should pass normally for requests with <=5 short parameters', async () => {
+    const res = await request(app).get('/resource/1/2');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('integration test: should reject ReDoS attempt quickly (<200ms)', async () => {
+    const start = Date.now();
+    
+    // Pathological request sending 20 segments -> hits the (maxParams + 10) total segment limit
+    const pathologicalPath = '/' + Array(20).fill('param').join('/');
+    const res = await request(app).get('/api' + pathologicalPath);
+    
+    const duration = Date.now() - start;
+    
+    expect(res.status).toBe(400);
+    expect(duration).toBeLessThan(200);
+  });
+});


### PR DESCRIPTION
This PR implements server-side validation middleware in the gateway to mitigate a Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (< 0.1.13) used transitively by Express.

### Changes
- **`paramLimit.ts`**: Introduced an Express middleware function `limitPathParams(maxParams, maxLength)` that:
  1. Parses `req.params` and limits the number of parameters (default `5`) and their lengths (default `200`).
  2. Further enforces a RegExp-based check against `req.path` to prevent ReDoS from triggering before path parameters are bound, especially when mounted via `router.use()`.
- **Route Implementations**: Applied the middleware to the `userRoutes` and `projectRoutes` logic blocks as candidates.
- **Testing**: Added `cve-mitigation.test.ts` to assert that normal requests pass correctly and pathological requests designed to exhaust CPU are rejected promptly (<200ms) with a 400 Bad Request.

### Note to Operators
The `paramLimit` middleware should be applied to any other Express route configurations under `services/gateway/src/routes/` that make use of path parameters. This restricts the gateway's attack surface until the `path-to-regexp` package can be properly bumped inside `package.json`.