### PR TITLE
ci(VTID-02845): PR 1.B-10 — promote ORB tools parity scanner to hard gate

### DIFF
--- a/.github/workflows/ORB-TOOLS-LIFT-SCANNER.yml
+++ b/.github/workflows/ORB-TOOLS-LIFT-SCANNER.yml
@@ -5,9 +5,18 @@ name: Orb Tools Lift Scanner
 # (Vertex pipeline) — specifically: Vertex cases for tools in the registry
 # that still have inline logic instead of delegating to dispatchOrbToolForVertex.
 #
-# REPORT-ONLY today. Posts the diff as a sticky PR comment; never fails
-# the build. Promote to gate by setting `ORB_TOOLS_PARITY_GATE: '1'` in
-# the env block below once all intentional drift is lifted.
+# GATE MODE (PR 1.B-10 / VTID-02845). All Phase 1.B lifts have landed:
+# 41/47 Vertex case-arms delegate via dispatchOrbTool(ForVertex), the
+# remaining 6 are either intentional Vertex-only (switch_persona,
+# report_to_specialist) or inline-but-not-shared (calendar / reminders /
+# index / intents — flagged by the scanner as "vertex-only inline" with
+# no critical drift). Promoting ORB_TOOLS_PARITY_GATE=1 turns the scanner
+# into a hard merge gate so any future PR that adds a new inline Vertex
+# case for a tool that's already in the shared registry — i.e.
+# re-introduces parity drift — fails CI on contact.
+#
+# Report-only behavior is recoverable: flip back to '0' to silence the
+# gate while a new lift is in progress.
 
 on:
   pull_request:
@@ -45,10 +54,12 @@ jobs:
       - name: Run lift-not-duplicate parity scanner
         id: scan
         env:
-          # Set to '1' to fail the build on drift (gate mode). Today
-          # report-only so it doesn't block work while remaining tools
-          # are progressively lifted.
-          ORB_TOOLS_PARITY_GATE: '0'
+          # PR 1.B-10 promoted this from '0' to '1'. Phase 1.B lifts
+          # complete — any new inline Vertex case for a tool already in
+          # ORB_TOOL_REGISTRY now FAILS the build (DRIFT-CRITICAL exit
+          # code 2). Flip back to '0' if a future lift is in progress
+          # and you need to merge work-in-progress.
+          ORB_TOOLS_PARITY_GATE: '1'
         run: |
           set -o pipefail
           node scripts/orb-tools-lift-scanner.mjs 2>&1 | tee /tmp/orb-tools-parity.md

--- a/scripts/orb-tools-lift-scanner.mjs
+++ b/scripts/orb-tools-lift-scanner.mjs
@@ -192,12 +192,27 @@ const VERTEX_ONLY_INTENTIONAL = new Set([
   'switch_persona',       // mutates session.pendingPersonaSwap, persona-overrides, etc.
   'report_to_specialist', // tied to Vertex's WebSocket persona-swap orchestration
 ]);
+// Tools in ORB_TOOL_REGISTRY that don't have a `case` arm in the switch
+// because Vertex routes them via a DEDICATED handler before the switch
+// (handleNavigate, handleNavigateToScreen, handleGetCurrentScreen — all
+// PR 1.B-3..5 lifts that delegate via dispatchOrbTool internally). Without
+// this allowlist the scanner flags them as `shared-only` warnings, which
+// in gate mode causes a false-positive build failure.
+const SHARED_ONLY_INTENTIONAL = new Set([
+  'navigate',             // Vertex: handleNavigate at orb-live.ts (PR 1.B-4)
+  'navigate_to_screen',   // Vertex: handleNavigateToScreen (PR 1.B-5)
+  'get_current_screen',   // Vertex: handleGetCurrentScreen (PR 1.B-3)
+]);
 const intentionalInline = [];
 
