### PR TITLE
DEV-AUTOPILOT: Add system controls API endpoint for frontend DYK flag

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,20 @@
+import { Router, Request, Response, NextFunction } from 'express';
+import { getSystemControl } from '../services/system-controls';
+
+export const systemControlsRouter = Router();
+
+systemControlsRouter.get('/:key', async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    const { key } = req.params;
+    const control = await getSystemControl(key);
+
+    if (!control) {
+      res.status(404).json({ error: 'System control not found' });
+      return;
+    }
+
+    res.json(control);
+  } catch (error) {
+    next(error);
+  }
+});

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,20 @@
+import { supabase } from '../lib/supabase';
+import { SystemControl } from '../types/system-controls';
+
+export async function getSystemControl(key: string): Promise<SystemControl | null> {
+  const { data, error } = await supabase
+    .from('system_controls')
+    .select('*')
+    .eq('key', key)
+    .single();
+
+  if (error) {
+    if (error.code === 'PGRST116') {
+      // PGRST116 indicates no rows were returned from a .single() query
+      return null;
+    }
+    throw error;
+  }
+
+  return data as SystemControl;
+}

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at?: string;
+  updated_by?: string;
+  reason?: string;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,49 @@
+import request from 'supertest';
+import express, { Request, Response, NextFunction } from 'express';
+import { systemControlsRouter } from '../../src/routes/system-controls';
+import * as systemControlsService from '../../src/services/system-controls';
+
+jest.mock('../../src/services/system-controls');
+
+const app = express();
+app.use(express.json());
+app.use('/api/system-controls', systemControlsRouter);
+// Basic error handler to catch next(error) calls
+app.use((err: any, req: Request, res: Response, next: NextFunction) => {
+  res.status(500).json({ error: 'Internal Server Error' });
+});
+
+describe('System Controls Route', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return 200 and the control if found', async () => {
+    const mockControl = { key: 'vitana_did_you_know_enabled', enabled: true };
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(mockControl);
+
+    const response = await request(app).get('/api/system-controls/vitana_did_you_know_enabled');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual(mockControl);
+    expect(systemControlsService.getSystemControl).toHaveBeenCalledWith('vitana_did_you_know_enabled');
+  });
+
+  it('should return 404 if control not found', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockResolvedValue(null);
+
+    const response = await request(app).get('/api/system-controls/unknown_key');
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'System control not found' });
+  });
+
+  it('should call next(error) if service throws an error', async () => {
+    (systemControlsService.getSystemControl as jest.Mock).mockRejectedValue(new Error('Test error'));
+
+    const response = await request(app).get('/api/system-controls/error_key');
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: 'Internal Server Error' });
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,52 @@
+import { getSystemControl } from '../src/services/system-controls';
+import { supabase } from '../src/lib/supabase';
+
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn(),
+  },
+}));
+
+describe('System Controls Service', () => {
+  const mockFrom = supabase.from as jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return a system control if found', async () => {
+    const mockData = { key: 'vitana_did_you_know_enabled', enabled: true };
+    const mockSingle = jest.fn().mockResolvedValue({ data: mockData, error: null });
+    const mockEq = jest.fn().mockReturnValue({ single: mockSingle });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    mockFrom.mockReturnValue({ select: mockSelect });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+
+    expect(mockFrom).toHaveBeenCalledWith('system_controls');
+    expect(mockSelect).toHaveBeenCalledWith('*');
+    expect(mockEq).toHaveBeenCalledWith('key', 'vitana_did_you_know_enabled');
+    expect(result).toEqual(mockData);
+  });
+
+  it('should return null if control is not found (PGRST116)', async () => {
+    const mockSingle = jest.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } });
+    const mockEq = jest.fn().mockReturnValue({ single: mockSingle });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    mockFrom.mockReturnValue({ select: mockSelect });
+
+    const result = await getSystemControl('missing_key');
+
+    expect(result).toBeNull();
+  });
+
+  it('should throw an error on other database errors', async () => {
+    const mockError = { code: 'OTHER', message: 'DB Error' };
+    const mockSingle = jest.fn().mockResolvedValue({ data: null, error: mockError });
+    const mockEq = jest.fn().mockReturnValue({ single: mockSingle });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    mockFrom.mockReturnValue({ select: mockSelect });
+
+    await expect(getSystemControl('error_key')).rejects.toEqual(mockError);
+  });
+});


### PR DESCRIPTION
This PR introduces the necessary backend infrastructure for querying system control flags from the database, specifically to check the `vitana_did_you_know_enabled` flag toggled in migration `20260425100000_BOOTSTRAP_dyk_flag_on.sql`.

It sets up a new `GET /api/system-controls/:key` endpoint which fetches records from the `system_controls` table using Supabase.

### Out of scope note for operator:
Since frontend files were not included in the strictly constrained file list for this PR, the update to the `command-hub` frontend application (to fetch `/api/system-controls/vitana_did_you_know_enabled` on mount and conditionally display the DYK tour) has been deferred. Please add the required frontend HTTP call and conditional rendering logic in the relevant `command-hub` components in a follow-up commit or PR.

Files touched:
- `services/gateway/src/types/system-controls.ts`
- `services/gateway/src/services/system-controls.ts`
- `services/gateway/src/routes/system-controls.ts`
- `services/gateway/test/system-controls.test.ts`
- `services/gateway/test/routes/system-controls.test.ts`