### PR TITLE
DEV-AUTOPILOT: Refactor admin-notifications router to use shared auth middleware

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -12,49 +12,17 @@
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/auth';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIFICATIONS';
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
+router.use(requireAdmin);
 
 // ── POST /compose — Send notification to user(s) ────────────
 
 router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -139,6 +107,8 @@ router.post('/compose', async (req: Request, res: Response) => {
     // Determine effective tenant_id for dispatching
     const effectiveTenantId = tenant_id || (recipient_ids?.length === 1 ? undefined : undefined);
 
+    const adminEmail = (req as any).user?.email || 'unknown';
+
     // For single recipients, use synchronous dispatch for immediate feedback
     if (targetUserIds.length === 1) {
       const result = await notifyUser(
@@ -148,7 +118,7 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      console.log(`[${VTID}] Composed notification for 1 user by ${adminEmail}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +131,7 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${adminEmail}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -177,9 +147,6 @@ router.post('/compose', async (req: Request, res: Response) => {
 // ── GET /sent — Admin notification log ──────────────────────
 
 router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -224,9 +191,6 @@ router.get('/sent', async (req: Request, res: Response) => {
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
 router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,123 @@
+import express from 'express';
+import request from 'supertest';
+import adminNotificationsRouter from '../../src/routes/admin-notifications';
+import { getSupabase } from '../../src/lib/supabase';
+import { notifyUser } from '../../src/services/notification-service';
+
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn(),
+}));
+
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn(),
+  notifyUsersAsync: jest.fn(),
+}));
+
+jest.mock('../../src/middleware/auth', () => ({
+  requireAdmin: jest.fn((req, res, next) => {
+    req.user = { id: 'admin-123', email: 'admin@test.com' };
+    next();
+  }),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/admin/notifications', adminNotificationsRouter);
+
+describe('Admin Notifications Router', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('POST /compose', () => {
+    it('returns 400 if title or body is missing', async () => {
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ recipient_ids: ['user-1'] });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('INVALID_INPUT');
+    });
+
+    it('returns 400 if no recipient criteria provided', async () => {
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ title: 'Test', body: 'Test body' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('INVALID_INPUT');
+    });
+
+    it('sends to single recipient synchronously', async () => {
+      (getSupabase as jest.Mock).mockReturnValue({});
+      (notifyUser as jest.Mock).mockResolvedValue({ success: true });
+
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ title: 'Test', body: 'Body', recipient_ids: ['user-1'] });
+
+      expect(res.status).toBe(200);
+      expect(res.body.sent_to).toBe(1);
+      expect(notifyUser).toHaveBeenCalledWith('user-1', '', 'welcome_to_vitana', {
+        title: 'Test',
+        body: 'Body',
+        data: undefined
+      }, expect.anything());
+    });
+  });
+
+  describe('GET /sent', () => {
+    it('returns 500 if supabase is unavailable', async () => {
+      (getSupabase as jest.Mock).mockReturnValue(null);
+      const res = await request(app).get('/admin/notifications/sent');
+      expect(res.status).toBe(500);
+    });
+
+    it('returns paginated results', async () => {
+      const mockQuery = {
+        select: jest.fn().mockReturnThis(),
+        gte: jest.fn().mockReturnThis(),
+        order: jest.fn().mockReturnThis(),
+        range: jest.fn().mockResolvedValue({ data: [{ id: 1 }], count: 1 })
+      };
+      (getSupabase as jest.Mock).mockReturnValue({ from: jest.fn().mockReturnValue(mockQuery) });
+
+      const res = await request(app).get('/admin/notifications/sent');
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.total).toBe(1);
+    });
+  });
+
+  describe('GET /preferences/stats', () => {
+    it('returns stats', async () => {
+      const mockPrefsQuery = {
+        select: jest.fn().mockResolvedValue({ data: [{ push_enabled: true }, { push_enabled: false }] })
+      };
+
+      const mockNotificationsQuery = {
+        select: jest.fn().mockReturnThis(),
+        gte: jest.fn().mockImplementation(() => {
+          const promise = Promise.resolve({ count: 10 }) as any;
+          promise.not = jest.fn().mockResolvedValue({ count: 5 });
+          return promise;
+        })
+      };
+
+      const mockFrom = jest.fn((table) => {
+        if (table === 'user_notification_preferences') return mockPrefsQuery;
+        if (table === 'user_notifications') return mockNotificationsQuery;
+        return { select: jest.fn() };
+      });
+
+      (getSupabase as jest.Mock).mockReturnValue({ from: mockFrom });
+
+      const res = await request(app).get('/admin/notifications/preferences/stats');
+      expect(res.status).toBe(200);
+      expect(res.body.stats.total_users_with_prefs).toBe(2);
+      expect(res.body.stats.push_enabled).toBe(1);
+      expect(res.body.delivery.total_sent_30d).toBe(10);
+      expect(res.body.delivery.total_read_30d).toBe(5);
+    });
+  });
+});


### PR DESCRIPTION
**What this PR does:**
- Replaces custom, inline auth checks (`getBearerToken`, `verifyExafyAdmin`) in `admin-notifications.ts` with the shared `requireAdmin` middleware.
- Updates route handlers to rely on `req.user` rather than returning an auth context manually.
- Adds test coverage for the `admin-notifications.ts` route, mocking the shared `requireAdmin` middleware.

**Why:**
To unify authentication logic across the project, reduce maintenance burden, and fix the `missing_auth` finding reported by `route-auth-scanner-v1`.

**Files touched:**
- `services/gateway/src/routes/admin-notifications.ts` (modified)
- `services/gateway/test/routes/admin-notifications.test.ts` (created)