### PR TITLE
fix(dev-autopilot): align bridge DRY_RUN default + reconciler auto-archives closed-unmerged PRs

### DIFF
--- a/services/gateway/src/services/dev-autopilot-bridge.ts
+++ b/services/gateway/src/services/dev-autopilot-bridge.ts
@@ -21,7 +21,14 @@
  *        - confidence < 0.5 OR triage errored
  *             → mark failed_escalated; surface for human review
  *
- * DRY_RUN honors DEV_AUTOPILOT_DRY_RUN=true (default) — no real GitHub calls.
+ * DRY_RUN honors DEV_AUTOPILOT_DRY_RUN=true (opt-in for tests / dev). The
+ * default is 'false' so the bridge actually closes failed PRs in production.
+ * The previous default of 'true' was misaligned with the executor's default
+ * of 'false' and was load-bearing: the bridge logged "reverted via
+ * #closed-dry-run" while leaving the GitHub PR open, then
+ * spawnChildExecution() opened a fresh PR for the same finding. Combined
+ * with autoApproveTick re-picking the still-status='new' finding, that
+ * mechanism produced the 2026-05-07 flood (530 stranded PRs in 4 days).
  */
 
 import { randomUUID } from 'crypto';
@@ -36,7 +43,8 @@ import { isEnvironmentalBlocker } from './dev-autopilot-self-heal-log';
 const LOG_PREFIX = '[dev-autopilot-bridge]';
 const BRIDGE_VTID = 'VTID-DEV-AUTOPILOT';
 
-const DRY_RUN = (process.env.DEV_AUTOPILOT_DRY_RUN || 'true').toLowerCase() === 'true';
+// Default 'false' — match the executor's default. See header doc.
+const DRY_RUN = (process.env.DEV_AUTOPILOT_DRY_RUN || 'false').toLowerCase() === 'true';
 const GITHUB_TOKEN =
   process.env.DEV_AUTOPILOT_GITHUB_TOKEN ||
   process.env.GITHUB_SAFE_MERGE_TOKEN ||

--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -1878,21 +1878,29 @@ async function reconcileCi(s: SupaConfig, exec: StuckExecRow): Promise<void> {
   }
 
   if (prR.data.state === 'closed' && !prR.data.merged) {
-    // PR closed without merge — terminal failure.
+    // PR closed without merge — terminal "PR was handled" state. Mark
+    // status='auto_archived' (NOT 'failed') so the runExecutionSession +
+    // approveAutoExecute PR-flood guards stop treating this finding as
+    // stranded. Without auto_archived, the operator's manual close keeps
+    // the finding blocked forever — the original bug that forced the
+    // 2026-05-07 cleanup. Skip bridgeFailure too: spawning a self-heal
+    // child here would burn an LLM call to re-fix a finding whose
+    // proposed PR was just closed (operator/CI rejected it). If the
+    // finding is still actionable, autoApproveTick will pick it up on
+    // its next sweep — bounded by the per-finding retry cap.
     await patchExecution(s, exec.id, {
-      status: 'failed',
+      status: 'auto_archived',
       completed_at: new Date().toISOString(),
-      metadata: { ...(exec.metadata || {}), error: 'reconciler: PR closed without merge' },
+      metadata: { ...(exec.metadata || {}), error: 'reconciler: PR closed without merge (auto_archived)' },
     });
     await emitOasisEvent({
       vtid: EXEC_VTID,
-      type: 'dev_autopilot.execution.failed',
+      type: 'dev_autopilot.execution.auto_archived',
       source: 'dev-autopilot',
-      status: 'error',
-      message: `Reconciler: ${exec.id.slice(0, 8)} PR #${exec.pr_number} closed without merge`,
+      status: 'info',
+      message: `Reconciler: ${exec.id.slice(0, 8)} PR #${exec.pr_number} closed without merge — auto_archived`,
       payload: { execution_id: exec.id, pr_number: exec.pr_number, reason: 'pr_closed_unmerged' },
     });
-    bridgeFailure(exec.id, 'ci', 'PR closed without merge').catch(() => {});
     return;
   }
 

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -636,6 +636,7 @@ export type CicdEventType =
   | 'dev_autopilot.execution.escalated'
   | 'dev_autopilot.execution.completed'
   | 'dev_autopilot.execution.failed'
+  | 'dev_autopilot.execution.auto_archived'
   | 'dev_autopilot.batch.first_failure'
   | 'dev_autopilot.kill_switch.activated'
   | 'dev_autopilot.kill_switch.deactivated'

