### PR TITLE
DEV-AUTOPILOT: Add paramLimit middleware to mitigate ReDoS CVE

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,39 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    // 1. Validate route parameters extracted by Express (if applied directly at the route level)
+    const keys = Object.keys(req.params || {});
+
+    if (keys.length > maxParams) {
+      return res.status(400).json({
+        ok: false,
+        error: 'Too many path parameters or parameter too long'
+      });
+    }
+
+    for (const key of keys) {
+      if (req.params[key] && req.params[key].length > maxLength) {
+        return res.status(400).json({
+          ok: false,
+          error: 'Too many path parameters or parameter too long'
+        });
+      }
+    }
+
+    // 2. Validate raw path segments as an early safeguard
+    // This pre-emptively intercepts malicious paths before they hit vulnerable Express route matching
+    const segments = req.path.split('/').filter(Boolean);
+
+    for (const segment of segments) {
+      if (segment.length > maxLength) {
+        return res.status(400).json({
+          ok: false,
+          error: 'Too many path parameters or parameter too long'
+        });
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply the ReDoS mitigation middleware to all project routes
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  return res.json({ 
+    ok: true, 
+    data: { project_id: req.params.projectId } 
+  });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply the ReDoS mitigation middleware to all user routes
+router.use(limitPathParams());
+
+router.get('/:userId', requireAuth, async (req: Request, res: Response) => {
+  return res.json({ 
+    ok: true, 
+    data: { user_id: req.params.userId } 
+  });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,63 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - limitPathParams middleware', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+
+    // Bind middleware globally to test early segment-length safeguarding
+    app.use(limitPathParams(5, 200));
+
+    // Test route designed to validate req.params boundaries
+    app.get(
+      '/api/resource/:a/:b/:c/:d/:e/:f',
+      limitPathParams(5, 200),
+      (req: Request, res: Response) => {
+        res.json({ ok: true, data: req.params });
+      }
+    );
+
+    // Test route for valid traffic
+    app.get(
+      '/api/resource/:a/:b',
+      limitPathParams(5, 200),
+      (req: Request, res: Response) => {
+        res.json({ ok: true, data: req.params });
+      }
+    );
+  });
+
+  it('should allow valid requests (<= maxParams, <= maxLength)', async () => {
+    const res = await request(app).get('/api/resource/1/2');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('should reject requests with > maxParams (6 parameters)', async () => {
+    const res = await request(app).get('/api/resource/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('should reject requests with path parameters exceeding maxLength', async () => {
+    const longParam = 'a'.repeat(201);
+    const res = await request(app).get(`/api/resource/1/${longParam}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('integration: should reject pathological requests designed to trigger ReDoS quickly (<200ms)', async () => {
+    const start = Date.now();
+    // Generate a payload heavily exceeding the 200 character boundary
+    const pathologicalParam = 'a'.repeat(1000);
+    const res = await request(app).get(`/api/resource/1/${pathologicalParam}`);
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(duration).toBeLessThan(200);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+});


### PR DESCRIPTION
This PR addresses a Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (CVE mitigation) by implementing server-side validation middleware in the gateway to strictly limit the number and length of path parameters.

**Mitigation Details**:
- Introduced `limitPathParams` middleware that acts as a circuit breaker against deeply nested or pathologically long URL structures before Express hands them off to the vulnerable `path-to-regexp` engine.
- Binds globally via `router.use()` to intercept requests and caps maximum route parameters (default: 5) and maximum segment length (default: 200).
- Applied as test scaffolding to `userRoutes.ts` and `projectRoutes.ts`. *Note: The developer must manually extend this implementation to any other legacy routes exposing path parameters.*
- Includes comprehensive unit and integration tests via `supertest` guaranteeing correct rejection, correct passthrough, and <200ms response SLAs on pathological requests.

*Note to operator: The codebase conventions mandate kebab-case file names (e.g., `param-limit.ts`, `user-routes.ts`), but this PR strictly outputs camelCase filenames to comply with the explicitly specified locked file list validator. These may need to be renamed in a follow-up commit to pass CI Phase 2B checks.*