### PR TITLE
feat(conductor): add DeepSeek adapter to Python LLM router (BOOTSTRAP-CONDUCTOR-DS)

### DIFF
--- a/services/agents/conductor/llm-router/router.py
+++ b/services/agents/conductor/llm-router/router.py
@@ -124,6 +124,8 @@ class LLMRouter:
     def __init__(self, service_name: str = "conductor"):
         self.oasis_url = os.getenv("OASIS_GATEWAY_URL", "https://oasis-gateway.vitana.ai")
         self.anthropic_key = os.getenv("ANTHROPIC_API_KEY")
+        self.deepseek_key = os.getenv("DEEPSEEK_API_KEY")
+        self.deepseek_base_url = os.getenv("DEEPSEEK_BASE_URL", "https://api.deepseek.com")
         self.project_id = os.getenv("GCP_PROJECT_ID", "lovable-vitana-vers1")
         self.service_name = service_name
 
@@ -233,6 +235,8 @@ class LLMRouter:
             return self._call_anthropic(model, prompt, max_tokens, temperature)
         elif provider == "vertex_ai":
             return self._call_vertex(model, prompt, max_tokens, temperature)
+        elif provider == "deepseek":
+            return self._call_deepseek(model, prompt, max_tokens, temperature)
         else:
             raise ValueError(f"Unknown provider: {provider}")
 
@@ -290,6 +294,53 @@ class LLMRouter:
             "provider": "vertex_ai",
             "tokens": {"input": int(input_tokens), "output": int(output_tokens), "total": int(input_tokens + output_tokens)},
             "cost_usd": round(cost, 6)
+        }
+
+    def _call_deepseek(self, model: str, prompt: str, max_tokens: int, temperature: float) -> Dict[str, Any]:
+        """Call DeepSeek via OpenAI-compatible API.
+
+        DeepSeek exposes an OpenAI-compatible chat completions endpoint at
+        https://api.deepseek.com. Models in scope: 'deepseek-chat' (V3) and
+        'deepseek-reasoner' (R1). Uses raw HTTP to avoid pulling in the
+        full OpenAI SDK as a hard dependency.
+        """
+        if not self.deepseek_key:
+            raise Exception("DEEPSEEK_API_KEY not set")
+
+        resp = requests.post(
+            f"{self.deepseek_base_url}/chat/completions",
+            headers={
+                "Authorization": f"Bearer {self.deepseek_key}",
+                "Content-Type": "application/json",
+            },
+            json={
+                "model": model,
+                "messages": [{"role": "user", "content": prompt}],
+                "max_tokens": max_tokens,
+                "temperature": temperature,
+            },
+            timeout=120,
+        )
+        resp.raise_for_status()
+        body = resp.json()
+
+        text = body["choices"][0]["message"]["content"]
+        usage = body.get("usage", {})
+        input_tokens = usage.get("prompt_tokens", 0)
+        output_tokens = usage.get("completion_tokens", 0)
+
+        # Published rates: deepseek-chat (V3) = $0.14/$0.28 per 1M, reasoner (R1) = $0.55/$2.19
+        if "reasoner" in model:
+            cost = (input_tokens * 0.55 / 1_000_000) + (output_tokens * 2.19 / 1_000_000)
+        else:
+            cost = (input_tokens * 0.14 / 1_000_000) + (output_tokens * 0.28 / 1_000_000)
+
+        return {
+            "text": text,
+            "model": model,
+            "provider": "deepseek",
+            "tokens": {"input": input_tokens, "output": output_tokens, "total": input_tokens + output_tokens},
+            "cost_usd": round(cost, 6),
         }
 
     def _log_to_oasis(self, event_type: str, data: Dict[str, Any]) -> str:


### PR DESCRIPTION
## Summary

The Python conductor at services/agents/conductor/llm-router/router.py previously supported only 'anthropic' and 'vertex_ai' providers, while the TypeScript gateway llm-router already had a fully wired DeepSeek adapter and DEEPSEEK_API_KEY plumbed in EXEC-DEPLOY.yml. This left the conductor unable to dispatch to DeepSeek even when crew.yaml asked for it.

Part of the broader agent registry truth + DeepSeek wiring effort (companion to PR #1853 metadata fix and PR #1855 heartbeat fix).

## Changes

- DEEPSEEK_API_KEY + DEEPSEEK_BASE_URL env reads in LLMRouter.__init__
- _call_deepseek() using DeepSeek's OpenAI-compatible /chat/completions endpoint via raw HTTP (no hard openai SDK dep)
- 'deepseek' branch in _call_llm() dispatcher
- Cost computation aligned with published DeepSeek rates: V3 chat ($0.14/$0.28 per 1M) and R1 reasoner ($0.55/$2.19 per 1M)

## Behavior change

Purely additive — no provider priority changes. crew.yaml continues to drive which roles use which provider. To use DeepSeek for a role, set the role's primary or fallback in crew.yaml to a model entry whose provider='deepseek'.

## Test plan

- [x] Module imports cleanly (verified locally with importlib)
- [ ] After deploy: set DEEPSEEK_API_KEY in conductor Cloud Run env
- [ ] Add a test model entry in crew.yaml with provider=deepseek, model_id=deepseek-chat
- [ ] Trigger a validator role call and confirm telemetry shows provider=deepseek

🤖 Generated with [Claude Code](https://claude.com/claude-code)