### PR TITLE
feat(intents): realistic, gender-matched, multi-activity match cover prompts

### DIFF
--- a/services/gateway/src/services/intent-cover-service.ts
+++ b/services/gateway/src/services/intent-cover-service.ts
@@ -31,7 +31,19 @@ import path from 'node:path';
 import { promises as fs } from 'node:fs';
 import { createHash } from 'node:crypto';
 
-export type CoverTheme = 'dance' | 'fitness' | 'generic';
+export type CoverTheme =
+  | 'dance'
+  | 'fitness'
+  | 'walking'
+  | 'tennis'
+  | 'soccer'
+  | 'basketball'
+  | 'biking'
+  | 'cooking'
+  | 'panel'
+  | 'generic';
+
+export type Gender = 'male' | 'female' | null;
 
 export type CoverSource = 'user_upload' | 'ai_generated' | 'fallback_curated';
 
@@ -39,6 +51,11 @@ export interface GenerateCoverArgs {
   intentId: string;
   userId: string;
   theme: CoverTheme;
+  /**
+   * Foreground subject gender. When omitted we look it up from
+   * `profiles.gender` so the centered person matches the requesting user.
+   */
+  gender?: Gender;
   /** When true, bypass the cache and produce a fresh image. */
   force?: boolean;
 }
@@ -93,29 +110,113 @@ function getGoogleAuth(): GoogleAuth {
   return googleAuth;
 }
 
