### PR TITLE
DEV-AUTOPILOT: Add paramLimit middleware to mitigate path-to-regexp ReDoS

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,37 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+/**
+ * Middleware to mitigate Regular Expression Denial of Service (ReDoS)
+ * vulnerability in path-to-regexp (< 0.1.13) by limiting the number 
+ * and length of route parameters.
+ *
+ * @param maxParams Maximum number of path parameters allowed (default 5)
+ * @param maxLength Maximum string length for any single parameter (default 200)
+ */
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    if (!req.params) {
+      next();
+      return;
+    }
+
+    const keys = Object.keys(req.params);
+
+    // Limit the number of parameters
+    if (keys.length > maxParams) {
+      res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    // Limit the length of each parameter value
+    for (const key of keys) {
+      const value = req.params[key];
+      if (typeof value === 'string' && value.length > maxLength) {
+        res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,24 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router({ mergeParams: true });
+
+// Apply parameter limit middleware to mitigate ReDoS vulnerabilities
+router.use(limitPathParams());
+
+router.get('/', (req: Request, res: Response) => {
+  res.status(200).json({ projects: [] });
+});
+
+router.get('/:projectId', (req: Request, res: Response) => {
+  res.status(200).json({ id: req.params.projectId });
+});
+
+router.get('/:projectId/tasks/:taskId', (req: Request, res: Response) => {
+  res.status(200).json({ 
+    projectId: req.params.projectId, 
+    taskId: req.params.taskId 
+  });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,21 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router({ mergeParams: true });
+
+// Apply parameter limit middleware to mitigate ReDoS vulnerabilities
+router.use(limitPathParams());
+
+router.get('/', (req: Request, res: Response) => {
+  res.status(200).json({ users: [] });
+});
+
+router.get('/:userId', (req: Request, res: Response) => {
+  res.status(200).json({ id: req.params.userId });
+});
+
+router.get('/:userId/profile', (req: Request, res: Response) => {
+  res.status(200).json({ id: req.params.userId, type: 'profile' });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,70 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - ReDoS Prevention (paramLimit Middleware)', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+
+    // Test route designed with > 5 path parameters to test limit bounds
+    app.get('/resource/:a/:b/:c/:d/:e/:f', limitPathParams(), (req: Request, res: Response) => {
+      res.status(200).json({ success: true });
+    });
+
+    // Test route for valid parameter requests
+    app.get('/valid/:a/:b', limitPathParams(), (req: Request, res: Response) => {
+      res.status(200).json({ success: true });
+    });
+
+    // Simulate usage in a nested router mounting (how the gateway typically mounts routes)
+    const router = express.Router({ mergeParams: true });
+    router.use(limitPathParams());
+    router.get('/test', (req: Request, res: Response) => {
+      res.status(200).json({ success: true });
+    });
+    app.use('/mounted/:a/:b/:c/:d/:e/:f', router);
+  });
+
+  it('should reject requests with more than 5 path parameters (Integration Test)', async () => {
+    const start = Date.now();
+    const response = await request(app).get('/resource/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ error: 'Too many path parameters or parameter too long' });
+    
+    // Assert response time is fast to ensure backtracking hasn't hung the process
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('should reject requests where a parameter exceeds 200 characters (Integration Test)', async () => {
+    const longParam = 'a'.repeat(201);
+    const start = Date.now();
+    const response = await request(app).get(`/valid/1/${longParam}`);
+    const duration = Date.now() - start;
+    
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ error: 'Too many path parameters or parameter too long' });
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('should allow valid requests with 5 or fewer parameters and acceptable lengths (Passthrough Test)', async () => {
+    const response = await request(app).get('/valid/1/2');
+    
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ success: true });
+  });
+
+  it('should reject requests when middleware is applied via router.use and parent route exceeds limits', async () => {
+    const start = Date.now();
+    const response = await request(app).get('/mounted/1/2/3/4/5/6/test');
+    const duration = Date.now() - start;
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ error: 'Too many path parameters or parameter too long' });
+    expect(duration).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
**Context & Finding:**
A Regular Expression Denial of Service (ReDoS) vulnerability exists in `path-to-regexp` (< 0.1.13), a transitive dependency of `express` used by the gateway. Attackers could craft requests with deeply nested path parameters to cause exponential backtracking and CPU exhaustion.

**Mitigation:**
Because bumping the dependency directly is out of scope for this change, we are introducing a server-side mitigation layer. 
We've added a new `paramLimit` middleware to `services/gateway/src/routes/middleware/paramLimit.ts` which limits the maximum number of path parameters (default: 5) and the maximum length of any single parameter (default: 200 characters). 

This middleware has been applied globally on the `userRoutes` and `projectRoutes` via `router.use(limitPathParams())`, which blocks requests exceeding these thresholds before they can trigger extensive regex processing downstream.

**Files Touched:**
- `services/gateway/src/routes/middleware/paramLimit.ts`
- `services/gateway/src/routes/v1/userRoutes.ts`
- `services/gateway/src/routes/v1/projectRoutes.ts`
- `services/gateway/test/cve-mitigation.test.ts`

*Note to Operators:* This middleware should be applied similarly to any other route files in `services/gateway/src/routes/` containing complex path parameters. An ultimate fix still requires upgrading `path-to-regexp` globally in `package.json`.