### PR TITLE
DEV-AUTOPILOT: Add system-controls API endpoint for feature flags

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,23 @@
+import { Router, Request, Response } from 'express';
+import { getSystemControl } from '../services/system-controls';
+
+const router = Router();
+
+router.get('/:key', async (req: Request, res: Response) => {
+  try {
+    const { key } = req.params;
+    const control = await getSystemControl(key);
+
+    if (!control) {
+      res.status(404).json({ error: 'System control not found' });
+      return;
+    }
+
+    res.status(200).json(control);
+  } catch (error) {
+    console.error('Error in GET /api/system-controls/:key:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router;

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,25 @@
+import { supabase } from '../lib/supabase';
+import { SystemControl } from '../types/system-controls';
+
+export async function getSystemControl(key: string): Promise<SystemControl | null> {
+  const { data, error } = await supabase
+    .from('system_controls')
+    .select('*')
+    .eq('key', key)
+    .single();
+
+  if (error) {
+    // PGRST116 indicates no rows returned from a .single() query
+    if (error.code === 'PGRST116') {
+      return null;
+    }
+    console.error(`Error fetching system control ${key}:`, error);
+    return null;
+  }
+
+  if (!data) {
+    return null;
+  }
+
+  return data as SystemControl;
+}

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at?: string;
+  updated_by?: string;
+  reason?: string;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,51 @@
+import request from 'supertest';
+import express from 'express';
+import systemControlsRouter from '../../src/routes/system-controls';
+import * as systemControlsService from '../../src/services/system-controls';
+
+jest.mock('../../src/services/system-controls');
+
+const app = express();
+app.use(express.json());
+app.use('/api/system-controls', systemControlsRouter);
+
+describe('GET /api/system-controls/:key', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return 200 and the control data if found', async () => {
+    const mockControl = {
+      key: 'vitana_did_you_know_enabled',
+      enabled: true
+    };
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(mockControl);
+
+    const response = await request(app).get('/api/system-controls/vitana_did_you_know_enabled');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockControl);
+    expect(systemControlsService.getSystemControl).toHaveBeenCalledWith('vitana_did_you_know_enabled');
+  });
+
+  it('should return 404 if control not found', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(null);
+
+    const response = await request(app).get('/api/system-controls/missing_key');
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'System control not found' });
+  });
+
+  it('should return 500 on service error', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+    (systemControlsService.getSystemControl as jest.Mock).mockRejectedValue(new Error('Test error'));
+
+    const response = await request(app).get('/api/system-controls/error_key');
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: 'Internal server error' });
+    
+    consoleSpy.mockRestore();
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,62 @@
+import { getSystemControl } from '../src/services/system-controls';
+import { supabase } from '../src/lib/supabase';
+
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+describe('System Controls Service', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return a system control when found', async () => {
+    const mockData = {
+      key: 'vitana_did_you_know_enabled',
+      enabled: true,
+      updated_at: '2023-01-01T00:00:00.000Z'
+    };
+
+    const eqMock = jest.fn().mockReturnValue({
+      single: jest.fn().mockResolvedValue({ data: mockData, error: null })
+    });
+    const selectMock = jest.fn().mockReturnValue({ eq: eqMock });
+    (supabase.from as jest.Mock).mockReturnValue({ select: selectMock });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+
+    expect(supabase.from).toHaveBeenCalledWith('system_controls');
+    expect(selectMock).toHaveBeenCalledWith('*');
+    expect(eqMock).toHaveBeenCalledWith('key', 'vitana_did_you_know_enabled');
+    expect(result).toEqual(mockData);
+  });
+
+  it('should return null when not found', async () => {
+    const eqMock = jest.fn().mockReturnValue({
+      single: jest.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } })
+    });
+    const selectMock = jest.fn().mockReturnValue({ eq: eqMock });
+    (supabase.from as jest.Mock).mockReturnValue({ select: selectMock });
+
+    const result = await getSystemControl('missing_key');
+
+    expect(result).toBeNull();
+  });
+
+  it('should return null on other errors and log to console', async () => {
+    const consoleSpy = jest.spyOn(console, 'error').mockImplementation();
+    const eqMock = jest.fn().mockReturnValue({
+      single: jest.fn().mockResolvedValue({ data: null, error: { message: 'Some database error' } })
+    });
+    const selectMock = jest.fn().mockReturnValue({ eq: eqMock });
+    (supabase.from as jest.Mock).mockReturnValue({ select: selectMock });
+
+    const result = await getSystemControl('error_key');
+
+    expect(result).toBeNull();
+    expect(consoleSpy).toHaveBeenCalled();
+    consoleSpy.mockRestore();
+  });
+});


### PR DESCRIPTION
This PR adds a new Gateway API endpoint to query `system_controls` via Supabase. It exposes a minimal, reusable endpoint to fetch any system control by its key, providing the missing Gateway logic to expose the `vitana_did_you_know_enabled` flag to the frontend.

### Files changed:
- `services/gateway/src/types/system-controls.ts`: Types for System Controls records.
- `services/gateway/src/services/system-controls.ts`: Service encapsulating the Supabase query.
- `services/gateway/src/routes/system-controls.ts`: Express router exposing `GET /:key`.
- `services/gateway/test/system-controls.test.ts`: Unit tests for the service.
- `services/gateway/test/routes/system-controls.test.ts`: Unit tests for the API routes.

### ⚠️ Operator Follow-up Required
The plan implied adding the route to the main application and updating the command-hub frontend. However, the respective files were not present in the strict locked list for this step. Please manually complete the following:
1. **Mount the Route**: Import and mount the `system-controls` router in the Gateway's main Express app (e.g. `app.ts` or `server.ts`) at `/api/system-controls`.
2. **Frontend Integration**: Update the `command-hub` frontend application to fetch `GET /api/system-controls/vitana_did_you_know_enabled` and render the "Did You Know?" tour component conditionally.