### PR TITLE
fix(dev-autopilot): block re-approval when finding has unmerged PR

### DIFF
--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -353,6 +353,40 @@ export async function approveAutoExecute(input: ApprovalInput): Promise<Approval
     };
   }
 
+  // VTID-AUTOPILOT-PR-FLOOD: refuse to approve a finding that already has
+  // a PR opened by an earlier execution where the PR was never merged.
+  // The pre-existing in-flight check (autoApproveTick line ~2487) only
+  // skips findings whose execution status is in
+  // (cooling,running,ci,merging,deploying,verifying) — it does NOT cover
+  // failed/reverted executions. The executor never closes the GitHub PR
+  // on failure (see reconciler line ~1812 — it only OBSERVES PR state),
+  // so each failed execution leaves a stranded open PR. autoApproveTick
+  // then re-picks the still-status='new' finding, opens another PR, and
+  // the cycle repeats. The 2026-05-07 sweep had to close 530 PRs from
+  // a handful of findings (one had 290 stranded PRs alone) because the
+  // retry cap (5 failures / 24h) wasn't enough to outrun a 30s tick
+  // running for days. This guard makes "PR opened, not merged, prior
+  // execution didn't reach 'completed' or 'self_healed'" a hard block
+  // at approval time. Operator must close/merge the existing PR (which
+  // flips its execution to 'completed' or 'auto_archived') before any
+  // new attempt is approved.
+  const openPrR = await supa<Array<{ id: string; pr_url: string | null; pr_number: number | null; status: string }>>(
+    s,
+    `/rest/v1/dev_autopilot_executions?finding_id=eq.${input.finding_id}`
+    + `&pr_url=not.is.null`
+    + `&status=not.in.(completed,self_healed,auto_archived)`
+    + `&select=id,pr_url,pr_number,status&order=approved_at.desc&limit=1`,
+  );
+  if (openPrR.ok && openPrR.data && openPrR.data.length > 0) {
+    const stranded = openPrR.data[0];
+    return {
+      ok: false,
+      error: `finding ${input.finding_id.slice(0, 8)} already has an unmerged PR `
+        + `(${stranded.pr_url || `#${stranded.pr_number}`}) from a prior execution `
+        + `(status=${stranded.status}) — close or merge it before re-approving`,
+    };
+  }
+
   // 2. Load latest plan version
   const planR = await supa<Array<{ version: number; files_referenced: string[]; plan_markdown: string }>>(
     s,
@@ -2491,6 +2525,20 @@ export async function autoApproveTick(): Promise<void> {
       + `&select=id&limit=1`,
     );
     if (inflightR.ok && inflightR.data && inflightR.data.length > 0) continue;
+
+    // VTID-AUTOPILOT-PR-FLOOD: also skip findings whose prior execution
+    // opened a PR that was never merged. The status-based inflight check
+    // above misses failed/reverted executions whose GitHub PR is still
+    // open — the executor never closes a PR on failure. See the matching
+    // guard in approveAutoExecute() for the full root-cause writeup.
+    const strandedPrR = await supa<Array<{ id: string }>>(
+      s,
+      `/rest/v1/dev_autopilot_executions?finding_id=eq.${f.id}`
+      + `&pr_url=not.is.null`
+      + `&status=not.in.(completed,self_healed,auto_archived)`
+      + `&select=id&limit=1`,
+    );
+    if (strandedPrR.ok && strandedPrR.data && strandedPrR.data.length > 0) continue;
 
     // VTID-AUTOPILOT-RETRY-CAP: per-finding aggregate retry circuit breaker.
     // The bridge has per-chain max_auto_fix_depth=2, but autoApproveTick

--- a/services/gateway/test/dev-autopilot-finding-completion.test.ts
+++ b/services/gateway/test/dev-autopilot-finding-completion.test.ts
@@ -128,15 +128,141 @@ describe('approveAutoExecute — VTID-02639 finding-completion guard', () => {
       spec_snapshot: {},
       status: 'new',
     }]));
+    // Open-PR check → empty (no stranded PR from a prior execution).
+    fetchMock.mockResolvedValueOnce(mockResponse([]));
     // Plan-version lookup → empty (so we error with "plan version required",
