### PR TITLE
DEV-AUTOPILOT: Mitigate path-to-regexp ReDoS vulnerability (CVE-2024-4068)

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,37 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // 1. Prevent ReDoS at the global/router level before route matching populates req.params.
+    // We split the raw path to inspect individual raw segments for excessive length.
+    const segments = req.path.split('/').filter(Boolean);
+
+    for (const segment of segments) {
+      if (segment.length > maxLength) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    // 2. Validate req.params if the middleware is applied at the route level
+    // where Express has already parsed and populated the parameters.
+    if (req.params) {
+      const keys = Object.keys(req.params);
+      
+      if (keys.length > maxParams) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+
+      for (const key of keys) {
+        const val = req.params[key];
+        if (val && val.length > maxLength) {
+          res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+          return;
+        }
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,20 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply mitigation to limit path parameter parsing footprint
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  return res.json({ ok: true, data: { project_id: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,20 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply mitigation to limit path parameter parsing footprint
+router.use(limitPathParams());
+
+router.get('/:userId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  return res.json({ ok: true, data: { user_id: req.params.userId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,58 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('ReDoS CVE Mitigation Middleware', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+
+    // 1. Apply globally to catch overly long segments early
+    app.use(limitPathParams(5, 200));
+
+    // 2. Apply at the route level to explicitly test req.params logic as required by the plan
+    app.get('/api/test/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    app.get('/api/short/:a/:b', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    app.get('/api/long/:a', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+  });
+
+  it('should return 400 when there are >5 path parameters', async () => {
+    const res = await request(app).get('/api/test/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('should return 400 when a parameter is >200 chars', async () => {
+    const longParam = 'a'.repeat(201);
+    const res = await request(app).get(`/api/long/${longParam}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+
+  it('should pass for a valid request with <=5 parameters and normal lengths', async () => {
+    const res = await request(app).get('/api/short/1/2');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('should complete within 500ms for a pathological request (integration test)', async () => {
+    const start = Date.now();
+    // Pathological values designed to trigger exponential backtracking in vulnerable path-to-regexp versions
+    const pathological = '/api/test/' + Array(6).fill('a'.repeat(50) + '!').join('/');
+    
+    const res = await request(app).get(pathological);
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(duration).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
This PR addresses a Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (< 0.1.13) used transitively by Express. Attackers can trigger catastrophic backtracking by sending requests with many path parameters or exceedingly long segment strings.

Because direct package updates are deferred to a separate dependency management operation, this change introduces a server-side Express middleware (`paramLimit.ts`) deployed in the gateway. 

The middleware acts on two fronts:
1. Validates raw path segments to prevent backtracking triggered by oversized segments before Express fully evaluates the route.
2. Interrogates `req.params` to strictly enforce max consecutive parameters (≤ 5) and max string length per parameter (≤ 200 chars).

**Files Modified:**
- `services/gateway/src/routes/middleware/paramLimit.ts` (Core validation logic)
- `services/gateway/src/routes/v1/userRoutes.ts` (Example implementation of middleware)
- `services/gateway/src/routes/v1/projectRoutes.ts` (Example implementation of middleware)
- `services/gateway/test/cve-mitigation.test.ts` (Unit and integration tests verifying 400 responses and <500ms bounds)

*Note: The locked file list of the execution plan mandated the use of camelCase naming for the injected route and middleware files (e.g., `paramLimit.ts`, `userRoutes.ts`). This is an acknowledged deviation from the standard Vitana platform conventions (kebab-case) to strictly adhere to the provided hard constraints.*