### PR TITLE
DEV-AUTOPILOT: Mitigation for path-to-regexp ReDoS vulnerability

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,42 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // 1. Validate parsed path parameters (applicable if middleware is mounted directly on a route)
+    const keys = Object.keys(req.params || {});
+    if (keys.length > maxParams) {
+      res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    for (const key of keys) {
+      const value = req.params[key];
+      if (typeof value === 'string' && value.length > maxLength) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    // 2. Validate raw path segments (crucial when applied via router.use() prior to route matching)
+    // This prevents Express from executing the vulnerable path-to-regexp logic on malicious nested paths.
+    if (req.path) {
+      const segments = req.path.split('/').filter(Boolean);
+      
+      // We check segments against maxParams plus a generous buffer for static path parts
+      // (e.g., '/api/v1/users/:id/projects/:projectId' has static segments mixed with params).
+      if (segments.length > maxParams + 5) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+
+      for (const segment of segments) {
+        if (segment.length > maxLength) {
+          res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+          return;
+        }
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,19 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  return res.json({ ok: true, data: { project_id: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,19 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:userId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  return res.json({ ok: true, data: { user_id: req.params.userId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,53 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - paramLimit Middleware', () => {
+  const app = express();
+  
+  // 1. Integration mount: global middleware to test ReDoS prevention on raw paths
+  app.use('/integration', limitPathParams(5, 200));
+  app.get('/integration/valid', (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+  
+  // 2. Route-level mount: to specifically test req.params parsing logic
+  app.get('/route-level/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+  
+  app.get('/route-level-valid/:a', limitPathParams(5, 200), (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  it('should return 400 when >5 path parameters are provided (req.params check)', async () => {
+    const res = await request(app).get('/route-level/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('should return 400 when a path parameter exceeds maxLength', async () => {
+    const longParam = 'a'.repeat(201);
+    const res = await request(app).get(`/route-level-valid/${longParam}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('should succeed with valid parameters', async () => {
+    const res = await request(app).get('/route-level-valid/123');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('should process request quickly to mitigate ReDoS (integration via raw path)', async () => {
+    const start = Date.now();
+    // Pathological request with 15 segments to trigger the raw path safeguard
+    const segments = Array.from({ length: 15 }, (_, i) => i).join('/');
+    const res = await request(app).get(`/integration/${segments}?malicious=true`);
+    const duration = Date.now() - start;
+    
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
This PR implements server-side validation middleware to mitigate the `path-to-regexp` Regular Expression Denial of Service (ReDoS) vulnerability. 

The `limitPathParams` middleware limits the number and length of path parameters. It actively guards against catastrophic backtracking in the Express routing engine by halting excessively deep or lengthy paths before matching completes. 

### Changes:
- **`services/gateway/src/routes/middleware/paramLimit.ts`**: New middleware verifying `req.params` and checking raw `req.path` lengths as an early-bail guard.
- **`services/gateway/src/routes/v1/userRoutes.ts`**: Example implementation applying the middleware on the user routes.
- **`services/gateway/src/routes/v1/projectRoutes.ts`**: Example implementation applying the middleware on the project routes.
- **`services/gateway/test/cve-mitigation.test.ts`**: Unit and integration tests to ensure invalid payloads are caught in < 500ms while valid ones succeed.

*Note for Operators: This mitigation applies to the representative candidate files specified in the autopilot plan. You must manually verify and apply `router.use(limitPathParams())` to any other remaining route files that define path parameters. Direct dependency bumps for `path-to-regexp` will be done in a separate action.*