### PR TITLE
DEV-AUTOPILOT: Refactor admin-notifications routes to use standard auth

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -12,49 +12,18 @@
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/auth';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIFICATIONS';
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
+// Apply shared admin authentication to all routes in this router
+router.use(requireAdmin);
 
 // ── POST /compose — Send notification to user(s) ────────────
 
 router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -139,6 +108,8 @@ router.post('/compose', async (req: Request, res: Response) => {
     // Determine effective tenant_id for dispatching
     const effectiveTenantId = tenant_id || (recipient_ids?.length === 1 ? undefined : undefined);
 
+    const userEmail = (req as any).user?.email || 'admin';
+
     // For single recipients, use synchronous dispatch for immediate feedback
     if (targetUserIds.length === 1) {
       const result = await notifyUser(
@@ -148,7 +119,7 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      console.log(`[${VTID}] Composed notification for 1 user by ${userEmail}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +132,7 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${userEmail}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -177,9 +148,6 @@ router.post('/compose', async (req: Request, res: Response) => {
 // ── GET /sent — Admin notification log ──────────────────────
 
 router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -224,9 +192,6 @@ router.get('/sent', async (req: Request, res: Response) => {
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
 router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,130 @@
+import express from 'express';
+import request from 'supertest';
+import router from '../../../src/routes/admin-notifications';
+import { notifyUser, notifyUsersAsync } from '../../../src/services/notification-service';
+
+// Mock the shared authentication middleware
+jest.mock('../../../src/middleware/auth', () => ({
+  requireAdmin: jest.fn((req: any, res: any, next: any) => {
+    req.user = { id: 'admin-id', email: 'admin@test.com' };
+    next();
+  })
+}));
+
+// Mock Supabase with chainable queries
+const mockSupabase = {
+  from: jest.fn((table: string) => {
+    const chain: any = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      range: jest.fn().mockReturnThis(),
+      or: jest.fn().mockReturnThis(),
+      not: jest.fn().mockReturnThis(),
+    };
+    
+    // Allow the chain to be awaited directly
+    chain.then = function(resolve: any) {
+      if (table === 'user_notifications') {
+        // If checking unread vs total
+        if (this.not.mock.calls.length > 0) {
+          return resolve({ data: [], count: 50, error: null });
+        }
+        return resolve({ data: [{ id: 'notif-1' }], count: 100, error: null });
+      }
+      if (table === 'user_notification_preferences') {
+        return resolve({ data: [{ push_enabled: true }], error: null });
+      }
+      return resolve({ data: [], error: null });
+    };
+    
+    return chain;
+  })
+};
+
+jest.mock('../../../src/lib/supabase', () => ({
+  getSupabase: () => mockSupabase
+}));
+
+// Mock Notification Service
+jest.mock('../../../src/services/notification-service', () => ({
+  notifyUser: jest.fn().mockResolvedValue({ success: true }),
+  notifyUsersAsync: jest.fn().mockResolvedValue({ success: true })
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/admin-notifications', router);
+
+describe('Admin Notifications Routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('POST /compose', () => {
+    it('should send notification to a single user successfully', async () => {
+      const res = await request(app)
+        .post('/admin-notifications/compose')
+        .send({
+          title: 'Test Title',
+          body: 'Test Body',
+          recipient_ids: ['user1']
+        });
+        
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(notifyUser).toHaveBeenCalled();
+    });
+
+    it('should reject request without title or body', async () => {
+      const res = await request(app)
+        .post('/admin-notifications/compose')
+        .send({
+          recipient_ids: ['user1']
+        });
+        
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('INVALID_INPUT');
+    });
+
+    it('should reject request without recipients criteria', async () => {
+      const res = await request(app)
+        .post('/admin-notifications/compose')
+        .send({
+          title: 'Test Title',
+          body: 'Test Body'
+        });
+        
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('INVALID_INPUT');
+    });
+  });
+
+  describe('GET /sent', () => {
+    it('should return sent notifications with total count', async () => {
+      const res = await request(app)
+        .get('/admin-notifications/sent')
+        .query({ limit: 10, offset: 0 });
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.total).toBe(100);
+    });
+  });
+
+  describe('GET /preferences/stats', () => {
+    it('should return aggregate preference statistics', async () => {
+      const res = await request(app)
+        .get('/admin-notifications/preferences/stats');
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.stats.total_users_with_prefs).toBe(1);
+      expect(res.body.delivery.total_sent_30d).toBe(100);
+      expect(res.body.delivery.total_read_30d).toBe(50);
+      expect(res.body.delivery.read_rate).toBe(50); // 50 / 100 * 100
+    });
+  });
+});


### PR DESCRIPTION
**Context**
The scanner `route-auth-scanner-v1` flagged `admin-notifications.ts` for not using the standard shared authentication pattern. Instead of relying on centrally-managed middleware, the file used its own inline authentication helper (`verifyExafyAdmin`).

**Changes**
1. Removed `verifyExafyAdmin` and `getBearerToken` custom auth logic from `admin-notifications.ts`.
2. Applied the shared `requireAdmin` middleware (`router.use(requireAdmin)`) to protect the entire router.
3. Updated logging to use `req.user.email` (populated by `requireAdmin`).
4. Created the corresponding test file `admin-notifications.test.ts` to mock the newly introduced middleware and assert basic functionality.

**Affected Files**
- `services/gateway/src/routes/admin-notifications.ts`
- `services/gateway/test/routes/admin-notifications.test.ts`