### PR TITLE
diag(orb-agent): bypass LLM with session.say to isolate TTS silence

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -65,7 +65,7 @@ except ImportError:
     LK_AVAILABLE = False
 
 
-CODE_VERSION = "agent-2026-05-07-phase-traces"
+CODE_VERSION = "agent-2026-05-07-tts-isolation"
 
 
 async def _early_trace_heartbeat(gateway_url: str, payload: dict) -> None:
@@ -396,71 +396,78 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
         )
     )
 
-    # Initial greeting — fire as soon as the session is ready so the user
-    # hears their personalized hello on connect. Mirrors the Vertex pipeline
-    # behaviour (orb-live.ts opens with a generated greeting). The
-    # bootstrap_context already has the user's display_name / vitana_id /
-    # verified facts, so the LLM can reach into the prompt and pull the
-    # right name without an extra tool call.
-    if not identity.is_anonymous:
-        # Greeting must always include the user's @vitana_id handle. If a
-        # `user_name` memory_fact exists, also use the first name. The
-        # WHO YOU ARE TALKING TO block of the system prompt has the handle
-        # at position #1, so the LLM cannot truthfully claim it doesn't
-        # know.
-        vid = (bootstrap.vitana_id or "").strip()
-        try:
-            await session.generate_reply(
-                instructions=(
-                    "Greet the user warmly RIGHT NOW. **MUST** include their "
-                    f"@vitana_id handle (it is @{vid or 'their handle'}) in the "
-                    "greeting so they can hear you recognize them. If a "
-                    "`user_name` fact is in your YOUR USER'S CONTEXT block, "
-                    "use the first name (e.g. 'Hi Dragan!'). Otherwise just "
-                    f"use the handle: 'Hi @{vid or 'there'}!'. ONE short "
-                    "sentence + brief 'What can I help with today?'. NEVER "
-                    "say you don't know them — you do. NEVER apologize for "
-                    "anything in the greeting."
-                ),
-            )
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("initial greeting generate_reply failed: %s", exc)
+    # ── TTS-isolation diagnostic ─────────────────────────────────────
+    # Wire-level capture proved the agent publishes an audio track but every
+    # sample is zero (RMS=0.14). That means the AgentSession audio source is
+    # alive but the TTS plugin never emitted real bytes. To isolate whether
+    # the LLM-to-TTS pipeline is broken vs the TTS plugin itself is broken,
+    # we replace the LLM-driven greeting with a deterministic session.say()
+    # that goes straight to TTS. We also hook speech_created so we can see
+    # in the firehose whether TTS was even asked to speak.
+    try:
+        @session.on("speech_created")  # type: ignore[misc]
+        def _on_speech(ev: Any) -> None:  # noqa: ARG001
             asyncio.create_task(
                 _early_trace_heartbeat(
                     cfg.gateway_url,
                     {
                         "user_id": identity.user_id or "unknown",
                         "code_version": CODE_VERSION,
-                        "phase": "greeting_failed",
-                        "orb_session_id": orb_session_id,
-                        "error": str(exc)[:500],
-                    },
-                )
-            )
-        else:
-            asyncio.create_task(
-                _early_trace_heartbeat(
-                    cfg.gateway_url,
-                    {
-                        "user_id": identity.user_id or "unknown",
-                        "code_version": CODE_VERSION,
-                        "phase": "greeting_ok",
+                        "phase": "speech_created",
                         "orb_session_id": orb_session_id,
                     },
                 )
             )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("could not hook speech_created: %s", exc)
+
+    vid = (bootstrap.vitana_id or "").strip()
+    if identity.is_anonymous:
+        greeting_text = "Hi! How can I help you today?"
+    elif vid:
+        greeting_text = f"Hi at {vid}! What can I help with today?"
     else:
-        try:
-            await session.generate_reply(
-                instructions=(
-                    "Greet the visitor briefly as Vitana. They are not signed "
-                    "in, so do not invent personal details. Offer to help with "
-                    "general questions or guide them to sign in for personalized "
-                    "answers. One short sentence."
-                ),
+        greeting_text = "Hi there! What can I help with today?"
+
+    # session.say bypasses the LLM and goes straight to the TTS plugin.
+    # If audio bytes are non-silent after this, TTS works and the LLM
+    # (or generate_reply) was the broken layer. If still silent, the
+    # TTS plugin itself is broken.
+    try:
+        say_handle = session.say(greeting_text, add_to_chat_ctx=False)
+        # If session.say returns an awaitable, await it so we know when
+        # the speech finished. In livekit-agents 1.x it returns a SpeechHandle
+        # we can await.
+        if hasattr(say_handle, "wait_for_playout"):
+            await asyncio.wait_for(say_handle.wait_for_playout(), timeout=20)
+        elif asyncio.iscoroutine(say_handle):
+            await asyncio.wait_for(say_handle, timeout=20)
+        asyncio.create_task(
+            _early_trace_heartbeat(
+                cfg.gateway_url,
+                {
+                    "user_id": identity.user_id or "unknown",
+                    "code_version": CODE_VERSION,
+                    "phase": "say_ok",
+                    "orb_session_id": orb_session_id,
+                    "greeting_text": greeting_text,
+                },
             )
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("anonymous greeting generate_reply failed: %s", exc)
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.exception("session.say failed: %s", exc)
+        asyncio.create_task(
+            _early_trace_heartbeat(
+                cfg.gateway_url,
+                {
+                    "user_id": identity.user_id or "unknown",
+                    "code_version": CODE_VERSION,
+                    "phase": "say_failed",
+                    "orb_session_id": orb_session_id,
+                    "error": str(exc)[:500],
+                },
+            )
+        )
 
     # Park here until the room disconnects. The AgentSession keeps running
     # autonomously via the tasks it spawned in start(); we just need to


### PR DESCRIPTION
Wire-level audio probe (livekit Python SDK subscribed to agent's track):

- TrackSubscribed fires
- 2.26 MB of audio frames over 24s
- BUT every sample is zero: RMS=0.14, min=-2, max=1

So agent publishes a track and the source emits frames, but TTS never produced real bytes — even though greeting_ok logged because generate_reply returned cleanly.

This PR isolates whether the silence is TTS-plugin failure or LLM-to-TTS pipeline:

1. session.generate_reply -> session.say(text) + await wait_for_playout. Bypasses LLM, goes straight to TTS.
2. Hook AgentSession.on('speech_created') -> emit phase trace each time TTS is asked to speak.
3. say_ok / say_failed traces around session.say.

CODE_VERSION bumped to agent-2026-05-07-tts-isolation. After deploy, re-run /tmp/test_livekit_audio.py — non-silent audio confirms TTS works (then restore LLM); still silent confirms TTS plugin/auth is broken.

🤖 Generated with Claude Code