### PR TITLE
DEV-AUTOPILOT: Support updated provenance sources for memory facts

### DIFF
--- a/services/gateway/src/routes/settings.ts
+++ b/services/gateway/src/routes/settings.ts
@@ -1,0 +1,47 @@
+import { Router, Response } from 'express';
+import { z } from 'zod';
+import { requireAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
+import { upsertMemoryFact } from '../services/memory-facts';
+
+const router = Router();
+
+const updateProfileSchema = z.object({
+  first_name: z.string().optional(),
+  nickname: z.string().optional(),
+});
+
+router.patch('/profile', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const userId = req.identity?.user_id;
+  if (!userId) {
+    return res.status(401).json({ ok: false, error: 'unauthorized' });
+  }
+
+  const parseResult = updateProfileSchema.safeParse(req.body);
+  if (!parseResult.success) {
+    return res.status(400).json({ 
+      ok: false, 
+      error: 'invalid payload', 
+      details: parseResult.error.format() 
+    });
+  }
+
+  const { first_name, nickname } = parseResult.data;
+
+  if (first_name !== undefined) {
+    const result = await upsertMemoryFact(userId, 'user_first_name', first_name, 'user_stated_via_settings');
+    if (!result.ok) {
+      return res.status(500).json({ ok: false, error: result.error });
+    }
+  }
+
+  if (nickname !== undefined) {
+    const result = await upsertMemoryFact(userId, 'user_nickname', nickname, 'user_stated_via_settings');
+    if (!result.ok) {
+      return res.status(500).json({ ok: false, error: result.error });
+    }
+  }
+
+  return res.json({ ok: true, data: { success: true } });
+});
+
+export default router;

--- a/services/gateway/src/services/memory-facts.ts
+++ b/services/gateway/src/services/memory-facts.ts
@@ -1,0 +1,37 @@
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabase } from '../lib/supabase';
+import { ProvenanceSource, MemoryFact } from '../types/memory-facts';
+
+export async function upsertMemoryFact(
+  userId: string,
+  factKey: string,
+  factValue: string,
+  provenanceSource: ProvenanceSource = 'user_stated',
+  supabaseClient?: SupabaseClient
+): Promise<{ ok: boolean; data?: MemoryFact; error?: string }> {
+  const supabase = supabaseClient ?? getSupabase();
+  if (!supabase) {
+    return { ok: false, error: 'no supabase' };
+  }
+
+  const { data, error } = await supabase
+    .from('memory_facts')
+    .upsert(
+      {
+        user_id: userId,
+        fact_key: factKey,
+        fact_value: factValue,
+        provenance_source: provenanceSource,
+        updated_at: new Date().toISOString(),
+      },
+      { onConflict: 'user_id, fact_key' }
+    )
+    .select()
+    .single();
+
+  if (error) {
+    return { ok: false, error: error.message };
+  }
+
+  return { ok: true, data };
+}

--- a/services/gateway/src/types/memory-facts.ts
+++ b/services/gateway/src/types/memory-facts.ts
@@ -1,0 +1,22 @@
+export const PROVENANCE_SOURCES = [
+  'user_stated',
+  'user_stated_via_settings',
+  'user_stated_via_memory_garden_ui',
+  'admin_correction',
+  'user_stated_via_onboarding',
+  'user_stated_via_baseline_survey',
+  'system_provision',
+  'assistant_inferred'
+] as const;
+
+export type ProvenanceSource = typeof PROVENANCE_SOURCES[number];
+
+export interface MemoryFact {
+  id: string;
+  user_id: string;
+  fact_key: string;
+  fact_value: string;
+  provenance_source: ProvenanceSource;
+  created_at: string;
+  updated_at: string;
+}

