### PR TITLE
DEV-AUTOPILOT: Add auth enforcement to telemetry API endpoints

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,7 +1,8 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
 
@@ -24,9 +25,29 @@ const TelemetryEventSchema = z.object({
 
 type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
+// Auth middleware for telemetry routes modifying database
+const requireAuth = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      return res.status(401).json({ error: "Unauthorized", detail: "Missing or invalid Authorization header" });
+    }
+    const token = authHeader.split(" ")[1];
+    const { data, error } = await supabase.auth.getUser(token);
+    
+    if (error || !data?.user) {
+      return res.status(401).json({ error: "Unauthorized", detail: "Invalid token" });
+    }
+    
+    next();
+  } catch (err: any) {
+    return res.status(500).json({ error: "Internal server error", detail: "Auth check failed" });
+  }
+};
+
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +167,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,136 @@
+import express from 'express';
+import request from 'supertest';
+import { router } from '../../src/routes/telemetry';
+import { supabase } from '../../src/lib/supabase';
+
+jest.mock('../../src/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn()
+    }
+  }
+}));
+
+jest.mock('../../src/routes/devhub', () => ({
+  broadcastEvent: jest.fn()
+}));
+
+global.fetch = jest.fn() as jest.Mock;
+
+const app = express();
+app.use(express.json());
+app.use('/api/v1/telemetry', router);
+
+describe('Telemetry Routes Auth', () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  describe('POST /api/v1/telemetry/event', () => {
+    const validPayload = {
+      vtid: "VTID-123",
+      layer: "app",
+      module: "test",
+      source: "test-src",
+      kind: "test.event",
+      status: "success",
+      title: "Test Event"
+    };
+
+    it('returns 401 when missing auth token', async () => {
+      const response = await request(app)
+        .post('/api/v1/telemetry/event')
+        .send(validPayload);
+      
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe('Unauthorized');
+    });
+
+    it('returns 401 when token is invalid', async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: null },
+        error: { message: 'Invalid token' }
+      });
+
+      const response = await request(app)
+        .post('/api/v1/telemetry/event')
+        .set('Authorization', 'Bearer invalid-token')
+        .send(validPayload);
+      
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe('Unauthorized');
+    });
+
+    it('proceeds to 202 when token is valid', async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: 'user-123' } },
+        error: null
+      });
+
+      process.env.SUPABASE_URL = 'http://localhost';
+      process.env.SUPABASE_SERVICE_ROLE = 'test-key';
+      
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({})
+      });
+
+      const response = await request(app)
+        .post('/api/v1/telemetry/event')
+        .set('Authorization', 'Bearer valid-token')
+        .send(validPayload);
+      
+      expect(response.status).toBe(202);
+    });
+  });
+
+  describe('POST /api/v1/telemetry/batch', () => {
+    const validPayload = [{
+      vtid: "VTID-123",
+      layer: "app",
+      module: "test",
+      source: "test-src",
+      kind: "test.event",
+      status: "success",
+      title: "Test Event"
+    }];
+
+    it('returns 401 when missing auth token', async () => {
+      const response = await request(app)
+        .post('/api/v1/telemetry/batch')
+        .send(validPayload);
+      
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe('Unauthorized');
+    });
+    
+    it('proceeds to 202 when token is valid', async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: 'user-123' } },
+        error: null
+      });
+
+      process.env.SUPABASE_URL = 'http://localhost';
+      process.env.SUPABASE_SERVICE_ROLE = 'test-key';
+      
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: jest.fn().mockResolvedValue({})
+      });
+
+      const response = await request(app)
+        .post('/api/v1/telemetry/batch')
+        .set('Authorization', 'Bearer valid-token')
+        .send(validPayload);
+      
+      expect(response.status).toBe(202);
+    });
+  });
+});


### PR DESCRIPTION
**Context**
The scanner `rls-policy-scanner-v1` identified a medium-risk RLS gap on the `oasis_events` table (created in migration `20251209000000_add_task_stage.sql` without RLS or policies). Since we cannot generate new migration files within this automated execution plan, we are adding application-layer authentication middleware to secure the Gateway endpoints that perform inserts into this table.

**Changes**
1. Added `requireAuth` middleware using `supabase.auth.getUser` to verify Supabase session tokens from the `Authorization` header.
2. Applied `requireAuth` to the `POST /event` and `POST /batch` endpoints in `services/gateway/src/routes/telemetry.ts`. Requests without a valid user token will now be rejected with a `401 Unauthorized`.
3. Created a new unit test suite in `services/gateway/test/routes/telemetry.test.ts` that mocks Supabase and ensures unauthorized requests are properly blocked.

*Note for Operators: The actual database-layer RLS policy migration must be manually created by a developer to fully resolve the issue.*