### PR TITLE
DEV-AUTOPILOT: Refactor admin-notifications to use shared auth middleware

### DIFF
--- a/services/gateway/src/routes/admin-notifications.ts
+++ b/services/gateway/src/routes/admin-notifications.ts
@@ -12,51 +12,21 @@
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
 import { notifyUser, notifyUsersAsync, NotificationPayload } from '../services/notification-service';
+import { requireExafyAdmin, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
 
 const router = Router();
 const VTID = 'ADMIN-NOTIFICATIONS';
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
+router.use(requireExafyAdmin);
 
 // ── POST /compose — Send notification to user(s) ────────────
 
-router.post('/compose', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
+router.post('/compose', async (req: AuthenticatedRequest, res: Response) => {
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
+
+  const email = req.identity?.email || 'unknown';
 
   const {
     recipient_ids,   // string[] — specific user IDs
@@ -148,7 +118,7 @@ router.post('/compose', async (req: Request, res: Response) => {
         payload,
         supabase
       );
-      console.log(`[${VTID}] Composed notification for 1 user by ${authResult.email}: type=${notificationType}`);
+      console.log(`[${VTID}] Composed notification for 1 user by ${email}: type=${notificationType}`);
       return res.json({ ok: true, sent_to: 1, result });
     }
 
@@ -161,7 +131,7 @@ router.post('/compose', async (req: Request, res: Response) => {
       supabase
     );
 
-    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${authResult.email}: type=${notificationType}`);
+    console.log(`[${VTID}] Composed notification for ${targetUserIds.length} users by ${email}: type=${notificationType}`);
 
     return res.json({
       ok: true,
@@ -176,10 +146,7 @@ router.post('/compose', async (req: Request, res: Response) => {
 
 // ── GET /sent — Admin notification log ──────────────────────
 
-router.get('/sent', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
+router.get('/sent', async (req: AuthenticatedRequest, res: Response) => {
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -223,10 +190,7 @@ router.get('/sent', async (req: Request, res: Response) => {
 
 // ── GET /preferences/stats — Aggregate preference statistics ─
 
-router.get('/preferences/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
+router.get('/preferences/stats', async (req: AuthenticatedRequest, res: Response) => {
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-notifications.test.ts
+++ b/services/gateway/test/routes/admin-notifications.test.ts
@@ -1,0 +1,104 @@
+import request from 'supertest';
+import express, { Express } from 'express';
+import adminNotificationsRouter from '../../src/routes/admin-notifications';
+import { getSupabase } from '../../src/lib/supabase';
+
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn()
+}));
+
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUser: jest.fn().mockResolvedValue({}),
+  notifyUsersAsync: jest.fn()
+}));
+
+jest.mock('../../src/middleware/auth-supabase-jwt', () => ({
+  requireExafyAdmin: jest.fn((req, res, next) => {
+    req.identity = {
+      user_id: 'admin-id',
+      email: 'admin@test.com',
+      tenant_id: 'test-tenant',
+      exafy_admin: true,
+      role: 'admin'
+    };
+    next();
+  })
+}));
+
+describe('Admin Notifications Router', () => {
+  let app: Express;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+
+    app = express();
+    app.use(express.json());
+    app.use('/admin-notifications', adminNotificationsRouter);
+  });
+
+  const mockSupabaseQuery = (resolvedValue: any) => {
+    const chainable: any = {
+      select: jest.fn().mockReturnThis(),
+      eq: jest.fn().mockReturnThis(),
+      gte: jest.fn().mockReturnThis(),
+      order: jest.fn().mockReturnThis(),
+      range: jest.fn().mockReturnThis(),
+      not: jest.fn().mockReturnThis(),
+      or: jest.fn().mockReturnThis()
+    };
+    chainable.then = (resolve: any) => resolve(resolvedValue);
+    return chainable;
+  };
+
+  it('POST /compose - requires recipients', async () => {
+    (getSupabase as jest.Mock).mockReturnValue({
+      from: jest.fn().mockReturnValue(mockSupabaseQuery({ data: [], error: null }))
+    });
+
+    const response = await request(app)
+      .post('/admin-notifications/compose')
+      .send({ title: 'T', body: 'B' });
+    
+    expect(response.status).toBe(400);
+    expect(response.body.message).toMatch(/Must specify recipient_ids/);
+  });
+
+  it('POST /compose - direct user', async () => {
+    (getSupabase as jest.Mock).mockReturnValue({
+      from: jest.fn()
+    });
+
+    const response = await request(app)
+      .post('/admin-notifications/compose')
+      .send({ title: 'T', body: 'B', recipient_ids: ['u1'] });
+    
+    expect(response.status).toBe(200);
+    expect(response.body.sent_to).toBe(1);
+  });
+
+  it('GET /sent - returns 200', async () => {
+    (getSupabase as jest.Mock).mockReturnValue({
+      from: jest.fn().mockReturnValue(mockSupabaseQuery({ data: [{ id: 'n1' }], count: 1, error: null }))
+    });
+
+    const response = await request(app)
+      .get('/admin-notifications/sent')
+      .query({ limit: 10 });
+    
+    expect(response.status).toBe(200);
+    expect(response.body.total).toBe(1);
+  });
+
+  it('GET /preferences/stats - returns 200', async () => {
+    (getSupabase as jest.Mock).mockReturnValue({
+      from: jest.fn().mockReturnValue(mockSupabaseQuery({ data: [], count: 0, error: null }))
+    });
+
+    const response = await request(app)
+      .get('/admin-notifications/preferences/stats');
+    
+    expect(response.status).toBe(200);
+    expect(response.body.stats).toBeDefined();
+    expect(response.body.delivery).toBeDefined();
+  });
+});


### PR DESCRIPTION
**Context & Finding:**
The `route-auth-scanner-v1` scanner flagged `services/gateway/src/routes/admin-notifications.ts` because it used a custom inline `verifyExafyAdmin` authentication helper rather than the standard project auth middleware. 

**Changes:**
1. Replaced the custom `verifyExafyAdmin` and `getBearerToken` helper functions with the shared `requireExafyAdmin` middleware from `../middleware/auth-supabase-jwt`.
2. Applied `router.use(requireExafyAdmin)` to securely protect all routes defined in `admin-notifications.ts`.
3. Updated local endpoint logic to directly rely on the initialized `req.identity` for user logs instead of manual verification logic.
4. Created a comprehensive suite of unit tests for the route in `services/gateway/test/routes/admin-notifications.test.ts` mocking the shared standard middleware.

**Files modified:**
- `services/gateway/src/routes/admin-notifications.ts`
- `services/gateway/test/routes/admin-notifications.test.ts`