### PR TITLE
DEV-AUTOPILOT: Add system controls API endpoint

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,20 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { getSystemControl } from '../services/system-controls';
+
+export const systemControlsRouter = Router();
+
+systemControlsRouter.get('/:key', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { key } = req.params;
+    const control = await getSystemControl(key);
+
+    if (!control) {
+      res.status(404).json({ error: 'System control not found' });
+      return;
+    }
+
+    res.json(control);
+  } catch (error) {
+    next(error);
+  }
+});

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,20 @@
+import { supabase } from '../lib/supabase';
+import { SystemControl } from '../types/system-controls';
+
+export async function getSystemControl(key: string): Promise<SystemControl | null> {
+  const { data, error } = await supabase
+    .from('system_controls')
+    .select('*')
+    .eq('key', key)
+    .single();
+
+  if (error) {
+    if (error.code === 'PGRST116') {
+      // Postgres error code for "Row not found"
+      return null;
+    }
+    throw new Error(`Failed to fetch system control: ${error.message}`);
+  }
+
+  return data as SystemControl;
+}

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at?: string;
+  updated_by?: string;
+  reason?: string;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,58 @@
+import request from 'supertest';
+import express from 'express';
+import { systemControlsRouter } from '../../src/routes/system-controls';
+import * as systemControlsService from '../../src/services/system-controls';
+
+// Mock the service
+jest.mock('../../src/services/system-controls');
+
+const app = express();
+app.use(express.json());
+app.use('/api/system-controls', systemControlsRouter);
+
+describe('System Controls Routes', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return 200 and the control if found', async () => {
+    const mockControl = {
+      key: 'vitana_did_you_know_enabled',
+      enabled: true
+    };
+
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(mockControl);
+
+    const response = await request(app).get('/api/system-controls/vitana_did_you_know_enabled');
+    
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockControl);
+    expect(systemControlsService.getSystemControl).toHaveBeenCalledWith('vitana_did_you_know_enabled');
+  });
+
+  it('should return 404 if control is not found', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(null);
+
+    const response = await request(app).get('/api/system-controls/missing_key');
+    
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'System control not found' });
+  });
+
+  it('should return 500 if an error occurs', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockRejectedValue(new Error('Test error'));
+
+    // Express error handler to capture the 500 status code
+    const appWithError = express();
+    appWithError.use(express.json());
+    appWithError.use('/api/system-controls', systemControlsRouter);
+    appWithError.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
+      res.status(500).json({ error: 'Internal Server Error' });
+    });
+
+    const response = await request(appWithError).get('/api/system-controls/error_key');
+    
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: 'Internal Server Error' });
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,53 @@
+import { getSystemControl } from '../src/services/system-controls';
+import { supabase } from '../src/lib/supabase';
+
+// Mock the supabase client
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+describe('System Controls Service', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return a system control when found', async () => {
+    const mockControl = {
+      key: 'vitana_did_you_know_enabled',
+      enabled: true
+    };
+
+    const mockSingle = jest.fn().mockResolvedValue({ data: mockControl, error: null });
+    const mockEq = jest.fn().mockReturnValue({ single: mockSingle });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    (supabase.from as jest.Mock).mockReturnValue({ select: mockSelect });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+    
+    expect(supabase.from).toHaveBeenCalledWith('system_controls');
+    expect(mockSelect).toHaveBeenCalledWith('*');
+    expect(mockEq).toHaveBeenCalledWith('key', 'vitana_did_you_know_enabled');
+    expect(result).toEqual(mockControl);
+  });
+
+  it('should return null when not found', async () => {
+    const mockSingle = jest.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } });
+    const mockEq = jest.fn().mockReturnValue({ single: mockSingle });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    (supabase.from as jest.Mock).mockReturnValue({ select: mockSelect });
+
+    const result = await getSystemControl('missing_key');
+    expect(result).toBeNull();
+  });
+
+  it('should throw an error on database failure', async () => {
+    const mockSingle = jest.fn().mockResolvedValue({ data: null, error: { message: 'DB Error' } });
+    const mockEq = jest.fn().mockReturnValue({ single: mockSingle });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    (supabase.from as jest.Mock).mockReturnValue({ select: mockSelect });
+
+    await expect(getSystemControl('some_key')).rejects.toThrow('Failed to fetch system control: DB Error');
+  });
+});


### PR DESCRIPTION
This PR adds the gateway API endpoint to fetch system controls, which is necessary to read the `vitana_did_you_know_enabled` flag created in a recent database migration. 

It implements the type definitions, a service interacting with Supabase to read the flag from the `public.system_controls` table, and an Express route exposing `GET /api/system-controls/:key`.

*Note for operator:* As per the system constraints, this PR strictly includes the gateway API logic. The command-hub frontend updates (to fetch and display the tour using this endpoint) and the gateway Express app registration must be done in follow-up commits.

Files touched:
- `services/gateway/src/types/system-controls.ts`
- `services/gateway/src/services/system-controls.ts`
- `services/gateway/src/routes/system-controls.ts`
- `services/gateway/test/system-controls.test.ts`
- `services/gateway/test/routes/system-controls.test.ts`