### PR TITLE
feat(VTID-02843): PR 1.B-8 — auto-navigate search_events when unambiguous

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/tools.py
+++ b/services/agents/orb-agent/src/orb_agent/tools.py
@@ -258,7 +258,13 @@ async def search_events(context: RunContext, query: str = "") -> str:
         query: Optional substring to filter on title/description (case-insensitive).
                Pass "" or omit to list all upcoming events.
     """
-    body = await _dispatch(context, "search_events", {"query": query})
+    # PR 1.B-8: when the result has a single dominant event, auto-redirect
+    # the user to the event-drawer overlay via the data channel. Comparable
+    # results (live_rooms in the mix, or top score not dominant) → list-only
+    # and the LLM lets the user pick.
+    body = await _dispatch_with_directive(context, "search_events", {"query": query})
+    # No gw.current_route eager update — the event-drawer is an overlay and
+    # the underlying screen does not change.
     return summarize(body)
 
 

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -5032,9 +5032,12 @@ async function executeLiveApiToolInner(
       // =====================================================================
 
       case 'search_events': {
-        // PR B-10: lifted to services/orb-tools-shared.ts. Both pipelines now
-        // run scoreAndRankEvents through the shared dispatcher — same scoring,
-        // same home-city proximity boost, same parallel live_rooms fetch.
+        // PR B-10 lifted the scoring engine; PR 1.B-8 added auto-nav to
+        // OVERLAY.EVENT_DRAWER when the top event dominates the runner-up
+        // and there are no live-rooms competing. Switch from
+        // dispatchOrbToolForVertex to dispatchOrbTool so we can read the
+        // structured directive and emit it via SSE/WS just like
+        // search_community + view_intent_matches do.
         const SUPABASE_URL = process.env.SUPABASE_URL;
         const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
         if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
@@ -5042,8 +5045,8 @@ async function executeLiveApiToolInner(
         }
         const { createClient } = await import('@supabase/supabase-js');
         const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
-        const { dispatchOrbToolForVertex } = await import('../services/orb-tools-shared');
-        return await dispatchOrbToolForVertex(
+        const { dispatchOrbTool } = await import('../services/orb-tools-shared');
+        const r = await dispatchOrbTool(
           'search_events',
           args ?? {},
           {
@@ -5051,9 +5054,53 @@ async function executeLiveApiToolInner(
             tenant_id: lens.tenant_id ?? null,
             role: session.identity?.role ?? null,
             vitana_id: session.identity?.vitana_id ?? null,
+            session_id: session.sessionId,
           },
           supabase,
         );
+        if (r.ok === false) {
+          return { success: false, result: '', error: r.error };
+        }
+        const result = (r.result ?? {}) as {
+          decision?: string;
+          directive?: {
+            type: string;
+            directive: string;
+            screen_id: string;
+            route: string;
+            title: string;
+            reason: string;
+            vtid: string;
+          };
+        };
+        if (result.decision === 'auto_nav' && result.directive) {
+          const directive = result.directive;
+          const directiveJson = JSON.stringify(directive);
+          if (session.sseResponse) {
+            try { session.sseResponse.write(`data: ${directiveJson}\n\n`); } catch (_e) { /* SSE closed */ }
+          }
+          if ((session as unknown as { clientWs?: { readyState: number } }).clientWs &&
+              (session as unknown as { clientWs?: { readyState: number } }).clientWs!.readyState === 1) {
+            try { sendWsMessage((session as unknown as { clientWs: unknown }).clientWs as Parameters<typeof sendWsMessage>[0], directive); } catch (_e) { /* WS closed */ }
+          }
+          // Event drawer is overlay-kind — DO NOT mutate session.current_route
+          // (the user stays on the underlying page; only a drawer opens).
+          // Set pendingNavigation so the turn_complete handler is informed.
+          session.pendingNavigation = {
+            screen_id: directive.screen_id,
+            route: directive.route,
+            title: directive.title,
+            reason: directive.reason,
+            decision_source: 'direct',
+            requested_at: Date.now(),
+          };
+          session.navigationDispatched = true;
+          session.pendingNavigation = undefined;
+        }
+        return {
+          success: true,
+          result: typeof r.text === 'string' ? r.text : '',
+        };
       }
 
       case 'search_community': {

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -497,12 +497,80 @@ export async function tool_search_events(
     formatted += liveRoomResults.join('\n');
   }
 
+  // PR 1.B-8: auto-redirect to the event-drawer overlay when the result
+  // is unambiguous. Vertex/LiveKit both call into the existing
+  // OVERLAY.EVENT_DRAWER catalog entry (route /comm/events-meetups?open=event&event_id=…),
+  // which the frontend orb widget already knows how to open as a drawer.
+  // Heuristic: 1 event in best[] AND no live_rooms, OR top.score gaps
+  // runner-up by >= EVENT_AUTONAV_GAP. Comparable matches → list-only.
+  const EVENT_AUTONAV_GAP = 0.15;
+  const top = sr?.best?.[0];
+  const second = sr?.best?.[1];
+  const dominant =
+    !!top &&
+    !hasRooms &&
+    (
+      (sr!.best.length === 1 && sr!.alternatives.length === 0) ||
+      (typeof top.score === 'number' &&
+        typeof second?.score === 'number' &&
+        top.score - second.score >= EVENT_AUTONAV_GAP)
+    );
+
+  if (dominant && top) {
+    const eventId = top.event.id;
+    const eventTitle = top.event.title || 'Event';
+    const route = `/comm/events-meetups?open=event&event_id=${encodeURIComponent(eventId)}`;
+    const directive = {
+      type: 'orb_directive',
+      directive: 'navigate',
+      screen_id: 'OVERLAY.EVENT_DRAWER',
+      route,
+      title: eventTitle,
+      reason: 'search_events dominant pick',
+      vtid: 'VTID-01270A',
+    };
+    const { emitOasisEvent } = await import('./oasis-event-service');
+    emitOasisEvent({
+      vtid: 'VTID-01270A',
+      type: 'orb.search_events.auto_nav',
+      source: 'orb-tools-shared',
+      status: 'info',
+      message: `search_events auto-redirect → ${eventTitle}`,
+      payload: {
+        session_id: id.session_id || null,
+        query,
+        event_id: eventId,
+        event_title: eventTitle,
+        score: top.score,
+        runner_up_score: second?.score ?? null,
+        result_count: sr!.best.length + sr!.alternatives.length,
+      },
+      actor_id: id.user_id,
+      actor_role: 'user',
+      surface: 'orb',
+    }).catch(() => {});
+
+    return {
+      ok: true,
+      result: {
+        best: sr?.best ?? [],
+        alternatives: sr?.alternatives ?? [],
+        live_rooms: liveRoomResults,
+        decision: 'auto_nav',
+        directive,
+        redirect: { route },
+      },
+      text: `Opening "${eventTitle}".`,
+    };
+  }
+
   return {
     ok: true,
     result: {
       best: sr?.best ?? [],
       alternatives: sr?.alternatives ?? [],
       live_rooms: liveRoomResults,
+      decision: 'list_only',
     },
     text: formatted,
   };

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -552,6 +552,10 @@ export type CicdEventType =
   // COMM.GROUP_DETAIL because result was unambiguous (single hit or
   // exact name match). Lets ops measure auto-nav vs list-only ratio.
   | 'orb.search_community.auto_nav'
+  // VTID-01270A (PR 1.B-8): search_events auto-redirected to the
+  // OVERLAY.EVENT_DRAWER overlay because the top event dominated the
+  // runner-up by >= 0.15 and there were no live_rooms in the result.
+  | 'orb.search_events.auto_nav'
   // VTID-01225: Cognee Entity Extraction Events
   | 'cognee.extraction.started'
   | 'cognee.extraction.completed'


### PR DESCRIPTION
## Summary

Extends `tool_search_events` with auto-redirect to `OVERLAY.EVENT_DRAWER` when the top scored event dominates the runner-up (gap >= 0.15) and there are no `live_rooms` competing in the result. Comparable matches and mixed event/live-room results stay list-only.

**Revision from plan**: the plan called for adding a new `EVENTS.DETAIL` catalog entry, but the existing `OVERLAY.EVENT_DRAWER` (route `/comm/events-meetups` + overlay marker `event` + `needs_param: 'event_id'`) is already what the frontend uses to drill into a specific event. No new catalog entry needed — the orb widget already handles overlay directives.

After this PR a user saying *"find the SPF Party event"* gets:
- Score-dominant event + no live_rooms → auto-redirects to `/comm/events-meetups?open=event&event_id=<id>`. Drawer opens.
- Multiple comparable events → list-only; LLM disambiguates.
- Live_rooms in result → list-only (time-sensitive alternatives the user might prefer; never auto-skip).

## Changes

**`services/gateway/src/services/orb-tools-shared.ts`**:
- `tool_search_events` computes dominance, returns `directive` + `decision='auto_nav'`. Suppressed when `live_rooms.length > 0`. Emits `orb.search_events.auto_nav` OASIS event with score + runner-up score + result_count.

**`services/gateway/src/types/cicd.ts`**:
- New `orb.search_events.auto_nav` `CicdEventType`.

**`services/gateway/src/routes/orb-live.ts`**:
- Vertex case switches from `dispatchOrbToolForVertex` to `dispatchOrbTool`. On auto_nav: emits directive over SSE/WS, sets `pendingNavigation`. Does NOT update `session.current_route` (overlay — user stays on underlying page).

**`services/agents/orb-agent/src/orb_agent/tools.py`**:
- `search_events` wrapper uses `_dispatch_with_directive`. No eager `current_route` update (overlay).

## Verification

- `npm run build` (gateway) — clean.
- `npx jest test/nav-redirect-flow.test.ts` — 13 pass.
- `python3 -m py_compile` (orb-agent) — clean.
- `node scripts/orb-tools-lift-scanner.mjs` — clean.
- VTID: VTID-02843.

## Test plan

- [ ] Voice on `/command-hub/testing-qa/livekit-test/`: "find the SPF Party event" → if 1 dominant + no live_rooms: auto-opens event drawer at `/comm/events-meetups?open=event&event_id=<id>`. If multiple: agent reads list and asks which.
- [ ] OASIS query: `topic='orb.search_events.auto_nav'` row exists with `event_id` + `event_title` + `score` + `runner_up_score`.
- [ ] Vertex regression: same scripted scenarios on Vertex pipeline → identical behaviour.

🤖 Generated with [Claude Code](https://claude.com/claude-code)