### PR TITLE
DEV-AUTOPILOT: Mitigate ReDoS in express routing via path parameter limits

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,48 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    // Express populates req.params after route matching.
+    // Since this middleware is applied via router.use() to stop ReDoS *before* matching occurs,
+    // we also inspect the raw path segments directly.
+    const pathSegments = req.path.split('/').filter(Boolean);
+
+    // Provide a generous buffer for static path segments in the raw URL check
+    if (pathSegments.length > maxParams + 5) {
+      return res.status(400).json({ 
+        ok: false, 
+        error: 'Too many path segments' 
+      });
+    }
+
+    for (const segment of pathSegments) {
+      if (segment.length > maxLength) {
+        return res.status(400).json({ 
+          ok: false, 
+          error: 'Path segment too long' 
+        });
+      }
+    }
+
+    // Also strictly validate req.params in case this is applied as a route-specific middleware
+    const keys = Object.keys(req.params || {});
+    if (keys.length > maxParams) {
+      return res.status(400).json({ 
+        ok: false, 
+        error: 'Too many path parameters' 
+      });
+    }
+
+    for (const key of keys) {
+      const value = req.params[key];
+      if (typeof value === 'string' && value.length > maxLength) {
+        return res.status(400).json({ 
+          ok: false, 
+          error: 'Path parameter too long' 
+        });
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,13 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply mitigation for path-to-regexp ReDoS
+router.use(limitPathParams(5, 200));
+
+router.get('/:projectId', (req: Request, res: Response) => {
+  return res.json({ ok: true, data: { project_id: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,13 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply mitigation for path-to-regexp ReDoS
+router.use(limitPathParams(5, 200));
+
+router.get('/:userId', (req: Request, res: Response) => {
+  return res.json({ ok: true, data: { user_id: req.params.userId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,52 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE-2024 Mitigation - paramLimit middleware', () => {
+  const app = express();
+  app.use(express.json());
+
+  const router = express.Router();
+  
+  // Apply exactly as it would be in the production route files
+  router.use(limitPathParams(5, 200));
+
+  router.get('/resource/:a/:b/:c/:d/:e/:f', (req: Request, res: Response) => {
+    res.json({ ok: true, data: 'success' });
+  });
+
+  router.get('/short/:a', (req: Request, res: Response) => {
+    res.json({ ok: true, data: 'success' });
+  });
+
+  app.use('/', router);
+
+  it('should reject requests with more than 5 path parameters (simulated by segments)', async () => {
+    const start = Date.now();
+    // Path deliberately exceeds maxParams + 5 static segments to test the raw fallback
+    const res = await request(app).get('/resource/1/2/3/4/5/6/7/8/9/10/11');
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ ok: false, error: 'Too many path segments' });
+    expect(duration).toBeLessThan(200); // Ensures no CPU lockup
+  });
+
+  it('should reject requests with a path parameter longer than 200 chars', async () => {
+    const longParam = 'a'.repeat(201);
+    const start = Date.now();
+    const res = await request(app).get(`/short/${longParam}`);
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ ok: false, error: 'Path segment too long' });
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('should allow valid requests (<=5 params, <=200 chars)', async () => {
+    const res = await request(app).get('/short/123');
+
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, data: 'success' });
+  });
+});


### PR DESCRIPTION
**Context & Finding:**
A Regular Expression Denial of Service (ReDoS) vulnerability exists in `path-to-regexp` versions `< 0.1.13` (used transitively by `express`). This allows attackers to cause catastrophic CPU backtracking by sending paths with multiple deeply-nested or overly long segments. 

While a permanent fix requires a dependency bump across `services/oasis-projector` and `services/gateway`, this PR implements an immediate server-side mitigation for the gateway. By capping the number of path parameters (and raw path segments) and restricting their length before Express evaluates the route, we eliminate the conditions required for the ReDoS to trigger.

**Changes:**
1. Created `limitPathParams` middleware which intercepts requests to count and measure path segments and `req.params`.
2. Applied the middleware globally to target routers (`userRoutes.ts` and `projectRoutes.ts`).
3. Added full unit and integration tests asserting rapid 400 rejection for malicious payloads.

*Note on file names:* The autopilot plan strictly locked the file names as `paramLimit.ts`, `userRoutes.ts`, and `projectRoutes.ts` (camelCase). While our Phase 2B conventions prefer kebab-case (`param-limit.ts`, etc.), the post-LLM validation enforces exact character-for-character adherence to the locked plan. I have used the locked names to prevent validation failures, but recommend a quick follow-up to rename these to kebab-case.