### PR TITLE
DEV-AUTOPILOT: Implement path parameter limits to mitigate Express ReDoS

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,44 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // 1. Pre-check the raw path to mitigate ReDoS before Express route parsing.
+    // path-to-regexp operates on the raw path, so bounding the segments prevents deeply 
+    // nested paths or overly long segments from reaching the vulnerable regex matcher.
+    if (req.path) {
+      const segments = req.path.split('/');
+      
+      if (segments.length > maxParams + 10) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+
+      for (const segment of segments) {
+        if (segment.length > maxLength) {
+          res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+          return;
+        }
+      }
+    }
+
+    // 2. Explicitly validate req.params (post route-match validation)
+    if (req.params) {
+      const keys = Object.keys(req.params);
+      
+      if (keys.length > maxParams) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+
+      for (const key of keys) {
+        const val = req.params[key];
+        if (val && String(val).length > maxLength) {
+          res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+          return;
+        }
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,31 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth, AuthenticatedRequest } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply CVE mitigation middleware to limit path parameters
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  const { projectId } = req.params;
+  const { data, error } = await supabase
+    .from('projects')
+    .select('*')
+    .eq('id', projectId)
+    .single();
+
+  if (error) {
+    return res.status(404).json({ ok: false, error: 'Project not found' });
+  }
+
+  return res.json({ ok: true, data });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,31 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth, AuthenticatedRequest } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply CVE mitigation middleware to limit path parameters
+router.use(limitPathParams());
+
+router.get('/:userId', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  const { userId } = req.params;
+  const { data, error } = await supabase
+    .from('users')
+    .select('*')
+    .eq('id', userId)
+    .single();
+
+  if (error) {
+    return res.status(404).json({ ok: false, error: 'User not found' });
+  }
+
+  return res.json({ ok: true, data });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,70 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - limitPathParams middleware ReDoS protection', () => {
+  const app = express();
+  
+  // Setup route with valid request parameters
+  app.get('/test/normal/:a/:b', limitPathParams(5, 200), (req: Request, res: Response) => {
+    res.json({ ok: true, data: req.params });
+  });
+
+  // Setup route with too many expected parameters
+  app.get('/test/many/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+    res.json({ ok: true, data: req.params });
+  });
+
+  // Setup route for testing parameter length rules
+  app.get('/test/long/:a', limitPathParams(5, 10), (req: Request, res: Response) => {
+    res.json({ ok: true, data: req.params });
+  });
+
+  // Setup router-level test
+  const router = express.Router();
+  router.use(limitPathParams(5, 200));
+  router.get('/nested/:a', (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+  app.use('/router', router);
+
+  it('should pass a normal request with <=5 params', async () => {
+    const res = await request(app).get('/test/normal/foo/bar');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('should reject request with >5 path params', async () => {
+    const start = Date.now();
+    const res = await request(app).get('/test/many/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+    
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    // Integration verification: ensures malicious payload resolves quickly (mitigating ReDoS)
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('should reject request with param length > threshold', async () => {
+    const longParam = 'a'.repeat(15);
+    const res = await request(app).get(`/test/long/${longParam}`);
+    
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('should reject deeply nested malicious path before Express matches the route', async () => {
+    const longParam = 'a'.repeat(250);
+    const start = Date.now();
+    // This evaluates against `req.path.split('/')` within the global router middleware
+    const res = await request(app).get(`/router/nested/${longParam}`);
+    const duration = Date.now() - start;
+    
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(200);
+  });
+});


### PR DESCRIPTION
This PR implements server-side validation middleware to mitigate a Regular Expression Denial of Service (ReDoS) vulnerability originating from the `path-to-regexp` package used transitively by Express.

By enforcing strict thresholds on the number of path parameters (max `5`) and the length of each segment/parameter (max `200` characters), we preemptively drop requests that could trigger catastrophic backtracking, mitigating the risk of CPU exhaustion.

**Files modified/created:**
- `services/gateway/src/routes/middleware/paramLimit.ts`: The ReDoS mitigation middleware.
- `services/gateway/src/routes/v1/userRoutes.ts` & `services/gateway/src/routes/v1/projectRoutes.ts`: Example routers applying the middleware.
- `services/gateway/test/cve-mitigation.test.ts`: Test coverage validating parameter limiting functionality and response time.

**⚠️ Operator Note on Naming Conventions:**
The execution plan requested file names using `camelCase` (e.g., `paramLimit.ts`, `userRoutes.ts`), which violates the Phase 2B standard (must be `kebab-case`). To adhere strictly to the locked file scope and avoid a post-LLM validation rejection, the autopilot generated the exact names specified in the plan. **Please rename these files** (e.g. `param-limit.ts`, `user-routes.ts`) before merge.

**⚠️ Operator Note on Application Scope:**
The plan required demonstrating the middleware application in two candidate routers (`userRoutes` and `projectRoutes`). Ensure that `router.use(limitPathParams())` or equivalent is manually applied to any other pre-existing route files in `services/gateway/src/routes/` as part of your follow-up actions.