--- a/services/gateway/test/integration/settings-profile.test.ts
+++ b/services/gateway/test/integration/settings-profile.test.ts
@@ -1,0 +1,101 @@
+import request from 'supertest';
+import express from 'express';
+import settingsRouter from '../../../src/routes/settings';
+import { getSupabase } from '../../../src/lib/supabase';
+
+// Mock dependencies
+jest.mock('../../../src/lib/supabase');
+jest.mock('../../../src/middleware/auth-supabase-jwt', () => ({
+  requireAuth: jest.fn((req, res, next) => {
+    req.identity = { user_id: 'test-user-id' };
+    next();
+  }),
+}));
+
+describe('Settings Profile Integration Test', () => {
+  let app: express.Express;
+
+  const mockSingle = jest.fn();
+  const mockSelect = jest.fn(() => ({ single: mockSingle }));
+  const mockUpsert = jest.fn(() => ({ select: mockSelect }));
+  const mockFrom = jest.fn(() => ({ upsert: mockUpsert }));
+
+  beforeAll(() => {
+    app = express();
+    app.use(express.json());
+    app.use('/settings', settingsRouter);
+
+    (getSupabase as jest.Mock).mockReturnValue({
+      from: mockFrom
+    });
+  });
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('updates first name with provenance_source: user_stated_via_settings', async () => {
+    mockSingle.mockResolvedValueOnce({ data: { id: 'fact-1' }, error: null });
+
+    const response = await request(app)
+      .patch('/settings/profile')
+      .send({ first_name: 'Alice' });
+
+    expect(response.status).toBe(200);
+    expect(response.body.ok).toBe(true);
+
+    expect(mockFrom).toHaveBeenCalledWith('memory_facts');
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'test-user-id',
+        fact_key: 'user_first_name',
+        fact_value: 'Alice',
+        provenance_source: 'user_stated_via_settings',
+      }),
+      expect.anything()
+    );
+  });
+
+  it('updates nickname with provenance_source: user_stated_via_settings', async () => {
+    mockSingle.mockResolvedValueOnce({ data: { id: 'fact-2' }, error: null });
+
+    const response = await request(app)
+      .patch('/settings/profile')
+      .send({ nickname: 'Ali' });
+
+    expect(response.status).toBe(200);
+    expect(response.body.ok).toBe(true);
+
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'test-user-id',
+        fact_key: 'user_nickname',
+        fact_value: 'Ali',
+        provenance_source: 'user_stated_via_settings',
+      }),
+      expect.anything()
+    );
+  });
+
+  it('returns error on invalid payload structure (zod check)', async () => {
+    const response = await request(app)
+      .patch('/settings/profile')
+      .send({ first_name: 1234 });
+
+    expect(response.status).toBe(400);
+    expect(response.body.ok).toBe(false);
+    expect(response.body.error).toBe('invalid payload');
+  });
+
+  it('returns error if db write fails', async () => {
+    mockSingle.mockResolvedValueOnce({ data: null, error: { message: 'Database failure' } });
+
+    const response = await request(app)
+      .patch('/settings/profile')
+      .send({ first_name: 'Alice' });
+
+    expect(response.status).toBe(500);
+    expect(response.body.ok).toBe(false);
+    expect(response.body.error).toBe('Database failure');
+  });
+});

--- a/services/gateway/test/unit/services/memory-facts.test.ts
+++ b/services/gateway/test/unit/services/memory-facts.test.ts
@@ -1,0 +1,49 @@
+import { upsertMemoryFact } from '../../../src/services/memory-facts';
+
+describe('Memory Facts Service', () => {
+  const mockSingle = jest.fn();
+  const mockSelect = jest.fn(() => ({ single: mockSingle }));
+  const mockUpsert = jest.fn(() => ({ select: mockSelect }));
+  const mockFrom = jest.fn(() => ({ upsert: mockUpsert }));
+
+  const mockSupabase = {
+    from: mockFrom
+  } as any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+  });
+
+  it('should use default provenance source if not provided', async () => {
+    mockSingle.mockResolvedValueOnce({ data: { id: '1' }, error: null });
+
+    const result = await upsertMemoryFact('user_1', 'key', 'val', undefined, mockSupabase);
+
+    expect(result.ok).toBe(true);
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ provenance_source: 'user_stated' }),
+      expect.anything()
+    );
+  });
+
+  it('should use provided provenance source', async () => {
+    mockSingle.mockResolvedValueOnce({ data: { id: '1' }, error: null });
+
+    const result = await upsertMemoryFact('user_1', 'key', 'val', 'user_stated_via_settings', mockSupabase);
+
+    expect(result.ok).toBe(true);
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({ provenance_source: 'user_stated_via_settings' }),
+      expect.anything()
+    );
+  });
+
+  it('should return error on database failure', async () => {
+    mockSingle.mockResolvedValueOnce({ data: null, error: { message: 'db error' } });
+
+    const result = await upsertMemoryFact('user_1', 'key', 'val', 'user_stated_via_settings', mockSupabase);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('db error');
+  });
+});


### PR DESCRIPTION
This PR addresses the bug where identity-class memory facts (such as first name and nickname) were being rejected when written from the Settings UI because the Identity Lock trigger blocks the legacy `user_stated` source. 

Following the migration `20260426000002_vtid_01952_relax_provenance_check_constraint.sql`, this PR:
1. Adds `user_stated_via_settings` and other expanded sources to the newly created `memory-facts` types.
2. Creates the `upsertMemoryFact` service function that passes down the optional `provenanceSource` to the DB.
3. Implements the `/settings/profile` endpoint which uses Zod for validation and saves `user_first_name` and `user_nickname` using the correct `'user_stated_via_settings'` provenance source.
4. Adds corresponding unit and integration tests to verify the expanded source logic.

Files modified/created:
- `services/gateway/src/types/memory-facts.ts`
- `services/gateway/src/services/memory-facts.ts`
- `services/gateway/src/routes/settings.ts`
- `services/gateway/test/unit/services/memory-facts.test.ts`
- `services/gateway/test/integration/settings-profile.test.ts`