### PR TITLE
DEV-AUTOPILOT: Add paramLimit middleware to mitigate path-to-regexp ReDoS

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,26 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    if (!req.params) {
+      next();
+      return;
+    }
+
+    const keys = Object.keys(req.params);
+    if (keys.length > maxParams) {
+      res.status(400).json({ ok: false, error: 'Too many path parameters' });
+      return;
+    }
+
+    for (const key of keys) {
+      const val = req.params[key];
+      if (typeof val === 'string' && val.length > maxLength) {
+        res.status(400).json({ ok: false, error: 'Path parameter too long' });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,20 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { limitPathParams } from '../middleware/paramLimit';
+import { getSupabase } from '../../lib/supabase';
+
+const router = Router();
+
+// Apply param limiting to mitigate ReDoS for path parsing
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  return res.json({ ok: true, data: { projectId: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,20 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { limitPathParams } from '../middleware/paramLimit';
+import { getSupabase } from '../../lib/supabase';
+
+const router = Router();
+
+// Apply param limiting to all routes utilizing path params
+router.use(limitPathParams());
+
+router.get('/:id', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  return res.json({ ok: true, data: { id: req.params.id } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,53 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - paramLimit middleware', () => {
+  it('passes requests with parameter count and length within limits', async () => {
+    const app = express();
+    app.get('/test/:a/:b', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    const res = await request(app).get('/test/1/2');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('rejects requests with more path parameters than allowed', async () => {
+    const app = express();
+    app.get('/resource/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    const res = await request(app).get('/resource/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters');
+  });
+
+  it('rejects requests with a path parameter value exceeding the max length', async () => {
+    const app = express();
+    app.get('/resource/:id', limitPathParams(5, 20), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    const longParam = 'x'.repeat(25);
+    const res = await request(app).get(`/resource/${longParam}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Path parameter too long');
+  });
+
+  it('returns quickly for requests triggering parameter limits (integration)', async () => {
+    const app = express();
+    app.get('/resource/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    const start = Date.now();
+    const res = await request(app).get('/resource/v1/v2/v3/v4/v5/v6');
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(duration).toBeLessThan(200); // Ensures no CPU block delays the response
+  });
+});


### PR DESCRIPTION
**Context & Mitigation**
This PR addresses a ReDoS vulnerability in transitive dependencies (`path-to-regexp` < 0.1.13) by implementing server-side validation middleware (`paramLimit.ts`) in the gateway. This caps the maximum number of path parameters (default 5) and the string length of each parameter (default 200 characters). The middleware protects downstream Express request handlers from excessive and computationally expensive input before full processing occurs.

**Implementation Details**
- Created `paramLimit` middleware to check `req.params` keys count and value sizes.
- Applied the mitigation to placeholder routes (`userRoutes.ts`, `projectRoutes.ts`). Note: *All* gateway routes utilizing path parameters should adopt this middleware to ensure comprehensive coverage.
- Added a full suite of unit and integration test assertions under `cve-mitigation.test.ts`.

*Note on File Naming Conventions:* The execution strictly adhered to the locked file list provided by the plan, which contained camelCase names (`paramLimit.ts`, `userRoutes.ts`, `projectRoutes.ts`). The codebase standards specify kebab-case for Phase 2B CI checks. A quick follow-up PR might be necessary to rename these to `param-limit.ts`, `user-routes.ts`, and `project-routes.ts` if the CI pipeline rejects them.