### PR TITLE
DEV-AUTOPILOT: Add paramLimit middleware to mitigate path-to-regexp CVE

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,42 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // 1. Raw segment check (effective for router.use() before route match)
+    // Checking the raw path prevents regex evaluation from hanging entirely
+    if (req.path) {
+      const segments = req.path.split('/');
+      for (const segment of segments) {
+        if (segment.length > maxLength) {
+          res.status(400).json({
+            ok: false,
+            error: 'Too many path parameters or parameter too long',
+          });
+          return;
+        }
+      }
+    }
+
+    // 2. Parsed params check (effective when applied to specific routes)
+    const keys = Object.keys(req.params || {});
+    if (keys.length > maxParams) {
+      res.status(400).json({
+        ok: false,
+        error: 'Too many path parameters or parameter too long',
+      });
+      return;
+    }
+
+    for (const key of keys) {
+      if (req.params[key] && req.params[key].length > maxLength) {
+        res.status(400).json({
+          ok: false,
+          error: 'Too many path parameters or parameter too long',
+        });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,14 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+
+const router = Router();
+
+// Apply param limit middleware to all routes in this router
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, (req: Request, res: Response): void => {
+  res.json({ ok: true, data: { projectId: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,14 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+
+const router = Router();
+
+// Apply param limit middleware to all routes in this router
+router.use(limitPathParams());
+
+router.get('/:userId', requireAuth, (req: Request, res: Response): void => {
+  res.json({ ok: true, data: { userId: req.params.userId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,90 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - paramLimit Middleware', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    const router = express.Router();
+
+    // Setup routes. For parameter counting to work on parsed params,
+    // we attach the middleware directly to the route definitions.
+    router.get('/many/:a/:b/:c/:d/:e/:f', limitPathParams(), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    router.get('/single/:id', limitPathParams(), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    router.get('/exact/:a/:b/:c/:d/:e', limitPathParams(), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    // To test segment length logic which runs before param matching
+    router.use('/global', limitPathParams());
+    router.get('/global/path', (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    app.use('/', router);
+  });
+
+  it('should accept requests with parameters below the limit', async () => {
+    const res = await request(app).get('/single/123');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('should accept requests with exactly the maximum number of parameters', async () => {
+    const res = await request(app).get('/exact/1/2/3/4/5');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('should reject requests with more than the allowed number of parameters', async () => {
+    const start = Date.now();
+    const res = await request(app).get('/many/1/2/3/4/5/6');
+    const end = Date.now();
+    
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    // Ensure the request returns quickly without catastrophic backtracking
+    expect(end - start).toBeLessThan(200);
+  });
+
+  it('should reject requests with a parameter that exceeds the maximum length', async () => {
+    const longParam = 'a'.repeat(201);
+    const start = Date.now();
+    const res = await request(app).get(`/single/${longParam}`);
+    const end = Date.now();
+
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(end - start).toBeLessThan(200);
+  });
+
+  it('should accept requests with a parameter at exactly the maximum length', async () => {
+    const maxParam = 'a'.repeat(200);
+    const res = await request(app).get(`/single/${maxParam}`);
+    
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('should reject requests with an excessively long path segment before route match', async () => {
+    const longSegment = 'a'.repeat(201);
+    const start = Date.now();
+    const res = await request(app).get(`/global/${longSegment}`);
+    const end = Date.now();
+
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(end - start).toBeLessThan(200);
+  });
+});


### PR DESCRIPTION
This PR implements server-side validation middleware to mitigate the ReDoS vulnerability in `path-to-regexp` (<0.1.13) used by Express. It adds a `paramLimit` middleware to cap the number of path parameters and the length of any parameter, stopping catastrophic backtracking before it exhausts CPU resources.

### Implemented Changes
1. Created `paramLimit` middleware to enforce constraints on `req.params` and raw path segments.
2. Applied the middleware to `userRoutes.ts` and `projectRoutes.ts` as specified by the plan.
3. Added comprehensive unit and integration tests under `test/cve-mitigation.test.ts` to assert <200ms response time on pathological payloads.

### Important Notes for the Operator
- **Action Required**: The plan requires applying this middleware to *all* route files in `services/gateway/src/routes/` containing path parameters. Only `userRoutes.ts` and `projectRoutes.ts` were included in the locked file list. Please manually extend this to the other routes.
- **File Naming Standards**: The plan explicitly specified camelCase file names (`paramLimit.ts`, `userRoutes.ts`, `projectRoutes.ts`), which violates the project's Phase 2B kebab-case naming standard. Because the Developer Autopilot strictly enforces the provided locked file list and will reject unauthorized paths, these files were created with the requested camelCase names. You may need to rename these files to `param-limit.ts`, `user-routes.ts`, and `project-routes.ts` (and update imports) to satisfy CI.