### PR TITLE
DEV-AUTOPILOT: Add parameter limit middleware to mitigate path-to-regexp ReDoS

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,36 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // 1. Validate based on already-parsed req.params
+    if (req.params) {
+      const keys = Object.keys(req.params);
+      if (keys.length > maxParams) {
+        res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+
+      for (const key of keys) {
+        const val = req.params[key];
+        if (typeof val === 'string' && val.length > maxLength) {
+          res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+          return;
+        }
+      }
+    }
+
+    // 2. Pre-validate req.path to prevent ReDoS in downstream route matching.
+    // This avoids vulnerable path-to-regexp matching on excessively long segments.
+    if (req.path) {
+      const segments = req.path.split('/');
+      for (const segment of segments) {
+        if (segment.length > maxLength) {
+          res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+          return;
+        }
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply paramLimit middleware to protect all project routes against ReDoS
+router.use(limitPathParams());
+
+router.get('/:projectId', (req: Request, res: Response) => {
+  res.status(200).json({ projectId: req.params.projectId });
+});
+
+router.put('/:projectId/settings/:key', (req: Request, res: Response) => {
+  res.status(200).json({ projectId: req.params.projectId, key: req.params.key });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply paramLimit middleware to protect all user routes against ReDoS
+router.use(limitPathParams());
+
+router.get('/:id', (req: Request, res: Response) => {
+  res.status(200).json({ userId: req.params.id });
+});
+
+router.post('/:id/actions/:action', (req: Request, res: Response) => {
+  res.status(200).json({ userId: req.params.id, action: req.params.action });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,62 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - ReDoS in path-to-regexp', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = express();
+    
+    // Mount the middleware globally to simulate it acting before route-level matching
+    app.use(limitPathParams(5, 200));
+
+    app.get('/valid/:a/:b', (req: Request, res: Response) => {
+      res.status(200).json({ ok: true, params: req.params });
+    });
+
+    // A route with 6 parameters (exceeds default maxParams = 5)
+    // Mounted with the middleware to test the req.params parsing logic post-match
+    app.get('/many/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.status(200).json({ ok: true, params: req.params });
+    });
+
+    app.get('/long/:a', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.status(200).json({ ok: true });
+    });
+  });
+
+  it('should pass a valid request with <= 5 parameters', async () => {
+    const response = await request(app).get('/valid/val1/val2');
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true, params: { a: 'val1', b: 'val2' } });
+  });
+
+  it('should reject a request with > 5 parameters', async () => {
+    const response = await request(app).get('/many/1/2/3/4/5/6');
+    expect(response.status).toBe(400);
+    expect(response.body).toHaveProperty('error');
+    expect(response.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('should reject a request with a parameter exceeding max length', async () => {
+    const longParam = 'a'.repeat(201);
+    const response = await request(app).get(`/long/${longParam}`);
+    expect(response.status).toBe(400);
+    expect(response.body).toHaveProperty('error');
+    expect(response.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('integration: should respond quickly rejecting pathological paths to prevent ReDoS', async () => {
+    const start = Date.now();
+    const longParam = 'a'.repeat(500);
+    
+    // Request crafted to potentially trigger ReDoS with a pathological parameter value
+    const response = await request(app).get(`/many/a/b/c/d/e/${longParam}`);
+    const end = Date.now();
+    
+    expect(response.status).toBe(400);
+    // Assert response time is highly performant (< 200ms)
+    expect(end - start).toBeLessThan(200);
+  });
+});


### PR DESCRIPTION
**Context**
A Regular Expression Denial of Service (ReDoS) vulnerability exists in `path-to-regexp` < 0.1.13, which can cause CPU exhaustion during route matching. This pull request mitigates the issue at the Gateway layer by introducing a server-side parameter limitation middleware.

**Plan**
1. Created `limitPathParams` middleware to cap the number of path parameters (default 5) and their lengths (default 200).
2. The middleware validates both `req.params` (for already matched parameters) and `req.path` segments (to pre-emptively drop excessively long paths before vulnerable evaluation occurs).
3. Applied the middleware globally to `userRoutes` and `projectRoutes`.
4. Added comprehensive unit and integration testing in `cve-mitigation.test.ts` to guarantee malicious payloads return `400 Bad Request` in <200ms.

**Files modified:**
- `services/gateway/src/routes/middleware/paramLimit.ts`
- `services/gateway/src/routes/v1/userRoutes.ts`
- `services/gateway/src/routes/v1/projectRoutes.ts`
- `services/gateway/test/cve-mitigation.test.ts`