### PR TITLE
DEV-AUTOPILOT: Enforce auth for telemetry writes to oasis_events

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,35 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+// Middleware to require Supabase authentication
+const requireAuth = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      res.status(401).json({ error: "Unauthorized", detail: "Missing or invalid Authorization header" });
+      return;
+    }
+
+    const token = authHeader.substring(7);
+    const { data, error } = await supabase.auth.getUser(token);
+
+    if (error || !data.user) {
+      res.status(401).json({ error: "Unauthorized", detail: "Invalid token" });
+      return;
+    }
+
+    next();
+  } catch (error) {
+    console.error("Auth middleware error:", error);
+    res.status(401).json({ error: "Unauthorized", detail: "Authentication failed" });
+    return;
+  }
+};
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +52,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +172,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,142 @@
+import request from "supertest";
+import express from "express";
+import { router as telemetryRouter } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+// Mock Supabase
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+// Mock devhub to prevent requires
+jest.mock("../../src/routes/devhub", () => ({
+  broadcastEvent: jest.fn(),
+}), { virtual: true });
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1/telemetry", telemetryRouter);
+
+describe("Telemetry Routes", () => {
+  const originalEnv = process.env;
+
+  beforeAll(() => {
+    process.env.SUPABASE_URL = "http://mock-supabase.local";
+    process.env.SUPABASE_SERVICE_ROLE = "mock-service-key";
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (global as any).fetch = jest.fn();
+  });
+
+  describe("POST /api/v1/telemetry/event", () => {
+    const validPayload = {
+      vtid: "VTID-123",
+      layer: "app",
+      module: "auth",
+      source: "client",
+      kind: "login",
+      status: "success",
+      title: "User logged in",
+    };
+
+    it("should return 401 when unauthenticated", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validPayload);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+      expect((global as any).fetch).not.toHaveBeenCalled();
+    });
+
+    it("should return 401 with invalid token", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: null },
+        error: new Error("Invalid token"),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validPayload);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+      expect((global as any).fetch).not.toHaveBeenCalled();
+    });
+
+    it("should proceed when authenticated", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      ((global as any).fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({ id: "event-123" }),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send(validPayload);
+
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect((global as any).fetch).toHaveBeenCalled();
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    const validPayload = [{
+      vtid: "VTID-123",
+      layer: "app",
+      module: "auth",
+      source: "client",
+      kind: "login",
+      status: "success",
+      title: "User logged in",
+    }];
+
+    it("should return 401 when unauthenticated", async () => {
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send(validPayload);
+
+      expect(res.status).toBe(401);
+      expect(res.body.error).toBe("Unauthorized");
+      expect((global as any).fetch).not.toHaveBeenCalled();
+    });
+
+    it("should proceed when authenticated", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      ((global as any).fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ([{ id: "event-123" }]),
+      });
+
+      const res = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-token")
+        .send(validPayload);
+
+      expect(res.status).toBe(202);
+      expect(res.body.ok).toBe(true);
+      expect((global as any).fetch).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
This PR implements application-level authentication for the telemetry routes (`/api/v1/telemetry/event` and `/api/v1/telemetry/batch`) that write to the `oasis_events` table. This addresses the `rls_gap` finding by ensuring that only authenticated requests can trigger inserts into this table.

### Changes:
- Added `requireAuth` middleware in `telemetry.ts` which uses `supabase.auth.getUser` to verify the user token from the `Authorization` header.
- Applied `requireAuth` to `POST /event` and `POST /batch`.
- Added unit tests in `telemetry.test.ts` to verify the authentication logic works as intended.

### Operator Follow-Up Required:
The automated execution scope forbids modifying files under `supabase/migrations/`. Therefore, the database-level RLS migration to lock down `oasis_events` must be created manually. Please create a new migration file (e.g. `supabase/migrations/20251215000000_enable_rls_oasis_events.sql`) with the following content:

```sql
ALTER TABLE public.oasis_events ENABLE ROW LEVEL SECURITY;
CREATE POLICY "allow_authenticated_insert" ON public.oasis_events
 FOR INSERT TO authenticated WITH CHECK (true);
CREATE POLICY "allow_authenticated_update" ON public.oasis_events
 FOR UPDATE TO authenticated USING (true);
REVOKE INSERT, UPDATE ON public.oasis_events FROM anon, public;
```