### PR TITLE
DEV-AUTOPILOT: Add system controls endpoint to gateway

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,22 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { getSystemControl } from '../services/system-controls';
+
+const router = Router();
+
+router.get('/:key', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { key } = req.params;
+    const control = await getSystemControl(key);
+
+    if (!control) {
+      res.status(404).json({ error: 'System control not found' });
+      return;
+    }
+
+    res.json(control);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,19 @@
+import { supabase } from '../lib/supabase';
+import { SystemControl } from '../types/system-controls';
+
+export async function getSystemControl(key: string): Promise<SystemControl | null> {
+  const { data, error } = await supabase
+    .from('system_controls')
+    .select('*')
+    .eq('key', key)
+    .single();
+
+  if (error) {
+    if (error.code === 'PGRST116') {
+      return null;
+    }
+    throw error;
+  }
+
+  return data as SystemControl;
+}

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at?: string;
+  updated_by?: string;
+  reason?: string;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,48 @@
+import express from 'express';
+import request from 'supertest';
+import systemControlsRouter from '../../src/routes/system-controls';
+import * as systemControlsService from '../../src/services/system-controls';
+
+jest.mock('../../src/services/system-controls');
+
+const app = express();
+app.use(express.json());
+app.use('/api/system-controls', systemControlsRouter);
+app.use((err: Error, req: express.Request, res: express.Response, next: express.NextFunction) => {
+  res.status(500).json({ error: err.message });
+});
+
+describe('System Controls Routes', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('GET /api/system-controls/:key should return 200 and the control when found', async () => {
+    const mockControl = { key: 'vitana_did_you_know_enabled', enabled: true };
+    jest.spyOn(systemControlsService, 'getSystemControl').mockResolvedValue(mockControl);
+
+    const response = await request(app).get('/api/system-controls/vitana_did_you_know_enabled');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockControl);
+    expect(systemControlsService.getSystemControl).toHaveBeenCalledWith('vitana_did_you_know_enabled');
+  });
+
+  it('GET /api/system-controls/:key should return 404 when not found', async () => {
+    jest.spyOn(systemControlsService, 'getSystemControl').mockResolvedValue(null);
+
+    const response = await request(app).get('/api/system-controls/missing_flag');
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'System control not found' });
+  });
+
+  it('GET /api/system-controls/:key should return 500 on service errors', async () => {
+    jest.spyOn(systemControlsService, 'getSystemControl').mockRejectedValue(new Error('Internal failure'));
+
+    const response = await request(app).get('/api/system-controls/error_flag');
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: 'Internal failure' });
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,53 @@
+import { getSystemControl } from '../src/services/system-controls';
+import { supabase } from '../src/lib/supabase';
+
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+describe('System Controls Service', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return a system control when it exists', async () => {
+    const mockData = { key: 'vitana_did_you_know_enabled', enabled: true };
+    const singleMock = jest.fn().mockResolvedValue({ data: mockData, error: null });
+    const eqMock = jest.fn().mockReturnValue({ single: singleMock });
+    const selectMock = jest.fn().mockReturnValue({ eq: eqMock });
+    
+    (supabase.from as jest.Mock).mockReturnValue({ select: selectMock });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+
+    expect(result).toEqual(mockData);
+    expect(supabase.from).toHaveBeenCalledWith('system_controls');
+    expect(selectMock).toHaveBeenCalledWith('*');
+    expect(eqMock).toHaveBeenCalledWith('key', 'vitana_did_you_know_enabled');
+    expect(singleMock).toHaveBeenCalled();
+  });
+
+  it('should return null when the system control is not found', async () => {
+    const singleMock = jest.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } });
+    const eqMock = jest.fn().mockReturnValue({ single: singleMock });
+    const selectMock = jest.fn().mockReturnValue({ eq: eqMock });
+    
+    (supabase.from as jest.Mock).mockReturnValue({ select: selectMock });
+
+    const result = await getSystemControl('missing_flag');
+
+    expect(result).toBeNull();
+  });
+
+  it('should throw an error for unexpected database errors', async () => {
+    const singleMock = jest.fn().mockResolvedValue({ data: null, error: new Error('Database connection failed') });
+    const eqMock = jest.fn().mockReturnValue({ single: singleMock });
+    const selectMock = jest.fn().mockReturnValue({ eq: eqMock });
+    
+    (supabase.from as jest.Mock).mockReturnValue({ select: selectMock });
+
+    await expect(getSystemControl('some_flag')).rejects.toThrow('Database connection failed');
+  });
+});


### PR DESCRIPTION
This PR adds a new gateway endpoint `GET /api/system-controls/:key` to fetch system control flags.
This fulfills the gateway backend portion of the plan to expose the `vitana_did_you_know_enabled`
flag, allowing the frontend to enable or disable the "Did You Know?" tour.

- Added `SystemControl` type definitions.
- Created `getSystemControl` service wrapping the `system_controls` Supabase table.
- Registered the route `GET /:key` which resolves 200 on success or 404 if the key is not found.
- Added corresponding unit tests for the service and the route.

**Note for operators:** The frontend (command-hub) changes discussed in the original plan are not included in this PR due to strictly locked file constraints. A subsequent change or an operator will need to update the command-hub code to call `/api/system-controls/vitana_did_you_know_enabled` on load and conditionally render the tour.