### PR TITLE
DEV-AUTOPILOT: Enforce auth for telemetry routes modifying oasis_events

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,7 +1,8 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
 
@@ -24,9 +25,38 @@ const TelemetryEventSchema = z.object({
 
 type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
+// Auth middleware to protect write operations
+export const requireAuth = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    let token: string | undefined;
+
+    const authHeader = req.headers.authorization;
+    if (authHeader && authHeader.startsWith("Bearer ")) {
+      token = authHeader.substring(7);
+    } else if ((req as any).cookies) {
+      token = (req as any).cookies["sb-access-token"] || (req as any).cookies["supabase-auth-token"];
+    }
+
+    if (!token) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    const { data, error } = await supabase.auth.getUser(token);
+    
+    if (error || !data?.user) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    next();
+  } catch (err: any) {
+    console.error("Auth middleware error:", err);
+    return res.status(500).json({ error: "Internal server error" });
+  }
+};
+
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +176,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,123 @@
+import request from "supertest";
+import express from "express";
+import { router } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+// Mock supabase client
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn()
+    }
+  }
+}));
+
+// Mock devhub broadcastEvent
+jest.mock("../../src/routes/devhub", () => ({
+  broadcastEvent: jest.fn()
+}));
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1/telemetry", router);
+
+describe("Telemetry Routes Authentication", () => {
+  let originalFetch: typeof global.fetch;
+
+  beforeAll(() => {
+    originalFetch = global.fetch;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SUPABASE_URL = "http://localhost:8000";
+    process.env.SUPABASE_SERVICE_ROLE = "test-service-key";
+    
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+      text: async () => ""
+    });
+  });
+
+  describe("Authentication Enforcement", () => {
+    const validEvent = {
+      vtid: "test-vtid",
+      layer: "test-layer",
+      module: "test-module",
+      source: "test-source",
+      kind: "test-kind",
+      status: "success",
+      title: "test-title"
+    };
+
+    it("POST /event should return 401 when missing token", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validEvent);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("POST /event should return 401 when token is invalid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: null },
+        error: new Error("Invalid token")
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validEvent);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("POST /event should proceed and return 202 when authenticated", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send(validEvent);
+
+      expect(res.status).toBe(202);
+      expect(global.fetch).toHaveBeenCalled();
+    });
+
+    it("POST /batch should return 401 when missing token", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send([validEvent]);
+
+      expect(res.status).toBe(401);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("POST /batch should proceed and return 202 when authenticated", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-token")
+        .send([validEvent]);
+
+      expect(res.status).toBe(202);
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses the security gap identified in `oasis_events` writes via the telemetry API (`rls_gap`). Since the automated execution scope forbids modifying database migrations to enable Row-Level Security directly, this PR introduces application-level authentication checks to close the vulnerability.

The `requireAuth` middleware has been added to extract the Supabase session token from the `Authorization` header or cookies. This middleware is applied to the `POST /event` and `POST /batch` endpoints, rejecting unauthenticated requests with HTTP `401 Unauthorized`. This ensures that only verified requests can write to the `oasis_events` table. 

**Note for operators:** The database-level RLS migration for `oasis_events` (enabling RLS and adding policies) must be applied manually by the developer, as modifying `supabase/migrations/` is out of scope for automated execution.

Files touched:
- `services/gateway/src/routes/telemetry.ts` (added middleware and protected endpoints)
- `services/gateway/test/routes/telemetry.test.ts` (added auth enforcement unit tests)