### PR TITLE
DEV-AUTOPILOT: Add auth middleware to telemetry API routes

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,51 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+// Middleware to enforce authentication for telemetry writes
+const requireAuth = async (req: Request, res: Response, next: NextFunction) => {
+  let token: string | undefined;
+
+  const authHeader = req.headers.authorization;
+  if (authHeader && authHeader.startsWith("Bearer ")) {
+    token = authHeader.split(" ")[1];
+  } else if (req.headers.cookie) {
+    // Basic extraction if cookie-parser is not available
+    const match = req.headers.cookie.match(/(?:^|;\s*)sb-access-token=([^;]*)/);
+    if (match) {
+      token = match[1];
+    }
+  }
+
+  if (!token) {
+    return res.status(401).json({
+      error: "Unauthorized",
+      detail: "Missing or invalid Authorization header",
+    });
+  }
+
+  try {
+    const { data, error } = await supabase.auth.getUser(token);
+    if (error || !data?.user) {
+      return res.status(401).json({
+        error: "Unauthorized",
+        detail: "Invalid session token",
+      });
+    }
+    // Auth valid, proceed
+    next();
+  } catch (err: any) {
+    console.error("❌ Auth verification error:", err);
+    return res.status(500).json({
+      error: "Internal server error",
+      detail: "Auth verification failed",
+    });
+  }
+};
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +68,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +188,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,130 @@
+import request from "supertest";
+import express from "express";
+import { router } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+// Mock supabase auth
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+// Mock optional devhub dependency inside the router
+jest.mock("../../src/routes/devhub", () => ({
+  broadcastEvent: jest.fn(),
+}), { virtual: true });
+
+// Mock global fetch for Supabase HTTP requests
+global.fetch = jest.fn();
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1/telemetry", router);
+
+describe("Telemetry Routes Authentication", () => {
+  const validEventPayload = {
+    vtid: "VTID-TEST",
+    layer: "test-layer",
+    module: "test-module",
+    source: "test-source",
+    kind: "test.event",
+    status: "success",
+    title: "Test Event"
+  };
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SUPABASE_URL = "http://localhost:8000";
+    process.env.SUPABASE_SERVICE_ROLE = "mock-service-role";
+    
+    // Default fetch mock to return success
+    (global.fetch as jest.Mock).mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+      text: async () => "{}",
+    });
+  });
+
+  describe("POST /api/v1/telemetry/event", () => {
+    it("returns 401 when no token is provided", async () => {
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validEventPayload);
+        
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe("Unauthorized");
+      expect(supabase.auth.getUser).not.toHaveBeenCalled();
+    });
+
+    it("returns 401 when an invalid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: null },
+        error: { message: "Invalid token" },
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validEventPayload);
+        
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe("Unauthorized");
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("invalid-token");
+    });
+
+    it("proceeds and returns 202 when a valid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send(validEventPayload);
+
+      expect(response.status).toBe(202);
+      expect(response.body.ok).toBe(true);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("valid-token");
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    it("returns 401 when no token is provided", async () => {
+      const response = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send([validEventPayload]);
+        
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe("Unauthorized");
+    });
+
+    it("proceeds and returns 202 when a valid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-token")
+        .send([validEventPayload]);
+
+      expect(response.status).toBe(202);
+      expect(response.body.ok).toBe(true);
+      expect(response.body.count).toBe(1);
+    });
+  });
+
+  describe("GET /api/v1/telemetry/health", () => {
+    it("does not require authentication", async () => {
+      const response = await request(app).get("/api/v1/telemetry/health");
+      expect(response.status).toBe(200);
+      expect(response.body.ok).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
**Context & Issue**
The `rls-policy-scanner-v1` flagged `oasis_events` table with a medium-risk `rls_gap` since it lacks RLS and policies. While a manual database migration is required to enforce RLS at the Postgres layer (since the automated runner cannot modify `supabase/migrations/`), this PR addresses the vulnerability at the application level.

**What this PR does**
- Adds `requireAuth` middleware to `services/gateway/src/routes/telemetry.ts`.
- Extracts the Supabase session token from the `Authorization: Bearer <token>` header (or `sb-access-token` cookie) and validates it via `supabase.auth.getUser()`.
- Applies the middleware to the `POST /event` and `POST /batch` endpoints to block unauthenticated inserts to `oasis_events`.
- Adds unit tests in `services/gateway/test/routes/telemetry.test.ts` to guarantee that unauthenticated writes receive a `401 Unauthorized`, whereas authenticated ones proceed correctly.

**Files Touched**
- `services/gateway/src/routes/telemetry.ts`
- `services/gateway/test/routes/telemetry.test.ts`

*(Note for Operator: Please manually apply the RLS migration to Postgres to complete this security patch).*