### PR TITLE
DEV-AUTOPILOT: Add regression test for @modelcontextprotocol/sdk ReDoS CVE

### DIFF
--- a/services/gateway/test/mcp-cve-regression.test.ts
+++ b/services/gateway/test/mcp-cve-regression.test.ts
@@ -1,0 +1,48 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('MCP SDK ReDoS CVE Regression', () => {
+  it('should enforce @modelcontextprotocol/sdk version >= 1.25.2 in package.json', () => {
+    // Resolve path to package.json (testing both ../ and ../../ to accommodate ts-jest vs compiled test execution)
+    let packageJsonPath = path.resolve(__dirname, '../package.json');
+    if (!fs.existsSync(packageJsonPath)) {
+      packageJsonPath = path.resolve(__dirname, '../../package.json');
+    }
+
+    expect(fs.existsSync(packageJsonPath)).toBe(true);
+
+    const packageJsonContent = fs.readFileSync(packageJsonPath, 'utf8');
+    const packageJson = JSON.parse(packageJsonContent);
+
+    const mcpVersion = packageJson.dependencies?.['@modelcontextprotocol/sdk'];
+    
+    // Ensure the dependency exists
+    expect(mcpVersion).toBeDefined();
+
+    // Strip leading non-digit characters (e.g., ^, ~, >=)
+    const cleanVersion = mcpVersion.replace(/^[^0-9]+/, '');
+    
+    // Split by .
+    const [majorStr, minorStr, patchStr] = cleanVersion.split('.');
+    const major = parseInt(majorStr, 10);
+    const minor = parseInt(minorStr, 10) || 0;
+    const patch = parseInt(patchStr, 10) || 0;
+
+    expect(Number.isNaN(major)).toBe(false);
+    expect(Number.isNaN(minor)).toBe(false);
+    expect(Number.isNaN(patch)).toBe(false);
+
+    // Assert major >= 1
+    expect(major).toBeGreaterThanOrEqual(1);
+
+    // Assert if major === 1, then minor >= 25
+    if (major === 1) {
+      expect(minor).toBeGreaterThanOrEqual(25);
+      
+      // Assert if major === 1 && minor === 25, then patch >= 2
+      if (minor === 25) {
+        expect(patch).toBeGreaterThanOrEqual(2);
+      }
+    }
+  });
+});


### PR DESCRIPTION
This PR introduces a security regression test to enforce the mitigation of a known Regular Expression Denial of Service (ReDoS) vulnerability in the `@modelcontextprotocol/sdk` package.

The newly added test parses the `services/gateway/package.json` file to ensure that the configured version of `@modelcontextprotocol/sdk` is `>= 1.25.2`. This ensures the vulnerability is patched and cannot be reintroduced in the future. CI will fail until the version is updated to meet this baseline.

**Developer Action Required:**
The automated executor is strictly scoped to not modify dependency manifests. To resolve this and pass the new test, please perform the following locally:
1. Open `services/gateway/package.json` and manually update the `"@modelcontextprotocol/sdk"` dependency to `"^1.25.2"`.
2. Run `npm install` within `services/gateway` to generate the updated `package-lock.json`.
3. Verify type compatibility by running `npm run typecheck`. The major version jump (`0.5.x` -> `1.25.x`) may introduce structural TypeScript changes that need manual resolution.
4. Validate the guard rail by confirming `npm test` successfully executes the `mcp-cve-regression.test.ts` test.

Files touched:
- `services/gateway/test/mcp-cve-regression.test.ts` (New)