### PR TITLE
DEV-AUTOPILOT: Refactor admin notification categories to use standard requireAdmin

### DIFF
--- a/services/gateway/src/routes/admin-notification-categories.ts
+++ b/services/gateway/src/routes/admin-notification-categories.ts
@@ -11,55 +11,20 @@
  * - POST   /:id/test      — Send test notification to admin
  *
  * Security:
- * - All endpoints are protected by the `requireExafyAdmin` middleware.
+ * - All endpoints are protected by the `requireAdmin` middleware.
  */
 
-import { Router, Request, Response, NextFunction } from 'express';
+import { Router, Request, Response } from 'express';
 import { createClient } from '@supabase/supabase-js';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/requireAdmin';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIF-CATEGORIES';
 
 const VALID_TYPES = ['chat', 'calendar', 'community'];
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-// ── Auth Middleware ─────────────────────────────────────────
-
-async function requireExafyAdmin(req: Request, res: Response, next: NextFunction) {
-  const token = getBearerToken(req);
-  if (!token) return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) {
-      return res.status(401).json({ ok: false, error: 'INVALID_TOKEN' });
-    }
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return res.status(403).json({ ok: false, error: 'FORBIDDEN' });
-    }
-
-    // Attach user info to request for downstream handlers
-    (req as any).authUser = { user_id: authData.user.id, email: authData.user.email || 'unknown' };
-    next();
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
-  }
-}
-
-router.use(requireExafyAdmin);
+router.use(requireAdmin);
 
 // ── Supabase ────────────────────────────────────────────────
 
