### PR TITLE
DEV-AUTOPILOT: Refactor admin-notifications to use shared requireAdmin middleware

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -12,49 +12,17 @@
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/auth';
 
 const router = Router();
+router.use(requireAdmin);
+
 const VTID = 'ADMIN-NOTIFICATIONS';
-
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
 
 // ── POST /compose — Send notification to user(s) ────────────
 
 router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -148,7 +116,7 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      console.log(`[${VTID}] Composed notification for 1 user by ${(req as any).user?.email}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +129,7 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${(req as any).user?.email}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -177,9 +145,6 @@ router.post('/compose', async (req: Request, res: Response) => {
 // ── GET /sent — Admin notification log ──────────────────────
 
 router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -224,9 +189,6 @@ router.get('/sent', async (req: Request, res: Response) => {
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
 router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,142 @@
+import request from 'supertest';
+import express from 'express';
+import adminNotificationsRouter from '../../src/routes/admin-notifications';
+import { getSupabase } from '../../src/lib/supabase';
+import { notifyUser, notifyUsersAsync } from '../../src/services/notification-service';
+
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn()
+}));
+
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn(),
+  notifyUsersAsync: jest.fn()
+}));
+
+jest.mock('../../src/middleware/auth', () => ({
+  requireAdmin: jest.fn((req, res, next) => {
+    (req as any).user = { id: 'admin-id', email: 'admin@test.com' };
+    next();
+  })
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/admin/notifications', adminNotificationsRouter);
+
+describe('Admin Notifications Routes', () => {
+  let mockSupabase: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockSupabase = {
+      from: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      range: jest.fn().mockReturnThis(),
+      or: jest.fn().mockReturnThis(),
+      not: jest.fn().mockReturnThis(),
+      then: jest.fn((resolve) => resolve({ data: [], error: null, count: 0 }))
+    };
+    (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+  });
+
+  describe('POST /compose', () => {
+    it('returns 400 if title or body is missing', async () => {
+      const res = await request(app).post('/admin/notifications/compose').send({
+        recipient_ids: ['user1']
+      });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('INVALID_INPUT');
+    });
+
+    it('returns 400 if no recipient criteria is provided', async () => {
+      const res = await request(app).post('/admin/notifications/compose').send({
+        title: 'Hello',
+        body: 'World'
+      });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('INVALID_INPUT');
+    });
+
+    it('sends notification to single user', async () => {
+      (notifyUser as jest.Mock).mockResolvedValue({ success: true });
+      const res = await request(app).post('/admin/notifications/compose').send({
+        title: 'Hello',
+        body: 'World',
+        recipient_ids: ['user1']
+      });
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(notifyUser).toHaveBeenCalledWith(
+        'user1',
+        '',
+        'welcome_to_vitana',
+        { title: 'Hello', body: 'World', data: undefined },
+        mockSupabase
+      );
+    });
+
+    it('sends notification to multiple users via role', async () => {
+      mockSupabase.then = jest.fn((resolve) => resolve({
+        data: [{ user_id: 'user1' }, { user_id: 'user2' }],
+        error: null
+      }));
+
+      const res = await request(app).post('/admin/notifications/compose').send({
+        title: 'Hello',
+        body: 'World',
+        recipient_role: 'member',
+        tenant_id: 't1'
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.sent_to).toBe(2);
+      expect(notifyUsersAsync).toHaveBeenCalledWith(
+        ['user1', 'user2'],
+        't1',
+        'welcome_to_vitana',
+        { title: 'Hello', body: 'World', data: undefined },
+        mockSupabase
+      );
+    });
+  });
+
+  describe('GET /sent', () => {
+    it('returns sent notifications', async () => {
+      mockSupabase.then = jest.fn((resolve) => resolve({
+        data: [{ id: 'notif1' }],
+        count: 1,
+        error: null
+      }));
+
+      const res = await request(app).get('/admin/notifications/sent');
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.data).toEqual([{ id: 'notif1' }]);
+      expect(res.body.total).toBe(1);
+    });
+  });
+
+  describe('GET /preferences/stats', () => {
+    it('returns preferences stats', async () => {
+      mockSupabase.then = jest.fn()
+        .mockImplementationOnce((resolve) => resolve({
+          data: [{ push_enabled: true }, { push_enabled: false }],
+          error: null
+        }))
+        .mockImplementationOnce((resolve) => resolve({ count: 10, error: null }))
+        .mockImplementationOnce((resolve) => resolve({ count: 5, error: null }));
+      
+      const res = await request(app).get('/admin/notifications/preferences/stats');
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.stats.total_users_with_prefs).toBe(2);
+      expect(res.body.delivery.total_sent_30d).toBe(10);
+      expect(res.body.delivery.total_read_30d).toBe(5);
+    });
+  });
+});


### PR DESCRIPTION
**Context**
The scanner `route-auth-scanner-v1` flagged `admin-notifications.ts` for using an inline authentication function rather than standard middleware. This inconsistency creates a maintenance burden.

**Changes made**
1. Removed inline `verifyExafyAdmin` and `getBearerToken` helper functions.
2. Removed manual invocation of auth checks inside handlers.
3. Added `router.use(requireAdmin)` using the standard shared authentication middleware.
4. Converted usage of `authResult.email` to directly access `(req as any).user?.email`.
5. Created unit tests ensuring endpoint correctness and mocking the new shared middleware properly.

**Files touched**
- `services/gateway/src/routes/admin-notifications.ts`
- `services/gateway/test/routes/admin-notifications.test.ts`