### PR TITLE
DEV-AUTOPILOT: Relax provenance source check for memory facts from Settings

### DIFF
--- a/services/gateway/src/routes/settings.ts
+++ b/services/gateway/src/routes/settings.ts
@@ -1,0 +1,60 @@
+import { Router, Request, Response } from 'express';
+import { requireAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
+import { getSupabase } from '../lib/supabase';
+import { upsertMemoryFact } from '../services/memory-facts';
+import { z } from 'zod';
+
+const router = Router();
+
+const profileUpdateSchema = z.object({
+  firstName: z.string().optional(),
+  nickname: z.string().optional()
+});
+
+router.patch('/profile', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  if (!req.identity || !req.identity.user_id || !req.identity.tenant_id) {
+    return res.status(401).json({ ok: false, error: 'unauthorized' });
+  }
+
+  const { user_id: userId, tenant_id: tenantId } = req.identity;
+
+  const parsed = profileUpdateSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ ok: false, error: 'invalid body' });
+  }
+
+  const { firstName, nickname } = parsed.data;
+
+  if (firstName !== undefined) {
+    const resFirstName = await upsertMemoryFact(supabase, {
+      userId,
+      tenantId,
+      factType: 'user_first_name',
+      factValue: firstName,
+      provenanceSource: 'user_stated_via_settings'
+    });
+    if (!resFirstName.ok) {
+      return res.status(500).json({ ok: false, error: resFirstName.error });
+    }
+  }
+
+  if (nickname !== undefined) {
+    const resNickname = await upsertMemoryFact(supabase, {
+      userId,
+      tenantId,
+      factType: 'user_nickname',
+      factValue: nickname,
+      provenanceSource: 'user_stated_via_settings'
+    });
+    if (!resNickname.ok) {
+      return res.status(500).json({ ok: false, error: resNickname.error });
+    }
+  }
+
+  return res.json({ ok: true });
+});
+
+export default router;

--- a/services/gateway/src/services/memory-facts.ts
+++ b/services/gateway/src/services/memory-facts.ts
@@ -1,0 +1,36 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { ProvenanceSource, MemoryFact } from '../types/memory-facts';
+
+export async function upsertMemoryFact(
+  supabase: SupabaseClient,
+  params: {
+    userId: string;
+    tenantId: string;
+    factType: string;
+    factValue: string;
+    provenanceSource?: ProvenanceSource;
+  }
+): Promise<{ ok: boolean; data?: MemoryFact; error?: string }> {
+  const provenance = params.provenanceSource || 'user_stated';
+
+  const { data, error } = await supabase
+    .from('memory_facts')
+    .upsert({
+      user_id: params.userId,
+      tenant_id: params.tenantId,
+      fact_type: params.factType,
+      fact_value: params.factValue,
+      provenance_source: provenance,
+      updated_at: new Date().toISOString()
+    }, {
+      onConflict: 'user_id,tenant_id,fact_type'
+    })
+    .select()
+    .single();
+
+  if (error) {
+    return { ok: false, error: error.message };
+  }
+
+  return { ok: true, data };
+}

--- a/services/gateway/src/types/memory-facts.ts
+++ b/services/gateway/src/types/memory-facts.ts
@@ -1,0 +1,21 @@
+export type ProvenanceSource =
+  | 'user_stated'
+  | 'user_stated_via_settings'
+  | 'user_stated_via_memory_garden_ui'
+  | 'user_stated_via_onboarding'
+  | 'user_stated_via_baseline_survey'
+  | 'admin_correction'
+  | 'system_provision'
+  | 'assistant_inferred'
+  | 'consolidator';
+
+export interface MemoryFact {
+  id: string;
+  user_id: string;
+  tenant_id: string;
+  fact_type: string;
+  fact_value: string;
+  provenance_source: ProvenanceSource;
+  created_at?: string;
+  updated_at?: string;
+}

