### PR TITLE
DEV-AUTOPILOT: Add parameter limit middleware to mitigate Express ReDoS

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,29 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const params = req.params || {};
+    const keys = Object.keys(params);
+
+    if (keys.length > maxParams) {
+      res.status(400).json({ 
+        ok: false, 
+        error: 'Too many path parameters' 
+      });
+      return;
+    }
+
+    for (const key of keys) {
+      const value = params[key];
+      if (typeof value === 'string' && value.length > maxLength) {
+        res.status(400).json({ 
+          ok: false, 
+          error: 'Path parameter too long' 
+        });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,16 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply ReDoS mitigation middleware
+router.use(limitPathParams());
+
+router.get('/:projectId', (req: Request, res: Response) => {
+  return res.json({ 
+    ok: true, 
+    data: { projectId: req.params.projectId } 
+  });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,16 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply ReDoS mitigation middleware
+router.use(limitPathParams());
+
+router.get('/:userId', (req: Request, res: Response) => {
+  return res.json({ 
+    ok: true, 
+    data: { userId: req.params.userId } 
+  });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,55 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - paramLimit Middleware', () => {
+  const app = express();
+
+  // Mount middleware with defaults: 5 max parameters, 200 max length
+  app.use(limitPathParams(5, 200));
+
+  // Dummy route specifically to test exceeding parameter counts
+  app.get('/api/test/:a/:b/:c/:d/:e/:f', (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  // Dummy route for valid parameter counts and lengths
+  app.get('/api/test2/:a', (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  it('should accept requests with acceptable parameter counts', async () => {
+    const response = await request(app).get('/api/test2/valid-param');
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+  });
+
+  it('should reject requests with >5 path parameters', async () => {
+    // Hits the >5 threshold boundary
+    const response = await request(app).get('/api/test/1/2/3/4/5/6');
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ 
+      ok: false, 
+      error: 'Too many path parameters' 
+    });
+  });
+
+  it('should reject requests with excessively long parameters', async () => {
+    const longParam = 'a'.repeat(250);
+    const response = await request(app).get(`/api/test2/${longParam}`);
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ 
+      ok: false, 
+      error: 'Path parameter too long' 
+    });
+  });
+
+  it('should reject ReDoS pathological request in under 200ms', async () => {
+    const start = Date.now();
+    const response = await request(app).get('/api/test/1/2/3/4/5/6');
+    const end = Date.now();
+
+    expect(response.status).toBe(400);
+    expect(end - start).toBeLessThan(200);
+  });
+});


### PR DESCRIPTION
This PR addresses the Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (< 0.1.13) used transitively by Express. As a runtime mitigation, we're introducing the `limitPathParams` middleware to cap the number of path parameters (default 5) and their maximum length (default 200). This proactively rejects complex path traversals that could lead to CPU exhaustion due to catastrophic backtracking. 

The middleware has been mocked and applied to `userRoutes` and `projectRoutes` per the provided plan.

**Note on Naming Conventions:**
The provided execution plan strictly locked the file targets as `paramLimit.ts`, `userRoutes.ts`, and `projectRoutes.ts`. To satisfy the post-LLM validator which mandates character-for-character adherence to the locked list, these files were created using camelCase rather than the required kebab-case standard (e.g. `param-limit.ts`). A follow-up commit or PR may be required to align these specific filenames with the `Enforce Phase 2B Naming Standards` CI check.

**Files modified:**
- `services/gateway/src/routes/middleware/paramLimit.ts`
- `services/gateway/src/routes/v1/userRoutes.ts`
- `services/gateway/src/routes/v1/projectRoutes.ts`
- `services/gateway/test/cve-mitigation.test.ts`