### PR TITLE
DEV-AUTOPILOT: Expose system controls API endpoint for gateway

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,22 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { getSystemControl } from '../services/system-controls';
+
+const router = Router();
+
+router.get('/:key', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const { key } = req.params;
+    const control = await getSystemControl(key);
+    
+    if (!control) {
+      res.status(404).json({ error: 'System control not found' });
+      return;
+    }
+
+    res.json(control);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,20 @@
+import { supabase } from '../lib/supabase';
+import { SystemControl } from '../types/system-controls';
+
+export async function getSystemControl(key: string): Promise<SystemControl | null> {
+  const { data, error } = await supabase
+    .from('system_controls')
+    .select('*')
+    .eq('key', key)
+    .single();
+
+  if (error) {
+    if (error.code === 'PGRST116') {
+      // PGRST116 indicates 0 rows returned
+      return null;
+    }
+    throw new Error(`Failed to fetch system control: ${error.message}`);
+  }
+
+  return data as SystemControl;
+}

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at?: string;
+  updated_by?: string;
+  reason?: string;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,50 @@
+import express from 'express';
+import request from 'supertest';
+import systemControlsRouter from '../../src/routes/system-controls';
+import * as systemControlsService from '../../src/services/system-controls';
+
+jest.mock('../../src/services/system-controls');
+
+const app = express();
+app.use(express.json());
+app.use('/api/system-controls', systemControlsRouter);
+
+describe('GET /api/system-controls/:key', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return 200 and the control if found', async () => {
+    const mockControl = { key: 'vitana_did_you_know_enabled', enabled: true };
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(mockControl);
+
+    const response = await request(app).get('/api/system-controls/vitana_did_you_know_enabled');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockControl);
+    expect(systemControlsService.getSystemControl).toHaveBeenCalledWith('vitana_did_you_know_enabled');
+  });
+
+  it('should return 404 if control is not found', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(null);
+
+    const response = await request(app).get('/api/system-controls/missing_key');
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'System control not found' });
+  });
+
+  it('should handle errors and call next', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockRejectedValue(new Error('Internal error'));
+
+    // Provide a simple error handler
+    app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
+      res.status(500).json({ error: err.message });
+    });
+
+    const response = await request(app).get('/api/system-controls/error_key');
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: 'Internal error' });
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,52 @@
+import { getSystemControl } from '../src/services/system-controls';
+import { supabase } from '../src/lib/supabase';
+
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+describe('System Controls Service', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return a system control when found', async () => {
+    const mockData = { key: 'vitana_did_you_know_enabled', enabled: true };
+    const mockEq = jest.fn().mockReturnThis();
+    const mockSingle = jest.fn().mockResolvedValue({ data: mockData, error: null });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq, single: mockSingle });
+
+    (supabase.from as jest.Mock).mockReturnValue({ select: mockSelect });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+
+    expect(supabase.from).toHaveBeenCalledWith('system_controls');
+    expect(mockSelect).toHaveBeenCalledWith('*');
+    expect(mockEq).toHaveBeenCalledWith('key', 'vitana_did_you_know_enabled');
+    expect(result).toEqual(mockData);
+  });
+
+  it('should return null when not found (PGRST116)', async () => {
+    const mockEq = jest.fn().mockReturnThis();
+    const mockSingle = jest.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq, single: mockSingle });
+
+    (supabase.from as jest.Mock).mockReturnValue({ select: mockSelect });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+
+    expect(result).toBeNull();
+  });
+
+  it('should throw an error on other errors', async () => {
+    const mockEq = jest.fn().mockReturnThis();
+    const mockSingle = jest.fn().mockResolvedValue({ data: null, error: { message: 'DB Error' } });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq, single: mockSingle });
+
+    (supabase.from as jest.Mock).mockReturnValue({ select: mockSelect });
+
+    await expect(getSystemControl('vitana_did_you_know_enabled')).rejects.toThrow('Failed to fetch system control: DB Error');
+  });
+});


### PR DESCRIPTION
This PR exposes the `public.system_controls` table via a new API endpoint in the gateway. This enables clients to fetch flags, such as `vitana_did_you_know_enabled`, which was recently enabled in the backend migrations but not yet readable by the frontend.

**Changes:**
- Created `SystemControl` type definition.
- Added `getSystemControl` service to interact with Supabase and fetch by key.
- Created `GET /api/system-controls/:key` express route to serve the data.
- Added corresponding unit tests for the service and the route.

**NOTE TO OPERATOR:** The plan requested updating the `command-hub` frontend to consume this new endpoint (`services/gateway/src/frontend/command-hub/...`). Because the specific file wasn't provided in the locked file list (and wasn't determinable from the plan), I have excluded it to respect the hard boundary constraint. Please follow up in a separate commit to integrate the frontend changes!