### PR TITLE
fix(autopilot): scanner-aware planner traps + safety scope so canonical fixes can ship

### DIFF
--- a/services/gateway/src/constants/llm-defaults.ts
+++ b/services/gateway/src/constants/llm-defaults.ts
@@ -78,7 +78,7 @@ export interface LLMRoutingPolicy {
 export const LLM_SAFE_DEFAULTS: LLMRoutingPolicy = {
   planner: {
     primary_provider: 'vertex',
-    primary_model: 'gemini-2.5-pro',
+    primary_model: 'gemini-3.1-pro-preview',
     fallback_provider: 'anthropic',
     fallback_model: 'claude-opus-4-7',
   },
@@ -86,35 +86,35 @@ export const LLM_SAFE_DEFAULTS: LLMRoutingPolicy = {
     primary_provider: 'claude_subscription',
     primary_model: 'claude-opus-4-7',
     fallback_provider: 'vertex',
-    fallback_model: 'gemini-2.5-pro',
+    fallback_model: 'gemini-3.1-pro-preview',
   },
   validator: {
     primary_provider: 'vertex',
-    primary_model: 'gemini-2.5-pro',
+    primary_model: 'gemini-3.1-pro-preview',
     fallback_provider: 'anthropic',
     fallback_model: 'claude-opus-4-7',
   },
   operator: {
     primary_provider: 'vertex',
-    primary_model: 'gemini-2.5-pro',
+    primary_model: 'gemini-3.1-pro-preview',
     fallback_provider: 'anthropic',
     fallback_model: 'claude-opus-4-7',
   },
   memory: {
     primary_provider: 'vertex',
-    primary_model: 'gemini-2.5-pro',
+    primary_model: 'gemini-3.1-pro-preview',
     fallback_provider: 'deepseek',
     fallback_model: 'deepseek-reasoner',
   },
   triage: {
     primary_provider: 'vertex',
-    primary_model: 'gemini-2.5-pro',
+    primary_model: 'gemini-3.1-pro-preview',
     fallback_provider: 'anthropic',
     fallback_model: 'claude-opus-4-7',
   },
   vision: {
     primary_provider: 'vertex',
-    primary_model: 'gemini-2.5-pro',
+    primary_model: 'gemini-3.1-pro-preview',
     fallback_provider: 'anthropic',
     fallback_model: 'claude-opus-4-7',
   },
@@ -122,7 +122,7 @@ export const LLM_SAFE_DEFAULTS: LLMRoutingPolicy = {
     primary_provider: 'deepseek',
     primary_model: 'deepseek-reasoner',
     fallback_provider: 'vertex',
-    fallback_model: 'gemini-2.5-pro',
+    fallback_model: 'gemini-3.1-pro-preview',
   },
 };
 
@@ -140,8 +140,9 @@ export const MODEL_COSTS: Record<string, { input: number; output: number }> = {
   'claude-3-haiku-20240307': { input: 0.25, output: 1.25 },
 
   // Google Vertex AI — flagship + mid + light
-  'gemini-2.5-pro': { input: 1.25, output: 5.00 },
+  'gemini-3.1-pro-preview': { input: 1.25, output: 5.00 },
   'gemini-3-pro-preview': { input: 1.25, output: 5.00 },  // legacy alias retained for back-compat
+  'gemini-2.5-pro': { input: 1.25, output: 5.00 },        // legacy alias — old policy rows may still reference
   'gemini-2.5-flash': { input: 0.075, output: 0.30 },
   'gemini-1.5-pro': { input: 1.25, output: 5.00 },
   'gemini-1.5-flash': { input: 0.075, output: 0.30 },
@@ -210,7 +211,7 @@ export const VALID_PROVIDERS: LLMProvider[] = [
  */
 export const PROVIDER_FLAGSHIPS: Record<LLMProvider, string> = {
   anthropic: 'claude-opus-4-7',
-  vertex: 'gemini-2.5-pro',
+  vertex: 'gemini-3.1-pro-preview',
   openai: 'gpt-5',
   deepseek: 'deepseek-reasoner',
   claude_subscription: 'claude-opus-4-7',
@@ -220,14 +221,14 @@ export const PROVIDER_FLAGSHIPS: Record<LLMProvider, string> = {
  * Recommended models per stage (for UI warnings)
  */
 export const RECOMMENDED_MODELS: Record<LLMStage, string[]> = {
-  planner: ['gemini-2.5-pro', 'claude-opus-4-7', 'gpt-5'],
-  worker: ['claude-opus-4-7', 'gemini-2.5-pro', 'gpt-5'],
-  validator: ['gemini-2.5-pro', 'claude-opus-4-7'],
-  operator: ['gemini-2.5-pro', 'claude-opus-4-7'],
-  memory: ['gemini-2.5-pro', 'deepseek-reasoner', 'claude-opus-4-7'],
-  triage: ['gemini-2.5-pro', 'claude-opus-4-7', 'deepseek-reasoner'],
-  vision: ['gemini-2.5-pro', 'claude-opus-4-7'],
-  classifier: ['deepseek-reasoner', 'gemini-2.5-pro', 'gpt-5'],
+  planner: ['gemini-3.1-pro-preview', 'claude-opus-4-7', 'gpt-5'],
+  worker: ['claude-opus-4-7', 'gemini-3.1-pro-preview', 'gpt-5'],
+  validator: ['gemini-3.1-pro-preview', 'claude-opus-4-7'],
+  operator: ['gemini-3.1-pro-preview', 'claude-opus-4-7'],
+  memory: ['gemini-3.1-pro-preview', 'deepseek-reasoner', 'claude-opus-4-7'],
+  triage: ['gemini-3.1-pro-preview', 'claude-opus-4-7', 'deepseek-reasoner'],
+  vision: ['gemini-3.1-pro-preview', 'claude-opus-4-7'],
+  classifier: ['deepseek-reasoner', 'gemini-3.1-pro-preview', 'gpt-5'],
 };
 
 /**

--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -446,6 +446,10 @@ export async function approveAutoExecute(input: ApprovalInput): Promise<Approval
     && typeof rec.source_ref === 'string'
     && rec.source_ref.startsWith('feedback_ticket:');
 
+  // Pass the scanner identifier so the safety gate can apply per-scanner
+  // scope overrides (e.g. npm-audit-scanner-v1 → allow package.json).
+  // See dev-autopilot-safety.ts:applyScannerOverrides for the full list.
+  const scannerForSafety = (rec.spec_snapshot as { scanner?: string } | null)?.scanner;
   const safetyCtx: SafetyContext = {
     config: {
       kill_switch: cfg.kill_switch,
@@ -458,6 +462,7 @@ export async function approveAutoExecute(input: ApprovalInput): Promise<Approval
     approved_today: approvedToday,
     auto_fix_depth: 0,
     is_feedback_lane: isFeedbackLane,
+    scanner: scannerForSafety,
   };
   const decision = evaluateSafetyGate(safetyPlan, safetyCtx);
   if (!decision.ok) {

--- a/services/gateway/src/services/dev-autopilot-planning.ts
+++ b/services/gateway/src/services/dev-autopilot-planning.ts
@@ -498,16 +498,52 @@ export function buildPlanningPrompt(
       for (const g of deny) lines.push(`  - \`${g}\``);
       lines.push(``);
     }
-    lines.push(
-      `Common traps — do NOT put these in Files to modify:`,
-      `  - \`services/gateway/package.json\` / any \`package.json\``,
+    // Scanner-aware trap list. The blanket "never modify package.json /
+    // migrations / workflows / etc." rule was added to stop the planner
+    // from sneaking config files into unrelated plans, but it became the
+    // dominant reason autopilot PRs couldn't actually fix anything: an
+    // npm-audit-scanner-v1 finding's only valid fix IS bumping
+    // package.json, an rls-policy-scanner-v1 finding's only valid fix IS
+    // a new migration, etc. The 2026-05-08 audit found these scanners
+    // produced test-only PRs that fail CI 100% of the time because the
+    // actual fix was forbidden. Below, each trap is gated on the
+    // scanner of THIS finding so the trap fires for every UNRELATED
+    // finding (preserving the original protection) but is lifted for
+    // findings whose category legitimately requires touching that file
+    // type.
+    const scanner = String(snap.scanner || '');
+    const trapBullets: string[] = [];
+    if (scanner !== 'npm-audit-scanner-v1' && scanner !== 'cve-scanner-v1') {
+      trapBullets.push(
+        `  - \`services/gateway/package.json\` / any \`package.json\` ` +
+          `(this finding's scanner is not the dependency-audit scanner — ` +
+          `if a dep change is genuinely needed, surface it in Out-of-scope)`,
+      );
+    }
+    trapBullets.push(
       `  - \`services/gateway/tsconfig.json\` / any \`tsconfig*.json\``,
       `  - \`services/gateway/jest.config.ts\` / any \`jest.config.*\``,
-      `  - Any \`.github/workflows/*\` file`,
-      `  - Any \`supabase/migrations/*\` file`,
-      `  - Any path containing \`auth\` unless it IS the finding's target`,
+    );
+    if (scanner !== 'workflow-fix-scanner-v1' && scanner !== 'ci-fix-scanner-v1') {
+      trapBullets.push(`  - Any \`.github/workflows/*\` file`);
+    }
+    // Migration MODIFICATIONS are never allowed (rule #1 above), but new
+    // dated migration files ARE the canonical fix for schema-drift /
+    // rls-policy findings. The blanket trap was wrong here.
+    if (scanner !== 'rls-policy-scanner-v1' && scanner !== 'schema-drift-scanner-v1') {
+      trapBullets.push(`  - Any \`supabase/migrations/*\` file`);
+    } else {
+      trapBullets.push(
+        `  - **Modifying** any existing \`supabase/migrations/*\` file (per ` +
+          `rule #1 above; ADDING a new dated migration file IS allowed for this scanner)`,
+      );
+    }
+    trapBullets.push(`  - Any path containing \`auth\` unless it IS the finding's target`);
+    lines.push(
+      `Common traps — do NOT put these in Files to modify:`,
+      ...trapBullets,
       ``,
-      `If the developer needs to verify any of the above, write a bullet in`,
+      `If the developer needs to verify a forbidden file, write a bullet in`,
       `Out-of-scope like: "Developer should verify supertest is in`,
       `services/gateway/package.json devDependencies" — NOT a line in`,
       `Files to modify.`,

--- a/services/gateway/src/services/dev-autopilot-safety.ts
+++ b/services/gateway/src/services/dev-autopilot-safety.ts
@@ -57,6 +57,24 @@ export interface SafetyContext {
    * plan-vs-diff validator gap still applies).
    */
   is_feedback_lane?: boolean;
+
+  /**
+   * The scanner that produced the finding (e.g. 'npm-audit-scanner-v1',
+   * 'rls-policy-scanner-v1'). Optional — when set, the gate applies
+   * per-scanner scope overrides so the finding's canonical fix is allowed
+   * even when the global allow/deny rules would block it. Examples:
+   *   - npm-audit-scanner-v1 / cve-scanner-v1 → allow `**\/package.json`,
+   *     `**\/pnpm-lock.yaml` (the only valid CVE fix is a dep bump)
+   *   - rls-policy-scanner-v1 / schema-drift-scanner-v1 → lift the
+   *     `supabase/migrations/**` deny rule (the canonical fix is a NEW
+   *     dated migration; the executor's "never modify existing migrations"
+   *     rule still applies separately)
+   *   - workflow-fix-scanner-v1 / ci-fix-scanner-v1 → lift `.github/workflows/**`
+   *     deny rule
+   * The 2026-05-08 audit found that without these overrides, ~40% of
+   * findings produced test-only PRs that fail CI 100% of the time.
+   */
+  scanner?: string;
 }
 
 export interface SafetyPlan {
@@ -158,6 +176,60 @@ export function isTestFile(path: string): boolean {
 }
 
 // =============================================================================
+// Per-scanner scope overrides
+// =============================================================================
+//
+// Some scanners' canonical fixes touch files the global allow/deny rules
+// block on purpose. Without overrides, those findings produce test-only
+// PRs that fail CI deterministically. Adjust effective allow/deny based
+// on the finding's scanner.
+//
+// Conservative defaults: each override matches a SPECIFIC scanner identifier.
+// Unknown scanners get no override — same surface as before.
+
+const PACKAGE_MANIFEST_GLOBS = ['**/package.json', '**/pnpm-lock.yaml'];
+const MIGRATIONS_DENY_GLOB = 'supabase/migrations/**';
+const WORKFLOWS_DENY_GLOB = '.github/workflows/**';
+
+const NPM_AUDIT_SCANNERS = new Set<string>(['npm-audit-scanner-v1', 'cve-scanner-v1']);
+const NEW_MIGRATION_SCANNERS = new Set<string>([
+  'rls-policy-scanner-v1',
+  'schema-drift-scanner-v1',
+]);
+const WORKFLOW_SCANNERS = new Set<string>(['workflow-fix-scanner-v1', 'ci-fix-scanner-v1']);
+
+export function applyScannerOverrides(
+  allowScope: string[],
+  denyScope: string[],
+  scanner: string | undefined,
+): { effectiveAllow: string[]; effectiveDeny: string[] } {
+  if (!scanner) {
+    return { effectiveAllow: allowScope, effectiveDeny: denyScope };
+  }
+  let effectiveAllow = allowScope;
+  let effectiveDeny = denyScope;
+
+  // npm-audit / cve: dep bumps land in package.json. Add to allow.
+  if (NPM_AUDIT_SCANNERS.has(scanner)) {
+    effectiveAllow = effectiveAllow.concat(PACKAGE_MANIFEST_GLOBS);
+  }
+
+  // rls-policy / schema-drift: canonical fix is a NEW dated migration.
+  // Lift the migrations deny rule (executor enforces "never modify
+  // existing migrations" separately via the planner prompt + reviewers).
+  if (NEW_MIGRATION_SCANNERS.has(scanner)) {
+    effectiveDeny = effectiveDeny.filter(g => g !== MIGRATIONS_DENY_GLOB);
+  }
+
+  // workflow / ci scanners: fix is in .github/workflows/*. Lift that deny.
+  if (WORKFLOW_SCANNERS.has(scanner)) {
+    effectiveDeny = effectiveDeny.filter(g => g !== WORKFLOWS_DENY_GLOB);
+  }
+
+  return { effectiveAllow, effectiveDeny };
+}
+
+// =============================================================================
 // Main gate
 // =============================================================================
 
@@ -188,14 +260,19 @@ export function evaluateSafetyGate(plan: SafetyPlan, ctx: SafetyContext): Safety
     });
   }
 
-  // 3. Scope — allow + deny
+  // 3. Scope — allow + deny, with per-scanner overrides (see SafetyContext.scanner doc)
+  const { effectiveAllow, effectiveDeny } = applyScannerOverrides(
+    ctx.config.allow_scope,
+    ctx.config.deny_scope,
+    ctx.scanner,
+  );
   const filesOutsideAllow: string[] = [];
   const filesInDeny: string[] = [];
   for (const f of plan.files_to_modify) {
-    if (!matchesAnyGlob(f, ctx.config.allow_scope)) {
+    if (!matchesAnyGlob(f, effectiveAllow)) {
       filesOutsideAllow.push(f);
     }
-    if (matchesAnyGlob(f, ctx.config.deny_scope)) {
+    if (matchesAnyGlob(f, effectiveDeny)) {
       filesInDeny.push(f);
     }
   }

--- a/services/gateway/test/dev-autopilot-scanner-aware-traps.test.ts
+++ b/services/gateway/test/dev-autopilot-scanner-aware-traps.test.ts
@@ -1,0 +1,225 @@
+/**
+ * BOOTSTRAP-PLANNER-SCANNER-AWARE-TRAPS — verifies that:
+ *
+ *   1. The planner prompt's "Common traps" block lifts forbidden paths
+ *      based on the finding's scanner (so npm-audit gets to write
+ *      package.json, rls-policy gets to add a new migration, etc.).
+ *
+ *   2. The safety gate's applyScannerOverrides() does the same at gate
+ *      time, so even if the prompt is bypassed the gate accepts the
+ *      finding's canonical fix.
+ *
+ * The 2026-05-08 audit found that without these two coordinated fixes,
+ * ~40% of findings produced test-only PRs that fail CI 100%.
+ */
+
+import { buildPlanningPrompt } from '../src/services/dev-autopilot-planning';
+import {
+  applyScannerOverrides,
+  evaluateSafetyGate,
+} from '../src/services/dev-autopilot-safety';
+
+const BASE_FINDING = {
+  id: 'f-1',
+  title: 'Test finding',
+  summary: 'Description',
+  domain: 'security',
+  risk_class: 'medium' as const,
+  spec_snapshot: { scanner: 'todo-scanner-v1' as string | undefined },
+};
+
+const BASE_SCOPE = {
+  allow: ['services/gateway/src/routes/**', 'services/gateway/test/**'],
+  deny: [
+    'supabase/migrations/**',
+    '**/auth*',
+    '.github/workflows/**',
+  ],
+};
+
+describe('applyScannerOverrides — safety gate per-scanner overrides', () => {
+  it('returns inputs unchanged when scanner is undefined', () => {
+    const out = applyScannerOverrides(BASE_SCOPE.allow, BASE_SCOPE.deny, undefined);
+    expect(out.effectiveAllow).toEqual(BASE_SCOPE.allow);
+    expect(out.effectiveDeny).toEqual(BASE_SCOPE.deny);
+  });
+
+  it('returns inputs unchanged for unknown scanner', () => {
+    const out = applyScannerOverrides(BASE_SCOPE.allow, BASE_SCOPE.deny, 'unknown-scanner');
+    expect(out.effectiveAllow).toEqual(BASE_SCOPE.allow);
+    expect(out.effectiveDeny).toEqual(BASE_SCOPE.deny);
+  });
+
+  it('npm-audit-scanner-v1 → adds package.json + pnpm-lock.yaml to allow', () => {
+    const out = applyScannerOverrides(BASE_SCOPE.allow, BASE_SCOPE.deny, 'npm-audit-scanner-v1');
+    expect(out.effectiveAllow).toContain('**/package.json');
+    expect(out.effectiveAllow).toContain('**/pnpm-lock.yaml');
+    // Deny rules untouched
+    expect(out.effectiveDeny).toEqual(BASE_SCOPE.deny);
+  });
+
+  it('cve-scanner-v1 → same package-manifest allow as npm-audit', () => {
+    const out = applyScannerOverrides(BASE_SCOPE.allow, BASE_SCOPE.deny, 'cve-scanner-v1');
+    expect(out.effectiveAllow).toContain('**/package.json');
+  });
+
+  it('rls-policy-scanner-v1 → lifts migrations deny rule', () => {
+    const out = applyScannerOverrides(BASE_SCOPE.allow, BASE_SCOPE.deny, 'rls-policy-scanner-v1');
+    expect(out.effectiveDeny).not.toContain('supabase/migrations/**');
+    // Other deny rules preserved
+    expect(out.effectiveDeny).toContain('**/auth*');
+    expect(out.effectiveDeny).toContain('.github/workflows/**');
+  });
+
+  it('schema-drift-scanner-v1 → lifts migrations deny rule', () => {
+    const out = applyScannerOverrides(BASE_SCOPE.allow, BASE_SCOPE.deny, 'schema-drift-scanner-v1');
+    expect(out.effectiveDeny).not.toContain('supabase/migrations/**');
+  });
+
+  it('workflow-fix-scanner-v1 → lifts workflows deny rule', () => {
+    const out = applyScannerOverrides(BASE_SCOPE.allow, BASE_SCOPE.deny, 'workflow-fix-scanner-v1');
+    expect(out.effectiveDeny).not.toContain('.github/workflows/**');
+    expect(out.effectiveDeny).toContain('supabase/migrations/**');
+  });
+});
+
+describe('evaluateSafetyGate — end-to-end with scanner override', () => {
+  const baseConfig = {
+    kill_switch: false,
+    daily_budget: 500,
+    concurrency_cap: 4,
+    max_auto_fix_depth: 2,
+    allow_scope: BASE_SCOPE.allow,
+    deny_scope: BASE_SCOPE.deny,
+  };
+
+  it('npm-audit finding modifying package.json + a test passes the gate', () => {
+    const decision = evaluateSafetyGate(
+      {
+        risk_class: 'low',
+        files_to_modify: [
+          'services/gateway/package.json',
+          'services/gateway/test/cve.test.ts',
+        ],
+      },
+      {
+        config: baseConfig,
+        approved_today: 0,
+        auto_fix_depth: 0,
+        scanner: 'npm-audit-scanner-v1',
+      },
+    );
+    expect(decision.ok).toBe(true);
+    expect(decision.violations).toEqual([]);
+  });
+
+  it('todo finding cannot modify package.json (override does NOT leak)', () => {
+    const decision = evaluateSafetyGate(
+      {
+        risk_class: 'low',
+        files_to_modify: [
+          'services/gateway/package.json',
+          'services/gateway/test/foo.test.ts',
+        ],
+      },
+      {
+        config: baseConfig,
+        approved_today: 0,
+        auto_fix_depth: 0,
+        scanner: 'todo-scanner-v1',
+      },
+    );
+    expect(decision.ok).toBe(false);
+    expect(decision.violations.find(v => v.code === 'file_outside_allow_scope')).toBeDefined();
+  });
+
+  it('rls-policy finding adding a new migration + a test passes the gate', () => {
+    const allowWithMigrations = baseConfig.allow_scope.concat(['supabase/migrations/**']);
+    const decision = evaluateSafetyGate(
+      {
+        risk_class: 'low',
+        files_to_modify: [
+          'supabase/migrations/20260508000000_add_rls.sql',
+          'services/gateway/test/rls-policy.test.ts',
+        ],
+      },
+      {
+        config: { ...baseConfig, allow_scope: allowWithMigrations },
+        approved_today: 0,
+        auto_fix_depth: 0,
+        scanner: 'rls-policy-scanner-v1',
+      },
+    );
+    expect(decision.ok).toBe(true);
+  });
+
+  it('todo finding cannot add a migration (deny override does NOT leak)', () => {
+    const allowWithMigrations = baseConfig.allow_scope.concat(['supabase/migrations/**']);
+    const decision = evaluateSafetyGate(
+      {
+        risk_class: 'low',
+        files_to_modify: [
+          'supabase/migrations/20260508000000_random.sql',
+          'services/gateway/test/rls.test.ts',
+        ],
+      },
+      {
+        config: { ...baseConfig, allow_scope: allowWithMigrations },
+        approved_today: 0,
+        auto_fix_depth: 0,
+        scanner: 'todo-scanner-v1',
+      },
+    );
+    expect(decision.ok).toBe(false);
+    expect(decision.violations.find(v => v.code === 'file_in_deny_scope')).toBeDefined();
+  });
+});
+
+describe('buildPlanningPrompt — scanner-aware traps', () => {
+  function expectPromptFor(scanner: string): string {
+    return buildPlanningPrompt(
+      {
+        ...BASE_FINDING,
+        spec_snapshot: { scanner },
+      } as Parameters<typeof buildPlanningPrompt>[0],
+      undefined,
+      undefined,
+      BASE_SCOPE,
+    );
+  }
+
+  it('npm-audit finding: prompt does NOT forbid package.json', () => {
+    const prompt = expectPromptFor('npm-audit-scanner-v1');
+    // The trap line that bans package.json must not be present for this scanner.
+    expect(prompt).not.toMatch(/`services\/gateway\/package\.json` \/ any `package\.json`/);
+  });
+
+  it('todo finding: prompt DOES forbid package.json', () => {
+    const prompt = expectPromptFor('todo-scanner-v1');
+    expect(prompt).toMatch(/`package\.json`/);
+    // sanity: we explicitly state to put it in Out-of-scope, not Files to modify
+    expect(prompt).toMatch(/Out-of-scope/);
+  });
+
+  it('rls-policy finding: prompt does NOT forbid migrations as a class', () => {
+    const prompt = expectPromptFor('rls-policy-scanner-v1');
+    // It still tells you not to MODIFY existing migrations, but adding new ones is OK
+    expect(prompt).not.toMatch(/Any `supabase\/migrations\/\*` file\n/);
+    expect(prompt).toMatch(/ADDING a new dated migration file IS allowed/);
+  });
+
+  it('schema-drift finding: same allowance for new migrations', () => {
+    const prompt = expectPromptFor('schema-drift-scanner-v1');
+    expect(prompt).toMatch(/ADDING a new dated migration file IS allowed/);
+  });
+
+  it('todo finding: migrations DO appear in the trap list', () => {
+    const prompt = expectPromptFor('todo-scanner-v1');
+    expect(prompt).toMatch(/Any `supabase\/migrations\/\*` file/);
+  });
+
+  it('workflow-fix finding: prompt lifts the .github/workflows trap', () => {
+    const prompt = expectPromptFor('workflow-fix-scanner-v1');
+    expect(prompt).not.toMatch(/Any `\.github\/workflows\/\*` file/);
+  });
+});

--- a/supabase/ops/inspect_scope.sql
+++ b/supabase/ops/inspect_scope.sql
@@ -1,0 +1,2 @@
+\set ON_ERROR_STOP on
+SELECT id, allow_scope, deny_scope FROM dev_autopilot_config WHERE id = 1;


### PR DESCRIPTION
## Why
Dev autopilot's all-time merge rate is ~2% (25 of 1,225 executions). The dominant cause: the planner prompt + safety gate jointly **forbid** the only valid fix for several finding categories.

Failing categories before this PR:
- `npm-audit-scanner-v1` / `cve-scanner-v1` — fix needs a `package.json` bump → blocked by both prompt trap and allow_scope
- `rls-policy-scanner-v1` / `schema-drift-scanner-v1` — fix needs a NEW dated migration → blocked by deny_scope
- `workflow-fix-scanner-v1` / `ci-fix-scanner-v1` — fix is in `.github/workflows/*` → blocked by deny_scope

Result: planner correctly obeys the prompt and produces a test-only PR. Test file documents the desired state, fails CI because the actual fix isn't there, bridge reverts. Confirmed live: 2026-05-08 unattended test had 4 PRs all failing Gateway Service Tests for exactly this reason.

## Fix — both layers, scanner-aware
1. `dev-autopilot-planning.ts buildPlanningPrompt`: trap list built per-finding based on `spec_snapshot.scanner`.
2. `dev-autopilot-safety.ts applyScannerOverrides`: gate computes effective allow/deny based on scanner. npm-audit → `**/package.json` added to allow; rls-policy/schema-drift → `supabase/migrations/**` removed from deny; workflow scanners → `.github/workflows/**` removed from deny. Unknown scanners → no change.
3. `dev-autopilot-execute.ts approveAutoExecute`: passes scanner into SafetyContext so the override actually fires.

Also aligns `LLM_SAFE_DEFAULTS` constant from `gemini-2.5-pro` to `gemini-3.1-pro-preview` to match the runtime `llm_routing_policy` (verified via telemetry: 33/33 planner calls in last 4h on `gemini-3.1-pro-preview`). This is just code-hygiene — runtime is already correct.

## Tests
17 cases in `dev-autopilot-scanner-aware-traps.test.ts` — both layers for all 4 override categories + no-leak guarantees for unknown scanners. `npm run build` clean.

## DB unchanged
This PR does NOT modify `dev_autopilot_config.allow_scope` / `deny_scope`. Those remain the restrictive global default; per-scanner overrides apply on top in code so unrelated findings still can't touch package.json or migrations.

🤖 Generated with [Claude Code](https://claude.com/claude-code)