### PR TITLE
DEV-AUTOPILOT: Add paramLimit middleware to mitigate path-to-regexp ReDoS

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,29 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    // 1. Validate raw path length to prevent ReDoS before route matching occurs.
+    // Uses RegExp for validation, avoiding vulnerable path-to-regexp backtracking.
+    const segmentRegex = new RegExp(`[^/]{${maxLength + 1},}`);
+    if (segmentRegex.test(req.path)) {
+      res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    // 2. Parse req.params and count keys (effective when applied to specific routes)
+    const paramKeys = Object.keys(req.params || {});
+    if (paramKeys.length > maxParams) {
+      res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    for (const key of paramKeys) {
+      if (req.params[key] && req.params[key].length > maxLength) {
+        res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,17 @@
+import { Router } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply the ReDoS mitigation middleware
+router.use(limitPathParams());
+
+router.get('/:projectId', (req, res) => {
+  res.status(200).json({ id: req.params.projectId });
+});
+
+router.get('/:projectId/tasks/:taskId', (req, res) => {
+  res.status(200).json({ projectId: req.params.projectId, taskId: req.params.taskId });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,17 @@
+import { Router } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply the ReDoS mitigation middleware
+router.use(limitPathParams());
+
+router.get('/:userId', (req, res) => {
+  res.status(200).json({ id: req.params.userId });
+});
+
+router.get('/:userId/posts/:postId', (req, res) => {
+  res.status(200).json({ userId: req.params.userId, postId: req.params.postId });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,91 @@
+import express from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+import userRoutes from '../src/routes/v1/userRoutes';
+import projectRoutes from '../src/routes/v1/projectRoutes';
+
+describe('CVE Mitigation - path-to-regexp ReDoS', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = express();
+
+    // 1. Test route with multiple params (to test req.params parsing directly)
+    app.get('/test/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req, res) => {
+      res.status(200).json({ success: true });
+    });
+
+    // 2. Test route with valid params
+    app.get('/test/:a/:b', limitPathParams(5, 200), (req, res) => {
+      res.status(200).json({ success: true });
+    });
+
+    // 3. Mount actual routers
+    app.use('/users', userRoutes);
+    app.use('/projects', projectRoutes);
+  });
+
+  it('should return 400 when there are more than 5 path parameters', async () => {
+    const start = Date.now();
+    const response = await request(app).get('/test/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('should return 400 when a path parameter exceeds maxLength (200 chars)', async () => {
+    const longParam = 'a'.repeat(201);
+    const start = Date.now();
+    const response = await request(app).get(`/test/${longParam}/2`);
+    const duration = Date.now() - start;
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('should pass and return 200 when parameters are within limits', async () => {
+    const response = await request(app).get('/test/1/2');
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+  });
+
+  it('should protect userRoutes against long path segments (Integration)', async () => {
+    const longParam = 'y'.repeat(250);
+    const start = Date.now();
+    const response = await request(app).get(`/users/${longParam}`);
+    const duration = Date.now() - start;
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(500); // Expect fast rejection
+  });
+
+  it('should allow valid requests to userRoutes', async () => {
+    const response = await request(app).get('/users/123');
+    expect(response.status).toBe(200);
+    expect(response.body.id).toBe('123');
+  });
+
+  it('should allow valid requests to projectRoutes', async () => {
+    const response = await request(app).get('/projects/abc/tasks/def');
+    expect(response.status).toBe(200);
+    expect(response.body.projectId).toBe('abc');
+    expect(response.body.taskId).toBe('def');
+  });
+
+  it('Integration test: mitigate ReDoS pathological requests fast', async () => {
+    // A pathological route match string could be sent, we want to ensure it rejects fast.
+    // Because router.use() executes before route match, the paramLimit middleware's regex
+    // catches the long path immediately.
+    const pathologicalParam = 'a'.repeat(500);
+    const start = Date.now();
+    const response = await request(app).get(`/users/${pathologicalParam}`);
+    const duration = Date.now() - start;
+
+    expect(response.status).toBe(400);
+    expect(duration).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
This PR implements a server-side validation middleware to mitigate a Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (< 0.1.13) used by Express.

- Adds `limitPathParams` middleware to cap the number of path parameters and their maximum length.
- Applies the middleware to `userRoutes.ts` and `projectRoutes.ts`.
- Adds unit and integration tests to verify that malicious requests are rejected quickly without causing catastrophic backtracking.

*Note: The plan applies this mitigation to `userRoutes.ts` and `projectRoutes.ts` as examples. Any additional route files under `services/gateway/src/routes/` containing path parameters must also be updated to use this middleware.*