### PR TITLE
DEV-AUTOPILOT: connection-issue-debouncer (FB-2026-05-000061)

### DIFF
--- a/services/gateway/src/services/connection-issue-debouncer.ts
+++ b/services/gateway/src/services/connection-issue-debouncer.ts
@@ -1,0 +1,27 @@
+export class ConnectionIssueDebouncer {
+  private timers = new Map<string, NodeJS.Timeout>();
+
+  reportIssue(connectionId: string, debounceMs: number, onConfirm: () => void): void {
+    if (this.timers.has(connectionId)) {
+      clearTimeout(this.timers.get(connectionId));
+    }
+    
+    const timer = setTimeout(() => {
+      this.timers.delete(connectionId);
+      onConfirm();
+    }, debounceMs);
+    
+    this.timers.set(connectionId, timer);
+  }
+
+  resolveIssue(connectionId: string): void {
+    if (this.timers.has(connectionId)) {
+      clearTimeout(this.timers.get(connectionId));
+      this.timers.delete(connectionId);
+    }
+  }
+
+  cleanup(connectionId: string): void {
+    this.resolveIssue(connectionId);
+  }
+}

--- a/services/gateway/test/connection-issue-debouncer.test.ts
+++ b/services/gateway/test/connection-issue-debouncer.test.ts
@@ -1,0 +1,58 @@
+import { ConnectionIssueDebouncer } from '../src/services/connection-issue-debouncer';
+
+describe('ConnectionIssueDebouncer', () => {
+  let debouncer: ConnectionIssueDebouncer;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    debouncer = new ConnectionIssueDebouncer();
+  });
+
+  afterEach(() => {
+    jest.clearAllTimers();
+    jest.useRealTimers();
+  });
+
+  it('executes callback after timeout', () => {
+    const callback = jest.fn();
+    debouncer.reportIssue('conn-1', 2000, callback);
+    
+    expect(callback).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(2000);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('does not execute callback if resolveIssue is called before timeout', () => {
+    const callback = jest.fn();
+    debouncer.reportIssue('conn-1', 2000, callback);
+    
+    jest.advanceTimersByTime(1000);
+    debouncer.resolveIssue('conn-1');
+    jest.advanceTimersByTime(1000);
+    
+    expect(callback).not.toHaveBeenCalled();
+  });
+
+  it('resets the timer if reportIssue is called multiple times', () => {
+    const callback = jest.fn();
+    debouncer.reportIssue('conn-1', 2000, callback);
+    
+    jest.advanceTimersByTime(1000);
+    debouncer.reportIssue('conn-1', 2000, callback);
+    jest.advanceTimersByTime(1000);
+    
+    expect(callback).not.toHaveBeenCalled();
+    jest.advanceTimersByTime(1000);
+    expect(callback).toHaveBeenCalledTimes(1);
+  });
+
+  it('cleanup removes the timer', () => {
+    const callback = jest.fn();
+    debouncer.reportIssue('conn-1', 2000, callback);
+    
+    debouncer.cleanup('conn-1');
+    jest.advanceTimersByTime(2000);
+    
+    expect(callback).not.toHaveBeenCalled();
+  });
+});


### PR DESCRIPTION
This PR addresses FB-2026-05-000061 where ORB voice incorrectly disconnects with "internet problem" on stable connections due to transient upstream network blips.

It introduces a `ConnectionIssueDebouncer` class and its corresponding unit tests to wait for a configurable grace period before executing a connection drop logic.

**NOTE to Operator**: `services/gateway/src/routes/orb-live.ts` was not modified in this PR because the file contents provided to the autopilot context were truncated (at character 82,103 out of 821,036). Emitting a partial file would have destroyed the remainder of the route definitions. Please manually integrate `ConnectionIssueDebouncer` into `orb-live.ts` as specified in the plan (instantiate it, wrap the disconnect/event logic inside `debouncer.reportIssue`, and call `resolveIssue`/`cleanup` appropriately).