### PR TITLE
DEV-AUTOPILOT: Bump @modelcontextprotocol/sdk to mitigate ReDoS (>=1.25.2)

### DIFF
--- a/services/gateway/package.json
+++ b/services/gateway/package.json
@@ -22,7 +22,7 @@
     "@google-cloud/text-to-speech": "^5.5.0",
     "@google-cloud/vertexai": "^1.9.2",
     "@google/generative-ai": "^0.24.1",
-    "@modelcontextprotocol/sdk": "^0.5.0",
+    "@modelcontextprotocol/sdk": "^1.25.2",
     "@playwright/test": "^1.40.0",
     "@supabase/supabase-js": "^2.80.0",
     "cors": "^2.8.5",

--- a/services/gateway/test/mcp-sdk-version.test.ts
+++ b/services/gateway/test/mcp-sdk-version.test.ts
@@ -1,0 +1,32 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('MCP SDK Version Verification', () => {
+  it('should explicitly use @modelcontextprotocol/sdk version 1.25.2 or higher to prevent ReDoS', () => {
+    const pkgPath = path.resolve(__dirname, '../package.json');
+    const pkgJson = JSON.parse(fs.readFileSync(pkgPath, 'utf-8'));
+    const mcpVersion: string = pkgJson.dependencies['@modelcontextprotocol/sdk'];
+
+    expect(mcpVersion).toBeDefined();
+
+    // Must not be a 0.x version to prevent regressions
+    expect(mcpVersion).not.toMatch(/^[~^]?0\./);
+
+    const cleanVersion = mcpVersion.replace(/^[~^]/, '');
+    const [majorStr, minorStr, patchStr] = cleanVersion.split('.');
+    
+    const major = parseInt(majorStr, 10);
+    const minor = parseInt(minorStr, 10);
+    const patch = parseInt(patchStr, 10);
+
+    expect(major).toBeGreaterThanOrEqual(1);
+
+    if (major === 1) {
+      if (minor === 25) {
+        expect(patch).toBeGreaterThanOrEqual(2);
+      } else {
+        expect(minor).toBeGreaterThan(25);
+      }
+    }
+  });
+});


### PR DESCRIPTION
This PR addresses a Regular Expression Denial of Service (ReDoS) vulnerability in `@modelcontextprotocol/sdk` (currently on `^0.5.0`) flagged by `npm-audit-scanner-v1`.

### Changes made
- Bumped `@modelcontextprotocol/sdk` in `services/gateway/package.json` to securely constrain it at version `^1.25.2`.
- Added a regression unit test in `services/gateway/test/mcp-sdk-version.test.ts` to statically enforce the safe constraint for future updates and prevent accidental rollbacks.

### Operator Actions Needed
The automated execution cannot securely regenerate the lockfile natively. After merging or checking out this branch, please run:
```bash
pnpm install
```
or the equivalent package manager command from the monorepo root to lock `pnpm-lock.yaml` with the upgraded transitive dependencies before proceeding.