### PR TITLE
DEV-AUTOPILOT: Add auth middleware to telemetry endpoints to fix RLS gap

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,29 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+// Middleware to enforce authentication
+const requireAuth = async (req: Request, res: Response, next: NextFunction) => {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    return res.status(401).json({ error: "Unauthorized", detail: "Missing or invalid authorization header" });
+  }
+
+  const token = authHeader.substring(7);
+  try {
+    const { data, error } = await supabase.auth.getUser(token);
+    if (error || !data?.user) {
+      return res.status(401).json({ error: "Unauthorized", detail: "Invalid session token" });
+    }
+    next();
+  } catch (e: any) {
+    return res.status(401).json({ error: "Unauthorized", detail: e.message });
+  }
+};
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +46,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +166,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,143 @@
+import express from "express";
+import request from "supertest";
+import { router } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+// Mock supabase client
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1/telemetry", router);
+
+describe("Telemetry Routes Authentication", () => {
+  let fetchMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SUPABASE_URL = "http://localhost:8000";
+    process.env.SUPABASE_SERVICE_ROLE = "mock-service-role";
+
+    fetchMock = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+      text: async () => "",
+    });
+    global.fetch = fetchMock as any;
+
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const validEvent = {
+    vtid: "VTID-1234",
+    layer: "core",
+    module: "auth",
+    source: "test",
+    kind: "test.event",
+    status: "success",
+    title: "Test Event",
+  };
+
+  describe("POST /api/v1/telemetry/event", () => {
+    it("should return 401 when no authorization header is provided", async () => {
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validEvent);
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe("Unauthorized");
+      expect(supabase.auth.getUser).not.toHaveBeenCalled();
+    });
+
+    it("should return 401 when an invalid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: null },
+        error: new Error("Invalid token"),
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validEvent);
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe("Unauthorized");
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("invalid-token");
+    });
+
+    it("should proceed to handler when a valid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send(validEvent);
+
+      expect(response.status).toBe(202);
+      expect(response.body.ok).toBe(true);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("valid-token");
+      expect(fetchMock).toHaveBeenCalled();
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    const validEvents = [validEvent, { ...validEvent, title: "Test Event 2" }];
+
+    it("should return 401 when no authorization header is provided", async () => {
+      const response = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send(validEvents);
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe("Unauthorized");
+    });
+
+    it("should return 401 when an invalid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: null },
+        error: new Error("Invalid token"),
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validEvents);
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe("Unauthorized");
+    });
+
+    it("should proceed to handler when a valid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-token")
+        .send(validEvents);
+
+      expect(response.status).toBe(202);
+      expect(response.body.ok).toBe(true);
+      expect(response.body.count).toBe(2);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("valid-token");
+      expect(fetchMock).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
**Fixes**: Medium-risk RLS gap on the `oasis_events` table (flagged by rls-policy-scanner-v1).

**What changed**:
- Added a `requireAuth` middleware to `services/gateway/src/routes/telemetry.ts` which verifies tokens using `supabase.auth.getUser()`.
- Applied the `requireAuth` middleware to `POST /api/v1/telemetry/event` and `POST /api/v1/telemetry/batch` (the endpoints that insert into `oasis_events`).
- Created unit tests in `services/gateway/test/routes/telemetry.test.ts` to ensure missing or invalid tokens result in an immediate `401 Unauthorized` response, preventing unauthenticated writes.

**Note to operator**:
Because the automated executor scope restricts modifying files under `supabase/migrations/`, the required database-level RLS migration must be applied manually by a developer. Please manually apply the SQL to enable RLS and add the authenticated-insert policy for `oasis_events`.