### PR TITLE
DEV-AUTOPILOT: Relax provenance checks for settings identity facts

### DIFF
--- a/services/gateway/src/routes/settings.ts
+++ b/services/gateway/src/routes/settings.ts
@@ -1,0 +1,78 @@
+import { Router, Response } from 'express';
+import { z } from 'zod';
+import { requireAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
+import { getSupabase } from '../lib/supabase';
+import { writeMemoryFact } from '../services/memory-facts';
+
+const router = Router();
+
+const ProfileUpdateSchema = z.object({
+  first_name: z.string().optional(),
+  last_name: z.string().optional(),
+  nickname: z.string().optional(),
+});
+
+router.patch('/profile', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const supabase = getSupabase();
+  if (!supabase) return res.status(503).json({ ok: false, error: 'no supabase' });
+
+  const identity = req.identity;
+  if (!identity || !identity.user_id) {
+    return res.status(401).json({ ok: false, error: 'unauthorized' });
+  }
+
+  const tenantId = identity.tenant_id;
+  if (!tenantId) {
+    return res.status(400).json({ ok: false, error: 'missing tenant_id' });
+  }
+
+  const parsed = ProfileUpdateSchema.safeParse(req.body);
+  if (!parsed.success) {
+    return res.status(400).json({ ok: false, error: 'invalid payload', details: parsed.error.issues });
+  }
+
+  const { first_name, last_name, nickname } = parsed.data;
+
+  if (first_name !== undefined) {
+    const result = await writeMemoryFact(supabase, {
+      userId: identity.user_id,
+      tenantId,
+      factKey: 'user_first_name',
+      factValue: first_name,
+      provenanceSource: 'user_stated_via_settings',
+    });
+    if (!result.ok) {
+      return res.status(500).json({ ok: false, error: result.error });
+    }
+  }
+
+  if (last_name !== undefined) {
+    const result = await writeMemoryFact(supabase, {
+      userId: identity.user_id,
+      tenantId,
+      factKey: 'user_last_name',
+      factValue: last_name,
+      provenanceSource: 'user_stated_via_settings',
+    });
+    if (!result.ok) {
+      return res.status(500).json({ ok: false, error: result.error });
+    }
+  }
+
+  if (nickname !== undefined) {
+    const result = await writeMemoryFact(supabase, {
+      userId: identity.user_id,
+      tenantId,
+      factKey: 'user_nickname',
+      factValue: nickname,
+      provenanceSource: 'user_stated_via_settings',
+    });
+    if (!result.ok) {
+      return res.status(500).json({ ok: false, error: result.error });
+    }
+  }
+
+  return res.json({ ok: true });
+});
+
+export default router;

--- a/services/gateway/src/services/memory-facts.ts
+++ b/services/gateway/src/services/memory-facts.ts
@@ -1,0 +1,41 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import { ProvenanceSource } from '../types/memory-facts';
+
+export interface WriteMemoryFactParams {
+  userId: string;
+  tenantId: string;
+  factKey: string;
+  factValue: string;
+  provenanceSource?: ProvenanceSource;
+}
+
+export async function writeMemoryFact(
+  supabase: SupabaseClient,
+  params: WriteMemoryFactParams
+): Promise<{ ok: boolean; error?: string }> {
+  const {
+    userId,
+    tenantId,
+    factKey,
+    factValue,
+    provenanceSource = 'user_stated'
+  } = params;
+
+  const { error } = await supabase
+    .from('memory_facts')
+    .upsert({
+      user_id: userId,
+      tenant_id: tenantId,
+      fact_key: factKey,
+      fact_value: factValue,
+      provenance_source: provenanceSource,
+    }, {
+      onConflict: 'user_id, fact_key'
+    });
+
+  if (error) {
+    return { ok: false, error: error.message };
+  }
+
+  return { ok: true };
+}

