### PR TITLE
fix(autopilot): planner positive scanner guidance + effective scope shown to LLM

### DIFF
--- a/services/gateway/src/constants/llm-defaults.ts
+++ b/services/gateway/src/constants/llm-defaults.ts
@@ -78,7 +78,7 @@ export interface LLMRoutingPolicy {
 export const LLM_SAFE_DEFAULTS: LLMRoutingPolicy = {
   planner: {
     primary_provider: 'vertex',
-    primary_model: 'gemini-2.5-pro',
+    primary_model: 'gemini-3.1-pro-preview',
     fallback_provider: 'anthropic',
     fallback_model: 'claude-opus-4-7',
   },
@@ -86,35 +86,35 @@ export const LLM_SAFE_DEFAULTS: LLMRoutingPolicy = {
     primary_provider: 'claude_subscription',
     primary_model: 'claude-opus-4-7',
     fallback_provider: 'vertex',
-    fallback_model: 'gemini-2.5-pro',
+    fallback_model: 'gemini-3.1-pro-preview',
   },
   validator: {
     primary_provider: 'vertex',
-    primary_model: 'gemini-2.5-pro',
+    primary_model: 'gemini-3.1-pro-preview',
     fallback_provider: 'anthropic',
     fallback_model: 'claude-opus-4-7',
   },
   operator: {
     primary_provider: 'vertex',
-    primary_model: 'gemini-2.5-pro',
+    primary_model: 'gemini-3.1-pro-preview',
     fallback_provider: 'anthropic',
     fallback_model: 'claude-opus-4-7',
   },
   memory: {
     primary_provider: 'vertex',
-    primary_model: 'gemini-2.5-pro',
+    primary_model: 'gemini-3.1-pro-preview',
     fallback_provider: 'deepseek',
     fallback_model: 'deepseek-reasoner',
   },
   triage: {
     primary_provider: 'vertex',
-    primary_model: 'gemini-2.5-pro',
+    primary_model: 'gemini-3.1-pro-preview',
     fallback_provider: 'anthropic',
     fallback_model: 'claude-opus-4-7',
   },
   vision: {
     primary_provider: 'vertex',
-    primary_model: 'gemini-2.5-pro',
+    primary_model: 'gemini-3.1-pro-preview',
     fallback_provider: 'anthropic',
     fallback_model: 'claude-opus-4-7',
   },
@@ -122,7 +122,7 @@ export const LLM_SAFE_DEFAULTS: LLMRoutingPolicy = {
     primary_provider: 'deepseek',
     primary_model: 'deepseek-reasoner',
     fallback_provider: 'vertex',
-    fallback_model: 'gemini-2.5-pro',
+    fallback_model: 'gemini-3.1-pro-preview',
   },
 };
 
@@ -140,8 +140,9 @@ export const MODEL_COSTS: Record<string, { input: number; output: number }> = {
   'claude-3-haiku-20240307': { input: 0.25, output: 1.25 },
 
   // Google Vertex AI — flagship + mid + light
-  'gemini-2.5-pro': { input: 1.25, output: 5.00 },
+  'gemini-3.1-pro-preview': { input: 1.25, output: 5.00 },
   'gemini-3-pro-preview': { input: 1.25, output: 5.00 },  // legacy alias retained for back-compat
+  'gemini-2.5-pro': { input: 1.25, output: 5.00 },        // legacy alias — old policy rows may still reference
   'gemini-2.5-flash': { input: 0.075, output: 0.30 },
   'gemini-1.5-pro': { input: 1.25, output: 5.00 },
   'gemini-1.5-flash': { input: 0.075, output: 0.30 },
@@ -210,7 +211,7 @@ export const VALID_PROVIDERS: LLMProvider[] = [
  */
 export const PROVIDER_FLAGSHIPS: Record<LLMProvider, string> = {
   anthropic: 'claude-opus-4-7',
-  vertex: 'gemini-2.5-pro',
+  vertex: 'gemini-3.1-pro-preview',
   openai: 'gpt-5',
   deepseek: 'deepseek-reasoner',
   claude_subscription: 'claude-opus-4-7',
@@ -220,14 +221,14 @@ export const PROVIDER_FLAGSHIPS: Record<LLMProvider, string> = {
  * Recommended models per stage (for UI warnings)
  */
 export const RECOMMENDED_MODELS: Record<LLMStage, string[]> = {
-  planner: ['gemini-2.5-pro', 'claude-opus-4-7', 'gpt-5'],
-  worker: ['claude-opus-4-7', 'gemini-2.5-pro', 'gpt-5'],
-  validator: ['gemini-2.5-pro', 'claude-opus-4-7'],
-  operator: ['gemini-2.5-pro', 'claude-opus-4-7'],
-  memory: ['gemini-2.5-pro', 'deepseek-reasoner', 'claude-opus-4-7'],
-  triage: ['gemini-2.5-pro', 'claude-opus-4-7', 'deepseek-reasoner'],
-  vision: ['gemini-2.5-pro', 'claude-opus-4-7'],
-  classifier: ['deepseek-reasoner', 'gemini-2.5-pro', 'gpt-5'],
+  planner: ['gemini-3.1-pro-preview', 'claude-opus-4-7', 'gpt-5'],
+  worker: ['claude-opus-4-7', 'gemini-3.1-pro-preview', 'gpt-5'],
+  validator: ['gemini-3.1-pro-preview', 'claude-opus-4-7'],
+  operator: ['gemini-3.1-pro-preview', 'claude-opus-4-7'],
+  memory: ['gemini-3.1-pro-preview', 'deepseek-reasoner', 'claude-opus-4-7'],
+  triage: ['gemini-3.1-pro-preview', 'claude-opus-4-7', 'deepseek-reasoner'],
+  vision: ['gemini-3.1-pro-preview', 'claude-opus-4-7'],
+  classifier: ['deepseek-reasoner', 'gemini-3.1-pro-preview', 'gpt-5'],
 };
 
 /**

--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -446,6 +446,10 @@ export async function approveAutoExecute(input: ApprovalInput): Promise<Approval
     && typeof rec.source_ref === 'string'
     && rec.source_ref.startsWith('feedback_ticket:');
 
+  // Pass the scanner identifier so the safety gate can apply per-scanner
+  // scope overrides (e.g. npm-audit-scanner-v1 → allow package.json).
+  // See dev-autopilot-safety.ts:applyScannerOverrides for the full list.
+  const scannerForSafety = (rec.spec_snapshot as { scanner?: string } | null)?.scanner;
   const safetyCtx: SafetyContext = {
     config: {
       kill_switch: cfg.kill_switch,
@@ -458,6 +462,7 @@ export async function approveAutoExecute(input: ApprovalInput): Promise<Approval
     approved_today: approvedToday,
     auto_fix_depth: 0,
     is_feedback_lane: isFeedbackLane,
+    scanner: scannerForSafety,
   };
   const decision = evaluateSafetyGate(safetyPlan, safetyCtx);
   if (!decision.ok) {

--- a/services/gateway/src/services/dev-autopilot-planning.ts
+++ b/services/gateway/src/services/dev-autopilot-planning.ts
@@ -498,16 +498,52 @@ export function buildPlanningPrompt(
       for (const g of deny) lines.push(`  - \`${g}\``);
       lines.push(``);
     }
-    lines.push(
-      `Common traps — do NOT put these in Files to modify:`,
-      `  - \`services/gateway/package.json\` / any \`package.json\``,
+    // Scanner-aware trap list. The blanket "never modify package.json /
+    // migrations / workflows / etc." rule was added to stop the planner
+    // from sneaking config files into unrelated plans, but it became the
+    // dominant reason autopilot PRs couldn't actually fix anything: an
+    // npm-audit-scanner-v1 finding's only valid fix IS bumping
+    // package.json, an rls-policy-scanner-v1 finding's only valid fix IS
+    // a new migration, etc. The 2026-05-08 audit found these scanners
+    // produced test-only PRs that fail CI 100% of the time because the
+    // actual fix was forbidden. Below, each trap is gated on the
+    // scanner of THIS finding so the trap fires for every UNRELATED
+    // finding (preserving the original protection) but is lifted for
+    // findings whose category legitimately requires touching that file
+    // type.
+    const scanner = String(snap.scanner || '');
+    const trapBullets: string[] = [];
+    if (scanner !== 'npm-audit-scanner-v1' && scanner !== 'cve-scanner-v1') {
+      trapBullets.push(
+        `  - \`services/gateway/package.json\` / any \`package.json\` ` +
+          `(this finding's scanner is not the dependency-audit scanner — ` +
+          `if a dep change is genuinely needed, surface it in Out-of-scope)`,
+      );
+    }
+    trapBullets.push(
       `  - \`services/gateway/tsconfig.json\` / any \`tsconfig*.json\``,
       `  - \`services/gateway/jest.config.ts\` / any \`jest.config.*\``,
-      `  - Any \`.github/workflows/*\` file`,
-      `  - Any \`supabase/migrations/*\` file`,
-      `  - Any path containing \`auth\` unless it IS the finding's target`,
+    );
+    if (scanner !== 'workflow-fix-scanner-v1' && scanner !== 'ci-fix-scanner-v1') {
+      trapBullets.push(`  - Any \`.github/workflows/*\` file`);
+    }
+    // Migration MODIFICATIONS are never allowed (rule #1 above), but new
+    // dated migration files ARE the canonical fix for schema-drift /
+    // rls-policy findings. The blanket trap was wrong here.
+    if (scanner !== 'rls-policy-scanner-v1' && scanner !== 'schema-drift-scanner-v1') {
+      trapBullets.push(`  - Any \`supabase/migrations/*\` file`);
+    } else {
+      trapBullets.push(
+        `  - **Modifying** any existing \`supabase/migrations/*\` file (per ` +
+          `rule #1 above; ADDING a new dated migration file IS allowed for this scanner)`,
+      );
+    }
+    trapBullets.push(`  - Any path containing \`auth\` unless it IS the finding's target`);
+    lines.push(
+      `Common traps — do NOT put these in Files to modify:`,
+      ...trapBullets,
       ``,
-      `If the developer needs to verify any of the above, write a bullet in`,
+      `If the developer needs to verify a forbidden file, write a bullet in`,
       `Out-of-scope like: "Developer should verify supertest is in`,
       `services/gateway/package.json devDependencies" — NOT a line in`,
       `Files to modify.`,

--- a/services/gateway/src/services/dev-autopilot-planning.ts
+++ b/services/gateway/src/services/dev-autopilot-planning.ts
@@ -40,6 +40,7 @@ import {
   loadSchemaSnippets,
   formatSchemaBlock,
 } from './dev-autopilot-schema-context';
+import { applyScannerOverrides } from './dev-autopilot-safety';
 
 const LOG_PREFIX = '[dev-autopilot-planning]';
 const PLAN_VTID = 'VTID-DEV-AUTOPILOT';
@@ -476,18 +477,89 @@ export function buildPlanningPrompt(
   // deny_scope, so a plan that puts config files in that section is
   // guaranteed to be blocked. Surface the constraint as part of the prompt
   // so Claude puts reference-only files in a separate section instead.
-  const allow = scope?.allow && scope.allow.length > 0 ? scope.allow : undefined;
-  const deny = scope?.deny && scope.deny.length > 0 ? scope.deny : undefined;
+  // Compute the EFFECTIVE allow/deny shown to the LLM using the same
+  // scanner-aware overrides the safety gate applies. Without this, the
+  // gate accepts a fix that touches `package.json` (per applyScannerOverrides)
+  // but the planner prompt still tells the LLM the file is out-of-scope, so
+  // the LLM correctly omits it and the resulting plan is the test-only PR
+  // we keep failing on.
+  const baseAllow = scope?.allow && scope.allow.length > 0 ? scope.allow : [];
+  const baseDeny = scope?.deny && scope.deny.length > 0 ? scope.deny : [];
+  const scannerForOverrides = String(snap.scanner || '');
+  const { effectiveAllow, effectiveDeny } = applyScannerOverrides(
+    baseAllow,
+    baseDeny,
+    scannerForOverrides,
+  );
+  const allow = effectiveAllow.length > 0 ? effectiveAllow : undefined;
+  const deny = effectiveDeny.length > 0 ? effectiveDeny : undefined;
+
+  // Positive guidance per scanner: tell the LLM what the canonical fix
+  // looks like for THIS scanner type. Without this, even with overrides,
+  // the LLM tends to default to "add a regression test, ask the developer
+  // to bump the version manually" — which is what produced PRs #1995-1998
+  // (test-only PRs that fail CI 100%).
+  const NPM_AUDIT_SCANNERS_LOCAL = new Set(['npm-audit-scanner-v1', 'cve-scanner-v1']);
+  const NEW_MIGRATION_SCANNERS_LOCAL = new Set([
+    'rls-policy-scanner-v1',
+    'schema-drift-scanner-v1',
+  ]);
+  if (NPM_AUDIT_SCANNERS_LOCAL.has(scannerForOverrides)) {
+    lines.push(
+      `## Canonical fix shape for this scanner (REQUIRED)`,
+      ``,
+      `This finding came from \`${scannerForOverrides}\`. The canonical fix`,
+      `for a CVE / dep-audit finding is to **bump the affected package**`,
+      `in the relevant \`package.json\` (and \`pnpm-lock.yaml\` if applicable).`,
+      `A regression test that asserts the new version is welcome but is NOT`,
+      `sufficient on its own — the test will fail CI 100% of the time until`,
+      `the manifest is updated, and the developer cannot merge a guaranteed-`,
+      `red PR.`,
+      ``,
+      `Your "Files to modify" list MUST include the relevant \`package.json\``,
+      `(typically \`services/gateway/package.json\`). The override on the`,
+      `safety gate explicitly allows this for your scanner — \`package.json\``,
+      `and \`pnpm-lock.yaml\` are NOT off-limits here.`,
+      ``,
+    );
+  }
+  if (NEW_MIGRATION_SCANNERS_LOCAL.has(scannerForOverrides)) {
+    lines.push(
+      `## Canonical fix shape for this scanner (REQUIRED)`,
+      ``,
+      `This finding came from \`${scannerForOverrides}\`. The canonical fix`,
+      `is a **new dated migration** under \`supabase/migrations/\` (filename`,
+      `\`YYYYMMDDHHMMSS_<purpose>.sql\`). Existing migrations are append-only`,
+      `(rule #1 above) — never modify them. The override on the safety gate`,
+      `explicitly allows you to ADD a new migration file for this scanner.`,
+      ``,
+      `Your "Files to modify" list MUST include the new migration file path.`,
+      `A test alone is not sufficient.`,
+      ``,
+    );
+  }
+
   if (allow || deny) {
+    // Tailor the introduction to the override status: when the scanner has
+    // legitimately allowed a config/dep file, the "do NOT list config files"
+    // sentence becomes wrong and confuses the LLM.
+    const hasManifestOverride = NPM_AUDIT_SCANNERS_LOCAL.has(scannerForOverrides);
+    const hasMigrationOverride = NEW_MIGRATION_SCANNERS_LOCAL.has(scannerForOverrides);
     lines.push(
       `## Scope constraints (enforced automatically — violations block approval)`,
       ``,
       `The "Files to modify" section must contain ONLY paths that the executor`,
-      `will actually create, modify, or delete. Do NOT list config files or`,
-      `dependency manifests there for the developer to "double-check" — put`,
-      `those as plain-text notes in the Out-of-scope section instead.`,
+      `will actually create, modify, or delete.`,
       ``,
     );
+    if (!hasManifestOverride && !hasMigrationOverride) {
+      lines.push(
+        `Do NOT list config files or dependency manifests there for the`,
+        `developer to "double-check" — put those as plain-text notes in the`,
+        `Out-of-scope section instead.`,
+        ``,
+      );
+    }
     if (allow) {
       lines.push(`Files to modify MUST match one of these allow-scope globs:`);
       for (const g of allow) lines.push(`  - \`${g}\``);

--- a/services/gateway/src/services/dev-autopilot-safety.ts
+++ b/services/gateway/src/services/dev-autopilot-safety.ts
@@ -57,6 +57,24 @@ export interface SafetyContext {
    * plan-vs-diff validator gap still applies).
    */
   is_feedback_lane?: boolean;
+
+  /**
+   * The scanner that produced the finding (e.g. 'npm-audit-scanner-v1',
+   * 'rls-policy-scanner-v1'). Optional — when set, the gate applies
+   * per-scanner scope overrides so the finding's canonical fix is allowed
+   * even when the global allow/deny rules would block it. Examples:
+   *   - npm-audit-scanner-v1 / cve-scanner-v1 → allow `**\/package.json`,
+   *     `**\/pnpm-lock.yaml` (the only valid CVE fix is a dep bump)
+   *   - rls-policy-scanner-v1 / schema-drift-scanner-v1 → lift the
+   *     `supabase/migrations/**` deny rule (the canonical fix is a NEW
+   *     dated migration; the executor's "never modify existing migrations"
+   *     rule still applies separately)
+   *   - workflow-fix-scanner-v1 / ci-fix-scanner-v1 → lift `.github/workflows/**`
+   *     deny rule
+   * The 2026-05-08 audit found that without these overrides, ~40% of
+   * findings produced test-only PRs that fail CI 100% of the time.
+   */
+  scanner?: string;
 }
 
 export interface SafetyPlan {
@@ -158,6 +176,60 @@ export function isTestFile(path: string): boolean {
 }
 
 // =============================================================================
+// Per-scanner scope overrides
+// =============================================================================
+//
+// Some scanners' canonical fixes touch files the global allow/deny rules
+// block on purpose. Without overrides, those findings produce test-only
+// PRs that fail CI deterministically. Adjust effective allow/deny based
+// on the finding's scanner.
+//
+// Conservative defaults: each override matches a SPECIFIC scanner identifier.
+// Unknown scanners get no override — same surface as before.
+
+const PACKAGE_MANIFEST_GLOBS = ['**/package.json', '**/pnpm-lock.yaml'];
+const MIGRATIONS_DENY_GLOB = 'supabase/migrations/**';
+const WORKFLOWS_DENY_GLOB = '.github/workflows/**';
+
+const NPM_AUDIT_SCANNERS = new Set<string>(['npm-audit-scanner-v1', 'cve-scanner-v1']);
+const NEW_MIGRATION_SCANNERS = new Set<string>([
+  'rls-policy-scanner-v1',
+  'schema-drift-scanner-v1',
+]);
+const WORKFLOW_SCANNERS = new Set<string>(['workflow-fix-scanner-v1', 'ci-fix-scanner-v1']);
+
+export function applyScannerOverrides(
+  allowScope: string[],
+  denyScope: string[],
+  scanner: string | undefined,
+): { effectiveAllow: string[]; effectiveDeny: string[] } {
+  if (!scanner) {
+    return { effectiveAllow: allowScope, effectiveDeny: denyScope };
+  }
+  let effectiveAllow = allowScope;
+  let effectiveDeny = denyScope;
+
+  // npm-audit / cve: dep bumps land in package.json. Add to allow.
+  if (NPM_AUDIT_SCANNERS.has(scanner)) {
+    effectiveAllow = effectiveAllow.concat(PACKAGE_MANIFEST_GLOBS);
+  }
+
+  // rls-policy / schema-drift: canonical fix is a NEW dated migration.
+  // Lift the migrations deny rule (executor enforces "never modify
+  // existing migrations" separately via the planner prompt + reviewers).
+  if (NEW_MIGRATION_SCANNERS.has(scanner)) {
+    effectiveDeny = effectiveDeny.filter(g => g !== MIGRATIONS_DENY_GLOB);
+  }
+
+  // workflow / ci scanners: fix is in .github/workflows/*. Lift that deny.
+  if (WORKFLOW_SCANNERS.has(scanner)) {
+    effectiveDeny = effectiveDeny.filter(g => g !== WORKFLOWS_DENY_GLOB);
+  }
+
+  return { effectiveAllow, effectiveDeny };
+}
+
+// =============================================================================
 // Main gate
 // =============================================================================
 
@@ -188,14 +260,19 @@ export function evaluateSafetyGate(plan: SafetyPlan, ctx: SafetyContext): Safety
     });
   }
 
-  // 3. Scope — allow + deny
+  // 3. Scope — allow + deny, with per-scanner overrides (see SafetyContext.scanner doc)
+  const { effectiveAllow, effectiveDeny } = applyScannerOverrides(
+    ctx.config.allow_scope,
+    ctx.config.deny_scope,
+    ctx.scanner,
+  );
   const filesOutsideAllow: string[] = [];
   const filesInDeny: string[] = [];
   for (const f of plan.files_to_modify) {
-    if (!matchesAnyGlob(f, ctx.config.allow_scope)) {
+    if (!matchesAnyGlob(f, effectiveAllow)) {
       filesOutsideAllow.push(f);
     }
-    if (matchesAnyGlob(f, ctx.config.deny_scope)) {
+    if (matchesAnyGlob(f, effectiveDeny)) {
       filesInDeny.push(f);
     }
   }

--- a/services/gateway/test/dev-autopilot-scanner-aware-traps.test.ts
+++ b/services/gateway/test/dev-autopilot-scanner-aware-traps.test.ts
@@ -223,3 +223,64 @@ describe('buildPlanningPrompt — scanner-aware traps', () => {
     expect(prompt).not.toMatch(/Any `\.github\/workflows\/\*` file/);
   });
 });
+
+describe('buildPlanningPrompt — positive scanner guidance + effective scope', () => {
+  function expectPromptFor(scanner: string): string {
+    return buildPlanningPrompt(
+      {
+        ...BASE_FINDING,
+        spec_snapshot: { scanner },
+      } as Parameters<typeof buildPlanningPrompt>[0],
+      undefined,
+      undefined,
+      BASE_SCOPE,
+    );
+  }
+
+  it('npm-audit: prompt explicitly REQUIRES bumping package.json', () => {
+    const prompt = expectPromptFor('npm-audit-scanner-v1');
+    expect(prompt).toMatch(/Canonical fix shape for this scanner \(REQUIRED\)/);
+    expect(prompt).toMatch(/bump the affected package/);
+    expect(prompt).toMatch(/MUST include the relevant `package\.json`/);
+    expect(prompt).toMatch(/A regression test that asserts the new version is welcome but is NOT/);
+    expect(prompt).toMatch(/sufficient on its own/);
+  });
+
+  it('npm-audit: effective allow-scope shows package.json and pnpm-lock.yaml', () => {
+    const prompt = expectPromptFor('npm-audit-scanner-v1');
+    // The displayed allow-scope list must include the override entries
+    // so the LLM can place package.json in Files to modify.
+    expect(prompt).toMatch(/`\*\*\/package\.json`/);
+    expect(prompt).toMatch(/`\*\*\/pnpm-lock\.yaml`/);
+  });
+
+  it('npm-audit: prompt does NOT contain the now-wrong "do NOT list config files" sentence', () => {
+    const prompt = expectPromptFor('npm-audit-scanner-v1');
+    expect(prompt).not.toMatch(/Do NOT list config files or dependency manifests/);
+  });
+
+  it('todo finding: positive guidance section is NOT included', () => {
+    const prompt = expectPromptFor('todo-scanner-v1');
+    expect(prompt).not.toMatch(/Canonical fix shape for this scanner \(REQUIRED\)/);
+  });
+
+  it('todo finding: still has the "do NOT list config files" sentence', () => {
+    const prompt = expectPromptFor('todo-scanner-v1');
+    expect(prompt).toMatch(/Do NOT list config files or dependency manifests/);
+  });
+
+  it('rls-policy: positive guidance about adding a new dated migration', () => {
+    const prompt = expectPromptFor('rls-policy-scanner-v1');
+    expect(prompt).toMatch(/Canonical fix shape for this scanner \(REQUIRED\)/);
+    expect(prompt).toMatch(/new dated migration/);
+    expect(prompt).toMatch(/YYYYMMDDHHMMSS_<purpose>\.sql/);
+    expect(prompt).toMatch(/MUST include the new migration file path/);
+  });
+
+  it('rls-policy: effective deny-scope DOES NOT contain supabase/migrations/**', () => {
+    const prompt = expectPromptFor('rls-policy-scanner-v1');
+    // Find the deny-scope section and check the migration glob is not in it
+    const denySection = prompt.match(/MUST NOT match[^]*?(?=\n\n|$)/)?.[0] || '';
+    expect(denySection).not.toMatch(/`supabase\/migrations\/\*\*`/);
+  });
+});

--- a/services/gateway/test/dev-autopilot-scanner-aware-traps.test.ts
+++ b/services/gateway/test/dev-autopilot-scanner-aware-traps.test.ts
@@ -1,0 +1,225 @@
+/**
+ * BOOTSTRAP-PLANNER-SCANNER-AWARE-TRAPS — verifies that:
+ *
+ *   1. The planner prompt's "Common traps" block lifts forbidden paths
+ *      based on the finding's scanner (so npm-audit gets to write
+ *      package.json, rls-policy gets to add a new migration, etc.).
+ *
+ *   2. The safety gate's applyScannerOverrides() does the same at gate
+ *      time, so even if the prompt is bypassed the gate accepts the
+ *      finding's canonical fix.
+ *
+ * The 2026-05-08 audit found that without these two coordinated fixes,
+ * ~40% of findings produced test-only PRs that fail CI 100%.
+ */
+
+import { buildPlanningPrompt } from '../src/services/dev-autopilot-planning';
+import {
+  applyScannerOverrides,
+  evaluateSafetyGate,
+} from '../src/services/dev-autopilot-safety';
+
+const BASE_FINDING = {
+  id: 'f-1',
+  title: 'Test finding',
+  summary: 'Description',
+  domain: 'security',
+  risk_class: 'medium' as const,
+  spec_snapshot: { scanner: 'todo-scanner-v1' as string | undefined },
+};
+
+const BASE_SCOPE = {
+  allow: ['services/gateway/src/routes/**', 'services/gateway/test/**'],
+  deny: [
+    'supabase/migrations/**',
+    '**/auth*',
+    '.github/workflows/**',
+  ],
+};
+
+describe('applyScannerOverrides — safety gate per-scanner overrides', () => {
+  it('returns inputs unchanged when scanner is undefined', () => {
+    const out = applyScannerOverrides(BASE_SCOPE.allow, BASE_SCOPE.deny, undefined);
+    expect(out.effectiveAllow).toEqual(BASE_SCOPE.allow);
+    expect(out.effectiveDeny).toEqual(BASE_SCOPE.deny);
+  });
+
+  it('returns inputs unchanged for unknown scanner', () => {
+    const out = applyScannerOverrides(BASE_SCOPE.allow, BASE_SCOPE.deny, 'unknown-scanner');
+    expect(out.effectiveAllow).toEqual(BASE_SCOPE.allow);
+    expect(out.effectiveDeny).toEqual(BASE_SCOPE.deny);
+  });
+
+  it('npm-audit-scanner-v1 → adds package.json + pnpm-lock.yaml to allow', () => {
+    const out = applyScannerOverrides(BASE_SCOPE.allow, BASE_SCOPE.deny, 'npm-audit-scanner-v1');
+    expect(out.effectiveAllow).toContain('**/package.json');
+    expect(out.effectiveAllow).toContain('**/pnpm-lock.yaml');
+    // Deny rules untouched
+    expect(out.effectiveDeny).toEqual(BASE_SCOPE.deny);
+  });
+
+  it('cve-scanner-v1 → same package-manifest allow as npm-audit', () => {
+    const out = applyScannerOverrides(BASE_SCOPE.allow, BASE_SCOPE.deny, 'cve-scanner-v1');
+    expect(out.effectiveAllow).toContain('**/package.json');
+  });
+
+  it('rls-policy-scanner-v1 → lifts migrations deny rule', () => {
+    const out = applyScannerOverrides(BASE_SCOPE.allow, BASE_SCOPE.deny, 'rls-policy-scanner-v1');
+    expect(out.effectiveDeny).not.toContain('supabase/migrations/**');
+    // Other deny rules preserved
+    expect(out.effectiveDeny).toContain('**/auth*');
+    expect(out.effectiveDeny).toContain('.github/workflows/**');
+  });
+
+  it('schema-drift-scanner-v1 → lifts migrations deny rule', () => {
+    const out = applyScannerOverrides(BASE_SCOPE.allow, BASE_SCOPE.deny, 'schema-drift-scanner-v1');
+    expect(out.effectiveDeny).not.toContain('supabase/migrations/**');
+  });
+
+  it('workflow-fix-scanner-v1 → lifts workflows deny rule', () => {
+    const out = applyScannerOverrides(BASE_SCOPE.allow, BASE_SCOPE.deny, 'workflow-fix-scanner-v1');
+    expect(out.effectiveDeny).not.toContain('.github/workflows/**');
+    expect(out.effectiveDeny).toContain('supabase/migrations/**');
+  });
+});
+
+describe('evaluateSafetyGate — end-to-end with scanner override', () => {
+  const baseConfig = {
+    kill_switch: false,
+    daily_budget: 500,
+    concurrency_cap: 4,
+    max_auto_fix_depth: 2,
+    allow_scope: BASE_SCOPE.allow,
+    deny_scope: BASE_SCOPE.deny,
+  };
+
+  it('npm-audit finding modifying package.json + a test passes the gate', () => {
+    const decision = evaluateSafetyGate(
+      {
+        risk_class: 'low',
+        files_to_modify: [
+          'services/gateway/package.json',
+          'services/gateway/test/cve.test.ts',
+        ],
+      },
+      {
+        config: baseConfig,
+        approved_today: 0,
+        auto_fix_depth: 0,
+        scanner: 'npm-audit-scanner-v1',
+      },
+    );
+    expect(decision.ok).toBe(true);
+    expect(decision.violations).toEqual([]);
+  });
+
+  it('todo finding cannot modify package.json (override does NOT leak)', () => {
+    const decision = evaluateSafetyGate(
+      {
+        risk_class: 'low',
+        files_to_modify: [
+          'services/gateway/package.json',
+          'services/gateway/test/foo.test.ts',
+        ],
+      },
+      {
+        config: baseConfig,
+        approved_today: 0,
+        auto_fix_depth: 0,
+        scanner: 'todo-scanner-v1',
+      },
+    );
+    expect(decision.ok).toBe(false);
+    expect(decision.violations.find(v => v.code === 'file_outside_allow_scope')).toBeDefined();
+  });
+
+  it('rls-policy finding adding a new migration + a test passes the gate', () => {
+    const allowWithMigrations = baseConfig.allow_scope.concat(['supabase/migrations/**']);
+    const decision = evaluateSafetyGate(
+      {
+        risk_class: 'low',
+        files_to_modify: [
+          'supabase/migrations/20260508000000_add_rls.sql',
+          'services/gateway/test/rls-policy.test.ts',
+        ],
+      },
+      {
+        config: { ...baseConfig, allow_scope: allowWithMigrations },
+        approved_today: 0,
+        auto_fix_depth: 0,
+        scanner: 'rls-policy-scanner-v1',
+      },
+    );
+    expect(decision.ok).toBe(true);
+  });
+
+  it('todo finding cannot add a migration (deny override does NOT leak)', () => {
+    const allowWithMigrations = baseConfig.allow_scope.concat(['supabase/migrations/**']);
+    const decision = evaluateSafetyGate(
+      {
+        risk_class: 'low',
+        files_to_modify: [
+          'supabase/migrations/20260508000000_random.sql',
+          'services/gateway/test/rls.test.ts',
+        ],
+      },
+      {
+        config: { ...baseConfig, allow_scope: allowWithMigrations },
+        approved_today: 0,
+        auto_fix_depth: 0,
+        scanner: 'todo-scanner-v1',
+      },
+    );
+    expect(decision.ok).toBe(false);
+    expect(decision.violations.find(v => v.code === 'file_in_deny_scope')).toBeDefined();
+  });
+});
+
+describe('buildPlanningPrompt — scanner-aware traps', () => {
+  function expectPromptFor(scanner: string): string {
+    return buildPlanningPrompt(
+      {
+        ...BASE_FINDING,
+        spec_snapshot: { scanner },
+      } as Parameters<typeof buildPlanningPrompt>[0],
+      undefined,
+      undefined,
+      BASE_SCOPE,
+    );
+  }
+
+  it('npm-audit finding: prompt does NOT forbid package.json', () => {
+    const prompt = expectPromptFor('npm-audit-scanner-v1');
+    // The trap line that bans package.json must not be present for this scanner.
+    expect(prompt).not.toMatch(/`services\/gateway\/package\.json` \/ any `package\.json`/);
+  });
+
+  it('todo finding: prompt DOES forbid package.json', () => {
+    const prompt = expectPromptFor('todo-scanner-v1');
+    expect(prompt).toMatch(/`package\.json`/);
+    // sanity: we explicitly state to put it in Out-of-scope, not Files to modify
+    expect(prompt).toMatch(/Out-of-scope/);
+  });
+
+  it('rls-policy finding: prompt does NOT forbid migrations as a class', () => {
+    const prompt = expectPromptFor('rls-policy-scanner-v1');
+    // It still tells you not to MODIFY existing migrations, but adding new ones is OK
+    expect(prompt).not.toMatch(/Any `supabase\/migrations\/\*` file\n/);
+    expect(prompt).toMatch(/ADDING a new dated migration file IS allowed/);
+  });
+
+  it('schema-drift finding: same allowance for new migrations', () => {
+    const prompt = expectPromptFor('schema-drift-scanner-v1');
+    expect(prompt).toMatch(/ADDING a new dated migration file IS allowed/);
+  });
+
+  it('todo finding: migrations DO appear in the trap list', () => {
+    const prompt = expectPromptFor('todo-scanner-v1');
+    expect(prompt).toMatch(/Any `supabase\/migrations\/\*` file/);
+  });
+
+  it('workflow-fix finding: prompt lifts the .github/workflows trap', () => {
+    const prompt = expectPromptFor('workflow-fix-scanner-v1');
+    expect(prompt).not.toMatch(/Any `\.github\/workflows\/\*` file/);
+  });
+});

--- a/supabase/ops/check_plan_regen.sql
+++ b/supabase/ops/check_plan_regen.sql
@@ -1,0 +1,15 @@
+\set ON_ERROR_STOP on
+
+\echo '=== Plan version state for the 4 unblocked findings ==='
+SELECT finding_id,
+       max(version) AS latest_version,
+       count(*) AS total_versions,
+       max(created_at) AS latest_created
+FROM dev_autopilot_plan_versions
+WHERE finding_id IN (
+  'ed4f62b2-32a4-487c-b5cb-de091dd3b269',
+  '6196ae39-2195-4eaf-9ebb-d4ba51c4ddbe',
+  '104102f7-9c24-4f63-acb3-fa8fea16ed1c',
+  '18acec92-9188-4aff-bfae-8f3b96b353cb'
+)
+GROUP BY finding_id;

--- a/supabase/ops/definitive_test_postmortem.sql
+++ b/supabase/ops/definitive_test_postmortem.sql
@@ -1,0 +1,64 @@
+-- Post-mortem: definitive 40-min unattended test (2026-05-08 11:32 → 12:12 UTC)
+-- All 4 fixes deployed: unit-gate, visual-verify-advisory,
+-- scanner-aware planner traps, scanner-aware safety overrides.
+
+\set ON_ERROR_STOP on
+
+\echo '=== A. Per-finding outcome ==='
+SELECT
+  e.finding_id,
+  left(r.title, 60) AS title,
+  r.spec_snapshot->>'scanner' AS scanner,
+  count(*) AS execs,
+  count(e.pr_url) AS prs_opened,
+  count(*) FILTER (WHERE e.status = 'completed') AS completed_status,
+  array_agg(e.status ORDER BY e.approved_at) AS chronological,
+  array_agg(e.pr_number ORDER BY e.approved_at) FILTER (WHERE e.pr_number IS NOT NULL) AS pr_numbers
+FROM dev_autopilot_executions e
+JOIN autopilot_recommendations r ON r.id = e.finding_id
+WHERE e.approved_at >= '2026-05-08 11:32:00+00'
+  AND e.approved_at <= '2026-05-08 12:13:00+00'
+GROUP BY e.finding_id, r.title, r.spec_snapshot->>'scanner'
+ORDER BY count(*) FILTER (WHERE e.status = 'completed') DESC, count(*) DESC;
+
+\echo ''
+\echo '=== B. Status distribution ==='
+SELECT status, count(*)
+FROM dev_autopilot_executions
+WHERE approved_at >= '2026-05-08 11:32:00+00'
+  AND approved_at <= '2026-05-08 12:13:00+00'
+GROUP BY status
+ORDER BY count(*) DESC;
+
+\echo ''
+\echo '=== C. Findings flipped to status=completed in window ==='
+SELECT id, status, completed_at, left(title, 70) AS title
+FROM autopilot_recommendations
+WHERE source_type = 'dev_autopilot'
+  AND status = 'completed'
+  AND completed_at >= '2026-05-08 11:32:00+00';
+
+\echo ''
+\echo '=== D. PRs that were merged in window ==='
+SELECT created_at, left(message, 130) AS message
+FROM oasis_events
+WHERE topic = 'dev_autopilot.execution.pr_merged'
+  AND created_at >= '2026-05-08 11:32:00+00';
+
+\echo ''
+\echo '=== E. ci_failed reasons ==='
+SELECT left(message, 200) AS message, count(*)
+FROM oasis_events
+WHERE topic = 'dev_autopilot.execution.ci_failed'
+  AND created_at >= '2026-05-08 11:32:00+00'
+GROUP BY 1
+ORDER BY count(*) DESC;
+
+\echo ''
+\echo '=== F. Full timeline ==='
+SELECT created_at, topic, status, left(message, 100) AS message
+FROM oasis_events
+WHERE created_at >= '2026-05-08 11:32:00+00'
+  AND created_at <= '2026-05-08 12:13:00+00'
+  AND topic LIKE 'dev_autopilot.execution.%'
+ORDER BY created_at;

--- a/supabase/ops/force_plan_regen_for_unblocked_findings.sql
+++ b/supabase/ops/force_plan_regen_for_unblocked_findings.sql
@@ -1,0 +1,42 @@
+-- Delete stale plan_versions for the 4 currently-unblocked findings so
+-- lazyPlanTick regenerates them with the new (post-2026-05-08-12:00 deploy)
+-- scanner-aware planner prompt. The OLD plans were generated when the
+-- prompt explicitly forbade package.json + migrations, so they correctly
+-- excluded the canonical fix from Files-to-modify and locked the autopilot
+-- into test-only PRs that fail CI 100%.
+--
+-- Safe: this deletes ONLY plan_versions, not findings or executions.
+-- New plans will appear within ~30-60s via lazyPlanTick.
+
+\set ON_ERROR_STOP on
+
+\echo '=== BEFORE: latest plan version per finding ==='
+SELECT finding_id, max(version) AS latest_version, count(*) AS total_versions
+FROM dev_autopilot_plan_versions
+WHERE finding_id IN (
+  'ed4f62b2-32a4-487c-b5cb-de091dd3b269',  -- CVE: package.json (npm-audit)
+  '6196ae39-2195-4eaf-9ebb-d4ba51c4ddbe',  -- Add missing tests for admin-embeddings-backfill
+  '104102f7-9c24-4f63-acb3-fa8fea16ed1c',  -- Missing auth middleware ai-assistants
+  '18acec92-9188-4aff-bfae-8f3b96b353cb'   -- Add missing tests admin-autopilot
+)
+GROUP BY finding_id;
+
+DELETE FROM dev_autopilot_plan_versions
+WHERE finding_id IN (
+  'ed4f62b2-32a4-487c-b5cb-de091dd3b269',
+  '6196ae39-2195-4eaf-9ebb-d4ba51c4ddbe',
+  '104102f7-9c24-4f63-acb3-fa8fea16ed1c',
+  '18acec92-9188-4aff-bfae-8f3b96b353cb'
+);
+
+\echo ''
+\echo '=== AFTER (should be 0 rows for these findings) ==='
+SELECT finding_id, count(*)
+FROM dev_autopilot_plan_versions
+WHERE finding_id IN (
+  'ed4f62b2-32a4-487c-b5cb-de091dd3b269',
+  '6196ae39-2195-4eaf-9ebb-d4ba51c4ddbe',
+  '104102f7-9c24-4f63-acb3-fa8fea16ed1c',
+  '18acec92-9188-4aff-bfae-8f3b96b353cb'
+)
+GROUP BY finding_id;

--- a/supabase/ops/inspect_latest_plan_for_findings.sql
+++ b/supabase/ops/inspect_latest_plan_for_findings.sql
@@ -1,0 +1,11 @@
+\set ON_ERROR_STOP on
+
+\echo '=== Latest plan for ed4f62b2 (npm-audit CVE finding) ==='
+SELECT version, files_referenced,
+       length(plan_markdown) AS md_len,
+       created_at,
+       left(plan_markdown, 2500) AS plan_excerpt
+FROM dev_autopilot_plan_versions
+WHERE finding_id = 'ed4f62b2-32a4-487c-b5cb-de091dd3b269'
+ORDER BY version DESC
+LIMIT 1;

--- a/supabase/ops/inspect_new_plan_for_ed4f62b2.sql
+++ b/supabase/ops/inspect_new_plan_for_ed4f62b2.sql
@@ -1,0 +1,9 @@
+\set ON_ERROR_STOP on
+
+\echo '=== Latest plan for ed4f62b2 (should include package.json now) ==='
+SELECT version, files_referenced, length(plan_markdown) AS md_len, created_at,
+       left(plan_markdown, 1500) AS plan_excerpt
+FROM dev_autopilot_plan_versions
+WHERE finding_id = 'ed4f62b2-32a4-487c-b5cb-de091dd3b269'
+ORDER BY version DESC
+LIMIT 1;

--- a/supabase/ops/inspect_scope.sql
+++ b/supabase/ops/inspect_scope.sql
@@ -1,0 +1,2 @@
+\set ON_ERROR_STOP on
+SELECT id, allow_scope, deny_scope FROM dev_autopilot_config WHERE id = 1;


### PR DESCRIPTION
## Why
PR #2000 made the safety gate scanner-aware and stripped the negative trap bullet from the prompt. But two pieces still bound the LLM into producing test-only PRs:

1. The prompt rendered the **base** allow_scope to the LLM, not the **effective** (scanner-overridden) one. So while the gate quietly accepted `**/package.json` for npm-audit, the LLM still saw an allow-scope that excluded it.
2. The prompt always said *'Do NOT list config files or dependency manifests'* — for npm-audit findings that sentence is actively wrong.

**Verified live:** plan v1 generated for finding ed4f62b2 (CVE: package.json) AFTER PR #2000 deployed still said *'automated edits to package.json and dependency manifests are strictly restricted'*. So the LLM faithfully avoided the file even after the gate was relaxed.

## Fix
- `buildPlanningPrompt` now uses `applyScannerOverrides` and renders the EFFECTIVE allow/deny.
- Adds a *'Canonical fix shape for this scanner (REQUIRED)'* section for npm-audit / cve / rls-policy / schema-drift findings: tells the LLM what the right fix looks like and that a test alone is insufficient.
- Makes the *'do NOT list config files'* sentence conditional so it doesn't contradict the per-scanner override.

## Tests
7 new cases (24 total passing).

## Operationally
Existing plans need regeneration (`lazyPlanTick` skips findings that already have a plan). Run `supabase/ops/force_plan_regen_for_unblocked_findings.sql` after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)