### PR TITLE
DEV-AUTOPILOT: Add param limit middleware to mitigate ReDoS CVE

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,23 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const params = req.params || {};
+    const keys = Object.keys(params);
+
+    if (keys.length > maxParams) {
+      res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    for (const key of keys) {
+      const value = params[key];
+      if (value && value.length > maxLength) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,12 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:projectId', async (req: Request, res: Response) => {
+  return res.json({ ok: true, data: { project_id: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,12 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:userId', async (req: Request, res: Response) => {
+  return res.json({ ok: true, data: { user_id: req.params.userId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,64 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - paramLimit middleware', () => {
+  const app = express();
+  
+  app.get(
+    '/test/:a/:b/:c/:d/:e/:f',
+    limitPathParams(5, 200),
+    (req: Request, res: Response) => {
+      res.json({ ok: true });
+    }
+  );
+
+  app.get(
+    '/test-long/:a',
+    limitPathParams(5, 10),
+    (req: Request, res: Response) => {
+      res.json({ ok: true });
+    }
+  );
+
+  app.get(
+    '/test-valid/:a/:b',
+    limitPathParams(5, 200),
+    (req: Request, res: Response) => {
+      res.json({ ok: true });
+    }
+  );
+
+  it('returns 400 when there are >5 path parameters', async () => {
+    const start = Date.now();
+    const res = await request(app).get('/test/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+    
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('returns 400 when a parameter exceeds maxLength', async () => {
+    const res = await request(app).get('/test-long/thisisaverylongparameter');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('passes a valid request with <=5 parameters and acceptable lengths', async () => {
+    const res = await request(app).get('/test-valid/1/2');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+  
+  it('Integration test: short response time for ReDoS pathological values', async () => {
+    const start = Date.now();
+    // Craft a request that could cause ReDoS in vulnerable path-to-regexp versions
+    const pathological = 'a'.repeat(250); 
+    const res = await request(app).get(`/test/${pathological}/${pathological}/c/d/e/f`);
+    const duration = Date.now() - start;
+    
+    expect(res.status).toBe(400);
+    expect(duration).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
This PR implements a server-side validation middleware (`limitPathParams`) to mitigate a Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (< 0.1.13) used by Express. 

By limiting the number and length of path parameters, we reduce the attack surface and prevent catastrophic backtracking leading to CPU exhaustion.

**Plan execution details:**
- Created `paramLimit.ts` middleware to enforce `maxParams` and `maxLength` checks.
- Created representative route files `userRoutes.ts` and `projectRoutes.ts` with the middleware applied. *(Note: The plan requested these specific file names. While they violate the standard kebab-case naming conventions, they have been implemented exactly as defined in the plan's locked file list).*
- Added integration and unit tests in `cve-mitigation.test.ts` using `supertest`.