### PR TITLE
DEV-AUTOPILOT: Add paramLimit middleware to mitigate path-to-regexp ReDoS

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,37 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    // 1. Defend against excessively long path segments before matching
+    if (req.path) {
+      // Uses RegExp only for validation, avoiding the vulnerable path-to-regexp matching
+      const segmentsMatch = req.path.match(/[^\/]+/g);
+      if (segmentsMatch) {
+        for (const segment of segmentsMatch) {
+          if (segment.length > maxLength) {
+            res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+            return;
+          }
+        }
+      }
+    }
+
+    // 2. Defend against too many resolved parameters (if mounted on a specific route)
+    const params = req.params || {};
+    const keys = Object.keys(params);
+
+    if (keys.length > maxParams) {
+      res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    for (const key of keys) {
+      if (typeof params[key] === 'string' && params[key].length > maxLength) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,18 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth, AuthenticatedRequest } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply mitigation for path-to-regexp ReDoS
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  return res.json({ ok: true, data: { project_id: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,18 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth, AuthenticatedRequest } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+import { limitPathParams } from '../middleware/paramLimit';
+
+const router = Router();
+
+// Apply mitigation for path-to-regexp ReDoS
+router.use(limitPathParams());
+
+router.get('/:userId', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  return res.json({ ok: true, data: { user_id: req.params.userId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,59 @@
+import express from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - limitPathParams Middleware', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    
+    // Apply locally to ensure req.params is populated for the >5 params test
+    app.get('/api/test/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req, res) => {
+      res.json({ ok: true, data: 'success' });
+    });
+
+    // Apply globally for raw path segment length checks
+    app.use(limitPathParams(5, 200));
+    app.get('/api/valid/:a/:b', (req, res) => {
+      res.json({ ok: true, data: 'success' });
+    });
+  });
+
+  it('should accept a request with <= 5 path parameters and valid lengths', async () => {
+    const res = await request(app).get('/api/valid/param1/param2');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true, data: 'success' });
+  });
+
+  it('should reject a request with > 5 path parameters', async () => {
+    const start = Date.now();
+    const res = await request(app).get('/api/test/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('should reject a request with a path parameter exceeding maximum length', async () => {
+    const longParam = 'a'.repeat(201);
+    const start = Date.now();
+    const res = await request(app).get(`/api/valid/param1/${longParam}`);
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('Too many path parameters or parameter too long');
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('Integration test: assert fast rejection to avoid ReDoS', async () => {
+    const maliciousParam = 'a'.repeat(5000);
+    const start = Date.now();
+    const res = await request(app).get(`/api/valid/param1/${maliciousParam}`);
+    const duration = Date.now() - start;
+
+    expect(res.status).toBe(400);
+    expect(duration).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
This PR addresses the `path-to-regexp` ReDoS vulnerability (CVE-2024-28176) by implementing server-side validation middleware that restricts the maximum length of path segments and the number of path parameters. This mitigates the risk of catastrophic backtracking and CPU exhaustion during Express route matching.

**Changes:**
- Created `limitPathParams` middleware that uses safe RegExp validation on the raw path segments and bounds `req.params` keys.
- Applied the mitigation middleware to `userRoutes` and `projectRoutes`.
- Added unit and integration tests confirming >5 params and excessively long parameters are rejected with `400 Bad Request` in <500ms.

**Note to Operator:**
The AI plan prescribed camelCase filenames (`paramLimit.ts`, `userRoutes.ts`, `projectRoutes.ts`), but the codebase strictly enforces kebab-case. Due to the strict exact-match restrictions of the diff validator's locked file list, these files had to be emitted with camelCase to avoid automated rejection. **You will need to rename these files to kebab-case before merging to pass the `Enforce Phase 2B Naming Standards` CI check.** Also, please ensure this middleware is applied to any other existing route files with path parameters.