### PR TITLE
DEV-AUTOPILOT: Add system-controls gateway endpoint for DYK tour flags

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,21 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { getSystemControl } from '../services/system-controls';
+
+const router = Router();
+
+router.get('/:key', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { key } = req.params;
+    const control = await getSystemControl(key);
+
+    if (!control) {
+      return res.status(404).json({ error: 'System control not found' });
+    }
+
+    return res.json(control);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default router;

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,26 @@
+import { supabase } from '../lib/supabase';
+import { SystemControl } from '../types/system-controls';
+
+/**
+ * Fetches a single system control by its key from the database.
+ * 
+ * @param key The unique key of the system control flag
+ * @returns The SystemControl object or null if not found
+ */
+export const getSystemControl = async (key: string): Promise<SystemControl | null> => {
+  const { data, error } = await supabase
+    .from('system_controls')
+    .select('*')
+    .eq('key', key)
+    .single();
+
+  if (error) {
+    // PGRST116 is the standard PostgREST error code when .single() yields no rows
+    if (error.code === 'PGRST116') {
+      return null;
+    }
+    throw new Error(`Failed to fetch system control ${key}: ${error.message}`);
+  }
+
+  return data as SystemControl;
+};

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at?: string;
+  updated_by?: string;
+  reason?: string;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,51 @@
+import request from 'supertest';
+import express from 'express';
+import systemControlsRouter from '../../src/routes/system-controls';
+import * as systemControlsService from '../../src/services/system-controls';
+
+// Mock the service layer
+jest.mock('../../src/services/system-controls');
+
+const app = express();
+app.use(express.json());
+app.use('/api/system-controls', systemControlsRouter);
+
+// Fallback error handler to mirror typical gateway setup
+app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
+  res.status(500).json({ error: err.message });
+});
+
+describe('System Controls Route', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('GET /api/system-controls/:key should return 200 and the control if it exists', async () => {
+    const mockControl = { key: 'vitana_did_you_know_enabled', enabled: true };
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(mockControl);
+
+    const response = await request(app).get('/api/system-controls/vitana_did_you_know_enabled');
+    
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockControl);
+    expect(systemControlsService.getSystemControl).toHaveBeenCalledWith('vitana_did_you_know_enabled');
+  });
+
+  it('GET /api/system-controls/:key should return 404 if the control does not exist', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(null);
+
+    const response = await request(app).get('/api/system-controls/missing_key');
+    
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'System control not found' });
+  });
+
+  it('GET /api/system-controls/:key should pass errors to the error handling middleware', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockRejectedValue(new Error('Database error'));
+
+    const response = await request(app).get('/api/system-controls/error_key');
+    
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: 'Database error' });
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,55 @@
+import { getSystemControl } from '../src/services/system-controls';
+import { supabase } from '../src/lib/supabase';
+
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+describe('System Controls Service', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return a system control when found', async () => {
+    const mockData = { key: 'vitana_did_you_know_enabled', enabled: true };
+    const singleMock = jest.fn().mockResolvedValue({ data: mockData, error: null });
+    const eqMock = jest.fn().mockReturnValue({ single: singleMock });
+    const selectMock = jest.fn().mockReturnValue({ eq: eqMock });
+    (supabase.from as jest.Mock).mockReturnValue({ select: selectMock });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+    
+    expect(result).toEqual(mockData);
+    expect(supabase.from).toHaveBeenCalledWith('system_controls');
+    expect(selectMock).toHaveBeenCalledWith('*');
+    expect(eqMock).toHaveBeenCalledWith('key', 'vitana_did_you_know_enabled');
+  });
+
+  it('should return null when the control is not found (PGRST116)', async () => {
+    const singleMock = jest.fn().mockResolvedValue({ 
+      data: null, 
+      error: { code: 'PGRST116', message: 'JSON object requested, multiple (or no) rows returned' } 
+    });
+    const eqMock = jest.fn().mockReturnValue({ single: singleMock });
+    const selectMock = jest.fn().mockReturnValue({ eq: eqMock });
+    (supabase.from as jest.Mock).mockReturnValue({ select: selectMock });
+
+    const result = await getSystemControl('missing_key');
+    
+    expect(result).toBeNull();
+  });
+
+  it('should throw an error on generic database error', async () => {
+    const singleMock = jest.fn().mockResolvedValue({ 
+      data: null, 
+      error: { code: '500', message: 'Internal Server Error' } 
+    });
+    const eqMock = jest.fn().mockReturnValue({ single: singleMock });
+    const selectMock = jest.fn().mockReturnValue({ eq: eqMock });
+    (supabase.from as jest.Mock).mockReturnValue({ select: selectMock });
+
+    await expect(getSystemControl('some_key')).rejects.toThrow('Failed to fetch system control some_key: Internal Server Error');
+  });
+});


### PR DESCRIPTION
This PR adds the necessary gateway service, route, and types to fetch system controls from the database (`public.system_controls` table). This exposes the `vitana_did_you_know_enabled` flag (enabled in migration `20260425100000_BOOTSTRAP_dyk_flag_on.sql`) so the frontend can check whether the "Did You Know?" tour should be active.

**Files added:**
- `services/gateway/src/types/system-controls.ts`: Data types for system controls.
- `services/gateway/src/services/system-controls.ts`: Supabase query integration to fetch a flag by key.
- `services/gateway/src/routes/system-controls.ts`: Express router exposing `GET /:key`.
- `services/gateway/test/system-controls.test.ts`: Unit tests for the service.
- `services/gateway/test/routes/system-controls.test.ts`: Unit tests for the route.

**Operator Note:**
The plan implies modifying the command-hub frontend code (`services/gateway/src/frontend/command-hub/...`) to query this endpoint. However, the precise frontend files were excluded from the locked list constraints. An operator will need to follow up in this branch to add the `fetch('/api/system-controls/vitana_did_you_know_enabled')` call inside the frontend component that mounts the tour. Ensure the new route is also registered in the main gateway express app (e.g. `app.use('/api/system-controls', systemControlsRouter)`).