### PR TITLE
DEV-AUTOPILOT: Add paramLimit middleware to mitigate path-to-regexp ReDoS

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,28 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const keys = Object.keys(req.params);
+
+    if (keys.length > maxParams) {
+      res.status(400).json({ 
+        ok: false, 
+        error: 'Too many path parameters' 
+      });
+      return;
+    }
+
+    for (const key of keys) {
+      const value = req.params[key];
+      if (value && value.length > maxLength) {
+        res.status(400).json({ 
+          ok: false, 
+          error: 'Path parameter too long' 
+        });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply parameter limits to prevent ReDoS on all routes in this router
+router.use(limitPathParams());
+
+router.get('/:projectId', async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  return res.json({ ok: true, data: { project_id: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply parameter limits to prevent ReDoS on all routes in this router
+router.use(limitPathParams());
+
+router.get('/:id', async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  return res.json({ ok: true, data: { user_id: req.params.id } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,51 @@
+import request from 'supertest';
+import express, { Request, Response } from 'express';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - paramLimit middleware', () => {
+  const app = express();
+  const router = express.Router();
+
+  // Apply the middleware
+  router.use(limitPathParams(5, 200));
+
+  router.get('/users/:id', (req: Request, res: Response) => {
+    res.json({ ok: true, data: { id: req.params.id } });
+  });
+
+  router.get('/projects/:a/:b/:c/:d/:e/:f', (req: Request, res: Response) => {
+    res.json({ ok: true, data: { a: req.params.a } });
+  });
+
+  app.use('/api/v1', router);
+
+  it('should allow normal requests with parameters under threshold', async () => {
+    const response = await request(app).get('/api/v1/users/123');
+    
+    expect(response.status).toBe(200);
+    expect(response.body.ok).toBe(true);
+  });
+
+  it('should reject requests with >5 path parameters', async () => {
+    const start = Date.now();
+    const response = await request(app).get('/api/v1/projects/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+
+    expect(response.status).toBe(400);
+    expect(response.body.ok).toBe(false);
+    expect(response.body.error).toBe('Too many path parameters');
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('should reject requests with extremely long parameter values', async () => {
+    const longParam = 'a'.repeat(201);
+    const start = Date.now();
+    const response = await request(app).get(`/api/v1/users/${longParam}`);
+    const duration = Date.now() - start;
+
+    expect(response.status).toBe(400);
+    expect(response.body.ok).toBe(false);
+    expect(response.body.error).toBe('Path parameter too long');
+    expect(duration).toBeLessThan(200);
+  });
+});


### PR DESCRIPTION
This PR addresses a Regular Expression Denial of Service (ReDoS) vulnerability in transitively dependent `path-to-regexp` versions by introducing a server-side route parameter validation middleware.

### Changes
- **`paramLimit.ts`**: Express middleware that caps route parameters to a default max of 5, and each value to a maximum of 200 characters. If these thresholds are exceeded, the server returns an immediate `400 Bad Request`.
- **`userRoutes.ts` & `projectRoutes.ts`**: Stubbed route files representing implementation. We import and mount `limitPathParams()` on the routers to protect downstream routes. (Note: These should be further integrated with actual domain logic and additional router files per the codebase).
- **`cve-mitigation.test.ts`**: Supertest integration tests verifying that requests matching >5 parameters or >200 character values are swiftly rejected within 200ms.

### ⚠️ Note on File Naming Conventions
The execution plan mandated creating files with camelCase names (`paramLimit.ts`, `userRoutes.ts`, `projectRoutes.ts`). To strictly satisfy the locked file diff bounds of the autopilot executor, I have kept these names exactly as planned. **However, this violates the Phase 2B `kebab-case` naming standard.** These files will need to be renamed to `param-limit.ts`, `user-routes.ts`, and `project-routes.ts` in a follow-up commit to satisfy CI checks.