-    // proving we got past the status check).
+    // proving we got past both early guards).
     fetchMock.mockResolvedValueOnce(mockResponse([]));
 
     const result = await approveAutoExecute({ finding_id: 'f-5' });
 
     expect(result.ok).toBe(false);
     expect(result.error).not.toMatch(/status is/);
+    expect(result.error).not.toMatch(/already has an unmerged PR/);
     expect(result.error).toMatch(/plan version required/);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+});
+
+describe('approveAutoExecute — VTID-AUTOPILOT-PR-FLOOD open-PR guard', () => {
+  let fetchMock: FetchMock;
+
+  beforeAll(() => {
+    process.env.SUPABASE_URL = 'https://test.supabase.co';
+    process.env.SUPABASE_SERVICE_ROLE = 'test_service_role_key';
+  });
+
+  afterAll(() => {
+    if (ORIGINAL_SUPABASE_URL === undefined) delete process.env.SUPABASE_URL;
+    else process.env.SUPABASE_URL = ORIGINAL_SUPABASE_URL;
+    if (ORIGINAL_SUPABASE_SERVICE_ROLE === undefined) delete process.env.SUPABASE_SERVICE_ROLE;
+    else process.env.SUPABASE_SERVICE_ROLE = ORIGINAL_SUPABASE_SERVICE_ROLE;
+    global.fetch = ORIGINAL_FETCH;
+  });
+
+  beforeEach(() => {
+    fetchMock = jest.fn() as FetchMock;
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  it('rejects a status="new" finding that has an unmerged PR from a failed prior execution', async () => {
+    // 1. Finding lookup → status='new', would normally pass the first guard.
+    fetchMock.mockResolvedValueOnce(mockResponse([{
+      id: 'f-flood-1',
+      risk_class: 'low',
+      source_type: 'dev_autopilot',
+      spec_snapshot: {},
+      status: 'new',
+    }]));
+    // 2. Open-PR check → returns a stranded execution row from a prior
+    //    failed run that opened PR #1234 and never closed it.
+    fetchMock.mockResolvedValueOnce(mockResponse([{
+      id: 'exec-prior-1',
+      pr_url: 'https://github.com/exafyltd/vitana-platform/pull/1234',
+      pr_number: 1234,
+      status: 'failed',
+    }]));
+
+    const result = await approveAutoExecute({ finding_id: 'f-flood-1' });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/already has an unmerged PR/);
+    expect(result.error).toMatch(/pull\/1234/);
+    expect(result.error).toMatch(/status=failed/);
+    expect(result.error).toMatch(/close or merge it before re-approving/);
+    // Should short-circuit BEFORE loading the plan — exactly two fetches.
     expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('rejects when a prior execution has reverted state and a stranded PR', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse([{
+      id: 'f-flood-2',
+      risk_class: 'medium',
+      source_type: 'dev_autopilot_impact',
+      spec_snapshot: {},
+      status: 'new',
+    }]));
+    fetchMock.mockResolvedValueOnce(mockResponse([{
+      id: 'exec-prior-2',
+      pr_url: 'https://github.com/exafyltd/vitana-platform/pull/9999',
+      pr_number: 9999,
+      status: 'reverted',
+    }]));
+
+    const result = await approveAutoExecute({ finding_id: 'f-flood-2' });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/already has an unmerged PR/);
+    expect(result.error).toMatch(/status=reverted/);
+  });
+
+  it('does NOT block when prior executions all reached completed/self_healed/auto_archived', async () => {
+    // The PostgREST filter status=not.in.(completed,self_healed,auto_archived)
+    // returns an empty array because every prior execution is in a terminal
+    // "PR was handled" state. The guard must allow the new approval to
+    // proceed. We mock that filter result and assert we drop into the
+    // plan-version lookup (which we then short-circuit with empty).
+    fetchMock.mockResolvedValueOnce(mockResponse([{
+      id: 'f-flood-3',
+      risk_class: 'low',
+      source_type: 'dev_autopilot',
+      spec_snapshot: {},
+      status: 'new',
+    }]));
+    // Open-PR check → empty (filter excludes completed/self_healed/auto_archived).
+    fetchMock.mockResolvedValueOnce(mockResponse([]));
+    // Plan-version lookup → empty so we error with "plan version required".
+    fetchMock.mockResolvedValueOnce(mockResponse([]));
+
+    const result = await approveAutoExecute({ finding_id: 'f-flood-3' });
+
+    expect(result.ok).toBe(false);
+    expect(result.error).not.toMatch(/already has an unmerged PR/);
+    expect(result.error).toMatch(/plan version required/);
+    expect(fetchMock).toHaveBeenCalledTimes(3);
+  });
+
+  it('issues the correct PostgREST filter for the open-PR check', async () => {
+    fetchMock.mockResolvedValueOnce(mockResponse([{
+      id: 'f-flood-4',
+      risk_class: 'low',
+      source_type: 'dev_autopilot',
+      spec_snapshot: {},
+      status: 'new',
+    }]));
+    fetchMock.mockResolvedValueOnce(mockResponse([]));
+    fetchMock.mockResolvedValueOnce(mockResponse([]));
+
+    await approveAutoExecute({ finding_id: 'f-flood-4' });
+
+    // Assert the second fetch (the open-PR check) hit the right URL with
+    // the right filters. Without these we'd silently regress to the
+    // pre-fix behaviour where dev_autopilot_executions was never queried.
+    const openPrCall = fetchMock.mock.calls[1];
+    const url = String(openPrCall?.[0] ?? '');
+    expect(url).toMatch(/dev_autopilot_executions/);
+    expect(url).toMatch(/finding_id=eq\.f-flood-4/);
+    expect(url).toMatch(/pr_url=not\.is\.null/);
+    expect(url).toMatch(/status=not\.in\.\(completed,self_healed,auto_archived\)/);
   });
 });

