### PR TITLE
DEV-AUTOPILOT: Refactor admin notification categories route to use standard requireAdmin middleware

### DIFF
--- a/services/gateway/src/routes/admin-notification-categories.ts
+++ b/services/gateway/src/routes/admin-notification-categories.ts
@@ -11,55 +11,20 @@
  * - POST   /:id/test      — Send test notification to admin
  *
  * Security:
- * - All endpoints are protected by the `requireExafyAdmin` middleware.
+ * - All endpoints are protected by the `requireAdmin` middleware.
  */
 
-import { Router, Request, Response, NextFunction } from 'express';
+import { Router, Request, Response } from 'express';
 import { createClient } from '@supabase/supabase-js';
-import { createUserSupabaseClient } from '../lib/supabase-user';
+import { requireAdmin } from '../middleware/requireAdmin';
 import { notifyUser, NotificationPayload } from '../services/notification-service';
 
 const router = Router();
+router.use(requireAdmin);
+
 const VTID = 'ADMIN-NOTIF-CATEGORIES';
 
 const VALID_TYPES = ['chat', 'calendar', 'community'];
-
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-// ── Auth Middleware ─────────────────────────────────────────
-
-async function requireExafyAdmin(req: Request, res: Response, next: NextFunction) {
-  const token = getBearerToken(req);
-  if (!token) return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) {
-      return res.status(401).json({ ok: false, error: 'INVALID_TOKEN' });
-    }
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return res.status(403).json({ ok: false, error: 'FORBIDDEN' });
-    }
-
-    // Attach user info to request for downstream handlers
-    (req as any).authUser = { user_id: authData.user.id, email: authData.user.email || 'unknown' };
-    next();
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
-  }
-}
-
-router.use(requireExafyAdmin);
 
 // ── Supabase ────────────────────────────────────────────────
 
