### PR TITLE
DEV-AUTOPILOT: Implement paramLimit middleware to mitigate ReDoS CVE

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,42 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // 1. Validate route parameters if already parsed by Express inline
+    const params = req.params || {};
+    const keys = Object.keys(params);
+
+    if (keys.length > maxParams) {
+      res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    for (const key of keys) {
+      const val = params[key];
+      if (typeof val === 'string' && val.length > maxLength) {
+        res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    // 2. Validate raw path segments (Mitigates ReDoS before route matching)
+    // This is crucial because standard router-level middleware executes before req.params 
+    // are fully populated by the specific route handler. req.path drops the query string.
+    const segments = req.path.split('/').filter(Boolean);
+    
+    // Count heuristic: allow a small buffer (+2) for structural base route segments
+    if (segments.length > maxParams + 2) {
+      res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    for (const segment of segments) {
+      if (segment.length > maxLength) {
+        res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply param limits to mitigate ReDoS vulnerability
+router.use(limitPathParams(5, 200));
+
+router.get('/:projectId', (req: Request, res: Response) => {
+  res.status(200).json({ projectId: req.params.projectId });
+});
+
+router.get('/:projectId/settings', (req: Request, res: Response) => {
+  res.status(200).json({ projectId: req.params.projectId, settings: true });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply param limits to mitigate ReDoS vulnerability
+router.use(limitPathParams());
+
+router.get('/:id', (req: Request, res: Response) => {
+  res.status(200).json({ id: req.params.id });
+});
+
+router.get('/:id/profile', (req: Request, res: Response) => {
+  res.status(200).json({ id: req.params.id, profile: true });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,80 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+import userRoutes from '../src/routes/v1/userRoutes';
+import projectRoutes from '../src/routes/v1/projectRoutes';
+
+describe('CVE Mitigation - ReDoS in path parameters', () => {
+  let app: express.Express;
+
+  beforeAll(() => {
+    app = express();
+    
+    // Mount standard routers
+    app.use('/v1/users', userRoutes);
+    app.use('/v1/projects', projectRoutes);
+
+    // Mount a direct test route to specifically verify inline req.params limits
+    app.get('/resource/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.status(200).json({ message: 'Success', params: req.params });
+    });
+    
+    app.get('/resource/:a/:b', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.status(200).json({ message: 'Success' });
+    });
+  });
+
+  describe('Unit Test: paramLimit middleware directly', () => {
+    it('should return 400 when >5 path parameters exist in the route', async () => {
+      const res = await request(app).get('/resource/1/2/3/4/5/6');
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    });
+
+    it('should return 400 when a path parameter length > 200', async () => {
+      const longParam = 'a'.repeat(201);
+      const res = await request(app).get(`/resource/1/${longParam}`);
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    });
+
+    it('should pass normally when parameters are within limits', async () => {
+      const res = await request(app).get('/resource/1/2');
+      expect(res.status).toBe(200);
+      expect(res.body.message).toBe('Success');
+    });
+  });
+
+  describe('Integration Test: Gateway Routes', () => {
+    it('prevents ReDoS payload by rejecting deep paths extremely fast', async () => {
+      // Pathological payload simulating ReDoS attempt
+      const pathologicalPath = `/v1/users/${'a'.repeat(50)}/${'b'.repeat(50)}/${'c'.repeat(50)}/${'d'.repeat(50)}/${'e'.repeat(50)}/${'f'.repeat(50)}`;
+      
+      const start = Date.now();
+      const res = await request(app).get(pathologicalPath);
+      const duration = Date.now() - start;
+
+      // Fails due to too many parameter segments
+      expect(res.status).toBe(400);
+      expect(duration).toBeLessThan(200);
+    });
+
+    it('prevents ReDoS payload by rejecting excessively long segments fast', async () => {
+      const longSegment = 'x'.repeat(250);
+      
+      const start = Date.now();
+      const res = await request(app).get(`/v1/projects/${longSegment}`);
+      const duration = Date.now() - start;
+
+      // Fails due to length constraint
+      expect(res.status).toBe(400);
+      expect(duration).toBeLessThan(200);
+    });
+
+    it('allows normal requests to standard routers', async () => {
+      const res = await request(app).get('/v1/users/123');
+      expect(res.status).toBe(200);
+      expect(res.body.id).toBe('123');
+    });
+  });
+});


### PR DESCRIPTION
### Description
Implements server-side validation middleware to mitigate a Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (<0.1.13) used transitively by Express. Attackers could craft requests with numerous or exceptionally long route parameters to trigger catastrophic backtracking, causing CPU exhaustion.

By capping the maximum number of path parameters (default 5) and the length of each parameter string (default 200 chars), we prevent the exponential backtracking and effectively close the attack vector on the Gateway level.

### Changes Included
- **`services/gateway/src/routes/middleware/paramLimit.ts`**: New Express middleware. Parses `req.params` and raw path segments to block oversized or overly deep requests before complex regex evaluation can occur.
- **`services/gateway/src/routes/v1/userRoutes.ts`**: Applies the middleware.
- **`services/gateway/src/routes/v1/projectRoutes.ts`**: Applies the middleware.
- **`services/gateway/test/cve-mitigation.test.ts`**: Adds unit & integration tests verifying `<200ms` rejection of payload strings mimicking a ReDoS attempt.

**Note to operator**: Please ensure that any other route files under `services/gateway/src/routes/` containing path parameters also apply this middleware, as this PR updates the candidate examples specified in the plan.