--- a/supabase/ops/arm_dev_autopilot_kill_switch.sql
+++ b/supabase/ops/arm_dev_autopilot_kill_switch.sql
@@ -1,0 +1,15 @@
+-- One-shot operational SQL to ARM the Dev Autopilot kill switch.
+-- Run via RUN-MIGRATION.yml against this file path.
+-- Disarm with disarm_dev_autopilot_kill_switch.sql once the duplicate-PR
+-- guard has shipped and been verified in production.
+
+\set ON_ERROR_STOP on
+
+UPDATE dev_autopilot_config
+SET kill_switch = true,
+    updated_at = now()
+WHERE id = 1;
+
+SELECT id, kill_switch, updated_at
+FROM dev_autopilot_config
+WHERE id = 1;

--- a/supabase/ops/diagnose_autopilot_duplicates.sql
+++ b/supabase/ops/diagnose_autopilot_duplicates.sql
@@ -1,0 +1,83 @@
+-- Diagnostic: explain the duplicate-PR storm.
+-- Read-only; safe to run.
+
+\set ON_ERROR_STOP on
+
+\echo '=== 1. Findings created in last 5 days ==='
+SELECT date_trunc('day', created_at) AS day,
+       count(*) AS findings,
+       count(DISTINCT signal_fingerprint) AS distinct_fingerprints,
+       count(*) FILTER (WHERE status = 'new') AS still_new,
+       count(*) FILTER (WHERE status = 'completed') AS completed,
+       count(*) FILTER (WHERE status = 'snoozed') AS snoozed,
+       count(*) FILTER (WHERE status = 'rejected') AS rejected
+FROM autopilot_recommendations
+WHERE source_type IN ('dev_autopilot', 'dev_autopilot_impact')
+  AND created_at >= now() - interval '5 days'
+GROUP BY 1
+ORDER BY 1 DESC;
+
+\echo ''
+\echo '=== 2. Top 10 fingerprints by execution count (last 5 days) ==='
+SELECT r.signal_fingerprint,
+       count(DISTINCT r.id) AS finding_count,
+       count(e.id) AS exec_count,
+       count(e.pr_url) AS prs_opened,
+       array_agg(DISTINCT e.status) AS exec_statuses,
+       max(r.title) AS sample_title
+FROM autopilot_recommendations r
+LEFT JOIN dev_autopilot_executions e ON e.finding_id = r.id
+WHERE r.source_type IN ('dev_autopilot', 'dev_autopilot_impact')
+  AND r.created_at >= now() - interval '5 days'
+GROUP BY r.signal_fingerprint
+ORDER BY exec_count DESC NULLS LAST
+LIMIT 10;
+
+\echo ''
+\echo '=== 3. Findings with > 1 execution row ==='
+SELECT r.id AS finding_id,
+       r.signal_fingerprint,
+       r.status,
+       r.title,
+       count(e.id) AS exec_count,
+       count(e.pr_url) AS prs_opened,
+       array_agg(e.status ORDER BY e.approved_at) AS exec_statuses
+FROM autopilot_recommendations r
+JOIN dev_autopilot_executions e ON e.finding_id = r.id
+WHERE r.source_type IN ('dev_autopilot', 'dev_autopilot_impact')
+  AND r.created_at >= now() - interval '5 days'
+GROUP BY r.id, r.signal_fingerprint, r.status, r.title
+HAVING count(e.id) > 1
+ORDER BY count(e.id) DESC
+LIMIT 15;
+
+\echo ''
+\echo '=== 4. Execution status distribution (last 5 days) ==='
+SELECT status, count(*) AS rows
+FROM dev_autopilot_executions
+WHERE approved_at >= now() - interval '5 days'
+GROUP BY 1
+ORDER BY 2 DESC;
+
+\echo ''
+\echo '=== 5. Are duplicate PRs sharing finding_id, or one-PR-per-finding? ==='
+WITH pr_per_finding AS (
+  SELECT finding_id, count(*) AS prs
+  FROM dev_autopilot_executions
+  WHERE pr_url IS NOT NULL
+    AND approved_at >= now() - interval '5 days'
+  GROUP BY finding_id
+)
+SELECT prs AS prs_per_finding,
+       count(*) AS findings_with_this_many_prs,
+       sum(prs) AS total_prs_in_bucket
+FROM pr_per_finding
+GROUP BY prs
+ORDER BY prs DESC;
+
+\echo ''
+\echo '=== 6. Did the inflight unique index actually exist? ==='
+SELECT indexname, indexdef
+FROM pg_indexes
+WHERE tablename = 'dev_autopilot_executions'
+  AND indexname LIKE '%inflight%';

