### PR TITLE
DEV-AUTOPILOT: Mitigate path-to-regexp ReDoS vulnerability in gateway

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,41 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    // 1. Strict limit on parsed path parameters 
+    // (Used when the middleware runs directly on a matched route)
+    const keys = Object.keys(req.params);
+    if (keys.length > maxParams) {
+      res.status(400).json({ ok: false, error: 'Too many path parameters' });
+      return;
+    }
+
+    for (const key of keys) {
+      if (req.params[key] && req.params[key].length > maxLength) {
+        res.status(400).json({ ok: false, error: 'Path parameter too long' });
+        return;
+      }
+    }
+
+    // 2. Pre-check on raw path segments 
+    // (Runs when middleware is applied globally via router.use(), stopping ReDoS 
+    // before the vulnerable path-to-regexp compilation/matching is executed)
+    const segments = req.path.split('/').filter(Boolean);
+    
+    for (const segment of segments) {
+      if (segment.length > maxLength) {
+        res.status(400).json({ ok: false, error: 'Path parameter too long' });
+        return;
+      }
+    }
+
+    // Apply a generous upper bound for total segments to avoid blocking valid deep 
+    // REST routes while stopping extreme backtracking paths.
+    if (segments.length > Math.max(maxParams + 10, 20)) {
+      res.status(400).json({ ok: false, error: 'Too many path parameters' });
+      return;
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,18 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+
+const router = Router();
+
+// Apply CVE mitigation middleware to prevent ReDoS via path-to-regexp
+router.use(limitPathParams());
+
+router.get('/', requireAuth, (req: Request, res: Response) => {
+  res.json({ ok: true, data: [] });
+});
+
+router.get('/:projectId', requireAuth, (req: Request, res: Response) => {
+  res.json({ ok: true, data: { projectId: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,18 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+
+const router = Router();
+
+// Apply CVE mitigation middleware to prevent ReDoS via path-to-regexp
+router.use(limitPathParams());
+
+router.get('/', requireAuth, (req: Request, res: Response) => {
+  res.json({ ok: true, data: [] });
+});
+
+router.get('/:userId', requireAuth, (req: Request, res: Response) => {
+  res.json({ ok: true, data: { userId: req.params.userId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,62 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - limitPathParams middleware', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = express();
+    const router = express.Router();
+    
+    // Mount globally to test pre-matching protection (raw path evaluation)
+    router.use(limitPathParams(5, 200));
+
+    router.get('/resource/:a', (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    // Mount directly on route to test req.params validation logic
+    router.get('/direct/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    app.use('/', router);
+  });
+
+  it('allows normal requests with <=5 parameters', async () => {
+    const res = await request(app).get('/resource/123');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it('rejects requests with >5 path parameters and responds within 200ms', async () => {
+    const start = Date.now();
+    // Tests req.params limits via direct route mapping
+    const res = await request(app).get('/direct/1/2/3/4/5/6');
+    const end = Date.now();
+    
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/too many path parameters/i);
+    expect(end - start).toBeLessThan(200);
+  });
+
+  it('rejects requests with a path parameter exceeding maxLength', async () => {
+    const longParam = 'a'.repeat(201);
+    const res = await request(app).get(`/resource/${longParam}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/parameter too long/i);
+  });
+
+  it('rejects extreme raw paths to protect path-to-regexp before matching', async () => {
+    const start = Date.now();
+    // Generates a deep backtracking path simulating a ReDoS payload
+    const maliciousPath = '/' + Array(25).fill('a').join('/');
+    const res = await request(app).get(maliciousPath);
+    const end = Date.now();
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/too many path parameters/i);
+    expect(end - start).toBeLessThan(200);
+  });
+});


### PR DESCRIPTION
This PR mitigates a Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (< 0.1.13) by implementing server-side path parameter validation in the gateway. This temporary middleware reduces the attack surface while the dependency can be bumped globally.

### Changes
- **`paramLimit.ts`**: Created a new Express middleware to enforce upper bounds on the number of path parameters (default 5) and the length of each segment/parameter (default 200). It inspects both `req.params` and raw path segments to guard against deep backtracking inputs before route matching evaluates them.
- **`userRoutes.ts` & `projectRoutes.ts`**: Bootstrapped representative route files integrating the new `limitPathParams()` middleware.
- **`cve-mitigation.test.ts`**: Added unit and integration tests to verify successful passthrough of valid requests and immediate `400` rejection (under 200ms) for overly deep/long paths.

**Note for Developers:** 
The plan detailed applying this mitigation to two representative files (`userRoutes.ts` and `projectRoutes.ts`). You must extend this change and apply `router.use(limitPathParams())` to all other relevant route files in `services/gateway/src/routes/` that contain path parameters. A complete fix also requires bumping `express` or `path-to-regexp` in `package.json` in a subsequent change.