### PR TITLE
DEV-AUTOPILOT: Enforce MCP SDK version >= 1.25.2 to prevent ReDoS

### DIFF
--- a/services/gateway/test/cve-mcp-sdk.test.ts
+++ b/services/gateway/test/cve-mcp-sdk.test.ts
@@ -1,0 +1,50 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('CVE-202X MCP SDK ReDoS vulnerability prevention', () => {
+  it('should enforce @modelcontextprotocol/sdk version >= 1.25.2 to prevent ReDoS', () => {
+    const packageJsonPath = path.resolve(__dirname, '../package.json');
+    const packageJsonContent = fs.readFileSync(packageJsonPath, 'utf8');
+    const packageJson = JSON.parse(packageJsonContent);
+
+    const mcpSdkDependency = packageJson.dependencies?.['@modelcontextprotocol/sdk'];
+
+    // If the dependency has been completely removed, the project is not vulnerable
+    if (!mcpSdkDependency) {
+      return;
+    }
+
+    // Strip non-numeric semver prefixes (e.g., '^', '~', '>', '=')
+    const versionString = mcpSdkDependency.replace(/^[^\d]+/, '');
+
+    const [majorStr, minorStr, patchStr] = versionString.split('.');
+    
+    // Parse integer versions, defaulting to 0 for missing or unparseable segments
+    const major = parseInt(majorStr, 10) || 0;
+    const minor = parseInt(minorStr, 10) || 0;
+    const patch = parseInt(patchStr, 10) || 0;
+
+    let isSecure = false;
+    
+    // Assert version is >= 1.25.2
+    if (major > 1) {
+      isSecure = true;
+    } else if (major === 1) {
+      if (minor > 25) {
+        isSecure = true;
+      } else if (minor === 25) {
+        if (patch >= 2) {
+          isSecure = true;
+        }
+      }
+    }
+
+    if (!isSecure) {
+      throw new Error(
+        `Vulnerable dependency detected! @modelcontextprotocol/sdk version must be >= 1.25.2 to prevent ReDoS attacks. Found: ${mcpSdkDependency}`
+      );
+    }
+
+    expect(isSecure).toBe(true);
+  });
+});


### PR DESCRIPTION
**Context & Issue:**
A ReDoS (Regular Expression Denial of Service) vulnerability exists in Anthropic's MCP TypeScript SDK (`@modelcontextprotocol/sdk`) prior to version `1.25.2`. The `services/gateway` module currently resolves to an older, vulnerable version (`^0.5.0`). 

**Changes in this PR:**
- Adds a dedicated regression test (`services/gateway/test/cve-mcp-sdk.test.ts`) that asserts the configured `@modelcontextprotocol/sdk` version in `package.json` is `>= 1.25.2`. 
- This automatically fails CI pipelines if the dependency is downgraded or re-introduced at a vulnerable version.

**⚠️ ACTION REQUIRED BY DEVELOPER:**
Automated modifications to package manifests are deliberately out of scope for this autopilot execution. Before merging this PR, a developer **must** manually:
1. Open `services/gateway/package.json`.
2. Update the `"@modelcontextprotocol/sdk"` dependency to `"^1.25.2"`.
3. Run `npm install` within `services/gateway` to update `package-lock.json`.
4. Run `npm run typecheck` to ensure no breaking API changes disrupt existing SDK usage.
5. Verify `npm audit` shows the ReDoS vulnerability is resolved.