--- a/supabase/ops/disarm_dev_autopilot_kill_switch.sql
+++ b/supabase/ops/disarm_dev_autopilot_kill_switch.sql
@@ -1,0 +1,14 @@
+-- One-shot operational SQL to DISARM the Dev Autopilot kill switch.
+-- Run via RUN-MIGRATION.yml after the duplicate-PR guard has shipped and
+-- the queue of stuck duplicate PRs has been reconciled.
+
+\set ON_ERROR_STOP on
+
+UPDATE dev_autopilot_config
+SET kill_switch = false,
+    updated_at = now()
+WHERE id = 1;
+
+SELECT id, kill_switch, updated_at
+FROM dev_autopilot_config
+WHERE id = 1;


### PR DESCRIPTION
## Why
Dev Autopilot accumulated **530 open PRs in 4 days**. One finding alone produced **290 stranded PRs**.

The pre-existing in-flight check in autoApproveTick only skipped findings whose execution was in (cooling, running, ci, merging, deploying, verifying). It did NOT cover (failed, reverted, failed_escalated). The executor never closes the GitHub PR on failure (the reconciler around line 1812 only OBSERVES PR state). So every failed execution left a stranded open PR, the finding stayed status='new', and the next 30-second tick approved a fresh execution that opened yet another PR.

The 5-failures-in-24h retry cap is too loose to outrun a 30-second tick running for days.

## What
Two-layer guard in services/gateway/src/services/dev-autopilot-execute.ts:

1. approveAutoExecute — early-return when the finding has any prior execution row with pr_url IS NOT NULL whose status is not in (completed, self_healed, auto_archived). Operator must close or merge the stranded PR before another can be approved.
2. autoApproveTick — same check, applied before the approval call so the LLM / cost path is never entered.

## Tests
4 new cases in dev-autopilot-finding-completion.test.ts. All 9 tests in the suite pass. npm run build clean.

## Stop-the-bleed companion
- arm_dev_autopilot_kill_switch.sql — already applied via RUN-MIGRATION run 25523386719. Kill switch is currently ARMED in production.
- disarm_dev_autopilot_kill_switch.sql — apply via RUN-MIGRATION after this PR is merged + deployed AND the existing open PR queue has been bulk-closed.

## Order of operations after merge
1. EXEC-DEPLOY ships gateway with the guard
2. Bulk-close the 530 duplicate PRs + delete their branches
3. Apply disarm_dev_autopilot_kill_switch.sql
4. Watch autopilot_recommendations over the next 24h to confirm no resurgence

🤖 Generated with [Claude Code](https://claude.com/claude-code)