### PR TITLE
feat(orb-tool): voice tools for community superlatives — "who is...?" (VTID-02754)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -3577,6 +3577,143 @@ function buildLiveApiTools(
             required: ['pillar'],
           },
         },
+        // ─── VTID-02754 — Voice Tool Expansion P1b: Community Superlatives ("who is...?") ───
+        // Six tools answering ranking/superlative questions about community members.
+        // Privacy-gated by global_community_profiles.is_visible — opted-out members
+        // never appear, even when objectively the answer.
+        {
+          name: 'get_highest_vitana_index',
+          description: [
+            "Return the community member with the highest Vitana Index total score.",
+            "",
+            "CALL THIS WHEN the user asks:",
+            "  - 'Who has the highest Vitana Index?' / 'Wer hat den höchsten Vitana Index?'",
+            "  - \"Who's at the top of the leaderboard?\"",
+            "  - 'Show me the best Vitana score in the community'",
+            "",
+            "Returns a single profile (display_name, vitana_id, location, score) plus",
+            "the total_eligible count. Speak the result naturally — 'Anna has the highest",
+            "Vitana Index in the community at 712 points.' Use limit > 1 only if the user",
+            "explicitly asks for top-N ('top 5 scores').",
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              limit: { type: 'integer', description: 'Default 1. Max 10.' },
+            },
+          },
+        },
+        {
+          name: 'get_top_in_pillar',
+          description: [
+            "Return the community member with the highest score in a specific pillar.",
+            "",
+            "CALL THIS WHEN the user asks:",
+            "  - 'Who has the best Sleep score?' / 'Wer hat die beste Schlaf-Säule?'",
+            "  - 'Best at Nutrition in the community'",
+            "  - 'Top exerciser' / 'Most hydrated person'",
+            "  - \"Who's strongest in mental health?\"",
+            "",
+            "Map English/German pillar synonyms to the canonical 5 pillars:",
+            "  - water/Wasser → hydration",
+            "  - fitness/workout/movement/Bewegung → exercise",
+            "  - mind/mood/Geist → mental",
+            "  - food/diet/Ernährung → nutrition",
+            "  - rest/Schlaf → sleep",
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              pillar: {
+                type: 'string',
+                enum: ['nutrition', 'hydration', 'exercise', 'sleep', 'mental'],
+              },
+              limit: { type: 'integer', description: 'Default 1. Max 10.' },
+            },
+            required: ['pillar'],
+          },
+        },
+        {
+          name: 'get_first_member',
+          description: [
+            "Return the FIRST member who registered for the community (lowest registration_seq).",
+            "",
+            "CALL THIS WHEN the user asks:",
+            "  - 'Who was the first member of the community?'",
+            "  - 'Who registered first?' / 'Wer war der erste?'",
+            "  - 'Who are the OG members?' (use limit > 1 for OGs)",
+            "  - 'The original member'",
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              limit: { type: 'integer', description: 'Default 1. Max 10 for OG list.' },
+            },
+          },
+        },
+        {
+          name: 'get_newest_member',
+          description: [
+            "Return the most-recently-joined community member.",
+            "",
+            "CALL THIS WHEN the user asks:",
+            "  - 'Who is the newest member?' / 'Wer ist neu?'",
+            "  - 'Who just joined?'",
+            "  - 'Most recent signups' (use limit > 1)",
+            "  - 'Latest community member'",
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              limit: { type: 'integer', description: 'Default 1. Max 10.' },
+            },
+          },
+        },
+        {
+          name: 'get_most_followed',
+          description: [
+            "Return the community member with the most followers.",
+            "",
+            "CALL THIS WHEN the user asks:",
+            "  - 'Who has the most followers?' / 'Wer hat die meisten Follower?'",
+            "  - 'Most popular member'",
+            "  - 'Top influencer in the community'",
+            "  - 'Who has the biggest fanbase?'",
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              limit: { type: 'integer', description: 'Default 1. Max 10.' },
+            },
+          },
+        },
+        {
+          name: 'ask_who_is',
+          description: [
+            "Free-form superlative question router — use this ONLY when the user asks a",
+            "'who is...?' style question that doesn't map cleanly to one of the more",
+            "specific superlative tools (get_highest_vitana_index, get_top_in_pillar,",
+            "get_first_member, get_newest_member, get_most_followed).",
+            "",
+            "WHEN THE QUESTION CLEARLY MAPS, prefer the specific tool — it's faster and",
+            "more accurate. Use ask_who_is only as a fallback for ambiguous or compound",
+            "questions like 'who is the most active in my city?'",
+            "",
+            "If the router can't categorize the question, it returns a clarifying",
+            "follow-up — read it back to the user verbatim and let them refine.",
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              question: {
+                type: 'string',
+                description: "The user's verbatim 'who is...?' question.",
+              },
+              limit: { type: 'integer', description: 'Default 1. Max 10 for ranked lists.' },
+            },
+            required: ['question'],
+          },
+        },
         // BOOTSTRAP-ADMIN-DD: admin voice tools — only injected when active_role
         // is admin / exafy_admin / developer. Community sessions never see them
         // and the orb dispatcher rejects them server-side regardless.
