### PR TITLE
DEV-AUTOPILOT: Implement Luhn-validated credit card detection in content filter

### DIFF
--- a/services/gateway/src/services/intent-content-filter.test.ts
+++ b/services/gateway/src/services/intent-content-filter.test.ts
@@ -1,0 +1,51 @@
+import { checkIntentContent } from './intent-content-filter';
+import type { IntentKind } from './intent-classifier';
+
+describe('checkIntentContent', () => {
+  it('should not trigger false positives on phone numbers or arbitrary 13+ digit numbers', () => {
+    const result = checkIntentContent({
+      kind: 'commercial_buy' as unknown as IntentKind,
+      title: 'Call me at +1 800-555-0199',
+      scope: 'Or random digits 123456789012345'
+    });
+    expect(result.reasons.some(r => r.includes('credit_card'))).toBe(false);
+  });
+
+  it('should detect a 16-digit valid Visa card number formatted with spaces', () => {
+    const result = checkIntentContent({
+      kind: 'partner_seek' as unknown as IntentKind,
+      title: 'My card is',
+      scope: '4111 1111 1111 1111'
+    });
+    expect(result.reasons).toContain('pii_credit_card_blocked_strict');
+  });
+
+  it('should ignore a 16-digit string that fails the Luhn check', () => {
+    const result = checkIntentContent({
+      kind: 'commercial_buy' as unknown as IntentKind,
+      title: 'Card 4111 1111 1111 1112',
+      scope: 'Buying goods'
+    });
+    expect(result.reasons.some(r => r.includes('credit_card'))).toBe(false);
+  });
+
+  it('should return ok: false with pii_credit_card_blocked_strict for partner_seek', () => {
+    const result = checkIntentContent({
+      kind: 'partner_seek' as unknown as IntentKind,
+      title: 'Here is my visa',
+      scope: '4111-1111-1111-1111'
+    });
+    expect(result.ok).toBe(false);
+    expect(result.reasons).toContain('pii_credit_card_blocked_strict');
+  });
+
+  it('should return ok: true with pii_credit_card_warning for commercial_buy', () => {
+    const result = checkIntentContent({
+      kind: 'commercial_buy' as unknown as IntentKind,
+      title: 'Here is my visa',
+      scope: '4111-1111-1111-1111'
+    });
+    expect(result.ok).toBe(true);
+    expect(result.reasons).toContain('pii_credit_card_warning');
+  });
+});

--- a/services/gateway/src/services/intent-content-filter.ts
+++ b/services/gateway/src/services/intent-content-filter.ts
@@ -24,11 +24,39 @@ const PII_EMAIL = /[a-z0-9._%+-]+@[a-z0-9.-]+\.[a-z]{2,}/i;
 const PII_PHONE = /\b\+?\d[\d\s\-]{7,}\d\b/;
 const PII_IBAN = /\b[A-Z]{2}\d{2}[A-Z0-9]{10,30}\b/;
 
+function isValidLuhn(value: string): boolean {
+  let sum = 0;
+  let shouldDouble = false;
+  for (let i = value.length - 1; i >= 0; i--) {
+    let digit = parseInt(value.charAt(i), 10);
+    if (shouldDouble) {
+      digit *= 2;
+      if (digit > 9) digit -= 9;
+    }
+    sum += digit;
+    shouldDouble = !shouldDouble;
+  }
+  return sum % 10 === 0;
+}
+
 function detectPII(text: string): string[] {
   const found: string[] = [];
   if (PII_EMAIL.test(text)) found.push('email');
   if (PII_PHONE.test(text)) found.push('phone');
   if (PII_IBAN.test(text)) found.push('iban');
+
+  const ccRegex = /\b(?:\d[ -]*){13,19}\b/g;
+  let match;
+  while ((match = ccRegex.exec(text)) !== null) {
+    const digitsOnly = match[0].replace(/[ -]/g, '');
+    if (digitsOnly.length >= 13 && digitsOnly.length <= 19) {
+      if (isValidLuhn(digitsOnly)) {
+        found.push('credit_card');
+        break;
+      }
+    }
+  }
+
   return found;
 }
 


### PR DESCRIPTION
This PR addresses a missing capability in the P2-A intent content filter stub: detecting and handling credit card numbers. 

Previously, 13-19 digit sequences (such as Visa/Mastercard numbers) slipped past the PII filtering without being mapped to strict blocking or warnings. This PR introduces:
- A local `isValidLuhn` helper function using the standard modulus 10 validation.
- An update to `detectPII` to identify 13-19 digit boundaries (handling spaces and dashes) and process them through the Luhn check.
- Valid sequences trigger a `'credit_card'` reason, automatically leveraging the existing platform string generation for `pii_credit_card_blocked_strict` (hard reject for `partner_seek`/`social_seek`) and `pii_credit_card_warning` (for others).
- A new co-located unit test file (`intent-content-filter.test.ts`) that asserts Luhn adherence, checks standard boundaries, avoids false positives on non-compliant digits, and validates the specific payload rules for different intent kinds.

Files modified/created:
- `services/gateway/src/services/intent-content-filter.ts`
- `services/gateway/src/services/intent-content-filter.test.ts`