### PR TITLE
feat(navigator): mobile-aware redirects (VTID-02789)

### DIFF
--- a/services/gateway/src/lib/navigation-catalog.ts
+++ b/services/gateway/src/lib/navigation-catalog.ts
@@ -89,6 +89,21 @@ export interface NavCatalogEntry {
    */
   entry_kind?: 'route' | 'overlay';
   overlay?: NavOverlayMeta;
+  /**
+   * VTID-02789: Mobile-aware URL override. When the ORB session is from a
+   * mobile viewport (`session.is_mobile === true`), the Navigator uses
+   * `mobile_route` instead of `route`. Use for pages that auto-redirect on
+   * mobile (e.g. /comm → /comm/events-meetups?tab=hot) so we skip the
+   * redirect hop. May contain `:param` placeholders just like `route`.
+   */
+  mobile_route?: string;
+  /**
+   * VTID-02789: Viewport gate. `'mobile'` = only mobile sessions can be
+   * redirected here (desktop callers get blocked with kind='wrong_viewport').
+   * `'desktop'` = mirror, mobile gets blocked. Omitted = no restriction.
+   * Use for entries like /daily-diary which are mobile-only flows.
+   */
+  viewport_only?: 'mobile' | 'desktop';
 }
 
 /**
@@ -501,6 +516,11 @@ export const NAVIGATION_CATALOG: ReadonlyArray<NavCatalogEntry> = [
   {
     screen_id: 'COMM.OVERVIEW',
     route: '/comm',
+    // VTID-02789: On mobile, /comm auto-redirects to /comm/events-meetups?tab=hot
+    // inside Community.tsx — so the Navigator emits the post-redirect URL
+    // directly to skip the redirect hop and let the user land on the right
+    // screen one navigation faster.
+    mobile_route: '/comm/events-meetups?tab=hot',
     category: 'community',
     access: 'authenticated',
     anonymous_safe: false,
@@ -1711,6 +1731,9 @@ export const NAVIGATION_CATALOG: ReadonlyArray<NavCatalogEntry> = [
   {
     screen_id: 'MEMORY.DAILY_DIARY', route: '/daily-diary', category: 'memory',
     access: 'authenticated', anonymous_safe: false,
+    // VTID-02789: /daily-diary is implemented ONLY as MobileDailyDiary.tsx.
+    // No desktop layout exists, so block desktop sessions before redirect.
+    viewport_only: 'mobile',
     aliases: ['today-diary', 'today-journal', 'todays-diary'],
     i18n: {
       // Narrow keywords on purpose. The generic "open my diary" / "open daily

--- a/services/gateway/src/lib/screen-manifest-types.ts
+++ b/services/gateway/src/lib/screen-manifest-types.ts
@@ -68,6 +68,22 @@ export interface ScreenManifestEntry {
   /** 'route' (default) navigates; 'overlay' opens a popup via CustomEvent. */
   entry_kind?: 'route' | 'overlay';
   overlay?: ScreenOverlayMeta;
+  /**
+   * VTID-02789: Mobile-aware URL override. When the ORB session is from a
+   * mobile viewport (`is_mobile=true` in session context), the Navigator
+   * uses `mobile_route` instead of `path`. Use for pages that auto-redirect
+   * on mobile (e.g. /comm → /comm/events-meetups?tab=hot) so the Navigator
+   * skips the redirect hop. May contain `:param` placeholders just like
+   * `path`. Param substitution applies to whichever URL is selected.
+   */
+  mobile_route?: string;
+  /**
+   * VTID-02789: Viewport gate. `'mobile'` = only mobile sessions can be
+   * redirected here (desktop callers get blocked with kind='wrong_viewport').
+   * `'desktop'` = mirror, mobile gets blocked. Omitted = no restriction.
+   * Use for entries like /daily-diary which are mobile-only flows.
+   */
+  viewport_only?: 'mobile' | 'desktop';
   /** Localized content. EN required; DE strongly recommended. */
   i18n: Record<LangCode, ScreenManifestI18n>;
 }

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -912,6 +912,10 @@ interface GeminiLiveSession {
   // VTID-NAV: Last few routes the user visited (newest first), pushed by the
   // host React Router via VTOrb.updateContext before the session started.
   recent_routes?: string[];
+  // VTID-02789: Mobile viewport flag, set from the frontend's useIsMobile()
+  // hook in the session start payload + every updateContext. Drives the
+  // mobile_route override + viewport_only block in handleNavigateToScreen.
+  is_mobile?: boolean;
   // VTID-NAV: Cached memory pack from the first navigator_consult call this
   // session, with a 30s TTL — subsequent consult calls reuse it instead of
   // re-paying retrieval cost.
@@ -3941,17 +3945,52 @@ export async function handleNavigateToScreen(
     };
   }
 
