### PR TITLE
DEV-AUTOPILOT: Bump @modelcontextprotocol/sdk to ^1.25.2 to fix ReDoS

### DIFF
--- a/services/gateway/package.json
+++ b/services/gateway/package.json
@@ -22,7 +22,7 @@
     "@google-cloud/text-to-speech": "^5.5.0",
     "@google-cloud/vertexai": "^1.9.2",
     "@google/generative-ai": "^0.24.1",
-    "@modelcontextprotocol/sdk": "^0.5.0",
+    "@modelcontextprotocol/sdk": "^1.25.2",
     "@playwright/test": "^1.40.0",
     "@supabase/supabase-js": "^2.80.0",
     "cors": "^2.8.5",

--- a/services/gateway/test/mcp-sdk-version.test.ts
+++ b/services/gateway/test/mcp-sdk-version.test.ts
@@ -1,0 +1,33 @@
+import fs from 'fs';
+import path from 'path';
+
+describe('MCP SDK Version', () => {
+  it('should use @modelcontextprotocol/sdk version 1.25.2 or greater to prevent ReDoS', () => {
+    const pkgPath = path.join(__dirname, '..', 'package.json');
+    const pkg = JSON.parse(fs.readFileSync(pkgPath, 'utf8'));
+    
+    const mcpVersion = pkg.dependencies['@modelcontextprotocol/sdk'];
+    
+    expect(mcpVersion).toBeDefined();
+    expect(mcpVersion.startsWith('^0.')).toBe(false);
+    expect(mcpVersion.startsWith('~0.')).toBe(false);
+    expect(mcpVersion.startsWith('0.')).toBe(false);
+    
+    // Match version string like "^1.25.2", "~1.25.2", or "1.25.2"
+    const match = mcpVersion.match(/^[^\d]*(\d+)\.(\d+)\.(\d+)/);
+    expect(match).not.toBeNull();
+    
+    if (match) {
+      const major = parseInt(match[1], 10);
+      const minor = parseInt(match[2], 10);
+      const patch = parseInt(match[3], 10);
+      
+      const isAtLeast1_25_2 = 
+        major > 1 || 
+        (major === 1 && minor > 25) || 
+        (major === 1 && minor === 25 && patch >= 2);
+        
+      expect(isAtLeast1_25_2).toBe(true);
+    }
+  });
+});


### PR DESCRIPTION
This PR updates the `@modelcontextprotocol/sdk` dependency from `^0.5.0` to `^1.25.2` in the gateway service to mitigate a Regular Expression Denial of Service (ReDoS) vulnerability reported by `npm-audit-scanner-v1`.

A test has been added to statically verify the manifest version and prevent accidental regressions or rollbacks in the future.

**Note to operator:** Please run `pnpm install` from the monorepo root to regenerate and update `pnpm-lock.yaml` with the locked transitive dependencies, as lockfile regeneration is omitted from this automated plan execution. Additionally, run a root-level `pnpm audit` to verify if other packages need a bump.

Files touched:
- `services/gateway/package.json`
- `services/gateway/test/mcp-sdk-version.test.ts`