### PR TITLE
DEV-AUTOPILOT: Enforce auth on telemetry writes to close RLS gap

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -2,6 +2,7 @@ import { Router, Request, Response } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
+import { requireAuth } from "../middleware/auth-supabase-jwt";
 
 export const router = Router();
 
@@ -26,7 +27,7 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-router.post("/event", async (req: Request, res: Response) => {
+router.post("/event", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -146,7 +147,7 @@ router.post("/event", async (req: Request, res: Response) => {
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-router.post("/batch", async (req: Request, res: Response) => {
+router.post("/batch", requireAuth, async (req: Request, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -1,0 +1,119 @@
+import request from 'supertest';
+import express from 'express';
+import { router } from '../../src/routes/telemetry';
+
+// Mock auth middleware to simulate authenticated and unauthenticated states
+jest.mock('../../src/middleware/auth-supabase-jwt', () => ({
+  requireAuth: jest.fn((req, res, next) => {
+    const authHeader = req.headers.authorization;
+    if (authHeader && authHeader.startsWith('Bearer valid-token')) {
+      req.identity = { user_id: 'test-user', email: 'test@example.com' };
+      return next();
+    }
+    return res.status(401).json({ error: 'Unauthorized' });
+  })
+}));
+
+// Mock devhub SSE broadcast to prevent runtime require errors during tests
+jest.mock('../../src/routes/devhub', () => ({
+  broadcastEvent: jest.fn()
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/api/v1/telemetry', router);
+
+describe('Telemetry Routes Auth Enforcement', () => {
+  const originalFetch = global.fetch;
+  const mockFetch = jest.fn();
+
+  beforeAll(() => {
+    global.fetch = mockFetch as any;
+  });
+
+  afterAll(() => {
+    global.fetch = originalFetch;
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    process.env.SUPABASE_URL = 'http://localhost:8000';
+    process.env.SUPABASE_SERVICE_ROLE = 'test-service-key';
+  });
+
+  describe('POST /api/v1/telemetry/event', () => {
+    const validEvent = {
+      vtid: 'VTID-12345',
+      layer: 'test-layer',
+      module: 'test-module',
+      source: 'test-source',
+      kind: 'test.event',
+      status: 'success',
+      title: 'Test Event'
+    };
+
+    it('should return 401 when no authorization header is provided', async () => {
+      const response = await request(app)
+        .post('/api/v1/telemetry/event')
+        .send(validEvent);
+      
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe('Unauthorized');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('should proceed and return 202 when a valid authorization token is provided', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({})
+      });
+
+      const response = await request(app)
+        .post('/api/v1/telemetry/event')
+        .set('Authorization', 'Bearer valid-token')
+        .send(validEvent);
+      
+      expect(response.status).toBe(202);
+      expect(response.body.ok).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+
+  describe('POST /api/v1/telemetry/batch', () => {
+    const validBatch = [{
+      vtid: 'VTID-12345',
+      layer: 'test-layer',
+      module: 'test-module',
+      source: 'test-source',
+      kind: 'test.event',
+      status: 'success',
+      title: 'Test Event'
+    }];
+
+    it('should return 401 when no authorization header is provided', async () => {
+      const response = await request(app)
+        .post('/api/v1/telemetry/batch')
+        .send(validBatch);
+      
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe('Unauthorized');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('should proceed and return 202 when a valid authorization token is provided', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ({})
+      });
+
+      const response = await request(app)
+        .post('/api/v1/telemetry/batch')
+        .set('Authorization', 'Bearer valid-token')
+        .send(validBatch);
+      
+      expect(response.status).toBe(202);
+      expect(response.body.ok).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(1);
+    });
+  });
+});


### PR DESCRIPTION
This PR adds application-level authentication checks to the telemetry routes (`/event` and `/batch`) that write to `oasis_events`. This acts as an immediate mitigation for the `rls_gap` flagged by `rls-policy-scanner-v1`. Unauthenticated requests to these endpoints will now return `401 Unauthorized`.

As outlined in the plan, the database-level RLS migration must be applied manually by a developer.

Files modified:
- `services/gateway/src/routes/telemetry.ts`: Added `requireAuth` middleware to write paths.
- `services/gateway/test/routes/telemetry.test.ts`: Created new unit tests validating the enforcement logic.