### PR TITLE
fix(VTID-02860 / DEV-COMHU-2860): three LiveKit parity fixes — language set, web search, no auto-disconnect

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/providers.py
+++ b/services/agents/orb-agent/src/orb_agent/providers.py
@@ -66,16 +66,19 @@ class ResolvedCascade:
 # through unchanged.
 # ---------------------------------------------------------------------------
 
+# Match Vertex's NEURAL2_TTS_VOICES set (orb-live.ts:1176): the languages
+# the Vitana team has actually provisioned for production. NOT a generic
+# EU/European set. Adding a language is a deliberate decision that has
+# to land in BOTH pipelines.
 _BCP47_DEFAULTS: dict[str, str] = {
     "en": "en-US",
     "de": "de-DE",
     "es": "es-ES",
     "fr": "fr-FR",
-    "it": "it-IT",
-    "pt": "pt-BR",
-    "nl": "nl-NL",
-    "sv": "sv-SE",
-    "pl": "pl-PL",
+    "ar": "ar-XA",   # Vertex uses ar-XA (multi-region Arabic), not ar-SA
+    "zh": "cmn-CN",  # Vertex uses cmn-CN (Mandarin), not zh-CN
+    "ru": "ru-RU",
+    "sr": "sr-RS",
 }
 
 
