### PR TITLE
DEV-AUTOPILOT: Mitigate path-to-regexp ReDoS vulnerability

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,34 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // Phase 1: Validate raw path segments before route matching (prevent ReDoS)
+    if (req.path) {
+      const segments = req.path.split('/');
+      for (const segment of segments) {
+        if (segment.length > maxLength) {
+          res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+          return;
+        }
+      }
+    }
+
+    // Phase 2: Validate extracted params (if middleware is applied at the route level)
+    if (req.params) {
+      const keys = Object.keys(req.params);
+      if (keys.length > maxParams) {
+        res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+
+      for (const key of keys) {
+        if (req.params[key] && req.params[key].length > maxLength) {
+          res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+          return;
+        }
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,14 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+
+const router = Router();
+
+// Apply ReDoS mitigation middleware
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  return res.json({ ok: true, data: { project_id: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,14 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+
+const router = Router();
+
+// Apply ReDoS mitigation middleware
+router.use(limitPathParams());
+
+router.get('/:userId', requireAuth, async (req: Request, res: Response) => {
+  return res.json({ ok: true, data: { user_id: req.params.userId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,51 @@
+import express from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('paramLimit middleware (CVE Mitigation)', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    
+    // Apply middleware at the route level to test both path pre-check and req.params limits
+    app.get('/test/:a?/:b?/:c?/:d?/:e?/:f?', limitPathParams(5, 200), (req, res) => {
+      res.json({ ok: true });
+    });
+
+    app.get('/long/:id', limitPathParams(5, 200), (req, res) => {
+      res.json({ ok: true });
+    });
+  });
+
+  it('should allow valid requests (<=5 params)', async () => {
+    const res = await request(app).get('/test/1/2/3');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('should block requests with >5 params', async () => {
+    const res = await request(app).get('/test/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('should block requests with overly long parameters', async () => {
+    const longParam = 'a'.repeat(201);
+    const res = await request(app).get(`/long/${longParam}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('should block requests quickly and prevent ReDoS on pathological inputs', async () => {
+    const start = Date.now();
+    const longString = 'a'.repeat(500);
+    
+    const res = await request(app).get(`/test/${longString}`);
+    const duration = Date.now() - start;
+    
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(200);
+  });
+});


### PR DESCRIPTION
This PR introduces the `paramLimit` Express middleware to mitigate a Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (< 0.1.13). The middleware inspects inbound requests and limits both the maximum number of path parameters (default 5) and the maximum length of any path parameter (default 200). 

By failing requests early, we prevent catastrophic backtracking and CPU exhaustion in Express's route matching while a permanent dependency update is prepared out-of-band.

Files modified/created:
- `services/gateway/src/routes/middleware/paramLimit.ts`: The new mitigation middleware.
- `services/gateway/src/routes/v1/userRoutes.ts`: Applied the middleware.
- `services/gateway/src/routes/v1/projectRoutes.ts`: Applied the middleware.
- `services/gateway/test/cve-mitigation.test.ts`: Added tests verifying parameter limit checks.