### PR TITLE
DEV-AUTOPILOT: Add regression test for MCP SDK ReDoS CVE

### DIFF
--- a/services/gateway/test/cve-mcp-sdk.test.ts
+++ b/services/gateway/test/cve-mcp-sdk.test.ts
@@ -1,0 +1,41 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('CVE Regression Test: MCP SDK ReDoS', () => {
+  it('requires @modelcontextprotocol/sdk version to be >= 1.25.2', () => {
+    const pkgPath = path.resolve(__dirname, '../package.json');
+    const pkgContent = fs.readFileSync(pkgPath, 'utf8');
+    const pkg = JSON.parse(pkgContent);
+
+    const dependencies = pkg.dependencies || {};
+    const versionString = dependencies['@modelcontextprotocol/sdk'];
+
+    // If the dependency has been removed entirely, we are safe.
+    if (!versionString) {
+      expect(versionString).toBeUndefined();
+      return;
+    }
+
+    // Strip semver prefixes like ^, ~, >=
+    const cleanVersion = versionString.replace(/^[^\d]+/, '');
+    const parts = cleanVersion.split('.');
+    
+    const major = parseInt(parts[0] || '0', 10);
+    const minor = parseInt(parts[1] || '0', 10);
+    const patch = parseInt(parts[2] || '0', 10);
+
+    const isSafe =
+      major > 1 ||
+      (major === 1 && minor > 25) ||
+      (major === 1 && minor === 25 && patch >= 2);
+
+    if (!isSafe) {
+      throw new Error(
+        `Vulnerable @modelcontextprotocol/sdk version found: ${versionString}. ` +
+        `Must be >= 1.25.2 to prevent ReDoS vulnerability.`
+      );
+    }
+
+    expect(isSafe).toBe(true);
+  });
+});


### PR DESCRIPTION
**Context**
A ReDoS (Regular Expression Denial of Service) vulnerability was identified in Anthropic's MCP TypeScript SDK (`@modelcontextprotocol/sdk`) for versions prior to 1.25.2. The gateway currently relies on version `^0.5.0`. 

**What this PR does**
This PR introduces a regression test that checks `services/gateway/package.json` to ensure the version of `@modelcontextprotocol/sdk` is strictly `>= 1.25.2`. 

**Developer Action Required**
Modifying `package.json` and `package-lock.json` directly is outside the automated executor's allow-scope. To get this CI test to pass, a human developer must manually:
1. Update `"@modelcontextprotocol/sdk": "^1.25.2"` in `services/gateway/package.json`.
2. Run `npm install` in `services/gateway` to update the lockfile.
3. Run `npm run typecheck` to ensure there are no breaking changes with the newly bumped SDK.