### PR TITLE
DEV-AUTOPILOT: Secure telemetry routes with authentication middleware

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,43 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+// Middleware to enforce authentication
+export const requireAuthenticatedUser = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    let token: string | undefined;
+
+    const authHeader = req.headers.authorization;
+    const cookies = (req as any).cookies;
+    
+    if (authHeader && authHeader.startsWith("Bearer ")) {
+      token = authHeader.substring(7);
+    } else if (cookies && cookies["sb-access-token"]) {
+      token = cookies["sb-access-token"];
+    }
+
+    if (!token) {
+      res.status(401).json({ error: "Unauthorized", detail: "Missing authorization token" });
+      return;
+    }
+
+    const { data, error } = await supabase.auth.getUser(token);
+
+    if (error || !data?.user) {
+      res.status(401).json({ error: "Unauthorized", detail: "Invalid session token" });
+      return;
+    }
+
+    next();
+  } catch (err: any) {
+    res.status(500).json({ error: "Internal server error", detail: "Authentication check failed" });
+    return;
+  }
+};
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +60,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +180,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,145 @@
+import request from "supertest";
+import express from "express";
+import { router } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+jest.mock("../../src/routes/devhub", () => ({
+  broadcastEvent: jest.fn(),
+}));
+
+describe("Telemetry Routes Auth Enforcement", () => {
+  let app: express.Application;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    // Middleware to mock cookie parsing capabilities if accessed by the middleware
+    app.use((req, res, next) => {
+      (req as any).cookies = {};
+      next();
+    });
+    app.use("/api/v1/telemetry", router);
+
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+      text: async () => "OK",
+    });
+    process.env.SUPABASE_SERVICE_ROLE = "test-service-key";
+    process.env.SUPABASE_URL = "http://localhost:8000";
+  });
+
+  describe("POST /api/v1/telemetry/event", () => {
+    const validPayload = {
+      vtid: "VTID-123",
+      layer: "app",
+      module: "test",
+      source: "jest",
+      kind: "test.event",
+      status: "success",
+      title: "Test Event",
+    };
+
+    it("returns 401 when missing Authorization header", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validPayload);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+      expect(supabase.auth.getUser).not.toHaveBeenCalled();
+    });
+
+    it("returns 401 when token is invalid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: null },
+        error: new Error("Invalid token"),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validPayload);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("invalid-token");
+    });
+
+    it("proceeds when token is valid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send(validPayload);
+
+      expect(res.status).toBe(202);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("valid-token");
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    const validBatchPayload = [
+      {
+        vtid: "VTID-123",
+        layer: "app",
+        module: "test",
+        source: "jest",
+        kind: "test.event",
+        status: "success",
+        title: "Test Event 1",
+      },
+    ];
+
+    it("returns 401 when missing Authorization header", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send(validBatchPayload);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+    });
+
+    it("returns 202 when token is valid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-token")
+        .send(validBatchPayload);
+
+      expect(res.status).toBe(202);
+    });
+  });
+
+  describe("GET /api/v1/telemetry/health", () => {
+    it("returns 200 without authentication", async () => {
+      const res = await request(app).get("/api/v1/telemetry/health");
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
**Context & Issue:**
The vulnerability scanner `rls-policy-scanner-v1` flagged `oasis_events` as a medium-risk `rls_gap` because the table lacks Row-Level Security (RLS) enforcement. While the ultimate fix involves applying RLS policies on the database level, automated execution is restricted from modifying `supabase/migrations/`. 

**What this PR does:**
To address the exposure at the application tier, this PR adds a strict authentication middleware (`requireAuthenticatedUser`) to the gateway telemetry endpoint. Before persisting to the database, the API will now require a valid Supabase session token (via `Authorization: Bearer <token>` or Supabase auth cookies). 
- Modifies `POST /api/v1/telemetry/event` to require authentication.
- Modifies `POST /api/v1/telemetry/batch` to require authentication.
- Adds comprehensive unit tests to enforce the middleware correctly catches missing/invalid session tokens (yielding HTTP 401) and permits valid requests.

**Follow-up action for Operator:**
The Database migration must be handled manually. Please add a new file to `supabase/migrations/` enabling RLS on `oasis_events` with the appropriate `allow_authenticated_insert` policy.