### PR TITLE
fix(voice-tools-catalog): truthful manifest status — 135 → 147, 45 actually live not 135 (VTID-02829)

### DIFF
--- a/services/gateway/src/services/tool-manifest.json
+++ b/services/gateway/src/services/tool-manifest.json
@@ -1,161 +1,1766 @@
 {
-  "generated_at": "2026-05-07T00:00:00.000Z",
+  "generated_at": "2026-05-07T15:30:00.000Z",
   "source": "manual",
-  "total": 135,
+  "total": 147,
   "tools": [
-    { "name": "search_knowledge", "surface": "Knowledge", "category": "knowledge", "role": ["community", "user", "operator", "admin", "developer"], "status": "live", "description": "Search the Vitana knowledge base." },
-    { "name": "search_calendar", "surface": "Calendar", "category": "calendar", "role": ["community", "user", "operator"], "status": "live", "description": "Search calendar events." },
-    { "name": "get_schedule", "surface": "Calendar", "category": "calendar", "role": ["community", "user"], "status": "live", "description": "Read the user's calendar via connected provider." },
-    { "name": "create_calendar_event", "surface": "Calendar", "category": "calendar", "role": ["community", "user"], "status": "live", "description": "Create a calendar event." },
-    { "name": "add_to_calendar", "surface": "Calendar", "category": "calendar", "role": ["community", "user"], "status": "live", "description": "Add an event via connected provider." },
-    { "name": "get_recommendations", "surface": "Autopilot", "category": "autopilot", "role": ["community", "user"], "status": "live", "description": "Fetch Autopilot recommendations." },
-    { "name": "activate_recommendation", "surface": "Autopilot", "category": "autopilot", "role": ["community", "user"], "status": "live", "description": "Activate a recommendation." },
-    { "name": "get_vitana_index", "surface": "Health", "category": "health", "role": ["community", "user"], "status": "live", "description": "Return the user's current Vitana Index." },
-    { "name": "get_index_improvement_suggestions", "surface": "Health", "category": "health", "role": ["community", "user"], "status": "live", "description": "Suggest concrete actions to lift the Index." },
-    { "name": "save_diary_entry", "surface": "Diary", "category": "diary", "role": ["community", "user"], "status": "live", "vtid": "VTID-01983", "description": "Save a diary entry from voice." },
-    { "name": "set_reminder", "surface": "Reminders", "category": "reminders", "role": ["community", "user"], "status": "live", "vtid": "VTID-02601", "description": "Create a one-shot reminder." },
-    { "name": "find_reminders", "surface": "Reminders", "category": "reminders", "role": ["community", "user"], "status": "live", "vtid": "VTID-02601", "description": "Search active reminders." },
-    { "name": "delete_reminder", "surface": "Reminders", "category": "reminders", "role": ["community", "user"], "status": "live", "vtid": "VTID-02601", "description": "Delete one or all reminders (after confirm)." },
-    { "name": "post_intent", "surface": "Intents", "category": "intents", "role": ["community", "user"], "status": "live", "description": "Post a new intent (find-a-partner, etc.)." },
-    { "name": "list_my_intents", "surface": "Intents", "category": "intents", "role": ["community", "user"], "status": "live", "description": "List the user's posted intents." },
-    { "name": "view_intent_matches", "surface": "Intents", "category": "intents", "role": ["community", "user"], "status": "live", "description": "View matches on a specific intent." },
-    { "name": "get_matchmaker_result", "surface": "Intents", "category": "intents", "role": ["community", "user"], "status": "live", "description": "Poll for matchmaker agent's polished result." },
-    { "name": "mark_intent_fulfilled", "surface": "Intents", "category": "intents", "role": ["community", "user"], "status": "live", "description": "Mark an intent as fulfilled." },
-
-    { "name": "search_memory", "surface": "Memory", "category": "memory", "role": ["community", "user", "developer"], "status": "live", "description": "Keyword-search memory items." },
-    { "name": "search_web", "surface": "Search", "category": "search", "role": ["community", "user"], "status": "live", "description": "Web search (provider-gated)." },
-    { "name": "recall_conversation_at_time", "surface": "Memory", "category": "memory", "role": ["community", "user"], "status": "live", "vtid": "VTID-02052", "description": "Recall a past conversation by time reference." },
-    { "name": "switch_persona", "surface": "Persona", "category": "persona", "role": ["community", "user"], "status": "live", "description": "Switch ORB persona style." },
-    { "name": "report_to_specialist", "surface": "Specialist", "category": "specialist", "role": ["community", "user"], "status": "live", "description": "Hand off to a specialist persona (Devon/Sage/Atlas/Mira)." },
-    { "name": "search_events", "surface": "Community", "category": "community", "role": ["community", "user"], "status": "live", "description": "Search community events." },
-    { "name": "search_community", "surface": "Community", "category": "community", "role": ["community", "user"], "status": "live", "description": "Search community groups." },
-    { "name": "play_music", "surface": "Music", "category": "music", "role": ["community", "user"], "status": "live", "description": "Play music via connected provider." },
-    { "name": "set_capability_preference", "surface": "Settings", "category": "settings", "role": ["community", "user"], "status": "live", "description": "Choose default provider for a capability." },
-    { "name": "read_email", "surface": "Email", "category": "email", "role": ["community", "user"], "status": "live", "description": "Read email via connected Gmail account." },
-    { "name": "find_contact", "surface": "Contacts", "category": "contacts", "role": ["community", "user"], "status": "live", "description": "Find a contact by name." },
-    { "name": "consult_external_ai", "surface": "AI", "category": "ai", "role": ["community", "user"], "status": "live", "description": "Delegate a question to a connected external AI." },
-    { "name": "create_index_improvement_plan", "surface": "Health", "category": "health", "role": ["community", "user"], "status": "live", "description": "Schedule a calendar plan to lift a pillar." },
-    { "name": "ask_pillar_agent", "surface": "Health", "category": "health", "role": ["community", "user"], "status": "live", "description": "Ask a pillar-specific agent a question." },
-    { "name": "explain_feature", "surface": "Help", "category": "help", "role": ["community", "user"], "status": "live", "description": "Explain a Vitana feature." },
-    { "name": "resolve_recipient", "surface": "Chat", "category": "chat", "role": ["community", "user"], "status": "live", "description": "Map a name to a community member user_id." },
-    { "name": "send_chat_message", "surface": "Chat", "category": "chat", "role": ["community", "user"], "status": "live", "description": "Send a DM to another member." },
-    { "name": "share_link", "surface": "Chat", "category": "chat", "role": ["community", "user"], "status": "live", "description": "Share a deep link with another member." },
-    { "name": "share_intent_post", "surface": "Intents", "category": "intents", "role": ["community", "user"], "status": "live", "description": "Share an intent post with someone." },
-    { "name": "scan_existing_matches", "surface": "Intents", "category": "intents", "role": ["community", "user"], "status": "live", "description": "Scan for new matches on existing intents." },
-    { "name": "respond_to_match", "surface": "Intents", "category": "intents", "role": ["community", "user"], "status": "live", "description": "Mark interested/not-interested on a match." },
-    { "name": "navigate_to_screen", "surface": "Navigation", "category": "navigation", "role": ["community", "user"], "status": "live", "description": "Navigate to a canonical app screen." },
-
-    { "name": "log_water", "surface": "Health", "category": "health", "role": ["community"], "status": "live", "vtid": "VTID-02753", "added_in_pr": 1837, "description": "Log a hydration entry (ml).", "backing_endpoint": "POST /api/v1/integrations/manual/log" },
-    { "name": "log_sleep", "surface": "Health", "category": "health", "role": ["community"], "status": "live", "vtid": "VTID-02753", "added_in_pr": 1837, "description": "Log a sleep duration (minutes).", "backing_endpoint": "POST /api/v1/integrations/manual/log" },
-    { "name": "log_exercise", "surface": "Health", "category": "health", "role": ["community"], "status": "live", "vtid": "VTID-02753", "added_in_pr": 1837, "description": "Log an exercise session (minutes + activity type).", "backing_endpoint": "POST /api/v1/integrations/manual/log" },
-    { "name": "log_meditation", "surface": "Health", "category": "health", "role": ["community"], "status": "live", "vtid": "VTID-02753", "added_in_pr": 1837, "description": "Log a meditation/mindfulness session (minutes).", "backing_endpoint": "POST /api/v1/integrations/manual/log" },
-    { "name": "get_pillar_subscores", "surface": "Health", "category": "health", "role": ["community"], "status": "live", "vtid": "VTID-02753", "added_in_pr": 1837, "description": "Break down a pillar score into baseline/completions/data/streak." },
-
-    { "name": "get_highest_vitana_index", "surface": "Superlatives", "category": "community", "role": ["community"], "status": "live", "vtid": "VTID-02754", "added_in_pr": 1857, "description": "Top scorer in the community." },
-    { "name": "get_top_in_pillar", "surface": "Superlatives", "category": "community", "role": ["community"], "status": "live", "vtid": "VTID-02754", "added_in_pr": 1857, "description": "Top scorer in a single pillar." },
-    { "name": "get_first_member", "surface": "Superlatives", "category": "community", "role": ["community"], "status": "live", "vtid": "VTID-02754", "added_in_pr": 1857, "description": "First/OG community member." },
-    { "name": "get_newest_member", "surface": "Superlatives", "category": "community", "role": ["community"], "status": "live", "vtid": "VTID-02754", "added_in_pr": 1857, "description": "Most recent community signup." },
-    { "name": "get_most_followed", "surface": "Superlatives", "category": "community", "role": ["community"], "status": "live", "vtid": "VTID-02754", "added_in_pr": 1857, "description": "Member with the most followers." },
-    { "name": "ask_who_is", "surface": "Superlatives", "category": "community", "role": ["community"], "status": "live", "vtid": "VTID-02754", "added_in_pr": 1857, "description": "NL router for free-form 'who is...?' questions." },
-
-    { "name": "list_diary_entries", "surface": "Diary", "category": "diary", "role": ["community"], "status": "live", "vtid": "VTID-02757", "added_in_pr": 1858, "description": "List the user's diary entries in a date window." },
-    { "name": "get_diary_streak", "surface": "Diary", "category": "diary", "role": ["community"], "status": "live", "vtid": "VTID-02757", "added_in_pr": 1858, "description": "Current + longest diary streak." },
-    { "name": "get_memory_timeline", "surface": "Memory", "category": "memory", "role": ["community"], "status": "live", "vtid": "VTID-02757", "added_in_pr": 1858, "description": "Chronological timeline of facts/diary/events." },
-    { "name": "recall_memory_about", "surface": "Memory", "category": "memory", "role": ["community"], "status": "live", "vtid": "VTID-02757", "added_in_pr": 1858, "description": "Topic search across memory items with category filter." },
-    { "name": "get_memory_garden_summary", "surface": "Memory", "category": "memory", "role": ["community"], "status": "live", "vtid": "VTID-02757", "added_in_pr": 1858, "description": "Counts per memory category — for 'what do you remember about me?'." },
-    { "name": "forget_memory", "surface": "Memory", "category": "memory", "role": ["community"], "status": "live", "vtid": "VTID-02757", "added_in_pr": 1858, "description": "Soft-delete a single memory item by id (after confirm)." },
-
-    { "name": "reschedule_event", "surface": "Calendar", "category": "calendar", "role": ["community"], "status": "live", "vtid": "VTID-02761", "added_in_pr": 1860, "description": "Move a calendar event to a new time." },
-    { "name": "cancel_event", "surface": "Calendar", "category": "calendar", "role": ["community"], "status": "live", "vtid": "VTID-02761", "added_in_pr": 1860, "description": "Soft-cancel a calendar event." },
-    { "name": "complete_event", "surface": "Calendar", "category": "calendar", "role": ["community"], "status": "live", "vtid": "VTID-02761", "added_in_pr": 1860, "description": "Mark an event completed/skipped/partial." },
-    { "name": "find_free_slot", "surface": "Calendar", "category": "calendar", "role": ["community"], "status": "live", "vtid": "VTID-02761", "added_in_pr": 1860, "description": "Find next available slot for a duration." },
-    { "name": "get_event_details", "surface": "Calendar", "category": "calendar", "role": ["community"], "status": "live", "vtid": "VTID-02761", "added_in_pr": 1860, "description": "Read full details of a single event." },
-    { "name": "check_calendar_conflicts", "surface": "Calendar", "category": "calendar", "role": ["community"], "status": "live", "vtid": "VTID-02761", "added_in_pr": 1860, "description": "Find events overlapping a proposed window." },
-
-    { "name": "snooze_reminder", "surface": "Reminders", "category": "reminders", "role": ["community"], "status": "live", "vtid": "VTID-02763", "added_in_pr": 1861, "description": "Push a reminder out by N minutes." },
-    { "name": "update_reminder", "surface": "Reminders", "category": "reminders", "role": ["community"], "status": "live", "vtid": "VTID-02763", "added_in_pr": 1861, "description": "Edit a reminder's text/time." },
-    { "name": "acknowledge_reminder", "surface": "Reminders", "category": "reminders", "role": ["community"], "status": "live", "vtid": "VTID-02763", "added_in_pr": 1861, "description": "Mark a reminder as delivered." },
-    { "name": "complete_reminder", "surface": "Reminders", "category": "reminders", "role": ["community"], "status": "live", "vtid": "VTID-02763", "added_in_pr": 1861, "description": "Mark a reminder as DONE." },
-    { "name": "list_missed_reminders", "surface": "Reminders", "category": "reminders", "role": ["community"], "status": "live", "vtid": "VTID-02763", "added_in_pr": 1861, "description": "List reminders that fired but weren't acked." },
-
-    { "name": "list_my_groups", "surface": "Community", "category": "community", "role": ["community"], "status": "live", "vtid": "VTID-02764", "added_in_pr": 1862, "description": "List the user's group memberships." },
-    { "name": "create_group", "surface": "Community", "category": "community", "role": ["community"], "status": "live", "vtid": "VTID-02764", "added_in_pr": 1862, "description": "Create a new community group." },
-    { "name": "join_group", "surface": "Community", "category": "community", "role": ["community"], "status": "live", "vtid": "VTID-02764", "added_in_pr": 1862, "description": "Join an existing group by id." },
-    { "name": "invite_to_group", "surface": "Community", "category": "community", "role": ["community"], "status": "live", "vtid": "VTID-02764", "added_in_pr": 1862, "description": "Invite a member to a group." },
-    { "name": "accept_invitation", "surface": "Community", "category": "community", "role": ["community"], "status": "live", "vtid": "VTID-02764", "added_in_pr": 1862, "description": "Accept a pending group invitation." },
-    { "name": "decline_invitation", "surface": "Community", "category": "community", "role": ["community"], "status": "live", "vtid": "VTID-02764", "added_in_pr": 1862, "description": "Decline a pending group invitation." },
-
-    { "name": "submit_bug_report", "surface": "Feedback", "category": "feedback", "role": ["community"], "status": "live", "vtid": "VTID-02768", "added_in_pr": 1865, "description": "Hand off to Devon (bug-report specialist)." },
-    { "name": "submit_support_ticket", "surface": "Feedback", "category": "feedback", "role": ["community"], "status": "live", "vtid": "VTID-02768", "added_in_pr": 1865, "description": "Hand off to Sage (support specialist)." },
-    { "name": "submit_marketplace_dispute", "surface": "Feedback", "category": "feedback", "role": ["community"], "status": "live", "vtid": "VTID-02768", "added_in_pr": 1865, "description": "Hand off to Atlas (marketplace dispute)." },
-    { "name": "submit_account_issue", "surface": "Feedback", "category": "feedback", "role": ["community"], "status": "live", "vtid": "VTID-02768", "added_in_pr": 1865, "description": "Hand off to Mira (account specialist)." },
-    { "name": "list_my_tickets", "surface": "Feedback", "category": "feedback", "role": ["community"], "status": "live", "vtid": "VTID-02768", "added_in_pr": 1865, "description": "List the user's open tickets." },
-
-    { "name": "start_conversation", "surface": "Chat", "category": "chat", "role": ["community"], "status": "live", "vtid": "VTID-02771", "added_in_pr": 1866, "description": "Start a new DM conversation." },
-    { "name": "list_conversations", "surface": "Chat", "category": "chat", "role": ["community"], "status": "live", "vtid": "VTID-02771", "added_in_pr": 1866, "description": "List recent conversations." },
-    { "name": "mark_conversation_read", "surface": "Chat", "category": "chat", "role": ["community"], "status": "live", "vtid": "VTID-02771", "added_in_pr": 1866, "description": "Mark a conversation read." },
-    { "name": "mute_conversation", "surface": "Chat", "category": "chat", "role": ["community"], "status": "live", "vtid": "VTID-02771", "added_in_pr": 1866, "description": "Mute a conversation." },
-    { "name": "archive_conversation", "surface": "Chat", "category": "chat", "role": ["community"], "status": "live", "vtid": "VTID-02771", "added_in_pr": 1866, "description": "Archive a conversation." },
-
-    { "name": "set_language", "surface": "Settings", "category": "settings", "role": ["community"], "status": "live", "vtid": "VTID-02772", "added_in_pr": 1869, "description": "Set the UI / voice language." },
-    { "name": "set_theme", "surface": "Settings", "category": "settings", "role": ["community"], "status": "live", "vtid": "VTID-02772", "added_in_pr": 1869, "description": "Set the visual theme." },
-    { "name": "set_voice_preferences", "surface": "Settings", "category": "settings", "role": ["community"], "status": "live", "vtid": "VTID-02772", "added_in_pr": 1869, "description": "Tune voice tone / pace / persona." },
-    { "name": "list_connected_apps", "surface": "Settings", "category": "settings", "role": ["community"], "status": "live", "vtid": "VTID-02772", "added_in_pr": 1869, "description": "List connected integrations." },
-    { "name": "disconnect_app", "surface": "Settings", "category": "settings", "role": ["community"], "status": "live", "vtid": "VTID-02772", "added_in_pr": 1869, "description": "Disconnect an integration." },
-
-    { "name": "global_search", "surface": "Search", "category": "search", "role": ["community"], "status": "live", "vtid": "VTID-02773", "added_in_pr": 1871, "description": "Unified search across people / posts / products / events." },
-    { "name": "browse_news_feed", "surface": "News", "category": "news", "role": ["community"], "status": "live", "vtid": "VTID-02773", "added_in_pr": 1871, "description": "Browse the community news feed." },
-
-    { "name": "rsvp_event", "surface": "Events", "category": "events", "role": ["community"], "status": "live", "vtid": "VTID-02774", "added_in_pr": 1873, "description": "RSVP to an event." },
-    { "name": "cancel_rsvp", "surface": "Events", "category": "events", "role": ["community"], "status": "live", "vtid": "VTID-02774", "added_in_pr": 1873, "description": "Cancel an RSVP." },
-    { "name": "list_upcoming_meetups", "surface": "Events", "category": "events", "role": ["community"], "status": "live", "vtid": "VTID-02774", "added_in_pr": 1873, "description": "List upcoming meetups near the user." },
-    { "name": "join_live_room", "surface": "Events", "category": "events", "role": ["community"], "status": "live", "vtid": "VTID-02774", "added_in_pr": 1873, "description": "Join a live room." },
-
-    { "name": "snooze_recommendation", "surface": "Autopilot", "category": "autopilot", "role": ["community"], "status": "live", "vtid": "VTID-02775", "added_in_pr": 1874, "description": "Push an Autopilot recommendation later." },
-    { "name": "dismiss_recommendation", "surface": "Autopilot", "category": "autopilot", "role": ["community"], "status": "live", "vtid": "VTID-02775", "added_in_pr": 1874, "description": "Dismiss an Autopilot recommendation." },
-    { "name": "explain_recommendation", "surface": "Autopilot", "category": "autopilot", "role": ["community"], "status": "live", "vtid": "VTID-02775", "added_in_pr": 1874, "description": "Get a natural-language reason for a recommendation." },
-
-    { "name": "update_account_visibility", "surface": "Privacy", "category": "privacy", "role": ["community"], "status": "live", "vtid": "VTID-02776", "added_in_pr": 1875, "description": "Toggle account visibility (public / followers-only / private)." },
-    { "name": "update_privacy_field", "surface": "Privacy", "category": "privacy", "role": ["community"], "status": "live", "vtid": "VTID-02776", "added_in_pr": 1875, "description": "Set per-field visibility (e.g. age, location)." },
-    { "name": "block_user", "surface": "Privacy", "category": "privacy", "role": ["community"], "status": "live", "vtid": "VTID-02776", "added_in_pr": 1875, "description": "Block another community member." },
-    { "name": "unblock_user", "surface": "Privacy", "category": "privacy", "role": ["community"], "status": "live", "vtid": "VTID-02776", "added_in_pr": 1875, "description": "Unblock a previously-blocked member." },
-
-    { "name": "update_intent", "surface": "Intents", "category": "intents", "role": ["community"], "status": "live", "vtid": "VTID-02777", "added_in_pr": 1877, "description": "Edit an existing intent post." },
-    { "name": "delete_intent", "surface": "Intents", "category": "intents", "role": ["community"], "status": "live", "vtid": "VTID-02777", "added_in_pr": 1877, "description": "Delete an intent post." },
-    { "name": "browse_intent_board", "surface": "Intents", "category": "intents", "role": ["community"], "status": "live", "vtid": "VTID-02777", "added_in_pr": 1877, "description": "Browse the cross-tenant intent board." },
-    { "name": "dispute_match", "surface": "Intents", "category": "intents", "role": ["community"], "status": "live", "vtid": "VTID-02777", "added_in_pr": 1877, "description": "Open a dispute on a match." },
-
-    { "name": "get_emotional_state", "surface": "Awareness", "category": "awareness", "role": ["community"], "status": "live", "vtid": "VTID-02778", "added_in_pr": 1879, "description": "D28 emotional / cognitive signals." },
-    { "name": "get_situational_awareness", "surface": "Awareness", "category": "awareness", "role": ["community"], "status": "live", "vtid": "VTID-02778", "added_in_pr": 1879, "description": "D32 situational awareness signals." },
-    { "name": "get_availability", "surface": "Awareness", "category": "awareness", "role": ["community"], "status": "live", "vtid": "VTID-02778", "added_in_pr": 1879, "description": "D33 availability / readiness signals." },
-    { "name": "get_environmental_context", "surface": "Awareness", "category": "awareness", "role": ["community"], "status": "live", "vtid": "VTID-02778", "added_in_pr": 1879, "description": "D34 environmental / mobility signals." },
-    { "name": "get_social_context", "surface": "Awareness", "category": "awareness", "role": ["community"], "status": "live", "vtid": "VTID-02778", "added_in_pr": 1879, "description": "D35 social context signals." },
-    { "name": "get_life_stage_context", "surface": "Awareness", "category": "awareness", "role": ["community"], "status": "live", "vtid": "VTID-02778", "added_in_pr": 1879, "description": "D40 life stage signals." },
-
-    { "name": "set_alarm", "surface": "Clock", "category": "clock", "role": ["community"], "status": "live", "vtid": "VTID-02779", "added_in_pr": 1881, "description": "Set a wake-up alarm at HH:MM." },
-    { "name": "list_alarms", "surface": "Clock", "category": "clock", "role": ["community"], "status": "live", "vtid": "VTID-02779", "added_in_pr": 1881, "description": "List active alarms." },
-    { "name": "delete_alarm", "surface": "Clock", "category": "clock", "role": ["community"], "status": "live", "vtid": "VTID-02779", "added_in_pr": 1881, "description": "Cancel an alarm." },
-    { "name": "start_timer", "surface": "Clock", "category": "clock", "role": ["community"], "status": "live", "vtid": "VTID-02779", "added_in_pr": 1881, "description": "Start a countdown timer (60s-24h)." },
-    { "name": "start_pomodoro", "surface": "Clock", "category": "clock", "role": ["community"], "status": "live", "vtid": "VTID-02779", "added_in_pr": 1881, "description": "Start a pomodoro work block (5-90min)." },
-    { "name": "list_active_timers", "surface": "Clock", "category": "clock", "role": ["community"], "status": "live", "vtid": "VTID-02779", "added_in_pr": 1881, "description": "List active timers and pomodoros." },
-    { "name": "get_world_time", "surface": "Clock", "category": "clock", "role": ["community"], "status": "live", "vtid": "VTID-02779", "added_in_pr": 1881, "description": "Current local time in a city or IANA timezone." },
-
-    { "name": "find_perfect_product", "surface": "Marketplace", "category": "marketplace", "role": ["community"], "status": "live", "vtid": "VTID-02780", "added_in_pr": 1883, "description": "Flagship deep search — fuses pillar deficits, Life Compass goal, and multi-criteria filters into top-3 product picks with rationale." },
-    { "name": "find_perfect_practitioner", "surface": "Marketplace", "category": "marketplace", "role": ["community"], "status": "live", "vtid": "VTID-02780", "added_in_pr": 1883, "description": "Flagship practitioner / coach / doctor search with multi-criteria filtering." },
-    { "name": "find_perfect_match", "surface": "Match", "category": "match", "role": ["community"], "status": "live", "vtid": "VTID-02780", "added_in_pr": 1883, "description": "Flagship people-match search (workout partner, accountability buddy, mentor)." },
-    { "name": "ask_who_is", "surface": "Superlatives", "category": "superlatives", "role": ["community"], "status": "live", "vtid": "VTID-02780", "added_in_pr": 1883, "description": "Free-form 'who is...' superlative questions about the community." },
-
-    { "name": "dev_list_vtids", "surface": "Developer", "category": "developer", "role": ["developer", "admin", "exafy_admin"], "status": "live", "vtid": "VTID-02782", "added_in_pr": 1926, "description": "Recent VTIDs from the ledger; filter by status." },
-    { "name": "dev_get_vtid_status", "surface": "Developer", "category": "developer", "role": ["developer", "admin", "exafy_admin"], "status": "live", "vtid": "VTID-02782", "added_in_pr": 1926, "description": "Lookup a single VTID by id." },
-    { "name": "dev_list_pending_approvals", "surface": "Developer", "category": "developer", "role": ["developer", "admin", "exafy_admin"], "status": "live", "vtid": "VTID-02782", "added_in_pr": 1926, "description": "PRs / actions waiting on approval." },
-    { "name": "dev_count_approvals", "surface": "Developer", "category": "developer", "role": ["developer", "admin", "exafy_admin"], "status": "live", "vtid": "VTID-02782", "added_in_pr": 1926, "description": "Pending approval count — for 'how many PRs are waiting?'." },
-    { "name": "dev_approve_pr", "surface": "Developer", "category": "developer", "role": ["developer", "admin", "exafy_admin"], "status": "live", "vtid": "VTID-02782", "added_in_pr": 1926, "description": "Approve a queued PR / action by id (EXEC-DEPLOY hard gate applies)." },
-    { "name": "dev_reject_pr", "surface": "Developer", "category": "developer", "role": ["developer", "admin", "exafy_admin"], "status": "live", "vtid": "VTID-02782", "added_in_pr": 1926, "description": "Reject a queued PR / action with reason." },
-    { "name": "dev_list_voice_sessions", "surface": "Developer", "category": "developer", "role": ["developer", "admin", "exafy_admin"], "status": "live", "vtid": "VTID-02782", "added_in_pr": 1926, "description": "Recent ORB voice sessions for Voice Lab." },
-    { "name": "dev_list_routines", "surface": "Developer", "category": "developer", "role": ["developer", "admin", "exafy_admin"], "status": "live", "vtid": "VTID-02782", "added_in_pr": 1926, "description": "Daily routines + last run status." },
-    { "name": "dev_get_routine_detail", "surface": "Developer", "category": "developer", "role": ["developer", "admin", "exafy_admin"], "status": "live", "vtid": "VTID-02782", "added_in_pr": 1926, "description": "Routine detail + last N runs." },
-    { "name": "dev_list_active_healing", "surface": "Developer", "category": "developer", "role": ["developer", "admin", "exafy_admin"], "status": "live", "vtid": "VTID-02782", "added_in_pr": 1926, "description": "Self-healing runs in flight." },
-    { "name": "dev_get_autonomy_pulse", "surface": "Developer", "category": "developer", "role": ["developer", "admin", "exafy_admin"], "status": "live", "vtid": "VTID-02782", "added_in_pr": 1926, "description": "Autonomy loop metrics (in-flight VTIDs, terminalized, healing runs)." },
-    { "name": "dev_list_agents", "surface": "Developer", "category": "developer", "role": ["developer", "admin", "exafy_admin"], "status": "live", "vtid": "VTID-02782", "added_in_pr": 1926, "description": "21-agent registry with heartbeat status." }
+    {
+      "name": "search_knowledge",
+      "surface": "Knowledge",
+      "category": "knowledge",
+      "role": [
+        "community",
+        "user",
+        "operator",
+        "admin",
+        "developer"
+      ],
+      "status": "live",
+      "description": "Search the Vitana knowledge base."
+    },
+    {
+      "name": "search_calendar",
+      "surface": "Calendar",
+      "category": "calendar",
+      "role": [
+        "community",
+        "user",
+        "operator"
+      ],
+      "status": "live",
+      "description": "Search calendar events."
+    },
+    {
+      "name": "get_schedule",
+      "surface": "Calendar",
+      "category": "calendar",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Read the user's calendar via connected provider."
+    },
+    {
+      "name": "create_calendar_event",
+      "surface": "Calendar",
+      "category": "calendar",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Create a calendar event."
+    },
+    {
+      "name": "add_to_calendar",
+      "surface": "Calendar",
+      "category": "calendar",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Add an event via connected provider."
+    },
+    {
+      "name": "get_recommendations",
+      "surface": "Autopilot",
+      "category": "autopilot",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Fetch Autopilot recommendations."
+    },
+    {
+      "name": "activate_recommendation",
+      "surface": "Autopilot",
+      "category": "autopilot",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Activate a recommendation."
+    },
+    {
+      "name": "get_vitana_index",
+      "surface": "Health",
+      "category": "health",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Return the user's current Vitana Index."
+    },
+    {
+      "name": "get_index_improvement_suggestions",
+      "surface": "Health",
+      "category": "health",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Suggest concrete actions to lift the Index."
+    },
+    {
+      "name": "save_diary_entry",
+      "surface": "Diary",
+      "category": "diary",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "vtid": "VTID-01983",
+      "description": "Save a diary entry from voice."
+    },
+    {
+      "name": "set_reminder",
+      "surface": "Reminders",
+      "category": "reminders",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "vtid": "VTID-02601",
+      "description": "Create a one-shot reminder."
+    },
+    {
+      "name": "find_reminders",
+      "surface": "Reminders",
+      "category": "reminders",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "vtid": "VTID-02601",
+      "description": "Search active reminders."
+    },
+    {
+      "name": "delete_reminder",
+      "surface": "Reminders",
+      "category": "reminders",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "vtid": "VTID-02601",
+      "description": "Delete one or all reminders (after confirm)."
+    },
+    {
+      "name": "post_intent",
+      "surface": "Intents",
+      "category": "intents",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Post a new intent (find-a-partner, etc.)."
+    },
+    {
+      "name": "list_my_intents",
+      "surface": "Intents",
+      "category": "intents",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "List the user's posted intents."
+    },
+    {
+      "name": "view_intent_matches",
+      "surface": "Intents",
+      "category": "intents",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "View matches on a specific intent."
+    },
+    {
+      "name": "get_matchmaker_result",
+      "surface": "Intents",
+      "category": "intents",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Poll for matchmaker agent's polished result."
+    },
+    {
+      "name": "mark_intent_fulfilled",
+      "surface": "Intents",
+      "category": "intents",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Mark an intent as fulfilled."
+    },
+    {
+      "name": "search_memory",
+      "surface": "Memory",
+      "category": "memory",
+      "role": [
+        "community",
+        "user",
+        "developer"
+      ],
+      "status": "live",
+      "description": "Keyword-search memory items."
+    },
+    {
+      "name": "search_web",
+      "surface": "Search",
+      "category": "search",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Web search (provider-gated)."
+    },
+    {
+      "name": "recall_conversation_at_time",
+      "surface": "Memory",
+      "category": "memory",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "vtid": "VTID-02052",
+      "description": "Recall a past conversation by time reference."
+    },
+    {
+      "name": "switch_persona",
+      "surface": "Persona",
+      "category": "persona",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Switch ORB persona style."
+    },
+    {
+      "name": "report_to_specialist",
+      "surface": "Specialist",
+      "category": "specialist",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Hand off to a specialist persona (Devon/Sage/Atlas/Mira)."
+    },
+    {
+      "name": "search_events",
+      "surface": "Community",
+      "category": "community",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Search community events."
+    },
+    {
+      "name": "search_community",
+      "surface": "Community",
+      "category": "community",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Search community groups."
+    },
+    {
+      "name": "play_music",
+      "surface": "Music",
+      "category": "music",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Play music via connected provider."
+    },
+    {
+      "name": "set_capability_preference",
+      "surface": "Settings",
+      "category": "settings",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Choose default provider for a capability."
+    },
+    {
+      "name": "read_email",
+      "surface": "Email",
+      "category": "email",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Read email via connected Gmail account."
+    },
+    {
+      "name": "find_contact",
+      "surface": "Contacts",
+      "category": "contacts",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Find a contact by name."
+    },
+    {
+      "name": "consult_external_ai",
+      "surface": "AI",
+      "category": "ai",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Delegate a question to a connected external AI."
+    },
+    {
+      "name": "create_index_improvement_plan",
+      "surface": "Health",
+      "category": "health",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Schedule a calendar plan to lift a pillar."
+    },
+    {
+      "name": "ask_pillar_agent",
+      "surface": "Health",
+      "category": "health",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Ask a pillar-specific agent a question."
+    },
+    {
+      "name": "explain_feature",
+      "surface": "Help",
+      "category": "help",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Explain a Vitana feature."
+    },
+    {
+      "name": "resolve_recipient",
+      "surface": "Chat",
+      "category": "chat",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Map a name to a community member user_id."
+    },
+    {
+      "name": "send_chat_message",
+      "surface": "Chat",
+      "category": "chat",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Send a DM to another member."
+    },
+    {
+      "name": "share_link",
+      "surface": "Chat",
+      "category": "chat",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Share a deep link with another member."
+    },
+    {
+      "name": "share_intent_post",
+      "surface": "Intents",
+      "category": "intents",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Share an intent post with someone."
+    },
+    {
+      "name": "scan_existing_matches",
+      "surface": "Intents",
+      "category": "intents",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Scan for new matches on existing intents."
+    },
+    {
+      "name": "respond_to_match",
+      "surface": "Intents",
+      "category": "intents",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Mark interested/not-interested on a match."
+    },
+    {
+      "name": "navigate_to_screen",
+      "surface": "Navigation",
+      "category": "navigation",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Navigate to a canonical app screen."
+    },
+    {
+      "name": "log_water",
+      "surface": "Health",
+      "category": "health",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "vtid": "VTID-02753",
+      "added_in_pr": 1837,
+      "description": "Log a hydration entry (ml).",
+      "backing_endpoint": "POST /api/v1/integrations/manual/log"
+    },
+    {
+      "name": "log_sleep",
+      "surface": "Health",
+      "category": "health",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "vtid": "VTID-02753",
+      "added_in_pr": 1837,
+      "description": "Log a sleep duration (minutes).",
+      "backing_endpoint": "POST /api/v1/integrations/manual/log"
+    },
+    {
+      "name": "log_exercise",
+      "surface": "Health",
+      "category": "health",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "vtid": "VTID-02753",
+      "added_in_pr": 1837,
+      "description": "Log an exercise session (minutes + activity type).",
+      "backing_endpoint": "POST /api/v1/integrations/manual/log"
+    },
+    {
+      "name": "log_meditation",
+      "surface": "Health",
+      "category": "health",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "vtid": "VTID-02753",
+      "added_in_pr": 1837,
+      "description": "Log a meditation/mindfulness session (minutes).",
+      "backing_endpoint": "POST /api/v1/integrations/manual/log"
+    },
+    {
+      "name": "get_pillar_subscores",
+      "surface": "Health",
+      "category": "health",
+      "role": [
+        "community"
+      ],
+      "status": "live",
+      "vtid": "VTID-02753",
+      "added_in_pr": 1837,
+      "description": "Break down a pillar score into baseline/completions/data/streak."
+    },
+    {
+      "name": "get_highest_vitana_index",
+      "surface": "Superlatives",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02754",
+      "added_in_pr": 1857,
+      "description": "Top scorer in the community."
+    },
+    {
+      "name": "get_top_in_pillar",
+      "surface": "Superlatives",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02754",
+      "added_in_pr": 1857,
+      "description": "Top scorer in a single pillar."
+    },
+    {
+      "name": "get_first_member",
+      "surface": "Superlatives",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02754",
+      "added_in_pr": 1857,
+      "description": "First/OG community member."
+    },
+    {
+      "name": "get_newest_member",
+      "surface": "Superlatives",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02754",
+      "added_in_pr": 1857,
+      "description": "Most recent community signup."
+    },
+    {
+      "name": "get_most_followed",
+      "surface": "Superlatives",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02754",
+      "added_in_pr": 1857,
+      "description": "Member with the most followers."
+    },
+    {
+      "name": "ask_who_is",
+      "surface": "Superlatives",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02754",
+      "added_in_pr": 1857,
+      "description": "NL router for free-form 'who is...?' questions."
+    },
+    {
+      "name": "list_diary_entries",
+      "surface": "Diary",
+      "category": "diary",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02757",
+      "added_in_pr": 1858,
+      "description": "List the user's diary entries in a date window."
+    },
+    {
+      "name": "get_diary_streak",
+      "surface": "Diary",
+      "category": "diary",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02757",
+      "added_in_pr": 1858,
+      "description": "Current + longest diary streak."
+    },
+    {
+      "name": "get_memory_timeline",
+      "surface": "Memory",
+      "category": "memory",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02757",
+      "added_in_pr": 1858,
+      "description": "Chronological timeline of facts/diary/events."
+    },
+    {
+      "name": "recall_memory_about",
+      "surface": "Memory",
+      "category": "memory",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02757",
+      "added_in_pr": 1858,
+      "description": "Topic search across memory items with category filter."
+    },
+    {
+      "name": "get_memory_garden_summary",
+      "surface": "Memory",
+      "category": "memory",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02757",
+      "added_in_pr": 1858,
+      "description": "Counts per memory category \u2014 for 'what do you remember about me?'."
+    },
+    {
+      "name": "forget_memory",
+      "surface": "Memory",
+      "category": "memory",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02757",
+      "added_in_pr": 1858,
+      "description": "Soft-delete a single memory item by id (after confirm)."
+    },
+    {
+      "name": "reschedule_event",
+      "surface": "Calendar",
+      "category": "calendar",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02761",
+      "added_in_pr": 1860,
+      "description": "Move a calendar event to a new time."
+    },
+    {
+      "name": "cancel_event",
+      "surface": "Calendar",
+      "category": "calendar",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02761",
+      "added_in_pr": 1860,
+      "description": "Soft-cancel a calendar event."
+    },
+    {
+      "name": "complete_event",
+      "surface": "Calendar",
+      "category": "calendar",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02761",
+      "added_in_pr": 1860,
+      "description": "Mark an event completed/skipped/partial."
+    },
+    {
+      "name": "find_free_slot",
+      "surface": "Calendar",
+      "category": "calendar",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02761",
+      "added_in_pr": 1860,
+      "description": "Find next available slot for a duration."
+    },
+    {
+      "name": "get_event_details",
+      "surface": "Calendar",
+      "category": "calendar",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02761",
+      "added_in_pr": 1860,
+      "description": "Read full details of a single event."
+    },
+    {
+      "name": "check_calendar_conflicts",
+      "surface": "Calendar",
+      "category": "calendar",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02761",
+      "added_in_pr": 1860,
+      "description": "Find events overlapping a proposed window."
+    },
+    {
+      "name": "snooze_reminder",
+      "surface": "Reminders",
+      "category": "reminders",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02763",
+      "added_in_pr": 1861,
+      "description": "Push a reminder out by N minutes."
+    },
+    {
+      "name": "update_reminder",
+      "surface": "Reminders",
+      "category": "reminders",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02763",
+      "added_in_pr": 1861,
+      "description": "Edit a reminder's text/time."
+    },
+    {
+      "name": "acknowledge_reminder",
+      "surface": "Reminders",
+      "category": "reminders",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02763",
+      "added_in_pr": 1861,
+      "description": "Mark a reminder as delivered."
+    },
+    {
+      "name": "complete_reminder",
+      "surface": "Reminders",
+      "category": "reminders",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02763",
+      "added_in_pr": 1861,
+      "description": "Mark a reminder as DONE."
+    },
+    {
+      "name": "list_missed_reminders",
+      "surface": "Reminders",
+      "category": "reminders",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02763",
+      "added_in_pr": 1861,
+      "description": "List reminders that fired but weren't acked."
+    },
+    {
+      "name": "list_my_groups",
+      "surface": "Community",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02764",
+      "added_in_pr": 1862,
+      "description": "List the user's group memberships."
+    },
+    {
+      "name": "create_group",
+      "surface": "Community",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02764",
+      "added_in_pr": 1862,
+      "description": "Create a new community group."
+    },
+    {
+      "name": "join_group",
+      "surface": "Community",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02764",
+      "added_in_pr": 1862,
+      "description": "Join an existing group by id."
+    },
+    {
+      "name": "invite_to_group",
+      "surface": "Community",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02764",
+      "added_in_pr": 1862,
+      "description": "Invite a member to a group."
+    },
+    {
+      "name": "accept_invitation",
+      "surface": "Community",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02764",
+      "added_in_pr": 1862,
+      "description": "Accept a pending group invitation."
+    },
+    {
+      "name": "decline_invitation",
+      "surface": "Community",
+      "category": "community",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02764",
+      "added_in_pr": 1862,
+      "description": "Decline a pending group invitation."
+    },
+    {
+      "name": "submit_bug_report",
+      "surface": "Feedback",
+      "category": "feedback",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02768",
+      "added_in_pr": 1865,
+      "description": "Hand off to Devon (bug-report specialist)."
+    },
+    {
+      "name": "submit_support_ticket",
+      "surface": "Feedback",
+      "category": "feedback",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02768",
+      "added_in_pr": 1865,
+      "description": "Hand off to Sage (support specialist)."
+    },
+    {
+      "name": "submit_marketplace_dispute",
+      "surface": "Feedback",
+      "category": "feedback",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02768",
+      "added_in_pr": 1865,
+      "description": "Hand off to Atlas (marketplace dispute)."
+    },
+    {
+      "name": "submit_account_issue",
+      "surface": "Feedback",
+      "category": "feedback",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02768",
+      "added_in_pr": 1865,
+      "description": "Hand off to Mira (account specialist)."
+    },
+    {
+      "name": "list_my_tickets",
+      "surface": "Feedback",
+      "category": "feedback",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02768",
+      "added_in_pr": 1865,
+      "description": "List the user's open tickets."
+    },
+    {
+      "name": "start_conversation",
+      "surface": "Chat",
+      "category": "chat",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02771",
+      "added_in_pr": 1866,
+      "description": "Start a new DM conversation."
+    },
+    {
+      "name": "list_conversations",
+      "surface": "Chat",
+      "category": "chat",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02771",
+      "added_in_pr": 1866,
+      "description": "List recent conversations."
+    },
+    {
+      "name": "mark_conversation_read",
+      "surface": "Chat",
+      "category": "chat",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02771",
+      "added_in_pr": 1866,
+      "description": "Mark a conversation read."
+    },
+    {
+      "name": "mute_conversation",
+      "surface": "Chat",
+      "category": "chat",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02771",
+      "added_in_pr": 1866,
+      "description": "Mute a conversation."
+    },
+    {
+      "name": "archive_conversation",
+      "surface": "Chat",
+      "category": "chat",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02771",
+      "added_in_pr": 1866,
+      "description": "Archive a conversation."
+    },
+    {
+      "name": "set_language",
+      "surface": "Settings",
+      "category": "settings",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02772",
+      "added_in_pr": 1869,
+      "description": "Set the UI / voice language."
+    },
+    {
+      "name": "set_theme",
+      "surface": "Settings",
+      "category": "settings",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02772",
+      "added_in_pr": 1869,
+      "description": "Set the visual theme."
+    },
+    {
+      "name": "set_voice_preferences",
+      "surface": "Settings",
+      "category": "settings",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02772",
+      "added_in_pr": 1869,
+      "description": "Tune voice tone / pace / persona."
+    },
+    {
+      "name": "list_connected_apps",
+      "surface": "Settings",
+      "category": "settings",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02772",
+      "added_in_pr": 1869,
+      "description": "List connected integrations."
+    },
+    {
+      "name": "disconnect_app",
+      "surface": "Settings",
+      "category": "settings",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02772",
+      "added_in_pr": 1869,
+      "description": "Disconnect an integration."
+    },
+    {
+      "name": "global_search",
+      "surface": "Search",
+      "category": "search",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02773",
+      "added_in_pr": 1871,
+      "description": "Unified search across people / posts / products / events."
+    },
+    {
+      "name": "browse_news_feed",
+      "surface": "News",
+      "category": "news",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02773",
+      "added_in_pr": 1871,
+      "description": "Browse the community news feed."
+    },
+    {
+      "name": "rsvp_event",
+      "surface": "Events",
+      "category": "events",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02774",
+      "added_in_pr": 1873,
+      "description": "RSVP to an event."
+    },
+    {
+      "name": "cancel_rsvp",
+      "surface": "Events",
+      "category": "events",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02774",
+      "added_in_pr": 1873,
+      "description": "Cancel an RSVP."
+    },
+    {
+      "name": "list_upcoming_meetups",
+      "surface": "Events",
+      "category": "events",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02774",
+      "added_in_pr": 1873,
+      "description": "List upcoming meetups near the user."
+    },
+    {
+      "name": "join_live_room",
+      "surface": "Events",
+      "category": "events",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02774",
+      "added_in_pr": 1873,
+      "description": "Join a live room."
+    },
+    {
+      "name": "snooze_recommendation",
+      "surface": "Autopilot",
+      "category": "autopilot",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02775",
+      "added_in_pr": 1874,
+      "description": "Push an Autopilot recommendation later."
+    },
+    {
+      "name": "dismiss_recommendation",
+      "surface": "Autopilot",
+      "category": "autopilot",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02775",
+      "added_in_pr": 1874,
+      "description": "Dismiss an Autopilot recommendation."
+    },
+    {
+      "name": "explain_recommendation",
+      "surface": "Autopilot",
+      "category": "autopilot",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02775",
+      "added_in_pr": 1874,
+      "description": "Get a natural-language reason for a recommendation."
+    },
+    {
+      "name": "update_account_visibility",
+      "surface": "Privacy",
+      "category": "privacy",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02776",
+      "added_in_pr": 1875,
+      "description": "Toggle account visibility (public / followers-only / private)."
+    },
+    {
+      "name": "update_privacy_field",
+      "surface": "Privacy",
+      "category": "privacy",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02776",
+      "added_in_pr": 1875,
+      "description": "Set per-field visibility (e.g. age, location)."
+    },
+    {
+      "name": "block_user",
+      "surface": "Privacy",
+      "category": "privacy",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02776",
+      "added_in_pr": 1875,
+      "description": "Block another community member."
+    },
+    {
+      "name": "unblock_user",
+      "surface": "Privacy",
+      "category": "privacy",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02776",
+      "added_in_pr": 1875,
+      "description": "Unblock a previously-blocked member."
+    },
+    {
+      "name": "update_intent",
+      "surface": "Intents",
+      "category": "intents",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02777",
+      "added_in_pr": 1877,
+      "description": "Edit an existing intent post."
+    },
+    {
+      "name": "delete_intent",
+      "surface": "Intents",
+      "category": "intents",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02777",
+      "added_in_pr": 1877,
+      "description": "Delete an intent post."
+    },
+    {
+      "name": "browse_intent_board",
+      "surface": "Intents",
+      "category": "intents",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02777",
+      "added_in_pr": 1877,
+      "description": "Browse the cross-tenant intent board."
+    },
+    {
+      "name": "dispute_match",
+      "surface": "Intents",
+      "category": "intents",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02777",
+      "added_in_pr": 1877,
+      "description": "Open a dispute on a match."
+    },
+    {
+      "name": "get_emotional_state",
+      "surface": "Awareness",
+      "category": "awareness",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02778",
+      "added_in_pr": 1879,
+      "description": "D28 emotional / cognitive signals."
+    },
+    {
+      "name": "get_situational_awareness",
+      "surface": "Awareness",
+      "category": "awareness",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02778",
+      "added_in_pr": 1879,
+      "description": "D32 situational awareness signals."
+    },
+    {
+      "name": "get_availability",
+      "surface": "Awareness",
+      "category": "awareness",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02778",
+      "added_in_pr": 1879,
+      "description": "D33 availability / readiness signals."
+    },
+    {
+      "name": "get_environmental_context",
+      "surface": "Awareness",
+      "category": "awareness",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02778",
+      "added_in_pr": 1879,
+      "description": "D34 environmental / mobility signals."
+    },
+    {
+      "name": "get_social_context",
+      "surface": "Awareness",
+      "category": "awareness",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02778",
+      "added_in_pr": 1879,
+      "description": "D35 social context signals."
+    },
+    {
+      "name": "get_life_stage_context",
+      "surface": "Awareness",
+      "category": "awareness",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02778",
+      "added_in_pr": 1879,
+      "description": "D40 life stage signals."
+    },
+    {
+      "name": "set_alarm",
+      "surface": "Clock",
+      "category": "clock",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02779",
+      "added_in_pr": 1881,
+      "description": "Set a wake-up alarm at HH:MM."
+    },
+    {
+      "name": "list_alarms",
+      "surface": "Clock",
+      "category": "clock",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02779",
+      "added_in_pr": 1881,
+      "description": "List active alarms."
+    },
+    {
+      "name": "delete_alarm",
+      "surface": "Clock",
+      "category": "clock",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02779",
+      "added_in_pr": 1881,
+      "description": "Cancel an alarm."
+    },
+    {
+      "name": "start_timer",
+      "surface": "Clock",
+      "category": "clock",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02779",
+      "added_in_pr": 1881,
+      "description": "Start a countdown timer (60s-24h)."
+    },
+    {
+      "name": "start_pomodoro",
+      "surface": "Clock",
+      "category": "clock",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02779",
+      "added_in_pr": 1881,
+      "description": "Start a pomodoro work block (5-90min)."
+    },
+    {
+      "name": "list_active_timers",
+      "surface": "Clock",
+      "category": "clock",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02779",
+      "added_in_pr": 1881,
+      "description": "List active timers and pomodoros."
+    },
+    {
+      "name": "get_world_time",
+      "surface": "Clock",
+      "category": "clock",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02779",
+      "added_in_pr": 1881,
+      "description": "Current local time in a city or IANA timezone."
+    },
+    {
+      "name": "find_perfect_product",
+      "surface": "Marketplace",
+      "category": "marketplace",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02780",
+      "added_in_pr": 1883,
+      "description": "Flagship deep search \u2014 fuses pillar deficits, Life Compass goal, and multi-criteria filters into top-3 product picks with rationale."
+    },
+    {
+      "name": "find_perfect_practitioner",
+      "surface": "Marketplace",
+      "category": "marketplace",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02780",
+      "added_in_pr": 1883,
+      "description": "Flagship practitioner / coach / doctor search with multi-criteria filtering."
+    },
+    {
+      "name": "find_perfect_match",
+      "surface": "Match",
+      "category": "match",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02780",
+      "added_in_pr": 1883,
+      "description": "Flagship people-match search (workout partner, accountability buddy, mentor)."
+    },
+    {
+      "name": "ask_who_is",
+      "surface": "Superlatives",
+      "category": "superlatives",
+      "role": [
+        "community"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02780",
+      "added_in_pr": 1883,
+      "description": "Free-form 'who is...' superlative questions about the community."
+    },
+    {
+      "name": "dev_list_vtids",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02782",
+      "added_in_pr": 1926,
+      "description": "Recent VTIDs from the ledger; filter by status."
+    },
+    {
+      "name": "dev_get_vtid_status",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02782",
+      "added_in_pr": 1926,
+      "description": "Lookup a single VTID by id."
+    },
+    {
+      "name": "dev_list_pending_approvals",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02782",
+      "added_in_pr": 1926,
+      "description": "PRs / actions waiting on approval."
+    },
+    {
+      "name": "dev_count_approvals",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02782",
+      "added_in_pr": 1926,
+      "description": "Pending approval count \u2014 for 'how many PRs are waiting?'."
+    },
+    {
+      "name": "dev_approve_pr",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02782",
+      "added_in_pr": 1926,
+      "description": "Approve a queued PR / action by id (EXEC-DEPLOY hard gate applies)."
+    },
+    {
+      "name": "dev_reject_pr",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02782",
+      "added_in_pr": 1926,
+      "description": "Reject a queued PR / action with reason."
+    },
+    {
+      "name": "dev_list_voice_sessions",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02782",
+      "added_in_pr": 1926,
+      "description": "Recent ORB voice sessions for Voice Lab."
+    },
+    {
+      "name": "dev_list_routines",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02782",
+      "added_in_pr": 1926,
+      "description": "Daily routines + last run status."
+    },
+    {
+      "name": "dev_get_routine_detail",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02782",
+      "added_in_pr": 1926,
+      "description": "Routine detail + last N runs."
+    },
+    {
+      "name": "dev_list_active_healing",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02782",
+      "added_in_pr": 1926,
+      "description": "Self-healing runs in flight."
+    },
+    {
+      "name": "dev_get_autonomy_pulse",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02782",
+      "added_in_pr": 1926,
+      "description": "Autonomy loop metrics (in-flight VTIDs, terminalized, healing runs)."
+    },
+    {
+      "name": "dev_list_agents",
+      "surface": "Developer",
+      "category": "developer",
+      "role": [
+        "developer",
+        "admin",
+        "exafy_admin"
+      ],
+      "status": "planned",
+      "vtid": "VTID-02782",
+      "added_in_pr": 1926,
+      "description": "21-agent registry with heartbeat status."
+    },
+    {
+      "name": "admin_briefing",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin",
+        "developer"
+      ],
+      "status": "live",
+      "description": "Top open admin_insights for the tenant."
+    },
+    {
+      "name": "admin_kpi_snapshot",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin",
+        "developer"
+      ],
+      "status": "live",
+      "description": "Current KPI family snapshot for the tenant."
+    },
+    {
+      "name": "admin_insight_detail",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin",
+        "developer"
+      ],
+      "status": "live",
+      "description": "Full body of one admin insight."
+    },
+    {
+      "name": "admin_approve",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin",
+        "developer"
+      ],
+      "status": "live",
+      "description": "Mark an insight approved."
+    },
+    {
+      "name": "admin_reject",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin",
+        "developer"
+      ],
+      "status": "live",
+      "description": "Mark an insight rejected."
+    },
+    {
+      "name": "admin_snooze",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin",
+        "developer"
+      ],
+      "status": "live",
+      "description": "Snooze an insight for N hours/days."
+    },
+    {
+      "name": "admin_history",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin",
+        "developer"
+      ],
+      "status": "live",
+      "description": "KPI family time-series for the last N days."
+    },
+    {
+      "name": "admin_health_check",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin",
+        "developer"
+      ],
+      "status": "live",
+      "description": "Tenant-health-index probe."
+    },
+    {
+      "name": "admin_pause_autopilot",
+      "surface": "Admin",
+      "category": "admin",
+      "role": [
+        "admin",
+        "exafy_admin",
+        "developer"
+      ],
+      "status": "live",
+      "description": "Emergency pause request for tenant autopilot."
+    },
+    {
+      "name": "find_community_member",
+      "surface": "Community",
+      "category": "community",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Resolve a community member by name (alias for resolve_recipient on the discover surface)."
+    },
+    {
+      "name": "get_current_screen",
+      "surface": "Navigation",
+      "category": "navigation",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Return the screen the user is currently looking at."
+    },
+    {
+      "name": "navigate",
+      "surface": "Navigation",
+      "category": "navigation",
+      "role": [
+        "community",
+        "user"
+      ],
+      "status": "live",
+      "description": "Navigate to a target screen (alias for navigate_to_screen)."
+    }
   ]
 }


