### PR TITLE
DEV-AUTOPILOT: Mitigate path-to-regexp ReDoS vulnerability in gateway

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,22 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const paramKeys = Object.keys(req.params || {});
+
+    if (paramKeys.length > maxParams) {
+      res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    for (const key of paramKeys) {
+      const value = req.params[key];
+      if (value && String(value).length > maxLength) {
+        res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,14 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply the paramLimit middleware to prevent path-to-regexp ReDoS
+// NOTE: All route files with path parameters should apply this middleware.
+router.use(limitPathParams());
+
+router.get('/:projectId', (req: Request, res: Response) => {
+  res.status(200).json({ projectId: req.params.projectId, type: 'project' });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,18 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply the paramLimit middleware to prevent path-to-regexp ReDoS
+// NOTE: All route files with path parameters should apply this middleware.
+router.use(limitPathParams());
+
+router.get('/:id', (req: Request, res: Response) => {
+  res.status(200).json({ id: req.params.id, type: 'user' });
+});
+
+router.get('/:id/settings/:settingId', (req: Request, res: Response) => {
+  res.status(200).json({ id: req.params.id, settingId: req.params.settingId });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,96 @@
+import express, { Request, Response, NextFunction } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE-Mitigation: paramLimit middleware', () => {
+  describe('Unit tests', () => {
+    it('should return 400 if req.params has more keys than maxParams', () => {
+      const middleware = limitPathParams(5, 200);
+      const req = {
+        params: { p1: '1', p2: '2', p3: '3', p4: '4', p5: '5', p6: '6' }
+      } as unknown as Request;
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn()
+      } as unknown as Response;
+      const next = jest.fn() as NextFunction;
+
+      middleware(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Too many path parameters or parameter too long' });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should return 400 if any parameter exceeds maxLength', () => {
+      const middleware = limitPathParams(5, 20);
+      const req = {
+        params: { p1: '123', p2: 'a'.repeat(21) }
+      } as unknown as Request;
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn()
+      } as unknown as Response;
+      const next = jest.fn() as NextFunction;
+
+      middleware(req, res, next);
+
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Too many path parameters or parameter too long' });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should call next() if parameters are within limits', () => {
+      const middleware = limitPathParams(5, 200);
+      const req = {
+        params: { p1: '123', p2: '456' }
+      } as unknown as Request;
+      const res = {
+        status: jest.fn().mockReturnThis(),
+        json: jest.fn()
+      } as unknown as Response;
+      const next = jest.fn() as NextFunction;
+
+      middleware(req, res, next);
+
+      expect(next).toHaveBeenCalled();
+    });
+  });
+
+  describe('Integration tests', () => {
+    let app: express.Express;
+
+    beforeEach(() => {
+      app = express();
+      
+      // Setup a route simulating multiple parameters for ReDoS testing
+      app.get('/api/resource/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req, res) => {
+        res.status(200).json({ success: true });
+      });
+
+      // Setup a route for valid normal requests
+      app.get('/api/valid/:a/:b', limitPathParams(5, 200), (req, res) => {
+        res.status(200).json({ success: true });
+      });
+    });
+
+    it('should return 400 with short response time for >5 path parameters (ReDoS mitigation)', async () => {
+      const start = Date.now();
+      // Sending a request with 6 segments, which matches the :a to :f route and gets parsed into 6 params
+      const response = await request(app).get('/api/resource/1/2/3/4/5/6');
+      const duration = Date.now() - start;
+
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe('Too many path parameters or parameter too long');
+      // Assert response time is fast to ensure CPU exhaustion is prevented
+      expect(duration).toBeLessThan(200);
+    });
+
+    it('should allow normal request with <=5 parameters (passthrough)', async () => {
+      const response = await request(app).get('/api/valid/1/2');
+      
+      expect(response.status).toBe(200);
+      expect(response.body.success).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Mitigates the ReDoS vulnerability in `path-to-regexp` (<0.1.13) used by `express` in the API gateway by capping path parameters.

### Plan execution
- Implemented `paramLimit.ts` middleware to enforce `maxParams` (default 5) and `maxLength` (default 200) limits on `req.params`.
- Applied `router.use(limitPathParams())` to newly bootstrapped `userRoutes.ts` and `projectRoutes.ts` as representative examples.
- Added unit and integration tests under `test/cve-mitigation.test.ts` to assert that requests with >5 params or overly long params are promptly rejected with a `400 Bad Request` (<200ms).

### Note to Operator
The plan states: "The developer must apply the same change to any other route files in `services/gateway/src/routes/` that contain path parameters." Because this autopilot run is strictly locked to a specific list of 4 files, I could only apply it to `userRoutes.ts` and `projectRoutes.ts`. Please follow up to ensure any other existing route files in that directory also import and `router.use()` the `limitPathParams` middleware.