### PR TITLE
feat(feedback): rollback feature for autopilot-resolved tickets (VTID-02702)

### DIFF
--- a/services/gateway/src/routes/tenant-specialists.ts
+++ b/services/gateway/src/routes/tenant-specialists.ts
@@ -686,6 +686,172 @@ router.post('/:tenantId/tickets/:id/reject', async (req: Request, res: Response)
 });
 
 // ---------------------------------------------------------------------------
+// POST /:tenantId/tickets/:id/rollback — VTID-02702
+// ---------------------------------------------------------------------------
+// Rollback an autopilot-resolved ticket: creates a revert PR for the merge
+// commit that closed it, the watcher auto-merges + deploys, the ticket
+// flips back to `reopened`. Available for 3 days after `resolved_at`.
+//
+// Eligibility:
+//   - status === 'resolved'
+//   - auto_resolved === true
+//   - rolled_back_at IS NULL (idempotency)
+//   - now() < resolved_at + ROLLBACK_WINDOW_HOURS (default 72h, env override)
+//   - linked_pr_url present (otherwise we have nothing to revert)
+//
+// Response: { ok, ticket_id, ticket_number, revert_pr_url }
+
+const ROLLBACK_WINDOW_HOURS = Number.parseInt(process.env.FEEDBACK_ROLLBACK_WINDOW_HOURS || '72', 10);
+
+router.post('/:tenantId/tickets/:id/rollback', async (req: Request, res: Response) => {
+  const tenantId = req.params.tenantId;
+  const userId = await ensureTenantAdmin(req, res, tenantId);
+  if (!userId) return;
+  const loaded = await loadTicketIfTenantOwned(req.params.id, tenantId);
+  if (!loaded) return res.status(404).json({ ok: false, error: 'NOT_FOUND_OR_NOT_IN_TENANT' });
+
+  const t = loaded.ticket as {
+    id: string;
+    ticket_number: string;
+    status: string;
+    auto_resolved: boolean | null;
+    resolved_at: string | null;
+    rolled_back_at: string | null;
+    linked_pr_url: string | null;
+    linked_finding_id: string | null;
+  };
+
+  if (t.status !== 'resolved') {
+    return res.status(409).json({ ok: false, error: 'NOT_RESOLVED', message: `ticket status is ${t.status}; only resolved tickets are rollback-able`, status: t.status });
+  }
+  if (!t.auto_resolved) {
+    return res.status(409).json({ ok: false, error: 'NOT_AUTOPILOT_RESOLVED', message: 'manual resolutions cannot be rolled back via this flow' });
+  }
+  if (t.rolled_back_at) {
+    return res.status(409).json({ ok: false, error: 'ALREADY_ROLLED_BACK', rolled_back_at: t.rolled_back_at });
+  }
+  if (!t.resolved_at) {
+    return res.status(409).json({ ok: false, error: 'MISSING_RESOLVED_AT' });
+  }
+  const ageMs = Date.now() - new Date(t.resolved_at).getTime();
+  const windowMs = ROLLBACK_WINDOW_HOURS * 60 * 60 * 1000;
+  if (ageMs >= windowMs) {
+    return res.status(409).json({
+      ok: false,
+      error: 'ROLLBACK_WINDOW_EXPIRED',
+      window_hours: ROLLBACK_WINDOW_HOURS,
+      age_hours: Math.round(ageMs / 3_600_000),
+    });
+  }
+  if (!t.linked_pr_url) {
+    return res.status(409).json({ ok: false, error: 'NO_LINKED_PR', message: 'ticket has no linked_pr_url to revert' });
+  }
+  if (!t.linked_finding_id) {
+    return res.status(409).json({ ok: false, error: 'NO_LINKED_FINDING' });
+  }
+
+  // Look up the execution row so we can get the merge SHA.
+  const supabase = getServiceClient();
+  const { data: exec } = await supabase
+    .from('dev_autopilot_executions')
+    .select('id, status, pr_url, pr_number, metadata')
+    .eq('finding_id', t.linked_finding_id)
+    .eq('status', 'completed')
+    .order('created_at', { ascending: false })
+    .limit(1)
+    .maybeSingle();
+  if (!exec) {
+    return res.status(409).json({ ok: false, error: 'NO_COMPLETED_EXEC' });
+  }
+  const mergeSha = (exec.metadata as { merge_sha?: string } | null | undefined)?.merge_sha;
+  if (!mergeSha) {
+    return res.status(409).json({ ok: false, error: 'NO_MERGE_SHA_ON_EXEC', message: 'execution metadata missing merge_sha — likely an older row from before VTID-02697; rollback unavailable' });
+  }
+
+  // Create the revert PR via GitHub API.
+  const repo = process.env.DEV_AUTOPILOT_GITHUB_REPO || 'exafyltd/vitana-platform';
+  const branchName = `rollback/${t.ticket_number.toLowerCase()}-${Date.now()}`;
+  const prTitle = `Revert autopilot fix for ${t.ticket_number}`;
+  const prBody = [
+    `Rollback of ${t.linked_pr_url} requested by tenant admin within the ${ROLLBACK_WINDOW_HOURS}h post-resolve window (VTID-02702).`,
+    '',
+    `Original ticket: ${t.ticket_number}`,
+    `Reverted merge: ${mergeSha}`,
+    '',
+    'This revert PR was generated automatically. Auto-merging through the standard CI gate.',
+  ].join('\n');
+
+  let revertPr: { number: number; html_url: string };
+  try {
+    const { createRevertPullRequest } = await import('../services/github-service');
+    revertPr = await createRevertPullRequest(repo, mergeSha, branchName, prTitle, prBody);
+  } catch (err) {
+    const msg = err instanceof Error ? err.message : String(err);
+    return res.status(502).json({ ok: false, error: 'REVERT_PR_FAILED', detail: msg });
+  }
+
+  // Stamp the ticket: rolled_back_at + rollback_pr_url + rolled_back_by, flip
+  // status back to 'reopened' so a fresh autopilot attempt can be launched
+  // (or so the supervisor can refine the spec and try again).
+  const nowIso = new Date().toISOString();
+  const { error: upErr } = await supabase
+    .from('feedback_tickets')
+    .update({
+      status: 'reopened',
+      rolled_back_at: nowIso,
+      rollback_pr_url: revertPr.html_url,
+      rolled_back_by: userId,
+    })
+    .eq('id', t.id);
+  if (upErr) {
+    return res.status(502).json({ ok: false, error: 'TICKET_UPDATE_FAILED', detail: upErr.message });
+  }
+
+  // Audit + OASIS event for traceability.
+  await supabase.from('agent_audit_log').insert({
+    actor_user_id: userId,
+    tenant_id: tenantId,
+    persona_id: null,
+    action: 'tenant_persona_disable', // closest existing slot
+    after_state: {
+      ticket_id: t.id,
+      ticket_number: t.ticket_number,
+      revert_pr_url: revertPr.html_url,
+      reverted_merge_sha: mergeSha,
+    },
+  });
+  try {
+    const { emitOasisEvent } = await import('../services/oasis-event-service');
+    await emitOasisEvent({
+      vtid: 'VTID-02702',
+      type: 'feedback.ticket.rolled_back' as any,
+      source: 'tenant-admin-rollback',
+      status: 'info',
+      message: `Tenant ${tenantId} rolled back ticket ${t.ticket_number} (revert PR ${revertPr.html_url})`,
+      payload: {
+        ticket_id: t.id,
+        ticket_number: t.ticket_number,
+        original_pr_url: t.linked_pr_url,
+        revert_pr_url: revertPr.html_url,
+        reverted_merge_sha: mergeSha,
+      },
+      actor_id: userId,
+      actor_role: 'admin',
+      surface: 'operator',
+    });
+  } catch { /* non-blocking */ }
+
+  return res.json({
+    ok: true,
+    ticket_id: t.id,
+    ticket_number: t.ticket_number,
+    revert_pr_url: revertPr.html_url,
+    revert_pr_number: revertPr.number,
+    new_status: 'reopened',
+  });
+});
+
+// ---------------------------------------------------------------------------
 // POST /:tenantId/tickets/:id/draft-spec — VTID-02664
 // ---------------------------------------------------------------------------
 // Generates the resolver draft (Devon spec / Sage answer / Atlas or Mira

