### PR TITLE
fix(intent-covers): storage RLS policies for self-uploads (VTID-02806d)

### DIFF
--- a/supabase/migrations/20260514000000_VTID_02806d_intent_covers_storage_policies.sql
+++ b/supabase/migrations/20260514000000_VTID_02806d_intent_covers_storage_policies.sql
@@ -1,0 +1,56 @@
+-- VTID-02806d — Storage RLS for the intent-covers bucket.
+--
+-- The bucket was created with public:true (read), but writes still
+-- need explicit policies on storage.objects. Without these, an
+-- authenticated user uploading their universal/library photo from
+-- the browser hits "new row violates row-level security policy".
+--
+-- Path conventions used by CoverLibraryDrawer (vitana-v1):
+--   user-universal/{userId}/{ts}.{ext}      — single per-user
+--   user-library/{userId}/{photoId}.{ext}   — many per-user
+-- AI/fallback writes done by the gateway use service role and
+-- bypass these policies.
+
+-- Public read — covers actually need to render anonymously on
+-- match cards, so we keep this open. (Already implied by the
+-- bucket's public:true, but make it explicit on the table.)
+DROP POLICY IF EXISTS "intent-covers public read" ON storage.objects;
+CREATE POLICY "intent-covers public read"
+  ON storage.objects FOR SELECT
+  USING (bucket_id = 'intent-covers');
+
+-- Self-write: allow an authenticated user to INSERT / UPDATE / DELETE
+-- objects whose key starts with `user-universal/<their-uid>/...` or
+-- `user-library/<their-uid>/...`. The folder check (storage.foldername)
+-- splits the key by `/`; element [1] is the prefix, [2] is the user_id.
+DROP POLICY IF EXISTS "intent-covers self insert" ON storage.objects;
+CREATE POLICY "intent-covers self insert"
+  ON storage.objects FOR INSERT
+  WITH CHECK (
+    bucket_id = 'intent-covers'
+    AND (storage.foldername(name))[1] IN ('user-universal', 'user-library')
+    AND auth.uid()::text = (storage.foldername(name))[2]
+  );
+
+DROP POLICY IF EXISTS "intent-covers self update" ON storage.objects;
+CREATE POLICY "intent-covers self update"
+  ON storage.objects FOR UPDATE
+  USING (
+    bucket_id = 'intent-covers'
+    AND (storage.foldername(name))[1] IN ('user-universal', 'user-library')
+    AND auth.uid()::text = (storage.foldername(name))[2]
+  )
+  WITH CHECK (
+    bucket_id = 'intent-covers'
+    AND (storage.foldername(name))[1] IN ('user-universal', 'user-library')
+    AND auth.uid()::text = (storage.foldername(name))[2]
+  );
+
+DROP POLICY IF EXISTS "intent-covers self delete" ON storage.objects;
+CREATE POLICY "intent-covers self delete"
+  ON storage.objects FOR DELETE
+  USING (
+    bucket_id = 'intent-covers'
+    AND (storage.foldername(name))[1] IN ('user-universal', 'user-library')
+    AND auth.uid()::text = (storage.foldername(name))[2]
+  );


### PR DESCRIPTION
Browser uploads to the new `intent-covers` bucket fail with `new row violates row-level security policy` — the bucket was created with public read but no write policies on `storage.objects`. This adds INSERT/UPDATE/DELETE policies scoped to the user's own `user-universal/{uid}/...` and `user-library/{uid}/...` paths.

Service-role writes (gateway AI + curated paths) bypass RLS as before.

Apply via Run SQL Migration workflow with file `supabase/migrations/20260514000000_VTID_02806d_intent_covers_storage_policies.sql`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)