### PR TITLE
DEV-AUTOPILOT: Add param limit middleware to mitigate ReDoS

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,34 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    // 1. Check req.path segments for maxLength to protect against ReDoS
+    // during route matching (before req.params is populated).
+    // Using RegExp for validation as specified in the plan.
+    const segmentRegex = new RegExp(`^[^/]{0,${maxLength}}$`);
+    const segments = req.path.split('/').filter(Boolean);
+    
+    for (const segment of segments) {
+      if (!segmentRegex.test(segment)) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    // 2. Check req.params to enforce route-parameter boundaries if already matched
+    const keys = Object.keys(req.params || {});
+    if (keys.length > maxParams) {
+      res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    for (const key of keys) {
+      if (req.params[key] && req.params[key].length > maxLength) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  return res.json({ ok: true, data: { projectId: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:userId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  return res.json({ ok: true, data: { userId: req.params.userId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,63 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - path-to-regexp ReDoS', () => {
+  const app = express();
+
+  // Apply globally to test raw path validation logic
+  app.use(limitPathParams(5, 200));
+
+  app.get('/normal/:a/:b', (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  // Apply directly to test req.params limit evaluation post-match
+  app.get('/many/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  app.get('/long/:a', (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  it('Test 3: Valid request with 2 params passes', async () => {
+    const res = await request(app).get('/normal/val1/val2');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('Test 1: Set up a test route with multiple params, confirm 400 when >5 params', async () => {
+    const start = Date.now();
+    const res = await request(app).get('/many/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('Test 2: Set up a test route with long param (>200 chars), confirm 400', async () => {
+    const longParam = 'a'.repeat(201);
+    const start = Date.now();
+    const res = await request(app).get(`/long/${longParam}`);
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('Integration test: Craft a request designed to trigger ReDoS and assert response time <500ms', async () => {
+    const start = Date.now();
+    // A pathological URL that would typically cause heavy backtracking in unpatched path-to-regexp
+    const pathologicalPath = '/many/' + Array(20).fill('a'.repeat(50)).join('/');
+    const res = await request(app).get(pathologicalPath);
+    const duration = Date.now() - start;
+
+    expect(duration).toBeLessThan(500);
+    expect([400, 404]).toContain(res.status);
+  });
+});


### PR DESCRIPTION
This PR implements server-side validation middleware in the gateway to mitigate a Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (< 0.1.13) used transitively by `express`.

### Why
Attackers can craft requests with multiple or excessively long route parameters that cause catastrophic backtracking during route matching, leading to CPU exhaustion. Direct dependency updates are deferred to a separate package bump. This provides immediate runtime defense.

### What
- **`paramLimit.ts`**: New middleware that validates `req.path` segments and `req.params` keys against configured thresholds (default: max 5 parameters, max 200 chars each). Validating raw path segments provides defense-in-depth before vulnerable route-matching executes.
- **`userRoutes.ts` & `projectRoutes.ts`**: Applied the `limitPathParams` middleware to representative route files. *(Note: All other route files containing path parameters should be updated similarly in follow-up).*
- **`cve-mitigation.test.ts`**: Unit and integration tests to verify standard pass-through, rejection bounds, and robust handling of pathological request URLs.

### Files Touched
- `services/gateway/src/routes/middleware/paramLimit.ts`
- `services/gateway/src/routes/v1/userRoutes.ts`
- `services/gateway/src/routes/v1/projectRoutes.ts`
- `services/gateway/test/cve-mitigation.test.ts`