### PR TITLE
DEV-AUTOPILOT: Add regression test for MCP SDK ReDoS CVE

### DIFF
--- a/services/gateway/test/mcp-cve-regression.test.ts
+++ b/services/gateway/test/mcp-cve-regression.test.ts
@@ -1,0 +1,42 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('MCP SDK CVE Regression', () => {
+  it('should use @modelcontextprotocol/sdk version >= 1.25.2 to prevent ReDoS', () => {
+    // Resolve the path to services/gateway/package.json relative to this test directory
+    const packageJsonPath = path.join(__dirname, '../package.json');
+    
+    expect(fs.existsSync(packageJsonPath)).toBe(true);
+
+    const packageJsonContent = fs.readFileSync(packageJsonPath, 'utf-8');
+    const packageJson = JSON.parse(packageJsonContent);
+
+    const dependencies = packageJson.dependencies || {};
+    const mcpVersionString = dependencies['@modelcontextprotocol/sdk'];
+
+    // Ensure the dependency exists
+    expect(mcpVersionString).toBeDefined();
+    expect(typeof mcpVersionString).toBe('string');
+
+    // Strip non-digit characters (e.g., ^, ~, >=) and split into major, minor, patch
+    const versionMatch = mcpVersionString.match(/(\d+)\.(\d+)\.(\d+)/);
+    expect(versionMatch).not.toBeNull();
+
+    const major = parseInt(versionMatch![1], 10);
+    const minor = parseInt(versionMatch![2], 10);
+    const patch = parseInt(versionMatch![3], 10);
+
+    // Assert major >= 1
+    expect(major).toBeGreaterThanOrEqual(1);
+
+    // Assert if major === 1, then minor >= 25
+    if (major === 1) {
+      expect(minor).toBeGreaterThanOrEqual(25);
+
+      // Assert if major === 1 && minor === 25, then patch >= 2
+      if (minor === 25) {
+        expect(patch).toBeGreaterThanOrEqual(2);
+      }
+    }
+  });
+});


### PR DESCRIPTION
This PR introduces a security regression test to protect the gateway against a known Regular Expression Denial of Service (ReDoS) vulnerability present in older versions (`< 1.25.2`) of the `@modelcontextprotocol/sdk` package. 

To comply with executor scope restrictions, this PR **only** implements the CI guard rail. It will fail locally and in CI until the developer manually bumps the dependency.

### Developer Tasks Needed Before Merging:
1. Open `services/gateway/package.json`.
2. Update the `@modelcontextprotocol/sdk` dependency from `"^0.5.0"` (or similar) to `"^1.25.2"`.
3. Run `npm install` in `services/gateway` to update `package-lock.json`.
4. Run `npm test` locally to verify the new test (`mcp-cve-regression.test.ts`) passes.
5. Run `npm run typecheck` to detect and fix any TypeScript compilation errors introduced by the jump from `0.5.x` to `1.25.x`.