### PR TITLE
DEV-AUTOPILOT: Mitigate path-to-regexp ReDoS vulnerability in gateway

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,39 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    // 1. Direct validation of req.params (if already parsed by an Express router)
+    const keys = Object.keys(req.params || {});
+    if (keys.length > maxParams) {
+      res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    for (const key of keys) {
+      if (typeof req.params[key] === 'string' && req.params[key].length > maxLength) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    // 2. Pre-emptive path validation using safe RegExp to prevent Express 
+    // catastrophic backtracking before or during route matching.
+    const path = req.path || '';
+    const segments = path.match(/([^/]+)/g) || [];
+    
+    for (const segment of segments) {
+      if (segment.length > maxLength) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    // Rough upper-bound heuristic to block ReDoS attempts via path nesting
+    if (segments.length > maxParams * 2 + 5) {
+      res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,18 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply mitigation middleware before processing routes with parameters
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+  
+  return res.json({ ok: true, data: { projectId: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,18 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply mitigation middleware before processing routes with parameters
+router.use(limitPathParams());
+
+router.get('/:userId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+  
+  return res.json({ ok: true, data: { userId: req.params.userId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,48 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - limitPathParams middleware', () => {
+  it('should pass normal requests with <=5 params', async () => {
+    const app = express();
+    app.get('/test/:a/:b', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    const res = await request(app).get('/test/1/2');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it('should reject requests with >5 params', async () => {
+    const app = express();
+    app.get('/test/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    const start = Date.now();
+    const res = await request(app).get('/test/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+    
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ ok: false, error: 'Too many path parameters or parameter too long' });
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('should reject requests with long param values (pre-emptive path check)', async () => {
+    const app = express();
+    app.use(limitPathParams(5, 200));
+    app.get('/test/:a', (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    const longParam = 'a'.repeat(201);
+    const start = Date.now();
+    const res = await request(app).get(`/test/${longParam}`);
+    const duration = Date.now() - start;
+    
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ ok: false, error: 'Too many path parameters or parameter too long' });
+    expect(duration).toBeLessThan(200);
+  });
+});


### PR DESCRIPTION
This PR implements server-side validation middleware to mitigate a ReDoS vulnerability in `path-to-regexp` (< 0.1.13) used by Express. It adds the `limitPathParams` middleware to cap the number and length of path parameters, preventing catastrophic backtracking and CPU exhaustion prior to an actual dependency update.

**Note on Naming Conventions:** The `LOCKED FILE LIST` for this plan contained camelCase filenames (`paramLimit.ts`, `userRoutes.ts`, `projectRoutes.ts`) and nested `v1/` routes which violate the Vitana Phase 2B codebase conventions (which require kebab-case and flat route directories). I was required to use the locked filenames exactly as requested to pass the Dev Autopilot's exact-match validation harness. The CI `validate` checks will likely fail because of these names. A follow-up operation will be needed to rename these files to `param-limit.ts`, `user-routes.ts`, and `project-routes.ts` and move them to the flat `src/routes/` directory.

**Changes:**
- `services/gateway/src/routes/middleware/paramLimit.ts`: New middleware that asserts path parameter counts and string lengths, and checks raw path segments via safe RegExp to avoid deep evaluation.
- `services/gateway/src/routes/v1/userRoutes.ts` & `services/gateway/src/routes/v1/projectRoutes.ts`: Example routes demonstrating the usage of the new middleware. 
- `services/gateway/test/cve-mitigation.test.ts`: Integration and unit tests verifying the ReDoS mitigation works efficiently (rejecting within < 200ms) and successfully blocks overly long/numerous parameters.