### PR TITLE
DEV-AUTOPILOT: Refactor admin-notifications router to use shared requireAdmin auth

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -12,51 +12,21 @@
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/auth';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIFICATIONS';
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
+router.use(requireAdmin);
 
 // ── POST /compose — Send notification to user(s) ────────────
 
 router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
+
+  const adminEmail = (req as any).user?.email || 'unknown';
 
   const {
     recipient_ids,   // string[] — specific user IDs
@@ -148,7 +118,7 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      console.log(`[${VTID}] Composed notification for 1 user by ${adminEmail}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +131,7 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${adminEmail}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -177,9 +147,6 @@ router.post('/compose', async (req: Request, res: Response) => {
 // ── GET /sent — Admin notification log ──────────────────────
 
 router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -224,9 +191,6 @@ router.get('/sent', async (req: Request, res: Response) => {
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
 router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,133 @@
+import request from 'supertest';
+import express from 'express';
+import adminNotificationsRouter from '../../src/routes/admin-notifications';
+import { getSupabase } from '../../src/lib/supabase';
+import { notifyUser, notifyUsersAsync } from '../../src/services/notification-service';
+
+jest.mock('../../src/middleware/auth', () => ({
+  requireAdmin: jest.fn((req, res, next) => {
+    req.user = { id: 'admin-id', email: 'admin@test.com' };
+    next();
+  }),
+}));
+
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn(),
+}));
+
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn(),
+  notifyUsersAsync: jest.fn(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/admin/notifications', adminNotificationsRouter);
+
+describe('Admin Notifications API', () => {
+  let mockSupabase: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSupabase = {
+      from: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      range: jest.fn().mockReturnThis(),
+      or: jest.fn().mockReturnThis(),
+      not: jest.fn().mockReturnThis(),
+      then: jest.fn((resolve) => resolve({ data: [], count: 0, error: null }))
+    };
+    (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+  });
+
+  describe('POST /compose', () => {
+    it('returns 400 if title or body is missing', async () => {
+      const res = await request(app).post('/admin/notifications/compose').send({
+        recipient_ids: ['user-1'],
+        title: 'Hello',
+      });
+      expect(res.status).toBe(400);
+      expect(res.body.message).toBe('title and body are required');
+    });
+
+    it('returns 400 if no recipients specified', async () => {
+      const res = await request(app).post('/admin/notifications/compose').send({
+        title: 'Hello',
+        body: 'World',
+      });
+      expect(res.status).toBe(400);
+      expect(res.body.message).toMatch(/Must specify recipient_ids/);
+    });
+
+    it('sends to a single user synchronously', async () => {
+      (notifyUser as jest.Mock).mockResolvedValue({ success: true });
+      const res = await request(app).post('/admin/notifications/compose').send({
+        recipient_ids: ['user-1'],
+        title: 'Hello',
+        body: 'World',
+      });
+      expect(res.status).toBe(200);
+      expect(res.body.sent_to).toBe(1);
+      expect(notifyUser).toHaveBeenCalledWith(
+        'user-1',
+        '',
+        'welcome_to_vitana',
+        expect.any(Object),
+        mockSupabase
+      );
+    });
+
+    it('sends to multiple users asynchronously', async () => {
+      const res = await request(app).post('/admin/notifications/compose').send({
+        recipient_ids: ['user-1', 'user-2'],
+        title: 'Hello',
+        body: 'World',
+      });
+      expect(res.status).toBe(200);
+      expect(res.body.sent_to).toBe(2);
+      expect(notifyUsersAsync).toHaveBeenCalledWith(
+        ['user-1', 'user-2'],
+        '',
+        'welcome_to_vitana',
+        expect.any(Object),
+        mockSupabase
+      );
+    });
+  });
+
+  describe('GET /sent', () => {
+    it('returns sent notifications', async () => {
+      mockSupabase.then = jest.fn((resolve) => resolve({
+        data: [{ id: 'notif-1' }],
+        count: 1,
+        error: null
+      }));
+
+      const res = await request(app).get('/admin/notifications/sent');
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.total).toBe(1);
+    });
+  });
+
+  describe('GET /preferences/stats', () => {
+    it('returns preferences stats', async () => {
+      mockSupabase.then = jest.fn((resolve) => resolve({
+        data: [{ push_enabled: true, dnd_enabled: false }],
+        count: 10,
+        error: null
+      }));
+
+      const res = await request(app).get('/admin/notifications/preferences/stats');
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.stats.total_users_with_prefs).toBe(1);
+      expect(res.body.delivery.total_sent_30d).toBe(10);
+      expect(res.body.delivery.total_read_30d).toBe(10);
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses the missing authentication issue flagged by `route-auth-scanner-v1` in `admin-notifications.ts`. 

Previously, this file used a custom, inline `verifyExafyAdmin` function which caused inconsistencies across the codebase and caused the file to be flagged. This PR removes the inline helper and replaces it with the standard `requireAdmin` middleware from `../middleware/auth`, bringing it in line with the rest of our admin-protected routes. 

A test file has also been created to mock the updated auth middleware and provide baseline validation for the endpoints.

Files touched:
- `services/gateway/src/routes/admin-notifications.ts`
- `services/gateway/test/routes/admin-notifications.test.ts`