### PR TITLE
fix(orb-live): voice post_intent now triggers cover resolution chain (VTID-02806g)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -6597,6 +6597,29 @@ async function executeLiveApiToolInner(
           postedVid = vid;
           postedKind = intentKind;
 
+          // VTID-02806g — Fire-and-forget cover-photo resolution. The form
+          // composer (POST /api/v1/intents) does this on every insert;
+          // the voice path was missing it, so every dictated intent ended
+          // up with cover_url=NULL and the frontend fell back to a static
+          // themed JPG that looked AI-generated. Now the resolution chain
+          // runs (library exact-category → universal → gender-aware AI →
+          // curated) so a user with a universal photo or a category-tagged
+          // library entry sees their own photo on dictated posts.
+          import('../services/intent-cover-service')
+            .then(({ generateCoverForIntent, themeFromCategory }) =>
+              generateCoverForIntent({
+                intentId,
+                userId: session.identity!.user_id,
+                theme: themeFromCategory(extract.category),
+              }),
+            )
+            .catch((err: unknown) => {
+              const msg = err instanceof Error ? err.message : 'unknown';
+              console.warn(
+                `[cover] voice-post auto-gen failed for ${intentId}: ${msg}`,
+              );
+            });
+
           // VTID-02716: row is now in user_intents — every side-effect below must be
           // best-effort. A throw here would otherwise reach the outer catch and Gemini
           // would say "I have a problem making the post" while the post sits in the user's list.


### PR DESCRIPTION
## Summary

Voice posts (via the ORB `post_intent` tool) skipped cover-photo generation entirely. They inserted directly into `user_intents` and never called `generateCoverForIntent`, so:

- `cover_url` and `cover_source` stayed NULL
- The frontend's `getIntentCoverUrl()` fell back to `pickThemedCover()` — a deterministic stock JPG that *looked* AI-generated
- Users who set a universal photo or category-tagged library entry never saw it on dictated posts

This adds the same fire-and-forget `generateCoverForIntent` call the form-composer route (`POST /api/v1/intents`) already does, right after the row is inserted. The chain now runs for voice posts too: library exact-category → universal → gender-aware Vertex Imagen → curated.

## Backfill

The 4 most recent voice-posted intents have NULL covers. They can be filled by hitting `POST /api/v1/intents/:id/cover/generate {"force":true}` for each, which I'll do in this session post-deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)