### PR TITLE
DEV-AUTOPILOT: Robust locale extraction for persona greetings

### DIFF
--- a/services/gateway/src/services/persona-registry.ts
+++ b/services/gateway/src/services/persona-registry.ts
@@ -101,10 +101,21 @@ export async function getPersonaVoice(key: string): Promise<string> {
 function extractLocale(langOrCtx: any): string {
   if (!langOrCtx) return 'en';
   
+  if (typeof langOrCtx === 'string' && langOrCtx.trim().startsWith('{')) {
+    try {
+      const parsed = JSON.parse(langOrCtx);
+      if (typeof parsed === 'object' && parsed !== null) {
+        langOrCtx = parsed;
+      }
+    } catch (e) {
+      // ignore, keep as string
+    }
+  }
+
   let val: any = 'en';
   if (typeof langOrCtx === 'string') {
     val = langOrCtx;
-  } else if (typeof langOrCtx === 'object') {
+  } else if (typeof langOrCtx === 'object' && langOrCtx !== null) {
     val = langOrCtx.user?.locale 
        || langOrCtx.user?.language 
        || langOrCtx.session?.locale 


### PR DESCRIPTION
**Issue:**
During persona handoffs, the voice agent is switching to English even when the user's configured language is German. This happens because the caller is passing a request/session context object (or its JSON-stringified representation) into the greeting lookup, which historically expected a simple string (`lang: string`). As a result, object-stringification masks the true locale, failing the template dictionary lookup and triggering the fallback to the default English greeting. Once an English greeting is selected, the LLM continues the rest of the conversation in English.

**Changes:**
- Hardened `extractLocale` in `services/gateway/src/services/persona-registry.ts`.
- It now handles JSON stringified context objects explicitly (in addition to direct context objects) and gracefully normalizes the output (e.g., `de-DE` → `de`).
- If an unknown object structure or standard stringification artifact (`[object Object]`) is passed, it falls back to `'en'`.

**Affected files:**
- `services/gateway/src/services/persona-registry.ts`