### PR TITLE
DEV-AUTOPILOT: Add system controls API endpoint for DYK flag

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,27 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { getSystemControl } from '../services/system-controls';
+
+export const systemControlsRouter = Router();
+
+systemControlsRouter.get(
+  '/:key',
+  async (req: Request, res: Response, next: NextFunction) => {
+    try {
+      const { key } = req.params;
+      
+      if (!key) {
+        return res.status(400).json({ error: 'System control key is required' });
+      }
+
+      const control = await getSystemControl(key);
+
+      if (!control) {
+        return res.status(404).json({ error: 'System control not found' });
+      }
+
+      return res.status(200).json(control);
+    } catch (error) {
+      next(error);
+    }
+  }
+);

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,26 @@
+import { supabase } from '../lib/supabase';
+import { SystemControl } from '../types/system-controls';
+
+/**
+ * Fetches a single system control configuration by its key.
+ *
+ * @param key The unique key of the system control (e.g., 'vitana_did_you_know_enabled')
+ * @returns The SystemControl record or null if not found
+ */
+export async function getSystemControl(key: string): Promise<SystemControl | null> {
+  const { data, error } = await supabase
+    .from('system_controls')
+    .select('*')
+    .eq('key', key)
+    .single();
+
+  if (error) {
+    // Supabase returns PGRST116 when .single() finds no rows
+    if (error.code === 'PGRST116') {
+      return null;
+    }
+    throw new Error(`Failed to fetch system control: ${error.message}`);
+  }
+
+  return data as SystemControl;
+}

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at?: string;
+  updated_by?: string;
+  reason?: string;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,50 @@
+import request from 'supertest';
+import express, { Request, Response, NextFunction } from 'express';
+import { systemControlsRouter } from '../../src/routes/system-controls';
+import * as systemControlsService from '../../src/services/system-controls';
+
+jest.mock('../../src/services/system-controls');
+
+const app = express();
+app.use(express.json());
+app.use('/api/system-controls', systemControlsRouter);
+
+// Fallback error handler to catch next(error) calls
+app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
+  res.status(500).json({ error: err.message });
+});
+
+describe('System Controls Routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('GET /api/system-controls/:key returns 200 and the control object', async () => {
+    const mockControl = { key: 'vitana_did_you_know_enabled', enabled: true };
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(mockControl);
+
+    const response = await request(app).get('/api/system-controls/vitana_did_you_know_enabled');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockControl);
+    expect(systemControlsService.getSystemControl).toHaveBeenCalledWith('vitana_did_you_know_enabled');
+  });
+
+  it('GET /api/system-controls/:key returns 404 when the key is not found', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(null);
+
+    const response = await request(app).get('/api/system-controls/unknown_key');
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'System control not found' });
+  });
+
+  it('GET /api/system-controls/:key returns 500 when the service throws an error', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockRejectedValue(new Error('Internal DB failure'));
+
+    const response = await request(app).get('/api/system-controls/some_key');
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: 'Internal DB failure' });
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,55 @@
+import { getSystemControl } from '../src/services/system-controls';
+import { supabase } from '../src/lib/supabase';
+
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+describe('System Controls Service', () => {
+  let selectMock: jest.Mock;
+  let eqMock: jest.Mock;
+  let singleMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    singleMock = jest.fn();
+    eqMock = jest.fn().mockReturnValue({ single: singleMock });
+    selectMock = jest.fn().mockReturnValue({ eq: eqMock });
+
+    (supabase.from as jest.Mock).mockReturnValue({ select: selectMock });
+  });
+
+  it('returns a system control if found', async () => {
+    const mockControl = { key: 'vitana_did_you_know_enabled', enabled: true };
+    singleMock.mockResolvedValue({ data: mockControl, error: null });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+
+    expect(supabase.from).toHaveBeenCalledWith('system_controls');
+    expect(selectMock).toHaveBeenCalledWith('*');
+    expect(eqMock).toHaveBeenCalledWith('key', 'vitana_did_you_know_enabled');
+    expect(result).toEqual(mockControl);
+  });
+
+  it('returns null if the system control is not found (PGRST116)', async () => {
+    singleMock.mockResolvedValue({ data: null, error: { code: 'PGRST116', message: 'Not found' } });
+
+    const result = await getSystemControl('missing_key');
+
+    expect(result).toBeNull();
+  });
+
+  it('throws an error on other database errors', async () => {
+    singleMock.mockResolvedValue({ 
+      data: null, 
+      error: { code: '500', message: 'Database connection failed' } 
+    });
+
+    await expect(getSystemControl('some_key'))
+      .rejects
+      .toThrow('Failed to fetch system control: Database connection failed');
+  });
+});


### PR DESCRIPTION
This PR adds the gateway API components required to expose system controls (specifically the `vitana_did_you_know_enabled` flag) to frontend consumers. It implements a reusable service querying the `public.system_controls` table in Supabase, and provides an Express route mapped to `GET /api/system-controls/:key`.

**Note for operators**: The frontend changes (command-hub) to consume this new endpoint were intentionally omitted from this PR to comply with directory constraints. A follow-up commit or PR is needed to update the frontend code to call `fetch('/api/system-controls/vitana_did_you_know_enabled')` on mount and control the "Did You Know?" tour visibility.

Files touched:
- `services/gateway/src/types/system-controls.ts` (new)
- `services/gateway/src/services/system-controls.ts` (new)
- `services/gateway/src/routes/system-controls.ts` (new)
- `services/gateway/test/system-controls.test.ts` (new)
- `services/gateway/test/routes/system-controls.test.ts` (new)