### PR TITLE
DEV-AUTOPILOT: Add auth validation to telemetry endpoints (RLS gap mitigation)

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,37 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+// Middleware to require authentication for writing to telemetry
+const requireAuth = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    let token = "";
+    if (req.headers.authorization && req.headers.authorization.startsWith("Bearer ")) {
+      token = req.headers.authorization.split(" ")[1];
+    }
+
+    if (!token) {
+      res.status(401).json({ error: "Unauthorized" });
+      return;
+    }
+
+    const { data, error } = await supabase.auth.getUser(token);
+    
+    if (error || !data?.user) {
+      res.status(401).json({ error: "Unauthorized" });
+      return;
+    }
+
+    next();
+  } catch (err) {
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+};
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +54,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +174,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,161 @@
+import request from "supertest";
+import express from "express";
+import { router } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+// Mock supabase client
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+// Mock devhub broadcasting to avoid actual imports
+jest.mock("../../src/routes/devhub", () => ({
+  broadcastEvent: jest.fn(),
+}), { virtual: true });
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1/telemetry", router);
+
+describe("Telemetry Routes", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SUPABASE_URL = "http://localhost:8000";
+    process.env.SUPABASE_SERVICE_ROLE = "test-svc-key";
+    
+    // Mock global fetch for OASIS persistence
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+      text: async () => "",
+    } as any);
+  });
+
+  describe("POST /api/v1/telemetry/event", () => {
+    const validPayload = {
+      vtid: "VTID-123",
+      layer: "app",
+      module: "test",
+      source: "jest",
+      kind: "test.event",
+      status: "info",
+      title: "Test Event",
+    };
+
+    it("should return 401 when no token is provided", async () => {
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validPayload);
+
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({ error: "Unauthorized" });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should return 401 when an invalid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: new Error("Invalid token"),
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validPayload);
+
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({ error: "Unauthorized" });
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("invalid-token");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should return 202 when a valid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send(validPayload);
+
+      expect(response.status).toBe(202);
+      expect(response.body).toHaveProperty("ok", true);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("valid-token");
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    const validBatch = [
+      {
+        vtid: "VTID-123",
+        layer: "app",
+        module: "test",
+        source: "jest",
+        kind: "test.event.1",
+        status: "info",
+        title: "Test Event 1",
+      },
+      {
+        vtid: "VTID-123",
+        layer: "app",
+        module: "test",
+        source: "jest",
+        kind: "test.event.2",
+        status: "success",
+        title: "Test Event 2",
+      }
+    ];
+
+    it("should return 401 when no token is provided", async () => {
+      const response = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send(validBatch);
+
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({ error: "Unauthorized" });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should return 401 when an invalid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: new Error("Invalid token"),
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validBatch);
+
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({ error: "Unauthorized" });
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("invalid-token");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should return 202 when a valid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-token")
+        .send(validBatch);
+
+      expect(response.status).toBe(202);
+      expect(response.body).toHaveProperty("ok", true);
+      expect(response.body).toHaveProperty("count", 2);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("valid-token");
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
This PR introduces application-level authentication checks for the telemetry API routes that write to `oasis_events` (`POST /event` and `POST /batch`), mitigating a medium-risk `rls_gap` finding.

Changes included:
- Added a `requireAuth` middleware in `services/gateway/src/routes/telemetry.ts` to extract the `Authorization: Bearer <token>` header.
- The middleware uses `supabase.auth.getUser(token)` to verify the user and returns HTTP 401 if the token is missing or invalid.
- Implemented test coverage in `services/gateway/test/routes/telemetry.test.ts` to verify proper enforcement of the authentication requirements.

**Out of Scope / Developer Action Required:**
Due to automation constraints on modifying `supabase/migrations/` directly, this plan only implements application-level restrictions. A developer must still manually create the corresponding database migration to enable Row-Level Security (RLS) on the `oasis_events` table and restrict `INSERT/UPDATE` to authenticated users.