### PR TITLE
DEV-AUTOPILOT: Mitigate path-to-regexp ReDoS via paramLimit middleware

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,40 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    // 1. Standard check: evaluate explicitly matched route parameters
+    const keys = Object.keys(req.params || {});
+
+    if (keys.length > maxParams) {
+      return res.status(400).json({
+        ok: false,
+        error: 'Too many path parameters or parameter too long'
+      });
+    }
+
+    for (const key of keys) {
+      const val = req.params[key];
+      if (val && typeof val === 'string' && val.length > maxLength) {
+        return res.status(400).json({
+          ok: false,
+          error: 'Too many path parameters or parameter too long'
+        });
+      }
+    }
+
+    // 2. Global fallback: since Express defers req.params population until 
+    // the specific route definition matches, we examine raw URL segments.
+    // This mitigates CVE-2024-28176 before `path-to-regexp` executes deeply.
+    const segments = req.path.split('/').filter(Boolean);
+    for (const segment of segments) {
+      if (segment.length > maxLength) {
+        return res.status(400).json({
+          ok: false,
+          error: 'Too many path parameters or parameter too long'
+        });
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,19 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply parameter limiting to mitigate path-to-regexp ReDoS
+// Note: All route files with path parameters should apply this middleware.
+router.use(limitPathParams());
+
+router.get('/:id', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  return res.json({ ok: true, data: { project_id: req.params.id } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,19 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply parameter limiting to mitigate path-to-regexp ReDoS
+// Note: All route files with path parameters should apply this middleware.
+router.use(limitPathParams());
+
+router.get('/:id', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  return res.json({ ok: true, data: { user_id: req.params.id } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,54 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE-2024-28176 Mitigation - limitPathParams', () => {
+  const app = express();
+
+  // Express parses params per-route. To test req.params bounding globally
+  // we apply the middleware in the router definition.
+  const router = express.Router();
+  router.use(limitPathParams(5, 200));
+
+  router.get('/normal/:a/:b', (req: Request, res: Response) => {
+    res.json({ ok: true, data: req.params });
+  });
+
+  // Test global path segment length fallback
+  router.get('/long/:a', (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  app.use('/api', router);
+
+  // Apply middleware directly to test explicit parameter counting logic
+  app.get('/excessive/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  it('should pass normal requests', async () => {
+    const res = await request(app).get('/api/normal/1/2');
+    expect(res.status).toBe(200);
+  });
+
+  it('should reject requests with >5 path parameters and respond <200ms', async () => {
+    const start = Date.now();
+    const res = await request(app).get('/excessive/1/2/3/4/5/6');
+    const end = Date.now();
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(end - start).toBeLessThan(200);
+  });
+
+  it('should reject requests with a parameter >200 chars and respond <200ms', async () => {
+    const start = Date.now();
+    const longParam = 'x'.repeat(201);
+    const res = await request(app).get(`/api/long/${longParam}`);
+    const end = Date.now();
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(end - start).toBeLessThan(200);
+  });
+});


### PR DESCRIPTION
Mitigates CVE-2024-28176 (ReDoS in `path-to-regexp` < 0.1.13) by introducing a gateway middleware to constrain Express route parameters.

This implementation limits exponential backtracking by validating request paths:
- Rejects requests if path parameters exceed 5.
- Rejects requests if any path parameter or segment length exceeds 200 characters.
- Defends before `path-to-regexp` evaluation finishes by examining raw path segments globally.

The middleware is applied to `userRoutes.ts` and `projectRoutes.ts` as test candidates and verified through isolation and integration tests.

*Note: The locked file list of the plan dictates camelCase filenames (`paramLimit.ts`, `userRoutes.ts`, `projectRoutes.ts`) which typically violates standard kebab-case naming conventions. They are emitted exactly as requested to satisfy the required exact path patch validation.*