+  // VTID-02789: Viewport gate — refuse the redirect if the entry is
+  // viewport-locked to mobile-only or desktop-only and the session doesn't
+  // match. Lets us mark `/daily-diary` (mobile-only flow) so a desktop
+  // session never gets sent there.
+  if (entry.viewport_only) {
+    const sessionViewport: 'mobile' | 'desktop' = session.is_mobile === true ? 'mobile' : 'desktop';
+    if (entry.viewport_only !== sessionViewport) {
+      emitOasisEvent({
+        vtid: 'VTID-02789',
+        type: 'orb.navigator.blocked',
+        source: 'orb-live-ws',
+        status: 'warning',
+        message: `Screen '${entry.screen_id}' is ${entry.viewport_only}-only; session is ${sessionViewport}`,
+        payload: {
+          session_id: session.sessionId,
+          attempted_screen_id: screenId,
+          error_kind: 'wrong_viewport',
+          required_viewport: entry.viewport_only,
+          session_viewport: sessionViewport,
+        },
+      }).catch(() => {});
+      return {
+        success: false,
+        result: '',
+        error: `Screen '${entry.screen_id}' is only available on ${entry.viewport_only}. Suggest a different screen or stay in voice.`,
+      };
+    }
+  }
+
   // VTID-02770: Resolve the final URL the frontend will receive.
-  //   1. Substitute `:param` placeholders in entry.route with values from
-  //      args. Missing required params are reported as a typed error so
+  //   1. VTID-02789: Mobile-aware URL — when session.is_mobile=true AND the
+  //      entry has a mobile_route override, use that instead of route. Lets
+  //      pages that auto-redirect on mobile (e.g. /comm →
+  //      /comm/events-meetups?tab=hot) skip the redirect hop.
+  //   2. Substitute `:param` placeholders in the chosen base URL with values
+  //      from args. Missing required params are reported as a typed error so
   //      Gemini knows it must ask the user for the missing piece.
-  //   2. For overlay entries (entry_kind === 'overlay'), append
+  //   3. For overlay entries (entry_kind === 'overlay'), append
   //      `?open=<query_marker>` so the frontend ORB widget intercepts and
   //      dispatches the corresponding CustomEvent instead of routing.
-  //   3. For overlay entries that need a parameter (e.g. user_id for
+  //   4. For overlay entries that need a parameter (e.g. user_id for
   //      OVERLAY.PROFILE_PREVIEW), append it as a query param too — the
   //      frontend reads it from the URL on dispatch.
