### PR TITLE
DEV-AUTOPILOT: Add auth middleware to telemetry routes for oasis_events

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,29 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+// Middleware to enforce authentication for routes that modify oasis_events
+export const requireAuthenticatedUser = async (req: Request, res: Response, next: NextFunction) => {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    return res.status(401).json({ error: "Unauthorized", detail: "Missing or invalid Authorization header" });
+  }
+
+  const token = authHeader.substring(7);
+  try {
+    const { data, error } = await supabase.auth.getUser(token);
+    if (error || !data?.user) {
+      return res.status(401).json({ error: "Unauthorized", detail: "Invalid session token" });
+    }
+    next();
+  } catch (e: any) {
+    return res.status(500).json({ error: "Internal server error", detail: "Auth check failed" });
+  }
+};
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +46,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +166,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,132 @@
+import request from "supertest";
+import express from "express";
+import { router as telemetryRouter } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+describe("Telemetry Routes Authentication", () => {
+  let app: express.Application;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use("/api/v1/telemetry", telemetryRouter);
+    
+    // Silence console during tests to avoid polluting the output logs
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SUPABASE_URL = "http://localhost:8000";
+    process.env.SUPABASE_SERVICE_ROLE = "test-service-key";
+    
+    // Mock global fetch
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+      text: async () => "",
+    } as any);
+  });
+
+  afterAll(() => {
+    jest.restoreAllMocks();
+  });
+
+  const validEvent = {
+    vtid: "VTID-1234",
+    layer: "test-layer",
+    module: "test-module",
+    source: "test-source",
+    kind: "test-kind",
+    status: "success",
+    title: "Test Event",
+  };
+
+  describe("POST /api/v1/telemetry/event", () => {
+    it("returns 401 without Authorization header", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validEvent);
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+    });
+
+    it("returns 401 with invalid token", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: null },
+        error: { message: "Invalid token" },
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid")
+        .send(validEvent);
+      expect(res.status).toBe(401);
+    });
+
+    it("proceeds with valid token", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid")
+        .send(validEvent);
+      
+      expect(res.status).toBe(202);
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    const validBatch = [validEvent];
+
+    it("returns 401 without Authorization header", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send(validBatch);
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+    });
+
+    it("returns 401 with invalid token", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: null },
+        error: { message: "Invalid token" },
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer invalid")
+        .send(validBatch);
+      expect(res.status).toBe(401);
+    });
+
+    it("proceeds with valid token", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid")
+        .send(validBatch);
+      
+      expect(res.status).toBe(202);
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Addresses a medium-risk `rls_gap` vulnerability for the `oasis_events` table. 
This PR adds an application-level authentication middleware to the telemetry API routes (both `/event` and `/batch` endpoints) that write to `oasis_events`. The new middleware extracts a Supabase session token from the `Authorization` header and verifies it via `supabase.auth.getUser()`. If the token is missing or invalid, the request is rejected with a `401 Unauthorized` response. If authenticated, the request proceeds, executing the write as previously configured.

Corresponding unit tests have also been implemented to ensure robust test coverage of the auth validation flows.

**Files touched:**
- `services/gateway/src/routes/telemetry.ts`
- `services/gateway/test/routes/telemetry.test.ts`

**Note for operator:** The database migration enabling RLS and mapping appropriate access policies for `oasis_events` is out of scope for automated execution. Please create and run the manual SQL migration (e.g. `ALTER TABLE public.oasis_events ENABLE ROW LEVEL SECURITY; ...`) as detailed in the action plan.