### PR TITLE
feat(intent-matches): enrich match payload with counterparty profile

### DIFF
--- a/services/gateway/src/routes/intent-matches.ts
+++ b/services/gateway/src/routes/intent-matches.ts
@@ -14,7 +14,8 @@ import {
   requireTenant,
   AuthenticatedRequest,
 } from '../middleware/auth-supabase-jwt';
-import { redactMatchForReader, tryUnlockReveal } from '../services/intent-mutual-reveal';
+import { tryUnlockReveal } from '../services/intent-mutual-reveal';
+import { enrichMatchesWithCounterpartyProfiles } from '../services/intent-match-enrich';
 import { notifyMutualInterest } from '../services/intent-notifier';
 import { emitOasisEvent } from '../services/oasis-event-service';
 import type { MatchRow } from '../services/intent-matcher';
@@ -56,8 +57,8 @@ router.get('/outgoing', requireAuth, requireTenant, async (req: Request, res: Re
     .limit(limit);
   if (error) return res.status(500).json({ ok: false, error: error.message });
 
-  const redacted = await Promise.all(((data ?? []) as MatchRow[]).map(m => redactMatchForReader(m, identity.user_id)));
-  return res.json({ ok: true, matches: redacted });
+  const enriched = await enrichMatchesWithCounterpartyProfiles((data ?? []) as MatchRow[], identity.user_id);
+  return res.json({ ok: true, matches: enriched });
 });
 
 // ── GET /intent-matches/incoming (I'm party B) ───────────────
@@ -84,8 +85,8 @@ router.get('/incoming', requireAuth, requireTenant, async (req: Request, res: Re
     .limit(limit);
   if (error) return res.status(500).json({ ok: false, error: error.message });
 
-  const redacted = await Promise.all(((data ?? []) as MatchRow[]).map(m => redactMatchForReader(m, identity.user_id)));
-  return res.json({ ok: true, matches: redacted });
+  const enriched = await enrichMatchesWithCounterpartyProfiles((data ?? []) as MatchRow[], identity.user_id);
+  return res.json({ ok: true, matches: enriched });
 });
 
 // ── POST /intent-matches/:id/state ───────────────────────────

--- a/services/gateway/src/routes/intents.ts
+++ b/services/gateway/src/routes/intents.ts
@@ -35,7 +35,7 @@ import { checkIntentContent } from '../services/intent-content-filter';
 import { canPostIntent } from '../services/intent-throttle';
 import { gateCommercialBudget } from '../services/intent-tier-gate';
 import { gateIntentByTier } from '../services/intent-trust-gate';
-import { redactMatchForReader } from '../services/intent-mutual-reveal';
+import { enrichMatchesWithCounterpartyProfiles } from '../services/intent-match-enrich';
 import { notifyMatchSurfaced } from '../services/intent-notifier';
 import { writeIntentFacts } from '../services/intent-memory-hooks';
 import { getActiveCompassGoal } from '../services/intent-compass-lens';
@@ -530,9 +530,9 @@ router.get('/:id/matches', requireAuth, requireTenant, async (req: Request, res:
   if (!canRead) return res.status(404).json({ ok: false, error: 'not_found' });
 
   const matches = await surfaceTopMatches(req.params.id, Math.min(Number(req.query.limit) || 5, 20));
-  // Apply mutual-reveal redaction.
-  const redacted = await Promise.all(matches.map(m => redactMatchForReader(m, identity.user_id)));
-  return res.json({ ok: true, matches: redacted });
+  // Apply mutual-reveal redaction + counterparty profile enrichment (E6).
+  const enriched = await enrichMatchesWithCounterpartyProfiles(matches, identity.user_id);
+  return res.json({ ok: true, matches: enriched });
 });
 
 export default router;

