### PR TITLE
DEV-AUTOPILOT: Add middleware to mitigate path-to-regexp ReDoS

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,34 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    // Validate raw path segments to avoid vulnerable path-to-regexp matching
+    if (req.path) {
+      const segments = req.path.match(/[^/]+/g) || [];
+      for (const segment of segments) {
+        if (segment.length > maxLength) {
+          res.status(400).json({ ok: false, error: 'Path parameter too long' });
+          return;
+        }
+      }
+    }
+
+    // Strictly validate parsed req.params
+    const params = req.params || {};
+    const keys = Object.keys(params);
+
+    if (keys.length > maxParams) {
+      res.status(400).json({ ok: false, error: 'Too many path parameters' });
+      return;
+    }
+
+    for (const key of keys) {
+      if (params[key] && params[key].length > maxLength) {
+        res.status(400).json({ ok: false, error: 'Path parameter too long' });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+  
+  return res.json({ ok: true, data: { projectId: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:userId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+  
+  return res.json({ ok: true, data: { userId: req.params.userId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,55 @@
+import request from 'supertest';
+import express, { Request, Response } from 'express';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - limitPathParams middleware', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+    
+    // Mount globally to test path segment checks
+    app.use(limitPathParams(5, 200));
+
+    // Mount on specific routes to test req.params checks
+    app.get(
+      '/resource/:a/:b/:c/:d/:e/:f',
+      limitPathParams(5, 200),
+      (req: Request, res: Response) => {
+        res.json({ ok: true, params: req.params });
+      }
+    );
+
+    app.get(
+      '/resource/:a/:b',
+      limitPathParams(5, 200),
+      (req: Request, res: Response) => {
+        res.json({ ok: true, params: req.params });
+      }
+    );
+  });
+
+  it('should allow valid requests (passthrough)', async () => {
+    const res = await request(app).get('/resource/1/2');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('should reject requests with > 5 path parameters and respond in <200ms', async () => {
+    const start = Date.now();
+    const res = await request(app).get('/resource/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters');
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('should reject requests with parameters exceeding maxLength', async () => {
+    const longParam = 'a'.repeat(201);
+    const res = await request(app).get(`/resource/1/${longParam}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Path parameter too long');
+  });
+});


### PR DESCRIPTION
This PR introduces the `paramLimit` middleware to mitigate the `path-to-regexp` ReDoS vulnerability (CVE-2024-28176) by limiting the number of path parameters and their maximum length.

*Note: The newly created files use camelCase names (`paramLimit.ts`, `userRoutes.ts`, `projectRoutes.ts`) in order to strictly conform to the provided Locked File List, overriding the repository's standard kebab-case naming convention.*

**Changes**:
- `paramLimit.ts`: New middleware that validates `req.params` and `req.path` length using safe RegExps, rejecting excessive parameters or lengths with `400 Bad Request`.
- `userRoutes.ts` & `projectRoutes.ts`: Apply the new middleware to the Express routers.
- `cve-mitigation.test.ts`: Adds integration and unit tests verifying the protection blocks requests exceeding 5 path parameters or 200 characters in <200ms.