### PR TITLE
DEV-AUTOPILOT: Add paramLimit middleware to mitigate path-to-regexp ReDoS

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,21 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    if (req.params) {
+      const keys = Object.keys(req.params);
+      if (keys.length > maxParams) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+
+      for (const key of keys) {
+        if (req.params[key] && req.params[key].length > maxLength) {
+          res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+          return;
+        }
+      }
+    }
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,19 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+  
+  return res.json({ ok: true, data: { project_id: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,19 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:id', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+  
+  return res.json({ ok: true, data: { user_id: req.params.id } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,61 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - paramLimit Middleware', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = express();
+    
+    app.get('/test/multiple/:a/:b/:c/:d/:e/:f', limitPathParams(), (req: Request, res: Response) => {
+      res.status(200).json({ ok: true });
+    });
+    
+    app.get('/test/long/:param', limitPathParams(), (req: Request, res: Response) => {
+      res.status(200).json({ ok: true });
+    });
+
+    app.get('/test/valid/:a/:b', limitPathParams(), (req: Request, res: Response) => {
+      res.status(200).json({ ok: true });
+    });
+  });
+
+  it('rejects requests with more than 5 path parameters', async () => {
+    const start = Date.now();
+    const res = await request(app).get('/test/multiple/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+    
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ ok: false, error: 'Too many path parameters or parameter too long' });
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('rejects requests with path parameter exceeding 200 characters', async () => {
+    const longParam = 'a'.repeat(201);
+    const start = Date.now();
+    const res = await request(app).get(`/test/long/${longParam}`);
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ ok: false, error: 'Too many path parameters or parameter too long' });
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('allows valid requests with fewer than 5 parameters and short lengths', async () => {
+    const res = await request(app).get('/test/valid/hello/world');
+    
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it('integration test for catastrophic backtracking mitigation', async () => {
+    const maliciousPayload = 'a'.repeat(500) + '!';
+    const start = Date.now();
+    const res = await request(app).get(`/test/long/${maliciousPayload}`);
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(duration).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
This PR introduces the `paramLimit` Express middleware to mitigate the `path-to-regexp` ReDoS vulnerability (CVE-2024-4068) in the API gateway. The middleware validates the number and length of parsed route parameters, returning `400 Bad Request` if bounds are exceeded, thereby reducing the attack surface.

**A note on naming conventions:** 
The autopilot execution plan specifically enforced the camelCase names for the created files (`paramLimit.ts`, `userRoutes.ts`, `projectRoutes.ts`) through its locked file constraints. Although our conventions require kebab-case for these `.ts` files, this automated pass followed the strictly enforced paths to ensure safe CI handover. These files will need to be renamed to match standard kebab-case conventions (`param-limit.ts`, `user-routes.ts`, `project-routes.ts`) in a subsequent manual or script commit to satisfy the `Enforce Phase 2B Naming Standards` CI check.

**Files created:**
- `services/gateway/src/routes/middleware/paramLimit.ts`
- `services/gateway/src/routes/v1/userRoutes.ts`
- `services/gateway/src/routes/v1/projectRoutes.ts`
- `services/gateway/test/cve-mitigation.test.ts`