### PR TITLE
DEV-AUTOPILOT: Add auth enforcement to telemetry write endpoints

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,40 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+// Middleware to require authentication via Supabase
+const requireAuthenticatedUser = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      return res.status(401).json({ 
+        error: "Unauthorized", 
+        detail: "Missing or invalid Authorization header" 
+      });
+    }
+
+    const token = authHeader.substring(7);
+    const { data, error } = await supabase.auth.getUser(token);
+
+    if (error || !data?.user) {
+      return res.status(401).json({ 
+        error: "Unauthorized", 
+        detail: "Invalid or expired token" 
+      });
+    }
+
+    next();
+  } catch (err: any) {
+    console.error("Auth middleware error:", err);
+    return res.status(500).json({ 
+      error: "Internal server error during authentication" 
+    });
+  }
+};
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +57,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +177,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,152 @@
+import request from 'supertest';
+import express from 'express';
+import { router } from '../../src/routes/telemetry';
+import { supabase } from '../../src/lib/supabase';
+
+// Mock Supabase client
+jest.mock('../../src/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn()
+    }
+  }
+}));
+
+// Mock devhub broadcast to avoid errors when dynamic require is called
+jest.mock('../../src/routes/devhub', () => ({
+  broadcastEvent: jest.fn()
+}), { virtual: true });
+
+describe('Telemetry Routes', () => {
+  let app: express.Application;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api/v1/telemetry', router);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SUPABASE_URL = 'http://localhost:8000';
+    process.env.SUPABASE_SERVICE_ROLE = 'test-service-key';
+  });
+
+  describe('Auth Middleware Enforcement', () => {
+    const validEvent = {
+      vtid: 'VTID-123',
+      layer: 'test-layer',
+      module: 'test-module',
+      source: 'test-source',
+      kind: 'test.event',
+      status: 'success',
+      title: 'Test Event'
+    };
+
+    describe('POST /api/v1/telemetry/event', () => {
+      it('should return 401 if Authorization header is missing', async () => {
+        const response = await request(app)
+          .post('/api/v1/telemetry/event')
+          .send(validEvent);
+        
+        expect(response.status).toBe(401);
+        expect(response.body.error).toBe('Unauthorized');
+      });
+
+      it('should return 401 if token is invalid', async () => {
+        (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+          data: { user: null },
+          error: new Error('Invalid token')
+        });
+
+        const response = await request(app)
+          .post('/api/v1/telemetry/event')
+          .set('Authorization', 'Bearer invalid-token')
+          .send(validEvent);
+        
+        expect(response.status).toBe(401);
+        expect(response.body.error).toBe('Unauthorized');
+        expect(supabase.auth.getUser).toHaveBeenCalledWith('invalid-token');
+      });
+
+      it('should proceed if token is valid', async () => {
+        (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+          data: { user: { id: 'user-123' } },
+          error: null
+        });
+
+        const originalFetch = global.fetch;
+        global.fetch = jest.fn().mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({})
+        }) as any;
+
+        const response = await request(app)
+          .post('/api/v1/telemetry/event')
+          .set('Authorization', 'Bearer valid-token')
+          .send(validEvent);
+        
+        expect(response.status).toBe(202);
+        expect(global.fetch).toHaveBeenCalled();
+
+        global.fetch = originalFetch;
+      });
+    });
+
+    describe('POST /api/v1/telemetry/batch', () => {
+      const validBatch = [validEvent];
+
+      it('should return 401 if Authorization header is missing', async () => {
+        const response = await request(app)
+          .post('/api/v1/telemetry/batch')
+          .send(validBatch);
+        
+        expect(response.status).toBe(401);
+      });
+
+      it('should return 401 if token is invalid', async () => {
+        (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+          data: { user: null },
+          error: new Error('Invalid token')
+        });
+
+        const response = await request(app)
+          .post('/api/v1/telemetry/batch')
+          .set('Authorization', 'Bearer invalid-token')
+          .send(validBatch);
+        
+        expect(response.status).toBe(401);
+      });
+
+      it('should proceed if token is valid', async () => {
+        (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+          data: { user: { id: 'user-123' } },
+          error: null
+        });
+
+        const originalFetch = global.fetch;
+        global.fetch = jest.fn().mockResolvedValueOnce({
+          ok: true,
+          json: async () => ({})
+        }) as any;
+
+        const response = await request(app)
+          .post('/api/v1/telemetry/batch')
+          .set('Authorization', 'Bearer valid-token')
+          .send(validBatch);
+        
+        expect(response.status).toBe(202);
+
+        global.fetch = originalFetch;
+      });
+    });
+
+    describe('GET /api/v1/telemetry/health', () => {
+      it('should return 200 without auth as it is a read-only unauthenticated route', async () => {
+        const response = await request(app).get('/api/v1/telemetry/health');
+        expect(response.status).toBe(200);
+        expect(response.body.ok).toBe(true);
+      });
+    });
+  });
+});


### PR DESCRIPTION
**Summary:**
This PR addresses a medium-risk `rls_gap` identified by the `rls-policy-scanner-v1` scanner. It adds application-level authentication to the telemetry API routes that insert into `oasis_events` by enforcing valid Supabase user sessions. Unauthenticated calls will now be rejected with HTTP 401 Unauthorized before any DB operations occur.

**Files touched:**
- `services/gateway/src/routes/telemetry.ts`: Added `requireAuthenticatedUser` middleware using the existing `supabase.auth.getUser` mechanism and applied it to `POST /event` and `POST /batch`.
- `services/gateway/test/routes/telemetry.test.ts`: Created new unit tests verifying both successful passes and 401 rejection scenarios.

**Out of scope follow-up:**
Please note that you will still need to manually apply the DB migration (e.g., `ALTER TABLE public.oasis_events ENABLE ROW LEVEL SECURITY;` + appropriate insertion policies for `authenticated` roles) to harden the table fully at the DB layer, as migrations are outside the automated execution scope.