### PR TITLE
DEV-AUTOPILOT: Expose system controls endpoint for DYK tour flag

### DIFF
--- a/services/gateway/src/routes/system-controls.ts
+++ b/services/gateway/src/routes/system-controls.ts
@@ -1,0 +1,31 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../middleware/auth-supabase-jwt';
+import { getSupabase } from '../lib/supabase';
+import { getSystemControl } from '../services/system-controls';
+
+const router = Router();
+
+router.get('/:key', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  const { key } = req.params;
+  if (!key) {
+    return res.status(400).json({ ok: false, error: 'missing key parameter' });
+  }
+
+  const result = await getSystemControl(supabase, key);
+  
+  if (!result.ok) {
+    if (result.error === 'Not found') {
+      return res.status(404).json({ ok: false, error: 'system control not found' });
+    }
+    return res.status(500).json({ ok: false, error: result.error });
+  }
+
+  return res.json({ ok: true, data: result.data });
+});
+
+export default router;

--- a/services/gateway/src/services/system-controls.ts
+++ b/services/gateway/src/services/system-controls.ts
@@ -1,0 +1,27 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { SystemControl } from '../types/system-controls';
+
+export async function getSystemControl(
+  supabase: SupabaseClient,
+  key: string
+): Promise<{ ok: boolean; data?: SystemControl; error?: string }> {
+  try {
+    const { data, error } = await supabase
+      .from('system_controls')
+      .select('*')
+      .eq('key', key)
+      .single();
+
+    if (error) {
+      // PGRST116 indicates 0 rows returned on a .single() query
+      if (error.code === 'PGRST116') {
+        return { ok: false, error: 'Not found' };
+      }
+      return { ok: false, error: error.message };
+    }
+
+    return { ok: true, data };
+  } catch (err: any) {
+    return { ok: false, error: err.message || 'Unknown error' };
+  }
+}

--- a/services/gateway/src/types/system-controls.ts
+++ b/services/gateway/src/types/system-controls.ts
@@ -1,0 +1,7 @@
+export interface SystemControl {
+  key: string;
+  enabled: boolean;
+  updated_at?: string;
+  updated_by?: string;
+  reason?: string;
+}

