### PR TITLE
DEV-AUTOPILOT: Mitigate path-to-regexp ReDoS via paramLimit middleware

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,36 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    // 1. Direct path-segment check to prevent ReDoS before route matching occurs.
+    // When mounted in a router, req.path strips the mount path, so we count
+    // the remaining segments. We use a generous threshold (maxParams + 2) to account
+    // for literal segments like '/projects' inside the router path.
+    const pathSegments = req.path.split('/').filter(Boolean);
+    if (pathSegments.length > maxParams + 2) {
+      return res.status(400).json({ ok: false, error: 'Too many path parameters' });
+    }
+
+    for (const segment of pathSegments) {
+      if (segment.length > maxLength) {
+        return res.status(400).json({ ok: false, error: 'Path parameter too long' });
+      }
+    }
+
+    // 2. req.params check as specified in the plan (effective if applied as route-specific middleware)
+    if (req.params) {
+      const keys = Object.keys(req.params);
+      if (keys.length > maxParams) {
+        return res.status(400).json({ ok: false, error: 'Too many path parameters' });
+      }
+
+      for (const key of keys) {
+        if (req.params[key] && req.params[key].length > maxLength) {
+          return res.status(400).json({ ok: false, error: 'Path parameter too long' });
+        }
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,20 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+
+const router = Router();
+
+// Apply ReDoS mitigation middleware
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+  
+  return res.json({ ok: true, data: { project_id: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,20 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+
+const router = Router();
+
+// Apply ReDoS mitigation middleware
+router.use(limitPathParams());
+
+router.get('/:id', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+  
+  return res.json({ ok: true, data: { user_id: req.params.id } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,60 @@
+import express, { Router } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - ReDoS in path-to-regexp', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = express();
+    const router = Router();
+
+    // 1. Applied globally to router
+    router.use(limitPathParams(5, 200));
+
+    router.get('/normal/:a/:b', (req, res) => {
+      res.json({ ok: true, data: 'success' });
+    });
+
+    app.use('/api/v1', router);
+
+    // 2. Applied directly to route (to fully test req.params check)
+    app.get(
+      '/resource/:a/:b/:c/:d/:e/:f',
+      limitPathParams(5, 200),
+      (req, res) => {
+        res.json({ ok: true, data: 'success' });
+      }
+    );
+  });
+
+  it('should pass normal request with <=5 params', async () => {
+    const res = await request(app).get('/api/v1/normal/1/2');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('should reject request with param >200 chars with 400', async () => {
+    const longParam = 'a'.repeat(201);
+    const res = await request(app).get(`/api/v1/normal/1/${longParam}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Path parameter too long');
+  });
+
+  it('should reject request with >5 path parameters with 400', async () => {
+    // Tests the req.params check when route is matched
+    const res = await request(app).get('/resource/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters');
+  });
+
+  it('integration test: should respond quickly for malicious request', async () => {
+    const start = Date.now();
+    // Simulate pathological backtracking request with deep path segments
+    const res = await request(app).get('/api/v1/normal/1/2/3/4/5/6/7/8/9/10/11/12/13/14');
+    const duration = Date.now() - start;
+    
+    expect(res.status).toBe(400);
+    expect(duration).toBeLessThan(200);
+  });
+});


### PR DESCRIPTION
This PR addresses a Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (< 0.1.13) by implementing server-side validation middleware in the gateway.

### Changes
1. **Middleware (`paramLimit.ts`)**: Introduces `limitPathParams` to validate `req.params` and `req.path`. It ensures requests with excessive path parameters (default >5) or excessively long values (default >200 chars) are rejected with a `400 Bad Request`. By inspecting the raw path segments alongside `req.params`, it stops catastrophic backtracking CPU exhaustion before the vulnerable dependency gets executed.
2. **Routes (`userRoutes.ts`, `projectRoutes.ts`)**: Applies the new `limitPathParams` middleware across user and project routers.
3. **Tests (`cve-mitigation.test.ts`)**: Adds unit and integration test coverage to assert normal requests pass and pathologically crafted ones are rejected promptly (<200ms).

### ⚠️ Note on File Naming Conventions
The execution plan enforced the use of camelCase file names (`paramLimit.ts`, `userRoutes.ts`, `projectRoutes.ts`) in its locked file list. These have been emitted verbatim to pass the post-LLM autopilot strict validation. However, this violates the Vitana Phase 2B Naming Standards (`param-limit.ts`, `user-routes.ts`). A follow-up rename to kebab-case is required before merging to satisfy CI checks.