### PR TITLE
DEV-AUTOPILOT: Secure telemetry routes with auth middleware

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,7 +1,8 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
 
@@ -24,9 +25,31 @@ const TelemetryEventSchema = z.object({
 
 type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
+// Auth middleware to enforce authenticated writes to oasis_events
+const requireAuth = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.toLowerCase().startsWith("bearer ")) {
+      return res.status(401).json({ error: "Unauthorized", detail: "Missing or invalid Authorization header" });
+    }
+
+    const token = authHeader.substring(7);
+    const { data, error } = await supabase.auth.getUser(token);
+
+    if (error || !data?.user) {
+      return res.status(401).json({ error: "Unauthorized", detail: "Invalid or expired token" });
+    }
+
+    next();
+  } catch (e: any) {
+    console.error("❌ Auth middleware error:", e);
+    return res.status(500).json({ error: "Internal server error", detail: "Auth verification failed" });
+  }
+};
+
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +169,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,142 @@
+import request from "supertest";
+import express from "express";
+import { router } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+// Mock devhub to prevent side effects during testing
+jest.mock("../../src/routes/devhub", () => ({
+  broadcastEvent: jest.fn(),
+}));
+
+// Mock supabase client to intercept and fake auth calls
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+describe("Telemetry Routes Auth Restrictions", () => {
+  let app: express.Application;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    // Mount router in exact path matching actual execution
+    app.use("/api/v1/telemetry", router);
+
+    process.env.SUPABASE_URL = "http://localhost:8000";
+    process.env.SUPABASE_SERVICE_ROLE = "test-service-key";
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    
+    // Mock global fetch returning ok by default for oasis_events insertions
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve({}),
+        text: () => Promise.resolve(""),
+      } as any)
+    );
+  });
+
+  const validEventPayload = {
+    vtid: "VTID-1234",
+    layer: "gateway",
+    module: "telemetry",
+    source: "test-source",
+    kind: "test.kind",
+    status: "success",
+    title: "Test Event"
+  };
+
+  describe("POST /api/v1/telemetry/event", () => {
+    it("returns 401 when Authorization header is missing", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validEventPayload);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("returns 401 when token is invalid or expired", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: new Error("Token expired"),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validEventPayload);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("returns 202 when authenticated and payload is valid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "test-user-id" } },
+        error: null,
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send(validEventPayload);
+
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    it("returns 401 when Authorization header is missing", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send([validEventPayload]);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("returns 401 when token is invalid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: new Error("Bad token"),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer bad-token")
+        .send([validEventPayload]);
+
+      expect(res.status).toBe(401);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("returns 202 when authenticated and payload is valid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "test-user-id" } },
+        error: null,
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-token")
+        .send([validEventPayload]);
+
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
**Summary:**
This PR adds application-level authentication middleware to the telemetry APIs (`POST /api/v1/telemetry/event` and `POST /api/v1/telemetry/batch`) to prevent unauthorized writes to the `oasis_events` table. 

**Reasoning:**
The `oasis_events` table currently lacks database-level Row-Level Security (RLS) policies blocking anonymous users (flagged as `rls_gap`). While the migration to enable RLS must be applied manually to avoid violating strict automated deployment constraints for `supabase/migrations/`, this PR temporarily closes the gap at the API layer. The telemetry handlers will now verify the presence of a valid Supabase `Authorization` bearer token before processing `INSERT`s.

**Changes:**
- Extracted and implemented an auth check middleware `requireAuth` using `supabase.auth.getUser()`.
- Applied `requireAuth` to all telemetry routes that perform writes (`/event` and `/batch`).
- Added a full Jest test suite verifying 401 rejections on unauthorized calls and 202 acceptance on authenticated ones.