### PR TITLE
feat(orb-tool): voice tools for reminder lifecycle extension (VTID-02763)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -3577,6 +3577,113 @@ function buildLiveApiTools(
             required: ['pillar'],
           },
         },
+        // ─── VTID-02763 — Voice Tool Expansion P1e: Reminders extension ───
+        // Five tools that complete the reminder lifecycle beyond the existing
+        // set_reminder / find_reminders / delete_reminder primitives.
+        {
+          name: 'snooze_reminder',
+          description: [
+            "Push a reminder out by N minutes (default 10, max 24 hours).",
+            "",
+            "CALL THIS WHEN the user says:",
+            "  - 'Snooze that reminder for 15 minutes'",
+            "  - 'Remind me again in an hour'",
+            "  - 'Verschiebe die Erinnerung'",
+            "",
+            "Use after the reminder has fired. Use find_reminders first if",
+            "you need the reminder_id.",
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              reminder_id: { type: 'string', description: 'UUID of the reminder.' },
+              minutes: { type: 'integer', description: 'How many minutes to push (default 10, max 1440).' },
+            },
+            required: ['reminder_id'],
+          },
+        },
+        {
+          name: 'update_reminder',
+          description: [
+            "Edit an existing reminder — change its text, spoken message, or",
+            "scheduled time. New time must be at least 60s in the future.",
+            "",
+            "CALL THIS WHEN the user says:",
+            "  - 'Move my magnesium reminder to 9pm'",
+            "  - 'Change that reminder to say take vitamin D'",
+            "  - 'Update the spoken message'",
+            "",
+            "Always confirm the change verbally after the tool returns.",
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              reminder_id: { type: 'string', description: 'UUID of the reminder.' },
+              action_text: { type: 'string', description: 'New short label (max 60 chars).' },
+              spoken_message: { type: 'string', description: 'New friendly sentence to speak at fire time.' },
+              scheduled_for_iso: { type: 'string', description: 'New absolute UTC ISO time. Must be ≥60s in future.' },
+              description: { type: 'string', description: 'Optional extended details.' },
+            },
+            required: ['reminder_id'],
+          },
+        },
+        {
+          name: 'acknowledge_reminder',
+          description: [
+            "Record that a reminder was delivered. Use IMMEDIATELY after the",
+            "ORB has spoken a fired reminder so it doesn't repeat.",
+            "",
+            "via must be one of: 'sse' (live SSE delivery), 'fcm' (push), 'manual'",
+            "(user said 'I heard it' on a missed reminder), 'manual_replay'",
+            "(user replayed a missed one), 'none' (silenced without delivery).",
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              reminder_id: { type: 'string', description: 'UUID of the reminder.' },
+              via: {
+                type: 'string',
+                enum: ['sse', 'fcm', 'manual', 'manual_replay', 'none'],
+                description: 'How the reminder was delivered.',
+              },
+            },
+            required: ['reminder_id'],
+          },
+        },
+        {
+          name: 'complete_reminder',
+          description: [
+            "Mark a reminder as DONE — the user did the thing it was reminding",
+            "about. Distinct from acknowledge_reminder (which only records",
+            "delivery).",
+            "",
+            "CALL THIS WHEN the user says:",
+            "  - 'I took my magnesium'",
+            "  - 'Done with that reminder'",
+            "  - 'Erledigt'",
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              reminder_id: { type: 'string', description: 'UUID of the reminder.' },
+            },
+            required: ['reminder_id'],
+          },
+        },
+        {
+          name: 'list_missed_reminders',
+          description: [
+            "List reminders that fired but the user never acknowledged (still",
+            "pending replay). Use when the user asks 'what did I miss?' or at",
+            "session start to surface things they should hear.",
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              limit: { type: 'integer', description: 'Default 5. Max 20.' },
+            },
+          },
+        },
         // BOOTSTRAP-ADMIN-DD: admin voice tools — only injected when active_role
         // is admin / exafy_admin / developer. Community sessions never see them
         // and the orb dispatcher rejects them server-side regardless.
