### PR TITLE
DEV-AUTOPILOT: Add application-level auth to telemetry write routes

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,9 +1,62 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { supabase } from "../lib/supabase";
 
 export const router = Router();
+
+// Application-level authentication middleware for telemetry write operations
+const requireAuth = async (req: Request, res: Response, next: NextFunction) => {
+  try {
+    let token: string | null = null;
+    
+    // 1. Check Authorization header
+    const authHeader = req.headers.authorization;
+    if (authHeader && authHeader.startsWith("Bearer ")) {
+      token = authHeader.substring(7);
+    } 
+    // 2. Check cookies if no header
+    else if (req.headers.cookie) {
+      const match = req.headers.cookie.match(/(?:^|;\s*)(?:supabase-auth-token|sb-access-token|sb-[a-z0-9]+-auth-token)=([^;]+)/);
+      if (match) {
+        const raw = decodeURIComponent(match[1]);
+        try {
+          if (raw.startsWith("[")) {
+            const parsed = JSON.parse(raw);
+            token = parsed[0]; // Standard Supabase SSR cookie format
+          } else {
+            token = raw;
+          }
+        } catch {
+          token = raw;
+        }
+      }
+    }
+
+    if (!token) {
+      return res.status(401).json({ 
+        error: "Unauthorized", 
+        detail: "Missing or invalid Authorization token" 
+      });
+    }
+
+    const { data, error } = await supabase.auth.getUser(token);
+
+    if (error || !data?.user) {
+      return res.status(401).json({ 
+        error: "Unauthorized", 
+        detail: "Invalid session token" 
+      });
+    }
+
+    // Token is valid, proceed
+    next();
+  } catch (err: any) {
+    console.error("Auth middleware error:", err);
+    return res.status(500).json({ error: "Internal server error", detail: "Authentication failed" });
+  }
+};
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -26,7 +79,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +199,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,147 @@
+import request from "supertest";
+import express from "express";
+import { router } from "../../src/routes/telemetry";
+import { supabase } from "../../src/lib/supabase";
+
+// Mock the supabase client
+jest.mock("../../src/lib/supabase", () => ({
+  supabase: {
+    auth: {
+      getUser: jest.fn(),
+    },
+  },
+}));
+
+// Mock devhub to prevent actual SSE broadcasts during tests
+jest.mock("../../src/routes/devhub", () => ({
+  broadcastEvent: jest.fn(),
+}), { virtual: true });
+
+const app = express();
+app.use(express.json());
+app.use("/api/v1/telemetry", router);
+
+describe("Telemetry API Routes", () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    global.fetch = jest.fn() as any;
+    process.env.SUPABASE_URL = "http://localhost:8000";
+    process.env.SUPABASE_SERVICE_ROLE = "test-service-key";
+  });
+
+  describe("Authentication", () => {
+    const validPayload = {
+      vtid: "VT-123",
+      layer: "test-layer",
+      module: "test-module",
+      source: "test-source",
+      kind: "test.event",
+      status: "success",
+      title: "Test Event"
+    };
+
+    it("should return 401 for unauthenticated request to /event", async () => {
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .send(validPayload);
+      
+      expect(response.status).toBe(401);
+      expect(response.body).toHaveProperty("error", "Unauthorized");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should return 401 for invalid session token", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: null },
+        error: { message: "Invalid token" }
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer invalid_token")
+        .send(validPayload);
+      
+      expect(response.status).toBe(401);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("invalid_token");
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should allow request with valid Authorization header", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({})
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Authorization", "Bearer valid_token")
+        .send(validPayload);
+      
+      expect(response.status).toBe(202);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("valid_token");
+      expect(global.fetch).toHaveBeenCalled();
+    });
+
+    it("should allow request with valid Supabase cookie", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({})
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/event")
+        .set("Cookie", "sb-access-token=valid_cookie_token")
+        .send(validPayload);
+      
+      expect(response.status).toBe(202);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("valid_cookie_token");
+      expect(global.fetch).toHaveBeenCalled();
+    });
+
+    it("should protect /batch route as well", async () => {
+      const response = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .send([validPayload]);
+      
+      expect(response.status).toBe(401);
+      expect(global.fetch).not.toHaveBeenCalled();
+    });
+
+    it("should allow /batch request with valid Authorization header", async () => {
+      (supabase.auth.getUser as jest.Mock).mockResolvedValue({
+        data: { user: { id: "user-123" } },
+        error: null
+      });
+
+      (global.fetch as jest.Mock).mockResolvedValue({
+        ok: true,
+        json: async () => ({})
+      });
+
+      const response = await request(app)
+        .post("/api/v1/telemetry/batch")
+        .set("Authorization", "Bearer valid_token")
+        .send([validPayload]);
+      
+      expect(response.status).toBe(202);
+      expect(supabase.auth.getUser).toHaveBeenCalledWith("valid_token");
+      expect(global.fetch).toHaveBeenCalled();
+    });
+
+    it("should leave /health read-only endpoint unauthenticated", async () => {
+      const response = await request(app).get("/api/v1/telemetry/health");
+      expect(response.status).toBe(200);
+      expect(response.body).toHaveProperty("ok", true);
+    });
+  });
+});


### PR DESCRIPTION
This PR addresses the medium-risk `rls_gap` flagged by `rls-policy-scanner-v1` on the `oasis_events` table. 
Because direct DB migrations for RLS cannot be automated in this scope, this PR adds a strict application-level authentication middleware to the telemetry API routes (`POST /event` and `POST /batch`) that write to `oasis_events`.

Changes:
- Extracted session token from `Authorization` header or Supabase-auth cookies.
- Verified the token using `supabase.auth.getUser()`.
- Returns `401 Unauthorized` and skips the write if the user token is missing or invalid.
- Left read-only endpoints (`/health` and `/snapshot`) accessible as per the plan's scope.
- Added comprehensive unit tests for both authenticated and unauthenticated telemetry calls.

**Note for Operator:** The database-level RLS migration must still be applied manually via a new migration file. Please apply the `ALTER TABLE public.oasis_events ENABLE ROW LEVEL SECURITY;` and respective policies as defined in the plan to fully close the security gap at the database level.