### PR TITLE
refactor(VTID-02819): PR B-8 — lift search_community + ask_pillar_agent

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -5289,57 +5289,26 @@ async function executeLiveApiToolInner(
       }
 
       case 'search_community': {
-        const query = (args.query as string) || '';
+        // PR B-8: lifted to services/orb-tools-shared.ts.
         const SUPABASE_URL = process.env.SUPABASE_URL;
-        const SUPABASE_SERVICE_ROLE_KEY = process.env.SUPABASE_SERVICE_ROLE;
-
-        if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE_KEY) {
+        const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
+        if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
           return { success: true, result: 'Community search is temporarily unavailable.' };
         }
-
-        const headers = {
-          'Content-Type': 'application/json',
-          apikey: SUPABASE_SERVICE_ROLE_KEY,
-          Authorization: `Bearer ${SUPABASE_SERVICE_ROLE_KEY}`,
-        };
-
-        const tenantId = lens.tenant_id;
-        let groupsUrl = `${SUPABASE_URL}/rest/v1/community_groups?select=id,name,topic_key,description,is_public&tenant_id=eq.${tenantId}&is_public=eq.true&order=created_at.desc&limit=8`;
-        if (query) {
-          groupsUrl += `&or=(name.ilike.*${encodeURIComponent(query)}*,description.ilike.*${encodeURIComponent(query)}*,topic_key.ilike.*${encodeURIComponent(query)}*)`;
-        }
-
-        try {
-          const resp = await fetch(groupsUrl, { method: 'GET', headers });
-          if (!resp.ok) {
-            console.warn(`[VTID-01270A] community_groups query failed: ${resp.status}`);
-            return { success: true, result: 'Could not search community groups at this time.' };
-          }
-
-          const groups = await resp.json() as Array<{
-            id: string; name: string; topic_key: string;
-            description: string; is_public: boolean;
-          }>;
-
-          if (groups.length === 0) {
-            console.log(`[VTID-01270A] search_community: 0 hits for "${query}", ${Date.now() - startTime}ms`);
-            return { success: true, result: 'No community groups found matching your query.' };
-          }
-
-          const MAX_TOOL_RESPONSE_CHARS = 2000;
-          let formatted = groups
-            .map(g => `${g.name} — ${(g.description || '').substring(0, 120)} | Topic: ${g.topic_key}`)
-            .join('\n');
-          if (formatted.length > MAX_TOOL_RESPONSE_CHARS) {
-            formatted = formatted.substring(0, MAX_TOOL_RESPONSE_CHARS) + '\n... (truncated)';
-          }
-
-          console.log(`[VTID-01270A] search_community: ${groups.length} hits for "${query}", ${formatted.length} chars, ${Date.now() - startTime}ms`);
-          return { success: true, result: `Found ${groups.length} community groups:\n${formatted}` };
-        } catch (e: any) {
-          console.warn(`[VTID-01270A] search_community error: ${e.message}`);
-          return { success: true, result: 'Community search encountered an error. Please try again.' };
-        }
+        const { createClient } = await import('@supabase/supabase-js');
+        const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
+        const { dispatchOrbToolForVertex } = await import('../services/orb-tools-shared');
+        return await dispatchOrbToolForVertex(
+          'search_community',
+          args ?? {},
+          {
+            user_id: lens.user_id,
+            tenant_id: lens.tenant_id ?? null,
+            role: session.identity?.role ?? null,
+            vitana_id: session.identity?.vitana_id ?? null,
+          },
+          supabase,
+        );
       }
 
       case 'get_recommendations': {
@@ -6254,50 +6223,28 @@ async function executeLiveApiToolInner(
 
       // ─── BOOTSTRAP-PILLAR-AGENT-Q — per-pillar deep-question dispatch ───
       case 'ask_pillar_agent': {
-        try {
-          const { askPillarAgent } = await import('../services/pillar-agents/router');
-          const { resolvePillarKey } = await import('../lib/vitana-pillars');
-          const { createClient } = await import('@supabase/supabase-js');
-          const url = process.env.SUPABASE_URL;
-          const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
-          if (!url || !key) return { success: false, result: '', error: 'Supabase not configured' };
-          const client = createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
-
-          const question = typeof args.question === 'string' ? args.question.trim() : '';
-          if (!question) {
-            return { success: false, result: '', error: 'question is required' };
-          }
-          // resolvePillarKey silently translates retired aliases; undefined
-          // = no explicit pillar passed, let the router auto-detect.
-          const explicit = resolvePillarKey(args.pillar);
-
-          const answer = await askPillarAgent(client, lens.user_id, question, explicit);
-          if (!answer) {
-            return {
-              success: true,
-              result: JSON.stringify({
-                routed: false,
-                reason: 'no_pillar_detected_or_agent_unavailable',
-                guidance: 'Voice should fall back to search_knowledge against the Book of the Vitana Index.',
-              }),
-            };
-          }
-
-          return {
-            success: true,
-            result: JSON.stringify({
-              routed: true,
-              pillar: answer.pillar,
-              text: answer.text,
-              citations: answer.citations,
-              data: answer.data,
-              agent_version: answer.agent_version,
-            }),
-          };
-        } catch (err: any) {
-          console.error('[ask_pillar_agent] error:', err?.message);
-          return { success: false, result: '', error: err?.message || 'unknown' };
+        // PR B-8: lifted to services/orb-tools-shared.ts.
+        const SUPABASE_URL = process.env.SUPABASE_URL;
+        const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+        if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
+          return { success: false, result: '', error: 'Supabase not configured' };
         }
+        const { createClient } = await import('@supabase/supabase-js');
+        const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE, {
+          auth: { autoRefreshToken: false, persistSession: false },
+        });
+        const { dispatchOrbToolForVertex } = await import('../services/orb-tools-shared');
+        return await dispatchOrbToolForVertex(
+          'ask_pillar_agent',
+          args ?? {},
+          {
+            user_id: lens.user_id,
+            tenant_id: lens.tenant_id ?? null,
+            role: session.identity?.role ?? null,
+            vitana_id: session.identity?.vitana_id ?? null,
+          },
+          supabase,
+        );
       }
 
       // ─── BOOTSTRAP-TEACH-BEFORE-REDIRECT — explanation-first dispatch ───

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -216,33 +216,69 @@ export async function tool_search_events(
 
 export async function tool_search_community(
   args: OrbToolArgs,
-  _id: OrbToolIdentity,
+  id: OrbToolIdentity,
   sb: SupabaseClient,
 ): Promise<OrbToolResult> {
-  const query = String(args.query ?? '').trim().toLowerCase();
-  const { data, error } = await sb
+  // PR B-8: lifted from orb-live.ts:5291 (VTID-01270A). The previous shared
+  // stub queried community_groups with no tenant scope and selected only
+  // (id, name, slug) — but the canonical schema has the public-listing
+  // columns (topic_key, description, is_public) Vertex reads. The stub
+  // also failed entirely on environments where the schema cache hadn't
+  // loaded the columns. Lifting Vertex's authoritative impl: tenant-
+  // scoped, public-only, OR-filter on (name|description|topic_key),
+  // voice-friendly truncation at 2 KB.
+  const query = String(args.query ?? '').trim();
+  if (!id.tenant_id) {
+    // Without a tenant_id we can't safely scope the search.
+    return {
+      ok: true,
+      result: { groups: [] },
+      text: 'Community search is unavailable for this session (no tenant context).',
+    };
+  }
+
+  let q = sb
     .from('community_groups')
-    .select('id, name, slug')
-    .limit(100);
+    .select('id, name, topic_key, description, is_public')
+    .eq('tenant_id', id.tenant_id)
+    .eq('is_public', true)
+    .order('created_at', { ascending: false })
+    .limit(8);
+  if (query) {
+    // Match Vertex's OR filter across name + description + topic_key.
+    q = q.or(
+      `name.ilike.*${query}*,description.ilike.*${query}*,topic_key.ilike.*${query}*`,
+    );
+  }
+
+  const { data, error } = await q;
   if (error) {
     return {
       ok: true,
       result: { groups: [] },
-      text: `Community group search isn't available right now: ${error.message}`,
+      text: 'Could not search community groups at this time.',
     };
   }
-  const filtered = query
-    ? (data || []).filter((g: { name?: string }) => (g.name || '').toLowerCase().includes(query))
-    : data || [];
+  const groups =
+    (data as Array<{ id: string; name: string; topic_key: string; description: string }>) ?? [];
+  if (groups.length === 0) {
+    return {
+      ok: true,
+      result: { groups: [] },
+      text: 'No community groups found matching your query.',
+    };
+  }
+  const MAX = 2000;
+  let formatted = groups
+    .map((g) => `${g.name} — ${(g.description || '').substring(0, 120)} | Topic: ${g.topic_key}`)
+    .join('\n');
+  if (formatted.length > MAX) {
+    formatted = formatted.substring(0, MAX) + '\n... (truncated)';
+  }
   return {
     ok: true,
-    result: {
-      groups: filtered.slice(0, 10).map((g) => ({ id: g.id, name: g.name, slug: g.slug })),
-    },
-    text:
-      filtered.length === 0
-        ? `No matching community groups found for "${query || 'all'}".`
-        : `Found ${filtered.length} group${filtered.length === 1 ? '' : 's'}.`,
+    result: { groups },
+    text: `Found ${groups.length} community groups:\n${formatted}`,
   };
 }
 
@@ -617,25 +653,41 @@ export async function tool_ask_pillar_agent(
   id: OrbToolIdentity,
   sb: SupabaseClient,
 ): Promise<OrbToolResult> {
-  const pillar =
-    resolvePillarKey(String(args.pillar ?? '')) ||
-    (await fetchVitanaIndexForProfiler(sb, id.user_id))?.weakest_pillar?.name ||
-    null;
-  const question = String(args.question ?? '').trim();
-  if (!pillar || !question) {
-    return { ok: false, error: 'pillar and question are required' };
+  // PR B-8: lifted from orb-live.ts:6225. Vertex calls the real
+  // pillar-agents/router service (askPillarAgent) which routes by pillar
+  // intent + returns answer text + citations + structured data. The
+  // previous shared stub just surfaced raw subscores with a note saying
+  // "lightweight mode" — a strict regression vs Vertex.
+  const question = typeof args.question === 'string' ? (args.question as string).trim() : '';
+  if (!question) {
+    return { ok: false, error: 'question is required' };
   }
-  const snap = await fetchVitanaIndexForProfiler(sb, id.user_id);
-  const subs = (snap?.subscores as Record<string, unknown> | undefined)?.[pillar];
-  return {
-    ok: true,
-    result: {
-      pillar,
-      question,
-      subscores: subs ?? null,
-      note: 'pillar agent is in lightweight mode — surfaces sub-scores; full agentic answer ships in a follow-up',
-    },
-  };
+  // resolvePillarKey silently translates retired aliases; undefined =
+  // no explicit pillar passed, let the router auto-detect.
+  const explicit = resolvePillarKey(args.pillar as string | undefined);
+  try {
+    const { askPillarAgent } = await import('./pillar-agents/router');
+    const answer = await askPillarAgent(sb, id.user_id, question, explicit);
+    if (!answer) {
+      const payload = {
+        routed: false as const,
+        reason: 'no_pillar_detected_or_agent_unavailable',
+        guidance: 'Voice should fall back to search_knowledge against the Book of the Vitana Index.',
+      };
+      return { ok: true, result: payload, text: JSON.stringify(payload) };
+    }
+    const payload = {
+      routed: true as const,
+      pillar: answer.pillar,
+      text: answer.text,
+      citations: answer.citations,
+      data: answer.data,
+      agent_version: answer.agent_version,
+    };
+    return { ok: true, result: payload, text: answer.text || JSON.stringify(payload) };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'ask_pillar_agent error' };
+  }
 }
 
 export async function tool_explain_feature(args: OrbToolArgs): Promise<OrbToolResult> {


### PR DESCRIPTION
PR B-8 of the lift-not-duplicate refactor.

**search_community** (VTID-01270A): the previous shared stub had no tenant scope and selected only (id, name, slug). Vertex tenant-scopes, filters is_public=true, runs OR ilike across name+description+topic_key, formats voice response with description preview. Now both pipelines use Vertex's logic.

**ask_pillar_agent**: the previous shared stub returned just raw subscores with a 'lightweight mode' note. Vertex calls services/pillar-agents/router askPillarAgent which routes by pillar intent and returns answer text + citations + data. Now both pipelines use the real router.

Each Vertex case body collapses to a dispatchOrbToolForVertex one-liner.

🤖 Generated with Claude Code