@@ -6164,6 +6301,51 @@ async function executeLiveApiToolInner(
           };
         } catch (err: any) {
           console.error('[get_pillar_subscores] error:', err?.message);
+          return { success: false, result: '', error: err?.message || 'unknown' };
+        }
+      }
+
+      // ─── VTID-02754 — Voice Tool Expansion P1b: Community Superlatives ("who is...?") ───
+      case 'get_highest_vitana_index':
+      case 'get_top_in_pillar':
+      case 'get_first_member':
+      case 'get_newest_member':
+      case 'get_most_followed':
+      case 'ask_who_is': {
+        try {
+          const sup = await import('../services/voice-tools/superlatives');
+          const { createClient } = await import('@supabase/supabase-js');
+          const url = process.env.SUPABASE_URL;
+          const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+          if (!url || !key) return { success: false, result: '', error: 'Supabase not configured' };
+          const sb = createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
+          const limit = typeof args.limit === 'number' ? Math.max(1, Math.min(10, args.limit)) : 1;
+
+          let r: any;
+          if (toolName === 'get_highest_vitana_index') {
+            r = await sup.getHighestVitanaIndex(sb, limit);
+          } else if (toolName === 'get_top_in_pillar') {
+            const pillar = String(args.pillar || '').toLowerCase() as 'nutrition' | 'hydration' | 'exercise' | 'sleep' | 'mental';
+            r = await sup.getTopInPillar(sb, pillar, limit);
+          } else if (toolName === 'get_first_member') {
+            r = await sup.getMemberByRegistration(sb, 'first', limit);
+          } else if (toolName === 'get_newest_member') {
+            r = await sup.getMemberByRegistration(sb, 'newest', limit);
+          } else if (toolName === 'get_most_followed') {
+            r = await sup.getMostFollowed(sb, limit);
+          } else if (toolName === 'ask_who_is') {
+            r = await sup.askWhoIs(sb, { question: String(args.question || ''), limit });
+          }
+
+          if (r && r.ok === 'clarify') {
+            return { success: true, result: JSON.stringify({ clarify: true, question: r.question }) };
+          }
+          if (!r || r.ok === false) {
+            return { success: false, result: '', error: (r && r.error) || 'superlative_failed' };
+          }
+          return { success: true, result: JSON.stringify(r) };
+        } catch (err: any) {
+          console.error(`[${toolName}] error:`, err?.message);
           return { success: false, result: '', error: err?.message || 'unknown' };
         }
       }

--- a/services/gateway/src/routes/orb-tool.ts
+++ b/services/gateway/src/routes/orb-tool.ts
@@ -620,6 +620,64 @@ async function tool_log_health(
   };
 }
 
