### PR TITLE
DEV-AUTOPILOT: Enforce auth for telemetry API write routes

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,39 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+// Middleware to ensure user is authenticated via Supabase
+const requireAuthenticatedUser = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      res.status(401).json({ error: "Unauthorized", detail: "Missing or invalid Authorization header" });
+      return;
+    }
+
+    const token = authHeader.split(" ")[1];
+    if (!token) {
+      res.status(401).json({ error: "Unauthorized", detail: "Missing token" });
+      return;
+    }
+
+    const { data, error } = await supabase.auth.getUser(token);
+
+    if (error || !data.user) {
+      res.status(401).json({ error: "Unauthorized", detail: "Invalid token" });
+      return;
+    }
+
+    next();
+  } catch (e: any) {
+    console.error("Auth middleware error:", e);
+    res.status(500).json({ error: "Internal server error", detail: "Auth check failed" });
+  }
+};
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +56,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +176,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,133 @@
+import request from 'supertest';
+import express from 'express';
+import { router } from '../../src/routes/telemetry';
+import { supabase } from '../../src/lib/supabase';
+
+jest.mock('../../src/lib/supabase', () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+jest.mock('../../src/routes/devhub', () => ({
+  broadcastEvent: jest.fn(),
+}));
+
+describe('Telemetry Routes Auth Enforcement', () => {
+  let app: express.Express;
+
+  beforeAll(() => {
+    process.env.SUPABASE_SERVICE_ROLE = 'test-svc-key';
+    process.env.SUPABASE_URL = 'http://localhost:8000';
+    app = express();
+    app.use(express.json());
+    app.use('/api/v1/telemetry', router);
+    global.fetch = jest.fn();
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  const validEvent = {
+    vtid: 'VTID-123',
+    layer: 'test-layer',
+    module: 'test-module',
+    source: 'test-source',
+    kind: 'test.kind',
+    status: 'success',
+    title: 'Test Event'
+  };
+
+  describe('POST /api/v1/telemetry/event', () => {
+    it('returns 401 when no token is provided', async () => {
+      const response = await request(app)
+        .post('/api/v1/telemetry/event')
+        .send(validEvent);
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe('Unauthorized');
+    });
+
+    it('returns 401 when an invalid token is provided', async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: { message: 'Invalid token' }
+      });
+
+      const response = await request(app)
+        .post('/api/v1/telemetry/event')
+        .set('Authorization', 'Bearer invalid-token')
+        .send(validEvent);
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe('Unauthorized');
+      expect(supabase.auth.getUser).toHaveBeenCalledWith('invalid-token');
+    });
+
+    it('returns 202 when a valid token is provided', async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: 'user-123' } },
+        error: null
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({})
+      });
+
+      const response = await request(app)
+        .post('/api/v1/telemetry/event')
+        .set('Authorization', 'Bearer valid-token')
+        .send(validEvent);
+
+      expect(response.status).toBe(202);
+      expect(response.body.ok).toBe(true);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith('valid-token');
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+
+  describe('POST /api/v1/telemetry/batch', () => {
+    const validEvents = [validEvent];
+
+    it('returns 401 when no token is provided', async () => {
+      const response = await request(app)
+        .post('/api/v1/telemetry/batch')
+        .send(validEvents);
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe('Unauthorized');
+    });
+
+    it('returns 202 when a valid token is provided', async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: 'user-123' } },
+        error: null
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({})
+      });
+
+      const response = await request(app)
+        .post('/api/v1/telemetry/batch')
+        .set('Authorization', 'Bearer valid-token')
+        .send(validEvents);
+
+      expect(response.status).toBe(202);
+      expect(response.body.ok).toBe(true);
+    });
+  });
+
+  describe('GET /api/v1/telemetry/health', () => {
+    it('returns 200 and does not require auth', async () => {
+      const response = await request(app).get('/api/v1/telemetry/health');
+      expect(response.status).toBe(200);
+      expect(response.body.ok).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
**Fixes RLS gap for `oasis_events` writes**

This PR adds an application-level `requireAuthenticatedUser` middleware to the `/event` and `/batch` telemetry endpoints. This ensures that direct API calls attempting to insert into `oasis_events` are authenticated with a valid Supabase session, resolving a security gap where unauthenticated callers could write events.

- Extracts the Supabase session from the `Authorization: Bearer <token>` header.
- Verifies the token using `supabase.auth.getUser()`.
- Unauthenticated requests are rejected with a `401 Unauthorized` status.
- Added comprehensive unit tests in `telemetry.test.ts` to verify the auth requirement.

Note: The database-level RLS policy for `oasis_events` must be added in a separate, manual migration by a developer as the automated executor scope forbids modifying files under `supabase/migrations/`.