### PR TITLE
DEV-AUTOPILOT: Add ReDoS mitigation middleware for path parameters

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,23 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    if (req.params) {
+      const keys = Object.keys(req.params);
+      
+      if (keys.length > maxParams) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+      
+      for (const key of keys) {
+        const value = req.params[key];
+        if (typeof value === 'string' && value.length > maxLength) {
+          res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+          return;
+        }
+      }
+    }
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { limitPathParams } from '../middleware/paramLimit';
+import { getSupabase } from '../../lib/supabase';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  return res.json({ ok: true, data: { project_id: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { limitPathParams } from '../middleware/paramLimit';
+import { getSupabase } from '../../lib/supabase';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:userId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  return res.json({ ok: true, data: { user_id: req.params.userId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,55 @@
+import express, { Request, Response } from 'express';
+import supertest from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - ReDoS in path-to-regexp', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = express();
+  });
+
+  it('rejects requests with more than 5 path parameters', async () => {
+    app.get('/test/:a/:b/:c/:d/:e/:f', limitPathParams(), (req: Request, res: Response) => {
+      res.status(200).json({ ok: true });
+    });
+
+    const res = await supertest(app).get('/test/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('rejects requests with a long param (>200 chars)', async () => {
+    app.get('/test-long/:a', limitPathParams(), (req: Request, res: Response) => {
+      res.status(200).json({ ok: true });
+    });
+
+    const longParam = 'A'.repeat(201);
+    const res = await supertest(app).get(`/test-long/${longParam}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('valid request with 2 params passes', async () => {
+    app.get('/test-valid/:a/:b', limitPathParams(), (req: Request, res: Response) => {
+      res.status(200).json({ ok: true });
+    });
+
+    const res = await supertest(app).get('/test-valid/foo/bar');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('integration test handles pathological requests quickly', async () => {
+    app.get('/:a/:b/:c/:d/:e/:f', limitPathParams(), (req: Request, res: Response) => {
+      res.status(200).json({ ok: true });
+    });
+
+    const start = Date.now();
+    const res = await supertest(app).get('/1/2/3/4/5/6?malicious=true');
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(duration).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
This PR implements server-side validation middleware to mitigate a Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (< 0.1.13) used by Express.

The new `limitPathParams` middleware inspects `req.params` to enforce maximums on the number of path parameters (default 5) and the length of each parameter (default 200). If these limits are exceeded, a 400 Bad Request is returned. This helps mitigate exponential backtracking attacks triggered by pathological route patterns while the dependency is bumped elsewhere. 

**Note on Naming Standards**: The execution plan explicitly locked the paths `paramLimit.ts`, `userRoutes.ts`, and `projectRoutes.ts` (camelCase). Although this violates the Phase 2B Naming Standards (kebab-case), I have emitted them character-for-character to pass the locked-files validator. They should be manually renamed in a follow-up commit to maintain strict compliance.

Files modified/created:
- `services/gateway/src/routes/middleware/paramLimit.ts`
- `services/gateway/src/routes/v1/userRoutes.ts`
- `services/gateway/src/routes/v1/projectRoutes.ts`
- `services/gateway/test/cve-mitigation.test.ts`