### PR TITLE
DEV-AUTOPILOT: Add paramLimit middleware to mitigate path-to-regexp ReDoS

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,27 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const params = req.params || {};
+    const keys = Object.keys(params);
+
+    if (keys.length > maxParams) {
+      return res.status(400).json({
+        ok: false,
+        error: 'Too many path parameters or parameter too long'
+      });
+    }
+
+    for (const key of keys) {
+      const val = params[key];
+      if (val && val.length > maxLength) {
+        return res.status(400).json({
+          ok: false,
+          error: 'Too many path parameters or parameter too long'
+        });
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,25 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply ReDoS mitigation middleware to all project routes
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  return res.json({ 
+    ok: true, 
+    data: { 
+      projectId: req.params.projectId 
+    } 
+  });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,25 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply ReDoS mitigation middleware to all user routes
+router.use(limitPathParams());
+
+router.get('/:userId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  return res.json({ 
+    ok: true, 
+    data: { 
+      userId: req.params.userId 
+    } 
+  });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,63 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - path-to-regexp ReDoS Middleware', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    
+    // Test route designed to match multiple path parameters to verify limits
+    app.get(
+      '/resource/:a/:b/:c/:d/:e/:f',
+      limitPathParams(5, 200),
+      (req: Request, res: Response) => {
+        res.json({ ok: true });
+      }
+    );
+
+    // Test route designed to enforce parameter length constraints
+    app.get(
+      '/resource/:a',
+      limitPathParams(5, 10),
+      (req: Request, res: Response) => {
+        res.json({ ok: true });
+      }
+    );
+  });
+
+  it('should reject requests with >5 path parameters (Returns 400 quickly)', async () => {
+    const start = Date.now();
+    // 6 consecutive path parameters triggers rejection
+    const response = await request(app).get('/resource/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      ok: false,
+      error: 'Too many path parameters or parameter too long'
+    });
+    // Ensure response is short-circuited and averts CPU exhaustion (fast response time)
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('should reject requests with path parameters exceeding maximum length', async () => {
+    // Generate pathological payload exceeding the defined max length of 10
+    const pathologicalParam = 'A'.repeat(15); 
+    const response = await request(app).get(`/resource/${pathologicalParam}`);
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      ok: false,
+      error: 'Too many path parameters or parameter too long'
+    });
+  });
+
+  it('should allow valid requests that abide by threshold limits', async () => {
+    const response = await request(app).get('/resource/valid');
+    
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+  });
+});


### PR DESCRIPTION
Implements `paramLimit` middleware to mitigate the `path-to-regexp` ReDoS vulnerability (CVE) affecting Express by capping the number of path parameters and their maximum lengths. This acts as a server-side runtime mitigation to avoid catastrophic backtracking and CPU exhaustion while the upstream dependencies are bumped separately.

Files touched:
- `services/gateway/src/routes/middleware/paramLimit.ts`
- `services/gateway/src/routes/v1/userRoutes.ts`
- `services/gateway/src/routes/v1/projectRoutes.ts`
- `services/gateway/test/cve-mitigation.test.ts`

**Note on File Naming Conventions:**
The autopilot plan explicitly specified file paths utilizing `camelCase` for TypeScript files (e.g. `paramLimit.ts`, `userRoutes.ts`). Because the validation requires strict character-for-character adherence to the plan's Locked File List, these files have been generated exactly as requested in the plan to bypass immediate rejection. This will likely trigger the Phase 2B Naming Standards check in CI, requiring a human operator to rename them to `kebab-case` and adjust imports appropriately prior to merging.