### PR TITLE
fix(VTID-02851): German still silent — livekit-plugins-google can't drive Neural2 voices, revert to Chirp3-HD

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/providers.py
+++ b/services/agents/orb-agent/src/orb_agent/providers.py
@@ -108,22 +108,26 @@ def _resolve_bcp47(lang: str | None) -> str:
 
 LANG_DEFAULTS: dict[str, dict[str, str]] = {
     "google_tts": {
-        # English Chirp3-HD is GA on Cloud TTS REST and works empirically
-        # (user confirmed). Other languages: prefer Neural2 / Wavenet which
-        # the Vertex pipeline already ships against (NEURAL2_TTS_VOICES in
-        # orb-live.ts) — verified-working voices. Chirp3-HD outside en-US
-        # is partially rolled out and silently fails for some locales when
-        # called via the Cloud TTS REST endpoint (gives a working
-        # construction but no audio at synth time).
+        # MUST use Chirp3-HD voice names. The livekit-plugins-google TTS
+        # class auto-selects the underlying TTS model from voice_name:
+        #   - "chirp" in voice_name → model_name="chirp_3"
+        #   - else                  → model_name="gemini-2.5-flash-tts"
+        # Neural2/Wavenet voices fall into the second branch, but Cloud TTS
+        # rejects voice="de-DE-Neural2-G" + model="gemini-2.5-flash-tts" as
+        # an invalid pair → silent 400 → no audio. Chirp3-HD voices ARE
+        # GA on Cloud TTS REST for all 9 languages below; the previous
+        # "no audio for German" was caused by row-seeded language_code +
+        # missing system-prompt language threading (fixed in PR-1.B-Lang-4),
+        # not the voice itself.
         "en": "en-US-Chirp3-HD-Aoede",
-        "de": "de-DE-Neural2-G",
-        "es": "es-ES-Neural2-A",
-        "fr": "fr-FR-Neural2-A",
-        "it": "it-IT-Neural2-A",
-        "pt": "pt-BR-Neural2-A",
-        "nl": "nl-NL-Wavenet-A",  # Neural2 not GA for nl-NL
-        "sv": "sv-SE-Wavenet-A",  # Neural2 not GA for sv-SE
-        "pl": "pl-PL-Wavenet-A",  # Neural2 not GA for pl-PL
+        "de": "de-DE-Chirp3-HD-Aoede",
+        "es": "es-ES-Chirp3-HD-Aoede",
+        "fr": "fr-FR-Chirp3-HD-Aoede",
+        "it": "it-IT-Chirp3-HD-Aoede",
+        "pt": "pt-BR-Chirp3-HD-Aoede",
+        "nl": "nl-NL-Chirp3-HD-Aoede",
+        "sv": "sv-SE-Chirp3-HD-Aoede",
+        "pl": "pl-PL-Chirp3-HD-Aoede",
     },
     # Cartesia Sonic-3 is multilingual — same voice handle works across
     # languages, the model auto-detects from the input text. Documented at


### PR DESCRIPTION
## Real root cause #3 — found by reading the plugin source

`livekit-plugins-google` v1.5.8, `tts.py:142-162`:

\`\`\`python
if not is_given(model_name):
    if "chirp" in voice_name.lower():
        model_name = "chirp_3"
    else:
        model_name = "gemini-2.5-flash-tts"   # ← auto-selected for non-Chirp voices
if model_name != "chirp_3":
    voice_params.model_name = model_name      # ← sent to Cloud TTS
\`\`\`

The plugin pinch-points every voice into either the **chirp_3** model or the **gemini-2.5-flash-tts** model. Voice names without `"chirp"` in them auto-fall to `gemini-2.5-flash-tts`. Cloud TTS receives `voice="de-DE-Neural2-G" + model="gemini-2.5-flash-tts"` → **invalid pair** → silent 400 → no audio.

PR-1.B-Lang-3 (#1994) switched to Neural2 because Vertex's `NEURAL2_TTS_VOICES` map worked for German. But Vertex calls Cloud TTS through `@google-cloud/text-to-speech` directly, not through `livekit-plugins-google`. The plugin doesn't expose Neural2/Wavenet voices.

## Fix

Switch every language back to `Chirp3-HD-Aoede` (with locale prefix). The plugin sees `"chirp"` in the name → uses `model_name="chirp_3"` → Cloud TTS serves it. Chirp3-HD voices are GA for all 9 languages per Google's catalog.

The original "no audio for German with Chirp3-HD-Aoede" was caused by the **other two bugs** (PR-1.B-Lang-4 / #1999):
- System prompt built for English (bootstrap fetch didn't pass `lang`)
- STT row-locked to `languages: ['en-US']`

Both fixed. With those fixed + Chirp3-HD-Aoede German voice, German should now work.

## Verification

- `python3 -m py_compile` (orb-agent) — clean.
- `_resolve_tts_voice('google_tts', ..., 'de')` → `'de-DE-Chirp3-HD-Aoede'`.
- VTID: VTID-02851.

## Test plan

- [ ] LiveKit test page → pick **Deutsch (de)** → Connect → speak German → agent transcribes German, replies in German via `de-DE-Chirp3-HD-Aoede`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)