### PR TITLE
DEV-AUTOPILOT: Mitigate path-to-regexp ReDoS via paramLimit middleware

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,33 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // 1. Check parsed route parameters (works when attached to specific parameterised routes)
+    if (req.params) {
+      const keys = Object.keys(req.params);
+      if (keys.length > maxParams) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+
+      for (const key of keys) {
+        if (req.params[key] && req.params[key].length > maxLength) {
+          res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+          return;
+        }
+      }
+    }
+
+    // 2. Check raw path segments (works when attached via router.use())
+    // This provides robust defense-in-depth against ReDoS before path-to-regexp matching occurs.
+    const segments = req.path.split('/').filter(Boolean);
+    for (const segment of segments) {
+      if (segment.length > maxLength) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,18 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { getSupabase } from '../../lib/supabase';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+
+const router = Router();
+
+// Apply ReDoS mitigation middleware to all project routes
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  return res.json({ ok: true, data: { project_id: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,18 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { getSupabase } from '../../lib/supabase';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+
+const router = Router();
+
+// Apply ReDoS mitigation middleware to all user routes
+router.use(limitPathParams());
+
+router.get('/:userId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  return res.json({ ok: true, data: { user_id: req.params.userId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,53 @@
+import express from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - limitPathParams', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    
+    // Route 1: tests the parameter count limit logic
+    app.get('/test/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req, res) => {
+      res.json({ ok: true });
+    });
+    
+    // Route 2: baseline valid route
+    app.get('/test/:a/:b', limitPathParams(5, 200), (req, res) => {
+      res.json({ ok: true });
+    });
+  });
+
+  it('should reject requests with >5 path parameters (400)', async () => {
+    const res = await request(app).get('/test/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('should reject requests with excessively long parameters', async () => {
+    const longParam = 'a'.repeat(201);
+    const res = await request(app).get(`/test/1/${longParam}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('should pass normal requests with <=5 parameters', async () => {
+    const res = await request(app).get('/test/1/2');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('integration test: pathological values should execute quickly (<500ms)', async () => {
+    const start = Date.now();
+    
+    // Generate a pathological string designed to test catastrophic backtracking
+    const pathological = 'a'.repeat(1000);
+    
+    const res = await request(app).get(`/test/${pathological}/2/3/4/5/6`);
+    const duration = Date.now() - start;
+    
+    expect(res.status).toBe(400);
+    expect(duration).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
This PR implements server-side validation middleware to mitigate a ReDoS vulnerability in `path-to-regexp` (< 0.1.13) used by Express. 
Because direct dependency updates are outside the scope of this plan, we mitigate the risk by capping the number of parameters and parameter length to prevent the catastrophic backtracking associated with this CVE.

**Changes:**
- Created `paramLimit.ts` middleware to restrict both the number of parsed path parameters and the maximum length of any path segment.
- Applied `limitPathParams` to `userRoutes.ts` and `projectRoutes.ts` to protect routes that consume path parameters.
- Added comprehensive unit and integration tests in `cve-mitigation.test.ts`.

*Note on file naming:* The provided file paths (`paramLimit.ts`, `userRoutes.ts`, `projectRoutes.ts`) use camelCase, which violates the `Phase 2B Naming Standards` (kebab-case) constraint. However, they were strictly enforced by the LOCKED FILE LIST. Follow-up work may be needed to rename these files to `param-limit.ts`, `user-routes.ts`, and `project-routes.ts` in order to fully comply with CI linting rules.