@@ -140,7 +105,7 @@ router.get('/:id', async (req: Request, res: Response) => {
 // ── POST / — Create category ───────────────────────────────
 
 router.post('/', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const user = (req as any).user;
 
   const supabase = getSupabase();
   const {
@@ -180,7 +145,7 @@ router.post('/', async (req: Request, res: Response) => {
     default_enabled: default_enabled ?? true,
     mapped_types: mapped_types || [],
     tenant_id: tenant_id || null,
-    created_by: authUser.user_id,
+    created_by: user?.id,
   };
 
   const { data, error } = await supabase
@@ -197,14 +162,14 @@ router.post('/', async (req: Request, res: Response) => {
     return res.status(500).json({ ok: false, error: error.message });
   }
 
-  console.log(`[${VTID}] Created category "${slug}" (${type}) by ${authUser.email}`);
+  console.log(`[${VTID}] Created category "${slug}" (${type}) by ${user?.email ?? 'unknown'}`);
   return res.status(201).json({ ok: true, data });
 });
 
 // ── PATCH /:id — Update category ────────────────────────────
 
 router.patch('/:id', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const user = (req as any).user;
 
   const supabase = getSupabase();
   const allowedFields = ['display_name', 'description', 'icon', 'sort_order', 'is_active', 'default_enabled', 'mapped_types'];
@@ -236,14 +201,14 @@ router.patch('/:id', async (req: Request, res: Response) => {
     return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
   }
 
-  console.log(`[${VTID}] Updated category "${data.slug}" by ${authUser.email}`);
+  console.log(`[${VTID}] Updated category "${data.slug}" by ${user?.email ?? 'unknown'}`);
   return res.json({ ok: true, data });
 });
 
 // ── DELETE /:id — Soft-delete (set is_active=false) ─────────
 
 router.delete('/:id', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const user = (req as any).user;
 
   const supabase = getSupabase();
   const { data, error } = await supabase
@@ -261,14 +226,14 @@ router.delete('/:id', async (req: Request, res: Response) => {
     return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
   }
 
-  console.log(`[${VTID}] Soft-deleted category "${data.slug}" by ${authUser.email}`);
+  console.log(`[${VTID}] Soft-deleted category "${data.slug}" by ${user?.email ?? 'unknown'}`);
   return res.json({ ok: true, data });
 });
 
 // ── POST /:id/test — Send test notification to admin ────────
 
 router.post('/:id/test', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const user = (req as any).user;
 
   const supabase = getSupabase();
 
@@ -296,15 +261,15 @@ router.post('/:id/test', async (req: Request, res: Response) => {
   const { data: tenantRow } = await supabase
     .from('user_tenants')
     .select('tenant_id')
-    .eq('user_id', authUser.user_id)
+    .eq('user_id', user?.id)
     .limit(1)
     .single();
 
   const tenantId = tenantRow?.tenant_id || '00000000-0000-0000-0000-000000000000';
 
   try {
-    const result = await notifyUser(authUser.user_id, tenantId, testType, payload, supabase);
-    console.log(`[${VTID}] Test notification sent for category "${category.slug}" by ${authUser.email}`);
+    const result = await notifyUser(user?.id, tenantId, testType, payload, supabase);
+    console.log(`[${VTID}] Test notification sent for category "${category.slug}" by ${user?.email ?? 'unknown'}`);
     return res.json({ ok: true, result });
   } catch (err: any) {
     console.error(`[${VTID}] POST /:id/test error:`, err.message);

--- a/services/gateway/tests/admin-notification-categories.test.ts
+++ b/services/gateway/tests/admin-notification-categories.test.ts
@@ -1,0 +1,73 @@
+import request from 'supertest';
+import express from 'express';
+import adminNotificationCategoriesRouter from '../src/routes/admin-notification-categories';
+import { requireAdmin } from '../src/middleware/requireAdmin';
+
+// Mock the middleware
+jest.mock('../src/middleware/requireAdmin', () => ({
+  requireAdmin: jest.fn()
+}));
+
+// Mock Supabase
+const mockSupabaseQuery = {
+  select: jest.fn().mockReturnThis(),
+  order: jest.fn().mockReturnThis(),
+  eq: jest.fn().mockReturnThis(),
+  or: jest.fn().mockReturnThis(),
+  is: jest.fn().mockReturnThis(),
+  single: jest.fn().mockReturnThis(),
+  insert: jest.fn().mockReturnThis(),
+  update: jest.fn().mockReturnThis(),
+  limit: jest.fn().mockReturnThis(),
+  then: jest.fn((resolve) => resolve({ data: [], error: null }))
+};
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({
+    from: jest.fn(() => mockSupabaseQuery)
+  }))
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/admin/notification-categories', adminNotificationCategoriesRouter);
+
+describe('Admin Notification Categories Auth', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 401 for unauthenticated request', async () => {
+    // Setup mock to simulate unauthenticated
+    (requireAdmin as jest.Mock).mockImplementation((req, res, next) => {
+      res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+    });
+
+    const response = await request(app).get('/admin/notification-categories');
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({ ok: false, error: 'UNAUTHENTICATED' });
+  });
+
+  it('returns 403 for authenticated non-admin', async () => {
+    // Setup mock to simulate non-admin
+    (requireAdmin as jest.Mock).mockImplementation((req, res, next) => {
+      res.status(403).json({ ok: false, error: 'FORBIDDEN' });
+    });
+
+    const response = await request(app).get('/admin/notification-categories');
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({ ok: false, error: 'FORBIDDEN' });
+  });
+
+  it('returns 200 for authenticated admin on GET /', async () => {
+    // Setup mock to simulate admin
+    (requireAdmin as jest.Mock).mockImplementation((req, res, next) => {
+      (req as any).user = { id: 'admin-123', email: 'admin@exafy.com' };
+      next();
+    });
+
+    const response = await request(app).get('/admin/notification-categories');
+    expect(response.status).toBe(200);
+    expect(response.body.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
This PR replaces inline authentication in `admin-notification-categories.ts` with the standard `requireAdmin` middleware.

The `route-auth-scanner-v1` flagged this file for using an inline authentication helper rather than the standard shared middleware. While functionality and security were already sound, centralising this to `router.use(requireAdmin)` improves scanner visibility, maintains a standard auth posture, and reduces boilerplate code. 

**Changes:**
- Removed `getBearerToken()` and `requireExafyAdmin()` inline helpers.
- Added `router.use(requireAdmin)` from the shared middleware.
- Adjusted properties from `authUser.user_id` & `authUser.email` to `(req as any).user?.id` & `(req as any).user?.email`.
- Removed unused `createUserSupabaseClient` and `NextFunction` imports.
- Added auth boundary tests in `admin-notification-categories.test.ts`.