### PR TITLE
DEV-AUTOPILOT: Enforce auth checks on telemetry event routes

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,37 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+// Middleware to enforce Supabase session
+async function requireAuth(req: Request, res: Response, next: NextFunction): Promise<void> {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    res.status(401).json({ error: "Unauthorized", detail: "Missing or invalid Authorization header" });
+    return;
+  }
+
+  const token = authHeader.split(" ")[1];
+  let data, error;
+  try {
+    const result = await supabase.auth.getUser(token);
+    data = result.data;
+    error = result.error;
+  } catch (err) {
+    res.status(500).json({ error: "Internal server error", detail: "Auth verification failed" });
+    return;
+  }
+
+  if (error || !data?.user) {
+    res.status(401).json({ error: "Unauthorized", detail: "Invalid session token" });
+    return;
+  }
+
+  next();
+}
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +54,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +174,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,164 @@
+import request from "supertest";
+import express from "express";
+import { router as telemetryRouter } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn()
+    }
+  }
+}));
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1/telemetry", telemetryRouter);
+
+describe("Telemetry Routes Auth Enforcement", () => {
+  let consoleErrorSpy: jest.SpyInstance;
+  let consoleLogSpy: jest.SpyInstance;
+  let consoleWarnSpy: jest.SpyInstance;
+  let originalFetch: typeof global.fetch;
+
+  beforeAll(() => {
+    process.env.SUPABASE_URL = "http://localhost:8000";
+    process.env.SUPABASE_SERVICE_ROLE = "test-key";
+    
+    consoleErrorSpy = jest.spyOn(console, "error").mockImplementation(() => {});
+    consoleLogSpy = jest.spyOn(console, "log").mockImplementation(() => {});
+    consoleWarnSpy = jest.spyOn(console, "warn").mockImplementation(() => {});
+  });
+
+  afterAll(() => {
+    delete process.env.SUPABASE_URL;
+    delete process.env.SUPABASE_SERVICE_ROLE;
+    
+    consoleErrorSpy.mockRestore();
+    consoleLogSpy.mockRestore();
+    consoleWarnSpy.mockRestore();
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    originalFetch = global.fetch;
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      json: async () => ({})
+    } as any);
+  });
+
+  afterEach(() => {
+    global.fetch = originalFetch;
+  });
+
+  describe("POST /api/v1/telemetry/event", () => {
+    it("returns 401 when no token is provided", async () => {
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send({
+          vtid: "VTID-123",
+          layer: "app",
+          module: "test",
+          source: "jest",
+          kind: "test.event",
+          status: "info",
+          title: "Test Event"
+        });
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe("Unauthorized");
+    });
+
+    it("returns 401 when an invalid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: null },
+        error: new Error("Invalid token")
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid-token")
+        .send({
+          vtid: "VTID-123",
+          layer: "app",
+          module: "test",
+          source: "jest",
+          kind: "test.event",
+          status: "info",
+          title: "Test Event"
+        });
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe("Unauthorized");
+    });
+
+    it("proceeds when a valid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send({
+          vtid: "VTID-123",
+          layer: "app",
+          module: "test",
+          source: "jest",
+          kind: "test.event",
+          status: "info",
+          title: "Test Event"
+        });
+
+      expect(response.status).toBe(202);
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    it("returns 401 when no token is provided", async () => {
+      const response = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send([
+          {
+            vtid: "VTID-123",
+            layer: "app",
+            module: "test",
+            source: "jest",
+            kind: "test.event",
+            status: "info",
+            title: "Test Event"
+          }
+        ]);
+
+      expect(response.status).toBe(401);
+    });
+
+    it("proceeds when a valid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-token")
+        .send([
+          {
+            vtid: "VTID-123",
+            layer: "app",
+            module: "test",
+            source: "jest",
+            kind: "test.event",
+            status: "info",
+            title: "Test Event"
+          }
+        ]);
+
+      expect(response.status).toBe(202);
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
This PR adds application-level authentication checks to telemetry routes that modify `oasis_events` to mitigate a flagged `rls_gap` vulnerability.

- A new `requireAuth` middleware is introduced to extract and verify Supabase sessions.
- The middleware is applied to `POST /event` and `POST /batch` to prevent unauthenticated clients from proxying writes to `oasis_events` via the API.
- Comprehensive unit tests are added to ensure unauthenticated requests receive a `401 Unauthorized` and authenticated requests proceed normally.
- **Note to Operator:** The automated executor is forbidden from modifying `supabase/migrations/`. You must manually create and apply the database-level RLS migration to fully close the gap (e.g., `ALTER TABLE public.oasis_events ENABLE ROW LEVEL SECURITY;`).

Files touched:
- `services/gateway/src/routes/telemetry.ts`
- `services/gateway/test/routes/telemetry.test.ts`