### PR TITLE
DEV-AUTOPILOT: Add regression test for MCP SDK ReDoS vulnerability

### DIFF
--- a/services/gateway/test/mcp-cve-regression.test.ts
+++ b/services/gateway/test/mcp-cve-regression.test.ts
@@ -1,0 +1,40 @@
+import * as fs from 'fs';
+import * as path from 'path';
+
+describe('MCP CVE Regression Test', () => {
+  it('should verify @modelcontextprotocol/sdk is >= 1.25.2 to mitigate ReDoS', () => {
+    const packageJsonPath = path.resolve(__dirname, '../package.json');
+    const packageData = fs.readFileSync(packageJsonPath, 'utf8');
+    const pkg = JSON.parse(packageData);
+
+    const versionString = pkg.dependencies && pkg.dependencies['@modelcontextprotocol/sdk'];
+    
+    // Ensure the dependency exists
+    expect(versionString).toBeDefined();
+
+    // Strip leading non-digit characters (e.g., ^, ~, or >=)
+    const cleanVersion = versionString.replace(/^[^0-9]+/, '');
+    
+    // Split the version by . into major, minor, and patch numbers
+    const parts = cleanVersion.split('.');
+    const major = parseInt(parts[0], 10);
+    const minor = parseInt(parts[1], 10);
+    const patch = parseInt(parts[2], 10);
+
+    expect(Number.isNaN(major)).toBe(false);
+    expect(Number.isNaN(minor)).toBe(false);
+
+    // Assert major >= 1
+    expect(major).toBeGreaterThanOrEqual(1);
+
+    // Assert if major === 1, then minor >= 25
+    if (major === 1) {
+      expect(minor).toBeGreaterThanOrEqual(25);
+
+      // Assert if major === 1 && minor === 25, then patch >= 2
+      if (minor === 25) {
+        expect(patch).toBeGreaterThanOrEqual(2);
+      }
+    }
+  });
+});


### PR DESCRIPTION
This PR adds a security regression test to ensure that the `@modelcontextprotocol/sdk` package version in `services/gateway/package.json` is securely versioned to `>= 1.25.2`. This guardrail mitigates a known Regular Expression Denial of Service (ReDoS) vulnerability present in older versions.

**Important Developer Instructions:**
- The automated executor is restricted from modifying dependency manifests directly.
- You MUST manually open `services/gateway/package.json` and update the `"@modelcontextprotocol/sdk"` dependency from `"^0.5.0"` to `"^1.25.2"`.
- Run `npm install` within the `services/gateway` directory to update the `package-lock.json`.
- The new regression test (`npm test`) will fail until this package bump is completed. 
- You should also verify and resolve any structural TypeScript/API changes resulting from the major version jump by running `npm run typecheck`.

**Files touched:**
- Created `services/gateway/test/mcp-cve-regression.test.ts`