### PR TITLE
DEV-AUTOPILOT: Add ReDoS regression test for @modelcontextprotocol/sdk

### DIFF
--- a/services/gateway/test/mcp-cve-regression.test.ts
+++ b/services/gateway/test/mcp-cve-regression.test.ts
@@ -1,0 +1,39 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('CVE Regression: @modelcontextprotocol/sdk ReDoS', () => {
+  it('should enforce @modelcontextprotocol/sdk version >= 1.25.2 in package.json', () => {
+    const packageJsonPath = path.resolve(__dirname, '../package.json');
+    const packageJsonContent = fs.readFileSync(packageJsonPath, 'utf-8');
+    const packageJson = JSON.parse(packageJsonContent);
+
+    const dependencies = packageJson.dependencies || {};
+    const mcpVersionString = dependencies['@modelcontextprotocol/sdk'];
+
+    // Ensure the dependency exists
+    expect(mcpVersionString).toBeDefined();
+    expect(typeof mcpVersionString).toBe('string');
+
+    // Strip leading non-digit characters (e.g., ^, ~, or >=)
+    const cleanVersion = mcpVersionString.replace(/^[^0-9]+/, '');
+
+    // Split the version by . into major, minor, and patch numbers
+    const parts = cleanVersion.split('.');
+    const major = parseInt(parts[0] || '0', 10);
+    const minor = parseInt(parts[1] || '0', 10);
+    const patch = parseInt(parts[2] || '0', 10);
+
+    // Assert major >= 1
+    expect(major).toBeGreaterThanOrEqual(1);
+
+    // Assert if major === 1, then minor >= 25
+    if (major === 1) {
+      expect(minor).toBeGreaterThanOrEqual(25);
+
+      // Assert if major === 1 && minor === 25, then patch >= 2
+      if (minor === 25) {
+        expect(patch).toBeGreaterThanOrEqual(2);
+      }
+    }
+  });
+});


### PR DESCRIPTION
This PR adds a security regression test to enforce that `@modelcontextprotocol/sdk` is bumped to version `1.25.2` or higher in `services/gateway/package.json`. This mitigates a known Regular Expression Denial of Service (ReDoS) vulnerability found in older versions (`^0.5.0`).

### Developer Action Required
The Autopilot executor does not modify `package.json` or lockfiles to avoid breaking dependency resolution chains. **You must manually perform the following before merging:**

1. Open `services/gateway/package.json` and update `"@modelcontextprotocol/sdk"` to `"^1.25.2"`.
2. Run `npm install` inside `services/gateway/` to update `package-lock.json`.
3. Address any potential TypeScript/API breaking changes from the `0.5.x` -> `1.25.x` bump by running `npm run typecheck`.

**Files touched:**
- `services/gateway/test/mcp-cve-regression.test.ts` (New test to guard against CVE reintroduction)