### PR TITLE
DEV-AUTOPILOT: Mitigate path-to-regexp ReDoS via paramLimit middleware

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,42 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // 1. Manually check the raw path to protect against ReDoS BEFORE Express 
+    // triggers path-to-regexp route matching.
+    const segments = req.path.split('/').filter(Boolean);
+    for (const segment of segments) {
+      if (segment.length > maxLength) {
+        res.status(400).json({ 
+          ok: false, 
+          error: 'Too many path parameters or parameter too long' 
+        });
+        return;
+      }
+    }
+
+    // 2. Check req.params as per the mitigation plan requirements
+    // (useful when mounted on specific routes with route parameters).
+    const keys = Object.keys(req.params || {});
+    if (keys.length > maxParams) {
+      res.status(400).json({ 
+        ok: false, 
+        error: 'Too many path parameters or parameter too long' 
+      });
+      return;
+    }
+
+    for (const key of keys) {
+      const val = req.params[key];
+      if (typeof val === 'string' && val.length > maxLength) {
+        res.status(400).json({ 
+          ok: false, 
+          error: 'Too many path parameters or parameter too long' 
+        });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,18 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { limitPathParams } from '../middleware/paramLimit';
+import { getSupabase } from '../../lib/supabase';
+
+const router = Router();
+
+// Apply param limits to mitigate path-to-regexp ReDoS
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  return res.json({ ok: true, data: { projectId: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,18 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { limitPathParams } from '../middleware/paramLimit';
+import { getSupabase } from '../../lib/supabase';
+
+const router = Router();
+
+// Apply param limits to mitigate path-to-regexp ReDoS
+router.use(limitPathParams());
+
+router.get('/:userId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  return res.json({ ok: true, data: { userId: req.params.userId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,54 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE-2024 Mitigation: limitPathParams middleware', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = express();
+
+    // Directly apply middleware to a complex route to verify req.params limits
+    app.get('/resource/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    app.get('/resource/:a/:b', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    // Apply globally to verify raw segment length validation before matching
+    app.use(limitPathParams(5, 200));
+    app.get('/long-param/:a', (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+  });
+
+  it('should accept valid requests with <= 5 path parameters', async () => {
+    const res = await request(app).get('/resource/1/2');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it('should reject requests with > 5 path parameters', async () => {
+    const res = await request(app).get('/resource/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Too many path parameters/i);
+  });
+
+  it('should reject requests with path parameters exceeding max length', async () => {
+    const longParam = 'A'.repeat(205);
+    const res = await request(app).get(`/long-param/${longParam}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Too many path parameters/i);
+  });
+
+  it('should respond quickly to potentially pathological paths (ReDoS mitigation)', async () => {
+    const start = Date.now();
+    const res = await request(app).get('/resource/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(duration).toBeLessThan(200);
+  });
+});


### PR DESCRIPTION
Fix ReDoS vulnerability in `path-to-regexp` by implementing server-side param limit middleware.

This PR introduces mitigation for the ReDoS vulnerability in Express's `path-to-regexp` transitive dependency. Direct dependency updates are deferred to a separate package.json update plan, so we implement server-side validation middleware (`paramLimit.ts`) in the gateway as an immediate mitigation layer.

Modifications:
- Added `limitPathParams` middleware to cap the number of path parameters (max 5) and the length of each segment (max 200). It validates the raw path segments to prevent ReDoS from triggering during `path-to-regexp` route matching.
- Created `userRoutes.ts` and `projectRoutes.ts` as example API endpoints and applied the mitigation middleware to them.
- Added unit and integration tests (`cve-mitigation.test.ts`) to ensure that >5 params and long params are safely rejected, while valid paths passthrough effectively with short response times.

*Note for operator*: Other existing route files under `services/gateway/src/routes/` with path parameters will also need this middleware applied.