### PR TITLE
DEV-AUTOPILOT: Mitigate ReDoS in path-to-regexp via param limit middleware

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,28 @@
+import { Request, Response, NextFunction } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    // Validate raw path segments to protect against ReDoS before route matching
+    const segments = req.path.split('/');
+    for (const segment of segments) {
+      if (segment.length > maxLength) {
+        return res.status(400).json({ ok: false, error: 'Path parameter too long' });
+      }
+    }
+
+    // Validate req.params if available (e.g., when applied at the route level)
+    const keys = Object.keys(req.params || {});
+    if (keys.length > maxParams) {
+      return res.status(400).json({ ok: false, error: 'Too many path parameters' });
+    }
+
+    for (const key of keys) {
+      const val = req.params[key];
+      if (val && val.length > maxLength) {
+        return res.status(400).json({ ok: false, error: 'Path parameter too long' });
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Response } from 'express';
+import { requireAuth, AuthenticatedRequest } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  return res.json({ ok: true, data: { projectId: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Response } from 'express';
+import { requireAuth, AuthenticatedRequest } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:userId', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  return res.json({ ok: true, data: { userId: req.params.userId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,48 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE-2024-XXXXX path-to-regexp ReDoS mitigation', () => {
+  const app = express();
+
+  // Test req.params limits by applying directly to routes
+  app.get('/test/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  app.get('/test/:a/:b', limitPathParams(5, 200), (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  // Test global path segment length check
+  app.use(limitPathParams(5, 200));
+
+  app.get('/long/:id', (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  it('rejects requests with parameters that are too long', async () => {
+    const longParam = 'a'.repeat(201);
+    const response = await request(app).get(`/long/${longParam}`);
+    
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Path parameter too long');
+  });
+
+  it('rejects requests with too many parameters', async () => {
+    const startTime = Date.now();
+    const response = await request(app).get('/test/1/2/3/4/5/6');
+    const endTime = Date.now();
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Too many path parameters');
+    expect(endTime - startTime).toBeLessThan(200);
+  });
+
+  it('accepts valid requests', async () => {
+    const response = await request(app).get('/test/1/2');
+    
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+  });
+});


### PR DESCRIPTION
Mitigates the Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (< 0.1.13) used by Express. It introduces server-side validation middleware that caps both the number of route parameters and the maximum length of path segments to prevent the catastrophic backtracking CPU exhaustion before dependencies can be bumped.

- Created `paramLimit` middleware that limits path parameters to 5 by default, and limits any single segment length to 200 characters.
- Applied the middleware via `router.use(limitPathParams())` to new route files: `userRoutes.ts` and `projectRoutes.ts`.
- Included an integration test suite validating that malformed and maliciously long paths are quickly rejected with a `400 Bad Request` in <200ms.

*Note on file names: The locked file list in the plan specified camelCase file names (`paramLimit.ts`, `userRoutes.ts`, `projectRoutes.ts`). To comply with the strict instruction not to deviate from the locked list (or risk post-LLM validation failure), I have emitted them verbatim. If this conflicts with the `Enforce Phase 2B Naming Standards` CI check, these files will need to be manually renamed to kebab-case (e.g., `param-limit.ts`) and their imports adjusted.*