### PR TITLE
DEV-AUTOPILOT: Refactor admin-notifications routes to use standard requireAdmin middleware

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -12,51 +12,21 @@
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/auth';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIFICATIONS';
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
+router.use(requireAdmin);
 
 // ── POST /compose — Send notification to user(s) ────────────
 
 router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
+
+  const userEmail = (req as any).user?.email || 'unknown';
 
   const {
     recipient_ids,   // string[] — specific user IDs
@@ -148,7 +118,7 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      console.log(`[${VTID}] Composed notification for 1 user by ${userEmail}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +131,7 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${userEmail}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -177,9 +147,6 @@ router.post('/compose', async (req: Request, res: Response) => {
 // ── GET /sent — Admin notification log ──────────────────────
 
 router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -224,9 +191,6 @@ router.get('/sent', async (req: Request, res: Response) => {
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
 router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,132 @@
+import request from 'supertest';
+import express from 'express';
+import adminNotificationsRouter from '../../src/routes/admin-notifications';
+import { getSupabase } from '../../src/lib/supabase';
+import { notifyUser, notifyUsersAsync } from '../../src/services/notification-service';
+
+// Mock middleware
+jest.mock('../../src/middleware/auth', () => ({
+  requireAdmin: jest.fn((req, res, next) => {
+    (req as any).user = { id: 'admin-id', email: 'admin@test.com' };
+    next();
+  }),
+}));
+
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn(),
+}));
+
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn(),
+  notifyUsersAsync: jest.fn(),
+}));
+
+describe('Admin Notifications Routes', () => {
+  let app: express.Express;
+  let mockSupabase: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    app = express();
+    app.use(express.json());
+    app.use('/admin/notifications', adminNotificationsRouter);
+
+    mockSupabase = {
+      from: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      or: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      range: jest.fn().mockReturnThis(),
+      not: jest.fn().mockReturnThis(),
+    };
+    (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+  });
+
+  describe('POST /compose', () => {
+    it('requires valid input', async () => {
+      const res = await request(app).post('/admin/notifications/compose').send({});
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('INVALID_INPUT');
+    });
+
+    it('sends notification to specific recipient', async () => {
+      (notifyUser as jest.Mock).mockResolvedValueOnce(true);
+
+      const res = await request(app).post('/admin/notifications/compose').send({
+        recipient_ids: ['user-1'],
+        title: 'Test',
+        body: 'Test body',
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body.sent_to).toBe(1);
+      expect(notifyUser).toHaveBeenCalledWith(
+        'user-1',
+        '',
+        'welcome_to_vitana',
+        expect.objectContaining({ title: 'Test', body: 'Test body' }),
+        mockSupabase
+      );
+    });
+
+    it('sends to multiple users', async () => {
+      mockSupabase.from.mockReturnValueOnce({
+        select: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockReturnThis(),
+        eq: jest.fn().mockResolvedValueOnce({
+          data: [{ user_id: 'user-2' }, { user_id: 'user-3' }],
+          error: null,
+        }),
+      });
+
+      const res = await request(app).post('/admin/notifications/compose').send({
+        recipient_role: 'community',
+        tenant_id: 'tenant-1',
+        title: 'Test',
+        body: 'Test body',
+      });
+
+      expect(res.status).toBe(200);
+      expect(res.body.sent_to).toBe(2);
+      expect(notifyUsersAsync).toHaveBeenCalled();
+    });
+  });
+
+  describe('GET /sent', () => {
+    it('returns sent notifications', async () => {
+      mockSupabase.range.mockResolvedValueOnce({
+        data: [{ id: 'notif-1' }],
+        count: 1,
+        error: null,
+      });
+
+      const res = await request(app).get('/admin/notifications/sent');
+      expect(res.status).toBe(200);
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.total).toBe(1);
+    });
+  });
+
+  describe('GET /preferences/stats', () => {
+    it('returns preference stats', async () => {
+      // Mock preferences
+      mockSupabase.select.mockResolvedValueOnce({
+        data: [{ push_enabled: true }, { push_enabled: false }],
+        error: null,
+      });
+
+      // Mock count 1
+      mockSupabase.gte.mockResolvedValueOnce({ count: 10, error: null });
+      // Mock count 2
+      mockSupabase.not.mockResolvedValueOnce({ count: 5, error: null });
+
+      const res = await request(app).get('/admin/notifications/preferences/stats');
+      expect(res.status).toBe(200);
+      expect(res.body.stats.push_enabled).toBe(1);
+      expect(res.body.delivery.total_sent_30d).toBe(10);
+      expect(res.body.delivery.read_rate).toBe(50);
+    });
+  });
+});


### PR DESCRIPTION
**Summary**
This PR standardizes authentication in `admin-notifications.ts` by replacing inline authentication helpers (`verifyExafyAdmin`) with the standard `requireAdmin` middleware. 

**Changes**
- Removed `getBearerToken` and `verifyExafyAdmin` inline functions.
- Dropped `createUserSupabaseClient` dependency as token parsing is done by `requireAdmin`.
- Applied `router.use(requireAdmin)` to the `admin-notifications` router.
- Updated `console.log` statements to pull the admin user's email from `req.user`.
- Added corresponding unit tests in `services/gateway/test/routes/admin-notifications.test.ts`.

These changes resolve the `missing_auth` flag raised by `route-auth-scanner-v1`.