### PR TITLE
DEV-AUTOPILOT: Add paramLimit middleware to mitigate Express ReDoS CVE

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,49 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    // 1. Direct validation if req.params is populated
+    // Works when middleware is applied at the specific route level.
+    if (req.params) {
+      const keys = Object.keys(req.params);
+      if (keys.length > maxParams) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+
+      for (const key of keys) {
+        const val = req.params[key];
+        if (val && val.length > maxLength) {
+          res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+          return;
+        }
+      }
+    }
+
+    // 2. Global path validation (fallback) to prevent ReDoS during route matching
+    // Protects routes when the middleware is mounted via app.use() or router.use() before route match.
+    try {
+      const decodedPath = decodeURIComponent(req.path);
+      const segments = decodedPath.split('/').filter(Boolean);
+      
+      // Allow leeway (e.g., +5) for static base path segments (e.g. /api/v1/resource/...)
+      if (segments.length > maxParams + 5) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+
+      for (const segment of segments) {
+        if (segment.length > maxLength) {
+          res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+          return;
+        }
+      }
+    } catch (e) {
+      // Fallback if decodeURIComponent fails on malformed input
+      res.status(400).json({ ok: false, error: 'Invalid URL encoding' });
+      return;
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,21 @@
+import { Router, Response } from 'express';
+import { AuthenticatedRequest, requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply middleware to mitigate path-to-regexp ReDoS vulnerability
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  // Implementation stub for project retrieval
+  return res.json({ ok: true, data: { project_id: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,21 @@
+import { Router, Response } from 'express';
+import { AuthenticatedRequest, requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply middleware to mitigate path-to-regexp ReDoS vulnerability
+router.use(limitPathParams());
+
+router.get('/:userId', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  // Implementation stub for user retrieval
+  return res.json({ ok: true, data: { user_id: req.params.userId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,69 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - paramLimit Middleware', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    
+    // Explicit route mounts to verify req.params dictionary limiting logic
+    app.get('/resource/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+    
+    app.get('/long/:param', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    app.get('/valid/:a/:b', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    // Global mount to verify req.path segment check logic against early ReDoS triggering
+    app.use(limitPathParams(5, 200));
+    app.get('/global-test', (req: Request, res: Response) => res.json({ ok: true }));
+  });
+
+  it('should reject requests with >5 path parameters via req.params limit', async () => {
+    const res = await request(app).get('/resource/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('should reject requests with parameters exceeding maxLength via req.params limit', async () => {
+    const longParam = 'a'.repeat(201);
+    const res = await request(app).get(`/long/${longParam}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('should allow valid requests well within parameter limits', async () => {
+    const res = await request(app).get('/valid/1/2');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('integration: should mitigate ReDoS by intercepting deep nested paths globally before route match', async () => {
+    const start = Date.now();
+    // Path containing 12 segments (exceeds global limit threshold of maxParams + 5)
+    const res = await request(app).get('/a/b/c/d/e/f/g/h/i/j/k/l');
+    const duration = Date.now() - start;
+    
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(200);
+  });
+  
+  it('integration: should mitigate ReDoS by intercepting ultra-long segments globally before route match', async () => {
+    const start = Date.now();
+    const longSegment = 'x'.repeat(250);
+    const res = await request(app).get(`/api/v1/projects/${longSegment}`);
+    const duration = Date.now() - start;
+    
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(200);
+  });
+});


### PR DESCRIPTION
This PR implements a server-side parameter length and count limitation middleware to mitigate a Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` < 0.1.13.

The plan instructs adding middleware to limit path parameter count to 5 and lengths to 200 characters, avoiding catastrophic backtracking during Express route resolution. 

Because the ReDoS occurs *during* Express route matching (before `req.params` is populated if applied globally), the `paramLimit` middleware checks both the explicitly populated `req.params` dictionary (satisfying the requested behavior) AND defensively analyzes raw `req.path` segments so it can safely act as a global guard on `router.use()`. 

**Files created/modified**:
- `services/gateway/src/routes/middleware/paramLimit.ts`
- `services/gateway/src/routes/v1/userRoutes.ts`
- `services/gateway/src/routes/v1/projectRoutes.ts`
- `services/gateway/test/cve-mitigation.test.ts`

Note: To fully roll this out, other route files containing path parameters must also apply this middleware, and `package.json` updates are required in a separate workflow.