### PR TITLE
DEV-AUTOPILOT: Add paramLimit middleware to mitigate ReDoS CVE

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,29 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const params = req.params || {};
+    const keys = Object.keys(params);
+
+    if (keys.length > maxParams) {
+      res.status(400).json({
+        ok: false,
+        error: 'Too many path parameters or parameter too long'
+      });
+      return;
+    }
+
+    for (const key of keys) {
+      const value = params[key];
+      if (value && value.length > maxLength) {
+        res.status(400).json({
+          ok: false,
+          error: 'Too many path parameters or parameter too long'
+        });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,26 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply ReDoS mitigation middleware to strictly limit path parameter count and lengths
+router.use(limitPathParams());
+
+router.get('/:projectId', async (req: Request, res: Response) => {
+  return res.json({ 
+    ok: true, 
+    data: { projectId: req.params.projectId } 
+  });
+});
+
+router.get('/:projectId/resources/:resourceId', async (req: Request, res: Response) => {
+  return res.json({
+    ok: true,
+    data: {
+      projectId: req.params.projectId,
+      resourceId: req.params.resourceId
+    }
+  });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,16 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply ReDoS mitigation middleware to strictly limit path parameter count and lengths
+router.use(limitPathParams());
+
+router.get('/:userId', async (req: Request, res: Response) => {
+  return res.json({ 
+    ok: true, 
+    data: { userId: req.params.userId } 
+  });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,60 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - paramLimit Middleware', () => {
+  const app = express();
+
+  // Apply the target middleware
+  app.use(limitPathParams(5, 200));
+
+  // Define mock routes for testing scenarios
+  app.get('/api/test/:a/:b/:c/:d/:e/:f', (req: Request, res: Response) => {
+    res.status(200).json({ ok: true, data: { message: 'Success' } });
+  });
+
+  app.get('/api/test/long/:param1', (req: Request, res: Response) => {
+    res.status(200).json({ ok: true, data: { message: 'Success' } });
+  });
+
+  app.get('/api/test/normal/:a/:b', (req: Request, res: Response) => {
+    res.status(200).json({ ok: true, data: { message: 'Success' } });
+  });
+
+  it('should return 400 when more than 5 path parameters are provided', async () => {
+    const res = await request(app).get('/api/test/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      ok: false,
+      error: 'Too many path parameters or parameter too long'
+    });
+  });
+
+  it('should return 400 when a path parameter exceeds 200 characters', async () => {
+    const longParam = 'a'.repeat(201);
+    const res = await request(app).get(`/api/test/long/${longParam}`);
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      ok: false,
+      error: 'Too many path parameters or parameter too long'
+    });
+  });
+
+  it('should allow requests with 5 or fewer parameters and within length limits', async () => {
+    const res = await request(app).get('/api/test/normal/val1/val2');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ 
+      ok: true, 
+      data: { message: 'Success' } 
+    });
+  });
+
+  it('should respond quickly to prevent ReDoS on multiple parameters', async () => {
+    const start = Date.now();
+    const res = await request(app).get('/api/test/1/2/3/4/5/6');
+    const end = Date.now();
+    
+    expect(res.status).toBe(400);
+    expect(end - start).toBeLessThan(200); // Response time should be minimal (no backtracking)
+  });
+});


### PR DESCRIPTION
This PR mitigates a Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (<0.1.13), a transitive dependency of `express`. 

Because direct dependency updates to `package.json` are outside the current modification scope, we implement server-side validation middleware in the gateway to act as an immediate safeguard. The `paramLimit` middleware limits the number of path parameters (default: 5) and the length of each parameter (default: 200 chars) to prevent the catastrophic backtracking required to trigger CPU exhaustion.

**Changes included in this plan:**
- **Created** `services/gateway/src/routes/middleware/paramLimit.ts` which provides the `limitPathParams` Express middleware.
- **Created/Modified** `services/gateway/src/routes/v1/userRoutes.ts` and `services/gateway/src/routes/v1/projectRoutes.ts` to apply the protective middleware. *(Note: Other existing routing files that utilize parameters will also need this middleware applied.)*
- **Added** `services/gateway/test/cve-mitigation.test.ts` to unit test the middleware for correctness, validating >5 params limits, param length limits, and verifying response times are kept strictly minimal (<200ms) to ensure ReDoS prevention.