### PR TITLE
feat(cognee): add DeepSeek-V3 mode for cost-optimized entity extraction (BOOTSTRAP-COGNEE-DS)

### DIFF
--- a/services/agents/cognee-extractor/main.py
+++ b/services/agents/cognee-extractor/main.py
@@ -54,12 +54,34 @@ logger = logging.getLogger('cognee-extractor')
 # Configuration
 # =============================================================================
 
-# LLM Configuration - Uses Gemini API (same key as ORB)
-# Cognee requires API key authentication for Gemini
+# LLM Configuration
+#
+# Default: Gemini (legacy). Operators can flip to DeepSeek-V3 for cost savings
+# (~50x cheaper per token for entity extraction) by setting Cloud Run env vars:
+#   LLM_PROVIDER=deepseek
+#   LLM_MODEL=deepseek-chat        # V3, cheap; or deepseek-reasoner for R1
+#   DEEPSEEK_API_KEY=<key>
+# When LLM_PROVIDER=deepseek, the lifespan handler maps these to litellm's
+# OpenAI-compatible adapter targeting https://api.deepseek.com.
 LLM_PROVIDER = os.getenv('LLM_PROVIDER', 'gemini')
 LLM_MODEL = os.getenv('LLM_MODEL', 'gemini/gemini-3.1-pro-preview')
 LLM_API_KEY = os.getenv('GOOGLE_GEMINI_API_KEY') or os.getenv('LLM_API_KEY')
 LLM_ENDPOINT = os.getenv('LLM_ENDPOINT', 'https://generativelanguage.googleapis.com/')
+
+# DeepSeek mode: when LLM_PROVIDER=deepseek, override LLM_API_KEY/LLM_ENDPOINT
+# to point at the DeepSeek OpenAI-compatible API. This lets the operator flip
+# providers via env vars alone — no code redeploy.
+if LLM_PROVIDER.lower() == 'deepseek':
+    _deepseek_key = os.getenv('DEEPSEEK_API_KEY')
+    if _deepseek_key:
+        LLM_API_KEY = _deepseek_key
+        LLM_ENDPOINT = os.getenv('LLM_ENDPOINT', 'https://api.deepseek.com')
+        # litellm understands openai/<model> with a custom base_url for OpenAI-
+        # compatible providers like DeepSeek. Default to deepseek-chat (V3).
+        if not LLM_MODEL.startswith('openai/') and not LLM_MODEL.startswith('deepseek/'):
+            LLM_MODEL = f'openai/{LLM_MODEL}' if LLM_MODEL else 'openai/deepseek-chat'
+        # Tell litellm to treat this as openai-compatible
+        LLM_PROVIDER = 'openai'
 
 # Google Cloud project (for reference)
 GCP_PROJECT = os.getenv('GOOGLE_CLOUD_PROJECT') or os.getenv('GCP_PROJECT') or 'lovable-vitana-vers1'

--- a/services/agents/cognee-extractor/service.yaml
+++ b/services/agents/cognee-extractor/service.yaml
@@ -76,6 +76,24 @@ spec:
             - name: VERTEX_LOCATION
               value: "us-central1"
 
+            # ─── DeepSeek-V3 swap (opt-in cost optimization) ─────────────────
+            # main.py detects LLM_PROVIDER=deepseek and routes through litellm's
+            # OpenAI-compatible adapter at https://api.deepseek.com. To flip:
+            #
+            #   - name: LLM_PROVIDER
+            #     value: "deepseek"
+            #   - name: LLM_MODEL
+            #     value: "deepseek-chat"        # V3 chat (fastest/cheapest)
+            #     # OR "deepseek-reasoner"      # R1 (deeper reasoning)
+            #   - name: DEEPSEEK_API_KEY
+            #     valueFrom:
+            #       secretKeyRef:
+            #         name: deepseek-api-key
+            #         key: latest
+            #
+            # Remove GOOGLE_CLOUD_PROJECT/VERTEX_LOCATION when on DeepSeek.
+            # ────────────────────────────────────────────────────────────────
+
             # Service configuration
             - name: ENV
               value: "production"


### PR DESCRIPTION
## Summary

Cognee Extractor handles every voice transcript and is high-volume; entity extraction is a structured-output task where DeepSeek-V3 reaches comparable quality to Gemini Pro at ~50x lower per-token cost. Litellm (under cognee) already supports OpenAI-compatible providers, so this is an env-var swap with a small adapter shim — no SDK or framework change.

Part of the broader DeepSeek wiring effort. Companion to PR #1853 (registry truth), PR #1855 (heartbeat fix), PR #1891 (conductor DeepSeek adapter).

## Changes

- main.py: when LLM_PROVIDER=deepseek is set, configuration maps to litellm's OpenAI-compatible adapter (LLM_PROVIDER=openai, LLM_ENDPOINT=https://api.deepseek.com, LLM_API_KEY=DEEPSEEK_API_KEY, LLM_MODEL=openai/<model>). Defaults stay Gemini — operators flip via Cloud Run env when ready.
- service.yaml: documents the DeepSeek env block with a secret reference for DEEPSEEK_API_KEY. Defaults unchanged.

## Behavior change

No provider priority change in code. Defaults remain Gemini. Operators consciously flip Cloud Run env to LLM_PROVIDER=deepseek + LLM_MODEL=deepseek-chat + DEEPSEEK_API_KEY when ready.

## Test plan

- [x] main.py compiles cleanly (verified with py_compile)
- [ ] After deploy: confirm cognee-extractor still runs on Gemini default
- [ ] Operator: gcloud run services update cognee-extractor with new env vars
- [ ] After flip: trigger a voice session, watch cognee logs for 'provider=openai, endpoint=api.deepseek.com'
- [ ] Compare extracted entities for same transcript on Gemini vs DeepSeek
- [ ] Confirm cost telemetry in OASIS shows DeepSeek pricing

🤖 Generated with [Claude Code](https://claude.com/claude-code)