### PR TITLE
feat(navigator): intent classification + disambiguation gate (VTID-02781)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -3558,18 +3558,69 @@ async function handleNavigate(
     type: 'orb.navigator.consulted',
     source: 'orb-live-ws',
     status: consultResult.confidence === 'low' ? 'warning' : 'info',
-    message: `navigate: confidence=${consultResult.confidence}, primary=${consultResult.primary?.screen_id || 'none'}`,
+    message: `navigate: confidence=${consultResult.confidence}, decision=${consultResult.decision}, primary=${consultResult.primary?.screen_id || 'none'}`,
     payload: {
       session_id: session.sessionId,
       question,
       primary_screen_id: consultResult.primary?.screen_id || null,
       confidence: consultResult.confidence,
+      // VTID-02781: surface decision in consulted-event payload
+      decision: consultResult.decision,
+      alternative_screen_ids: consultResult.alternatives.slice(0, 3).map(a => a.screen_id),
       kb_excerpt_count: consultResult.kb_excerpt_count,
       memory_hint_count: consultResult.memory_hint_count,
       ms_elapsed: consultResult.ms_elapsed,
       is_anonymous: consultInput.is_anonymous,
     },
   }).catch(() => {});
+
+  // VTID-02781: If the consult decided the request is ambiguous, return an
+  // either/or clarification BEFORE auto-navigating. Better to ask once than
+  // to redirect to the wrong screen.
+  if (
+    consultResult.decision === 'ambiguous' &&
+    consultResult.alternatives.length >= 2 &&
+    !consultResult.blocked_reason
+  ) {
+    const top = consultResult.alternatives[0];
+    const second = consultResult.alternatives[1];
+    const third = consultResult.alternatives[2] || null;
+    emitOasisEvent({
+      vtid: 'VTID-02781',
+      type: 'orb.navigator.disambiguated',
+      source: 'orb-live-ws',
+      status: 'info',
+      message: `disambiguating: ${top.screen_id} vs ${second.screen_id}${third ? ' vs ' + third.screen_id : ''}`,
+      payload: {
+        session_id: session.sessionId,
+        question,
+        candidates: consultResult.alternatives.slice(0, 3).map(a => ({
+          screen_id: a.screen_id, route: a.route, title: a.title,
+        })),
+        ms_elapsed: consultResult.ms_elapsed,
+        lang: consultInput.lang,
+      },
+    }).catch(() => {});
+
+    const lines: string[] = [];
+    lines.push('NAVIGATING_TO: null (waiting for user choice — DO NOT redirect)');
+    lines.push(`DECISION: ambiguous`);
+    lines.push(`CANDIDATES:`);
+    consultResult.alternatives.slice(0, 3).forEach((a, i) => {
+      lines.push(`  [${i + 1}] ${a.screen_id} — ${a.title} (${a.route})`);
+    });
+    const askLine =
+      consultResult.suggested_question ||
+      (consultInput.lang.startsWith('de')
+        ? `Meinst du ${top.title} oder ${second.title}${third ? ' — oder ' + third.title : ''}?`
+        : `Do you mean ${top.title} or ${second.title}${third ? ' — or ' + third.title : ''}?`);
+    lines.push(`ASK_USER: ${askLine}`);
+    lines.push('');
+    lines.push('Ask the either/or question naturally. WAIT for the user to pick.');
+    lines.push('Then call navigate_to_screen with the chosen screen_id directly —');
+    lines.push('do not call navigate again unless the user rephrases their request.');
+    return { success: true, result: lines.join('\n') };
+  }
 
   // Step 2: If we found a match with sufficient confidence, auto-navigate
   if (consultResult.primary && consultResult.confidence !== 'low' && !consultResult.blocked_reason) {

--- a/services/gateway/src/services/navigator-consult.ts
+++ b/services/gateway/src/services/navigator-consult.ts
@@ -87,10 +87,33 @@ export type ConsultConfidence = 'high' | 'medium' | 'low';
 // "tenant forced a custom screen".
 export type ConsultDecisionSource = 'scoring' | 'override_trigger' | 'static_fallback';
 
+/**
+ * VTID-02781: The Navigator's call on what to do with this consult.
+ *
+ *   `confident`  — primary is a clear winner. Caller should auto-redirect.
+ *   `ambiguous`  — top-2 scores are too close, both viable. Ask either/or.
+ *   `unknown`    — no viable match. Ask the user to rephrase.
+ *
+ * Distinct from `confidence` (low/medium/high), which scores the absolute
+ * top match. `decision` is the action contract for the caller, derived
+ * from confidence + the gap between top and runner-up.
+ */
+export type ConsultDecision = 'confident' | 'ambiguous' | 'unknown';
+
 export interface NavigatorConsultResult {
   confidence: ConsultConfidence;
+  /** VTID-02781: action contract for the caller. */
+  decision: ConsultDecision;
   primary: NavigatorConsultPick | null;
+  /** Closest near-miss (if any). Kept for back-compat with older callers. */
   alternative?: NavigatorConsultPick;
+  /**
+   * VTID-02781: Up to 3 alternatives ranked by score. When `decision ===
+   * 'ambiguous'` this is what the caller renders in the either/or question.
+   * Always includes `primary` as `alternatives[0]` when ambiguous; empty
+   * for `unknown`; `[primary]` for `confident`.
+   */
+  alternatives: NavigatorConsultPick[];
   explanation: string;
   confirmation_needed: boolean;
   suggested_question?: string;
@@ -119,6 +142,13 @@ const CONSULT_CONFIG = {
   MEDIUM_CONFIDENCE_MIN: 12,
   // If 2nd-best is at least this fraction of the top score, treat as ambiguous
   AMBIGUITY_RATIO: 0.7,
+  // VTID-02781: Tighter normalized-gap threshold for the explicit `decision`
+  // field. Computed as 1 - score(top2)/score(top1). Below 0.20 = ambiguous,
+  // above = confident (when the top score also clears MEDIUM_CONFIDENCE_MIN).
+  // 0.20 means top must be 25%+ better than runner-up to skip the either/or.
+  AMBIGUITY_GAP: 0.20,
+  // Don't disambiguate if runner-up isn't even viable.
+  DISAMBIGUATE_RUNNER_UP_MIN: 12,
   // Absolute cosine-similarity floor for semantic-only matches (no keyword
   // hits at all). Without this, a query like "open the screen with the
   // connectors" picks an arbitrary community page that happens to share the
@@ -403,7 +433,9 @@ export async function consultNavigator(
     });
     return {
       confidence: 'high',
+      decision: 'confident',
       primary: pick,
+      alternatives: [pick],
       explanation,
       confirmation_needed: false,
       kb_excerpts: staticKbAnchors(overrideMatch as NavCatalogEntry),
@@ -452,7 +484,9 @@ export async function consultNavigator(
         if (entry && !entry.anonymous_safe) {
           return {
             confidence: 'low',
+            decision: 'unknown',
             primary: null,
+            alternatives: [],
             explanation: buildExplanation({ primary: null, confidence: 'low', blockedReason: 'requires_auth', hints: EMPTY_HINTS, lang: input.lang }),
             confirmation_needed: false,
             kb_excerpts: [],
@@ -478,7 +512,9 @@ export async function consultNavigator(
 
       return {
         confidence: 'high',
+        decision: 'confident',
         primary: pick,
+        alternatives: [pick],
         explanation,
         confirmation_needed: false,
         kb_excerpts: staticKbAnchors(fastTop.entry),
@@ -649,6 +685,59 @@ export async function consultNavigator(
     }
   }
 
+  // ── VTID-02781: Compute `decision` (the action contract for the caller).
+  //
+  // Three buckets:
+  //   `confident`  — top is a clear winner. Auto-redirect.
+  //   `ambiguous`  — top-2 are too close, both viable. Ask either/or.
+  //   `unknown`    — nothing viable. Ask user to rephrase.
+  //
+  // Logic:
+  //   - `low` confidence (or auth-blocked) → unknown
+  //   - top has runner-up within AMBIGUITY_GAP AND runner-up clears
+  //     DISAMBIGUATE_RUNNER_UP_MIN → ambiguous
+  //   - otherwise → confident
+  //
+  // Also build `alternatives[]` (up to 3) for the caller to surface in the
+  // clarifying question. Always includes primary as alternatives[0] when
+  // ambiguous; [primary] for confident; empty for unknown.
+  let decision: ConsultDecision;
+  let alternatives: NavigatorConsultPick[] = [];
+
+  if (!primary || confidence === 'low' || blockedReason) {
+    decision = 'unknown';
+  } else {
+    const topScore = top!.score;
+    const runnerUp = second && second.entry.screen_id !== primary.screen_id ? second : null;
+    const gap = runnerUp ? 1 - runnerUp.score / topScore : 1;
+    const isAmbiguous =
+      runnerUp !== null &&
+      runnerUp.score >= CONSULT_CONFIG.DISAMBIGUATE_RUNNER_UP_MIN &&
+      gap < CONSULT_CONFIG.AMBIGUITY_GAP;
+
+    if (isAmbiguous) {
+      decision = 'ambiguous';
+      // Surface top 3 viable picks as alternatives.
+      alternatives = scored
+        .filter(s => s.score >= CONSULT_CONFIG.DISAMBIGUATE_RUNNER_UP_MIN)
+        .slice(0, 3)
+        .map(s => entryToPick(s.entry, input.lang));
+      // The legacy `alternative` field tracks the closest near-miss.
+      if (!alternative && alternatives.length > 1) {
+        alternative = alternatives[1];
+      }
+      // Force `confirmation_needed` so the existing tool-result formatter
+      // also signals the caller (older Gemini turns may key off this field).
+      confirmationNeeded = true;
+      if (!suggestedQuestion && alternatives.length >= 2) {
+        suggestedQuestion = buildClarification(top!.entry, runnerUp!.entry, input.lang);
+      }
+    } else {
+      decision = 'confident';
+      alternatives = [entryToPick(top!.entry, input.lang)];
+    }
+  }
+
   // ── Compose KB excerpts: static anchors + runtime hits, deduped ────────
   const staticAnchors = staticKbAnchors(top?.entry || null);
   const kbExcerpts: string[] = [];
@@ -673,8 +762,10 @@ export async function consultNavigator(
 
   return {
     confidence,
+    decision,
     primary,
     alternative,
+    alternatives,
     explanation,
     confirmation_needed: confirmationNeeded,
     suggested_question: suggestedQuestion,
@@ -703,6 +794,10 @@ export async function consultNavigator(
 export function formatConsultResultForLLM(result: NavigatorConsultResult): string {
   const lines: string[] = [];
   lines.push(`RECOMMENDATION: ${result.confidence}`);
+  // VTID-02781: Surface the explicit decision so Gemini sees the action
+  // contract front-and-center: confident → redirect now; ambiguous → ask
+  // either/or; unknown → ask the user to rephrase.
+  lines.push(`DECISION: ${result.decision}`);
   if (result.blocked_reason) {
     lines.push(`BLOCKED_REASON: ${result.blocked_reason}`);
   }
@@ -711,7 +806,15 @@ export function formatConsultResultForLLM(result: NavigatorConsultResult): strin
   } else {
     lines.push('PRIMARY: none');
   }
-  if (result.alternative) {
+  if (result.decision === 'ambiguous' && result.alternatives.length > 1) {
+    // List up to 3 alternatives so the LLM can construct a clean either/or
+    // question. Always render alternatives[0] (the primary) too so the
+    // model sees the full picture.
+    for (let i = 0; i < Math.min(result.alternatives.length, 3); i++) {
+      const a = result.alternatives[i];
+      lines.push(`ALTERNATIVE_${i + 1}: ${a.screen_id} (${a.route}) — ${a.title}`);
+    }
+  } else if (result.alternative) {
     lines.push(`ALTERNATIVE: ${result.alternative.screen_id} (${result.alternative.route}) — ${result.alternative.title}`);
   }
   lines.push(`CONFIRMATION_NEEDED: ${result.confirmation_needed}`);

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -538,6 +538,11 @@ export type CicdEventType =
   | 'orb.navigator.requested'
   | 'orb.navigator.blocked'
   | 'orb.navigator.dispatched'
+  // VTID-02781: emitted whenever the Navigator returns `decision: 'ambiguous'`
+  // and the ORB asks the user an either/or clarification. Pairs with a
+  // subsequent orb.navigator.dispatched (or .blocked) on the user's reply —
+  // lets us measure clarification → resolution rate.
+  | 'orb.navigator.disambiguated'
   // VTID-01225: Cognee Entity Extraction Events
   | 'cognee.extraction.started'
   | 'cognee.extraction.completed'

--- a/services/gateway/test/navigator-consult.test.ts
+++ b/services/gateway/test/navigator-consult.test.ts
@@ -43,6 +43,7 @@ import {
   formatConsultResultForLLM,
   writeNavigatorActionMemory,
   NavigatorConsultInput,
+  NavigatorConsultResult,
 } from '../src/services/navigator-consult';
 import { writeMemoryItemWithIdentity } from '../src/services/orb-memory-bridge';
 
@@ -289,5 +290,89 @@ describe('writeNavigatorActionMemory', () => {
       orb_session_id: 's',
       lang: 'en',
     })).resolves.toBeUndefined();
+  });
+});
+
+// ─── VTID-02781: decision + alternatives ────────────────────────────────────
+
+describe('consultNavigator — decision field (VTID-02781)', () => {
+  test('confident: clear high-score winner returns decision="confident" with primary in alternatives[0]', async () => {
+    const result = await consultNavigator(authedInput({
+      question: 'how do I track my biology',
+    }));
+    expect(result.decision).toBe('confident');
+    expect(result.primary).not.toBeNull();
+    expect(result.alternatives.length).toBeGreaterThanOrEqual(1);
+    expect(result.alternatives[0].screen_id).toBe(result.primary?.screen_id);
+  });
+
+  test('unknown: no viable match returns decision="unknown" with empty alternatives', async () => {
+    const result = await consultNavigator(authedInput({
+      question: 'recite the periodic table',
+    }));
+    expect(result.decision).toBe('unknown');
+    expect(result.primary).toBeNull();
+    expect(result.alternatives).toEqual([]);
+  });
+
+  test('unknown: anonymous user blocked from authed screen returns decision="unknown"', async () => {
+    const result = await consultNavigator(anonymousInput({
+      question: 'open my wallet',
+    }));
+    expect(result.decision).toBe('unknown');
+    expect(result.primary).toBeNull();
+    expect(result.alternatives).toEqual([]);
+  });
+
+  test('decision is always one of the three documented values', async () => {
+    for (const q of [
+      'how do I track my biology',
+      'tell me a joke about gravity',
+      'open the events page',
+      'show me my matches',
+    ]) {
+      const result = await consultNavigator(authedInput({ question: q }));
+      expect(['confident', 'ambiguous', 'unknown']).toContain(result.decision);
+    }
+  });
+});
+
+describe('formatConsultResultForLLM — DECISION line (VTID-02781)', () => {
+  test('renders DECISION on every result', async () => {
+    const result = await consultNavigator(authedInput({
+      question: 'how do I track my biology',
+    }));
+    const formatted = formatConsultResultForLLM(result);
+    expect(formatted).toMatch(/^DECISION: (confident|ambiguous|unknown)$/m);
+  });
+
+  test('ambiguous result lists ALTERNATIVE_1, ALTERNATIVE_2, ALTERNATIVE_3', () => {
+    // Synthesize an ambiguous result manually since the live catalog rarely
+    // produces one with our test fixtures.
+    const result: NavigatorConsultResult = {
+      confidence: 'medium',
+      decision: 'ambiguous',
+      primary: { screen_id: 'A.X', route: '/a', title: 'A', description: 'a', when_to_visit: 'a' },
+      alternative: { screen_id: 'B.X', route: '/b', title: 'B', description: 'b', when_to_visit: 'b' },
+      alternatives: [
+        { screen_id: 'A.X', route: '/a', title: 'A', description: 'a', when_to_visit: 'a' },
+        { screen_id: 'B.X', route: '/b', title: 'B', description: 'b', when_to_visit: 'b' },
+        { screen_id: 'C.X', route: '/c', title: 'C', description: 'c', when_to_visit: 'c' },
+      ],
+      explanation: 'pick one',
+      confirmation_needed: true,
+      kb_excerpts: [],
+      top_picks: [],
+      decision_source: 'scoring',
+      ms_elapsed: 1,
+      catalog_match_count: 3,
+      memory_hint_count: 0,
+      kb_excerpt_count: 0,
+    };
+    const formatted = formatConsultResultForLLM(result);
+    expect(formatted).toContain('DECISION: ambiguous');
+    expect(formatted).toContain('ALTERNATIVE_1: A.X');
+    expect(formatted).toContain('ALTERNATIVE_2: B.X');
+    expect(formatted).toContain('ALTERNATIVE_3: C.X');
   });
 });


### PR DESCRIPTION
## Summary

PR-2 of the Navigator rework. Pairs with [#1872](https://github.com/exafyltd/vitana-platform/pull/1872).

Catalog correctness alone (PR-1) doesn't fix every wrong redirect — some phrases are intrinsically ambiguous: \"show me my news\" → inbox / AI feed / news article; \"where can I see my events\" → events / calendar / reminders. Today the Navigator picks the top-scored entry and ships a redirect; sometimes it's wrong. **This PR makes the Navigator ASK either/or instead of guessing when the runner-up is too close.**

## What changed

**`NavigatorConsultResult` shape**:
- New `decision: 'confident' | 'ambiguous' | 'unknown'` — the explicit action contract for the caller. Distinct from `confidence` (low/medium/high), which scores the absolute top match.
- New `alternatives: NavigatorConsultPick[]` (up to 3, ranked by score). \`alternatives[0]\` is always the primary; populated for confident + ambiguous, empty for unknown.

**Decision logic** (computed across all four return paths in `consultNavigator()`):
- `low` confidence or auth-blocked → `unknown`
- top has runner-up within \`AMBIGUITY_GAP = 0.20\` (i.e. top is less than 25% better than runner-up) AND runner-up clears \`DISAMBIGUATE_RUNNER_UP_MIN = 12\` → \`ambiguous\`
- otherwise → \`confident\`

**`formatConsultResultForLLM()`**: renders \`DECISION:\` on every result so the action contract is front-and-center for Gemini. Lists \`ALTERNATIVE_1\`, \`ALTERNATIVE_2\`, \`ALTERNATIVE_3\` when ambiguous so the LLM has the catalog titles to construct a clean either/or question.

**`handleNavigate()` in orb-live.ts**: new disambiguation branch BEFORE the auto-navigate block. Returns:

\`\`\`
NAVIGATING_TO: null (waiting for user choice — DO NOT redirect)
DECISION: ambiguous
CANDIDATES:
  [1] INBOX.OVERVIEW — Inbox (/inbox)
  [2] AI.OVERVIEW — AI Assistant (/ai)
  [3] NEWS.DETAIL — News Article (/news/:id)
ASK_USER: Do you mean your Inbox or your AI Assistant — or your News Article?
\`\`\`

The ASK_USER line is rendered in the user's language (EN/DE).

**OASIS telemetry**:
- New event type \`orb.navigator.disambiguated\` (added to \`CicdEventType\`) emitted whenever the clarification path fires. Pairs with subsequent \`orb.navigator.dispatched\` (or \`.blocked\`) — lets us measure clarification → resolution rate from telemetry alone.
- \`consulted\` event payload now carries \`decision\` and \`alternative_screen_ids\` so the admin view can distinguish \"we redirected\" from \"we asked\".

## Tests

- **6 new tests** in \`navigator-consult.test.ts\`:
  - \`decision === 'confident'\` for clear winner with primary in \`alternatives[0]\`
  - \`decision === 'unknown'\` + empty alternatives on no-match queries
  - \`decision === 'unknown'\` for anonymous user blocked from authed screen
  - \`decision\` is always one of the three documented values across seeded queries
  - \`DECISION:\` line renders on every formatted result
  - \`ALTERNATIVE_1/2/3\` lines render when ambiguous

- **135/135 nav-related tests passing** (\`navigation-catalog.test.ts\`, \`navigator-consult.test.ts\`, \`nav-redirect-flow.test.ts\`).

## Out of scope (deferred)

- PR-3 (manifest-driven catalog automation) ships next — separate VTID.

## Test plan

- [ ] CI passes
- [ ] After deploy: smoke an ambiguous voice intent (\"show me my news\") and confirm Vitana asks either/or instead of redirecting
- [ ] Check \`oasis_events\` for \`orb.navigator.disambiguated\` after smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)