### PR TITLE
fix(orb-live): never claim post_intent failed after row is inserted (VTID-02716)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -6554,6 +6554,10 @@ async function executeLiveApiToolInner(
         if (!utterance) {
           return { success: false, result: '', error: 'utterance is required' };
         }
+        // VTID-02716: once the row is inserted, no error path may report failure to the user.
+        let postedIntentId: string | null = null;
+        let postedVid: string | null = null;
+        let postedKind: string | null = null;
         try {
           const { classifyIntentKind } = await import('../services/intent-classifier');
           const { extractIntent } = await import('../services/intent-extractor');
@@ -6674,11 +6678,25 @@ async function executeLiveApiToolInner(
 
           const intentId = (inserted as any).intent_id;
           const vid = (inserted as any).requester_vitana_id;
+          postedIntentId = intentId;
+          postedVid = vid;
+          postedKind = intentKind;
 
-          const embedding = await embedIntent({ intent_kind: intentKind, category: extract.category, title: extract.title!, scope: extract.scope!, kind_payload: extract.kind_payload });
-          if (embedding) {
-            await supabase.from('user_intents').update({ embedding: embedding as any }).eq('intent_id', intentId);
+          // VTID-02716: row is now in user_intents — every side-effect below must be
+          // best-effort. A throw here would otherwise reach the outer catch and Gemini
+          // would say "I have a problem making the post" while the post sits in the user's list.
+          try {
+            const embedding = await embedIntent({ intent_kind: intentKind, category: extract.category, title: extract.title!, scope: extract.scope!, kind_payload: extract.kind_payload });
+            if (embedding) {
+              const { error: embedUpdErr } = await supabase.from('user_intents').update({ embedding: embedding as any }).eq('intent_id', intentId);
+              if (embedUpdErr) {
+                console.warn(`[VTID-02716] post_intent embedding update non-fatal: ${embedUpdErr.message}`);
+              }
+            }
+          } catch (err: any) {
+            console.warn(`[VTID-02716] post_intent embedding non-fatal: ${err?.message}`);
           }
+
           writeIntentFacts({
             user_id: session.identity!.user_id,
             tenant_id: session.identity!.tenant_id!,
@@ -6755,6 +6773,26 @@ async function executeLiveApiToolInner(
           };
         } catch (err: any) {
           console.error('[VTID-01975] post_intent error:', err?.message);
+          // VTID-02716: if the row was already inserted, never tell the user it failed.
+          if (postedIntentId) {
+            console.warn(`[VTID-02716] post_intent post-insert throw recovered; intent_id=${postedIntentId}`);
+            return {
+              success: true,
+              result: JSON.stringify({
+                ok: true,
+                stage: 'posted',
+                intent_id: postedIntentId,
+                vitana_id: postedVid,
+                intent_kind: postedKind,
+                match_count: 0,
+                top_matches: [],
+                compass_aligned: false,
+                partner_seek_redacted: postedKind === 'partner_seek',
+                cold_start: true,
+                degraded: true,
+              }),
+            };
+          }
           return { success: false, result: '', error: err?.message || 'unknown' };
         }
       }


### PR DESCRIPTION
## Summary
- Voice-creating a Find-a-Match post ("find a tennis partner in Cologne") inserted the row into `user_intents`, but Vitana then said "I have a problem making the post" — even though the post showed up in the user's list.
- Root cause: `embedIntent` (and the subsequent embedding-column update) ran AFTER the insert without try/catch. Any throw reached the outer catch at `orb-live.ts:6756`, which returned `{ success: false }`, which the Live API loop turned into `Error: …`, which Gemini paraphrased as "I have a problem making the post."
- Fix: wrap the unguarded embedding side-effects, and add a recovery branch in the outer catch that returns a degraded `success: true` whenever the row was already inserted. Net effect: once the row exists in user_intents, no path can tell the user the post failed.

## Files
- services/gateway/src/routes/orb-live.ts — case 'post_intent'

## Test plan
- [ ] Mobile (community user via vitanaland.com WebView): trigger ORB → "Ich suche jemanden, der mit mir Tennis spielt in Köln" → confirm with "ja/post" → ORB should say "Posted" / cold-start readback (NOT "I have a problem making the post").
- [ ] Verify the new post appears under My Posts.
- [ ] Cloud Run logs: confirm any failing side-effect is now logged as [VTID-02716] post_intent embedding non-fatal: ... (or similar) instead of [VTID-01975] post_intent error: ...

🤖 Generated with [Claude Code](https://claude.com/claude-code)