--- a/services/gateway/test/integration/settings-profile.test.ts
+++ b/services/gateway/test/integration/settings-profile.test.ts
@@ -1,0 +1,109 @@
+import request from 'supertest';
+import express from 'express';
+import settingsRouter from '../../src/routes/settings';
+import { getSupabase } from '../../src/lib/supabase';
+
+jest.mock('../../src/middleware/auth-supabase-jwt', () => ({
+  requireAuth: (req: any, res: any, next: any) => {
+    req.identity = {
+      user_id: 'user-1',
+      tenant_id: 'tenant-1',
+      email: 'test@example.com',
+      exafy_admin: false,
+      role: 'user'
+    };
+    next();
+  }
+}));
+
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn()
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/api/v1/settings', settingsRouter);
+
+describe('Settings Profile Integration', () => {
+  let mockSupabase: any;
+
+  beforeEach(() => {
+    mockSupabase = {
+      from: jest.fn().mockReturnThis(),
+      upsert: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      single: jest.fn()
+    };
+    (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+  });
+
+  afterEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('updates first name with provenanceSource user_stated_via_settings', async () => {
+    mockSupabase.single.mockResolvedValue({ data: { id: 'fact-1' }, error: null });
+
+    const response = await request(app)
+      .patch('/api/v1/settings/profile')
+      .send({ firstName: 'Bob' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('memory_facts');
+    expect(mockSupabase.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'user-1',
+        tenant_id: 'tenant-1',
+        fact_type: 'user_first_name',
+        fact_value: 'Bob',
+        provenance_source: 'user_stated_via_settings'
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it('updates nickname with provenanceSource user_stated_via_settings', async () => {
+    mockSupabase.single.mockResolvedValue({ data: { id: 'fact-2' }, error: null });
+
+    const response = await request(app)
+      .patch('/api/v1/settings/profile')
+      .send({ nickname: 'Bobby' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+
+    expect(mockSupabase.from).toHaveBeenCalledWith('memory_facts');
+    expect(mockSupabase.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'user-1',
+        tenant_id: 'tenant-1',
+        fact_type: 'user_nickname',
+        fact_value: 'Bobby',
+        provenance_source: 'user_stated_via_settings'
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it('returns 500 when supabase throws an error', async () => {
+    mockSupabase.single.mockResolvedValue({ data: null, error: { message: 'identity_locked' } });
+
+    const response = await request(app)
+      .patch('/api/v1/settings/profile')
+      .send({ firstName: 'Bob' });
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ ok: false, error: 'identity_locked' });
+  });
+
+  it('returns 400 for invalid body', async () => {
+    const response = await request(app)
+      .patch('/api/v1/settings/profile')
+      .send({ firstName: 123 }); // invalid type
+
+    expect(response.status).toBe(400);
+    expect(response.body).toEqual({ ok: false, error: 'invalid body' });
+  });
+});

--- a/services/gateway/test/unit/services/memory-facts.test.ts
+++ b/services/gateway/test/unit/services/memory-facts.test.ts
@@ -1,0 +1,81 @@
+import { upsertMemoryFact } from '../../../src/services/memory-facts';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+describe('Memory Facts Service', () => {
+  let mockSupabase: any;
+
+  beforeEach(() => {
+    mockSupabase = {
+      from: jest.fn().mockReturnThis(),
+      upsert: jest.fn().mockReturnThis(),
+      select: jest.fn().mockReturnThis(),
+      single: jest.fn()
+    };
+  });
+
+  it('upserts a memory fact with default provenance_source if not provided', async () => {
+    mockSupabase.single.mockResolvedValue({
+      data: { id: '123', provenance_source: 'user_stated' },
+      error: null
+    });
+
+    const result = await upsertMemoryFact(mockSupabase as unknown as SupabaseClient, {
+      userId: 'user-1',
+      tenantId: 'tenant-1',
+      factType: 'user_first_name',
+      factValue: 'Alice'
+    });
+
+    expect(result.ok).toBe(true);
+    expect(mockSupabase.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'user-1',
+        tenant_id: 'tenant-1',
+        fact_type: 'user_first_name',
+        fact_value: 'Alice',
+        provenance_source: 'user_stated'
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it('upserts a memory fact with provided provenance_source', async () => {
+    mockSupabase.single.mockResolvedValue({
+      data: { id: '123', provenance_source: 'user_stated_via_settings' },
+      error: null
+    });
+
+    const result = await upsertMemoryFact(mockSupabase as unknown as SupabaseClient, {
+      userId: 'user-1',
+      tenantId: 'tenant-1',
+      factType: 'user_first_name',
+      factValue: 'Alice',
+      provenanceSource: 'user_stated_via_settings'
+    });
+
+    expect(result.ok).toBe(true);
+    expect(mockSupabase.upsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        provenance_source: 'user_stated_via_settings'
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it('returns error if supabase fails', async () => {
+    mockSupabase.single.mockResolvedValue({
+      data: null,
+      error: { message: 'Database error' }
+    });
+
+    const result = await upsertMemoryFact(mockSupabase as unknown as SupabaseClient, {
+      userId: 'user-1',
+      tenantId: 'tenant-1',
+      factType: 'user_first_name',
+      factValue: 'Alice'
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('Database error');
+  });
+});


### PR DESCRIPTION
This PR addresses the issue where identity-class memory facts (like first name or nickname) written from the Settings UI fail. The Identity Lock trigger rejects the legacy `'user_stated'` provenance source, so we must explicitly pass `'user_stated_via_settings'`.

### Changes
- **Types**: Added `ProvenanceSource` to `services/gateway/src/types/memory-facts.ts` containing the 6 new sources from the migration (`user_stated_via_settings`, `admin_correction`, etc.).
- **Service**: Implemented `upsertMemoryFact` in `services/gateway/src/services/memory-facts.ts`. It allows specifying a `provenanceSource` and gracefully falls back to `'user_stated'`.
- **Route**: Implemented `PATCH /profile` in `services/gateway/src/routes/settings.ts`, ensuring changes to `firstName` and `nickname` pass `provenanceSource: 'user_stated_via_settings'`.
- **Tests**: Added unit tests for the service layer and integration tests for the endpoint.

*(Note: In the integration test, `getSupabase()` is mocked. While the plan mentioned test helpers like `createTestUser` and `createTestTenant` that write to a test database, their exact import paths were not available in the public surface block, so mocking was used to prevent hallucinated module APIs).*