### PR TITLE
DEV-AUTOPILOT: Mitigate ReDoS CVE via path parameter limiting middleware

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,28 @@
+import { RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req, res, next) => {
+    const keys = Object.keys(req.params || {});
+    
+    if (keys.length > maxParams) {
+      res.status(400).json({ 
+        ok: false, 
+        error: 'Too many path parameters or parameter too long' 
+      });
+      return;
+    }
+
+    for (const key of keys) {
+      const value = req.params[key];
+      if (value && typeof value === 'string' && value.length > maxLength) {
+        res.status(400).json({ 
+          ok: false, 
+          error: 'Too many path parameters or parameter too long' 
+        });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,25 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply the ReDoS mitigation middleware
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+  
+  return res.json({ 
+    ok: true, 
+    data: { 
+      project_id: req.params.projectId 
+    } 
+  });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,25 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply the ReDoS mitigation middleware to all routes in this router
+router.use(limitPathParams());
+
+router.get('/:userId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+  
+  return res.json({ 
+    ok: true, 
+    data: { 
+      user_id: req.params.userId 
+    } 
+  });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,59 @@
+import request from 'supertest';
+import express, { Request, Response } from 'express';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - paramLimit middleware', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    
+    app.get('/resource/:a?/:b?/:c?/:d?/:e?/:f?', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.status(200).json({ ok: true });
+    });
+
+    app.get('/exact/:id', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.status(200).json({ ok: true });
+    });
+  });
+
+  it('should pass requests with fewer than max parameters', async () => {
+    const res = await request(app).get('/resource/1/2/3');
+    
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('should pass requests with exactly the maximum allowed parameters', async () => {
+    const res = await request(app).get('/resource/1/2/3/4/5');
+    
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('should block requests with more than max parameters and resolve quickly', async () => {
+    const startTime = Date.now();
+    const res = await request(app).get('/resource/1/2/3/4/5/6');
+    const duration = Date.now() - startTime;
+
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    
+    // Ensure the response aborts rapidly before ReDoS catastrophic backtracking could take hold
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('should block requests with extremely long parameters', async () => {
+    const longParam = 'a'.repeat(201);
+    const startTime = Date.now();
+    const res = await request(app).get(`/exact/${longParam}`);
+    const duration = Date.now() - startTime;
+
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    
+    expect(duration).toBeLessThan(200);
+  });
+});


### PR DESCRIPTION
This PR introduces the `limitPathParams` middleware to mitigate the `path-to-regexp` Regular Expression Denial of Service (ReDoS) vulnerability in Express route matching.

Since dependency version updates to `package.json` are outside the scope of this autopilot execution, we are capping the potential for catastrophic backtracking at the gateway level. The middleware intercepts and rejects requests that exceed a set threshold of path parameters (default 5) or contain parameter segments that are pathologically long (default > 200 chars). 

**Changes:**
- `services/gateway/src/routes/middleware/paramLimit.ts`: New middleware enforcing max param limits and lengths.
- `services/gateway/src/routes/v1/userRoutes.ts`: Route stub implementing the new middleware.
- `services/gateway/src/routes/v1/projectRoutes.ts`: Route stub implementing the new middleware.
- `services/gateway/test/cve-mitigation.test.ts`: Integration and unit tests to ensure boundary conditions block attacks correctly while normal requests pass through (latency <200ms).

*Note: The locked file list provided for this execution mandates the creation of `paramLimit.ts`, `userRoutes.ts`, and `projectRoutes.ts` using camelCase. This deviates from the core Vitana codebase convention of kebab-case, but has been strictly adhered to as instructed by the plan constraint. An operator may rename these to Phase 2B standards post-merge.*