### PR TITLE
DEV-AUTOPILOT: Mitigate ReDoS vulnerability in express path-to-regexp

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,38 @@
+import { Request, Response, NextFunction } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    // 1. Proactive check on raw path segments to prevent ReDoS during downstream route matching.
+    // This executes early if mounted globally or at the router level.
+    if (req.path) {
+      const segments = req.path.split('/').filter(Boolean);
+      for (const segment of segments) {
+        if (segment.length > maxLength) {
+          return res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        }
+      }
+      // Add a generous buffer for segment count to allow deep static paths, 
+      // while preventing fundamentally excessive path inputs.
+      if (segments.length > maxParams + 20) {
+        return res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+      }
+    }
+
+    // 2. Exact check on req.params as specified in the mitigation plan.
+    // This executes effectively if the middleware is mounted directly on the vulnerable route.
+    if (req.params) {
+      const definedKeys = Object.keys(req.params).filter(k => req.params[k] !== undefined);
+      if (definedKeys.length > maxParams) {
+        return res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+      }
+      for (const key of definedKeys) {
+        const val = req.params[key];
+        if (val && val.length > maxLength) {
+          return res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        }
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,18 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply mitigation for path-to-regexp ReDoS vulnerability
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+  
+  return res.json({ ok: true, data: { projectId: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,18 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply mitigation for path-to-regexp ReDoS vulnerability
+router.use(limitPathParams());
+
+router.get('/:id', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+  
+  return res.json({ ok: true, data: { id: req.params.id } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,54 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE-2024-XXXX Mitigation (ReDoS via path parameters)', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    
+    // Mount globally to protect against ReDoS before route match (as it would be in a real app)
+    app.use(limitPathParams(5, 200));
+
+    // Test route with limit applied directly so req.params logic check is triggered after matching
+    app.get('/test/:a?/:b?/:c?/:d?/:e?/:f?', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.status(200).json({ ok: true });
+    });
+    
+    // Normal route without wildcards for basic length testing
+    app.get('/length-test/:param', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.status(200).json({ ok: true });
+    });
+  });
+
+  it('should accept requests with an acceptable number of path parameters', async () => {
+    const res = await request(app).get('/test/1/2/3');
+    expect(res.status).toBe(200);
+  });
+
+  it('should reject requests exceeding max parameters', async () => {
+    const res = await request(app).get('/test/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('should reject requests with path parameters exceeding max length', async () => {
+    const longParam = 'a'.repeat(201);
+    const res = await request(app).get(`/length-test/${longParam}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('should process quickly on potential ReDoS request (integration)', async () => {
+    const startTime = Date.now();
+    // A request that could trigger backtracking in unpatched express without param limits
+    const longString = 'a'.repeat(500);
+    const res = await request(app).get(`/test/${longString}/${longString}/${longString}/${longString}/${longString}/${longString}`);
+    const duration = Date.now() - startTime;
+    
+    expect(res.status).toBe(400); 
+    // If the ReDoS occurred, response time would significantly spike (or hang)
+    expect(duration).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
**Context**
Addresses a Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (< 0.1.13) used by `express`. Attackers can trigger catastrophic backtracking via crafted requests with multiple route parameters, leading to CPU exhaustion.

**Implementation**
- Created `paramLimit` middleware to validate `req.path` and `req.params`. By preemptively capping the number of consecutive path parameters and the length of each segment, we block excessive inputs before vulnerable path parsing can exhaust the event loop.
- Applied the middleware to `userRoutes` and `projectRoutes`.
- Added unit and integration tests under `cve-mitigation.test.ts` to assert that the middleware behaves correctly, blocking over-length and over-count parameters while successfully passing legitimate requests. 

**Operator Note**
- As outlined in the execution plan, the dependency update in `package.json` falls out of scope for this task and must be completed separately to fully remediate the CVE long-term.
- The `paramLimit` middleware should be applied to any other route files containing path parameters as necessary.