### PR TITLE
DEV-AUTOPILOT: Refactor admin-notifications to use requireAdmin middleware

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -12,48 +12,18 @@
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/auth';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIFICATIONS';
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
+router.use(requireAdmin);
 
 // ── POST /compose — Send notification to user(s) ────────────
 
 router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
+  const adminEmail = (req as any).user?.email || 'unknown';
 
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
@@ -148,7 +118,7 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      console.log(`[${VTID}] Composed notification for 1 user by ${adminEmail}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +131,7 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${adminEmail}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -177,9 +147,6 @@ router.post('/compose', async (req: Request, res: Response) => {
 // ── GET /sent — Admin notification log ──────────────────────
 
 router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -224,9 +191,6 @@ router.get('/sent', async (req: Request, res: Response) => {
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
 router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,129 @@
+import request from 'supertest';
+import express from 'express';
+import adminNotificationsRouter from '../../src/routes/admin-notifications';
+
+// Mock the shared requireAdmin middleware to simulate an authenticated admin user
+jest.mock('../../src/middleware/auth', () => ({
+  requireAdmin: jest.fn((req, res, next) => {
+    req.user = { id: 'admin-1', email: 'admin@test.com' };
+    next();
+  })
+}));
+
+// Mock Supabase
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn()
+}));
+
+// Mock Notification Service
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn(),
+  notifyUsersAsync: jest.fn()
+}));
+
+const { getSupabase } = require('../../src/lib/supabase');
+const { notifyUser, notifyUsersAsync } = require('../../src/services/notification-service');
+
+describe('Admin Notifications Router', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    app = express();
+    app.use(express.json());
+    app.use('/admin/notifications', adminNotificationsRouter);
+  });
+
+  describe('POST /compose', () => {
+    it('should return 400 if title or body is missing', async () => {
+      getSupabase.mockReturnValue({});
+      
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ recipient_ids: ['user-1'] });
+      
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('INVALID_INPUT');
+    });
+
+    it('should return 400 if no recipients specified', async () => {
+      getSupabase.mockReturnValue({});
+      
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({ title: 'Test', body: 'Test body' });
+      
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('INVALID_INPUT');
+    });
+
+    it('should send notification to specific users', async () => {
+      getSupabase.mockReturnValue({});
+      notifyUser.mockResolvedValue(true);
+
+      const res = await request(app)
+        .post('/admin/notifications/compose')
+        .send({
+          title: 'Test',
+          body: 'Test body',
+          recipient_ids: ['user-1']
+        });
+      
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(notifyUser).toHaveBeenCalled();
+    });
+  });
+
+  describe('GET /sent', () => {
+    it('should return sent notifications', async () => {
+      const mockSupabase = {
+        from: jest.fn().mockReturnThis(),
+        select: jest.fn().mockReturnThis(),
+        gte: jest.fn().mockReturnThis(),
+        order: jest.fn().mockReturnThis(),
+        range: jest.fn().mockResolvedValue({ data: [{ id: 1 }], count: 1 })
+      };
+      getSupabase.mockReturnValue(mockSupabase);
+
+      const res = await request(app).get('/admin/notifications/sent');
+      
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.data).toHaveLength(1);
+    });
+  });
+
+  describe('GET /preferences/stats', () => {
+    it('should return aggregate stats', async () => {
+      const mockSupabase = {
+        from: jest.fn().mockImplementation((table) => {
+          if (table === 'user_notification_preferences') {
+            return {
+              select: jest.fn().mockResolvedValue({
+                data: [{ push_enabled: true }, { push_enabled: false }]
+              })
+            };
+          }
+          if (table === 'user_notifications') {
+            return {
+              select: jest.fn().mockReturnThis(),
+              gte: jest.fn().mockImplementation(() => {
+                const p: any = Promise.resolve({ count: 10 });
+                p.not = jest.fn().mockResolvedValue({ count: 5 });
+                return p;
+              })
+            };
+          }
+        })
+      };
+      getSupabase.mockReturnValue(mockSupabase);
+
+      const res = await request(app).get('/admin/notifications/preferences/stats');
+      
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.stats.push_enabled).toBe(1);
+    });
+  });
+});


### PR DESCRIPTION
This PR refactors the `admin-notifications.ts` route file to use the shared `requireAdmin` authentication middleware. This resolves missing-auth flags generated by `route-auth-scanner-v1` and ensures consistent access control across admin endpoints.

Changes include:
- Removing the inline `getBearerToken` and `verifyExafyAdmin` functions.
- Adding `router.use(requireAdmin)` to enforce authentication on all routes in the file.
- Adjusting `console.log` statements to use `req.user.email` from the middleware's request object context.
- Creating the `admin-notifications.test.ts` file to ensure the route endpoints correctly handle authenticated requests using the shared middleware.