### PR TITLE
feat(orb-agent): endpoint triage — path fixes + Vitana Index routes (VTID-02711)

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/tools.py
+++ b/services/agents/orb-agent/src/orb_agent/tools.py
@@ -87,7 +87,7 @@ async def search_memory(context: RunContext, query: str, limit: int = 5) -> str:
 @function_tool
 async def search_knowledge(context: RunContext, query: str) -> str:
     """Search the Vitana Knowledge Hub (longevity, platform docs)."""
-    body = await _gw(context).post("/api/v1/knowledge/search", {"query": query})
+    body = await _gw(context).post("/api/v1/assistant/knowledge/search", {"query": query})
     return summarize(body)
 
 
@@ -155,8 +155,8 @@ async def report_to_specialist(
 async def search_calendar(context: RunContext, query: str, days_ahead: int = 14) -> str:
     """Search the user's calendar for upcoming events matching `query`."""
     body = await _gw(context).get(
-        "/api/v1/integrations/calendar/events",
-        {"query": query, "days_ahead": days_ahead},
+        "/api/v1/calendar/events",
+        {"q": query, "days_ahead": days_ahead},
     )
     return summarize(body)
 
@@ -167,7 +167,7 @@ async def create_calendar_event(
 ) -> str:
     """Create a calendar event."""
     body = await _gw(context).post(
-        "/api/v1/integrations/calendar/events",
+        "/api/v1/calendar/events",
         {"title": title, "when_iso": when_iso, "duration_min": duration_min},
     )
     return summarize(body)
@@ -177,7 +177,7 @@ async def create_calendar_event(
 async def add_to_calendar(context: RunContext, title: str, when_iso: str) -> str:
     """Add an event to the user's calendar (VTID-01943)."""
     body = await _gw(context).post(
-        "/api/v1/integrations/calendar/events",
+        "/api/v1/calendar/events",
         {"title": title, "when_iso": when_iso},
     )
     return summarize(body)
@@ -186,10 +186,16 @@ async def add_to_calendar(context: RunContext, title: str, when_iso: str) -> str
 @function_tool
 async def get_schedule(context: RunContext, date_iso: str | None = None) -> str:
     """Return the user's schedule for a given date (defaults to today)."""
-    params: dict[str, Any] = {}
+    # Calendar router exposes /events/today and /events/upcoming. Without a
+    # specific date we default to /today; with a date we fall back to the
+    # generic /events search constrained to that day.
     if date_iso:
-        params["date_iso"] = date_iso
-    body = await _gw(context).get("/api/v1/integrations/calendar/schedule", params)
+        body = await _gw(context).get(
+            "/api/v1/calendar/events",
+            {"from": date_iso, "to": date_iso},
+        )
+    else:
+        body = await _gw(context).get("/api/v1/calendar/events/today")
     return summarize(body)
 
 
@@ -434,22 +440,26 @@ async def post_intent(context: RunContext, kind: str, body_text: str) -> str:
 @function_tool
 async def view_intent_matches(context: RunContext) -> str:
     """View match candidates for the user's open intents (VTID-01976)."""
-    body = await _gw(context).get("/api/v1/intents/matches")
+    # Mounted at /api/v1/intent-matches/{outgoing,incoming}; surface incoming
+    # matches (the ones the LLM cares about — what came back to the user).
+    body = await _gw(context).get("/api/v1/intent-matches/incoming")
     return summarize(body)
 
 
 @function_tool
 async def list_my_intents(context: RunContext) -> str:
     """List the user's open and historical intents."""
-    body = await _gw(context).get("/api/v1/intents/mine")
+    body = await _gw(context).get("/api/v1/intents")
     return summarize(body)
 
 
 @function_tool
 async def respond_to_match(context: RunContext, match_id: str, response: str) -> str:
     """Respond to a match candidate (VTID-01976)."""
+    # /api/v1/intent-matches/:id/state takes {state} as body; pass the user's
+    # 'response' string through unchanged and let the gateway map it.
     body = await _gw(context).post(
-        f"/api/v1/intents/matches/{match_id}/respond", {"response": response}
+        f"/api/v1/intent-matches/{match_id}/state", {"state": response}
     )
     return summarize(body)
 
@@ -457,7 +467,7 @@ async def respond_to_match(context: RunContext, match_id: str, response: str) ->
 @function_tool
 async def mark_intent_fulfilled(context: RunContext, intent_id: str) -> str:
     """Mark an intent as fulfilled."""
-    body = await _gw(context).post(f"/api/v1/intents/{intent_id}/fulfill")
+    body = await _gw(context).post(f"/api/v1/intents/{intent_id}/close")
     return summarize(body)
 
 
@@ -478,9 +488,9 @@ async def scan_existing_matches(context: RunContext) -> str:
 
 
 @function_tool
-async def get_matchmaker_result(context: RunContext, intent_id: str) -> str:
+async def get_matchmaker_result(context: RunContext, intent_id: str) -> str:  # noqa: D401
     """Get the matchmaker's current result for a specific intent."""
-    body = await _gw(context).get(f"/api/v1/intents/{intent_id}/matchmaker-result")
+    body = await _gw(context).get(f"/api/v1/intents/{intent_id}/matchmaker")
     return summarize(body)
 
 

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -88,6 +88,7 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const orbLiveRouter = require('./routes/orb-live').default;
   // VTID-LIVEKIT-FOUNDATION: ORB LiveKit pipeline (parallel/standby to Vertex orb-live).
   const orbLivekitRouter = require('./routes/orb-livekit').default;
+  const vitanaIndexRouter = require('./routes/vitana-index').default;
   const awarenessConfigRouter = require('./routes/awareness-config').default;
   // VTID-01222: WebSocket server initialization for ORB Live API
   const { initializeOrbWebSocket } = require('./routes/orb-live');
@@ -658,6 +659,11 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   // Mounted at /api/v1 because its routes span /orb/*, /voice-providers/*,
   // /agents/*/voice-config — the leaf paths inside the router carry the prefix.
   mountRouterSync(app, '/api/v1', orbLivekitRouter, { owner: 'orb-livekit' });
+
+  // VTID-LIVEKIT-TOOLS: Vitana Index endpoints used by the LiveKit tool catalogue
+  // (get_vitana_index, get_index_improvement_suggestions). Lifted from the
+  // inline case bodies in orb-live.ts so both pipelines share the helper layer.
+  mountRouterSync(app, '/api/v1/vitana-index', vitanaIndexRouter, { owner: 'vitana-index' });
 
   // BOOTSTRAP-AWARENESS-REGISTRY: admin API for the Awareness Registry
   mountRouterSync(app, '/api/v1/awareness', awarenessConfigRouter, { owner: 'awareness-registry' });

--- a/services/gateway/src/routes/vitana-index.ts
+++ b/services/gateway/src/routes/vitana-index.ts
@@ -1,0 +1,189 @@
+/**
+ * VTID-LIVEKIT-TOOLS: Vitana Index endpoints for the LiveKit orb-agent.
+ *
+ * The Vertex pipeline implements `get_vitana_index` /
+ * `get_index_improvement_suggestions` inline in orb-live.ts (case blocks).
+ * The LiveKit agent calls them via HTTP because its tool catalogue is built
+ * from `services/agents/orb-agent/src/orb_agent/tools.py` which dispatches
+ * every call through `GatewayClient`. This file lifts the same business
+ * logic into a stable HTTP route so the LiveKit agent reaches behaviour
+ * parity with Vertex without duplicating the underlying helpers.
+ *
+ * Both endpoints accept the per-session user JWT minted by
+ * `/api/v1/orb/livekit/token` (see VTID-02709).
+ */
+
+import { Router, Response } from 'express';
+import { createClient } from '@supabase/supabase-js';
+import { requireAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
+import { fetchVitanaIndexForProfiler } from '../services/user-context-profiler';
+import { resolvePillarKey } from '../lib/vitana-pillars';
+
+const router = Router();
+
+const VTID = 'VTID-LIVEKIT-TOOLS';
+
+function getServiceClient() {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+  if (!url || !key) return null;
+  return createClient(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+/**
+ * GET /api/v1/vitana-index
+ *
+ * Returns the user's current Vitana Index snapshot — total score, tier,
+ * 5-pillar breakdown, weakest/strongest pillar, sub-scores, balance factor,
+ * 7-day trend, and aspirational distance. Mirrors the `get_vitana_index`
+ * tool body at orb-live.ts:5631.
+ */
+router.get('/', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const userId = req.identity?.user_id;
+  if (!userId) {
+    return res.status(401).json({ ok: false, error: 'unauthenticated', vtid: VTID });
+  }
+
+  const client = getServiceClient();
+  if (!client) {
+    return res.status(500).json({ ok: false, error: 'supabase_not_configured', vtid: VTID });
+  }
+
+  try {
+    const snap = await fetchVitanaIndexForProfiler(client, userId);
+    if (!snap) {
+      return res.json({
+        ok: true,
+        text: "I don't see a Vitana Index score yet — it looks like the baseline survey hasn't been completed. Want me to point you to the health screen so you can start?",
+        snapshot: null,
+        vtid: VTID,
+      });
+    }
+    return res.json({
+      ok: true,
+      snapshot: {
+        total: snap.total,
+        tier: snap.tier,
+        tier_framing: snap.tier_framing,
+        pillars: snap.pillars,
+        weakest_pillar: snap.weakest_pillar,
+        strongest_pillar: snap.strongest_pillar,
+        balance_factor: snap.balance_factor,
+        balance_label: snap.balance_label,
+        balance_hint: snap.balance_hint,
+        subscores: snap.subscores,
+        trend_7d: snap.trend_7d,
+        goal_target: snap.goal_target,
+        points_to_really_good: snap.points_to_really_good,
+        last_computed: snap.last_computed,
+        model_version: snap.model_version,
+        confidence: snap.confidence,
+        last_movement: snap.last_movement,
+      },
+      vtid: VTID,
+    });
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'unknown';
+    console.error('[vitana-index] get error:', msg);
+    return res.status(500).json({ ok: false, error: msg, vtid: VTID });
+  }
+});
+
+/**
+ * GET /api/v1/vitana-index/suggestions?pillar=<key>&limit=<n>
+ *
+ * Returns 1..N pending autopilot recommendations whose `contribution_vector`
+ * lifts the requested pillar (or the weakest pillar when `pillar` is
+ * omitted). Mirrors `get_index_improvement_suggestions` at orb-live.ts:5674.
+ */
+router.get('/suggestions', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const userId = req.identity?.user_id;
+  if (!userId) {
+    return res.status(401).json({ ok: false, error: 'unauthenticated', vtid: VTID });
+  }
+
+  const client = getServiceClient();
+  if (!client) {
+    return res.status(500).json({ ok: false, error: 'supabase_not_configured', vtid: VTID });
+  }
+
+  const limitRaw = parseInt(String(req.query.limit ?? '3'), 10);
+  const limit = Math.max(1, Math.min(10, Number.isFinite(limitRaw) ? limitRaw : 3));
+
+  let pillar: string | undefined = resolvePillarKey(String(req.query.pillar ?? ''));
+  if (!pillar) {
+    try {
+      const snap = await fetchVitanaIndexForProfiler(client, userId);
+      pillar = snap?.weakest_pillar?.name;
+    } catch {
+      // fall through — handled below
+    }
+  }
+  if (!pillar) {
+    return res.json({
+      ok: true,
+      text: "I don't see Index data for this user yet, so I can't pick a target pillar. Complete the 5-question baseline survey first.",
+      pillar: null,
+      suggestions: [],
+      vtid: VTID,
+    });
+  }
+
+  try {
+    const { data, error } = await client
+      .from('autopilot_recommendations')
+      .select('id, title, action_description, contribution_vector, priority, status')
+      .eq('user_id', userId)
+      .in('status', ['pending', 'new', 'snoozed'])
+      .not('contribution_vector', 'is', null)
+      .order('priority', { ascending: false })
+      .limit(50);
+
+    if (error) {
+      return res
+        .status(500)
+        .json({ ok: false, error: `Could not fetch recommendations: ${error.message}`, vtid: VTID });
+    }
+
+    const ranked = (data || [])
+      .map((r: { id: string; title: string; action_description: string; contribution_vector: Record<string, number> | null; priority: number; status: string }) => {
+        const cv = r.contribution_vector;
+        const lift = cv && typeof cv[pillar!] === 'number' ? cv[pillar!] : 0;
+        return { ...r, _lift: lift };
+      })
+      .filter((r) => r._lift > 0)
+      .sort((a, b) => b._lift - a._lift)
+      .slice(0, limit);
+
+    if (ranked.length === 0) {
+      return res.json({
+        ok: true,
+        pillar,
+        suggestions: [],
+        text: `No pending recommendations with a positive ${pillar} contribution right now. Completing ANY existing recommendation will trigger the Index engine to propose more.`,
+        vtid: VTID,
+      });
+    }
+
+    return res.json({
+      ok: true,
+      pillar,
+      suggestions: ranked.map((r) => ({
+        id: r.id,
+        title: r.title,
+        action: r.action_description,
+        lift: r._lift,
+        contribution_vector: r.contribution_vector,
+      })),
+      vtid: VTID,
+    });
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'unknown';
+    console.error('[vitana-index] suggestions error:', msg);
+    return res.status(500).json({ ok: false, error: msg, vtid: VTID });
+  }
+});
+
+export default router;


### PR DESCRIPTION
Phase 1.A PR 4 of 11. Fixes path mismatches between tools.py and the gateway mount table, and adds two new routes for Vitana Index parity with the Vertex inline case bodies. After merge: calendar/recommendations/reminders/index/diary/knowledge tool calls return real data instead of 404s.