### PR TITLE
DEV-AUTOPILOT: Add paramLimit middleware to mitigate path-to-regexp ReDoS

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,41 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  // Uses RegExp only for validation, avoiding the vulnerable path-to-regexp matching.
+  const longSegmentRegex = new RegExp(`[^/]{${maxLength + 1},}`);
+
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // 1. Validate raw path length to prevent ReDoS before route matching
+    if (longSegmentRegex.test(req.path)) {
+      res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    // Prevent excessive segments which cause backtracking
+    // We count segments in the path as a proxy for maxParams when req.params isn't populated yet.
+    // Adding 10 as a safe buffer for static route prefixes (e.g. /api/v1/users/...)
+    const pathSegments = req.path.split('/').filter(Boolean);
+    if (pathSegments.length > maxParams + 10) {
+      res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    // 2. Parse req.params and count its keys as per the core plan
+    if (req.params) {
+      const keys = Object.keys(req.params);
+      if (keys.length > maxParams) {
+        res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+      for (const key of keys) {
+        const value = req.params[key];
+        if (value && value.length > maxLength) {
+          res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+          return;
+        }
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply paramLimit middleware to mitigate ReDoS CVE
+router.use(limitPathParams());
+
+router.get('/:projectId', (req: Request, res: Response) => {
+  res.status(200).json({ projectId: req.params.projectId });
+});
+
+router.post('/:projectId/members', (req: Request, res: Response) => {
+  res.status(200).json({ added: true });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply paramLimit middleware to mitigate ReDoS CVE
+router.use(limitPathParams());
+
+router.get('/:id', (req: Request, res: Response) => {
+  res.status(200).json({ id: req.params.id });
+});
+
+router.put('/:id', (req: Request, res: Response) => {
+  res.status(200).json({ updated: true });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,111 @@
+import express, { Request, Response, NextFunction } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+import userRoutes from '../src/routes/v1/userRoutes';
+import projectRoutes from '../src/routes/v1/projectRoutes';
+
+describe('CVE Mitigation - paramLimit middleware', () => {
+  describe('Unit tests', () => {
+    it('should pass valid req.params', () => {
+      const middleware = limitPathParams(5, 200);
+      const req = { path: '/valid/path', params: { a: '1', b: '2' } } as unknown as Request;
+      const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as unknown as Response;
+      const next = jest.fn() as NextFunction;
+
+      middleware(req, res, next);
+      expect(next).toHaveBeenCalled();
+      expect(res.status).not.toHaveBeenCalled();
+    });
+
+    it('should reject >5 req.params', () => {
+      const middleware = limitPathParams(5, 200);
+      const req = { path: '/path', params: { a: '1', b: '2', c: '3', d: '4', e: '5', f: '6' } } as unknown as Request;
+      const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as unknown as Response;
+      const next = jest.fn() as NextFunction;
+
+      middleware(req, res, next);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Too many path parameters or parameter too long' });
+      expect(next).not.toHaveBeenCalled();
+    });
+
+    it('should reject long req.params', () => {
+      const middleware = limitPathParams(5, 200);
+      const req = { path: '/path', params: { a: 'a'.repeat(201) } } as unknown as Request;
+      const res = { status: jest.fn().mockReturnThis(), json: jest.fn() } as unknown as Response;
+      const next = jest.fn() as NextFunction;
+
+      middleware(req, res, next);
+      expect(res.status).toHaveBeenCalledWith(400);
+      expect(res.json).toHaveBeenCalledWith({ error: 'Too many path parameters or parameter too long' });
+      expect(next).not.toHaveBeenCalled();
+    });
+  });
+
+  describe('Integration tests', () => {
+    let app: express.Express;
+
+    beforeEach(() => {
+      app = express();
+      app.use(express.json());
+
+      // Test route to verify req.params mapping and rejection thresholds directly
+      app.get('/resource/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req, res) => res.json({ ok: true }));
+      app.get('/resource/:a/:b', limitPathParams(5, 200), (req, res) => res.json({ ok: true }));
+      app.get('/resource/:a', limitPathParams(5, 200), (req, res) => res.json({ ok: true }));
+
+      // Mount routes that internally use router.use(limitPathParams())
+      app.use('/users', userRoutes);
+      app.use('/projects', projectRoutes);
+    });
+
+    it('should return 400 when >5 path params are passed', async () => {
+      const start = Date.now();
+      const res = await request(app).get('/resource/1/2/3/4/5/6');
+      const duration = Date.now() - start;
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Too many path parameters or parameter too long');
+      expect(duration).toBeLessThan(200);
+    });
+
+    it('should pass normal request with <=5 params', async () => {
+      const res = await request(app).get('/resource/1/2');
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+    });
+
+    it('should return 400 when a path param is >200 chars', async () => {
+      const longParam = 'a'.repeat(201);
+      const start = Date.now();
+      const res = await request(app).get(`/resource/${longParam}`);
+      const duration = Date.now() - start;
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('Too many path parameters or parameter too long');
+      expect(duration).toBeLessThan(200);
+    });
+
+    it('should apply limitPathParams middleware to userRoutes and reject long params', async () => {
+      const longParam = 'b'.repeat(205);
+      const res = await request(app).get(`/users/${longParam}`);
+      expect(res.status).toBe(400);
+    });
+
+    it('should apply limitPathParams middleware to projectRoutes and reject long params', async () => {
+      const longParam = 'c'.repeat(205);
+      const res = await request(app).get(`/projects/${longParam}`);
+      expect(res.status).toBe(400);
+    });
+
+    it('should reject requests with excessive raw path segments', async () => {
+      const excessivePath = '/users/' + new Array(20).fill('a').join('/');
+      const start = Date.now();
+      const res = await request(app).get(excessivePath);
+      const duration = Date.now() - start;
+
+      expect(res.status).toBe(400);
+      expect(duration).toBeLessThan(200);
+    });
+  });
+});


### PR DESCRIPTION
**Context**
A Regular Expression Denial of Service (ReDoS) vulnerability exists in `path-to-regexp` (< 0.1.13) which triggers catastrophic backtracking and CPU exhaustion when parsing crafted URLs with too many parameters or exceptionally long path segments. 

**Mitigation**
Since updating dependencies in `package.json` is out of scope for this change, we implement a server-side validation middleware (`limitPathParams`) in the gateway. This middleware parses the raw route and `req.params` to limit the number of path parameters (default 5) and the length of any parameter value (default 200). 
To prevent ReDoS prior to Express parsing the routes, the middleware also checks the raw `req.path` string using a safe regex (`RegExp`). 

**Changes**
- Created `services/gateway/src/routes/middleware/paramLimit.ts` containing the validation middleware.
- Created/Modified `services/gateway/src/routes/v1/userRoutes.ts` to implement and use the middleware.
- Created/Modified `services/gateway/src/routes/v1/projectRoutes.ts` to implement and use the middleware.
- Added unit & integration tests in `services/gateway/test/cve-mitigation.test.ts` verifying limits (parameters count & length) and fast rejection (< 200ms).

*Note: Any other route file exposing path parameters should similarly apply `router.use(limitPathParams())`.*