### PR TITLE
DEV-AUTOPILOT: Add auth middleware to telemetry routes for oasis_events

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,38 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+// Auth middleware for telemetry routes that modify data
+export const requireAuthenticatedUser = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    let token = "";
+    const authHeader = req.headers.authorization;
+    
+    if (authHeader && authHeader.toLowerCase().startsWith("bearer ")) {
+      token = authHeader.substring(7);
+    } else if (req.cookies && req.cookies["sb-access-token"]) {
+      token = req.cookies["sb-access-token"];
+    }
+
+    if (!token) {
+      return res.status(401).json({ error: "Unauthorized", detail: "Missing authentication token" });
+    }
+
+    const { data, error } = await supabase.auth.getUser(token);
+
+    if (error || !data?.user) {
+      return res.status(401).json({ error: "Unauthorized", detail: error?.message || "Invalid session" });
+    }
+
+    next();
+  } catch (e: any) {
+    return res.status(401).json({ error: "Unauthorized", detail: "Authentication failed" });
+  }
+};
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +55,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +175,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,132 @@
+import { router } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+import express from "express";
+import request from "supertest";
+
+// Mock supabase client
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+// Mock the devhub SSE broadcast to avoid failures during tests
+jest.mock("../../src/routes/devhub", () => ({
+  broadcastEvent: jest.fn(),
+}), { virtual: true });
+
+const app = express();
+app.use(express.json());
+// Mount router with a base path for consistency with actual app
+app.use("/api/v1/telemetry", router);
+
+describe("Telemetry Routes Authentication", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SUPABASE_URL = "http://localhost:8000";
+    process.env.SUPABASE_SERVICE_ROLE = "test-service-role";
+    
+    // Mock global fetch for OASIS persistence
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({}),
+        text: () => Promise.resolve(""),
+      })
+    ) as jest.Mock;
+  });
+
+  describe("POST /api/v1/telemetry/event", () => {
+    const validEvent = {
+      vtid: "VTID-123",
+      layer: "app",
+      module: "test",
+      source: "test-runner",
+      kind: "test.event",
+      status: "success",
+      title: "Test Event",
+    };
+
+    it("should return 401 when no token is provided", async () => {
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validEvent);
+
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual(expect.objectContaining({
+        error: "Unauthorized",
+      }));
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should return 401 when token is invalid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: { message: "Invalid session" },
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validEvent);
+
+      expect(response.status).toBe(401);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("invalid-token");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should proceed and return 202 when token is valid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send(validEvent);
+
+      expect(response.status).toBe(202);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("valid-token");
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    const validEvents = [{
+      vtid: "VTID-123",
+      layer: "app",
+      module: "test",
+      source: "test-runner",
+      kind: "test.event",
+      status: "success",
+      title: "Test Event",
+    }];
+
+    it("should return 401 when no token is provided", async () => {
+      const response = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send(validEvents);
+
+      expect(response.status).toBe(401);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should proceed and return 202 when token is valid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-token")
+        .send(validEvents);
+
+      expect(response.status).toBe(202);
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
This PR introduces application-level authentication enforcement to telemetry routes to prevent unauthenticated writes to the `oasis_events` table. This addresses a medium-risk `rls_gap` flagged by the `rls-policy-scanner-v1`.

### Changes:
- **`services/gateway/src/routes/telemetry.ts`**: Implemented `requireAuthenticatedUser` middleware. Extracted the Supabase session token from the `Authorization` header and verified it using `supabase.auth.getUser()`. The middleware is applied strictly to routes modifying `oasis_events` (`POST /event` and `POST /batch`).
- **`services/gateway/test/routes/telemetry.test.ts`**: Added unit tests to verify that both unauthenticated requests and invalid sessions yield `401 Unauthorized`, while correctly authenticated requests process successfully.

### Note:
Database-level RLS enablement and corresponding policies for `oasis_events` fall outside the scope of this automated commit and must be created manually via a new Supabase migration.