### PR TITLE
DEV-AUTOPILOT: Mitigate ReDoS vulnerability in path-to-regexp

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,44 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // 1. Mitigate ReDoS by validating the raw path before Express route matching completes.
+    // This prevents deep path backtracking before path-to-regexp parses the route.
+    const rawPath = req.originalUrl ? req.originalUrl.split('?')[0] : req.url.split('?')[0];
+    const segments = rawPath.split('/').filter(Boolean);
+    
+    // Check lengths of raw segments
+    for (const segment of segments) {
+      if (segment.length > maxLength) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    // Heuristic: If an attacker sends deeply nested paths to trigger backtracking, reject it.
+    // Allows maxParams + a sensible buffer for static API prefixes (e.g., api/v1/users).
+    if (segments.length > maxParams + 5) {
+      res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    // 2. Validate explicit req.params (covers cases when mounted as route-level middleware)
+    if (req.params) {
+      const keys = Object.keys(req.params);
+      if (keys.length > maxParams) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+      
+      for (const key of keys) {
+        const val = req.params[key];
+        if (val && typeof val === 'string' && val.length > maxLength) {
+          res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+          return;
+        }
+      }
+    }
+    
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,20 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { getSupabase } from '../../lib/supabase';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+
+const router = Router();
+
+// Apply param limits globally on all project routes to mitigate path-to-regexp ReDoS
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  return res.json({ ok: true, data: { projectId: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,20 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { getSupabase } from '../../lib/supabase';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+
+const router = Router();
+
+// Apply param limits globally on all user routes to mitigate path-to-regexp ReDoS
+router.use(limitPathParams());
+
+router.get('/:userId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  return res.json({ ok: true, data: { userId: req.params.userId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,71 @@
+import request from 'supertest';
+import express, { Request, Response } from 'express';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE-2024-4068 ReDoS Mitigation - limitPathParams Middleware', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+
+    // Mount the middleware globally to test raw path inspection capabilities
+    app.use(limitPathParams(5, 200));
+
+    // Mount the middleware explicitly on routes to test req.params processing
+    const paramMw = limitPathParams(5, 200);
+
+    // Test route for multiple parameters
+    app.get('/test/:a/:b/:c/:d/:e/:f', paramMw, (req: Request, res: Response) => {
+      res.status(200).json({ ok: true });
+    });
+
+    // Test route for standard requests with valid constraints
+    app.get('/test/:a/:b', paramMw, (req: Request, res: Response) => {
+      res.status(200).json({ ok: true });
+    });
+    
+    // Test route for single parameter (useful for testing excessive length)
+    app.get('/single/:a', paramMw, (req: Request, res: Response) => {
+       res.status(200).json({ ok: true });
+    });
+  });
+
+  it('should return 400 when more than 5 path parameters are provided', async () => {
+    const start = Date.now();
+    const response = await request(app).get('/test/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+    
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ ok: false, error: 'Too many path parameters or parameter too long' });
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('should return 400 when a path parameter exceeds 200 characters', async () => {
+    const longParam = 'a'.repeat(201);
+    const response = await request(app).get(`/single/${longParam}`);
+    
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ ok: false, error: 'Too many path parameters or parameter too long' });
+  });
+
+  it('should pass through when parameters are within defined limits', async () => {
+    const response = await request(app).get('/test/val1/val2');
+    
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+  });
+
+  it('integration: pathological request designed to trigger ReDoS is rejected quickly', async () => {
+    const start = Date.now();
+    
+    // A deeply nested path constructed to hit catastrophic backtracking on vulnerable regex engines
+    // Our middleware should intercept the raw URI before matching finishes.
+    const response = await request(app).get('/api/v1/trigger/a/b/c/d/e/f/g/h/i/j/k/l?search=deep');
+    const duration = Date.now() - start;
+
+    expect(response.status).toBe(400);
+    // Enforce rejection is extremely fast without regex stalling CPU bounds
+    expect(duration).toBeLessThan(500); 
+  });
+});


### PR DESCRIPTION
Mitigates the ReDoS vulnerability in `path-to-regexp` (CVE-2024-4068) by restricting the maximum number and length of route path parameters before deep regex processing occurs.

- Adds the `paramLimit` middleware to defensively validate parameter dimensions (caps at 5 path parameters and 200 characters per parameter).
- Applies the middleware to `userRoutes` and `projectRoutes` to intercept excessive inputs.
- Validates both raw URI path segments (to prevent complex path parsing hangs) and explicitly parsed `req.params`.
- Incorporates integration and unit test suites confirming proper pass/reject logic and tightly bounded response times (<500ms).

*Note: The filenames (`paramLimit.ts`, `userRoutes.ts`, etc.) strictly follow the locked file list constraints mandated by the initial plan, despite the platform's general kebab-case file naming convention.*