--- a/services/gateway/src/services/intent-match-enrich.ts
+++ b/services/gateway/src/services/intent-match-enrich.ts
@@ -1,0 +1,139 @@
+/**
+ * E6 — Match enrichment with counterparty profile fields.
+ *
+ * Given a list of matches (after `redactMatchForReader`), batch-lookup the
+ * counterparty's display_name, avatar_url, gender from `profiles` and
+ * populate `partner_display_name`, `partner_avatar_url`, `partner_gender`
+ * on each match.
+ *
+ * Defense-in-depth:
+ *   - Redacted matches stay redacted; partner fields stay null.
+ *   - Counterparties whose `global_community_profiles.is_visible = false`
+ *     get null partner fields (matches still surface; identity stays hidden).
+ *   - `partner_gender` is normalized to 'male' | 'female' | null. Anything
+ *     else (empty, 'other', 'private', 'non-binary', etc.) collapses to null.
+ */
+
+import { createClient } from '@supabase/supabase-js';
+import { redactMatchForReader, type RedactedMatch } from './intent-mutual-reveal';
+import type { MatchRow } from './intent-matcher';
+
+function getSupabase() {
+  return createClient(process.env.SUPABASE_URL!, process.env.SUPABASE_SERVICE_ROLE!);
+}
+
+function normalizeGender(raw: unknown): 'male' | 'female' | null {
+  if (typeof raw !== 'string') return null;
+  const v = raw.trim().toLowerCase();
+  if (v === 'male' || v === 'm') return 'male';
+  if (v === 'female' || v === 'f') return 'female';
+  return null;
+}
+
+function pickCounterpartyVid(
+  match: RedactedMatch,
+  readerOwnsA: boolean,
+): string | null {
+  return readerOwnsA ? match.vitana_id_b : match.vitana_id_a;
+}
+
+export async function enrichMatchesWithCounterpartyProfiles(
+  matches: MatchRow[],
+  readerUserId: string,
+): Promise<RedactedMatch[]> {
+  if (matches.length === 0) return [];
+
+  const supabase = getSupabase();
+
+  // 1. Apply redaction first (per-match async — keeps existing semantics).
+  const redactedAll = await Promise.all(
+    matches.map((m) => redactMatchForReader(m, readerUserId)),
+  );
+
+  // 2. Determine which intents the reader owns (for counterparty side selection).
+  //    `redactMatchForReader` already does this lookup internally for partner_seek;
+  //    we re-do it here in batch for the non-redacted case so we don't N+1.
+  const intentIds = Array.from(
+    new Set(redactedAll.flatMap((m) => [m.intent_a_id, m.intent_b_id].filter(Boolean) as string[])),
+  );
+  const ownerByIntent = new Map<string, string>(); // intent_id → requester_user_id
+  if (intentIds.length > 0) {
+    const { data: owners } = await supabase
+      .from('user_intents')
+      .select('intent_id, requester_user_id')
+      .in('intent_id', intentIds);
+    for (const row of (owners ?? []) as { intent_id: string; requester_user_id: string }[]) {
+      ownerByIntent.set(row.intent_id, row.requester_user_id);
+    }
+  }
+
+  // 3. Collect counterparty vitana_ids for non-redacted matches.
+  const counterpartyVids = new Set<string>();
+  for (const m of redactedAll) {
+    if (m.redacted) continue;
+    const readerOwnsA = ownerByIntent.get(m.intent_a_id) === readerUserId;
+    const cpVid = pickCounterpartyVid(m, readerOwnsA);
+    if (cpVid) counterpartyVids.add(cpVid);
+  }
+
+  // 4. Batch-load profile rows for all counterparties.
+  type ProfileRow = {
+    user_id: string;
+    vitana_id: string | null;
+    display_name: string | null;
+    full_name: string | null;
+    avatar_url: string | null;
+    gender: string | null;
+  };
+  const profileByVid = new Map<string, ProfileRow>();
+  if (counterpartyVids.size > 0) {
+    const { data: profiles } = await supabase
+      .from('profiles')
+      .select('user_id, vitana_id, display_name, full_name, avatar_url, gender')
+      .in('vitana_id', Array.from(counterpartyVids));
+    for (const p of (profiles ?? []) as ProfileRow[]) {
+      if (p.vitana_id) profileByVid.set(p.vitana_id, p);
+    }
+  }
+
+  // 5. Batch-load is_visible flags. Default to true when row is missing
+  //    (matches the behaviour of `community-members.ts`).
+  const visibleByUserId = new Map<string, boolean>();
+  const userIds = Array.from(profileByVid.values()).map((p) => p.user_id);
+  if (userIds.length > 0) {
+    const { data: gcps } = await supabase
+      .from('global_community_profiles')
+      .select('user_id, is_visible')
+      .in('user_id', userIds);
+    for (const row of (gcps ?? []) as { user_id: string; is_visible: boolean | null }[]) {
+      visibleByUserId.set(row.user_id, row.is_visible !== false);
+    }
+  }
+
+  // 6. Assemble enriched results.
+  return redactedAll.map((m) => {
+    if (m.redacted) {
+      return { ...m, partner_display_name: null, partner_avatar_url: null, partner_gender: null };
+    }
+    const readerOwnsA = ownerByIntent.get(m.intent_a_id) === readerUserId;
+    const cpVid = pickCounterpartyVid(m, readerOwnsA);
+    if (!cpVid) {
+      return { ...m, partner_display_name: null, partner_avatar_url: null, partner_gender: null };
+    }
+    const profile = profileByVid.get(cpVid);
+    if (!profile) {
+      return { ...m, partner_display_name: null, partner_avatar_url: null, partner_gender: null };
+    }
+    const visible = visibleByUserId.get(profile.user_id);
+    if (visible === false) {
+      // Hidden user → no leak.
+      return { ...m, partner_display_name: null, partner_avatar_url: null, partner_gender: null };
+    }
+    return {
+      ...m,
+      partner_display_name: profile.display_name ?? profile.full_name ?? null,
+      partner_avatar_url: profile.avatar_url ?? null,
+      partner_gender: normalizeGender(profile.gender),
+    };
+  });
+}

