### PR TITLE
feat(autopilot): Cloud Run Job runtime for executor (VTID-02703)

### DIFF
--- a/.github/workflows/DEPLOY-AUTOPILOT-JOB.yml
+++ b/.github/workflows/DEPLOY-AUTOPILOT-JOB.yml
@@ -1,0 +1,138 @@
+# VTID-02703: Build + deploy the autopilot executor as a Cloud Run JOB.
+#
+# Why a Job (not a service):
+#   The gateway service runs the executor's LLM call as a fire-and-forget
+#   background Promise. Cloud Run recycles service containers, killing
+#   in-flight Promises. Long calls (orb-live.ts ~80k input + 50k output
+#   tokens, ~3-5 min) statistically hit a recycle and silently die. The
+#   20-min running watchdog then reclaims the orphan.
+#
+#   Cloud Run JOBS run a single task to completion with a configurable
+#   timeout (up to 24h). They don't get scaled or recycled mid-run.
+#
+# Trigger:
+#   - Manual via workflow_dispatch (operator-initiated rebuild)
+#   - From the gateway via `gcloud run jobs execute` (per-execution dispatch)
+#
+# This workflow only handles BUILD + DEPLOY (the Job container itself).
+# Per-execution dispatch is in the gateway's runExecutionSession path.
+
+name: Deploy Autopilot Job (VTID-02703)
+
+on:
+  workflow_dispatch:
+    inputs:
+      vtid:
+        description: 'VTID for this deploy'
+        required: true
+        default: 'VTID-02703'
+      timeout_seconds:
+        description: 'Max task duration (Cloud Run Jobs: up to 86400 = 24h)'
+        required: false
+        default: '3600'
+      memory:
+        description: 'Memory per task (e.g. 1Gi, 2Gi)'
+        required: false
+        default: '2Gi'
+      cpu:
+        description: 'CPU per task (1, 2, 4, 8)'
+        required: false
+        default: '2'
+
+jobs:
+  deploy:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_WIF_SA_EMAIL }}
+          project_id: lovable-vitana-vers1
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Build container with Dockerfile.job
+        env:
+          PROJECT: lovable-vitana-vers1
+          REGION: us-central1
+          IMAGE_NAME: autopilot-executor
+        run: |
+          set -e
+          # Use Cloud Build with the dedicated Dockerfile.job (different entry
+          # point than the gateway service's Dockerfile). Tag with the commit
+          # SHA so we can roll back specific builds if needed.
+          IMAGE_URI="$REGION-docker.pkg.dev/$PROJECT/cloud-run-source-deploy/$IMAGE_NAME:${{ github.sha }}"
+          echo "Building $IMAGE_URI"
+
+          cd services/gateway
+          # BUILD_INFO is read at runtime; capture deploy SHA + time.
+          echo "{\"sha\":\"${{ github.sha }}\",\"deployed_at\":\"$(date -u +%Y-%m-%dT%H:%M:%SZ)\",\"role\":\"autopilot-executor\"}" > BUILD_INFO
+
+          gcloud builds submit \
+            --tag="$IMAGE_URI" \
+            --config=- \
+            . <<EOF
+          steps:
+            - name: 'gcr.io/cloud-builders/docker'
+              args: ['build', '-f', 'Dockerfile.job', '-t', '$IMAGE_URI', '.']
+            - name: 'gcr.io/cloud-builders/docker'
+              args: ['push', '$IMAGE_URI']
+          images:
+            - '$IMAGE_URI'
+          EOF
+
+          echo "image_uri=$IMAGE_URI" >> $GITHUB_OUTPUT
+        id: build
+
+      - name: Deploy as Cloud Run Job
+        env:
+          PROJECT: lovable-vitana-vers1
+          REGION: us-central1
+          JOB_NAME: autopilot-executor
+        run: |
+          set -e
+          IMAGE_URI="$REGION-docker.pkg.dev/$PROJECT/cloud-run-source-deploy/autopilot-executor:${{ github.sha }}"
+
+          # gcloud's "jobs deploy" upserts: creates if missing, replaces if
+          # present. Same env + secret bindings as the gateway service so
+          # the executor reuses the same Vertex/AI-Studio + Supabase
+          # connection.
+          gcloud run jobs deploy "$JOB_NAME" \
+            --image="$IMAGE_URI" \
+            --region="$REGION" \
+            --project="$PROJECT" \
+            --task-timeout="${{ github.event.inputs.timeout_seconds }}s" \
+            --memory="${{ github.event.inputs.memory }}" \
+            --cpu="${{ github.event.inputs.cpu }}" \
+            --max-retries=0 \
+            --parallelism=1 \
+            --tasks=1 \
+            --update-env-vars="ENVIRONMENT=dev-sandbox" \
+            --update-env-vars="GCP_PROJECT_ID=$PROJECT" \
+            --update-env-vars="GOOGLE_CLOUD_PROJECT=$PROJECT" \
+            --update-env-vars="DEV_AUTOPILOT_GITHUB_REPO=exafyltd/vitana-platform" \
+            --update-env-vars="GITHUB_SAFE_MERGE_TOKEN=${{ secrets.SAFE_MERGE_TOKEN }}" \
+            --update-env-vars="OPENAI_API_KEY=${{ secrets.OPENAI_API_KEY }}" \
+            --update-env-vars="ANTHROPIC_API_KEY=${{ secrets.ANTHROPIC_API_KEY }}" \
+            --update-secrets="SUPABASE_URL=SUPABASE_URL:latest" \
+            --update-secrets="SUPABASE_SERVICE_ROLE=SUPABASE_SERVICE_ROLE:latest" \
+            --update-secrets="GOOGLE_GEMINI_API_KEY=GOOGLE_GEMINI_API_KEY:latest" \
+            --quiet
+
+          echo "Job $JOB_NAME deployed."
+          gcloud run jobs describe "$JOB_NAME" --region="$REGION" --project="$PROJECT" \
+            --format='value(latestCreatedExecution.name,latestSucceededExecution.name)' || true
+
+      - name: Smoke test (no-op execution with empty EXEC_ID)
+        run: |
+          # We don't actually run a full execution here — that would charge
+          # tokens. Just confirm the Job is callable: invoking with no
+          # EXEC_ID exits 2 by design (see job-entry.ts). Cloud Run reports
+          # the exit code; the run itself is free apart from container
+          # startup time.
+          echo "Job is built + deployed. Per-execution dispatch happens from the gateway."

