### PR TITLE
DEV-AUTOPILOT: Enforce explicit Supabase session auth for telemetry API

### DIFF
--- a/services/gateway/src/routes/telemetry.ts
+++ b/services/gateway/src/routes/telemetry.ts
@@ -1,10 +1,51 @@
-import { Router, Request, Response } from "express";
+import { Router, Request, Response, NextFunction } from "express";
 import { z } from "zod";
 import { randomUUID } from "crypto";
 import { mapRawToStage, normalizeStage, isValidStage, emptyStageCounters, VALID_STAGES, type TaskStage, type StageCounters } from "../lib/stage-mapping";
-import { requireAuth, AuthenticatedRequest } from "../middleware/auth-supabase-jwt";
+import { AuthenticatedRequest } from "../middleware/auth-supabase-jwt";
+import { getSupabase } from "../lib/supabase";
 
 export const router = Router();
+
+// Middleware to strictly verify via supabase.auth.getUser as required
+const requireAuthenticatedUser = async (req: Request, res: Response, next: NextFunction): Promise<any> => {
+  try {
+    const authHeader = req.headers.authorization;
+    if (!authHeader || !authHeader.startsWith("Bearer ")) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+    
+    const token = authHeader.split(" ")[1];
+    if (!token) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    const supabase = getSupabase();
+    if (!supabase) {
+      console.error("❌ Gateway misconfigured: No Supabase client");
+      return res.status(503).json({ error: "Service unavailable", detail: "Database not reachable" });
+    }
+
+    const { data, error } = await supabase.auth.getUser(token);
+    if (error || !data.user) {
+      return res.status(401).json({ error: "Unauthorized" });
+    }
+
+    // Attach minimal identity for downstream handlers
+    (req as AuthenticatedRequest).identity = {
+      user_id: data.user.id,
+      email: data.user.email || null,
+      tenant_id: null,
+      exafy_admin: false,
+      role: null,
+    };
+
+    return next();
+  } catch (err) {
+    console.error("❌ Auth middleware error:", err);
+    return res.status(401).json({ error: "Unauthorized" });
+  }
+};
 
 // Telemetry Event Schema (TickerEvent format)
 // VTID-0526-D: Added task_stage for 4-stage mapping