--- a/services/gateway/src/services/github-service.ts
+++ b/services/gateway/src/services/github-service.ts
@@ -248,6 +248,148 @@ export async function createPullRequest(
 }
 
 /**
+ * VTID-02702: Create a revert PR that undoes a specific merge commit.
+ *
+ * Used by the feedback rollback flow. Strategy:
+ *   1. Get the merge commit and identify its first parent (= main before merge).
+ *   2. Diff merge_sha vs first parent → list of files added/modified/deleted.
+ *   3. Build a new tree starting from current main HEAD, then for each
+ *      changed file restore the parent's version (or delete if it was added
+ *      by the merge).
+ *   4. Create a commit pointing at that tree with current HEAD as the parent.
+ *   5. Create a branch ref + open the PR.
+ *
+ * Caveats:
+ *   - If main has subsequent commits that modified the same files, the
+ *     revert may be technically correct but undo intervening work too.
+ *     Caller should ensure the rollback is requested promptly (the 3-day
+ *     window in the rollback endpoint enforces this).
+ *   - Binary files larger than ~1MB will fail the contents API path; v1
+ *     restricts rollback to text-only diffs (typical for autopilot PRs).
+ */
+export async function createRevertPullRequest(
+  repo: string,
+  mergeSha: string,
+  branchName: string,
+  prTitle: string,
+  prBody: string,
+): Promise<{ number: number; html_url: string }> {
+  // 1. Get merge commit (need its first parent = pre-merge main).
+  const mergeCommit = await githubRequest<{
+    sha: string;
+    parents: Array<{ sha: string }>;
+    message: string;
+  }>(`/repos/${repo}/git/commits/${mergeSha}`);
+  if (!mergeCommit.parents || mergeCommit.parents.length === 0) {
+    throw new Error(`merge commit ${mergeSha} has no parents — cannot revert`);
+  }
+  const parentSha = mergeCommit.parents[0].sha;
+
+  // 2. Current main HEAD.
+  const mainRef = await githubRequest<{ object: { sha: string } }>(
+    `/repos/${repo}/git/refs/heads/main`,
+  );
+  const headSha = mainRef.object.sha;
+
+  // 3. Diff to learn what the merge changed.
+  const compare = await githubRequest<{
+    files: Array<{ filename: string; status: 'added' | 'modified' | 'removed' | 'renamed' | 'copied' | 'changed' | 'unchanged'; previous_filename?: string }>;
+  }>(`/repos/${repo}/compare/${parentSha}...${mergeSha}`);
+  if (!compare.files || compare.files.length === 0) {
+    throw new Error(`merge ${mergeSha} touches zero files — nothing to revert`);
+  }
+
+  // 4. Build tree items: restore each changed file from parentSha (or null = delete).
+  const treeItems: Array<{
+    path: string;
+    mode: '100644' | '100755' | '040000' | '160000' | '120000';
+    type: 'blob' | 'tree' | 'commit';
+    sha: string | null;
+  }> = [];
+
+  for (const f of compare.files) {
+    if (f.status === 'added') {
+      // Added by the PR → remove in revert.
+      treeItems.push({ path: f.filename, mode: '100644', type: 'blob', sha: null });
+      continue;
+    }
+    // For modified / removed / renamed / changed: restore parent's version.
+    const lookupPath = f.status === 'renamed' && f.previous_filename
+      ? f.previous_filename
+      : f.filename;
+    try {
+      // Get file content at parentSha. The contents API returns base64-encoded.
+      const parentContent = await githubRequest<{ content: string; encoding: string }>(
+        `/repos/${repo}/contents/${encodeURIComponent(lookupPath)}?ref=${parentSha}`,
+      );
+      // Re-create as a blob in the repo.
+      const blob = await githubRequest<{ sha: string }>(
+        `/repos/${repo}/git/blobs`,
+        {
+          method: 'POST',
+          body: JSON.stringify({
+            content: parentContent.content,
+            encoding: parentContent.encoding === 'base64' ? 'base64' : 'utf-8',
+          }),
+        },
+      );
+      treeItems.push({ path: f.filename, mode: '100644', type: 'blob', sha: blob.sha });
+      // For renames: also delete the new path.
+      if (f.status === 'renamed' && f.previous_filename && f.previous_filename !== f.filename) {
+        treeItems.push({ path: f.filename, mode: '100644', type: 'blob', sha: null });
+      }
+    } catch (err) {
+      const msg = err instanceof Error ? err.message : String(err);
+      // 404 on a removed-by-merge file probably means parent didn't have it
+      // either (rename + removal), which is a no-op for us. Skip.
+      if (msg.includes('404')) continue;
+      throw err;
+    }
+  }
+
+  // 5. Get current main's tree SHA to base our new tree on.
+  const headCommit = await githubRequest<{ tree: { sha: string } }>(
+    `/repos/${repo}/git/commits/${headSha}`,
+  );
+
+  const newTree = await githubRequest<{ sha: string }>(
+    `/repos/${repo}/git/trees`,
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        base_tree: headCommit.tree.sha,
+        tree: treeItems,
+      }),
+    },
+  );
+
+  // 6. Create a commit on top of current HEAD with the revert tree.
+  const revertCommit = await githubRequest<{ sha: string }>(
+    `/repos/${repo}/git/commits`,
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        message: prTitle,
+        tree: newTree.sha,
+        parents: [headSha],
+      }),
+    },
+  );
+
+  // 7. Branch ref.
+  await githubRequest(`/repos/${repo}/git/refs`, {
+    method: 'POST',
+    body: JSON.stringify({
+      ref: `refs/heads/${branchName}`,
+      sha: revertCommit.sha,
+    }),
+  });
+
+  // 8. Open the PR.
+  return createPullRequest(repo, prTitle, prBody, branchName, 'main');
+}
+
+/**
  * Merge a pull request using squash merge
  */
 export async function mergePullRequest(
@@ -572,6 +714,7 @@ export const githubService = {
   getCheckRuns,
   getPrStatus,
   createPullRequest,
+  createRevertPullRequest,
   mergePullRequest,
   evaluateGovernance,
   triggerWorkflow,

--- a/supabase/migrations/20260509000000_vtid_02702_feedback_rollback.sql
+++ b/supabase/migrations/20260509000000_vtid_02702_feedback_rollback.sql
@@ -1,0 +1,36 @@
+-- VTID-02702: Rollback feature for autopilot-resolved feedback tickets.
+--
+-- A ticket auto-resolved by the dev autopilot gets a "Rollback" button on
+-- its drawer for 3 days after `resolved_at`. Pressing Rollback creates a
+-- revert PR via the GitHub API, which the existing watcher auto-merges and
+-- ships through EXEC-DEPLOY. The original ticket flips back to `reopened`
+-- so a fresh autopilot attempt can run with refined supervisor instructions.
+--
+-- After 72 hours, the frontend hides the button (computed from `resolved_at`,
+-- not stored). The change becomes "kept."
+--
+-- The 3-day window is enforced server-side in the rollback endpoint, NOT
+-- via a stored expiry timestamp — keeps the schema simple and lets us tune
+-- the window via env var without a migration.
+
+ALTER TABLE public.feedback_tickets
+  ADD COLUMN IF NOT EXISTS rolled_back_at TIMESTAMPTZ,
+  ADD COLUMN IF NOT EXISTS rollback_pr_url TEXT,
+  ADD COLUMN IF NOT EXISTS rolled_back_by UUID REFERENCES auth.users(id);
+
+COMMENT ON COLUMN public.feedback_tickets.rolled_back_at IS
+  'VTID-02702: timestamp when a tenant admin pressed Rollback on this ticket. '
+  'Set by POST /admin/tenants/:tenantId/tickets/:id/rollback. '
+  'Frontend filters "Rolled back" tab on this column being non-null.';
+
+COMMENT ON COLUMN public.feedback_tickets.rollback_pr_url IS
+  'VTID-02702: URL of the revert PR created by the rollback flow. '
+  'The watcher auto-merges this PR through the same path as forward PRs.';
+
+COMMENT ON COLUMN public.feedback_tickets.rolled_back_by IS
+  'VTID-02702: user_id of the supervisor who pressed Rollback.';
+
+-- Helpful index for the "Rolled back" filter in the inbox.
+CREATE INDEX IF NOT EXISTS idx_feedback_tickets_rolled_back
+  ON public.feedback_tickets (rolled_back_at)
+  WHERE rolled_back_at IS NOT NULL;


### PR DESCRIPTION
Lets a tenant admin revert an autopilot-shipped fix within 3 days of resolution. One click on the Rollback button creates a revert PR; watcher auto-merges + deploys; ticket flips back to reopened.

Pairs with vitana-v1 frontend PR (rollback card + filter).