@@ -140,7 +105,7 @@ router.get('/:id', async (req: Request, res: Response) => {
 // ── POST / — Create category ───────────────────────────────
 
 router.post('/', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const user = (req as any).user;
 
   const supabase = getSupabase();
   const {
@@ -180,7 +145,7 @@ router.post('/', async (req: Request, res: Response) => {
     default_enabled: default_enabled ?? true,
     mapped_types: mapped_types || [],
     tenant_id: tenant_id || null,
-    created_by: authUser.user_id,
+    created_by: user?.id,
   };
 
   const { data, error } = await supabase
@@ -197,14 +162,14 @@ router.post('/', async (req: Request, res: Response) => {
     return res.status(500).json({ ok: false, error: error.message });
   }
 
-  console.log(`[${VTID}] Created category "${slug}" (${type}) by ${authUser.email}`);
+  console.log(`[${VTID}] Created category "${slug}" (${type}) by ${user?.email ?? 'unknown'}`);
   return res.status(201).json({ ok: true, data });
 });
 
 // ── PATCH /:id — Update category ────────────────────────────
 
 router.patch('/:id', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const user = (req as any).user;
 
   const supabase = getSupabase();
   const allowedFields = ['display_name', 'description', 'icon', 'sort_order', 'is_active', 'default_enabled', 'mapped_types'];
@@ -236,14 +201,14 @@ router.patch('/:id', async (req: Request, res: Response) => {
     return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
   }
 
-  console.log(`[${VTID}] Updated category "${data.slug}" by ${authUser.email}`);
+  console.log(`[${VTID}] Updated category "${data.slug}" by ${user?.email ?? 'unknown'}`);
   return res.json({ ok: true, data });
 });
 
 // ── DELETE /:id — Soft-delete (set is_active=false) ─────────
 
 router.delete('/:id', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const user = (req as any).user;
 
   const supabase = getSupabase();
   const { data, error } = await supabase
@@ -261,14 +226,14 @@ router.delete('/:id', async (req: Request, res: Response) => {
     return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
   }
 
-  console.log(`[${VTID}] Soft-deleted category "${data.slug}" by ${authUser.email}`);
+  console.log(`[${VTID}] Soft-deleted category "${data.slug}" by ${user?.email ?? 'unknown'}`);
   return res.json({ ok: true, data });
 });
 
 // ── POST /:id/test — Send test notification to admin ────────
 
 router.post('/:id/test', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const user = (req as any).user;
 
   const supabase = getSupabase();
 
@@ -296,15 +261,15 @@ router.post('/:id/test', async (req: Request, res: Response) => {
   const { data: tenantRow } = await supabase
     .from('user_tenants')
     .select('tenant_id')
-    .eq('user_id', authUser.user_id)
+    .eq('user_id', user?.id)
     .limit(1)
     .single();
 
   const tenantId = tenantRow?.tenant_id || '00000000-0000-0000-0000-000000000000';
 
   try {
-    const result = await notifyUser(authUser.user_id, tenantId, testType, payload, supabase);
-    console.log(`[${VTID}] Test notification sent for category "${category.slug}" by ${authUser.email}`);
+    const result = await notifyUser(user?.id, tenantId, testType, payload, supabase);
+    console.log(`[${VTID}] Test notification sent for category "${category.slug}" by ${user?.email ?? 'unknown'}`);
     return res.json({ ok: true, result });
   } catch (err: any) {
     console.error(`[${VTID}] POST /:id/test error:`, err.message);

--- a/services/gateway/tests/admin-notification-categories.test.ts
+++ b/services/gateway/tests/admin-notification-categories.test.ts
@@ -1,0 +1,101 @@
+import request from 'supertest';
+import express from 'express';
+
+// 1. Mock the requireAdmin middleware boundary
+jest.mock('../src/middleware/requireAdmin', () => ({
+  requireAdmin: (req: any, res: any, next: any) => {
+    const auth = req.headers.authorization;
+    if (!auth) {
+      return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+    }
+    if (auth === 'Bearer non-admin') {
+      return res.status(403).json({ ok: false, error: 'FORBIDDEN' });
+    }
+    if (auth === 'Bearer admin') {
+      req.user = { id: 'admin-123', email: 'admin@exafy.com' };
+      return next();
+    }
+    return res.status(401).json({ ok: false, error: 'INVALID_TOKEN' });
+  }
+}));
+
+// 2. Mock external services so handlers don't fail internally
+const mockQuery = {
+  select: jest.fn().mockReturnThis(),
+  order: jest.fn().mockReturnThis(),
+  eq: jest.fn().mockReturnThis(),
+  is: jest.fn().mockReturnThis(),
+  or: jest.fn().mockReturnThis(),
+  insert: jest.fn().mockReturnThis(),
+  update: jest.fn().mockReturnThis(),
+  limit: jest.fn().mockReturnThis(),
+  single: jest.fn().mockResolvedValue({ data: { id: '1', type: 'chat', slug: 'test' }, error: null }),
+  then: jest.fn(function(this: any, resolve: any) {
+    return Promise.resolve({ data: [{ id: '1', type: 'chat', slug: 'test' }], error: null }).then(resolve);
+  })
+};
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(() => ({
+    from: jest.fn(() => mockQuery)
+  }))
+}));
+
+jest.mock('../src/services/notification-service', () => ({
+  notifyUser: jest.fn().mockResolvedValue(true)
+}));
+
+import adminNotificationCategoriesRouter from '../src/routes/admin-notification-categories';
+
+const app = express();
+app.use(express.json());
+app.use('/admin/notification-categories', adminNotificationCategoriesRouter);
+
+describe('Admin Notification Categories - Auth Boundary', () => {
+  beforeAll(() => {
+    process.env.SUPABASE_URL = 'http://localhost';
+    process.env.SUPABASE_SERVICE_ROLE = 'test-key';
+    
+    // Silence console logs during tests
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('rejects unauthenticated requests with 401 UNAUTHENTICATED', async () => {
+    const res = await request(app).get('/admin/notification-categories');
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('UNAUTHENTICATED');
+  });
+
+  it('rejects authenticated non-admins with 403 FORBIDDEN', async () => {
+    const res = await request(app)
+      .get('/admin/notification-categories')
+      .set('Authorization', 'Bearer non-admin');
+    
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('FORBIDDEN');
+  });
+
+  it('allows authenticated admins on GET and returns 200', async () => {
+    const res = await request(app)
+      .get('/admin/notification-categories')
+      .set('Authorization', 'Bearer admin');
+    
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('allows authenticated admins on POST and returns 201', async () => {
+    const res = await request(app)
+      .post('/admin/notification-categories')
+      .set('Authorization', 'Bearer admin')
+      .send({ type: 'chat', display_name: 'Test Chat' });
+    
+    expect(res.status).toBe(201);
+    expect(res.body.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
**Context & Finding**
The `route-auth-scanner-v1` flagged `admin-notification-categories.ts` for using a non-standard inline auth pattern (`requireExafyAdmin`). Although the file was functionally secure, this setup prevented automated posture verification and diverged from the project's standard approach to admin routes.

**Fix**
- Removed the inline `requireExafyAdmin` and `getBearerToken` helper functions.
- Replaced the inline middleware with the shared standard `requireAdmin` middleware via `router.use(requireAdmin)` applied globally to the router.
- Updated user extraction in the endpoints from `(req as any).authUser` to `(req as any).user`.
- Removed the now-unused `createUserSupabaseClient` import.
- Added a new integration test suite `tests/admin-notification-categories.test.ts` to assert the required auth boundaries (401 unauthenticated, 403 non-admin, 200/201 authorized admin).

**Files Modified**
- `services/gateway/src/routes/admin-notification-categories.ts`
- `services/gateway/tests/admin-notification-categories.test.ts` (created)