### PR TITLE
DEV-AUTOPILOT: Mitigate path-to-regexp ReDoS with paramLimit middleware

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,30 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    if (req.params) {
+      const keys = Object.keys(req.params);
+      
+      if (keys.length > maxParams) {
+        res.status(400).json({ 
+          ok: false, 
+          error: 'Too many path parameters' 
+        });
+        return;
+      }
+
+      for (const key of keys) {
+        const val = req.params[key];
+        if (typeof val === 'string' && val.length > maxLength) {
+          res.status(400).json({ 
+            ok: false, 
+            error: 'Path parameter too long' 
+          });
+          return;
+        }
+      }
+    }
+    
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,21 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply parameter limiting middleware to mitigate ReDoS vulnerabilities
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  // Implementation stub for project retrieval
+  return res.json({ ok: true, data: { project_id: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,21 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply parameter limiting middleware to mitigate ReDoS vulnerabilities
+router.use(limitPathParams());
+
+router.get('/:id', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  // Implementation stub for user retrieval
+  return res.json({ ok: true, data: { user_id: req.params.id } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,54 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - paramLimit Middleware', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = express();
+    const testRouter = express.Router();
+
+    // The middleware is applied exactly as it would be in live routes
+    testRouter.use(limitPathParams(5, 200));
+
+    testRouter.get('/single/:id', (req: Request, res: Response) => {
+      res.json({ ok: true, id: req.params.id });
+    });
+
+    testRouter.get('/many/:a/:b/:c/:d/:e/:f', (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    app.use('/', testRouter);
+  });
+
+  it('allows valid request with < 5 params and short length', async () => {
+    const res = await request(app).get('/single/123');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('blocks request with > 5 params', async () => {
+    const res = await request(app).get('/many/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters');
+  });
+
+  it('blocks request with param length > 200', async () => {
+    const longStr = 'a'.repeat(201);
+    const res = await request(app).get(`/single/${longStr}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Path parameter too long');
+  });
+
+  it('executes under 200ms for excessively large input (ReDoS prevention)', async () => {
+    const start = Date.now();
+    const heavyStr = 'a'.repeat(10000);
+    const res = await request(app).get(`/single/${heavyStr}`);
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(duration).toBeLessThan(200);
+  });
+});


### PR DESCRIPTION
This PR addresses a Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` < 0.1.13. Since direct dependency updates to `package.json` are deferred, we mitigate the risk at the Express application layer by introducing server-side validation middleware (`limitPathParams`).

This middleware restricts the number of path parameters (default max: 5) and the length of each parameter (default max: 200 characters), which prevents attackers from triggering the exponential backtracking that leads to CPU exhaustion. 

The middleware has been implemented and applied to `userRoutes.ts` and `projectRoutes.ts` as proof-of-concepts to secure those paths. Appropriate unit and integration testing have also been included to verify both valid pass-throughs and rejections of heavy inputs.

*Note for Operators: The locked file list enforced camelCase names for new files (`paramLimit.ts`, `userRoutes.ts`, `projectRoutes.ts`), which conflicts with the standard kebab-case naming convention enforced by CI. Since emitting files outside the locked list causes immediate validation failure, they have been committed exactly as specified. You may need to rename these to kebab-case before landing if the `validate` CI gate trips.*