### PR TITLE
fix(intents): lift posting + share caps for pre-1k phase (VTID-02831)

### DIFF
--- a/services/gateway/src/routes/intents-share.ts
+++ b/services/gateway/src/routes/intents-share.ts
@@ -18,8 +18,8 @@
  *     public posts render for everyone (auth or not); tenant posts require
  *     login + same tenant; private/mutual_reveal soft-403.
  *
- * Rate limits + tier-aware caps come from getEffectiveLimits()
- * (vitana-business-model.md Feature 1). Operator override is unconditional.
+ * VTID-02831 (2026-05-07): per-batch and per-post share caps lifted for the
+ * pre-1k-user growth phase. Operator override remains unconditional.
  */
 
 import { Router, Request, Response } from 'express';
@@ -29,9 +29,8 @@ import { emitOasisEvent } from '../services/oasis-event-service';
 
 const router = Router();
 
-// MVP caps. Once entitlements.ts lands these become tier-driven.
-const MAX_RECIPIENTS_PER_BATCH_FREE = 20;
-const MAX_SHARES_PER_POST_FREE = 50;
+// VTID-02831 (2026-05-07): per-batch + per-post share caps lifted for the
+// pre-1k-user growth phase. Re-introduce when abuse signal demands it.
 
 // ── POST /api/v1/intents/:intent_id/share ──────────────────────
 // Absolute path so we can keep this router mounted at '/' and serve the
@@ -56,14 +55,6 @@ router.post('/api/v1/intents/:intent_id/share', requireAuth, requireTenant, asyn
   }
   if (recipientIds.length === 0) {
     return res.status(400).json({ ok: false, error: 'RECIPIENTS_REQUIRED', message: 'recipient_vitana_ids must be a non-empty array of valid vitana_ids.' });
-  }
-  if (recipientIds.length > MAX_RECIPIENTS_PER_BATCH_FREE) {
-    return res.status(429).json({
-      ok: false,
-      error: 'BATCH_TOO_LARGE',
-      message: `Free tier allows up to ${MAX_RECIPIENTS_PER_BATCH_FREE} recipients per share. Upgrade to Pro for 50.`,
-      limit: MAX_RECIPIENTS_PER_BATCH_FREE,
-    });
   }
 
   const supabase = getSupabase();
@@ -95,22 +86,7 @@ router.post('/api/v1/intents/:intent_id/share', requireAuth, requireTenant, asyn
     return res.status(403).json({ ok: false, error: 'PRIVATE_POST', message: 'Private posts cannot be shared.' });
   }
 
-  // 2. Per-post lifetime cap check.
-  const { count: existingShares } = await supabase
-    .from('intent_matches')
-    .select('match_id', { count: 'exact', head: true })
-    .eq('intent_a_id', intentId)
-    .eq('kind_pairing', 'direct_share');
-  if (typeof existingShares === 'number' && existingShares >= MAX_SHARES_PER_POST_FREE) {
-    return res.status(429).json({
-      ok: false,
-      error: 'SHARE_QUOTA_EXCEEDED',
-      message: `This post has reached its free-tier share limit (${MAX_SHARES_PER_POST_FREE}). Upgrade to Pro for 200 or Biz for unlimited.`,
-      limit: MAX_SHARES_PER_POST_FREE,
-    });
-  }
-
-  // 3. Resolve recipient vitana_ids → user_ids. Only matches inside the
+  // 2. Resolve recipient vitana_ids → user_ids. Only matches inside the
   // sharer's tenant (when the intent is tenant-scoped). For public posts we
   // allow cross-tenant resolution.
   const tenantScope = visibility === 'public' ? null : (srcIntent as any).tenant_id;

--- a/services/gateway/src/services/intent-throttle.ts
+++ b/services/gateway/src/services/intent-throttle.ts
@@ -1,24 +1,20 @@
 /**
  * VTID-01973: Throttle (P2-A).
  *
- * Per-user posting caps to deter spam and bound new-account abuse:
- *   - Account < 7 days old: 1 open intent across all kinds, max budget €500.
- *   - Mature accounts: 20 open intents per kind, 3 posts per kind per 24h.
+ * VTID-02831 (2026-05-07): all per-day / per-month / per-person posting caps
+ * lifted for the pre-1k-user growth phase. The voice assistant was apologizing
+ * whenever the throttle blocked a post even though the row was never inserted,
+ * which produced a confusing UX where users heard "I cannot post" while seeing
+ * earlier posts in their list. With caps lifted, the only remaining pre-insert
+ * blocks are content filter and tier gates — both legitimate "no row created"
+ * cases the voice can honestly report.
  *
- * VTID-02719 (2026-05-04): per-kind open cap raised 5 → 20 after early
- * users hit the limit on legitimate use. Daily 3/24h anti-spam cap
- * unchanged.
+ * The function is preserved (always returns ok:true) so call sites in
+ * intents.ts and orb-live.ts don't have to change. Re-introduce caps here once
+ * the user base passes ~1k and abuse signal demands it.
  */
 
-import { createClient } from '@supabase/supabase-js';
 import type { IntentKind } from './intent-classifier';
