### PR TITLE
DEV-AUTOPILOT: Add system-controls API endpoint for feature flags

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,22 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { getSystemControl } from '../services/system-controls';
+
+const router = Router();
+
+router.get('/:key', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const { key } = req.params;
+    const control = await getSystemControl(key);
+
+    if (!control) {
+      res.status(404).json({ error: 'System control not found' });
+      return;
+    }
+
+    res.json(control);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,20 @@
+import { supabase } from '../lib/supabase';
+import { SystemControl } from '../types/system-controls';
+
+export async function getSystemControl(key: string): Promise<SystemControl | null> {
+  const { data, error } = await supabase
+    .from('system_controls')
+    .select('*')
+    .eq('key', key)
+    .single();
+
+  if (error) {
+    if (error.code === 'PGRST116') {
+      // Postgres error code for zero rows in single()
+      return null;
+    }
+    throw error;
+  }
+
+  return data as SystemControl;
+}

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at?: string;
+  updated_by?: string;
+  reason?: string;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,48 @@
+import request from 'supertest';
+import express from 'express';
+import systemControlsRouter from '../../src/routes/system-controls';
+import * as systemControlsService from '../../src/services/system-controls';
+
+jest.mock('../../src/services/system-controls');
+
+const app = express();
+app.use(express.json());
+app.use('/api/system-controls', systemControlsRouter);
+app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
+  res.status(500).json({ error: 'Internal Server Error' });
+});
+
+describe('System Controls Routes', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return 200 and the control data if found', async () => {
+    const mockControl = { key: 'test_key', enabled: true };
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(mockControl);
+
+    const response = await request(app).get('/api/system-controls/test_key');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockControl);
+    expect(systemControlsService.getSystemControl).toHaveBeenCalledWith('test_key');
+  });
+
+  it('should return 404 if control not found', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(null);
+
+    const response = await request(app).get('/api/system-controls/missing_key');
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'System control not found' });
+  });
+
+  it('should return 500 if service throws an error', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockRejectedValue(new Error('Test error'));
+
+    const response = await request(app).get('/api/system-controls/test_key');
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: 'Internal Server Error' });
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,75 @@
+import { getSystemControl } from '../src/services/system-controls';
+import { supabase } from '../src/lib/supabase';
+
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+describe('System Controls Service', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return a system control when found', async () => {
+    const mockControl = {
+      key: 'vitana_did_you_know_enabled',
+      enabled: true
+    };
+
+    const eqMock = jest.fn().mockReturnValue({
+      single: jest.fn().mockResolvedValue({ data: mockControl, error: null })
+    });
+
+    const selectMock = jest.fn().mockReturnValue({
+      eq: eqMock
+    });
+
+    (supabase.from as jest.Mock).mockReturnValue({
+      select: selectMock
+    });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+    
+    expect(supabase.from).toHaveBeenCalledWith('system_controls');
+    expect(selectMock).toHaveBeenCalledWith('*');
+    expect(eqMock).toHaveBeenCalledWith('key', 'vitana_did_you_know_enabled');
+    expect(result).toEqual(mockControl);
+  });
+
+  it('should return null when not found (PGRST116)', async () => {
+    const eqMock = jest.fn().mockReturnValue({
+      single: jest.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } })
+    });
+
+    const selectMock = jest.fn().mockReturnValue({
+      eq: eqMock
+    });
+
+    (supabase.from as jest.Mock).mockReturnValue({
+      select: selectMock
+    });
+
+    const result = await getSystemControl('missing_key');
+    
+    expect(result).toBeNull();
+  });
+
+  it('should throw on other errors', async () => {
+    const error = new Error('Database connection failed');
+    const eqMock = jest.fn().mockReturnValue({
+      single: jest.fn().mockResolvedValue({ data: null, error })
+    });
+
+    const selectMock = jest.fn().mockReturnValue({
+      eq: eqMock
+    });
+
+    (supabase.from as jest.Mock).mockReturnValue({
+      select: selectMock
+    });
+
+    await expect(getSystemControl('some_key')).rejects.toThrow('Database connection failed');
+  });
+});


### PR DESCRIPTION
This PR adds a new `system-controls` API endpoint to the gateway to support querying feature flags from the `public.system_controls` table via Supabase. It exposes the `vitana_did_you_know_enabled` flag to consumers so they can query if features are enabled.

### Changes
* `services/gateway/src/types/system-controls.ts`: Added type definitions for System Control.
* `services/gateway/src/services/system-controls.ts`: Service function to fetch by key using Supabase.
* `services/gateway/src/routes/system-controls.ts`: Express route for `GET /api/system-controls/:key`.
* `services/gateway/test/system-controls.test.ts` & `services/gateway/test/routes/system-controls.test.ts`: Unit tests for the service and route logic.

### Notes for Operator
The plan requires modifying the `command-hub` frontend to call this endpoint and actually toggle the "Did You Know?" tour. Due to strict constraints on out-of-scope files for this pass, the frontend changes were omitted from this automated PR. An operator needs to:
1. Ensure the Express route is registered on the main Gateway Express app (e.g., `app.use('/api/system-controls', systemControlsRouter)` in the main gateway app setup).
2. Locate the "Did You Know" tour component in `command-hub`.
3. Add a `fetch('/api/system-controls/vitana_did_you_know_enabled')` call on mount to conditionally render the tour based on the `enabled` boolean in the response payload.