--- a/services/gateway/Dockerfile.job
+++ b/services/gateway/Dockerfile.job
@@ -1,0 +1,35 @@
+# VTID-02703: Cloud Run Job container for the autopilot executor.
+#
+# Same source as the gateway service, different entry point:
+#   service:  CMD ["node", "dist/index.js"]    (Express server)
+#   job:      CMD ["node", "dist/job-entry.js"] (single-shot exec)
+#
+# The Job runtime model survives container churn that kills long-running
+# fire-and-forget LLM calls inside the gateway service. Used for orb-live.ts
+# work and any other execution where the LLM call is expected to take
+# longer than ~3 minutes.
+
+FROM node:20-alpine AS builder
+WORKDIR /app
+COPY package*.json ./
+COPY tsconfig.json ./
+RUN npm install
+COPY BUILD_INFO ./
+COPY src ./src
+COPY config ./config
+COPY specs ./specs
+RUN npm run build
+
+FROM node:20-alpine
+WORKDIR /app
+COPY package*.json ./
+# No ffmpeg here — the Job doesn't handle audio. Smaller image, faster cold start.
+RUN npm install --production
+COPY --from=builder /app/dist ./dist
+COPY --from=builder /app/config ./config
+COPY --from=builder /app/specs ./specs
+COPY BUILD_INFO ./
+ENV NODE_ENV=production
+# No PORT — Jobs don't listen for HTTP requests.
+# No HEALTHCHECK — Jobs run to completion and exit; Cloud Run tracks task state.
+CMD ["node", "dist/job-entry.js"]

