### PR TITLE
DEV-AUTOPILOT: Add gateway endpoints for system controls

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,22 @@
+import { Router, Request, Response } from 'express';
+import { getSystemControl } from '../services/system-controls';
+
+const router = Router();
+
+router.get('/:key', async (req: Request, res: Response) => {
+  try {
+    const key = req.params.key;
+    const control = await getSystemControl(key);
+
+    if (!control) {
+      return res.status(404).json({ error: 'System control not found' });
+    }
+
+    return res.status(200).json(control);
+  } catch (error) {
+    console.error(`Error fetching system control for key ${req.params.key}:`, error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router;

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,16 @@
+import { supabase } from '../lib/supabase';
+import { SystemControl } from '../types/system-controls';
+
+export async function getSystemControl(key: string): Promise<SystemControl | null> {
+  const { data, error } = await supabase
+    .from('system_controls')
+    .select('*')
+    .eq('key', key)
+    .single();
+
+  if (error || !data) {
+    return null;
+  }
+
+  return data as SystemControl;
+}

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at?: string;
+  updated_by?: string;
+  reason?: string;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,46 @@
+import request from 'supertest';
+import express from 'express';
+import systemControlsRouter from '../../src/routes/system-controls';
+import * as systemControlsService from '../../src/services/system-controls';
+
+jest.mock('../../src/services/system-controls');
+
+const app = express();
+app.use(express.json());
+app.use('/api/system-controls', systemControlsRouter);
+
+describe('System Controls Route', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return 200 and the control if found', async () => {
+    const mockControl = { key: 'vitana_did_you_know_enabled', enabled: true };
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(mockControl);
+
+    const response = await request(app).get('/api/system-controls/vitana_did_you_know_enabled');
+    
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockControl);
+    expect(systemControlsService.getSystemControl).toHaveBeenCalledWith('vitana_did_you_know_enabled');
+  });
+
+  it('should return 404 if control not found', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(null);
+
+    const response = await request(app).get('/api/system-controls/missing_key');
+    
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'System control not found' });
+    expect(systemControlsService.getSystemControl).toHaveBeenCalledWith('missing_key');
+  });
+
+  it('should return 500 on internal error', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockRejectedValue(new Error('Database disconnected'));
+
+    const response = await request(app).get('/api/system-controls/error_key');
+    
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: 'Internal server error' });
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,53 @@
+import { getSystemControl } from '../src/services/system-controls';
+import { supabase } from '../src/lib/supabase';
+
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+describe('System Controls Service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns a system control when found', async () => {
+    const mockData = { key: 'vitana_did_you_know_enabled', enabled: true };
+    
+    const mockEq = jest.fn().mockReturnValue({
+      single: jest.fn().mockResolvedValue({ data: mockData, error: null })
+    });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    (supabase.from as jest.Mock).mockReturnValue({ select: mockSelect });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+    
+    expect(result).toEqual(mockData);
+    expect(supabase.from).toHaveBeenCalledWith('system_controls');
+    expect(mockSelect).toHaveBeenCalledWith('*');
+    expect(mockEq).toHaveBeenCalledWith('key', 'vitana_did_you_know_enabled');
+  });
+
+  it('returns null when not found', async () => {
+    const mockEq = jest.fn().mockReturnValue({
+      single: jest.fn().mockResolvedValue({ data: null, error: { message: 'Not found' } })
+    });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    (supabase.from as jest.Mock).mockReturnValue({ select: mockSelect });
+
+    const result = await getSystemControl('missing_key');
+    expect(result).toBeNull();
+  });
+
+  it('returns null on database error', async () => {
+    const mockEq = jest.fn().mockReturnValue({
+      single: jest.fn().mockResolvedValue({ data: null, error: new Error('DB Error') })
+    });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    (supabase.from as jest.Mock).mockReturnValue({ select: mockSelect });
+
+    const result = await getSystemControl('error_key');
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
This PR adds the necessary Gateway service and route to expose `system_controls` via the API. This is required so the frontend can query flags such as `vitana_did_you_know_enabled` after the associated migration flips the flag to TRUE.

### Changes
* Created `SystemControl` type definition.
* Added `getSystemControl` service function to fetch from the Supabase `system_controls` table.
* Added an Express route at `GET /:key` to serve the system control status.
* Unit tests for both the service and the route.

**Operator Note regarding Command-Hub Frontend:**
The plan implies modifying the command-hub frontend to consume this new endpoint (`GET /api/system-controls/vitana_did_you_know_enabled`). Since the exact frontend file path wasn't provided in the strict locked list, its modification has been omitted from this PR. Please follow up by adding the API call to the command-hub tour component.