### PR TITLE
feat(autopilot): conventions+imports context in planner/executor prompts + reconciler ci-failure short-circuit (VTID-AUTOPILOT-PROMPT)

### DIFF
--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -40,6 +40,7 @@ import { extractFilePaths, generatePlanVersion } from './dev-autopilot-planning'
 import { isWorkerQueueEnabled, isWorkerOwnsPrEnabled, runWorkerTask, reclaimStuckWorkerTasks, reclaimStuckPendingWorkerTasks, type WorkerAttemptFailure } from './dev-autopilot-worker-queue';
 import { writeAutopilotFailure, writeAutopilotSuccess } from './dev-autopilot-self-heal-log';
 import { recordOutcome, recordExecOutcome } from './dev-autopilot-outcomes';
+import { loadAutopilotContext } from './dev-autopilot/context-loader';
 
 const LOG_PREFIX = '[dev-autopilot-execute]';
 const EXEC_VTID = 'VTID-DEV-AUTOPILOT';
@@ -971,6 +972,16 @@ function buildExecutionPrompt(
   const lockedFiles = fileCtx.map(f => f.path);
   lines.push(
     `# Developer Autopilot — Execute plan ${findingId} (plan v${planVersion})`,
+    ``,
+    `## Codebase conventions + imports surface`,
+    ``,
+    `READ THIS FIRST. Apply these rules to every file you emit. Common`,
+    `hallucinations the autopilot has made before are listed at the bottom`,
+    `of the conventions block.`,
+    ``,
+    loadAutopilotContext(),
+    ``,
+    `---`,
     ``,
     `## LOCKED FILE LIST — DO NOT DEVIATE`,
     ``,

--- a/services/gateway/src/services/dev-autopilot-planning.ts
+++ b/services/gateway/src/services/dev-autopilot-planning.ts
@@ -33,6 +33,7 @@ import { emitOasisEvent } from './oasis-event-service';
 import { renderPlanHtml } from './dev-autopilot-html';
 import { isWorkerQueueEnabled, runWorkerTask } from './dev-autopilot-worker-queue';
 import { writeAutopilotFailure, isWorkerBinaryMissing } from './dev-autopilot-self-heal-log';
+import { loadAutopilotContext } from './dev-autopilot/context-loader';
 import {
   extractTableNames,
   loadSchemaSnippets,
@@ -362,6 +363,16 @@ export function buildPlanningPrompt(
     `You are generating a plan that a developer will approve with one click.`,
     `A single click triggers end-to-end execution (branch → edits → PR → CI →`,
     `merge → deploy). Depth and precision matter.`,
+    ``,
+    `## Codebase conventions + imports surface`,
+    ``,
+    `READ THIS FIRST. Reference these rules in your Files-to-modify and`,
+    `Implementation steps so the executor doesn't hallucinate APIs or`,
+    `produce non-conforming filenames.`,
+    ``,
+    loadAutopilotContext(),
+    ``,
+    `---`,
     ``,
     `## Finding`,
     `- **Title:** ${finding.title}`,

--- a/services/gateway/src/services/dev-autopilot/context-loader.ts
+++ b/services/gateway/src/services/dev-autopilot/context-loader.ts
@@ -1,0 +1,249 @@
+/**
+ * Autopilot prompt-context loader — VTID-AUTOPILOT-PROMPT
+ *
+ * Returns the codebase conventions + curated imports surface that gets
+ * injected into every Dev Autopilot planner + executor prompt.
+ *
+ * Why: PR backlog tests showed Gemini 3.1 Pro Preview hallucinating module
+ * exports (e.g. `import { supabase } from '../lib/supabase'` — actual export
+ * is the `getSupabase()` factory) and ignoring repo file-naming conventions
+ * (camelCase filenames trip the `Enforce Phase 2B Naming Standards` CI
+ * check). Both are prompt-context gaps, not LLM-quality issues. Inject the
+ * rules so the model has them in front of it on every call.
+ *
+ * Why embedded as TS string constants instead of separate .md files:
+ * the gateway's build (`tsc && copy-frontend`) doesn't copy arbitrary
+ * non-TS assets to dist by default. Embedding here means the conventions
+ * survive `tsc` cleanly with zero build-chain changes.
+ *
+ * Editing: change the strings below, run `npm run typecheck`, redeploy
+ * the gateway. The change is in front of the next planner/executor call.
+ */
+
+const LOG_PREFIX = '[dev-autopilot/context-loader]';
+
+const CONVENTIONS = `# Vitana platform — code conventions
+
+## File naming
+
+- All \`.ts\` / \`.tsx\` / \`.js\` / \`.jsx\` files MUST use **kebab-case**.
+  - ✅ \`param-limit.ts\`, \`user-routes.ts\`, \`auth-supabase-jwt.ts\`
+  - ❌ \`paramLimit.ts\`, \`userRoutes.ts\`, \`auth_supabase_jwt.ts\`
+- The CI check \`Enforce Phase 2B Naming Standards\` rejects camelCase and
+  snake_case file names. Allowed exceptions: \`README\`, \`LICENSE\`,
+  \`CHANGELOG\`, \`Dockerfile\`, \`Makefile\`.
+- \`.github/workflows/*.yml\` files MUST use **UPPERCASE-WITH-HYPHENS**.
+
+## Database & API
+
+- **Postgres tables: snake_case** (\`vtid_ledger\`, \`oasis_events\`,
+  \`dev_autopilot_executions\`). Never \`VtidLedger\` / \`vtidLedger\`.
+- **API routes: \`/api/v1/...\`** with kebab-case path segments
+  (\`/api/v1/dev-autopilot/findings\`).
+- **Response shape:** \`{ ok: boolean, error?: string, data?: T }\`. JSON
+  keys are snake_case.
+- **TS imports of \`@supabase/supabase-js\` directly are forbidden** in
+  route handlers — use the \`getSupabase()\` factory below.
+
+## VTID format
+
+- VTIDs are \`VTID-XXXXX\` (5-digit zero-padded). Other accepted prefixes:
+  \`DEV-COMHU-XXXX-YYYY\`, \`BOOTSTRAP-...\`.
+- VTID constants in code: \`const VTID = 'VTID-01234';\` (UPPERCASE name).
+
+## TypeScript style
+
+- Strict mode is on; \`tsc --noEmit\` is a required CI check (\`validate\`).
+  Code MUST compile clean before any merge — branch protection enforces it.
+- Prefer \`async function\`/\`await\` over \`.then()\` chains.
+- Use Zod for incoming-request validation (\`req.body\`, \`req.params\`,
+  \`req.query\`).
+
+## Express route pattern
+
+\`\`\`ts
+import { Router, Request, Response } from 'express';
+import { requireAuth, requireExafyAdmin } from '../middleware/auth-supabase-jwt';
+import { getSupabase } from '../lib/supabase';
+
+const router = Router();
+
+router.get('/path', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+  // ...
+  return res.json({ ok: true, data: { /* ... */ } });
+});
+
+export default router;
+\`\`\`
+
+## Common antipatterns the Dev Autopilot has previously hallucinated
+
+| ❌ Wrong | ✅ Right |
+|---|---|
+| \`import { supabase } from '../lib/supabase'\` | \`import { getSupabase } from '../lib/supabase';\` then \`const supabase = getSupabase(); if (!supabase) return ...;\` |
+| \`import { authMiddleware } from '../middleware/auth'\` | \`import { requireAuth } from '../middleware/auth-supabase-jwt';\` |
+| \`import { db } from '../lib/db'\` | \`import { getSupabase } from '../lib/supabase';\` (there is no separate \`db\` module) |
+| \`services/agents/voice/*.py\` (Python paths) | This codebase is **TypeScript + Node only**. Python paths are always wrong. |
+| \`services/gateway/src/routes/v1/...\` (deep nesting) | Flat under \`services/gateway/src/routes/\`. The \`/api/v1/\` prefix lives at mount time in \`index.ts\`. |
+| \`paramLimit.ts\`, \`userRoutes.ts\` (camelCase) | \`param-limit.ts\`, \`user-routes.ts\` (kebab-case) |
+
+## When in doubt
+
+- Check the imports surface section below for actual public exports.
+- If a needed export isn't in the surface or in the file you're editing,
+  STOP and surface the gap in the PR body — do NOT guess at module APIs.
+- Keep the diff minimal. The plan's \`LOCKED FILE LIST\` is hard — never
+  emit a file outside it.
+`;
+
+const IMPORTS_SURFACE = `# Imports surface — public exports of frequently-imported gateway modules
+
+## \`services/gateway/src/lib/supabase.ts\` (70+ importers)
+
+\`\`\`ts
+export const getSupabase: () => SupabaseClient | null;
+\`\`\`
+
+Usage:
+\`\`\`ts
+import { getSupabase } from '../lib/supabase';
+const supabase = getSupabase();
+if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+\`\`\`
+
+There is **no** bare \`supabase\` named export. There is **no** default export.
+
+## \`services/gateway/src/lib/supabase-user.ts\` (40+ importers)
+
+\`\`\`ts
+export function createUserSupabaseClient(userToken: string): SupabaseClient;
+\`\`\`
+
+Wraps a Supabase client scoped to a user JWT (RLS-enforcing).
+
+## \`services/gateway/src/middleware/auth-supabase-jwt.ts\` (27+ importers)
+
+\`\`\`ts
+export interface SupabaseIdentity {
+  user_id: string;
+  email: string | null;
+  tenant_id: string | null;
+  exafy_admin: boolean;
+  role: string | null;
+}
+export interface AuthenticatedRequest extends Request {
+  identity?: SupabaseIdentity;
+}
+export type AuthSource = 'platform' | 'lovable';
+
+export async function verifyAndExtractIdentity(req: Request):
+  Promise<{ ok: true; identity: SupabaseIdentity } | { ok: false; status: number; error: string }>;
+
+export const requireAuth: RequestHandler;
+export const optionalAuth: RequestHandler;
+export const requireExafyAdmin: RequestHandler;
+export async function requireTenant(req, res, next): Promise<void>;
+
+export async function resolveVitanaId(userId: string): Promise<string | null>;
+export function invalidateVitanaIdCache(userId: string): void;
+\`\`\`
+
+Usage in a route:
+\`\`\`ts
+import { requireAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
+router.get('/me', requireAuth, async (req: AuthenticatedRequest, res) => {
+  const userId = req.identity!.user_id;
+  // ...
+});
+\`\`\`
+
+## \`services/gateway/src/services/oasis-event-service.ts\` (104+ importers)
+
+\`\`\`ts
+export async function emitOasisEvent(event: CicdOasisEvent):
+  Promise<{ ok: boolean; event_id?: string; error?: string }>;
+
+export const cicdEvents: { /* helpers per CICD event type */ };
+export const memoryGovernanceEvents: { /* helpers */ };
+export const responseFramingEvents: { /* helpers */ };
+
+export const GOVERNANCE_EVENT_TYPES: readonly string[];
+export const MEMORY_GOVERNANCE_EVENT_TYPES: readonly string[];
+export const RESPONSE_FRAMING_EVENT_TYPES: readonly string[];
+
+export interface GovernanceHistoryEvent { /* ... */ }
+export async function getGovernanceHistory(params: GovernanceHistoryParams):
+  Promise<{ ok: boolean; events?: GovernanceHistoryEvent[]; error?: string }>;
+\`\`\`
+
+The event payload type \`CicdOasisEvent\` lives in \`../types/cicd.ts\`. Add
+new event types to \`CicdEventType\` (string-literal union) BEFORE emitting
+them — \`tsc\` will reject unknown types.
+
+## \`services/gateway/src/services/notification-service.ts\` (13+ importers)
+
+\`\`\`ts
+export interface NotificationPayload {
+  title: string;
+  body: string;
+  data?: Record<string, string>;
+}
+
+export async function notifyUser(
+  userId: string,
+  tenantId: string,
+  category: string,
+  payload: NotificationPayload,
+  supabase?: SupabaseClient,
+): Promise<void>;
+
+export function notifyUserAsync(/* fire-and-forget variant */): void;
+export function notifyUsersAsync(/* batch variant */): void;
+export async function sendPushNotification(/* ... */): Promise<void>;
+export async function sendPushToUser(/* ... */): Promise<void>;
+export async function sendAppilixPush(/* ... */): Promise<void>;
+\`\`\`
+
+## \`services/gateway/src/types/cicd.ts\`
+
+Big string-literal union \`CicdEventType\`. Add a new event type here BEFORE
+\`emitOasisEvent\` will accept it (\`tsc\` will error otherwise — that's
+the spec compliance gate).
+
+\`\`\`ts
+export type CicdEventType =
+  | 'cicd.github.create_pr.requested'
+  | 'cicd.github.safe_merge.executed'
+  | 'dev_autopilot.execution.approved'
+  | 'dev_autopilot.execution.bridged'
+  | 'vtid.lifecycle.completed'
+  | 'vtid.lifecycle.failed'
+  // ...many more — see the full file before adding
+  ;
+\`\`\`
+
+## How to use this section
+
+When you need to import from a module not listed above:
+1. Read the actual file (it's in the LOCKED-FILE-LIST file context block
+   below if your plan touches it).
+2. Use only exports that appear in the file's \`export ...\` statements.
+3. If your plan needs an API surface that doesn't exist yet, STOP — surface
+   the gap in the PR body. Do not invent module shapes.
+`;
+
+let cached: string | null = null;
+
+export function loadAutopilotContext(): string {
+  if (cached !== null) return cached;
+  cached = `${CONVENTIONS.trim()}\n\n---\n\n${IMPORTS_SURFACE.trim()}`;
+  console.log(`${LOG_PREFIX} loaded ${cached.length} chars of conventions + imports surface`);
+  return cached;
+}
+
+/** Test-only: clear the cache so unit tests can reload after edits. */
+export function _resetContextCacheForTests(): void {
+  cached = null;
+}

--- a/services/gateway/src/services/self-healing-reconciler.ts
+++ b/services/gateway/src/services/self-healing-reconciler.ts
@@ -203,6 +203,7 @@ type EscalateReason =
   | 'stale_no_progress'
   | 'stale_agent_exhausted'
   | 'environmental_blocker'
+  | 'ci_bridge_owned'
   | 'probe_verified'
   | 'probe_failed';
 
@@ -508,6 +509,29 @@ async function runReconcileCycle(thresholdMs: number): Promise<void> {
       if (row.failure_class === 'environmental_blocker') {
         console.log(`${LOG_PREFIX} env-blocker for ${row.vtid}: skipping triage agent + spawn (operator must fix host)`);
         await markEscalated(row, 'environmental_blocker', http_status);
+        continue;
+      }
+
+      // CI-FAILURE SHORT-CIRCUIT (2026-05-03 incident): the dev-autopilot
+      // bridge owns the CI-failure → revert-PR → spawn-child-execution
+      // recovery path. It already retries up to `max_auto_fix_depth` and
+      // then escalates cleanly. The reconciler's separate triage-then-spawn
+      // path is redundant for those failures and creates phantom SELF-HEAL
+      // retry VTIDs in `vtid_ledger` that the operator sees as duplicate
+      // work. During a 60-min batch test, this leaked 9 SELF-HEAL VTIDs
+      // even though the bridge had cleanly handled every CI failure.
+      //
+      // Skip if the underlying execution row is in a state the bridge owns:
+      //   - failed_escalated (bridge already escalated; respect that)
+      //   - reverted (CI failed, bridge reverted, depth-cap may have been hit)
+      // These never need reconciler triage — they need either a human review
+      // (failed_escalated) or a planner re-prompt (reverted at depth-cap).
+      const bridgeStage = (row.diagnosis || {} as any).stage
+        || (row.diagnosis || {} as any).failure_stage
+        || row.failure_class;
+      if (bridgeStage === 'ci' || row.failure_class === 'ci_check_failed') {
+        console.log(`${LOG_PREFIX} ci-failure for ${row.vtid}: bridge owns this, skipping reconciler triage spawn`);
+        await markEscalated(row, 'ci_bridge_owned', http_status);
         continue;
       }
 


### PR DESCRIPTION
## Summary

Two related changes to make the Dev Autopilot productive on the 193-finding backlog. Implements steps 3+4 of the approved plan in `/home/dstev/.claude/plans/i-agree-with-the-quizzical-bunny.md`. (Step 1 — branch protection — already applied. Step 2 deferred pending smoke-test outcome.)

### Step 3 — codebase context for planner + executor

200-exec batch run on 2026-05-03 produced 152 PRs and **zero merges**. Top failures, in order:
- `Enforce Phase 2B Naming Standards` (kebab-case rule) — 56× — Gemini creates `paramLimit.ts`, `userRoutes.ts`
- `Gateway Service Tests` (typecheck) — 54× — same root TS error as `validate`
- `validate` (tsc) — 41× — Gemini hallucinates `import { supabase } from '../lib/supabase'` (actual export: `getSupabase()` factory)

All three are prompt-context gaps, not LLM-quality issues. This PR injects:
- **Conventions**: kebab-case files, snake_case tables, VTID format, Express route pattern, list of common antipatterns the autopilot has hallucinated before
- **Imports surface**: actual exports of the 6 most-imported modules (`lib/supabase`, `lib/supabase-user`, `middleware/auth-supabase-jwt`, `services/oasis-event-service`, `services/notification-service`, `types/cicd`)

Embedded as TS string constants (no .md files → no build-chain change). Loaded once, cached, prepended to every planner + executor prompt before the LOCKED FILE LIST.

### Step 4 — reconciler CI-failure short-circuit

Hour-long batch leaked 9 SELF-HEAL retry VTIDs even though the bridge had cleanly handled every CI failure. Root cause: the reconciler's triage-then-spawn-VTID path runs in parallel with the bridge's own ci-failure recovery. Both ended up "healing" the same event; the reconciler's spawn-fresh-VTID is the visible duplicate work.

Companion to the env-blocker short-circuit (#1069). Skip reconciler triage when:
- `row.failure_class === 'ci_check_failed'`, OR
- `diagnosis.stage === 'ci'`

These are bridge-owned; reconciler tombstones with `escalate_reason = 'ci_bridge_owned'`.

## Files

| File | Change |
|---|---|
| `services/gateway/src/services/dev-autopilot/context-loader.ts` | **NEW** — embedded conventions + imports surface, cached on first call |
| `services/gateway/src/services/dev-autopilot-execute.ts` | +11 lines — prepend context block to `buildExecutionPrompt` |
| `services/gateway/src/services/dev-autopilot-planning.ts` | +11 lines — same in `buildPlanningPrompt` |
| `services/gateway/src/services/self-healing-reconciler.ts` | +24 lines — `ci_bridge_owned` short-circuit + add to `EscalateReason` union |

## Test plan

- [ ] `validate` CI green on this PR
- [ ] EXEC-DEPLOY succeeds → new gateway revision serves /alive
- [ ] Trigger 5 fresh `dev_autopilot_executions` (bypass kill_switch + autoApproveTick OR direct REST insert)
- [ ] Inspect resulting PR diffs:
  - All `import` statements use the real exports (no `import { supabase } from ...`)
  - All new files are kebab-case
  - Target: ≥4 of 5 PRs reach `validate=success`
- [ ] After 30 min: query `SELECT count(*) FROM vtid_ledger WHERE title LIKE 'SELF-HEAL%' AND created_at > now() - interval '1 hour'` → target 0
- [ ] If smoke is good, lift `kill_switch=false`, drain a 50-task batch, evaluate

VTID: VTID-AUTOPILOT-PROMPT

🤖 Generated with [Claude Code](https://claude.com/claude-code)