### PR TITLE
DEV-AUTOPILOT: Add regression test for MCP SDK ReDoS vulnerability

### DIFF
--- a/services/gateway/test/cve-mcp-sdk.test.ts
+++ b/services/gateway/test/cve-mcp-sdk.test.ts
@@ -1,0 +1,38 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('CVE Regression: MCP SDK ReDoS Vulnerability', () => {
+  it('must use @modelcontextprotocol/sdk version 1.25.2 or higher to prevent ReDoS', () => {
+    const packageJsonPath = path.resolve(__dirname, '../package.json');
+    const packageJsonContent = fs.readFileSync(packageJsonPath, 'utf8');
+    const packageJson = JSON.parse(packageJsonContent);
+
+    const mcpVersionStr = packageJson.dependencies?.['@modelcontextprotocol/sdk'];
+
+    // Ensure the dependency exists in the production dependencies list
+    expect(mcpVersionStr).toBeDefined();
+
+    // Strip non-numeric semver prefixes (e.g., '^', '~', '>=')
+    const cleanVersion = mcpVersionStr.replace(/^[^\d]+/, '');
+    const [majorStr, minorStr, patchStr] = cleanVersion.split('.');
+
+    const major = parseInt(majorStr, 10) || 0;
+    const minor = parseInt(minorStr, 10) || 0;
+    const patch = parseInt(patchStr, 10) || 0;
+
+    // Verify version >= 1.25.2
+    const isSecure =
+      major > 1 ||
+      (major === 1 && minor > 25) ||
+      (major === 1 && minor === 25 && patch >= 2);
+
+    if (!isSecure) {
+      throw new Error(
+        `Vulnerable @modelcontextprotocol/sdk version detected: ${mcpVersionStr}. ` +
+        `Must be >= 1.25.2 to prevent ReDoS attacks. Please update package.json.`
+      );
+    }
+
+    expect(isSecure).toBe(true);
+  });
+});


### PR DESCRIPTION
**Context**
A ReDoS (Regular Expression Denial of Service) vulnerability was identified in Anthropic's MCP TypeScript SDK (`@modelcontextprotocol/sdk`) for versions prior to `1.25.2`. This PR introduces a regression test that parses `package.json` to enforce that the `@modelcontextprotocol/sdk` dependency is safely maintained at version `>= 1.25.2`.

**Files touched**
- `services/gateway/test/cve-mcp-sdk.test.ts` (New file)

**⚠️ Developer Action Required ⚠️**
Automated package manifest updates are currently out of scope for the dev autopilot. To make this CI test pass and resolve the vulnerability, you must manually perform the following:
1. Update `services/gateway/package.json`: bump `"@modelcontextprotocol/sdk"` to `"^1.25.2"` (or higher).
2. Run `npm install` inside the `services/gateway` directory to update `package-lock.json`.
3. Verify that `npm run typecheck` and `npm audit` succeed.