### PR TITLE
DEV-AUTOPILOT: Mitigate ReDoS in path parameters (CVE-2024-4068)

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,28 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const keys = Object.keys(req.params || {});
+
+    if (keys.length > maxParams) {
+      res.status(400).json({
+        ok: false,
+        error: 'Too many path parameters or parameter too long'
+      });
+      return;
+    }
+
+    for (const key of keys) {
+      const val = req.params[key];
+      if (val && val.length > maxLength) {
+        res.status(400).json({
+          ok: false,
+          error: 'Too many path parameters or parameter too long'
+        });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,18 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply ReDoS mitigation middleware to all routes in this router
+router.use(limitPathParams());
+
+router.get('/:projectId', async (req: Request, res: Response) => {
+  return res.json({
+    ok: true,
+    data: {
+      projectId: req.params.projectId
+    }
+  });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,18 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply ReDoS mitigation middleware to all routes in this router
+router.use(limitPathParams());
+
+router.get('/:userId', async (req: Request, res: Response) => {
+  return res.json({
+    ok: true,
+    data: {
+      userId: req.params.userId
+    }
+  });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,60 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE-2024-XXXX ReDoS Mitigation: limitPathParams middleware', () => {
+  const app = express();
+
+  // Test route configured with multiple optional parameters
+  app.get(
+    '/api/v1/test/:a?/:b?/:c?/:d?/:e?/:f?',
+    limitPathParams(5, 200),
+    (req: Request, res: Response) => {
+      res.json({ ok: true, data: { params: req.params } });
+    }
+  );
+
+  // Test route configured to test maximum length constraints
+  app.get(
+    '/api/v1/long/:param',
+    limitPathParams(5, 200),
+    (req: Request, res: Response) => {
+      res.json({ ok: true, data: { params: req.params } });
+    }
+  );
+
+  it('should allow normal requests with <= 5 path parameters', async () => {
+    const response = await request(app).get('/api/v1/test/1/2/3');
+    expect(response.status).toBe(200);
+    expect(response.body.ok).toBe(true);
+  });
+
+  it('should reject requests with > 5 path parameters and respond quickly', async () => {
+    const startTime = Date.now();
+    const response = await request(app).get('/api/v1/test/1/2/3/4/5/6');
+    const endTime = Date.now();
+
+    expect(response.status).toBe(400);
+    expect(response.body.ok).toBe(false);
+    expect(response.body.error).toBe('Too many path parameters or parameter too long');
+    // Ensure the middleware fails quickly, preventing exponential backtracking exhaustion
+    expect(endTime - startTime).toBeLessThan(200);
+  });
+
+  it('should reject requests with overly long path parameters', async () => {
+    const longParam = 'a'.repeat(201);
+    const response = await request(app).get(`/api/v1/long/${longParam}`);
+
+    expect(response.status).toBe(400);
+    expect(response.body.ok).toBe(false);
+    expect(response.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('should allow requests with long but acceptable path parameters', async () => {
+    const acceptableParam = 'a'.repeat(200);
+    const response = await request(app).get(`/api/v1/long/${acceptableParam}`);
+
+    expect(response.status).toBe(200);
+    expect(response.body.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
**Summary**
This PR implements a mitigation for the Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` versions `< 0.1.13` (used transitively by `express`). Since dependency bumping is outside the currently authorized execution scope, we introduce an Express middleware (`paramLimit.ts`) that validates and limits both the number of path parameters (default: 5) and their maximum lengths (default: 200 characters) across sensitive routes.

**Changes**
1. Created `services/gateway/src/routes/middleware/paramLimit.ts` containing the `limitPathParams` middleware logic.
2. Created `services/gateway/src/routes/v1/userRoutes.ts` with the middleware applied.
3. Created `services/gateway/src/routes/v1/projectRoutes.ts` with the middleware applied.
4. Created `services/gateway/test/cve-mitigation.test.ts` to assert the boundary behaviors and ensure limits are strictly adhered to.

**Note on Naming Conventions:**
The execution plan's LOCKED FILE LIST specified camelCase file paths (e.g., `paramLimit.ts`, `userRoutes.ts`). To comply with the execution constraints and avoid breaking the exact-path validator, these files were created using the requested camelCase names, despite the project's standard convention of `kebab-case.ts`. A follow-up action is recommended to rename these files to conform to Phase 2B Naming Standards (`param-limit.ts`, `user-routes.ts`, `project-routes.ts`).

**Future Action Required:**
Update `package.json` across both `services/gateway` and `services/oasis-projector` to bump the dependency for `path-to-regexp` to `>= 0.1.13` or `express` to a patched version once authorized.