### PR TITLE
DEV-AUTOPILOT: Add paramLimit middleware to mitigate path-to-regexp ReDoS

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,53 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // 1. Prevent ReDoS before route matching by validating raw path segments.
+    // This is effective when applied globally or at the router level.
+    const segments = req.path.split('/').filter(Boolean);
+    for (const segment of segments) {
+      if (segment.length > maxLength) {
+        res.status(400).json({ 
+          ok: false, 
+          error: 'Too many path parameters or parameter too long' 
+        });
+        return;
+      }
+    }
+    
+    // Fallback heuristic for an extraordinarily large number of raw path segments.
+    // (We use maxParams + 20 to allow for static segments while bounding complexity)
+    if (segments.length > maxParams + 20) {
+      res.status(400).json({ 
+        ok: false, 
+        error: 'Too many path parameters or parameter too long' 
+      });
+      return;
+    }
+
+    // 2. Validate parsed parameters if route matching has already occurred.
+    // This takes effect when applied as a route-level middleware.
+    if (req.params) {
+      const providedKeys = Object.keys(req.params).filter(k => req.params[k] !== undefined);
+      if (providedKeys.length > maxParams) {
+        res.status(400).json({ 
+          ok: false, 
+          error: 'Too many path parameters or parameter too long' 
+        });
+        return;
+      }
+      for (const key of providedKeys) {
+        const val = req.params[key];
+        if (typeof val === 'string' && val.length > maxLength) {
+          res.status(400).json({ 
+            ok: false, 
+            error: 'Too many path parameters or parameter too long' 
+          });
+          return;
+        }
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,14 @@
+import { Router, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { requireAuth, AuthenticatedRequest } from '../../middleware/auth-supabase-jwt';
+
+const router = Router();
+
+// Apply mitigation to all routes within this router
+router.use(limitPathParams());
+
+router.get('/:id', requireAuth, async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+  res.json({ ok: true, data: { projectId: req.params.id } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,14 @@
+import { Router, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { requireAuth, AuthenticatedRequest } from '../../middleware/auth-supabase-jwt';
+
+const router = Router();
+
+// Apply mitigation to all routes within this router
+router.use(limitPathParams());
+
+router.get('/:id', requireAuth, async (req: AuthenticatedRequest, res: Response): Promise<void> => {
+  res.json({ ok: true, data: { userId: req.params.id } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,50 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - paramLimit middleware', () => {
+  const app = express();
+  
+  // Apply globally to catch long path segments before routing
+  app.use(limitPathParams(5, 200));
+  
+  // Apply locally to enforce req.params check for tests specifically triggering it
+  app.get('/test/:a?/:b?/:c?/:d?/:e?/:f?', limitPathParams(5, 200), (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  it('should pass normal request with <=5 params', async () => {
+    // 2 params provided
+    const res = await request(app).get('/test/1/2');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('should reject request with >5 params', async () => {
+    // 6 params provided
+    const res = await request(app).get('/test/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toMatch(/Too many/);
+  });
+
+  it('should reject request with param length >200', async () => {
+    const longParam = 'a'.repeat(201);
+    const res = await request(app).get(`/test/${longParam}`);
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+  });
+
+  it('integration: returns 400 quickly for malformed ReDoS attempt', async () => {
+    const start = Date.now();
+    // Pathological values to trigger backtracking if vulnerable. 
+    // The global middleware should catch this via path split length check before route match.
+    const longParam = 'a'.repeat(250);
+    const res = await request(app).get(`/test/${longParam}/b/c/d/e/f`);
+    const duration = Date.now() - start;
+    
+    expect(res.status).toBe(400);
+    // Assertion ensures the gateway responds immediately without hanging the CPU
+    expect(duration).toBeLessThan(200);
+  });
+});


### PR DESCRIPTION
This PR implements a server-side mitigation for the ReDoS vulnerability found in `path-to-regexp` < 0.1.13. By enforcing limits on both the number of route parameters and the maximum length of any individual parameter or path segment, we protect the Gateway from CPU exhaustion attacks triggered by catastrophic backtracking.

The mitigation introduces a new middleware `paramLimit` that validates both pre-match raw path segments and post-match `req.params`. It is applied to the newly created user and project routers as examples of the requested mitigation pattern.

**Files touched:**
- `services/gateway/src/routes/middleware/paramLimit.ts`
- `services/gateway/src/routes/v1/userRoutes.ts`
- `services/gateway/src/routes/v1/projectRoutes.ts`
- `services/gateway/test/cve-mitigation.test.ts`