### PR TITLE
DEV-AUTOPILOT: Refactor admin-notifications to use shared auth middleware

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -12,51 +12,21 @@
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
+import { requireAdmin } from '../middleware/auth';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIFICATIONS';
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
+router.use(requireAdmin);
 
 // ── POST /compose — Send notification to user(s) ────────────
 
 router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
+
+  const userEmail = (req as any).user?.email || 'unknown';
 
   const {
     recipient_ids,   // string[] — specific user IDs
@@ -148,7 +118,7 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      console.log(`[${VTID}] Composed notification for 1 user by ${userEmail}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +131,7 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${userEmail}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -177,9 +147,6 @@ router.post('/compose', async (req: Request, res: Response) => {
 // ── GET /sent — Admin notification log ──────────────────────
 
 router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -224,9 +191,6 @@ router.get('/sent', async (req: Request, res: Response) => {
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
 router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,183 @@
+import request from 'supertest';
+import express from 'express';
+import adminNotificationsRouter from '../../src/routes/admin-notifications';
+import { getSupabase } from '../../src/lib/supabase';
+import { notifyUser, notifyUsersAsync } from '../../src/services/notification-service';
+
+// Mock middleware
+jest.mock('../../src/middleware/auth', () => ({
+  requireAdmin: jest.fn((req, res, next) => {
+    req.user = { id: 'admin-id', email: 'admin@test.com' };
+    next();
+  })
+}));
+
+// Mock services
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn()
+}));
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn(),
+  notifyUsersAsync: jest.fn()
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/admin-notifications', adminNotificationsRouter);
+
+describe('Admin Notifications Route', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  describe('POST /compose', () => {
+    it('returns 400 for missing title or body', async () => {
+      (getSupabase as jest.Mock).mockReturnValue({});
+
+      const res = await request(app)
+        .post('/admin-notifications/compose')
+        .send({ recipient_ids: ['user1'] });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('INVALID_INPUT');
+    });
+
+    it('returns 400 for missing recipient info', async () => {
+      (getSupabase as jest.Mock).mockReturnValue({});
+
+      const res = await request(app)
+        .post('/admin-notifications/compose')
+        .send({ title: 'Test Title', body: 'Test Body' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('INVALID_INPUT');
+    });
+
+    it('dispatches to a single user synchronously', async () => {
+      (getSupabase as jest.Mock).mockReturnValue({});
+      (notifyUser as jest.Mock).mockResolvedValue({ success: true });
+
+      const res = await request(app)
+        .post('/admin-notifications/compose')
+        .send({
+          title: 'Test',
+          body: 'Test Body',
+          recipient_ids: ['user1']
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.sent_to).toBe(1);
+      expect(notifyUser).toHaveBeenCalledWith(
+        'user1',
+        '',
+        'welcome_to_vitana',
+        expect.objectContaining({ title: 'Test', body: 'Test Body' }),
+        expect.anything()
+      );
+    });
+
+    it('dispatches to multiple users asynchronously', async () => {
+      (getSupabase as jest.Mock).mockReturnValue({});
+      
+      const res = await request(app)
+        .post('/admin-notifications/compose')
+        .send({
+          title: 'Test',
+          body: 'Test Body',
+          recipient_ids: ['user1', 'user2']
+        });
+
+      expect(res.status).toBe(200);
+      expect(res.body.sent_to).toBe(2);
+      expect(notifyUsersAsync).toHaveBeenCalledWith(
+        ['user1', 'user2'],
+        '',
+        'welcome_to_vitana',
+        expect.objectContaining({ title: 'Test', body: 'Test Body' }),
+        expect.anything()
+      );
+    });
+  });
+
+  describe('GET /sent', () => {
+    it('returns 500 if Supabase is unavailable', async () => {
+      (getSupabase as jest.Mock).mockReturnValue(null);
+      const res = await request(app).get('/admin-notifications/sent');
+      expect(res.status).toBe(500);
+    });
+
+    it('returns fetched notifications', async () => {
+      const mockChain = {
+        select: jest.fn().mockReturnThis(),
+        gte: jest.fn().mockReturnThis(),
+        order: jest.fn().mockReturnThis(),
+        range: jest.fn().mockResolvedValue({
+          data: [{ id: 'notif-1' }],
+          count: 1,
+          error: null
+        })
+      };
+
+      (getSupabase as jest.Mock).mockReturnValue({
+        from: jest.fn().mockReturnValue(mockChain)
+      });
+
+      const res = await request(app).get('/admin-notifications/sent?limit=10&offset=0');
+      
+      expect(res.status).toBe(200);
+      expect(res.body.data.length).toBe(1);
+      expect(res.body.total).toBe(1);
+    });
+  });
+
+  describe('GET /preferences/stats', () => {
+    it('returns calculated statistics', async () => {
+      let isFirstNotificationsCall = true;
+
+      const mockSupabase = {
+        from: jest.fn((table) => {
+          if (table === 'user_notification_preferences') {
+            return {
+              select: jest.fn().mockResolvedValue({
+                data: [
+                  { push_enabled: true },
+                  { push_enabled: false },
+                  { push_enabled: true, dnd_enabled: true }
+                ],
+                error: null
+              })
+            };
+          }
+          if (table === 'user_notifications') {
+            const chain: any = {
+              select: jest.fn().mockReturnThis(),
+              gte: jest.fn().mockReturnThis(),
+              not: jest.fn().mockReturnThis()
+            };
+            chain.then = (resolve: any) => {
+              if (isFirstNotificationsCall) {
+                isFirstNotificationsCall = false;
+                resolve({ count: 100 });
+              } else {
+                resolve({ count: 45 });
+              }
+            };
+            return chain;
+          }
+        })
+      };
+
+      (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+
+      const res = await request(app).get('/admin-notifications/preferences/stats');
+      
+      expect(res.status).toBe(200);
+      expect(res.body.stats.push_enabled).toBe(2);
+      expect(res.body.stats.push_disabled).toBe(1);
+      expect(res.body.stats.dnd_enabled).toBe(1);
+      expect(res.body.delivery.total_sent_30d).toBe(100);
+      expect(res.body.delivery.total_read_30d).toBe(45);
+      expect(res.body.delivery.read_rate).toBe(45);
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses missing authentication findings flagged by `route-auth-scanner-v1`. 

The `admin-notifications.ts` route file previously used inline custom authentication methods, causing it to be flagged and increasing maintenance overhead. This change removes the custom inline authentication (`verifyExafyAdmin` and `getBearerToken`) and replaces it with the standard, centrally-managed `requireAdmin` middleware across all routes. 

Affected files:
- `services/gateway/src/routes/admin-notifications.ts`: Replaces the custom inline auth with `router.use(requireAdmin)`.
- `services/gateway/test/routes/admin-notifications.test.ts`: Creates tests using Supertest to verify routes with mocked standard middleware.