### PR TITLE
DEV-AUTOPILOT: Fix persona greeting language fallback on handoff

### DIFF
--- a/services/gateway/src/services/persona-registry.ts
+++ b/services/gateway/src/services/persona-registry.ts
@@ -98,16 +98,31 @@ export async function getPersonaVoice(key: string): Promise<string> {
   return reg.get(key)?.voice_id ?? '';
 }
 
+function extractLocale(langOrCtx: any): string {
+  if (!langOrCtx) return 'en';
+  let val = 'en';
+  if (typeof langOrCtx === 'string') {
+    val = langOrCtx;
+  } else if (typeof langOrCtx === 'object') {
+    val = langOrCtx.user?.locale || langOrCtx.session?.language || langOrCtx.language || 'en';
+  }
+  if (typeof val !== 'string') {
+    val = 'en';
+  }
+  return val.split('-')[0].toLowerCase() || 'en';
+}
+
 /**
  * Returns the persona's greeting in the requested language, falling
  * through `lang → 'en' → generic` so a missing language never hard-fails.
  */
-export async function getPersonaGreeting(key: string, lang: string): Promise<string> {
+export async function getPersonaGreeting(key: string, lang: any): Promise<string> {
+  const locale = extractLocale(lang);
   const reg = await loadPersonaRegistry();
   const p = reg.get(key);
   if (!p) return `Hi, ${key} here. How can I help?`;
   const tpls = p.greeting_templates ?? {};
-  if (tpls[lang]) return tpls[lang];
+  if (tpls[locale]) return tpls[locale];
   if (tpls['en']) return tpls['en'];
   // Last-resort generic — covers the "operator just inserted a new persona
   // and forgot to fill greeting_templates" case so the swap never sounds
@@ -281,14 +296,15 @@ export async function getPersonaVoiceForTenant(key: string, tenantId: string): P
  */
 export async function getPersonaGreetingForTenant(
   key: string,
-  lang: string,
+  lang: any,
   tenantId: string,
 ): Promise<string> {
+  const locale = extractLocale(lang);
   const reg = await loadPersonaRegistryForTenant(tenantId);
   const p = reg.get(key);
   if (!p) return `Hi, ${key} here. How can I help?`;
   const tpls = p.greeting_templates ?? {};
-  if (tpls[lang]) return tpls[lang];
+  if (tpls[locale]) return tpls[locale];
   if (tpls['en']) return tpls['en'];
   return `Hi, ${p.display_name} here. How can I help?`;
 }


### PR DESCRIPTION
Fixes an issue where persona handoffs default to English even when the user's configured language is German (or another supported locale).

**Finding:** The caller was passing a request/session context object into the greeting lookup, which `getPersonaGreeting` interpreted as a string. This stringified to `"[object Object]"`, failing the template dictionary lookup and causing a fallback to English. The LLM then continued the conversation in English because the system prompt was anchored by an English greeting.

**Plan implementation:**
- Created a private `extractLocale(langOrCtx: any)` helper in `persona-registry.ts`.
- Safely extracts the locale whether passed as a string or a context object containing `user.locale`, `session.language`, or `language`.
- Normalizes the extracted locale (e.g., `de-DE` → `de`).
- Updated `getPersonaGreeting` and `getPersonaGreetingForTenant` to use the helper.

**Touched files:**
- `services/gateway/src/services/persona-registry.ts`