### PR TITLE
DEV-AUTOPILOT: Add system controls API endpoint for frontend flags

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,21 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { getSystemControl } from '../services/system-controls';
+
+const router = Router();
+
+router.get('/:key', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { key } = req.params;
+    const control = await getSystemControl(key);
+
+    if (!control) {
+      return res.status(404).json({ error: 'System control not found' });
+    }
+
+    return res.json(control);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,27 @@
+import { supabase } from '../lib/supabase';
+import { SystemControl } from '../types/system-controls';
+
+/**
+ * Fetch a single system control configuration by its unique key.
+ * 
+ * @param key The unique identifier for the system control (e.g. 'vitana_did_you_know_enabled')
+ * @returns The SystemControl object if found, or null if it doesn't exist
+ */
+export async function getSystemControl(key: string): Promise<SystemControl | null> {
+  const { data, error } = await supabase
+    .from('system_controls')
+    .select('*')
+    .eq('key', key)
+    .single();
+
+  if (error) {
+    // PGRST116 is the PostgREST error code for a query returning zero rows
+    // when exactly one row was expected via .single()
+    if (error.code === 'PGRST116') {
+      return null;
+    }
+    throw error;
+  }
+
+  return data as SystemControl;
+}

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at?: string;
+  updated_by?: string;
+  reason?: string;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,55 @@
+import request from 'supertest';
+import express, { Request, Response, NextFunction } from 'express';
+import systemControlsRouter from '../../src/routes/system-controls';
+import { getSystemControl } from '../../src/services/system-controls';
+
+jest.mock('../../src/services/system-controls');
+
+describe('System Controls Routes', () => {
+  let app: express.Application;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/api/system-controls', systemControlsRouter);
+
+    // Mock error handling middleware for testing
+    app.use((err: any, req: Request, res: Response, next: NextFunction) => {
+      res.status(500).json({ error: 'Internal server error' });
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return 200 and the control if found', async () => {
+    const mockControl = { key: 'vitana_did_you_know_enabled', enabled: true };
+    (getSystemControl as jest.Mock).mockResolvedValue(mockControl);
+
+    const response = await request(app).get('/api/system-controls/vitana_did_you_know_enabled');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockControl);
+    expect(getSystemControl).toHaveBeenCalledWith('vitana_did_you_know_enabled');
+  });
+
+  it('should return 404 if control not found', async () => {
+    (getSystemControl as jest.Mock).mockResolvedValue(null);
+
+    const response = await request(app).get('/api/system-controls/missing_key');
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'System control not found' });
+    expect(getSystemControl).toHaveBeenCalledWith('missing_key');
+  });
+
+  it('should return 500 and pass errors to next()', async () => {
+    (getSystemControl as jest.Mock).mockRejectedValue(new Error('Service failure'));
+
+    const response = await request(app).get('/api/system-controls/error_key');
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: 'Internal server error' });
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,55 @@
+import { getSystemControl } from '../src/services/system-controls';
+import { supabase } from '../src/lib/supabase';
+
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+describe('System Controls Service', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return a system control by key', async () => {
+    const mockControl = { key: 'vitana_did_you_know_enabled', enabled: true };
+    const singleMock = jest.fn().mockResolvedValue({ data: mockControl, error: null });
+    const eqMock = jest.fn().mockReturnValue({ single: singleMock });
+    const selectMock = jest.fn().mockReturnValue({ eq: eqMock });
+    
+    (supabase.from as jest.Mock).mockReturnValue({ select: selectMock });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+    
+    expect(supabase.from).toHaveBeenCalledWith('system_controls');
+    expect(selectMock).toHaveBeenCalledWith('*');
+    expect(eqMock).toHaveBeenCalledWith('key', 'vitana_did_you_know_enabled');
+    expect(result).toEqual(mockControl);
+  });
+
+  it('should return null if control is not found (PGRST116)', async () => {
+    const singleMock = jest.fn().mockResolvedValue({ 
+      data: null, 
+      error: { code: 'PGRST116', message: 'Not Found' } 
+    });
+    const eqMock = jest.fn().mockReturnValue({ single: singleMock });
+    const selectMock = jest.fn().mockReturnValue({ eq: eqMock });
+    
+    (supabase.from as jest.Mock).mockReturnValue({ select: selectMock });
+
+    const result = await getSystemControl('missing_key');
+    expect(result).toBeNull();
+  });
+
+  it('should throw an error on database failure', async () => {
+    const dbError = new Error('Database connection failed');
+    const singleMock = jest.fn().mockResolvedValue({ data: null, error: dbError });
+    const eqMock = jest.fn().mockReturnValue({ single: singleMock });
+    const selectMock = jest.fn().mockReturnValue({ eq: eqMock });
+    
+    (supabase.from as jest.Mock).mockReturnValue({ select: selectMock });
+
+    await expect(getSystemControl('error_key')).rejects.toThrow('Database connection failed');
+  });
+});


### PR DESCRIPTION
**Context**
This PR exposes the `system_controls` table (specifically needed for the `vitana_did_you_know_enabled` flag introduced in migration `20260425100000_BOOTSTRAP_dyk_flag_on.sql`) via a new Gateway API endpoint. The frontend (command-hub) requires this flag to conditionally render the "Did You Know?" tour.

**Changes**
1. Added `SystemControl` type definitions.
2. Created a service to fetch system controls from Supabase by key.
3. Added the `GET /api/system-controls/:key` endpoint.
4. Created corresponding unit tests for the service and route.

**Operator Note (Action Required)**
The plan specified updating the command-hub frontend (e.g. `services/gateway/src/frontend/command-hub/...`) to consume this new endpoint and render the tour. However, the exact frontend file was not explicitly provided in the locked file list. **Please follow up by adding the frontend component changes** to call `/api/system-controls/vitana_did_you_know_enabled` and update the view accordingly.

**Files Touched**
- `services/gateway/src/types/system-controls.ts`
- `services/gateway/src/services/system-controls.ts`
- `services/gateway/src/routes/system-controls.ts`
- `services/gateway/test/system-controls.test.ts`
- `services/gateway/test/routes/system-controls.test.ts`