### PR TITLE
feat(VTID-02833): PR 1.B-0 — LiveKit data-channel directive emission

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/directives.py
+++ b/services/agents/orb-agent/src/orb_agent/directives.py
@@ -1,0 +1,98 @@
+"""LiveKit data-channel directive emission.
+
+Vertex's voice pipeline emits structured "orb_directive" payloads via SSE/WS
+so the orb widget can react out-of-band — open URLs natively, navigate to a
+profile after find_community_member, autoplay a music track, etc. LiveKit
+has no SSE/WS, but it does have a reliable data channel on the Room. This
+module exposes a small helper that publishes a directive on a fixed topic
+("orb_directive") so the test page (and eventually the production orb
+widget) can subscribe and apply the same directive types byte-for-byte.
+
+Wire-up:
+
+    1. session.py stashes the live `Room` on the GatewayClient (`gw.room`).
+    2. Tool wrappers that receive a structured directive in the gateway
+       response call `await publish_orb_directive(gw.room, directive)`
+       before returning the voice text to the LLM.
+    3. The browser side listens to `room.on(RoomEvent.DataReceived, ...)`,
+       JSON-decodes the payload, dispatches by `directive` (open_url,
+       navigate, etc.) the same way the SSE/WS branch does today.
+
+Why a fixed topic: gives subscribers a clean filter without needing to
+parse every message that flows on the data channel. Reliable=True because
+losing a directive (e.g. "navigate to /u/dragan1") materially breaks UX.
+"""
+from __future__ import annotations
+
+import json
+import logging
+from typing import Any
+
+logger = logging.getLogger(__name__)
+
+ORB_DIRECTIVE_TOPIC = "orb_directive"
+
+# Lazy import — keeps this module importable in unit tests on machines that
+# don't have livekit installed (the rest of the agent code uses the same
+# pattern).
+try:  # pragma: no cover
+    from livekit import rtc  # type: ignore[import-not-found]
+    LK_AVAILABLE = True
+except ImportError:  # pragma: no cover
+    rtc = None  # type: ignore[assignment]
+    LK_AVAILABLE = False
+
+
+async def publish_orb_directive(room: Any, payload: dict[str, Any]) -> bool:
+    """Publish an orb directive on the room's data channel.
+
+    Returns True if the publish succeeded, False otherwise. Never raises —
+    a failed directive must not bubble up and kill the tool call. The LLM
+    has already spoken the voice cue at this point, so a missed redirect
+    becomes a user-recoverable miss (they re-ask) rather than a tool error.
+    """
+    if not LK_AVAILABLE or room is None:
+        logger.warning("publish_orb_directive: livekit not available or room missing")
+        return False
+
+    try:
+        body = json.dumps(payload, ensure_ascii=False).encode("utf-8")
+    except (TypeError, ValueError) as exc:
+        logger.warning("publish_orb_directive: failed to JSON-encode payload: %s", exc)
+        return False
+
+    try:
+        # livekit-rtc API: room.local_participant.publish_data(payload, *,
+        # reliable=True, topic="...")
+        await room.local_participant.publish_data(
+            body,
+            reliable=True,
+            topic=ORB_DIRECTIVE_TOPIC,
+        )
+        return True
+    except Exception as exc:  # noqa: BLE001 — never propagate
+        logger.warning("publish_orb_directive: publish_data failed: %s", exc)
+        return False
+
+
+def extract_directive(body: dict[str, Any] | None) -> dict[str, Any] | None:
+    """Pull a directive out of a gateway tool-response body.
+
+    Both shapes are accepted:
+      { "ok": true, "result": { "directive": {...} }, ... }
+      { "ok": true, "directive": {...}, ... }
+
+    Returns None when no directive is present (the common case for tools
+    that just speak text back).
+    """
+    if not isinstance(body, dict):
+        return None
+    direct = body.get("directive")
+    if isinstance(direct, dict):
+        return direct
+    nested = body.get("result")
+    if isinstance(nested, dict):
+        d = nested.get("directive")
+        if isinstance(d, dict):
+            return d
+    return None