--- a/services/gateway/src/services/intent-mutual-reveal.ts
+++ b/services/gateway/src/services/intent-mutual-reveal.ts
@@ -34,6 +34,12 @@ export interface RedactedMatch extends Omit<MatchRow, 'vitana_id_a' | 'vitana_id
   vitana_id_a: string | null;
   vitana_id_b: string | null;
   redacted: boolean;
+  // E6 — counterparty profile fields populated by enrichMatchesWithCounterpartyProfiles.
+  // null when redacted, when the counterparty is hidden (global_community_profiles.is_visible=false),
+  // or when the field is unset in profiles.
+  partner_display_name?: string | null;
+  partner_avatar_url?: string | null;
+  partner_gender?: 'male' | 'female' | null;
 }
 
 /**


### PR DESCRIPTION
## Summary

Backend half of E6 follow-up: add counterparty profile fields to the `intent_matches` API responses so the frontend can render avatars + names on the "Find a Match → My Matches" cards (instead of only `@vitana_id`).

The companion frontend PR is exafyltd/vitana-v1#TBD.

## Changes

- **`services/gateway/src/services/intent-mutual-reveal.ts`** — `RedactedMatch` now exposes optional `partner_display_name`, `partner_avatar_url`, `partner_gender` (`'male' | 'female' | null`).
- **`services/gateway/src/services/intent-match-enrich.ts`** _(new)_ — `enrichMatchesWithCounterpartyProfiles(matches, readerUserId)`:
  1. Runs `redactMatchForReader` first (existing semantics preserved).
  2. Batches a `profiles` lookup keyed on counterparty `vitana_id` (no N+1).
  3. Cross-checks `global_community_profiles.is_visible` — hidden users get null partner fields (defense-in-depth).
  4. Normalizes `gender` to `'male' | 'female' | null`. Anything else (`'other'`, `'private'`, empty, etc.) → null.
  5. Redacted matches keep all three partner fields null. No leaks.
- **Routes updated to use the enricher** — `intent-matches.ts` (`/outgoing`, `/incoming`) and `intents.ts` (`/intents/:id/matches`). `orb-live.ts` voice surface intentionally untouched (no avatars needed).

## Privacy & redaction

- `partner_seek` pre-reveal matches still pass through `redactMatchForReader` first; partner_* fields stay null until mutual unlock.
- `global_community_profiles.is_visible = false` users surface as matches (intentional) but with null partner fields — same gate `community-members.ts` already uses.
- Gender exposure is scoped to counterparties on a match the reader is actually a party to — drives a gender-aware DiceBear fallback when no avatar is set. No broader gender exposure on `/community/members` or any other public surface.

## Test plan

- [ ] `npm run build` (passes locally)
- [ ] `curl /api/v1/intent-matches/outgoing` (auth) — non-redacted rows include `partner_display_name`, `partner_avatar_url`, `partner_gender`; redacted rows have all three set to `null`.
- [ ] Force a `partner_seek` pre-reveal match → confirm all three are `null`.
- [ ] Force a counterparty whose `is_visible = false` → confirm all three are `null`.
- [ ] Frontend PR (vitana-v1) renders avatars from these fields.

https://claude.ai/code/session_01A55cp16b5p3zEPxAqBUqfi

---
_Generated by [Claude Code](https://claude.ai/code/session_01A55cp16b5p3zEPxAqBUqfi)_