### PR TITLE
fix(orb-live): stop Gemini saying 'I had a problem' after a successful post (VTID-02790)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -3202,6 +3202,16 @@ function buildLiveApiTools(
             '',
             'NEVER repeat-post the same generic ask. If the user repeats verbatim, treat it as "show me my',
             'existing post" — call list_my_intents and surface what they already have.',
+            '',
+            'SUCCESS CONTRACT (VTID-02790, mandatory):',
+            'When the response contains stage:"posted" — regardless of match_count, cold_start, or any',
+            'other field — the post is LIVE in the database. You MUST confirm success.',
+            '- NEVER say "I had a problem", "there was an issue", "I couldn\'t post", "etwas ging schief",',
+            '  "es gab ein Problem", "ich konnte den Beitrag nicht erstellen", or any apologetic phrase.',
+            '- For match_count > 0: announce the post is live and that there are N potential matches.',
+            '- For match_count = 0 (cold_start): use the "you\'re the first" copy above.',
+            '- If the user later doubts ("did it really post?"), call list_my_intents and SHOW them.',
+            'Do NOT invent failure modes. Do NOT apologize when the server reported success.',
           ].join('\n'),
           parameters: {
             type: 'object',
@@ -6959,7 +6969,9 @@ async function executeLiveApiToolInner(
           };
         } catch (err: any) {
           console.error('[VTID-01975] post_intent error:', err?.message);
-          // VTID-02716: if the row was already inserted, never tell the user it failed.
+          // VTID-02716 + VTID-02790: if the row was already inserted, return a normal
+          // success shape — Gemini misreads any "degraded"/"partial" hint as failure
+          // and apologizes to the user, even though the post is live.
           if (postedIntentId) {
             console.warn(`[VTID-02716] post_intent post-insert throw recovered; intent_id=${postedIntentId}`);
             return {
@@ -6975,7 +6987,6 @@ async function executeLiveApiToolInner(
                 compass_aligned: false,
                 partner_seek_redacted: postedKind === 'partner_seek',
                 cold_start: true,
-                degraded: true,
               }),
             };
           }


### PR DESCRIPTION
## Why
After [#1666](https://github.com/exafyltd/vitana-platform/pull/1666) (VTID-02716) the `post_intent` handler always returns `success: true` once the row is in `user_intents`. Yet the user still hears Vitana say "there was an issue, I couldn't make the post" — even though the post is in their list.

Investigation: the gateway is doing the right thing. **Gemini is** the one paraphrasing it as a failure, for two reasons:

1. The VTID-02716 recovery branch returned `degraded: true` alongside `stage: 'posted'`. Gemini reads `degraded` as "partial failure" and apologizes regardless of `ok:true`.
2. The tool description has explicit copy for the cold-start (match_count=0) case but **no explicit ban on apologetic phrases when ok:true**. Without the ban, Gemini freelances.

## Fix
- Drop `degraded: true` from the recovery response. Log the recovery via `console.warn` for telemetry but don't expose it to the model.
- Add a SUCCESS CONTRACT block to the `post_intent` tool description, banning phrases like "I had a problem", "I couldn't post", "es gab ein Problem", "ich konnte den Beitrag nicht erstellen" whenever `stage: 'posted'` is in the response.

## Files
- `services/gateway/src/routes/orb-live.ts` (tool description + recovery branch)

## Test plan
- [ ] Mobile: voice-create a Find-a-Match post ("Ich suche jemanden, der mit mir Tennis spielt in Köln"). Confirm with "ja". Vitana must announce success — never apologize.
- [ ] Confirm the post appears in /intents/mine.
- [ ] If anything in Cloud Run logs shows `[VTID-02716] post_intent post-insert throw recovered`, the user should still have heard a clean cold-start readback.

🤖 Generated with [Claude Code](https://claude.com/claude-code)