### PR TITLE
DEV-AUTOPILOT: Add regression test for MCP SDK ReDoS CVE

### DIFF
--- a/services/gateway/test/cve-mcp-sdk.test.ts
+++ b/services/gateway/test/cve-mcp-sdk.test.ts
@@ -1,0 +1,38 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('Security: @modelcontextprotocol/sdk ReDoS Vulnerability', () => {
+  it('should ensure the configured version is >= 1.25.2 to prevent ReDoS', () => {
+    const packageJsonPath = path.resolve(__dirname, '../package.json');
+    const packageJsonContent = fs.readFileSync(packageJsonPath, 'utf8');
+    const packageJson = JSON.parse(packageJsonContent);
+
+    const dependencies = packageJson.dependencies || {};
+    const sdkVersionString = dependencies['@modelcontextprotocol/sdk'];
+
+    // Ensure the SDK is actually defined in the dependencies
+    expect(sdkVersionString).toBeDefined();
+
+    // Strip semver prefixes like '^' or '~'
+    const cleanVersion = sdkVersionString.replace(/^[^\d]+/, '');
+    const versionParts = cleanVersion.split('.');
+
+    const major = parseInt(versionParts[0] || '0', 10);
+    const minor = parseInt(versionParts[1] || '0', 10);
+    const patch = parseInt(versionParts[2] || '0', 10);
+
+    const isSecure =
+      major > 1 ||
+      (major === 1 && minor > 25) ||
+      (major === 1 && minor === 25 && patch >= 2);
+
+    if (!isSecure) {
+      throw new Error(
+        `Vulnerable @modelcontextprotocol/sdk version found: "${sdkVersionString}". ` +
+        `Must be updated to >= 1.25.2 to prevent ReDoS vulnerability.`
+      );
+    }
+
+    expect(isSecure).toBe(true);
+  });
+});


### PR DESCRIPTION
This PR implements an automated regression test targeting a known Regular Expression Denial of Service (ReDoS) vulnerability in the Anthropic MCP TypeScript SDK (`@modelcontextprotocol/sdk`). 

The test statically parses `services/gateway/package.json` to verify that the dependency version is logically `>= 1.25.2`, preventing future regressions.

### ⚠️ Developer Actions Required Before Merging
Automated dependency bumps and lockfile changes are intentionally excluded from this PR's scope to prevent breaking changes in the executor. Before merging this branch, an operator must:
1. Manually bump `"@modelcontextprotocol/sdk"` to `"^1.25.2"` in the `services/gateway/package.json` dependencies block.
2. Run `npm install` within `services/gateway` to update `package-lock.json`.
3. Run `npx jest test/cve-mcp-sdk.test.ts` within `services/gateway` to confirm the new regression test now passes.
4. Run `npm run typecheck` to ensure no breaking API changes disrupt existing MCP SDK usage.
5. Ensure `npm audit` shows the ReDoS vulnerability is fully resolved.