### PR TITLE
fix(autopilot): bump verifying timeout + retry /alive + preserve metadata (VTID-02698)

### DIFF
--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -1436,12 +1436,21 @@ interface StuckExecRow {
 }
 
 /** Per-state timeout. Beyond this, the state is considered "stuck" and
- *  the reconciler asks reality. */
+ *  the reconciler asks reality.
+ *
+ * VTID-02698: bumped `verifying` from 15m → 60m. The watcher's
+ * `verificationWatcherTick` owns the verifying state with a 30m
+ * window of error-event analysis; the executor's `reconcileVerifying`
+ * was firing FIRST (at 15m) with a brittle single `/alive` probe and
+ * marking healthy execs failed when the probe hit a 429 from a deploy-
+ * churn rate-limit. Bumping past the watcher's window lets the proper
+ * owner advance the state; the executor only steps in if the watcher
+ * is genuinely broken. */
 const RECONCILE_TIMEOUT_MS: Record<string, number> = {
   ci:        30 * 60 * 1000,  // 30 min
   merging:   15 * 60 * 1000,  // 15 min
   deploying: 30 * 60 * 1000,  // 30 min
-  verifying: 15 * 60 * 1000,  // 15 min
+  verifying: 60 * 60 * 1000,  // 60 min — must exceed watcher's 30m window
 };
 
 const RECONCILE_BATCH_SIZE = 10;
