### PR TITLE
feat(orb-tool): voice tools for calendar deep actions (VTID-02761)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -3577,6 +3577,139 @@ function buildLiveApiTools(
             required: ['pillar'],
           },
         },
+        // ─── VTID-02761 — Voice Tool Expansion P1d: Calendar deep tools ───
+        // Six tools that go beyond the existing search/create primitives:
+        // reschedule, cancel, complete, find_free_slot, get_event_details,
+        // check_calendar_conflicts. Each scopes to the calling user_id.
+        {
+          name: 'reschedule_event',
+          description: [
+            "Move an existing calendar event to a new time. Use when the user",
+            "says 'move my 3pm to 4pm', 'reschedule the dentist to tomorrow",
+            "morning', 'verschiebe den Termin'.",
+            "",
+            "BEFORE calling: confirm with the user the new start time. Compute",
+            "the absolute UTC ISO 8601 timestamp from their words + their tz",
+            "(in your context as user_tz). Optionally pass end_time; if omitted,",
+            "the event's existing duration is preserved.",
+            "",
+            "If the user references the event vaguely ('that thing on Tuesday'),",
+            "call search_calendar first to get the event_id, then this tool.",
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              event_id: { type: 'string', description: 'UUID of the event to reschedule.' },
+              start_time: { type: 'string', description: 'New start time, ISO 8601 UTC.' },
+              end_time: { type: 'string', description: 'Optional new end time, ISO 8601 UTC.' },
+            },
+            required: ['event_id', 'start_time'],
+          },
+        },
+        {
+          name: 'cancel_event',
+          description: [
+            "Cancel an event (soft delete — sets status=cancelled, recoverable",
+            "via UI). Use when the user says 'cancel my 3pm', 'I'm not going",
+            "to the meeting', 'lösche den Termin'.",
+            "",
+            "DESTRUCTIVE — confirm verbally before calling. Use search_calendar",
+            "first if the user references the event vaguely.",
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              event_id: { type: 'string', description: 'UUID of the event to cancel.' },
+            },
+            required: ['event_id'],
+          },
+        },
+        {
+          name: 'complete_event',
+          description: [
+            "Mark a calendar event as completed / skipped / partial after the",
+            "fact. When marked 'completed', the user's Vitana Index is",
+            "recomputed if the event has wellness_tags (e.g. 'meditation',",
+            "'workout').",
+            "",
+            "CALL THIS WHEN the user says:",
+            "  - 'I finished my workout' → completed",
+            "  - 'I skipped meditation today' → skipped",
+            "  - 'I only did half my run' → partial",
+            "  - 'Habe das Meeting gemacht' → completed",
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              event_id: { type: 'string', description: 'UUID of the event.' },
+              completion_status: {
+                type: 'string',
+                enum: ['completed', 'skipped', 'partial'],
+                description: 'How the event ended.',
+              },
+              completion_notes: { type: 'string', description: 'Optional free-text note.' },
+            },
+            required: ['event_id', 'completion_status'],
+          },
+        },
+        {
+          name: 'find_free_slot',
+          description: [
+            "Find the next available calendar slot of a given duration. Looks",
+            "for gaps today first, then tomorrow morning if none fit.",
+            "",
+            "CALL THIS WHEN the user asks:",
+            "  - 'When am I free for a 30-minute walk?'",
+            "  - 'Find me a 1-hour gap for the meeting'",
+            "  - 'Wann hätte ich Zeit für 45 Minuten?'",
+            "",
+            "Returns the next slot's start_time (ISO UTC). Speak it naturally",
+            "in the user's local time.",
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              duration_minutes: {
+                type: 'integer',
+                description: 'Required slot length in minutes. Min 5, max 480.',
+              },
+            },
+            required: ['duration_minutes'],
+          },
+        },
+        {
+          name: 'get_event_details',
+          description: [
+            "Fetch full details for one calendar event by id. Use AFTER",
+            "search_calendar when the user wants more info ('tell me about",
+            "that 3pm', 'what's the description for the dentist?').",
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              event_id: { type: 'string', description: 'UUID of the event.' },
+            },
+            required: ['event_id'],
+          },
+        },
+        {
+          name: 'check_calendar_conflicts',
+          description: [
+            "Find all confirmed events that overlap a proposed time window.",
+            "Use BEFORE create_calendar_event or reschedule_event when the",
+            "user proposes a time and you want to warn about clashes.",
+            "",
+            "Returns the list of overlapping events. Empty list = no conflict.",
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              start_time: { type: 'string', description: 'Proposed start, ISO 8601 UTC.' },
+              end_time: { type: 'string', description: 'Proposed end, ISO 8601 UTC.' },
+            },
+            required: ['start_time', 'end_time'],
+          },
+        },
         // BOOTSTRAP-ADMIN-DD: admin voice tools — only injected when active_role
         // is admin / exafy_admin / developer. Community sessions never see them
         // and the orb dispatcher rejects them server-side regardless.
