### PR TITLE
DEV-AUTOPILOT: Secures telemetry write endpoints with auth middleware

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,7 +1,8 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
 
@@ -24,9 +25,42 @@ const TelemetryEventSchema = z.object({
 
 type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
+// Authentication middleware to secure oasis_events writes
+const requireAuthenticatedUser = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      res.status(401).json({
+        error: "Unauthorized",
+        detail: "Missing or invalid Authorization header",
+      });
+      return;
+    }
+
+    const token = authHeader.split(" ")[1];
+    const { data, error } = await supabase.auth.getUser(token);
+
+    if (error || !data?.user) {
+      res.status(401).json({
+        error: "Unauthorized",
+        detail: "Invalid session token",
+      });
+      return;
+    }
+
+    next();
+  } catch (e: any) {
+    res.status(401).json({
+      error: "Unauthorized",
+      detail: "Session verification failed",
+    });
+    return;
+  }
+};
+
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +180,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,147 @@
+import request from 'supertest';
+import express from 'express';
+import { router } from '../../src/routes/telemetry';
+import { supabase } from '../../src/lib/supabase';
+
+// Mock the supabase client
+jest.mock('../../src/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+// Mock devhub inline require to prevent errors during tests
+jest.mock('../../src/routes/devhub', () => ({
+  broadcastEvent: jest.fn(),
+}), { virtual: true });
+
+const app = express();
+app.use(express.json());
+app.use('/api/v1/telemetry', router);
+
+describe('Telemetry Routes Authorization', () => {
+  let originalFetch: typeof fetch;
+
+  beforeAll(() => {
+    originalFetch = global.fetch;
+    process.env.SUPABASE_URL = 'http://localhost:8000';
+    process.env.SUPABASE_SERVICE_ROLE = 'test-svc-key';
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_ROLE;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Mock global fetch to return success for Supabase REST calls
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+      text: async () => 'OK',
+    } as any);
+  });
+
+  const validEventPayload = {
+    vtid: 'VTID-123',
+    layer: 'test-layer',
+    module: 'test-module',
+    source: 'test-source',
+    kind: 'test.kind',
+    status: 'success',
+    title: 'Test Title'
+  };
+
+  describe('POST /api/v1/telemetry/event', () => {
+    it('should return 401 Unauthorized if no token is provided', async () => {
+      const res = await request(app)
+        .post('/api/v1/telemetry/event')
+        .send(validEventPayload);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe('Unauthorized');
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should return 401 Unauthorized if token is invalid', async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: new Error('Invalid token'),
+      });
+
+      const res = await request(app)
+        .post('/api/v1/telemetry/event')
+        .set('Authorization', 'Bearer invalid-token')
+        .send(validEventPayload);
+
+      expect(res.status).toBe(401);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith('invalid-token');
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should return 202 Accepted if token is valid', async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: 'user-123' } },
+        error: null,
+      });
+
+      const res = await request(app)
+        .post('/api/v1/telemetry/event')
+        .set('Authorization', 'Bearer valid-token')
+        .send(validEventPayload);
+
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith('valid-token');
+      expect(global.fetch).toHaveBeenCalled(); // Should proceed to save to OASIS
+    });
+  });
+
+  describe('POST /api/v1/telemetry/batch', () => {
+    const batchPayload = [validEventPayload, validEventPayload];
+
+    it('should return 401 Unauthorized if no token is provided', async () => {
+      const res = await request(app)
+        .post('/api/v1/telemetry/batch')
+        .send(batchPayload);
+
+      expect(res.status).toBe(401);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should return 401 Unauthorized if token is invalid', async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: new Error('Invalid token'),
+      });
+
+      const res = await request(app)
+        .post('/api/v1/telemetry/batch')
+        .set('Authorization', 'Bearer invalid-token')
+        .send(batchPayload);
+
+      expect(res.status).toBe(401);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it('should return 202 Accepted if token is valid', async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: 'user-123' } },
+        error: null,
+      });
+
+      const res = await request(app)
+        .post('/api/v1/telemetry/batch')
+        .set('Authorization', 'Bearer valid-token')
+        .send(batchPayload);
+
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses a medium-risk `rls_gap` finding related to the `oasis_events` table by enforcing authentication at the API gateway layer before any telemetry writes are permitted.

**Changes:**
- Created `requireAuthenticatedUser` Express middleware that verifies incoming `Authorization: Bearer <token>` credentials via `supabase.auth.getUser()`.
- Applied this middleware to the `POST /event` and `POST /batch` endpoints in `services/gateway/src/routes/telemetry.ts` which write to the `oasis_events` table.
- Created `services/gateway/test/routes/telemetry.test.ts` to enforce and verify that unauthorized requests return `401 Unauthorized` and authorized requests succeed.

**Out of Scope / Developer Action Required:**
The database-level migration to enable RLS and create the policies was out of scope for the automated agent. A manual migration is required. Please create a migration (e.g., `supabase/migrations/20251215000000_enable_rls_oasis_events.sql`) with the following:
```sql
ALTER TABLE public.oasis_events ENABLE ROW LEVEL SECURITY;
CREATE POLICY "allow_authenticated_insert" ON public.oasis_events
 FOR INSERT TO authenticated WITH CHECK (true);
CREATE POLICY "allow_authenticated_update" ON public.oasis_events
 FOR UPDATE TO authenticated USING (true);
REVOKE INSERT, UPDATE ON public.oasis_events FROM anon, public;
```