### PR TITLE
fix(orb-agent-trace): add required role column to oasis_events insert

### DIFF
--- a/services/gateway/src/routes/orb-agent-trace.ts
+++ b/services/gateway/src/routes/orb-agent-trace.ts
@@ -57,6 +57,7 @@ router.post('/orb/agent-trace', async (req: Request, res: Response) => {
       vtid: VTID,
       source: 'orb-agent',
       service: 'orb-agent',
+      role: 'orb-agent',
       status: 'info',
       message: `LiveKit agent session trace for ${userId}`,
       metadata: body,


### PR DESCRIPTION
Trivial fix — oasis_events.role is NOT NULL.