### PR TITLE
DEV-AUTOPILOT: Support specialized provenance sources in Settings memory facts

### DIFF
--- a/services/gateway/src/routes/settings.ts
+++ b/services/gateway/src/routes/settings.ts
@@ -1,0 +1,53 @@
+import { Router, Response } from 'express';
+import { z } from 'zod';
+import { requireAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
+import { upsertMemoryFact } from '../services/memory-facts';
+
+const router = Router();
+
+const updateProfileSchema = z.object({
+  first_name: z.string().optional(),
+  nickname: z.string().optional(),
+});
+
+router.patch('/profile', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const userId = req.identity?.user_id;
+  if (!userId) {
+    return res.status(401).json({ ok: false, error: 'unauthorized' });
+  }
+
+  const parsed = updateProfileSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ ok: false, error: 'invalid payload' });
+  }
+
+  const { first_name, nickname } = parsed.data;
+
+  if (first_name !== undefined) {
+    const result = await upsertMemoryFact(
+      userId,
+      'user_first_name',
+      first_name,
+      'user_stated_via_settings'
+    );
+    if (!result.ok) {
+      return res.status(500).json({ ok: false, error: 'failed to save first_name' });
+    }
+  }
+
+  if (nickname !== undefined) {
+    const result = await upsertMemoryFact(
+      userId,
+      'user_nickname',
+      nickname,
+      'user_stated_via_settings'
+    );
+    if (!result.ok) {
+      return res.status(500).json({ ok: false, error: 'failed to save nickname' });
+    }
+  }
+
+  return res.json({ ok: true });
+});
+
+export default router;

--- a/services/gateway/src/services/memory-facts.ts
+++ b/services/gateway/src/services/memory-facts.ts
@@ -1,0 +1,33 @@
+import { getSupabase } from '../lib/supabase';
+import { ProvenanceSource } from '../types/memory-facts';
+
+export async function upsertMemoryFact(
+  userId: string,
+  factKey: string,
+  factValue: string,
+  provenanceSource: ProvenanceSource = 'user_stated'
+): Promise<{ ok: boolean; error?: string }> {
+  const supabase = getSupabase();
+  if (!supabase) {
+    return { ok: false, error: 'no supabase' };
+  }
+
+  const { error } = await supabase
+    .from('memory_facts')
+    .upsert(
+      {
+        user_id: userId,
+        fact_key: factKey,
+        fact_value: factValue,
+        provenance_source: provenanceSource,
+        updated_at: new Date().toISOString()
+      },
+      { onConflict: 'user_id, fact_key' }
+    );
+
+  if (error) {
+    return { ok: false, error: error.message };
+  }
+
+  return { ok: true };
+}

--- a/services/gateway/src/types/memory-facts.ts
+++ b/services/gateway/src/types/memory-facts.ts
@@ -1,0 +1,20 @@
+export const PROVENANCE_SOURCES = [
+  'user_stated',
+  'user_stated_via_settings',
+  'user_stated_via_memory_garden_ui',
+  'user_stated_via_onboarding',
+  'user_stated_via_baseline_survey',
+  'admin_correction',
+  'system_provision',
+  'consolidator',
+  'assistant_inferred'
+] as const;
+
+export type ProvenanceSource = typeof PROVENANCE_SOURCES[number];
+
+export interface MemoryFactPayload {
+  user_id: string;
+  fact_key: string;
+  fact_value: string;
+  provenance_source?: ProvenanceSource;
+}