--- a/services/agents/orb-agent/src/orb_agent/gateway_client.py
+++ b/services/agents/orb-agent/src/orb_agent/gateway_client.py
@@ -39,6 +39,14 @@ class GatewayClient:
         self._tenant_id = tenant_id
         self._active_role = active_role
         self._client = httpx.AsyncClient(timeout=timeout_s)
+        # The live LiveKit Room handle is stashed by session.py after the
+        # AgentSession spins up. Tool wrappers that receive a structured
+        # `directive` payload from the gateway use this to call
+        # publish_orb_directive() and the data-channel listener on the
+        # frontend handles the redirect / open-url. Optional — typed Any
+        # here so unit tests on machines without livekit installed don't
+        # need to import rtc just to construct a stub.
+        self.room: Any = None
 
     def _headers(self) -> dict[str, str]:
         h = {"Content-Type": "application/json"}

--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -332,6 +332,13 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     # AgentSession glues together STT + LLM + TTS + the room. userdata
     # carries the per-session GatewayClient so each tool body can pull it off
     # RunContext.userdata. max_tool_steps is the tool-loop guard threshold.
+    # PR 1.B-0: stash the live Room handle on the GatewayClient so tool
+    # wrappers that receive a `directive` payload can publish on the data
+    # channel via publish_orb_directive(gw.room, directive). The frontend's
+    # data-channel listener applies the directive (open_url, navigate, etc.)
+    # the same way the SSE/WS branch does on Vertex.
+    gw.room = ctx.room
+
     session = AgentSession(
         stt=cascade.stt,
         llm=cascade.llm,

--- a/services/agents/orb-agent/src/orb_agent/tools.py
+++ b/services/agents/orb-agent/src/orb_agent/tools.py
@@ -78,6 +78,35 @@ async def _dispatch(ctx: RunContext, name: str, args: dict[str, Any] | None = No
     return await _gw(ctx).post("/api/v1/orb/tool", {"name": name, "args": args or {}})
 
 
+async def _dispatch_with_directive(
+    ctx: RunContext,
+    name: str,
+    args: dict[str, Any] | None = None,
+) -> dict[str, Any]:
+    """`_dispatch` plus auto-publish any `directive` payload via the data channel.
+
+    Tools whose gateway response includes a structured `result.directive`
+    (find_community_member, play_music, navigate, view_intent_matches, etc.)
+    use this wrapper instead of `_dispatch`. The directive flows out on the
+    LiveKit data channel — the frontend listener applies it (open URL,
+    navigate to profile, autoplay track) the same way the Vertex SSE/WS
+    branch does today.
+
+    Returns the raw gateway body so the caller can still build the LLM-facing
+    voice text via `summarize(body)`.
+    """
+    from .directives import extract_directive, publish_orb_directive  # local import
+
+    gw = _gw(ctx)
+    body = await gw.post("/api/v1/orb/tool", {"name": name, "args": args or {}})
+    directive = extract_directive(body)
+    if directive is not None:
+        published = await publish_orb_directive(gw.room, directive)
+        if not published:
+            logger.warning("tool %s: directive present but data-channel publish failed", name)
+    return body
+
+
 # ---------------------------------------------------------------------------
 # Memory / Knowledge / Recall
 # ---------------------------------------------------------------------------

--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -35689,6 +35689,33 @@ function renderLivekitTestView() {
         transcriptEl.scrollTop = transcriptEl.scrollHeight;
     }
 
+    /**
+     * PR 1.B-0 — handle an orb_directive received on the LiveKit data channel.
+     * Parallel to Vertex's SSE/WS orb_directive handler in orb-widget.js.
+     *
+     * Supported directives:
+     *   - open_url      → window.open(url, '_blank') (e.g. play_music opens the native music app)
+     *   - navigate      → window.location.href = route (e.g. find_community_member redirects to /u/:vitana_id)
+     *
+     * Logged to the on-screen events panel so testers can see exactly what fired.
+     */
+    function handleOrbDirective(msg) {
+        if (!msg || typeof msg !== 'object') return;
+        var kind = msg.directive || msg.kind;
+        if (kind === 'open_url' && msg.url) {
+            log('info', 'orb_directive open_url', { url: msg.url, title: msg.title || '' });
+            try { window.open(String(msg.url), '_blank', 'noopener,noreferrer'); } catch (e) { log('warn', 'open_url failed', { error: String(e) }); }
+            return;
+        }
+        if (kind === 'navigate' && msg.route) {
+            log('info', 'orb_directive navigate', { route: msg.route, screen_id: msg.screen_id || '' });
+            // Use a brief delay so the agent's voice cue plays before the page transitions.
+            setTimeout(function () { window.location.href = String(msg.route); }, 250);
+            return;
+        }
+        log('event', 'orb_directive (unhandled kind)', msg);
+    }
+
     // Load active provider on mount.
     fetch((window.GATEWAY_URL || '') + '/api/v1/orb/active-provider')
         .then(function (r) { return r.json(); })
@@ -35797,12 +35824,24 @@ function renderLivekitTestView() {
                 }
             });
 
