### PR TITLE
DEV-AUTOPILOT: Mitigate path-to-regexp ReDoS via paramLimit middleware

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,33 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    // 1. Pre-validation of path segments to prevent ReDoS before route parameter matching occurs.
+    // We split by '/' using RegExp directly, avoiding the vulnerable path-to-regexp engine.
+    const pathSegments = req.path.split(/\//).filter(Boolean);
+    for (const segment of pathSegments) {
+      if (segment.length > maxLength) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    // 2. Validation of parsed route parameters (if the middleware is mounted where params are populated)
+    if (req.params) {
+      const keys = Object.keys(req.params);
+      if (keys.length > maxParams) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+      
+      for (const key of keys) {
+        if (req.params[key] && req.params[key].length > maxLength) {
+          res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+          return;
+        }
+      }
+    }
+    
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,14 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply the middleware to abort execution before downstream route evaluation
+// if the path segments are pathologically long.
+router.use(limitPathParams());
+
+router.get('/:projectId', (req: Request, res: Response) => {
+  return res.json({ ok: true, data: { projectId: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,18 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply the middleware to abort execution before downstream route evaluation 
+// if the path segments are pathologically long.
+router.use(limitPathParams());
+
+router.get('/:id', (req: Request, res: Response) => {
+  return res.json({ ok: true, data: { id: req.params.id } });
+});
+
+router.get('/:id/settings/:settingId', (req: Request, res: Response) => {
+  return res.json({ ok: true, data: { id: req.params.id, settingId: req.params.settingId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,69 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+import userRoutes from '../src/routes/v1/userRoutes';
+import projectRoutes from '../src/routes/v1/projectRoutes';
+
+describe('CVE-XXXX Mitigation: limitPathParams middleware', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = express();
+    
+    // Mount the primary application routers
+    app.use('/api/v1/users', userRoutes);
+    app.use('/api/v1/projects', projectRoutes);
+    
+    // Setup specific test routes to validate the middleware logic directly
+    app.get('/test/params/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+    
+    app.get('/test/valid/:a/:b', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+  });
+
+  it('should accept requests with normal path parameters', async () => {
+    const res = await request(app).get('/api/v1/users/123');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.data.id).toBe('123');
+  });
+
+  it('should allow valid requests with <=5 parameters on a route', async () => {
+    const res = await request(app).get('/test/valid/one/two');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('should reject requests with >5 parameters', async () => {
+    const res = await request(app).get('/test/params/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('should reject requests with a parameter length > 200', async () => {
+    const longParam = 'a'.repeat(201);
+    const res = await request(app).get(`/api/v1/users/${longParam}`);
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('integration: should reject pathological ReDoS attempt quickly', async () => {
+    const startTime = Date.now();
+    
+    // Construct a pathological input pattern attempting to trigger exponential backtracking
+    const maliciousPayload = Array(250).fill('a').join('');
+    
+    const res = await request(app).get(`/api/v1/users/${maliciousPayload}`);
+    const duration = Date.now() - startTime;
+    
+    // Validation is pushed out upfront via req.path evaluation; 
+    // it never reaches downstream vulnerability.
+    expect(res.status).toBe(400);
+    expect(duration).toBeLessThan(200);
+  });
+});


### PR DESCRIPTION
**Context**
A Regular Expression Denial of Service (ReDoS) vulnerability exists in `path-to-regexp` (< 0.1.13), which is used transitively by Express. Attackers can craft requests with excessive numbers of route parameters or exceedingly long parameters, causing catastrophic backtracking and CPU exhaustion during route matching. 

**Changes**
- Implemented `limitPathParams` middleware in `services/gateway/src/routes/middleware/paramLimit.ts` that validates both `req.params` (when matched) and `req.path` segments (to pre-emptively abort before vulnerable downstream routes are evaluated).
- Applied the middleware to `userRoutes.ts` and `projectRoutes.ts` as an immediate protection layer.
- Added unit and integration tests in `cve-mitigation.test.ts` to assert that pathological inputs are blocked in <200ms, effectively stopping execution before vulnerable route matching occurs.

*Note for developers:* This middleware should be applied to all other Express routers under `services/gateway/src/routes/` that utilize route parameters. (File names in this PR are generated matching the locked file list conventions assigned by the plan).