### PR TITLE
DEV-AUTOPILOT: Implement param-limit middleware to mitigate ReDoS CVE

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,23 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const params = req.params || {};
+    const keys = Object.keys(params);
+
+    if (keys.length > maxParams) {
+      res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    for (const key of keys) {
+      const val = params[key];
+      if (val && val.length > maxLength) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,14 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply ReDoS mitigation middleware to cap parameter counts and lengths
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  return res.json({ ok: true, data: { project_id: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,14 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply ReDoS mitigation middleware to cap parameter counts and lengths
+router.use(limitPathParams());
+
+router.get('/:userId', requireAuth, async (req: Request, res: Response) => {
+  return res.json({ ok: true, data: { user_id: req.params.userId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,57 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation: limitPathParams middleware', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = express();
+    const router = express.Router();
+
+    // Use default constraints: max 5 parameters, max length 200
+    router.use(limitPathParams(5, 200));
+
+    router.get('/resource/:a/:b/:c/:d/:e/:f', (req: Request, res: Response) => {
+      res.json({ ok: true, data: req.params });
+    });
+
+    router.get('/short/:a/:b', (req: Request, res: Response) => {
+      res.json({ ok: true, data: req.params });
+    });
+
+    app.use('/', router);
+  });
+
+  it('should return 400 when more than 5 path parameters are matched', async () => {
+    const start = Date.now();
+    const res = await request(app).get('/resource/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(500); // Should reject swiftly without catastrophic backtracking delays
+  });
+
+  it('should return 400 when a path parameter exceeds max length', async () => {
+    const longParam = 'x'.repeat(201);
+    const start = Date.now();
+    const res = await request(app).get(`/short/1/${longParam}`);
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(500);
+  });
+
+  it('should allow valid requests with <=5 params and valid lengths', async () => {
+    const res = await request(app).get('/short/1/2');
+    
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.data.a).toBe('1');
+    expect(res.body.data.b).toBe('2');
+  });
+});


### PR DESCRIPTION
This PR addresses a Regular Expression Denial of Service (ReDoS) vulnerability found in `path-to-regexp` (< 0.1.13) by adding a defensive middleware to the gateway. While the actual dependency updates to `express` / `path-to-regexp` will be handled separately in `package.json`, this server-side validation actively restricts the surface area for exponential backtracking attacks.

The mitigation creates a reusable `limitPathParams` middleware that limits the maximum allowed number of path parameters (default 5) and the maximum length of any individual parameter (default 200 characters). Requests exceeding these constraints are immediately rejected with a 400 Bad Request, safeguarding CPU resources. 

The middleware has been implemented and attached to `userRoutes.ts` and `projectRoutes.ts` as primary examples. 

**Note on File Naming:** Although the repository strictly mandates `kebab-case` for TypeScript files, the files (`paramLimit.ts`, `userRoutes.ts`, `projectRoutes.ts`) have been created using `camelCase` to exactly adhere to the strict locked file constraints of the execution plan. 

**Files touched:**
- `services/gateway/src/routes/middleware/paramLimit.ts` (New middleware)
- `services/gateway/src/routes/v1/userRoutes.ts` (Applied middleware)
- `services/gateway/src/routes/v1/projectRoutes.ts` (Applied middleware)
- `services/gateway/test/cve-mitigation.test.ts` (Unit and Integration tests)