### PR TITLE
DEV-AUTOPILOT: Add system controls gateway API for feature flags

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,22 @@
+import { Router, Request, Response } from 'express';
+import { getSystemControl } from '../services/system-controls';
+
+const router = Router();
+
+router.get('/:key', async (req: Request, res: Response) => {
+  try {
+    const key = req.params.key;
+    const control = await getSystemControl(key);
+
+    if (!control) {
+      return res.status(404).json({ error: 'System control not found' });
+    }
+
+    return res.json(control);
+  } catch (error) {
+    console.error(`Error fetching system control ${req.params.key}:`, error);
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router;

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,20 @@
+import { supabase } from '../lib/supabase';
+import { SystemControl } from '../types/system-controls';
+
+export const getSystemControl = async (key: string): Promise<SystemControl | null> => {
+  const { data, error } = await supabase
+    .from('system_controls')
+    .select('*')
+    .eq('key', key)
+    .single();
+
+  if (error) {
+    // Supabase returns PGRST116 when `.single()` finds exactly 0 rows
+    if (error.code === 'PGRST116') {
+      return null;
+    }
+    throw new Error(`Failed to fetch system control: ${error.message}`);
+  }
+
+  return data as SystemControl;
+};

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at: string;
+  updated_by?: string;
+  reason?: string;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,49 @@
+import request from 'supertest';
+import express from 'express';
+import systemControlsRouter from '../../src/routes/system-controls';
+import * as systemControlsService from '../../src/services/system-controls';
+
+jest.mock('../../src/services/system-controls');
+
+const app = express();
+app.use(express.json());
+app.use('/api/system-controls', systemControlsRouter);
+
+describe('System Controls Routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('GET /api/system-controls/:key should return 200 and control data if found', async () => {
+    const mockControl = { 
+      key: 'test_flag', 
+      enabled: true, 
+      updated_at: '2023-01-01T00:00:00Z' 
+    };
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(mockControl);
+
+    const res = await request(app).get('/api/system-controls/test_flag');
+    
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockControl);
+    expect(systemControlsService.getSystemControl).toHaveBeenCalledWith('test_flag');
+  });
+
+  it('GET /api/system-controls/:key should return 404 when not found', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(null);
+
+    const res = await request(app).get('/api/system-controls/missing_flag');
+    
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'System control not found' });
+  });
+
+  it('GET /api/system-controls/:key should return 500 on service error', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockRejectedValue(new Error('Internal exception'));
+
+    const res = await request(app).get('/api/system-controls/error_flag');
+    
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'Internal server error' });
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,52 @@
+import { getSystemControl } from '../src/services/system-controls';
+import { supabase } from '../src/lib/supabase';
+
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+describe('System Controls Service', () => {
+  const mockSelect = jest.fn();
+  const mockEq = jest.fn();
+  const mockSingle = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (supabase.from as jest.Mock).mockReturnValue({ select: mockSelect });
+    mockSelect.mockReturnValue({ eq: mockEq });
+    mockEq.mockReturnValue({ single: mockSingle });
+  });
+
+  it('should return a system control when found', async () => {
+    const mockControl = { 
+      key: 'vitana_did_you_know_enabled', 
+      enabled: true, 
+      updated_at: '2023-01-01T00:00:00Z' 
+    };
+    mockSingle.mockResolvedValue({ data: mockControl, error: null });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+    expect(result).toEqual(mockControl);
+    expect(supabase.from).toHaveBeenCalledWith('system_controls');
+    expect(mockSelect).toHaveBeenCalledWith('*');
+    expect(mockEq).toHaveBeenCalledWith('key', 'vitana_did_you_know_enabled');
+  });
+
+  it('should return null when control is not found (PGRST116)', async () => {
+    mockSingle.mockResolvedValue({ data: null, error: { code: 'PGRST116' } });
+
+    const result = await getSystemControl('missing_flag');
+    expect(result).toBeNull();
+  });
+
+  it('should throw an error on unexpected DB errors', async () => {
+    mockSingle.mockResolvedValue({ 
+      data: null, 
+      error: { code: 'OTHER_CODE', message: 'Database failure' } 
+    });
+
+    await expect(getSystemControl('error_flag')).rejects.toThrow('Failed to fetch system control: Database failure');
+  });
+});


### PR DESCRIPTION
This PR adds the gateway API needed to fetch system controls, fulfilling the backend requirement for the `vitana_did_you_know_enabled` flag migration. 

We have implemented:
- A new `SystemControl` type representing the database structure.
- A service to query the `system_controls` table by key via Supabase.
- An Express route (`GET /api/system-controls/:key`) exposing this data.
- Full unit test coverage for the service and the route.

**Note for Operator**: The plan included modifying the command-hub frontend to consume this new endpoint and toggle the "Did You Know?" tour. Because the exact frontend file path was outside the locked scope for this step, no changes were made to the frontend in this branch. Please follow up by integrating `fetch('/api/system-controls/vitana_did_you_know_enabled')` in the appropriate React component or store inside `command-hub`.