### PR TITLE
fix(orb-agent): tool catalogue iteration 2 — 5 fixes + drop deferred (VTID-02723)

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/tools.py
+++ b/services/agents/orb-agent/src/orb_agent/tools.py
@@ -322,7 +322,7 @@ async def create_index_improvement_plan(context: RunContext, target_pillar: str)
 @function_tool
 async def save_diary_entry(context: RunContext, text: str) -> str:
     """Save a diary entry. Triggers Vitana Index recompute via /memory/diary/sync-index (VTID-01983)."""
-    body = await _gw(context).post("/api/v1/memory/diary/sync-index", {"text": text})
+    body = await _gw(context).post("/api/v1/memory/diary/sync-index", {"raw_text": text})
     return summarize(body)
 
 
@@ -333,9 +333,19 @@ async def save_diary_entry(context: RunContext, text: str) -> str:
 
 @function_tool
 async def set_reminder(context: RunContext, text: str, when_iso: str) -> str:
-    """Set a reminder (VTID-02601)."""
+    """Set a reminder (VTID-02601).
+
+    Args:
+        text: Short action label, e.g. "take magnesium". <=60 chars.
+        when_iso: When to fire, ISO 8601 UTC. Must be 60s..90 days in the future.
+    """
     body = await _gw(context).post(
-        "/api/v1/reminders", {"text": text, "when_iso": when_iso}
+        "/api/v1/reminders",
+        {
+            "action_text": text,
+            "spoken_message": text,
+            "scheduled_for_iso": when_iso,
+        },
     )
     return summarize(body)
 
