### PR TITLE
DEV-AUTOPILOT: Add ReDoS regression test for @modelcontextprotocol/sdk

### DIFF
--- a/services/gateway/test/mcp-cve-regression.test.ts
+++ b/services/gateway/test/mcp-cve-regression.test.ts
@@ -1,0 +1,37 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('Security Regression: @modelcontextprotocol/sdk ReDoS', () => {
+  it('enforces @modelcontextprotocol/sdk is at least v1.25.2', () => {
+    const packageJsonPath = path.resolve(__dirname, '../package.json');
+    const packageJsonContent = fs.readFileSync(packageJsonPath, 'utf-8');
+    const packageJson = JSON.parse(packageJsonContent);
+
+    const mcpVersion = packageJson.dependencies?.['@modelcontextprotocol/sdk'];
+    
+    // Ensure the dependency exists
+    expect(mcpVersion).toBeDefined();
+
+    // Strip leading non-digit characters (e.g., ^, ~, or >=)
+    const cleanVersion = mcpVersion.replace(/^[^0-9]+/, '');
+    
+    // Split the version by . into major, minor, and patch numbers
+    const [majorStr, minorStr, patchStr] = cleanVersion.split('.');
+    const major = parseInt(majorStr, 10);
+    const minor = parseInt(minorStr, 10);
+    const patch = parseInt(patchStr, 10);
+
+    // Assert major >= 1
+    expect(major).toBeGreaterThanOrEqual(1);
+
+    // Assert if major === 1, then minor >= 25
+    if (major === 1) {
+      expect(minor).toBeGreaterThanOrEqual(25);
+      
+      // Assert if major === 1 && minor === 25, then patch >= 2
+      if (minor === 25) {
+        expect(patch).toBeGreaterThanOrEqual(2);
+      }
+    }
+  });
+});


### PR DESCRIPTION
This PR introduces a security regression test to ensure that the gateway's `@modelcontextprotocol/sdk` dependency is structurally locked to `>= 1.25.2`. The `^0.5.0` series has a known Regular Expression Denial of Service (ReDoS) vulnerability.

**Developer Action Required:**
The autopilot executor cannot securely modify `package.json` or update package lockfiles directly. To successfully pass this CI guardrail:
1. Manually bump `"@modelcontextprotocol/sdk": "^0.5.0"` to `"^1.25.2"` in `services/gateway/package.json`.
2. Run `npm install` in `services/gateway` to update `package-lock.json`.
3. Fix any breaking TypeScript changes locally and verify with `npm run typecheck` or `npm test`.

Files added:
- `services/gateway/test/mcp-cve-regression.test.ts`