### PR TITLE
DEV-AUTOPILOT: Add paramLimit middleware to mitigate path-to-regexp ReDoS

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,47 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+/**
+ * Middleware to mitigate CVE-2024-3651 (ReDoS in path-to-regexp).
+ * Limits the number and length of path parameters.
+ * Runs validation on both `req.params` (if populated by router)
+ * and the raw `req.path` segments (to protect against ReDoS prior to route matching).
+ */
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // 1. Check req.params if already populated (e.g. inline middleware)
+    const params = req.params || {};
+    const keys = Object.keys(params);
+
+    if (keys.length > maxParams) {
+      res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    for (const key of keys) {
+      const value = params[key];
+      if (value && value.length > maxLength) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    // 2. Fallback check on raw URL path segments to prevent ReDoS before route matching
+    // occurs in Express's vulnerable path-to-regexp router.
+    const pathSegments = req.path.split('/').filter(Boolean);
+
+    // Using maxParams + 10 to account for static segments in typical REST prefixes
+    if (pathSegments.length > maxParams + 10) {
+      res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    for (const segment of pathSegments) {
+      if (segment.length > maxLength) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,18 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { getSupabase } from '../../lib/supabase';
+import { requireAuth, AuthenticatedRequest } from '../../middleware/auth-supabase-jwt';
+
+const router = Router();
+
+// Mitigate CVE-2024-3651 ReDoS vulnerability
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  return res.json({ ok: true, data: { project_id: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,19 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { getSupabase } from '../../lib/supabase';
+import { requireAuth, AuthenticatedRequest } from '../../middleware/auth-supabase-jwt';
+
+const router = Router();
+
+// Mitigate CVE-2024-3651 ReDoS vulnerability
+router.use(limitPathParams());
+
+router.get('/:userId', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  const userId = req.identity?.user_id || req.params.userId;
+  return res.json({ ok: true, data: { user_id: userId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,54 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE-2024-3651 Mitigation: limitPathParams middleware', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+
+    // Global application mitigates attacks before route mapping
+    app.use(limitPathParams(5, 200));
+
+    app.get('/api/resource/:p1', (req: Request, res: Response) => {
+      res.status(200).json({ ok: true });
+    });
+
+    // Inline middleware testing evaluates req.params
+    app.get('/api/inline/:p1/:p2/:p3/:p4/:p5/:p6', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.status(200).json({ ok: true });
+    });
+  });
+
+  it('should allow normal requests with valid path parameters', async () => {
+    const res = await request(app).get('/api/resource/valid-id-123');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('should reject requests with >5 path parameters (inline check)', async () => {
+    const res = await request(app).get('/api/inline/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('should reject requests with path parameters >200 chars', async () => {
+    const longParam = 'a'.repeat(201);
+    const res = await request(app).get(`/api/resource/${longParam}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('should enforce limits quickly (< 200ms) for ReDoS payload attempts', async () => {
+    const start = Date.now();
+    // Simulating a deep path that might trigger ReDoS in vulnerable path-to-regexp versions
+    const maliciousPath = '/api/resource/' + Array(20).fill('a').join('/');
+    const res = await request(app).get(maliciousPath);
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(duration).toBeLessThan(200);
+  });
+});


### PR DESCRIPTION
This PR implements server-side validation middleware in the API Gateway to limit the number and length of path parameters. This mitigates the Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (< 0.1.13) which is transitively used by Express (CVE-2024-3651). 

**Changes included:**
* Implemented `limitPathParams` middleware which parses both `req.params` (when applied at the route level) and raw URL path segments (to pre-emptively drop requests prior to Express route resolution).
* Applied the middleware globally to the newly scaffolded `userRoutes.ts` and `projectRoutes.ts` routers.
* Added comprehensive integration tests covering ReDoS payload rejection and enforcing response times < 200ms for malicious paths.

**Operator follow-up notes:**
1. **Naming conventions:** The execution plan and locked file list explicitly mandated camelCase paths for `paramLimit.ts`, `userRoutes.ts`, and `projectRoutes.ts`. To pass the strict file-lock validation, they were created verbatim. A follow-up PR might be necessary to rename these to kebab-case (`param-limit.ts`, `user-routes.ts`, `project-routes.ts`) to satisfy the `Enforce Phase 2B Naming Standards` CI check.
2. **Extending mitigation:** The plan requires applying this mitigation across *all* relevant route files. The autopilot was scoped to modify only the two representative files provided in the locked list. Please ensure `router.use(limitPathParams())` is applied to remaining routers containing route variables.