+// Tracked separately so the report shows "shared-only OK" for the
+// dedicated-handler set without contributing to the warning exit code.
+const sharedOnlyOk = [];
 for (const name of registry) {
   const v = vertexCases.get(name);
   if (!v) {
-    sharedOnly.push(name);
+    if (SHARED_ONLY_INTENTIONAL.has(name)) sharedOnlyOk.push(name);
+    else sharedOnly.push(name);
     continue;
   }
   if (!v.delegated) {
@@ -261,6 +276,20 @@ if (sharedOnly.length > 0) {
   }
   out += '\n';
   if (exitCode === 0) exitCode = 1;
+}
+
+if (sharedOnlyOk.length > 0) {
+  out += `### ℹ️ shared-only OK — ${sharedOnlyOk.length} tool(s) routed via dedicated Vertex handler\n\n`;
+  out += 'These are in `ORB_TOOL_REGISTRY` but DON\'T appear as a `case` arm in ';
+  out += 'the switch because Vertex routes them via a dedicated handler ';
+  out += '(handleNavigate / handleNavigateToScreen / handleGetCurrentScreen) ';
+  out += 'before the switch. Each handler delegates to the shared dispatcher ';
+  out += 'internally — full parity, just not via a case arm. ';
+  out += 'Allowlist: `SHARED_ONLY_INTENTIONAL` in `scripts/orb-tools-lift-scanner.mjs`.\n\n';
+  for (const n of sharedOnlyOk) {
+    out += `- \`${n}\`\n`;
+  }
+  out += '\n';
 }
 
 if (vertexOnly.length > 0) {


### PR DESCRIPTION
## Summary

**Final PR of Phase 1.B.** Sets `ORB_TOOLS_PARITY_GATE=1` in `.github/workflows/ORB-TOOLS-LIFT-SCANNER.yml` so the scanner now FAILS the build (exit code 2) on DRIFT-CRITICAL — i.e. any new Vertex inline `case 'tool_name':` whose body does NOT delegate via `dispatchOrbTool` / `dispatchOrbToolForVertex` when the same tool is in `ORB_TOOL_REGISTRY`.

After this PR a contributor cannot accidentally re-introduce the "Vertex grew a new tool, LiveKit forgot" drift class — the merge gate catches it on the first PR that tries.

## Phase 1.B summary (all 11 PRs, all merged)

| | PR | What |
|---|---|---|
| 1.B-0 | #1958 | data-channel directives (LiveKit transport for `orb_directive`) |
| 1.B-1 | #1961 | `find_community_member` end-to-end + auto-redirect |
| 1.B-2 | #1959 | 5 health-log Python wrappers |
| 1.B-3 | #1962 | `get_current_screen` + identity threading for `current_route` |
| 1.B-4 | #1966 | free-text `navigate` (consultNavigator) + auto-redirect |
| 1.B-5 | #1972 | close 7 navigator gates |
| 1.B-6 | #1973 | auto-navigate `view_intent_matches` |
| 1.B-7 | #1974 | auto-navigate `search_community` |
| 1.B-8 | #1975 | auto-navigate `search_events` to event drawer |
| 1.B-Lang | #1971 | per-language STT/TTS at session level (en+de minimum) |
| 1.B-9 | #1976 | Voice Tools manifest reconciliation + Wired in UI |
| **1.B-10** | **this** | promote scanner gate |

The LiveKit voice pipeline now runs every Vertex tool through the same shared dispatcher, with identical behavior on:
- `find_community_member` (auto-redirect to `/u/:vid?match_intent=…`)
- free-text `navigate` (consultNavigator's 8-step resolution + directive emit)
- `navigate_to_screen` (7 gates: anonymous, viewport, mobile_route, already_there, OASIS error_kind, identity threading, eager current_route update)
- `get_current_screen` (recent-routes trail through nav catalog)
- 4 entity-resolving tools auto-nav to detail screens when unambiguous
- Multilingual: `identity.lang` threaded into `build_cascade`; STT + TTS pick per-language config; 9 langs seeded in `LANG_DEFAULTS`

The Voice Tools Catalog UI now tells operators which pipeline each tool is wired in (BOTH / VERTEX / LIVEKIT / NONE), and the manifest reconciler keeps it honest. This scanner gate makes drift unrecoverable as a silent regression.

## Verification

- `ORB_TOOLS_PARITY_GATE=1 node scripts/orb-tools-lift-scanner.mjs` → exit code 0 against current main.
- VTID: VTID-02845.

## Test plan

- [ ] CI on this PR runs the scanner with `GATE=1` and passes.
- [ ] Open a follow-up PR that adds an inline `case 'foo':` to `orb-live.ts` for a tool already in `ORB_TOOL_REGISTRY` without delegating → confirms CI fails.
- [ ] Flip `ORB_TOOLS_PARITY_GATE` back to `'0'` is a recoverable action when a future lift is in progress.

🤖 Generated with [Claude Code](https://claude.com/claude-code)