### PR TITLE
DEV-AUTOPILOT: Refactor admin-notifications auth to use shared middleware

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -12,49 +12,17 @@
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/auth';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIFICATIONS';
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
+router.use(requireAdmin);
 
 // ── POST /compose — Send notification to user(s) ────────────
 
 router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -139,6 +107,8 @@ router.post('/compose', async (req: Request, res: Response) => {
     // Determine effective tenant_id for dispatching
     const effectiveTenantId = tenant_id || (recipient_ids?.length === 1 ? undefined : undefined);
 
+    const userEmail = (req as any).user?.email || 'unknown';
+
     // For single recipients, use synchronous dispatch for immediate feedback
     if (targetUserIds.length === 1) {
       const result = await notifyUser(
@@ -148,7 +118,7 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      console.log(`[${VTID}] Composed notification for 1 user by ${userEmail}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +131,7 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${userEmail}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -177,9 +147,6 @@ router.post('/compose', async (req: Request, res: Response) => {
 // ── GET /sent — Admin notification log ──────────────────────
 
 router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -224,9 +191,6 @@ router.get('/sent', async (req: Request, res: Response) => {
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
 router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,137 @@
+import express from 'express';
+import request from 'supertest';
+import adminNotificationsRouter from '../../src/routes/admin-notifications';
+import { getSupabase } from '../../src/lib/supabase';
+import { notifyUser, notifyUsersAsync } from '../../src/services/notification-service';
+
+jest.mock('../../src/lib/supabase');
+jest.mock('../../src/services/notification-service');
+jest.mock('../../src/middleware/auth', () => ({
+  requireAdmin: jest.fn((req, res, next) => {
+    req.user = { id: 'admin-id', email: 'admin@test.com' };
+    next();
+  })
+}));
+
+describe('Admin Notifications Router', () => {
+  let app: express.Application;
+  let mockSupabase: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    
+    mockSupabase = {
+      from: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      range: jest.fn().mockReturnThis(),
+      not: jest.fn().mockReturnThis(),
+      or: jest.fn().mockReturnThis(),
+      then: jest.fn((resolve) => resolve({ data: [], error: null }))
+    };
+    
+    (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+
+    app = express();
+    app.use(express.json());
+    app.use('/admin/notifications', adminNotificationsRouter);
+  });
+
+  describe('POST /compose', () => {
+    it('returns 400 if title or body is missing', async () => {
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ recipient_ids: ['user1'] });
+      
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('INVALID_INPUT');
+    });
+
+    it('returns 400 if no recipient targets specified', async () => {
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ title: 'Hello', body: 'World' });
+      
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('INVALID_INPUT');
+    });
+
+    it('sends notification to single user synchronously', async () => {
+      (notifyUser as jest.Mock).mockResolvedValue({ success: true });
+
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ title: 'Hello', body: 'World', recipient_ids: ['user1'] });
+      
+      expect(res.status).toBe(200);
+      expect(res.body.sent_to).toBe(1);
+      expect(notifyUser).toHaveBeenCalledWith(
+        'user1', 
+        '', 
+        'welcome_to_vitana', 
+        { title: 'Hello', body: 'World', data: undefined }, 
+        mockSupabase
+      );
+    });
+
+    it('sends notification to multiple users asynchronously', async () => {
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ title: 'Hello', body: 'World', recipient_ids: ['user1', 'user2'] });
+      
+      expect(res.status).toBe(200);
+      expect(res.body.sent_to).toBe(2);
+      expect(notifyUsersAsync).toHaveBeenCalledWith(
+        ['user1', 'user2'], 
+        '', 
+        'welcome_to_vitana', 
+        { title: 'Hello', body: 'World', data: undefined }, 
+        mockSupabase
+      );
+    });
+
+    it('resolves users by role', async () => {
+      mockSupabase.then = jest.fn((resolve) => resolve({ data: [{ user_id: 'user1' }, { user_id: 'user2' }] }));
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ title: 'Hello', body: 'World', recipient_role: 'admin', tenant_id: 'tenant1' });
+      
+      expect(res.status).toBe(200);
+      expect(res.body.sent_to).toBe(2);
+    });
+  });
+
+  describe('GET /sent', () => {
+    it('returns sent notifications', async () => {
+      mockSupabase.then = jest.fn((resolve) => resolve({ data: [{ id: 'notif1' }], count: 1 }));
+
+      const res = await request(app).get('/admin/notifications/sent');
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.data).toEqual([{ id: 'notif1' }]);
+    });
+  });
+
+  describe('GET /preferences/stats', () => {
+    it('returns preferences stats', async () => {
+      mockSupabase.then = jest.fn()
+        .mockImplementationOnce((resolve) => resolve({ 
+          data: [{ push_enabled: true }, { push_enabled: false }] 
+        }))
+        .mockImplementationOnce((resolve) => resolve({ count: 10 }))
+        .mockImplementationOnce((resolve) => resolve({ count: 5 }));
+
+      const res = await request(app).get('/admin/notifications/preferences/stats');
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.stats.push_enabled).toBe(1);
+      expect(res.body.stats.push_disabled).toBe(1);
+      expect(res.body.delivery.total_sent_30d).toBe(10);
+      expect(res.body.delivery.total_read_30d).toBe(5);
+    });
+  });
+});


### PR DESCRIPTION
This PR removes custom, inline authentication logic (`verifyExafyAdmin`) from `admin-notifications.ts` and replaces it with the shared `requireAdmin` middleware. 

Changes included:
- Adopted `router.use(requireAdmin)` for global authentication across the router endpoints.
- Removed custom bearer token parsing and inline Superbase verification functions.
- Updated endpoints to extract the executing admin's email directly from `req.user.email`.
- Added a full suite of unit tests for the route using standard mocked middleware.

This addresses the missing authentication findings raised by the `route-auth-scanner-v1` tool and standardizes admin auth in the gateway service.

Files touched:
- `services/gateway/src/routes/admin-notifications.ts` (modified)
- `services/gateway/test/routes/admin-notifications.test.ts` (created)