### PR TITLE
fix(VTID-02849): German session silent — bootstrap built en prompt + STT row-locked to en-US

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/bootstrap.py
+++ b/services/agents/orb-agent/src/orb_agent/bootstrap.py
@@ -60,6 +60,7 @@ class ContextBootstrap:
         agent_id: str = "vitana",
         is_reconnect: bool = False,
         last_n_turns: int = 0,
+        lang: str | None = None,
     ) -> BootstrapResult:
         params: dict[str, str | int | bool] = {
             "agent_id": agent_id,
@@ -73,6 +74,12 @@ class ContextBootstrap:
         request_headers: dict[str, str] = dict(self._headers)
         if user_jwt:
             request_headers["Authorization"] = f"Bearer {user_jwt}"
+        # PR 1.B-Lang-4: pass the user's language via Accept-Language so the
+        # gateway's /orb/context-bootstrap builds the system prompt in the
+        # right language. Without this the gateway defaults to 'en' and the
+        # LLM keeps responding in English even when the user speaks German.
+        if lang:
+            request_headers["Accept-Language"] = lang
         try:
             r = await self._client.get(
                 self._endpoint,

--- a/services/agents/orb-agent/src/orb_agent/providers.py
+++ b/services/agents/orb-agent/src/orb_agent/providers.py
@@ -108,15 +108,22 @@ def _resolve_bcp47(lang: str | None) -> str:
 
 LANG_DEFAULTS: dict[str, dict[str, str]] = {
     "google_tts": {
+        # English Chirp3-HD is GA on Cloud TTS REST and works empirically
+        # (user confirmed). Other languages: prefer Neural2 / Wavenet which
+        # the Vertex pipeline already ships against (NEURAL2_TTS_VOICES in
+        # orb-live.ts) — verified-working voices. Chirp3-HD outside en-US
+        # is partially rolled out and silently fails for some locales when
+        # called via the Cloud TTS REST endpoint (gives a working
+        # construction but no audio at synth time).
         "en": "en-US-Chirp3-HD-Aoede",
-        "de": "de-DE-Chirp3-HD-Aoede",
-        "es": "es-ES-Chirp3-HD-Aoede",
-        "fr": "fr-FR-Chirp3-HD-Aoede",
-        "it": "it-IT-Chirp3-HD-Aoede",
-        "pt": "pt-BR-Chirp3-HD-Aoede",
-        "nl": "nl-NL-Chirp3-HD-Aoede",
-        "sv": "sv-SE-Chirp3-HD-Aoede",
-        "pl": "pl-PL-Chirp3-HD-Aoede",
+        "de": "de-DE-Neural2-G",
+        "es": "es-ES-Neural2-A",
+        "fr": "fr-FR-Neural2-A",
+        "it": "it-IT-Neural2-A",
+        "pt": "pt-BR-Neural2-A",
+        "nl": "nl-NL-Wavenet-A",  # Neural2 not GA for nl-NL
+        "sv": "sv-SE-Wavenet-A",  # Neural2 not GA for sv-SE
+        "pl": "pl-PL-Wavenet-A",  # Neural2 not GA for pl-PL
     },
     # Cartesia Sonic-3 is multilingual — same voice handle works across
     # languages, the model auto-detects from the input text. Documented at
@@ -135,15 +142,23 @@ def _resolve_tts_voice(
     fallback_model: str | None,
     options: dict[str, Any],
     lang: str,
-) -> str | None:
+) -> tuple[str | None, bool]:
     """Pick the TTS voice for this language.
 
+    Returns ``(voice_id, language_locked)``. ``language_locked=True`` means
+    we picked a per-language voice (from voices_per_lang or LANG_DEFAULTS),
+    so the caller must force the TTS language kwarg to bcp47 — otherwise
+    a row-seeded `tts_options.language_code: 'en-US'` would mismatch the
+    German voice and Cloud TTS rejects the synth (silent failure was the
+    bug in the first German session: voice_name='de-DE-Neural2-G' +
+    language_code='en-US' → 400 → no audio).
+
     Resolution order:
-      1. tts_options.voices_per_lang[lang]   (operator override per agent)
-      2. tts_options.voices_per_lang[short]  (e.g. 'de' even when full lang is 'de-AT')
-      3. LANG_DEFAULTS[provider][lang]       (hardcoded fallback)
-      4. tts_options.voices_per_lang['en']   (final lang fallback)
-      5. fallback_model                      (the row's static tts_model)
+      1. tts_options.voices_per_lang[lang]   (operator override per agent) — locked
+      2. tts_options.voices_per_lang[short]  (e.g. 'de' even when full lang is 'de-AT') — locked
+      3. LANG_DEFAULTS[provider][lang]       (hardcoded fallback) — locked
+      4. tts_options.voices_per_lang['en']   (final lang fallback) — locked to en
+      5. fallback_model                      (the row's static tts_model) — NOT locked
     """
     voices_per_lang = options.get("voices_per_lang") or {}
     if not isinstance(voices_per_lang, dict):
@@ -154,20 +169,20 @@ def _resolve_tts_voice(
     for key in candidates:
         v = voices_per_lang.get(key)
         if isinstance(v, str) and v:
-            return v
+            return v, True
 
     if provider:
         prov_defaults = LANG_DEFAULTS.get(provider, {}) or {}
         for key in candidates:
             v = prov_defaults.get(key)
             if isinstance(v, str) and v:
-                return v
+                return v, True
 
     en_override = voices_per_lang.get("en")
     if isinstance(en_override, str) and en_override:
-        return en_override
+        return en_override, True
 
-    return fallback_model
+    return fallback_model, False
 
 
 def build_cascade(voice_config: dict[str, Any] | None, lang: str | None = None) -> ResolvedCascade:
@@ -340,13 +355,20 @@ def _build_tts(
     → row's tts_model). For Google TTS the `language` kwarg is also
     resolved from BCP-47 so prosody matches the voice.
     """
-    voice = _resolve_tts_voice(provider, model, options or {}, lang)
+    voice, language_locked = _resolve_tts_voice(provider, model, options or {}, lang)
     if voice and model and voice != model:
         notes.append(f"tts: resolved voice {voice} for lang={lang} (row model={model})")
 
     # Strip voices_per_lang from options since plugins won't accept it.
     opts_base = dict(options or {})
     opts_base.pop("voices_per_lang", None)
+    if language_locked:
+        # The voice we picked is bound to a specific language. Drop any
+        # row-seeded language/language_code so they can't mismatch the
+        # voice (e.g. en-US language_code + de-DE-Neural2-G voice → silent
+        # 400 from Cloud TTS — that was the German bug).
+        opts_base.pop("language", None)
+        opts_base.pop("language_code", None)
 
     if provider == "cartesia":
         try:
@@ -382,8 +404,15 @@ def _build_tts(
             # accepts `language=`, so an un-renamed `language_code` would
             # surface as an unexpected-kwarg TypeError → caught silently
             # below → cascade.tts=None → AgentSession runs but produces
-            # silent audio. Normalise here. PR 1.B-Lang: when the row
-            # doesn't pin a language, resolve from identity.lang via BCP-47.
+            # silent audio. Normalise here.
+            #
+            # PR 1.B-Lang-3: when the voice was resolved via per-language
+            # lookup (language_locked=True), opts_base no longer carries
+            # any language/language_code (we stripped them above). Force
+            # bcp47 so voice_name and language match. When the voice is
+            # the row's static fallback (language_locked=False), respect
+            # any pre-seeded language_code so operators can still pin a
+            # specific locale per agent.
             opts = dict(opts_base)
             language = opts.pop("language", None) or opts.pop("language_code", None) or bcp47
             # Drop any other keys the Google plugin doesn't accept rather

--- a/services/agents/orb-agent/src/orb_agent/providers.py
+++ b/services/agents/orb-agent/src/orb_agent/providers.py
@@ -258,20 +258,26 @@ def _build_stt(
     # Strip the multilingual-routing carrier so it doesn't leak into the
     # plugin kwargs (it's a TTS-only convention but we drop it defensively).
     opts.pop("voices_per_lang", None)
+    # PR 1.B-Lang-4: ALWAYS override row-seeded language(s). The agent_voice_configs
+    # row often carries hardcoded English (`languages: ['en-US']` for google_stt,
+    # `language: 'en-US'` for deepgram/assemblyai) from the original Vertex-era
+    # seed. STT language MUST match the user's actual speech, not a per-agent
+    # config — there is no operator override that makes sense here. Drop the row
+    # values; the bcp47 resolved from identity.lang is always correct.
+    opts.pop("language", None)
+    opts.pop("languages", None)
 
     if provider == "deepgram":
         try:
             from livekit.plugins import deepgram  # type: ignore[import-not-found]
-            opts.setdefault("language", bcp47)
-            return deepgram.STT(model=model or "nova-3", **opts)
+            return deepgram.STT(model=model or "nova-3", language=bcp47, **opts)
         except ImportError:
             notes.append("STT provider 'deepgram' requested but livekit-plugins-deepgram not installed")
             return None
     if provider == "assemblyai":
         try:
             from livekit.plugins import assemblyai  # type: ignore[import-not-found]
-            opts.setdefault("language", bcp47)
-            return assemblyai.STT(**opts)
+            return assemblyai.STT(language=bcp47, **opts)
         except ImportError:
             notes.append("STT provider 'assemblyai' requested but livekit-plugins-assemblyai not installed")
             return None
@@ -280,12 +286,11 @@ def _build_stt(
             from livekit.plugins import google  # type: ignore[import-not-found]
             # Google Cloud Speech-to-Text via ADC. Passing project explicitly
             # so the plugin doesn't fall back to the consumer Speech endpoint
-            # that requires GOOGLE_API_KEY. The plugin takes a `languages`
-            # list — we send the resolved BCP-47 every session.
-            languages = opts.pop("languages", None) or [bcp47]
+            # that requires GOOGLE_API_KEY. Always send identity.lang's BCP-47
+            # — see comment above on why we ignore the row's `languages` field.
             return google.STT(
                 model=model or "latest_long",
-                languages=languages,
+                languages=[bcp47],
                 **opts,
             )
         except ImportError:

--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -198,11 +198,15 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     )
 
     # Fetch the merged context (memory + role + agent voice config).
+    # PR 1.B-Lang-4: pass identity.lang so the system prompt is built in
+    # the user's language. Without this the gateway falls back to 'en'
+    # and the LLM keeps responding in English even for German users.
     bootstrap = await ctx_fetcher.fetch(
         user_jwt=user_jwt or "",
         agent_id=agent_id,
         is_reconnect=False,
         last_n_turns=0,
+        lang=identity.lang,
     )
 
     # System instruction.
@@ -584,7 +588,7 @@ async def perform_handoff(
 
     # Fetch new agent's context + voice config.
     new_bootstrap = await ctx_fetcher.fetch(
-        user_jwt=user_jwt, agent_id=to_agent_id, is_reconnect=True, last_n_turns=10
+        user_jwt=user_jwt, agent_id=to_agent_id, is_reconnect=True, last_n_turns=10, lang=lang,
     )
     new_cascade = build_cascade(new_bootstrap.voice_config, lang=lang)
 


### PR DESCRIPTION
## Real root cause (found via agent traces, not guessing)

`/api/v1/orb/agent-trace/recent` from the user's failed German session shows:

```
cascade_summary.notes:
  "language: identity.lang=de → bcp47=de-DE"     ← correct
  "tts: resolved voice de-DE-Neural2-G for lang=de"  ← correct

bootstrap_first_1500_chars:
  "...Language: en. ..."                          ← WRONG — prompt built for English

bootstrap_voice_config_stt: "latest_long"
  with row stt_options: {"languages": ["en-US"]}  ← WRONG — STT listening for English
```

So the agent received `lang=de` correctly, but:
1. **Bootstrap fetch didn't pass `lang`** to the gateway → gateway's `/orb/context-bootstrap` defaulted to en (Accept-Language fallback) → system prompt told the LLM to speak English
2. **STT used the row's pre-seeded `languages: ['en-US']`** from the Vertex-era seed migration → German speech wasn't transcribed → LLM never received the user's input

Result: 11 `speech_created` events (the LLM kept generating English-prompted greetings), zero recognition of German speech, user heard nothing intelligible.

## Fixes

**`bootstrap.py` + `session.py`**: pass `lang=identity.lang` into the bootstrap fetch as `Accept-Language` header. The gateway already reads this header to build the prompt's `Language:` block.

**`providers.py`**: STT language is **never** an operator-configurable per-agent setting. The user speaks the language they speak, period. Strip `language` + `languages` from row options before plugin construction; force `bcp47` from `identity.lang` on every STT plugin (deepgram, assemblyai, google_stt).

## Verification

- `python3 -m py_compile` — clean.
- The agent-trace dump that exposed both bugs is reproducible: `curl /api/v1/orb/agent-trace/recent` after the user's German session.
- VTID: VTID-02849.

## Test plan

- [ ] LiveKit test page → pick **Deutsch (de)** → Connect → speak German.
- [ ] Agent transcribes German speech (visible in transcript).
- [ ] LLM replies in German (system prompt now says `Language: de`).
- [ ] TTS speaks the German reply in `de-DE-Neural2-G`.
- [ ] No regression on English session.

🤖 Generated with [Claude Code](https://claude.com/claude-code)