### PR TITLE
fix(orb-agent): TTS plugin silently failed init due to language_code kwarg drift

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/providers.py
+++ b/services/agents/orb-agent/src/orb_agent/providers.py
@@ -166,8 +166,32 @@ def _build_tts(provider: str | None, model: str | None, options: dict[str, Any],
         try:
             from livekit.plugins import google  # type: ignore[import-not-found]
             voice = model or "en-US-Chirp3-HD-Aoede"
+            # tts_options from the agent_voice_configs row may carry legacy
+            # keys like `language_code` (the seed migration uses Google's
+            # API-side spelling). The livekit-plugins-google TTS class only
+            # accepts `language=`, so an un-renamed `language_code` would
+            # surface as an unexpected-kwarg TypeError → caught silently
+            # below → cascade.tts=None → AgentSession runs but produces
+            # silent audio. Normalise here.
+            opts = dict(options or {})
+            language = opts.pop("language", None) or opts.pop("language_code", None) or "en-US"
+            # Drop any other keys the Google plugin doesn't accept rather
+            # than crash. Whitelist only the kwargs we know are safe; future
+            # additions need to be added explicitly.
+            allowed = {
+                "gender", "voice_cloning_key", "model_name", "prompt",
+                "sample_rate", "pitch", "effects_profile_id", "speaking_rate",
+                "volume_gain_db", "location", "audio_encoding",
+                "credentials_info", "credentials_file", "tokenizer",
+                "custom_pronunciations", "use_streaming", "enable_ssml",
+                "use_markup",
+            }
+            forwarded = {k: v for k, v in opts.items() if k in allowed}
+            dropped = sorted(set(opts.keys()) - allowed)
+            if dropped:
+                notes.append(f"google_tts: dropped unsupported tts_options keys: {dropped}")
             # Google Cloud Text-to-Speech via ADC (no API key needed).
-            return google.TTS(voice_name=voice, language="en-US", **options)
+            return google.TTS(voice_name=voice, language=language, **forwarded)
         except ImportError:
             notes.append("TTS provider 'google_tts' requested but livekit-plugins-google not installed")
             return None

--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -65,7 +65,7 @@ except ImportError:
     LK_AVAILABLE = False
 
 
-CODE_VERSION = "agent-2026-05-07-tts-isolation"
+CODE_VERSION = "agent-2026-05-07-tts-language-fix"
 
 
 async def _early_trace_heartbeat(gateway_url: str, payload: dict) -> None:
@@ -228,8 +228,29 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
             vitana_id=bootstrap.vitana_id or identity.vitana_id,
         )
 
-    # Cascade.
+    # Cascade. If any of stt/llm/tts is None it means the corresponding
+    # plugin failed to instantiate (wrong provider name, ImportError,
+    # config kwarg not accepted, ADC missing scopes, etc.). Trace the
+    # cascade.notes so we never have to guess again.
     cascade = build_cascade(bootstrap.voice_config)
+    cascade_summary = {
+        "stt_present": cascade.stt is not None,
+        "llm_present": cascade.llm is not None,
+        "tts_present": cascade.tts is not None,
+        "notes": list(cascade.notes),
+    }
+    asyncio.create_task(
+        _early_trace_heartbeat(
+            cfg.gateway_url,
+            {
+                "user_id": identity.user_id or "unknown",
+                "code_version": CODE_VERSION,
+                "phase": "cascade_built",
+                "orb_session_id": orb_session_id,
+                "cascade_summary": cascade_summary,
+            },
+        )
+    )
 
     # OASIS session start.
     await oasis.emit(


### PR DESCRIPTION
**Root cause of \"no audio at all\" on LiveKit:**

agent_voice_configs.tts_options = {language_code: en-US}, but google.TTS() accepts only language=, not language_code=. providers.py forwarded the dict via **options → TypeError → caught by the broad except → cascade.tts = None → AgentSession ran but session.say raised "trying to generate speech... without a TTS model".

Wire-level capture (/tmp/test_livekit_audio.py) confirmed: track published, 2.26 MB of frames, every sample zero. RMS = 0.14, min = -2, max = 1 over 24s.

**Fix:**

1. providers._build_tts(google_tts): pop language_code as fallback for language; whitelist plugin-accepted kwargs; surface dropped keys via cascade notes.
2. session.py: emit cascade_built phase trace with STT/LLM/TTS presence + cascade notes so any future None-plugin failure is visible in firehose within seconds.

CODE_VERSION = agent-2026-05-07-tts-language-fix.

Local repro with prod voice_config confirms all three plugins instantiate cleanly with zero notes.

🤖 Generated with Claude Code