### PR TITLE
chore(agents-registry): fix metadata drift to match running code (BOOTSTRAP-AGENTS-TRUTH)

### DIFF
--- a/supabase/migrations/20260510000000_BOOTSTRAP_agents_registry_truth.sql
+++ b/supabase/migrations/20260510000000_BOOTSTRAP_agents_registry_truth.sql
@@ -1,0 +1,68 @@
+-- =============================================================================
+-- Agents Registry — fix metadata drift to match what the code actually runs
+-- =============================================================================
+-- The original seed (20260410000000_agents_registry.sql) recorded aspirational
+-- LLM wiring rather than what each service actually invokes. Operators looking
+-- at the Command Hub Agents page see the wrong provider/model for several
+-- services and a duplicate row for an empty stub directory. This migration
+-- updates the rows to reflect ground truth in the code:
+--
+--   - vitana-orchestrator: deterministic verifier, no LLM call (was claimed
+--     claude-3-5-sonnet-20241022, but server.py records that as metadata only;
+--     verification.py has no LLM client)
+--   - worker-runner:      hardcoded claude-opus-4-6 in execution-service.ts
+--                         (was claimed gemini-3.1-pro-preview)
+--   - cognee-extractor:   gemini-3.1-pro-preview via litellm (was 'none')
+--   - openclaw-bridge:    bridge stub, currently DOWN (was 'unknown')
+--   - mcp-server:         empty directory pointing at services/mcp-gateway/;
+--                         row is a duplicate of mcp-gateway. Removed.
+-- =============================================================================
+
+UPDATE agents_registry
+SET
+  llm_provider = 'none',
+  llm_model    = NULL,
+  description  = 'Deterministic verification stage gate (VTID-01175). Runs file/mtime/test/artifact checks before terminalizing worker output. No LLM call.',
+  metadata     = metadata
+                 || jsonb_build_object('vtid', 'VTID-01175',
+                                       'invocation', 'http_only',
+                                       'note', 'Cloud Run service deploys deterministic checker; LLM fields previously misset.')
+WHERE agent_id = 'vitana-orchestrator';
+
+UPDATE agents_registry
+SET
+  llm_provider = 'claude',
+  llm_model    = 'claude-opus-4-6',
+  description  = 'Autonomous VTID execution plane (VTID-01200). Polls, claims, executes via Anthropic SDK (claude-opus-4-6 hardcoded in execution-service.ts), terminalizes. Bypasses llm-router; planned migration to callViaRouter() will make model config-driven.',
+  metadata     = metadata
+                 || jsonb_build_object('routing', 'hardcoded',
+                                       'planned', 'route_via_llm_router')
+WHERE agent_id = 'worker-runner';
+
+UPDATE agents_registry
+SET
+  llm_provider = 'gemini',
+  llm_model    = 'gemini-3.1-pro-preview',
+  description  = 'Extracts entities and relationships from ORB voice transcripts via Cognee + litellm; writes to memory_facts. Configurable via LLM_PROVIDER/LLM_MODEL env (currently gemini/gemini-3.1-pro-preview). Candidate for DeepSeek-V3 swap to reduce cost.',
+  metadata     = metadata
+                 || jsonb_build_object('runtime_config', 'env_driven',
+                                       'env_vars', jsonb_build_array('LLM_PROVIDER', 'LLM_MODEL'),
+                                       'swap_candidate', 'deepseek-chat')
+WHERE agent_id = 'cognee-extractor';
+
+UPDATE agents_registry
+SET
+  llm_provider = 'none',
+  llm_model    = NULL,
+  status       = 'down',
+  description  = 'OpenClaw integration bridge stub. Mixed local-Ollama (llama3.1:8b) for health calls + Anthropic Claude for non-health. No active gateway callers found; service has not heartbeated since seed. Confirm before unregistering.',
+  metadata     = metadata
+                 || jsonb_build_object('confirm_required', true,
+                                       'callers_found', 0,
+                                       'note', 'Has Ollama integration; keep code, may be repurposed.')
+WHERE agent_id = 'openclaw-bridge';
+
+-- mcp-server: services/mcp/ is an empty stub directory whose contents point at
+-- services/mcp-gateway/. The registry row is a duplicate. Remove it; mcp-gateway
+-- remains as the canonical entry.
+DELETE FROM agents_registry WHERE agent_id = 'mcp-server';


### PR DESCRIPTION
## Summary

The agents_registry seed (20260410000000_agents_registry.sql) recorded aspirational LLM wiring rather than what each service actually invokes. Operators looking at the Command Hub Agents page see misleading provider/model values for several services and a duplicate row for an empty stub directory.

This migration aligns the rows with ground truth in the code:

- vitana-orchestrator → provider=none, model=null. The Verification Engine is a deterministic checker; verification.py has no LLM client. The previous claude-3-5-sonnet-20241022 was metadata recorded in server.py but never invoked.
- worker-runner → provider=claude, model=claude-opus-4-6. Source: services/worker-runner/src/services/execution-service.ts:23. Bypasses llm-router. Marked routing=hardcoded with planned route_via_llm_router flag.
- cognee-extractor → provider=gemini, model=gemini-3.1-pro-preview. Source: services/agents/cognee-extractor/main.py:60 (env-driven). Marked swap_candidate=deepseek-chat.
- openclaw-bridge → provider=none, status=down. No active gateway callers. Marked confirm_required=true rather than deleted.
- mcp-server row deleted. services/mcp/ is an empty stub pointing at services/mcp-gateway/.

SQL-only; no service deploy required.

## Test plan

- [ ] Run via RUN-MIGRATION.yml workflow (manual)
- [ ] Tail logs for ROLLBACK (per memory: psql -f doesn't stop on error)
- [ ] Open Command Hub → Agents → Registered Agents and confirm rows match
- [ ] Run: SELECT agent_id, llm_provider, llm_model, status FROM agents_registry ORDER BY agent_id;

🤖 Generated with [Claude Code](https://claude.com/claude-code)