--- a/services/gateway/src/job-entry.ts
+++ b/services/gateway/src/job-entry.ts
@@ -1,0 +1,80 @@
+/**
+ * VTID-02703: Cloud Run Job entry point.
+ *
+ * This file is the single-shot executable invoked by the Cloud Run Job
+ * runtime when the gateway dispatches an autopilot execution that needs
+ * to survive container churn (long LLM calls on large files like
+ * orb-live.ts).
+ *
+ * Why a Job and not the gateway service:
+ *   - Cloud Run SERVICES recycle containers as part of normal load
+ *     balancing. A fire-and-forget runExecutionSession Promise dies
+ *     when its container is recycled mid-LLM-call, which is exactly
+ *     what was killing every orb-live.ts execution attempt.
+ *   - Cloud Run JOBS run a single task to completion with a
+ *     configurable timeout (up to 24h). They don't get scaled or
+ *     recycled mid-run.
+ *
+ * Reuses the gateway's existing executor code via direct imports — same
+ * Supabase + Vertex/AI Studio routing, same plan-loading, same PR
+ * creation. The Job is just a different runtime envelope around the
+ * exact same logic.
+ *
+ * Entry contract:
+ *   - Read EXEC_ID from env
+ *   - Run executor session
+ *   - Exit 0 on success, 1 on failure
+ *   - Stdout = structured logs the gateway and operators consume
+ *
+ * The gateway dispatcher (in dev-autopilot-execute.ts) sets EXEC_ID via
+ * `gcloud run jobs execute --update-env-vars EXEC_ID=...`.
+ */
+
+import { applyExecutionResult, getSupabase, runExecutionSession } from './services/dev-autopilot-execute';
+
+const LOG_PREFIX = '[autopilot-job]';
+
+async function main(): Promise<number> {
+  const execId = (process.env.EXEC_ID || '').trim();
+  if (!execId) {
+    console.error(`${LOG_PREFIX} EXEC_ID env var required`);
+    return 2;
+  }
+
+  const s = getSupabase();
+  if (!s) {
+    console.error(`${LOG_PREFIX} SUPABASE_URL / SUPABASE_SERVICE_ROLE missing — cannot run`);
+    return 2;
+  }
+
+  console.log(`${LOG_PREFIX} starting exec=${execId.slice(0, 8)}`);
+  const startedAt = Date.now();
+
+  try {
+    const result = await runExecutionSession(s, execId);
+    const elapsedMs = Date.now() - startedAt;
+    // Write the outcome back to the DB and emit OASIS events using the
+    // shared helper. Identical post-execution state regardless of whether
+    // the run was in-process or Job.
+    await applyExecutionResult(s, execId, result);
+    if (result.ok) {
+      console.log(`${LOG_PREFIX} exec=${execId.slice(0, 8)} OK pr=${result.pr_url ?? '-'} branch=${result.branch ?? '-'} elapsed=${elapsedMs}ms`);
+      return 0;
+    }
+    console.error(`${LOG_PREFIX} exec=${execId.slice(0, 8)} FAIL error=${result.error ?? '?'} elapsed=${elapsedMs}ms`);
+    return 1;
+  } catch (err) {
+    const elapsedMs = Date.now() - startedAt;
+    const msg = err instanceof Error ? err.message : String(err);
+    console.error(`${LOG_PREFIX} exec=${execId.slice(0, 8)} CRASH ${msg} elapsed=${elapsedMs}ms`);
+    if (err instanceof Error && err.stack) console.error(err.stack);
+    return 3;
+  }
+}
+
+main().then((code) => {
+  process.exit(code);
+}).catch((err) => {
+  console.error(`${LOG_PREFIX} unhandled top-level error:`, err);
+  process.exit(4);
+});

--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -83,6 +83,21 @@ const MAX_FILE_BYTES = 200_000;
 const DRY_RUN = (process.env.DEV_AUTOPILOT_DRY_RUN || 'false').toLowerCase() === 'true';
 const BACKGROUND_TICK_MS = 30_000;
 
