### PR TITLE
DEV-AUTOPILOT: Add system controls gateway API for feature flags

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,22 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { getSystemControl } from '../services/system-controls';
+
+export const systemControlsRouter = Router();
+
+systemControlsRouter.get('/:key', async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const { key } = req.params;
+    const control = await getSystemControl(key);
+
+    if (!control) {
+      res.status(404).json({ error: 'System control not found' });
+      return;
+    }
+
+    res.status(200).json(control);
+  } catch (error) {
+    next(error);
+  }
+});
+
+export default systemControlsRouter;

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,19 @@
+import { supabase } from '../lib/supabase';
+import { SystemControl } from '../types/system-controls';
+
+export async function getSystemControl(key: string): Promise<SystemControl | null> {
+  const { data, error } = await supabase
+    .from('system_controls')
+    .select('*')
+    .eq('key', key)
+    .single();
+
+  if (error) {
+    if (error.code === 'PGRST116') {
+      return null;
+    }
+    throw error;
+  }
+
+  return data as SystemControl;
+}

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at?: string | null;
+  updated_by?: string | null;
+  reason?: string | null;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,52 @@
+import request from 'supertest';
+import express, { Request, Response, NextFunction } from 'express';
+import { systemControlsRouter } from '../../src/routes/system-controls';
+import * as systemControlsService from '../../src/services/system-controls';
+
+jest.mock('../../src/services/system-controls');
+
+const app = express();
+app.use(express.json());
+app.use('/api/system-controls', systemControlsRouter);
+
+// Add a generic error handler to prevent supertest from logging errors to console
+app.use((err: Error, req: Request, res: Response, next: NextFunction) => {
+  res.status(500).json({ error: err.message });
+});
+
+describe('System Controls Routes', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('GET /api/system-controls/:key', () => {
+    it('should return 200 and the control if found', async () => {
+      const mockControl = { key: 'test_flag', enabled: true };
+      jest.spyOn(systemControlsService, 'getSystemControl').mockResolvedValue(mockControl);
+
+      const res = await request(app).get('/api/system-controls/test_flag');
+
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual(mockControl);
+      expect(systemControlsService.getSystemControl).toHaveBeenCalledWith('test_flag');
+    });
+
+    it('should return 404 if control not found', async () => {
+      jest.spyOn(systemControlsService, 'getSystemControl').mockResolvedValue(null);
+
+      const res = await request(app).get('/api/system-controls/missing_flag');
+
+      expect(res.status).toBe(404);
+      expect(res.body).toEqual({ error: 'System control not found' });
+    });
+
+    it('should return 500 on server error', async () => {
+      jest.spyOn(systemControlsService, 'getSystemControl').mockRejectedValue(new Error('Internal Server Error'));
+
+      const res = await request(app).get('/api/system-controls/test_flag');
+
+      expect(res.status).toBe(500);
+      expect(res.body).toEqual({ error: 'Internal Server Error' });
+    });
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,54 @@
+import { getSystemControl } from '../src/services/system-controls';
+import { supabase } from '../src/lib/supabase';
+
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+describe('System Controls Service', () => {
+  let fromMock: jest.Mock;
+  let selectMock: jest.Mock;
+  let eqMock: jest.Mock;
+  let singleMock: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    singleMock = jest.fn();
+    eqMock = jest.fn().mockReturnValue({ single: singleMock });
+    selectMock = jest.fn().mockReturnValue({ eq: eqMock });
+    fromMock = jest.fn().mockReturnValue({ select: selectMock });
+
+    (supabase.from as jest.Mock) = fromMock;
+  });
+
+  describe('getSystemControl', () => {
+    it('should return a system control if found', async () => {
+      const mockControl = { key: 'test_flag', enabled: true };
+      singleMock.mockResolvedValue({ data: mockControl, error: null });
+
+      const result = await getSystemControl('test_flag');
+
+      expect(fromMock).toHaveBeenCalledWith('system_controls');
+      expect(selectMock).toHaveBeenCalledWith('*');
+      expect(eqMock).toHaveBeenCalledWith('key', 'test_flag');
+      expect(result).toEqual(mockControl);
+    });
+
+    it('should return null if not found (PGRST116)', async () => {
+      singleMock.mockResolvedValue({ data: null, error: { code: 'PGRST116' } });
+
+      const result = await getSystemControl('missing_flag');
+
+      expect(result).toBeNull();
+    });
+
+    it('should throw on other errors', async () => {
+      singleMock.mockResolvedValue({ data: null, error: { message: 'DB Error' } });
+
+      await expect(getSystemControl('test_flag')).rejects.toEqual({ message: 'DB Error' });
+    });
+  });
+});


### PR DESCRIPTION
This PR introduces the `system-controls` API endpoints to the gateway, which enables fetching system configuration flags (like the newly added `vitana_did_you_know_enabled` flag from the `20260425100000_BOOTSTRAP_dyk_flag_on.sql` migration) via the frontend or other consumers.

Files created:
- `services/gateway/src/types/system-controls.ts` - Type definitions for a system control.
- `services/gateway/src/services/system-controls.ts` - Service layer interacting with Supabase to fetch system controls by key.
- `services/gateway/src/routes/system-controls.ts` - Express router exposing `GET /api/system-controls/:key`.
- Tests for both the service and the router.

*Note on Command Hub (Frontend) Changes:*
Due to strict PR file-scope constraints for this plan, modifications to the `command-hub` codebase are out of scope here. To complete the "Did You Know?" tour feature, please follow up by adding a fetch to `/api/system-controls/vitana_did_you_know_enabled` on component mount in the appropriate tour-rendering component in `command-hub`.