### PR TITLE
DEV-AUTOPILOT: Add system controls API endpoint for gateway

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,21 @@
+import { Router, Request, Response } from 'express';
+import { getSystemControl } from '../services/system-controls';
+
+const router = Router();
+
+router.get('/:key', async (req: Request, res: Response) => {
+  try {
+    const { key } = req.params;
+    const control = await getSystemControl(key);
+
+    if (!control) {
+      return res.status(404).json({ error: 'System control not found' });
+    }
+
+    return res.status(200).json(control);
+  } catch (error) {
+    return res.status(500).json({ error: 'Internal server error' });
+  }
+});
+
+export default router;

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,16 @@
+import { supabase } from '../lib/supabase';
+import { SystemControl } from '../types/system-controls';
+
+export async function getSystemControl(key: string): Promise<SystemControl | null> {
+  const { data, error } = await supabase
+    .from('system_controls')
+    .select('*')
+    .eq('key', key)
+    .single();
+
+  if (error || !data) {
+    return null;
+  }
+
+  return data as SystemControl;
+}

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at?: string;
+  updated_by?: string;
+  reason?: string;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,47 @@
+import request from 'supertest';
+import express from 'express';
+import systemControlsRouter from '../../src/routes/system-controls';
+import * as systemControlsService from '../../src/services/system-controls';
+
+const app = express();
+app.use(express.json());
+app.use('/api/system-controls', systemControlsRouter);
+
+describe('system-controls route', () => {
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  it('should return 200 and the system control if found', async () => {
+    jest.spyOn(systemControlsService, 'getSystemControl').mockResolvedValue({
+      key: 'vitana_did_you_know_enabled',
+      enabled: true
+    });
+
+    const response = await request(app).get('/api/system-controls/vitana_did_you_know_enabled');
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({
+      key: 'vitana_did_you_know_enabled',
+      enabled: true
+    });
+  });
+
+  it('should return 404 if the system control is not found', async () => {
+    jest.spyOn(systemControlsService, 'getSystemControl').mockResolvedValue(null);
+
+    const response = await request(app).get('/api/system-controls/missing_key');
+
+    expect(response.status).toBe(404);
+    expect(response.body).toEqual({ error: 'System control not found' });
+  });
+
+  it('should return 500 on internal error', async () => {
+    jest.spyOn(systemControlsService, 'getSystemControl').mockRejectedValue(new Error('DB connection failed'));
+
+    const response = await request(app).get('/api/system-controls/some_key');
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ error: 'Internal server error' });
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,47 @@
+import { getSystemControl } from '../src/services/system-controls';
+import { supabase } from '../src/lib/supabase';
+
+jest.mock('../src/lib/supabase', () => ({
+  supabase: {
+    from: jest.fn()
+  }
+}));
+
+describe('system-controls service', () => {
+  const mockFrom = supabase.from as jest.Mock;
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should return a system control when found', async () => {
+    const mockData = { key: 'vitana_did_you_know_enabled', enabled: true };
+    
+    mockFrom.mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({ data: mockData, error: null })
+        })
+      })
+    });
+
+    const result = await getSystemControl('vitana_did_you_know_enabled');
+
+    expect(mockFrom).toHaveBeenCalledWith('system_controls');
+    expect(result).toEqual(mockData);
+  });
+
+  it('should return null when not found', async () => {
+    mockFrom.mockReturnValue({
+      select: jest.fn().mockReturnValue({
+        eq: jest.fn().mockReturnValue({
+          single: jest.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116' } })
+        })
+      })
+    });
+
+    const result = await getSystemControl('missing_key');
+
+    expect(result).toBeNull();
+  });
+});


### PR DESCRIPTION
This PR introduces the necessary service, route, and types in the gateway to fetch system control flags, specifically to allow the frontend to check the `vitana_did_you_know_enabled` flag.

## Changes:
- **`services/gateway/src/types/system-controls.ts`**: Defines the `SystemControl` type.
- **`services/gateway/src/services/system-controls.ts`**: Implements `getSystemControl(key)` using Supabase.
- **`services/gateway/src/routes/system-controls.ts`**: Adds `GET /:key` route to expose the system control.
- **Unit Tests**: Coverage added for the service and the route.

## Operator Note:
The frontend `command-hub` requires updates to fetch the newly exposed `/api/system-controls/vitana_did_you_know_enabled` endpoint. Since the exact frontend file path is unknown, please locate or create the relevant tour component (e.g., `DidYouKnowTour.tsx`) in the frontend, dispatch the fetch on mount, and conditionally render the tour based on the `enabled` flag. Also, remember to mount this new route in the main Express app, presumably at `/api/system-controls`.