### PR TITLE
DEV-AUTOPILOT: Refactor auth in admin-notification-categories route

### DIFF
--- a/services/gateway/src/routes/admin-notification-categories.ts
+++ b/services/gateway/src/routes/admin-notification-categories.ts
@@ -11,55 +11,20 @@
  * - POST   /:id/test      — Send test notification to admin
  *
  * Security:
- * - All endpoints are protected by the `requireExafyAdmin` middleware.
+ * - All endpoints are protected by the `requireAdmin` middleware.
  */
 
-import { Router, Request, Response, NextFunction } from 'express';
+import { Router, Request, Response } from 'express';
 import { createClient } from '@supabase/supabase-js';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/requireAdmin';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIF-CATEGORIES';
 
 const VALID_TYPES = ['chat', 'calendar', 'community'];
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-// ── Auth Middleware ─────────────────────────────────────────
-
-async function requireExafyAdmin(req: Request, res: Response, next: NextFunction) {
-  const token = getBearerToken(req);
-  if (!token) return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) {
-      return res.status(401).json({ ok: false, error: 'INVALID_TOKEN' });
-    }
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return res.status(403).json({ ok: false, error: 'FORBIDDEN' });
-    }
-
-    // Attach user info to request for downstream handlers
-    (req as any).authUser = { user_id: authData.user.id, email: authData.user.email || 'unknown' };
-    next();
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
-  }
-}
-
-router.use(requireExafyAdmin);
+router.use(requireAdmin);
 
 // ── Supabase ────────────────────────────────────────────────
 
