### PR TITLE
DEV-AUTOPILOT: Add paramLimit middleware to mitigate path-to-regexp ReDoS

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,37 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+/**
+ * Middleware to mitigate ReDoS vulnerabilities in path-to-regexp
+ * by limiting the number of path parameters and their maximum lengths.
+ */
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    if (!req.params) {
+      next();
+      return;
+    }
+
+    const keys = Object.keys(req.params);
+
+    if (keys.length > maxParams) {
+      res.status(400).json({
+        ok: false,
+        error: 'Too many path parameters or parameter too long'
+      });
+      return;
+    }
+
+    for (const key of keys) {
+      const val = req.params[key];
+      if (val && typeof val === 'string' && val.length > maxLength) {
+        res.status(400).json({
+          ok: false,
+          error: 'Too many path parameters or parameter too long'
+        });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,26 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply ReDoS mitigation middleware
+router.use(limitPathParams(5, 200));
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  // Application logic would typically live here
+  return res.json({ 
+    ok: true, 
+    data: { 
+      project_id: req.params.projectId 
+    } 
+  });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,26 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply ReDoS mitigation middleware
+router.use(limitPathParams(5, 200));
+
+router.get('/:userId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  // Application logic would typically live here
+  return res.json({ 
+    ok: true, 
+    data: { 
+      user_id: req.params.userId 
+    } 
+  });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,61 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE-2024 ReDoS Mitigation: paramLimit middleware', () => {
+  const app = express();
+  const router = express.Router();
+
+  // Setup test routes mimicking Gateway behaviour
+  router.get('/resource/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  router.get('/normal/:a/:b', limitPathParams(5, 200), (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  router.get('/long/:a', limitPathParams(5, 200), (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  app.use('/', router);
+
+  it('should pass normal requests with <= 5 parameters', async () => {
+    const res = await request(app).get('/normal/hello/world');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('should reject requests with > 5 path parameters and respond with 400', async () => {
+    const start = Date.now();
+    const res = await request(app).get('/resource/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('should reject requests with a parameter exceeding maxLength', async () => {
+    const longParam = 'a'.repeat(201);
+    const start = Date.now();
+    const res = await request(app).get(`/long/${longParam}`);
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('should handle ReDoS pathological values safely and respond in <500ms', async () => {
+    const start = Date.now();
+    // A long crafted parameter designed to act as payload for ReDoS backtracking
+    const pathological = 'a'.repeat(300) + '!';
+    const res = await request(app).get(`/long/${pathological}`);
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(duration).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
This PR addresses the Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (< 0.1.13) by limiting the number and length of path parameters. Because a direct dependency bump is out of scope for this task, server-side validation acts as a mitigation layer to prevent catastrophic backtracking.

### Changes
- Implements `limitPathParams` Express middleware to limit parameter keys to 5 and lengths to 200 characters.
- Injects the mitigation into `userRoutes.ts` and `projectRoutes.ts`.
- Adds integration and unit tests asserting that normal traffic passes, malicious payloads are rejected with `400 Bad Request`, and mitigation resolves in `< 200ms`.

**Note to maintainers:** 
The autopilot execution plan specified file paths (`paramLimit.ts`, `userRoutes.ts`, `v1/projectRoutes.ts`) that deviate from the standard Vitana codebase conventions (kebab-case filenames, flat routing structure). I have emitted them exactly as requested to satisfy the rigid `LOCKED FILE LIST` constraint of the automated execution environment. You will likely need to rename these to `param-limit.ts`, `user-routes.ts`, and flatten them before merging to pass the `Enforce Phase 2B Naming Standards` CI check.