### PR TITLE
DEV-AUTOPILOT: Add auth enforcement to telemetry endpoints for oasis_events

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,7 +1,8 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
 
@@ -24,9 +25,39 @@ const TelemetryEventSchema = z.object({
 
 type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
+const requireAuthenticatedUser = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      return res.status(401).json({
+        error: "Unauthorized",
+        detail: "Missing or invalid Authorization header",
+      });
+    }
+
+    const token = authHeader.split(" ")[1];
+    const { data, error } = await supabase.auth.getUser(token);
+
+    if (error || !data?.user) {
+      return res.status(401).json({
+        error: "Unauthorized",
+        detail: "Invalid session token",
+      });
+    }
+
+    return next();
+  } catch (err: any) {
+    console.error("Auth middleware error:", err);
+    return res.status(500).json({
+      error: "Internal server error during authentication",
+      detail: err.message,
+    });
+  }
+};
+
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +177,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,156 @@
+import request from "supertest";
+import express from "express";
+import { router } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+// Mock the Supabase client
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+// Mock devhub to avoid dependency issues during tests
+jest.mock("../../src/routes/devhub", () => ({
+  broadcastEvent: jest.fn(),
+}), { virtual: true });
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1/telemetry", router);
+
+describe("Telemetry Routes Authentication", () => {
+  let originalFetch: typeof global.fetch;
+
+  beforeAll(() => {
+    originalFetch = global.fetch;
+    process.env.SUPABASE_URL = "https://mock.supabase.co";
+    process.env.SUPABASE_SERVICE_ROLE = "mock-service-key";
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_ROLE;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    // Mock global fetch used for OASIS persistence
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+      text: async () => (""),
+    } as any);
+  });
+
+  describe("POST /api/v1/telemetry/event", () => {
+    const validPayload = {
+      vtid: "VTID-123",
+      layer: "test-layer",
+      module: "test-module",
+      source: "test-source",
+      kind: "test.kind",
+      status: "success",
+      title: "Test Event"
+    };
+
+    it("should return 401 if no Authorization header is provided", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validPayload);
+
+      expect(res.status).toBe(401);
+      expect(res.body).toHaveProperty("error", "Unauthorized");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should return 401 if session token is invalid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: { message: "Invalid token" },
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validPayload);
+
+      expect(res.status).toBe(401);
+      expect(res.body).toHaveProperty("error", "Unauthorized");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should proceed and return 202 if valid session token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send(validPayload);
+
+      expect(res.status).toBe(202);
+      expect(res.body).toHaveProperty("ok", true);
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    const validPayload = [{
+      vtid: "VTID-123",
+      layer: "test-layer",
+      module: "test-module",
+      source: "test-source",
+      kind: "test.kind",
+      status: "success",
+      title: "Test Batch Event"
+    }];
+
+    it("should return 401 if no Authorization header is provided", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send(validPayload);
+
+      expect(res.status).toBe(401);
+      expect(res.body).toHaveProperty("error", "Unauthorized");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should return 401 if session token is invalid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: { message: "Invalid token" },
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validPayload);
+
+      expect(res.status).toBe(401);
+      expect(res.body).toHaveProperty("error", "Unauthorized");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should proceed and return 202 if valid session token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-token")
+        .send(validPayload);
+
+      expect(res.status).toBe(202);
+      expect(res.body).toHaveProperty("ok", true);
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Addresses a medium-risk `rls_gap` identified by `rls-policy-scanner-v1` on the `oasis_events` table. 

This PR implements application-level authentication checks on the `/event` and `/batch` telemetry endpoints (which mutate the `oasis_events` table). It ensures that any request reaching these routes provides a valid Supabase session token in the `Authorization: Bearer <token>` header, verified against `supabase.auth.getUser()`. Unauthorized requests are proactively rejected with HTTP 401.

**Note to Operator:** 
The automated executor is scoped to application code and cannot modify files under `supabase/migrations/`. **You must manually create the database migration to enable RLS on `oasis_events`.** 
Please add a new migration (e.g., `supabase/migrations/20251215000000_enable_rls_oasis_events.sql`) with the following logic:

```sql
ALTER TABLE public.oasis_events ENABLE ROW LEVEL SECURITY;
CREATE POLICY "allow_authenticated_insert" ON public.oasis_events
 FOR INSERT TO authenticated WITH CHECK (true);
CREATE POLICY "allow_authenticated_update" ON public.oasis_events
 FOR UPDATE TO authenticated USING (true);
REVOKE INSERT, UPDATE ON public.oasis_events FROM anon, public;
```

Files modified/created:
- `services/gateway/src/routes/telemetry.ts` (added `requireAuthenticatedUser` middleware)
- `services/gateway/test/routes/telemetry.test.ts` (added test coverage for authenticated access)