### PR TITLE
feat(orb-tool): voice tools for awareness engine queries (VTID-02778)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -3577,6 +3577,37 @@ function buildLiveApiTools(
             required: ['pillar'],
           },
         },
+        // ─── VTID-02778 — Voice Tool Expansion P1p: Awareness engine queries ───
+        {
+          name: 'get_emotional_state',
+          description: "Read the user's current emotional/cognitive state signals (D28). Use when ORB needs context about mood/stress/focus to tune responses.",
+          parameters: { type: 'object', properties: {} },
+        },
+        {
+          name: 'get_situational_awareness',
+          description: "Read the user's situational awareness signals (D32) — current situation, intent, environment.",
+          parameters: { type: 'object', properties: {} },
+        },
+        {
+          name: 'get_availability',
+          description: "Read the user's availability/readiness signals (D33) — busy/free/do-not-disturb state.",
+          parameters: { type: 'object', properties: {} },
+        },
+        {
+          name: 'get_environmental_context',
+          description: "Read environmental/mobility signals (D34) — location class, weather, motion.",
+          parameters: { type: 'object', properties: {} },
+        },
+        {
+          name: 'get_social_context',
+          description: "Read social context signals (D35) — alone/with others, social load.",
+          parameters: { type: 'object', properties: {} },
+        },
+        {
+          name: 'get_life_stage_context',
+          description: "Read life-stage signals (D40) — age band, family status, life phase.",
+          parameters: { type: 'object', properties: {} },
+        },
         // BOOTSTRAP-ADMIN-DD: admin voice tools — only injected when active_role
         // is admin / exafy_admin / developer. Community sessions never see them
         // and the orb dispatcher rejects them server-side regardless.
@@ -6164,6 +6195,43 @@ async function executeLiveApiToolInner(
           };
         } catch (err: any) {
           console.error('[get_pillar_subscores] error:', err?.message);
+          return { success: false, result: '', error: err?.message || 'unknown' };
+        }
+      }
+
+      // ─── VTID-02778 — Voice Tool Expansion P1p: Awareness engine queries ───
+      case 'get_emotional_state':
+      case 'get_situational_awareness':
+      case 'get_availability':
+      case 'get_environmental_context':
+      case 'get_social_context':
+      case 'get_life_stage_context': {
+        try {
+          const aq = await import('../services/voice-tools/awareness-queries');
+          const { createClient } = await import('@supabase/supabase-js');
+          const url = process.env.SUPABASE_URL;
+          const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+          if (!url || !key) return { success: false, result: '', error: 'Supabase not configured' };
+          const sb = createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
+
+          const map: Record<string, (s: any, u: string) => Promise<any>> = {
+            get_emotional_state: aq.getEmotionalState,
+            get_situational_awareness: aq.getSituationalAwareness,
+            get_availability: aq.getAvailability,
+            get_environmental_context: aq.getEnvironmentalContext,
+            get_social_context: aq.getSocialContext,
+            get_life_stage_context: aq.getLifeStageContext,
+          };
+          const fn = map[toolName];
+          if (!fn) return { success: false, result: '', error: 'unknown_awareness_tool' };
+          const r = await fn(sb, lens.user_id);
+
+          if (!r || r.ok === false) {
+            return { success: false, result: '', error: (r && r.error) || `${toolName}_failed` };
+          }
+          return { success: true, result: JSON.stringify(r) };
+        } catch (err: any) {
+          console.error(`[${toolName}] error:`, err?.message);
           return { success: false, result: '', error: err?.message || 'unknown' };
         }
       }

--- a/services/gateway/src/routes/orb-tool.ts
+++ b/services/gateway/src/routes/orb-tool.ts
@@ -620,6 +620,29 @@ async function tool_log_health(
   };
 }
 
