### PR TITLE
DEV-AUTOPILOT: Refactor admin-notifications auth to use requireAdmin

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -12,49 +12,17 @@
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/auth';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIFICATIONS';
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
+router.use(requireAdmin);
 
 // ── POST /compose — Send notification to user(s) ────────────
 
 router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -139,6 +107,8 @@ router.post('/compose', async (req: Request, res: Response) => {
     // Determine effective tenant_id for dispatching
     const effectiveTenantId = tenant_id || (recipient_ids?.length === 1 ? undefined : undefined);
 
+    const userEmail = (req as any).user?.email || 'unknown';
+
     // For single recipients, use synchronous dispatch for immediate feedback
     if (targetUserIds.length === 1) {
       const result = await notifyUser(
@@ -148,7 +118,7 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      console.log(`[${VTID}] Composed notification for 1 user by ${userEmail}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +131,7 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${userEmail}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -177,9 +147,6 @@ router.post('/compose', async (req: Request, res: Response) => {
 // ── GET /sent — Admin notification log ──────────────────────
 
 router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -224,9 +191,6 @@ router.get('/sent', async (req: Request, res: Response) => {
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
 router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,144 @@
+import request from 'supertest';
+import express, { Request, Response, NextFunction } from 'express';
+import adminNotificationsRouter from '../../src/routes/admin-notifications';
+import { getSupabase } from '../../src/lib/supabase';
+import { notifyUser, notifyUsersAsync } from '../../src/services/notification-service';
+
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn()
+}));
+
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn(),
+  notifyUsersAsync: jest.fn()
+}));
+
+jest.mock('../../src/middleware/auth', () => ({
+  requireAdmin: jest.fn((req: Request, res: Response, next: NextFunction) => {
+    (req as any).user = { id: 'admin-id', email: 'admin@test.com' };
+    next();
+  })
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/admin/notifications', adminNotificationsRouter);
+
+describe('Admin Notifications API', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('POST /compose', () => {
+    it('requires title and body', async () => {
+      const response = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ recipient_ids: ['u1'] });
+      
+      expect(response.status).toBe(400);
+      expect(response.body.message).toBe('title and body are required');
+    });
+
+    it('requires recipients', async () => {
+      const response = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ title: 'Hello', body: 'World' });
+      
+      expect(response.status).toBe(400);
+      expect(response.body.message).toBe('Must specify recipient_ids, recipient_role, or send_to_all');
+    });
+
+    it('sends to single recipient synchronously', async () => {
+      (getSupabase as jest.Mock).mockReturnValue({});
+      (notifyUser as jest.Mock).mockResolvedValue({ success: true });
+
+      const response = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ title: 'Hello', body: 'World', recipient_ids: ['u1'] });
+      
+      expect(response.status).toBe(200);
+      expect(response.body.sent_to).toBe(1);
+      expect(notifyUser).toHaveBeenCalledWith('u1', '', 'welcome_to_vitana', { title: 'Hello', body: 'World', data: undefined }, expect.anything());
+    });
+
+    it('sends to multiple recipients via role asynchronously', async () => {
+      const mockSupabase = {
+        from: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            eq: jest.fn().mockReturnValue({
+              eq: jest.fn().mockResolvedValue({
+                data: [{ user_id: 'u1' }, { user_id: 'u2' }],
+                error: null
+              })
+            })
+          })
+        })
+      };
+      (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+
+      const response = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ title: 'Hello', body: 'World', recipient_role: 'admin', tenant_id: 't1' });
+      
+      expect(response.status).toBe(200);
+      expect(response.body.sent_to).toBe(2);
+      expect(notifyUsersAsync).toHaveBeenCalledWith(['u1', 'u2'], 't1', 'welcome_to_vitana', { title: 'Hello', body: 'World', data: undefined }, expect.anything());
+    });
+  });
+
+  describe('GET /sent', () => {
+    it('returns sent notifications', async () => {
+      const mockSupabase = {
+        from: jest.fn().mockReturnValue({
+          select: jest.fn().mockReturnValue({
+            gte: jest.fn().mockReturnValue({
+              order: jest.fn().mockReturnValue({
+                range: jest.fn().mockResolvedValue({ data: [{ id: 1 }], count: 1, error: null })
+              })
+            })
+          })
+        })
+      };
+      (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+
+      const response = await request(app).get('/admin/notifications/sent');
+      
+      expect(response.status).toBe(200);
+      expect(response.body.data).toEqual([{ id: 1 }]);
+      expect(response.body.total).toBe(1);
+    });
+  });
+
+  describe('GET /preferences/stats', () => {
+    it('returns preference stats', async () => {
+      const mockSupabase = {
+        from: jest.fn().mockImplementation((table) => {
+          if (table === 'user_notification_preferences') {
+            return {
+              select: jest.fn().mockResolvedValue({ data: [{ push_enabled: true }], error: null })
+            };
+          }
+          if (table === 'user_notifications') {
+            const queryBuilder: any = {
+              then: (resolve: any) => resolve({ count: 10 }),
+              not: jest.fn().mockResolvedValue({ count: 5 })
+            };
+            return {
+              select: jest.fn().mockReturnValue({
+                gte: jest.fn().mockReturnValue(queryBuilder)
+              })
+            };
+          }
+        })
+      };
+      (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+
+      const response = await request(app).get('/admin/notifications/preferences/stats');
+      
+      expect(response.status).toBe(200);
+      expect(response.body.stats.total_users_with_prefs).toBe(1);
+      expect(response.body.delivery.total_sent_30d).toBe(10);
+      expect(response.body.delivery.total_read_30d).toBe(5);
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses missing authentication findings flagged by `route-auth-scanner-v1`.
The `admin-notifications.ts` route used an inline custom authentication helper (`verifyExafyAdmin`) instead of the standard project authentication middleware. This PR:
- Imports and applies the `requireAdmin` middleware from `../middleware/auth`.
- Removes the ad-hoc inline authentication functions (`getBearerToken` and `verifyExafyAdmin`).
- Refactors the route handler parameters and log statements to use `req.user` populated by the standard middleware.
- Creates `admin-notifications.test.ts` with test coverage for the refactored endpoints, mocking the `requireAdmin` middleware.

Files touched:
- `services/gateway/src/routes/admin-notifications.ts`
- `services/gateway/test/routes/admin-notifications.test.ts`