### PR TITLE
DEV-AUTOPILOT: Enforce application-level authentication for telemetry writes

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,32 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+const requireAuth = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      res.status(401).json({ error: "Unauthorized", detail: "Missing or invalid token" });
+      return;
+    }
+
+    const token = authHeader.substring(7);
+    const { data, error } = await supabase.auth.getUser(token);
+
+    if (error || !data?.user) {
+      res.status(401).json({ error: "Unauthorized", detail: "Invalid session token" });
+      return;
+    }
+
+    next();
+  } catch (err: any) {
+    res.status(500).json({ error: "Internal server error", detail: err.message });
+  }
+};
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +49,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +169,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,123 @@
+import express from "express";
+import request from "supertest";
+import { router } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+// Mock dependencies to prevent actual broadcast logic or auth queries during tests
+jest.mock("../../src/routes/devhub", () => ({
+  broadcastEvent: jest.fn(),
+}));
+
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1/telemetry", router);
+
+describe("Telemetry Routes Authentication", () => {
+  const originalEnv = process.env;
+
+  beforeAll(() => {
+    process.env = { ...originalEnv };
+    process.env.SUPABASE_SERVICE_ROLE = "test-service-key";
+    process.env.SUPABASE_URL = "http://localhost:8000";
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn(() =>
+      Promise.resolve({
+        ok: true,
+        json: () => Promise.resolve([]),
+        text: () => Promise.resolve(""),
+      })
+    ) as jest.Mock;
+  });
+
+  const validPayload = {
+    vtid: "test-vtid",
+    layer: "test-layer",
+    module: "test-module",
+    source: "test-source",
+    kind: "test-kind",
+    status: "success",
+    title: "Test Event",
+  };
+
+  describe("POST /event", () => {
+    it("should return 401 without Authorization header", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validPayload);
+      
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+    });
+
+    it("should return 401 with invalid token", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: new Error("Invalid token"),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validPayload);
+      
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+    });
+
+    it("should proceed when authenticated", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "test-user-id" } },
+        error: null,
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send(validPayload);
+      
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+    });
+  });
+
+  describe("POST /batch", () => {
+    it("should return 401 without Authorization header", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send([validPayload]);
+      
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+    });
+
+    it("should proceed when authenticated", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "test-user-id" } },
+        error: null,
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-token")
+        .send([validPayload]);
+      
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses an RLS gap flagged by `rls-policy-scanner-v1` for `oasis_events`. It introduces an application-level middleware to enforce authentication on all API routes that write to `oasis_events` (`POST /api/v1/telemetry/event` and `POST /api/v1/telemetry/batch`).

Changes included:
- Added `requireAuth` middleware in `services/gateway/src/routes/telemetry.ts` which verifies Supabase JWT via `supabase.auth.getUser`.
- Injected `requireAuth` into mutating endpoints (`/event` and `/batch`) ensuring that anonymous calls are rejected with `401 Unauthorized`.
- Added unit tests in `services/gateway/test/routes/telemetry.test.ts` to cover positive and negative auth scenarios.

*Note: The corresponding database-level RLS migration for `oasis_events` falls out of automated execution scope and must be applied manually as an SQL migration by the operator.*