@@ -140,8 +105,6 @@ router.get('/:id', async (req: Request, res: Response) => {
 // ── POST / — Create category ───────────────────────────────
 
 router.post('/', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
-
   const supabase = getSupabase();
   const {
     type,
@@ -180,7 +143,7 @@ router.post('/', async (req: Request, res: Response) => {
     default_enabled: default_enabled ?? true,
     mapped_types: mapped_types || [],
     tenant_id: tenant_id || null,
-    created_by: authUser.user_id,
+    created_by: (req as any).user?.id,
   };
 
   const { data, error } = await supabase
@@ -197,15 +160,13 @@ router.post('/', async (req: Request, res: Response) => {
     return res.status(500).json({ ok: false, error: error.message });
   }
 
-  console.log(`[${VTID}] Created category "${slug}" (${type}) by ${authUser.email}`);
+  console.log(`[${VTID}] Created category "${slug}" (${type}) by ${(req as any).user?.email ?? 'unknown'}`);
   return res.status(201).json({ ok: true, data });
 });
 
 // ── PATCH /:id — Update category ────────────────────────────
 
 router.patch('/:id', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
-
   const supabase = getSupabase();
   const allowedFields = ['display_name', 'description', 'icon', 'sort_order', 'is_active', 'default_enabled', 'mapped_types'];
   const updateData: Record<string, any> = { updated_at: new Date().toISOString() };
@@ -236,15 +197,13 @@ router.patch('/:id', async (req: Request, res: Response) => {
     return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
   }
 
-  console.log(`[${VTID}] Updated category "${data.slug}" by ${authUser.email}`);
+  console.log(`[${VTID}] Updated category "${data.slug}" by ${(req as any).user?.email ?? 'unknown'}`);
   return res.json({ ok: true, data });
 });
 
 // ── DELETE /:id — Soft-delete (set is_active=false) ─────────
 
 router.delete('/:id', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
-
   const supabase = getSupabase();
   const { data, error } = await supabase
     .from('notification_categories')
@@ -261,15 +220,13 @@ router.delete('/:id', async (req: Request, res: Response) => {
     return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
   }
 
-  console.log(`[${VTID}] Soft-deleted category "${data.slug}" by ${authUser.email}`);
+  console.log(`[${VTID}] Soft-deleted category "${data.slug}" by ${(req as any).user?.email ?? 'unknown'}`);
   return res.json({ ok: true, data });
 });
 
 // ── POST /:id/test — Send test notification to admin ────────
 
 router.post('/:id/test', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
-
   const supabase = getSupabase();
 
   // Get the category
@@ -296,15 +253,15 @@ router.post('/:id/test', async (req: Request, res: Response) => {
   const { data: tenantRow } = await supabase
     .from('user_tenants')
     .select('tenant_id')
-    .eq('user_id', authUser.user_id)
+    .eq('user_id', (req as any).user?.id)
     .limit(1)
     .single();
 
   const tenantId = tenantRow?.tenant_id || '00000000-0000-0000-0000-000000000000';
 
   try {
-    const result = await notifyUser(authUser.user_id, tenantId, testType, payload, supabase);
-    console.log(`[${VTID}] Test notification sent for category "${category.slug}" by ${authUser.email}`);
+    const result = await notifyUser((req as any).user?.id, tenantId, testType, payload, supabase);
+    console.log(`[${VTID}] Test notification sent for category "${category.slug}" by ${(req as any).user?.email ?? 'unknown'}`);
     return res.json({ ok: true, result });
   } catch (err: any) {
     console.error(`[${VTID}] POST /:id/test error:`, err.message);

--- a/services/gateway/tests/admin-notification-categories.test.ts
+++ b/services/gateway/tests/admin-notification-categories.test.ts
@@ -1,0 +1,81 @@
+import request from 'supertest';
+import express from 'express';
+import router from '../src/routes/admin-notification-categories';
+
+jest.mock('@supabase/supabase-js', () => {
+  const chainable = {
+    from: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    order: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    or: jest.fn().mockReturnThis(),
+    is: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    insert: jest.fn().mockReturnThis(),
+    update: jest.fn().mockReturnThis(),
+    delete: jest.fn().mockReturnThis(),
+    single: jest.fn().mockResolvedValue({ data: { id: '1', slug: 'test', type: 'chat', mapped_types: [] }, error: null }),
+    then: jest.fn((resolve) => resolve({ data: [{ id: '1', type: 'chat', slug: 'test', mapped_types: [] }], error: null }))
+  };
+  return { createClient: jest.fn(() => chainable) };
+});
+
+jest.mock('../src/services/notification-service', () => ({
+  notifyUser: jest.fn().mockResolvedValue(true)
+}));
+
+jest.mock('../src/middleware/requireAdmin', () => ({
+  requireAdmin: jest.fn((req, res, next) => {
+    const token = req.headers.authorization;
+    if (!token) {
+      return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+    }
+    if (token === 'Bearer user-token') {
+      return res.status(403).json({ ok: false, error: 'FORBIDDEN' });
+    }
+    if (token === 'Bearer admin-token') {
+      req.user = { id: 'admin-123', email: 'admin@test.com' };
+      return next();
+    }
+    return res.status(401).json({ ok: false, error: 'INVALID_TOKEN' });
+  })
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/admin/notification-categories', router);
+
+describe('Admin Notification Categories API', () => {
+  describe('Auth Boundaries', () => {
+    it('returns 401 for unauthenticated request', async () => {
+      const res = await request(app).get('/admin/notification-categories');
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe('UNAUTHENTICATED');
+    });
+
+    it('returns 403 for authenticated non-admin request', async () => {
+      const res = await request(app)
+        .get('/admin/notification-categories')
+        .set('Authorization', 'Bearer user-token');
+      expect(res.status).toBe(403);
+      expect(res.body.error).toBe('FORBIDDEN');
+    });
+
+    it('returns 200 for authenticated admin request on GET /', async () => {
+      const res = await request(app)
+        .get('/admin/notification-categories')
+        .set('Authorization', 'Bearer admin-token');
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+    });
+
+    it('returns 201 for authenticated admin request on POST /', async () => {
+      const res = await request(app)
+        .post('/admin/notification-categories')
+        .set('Authorization', 'Bearer admin-token')
+        .send({ type: 'chat', display_name: 'Test Chat Category' });
+      expect(res.status).toBe(201);
+      expect(res.body.ok).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
**Context & Plan**
This PR resolves the `route-auth-scanner-v1` finding for `admin-notification-categories.ts`. The scanner flagged this file for using a non-standard inline auth pattern instead of the centralized middleware.

**Changes**
1. Removed inline `getBearerToken` and `requireExafyAdmin` functions.
2. Imported and attached `requireAdmin` middleware cleanly at the router level via `router.use(requireAdmin)`.
3. Adjusted endpoints to read user details (`id` and `email`) from standard `req.user` rather than custom locals.
4. Cleaned up unused imports (like `createUserSupabaseClient` and `NextFunction`).
5. Added `tests/admin-notification-categories.test.ts` to explicitly test auth boundaries (unauthenticated -> 401, non-admin -> 403, and admin -> 200/201).

**Files touched**
- `services/gateway/src/routes/admin-notification-categories.ts`
- `services/gateway/tests/admin-notification-categories.test.ts`