### PR TITLE
DEV-AUTOPILOT: Add middleware to mitigate path-to-regexp ReDoS vulnerability

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,36 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+/**
+ * Middleware to mitigate ReDoS vulnerabilities in path-to-regexp by enforcing limits
+ * on the number and length of path parameters.
+ * 
+ * @param maxParams Maximum number of allowed path parameters.
+ * @param maxLength Maximum allowed string length for any single path parameter.
+ */
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const params = req.params || {};
+    const keys = Object.keys(params);
+
+    if (keys.length > maxParams) {
+      res.status(400).json({
+        ok: false,
+        error: 'Too many path parameters'
+      });
+      return;
+    }
+
+    for (const key of keys) {
+      const value = params[key];
+      if (value && typeof value === 'string' && value.length > maxLength) {
+        res.status(400).json({
+          ok: false,
+          error: 'Path parameter too long'
+        });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,16 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply ReDoS mitigation middleware
+router.use(limitPathParams());
+
+router.get('/:projectId', (req: Request, res: Response) => {
+  return res.json({
+    ok: true,
+    data: { projectId: req.params.projectId }
+  });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,16 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply ReDoS mitigation middleware
+router.use(limitPathParams());
+
+router.get('/:id', (req: Request, res: Response) => {
+  return res.json({
+    ok: true,
+    data: { userId: req.params.id }
+  });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,49 @@
+import request from 'supertest';
+import express from 'express';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - limitPathParams middleware', () => {
+  const app = express();
+  
+  // Routes for testing different parameter lengths and counts
+  app.use('/test-route/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req, res) => {
+    res.json({ ok: true });
+  });
+
+  app.use('/short-route/:a/:b', limitPathParams(5, 200), (req, res) => {
+    res.json({ ok: true });
+  });
+
+  it('should allow valid requests with parameters well within limits', async () => {
+    const res = await request(app).get('/short-route/123/456');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('should reject requests with too many path parameters', async () => {
+    const start = Date.now();
+    const res = await request(app).get('/test-route/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+    
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('Too many path parameters');
+    
+    // Ensure the rejection is fast (avoids catastrophic backtracking hang)
+    expect(duration).toBeLessThan(500);
+  });
+
+  it('should reject requests with path parameters that exceed the max length', async () => {
+    const longParam = 'a'.repeat(201);
+    const start = Date.now();
+    const res = await request(app).get(`/short-route/123/${longParam}`);
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('Path parameter too long');
+
+    // Ensure the rejection is fast
+    expect(duration).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
Addresses the ReDoS vulnerability in `path-to-regexp` (< 0.1.13) by adding a server-side parameter validation middleware. 

This PR implements `limitPathParams` to ensure any matched path parameters do not exceed a safe count threshold or length limit, reducing the attack surface for backtracking CPU exhaustion until the transitive dependency can be bumped in `package.json`.

**Notes on implementation:**
- Created `paramLimit` middleware to check `req.params` against size and count bounds.
- Applied the mitigation to `userRoutes` and `projectRoutes` (scaffolded to demonstrate usage).
- Included unit tests to verify the limits are enforced accurately.

*(Note: The plan explicitly required creating `paramLimit.ts`, `userRoutes.ts`, and `projectRoutes.ts`. While the codebase conventions favor kebab-case, the filenames were strictly generated according to the `LOCKED FILE LIST` constraint. If kebab-case names like `param-limit.ts` are preferred, this can be renamed in a follow-up PR where the locked list is adjusted.)*