### PR TITLE
DEV-AUTOPILOT: Add paramLimit middleware to mitigate path-to-regexp ReDoS

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,41 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    // Secondary validation using RegExp on the raw URI to catch extremely long 
+    // segments before route matching if mounted at the top level
+    const url = req.url || '';
+    const segmentRegex = new RegExp(`/[^/?#]{${maxLength + 1},}`);
+    if (segmentRegex.test(url)) {
+      res.status(400).json({ 
+        ok: false, 
+        error: 'Too many path parameters or parameter too long' 
+      });
+      return;
+    }
+
+    const params = req.params || {};
+    const keys = Object.keys(params);
+
+    if (keys.length > maxParams) {
+      res.status(400).json({ 
+        ok: false, 
+        error: 'Too many path parameters or parameter too long' 
+      });
+      return;
+    }
+
+    for (const key of keys) {
+      const value = params[key];
+      if (typeof value === 'string' && value.length > maxLength) {
+        res.status(400).json({ 
+          ok: false, 
+          error: 'Too many path parameters or parameter too long' 
+        });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { requireAuth, AuthenticatedRequest } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  return res.json({ ok: true, data: { project_id: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { requireAuth, AuthenticatedRequest } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:userId', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  return res.json({ ok: true, data: { user_id: req.params.userId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,54 @@
+import express from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - paramLimit Middleware', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = express();
+    
+    // Mount globally to test raw URL regex fallback
+    app.use(limitPathParams(5, 200));
+
+    // Endpoint with 2 parameters
+    app.get('/api/normal/:a/:b', limitPathParams(5, 200), (req, res) => {
+      res.json({ ok: true });
+    });
+
+    // Endpoint with 6 parameters (exceeds limit), mount middleware to populate req.params
+    app.get('/api/resource/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req, res) => {
+      res.json({ ok: true });
+    });
+  });
+
+  it('should accept requests with acceptable parameter counts', async () => {
+    const response = await request(app).get('/api/normal/123/456');
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+  });
+
+  it('should reject requests with >5 path parameters', async () => {
+    const response = await request(app).get('/api/resource/1/2/3/4/5/6');
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('should reject requests with param longer than 200 chars', async () => {
+    const longParam = 'a'.repeat(201);
+    const response = await request(app).get(`/api/normal/123/${longParam}`);
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('should process potentially malicious request quickly without ReDoS', async () => {
+    const start = Date.now();
+    // Craft a request that might trigger ReDoS in unpatched systems
+    const pathologicalParam = 'a'.repeat(500);
+    const response = await request(app).get(`/api/resource/1/2/3/4/5/${pathologicalParam}`);
+    const duration = Date.now() - start;
+    
+    expect(response.status).toBe(400);
+    expect(duration).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
This PR implements server-side validation middleware to mitigate a Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (< 0.1.13) used transitively by `express` in the gateway service.

By adding a `paramLimit` middleware to route files that parse URL parameters, we restrict both the number of URL parameters (default 5) and the maximum length of any single parameter (default 200 characters). The middleware proactively validates the raw URL using a fast RegExp, and enforces the limits on populated `req.params`, avoiding the exponential backtracking that triggers the ReDoS during Express route matching.

*Note: The locked file list in the autopilot plan specifies camelCase file names (`paramLimit.ts`, `userRoutes.ts`, `projectRoutes.ts`). To comply strictly with the plan's exact path requirements, these specific file names are emitted verbatim, despite the Phase 2B naming standard enforcing kebab-case. A follow-up may be required to rename these to `param-limit.ts`, `user-routes.ts`, and `project-routes.ts`.*

Files touched:
- `services/gateway/src/routes/middleware/paramLimit.ts`
- `services/gateway/src/routes/v1/userRoutes.ts`
- `services/gateway/src/routes/v1/projectRoutes.ts`
- `services/gateway/test/cve-mitigation.test.ts`