### PR TITLE
chore(command-hub): self-heal old *.run.app URL + bare-host redirect (DEV-COMHU-0501 / BOOTSTRAP-CLOUDFLARE-CMDHUB-REDIRECT)

### DIFF
--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -4,6 +4,24 @@
   <meta charset="UTF-8" />
   <meta name="viewport" content="width=device-width, initial-scale=1.0" />
   <title>Vitana Command Hub</title>
+  <!--
+    BOOTSTRAP-CLOUDFLARE-CMDHUB-REDIRECT: when the Command Hub is loaded
+    from the un-migrated *.a.run.app host, hop to the Cloudflare-fronted
+    domain. The *.run.app host is rate-limited at Google's edge (per-IP
+    GFE), so the Service Health monitor's 54 parallel probes drain the
+    bucket within a second and panels show red even when every backend
+    is healthy. Run synchronously in <head> before any JS/CSS so the user
+    lands on the right host before the panel-init storm starts.
+  -->
+  <script>
+    (function () {
+      try {
+        if (location.hostname === 'gateway-q74ibpv6ia-uc.a.run.app') {
+          location.replace('https://gateway.vitanaland.com' + location.pathname + location.search + location.hash);
+        }
+      } catch (e) { /* never block on a redirect failure */ }
+    })();
+  </script>
   <link rel="stylesheet" href="/command-hub/styles.css?v=20260424-dev-comhu-0411-docs-screens-num" />
 </head>
 <body>

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -1050,6 +1050,11 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
     }
   }));
 
+  // BOOTSTRAP-CLOUDFLARE-CMDHUB-REDIRECT: bare-host hit lands on the Hub.
+  // Operators type just `gateway.vitanaland.com` and get the Command Hub
+  // instead of `Cannot GET /`. Path-only redirect — no domain hardcoded.
+  app.get('/', (_req, res) => res.redirect(302, '/command-hub/'));
+
   // Command Hub router handles HTML routes and API (after static files)
   mountRouterSync(app, '/command-hub', commandHubRouter, { owner: 'command-hub-ui' });
 


### PR DESCRIPTION
## Summary

Self-healing redirect for the Command Hub. When loaded from the un-migrated host `gateway-q74ibpv6ia-uc.a.run.app/command-hub/`, hops to `gateway.vitanaland.com/command-hub/` synchronously in <head> before any JS/CSS executes.

## Why

User opened the Command Hub on the old bookmark and hit the GFE per-IP rate limit:
- Service Health monitor fires 54 parallel `/api/v1/health/*` probes
- ~20 of them get HTTP 429 `Rate exceeded.`
- Login screen shows `Unexpected token 'R', "Rate exceeded." is not valid JSON`
- Looks like a backend outage; every backend is actually fine — just sitting behind a saturated bucket.

The Command Hub UI uses relative URLs (`fetch('/api/v1/...')`), so the same code works correctly when served from `gateway.vitanaland.com` (which routes via Cloudflare → Cloud Run domain mapping; no GFE per-IP throttle).

## Fix

5-line synchronous redirect in <head>:
```js
if (location.hostname === 'gateway-q74ibpv6ia-uc.a.run.app') {
  location.replace('https://gateway.vitanaland.com' + location.pathname + ...);
}
```

No effect when loaded from the new host or local dev. Wrapped in try/catch so a freak failure never blocks the page.

## Test plan

- [ ] Merge → EXEC-DEPLOY
- [ ] Hit `gateway-q74ibpv6ia-uc.a.run.app/command-hub/` in browser → should immediately bounce to `gateway.vitanaland.com/command-hub/` with the same path/query preserved
- [ ] Service Health goes 54/54 green (no rate-limit storm on first load)
- [ ] Existing bookmarks at the new domain still work unchanged

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>