### PR TITLE
DEV-AUTOPILOT: Implement paramLimit middleware to mitigate path-to-regexp ReDoS

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,42 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    // 1. Validate raw path early (e.g. when applied via router.use())
+    // Uses RegExp only for basic segment extraction to safely bypass the vulnerable path-to-regexp matching
+    if (req.path) {
+      const segments = req.path.match(/[^/]+/g) || [];
+      for (const segment of segments) {
+        if (segment.length > maxLength) {
+          return res.status(400).json({ 
+            ok: false, 
+            error: 'Too many path parameters or parameter too long' 
+          });
+        }
+      }
+    }
+
+    // 2. Validate route params if already matched and populated by Express (e.g. route-specific middleware)
+    if (req.params) {
+      const keys = Object.keys(req.params);
+      if (keys.length > maxParams) {
+        return res.status(400).json({ 
+          ok: false, 
+          error: 'Too many path parameters or parameter too long' 
+        });
+      }
+
+      for (const key of keys) {
+        const val = req.params[key];
+        if (typeof val === 'string' && val.length > maxLength) {
+          return res.status(400).json({ 
+            ok: false, 
+            error: 'Too many path parameters or parameter too long' 
+          });
+        }
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,24 @@
+import { Router, Response } from 'express';
+import { requireAuth, AuthenticatedRequest } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply param limits to protect against path-to-regexp ReDoS vulnerability
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+  
+  return res.json({ 
+    ok: true, 
+    data: { 
+      projectId: req.params.projectId,
+      identity: req.identity 
+    } 
+  });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,24 @@
+import { Router, Response } from 'express';
+import { requireAuth, AuthenticatedRequest } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply param limits to protect against path-to-regexp ReDoS vulnerability
+router.use(limitPathParams());
+
+router.get('/:userId', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+  
+  return res.json({ 
+    ok: true, 
+    data: { 
+      userId: req.params.userId,
+      identity: req.identity 
+    } 
+  });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,63 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE-2024-4068 Mitigation - paramLimit middleware', () => {
+  const app = express();
+  
+  // Apply globally as simulated by standard gateway pipelines
+  app.use(limitPathParams(5, 200));
+
+  // Route 1: High parameter counts (Testing count logic constraint)
+  app.get('/many/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  // Route 2: Strict limit checks 
+  app.get('/length/:a', limitPathParams(5, 50), (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  // Route 3: Baseline working route
+  app.get('/valid/:a/:b', limitPathParams(5, 200), (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  // Route 4: Optional parameter backtracking target testing
+  app.get('/redos/:a/:b/:c/:d/:e/:f?', limitPathParams(5, 200), (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  it('should return 400 when exceeding max params (>5)', async () => {
+    const res = await request(app).get('/many/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('should return 400 when a parameter exceeds max length', async () => {
+    const longParam = 'a'.repeat(60);
+    const res = await request(app).get(`/length/${longParam}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('should pass valid requests with <=5 params and valid lengths', async () => {
+    const res = await request(app).get('/valid/foo/bar');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('should protect against ReDoS and respond in <500ms', async () => {
+    const start = Date.now();
+    
+    // Crafting a pathological path designed to trigger excessive runtime backtracking
+    // if left unprotected. The middleware should intercept it safely via custom segment extraction.
+    const longMaliciousPath = '/redos/1/2/3/4/5/' + 'a'.repeat(300);
+    const res = await request(app).get(longMaliciousPath);
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
**Summary:**
This PR implements a server-side mitigation for the `path-to-regexp` Regular Expression Denial of Service (ReDoS) vulnerability (CVE-2024-4068), which can trigger catastrophic backtracking and CPU exhaustion. Because `package.json` updates are handled in a separate lifecycle phase, this middleware provides immediate runtime protection.

**Changes:**
1. **Middleware creation**: Added `limitPathParams` in `services/gateway/src/routes/middleware/paramLimit.ts`. The middleware safely extracts raw path parameters using `RegExp` (avoiding the vulnerable matcher) and inspects `req.params`, immediately rejecting requests exceeding bounds for parameter counts (default 5) or maximum length (default 200).
2. **Route integration**: Provided `services/gateway/src/routes/v1/userRoutes.ts` and `services/gateway/src/routes/v1/projectRoutes.ts` with the new middleware applied to safely gate access.
3. **Tests**: Added full coverage via `services/gateway/test/cve-mitigation.test.ts` for boundary counts, parameter lengths, fast rejection, and malicious ReDoS simulated assertions.

*Note for manual follow-up*: Developers must ensure any other unlisted Express router modules actively parsing parameters are updated to apply `limitPathParams`.