### PR TITLE
fix(orb-agent): flash-lite + plain-text identity prompt + trace observability (VTID-02767)

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/instructions.py
+++ b/services/agents/orb-agent/src/orb_agent/instructions.py
@@ -51,22 +51,30 @@ def build_live_system_instruction(
     """
     parts: list[str] = []
 
-    # ── 1. WHO YOU ARE TALKING TO — top-of-prompt, ground truth ───────────
-    # Elevate the user's identity facts to position #1 so the LLM can't
-    # miss them. The bootstrap_context block (added below) carries the
-    # full memory_facts + Vitana Index + recent memory items.
-    identity_block: list[str] = ["## WHO YOU ARE TALKING TO (GROUND TRUTH — never contradict)"]
-    if vitana_id:
-        identity_block.append(f"- Their Vitana ID is **@{vitana_id}** — say it back as @{vitana_id} (with the @ symbol).")
-    if active_role:
-        identity_block.append(f"- Their active role: {active_role}.")
-    identity_block.append(
-        "- They are SIGNED IN. The auth chain is fully wired (Bearer JWT → "
-        "gateway → tools). You have working tool access RIGHT NOW for their "
-        "Vitana Index, calendar, reminders, intents, recommendations, memory, "
-        "diary, and 30+ other capabilities."
-    )
-    parts.append("\n".join(identity_block))
+    # ── 1. THE USER YOU ARE TALKING TO — first line of the prompt ────────
+    # Plain text, no markdown. Repeat the handle so any attention head
+    # has to see it. This is what the LLM should ALWAYS use to address
+    # the user. Avoid markdown bold (**...**) since some smaller LLMs
+    # treat it as decoration and skip the content.
+    handle = f"@{vitana_id}" if vitana_id else None
+    if handle:
+        parts.append(
+            f"You are talking to {handle}.\n"
+            f"- Their handle is {handle}.\n"
+            f"- Always use {handle} when greeting or addressing them. Never call them anything else.\n"
+            f"- Their active role is {active_role or 'community'}.\n"
+            f"- They are SIGNED IN. You have working tool access right now for "
+            f"their Vitana Index, calendar, reminders, intents, recommendations, "
+            f"memory, diary, and 30+ other capabilities. The auth chain is wired "
+            f"end-to-end."
+        )
+    else:
+        # Anonymous fallback — should be very rare since the gateway only
+        # mints a non-anonymous LiveKit token for signed-in users.
+        parts.append(
+            "You are talking to an unauthenticated visitor. Help them with "
+            "general questions and offer to sign in for personalized answers."
+        )
 
     # ── 2. CORE IDENTITY ─────────────────────────────────────────────────
     parts.append(

--- a/services/agents/orb-agent/src/orb_agent/providers.py
+++ b/services/agents/orb-agent/src/orb_agent/providers.py
@@ -59,7 +59,7 @@ def build_cascade(voice_config: dict[str, Any] | None) -> ResolvedCascade:
         logger.warning("build_cascade: no voice_config — falling back to hardcoded Google cascade")
         voice_config = {
             "stt_provider": "google_stt",  "stt_model": "latest_long", "stt_options": {},
-            "llm_provider": "google_llm",  "llm_model": "gemini-3.1-pro-preview", "llm_options": {},
+            "llm_provider": "google_llm",  "llm_model": "gemini-3.1-flash-lite-preview", "llm_options": {},
             "tts_provider": "google_tts",  "tts_model": "en-US-Chirp3-HD-Aoede", "tts_options": {},
         }
 
@@ -131,7 +131,7 @@ def _build_llm(provider: str | None, model: str | None, options: dict[str, Any],
             project = os.environ.get("GOOGLE_CLOUD_PROJECT", "lovable-vitana-vers1")
             location = os.environ.get("VERTEX_AI_LOCATION", "us-central1")
             return google.LLM(
-                model=model or "gemini-3.1-pro-preview",
+                model=model or "gemini-3.1-flash-lite-preview",
                 vertexai=True,
                 project=project,
                 location=location,

--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -180,17 +180,50 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     # function in the module, exported via all_tools(). Each tool body is a
     # thin async call to a gateway endpoint via the GatewayClient carried on
     # RunContext.userdata (set on AgentSession below).
-    #
-    # VTID-LIVEKIT-TOOLS root cause: the earlier blocker was a wrong import
-    # path in tools.py (`from livekit.agents.llm import RunContext` no longer
-    # exists in livekit-agents 1.x; RunContext moved to `livekit.agents`). The
-    # try/except ImportError fallback was substituting a no-op decorator that
-    # returned the raw function, which AgentSession then rejected. Fix landed
-    # in tools.py's import block; tools list is now real.
+    tool_list = list(all_tools())
     agent = Agent(
         instructions=sys_prompt,
-        tools=list(all_tools()),
+        tools=tool_list,
     )
+
+    # VTID-LIVEKIT-AGENT-TRACE: post a structured trace to the gateway so
+    # the diagnostics panel can show what the agent ACTUALLY had at session
+    # start — proves whether the prompt rewrite is reaching the LLM and
+    # the bootstrap context is enriched.
+    try:
+        tool_names: list[str] = []
+        for t in tool_list:
+            try:
+                tool_names.append(getattr(getattr(t, "info", None), "name", None) or repr(t))
+            except Exception:
+                tool_names.append("<?>")
+        trace_payload = {
+            "user_id": identity.user_id,
+            "tenant_id": identity.tenant_id,
+            "vitana_id": bootstrap.vitana_id or identity.vitana_id,
+            "role": identity.role,
+            "lang": identity.lang,
+            "orb_session_id": orb_session_id,
+            "agent_id": agent_id,
+            "is_mobile": identity.is_mobile,
+            "is_anonymous": identity.is_anonymous,
+            "user_jwt_present": bool(user_jwt),
+            "user_jwt_len": len(user_jwt) if user_jwt else 0,
+            "bootstrap_context_length": len(bootstrap.bootstrap_context or ""),
+            "bootstrap_active_role": bootstrap.active_role,
+            "bootstrap_vitana_id": bootstrap.vitana_id,
+            "bootstrap_voice_config_llm": (bootstrap.voice_config or {}).get("llm_model"),
+            "bootstrap_voice_config_stt": (bootstrap.voice_config or {}).get("stt_model"),
+            "bootstrap_voice_config_tts": (bootstrap.voice_config or {}).get("tts_model"),
+            "system_prompt_length": len(sys_prompt),
+            "system_prompt_first_400_chars": sys_prompt[:400],
+            "tools_count": len(tool_list),
+            "tools_first_5": tool_names[:5],
+            "tools_handle_in_first_chars": "@" + (bootstrap.vitana_id or identity.vitana_id or "") in sys_prompt[:600],
+        }
+        await gw.post("/api/v1/orb/agent-trace", trace_payload)
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("agent-trace post failed: %s", exc)
 
     # AgentSession glues together STT + LLM + TTS + the room. userdata
     # carries the per-session GatewayClient so each tool body can pull it off

--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -35307,6 +35307,46 @@ function renderLivekitTestView() {
         }
         diagRow('auth', 'token in localStorage', true, 'len=' + session.token.length);
 
+        // Phase 0 — latest agent-trace (only present if user clicked Connect within
+        // the last 10 minutes). Tells us EXACTLY what the running agent had at
+        // session start.
+        diagAppend('<br><strong style="color:#facc15;">Latest agent-trace (from your last Connect):</strong>');
+        var atr = await diagFetch('GET', '/api/v1/orb/agent-trace');
+        if (atr.status === 404) {
+            diagRow('agent-trace', 'available', false, 'no recent trace — click Connect first, then re-run diagnostics');
+        } else if (!atr.ok) {
+            diagRow('agent-trace', 'available', false, atr.status + '');
+        } else {
+            var t = (atr.body && atr.body.trace && atr.body.trace.payload) || {};
+            diagRow('agent-trace', 'session ts', true, atr.body.trace.ts);
+            diagRow('agent-trace', 'user_id', !!t.user_id, String(t.user_id || ''));
+            diagRow('agent-trace', 'vitana_id', !!t.vitana_id, String(t.vitana_id || ''));
+            diagRow('agent-trace', 'role', !!t.role, String(t.role || ''));
+            diagRow('agent-trace', 'is_anonymous=false', t.is_anonymous === false, String(t.is_anonymous));
+            diagRow('agent-trace', 'user_jwt_present', !!t.user_jwt_present, 'len=' + (t.user_jwt_len || 0));
+            diagRow('agent-trace', 'bootstrap_context_length > 200', (t.bootstrap_context_length || 0) > 200, 'chars=' + (t.bootstrap_context_length || 0));
+            diagRow('agent-trace', 'bootstrap_voice_config_llm', !!t.bootstrap_voice_config_llm, String(t.bootstrap_voice_config_llm || ''));
+            diagRow('agent-trace', 'system_prompt_length', (t.system_prompt_length || 0) > 200, 'chars=' + (t.system_prompt_length || 0));
+            diagRow(
+                'agent-trace',
+                'system_prompt has @' + (t.vitana_id || '?') + ' in first 600 chars',
+                !!t.tools_handle_in_first_chars,
+                t.tools_handle_in_first_chars ? 'YES' : 'NO — handle missing',
+            );
+            diagRow('agent-trace', 'tools_count registered', (t.tools_count || 0) >= 30, 'count=' + (t.tools_count || 0));
+            if (t.system_prompt_first_400_chars) {
+                var safe = String(t.system_prompt_first_400_chars).replace(/[<>&]/g, function (c) {
+                    return c === '<' ? '&lt;' : c === '>' ? '&gt;' : '&amp;';
+                });
+                diagAppend(
+                    '<div style="margin-left:20px;margin-top:4px;padding:8px;background:#1e293b;border-left:2px solid #facc15;color:#cbd5e1;white-space:pre-wrap;font-size:11px;">' +
+                        safe +
+                        '…</div>',
+                );
+            }
+        }
+        diagAppend('<br>');
+
         // Phase 1: auth round-trip
         var me = await diagFetch('GET', '/api/v1/auth/me');
         diagRow(

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -12,7 +12,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260504-vtid-02710-ios-ctx-keepalive"></script>
-  <script src="/command-hub/app.js?v=20260505-livekit-agent-jwt-diag"></script>
+  <script src="/command-hub/app.js?v=20260505-livekit-agent-trace"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
 </body>

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -90,6 +90,7 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const orbLivekitRouter = require('./routes/orb-livekit').default;
   const vitanaIndexRouter = require('./routes/vitana-index').default;
   const orbToolRouter = require('./routes/orb-tool').default;
+  const orbAgentTraceRouter = require('./routes/orb-agent-trace').default;
   const awarenessConfigRouter = require('./routes/awareness-config').default;
   // VTID-01222: WebSocket server initialization for ORB Live API
   const { initializeOrbWebSocket } = require('./routes/orb-live');
@@ -670,6 +671,10 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   // implementation is inline-only in orb-live.ts. Single POST /api/v1/orb/tool
   // route with per-tool handlers — see services/gateway/src/routes/orb-tool.ts.
   mountRouterSync(app, '/api/v1', orbToolRouter, { owner: 'orb-tool-dispatcher' });
+
+  // VTID-LIVEKIT-AGENT-TRACE: runtime telemetry — agent posts session-start
+  // trace; diag panel reads. See services/gateway/src/routes/orb-agent-trace.ts.
+  mountRouterSync(app, '/api/v1', orbAgentTraceRouter, { owner: 'orb-agent-trace' });
 
   // BOOTSTRAP-AWARENESS-REGISTRY: admin API for the Awareness Registry
   mountRouterSync(app, '/api/v1/awareness', awarenessConfigRouter, { owner: 'awareness-registry' });

--- a/services/gateway/src/routes/orb-agent-trace.ts
+++ b/services/gateway/src/routes/orb-agent-trace.ts
@@ -1,0 +1,95 @@
+/**
+ * VTID-LIVEKIT-AGENT-TRACE: runtime telemetry from the orb-agent into the
+ * gateway so we can see what the agent has at session start without
+ * touching Cloud Run logs.
+ *
+ *   POST /api/v1/orb/agent-trace  — agent posts a session-start trace
+ *   GET  /api/v1/orb/agent-trace  — operator/diag panel reads the latest
+ *                                    trace for the authenticated user.
+ *
+ * Stored in-memory in a per-user Map; capped + TTL'd. Sufficient for
+ * the diag-loop use case (operator clicks Connect, then clicks Run
+ * Diagnostics within ~30s and reads the trace). Persisted observability
+ * goes through OASIS in a follow-up.
+ */
+
+import { Router, Request, Response } from 'express';
+import { requireAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
+
+const router = Router();
+const VTID = 'VTID-LIVEKIT-AGENT-TRACE';
+
+interface TraceEntry {
+  ts: string;
+  user_id: string;
+  payload: Record<string, unknown>;
+}
+
+// Per-user latest trace. Map preserves insertion order for the few-user
+// staging environment; we only ever serve the latest entry per user.
+const TRACE_TTL_MS = 10 * 60 * 1000; // 10 minutes
+const traces = new Map<string, TraceEntry>();
+
+function cleanup(): void {
+  const now = Date.now();
+  for (const [k, v] of traces) {
+    if (now - new Date(v.ts).getTime() > TRACE_TTL_MS) {
+      traces.delete(k);
+    }
+  }
+}
+
+/**
+ * POST /api/v1/orb/agent-trace — agent → gateway write
+ *
+ * Service-token (or any valid Bearer JWT) auth. The agent calls this
+ * with its own service token; user identity comes from the body's
+ * user_id field, NOT req.identity, because the agent isn't acting as
+ * the user. The body shape is open-ended; the diag panel renders
+ * whatever fields are present.
+ *
+ * Expected payload from session.py at session start:
+ *   {
+ *     user_id, tenant_id, vitana_id, role, lang,
+ *     orb_session_id, agent_id, is_reconnect, is_anonymous,
+ *     user_jwt_present, user_jwt_sub, bootstrap_context_length,
+ *     bootstrap_has_vitana_id, bootstrap_voice_config_llm,
+ *     system_prompt_length, system_prompt_first_400_chars,
+ *     tools_count, tools_first_5,
+ *   }
+ */
+router.post('/orb/agent-trace', async (req: Request, res: Response) => {
+  cleanup();
+  const body = (req.body ?? {}) as Record<string, unknown>;
+  const userId = String(body.user_id ?? '').trim();
+  if (!userId) {
+    return res.status(400).json({ ok: false, error: 'user_id required', vtid: VTID });
+  }
+  traces.set(userId, {
+    ts: new Date().toISOString(),
+    user_id: userId,
+    payload: body,
+  });
+  return res.json({ ok: true, vtid: VTID });
+});
+
+/**
+ * GET /api/v1/orb/agent-trace — diag panel → gateway read
+ *
+ * Authenticated. Returns the latest trace for the calling user_id (from
+ * req.identity.user_id). 404 if no trace within the TTL window.
+ */
+router.get('/orb/agent-trace', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  cleanup();
+  const userId = req.identity?.user_id;
+  if (!userId) {
+    return res.status(401).json({ ok: false, error: 'unauthenticated', vtid: VTID });
+  }
+  const entry = traces.get(userId);
+  if (!entry) {
+    return res.status(404).json({ ok: false, error: 'no_recent_trace', vtid: VTID });
+  }
+  return res.json({ ok: true, trace: entry, vtid: VTID });
+});
+
+export default router;

--- a/supabase/migrations/20260502120000_vtid_02690_seed_orb_agent_google_cascade.sql
+++ b/supabase/migrations/20260502120000_vtid_02690_seed_orb_agent_google_cascade.sql
@@ -10,7 +10,7 @@
 --   1. Inserts the agents_registry row for orb-agent (idempotent).
 --   2. Upserts the agent_voice_configs row pointing to the all-Google cascade:
 --        STT: google_stt / latest_long
---        LLM: google_llm / gemini-3.1-pro-preview
+--        LLM: google_llm / gemini-3.1-flash-lite-preview
 --        TTS: google_tts / en-US-Chirp3-HD-Aoede
 --      All three use Application Default Credentials — no third-party API
 --      keys needed; the Cloud Run service account inherits the project's
@@ -26,7 +26,7 @@ VALUES
   ('orb-agent',
    'ORB LiveKit Agent',
    'LiveKit-based ORB voice agent worker. Standby alternative to the Vertex Live pipeline (services/gateway/src/routes/orb-live.ts). Joins LiveKit rooms as a participant and runs a configurable STT/LLM/TTS cascade.',
-   'service', 'voice', 'gemini', 'gemini-3.1-pro-preview',
+   'service', 'voice', 'gemini', 'gemini-3.1-flash-lite-preview',
    'services/agents/orb-agent/', '/health',
    jsonb_build_object('language', 'python', 'framework', 'livekit-agents', 'vtid', 'VTID-LIVEKIT-FOUNDATION'))
 ON CONFLICT (agent_id) DO UPDATE SET
@@ -44,7 +44,7 @@ INSERT INTO agent_voice_configs (
 ) VALUES (
   'orb-agent', 'livekit_cascade',
   'google_stt',  'latest_long',                      jsonb_build_object('languages', ARRAY['en-US']),
-  'google_llm',  'gemini-3.1-pro-preview',           jsonb_build_object('temperature', 0.7),
+  'google_llm',  'gemini-3.1-flash-lite-preview',           jsonb_build_object('temperature', 0.7),
   'google_tts',  'en-US-Chirp3-HD-Aoede',            jsonb_build_object('language_code', 'en-US')
 ) ON CONFLICT (agent_id) DO UPDATE SET
   transport     = EXCLUDED.transport,


### PR DESCRIPTION
Reverts LLM to flash-lite (latency), restructures the prompt to repeat @vitana_id 3× in plain text without markdown (flash-lite was ignoring bold), and adds POST/GET /api/v1/orb/agent-trace so the diag panel shows what the running agent actually has at session start (user_id, prompt first 400 chars, tool count, etc.).