### PR TITLE
DEV-AUTOPILOT: Add system controls endpoint for DYK tour flag

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,24 @@
+import { Router, RequestHandler } from 'express';
+import { getSystemControl } from '../services/system-controls';
+
+const router = Router();
+
+const getSystemControlHandler: RequestHandler = async (req, res, next) => {
+  try {
+    const { key } = req.params;
+    const control = await getSystemControl(key);
+
+    if (!control) {
+      res.status(404).json({ error: 'System control not found' });
+      return;
+    }
+
+    res.json(control);
+  } catch (error) {
+    res.status(500).json({ error: 'Internal server error' });
+  }
+};
+
+router.get('/:key', getSystemControlHandler);
+
+export default router;

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,19 @@
+import { supabase } from '../lib/supabase';
+import { SystemControl } from '../types/system-controls';
+
+export async function getSystemControl(key: string): Promise<SystemControl | null> {
+  const { data, error } = await supabase
+    .from('system_controls')
+    .select('*')
+    .eq('key', key)
+    .single();
+
+  if (error) {
+    if (error.code === 'PGRST116') {
+      return null;
+    }
+    throw new Error(`Failed to fetch system control: ${error.message}`);
+  }
+
+  return data as SystemControl;
+}

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at?: string;
+  updated_by?: string;
+  reason?: string;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,47 @@
+import request from 'supertest';
+import express from 'express';
+import systemControlsRouter from '../../src/routes/system-controls';
+import * as systemControlsService from '../../src/services/system-controls';
+
+jest.mock('../../src/services/system-controls');
+
+const app = express();
+app.use(express.json());
+app.use('/api/system-controls', systemControlsRouter);
+
+describe('GET /api/system-controls/:key', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return 200 and the control object if found', async () => {
+    const mockControl = { key: 'vitana_did_you_know_enabled', enabled: true };
+    jest.spyOn(systemControlsService, 'getSystemControl').mockResolvedValue(mockControl);
+
+    const res = await request(app).get('/api/system-controls/vitana_did_you_know_enabled');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual(mockControl);
+    expect(systemControlsService.getSystemControl).toHaveBeenCalledWith('vitana_did_you_know_enabled');
+  });
+
+  it('should return 404 if the control object is not found', async () => {
+    jest.spyOn(systemControlsService, 'getSystemControl').mockResolvedValue(null);
+
+    const res = await request(app).get('/api/system-controls/missing_key');
+
+    expect(res.status).toBe(404);
+    expect(res.body).toEqual({ error: 'System control not found' });
+    expect(systemControlsService.getSystemControl).toHaveBeenCalledWith('missing_key');
+  });
+
+  it('should return 500 on internal server error', async () => {
+    jest.spyOn(systemControlsService, 'getSystemControl').mockRejectedValue(new Error('Internal'));
+
+    const res = await request(app).get('/api/system-controls/error_key');
+
+    expect(res.status).toBe(500);
+    expect(res.body).toEqual({ error: 'Internal server error' });
+    expect(systemControlsService.getSystemControl).toHaveBeenCalledWith('error_key');
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,56 @@
+import { getSystemControl } from '../src/services/system-controls';
+import { supabase } from '../src/lib/supabase';
+
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+describe('getSystemControl service', () => {
+  const mockSelect = jest.fn();
+  const mockEq = jest.fn();
+  const mockSingle = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (supabase.from as jest.Mock).mockReturnValue({ select: mockSelect });
+    mockSelect.mockReturnValue({ eq: mockEq });
+    mockEq.mockReturnValue({ single: mockSingle });
+  });
+
+  it('should return a system control when found', async () => {
+    const mockData = { key: 'vitana_did_you_know_enabled', enabled: true };
+    mockSingle.mockResolvedValue({ data: mockData, error: null });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+
+    expect(supabase.from).toHaveBeenCalledWith('system_controls');
+    expect(mockSelect).toHaveBeenCalledWith('*');
+    expect(mockEq).toHaveBeenCalledWith('key', 'vitana_did_you_know_enabled');
+    expect(mockSingle).toHaveBeenCalled();
+    expect(result).toEqual(mockData);
+  });
+
+  it('should return null when the record is not found (PGRST116)', async () => {
+    mockSingle.mockResolvedValue({
+      data: null,
+      error: { code: 'PGRST116', message: 'Not found' }
+    });
+
+    const result = await getSystemControl('non_existent');
+
+    expect(result).toBeNull();
+  });
+
+  it('should throw an error on other database errors', async () => {
+    mockSingle.mockResolvedValue({
+      data: null,
+      error: { code: '500', message: 'Database Error' }
+    });
+
+    await expect(getSystemControl('error_key')).rejects.toThrow(
+      'Failed to fetch system control: Database Error'
+    );
+  });
+});


### PR DESCRIPTION
This PR adds a new gateway service and route to expose `system_controls` via the API. This enables the frontend (command-hub) to determine whether features like the "Did You Know?" (DYK) tour should be enabled, by evaluating flags driven by database migrations (such as `vitana_did_you_know_enabled`). 

**Note for operators regarding frontend changes:**
The original plan specified updating the frontend (command-hub) to use this endpoint, but the exact path to the target file was unknown and intentionally omitted from the locked file list to prevent validation failures. A follow-up change is required in `services/gateway/src/frontend/command-hub/...` to query `GET /api/system-controls/vitana_did_you_know_enabled` on mount and conditionally render the tour based on the response.

**Files changed:**
- `services/gateway/src/types/system-controls.ts` (new type definitions)
- `services/gateway/src/services/system-controls.ts` (new Supabase service wrapper)
- `services/gateway/src/routes/system-controls.ts` (new Express route)
- Unit tests in `services/gateway/test/system-controls.test.ts` and `services/gateway/test/routes/system-controls.test.ts`