### PR DESCRIPTION
## Problem
The manifest shipped in #1935 marked every entry as \`status: live\` regardless of whether the tool was actually wired into the dispatcher. The catalog UI was lying to operators — 135 entries all showing the LIVE pill when only ~45 of them actually dispatched.

## Audit
A tool is \`live\` iff its name appears in any of:
- \`services/gateway/src/routes/orb-live.ts\` (Vertex / Gemini Live declarations)
- \`services/gateway/src/services/orb-tools-shared.ts\` (LiveKit \`ORB_TOOL_REGISTRY\`)
- \`services/gateway/src/services/admin-voice-tools.ts\` (admin tools)

Cross-referencing the manifest against those three sources on current \`main\`:

| Status | Before | After |
|---|---|---|
| Total entries | 135 | **147** |
| Live | 135 (claimed) | **57** (truth) |
| Planned | 0 | **90** |

## Changes
1. Flipped 90 entries from \`live\` → \`planned\` based on the audit.
2. Added 12 live tools that were missing from the manifest entirely:
   - 9 admin tools (\`admin_briefing\`, \`admin_kpi_snapshot\`, \`admin_insight_detail\`, \`admin_approve\`, \`admin_reject\`, \`admin_snooze\`, \`admin_history\`, \`admin_health_check\`, \`admin_pause_autopilot\`)
   - 3 navigation/community tools (\`find_community_member\`, \`get_current_screen\`, \`navigate\`)

The 90 \`planned\` entries are real follow-up work — they correspond to the P1b–P1s expansion PRs whose branches never merged because \`main\` moved 58 commits ahead with the dispatcher refactor. Migrating them to the new \`ORB_TOOL_REGISTRY\` shape flips each one from \`planned\` → \`live\`.

## Test plan
- [ ] After deploy: \`/api/v1/voice-tools/catalog/stats\` returns \`by_status: { live: 57, planned: 90 }\`.
- [ ] Catalog UI shows the LIVE pill on 57 rows; the rest show a neutral PLANNED badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)