-
-const SUPABASE_URL = process.env.SUPABASE_URL!;
-const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE!;
-
-function getSupabase() {
-  return createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
-}
 
 interface ThrottleResult {
   ok: boolean;
@@ -26,78 +22,10 @@ interface ThrottleResult {
   detail?: string;
 }
 
-const NEW_ACCOUNT_DAYS = 7;
-const NEW_ACCOUNT_MAX_OPEN = 1;
-const NEW_ACCOUNT_MAX_BUDGET_EUR = 500;
-const MATURE_MAX_OPEN_PER_KIND = 20;
-const MATURE_MAX_POSTS_PER_KIND_PER_24H = 3;
-
-export async function canPostIntent(args: {
+export async function canPostIntent(_args: {
   userId: string;
   kind: IntentKind;
   budgetMaxEur: number | null;
 }): Promise<ThrottleResult> {
-  const supabase = getSupabase();
-
-  // 1. Account age — read auth.users.created_at via app_users (already keyed by user_id).
-  const { data: appUser } = await supabase
-    .from('app_users')
-    .select('created_at')
-    .eq('user_id', args.userId)
-    .maybeSingle();
-
-  const accountCreatedAt = appUser?.created_at ? new Date(appUser.created_at as string) : new Date();
-  const accountAgeDays = (Date.now() - accountCreatedAt.getTime()) / (1000 * 60 * 60 * 24);
-  const isNewAccount = accountAgeDays < NEW_ACCOUNT_DAYS;
-
-  // 2. Open intent count.
-  const { count: openCount } = await supabase
-    .from('user_intents')
-    .select('*', { count: 'exact', head: true })
-    .eq('requester_user_id', args.userId)
-    .in('status', ['open', 'matched', 'engaged']);
-
-  if (isNewAccount && (openCount ?? 0) >= NEW_ACCOUNT_MAX_OPEN) {
-    return { ok: false, reason: 'new_account_cap', detail: `New accounts (<${NEW_ACCOUNT_DAYS}d) limited to ${NEW_ACCOUNT_MAX_OPEN} open intent.` };
-  }
-
-  // Per-kind open cap (mature accounts).
-  if (!isNewAccount) {
-    const { count: openKindCount } = await supabase
-      .from('user_intents')
-      .select('*', { count: 'exact', head: true })
-      .eq('requester_user_id', args.userId)
-      .eq('intent_kind', args.kind)
-      .in('status', ['open', 'matched', 'engaged']);
-
-    if ((openKindCount ?? 0) >= MATURE_MAX_OPEN_PER_KIND) {
-      return { ok: false, reason: 'open_intent_cap', detail: `Limit of ${MATURE_MAX_OPEN_PER_KIND} open ${args.kind} intents.` };
-    }
-  }
-
-  // 3. New-account budget cap (commercial only).
-  if (isNewAccount && (args.kind === 'commercial_buy' || args.kind === 'commercial_sell')) {
-    if (args.budgetMaxEur !== null && args.budgetMaxEur > NEW_ACCOUNT_MAX_BUDGET_EUR) {
-      return { ok: false, reason: 'budget_cap', detail: `New accounts capped at €${NEW_ACCOUNT_MAX_BUDGET_EUR}.` };
-    }
-  }
-
-  // 4. Daily post cap per kind (mature).
-  // VTID-02719: exclude user-closed rows so manually freeing a slot also frees
-  // the 24h slot. Other terminal statuses (flagged/rejected) still count, so
-  // anti-spam is preserved.
-  const since = new Date(Date.now() - 24 * 60 * 60 * 1000).toISOString();
-  const { count: dayCount } = await supabase
-    .from('user_intents')
-    .select('*', { count: 'exact', head: true })
-    .eq('requester_user_id', args.userId)
-    .eq('intent_kind', args.kind)
-    .gte('created_at', since)
-    .neq('status', 'closed');
-
-  if (!isNewAccount && (dayCount ?? 0) >= MATURE_MAX_POSTS_PER_KIND_PER_24H) {
-    return { ok: false, reason: 'daily_post_cap', detail: `Max ${MATURE_MAX_POSTS_PER_KIND_PER_24H} ${args.kind} posts per 24h.` };
-  }
-
   return { ok: true };
 }


### PR DESCRIPTION
## Summary
- canPostIntent() always returns ok:true — drops the new-account 1-open cap, the mature 20-open-per-kind cap, the 3-per-kind-per-24h daily cap, and the new-account 500€ budget cap. Function + result type retained so intents.ts and orb-live.ts don't change.
- intents-share.ts drops MAX_RECIPIENTS_PER_BATCH_FREE (20) and MAX_SHARES_PER_POST_FREE (50) so /intents/:id/share never 429s on count.
- Content filter, dedup, and trust-tier gates untouched — legitimate "no row inserted" cases the voice can honestly report.

## Why
User reports two issues with "find a match":
1. Posting hits limits prematurely while we're still pre-1k users.
2. Voice assistant says "I cannot post" while the post still appears in the list.

Both stem from the same path: throttle blocks the new attempt (voice rightly reports failure for that attempt), but the user's earlier posts remain visible. Lifting the caps removes the false-positive block entirely — voice and backend now agree.

## Test plan
- [ ] EXEC-DEPLOY runs on merge (VTID in commit + branch)
- [ ] gateway /api/v1/intents POST x5 → no 429
- [ ] Voice ORB: dictate "find me a match" 5x → all land in user_intents, voice confirms each