### PR TITLE
feat(orb-agent): re-enable full LiveKit tool catalogue (VTID-02708)

### DIFF
--- a/services/agents/orb-agent/pyproject.toml
+++ b/services/agents/orb-agent/pyproject.toml
@@ -7,7 +7,10 @@ readme = "README.md"
 license = { text = "Proprietary" }
 
 dependencies = [
-    "livekit-agents>=0.12.0",
+    # >=1.0 required: RunContext moved from livekit.agents.llm to livekit.agents
+    # in the 1.0 split, and AgentSession gained `userdata` + `max_tool_steps`
+    # constructor kwargs we depend on for tool wiring.
+    "livekit-agents>=1.0.0",
     "livekit-plugins-deepgram>=0.6.0",
     "livekit-plugins-anthropic>=0.2.0",
     "livekit-plugins-cartesia>=0.4.0",

--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -48,6 +48,11 @@ from .tools import all_tools
 
 logger = logging.getLogger(__name__)
 
+# Tool-loop guard threshold (matches Vertex VTID-TOOLGUARD). livekit-agents'
+# AgentSession enforces tool_choice='none' once max_tool_steps consecutive
+# tool calls happen without the LLM emitting an audio response.
+MAX_TOOL_STEPS = 5
+
 
 # livekit-agents primitives, lazily imported so unit tests on the rest of
 # the agent code don't need the full SDK.
@@ -154,26 +159,31 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
         },
     )
 
-    # VTID-02696: Smoke-test path — tools temporarily disabled.
-    # all_tools() returns the raw async functions decorated with
-    # @function_tool, but livekit-agents 0.12 expects FunctionTool instances
-    # — the decorator usage needs to be revisited (likely needs `()` or
-    # different signature). Without the framework's FunctionTool wrapper,
-    # AgentSession.start() raises ValueError at session boot. Disabling
-    # tools entirely so the basic STT/LLM/TTS round-trip works for the
-    # smoke test; tool wiring lands in a follow-up.
+    # Tool catalogue from tools.py — every @function_tool-decorated async
+    # function in the module, exported via all_tools(). Each tool body is a
+    # thin async call to a gateway endpoint via the GatewayClient carried on
+    # RunContext.userdata (set on AgentSession below).
+    #
+    # VTID-LIVEKIT-TOOLS root cause: the earlier blocker was a wrong import
+    # path in tools.py (`from livekit.agents.llm import RunContext` no longer
+    # exists in livekit-agents 1.x; RunContext moved to `livekit.agents`). The
+    # try/except ImportError fallback was substituting a no-op decorator that
+    # returned the raw function, which AgentSession then rejected. Fix landed
+    # in tools.py's import block; tools list is now real.
     agent = Agent(
         instructions=sys_prompt,
-        tools=[],  # TODO(VTID-LIVEKIT-TOOLS): re-enable after fixing decorator wrapping
+        tools=list(all_tools()),
     )
 
-    # AgentSession glues together STT + LLM + TTS + the room.
-    # `userdata=gw` would carry the per-session GatewayClient for tool
-    # bodies — re-enabled with tool wiring.
+    # AgentSession glues together STT + LLM + TTS + the room. userdata
+    # carries the per-session GatewayClient so each tool body can pull it off
+    # RunContext.userdata. max_tool_steps is the tool-loop guard threshold.
     session = AgentSession(
         stt=cascade.stt,
         llm=cascade.llm,
         tts=cascade.tts,
+        userdata=gw,
+        max_tool_steps=MAX_TOOL_STEPS,
     )
 
     try:

--- a/services/agents/orb-agent/src/orb_agent/tools.py
+++ b/services/agents/orb-agent/src/orb_agent/tools.py
@@ -25,8 +25,15 @@ from typing import Any
 from .gateway_client import GatewayClient, summarize
 
 # livekit-agents plumbing — `@function_tool` decorator + RunContext.
+# In livekit-agents 1.x, `RunContext` lives at `livekit.agents` (it moved out
+# of `livekit.agents.llm` during the 1.0 split). The `function_tool` decorator
+# stayed under `livekit.agents.llm`. Importing from the wrong path silently
+# falls into the ImportError branch below, which substitutes a no-op decorator
+# that returns the raw function — and `Agent(tools=[...])` then rejects the
+# raw functions at session start. That was the actual blocker for VTID-LIVEKIT-TOOLS.
 try:
-    from livekit.agents.llm import RunContext, function_tool  # type: ignore[import-not-found]
+    from livekit.agents import RunContext  # type: ignore[import-not-found]
+    from livekit.agents.llm import function_tool  # type: ignore[import-not-found]
 except ImportError:  # pragma: no cover
 
     class RunContext:  # type: ignore[no-redef]


### PR DESCRIPTION
## Summary
- Phase 1.A PR 1 of 11. Re-enables the 40-tool catalogue on the LiveKit Python orb-agent.
- Root cause was a one-line import-path mismatch: \`RunContext\` moved from \`livekit.agents.llm\` to \`livekit.agents\` in the SDK's 1.0 split, and the \`try/except ImportError\` in tools.py was silently substituting a no-op decorator that returned raw functions, which \`Agent(tools=...)\` then rejects.
- Fix: import \`RunContext\` from the new path; pass \`tools=list(all_tools())\` to \`Agent\`; pass \`userdata=gw\` + \`max_tool_steps=5\` to \`AgentSession\` (matches Vertex VTID-TOOLGUARD threshold). Bump pyproject floor to \`livekit-agents>=1.0.0\`.

## Verified locally
Against \`livekit-agents==1.5.7\` (the version that resolves from \`>=1.0.0\`):
- All 40 \`@function_tool\` declarations wrap into proper \`FunctionTool\` instances.
- \`Agent(instructions=..., tools=list(all_tools()))\` builds.
- \`AgentSession(userdata=GatewayClient, max_tool_steps=5)\` builds; \`userdata\` round-trips.
- \`pytest tests/test_tools_catalogue.py tests/test_smoke.py\` — all pass.

## Test plan post-merge
- [ ] DEPLOY-ORB-AGENT auto-deploys
- [ ] Smoke on /command-hub/testing-qa/livekit-test/ — agent boots without ValueError, joins room, model can call at least one tool that maps to an existing endpoint (e.g. \`get_recommendations\` → \`/api/v1/autopilot/recommendations\`)
- [ ] Confirm via Cloud Run logs that \`Agent\` constructed with 40 tools and no startup exception

## Follow-ups in Phase 1.A
- PR 2: gateway-side system prompt rendering (\`buildLiveSystemInstruction\` lifted into shared module, \`/orb/context-bootstrap\` returns the rendered string).
- PR 3: \`POST /api/v1/oasis/emit\` endpoint + per-tool telemetry wiring.
- PR 4: ship-now vs. defer triage for the 40 tools (some endpoints are still missing/misrouted).
- PR 5+6: multi-specialist handoff (\`POST /api/v1/orb/handoff\` + \`perform_handoff\` wiring; activate Devon/Sage/Atlas/Mira).
- PR 7-11: watchdogs, persistence, Cognee pipe, parity canary, Voice Lab UI panel.