### PR TITLE
DEV-AUTOPILOT: Add middleware to mitigate path-to-regexp ReDoS CVE

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,27 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const keys = Object.keys(req.params || {});
+    if (keys.length > maxParams) {
+      res.status(400).json({ 
+        ok: false, 
+        error: 'Too many path parameters or parameter too long' 
+      });
+      return;
+    }
+
+    for (const key of keys) {
+      const val = req.params[key];
+      if (val && typeof val === 'string' && val.length > maxLength) {
+        res.status(400).json({ 
+          ok: false, 
+          error: 'Too many path parameters or parameter too long' 
+        });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,19 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router({ mergeParams: true });
+
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+  
+  return res.json({ ok: true, data: { project_id: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,19 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router({ mergeParams: true });
+
+router.use(limitPathParams());
+
+router.get('/:userId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+  
+  return res.json({ ok: true, data: { user_id: req.params.userId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,64 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - paramLimit middleware', () => {
+  it('should pass normal requests with <= 5 path params', async () => {
+    const app = express();
+    const router = express.Router({ mergeParams: true });
+    router.use(limitPathParams(5, 200));
+    router.get('/', (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+    app.use('/api/v1/test/:a/:b', router);
+
+    const res = await request(app).get('/api/v1/test/1/2');
+    expect(res.status).toBe(200);
+  });
+
+  it('should reject requests with > 5 path params', async () => {
+    const app = express();
+    const router = express.Router({ mergeParams: true });
+    router.use(limitPathParams(5, 200));
+    router.get('/', (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+    app.use('/api/v1/test/:a/:b/:c/:d/:e/:f', router);
+
+    const res = await request(app).get('/api/v1/test/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('should reject requests with path param > 200 chars', async () => {
+    const app = express();
+    const router = express.Router({ mergeParams: true });
+    router.use(limitPathParams(5, 200));
+    router.get('/', (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+    app.use('/api/v1/test/:a', router);
+
+    const longParam = 'a'.repeat(201);
+    const res = await request(app).get(`/api/v1/test/${longParam}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('integration test: assert response time < 500ms for pathological-style request', async () => {
+    const app = express();
+    const router = express.Router({ mergeParams: true });
+    router.use(limitPathParams(5, 200));
+    router.get('/', (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+    app.use('/api/v1/test/:a/:b/:c/:d/:e/:f', router);
+
+    const start = Date.now();
+    const res = await request(app).get('/api/v1/test/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+    
+    expect(res.status).toBe(400);
+    expect(duration).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
This PR implements server-side middleware to mitigate a ReDoS vulnerability in `path-to-regexp` (transitively used by `express`) by capping the number and length of path parameters. This prevents catastrophic backtracking CPU exhaustion caused by crafted multi-parameter or excessively long-parameter requests.

**Note on naming standards**: The plan explicitly requested creating files with camelCase names (`paramLimit.ts`, `userRoutes.ts`, `projectRoutes.ts`). This was mandated by the rigid locked file list, so the files were emitted exactly as specified to pass the Autopilot bounds validator. However, this violates the platform's `kebab-case` naming rules. **Please rename these files to `param-limit.ts`, `user-routes.ts`, and `project-routes.ts`** and update their respective imports in a follow-up commit to allow the PR to pass CI checks.

Files added:
- `services/gateway/src/routes/middleware/paramLimit.ts` (Validates `req.params` counts and length bounds)
- `services/gateway/src/routes/v1/userRoutes.ts` (Example integration)
- `services/gateway/src/routes/v1/projectRoutes.ts` (Example integration)
- `services/gateway/test/cve-mitigation.test.ts` (Unit and integration tests enforcing bounds)