### PR TITLE
DEV-AUTOPILOT: Add system-controls API endpoint for feature flags

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,22 @@
+import { Router, Request, Response } from 'express';
+import { getSystemControl } from '../services/system-controls';
+
+const router = Router();
+
+router.get('/:key', async (req: Request, res: Response) => {
+  try {
+    const { key } = req.params;
+    const control = await getSystemControl(key);
+
+    if (!control) {
+      return res.status(404).json({ error: 'System control not found' });
+    }
+
+    res.json(control);
+  } catch (error) {
+    console.error('Error fetching system control:', error);
+    res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router;

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,27 @@
+import { supabase } from '../lib/supabase';
+import { SystemControl } from '../types/system-controls';
+
+/**
+ * Fetches a system control by its key.
+ * 
+ * @param key The key of the system control to fetch.
+ * @returns The SystemControl object if found, or null if not found.
+ */
+export async function getSystemControl(key: string): Promise<SystemControl | null> {
+  const { data, error } = await supabase
+    .from('system_controls')
+    .select('*')
+    .eq('key', key)
+    .single();
+
+  if (error) {
+    // PGRST116 is the PostgREST error code for "Results contain 0 rows"
+    // when using .single()
+    if (error.code === 'PGRST116') {
+      return null;
+    }
+    throw error;
+  }
+
+  return data as SystemControl;
+}

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at?: string;
+  updated_by?: string;
+  reason?: string;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,46 @@
+import express from 'express';
+import request from 'supertest';
+import systemControlsRouter from '../src/routes/system-controls';
+import * as systemControlsService from '../src/services/system-controls';
+
+jest.mock('../src/services/system-controls');
+
+const app = express();
+app.use(express.json());
+app.use('/api/system-controls', systemControlsRouter);
+
+describe('System Controls Routes', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return 200 and the system control if found', async () => {
+    const mockControl = { key: 'test_flag', enabled: true };
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(mockControl);
+
+    const response = await request(app).get('/api/system-controls/test_flag');
+    
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockControl);
+    expect(systemControlsService.getSystemControl).toHaveBeenCalledWith('test_flag');
+  });
+
+  it('should return 404 if the system control is not found', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(null);
+
+    const response = await request(app).get('/api/system-controls/missing_flag');
+    
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'System control not found' });
+    expect(systemControlsService.getSystemControl).toHaveBeenCalledWith('missing_flag');
+  });
+
+  it('should return 500 if the service throws an error', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockRejectedValue(new Error('DB connection failed'));
+
+    const response = await request(app).get('/api/system-controls/error_flag');
+    
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: 'Internal server error' });
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,55 @@
+import { getSystemControl } from '../src/services/system-controls';
+import { supabase } from '../src/lib/supabase';
+
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+describe('System Controls Service', () => {
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return a system control when found', async () => {
+    const mockData = { key: 'vitana_did_you_know_enabled', enabled: true };
+    const mockEq = jest.fn().mockReturnValue({ 
+      single: jest.fn().mockResolvedValue({ data: mockData, error: null }) 
+    });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    
+    (supabase.from as jest.Mock).mockReturnValue({ select: mockSelect });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+    
+    expect(result).toEqual(mockData);
+    expect(supabase.from).toHaveBeenCalledWith('system_controls');
+    expect(mockSelect).toHaveBeenCalledWith('*');
+    expect(mockEq).toHaveBeenCalledWith('key', 'vitana_did_you_know_enabled');
+  });
+
+  it('should return null when the control is not found (PGRST116)', async () => {
+    const mockEq = jest.fn().mockReturnValue({ 
+      single: jest.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } }) 
+    });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    
+    (supabase.from as jest.Mock).mockReturnValue({ select: mockSelect });
+
+    const result = await getSystemControl('missing_key');
+    expect(result).toBeNull();
+  });
+
+  it('should throw an error for unexpected database errors', async () => {
+    const mockError = { code: '500', message: 'Internal DB Error' };
+    const mockEq = jest.fn().mockReturnValue({ 
+      single: jest.fn().mockResolvedValue({ data: null, error: mockError }) 
+    });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    
+    (supabase.from as jest.Mock).mockReturnValue({ select: mockSelect });
+
+    await expect(getSystemControl('error_key')).rejects.toEqual(mockError);
+  });
+});


### PR DESCRIPTION
This PR implements the gateway backend API for `system_controls`, allowing the frontend to query feature flags like `vitana_did_you_know_enabled` that are managed in the `public.system_controls` table.

### Changes:
- **`types/system-controls.ts`**: Defines the `SystemControl` type.
- **`services/system-controls.ts`**: Implements a service to fetch a flag by key from Supabase (`supabase.from('system_controls')`).
- **`routes/system-controls.ts`**: Exposes `GET /:key` returning the flag or a 404 if not found.
- **Tests**: Adds unit tests for the service and the route.

### Notes for Operator:
The plan mentioned updating the frontend (command-hub) to use this new endpoint (`GET /api/system-controls/vitana_did_you_know_enabled`). Since frontend files were out of scope of the locked file list for this PR, they have not been included. Please follow up with the `command-hub` changes in a separate commit or PR to start utilizing this new backend endpoint.