### PR TITLE
DEV-AUTOPILOT: Secure telemetry API routes with Supabase auth middleware

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,38 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+// Middleware to verify authentication
+const requireAuthenticatedUser = async (req: Request, res: Response, next: NextFunction): Promise<void> => {
+  try {
+    const authHeader = req.headers.authorization;
+    let token = "";
+
+    if (authHeader && authHeader.startsWith("Bearer ")) {
+      token = authHeader.substring(7);
+    }
+
+    if (!token) {
+      res.status(401).json({ error: "Unauthorized", detail: "Missing authentication token" });
+      return;
+    }
+
+    const { data, error } = await supabase.auth.getUser(token);
+
+    if (error || !data?.user) {
+      res.status(401).json({ error: "Unauthorized", detail: "Invalid token" });
+      return;
+    }
+
+    next();
+  } catch (err: any) {
+    res.status(500).json({ error: "Internal server error during auth", detail: err.message });
+  }
+};
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +55,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +175,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuthenticatedUser, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,131 @@
+import request from "supertest";
+import express from "express";
+import { router } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+// Mock supabase client
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+// Mock process.env for the route
+process.env.SUPABASE_URL = "http://mock-supabase.local";
+process.env.SUPABASE_SERVICE_ROLE = "mock-service-role";
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1/telemetry", router);
+
+// Mock global fetch
+global.fetch = jest.fn();
+
+describe("Telemetry Routes Authentication", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (global.fetch as jest.Mock).mockReset();
+  });
+
+  describe("POST /api/v1/telemetry/event", () => {
+    const validPayload = {
+      vtid: "test-vtid",
+      layer: "test-layer",
+      module: "test-module",
+      source: "test-source",
+      kind: "test-kind",
+      status: "success",
+      title: "test-title",
+    };
+
+    it("should return 401 if no Authorization header is provided", async () => {
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validPayload);
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe("Unauthorized");
+      expect(supabase.auth.getUser).not.toHaveBeenCalled();
+    });
+
+    it("should return 401 if an invalid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: null },
+        error: new Error("Invalid token"),
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid-token")
+        .send(validPayload);
+
+      expect(response.status).toBe(401);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("invalid-token");
+    });
+
+    it("should proceed (return 202) if a valid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({ id: "mocked-event-id" }),
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid-token")
+        .send(validPayload);
+
+      expect(response.status).toBe(202);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("valid-token");
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+
+  describe("POST /api/v1/telemetry/batch", () => {
+    const validBatchPayload = [{
+      vtid: "test-vtid",
+      layer: "test-layer",
+      module: "test-module",
+      source: "test-source",
+      kind: "test-kind",
+      status: "success",
+      title: "test-title",
+    }];
+
+    it("should return 401 if no Authorization header is provided", async () => {
+      const response = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send(validBatchPayload);
+
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe("Unauthorized");
+    });
+
+    it("should proceed (return 202) if a valid token is provided", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValueOnce({
+        data: { user: { id: "user-123" } },
+        error: null,
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        json: async () => [{ id: "mocked-event-id" }],
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid-token")
+        .send(validBatchPayload);
+
+      expect(response.status).toBe(202);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("valid-token");
+      expect(global.fetch).toHaveBeenCalled();
+    });
+  });
+});


### PR DESCRIPTION
This PR implements application-level Row-Level Security (RLS) enforcement on the telemetry API routes that write to `oasis_events`. Since automated modification of `supabase/migrations/` is out of scope, this adds an API-layer authentication guard to ensure only authenticated users can submit telemetry events.

- Added an Express middleware `requireAuthenticatedUser` that extracts the `Authorization: Bearer` token and validates it using `supabase.auth.getUser()`.
- Applied the middleware to `POST /event` and `POST /batch` endpoints (which write to `oasis_events`).
- Created unit tests in `telemetry.test.ts` to verify the authentication middleware behaves exactly as expected (returning 401 when missing or invalid token, and proceeding on valid token).

**Note for operators**: The database-level RLS migration for `oasis_events` must be added manually in a separate Supabase migration file.