### PR TITLE
DEV-AUTOPILOT: Mitigate path-to-regexp ReDoS via param limits

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,30 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const paramKeys = Object.keys(req.params || {});
+
+    // Check maximum number of route parameters
+    if (paramKeys.length > maxParams) {
+      res.status(400).json({
+        ok: false,
+        error: 'Too many path parameters or parameter too long'
+      });
+      return;
+    }
+
+    // Check maximum length of any single parameter
+    for (const key of paramKeys) {
+      const val = req.params[key];
+      if (typeof val === 'string' && val.length > maxLength) {
+        res.status(400).json({
+          ok: false,
+          error: 'Too many path parameters or parameter too long'
+        });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,19 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { getSupabase } from '../../lib/supabase';
+
+const router = Router();
+
+// Apply mitigation for ReDoS vulnerability in path-to-regexp
+router.use(limitPathParams());
+
+router.get('/:projectId', async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  return res.json({ ok: true, data: { project_id: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,19 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { getSupabase } from '../../lib/supabase';
+
+const router = Router();
+
+// Apply mitigation for ReDoS vulnerability in path-to-regexp
+router.use(limitPathParams());
+
+router.get('/:id', async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  return res.json({ ok: true, data: { user_id: req.params.id } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,61 @@
+import request from 'supertest';
+import express from 'express';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - ReDoS in path parameters', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    
+    // Test route with 6 parameters to verify count limits
+    app.get('/test-count/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req, res) => {
+      res.json({ ok: true });
+    });
+
+    // Test route for parameter length limits
+    app.get('/test-length/:a', limitPathParams(5, 200), (req, res) => {
+      res.json({ ok: true });
+    });
+
+    // Standard valid route
+    app.get('/valid/:a/:b', limitPathParams(5, 200), (req, res) => {
+      res.json({ ok: true });
+    });
+  });
+
+  it('should allow valid requests with <= 5 params and short values', async () => {
+    const response = await request(app).get('/valid/foo/bar');
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+  });
+
+  it('should reject requests with > 5 path parameters', async () => {
+    const response = await request(app).get('/test-count/1/2/3/4/5/6');
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      ok: false,
+      error: 'Too many path parameters or parameter too long'
+    });
+  });
+
+  it('should reject requests with path parameters exceeding max length', async () => {
+    const longParam = 'a'.repeat(201);
+    const response = await request(app).get(`/test-length/${longParam}`);
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      ok: false,
+      error: 'Too many path parameters or parameter too long'
+    });
+  });
+
+  it('should return quickly and reject potential ReDoS payload (Integration test)', async () => {
+    const start = Date.now();
+    const payload = 'a'.repeat(500);
+    const response = await request(app).get(`/test-length/${payload}`);
+    const duration = Date.now() - start;
+
+    expect(response.status).toBe(400);
+    expect(duration).toBeLessThan(500); // Fast rejection expected
+  });
+});


### PR DESCRIPTION
**Context**
A Regular Expression Denial of Service (ReDoS) vulnerability exists in `path-to-regexp` (< 0.1.13) which is transitively used by Express. As a server-side mitigation until direct dependency updates can be cleanly applied across `package.json` files, this PR introduces generic path-parameter limits.

**Plan Execution**
- Created `paramLimit` middleware to reject requests when `req.params` exceed 5 keys or when any single parameter's length exceeds 200 characters.
- Applied the middleware to newly instantiated routers for `userRoutes` and `projectRoutes`.
- Implemented unit and integration tests verifying that standard requests succeed and ReDoS-oriented requests fast-fail with `400 Bad Request`.

*Note: The newly created files strictly use the exact camelCase filenames (`paramLimit.ts`, `userRoutes.ts`, `projectRoutes.ts`) specified in the locked file list constraint of the autopilot plan, which overrides the general phase 2B naming standard for this execution.*