### PR TITLE
refactor(VTID-02814): PR B-4 — lift set_capability_preference to shared

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -5579,19 +5579,9 @@ async function executeLiveApiToolInner(
         return { success: true, result: `${baseAck}${tail}` };
       }
 
-      // VTID-01942 PR 3: voice "make X my default for music" tool. Writes
-      // (or clears) user_capability_preferences row. Confirms back.
+      // PR B-4: lifted to services/orb-tools-shared.ts. Both pipelines now
+      // write to user_capability_preferences through the same wrapper.
       case 'set_capability_preference': {
-        const capability = String(args.capability ?? '').trim();
-        const connectorId = String(args.connector_id ?? '').trim();
-        const clear = Boolean(args.clear);
-        if (!capability) {
-          return { success: false, result: '', error: 'capability is required' };
-        }
-        if (!clear && !connectorId) {
-          return { success: false, result: '', error: 'connector_id is required unless clear=true' };
-        }
-
         const SUPABASE_URL = process.env.SUPABASE_URL;
         const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
         if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
@@ -5599,47 +5589,17 @@ async function executeLiveApiToolInner(
         }
         const { createClient } = await import('@supabase/supabase-js');
         const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
-
-        if (clear) {
-          const { error } = await supabase
-            .from('user_capability_preferences')
-            .delete()
-            .eq('user_id', lens.user_id)
-            .eq('capability_id', capability);
-          if (error) {
-            return { success: false, result: '', error: `Couldn't clear preference: ${error.message}` };
-          }
-          console.log(`[VTID-01942] preference cleared: user=${lens.user_id.slice(0,8)} cap=${capability}`);
-          return { success: true, result: `Okay — cleared your default for ${capability}. I'll ask again next time.` };
-        }
-
-        const { error } = await supabase
-          .from('user_capability_preferences')
-          .upsert({
-            tenant_id: lens.tenant_id,
+        const { dispatchOrbToolForVertex } = await import('../services/orb-tools-shared');
+        return await dispatchOrbToolForVertex(
+          'set_capability_preference',
+          args ?? {},
+          {
             user_id: lens.user_id,
-            capability_id: capability,
-            preferred_connector_id: connectorId,
-            set_method: 'explicit',
-            updated_at: new Date().toISOString(),
-          }, { onConflict: 'tenant_id,user_id,capability_id' });
-
-        if (error) {
-          return { success: false, result: '', error: `Couldn't save preference: ${error.message}` };
-        }
-
-        const displayName =
-          connectorId === 'google' ? 'YouTube Music' :
-          connectorId === 'spotify' ? 'Spotify' :
-          connectorId === 'apple_music' ? 'Apple Music' :
-          connectorId === 'vitana_hub' ? 'the Vitana Media Hub' :
-          connectorId;
-
-        console.log(`[VTID-01942] preference set: user=${lens.user_id.slice(0,8)} cap=${capability} → ${connectorId}`);
-        return {
-          success: true,
-          result: `Got it — ${displayName} is your default for ${capability} now.`,
-        };
+            tenant_id: lens.tenant_id ?? null,
+            role: session.identity?.role ?? null,
+          },
+          supabase,
+        );
       }
 
       // VTID-01943: the Gmail + Calendar + Contacts voice tools all share

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -269,31 +269,66 @@ export async function tool_set_capability_preference(
   id: OrbToolIdentity,
   sb: SupabaseClient,
 ): Promise<OrbToolResult> {
+  // PR B-4: lifted from orb-live.ts:5572 (VTID-01942).
+  // Vertex's authoritative impl: writes/clears user_capability_preferences
+  // (the schema the rest of the platform reads from), not the LiveKit-only
+  // user_preferences table. Both pipelines now persist preferences to the
+  // same row.
   const capability = String(args.capability ?? '').trim();
-  const provider = String(args.provider ?? '').trim();
-  if (!capability) return { ok: false, error: 'capability is required' };
-  try {
-    await sb
-      .from('user_preferences')
-      .upsert(
-        {
-          user_id: id.user_id,
-          key: `capability.${capability}.provider`,
-          value: provider || null,
-          updated_at: new Date().toISOString(),
-        },
-        { onConflict: 'user_id,key' },
-      );
-  } catch {
-    /* table layout varies; preference still acknowledged */
+  // Accept both 'connector_id' (Vertex's canonical) and 'provider' (legacy
+  // LiveKit Python tool key) so call sites continue to work unchanged.
+  const connectorId = String(args.connector_id ?? args.provider ?? '').trim();
+  const clear = Boolean(args.clear);
+
+  if (!capability) {
+    return { ok: false, error: 'capability is required' };
   }
+  if (!clear && !connectorId) {
+    return { ok: false, error: 'connector_id is required unless clear=true' };
+  }
+
+  if (clear) {
+    const { error } = await sb
+      .from('user_capability_preferences')
+      .delete()
+      .eq('user_id', id.user_id)
+      .eq('capability_id', capability);
+    if (error) {
+      return { ok: false, error: `Couldn't clear preference: ${error.message}` };
+    }
+    return {
+      ok: true,
+      result: { capability, cleared: true },
+      text: `Okay — cleared your default for ${capability}. I'll ask again next time.`,
+    };
+  }
+
+  const { error } = await sb.from('user_capability_preferences').upsert(
+    {
+      tenant_id: id.tenant_id,
+      user_id: id.user_id,
+      capability_id: capability,
+      preferred_connector_id: connectorId,
+      set_method: 'explicit',
+      updated_at: new Date().toISOString(),
+    },
+    { onConflict: 'tenant_id,user_id,capability_id' },
+  );
+  if (error) {
+    return { ok: false, error: `Couldn't save preference: ${error.message}` };
+  }
+
+  const displayName =
+    connectorId === 'google' ? 'YouTube Music'
+      : connectorId === 'spotify' ? 'Spotify'
+      : connectorId === 'apple_music' ? 'Apple Music'
+      : connectorId === 'vitana_hub' ? 'the Vitana Media Hub'
+      : connectorId;
+
   return {
     ok: true,
-    result: { capability, provider, saved: true },
-    text:
-      provider
-        ? `Got it — ${capability} will route to ${provider} from now on.`
-        : `Cleared default for ${capability}; I'll ask each time going forward.`,
+    result: { capability, connector_id: connectorId, saved: true },
+    text: `Got it — ${displayName} is your default for ${capability} now.`,
   };
 }
 


### PR DESCRIPTION
PR B-4 of the lift-not-duplicate refactor.

The shared module wrote to a different table (user_preferences) than the rest of the platform reads from (user_capability_preferences). LiveKit users setting a preference weren't actually setting anything the connector router would read.

Lifted Vertex's authoritative impl (orb-live.ts:5572). Both pipelines now write to user_capability_preferences with the same upsert+conflict semantics. Accepts both 'connector_id' (Vertex) and 'provider' (LiveKit Python) keys.

Vertex case body collapses to a single dispatchOrbToolForVertex call.

Build clean.

🤖 Generated with Claude Code