### PR TITLE
fix(voice-lab): make /api/v1/voice-lab/health public (VTID-VOICE-LAB-HEALTH-PUBLIC)

### DIFF
--- a/services/gateway/src/routes/voice-lab.ts
+++ b/services/gateway/src/routes/voice-lab.ts
@@ -30,16 +30,17 @@ import {
 
 const router = Router();
 
-// VTID-VOICE-LAB-HEALTH-PUBLIC: register `/health` BEFORE `requireAuth` so
-// uptime probes (and the self-healing analyzer's synthetic monitor) can
-// hit it without a Bearer token. Without this, every probe came back 401,
-// the analyzer misclassified the 401 as `import_error`, and a fresh
-// VTID-027xx self-heal failure event was logged on every check —
-// ~20 false-positive VTIDs (02756 → 02801) accumulated over 2 days
-// before the cause was traced. The `// public-route` comment near
-// the duplicate `router.get('/health')` registration further down was a
-// hint that this was always intended to be public; gating it under
-// `router.use(requireAuth)` was the bug.
+// VTID-VOICE-LAB-HEALTH-PUBLIC: register the health endpoint BEFORE
+// `requireAuth` so uptime probes (and the self-healing analyzer's
+// synthetic monitor) can hit it without a Bearer token. Without this,
+// every probe came back 401, the analyzer misclassified the 401 as
+// `import_error`, and a fresh VTID-027xx self-heal failure event was
+// logged on every check — ~20 false-positive VTIDs (02756 → 02801)
+// accumulated over 2 days before the cause was traced. The duplicate
+// registration that used to live near the bottom of this file with a
+// `public-route` marker comment was always intended to be public;
+// gating it under `requireAuth` was the bug. That now-shadowed
+// duplicate has been removed.
 router.get('/health', (_req: Request, res: Response) => {
   return res.json({
     ok: true,

--- a/services/gateway/src/routes/voice-lab.ts
+++ b/services/gateway/src/routes/voice-lab.ts
@@ -30,6 +30,25 @@ import {
 
 const router = Router();
 
+// VTID-VOICE-LAB-HEALTH-PUBLIC: register `/health` BEFORE `requireAuth` so
+// uptime probes (and the self-healing analyzer's synthetic monitor) can
+// hit it without a Bearer token. Without this, every probe came back 401,
+// the analyzer misclassified the 401 as `import_error`, and a fresh
+// VTID-027xx self-heal failure event was logged on every check —
+// ~20 false-positive VTIDs (02756 → 02801) accumulated over 2 days
+// before the cause was traced. The `// public-route` comment near
+// the duplicate `router.get('/health')` registration further down was a
+// hint that this was always intended to be public; gating it under
+// `router.use(requireAuth)` was the bug.
+router.get('/health', (_req: Request, res: Response) => {
+  return res.json({
+    ok: true,
+    service: 'voice-lab',
+    vtid: 'VTID-01218A',
+    timestamp: new Date().toISOString(),
+  });
+});
+
 router.use(requireAuth);
 
 // =============================================================================
@@ -1235,20 +1254,10 @@ router.get('/healing/live-monitor', async (_req: Request, res: Response) => {
   }
 });
 
-/**
- * GET /api/v1/voice-lab/health
- *
- * Health check for Voice LAB API
- */
-// public-route
-router.get('/health', (_req: Request, res: Response) => {
-  return res.json({
-    ok: true,
-    service: 'voice-lab',
-    vtid: 'VTID-01218A',
-    timestamp: new Date().toISOString(),
-  });
-});
+// `/health` is registered above `router.use(requireAuth)` near the top of
+// this file (VTID-VOICE-LAB-HEALTH-PUBLIC) so uptime monitors hit it
+// without auth. The duplicate registration that used to live here was
+// shadowed by the earlier one and is removed.
 
 /**
  * GET /api/v1/voice-lab/debug/events


### PR DESCRIPTION
## Summary

\`/api/v1/voice-lab/health\` was registered AFTER \`router.use(requireAuth)\`, so every probe returned **401 UNAUTHENTICATED**. The self-healing analyzer misclassified the 401 as \`import_error\` with a fabricated diagnosis (\"route file does not exist on disk\" — file is 46k bytes on main), and a new VTID-027xx self-heal failure event fired on every probe.

**Symptom**: ~20 false-positive VTIDs accumulated over 2 days:
\`\`\`
VTID-02756 2026-05-05 12:07
VTID-02769 2026-05-05 13:59
VTID-02786 2026-05-05 18:20
... [16 more] ...
VTID-02801 2026-05-07 01:43
\`\`\`

The autopilot couldn't auto-fix this because:
1. Its diagnosis was wrong (file doesn't exist → recreate it)
2. Any plan touching surrounding code exceeded scope and failed the safety gate
3. After [VTID-AUTOPILOT-SAFETY-SPIN (#1854)](https://github.com/exafyltd/vitana-platform/pull/1854), the recommendation got snoozed without actually fixing production

## Fix

Register \`/health\` **before** \`router.use(requireAuth)\` near the top of the file. Drop the now-shadowed duplicate registration at the bottom (which had a \`// public-route\` comment — that intent was always there; the gating was the bug).

## Test plan

- [x] \`npm run build\` clean
- [ ] After deploy: \`curl https://gateway-q74ibpv6ia-uc.a.run.app/api/v1/voice-lab/health\` returns HTTP 200 with \`{ok:true,service:\"voice-lab\",...}\` (no Bearer token)
- [ ] Self-healing analyzer stops emitting new VTID-027xx \`import_error\` events on this endpoint
- [ ] All other voice-lab routes still 401 without auth (auth gate still applied to everything except \`/health\`)

🤖 Generated with [Claude Code](https://claude.com/claude-code)