### PR TITLE
fix(dev-autopilot): block runExecutionSession from opening duplicate PRs

### DIFF
--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -1292,6 +1292,40 @@ export async function runExecutionSession(
   }
   const exec = execR.data[0];
 
+  // VTID-AUTOPILOT-PR-FLOOD: final defense — refuse to start an execution
+  // session if the same finding already has an OPEN GitHub PR from a prior
+  // (non-terminal) execution. The earlier guard in approveAutoExecute /
+  // autoApproveTick covers the auto-approve path, but the bridge's
+  // spawnChildExecution() inserts directly into dev_autopilot_executions
+  // for self-heal retries — bypassing both. Combined with the bridge's
+  // DRY_RUN default of 'true' (revertExecutionPR is a no-op stub when
+  // DEV_AUTOPILOT_DRY_RUN is unset), the parent's PR stays open while
+  // the child execution opens a fresh one. The 2026-05-07 live test
+  // reproduced this in 9 minutes (PRs #1964 + #1968 both open against
+  // finding 709356c3). This check catches all paths regardless of how
+  // the execution row got inserted, and it runs before any LLM/GitHub
+  // cost is spent.
+  const priorOpenR = await supa<Array<{ id: string; pr_url: string | null; pr_number: number | null; status: string }>>(
+    s,
+    `/rest/v1/dev_autopilot_executions?finding_id=eq.${exec.finding_id}`
+    + `&id=neq.${executionId}`
+    + `&pr_url=not.is.null`
+    + `&status=not.in.(completed,self_healed,auto_archived)`
+    + `&select=id,pr_url,pr_number,status&order=approved_at.desc&limit=1`,
+  );
+  if (priorOpenR.ok && priorOpenR.data && priorOpenR.data.length > 0) {
+    const prior = priorOpenR.data[0];
+    const reason = `finding ${exec.finding_id.slice(0, 8)} already has an unmerged PR `
+      + `${prior.pr_url || `#${prior.pr_number}`} from execution ${prior.id.slice(0, 8)} `
+      + `(status=${prior.status}); refusing to open a duplicate. `
+      + `Close or merge the prior PR before retrying.`;
+    return {
+      ok: false,
+      error: reason,
+      session_id: `pr-flood-block-${executionId.slice(0, 8)}`,
+    };
+  }
+
   const planR = await supa<Array<{ plan_markdown: string; files_referenced: string[] }>>(
     s,
     `/rest/v1/dev_autopilot_plan_versions?finding_id=eq.${exec.finding_id}&version=eq.${exec.plan_version}&limit=1`,

--- a/services/gateway/test/dev-autopilot-runexec-pr-flood-guard.test.ts
+++ b/services/gateway/test/dev-autopilot-runexec-pr-flood-guard.test.ts
@@ -1,0 +1,138 @@
+/**
+ * VTID-AUTOPILOT-PR-FLOOD — runExecutionSession guard.
+ *
+ * Earlier guard in approveAutoExecute / autoApproveTick covers the
+ * auto-approve path. This guard covers everything else (self-heal
+ * spawnChildExecution(), operator-driven activate, manual API calls)
+ * by checking at the executor entry-point that no other execution for
+ * the same finding currently has an unmerged PR.
+ *
+ * Discovered live 2026-05-07: with auto_approve_enabled=true, finding
+ * 709356c3 produced 2 open PRs (#1964 + #1968) within 9 minutes because
+ * the bridge's revertExecutionPR is a no-op stub when DEV_AUTOPILOT_DRY_RUN
+ * is unset (default 'true'), and spawnChildExecution inserts the child
+ * execution row directly without going through approveAutoExecute.
+ */
+
+import { runExecutionSession } from '../src/services/dev-autopilot-execute';
+
+type FetchMock = jest.Mock<Promise<Response>, [RequestInfo | URL, RequestInit?]>;
+
+const ORIGINAL_FETCH = global.fetch;
+const ORIGINAL_SUPABASE_URL = process.env.SUPABASE_URL;
+const ORIGINAL_SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
+
+function mockResponse(body: unknown, status = 200): Response {
+  return {
+    ok: status >= 200 && status < 300,
+    status,
+    text: async () => JSON.stringify(body),
+    json: async () => body,
+  } as unknown as Response;
+}
+
+const SUPA_CONFIG = {
+  url: 'https://test.supabase.co',
+  key: 'test_service_role_key',
+};
+
+describe('runExecutionSession — PR-flood guard (self-heal + activate paths)', () => {
+  let fetchMock: FetchMock;
+
+  beforeAll(() => {
+    process.env.SUPABASE_URL = SUPA_CONFIG.url;
+    process.env.SUPABASE_SERVICE_ROLE = SUPA_CONFIG.key;
+  });
+
+  afterAll(() => {
+    if (ORIGINAL_SUPABASE_URL === undefined) delete process.env.SUPABASE_URL;
+    else process.env.SUPABASE_URL = ORIGINAL_SUPABASE_URL;
+    if (ORIGINAL_SUPABASE_SERVICE_ROLE === undefined) delete process.env.SUPABASE_SERVICE_ROLE;
+    else process.env.SUPABASE_SERVICE_ROLE = ORIGINAL_SUPABASE_SERVICE_ROLE;
+    global.fetch = ORIGINAL_FETCH;
+  });
+
+  beforeEach(() => {
+    fetchMock = jest.fn() as FetchMock;
+    global.fetch = fetchMock as unknown as typeof fetch;
+  });
+
+  it('refuses to open a 2nd PR when the same finding has an unmerged PR from another execution', async () => {
+    const childExecId = '00000000-0000-0000-0000-00000000aaaa';
+    const findingId = '11111111-1111-1111-1111-111111111111';
+
+    // 1. Load execution row — child execution spawned by self-heal bridge.
+    fetchMock.mockResolvedValueOnce(mockResponse([{
+      id: childExecId,
+      finding_id: findingId,
+      plan_version: 1,
+      status: 'running',
+    }]));
+
+    // 2. PR-FLOOD guard: prior execution's PR still open.
+    fetchMock.mockResolvedValueOnce(mockResponse([{
+      id: '99999999-9999-9999-9999-999999999999',
+      pr_url: 'https://github.com/exafyltd/vitana-platform/pull/1964',
+      pr_number: 1964,
+      status: 'reverted',
+    }]));
+
+    const result = await runExecutionSession(SUPA_CONFIG, childExecId);
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toMatch(/already has an unmerged PR/);
+    expect(result.error).toMatch(/pull\/1964/);
+    expect(result.error).toMatch(/status=reverted/);
+    expect(result.error).toMatch(/refusing to open a duplicate/);
+    expect(result.session_id).toMatch(/^pr-flood-block-/);
+    // Should short-circuit BEFORE loading plan / files / LLM — exactly two fetches.
+    expect(fetchMock).toHaveBeenCalledTimes(2);
+  });
+
+  it('issues the correct PostgREST filter for the prior-execution check', async () => {
+    const execId = 'aaaaaaaa-aaaa-aaaa-aaaa-aaaaaaaaaaaa';
+    const findingId = 'bbbbbbbb-bbbb-bbbb-bbbb-bbbbbbbbbbbb';
+
+    fetchMock.mockResolvedValueOnce(mockResponse([{
+      id: execId,
+      finding_id: findingId,
+      plan_version: 2,
+      status: 'running',
+    }]));
+    fetchMock.mockResolvedValueOnce(mockResponse([])); // no prior open PR
+    fetchMock.mockResolvedValueOnce(mockResponse([])); // plan lookup empty → bail
+
+    await runExecutionSession(SUPA_CONFIG, execId);
+
+    const guardCall = fetchMock.mock.calls[1];
+    const url = String(guardCall?.[0] ?? '');
+    expect(url).toMatch(/dev_autopilot_executions/);
+    expect(url).toMatch(new RegExp(`finding_id=eq\\.${findingId}`));
+    expect(url).toMatch(new RegExp(`id=neq\\.${execId}`));
+    expect(url).toMatch(/pr_url=not\.is\.null/);
+    expect(url).toMatch(/status=not\.in\.\(completed,self_healed,auto_archived\)/);
+  });
+
+  it('proceeds past the guard when no other execution has an open PR', async () => {
+    const execId = 'cccccccc-cccc-cccc-cccc-cccccccccccc';
+    const findingId = 'dddddddd-dddd-dddd-dddd-dddddddddddd';
+
+    fetchMock.mockResolvedValueOnce(mockResponse([{
+      id: execId,
+      finding_id: findingId,
+      plan_version: 1,
+      status: 'running',
+    }]));
+    // Guard query returns empty → no stranded PR → proceed.
+    fetchMock.mockResolvedValueOnce(mockResponse([]));
+    // Plan lookup returns empty → executor errors with "plan version not found".
+    fetchMock.mockResolvedValueOnce(mockResponse([]));
+
+    const result = await runExecutionSession(SUPA_CONFIG, execId);
+
+    expect(result.ok).toBe(false);
+    // Crucially NOT the PR-flood error.
+    expect(result.error).not.toMatch(/already has an unmerged PR/);
+    expect(result.error).toMatch(/plan version not found/);
+  });
+});


### PR DESCRIPTION
## Why
Live test 2026-05-07 with auto_approve_enabled=true reproduced the flood mechanism in 9 minutes:

- Finding 709356c3 → 2 open PRs (#1964 + #1968) within 9 minutes
- PR #1957's guard only covered approveAutoExecute / autoApproveTick. Self-heal bypasses both.

## Mechanism
1. Bridge's revertExecutionPR is a no-op when DEV_AUTOPILOT_DRY_RUN is unset — its default is 'true' in services/gateway/src/services/dev-autopilot-bridge.ts:39, misaligned with the executor's default of 'false'. The parent PR stays open after the bridge logs 'reverted via #closed-dry-run'.
2. spawnChildExecution() inserts a new dev_autopilot_executions row directly, bypassing approveAutoExecute and autoApproveTick.
3. The child runs runExecutionSession, generates a fix, opens its own PR — duplicate.

## Fix
Guard at the start of runExecutionSession refuses to proceed if any OTHER execution row for the same finding_id has pr_url set with status not in (completed, self_healed, auto_archived). Catches every entry-point — self-heal, operator-driven activate, manual API, autoApproveTick (defense-in-depth).

## Tests
3 new cases in dev-autopilot-runexec-pr-flood-guard.test.ts. All 12 PR-flood guard tests pass. npm run build clean.

## Follow-up worth doing
The bridge DRY_RUN default mismatch is a real underlying bug. Worth aligning to 'false' in a separate PR — but this guard makes the system safe even while that mismatch persists.

🤖 Generated with [Claude Code](https://claude.com/claude-code)