### PR TITLE
feat(VTID-02842): PR 1.B-7 — auto-navigate search_community when unambiguous

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/tools.py
+++ b/services/agents/orb-agent/src/orb_agent/tools.py
@@ -264,8 +264,28 @@ async def search_events(context: RunContext, query: str = "") -> str:
 
 @function_tool
 async def search_community(context: RunContext, query: str) -> str:
-    """Search community groups / channels (VTID-01270A)."""
-    body = await _dispatch(context, "search_community", {"query": query})
+    """Search community groups / channels.
+
+    PR 1.B-7: when the result is unambiguous (single hit OR exact name
+    match) the user is auto-redirected to that group's detail screen via
+    the data-channel directive. When several groups are comparable, the
+    list is returned and you should ask the user which to open.
+
+    Args:
+        query: Free-text search across group name + description + topic.
+    """
+    body = await _dispatch_with_directive(context, "search_community", {"query": query})
+    res = body.get("result") if isinstance(body, dict) else None
+    if isinstance(res, dict) and res.get("decision") == "auto_nav":
+        directive = res.get("directive") or {}
+        new_route = directive.get("route") if isinstance(directive, dict) else None
+        if isinstance(new_route, str) and new_route:
+            gw = _gw(context)
+            previous = gw.current_route
+            gw.current_route = new_route
+            if previous and previous != new_route:
+                trail = [r for r in (gw.recent_routes or []) if r != previous]
+                gw.recent_routes = ([previous] + trail)[:5]
     return summarize(body)
 
 

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -5057,7 +5057,11 @@ async function executeLiveApiToolInner(
       }
 
       case 'search_community': {
-        // PR B-8: lifted to services/orb-tools-shared.ts.
+        // PR B-8 lifted the search; PR 1.B-7 added auto-nav to COMM.GROUP_DETAIL
+        // when the result is unambiguous. Switch from dispatchOrbToolForVertex
+        // to dispatchOrbTool so the structured `result.directive` is readable
+        // and Vertex can emit it via SSE/WS + set session.pendingNavigation
+        // + eagerly update session.current_route.
         const SUPABASE_URL = process.env.SUPABASE_URL;
         const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
         if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
@@ -5065,8 +5069,8 @@ async function executeLiveApiToolInner(
         }
         const { createClient } = await import('@supabase/supabase-js');
         const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
-        const { dispatchOrbToolForVertex } = await import('../services/orb-tools-shared');
-        return await dispatchOrbToolForVertex(
+        const { dispatchOrbTool } = await import('../services/orb-tools-shared');
+        const r = await dispatchOrbTool(
           'search_community',
           args ?? {},
           {
@@ -5074,9 +5078,58 @@ async function executeLiveApiToolInner(
             tenant_id: lens.tenant_id ?? null,
             role: session.identity?.role ?? null,
             vitana_id: session.identity?.vitana_id ?? null,
+            session_id: session.sessionId,
           },
           supabase,
         );
+        if (r.ok === false) {
+          return { success: false, result: '', error: r.error };
+        }
+        const result = (r.result ?? {}) as {
+          groups?: unknown[];
+          decision?: string;
+          directive?: {
+            type: string;
+            directive: string;
+            screen_id: string;
+            route: string;
+            title: string;
+            reason: string;
+            vtid: string;
+          };
+        };
+        if (result.decision === 'auto_nav' && result.directive) {
+          const directive = result.directive;
+          const directiveJson = JSON.stringify(directive);
+          if (session.sseResponse) {
+            try { session.sseResponse.write(`data: ${directiveJson}\n\n`); } catch (_e) { /* SSE closed */ }
+          }
+          if ((session as unknown as { clientWs?: { readyState: number } }).clientWs &&
+              (session as unknown as { clientWs?: { readyState: number } }).clientWs!.readyState === 1) {
+            try { sendWsMessage((session as unknown as { clientWs: unknown }).clientWs as Parameters<typeof sendWsMessage>[0], directive); } catch (_e) { /* WS closed */ }
+          }
+          session.pendingNavigation = {
+            screen_id: directive.screen_id,
+            route: directive.route,
+            title: directive.title,
+            reason: directive.reason,
+            decision_source: 'direct',
+            requested_at: Date.now(),
+          };
+          session.navigationDispatched = true;
+          session.pendingNavigation = undefined;
+          const previousRoute = session.current_route;
+          session.current_route = directive.route;
+          if (previousRoute && previousRoute !== directive.route) {
+            const trail = Array.isArray(session.recent_routes) ? [...session.recent_routes] : [];
+            const deduped = trail.filter((rt) => rt !== previousRoute);
+            session.recent_routes = [previousRoute, ...deduped].slice(0, 5);
+          }
+        }
+        return {
+          success: true,
+          result: typeof r.text === 'string' ? r.text : '',
+        };
       }
 
       // VTID-02754 — Find ONE community member by free-text query and redirect

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -562,6 +562,25 @@ export async function tool_search_community(
       text: 'No community groups found matching your query.',
     };
   }
+
+  // PR 1.B-7: auto-redirect when the result is unambiguous (single hit, OR
+  // the query exactly matches one group's name / topic_key — Postgres ilike
+  // with `*query*` wildcards is permissive, so we score the top hit's name
+  // similarity to disambiguate). For comparable matches, list-only and let
+  // the LLM ask which the user wants. Mirrors the gap-based heuristic used
+  // for view_intent_matches (PR 1.B-6) and find_community_member.
+  const isExactName = (group: { name: string; topic_key: string }) => {
+    const nq = query.toLowerCase().trim();
+    if (!nq) return false;
+    return (
+      group.name.toLowerCase() === nq ||
+      group.topic_key.toLowerCase() === nq ||
+      group.name.toLowerCase().includes(nq) && nq.length >= 3 && groups.length <= 2
+    );
+  };
+  const top = groups[0];
+  const dominant = top && (groups.length === 1 || isExactName(top));
+
   const MAX = 2000;
   let formatted = groups
     .map((g) => `${g.name} — ${(g.description || '').substring(0, 120)} | Topic: ${g.topic_key}`)
@@ -569,9 +588,52 @@ export async function tool_search_community(
   if (formatted.length > MAX) {
     formatted = formatted.substring(0, MAX) + '\n... (truncated)';
   }
+
+  if (dominant && top) {
+    const route = `/comm/groups/${encodeURIComponent(top.id)}`;
+    const directive = {
+      type: 'orb_directive',
+      directive: 'navigate',
+      screen_id: 'COMM.GROUP_DETAIL',
+      route,
+      title: top.name,
+      reason: 'search_community dominant pick',
+      vtid: 'VTID-01270A',
+    };
+    const { emitOasisEvent } = await import('./oasis-event-service');
+    emitOasisEvent({
+      vtid: 'VTID-01270A',
+      type: 'orb.search_community.auto_nav',
+      source: 'orb-tools-shared',
+      status: 'info',
+      message: `search_community auto-redirect → ${top.name}`,
+      payload: {
+        session_id: id.session_id || null,
+        query,
+        group_id: top.id,
+        topic_key: top.topic_key,
+        result_count: groups.length,
+      },
+      actor_id: id.user_id,
+      actor_role: 'user',
+      surface: 'orb',
+    }).catch(() => {});
+
+    return {
+      ok: true,
+      result: {
+        groups,
+        decision: 'auto_nav',
+        directive,
+        redirect: { route },
+      },
+      text: `Opening "${top.name}" — ${(top.description || '').substring(0, 120)}`,
+    };
+  }
+
   return {
     ok: true,
-    result: { groups },
+    result: { groups, decision: 'list_only' },
     text: `Found ${groups.length} community groups:\n${formatted}`,
   };
 }

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -548,6 +548,10 @@ export type CicdEventType =
   // runner-up. Lets ops measure how often the disambiguation gap is
   // wide enough for confident auto-nav vs list-only.
   | 'orb.intent_matches.auto_nav'
+  // VTID-01270A (PR 1.B-7): search_community auto-redirected to
+  // COMM.GROUP_DETAIL because result was unambiguous (single hit or
+  // exact name match). Lets ops measure auto-nav vs list-only ratio.
+  | 'orb.search_community.auto_nav'
   // VTID-01225: Cognee Entity Extraction Events
   | 'cognee.extraction.started'
   | 'cognee.extraction.completed'


### PR DESCRIPTION
## Summary

Extends `tool_search_community` (lifted in PR B-8) with auto-redirect to `COMM.GROUP_DETAIL` when the result is unambiguous — single hit OR exact name/topic match. Comparable matches keep list-only behaviour and the LLM disambiguates verbally.

After this PR a user saying *"show me the meditation group"* gets:
- Single hit / exact name → auto-redirects to `/comm/groups/<id>` via the data channel (LiveKit) or SSE/WS (Vertex). Group detail screen mounts on landing.
- Multiple comparable groups → list-only payload; LLM asks which.

## Disambiguity heuristic

- `groups.length === 1` → auto-nav.
- Top group's `name` (or `topic_key`) matches query exactly → auto-nav.
- Top name *contains* query AND `groups.length ≤ 2` AND `query.length ≥ 3` → auto-nav (handles "meditation" → "Meditation Group" with at most one near-miss).
- Otherwise → list-only.

## Changes

**`services/gateway/src/services/orb-tools-shared.ts`**:
- `tool_search_community` now computes dominance, returns `directive` + `decision='auto_nav'` on unambiguous result, `decision='list_only'` otherwise.
- Emits `orb.search_community.auto_nav` OASIS event (query + group_id + topic_key + result_count).

**`services/gateway/src/types/cicd.ts`**:
- New `orb.search_community.auto_nav` `CicdEventType`.

**`services/gateway/src/routes/orb-live.ts`**:
- Vertex case switches from `dispatchOrbToolForVertex` to `dispatchOrbTool` so it can read `result.directive`. On `auto_nav`: emits directive over SSE/WS, sets `pendingNavigation`, eagerly updates `session.current_route`.

**`services/agents/orb-agent/src/orb_agent/tools.py`**:
- `search_community` wrapper uses `_dispatch_with_directive`. Eagerly updates `gw.current_route` on auto_nav.

## Verification

- `npm run build` (gateway) — clean.
- `npx jest test/nav-redirect-flow.test.ts` — 13 pass.
- `python3 -m py_compile` (orb-agent) — clean.
- VTID: VTID-02842.

## Test plan

- [ ] Voice on `/command-hub/testing-qa/livekit-test/`: "show me the meditation group" → if 1 dominant: auto-redirects to `/comm/groups/<id>`. If multiple: agent reads list and asks which.
- [ ] OASIS query: `topic='orb.search_community.auto_nav'` row exists with `query` + `group_id` + `topic_key`.
- [ ] Vertex regression: same scripted scenarios on Vertex pipeline → identical behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)