### PR TITLE
DEV-AUTOPILOT: Refactor admin-notifications to use shared requireAdmin auth

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -12,51 +12,21 @@
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/auth';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIFICATIONS';
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
+router.use(requireAdmin);
 
 // ── POST /compose — Send notification to user(s) ────────────
 
 router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
+
+  const adminEmail = (req as any).user?.email || 'unknown';
 
   const {
     recipient_ids,   // string[] — specific user IDs
@@ -148,7 +118,7 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      console.log(`[${VTID}] Composed notification for 1 user by ${adminEmail}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +131,7 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${adminEmail}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -177,9 +147,6 @@ router.post('/compose', async (req: Request, res: Response) => {
 // ── GET /sent — Admin notification log ──────────────────────
 
 router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -224,9 +191,6 @@ router.get('/sent', async (req: Request, res: Response) => {
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
 router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,101 @@
+import request from 'supertest';
+import express, { Request, Response, NextFunction } from 'express';
+
+// Mock the auth middleware BEFORE importing the router
+jest.mock('../../src/middleware/auth', () => ({
+  requireAdmin: (req: Request, res: Response, next: NextFunction) => {
+    (req as any).user = { id: 'admin-id', email: 'admin@test.com' };
+    next();
+  }
+}));
+
+const mockSupabaseChain = (table: string, overrides: any = {}) => {
+  const chain: any = {
+    select: jest.fn(() => chain),
+    eq: jest.fn(() => chain),
+    or: jest.fn(() => chain),
+    gte: jest.fn(() => chain),
+    not: jest.fn(() => chain),
+    order: jest.fn(() => chain),
+    range: jest.fn(() => chain),
+    then: jest.fn((resolve) => resolve(overrides))
+  };
+  return chain;
+};
+
+let tableMocks: Record<string, any> = {};
+
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn(() => ({
+    from: jest.fn((table: string) => mockSupabaseChain(table, tableMocks[table]))
+  }))
+}));
+
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn().mockResolvedValue({ success: true }),
+  notifyUsersAsync: jest.fn()
+}));
+
+import adminNotificationsRouter from '../../src/routes/admin-notifications';
+
+const app = express();
+app.use(express.json());
+app.use('/admin', adminNotificationsRouter);
+
+describe('Admin Notifications Router', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    tableMocks = {
+      'user_notifications': { data: [{ id: 1 }], count: 1, error: null },
+      'user_notification_preferences': { data: [{ push_enabled: true, dnd_enabled: false }], error: null }
+    };
+  });
+
+  describe('POST /compose', () => {
+    it('should send notification to specific users', async () => {
+      const res = await request(app)
+        .post('/admin/compose')
+        .send({
+          title: 'Test',
+          body: 'Test body',
+          recipient_ids: ['user1']
+        });
+      
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.sent_to).toBe(1);
+    });
+
+    it('should fail if missing title or body', async () => {
+      const res = await request(app)
+        .post('/admin/compose')
+        .send({
+          recipient_ids: ['user1']
+        });
+      
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('INVALID_INPUT');
+    });
+  });
+
+  describe('GET /sent', () => {
+    it('should return sent notifications', async () => {
+      const res = await request(app).get('/admin/sent?limit=10');
+      
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.data).toHaveLength(1);
+    });
+  });
+
+  describe('GET /preferences/stats', () => {
+    it('should return preferences stats', async () => {
+      const res = await request(app).get('/admin/preferences/stats');
+      
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.stats.push_enabled).toBe(1);
+      expect(res.body.stats.push_disabled).toBe(0);
+    });
+  });
+});


### PR DESCRIPTION
**Context**
The scanner `route-auth-scanner-v1` flagged `admin-notifications.ts` because it used an inline custom authentication helper (`verifyExafyAdmin`) rather than the project's standard auth middleware pattern.

**What this PR does**
- Replaces the inline `verifyExafyAdmin` and `getBearerToken` helper functions with the shared `requireAdmin` middleware from `../middleware/auth`.
- Applies the middleware router-wide via `router.use(requireAdmin)`.
- Replaces explicit guard checks and passes through the administrator's email using `req.user.email` for logging.
- Adds comprehensive unit tests mocking the shared authentication middleware.

**Files touched**
- `services/gateway/src/routes/admin-notifications.ts` (modified)
- `services/gateway/test/routes/admin-notifications.test.ts` (created)