### PR TITLE
fix(autopilot): match deploy event by merge SHA + use correct column (VTID-02697)

### DIFF
--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -1432,6 +1432,7 @@ interface StuckExecRow {
   pr_number: number | null;
   branch: string | null;
   updated_at: string;
+  metadata: Record<string, unknown> | null;
 }
 
 /** Per-state timeout. Beyond this, the state is considered "stuck" and
@@ -1713,24 +1714,43 @@ async function reconcileMerging(s: SupaConfig, exec: StuckExecRow): Promise<void
 /** Reconcile status='deploying'. Source of truth: oasis_events for
  *  deploy.gateway.success or any event tagged with the merge SHA / branch. */
 async function reconcileDeploying(s: SupaConfig, exec: StuckExecRow): Promise<void> {
-  // Look for a deploy success event newer than the execution's last update.
+  // VTID-02697: Two bugs in the previous version:
+  //   1. Filtered on `type=in.(...)` but the column is `topic` — the request
+  //      400'd, returned empty, and we always concluded "no deploy event"
+  //      regardless of reality.
+  //   2. Even when the column was right, it took ANY recent deploy event
+  //      across the platform as proof that THIS exec deployed. False
+  //      positive risk during concurrent autopilot runs.
+  //
+  // Fixed query uses `topic` and selects `metadata` so we can match by
+  // merge SHA (set on the exec when the watcher merges its PR).
   const since = new Date(Date.now() - RECONCILE_TIMEOUT_MS.deploying * 2).toISOString();
-  const deployR = await supa<Array<{ id: string; type: string; created_at: string }>>(s,
-    `/rest/v1/oasis_events?type=in.(deploy.gateway.success,deploy.success,vtid.lifecycle.deployed)`
-    + `&created_at=gte.${since}&order=created_at.desc&limit=20&select=id,type,created_at`);
+  const deployR = await supa<Array<{ id: string; topic: string; created_at: string; metadata?: Record<string, unknown> }>>(s,
+    `/rest/v1/oasis_events?topic=in.(deploy.gateway.success,deploy.success,vtid.lifecycle.deployed)`
+    + `&created_at=gte.${since}&order=created_at.desc&limit=20&select=id,topic,created_at,metadata`);
   if (deployR.ok && deployR.data && deployR.data.length > 0) {
-    // We saw at least one recent deploy success event. Best-effort: advance
-    // this execution to verifying; the verification step will run next.
-    await patchExecution(s, exec.id, { status: 'verifying' });
-    await emitOasisEvent({
-      vtid: EXEC_VTID,
-      type: 'dev_autopilot.execution.deployed',
-      source: 'dev-autopilot',
-      status: 'success',
-      message: `Reconciler: ${exec.id.slice(0, 8)} deploy success event observed — advancing to verifying`,
-      payload: { execution_id: exec.id, deploy_event_id: deployR.data[0].id, reconciled_from: 'deploying' },
-    });
-    return;
+    const mergeSha = (exec.metadata as { merge_sha?: string } | null | undefined)?.merge_sha;
+    // Prefer events whose git_commit matches the exec's merge SHA. If the
+    // exec has no merge_sha (older row from before VTID-02697), fall back
+    // to the original "any recent deploy success" behavior.
+    const matched = mergeSha
+      ? deployR.data.find((e) => {
+          const m = (e.metadata as { git_commit?: string } | null | undefined);
+          return typeof m?.git_commit === 'string' && m.git_commit === mergeSha;
+        })
+      : deployR.data[0];
+    if (matched) {
+      await patchExecution(s, exec.id, { status: 'verifying' });
+      await emitOasisEvent({
+        vtid: EXEC_VTID,
+        type: 'dev_autopilot.execution.deployed',
+        source: 'dev-autopilot',
+        status: 'success',
+        message: `Reconciler: ${exec.id.slice(0, 8)} deploy success event observed — advancing to verifying`,
+        payload: { execution_id: exec.id, deploy_event_id: matched.id, reconciled_from: 'deploying', matched_by: mergeSha ? 'merge_sha' : 'recency' },
+      });
+      return;
+    }
   }
 
   // No deploy event seen within the look-back window — fail.
@@ -1754,10 +1774,12 @@ async function reconcileDeploying(s: SupaConfig, exec: StuckExecRow): Promise<vo
  *  recent verification-passed event. */
 async function reconcileVerifying(s: SupaConfig, exec: StuckExecRow): Promise<void> {
   // Look for a verification event tagged for this execution.
+  // VTID-02697: same fix as reconcileDeploying — column is `topic`, not
+  // `type`. The previous query 400'd silently.
   const since = new Date(Date.now() - RECONCILE_TIMEOUT_MS.verifying * 2).toISOString();
-  const verifyR = await supa<Array<{ id: string; type: string }>>(s,
-    `/rest/v1/oasis_events?type=in.(dev_autopilot.execution.verification_passed,vtid.lifecycle.completed)`
-    + `&created_at=gte.${since}&order=created_at.desc&limit=10&select=id,type`);
+  const verifyR = await supa<Array<{ id: string; topic: string }>>(s,
+    `/rest/v1/oasis_events?topic=in.(dev_autopilot.execution.verification_passed,vtid.lifecycle.completed)`
+    + `&created_at=gte.${since}&order=created_at.desc&limit=10&select=id,topic`);
   if (verifyR.ok && verifyR.data && verifyR.data.length > 0) {
     await patchExecution(s, exec.id, {
       status: 'completed',
@@ -1815,7 +1837,7 @@ export async function reconcileStuckExecutions(s: SupaConfig): Promise<void> {
     const cutoff = new Date(Date.now() - RECONCILE_TIMEOUT_MS[status]).toISOString();
     const stuckR = await supa<StuckExecRow[]>(s,
       `/rest/v1/dev_autopilot_executions?status=eq.${status}&updated_at=lt.${cutoff}`
-      + `&select=id,finding_id,status,pr_url,pr_number,branch,updated_at`
+      + `&select=id,finding_id,status,pr_url,pr_number,branch,updated_at,metadata`
       + `&order=updated_at.asc&limit=${RECONCILE_BATCH_SIZE}`);
     if (!stuckR.ok || !stuckR.data || stuckR.data.length === 0) continue;
     console.log(`${LOG_PREFIX} reconciler: ${stuckR.data.length} execution(s) stuck in '${status}'`);

--- a/services/gateway/src/services/dev-autopilot-watcher.ts
+++ b/services/gateway/src/services/dev-autopilot-watcher.ts
@@ -178,10 +178,20 @@ export type DeployOutcome = 'success' | 'failed' | 'pending';
 
 export function findDeployOutcomeForExecution(
   events: Array<{ type: string; payload?: Record<string, unknown>; created_at?: string; status?: string }>,
-  exec: { pr_url?: string | null; pr_number?: number | null; branch?: string | null; updated_at?: string },
+  exec: { pr_url?: string | null; pr_number?: number | null; branch?: string | null; updated_at?: string; metadata?: Record<string, unknown> | null },
 ): DeployOutcome {
-  // We match on whatever signal we have — pr_url (most specific), pr_number,
-  // branch name, or fall back to time-window if none of the above match.
+  // VTID-02697: Match on whatever signal we have. The `branch` check used to
+  // be the primary post-merge fallback, but the EXEC-DEPLOY workflow emits
+  // `deploy.gateway.success` with `metadata.branch = "main"` (because the
+  // workflow runs against main after merge). The exec, however, stores its
+  // FEATURE branch (e.g. `dev-autopilot/abc12345`). Result: branch never
+  // matches and the deploy reconciler hits its 30m timeout, marking the
+  // execution failed — even though the deploy genuinely succeeded.
+  //
+  // Fix: when the CI watcher auto-merges the PR, it now stamps the merge
+  // commit SHA on `exec.metadata.merge_sha`. Match by that against the
+  // event's `metadata.git_commit` for a definitive post-merge link.
+  const mergeSha = (exec.metadata as { merge_sha?: string } | null | undefined)?.merge_sha;
   const since = exec.updated_at ? new Date(exec.updated_at).getTime() : 0;
   const matches = events.filter((e) => {
     const created = e.created_at ? new Date(e.created_at).getTime() : 0;
@@ -189,6 +199,7 @@ export function findDeployOutcomeForExecution(
     const p = e.payload || {};
     if (exec.pr_url && p.pr_url === exec.pr_url) return true;
     if (exec.pr_number && (p.pr_number === exec.pr_number || p.pr === exec.pr_number)) return true;
+    if (mergeSha && typeof p.git_commit === 'string' && p.git_commit === mergeSha) return true;
     if (exec.branch && (p.branch === exec.branch || p.head_branch === exec.branch)) return true;
     return false;
   });
@@ -482,7 +493,13 @@ export async function ciWatcherTick(): Promise<void> {
         'squash',
       );
       if (mergeRes.merged) {
-        await transitionStatus(s, exec.id, 'merging', 'deploying');
+        // VTID-02697: stamp the merge commit SHA on the exec so the deploy
+        // reconciler can match the post-merge `deploy.gateway.success` event
+        // (which carries `metadata.git_commit = <merge SHA>` and
+        // `metadata.branch = "main"`, NOT the feature branch).
+        await transitionStatus(s, exec.id, 'merging', 'deploying', {
+          metadata: { ...(exec.metadata || {}), merge_sha: mergeRes.sha },
+        });
         await emitOasisEvent({
           vtid: WATCHER_VTID,
           type: 'dev_autopilot.execution.pr_merged',


### PR DESCRIPTION
## Summary
After autopilot auto-merges a PR, the post-merge `deploy.gateway.success` event has metadata `{branch: \"main\", git_commit: <merge SHA>}` — but the exec stores its FEATURE branch (`dev-autopilot/X`), so neither the watcher's `findDeployOutcomeForExecution` nor the executor's `reconcileDeploying` could link the event to its own exec.

Result: every successfully-merged-and-deployed autopilot PR sat in `deploying` until the 30m timeout, then got falsely marked failed → linked feedback ticket flipped to `needs_more_info`.

Verified live by FB-2026-05-000040 attempt 4 today (exec `1414a931`): merge SHA `5c5bafd`, deploy event landed at 12:46, exec timed out at 13:09 and marked failed. With this fix the close-loop completes.

## Two issues, one fix
1. **Watcher merge step** stamps `mergeRes.sha` on `exec.metadata.merge_sha`. Matcher accepts optional `metadata` and prefers SHA-based match.
2. **Executor reconciler** (`reconcileDeploying`/`reconcileVerifying`) queried `type=in.(...)` but the column is `topic` — silent 400 → empty data → \"no deploy event\" forever. Switched to `topic` + same SHA-based preference.

## Complementary to parallel session
This is the post-merge half of the autonomous loop. The parallel session's plan (Steps 1+3+4) targets the pre-merge half (LLM hallucinations, branch protection, SELF-HEAL leak). Different files, no conflict.

🤖 Generated with [Claude Code](https://claude.com/claude-code)