### PR TITLE
DEV-AUTOPILOT: Mitigate ReDoS in path-to-regexp using paramLimit middleware

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,37 @@
+import { Request, Response, NextFunction } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200) {
+  return (req: Request, res: Response, next: NextFunction) => {
+    // 1. Regex validation on the raw path to prevent long segments 
+    // causing ReDoS before Express route matching even processes them.
+    const longSegmentRegex = new RegExp(`[^/]{${maxLength + 1},}`);
+    if (longSegmentRegex.test(req.path)) {
+      return res.status(400).json({ 
+        ok: false, 
+        error: 'Path parameter too long' 
+      });
+    }
+
+    // 2. Validate parsed parameters (handles cases where middleware is mounted 
+    // directly on a route and params are already extracted).
+    const keys = Object.keys(req.params);
+    if (keys.length > maxParams) {
+      return res.status(400).json({ 
+        ok: false, 
+        error: 'Too many path parameters' 
+      });
+    }
+
+    for (const key of keys) {
+      const value = req.params[key];
+      if (typeof value === 'string' && value.length > maxLength) {
+        return res.status(400).json({ 
+          ok: false, 
+          error: 'Path parameter too long' 
+        });
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,16 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply param limits to mitigate path-to-regexp ReDoS vulnerability
+router.use(limitPathParams());
+
+router.get('/:projectId', async (req: Request, res: Response) => {
+  return res.json({ 
+    ok: true, 
+    data: { projectId: req.params.projectId } 
+  });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,16 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply param limits to mitigate path-to-regexp ReDoS vulnerability
+router.use(limitPathParams());
+
+router.get('/:userId', async (req: Request, res: Response) => {
+  return res.json({ 
+    ok: true, 
+    data: { userId: req.params.userId } 
+  });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,70 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - paramLimit Middleware', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    app.use(express.json());
+
+    // Applying middleware globally (matches how it's used in routers via router.use)
+    app.use(limitPathParams(5, 200));
+
+    // Also applying it at the route level to test req.params checking logic
+    const testRouter = express.Router();
+    
+    testRouter.get('/resource/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.status(200).json({ ok: true });
+    });
+
+    testRouter.get('/valid/:a/:b', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.status(200).json({ ok: true });
+    });
+    
+    testRouter.get('/long/:a', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.status(200).json({ ok: true });
+    });
+
+    app.use('/', testRouter);
+  });
+
+  it('should pass normal request with <=5 params', async () => {
+    const res = await request(app).get('/valid/1/2');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('should reject request with >5 path params', async () => {
+    const start = Date.now();
+    const res = await request(app).get('/resource/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+    
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/too many path parameters/i);
+    expect(duration).toBeLessThan(200); // Quick rejection assertion
+  });
+
+  it('should reject request with a param exceeding maxLength', async () => {
+    const longParam = 'a'.repeat(201);
+    const start = Date.now();
+    const res = await request(app).get(`/long/${longParam}`);
+    const duration = Date.now() - start;
+    
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/path parameter too long/i);
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('should reject extremely long paths early using regex check', async () => {
+    const maliciousPath = '/valid/1/' + 'b'.repeat(500);
+    const start = Date.now();
+    const res = await request(app).get(maliciousPath);
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/path parameter too long/i);
+    expect(duration).toBeLessThan(200);
+  });
+});


### PR DESCRIPTION
This PR implements server-side validation middleware to mitigate a Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (< 0.1.13), resolving the CVE flagged against our Express dependencies without waiting for out-of-bounds `package.json` updates.

- **Middleware**: Creates `limitPathParams` which uses standard `RegExp` constraints on the raw path and introspects `req.params` to cap URL path limits (max 5 parameters, each capped at 200 chars). This stops exponential backtracking before it exhausts the event loop.
- **Routes**: Applies this middleware to candidate route sets (`userRoutes` and `projectRoutes`). *Note: All route files using path params should integrate this middleware until the direct dependency is bumped.*
- **Testing**: Adds full integration tests confirming rapid rejection of ReDoS-style requests (<200ms latency on violation).

*(Note: The autopilot executed strictly against the locked file list in the execution plan. To comply with the verification gate, `paramLimit.ts`, `userRoutes.ts`, and `projectRoutes.ts` use the requested camelCase names despite overarching phase 2B naming standard guidelines favouring kebab-case).*