### PR TITLE
DEV-AUTOPILOT: Mitigate ReDoS via paramLimit middleware

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,22 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const keys = Object.keys(req.params || {});
+    
+    if (keys.length > maxParams) {
+      res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    for (const key of keys) {
+      const val = req.params[key];
+      if (typeof val === 'string' && val.length > maxLength) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,19 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  return res.json({ ok: true, data: { project_id: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,19 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:id', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  return res.json({ ok: true, data: { user_id: req.params.id } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,67 @@
+import express from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - paramLimit Middleware', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    
+    // Test route with > 5 params
+    app.get('/resource/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req, res) => {
+      res.json({ ok: true });
+    });
+
+    // Test route for long param
+    app.get('/resource/:a', limitPathParams(5, 200), (req, res) => {
+      res.json({ ok: true });
+    });
+
+    // Test route for valid
+    app.get('/resource/:a/:b', limitPathParams(5, 200), (req, res) => {
+      res.json({ ok: true });
+    });
+
+    // Test route using router.use pattern
+    const router = express.Router({ mergeParams: true });
+    router.use(limitPathParams(5, 200));
+    router.get('/', (req, res) => res.json({ ok: true }));
+    app.use('/test-router/:a/:b/:c/:d/:e/:f', router);
+  });
+
+  it('allows normal requests with <=5 path parameters', async () => {
+    const res = await request(app).get('/resource/1/2');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('rejects requests with >5 path parameters with 400 status', async () => {
+    const start = Date.now();
+    const res = await request(app).get('/resource/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+    
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(res.body.ok).toBe(false);
+    expect(duration).toBeLessThan(500);
+  });
+
+  it('rejects requests with path parameter length >200', async () => {
+    const longParam = 'x'.repeat(201);
+    const start = Date.now();
+    const res = await request(app).get(`/resource/${longParam}`);
+    const duration = Date.now() - start;
+    
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(res.body.ok).toBe(false);
+    expect(duration).toBeLessThan(500);
+  });
+
+  it('works correctly when applied via router.use on a mounted router', async () => {
+    const res = await request(app).get('/test-router/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+});


### PR DESCRIPTION
This PR implements a middleware `limitPathParams` to mitigate the ReDoS vulnerability in `path-to-regexp` < 0.1.13. 
It limits the number of path parameters to 5 and the maximum length of any path parameter to 200 characters.
This prevents exponential backtracking when processing overly complex or long paths. 
The middleware has been added to `userRoutes.ts` and `projectRoutes.ts` as examples, and should be applied to all route files containing path parameters.

Files modified/created:
- `services/gateway/src/routes/middleware/paramLimit.ts`
- `services/gateway/src/routes/v1/userRoutes.ts`
- `services/gateway/src/routes/v1/projectRoutes.ts`
- `services/gateway/test/cve-mitigation.test.ts`