@@ -6164,6 +6297,60 @@ async function executeLiveApiToolInner(
           };
         } catch (err: any) {
           console.error('[get_pillar_subscores] error:', err?.message);
+          return { success: false, result: '', error: err?.message || 'unknown' };
+        }
+      }
+
+      // ─── VTID-02761 — Voice Tool Expansion P1d: Calendar deep tools ───
+      case 'reschedule_event':
+      case 'cancel_event':
+      case 'complete_event':
+      case 'find_free_slot':
+      case 'get_event_details':
+      case 'check_calendar_conflicts': {
+        try {
+          const cd = await import('../services/voice-tools/calendar-deep');
+          const { createClient } = await import('@supabase/supabase-js');
+          const url = process.env.SUPABASE_URL;
+          const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+          if (!url || !key) return { success: false, result: '', error: 'Supabase not configured' };
+          const sb = createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
+          const role = (session as any)?.active_role || 'community';
+
+          let r: any;
+          if (toolName === 'reschedule_event') {
+            r = await cd.rescheduleEvent(lens.user_id, {
+              event_id: String(args.event_id || ''),
+              start_time: String(args.start_time || ''),
+              end_time: typeof args.end_time === 'string' ? args.end_time : undefined,
+            });
+          } else if (toolName === 'cancel_event') {
+            r = await cd.cancelEvent(lens.user_id, { event_id: String(args.event_id || '') });
+          } else if (toolName === 'complete_event') {
+            r = await cd.completeEvent(lens.user_id, {
+              event_id: String(args.event_id || ''),
+              completion_status: String(args.completion_status || 'completed') as any,
+              completion_notes: typeof args.completion_notes === 'string' ? args.completion_notes : undefined,
+            });
+          } else if (toolName === 'find_free_slot') {
+            r = await cd.findFreeSlot(lens.user_id, role, {
+              duration_minutes: Number(args.duration_minutes || 0),
+            });
+          } else if (toolName === 'get_event_details') {
+            r = await cd.getEventDetails(sb, lens.user_id, { event_id: String(args.event_id || '') });
+          } else if (toolName === 'check_calendar_conflicts') {
+            r = await cd.checkCalendarConflicts(lens.user_id, role, {
+              start_time: String(args.start_time || ''),
+              end_time: String(args.end_time || ''),
+            });
+          }
+
+          if (!r || r.ok === false) {
+            return { success: false, result: '', error: (r && r.error) || `${toolName}_failed` };
+          }
+          return { success: true, result: JSON.stringify(r) };
+        } catch (err: any) {
+          console.error(`[${toolName}] error:`, err?.message);
           return { success: false, result: '', error: err?.message || 'unknown' };
         }
       }

--- a/services/gateway/src/routes/orb-tool.ts
+++ b/services/gateway/src/routes/orb-tool.ts
@@ -620,6 +620,68 @@ async function tool_log_health(
   };
 }
 
