### PR TITLE
fix(migration): use $body$ tag in pg_cron retention block (VTID-02754)

### DIFF
--- a/supabase/migrations/20260510000000_vtid_02754_community_search_history.sql
+++ b/supabase/migrations/20260510000000_vtid_02754_community_search_history.sql
@@ -48,13 +48,16 @@ CREATE POLICY community_search_history_self_read
 -- Daily TTL cleanup: drop rows older than 30 days. Mirrors
 -- oasis-events-info-retention pattern. No-op if pg_cron isn't available
 -- (the gateway will still function; rows just won't auto-prune).
-DO $$
+-- Uses $body$ outer tag to avoid nested $$ ambiguity with the inner
+-- cron.schedule SQL string.
+DO $body$
 BEGIN
   IF EXISTS (SELECT 1 FROM pg_extension WHERE extname = 'pg_cron') THEN
     PERFORM cron.schedule(
       'community-search-history-retention',
       '15 4 * * *',
-      $$DELETE FROM public.community_search_history WHERE created_at < now() - interval '30 days'$$
+      'DELETE FROM public.community_search_history WHERE created_at < now() - interval ''30 days'''
     );
   END IF;
-END $$;
+END
+$body$;


### PR DESCRIPTION
Fixes nested `$$` ambiguity in the community_search_history migration. CREATE TABLE / INDEX / RLS / POLICY already applied successfully; only the cron retention scheduling failed because psql couldn't parse the nested dollar-quotes. Retagging the outer DO block as `$body$` and using escaped single quotes for the inner SQL fixes the parse. Re-running is idempotent.