### PR TITLE
DEV-AUTOPILOT: Add gateway API for system controls (DYK tour flag)

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,21 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { getSystemControl } from '../services/system-controls';
+
+const router = Router();
+
+router.get('/:key', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { key } = req.params;
+    const control = await getSystemControl(key);
+
+    if (!control) {
+      return res.status(404).json({ error: 'System control not found' });
+    }
+
+    return res.status(200).json(control);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,24 @@
+import { supabase } from '../lib/supabase';
+import { SystemControl } from '../types/system-controls';
+
+/**
+ * Fetches a single system control by its key.
+ * Returns null if the control does not exist.
+ */
+export async function getSystemControl(key: string): Promise<SystemControl | null> {
+  const { data, error } = await supabase
+    .from('system_controls')
+    .select('*')
+    .eq('key', key)
+    .single();
+
+  if (error) {
+    // PGRST116 means zero rows returned (not found)
+    if (error.code === 'PGRST116') {
+      return null;
+    }
+    throw error;
+  }
+
+  return data as SystemControl;
+}

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at?: string;
+  updated_by?: string;
+  reason?: string;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,53 @@
+import express from 'express';
+import request from 'supertest';
+import systemControlsRouter from '../../src/routes/system-controls';
+import * as systemControlsService from '../../src/services/system-controls';
+
+const app = express();
+app.use(express.json());
+app.use('/api/system-controls', systemControlsRouter);
+
+// Basic mock error handler
+app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
+  res.status(500).json({ error: 'Internal Server Error' });
+});
+
+jest.mock('../../src/services/system-controls');
+
+describe('System Controls Routes', () => {
+  const mockGetSystemControl = systemControlsService.getSystemControl as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 200 and the control data when found', async () => {
+    const mockData = { key: 'vitana_did_you_know_enabled', enabled: true };
+    mockGetSystemControl.mockResolvedValue(mockData);
+
+    const response = await request(app).get('/api/system-controls/vitana_did_you_know_enabled');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockData);
+    expect(mockGetSystemControl).toHaveBeenCalledWith('vitana_did_you_know_enabled');
+  });
+
+  it('returns 404 when the control is not found', async () => {
+    mockGetSystemControl.mockResolvedValue(null);
+
+    const response = await request(app).get('/api/system-controls/missing_key');
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'System control not found' });
+    expect(mockGetSystemControl).toHaveBeenCalledWith('missing_key');
+  });
+
+  it('returns 500 when the service throws an error', async () => {
+    mockGetSystemControl.mockRejectedValue(new Error('Service failure'));
+
+    const response = await request(app).get('/api/system-controls/some_key');
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: 'Internal Server Error' });
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,58 @@
+import { getSystemControl } from '../src/services/system-controls';
+import { supabase } from '../src/lib/supabase';
+
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn(),
+  },
+}));
+
+describe('System Controls Service', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns a system control if found', async () => {
+    const mockData = { key: 'vitana_did_you_know_enabled', enabled: true };
+    const mockSingle = jest.fn().mockResolvedValue({ data: mockData, error: null });
+    const mockEq = jest.fn().mockReturnValue({ single: mockSingle });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    
+    (supabase.from as jest.Mock).mockReturnValue({ select: mockSelect });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+
+    expect(supabase.from).toHaveBeenCalledWith('system_controls');
+    expect(mockSelect).toHaveBeenCalledWith('*');
+    expect(mockEq).toHaveBeenCalledWith('key', 'vitana_did_you_know_enabled');
+    expect(result).toEqual(mockData);
+  });
+
+  it('returns null if the system control is not found (PGRST116)', async () => {
+    const mockSingle = jest.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } });
+    const mockEq = jest.fn().mockReturnValue({ single: mockSingle });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    
+    (supabase.from as jest.Mock).mockReturnValue({ select: mockSelect });
+
+    const result = await getSystemControl('missing_key');
+
+    expect(result).toBeNull();
+  });
+
+  it('throws an error for unhandled Supabase errors', async () => {
+    const mockSingle = jest.fn().mockResolvedValue({ 
+      data: null, 
+      error: { code: 'OTHER_ERR', message: 'Database connection failed' } 
+    });
+    const mockEq = jest.fn().mockReturnValue({ single: mockSingle });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    
+    (supabase.from as jest.Mock).mockReturnValue({ select: mockSelect });
+
+    await expect(getSystemControl('some_key')).rejects.toEqual({ 
+      code: 'OTHER_ERR', 
+      message: 'Database connection failed' 
+    });
+  });
+});


### PR DESCRIPTION
This PR adds a new gateway API endpoint to fetch system controls by key, supporting the "Did You Know?" tour feature flag (`vitana_did_you_know_enabled`) introduced in a recent migration.

### Changes
- **Type Definitions:** Created `SystemControl` type.
- **Service:** Implemented `getSystemControl` to query `public.system_controls` via the Supabase client.
- **Route:** Added `GET /api/system-controls/:key` to safely expose these configuration flags to consumers.
- **Tests:** Included unit tests for the service and route logic.

### ⚠️ Operator Note
The command-hub (frontend) modifications required to complete the plan were intentionally excluded to respect the strict scope limits of the current branch/file lock. To complete the feature, please locate or create the `DidYouKnowTour` component in `services/gateway/src/frontend/command-hub/...` and add the fetch to `/api/system-controls/vitana_did_you_know_enabled`.