### PR TITLE
DEV-AUTOPILOT: Mitigate ReDoS in path-to-regexp with param limit middleware

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,24 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    if (req.params) {
+      const keys = Object.keys(req.params);
+      
+      if (keys.length > maxParams) {
+        res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+      
+      for (const key of keys) {
+        const val = req.params[key];
+        if (val && val.length > maxLength) {
+          res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+          return;
+        }
+      }
+    }
+    
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,13 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply mitigation middleware
+router.use(limitPathParams());
+
+router.get('/:projectId', (req: Request, res: Response) => {
+  res.status(200).json({ project: req.params.projectId });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply mitigation middleware
+router.use(limitPathParams());
+
+router.get('/:id', (req: Request, res: Response) => {
+  res.status(200).json({ user: req.params.id });
+});
+
+router.get('/:id/settings/:settingId', (req: Request, res: Response) => {
+  res.status(200).json({ user: req.params.id, setting: req.params.settingId });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,62 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE-202X ReDoS Mitigation - Path Parameter Limits', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    const router = express.Router();
+    
+    // Apply mitigation middleware
+    router.use(limitPathParams(5, 200));
+
+    router.get('/test/:a/:b/:c/:d/:e/:f', (req: Request, res: Response) => {
+      res.status(200).json({ message: 'Success' });
+    });
+
+    router.get('/single/:id', (req: Request, res: Response) => {
+      res.status(200).json({ message: 'Success' });
+    });
+
+    app.use('/', router);
+  });
+
+  it('should reject requests with more than 5 path parameters', async () => {
+    const startTime = Date.now();
+    const response = await request(app).get('/test/1/2/3/4/5/6');
+    const duration = Date.now() - startTime;
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ error: 'Too many path parameters or parameter too long' });
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('should reject requests with a path parameter exceeding 200 characters', async () => {
+    const longParam = 'a'.repeat(201);
+    const startTime = Date.now();
+    const response = await request(app).get(`/single/${longParam}`);
+    const duration = Date.now() - startTime;
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ error: 'Too many path parameters or parameter too long' });
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('should allow valid requests (<= 5 params, <= 200 chars)', async () => {
+    const response = await request(app).get('/single/12345');
+    
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ message: 'Success' });
+  });
+
+  it('should return quickly (< 500ms) for pathological ReDoS-like structures', async () => {
+    const startTime = Date.now();
+    const response = await request(app).get('/test/a/b/c/d/e/f?pathological=true');
+    const duration = Date.now() - startTime;
+
+    expect(response.status).toBe(400);
+    expect(duration).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
This PR addresses a Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (versions < 0.1.13) used transitively by `express` in `services/gateway`. 

Since dependency updates to `package.json` are outside the scope of this update, we are mitigating the vulnerability by enforcing server-side limits on path parameters via middleware. 

### Changes
* `services/gateway/src/routes/middleware/paramLimit.ts`: Creates `limitPathParams` middleware to reject requests with >5 path parameters or parameters longer than 200 characters.
* `services/gateway/src/routes/v1/userRoutes.ts`: Applies the mitigation middleware to user routes.
* `services/gateway/src/routes/v1/projectRoutes.ts`: Applies the mitigation middleware to project routes.
* `services/gateway/test/cve-mitigation.test.ts`: Adds unit and integration tests to verify the limits and ensure response times remain performant (<500ms) for potential pathological inputs.

**Note to operator:** Ensure the new `limitPathParams` middleware is applied to any other existing or newly created route files that utilize path parameters within `services/gateway/src/routes/`. A full dependency bump for `path-to-regexp` or `express` across all `package.json` files should be prioritized separately for long-term resolution.