### PR TITLE
DEV-AUTOPILOT: Enforce authentication on telemetry API to close oasis_events RLS gap

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,36 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+const requireAuthenticatedUser = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    let token = "";
+    
+    const authHeader = req.headers.authorization;
+    if (authHeader && authHeader.toLowerCase().startsWith("bearer ")) {
+      token = authHeader.substring(7).trim();
+    } else if (req.cookies && req.cookies["sb-access-token"]) {
+      token = req.cookies["sb-access-token"];
+    }
+
+    if (!token) {
+      return res.status(401).json({ error: "Unauthorized", detail: "Missing authentication token" });
+    }
+
+    const { data, error } = await supabase.auth.getUser(token);
+    if (error || !data?.user) {
+      return res.status(401).json({ error: "Unauthorized", detail: "Invalid token" });
+    }
+
+    next();
+  } catch (err) {
+    return res.status(401).json({ error: "Unauthorized", detail: "Authentication failed" });
+  }
+};
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +53,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +173,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,144 @@
+import request from "supertest";
+import express from "express";
+import { router } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+// Mock the Supabase client
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+// Mock devhub to prevent SSE errors during tests
+jest.mock("../../src/routes/devhub", () => ({
+  broadcastEvent: jest.fn(),
+}), { virtual: true });
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1/telemetry", router);
+
+describe("Telemetry API Auth Enforcement", () => {
+  beforeAll(() => {
+    process.env.SUPABASE_URL = "http://localhost:8000";
+    process.env.SUPABASE_SERVICE_ROLE = "test-svc-key";
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe("POST /api/v1/telemetry/event", () => {
+    const validPayload = {
+      vtid: "VT-123",
+      layer: "app",
+      module: "test",
+      source: "jest",
+      kind: "test.event",
+      status: "success",
+      title: "Test Event"
+    };
+
+    it("should return 401 when no Authorization header is present", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validPayload);
+      
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+    });
+
+    it("should return 401 when token is invalid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: null },
+        error: new Error("Invalid token")
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validPayload);
+      
+      expect(res.status).toBe(401);
+    });
+
+    it("should proceed (202) when token is valid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null
+      });
+
+      // Mock global fetch for the OASIS persistence call
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({})
+      } as Response);
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send(validPayload);
+
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    const validPayload = [{
+      vtid: "VT-123",
+      layer: "app",
+      module: "test",
+      source: "jest",
+      kind: "test.event",
+      status: "success",
+      title: "Test Event"
+    }];
+
+    it("should return 401 when no Authorization header is present", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send(validPayload);
+        
+      expect(res.status).toBe(401);
+    });
+
+    it("should return 401 when token is invalid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: null },
+        error: new Error("Invalid token")
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validPayload);
+        
+      expect(res.status).toBe(401);
+    });
+
+    it("should proceed (202) when token is valid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null
+      });
+
+      // Mock global fetch
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({})
+      } as Response);
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-token")
+        .send(validPayload);
+
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses a medium-risk RLS gap (`rls_gap`) flagged on the `oasis_events` table. Currently, anyone able to connect to the database can directly bypass the API layer and write to `oasis_events` because Row-Level Security (RLS) is disabled.

To close this gap, this PR introduces application-level authentication checks. A new `requireAuthenticatedUser` middleware extracts the Supabase session token from the `Authorization` header and ensures that only authenticated callers can write to `oasis_events` via `POST /api/v1/telemetry/event` and `POST /api/v1/telemetry/batch`. Fully validating tokens at the API edge significantly mitigates unauthorized insert exposure.

**⚠️ IMPORTANT — Manual Developer Action Required:**
The automated executor is scoped to forbid modifying files under `supabase/migrations/`. **You must manually generate the RLS database migration** to complete the fix.

Please create a new migration (e.g., `supabase/migrations/20251215000000_enable_rls_oasis_events.sql`) with the following statements:
```sql
ALTER TABLE public.oasis_events ENABLE ROW LEVEL SECURITY;
CREATE POLICY "allow_authenticated_insert" ON public.oasis_events FOR INSERT TO authenticated WITH CHECK (true);
CREATE POLICY "allow_authenticated_update" ON public.oasis_events FOR UPDATE TO authenticated USING (true);
REVOKE INSERT, UPDATE ON public.oasis_events FROM anon, public;
```

**Files modified/created:**
- `services/gateway/src/routes/telemetry.ts`: Added Auth middleware to write endpoints.
- `services/gateway/test/routes/telemetry.test.ts`: Auth verification unit tests added.