### PR TITLE
DEV-AUTOPILOT: fix persona greeting language locale extraction

### DIFF
--- a/services/gateway/src/services/persona-registry.ts
+++ b/services/gateway/src/services/persona-registry.ts
@@ -104,9 +104,9 @@ function extractLocale(langOrCtx: any): string {
   if (typeof langOrCtx === 'string') {
     val = langOrCtx;
   } else if (typeof langOrCtx === 'object') {
-    val = langOrCtx.user?.locale || langOrCtx.session?.language || langOrCtx.language || 'en';
+    val = langOrCtx.user?.locale || langOrCtx.session?.language || langOrCtx.locale || langOrCtx.language || 'en';
   }
-  if (typeof val !== 'string') {
+  if (typeof val !== 'string' || val === '[object Object]') {
     val = 'en';
   }
   return val.split('-')[0].toLowerCase() || 'en';


### PR DESCRIPTION
**Issue:**
During persona handoffs, the voice agent switches to English even when the user's configured language is German. The root cause is that the caller is passing a request/session context object into the greeting lookup. If the object gets implicitly stringified or doesn't match the exact extracted keys, it defaults to English.

**Plan:**
- Ensure `extractLocale` robustly detects `langOrCtx` as an object.
- Safely extract the locale via `user.locale`, `session.language`, `locale`, or `language`.
- Protect against inadvertent `"[object Object]"` strings that would break the dictionary lookup when extracting the locale prefix.
- Retain the fallback `en` so that missing templates never crash the runtime.

**Files touched:**
- `services/gateway/src/services/persona-registry.ts`