### PR TITLE
fix(VTID-02855): wire ENVIRONMENT CONTEXT (geo-IP + time + device) into LiveKit bootstrap

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -929,7 +929,7 @@ interface GeminiLiveSession {
  * VTID-CONTEXT: Client environment context gathered at session start.
  * Injected into system instruction to make Vitana contextually aware.
  */
-interface ClientContext {
+export interface ClientContext {
   ip: string;
   city?: string;
   country?: string;
@@ -8326,7 +8326,7 @@ naturally, never call a tool.`;
  * VTID-CONTEXT: Format client context into a context section for the system instruction.
  * Used for both anonymous and authenticated sessions.
  */
-function formatClientContextForInstruction(ctx: ClientContext): string {
+export function formatClientContextForInstruction(ctx: ClientContext): string {
   const parts: string[] = [];
   if (ctx.city && ctx.country) parts.push(`User location: ${ctx.city}, ${ctx.country}`);
   else if (ctx.country) parts.push(`User location: ${ctx.country}`);
@@ -10833,7 +10833,7 @@ function getLocalTimeContext(timezone?: string): { localTime: string; timeOfDay:
 /**
  * Build full client context from request.
  */
-async function buildClientContext(req: Request): Promise<ClientContext> {
+export async function buildClientContext(req: Request): Promise<ClientContext> {
   const ip = getClientIP(req);
   // Log all IP-related headers for debugging Cloud Run IP extraction
   console.log(`[VTID-CONTEXT] IP headers: xff="${req.get('x-forwarded-for') || ''}", xri="${req.get('x-real-ip') || ''}", xaui="${req.get('x-appengine-user-ip') || ''}", req.ip="${req.ip || ''}" → resolved="${ip}"`);

--- a/services/gateway/src/routes/orb-livekit.ts
+++ b/services/gateway/src/routes/orb-livekit.ts
@@ -38,6 +38,15 @@ import { AccessToken } from 'livekit-server-sdk';
 import * as jose from 'jose';
 import { emitOasisEvent } from '../services/oasis-event-service';
 import { getSupabase } from '../lib/supabase';
+// VTID-02855: reuse Vertex's geo-IP + UA-parse + format helpers so the
+// LiveKit bootstrap injects the same ENVIRONMENT CONTEXT block (city,
+// country, timezone, localTime, UTC, device) that Vertex's authenticated
+// system prompt has. Without this, LiveKit's LLM has no location/time
+// awareness and answers "where am I?" / "what time is it?" with garbage.
+import {
+  buildClientContext,
+  formatClientContextForInstruction,
+} from './orb-live';
 import {
   optionalAuth,
   requireAuthWithTenant,
@@ -646,6 +655,20 @@ router.get(
     const fullName = (userNameFact?.fact_value || displayName || '').trim();
     const firstName = fullName ? fullName.split(/\s+/)[0] : null;
 
+    // VTID-02855: ENVIRONMENT CONTEXT — geo-IP + UA + local time, mirrors
+    // Vertex's orb-live.ts:14026 path. Without this, LiveKit's LLM has
+    // no idea where the user is or what time it is. The block goes at
+    // the END of bootstrap_context so identity facts come first.
+    let envContext: import('./orb-live').ClientContext | null = null;
+    try {
+      envContext = await buildClientContext(req);
+      const envBlock = formatClientContextForInstruction(envContext);
+      if (envBlock) ctxParts.push(envBlock);
+    } catch (exc) {
+      // Geo lookup is best-effort; never fail the bootstrap on it.
+      console.warn(`[${VTID}] buildClientContext failed: ${(exc as Error).message}`);
+    }
+
     res.json({
       ok: true,
       vtid: VTID,
@@ -659,7 +682,7 @@ router.get(
       last_session_info: null,
       current_route: null,
       recent_routes: [],
-      client_context: { user_agent: req.headers['user-agent'] ?? null },
+      client_context: envContext ?? { user_agent: req.headers['user-agent'] ?? null },
       vitana_id: req.identity?.vitana_id ?? null,
       // VTID-LIVEKIT-IDENTITY-NAME: surface the user's name + verified facts as
       // structured fields so the agent's instructions.py can address them by


### PR DESCRIPTION
Vertex's authenticated system prompt has city/country/timezone/localTime/device via `buildClientContext(req) → formatClientContextForInstruction(ctx)`. LiveKit's `/orb/context-bootstrap` returned only `{ user_agent }` and never formatted it into the prompt — so the LLM had no clue where the user is or what time it is.

Fix: export `buildClientContext` + `formatClientContextForInstruction` from orb-live.ts and call them from orb-livekit.ts inside the bootstrap handler. Same geo-IP + UA-parse + ENVIRONMENT CONTEXT block both pipelines, no duplication. Best-effort: geo lookup failures don't break bootstrap.

VTID: VTID-02855.

🤖 Generated with [Claude Code](https://claude.com/claude-code)