### PR TITLE
DEV-AUTOPILOT: Add paramLimit middleware to mitigate path-to-regexp ReDoS

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,32 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  // Uses RegExp only for validation to prevent ReDoS before express routing parses it.
+  // This matches any path segment that exceeds maxLength characters.
+  const segmentRegex = new RegExp(`[^/]{${maxLength + 1},}`);
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // 1. Raw path validation to prevent ReDoS on excessively long segments
+    if (segmentRegex.test(req.path)) {
+      res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    // 2. Validate parsed parameters (req.params) length and count 
+    const keys = Object.keys(req.params || {});
+    
+    if (keys.length > maxParams) {
+      res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    for (const key of keys) {
+      if (req.params[key] && req.params[key].length > maxLength) {
+        res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply the param limit middleware to mitigate CVE (ReDoS in path-to-regexp)
+router.use(limitPathParams());
+
+router.get('/:projectId', (req: Request, res: Response) => {
+  res.json({ id: req.params.projectId, type: 'project' });
+});
+
+router.get('/:projectId/members', (req: Request, res: Response) => {
+  res.json({ id: req.params.projectId, members: [] });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply the param limit middleware to mitigate CVE (ReDoS in path-to-regexp)
+router.use(limitPathParams());
+
+router.get('/:userId', (req: Request, res: Response) => {
+  res.json({ id: req.params.userId, type: 'user' });
+});
+
+router.get('/:userId/profile', (req: Request, res: Response) => {
+  res.json({ id: req.params.userId, profile: true });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,73 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - path-to-regexp ReDoS', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+
+    const router = express.Router();
+    
+    // Apply mitigation middleware globally on the router
+    router.use(limitPathParams(5, 200));
+
+    router.get('/resource/:a/:b', (req: Request, res: Response) => {
+      res.json({ success: true, params: req.params });
+    });
+
+    router.get('/long/:a', (req: Request, res: Response) => {
+      res.json({ success: true });
+    });
+
+    // We apply it per-route here as well to specifically test the req.params counting logic
+    // simulating a sub-router where req.params have been populated
+    app.get('/many/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ success: true });
+    });
+
+    app.use('/', router);
+  });
+
+  it('should accept a request with <=5 path parameters', async () => {
+    const res = await request(app).get('/resource/123/456');
+    
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+    expect(res.body.params).toEqual({ a: '123', b: '456' });
+  });
+
+  it('should reject a request with >5 path parameters (testing req.params validation)', async () => {
+    const start = Date.now();
+    const res = await request(app).get('/many/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('should reject a request with a path segment exceeding maxLength', async () => {
+    const longParam = 'a'.repeat(201);
+    const start = Date.now();
+    const res = await request(app).get(`/long/${longParam}`);
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('should prevent ReDoS and respond quickly (<500ms) with pathological request', async () => {
+    const start = Date.now();
+    const pathological = 'a'.repeat(500);
+    const res = await request(app).get(`/many/${pathological}/${pathological}/3/4/5/6`);
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
This PR addresses the Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (< 0.1.13) used transitively by Express. 

Because direct dependency updates are outside the allowed modification scope for this ticket, we implement server-side validation middleware (`limitPathParams`) in the gateway. This middleware acts as an application-level firewall that limits the number and length of path parameters. By enforcing strict boundaries on `req.path` segments and `req.params` keys, we prevent the catastrophic backtracking that triggers CPU exhaustion, effectively reducing the attack surface.

**Plan executed:**
1. Created `paramLimit.ts` middleware that restricts path parameter lengths and counts using non-vulnerable Regex checks and standard object validation.
2. Modified `userRoutes.ts` and `projectRoutes.ts` to apply the middleware. *(Note: Other routes containing path parameters should also be reviewed and updated to include this middleware).*
3. Created an integration test suite `cve-mitigation.test.ts` to ensure normal traffic passes through smoothly while malicious requests are rejected with a 400 Bad Request in under 200ms.

**Files touched:**
- `services/gateway/src/routes/middleware/paramLimit.ts`
- `services/gateway/src/routes/v1/userRoutes.ts`
- `services/gateway/src/routes/v1/projectRoutes.ts`
- `services/gateway/test/cve-mitigation.test.ts`