### PR TITLE
DEV-AUTOPILOT: Implement paramLimit middleware for ReDoS mitigation

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,26 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return function (req: Request, res: Response, next: NextFunction): void {
+    if (!req.params) {
+      next();
+      return;
+    }
+
+    const keys = Object.keys(req.params);
+    if (keys.length > maxParams) {
+      res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    for (const key of keys) {
+      const val = req.params[key];
+      if (typeof val === 'string' && val.length > maxLength) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,12 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:projectId', (req: Request, res: Response) => {
+  return res.json({ ok: true, data: { projectId: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,12 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:userId', (req: Request, res: Response) => {
+  return res.json({ ok: true, data: { userId: req.params.userId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,54 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE-2024-4068 Mitigation - paramLimit', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    
+    // Test 1: Route with multiple params
+    app.get('/test/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+    
+    // Test 2: Route for long param
+    app.get('/long/:a', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+    
+    // Test 3: Valid request with 2 params
+    app.get('/valid/:a/:b', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+  });
+
+  it('Test 1: confirm 400 when >5 params', async () => {
+    const res = await request(app).get('/test/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('Test 2: confirm 400 when param >200 chars', async () => {
+    const longStr = 'a'.repeat(201);
+    const res = await request(app).get(`/long/${longStr}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('Test 3: Valid request with 2 params passes', async () => {
+    const res = await request(app).get('/valid/1/2');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('Integration test: assert response time <500ms', async () => {
+    const start = Date.now();
+    const res = await request(app).get('/test/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+    
+    expect(res.status).toBe(400);
+    expect(duration).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
Addresses the ReDoS vulnerability in `path-to-regexp` used by `express` by introducing a `paramLimit` middleware to cap the number of path parameters and their maximum length.

**NOTE on file naming**: The plan specifies camelCase filenames for `paramLimit.ts`, `userRoutes.ts`, and `projectRoutes.ts` in the LOCKED FILE LIST. To comply with the strict locked file check (which requires exact verbatim character-for-character paths), these files were created with the camelCase names. However, this violates the `Enforce Phase 2B Naming Standards` CI check which expects kebab-case. A follow-up PR or rename may be necessary to fix the naming convention.

**Plan executed:**
- Created `services/gateway/src/routes/middleware/paramLimit.ts` exporting `limitPathParams(maxParams, maxLength)`.
- Applied middleware to candidate route files `services/gateway/src/routes/v1/userRoutes.ts` and `services/gateway/src/routes/v1/projectRoutes.ts`.
- Added unit and integration tests in `services/gateway/test/cve-mitigation.test.ts`.

Other route files not listed in the plan may also require applying this middleware.