### PR TITLE
DEV-AUTOPILOT: Refactor admin-notifications route to use requireAdmin middleware

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -7,56 +7,27 @@
  * - GET  /preferences/stats — Aggregate opt-in/out rates per category
  *
  * Security:
- * - All endpoints require Bearer token + exafy_admin
+ * - All endpoints require Bearer token + exafy_admin (handled via requireAdmin middleware)
  */
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/auth';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIFICATIONS';
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
+// Apply centralized admin authentication to all routes
+router.use(requireAdmin);
 
 // ── POST /compose — Send notification to user(s) ────────────
 
 router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
+
+  const userEmail = (req as any).user?.email || 'unknown';
 
   const {
     recipient_ids,   // string[] — specific user IDs
@@ -148,7 +119,7 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      console.log(`[${VTID}] Composed notification for 1 user by ${userEmail}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +132,7 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${userEmail}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -177,9 +148,6 @@ router.post('/compose', async (req: Request, res: Response) => {
 // ── GET /sent — Admin notification log ──────────────────────
 
 router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -224,9 +192,6 @@ router.get('/sent', async (req: Request, res: Response) => {
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
 router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,172 @@
+import request from 'supertest';
+import express from 'express';
+import adminNotificationsRouter from '../../src/routes/admin-notifications';
+import { getSupabase } from '../../src/lib/supabase';
+import { notifyUser, notifyUsersAsync } from '../../src/services/notification-service';
+
+// Mock the shared requireAdmin middleware
+jest.mock('../../src/middleware/auth', () => ({
+  requireAdmin: jest.fn((req, res, next) => {
+    req.user = { id: 'admin-id', email: 'admin@test.com' };
+    next();
+  })
+}));
+
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn()
+}));
+
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn().mockResolvedValue({ message_id: '123' }),
+  notifyUsersAsync: jest.fn()
+}));
+
+describe('Admin Notifications API', () => {
+  let app: express.Application;
+  let mockData: any = [];
+  let mockError: any = null;
+  let mockCount: number | null = null;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/admin/notifications', adminNotificationsRouter);
+
+    mockData = [];
+    mockError = null;
+    mockCount = null;
+
+    const chainObj = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      not: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      range: jest.fn().mockReturnThis(),
+      or: jest.fn().mockReturnThis(),
+      then: jest.fn((resolve) => Promise.resolve({ data: mockData, error: mockError, count: mockCount }).then(resolve))
+    };
+
+    const mockSupabase = {
+      from: jest.fn(() => chainObj)
+    };
+
+    (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+    jest.clearAllMocks();
+  });
+
+  describe('POST /compose', () => {
+    it('should require title and body', async () => {
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ recipient_ids: ['u1'] });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('INVALID_INPUT');
+    });
+
+    it('should return 400 if no recipients found', async () => {
+      mockData = [];
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ title: 'Test', body: 'Test body', send_to_all: true, tenant_id: 't1' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('NO_RECIPIENTS');
+    });
+
+    it('should return 400 if too many recipients found (>500)', async () => {
+      mockData = Array(501).fill({ user_id: 'ux' });
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ title: 'Test', body: 'Test body', send_to_all: true, tenant_id: 't1' });
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('TOO_MANY_RECIPIENTS');
+    });
+
+    it('should compose notification for a single user', async () => {
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ title: 'Test', body: 'Test body', recipient_ids: ['u1'] });
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(notifyUser).toHaveBeenCalledWith(
+        'u1',
+        '',
+        'welcome_to_vitana',
+        { title: 'Test', body: 'Test body', data: undefined },
+        expect.anything()
+      );
+    });
+
+    it('should dispatch async for multiple recipients via direct array', async () => {
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ title: 'Test', body: 'Test body', recipient_ids: ['u1', 'u2'] });
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.sent_to).toBe(2);
+      expect(notifyUsersAsync).toHaveBeenCalled();
+    });
+
+    it('should fetch and dispatch users by recipient_role', async () => {
+      mockData = [{ user_id: 'u3' }, { user_id: 'u4' }];
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ title: 'Test', body: 'Test body', recipient_role: 'admin', tenant_id: 't1' });
+      expect(res.status).toBe(200);
+      expect(res.body.sent_to).toBe(2);
+      expect(notifyUsersAsync).toHaveBeenCalled();
+    });
+
+    it('should fetch and dispatch to all users in tenant', async () => {
+      mockData = [{ user_id: 'u5' }];
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ title: 'Test', body: 'Test body', send_to_all: true, tenant_id: 't1' });
+      expect(res.status).toBe(200);
+      expect(res.body.sent_to).toBe(1);
+    });
+
+    it('returns 500 if Supabase is unavailable', async () => {
+      (getSupabase as jest.Mock).mockReturnValue(null);
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ title: 'T', body: 'B', recipient_ids: ['u1'] });
+      expect(res.status).toBe(500);
+      expect(res.body.error).toBe('SUPABASE_UNAVAILABLE');
+    });
+  });
+
+  describe('GET /sent', () => {
+    it('should fetch sent notifications', async () => {
+      mockData = [{ id: 'n1', title: 'Test' }];
+      mockCount = 1;
+      const res = await request(app).get('/admin/notifications/sent');
+      expect(res.status).toBe(200);
+      expect(res.body.data).toEqual(mockData);
+    });
+
+    it('returns 500 if Supabase is unavailable', async () => {
+      (getSupabase as jest.Mock).mockReturnValue(null);
+      const res = await request(app).get('/admin/notifications/sent');
+      expect(res.status).toBe(500);
+    });
+  });
+
+  describe('GET /preferences/stats', () => {
+    it('should fetch preference statistics', async () => {
+      mockData = [{ push_enabled: true }, { push_enabled: false }];
+      mockCount = 10;
+      const res = await request(app).get('/admin/notifications/preferences/stats');
+      expect(res.status).toBe(200);
+      expect(res.body.stats.total_users_with_prefs).toBe(2);
+      expect(res.body.stats.push_enabled).toBe(1);
+      expect(res.body.stats.push_disabled).toBe(1);
+    });
+
+    it('returns 500 if Supabase is unavailable', async () => {
+      (getSupabase as jest.Mock).mockReturnValue(null);
+      const res = await request(app).get('/admin/notifications/preferences/stats');
+      expect(res.status).toBe(500);
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses the missing authentication standard flagged by `route-auth-scanner-v1` in the `admin-notifications.ts` route. 

**Changes:**
- Replaced the inline custom `verifyExafyAdmin` authentication helper with the centralized `requireAdmin` middleware.
- Applied `router.use(requireAdmin)` globally to protect all admin endpoints in this file.
- Updated user identity lookups from `authResult.email` to directly use `req.user.email` attached by the middleware.
- Removed unused imports and cleaned up the old auth handler functions.
- Created `admin-notifications.test.ts` to mock the shared middleware and test all path branches (single dispatch, bulk dispatch, tenant scopes, filtering) to ensure no regressions occur.