### PR TITLE
DEV-AUTOPILOT: Enforce app-level auth on telemetry API endpoints (RLS gap)

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -289,7 +289,7 @@ router.get("/health", (_req: Request, res: Response) => {
  * This endpoint is used by the frontend for auto-loading telemetry
  * when the Operator Console / Command Hub opens.
  */
-router.get("/snapshot", async (req: Request, res: Response) => {
+router.get("/snapshot", requireAuth, async (req: Request, res: Response) => {
   console.log("[Telemetry Snapshot] Request received");
 
   try {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -116,4 +116,35 @@ describe('Telemetry Routes Auth Enforcement', () => {
       expect(mockFetch).toHaveBeenCalledTimes(1);
     });
   });
+
+  describe('GET /api/v1/telemetry/snapshot', () => {
+    it('should return 401 when no authorization header is provided', async () => {
+      const response = await request(app)
+        .get('/api/v1/telemetry/snapshot')
+        .query({ limit: 5 });
+      
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe('Unauthorized');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('should proceed and return 200 when a valid authorization token is provided', async () => {
+      mockFetch.mockResolvedValueOnce({
+        ok: true,
+        json: async () => ([]) // Events
+      }).mockResolvedValueOnce({
+        ok: true,
+        json: async () => ([]) // Counters
+      });
+
+      const response = await request(app)
+        .get('/api/v1/telemetry/snapshot')
+        .set('Authorization', 'Bearer valid-token')
+        .query({ limit: 5 });
+      
+      expect(response.status).toBe(200);
+      expect(response.body.ok).toBe(true);
+      expect(mockFetch).toHaveBeenCalledTimes(2);
+    });
+  });
 });


### PR DESCRIPTION
Addresses the medium-risk `rls_gap` finding for `oasis_events` by enforcing application-level authentication on the telemetry API routes. 

Since the automated executor is restricted from modifying `supabase/migrations/` directly, this PR ensures that `POST /event`, `POST /batch`, and `GET /snapshot` are protected by the `requireAuth` middleware. This guarantees that requests reaching the `oasis_events` table via the service key are strictly authenticated. 

**Files touched:**
- `services/gateway/src/routes/telemetry.ts` - Added `requireAuth` to the `GET /snapshot` route (and ensured `POST` routes maintain it).
- `services/gateway/test/routes/telemetry.test.ts` - Added auth enforcement unit tests for the snapshot endpoint.

*Note: The corresponding database-level RLS migration must still be applied manually by the developer.*