### PR TITLE
DEV-AUTOPILOT: Implement paramLimit middleware to mitigate path-to-regexp ReDoS

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,28 @@
+import { Request, Response, NextFunction } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200) {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const params = req.params || {};
+    const keys = Object.keys(params);
+    
+    if (keys.length > maxParams) {
+      res.status(400).json({ 
+        ok: false, 
+        error: 'Too many path parameters or parameter too long' 
+      });
+      return;
+    }
+    
+    for (const key of keys) {
+      if (typeof params[key] === 'string' && params[key].length > maxLength) {
+        res.status(400).json({ 
+          ok: false, 
+          error: 'Too many path parameters or parameter too long' 
+        });
+        return;
+      }
+    }
+    
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:id', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  return res.json({ ok: true, data: { project_id: req.params.id } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:id', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  return res.json({ ok: true, data: { user_id: req.params.id } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,57 @@
+import request from 'supertest';
+import express, { Request, Response } from 'express';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - paramLimit middleware', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    
+    app.get('/test/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    app.get('/test-length/:a', limitPathParams(5, 10), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    app.get('/valid/:a/:b', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+  });
+
+  it('should reject requests with too many path parameters', async () => {
+    const res = await request(app).get('/test/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ 
+      ok: false, 
+      error: 'Too many path parameters or parameter too long' 
+    });
+  });
+
+  it('should reject requests with path parameters that are too long', async () => {
+    const res = await request(app).get('/test-length/12345678901');
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ 
+      ok: false, 
+      error: 'Too many path parameters or parameter too long' 
+    });
+  });
+
+  it('should allow valid requests', async () => {
+    const res = await request(app).get('/valid/1/2');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+  
+  it('integration test for fast response time on rejected requests', async () => {
+    const start = Date.now();
+    const res = await request(app).get('/test/1/2/3/4/5/6');
+    const end = Date.now();
+    
+    expect(res.status).toBe(400);
+    // Even pathological inputs should return quickly
+    expect(end - start).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
This PR addresses a Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (< 0.1.13) used transitively by `express`. Since bumping dependencies directly in `package.json` falls outside the permitted scope of this plan, we implement a server-side mitigation.

The new middleware `limitPathParams` caps the number of path parameters (default 5) and the string length of each parameter (default 200). Applying this middleware ensures we intercept requests before subsequent route handlers process them, restricting input size and limiting the exponential backtracking attack surface.

**Implementation Notes & Follow-ups for the Operator:**
- The requested execution enforces strict file paths via a `LOCKED FILE LIST`. These locked filenames (`paramLimit.ts`, `userRoutes.ts`, `projectRoutes.ts`) use `camelCase`, violating the Phase 2B `kebab-case` naming convention. A subsequent PR may be required to rename them if CI objects.
- The `paramLimit` middleware was applied to `userRoutes.ts` and `projectRoutes.ts` as specified by the plan. Please manually verify and apply this middleware to **all other** route files in `services/gateway/src/routes/` that utilize path parameters.
- The long-term fix requires bumping the `path-to-regexp` and/or `express` dependencies in both `services/gateway` and `services/oasis-projector`.