### PR TITLE
DEV-AUTOPILOT: Enforce auth middleware for telemetry endpoints

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,31 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+const requireAuthenticatedUser = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      return res.status(401).json({ error: "Unauthorized", detail: "Missing or invalid Authorization header" });
+    }
+
+    const token = authHeader.split(" ")[1];
+    const { data, error } = await supabase.auth.getUser(token);
+
+    if (error || !data?.user) {
+      return res.status(401).json({ error: "Unauthorized", detail: "Invalid session token" });
+    }
+
+    next();
+  } catch (error) {
+    console.error("❌ Auth middleware error:", error);
+    return res.status(500).json({ error: "Internal server error", detail: "Auth verification failed" });
+  }
+};
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +48,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +168,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,160 @@
+import request from "supertest";
+import express from "express";
+import { router } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+// Mock the supabase client
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+// Mock devhub to prevent issues with missing files or side effects during tests
+jest.mock("../../src/routes/devhub", () => ({
+  broadcastEvent: jest.fn(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1/telemetry", router);
+
+describe("Telemetry Routes Authentication", () => {
+  let originalFetch: typeof fetch;
+
+  beforeAll(() => {
+    originalFetch = global.fetch;
+    process.env.SUPABASE_SERVICE_ROLE = "test-service-key";
+    process.env.SUPABASE_URL = "http://test-supabase-url.com";
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+    delete process.env.SUPABASE_SERVICE_ROLE;
+    delete process.env.SUPABASE_URL;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({}),
+      text: async () => "OK",
+    });
+  });
+
+  const validEventPayload = {
+    vtid: "test-vtid",
+    layer: "test-layer",
+    module: "test-module",
+    source: "test-source",
+    kind: "test-kind",
+    status: "success",
+    title: "test-title",
+  };
+
+  describe("POST /api/v1/telemetry/event", () => {
+    it("should return 401 if no Authorization header is provided", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validEventPayload);
+
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({
+        error: "Unauthorized",
+        detail: "Missing or invalid Authorization header",
+      });
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should return 401 if invalid Authorization header format", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "InvalidTokenFormat")
+        .send(validEventPayload);
+
+      expect(res.status).toBe(401);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should return 401 if token is rejected by Supabase auth", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: new Error("Invalid token"),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer bad-token")
+        .send(validEventPayload);
+
+      expect(res.status).toBe(401);
+      expect(res.body).toEqual({
+        error: "Unauthorized",
+        detail: "Invalid session token",
+      });
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("bad-token");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should proceed (202) if token is valid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer good-token")
+        .send(validEventPayload);
+
+      expect(res.status).toBe(202);
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    const validBatchPayload = [validEventPayload];
+
+    it("should return 401 if no Authorization header is provided", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send(validBatchPayload);
+
+      expect(res.status).toBe(401);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should return 401 if token is rejected by Supabase auth", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: { message: "jwt expired" },
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer expired-token")
+        .send(validBatchPayload);
+
+      expect(res.status).toBe(401);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should proceed (202) if token is valid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer good-token")
+        .send(validBatchPayload);
+
+      expect(res.status).toBe(202);
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
### Description
This PR addresses an `rls_gap` on the `oasis_events` table (flagged by `rls-policy-scanner-v1`) by enforcing application-level authentication checks on the telemetry API routes (`POST /api/v1/telemetry/event` and `POST /api/v1/telemetry/batch`).

Before writing data to OASIS via the Supabase service role key, the new `requireAuthenticatedUser` middleware verifies that the incoming request includes a valid session token in the `Authorization` header. It validates this token via `supabase.auth.getUser()`. If the token is missing or invalid, a `401 Unauthorized` response is returned and the write is blocked.

### Files Touched
- `services/gateway/src/routes/telemetry.ts`: Added `requireAuthenticatedUser` middleware and applied it to the `POST` endpoints.
- `services/gateway/test/routes/telemetry.test.ts`: Added unit tests verifying that unauthenticated requests fail with 401 and authenticated ones succeed.

**Note to Operator**: The database-level RLS migration for `oasis_events` (enabling RLS and adding the insert/update policies) is out of scope for this automated PR and must be applied manually.