### PR TITLE
DEV-AUTOPILOT: Mitigate path-to-regexp ReDoS via paramLimit middleware

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,27 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const keys = Object.keys(req.params || {});
+    
+    if (keys.length > maxParams) {
+      res.status(400).json({ 
+        ok: false, 
+        error: 'Too many path parameters or parameter too long' 
+      });
+      return;
+    }
+
+    for (const key of keys) {
+      if (req.params[key] && req.params[key].length > maxLength) {
+        res.status(400).json({ 
+          ok: false, 
+          error: 'Too many path parameters or parameter too long' 
+        });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+  
+  return res.json({ ok: true, data: { projectId: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:userId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+  
+  return res.json({ ok: true, data: { userId: req.params.userId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,47 @@
+import request from 'supertest';
+import express, { Request, Response } from 'express';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE-2024-XXXX Mitigation: paramLimit middleware', () => {
+  const app = express();
+  
+  app.get('/test/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  app.get('/test-long/:a', limitPathParams(5, 200), (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  app.get('/test-valid/:a/:b', limitPathParams(5, 200), (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  it('rejects requests with more than 5 path parameters', async () => {
+    const start = Date.now();
+    const res = await request(app).get('/test/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(500);
+  });
+
+  it('rejects requests with excessively long path parameters', async () => {
+    const longParam = 'a'.repeat(201);
+    const start = Date.now();
+    const res = await request(app).get(`/test-long/${longParam}`);
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(500);
+  });
+
+  it('allows valid requests to pass through', async () => {
+    const res = await request(app).get('/test-valid/hello/world');
+    
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
**Context**
A Regular Expression Denial of Service (ReDoS) vulnerability exists in `path-to-regexp` < 0.1.13, which is used transitively by Express. This PR mitigates the vulnerability by creating server-side validation middleware (`paramLimit.ts`) that strictly enforces boundaries on the maximum number of path parameters (default: 5) and the maximum length of any single parameter (default: 200). 

**Changes in this PR**
1. Added `services/gateway/src/routes/middleware/paramLimit.ts` which exposes the `limitPathParams` Express RequestHandler.
2. Applied the `limitPathParams()` middleware to candidate routes `userRoutes.ts` and `projectRoutes.ts` as per the plan.
3. Added unit/integration tests to ensure `limitPathParams` properly intercepts abusive payloads with execution times under bounded constraints.

*Note on Naming Conventions:* The files `paramLimit.ts`, `userRoutes.ts`, and `projectRoutes.ts` have been generated exactly with these camelCase names as mandated strictly by the locked file list in the execution plan to pass the strict post-LLM validation gate. They may violate the Phase 2B `kebab-case` naming standards and will likely need to be renamed in a follow-up commit to clear the CI check.