### PR TITLE
DEV-AUTOPILOT: Enforce auth for telemetry writes to mitigate RLS gap

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,7 +1,8 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
 
@@ -24,9 +25,42 @@ const TelemetryEventSchema = z.object({
 
 type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
+// Auth middleware for telemetry routes writing to oasis_events
+const requireAuthenticatedUser = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      return res.status(401).json({
+        error: "Unauthorized",
+        detail: "Missing or invalid Authorization header",
+      });
+    }
+
+    const token = authHeader.substring(7);
+    const { data, error } = await supabase.auth.getUser(token);
+
+    if (error || !data?.user) {
+      return res.status(401).json({
+        error: "Unauthorized",
+        detail: "Invalid token",
+      });
+    }
+
+    // Attach user to request
+    (req as any).user = data.user;
+    next();
+  } catch (err: any) {
+    console.error("❌ Auth middleware error:", err);
+    return res.status(500).json({
+      error: "Internal server error",
+      detail: "Authentication failed",
+    });
+  }
+};
+
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +180,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,149 @@
+import request from "supertest";
+import express from "express";
+import { router } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+// Mock Supabase client
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+// Mock devhub to avoid external dependencies throwing errors in unit tests
+jest.mock("../../src/routes/devhub", () => ({
+  broadcastEvent: jest.fn(),
+}), { virtual: true });
+
+describe("Telemetry Routes Authentication", () => {
+  let app: express.Express;
+
+  const validEventPayload = {
+    vtid: "test-vtid",
+    layer: "test-layer",
+    module: "test-module",
+    source: "test-source",
+    kind: "test-kind",
+    status: "success",
+    title: "test-title",
+  };
+
+  beforeAll(() => {
+    // Set required environment variables
+    process.env.SUPABASE_URL = "http://localhost:8000";
+    process.env.SUPABASE_SERVICE_ROLE = "mock-service-role";
+
+    // Setup Express app with the router mapped to expected API path
+    app = express();
+    app.use(express.json());
+    app.use("/api/v1/telemetry", router);
+
+    // Mock global fetch used for OASIS insertion
+    global.fetch = jest.fn();
+
+    // Supress expected console output for clean test logs
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+    jest.spyOn(console, "log").mockImplementation(() => {});
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("POST /api/v1/telemetry/event", () => {
+    it("should return 401 when no Authorization header is provided", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validEventPayload);
+      
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+      expect(res.body.detail).toBe("Missing or invalid Authorization header");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should return 401 when an invalid token is provided", async () => {
+      // Mock Supabase to return an error/no user for this token
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({ 
+        data: { user: null }, 
+        error: { message: "Invalid token" } 
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validEventPayload);
+      
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("invalid-token");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should proceed and return 202 when a valid token is provided", async () => {
+      // Mock Supabase to return a valid user payload
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({ 
+        data: { user: { id: "user-123" } }, 
+        error: null 
+      });
+
+      // Mock OASIS database fetch to return success
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send(validEventPayload);
+      
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("valid-token");
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    const validBatchPayload = [validEventPayload];
+
+    it("should return 401 when no Authorization header is provided", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send(validBatchPayload);
+      
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should proceed and return 202 when a valid token is provided", async () => {
+      // Mock Supabase to return a valid user payload
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({ 
+        data: { user: { id: "user-123" } }, 
+        error: null 
+      });
+
+      // Mock OASIS database fetch to return success
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-token")
+        .send(validBatchPayload);
+      
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.count).toBe(1);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("valid-token");
+      expect(global.fetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
Resolves a medium-risk security issue flagged by `rls-policy-scanner-v1` on the `oasis_events` table where unauthenticated users could potentially write arbitrary events bypassing API layers. 

Since the database-level RLS migration falls outside the automated execution scope (modifying `supabase/migrations` is forbidden for this tool and requires manual operator deployment), this PR implements application-layer authentication enforcement on the gateway's telemetry writing endpoints (`POST /api/v1/telemetry/event` and `POST /api/v1/telemetry/batch`).

Changes included:
- Added a `requireAuthenticatedUser` middleware in `telemetry.ts` that verifies Supabase authorization via `supabase.auth.getUser()`.
- Applied the middleware to the event and batch persistence routes.
- Created complete unit tests in `telemetry.test.ts` to ensure strict enforcement of authentication (401 for missing/invalid tokens, 202 for valid tokens).

*Note for operator: Please follow up by manually creating and applying the DB migration to enable RLS and strictly lock down `oasis_events`.*