### PR TITLE
fix(orb-live): kick matchmaker agent from voice post_intent (VTID-02832)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -6484,6 +6484,7 @@ async function executeLiveApiToolInner(
           const { notifyMatchSurfaced } = await import('../services/intent-notifier');
           const { writeIntentFacts } = await import('../services/intent-memory-hooks');
           const { getActiveCompassGoal } = await import('../services/intent-compass-lens');
+          const { runMatchmakerAsync } = await import('../services/matchmaker-agent');
           const { createClient } = await import('@supabase/supabase-js');
 
           // Classify (or use kind_hint).
@@ -6610,6 +6611,19 @@ async function executeLiveApiToolInner(
             }
           } catch (err: any) {
             console.warn(`[VTID-02716] post_intent embedding non-fatal: ${err?.message}`);
+          }
+
+          // VTID-02832: kick the async matchmaker agent so the row exists in
+          // intent_match_recommendations by the time Gemini polls
+          // get_matchmaker_result (~3s later). Without this kick the poll
+          // returns status='not_started' — a status the tool description
+          // doesn't enumerate, so Gemini freelances and apologizes ("I had a
+          // problem making the post") even though the post is live. Mirrors
+          // intents.ts:370 (REST POST path).
+          try {
+            runMatchmakerAsync(intentId);
+          } catch (err: any) {
+            console.warn(`[VTID-02832] matchmaker async kick failed (non-fatal): ${err?.message}`);
           }
 
           writeIntentFacts({


### PR DESCRIPTION
## Why
After a voice-posted intent, Vitana says "I had a problem making the post" even though the post is live in `user_intents`. VTID-02716 and VTID-02790 made the `post_intent` handler bulletproof on its own response shape, but a different tool was producing the apology.

## Root cause
The `get_matchmaker_result` tool description ([orb-live.ts:3471-3488](services/gateway/src/routes/orb-live.ts#L3471-L3488)) tells Gemini "Call this 3 seconds after post_intent" and enumerates four statuses: `pending`, `running`, `complete`, `error`.

The poll endpoint at [intents.ts:407](services/gateway/src/routes/intents.ts#L407) reads from `intent_match_recommendations`. The REST POST `/intents` path at [intents.ts:370](services/gateway/src/routes/intents.ts#L370) calls `runMatchmakerAsync()` right after insert. The **voice** `post_intent` tool handler at [orb-live.ts:6606](services/gateway/src/routes/orb-live.ts#L6606) **did not**. So:

- voice insert → no matchmaker kicked → no row in `intent_match_recommendations`
- 3 s later, Gemini calls `get_matchmaker_result` → server returns `status: 'not_started'` (a status the tool description doesn't enumerate)
- Gemini freelances → "I had a problem making the post"

## Fix
Mirror the REST path. After insert in the voice tool, fire-and-forget `runMatchmakerAsync(intentId)`. The agent writes `pending` immediately, runs in the background, and updates to `complete`/`error` — all known to Gemini. Kick is wrapped in try/catch and logged, so a kick failure can never reach the user (per VTID-02716 lesson).

## Files
- `services/gateway/src/routes/orb-live.ts` — `case 'post_intent'` (added import + kick)

## Test plan
- [ ] Mobile: voice-create a Find-a-Match post. Vitana should announce success — no apology.
- [ ] Cloud Run logs: confirm `[VTID-DANCE-D12]` poll on a freshly voice-posted intent now hits `status='pending'` first, then `complete`/`error` — never `not_started`.
- [ ] `intent_match_recommendations` has a row for every voice-posted intent.

🤖 Generated with [Claude Code](https://claude.com/claude-code)