-            room.on(LivekitClient.RoomEvent.DataReceived, function (payload) {
+            room.on(LivekitClient.RoomEvent.DataReceived, function (payload, _participant, _kind, topic) {
                 try {
                     var msg = JSON.parse(new TextDecoder().decode(payload));
                     log('event', 'DataReceived', msg);
                     if (msg.type === 'transcript') appendTranscript(msg.is_user ? 'user' : 'agent', String(msg.text || ''));
                     if (msg.type === 'tool_call') log('event', 'tool_call', msg);
+                    // PR 1.B-0 — orb_directive: the agent publishes structured payloads on
+                    // the data channel (topic='orb_directive') so the page can react out-of-band
+                    // the same way the SSE/WS branch does on Vertex. Currently 2 directive
+                    // types: 'open_url' (e.g. play_music URL → opens in new tab native app
+                    // intent if present) and 'navigate' (e.g. find_community_member redirect
+                    // → window.location.href).
+                    var isDirective = topic === 'orb_directive' || msg.type === 'orb_directive';
+                    if (isDirective) {
+                        try {
+                            handleOrbDirective(msg);
+                        } catch (dErr) { log('warn', 'orb_directive handler error', { error: String(dErr) }); }
+                    }
                 } catch (e) { log('event', 'DataReceived (non-json)', { len: payload && payload.byteLength }); }
             });
 


### PR DESCRIPTION
First PR of Phase 1.B (Complete LiveKit Tool Parity + Navigator). Foundation for every later auto-redirect.

Vertex emits structured `orb_directive` payloads via SSE/WS so the orb widget can react out-of-band (open URL, navigate to profile, autoplay track). LiveKit has no SSE/WS — this PR adds the parallel transport via the room's data channel.

**Components:**
1. **NEW** `services/agents/orb-agent/src/orb_agent/directives.py` — `publish_orb_directive(room, payload)` calls `room.local_participant.publish_data(JSON, reliable=True, topic='orb_directive')`. Never raises. Companion `extract_directive()` pulls a directive out of either `{result: {directive: ...}}` or top-level `{directive: ...}` shapes.
2. `gateway_client.py` — GatewayClient gains `.room` field. session.py stashes `ctx.room` there after AgentSession boots.
3. `tools.py` — adds `_dispatch_with_directive(ctx, name, args)` — same as `_dispatch` but auto-publishes any directive. Subsequent PRs use this helper.
4. `app.js` (LiveKit test page) — extends DataReceived handler. detects `topic='orb_directive'` OR `msg.type==='orb_directive'` and dispatches by kind: `open_url` → `window.open`, `navigate` → `window.location.href` (after a 250ms delay so the voice cue plays first).

After this lands, any tool returning `result.directive` auto-redirects on LiveKit when wrapped via `_dispatch_with_directive`. The remaining lifts (1.B-1..8) just swap `_dispatch` → `_dispatch_with_directive`.

🤖 Generated with Claude Code