-const PROMPTS: Record<CoverTheme, string> = {
-  // Hero composition: a single smiling adult (man or woman) in
-  // sharp focus in the foreground, with a softly blurred group of
-  // dance / fitness participants behind them. Mirrors the look of
-  // the reference cover the user shared.
-  dance:
-    'A photorealistic, vibrant landscape photograph of one smiling adult — a man or a woman, ' +
-    'mid-twenties to late-thirties — facing the camera in the foreground in sharp focus, with ' +
-    'a softly blurred group of fellow dancers practising partner dance behind them in a sunlit ' +
-    'modern dance studio with wooden floors and mirrors. Warm natural light, documentary ' +
-    'photography style, wide 16:9 composition. Friendly, welcoming mood. No text, no logos.',
-  fitness:
-    'A photorealistic, vibrant landscape photograph of one smiling adult — a man or a woman, ' +
-    'mid-twenties to late-thirties — facing the camera in the foreground in sharp focus, with ' +
-    'a softly blurred group of fellow gym-goers stretching, training, or doing a class behind ' +
-    'them in a bright modern gym with natural light through tall windows. Documentary ' +
-    'photography style, wide 16:9 composition. Friendly, welcoming mood. No text, no logos.',
-  generic:
-    'A photorealistic, warm landscape photograph of one smiling adult — a man or a woman, ' +
-    'mid-twenties to late-thirties — in sharp focus in the foreground, with a softly blurred ' +
-    'group of friendly community members behind them in a sunlit cafe, park, or studio. ' +
-    'Candid documentary photography style, wide 16:9 composition. No text, no logos.',
+// Per-theme scene primitives. The full prompt is built at request time so
+// we can splice the requesting user's gender into the foreground subject.
+// Goal: realistic, location-appropriate photos with one smiling person of
+// the user's gender up front and a mixed group blurred behind them.
+const THEME_SCENES: Record<
+  CoverTheme,
+  { subject: string; location: string; group: string }
+> = {
+  dance: {
+    subject: 'mid-step in a confident social-dance pose',
+    location:
+      'a sunlit modern dance studio with wooden floors and tall mirrors',
+    group: 'practising partner-dance steps in pairs',
+  },
+  fitness: {
+    subject: 'standing relaxed in athletic wear after a workout',
+    location:
+      'a bright modern gym with natural daylight through tall windows',
+    group: 'stretching, lifting, or finishing a group class',
+  },
+  walking: {
+    subject: 'walking confidently along a tree-lined park path',
+    location: 'a leafy urban park on a clear morning',
+    group:
+      'walking and chatting in pairs along the same path, some with small day-packs',
+  },
+  tennis: {
+    subject:
+      'holding a tennis racket on the baseline in athletic kit',
+    location:
+      'an outdoor clay tennis court on a sunny afternoon',
+    group:
+      'rallying on the next court and chatting on a sideline bench',
+  },
+  soccer: {
+    subject: 'in a football kit, foot resting on a soccer ball',
+    location:
+      'a green grass football pitch at golden hour',
+    group: 'playing a friendly five-a-side match',
+  },
+  basketball: {
+    subject: 'holding a basketball at chest height in a relaxed stance',
+    location:
+      'an outdoor street basketball court in a sunlit city neighbourhood',
+    group: 'shooting hoops and high-fiving each other',
+  },
+  biking: {
+    subject:
+      'standing next to a road bike in cycling gear, helmet in hand',
+    location:
+      'a coastal cycle path with the sea behind and a clear sky',
+    group: 'riding road bikes in a relaxed group along the path',
+  },
+  cooking: {
+    subject:
+      'wearing a clean apron at a kitchen counter, smiling at the camera',
+    location:
+      'a bright communal cooking-school kitchen with natural wood, hanging pans, and big windows',
+    group: 'chopping vegetables and laughing around a long shared counter',
+  },
+  panel: {
+    subject:
+      'seated, microphone in hand, smiling warmly at the camera',
+    location:
+      'a warm panel-discussion lounge with soft lighting and a small audience',
+    group: 'seated at a long table mid-discussion',
+  },
+  generic: {
+    subject: 'smiling warmly at the camera in casual clothes',
+    location: 'a sunlit cafe or co-working lounge',
+    group: 'chatting in small clusters around the room',
+  },
 };
+
+function describeForegroundSubject(gender: Gender): string {
+  if (gender === 'male') {
+    return 'one smiling man, mid-twenties to late-thirties, of mixed ethnicity';
+  }
+  if (gender === 'female') {
+    return 'one smiling woman, mid-twenties to late-thirties, of mixed ethnicity';
+  }
+  return 'one smiling adult — either a man or a woman — mid-twenties to late-thirties, of mixed ethnicity';
+}
+
+/**
+ * Compose the full Imagen prompt for one (theme, gender) pair.
+ *
+ * The opening sentence is the strongest anti-stylisation guard we have:
+ * Imagen will sometimes drift into illustration / 3D-render territory if
+ * left to interpret a short prompt — listing every disallowed style up
+ * front keeps the output looking like a real photograph.
+ */
+export function buildCoverPrompt(theme: CoverTheme, gender: Gender): string {
+  const scene = THEME_SCENES[theme] ?? THEME_SCENES.generic;
+  const subject = describeForegroundSubject(gender);
+  return [
+    'A photorealistic, high-quality DSLR landscape photograph — documentary style,',
+    'natural light, shallow depth of field, real human skin and clothing detail.',
+    'Absolutely not a cartoon, anime, illustration, painting, 3D render, CGI,',
+    'stylised art, or AI-art look. Looks like an unedited modern stock photo.',
+    `Foreground: ${subject}, ${scene.subject}, in sharp focus, looking warmly at the camera.`,
+    `Background (softly blurred): a mixed group of men and women of varied ethnicities, ${scene.group}.`,
+    `Setting: ${scene.location}.`,
+    'Wide 16:9 composition. Friendly, welcoming, optimistic mood.',
+    'No text, no captions, no logos, no watermarks.',
+  ].join(' ');
+}
 
 // Resolve the static fallback library directory at runtime.
 // Built JS lives at services/gateway/dist/services/intent-cover-service.js;
@@ -126,9 +227,21 @@ function fallbackDir(): string {
   return path.resolve(__dirname, '..', '..', 'static', 'intent-covers');
 }
 
+// Curated server-shipped fallback library. The dedicated dirs live under
+// services/gateway/static/intent-covers/. New activity themes route to
+// the closest existing dir until tailored JPGs are added — they're only
+// reached when the AI provider is unavailable, so freshness here is
+// secondary to never-empty.
 const FALLBACK_FILES: Record<CoverTheme, string[]> = {
   dance: ['dance/01.jpg', 'dance/02.jpg', 'dance/03.jpg'],
   fitness: ['fitness/01.jpg', 'fitness/02.jpg', 'fitness/03.jpg'],
+  walking: ['fitness/01.jpg', 'fitness/02.jpg', 'fitness/03.jpg'],
+  tennis: ['fitness/01.jpg', 'fitness/02.jpg', 'fitness/03.jpg'],
+  soccer: ['fitness/01.jpg', 'fitness/02.jpg', 'fitness/03.jpg'],
+  basketball: ['fitness/01.jpg', 'fitness/02.jpg', 'fitness/03.jpg'],
+  biking: ['fitness/01.jpg', 'fitness/02.jpg', 'fitness/03.jpg'],
+  cooking: ['generic/01.jpg', 'generic/02.jpg'],
+  panel: ['generic/01.jpg', 'generic/02.jpg'],
   generic: ['generic/01.jpg', 'generic/02.jpg'],
 };
 
@@ -157,7 +270,7 @@ async function uploadFallbackCover(args: {
   return data.publicUrl;
 }
 
-async function generateAiCover(theme: CoverTheme): Promise<Buffer> {
+async function generateAiCover(theme: CoverTheme, gender: Gender): Promise<Buffer> {
   if (!VERTEX_PROJECT) throw new CoverGenError('provider_failed', 'gcp_project_unset');
 
   let token: string;
@@ -179,7 +292,7 @@ async function generateAiCover(theme: CoverTheme): Promise<Buffer> {
   // ship the smiling-individual composition; `safetyFilterLevel: 'block_some'`
   // (default) keeps the existing content guardrails.
   const body = {
-    instances: [{ prompt: PROMPTS[theme] }],
+    instances: [{ prompt: buildCoverPrompt(theme, gender) }],
     parameters: {
       sampleCount: 1,
       aspectRatio: '16:9',
@@ -235,6 +348,27 @@ async function uploadAiCover(args: { intentId: string; bytes: Buffer }): Promise
   if (error) throw new CoverGenError('storage_failed', error.message);
   const { data } = supabase.storage.from(BUCKET).getPublicUrl(remotePath);
   return data.publicUrl;
+}
+
+async function getUserGenderFromProfile(userId: string): Promise<Gender> {
+  try {
+    const supabase = getSupabase();
+    const { data } = await supabase
+      .from('profiles')
+      .select('gender')
+      .eq('user_id', userId)
+      .maybeSingle();
+    const raw = (data as { gender?: string | null } | null)?.gender;
+    if (typeof raw !== 'string') return null;
+    const v = raw.trim().toLowerCase();
+    if (v === 'male' || v === 'm') return 'male';
+    if (v === 'female' || v === 'f') return 'female';
+    return null;
+  } catch {
+    // Don't let a profile lookup failure block image generation —
+    // fall back to a gender-agnostic prompt.
+    return null;
+  }
 }
 
 async function checkRateLimit(userId: string): Promise<void> {
@@ -310,12 +444,19 @@ export async function generateCoverForIntent(
 
   await checkRateLimit(args.userId);
 
+  // Resolve the foreground subject's gender. Caller-provided wins;
+  // otherwise we look it up from the requester's profile so the centered
+  // person matches the user (men get a man, women get a woman). Unknown
+  // / private values fall back to a gender-agnostic prompt.
+  const gender: Gender =
+    args.gender !== undefined ? args.gender : await getUserGenderFromProfile(args.userId);
+
   // Try AI gen → upload → persist. Vertex auth runs off the Cloud
   // Run service-account credentials by default; tests / local dev
   // can disable the call by setting INTENT_COVER_DRY_RUN=true.
   if (!DRY_RUN) {
     try {
-      const bytes = await generateAiCover(args.theme);
+      const bytes = await generateAiCover(args.theme, gender);
       const url = await uploadAiCover({ intentId: args.intentId, bytes });
       await persistCover({
         intentId: args.intentId,
@@ -342,12 +483,51 @@ export async function generateCoverForIntent(
 }
 
 /**
- * Map an intent's `category` (e.g., "dance.salsa", "fitness.gym") to a cover theme.
- * Mirrors the frontend `themeFromCategory` so the picker and the gateway agree.
+ * Map an intent's `category` (e.g., "dance.salsa", "sport.tennis",
+ * "fitness.gym") to a cover theme. Categories come from
+ * `intent-extractor` (dance.*, sport.*, etc.) plus a small set of
+ * keyword fall-throughs for free-form values.
  */
 export function themeFromCategory(category: string | null | undefined): CoverTheme {
   if (!category) return 'generic';
-  if (category.startsWith('dance.')) return 'dance';
-  if (category.startsWith('fitness.')) return 'fitness';
+  const c = category.trim().toLowerCase();
+  if (!c) return 'generic';
+
+  if (c.startsWith('dance.')) return 'dance';
+  if (c.startsWith('fitness.')) return 'fitness';
+
+  // Sport sub-categories — order matters: more specific tokens first.
+  if (c === 'sport.tennis' || c.includes('tennis')) return 'tennis';
+  if (
+    c === 'sport.soccer' ||
+    c === 'sport.football' ||
+    c.includes('soccer') ||
+    /\bfootball\b/.test(c)
+  )
+    return 'soccer';
+  if (c === 'sport.basketball' || c.includes('basketball')) return 'basketball';
+  if (c === 'sport.cycling' || c.includes('cycling') || c.includes('biking') || c.includes('bike'))
+    return 'biking';
+  if (
+    c === 'sport.running' ||
+    c === 'sport.hiking' ||
+    c.includes('walking') ||
+    c.includes('hiking') ||
+    c.includes('running')
+  )
+    return 'walking';
+  // Anything else under sport.* (gym, yoga, swim, pilates, …) is
+  // visually closest to the gym / studio scene.
+  if (c.startsWith('sport.')) return 'fitness';
+
+  if (c.includes('cooking') || c.startsWith('food.') || c.includes('culinary')) return 'cooking';
+  if (
+    c === 'learning.book_club' ||
+    c.startsWith('panel.') ||
+    c.includes('discussion') ||
+    c.includes('talk')
+  )
+    return 'panel';
+
   return 'generic';
 }

--- a/services/gateway/test/intent-cover-service.test.ts
+++ b/services/gateway/test/intent-cover-service.test.ts
@@ -139,6 +139,8 @@ describe('generateCoverForIntent', () => {
     supabaseMock.from
       .mockReturnValueOnce(chain({ data: { intent_id: 'i1', requester_user_id: 'u1', cover_url: null } }))
       .mockReturnValueOnce(chain({ count: 0 }))
+      // profile gender lookup
+      .mockReturnValueOnce(chain({ data: { gender: 'female' } }))
       // persistCover update
       .mockReturnValueOnce(chain({ data: null, error: null }));
     supabaseMock.storage.from.mockReturnValue(
@@ -155,6 +157,7 @@ describe('generateCoverForIntent', () => {
     supabaseMock.from
       .mockReturnValueOnce(chain({ data: { intent_id: 'i1', requester_user_id: 'u1', cover_url: null } }))
       .mockReturnValueOnce(chain({ count: 0 }))
+      .mockReturnValueOnce(chain({ data: { gender: 'male' } }))
       .mockReturnValueOnce(chain({ data: null, error: null }));
     supabaseMock.storage.from.mockReturnValue(
       storageStub({ publicUrl: 'https://files.example/ai.png' }),
@@ -172,12 +175,20 @@ describe('generateCoverForIntent', () => {
     const out = await generateCoverForIntent({ intentId: 'i1', userId: 'u1', theme: 'dance' });
     expect(out).toEqual({ cover_url: 'https://files.example/ai.png', source: 'ai_generated', cached: false });
     expect(vertexFetch).toHaveBeenCalledTimes(1);
+
+    // The Imagen prompt must reflect the requester's gender.
+    const sentBody = JSON.parse(vertexFetch.mock.calls[0][1].body) as {
+      instances: { prompt: string }[];
+    };
+    expect(sentBody.instances[0].prompt).toMatch(/one smiling man/i);
+    expect(sentBody.instances[0].prompt).toMatch(/dance studio/i);
   });
 
   it('AI failure → curated fallback (still resolves with success)', async () => {
     supabaseMock.from
       .mockReturnValueOnce(chain({ data: { intent_id: 'i1', requester_user_id: 'u1', cover_url: null } }))
       .mockReturnValueOnce(chain({ count: 0 }))
+      .mockReturnValueOnce(chain({ data: { gender: null } }))
       .mockReturnValueOnce(chain({ data: null, error: null }));
     supabaseMock.storage.from.mockReturnValue(
       storageStub({ publicUrl: 'https://files.example/fb.jpg' }),
@@ -192,6 +203,43 @@ describe('generateCoverForIntent', () => {
     const out = await generateCoverForIntent({ intentId: 'i1', userId: 'u1', theme: 'dance' });
     expect(out.source).toBe('fallback_curated');
   });
+
+  it('skips the profile gender lookup when caller passes gender explicitly', async () => {
+    supabaseMock.from
+      .mockReturnValueOnce(chain({ data: { intent_id: 'i1', requester_user_id: 'u1', cover_url: null } }))
+      .mockReturnValueOnce(chain({ count: 0 }))
+      // No profile chain — caller passes gender, so the service must NOT look it up.
+      .mockReturnValueOnce(chain({ data: null, error: null }));
+    supabaseMock.storage.from.mockReturnValue(
+      storageStub({ publicUrl: 'https://files.example/ai.png' }),
+    );
+    vertexFetch.mockResolvedValueOnce({
+      ok: true,
+      status: 200,
+      statusText: 'OK',
+      json: async () => ({
+        predictions: [{ bytesBase64Encoded: Buffer.from('img').toString('base64') }],
+      }),
+      text: async () => '',
+    } as unknown as Response);
+    const { generateCoverForIntent } = await import('../src/services/intent-cover-service');
+    await generateCoverForIntent({
+      intentId: 'i1',
+      userId: 'u1',
+      theme: 'tennis',
+      gender: 'female',
+    });
+    const sentBody = JSON.parse(vertexFetch.mock.calls[0][1].body) as {
+      instances: { prompt: string }[];
+    };
+    expect(sentBody.instances[0].prompt).toMatch(/one smiling woman/i);
+    expect(sentBody.instances[0].prompt).toMatch(/tennis/i);
+    // Caller passed gender — the test only mocked 3 supabase.from chains
+    // (intent, rate-limit, persist). If we erroneously called profiles
+    // lookup, persist would silently get the wrong stub; the upload
+    // assertion on vertexFetch above is what guarantees we got there.
+    expect(supabaseMock.from).toHaveBeenCalledTimes(3);
+  });
 });
 
 describe('themeFromCategory', () => {
@@ -201,5 +249,63 @@ describe('themeFromCategory', () => {
     expect(themeFromCategory('fitness.gym')).toBe('fitness');
     expect(themeFromCategory('commercial.buy')).toBe('generic');
     expect(themeFromCategory(null)).toBe('generic');
+  });
+
+  it('maps the expanded activity categories', async () => {
+    const { themeFromCategory } = await import('../src/services/intent-cover-service');
+    expect(themeFromCategory('sport.tennis')).toBe('tennis');
+    expect(themeFromCategory('sport.soccer')).toBe('soccer');
+    expect(themeFromCategory('sport.football')).toBe('soccer');
+    expect(themeFromCategory('sport.basketball')).toBe('basketball');
+    expect(themeFromCategory('sport.cycling')).toBe('biking');
+    expect(themeFromCategory('sport.hiking')).toBe('walking');
+    expect(themeFromCategory('sport.running')).toBe('walking');
+    expect(themeFromCategory('sport.gym')).toBe('fitness');
+    expect(themeFromCategory('sport.yoga')).toBe('fitness');
+    expect(themeFromCategory('food.cooking_class')).toBe('cooking');
+    expect(themeFromCategory('learning.book_club')).toBe('panel');
+  });
+});
+
+describe('buildCoverPrompt', () => {
+  it('produces a realism-anchored prompt and matches the gender of the requester', async () => {
+    const { buildCoverPrompt } = await import('../src/services/intent-cover-service');
+
+    const male = buildCoverPrompt('tennis', 'male');
+    expect(male).toMatch(/photorealistic/i);
+    expect(male).toMatch(/not a cartoon/i);
+    expect(male).toMatch(/one smiling man/i);
+    expect(male).toMatch(/tennis/i);
+    expect(male).toMatch(/mixed group of men and women/i);
+
+    const female = buildCoverPrompt('cooking', 'female');
+    expect(female).toMatch(/one smiling woman/i);
+    expect(female).toMatch(/kitchen/i);
+
+    const neutral = buildCoverPrompt('panel', null);
+    expect(neutral).toMatch(/either a man or a woman/i);
+  });
+
+  it('covers every theme without throwing', async () => {
+    const { buildCoverPrompt } = await import('../src/services/intent-cover-service');
+    const themes = [
+      'dance',
+      'fitness',
+      'walking',
+      'tennis',
+      'soccer',
+      'basketball',
+      'biking',
+      'cooking',
+      'panel',
+      'generic',
+    ] as const;
+    for (const t of themes) {
+      const p = buildCoverPrompt(t, null);
+      expect(p.length).toBeGreaterThan(120);
+      // Realism + no-cartoon guarantee shared across every theme.
+      expect(p).toMatch(/photorealistic/i);
+      expect(p).toMatch(/not a cartoon/i);
+    }
   });
 });


### PR DESCRIPTION
## Summary

Match-card cover photos were defaulting to a generic, sometimes stylised image and ignored who the requester actually was. This PR rewrites the Imagen prompt and expands the activity coverage so every generated cover is:

- **Photorealistic.** Opening sentence enumerates every disallowed style (cartoon, anime, illustration, painting, 3D render, CGI, AI-art look) — Imagen drifts when given a short prompt; spelling it out keeps the output in real-photo territory.
- **Gender-matched to the requester.** Foreground subject is a man if `profiles.gender = male`, a woman if `female`, otherwise gender-agnostic. Background is always a blurred mixed group of men and women of varied ethnicities. New optional `gender` arg on `GenerateCoverArgs`; falls through to a profile lookup when not passed explicitly.
- **Activity-appropriate.** `CoverTheme` expanded from 3 to 10: `dance`, `fitness`, `walking`, `tennis`, `soccer`, `basketball`, `biking`, `cooking`, `panel`, `generic`. Each has its own `{subject, location, group}` scene primitive composed at request time by `buildCoverPrompt(theme, gender)`.

`themeFromCategory` widened so existing categories from `intent-extractor` (`dance.*`, `sport.tennis`, `sport.cycling`, `sport.hiking`, `sport.running`, `sport.gym`, `sport.yoga`, `learning.book_club`, ...) and free-form keywords (`cooking`, `biking`, `basketball`, ...) reach the right theme instead of collapsing to generic.

## Why this matters

The user reported the deployed cards are still showing the same generic dance scene across matches and asked for realistic photos with a real human in the centre matching the user's gender, a mixed group in the background, and varied locations per activity. The frontend already consumes `partner_match_cover_url` — the missing piece is the prompt the gateway sends to Vertex Imagen.

## Files

- `services/gateway/src/services/intent-cover-service.ts` — new `buildCoverPrompt`, `THEME_SCENES`, `getUserGenderFromProfile`; widened `CoverTheme`, `themeFromCategory`, and `FALLBACK_FILES`.
- `services/gateway/test/intent-cover-service.test.ts` — added prompt-builder + category-mapping coverage; updated existing chain mocks for the new profile-gender lookup; added a "skips profile lookup when gender passed explicitly" test.

## Test plan

- [x] `npm test test/intent-cover-service.test.ts` — 11 / 11 pass locally.
- [x] `npm run typecheck` — clean.
- [ ] Apply migration / verify `intent-covers` Supabase Storage bucket exists.
- [ ] Deploy gateway via EXEC-DEPLOY (this PR's commit message uses `BOOTSTRAP-MATCH-COVER-REALISM` so Auto-Deploy will dispatch).
- [ ] After deploy, regenerate one existing match cover: `POST /api/v1/intents/<id>/cover/generate` with `{ "force": true }` for a male profile → response shows `source: "ai_generated"` and the persisted image is a photoreal man up front + mixed group behind.
- [ ] Same call with a female profile → woman in foreground.
- [ ] Try one of each new theme by creating intents with `category=sport.tennis`, `sport.cycling`, `sport.basketball`, `food.cooking_class` → covers reflect the right venue.

## Out of scope

- Curated fallback JPGs for the new themes still route to the closest existing dir (`fitness/*` for sport themes, `generic/*` for cooking/panel). They're only used on provider failure; tailored JPGs can land in a follow-up.
- The frontend image-led card already renders these covers — no v1 frontend changes needed.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CwWdVw9josnGca17vjWJ5a)_