### PR TITLE
DEV-AUTOPILOT: Add auth middleware to telemetry endpoints for oasis_events

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,7 +1,8 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
 
@@ -24,9 +25,35 @@ const TelemetryEventSchema = z.object({
 
 type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
+// Auth middleware to enforce row-level security equivalent for telemetry writes
+const requireAuth = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader) {
+      return res.status(401).json({ error: "Unauthorized", detail: "Missing Authorization header" });
+    }
+
+    const token = authHeader.replace(/^Bearer\s+/i, "").trim();
+    if (!token) {
+      return res.status(401).json({ error: "Unauthorized", detail: "Invalid token format" });
+    }
+
+    const { data, error } = await supabase.auth.getUser(token);
+
+    if (error || !data?.user) {
+      return res.status(401).json({ error: "Unauthorized", detail: "Invalid or expired token" });
+    }
+
+    next();
+  } catch (err: any) {
+    console.error("❌ Auth middleware error:", err);
+    return res.status(500).json({ error: "Internal server error", detail: err.message });
+  }
+};
+
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +173,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,125 @@
+import express from "express";
+import request from "supertest";
+import { router } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+// Mock Supabase client
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn()
+    }
+  }
+}));
+
+// Mock Devhub (to prevent missing module errors in tests)
+jest.mock("../../src/routes/devhub", () => ({
+  broadcastEvent: jest.fn()
+}), { virtual: true });
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1/telemetry", router);
+
+describe("Telemetry Routes Auth Enforcement", () => {
+  const originalEnv = process.env;
+
+  beforeAll(() => {
+    process.env = { ...originalEnv };
+    process.env.SUPABASE_SERVICE_ROLE = "test-svc-key";
+    process.env.SUPABASE_URL = "http://localhost:8000";
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+      text: async () => "ok"
+    }) as jest.Mock;
+  });
+
+  const validEvent = {
+    vtid: "VT-000",
+    layer: "core",
+    module: "auth",
+    source: "gateway",
+    kind: "system.test",
+    status: "success",
+    title: "Test Event"
+  };
+
+  describe("POST /api/v1/telemetry/event", () => {
+    it("should return 401 if no Authorization header is present", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validEvent);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should return 401 if token is invalid or user is not found", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: new Error("Invalid token")
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer bad-token")
+        .send(validEvent);
+
+      expect(res.status).toBe(401);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should return 202 if user is authenticated", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "test-user" } },
+        error: null
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send(validEvent);
+
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    it("should return 401 if no Authorization header is present", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send([validEvent]);
+
+      expect(res.status).toBe(401);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should return 202 if user is authenticated", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "test-user" } },
+        error: null
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-token")
+        .send([validEvent]);
+
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
**Context & Issue:**
The `oasis_events` table was flagged for lacking Row-Level Security (RLS) policies (medium-risk `rls_gap`), allowing unauthenticated inserts bypassing the API layer. While the RLS migration must be manually applied at the database level, the application layer also needs to enforce authentication before attempting to write to `oasis_events`.

**Changes in this PR:**
1. Added `requireAuth` middleware to `services/gateway/src/routes/telemetry.ts` utilizing the existing `supabase` client.
2. Applied `requireAuth` to both `POST /api/v1/telemetry/event` and `POST /api/v1/telemetry/batch` routes so that requests without a valid Supabase token are rejected with HTTP 401.
3. Created a new unit test suite `services/gateway/test/routes/telemetry.test.ts` to verify the authentication checks, mocking both the Supabase `getUser` response and the upstream Supabase `fetch` behavior.

*(Note: The database migration to enforce this natively via RLS must be done separately as described in the incident runbook.)*