+// VTID-02754 — Community Superlatives ("who is...?")
+async function tool_superlative(
+  toolName:
+    | 'get_highest_vitana_index'
+    | 'get_top_in_pillar'
+    | 'get_first_member'
+    | 'get_newest_member'
+    | 'get_most_followed'
+    | 'ask_who_is',
+  args: ToolArgs,
+  sb: SupabaseClient,
+): Promise<ToolResult> {
+  const sup = await import('../services/voice-tools/superlatives');
+  const limit = typeof args.limit === 'number' ? Math.max(1, Math.min(10, args.limit)) : 1;
+
+  let r: any;
+  if (toolName === 'get_highest_vitana_index') {
+    r = await sup.getHighestVitanaIndex(sb, limit);
+  } else if (toolName === 'get_top_in_pillar') {
+    const pillar = String(args.pillar || '').toLowerCase() as 'nutrition' | 'hydration' | 'exercise' | 'sleep' | 'mental';
+    r = await sup.getTopInPillar(sb, pillar, limit);
+  } else if (toolName === 'get_first_member') {
+    r = await sup.getMemberByRegistration(sb, 'first', limit);
+  } else if (toolName === 'get_newest_member') {
+    r = await sup.getMemberByRegistration(sb, 'newest', limit);
+  } else if (toolName === 'get_most_followed') {
+    r = await sup.getMostFollowed(sb, limit);
+  } else if (toolName === 'ask_who_is') {
+    r = await sup.askWhoIs(sb, { question: String(args.question || ''), limit });
+  }
+
+  if (r && r.ok === 'clarify') {
+    return { ok: true, result: { clarify: true, question: r.question }, text: r.question };
+  }
+  if (!r || r.ok === false) {
+    return { ok: false, error: (r && r.error) || 'superlative_failed' };
+  }
+
+  // Friendly TTS line for the orb to speak.
+  const p = r.profile;
+  const name = p?.display_name ?? 'A community member';
+  let text = '';
+  if (toolName === 'get_highest_vitana_index') {
+    text = `${name} has the highest Vitana Index at ${r.metric_value} points.`;
+  } else if (toolName === 'get_top_in_pillar') {
+    text = `${name} leads ${args.pillar} at ${r.metric_value} points.`;
+  } else if (toolName === 'get_first_member') {
+    text = `${name} was the first member to join the community.`;
+  } else if (toolName === 'get_newest_member') {
+    text = `${name} just joined the community.`;
+  } else if (toolName === 'get_most_followed') {
+    text = `${name} has the most followers — ${r.metric_value} of them.`;
+  } else if (toolName === 'ask_who_is') {
+    text = `${name} — ${r.metric}: ${r.metric_value}.`;
+  }
+  return { ok: true, result: r, text };
+}
+
 async function tool_get_pillar_subscores(
   args: ToolArgs,
   id: Identity,
@@ -767,6 +825,15 @@ router.post('/orb/tool', requireAuth, async (req: AuthenticatedRequest, res: Res
         break;
       case 'get_pillar_subscores':
         r = await tool_get_pillar_subscores(args, identity, sb);
+        break;
+      // VTID-02754 — Community Superlatives ("who is...?")
+      case 'get_highest_vitana_index':
+      case 'get_top_in_pillar':
+      case 'get_first_member':
+      case 'get_newest_member':
+      case 'get_most_followed':
+      case 'ask_who_is':
+        r = await tool_superlative(name as any, args, sb);
         break;
       default:
         return res.status(404).json({ ok: false, error: `unknown tool: ${name}`, vtid: VTID });

--- a/services/gateway/src/services/voice-tools/superlatives.ts
+++ b/services/gateway/src/services/voice-tools/superlatives.ts
@@ -1,0 +1,397 @@
+/**
+ * VTID-02754 — Voice Tool Expansion P1b: Community Superlatives.
+ *
+ * Backs the "who is...?" voice tools. UX paradigm: the user asks a
+ * superlative question ("who has the highest Vitana Index?", "who is
+ * the youngest member?") and the ORB returns a single profile card
+ * (or top-N when explicitly requested).
+ *
+ * Privacy gate (CRITICAL):
+ *   Every result must respect global_community_profiles.is_visible.
+ *   A user who set their profile to private MUST NOT appear in any
+ *   superlative result, even if they're objectively the answer.
+ *
+ * Source-of-truth tables:
+ *   - app_users — display_name, avatar_url, vitana_id, created_at
+ *   - global_community_profiles — is_visible flag
+ *   - profiles — registration_seq, location
+ *   - vitana_index_scores — score_total + per-pillar scores
+ *   - relationships — follower edges (where defined; falls back to 0)
+ */
+
+import { SupabaseClient } from '@supabase/supabase-js';
+
+export type Pillar = 'nutrition' | 'hydration' | 'exercise' | 'sleep' | 'mental';
+
+export interface ProfileCard {
+  vitana_id: string | null;
+  display_name: string;
+  avatar_url: string | null;
+  location: string | null;
+  registration_seq: number | null;
+  member_since: string | null;
+}
+
+export interface SuperlativeResult {
+  ok: true;
+  metric: string;
+  metric_value: number | string | null;
+  metric_unit?: string;
+  profile: ProfileCard;
+  ranking?: ProfileCard[]; // top-N when requested
+  total_eligible: number;  // how many candidates were in scope after privacy filtering
+}
+
+export interface SuperlativeError {
+  ok: false;
+  error: string;
+}
+
+/**
+ * Returns the set of user_ids who have opted out of community visibility.
+ * Used to filter every superlative response.
+ */
+async function getHiddenUserIds(sb: SupabaseClient): Promise<Set<string>> {
+  const { data } = await sb
+    .from('global_community_profiles')
+    .select('user_id')
+    .eq('is_visible', false);
+  return new Set<string>((data || []).map((r: any) => String(r.user_id)));
+}
+
+/** Hydrate ProfileCard rows from app_users + profiles for a given list of user_ids. */
+async function hydrateProfiles(
+  sb: SupabaseClient,
+  userIds: string[],
+): Promise<Map<string, ProfileCard>> {
+  if (userIds.length === 0) return new Map();
+  const [{ data: users }, { data: profs }] = await Promise.all([
+    sb
+      .from('app_users')
+      .select('user_id, display_name, avatar_url, vitana_id, created_at')
+      .in('user_id', userIds),
+    sb
+      .from('profiles')
+      .select('user_id, registration_seq, location')
+      .in('user_id', userIds),
+  ]);
+  const profMap = new Map<string, any>((profs || []).map((p: any) => [String(p.user_id), p]));
+  const out = new Map<string, ProfileCard>();
+  for (const u of users || []) {
+    const p = profMap.get(String((u as any).user_id)) || {};
+    out.set(String((u as any).user_id), {
+      vitana_id: (u as any).vitana_id ?? null,
+      display_name: (u as any).display_name ?? 'A community member',
+      avatar_url: (u as any).avatar_url ?? null,
+      location: p.location ?? null,
+      registration_seq: p.registration_seq ?? null,
+      member_since: (u as any).created_at ?? null,
+    });
+  }
+  return out;
+}
+
+// ---------------------------------------------------------------------------
+// 1. Highest Vitana Index — top scorer on the most recent index row
+// ---------------------------------------------------------------------------
+
+export async function getHighestVitanaIndex(
+  sb: SupabaseClient,
+  limit = 1,
+): Promise<SuperlativeResult | SuperlativeError> {
+  const hidden = await getHiddenUserIds(sb);
+
+  const { data, error } = await sb
+    .from('vitana_index_scores')
+    .select('user_id, score_total, date')
+    .order('score_total', { ascending: false })
+    .order('date', { ascending: false })
+    .limit(Math.max(50, limit * 5));
+  if (error) return { ok: false, error: `index_query_failed: ${error.message}` };
+
+  const seen = new Set<string>();
+  const winners: Array<{ user_id: string; score_total: number; date: string }> = [];
+  for (const row of data || []) {
+    const uid = String((row as any).user_id);
+    if (hidden.has(uid) || seen.has(uid)) continue;
+    seen.add(uid);
+    winners.push({
+      user_id: uid,
+      score_total: Number((row as any).score_total) || 0,
+      date: String((row as any).date),
+    });
+    if (winners.length >= limit) break;
+  }
+  if (winners.length === 0) {
+    return { ok: false, error: 'no_eligible_candidates' };
+  }
+  const profiles = await hydrateProfiles(sb, winners.map(w => w.user_id));
+  const ranking = winners
+    .map(w => profiles.get(w.user_id))
+    .filter((p): p is ProfileCard => Boolean(p));
+
+  return {
+    ok: true,
+    metric: 'vitana_index_total',
+    metric_value: winners[0].score_total,
+    metric_unit: 'points',
+    profile: ranking[0],
+    ranking: limit > 1 ? ranking : undefined,
+    total_eligible: seen.size,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 2. Top in pillar — best score for a single pillar
+// ---------------------------------------------------------------------------
+
+export async function getTopInPillar(
+  sb: SupabaseClient,
+  pillar: Pillar,
+  limit = 1,
+): Promise<SuperlativeResult | SuperlativeError> {
+  const valid: Pillar[] = ['nutrition', 'hydration', 'exercise', 'sleep', 'mental'];
+  if (!valid.includes(pillar)) {
+    return { ok: false, error: `invalid pillar: ${pillar}` };
+  }
+  const column = `score_${pillar}` as const;
+  const hidden = await getHiddenUserIds(sb);
+
+  const { data, error } = await sb
+    .from('vitana_index_scores')
+    .select(`user_id, ${column}, date`)
+    .order(column, { ascending: false })
+    .order('date', { ascending: false })
+    .limit(Math.max(50, limit * 5));
+  if (error) return { ok: false, error: `pillar_query_failed: ${error.message}` };
+
+  const seen = new Set<string>();
+  const winners: Array<{ user_id: string; pillar_score: number }> = [];
+  for (const row of data || []) {
+    const uid = String((row as any).user_id);
+    if (hidden.has(uid) || seen.has(uid)) continue;
+    seen.add(uid);
+    winners.push({
+      user_id: uid,
+      pillar_score: Number((row as any)[column]) || 0,
+    });
+    if (winners.length >= limit) break;
+  }
+  if (winners.length === 0) {
+    return { ok: false, error: 'no_eligible_candidates' };
+  }
+  const profiles = await hydrateProfiles(sb, winners.map(w => w.user_id));
+  const ranking = winners
+    .map(w => profiles.get(w.user_id))
+    .filter((p): p is ProfileCard => Boolean(p));
+
+  return {
+    ok: true,
+    metric: `pillar_${pillar}`,
+    metric_value: winners[0].pillar_score,
+    metric_unit: 'points',
+    profile: ranking[0],
+    ranking: limit > 1 ? ranking : undefined,
+    total_eligible: seen.size,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 3 & 4. First / newest member — by registration_seq
+// ---------------------------------------------------------------------------
+
+export async function getMemberByRegistration(
+  sb: SupabaseClient,
+  direction: 'first' | 'newest',
+  limit = 1,
+): Promise<SuperlativeResult | SuperlativeError> {
+  const ascending = direction === 'first';
+  const hidden = await getHiddenUserIds(sb);
+
+  const { data, error } = await sb
+    .from('profiles')
+    .select('user_id, registration_seq')
+    .order('registration_seq', { ascending, nullsFirst: false })
+    .limit(Math.max(50, limit * 5));
+  if (error) return { ok: false, error: `registration_query_failed: ${error.message}` };
+
+  const seen = new Set<string>();
+  const winners: Array<{ user_id: string; registration_seq: number | null }> = [];
+  for (const row of data || []) {
+    const uid = String((row as any).user_id);
+    if (hidden.has(uid) || seen.has(uid)) continue;
+    seen.add(uid);
+    winners.push({
+      user_id: uid,
+      registration_seq: (row as any).registration_seq ?? null,
+    });
+    if (winners.length >= limit) break;
+  }
+  if (winners.length === 0) {
+    return { ok: false, error: 'no_eligible_candidates' };
+  }
+  const profiles = await hydrateProfiles(sb, winners.map(w => w.user_id));
+  const ranking = winners
+    .map(w => profiles.get(w.user_id))
+    .filter((p): p is ProfileCard => Boolean(p));
+
+  return {
+    ok: true,
+    metric: direction === 'first' ? 'first_member_registered' : 'newest_member_registered',
+    metric_value: winners[0].registration_seq ?? ranking[0].member_since,
+    profile: ranking[0],
+    ranking: limit > 1 ? ranking : undefined,
+    total_eligible: seen.size,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 5. Most followed — most followers via relationships table
+// ---------------------------------------------------------------------------
+
+export async function getMostFollowed(
+  sb: SupabaseClient,
+  limit = 1,
+): Promise<SuperlativeResult | SuperlativeError> {
+  const hidden = await getHiddenUserIds(sb);
+
+  // Probe to_user_id first (most common naming), fall back to followee_id.
+  let counts = new Map<string, number>();
+  let errMsg = '';
+
+  const probe1 = await sb
+    .from('relationships')
+    .select('to_user_id')
+    .limit(20000);
+  if (!probe1.error && Array.isArray(probe1.data)) {
+    for (const r of probe1.data) {
+      const u = String((r as any).to_user_id ?? '');
+      if (!u) continue;
+      counts.set(u, (counts.get(u) ?? 0) + 1);
+    }
+  } else {
+    errMsg = probe1.error?.message ?? '';
+  }
+
+  if (counts.size === 0) {
+    const probe2 = await sb
+      .from('relationships')
+      .select('followee_id')
+      .limit(20000);
+    if (!probe2.error && Array.isArray(probe2.data)) {
+      for (const r of probe2.data) {
+        const u = String((r as any).followee_id ?? '');
+        if (!u) continue;
+        counts.set(u, (counts.get(u) ?? 0) + 1);
+      }
+    } else if (!errMsg) {
+      errMsg = probe2.error?.message ?? '';
+    }
+  }
+
+  if (counts.size === 0) {
+    return {
+      ok: false,
+      error: `no_followers_data${errMsg ? `: ${errMsg}` : ''}`,
+    };
+  }
+
+  const sorted = Array.from(counts.entries())
+    .filter(([uid]) => !hidden.has(uid))
+    .sort((a, b) => b[1] - a[1])
+    .slice(0, Math.max(limit, 1));
+
+  if (sorted.length === 0) {
+    return { ok: false, error: 'no_eligible_candidates' };
+  }
+
+  const profiles = await hydrateProfiles(sb, sorted.map(([u]) => u));
+  const ranking = sorted
+    .map(([u]) => profiles.get(u))
+    .filter((p): p is ProfileCard => Boolean(p));
+
+  return {
+    ok: true,
+    metric: 'follower_count',
+    metric_value: sorted[0][1],
+    metric_unit: 'followers',
+    profile: ranking[0],
+    ranking: limit > 1 ? ranking : undefined,
+    total_eligible: counts.size,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// 6. ask_who_is — NL router for free-form superlative questions
+// ---------------------------------------------------------------------------
+
+interface AskWhoIsInput {
+  question: string;
+  limit?: number;
+}
+
+export async function askWhoIs(
+  sb: SupabaseClient,
+  input: AskWhoIsInput,
+): Promise<SuperlativeResult | SuperlativeError | { ok: 'clarify'; question: string }> {
+  const q = (input.question || '').toLowerCase().trim();
+  const limit = Math.max(1, Math.min(10, input.limit ?? 1));
+  if (!q) return { ok: false, error: 'empty_question' };
+
+  // Pillar superlatives
+  const pillarHit = (['nutrition', 'hydration', 'exercise', 'sleep', 'mental'] as Pillar[]).find(p =>
+    q.includes(p) ||
+    (p === 'exercise' && (q.includes('fit') || q.includes('workout'))) ||
+    (p === 'mental' && (q.includes('mind') || q.includes('mood'))) ||
+    (p === 'hydration' && q.includes('water')),
+  );
+  if (
+    pillarHit &&
+    (q.includes('best') || q.includes('top') || q.includes('highest') || q.includes('strongest'))
+  ) {
+    return getTopInPillar(sb, pillarHit, limit);
+  }
+
+  // Vitana Index leaderboard
+  if (
+    (q.includes('vitana index') || q.includes('vitana score') || q.includes('index')) &&
+    (q.includes('highest') || q.includes('best') || q.includes('top') || q.includes('leaderboard'))
+  ) {
+    return getHighestVitanaIndex(sb, limit);
+  }
+
+  // Tenure: first / OG members
+  if (
+    q.includes('first') ||
+    q.includes('og member') ||
+    q.includes('original') ||
+    (q.includes('oldest') && q.includes('member'))
+  ) {
+    return getMemberByRegistration(sb, 'first', limit);
+  }
+  if (
+    q.includes('newest') ||
+    q.includes('most recent') ||
+    (q.includes('latest') && q.includes('member')) ||
+    q.includes('just joined')
+  ) {
+    return getMemberByRegistration(sb, 'newest', limit);
+  }
+
+  // Followers
+  if (
+    q.includes('most follow') ||
+    q.includes('most popular') ||
+    q.includes('biggest fanbase') ||
+    q.includes('most fans')
+  ) {
+    return getMostFollowed(sb, limit);
+  }
+
+  // Couldn't map — clarify.
+  return {
+    ok: 'clarify',
+    question:
+      "I can answer who-is questions about: highest Vitana Index, best in a pillar (Nutrition/Hydration/Exercise/Sleep/Mental), first or newest member, or most followed. Which of those do you mean?",
+  };
+}


### PR DESCRIPTION
## Summary

Second slice of the 269-tool voice-expansion plan ([plan file](https://github.com/exafyltd/vitana-platform/blob/feat/voice-tools-p1a-VTID-02753/.claude/plans/make-a-plan-which-sunny-sifakis.md)).

Adds **6 new voice tools** for community superlatives. UX paradigm: voice asks \"who is...?\", ORB returns a single profile card (or top-N when explicitly requested). Distinct from match search (#9b) — that's \"find me a match for ME\"; this is \"tell me who in the community is the best/first/etc.\"

| Tool | Returns | Backed by |
|---|---|---|
| `get_highest_vitana_index` | Top scorer | `vitana_index_scores ORDER BY score_total DESC` |
| `get_top_in_pillar` | Best in 1 of 5 pillars | `vitana_index_scores ORDER BY score_<pillar> DESC` |
| `get_first_member` | Community OG | `profiles ORDER BY registration_seq ASC` |
| `get_newest_member` | Most recent signup | `profiles ORDER BY registration_seq DESC` |
| `get_most_followed` | Biggest follower count | `relationships GROUP BY to_user_id` |
| `ask_who_is` (NL router) | Routes free-form to specific tool | keyword heuristics + clarify fallback |

All six are \`community\`-tier — they appear on mobile + desktop sessions.

## Privacy gate (CRITICAL)

Every result respects \`global_community_profiles.is_visible\`. Members who opted out of community visibility never appear in any superlative result, even when objectively the answer. The shared service module fetches the hidden-id set first and filters every candidate against it before hydrating profile cards.

## Architecture (mirrors VTID-02753 P1a)

- Vertex declarations: \`services/gateway/src/routes/orb-live.ts\` (after \`get_pillar_subscores\` declaration)
- Vertex handlers: \`executeLiveApiToolInner\` switch in same file (after subscore case)
- LiveKit dispatcher mirror: \`services/gateway/src/routes/orb-tool.ts\` (single \`tool_superlative\` helper handles all 6 tool names via name discriminator)
- Shared service: **new file** \`services/gateway/src/services/voice-tools/superlatives.ts\` queries Supabase directly (no new HTTP endpoints needed; all ORDER BY queries on existing tables)

## Why this is small

The plan covers 24 tools in Surface 9c. This PR ships the high-leverage subset (5 deterministic + 1 NL router = 6). The remaining 18 (skill superlatives, geo-aware, streak, helpers, archetype, balance, age) land in subsequent slices.

## Base branch

This PR targets \`feat/voice-tools-p1a-VTID-02753\` (the P1a PR #1837), not main directly. After P1a merges to main, this PR will auto-rebase to main. This keeps the chain clean and lets reviewers see only the P1b delta.

## Test plan

- [ ] Voice E2E (Vertex): say \"Who has the highest Vitana Index?\" — confirm \`get_highest_vitana_index\` fires
- [ ] Voice E2E (Vertex): say \"Who's the best at Sleep?\" — confirm \`get_top_in_pillar\` fires with pillar='sleep'
- [ ] Voice E2E (Vertex): say \"Who was the first member?\" — confirm \`get_first_member\` fires
- [ ] Voice E2E (Vertex): say \"Who has the most followers?\" — confirm \`get_most_followed\` fires
- [ ] Voice E2E (Vertex): say \"Who is the most active in my city?\" (ambiguous) — confirm \`ask_who_is\` fires and returns clarify question
- [ ] Privacy gate: temporarily flip a top-scorer's \`global_community_profiles.is_visible=false\` — confirm they're skipped
- [ ] LiveKit parity: \`POST /api/v1/orb/tool\` with \`{\"name\":\"get_highest_vitana_index\",\"args\":{}}\` — confirm 200 + profile card

## Notes

- Pre-allocated **VTID-02754** before code (per CLAUDE.md rule + memory)
- Worktree built on /home/dstev/worktrees/p1b to avoid contention with the dev autopilot agent that was concurrently running on the main checkout
- Build verification deferred to CI (\`npm run build\` was blocked by cross-filesystem node_modules slowness on the new worktree); patterns mirror P1a (which built clean) so risk is low

🤖 Generated with [Claude Code](https://claude.com/claude-code)