--- a/supabase/ops/audit_empty_files_referenced_plans.sql
+++ b/supabase/ops/audit_empty_files_referenced_plans.sql
@@ -1,0 +1,69 @@
+-- Audit plans with empty/missing files_referenced. R2-real showed all 5
+-- approved executions failed at "plan has no files_referenced — cannot
+-- execute". This blocks the autopilot from doing real work even after
+-- the flood guards land.
+
+\set ON_ERROR_STOP on
+
+\echo '=== Plan-version stats ==='
+SELECT
+  count(*) AS total_plan_versions,
+  count(*) FILTER (WHERE coalesce(array_length(files_referenced, 1), 0) = 0) AS plans_with_zero_files,
+  count(*) FILTER (WHERE coalesce(array_length(files_referenced, 1), 0) BETWEEN 1 AND 5) AS plans_with_1_to_5_files,
+  count(*) FILTER (WHERE coalesce(array_length(files_referenced, 1), 0) > 5) AS plans_with_more_than_5_files
+FROM dev_autopilot_plan_versions;
+
+\echo ''
+\echo '=== Findings whose LATEST plan has zero files_referenced ==='
+WITH latest AS (
+  SELECT DISTINCT ON (finding_id) finding_id, version, files_referenced, plan_markdown
+  FROM dev_autopilot_plan_versions
+  ORDER BY finding_id, version DESC
+)
+SELECT
+  count(*) AS total_findings_with_plans,
+  count(*) FILTER (WHERE coalesce(array_length(files_referenced, 1), 0) = 0) AS findings_whose_latest_plan_has_zero_files,
+  count(*) FILTER (WHERE plan_markdown IS NULL OR plan_markdown = '') AS findings_whose_plan_markdown_is_empty
+FROM latest;
+
+\echo ''
+\echo '=== Top 10 status=new findings whose latest plan has zero files_referenced ==='
+WITH latest AS (
+  SELECT DISTINCT ON (finding_id) finding_id, version, files_referenced, plan_markdown, created_at AS plan_created
+  FROM dev_autopilot_plan_versions
+  ORDER BY finding_id, version DESC
+)
+SELECT r.id AS finding_id,
+       left(r.title, 80) AS title,
+       r.spec_snapshot->>'scanner' AS scanner,
+       l.version AS plan_version,
+       length(l.plan_markdown) AS plan_md_len,
+       l.plan_created
+FROM autopilot_recommendations r
+JOIN latest l ON l.finding_id = r.id
+WHERE r.source_type = 'dev_autopilot'
+  AND r.status = 'new'
+  AND coalesce(array_length(l.files_referenced, 1), 0) = 0
+ORDER BY r.impact_score DESC NULLS LAST, l.plan_created DESC
+LIMIT 10;
+
+\echo ''
+\echo '=== Sample plan_markdown for one offender (to see what the planner emitted) ==='
+WITH latest AS (
+  SELECT DISTINCT ON (finding_id) finding_id, version, files_referenced, plan_markdown
+  FROM dev_autopilot_plan_versions
+  ORDER BY finding_id, version DESC
+)
+SELECT r.id AS finding_id,
+       r.title,
+       r.spec_snapshot->>'scanner' AS scanner,
+       r.spec_snapshot->'proposed_files' AS spec_proposed_files,
+       l.files_referenced,
+       left(l.plan_markdown, 1500) AS plan_md_excerpt
+FROM autopilot_recommendations r
+JOIN latest l ON l.finding_id = r.id
+WHERE r.source_type = 'dev_autopilot'
+  AND r.status = 'new'
+  AND coalesce(array_length(l.files_referenced, 1), 0) = 0
+ORDER BY r.impact_score DESC NULLS LAST
+LIMIT 2;

--- a/supabase/ops/audit_empty_files_referenced_plans.sql
+++ b/supabase/ops/audit_empty_files_referenced_plans.sql
@@ -8,9 +8,9 @@
 \echo '=== Plan-version stats ==='
 SELECT
   count(*) AS total_plan_versions,
-  count(*) FILTER (WHERE coalesce(array_length(files_referenced, 1), 0) = 0) AS plans_with_zero_files,
-  count(*) FILTER (WHERE coalesce(array_length(files_referenced, 1), 0) BETWEEN 1 AND 5) AS plans_with_1_to_5_files,
-  count(*) FILTER (WHERE coalesce(array_length(files_referenced, 1), 0) > 5) AS plans_with_more_than_5_files
+  count(*) FILTER (WHERE coalesce(jsonb_array_length(files_referenced), 0) = 0) AS plans_with_zero_files,
+  count(*) FILTER (WHERE coalesce(jsonb_array_length(files_referenced), 0) BETWEEN 1 AND 5) AS plans_with_1_to_5_files,
+  count(*) FILTER (WHERE coalesce(jsonb_array_length(files_referenced), 0) > 5) AS plans_with_more_than_5_files
 FROM dev_autopilot_plan_versions;
 
 \echo ''
@@ -22,7 +22,7 @@ WITH latest AS (
 )
 SELECT
   count(*) AS total_findings_with_plans,
-  count(*) FILTER (WHERE coalesce(array_length(files_referenced, 1), 0) = 0) AS findings_whose_latest_plan_has_zero_files,
+  count(*) FILTER (WHERE coalesce(jsonb_array_length(files_referenced), 0) = 0) AS findings_whose_latest_plan_has_zero_files,
   count(*) FILTER (WHERE plan_markdown IS NULL OR plan_markdown = '') AS findings_whose_plan_markdown_is_empty
 FROM latest;
 