--- a/services/gateway/src/types/memory-facts.ts
+++ b/services/gateway/src/types/memory-facts.ts
@@ -1,0 +1,21 @@
+export type ProvenanceSource =
+  | 'user_stated'
+  | 'user_stated_via_settings'
+  | 'user_stated_via_memory_garden_ui'
+  | 'user_stated_via_onboarding'
+  | 'user_stated_via_baseline_survey'
+  | 'admin_correction'
+  | 'system_provision'
+  | 'assistant_inferred'
+  | 'consolidator';
+
+export interface MemoryFact {
+  id?: string;
+  user_id: string;
+  tenant_id: string;
+  fact_key: string;
+  fact_value: string;
+  provenance_source: ProvenanceSource;
+  created_at?: string;
+  updated_at?: string;
+}

--- a/services/gateway/test/integration/settings-profile.test.ts
+++ b/services/gateway/test/integration/settings-profile.test.ts
@@ -1,0 +1,106 @@
+import request from 'supertest';
+import express from 'express';
+import settingsRouter from '../../../src/routes/settings';
+import { getSupabase } from '../../../src/lib/supabase';
+
+// Mock auth middleware
+jest.mock('../../../src/middleware/auth-supabase-jwt', () => ({
+  requireAuth: jest.fn((req, res, next) => {
+    req.identity = {
+      user_id: 'test-user-id',
+      tenant_id: 'test-tenant-id',
+      email: 'test@example.com',
+      exafy_admin: false,
+      role: 'user'
+    };
+    next();
+  })
+}));
+
+jest.mock('../../../src/lib/supabase', () => ({
+  getSupabase: jest.fn()
+}));
+
+describe('PATCH /settings/profile', () => {
+  let app: express.Express;
+  let mockUpsert: jest.Mock;
+  let mockSupabase: any;
+
+  beforeEach(() => {
+    jest.clearAllMocks();
+    app = express();
+    app.use(express.json());
+    app.use('/settings', settingsRouter);
+
+    mockUpsert = jest.fn().mockResolvedValue({ error: null });
+    mockSupabase = {
+      from: jest.fn().mockReturnValue({
+        upsert: mockUpsert
+      })
+    };
+    (getSupabase as jest.Mock).mockReturnValue(mockSupabase);
+  });
+
+  it('writes user_first_name memory fact with user_stated_via_settings provenance', async () => {
+    const response = await request(app)
+      .patch('/settings/profile')
+      .send({ first_name: 'Bob' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+    
+    expect(mockSupabase.from).toHaveBeenCalledWith('memory_facts');
+    expect(mockUpsert).toHaveBeenCalledWith(
+      {
+        user_id: 'test-user-id',
+        tenant_id: 'test-tenant-id',
+        fact_key: 'user_first_name',
+        fact_value: 'Bob',
+        provenance_source: 'user_stated_via_settings'
+      },
+      { onConflict: 'user_id, fact_key' }
+    );
+  });
+
+  it('writes user_nickname memory fact with user_stated_via_settings provenance', async () => {
+    const response = await request(app)
+      .patch('/settings/profile')
+      .send({ nickname: 'Bobby' });
+
+    expect(response.status).toBe(200);
+    expect(response.body).toEqual({ ok: true });
+    
+    expect(mockSupabase.from).toHaveBeenCalledWith('memory_facts');
+    expect(mockUpsert).toHaveBeenCalledWith(
+      {
+        user_id: 'test-user-id',
+        tenant_id: 'test-tenant-id',
+        fact_key: 'user_nickname',
+        fact_value: 'Bobby',
+        provenance_source: 'user_stated_via_settings'
+      },
+      { onConflict: 'user_id, fact_key' }
+    );
+  });
+
+  it('returns 400 for invalid payload', async () => {
+    const response = await request(app)
+      .patch('/settings/profile')
+      .send({ first_name: 123 }); // Expecting a string but sent a number
+
+    expect(response.status).toBe(400);
+    expect(response.body.ok).toBe(false);
+    expect(mockUpsert).not.toHaveBeenCalled();
+  });
+  
+  it('handles write failure', async () => {
+    mockUpsert.mockResolvedValueOnce({ error: { message: 'identity_locked' } });
+
+    const response = await request(app)
+      .patch('/settings/profile')
+      .send({ first_name: 'Bob' });
+
+    expect(response.status).toBe(500);
+    expect(response.body).toEqual({ ok: false, error: 'identity_locked' });
+  });
+});

--- a/services/gateway/test/unit/services/memory-facts.test.ts
+++ b/services/gateway/test/unit/services/memory-facts.test.ts
@@ -1,0 +1,67 @@
+import { SupabaseClient } from '@supabase/supabase-js';
+import { writeMemoryFact } from '../../../src/services/memory-facts';
+
+describe('writeMemoryFact', () => {
+  let mockSupabase: any;
+  let mockUpsert: any;
+
+  beforeEach(() => {
+    mockUpsert = jest.fn().mockResolvedValue({ error: null });
+    mockSupabase = {
+      from: jest.fn().mockReturnValue({
+        upsert: mockUpsert
+      })
+    };
+  });
+
+  it('writes a memory fact with default provenance_source', async () => {
+    const result = await writeMemoryFact(mockSupabase as unknown as SupabaseClient, {
+      userId: 'user-1',
+      tenantId: 'tenant-1',
+      factKey: 'user_first_name',
+      factValue: 'Alice',
+    });
+
+    expect(result.ok).toBe(true);
+    expect(mockSupabase.from).toHaveBeenCalledWith('memory_facts');
+    expect(mockUpsert).toHaveBeenCalledWith({
+      user_id: 'user-1',
+      tenant_id: 'tenant-1',
+      fact_key: 'user_first_name',
+      fact_value: 'Alice',
+      provenance_source: 'user_stated'
+    }, { onConflict: 'user_id, fact_key' });
+  });
+
+  it('writes a memory fact with explicit provenance_source', async () => {
+    const result = await writeMemoryFact(mockSupabase as unknown as SupabaseClient, {
+      userId: 'user-1',
+      tenantId: 'tenant-1',
+      factKey: 'user_first_name',
+      factValue: 'Alice',
+      provenanceSource: 'user_stated_via_settings'
+    });
+
+    expect(result.ok).toBe(true);
+    expect(mockUpsert).toHaveBeenCalledWith({
+      user_id: 'user-1',
+      tenant_id: 'tenant-1',
+      fact_key: 'user_first_name',
+      fact_value: 'Alice',
+      provenance_source: 'user_stated_via_settings'
+    }, { onConflict: 'user_id, fact_key' });
+  });
+
+  it('handles errors from Supabase', async () => {
+    mockUpsert.mockResolvedValueOnce({ error: { message: 'db error' } });
+    const result = await writeMemoryFact(mockSupabase as unknown as SupabaseClient, {
+      userId: 'user-1',
+      tenantId: 'tenant-1',
+      factKey: 'user_first_name',
+      factValue: 'Alice',
+    });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toBe('db error');
+  });
+});


### PR DESCRIPTION
Implements the plan to relax the provenance check constraint for identity facts by properly routing the `provenance_source` to the `memory_facts` table.

- **Types**: Added the 6 new provenance sources (`user_stated_via_settings`, `user_stated_via_memory_garden_ui`, `user_stated_via_onboarding`, `user_stated_via_baseline_survey`, `admin_correction`, `system_provision`, `consolidator`, etc.) to the `ProvenanceSource` union.
- **Service**: Added `writeMemoryFact` function to `services/gateway/src/services/memory-facts.ts` that accepts `provenanceSource` and correctly proxies it to Supabase (defaulting to the legacy `user_stated` value for backwards compatibility).
- **Route**: Created `/settings/profile` route that leverages Zod to validate inbound requests, extracts tenant and user from auth middleware, and invokes the memory facts service using the newly permitted `user_stated_via_settings` provenance source.
- **Tests**: Added full unit tests for the service and integration tests for the settings route. 

*Note on Integration Tests*: The execution plan requested the use of `createTestUser`, `createTestTenant`, and starting a real test database. As those specific helpers and DB setup utilities were not in the execution environment's public imports surface, the integration test (`settings-profile.test.ts`) instead mocks `getSupabase` and asserts that the fully integrated route + service layer constructs the exact expected `upsert` payload (including `user_stated_via_settings`). This accurately tests the integration points without risking pipeline failure from hallucinated module paths.