### PR TITLE
fix(exec-deploy): use Cloudflare-fronted gateway domain for VTID + governance checks (BOOTSTRAP-CLOUDFLARE-CICD-FIX)

### DIFF
--- a/.github/workflows/EXEC-DEPLOY.yml
+++ b/.github/workflows/EXEC-DEPLOY.yml
@@ -85,11 +85,21 @@ jobs:
 
           echo "Checking if VTID $VTID exists in OASIS ledger..."
 
-          # Resolve gateway URL (current deployed instance)
-          GATEWAY_URL=$(gcloud run services describe gateway \
-            --region=us-central1 \
-            --project=lovable-vitana-vers1 \
-            --format="value(status.url)" 2>/dev/null || echo "")
+          # BOOTSTRAP-CLOUDFLARE-GATEWAY-DOMAIN: Prefer the Cloudflare-fronted
+          # custom domain over the raw *.run.app URL. The raw URL is throttled
+          # at Google's edge (per-IP GFE rate limit) — VTID lookup calls fail
+          # with "Rate exceeded." when the runner's bucket is empty. The
+          # custom domain routes via Cloudflare → Cloud Run domain mapping
+          # with no per-IP ceiling. Fallback to gcloud lookup only if the
+          # custom domain is unreachable.
+          GATEWAY_URL="https://gateway.vitanaland.com"
+          if ! curl -sS -o /dev/null --max-time 5 "$GATEWAY_URL/alive"; then
+            echo "Custom domain unreachable, falling back to gcloud lookup..."
+            GATEWAY_URL=$(gcloud run services describe gateway \
+              --region=us-central1 \
+              --project=lovable-vitana-vers1 \
+              --format="value(status.url)" 2>/dev/null || echo "")
+          fi
 
           if [ -z "$GATEWAY_URL" ]; then
             echo "::error::VTID-0542: HARD FAIL - Could not resolve gateway URL"


### PR DESCRIPTION
## Summary

Hotfix for the catch-22: today's deploy that fixes the GFE rate limit on the Command Hub (PR #1902) can't deploy because EXEC-DEPLOY itself hits the GFE rate limit when calling `gateway-q74ibpv6ia-uc.a.run.app/api/v1/governance/evaluate`.

## Root cause

`EXEC-DEPLOY.yml` resolves the gateway URL via `gcloud run services describe gateway --format='value(status.url)'` which returns the raw `*.run.app` URL. Every CI run uses that URL for the VTID existence check + governance pre-check. The runner's egress IP shares a per-IP bucket with the rest of the world, and we exhausted it with the back-to-back attempts. Response body `Rate exceeded.` isn't valid JSON, so the step aborts with exit code 5.

## Fix

Try `https://gateway.vitanaland.com` first (Cloud Run domain mapping → no GFE per-IP limit), fall back to the gcloud-resolved URL only if that custom domain is unreachable. Governance step inherits the URL from the VTID step's output, so both paths get the new domain transparently with one change.

## Out of scope (deferred)

- Line 369: `GATEWAY_PUBLIC_URL` env var that's set on the gateway service deploy itself. Will flip to the custom domain in a separate PR — not blocking the current deploy.
- Line 402: `GATEWAY_URL` for the cognee-extractor service. Different code path, different scope.

## Test plan

- [ ] Merge → AUTO-DEPLOY dispatches new EXEC-DEPLOY for THIS commit
- [ ] That EXEC-DEPLOY uses gateway.vitanaland.com for governance call → passes
- [ ] Re-run failed EXEC-DEPLOY for PR #1902 (id 25428752082) → also uses new domain → passes
- [ ] Command Hub redirect from old URL goes live

Co-Authored-By: Claude Opus 4.7 (1M context) <noreply@anthropic.com>