### PR TITLE
DEV-AUTOPILOT: Enforce auth checks for telemetry writes

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,7 +1,8 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
 
@@ -24,9 +25,35 @@ const TelemetryEventSchema = z.object({
 
 type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
+// Middleware to enforce authentication
+export const requireAuthenticatedUser = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const authHeader = req.headers.authorization;
+    let token: string | undefined;
+
+    if (authHeader && authHeader.startsWith("Bearer ")) {
+      token = authHeader.split(" ")[1];
+    }
+
+    if (!token) {
+      return res.status(401).json({ error: "Unauthorized", detail: "Missing or invalid Authorization header" });
+    }
+
+    const { data, error } = await supabase.auth.getUser(token);
+    if (error || !data?.user) {
+      return res.status(401).json({ error: "Unauthorized", detail: "Invalid session token" });
+    }
+
+    next();
+  } catch (err: any) {
+    console.error("Auth middleware error:", err);
+    return res.status(500).json({ error: "Internal server error", detail: "Auth verification failed" });
+  }
+};
+
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +173,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,133 @@
+import express from 'express';
+import request from 'supertest';
+import { router } from '../../src/routes/telemetry';
+import { supabase } from '../../src/lib/supabase';
+
+// Mock Supabase
+jest.mock('../../src/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn()
+    }
+  }
+}));
+
+// Mock devhub to prevent SSE broadcast require errors during testing
+jest.mock('../../src/routes/devhub', () => ({
+  broadcastEvent: jest.fn()
+}), { virtual: true });
+
+const app = express();
+app.use(express.json());
+app.use('/api/v1/telemetry', router);
+
+describe('Telemetry Routes Auth Enforcement', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+    process.env.SUPABASE_URL = 'http://localhost:8000';
+    process.env.SUPABASE_SERVICE_ROLE = 'test-svc-key';
+  });
+
+  const validEvent = {
+    vtid: 'VT-123',
+    layer: 'test',
+    module: 'test',
+    source: 'test',
+    kind: 'test.event',
+    status: 'success',
+    title: 'Test Event'
+  };
+
+  describe('POST /event', () => {
+    it('should return 401 when no auth token is provided', async () => {
+      const response = await request(app)
+        .post('/api/v1/telemetry/event')
+        .send(validEvent);
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe('Unauthorized');
+    });
+
+    it('should return 401 when an invalid auth token is provided', async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: new Error('Invalid token')
+      });
+
+      const response = await request(app)
+        .post('/api/v1/telemetry/event')
+        .set('Authorization', 'Bearer bad-token')
+        .send(validEvent);
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe('Unauthorized');
+    });
+
+    it('should process the event when a valid token is provided', async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: 'user-123' } },
+        error: null
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({})
+      });
+
+      const response = await request(app)
+        .post('/api/v1/telemetry/event')
+        .set('Authorization', 'Bearer good-token')
+        .send(validEvent);
+
+      expect(response.status).toBe(202);
+    });
+  });
+
+  describe('POST /batch', () => {
+    it('should return 401 when no auth token is provided', async () => {
+      const response = await request(app)
+        .post('/api/v1/telemetry/batch')
+        .send([validEvent]);
+
+      expect(response.status).toBe(401);
+    });
+
+    it('should return 202 when a valid token is provided', async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: 'user-123' } },
+        error: null
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({})
+      });
+
+      const response = await request(app)
+        .post('/api/v1/telemetry/batch')
+        .set('Authorization', 'Bearer good-token')
+        .send([validEvent]);
+
+      expect(response.status).toBe(202);
+    });
+  });
+
+  describe('GET /health', () => {
+    it('should remain accessible without authentication', async () => {
+      const response = await request(app).get('/api/v1/telemetry/health');
+      expect(response.status).toBe(200);
+    });
+  });
+  
+  describe('GET /snapshot', () => {
+    it('should remain accessible without authentication', async () => {
+      (global.fetch as jest.Mock)
+        .mockResolvedValueOnce({ ok: true, json: async () => ([]) })
+        .mockResolvedValueOnce({ ok: true, json: async () => ([]) });
+
+      const response = await request(app).get('/api/v1/telemetry/snapshot');
+      expect(response.status).toBe(200);
+    });
+  });
+});


### PR DESCRIPTION
**Context & Issue:**
The `rls-policy-scanner-v1` flagged a medium-risk RLS gap on the `oasis_events` table (lack of row-level security). While the actual RLS implementation must be a database migration applied by developers, this PR introduces application-level safeguards as a temporary/additional defense-in-depth measure. 

**Changes:**
1. Created an Express middleware (`requireAuthenticatedUser`) in `services/gateway/src/routes/telemetry.ts` that enforces Supabase token validation via `supabase.auth.getUser()`.
2. Applied the middleware to the `POST /event` and `POST /batch` routes that write to `oasis_events`.
3. Added unit tests in `services/gateway/test/routes/telemetry.test.ts` to verify unauthorized requests are rejected (401) and valid requests proceed to insertion.

**Out of Scope:**
The database-level RLS migration (`supabase/migrations/`) remains out of scope for automated execution and should be applied manually by the operator following the standard template.