### PR TITLE
DEV-AUTOPILOT: Add paramLimit middleware to mitigate path-to-regexp ReDoS

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,43 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // 1. Validate route parameters if they are already populated
+    const params = req.params || {};
+    const keys = Object.keys(params);
+
+    if (keys.length > maxParams) {
+      res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    for (const key of keys) {
+      if (params[key] && params[key].length > maxLength) {
+        res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    // 2. Uses RegExp only for validation of the raw path, avoiding the vulnerable 
+    // path-to-regexp matching. This provides protection even when applied globally via router.use()
+    const path = req.path || '';
+
+    // Reject if any path segment exceeds maxLength
+    const longSegmentRegex = new RegExp(`[^/]{${maxLength + 1},}`);
+    if (longSegmentRegex.test(path)) {
+      res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    // Reject if there are an excessive number of path segments (ReDoS heuristic)
+    // We allow up to maxParams + a baseline of 5 static segments
+    const maxSegments = maxParams + 5;
+    const segmentCount = (path.match(/\//g) || []).length;
+    if (segmentCount > maxSegments) {
+      res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,21 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply param limit middleware to prevent ReDoS on all routes in this router
+router.use(limitPathParams());
+
+router.get('/', (req: Request, res: Response) => {
+  res.status(200).json({ projects: [] });
+});
+
+router.get('/:projectId', (req: Request, res: Response) => {
+  res.status(200).json({ id: req.params.projectId, type: 'project' });
+});
+
+router.post('/', (req: Request, res: Response) => {
+  res.status(201).json({ success: true });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,21 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply param limit middleware to prevent ReDoS on all routes in this router
+router.use(limitPathParams());
+
+router.get('/', (req: Request, res: Response) => {
+  res.status(200).json({ users: [] });
+});
+
+router.get('/:userId', (req: Request, res: Response) => {
+  res.status(200).json({ id: req.params.userId, type: 'user' });
+});
+
+router.post('/', (req: Request, res: Response) => {
+  res.status(201).json({ success: true });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,64 @@
+import express from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE-Mitigation: ReDoS on path-to-regexp', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = express();
+    const limitParams = limitPathParams(5, 200);
+
+    // Apply globally as router.use() to test the fallback regex logic
+    app.use(limitParams);
+
+    // Apply directly to routes to test the req.params parsing logic
+    app.get('/resource/:a/:b/:c/:d/:e/:f', limitParams, (req, res) => {
+      res.status(200).json({ success: true });
+    });
+
+    app.get('/normal/:id', limitParams, (req, res) => {
+      res.status(200).json({ id: req.params.id });
+    });
+    
+    app.get('/multiple/:a/:b', limitParams, (req, res) => {
+      res.status(200).json({ success: true });
+    });
+
+    app.get('/redos/:a/:b/:c/:d/:e/:f?', limitParams, (req, res) => {
+      res.status(200).json({ success: true });
+    });
+  });
+
+  it('should reject requests with >5 path parameters', async () => {
+    const start = Date.now();
+    const response = await request(app).get('/resource/1/2/3/4/5/6');
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Too many path parameters or parameter too long');
+    expect(Date.now() - start).toBeLessThan(200);
+  });
+
+  it('should reject requests with path parameter longer than 200 chars', async () => {
+    const longParam = 'a'.repeat(201);
+    const start = Date.now();
+    const response = await request(app).get(`/normal/${longParam}`);
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Too many path parameters or parameter too long');
+    expect(Date.now() - start).toBeLessThan(200);
+  });
+
+  it('should pass requests with <=5 path parameters of valid length', async () => {
+    const response = await request(app).get('/multiple/1/2');
+    expect(response.status).toBe(200);
+  });
+
+  it('integration: pathological request is mitigated and returns quickly', async () => {
+    // Generate a deeply nested path to trigger the raw path protection (segment count > maxParams + 5)
+    const pathologicalPath = '/redos/1/2/3/4/5/6/7/8/9/10/11/12/13/14/15';
+    const start = Date.now();
+    const response = await request(app).get(pathologicalPath);
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Too many path parameters or parameter too long');
+    expect(Date.now() - start).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
This PR addresses the Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (<0.1.13) used by `express` in `services/gateway`. 

Since dependency updates to `package.json` are outside the scope of this fix, we are introducing a server-side validation middleware `limitPathParams`. This middleware intercepts requests and restricts the maximum number of path parameters (default: 5) and the maximum length of any given parameter (default: 200). It employs direct evaluation of `req.params` and fallback raw-path `RegExp` checks to ensure execution finishes before catastrophic backtracking occurs during Express's internal route matching.

Files added/modified:
- `services/gateway/src/routes/middleware/paramLimit.ts`: The validation middleware.
- `services/gateway/src/routes/v1/userRoutes.ts`: Applied the mitigation middleware.
- `services/gateway/src/routes/v1/projectRoutes.ts`: Applied the mitigation middleware.
- `services/gateway/test/cve-mitigation.test.ts`: Integration and unit tests validating pass/reject criteria and response times.

*Note for Operators: Ensure that this middleware is also applied to any other pre-existing or new route files in `services/gateway/src/routes/` containing path parameters, and ensure that a separate PR is eventually scheduled to bump `express` and `path-to-regexp` across the mono-repo.*