### PR TITLE
feat(VTID-02840): PR 1.B-5 — close 7 navigator gates in shared dispatcher

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/gateway_client.py
+++ b/services/agents/orb-agent/src/orb_agent/gateway_client.py
@@ -57,6 +57,13 @@ class GatewayClient:
         # between turns.
         self.current_route: str | None = None
         self.recent_routes: list[str] = []
+        # PR 1.B-5 — identity facts the navigator gates need at dispatch
+        # time. session.py seeds is_mobile + is_anonymous from the resolved
+        # Identity. tool_navigate_to_screen reads them through the args
+        # payload to enforce the viewport gate (VTID-02789), the anonymous
+        # gate, and the mobile_route override.
+        self.is_mobile: bool = False
+        self.is_anonymous: bool = False
 
     def _headers(self) -> dict[str, str]:
         h = {"Content-Type": "application/json"}

--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -352,6 +352,9 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     # post-navigate so subsequent get_current_screen calls see fresh values.
     gw.current_route = bootstrap.current_route
     gw.recent_routes = list(bootstrap.recent_routes or [])
+    # PR 1.B-5 — identity facts the navigator gates need at dispatch.
+    gw.is_mobile = bool(identity.is_mobile)
+    gw.is_anonymous = bool(identity.is_anonymous)
 
     session = AgentSession(
         stt=cascade.stt,

--- a/services/agents/orb-agent/src/orb_agent/tools.py
+++ b/services/agents/orb-agent/src/orb_agent/tools.py
@@ -742,7 +742,33 @@ async def navigate_to_screen(context: RunContext, target: str) -> str:
     Args:
         target: Named screen identifier from the spec's navigation registry.
     """
-    body = await _dispatch(context, "navigate_to_screen", {"target": target})
+    # PR 1.B-5: thread the gate inputs the shared dispatcher reads —
+    # current_route (already-there dedup), is_mobile (viewport gate +
+    # mobile_route override), is_anonymous (anonymous gate). Auto-publish
+    # any directive on the data channel; eagerly update gw.current_route
+    # so the next get_current_screen / navigate_to_screen sees fresh state.
+    gw = _gw(context)
+    body = await _dispatch_with_directive(
+        context,
+        "navigate_to_screen",
+        {
+            "target": target,
+            "current_route": gw.current_route,
+            "is_mobile": gw.is_mobile,
+            "is_anonymous": gw.is_anonymous,
+        },
+    )
+    res = body.get("result") if isinstance(body, dict) else None
+    if isinstance(res, dict) and not res.get("already_there"):
+        new_base = res.get("base_route") or (
+            res["route"].split("?", 1)[0] if isinstance(res.get("route"), str) else None
+        )
+        if isinstance(new_base, str) and new_base:
+            previous = gw.current_route
+            gw.current_route = new_base
+            if previous and previous != new_base:
+                trail = [r for r in (gw.recent_routes or []) if r != previous]
+                gw.recent_routes = ([previous] + trail)[:5]
     return summarize(body)
 
 

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -4058,10 +4058,19 @@ export async function handleNavigateToScreen(
     directive?: { type: string; directive: string; screen_id: string; route: string; title: string; reason: string; entry_kind: string; vtid: string };
   };
 
-  // Already-there short-circuit — the shared dispatcher returned ok:true
-  // with already_there:true and a friendly text. Pass through unchanged.
+  // Already-there short-circuit — the shared dispatcher returns ok:true
+  // with already_there:true (so LiveKit gets a friendly LLM-visible text).
+  // Vertex's contract is success:false + error containing "already on…"
+  // (preserved from handleNavigateToScreen pre-lift; the tool-loop logic
+  // and the nav-redirect-flow tests both depend on that shape). Translate.
   if (result.already_there) {
-    return { success: true, result: typeof r.text === 'string' ? r.text : '' };
+    return {
+      success: false,
+      result: '',
+      error: typeof r.text === 'string' && r.text.length > 0
+        ? r.text
+        : `The user is already on ${result.route || ''}. Suggest a related screen or just answer in voice instead.`,
+    };
   }
 
   // Vertex-only: set pendingNavigation + eagerly update current_route so

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -4008,305 +4008,111 @@ export async function handleNavigateToScreen(
   session: GeminiLiveSession,
   args: Record<string, unknown>
 ): Promise<{ success: boolean; result: string; error?: string }> {
-  const hasIdentity = !!(session.identity?.tenant_id && session.identity?.user_id);
-  // VTID-02770: accept either `screen_id` (canonical) or legacy `target` slug.
-  // The handler resolves both via the catalog's three-tier lookup
-  // (exact id → alias → fuzzy).
+  // PR 1.B-5: lifted to services/orb-tools-shared.ts:tool_navigate_to_screen.
+  // The shared module now enforces all 7 gates (anonymous, viewport,
+  // mobile_route override, already-there dedup, OASIS error_kind events,
+  // identity threading, fuzzy resolution). Vertex post-processes the
+  // result here for session-state mutations: pendingNavigation +
+  // navigationDispatched + eager current_route + writeNavigatorActionMemory.
   const screenId = String(args.screen_id || args.target || '').trim();
-  const reason = String(args.reason || '').trim();
   if (!screenId) {
     return { success: false, result: '', error: 'navigate_to_screen requires screen_id (or legacy target).' };
   }
-
-  // VTID-02770: Three-tier resolution.
-  //   1. Exact screen_id match (BY_ID)
-  //   2. Alias match (BY_ALIAS — includes legacy slugs like "find_partner",
-  //      user-canonical paths like "/community/events", and language variants)
-  //   3. Fuzzy fallback (suggestSimilar) — last-resort recovery for partial
-  //      guesses like "MEDIA_HUB" instead of "COMM.MEDIA_HUB".
-  let entry = lookupNavScreen(screenId);
-  if (!entry) {
-    const aliased = lookupNavByAlias(screenId);
-    if (aliased) {
-      console.log(`[VTID-02770] Alias-resolved '${screenId}' → '${aliased.screen_id}' (${aliased.route})`);
-      entry = aliased;
-    }
-  }
-  if (!entry) {
-    const similar = suggestNavSimilar(screenId, 5);
-    // Auto-resolve: if the top suggestion is unambiguous (strong lead or
-    // single match), use it directly as if Gemini had sent the right id.
-    if (similar.length > 0) {
-      const topEntry = similar[0];
-      const secondScore = similar.length > 1
-        ? suggestNavSimilar(screenId, 5).indexOf(similar[1]) >= 0
-          ? similar[1] // exists
-          : null
-        : null;
-      // "Unambiguous" = only one suggestion OR top score exists (suggestSimilar
-      // already sorts by score descending, and we can't access raw scores from
-      // the public API, so we use a simpler heuristic: if there's a match at all,
-      // take it — the worst case is navigating to the wrong screen, which is
-      // strictly better than freezing the orb completely).
-      console.log(`[VTID-NAV-FUZZY] Auto-resolving '${screenId}' → '${topEntry.screen_id}' (${topEntry.route})`);
-      entry = topEntry;
-      emitOasisEvent({
-        vtid: 'VTID-NAV-01',
-        type: 'orb.navigator.blocked',
-        source: 'orb-live-ws',
-        status: 'info',
-        message: `Fuzzy-resolved screen_id '${screenId}' → '${topEntry.screen_id}'`,
-        payload: {
-          session_id: session.sessionId,
-          attempted_screen_id: screenId,
-          resolved_screen_id: topEntry.screen_id,
-          error_kind: 'fuzzy_resolved',
-        },
-      }).catch(() => {});
-    } else {
-      emitOasisEvent({
-        vtid: 'VTID-NAV-01',
-        type: 'orb.navigator.blocked',
-        source: 'orb-live-ws',
-        status: 'warning',
-        message: `Unknown screen_id '${screenId}' — no suggestions`,
-        payload: {
-          session_id: session.sessionId,
-          attempted_screen_id: screenId,
-          error_kind: 'unknown',
-          suggestions: [],
-        },
-      }).catch(() => {});
-      return {
-        success: false,
-        result: '',
-        error: `Unknown screen_id '${screenId}'. No matching screens found in the catalog.`,
-      };
-    }
+  const hasIdentity = !!(session.identity?.tenant_id && session.identity?.user_id);
+  const sb = getSupabase();
+  if (!sb) {
+    return { success: false, result: '', error: 'supabase_not_configured' };
   }
 
-  const isAnon = !!session.isAnonymous || !hasIdentity;
-  if (isAnon && !entry.anonymous_safe) {
-    emitOasisEvent({
-      vtid: 'VTID-NAV-01',
-      type: 'orb.navigator.blocked',
-      source: 'orb-live-ws',
-      status: 'warning',
-      message: `Screen '${screenId}' requires authentication`,
-      payload: {
-        session_id: session.sessionId,
-        attempted_screen_id: screenId,
-        error_kind: 'auth_required',
-      },
-    }).catch(() => {});
-    return {
-      success: false,
-      result: '',
-      error: `Screen '${screenId}' requires the user to be signed in. Tell them briefly and offer to take them to registration instead.`,
+  const { dispatchOrbTool } = await import('../services/orb-tools-shared');
+  const r = await dispatchOrbTool(
+    'navigate_to_screen',
+    {
+      ...args,
+      current_route: session.current_route ?? null,
+    },
+    {
+      user_id: session.identity?.user_id ?? '',
+      tenant_id: session.identity?.tenant_id ?? null,
+      role: session.identity?.role ?? null,
+      vitana_id: session.identity?.vitana_id ?? null,
+      lang: session.lang ?? 'en',
+      session_id: session.sessionId,
+      is_anonymous: !!session.isAnonymous || !hasIdentity,
+      is_mobile: session.is_mobile === true,
+    },
+    sb,
+  );
+
+  if (r.ok === false) {
+    return { success: false, result: '', error: r.error };
+  }
+
+  const result = (r.result ?? {}) as {
+    screen_id?: string;
+    route?: string;
+    base_route?: string;
+    title?: string;
+    entry_kind?: string;
+    already_there?: boolean;
+    directive?: { type: string; directive: string; screen_id: string; route: string; title: string; reason: string; entry_kind: string; vtid: string };
+  };
+
+  // Already-there short-circuit — the shared dispatcher returned ok:true
+  // with already_there:true and a friendly text. Pass through unchanged.
+  if (result.already_there) {
+    return { success: true, result: typeof r.text === 'string' ? r.text : '' };
+  }
+
+  // Vertex-only: set pendingNavigation + eagerly update current_route so
+  // turn_complete + get_current_screen see the fresh destination.
+  if (result.directive && result.screen_id && result.route && result.title) {
+    const reason = String(args.reason || 'navigate_to_screen tool call');
+    session.pendingNavigation = {
+      screen_id: result.screen_id,
+      route: result.route,
+      title: result.title,
+      reason,
+      decision_source: 'direct',
+      requested_at: Date.now(),
     };
-  }
+    session.navigationDispatched = true;
 
-  // VTID-02789: Viewport gate — refuse the redirect if the entry is
-  // viewport-locked to mobile-only or desktop-only and the session doesn't
-  // match. Lets us mark `/daily-diary` (mobile-only flow) so a desktop
-  // session never gets sent there.
-  if (entry.viewport_only) {
-    const sessionViewport: 'mobile' | 'desktop' = session.is_mobile === true ? 'mobile' : 'desktop';
-    if (entry.viewport_only !== sessionViewport) {
-      emitOasisEvent({
-        vtid: 'VTID-02789',
-        type: 'orb.navigator.blocked',
-        source: 'orb-live-ws',
-        status: 'warning',
-        message: `Screen '${entry.screen_id}' is ${entry.viewport_only}-only; session is ${sessionViewport}`,
-        payload: {
-          session_id: session.sessionId,
-          attempted_screen_id: screenId,
-          error_kind: 'wrong_viewport',
-          required_viewport: entry.viewport_only,
-          session_viewport: sessionViewport,
-        },
-      }).catch(() => {});
-      return {
-        success: false,
-        result: '',
-        error: `Screen '${entry.screen_id}' is only available on ${entry.viewport_only}. Suggest a different screen or stay in voice.`,
-      };
-    }
-  }
-
-  // VTID-02770: Resolve the final URL the frontend will receive.
-  //   1. VTID-02789: Mobile-aware URL — when session.is_mobile=true AND the
-  //      entry has a mobile_route override, use that instead of route. Lets
-  //      pages that auto-redirect on mobile (e.g. /comm →
-  //      /comm/events-meetups?tab=hot) skip the redirect hop.
-  //   2. Substitute `:param` placeholders in the chosen base URL with values
-  //      from args. Missing required params are reported as a typed error so
-  //      Gemini knows it must ask the user for the missing piece.
-  //   3. For overlay entries (entry_kind === 'overlay'), append
-  //      `?open=<query_marker>` so the frontend ORB widget intercepts and
-  //      dispatches the corresponding CustomEvent instead of routing.
-  //   4. For overlay entries that need a parameter (e.g. user_id for
-  //      OVERLAY.PROFILE_PREVIEW), append it as a query param too — the
-  //      frontend reads it from the URL on dispatch.
-  const isMobileSession = session.is_mobile === true;
-  const baseRoute = (isMobileSession && entry.mobile_route) ? entry.mobile_route : entry.route;
-  let resolvedRoute = baseRoute;
-  const missingParams: string[] = [];
-  resolvedRoute = resolvedRoute.replace(/:([a-zA-Z_][a-zA-Z0-9_]*)/g, (_match, name) => {
-    const v = args[name];
-    if (v === undefined || v === null || String(v).trim() === '') {
-      missingParams.push(String(name));
-      return ':' + String(name);
-    }
-    // Strip a leading `@` from vitana_id-style params before encoding.
-    const clean = String(v).trim().replace(/^@/, '');
-    return encodeURIComponent(clean);
-  });
-  if (missingParams.length > 0) {
-    emitOasisEvent({
-      vtid: 'VTID-NAV-01',
-      type: 'orb.navigator.blocked',
-      source: 'orb-live-ws',
-      status: 'warning',
-      message: `Missing route param(s) for ${entry.screen_id}: ${missingParams.join(', ')}`,
-      payload: {
-        session_id: session.sessionId,
-        attempted_screen_id: screenId,
-        error_kind: 'missing_param',
-        missing_params: missingParams,
-      },
-    }).catch(() => {});
-    return {
-      success: false,
-      result: '',
-      error: `Cannot navigate to ${entry.screen_id}: missing required parameter(s) ${missingParams.join(', ')}. Ask the user to provide them, then call navigate_to_screen again.`,
-    };
-  }
-
-  if (entry.entry_kind === 'overlay' && entry.overlay) {
-    const sep = resolvedRoute.includes('?') ? '&' : '?';
-    const params = new URLSearchParams();
-    params.set('open', entry.overlay.query_marker);
-    // If the overlay needs a specific param (user_id, meetup_id, etc.) and
-    // the caller provided it, pass it through so the frontend overlay can
-    // pick the right entity to render.
-    const needs = entry.overlay.needs_param;
-    if (needs) {
-      const v = args[needs];
-      if (v !== undefined && v !== null && String(v).trim() !== '') {
-        params.set(needs, String(v).trim().replace(/^@/, ''));
+    const isOverlay = result.entry_kind === 'overlay';
+    if (!isOverlay) {
+      const baseRoutePath = result.base_route || result.route.split('?')[0];
+      const previousRoute = session.current_route;
+      session.current_route = baseRoutePath;
+      if (previousRoute && previousRoute !== baseRoutePath) {
+        const trail = Array.isArray(session.recent_routes) ? [...session.recent_routes] : [];
+        const deduped = trail.filter((rt) => rt !== previousRoute);
+        session.recent_routes = [previousRoute, ...deduped].slice(0, 5);
       }
     }
-    resolvedRoute = `${resolvedRoute}${sep}${params.toString()}`;
-  }
 
-  // VTID-02789: Compare current_route against the *resolved* base path
-  // (mobile_route on mobile, route otherwise) so a mobile user already on
-  // /comm/events-meetups (because /comm aliased there) doesn't get bounced
-  // when they ask for "the community page" again.
-  const baseRoutePath = baseRoute.split('?')[0];
-  if (session.current_route && session.current_route === baseRoutePath && entry.entry_kind !== 'overlay') {
-    emitOasisEvent({
-      vtid: 'VTID-NAV-01',
-      type: 'orb.navigator.blocked',
-      source: 'orb-live-ws',
-      status: 'info',
-      message: `User is already on ${baseRoutePath}`,
-      payload: {
-        session_id: session.sessionId,
-        attempted_screen_id: screenId,
-        error_kind: 'already_there',
-      },
-    }).catch(() => {});
-    return {
-      success: false,
-      result: '',
-      error: `The user is already on ${entry.route}. Suggest a related screen or just answer in voice instead.`,
-    };
-  }
-
-  // Queue the navigation. The orb_directive dispatch in turn_complete
-  // will pick this up AFTER the existing memory flush completes.
-  const lang = session.lang || 'en';
-  const content = getNavContent(entry, lang);
-  session.pendingNavigation = {
-    screen_id: entry.screen_id,
-    route: resolvedRoute,
-    title: content.title,
-    reason: reason || 'navigate_to_screen tool call',
-    decision_source: 'direct',
-    requested_at: Date.now(),
-  };
-  // VTID-NAV: Set the gate that drops further input audio so Gemini does
-  // not start a new turn while the widget is closing.
-  session.navigationDispatched = true;
-
-  // VTID-NAV-TIMEJOURNEY (journey-awareness fix): Eagerly update the
-  // in-memory session route + journey trail so the next turn / any
-  // subsequent get_current_screen tool call sees the FRESH destination,
-  // not the stale route the user was on when the session started. This
-  // is what makes "which screen am I on?" answerable after Vitana has
-  // just redirected the user via this tool.
-  //
-  // VTID-02770: For overlay entries we do NOT change current_route, since the
-  // user stays on their original page — only a popup opens.
-  // VTID-02789: Use the resolved baseRoutePath (mobile_route on mobile, else
-  // route) so the eager update tracks the actual destination, not the
-  // generic desktop URL.
-  if (entry.entry_kind !== 'overlay') {
-    const previousRoute = session.current_route;
-    session.current_route = baseRoutePath;
-    if (previousRoute && previousRoute !== baseRoutePath) {
-      const trail = Array.isArray(session.recent_routes) ? [...session.recent_routes] : [];
-      const deduped = trail.filter(r => r !== previousRoute);
-      session.recent_routes = [previousRoute, ...deduped].slice(0, 5);
+    if (hasIdentity) {
+      const lang = session.lang || 'en';
+      writeNavigatorActionMemory({
+        identity: {
+          user_id: session.identity!.user_id,
+          tenant_id: session.identity!.tenant_id as string,
+          role: session.identity!.role || session.active_role || undefined,
+        },
+        screen: {
+          screen_id: result.screen_id,
+          route: result.route,
+          title: result.title,
+        },
+        reason,
+        decision_source: 'direct',
+        orb_session_id: session.sessionId,
+        conversation_id: session.conversation_id,
+        lang,
+      }).catch(() => {});
     }
   }
 
-  // Persist the navigation as a memory item (authenticated only).
-  if (hasIdentity) {
-    writeNavigatorActionMemory({
-      identity: {
-        user_id: session.identity!.user_id,
-        tenant_id: session.identity!.tenant_id as string,
-        role: session.identity!.role || session.active_role || undefined,
-      },
-      screen: {
-        screen_id: entry.screen_id,
-        route: resolvedRoute,
-        title: content.title,
-      },
-      reason: session.pendingNavigation.reason,
-      decision_source: session.pendingNavigation.decision_source,
-      orb_session_id: session.sessionId,
-      conversation_id: session.conversation_id,
-      lang,
-    }).catch(() => { /* fire-and-forget */ });
-  }
-
-  emitOasisEvent({
-    vtid: 'VTID-NAV-01',
-    type: 'orb.navigator.requested',
-    source: 'orb-live-ws',
-    status: 'info',
-    message: `navigate_to_screen ${entry.screen_id} (${resolvedRoute})`,
-    payload: {
-      session_id: session.sessionId,
-      screen_id: entry.screen_id,
-      route: resolvedRoute,
-      entry_kind: entry.entry_kind || 'route',
-      reason: session.pendingNavigation.reason,
-      is_anonymous: isAnon,
-    },
-  }).catch(() => {});
-
-  return {
-    success: true,
-    result: entry.entry_kind === 'overlay'
-      ? `Overlay opened: ${content.title}. The user stays on their current screen — the popup is now visible. Continue the conversation; do NOT navigate elsewhere unless the user asks.`
-      : `Navigation queued to ${content.title} (${resolvedRoute}). The user is now being taken to the "${content.title}" screen. The widget is closing now. DO NOT generate any more audio or text for this turn. Your turn is complete — stop speaking immediately. If the user later asks which screen they are on, they are on "${content.title}".`,
-  };
+  return { success: true, result: typeof r.text === 'string' ? r.text : '' };
 }
 
 /**

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -70,6 +70,16 @@ export interface OrbToolIdentity {
   turn_number?: number | null;
   session_started_iso?: string | null;
   lang?: string | null;
+  /**
+   * PR 1.B-5 — navigator-gate identity facts. Populated from session
+   * state (Vertex: session.isAnonymous + session.is_mobile; LiveKit:
+   * Identity.is_anonymous + Identity.is_mobile) so the shared
+   * tool_navigate_to_screen handler can enforce the same gates Vertex's
+   * handleNavigateToScreen has today: anonymous-safe screens, viewport
+   * lock (VTID-02789), mobile_route override.
+   */
+  is_anonymous?: boolean | null;
+  is_mobile?: boolean | null;
 }
 
 export type OrbToolResult =
@@ -1762,25 +1772,141 @@ export async function tool_respond_to_match(
   }
 }
 
-export async function tool_navigate_to_screen(args: OrbToolArgs): Promise<OrbToolResult> {
+/**
+ * PR 1.B-5: lifts orb-live.ts:handleNavigateToScreen's 7 gates into the
+ * shared dispatcher so LiveKit's tool_navigate_to_screen enforces the
+ * same robustness Vertex has today.
+ *
+ * Gates:
+ *   1. Anonymous gate — refuses non-anonymous_safe screens for anonymous
+ *      sessions. error_kind='auth_required'.
+ *   2. Viewport gate (VTID-02789) — refuses mobile-only screens on
+ *      desktop and desktop-only on mobile. error_kind='wrong_viewport'.
+ *   3. Mobile_route override — when session is mobile AND the entry has
+ *      a mobile_route, use it instead of route.
+ *   4. Already-there dedup — skips when current_route already matches
+ *      the resolved base path (overlay entries always pass).
+ *   5. OASIS error_kind events — every rejection emits orb.navigator.blocked
+ *      with a typed error_kind so admins can debug specific failure modes.
+ *   6. Identity threading — is_anonymous + is_mobile read from
+ *      OrbToolIdentity; current_route + recent_routes from args (consistent
+ *      with the get_current_screen / navigate convention).
+ *   7. Returns the directive payload — Vertex post-processes it for SSE/WS
+ *      session-state mutations; LiveKit's wrapper publishes via the data
+ *      channel.
+ */
+export async function tool_navigate_to_screen(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+): Promise<OrbToolResult> {
   const screenIdArg = String(args.screen_id ?? args.target ?? '').trim();
   if (!screenIdArg) return { ok: false, error: 'screen_id (or legacy target) is required' };
 
+  // Identity facts (with args fallback for the LiveKit Python wrapper that
+  // sends them in the body alongside current_route).
+  const isAnon = (typeof args.is_anonymous === 'boolean' ? args.is_anonymous : id.is_anonymous)
+    ?? !id.user_id;
+  const isMobile = (typeof args.is_mobile === 'boolean' ? args.is_mobile : id.is_mobile) ?? false;
+  const currentRoute = typeof args.current_route === 'string' && args.current_route.length > 0
+    ? args.current_route
+    : null;
+  const lang = (id.lang || 'en') as string;
+  const sessionId = id.session_id || null;
+
+  const { emitOasisEvent } = await import('./oasis-event-service');
+
+  // Three-tier resolution: exact → alias → fuzzy.
   let entry: NavCatalogEntry | null = lookupScreen(screenIdArg) || lookupByAlias(screenIdArg);
   if (!entry) {
     const similar = suggestSimilar(screenIdArg, 1);
-    if (similar.length > 0) entry = similar[0];
+    if (similar.length > 0) {
+      entry = similar[0];
+      emitOasisEvent({
+        vtid: 'VTID-NAV-01',
+        type: 'orb.navigator.blocked',
+        source: 'orb-tools-shared',
+        status: 'info',
+        message: `Fuzzy-resolved screen_id '${screenIdArg}' → '${entry.screen_id}'`,
+        payload: {
+          session_id: sessionId,
+          attempted_screen_id: screenIdArg,
+          resolved_screen_id: entry.screen_id,
+          error_kind: 'fuzzy_resolved',
+        },
+      }).catch(() => {});
+    }
   }
   if (!entry) {
+    emitOasisEvent({
+      vtid: 'VTID-NAV-01',
+      type: 'orb.navigator.blocked',
+      source: 'orb-tools-shared',
+      status: 'warning',
+      message: `Unknown screen_id '${screenIdArg}' — no suggestions`,
+      payload: {
+        session_id: sessionId,
+        attempted_screen_id: screenIdArg,
+        error_kind: 'unknown',
+        suggestions: [],
+      },
+    }).catch(() => {});
     return {
-      ok: true,
-      result: { screen_id: screenIdArg, route: null },
-      text: `I don't have a canonical screen for "${screenIdArg}" — tell me what you want to see and I'll match it.`,
+      ok: false,
+      error: `Unknown screen_id '${screenIdArg}'. No matching screens found in the catalog.`,
     };
   }
 
+  // GATE 1: anonymous_safe.
+  if (isAnon && !entry.anonymous_safe) {
+    emitOasisEvent({
+      vtid: 'VTID-NAV-01',
+      type: 'orb.navigator.blocked',
+      source: 'orb-tools-shared',
+      status: 'warning',
+      message: `Screen '${screenIdArg}' requires authentication`,
+      payload: {
+        session_id: sessionId,
+        attempted_screen_id: screenIdArg,
+        error_kind: 'auth_required',
+      },
+    }).catch(() => {});
+    return {
+      ok: false,
+      error: `Screen '${screenIdArg}' requires the user to be signed in. Tell them briefly and offer to take them to registration instead.`,
+    };
+  }
+
+  // GATE 2: viewport (VTID-02789).
+  if (entry.viewport_only) {
+    const sessionViewport: 'mobile' | 'desktop' = isMobile ? 'mobile' : 'desktop';
+    if (entry.viewport_only !== sessionViewport) {
+      emitOasisEvent({
+        vtid: 'VTID-02789',
+        type: 'orb.navigator.blocked',
+        source: 'orb-tools-shared',
+        status: 'warning',
+        message: `Screen '${entry.screen_id}' is ${entry.viewport_only}-only; session is ${sessionViewport}`,
+        payload: {
+          session_id: sessionId,
+          attempted_screen_id: screenIdArg,
+          error_kind: 'wrong_viewport',
+          required_viewport: entry.viewport_only,
+          session_viewport: sessionViewport,
+        },
+      }).catch(() => {});
+      return {
+        ok: false,
+        error: `Screen '${entry.screen_id}' is only available on ${entry.viewport_only}. Suggest a different screen or stay in voice.`,
+      };
+    }
+  }
+
+  // GATE 3: mobile_route override (VTID-02789).
+  const baseRoute = (isMobile && entry.mobile_route) ? entry.mobile_route : entry.route;
+
+  // Param substitution.
   const missing: string[] = [];
-  let route = entry.route.replace(/:([a-zA-Z_][a-zA-Z0-9_]*)/g, (_m, name) => {
+  let resolvedRoute = baseRoute.replace(/:([a-zA-Z_][a-zA-Z0-9_]*)/g, (_m, name) => {
     const v = args[name];
     if (v === undefined || v === null || String(v).trim() === '') {
       missing.push(String(name));
@@ -1789,14 +1915,28 @@ export async function tool_navigate_to_screen(args: OrbToolArgs): Promise<OrbToo
     return encodeURIComponent(String(v).trim().replace(/^@/, ''));
   });
   if (missing.length > 0) {
+    emitOasisEvent({
+      vtid: 'VTID-NAV-01',
+      type: 'orb.navigator.blocked',
+      source: 'orb-tools-shared',
+      status: 'warning',
+      message: `Missing route param(s) for ${entry.screen_id}: ${missing.join(', ')}`,
+      payload: {
+        session_id: sessionId,
+        attempted_screen_id: screenIdArg,
+        error_kind: 'missing_param',
+        missing_params: missing,
+      },
+    }).catch(() => {});
     return {
       ok: false,
-      error: `Missing required param(s) for ${entry.screen_id}: ${missing.join(', ')}.`,
+      error: `Cannot navigate to ${entry.screen_id}: missing required parameter(s) ${missing.join(', ')}. Ask the user to provide them, then call navigate_to_screen again.`,
     };
   }
 
+  // Overlay query-marker append.
   if (entry.entry_kind === 'overlay' && entry.overlay) {
-    const sep = route.includes('?') ? '&' : '?';
+    const sep = resolvedRoute.includes('?') ? '&' : '?';
     const params = new URLSearchParams();
     params.set('open', entry.overlay.query_marker);
     const needs = entry.overlay.needs_param;
@@ -1806,14 +1946,79 @@ export async function tool_navigate_to_screen(args: OrbToolArgs): Promise<OrbToo
         params.set(needs, String(v).trim().replace(/^@/, ''));
       }
     }
-    route = `${route}${sep}${params.toString()}`;
+    resolvedRoute = `${resolvedRoute}${sep}${params.toString()}`;
   }
 
-  const title = getContent(entry, 'en').title;
+  // GATE 4: already-there dedup. Compare to the resolved BASE path
+  // (mobile_route or route, no querystring) — same as Vertex line 4208.
+  const baseRoutePath = baseRoute.split('?')[0];
+  if (currentRoute && currentRoute === baseRoutePath && entry.entry_kind !== 'overlay') {
+    emitOasisEvent({
+      vtid: 'VTID-NAV-01',
+      type: 'orb.navigator.blocked',
+      source: 'orb-tools-shared',
+      status: 'info',
+      message: `User is already on ${baseRoutePath}`,
+      payload: {
+        session_id: sessionId,
+        attempted_screen_id: screenIdArg,
+        error_kind: 'already_there',
+      },
+    }).catch(() => {});
+    return {
+      ok: true,
+      result: {
+        screen_id: entry.screen_id,
+        route: entry.route,
+        already_there: true,
+        entry_kind: entry.entry_kind || 'route',
+      },
+      text: `The user is already on ${entry.route}. Suggest a related screen or just answer in voice instead.`,
+    };
+  }
+
+  // Success → directive payload.
+  const content = getContent(entry, lang);
+  const directive = {
+    type: 'orb_directive',
+    directive: 'navigate',
+    screen_id: entry.screen_id,
+    route: resolvedRoute,
+    title: content.title,
+    reason: String(args.reason || 'navigate_to_screen tool call'),
+    entry_kind: entry.entry_kind || 'route',
+    vtid: 'VTID-NAV-01',
+  };
+
+  emitOasisEvent({
+    vtid: 'VTID-NAV-01',
+    type: 'orb.navigator.requested',
+    source: 'orb-tools-shared',
+    status: 'info',
+    message: `navigate_to_screen ${entry.screen_id} (${resolvedRoute})`,
+    payload: {
+      session_id: sessionId,
+      screen_id: entry.screen_id,
+      route: resolvedRoute,
+      entry_kind: entry.entry_kind || 'route',
+      reason: directive.reason,
+      is_anonymous: isAnon,
+    },
+  }).catch(() => {});
+
   return {
     ok: true,
-    result: { screen_id: entry.screen_id, route, title, entry_kind: entry.entry_kind || 'route' },
-    text: `Opening ${title}.`,
+    result: {
+      screen_id: entry.screen_id,
+      route: resolvedRoute,
+      base_route: baseRoutePath,
+      title: content.title,
+      entry_kind: entry.entry_kind || 'route',
+      directive,
+    },
+    text: entry.entry_kind === 'overlay'
+      ? `Overlay opened: ${content.title}. The user stays on their current screen — the popup is now visible. Continue the conversation; do NOT navigate elsewhere unless the user asks.`
+      : `Navigation queued to ${content.title} (${resolvedRoute}). The user is now being taken to the "${content.title}" screen. The widget is closing now. DO NOT generate any more audio or text for this turn. Your turn is complete — stop speaking immediately. If the user later asks which screen they are on, they are on "${content.title}".`,
   };
 }
 
@@ -2604,7 +2809,7 @@ export const ORB_TOOL_REGISTRY: Record<string, OrbToolHandler> = {
   scan_existing_matches: tool_scan_existing_matches,
   share_intent_post: tool_share_intent_post,
   respond_to_match: tool_respond_to_match,
-  navigate_to_screen: (args) => tool_navigate_to_screen(args),
+  navigate_to_screen: (args, id) => tool_navigate_to_screen(args, id),
   // VTID-NAV-UNIFIED — free-text navigate (PR 1.B-4). Runs consultNavigator's
   // 8-step resolution and constructs the redirect directive.
   navigate: tool_navigate,
@@ -2674,6 +2879,8 @@ export interface VertexLikeIdentity {
   turn_number?: number | null;
   session_started_iso?: string | null;
   lang?: string | null;
+  is_anonymous?: boolean | null;
+  is_mobile?: boolean | null;
 }
 
 export interface VertexLikeToolResult {
@@ -2702,6 +2909,8 @@ export async function dispatchOrbToolForVertex(
       turn_number: identity.turn_number ?? null,
       session_started_iso: identity.session_started_iso ?? null,
       lang: identity.lang ?? null,
+      is_anonymous: identity.is_anonymous ?? null,
+      is_mobile: identity.is_mobile ?? null,
     },
     sb,
   );


### PR DESCRIPTION
## Summary

Lifts all 7 gates Vertex's `handleNavigateToScreen` has into `services/orb-tools-shared.ts:tool_navigate_to_screen` so LiveKit's `navigate_to_screen` calls enforce identical robustness.

After this PR a LiveKit session navigating to:
- `/admin` while anonymous → blocked with `auth_required`, OASIS event written
- `/daily-diary` on desktop → blocked with `wrong_viewport`
- `/diary` while already on `/diary` → `already_there` short-circuit
- `/comm` on mobile → uses `mobile_route` `/comm/events-meetups?tab=hot`

None of those were enforced before — LiveKit users could route into authenticated screens, mobile-only screens on desktop, etc.

## Gates closed

1. **Anonymous gate** — refuses non-`anonymous_safe` screens for anonymous sessions. `error_kind='auth_required'`.
2. **Viewport gate (VTID-02789)** — refuses mobile-only screens on desktop and desktop-only on mobile. `error_kind='wrong_viewport'`.
3. **Mobile_route override** — when `session.is_mobile=true` AND entry has `mobile_route`, use it instead of `route`. Same path Vertex resolves for `/comm` → `/comm/events-meetups?tab=hot` redirects.
4. **Already-there dedup** — skips when `current_route` matches the resolved base path (overlay entries always pass). `error_kind='already_there'`.
5. **OASIS error_kind events** — every rejection emits `orb.navigator.blocked` with the typed `error_kind` so admins can debug specific failure modes. Same payload shape Vertex emits today.
6. **Identity threading** — `is_anonymous` + `is_mobile` read from `OrbToolIdentity` (Vertex passes via identity; LiveKit passes via args from `gw.is_mobile` / `gw.is_anonymous` seeded at session start).
7. **Directive payload return** — Vertex post-processes for SSE/WS session-state mutations; LiveKit's wrapper publishes via the data channel (PR 1.B-0 wiring) and eagerly updates `gw.current_route`.

## Changes

**`services/gateway/src/services/orb-tools-shared.ts`**:
- `OrbToolIdentity` + `VertexLikeIdentity` gain `is_anonymous`, `is_mobile`.
- `dispatchOrbToolForVertex` passes them through.
- `tool_navigate_to_screen` rewritten with all 7 gates + OASIS emit on rejection + directive payload on success + `already_there:true` short-circuit.

**`services/gateway/src/routes/orb-live.ts`**:
- `handleNavigateToScreen` becomes a thin delegator. Vertex still owns `pendingNavigation` + `navigationDispatched` + eager `session.current_route` + `writeNavigatorActionMemory` (transport-specific session-state mutations). Removed ~250 lines of inline gate logic; same observable behaviour.

**`services/agents/orb-agent/src/orb_agent/gateway_client.py`**:
- New `is_mobile` + `is_anonymous` fields.

**`services/agents/orb-agent/src/orb_agent/session.py`**:
- Seeds `gw.is_mobile` + `gw.is_anonymous` from identity at session start.

**`services/agents/orb-agent/src/orb_agent/tools.py`**:
- `navigate_to_screen` wrapper uses `_dispatch_with_directive` so the data-channel auto-redirect lands. Sends `current_route` + `is_mobile` + `is_anonymous` in args. Eagerly updates `gw.current_route` + `recent_routes` from `result.base_route` post-navigate.

## Verification

- `npm run build` (gateway) — clean.
- `python3 -m py_compile` (orb-agent) — clean.
- `node scripts/orb-tools-lift-scanner.mjs` — clean.
- VTID: VTID-02840.

## Test plan

- [ ] Anonymous LiveKit session: `navigate_to_screen('admin')` → blocked with `auth_required`, OASIS row written.
- [ ] Desktop LiveKit session: `navigate_to_screen('daily-diary')` → blocked with `wrong_viewport`.
- [ ] LiveKit session on `/diary` → `navigate_to_screen('diary')` → `already_there:true`, no redundant directive.
- [ ] Mobile LiveKit session: `navigate_to_screen('comm.feed')` → routes to `/comm/events-meetups?tab=hot` (`mobile_route` override).
- [ ] All four rejections show in `oasis_events` with `topic='orb.navigator.blocked'` + matching `error_kind`.
- [ ] Vertex regression: same scripted scenarios as above on Vertex pipeline produce identical outcomes (regression check that the lift didn't change Vertex behaviour).

🤖 Generated with [Claude Code](https://claude.com/claude-code)