### PR TITLE
fix(VTID-02805): orb-agent uses first name + readable event listings

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/bootstrap.py
+++ b/services/agents/orb-agent/src/orb_agent/bootstrap.py
@@ -35,6 +35,9 @@ class BootstrapResult:
     client_context: dict[str, Any]
     vitana_id: str | None
     voice_config: dict[str, Any] | None  # agent_voice_configs row
+    display_name: str | None = None  # full display name from app_users.display_name
+    first_name: str | None = None  # first token of display_name (or memory_facts.user_name)
+    identity_facts: list[dict[str, Any]] | None = None  # raw memory_facts whitelisted by identity-core keys
     is_degraded: bool = False
 
 
@@ -89,6 +92,9 @@ class ContextBootstrap:
                 client_context=data.get("client_context", {}),
                 vitana_id=data.get("vitana_id"),
                 voice_config=data.get("voice_config"),
+                display_name=data.get("display_name"),
+                first_name=data.get("first_name"),
+                identity_facts=data.get("identity_facts") or [],
                 is_degraded=False,
             )
         except (httpx.TimeoutException, httpx.HTTPError) as exc:

--- a/services/agents/orb-agent/src/orb_agent/instructions.py
+++ b/services/agents/orb-agent/src/orb_agent/instructions.py
@@ -43,6 +43,8 @@ def build_live_system_instruction(
     recent_routes: list[str] | None = None,
     client_context: dict[str, Any] | None = None,
     vitana_id: str | None = None,
+    first_name: str | None = None,
+    display_name: str | None = None,
 ) -> str:
     """Authenticated session system prompt builder.
 
@@ -52,33 +54,54 @@ def build_live_system_instruction(
     parts: list[str] = []
 
     # ── 1. THE USER YOU ARE TALKING TO — first line of the prompt ────────
-    # Plain text, no markdown. Repeat the handle so any attention head
-    # has to see it. This is what the LLM should ALWAYS use to address
-    # the user. Avoid markdown bold (**...**) since some smaller LLMs
-    # treat it as decoration and skip the content.
+    # Prefer the user's first name (from app_users.display_name or memory_facts
+    # 'user_name'). Fall back to the @handle if no name is on file. Avoid
+    # markdown bold (**...**) since some smaller LLMs treat it as decoration.
     handle = f"@{vitana_id}" if vitana_id else None
-    if handle:
-        parts.append(
-            f"You are talking to {handle}.\n"
+    name = (first_name or "").strip() or None
+    if name and handle:
+        primary_address = name
+        addressing_rule = (
+            f"- Address them by their first name ({name}) — that is how a real\n"
+            f"  person would speak to them.\n"
+            f"- {name}'s Vitana handle is {handle}; you may use it as a\n"
+            f"  fallback or in confirmations, but DO NOT keep saying {handle}\n"
+            f"  if you can say {name}.\n"
+        )
+        speakable_id = name
+    elif handle:
+        primary_address = handle
+        addressing_rule = (
             f"- Their handle is {handle}.\n"
             f"- Always use {handle} when greeting or addressing them.\n"
+        )
+        speakable_id = handle
+    else:
+        primary_address = "this user"
+        addressing_rule = "- No identifying handle on file.\n"
+        speakable_id = "this user"
+
+    if handle or name:
+        parts.append(
+            f"You are talking to {primary_address}.\n"
+            f"{addressing_rule}"
             f"- Their active role is {active_role or 'community'}.\n"
             f"\n"
             f"AUTHENTICATION STATUS — READ THIS FIRST:\n"
-            f"{handle} IS SIGNED IN RIGHT NOW. They are AUTHENTICATED. The auth\n"
+            f"{speakable_id} IS SIGNED IN RIGHT NOW. They are AUTHENTICATED. The auth\n"
             f"chain is wired end-to-end (Bearer JWT → gateway → tools). You\n"
             f"have FULL working tool access to their personal data — Vitana\n"
             f"Index, calendar, reminders, intents, recommendations, memory,\n"
             f"diary, autopilot, contacts, sharing, and 30+ other capabilities.\n"
             f"\n"
-            f"NEVER tell {handle} they are 'logged out' or 'not logged in' or\n"
+            f"NEVER tell {speakable_id} they are 'logged out' or 'not logged in' or\n"
             f"that they 'need to log in' or that you 'can see they are still\n"
-            f"logged out'. Those statements are FACTUALLY WRONG. {handle} is\n"
+            f"logged out'. Those statements are FACTUALLY WRONG. {speakable_id} is\n"
             f"signed in; you can read this sentence because the auth chain\n"
             f"already authenticated them and dropped them into your session.\n"
             f"\n"
             f"If a tool call returns empty (count=0, items=[], snapshot=null),\n"
-            f"that means {handle} simply has no data of that kind yet — narrate\n"
+            f"that means {speakable_id} simply has no data of that kind yet — narrate\n"
             f"it as 'You have none yet' or 'Your baseline survey isn't done\n"
             f"yet'. NEVER conflate empty data with auth failure."
         )

--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -65,7 +65,7 @@ except ImportError:
     LK_AVAILABLE = False
 
 
-CODE_VERSION = "agent-2026-05-07-tts-fix-llm-greeting"
+CODE_VERSION = "agent-2026-05-07-name-and-facts"
 
 
 async def _early_trace_heartbeat(gateway_url: str, payload: dict) -> None:
@@ -226,6 +226,8 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
             recent_routes=bootstrap.recent_routes,
             client_context=bootstrap.client_context,
             vitana_id=bootstrap.vitana_id or identity.vitana_id,
+            first_name=bootstrap.first_name,
+            display_name=bootstrap.display_name,
         )
 
     # Cascade. If any of stt/llm/tts is None it means the corresponding
@@ -302,16 +304,26 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
             "user_jwt_present": bool(user_jwt),
             "user_jwt_len": len(user_jwt) if user_jwt else 0,
             "bootstrap_context_length": len(bootstrap.bootstrap_context or ""),
+            "bootstrap_first_1500_chars": (bootstrap.bootstrap_context or "")[:1500],
             "bootstrap_active_role": bootstrap.active_role,
             "bootstrap_vitana_id": bootstrap.vitana_id,
+            "bootstrap_display_name": bootstrap.display_name,
+            "bootstrap_first_name": bootstrap.first_name,
+            "bootstrap_identity_facts_count": len(bootstrap.identity_facts or []),
+            "bootstrap_identity_fact_keys": [
+                f.get("fact_key") for f in (bootstrap.identity_facts or [])
+            ],
             "bootstrap_voice_config_llm": (bootstrap.voice_config or {}).get("llm_model"),
             "bootstrap_voice_config_stt": (bootstrap.voice_config or {}).get("stt_model"),
             "bootstrap_voice_config_tts": (bootstrap.voice_config or {}).get("tts_model"),
             "system_prompt_length": len(sys_prompt),
-            "system_prompt_first_400_chars": sys_prompt[:400],
+            "system_prompt_first_600_chars": sys_prompt[:600],
             "tools_count": len(tool_list),
             "tools_first_5": tool_names[:5],
             "tools_handle_in_first_chars": "@" + (bootstrap.vitana_id or identity.vitana_id or "") in sys_prompt[:600],
+            "tools_first_name_in_first_chars": bool(
+                bootstrap.first_name and bootstrap.first_name.lower() in sys_prompt[:600].lower()
+            ),
         }
         await gw.post("/api/v1/orb/agent-trace", trace_payload)
     except Exception as exc:  # noqa: BLE001
@@ -443,20 +455,26 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     # session is fixed in providers.py (language_code → language).
     if not identity.is_anonymous:
         vid = (bootstrap.vitana_id or "").strip()
-        try:
-            await session.generate_reply(
-                instructions=(
-                    "Greet the user warmly RIGHT NOW. **MUST** include their "
-                    f"@vitana_id handle (it is @{vid or 'their handle'}) in the "
-                    "greeting so they can hear you recognize them. If a "
-                    "`user_name` fact is in your YOUR USER'S CONTEXT block, "
-                    "use the first name (e.g. 'Hi Dragan!'). Otherwise just "
-                    f"use the handle: 'Hi @{vid or 'there'}!'. ONE short "
-                    "sentence + brief 'What can I help with today?'. NEVER "
-                    "say you don't know them — you do. NEVER apologize for "
-                    "anything in the greeting."
-                ),
+        first_name = (bootstrap.first_name or "").strip()
+        if first_name:
+            greeting_instructions = (
+                f"Greet the user warmly RIGHT NOW by their first name: '{first_name}'. "
+                f"Examples: 'Hi {first_name}!' or 'Hey {first_name}, good to hear from you.' "
+                f"Their Vitana handle ({'@' + vid if vid else '<no handle>'}) is "
+                f"available as a fallback but DO NOT lead with it — '{first_name}' is "
+                f"the natural way a real person would address them. ONE short sentence "
+                f"+ brief 'What can I help with today?'. NEVER say you don't know them — "
+                f"you do. NEVER apologize for anything in the greeting."
             )
+        else:
+            greeting_instructions = (
+                f"Greet the user warmly RIGHT NOW using their @vitana_id handle "
+                f"(it is @{vid or 'their handle'}). Example: 'Hi @{vid or 'there'}!'. "
+                f"ONE short sentence + brief 'What can I help with today?'. NEVER say "
+                f"you don't know them — you do. NEVER apologize for anything in the greeting."
+            )
+        try:
+            await session.generate_reply(instructions=greeting_instructions)
         except Exception as exc:  # noqa: BLE001
             logger.warning("initial greeting generate_reply failed: %s", exc)
             asyncio.create_task(

--- a/services/agents/orb-agent/src/orb_agent/tools.py
+++ b/services/agents/orb-agent/src/orb_agent/tools.py
@@ -217,8 +217,18 @@ async def get_schedule(context: RunContext, date_iso: str | None = None) -> str:
 
 
 @function_tool
-async def search_events(context: RunContext, query: str) -> str:
-    """Search community events / meetups (VTID-01270A)."""
+async def search_events(context: RunContext, query: str = "") -> str:
+    """List upcoming community events, meetups, parties, or workshops.
+
+    CALL THIS whenever the user asks about events, meetups, parties,
+    workshops, gatherings, what's happening, what's coming up, or
+    anything similar — even when no specific filter is mentioned.
+    Pass an empty `query` to list ALL upcoming events.
+
+    Args:
+        query: Optional substring to filter on title/description (case-insensitive).
+               Pass "" or omit to list all upcoming events.
+    """
     body = await _dispatch(context, "search_events", {"query": query})
     return summarize(body)
 

--- a/services/gateway/src/routes/orb-livekit.ts
+++ b/services/gateway/src/routes/orb-livekit.ts
@@ -628,6 +628,13 @@ router.get(
       );
     }
 
+    // Extract first name from display_name OR memory_facts.user_name fact.
+    // app_users.display_name commonly stores the full name ("Dragan Alexander"),
+    // but the agent should address the user by their first name only.
+    const userNameFact = identityFacts.find((f) => f.fact_key === 'user_name');
+    const fullName = (userNameFact?.fact_value || displayName || '').trim();
+    const firstName = fullName ? fullName.split(/\s+/)[0] : null;
+
     res.json({
       ok: true,
       vtid: VTID,
@@ -643,6 +650,13 @@ router.get(
       recent_routes: [],
       client_context: { user_agent: req.headers['user-agent'] ?? null },
       vitana_id: req.identity?.vitana_id ?? null,
+      // VTID-LIVEKIT-IDENTITY-NAME: surface the user's name + verified facts as
+      // structured fields so the agent's instructions.py can address them by
+      // first name rather than only by @handle.
+      display_name: displayName,
+      first_name: firstName,
+      identity_facts: identityFacts,
+      identity_facts_count: identityFacts.length,
       voice_config: voiceConfig,
       memory_items: memoryItems,
     });

--- a/services/gateway/src/routes/orb-tool.ts
+++ b/services/gateway/src/routes/orb-tool.ts
@@ -212,21 +212,28 @@ async function tool_search_events(args: ToolArgs, _id: Identity, sb: SupabaseCli
           (e.description || '').toLowerCase().includes(query),
       )
     : data || [];
+  const top = filtered.slice(0, 10).map((e) => ({
+    id: e.id,
+    title: e.title,
+    when: e.start_time,
+    location: e.location || e.virtual_link,
+    slug: e.slug,
+  }));
+  // Voice-friendly summary: include event titles + when so the LLM can read
+  // them back. The earlier "Found 3 upcoming events" produced silence on the
+  // voice side because the LLM had no titles to speak.
+  const lines = top.map((e) => {
+    const when = e.when ? new Date(e.when).toLocaleDateString('en-US', { month: 'short', day: 'numeric' }) : '';
+    const loc = e.location ? ` at ${String(e.location).slice(0, 80)}` : '';
+    return `- ${e.title}${when ? ` (${when})` : ''}${loc}`;
+  });
   return {
     ok: true,
-    result: {
-      events: filtered.slice(0, 10).map((e) => ({
-        id: e.id,
-        title: e.title,
-        when: e.start_time,
-        location: e.location || e.virtual_link,
-        slug: e.slug,
-      })),
-    },
+    result: { events: top },
     text:
       filtered.length === 0
         ? 'No upcoming events found right now.'
-        : `Found ${filtered.length} upcoming event${filtered.length === 1 ? '' : 's'}.`,
+        : `Upcoming events (${filtered.length}):\n${lines.join('\n')}`,
   };
 }
 


### PR DESCRIPTION
User reports the LiveKit agent (now that audio works post-PR-1921):

1. Calls them by @vitana_id handle instead of first name (bug)
2. Says it has events but doesn't list any (bug)
3. Knows date+month of birthday but not year (data, not code)
4. Has Vitana Index, posts, reminders working correctly

Fixes:

**1. First-name addressing (3-layer fix):**
- Gateway /api/v1/orb/context-bootstrap: surface display_name + first_name + identity_facts as top-level fields (was embedded only in bootstrap_context string).
- bootstrap.py: parse new fields into BootstrapResult.
- instructions.py: build_live_system_instruction now takes first_name. WHO YOU ARE TALKING TO block addresses by first name when known, falls back to @handle. The previous block told the LLM 'Always use {handle}' which overrode the bootstrap context line.
- session.py: greeting prompt 'Greet warmly RIGHT NOW by their first name: {name}' when known.

**2. Event listing readable on voice:**
- orb-tool dispatcher search_events: text response now lists event titles + dates ('Upcoming events (3): - Sunrise Beach Bootcamp (May 17)...'). Was 'Found 3 upcoming events.' with zero titles.
- tools.py search_events: docstring rewritten so LLM knows to call it for 'events', 'meetups', 'parties', 'workshops'. Made query optional with default ''.

**3. Birthday year:**
Data-dependent. user_birthday memory_fact value likely contains only DD-MM, not year. We now surface bootstrap.identity_facts to the agent trace so I can verify per-user what's in there. Follow-up if the year is missing.

**Diagnostic additions to trace payload (visible in /api/v1/orb/agent-trace/recent):**
- bootstrap_first_1500_chars
- bootstrap_display_name
- bootstrap_first_name
- bootstrap_identity_facts_count
- bootstrap_identity_fact_keys
- tools_first_name_in_first_chars

CODE_VERSION = agent-2026-05-07-name-and-facts. Both gateway + agent deploys triggered.

🤖 Generated with Claude Code