### PR TITLE
DEV-AUTOPILOT: Mitigation for path-to-regexp ReDoS

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,25 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return function (req: Request, res: Response, next: NextFunction): void {
+    if (!req.params) {
+      return next();
+    }
+
+    const keys = Object.keys(req.params);
+    if (keys.length > maxParams) {
+      res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    for (const key of keys) {
+      const value = req.params[key];
+      if (value && typeof value === 'string' && value.length > maxLength) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,18 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, limitPathParams(), async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+  return res.json({ ok: true, data: { projectId: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,18 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:id', requireAuth, limitPathParams(), async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+  return res.json({ ok: true, data: { id: req.params.id } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,61 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - ReDoS in path-to-regexp', () => {
+  const app = express();
+  
+  const router = express.Router();
+  router.use(limitPathParams(5, 200));
+
+  router.get('/multiple/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  router.get('/long/:id', limitPathParams(5, 200), (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  router.get('/valid/:a/:b', limitPathParams(5, 200), (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  app.use('/', router);
+
+  it('rejects requests with more than 5 path parameters', async () => {
+    const start = Date.now();
+    const response = await request(app).get('/multiple/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+    
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(500);
+  });
+
+  it('rejects requests with a path parameter longer than 200 characters', async () => {
+    const longParam = 'a'.repeat(201);
+    const start = Date.now();
+    const response = await request(app).get(`/long/${longParam}`);
+    const duration = Date.now() - start;
+    
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(500);
+  });
+
+  it('allows valid requests with <=5 parameters and lengths <=200', async () => {
+    const response = await request(app).get('/valid/1/2');
+    expect(response.status).toBe(200);
+    expect(response.body.ok).toBe(true);
+  });
+
+  it('integration: handles pathological request within acceptable time', async () => {
+    const start = Date.now();
+    const longParam = 'a'.repeat(1000);
+    const response = await request(app).get(`/multiple/${longParam}/2/3/4/5/6`);
+    const duration = Date.now() - start;
+
+    expect(response.status).toBe(400);
+    expect(duration).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
This PR implements a middleware-based mitigation for the ReDoS vulnerability in `path-to-regexp` (< 0.1.13) by adding a `paramLimit` middleware to cap the number of path parameters and their maximum lengths.

### Changes:
- Added `paramLimit` middleware that counts the keys in `req.params` and enforces limits (`maxParams=5`, `maxLength=200`).
- Applied the middleware globally to `userRoutes.ts` and `projectRoutes.ts` via `router.use()`, and locally on the route handlers to ensure Express parsing picks it up correctly.
- Added test coverage in `cve-mitigation.test.ts` to assert that overly long params or too many params are rejected with a 400 response.

**Notes for Developers**:
1. You must manually verify and apply this middleware to any other route files in `services/gateway/src/routes/` that accept path parameters.
2. The file names `userRoutes.ts` and `projectRoutes.ts` were strictly followed as requested by the plan's locked file list, though this diverges from the project's standard kebab-case naming conventions. Future refactoring should rename these to `user-routes.ts` and `project-routes.ts`.