### PR TITLE
DEV-AUTOPILOT: Use standard requireAdmin middleware in admin notifications

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -12,49 +12,17 @@
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/auth';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIFICATIONS';
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
+router.use(requireAdmin);
 
 // ── POST /compose — Send notification to user(s) ────────────
 
 router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -148,7 +116,7 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      console.log(`[${VTID}] Composed notification for 1 user by ${(req as any).user?.email || 'unknown'}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +129,7 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${(req as any).user?.email || 'unknown'}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -177,9 +145,6 @@ router.post('/compose', async (req: Request, res: Response) => {
 // ── GET /sent — Admin notification log ──────────────────────
 
 router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -224,9 +189,6 @@ router.get('/sent', async (req: Request, res: Response) => {
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
 router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,162 @@
+import request from 'supertest';
+import express from 'express';
+import adminNotificationsRouter from '../../src/routes/admin-notifications';
+import { requireAdmin } from '../../src/middleware/auth';
+import { getSupabase } from '../../src/lib/supabase';
+import { notifyUser, notifyUsersAsync } from '../../src/services/notification-service';
+
+jest.mock('../../src/middleware/auth', () => ({
+  requireAdmin: jest.fn((req, res, next) => {
+    req.user = { id: 'admin-123', email: 'admin@test.com' };
+    next();
+  })
+}));
+
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn()
+}));
+
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn(),
+  notifyUsersAsync: jest.fn()
+}));
+
+describe('Admin Notifications Router', () => {
+  let app: express.Application;
+  let mockQueryObj: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    
+    mockQueryObj = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      range: jest.fn().mockReturnThis(),
+      or: jest.fn().mockReturnThis(),
+      not: jest.fn().mockReturnThis(),
+      then: jest.fn((resolve) => resolve({ data: [], error: null }))
+    };
+
+    (getSupabase as jest.Mock).mockReturnValue({
+      from: jest.fn(() => mockQueryObj)
+    });
+
+    app = express();
+    app.use(express.json());
+    app.use('/admin-notifications', adminNotificationsRouter);
+  });
+
+  describe('POST /compose', () => {
+    it('returns 400 if title or body is missing', async () => {
+      const res = await request(app)
+        .post('/admin-notifications/compose')
+        .send({ recipient_ids: ['user-1'] });
+        
+      expect(res.status).toBe(400);
+      expect(res.body.ok).toBe(false);
+      expect(res.body.error).toBe('INVALID_INPUT');
+    });
+
+    it('sends to single user and returns 200', async () => {
+      (notifyUser as jest.Mock).mockResolvedValueOnce({ success: true });
+      
+      const res = await request(app)
+        .post('/admin-notifications/compose')
+        .send({
+          title: 'Hello',
+          body: 'World',
+          recipient_ids: ['user-1']
+        });
+        
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.sent_to).toBe(1);
+    });
+
+    it('sends to role and returns 200', async () => {
+      mockQueryObj.then = jest.fn((resolve) => resolve({ data: [{ user_id: 'u1' }, { user_id: 'u2' }], error: null }));
+
+      const res = await request(app)
+        .post('/admin-notifications/compose')
+        .send({
+          title: 'Hello',
+          body: 'World',
+          recipient_role: 'admin',
+          tenant_id: 't1'
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.sent_to).toBe(2);
+      expect(notifyUsersAsync).toHaveBeenCalledWith(['u1', 'u2'], 't1', 'welcome_to_vitana', expect.any(Object), expect.any(Object));
+    });
+
+    it('returns 500 if supabase is unavailable', async () => {
+      (getSupabase as jest.Mock).mockReturnValue(null);
+      const res = await request(app)
+        .post('/admin-notifications/compose')
+        .send({
+          title: 'Hello',
+          body: 'World',
+          recipient_ids: ['user-1']
+        });
+      expect(res.status).toBe(500);
+      expect(res.body.error).toBe('SUPABASE_UNAVAILABLE');
+    });
+  });
+
+  describe('GET /sent', () => {
+    it('returns 200 and data', async () => {
+      mockQueryObj.then = jest.fn((resolve) => resolve({
+        data: [{ id: 'notif-1' }],
+        error: null,
+        count: 1
+      }));
+
+      const res = await request(app).get('/admin-notifications/sent?limit=10&offset=0&days=30');
+      
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.data).toHaveLength(1);
+      expect(res.body.total).toBe(1);
+    });
+
+    it('returns 500 on db error', async () => {
+      mockQueryObj.then = jest.fn((resolve) => resolve({
+        data: null,
+        error: { message: 'DB_ERROR' },
+        count: null
+      }));
+
+      const res = await request(app).get('/admin-notifications/sent');
+      
+      expect(res.status).toBe(500);
+      expect(res.body.error).toBe('DB_ERROR');
+    });
+  });
+
+  describe('GET /preferences/stats', () => {
+    it('returns 200 and stats', async () => {
+      mockQueryObj.then = jest.fn()
+        .mockImplementationOnce((resolve: any) => resolve({
+          data: [
+            { push_enabled: true, dnd_enabled: false },
+            { push_enabled: false, dnd_enabled: true }
+          ],
+          error: null
+        }))
+        .mockImplementationOnce((resolve: any) => resolve({ count: 10 }))
+        .mockImplementationOnce((resolve: any) => resolve({ count: 5 }));
+
+      const res = await request(app).get('/admin-notifications/preferences/stats');
+      
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.stats.total_users_with_prefs).toBe(2);
+      expect(res.body.delivery.total_sent_30d).toBe(10);
+      expect(res.body.delivery.total_read_30d).toBe(5);
+    });
+  });
+});


### PR DESCRIPTION
**Context & Issue:**
The `route-auth-scanner-v1` flagged `admin-notifications.ts` because it uses a custom, inline `verifyExafyAdmin` function rather than standard authentication middleware. This causes inconsistency and makes standardizing auth policy harder.

**Changes:**
1. Replaced `verifyExafyAdmin` with the standard `requireAdmin` middleware from `../middleware/auth`.
2. Removed the inline token parsing and Supabase auth verification logic.
3. Added `router.use(requireAdmin)` to guard all `admin-notifications` routes centrally.
4. Refactored the references of `authResult.email` in logs to `req.user?.email || 'unknown'`.
5. Added a test suite that properly mocks the central middleware and verifies the expected endpoint behaviors.

**Files Modifed/Created:**
- `services/gateway/src/routes/admin-notifications.ts`
- `services/gateway/test/routes/admin-notifications.test.ts`