### PR TITLE
DEV-AUTOPILOT: Mitigation for path-to-regexp ReDoS vulnerability

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,28 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const keys = Object.keys(req.params || {});
+    
+    if (keys.length > maxParams) {
+      res.status(400).json({ 
+        ok: false, 
+        error: 'Too many path parameters or parameter too long' 
+      });
+      return;
+    }
+    
+    for (const key of keys) {
+      const val = req.params[key];
+      if (val && typeof val === 'string' && val.length > maxLength) {
+        res.status(400).json({ 
+          ok: false, 
+          error: 'Too many path parameters or parameter too long' 
+        });
+        return;
+      }
+    }
+    
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,18 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply ReDoS mitigation middleware
+router.use(limitPathParams());
+
+router.get('/:projectId', async (req: Request, res: Response) => {
+  return res.json({ 
+    ok: true, 
+    data: { 
+      project_id: req.params.projectId 
+    } 
+  });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,18 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply ReDoS mitigation middleware
+router.use(limitPathParams());
+
+router.get('/:userId', async (req: Request, res: Response) => {
+  return res.json({ 
+    ok: true, 
+    data: { 
+      user_id: req.params.userId 
+    } 
+  });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,55 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - path-to-regexp ReDoS', () => {
+  let app: express.Application;
+
+  beforeEach(() => {
+    app = express();
+    const router = express.Router();
+    
+    // Apply mitigation middleware
+    router.use(limitPathParams(5, 200));
+
+    router.get('/valid/:a/:b', async (req: Request, res: Response) => {
+      res.status(200).json({ ok: true });
+    });
+
+    router.get('/many/:a/:b/:c/:d/:e/:f', async (req: Request, res: Response) => {
+      res.status(200).json({ ok: true });
+    });
+
+    router.get('/long/:a', async (req: Request, res: Response) => {
+      res.status(200).json({ ok: true });
+    });
+
+    app.use(router);
+  });
+
+  it('should allow requests with <= 5 parameters and length <= 200', async () => {
+    const res = await request(app).get('/valid/param1/param2');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+
+  it('should reject requests with > 5 parameters quickly', async () => {
+    const startTime = Date.now();
+    const res = await request(app).get('/many/1/2/3/4/5/6');
+    const duration = Date.now() - startTime;
+    
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('should reject requests with parameter length > 200', async () => {
+    const longParam = 'x'.repeat(201);
+    const res = await request(app).get(`/long/${longParam}`);
+    
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+  });
+});


### PR DESCRIPTION
**Finding:** A Regular Expression Denial of Service (ReDoS) vulnerability exists in `path-to-regexp` versions < 0.1.13, used by `express` in `services/gateway`.
**Plan:** Implement a generic `paramLimit` middleware to cap the maximum number of path parameters (default 5) and the maximum length of any path parameter (default 200 characters). This avoids catastrophic backtracking by ensuring excessively long or nested path routes are rejected with a `400 Bad Request` prior to further processing.
**Files Touched:**
- `services/gateway/src/routes/middleware/paramLimit.ts` (new)
- `services/gateway/src/routes/v1/userRoutes.ts` (newly scaffolded and protected)
- `services/gateway/src/routes/v1/projectRoutes.ts` (newly scaffolded and protected)
- `services/gateway/test/cve-mitigation.test.ts` (new)

*Note: The locked file list included non-kebab-case file names which were strictly adhered to per autopilot enforcement rules. Further rollout should apply this middleware to all other existing routes.*