### PR TITLE
chore(gateway): retrigger Auto-Deploy for #1915 (BOOTSTRAP-MATCH-COVER-REALISM)

### DIFF
--- a/services/gateway/src/services/intent-cover-service.ts
+++ b/services/gateway/src/services/intent-cover-service.ts
@@ -1,6 +1,6 @@
 /**
- * BOOTSTRAP-INTENT-COVER-GEN — server-side cover-photo generation for
- * the Find-a-Match preview card.
+ * BOOTSTRAP-INTENT-COVER-GEN / BOOTSTRAP-MATCH-COVER-REALISM —
+ * server-side cover-photo generation for the Find-a-Match preview card.
  *
  * Two responsibilities:
  *


### PR DESCRIPTION
## Summary

#1915 squash-merged without `BOOTSTRAP-MATCH-COVER-REALISM` in the commit subject, so Auto-Deploy's VTID regex did not match and **EXEC-DEPLOY never dispatched**. The gateway is therefore still serving the old prompt.

This is a one-line docblock-tag change to give Auto-Deploy a commit message it accepts, so EXEC-DEPLOY fires and the realistic gender-matched cover prompts go live on Cloud Run.

No behavioural change — only a comment edit on `intent-cover-service.ts`.

## Why a separate PR

Per `CLAUDE.md` §16 the regex requires `(DEV-…|VTID-…|BOOTSTRAP-…)` in the commit message. The cleanest fix is a new commit on main with the token in the subject; modifying history isn't an option.

## Test plan

- [ ] On merge, confirm Auto-Deploy → EXEC-DEPLOY dispatches (Actions tab).
- [ ] After EXEC-DEPLOY completes, hit `GET https://gateway-86804897789.us-central1.run.app/alive` → 200.
- [ ] `POST /api/v1/intents/<intent-id>/cover/generate -d '{"force":true}'` for a male profile → response `source: "ai_generated"`, persisted image is a photoreal man + mixed group behind.
- [ ] Same with a female profile → woman in foreground.

---
_Generated by [Claude Code](https://claude.ai/code/session_01CwWdVw9josnGca17vjWJ5a)_