### PR TITLE
DEV-AUTOPILOT: Add system controls API endpoint

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,22 @@
+import { Router, Request, Response } from 'express';
+import { getSystemControl } from '../services/system-controls';
+
+export const systemControlsRouter = Router();
+
+systemControlsRouter.get('/:key', async (req: Request, res: Response) => {
+  try {
+    const { key } = req.params;
+    const control = await getSystemControl(key);
+
+    if (!control) {
+      res.status(404).json({ error: 'System control not found' });
+      return;
+    }
+
+    res.status(200).json(control);
+  } catch (error) {
+    res.status(500).json({ 
+      error: error instanceof Error ? error.message : 'Internal server error' 
+    });
+  }
+});

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,20 @@
+import { supabase } from '../lib/supabase';
+import { SystemControl } from '../types/system-controls';
+
+export async function getSystemControl(key: string): Promise<SystemControl | null> {
+  const { data, error } = await supabase
+    .from('system_controls')
+    .select('*')
+    .eq('key', key)
+    .single();
+
+  if (error) {
+    // Supabase standard error code for "row not found" when using .single()
+    if (error.code === 'PGRST116') {
+      return null;
+    }
+    throw new Error(`Failed to fetch system control: ${error.message}`);
+  }
+
+  return data as SystemControl;
+}

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at?: string;
+  updated_by?: string;
+  reason?: string;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,45 @@
+import request from 'supertest';
+import express from 'express';
+import { systemControlsRouter } from '../../src/routes/system-controls';
+import * as systemControlsService from '../../src/services/system-controls';
+
+jest.mock('../../src/services/system-controls');
+
+const app = express();
+app.use(express.json());
+app.use('/api/system-controls', systemControlsRouter);
+
+describe('GET /api/system-controls/:key', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return 200 and the control data if found', async () => {
+    const mockControl = { key: 'test_key', enabled: true };
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(mockControl);
+
+    const response = await request(app).get('/api/system-controls/test_key');
+    
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockControl);
+    expect(systemControlsService.getSystemControl).toHaveBeenCalledWith('test_key');
+  });
+
+  it('should return 404 if control not found', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(null);
+
+    const response = await request(app).get('/api/system-controls/missing_key');
+    
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'System control not found' });
+  });
+
+  it('should return 500 if an error occurs', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockRejectedValue(new Error('Test error'));
+
+    const response = await request(app).get('/api/system-controls/error_key');
+    
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: 'Test error' });
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,45 @@
+import { getSystemControl } from '../src/services/system-controls';
+import { supabase } from '../src/lib/supabase';
+
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+describe('getSystemControl', () => {
+  const mockSelect = jest.fn();
+  const mockEq = jest.fn();
+  const mockSingle = jest.fn();
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (supabase.from as jest.Mock).mockReturnValue({ select: mockSelect });
+    mockSelect.mockReturnValue({ eq: mockEq });
+    mockEq.mockReturnValue({ single: mockSingle });
+  });
+
+  it('should return a system control when found', async () => {
+    const mockData = { key: 'test_key', enabled: true };
+    mockSingle.mockResolvedValue({ data: mockData, error: null });
+
+    const result = await getSystemControl('test_key');
+    expect(result).toEqual(mockData);
+    expect(supabase.from).toHaveBeenCalledWith('system_controls');
+    expect(mockSelect).toHaveBeenCalledWith('*');
+    expect(mockEq).toHaveBeenCalledWith('key', 'test_key');
+  });
+
+  it('should return null when not found (PGRST116)', async () => {
+    mockSingle.mockResolvedValue({ data: null, error: { code: 'PGRST116' } });
+
+    const result = await getSystemControl('missing_key');
+    expect(result).toBeNull();
+  });
+
+  it('should throw an error on other DB errors', async () => {
+    mockSingle.mockResolvedValue({ data: null, error: { message: 'DB Error' } });
+
+    await expect(getSystemControl('error_key')).rejects.toThrow('Failed to fetch system control: DB Error');
+  });
+});


### PR DESCRIPTION
This PR introduces the `SystemControls` API endpoint to the gateway to allow fetching of system control flags. Specifically, this supports the `vitana_did_you_know_enabled` flag flipped in the `20260425100000_BOOTSTRAP_dyk_flag_on.sql` migration, enabling the frontend to query if the "Did You Know?" tour should be displayed.

### Files modified
- `services/gateway/src/types/system-controls.ts` - Defined `SystemControl` type
- `services/gateway/src/services/system-controls.ts` - Service layer querying `public.system_controls` via Supabase client
- `services/gateway/src/routes/system-controls.ts` - Registered `GET /:key` Express route
- `services/gateway/test/system-controls.test.ts` - Unit tests for the service
- `services/gateway/test/routes/system-controls.test.ts` - Unit tests for the Express route

*Note for operator: The plan requested updating the command-hub frontend code to call the new `/api/system-controls/vitana_did_you_know_enabled` endpoint, but the specific frontend files were omitted from the locked file list. A follow-up commit or PR is needed to update the `command-hub` codebase accordingly.*