### PR TITLE
DEV-AUTOPILOT: Expose system controls via gateway API

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,21 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { getSystemControl } from '../services/system-controls';
+
+export const systemControlsRouter = Router();
+
+systemControlsRouter.get('/:key', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { key } = req.params;
+    const control = await getSystemControl(key);
+
+    if (!control) {
+      return res.status(404).json({ error: 'System control not found' });
+    }
+
+    return res.status(200).json(control);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default systemControlsRouter;

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,20 @@
+import { supabase } from '../lib/supabase';
+import { SystemControl } from '../types/system-controls';
+
+export async function getSystemControl(key: string): Promise<SystemControl | null> {
+  const { data, error } = await supabase
+    .from('system_controls')
+    .select('*')
+    .eq('key', key)
+    .single();
+
+  if (error) {
+    // PGRST116 is the PostgREST error code for zero rows returned on a .single() query
+    if (error.code === 'PGRST116') {
+      return null;
+    }
+    throw new Error(`Failed to fetch system control: ${error.message}`);
+  }
+
+  return data as SystemControl;
+}

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at?: string;
+  updated_by?: string;
+  reason?: string;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,52 @@
+import request from 'supertest';
+import express, { Request, Response, NextFunction } from 'express';
+import { systemControlsRouter } from '../../src/routes/system-controls';
+import { getSystemControl } from '../../src/services/system-controls';
+
+// Mock the service
+jest.mock('../../src/services/system-controls');
+
+const app = express();
+app.use(express.json());
+app.use('/api/system-controls', systemControlsRouter);
+
+// Simple error handler for next(error)
+app.use((err: any, req: Request, res: Response, next: NextFunction) => {
+  res.status(500).json({ error: 'Internal server error' });
+});
+
+describe('System Controls Routes', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('GET /api/system-controls/:key should return 200 and the control if found', async () => {
+    const mockControl = { key: 'vitana_did_you_know_enabled', enabled: true };
+    (getSystemControl as jest.Mock).mockResolvedValue(mockControl);
+
+    const response = await request(app).get('/api/system-controls/vitana_did_you_know_enabled');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockControl);
+    expect(getSystemControl).toHaveBeenCalledWith('vitana_did_you_know_enabled');
+  });
+
+  it('GET /api/system-controls/:key should return 404 if not found', async () => {
+    (getSystemControl as jest.Mock).mockResolvedValue(null);
+
+    const response = await request(app).get('/api/system-controls/missing_key');
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'System control not found' });
+    expect(getSystemControl).toHaveBeenCalledWith('missing_key');
+  });
+
+  it('GET /api/system-controls/:key should return 500 on service error', async () => {
+    (getSystemControl as jest.Mock).mockRejectedValue(new Error('Service failed'));
+
+    const response = await request(app).get('/api/system-controls/error_key');
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: 'Internal server error' });
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,57 @@
+import { getSystemControl } from '../src/services/system-controls';
+import { supabase } from '../src/lib/supabase';
+
+// Mock Supabase client
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+describe('System Controls Service', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return a system control when found', async () => {
+    const mockData = { key: 'vitana_did_you_know_enabled', enabled: true };
+    const mockSingle = jest.fn().mockResolvedValue({ data: mockData, error: null });
+    const mockEq = jest.fn().mockReturnValue({ single: mockSingle });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    (supabase.from as jest.Mock).mockReturnValue({ select: mockSelect });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+
+    expect(supabase.from).toHaveBeenCalledWith('system_controls');
+    expect(mockSelect).toHaveBeenCalledWith('*');
+    expect(mockEq).toHaveBeenCalledWith('key', 'vitana_did_you_know_enabled');
+    expect(result).toEqual(mockData);
+  });
+
+  it('should return null when system control is not found', async () => {
+    // Supabase returns PGRST116 for zero rows on single()
+    const mockSingle = jest.fn().mockResolvedValue({ 
+      data: null, 
+      error: { code: 'PGRST116', message: 'Not found' } 
+    });
+    const mockEq = jest.fn().mockReturnValue({ single: mockSingle });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    (supabase.from as jest.Mock).mockReturnValue({ select: mockSelect });
+
+    const result = await getSystemControl('missing_key');
+
+    expect(result).toBeNull();
+  });
+
+  it('should throw an error on database failure', async () => {
+    const mockSingle = jest.fn().mockResolvedValue({ 
+      data: null, 
+      error: { code: '500', message: 'DB Error' } 
+    });
+    const mockEq = jest.fn().mockReturnValue({ single: mockSingle });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    (supabase.from as jest.Mock).mockReturnValue({ select: mockSelect });
+
+    await expect(getSystemControl('some_key')).rejects.toThrow('Failed to fetch system control: DB Error');
+  });
+});


### PR DESCRIPTION
This PR introduces a new endpoint `GET /api/system-controls/:key` in the gateway API to retrieve system controls from the database. This allows consumers like the frontend (`command-hub`) to query feature flags, specifically the `vitana_did_you_know_enabled` flag introduced in a recent migration.

Files touched:
- `services/gateway/src/types/system-controls.ts`
- `services/gateway/src/services/system-controls.ts`
- `services/gateway/src/routes/system-controls.ts`
- `services/gateway/test/system-controls.test.ts`
- `services/gateway/test/routes/system-controls.test.ts`

**Note for Operator**: The plan included updating the `command-hub` frontend to call this endpoint and conditionally render the "Did You Know?" tour. Because the exact file path inside `services/gateway/src/frontend/command-hub/...` was unknown and missing from the locked file list, no frontend code was modified in this PR. Please locate the relevant tour component and add the fetch to `/api/system-controls/vitana_did_you_know_enabled` manually to complete the feature integration.