### PR TITLE
DEV-AUTOPILOT: Refactor auth in admin-notification-categories routes

### DIFF
--- a/services/gateway/src/routes/admin-notification-categories.ts
+++ b/services/gateway/src/routes/admin-notification-categories.ts
@@ -11,12 +11,12 @@
  * - POST   /:id/test      — Send test notification to admin
  *
  * Security:
- * - All endpoints are protected by the `requireExafyAdmin` middleware.
+ * - All endpoints are protected by the `requireAdmin` middleware.
  */
 
-import { Router, Request, Response, NextFunction } from 'express';
+import { Router, Request, Response } from 'express';
 import { createClient } from '@supabase/supabase-js';
-import { createUserSupabaseClient } from '../lib/supabase-user';
+import { requireAdmin } from '../middleware/requireAdmin';
 import { notifyUser, NotificationPayload } from '../services/notification-service';
 
 const router = Router();
@@ -24,42 +24,9 @@ const VTID = 'ADMIN-NOTIF-CATEGORIES';
 
 const VALID_TYPES = ['chat', 'calendar', 'community'];
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
 // ── Auth Middleware ─────────────────────────────────────────
 
-async function requireExafyAdmin(req: Request, res: Response, next: NextFunction) {
-  const token = getBearerToken(req);
-  if (!token) return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) {
-      return res.status(401).json({ ok: false, error: 'INVALID_TOKEN' });
-    }
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return res.status(403).json({ ok: false, error: 'FORBIDDEN' });
-    }
-
-    // Attach user info to request for downstream handlers
-    (req as any).authUser = { user_id: authData.user.id, email: authData.user.email || 'unknown' };
-    next();
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
-  }
-}
-
-router.use(requireExafyAdmin);
+router.use(requireAdmin);
 
 // ── Supabase ────────────────────────────────────────────────
 