@@ -27,8 +68,8 @@ type TelemetryEvent = z.infer<typeof TelemetryEventSchema>;
 
 // POST /event - Single telemetry event
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/event
-// Security: requireAuth mitigates RLS gap on oasis_events by enforcing application-level authentication
-router.post("/event", requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+// Security: requireAuthenticatedUser mitigates RLS gap on oasis_events by enforcing application-level authentication
+router.post("/event", requireAuthenticatedUser, async (req: AuthenticatedRequest, res: Response) => {
   try {
     // Validate request body
     const body = TelemetryEventSchema.parse(req.body);
@@ -148,8 +189,8 @@ router.post("/event", requireAuth, async (req: AuthenticatedRequest, res: Respon
 
 // POST /batch - Batch telemetry events
 // VTID-0526-D: Route mounted at /api/v1/telemetry, so this becomes /api/v1/telemetry/batch
-// Security: requireAuth mitigates RLS gap on oasis_events by enforcing application-level authentication
-router.post("/batch", requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+// Security: requireAuthenticatedUser mitigates RLS gap on oasis_events by enforcing application-level authentication
+router.post("/batch", requireAuthenticatedUser, async (req: AuthenticatedRequest, res: Response) => {
   try {
     // Validate that body is an array
     if (!Array.isArray(req.body)) {
@@ -291,8 +332,8 @@ router.get("/health", (_req: Request, res: Response) => {
  * This endpoint is used by the frontend for auto-loading telemetry
  * when the Operator Console / Command Hub opens.
  */
-// Security: requireAuth mitigates RLS gap on oasis_events by enforcing application-level authentication
-router.get("/snapshot", requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+// Security: requireAuthenticatedUser mitigates RLS gap on oasis_events by enforcing application-level authentication
+router.get("/snapshot", requireAuthenticatedUser, async (req: AuthenticatedRequest, res: Response) => {
   console.log("[Telemetry Snapshot] Request received");
 
   try {

--- a/services/gateway/test/routes/telemetry.test.ts
+++ b/services/gateway/test/routes/telemetry.test.ts
@@ -2,16 +2,18 @@ import request from 'supertest';
 import express from 'express';
 import { router } from '../../src/routes/telemetry';
 
-// Mock auth middleware to simulate authenticated and unauthenticated states
-jest.mock('../../src/middleware/auth-supabase-jwt', () => ({
-  requireAuth: jest.fn((req, res, next) => {
-    const authHeader = req.headers.authorization;
-    if (authHeader && authHeader.startsWith('Bearer valid-token')) {
-      req.identity = { user_id: 'test-user', email: 'test@example.com' };
-      return next();
+// Mock getSupabase to verify auth token using supabase.auth.getUser
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn(() => ({
+    auth: {
+      getUser: jest.fn((token: string) => {
+        if (token === 'valid-token') {
+          return Promise.resolve({ data: { user: { id: 'test-user', email: 'test@example.com' } }, error: null });
+        }
+        return Promise.resolve({ data: { user: null }, error: { message: 'Invalid token' } });
+      })
     }
-    return res.status(401).json({ error: 'Unauthorized' });
-  })
+  }))
 }));
 
 // Mock devhub SSE broadcast to prevent runtime require errors during tests
@@ -63,6 +65,17 @@ describe('Telemetry Routes Auth Enforcement', () => {
       expect(mockFetch).not.toHaveBeenCalled();
     });
 
+    it('should return 401 when an invalid authorization token is provided', async () => {
+      const response = await request(app)
+        .post('/api/v1/telemetry/event')
+        .set('Authorization', 'Bearer invalid-token')
+        .send(validEvent);
+      
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe('Unauthorized');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
     it('should proceed and return 202 when a valid authorization token is provided', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -101,6 +114,17 @@ describe('Telemetry Routes Auth Enforcement', () => {
       expect(mockFetch).not.toHaveBeenCalled();
     });
 
+    it('should return 401 when an invalid authorization token is provided', async () => {
+      const response = await request(app)
+        .post('/api/v1/telemetry/batch')
+        .set('Authorization', 'Bearer invalid-token')
+        .send(validBatch);
+      
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe('Unauthorized');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
     it('should proceed and return 202 when a valid authorization token is provided', async () => {
       mockFetch.mockResolvedValueOnce({
         ok: true,
@@ -122,6 +146,17 @@ describe('Telemetry Routes Auth Enforcement', () => {
     it('should return 401 when no authorization header is provided', async () => {
       const response = await request(app)
         .get('/api/v1/telemetry/snapshot')
+        .query({ limit: 5 });
+      
+      expect(response.status).toBe(401);
+      expect(response.body.error).toBe('Unauthorized');
+      expect(mockFetch).not.toHaveBeenCalled();
+    });
+
+    it('should return 401 when an invalid authorization token is provided', async () => {
+      const response = await request(app)
+        .get('/api/v1/telemetry/snapshot')
+        .set('Authorization', 'Bearer invalid-token')
         .query({ limit: 5 });
       
       expect(response.status).toBe(401);


### PR DESCRIPTION
This PR implements explicit application-level authentication for the `/api/v1/telemetry` routes that write to `oasis_events` to close a medium-risk `rls_gap` flagged by `rls-policy-scanner-v1`. While a database-level RLS policy will be applied manually out of band (due to automation restrictions on modifying migrations), this PR adds an explicit `supabase.auth.getUser()` middleware to ensure all incoming telemetry writes are strictly authenticated at the application layer. 

- Replaced the generic `requireAuth` middleware with a custom `requireAuthenticatedUser` middleware in `telemetry.ts` that enforces a live `getUser` check.
- Updated `telemetry.test.ts` to mock `supabase.auth.getUser` to accurately test and simulate both authorized and unauthorized access attempts.
- Requests with an invalid or missing token are rejected with HTTP 401.