### PR TITLE
DEV-AUTOPILOT: Add paramLimit middleware to mitigate path-to-regexp ReDoS

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,23 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    if (req.params) {
+      const keys = Object.keys(req.params);
+      
+      if (keys.length > maxParams) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+      
+      for (const key of keys) {
+        const val = req.params[key];
+        if (typeof val === 'string' && val.length > maxLength) {
+          res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+          return;
+        }
+      }
+    }
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+  
+  return res.json({ ok: true, data: { projectId: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:id', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+  
+  return res.json({ ok: true, data: { userId: req.params.id } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,52 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - paramLimit Middleware', () => {
+  const app = express();
+
+  app.use(limitPathParams(5, 200));
+
+  app.get('/api/v1/resource/:a/:b/:c/:d/:e/:f', (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  app.get('/api/v1/resource/:a/:b', (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  app.get('/api/v1/long/:param', (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  it('should return 400 when more than 5 path parameters are provided', async () => {
+    const start = Date.now();
+    const res = await request(app).get('/api/v1/resource/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+    
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(500);
+  });
+
+  it('should return 400 when a path parameter exceeds 200 characters', async () => {
+    const longParam = 'a'.repeat(201);
+    const start = Date.now();
+    const res = await request(app).get(`/api/v1/long/${longParam}`);
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(500);
+  });
+
+  it('should pass normal requests with <= 5 parameters', async () => {
+    const start = Date.now();
+    const res = await request(app).get('/api/v1/resource/1/2');
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(duration).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
This PR addresses the Regular Expression Denial of Service (ReDoS) vulnerability in the `path-to-regexp` transitive dependency (versions < 0.1.13) by implementing server-side validation middleware in the gateway.

Since `package.json` updates are handled outside the scope of this execution plan, we mitigate the immediate risk by enforcing limits on path parameters via the new `paramLimit` middleware. It caps the total number of route path parameters to a default of 5, and the maximum length of any individual path parameter to 200 characters.

**Plan implementation details:**
- **`services/gateway/src/routes/middleware/paramLimit.ts`**: The middleware checks `req.params` keys count and value strings' lengths. Any requests exceeding these metrics are immediately rejected with a `400 Bad Request`.
- **`services/gateway/src/routes/v1/userRoutes.ts` & `services/gateway/src/routes/v1/projectRoutes.ts`**: Sample implementations illustrating how the middleware is applied globally via the routers. (Note: These file names intentionally follow the exact paths prescribed in the locked execution plan despite global lint rules).
- **`services/gateway/test/cve-mitigation.test.ts`**: Comprehensive test coverage utilizing `supertest` to verify both unit thresholds (accept vs. reject) and quick resolution limits (<500ms) for potential malicious request strings.

_Note to reviewers:_ A follow-up may be necessary to globally integrate `limitPathParams` across all active routers and normalize the file naming to strict `kebab-case` based on CI constraints, as this PR strictly adheres to the execution plan's explicitly locked file path mandates.