### PR TITLE
DEV-AUTOPILOT: Expose system controls endpoint for feature flags

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,19 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { getSystemControl } from '../services/system-controls';
+
+export const systemControlsRouter = Router();
+
+systemControlsRouter.get('/:key', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { key } = req.params;
+    const control = await getSystemControl(key);
+
+    if (!control) {
+      return res.status(404).json({ error: 'System control not found' });
+    }
+
+    return res.status(200).json(control);
+  } catch (error) {
+    next(error);
+  }
+});

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,26 @@
+import { supabase } from '../lib/supabase';
+import { SystemControl } from '../types/system-controls';
+
+/**
+ * Fetches a single system control configuration by its unique key.
+ * @param key The string identifier of the system control.
+ * @returns The SystemControl object if found, otherwise null.
+ */
+export async function getSystemControl(key: string): Promise<SystemControl | null> {
+  const { data, error } = await supabase
+    .from('system_controls')
+    .select('*')
+    .eq('key', key)
+    .single();
+
+  if (error) {
+    // PGRST116 is the PostgREST error code for a query returning zero rows
+    // when exactly one row was expected via .single()
+    if (error.code === 'PGRST116') {
+      return null;
+    }
+    throw new Error(`Failed to fetch system control ${key}: ${error.message}`);
+  }
+
+  return data as SystemControl;
+}

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at?: string;
+  updated_by?: string;
+  reason?: string;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,58 @@
+import request from 'supertest';
+import express, { Request, Response, NextFunction } from 'express';
+import { systemControlsRouter } from '../../src/routes/system-controls';
+import * as systemControlsService from '../../src/services/system-controls';
+
+// Mock the underlying service
+jest.mock('../../src/services/system-controls');
+
+const setupApp = () => {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/system-controls', systemControlsRouter);
+  
+  // Generic error handler to catch next(error) calls
+  app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
+    res.status(500).json({ error: 'Internal Server Error' });
+  });
+  
+  return app;
+};
+
+describe('System Controls Route', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return 200 and the control data if found', async () => {
+    const mockData = { key: 'test_flag', enabled: true };
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(mockData);
+
+    const app = setupApp();
+    const response = await request(app).get('/api/system-controls/test_flag');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockData);
+    expect(systemControlsService.getSystemControl).toHaveBeenCalledWith('test_flag');
+  });
+
+  it('should return 404 if control not found', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(null);
+
+    const app = setupApp();
+    const response = await request(app).get('/api/system-controls/missing_flag');
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'System control not found' });
+  });
+
+  it('should pass errors to next middleware (resulting in 500)', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockRejectedValue(new Error('Service failure'));
+
+    const app = setupApp();
+    const response = await request(app).get('/api/system-controls/error_flag');
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: 'Internal Server Error' });
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,60 @@
+import { getSystemControl } from '../src/services/system-controls';
+import { supabase } from '../src/lib/supabase';
+
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+describe('System Controls Service', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return a system control when found', async () => {
+    const mockData = { key: 'vitana_did_you_know_enabled', enabled: true };
+    const selectMock = jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({ data: mockData, error: null })
+      })
+    });
+    (supabase.from as jest.Mock).mockReturnValue({ select: selectMock });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+    
+    expect(result).toEqual(mockData);
+    expect(supabase.from).toHaveBeenCalledWith('system_controls');
+  });
+
+  it('should return null when not found (PGRST116)', async () => {
+    const selectMock = jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({ 
+          data: null, 
+          error: { code: 'PGRST116', message: 'Not found' } 
+        })
+      })
+    });
+    (supabase.from as jest.Mock).mockReturnValue({ select: selectMock });
+
+    const result = await getSystemControl('missing_key');
+    expect(result).toBeNull();
+  });
+
+  it('should throw an error on other supabase errors', async () => {
+    const selectMock = jest.fn().mockReturnValue({
+      eq: jest.fn().mockReturnValue({
+        single: jest.fn().mockResolvedValue({ 
+          data: null, 
+          error: { code: 'OTHER_CODE', message: 'Database error' } 
+        })
+      })
+    });
+    (supabase.from as jest.Mock).mockReturnValue({ select: selectMock });
+
+    await expect(getSystemControl('test_key'))
+      .rejects
+      .toThrow('Failed to fetch system control test_key: Database error');
+  });
+});


### PR DESCRIPTION
This PR introduces a generic endpoint for querying system control flags by key, bridging the gap between recent DB migrations (which added feature flags like `vitana_did_you_know_enabled`) and the frontend.

**Changes:**
- Added a `SystemControl` type definition.
- Created a service (`getSystemControl`) to securely fetch flags from the `public.system_controls` table using the existing Supabase client.
- Exposed `GET /api/system-controls/:key` for programmatic retrieval.
- Provided comprehensive test coverage for both the route logic and service implementation.

**Note for operators:**
The frontend (Command Hub) updates mentioned in the original plan are intentionally excluded from this PR to conform to strict file-modification constraints. Please follow up by adding the fetch hook and conditional rendering logic within `services/gateway/src/frontend/command-hub/...` to query `/api/system-controls/vitana_did_you_know_enabled`.