### PR TITLE
DEV-AUTOPILOT: Add system controls API endpoint for gateway

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,21 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { getSystemControl } from '../services/system-controls';
+
+const router = Router();
+
+router.get('/:key', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { key } = req.params;
+    const control = await getSystemControl(key);
+
+    if (!control) {
+      return res.status(404).json({ error: 'System control not found' });
+    }
+
+    return res.status(200).json(control);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,27 @@
+import { supabase } from '../lib/supabase';
+import { SystemControl } from '../types/system-controls';
+
+export async function getSystemControl(key: string): Promise<SystemControl | null> {
+  try {
+    const { data, error } = await supabase
+      .from('system_controls')
+      .select('*')
+      .eq('key', key)
+      .single();
+
+    if (error) {
+      // PGRST116 is the PostgREST error code for "JSON object requested, multiple (or no) rows returned"
+      // It occurs when .single() finds no rows. We return null in this case.
+      if (error.code === 'PGRST116') {
+        return null;
+      }
+      console.error(`Error fetching system control for key "${key}":`, error);
+      return null;
+    }
+
+    return data as SystemControl;
+  } catch (err) {
+    console.error(`Unexpected error fetching system control for key "${key}":`, err);
+    return null;
+  }
+}

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at?: string;
+  updated_by?: string;
+  reason?: string;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,50 @@
+import request from 'supertest';
+import express from 'express';
+import systemControlsRouter from '../../src/routes/system-controls';
+import * as systemControlsService from '../../src/services/system-controls';
+
+jest.mock('../../src/services/system-controls');
+
+const app = express();
+app.use(express.json());
+app.use('/api/system-controls', systemControlsRouter);
+
+// Mock error handler
+app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
+  res.status(500).json({ error: 'Internal Server Error' });
+});
+
+describe('System Controls Route', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('GET /api/system-controls/:key returns 200 and the control if it exists', async () => {
+    const mockControl = { key: 'vitana_did_you_know_enabled', enabled: true };
+    jest.spyOn(systemControlsService, 'getSystemControl').mockResolvedValue(mockControl);
+
+    const response = await request(app).get('/api/system-controls/vitana_did_you_know_enabled');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockControl);
+    expect(systemControlsService.getSystemControl).toHaveBeenCalledWith('vitana_did_you_know_enabled');
+  });
+
+  it('GET /api/system-controls/:key returns 404 when not found', async () => {
+    jest.spyOn(systemControlsService, 'getSystemControl').mockResolvedValue(null);
+
+    const response = await request(app).get('/api/system-controls/unknown_key');
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'System control not found' });
+  });
+
+  it('GET /api/system-controls/:key returns 500 on unexpected route error', async () => {
+    jest.spyOn(systemControlsService, 'getSystemControl').mockRejectedValue(new Error('Internal failure'));
+
+    const response = await request(app).get('/api/system-controls/vitana_did_you_know_enabled');
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: 'Internal Server Error' });
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,63 @@
+import { getSystemControl } from '../src/services/system-controls';
+import { supabase } from '../src/lib/supabase';
+
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+describe('System Controls Service', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns a system control when found', async () => {
+    const mockData = { key: 'vitana_did_you_know_enabled', enabled: true };
+    const mockEq = jest.fn().mockReturnValue({
+      single: jest.fn().mockResolvedValue({ data: mockData, error: null })
+    });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    (supabase.from as jest.Mock).mockReturnValue({ select: mockSelect });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+    
+    expect(result).toEqual(mockData);
+    expect(supabase.from).toHaveBeenCalledWith('system_controls');
+    expect(mockSelect).toHaveBeenCalledWith('*');
+    expect(mockEq).toHaveBeenCalledWith('key', 'vitana_did_you_know_enabled');
+  });
+
+  it('returns null when control is not found (PGRST116)', async () => {
+    const mockEq = jest.fn().mockReturnValue({
+      single: jest.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116', message: 'Not found' } })
+    });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    (supabase.from as jest.Mock).mockReturnValue({ select: mockSelect });
+
+    const result = await getSystemControl('unknown_key');
+    expect(result).toBeNull();
+  });
+
+  it('returns null on database error', async () => {
+    const mockEq = jest.fn().mockReturnValue({
+      single: jest.fn().mockResolvedValue({ data: null, error: { code: '500', message: 'Internal error' } })
+    });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    (supabase.from as jest.Mock).mockReturnValue({ select: mockSelect });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+    expect(result).toBeNull();
+  });
+
+  it('returns null on unexpected exception', async () => {
+    const mockEq = jest.fn().mockReturnValue({
+      single: jest.fn().mockRejectedValue(new Error('Network failure'))
+    });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    (supabase.from as jest.Mock).mockReturnValue({ select: mockSelect });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
This PR introduces a generic backend API endpoint to retrieve system controls from the `public.system_controls` table. This addresses the missing API layer required to expose the `vitana_did_you_know_enabled` flag (enabled in migration `20260425100000_BOOTSTRAP_dyk_flag_on.sql`) to the frontend command-hub.

**Included in this PR:**
- `SystemControl` type definitions
- Service layer (`getSystemControl`) linking the Supabase client to the system controls query
- Express route (`GET /api/system-controls/:key`)
- Unit and integration tests for the service and route

**Note for Operator / Follow-up:**
The plan implies modifying the command-hub frontend (e.g. `services/gateway/src/frontend/command-hub/...`) to query this new endpoint and render the "Did You Know" tour. Since the exact path was not specified in the locked file list, you will need to add the frontend integration in a follow-up commit. The recommended approach is to fetch `GET /api/system-controls/vitana_did_you_know_enabled` on component mount and toggle the tour based on the `enabled` field in the response. You will also need to mount the new Express router to the main application inside `services/gateway/src/app.ts` (e.g., `app.use('/api/system-controls', systemControlsRouter)`).