### PR TITLE
fix(ci): unit workflow uses pnpm/action-setup so the gate actually passes

### DIFF
--- a/.github/workflows/UNIT.yml
+++ b/.github/workflows/UNIT.yml
@@ -5,10 +5,17 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+      # The previous step ran `curl get.pnpm.io/install.sh | sh -` which
+      # consistently failed in CI: "The configured global bin directory
+      # /home/runner/.local/share/pnpm is not in PATH" → exit 1. The
+      # failure was unconditional, so this required-status check broke
+      # every PR (autopilot AND human) because branch protection blocks
+      # merges until `unit` is green. The 2026-05-08 audit found 2%
+      # autopilot completion rate driven almost entirely by this gate.
+      # Use the maintained pnpm/action-setup action instead.
+      - uses: pnpm/action-setup@v4
+        with:
+          version: 9
       - run: |
-          # Install pnpm and use it in the same shell
-          curl -fsSL https://get.pnpm.io/install.sh | sh -
-          export PNPM_HOME="/home/runner/.local/share/pnpm"
-          export PATH="$PNPM_HOME:$PATH"
           pnpm --version
           echo "✅ lock-free unit job passes"

--- a/.github/workflows/UNIT.yml
+++ b/.github/workflows/UNIT.yml
@@ -13,9 +13,12 @@ jobs:
       # merges until `unit` is green. The 2026-05-08 audit found 2%
       # autopilot completion rate driven almost entirely by this gate.
       # Use the maintained pnpm/action-setup action instead.
+      # Don't pin a version here — the repo's root package.json already has
+      # `packageManager: "pnpm@9.0.0"`, and the action errors out if both are
+      # set ("Multiple versions of pnpm specified"). Letting the action read
+      # package.json keeps the version aligned with what the rest of the
+      # tooling uses.
       - uses: pnpm/action-setup@v4
-        with:
-          version: 9
       - run: |
           pnpm --version
           echo "✅ lock-free unit job passes"


### PR DESCRIPTION
## Why
The `unit` workflow has been failing on **every** PR — autopilot and human — because the curl-based pnpm installer fails with:
```
ERROR  The configured global bin directory "/home/runner/.local/share/pnpm" is not in PATH
```
…and exits 1. Branch protection requires `unit` green, so every PR was blocked from merging.

## Impact
Audit of `dev_autopilot_executions` over last 14 days:
- 1,225 total executions
- 25 reached `status='completed'` → **~2% merge rate**
- Dominant `ci_failed` reason: `branch-protection blocked`
- The protection that blocks them: this `unit` job

The autopilot has been opening reasonable PRs that simply cannot merge.

## Fix
Replace the curl bootstrap with `pnpm/action-setup@v4`. Same surface (pnpm + a passing echo); the action handles PATH/bin correctly.

## Verification
This PR's own `unit` check — if green, the fix is verified end-to-end on real CI infrastructure.

🤖 Generated with [Claude Code](https://claude.com/claude-code)