### PR TITLE
DEV-AUTOPILOT: Refactor admin-notifications to use shared requireAdmin auth

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -7,56 +7,26 @@
  * - GET  /preferences/stats — Aggregate opt-in/out rates per category
  *
  * Security:
- * - All endpoints require Bearer token + exafy_admin
+ * - All endpoints require Bearer token + exafy_admin (via requireAdmin middleware)
  */
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/auth';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIFICATIONS';
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
+router.use(requireAdmin);
 
 // ── POST /compose — Send notification to user(s) ────────────
 
 router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
+
+  const userEmail = (req as any).user?.email || 'unknown';
 
   const {
     recipient_ids,   // string[] — specific user IDs
@@ -148,7 +118,7 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      console.log(`[${VTID}] Composed notification for 1 user by ${userEmail}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +131,7 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${userEmail}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -177,9 +147,6 @@ router.post('/compose', async (req: Request, res: Response) => {
 // ── GET /sent — Admin notification log ──────────────────────
 
 router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -224,9 +191,6 @@ router.get('/sent', async (req: Request, res: Response) => {
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
 router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,177 @@
+import request from 'supertest';
+import express, { Request, Response, NextFunction } from 'express';
+import adminNotificationsRouter from '../../src/routes/admin-notifications';
+import { getSupabase } from '../../src/lib/supabase';
+import { notifyUser, notifyUsersAsync } from '../../src/services/notification-service';
+
+// Mock dependencies
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn()
+}));
+
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn(),
+  notifyUsersAsync: jest.fn()
+}));
+
+jest.mock('../../src/middleware/auth', () => ({
+  requireAdmin: jest.fn((req: Request, res: Response, next: NextFunction) => {
+    (req as any).user = { id: 'admin-123', email: 'admin@example.com' };
+    next();
+  })
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/admin/notifications', adminNotificationsRouter);
+
+describe('Admin Notifications Router', () => {
+  let mockQuery: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    
+    // Create chainable mock for Supabase
+    mockQuery = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      range: jest.fn().mockReturnThis(),
+      or: jest.fn().mockReturnThis(),
+      not: jest.fn().mockReturnThis(),
+      then: jest.fn((resolve) => resolve({ data: [], count: 0, error: null }))
+    };
+
+    (getSupabase as jest.Mock).mockReturnValue({
+      from: jest.fn(() => mockQuery)
+    });
+  });
+
+  describe('POST /compose', () => {
+    it('should return 400 if title or body is missing', async () => {
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ recipient_ids: ['user-1'] });
+      
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('INVALID_INPUT');
+    });
+
+    it('should return 400 if no recipient targeting is provided', async () => {
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ title: 'Test', body: 'Test body' });
+      
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('INVALID_INPUT');
+    });
+
+    it('should send direct notification synchronously for a single user', async () => {
+      (notifyUser as jest.Mock).mockResolvedValueOnce({ success: true });
+
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({
+          title: 'Hello',
+          body: 'World',
+          recipient_ids: ['user-1']
+        });
+      
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.sent_to).toBe(1);
+      expect(notifyUser).toHaveBeenCalledWith(
+        'user-1',
+        '',
+        'welcome_to_vitana', // fallback type
+        expect.any(Object),
+        expect.anything()
+      );
+    });
+
+    it('should fetch users and dispatch async for multiple users', async () => {
+      mockQuery.then.mockImplementationOnce((resolve: any) => 
+        resolve({ data: [{ user_id: 'user-1' }, { user_id: 'user-2' }], error: null })
+      );
+
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({
+          title: 'Hello',
+          body: 'World',
+          send_to_all: true,
+          tenant_id: 'tenant-1'
+        });
+      
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.sent_to).toBe(2);
+      expect(notifyUsersAsync).toHaveBeenCalledWith(
+        ['user-1', 'user-2'],
+        'tenant-1',
+        'welcome_to_vitana',
+        expect.any(Object),
+        expect.anything()
+      );
+    });
+  });
+
+  describe('GET /sent', () => {
+    it('should fetch paginated sent notifications', async () => {
+      mockQuery.then.mockImplementationOnce((resolve: any) => 
+        resolve({ data: [{ id: 'notif-1', title: 'Test' }], count: 1, error: null })
+      );
+
+      const res = await request(app)
+        .get('/admin/notifications/sent')
+        .query({ limit: 10, offset: 0, days: 7 });
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.total).toBe(1);
+      expect(res.body.data[0].id).toBe('notif-1');
+    });
+
+    it('should return 500 on supabase error', async () => {
+      mockQuery.then.mockImplementationOnce((resolve: any) => 
+        resolve({ data: null, error: { message: 'DB Error' } })
+      );
+
+      const res = await request(app).get('/admin/notifications/sent');
+
+      expect(res.status).toBe(500);
+      expect(res.body.ok).toBe(false);
+      expect(res.body.error).toBe('DB Error');
+    });
+  });
+
+  describe('GET /preferences/stats', () => {
+    it('should calculate stats properly based on preference records', async () => {
+      // Create a specific mock logic for sequential promises
+      mockQuery.then
+        .mockImplementationOnce((resolve: any) => 
+          resolve({ 
+            data: [
+              { push_enabled: true, dnd_enabled: false },
+              { push_enabled: false, dnd_enabled: true }
+            ], 
+            error: null 
+          })
+        )
+        .mockImplementationOnce((resolve: any) => resolve({ count: 100, error: null }))
+        .mockImplementationOnce((resolve: any) => resolve({ count: 45, error: null }));
+
+      const res = await request(app).get('/admin/notifications/preferences/stats');
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.stats.total_users_with_prefs).toBe(2);
+      expect(res.body.stats.push_enabled).toBe(1);
+      expect(res.body.stats.push_disabled).toBe(1);
+      expect(res.body.delivery.total_sent_30d).toBe(100);
+      expect(res.body.delivery.total_read_30d).toBe(45);
+      expect(res.body.delivery.read_rate).toBe(45);
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses missing auth flagging by the scanner `route-auth-scanner-v1`. 
The `admin-notifications.ts` route file previously used an inline helper `verifyExafyAdmin` instead of the project's standard auth middleware, leading to inconsistency across route files and causing the scanner to flag the file.

Changes:
- Removed `getBearerToken` and `verifyExafyAdmin` inline functions.
- Imported and applied the shared `requireAdmin` middleware from `../middleware/auth` via `router.use(requireAdmin)`.
- Replaced custom `authResult.email` logging with `req.user.email` to match standard middleware behavior.
- Created `admin-notifications.test.ts` to explicitly mock the shared middleware and cover existing endpoints.

This ensures uniform security paths for all admin-protected endpoints.