### PR TITLE
DEV-AUTOPILOT: Refactor admin notification categories to use requireAdmin

### DIFF
--- a/services/gateway/src/routes/admin-notification-categories.ts
+++ b/services/gateway/src/routes/admin-notification-categories.ts
@@ -11,55 +11,20 @@
  * - POST   /:id/test      — Send test notification to admin
  *
  * Security:
- * - All endpoints are protected by the `requireExafyAdmin` middleware.
+ * - All endpoints are protected by the `requireAdmin` middleware.
  */
 
-import { Router, Request, Response, NextFunction } from 'express';
+import { Router, Request, Response } from 'express';
 import { createClient } from '@supabase/supabase-js';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/requireAdmin';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIF-CATEGORIES';
 
 const VALID_TYPES = ['chat', 'calendar', 'community'];
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-// ── Auth Middleware ─────────────────────────────────────────
-
-async function requireExafyAdmin(req: Request, res: Response, next: NextFunction) {
-  const token = getBearerToken(req);
-  if (!token) return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) {
-      return res.status(401).json({ ok: false, error: 'INVALID_TOKEN' });
-    }
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return res.status(403).json({ ok: false, error: 'FORBIDDEN' });
-    }
-
-    // Attach user info to request for downstream handlers
-    (req as any).authUser = { user_id: authData.user.id, email: authData.user.email || 'unknown' };
-    next();
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
-  }
-}
-
-router.use(requireExafyAdmin);
+router.use(requireAdmin);
 
 // ── Supabase ────────────────────────────────────────────────
 
