### PR TITLE
DEV-AUTOPILOT: Use shared requireAdmin middleware for admin notifications

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -12,51 +12,21 @@
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/auth';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIFICATIONS';
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
+router.use(requireAdmin);
 
 // ── POST /compose — Send notification to user(s) ────────────
 
 router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
+
+  const userEmail = (req as any).user?.email || 'unknown';
 
   const {
     recipient_ids,   // string[] — specific user IDs
@@ -148,7 +118,7 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      console.log(`[${VTID}] Composed notification for 1 user by ${userEmail}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +131,7 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${userEmail}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -177,9 +147,6 @@ router.post('/compose', async (req: Request, res: Response) => {
 // ── GET /sent — Admin notification log ──────────────────────
 
 router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -224,9 +191,6 @@ router.get('/sent', async (req: Request, res: Response) => {
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
 router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,94 @@
+import request from 'supertest';
+import express from 'express';
+import router from '../../src/routes/admin-notifications';
+import { getSupabase } from '../../src/lib/supabase';
+import { notifyUser, notifyUsersAsync } from '../../src/services/notification-service';
+
+jest.mock('../../src/middleware/auth', () => ({
+  requireAdmin: (req: any, res: any, next: any) => {
+    req.user = { id: 'admin1', email: 'admin@example.com' };
+    next();
+  }
+}));
+
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn()
+}));
+
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn(),
+  notifyUsersAsync: jest.fn()
+}));
+
+describe('Admin Notifications Route', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/', router);
+    jest.clearAllMocks();
+  });
+
+  it('POST /compose handles missing input', async () => {
+    (getSupabase as jest.Mock).mockReturnValue({});
+    const res = await request(app).post('/compose').send({});
+    expect(res.status).toBe(400);
+    expect(res.body.message).toBe('title and body are required');
+  });
+
+  it('POST /compose calls notifyUser for 1 recipient', async () => {
+    (getSupabase as jest.Mock).mockReturnValue({});
+    (notifyUser as jest.Mock).mockResolvedValue('ok');
+    const res = await request(app).post('/compose').send({
+      title: 'T',
+      body: 'B',
+      recipient_ids: ['u1']
+    });
+    expect(res.status).toBe(200);
+    expect(notifyUser).toHaveBeenCalled();
+  });
+
+  it('GET /sent fetches data', async () => {
+    const mockQuery = {
+      select: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      range: jest.fn().mockResolvedValue({ data: [], count: 0, error: null })
+    };
+    (getSupabase as jest.Mock).mockReturnValue({
+      from: jest.fn().mockReturnValue(mockQuery)
+    });
+
+    const res = await request(app).get('/sent');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('GET /preferences/stats fetches stats', async () => {
+    const mockQuery = {
+      select: jest.fn().mockResolvedValue({ data: [], error: null })
+    };
+    
+    const mockUserNotifications = {
+      select: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockImplementation(() => {
+        const p = Promise.resolve({ count: 10 });
+        (p as any).not = jest.fn().mockResolvedValue({ count: 5 });
+        return p;
+      })
+    };
+
+    (getSupabase as jest.Mock).mockReturnValue({
+      from: jest.fn().mockImplementation((t) => {
+        if (t === 'user_notifications') return mockUserNotifications;
+        return mockQuery; 
+      })
+    });
+
+    const res = await request(app).get('/preferences/stats');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.delivery.total_sent_30d).toBe(10);
+  });
+});


### PR DESCRIPTION
**Summary**
This PR updates the `admin-notifications.ts` route to adopt the standard `requireAdmin` authentication middleware, replacing inline auth logic. 

**Changes**
- Removed custom `verifyExafyAdmin` and `getBearerToken` functions from `services/gateway/src/routes/admin-notifications.ts`.
- Imported and applied the common `requireAdmin` middleware across the entire router.
- Removed inline `verifyExafyAdmin` calls within each endpoint handler and transitioned log entries to use `req.user.email` attached by the middleware.
- Added `services/gateway/test/routes/admin-notifications.test.ts` to mock the shared middleware and test endpoints comprehensively.

**Security Impact**
Brings the admin-notifications endpoints into consistency with standard protected routes, resolving missing authentication findings from `route-auth-scanner-v1`.