### PR TITLE
DEV-AUTOPILOT: Secure telemetry events with application-level auth

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,7 +1,8 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
 
@@ -24,9 +25,43 @@ const TelemetryEventSchema = z.object({
 
 type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
+// Authentication Middleware to secure OASIS event writes
+const requireAuthenticatedUser = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      res.status(401).json({
+        error: "Unauthorized",
+        detail: "Missing or invalid Authorization header",
+      });
+      return;
+    }
+
+    const token = authHeader.split(" ")[1];
+    const { data, error } = await supabase.auth.getUser(token);
+
+    if (error || !data?.user) {
+      res.status(401).json({
+        error: "Unauthorized",
+        detail: "Invalid session token",
+      });
+      return;
+    }
+
+    next();
+  } catch (e: any) {
+    console.error("Auth middleware error:", e);
+    res.status(500).json({
+      error: "Internal server error",
+      detail: "Auth verification failed",
+    });
+    return;
+  }
+};
+
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +181,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,128 @@
+import request from "supertest";
+import express from "express";
+import { router } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+// Mock Supabase client
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+// Setup Express app for testing
+const app = express();
+app.use(express.json());
+app.use("/api/v1/telemetry", router);
+
+describe("Telemetry Routes Authentication", () => {
+  const originalFetch = global.fetch;
+
+  const validPayload = {
+    vtid: "VTID-TEST",
+    layer: "test-layer",
+    module: "test-module",
+    source: "test-source",
+    kind: "test.event",
+    status: "success",
+    title: "Test Event Title",
+  };
+
+  beforeAll(() => {
+    process.env.SUPABASE_URL = "http://localhost:54321";
+    process.env.SUPABASE_SERVICE_ROLE = "test-service-key";
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("POST /api/v1/telemetry/event", () => {
+    it("should return 401 when Authorization header is missing", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validPayload);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+      expect(supabase.auth.getUser).not.toHaveBeenCalled();
+    });
+
+    it("should return 401 when invalid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: { message: "Invalid token" },
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validPayload);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("invalid-token");
+    });
+
+    it("should proceed (202 Accepted) when valid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      // Mock fetch to simulate successful OASIS persistence
+      global.fetch = jest.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: "mock-id" }),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send(validPayload);
+
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("valid-token");
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    it("should return 401 when Authorization header is missing", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send([validPayload]);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+    });
+
+    it("should proceed (202 Accepted) when valid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      // Mock fetch to simulate successful batch OASIS persistence
+      global.fetch = jest.fn().mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-token")
+        .send([validPayload]);
+
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("valid-token");
+    });
+  });
+});


### PR DESCRIPTION
Addresses the `rls_gap` vulnerability in the `oasis_events` table (flagged by `rls-policy-scanner-v1`).
Since database migrations are out-of-scope for the automated executor, this PR temporarily mitigates the vulnerability by applying an application-level authentication check to the telemetry endpoints that write to the database (`POST /event` and `POST /batch`).

Changes:
- Adds `requireAuthenticatedUser` Express middleware to validate Supabase JWT tokens via `supabase.auth.getUser()`.
- Rejects unauthenticated requests with HTTP 401.
- Adds comprehensive unit tests validating the auth enforcement and correct passthrough of valid sessions.

**Developer Note**: The database-level RLS migration (`ALTER TABLE oasis_events ENABLE ROW LEVEL SECURITY`, etc.) must be applied manually to fully resolve the issue.