### PR TITLE
DEV-AUTOPILOT: Add security regression test for MCP SDK ReDoS vulnerability

### DIFF
--- a/services/gateway/test/mcp-cve-regression.test.ts
+++ b/services/gateway/test/mcp-cve-regression.test.ts
@@ -1,0 +1,44 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('Security Regression Guardrails', () => {
+  it('enforces @modelcontextprotocol/sdk version >= 1.25.2 to prevent ReDoS vulnerability', () => {
+    const packageJsonPath = path.join(__dirname, '../package.json');
+    
+    if (!fs.existsSync(packageJsonPath)) {
+      throw new Error(`package.json not found at expected path: ${packageJsonPath}`);
+    }
+
+    const packageJsonContent = fs.readFileSync(packageJsonPath, 'utf-8');
+    const packageJson = JSON.parse(packageJsonContent);
+
+    const dependencies = packageJson.dependencies || {};
+    const mcpVersion = dependencies['@modelcontextprotocol/sdk'];
+    
+    expect(mcpVersion).toBeDefined();
+    
+    // Strip leading non-digit characters (e.g., ^, ~, or >=) and extract semver digits
+    const cleanVersionMatch = mcpVersion.match(/\d+\.\d+\.\d+/);
+    if (!cleanVersionMatch) {
+      throw new Error(`Failed to parse semantic version string for @modelcontextprotocol/sdk: ${mcpVersion}`);
+    }
+    
+    const [majorStr, minorStr, patchStr] = cleanVersionMatch[0].split('.');
+    const major = parseInt(majorStr, 10);
+    const minor = parseInt(minorStr, 10);
+    const patch = parseInt(patchStr, 10);
+
+    // Assert major >= 1
+    expect(major).toBeGreaterThanOrEqual(1);
+
+    // Assert if major === 1, then minor >= 25
+    if (major === 1) {
+      expect(minor).toBeGreaterThanOrEqual(25);
+      
+      // Assert if major === 1 && minor === 25, then patch >= 2
+      if (minor === 25) {
+        expect(patch).toBeGreaterThanOrEqual(2);
+      }
+    }
+  });
+});


### PR DESCRIPTION
**Context**
The `@modelcontextprotocol/sdk` package previously used (`^0.5.0`) contains a known Regular Expression Denial of Service (ReDoS) vulnerability. To mitigate this, security scanning requires bumping the dependency to `>= 1.25.2`.

**Changes**
* Added a new unit test `mcp-cve-regression.test.ts` to evaluate the gateway's `package.json` at test time.
* The test statically parses `package.json` and asserts that the specified `@modelcontextprotocol/sdk` version is structurally `>= 1.25.2`.

**⚠️ DEVELOPER ACTION REQUIRED ⚠️**
The Dev Autopilot is strictly prevented from directly mutating `package.json` and lockfiles. To pass the CI check introduced by this PR, you must manually complete the following steps:
1. Open `services/gateway/package.json` and change the `"@modelcontextprotocol/sdk"` dependency version to `"^1.25.2"`.
2. Run `npm install` inside the `services/gateway/` directory to update `package-lock.json`.
3. Fix any local TypeScript errors introduced by the major version jump of the SDK (run `npm run typecheck` to verify).
4. Commit the `package.json`, `package-lock.json`, and any type fixes to this branch.