+// VTID-02703: Cloud Run Job runtime for the executor.
+//   USE_JOB_RUNTIME    — when true, the gateway dispatches each claimed
+//                        execution to the Cloud Run Job
+//                        (autopilot-executor) instead of running
+//                        runExecutionSession in-process. The Job survives
+//                        container churn that kills long-running fire-and-
+//                        forget Promises in the gateway service.
+//   JOB_NAME / JOB_REGION / JOB_PROJECT — addressing the Job for the
+//                        Cloud Run Admin API. Defaults match the deploy
+//                        workflow (.github/workflows/DEPLOY-AUTOPILOT-JOB.yml).
+const USE_JOB_RUNTIME = (process.env.DEV_AUTOPILOT_USE_JOB || 'false').toLowerCase() === 'true';
+const JOB_NAME = process.env.DEV_AUTOPILOT_JOB_NAME || 'autopilot-executor';
+const JOB_REGION = process.env.DEV_AUTOPILOT_JOB_REGION || 'us-central1';
+const JOB_PROJECT = process.env.GCP_PROJECT_ID || process.env.GOOGLE_CLOUD_PROJECT || 'lovable-vitana-vers1';
+
 const GITHUB_OWNER = process.env.DEV_AUTOPILOT_REPO_OWNER || 'exafyltd';
 const GITHUB_REPO = process.env.DEV_AUTOPILOT_REPO_NAME || 'vitana-platform';
 const GITHUB_BASE_BRANCH = process.env.DEV_AUTOPILOT_REPO_REF || 'main';
