### PR TITLE
DEV-AUTOPILOT: Enforce auth middleware on telemetry endpoints

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,31 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+const requireAuthenticatedUser = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  const authHeader = req.headers.authorization;
+  if (!authHeader || !authHeader.startsWith("Bearer ")) {
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+
+  const token = authHeader.substring(7);
+  try {
+    const { data, error } = await supabase.auth.getUser(token);
+    if (error || !data.user) {
+      res.status(401).json({ error: "Unauthorized" });
+      return;
+    }
+    next();
+  } catch (err) {
+    res.status(401).json({ error: "Unauthorized" });
+    return;
+  }
+};
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +48,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +168,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,155 @@
+import request from "supertest";
+import express from "express";
+import { router as telemetryRouter } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+// Mock supabase client
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+// Mock devhub to prevent SSE errors during tests
+jest.mock("../../src/routes/devhub", () => ({
+  broadcastEvent: jest.fn(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1/telemetry", telemetryRouter);
+
+describe("Telemetry Routes Authentication", () => {
+  const originalEnv = process.env;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env = { ...originalEnv };
+  });
+
+  afterAll(() => {
+    process.env = originalEnv;
+  });
+
+  describe("POST /api/v1/telemetry/event", () => {
+    const validPayload = {
+      vtid: "VTID-123",
+      layer: "app",
+      module: "auth",
+      source: "client",
+      kind: "auth.login",
+      status: "success",
+      title: "User logged in",
+    };
+
+    it("should return 401 if no Authorization header is provided", async () => {
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validPayload);
+      
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({ error: "Unauthorized" });
+    });
+
+    it("should return 401 if token is invalid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: null },
+        error: new Error("Invalid token"),
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validPayload);
+      
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({ error: "Unauthorized" });
+    });
+
+    it("should process request if authenticated", async () => {
+      process.env.SUPABASE_SERVICE_ROLE = "dummy-svc-key";
+      process.env.SUPABASE_URL = "http://dummy-supabase";
+
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      }) as jest.Mock;
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send(validPayload);
+
+      expect(response.status).toBe(202);
+      expect(response.body.ok).toBe(true);
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    const validBatchPayload = [{
+      vtid: "VTID-123",
+      layer: "app",
+      module: "auth",
+      source: "client",
+      kind: "auth.login",
+      status: "success",
+      title: "User logged in",
+    }];
+
+    it("should return 401 if no Authorization header is provided", async () => {
+      const response = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send(validBatchPayload);
+      
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({ error: "Unauthorized" });
+    });
+
+    it("should return 401 if token is invalid", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: null },
+        error: new Error("Invalid token"),
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validBatchPayload);
+      
+      expect(response.status).toBe(401);
+      expect(response.body).toEqual({ error: "Unauthorized" });
+    });
+
+    it("should process batch if authenticated", async () => {
+      process.env.SUPABASE_SERVICE_ROLE = "dummy-svc-key";
+      process.env.SUPABASE_URL = "http://dummy-supabase";
+
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      global.fetch = jest.fn().mockResolvedValue({
+        ok: true,
+        json: async () => ({}),
+      }) as jest.Mock;
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-token")
+        .send(validBatchPayload);
+
+      expect(response.status).toBe(202);
+      expect(response.body.ok).toBe(true);
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
Addresses the medium-risk `rls_gap` flagged by `rls-policy-scanner-v1` for `oasis_events`.

The `oasis_events` table currently lacks database-level Row-Level Security, leaving it exposed to arbitrary SQL inserts by unauthenticated users. As part of resolving this security gap, this PR introduces application-level authentication checks on the Gateway's telemetry endpoints (`POST /api/v1/telemetry/event` and `POST /api/v1/telemetry/batch`).

It accomplishes this via a new Express middleware that validates the `Authorization: Bearer <token>` header against Supabase. Unauthenticated telemetry writes will now correctly be rejected with an HTTP 401.

**Note to Developer:** You must separately apply the database-level RLS migration to `oasis_events` via a new `supabase/migrations/` file. The automated runner is out of scope to apply database migrations.

Files touched:
- `services/gateway/src/routes/telemetry.ts`
- `services/gateway/test/routes/telemetry.test.ts`