### PR TITLE
DEV-AUTOPILOT: Mitigate ReDoS via path parameter limits (CVE-2024-4068)

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,43 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+/**
+ * Middleware to mitigate ReDoS vulnerabilities in express's path-to-regexp router.
+ * Limits the number of path parameters and their maximum string length.
+ */
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // 1. Pre-routing defense: evaluate raw path segments.
+    // This catches excessively long segments before Express route matching occurs,
+    // which is vital for preventing backtracking loops when mounted globally via router.use()
+    const path = req.path || '';
+    const urlSegments = path.split('/');
+    
+    for (const segment of urlSegments) {
+      if (segment.length > maxLength) {
+        res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    // 2. Post-routing defense: evaluate parsed req.params.
+    // This evaluates against parameter counts directly as defined by the route,
+    // when the middleware is mounted inline on specific routes.
+    const params = req.params || {};
+    const keys = Object.keys(params);
+
+    if (keys.length > maxParams) {
+      res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    for (const key of keys) {
+      const value = params[key];
+      if (value && String(value).length > maxLength) {
+        res.status(400).json({ error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,26 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+
+const router = Router();
+
+// Apply the parameter limiting middleware to mitigate ReDoS in all project routes
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  return res.json({ 
+    ok: true, 
+    data: { 
+      projectId: req.params.projectId, 
+      type: 'project' 
+    } 
+  });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,26 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+
+const router = Router();
+
+// Apply the parameter limiting middleware to mitigate ReDoS in all user routes
+router.use(limitPathParams());
+
+router.get('/:userId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  return res.json({ 
+    ok: true, 
+    data: { 
+      userId: req.params.userId, 
+      type: 'user' 
+    } 
+  });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,87 @@
+import request from 'supertest';
+import express, { Request, Response } from 'express';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - limitPathParams middleware (ReDoS)', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+
+    const router = express.Router();
+    const limit = limitPathParams(5, 200);
+
+    // 1. Inline tests to validate req.params logic correctly counts >5 boundaries
+    router.get('/multi/:a/:b/:c/:d/:e/:f?', limit, (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    router.get('/single/:id', limit, (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    // 2. Pre-routing nested tests to validate router.use() effectiveness 
+    // simulating global bounds checking before complex routes execute.
+    const subRouter = express.Router();
+    subRouter.use(limitPathParams(5, 200));
+    subRouter.get('/protected/:id', (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+    router.use('/sub', subRouter);
+
+    app.use('/api', router);
+  });
+
+  it('should block requests with > 5 path parameters', async () => {
+    const start = Date.now();
+    const response = await request(app).get('/api/multi/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('should block requests with a parameter exceeding max length in inline params', async () => {
+    const longParam = 'a'.repeat(201);
+    const start = Date.now();
+    const response = await request(app).get(`/api/single/${longParam}`);
+    const duration = Date.now() - start;
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('should block requests with a long segment pre-routing (global mode)', async () => {
+    const longParam = 'b'.repeat(201);
+    const start = Date.now();
+    const response = await request(app).get(`/api/sub/protected/${longParam}`);
+    const duration = Date.now() - start;
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('should allow valid requests (<= 5 params, <= 200 chars)', async () => {
+    const response = await request(app).get('/api/single/123');
+    expect(response.status).toBe(200);
+    expect(response.body.ok).toBe(true);
+  });
+
+  it('integration test: prevents ReDoS by rejecting pathological inputs quickly', async () => {
+    // A structurally pathological input targeting regex parsing limits in path-to-regexp
+    const pathological = 'a'.repeat(500) + '!';
+    const start = Date.now();
+    
+    // Utilize the pre-routing setup to demonstrate that malicious back-tracking is preempted
+    const response = await request(app).get(`/api/sub/protected/${pathological}`);
+    const duration = Date.now() - start;
+
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(500); // Guarantees fail-fast response
+  });
+});


### PR DESCRIPTION
**Ref:** CVE-2024-4068 / `path-to-regexp` ReDoS vulnerability.

This PR introduces a server-side parameter limit middleware in the gateway to mitigate a Regular Expression Denial of Service (ReDoS) vulnerability in the `path-to-regexp` library (transitively used by Express). 

### Plan executed
1. **Middleware creation**: Added `limitPathParams` to strictly cap the number of path parameters (max `5`) and the length of each value (max `200` chars). This blocks pathological input paths before they can trigger catastrophic backtracking during Express route matching.
2. **Route application**: Applied the middleware to `userRoutes.ts` and `projectRoutes.ts` via `router.use()`. *Note: Any newly added route files with path parameters should also mount this middleware.*
3. **Verification**: Added `cve-mitigation.test.ts` to ensure normal parameters pass, while excessive lengths or counts return an immediate `400 Bad Request` without stalling the event loop.

*(Note for operators: The file names `paramLimit.ts`, `userRoutes.ts`, and `projectRoutes.ts` were explicitly mandated by the Autopilot's locked-file execution plan. If the CI checks reject camelCase formatting under Phase 2B rules, they may need to be renamed to kebab-case prior to merge.)*