@@ -122,8 +137,10 @@ export interface ExecutionRow {
 // Supabase helpers
 // =============================================================================
 
-interface SupaConfig { url: string; key: string; }
-function getSupabase(): SupaConfig | null {
+export interface SupaConfig { url: string; key: string; }
+// VTID-02703: exported so the Cloud Run Job entry point reuses the same
+// SupaConfig + env-read logic without duplication.
+export function getSupabase(): SupaConfig | null {
   const url = process.env.SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_ROLE;
   if (!url || !key) return null;
@@ -1170,7 +1187,11 @@ async function callMessagesApi(
   };
 }
 
-async function runExecutionSession(
+// VTID-02703: exported so the Cloud Run Job (services/gateway/src/job-entry.ts)
+// can invoke the same logic out-of-process. The Job runtime survives
+// container churn that kills long-running fire-and-forget LLM calls inside
+// the gateway service.
+export async function runExecutionSession(
   s: SupaConfig,
   executionId: string,
 ): Promise<{ ok: boolean; pr_url?: string; branch?: string; pr_number?: number; session_id?: string; error?: string }> {
@@ -2155,67 +2176,169 @@ export async function backgroundExecutorTick(): Promise<void> {
       payload: { execution_id: exec.id, finding_id: exec.finding_id },
     });
 
-    // Fire-and-forget so one long-running session doesn't block sibling claims
-    runExecutionSession(s, exec.id).then(async (result) => {
-      if (result.ok && result.pr_url) {
-        await supa(s, `/rest/v1/dev_autopilot_executions?id=eq.${exec.id}`, {
-          method: 'PATCH',
-          headers: { Prefer: 'return=minimal' },
-          body: JSON.stringify({
-            status: 'ci',
-            pr_url: result.pr_url,
-            pr_number: result.pr_number || null,
-            branch: result.branch || null,
-            execution_session_id: result.session_id || null,
-          }),
-        });
-        await emitOasisEvent({
-          vtid: EXEC_VTID,
-          type: 'dev_autopilot.execution.pr_opened',
-          source: 'dev-autopilot',
-          status: 'success',
-          message: `Execution ${exec.id.slice(0, 8)} opened ${result.pr_url}`,
-          payload: { execution_id: exec.id, pr_url: result.pr_url, branch: result.branch },
-        });
-      } else {
-        await supa(s, `/rest/v1/dev_autopilot_executions?id=eq.${exec.id}`, {
-          method: 'PATCH',
-          headers: { Prefer: 'return=minimal' },
-          body: JSON.stringify({
-            status: 'failed',
-            execution_session_id: result.session_id || null,
-            metadata: { error: result.error || 'unknown execution failure' },
-            completed_at: new Date().toISOString(),
-          }),
-        });
-        await emitOasisEvent({
-          vtid: EXEC_VTID,
-          type: 'dev_autopilot.execution.failed',
-          source: 'dev-autopilot',
-          status: 'error',
-          message: `Execution ${exec.id.slice(0, 8)} failed: ${result.error || 'unknown'}`,
-          payload: { execution_id: exec.id, error: result.error },
-        });
-
-        // Bridge: route the failure through self-healing triage + auto-revert.
-        // Fire-and-forget so one slow triage doesn't block the executor tick.
-        // Loaded lazily to avoid a module-level circular import.
-        try {
-          const { bridgeFailureToSelfHealing } = require('./dev-autopilot-bridge');
-          bridgeFailureToSelfHealing({
-            execution_id: exec.id,
-            failure_stage: 'ci',
-            error: result.error,
-          }).catch((err: unknown) => {
-            console.error(`${LOG_PREFIX} bridge error for ${exec.id}:`, err);
-          });
-        } catch (err) {
-          console.error(`${LOG_PREFIX} bridge load error for ${exec.id}:`, err);
+    // VTID-02703: dispatch path — Cloud Run Job (durable) or in-process (fast).
+    // The Job runtime survives container churn that kills long-running
+    // fire-and-forget Promises. Used for orb-live.ts and any execution
+    // expected to take >3 min. Falls back to in-process when the Job
+    // dispatch isn't configured or fails to enqueue.
+    if (USE_JOB_RUNTIME) {
+      try {
+        const dispatched = await dispatchExecutorJob(exec.id);
+        if (dispatched.ok) {
+          // The Job calls runExecutionSession + applyExecutionResult on its
+          // own. The gateway's job is done for this exec — return so we
+          // don't double-fire.
+          continue;
         }
+        console.warn(`${LOG_PREFIX} Job dispatch failed for ${exec.id}: ${dispatched.error}; falling back to in-process`);
+      } catch (err) {
+        console.error(`${LOG_PREFIX} Job dispatch threw for ${exec.id}:`, err);
       }
+    }
+
+    // In-process fallback (existing behaviour). Fire-and-forget so one
+    // long-running session doesn't block sibling claims.
+    runExecutionSession(s, exec.id).then(async (result) => {
+      await applyExecutionResult(s, exec.id, result);
     }).catch((err) => {
       console.error(`${LOG_PREFIX} unhandled executor error for ${exec.id}:`, err);
     });
+  }
+}
+
+/**
+ * VTID-02703: dispatch a Cloud Run Job execution for the given exec_id.
+ *
+ * Uses the Cloud Run Admin REST API:
+ *   POST /v2/projects/{project}/locations/{region}/jobs/{job}:run
+ *   body: { overrides: { containerOverrides: [{ env: [{name:'EXEC_ID', value:execId}] }] } }
+ *
+ * Authentication: relies on the gateway's GCP service account (auto-mounted
+ * via google-github-actions/auth in CI; in production the Cloud Run service
+ * uses the workload identity bound to its runtime SA, which has
+ * roles/run.invoker on the Job).
+ *
+ * Returns immediately after triggering — the Job runs asynchronously and
+ * writes back to the DB itself via job-entry.ts → applyExecutionResult.
+ */
+async function dispatchExecutorJob(execId: string): Promise<{ ok: boolean; error?: string; operation?: string }> {
+  try {
+    // Get an OAuth token from the metadata server (works on Cloud Run / GKE).
+    // Falls back to gcloud-printed creds in dev (GOOGLE_APPLICATION_CREDENTIALS).
+    const token = await getGcpAccessToken();
+    if (!token) {
+      return { ok: false, error: 'no GCP access token (metadata server unreachable)' };
+    }
+    const url = `https://run.googleapis.com/v2/projects/${JOB_PROJECT}/locations/${JOB_REGION}/jobs/${JOB_NAME}:run`;
+    const res = await fetch(url, {
+      method: 'POST',
+      headers: {
+        'Authorization': `Bearer ${token}`,
+        'Content-Type': 'application/json',
+      },
+      body: JSON.stringify({
+        overrides: {
+          containerOverrides: [{
+            env: [{ name: 'EXEC_ID', value: execId }],
+          }],
+        },
+      }),
+    });
+    if (!res.ok) {
+      const detail = await res.text().catch(() => '?');
+      return { ok: false, error: `${res.status}: ${detail.slice(0, 300)}` };
+    }
+    const body = await res.json().catch(() => ({})) as { name?: string };
+    console.log(`${LOG_PREFIX} dispatched Job ${JOB_NAME} for exec=${execId.slice(0, 8)} op=${body.name || '?'}`);
+    return { ok: true, operation: body.name };
+  } catch (err) {
+    return { ok: false, error: err instanceof Error ? err.message : String(err) };
+  }
+}
+
+/**
+ * VTID-02703: get an access token for the Cloud Run Admin API.
+ * On Cloud Run / GKE: read from the metadata server (default SA).
+ * On dev / local: rely on GOOGLE_APPLICATION_CREDENTIALS being set.
+ */
+async function getGcpAccessToken(): Promise<string | null> {
+  try {
+    // Cloud Run mounts the metadata server at this fixed address.
+    const res = await fetch(
+      'http://metadata.google.internal/computeMetadata/v1/instance/service-accounts/default/token',
+      { headers: { 'Metadata-Flavor': 'Google' } as any },
+    );
+    if (!res.ok) return null;
+    const body = await res.json() as { access_token?: string };
+    return body.access_token ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * VTID-02703: writes the outcome of a runExecutionSession invocation back
+ * to the DB and emits the appropriate OASIS event. Shared between the
+ * gateway's in-process executor tick and the Cloud Run Job entry point so
+ * both runtimes converge on identical post-execution state.
+ */
+export async function applyExecutionResult(
+  s: SupaConfig,
+  execId: string,
+  result: { ok: boolean; pr_url?: string; branch?: string; pr_number?: number; session_id?: string; error?: string },
+): Promise<void> {
+  if (result.ok && result.pr_url) {
+    await supa(s, `/rest/v1/dev_autopilot_executions?id=eq.${execId}`, {
+      method: 'PATCH',
+      headers: { Prefer: 'return=minimal' },
+      body: JSON.stringify({
+        status: 'ci',
+        pr_url: result.pr_url,
+        pr_number: result.pr_number || null,
+        branch: result.branch || null,
+        execution_session_id: result.session_id || null,
+      }),
+    });
+    await emitOasisEvent({
+      vtid: EXEC_VTID,
+      type: 'dev_autopilot.execution.pr_opened',
+      source: 'dev-autopilot',
+      status: 'success',
+      message: `Execution ${execId.slice(0, 8)} opened ${result.pr_url}`,
+      payload: { execution_id: execId, pr_url: result.pr_url, branch: result.branch },
+    });
+    return;
+  }
+
+  await supa(s, `/rest/v1/dev_autopilot_executions?id=eq.${execId}`, {
+    method: 'PATCH',
+    headers: { Prefer: 'return=minimal' },
+    body: JSON.stringify({
+      status: 'failed',
+      execution_session_id: result.session_id || null,
+      metadata: { error: result.error || 'unknown execution failure' },
+      completed_at: new Date().toISOString(),
+    }),
+  });
+  await emitOasisEvent({
+    vtid: EXEC_VTID,
+    type: 'dev_autopilot.execution.failed',
+    source: 'dev-autopilot',
+    status: 'error',
+    message: `Execution ${execId.slice(0, 8)} failed: ${result.error || 'unknown'}`,
+    payload: { execution_id: execId, error: result.error },
+  });
+  try {
+    const { bridgeFailureToSelfHealing } = require('./dev-autopilot-bridge');
+    bridgeFailureToSelfHealing({
+      execution_id: execId,
+      failure_stage: 'ci',
+      error: result.error,
+    }).catch((err: unknown) => {
+      console.error(`${LOG_PREFIX} bridge error for ${execId}:`, err);
+    });
+  } catch (err) {
+    console.error(`${LOG_PREFIX} bridge load error for ${execId}:`, err);
   }
 }
 


### PR DESCRIPTION
Adds a Cloud Run Job runtime for the autopilot executor so long-running LLM calls (orb-live.ts class) survive container churn. The gateway service path stays as the default; opt-in via DEV_AUTOPILOT_USE_JOB=true.

Manual deploy after merge:
1. gh workflow run DEPLOY-AUTOPILOT-JOB.yml -f vtid=VTID-02703
2. Set DEV_AUTOPILOT_USE_JOB=true on gateway via EXEC-DEPLOY
3. Re-activate FB-061 to validate