+// VTID-02778 — Awareness engine queries
+async function tool_awareness_queries(
+  toolName: 'get_emotional_state' | 'get_situational_awareness' | 'get_availability' | 'get_environmental_context' | 'get_social_context' | 'get_life_stage_context',
+  _args: ToolArgs,
+  id: Identity,
+  sb: SupabaseClient,
+): Promise<ToolResult> {
+  const aq = await import('../services/voice-tools/awareness-queries');
+  const map: Record<string, (s: any, u: string) => Promise<any>> = {
+    get_emotional_state: aq.getEmotionalState,
+    get_situational_awareness: aq.getSituationalAwareness,
+    get_availability: aq.getAvailability,
+    get_environmental_context: aq.getEnvironmentalContext,
+    get_social_context: aq.getSocialContext,
+    get_life_stage_context: aq.getLifeStageContext,
+  };
+  const fn = map[toolName];
+  if (!fn) return { ok: false, error: 'unknown_awareness_tool' };
+  const r = await fn(sb, id.user_id);
+  if (!r || r.ok === false) return { ok: false, error: (r && r.error) || `${toolName}_failed` };
+  return { ok: true, result: r, text: `Awareness signals retrieved.` };
+}
+
 async function tool_get_pillar_subscores(
   args: ToolArgs,
   id: Identity,
@@ -767,6 +790,15 @@ router.post('/orb/tool', requireAuth, async (req: AuthenticatedRequest, res: Res
         break;
       case 'get_pillar_subscores':
         r = await tool_get_pillar_subscores(args, identity, sb);
+        break;
+      // VTID-02778 — Awareness engine queries
+      case 'get_emotional_state':
+      case 'get_situational_awareness':
+      case 'get_availability':
+      case 'get_environmental_context':
+      case 'get_social_context':
+      case 'get_life_stage_context':
+        r = await tool_awareness_queries(name as 'get_emotional_state' | 'get_situational_awareness' | 'get_availability' | 'get_environmental_context' | 'get_social_context' | 'get_life_stage_context', args, identity, sb);
         break;
       default:
         return res.status(404).json({ ok: false, error: `unknown tool: ${name}`, vtid: VTID });

--- a/services/gateway/src/services/voice-tools/awareness-queries.ts
+++ b/services/gateway/src/services/voice-tools/awareness-queries.ts
@@ -1,0 +1,58 @@
+/**
+ * VTID-02778 — Voice Tool Expansion P1p: Awareness engine queries.
+ *
+ * Read-only voice tools that surface the latest computed signals from
+ * the awareness engines (D28/D32/D33/D34/D35/D40). Each tool calls the
+ * engine's `<engine>_get_current` RPC. If the RPC isn't deployed in this
+ * environment, the tool returns a graceful "not yet computed" response.
+ */
+
+import { SupabaseClient } from '@supabase/supabase-js';
+
+async function callGetCurrent(
+  sb: SupabaseClient,
+  rpcName: string,
+  userId: string,
+): Promise<{ ok: true; signals: any } | { ok: false; error: string }> {
+  // Most engines' get_current RPC takes (p_session_id, p_user_id) or
+  // similar. Pass null session and the user_id; engines that need a session
+  // will return their own error.
+  const { data, error } = await sb.rpc(rpcName, {
+    p_session_id: null,
+    p_user_id: userId,
+  });
+  if (error) {
+    if (error.message.includes('function') && error.message.includes('does not exist')) {
+      return { ok: false, error: 'rpc_unavailable' };
+    }
+    // Try without p_user_id (some engines auto-resolve from auth.uid)
+    const fallback = await sb.rpc(rpcName, { p_session_id: null });
+    if (fallback.error) return { ok: false, error: `${rpcName}_failed: ${error.message}` };
+    return { ok: true, signals: fallback.data ?? null };
+  }
+  return { ok: true, signals: data ?? null };
+}
+
+export async function getEmotionalState(sb: SupabaseClient, userId: string) {
+  return callGetCurrent(sb, 'emotional_cognitive_get_current', userId);
+}
+
+export async function getSituationalAwareness(sb: SupabaseClient, userId: string) {
+  return callGetCurrent(sb, 'situational_awareness_get_current', userId);
+}
+
+export async function getAvailability(sb: SupabaseClient, userId: string) {
+  return callGetCurrent(sb, 'availability_readiness_get_current', userId);
+}
+
+export async function getEnvironmentalContext(sb: SupabaseClient, userId: string) {
+  return callGetCurrent(sb, 'environmental_mobility_get_current', userId);
+}
+
+export async function getSocialContext(sb: SupabaseClient, userId: string) {
+  return callGetCurrent(sb, 'social_context_get_current', userId);
+}
+
+export async function getLifeStageContext(sb: SupabaseClient, userId: string) {
+  return callGetCurrent(sb, 'life_stage_get_current', userId);
+}


### PR DESCRIPTION
## Summary
- P1p of the voice tool expansion (40→269 plan).
- Adds 6 read-only voice tools that surface the latest signals from awareness engines D28/D32/D33/D34/D35/D40.
- Each tool calls the engine's \`<engine>_get_current\` RPC and gracefully degrades to \`rpc_unavailable\` when the engine isn't deployed.

## Tools
| name | engine |
|---|---|
| \`get_emotional_state\` | D28 emotional_cognitive |
| \`get_situational_awareness\` | D32 situational_awareness |
| \`get_availability\` | D33 availability_readiness |
| \`get_environmental_context\` | D34 environmental_mobility |
| \`get_social_context\` | D35 social_context |
| \`get_life_stage_context\` | D40 life_stage |

## Test plan
- [x] \`npm run build\` clean
- [ ] Voice probe: \"how am I feeling right now?\" → \`get_emotional_state\` fires; if engine missing, ORB speaks the not-yet-computed reply

🤖 Generated with [Claude Code](https://claude.com/claude-code)