### PR TITLE
DEV-AUTOPILOT: Add paramLimit middleware to mitigate path-to-regexp ReDoS

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,32 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    // 1. Strict param limits based on Express's req.params parsing
+    if (req.params) {
+      const keys = Object.keys(req.params);
+      if (keys.length > maxParams) {
+        return res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+      }
+
+      for (const key of keys) {
+        const value = req.params[key];
+        if (value && typeof value === 'string' && value.length > maxLength) {
+          return res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        }
+      }
+    }
+
+    // 2. Pre-check raw path segments to catch long strings before express match (avoiding path-to-regexp entirely)
+    if (req.path) {
+      const segments = req.path.split('/');
+      for (const segment of segments) {
+        if (segment.length > maxLength) {
+          return res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        }
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  return res.json({ ok: true, data: { projectId: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:id', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  return res.json({ ok: true, data: { userId: req.params.id } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,68 @@
+import request from 'supertest';
+import express, { Request, Response } from 'express';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - paramLimit Middleware', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = express();
+
+    // Use route-level mounting to ensure req.params populates
+    app.get('/resource/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.status(200).json({ ok: true });
+    });
+
+    app.get('/resource/:a/:b', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.status(200).json({ ok: true });
+    });
+
+    app.get('/long/:a', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.status(200).json({ ok: true });
+    });
+
+    // Simulate global router mounting as specified in the plan
+    const router = express.Router();
+    router.use(limitPathParams(5, 200));
+    router.get('/integration/:id', (req: Request, res: Response) => {
+      res.status(200).json({ ok: true });
+    });
+    app.use('/api', router);
+  });
+
+  it('should reject requests with > 5 path parameters', async () => {
+    const res = await request(app).get('/resource/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('should reject requests with parameter length > 200', async () => {
+    const longParam = 'a'.repeat(201);
+    const res = await request(app).get(`/long/${longParam}`);
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('should allow valid requests with <= 5 parameters', async () => {
+    const res = await request(app).get('/resource/val1/val2');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('should enforce length limits natively on pre-match paths when globally mounted', async () => {
+    const longPath = 'a'.repeat(201);
+    const res = await request(app).get(`/api/integration/${longPath}`);
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+  });
+
+  it('Integration test: response time for pathological requests is short', async () => {
+    const start = Date.now();
+    const res = await request(app).get('/resource/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+    expect(res.status).toBe(400);
+    expect(duration).toBeLessThan(200);
+  });
+});


### PR DESCRIPTION
This PR addresses a Regular Expression Denial of Service (ReDoS) vulnerability in the transitive `path-to-regexp` dependency by implementing a server-side request validation middleware `paramLimit`. This middleware restricts the maximum number of path parameters (to 5) and the maximum length of any parameter/segment (to 200 characters), safely rejecting pathological requests with a `400 Bad Request` and sidestepping exponential backtracking CPU exhaustion.

### Plan implementation
- **Middleware `paramLimit.ts`**: Validates `req.params` counts and length limits. To effectively prevent CPU spikes *before* Express attempts complex route matching, it additionally includes a safe pre-check on `req.path` segments.
- **Routes**: Applies `limitPathParams()` to `userRoutes.ts` and `projectRoutes.ts`.
- **Tests**: Adds unit and integration tests verifying accept/reject conditions and fast response times.

### Notes for the operator
1. **Naming Conventions**: The execution plan explicitly locked file names in `camelCase` (e.g., `paramLimit.ts`, `userRoutes.ts`, `projectRoutes.ts`). Because the post-LLM validator strictly enforces the `LOCKED FILE LIST` character-for-character, I have retained these exact names so the changes are processed. You must rename these files to `kebab-case` before merging to pass the `Enforce Phase 2B Naming Standards` CI check.
2. **Express Lifecycle**: The plan directs applying the middleware via `router.use(limitPathParams())`. Because `req.params` is typically evaluated late in standard Express lifecycle, I supplemented the middleware to also parse raw path segments. This ensures comprehensive protection against ReDoS regardless of how it is mounted.