--- a/services/gateway/test/integration/settings-profile.test.ts
+++ b/services/gateway/test/integration/settings-profile.test.ts
@@ -1,0 +1,85 @@
+import request from 'supertest';
+import express, { Response, NextFunction } from 'express';
+import settingsRouter from '../../../src/routes/settings';
+import { getSupabase } from '../../../src/lib/supabase';
+import { AuthenticatedRequest } from '../../../src/middleware/auth-supabase-jwt';
+
+jest.mock('../../../src/lib/supabase', () => ({
+  getSupabase: jest.fn()
+}));
+
+jest.mock('../../../src/middleware/auth-supabase-jwt', () => ({
+  requireAuth: (req: AuthenticatedRequest, res: Response, next: NextFunction) => {
+    req.identity = { 
+      user_id: 'test-user-123',
+      email: 'test@example.com',
+      tenant_id: null,
+      exafy_admin: false,
+      role: null
+    };
+    next();
+  }
+}));
+
+const app = express();
+app.use(express.json());
+app.use('/api/v1/settings', settingsRouter);
+
+describe('Settings Profile Integration', () => {
+  let mockUpsert: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUpsert = jest.fn().mockResolvedValue({ error: null });
+    
+    (getSupabase as jest.Mock).mockReturnValue({
+      from: jest.fn().mockReturnValue({
+        upsert: mockUpsert
+      })
+    });
+  });
+
+  it('should return 400 for an invalid payload', async () => {
+    const res = await request(app)
+      .patch('/api/v1/settings/profile')
+      .send({ first_name: 123 }); // integer instead of string
+
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toBe('invalid payload');
+  });
+
+  it('should update profile and write memory facts with correct provenance_source', async () => {
+    const res = await request(app)
+      .patch('/api/v1/settings/profile')
+      .send({
+        first_name: 'Bob',
+        nickname: 'Bobby'
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+
+    expect(mockUpsert).toHaveBeenCalledTimes(2);
+    
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'test-user-123',
+        fact_key: 'user_first_name',
+        fact_value: 'Bob',
+        provenance_source: 'user_stated_via_settings'
+      }),
+      expect.any(Object)
+    );
+    
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'test-user-123',
+        fact_key: 'user_nickname',
+        fact_value: 'Bobby',
+        provenance_source: 'user_stated_via_settings'
+      }),
+      expect.any(Object)
+    );
+  });
+});

--- a/services/gateway/test/unit/services/memory-facts.test.ts
+++ b/services/gateway/test/unit/services/memory-facts.test.ts
@@ -1,0 +1,72 @@
+import { upsertMemoryFact } from '../../../src/services/memory-facts';
+import { getSupabase } from '../../../src/lib/supabase';
+
+jest.mock('../../../src/lib/supabase', () => ({
+  getSupabase: jest.fn()
+}));
+
+describe('Memory Facts Service', () => {
+  let mockUpsert: jest.Mock;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    mockUpsert = jest.fn().mockResolvedValue({ error: null });
+    
+    (getSupabase as jest.Mock).mockReturnValue({
+      from: jest.fn().mockReturnValue({
+        upsert: mockUpsert
+      })
+    });
+  });
+
+  it('should upsert memory fact with default provenance source', async () => {
+    const result = await upsertMemoryFact('user-1', 'test_key', 'test_val');
+    
+    expect(result.ok).toBe(true);
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'user-1',
+        fact_key: 'test_key',
+        fact_value: 'test_val',
+        provenance_source: 'user_stated'
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it('should upsert memory fact with explicit provenance source', async () => {
+    const result = await upsertMemoryFact(
+      'user-1',
+      'user_first_name',
+      'Alice',
+      'user_stated_via_settings'
+    );
+    
+    expect(result.ok).toBe(true);
+    expect(mockUpsert).toHaveBeenCalledWith(
+      expect.objectContaining({
+        user_id: 'user-1',
+        fact_key: 'user_first_name',
+        fact_value: 'Alice',
+        provenance_source: 'user_stated_via_settings'
+      }),
+      expect.any(Object)
+    );
+  });
+
+  it('should handle supabase error gracefully', async () => {
+    mockUpsert.mockResolvedValueOnce({ error: { message: 'db error' } });
+    const result = await upsertMemoryFact('user-1', 'test_key', 'test_val');
+    
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('db error');
+  });
+
+  it('should handle missing supabase client', async () => {
+    (getSupabase as jest.Mock).mockReturnValue(null);
+    const result = await upsertMemoryFact('user-1', 'test_key', 'test_val');
+    
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('no supabase');
+  });
+});


### PR DESCRIPTION
**Summary**
This PR updates the memory facts write path to support explicit provenance sources. As part of Phase 0 identity locking fixes, identity-class memory facts (like first name, nickname) must use explicit provenance values (such as `user_stated_via_settings`) to pass the Identity Lock trigger constraint.

**Changes**
1. **Types**: Added `ProvenanceSource` union and constants covering the authorized provenance sources established in the database migration (`user_stated_via_settings`, etc) to `services/gateway/src/types/memory-facts.ts`.
2. **Service**: Created `upsertMemoryFact` in `services/gateway/src/services/memory-facts.ts` which accepts an optional `provenanceSource` parameter, defaulting to the legacy `user_stated` source.
3. **Routes**: Added `PATCH /profile` in `services/gateway/src/routes/settings.ts` with validation. It updates user identity facts, correctly supplying `user_stated_via_settings` to bypass the identity lock.
4. **Tests**: Covered the new functionality with unit and integration tests.

**References**
Plan execution: 6beb8aa7-693f-4501-a02b-2c98f437b3c6