@@ -140,7 +107,7 @@ router.get('/:id', async (req: Request, res: Response) => {
 // ── POST / — Create category ───────────────────────────────
 
 router.post('/', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const { user } = req as any;
 
   const supabase = getSupabase();
   const {
@@ -180,7 +147,7 @@ router.post('/', async (req: Request, res: Response) => {
     default_enabled: default_enabled ?? true,
     mapped_types: mapped_types || [],
     tenant_id: tenant_id || null,
-    created_by: authUser.user_id,
+    created_by: user.id,
   };
 
   const { data, error } = await supabase
@@ -197,14 +164,14 @@ router.post('/', async (req: Request, res: Response) => {
     return res.status(500).json({ ok: false, error: error.message });
   }
 
-  console.log(`[${VTID}] Created category "${slug}" (${type}) by ${authUser.email}`);
+  console.log(`[${VTID}] Created category "${slug}" (${type}) by ${user.email}`);
   return res.status(201).json({ ok: true, data });
 });
 
 // ── PATCH /:id — Update category ────────────────────────────
 
 router.patch('/:id', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const { user } = req as any;
 
   const supabase = getSupabase();
   const allowedFields = ['display_name', 'description', 'icon', 'sort_order', 'is_active', 'default_enabled', 'mapped_types'];
@@ -236,14 +203,14 @@ router.patch('/:id', async (req: Request, res: Response) => {
     return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
   }
 
-  console.log(`[${VTID}] Updated category "${data.slug}" by ${authUser.email}`);
+  console.log(`[${VTID}] Updated category "${data.slug}" by ${user.email}`);
   return res.json({ ok: true, data });
 });
 
 // ── DELETE /:id — Soft-delete (set is_active=false) ─────────
 
 router.delete('/:id', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const { user } = req as any;
 
   const supabase = getSupabase();
   const { data, error } = await supabase
@@ -261,14 +228,14 @@ router.delete('/:id', async (req: Request, res: Response) => {
     return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
   }
 
-  console.log(`[${VTID}] Soft-deleted category "${data.slug}" by ${authUser.email}`);
+  console.log(`[${VTID}] Soft-deleted category "${data.slug}" by ${user.email}`);
   return res.json({ ok: true, data });
 });
 
 // ── POST /:id/test — Send test notification to admin ────────
 
 router.post('/:id/test', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const { user } = req as any;
 
   const supabase = getSupabase();
 
@@ -296,15 +263,15 @@ router.post('/:id/test', async (req: Request, res: Response) => {
   const { data: tenantRow } = await supabase
     .from('user_tenants')
     .select('tenant_id')
-    .eq('user_id', authUser.user_id)
+    .eq('user_id', user.id)
     .limit(1)
     .single();
 
   const tenantId = tenantRow?.tenant_id || '00000000-0000-0000-0000-000000000000';
 
   try {
-    const result = await notifyUser(authUser.user_id, tenantId, testType, payload, supabase);
-    console.log(`[${VTID}] Test notification sent for category "${category.slug}" by ${authUser.email}`);
+    const result = await notifyUser(user.id, tenantId, testType, payload, supabase);
+    console.log(`[${VTID}] Test notification sent for category "${category.slug}" by ${user.email}`);
     return res.json({ ok: true, result });
   } catch (err: any) {
     console.error(`[${VTID}] POST /:id/test error:`, err.message);

--- a/services/gateway/tests/admin-notification-categories.test.ts
+++ b/services/gateway/tests/admin-notification-categories.test.ts
@@ -1,0 +1,108 @@
+import request from 'supertest';
+import express from 'express';
+import router from '../src/routes/admin-notification-categories';
+
+// 1. Mock standard requireAdmin middleware
+jest.mock('../src/middleware/requireAdmin', () => ({
+  requireAdmin: (req: any, res: any, next: any) => {
+    const authHeader = req.headers.authorization;
+    if (!authHeader) {
+      return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+    }
+    if (authHeader === 'Bearer non-admin-token') {
+      return res.status(403).json({ ok: false, error: 'FORBIDDEN' });
+    }
+    if (authHeader === 'Bearer admin-token') {
+      req.user = { id: 'admin-123', email: 'admin@exafy.com' };
+      return next();
+    }
+    return res.status(401).json({ ok: false, error: 'INVALID_TOKEN' });
+  }
+}));
+
+// 2. Mock Supabase Client chain cleanly
+jest.mock('@supabase/supabase-js', () => {
+  const createMockChain = (data: any) => {
+    const chain: any = {
+      select: jest.fn(() => chain),
+      order: jest.fn(() => chain),
+      eq: jest.fn(() => chain),
+      is: jest.fn(() => chain),
+      or: jest.fn(() => chain),
+      single: jest.fn(() => {
+        // Unpack array to a single object when .single() is called
+        chain.then = jest.fn((resolve: any) => 
+          resolve({ data: Array.isArray(data) ? data[0] : data, error: null })
+        );
+        return chain;
+      }),
+      insert: jest.fn(() => chain),
+      update: jest.fn(() => chain),
+      limit: jest.fn(() => chain),
+      // Default to returning the full array for list queries
+      then: jest.fn((resolve: any) => resolve({ data, error: null }))
+    };
+    return chain;
+  };
+
+  return {
+    createClient: jest.fn(() => ({
+      from: jest.fn(() => createMockChain([{ 
+        id: '1', 
+        slug: 'test-category', 
+        type: 'chat', 
+        mapped_types: [] 
+      }]))
+    }))
+  };
+});
+
+// 3. Mock Notification Service
+jest.mock('../src/services/notification-service', () => ({
+  notifyUser: jest.fn().mockResolvedValue({ success: true })
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/admin-categories', router);
+
+describe('Admin Notification Categories API - Authentication Boundaries', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 401 UNAUTHENTICATED when no token is provided', async () => {
+    const res = await request(app).get('/admin-categories');
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('UNAUTHENTICATED');
+  });
+
+  it('returns 403 FORBIDDEN when accessed by an authenticated non-admin user', async () => {
+    const res = await request(app)
+      .get('/admin-categories')
+      .set('Authorization', 'Bearer non-admin-token');
+    expect(res.status).toBe(403);
+    expect(res.body.error).toBe('FORBIDDEN');
+  });
+
+  it('allows access and returns 200 for an authenticated admin user (GET)', async () => {
+    const res = await request(app)
+      .get('/admin-categories')
+      .set('Authorization', 'Bearer admin-token');
+    
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    // Verifies the route returned mocked data
+    expect(res.body.data.chat).toHaveLength(1);
+  });
+
+  it('allows access and returns 201 for an authenticated admin user (POST)', async () => {
+    const res = await request(app)
+      .post('/admin-categories')
+      .set('Authorization', 'Bearer admin-token')
+      .send({ type: 'chat', display_name: 'Chat Category' });
+    
+    expect(res.status).toBe(201);
+    expect(res.body.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
**Context**
The `route-auth-scanner-v1` flagged `admin-notification-categories.ts` for using a non-standard, inline auth pattern. This PR refactors the file to use the shared `requireAdmin` middleware, aligning its security posture with the rest of the codebase and ensuring it is scanner-recognizable.

**Changes**
- Removed the inline `getBearerToken` and `requireExafyAdmin` helper functions.
- Imported and applied the standard `requireAdmin` middleware via `router.use(requireAdmin)`.
- Replaced `req.authUser.user_id` with `req.user.id` and `req.authUser.email` with `req.user.email` across all handlers to match the standard request object footprint.
- Removed the now-unused `createUserSupabaseClient` dependency.
- Created `tests/admin-notification-categories.test.ts` to assert correct behavior across the unauthenticated (401), non-admin (403), and authorized (200/201) boundaries.