### PR TITLE
feat(intent-cover): user library + universal photo (VTID-02806)

### DIFF
--- a/services/gateway/src/services/intent-cover-service.ts
+++ b/services/gateway/src/services/intent-cover-service.ts
@@ -45,12 +45,21 @@ export type CoverTheme =
 
 export type Gender = 'male' | 'female' | null;
 
-export type CoverSource = 'user_upload' | 'ai_generated' | 'fallback_curated';
+export type CoverSource =
+  | 'user_upload'
+  | 'user_library'
+  | 'user_universal'
+  | 'ai_generated'
+  | 'fallback_curated';
 
 export interface GenerateCoverArgs {
   intentId: string;
   userId: string;
-  theme: CoverTheme;
+  /**
+   * Theme to use for the AI prompt. Optional — when omitted the service
+   * derives it from the intent's category via `themeFromCategory`.
+   */
+  theme?: CoverTheme;
   /**
    * Foreground subject gender. When omitted we look it up from
    * `profiles.gender` so the centered person matches the requesting user.
@@ -371,6 +380,56 @@ async function getUserGenderFromProfile(userId: string): Promise<Gender> {
   }
 }
 
+/**
+ * Look up the user's universal cover photo — a single image they
+ * uploaded once in their profile, used as the second-line fallback
+ * before AI generation. Lets users avoid AI-generated covers entirely.
+ */
+async function getUserUniversalCover(userId: string): Promise<string | null> {
+  try {
+    const supabase = getSupabase();
+    const { data } = await supabase
+      .from('profiles')
+      .select('universal_intent_cover_url')
+      .eq('user_id', userId)
+      .maybeSingle();
+    const raw = (data as { universal_intent_cover_url?: string | null } | null)
+      ?.universal_intent_cover_url;
+    return typeof raw === 'string' && raw.length > 0 ? raw : null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * Pick a cover URL from the user's category-tagged library. We look
+ * for an exact-match category (no fuzzy / parent-bucket fallback —
+ * a tennis photo is never substituted for a jogging post). When
+ * several rows match, the choice is deterministic per intent so the
+ * same intent always renders the same image.
+ */
+async function getUserLibraryCoverForCategory(
+  userId: string,
+  category: string | null,
+  intentId: string,
+): Promise<string | null> {
+  if (!category) return null;
+  try {
+    const supabase = getSupabase();
+    const { data } = await supabase
+      .from('user_intent_cover_library')
+      .select('cover_url')
+      .eq('user_id', userId)
+      .eq('category', category);
+    const rows = (data ?? []) as { cover_url: string }[];
+    if (rows.length === 0) return null;
+    const idx = createHash('sha256').update(intentId).digest()[0] % rows.length;
+    return rows[idx].cover_url;
+  } catch {
+    return null;
+  }
+}
+
 async function checkRateLimit(userId: string): Promise<void> {
   if (RATE_LIMIT_PER_DAY <= 0) return; // disabled.
   const supabase = getSupabase();
@@ -412,10 +471,12 @@ async function persistCover(args: {
 /**
  * Idempotent cover-photo generator.
  *
- * Resolution order:
+ * Resolution order (top wins, never substitutes across categories):
  *   1. cache hit (cover_url already set) and !force → return it.
- *   2. AI generation via OpenAI Images, uploaded to Supabase Storage.
- *   3. Curated fallback library (server-shipped JPGs).
+ *   2. user library: an exact-category-tagged photo the user uploaded.
+ *   3. user universal: a single fallback photo on the user's profile.
+ *   4. AI generation (gender-aware Vertex Imagen).
+ *   5. Curated server-shipped fallback library (JPG).
  *
  * Throws CoverGenError for the route layer to map to HTTP statuses.
  * Never throws for "fallback used" — that's a successful result with
@@ -428,7 +489,7 @@ export async function generateCoverForIntent(
 
   const { data: intent, error } = await supabase
     .from('user_intents')
-    .select('intent_id, requester_user_id, cover_url')
+    .select('intent_id, requester_user_id, cover_url, cover_source, category')
     .eq('intent_id', args.intentId)
     .maybeSingle();
   if (error) throw new CoverGenError('storage_failed', error.message);
@@ -437,11 +498,56 @@ export async function generateCoverForIntent(
     throw new CoverGenError('forbidden', 'intent_not_owned_by_caller');
   }
 
-  const existing = (intent as { cover_url: string | null }).cover_url;
+  const intentRow = intent as {
+    cover_url: string | null;
+    cover_source: CoverSource | null;
+    category: string | null;
+  };
+
+  const existing = intentRow.cover_url;
   if (existing && !args.force) {
-    return { cover_url: existing, source: 'ai_generated', cached: true };
+    return {
+      cover_url: existing,
+      source: intentRow.cover_source ?? 'ai_generated',
+      cached: true,
+    };
   }
 
+  const category = intentRow.category;
+  const theme: CoverTheme = args.theme ?? themeFromCategory(category);
+
+  // 2. User library — exact-category match wins. No rate-limit; this
+  //    path doesn't generate, it reuses bytes the user already uploaded.
+  const libraryUrl = await getUserLibraryCoverForCategory(
+    args.userId,
+    category,
+    args.intentId,
+  );
+  if (libraryUrl) {
+    await persistCover({
+      intentId: args.intentId,
+      userId: args.userId,
+      url: libraryUrl,
+      source: 'user_library',
+    });
+    return { cover_url: libraryUrl, source: 'user_library', cached: false };
+  }
+
+  // 3. User universal — single fallback on the profile. Same story:
+  //    no generation, just reuse, so no rate-limit.
+  const universalUrl = await getUserUniversalCover(args.userId);
+  if (universalUrl) {
+    await persistCover({
+      intentId: args.intentId,
+      userId: args.userId,
+      url: universalUrl,
+      source: 'user_universal',
+    });
+    return { cover_url: universalUrl, source: 'user_universal', cached: false };
+  }
+
+  // 4. AI generation. The rate-limit only gates this path — library +
+  //    universal hits above are free to repeat.
   await checkRateLimit(args.userId);
 
   // Resolve the foreground subject's gender. Caller-provided wins;
@@ -456,7 +562,7 @@ export async function generateCoverForIntent(
   // can disable the call by setting INTENT_COVER_DRY_RUN=true.
   if (!DRY_RUN) {
     try {
-      const bytes = await generateAiCover(args.theme, gender);
+      const bytes = await generateAiCover(theme, gender);
       const url = await uploadAiCover({ intentId: args.intentId, bytes });
       await persistCover({
         intentId: args.intentId,
@@ -471,8 +577,8 @@ export async function generateCoverForIntent(
     }
   }
 
-  // Fallback path.
-  const url = await uploadFallbackCover({ intentId: args.intentId, theme: args.theme });
+  // 5. Curated fallback.
+  const url = await uploadFallbackCover({ intentId: args.intentId, theme });
   await persistCover({
     intentId: args.intentId,
     userId: args.userId,

--- a/services/gateway/test/intent-cover-service.test.ts
+++ b/services/gateway/test/intent-cover-service.test.ts
@@ -1,14 +1,15 @@
 /**
- * BOOTSTRAP-INTENT-COVER-GEN — unit tests for intent-cover-service.
+ * Unit tests for intent-cover-service.
  *
  * Mocks Supabase, GoogleAuth, and the global `fetch` so the suite
- * exercises:
- *   - cache hit (existing cover_url short-circuits)
- *   - rate-limit (>= configured cap returns 'rate_limited')
- *   - ownership check
- *   - AI happy path (Vertex Imagen OK → upload OK → persist OK)
- *   - AI failure → curated-fallback path (still resolves)
- *   - DRY_RUN env flag goes straight to fallback without touching Vertex
+ * exercises the full resolution chain:
+ *   1. cache hit (existing cover_url short-circuits)
+ *   2. user_library — exact-category-tagged photo from profile library
+ *   3. user_universal — single fallback photo on profile
+ *   4. AI generation (gender-aware Vertex Imagen)
+ *   5. fallback_curated — server-shipped JPGs when AI fails
+ *
+ * Plus: ownership check, rate-limit (only on the AI path), DRY_RUN.
  */
 
 const supabaseMock = {
@@ -29,11 +30,9 @@ jest.mock('google-auth-library', () => {
   };
 });
 
-// Stand-in for the global fetch the service calls against Vertex.
 const vertexFetch = jest.fn();
 (global as { fetch: typeof fetch }).fetch = vertexFetch as unknown as typeof fetch;
 
-// Stub fs.readFile so the fallback path doesn't need real files on disk.
 jest.mock('node:fs', () => {
   const real = jest.requireActual('node:fs');
   return {
@@ -45,7 +44,6 @@ jest.mock('node:fs', () => {
   };
 });
 
-// Helper: chainable supabase.from(...) builder.
 type Stub = Record<string, jest.Mock>;
 function chain(returns: { data?: unknown; error?: unknown; count?: number } = {}): Stub {
   const stub: Stub = {
@@ -57,10 +55,24 @@ function chain(returns: { data?: unknown; error?: unknown; count?: number } = {}
     gte: jest.fn(() => stub),
     maybeSingle: jest.fn(async () => returns),
     single: jest.fn(async () => returns),
+    // For library lookup: the chain ends with .eq() returning a thenable
+    // result. The test rig resolves the chain via maybeSingle / single
+    // for single-row queries; for the library case the service awaits the
+    // chain itself, which is implemented via the `then` shim below.
     then: undefined as unknown as jest.Mock,
   };
-  // Supabase counts use { count, head } in select(); the test relies on the
-  // `count` property when rate-limit checks read it.
+  // For multi-row queries (library lookup): the service does
+  //   await supabase.from(...).select(...).eq(...).eq(...)
+  // i.e. awaits the chain directly. Make the chain awaitable.
+  if (returns.data !== undefined && Array.isArray(returns.data)) {
+    (stub.eq as jest.Mock).mockImplementation(() => {
+      const inner: Stub = {
+        ...stub,
+        eq: jest.fn(async () => returns),
+      };
+      return inner;
+    });
+  }
   if (returns.count !== undefined) {
     (stub as unknown as { count: number }).count = returns.count;
     (stub.select as jest.Mock).mockImplementation(() => ({
@@ -95,21 +107,48 @@ beforeEach(() => {
   process.env.INTENT_COVER_RATE_LIMIT_PER_DAY = '10';
 });
 
+// Standard mock-chain order for the AI path (no library, no universal):
+//   1. intent fetch
+//   2. library lookup        (empty array)
+//   3. universal lookup      (null)
+//   4. rate-limit count
+//   5. gender lookup
+//   6. persistCover update
+
 describe('generateCoverForIntent', () => {
   it('returns cached cover_url when one is already set and force is not requested', async () => {
-    supabaseMock.from
-      .mockReturnValueOnce(
-        chain({ data: { intent_id: 'i1', requester_user_id: 'u1', cover_url: 'https://x/y.png' } }),
-      );
+    supabaseMock.from.mockReturnValueOnce(
+      chain({
+        data: {
+          intent_id: 'i1',
+          requester_user_id: 'u1',
+          cover_url: 'https://x/y.png',
+          cover_source: 'user_library',
+          category: 'sport.tennis',
+        },
+      }),
+    );
     const { generateCoverForIntent } = await import('../src/services/intent-cover-service');
     const out = await generateCoverForIntent({ intentId: 'i1', userId: 'u1', theme: 'dance' });
-    expect(out).toEqual({ cover_url: 'https://x/y.png', source: 'ai_generated', cached: true });
+    expect(out).toEqual({
+      cover_url: 'https://x/y.png',
+      source: 'user_library',
+      cached: true,
+    });
     expect(vertexFetch).not.toHaveBeenCalled();
   });
 
   it('rejects when caller is not the intent owner', async () => {
     supabaseMock.from.mockReturnValueOnce(
-      chain({ data: { intent_id: 'i1', requester_user_id: 'someone-else', cover_url: null } }),
+      chain({
+        data: {
+          intent_id: 'i1',
+          requester_user_id: 'someone-else',
+          cover_url: null,
+          cover_source: null,
+          category: 'dance.salsa',
+        },
+      }),
     );
     const { generateCoverForIntent, CoverGenError } = await import(
       '../src/services/intent-cover-service'
@@ -119,30 +158,121 @@ describe('generateCoverForIntent', () => {
     ).rejects.toBeInstanceOf(CoverGenError);
   });
 
-  it('rate-limits when >= configured generations in last 24h', async () => {
+  it('user_library: returns the user-uploaded category-tagged photo without calling Vertex', async () => {
     supabaseMock.from
-      // intent fetch
-      .mockReturnValueOnce(chain({ data: { intent_id: 'i1', requester_user_id: 'u1', cover_url: null } }))
-      // rate-limit count
+      // intent
+      .mockReturnValueOnce(
+        chain({
+          data: {
+            intent_id: 'i1',
+            requester_user_id: 'u1',
+            cover_url: null,
+            cover_source: null,
+            category: 'sport.tennis',
+          },
+        }),
+      )
+      // library lookup — one match
+      .mockReturnValueOnce(
+        chain({ data: [{ cover_url: 'https://lib.example/tennis.jpg' }] }),
+      )
+      // persistCover update
+      .mockReturnValueOnce(chain({ data: null, error: null }));
+
+    const { generateCoverForIntent } = await import('../src/services/intent-cover-service');
+    const out = await generateCoverForIntent({
+      intentId: 'i1',
+      userId: 'u1',
+      theme: 'tennis',
+      force: true,
+    });
+    expect(out).toEqual({
+      cover_url: 'https://lib.example/tennis.jpg',
+      source: 'user_library',
+      cached: false,
+    });
+    expect(vertexFetch).not.toHaveBeenCalled();
+  });
+
+  it('user_universal: when no library match, uses the profile universal photo', async () => {
+    supabaseMock.from
+      .mockReturnValueOnce(
+        chain({
+          data: {
+            intent_id: 'i1',
+            requester_user_id: 'u1',
+            cover_url: null,
+            cover_source: null,
+            category: 'food.cooking_class',
+          },
+        }),
+      )
+      // library lookup — no match
+      .mockReturnValueOnce(chain({ data: [] }))
+      // universal lookup — set
+      .mockReturnValueOnce(chain({ data: { universal_intent_cover_url: 'https://prof.example/me.jpg' } }))
+      // persistCover update
+      .mockReturnValueOnce(chain({ data: null, error: null }));
+
+    const { generateCoverForIntent } = await import('../src/services/intent-cover-service');
+    const out = await generateCoverForIntent({
+      intentId: 'i1',
+      userId: 'u1',
+      theme: 'cooking',
+      force: true,
+    });
+    expect(out).toEqual({
+      cover_url: 'https://prof.example/me.jpg',
+      source: 'user_universal',
+      cached: false,
+    });
+    expect(vertexFetch).not.toHaveBeenCalled();
+  });
+
+  it('rate-limits when >= configured generations in last 24h (only on AI path)', async () => {
+    supabaseMock.from
+      .mockReturnValueOnce(
+        chain({
+          data: {
+            intent_id: 'i1',
+            requester_user_id: 'u1',
+            cover_url: null,
+            cover_source: null,
+            category: 'fitness.gym',
+          },
+        }),
+      )
+      // library — empty
+      .mockReturnValueOnce(chain({ data: [] }))
+      // universal — null
+      .mockReturnValueOnce(chain({ data: { universal_intent_cover_url: null } }))
+      // rate-limit count — over the cap
       .mockReturnValueOnce(chain({ count: 10 }));
-    const { generateCoverForIntent, CoverGenError } = await import(
-      '../src/services/intent-cover-service'
-    );
+    const { generateCoverForIntent } = await import('../src/services/intent-cover-service');
     await expect(
       generateCoverForIntent({ intentId: 'i1', userId: 'u1', theme: 'fitness' }),
     ).rejects.toMatchObject({ code: 'rate_limited' });
-    expect(CoverGenError).toBeDefined();
   });
 
-  it('falls back to curated library when DRY_RUN is set', async () => {
+  it('falls back to curated library when DRY_RUN is set (no library, no universal)', async () => {
     process.env.INTENT_COVER_DRY_RUN = 'true';
     supabaseMock.from
-      .mockReturnValueOnce(chain({ data: { intent_id: 'i1', requester_user_id: 'u1', cover_url: null } }))
-      .mockReturnValueOnce(chain({ count: 0 }))
-      // profile gender lookup
-      .mockReturnValueOnce(chain({ data: { gender: 'female' } }))
-      // persistCover update
-      .mockReturnValueOnce(chain({ data: null, error: null }));
+      .mockReturnValueOnce(
+        chain({
+          data: {
+            intent_id: 'i1',
+            requester_user_id: 'u1',
+            cover_url: null,
+            cover_source: null,
+            category: 'fitness.gym',
+          },
+        }),
+      )
+      .mockReturnValueOnce(chain({ data: [] })) // library
+      .mockReturnValueOnce(chain({ data: { universal_intent_cover_url: null } })) // universal
+      .mockReturnValueOnce(chain({ count: 0 })) // rate-limit
+      .mockReturnValueOnce(chain({ data: { gender: 'female' } })) // gender
+      .mockReturnValueOnce(chain({ data: null, error: null })); // persist
     supabaseMock.storage.from.mockReturnValue(
       storageStub({ publicUrl: 'https://files.example/fallback.jpg' }),
     );
@@ -155,10 +285,22 @@ describe('generateCoverForIntent', () => {
 
   it('AI happy path: provider returns image, uploads to storage, persists URL', async () => {
     supabaseMock.from
-      .mockReturnValueOnce(chain({ data: { intent_id: 'i1', requester_user_id: 'u1', cover_url: null } }))
-      .mockReturnValueOnce(chain({ count: 0 }))
-      .mockReturnValueOnce(chain({ data: { gender: 'male' } }))
-      .mockReturnValueOnce(chain({ data: null, error: null }));
+      .mockReturnValueOnce(
+        chain({
+          data: {
+            intent_id: 'i1',
+            requester_user_id: 'u1',
+            cover_url: null,
+            cover_source: null,
+            category: 'dance.salsa',
+          },
+        }),
+      )
+      .mockReturnValueOnce(chain({ data: [] })) // library
+      .mockReturnValueOnce(chain({ data: { universal_intent_cover_url: null } })) // universal
+      .mockReturnValueOnce(chain({ count: 0 })) // rate-limit
+      .mockReturnValueOnce(chain({ data: { gender: 'male' } })) // gender
+      .mockReturnValueOnce(chain({ data: null, error: null })); // persist
     supabaseMock.storage.from.mockReturnValue(
       storageStub({ publicUrl: 'https://files.example/ai.png' }),
     );
@@ -173,10 +315,12 @@ describe('generateCoverForIntent', () => {
     } as unknown as Response);
     const { generateCoverForIntent } = await import('../src/services/intent-cover-service');
     const out = await generateCoverForIntent({ intentId: 'i1', userId: 'u1', theme: 'dance' });
-    expect(out).toEqual({ cover_url: 'https://files.example/ai.png', source: 'ai_generated', cached: false });
+    expect(out).toEqual({
+      cover_url: 'https://files.example/ai.png',
+      source: 'ai_generated',
+      cached: false,
+    });
     expect(vertexFetch).toHaveBeenCalledTimes(1);
-
-    // The Imagen prompt must reflect the requester's gender.
     const sentBody = JSON.parse(vertexFetch.mock.calls[0][1].body) as {
       instances: { prompt: string }[];
     };
@@ -186,7 +330,19 @@ describe('generateCoverForIntent', () => {
 
   it('AI failure → curated fallback (still resolves with success)', async () => {
     supabaseMock.from
-      .mockReturnValueOnce(chain({ data: { intent_id: 'i1', requester_user_id: 'u1', cover_url: null } }))
+      .mockReturnValueOnce(
+        chain({
+          data: {
+            intent_id: 'i1',
+            requester_user_id: 'u1',
+            cover_url: null,
+            cover_source: null,
+            category: 'dance.salsa',
+          },
+        }),
+      )
+      .mockReturnValueOnce(chain({ data: [] }))
+      .mockReturnValueOnce(chain({ data: { universal_intent_cover_url: null } }))
       .mockReturnValueOnce(chain({ count: 0 }))
       .mockReturnValueOnce(chain({ data: { gender: null } }))
       .mockReturnValueOnce(chain({ data: null, error: null }));
@@ -206,10 +362,23 @@ describe('generateCoverForIntent', () => {
 
   it('skips the profile gender lookup when caller passes gender explicitly', async () => {
     supabaseMock.from
-      .mockReturnValueOnce(chain({ data: { intent_id: 'i1', requester_user_id: 'u1', cover_url: null } }))
-      .mockReturnValueOnce(chain({ count: 0 }))
-      // No profile chain — caller passes gender, so the service must NOT look it up.
-      .mockReturnValueOnce(chain({ data: null, error: null }));
+      .mockReturnValueOnce(
+        chain({
+          data: {
+            intent_id: 'i1',
+            requester_user_id: 'u1',
+            cover_url: null,
+            cover_source: null,
+            category: 'sport.tennis',
+          },
+        }),
+      )
+      .mockReturnValueOnce(chain({ data: [] })) // library
+      .mockReturnValueOnce(chain({ data: { universal_intent_cover_url: null } })) // universal
+      .mockReturnValueOnce(chain({ count: 0 })) // rate-limit
+      // No gender lookup mocked — caller passed gender, the service must
+      // not hit profiles for gender.
+      .mockReturnValueOnce(chain({ data: null, error: null })); // persist
     supabaseMock.storage.from.mockReturnValue(
       storageStub({ publicUrl: 'https://files.example/ai.png' }),
     );
@@ -234,11 +403,8 @@ describe('generateCoverForIntent', () => {
     };
     expect(sentBody.instances[0].prompt).toMatch(/one smiling woman/i);
     expect(sentBody.instances[0].prompt).toMatch(/tennis/i);
-    // Caller passed gender — the test only mocked 3 supabase.from chains
-    // (intent, rate-limit, persist). If we erroneously called profiles
-    // lookup, persist would silently get the wrong stub; the upload
-    // assertion on vertexFetch above is what guarantees we got there.
-    expect(supabaseMock.from).toHaveBeenCalledTimes(3);
+    // 5 chains: intent, library, universal, rate-limit, persist.
+    expect(supabaseMock.from).toHaveBeenCalledTimes(5);
   });
 });
 
@@ -303,7 +469,6 @@ describe('buildCoverPrompt', () => {
     for (const t of themes) {
       const p = buildCoverPrompt(t, null);
       expect(p.length).toBeGreaterThan(120);
-      // Realism + no-cartoon guarantee shared across every theme.
       expect(p).toMatch(/photorealistic/i);
       expect(p).toMatch(/not a cartoon/i);
     }

--- a/supabase/migrations/20260513000000_VTID_02806_intent_cover_library.sql
+++ b/supabase/migrations/20260513000000_VTID_02806_intent_cover_library.sql
@@ -1,0 +1,68 @@
+-- VTID-02806 — User Cover-Photo Library + Universal Image
+--
+-- Adds two new resolution layers between the existing user_upload and
+-- ai_generated paths in the Find-a-Match cover-photo chain:
+--   2. user_intent_cover_library — multiple activity-tagged photos per user.
+--   3. profiles.universal_intent_cover_url — single fallback image used
+--      when no library row matches the intent's category. Typically a
+--      portrait of the user; lets them avoid AI-generated covers entirely.
+--
+-- Resolution chain (top wins):
+--   1. user_upload      (kind_payload.cover_url at insert)
+--   2. user_library     (this migration)
+--   3. user_universal   (this migration)
+--   4. ai_generated     (existing, becomes gender-aware via gateway change)
+--   5. fallback_curated (existing)
+
+-- 1. Universal image column on profiles -------------------------------------
+
+ALTER TABLE profiles
+  ADD COLUMN IF NOT EXISTS universal_intent_cover_url TEXT NULL;
+
+COMMENT ON COLUMN profiles.universal_intent_cover_url IS
+  'Single fallback cover photo used when no entry in user_intent_cover_library matches an intent''s category. Typically a portrait of the user; lets them avoid AI-generated covers.';
+
+-- 2. New library table ------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS user_intent_cover_library (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  user_id      UUID NOT NULL REFERENCES auth.users(id) ON DELETE CASCADE,
+  category     TEXT NOT NULL,
+  cover_url    TEXT NOT NULL,
+  created_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at   TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE user_intent_cover_library IS
+  'Per-user library of activity-tagged cover photos. The gateway picks one matching the intent''s category at cover-resolution time.';
+COMMENT ON COLUMN user_intent_cover_library.category IS
+  'Dotted intent category, e.g. sport.tennis or dance.social_partner. Matches user_intents.category exactly (no fuzzy or parent-bucket fallback).';
+
+CREATE INDEX IF NOT EXISTS idx_uicl_user_category
+  ON user_intent_cover_library (user_id, category);
+
+ALTER TABLE user_intent_cover_library ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS uicl_self_read   ON user_intent_cover_library;
+DROP POLICY IF EXISTS uicl_self_insert ON user_intent_cover_library;
+DROP POLICY IF EXISTS uicl_self_update ON user_intent_cover_library;
+DROP POLICY IF EXISTS uicl_self_delete ON user_intent_cover_library;
+
+CREATE POLICY uicl_self_read   ON user_intent_cover_library FOR SELECT USING (user_id = auth.uid());
+CREATE POLICY uicl_self_insert ON user_intent_cover_library FOR INSERT WITH CHECK (user_id = auth.uid());
+CREATE POLICY uicl_self_update ON user_intent_cover_library FOR UPDATE USING (user_id = auth.uid());
+CREATE POLICY uicl_self_delete ON user_intent_cover_library FOR DELETE USING (user_id = auth.uid());
+
+-- 3. Expand user_intents.cover_source CHECK ---------------------------------
+-- Existing values: user_upload | ai_generated | fallback_curated
+-- New values:      user_library | user_universal
+
+ALTER TABLE user_intents DROP CONSTRAINT IF EXISTS user_intents_cover_source_check;
+ALTER TABLE user_intents ADD CONSTRAINT user_intents_cover_source_check
+  CHECK (cover_source IS NULL OR cover_source IN (
+    'user_upload',
+    'ai_generated',
+    'fallback_curated',
+    'user_library',
+    'user_universal'
+  ));


### PR DESCRIPTION
## Summary

- Adds two new resolution layers between `user_upload` and `ai_generated` so users can avoid AI-generated covers entirely:
  - **`user_library`** — multiple activity-tagged photos uploaded once in the profile; gateway picks the exact-category match per intent
  - **`user_universal`** — single fallback image on the profile (typically a portrait); used when no library row matches the intent's category
- Hard rule: **never substitute across categories** (a tennis photo is never used for a jogging post)
- AI path remains gender-aware (already on `main`); library/universal hits are free of the rate-limit
- Cache-hit return path now reports the actual `cover_source` instead of always `ai_generated`

## Resolution chain (top wins)

| # | Source | Trigger |
|---|---|---|
| 1 | `user_upload` | `kind_payload.cover_url` at insert |
| 2 | `user_library` | matching `category` row in `user_intent_cover_library` |
| 3 | `user_universal` | `profiles.universal_intent_cover_url` is set |
| 4 | `ai_generated` | gender-aware Vertex Imagen |
| 5 | `fallback_curated` | AI failure → server-shipped JPG |

## Schema

Migration `supabase/migrations/20260513000000_VTID_02806_intent_cover_library.sql`:

- `profiles.universal_intent_cover_url TEXT NULL`
- new table `user_intent_cover_library` with RLS (`user_id = auth.uid()` for select/insert/update/delete) + index on `(user_id, category)`
- `user_intents.cover_source` CHECK expanded to include `user_library` and `user_universal`

Idempotent — every DDL guarded with IF NOT EXISTS / DROP CONSTRAINT IF EXISTS. Apply via Run SQL Migration workflow.

## Tests

13 cases in `services/gateway/test/intent-cover-service.test.ts`, all passing locally:
- 4 new: `user_library` hit, `user_universal` on library miss, accurate `cover_source` on cache hit, rate-limit only on AI path
- Existing AI happy/failure/DRY_RUN tests updated for the new mock chain (intent → library → universal → rate-limit → gender → persist)

## Test plan

- [ ] Apply migration via `Run SQL Migration` workflow
- [ ] Verify schema (new column, table, expanded CHECK, RLS policies present)
- [ ] After deploy: insert a library row + create an intent in matching category — confirm `cover_source='user_library'`
- [ ] Set `profiles.universal_intent_cover_url` + create intent in a non-tagged category — confirm `cover_source='user_universal'`
- [ ] Empty profile → create intent → confirm `cover_source='ai_generated'`, prompt is gender-aware

## Frontend (separate PR)

vitana-v1 PR ships the Cover Library drawer, the IntentComposer miss banner, and removes the deterministic "Generate for me" stock-picker. Lands after this PR + migration are deployed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
