### PR TITLE
DEV-AUTOPILOT: Use standard requireAdmin middleware for admin-notifications

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -12,49 +12,18 @@
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/auth';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIFICATIONS';
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
+// Apply standard admin auth middleware to all routes in this router
+router.use(requireAdmin);
 
 // ── POST /compose — Send notification to user(s) ────────────
 
 router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -139,6 +108,8 @@ router.post('/compose', async (req: Request, res: Response) => {
     // Determine effective tenant_id for dispatching
     const effectiveTenantId = tenant_id || (recipient_ids?.length === 1 ? undefined : undefined);
 
+    const userEmail = (req as any).user?.email || 'unknown';
+
     // For single recipients, use synchronous dispatch for immediate feedback
     if (targetUserIds.length === 1) {
       const result = await notifyUser(
@@ -148,7 +119,7 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      console.log(`[${VTID}] Composed notification for 1 user by ${userEmail}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +132,7 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${userEmail}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -177,9 +148,6 @@ router.post('/compose', async (req: Request, res: Response) => {
 // ── GET /sent — Admin notification log ──────────────────────
 
 router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -224,9 +192,6 @@ router.get('/sent', async (req: Request, res: Response) => {
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
 router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,133 @@
+import express from 'express';
+import request from 'supertest';
+
+// Mock dependencies before importing the router
+jest.mock('../../src/middleware/auth', () => ({
+  requireAdmin: jest.fn((req, _res, next) => {
+    req.user = { id: 'admin-id', email: 'admin@test.com' };
+    next();
+  }),
+}));
+
+const mockSupabase = {
+  from: jest.fn(),
+};
+
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn(() => mockSupabase),
+}));
+
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn().mockResolvedValue({ success: true }),
+  notifyUsersAsync: jest.fn(),
+}));
+
+import adminNotificationsRouter from '../../src/routes/admin-notifications';
+import { requireAdmin } from '../../src/middleware/auth';
+
+describe('Admin Notifications Router', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    app = express();
+    app.use(express.json());
+    app.use('/admin/notifications', adminNotificationsRouter);
+  });
+
+  describe('POST /compose', () => {
+    it('should use the requireAdmin middleware', async () => {
+      await request(app).post('/admin/notifications/compose').send({ title: 'a', body: 'b', recipient_ids: ['1'] });
+      expect(requireAdmin).toHaveBeenCalled();
+    });
+
+    it('should fail if title or body is missing', async () => {
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ recipient_ids: ['user-1'] });
+      
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('INVALID_INPUT');
+    });
+
+    it('should fail if no recipients are specified', async () => {
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ title: 'Test Title', body: 'Test Body' });
+      
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('INVALID_INPUT');
+    });
+
+    it('should send notification to a single user successfully', async () => {
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ title: 'Test Title', body: 'Test Body', recipient_ids: ['user-1'] });
+      
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.sent_to).toBe(1);
+    });
+
+    it('should return error if Supabase query fails for role lookup', async () => {
+      const eqMock2 = jest.fn().mockResolvedValue({ data: null, error: { message: 'DB Error' } });
+      const eqMock1 = jest.fn().mockReturnValue({ eq: eqMock2 });
+      mockSupabase.from.mockReturnValue({
+        select: jest.fn().mockReturnValue({ eq: eqMock1 }),
+      });
+
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ title: 'Test', body: 'Body', recipient_role: 'user', tenant_id: 't1' });
+      
+      expect(res.status).toBe(500);
+      expect(res.body.ok).toBe(false);
+    });
+  });
+
+  describe('GET /sent', () => {
+    it('should return sent notifications', async () => {
+      const rangeMock = jest.fn().mockResolvedValue({ data: [{ id: 1 }], count: 1, error: null });
+      const orderMock = jest.fn().mockReturnValue({ range: rangeMock });
+      const gteMock = jest.fn().mockReturnValue({ order: orderMock });
+      mockSupabase.from.mockReturnValue({
+        select: jest.fn().mockReturnValue({ gte: gteMock }),
+      });
+
+      const res = await request(app).get('/admin/notifications/sent');
+      
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.data.length).toBe(1);
+      expect(res.body.total).toBe(1);
+    });
+  });
+
+  describe('GET /preferences/stats', () => {
+    it('should return stats correctly', async () => {
+      const mockGte = jest.fn();
+      mockGte.mockReturnValueOnce(Promise.resolve({ count: 5 }));
+      mockGte.mockReturnValueOnce({ not: jest.fn().mockResolvedValue({ count: 1 }) });
+
+      mockSupabase.from.mockImplementation((table) => {
+        if (table === 'user_notification_preferences') {
+          return {
+            select: jest.fn().mockResolvedValue({ data: [{ push_enabled: true }], error: null }),
+          };
+        }
+        if (table === 'user_notifications') {
+          return {
+            select: jest.fn().mockReturnValue({ gte: mockGte }),
+          };
+        }
+      });
+
+      const res = await request(app).get('/admin/notifications/preferences/stats');
+      
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.stats.push_enabled).toBe(1);
+      expect(res.body.delivery.total_sent_30d).toBe(5);
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses missing authentication findings from `route-auth-scanner-v1`. 
The `admin-notifications.ts` route file previously implemented an inline `verifyExafyAdmin` function, which duplicated standard admin auth logic and bypassed the scanner.

This change:
1. Replaces the inline `verifyExafyAdmin` and token extraction logic with the shared `requireAdmin` middleware.
2. Applies the middleware to the entire router (`router.use(requireAdmin)`).
3. Adapts handler code to use `req.user.email` instead of `authResult.email` for logging purposes.
4. Creates a new test file `admin-notifications.test.ts` to mock the middleware and ensure the endpoints remain testable.

Files touched:
- `services/gateway/src/routes/admin-notifications.ts` (modified)
- `services/gateway/test/routes/admin-notifications.test.ts` (created)