### PR TITLE
DEV-AUTOPILOT: Add auth middleware to telemetry API endpoints

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,31 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+// Middleware to enforce authentication on telemetry routes
+const requireAuthenticatedUser = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader) {
+      return res.status(401).json({ error: "Unauthorized", detail: "Missing Authorization header" });
+    }
+
+    const token = authHeader.replace(/^Bearer\s+/i, "");
+    const { data, error } = await supabase.auth.getUser(token);
+
+    if (error || !data?.user) {
+      return res.status(401).json({ error: "Unauthorized", detail: "Invalid session token" });
+    }
+
+    next();
+  } catch (e) {
+    return res.status(401).json({ error: "Unauthorized", detail: "Authentication failed" });
+  }
+};
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +48,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +168,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,143 @@
+import request from "supertest";
+import express from "express";
+import { router } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+describe("Telemetry Routes Auth", () => {
+  let app: express.Application;
+  let mockFetch: jest.Mock;
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use("/api/v1/telemetry", router);
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SUPABASE_URL = "http://localhost:8000";
+    process.env.SUPABASE_SERVICE_ROLE = "test-service-key";
+
+    mockFetch = jest.fn();
+    global.fetch = mockFetch as unknown as typeof fetch;
+
+    // Suppress console output to keep tests clean
+    jest.spyOn(console, "log").mockImplementation(() => {});
+    jest.spyOn(console, "error").mockImplementation(() => {});
+    jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  const validPayload = {
+    vtid: "VTID-123",
+    layer: "app",
+    module: "test",
+    source: "jest",
+    kind: "test.event",
+    status: "info",
+    title: "Test Event"
+  };
+
+  it("should return 401 if no Authorization header is provided to /event", async () => {
+    const res = await request(app)
+      .post("/api/v1/telemetry/event")
+      .send(validPayload);
+    
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("Unauthorized");
+    expect(res.body.detail).toBe("Missing Authorization header");
+  });
+
+  it("should return 401 if the token is invalid for /event", async () => {
+    (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+      data: { user: null },
+      error: { message: "Invalid session" }
+    });
+
+    const res = await request(app)
+      .post("/api/v1/telemetry/event")
+      .set("Authorization", "Bearer bad-token")
+      .send(validPayload);
+    
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("Unauthorized");
+    expect(res.body.detail).toBe("Invalid session token");
+  });
+
+  it("should proceed and return 202 if the token is valid for /event", async () => {
+    (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+      data: { user: { id: "user-123" } },
+      error: null
+    });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({})
+    });
+
+    const res = await request(app)
+      .post("/api/v1/telemetry/event")
+      .set("Authorization", "Bearer good-token")
+      .send(validPayload);
+
+    expect(res.status).toBe(202);
+    expect(res.body.ok).toBe(true);
+    expect(mockFetch).toHaveBeenCalled();
+  });
+
+  it("should return 401 if no Authorization header is provided to /batch", async () => {
+    const res = await request(app)
+      .post("/api/v1/telemetry/batch")
+      .send([validPayload]);
+    
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe("Unauthorized");
+  });
+
+  it("should return 202 if the token is valid for /batch", async () => {
+    (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+      data: { user: { id: "user-123" } },
+      error: null
+    });
+
+    mockFetch.mockResolvedValueOnce({
+      ok: true,
+      json: async () => ({})
+    });
+
+    const res = await request(app)
+      .post("/api/v1/telemetry/batch")
+      .set("Authorization", "Bearer good-token")
+      .send([validPayload]);
+
+    expect(res.status).toBe(202);
+    expect(res.body.ok).toBe(true);
+    expect(mockFetch).toHaveBeenCalled();
+  });
+
+  it("should allow unauthenticated access to /health", async () => {
+    const res = await request(app).get("/api/v1/telemetry/health");
+    expect(res.status).toBe(200);
+  });
+
+  it("should allow unauthenticated access to /snapshot", async () => {
+    mockFetch.mockResolvedValue({
+      ok: true,
+      json: async () => ([])
+    });
+
+    const res = await request(app).get("/api/v1/telemetry/snapshot");
+    expect(res.status).toBe(200);
+  });
+});


### PR DESCRIPTION
This PR addresses an RLS gap identified by the `rls-policy-scanner-v1` on the `oasis_events` table. 

It introduces an application-level layer of authentication on the API routes (`POST /event` and `POST /batch` in `telemetry.ts`) that write to `oasis_events`. Clients are now required to provide a valid Supabase session token in the `Authorization` header, which is verified using `supabase.auth.getUser()`. Invalid or missing tokens result in a `401 Unauthorized` response.

**Note to developers**: A manual database migration is still required to permanently enable Row-Level Security on the `oasis_events` table in `supabase/migrations/` (to prevent unauthorized direct SQL access). 

**Files touched:**
- `services/gateway/src/routes/telemetry.ts`: Added the `requireAuthenticatedUser` middleware.
- `services/gateway/test/routes/telemetry.test.ts`: Added unit tests verifying standard auth flows (401 blocking & successful validation).