@@ -6164,6 +6271,59 @@ async function executeLiveApiToolInner(
           };
         } catch (err: any) {
           console.error('[get_pillar_subscores] error:', err?.message);
+          return { success: false, result: '', error: err?.message || 'unknown' };
+        }
+      }
+
+      // ─── VTID-02763 — Voice Tool Expansion P1e: Reminders extension ───
+      case 'snooze_reminder':
+      case 'update_reminder':
+      case 'acknowledge_reminder':
+      case 'complete_reminder':
+      case 'list_missed_reminders': {
+        try {
+          const re = await import('../services/voice-tools/reminders-extra');
+          const { createClient } = await import('@supabase/supabase-js');
+          const url = process.env.SUPABASE_URL;
+          const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+          if (!url || !key) return { success: false, result: '', error: 'Supabase not configured' };
+          const sb = createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
+
+          let r: any;
+          if (toolName === 'snooze_reminder') {
+            r = await re.snoozeReminder(sb, lens.user_id, {
+              reminder_id: String(args.reminder_id || ''),
+              minutes: typeof args.minutes === 'number' ? args.minutes : undefined,
+            });
+          } else if (toolName === 'update_reminder') {
+            r = await re.updateReminder(sb, lens.user_id, {
+              reminder_id: String(args.reminder_id || ''),
+              action_text: typeof args.action_text === 'string' ? args.action_text : undefined,
+              spoken_message: typeof args.spoken_message === 'string' ? args.spoken_message : undefined,
+              scheduled_for_iso: typeof args.scheduled_for_iso === 'string' ? args.scheduled_for_iso : undefined,
+              description: typeof args.description === 'string' ? args.description : undefined,
+            });
+          } else if (toolName === 'acknowledge_reminder') {
+            r = await re.acknowledgeReminder(sb, lens.user_id, {
+              reminder_id: String(args.reminder_id || ''),
+              via: typeof args.via === 'string' ? args.via : 'manual',
+            });
+          } else if (toolName === 'complete_reminder') {
+            r = await re.completeReminder(sb, lens.user_id, {
+              reminder_id: String(args.reminder_id || ''),
+            });
+          } else if (toolName === 'list_missed_reminders') {
+            r = await re.listMissedReminders(sb, lens.user_id, {
+              limit: typeof args.limit === 'number' ? args.limit : undefined,
+            });
+          }
+
+          if (!r || r.ok === false) {
+            return { success: false, result: '', error: (r && r.error) || `${toolName}_failed` };
+          }
+          return { success: true, result: JSON.stringify(r) };
+        } catch (err: any) {
+          console.error(`[${toolName}] error:`, err?.message);
           return { success: false, result: '', error: err?.message || 'unknown' };
         }
       }

--- a/services/gateway/src/routes/orb-tool.ts
+++ b/services/gateway/src/routes/orb-tool.ts
@@ -620,6 +620,66 @@ async function tool_log_health(
   };
 }
 
