### PR TITLE
DEV-AUTOPILOT: Add system-controls gateway service and endpoint

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,19 @@
+import { Router } from 'express';
+import { getSystemControl } from '../services/system-controls';
+
+export const systemControlsRouter = Router();
+
+systemControlsRouter.get('/:key', async (req, res, next) => {
+  try {
+    const { key } = req.params;
+    const control = await getSystemControl(key);
+
+    if (!control) {
+      return res.status(404).json({ error: 'System control not found' });
+    }
+
+    return res.json(control);
+  } catch (error) {
+    next(error);
+  }
+});

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,20 @@
+import { supabase } from '../lib/supabase';
+import { SystemControl } from '../types/system-controls';
+
+export async function getSystemControl(key: string): Promise<SystemControl | null> {
+  const { data, error } = await supabase
+    .from('system_controls')
+    .select('*')
+    .eq('key', key)
+    .single();
+
+  if (error) {
+    // PGRST116 is the Postgres code for "Results contain 0 rows" on .single()
+    if (error.code === 'PGRST116') {
+      return null;
+    }
+    throw new Error(`Failed to fetch system control: ${error.message}`);
+  }
+
+  return data as SystemControl;
+}

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at?: string;
+  updated_by?: string;
+  reason?: string;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,48 @@
+import express from 'express';
+import request from 'supertest';
+import { systemControlsRouter } from '../../src/routes/system-controls';
+import { getSystemControl } from '../../src/services/system-controls';
+
+jest.mock('../../src/services/system-controls');
+
+const app = express();
+app.use(express.json());
+app.use('/api/system-controls', systemControlsRouter);
+app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
+  res.status(500).json({ error: 'Internal Server Error' });
+});
+
+describe('GET /api/system-controls/:key', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return 200 and the control if found', async () => {
+    const mockControl = { key: 'vitana_did_you_know_enabled', enabled: true };
+    (getSystemControl as jest.Mock).mockResolvedValue(mockControl);
+
+    const res = await request(app).get('/api/system-controls/vitana_did_you_know_enabled');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockControl);
+    expect(getSystemControl).toHaveBeenCalledWith('vitana_did_you_know_enabled');
+  });
+
+  it('should return 404 if not found', async () => {
+    (getSystemControl as jest.Mock).mockResolvedValue(null);
+
+    const res = await request(app).get('/api/system-controls/non_existent_key');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'System control not found' });
+  });
+
+  it('should return 500 if service throws', async () => {
+    (getSystemControl as jest.Mock).mockRejectedValue(new Error('Test error'));
+
+    const res = await request(app).get('/api/system-controls/test_key');
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'Internal Server Error' });
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,56 @@
+import { getSystemControl } from '../src/services/system-controls';
+import { supabase } from '../src/lib/supabase';
+
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+describe('getSystemControl', () => {
+  let mockSelect: jest.Mock;
+  let mockEq: jest.Mock;
+  let mockSingle: jest.Mock;
+
+  beforeEach(() => {
+    mockSingle = jest.fn();
+    mockEq = jest.fn().mockReturnValue({ single: mockSingle });
+    mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+
+    (supabase.from as jest.Mock).mockReturnValue({
+      select: mockSelect
+    });
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns the system control if found', async () => {
+    const mockData = {
+      key: 'vitana_did_you_know_enabled',
+      enabled: true
+    };
+    mockSingle.mockResolvedValue({ data: mockData, error: null });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+
+    expect(supabase.from).toHaveBeenCalledWith('system_controls');
+    expect(mockSelect).toHaveBeenCalledWith('*');
+    expect(mockEq).toHaveBeenCalledWith('key', 'vitana_did_you_know_enabled');
+    expect(result).toEqual(mockData);
+  });
+
+  it('returns null if not found (PGRST116)', async () => {
+    mockSingle.mockResolvedValue({ data: null, error: { code: 'PGRST116' } });
+
+    const result = await getSystemControl('non_existent_key');
+    expect(result).toBeNull();
+  });
+
+  it('throws an error for other supabase errors', async () => {
+    mockSingle.mockResolvedValue({ data: null, error: { code: 'OTHER', message: 'DB Error' } });
+
+    await expect(getSystemControl('some_key')).rejects.toThrow('Failed to fetch system control: DB Error');
+  });
+});


### PR DESCRIPTION
This PR adds the gateway service and API route to expose system controls to frontend consumers. It implements a generic `GET /api/system-controls/:key` route which allows the command-hub (or any other client) to query whether a specific control, such as `vitana_did_you_know_enabled`, is enabled.

Files modified:
- `services/gateway/src/types/system-controls.ts`
- `services/gateway/src/services/system-controls.ts`
- `services/gateway/src/routes/system-controls.ts`
- `services/gateway/test/system-controls.test.ts`
- `services/gateway/test/routes/system-controls.test.ts`

**Note for the Operator:**
1. The main application file (e.g. `services/gateway/src/app.ts`) is not within the scope of this automated PR. You will need to manually mount the new router: `app.use('/api/system-controls', systemControlsRouter);`.
2. The command-hub frontend component that houses the "Did You Know?" tour needs to be updated to fetch the control from `/api/system-controls/vitana_did_you_know_enabled`. The specific file path for this frontend logic was excluded from the automated scope.