### PR TITLE
DEV-AUTOPILOT: Add security regression test for MCP SDK ReDoS CVE

### DIFF
--- a/services/gateway/test/mcp-cve-regression.test.ts
+++ b/services/gateway/test/mcp-cve-regression.test.ts
@@ -1,0 +1,44 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('MCP SDK CVE Regression Test', () => {
+  it('should enforce @modelcontextprotocol/sdk version >= 1.25.2 to prevent ReDoS vulnerability', () => {
+    const packageJsonPath = path.resolve(__dirname, '../package.json');
+    
+    // Read and parse package.json
+    expect(fs.existsSync(packageJsonPath)).toBe(true);
+    const packageJsonContent = fs.readFileSync(packageJsonPath, 'utf8');
+    const packageJson = JSON.parse(packageJsonContent);
+
+    // Ensure the dependency exists
+    const versionString = packageJson.dependencies?.['@modelcontextprotocol/sdk'];
+    expect(versionString).toBeDefined();
+
+    // Strip leading non-digit characters (e.g., ^, ~, >=)
+    const cleanVersion = versionString.replace(/^[^\d]+/, '');
+    
+    // Split the version by . into major, minor, and patch numbers
+    const [majorStr, minorStr, patchStr] = cleanVersion.split('.');
+    const major = parseInt(majorStr, 10);
+    const minor = parseInt(minorStr, 10);
+    const patch = parseInt(patchStr, 10);
+
+    // Validate parsing
+    expect(Number.isNaN(major)).toBe(false);
+    expect(Number.isNaN(minor)).toBe(false);
+    expect(Number.isNaN(patch)).toBe(false);
+
+    // Assert major >= 1
+    expect(major).toBeGreaterThanOrEqual(1);
+    
+    // Assert if major === 1, then minor >= 25
+    if (major === 1) {
+      expect(minor).toBeGreaterThanOrEqual(25);
+      
+      // Assert if major === 1 && minor === 25, then patch >= 2
+      if (minor === 25) {
+        expect(patch).toBeGreaterThanOrEqual(2);
+      }
+    }
+  });
+});


### PR DESCRIPTION
This PR adds a security regression test to prevent the reintroduction of a known Regular Expression Denial of Service (ReDoS) vulnerability in the `@modelcontextprotocol/sdk` package. The vulnerability is present in versions prior to `1.25.2`.

**Plan Summary**:
- Implements `services/gateway/test/mcp-cve-regression.test.ts` to parse the `services/gateway/package.json` file.
- Asserts that the `@modelcontextprotocol/sdk` version in the `dependencies` block strictly evaluates to `>= 1.25.2`.

### ⚠️ IMPORTANT: Developer Action Required
The Autopilot is restricted from modifying `package.json` directly. To pass the newly added test and successfully merge this branch, you must manually perform the following steps:
1. Open `services/gateway/package.json` and change the `"@modelcontextprotocol/sdk"` dependency to `"^1.25.2"`.
2. Run `npm install` within `services/gateway` to update `package-lock.json` and resolve the CVE.
3. Review `npm run typecheck` to catch any breaking types from the `0.5.x` -> `1.25.x` jump.