+// VTID-02763 — Reminders extension
+async function tool_reminders_extra(
+  toolName:
+    | 'snooze_reminder'
+    | 'update_reminder'
+    | 'acknowledge_reminder'
+    | 'complete_reminder'
+    | 'list_missed_reminders',
+  args: ToolArgs,
+  id: Identity,
+  sb: SupabaseClient,
+): Promise<ToolResult> {
+  const re = await import('../services/voice-tools/reminders-extra');
+  let r: any;
+  if (toolName === 'snooze_reminder') {
+    r = await re.snoozeReminder(sb, id.user_id, {
+      reminder_id: String(args.reminder_id || ''),
+      minutes: typeof args.minutes === 'number' ? args.minutes : undefined,
+    });
+  } else if (toolName === 'update_reminder') {
+    r = await re.updateReminder(sb, id.user_id, {
+      reminder_id: String(args.reminder_id || ''),
+      action_text: typeof args.action_text === 'string' ? args.action_text : undefined,
+      spoken_message: typeof args.spoken_message === 'string' ? args.spoken_message : undefined,
+      scheduled_for_iso: typeof args.scheduled_for_iso === 'string' ? args.scheduled_for_iso : undefined,
+      description: typeof args.description === 'string' ? args.description : undefined,
+    });
+  } else if (toolName === 'acknowledge_reminder') {
+    r = await re.acknowledgeReminder(sb, id.user_id, {
+      reminder_id: String(args.reminder_id || ''),
+      via: typeof args.via === 'string' ? args.via : 'manual',
+    });
+  } else if (toolName === 'complete_reminder') {
+    r = await re.completeReminder(sb, id.user_id, {
+      reminder_id: String(args.reminder_id || ''),
+    });
+  } else if (toolName === 'list_missed_reminders') {
+    r = await re.listMissedReminders(sb, id.user_id, {
+      limit: typeof args.limit === 'number' ? args.limit : undefined,
+    });
+  }
+  if (!r || r.ok === false) return { ok: false, error: (r && r.error) || `${toolName}_failed` };
+
+  let text = '';
+  if (toolName === 'snooze_reminder') {
+    const m = Number(args.minutes ?? 10) || 10;
+    text = `Snoozed by ${m} minutes.`;
+  } else if (toolName === 'update_reminder') {
+    text = 'Reminder updated.';
+  } else if (toolName === 'acknowledge_reminder') {
+    text = `Reminder acknowledged.`;
+  } else if (toolName === 'complete_reminder') {
+    text = `Reminder marked complete.`;
+  } else if (toolName === 'list_missed_reminders') {
+    const n = r.count ?? 0;
+    text = n === 0 ? 'No missed reminders.' : `${n} missed reminder${n === 1 ? '' : 's'}.`;
+  }
+  return { ok: true, result: r, text };
+}
+
 async function tool_get_pillar_subscores(
   args: ToolArgs,
   id: Identity,
@@ -767,6 +827,14 @@ router.post('/orb/tool', requireAuth, async (req: AuthenticatedRequest, res: Res
         break;
       case 'get_pillar_subscores':
         r = await tool_get_pillar_subscores(args, identity, sb);
+        break;
+      // VTID-02763 — Reminders extension
+      case 'snooze_reminder':
+      case 'update_reminder':
+      case 'acknowledge_reminder':
+      case 'complete_reminder':
+      case 'list_missed_reminders':
+        r = await tool_reminders_extra(name as any, args, identity, sb);
         break;
       default:
         return res.status(404).json({ ok: false, error: `unknown tool: ${name}`, vtid: VTID });

--- a/services/gateway/src/services/voice-tools/reminders-extra.ts
+++ b/services/gateway/src/services/voice-tools/reminders-extra.ts
@@ -1,0 +1,197 @@
+/**
+ * VTID-02763 — Voice Tool Expansion P1e: Reminders extension.
+ *
+ * Backs voice tools for the reminder lifecycle BEYOND the existing
+ * set_reminder / find_reminders / delete_reminder primitives:
+ *   - snooze_reminder        → push out by N minutes
+ *   - update_reminder        → change text / spoken_message / time
+ *   - acknowledge_reminder   → mark delivered (manual replay)
+ *   - complete_reminder      → user did the thing
+ *   - list_missed_reminders  → fired but not acked
+ *
+ * Each helper enforces user_id ownership before mutating, mirroring
+ * the controls in routes/reminders.ts so voice can't reach across
+ * users by id.
+ */
+
+import { SupabaseClient } from '@supabase/supabase-js';
+
+export interface ReminderRow {
+  id: string;
+  action_text: string;
+  spoken_message?: string | null;
+  next_fire_at: string;
+  status: string;
+  snooze_count?: number | null;
+  fired_at?: string | null;
+  acked_at?: string | null;
+  delivery_via?: string | null;
+}
+
+// ---------------------------------------------------------------------------
+// 1. snooze_reminder — push by minutes (default 10, max 24h)
+// ---------------------------------------------------------------------------
+
+export async function snoozeReminder(
+  sb: SupabaseClient,
+  userId: string,
+  args: { reminder_id: string; minutes?: number },
+): Promise<{ ok: true; reminder: ReminderRow } | { ok: false; error: string }> {
+  if (!args.reminder_id) return { ok: false, error: 'reminder_id_required' };
+  const minutes = Math.max(1, Math.min(Number(args.minutes ?? 10) || 10, 24 * 60));
+  const newTime = new Date(Date.now() + minutes * 60_000).toISOString();
+
+  const { data: row } = await sb
+    .from('reminders')
+    .select('snooze_count')
+    .eq('id', args.reminder_id)
+    .eq('user_id', userId)
+    .maybeSingle();
+  if (!row) return { ok: false, error: 'reminder_not_found' };
+
+  const { data, error } = await sb
+    .from('reminders')
+    .update({
+      next_fire_at: newTime,
+      status: 'pending',
+      fired_at: null,
+      acked_at: null,
+      delivery_via: null,
+      snooze_count: ((row as any).snooze_count || 0) + 1,
+    })
+    .eq('id', args.reminder_id)
+    .eq('user_id', userId)
+    .select('*')
+    .single();
+  if (error) return { ok: false, error: `snooze_failed: ${error.message}` };
+  return { ok: true, reminder: data as any };
+}
+
+// ---------------------------------------------------------------------------
+// 2. update_reminder — change action_text / spoken_message / scheduled_for_iso
+// ---------------------------------------------------------------------------
+
+export async function updateReminder(
+  sb: SupabaseClient,
+  userId: string,
+  args: {
+    reminder_id: string;
+    action_text?: string;
+    spoken_message?: string;
+    scheduled_for_iso?: string;
+    description?: string;
+  },
+): Promise<{ ok: true; reminder: ReminderRow } | { ok: false; error: string }> {
+  if (!args.reminder_id) return { ok: false, error: 'reminder_id_required' };
+
+  const updates: Record<string, unknown> = {};
+  if (typeof args.action_text === 'string') updates.action_text = args.action_text.trim();
+  if (typeof args.spoken_message === 'string') updates.spoken_message = args.spoken_message.trim();
+  if (typeof args.description === 'string') updates.description = args.description;
+  if (typeof args.scheduled_for_iso === 'string') {
+    const t = new Date(args.scheduled_for_iso);
+    if (isNaN(t.getTime())) return { ok: false, error: 'invalid_scheduled_for_iso' };
+    if (t.getTime() < Date.now() + 60_000) {
+      return { ok: false, error: 'time_must_be_60s_in_future' };
+    }
+    updates.next_fire_at = t.toISOString();
+    updates.status = 'pending';
+    updates.fired_at = null;
+    updates.acked_at = null;
+    updates.delivery_via = null;
+  }
+  if (Object.keys(updates).length === 0) {
+    return { ok: false, error: 'no_updatable_fields' };
+  }
+
+  const { data, error } = await sb
+    .from('reminders')
+    .update(updates)
+    .eq('id', args.reminder_id)
+    .eq('user_id', userId)
+    .select('*')
+    .maybeSingle();
+  if (error) return { ok: false, error: `update_failed: ${error.message}` };
+  if (!data) return { ok: false, error: 'reminder_not_found' };
+  return { ok: true, reminder: data as any };
+}
+
+// ---------------------------------------------------------------------------
+// 3. acknowledge_reminder — mark delivered (used after voice playback)
+// ---------------------------------------------------------------------------
+
+export async function acknowledgeReminder(
+  sb: SupabaseClient,
+  userId: string,
+  args: { reminder_id: string; via?: string },
+): Promise<
+  | { ok: true; reminder: { id: string; acked_at: string; delivery_via: string } }
+  | { ok: false; error: string }
+> {
+  if (!args.reminder_id) return { ok: false, error: 'reminder_id_required' };
+  const via = String(args.via || 'manual');
+  if (!['sse', 'fcm', 'manual', 'manual_replay', 'none'].includes(via)) {
+    return { ok: false, error: 'invalid_via' };
+  }
+
+  const { data, error } = await sb
+    .from('reminders')
+    .update({ acked_at: new Date().toISOString(), delivery_via: via })
+    .eq('id', args.reminder_id)
+    .eq('user_id', userId)
+    .select('id, acked_at, delivery_via')
+    .maybeSingle();
+  if (error) return { ok: false, error: `ack_failed: ${error.message}` };
+  if (!data) return { ok: false, error: 'reminder_not_found' };
+  return { ok: true, reminder: data as any };
+}
+
+// ---------------------------------------------------------------------------
+// 4. complete_reminder — user did the thing
+// ---------------------------------------------------------------------------
+
+export async function completeReminder(
+  sb: SupabaseClient,
+  userId: string,
+  args: { reminder_id: string },
+): Promise<{ ok: true; reminder: ReminderRow } | { ok: false; error: string }> {
+  if (!args.reminder_id) return { ok: false, error: 'reminder_id_required' };
+  const { data, error } = await sb
+    .from('reminders')
+    .update({ status: 'completed', completed_at: new Date().toISOString() })
+    .eq('id', args.reminder_id)
+    .eq('user_id', userId)
+    .select('*')
+    .maybeSingle();
+  if (error) return { ok: false, error: `complete_failed: ${error.message}` };
+  if (!data) return { ok: false, error: 'reminder_not_found' };
+  return { ok: true, reminder: data as any };
+}
+
+// ---------------------------------------------------------------------------
+// 5. list_missed_reminders — fired but not acked
+// ---------------------------------------------------------------------------
+
+export async function listMissedReminders(
+  sb: SupabaseClient,
+  userId: string,
+  args: { limit?: number },
+): Promise<
+  | { ok: true; reminders: ReminderRow[]; count: number }
+  | { ok: false; error: string }
+> {
+  const limit = Math.max(1, Math.min(20, args.limit ?? 5));
+  const { data, error } = await sb
+    .from('reminders')
+    .select('*')
+    .eq('user_id', userId)
+    .not('fired_at', 'is', null)
+    .is('acked_at', null)
+    .neq('status', 'cancelled')
+    .neq('status', 'completed')
+    .order('fired_at', { ascending: false })
+    .limit(limit);
+  if (error) return { ok: false, error: `missed_query_failed: ${error.message}` };
+  const list = (data || []) as ReminderRow[];
+  return { ok: true, reminders: list, count: list.length };
+}


### PR DESCRIPTION
## Summary

Fifth slice of the 269-tool voice-expansion plan ([plan](https://github.com/exafyltd/vitana-platform/blob/feat/voice-tools-p1a-VTID-02753/.claude/plans/make-a-plan-which-sunny-sifakis.md)).

Adds **5 new voice tools** that complete the reminder lifecycle beyond \`set_reminder\` / \`find_reminders\` / \`delete_reminder\`.

| Tool | Maps to | Notes |
|---|---|---|
| \`snooze_reminder\` | \`POST /reminders/:id/snooze\` | Default 10 min, max 24h |
| \`update_reminder\` | \`PATCH /reminders/:id\` | text/spoken_message/scheduled |
| \`acknowledge_reminder\` | \`POST /reminders/:id/ack\` | sse/fcm/manual/replay/none |
| \`complete_reminder\` | \`POST /reminders/:id/complete\` | User did the thing |
| \`list_missed_reminders\` | \`GET /reminders/missed\` (table query) | fired but not acked |

All five are \`community\`-tier — they appear on mobile + desktop sessions.

## Architecture (mirrors P1a–P1d)

- Vertex declarations: \`services/gateway/src/routes/orb-live.ts\` (after P1d calendar block)
- Vertex handlers: \`executeLiveApiToolInner\` switch (after subscore case)
- LiveKit dispatcher mirror: \`services/gateway/src/routes/orb-tool.ts\` (single \`tool_reminders_extra\` helper)
- Shared service: **new file** \`services/gateway/src/services/voice-tools/reminders-extra.ts\` does direct Supabase queries against \`reminders\` table, mirroring ownership checks from \`routes/reminders.ts\` (every UPDATE filters by both id and user_id).

## Base branch

Targets \`feat/voice-tools-p1a-VTID-02753\` (P1a #1837), same as #1857, #1858, #1860. Will rebase cleanly to main after P1a merges.

## Test plan

- [ ] Voice E2E: \"Snooze that for 15 minutes\" after a fired reminder → \`snooze_reminder\` fires
- [ ] Voice E2E: \"Move my magnesium reminder to 9pm\" → \`update_reminder\` fires
- [ ] Voice E2E: ORB speaks fired reminder → it auto-calls \`acknowledge_reminder\` with via='manual'
- [ ] Voice E2E: \"I took my magnesium\" → \`complete_reminder\` fires
- [ ] Voice E2E: \"What did I miss?\" → \`list_missed_reminders\` fires
- [ ] LiveKit parity: \`POST /api/v1/orb/tool\` with \`{\"name\":\"list_missed_reminders\",\"args\":{}}\`

## Notes

- Pre-allocated **VTID-02763** before code (per CLAUDE.md rule + memory)
- Worktree on /home/dstev/worktrees/p1e (proven autopilot-safe pattern)
- Build verification deferred to CI; patterns mirror P1a–P1d which built clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)