### PR TITLE
DEV-AUTOPILOT: Refactor admin-notification-categories to use shared requireAdmin

### DIFF
--- a/services/gateway/src/routes/admin-notification-categories.ts
+++ b/services/gateway/src/routes/admin-notification-categories.ts
@@ -11,55 +11,22 @@
  * - POST   /:id/test      — Send test notification to admin
  *
  * Security:
- * - All endpoints are protected by the `requireExafyAdmin` middleware.
+ * - All endpoints are protected by the `requireAdmin` middleware.
  */
 
-import { Router, Request, Response, NextFunction } from 'express';
+import { Router, Request, Response } from 'express';
 import { createClient } from '@supabase/supabase-js';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/requireAdmin';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIF-CATEGORIES';
 
 const VALID_TYPES = ['chat', 'calendar', 'community'];
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
 // ── Auth Middleware ─────────────────────────────────────────
 
-async function requireExafyAdmin(req: Request, res: Response, next: NextFunction) {
-  const token = getBearerToken(req);
-  if (!token) return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) {
-      return res.status(401).json({ ok: false, error: 'INVALID_TOKEN' });
-    }
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return res.status(403).json({ ok: false, error: 'FORBIDDEN' });
-    }
-
-    // Attach user info to request for downstream handlers
-    (req as any).authUser = { user_id: authData.user.id, email: authData.user.email || 'unknown' };
-    next();
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
-  }
-}
-
-router.use(requireExafyAdmin);
+router.use(requireAdmin);
 
 // ── Supabase ────────────────────────────────────────────────
 
