### PR TITLE
DEV-AUTOPILOT: Add system controls API endpoint for feature flags

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,26 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { getSystemControl } from '../services/system-controls';
+
+const router = Router();
+
+router.get('/:key', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { key } = req.params;
+    
+    if (!key) {
+      return res.status(400).json({ error: 'System control key is required' });
+    }
+
+    const control = await getSystemControl(key);
+
+    if (!control) {
+      return res.status(404).json({ error: 'System control not found' });
+    }
+
+    return res.json(control);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,27 @@
+import { supabase } from '../lib/supabase';
+import { SystemControl } from '../types/system-controls';
+
+/**
+ * Fetch a single system control record by its key.
+ * Returns null if the control does not exist.
+ *
+ * @param key The unique identifier of the system control (e.g., 'vitana_did_you_know_enabled')
+ * @returns SystemControl object or null
+ */
+export async function getSystemControl(key: string): Promise<SystemControl | null> {
+  const { data, error } = await supabase
+    .from('system_controls')
+    .select('*')
+    .eq('key', key)
+    .single();
+
+  if (error) {
+    // PGRST116 is the PostgREST error code for "JSON object requested, multiple (or no) rows returned"
+    if (error.code === 'PGRST116') {
+      return null;
+    }
+    throw error;
+  }
+
+  return data as SystemControl;
+}

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at: string;
+  updated_by?: string | null;
+  reason?: string | null;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,57 @@
+import express from 'express';
+import request from 'supertest';
+import systemControlsRouter from '../../src/routes/system-controls';
+import * as systemControlsService from '../../src/services/system-controls';
+
+// Mock the system-controls service
+jest.mock('../../src/services/system-controls');
+
+const app = express();
+app.use(express.json());
+app.use('/api/system-controls', systemControlsRouter);
+
+// Basic error handler to catch next(err) and return a 500
+app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
+  res.status(500).json({ error: 'Internal Server Error' });
+});
+
+describe('SystemControls Routes', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('GET /api/system-controls/:key returns 200 and data if found', async () => {
+    const mockData = {
+      key: 'vitana_did_you_know_enabled',
+      enabled: true,
+      updated_at: '2023-10-01T00:00:00Z',
+    };
+    
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(mockData);
+
+    const response = await request(app).get('/api/system-controls/vitana_did_you_know_enabled');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockData);
+    expect(systemControlsService.getSystemControl).toHaveBeenCalledWith('vitana_did_you_know_enabled');
+  });
+
+  it('GET /api/system-controls/:key returns 404 if not found', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(null);
+
+    const response = await request(app).get('/api/system-controls/missing_key');
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'System control not found' });
+    expect(systemControlsService.getSystemControl).toHaveBeenCalledWith('missing_key');
+  });
+
+  it('GET /api/system-controls/:key returns 500 on service error', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockRejectedValue(new Error('DB connection failed'));
+
+    const response = await request(app).get('/api/system-controls/broken_key');
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: 'Internal Server Error' });
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,78 @@
+import { getSystemControl } from '../src/services/system-controls';
+import { supabase } from '../src/lib/supabase';
+
+// Mock the Supabase client
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn(),
+  },
+}));
+
+describe('SystemControls Service', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns a system control when found', async () => {
+    const mockData = {
+      key: 'vitana_did_you_know_enabled',
+      enabled: true,
+      updated_at: '2023-10-01T00:00:00Z',
+    };
+
+    const mockEq = jest.fn().mockReturnThis();
+    const mockSingle = jest.fn().mockResolvedValue({ data: mockData, error: null });
+
+    (supabase.from as jest.Mock).mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        eq: mockEq,
+        single: mockSingle,
+      }),
+    });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+
+    expect(supabase.from).toHaveBeenCalledWith('system_controls');
+    expect(mockEq).toHaveBeenCalledWith('key', 'vitana_did_you_know_enabled');
+    expect(result).toEqual(mockData);
+  });
+
+  it('returns null when system control is not found (PGRST116)', async () => {
+    const mockEq = jest.fn().mockReturnThis();
+    const mockSingle = jest.fn().mockResolvedValue({
+      data: null,
+      error: { code: 'PGRST116', message: 'JSON object requested, multiple (or no) rows returned' },
+    });
+
+    (supabase.from as jest.Mock).mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        eq: mockEq,
+        single: mockSingle,
+      }),
+    });
+
+    const result = await getSystemControl('missing_key');
+
+    expect(result).toBeNull();
+  });
+
+  it('throws an error on other database errors', async () => {
+    const mockEq = jest.fn().mockReturnThis();
+    const mockSingle = jest.fn().mockResolvedValue({
+      data: null,
+      error: { code: '500', message: 'Internal Server Error' },
+    });
+
+    (supabase.from as jest.Mock).mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        eq: mockEq,
+        single: mockSingle,
+      }),
+    });
+
+    await expect(getSystemControl('broken_key')).rejects.toEqual({
+      code: '500',
+      message: 'Internal Server Error',
+    });
+  });
+});


### PR DESCRIPTION
This PR introduces the necessary Gateway API components to expose `system_controls` (such as the `vitana_did_you_know_enabled` flag) to consumers like the frontend application. 

### Changes Included:
- **Type definitions**: Added `SystemControl` type.
- **Service**: Added `getSystemControl` service to query the `system_controls` table using Supabase.
- **Route**: Added `GET /api/system-controls/:key` endpoint.
- **Tests**: Comprehensive unit tests for both the service and the route.

### Important Operator Note:
The plan specifies updating `services/gateway/src/frontend/command-hub/...` to query this new endpoint for the "Did You Know?" tour. Due to the exact locked file constraints in this developer execution step, those frontend files have **not** been modified. An operator will need to update the command-hub UI components to execute `fetch('/api/system-controls/vitana_did_you_know_enabled')` in a follow-up commit or PR.