### PR TITLE
DEV-AUTOPILOT: Implement path param limiting to mitigate ReDoS CVE

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,28 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const keys = Object.keys(req.params || {});
+
+    if (keys.length > maxParams) {
+      res.status(400).json({
+        ok: false,
+        error: 'Too many path parameters'
+      });
+      return;
+    }
+
+    for (const key of keys) {
+      const val = req.params[key];
+      if (val && val.length > maxLength) {
+        res.status(400).json({
+          ok: false,
+          error: 'Path parameter too long'
+        });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,26 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply CVE mitigation middleware to prevent path-to-regexp ReDoS
+router.use(limitPathParams());
+
+router.get('/:projectId', async (req: Request, res: Response) => {
+  return res.json({ 
+    ok: true, 
+    data: { project_id: req.params.projectId } 
+  });
+});
+
+router.get('/:projectId/members/:memberId', async (req: Request, res: Response) => {
+  return res.json({ 
+    ok: true, 
+    data: { 
+      project_id: req.params.projectId,
+      member_id: req.params.memberId
+    } 
+  });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,26 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply CVE mitigation middleware to prevent path-to-regexp ReDoS
+router.use(limitPathParams());
+
+router.get('/:userId', async (req: Request, res: Response) => {
+  return res.json({ 
+    ok: true, 
+    data: { user_id: req.params.userId } 
+  });
+});
+
+router.get('/:userId/settings/:settingId', async (req: Request, res: Response) => {
+  return res.json({ 
+    ok: true, 
+    data: { 
+      user_id: req.params.userId,
+      setting_id: req.params.settingId
+    } 
+  });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,62 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('paramLimit middleware (ReDoS Mitigation)', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = express();
+    const router = express.Router();
+    
+    // Apply mitigation with default plan limits: max 5 params, max 200 chars per param
+    router.use(limitPathParams(5, 200));
+
+    router.get('/resource/:id', (req: Request, res: Response) => {
+      res.json({ ok: true, data: req.params });
+    });
+
+    router.get('/resource/:a/:b/:c/:d/:e/:f', (req: Request, res: Response) => {
+      res.json({ ok: true, data: req.params });
+    });
+
+    app.use('/', router);
+  });
+
+  it('should pass normal requests with parameters within limits', async () => {
+    const res = await request(app).get('/resource/123');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.data.id).toBe('123');
+  });
+
+  it('should reject requests with too many path parameters', async () => {
+    const res = await request(app).get('/resource/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toMatch(/Too many path parameters/);
+  });
+
+  it('should reject requests with path parameters exceeding max length', async () => {
+    const longParam = 'a'.repeat(201);
+    const res = await request(app).get(`/resource/${longParam}`);
+    
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toMatch(/Path parameter too long/);
+  });
+
+  it('should execute quickly under ReDoS-like attack conditions', async () => {
+    const start = Date.now();
+    
+    // Pathological values simulation (> 200 length to hit mitigation logic immediately)
+    const longParam = 'a'.repeat(5000);
+    const res = await request(app).get(`/resource/${longParam}`);
+    
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    // Assertion ensures middleware rejects fast and doesn't get stuck backtracking
+    expect(duration).toBeLessThan(200);
+  });
+});


### PR DESCRIPTION
This PR addresses a Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (<0.1.13) used transitively by `express`. It implements a server-side validation middleware that restricts the maximum number of path parameters (default 5) and limits the string length of each parameter (default 200 characters). 

By capping the exponential backtracking paths before deeper controllers execute, this mitigation drops CPU-exhaustion attack vectors via path routing. Note: this is a server-side mitigation; upgrading the transitive dependency in `package.json` will be performed in a separate step.

**Files touched:**
- `services/gateway/src/routes/middleware/paramLimit.ts` (new middleware)
- `services/gateway/src/routes/v1/userRoutes.ts` (applied middleware)
- `services/gateway/src/routes/v1/projectRoutes.ts` (applied middleware)
- `services/gateway/test/cve-mitigation.test.ts` (unit & integration tests)

*(Note: Operator should follow up to apply this middleware uniformly to all other route handlers missing from the locked file scope)*