### PR TITLE
DEV-AUTOPILOT: Mitigate path-to-regexp ReDoS via paramLimit middleware

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,28 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const keys = Object.keys(req.params);
+
+    if (keys.length > maxParams) {
+      res.status(400).json({
+        ok: false,
+        error: 'Too many path parameters or parameter too long'
+      });
+      return;
+    }
+
+    for (const key of keys) {
+      const val = req.params[key];
+      if (val && val.length > maxLength) {
+        res.status(400).json({
+          ok: false,
+          error: 'Too many path parameters or parameter too long'
+        });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,18 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply parameter limiting middleware to mitigate path-to-regexp ReDoS
+router.use(limitPathParams(5, 200));
+
+router.get('/:projectId', async (req: Request, res: Response) => {
+  return res.json({ 
+    ok: true, 
+    data: { 
+      project_id: req.params.projectId 
+    } 
+  });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,18 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply parameter limiting middleware to mitigate path-to-regexp ReDoS
+router.use(limitPathParams(5, 200));
+
+router.get('/:userId', async (req: Request, res: Response) => {
+  return res.json({ 
+    ok: true, 
+    data: { 
+      user_id: req.params.userId 
+    } 
+  });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,54 @@
+import express from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - ReDoS in path-to-regexp (paramLimit)', () => {
+  const app = express();
+
+  // Route with a normal amount of path parameters
+  app.get('/api/resource/:a/:b/:c', limitPathParams(5, 200), (req, res) => {
+    res.status(200).json({ ok: true, data: 'success' });
+  });
+
+  // Route deliberately setup to catch excess parameters to simulate deep nesting ReDoS vectors
+  app.get('/api/deep/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req, res) => {
+    res.status(200).json({ ok: true, data: 'success' });
+  });
+
+  // Route setup to capture a single parameter that might be too long
+  app.get('/api/long/:id', limitPathParams(5, 200), (req, res) => {
+    res.status(200).json({ ok: true, data: 'success' });
+  });
+
+  it('should allow valid requests with <= 5 parameters', async () => {
+    const start = Date.now();
+    const res = await request(app).get('/api/resource/1/2/3');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, data: 'success' });
+    expect(Date.now() - start).toBeLessThan(200);
+  });
+
+  it('should reject requests with more than 5 parameters', async () => {
+    const start = Date.now();
+    const res = await request(app).get('/api/deep/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      ok: false,
+      error: 'Too many path parameters or parameter too long'
+    });
+    // Integration bound: ensuring standard processing overhead doesn't stall CPU via backtracking
+    expect(Date.now() - start).toBeLessThan(500);
+  });
+
+  it('should reject requests with parameters exceeding max length', async () => {
+    const start = Date.now();
+    const longParam = 'x'.repeat(201);
+    const res = await request(app).get(`/api/long/${longParam}`);
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({
+      ok: false,
+      error: 'Too many path parameters or parameter too long'
+    });
+    expect(Date.now() - start).toBeLessThan(200);
+  });
+});


### PR DESCRIPTION
**Context**
A Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (< 0.1.13) allows attackers to cause catastrophic backtracking via requests with multiple, deeply nested, or extremely long route parameters, leading to CPU exhaustion.

**Changes**
As updating `package.json` dependencies directly is currently out of scope for this plan execution, this PR implements server-side validation middleware in the gateway to significantly reduce the attack surface. 

1. **`paramLimit.ts`**: New middleware function that intercepts `req.params`. It counts the number of path parameters and evaluates their lengths. If the defaults (5 parameters max, 200 characters max length) are exceeded, it short-circuits the request with a `400 Bad Request`.
2. **`userRoutes.ts` & `projectRoutes.ts`**: Included standard implementations applying the parameter limit middleware on the router level to cap parameters during typical REST fetches. *(Note: Operators must ensure this middleware is propagated to all relevant route files)*
3. **`cve-mitigation.test.ts`**: Test suite ensuring standard traffic passes unimpeded, while maliciously crafted multi-parameter or long-parameter URLs are rejected within acceptable response times (< 200ms) before tying up resources.

**Note on File Naming Conventions**
The system's `LOCKED FILE LIST` explicitly enforced camelCase naming for several files (`paramLimit.ts`, `userRoutes.ts`, `projectRoutes.ts`). To prevent the CI from failing the exact-path constraint or sending the ticket into self-heal, the locked paths were provided verbatim as required. The operator may need to align these to the strict kebab-case standards (`param-limit.ts`, etc.) manually or via a separate automated phase.