### PR TITLE
DEV-AUTOPILOT: Mitigate path-to-regexp ReDoS via paramLimit middleware

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,42 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (req.params) {
+      const keys = Object.keys(req.params);
+      
+      if (keys.length > maxParams) {
+        res.status(400).json({ 
+          ok: false, 
+          error: 'Too many path parameters or parameter too long' 
+        });
+        return;
+      }
+      
+      for (const key of keys) {
+        if (req.params[key] && req.params[key].length > maxLength) {
+          res.status(400).json({ 
+            ok: false, 
+            error: 'Too many path parameters or parameter too long' 
+          });
+          return;
+        }
+      }
+    }
+
+    if (req.path) {
+      const segments = req.path.split('/').filter(Boolean);
+      for (const segment of segments) {
+        if (segment.length > maxLength) {
+          res.status(400).json({ 
+            ok: false, 
+            error: 'Too many path parameters or parameter too long' 
+          });
+          return;
+        }
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,12 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:projectId', (req: Request, res: Response) => {
+  return res.json({ ok: true, data: { projectId: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,12 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:id', (req: Request, res: Response) => {
+  return res.json({ ok: true, data: { id: req.params.id } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,49 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+import userRoutes from '../src/routes/v1/userRoutes';
+import projectRoutes from '../src/routes/v1/projectRoutes';
+
+describe('CVE-2024 Mitigation: paramLimit middleware', () => {
+  const app = express();
+
+  app.use('/api/v1/users', userRoutes);
+  app.use('/api/v1/projects', projectRoutes);
+
+  app.get('/api/v1/resource/:a/:b/:c/:d/:e/:f?', limitPathParams(5, 200), (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  app.get('/api/v1/test/:a/:b', limitPathParams(5, 200), (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  it('should allow requests with <= 5 path parameters', async () => {
+    const res = await request(app).get('/api/v1/test/value1/value2');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('should reject requests with > 5 path parameters', async () => {
+    const res = await request(app).get('/api/v1/resource/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('should reject requests with parameter length > 200', async () => {
+    const longParam = 'a'.repeat(201);
+    const res = await request(app).get(`/api/v1/test/${longParam}/val`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('integration test: pathological request responds in < 500ms', async () => {
+    const start = Date.now();
+    const longMalicious = 'x'.repeat(250);
+    const res = await request(app).get(`/api/v1/resource/1/2/3/4/5/${longMalicious}`);
+    const duration = Date.now() - start;
+    
+    expect(res.status).toBe(400);
+    expect(duration).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
This PR implements server-side validation middleware to mitigate the ReDoS vulnerability in `path-to-regexp` < 0.1.13. 

- Created `paramLimit.ts` middleware that caps the number and length of path parameters. It parses both `req.params` and raw path segments to protect against matching exploitation.
- Applied `paramLimit` to example candidate routes `userRoutes.ts` and `projectRoutes.ts`.
- Added unit and integration tests in `cve-mitigation.test.ts` to verify the middleware allows legitimate traffic but blocks excessive or lengthy parameters quickly.

**Note to operator**: The plan specified camelCase file names (`paramLimit.ts`, `userRoutes.ts`, `projectRoutes.ts`) in the locked file list, which violates the Vitana Phase 2B Kebab-Case Naming Standards. Because the locked file list is strictly enforced during this execution phase, I emitted the files with the exact paths requested to avoid validation failure. Please rename these files to kebab-case (`param-limit.ts`, `user-routes.ts`, `project-routes.ts`) and update their imports before merging to pass CI. Additionally, verify this middleware is applied to all other relevant route files.