@@ -1646,7 +1655,7 @@ async function reconcileCi(s: SupaConfig, exec: StuckExecRow): Promise<void> {
     await patchExecution(s, exec.id, {
       status: 'failed',
       completed_at: new Date().toISOString(),
-      metadata: { error: 'reconciler: PR closed without merge' },
+      metadata: { ...(exec.metadata || {}), error: 'reconciler: PR closed without merge' },
     });
     await emitOasisEvent({
       vtid: EXEC_VTID,
@@ -1668,7 +1677,7 @@ async function reconcileCi(s: SupaConfig, exec: StuckExecRow): Promise<void> {
     await patchExecution(s, exec.id, {
       status: 'failed',
       completed_at: new Date().toISOString(),
-      metadata: { error: `reconciler: PR mergeable_state=${prR.data.mergeable_state} after ${RECONCILE_TIMEOUT_MS.ci / 60_000}m` },
+      metadata: { ...(exec.metadata || {}), error: `reconciler: PR mergeable_state=${prR.data.mergeable_state} after ${RECONCILE_TIMEOUT_MS.ci / 60_000}m` },
     });
     await emitOasisEvent({
       vtid: EXEC_VTID,
@@ -1704,7 +1713,7 @@ async function reconcileMerging(s: SupaConfig, exec: StuckExecRow): Promise<void
     await patchExecution(s, exec.id, {
       status: 'failed',
       completed_at: new Date().toISOString(),
-      metadata: { error: 'reconciler: PR closed without merge while in merging' },
+      metadata: { ...(exec.metadata || {}), error: 'reconciler: PR closed without merge while in merging' },
     });
     bridgeFailure(exec.id, 'merging', 'PR closed without merge').catch(() => {});
   }
@@ -1757,7 +1766,7 @@ async function reconcileDeploying(s: SupaConfig, exec: StuckExecRow): Promise<vo
   await patchExecution(s, exec.id, {
     status: 'failed',
     completed_at: new Date().toISOString(),
-    metadata: { error: `reconciler: no deploy success event observed after ${RECONCILE_TIMEOUT_MS.deploying / 60_000}m in deploying` },
+    metadata: { ...(exec.metadata || {}), error: `reconciler: no deploy success event observed after ${RECONCILE_TIMEOUT_MS.deploying / 60_000}m in deploying` },
   });
   await emitOasisEvent({
     vtid: EXEC_VTID,
@@ -1797,14 +1806,25 @@ async function reconcileVerifying(s: SupaConfig, exec: StuckExecRow): Promise<vo
   }
 
   // No verification event — best-effort: probe /alive ourselves. If 200,
-  // call it good. (Conservative: only complete if /alive returns 200; else
-  // fail.)
+  // call it good.
+  //
+  // VTID-02698: probe up to 3 times with 5s spacing. A single transient
+  // 429 (rate-limited during deploy churn) or 503 (Cloud Run cold start)
+  // shouldn't fail an execution that's otherwise healthy. Only treat
+  // 4xx-non-429 / 5xx-non-503 / network errors as definitive failure.
   const gatewayUrl = process.env.GATEWAY_URL || 'https://gateway-q74ibpv6ia-uc.a.run.app';
   let alive = false;
-  try {
-    const r = await fetch(`${gatewayUrl}/alive`);
-    alive = r.ok;
-  } catch { /* alive=false */ }
+  let lastStatus: number | null = null;
+  for (let attempt = 0; attempt < 3 && !alive; attempt++) {
+    if (attempt > 0) await new Promise((res) => setTimeout(res, 5000));
+    try {
+      const r = await fetch(`${gatewayUrl}/alive`);
+      lastStatus = r.status;
+      if (r.ok) { alive = true; break; }
+      // 429/503 = transient, retry. Anything else = definitive non-alive.
+      if (r.status !== 429 && r.status !== 503) break;
+    } catch { /* network error — retry */ }
+  }
 
   if (alive) {
     await patchExecution(s, exec.id, {
@@ -1822,10 +1842,16 @@ async function reconcileVerifying(s: SupaConfig, exec: StuckExecRow): Promise<vo
     return;
   }
 
+  // VTID-02698: spread existing metadata so we don't blow away merge_sha
+  // (set by the watcher at merge) or other fields the reconciler may
+  // need on subsequent passes / for postmortem.
   await patchExecution(s, exec.id, {
     status: 'failed',
     completed_at: new Date().toISOString(),
-    metadata: { error: `reconciler: /alive failed after ${RECONCILE_TIMEOUT_MS.verifying / 60_000}m in verifying` },
+    metadata: {
+      ...(exec.metadata || {}),
+      error: `reconciler: /alive failed after ${RECONCILE_TIMEOUT_MS.verifying / 60_000}m in verifying (last_status=${lastStatus})`,
+    },
   });
   bridgeFailure(exec.id, 'verifying', '/alive probe failed').catch(() => {});
 }

--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -1432,6 +1432,7 @@ interface StuckExecRow {
   pr_number: number | null;
   branch: string | null;
   updated_at: string;
+  metadata: Record<string, unknown> | null;
 }
 
 /** Per-state timeout. Beyond this, the state is considered "stuck" and
@@ -1713,24 +1714,43 @@ async function reconcileMerging(s: SupaConfig, exec: StuckExecRow): Promise<void
 /** Reconcile status='deploying'. Source of truth: oasis_events for
  *  deploy.gateway.success or any event tagged with the merge SHA / branch. */
 async function reconcileDeploying(s: SupaConfig, exec: StuckExecRow): Promise<void> {
-  // Look for a deploy success event newer than the execution's last update.
+  // VTID-02697: Two bugs in the previous version:
+  //   1. Filtered on `type=in.(...)` but the column is `topic` — the request
+  //      400'd, returned empty, and we always concluded "no deploy event"
+  //      regardless of reality.
+  //   2. Even when the column was right, it took ANY recent deploy event
+  //      across the platform as proof that THIS exec deployed. False
+  //      positive risk during concurrent autopilot runs.
+  //
+  // Fixed query uses `topic` and selects `metadata` so we can match by
+  // merge SHA (set on the exec when the watcher merges its PR).
   const since = new Date(Date.now() - RECONCILE_TIMEOUT_MS.deploying * 2).toISOString();
-  const deployR = await supa<Array<{ id: string; type: string; created_at: string }>>(s,
-    `/rest/v1/oasis_events?type=in.(deploy.gateway.success,deploy.success,vtid.lifecycle.deployed)`
-    + `&created_at=gte.${since}&order=created_at.desc&limit=20&select=id,type,created_at`);
+  const deployR = await supa<Array<{ id: string; topic: string; created_at: string; metadata?: Record<string, unknown> }>>(s,
+    `/rest/v1/oasis_events?topic=in.(deploy.gateway.success,deploy.success,vtid.lifecycle.deployed)`
+    + `&created_at=gte.${since}&order=created_at.desc&limit=20&select=id,topic,created_at,metadata`);
   if (deployR.ok && deployR.data && deployR.data.length > 0) {
-    // We saw at least one recent deploy success event. Best-effort: advance
-    // this execution to verifying; the verification step will run next.
-    await patchExecution(s, exec.id, { status: 'verifying' });
-    await emitOasisEvent({
-      vtid: EXEC_VTID,
-      type: 'dev_autopilot.execution.deployed',
-      source: 'dev-autopilot',
-      status: 'success',
-      message: `Reconciler: ${exec.id.slice(0, 8)} deploy success event observed — advancing to verifying`,
-      payload: { execution_id: exec.id, deploy_event_id: deployR.data[0].id, reconciled_from: 'deploying' },
-    });
-    return;
+    const mergeSha = (exec.metadata as { merge_sha?: string } | null | undefined)?.merge_sha;
+    // Prefer events whose git_commit matches the exec's merge SHA. If the
+    // exec has no merge_sha (older row from before VTID-02697), fall back
+    // to the original "any recent deploy success" behavior.
+    const matched = mergeSha
+      ? deployR.data.find((e) => {
+          const m = (e.metadata as { git_commit?: string } | null | undefined);
+          return typeof m?.git_commit === 'string' && m.git_commit === mergeSha;
+        })
+      : deployR.data[0];
+    if (matched) {
+      await patchExecution(s, exec.id, { status: 'verifying' });
+      await emitOasisEvent({
+        vtid: EXEC_VTID,
+        type: 'dev_autopilot.execution.deployed',
+        source: 'dev-autopilot',
+        status: 'success',
+        message: `Reconciler: ${exec.id.slice(0, 8)} deploy success event observed — advancing to verifying`,
+        payload: { execution_id: exec.id, deploy_event_id: matched.id, reconciled_from: 'deploying', matched_by: mergeSha ? 'merge_sha' : 'recency' },
+      });
+      return;
+    }
   }
 
   // No deploy event seen within the look-back window — fail.
@@ -1754,10 +1774,12 @@ async function reconcileDeploying(s: SupaConfig, exec: StuckExecRow): Promise<vo
  *  recent verification-passed event. */
 async function reconcileVerifying(s: SupaConfig, exec: StuckExecRow): Promise<void> {
   // Look for a verification event tagged for this execution.
+  // VTID-02697: same fix as reconcileDeploying — column is `topic`, not
+  // `type`. The previous query 400'd silently.
   const since = new Date(Date.now() - RECONCILE_TIMEOUT_MS.verifying * 2).toISOString();
-  const verifyR = await supa<Array<{ id: string; type: string }>>(s,
-    `/rest/v1/oasis_events?type=in.(dev_autopilot.execution.verification_passed,vtid.lifecycle.completed)`
-    + `&created_at=gte.${since}&order=created_at.desc&limit=10&select=id,type`);
+  const verifyR = await supa<Array<{ id: string; topic: string }>>(s,
+    `/rest/v1/oasis_events?topic=in.(dev_autopilot.execution.verification_passed,vtid.lifecycle.completed)`
+    + `&created_at=gte.${since}&order=created_at.desc&limit=10&select=id,topic`);
   if (verifyR.ok && verifyR.data && verifyR.data.length > 0) {
     await patchExecution(s, exec.id, {
       status: 'completed',
@@ -1815,7 +1837,7 @@ export async function reconcileStuckExecutions(s: SupaConfig): Promise<void> {
     const cutoff = new Date(Date.now() - RECONCILE_TIMEOUT_MS[status]).toISOString();
     const stuckR = await supa<StuckExecRow[]>(s,
       `/rest/v1/dev_autopilot_executions?status=eq.${status}&updated_at=lt.${cutoff}`
-      + `&select=id,finding_id,status,pr_url,pr_number,branch,updated_at`
+      + `&select=id,finding_id,status,pr_url,pr_number,branch,updated_at,metadata`
       + `&order=updated_at.asc&limit=${RECONCILE_BATCH_SIZE}`);
     if (!stuckR.ok || !stuckR.data || stuckR.data.length === 0) continue;
     console.log(`${LOG_PREFIX} reconciler: ${stuckR.data.length} execution(s) stuck in '${status}'`);

--- a/services/gateway/src/services/dev-autopilot-watcher.ts
+++ b/services/gateway/src/services/dev-autopilot-watcher.ts
@@ -178,10 +178,20 @@ export type DeployOutcome = 'success' | 'failed' | 'pending';
 
 export function findDeployOutcomeForExecution(
   events: Array<{ type: string; payload?: Record<string, unknown>; created_at?: string; status?: string }>,
-  exec: { pr_url?: string | null; pr_number?: number | null; branch?: string | null; updated_at?: string },
+  exec: { pr_url?: string | null; pr_number?: number | null; branch?: string | null; updated_at?: string; metadata?: Record<string, unknown> | null },
 ): DeployOutcome {
-  // We match on whatever signal we have — pr_url (most specific), pr_number,
-  // branch name, or fall back to time-window if none of the above match.
+  // VTID-02697: Match on whatever signal we have. The `branch` check used to
+  // be the primary post-merge fallback, but the EXEC-DEPLOY workflow emits
+  // `deploy.gateway.success` with `metadata.branch = "main"` (because the
+  // workflow runs against main after merge). The exec, however, stores its
+  // FEATURE branch (e.g. `dev-autopilot/abc12345`). Result: branch never
+  // matches and the deploy reconciler hits its 30m timeout, marking the
+  // execution failed — even though the deploy genuinely succeeded.
+  //
+  // Fix: when the CI watcher auto-merges the PR, it now stamps the merge
+  // commit SHA on `exec.metadata.merge_sha`. Match by that against the
+  // event's `metadata.git_commit` for a definitive post-merge link.
+  const mergeSha = (exec.metadata as { merge_sha?: string } | null | undefined)?.merge_sha;
   const since = exec.updated_at ? new Date(exec.updated_at).getTime() : 0;
   const matches = events.filter((e) => {
     const created = e.created_at ? new Date(e.created_at).getTime() : 0;
@@ -189,6 +199,7 @@ export function findDeployOutcomeForExecution(
     const p = e.payload || {};
     if (exec.pr_url && p.pr_url === exec.pr_url) return true;
     if (exec.pr_number && (p.pr_number === exec.pr_number || p.pr === exec.pr_number)) return true;
+    if (mergeSha && typeof p.git_commit === 'string' && p.git_commit === mergeSha) return true;
     if (exec.branch && (p.branch === exec.branch || p.head_branch === exec.branch)) return true;
     return false;
   });
@@ -482,7 +493,13 @@ export async function ciWatcherTick(): Promise<void> {
         'squash',
       );
       if (mergeRes.merged) {
-        await transitionStatus(s, exec.id, 'merging', 'deploying');
+        // VTID-02697: stamp the merge commit SHA on the exec so the deploy
+        // reconciler can match the post-merge `deploy.gateway.success` event
+        // (which carries `metadata.git_commit = <merge SHA>` and
+        // `metadata.branch = "main"`, NOT the feature branch).
+        await transitionStatus(s, exec.id, 'merging', 'deploying', {
+          metadata: { ...(exec.metadata || {}), merge_sha: mergeRes.sha },
+        });
         await emitOasisEvent({
           vtid: WATCHER_VTID,
           type: 'dev_autopilot.execution.pr_merged',


### PR DESCRIPTION
Three issues exposed by FB-040 attempt 5 today:

1. **Verifying timeout race**: executor's `reconcileVerifying` fired at 15m and killed exec via single `/alive` probe (which got rate-limited 429), beating the watcher's proper 30m window. Bumped to 60m so watcher owns the state.
2. **/alive probe brittle**: now retries 3× with 5s spacing, ignores 429/503 as transient.
3. **Metadata overwrite**: error-path metadata writes blew away `merge_sha` set by VTID-02697. Spread existing metadata everywhere.

🤖 Generated with [Claude Code](https://claude.com/claude-code)