### PR TITLE
DEV-AUTOPILOT: Refactor admin-notifications router to use shared auth middleware

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -12,49 +12,17 @@
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/auth';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIFICATIONS';
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
+router.use(requireAdmin);
 
 // ── POST /compose — Send notification to user(s) ────────────
 
 router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -148,7 +116,7 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      console.log(`[${VTID}] Composed notification for 1 user by ${(req as any).user?.email || 'unknown'}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +129,7 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${(req as any).user?.email || 'unknown'}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -177,9 +145,6 @@ router.post('/compose', async (req: Request, res: Response) => {
 // ── GET /sent — Admin notification log ──────────────────────
 
 router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -224,9 +189,6 @@ router.get('/sent', async (req: Request, res: Response) => {
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
 router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,153 @@
+import request from 'supertest';
+import express from 'express';
+import adminNotificationsRouter from '../../src/routes/admin-notifications';
+import { getSupabase } from '../../src/lib/supabase';
+import { notifyUser, notifyUsersAsync } from '../../src/services/notification-service';
+
+jest.mock('../../src/middleware/auth', () => ({
+  requireAdmin: jest.fn((req, res, next) => {
+    (req as any).user = { id: 'admin-id', email: 'admin@test.com' };
+    next();
+  })
+}));
+
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn()
+}));
+
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn(),
+  notifyUsersAsync: jest.fn()
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/admin/notifications', adminNotificationsRouter);
+
+describe('Admin Notifications Router', () => {
+  let mockSupabase: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    
+    mockSupabase = {
+      from: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      range: jest.fn().mockReturnThis(),
+      or: jest.fn().mockReturnThis()
+    };
+    
+    (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+  });
+
+  describe('POST /compose', () => {
+    it('should return 400 if title and body are missing', async () => {
+      const res = await request(app).post('/admin/notifications/compose').send({});
+      expect(res.status).toBe(400);
+      expect(res.body.message).toBe('title and body are required');
+    });
+
+    it('should return 400 if no recipients specified', async () => {
+      const res = await request(app).post('/admin/notifications/compose').send({
+        title: 'Hello',
+        body: 'World'
+      });
+      expect(res.status).toBe(400);
+      expect(res.body.message).toBe('Must specify recipient_ids, recipient_role, or send_to_all');
+    });
+
+    it('should send notification directly for a single recipient', async () => {
+      (notifyUser as jest.Mock).mockResolvedValueOnce({ success: true });
+
+      const res = await request(app).post('/admin/notifications/compose').send({
+        title: 'Hello',
+        body: 'World',
+        recipient_ids: ['user-1']
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body.sent_to).toBe(1);
+      expect(notifyUser).toHaveBeenCalledWith(
+        'user-1',
+        '',
+        'welcome_to_vitana',
+        { title: 'Hello', body: 'World', data: undefined },
+        mockSupabase
+      );
+    });
+
+    it('should send notifications async for multiple recipients', async () => {
+      const res = await request(app).post('/admin/notifications/compose').send({
+        title: 'Hello',
+        body: 'World',
+        recipient_ids: ['user-1', 'user-2']
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body.sent_to).toBe(2);
+      expect(notifyUsersAsync).toHaveBeenCalledWith(
+        ['user-1', 'user-2'],
+        '',
+        'welcome_to_vitana',
+        { title: 'Hello', body: 'World', data: undefined },
+        mockSupabase
+      );
+    });
+  });
+
+  describe('GET /sent', () => {
+    it('should fetch paginated sent notifications', async () => {
+      mockSupabase.range.mockResolvedValueOnce({
+        data: [{ id: 'notif-1' }],
+        count: 1,
+        error: null
+      } as any);
+
+      const res = await request(app).get('/admin/notifications/sent').query({ limit: 10 });
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.total).toBe(1);
+      expect(res.body.limit).toBe(10);
+    });
+  });
+
+  describe('GET /preferences/stats', () => {
+    it('should return aggregate stats for notification preferences', async () => {
+      mockSupabase.from.mockImplementation((table: string) => {
+        if (table === 'user_notification_preferences') {
+          return {
+            select: jest.fn().mockResolvedValue({
+              data: [
+                { push_enabled: true, live_room_notifications: true },
+                { push_enabled: false, dnd_enabled: true }
+              ],
+              error: null
+            })
+          };
+        }
+        if (table === 'user_notifications') {
+          const chain: any = {
+            select: jest.fn().mockReturnThis(),
+            gte: jest.fn().mockImplementation(() => {
+              const promise = Promise.resolve({ count: 100 }) as any;
+              promise.not = jest.fn().mockResolvedValue({ count: 80 });
+              return promise;
+            })
+          };
+          return chain;
+        }
+      });
+
+      const res = await request(app).get('/admin/notifications/preferences/stats');
+      expect(res.status).toBe(200);
+      expect(res.body.stats.total_users_with_prefs).toBe(2);
+      expect(res.body.stats.push_enabled).toBe(1);
+      expect(res.body.delivery.total_sent_30d).toBe(100);
+      expect(res.body.delivery.total_read_30d).toBe(80);
+      expect(res.body.delivery.read_rate).toBe(80);
+    });
+  });
+});


### PR DESCRIPTION
Addresses the missing authentication finding by `route-auth-scanner-v1`. 

This PR removes the custom, inline `verifyExafyAdmin` function from `services/gateway/src/routes/admin-notifications.ts` and instead applies the shared `requireAdmin` middleware. 
This aligns the admin-notifications routes with the project's standard authentication patterns, resolving the scanner warning and reducing maintenance burden. Tests have been created to verify that the router responds correctly and delegates properly to services when standard middleware intercepts requests.

Files touched:
- `services/gateway/src/routes/admin-notifications.ts`
- `services/gateway/test/routes/admin-notifications.test.ts`