### PR TITLE
refactor(VTID-02823): PR D-1 — lift health-log tools + scanner fall-through fix

### DIFF
--- a/scripts/orb-tools-lift-scanner.mjs
+++ b/scripts/orb-tools-lift-scanner.mjs
@@ -117,17 +117,30 @@ function extractVertexCases(src) {
       i++;
       continue;
     }
-    const name = m[1];
-    if (PROTOCOL.has(name)) {
-      i++;
-      continue;
+    // Collect all consecutive fall-through case labels (case 'a': case 'b':
+    // { body }). The body belongs to ALL of them, so each name shares the
+    // same delegated status.
+    const fallThroughNames = [];
+    const fallThroughLines = [];
+    let cursor = i;
+    while (cursor < lines.length) {
+      const cur = lines[cursor];
+      const cm = cur.match(/^\s*case '([a-z_][a-z0-9_]*)':\s*\{?\s*$/);
+      if (!cm) break;
+      fallThroughNames.push(cm[1]);
+      fallThroughLines.push(cursor + 1);
+      // If this case line has the opening brace, the body starts here.
+      if (/\{\s*$/.test(cur)) {
+        break;
+      }
+      cursor++;
     }
-    // Find the case body — accumulate lines until matching closing brace
-    // or until we hit the next `case '...':`. Use a brace counter.
+    // The line we just stopped on is the case-with-body (or we ran out of
+    // case lines). Walk forward to find the closing brace of the body.
     let depth = 0;
     let openSeen = false;
     let body = '';
-    let j = i;
+    let j = cursor;
     for (; j < lines.length; j++) {
       const lj = lines[j];
       for (const ch of lj) {
@@ -138,12 +151,14 @@ function extractVertexCases(src) {
       }
       body += lj + '\n';
       if (openSeen && depth === 0) break;
-      // Fallback: stop if we hit a new `case '...':` (some cases share a body)
-      if (j > i && /^\s*case '[a-z_][a-z0-9_]*':/.test(lj) && !openSeen) break;
     }
     const delegated = /dispatchOrbToolForVertex\b/.test(body);
-    if (!cases.has(name)) {
-      cases.set(name, { delegated, lineNumber: i + 1 });
+    for (let k = 0; k < fallThroughNames.length; k++) {
+      const n = fallThroughNames[k];
+      if (PROTOCOL.has(n)) continue;
+      if (!cases.has(n)) {
+        cases.set(n, { delegated, lineNumber: fallThroughLines[k] });
+      }
     }
     i = j + 1;
   }

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -6029,80 +6029,54 @@ async function executeLiveApiToolInner(
       case 'log_sleep':
       case 'log_exercise':
       case 'log_meditation': {
-        try {
-          const { logHealthSignal } = await import('../services/voice-tools/health-log');
-          const today = new Date().toISOString().slice(0, 10);
-          const date = typeof args.date === 'string' && args.date ? args.date : today;
-          const out = await logHealthSignal({
-            user_id: lens.user_id,
-            tenant_id: lens.tenant_id,
-            tool: toolName as 'log_water' | 'log_sleep' | 'log_exercise' | 'log_meditation',
-            date,
-            amount_ml: typeof args.amount_ml === 'number' ? args.amount_ml : undefined,
-            minutes: typeof args.minutes === 'number' ? args.minutes : undefined,
-            activity_type: typeof args.activity_type === 'string' ? args.activity_type : undefined,
-          });
-          if (!out.ok) return { success: false, result: '', error: out.error };
-          return { success: true, result: JSON.stringify(out.summary) };
-        } catch (err: any) {
-          console.error(`[${toolName}] error:`, err?.message);
-          return { success: false, result: '', error: err?.message || 'unknown' };
+        // VTID-LIFT-HEALTH-LOG: delegate to the canonical shared dispatcher
+        // (services/orb-tools-shared.ts → tool_log_health → logHealthSignal).
+        // Both pipelines now run identical health-log code; drift impossible.
+        const SUPABASE_URL = process.env.SUPABASE_URL;
+        const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
+        if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
+          return { success: false, result: '', error: 'Service unavailable — Supabase creds not configured' };
         }
+        const { createClient } = await import('@supabase/supabase-js');
+        const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
+        const { dispatchOrbToolForVertex } = await import('../services/orb-tools-shared');
+        return await dispatchOrbToolForVertex(
+          toolName,
+          args ?? {},
+          {
+            user_id: lens.user_id,
+            tenant_id: lens.tenant_id ?? null,
+            role: session.identity?.role ?? null,
+            vitana_id: session.identity?.vitana_id ?? null,
+          },
+          supabase,
+        );
       }
 
       case 'get_pillar_subscores': {
-        try {
-          const pillar = String(args.pillar || '').toLowerCase();
-          const valid = ['nutrition', 'hydration', 'exercise', 'sleep', 'mental'];
-          if (!valid.includes(pillar)) {
-            return { success: false, result: '', error: `pillar must be one of ${valid.join(', ')}` };
-          }
-          const { fetchVitanaIndexForProfiler } = await import('../services/user-context-profiler');
-          const { createClient } = await import('@supabase/supabase-js');
-          const url = process.env.SUPABASE_URL;
-          const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
-          if (!url || !key) return { success: false, result: '', error: 'Supabase not configured' };
-          const client = createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
-          const snap = await fetchVitanaIndexForProfiler(client, lens.user_id);
-          if (!snap) {
-            return {
-              success: true,
-              result: JSON.stringify({ pillar, available: false, reason: 'no_index_snapshot' }),
-            };
-          }
-          const sub = snap.subscores?.[pillar as keyof typeof snap.subscores];
-          if (!sub) {
-            return {
-              success: true,
-              result: JSON.stringify({
-                pillar,
-                pillar_score: snap.pillars[pillar as keyof typeof snap.pillars] ?? 0,
-                subscores: null,
-                reason: 'no_subscores_for_pillar',
-                hint: 'Subscores are populated from the v3 compute RPC; older Index rows may not have them.',
-              }),
-            };
-          }
-          return {
-            success: true,
-            result: JSON.stringify({
-              pillar,
-              pillar_score: snap.pillars[pillar as keyof typeof snap.pillars] ?? 0,
-              subscores: sub,
-              caps: { baseline: 40, completions: 80, data: 40, streak: 40 },
-              dominant: Object.entries(sub).reduce((a, b) => (b[1] > a[1] ? b : a))[0],
-              hint:
-                sub.data < 10 && sub.completions < 20
-                  ? 'Mostly baseline — log entries or connect a tracker to climb.'
-                  : sub.streak < 10
-                    ? 'Streak is low — consistency for 3+ days will lift this pillar.'
-                    : 'Solid mix — keep doing what you\'re doing.',
-            }),
-          };
-        } catch (err: any) {
-          console.error('[get_pillar_subscores] error:', err?.message);
-          return { success: false, result: '', error: err?.message || 'unknown' };
+        // VTID-LIFT-PILLAR-SUBSCORES: delegate to the canonical shared
+        // dispatcher (services/orb-tools-shared.ts → tool_get_pillar_subscores).
+        const SUPABASE_URL = process.env.SUPABASE_URL;
+        const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+        if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
+          return { success: false, result: '', error: 'Supabase not configured' };
         }
+        const { createClient } = await import('@supabase/supabase-js');
+        const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE, {
+          auth: { autoRefreshToken: false, persistSession: false },
+        });
+        const { dispatchOrbToolForVertex } = await import('../services/orb-tools-shared');
+        return await dispatchOrbToolForVertex(
+          'get_pillar_subscores',
+          args ?? {},
+          {
+            user_id: lens.user_id,
+            tenant_id: lens.tenant_id ?? null,
+            role: session.identity?.role ?? null,
+            vitana_id: session.identity?.vitana_id ?? null,
+          },
+          supabase,
+        );
       }
 
       // ─── VTID-01983 — save_diary_entry: log a diary entry on user's behalf ───


### PR DESCRIPTION
Two fixes in one PR.

**1. Lift the 5 health-logging tools** (`log_water`, `log_sleep`, `log_exercise`, `log_meditation`, `get_pillar_subscores`) to the canonical shared dispatcher. These were added in VTID-02753 after PR A landed, so they had inline Vertex case bodies even though the shared module already had the canonical impls (both call the same `logHealthSignal` / `fetchVitanaIndexForProfiler` services Vertex used). Vertex now delegates via `dispatchOrbToolForVertex` — drift impossible.

**2. Fix orb-tools-lift-scanner.mjs fall-through detection**: the previous version walked one case label at a time. For combined fall-through cases (`case 'a': case 'b': { body }`), the scanner stopped at the next case label without seeing the body, falsely flagging the first 3 cases of any 4-tool combined case as drift. Now the scanner collects all consecutive case labels and assigns the same delegated status to all of them.

Scanner result on this branch: **6 DRIFT-CRITICAL remaining** (`search_memory`, `search_web`, `switch_persona`, `report_to_specialist`, `play_music`, `consult_external_ai`) — all session-state-coupled or WebSocket-specific tools that need careful design before lifting.

🤖 Generated with Claude Code