### PR TITLE
DEV-AUTOPILOT: Add paramLimit middleware to mitigate ReDoS vulnerability

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,24 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    if (req.params) {
+      const keys = Object.keys(req.params);
+      
+      if (keys.length > maxParams) {
+        res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+      
+      for (const key of keys) {
+        const val = req.params[key];
+        if (typeof val === 'string' && val.length > maxLength) {
+          res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+          return;
+        }
+      }
+    }
+    
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,20 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply middleware to limit path parameters and prevent ReDoS
+router.use(limitPathParams());
+
+router.get('/:projectId', (req: Request, res: Response) => {
+  res.status(200).json({ projectId: req.params.projectId });
+});
+
+router.get('/:projectId/users/:userId', (req: Request, res: Response) => {
+  res.status(200).json({ 
+    projectId: req.params.projectId, 
+    userId: req.params.userId 
+  });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply middleware to limit path parameters and prevent ReDoS
+router.use(limitPathParams());
+
+router.get('/:id', (req: Request, res: Response) => {
+  res.status(200).json({ id: req.params.id, name: 'User' });
+});
+
+router.put('/:id', (req: Request, res: Response) => {
+  res.status(200).json({ id: req.params.id, updated: true });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,57 @@
+import express from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - ReDoS in path parameters', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = express();
+    
+    // Test routes with the middleware applied
+    app.get('/test/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req, res) => {
+      res.status(200).json({ success: true });
+    });
+    
+    app.get('/valid/:a/:b', limitPathParams(5, 200), (req, res) => {
+      res.status(200).json({ success: true });
+    });
+
+    app.get('/long/:a', limitPathParams(5, 200), (req, res) => {
+      res.status(200).json({ success: true });
+    });
+
+    app.get('/integration/:a/:b/:c/:d/:e/:f?', limitPathParams(5, 200), (req, res) => {
+      res.status(200).json({ success: true });
+    });
+  });
+
+  it('should accept a valid request with <=5 parameters', async () => {
+    const res = await request(app).get('/valid/1/2');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('should reject a request with >5 parameters', async () => {
+    const res = await request(app).get('/test/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('should reject a request when a parameter exceeds maxLength (200)', async () => {
+    const longParam = 'a'.repeat(201);
+    const res = await request(app).get(`/long/${longParam}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('integration test: should respond quickly (<200ms) with 400 for ReDoS payload', async () => {
+    const start = Date.now();
+    const res = await request(app).get('/integration/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+    
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(200);
+  });
+});


### PR DESCRIPTION
This PR implements server-side validation middleware in the gateway to mitigate a Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` versions < 0.1.13.

### Changes
* **Middleware**: Added `limitPathParams` in `services/gateway/src/routes/middleware/paramLimit.ts` to limit the number (default 5) and length (default 200 chars) of path parameters. If limits are exceeded, a `400 Bad Request` is returned.
* **Routes**: Applied `router.use(limitPathParams())` to `userRoutes.ts` and `projectRoutes.ts`.
* **Tests**: Added unit and integration tests in `services/gateway/test/cve-mitigation.test.ts` to assert that excessive parameters trigger a 400 response in under 200ms, while valid requests pass through.

> **Note to operators:** This PR applies the middleware to two representative route files (`userRoutes.ts` and `projectRoutes.ts`) as outlined in the plan. Please ensure that this middleware is extended to all other relevant route files in `services/gateway/src/routes/` that contain path parameters. The ultimate fix of bumping the `express` / `path-to-regexp` dependencies in `package.json` must be done in a separate PR.