### PR TITLE
feat(reminders-autopilot): link reminders to recommendations (Path A) (BOOTSTRAP-REMINDERS-AUTOPILOT-LINK)

### DIFF
--- a/DATABASE_SCHEMA.md
+++ b/DATABASE_SCHEMA.md
@@ -403,6 +403,7 @@ CREATE TABLE my_new_table (
 | 2026-04-19 | Added ai_provider_policies, ai_assistant_credentials, ai_consent_log + extended connector_registry.category to include 'ai_assistant' | Claude | VTID-02403 |
 | 2026-04-27 | Added routines + routine_runs tables for daily Claude Code remote-agent catalog and run history | Claude | VTID-01981 |
 | 2026-04-28 | Added `pillar` + `contribution_vector` columns to `calendar_events` for typed Vitana Index linkage (replaces `pillar:*` wellness_tag heuristic on the frontend) | Claude | claude/vitana-index-navigation-VdSEQ |
+| 2026-05-04 | Added nullable `linked_reminder_id` (FK → reminders.id, ON DELETE SET NULL) + supporting partial index to `autopilot_recommendations`. Lets server-side callers spawn a `created_via='system'` reminder for a recommendation and record the link. Additive, no backfill. | Claude | BOOTSTRAP-REMINDERS-AUTOPILOT-LINK |
 
 ---
 

--- a/services/gateway/src/services/reminders-service.ts
+++ b/services/gateway/src/services/reminders-service.ts
@@ -158,6 +158,41 @@ export async function createReminder(
 }
 
 /**
+ * Spawn a system-origin reminder on behalf of an autopilot recommendation
+ * and link the rows together. Used by server-side callers (recommendation
+ * engine, automation handlers, future autopilot-worker integrations) to
+ * populate the "Suggested by Vitana" surface on the frontend.
+ *
+ * The created reminder always has `created_via='system'`, so callers should
+ * NOT use this path for user-initiated scheduling — that still goes through
+ * `createReminder({...created_via:'ui'|'voice'})`.
+ *
+ * Sets `autopilot_recommendations.linked_reminder_id` to the new reminder's
+ * id. Best-effort: if the link update fails, the reminder still exists and
+ * the failure is logged (the back-link is a navigability nicety, not a
+ * correctness invariant).
+ */
+export async function createReminderForRecommendation(
+  admin: SupabaseClient,
+  recommendationId: string,
+  input: Omit<CreateReminderInput, 'created_via'>,
+): Promise<ReminderRow> {
+  const reminder = await createReminder(admin, { ...input, created_via: 'system' });
+
+  const { error: linkErr } = await admin
+    .from('autopilot_recommendations')
+    .update({ linked_reminder_id: reminder.id, updated_at: new Date().toISOString() })
+    .eq('id', recommendationId);
+  if (linkErr) {
+    console.warn(
+      `[${VTID}] linked_reminder_id update failed for recommendation ${recommendationId}: ${linkErr.message}`,
+    );
+  }
+
+  return reminder;
+}
+
+/**
  * Soft-delete a reminder (single) or all active reminders for a user.
  * Returns the number of rows cancelled. Emits a single OASIS event.
  */

--- a/supabase/migrations/20260509000000_bootstrap_reminders_autopilot_link.sql
+++ b/supabase/migrations/20260509000000_bootstrap_reminders_autopilot_link.sql
@@ -1,0 +1,31 @@
+-- =============================================================================
+-- BOOTSTRAP-REMINDERS-AUTOPILOT-LINK
+-- =============================================================================
+-- Path A of the Reminders ↔ Autopilot integration plan:
+-- adds a one-directional link from autopilot_recommendations to a reminder
+-- created on its behalf. Server-side callers (recommendation engine, future
+-- automation handlers) populate this when they spawn a `created_via='system'`
+-- reminder so the row is identifiable as "Suggested by Vitana" on the
+-- frontend (vitana-v1 PR #349).
+--
+-- Schema changes are additive and nullable — no backfill, no behavior change
+-- until a caller starts populating the column.
+--
+-- Idempotent: safe to re-run. Uses IF NOT EXISTS guards per repo convention.
+-- =============================================================================
+
+-- 1. Add the link column.
+ALTER TABLE autopilot_recommendations
+  ADD COLUMN IF NOT EXISTS linked_reminder_id UUID
+    REFERENCES reminders(id) ON DELETE SET NULL;
+
+COMMENT ON COLUMN autopilot_recommendations.linked_reminder_id IS
+  'When set, points at a created_via=system reminder spawned for this recommendation. Cleared automatically if the reminder is deleted.';
+
+-- 2. Index for forward lookup (recommendation → reminder).
+CREATE INDEX IF NOT EXISTS idx_autopilot_recommendations_linked_reminder
+  ON autopilot_recommendations(linked_reminder_id)
+  WHERE linked_reminder_id IS NOT NULL;
+
+-- 3. Reload PostgREST schema cache so the new column is visible to API clients.
+NOTIFY pgrst, 'reload schema';


### PR DESCRIPTION
## Summary

PR 3 of the phased Reminders plan — **Path A** (caller-side integration), per the design call to skip the heavier schema unification for the same user-visible outcome.

Adds the minimum infrastructure for server-side callers to spawn a `created_via='system'` reminder on behalf of an `autopilot_recommendations` row, and to record the back-link. The frontend's "Suggested by Vitana" section (vitana-v1 PR #349) populates automatically the moment any caller starts using the new helper.

### Schema

```sql
ALTER TABLE autopilot_recommendations
  ADD COLUMN IF NOT EXISTS linked_reminder_id UUID
    REFERENCES reminders(id) ON DELETE SET NULL;

CREATE INDEX IF NOT EXISTS idx_autopilot_recommendations_linked_reminder
  ON autopilot_recommendations(linked_reminder_id)
  WHERE linked_reminder_id IS NOT NULL;
```

Additive, nullable, idempotent. No backfill. No behavior change until a caller starts populating the column.

### Service helper

`createReminderForRecommendation(admin, recommendationId, input)` in `services/gateway/src/services/reminders-service.ts`. Wraps the existing `createReminder()` with `created_via='system'` pinned, then patches the recommendation row with the new reminder id. Best-effort link update — if the patch fails, the reminder still exists and the failure is logged.

### Why no public endpoint

Keeps `created_via='system'` semantically honest — only server-side, Vitana-initiated callers can spawn these. User-initiated paths (UI modal, ORB voice intent) continue going through their existing `'ui' / 'voice'` code paths, no semantic drift between the agentic frame on the frontend and the data the backend produces.

### What's deferred (out of scope for Path A)

- Wiring an actual caller (recommendation engine, automation handlers, autopilot-worker) — that's a follow-up PR with a product decision attached: *which* recommendation flows should produce reminders.
- Bidirectional link (Path B in the plan): reverse FK on `reminders.recommendation_id`. Deferred unless the navigability is needed.
- Schema unification (Path C): a new `automations` table subsuming reminders. Skipped per design discussion — the two primitives serve genuinely different jobs (per-user fire-at-time UX vs. system-wide handler logs), and forcing them into one shape was ~1–2 weeks of churn for the same user-visible outcome A delivers in days.

### Files changed

- `supabase/migrations/20260509000000_bootstrap_reminders_autopilot_link.sql` — new (28 lines)
- `services/gateway/src/services/reminders-service.ts` — added helper (+34 lines)
- `DATABASE_SCHEMA.md` — change log entry (+1 line)

`npm run typecheck` ✅ in `services/gateway/` (clean, no errors).

## Migration runbook

Migrations on this repo are NOT applied automatically on deploy. Manual workflow dispatch required:

1. Run `.github/workflows/RUN-MIGRATION.yml` with input:
   `supabase/migrations/20260509000000_bootstrap_reminders_autopilot_link.sql`
2. Verify the column exists:
   ```sql
   SELECT column_name FROM information_schema.columns
   WHERE table_name = 'autopilot_recommendations'
     AND column_name = 'linked_reminder_id';
   ```
3. Confirm PostgREST schema reload was picked up (the migration emits `NOTIFY pgrst, 'reload schema'`).
4. Deploy the gateway separately via `EXEC-DEPLOY.yml` once code is on `main`.

If the migration runs before the gateway code is deployed, no harm done — the column sits unused.
If the gateway deploys before the migration runs, the helper still compiles and runs, but the `update({ linked_reminder_id })` call will hit a "column does not exist" error and log a warning. The reminder itself still gets created (best-effort linking).

## Test plan

- [ ] Run migration via RUN-MIGRATION.yml; verify column exists with expected type and FK.
- [ ] Verify partial index is created (`\d autopilot_recommendations`).
- [ ] After gateway deploys: in a Node shell with admin Supabase client, call `createReminderForRecommendation(admin, '<rec-id>', { user_id, tenant_id, action_text, spoken_message, scheduled_for_iso, user_tz })` and verify:
  - A new `reminders` row exists with `created_via='system'`.
  - The recommendation row's `linked_reminder_id` matches the new reminder's id.
  - OASIS `reminder.created` event was emitted with `source: 'system'`.
- [ ] Verify hard-deleting the reminder clears the recommendation's `linked_reminder_id` (ON DELETE SET NULL).
- [ ] Frontend verification (after a caller is wired in a follow-up PR): confirm the new system reminder appears in the "Suggested by Vitana" section on `/reminders` per vitana-v1 PR #349.

Builds on vitana-v1 PR #347 + #349.

https://claude.ai/code

---
_Generated by [Claude Code](https://claude.ai/code/session_01EK27XJ5Hf8XgFSzgsqSH3k)_