### PR TITLE
DEV-AUTOPILOT: Add parameter limit middleware to mitigate ReDoS CVE

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,28 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    const keys = Object.keys(req.params);
+
+    if (keys.length > maxParams) {
+      res.status(400).json({
+        ok: false,
+        error: 'Too many path parameters or parameter too long'
+      });
+      return;
+    }
+
+    for (const key of keys) {
+      const value = req.params[key];
+      if (value && value.length > maxLength) {
+        res.status(400).json({
+          ok: false,
+          error: 'Too many path parameters or parameter too long'
+        });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,20 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+
+const router = Router();
+
+// Apply mitigation middleware to all routes containing path parameters
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  return res.json({ ok: true, data: { project_id: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,20 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+
+const router = Router();
+
+// Apply mitigation middleware to all routes containing path parameters
+router.use(limitPathParams());
+
+router.get('/:userId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  return res.json({ ok: true, data: { user_id: req.params.userId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,57 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - limitPathParams middleware', () => {
+  it('Test 3: Valid request with 2 params passes', async () => {
+    const app = express();
+    app.get('/api/v1/resource/:a/:b', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    const response = await request(app).get('/api/v1/resource/123/456');
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+  });
+
+  it('Test 1: rejects requests with too many path parameters', async () => {
+    const app = express();
+    app.get('/api/v1/resource/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    const response = await request(app).get('/api/v1/resource/1/2/3/4/5/6');
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('Test 2: rejects requests with path parameters that are too long', async () => {
+    const app = express();
+    app.get('/api/v1/resource/:a', limitPathParams(5, 10), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    const response = await request(app).get('/api/v1/resource/12345678901');
+    expect(response.status).toBe(400);
+    expect(response.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('Integration test: protects against ReDoS by stopping fast', async () => {
+    const app = express();
+    
+    // Simulate pathological route setup
+    app.get('/:a/:b/:c/:d/:e/:f?', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    const start = Date.now();
+    // Send a long path that would otherwise cause high CPU if backtracking occurred
+    const pathologicalPath = '/' + 'a'.repeat(50) + '/' + 'b'.repeat(50) + '/' + 'c'.repeat(50) + '/' + 'd'.repeat(50) + '/' + 'e'.repeat(50) + '/' + 'f'.repeat(50);
+    const response = await request(app).get(pathologicalPath);
+    const end = Date.now();
+    
+    expect(response.status).toBe(400);
+    // Ensure the response is quick and avoids catastrophic backtracking
+    expect(end - start).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
This PR addresses a Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (< 0.1.13) which is transitively used by Express. Because direct dependency updates to `package.json` are outside the allowed modification scope, we implement server‑side validation middleware in the gateway as an application-level mitigation.

The new `limitPathParams` middleware caps the number of path parameters (default 5) and limits the length of any parameter value (default 200). This preempts the exponential backtracking that leads to CPU exhaustion.

**Notes on File Naming:**
The requested plan mandates the creation of `paramLimit.ts`, `userRoutes.ts`, and `projectRoutes.ts` in camelCase. While this ordinarily conflicts with the Phase 2B Kebab-Case Naming Standard enforced by CI, the exact paths are provided in the strict locked file list and are adhered to verbatim to satisfy the post-LLM validation gate. 

Files touched:
- `services/gateway/src/routes/middleware/paramLimit.ts`: The validation middleware.
- `services/gateway/src/routes/v1/userRoutes.ts`: Example route group applying the middleware.
- `services/gateway/src/routes/v1/projectRoutes.ts`: Example route group applying the middleware.
- `services/gateway/test/cve-mitigation.test.ts`: Test suite confirming correct request validation and failure states.