@@ -140,7 +105,7 @@ router.get('/:id', async (req: Request, res: Response) => {
 // ── POST / — Create category ───────────────────────────────
 
 router.post('/', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const user = (req as any).user;
 
   const supabase = getSupabase();
   const {
@@ -180,7 +145,7 @@ router.post('/', async (req: Request, res: Response) => {
     default_enabled: default_enabled ?? true,
     mapped_types: mapped_types || [],
     tenant_id: tenant_id || null,
-    created_by: authUser.user_id,
+    created_by: user?.id,
   };
 
   const { data, error } = await supabase
@@ -197,14 +162,14 @@ router.post('/', async (req: Request, res: Response) => {
     return res.status(500).json({ ok: false, error: error.message });
   }
 
-  console.log(`[${VTID}] Created category "${slug}" (${type}) by ${authUser.email}`);
+  console.log(`[${VTID}] Created category "${slug}" (${type}) by ${user?.email ?? 'unknown'}`);
   return res.status(201).json({ ok: true, data });
 });
 
 // ── PATCH /:id — Update category ────────────────────────────
 
 router.patch('/:id', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const user = (req as any).user;
 
   const supabase = getSupabase();
   const allowedFields = ['display_name', 'description', 'icon', 'sort_order', 'is_active', 'default_enabled', 'mapped_types'];
@@ -236,14 +201,14 @@ router.patch('/:id', async (req: Request, res: Response) => {
     return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
   }
 
-  console.log(`[${VTID}] Updated category "${data.slug}" by ${authUser.email}`);
+  console.log(`[${VTID}] Updated category "${data.slug}" by ${user?.email ?? 'unknown'}`);
   return res.json({ ok: true, data });
 });
 
 // ── DELETE /:id — Soft-delete (set is_active=false) ─────────
 
 router.delete('/:id', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const user = (req as any).user;
 
   const supabase = getSupabase();
   const { data, error } = await supabase
@@ -261,14 +226,14 @@ router.delete('/:id', async (req: Request, res: Response) => {
     return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
   }
 
-  console.log(`[${VTID}] Soft-deleted category "${data.slug}" by ${authUser.email}`);
+  console.log(`[${VTID}] Soft-deleted category "${data.slug}" by ${user?.email ?? 'unknown'}`);
   return res.json({ ok: true, data });
 });
 
 // ── POST /:id/test — Send test notification to admin ────────
 
 router.post('/:id/test', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const user = (req as any).user;
 
   const supabase = getSupabase();
 
@@ -296,15 +261,15 @@ router.post('/:id/test', async (req: Request, res: Response) => {
   const { data: tenantRow } = await supabase
     .from('user_tenants')
     .select('tenant_id')
-    .eq('user_id', authUser.user_id)
+    .eq('user_id', user?.id)
     .limit(1)
     .single();
 
   const tenantId = tenantRow?.tenant_id || '00000000-0000-0000-0000-000000000000';
 
   try {
-    const result = await notifyUser(authUser.user_id, tenantId, testType, payload, supabase);
-    console.log(`[${VTID}] Test notification sent for category "${category.slug}" by ${authUser.email}`);
+    const result = await notifyUser(user?.id, tenantId, testType, payload, supabase);
+    console.log(`[${VTID}] Test notification sent for category "${category.slug}" by ${user?.email ?? 'unknown'}`);
     return res.json({ ok: true, result });
   } catch (err: any) {
     console.error(`[${VTID}] POST /:id/test error:`, err.message);

--- a/services/gateway/tests/admin-notification-categories.test.ts
+++ b/services/gateway/tests/admin-notification-categories.test.ts
@@ -1,0 +1,106 @@
+import request from 'supertest';
+import express from 'express';
+import adminNotificationCategoriesRouter from '../src/routes/admin-notification-categories';
+
+// Mock requireAdmin middleware
+jest.mock('../src/middleware/requireAdmin', () => ({
+  requireAdmin: (req: any, res: any, next: any) => {
+    const authHeader = req.headers.authorization;
+    if (!authHeader) {
+      return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+    }
+    if (authHeader === 'Bearer non-admin') {
+      return res.status(403).json({ ok: false, error: 'FORBIDDEN' });
+    }
+    if (authHeader === 'Bearer admin') {
+      req.user = { id: 'admin-id', email: 'admin@example.com' };
+      return next();
+    }
+    return res.status(401).json({ ok: false, error: 'INVALID_TOKEN' });
+  }
+}));
+
+// Mock Supabase
+jest.mock('@supabase/supabase-js', () => {
+  const mockQuery: any = {
+    from: jest.fn().mockReturnThis(),
+    select: jest.fn().mockReturnThis(),
+    insert: jest.fn().mockReturnThis(),
+    update: jest.fn().mockReturnThis(),
+    eq: jest.fn().mockReturnThis(),
+    or: jest.fn().mockReturnThis(),
+    is: jest.fn().mockReturnThis(),
+    order: jest.fn().mockReturnThis(),
+    limit: jest.fn().mockReturnThis(),
+    single: jest.fn().mockResolvedValue({ data: null, error: null }),
+  };
+  
+  // Make the mock object itself thenable so we can await the chain
+  mockQuery.then = jest.fn((resolve) => {
+    resolve({ data: [], error: null });
+  });
+
+  return {
+    createClient: jest.fn(() => mockQuery)
+  };
+});
+
+// Mock Notification Service
+jest.mock('../src/services/notification-service', () => ({
+  notifyUser: jest.fn().mockResolvedValue({ success: true })
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/admin/notification-categories', adminNotificationCategoriesRouter);
+
+describe('Admin Notification Categories API - Auth Boundary', () => {
+  it('should return 401 UNAUTHENTICATED when no token is provided', async () => {
+    const response = await request(app).get('/admin/notification-categories');
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({ ok: false, error: 'UNAUTHENTICATED' });
+  });
+
+  it('should return 403 FORBIDDEN when an authenticated non-admin token is provided', async () => {
+    const response = await request(app)
+      .get('/admin/notification-categories')
+      .set('Authorization', 'Bearer non-admin');
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({ ok: false, error: 'FORBIDDEN' });
+  });
+
+  it('should return 200 on GET / when an admin token is provided', async () => {
+    const { createClient } = require('@supabase/supabase-js');
+    const mockSupabase = createClient();
+    
+    mockSupabase.then.mockImplementationOnce((resolve: any) => 
+      resolve({ data: [{ id: '1', type: 'chat', display_name: 'Chat Notifs' }], error: null })
+    );
+
+    const response = await request(app)
+      .get('/admin/notification-categories')
+      .set('Authorization', 'Bearer admin');
+    
+    expect(response.status).toBe(200);
+    expect(response.body.ok).toBe(true);
+    expect(response.body.data).toHaveProperty('chat');
+  });
+
+  it('should return 201 on POST / when an admin token is provided', async () => {
+    const { createClient } = require('@supabase/supabase-js');
+    const mockSupabase = createClient();
+    
+    mockSupabase.single.mockResolvedValueOnce({
+      data: { id: '2', type: 'chat', slug: 'test_chat' },
+      error: null
+    });
+
+    const response = await request(app)
+      .post('/admin/notification-categories')
+      .set('Authorization', 'Bearer admin')
+      .send({ type: 'chat', display_name: 'Test Chat' });
+    
+    expect(response.status).toBe(201);
+    expect(response.body.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
This PR addresses the `route-auth-scanner-v1` finding regarding non-standard authentication patterns. 

The inline `requireExafyAdmin` and `getBearerToken` helpers have been removed in favor of the standardized `requireAdmin` middleware. This makes the authorization declarative, recognizable by the security scanner, and consistent with other admin endpoints. 

**Files touched:**
- `services/gateway/src/routes/admin-notification-categories.ts`: Removed inline auth logic and replaced with `router.use(requireAdmin)`. Swapped `req.authUser` reads to use the standard `req.user` payload.
- `services/gateway/tests/admin-notification-categories.test.ts`: Created new test suite to cover the authentication boundary (401, 403, and successful 200/201 responses).