### PR TITLE
chore(cors): allowlist gateway.vitanaland.com for Cloudflare migration (BOOTSTRAP-CLOUDFLARE-GATEWAY-DOMAIN)

### DIFF
--- a/services/gateway/src/middleware/cors.ts
+++ b/services/gateway/src/middleware/cors.ts
@@ -8,6 +8,7 @@ const ALLOWED_ORIGINS = [
   "https://vitana-gateway-86804897789.us-central1.run.app",  // Canonical gateway
   "https://gateway-86804897789.us-central1.run.app",         // Short alias
   "https://gateway-q74ibpv6ia-uc.a.run.app",                 // Cloud Run generated
+  "https://gateway.vitanaland.com",                            // Cloudflare-fronted custom gateway domain (BOOTSTRAP-CLOUDFLARE-GATEWAY-DOMAIN)
   "https://vitana-dev-gateway-86804897789.us-central1.run.app", // Deprecated redirector
   "https://community-app-86804897789.us-central1.run.app",    // Community app on Cloud Run
   "https://community-app-q74ibpv6ia-uc.a.run.app",           // Community app Cloud Run alias


### PR DESCRIPTION
Wave 1 of migration off *.a.run.app rate-limited host. Adds https://gateway.vitanaland.com to the gateway CORS allow-list before any client switches to it, so cross-origin requests from vitanaland.com work the moment Cloudflare DNS propagates.

Why now: *.a.run.app is throttled at Google edge (GFE) per-IP. Three sequential curls observed 200 -> 429 -> 429 with response header server: Google Frontend and body Rate exceeded. — the request never reaches the gateway, so adding instances does nothing.

This PR is the safe additive Wave 1. Existing *.run.app entries untouched, fully reversible. Wave 2 (replace hardcoded URLs in v1 + workflows + Cloudflare worker) ships after DNS is verified.

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>