### PR TITLE
DEV-AUTOPILOT: Add paramLimit middleware to mitigate path-to-regexp ReDoS

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,33 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    // Primary mitigation: check populated route parameters (if mounted at router level)
+    const keys = Object.keys(req.params || {});
+    
+    if (keys.length > maxParams) {
+      res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    for (const key of keys) {
+      const val = req.params[key];
+      if (typeof val === 'string' && val.length > maxLength) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    // Secondary safeguard: check raw URL path segments to catch overly long parameters 
+    // upstream, preventing matching hangs even if mounted globally.
+    const pathSegments = req.path.split('/');
+    for (const segment of pathSegments) {
+      if (segment.length > maxLength) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,20 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply the parameter limit mitigation middleware to all project routes
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+  
+  return res.json({ ok: true, data: { projectId: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,20 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply the parameter limit mitigation middleware to all user routes
+router.use(limitPathParams());
+
+router.get('/:userId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+  
+  return res.json({ ok: true, data: { userId: req.params.userId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,63 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE-202X Mitigation: paramLimit middleware', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    
+    // We mount the middleware at the route level to ensure req.params is populated
+    // for testing the parameter count checks.
+    app.get('/test-many/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    app.get('/test-long/:a', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    app.get('/test-pass/:a/:b', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+  });
+
+  it('should accept requests with <= 5 path parameters of valid length', async () => {
+    const response = await request(app).get('/test-pass/123/456');
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+  });
+
+  it('should reject requests with > 5 path parameters', async () => {
+    const start = Date.now();
+    const response = await request(app).get('/test-many/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+    
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ ok: false, error: 'Too many path parameters or parameter too long' });
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('should reject requests with a parameter length > 200', async () => {
+    const longParam = 'a'.repeat(201);
+    const start = Date.now();
+    const response = await request(app).get(`/test-long/${longParam}`);
+    const duration = Date.now() - start;
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ ok: false, error: 'Too many path parameters or parameter too long' });
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('integration test: ReDoS pathological values short-circuit', async () => {
+    // Malicious request attempt: long parameter length to simulate potential backtracking
+    const longMaliciousParam = 'a'.repeat(300) + '!';
+    const start = Date.now();
+    const response = await request(app).get(`/test-long/${longMaliciousParam}`);
+    const duration = Date.now() - start;
+
+    expect(response.status).toBe(400);
+    expect(duration).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
This PR implements server-side validation middleware to mitigate the `path-to-regexp` ReDoS vulnerability in Express. It caps the number of route parameters and limits their individual lengths to prevent catastrophic backtracking.

**Note on File Naming Conventions**:
The original Dev Autopilot plan for this task used camelCase for file names (`paramLimit.ts`, `userRoutes.ts`, `projectRoutes.ts`). Because the execution engine strictly mandates 1:1 adherence to the locked file list, these files are created with the provided names to pass the post-LLM validation. The platform conventions require kebab-case, so the operator will need to rename these files to kebab-case prior to merging to satisfy the `Enforce Phase 2B Naming Standards` CI check.

**Files Created**:
- `services/gateway/src/routes/middleware/paramLimit.ts`
- `services/gateway/src/routes/v1/userRoutes.ts`
- `services/gateway/src/routes/v1/projectRoutes.ts`
- `services/gateway/test/cve-mitigation.test.ts`