### PR TITLE
DEV-AUTOPILOT: fix locale extraction for persona greetings

### DIFF
--- a/services/gateway/src/services/persona-registry.ts
+++ b/services/gateway/src/services/persona-registry.ts
@@ -100,15 +100,24 @@ export async function getPersonaVoice(key: string): Promise<string> {
 
 function extractLocale(langOrCtx: any): string {
   if (!langOrCtx) return 'en';
-  let val = 'en';
+  
+  let val: any = 'en';
   if (typeof langOrCtx === 'string') {
     val = langOrCtx;
   } else if (typeof langOrCtx === 'object') {
-    val = langOrCtx.user?.locale || langOrCtx.session?.language || langOrCtx.locale || langOrCtx.language || 'en';
+    val = langOrCtx.user?.locale 
+       || langOrCtx.user?.language 
+       || langOrCtx.session?.locale 
+       || langOrCtx.session?.language 
+       || langOrCtx.locale 
+       || langOrCtx.language 
+       || 'en';
   }
+
   if (typeof val !== 'string' || val === '[object Object]') {
-    val = 'en';
+    return 'en';
   }
+
   return val.split('-')[0].toLowerCase() || 'en';
 }
 


### PR DESCRIPTION
This PR ensures that persona greetings correctly resolve localized templates (e.g., German) even when the caller passes a full session/context object instead of a string.

### Root Cause
During persona handoffs, the voice agent is passing a session/context object to `getPersonaGreeting`. Previously, if this wasn't cleanly handled, it would stringify to `"[object Object]"`, failing the template dictionary lookup and triggering a fallback to the default English greeting. The LLM would then continue the conversation in English.

### Fix
- Enhanced `extractLocale` in `services/gateway/src/services/persona-registry.ts` to comprehensively inspect the context object and reliably extract nested locale configurations (`user.locale`, `session.language`, `user.language`, etc.) before normalizing them (e.g., `de-DE` -> `de`).