@@ -432,8 +442,26 @@ async def share_link(context: RunContext, url: str, with_recipient: str | None =
 
 @function_tool
 async def post_intent(context: RunContext, kind: str, body_text: str) -> str:
-    """Post an intent (commercial_buy/sell, activity_seek, partner_seek, social_seek, mutual_aid) (VTID-01975)."""
-    body = await _gw(context).post("/api/v1/intents", {"kind": kind, "body": body_text})
+    """Post an intent (VTID-01975).
+
+    Args:
+        kind: One of commercial_buy, commercial_sell, activity_seek,
+            partner_seek, social_seek, mutual_aid, learning_seek, mentor_seek.
+        body_text: The user's natural-language description of the intent
+            (used for both title and scope; classifier expands as needed).
+    """
+    # Endpoint accepts either {intent_kind, title, scope} or just
+    # {utterance} (which classifier expands). We send the explicit form
+    # since we already have the kind. Title is a short prefix of the
+    # body; scope is the full text (must be 20–1500 chars).
+    title = body_text[:80] if len(body_text) >= 3 else f"{kind} request"
+    if len(title) < 3:
+        title = f"{kind} request"
+    scope = body_text if len(body_text) >= 20 else (body_text + " — looking for matches in the community").ljust(20)[:1500]
+    body = await _gw(context).post(
+        "/api/v1/intents",
+        {"intent_kind": kind, "title": title, "scope": scope},
+    )
     return summarize(body)
 
 
@@ -520,30 +548,66 @@ async def navigate_to_screen(context: RunContext, target: str) -> str:
 
 
 def all_tool_names() -> list[str]:
-    """Returns the names of every @function_tool in this module.
+    """Returns the names of every @function_tool in this module that has a
+    working gateway endpoint right now.
+
+    Tools whose business logic is currently inline in orb-live.ts (Vertex
+    pipeline) and not yet exposed as standalone HTTP routes are tracked in
+    DEFERRED_TOOL_NAMES below. Re-enable each there as its endpoint lands.
 
     Used by tests/test_tools_catalogue.py to assert the tool list matches
-    voice-pipeline-spec/spec.json. Update when adding/removing a tool.
+    voice-pipeline-spec/spec.json. Update when wiring or unwiring a tool.
     """
     return [
-        "search_memory", "search_knowledge", "search_web", "recall_conversation_at_time",
-        "switch_persona", "report_to_specialist",
+        # Memory / Knowledge
+        "search_knowledge",
+        # Calendar (4)
         "search_calendar", "create_calendar_event", "add_to_calendar", "get_schedule",
-        "search_events", "search_community", "get_recommendations",
-        "play_music", "set_capability_preference",
-        "read_email", "find_contact",
-        "consult_external_ai",
-        "get_vitana_index", "get_index_improvement_suggestions", "create_index_improvement_plan",
+        # Recommendations (2)
+        "get_recommendations", "activate_recommendation",
+        # Vitana Index (2)
+        "get_vitana_index", "get_index_improvement_suggestions",
+        # Diary
         "save_diary_entry",
+        # Reminders (3)
         "set_reminder", "find_reminders", "delete_reminder",
-        "ask_pillar_agent", "explain_feature",
-        "resolve_recipient", "send_chat_message",
-        "activate_recommendation",
-        "share_link",
-        "post_intent", "view_intent_matches", "list_my_intents", "respond_to_match",
-        "mark_intent_fulfilled", "share_intent_post", "scan_existing_matches", "get_matchmaker_result",
-        "navigate_to_screen",
+        # Intents (5)
+        "post_intent", "view_intent_matches", "list_my_intents",
+        "mark_intent_fulfilled", "get_matchmaker_result",
     ]
+
+
+# Tools whose Vertex implementation is INLINE inside orb-live.ts case
+# blocks (not exposed as HTTP routes). Calling their gateway URL today
+# returns 404 because no router handles it. Each lands in a follow-up
+# PR that either (a) lifts the inline logic into a route file, or (b)
+# adds a generic POST /api/v1/orb/tool dispatcher that wraps the inline
+# logic. Until then we exclude them from the live catalogue so the LLM
+# doesn't try to call them and apologize for "no access".
+DEFERRED_TOOL_NAMES: list[str] = [
+    "search_memory",                  # orb-live.ts:4125 inline
+    "search_web",                     # orb-live.ts:4232 inline
+    "recall_conversation_at_time",    # no Vertex equivalent
+    "switch_persona",                 # orb-live.ts:2385 inline
+    "report_to_specialist",           # orb-live.ts:4458 — PR 5/6
+    "search_events",                  # orb-live.ts inline
+    "search_community",               # orb-live.ts inline
+    "play_music",                     # orb-live.ts:5251 inline
+    "set_capability_preference",      # orb-live.ts:5385 inline
+    "read_email",                     # orb-live.ts:5449 inline
+    "find_contact",                   # orb-live.ts:5452 inline
+    "consult_external_ai",            # orb-live.ts:2549 inline (path mismatch)
+    "create_index_improvement_plan",  # orb-live.ts:5758 inline
+    "ask_pillar_agent",               # orb-live.ts:6183 inline
+    "explain_feature",                # orb-live.ts:6231 inline
+    "resolve_recipient",              # orb-live.ts:6278 inline
+    "send_chat_message",              # orb-live.ts:6326 inline
+    "share_link",                     # orb-live.ts inline
+    "scan_existing_matches",          # orb-live.ts inline
+    "share_intent_post",              # orb-live.ts inline
+    "respond_to_match",               # path uncertain — need check
+    "navigate_to_screen",             # orb-live.ts:6959 inline
+]
 
 
 def all_tools() -> list[Any]:

--- a/services/agents/orb-agent/tests/test_tools_catalogue.py
+++ b/services/agents/orb-agent/tests/test_tools_catalogue.py
@@ -25,15 +25,27 @@ def _load_spec_tools() -> set[str]:
 
 
 def test_all_tool_names_exported() -> None:
-    """tools.all_tool_names() must equal spec.json's tool list."""
-    from src.orb_agent.tools import all_tool_names
+    """tools.all_tool_names() ∪ DEFERRED_TOOL_NAMES must equal spec.json's tool
+    list (the parity contract); skeleton must not have anything extra.
+
+    DEFERRED_TOOL_NAMES is the explicit "endpoint not yet wired on the
+    gateway" list. Each entry there has its Vertex implementation inline
+    in orb-live.ts and lands in a follow-up PR. Keeping them in spec.json
+    preserves parity-contract awareness while letting `all_tools()` ship
+    only the working subset to the LLM.
+    """
+    from src.orb_agent.tools import DEFERRED_TOOL_NAMES, all_tool_names
 
     spec_tools = _load_spec_tools()
-    skeleton_tools = set(all_tool_names())
-    missing_in_skeleton = spec_tools - skeleton_tools
-    extra_in_skeleton = skeleton_tools - spec_tools
-    assert not missing_in_skeleton, f"spec declares tools not in skeleton: {missing_in_skeleton}"
-    assert not extra_in_skeleton, f"skeleton has tools not in spec: {extra_in_skeleton}"
+    active = set(all_tool_names())
+    deferred = set(DEFERRED_TOOL_NAMES)
+    overlap = active & deferred
+    assert not overlap, f"tools cannot be both active and deferred: {overlap}"
+    union = active | deferred
+    missing = spec_tools - union
+    extra = union - spec_tools
+    assert not missing, f"spec declares tools missing from skeleton (active or deferred): {missing}"
+    assert not extra, f"skeleton has tools not in spec: {extra}"
 
 
 def test_tool_decorators_present() -> None:

--- a/services/gateway/src/routes/vitana-index.ts
+++ b/services/gateway/src/routes/vitana-index.ts
@@ -134,7 +134,7 @@ router.get('/suggestions', requireAuth, async (req: AuthenticatedRequest, res: R
   try {
     const { data, error } = await client
       .from('autopilot_recommendations')
-      .select('id, title, action_description, contribution_vector, priority, status')
+      .select('id, title, summary, contribution_vector, priority, status')
       .eq('user_id', userId)
       .in('status', ['pending', 'new', 'snoozed'])
       .not('contribution_vector', 'is', null)
@@ -148,7 +148,7 @@ router.get('/suggestions', requireAuth, async (req: AuthenticatedRequest, res: R
     }
 
     const ranked = (data || [])
-      .map((r: { id: string; title: string; action_description: string; contribution_vector: Record<string, number> | null; priority: number; status: string }) => {
+      .map((r: { id: string; title: string; summary: string; contribution_vector: Record<string, number> | null; priority: number; status: string }) => {
         const cv = r.contribution_vector;
         const lift = cv && typeof cv[pillar!] === 'number' ? cv[pillar!] : 0;
         return { ...r, _lift: lift };
@@ -173,7 +173,7 @@ router.get('/suggestions', requireAuth, async (req: AuthenticatedRequest, res: R
       suggestions: ranked.map((r) => ({
         id: r.id,
         title: r.title,
-        action: r.action_description,
+        action: r.summary,
         lift: r._lift,
         contribution_vector: r.contribution_vector,
       })),


### PR DESCRIPTION
End-to-end test harness driven. Fixes vitana-index/suggestions SQL column, save_diary_entry/set_reminder/post_intent body shapes, and reduces active catalogue to 18 tools that all hit working gateway endpoints. 22 tools whose implementations are inline-only in orb-live.ts move to DEFERRED_TOOL_NAMES; they re-enter the active list as their endpoints land.