### PR TITLE
DEV-AUTOPILOT: Enforce auth on telemetry events (RLS gap mitigation)

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,44 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+// Authentication middleware to protect oasis_events modifying routes
+const requireAuth = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    let token = "";
+    const authHeader = req.headers.authorization;
+    
+    if (authHeader && authHeader.startsWith("Bearer ")) {
+      token = authHeader.substring(7);
+    } else if (req.headers.cookie) {
+      const cookies = req.headers.cookie.split(";").map(c => c.trim());
+      const sbCookie = cookies.find(c => c.startsWith("sb-access-token="));
+      if (sbCookie) {
+        token = sbCookie.substring("sb-access-token=".length);
+      }
+    }
+
+    if (!token) {
+      res.status(401).json({ error: "Unauthorized", detail: "Missing authorization token" });
+      return;
+    }
+
+    const { data, error } = await supabase.auth.getUser(token);
+
+    if (error || !data.user) {
+      res.status(401).json({ error: "Unauthorized", detail: "Invalid or expired token" });
+      return;
+    }
+
+    next();
+  } catch (e: any) {
+    res.status(401).json({ error: "Unauthorized", detail: "Authentication failed" });
+  }
+};
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +61,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +181,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,150 @@
+import express from "express";
+import request from "supertest";
+import { router } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1/telemetry", router);
+
+describe("Telemetry Routes", () => {
+  const originalEnv = process.env;
+
+  beforeAll(() => {
+    process.env = {
+      ...originalEnv,
+      SUPABASE_URL: "http://mock-supabase.local",
+      SUPABASE_SERVICE_ROLE: "mock-service-key",
+    };
+    // Suppress expected error logs during testing
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+    jest.restoreAllMocks();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn();
+  });
+
+  const validEvent = {
+    vtid: "VTID-123",
+    layer: "app",
+    module: "auth",
+    source: "client",
+    kind: "login",
+    status: "success",
+    title: "User logged in",
+  };
+
+  describe("POST /api/v1/telemetry/event", () => {
+    it("returns 401 if no authorization header is provided", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validEvent);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+    });
+
+    it("returns 401 if token is invalid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: null },
+        error: new Error("Invalid token"),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer bad-token")
+        .send(validEvent);
+
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 202 if token is valid and insert succeeds", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-1" } },
+        error: null,
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer good-token")
+        .send(validEvent);
+
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    it("returns 401 if no authorization header is provided", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send([validEvent]);
+
+      expect(res.status).toBe(401);
+    });
+
+    it("returns 202 if token is valid and insert succeeds", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-1" } },
+        error: null,
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer good-token")
+        .send([validEvent]);
+
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("GET /api/v1/telemetry/health", () => {
+    it("returns 200 without requiring authentication", async () => {
+      const res = await request(app).get("/api/v1/telemetry/health");
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+    });
+  });
+  
+  describe("GET /api/v1/telemetry/snapshot", () => {
+    it("returns 200 without requiring authentication", async () => {
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ([]),
+      });
+
+      const res = await request(app).get("/api/v1/telemetry/snapshot");
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Mitigates the medium-risk `rls_gap` flagged by `rls-policy-scanner-v1` for the `oasis_events` table.

Because automated agents cannot directly modify or create files in `supabase/migrations/`, this pull request introduces an application-level guard via an Express middleware (`requireAuth`). This ensures that only requests with a valid Supabase authentication session can write to the `oasis_events` table through the telemetry API routes (`POST /event` and `POST /batch`). Read endpoints like `health` and `snapshot` remain accessible.

**Note to Developer:** A follow-up manual database migration is required to fully harden the table at the database layer. Example:
```sql
ALTER TABLE public.oasis_events ENABLE ROW LEVEL SECURITY;
CREATE POLICY "allow_authenticated_insert" ON public.oasis_events FOR INSERT TO authenticated WITH CHECK (true);
CREATE POLICY "allow_authenticated_update" ON public.oasis_events FOR UPDATE TO authenticated USING (true);
REVOKE INSERT, UPDATE ON public.oasis_events FROM anon, public;
```

Files touched:
- `services/gateway/src/routes/telemetry.ts`: Add and apply `requireAuth` middleware.
- `services/gateway/test/routes/telemetry.test.ts`: Add complete test coverage for telemetry auth validation.