### PR TITLE
DEV-AUTOPILOT: Enforce auth middleware on telemetry event routes

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,33 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+// Middleware to enforce authentication
+const requireAuth = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      res.status(401).json({ error: "Unauthorized", detail: "Missing or invalid authorization header" });
+      return;
+    }
+    
+    const token = authHeader.split(" ")[1];
+    const { data, error } = await supabase.auth.getUser(token);
+    
+    if (error || !data?.user) {
+      res.status(401).json({ error: "Unauthorized", detail: "Invalid session token" });
+      return;
+    }
+    
+    next();
+  } catch (e: any) {
+    res.status(401).json({ error: "Unauthorized", detail: "Token verification failed" });
+  }
+};
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +50,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +170,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,136 @@
+import express from "express";
+import request from "supertest";
+import { router } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+// Mock devhub to prevent require errors during testing if needed
+jest.mock("../../src/routes/devhub", () => ({
+  broadcastEvent: jest.fn(),
+}), { virtual: true });
+
+describe("Telemetry Routes Auth Enforcement", () => {
+  let app: express.Application;
+  
+  beforeEach(() => {
+    jest.clearAllMocks();
+    app = express();
+    app.use(express.json());
+    app.use("/api/v1/telemetry", router);
+    global.fetch = jest.fn();
+    
+    process.env.SUPABASE_URL = "http://localhost";
+    process.env.SUPABASE_SERVICE_ROLE = "test-svc-key";
+  });
+
+  const validEventPayload = {
+    vtid: "VT-123",
+    layer: "app",
+    module: "core",
+    source: "test",
+    kind: "test.event",
+    status: "success",
+    title: "Test Event"
+  };
+
+  describe("POST /api/v1/telemetry/event", () => {
+    it("returns 401 when no token is provided", async () => {
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validEventPayload);
+        
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe("Unauthorized");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("returns 401 when an invalid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({ 
+        data: { user: null }, 
+        error: new Error("invalid token") 
+      });
+      
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validEventPayload);
+        
+      expect(response.status).toBe(401);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("proceeds with a valid token and returns 202 on successful persistence", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({ 
+        data: { user: { id: "user-123" } }, 
+        error: null 
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send(validEventPayload);
+
+      expect(response.status).toBe(202);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("valid-token");
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    it("returns 401 when no token is provided", async () => {
+      const response = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send([validEventPayload]);
+        
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe("Unauthorized");
+    });
+
+    it("returns 401 when an invalid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({ 
+        data: { user: null }, 
+        error: new Error("invalid token") 
+      });
+      
+      const response = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer invalid-token")
+        .send([validEventPayload]);
+        
+      expect(response.status).toBe(401);
+    });
+
+    it("proceeds with a valid token and returns 202 on successful persistence", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({ 
+        data: { user: { id: "user-123" } }, 
+        error: null 
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-token")
+        .send([validEventPayload]);
+
+      expect(response.status).toBe(202);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("valid-token");
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
**Summary:**
This PR adds application-layer auth checks to the telemetry API routes to address a medium-risk RLS gap (`rls_gap`) flagged on the `oasis_events` table. 

**Details:**
1. Created an Express middleware `requireAuth` that intercepts requests to `/event` and `/batch` telemetry endpoints.
2. The middleware enforces that requests include a valid `Authorization: Bearer <token>` header, verifying it securely using `supabase.auth.getUser()`.
3. Requests with missing or invalid tokens are denied early with an HTTP `401 Unauthorized` response, preventing unauthorized writes to `oasis_events` that bypass API security logic.
4. `GET /health` and `GET /snapshot` endpoints are left unchanged as they do not perform data modification tasks.
5. Implemented comprehensive test coverage ensuring robust token validation handling and preserving the success-path expected logic.

*(Note: The database-layer RLS policy migration must be run independently as an out-of-scope manual step to harden the infrastructure against direct database connections.)*

**Files modified:**
- `services/gateway/src/routes/telemetry.ts`
- `services/gateway/test/routes/telemetry.test.ts`