### PR TITLE
DEV-AUTOPILOT: Mitigation for path-to-regexp ReDoS vulnerability

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,33 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // 1. Fast-path raw validation using RegExp to avoid vulnerable path-to-regexp matching.
+    // This executes before/during routing and stops excessively long segments 
+    // from triggering catastrophic backtracking in Express's route matchers.
+    const hasLongSegments = new RegExp(`[^/]{${maxLength + 1},}`).test(req.path);
+    if (hasLongSegments) {
+      res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    // 2. Parse req.params and count its keys as prescribed.
+    // This is effective when the middleware is applied at the route-level.
+    if (req.params) {
+      const keys = Object.keys(req.params);
+      if (keys.length > maxParams) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+      
+      for (const key of keys) {
+        if (req.params[key] && req.params[key].length > maxLength) {
+          res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+          return;
+        }
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,20 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply ReDoS mitigation middleware to limit parameter length and counts
+router.use(limitPathParams(5, 200));
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  return res.json({ ok: true, data: { project_id: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,20 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply ReDoS mitigation middleware to limit parameter length and counts
+router.use(limitPathParams(5, 200));
+
+router.get('/:userId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  return res.json({ ok: true, data: { user_id: req.params.userId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,44 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - limitPathParams middleware', () => {
+  const app = express();
+
+  // 1. Global mount: catches malicious requests before route matching (ReDoS prevention)
+  app.use(limitPathParams(5, 200));
+
+  // 2. Route mount: populates req.params to strictly test the key-counting logic
+  app.get('/api/test/:a?/:b?/:c?/:d?/:e?/:f?', limitPathParams(5, 200), (req: Request, res: Response) => {
+    res.status(200).json({ ok: true });
+  });
+
+  it('should pass normal requests with <= 5 params', async () => {
+    const res = await request(app).get('/api/test/1/2/3');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('should return 400 Bad Request if params exceed maxParams (> 5)', async () => {
+    const startTime = Date.now();
+    const res = await request(app).get('/api/test/1/2/3/4/5/6');
+    const duration = Date.now() - startTime;
+    
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('should return 400 Bad Request if any param exceeds maxLength', async () => {
+    const longParam = 'a'.repeat(201);
+    const startTime = Date.now();
+    const res = await request(app).get(`/api/test/${longParam}`);
+    const duration = Date.now() - startTime;
+    
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(200);
+  });
+});


### PR DESCRIPTION
Addresses the Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (< 0.1.13) used by Express (CVE-2024-4068 / CVE-2022-24999 context) by implementing server-side validation middleware. 

- Implements `limitPathParams` middleware to cap the length of raw path segments and the count of parsed parameters, protecting the vulnerable route-matching regex engine from catastrophic backtracking.
- Applies the middleware to newly scaffolded `userRoutes` and `projectRoutes`.
- Adds test coverage verifying that long parameters and excessive parameter counts return `400 Bad Request` in <200ms.

**Note on File Naming Conventions:**
The execution plan strictly mandated the creation of `paramLimit.ts`, `userRoutes.ts`, and `projectRoutes.ts` in camelCase. This conflicts with the codebase's strict Phase 2B convention (`kebab-case`). Because the file list in this execution plan is hard-locked and deviating causes validation failure, the exact paths requested have been emitted. The operator should rename these files to `param-limit.ts`, `user-routes.ts`, and `project-routes.ts` and update their imports before merging to pass CI.