@@ -140,7 +107,7 @@ router.get('/:id', async (req: Request, res: Response) => {
 // ── POST / — Create category ───────────────────────────────
 
 router.post('/', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const user = (req as any).user;
 
   const supabase = getSupabase();
   const {
@@ -180,7 +147,7 @@ router.post('/', async (req: Request, res: Response) => {
     default_enabled: default_enabled ?? true,
     mapped_types: mapped_types || [],
     tenant_id: tenant_id || null,
-    created_by: authUser.user_id,
+    created_by: user?.id,
   };
 
   const { data, error } = await supabase
@@ -197,14 +164,14 @@ router.post('/', async (req: Request, res: Response) => {
     return res.status(500).json({ ok: false, error: error.message });
   }
 
-  console.log(`[${VTID}] Created category "${slug}" (${type}) by ${authUser.email}`);
+  console.log(`[${VTID}] Created category "${slug}" (${type}) by ${user?.email ?? 'unknown'}`);
   return res.status(201).json({ ok: true, data });
 });
 
 // ── PATCH /:id — Update category ────────────────────────────
 
 router.patch('/:id', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const user = (req as any).user;
 
   const supabase = getSupabase();
   const allowedFields = ['display_name', 'description', 'icon', 'sort_order', 'is_active', 'default_enabled', 'mapped_types'];
@@ -236,14 +203,14 @@ router.patch('/:id', async (req: Request, res: Response) => {
     return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
   }
 
-  console.log(`[${VTID}] Updated category "${data.slug}" by ${authUser.email}`);
+  console.log(`[${VTID}] Updated category "${data.slug}" by ${user?.email ?? 'unknown'}`);
   return res.json({ ok: true, data });
 });
 
 // ── DELETE /:id — Soft-delete (set is_active=false) ─────────
 
 router.delete('/:id', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const user = (req as any).user;
 
   const supabase = getSupabase();
   const { data, error } = await supabase
@@ -261,14 +228,14 @@ router.delete('/:id', async (req: Request, res: Response) => {
     return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
   }
 
-  console.log(`[${VTID}] Soft-deleted category "${data.slug}" by ${authUser.email}`);
+  console.log(`[${VTID}] Soft-deleted category "${data.slug}" by ${user?.email ?? 'unknown'}`);
   return res.json({ ok: true, data });
 });
 
 // ── POST /:id/test — Send test notification to admin ────────
 
 router.post('/:id/test', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const user = (req as any).user;
 
   const supabase = getSupabase();
 
@@ -296,15 +263,15 @@ router.post('/:id/test', async (req: Request, res: Response) => {
   const { data: tenantRow } = await supabase
     .from('user_tenants')
     .select('tenant_id')
-    .eq('user_id', authUser.user_id)
+    .eq('user_id', user?.id)
     .limit(1)
     .single();
 
   const tenantId = tenantRow?.tenant_id || '00000000-0000-0000-0000-000000000000';
 
   try {
-    const result = await notifyUser(authUser.user_id, tenantId, testType, payload, supabase);
-    console.log(`[${VTID}] Test notification sent for category "${category.slug}" by ${authUser.email}`);
+    const result = await notifyUser(user?.id, tenantId, testType, payload, supabase);
+    console.log(`[${VTID}] Test notification sent for category "${category.slug}" by ${user?.email ?? 'unknown'}`);
     return res.json({ ok: true, result });
   } catch (err: any) {
     console.error(`[${VTID}] POST /:id/test error:`, err.message);

--- a/services/gateway/tests/admin-notification-categories.test.ts
+++ b/services/gateway/tests/admin-notification-categories.test.ts
@@ -1,0 +1,96 @@
+import request from 'supertest';
+import express from 'express';
+
+process.env.SUPABASE_URL = 'http://localhost';
+process.env.SUPABASE_SERVICE_ROLE = 'anon-key';
+
+// Mock the middleware
+jest.mock('../src/middleware/requireAdmin', () => ({
+  requireAdmin: (req: any, res: any, next: any) => {
+    const authHeader = req.headers.authorization;
+    if (!authHeader) {
+      return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+    }
+    if (authHeader === 'Bearer non-admin-token') {
+      return res.status(403).json({ ok: false, error: 'FORBIDDEN' });
+    }
+    if (authHeader === 'Bearer admin-token') {
+      req.user = { id: 'admin-123', email: 'admin@example.com' };
+      return next();
+    }
+    return res.status(401).json({ ok: false, error: 'INVALID_TOKEN' });
+  }
+}));
+
+class MockQueryBuilder {
+  from() { return this; }
+  select() { return this; }
+  order() { return this; }
+  eq() { return this; }
+  or() { return this; }
+  is() { return this; }
+  single() { return this; }
+  limit() { return this; }
+  insert() { return this; }
+  update() { return this; }
+  delete() { return this; }
+  then(resolve: any) {
+    return Promise.resolve({ data: [], error: null }).then(resolve);
+  }
+}
+
+// Mock Supabase
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: () => new MockQueryBuilder()
+}));
+
+// Mock Notification Service
+jest.mock('../src/services/notification-service', () => ({
+  notifyUser: jest.fn().mockResolvedValue({})
+}));
+
+import adminNotificationCategoriesRouter from '../src/routes/admin-notification-categories';
+
+const app = express();
+app.use(express.json());
+app.use('/admin-notification-categories', adminNotificationCategoriesRouter);
+
+describe('Admin Notification Categories API Auth', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 401 UNAUTHENTICATED without Bearer token', async () => {
+    const res = await request(app).get('/admin-notification-categories');
+    expect(res.status).toBe(401);
+    expect(res.body).toEqual({ ok: false, error: 'UNAUTHENTICATED' });
+  });
+
+  it('returns 403 FORBIDDEN for authenticated non-admin', async () => {
+    const res = await request(app)
+      .get('/admin-notification-categories')
+      .set('Authorization', 'Bearer non-admin-token');
+    
+    expect(res.status).toBe(403);
+    expect(res.body).toEqual({ ok: false, error: 'FORBIDDEN' });
+  });
+
+  it('returns 200 for authenticated admin on GET /', async () => {
+    const res = await request(app)
+      .get('/admin-notification-categories')
+      .set('Authorization', 'Bearer admin-token');
+    
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('returns 201 for authenticated admin on POST /', async () => {
+    const res = await request(app)
+      .post('/admin-notification-categories')
+      .set('Authorization', 'Bearer admin-token')
+      .send({ type: 'chat', display_name: 'Chat Group' });
+    
+    expect(res.status).toBe(201);
+    expect(res.body.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
Refactors `admin-notification-categories.ts` to address `route-auth-scanner-v1` findings regarding non-standard inline auth patterns.

- Replaced inline `requireExafyAdmin` and `getBearerToken` helpers with the standard `requireAdmin` middleware.
- Applied declarative auth via `router.use(requireAdmin)` at the route level.
- Updated user identity lookups to consume `req.user` instead of attaching custom `req.authUser` properties.
- Removed unused imports (`createUserSupabaseClient`).
- Created new test file to enforce auth boundaries for this specific route.