### PR TITLE
DEV-AUTOPILOT: Add middleware to limit path params and mitigate ReDoS

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,39 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams = 5, maxLength = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction) => {
+    // 1. Fast regex checks on the raw path to prevent ReDoS during downstream express routing.
+    // Uses RegExp only for validation, avoiding the vulnerable path-to-regexp matching.
+    const longSegmentRegex = new RegExp(`/[^/]{${maxLength + 1},}`);
+    if (longSegmentRegex.test(req.path)) {
+      res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    // Reject requests with excessively many segments (maxParams + allowance for static route parts)
+    const excessiveSegmentsRegex = new RegExp(`(?:/[^/]+){${maxParams + 10},}`);
+    if (excessiveSegmentsRegex.test(req.path)) {
+      res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+      return;
+    }
+
+    // 2. Exact check on req.params (effective if middleware is mounted directly on a route)
+    if (req.params) {
+      const keys = Object.keys(req.params);
+      if (keys.length > maxParams) {
+        res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+        return;
+      }
+
+      for (const key of keys) {
+        const value = req.params[key];
+        if (value && value.length > maxLength) {
+          res.status(400).json({ ok: false, error: 'Too many path parameters or parameter too long' });
+          return;
+        }
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { requireAuth, AuthenticatedRequest } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  return res.json({ ok: true, data: { project_id: req.params.projectId } });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,17 @@
+import { Router, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { requireAuth, AuthenticatedRequest } from '../../middleware/auth-supabase-jwt';
+import { getSupabase } from '../../lib/supabase';
+
+const router = Router();
+
+router.use(limitPathParams());
+
+router.get('/:userId', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  return res.json({ ok: true, data: { user_id: req.params.userId } });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,60 @@
+import express, { Request, Response } from 'express';
+import request from 'supertest';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation: limitPathParams middleware', () => {
+  let app: express.Express;
+
+  beforeEach(() => {
+    app = express();
+    
+    // Mount middleware globally as it would be in the real app
+    app.use(limitPathParams(5, 200));
+
+    app.get('/valid/:a/:b', (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    app.get('/long/:a', (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+  });
+
+  it('should pass a valid request with <=5 parameters', async () => {
+    const res = await request(app).get('/valid/1/2');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({ ok: true });
+  });
+
+  it('should return 400 when a parameter exceeds maxLength', async () => {
+    const longParam = 'a'.repeat(201);
+    const res = await request(app).get(`/long/${longParam}`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/parameter too long/i);
+  });
+
+  it('should return 400 when there are >5 parameters matched', async () => {
+    const specificApp = express();
+    
+    // Mount directly on route to ensure the req.params parsing logic is explicitly covered
+    specificApp.get('/test/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+      res.json({ ok: true });
+    });
+
+    const res = await request(specificApp).get('/test/1/2/3/4/5/6');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/Too many path parameters/i);
+  });
+
+  it('Integration test: mitigate ReDoS attack and respond in <500ms', async () => {
+    const start = Date.now();
+    // Path designed to trigger excessive segment checks prior to matching routing layers
+    const maliciousPath = '/' + Array.from({ length: 50 }, (_, i) => `param${i}`).join('/');
+    
+    const res = await request(app).get(maliciousPath);
+    
+    const duration = Date.now() - start;
+    expect(res.status).toBe(400);
+    expect(duration).toBeLessThan(500);
+  });
+});


### PR DESCRIPTION
This PR introduces the `limitPathParams` middleware to mitigate the `path-to-regexp` ReDoS vulnerability by enforcing bounds on route parameters.

- **`paramLimit.ts`**: Adds middleware to validate both the raw `req.path` (via non-overlapping RegExp checks that fire before Express processes vulnerable routing logic) and `req.params` (when applied at the route-level). Limits maximum path segments and segment length.
- **`userRoutes.ts` & `projectRoutes.ts`**: Example route files applying the middleware, strictly following the plan's instructions.
- **`cve-mitigation.test.ts`**: Validates the middleware accepts valid params, rejects oversized values/quantities, and handles simulated ReDoS payloads under 500ms.

**NOTE to human operator**: 
1. The plan provided a strict LOCKED FILE LIST containing `camelCase` filenames (`paramLimit.ts`, `userRoutes.ts`, `projectRoutes.ts`). The Autopilot strictly adheres to these path strings. If the `Enforce Phase 2B Naming Standards` CI check fails, please rename them to `kebab-case` (`param-limit.ts`, etc.) in a subsequent commit.
2. The plan specifies `userRoutes.ts` and `projectRoutes.ts` as representative candidate files. Please verify and extend the `limitPathParams()` middleware application to all remaining route files across the gateway.