### PR TITLE
DEV-AUTOPILOT: Replace inline auth helper with standard middleware

### DIFF
--- a/services/gateway/src/routes/admin-notification-categories.ts
+++ b/services/gateway/src/routes/admin-notification-categories.ts
@@ -14,52 +14,17 @@
  * - All endpoints are protected by the `requireExafyAdmin` middleware.
  */
 
-import { Router, Request, Response, NextFunction } from 'express';
+import { Router, Request, Response } from 'express';
 import { createClient } from '@supabase/supabase-js';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, NotificationPayload } from '../services/notification-service';
+import { requireAuth, requireExafyAdmin, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIF-CATEGORIES';
 
 const VALID_TYPES = ['chat', 'calendar', 'community'];
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-// ── Auth Middleware ─────────────────────────────────────────
-
-async function requireExafyAdmin(req: Request, res: Response, next: NextFunction) {
-  const token = getBearerToken(req);
-  if (!token) return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) {
-      return res.status(401).json({ ok: false, error: 'INVALID_TOKEN' });
-    }
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return res.status(403).json({ ok: false, error: 'FORBIDDEN' });
-    }
-
-    // Attach user info to request for downstream handlers
-    (req as any).authUser = { user_id: authData.user.id, email: authData.user.email || 'unknown' };
-    next();
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR' });
-  }
-}
-
-router.use(requireExafyAdmin);
+router.use(requireAuth, requireExafyAdmin);
 
 // ── Supabase ────────────────────────────────────────────────
 
