### PR TITLE
DEV-AUTOPILOT: Mitigate path-to-regexp ReDoS via paramLimit middleware

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,47 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+/**
+ * Middleware to mitigate ReDoS vulnerabilities in path-to-regexp parsing.
+ * Limits the number of parsed parameters and the length of any path segment.
+ */
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // 1. Validate raw URL segments
+    // This provides global protection before Express matches the route with `path-to-regexp`.
+    // It prevents ReDoS on global middleware mounts where req.params is not yet populated.
+    const segments = req.path.split('/').filter(Boolean);
+    for (const segment of segments) {
+      if (segment.length > maxLength) {
+        res.status(400).json({
+          ok: false,
+          error: 'Path parameter too long'
+        });
+        return;
+      }
+    }
+
+    // 2. Validate explicitly mapped req.params
+    // Provides strict constraint checking when mounted directly onto route definitions.
+    const paramKeys = Object.keys(req.params || {});
+    if (paramKeys.length > maxParams) {
+      res.status(400).json({
+        ok: false,
+        error: 'Too many path parameters'
+      });
+      return;
+    }
+
+    for (const key of paramKeys) {
+      const value = req.params[key];
+      if (typeof value === 'string' && value.length > maxLength) {
+        res.status(400).json({
+          ok: false,
+          error: 'Path parameter too long'
+        });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,28 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply ReDoS mitigation middleware to all project routes
+router.use(limitPathParams(5, 200));
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  const { projectId } = req.params;
+  
+  return res.json({ 
+    ok: true, 
+    data: { 
+      projectId,
+      entity: 'project'
+    } 
+  });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,28 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply ReDoS mitigation middleware to all user routes
+router.use(limitPathParams(5, 200));
+
+router.get('/:userId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  const { userId } = req.params;
+  
+  return res.json({ 
+    ok: true, 
+    data: { 
+      userId,
+      entity: 'user'
+    } 
+  });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,75 @@
+import request from 'supertest';
+import express, { Request, Response } from 'express';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - ReDoS Path Parameters Middleware', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+
+    // Setup global mitigation wrapper for URL segment limits
+    app.use(limitPathParams(5, 200));
+
+    // Test specific route mounts to trigger param counting logic
+    app.get(
+      '/api/resource/:a/:b',
+      limitPathParams(5, 200),
+      (req: Request, res: Response) => {
+        res.json({ ok: true, params: req.params });
+      }
+    );
+
+    app.get(
+      '/api/resource/:a/:b/:c/:d/:e/:f',
+      limitPathParams(5, 200),
+      (req: Request, res: Response) => {
+        res.json({ ok: true, params: req.params });
+      }
+    );
+
+    app.get('/api/global/:id', (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+  });
+
+  it('Test 3: should allow valid request with <=5 parameters', async () => {
+    const res = await request(app).get('/api/resource/1/2');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('Test 1: should return 400 when >5 parameters are matched on the route', async () => {
+    const start = Date.now();
+    const res = await request(app).get('/api/resource/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Too many path parameters/);
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('Test 2: should return 400 when a parameter exceeds max length', async () => {
+    const longParam = 'a'.repeat(201);
+    const start = Date.now();
+    const res = await request(app).get(`/api/global/${longParam}`);
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Path parameter too long/);
+    expect(duration).toBeLessThan(200); // Ensures early return
+  });
+
+  it('Integration test: pathological ReDoS attempt fails quickly without CPU exhaust', async () => {
+    const start = Date.now();
+    // Simulate a repetitive parameter segment designed to cause backtracking
+    const pathological = 'x'.repeat(500) + 'y!';
+    const res = await request(app).get(`/api/global/${pathological}`);
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    // Even under normal ReDoS conditions, this should fail under <500ms since
+    // the middleware aborts it on segment string length before evaluating complex regex.
+    expect(duration).toBeLessThan(500); 
+  });
+});


### PR DESCRIPTION
This PR implements server-side validation middleware to mitigate the `path-to-regexp` ReDoS vulnerability (CVE) present in older Express dependencies, pending a direct `package.json` version bump.

By capping the number of route parameters and validating the maximum length of URL segments, we can abort malicious requests before they trigger the catastrophic exponential backtracking scenarios that attackers use to exhaust CPU resources.

**Note on conventions:** The provided execution plan strictly locked the creation of new route files to `camelCase` paths (e.g. `userRoutes.ts`, `projectRoutes.ts`, `paramLimit.ts`). Since the autopilot execution environment has a strict lock on the `LOCKED FILE LIST`, those exact camelCase names were used verbatim to ensure successful patch application without being rejected by the Diff Validator, even though this deviates from the standard `kebab-case` Vitana naming convention.

Files modified:
- `services/gateway/src/routes/middleware/paramLimit.ts` (new)
- `services/gateway/src/routes/v1/userRoutes.ts` (new)
- `services/gateway/src/routes/v1/projectRoutes.ts` (new)
- `services/gateway/test/cve-mitigation.test.ts` (new)