### PR TITLE
feat(voice): Awareness Watchdogs sub-tab (VTID-02859)

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -41732,9 +41732,162 @@ function vpStyleInput(el) {
     el.style.cssText = 'padding:0.45rem 0.6rem;background:var(--color-surface);color:var(--color-text-primary);border:1px solid var(--color-border);border-radius:6px;font-size:0.85rem;';
 }
 
+// VTID-02859: Awareness Watchdogs table — fetches per-watchdog status from
+// /api/v1/voice/awareness/watchdogs and renders pass/fail/partial verdicts
+// with last-run timestamps and the signal keys each watchdog covers.
+function renderAwarenessWatchdogsTable() {
+    var c = document.createElement('div');
+    c.style.cssText = 'padding:1.5rem;';
+
+    var h = document.createElement('h3');
+    h.style.margin = '0 0 0.5rem 0';
+    h.textContent = 'Awareness Watchdogs';
+    c.appendChild(h);
+
+    var sub = document.createElement('p');
+    sub.className = 'section-subtitle';
+    sub.textContent = 'Continuous checks that verify each awareness signal is firing on production sessions.';
+    c.appendChild(sub);
+
+    if (!state.awarenessWatchdogs) {
+        state.awarenessWatchdogs = { loaded: false, loading: false, error: null, rows: [] };
+    }
+    var w = state.awarenessWatchdogs;
+
+    if (!w.loaded && !w.loading) {
+        w.loading = true;
+        fetch('/api/v1/voice/awareness/watchdogs', { headers: buildContextHeaders() })
+            .then(function (r) { return r.json(); })
+            .then(function (resp) {
+                w.loading = false;
+                if (resp && resp.ok) {
+                    w.rows = resp.watchdogs || [];
+                    w.loaded = true;
+                } else {
+                    w.error = (resp && resp.error) || 'failed to load';
+                }
+                renderApp();
+            })
+            .catch(function (err) {
+                w.loading = false;
+                w.error = err.message || String(err);
+                renderApp();
+            });
+    }
+
+    if (w.loading && !w.loaded) {
+        var l = document.createElement('div');
+        l.className = 'placeholder-content';
+        l.textContent = 'Loading watchdogs…';
+        c.appendChild(l);
+        return c;
+    }
+    if (w.error) {
+        var e = document.createElement('div');
+        e.className = 'placeholder-content error-text';
+        e.textContent = 'Error: ' + w.error;
+        c.appendChild(e);
+        return c;
+    }
+
+    var refreshBtn = document.createElement('button');
+    refreshBtn.className = 'task-spec-pipeline-btn';
+    refreshBtn.textContent = '⟳ Refresh';
+    refreshBtn.style.marginBottom = '1rem';
+    refreshBtn.onclick = function () { w.loaded = false; renderApp(); };
+    c.appendChild(refreshBtn);
+
+    var table = document.createElement('table');
+    table.style.cssText = 'width:100%;border-collapse:collapse;font-size:.8rem;';
+    var thead = document.createElement('thead');
+    thead.innerHTML = '<tr style="text-align:left;border-bottom:1px solid var(--color-border);">'
+        + '<th style="padding:.5rem;">Watchdog</th>'
+        + '<th style="padding:.5rem;">Verdict</th>'
+        + '<th style="padding:.5rem;">Last run</th>'
+        + '<th style="padding:.5rem;">Watches</th>'
+        + '</tr>';
+    table.appendChild(thead);
+    var tbody = document.createElement('tbody');
+    (w.rows || []).forEach(function (row) {
+        var tr = document.createElement('tr');
+        tr.style.cssText = 'border-bottom:1px solid var(--color-border);';
+
+        var nameCell = document.createElement('td');
+        nameCell.style.cssText = 'padding:.5rem;vertical-align:top;';
+        var nameStrong = document.createElement('strong');
+        nameStrong.textContent = (row.watchdog && row.watchdog.name) || row.watchdog.id;
+        nameCell.appendChild(nameStrong);
+        if (row.watchdog && row.watchdog.description) {
+            var d = document.createElement('div');
+            d.style.cssText = 'font-size:.7rem;color:var(--color-text-secondary);';
+            d.textContent = row.watchdog.description;
+            nameCell.appendChild(d);
+        }
+        if (row.last_result_summary) {
+            var sumDiv = document.createElement('div');
+            sumDiv.style.cssText = 'font-size:.65rem;color:var(--color-text-secondary);margin-top:.2rem;';
+            sumDiv.textContent = row.last_result_summary;
+            nameCell.appendChild(sumDiv);
+        }
+        tr.appendChild(nameCell);
+
+        var verdictCell = document.createElement('td');
+        verdictCell.style.cssText = 'padding:.5rem;vertical-align:top;';
+        var badge = document.createElement('span');
+        badge.style.cssText = 'padding:.15rem .45rem;border-radius:4px;font-size:.7rem;';
+        if (row.verdict === 'pass') {
+            badge.textContent = '✓ pass';
+            badge.style.color = '#22c55e';
+            badge.style.background = 'rgba(34,197,94,.12)';
+        } else if (row.verdict === 'fail') {
+            badge.textContent = '✗ fail';
+            badge.style.color = '#dc2626';
+            badge.style.background = 'rgba(220,38,38,.12)';
+        } else if (row.verdict === 'partial') {
+            badge.textContent = '⚠ partial';
+            badge.style.color = '#a16207';
+            badge.style.background = 'rgba(234,179,8,.12)';
+        } else {
+            badge.textContent = '? unknown';
+            badge.style.color = 'var(--color-text-secondary)';
+            badge.style.background = 'var(--color-bg)';
+        }
+        verdictCell.appendChild(badge);
+        tr.appendChild(verdictCell);
+
+        var lastCell = document.createElement('td');
+        lastCell.style.cssText = 'padding:.5rem;vertical-align:top;font-family:monospace;font-size:.7rem;color:var(--color-text-secondary);';
+        lastCell.textContent = row.last_run_at ? new Date(row.last_run_at).toLocaleString() : '—';
+        tr.appendChild(lastCell);
+
+        var watchesCell = document.createElement('td');
+        watchesCell.style.cssText = 'padding:.5rem;vertical-align:top;';
+        var watches = (row.watchdog && row.watchdog.watches) || [];
+        watches.forEach(function (k) {
+            var code = document.createElement('code');
+            code.textContent = k;
+            code.style.cssText = 'font-size:.65rem;background:var(--color-bg);padding:.1rem .35rem;border-radius:4px;margin-right:.25rem;display:inline-block;';
+            watchesCell.appendChild(code);
+        });
+        if (watches.length === 0) {
+            var dash = document.createElement('span');
+            dash.style.cssText = 'color:var(--color-text-secondary);';
+            dash.textContent = '—';
+            watchesCell.appendChild(dash);
+        }
+        tr.appendChild(watchesCell);
+
+        tbody.appendChild(tr);
+    });
+    table.appendChild(tbody);
+    c.appendChild(table);
+
+    return c;
+}
+
 // Awareness tab — hosts three sub-tabs (Registry / Test / Watchdogs).
 // Registry + Test reuse existing renderers (relocated, not rewritten).