@@ -140,7 +105,7 @@ router.get('/:id', async (req: Request, res: Response) => {
 // ── POST / — Create category ───────────────────────────────
 
 router.post('/', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const identity = (req as AuthenticatedRequest).identity!;
 
   const supabase = getSupabase();
   const {
@@ -180,7 +145,7 @@ router.post('/', async (req: Request, res: Response) => {
     default_enabled: default_enabled ?? true,
     mapped_types: mapped_types || [],
     tenant_id: tenant_id || null,
-    created_by: authUser.user_id,
+    created_by: identity.user_id,
   };
 
   const { data, error } = await supabase
@@ -197,14 +162,14 @@ router.post('/', async (req: Request, res: Response) => {
     return res.status(500).json({ ok: false, error: error.message });
   }
 
-  console.log(`[${VTID}] Created category "${slug}" (${type}) by ${authUser.email}`);
+  console.log(`[${VTID}] Created category "${slug}" (${type}) by ${identity.email || 'unknown'}`);
   return res.status(201).json({ ok: true, data });
 });
 
 // ── PATCH /:id — Update category ────────────────────────────
 
 router.patch('/:id', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const identity = (req as AuthenticatedRequest).identity!;
 
   const supabase = getSupabase();
   const allowedFields = ['display_name', 'description', 'icon', 'sort_order', 'is_active', 'default_enabled', 'mapped_types'];
@@ -236,14 +201,14 @@ router.patch('/:id', async (req: Request, res: Response) => {
     return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
   }
 
-  console.log(`[${VTID}] Updated category "${data.slug}" by ${authUser.email}`);
+  console.log(`[${VTID}] Updated category "${data.slug}" by ${identity.email || 'unknown'}`);
   return res.json({ ok: true, data });
 });
 
 // ── DELETE /:id — Soft-delete (set is_active=false) ─────────
 
 router.delete('/:id', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const identity = (req as AuthenticatedRequest).identity!;
 
   const supabase = getSupabase();
   const { data, error } = await supabase
@@ -261,14 +226,14 @@ router.delete('/:id', async (req: Request, res: Response) => {
     return res.status(404).json({ ok: false, error: 'CATEGORY_NOT_FOUND' });
   }
 
-  console.log(`[${VTID}] Soft-deleted category "${data.slug}" by ${authUser.email}`);
+  console.log(`[${VTID}] Soft-deleted category "${data.slug}" by ${identity.email || 'unknown'}`);
   return res.json({ ok: true, data });
 });
 
 // ── POST /:id/test — Send test notification to admin ────────
 
 router.post('/:id/test', async (req: Request, res: Response) => {
-  const { authUser } = req as any;
+  const identity = (req as AuthenticatedRequest).identity!;
 
   const supabase = getSupabase();
 
@@ -296,15 +261,15 @@ router.post('/:id/test', async (req: Request, res: Response) => {
   const { data: tenantRow } = await supabase
     .from('user_tenants')
     .select('tenant_id')
-    .eq('user_id', authUser.user_id)
+    .eq('user_id', identity.user_id)
     .limit(1)
     .single();
 
   const tenantId = tenantRow?.tenant_id || '00000000-0000-0000-0000-000000000000';
 
   try {
-    const result = await notifyUser(authUser.user_id, tenantId, testType, payload, supabase);
-    console.log(`[${VTID}] Test notification sent for category "${category.slug}" by ${authUser.email}`);
+    const result = await notifyUser(identity.user_id, tenantId, testType, payload, supabase);
+    console.log(`[${VTID}] Test notification sent for category "${category.slug}" by ${identity.email || 'unknown'}`);
     return res.json({ ok: true, result });
   } catch (err: any) {
     console.error(`[${VTID}] POST /:id/test error:`, err.message);

--- a/services/gateway/tests/admin-notification-categories.test.ts
+++ b/services/gateway/tests/admin-notification-categories.test.ts
@@ -1,0 +1,73 @@
+import request from 'supertest';
+import express from 'express';
+import adminNotificationCategoriesRouter from '../src/routes/admin-notification-categories';
+
+jest.mock('../src/middleware/auth-supabase-jwt', () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    const authHeader = req.headers.authorization;
+    if (!authHeader) {
+      return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+    }
+    if (authHeader === 'Bearer valid-user') {
+      req.identity = { user_id: 'user-1', email: 'user@example.com', exafy_admin: false };
+      return next();
+    }
+    if (authHeader === 'Bearer valid-admin') {
+      req.identity = { user_id: 'admin-1', email: 'admin@example.com', exafy_admin: true };
+      return next();
+    }
+    return res.status(401).json({ ok: false, error: 'INVALID_TOKEN' });
+  },
+  requireExafyAdmin: (req: any, res: any, next: any) => {
+    if (!req.identity?.exafy_admin) {
+      return res.status(403).json({ ok: false, error: 'FORBIDDEN' });
+    }
+    return next();
+  }
+}));
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: () => ({
+    from: () => ({
+      select: function () { return this; },
+      order: function () { return this; },
+      eq: function () { return this; },
+      or: function () { return this; },
+      is: function () { return this; },
+      insert: function () { return this; },
+      update: function () { return this; },
+      single: function () { return Promise.resolve({ data: { id: 'test-cat', type: 'chat', slug: 'test' }, error: null }); },
+      then: function (resolve: any, reject: any) {
+        return Promise.resolve({ data: [{ id: 'test-cat', type: 'chat', slug: 'test' }], error: null }).then(resolve, reject);
+      }
+    })
+  })
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/api/v1/admin/notification-categories', adminNotificationCategoriesRouter);
+
+describe('Admin Notification Categories API — Auth boundaries', () => {
+  it('should return 401 UNAUTHENTICATED when no token is provided', async () => {
+    const response = await request(app).get('/api/v1/admin/notification-categories');
+    expect(response.status).toBe(401);
+    expect(response.body).toEqual({ ok: false, error: 'UNAUTHENTICATED' });
+  });
+
+  it('should return 403 FORBIDDEN when user is an authenticated non-admin', async () => {
+    const response = await request(app)
+      .get('/api/v1/admin/notification-categories')
+      .set('Authorization', 'Bearer valid-user');
+    expect(response.status).toBe(403);
+    expect(response.body).toEqual({ ok: false, error: 'FORBIDDEN' });
+  });
+
+  it('should return 200 OK when user is a valid authenticated admin', async () => {
+    const response = await request(app)
+      .get('/api/v1/admin/notification-categories')
+      .set('Authorization', 'Bearer valid-admin');
+    expect(response.status).toBe(200);
+    expect(response.body.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
This PR addresses the `route-auth-scanner-v1` finding for `admin-notification-categories.ts` by replacing the inline `requireExafyAdmin` and `getBearerToken` helper functions with the shared, standard `requireAuth` and `requireExafyAdmin` middlewares.

By adopting the declarative shared middleware pattern:
- The `route-auth-scanner-v1` can now securely recognize the file's auth posture.
- We remove duplicated Supabase client setup and RLS context validation.
- All handlers now securely and uniformly consume `req.identity` variables.

Additionally, a new test file has been added to explicitly verify that the authentication bounds (401 Unauthenticated, 403 Forbidden, 200 OK) are enforced properly.