### PR TITLE
DEV-AUTOPILOT: Mitigate path-to-regexp ReDoS via paramLimit middleware

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,28 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const keys = Object.keys(req.params || {});
+    
+    if (keys.length > maxParams) {
+      res.status(400).json({ 
+        ok: false, 
+        error: 'Too many path parameters or parameter too long' 
+      });
+      return;
+    }
+
+    for (const key of keys) {
+      const value = req.params[key];
+      if (value && typeof value === 'string' && value.length > maxLength) {
+        res.status(400).json({ 
+          ok: false, 
+          error: 'Too many path parameters or parameter too long' 
+        });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,19 @@
+import { Router, Request, Response } from 'express';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply ReDoS mitigation middleware to all project routes
+router.use(limitPathParams());
+
+router.get('/:projectId', async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  return res.json({ ok: true, data: { projectId: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,19 @@
+import { Router, Request, Response } from 'express';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply ReDoS mitigation middleware to all user routes
+router.use(limitPathParams());
+
+router.get('/:userId', async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  return res.json({ ok: true, data: { userId: req.params.userId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,56 @@
+import express from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - paramLimit middleware', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+
+    // Route simulating multiple path parameters
+    app.get('/api/resource/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req, res) => {
+      res.json({ ok: true });
+    });
+
+    // Route simulating potentially long parameter injection
+    app.get('/api/long/:a', limitPathParams(5, 200), (req, res) => {
+      res.json({ ok: true });
+    });
+
+    // Route with standard / safe boundaries
+    app.get('/api/valid/:a/:b', limitPathParams(5, 200), (req, res) => {
+      res.json({ ok: true });
+    });
+  });
+
+  it('rejects requests with more than maxParams', async () => {
+    const res = await request(app).get('/api/resource/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('rejects requests with param length exceeding maxLength', async () => {
+    const longParam = 'a'.repeat(201);
+    const res = await request(app).get(`/api/long/${longParam}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('allows valid requests with fewer than maxParams and short lengths', async () => {
+    const res = await request(app).get('/api/valid/1/2');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('handles potential ReDoS payload efficiently (under 500ms)', async () => {
+    const start = Date.now();
+    // Simulate pathological crafted request designed to cause backtracking
+    const res = await request(app).get('/api/resource/1/2/3/4/5/6?malicious=true');
+    const duration = Date.now() - start;
+    
+    expect(res.status).toBe(400);
+    expect(duration).toBeLessThan(500); // Ensures CPU doesn't stall for exponential times
+  });
+});


### PR DESCRIPTION
Implements server-side validation middleware in the gateway to mitigate the ReDoS vulnerability in `path-to-regexp` (< 0.1.13) by limiting the number and length of path parameters.

### Changes
- Created `paramLimit` middleware to reject requests exceeding maximum parameter count or length.
- Applied `paramLimit` middleware to `userRoutes.ts` and `projectRoutes.ts`.
- Added unit and integration tests to verify middleware behavior and response times.

### Action required
Other route files containing path parameters will also need the `paramLimit` middleware applied. The current plan's strict file locking prevents touching other existing routes in this PR. Additionally, dependency updates in `package.json` for `express`/`path-to-regexp` must be done in a separate PR.

### Note on File Naming
The plan's LOCKED FILE LIST explicitly required camelCase filenames (`paramLimit.ts`, `userRoutes.ts`, `projectRoutes.ts`) which conflicts with the platform's kebab-case convention. To ensure the post-LLM validation succeeds, the files have been created verbatim as listed in the plan. They will trigger Phase 2B Naming Standards CI failures and will require a rename in a follow-up commit.