-// Watchdogs is a placeholder until PR 4.
+// VTID-02859: Watchdogs sub-tab now wired with real /voice/awareness/watchdogs feed.
 function renderVoiceAwarenessView() {
     var c = document.createElement('div');
     c.style.cssText = 'padding:0;';
@@ -41769,21 +41922,8 @@ function renderVoiceAwarenessView() {
     } else if (active === 'test') {
         body.appendChild(renderVitanaAwarenessTestView());
     } else if (active === 'watchdogs') {
-        var wb = document.createElement('div');
-        wb.style.cssText = 'padding:1.5rem;';
-        var wh = document.createElement('h3');
-        wh.style.margin = '0 0 0.5rem 0';
-        wh.textContent = 'Awareness Watchdogs';
-        wb.appendChild(wh);
-        var wsub = document.createElement('p');
-        wsub.className = 'section-subtitle';
-        wsub.textContent = 'Continuous checks that verify each awareness signal is firing on production sessions.';
-        wb.appendChild(wsub);
-        var wnote = document.createElement('div');
-        wnote.style.cssText = 'margin-top:1rem;padding:1rem 1.25rem;background:rgba(168,85,247,0.06);border:1px solid rgba(168,85,247,0.25);border-radius:8px;font-size:0.85rem;color:var(--color-text-secondary);line-height:1.55;';
-        wnote.textContent = 'Coming in PR 4 of the Voice reorganization (VTID-02856 scaffold ships first). The first 10 watchdogs cover the awareness signals tracked alongside this work.';
-        wb.appendChild(wnote);
-        body.appendChild(wb);
+        // VTID-02859: Awareness Watchdogs sub-tab — fetches /voice/awareness/watchdogs
+        body.appendChild(renderAwarenessWatchdogsTable());
     }
     c.appendChild(body);
     return c;

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -703,6 +703,11 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const voiceConfigRouter = require('./routes/voice-config').default;
   mountRouterSync(app, '/api/v1', voiceConfigRouter, { owner: 'voice-config' });
 
+  // VTID-02859: Voice Awareness Watchdogs (Voice / Awareness / Watchdogs sub-tab)
+  // GET /api/v1/voice/awareness/watchdogs
+  const voiceAwarenessRouter = require('./routes/voice-awareness').default;
+  mountRouterSync(app, '/api/v1', voiceAwarenessRouter, { owner: 'voice-awareness' });
+
   // AI Personality Configuration API
   mountRouterSync(app, '/api/v1/ai-personality', aiPersonalityRouter, { owner: 'ai-personality' });
 

--- a/services/gateway/src/routes/voice-awareness.ts
+++ b/services/gateway/src/routes/voice-awareness.ts
@@ -1,0 +1,26 @@
+/**
+ * VTID-02859: Awareness Watchdogs API.
+ *
+ *   GET /api/v1/voice/awareness/watchdogs   per-watchdog status (live telemetry)
+ *
+ * Surfaced under the Voice / Awareness / Watchdogs sub-tab so operators can
+ * scan in one place "is each awareness signal still firing?" without
+ * having to grep oasis_events by hand.
+ */
+
+import { Router, Request, Response } from 'express';
+import { getWatchdogStatuses } from '../services/awareness-watchdogs';
+
+const router = Router();
+const VTID = 'VTID-02859';
+
+router.get('/voice/awareness/watchdogs', async (_req: Request, res: Response) => {
+  try {
+    const statuses = await getWatchdogStatuses();
+    res.json({ ok: true, watchdogs: statuses, vtid: VTID });
+  } catch (e) {
+    res.status(500).json({ ok: false, error: (e as Error).message, vtid: VTID });
+  }
+});
+
+export default router;

--- a/services/gateway/src/services/awareness-watchdogs.ts
+++ b/services/gateway/src/services/awareness-watchdogs.ts
@@ -1,0 +1,184 @@
+/**
+ * VTID-02859: Awareness Watchdogs manifest.
+ *
+ * The 10 watchdogs that verify each awareness signal is firing on
+ * production sessions. Each watchdog watches one or more signal keys
+ * (from services/awareness-registry.ts) and joins telemetry from
+ * `oasis_events` to produce an "is the signal alive in the last N
+ * sessions?" verdict.
+ *
+ * The /api/v1/voice/awareness/watchdogs endpoint returns this manifest
+ * with optional last-run / last-result fields populated from telemetry.
+ * Today the timestamps come from oasis_events scans; future iterations
+ * can promote the watchdog to a scheduled probe.
+ *
+ * Adding a watchdog is a typed-array entry, no schema change.
+ */
+
+import { getSupabase } from '../lib/supabase';
+
+export type WatchdogVerdict = 'pass' | 'fail' | 'partial' | 'unknown';
+
+export interface AwarenessWatchdog {
+  /** Stable id: dot-notation, snake_case. */
+  id: string;
+  /** Operator-readable name. */
+  name: string;
+  /** What this watchdog verifies in one sentence. */
+  description: string;
+  /** Awareness signal keys (from awareness-registry) this watchdog covers. */
+  watches: string[];
+  /** Source-of-truth file:line so an operator can jump to the gate. */
+  source_hint?: string;
+  /**
+   * Telemetry probe: oasis_events `topic` filter to scan. The endpoint
+   * picks the most recent matching row's timestamp + actor/payload as
+   * "last_run". A row within the last 24h means pass.
+   */
+  oasis_topic?: string;
+}
+
+const WATCHDOGS: AwarenessWatchdog[] = [
+  {
+    id: 'identity_lock_active',
+    name: 'Identity Lock active',
+    description: 'Authoritative role + tenant headers are flowing into orb-live for every session.',
+    watches: ['identity.user_id', 'identity.tenant_id', 'identity.active_role'],
+    source_hint: 'services/gateway/src/routes/orb-live.ts',
+    oasis_topic: 'orb.session.started',
+  },
+  {
+    id: 'environment_context_geo',
+    name: 'Environment context (geo + time)',
+    description: 'IP geo + timezone + time-of-day sections are present in the bootstrap context.',
+    watches: ['context.client.city', 'context.client.country', 'context.client.timezone', 'context.client.time_of_day'],
+    source_hint: 'services/gateway/src/routes/orb-live.ts',
+    oasis_topic: 'orb.session.started',
+  },
+  {
+    id: 'memory_facts_injected',
+    name: 'Memory facts injected',
+    description: 'High-confidence memory_facts rows are being injected into ORB sessions.',
+    watches: ['memory.facts.enabled'],
+    source_hint: 'services/gateway/src/routes/orb-live.ts',
+    oasis_topic: 'orb.memory.context_injected',
+  },
+  {
+    id: 'temporal_journey_block',
+    name: 'Temporal + journey context block',
+    description: 'currentRoute + recentRoutes ring + journey_stage are present in the prompt.',
+    watches: ['context.current_route', 'context.recent_routes', 'context.journey_stage', 'overrides.temporal_journey'],
+    source_hint: 'services/gateway/src/routes/orb-live.ts',
+    oasis_topic: 'orb.session.started',
+  },
+  {
+    id: 'navigator_policy_section',
+    name: 'Navigator policy section',
+    description: 'Navigator routing rules section is appended to the prompt (gates wired; prose missing).',
+    watches: ['overrides.navigator_policy'],
+    source_hint: 'services/gateway/src/routes/orb-live.ts',
+    oasis_topic: 'orb.navigator.consulted',
+  },
+  {
+    id: 'conversation_summary',
+    name: 'Conversation summary',
+    description: 'Returning-user bridge summary text — currently NOT_WIRED (returns null).',
+    watches: ['context.conversation_summary'],
+    source_hint: 'services/gateway/src/routes/orb-live.ts',
+  },
+  {
+    id: 'conversation_history_reconnect',
+    name: 'Conversation history (reconnect)',
+    description: 'Last 10 turns are fed back when a session reconnects — currently NOT_WIRED.',
+    watches: ['context.conversation_history'],
+    source_hint: 'services/gateway/src/routes/orb-live.ts',
+  },
+  {
+    id: 'proactive_opener_override',
+    name: 'Proactive opener override',
+    description: 'PROACTIVE OPENER OVERRIDE block appended after temporal — currently NOT_WIRED.',
+    watches: ['overrides.proactive_opener', 'brain.opener.enabled'],
+    source_hint: 'services/gateway/src/routes/orb-live.ts',
+  },
+  {
+    id: 'health_pillar_data',
+    name: 'Health Pillar Data (Vitana Index)',
+    description: 'Health pillars + Vitana Index score sections are present in the prompt.',
+    watches: [],
+    source_hint: 'services/gateway/src/routes/orb-live.ts',
+    oasis_topic: 'orb.session.started',
+  },
+  {
+    id: 'surface_scoping',
+    name: 'Surface scoping (mobile community coercion)',
+    description: 'Surface header + mobile-community role coercion gate every tool call.',
+    watches: ['identity.surface'],
+    source_hint: 'services/gateway/src/middleware/auth-supabase-jwt.ts',
+    oasis_topic: 'orb.tool.invoked',
+  },
+];
+
+/**
+ * In-memory annotation merged from oasis_events. Built fresh on each
+ * /api/v1/voice/awareness/watchdogs request. We deliberately don't
+ * pre-compute / cache this — the volume is tiny (10 watchdogs × 1
+ * Supabase query each, batched) and operators expect fresh-on-load.
+ */
+export interface WatchdogStatus {
+  watchdog: AwarenessWatchdog;
+  verdict: WatchdogVerdict;
+  last_run_at: string | null;
+  last_result_summary: string | null;
+}
+
+/** Pass = topic emitted at least once in the last 24h. */
+const PASS_WINDOW_HOURS = 24;
+
+export async function getWatchdogStatuses(): Promise<WatchdogStatus[]> {
+  const sb = getSupabase();
+  const out: WatchdogStatus[] = [];
+
+  // Build the union of unique topics so we hit Supabase once for telemetry.
+  const topics = Array.from(
+    new Set(WATCHDOGS.map((w) => w.oasis_topic).filter((t): t is string => !!t)),
+  );
+
+  let mostRecentByTopic: Record<string, string> = {};
+  if (sb && topics.length > 0) {
+    const since = new Date(Date.now() - PASS_WINDOW_HOURS * 60 * 60 * 1000).toISOString();
+    const { data } = await sb
+      .from('oasis_events')
+      .select('topic, occurred_at')
+      .in('topic', topics)
+      .gte('occurred_at', since)
+      .order('occurred_at', { ascending: false })
+      .limit(500);
+    for (const row of (data || []) as Array<{ topic: string; occurred_at: string }>) {
+      if (!mostRecentByTopic[row.topic]) {
+        mostRecentByTopic[row.topic] = row.occurred_at;
+      }
+    }
+  }
+
+  for (const w of WATCHDOGS) {
+    const lastRun = w.oasis_topic ? mostRecentByTopic[w.oasis_topic] || null : null;
+    let verdict: WatchdogVerdict = 'unknown';
+    let summary: string | null = null;
+    if (!w.oasis_topic) {
+      verdict = 'unknown';
+      summary = 'No telemetry topic configured — manual probe required.';
+    } else if (lastRun) {
+      verdict = 'pass';
+      summary = `Topic '${w.oasis_topic}' fired at ${lastRun}.`;
+    } else {
+      verdict = 'fail';
+      summary = `Topic '${w.oasis_topic}' has no rows in the last ${PASS_WINDOW_HOURS}h.`;
+    }
+    out.push({ watchdog: w, verdict, last_run_at: lastRun, last_result_summary: summary });
+  }
+  return out;
+}
+
+export function getWatchdogManifest(): readonly AwarenessWatchdog[] {
+  return WATCHDOGS;
+}


### PR DESCRIPTION
## Summary

PR 4 of 4 in the Voice reorganization. Replaces the placeholder Watchdogs sub-tab in Voice / Awareness with a real verdict table backed by a 10-entry manifest and a small live-telemetry probe.

Plan reference: .claude/plans/build-a-new-voice-sequential-moon.md.

## Backend

- services/awareness-watchdogs.ts — manifest of 10 watchdogs (id · name · description · watches[] · oasis_topic). getWatchdogStatuses() scans oasis_events for the last 24h and returns { verdict: pass|fail|partial|unknown, last_run_at, last_result_summary } per watchdog.
- routes/voice-awareness.ts — single GET /api/v1/voice/awareness/watchdogs endpoint. Mounted under /api/v1.

## The 10 watchdogs (covering the operator's audit table)

- identity_lock_active — role + tenant + user_id headers
- environment_context_geo — IP geo + timezone + time-of-day
- memory_facts_injected — memory_facts injection topic
- temporal_journey_block — currentRoute + recent_routes ring
- navigator_policy_section — navigator routing rules section
- conversation_summary — bridge summary text (currently null)
- conversation_history_reconnect — last-10 turns on reconnect
- proactive_opener_override — PROACTIVE OPENER OVERRIDE block
- health_pillar_data — Vitana Index pillar block
- surface_scoping — surface header + mobile coercion

## Frontend (Voice / Awareness / Watchdogs)

- renderAwarenessWatchdogsTable replaces the "Coming in PR 4" placeholder.
- Table: name + description + per-row verdict badge (✓ pass / ✗ fail / ⚠ partial / ? unknown) + last-run timestamp + signal keys watched.
- Refresh button re-fetches the live status.

## Verdict logic

A watchdog with an oasis_topic passes if the topic emitted at least once in the last 24h. Watchdogs without a topic (signals not yet wired) report 'unknown' with a "manual probe required" note — they are placeholders until the underlying signal ships.

## Risk

Read-only endpoint, no auth gate, single Supabase query. No schema migration. No new OASIS topics.

## Test plan

- [ ] /command-hub/voice/awareness/ → Watchdogs sub-tab loads 10 rows
- [ ] Verdict badges render: known-good signals (orb.session.started topic) show ✓ pass; signals without topic show ? unknown
- [ ] Refresh button refetches
- [ ] No regression — Registry + Test sub-tabs still load

Generated with Claude Code