### PR TITLE
fix(orb-agent): swap LLM to gemini-3.1-flash-lite-preview

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/providers.py
+++ b/services/agents/orb-agent/src/orb_agent/providers.py
@@ -59,7 +59,7 @@ def build_cascade(voice_config: dict[str, Any] | None) -> ResolvedCascade:
         logger.warning("build_cascade: no voice_config — falling back to hardcoded Google cascade")
         voice_config = {
             "stt_provider": "google_stt",  "stt_model": "latest_long", "stt_options": {},
-            "llm_provider": "google_llm",  "llm_model": "gemini-3.1-pro-preview", "llm_options": {},
+            "llm_provider": "google_llm",  "llm_model": "gemini-3.1-flash-lite-preview", "llm_options": {},
             "tts_provider": "google_tts",  "tts_model": "en-US-Chirp3-HD-Aoede", "tts_options": {},
         }
 
@@ -131,7 +131,7 @@ def _build_llm(provider: str | None, model: str | None, options: dict[str, Any],
             project = os.environ.get("GOOGLE_CLOUD_PROJECT", "lovable-vitana-vers1")
             location = os.environ.get("VERTEX_AI_LOCATION", "us-central1")
             return google.LLM(
-                model=model or "gemini-3.1-pro-preview",
+                model=model or "gemini-3.1-flash-lite-preview",
                 vertexai=True,
                 project=project,
                 location=location,

--- a/supabase/migrations/20260502120000_vtid_02690_seed_orb_agent_google_cascade.sql
+++ b/supabase/migrations/20260502120000_vtid_02690_seed_orb_agent_google_cascade.sql
@@ -10,7 +10,7 @@
 --   1. Inserts the agents_registry row for orb-agent (idempotent).
 --   2. Upserts the agent_voice_configs row pointing to the all-Google cascade:
 --        STT: google_stt / latest_long
---        LLM: google_llm / gemini-3.1-pro-preview
+--        LLM: google_llm / gemini-3.1-flash-lite-preview
 --        TTS: google_tts / en-US-Chirp3-HD-Aoede
 --      All three use Application Default Credentials — no third-party API
 --      keys needed; the Cloud Run service account inherits the project's
@@ -26,7 +26,7 @@ VALUES
   ('orb-agent',
    'ORB LiveKit Agent',
    'LiveKit-based ORB voice agent worker. Standby alternative to the Vertex Live pipeline (services/gateway/src/routes/orb-live.ts). Joins LiveKit rooms as a participant and runs a configurable STT/LLM/TTS cascade.',
-   'service', 'voice', 'gemini', 'gemini-3.1-pro-preview',
+   'service', 'voice', 'gemini', 'gemini-3.1-flash-lite-preview',
    'services/agents/orb-agent/', '/health',
    jsonb_build_object('language', 'python', 'framework', 'livekit-agents', 'vtid', 'VTID-LIVEKIT-FOUNDATION'))
 ON CONFLICT (agent_id) DO UPDATE SET
@@ -44,7 +44,7 @@ INSERT INTO agent_voice_configs (
 ) VALUES (
   'orb-agent', 'livekit_cascade',
   'google_stt',  'latest_long',                      jsonb_build_object('languages', ARRAY['en-US']),
-  'google_llm',  'gemini-3.1-pro-preview',           jsonb_build_object('temperature', 0.7),
+  'google_llm',  'gemini-3.1-flash-lite-preview',           jsonb_build_object('temperature', 0.7),
   'google_tts',  'en-US-Chirp3-HD-Aoede',            jsonb_build_object('language_code', 'en-US')
 ) ON CONFLICT (agent_id) DO UPDATE SET
   transport     = EXCLUDED.transport,


### PR DESCRIPTION
## Summary
- ~10s LLM TTFB on `gemini-3.1-pro-preview` is too slow for voice. Swap to `gemini-3.1-flash-lite-preview` (the latency-optimised 3.1 family member).
- Updates providers.py fallback + seed migration. Migration must be re-applied via RUN-MIGRATION to update the live DB row.

## Test plan
- [ ] DEPLOY-ORB-AGENT auto-deploys after merge
- [ ] Apply migration to update agent_voice_configs.orb-agent.llm_model
- [ ] /command-hub/testing-qa/livekit-test/ — speak, measure first-byte latency