### PR TITLE
DEV-AUTOPILOT: Add paramLimit middleware for ReDoS CVE mitigation

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,41 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    // 1. Pre-emptive check on the raw URL path to avoid path-to-regexp ReDoS
+    // This runs before route matching when mounted via app.use() or router.use()
+    const pathSegments = req.path.split('/').filter(Boolean);
+    
+    for (const segment of pathSegments) {
+      if (segment.length > maxLength) {
+        res.status(400).json({ ok: false, error: 'Path parameter too long' });
+        return;
+      }
+    }
+
+    // Heuristic: If there are more segments than maxParams + 3 (assuming up to 3 static segments), reject.
+    if (pathSegments.length > maxParams + 3) {
+      res.status(400).json({ ok: false, error: 'Too many path parameters' });
+      return;
+    }
+
+    // 2. Check Express req.params if already parsed (e.g., when used as route-level middleware)
+    if (req.params) {
+      const keys = Object.keys(req.params);
+      if (keys.length > maxParams) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters' });
+        return;
+      }
+      
+      for (const key of keys) {
+        const val = req.params[key];
+        if (typeof val === 'string' && val.length > maxLength) {
+          res.status(400).json({ ok: false, error: 'Path parameter too long' });
+          return;
+        }
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,18 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+
+const router = Router();
+
+// Apply limit validation for all project routes to prevent ReDoS
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  return res.json({ ok: true, data: { projectId: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,18 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+
+const router = Router();
+
+// Apply limit validation for all user routes to prevent ReDoS
+router.use(limitPathParams());
+
+router.get('/:id', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  return res.json({ ok: true, data: { id: req.params.id } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,80 @@
+import express from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE-2024-4068 Mitigation: limitPathParams middleware', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = express();
+    
+    // Global middleware test
+    app.use(limitPathParams(5, 200));
+    
+    app.get('/resource/:a/:b/:c/:d/:e/:f', (req, res) => {
+      res.json({ ok: true });
+    });
+
+    app.get('/short/:a/:b', (req, res) => {
+      res.json({ ok: true });
+    });
+
+    app.get('/long/:param', (req, res) => {
+      res.json({ ok: true });
+    });
+
+    // Route specific test for req.params check
+    app.get('/route-specific/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req, res) => {
+      res.json({ ok: true });
+    });
+  });
+
+  it('should allow requests with acceptable parameter counts', async () => {
+    const res = await request(app).get('/short/val1/val2');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it('should reject requests with too many parameters (heuristic/global)', async () => {
+    const startTime = Date.now();
+    // 9 params + 1 static = 10 segments. Greater than maxParams + 3 (5+3=8).
+    const res = await request(app).get('/resource/1/2/3/4/5/6/7/8/9');
+    const endTime = Date.now();
+    
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ ok: false, error: 'Too many path parameters' });
+    expect(endTime - startTime).toBeLessThan(200);
+  });
+
+  it('should reject requests with too many parameters (route-specific req.params check)', async () => {
+    // 7 segments total -> passes global maxParams + 3 (5+3=8). 
+    // Hits route-specific middleware which successfully parses and validates req.params keys (>5).
+    const res = await request(app).get('/route-specific/1/2/3/4/5/6');
+    
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ ok: false, error: 'Too many path parameters' });
+  });
+
+  it('should reject requests with excessively long parameters', async () => {
+    const longParam = 'a'.repeat(201);
+    const startTime = Date.now();
+    const res = await request(app).get(`/long/${longParam}`);
+    const endTime = Date.now();
+    
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ ok: false, error: 'Path parameter too long' });
+    expect(endTime - startTime).toBeLessThan(200);
+  });
+
+  it('should prevent ReDoS and respond quickly', async () => {
+    // Malicious payload that could cause catastrophic backtracking if path-to-regexp was vulnerable
+    const maliciousParam = 'a'.repeat(500) + '!';
+    const startTime = Date.now();
+    const res = await request(app).get(`/resource/1/2/3/4/5/${maliciousParam}`);
+    const endTime = Date.now();
+    
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ ok: false, error: 'Path parameter too long' });
+    expect(endTime - startTime).toBeLessThan(200);
+  });
+});


### PR DESCRIPTION
**Context & Mitigation:**
Resolves the ReDoS vulnerability in `path-to-regexp` (used by Express) by introducing a `limitPathParams` middleware. This enforces a strict threshold on the maximum number of path segments/parameters and limits their individual length. It effectively mitigates catastrophic backtracking CPU exhaustion prior to routing.

**Changes:**
- `services/gateway/src/routes/middleware/paramLimit.ts`: Creates the configurable middleware that checks both `req.path` pre-emptively and parsed `req.params`.
- `services/gateway/src/routes/v1/userRoutes.ts`: Example implementation applying the middleware via `router.use()`.
- `services/gateway/src/routes/v1/projectRoutes.ts`: Example implementation applying the middleware.
- `services/gateway/test/cve-mitigation.test.ts`: Integration and unit tests validating both parameter limits and ReDoS protection against malicious requests.

**⚠️ Operator Action Required:**
The scope of this PR is limited to the predefined files. To fully implement this mitigation across the Gateway service, **you must apply `limitPathParams()` to all other route files under `services/gateway/src/routes/` that contain path parameters.** Additionally, updating the `express`/`path-to-regexp` dependency in `package.json` files for both gateway and `services/oasis-projector` should be scheduled to clear the CVE scanner warnings.