@@ -108,30 +111,32 @@ def _resolve_bcp47(lang: str | None) -> str:
 
 LANG_DEFAULTS: dict[str, dict[str, str]] = {
     "google_tts": {
-        # MUST use Chirp3-HD voice names. The livekit-plugins-google TTS
-        # class auto-selects the underlying TTS model from voice_name:
-        #   - "chirp" in voice_name → model_name="chirp_3"
-        #   - else                  → model_name="gemini-2.5-flash-tts"
-        # Neural2/Wavenet voices fall into the second branch, but Cloud TTS
-        # rejects voice="de-DE-Neural2-G" + model="gemini-2.5-flash-tts" as
-        # an invalid pair → silent 400 → no audio. Chirp3-HD voices ARE
-        # GA on Cloud TTS REST for all 9 languages below; the previous
-        # "no audio for German" was caused by row-seeded language_code +
-        # missing system-prompt language threading (fixed in PR-1.B-Lang-4),
-        # not the voice itself.
+        # Mirrors Vertex's production set (orb-live.ts:LIVE_API_VOICES +
+        # NEURAL2_TTS_VOICES). DO NOT add languages here that aren't in
+        # Vertex — that's a deliberate parity violation. The previous
+        # mistake (it/pt/nl/sv/pl substituted for ar/zh/ru/sr) was a
+        # generic-EU pick that broke the user's actual config.
+        #
+        # Voice routing through livekit-plugins-google:
+        #   - "chirp" in name → chirp_3 model (Cloud TTS REST GA voices)
+        #   - else            → gemini-2.5-flash-tts model (multilingual,
+        #                       voice name without locale prefix, model
+        #                       auto-detects language from input text)
+        #
+        # For ar/zh/ru/sr we use Gemini TTS multilingual voices because
+        # Chirp3-HD coverage outside the major Western locales is thin and
+        # we'd rather use a voice that's GUARANTEED to synthesize than
+        # ship a name that 400s. Mirrors Vertex's LIVE_API_VOICES which
+        # uses bare names ('Charon', 'Kore') for those same languages.
         "en": "en-US-Chirp3-HD-Aoede",
-        # PR-VTID-02853: Leda described as "soft, narrative" in Google's
-        # Chirp3-HD catalog — warmer / more human-like than Aoede's neutral
-        # tone. User feedback after first German session: Aoede sounded
-        # robotic.
+        # Leda = "soft, narrative" — warmer than Aoede per user feedback.
         "de": "de-DE-Chirp3-HD-Leda",
         "es": "es-ES-Chirp3-HD-Aoede",
         "fr": "fr-FR-Chirp3-HD-Aoede",
-        "it": "it-IT-Chirp3-HD-Aoede",
-        "pt": "pt-BR-Chirp3-HD-Aoede",
-        "nl": "nl-NL-Chirp3-HD-Aoede",
-        "sv": "sv-SE-Chirp3-HD-Aoede",
-        "pl": "pl-PL-Chirp3-HD-Aoede",
+        "ar": "Charon",  # Gemini TTS — Vertex's LIVE_API_VOICES['ar']
+        "zh": "Charon",  # Gemini TTS — Vertex's LIVE_API_VOICES['zh']
+        "ru": "Charon",  # Gemini TTS — Vertex's LIVE_API_VOICES['ru']
+        "sr": "Charon",  # Gemini TTS — Vertex's LIVE_API_VOICES['sr']
     },
     # Cartesia Sonic-3 is multilingual — same voice handle works across
     # languages, the model auto-detects from the input text. Documented at

--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -47,7 +47,7 @@ from .oasis import (
 )
 from .providers import build_cascade
 from .tools import all_tools
-from .watchdogs import ReconnectBucket, StallWatchdog, STALL_THRESHOLD_MS
+from .watchdogs import StallWatchdog, STALL_THRESHOLD_MS
 
 logger = logging.getLogger(__name__)
 
@@ -294,6 +294,22 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     # thin async call to a gateway endpoint via the GatewayClient carried on
     # RunContext.userdata (set on AgentSession below).
     tool_list = list(all_tools())
+    # PR-VTID-02856: Native Gemini Google Search grounding. Mirrors Vertex's
+    # orb-live.ts:3732 `{ google_search: {} }` declaration. Without this the
+    # LiveKit LLM has no way to fetch fresh facts (sports scores, news, etc.)
+    # — the search_web custom function is a stub when PERPLEXITY_API_KEY
+    # isn't set (it isn't, and per orb-live.ts the comment explicitly says
+    # native google_search REPLACED the broken Perplexity path). Add the
+    # GoogleSearch ProviderTool to the agent's tool list when the LLM
+    # provider is google_llm; the model handles tool calls automatically
+    # and returns answers with citations.
+    if (bootstrap.voice_config or {}).get("llm_provider") == "google_llm":
+        try:
+            from livekit.plugins.google.tools import GoogleSearch  # type: ignore[import-not-found]
+            tool_list.append(GoogleSearch())
+            logger.info("GoogleSearch grounding enabled (Gemini native tool)")
+        except ImportError as exc:
+            logger.warning("GoogleSearch grounding unavailable: %s", exc)
     agent = Agent(
         instructions=sys_prompt,
         tools=tool_list,
@@ -479,21 +495,25 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     # transparent transport reconnect (chat_ctx is preserved across it,
     # so the conversation resumes where it left off — same behaviour the
     # user observed today, just triggered in 30s instead of 60-120s).
-    reconnect_bucket = ReconnectBucket()
+    # PR-VTID-02856: telemetry-only watchdog. The previous version called
+    # ctx.room.disconnect() to provoke the SDK's auto-reconnect — but that
+    # surfaces as a visible "disconnect" to the user, which the user
+    # explicitly said is wrong: the connection must stay active until
+    # they manually disconnect. Instead, we just record the stall in
+    # OASIS so operators can see the rate, and let livekit-agents'
+    # underlying transport reconnect (which IS organic and silent — same
+    # 1-2 min recovery the user observed before my watchdog) handle it.
+    # Future option: add a soft pipeline-reset path that resets STT/LLM
+    # without dropping the room. For now: telemetry-only.
+    stall_count = {"n": 0}
     stall = StallWatchdog(threshold_ms=STALL_THRESHOLD_MS)
 
     async def _on_stall() -> None:
-        if not reconnect_bucket.record_attempt():
-            logger.error(
-                "StallWatchdog: max reconnects (%d) reached for orb_session_id=%s — giving up",
-                reconnect_bucket.count,
-                orb_session_id,
-            )
-            return
+        stall_count["n"] += 1
         logger.warning(
-            "StallWatchdog: no activity in %ds — forcing reconnect (attempt %d) for orb_session_id=%s",
+            "StallWatchdog: no activity in %ds (count=%d) for orb_session_id=%s — telemetry only, no disconnect",
             int(STALL_THRESHOLD_MS / 1000),
-            reconnect_bucket.count,
+            stall_count["n"],
             orb_session_id,
         )
         try:
@@ -503,19 +523,13 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
                     "orb_session_id": orb_session_id,
                     "user_id": identity.user_id,
                     "agent_id": agent_id,
-                    "reconnect_attempt": reconnect_bucket.count,
+                    "stall_count": stall_count["n"],
                     "threshold_ms": STALL_THRESHOLD_MS,
+                    "action": "telemetry_only",
                 },
             )
         except Exception:  # noqa: BLE001
             pass