+// VTID-02761 — Calendar deep tools
+async function tool_calendar_deep(
+  toolName:
+    | 'reschedule_event'
+    | 'cancel_event'
+    | 'complete_event'
+    | 'find_free_slot'
+    | 'get_event_details'
+    | 'check_calendar_conflicts',
+  args: ToolArgs,
+  id: Identity,
+  sb: SupabaseClient,
+): Promise<ToolResult> {
+  const cd = await import('../services/voice-tools/calendar-deep');
+  const role = id.role ?? 'community';
+  let r: any;
+  if (toolName === 'reschedule_event') {
+    r = await cd.rescheduleEvent(id.user_id, {
+      event_id: String(args.event_id || ''),
+      start_time: String(args.start_time || ''),
+      end_time: typeof args.end_time === 'string' ? args.end_time : undefined,
+    });
+  } else if (toolName === 'cancel_event') {
+    r = await cd.cancelEvent(id.user_id, { event_id: String(args.event_id || '') });
+  } else if (toolName === 'complete_event') {
+    r = await cd.completeEvent(id.user_id, {
+      event_id: String(args.event_id || ''),
+      completion_status: String(args.completion_status || 'completed') as any,
+      completion_notes: typeof args.completion_notes === 'string' ? args.completion_notes : undefined,
+    });
+  } else if (toolName === 'find_free_slot') {
+    r = await cd.findFreeSlot(id.user_id, role, {
+      duration_minutes: Number(args.duration_minutes || 0),
+    });
+  } else if (toolName === 'get_event_details') {
+    r = await cd.getEventDetails(sb, id.user_id, { event_id: String(args.event_id || '') });
+  } else if (toolName === 'check_calendar_conflicts') {
+    r = await cd.checkCalendarConflicts(id.user_id, role, {
+      start_time: String(args.start_time || ''),
+      end_time: String(args.end_time || ''),
+    });
+  }
+  if (!r || r.ok === false) return { ok: false, error: (r && r.error) || `${toolName}_failed` };
+
+  let text = '';
+  if (toolName === 'reschedule_event') {
+    text = `Rescheduled "${r.event?.title ?? 'event'}".`;
+  } else if (toolName === 'cancel_event') {
+    text = `Cancelled "${r.event?.title ?? 'event'}".`;
+  } else if (toolName === 'complete_event') {
+    text = `Marked "${r.event?.title ?? 'event'}" as ${args.completion_status}.`;
+  } else if (toolName === 'find_free_slot') {
+    text = `Next free slot: ${r.start_time} (${r.duration_minutes} min).`;
+  } else if (toolName === 'get_event_details') {
+    text = `${r.event?.title ?? 'Event'} at ${r.event?.start_time ?? 'unknown'}.`;
+  } else if (toolName === 'check_calendar_conflicts') {
+    const n = r.conflicts?.length ?? 0;
+    text = n === 0 ? 'No conflicts.' : `${n} conflicting event${n === 1 ? '' : 's'}.`;
+  }
+  return { ok: true, result: r, text };
+}
+
 async function tool_get_pillar_subscores(
   args: ToolArgs,
   id: Identity,
@@ -767,6 +829,15 @@ router.post('/orb/tool', requireAuth, async (req: AuthenticatedRequest, res: Res
         break;
       case 'get_pillar_subscores':
         r = await tool_get_pillar_subscores(args, identity, sb);
+        break;
+      // VTID-02761 — Calendar deep tools
+      case 'reschedule_event':
+      case 'cancel_event':
+      case 'complete_event':
+      case 'find_free_slot':
+      case 'get_event_details':
+      case 'check_calendar_conflicts':
+        r = await tool_calendar_deep(name as any, args, identity, sb);
         break;
       default:
         return res.status(404).json({ ok: false, error: `unknown tool: ${name}`, vtid: VTID });

--- a/services/gateway/src/services/voice-tools/calendar-deep.ts
+++ b/services/gateway/src/services/voice-tools/calendar-deep.ts
@@ -1,0 +1,172 @@
+/**
+ * VTID-02761 — Voice Tool Expansion P1d: Calendar deep tools.
+ *
+ * Backs the deep-action calendar voice tools that go beyond the
+ * existing search/create primitives:
+ *   - reschedule_event   → updateCalendarEvent
+ *   - cancel_event       → softDeleteEvent
+ *   - complete_event     → markEventCompleted
+ *   - find_free_slot     → computeNextAvailableSlot
+ *   - get_event_details  → direct read of calendar_events row
+ *   - check_calendar_conflicts → checkConflicts
+ *
+ * All helpers are user-scoped — every query passes the calling
+ * user_id to the underlying calendar-service function which enforces
+ * "this row belongs to this user" before touching it.
+ */
+
+import { SupabaseClient } from '@supabase/supabase-js';
+import {
+  updateCalendarEvent,
+  softDeleteEvent,
+  markEventCompleted,
+  computeNextAvailableSlot,
+  checkConflicts,
+} from '../calendar-service';
+
+export interface VoiceCalEvent {
+  id: string;
+  title: string;
+  start_time: string;
+  end_time: string | null;
+  status: string;
+  event_type: string | null;
+  description?: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// 1. reschedule_event
+// ---------------------------------------------------------------------------
+
+export async function rescheduleEvent(
+  userId: string,
+  args: { event_id: string; start_time: string; end_time?: string },
+): Promise<{ ok: true; event: VoiceCalEvent } | { ok: false; error: string }> {
+  if (!args.event_id) return { ok: false, error: 'event_id_required' };
+  if (!args.start_time) return { ok: false, error: 'start_time_required' };
+  try {
+    const updates: any = { start_time: args.start_time };
+    if (args.end_time) updates.end_time = args.end_time;
+    const event = await updateCalendarEvent(args.event_id, userId, updates);
+    if (!event) return { ok: false, error: 'event_not_found' };
+    return { ok: true, event: event as any };
+  } catch (e: any) {
+    return { ok: false, error: `reschedule_failed: ${e?.message ?? 'unknown'}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 2. cancel_event (soft-delete; row stays in DB with status=cancelled)
+// ---------------------------------------------------------------------------
+
+export async function cancelEvent(
+  userId: string,
+  args: { event_id: string },
+): Promise<{ ok: true; event: VoiceCalEvent } | { ok: false; error: string }> {
+  if (!args.event_id) return { ok: false, error: 'event_id_required' };
+  try {
+    const event = await softDeleteEvent(args.event_id, userId);
+    if (!event) return { ok: false, error: 'event_not_found' };
+    return { ok: true, event: event as any };
+  } catch (e: any) {
+    return { ok: false, error: `cancel_failed: ${e?.message ?? 'unknown'}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 3. complete_event — mark completed/skipped/partial
+// ---------------------------------------------------------------------------
+
+export async function completeEvent(
+  userId: string,
+  args: {
+    event_id: string;
+    completion_status: 'completed' | 'skipped' | 'partial';
+    completion_notes?: string;
+  },
+): Promise<{ ok: true; event: VoiceCalEvent } | { ok: false; error: string }> {
+  if (!args.event_id) return { ok: false, error: 'event_id_required' };
+  if (!['completed', 'skipped', 'partial'].includes(args.completion_status)) {
+    return { ok: false, error: 'invalid_completion_status' };
+  }
+  try {
+    const event = await markEventCompleted(
+      args.event_id,
+      userId,
+      args.completion_status,
+      args.completion_notes,
+    );
+    if (!event) return { ok: false, error: 'event_not_found' };
+    return { ok: true, event: event as any };
+  } catch (e: any) {
+    return { ok: false, error: `complete_failed: ${e?.message ?? 'unknown'}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 4. find_free_slot — returns the next free slot fitting the duration
+// ---------------------------------------------------------------------------
+
+export async function findFreeSlot(
+  userId: string,
+  role: string | null,
+  args: { duration_minutes: number },
+): Promise<
+  { ok: true; start_time: string; duration_minutes: number } | { ok: false; error: string }
+> {
+  const dur = Number(args.duration_minutes);
+  if (!Number.isFinite(dur) || dur < 5 || dur > 480) {
+    return { ok: false, error: 'duration_out_of_range' };
+  }
+  try {
+    const slot = await computeNextAvailableSlot(userId, role, dur);
+    return {
+      ok: true,
+      start_time: slot.toISOString(),
+      duration_minutes: dur,
+    };
+  } catch (e: any) {
+    return { ok: false, error: `slot_search_failed: ${e?.message ?? 'unknown'}` };
+  }
+}
+
+// ---------------------------------------------------------------------------
+// 5. get_event_details — direct read with user_id scoping
+// ---------------------------------------------------------------------------
+
+export async function getEventDetails(
+  sb: SupabaseClient,
+  userId: string,
+  args: { event_id: string },
+): Promise<{ ok: true; event: VoiceCalEvent } | { ok: false; error: string }> {
+  if (!args.event_id) return { ok: false, error: 'event_id_required' };
+  const { data, error } = await sb
+    .from('calendar_events')
+    .select('id, title, start_time, end_time, status, event_type, description')
+    .eq('id', args.event_id)
+    .eq('user_id', userId)
+    .maybeSingle();
+  if (error) return { ok: false, error: `details_query_failed: ${error.message}` };
+  if (!data) return { ok: false, error: 'event_not_found' };
+  return { ok: true, event: data as any };
+}
+
+// ---------------------------------------------------------------------------
+// 6. check_calendar_conflicts — find events that overlap a proposed window
+// ---------------------------------------------------------------------------
+
+export async function checkCalendarConflicts(
+  userId: string,
+  role: string | null,
+  args: { start_time: string; end_time: string },
+): Promise<{ ok: true; conflicts: VoiceCalEvent[] } | { ok: false; error: string }> {
+  if (!args.start_time || !args.end_time) {
+    return { ok: false, error: 'window_required' };
+  }
+  try {
+    const conflicts = await checkConflicts(userId, role, args.start_time, args.end_time);
+    return { ok: true, conflicts: conflicts as any };
+  } catch (e: any) {
+    return { ok: false, error: `conflict_check_failed: ${e?.message ?? 'unknown'}` };
+  }
+}


### PR DESCRIPTION
## Summary

Fourth slice of the 269-tool voice-expansion plan ([plan file](https://github.com/exafyltd/vitana-platform/blob/feat/voice-tools-p1a-VTID-02753/.claude/plans/make-a-plan-which-sunny-sifakis.md)).

Adds **6 new voice tools** for deep calendar actions — beyond the existing \`search_calendar\` / \`create_calendar_event\` / \`get_schedule\` / \`add_to_calendar\` primitives. These operate on specific events the user already has.

| Tool | Backed by | Notes |
|---|---|---|
| \`reschedule_event\` | \`updateCalendarEvent\` | Preserves duration if end_time omitted |
| \`cancel_event\` | \`softDeleteEvent\` | Soft delete — recoverable via UI |
| \`complete_event\` | \`markEventCompleted\` | \"completed\" + wellness_tags triggers Index recompute |
| \`find_free_slot\` | \`computeNextAvailableSlot\` | Next gap that fits requested duration |
| \`get_event_details\` | \`calendar_events\` SELECT | Scoped by user_id |
| \`check_calendar_conflicts\` | \`checkConflicts\` | Use BEFORE create/reschedule |

All six are \`community\`-tier — they appear on mobile + desktop sessions.

## Architecture (mirrors P1a–P1c)

- Vertex declarations: \`services/gateway/src/routes/orb-live.ts\` (after the P1c diary/memory block)
- Vertex handlers: \`executeLiveApiToolInner\` switch (after the subscore case)
- LiveKit dispatcher mirror: \`services/gateway/src/routes/orb-tool.ts\` (single \`tool_calendar_deep\` helper handles all 6 names via discriminator)
- Shared service: **new file** \`services/gateway/src/services/voice-tools/calendar-deep.ts\` wraps existing exports from \`services/calendar-service.ts\`. No new gateway endpoints needed — every helper is already implemented and used by the corresponding routes in \`routes/calendar.ts\`.

## Safety / scope

- Each helper passes \`user_id\` to the underlying service — application-layer ownership check before mutation.
- \`cancel_event\` is soft-delete (status=cancelled), so recoverable from UI.
- \`reschedule_event\` description tells the LLM to confirm the new time verbally before calling.

## Base branch

This PR targets \`feat/voice-tools-p1a-VTID-02753\` (P1a #1837), same as P1b #1857 and P1c #1858. After P1a merges to main, all three rebase cleanly.

## Test plan

- [ ] Voice E2E: \"Move my 3pm dentist to 4pm\" → \`reschedule_event\` fires
- [ ] Voice E2E: \"Cancel my 6pm gym\" → ORB confirms then \`cancel_event\` fires
- [ ] Voice E2E: \"I finished my workout\" → \`complete_event\` fires with status=completed; Vitana Index ticks up
- [ ] Voice E2E: \"When am I free for a 30-minute walk?\" → \`find_free_slot\` returns a slot
- [ ] Voice E2E: \"Tell me about that 3pm thing\" (after search_calendar) → \`get_event_details\` fires
- [ ] LiveKit parity: \`POST /api/v1/orb/tool\` with \`{\"name\":\"find_free_slot\",\"args\":{\"duration_minutes\":30}}\`

## Notes

- Pre-allocated **VTID-02761** before code (per CLAUDE.md rule + memory)
- Worktree on /home/dstev/worktrees/p1d (proven autopilot-safe pattern)
- Build verification deferred to CI; patterns mirror P1a–P1c which built clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)