### PR TITLE
DEV-AUTOPILOT: Refactor admin-notifications to use shared auth middleware

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -7,54 +7,22 @@
  * - GET  /preferences/stats — Aggregate opt-in/out rates per category
  *
  * Security:
- * - All endpoints require Bearer token + exafy_admin
+ * - All endpoints require Bearer token + exafy_admin (via requireAdmin middleware)
  */
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
+import { requireAdmin } from '../middleware/auth';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIFICATIONS';
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
+router.use(requireAdmin);
 
 // ── POST /compose — Send notification to user(s) ────────────
 
 router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -138,6 +106,7 @@ router.post('/compose', async (req: Request, res: Response) => {
 
     // Determine effective tenant_id for dispatching
     const effectiveTenantId = tenant_id || (recipient_ids?.length === 1 ? undefined : undefined);
+    const userEmail = (req as any).user?.email || 'unknown';
 
     // For single recipients, use synchronous dispatch for immediate feedback
     if (targetUserIds.length === 1) {
@@ -148,7 +117,7 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      console.log(`[${VTID}] Composed notification for 1 user by ${userEmail}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +130,7 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${userEmail}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -177,9 +146,6 @@ router.post('/compose', async (req: Request, res: Response) => {
 // ── GET /sent — Admin notification log ──────────────────────
 
 router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -224,9 +190,6 @@ router.get('/sent', async (req: Request, res: Response) => {
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
 router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,145 @@
+import request from 'supertest';
+import express from 'express';
+import adminNotificationsRouter from '../../src/routes/admin-notifications';
+import { getSupabase } from '../../src/lib/supabase';
+import { notifyUser, notifyUsersAsync } from '../../src/services/notification-service';
+
+jest.mock('../../src/middleware/auth', () => ({
+  requireAdmin: jest.fn((req, res, next) => {
+    req.user = { id: 'admin-id', email: 'admin@test.com' };
+    next();
+  }),
+}));
+
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn(),
+}));
+
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn(),
+  notifyUsersAsync: jest.fn(),
+}));
+
+describe('Admin Notifications Router', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    app = express();
+    app.use(express.json());
+    app.use('/admin/notifications', adminNotificationsRouter);
+  });
+
+  const createMockSupabase = () => {
+    return {
+      from: jest.fn().mockImplementation((table) => {
+        const chain = {
+          select: jest.fn().mockReturnThis(),
+          eq: jest.fn().mockReturnThis(),
+          or: jest.fn().mockReturnThis(),
+          gte: jest.fn().mockReturnThis(),
+          not: jest.fn().mockReturnThis(),
+          order: jest.fn().mockReturnThis(),
+          range: jest.fn().mockReturnThis()
+        };
+        (chain as any).then = function (resolve: any) {
+          if (table === 'user_notification_preferences') {
+            resolve({ data: [{ push_enabled: true }, { push_enabled: false }], error: null });
+          } else if (table === 'user_notifications') {
+            resolve({ data: [{ id: 'notif-1' }], count: 5, error: null });
+          } else if (table === 'user_tenants') {
+            resolve({ data: [{ user_id: 'user1' }, { user_id: 'user2' }], error: null });
+          }
+        };
+        return chain;
+      })
+    };
+  };
+
+  describe('POST /compose', () => {
+    it('should fail if missing title or body', async () => {
+      const response = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ recipient_ids: ['user1'] });
+      
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe('INVALID_INPUT');
+    });
+
+    it('should fail if no recipients specified', async () => {
+      const response = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ title: 'Hello', body: 'World' });
+      
+      expect(response.status).toBe(400);
+      expect(response.body.error).toBe('INVALID_INPUT');
+    });
+
+    it('should compose notification for a single recipient', async () => {
+      const mockSupabase = createMockSupabase();
+      (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+      (notifyUser as jest.Mock).mockResolvedValue({ id: 'notif-1' });
+
+      const response = await request(app)
+        .post('/admin/notifications/compose')
+        .send({
+          title: 'Hello',
+          body: 'World',
+          recipient_ids: ['user1']
+        });
+      
+      expect(response.status).toBe(200);
+      expect(response.body.ok).toBe(true);
+      expect(response.body.sent_to).toBe(1);
+      expect(notifyUser).toHaveBeenCalledWith('user1', '', 'welcome_to_vitana', expect.any(Object), mockSupabase);
+    });
+
+    it('should compose notification for multiple recipients', async () => {
+      const mockSupabase = createMockSupabase();
+      (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+
+      const response = await request(app)
+        .post('/admin/notifications/compose')
+        .send({
+          title: 'Hello',
+          body: 'World',
+          recipient_role: 'member',
+          tenant_id: 'tenant-1'
+        });
+      
+      expect(response.status).toBe(200);
+      expect(response.body.ok).toBe(true);
+      expect(response.body.sent_to).toBe(2);
+      expect(notifyUsersAsync).toHaveBeenCalledWith(['user1', 'user2'], 'tenant-1', 'welcome_to_vitana', expect.any(Object), mockSupabase);
+    });
+  });
+
+  describe('GET /sent', () => {
+    it('should return sent notifications', async () => {
+      const mockSupabase = createMockSupabase();
+      (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+
+      const response = await request(app).get('/admin/notifications/sent');
+      
+      expect(response.status).toBe(200);
+      expect(response.body.ok).toBe(true);
+      expect(response.body.data).toEqual([{ id: 'notif-1' }]);
+      expect(response.body.total).toBe(5);
+    });
+  });
+
+  describe('GET /preferences/stats', () => {
+    it('should return preference stats', async () => {
+      const mockSupabase = createMockSupabase();
+      (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+
+      const response = await request(app).get('/admin/notifications/preferences/stats');
+      
+      expect(response.status).toBe(200);
+      expect(response.body.ok).toBe(true);
+      expect(response.body.stats.total_users_with_prefs).toBe(2);
+      expect(response.body.stats.push_enabled).toBe(1);
+      expect(response.body.stats.push_disabled).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses missing authentication flagged by `route-auth-scanner-v1` in `admin-notifications.ts`. 

- Replaces inline `verifyExafyAdmin` logic with the centralized `requireAdmin` middleware.
- Refactors user identity extraction for logging to use `req.user` provided by the shared middleware.
- Adds comprehensive unit tests for the updated route implementation mocking the shared auth layer.