### PR TITLE
DEV-AUTOPILOT: Mitigate path-to-regexp ReDoS CVE via param middleware

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,43 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // 1. Validate already parsed req.params (e.g., if mounted as route-specific middleware)
+    const keys = Object.keys(req.params);
+    if (keys.length > maxParams) {
+      res.status(400).json({ ok: false, error: 'Too many path parameters' });
+      return;
+    }
+
+    for (const key of keys) {
+      const val = req.params[key];
+      if (val && val.length > maxLength) {
+        res.status(400).json({ ok: false, error: 'Path parameter too long' });
+        return;
+      }
+    }
+
+    // 2. Validate raw path segments to prevent ReDoS before route matching occurs.
+    // Express route matching is vulnerable to catastrophic backtracking with long segments.
+    // Checking req.path catches malicious payloads before they hit vulnerable path-to-regexp matching.
+    const segments = req.path.split('/').filter(Boolean);
+    
+    // Enforce max length on any raw segment to stop the ReDoS backtrack explosion.
+    for (const segment of segments) {
+      if (segment.length > maxLength) {
+        res.status(400).json({ ok: false, error: 'Path parameter too long' });
+        return;
+      }
+    }
+
+    // Prevent excessive segments overall to stop exponential backtracking complexity.
+    // We use a safe padding relative to maxParams to account for static path prefixes.
+    const maxTotalSegments = maxParams + 10; 
+    if (segments.length > maxTotalSegments) {
+      res.status(400).json({ ok: false, error: 'Too many path parameters' });
+      return;
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,18 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply middleware to limit path params and mitigate ReDoS
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  return res.json({ ok: true, data: { projectId: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,18 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply middleware to limit path params and mitigate ReDoS
+router.use(limitPathParams());
+
+router.get('/:userId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  return res.json({ ok: true, data: { userId: req.params.userId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,72 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - ReDoS in path-to-regexp', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = express();
+    const router = express.Router();
+    
+    // Mount middleware globally for the router to test raw path length/segment validation
+    router.use(limitPathParams(5, 200));
+
+    // Normal route
+    router.get('/passthrough/:a/:b', (req: Request, res: Response) => {
+      res.status(200).json({ ok: true, data: req.params });
+    });
+
+    // Malicious route: we apply the middleware AGAIN locally so req.params is fully populated
+    // This explicitly tests the req.params parsing behavior requested in the plan.
+    router.get('/malicious/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.status(200).json({ ok: true });
+    });
+
+    // Long param route
+    router.get('/long/:a', (req: Request, res: Response) => {
+      res.status(200).json({ ok: true });
+    });
+
+    app.use('/', router);
+  });
+
+  it('should allow normal requests with acceptable number of path parameters', async () => {
+    const res = await request(app).get('/passthrough/val1/val2');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('should reject requests with too many path parameters (via req.params)', async () => {
+    const start = Date.now();
+    const res = await request(app).get('/malicious/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+    
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters');
+    // Ensure response is quick to verify mitigation
+    expect(duration).toBeLessThan(500);
+  });
+
+  it('should reject requests with exceedingly long path parameters (via raw path)', async () => {
+    const longParam = 'a'.repeat(201);
+    const start = Date.now();
+    const res = await request(app).get(`/long/${longParam}`);
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Path parameter too long');
+    expect(duration).toBeLessThan(500);
+  });
+
+  it('should reject requests with too many raw path segments to prevent ReDoS', async () => {
+    // 5 params + 10 padding static segments limit = 15. We send 17 segments.
+    const start = Date.now();
+    const res = await request(app).get('/a/b/c/d/e/f/g/h/i/j/k/l/m/n/o/p/q');
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters');
+    expect(duration).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
This PR implements a server-side validation middleware `limitPathParams` in the gateway to mitigate a Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (< 0.1.13) used transitively by Express.

By capping the maximum number of path parameters (default 5) and the length of any parameter value (default 200 characters), we prevent the exponential backtracking that triggers the ReDoS. This limits the attack surface while we await a direct dependency update.

### Files modified:
- `services/gateway/src/routes/middleware/paramLimit.ts`
- `services/gateway/src/routes/v1/userRoutes.ts`
- `services/gateway/src/routes/v1/projectRoutes.ts`
- `services/gateway/test/cve-mitigation.test.ts`

### Notes to human operator
- **Naming Conventions Alert**: The execution plan strict-locked the filenames using `camelCase` (`paramLimit.ts`, `userRoutes.ts`, `projectRoutes.ts`). However, Vitana codebase conventions require `kebab-case`. Due to rigid safety constraints prohibiting the emission of files outside the locked list, I have strictly emitted the `camelCase` files. **You will likely need to rename these files to pass the `Enforce Phase 2B Naming Standards` CI check.**
- The middleware must also be applied to all other relevant route files under `services/gateway/src/routes/`. The scope of this plan only included `userRoutes` and `projectRoutes`. Please verify other routes.
- The `package.json` updates to bump `express` / `path-to-regexp` will still need to happen in a subsequent PR.