### PR TITLE
DEV-AUTOPILOT: Secure telemetry write endpoints with auth middleware

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,49 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+const requireAuth = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    let token = "";
+    
+    const authHeader = req.headers.authorization;
+    if (authHeader && authHeader.toLowerCase().startsWith("bearer ")) {
+      token = authHeader.substring(7).trim();
+    } else {
+      const cookieHeader = req.headers.cookie;
+      if (cookieHeader) {
+        const cookies = cookieHeader.split(';').map(c => c.trim());
+        for (const cookie of cookies) {
+          if (cookie.startsWith('sb-access-token=')) {
+            token = cookie.substring('sb-access-token='.length);
+            break;
+          }
+        }
+      }
+    }
+
+    if (!token) {
+      res.status(401).json({ error: "Unauthorized", detail: "Missing authentication token" });
+      return;
+    }
+
+    const { data, error } = await supabase.auth.getUser(token);
+    if (error || !data?.user) {
+      res.status(401).json({ error: "Unauthorized", detail: "Invalid session token" });
+      return;
+    }
+
+    next();
+  } catch (err: any) {
+    console.error("❌ Auth middleware error:", err);
+    res.status(401).json({ error: "Unauthorized", detail: "Authentication failed" });
+    return;
+  }
+};
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +66,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +186,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,114 @@
+import express from 'express';
+import request from 'supertest';
+import { router } from '../../src/routes/telemetry';
+import { supabase } from '../../src/lib/supabase';
+
+jest.mock('../../src/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn()
+    }
+  }
+}));
+
+// Mock node-fetch globally
+const mockFetch = jest.fn();
+global.fetch = mockFetch;
+
+const app = express();
+app.use(express.json());
+app.use('/api/v1/telemetry', router);
+
+describe('Telemetry Routes Auth', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SUPABASE_SERVICE_ROLE = 'test-svc-key';
+    process.env.SUPABASE_URL = 'http://test-supabase.local';
+  });
+
+  const validPayload = {
+    vtid: "VT-123",
+    layer: "app",
+    module: "test",
+    source: "test-src",
+    kind: "test.event",
+    status: "success",
+    title: "Test Event"
+  };
+
+  describe('POST /api/v1/telemetry/event', () => {
+    it('returns 401 if no token is provided', async () => {
+      const res = await request(app)
+        .post('/api/v1/telemetry/event')
+        .send(validPayload);
+        
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe('Unauthorized');
+      expect(supabase.auth.getUser).not.toHaveBeenCalled();
+    });
+
+    it('returns 401 if an invalid token is provided', async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({ 
+        data: { user: null }, 
+        error: new Error('Invalid token') 
+      });
+
+      const res = await request(app)
+        .post('/api/v1/telemetry/event')
+        .set('Authorization', 'Bearer invalid-token')
+        .send(validPayload);
+        
+      expect(res.status).toBe(401);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith('invalid-token');
+    });
+
+    it('proceeds to handler if valid token is provided', async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({ 
+        data: { user: { id: 'user-1' } }, 
+        error: null 
+      });
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ({})
+      });
+
+      const res = await request(app)
+        .post('/api/v1/telemetry/event')
+        .set('Authorization', 'Bearer valid-token')
+        .send(validPayload);
+        
+      expect(res.status).toBe(202);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith('valid-token');
+      expect(mockFetch).toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /api/v1/telemetry/batch', () => {
+    it('returns 401 if no token is provided', async () => {
+      const res = await request(app)
+        .post('/api/v1/telemetry/batch')
+        .send([validPayload]);
+        
+      expect(res.status).toBe(401);
+    });
+
+    it('proceeds to handler if valid token is provided', async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({ 
+        data: { user: { id: 'user-1' } }, 
+        error: null 
+      });
+      mockFetch.mockResolvedValue({
+        ok: true,
+        json: async () => ([{}])
+      });
+
+      const res = await request(app)
+        .post('/api/v1/telemetry/batch')
+        .set('Authorization', 'Bearer valid-token')
+        .send([validPayload]);
+        
+      expect(res.status).toBe(202);
+      expect(mockFetch).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
**Summary:**
This PR adds application-layer authentication checks to the `POST /event` and `POST /batch` endpoints in the telemetry router, successfully mitigating an RLS gap flagged for `oasis_events` by enforcing that only authenticated requests can write telemetry data. 

**Changes:**
- Extracted and validated Supabase session token from `Authorization` header or cookies in a new `requireAuth` middleware (`services/gateway/src/routes/telemetry.ts`).
- Applied the auth middleware to endpoints that write `oasis_events`.
- Created corresponding unit tests in `services/gateway/test/routes/telemetry.test.ts` to ensure unauthenticated requests are met with a `401 Unauthorized` response and valid requests proceed to the handler.

**Note for operators:**
This addresses the immediate unauthenticated access vector via the gateway API, but the database-level RLS migration for `oasis_events` is out of scope for automated execution and must be applied manually by the developer. 
Please refer to the incident context to create the corresponding `enable_rls` migration.