### PR TITLE
fix(orb-agent): read user identity from PARTICIPANT metadata, not ROOM metadata

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/identity.py
+++ b/services/agents/orb-agent/src/orb_agent/identity.py
@@ -33,12 +33,15 @@ def resolve_identity_from_room_metadata(
     *,
     user_jwt: str | None = None,
 ) -> Identity:
-    """Resolve identity from LiveKit room metadata + optional decoded JWT.
+    """Resolve identity from LiveKit user-participant metadata + optional decoded JWT.
 
-    Room metadata is set by the gateway's /api/v1/orb/livekit/token endpoint,
-    which already coerces role for mobile/WebView clients. The agent never
-    re-decodes the JWT for auth (gateway is the auth source of truth) — but
-    we DO re-check the mobile coercion here as defense-in-depth.
+    The metadata dict is parsed from the user's *participant* metadata (set
+    via the LiveKit AccessToken's `metadata` field by the gateway's
+    /api/v1/orb/livekit/token endpoint). The function name still says
+    "room_metadata" for backwards-compat with callers — the schema is
+    identical (user_id/tenant_id/role/lang/vitana_id/is_mobile/is_anonymous).
+    The gateway already coerces role for mobile/WebView clients; we re-check
+    the mobile coercion here as defense-in-depth.
     """
     user_id = str(metadata.get("user_id", "anon"))
     tenant_id = str(metadata.get("tenant_id", ""))

--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -65,7 +65,7 @@ except ImportError:
     LK_AVAILABLE = False
 
 
-CODE_VERSION = "agent-2026-05-05-no-logout-fix"
+CODE_VERSION = "agent-2026-05-06-participant-metadata-fix"
 
 
 async def _early_trace_heartbeat(gateway_url: str, payload: dict) -> None:
@@ -127,12 +127,42 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     # publisher.
     await ctx.connect()
 
-    # Read room metadata: the gateway's /orb/livekit/token endpoint
-    # embeds resolved identity here.
-    metadata_str = ctx.room.metadata or ""
+    # ── Identity metadata lives on the USER PARTICIPANT, not the room. ──
+    # The gateway's /api/v1/orb/livekit/token mints a LiveKit AccessToken
+    # with `metadata: JSON.stringify({user_id, tenant_id, vitana_id,
+    # user_jwt, ...})`. AccessToken metadata becomes the *participant's*
+    # metadata at join time. `ctx.room.metadata` is room-level metadata
+    # (a separate, server-side field set via LiveKit Server API), which
+    # the gateway does NOT write — it has always been empty, which is why
+    # every session was resolving to user_id="anon" before this fix.
+    #
+    # Strategy: try participants already in the room first (the user
+    # typically joins before the agent dispatch), then fall back to
+    # waiting for the next participant join.
+    metadata_str = ""
+    user_participant = None
+    for p in ctx.room.remote_participants.values():
+        if p.metadata:
+            user_participant = p
+            metadata_str = p.metadata
+            logger.info("agent_entrypoint: read metadata from already-joined participant %s", p.identity)
+            break
+
+    if not metadata_str:
+        try:
+            user_participant = await asyncio.wait_for(ctx.wait_for_participant(), timeout=10.0)
+            metadata_str = user_participant.metadata or ""
+            logger.info("agent_entrypoint: waited for participant %s, metadata_len=%d",
+                        user_participant.identity, len(metadata_str))
+        except asyncio.TimeoutError:
+            logger.warning("agent_entrypoint: no participant joined within 10s — anonymous fallback")
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("agent_entrypoint: wait_for_participant failed: %s", exc)
+
     try:
         metadata = json.loads(metadata_str) if metadata_str else {}
     except (json.JSONDecodeError, TypeError):
+        logger.warning("agent_entrypoint: participant metadata is not valid JSON: %r", metadata_str[:200])
         metadata = {}
 
     # VTID-LIVEKIT-AGENT-JWT: the gateway's /orb/livekit/token endpoint


### PR DESCRIPTION
## Root cause

The gateway's /api/v1/orb/livekit/token endpoint embeds the user's identity (user_id, tenant_id, vitana_id, user_jwt, is_anonymous, ...) by setting the metadata field on the LiveKit AccessToken. That becomes **participant metadata** at join time — accessed via participant.metadata on whichever RemoteParticipant is the user.

The agent was reading ctx.room.metadata, which is a *room-level* field set via the LiveKit Server API. The gateway never wrote room metadata, so it was always empty — every session resolved to user_id="anon", ran the anonymous bootstrap (bootstrap_context_length=30), and the LLM correctly told the user "you are not signed in" because the system prompt told it so.

This was hidden because the user-side LiveKit JWT round-trip worked (token decoded fine; metadata was correct), and network-level diagnostics showed all 40 tools authorized correctly with the agent JWT — but the agent's first action (building the system prompt) used the empty room metadata.

## Fix

After ctx.connect():

1. Iterate ctx.room.remote_participants and pick the first participant carrying metadata (the user typically joins before agent dispatch).
2. If none yet, await ctx.wait_for_participant() with a 10s timeout.
3. Anonymous fallback preserved when no metadata arrives.

Also bumps CODE_VERSION so the /api/v1/orb/agent-trace/recent debug firehose distinguishes pre-fix vs post-fix sessions on deploy.

## Verification

After merge, DEPLOY-ORB-AGENT auto-runs (path matches services/agents/orb-agent/) and the new revision-cleanup step deletes zombie revisions. Then /tmp/test_agent_trace.py should show user_id=a27552a3-..., vitana_id=e2etest33, bootstrap_context_length >> 30, tools_handle_in_first_chars=true.

🤖 Generated with Claude Code