### PR TITLE
DEV-AUTOPILOT: Mitigate path-to-regexp ReDoS with param limit middleware

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,24 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    if (req.params) {
+      const keys = Object.keys(req.params);
+      
+      if (keys.length > maxParams) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters' });
+        return;
+      }
+      
+      for (const key of keys) {
+        const val = req.params[key];
+        if (typeof val === 'string' && val.length > maxLength) {
+          res.status(400).json({ ok: false, error: 'Path parameter too long' });
+          return;
+        }
+      }
+    }
+    
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+  
+  return res.json({ ok: true, data: { projectId: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:id', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+  
+  return res.json({ ok: true, data: { id: req.params.id } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,47 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - paramLimit middleware', () => {
+  const app = express();
+  
+  app.use(limitPathParams(5, 200));
+  
+  app.get('/test/:a/:b/:c/:d/:e/:f', (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  app.get('/test/:a', (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  it('should return 400 when too many path parameters are provided', async () => {
+    const start = Date.now();
+    const response = await request(app).get('/test/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+    
+    expect(response.status).toBe(400);
+    expect(response.body.ok).toBe(false);
+    expect(response.body.error).toBe('Too many path parameters');
+    expect(duration).toBeLessThan(500);
+  });
+
+  it('should return 400 when a path parameter is too long', async () => {
+    const longParam = 'a'.repeat(201);
+    const start = Date.now();
+    const response = await request(app).get(`/test/${longParam}`);
+    const duration = Date.now() - start;
+    
+    expect(response.status).toBe(400);
+    expect(response.body.ok).toBe(false);
+    expect(response.body.error).toBe('Path parameter too long');
+    expect(duration).toBeLessThan(500);
+  });
+
+  it('should pass when parameters are within limits', async () => {
+    const response = await request(app).get('/test/valid');
+    
+    expect(response.status).toBe(200);
+    expect(response.body.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
Implements server-side validation middleware to mitigate the ReDoS vulnerability in `path-to-regexp` < 0.1.13 by capping the number of path parameters and their maximum length.

### Changes
- Created `paramLimit` middleware that limits path parameter count to 5 and max length to 200 characters.
- Applied the `paramLimit` middleware to `userRoutes.ts` and `projectRoutes.ts`.
- Added unit and integration tests in `cve-mitigation.test.ts` to assert 400 Bad Request responses on violations and ensure safe execution times.

### ⚠️ Notes for Operator
- **File Naming Convention**: The locked file list provided for this execution mandated creating `paramLimit.ts`, `userRoutes.ts`, and `projectRoutes.ts` using camelCase. This will violate the Phase 2B Naming Standards check, which enforces kebab-case (`param-limit.ts`, `user-routes.ts`). Please manually rename these files and update their import statements to pass the CI phase.
- **Route Discovery**: This PR applies the mitigation to `userRoutes` and `projectRoutes`. You must manually discover and apply `limitPathParams()` to any other route files under `services/gateway/src/routes/` that utilize path parameters.
- **Permanent Fix**: This is a runtime mitigation. The underlying CVE fix still requires a separate PR to bump `path-to-regexp` (via `express` updates or overrides) in the `package.json` files for both `services/oasis-projector` and `services/gateway`.