-  let resolvedRoute = entry.route;
+  const isMobileSession = session.is_mobile === true;
+  const baseRoute = (isMobileSession && entry.mobile_route) ? entry.mobile_route : entry.route;
+  let resolvedRoute = baseRoute;
   const missingParams: string[] = [];
   resolvedRoute = resolvedRoute.replace(/:([a-zA-Z_][a-zA-Z0-9_]*)/g, (_match, name) => {
     const v = args[name];
@@ -4001,13 +4040,18 @@ export async function handleNavigateToScreen(
     resolvedRoute = `${resolvedRoute}${sep}${params.toString()}`;
   }
 
-  if (session.current_route && session.current_route === entry.route && entry.entry_kind !== 'overlay') {
+  // VTID-02789: Compare current_route against the *resolved* base path
+  // (mobile_route on mobile, route otherwise) so a mobile user already on
+  // /comm/events-meetups (because /comm aliased there) doesn't get bounced
+  // when they ask for "the community page" again.
+  const baseRoutePath = baseRoute.split('?')[0];
+  if (session.current_route && session.current_route === baseRoutePath && entry.entry_kind !== 'overlay') {
     emitOasisEvent({
       vtid: 'VTID-NAV-01',
       type: 'orb.navigator.blocked',
       source: 'orb-live-ws',
       status: 'info',
-      message: `User is already on ${entry.route}`,
+      message: `User is already on ${baseRoutePath}`,
       payload: {
         session_id: session.sessionId,
         attempted_screen_id: screenId,
@@ -4046,10 +4090,13 @@ export async function handleNavigateToScreen(
   //
   // VTID-02770: For overlay entries we do NOT change current_route, since the
   // user stays on their original page — only a popup opens.
+  // VTID-02789: Use the resolved baseRoutePath (mobile_route on mobile, else
+  // route) so the eager update tracks the actual destination, not the
+  // generic desktop URL.
   if (entry.entry_kind !== 'overlay') {
     const previousRoute = session.current_route;
-    session.current_route = entry.route;
-    if (previousRoute && previousRoute !== entry.route) {
+    session.current_route = baseRoutePath;
+    if (previousRoute && previousRoute !== baseRoutePath) {
       const trail = Array.isArray(session.recent_routes) ? [...session.recent_routes] : [];
       const deduped = trail.filter(r => r !== previousRoute);
       session.recent_routes = [previousRoute, ...deduped].slice(0, 5);
@@ -14750,6 +14797,12 @@ router.post('/live/session/start', optionalAuth, async (req: AuthenticatedReques
           .filter((r): r is string => typeof r === 'string')
           .slice(0, 5)
       : undefined,
+    // VTID-02789: Frontend useOrbVoiceWidget reads useIsMobile() and
+    // includes is_mobile in the start payload so the Navigator picks
+    // mobile_route over route on mobile sessions.
+    is_mobile: typeof (body as any).is_mobile === 'boolean'
+      ? (body as any).is_mobile
+      : undefined,
   };
 
   // VTID-SESSION-LIMIT: Terminate any existing active sessions for this user.
@@ -16615,6 +16668,12 @@ async function handleWsStartMessage(clientSession: WsClientSession, message: WsC
       ? ((message as any).recent_routes as any[])
           .filter((r): r is string => typeof r === 'string')
           .slice(0, 5)
+      : undefined,
+    // VTID-02789: mobile viewport flag plumbed from useIsMobile() in the
+    // frontend; drives mobile_route override + viewport_only block in
+    // handleNavigateToScreen. WS path mirrors the SSE path above.
+    is_mobile: typeof (message as any).is_mobile === 'boolean'
+      ? (message as any).is_mobile
       : undefined,
   };
 

--- a/services/gateway/test/nav-redirect-flow.test.ts
+++ b/services/gateway/test/nav-redirect-flow.test.ts
@@ -247,3 +247,67 @@ describe('orb_directive dispatch simulation', () => {
     expect(parsed.route).toBe('/comm/events-meetups');
   });
 });
+
+// ─── VTID-02789: mobile_route override + viewport_only ──────────────────────
+
+describe('handleNavigateToScreen — mobile-awareness (VTID-02789)', () => {
+  test('mobile session redirected to mobile_route override (COMM.OVERVIEW)', async () => {
+    // COMM.OVERVIEW.route = '/comm', mobile_route = '/comm/events-meetups?tab=hot'
+    const session = buildAuthenticatedSession({ is_mobile: true, current_route: '/home' });
+    const result = await handleNavigateToScreen(session, {
+      screen_id: 'COMM.OVERVIEW',
+      reason: 'mobile user opens community',
+    });
+    expect(result.success).toBe(true);
+    expect(session.pendingNavigation.route).toBe('/comm/events-meetups?tab=hot');
+    // Eager session-route update strips the query string and tracks the path.
+    expect(session.current_route).toBe('/comm/events-meetups');
+  });
+
+  test('desktop session falls back to entry.route (no mobile_route hop)', async () => {
+    const session = buildAuthenticatedSession({ is_mobile: false, current_route: '/home' });
+    const result = await handleNavigateToScreen(session, {
+      screen_id: 'COMM.OVERVIEW',
+      reason: 'desktop user opens community',
+    });
+    expect(result.success).toBe(true);
+    expect(session.pendingNavigation.route).toBe('/comm');
+    expect(session.current_route).toBe('/comm');
+  });
+
+  test('viewport_only=mobile blocks desktop sessions (MEMORY.DAILY_DIARY)', async () => {
+    const session = buildAuthenticatedSession({ is_mobile: false, current_route: '/home' });
+    const result = await handleNavigateToScreen(session, {
+      screen_id: 'MEMORY.DAILY_DIARY',
+      reason: 'desktop user asks for daily diary capture',
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/only available on mobile/i);
+    // No pending navigation queued
+    expect(session.pendingNavigation).toBeUndefined();
+  });
+
+  test('viewport_only=mobile allows mobile sessions (MEMORY.DAILY_DIARY)', async () => {
+    const session = buildAuthenticatedSession({ is_mobile: true, current_route: '/home' });
+    const result = await handleNavigateToScreen(session, {
+      screen_id: 'MEMORY.DAILY_DIARY',
+      reason: 'mobile user asks for daily diary capture',
+    });
+    expect(result.success).toBe(true);
+    expect(session.pendingNavigation.route).toBe('/daily-diary');
+  });
+
+  test('mobile session already on mobile_route is blocked with already_there', async () => {
+    // User is already on the mobile destination of COMM.OVERVIEW.
+    const session = buildAuthenticatedSession({
+      is_mobile: true,
+      current_route: '/comm/events-meetups',
+    });
+    const result = await handleNavigateToScreen(session, {
+      screen_id: 'COMM.OVERVIEW',
+      reason: 'mobile user re-asks',
+    });
+    expect(result.success).toBe(false);
+    expect(result.error).toMatch(/already on/i);
+  });
+});


### PR DESCRIPTION
## Summary

Make the ORB Navigator pick **mobile destinations for mobile sessions** instead of always emitting desktop URLs. Pairs with [exafyltd/vitana-v1 PR-4](https://github.com/exafyltd/vitana-v1/pulls) which pipes \`is_mobile\` (from \`useIsMobile()\`) into the ORB session context.

The audit (per chat) found only 2 routes that need explicit mobile-awareness; the other ~10 mobile-responsive pages share a single URL with desktop and swap layouts internally via \`useIsMobile()\` — those work today and need no catalog change.

## What changed

**NavCatalogEntry + ScreenManifestEntry** (mirrored, kept in sync via \`nav:check\`):
- \`mobile_route?: string\` — overrides \`route\` when \`session.is_mobile === true\`. Lets the Navigator emit \`/comm/events-meetups?tab=hot\` directly for mobile users instead of \`/comm\` (which then auto-redirects there in \`Community.tsx\`, costing a hop).
- \`viewport_only?: 'mobile' | 'desktop'\` — viewport gate. Use for routes like \`/daily-diary\` that have **no desktop layout**. Desktop sessions hitting a mobile-only entry get blocked with \`error_kind='wrong_viewport'\` instead of being redirected to a non-existent page.

**\`handleNavigateToScreen\`**:
- Reads \`session.is_mobile\` (plumbed from session-start payload + WS start message).
- Viewport gate runs **before** URL resolution — refuses redirect with a typed error when \`viewport_only\` doesn't match.
- URL resolution: \`const baseRoute = (isMobile && entry.mobile_route) ? entry.mobile_route : entry.route\`. Param substitution + overlay \`?open=\` markers apply on top of the chosen base.
- The \"already on this route\" block now compares against the resolved baseRoutePath so a mobile user already on \`/comm/events-meetups\` isn't bounced when they re-ask for "the community page".
- Eager \`session.current_route\` update tracks the chosen path.

**Catalog edits** — only the two cases the audit identified:
- \`COMM.OVERVIEW.mobile_route = '/comm/events-meetups?tab=hot'\`
- \`MEMORY.DAILY_DIARY.viewport_only = 'mobile'\`

## What this does NOT touch

The other responsive pages (Health, Wallet, EditProfile, Home, Inbox, Discover, Business, Assistant, Invite) share a single URL between viewports. The Navigator emits the same URL; React's \`useIsMobile()\` swaps layouts internally. No catalog change needed.

## OASIS event

\`orb.navigator.blocked\` with \`error_kind='wrong_viewport'\` fires when a session attempts a viewport-locked entry from the wrong side. Lets us see in telemetry if any desktop session is trying to reach mobile-only routes (and vice versa) so we can spot the LLM hallucinating destinations.

## Tests

- 5 new tests in \`nav-redirect-flow.test.ts\`:
  - mobile session redirected to \`mobile_route\` override (COMM.OVERVIEW)
  - desktop session falls back to \`entry.route\` (no hop)
  - \`viewport_only='mobile'\` blocks desktop sessions (MEMORY.DAILY_DIARY)
  - \`viewport_only='mobile'\` allows mobile sessions
  - \`already_there\` compares against the resolved path on mobile
- **212/212 nav-related tests passing.**

## Test plan

- [ ] CI passes
- [ ] Pair-merge with vitana-v1 sibling PR (frontend must send \`is_mobile\` for the gateway to apply the override)
- [ ] After deploy: as a mobile user, ask ORB \"open community\" → confirm direct landing on \`/comm/events-meetups?tab=hot\` (no \`/comm\` flash)
- [ ] As a desktop user, ask ORB for \"daily diary\" → expect a polite refusal, not a redirect

🤖 Generated with [Claude Code](https://claude.com/claude-code)