### PR TITLE
fix(worker-runner): self-register with truthful provider/model (BOOTSTRAP-WORKER-TRUTH)

### DIFF
--- a/services/worker-runner/src/index.ts
+++ b/services/worker-runner/src/index.ts
@@ -195,19 +195,37 @@ async function main(): Promise<void> {
   console.log(`[${VTID}] Polling for tasks every ${process.env.POLL_INTERVAL_MS || '5000'}ms`);
 
   // Self-register with the agents registry (fire-and-forget, non-blocking)
+  // BOOTSTRAP-WORKER-TRUTH: report what execution-service.ts actually calls
+  // (Anthropic Claude, default claude-opus-4-6) rather than the legacy
+  // Gemini declaration. The hardcoded values were rolling the registry back
+  // to misleading defaults every heartbeat.
   try {
+    const workerLlmModel = process.env.WORKER_LLM_MODEL || 'claude-opus-4-6';
+    const workerLlmProvider: 'claude' | 'gemini' | 'deepseek' | 'unknown' =
+      workerLlmModel.startsWith('claude')
+        ? 'claude'
+        : workerLlmModel.startsWith('gemini')
+        ? 'gemini'
+        : workerLlmModel.startsWith('deepseek')
+        ? 'deepseek'
+        : 'unknown';
+
     stopAgentRegistration = startAgentRegistration({
       gatewayUrl: process.env.GATEWAY_URL || '',
       agentId: 'worker-runner',
       displayName: 'Worker Runner',
-      description: 'Autonomous VTID execution plane (VTID-01200). Polls, claims, executes via LLM, terminalizes.',
+      description: 'Autonomous VTID execution plane (VTID-01200). Polls, claims, executes via Anthropic SDK (default claude-opus-4-6, env-overridable via WORKER_LLM_MODEL). DeepSeek-reasoner fallback engages if primary fails.',
       tier: 'service',
       role: 'executor',
-      llmProvider: 'gemini',
-      llmModel: process.env.VERTEX_MODEL || 'gemini-3.1-pro-preview',
+      llmProvider: workerLlmProvider,
+      llmModel: workerLlmModel,
       sourcePath: 'services/worker-runner/',
       healthEndpoint: '/alive',
-      metadata: { vtid: VTID },
+      metadata: {
+        vtid: VTID,
+        fallback_model: process.env.WORKER_FALLBACK_MODEL || 'deepseek-reasoner',
+        fallback_enabled: process.env.WORKER_DEEPSEEK_FALLBACK !== 'false',
+      },
     });
   } catch (err) {
     console.warn(`[${VTID}] Agents registry self-registration failed (non-fatal):`, err);

--- a/services/worker-runner/src/lib/agents-registry-client.ts
+++ b/services/worker-runner/src/lib/agents-registry-client.ts
@@ -14,7 +14,17 @@
 import fetch from 'node-fetch';
 
 export type AgentTier = 'service' | 'embedded' | 'scheduled';
-export type AgentProvider = 'claude' | 'gemini' | 'conductor' | 'none' | 'unknown';
+// BOOTSTRAP-WORKER-TRUTH: extended to match the DB constraint after
+// 20260510000200_BOOTSTRAP_agents_provider_check_extend.sql.
+export type AgentProvider =
+  | 'claude'
+  | 'gemini'
+  | 'conductor'
+  | 'deepseek'
+  | 'openai'
+  | 'embedded'
+  | 'none'
+  | 'unknown';
 export type AgentStatus = 'healthy' | 'degraded' | 'down' | 'unknown';
 
 export interface AgentRegistrationConfig {


### PR DESCRIPTION
Followup fix to stop the registry-truth migration from being silently reverted on every worker heartbeat. index.ts hardcoded llmProvider='gemini' which overwrote my migration each minute. Now derives provider/model from WORKER_LLM_MODEL env (same env var the execution path uses post-#1899). Default is claude-opus-4-6/claude — matching reality.

🤖 Generated with [Claude Code](https://claude.com/claude-code)