### PR TITLE
DEV-AUTOPILOT: Secure telemetry routes with app-level auth middleware

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,30 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+// Middleware to ensure user is authenticated
+const requireAuth = async (req: Request, res: Response, next: NextFunction): Promise<any> => {
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      return res.status(401).json({ error: "Unauthorized", detail: "Missing or invalid Authorization header" });
+    }
+    const token = authHeader.substring(7);
+    const { data, error } = await supabase.auth.getUser(token);
+    
+    if (error || !data?.user) {
+      return res.status(401).json({ error: "Unauthorized", detail: error?.message || "Invalid token" });
+    }
+    
+    return next();
+  } catch (e: any) {
+    return res.status(500).json({ error: "Internal server error", detail: e.message });
+  }
+};
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +47,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +167,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,131 @@
+import request from "supertest";
+import express from "express";
+import { router } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+// Mock supabase client
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+// Mock stage-mapping to avoid test failures due to complex dependencies
+jest.mock("../../src/lib/stage-mapping", () => ({
+  mapRawToStage: jest.fn().mockReturnValue("PLANNER"),
+  normalizeStage: jest.fn(),
+  isValidStage: jest.fn(),
+  emptyStageCounters: jest.fn(),
+  VALID_STAGES: ["PLANNER", "WORKER", "VALIDATOR", "DEPLOY"],
+}));
+
+// Global fetch mock
+global.fetch = jest.fn() as jest.Mock;
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1/telemetry", router);
+
+describe("Telemetry Routes Authentication", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SUPABASE_URL = "http://localhost:8000";
+    process.env.SUPABASE_SERVICE_ROLE = "test-service-role-key";
+  });
+
+  describe("POST /api/v1/telemetry/event", () => {
+    const validPayload = {
+      vtid: "VTID-123",
+      layer: "app",
+      module: "auth",
+      source: "client",
+      kind: "login",
+      status: "success",
+      title: "User login",
+    };
+
+    it("should return 401 if Authorization header is missing", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validPayload);
+      
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+    });
+
+    it("should return 401 if token is invalid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({ 
+        data: { user: null }, 
+        error: { message: "Invalid token" } 
+      });
+      
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validPayload);
+      
+      expect(res.status).toBe(401);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("invalid-token");
+    });
+
+    it("should proceed (return 202) if token is valid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({ 
+        data: { user: { id: "user-123" } }, 
+        error: null 
+      });
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send(validPayload);
+      
+      expect(res.status).toBe(202);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("valid-token");
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    const validPayload = [{
+      vtid: "VTID-123",
+      layer: "app",
+      module: "auth",
+      source: "client",
+      kind: "login",
+      status: "success",
+      title: "User login",
+    }];
+
+    it("should return 401 if Authorization header is missing", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send(validPayload);
+      
+      expect(res.status).toBe(401);
+    });
+
+    it("should return 202 if token is valid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({ 
+        data: { user: { id: "user-123" } }, 
+        error: null 
+      });
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-token")
+        .send(validPayload);
+      
+      expect(res.status).toBe(202);
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses the security gap flagged by `rls-policy-scanner-v1` regarding the missing Row-Level Security on the `oasis_events` table.
Because modifying database migrations is outside of automated execution scope, we are introducing an application-level mitigation.
- Added `requireAuth` middleware to `services/gateway/src/routes/telemetry.ts` to verify the user's Supabase session from the `Authorization` header.
- Applied the middleware to the `POST /event` and `POST /batch` routes to prevent unauthenticated writes.
- Added unit tests in `services/gateway/test/routes/telemetry.test.ts` to ensure unauthenticated requests receive a 401 Unauthorized status while valid tokens succeed.

**Developer Follow-up**: The database-level RLS migration (e.g., `ALTER TABLE public.oasis_events ENABLE ROW LEVEL SECURITY;` + insert/update policies) should be applied manually to fully secure the table against direct SQL access.