--- a/services/gateway/test/routes/system-controls.test.ts
+++ b/services/gateway/test/routes/system-controls.test.ts
@@ -1,0 +1,75 @@
+import request from 'supertest';
+import express from 'express';
+import systemControlsRouter from '../../src/routes/system-controls';
+import * as supabaseLib from '../../src/lib/supabase';
+import * as systemControlsService from '../../src/services/system-controls';
+
+// Mock auth middleware to bypass auth entirely for these tests
+jest.mock('../../src/middleware/auth-supabase-jwt', () => ({
+  requireAuth: (req: any, res: any, next: any) => next(),
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/api/v1/system-controls', systemControlsRouter);
+
+describe('System Controls API Route', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('returns 503 if no supabase client is returned', async () => {
+    jest.spyOn(supabaseLib, 'getSupabase').mockReturnValue(null);
+    const res = await request(app).get('/api/v1/system-controls/some_key');
+    
+    expect(res.status).toBe(503);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('no supabase');
+  });
+
+  it('returns 200 and data when service succeeds', async () => {
+    const mockClient = {} as any;
+    jest.spyOn(supabaseLib, 'getSupabase').mockReturnValue(mockClient);
+    jest.spyOn(systemControlsService, 'getSystemControl').mockResolvedValue({
+      ok: true,
+      data: { key: 'some_key', enabled: true }
+    });
+
+    const res = await request(app).get('/api/v1/system-controls/some_key');
+    
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.data.enabled).toBe(true);
+    expect(res.body.data.key).toBe('some_key');
+  });
+
+  it('returns 404 when service returns Not found error', async () => {
+    const mockClient = {} as any;
+    jest.spyOn(supabaseLib, 'getSupabase').mockReturnValue(mockClient);
+    jest.spyOn(systemControlsService, 'getSystemControl').mockResolvedValue({
+      ok: false,
+      error: 'Not found'
+    });
+
+    const res = await request(app).get('/api/v1/system-controls/missing_key');
+    
+    expect(res.status).toBe(404);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('system control not found');
+  });
+
+  it('returns 500 when service returns any other error', async () => {
+    const mockClient = {} as any;
+    jest.spyOn(supabaseLib, 'getSupabase').mockReturnValue(mockClient);
+    jest.spyOn(systemControlsService, 'getSystemControl').mockResolvedValue({
+      ok: false,
+      error: 'DB connection failed'
+    });
+
+    const res = await request(app).get('/api/v1/system-controls/err_key');
+    
+    expect(res.status).toBe(500);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('DB connection failed');
+  });
+});

--- a/services/gateway/test/system-controls.test.ts
+++ b/services/gateway/test/system-controls.test.ts
@@ -1,0 +1,51 @@
+import { getSystemControl } from '../src/services/system-controls';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+describe('System Controls Service', () => {
+  it('returns a system control when found', async () => {
+    const mockData = { key: 'vitana_did_you_know_enabled', enabled: true };
+    const mockEq = jest.fn().mockReturnValue({
+      single: jest.fn().mockResolvedValue({ data: mockData, error: null })
+    });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    const mockFrom = jest.fn().mockReturnValue({ select: mockSelect });
+    const mockSupabase = { from: mockFrom } as unknown as SupabaseClient;
+
+    const result = await getSystemControl(mockSupabase, 'vitana_did_you_know_enabled');
+    
+    expect(result.ok).toBe(true);
+    expect(result.data).toEqual(mockData);
+    expect(mockFrom).toHaveBeenCalledWith('system_controls');
+    expect(mockSelect).toHaveBeenCalledWith('*');
+    expect(mockEq).toHaveBeenCalledWith('key', 'vitana_did_you_know_enabled');
+  });
+
+  it('returns an error when not found (PGRST116)', async () => {
+    const mockEq = jest.fn().mockReturnValue({
+      single: jest.fn().mockResolvedValue({ data: null, error: { code: 'PGRST116', message: 'Not found' } })
+    });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    const mockFrom = jest.fn().mockReturnValue({ select: mockSelect });
+    const mockSupabase = { from: mockFrom } as unknown as SupabaseClient;
+
+    const result = await getSystemControl(mockSupabase, 'missing_key');
+    
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('Not found');
+    expect(result.data).toBeUndefined();
+  });
+
+  it('returns an error on other DB errors', async () => {
+    const mockEq = jest.fn().mockReturnValue({
+      single: jest.fn().mockResolvedValue({ data: null, error: { code: '500', message: 'DB error' } })
+    });
+    const mockSelect = jest.fn().mockReturnValue({ eq: mockEq });
+    const mockFrom = jest.fn().mockReturnValue({ select: mockSelect });
+    const mockSupabase = { from: mockFrom } as unknown as SupabaseClient;
+
+    const result = await getSystemControl(mockSupabase, 'err_key');
+    
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('DB error');
+  });
+});


### PR DESCRIPTION
**What this PR does**
Adds a generic gateway route `GET /api/v1/system-controls/:key` and underlying service to fetch the state of system controls (specifically targeted at `vitana_did_you_know_enabled` per migration `20260425100000_BOOTSTRAP_dyk_flag_on.sql`).

**Why**
The migration flipped the DYK flag on in `public.system_controls`, but the frontend currently has no way of querying the table. By adding an authenticated endpoint for fetching a single system control, we decouple the flag state from the frontend deployment and pave the way for real-time toggle responses.

**Files touched**
- `services/gateway/src/types/system-controls.ts`
- `services/gateway/src/services/system-controls.ts`
- `services/gateway/src/routes/system-controls.ts`
- `services/gateway/test/system-controls.test.ts`
- `services/gateway/test/routes/system-controls.test.ts`

**Missing steps (Action required)**
As scoped in the dev-autopilot plan constraint, the companion frontend updates (to fetch the newly created endpoint and conditionalize the tour UI in `command-hub`) are **not included** in this diff due to path uncertainty. A follow-up commit to the `command-hub` codebase is required to consume `GET /api/v1/system-controls/vitana_did_you_know_enabled` before the overarching feature is fully complete.