### PR TITLE
DEV-AUTOPILOT: Add parameter limit middleware to mitigate ReDoS

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,22 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const keys = Object.keys(req.params || {});
+    
+    if (keys.length > maxParams) {
+      res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    for (const key of keys) {
+      const value = req.params[key];
+      if (value && value.length > maxLength) {
+        res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply the ReDoS mitigation middleware
+router.use(limitPathParams());
+
+router.get('/:projectId', (req: Request, res: Response) => {
+  res.status(200).json({ projectId: req.params.projectId, type: 'project' });
+});
+
+router.get('/:projectId/members/:memberId', (req: Request, res: Response) => {
+  res.status(200).json({ projectId: req.params.projectId, memberId: req.params.memberId });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply the ReDoS mitigation middleware
+router.use(limitPathParams());
+
+router.get('/:id', (req: Request, res: Response) => {
+  res.status(200).json({ id: req.params.id, type: 'user' });
+});
+
+router.get('/:id/settings/:settingId', (req: Request, res: Response) => {
+  res.status(200).json({ id: req.params.id, settingId: req.params.settingId });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,83 @@
+import express from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+import userRoutes from '../src/routes/v1/userRoutes';
+import projectRoutes from '../src/routes/v1/projectRoutes';
+
+describe('CVE Mitigation - ReDoS in path-to-regexp', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = express();
+
+    // Test route for >5 params
+    app.get('/test/:a/:b/:c/:d/:e/:f', limitPathParams(), (req, res) => {
+      res.status(200).json({ success: true });
+    });
+
+    // Test route for long param
+    app.get('/long/:a', limitPathParams(), (req, res) => {
+      res.status(200).json({ success: true });
+    });
+
+    // Test route for normal params
+    app.get('/normal/:a/:b', limitPathParams(), (req, res) => {
+      res.status(200).json({ success: true });
+    });
+
+    // Mount actual routers
+    app.use('/users', userRoutes);
+    app.use('/projects', projectRoutes);
+  });
+
+  it('should return 400 when there are more than 5 path parameters', async () => {
+    const start = Date.now();
+    const response = await request(app).get('/test/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('should return 400 when a path parameter exceeds 200 characters', async () => {
+    const longParam = 'a'.repeat(201);
+    const start = Date.now();
+    const response = await request(app).get(`/long/${longParam}`);
+    const duration = Date.now() - start;
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('should pass through when parameters are within limits', async () => {
+    const response = await request(app).get('/normal/1/2');
+    expect(response.status).toBe(200);
+    expect(response.body.success).toBe(true);
+  });
+
+  it('should apply mitigation on user routes', async () => {
+    const response = await request(app).get('/users/123');
+    expect(response.status).toBe(200);
+    expect(response.body.id).toBe('123');
+  });
+
+  it('should apply mitigation on project routes', async () => {
+    const response = await request(app).get('/projects/abc');
+    expect(response.status).toBe(200);
+    expect(response.body.projectId).toBe('abc');
+  });
+  
+  it('should integration test pathological ReDoS attempt securely', async () => {
+    // Send a request designed to trigger ReDoS (pathological inputs on multi-parameter route)
+    const payload = '/test/' + Array(6).fill('a'.repeat(250)).join('/');
+    const start = Date.now();
+    const response = await request(app).get(payload);
+    const duration = Date.now() - start;
+    
+    // Gateway should reject fast (<500ms bounds, practically <50ms)
+    expect(response.status).toBe(400);
+    expect(duration).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
This PR addresses a Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (<0.1.13), which is transitively used by `express` in `services/gateway`. 

Since a direct dependency bump is out of scope for this change, we are introducing an Express middleware, `limitPathParams`, to limit the number and length of path parameters. This prevents attackers from crafting requests that exploit catastrophic backtracking, drastically reducing the attack surface.

**Changes:**
- `services/gateway/src/routes/middleware/paramLimit.ts`: New middleware enforcing a maximum of 5 route parameters per request, capped at 200 characters each.
- `services/gateway/src/routes/v1/userRoutes.ts` & `services/gateway/src/routes/v1/projectRoutes.ts`: Applied the `limitPathParams` middleware to the route controllers. *(Note to operators: Other route files utilizing path parameters will need similar modifications if they exist).*
- `services/gateway/test/cve-mitigation.test.ts`: Added unit and integration tests confirming >5 parameters or >200 character bounds trigger an immediate `400 Bad Request` while legitimate requests pass through.