### PR TITLE
DEV-AUTOPILOT: Add paramLimit middleware to mitigate ReDoS CVE

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,35 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const errorMsg = 'Too many path parameters or parameter too long';
+
+    // 1. Raw path validation to catch ReDoS before route matching
+    const longSegmentRegex = new RegExp(`[^/]{${maxLength + 1},}`);
+    if (longSegmentRegex.test(req.path)) {
+      return res.status(400).json({ ok: false, error: errorMsg });
+    }
+
+    const segmentCount = (req.path.match(/\//g) || []).length;
+    // Heuristic: If segments > maxParams * 3, it is suspiciously deep.
+    if (segmentCount > maxParams * 3) {
+      return res.status(400).json({ ok: false, error: errorMsg });
+    }
+
+    // 2. Parsed req.params validation (enforces limit post-matching or route-level)
+    if (req.params) {
+      const keys = Object.keys(req.params);
+      if (keys.length > maxParams) {
+        return res.status(400).json({ ok: false, error: errorMsg });
+      }
+      for (const key of keys) {
+        const val = req.params[key];
+        if (typeof val === 'string' && val.length > maxLength) {
+          return res.status(400).json({ ok: false, error: errorMsg });
+        }
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+  
+  return res.json({ ok: true, data: { project_id: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:userId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+  
+  return res.json({ ok: true, data: { user_id: req.params.userId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,60 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - paramLimit Middleware', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = express();
+    
+    // Mount globally
+    app.use(limitPathParams(5, 200));
+
+    // Mount on specific routes to ensure req.params logic is executed
+    app.get('/test/:a/:b', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    app.get('/test-many/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    app.get('/test-long/:a', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    app.get('/redos/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+  });
+
+  it('should accept valid requests with <= 5 parameters', async () => {
+    const res = await request(app).get('/test/1/2');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it('should reject requests with > 5 path params', async () => {
+    const res = await request(app).get('/test-many/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Too many path parameters/);
+  });
+
+  it('should reject requests with path param > 200 chars', async () => {
+    const longParam = 'A'.repeat(201);
+    const res = await request(app).get(`/test-long/${longParam}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Too many path parameters/);
+  });
+
+  it('should execute integration test quickly (prevent ReDoS)', async () => {
+    const start = Date.now();
+    const pathological = 'A'.repeat(201);
+    const res = await request(app).get(`/redos/1/2/3/4/5/${pathological}`);
+    const duration = Date.now() - start;
+    
+    expect(res.status).toBe(400);
+    expect(duration).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
This PR addresses the ReDoS vulnerability in `path-to-regexp` (<0.1.13) by implementing server-side validation middleware (`paramLimit.ts`). 

Since direct dependency updates are outside the permitted modification scope for this specific phase, this change introduces middleware to cap the number of path parameters and their maximum length. This bounds the regular expression evaluation and prevents the catastrophic backtracking that leads to CPU exhaustion.

### Changes
- **`services/gateway/src/routes/middleware/paramLimit.ts`**: Created the `limitPathParams` middleware to validate both `req.path` (preventative raw string limits) and `req.params` limits.
- **`services/gateway/src/routes/v1/userRoutes.ts`**: Added the middleware to user routes as a representative application.
- **`services/gateway/src/routes/v1/projectRoutes.ts`**: Added the middleware to project routes.
- **`services/gateway/test/cve-mitigation.test.ts`**: Added unit and integration tests to ensure the middleware effectively blocks pathological requests in <500ms.

> **Note**: This middleware should be applied to all relevant route files under `services/gateway/src/routes/` containing path parameters. The vulnerability will still be flagged by dependency scanners until a `package.json` update is applied out-of-band.