### PR TITLE
fix(autopilot): planner positive scanner guidance + effective scope shown to LLM

### DIFF
--- a/services/gateway/src/services/dev-autopilot-planning.ts
+++ b/services/gateway/src/services/dev-autopilot-planning.ts
@@ -40,6 +40,7 @@ import {
   loadSchemaSnippets,
   formatSchemaBlock,
 } from './dev-autopilot-schema-context';
+import { applyScannerOverrides } from './dev-autopilot-safety';
 
 const LOG_PREFIX = '[dev-autopilot-planning]';
 const PLAN_VTID = 'VTID-DEV-AUTOPILOT';
@@ -476,18 +477,89 @@ export function buildPlanningPrompt(
   // deny_scope, so a plan that puts config files in that section is
   // guaranteed to be blocked. Surface the constraint as part of the prompt
   // so Claude puts reference-only files in a separate section instead.
-  const allow = scope?.allow && scope.allow.length > 0 ? scope.allow : undefined;
-  const deny = scope?.deny && scope.deny.length > 0 ? scope.deny : undefined;
+  // Compute the EFFECTIVE allow/deny shown to the LLM using the same
+  // scanner-aware overrides the safety gate applies. Without this, the
+  // gate accepts a fix that touches `package.json` (per applyScannerOverrides)
+  // but the planner prompt still tells the LLM the file is out-of-scope, so
+  // the LLM correctly omits it and the resulting plan is the test-only PR
+  // we keep failing on.
+  const baseAllow = scope?.allow && scope.allow.length > 0 ? scope.allow : [];
+  const baseDeny = scope?.deny && scope.deny.length > 0 ? scope.deny : [];
+  const scannerForOverrides = String(snap.scanner || '');
+  const { effectiveAllow, effectiveDeny } = applyScannerOverrides(
+    baseAllow,
+    baseDeny,
+    scannerForOverrides,
+  );
+  const allow = effectiveAllow.length > 0 ? effectiveAllow : undefined;
+  const deny = effectiveDeny.length > 0 ? effectiveDeny : undefined;
+
+  // Positive guidance per scanner: tell the LLM what the canonical fix
+  // looks like for THIS scanner type. Without this, even with overrides,
+  // the LLM tends to default to "add a regression test, ask the developer
+  // to bump the version manually" — which is what produced PRs #1995-1998
+  // (test-only PRs that fail CI 100%).
+  const NPM_AUDIT_SCANNERS_LOCAL = new Set(['npm-audit-scanner-v1', 'cve-scanner-v1']);
+  const NEW_MIGRATION_SCANNERS_LOCAL = new Set([
+    'rls-policy-scanner-v1',
+    'schema-drift-scanner-v1',
+  ]);
+  if (NPM_AUDIT_SCANNERS_LOCAL.has(scannerForOverrides)) {
+    lines.push(
+      `## Canonical fix shape for this scanner (REQUIRED)`,
+      ``,
+      `This finding came from \`${scannerForOverrides}\`. The canonical fix`,
+      `for a CVE / dep-audit finding is to **bump the affected package**`,
+      `in the relevant \`package.json\` (and \`pnpm-lock.yaml\` if applicable).`,
+      `A regression test that asserts the new version is welcome but is NOT`,
+      `sufficient on its own — the test will fail CI 100% of the time until`,
+      `the manifest is updated, and the developer cannot merge a guaranteed-`,
+      `red PR.`,
+      ``,
+      `Your "Files to modify" list MUST include the relevant \`package.json\``,
+      `(typically \`services/gateway/package.json\`). The override on the`,
+      `safety gate explicitly allows this for your scanner — \`package.json\``,
+      `and \`pnpm-lock.yaml\` are NOT off-limits here.`,
+      ``,
+    );
+  }
+  if (NEW_MIGRATION_SCANNERS_LOCAL.has(scannerForOverrides)) {
+    lines.push(
+      `## Canonical fix shape for this scanner (REQUIRED)`,
+      ``,
+      `This finding came from \`${scannerForOverrides}\`. The canonical fix`,
+      `is a **new dated migration** under \`supabase/migrations/\` (filename`,
+      `\`YYYYMMDDHHMMSS_<purpose>.sql\`). Existing migrations are append-only`,
+      `(rule #1 above) — never modify them. The override on the safety gate`,
+      `explicitly allows you to ADD a new migration file for this scanner.`,
+      ``,
+      `Your "Files to modify" list MUST include the new migration file path.`,
+      `A test alone is not sufficient.`,
+      ``,
+    );
+  }
+
   if (allow || deny) {
+    // Tailor the introduction to the override status: when the scanner has
+    // legitimately allowed a config/dep file, the "do NOT list config files"
+    // sentence becomes wrong and confuses the LLM.
+    const hasManifestOverride = NPM_AUDIT_SCANNERS_LOCAL.has(scannerForOverrides);
+    const hasMigrationOverride = NEW_MIGRATION_SCANNERS_LOCAL.has(scannerForOverrides);
     lines.push(
       `## Scope constraints (enforced automatically — violations block approval)`,
       ``,
       `The "Files to modify" section must contain ONLY paths that the executor`,
-      `will actually create, modify, or delete. Do NOT list config files or`,
-      `dependency manifests there for the developer to "double-check" — put`,
-      `those as plain-text notes in the Out-of-scope section instead.`,
+      `will actually create, modify, or delete.`,
       ``,
     );
+    if (!hasManifestOverride && !hasMigrationOverride) {
+      lines.push(
+        `Do NOT list config files or dependency manifests there for the`,
+        `developer to "double-check" — put those as plain-text notes in the`,
+        `Out-of-scope section instead.`,
+        ``,
+      );
+    }
     if (allow) {
       lines.push(`Files to modify MUST match one of these allow-scope globs:`);
       for (const g of allow) lines.push(`  - \`${g}\``);

--- a/services/gateway/test/dev-autopilot-scanner-aware-traps.test.ts
+++ b/services/gateway/test/dev-autopilot-scanner-aware-traps.test.ts
@@ -223,3 +223,64 @@ describe('buildPlanningPrompt — scanner-aware traps', () => {
     expect(prompt).not.toMatch(/Any `\.github\/workflows\/\*` file/);
   });
 });
+
+describe('buildPlanningPrompt — positive scanner guidance + effective scope', () => {
+  function expectPromptFor(scanner: string): string {
+    return buildPlanningPrompt(
+      {
+        ...BASE_FINDING,
+        spec_snapshot: { scanner },
+      } as Parameters<typeof buildPlanningPrompt>[0],
+      undefined,
+      undefined,
+      BASE_SCOPE,
+    );
+  }
+
+  it('npm-audit: prompt explicitly REQUIRES bumping package.json', () => {
+    const prompt = expectPromptFor('npm-audit-scanner-v1');
+    expect(prompt).toMatch(/Canonical fix shape for this scanner \(REQUIRED\)/);
+    expect(prompt).toMatch(/bump the affected package/);
+    expect(prompt).toMatch(/MUST include the relevant `package\.json`/);
+    expect(prompt).toMatch(/A regression test that asserts the new version is welcome but is NOT/);
+    expect(prompt).toMatch(/sufficient on its own/);
+  });
+
+  it('npm-audit: effective allow-scope shows package.json and pnpm-lock.yaml', () => {
+    const prompt = expectPromptFor('npm-audit-scanner-v1');
+    // The displayed allow-scope list must include the override entries
+    // so the LLM can place package.json in Files to modify.
+    expect(prompt).toMatch(/`\*\*\/package\.json`/);
+    expect(prompt).toMatch(/`\*\*\/pnpm-lock\.yaml`/);
+  });
+
+  it('npm-audit: prompt does NOT contain the now-wrong "do NOT list config files" sentence', () => {
+    const prompt = expectPromptFor('npm-audit-scanner-v1');
+    expect(prompt).not.toMatch(/Do NOT list config files or dependency manifests/);
+  });
+
+  it('todo finding: positive guidance section is NOT included', () => {
+    const prompt = expectPromptFor('todo-scanner-v1');
+    expect(prompt).not.toMatch(/Canonical fix shape for this scanner \(REQUIRED\)/);
+  });
+
+  it('todo finding: still has the "do NOT list config files" sentence', () => {
+    const prompt = expectPromptFor('todo-scanner-v1');
+    expect(prompt).toMatch(/Do NOT list config files or dependency manifests/);
+  });
+
+  it('rls-policy: positive guidance about adding a new dated migration', () => {
+    const prompt = expectPromptFor('rls-policy-scanner-v1');
+    expect(prompt).toMatch(/Canonical fix shape for this scanner \(REQUIRED\)/);
+    expect(prompt).toMatch(/new dated migration/);
+    expect(prompt).toMatch(/YYYYMMDDHHMMSS_<purpose>\.sql/);
+    expect(prompt).toMatch(/MUST include the new migration file path/);
+  });
+
+  it('rls-policy: effective deny-scope DOES NOT contain supabase/migrations/**', () => {
+    const prompt = expectPromptFor('rls-policy-scanner-v1');
+    // Find the deny-scope section and check the migration glob is not in it
+    const denySection = prompt.match(/MUST NOT match[^]*?(?=\n\n|$)/)?.[0] || '';
+    expect(denySection).not.toMatch(/`supabase\/migrations\/\*\*`/);
+  });
+});


### PR DESCRIPTION
## Why
PR #2000 made the safety gate scanner-aware and stripped the negative trap bullet. But two pieces still bound the LLM into producing test-only PRs:

1. The prompt rendered the **base** allow_scope to the LLM, not the **effective** (scanner-overridden) one.
2. The prompt always said *'Do NOT list config files or dependency manifests'* — for npm-audit findings that sentence is actively wrong.

**Verified live:** plan v1 generated for ed4f62b2 (CVE: package.json) AFTER PR #2000 deployed still said *'automated edits to package.json and dependency manifests are strictly restricted'*. The LLM faithfully avoided the file even after the gate was relaxed.

## Fix
- `buildPlanningPrompt` now uses `applyScannerOverrides` and renders the EFFECTIVE allow/deny.
- Adds a 'Canonical fix shape for this scanner (REQUIRED)' section for npm-audit / cve / rls-policy / schema-drift findings.
- Makes the 'do NOT list config files' sentence conditional.

## Tests
7 new cases (24 total passing).

## Operationally
Existing plans need regeneration — `lazyPlanTick` skips findings that already have a plan. Use `supabase/ops/force_plan_regen_for_unblocked_findings.sql` after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)