### PR TITLE
DEV-AUTOPILOT: Add paramLimit middleware to mitigate path-to-regexp ReDoS

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,29 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+/**
+ * Middleware to mitigate ReDoS vulnerabilities in express routing (path-to-regexp).
+ * Rejects requests that contain an excessive number of path parameters or parameter values that are too long.
+ *
+ * @param maxParams Maximum allowed number of path parameters (default: 5)
+ * @param maxLength Maximum allowed string length of any single path parameter (default: 200)
+ */
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+    return (req: Request, res: Response, next: NextFunction): void => {
+        const keys = Object.keys(req.params || {});
+
+        if (keys.length > maxParams) {
+            res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+            return;
+        }
+
+        for (const key of keys) {
+            const value = req.params[key];
+            if (value && typeof value === 'string' && value.length > maxLength) {
+                res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+                return;
+            }
+        }
+
+        next();
+    };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,21 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router({ mergeParams: true });
+
+// Apply path parameter limits to mitigate ReDoS
+router.use(limitPathParams());
+
+router.get('/', (req: Request, res: Response) => {
+    res.status(200).json({ message: 'Project list' });
+});
+
+router.get('/:projectId', (req: Request, res: Response) => {
+    res.status(200).json({ project: req.params.projectId });
+});
+
+router.get('/:projectId/members/:memberId', (req: Request, res: Response) => {
+    res.status(200).json({ project: req.params.projectId, member: req.params.memberId });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,21 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router({ mergeParams: true });
+
+// Apply path parameter limits to mitigate ReDoS
+router.use(limitPathParams());
+
+router.get('/', (req: Request, res: Response) => {
+    res.status(200).json({ message: 'User list' });
+});
+
+router.get('/:userId', (req: Request, res: Response) => {
+    res.status(200).json({ user: req.params.userId });
+});
+
+router.get('/:userId/profile', (req: Request, res: Response) => {
+    res.status(200).json({ user: req.params.userId, profile: true });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,55 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - paramLimit Middleware', () => {
+    let app: express.Application;
+
+    beforeEach(() => {
+        app = express();
+
+        // Test route 1: Excessive parameters
+        app.get('/test/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+            res.status(200).json({ success: true });
+        });
+
+        // Test route 2: Long parameter
+        app.get('/long/:a', limitPathParams(5, 200), (req: Request, res: Response) => {
+            res.status(200).json({ success: true });
+        });
+
+        // Test route 3: Valid standard request
+        app.get('/valid/:a/:b', limitPathParams(5, 200), (req: Request, res: Response) => {
+            res.status(200).json({ success: true });
+        });
+    });
+
+    it('should reject requests with more than 5 path parameters', async () => {
+        const response = await request(app).get('/test/1/2/3/4/5/6');
+        expect(response.status).toBe(400);
+        expect(response.body.error).toBe('Too many path parameters or parameter too long');
+    });
+
+    it('should reject requests with path parameters exceeding max length', async () => {
+        const longParam = 'a'.repeat(201);
+        const response = await request(app).get(`/long/${longParam}`);
+        expect(response.status).toBe(400);
+        expect(response.body.error).toBe('Too many path parameters or parameter too long');
+    });
+
+    it('should allow valid requests (<= 5 params, <= 200 length)', async () => {
+        const response = await request(app).get('/valid/foo/bar');
+        expect(response.status).toBe(200);
+        expect(response.body.success).toBe(true);
+    });
+
+    it('integration test: should respond quickly and block potential ReDoS payloads', async () => {
+        const start = Date.now();
+        const response = await request(app).get('/test/a/b/c/d/e/f');
+        const duration = Date.now() - start;
+
+        expect(response.status).toBe(400);
+        // Ensure that the rejection takes negligible processing time
+        expect(duration).toBeLessThan(200);
+    });
+});


### PR DESCRIPTION
**Context & Mitigation**
A Regular Expression Denial of Service (ReDoS) vulnerability exists in `path-to-regexp` (< 0.1.13) which is transitively used by Express. Attackers can trigger catastrophic backtracking by sending requests with excessive or excessively long path parameters. 

While a full dependency update is pending in another track, this PR introduces a server-side validation middleware (`paramLimit.ts`) in the API Gateway. This middleware limits the number of path parameters (max 5) and the string length of each parameter (max 200 characters). 

**Changes**
- Added `limitPathParams` middleware to parse `req.params`, enforcing parameter count and length limits.
- Applied this middleware to `userRoutes.ts` and `projectRoutes.ts` as a preventative layer. (Note: other routes containing path parameters should also use this middleware).
- Added `cve-mitigation.test.ts` to ensure the middleware successfully drops malicious shapes (returning `400 Bad Request`) and passes normal requests with minimal latency (<200ms).