@@ -43,7 +43,7 @@ FROM autopilot_recommendations r
 JOIN latest l ON l.finding_id = r.id
 WHERE r.source_type = 'dev_autopilot'
   AND r.status = 'new'
-  AND coalesce(array_length(l.files_referenced, 1), 0) = 0
+  AND coalesce(jsonb_array_length(l.files_referenced), 0) = 0
 ORDER BY r.impact_score DESC NULLS LAST, l.plan_created DESC
 LIMIT 10;
 
@@ -64,6 +64,6 @@ FROM autopilot_recommendations r
 JOIN latest l ON l.finding_id = r.id
 WHERE r.source_type = 'dev_autopilot'
   AND r.status = 'new'
-  AND coalesce(array_length(l.files_referenced, 1), 0) = 0
+  AND coalesce(jsonb_array_length(l.files_referenced), 0) = 0
 ORDER BY r.impact_score DESC NULLS LAST
 LIMIT 2;

--- a/supabase/ops/snooze_broken_plan_findings.sql
+++ b/supabase/ops/snooze_broken_plan_findings.sql
@@ -1,0 +1,40 @@
+-- Snooze the 8 status='new' findings whose latest plan has zero
+-- files_referenced AND no spec_proposed_files. Without snoozing, every
+-- autoApproveTick wastes a slot approving these only for
+-- runExecutionSession to fail at "plan has no files_referenced".
+--
+-- Snooze for 30 days — long enough to deprioritise without erasing.
+-- Operator can manually unsnooze after the planner audit lands.
+--
+-- Idempotent: re-running just bumps snoozed_until.
+
+\set ON_ERROR_STOP on
+
+WITH targets AS (
+  SELECT DISTINCT ON (l.finding_id) l.finding_id
+  FROM dev_autopilot_plan_versions l
+  JOIN autopilot_recommendations r ON r.id = l.finding_id
+  WHERE r.source_type = 'dev_autopilot'
+    AND r.status = 'new'
+    AND coalesce(jsonb_array_length(l.files_referenced), 0) = 0
+    AND (
+      r.spec_snapshot->'proposed_files' IS NULL
+      OR jsonb_array_length(r.spec_snapshot->'proposed_files') = 0
+    )
+  ORDER BY l.finding_id, l.version DESC
+)
+UPDATE autopilot_recommendations r
+SET status = 'snoozed',
+    snoozed_until = (now() + interval '30 days')::timestamptz,
+    updated_at = now()
+FROM targets
+WHERE r.id = targets.finding_id
+  AND r.status = 'new';
+
+\echo ''
+\echo '=== Findings just snoozed ==='
+SELECT id, status, snoozed_until, left(title, 80) AS title
+FROM autopilot_recommendations
+WHERE source_type = 'dev_autopilot'
+  AND status = 'snoozed'
+  AND snoozed_until > now() + interval '29 days';


### PR DESCRIPTION
## Why
Two surgical fixes addressing the underlying causes of the 2026-05-07 PR flood (530 stranded duplicates in 4 days). PRs #1957 and #1970 fixed the symptom (refuse to open duplicate PRs); this PR fixes the cause.

## Change 1 — Bridge DRY_RUN default 'true' → 'false'
services/gateway/src/services/dev-autopilot-bridge.ts:39

The bridge defaulted to dry-run while the executor defaulted to live. Failed PRs got logged `reverted via #closed-dry-run` but were never actually closed on GitHub. spawnChildExecution then opened a fresh PR for the same finding, and autoApproveTick re-picked the still-status='new' finding indefinitely.

Aligning to 'false' lets the bridge actually close the PR before spawning the self-heal child. DEV_AUTOPILOT_DRY_RUN=true remains available as opt-in for tests/dev.

## Change 2 — Reconciler PR-closed-unmerged → status='auto_archived'
services/gateway/src/services/dev-autopilot-execute.ts ~line 1880

When the reconciler observes a stranded execution's PR has been closed without merge, it now marks the execution `auto_archived` instead of `failed`. The PR-flood guards treat (completed, self_healed, auto_archived) as 'PR was handled' — so auto_archived correctly unblocks the finding for future attempts.

Also removes the bridgeFailure() spawn here: spawning a self-heal child on a closed-PR signal would burn an LLM call to re-fix a change the operator/CI just rejected. autoApproveTick picks the finding up on its next sweep, bounded by the per-finding retry cap.

Adds 'dev_autopilot.execution.auto_archived' to CicdEventType.

## Tests
All 12 PR-flood guard tests pass. npm run build clean.

## End-state defense layers
1. synthesis fingerprint dedup
2. autoApproveTick status + stranded-PR guard (#1957)
3. runExecutionSession stranded-PR guard (#1970)
4. **bridge actually closes failed PRs (this PR)**
5. **reconciler auto-archives orphan closed-unmerged PRs (this PR)**

🤖 Generated with [Claude Code](https://claude.com/claude-code)