### PR TITLE
refactor(VTID-02813): PR B-3 — lift recall_conversation_at_time to shared

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -4285,40 +4285,28 @@ async function executeLiveApiToolInner(
   try {
     switch (toolName) {
       case 'recall_conversation_at_time': {
-        // VTID-02052: voice/Live-API path for the recall tool. Without this case,
-        // an iPhone user asking "when did we talk about X" hits the default
-        // "Unknown tool" branch and the upstream Live API WS closes — the
-        // user sees "internet issues" on the device.
-        try {
-          const { executeRecallConversationAtTime } = await import(
-            '../services/tool-recall-conversation'
-          );
-          const recall = await executeRecallConversationAtTime(
-            args as { time_hint: string; topic_hint?: string },
-            {
-              user_id: session.identity.user_id,
-              user_timezone:
-                (session as any)?.clientContext?.timezone || undefined,
-            },
-          );
-          // The Live API expects a JSON string; cap to keep the function
-          // response payload safely under the 4 KB stall threshold.
-          const payload = JSON.stringify(recall);
-          const MAX = 4000;
-          const result = payload.length > MAX ? payload.slice(0, MAX) + '...(truncated)' : payload;
-          return {
-            success: !!recall.ok,
-            result: recall.ok ? result : '',
-            error: recall.ok ? undefined : recall.error || 'recall_failed',
-          };
-        } catch (err: any) {
-          console.error('[VTID-02052] recall_conversation_at_time failed:', err?.message);
-          return {
-            success: false,
-            result: '',
-            error: err?.message || 'recall_exception',
-          };
+        // PR B-3: lifted to services/orb-tools-shared.ts. Both pipelines now
+        // call executeRecallConversationAtTime through the shared dispatcher.
+        // Pass user_timezone via args so the lifted handler can use it.
+        const SUPABASE_URL = process.env.SUPABASE_URL;
+        const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
+        if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
+          return { success: false, result: '', error: 'Service unavailable — Supabase creds not configured' };
         }
+        const { createClient } = await import('@supabase/supabase-js');
+        const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
+        const { dispatchOrbToolForVertex } = await import('../services/orb-tools-shared');
+        const tz = (session as any)?.clientContext?.timezone;
+        return await dispatchOrbToolForVertex(
+          'recall_conversation_at_time',
+          { ...(args ?? {}), user_timezone: tz },
+          {
+            user_id: lens.user_id,
+            tenant_id: lens.tenant_id ?? null,
+            role: session.identity?.role ?? null,
+          },
+          supabase,
+        );
       }
 
       case 'search_memory': {

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -101,45 +101,39 @@ export async function tool_search_web(args: OrbToolArgs): Promise<OrbToolResult>
 export async function tool_recall_conversation_at_time(
   args: OrbToolArgs,
   id: OrbToolIdentity,
-  sb: SupabaseClient,
+  _sb: SupabaseClient,
 ): Promise<OrbToolResult> {
-  const when = String(args.when ?? '').trim();
-  const lower = when.toLowerCase();
-  const now = new Date();
-  let from = new Date(now.getTime() - 86400000);
-  let to = now;
-  if (/yesterday/.test(lower)) {
-    const y = new Date(now.getTime() - 86400000);
-    y.setHours(0, 0, 0, 0);
-    from = y;
-    to = new Date(y.getTime() + 86400000);
-  } else if (/two days ago|day before yesterday/.test(lower)) {
-    const d = new Date(now.getTime() - 2 * 86400000);
-    d.setHours(0, 0, 0, 0);
-    from = d;
-    to = new Date(d.getTime() + 86400000);
-  } else if (/last week/.test(lower)) {
-    from = new Date(now.getTime() - 7 * 86400000);
+  // Lifted from orb-live.ts:4287 (PR B-3 of the lift-not-duplicate refactor).
+  // Both pipelines now call services/tool-recall-conversation through the
+  // shared dispatcher. Accepts both `time_hint` (Vertex's canonical) and
+  // legacy `when` (the prior LiveKit Python tool key).
+  const time_hint = String(args.time_hint ?? args.when ?? '').trim();
+  if (!time_hint) {
+    return { ok: false, error: 'time_hint is required' };
   }
-  const { data } = await sb
-    .from('ai_messages')
-    .select('id, role, content, created_at')
-    .eq('user_id', id.user_id)
-    .gte('created_at', from.toISOString())
-    .lte('created_at', to.toISOString())
-    .order('created_at', { ascending: true })
-    .limit(50);
-  return {
-    ok: true,
-    result: {
-      window: { from: from.toISOString(), to: to.toISOString() },
-      turns: (data || []).map((m) => ({
-        role: m.role,
-        text: String(m.content ?? '').slice(0, 300),
-        when: m.created_at,
-      })),
-    },
-  };
+  const topic_hint = typeof args.topic_hint === 'string' ? args.topic_hint : undefined;
+
+  const userTimezone =
+    typeof args.user_timezone === 'string' ? (args.user_timezone as string) : undefined;
+
+  try {
+    const { executeRecallConversationAtTime } = await import('./tool-recall-conversation');
+    const recall = await executeRecallConversationAtTime(
+      { time_hint, topic_hint },
+      { user_id: id.user_id, user_timezone: userTimezone },
+    );
+    if (!recall.ok) {
+      return { ok: false, error: recall.error || 'recall_failed' };
+    }
+    // Cap payload to keep below the 4 KB function-response stall threshold.
+    const payload = JSON.stringify(recall);
+    const MAX = 4000;
+    const text = payload.length > MAX ? payload.slice(0, MAX) + '...(truncated)' : payload;
+    return { ok: true, result: recall, text };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'recall_exception';
+    return { ok: false, error: msg };
+  }
 }
 
 export async function tool_switch_persona(args: OrbToolArgs): Promise<OrbToolResult> {


### PR DESCRIPTION
PR B-3 of the lift-not-duplicate refactor.

The shared module's regex-based recall (yesterday/two days ago/last week) was strictly worse than Vertex's executeRecallConversationAtTime service. Now both pipelines call the same service.

- orb-tools-shared.ts tool_recall_conversation_at_time imports executeRecallConversationAtTime. Accepts both 'time_hint' (Vertex key) and 'when' (LiveKit Python key).
- orb-live.ts case body → dispatchOrbToolForVertex one-liner.
- Caps payload to 4 KB to stay under function-response stall threshold.

Build clean locally.

🤖 Generated with Claude Code