### PR TITLE
DEV-AUTOPILOT: Add system controls API endpoint for DYK flag

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,19 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { getSystemControl } from '../services/system-controls';
+
+export const systemControlsRouter = Router();
+
+systemControlsRouter.get('/:key', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { key } = req.params;
+    const control = await getSystemControl(key);
+
+    if (!control) {
+      return res.status(404).json({ error: 'System control not found' });
+    }
+
+    return res.status(200).json(control);
+  } catch (error) {
+    next(error);
+  }
+});

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,27 @@
+import { supabase } from '../lib/supabase';
+import { SystemControl } from '../types/system-controls';
+
+/**
+ * Fetches a single system control configuration by its unique key.
+ * 
+ * @param key The key of the system control (e.g., 'vitana_did_you_know_enabled')
+ * @returns The SystemControl object if found, or null if it doesn't exist.
+ */
+export async function getSystemControl(key: string): Promise<SystemControl | null> {
+  const { data, error } = await supabase
+    .from('system_controls')
+    .select('*')
+    .eq('key', key)
+    .single();
+
+  if (error) {
+    // PGRST116 is the standard Supabase/PostgREST error code for "zero rows returned"
+    // when using .single()
+    if (error.code === 'PGRST116') {
+      return null;
+    }
+    throw error;
+  }
+
+  return data as SystemControl;
+}

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at: string;
+  updated_by?: string | null;
+  reason?: string | null;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,58 @@
+import express from 'express';
+import request from 'supertest';
+import { systemControlsRouter } from '../../src/routes/system-controls';
+import * as systemControlsService from '../../src/services/system-controls';
+
+// Mock the service
+jest.mock('../../src/services/system-controls');
+
+// Setup a minimal Express app to test the router
+const app = express();
+app.use(express.json());
+app.use('/api/system-controls', systemControlsRouter);
+
+// Fallback error handler to catch unhandled errors explicitly and prevent Supertest from hanging
+app.use((err: any, req: express.Request, res: express.Response, next: express.NextFunction) => {
+  res.status(500).json({ error: 'Internal Server Error' });
+});
+
+describe('System Controls Route', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return 200 and the control object if the key exists', async () => {
+    const mockControl = {
+      key: 'vitana_did_you_know_enabled',
+      enabled: true,
+      updated_at: '2023-01-01T00:00:00Z',
+    };
+
+    jest.spyOn(systemControlsService, 'getSystemControl').mockResolvedValue(mockControl);
+
+    const response = await request(app).get('/api/system-controls/vitana_did_you_know_enabled');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockControl);
+    expect(systemControlsService.getSystemControl).toHaveBeenCalledWith('vitana_did_you_know_enabled');
+  });
+
+  it('should return 404 with an error message if the key does not exist', async () => {
+    jest.spyOn(systemControlsService, 'getSystemControl').mockResolvedValue(null);
+
+    const response = await request(app).get('/api/system-controls/missing_key');
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'System control not found' });
+    expect(systemControlsService.getSystemControl).toHaveBeenCalledWith('missing_key');
+  });
+
+  it('should pass errors to the next middleware (returns 500 in this test setup)', async () => {
+    jest.spyOn(systemControlsService, 'getSystemControl').mockRejectedValue(new Error('Internal failure'));
+
+    const response = await request(app).get('/api/system-controls/error_key');
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: 'Internal Server Error' });
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,61 @@
+import { getSystemControl } from '../src/services/system-controls';
+import { supabase } from '../src/lib/supabase';
+
+// Mock supabase client
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+describe('System Controls Service', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return a system control when found', async () => {
+    const mockControl = {
+      key: 'vitana_did_you_know_enabled',
+      enabled: true,
+      updated_at: '2023-01-01T00:00:00Z',
+      updated_by: 'admin',
+      reason: 'Launch rollout'
+    };
+
+    const singleMock = jest.fn().mockResolvedValue({ data: mockControl, error: null });
+    const eqMock = jest.fn().mockReturnValue({ single: singleMock });
+    const selectMock = jest.fn().mockReturnValue({ eq: eqMock });
+    (supabase.from as jest.Mock).mockReturnValue({ select: selectMock });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+
+    expect(supabase.from).toHaveBeenCalledWith('system_controls');
+    expect(selectMock).toHaveBeenCalledWith('*');
+    expect(eqMock).toHaveBeenCalledWith('key', 'vitana_did_you_know_enabled');
+    expect(result).toEqual(mockControl);
+  });
+
+  it('should return null when the control is not found (PGRST116 error)', async () => {
+    const singleMock = jest.fn().mockResolvedValue({ 
+      data: null, 
+      error: { code: 'PGRST116', message: 'Not found' } 
+    });
+    const eqMock = jest.fn().mockReturnValue({ single: singleMock });
+    const selectMock = jest.fn().mockReturnValue({ eq: eqMock });
+    (supabase.from as jest.Mock).mockReturnValue({ select: selectMock });
+
+    const result = await getSystemControl('non_existent_key');
+
+    expect(result).toBeNull();
+  });
+
+  it('should throw an error if the database query fails with a different error', async () => {
+    const mockError = new Error('Database connection failed');
+    const singleMock = jest.fn().mockResolvedValue({ data: null, error: mockError });
+    const eqMock = jest.fn().mockReturnValue({ single: singleMock });
+    const selectMock = jest.fn().mockReturnValue({ eq: eqMock });
+    (supabase.from as jest.Mock).mockReturnValue({ select: selectMock });
+
+    await expect(getSystemControl('some_key')).rejects.toThrow('Database connection failed');
+  });
+});


### PR DESCRIPTION
This PR exposes the `public.system_controls` table via the gateway API, allowing frontend consumers to query runtime system flags such as `vitana_did_you_know_enabled`. 

**Included in this PR:**
- `SystemControl` type definition.
- Service function `getSystemControl(key)` using the existing Supabase client.
- Express route `GET /api/system-controls/:key` which returns the requested system control or a 404.
- Unit tests for both the service and the route.

**Operator Note (Action Required):**
The plan called for updating the frontend (`command-hub`) to hit this endpoint and toggle the "Did You Know?" tour. Because the exact location of the frontend component was unknown and out of scope for the autopilot's locked file constraints, the frontend changes are omitted. You will need to wire up the frontend to fetch `/api/system-controls/vitana_did_you_know_enabled` manually.

**Files touched:**
- `services/gateway/src/types/system-controls.ts`
- `services/gateway/src/services/system-controls.ts`
- `services/gateway/src/routes/system-controls.ts`
- `services/gateway/test/system-controls.test.ts`
- `services/gateway/test/routes/system-controls.test.ts`