### PR TITLE
DEV-AUTOPILOT: Replace inline admin auth with standard middleware

### DIFF
--- a/services/gateway/src/routes/admin-signups.ts
+++ b/services/gateway/src/routes/admin-signups.ts
@@ -18,50 +18,16 @@
 
 import { Router, Request, Response } from 'express';
 import { getSupabase } from '../lib/supabase';
-import { createUserSupabaseClient } from '../lib/supabase-user';
+import { requireExafyAdmin, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
 import { notifyUserAsync } from '../services/notification-service';
 import { dispatchEvent } from '../services/automation-executor';
 
 const router = Router();
 const VTID = 'ADMIN-SIGNUPS';
 
-// ── Auth Helper ─────────────────────────────────────────────
-
-function getBearerToken(req: Request): string | null {
-  const authHeader = req.headers.authorization;
-  if (!authHeader || !authHeader.startsWith('Bearer ')) return null;
-  return authHeader.slice(7);
-}
-
-async function verifyExafyAdmin(
-  req: Request
-): Promise<{ ok: true; user_id: string; email: string } | { ok: false; status: number; error: string }> {
-  const token = getBearerToken(req);
-  if (!token) return { ok: false, status: 401, error: 'UNAUTHENTICATED' };
-
-  try {
-    const userClient = createUserSupabaseClient(token);
-    const { data: authData, error: authError } = await userClient.auth.getUser();
-    if (authError || !authData?.user) return { ok: false, status: 401, error: 'INVALID_TOKEN' };
-
-    const appMetadata = authData.user.app_metadata || {};
-    if (appMetadata.exafy_admin !== true) {
-      return { ok: false, status: 403, error: 'FORBIDDEN' };
-    }
-
-    return { ok: true, user_id: authData.user.id, email: authData.user.email || 'unknown' };
-  } catch (err: any) {
-    console.error(`[${VTID}] Auth error:`, err.message);
-    return { ok: false, status: 500, error: 'INTERNAL_ERROR' };
-  }
-}
-
 // ── GET / — Funnel dashboard ────────────────────────────────
 
-router.get('/', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
+router.get('/', requireExafyAdmin, async (req: AuthenticatedRequest, res: Response) => {
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -101,10 +67,7 @@ router.get('/', async (req: Request, res: Response) => {
 
 // ── GET /stats — Aggregate funnel statistics ────────────────
 
-router.get('/stats', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
+router.get('/stats', requireExafyAdmin, async (req: AuthenticatedRequest, res: Response) => {
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -161,10 +124,7 @@ router.get('/stats', async (req: Request, res: Response) => {
 
 // ── GET /attempts — Raw signup attempt log ──────────────────
 
-router.get('/attempts', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
+router.get('/attempts', requireExafyAdmin, async (req: AuthenticatedRequest, res: Response) => {
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -201,6 +161,7 @@ router.get('/attempts', async (req: Request, res: Response) => {
 
 // ── POST /log-attempt — Public: log registration attempt ────
 
+// public-route
 router.post('/log-attempt', async (req: Request, res: Response) => {
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
@@ -238,6 +199,7 @@ router.post('/log-attempt', async (req: Request, res: Response) => {
 
 // ── POST /log-result — Public: log signup success/failure ───
 
+// public-route
 router.post('/log-result', async (req: Request, res: Response) => {
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
@@ -310,10 +272,7 @@ router.post('/log-result', async (req: Request, res: Response) => {
 
 // ── POST /:id/invite — Send onboarding invitation ──────────
 
-router.post('/:id/invite', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
+router.post('/:id/invite', requireExafyAdmin, async (req: AuthenticatedRequest, res: Response) => {
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -340,7 +299,7 @@ router.post('/:id/invite', async (req: Request, res: Response) => {
         signup_attempt_id: id,
         target_user_id: attempt.auth_user_id || null,
         email: attempt.email,
-        invited_by: authResult.user_id,
+        invited_by: req.identity!.user_id,
         type: type || 'email',
         status: 'sent',
         message: message || 'We noticed you started signing up for Vitana. Would you like help completing your registration?',
@@ -368,7 +327,7 @@ router.post('/:id/invite', async (req: Request, res: Response) => {
       );
     }
 
-    console.log(`[${VTID}] Invitation sent to ${attempt.email} by ${authResult.email}`);
+    console.log(`[${VTID}] Invitation sent to ${attempt.email} by ${req.identity!.email || 'unknown'}`);
 
     return res.json({ ok: true, invitation_id: invitation?.id });
   } catch (err: any) {
@@ -379,10 +338,7 @@ router.post('/:id/invite', async (req: Request, res: Response) => {
 
 // ── POST /:id/repair — Re-run provisioning for stuck users ──
 
-router.post('/:id/repair', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
+router.post('/:id/repair', requireExafyAdmin, async (req: AuthenticatedRequest, res: Response) => {
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 
@@ -464,7 +420,7 @@ router.post('/:id/repair', async (req: Request, res: Response) => {
       .update({ status: 'onboarded', completed_at: new Date().toISOString() })
       .eq('id', id);
 
-    console.log(`[${VTID}] Repaired provisioning for ${attempt.email} by ${authResult.email}`);
+    console.log(`[${VTID}] Repaired provisioning for ${attempt.email} by ${req.identity!.email || 'unknown'}`);
 
     return res.json({ ok: true, message: 'User provisioning repaired', repaired: true });
   } catch (err: any) {
@@ -475,10 +431,7 @@ router.post('/:id/repair', async (req: Request, res: Response) => {
 
 // ── GET /invitations — List sent invitations ────────────────
 
-router.get('/invitations', async (req: Request, res: Response) => {
-  const authResult = await verifyExafyAdmin(req);
-  if (!authResult.ok) return res.status(authResult.status).json({ ok: false, error: authResult.error });
-
+router.get('/invitations', requireExafyAdmin, async (req: AuthenticatedRequest, res: Response) => {
   const supabase = getSupabase();
   if (!supabase) return res.status(500).json({ ok: false, error: 'SUPABASE_UNAVAILABLE' });
 

--- a/services/gateway/test/routes/admin-signups.test.ts
+++ b/services/gateway/test/routes/admin-signups.test.ts
@@ -1,0 +1,128 @@
+import request from 'supertest';
+import express from 'express';
+import router from '../../src/routes/admin-signups';
+import { getSupabase } from '../../src/lib/supabase';
+import { requireExafyAdmin } from '../../src/middleware/auth-supabase-jwt';
+
+// Mock Dependencies
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: jest.fn(),
+}));
+
+jest.mock('../../src/middleware/auth-supabase-jwt', () => ({
+  requireExafyAdmin: jest.fn((req, res, next) => {
+    if (req.headers.authorization === 'Bearer valid-admin-token') {
+      req.identity = { user_id: 'admin-123', email: 'admin@example.com', exafy_admin: true };
+      return next();
+    }
+    return res.status(403).json({ ok: false, error: 'FORBIDDEN' });
+  }),
+}));
+
+jest.mock('../../src/services/notification-service', () => ({
+  notifyUserAsync: jest.fn(),
+}));
+
+jest.mock('../../src/services/automation-executor', () => ({
+  dispatchEvent: jest.fn().mockResolvedValue(true),
+}));
+
+// Provide a flexible fluent mock for Supabase query chaining
+const createMockQuery = () => {
+  const q: any = {};
+  q.eq = jest.fn(() => q);
+  q.or = jest.fn(() => q);
+  q.ilike = jest.fn(() => q);
+  q.order = jest.fn(() => q);
+  q.range = jest.fn(() => q);
+  q.select = jest.fn(() => q);
+  q.insert = jest.fn(() => q);
+  q.update = jest.fn(() => q);
+  q.gte = jest.fn(() => q);
+  q.single = jest.fn().mockResolvedValue({ 
+    data: { id: 'mock-id', tenant_id: 't-1', email: 'test@example.com' }, 
+    error: null 
+  });
+  q.maybeSingle = jest.fn().mockResolvedValue({ data: null, error: null });
+  q.then = jest.fn((resolve) => resolve({ data: [], error: null, count: 0 }));
+  return q;
+};
+
+// Mount the app
+const app = express();
+app.use(express.json());
+app.use('/admin-signups', router);
+
+describe('Admin Signups Router', () => {
+  beforeEach(() => {
+    jest.clearAllMocks();
+    (getSupabase as jest.Mock).mockReturnValue({
+      from: jest.fn(() => createMockQuery()),
+      auth: {
+        admin: {
+          getUserById: jest.fn().mockResolvedValue({ data: { user: { email: 'auth@example.com' } } })
+        }
+      }
+    });
+  });
+
+  describe('Protected Routes', () => {
+    it('should reject unauthenticated access to /', async () => {
+      const res = await request(app).get('/admin-signups/');
+      expect(res.status).toBe(403);
+      expect(requireExafyAdmin).toHaveBeenCalled();
+    });
+
+    it('should reject unauthenticated access to /stats', async () => {
+      const res = await request(app).get('/admin-signups/stats');
+      expect(res.status).toBe(403);
+      expect(requireExafyAdmin).toHaveBeenCalled();
+    });
+
+    it('should reject unauthenticated access to /attempts', async () => {
+      const res = await request(app).get('/admin-signups/attempts');
+      expect(res.status).toBe(403);
+      expect(requireExafyAdmin).toHaveBeenCalled();
+    });
+
+    it('should allow authenticated access to /stats', async () => {
+      const res = await request(app)
+        .get('/admin-signups/stats')
+        .set('Authorization', 'Bearer valid-admin-token');
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(requireExafyAdmin).toHaveBeenCalled();
+    });
+
+    it('should allow authenticated access to /invitations', async () => {
+      const res = await request(app)
+        .get('/admin-signups/invitations')
+        .set('Authorization', 'Bearer valid-admin-token');
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+      expect(requireExafyAdmin).toHaveBeenCalled();
+    });
+  });
+
+  describe('Public Routes', () => {
+    it('should allow POST /log-attempt without authentication', async () => {
+      const res = await request(app)
+        .post('/admin-signups/log-attempt')
+        .send({ email: 'newuser@example.com', tenant_id: 't-1' });
+
+      expect(requireExafyAdmin).not.toHaveBeenCalled();
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+    });
+
+    it('should allow POST /log-result without authentication', async () => {
+      const res = await request(app)
+        .post('/admin-signups/log-result')
+        .send({ attempt_id: 'att-123', status: 'started' });
+
+      expect(requireExafyAdmin).not.toHaveBeenCalled();
+      expect(res.status).toBe(200);
+      expect(res.body.ok).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
This PR replaces the custom `verifyExafyAdmin` inline authentication logic in `admin-signups.ts` with the platform's standard `requireExafyAdmin` middleware. 

Additionally, it explicitly marks the intentional public tracking endpoints (`/log-attempt` and `/log-result`) with `// public-route` comments to clear warnings from the `route-auth-scanner-v1` security rule.

A new unit test suite has been added to verify that protected administrative routes successfully block unauthenticated access, while public routes remain openly accessible.

Files touched:
- `services/gateway/src/routes/admin-signups.ts` (Modified)
- `services/gateway/test/routes/admin-signups.test.ts` (Created)