### PR TITLE
DEV-AUTOPILOT: Add auth middleware to telemetry endpoints (RLS prep)

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,32 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+// Authentication middleware to protect oasis_events writes
+const requireAuthenticatedUser = async (req: Request, res: Response, next: NextFunction): Promise<any> => {
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    const token = authHeader.split(" ")[1];
+    const { data, error } = await supabase.auth.getUser(token);
+
+    if (error || !data?.user) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    next();
+  } catch (e: any) {
+    console.error("❌ Auth middleware error:", e);
+    return res.status(500).json({ error: "Internal server error during authentication" });
+  }
+};
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +49,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +169,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,143 @@
+import request from "supertest";
+import express from "express";
+import { router } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+// Mock the supabase client for auth verification
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn()
+    }
+  }
+}));
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1/telemetry", router);
+
+describe("Telemetry Routes Auth Enforcement", () => {
+  let originalEnv: NodeJS.ProcessEnv;
+  let originalFetch: typeof fetch;
+
+  beforeAll(() => {
+    originalEnv = process.env;
+    process.env = {
+      ...originalEnv,
+      SUPABASE_URL: "http://test.supabase.co",
+      SUPABASE_SERVICE_ROLE: "test-svc-key"
+    };
+    originalFetch = global.fetch;
+    global.fetch = jest.fn();
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+    global.fetch = originalFetch;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("POST /api/v1/telemetry/event", () => {
+    const validEventPayload = {
+      vtid: "test-vtid",
+      layer: "test-layer",
+      module: "test-module",
+      source: "test-source",
+      kind: "test-kind",
+      status: "success",
+      title: "Test Event"
+    };
+
+    it("should return 401 when no authorization header is provided", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validEventPayload);
+
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({ error: "Unauthorized" });
+    });
+
+    it("should return 401 when authorization header is invalid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: null },
+        error: new Error("Invalid token")
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validEventPayload);
+
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({ error: "Unauthorized" });
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("invalid-token");
+    });
+
+    it("should proceed and return 202 when valid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null
+      });
+
+      // Mock the successful insertion into oasis_events
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({})
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send(validEventPayload);
+
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("valid-token");
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    const validBatchPayload = [{
+      vtid: "test-vtid",
+      layer: "test-layer",
+      module: "test-module",
+      source: "test-source",
+      kind: "test-kind",
+      status: "success",
+      title: "Test Batch Event"
+    }];
+
+    it("should return 401 when no authorization header is provided", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send(validBatchPayload);
+
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({ error: "Unauthorized" });
+    });
+
+    it("should proceed and return 202 when valid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({})
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-token")
+        .send(validBatchPayload);
+
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("valid-token");
+    });
+  });
+});


### PR DESCRIPTION
**Context & Plan**
The `oasis_events` table currently lacks Row-Level Security (RLS), exposing it to unauthenticated writes via direct SQL access (flagged by `rls-policy-scanner-v1`). As automated executors cannot modify `supabase/migrations/` to enable RLS directly, this PR adds application-level enforcement.

**Changes**
- Added `requireAuthenticatedUser` middleware in `services/gateway/src/routes/telemetry.ts`.
- Applied middleware to all endpoints that write to `oasis_events` (`POST /event`, `POST /batch`).
- Reads the Supabase session token from the `Authorization: Bearer <token>` header and validates via `supabase.auth.getUser()`.
- Added unit tests in `services/gateway/test/routes/telemetry.test.ts` ensuring `401 Unauthorized` responses without valid auth headers.

**Manual Operator Action Required**
To fully secure the database, a developer must create a new manual database migration (e.g. `supabase/migrations/20251215000000_enable_rls_oasis_events.sql`) to enable RLS and add policies restricting INSERT/UPDATE on `public.oasis_events` to the authenticated role.