### PR TITLE
DEV-AUTOPILOT: Mitigate ReDoS CVE via paramLimit middleware

### DIFF
--- a/services/gateway/src/routes/middleware/paramLimit.ts
+++ b/services/gateway/src/routes/middleware/paramLimit.ts
@@ -1,0 +1,30 @@
+import { Request, Response, NextFunction, RequestHandler } from 'express';
+
+export function limitPathParams(maxParams: number = 5, maxLength: number = 200): RequestHandler {
+  return (req: Request, res: Response, next: NextFunction): void => {
+    const paramKeys = Object.keys(req.params || {});
+
+    // Check maximum number of path parameters
+    if (paramKeys.length > maxParams) {
+      res.status(400).json({
+        ok: false,
+        error: 'Too many path parameters or parameter too long'
+      });
+      return;
+    }
+
+    // Check maximum length of each path parameter
+    for (const key of paramKeys) {
+      const value = req.params[key];
+      if (value && typeof value === 'string' && value.length > maxLength) {
+        res.status(400).json({
+          ok: false,
+          error: 'Too many path parameters or parameter too long'
+        });
+        return;
+      }
+    }
+
+    next();
+  };
+}

--- a/services/gateway/src/routes/v1/projectRoutes.ts
+++ b/services/gateway/src/routes/v1/projectRoutes.ts
@@ -1,0 +1,25 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { getSupabase } from '../../lib/supabase';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+
+const router = Router();
+
+// Apply param-limit middleware to mitigate CVE ReDoS vulnerability
+router.use(limitPathParams());
+
+router.get('/:projectId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  return res.json({ 
+    ok: true, 
+    data: { 
+      projectId: req.params.projectId 
+    } 
+  });
+});
+
+export default router;

--- a/services/gateway/src/routes/v1/userRoutes.ts
+++ b/services/gateway/src/routes/v1/userRoutes.ts
@@ -1,0 +1,25 @@
+import { Router, Request, Response } from 'express';
+import { limitPathParams } from '../middleware/paramLimit';
+import { getSupabase } from '../../lib/supabase';
+import { requireAuth } from '../../middleware/auth-supabase-jwt';
+
+const router = Router();
+
+// Apply param-limit middleware to mitigate CVE ReDoS vulnerability
+router.use(limitPathParams());
+
+router.get('/:userId', requireAuth, async (req: Request, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return res.status(503).json({ ok: false, error: 'no supabase' });
+  }
+
+  return res.json({ 
+    ok: true, 
+    data: { 
+      userId: req.params.userId 
+    } 
+  });
+});
+
+export default router;

--- a/services/gateway/test/cve-mitigation.test.ts
+++ b/services/gateway/test/cve-mitigation.test.ts
@@ -1,0 +1,56 @@
+import request from 'supertest';
+import express, { Request, Response } from 'express';
+import { limitPathParams } from '../src/routes/middleware/paramLimit';
+
+describe('CVE Mitigation - paramLimit Middleware', () => {
+  const app = express();
+
+  // Test route configured with an excessive amount of path parameters
+  app.get('/resource/:a/:b/:c/:d/:e/:f', limitPathParams(5, 200), (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  // Test route configured normally
+  app.get('/normal/:id', limitPathParams(5, 200), (req: Request, res: Response) => {
+    res.json({ ok: true });
+  });
+
+  it('should allow normal requests with parameter count <= maxParams', async () => {
+    const start = Date.now();
+    const response = await request(app).get('/normal/123');
+    const duration = Date.now() - start;
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('should reject requests with > 5 path parameters (e.g., 6 params) to block backtracking ReDoS', async () => {
+    const start = Date.now();
+    const response = await request(app).get('/resource/1/2/3/4/5/6');
+    const duration = Date.now() - start;
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      ok: false,
+      error: 'Too many path parameters or parameter too long'
+    });
+    // Ensure rejection is fast and doesn't hang
+    expect(duration).toBeLessThan(200);
+  });
+
+  it('should reject requests with path parameters exceeding max length', async () => {
+    const longParam = 'a'.repeat(201);
+    const start = Date.now();
+    const response = await request(app).get(`/normal/${longParam}`);
+    const duration = Date.now() - start;
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({
+      ok: false,
+      error: 'Too many path parameters or parameter too long'
+    });
+    // Ensure rejection is fast and doesn't hang
+    expect(duration).toBeLessThan(200);
+  });
+});


### PR DESCRIPTION
## Description
This PR implements a server-side parameter limitation middleware to mitigate a Regular Expression Denial of Service (ReDoS) vulnerability in `path-to-regexp` versions `< 0.1.13` (used transitively by `express`). 

By enforcing limits on the maximum number of path parameters (default 5) and their maximum length (default 200 characters), we prevent catastrophic exponential backtracking CPU exhaustion when handling maliciously crafted parameterized requests. 

The dependency bump must happen in a separate plan modifying `package.json`. This server-side protection serves as an immediate runtime mitigation.

## Changes
- **`services/gateway/src/routes/middleware/paramLimit.ts`**: Creates the `limitPathParams(maxParams, maxLength)` middleware, failing with a `400 Bad Request` if bounds are exceeded.
- **`services/gateway/src/routes/v1/userRoutes.ts` & `services/gateway/src/routes/v1/projectRoutes.ts`**: Example route files applying the newly created middleware globally on the routers.
- **`services/gateway/test/cve-mitigation.test.ts`**: Unit and integration test validating the acceptance of normal parameters and the immediate rejection of malicious ReDoS parameter counts and lengths. Ensures response limits hit fast (`<200ms`).

*Note on file naming:* File names `paramLimit.ts`, `userRoutes.ts`, and `projectRoutes.ts` are using camelCase intentionally to adhere strictly to the autopilot `LOCKED FILE LIST` constraint, even though this technically violates Phase 2B Codebase Naming Standards (kebab-case).