### PR TITLE
feat(VTID-02841): PR 1.B-6 — auto-navigate view_intent_matches when unambiguous

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/tools.py
+++ b/services/agents/orb-agent/src/orb_agent/tools.py
@@ -669,11 +669,36 @@ async def post_intent(context: RunContext, kind: str, body_text: str) -> str:
 
 
 @function_tool
-async def view_intent_matches(context: RunContext) -> str:
-    """View match candidates for the user's open intents (VTID-01976)."""
-    # Mounted at /api/v1/intent-matches/{outgoing,incoming}; surface incoming
-    # matches (the ones the LLM cares about — what came back to the user).
-    body = await _gw(context).get("/api/v1/intent-matches/incoming")
+async def view_intent_matches(context: RunContext, intent_id: str, limit: int = 3) -> str:
+    """View the top match candidates for ONE of the user's intents.
+
+    PR 1.B-6: when the top match's score clearly dominates the runner-up
+    (gap >= 0.15), auto-redirects the user to that match's detail screen
+    via the data-channel directive. When matches are comparable, returns
+    the list and lets you ask the user which one they want.
+
+    Args:
+        intent_id: The user's intent to look up matches for.
+        limit: Max number of matches to return (1..10). Default 3.
+    """
+    body = await _dispatch_with_directive(
+        context,
+        "view_intent_matches",
+        {"intent_id": intent_id, "limit": max(1, min(10, int(limit)))},
+    )
+    # Eagerly update gw.current_route on auto_nav so the next
+    # get_current_screen call sees the fresh route.
+    res = body.get("result") if isinstance(body, dict) else None
+    if isinstance(res, dict) and res.get("decision") == "auto_nav":
+        directive = res.get("directive") or {}
+        new_route = directive.get("route") if isinstance(directive, dict) else None
+        if isinstance(new_route, str) and new_route:
+            gw = _gw(context)
+            previous = gw.current_route
+            gw.current_route = new_route
+            if previous and previous != new_route:
+                trail = [r for r in (gw.recent_routes or []) if r != previous]
+                gw.recent_routes = ([previous] + trail)[:5]
     return summarize(body)
 
 

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -6370,32 +6370,87 @@ async function executeLiveApiToolInner(
       }
 
       case 'view_intent_matches': {
-        const intentId = String(args.intent_id || '').trim();
-        const limit = Math.min(Math.max(Number(args.limit) || 3, 1), 10);
-        if (!intentId) return { success: false, result: '', error: 'intent_id is required' };
-        try {
-          const { surfaceTopMatches } = await import('../services/intent-matcher');
-          const { redactMatchForReader } = await import('../services/intent-mutual-reveal');
-          const matches = await surfaceTopMatches(intentId, limit);
-          const redacted = await Promise.all(matches.map((m) => redactMatchForReader(m, session.identity!.user_id)));
-          return {
-            success: true,
-            result: JSON.stringify({
-              ok: true,
-              matches: redacted.map((m) => ({
-                match_id: m.match_id,
-                vitana_id_b: m.vitana_id_b,
-                score: m.score,
-                kind_pairing: m.kind_pairing,
-                state: m.state,
-                redacted: m.redacted,
-              })),
-            }),
-          };
-        } catch (err: any) {
-          console.error('[VTID-01975] view_intent_matches error:', err?.message);
-          return { success: false, result: '', error: err?.message || 'unknown' };
+        // PR 1.B-6: lifted to services/orb-tools-shared.ts. Both pipelines run
+        // the same surfaceTopMatches + redactMatchForReader path. Auto-nav
+        // to INTENTS.MATCH_DETAIL when the top score dominates the runner-up
+        // (gap >= 0.15); otherwise list-only and let the LLM disambiguate.
+        const SUPABASE_URL = process.env.SUPABASE_URL;
+        const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+        if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
+          return { success: false, result: '', error: 'supabase_not_configured' };
         }
+        const { createClient } = await import('@supabase/supabase-js');
+        const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE, {
+          auth: { autoRefreshToken: false, persistSession: false },
+        });
+        const { dispatchOrbTool } = await import('../services/orb-tools-shared');
+        const r = await dispatchOrbTool(
+          'view_intent_matches',
+          args ?? {},
+          {
+            user_id: lens.user_id,
+            tenant_id: lens.tenant_id ?? null,
+            role: session.identity?.role ?? null,
+            vitana_id: session.identity?.vitana_id ?? null,
+            session_id: session.sessionId,
+          },
+          supabase,
+        );
+        if (r.ok === false) {
+          return { success: false, result: '', error: r.error };
+        }
+        const result = (r.result ?? {}) as {
+          matches?: unknown[];
+          decision?: string;
+          directive?: {
+            type: string;
+            directive: string;
+            screen_id: string;
+            route: string;
+            title: string;
+            reason: string;
+            vtid: string;
+          };
+        };
+        // Auto-nav: emit directive via SSE/WS + set session.pendingNavigation
+        // + eagerly update current_route so the next get_current_screen sees
+        // the fresh route.
+        if (result.decision === 'auto_nav' && result.directive) {
+          const directive = result.directive;
+          const directiveJson = JSON.stringify(directive);
+          if (session.sseResponse) {
+            try { session.sseResponse.write(`data: ${directiveJson}\n\n`); } catch (_e) { /* SSE closed */ }
+          }
+          if ((session as unknown as { clientWs?: { readyState: number } }).clientWs &&
+              (session as unknown as { clientWs?: { readyState: number } }).clientWs!.readyState === 1) {
+            try { sendWsMessage((session as unknown as { clientWs: unknown }).clientWs as Parameters<typeof sendWsMessage>[0], directive); } catch (_e) { /* WS closed */ }
+          }
+          session.pendingNavigation = {
+            screen_id: directive.screen_id,
+            route: directive.route,
+            title: directive.title,
+            reason: directive.reason,
+            decision_source: 'direct',
+            requested_at: Date.now(),
+          };
+          session.navigationDispatched = true;
+          session.pendingNavigation = undefined;
+          const previousRoute = session.current_route;
+          session.current_route = directive.route;
+          if (previousRoute && previousRoute !== directive.route) {
+            const trail = Array.isArray(session.recent_routes) ? [...session.recent_routes] : [];
+            const deduped = trail.filter((rt) => rt !== previousRoute);
+            session.recent_routes = [previousRoute, ...deduped].slice(0, 5);
+          }
+        }
+        // Vertex's prior contract: result is JSON-stringified body. Preserve.
+        const responseBody = { ok: true, matches: result.matches ?? [] };
+        return {
+          success: true,
+          result: typeof r.text === 'string' && r.text.length > 0 && result.decision === 'auto_nav'
+            ? r.text
+            : JSON.stringify(responseBody),
+        };
       }
 
       case 'list_my_intents': {

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -2314,6 +2314,108 @@ export async function tool_navigate(
 }
 
 // ---------------------------------------------------------------------------
+// VTID-01975 — view_intent_matches (PR 1.B-6)
+//
+// Lists the user's top-N intent matches for a given intent and auto-redirects
+// to INTENTS.MATCH_DETAIL when the result is unambiguous (single match OR
+// the top score dominates the runner-up by ≥ AMBIG_GAP). Otherwise returns
+// the list-only payload so the LLM can read it and ask the user which to
+// open. Same business logic Vertex's inline case at orb-live.ts:6372 ran;
+// the auto-nav directive is the new behaviour both pipelines pick up.
+// ---------------------------------------------------------------------------
+
+const INTENT_MATCH_AUTONAV_GAP = 0.15;
+
+export async function tool_view_intent_matches(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+): Promise<OrbToolResult> {
+  const intentId = String(args.intent_id ?? '').trim();
+  if (!intentId) return { ok: false, error: 'intent_id is required' };
+  if (!id.user_id) return { ok: false, error: 'authentication required' };
+
+  const limit = Math.min(Math.max(Number(args.limit) || 3, 1), 10);
+  try {
+    const { surfaceTopMatches } = await import('./intent-matcher');
+    const { redactMatchForReader } = await import('./intent-mutual-reveal');
+    const matches = await surfaceTopMatches(intentId, limit);
+    const redacted = await Promise.all(matches.map((m) => redactMatchForReader(m, id.user_id)));
+    const slim = redacted.map((m) => ({
+      match_id: m.match_id,
+      vitana_id_b: m.vitana_id_b,
+      score: m.score,
+      kind_pairing: m.kind_pairing,
+      state: m.state,
+      redacted: m.redacted,
+    }));
+
+    // Unambiguity: 1 match OR top score - second score >= AMBIG_GAP. Ambiguous
+    // results stay list-only and the LLM disambiguates verbally.
+    const top = slim[0];
+    const second = slim[1];
+    const dominant =
+      !!top &&
+      (slim.length === 1 ||
+        (typeof top.score === 'number' &&
+          typeof second?.score === 'number' &&
+          top.score - second.score >= INTENT_MATCH_AUTONAV_GAP));
+
+    if (dominant && top) {
+      const route = `/intents/match/${encodeURIComponent(top.match_id)}`;
+      const directive = {
+        type: 'orb_directive',
+        directive: 'navigate',
+        screen_id: 'INTENTS.MATCH_DETAIL',
+        route,
+        title: 'Match Detail',
+        reason: 'view_intent_matches dominant pick',
+        vtid: 'VTID-01975',
+      };
+      const { emitOasisEvent } = await import('./oasis-event-service');
+      emitOasisEvent({
+        vtid: 'VTID-01975',
+        type: 'orb.intent_matches.auto_nav',
+        source: 'orb-tools-shared',
+        status: 'info',
+        message: `view_intent_matches auto-redirect → match=${top.match_id}`,
+        payload: {
+          session_id: id.session_id || null,
+          intent_id: intentId,
+          match_id: top.match_id,
+          score: top.score,
+          runner_up_score: second?.score ?? null,
+        },
+        actor_id: id.user_id,
+        actor_role: 'user',
+        surface: 'orb',
+      }).catch(() => {});
+
+      return {
+        ok: true,
+        result: {
+          ok: true,
+          matches: slim,
+          decision: 'auto_nav',
+          directive,
+          redirect: { route },
+        },
+        text: `Opening your top match. Score ${top.score.toFixed(2)} — clearly the best fit.`,
+      };
+    }
+
+    return {
+      ok: true,
+      result: { ok: true, matches: slim, decision: 'list_only' },
+      text: JSON.stringify({ ok: true, matches: slim }),
+    };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'unknown';
+    console.error('[VTID-01975] view_intent_matches error:', msg);
+    return { ok: false, error: msg };
+  }
+}
+
+// ---------------------------------------------------------------------------
 // VTID-NAV-TIMEJOURNEY — get_current_screen (PR 1.B-3)
 //
 // Mirrors orb-live.ts:handleGetCurrentScreen byte-for-byte: resolves the
@@ -2813,6 +2915,10 @@ export const ORB_TOOL_REGISTRY: Record<string, OrbToolHandler> = {
   // VTID-NAV-UNIFIED — free-text navigate (PR 1.B-4). Runs consultNavigator's
   // 8-step resolution and constructs the redirect directive.
   navigate: tool_navigate,
+  // VTID-01975 — view_intent_matches (PR 1.B-6). Auto-redirects to
+  // INTENTS.MATCH_DETAIL when the top score dominates the runner-up;
+  // otherwise lists matches and lets the LLM disambiguate verbally.
+  view_intent_matches: tool_view_intent_matches,
   // VTID-NAV-TIMEJOURNEY — get_current_screen (PR 1.B-3). Resolves the user's
   // LIVE current screen via the nav catalog. Anonymous-safe — pulls
   // current_route + recent_routes from args (Vertex/LiveKit pass them via

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -543,6 +543,11 @@ export type CicdEventType =
   // subsequent orb.navigator.dispatched (or .blocked) on the user's reply —
   // lets us measure clarification → resolution rate.
   | 'orb.navigator.disambiguated'
+  // VTID-01975 (PR 1.B-6): view_intent_matches auto-redirected to a
+  // match-detail screen because the top match's score dominated the
+  // runner-up. Lets ops measure how often the disambiguation gap is
+  // wide enough for confident auto-nav vs list-only.
+  | 'orb.intent_matches.auto_nav'
   // VTID-01225: Cognee Entity Extraction Events
   | 'cognee.extraction.started'
   | 'cognee.extraction.completed'


### PR DESCRIPTION
## Summary

Lifts `view_intent_matches` from Vertex's inline case at `orb-live.ts:6372` into `services/orb-tools-shared.ts:tool_view_intent_matches` and adds auto-redirect to `INTENTS.MATCH_DETAIL` when the top match's score clearly dominates the runner-up (gap >= 0.15).

After this PR a user saying *"show me my matches for the salsa intent"* gets:
- Single dominant match → auto-redirects to `/intents/match/<match_id>` via the data channel (LiveKit) or SSE/WS (Vertex). WhyThisMatchCard mounts.
- Multiple comparable matches → list-only payload; LLM disambiguates verbally.

## Disambiguity heuristic

- Single match → auto-nav.
- Multiple matches → auto-nav iff `top.score - second.score >= 0.15`. Below the threshold the matches are "comparable" and the LLM should ask the user which one to open.

## Changes

**`services/gateway/src/services/orb-tools-shared.ts`**:
- `tool_view_intent_matches(args, id)` calls `surfaceTopMatches` + `redactMatchForReader` (existing services), computes dominance, returns directive when unambiguous. Emits new `orb.intent_matches.auto_nav` OASIS event with score + runner-up score.
- Registered in `ORB_TOOL_REGISTRY`.

**`services/gateway/src/types/cicd.ts`**:
- New `orb.intent_matches.auto_nav` `CicdEventType` so the dominance gap can be tracked.

**`services/gateway/src/routes/orb-live.ts`**:
- Vertex case becomes a `dispatchOrbTool` delegation. On `auto_nav`: emits directive over SSE/WS, sets `session.pendingNavigation`, eagerly updates `session.current_route`. Otherwise returns JSON-stringified matches list (preserves Vertex's prior contract).

**`services/agents/orb-agent/src/orb_agent/tools.py`**:
- `view_intent_matches` wrapper now takes `(intent_id, limit=3)` — was no-arg before pointing at `/api/v1/intent-matches/incoming`. Routes through the shared dispatcher via `_dispatch_with_directive` so the data-channel auto-redirect lands on LiveKit. Eagerly updates `gw.current_route` on auto_nav.

## Verification

- `npm run build` (gateway) — clean.
- `npx jest test/nav-redirect-flow.test.ts` — 13 pass.
- `python3 -m py_compile` (orb-agent) — clean.
- `node scripts/orb-tools-lift-scanner.mjs` — clean.
- VTID: VTID-02841.

## Test plan

- [ ] Voice on `/command-hub/testing-qa/livekit-test/`: "show me my matches for the salsa intent" → if 1 dominant: auto-redirects to `/intents/match/<match_id>`. If multiple comparable: agent reads list verbally and asks which.
- [ ] OASIS query for the session: `topic='orb.intent_matches.auto_nav'` row exists with `score` + `runner_up_score`.
- [ ] Same scenarios on Vertex pipeline → identical behavior (regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)