### PR TITLE
refactor(VTID-02824): PR D-2 — lift consult_external_ai + extend session context

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -5798,73 +5798,30 @@ async function executeLiveApiToolInner(
       // budget, credential, provider call, usage log) lives in
       // services/gateway/src/orb/delegation/.
       case 'consult_external_ai': {
-        if (!session.identity?.user_id) {
-          return {
-            success: true,
-            result: 'External AI consultation requires a signed-in session. I\'ll answer this one myself.',
-          };
+        // PR D-2: lifted to services/orb-tools-shared.ts. Both pipelines now
+        // call executeDelegation through the same wrapper.
+        const SUPABASE_URL = process.env.SUPABASE_URL;
+        const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
+        if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
+          return { success: false, result: '', error: 'Service unavailable — Supabase creds not configured' };
         }
-
-        const question = String(args.question ?? '').trim();
-        if (!question) {
-          return { success: false, result: '', error: 'consult_external_ai requires a non-empty question.' };
-        }
-
-        const providerHint = typeof args.provider_hint === 'string'
-          ? (args.provider_hint as 'chatgpt' | 'claude' | 'google-ai')
-          : undefined;
-        const taskClass = typeof args.task_class === 'string'
-          ? (args.task_class as import('../orb/delegation').DelegationStrength)
-          : undefined;
-
-        const { executeDelegation, adaptForDelivery } = await import('../orb/delegation');
-
-        const outcome = await executeDelegation({
-          userId: session.identity.user_id,
-          tenantId: session.identity.tenant_id ?? '',
-          sessionId: session.sessionId,
-          question,
-          taskClass,
-          providerHint,
-          privacyLevel: 'public',
-          lang: session.lang || 'en',
-          startedAt: startTime,
-        });
-
-        if (!outcome.ok) {
-          // Graceful user-facing copy based on failure reason. Gemini will
-          // read this string and speak it, so keep it short and natural.
-          const reason = outcome.failure.reason;
-          if (reason === 'no_providers_connected' || reason === 'no_credentials') {
-            return {
-              success: true,
-              result: "You haven't connected an external AI yet, so I'll answer this one myself.",
-            };
-          }
-          if (reason === 'budget_cap_exceeded') {
-            return {
-              success: true,
-              result: `You've reached this month's spending cap for that AI, so I'll answer this myself.`,
-            };
-          }
-          if (reason === 'provider_timeout') {
-            return {
-              success: true,
-              result: `That AI is taking too long to respond. Let me answer instead.`,
-            };
-          }
-          // provider_unauthorized / provider_error / network_error / etc.
-          console.warn(`[BOOTSTRAP-ORB-DELEGATION-ROUTE] delegation failed: ${reason} — ${outcome.failure.message}`);
-          return {
-            success: true,
-            result: `That external AI isn't reachable right now, so I'll answer this myself.`,
-          };
-        }
-
-        const voiceText = adaptForDelivery(outcome.result, 'voice');
-        console.log(`[BOOTSTRAP-ORB-DELEGATION-ROUTE] consult_external_ai ok: provider=${outcome.result.providerId} model=${outcome.result.model} in=${outcome.result.usage.inputTokens} out=${outcome.result.usage.outputTokens} cost=$${outcome.result.usage.costUsd.toFixed(4)} latency=${outcome.result.latencyMs}ms`);
-
-        return { success: true, result: voiceText };
+        const { createClient } = await import('@supabase/supabase-js');
+        const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
+        const { dispatchOrbToolForVertex } = await import('../services/orb-tools-shared');
+        return await dispatchOrbToolForVertex(
+          'consult_external_ai',
+          args ?? {},
+          {
+            user_id: lens.user_id,
+            tenant_id: lens.tenant_id ?? null,
+            role: session.identity?.role ?? null,
+            vitana_id: session.identity?.vitana_id ?? null,
+            session_id: session.sessionId,
+            session_started_iso: new Date(startTime).toISOString(),
+            lang: session.lang || 'en',
+          },
+          supabase,
+        );
       }
 
       // ─── BOOTSTRAP-ORB-INDEX-AWARENESS round 2 — Vitana Index tools ───

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -55,6 +55,20 @@ export interface OrbToolIdentity {
    * LiveKit's gateway-issued user_jwt) should populate this.
    */
   user_jwt?: string | null;
+  /**
+   * Optional WebSocket / room session context. Some tool handlers (the
+   * retrieval-router-backed search tools, the AI-delegation tool) take
+   * a session-scoped ID + locale + start-time so they can correlate
+   * traces and pick the right per-session ranking caches. Vertex
+   * populates from session.sessionId / session.thread_id / session.lang /
+   * session.createdAt / session.turn_count; LiveKit can synthesize from
+   * orb_session_id + sensible defaults.
+   */
+  session_id?: string | null;
+  thread_id?: string | null;
+  turn_number?: number | null;
+  session_started_iso?: string | null;
+  lang?: string | null;
 }
 
 export type OrbToolResult =
@@ -719,16 +733,80 @@ export async function tool_find_contact(
   return _runCapabilityTool('find_contact', args, id, sb);
 }
 
-export async function tool_consult_external_ai(args: OrbToolArgs): Promise<OrbToolResult> {
-  const prompt = String(args.prompt ?? '').slice(0, 200);
-  return {
-    ok: true,
-    result: { prompt, forwarded_to: null, status: 'no_external_ai_connected' },
-    text:
-      `You don't have an external AI assistant (ChatGPT/Claude/Gemini) connected ` +
-      `to your account yet. Connect one in Settings → Integrations and I'll forward ` +
-      `questions like "${prompt}" through next time.`,
-  };
+export async function tool_consult_external_ai(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  _sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  // PR D-2: lifted from orb-live.ts:5800 (BOOTSTRAP-ORB-DELEGATION-ROUTE).
+  // Vertex's auth impl calls the canonical executeDelegation pipeline which
+  // resolves the user's connected external-AI provider, enforces budget
+  // caps, calls the provider with their credentials, and returns
+  // adapted-for-voice text. The previous shared stub was a hardcoded
+  // "you don't have an external AI" placeholder — strict regression.
+  if (!id.user_id) {
+    return {
+      ok: true,
+      result: { reason: 'no_session' },
+      text: 'External AI consultation requires a signed-in session. I\'ll answer this one myself.',
+    };
+  }
+  const question = String(args.question ?? '').trim();
+  if (!question) {
+    return { ok: false, error: 'consult_external_ai requires a non-empty question.' };
+  }
+  const providerHint = typeof args.provider_hint === 'string'
+    ? (args.provider_hint as 'chatgpt' | 'claude' | 'google-ai')
+    : undefined;
+
+  try {
+    const { executeDelegation, adaptForDelivery } = await import('../orb/delegation');
+    const taskClass = typeof args.task_class === 'string'
+      ? (args.task_class as import('../orb/delegation').DelegationStrength)
+      : undefined;
+
+    const startedAt = id.session_started_iso ? new Date(id.session_started_iso).getTime() : Date.now();
+
+    const outcome = await executeDelegation({
+      userId: id.user_id,
+      tenantId: id.tenant_id ?? '',
+      sessionId: id.session_id ?? `${id.user_id}:consult_external_ai`,
+      question,
+      taskClass,
+      providerHint,
+      privacyLevel: 'public',
+      lang: id.lang ?? 'en',
+      startedAt,
+    });
+
+    if (!outcome.ok) {
+      // Graceful user-facing copy by failure reason, mirroring Vertex.
+      const reason = outcome.failure.reason;
+      let text = `That external AI isn't reachable right now, so I'll answer this myself.`;
+      if (reason === 'no_providers_connected' || reason === 'no_credentials') {
+        text = "You haven't connected an external AI yet, so I'll answer this one myself.";
+      } else if (reason === 'budget_cap_exceeded') {
+        text = `You've reached this month's spending cap for that AI, so I'll answer this myself.`;
+      } else if (reason === 'provider_timeout') {
+        text = `That AI is taking too long to respond. Let me answer instead.`;
+      }
+      return { ok: true, result: { reason }, text };
+    }
+
+    const voiceText = adaptForDelivery(outcome.result, 'voice');
+    return {
+      ok: true,
+      result: {
+        provider: outcome.result.providerId,
+        model: outcome.result.model,
+        usage: outcome.result.usage,
+        latency_ms: outcome.result.latencyMs,
+      },
+      text: voiceText,
+    };
+  } catch (err: unknown) {
+    return { ok: false, error: err instanceof Error ? err.message : 'consult_external_ai error' };
+  }
 }
 
 export async function tool_create_index_improvement_plan(
@@ -1572,7 +1650,7 @@ export const ORB_TOOL_REGISTRY: Record<string, OrbToolHandler> = {
   get_schedule: tool_get_schedule,
   add_to_calendar: tool_add_to_calendar,
   find_contact: tool_find_contact,
-  consult_external_ai: (args) => tool_consult_external_ai(args),
+  consult_external_ai: tool_consult_external_ai,
   create_index_improvement_plan: tool_create_index_improvement_plan,
   ask_pillar_agent: tool_ask_pillar_agent,
   explain_feature: (args) => tool_explain_feature(args),
@@ -1636,6 +1714,11 @@ export interface VertexLikeIdentity {
   role?: string | null;
   vitana_id?: string | null;
   user_jwt?: string | null;
+  session_id?: string | null;
+  thread_id?: string | null;
+  turn_number?: number | null;
+  session_started_iso?: string | null;
+  lang?: string | null;
 }
 
 export interface VertexLikeToolResult {
@@ -1659,6 +1742,11 @@ export async function dispatchOrbToolForVertex(
       role: identity.role ?? null,
       vitana_id: identity.vitana_id ?? null,
       user_jwt: identity.user_jwt ?? null,
+      session_id: identity.session_id ?? null,
+      thread_id: identity.thread_id ?? null,
+      turn_number: identity.turn_number ?? null,
+      session_started_iso: identity.session_started_iso ?? null,
+      lang: identity.lang ?? null,
     },
     sb,
   );


### PR DESCRIPTION
PR D-2 of the lift-not-duplicate refactor.

**consult_external_ai** (BOOTSTRAP-ORB-DELEGATION-ROUTE): shared stub was a hardcoded 'you don't have external AI' placeholder. Vertex calls executeDelegation which resolves the user's connected provider, enforces budget caps, and adaptForDelivery's the response for voice. Now both pipelines call executeDelegation through the same wrapper. Same failure-reason text-shaping (no_providers, budget_cap, timeout).

**Session context extension**: OrbToolIdentity gains optional `session_id`, `thread_id`, `turn_number`, `session_started_iso`, `lang`. Vertex populates from session.*. Sets up PR D-3 (search_memory + search_web lifts that need retrieval-router context).

Vertex case body collapses to a dispatchOrbToolForVertex one-liner.

🤖 Generated with Claude Code