-        # Disconnecting the room provokes livekit-client.js's auto-reconnect
-        # on the user's browser. AgentSession's chat_ctx persists across
-        # the reconnect so the conversation resumes where it stalled.
-        try:
-            await ctx.room.disconnect()
-        except Exception as exc:  # noqa: BLE001
-            logger.warning("StallWatchdog: room.disconnect() failed: %s", exc)
 
     stall.start(on_stall=_on_stall)
 

--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -35122,16 +35122,19 @@ function renderLivekitTestView() {
         try { savedLang = (localStorage.getItem('vitana.lang') || '').slice(0, 2); } catch (e) {}
     }
     if (!savedLang) savedLang = 'en';
+    // VTID-02856: mirror Vertex's production language set (orb-live.ts
+    // NEURAL2_TTS_VOICES + LIVE_API_VOICES). it/pt/nl/sv/pl were a
+    // mistake — never in Vertex; ar/zh/ru/sr were dropped by accident
+    // and are now restored.
     var langOptions = [
         ['en', 'English'],
         ['de', 'Deutsch'],
         ['es', 'Español'],
         ['fr', 'Français'],
-        ['it', 'Italiano'],
-        ['pt', 'Português'],
-        ['nl', 'Nederlands'],
-        ['sv', 'Svenska'],
-        ['pl', 'Polski'],
+        ['ar', 'العربية'],
+        ['zh', '中文'],
+        ['ru', 'Русский'],
+        ['sr', 'Srpski'],
     ];
     var langSelectHtml = '<select class="lkt-lang" title="Session language" style="padding:8px;background:#0f172a;color:#e5e7eb;border:1px solid #334155;border-radius:4px;">';
     for (var i = 0; i < langOptions.length; i++) {
@@ -35183,8 +35186,9 @@ function renderLivekitTestView() {
         ['Orus', 'M · smooth, broadcast'],
     ];
     var BCP47_FOR_LANG = {
-        en: 'en-US', de: 'de-DE', es: 'es-ES', fr: 'fr-FR', it: 'it-IT',
-        pt: 'pt-BR', nl: 'nl-NL', sv: 'sv-SE', pl: 'pl-PL',
+        en: 'en-US', de: 'de-DE', es: 'es-ES', fr: 'fr-FR',
+        // Vertex's production locales (multi-region Arabic, Mandarin, etc.)
+        ar: 'ar-XA', zh: 'cmn-CN', ru: 'ru-RU', sr: 'sr-RS',
     };
 
     function rebuildVoiceOptions() {

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -30,7 +30,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260504-vtid-02710-ios-ctx-keepalive"></script>
-  <script src="/command-hub/app.js?v=20260508-livekit-voice-selector"></script>
+  <script src="/command-hub/app.js?v=20260509-livekit-parity-three-fixes"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
 </body>


### PR DESCRIPTION
## Summary

Three independent issues, all caused by my prior PRs not mirroring Vertex's production behavior. Bundled because they're all "you broke parity, fix it."

### 1. Language set — restore Vertex's production locales

I shipped a generic EU set (`en/de/es/fr/it/pt/nl/sv/pl`) instead of mirroring Vertex's `NEURAL2_TTS_VOICES` + `LIVE_API_VOICES`. The user's actual production set is `en/de/es/fr/ar/zh/ru/sr`. Italian/Portuguese/Dutch/Swedish/Polish were never in Vertex; Arabic/Chinese/Russian/Serbian were intentionally provisioned and I dropped them.

| Lang | Restored | Voice routing |
|---|---|---|
| en | `en-US-Chirp3-HD-Aoede` | chirp_3 model |
| de | `de-DE-Chirp3-HD-Leda` | chirp_3 model |
| es | `es-ES-Chirp3-HD-Aoede` | chirp_3 model |
| fr | `fr-FR-Chirp3-HD-Aoede` | chirp_3 model |
| **ar** | `Charon` (Gemini TTS) | gemini-2.5-flash-tts |
| **zh** | `Charon` (Gemini TTS) | gemini-2.5-flash-tts |
| **ru** | `Charon` (Gemini TTS) | gemini-2.5-flash-tts |
| **sr** | `Charon` (Gemini TTS) | gemini-2.5-flash-tts |

ar/zh/ru/sr use Gemini TTS multilingual voices because Chirp3-HD coverage outside the major Western locales is thin and the LiveKit plugin only drives chirp_3 or gemini-2.5-flash-tts models. Mirrors Vertex's `LIVE_API_VOICES` which uses bare names ('Charon', 'Kore') for those same languages.

Test-page dropdown updated to match.

### 2. Web search — wire Gemini's native google_search grounding

[orb-live.ts:3732](services/gateway/src/routes/orb-live.ts#L3732) for Vertex:

```ts
{ google_search: {} },  // native Gemini grounding — replaces broken search_web
```

LiveKit's agent never got the same grounding tool, so sports scores / news / current events all returned nothing. `search_web` falls back to `fetchWebHits` which silently no-ops when `PERPLEXITY_API_KEY` is unset (it is unset; per the orb-live.ts comment, native `google_search` was supposed to replace Perplexity but the LiveKit side missed that swap).

Fix: when LLM provider is `google_llm`, append `livekit.plugins.google.tools.GoogleSearch()` to the agent's tool list. Gemini auto-handles the tool calls; results come back with citations.

### 3. StallWatchdog — telemetry only, NO auto-disconnect

User: *"It cannot be that it disconnects by itself. Disconnection should only happen by manual disconnection by the user."*

My VTID-02854 watchdog called `ctx.room.disconnect()` on stall — visible to the user as a drop. Reverted to telemetry-only: emit `livekit.stall_detected` with `stall_count` and let livekit-agents' organic transport reconnect handle recovery (the same 1-2 min recovery the user observed naturally — but no visible disconnect from us). The stall counter persists across the session so we can still measure rate. Future: a soft pipeline-reset path that resets STT/LLM without dropping the room.

### Memory

Saved [feedback_livekit_must_perform_100.md](memory/feedback_livekit_must_perform_100.md) — user's standing rule that LiveKit must mirror Vertex 100%, not partial parity.

## Verification

- `python3 -m py_compile` (orb-agent) — clean.
- `npm run build` (gateway) — clean.
- VTID: VTID-02860 / DEV-COMHU-2860.

## Test plan

- [ ] German session: voice still works (Leda).
- [ ] Test page: language dropdown shows en/de/es/fr/ar/zh/ru/sr.
- [ ] Connect, ask "who won the F1 Grand Prix this weekend" → agent responds with current data + citations (Gemini grounding).
- [ ] Long silent period mid-session → no visible disconnect from agent side; OASIS shows `livekit.stall_detected` with `action: telemetry_only`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)