### PR TITLE
feat(VTID-02853 / DEV-COMHU-2853): voice selector on LiveKit test page + warmer German default

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/providers.py
+++ b/services/agents/orb-agent/src/orb_agent/providers.py
@@ -120,7 +120,11 @@ LANG_DEFAULTS: dict[str, dict[str, str]] = {
         # missing system-prompt language threading (fixed in PR-1.B-Lang-4),
         # not the voice itself.
         "en": "en-US-Chirp3-HD-Aoede",
-        "de": "de-DE-Chirp3-HD-Aoede",
+        # PR-VTID-02853: Leda described as "soft, narrative" in Google's
+        # Chirp3-HD catalog — warmer / more human-like than Aoede's neutral
+        # tone. User feedback after first German session: Aoede sounded
+        # robotic.
+        "de": "de-DE-Chirp3-HD-Leda",
         "es": "es-ES-Chirp3-HD-Aoede",
         "fr": "fr-FR-Chirp3-HD-Aoede",
         "it": "it-IT-Chirp3-HD-Aoede",
@@ -189,7 +193,12 @@ def _resolve_tts_voice(
     return fallback_model, False
 
 
-def build_cascade(voice_config: dict[str, Any] | None, lang: str | None = None) -> ResolvedCascade:
+def build_cascade(
+    voice_config: dict[str, Any] | None,
+    lang: str | None = None,
+    *,
+    voice_override: str | None = None,
+) -> ResolvedCascade:
     """Instantiate the STT/LLM/TTS plugins per the agent_voice_configs row.
 
     voice_config shape (matches PR #3 migration):
@@ -238,6 +247,7 @@ def build_cascade(voice_config: dict[str, Any] | None, lang: str | None = None) 
         notes,
         lang=resolved_lang,
         bcp47=bcp47,
+        voice_override=voice_override,
     )
     return ResolvedCascade(stt=stt, llm=llm, tts=tts, notes=notes)
 
@@ -356,6 +366,7 @@ def _build_tts(
     *,
     lang: str = "en",
     bcp47: str = "en-US",
+    voice_override: str | None = None,
 ) -> _TTSPlugin | None:
     """Construct the configured TTS plugin with a per-language voice.
 
@@ -363,10 +374,19 @@ def _build_tts(
     is resolved via _resolve_tts_voice (operator override → LANG_DEFAULTS
     → row's tts_model). For Google TTS the `language` kwarg is also
     resolved from BCP-47 so prosody matches the voice.
+
+    `voice_override` is a per-session voice name (passed in via the
+    LiveKit token metadata from the test page's voice dropdown). When set,
+    skip the LANG_DEFAULTS lookup and use it directly. Treated as
+    language_locked so the row-seeded language_code can't mismatch.
     """
-    voice, language_locked = _resolve_tts_voice(provider, model, options or {}, lang)
-    if voice and model and voice != model:
-        notes.append(f"tts: resolved voice {voice} for lang={lang} (row model={model})")
+    if voice_override:
+        voice, language_locked = voice_override, True
+        notes.append(f"tts: voice_override={voice_override} (per-session)")
+    else:
+        voice, language_locked = _resolve_tts_voice(provider, model, options or {}, lang)
+        if voice and model and voice != model:
+            notes.append(f"tts: resolved voice {voice} for lang={lang} (row model={model})")
 
     # Strip voices_per_lang from options since plugins won't accept it.
     opts_base = dict(options or {})

--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -183,6 +183,15 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     identity = resolve_identity_from_room_metadata(metadata)
     agent_id = str(metadata.get("agent_id", "vitana"))
     orb_session_id = str(metadata.get("orb_session_id", ""))
+    # PR-VTID-02853: per-session voice override from the LiveKit test page
+    # dropdown. None / empty string means "use the language default from
+    # LANG_DEFAULTS." Operators experiment with different Chirp3-HD
+    # personas (Aoede / Kore / Leda / Charon / etc.) without a code-deploy
+    # cycle by picking from the dropdown — the value flows token mint →
+    # AccessToken metadata → here → build_cascade(voice_override=…).
+    voice_override = metadata.get("voice_override") or None
+    if voice_override is not None:
+        voice_override = str(voice_override).strip() or None
 
     # GatewayClient carries the user JWT (Bearer) PLUS X-User-ID /
     # X-Tenant-ID / X-Vitana-Active-Role headers as defense-in-depth for
@@ -242,7 +251,7 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     # the matching BCP-47 code and TTS picks a per-language voice via
     # voices_per_lang / LANG_DEFAULTS. Without this, German users get
     # English STT models + an English Chirp speaking German text.
-    cascade = build_cascade(bootstrap.voice_config, lang=identity.lang)
+    cascade = build_cascade(bootstrap.voice_config, lang=identity.lang, voice_override=voice_override)
     cascade_summary = {
         "stt_present": cascade.stt is not None,
         "llm_present": cascade.llm is not None,

--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -35115,6 +35115,68 @@ function renderLivekitTestView() {
     var langSelect = controls.querySelector('.lkt-lang');
     langSelect.addEventListener('change', function () {
         try { localStorage.setItem('lkt.lang', langSelect.value); } catch (e) {}
+        rebuildVoiceOptions();
+    });
+
+    // PR-VTID-02853: voice-override row. The dropdown rebuilds on language
+    // change to scope Chirp3-HD options to the selected locale (each
+    // persona only exists for that locale's voice). Gemini TTS voices are
+    // multilingual — same names work across all languages, the model
+    // detects from text — so they appear in the dropdown regardless.
+    var voiceRow = document.createElement('div');
+    voiceRow.style.cssText = 'display:flex;gap:8px;margin-bottom:16px;align-items:center;flex-wrap:wrap;font-size:12px;color:#94a3b8;';
+    voiceRow.innerHTML = '<span style="margin-right:4px;">VOICE:</span>'
+        + '<select class="lkt-voice" title="TTS voice override (Chirp3-HD has 8 personas per language; Gemini TTS personas are multilingual)" style="padding:8px;background:#0f172a;color:#e5e7eb;border:1px solid #334155;border-radius:4px;min-width:280px;">'
+        + '</select>'
+        + '<span style="font-size:11px;opacity:0.7;">— restart the session for voice change to take effect</span>';
+    container.appendChild(voiceRow);
+    var voiceSelect = voiceRow.querySelector('.lkt-voice');
+
+    var CHIRP_PERSONAS = [
+        ['Aoede', 'F · clear, neutral'],
+        ['Kore', 'F · warm, conversational'],
+        ['Leda', 'F · soft, narrative'],
+        ['Zephyr', 'F · bright, expressive'],
+        ['Charon', 'M · deep, calm'],
+        ['Puck', 'M · energetic, casual'],
+        ['Fenrir', 'M · bold, assertive'],
+        ['Orus', 'M · smooth, broadcast'],
+    ];
+    var BCP47_FOR_LANG = {
+        en: 'en-US', de: 'de-DE', es: 'es-ES', fr: 'fr-FR', it: 'it-IT',
+        pt: 'pt-BR', nl: 'nl-NL', sv: 'sv-SE', pl: 'pl-PL',
+    };
+
+    function rebuildVoiceOptions() {
+        var saved = '';
+        try { saved = localStorage.getItem('lkt.voice') || ''; } catch (e) {}
+        var lang = langSelect.value || 'en';
+        var bcp47 = BCP47_FOR_LANG[lang] || (lang + '-' + lang.toUpperCase());
+        var html = '<option value="">(default — Aoede for en, Leda for de, Aoede for others)</option>';
+        // Chirp3-HD voices, scoped to the selected language.
+        html += '<optgroup label="Chirp3-HD · ' + bcp47 + '">';
+        for (var i = 0; i < CHIRP_PERSONAS.length; i++) {
+            var name = CHIRP_PERSONAS[i][0];
+            var hint = CHIRP_PERSONAS[i][1];
+            var voice = bcp47 + '-Chirp3-HD-' + name;
+            var sel = voice === saved ? ' selected' : '';
+            html += '<option value="' + voice + '"' + sel + '>' + voice + ' — ' + hint + '</option>';
+        }
+        html += '</optgroup>';
+        // Gemini TTS voices (multilingual).
+        html += '<optgroup label="Gemini TTS · multilingual">';
+        for (var j = 0; j < CHIRP_PERSONAS.length; j++) {
+            var gname = CHIRP_PERSONAS[j][0];
+            var ghint = CHIRP_PERSONAS[j][1];
+            var gsel = gname === saved ? ' selected' : '';
+            html += '<option value="' + gname + '"' + gsel + '>' + gname + ' — ' + ghint + '</option>';
+        }
+        html += '</optgroup>';
+        voiceSelect.innerHTML = html;
+    }
+    rebuildVoiceOptions();
+    voiceSelect.addEventListener('change', function () {
+        try { localStorage.setItem('lkt.voice', voiceSelect.value); } catch (e) {}
     });
 
     // Diagnostics panel — fed by the "Run Diagnostics" button below.
@@ -35803,13 +35865,22 @@ function renderLivekitTestView() {
             var langEl = container.querySelector('.lkt-lang');
             if (langEl && langEl.value) selectedLang = langEl.value;
         } catch (e) {}
+        // PR-VTID-02853: voice override from the .lkt-voice dropdown — empty
+        // string means "use language default from LANG_DEFAULTS".
+        var selectedVoice = '';
+        try {
+            var voiceEl = container.querySelector('.lkt-voice');
+            if (voiceEl && voiceEl.value) selectedVoice = voiceEl.value;
+        } catch (e) {}
         var url, body;
         if (mode === 'test-session') {
             url = (window.GATEWAY_URL || '') + '/api/v1/agents/' + encodeURIComponent(agentId) + '/voice-config/test-session';
             body = { lang: selectedLang };
+            if (selectedVoice) body.voice_override = selectedVoice;
         } else {
             url = (window.GATEWAY_URL || '') + '/api/v1/orb/livekit/token';
             body = { lang: selectedLang, agent_id: agentId };
+            if (selectedVoice) body.voice_override = selectedVoice;
         }
         log('event', 'POST ' + url);
         var res = await fetch(url, {

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -30,7 +30,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260504-vtid-02710-ios-ctx-keepalive"></script>
-  <script src="/command-hub/app.js?v=20260508-livekit-lang-selector"></script>
+  <script src="/command-hub/app.js?v=20260508-livekit-voice-selector"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
 </body>

--- a/services/gateway/src/routes/orb-livekit.ts
+++ b/services/gateway/src/routes/orb-livekit.ts
@@ -283,6 +283,13 @@ interface MintTokenBody {
   lang?: string;
   agent_id?: string;
   voice_style?: string;
+  // PR-VTID-02853: per-session voice override from the LiveKit test page
+  // dropdown. Embedded in the AccessToken metadata; the agent reads it and
+  // hands to build_cascade(voice_override=…). Examples:
+  //   "de-DE-Chirp3-HD-Leda"  (Chirp3-HD German persona)
+  //   "Kore"                  (Gemini TTS multilingual voice)
+  // Empty / absent → use language default from LANG_DEFAULTS.
+  voice_override?: string;
 }
 
 router.post(
@@ -314,6 +321,9 @@ router.post(
     const body = (req.body ?? {}) as MintTokenBody;
     const lang = body.lang || 'en';
     const agentId = body.agent_id || 'vitana';
+    const voiceOverride = typeof body.voice_override === 'string' && body.voice_override.trim().length > 0
+      ? body.voice_override.trim()
+      : null;
     const isAnonymous = !req.identity;
     const userId = req.identity?.user_id ?? `anon-${randomUUID()}`;
     const tenantId = req.identity?.tenant_id ?? '';
@@ -346,6 +356,7 @@ router.post(
         agent_id: agentId,
         orb_session_id: orbSessionId,
         vitana_id: req.identity?.vitana_id ?? null,
+        voice_override: voiceOverride,
         // VTID-LIVEKIT-AGENT-JWT: the orb-agent extracts this and uses it as
         // Bearer for every gateway tool call. Same secret/shape as the
         // user's normal JWT — existing optionalAuth/requireAuth middleware
@@ -895,6 +906,9 @@ router.post(
     // TTS voice. Without this, every test-session falls back to en-US even
     // when the user picked German in the LiveKit test page dropdown.
     const lang = typeof proposed.lang === 'string' && proposed.lang ? proposed.lang : 'en';
+    const voiceOverride = typeof proposed.voice_override === 'string' && proposed.voice_override.trim().length > 0
+      ? proposed.voice_override.trim()
+      : null;
     const roomName = `orb-test-${id}-${Date.now()}`;
 
     const agentUserJwt = req.identity ? await mintAgentSessionJwt(req.identity) : null;
@@ -911,6 +925,7 @@ router.post(
         is_test_session: true,
         proposed_voice_config: proposed,
         vitana_id: req.identity?.vitana_id ?? null,
+        voice_override: voiceOverride,
         user_jwt: agentUserJwt,
       }),
     });


### PR DESCRIPTION
## Summary

User feedback after first working German session: *\"Aoede sounds robotic, no emotion.\"*

1. **New default German voice**: `de-DE-Chirp3-HD-Leda` (\"soft, narrative\" per Google's catalog — warmer than Aoede).
2. **Voice selector on the test page**: A/B-test all 16 voices without a code-deploy cycle.

## Voice selector

- 8 Chirp3-HD personas per language: Aoede / Kore / Leda / Zephyr (F) + Charon / Puck / Fenrir / Orus (M).
- 8 Gemini TTS multilingual voices (same names, no locale prefix; uses `gemini-2.5-flash-tts` model).
- Dropdown rebuilds on language change to scope Chirp3-HD options to the selected locale.
- Selection persists in `localStorage.lkt.voice`.

## Wiring

`test-page dropdown → body.voice_override → POST /orb/livekit/token (or /test-session) → AccessToken.metadata.voice_override → session.py → build_cascade(voice_override=…) → providers.py _build_tts uses it directly (treated as language_locked so row's en-US can't mismatch)`.

Empty / unset value → falls back to LANG_DEFAULTS (current behaviour).

## Files

- `providers.py`: LANG_DEFAULTS de → Leda; `build_cascade` + `_build_tts` accept `voice_override` kwarg.
- `session.py`: reads `metadata.voice_override`, passes through.
- `orb-livekit.ts`: both mint endpoints accept + embed `voice_override`.
- `app.js`: new `.lkt-voice` `<select>` row; threads to body.
- `index.html`: cachebuster bump (`20260508-livekit-voice-selector`) so the new UI lands without hard refresh.

## Verification

- `python3 -m py_compile` (orb-agent) — clean.
- `npm run build` (gateway) — clean.
- VTID: VTID-02853 / DEV-COMHU-2853.

## Test plan

- [ ] Hard-refresh test page, see new \"VOICE:\" dropdown.
- [ ] Default (empty) + lang=de → next session uses Leda. Confirm via `/api/v1/orb/agent-trace/recent` — `cascade_summary.notes` shows `de-DE-Chirp3-HD-Leda`.
- [ ] Pick `de-DE-Chirp3-HD-Charon` → next session note shows `voice_override=de-DE-Chirp3-HD-Charon`.
- [ ] Pick `Kore` (Gemini TTS) → next session uses multilingual Kore voice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)