### PR TITLE
DEV-AUTOPILOT: Mitigate ReDoS vulnerability via paramLimit middleware

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,37 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    // 1. Pre-route matching validation using req.path segments.
+    // This protects against ReDoS in path-to-regexp before route handlers are invoked
+    // by ensuring no single path segment can cause exponential backtracking.
+    const segments = req.path.split('/').filter(Boolean);
+    
+    for (const segment of segments) {
+      if (segment.length > maxLength) {
+        res.status(400).json({ ok: false, error: 'Path parameter too long' });
+        return;
+      }
+    }
+
+    // 2. Validate parsed req.params if available 
+    // (useful if middleware is mounted directly on a route rather than globally via router.use)
+    if (req.params) {
+      const keys = Object.keys(req.params);
+      if (keys.length > maxParams) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters' });
+        return;
+      }
+
+      for (const key of keys) {
+        const val = req.params[key];
+        if (typeof val === 'string' && val.length > maxLength) {
+          res.status(400).json({ ok: false, error: 'Path parameter too long' });
+          return;
+        }
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,14 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply param limits to prevent ReDoS via path-to-regexp
+router.use(limitPathParams(5, 200));
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  return res.json({ ok: true, data: { project_id: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,14 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply param limits to prevent ReDoS via path-to-regexp
+router.use(limitPathParams(5, 200));
+
+router.get('/:userId', requireAuth, async (req: Request, res: Response) => {
+  return res.json({ ok: true, data: { user_id: req.params.userId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,57 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation: ReDoS via Path Parameters', () => {
+  const app = express();
+  
+  // Mount middleware globally as it would be via router.use() in the gateway
+  app.use(limitPathParams(5, 200));
+  
+  // We apply the middleware directly to the route as well to test the req.params parsing logic explicitly
+  app.get('/resource/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  app.get('/resource/:a/:b', limitPathParams(5, 200), (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  // ReDoS simulation route
+  app.get('/redos/:a/:b/:c', (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  it('should accept requests with an acceptable number of path parameters', async () => {
+    const res = await request(app).get('/resource/1/2');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it('should reject requests with >5 path parameters with 400', async () => {
+    const res = await request(app).get('/resource/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ ok: false, error: 'Too many path parameters' });
+  });
+
+  it('should reject requests with path parameters exceeding max length with 400', async () => {
+    const longParam = 'a'.repeat(201);
+    const res = await request(app).get(`/resource/1/${longParam}`);
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ ok: false, error: 'Path parameter too long' });
+  });
+
+  it('integration test: should respond quickly (<500ms) and reject long payload to avoid ReDoS', async () => {
+    const start = Date.now();
+    const pathologicalValue = 'a'.repeat(1000) + '!';
+    
+    // The global middleware checks segment length and will short-circuit before Express matches the route,
+    // avoiding the path-to-regexp ReDoS vulnerability.
+    const res = await request(app).get(`/redos/${pathologicalValue}/b/c`);
+    const duration = Date.now() - start;
+    
+    expect(res.status).toBe(400);
+    expect(res.body).toEqual({ ok: false, error: 'Path parameter too long' });
+    expect(duration).toBeLessThan(500); // Should resolve immediately without catastrophic backtracking
+  });
+});


### PR DESCRIPTION
This PR implements server-side validation middleware (`limitPathParams`) to mitigate a Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` (< 0.1.13) used by Express. By capping the number of parameters and their maximum length, we prevent the catastrophic backtracking that triggers CPU exhaustion.

**Note for Developers:** This PR applies the mitigation to `userRoutes.ts` and `projectRoutes.ts` as representative files per the plan. All other route files in `services/gateway/src/routes/` that contain path parameters must also apply this middleware to be fully protected. 

**Note on File Naming:** The locked file list provided by the plan strictly specifies camelCase names (`paramLimit.ts`, `userRoutes.ts`, `projectRoutes.ts`). This is known to violate the `Enforce Phase 2B Naming Standards` check. Since the autopilot cannot deviate from the strict locked paths, a fast-follow may be required to rename these to kebab-case to satisfy CI constraints.