### PR TITLE
DEV-AUTOPILOT: Add paramLimit middleware to mitigate path-to-regexp ReDoS

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,35 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+/**
+ * Middleware to limit the number and length of path parameters.
+ * Mitigates Regular Expression Denial of Service (ReDoS) vulnerabilities
+ * in the underlying path-to-regexp Express routing dependency.
+ *
+ * @param maxParams Maximum allowed number of path parameters (default: 5)
+ * @param maxLength Maximum allowed length for any single path parameter (default: 200)
+ */
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    if (!req.params) {
+      next();
+      return;
+    }
+
+    const keys = Object.keys(req.params);
+    
+    if (keys.length > maxParams) {
+      res.status(400).json({ error: 'Too many path parameters' });
+      return;
+    }
+
+    for (const key of keys) {
+      const val = req.params[key];
+      if (val && val.length > maxLength) {
+        res.status(400).json({ error: 'Path parameter too long' });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,28 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply mitigation for ReDoS in path-to-regexp parsing
+router.use(limitPathParams());
+
+router.get('/', (req: Request, res: Response) => {
+  res.status(200).json({ projects: [] });
+});
+
+router.get('/:projectId', (req: Request, res: Response) => {
+  res.status(200).json({ 
+    id: req.params.projectId, 
+    title: 'Placeholder Project' 
+  });
+});
+
+router.get('/:projectId/tasks/:taskId', (req: Request, res: Response) => {
+  res.status(200).json({ 
+    projectId: req.params.projectId, 
+    taskId: req.params.taskId,
+    status: 'pending' 
+  });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,27 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply mitigation for ReDoS in path-to-regexp parsing
+router.use(limitPathParams());
+
+router.get('/', (req: Request, res: Response) => {
+  res.status(200).json({ users: [] });
+});
+
+router.get('/:userId', (req: Request, res: Response) => {
+  res.status(200).json({ 
+    id: req.params.userId, 
+    name: 'Placeholder User' 
+  });
+});
+
+router.get('/:userId/profile', (req: Request, res: Response) => {
+  res.status(200).json({ 
+    id: req.params.userId, 
+    profileDetails: 'Details' 
+  });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,56 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE-Mitigation: paramLimit middleware', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    
+    // Apply the ReDoS mitigation middleware with default limits (5 params, 200 chars)
+    app.use(limitPathParams(5, 200));
+
+    // Setup a route with an excessive number of parameters (simulating deep nesting)
+    app.get('/resource/:a/:b/:c/:d/:e/:f', (req: Request, res: Response) => {
+      res.status(200).json({ success: true });
+    });
+
+    // Setup a normal route with a few parameters
+    app.get('/resource/:a/:b', (req: Request, res: Response) => {
+      res.status(200).json({ success: true });
+    });
+  });
+
+  it('should pass normal requests with parameters under the limits (passthrough)', async () => {
+    const res = await request(app).get('/resource/val1/val2');
+    expect(res.status).toBe(200);
+    expect(res.body.success).toBe(true);
+  });
+
+  it('should reject requests with too many path parameters (>5)', async () => {
+    const res = await request(app).get('/resource/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters');
+  });
+
+  it('should reject requests with path parameters that are too long (>200 chars)', async () => {
+    const longParam = 'a'.repeat(201);
+    const res = await request(app).get(`/resource/${longParam}/normal`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Path parameter too long');
+  });
+
+  it('should reject a potential ReDoS attack quickly', async () => {
+    const start = Date.now();
+    
+    // Pathological payload trying to trigger backtracking across multiple boundary checks
+    // We expect the middleware to reject this efficiently in a few milliseconds.
+    const res = await request(app).get('/resource/1/2/3/4/5/6?malicious=payload');
+    
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(duration).toBeLessThan(200); // Ensures it's mitigated and not hanging the CPU
+  });
+});


### PR DESCRIPTION
**Context**
A Regular Expression Denial of Service (ReDoS) vulnerability exists in `path-to-regexp` versions < 0.1.13, which is a transitive dependency of `express`. A crafted request with a high number of route parameters or excessively long values can cause catastrophic backtracking and result in CPU exhaustion. 

**Plan**
Since modifying `package.json` directly is outside the authorized scope for this plan, we mitigate this dynamically by implementing custom validation middleware (`paramLimit.ts`) in the gateway application. 

**Changes**
- Created `services/gateway/src/routes/middleware/paramLimit.ts` to block requests containing more than 5 path parameters or parameters exceeding 200 characters in length.
- Added `limitPathParams` to `services/gateway/src/routes/v1/userRoutes.ts` and `services/gateway/src/routes/v1/projectRoutes.ts` to demonstrate deployment across API routes. 
- Added `services/gateway/test/cve-mitigation.test.ts` with unit and integration tests to verify parameter limits, limit rejections, and bounded response times for ReDoS payloads.

*Note for operator*: Please review other route files within the gateway and apply the `limitPathParams` middleware as needed to comprehensively cover all routes parsing path parameters. The ultimate fix is still to bump `express` dependency versions in `package.json` independently.