### PR TITLE
DEV-AUTOPILOT: Enforce auth on telemetry writes to close RLS gap

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,7 +1,8 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
 
@@ -24,9 +25,34 @@ const TelemetryEventSchema = z.object({
 
 type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
+// Middleware for enforcing authentication on telemetry write endpoints
+const requireAuthenticatedUser = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      res.status(401).json({ error: "Unauthorized", detail: "Missing or invalid Authorization header" });
+      return;
+    }
+
+    const token = authHeader.substring(7);
+    const { data, error } = await supabase.auth.getUser(token);
+
+    if (error || !data.user) {
+      res.status(401).json({ error: "Unauthorized", detail: "Invalid session token" });
+      return;
+    }
+
+    next();
+  } catch (err: any) {
+    console.error("Auth middleware error:", err);
+    res.status(401).json({ error: "Unauthorized", detail: "Authentication failed" });
+    return;
+  }
+};
+
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +172,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,132 @@
+import request from "supertest";
+import express from "express";
+import { router as telemetryRouter } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+// Mock the Supabase client
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+// Mock devhub to avoid SSE broadcast side effects during testing
+jest.mock("../../src/routes/devhub", () => ({
+  broadcastEvent: jest.fn(),
+}), { virtual: true });
+
+// Mock fetch for Supabase HTTP insertions
+global.fetch = jest.fn() as jest.Mock;
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1/telemetry", telemetryRouter);
+
+describe("Telemetry Routes Authentication", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SUPABASE_URL = "http://localhost:8000";
+    process.env.SUPABASE_SERVICE_ROLE = "test-service-key";
+  });
+
+  const validEvent = {
+    vtid: "VT-123",
+    layer: "app",
+    module: "auth",
+    source: "client",
+    kind: "login",
+    status: "success",
+    title: "User logged in",
+  };
+
+  describe("POST /api/v1/telemetry/event", () => {
+    it("should return 401 if missing Authorization header", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validEvent);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should return 401 if token is invalid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: { message: "Invalid token" },
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validEvent);
+
+      expect(res.status).toBe(401);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should proceed and return 202 if valid token", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send(validEvent);
+
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    const validBatch = [validEvent];
+
+    it("should return 401 if missing Authorization header", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send(validBatch);
+
+      expect(res.status).toBe(401);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should proceed and return 202 if valid token", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-token")
+        .send(validBatch);
+
+      expect(res.status).toBe(202);
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("GET /api/v1/telemetry/health", () => {
+    it("should not require authentication", async () => {
+      const res = await request(app).get("/api/v1/telemetry/health");
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses an `rls_gap` flagged by `rls-policy-scanner-v1` for the `oasis_events` table by enforcing authentication on the gateway telemetry write endpoints.

**Changes:**
- Added a `requireAuthenticatedUser` middleware in `services/gateway/src/routes/telemetry.ts` that validates the Supabase session token via `supabase.auth.getUser()`.
- Applied the middleware to the `POST /api/v1/telemetry/event` and `POST /api/v1/telemetry/batch` endpoints.
- Added comprehensive unit tests in `services/gateway/test/routes/telemetry.test.ts` to guarantee authenticated requests are processed and unauthenticated requests receive a `401 Unauthorized`.

**Action Required:**
As automated scripts cannot create files in `supabase/migrations/`, **the database-level RLS migration must be applied manually by the developer**. Please create a migration file (e.g. `supabase/migrations/20251215000000_enable_rls_oasis_events.sql`) with the following:
```sql
ALTER TABLE public.oasis_events ENABLE ROW LEVEL SECURITY;
CREATE POLICY "allow_authenticated_insert" ON public.oasis_events
 FOR INSERT TO authenticated WITH CHECK (true);
CREATE POLICY "allow_authenticated_update" ON public.oasis_events
 FOR UPDATE TO authenticated USING (true);
REVOKE INSERT, UPDATE ON public.oasis_events FROM anon, public;
```