### PR TITLE
fix(intents+orb-agent): post never times out the voice agent (VTID-02863)

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/gateway_client.py
+++ b/services/agents/orb-agent/src/orb_agent/gateway_client.py
@@ -13,7 +13,15 @@ import httpx
 
 logger = logging.getLogger(__name__)
 
-DEFAULT_TIMEOUT_S = 10.0
+DEFAULT_TIMEOUT_S = 30.0  # VTID-02863: bumped from 10s. /api/v1/intents POST
+                          # used to time out at 10s while embedding/match-compute
+                          # ran inline; the agent then reported a failure to the
+                          # LLM ("there was a problem creating your post") even
+                          # though the row was already in user_intents. Server-
+                          # side, those phases are now fire-and-forget so the
+                          # response returns in well under a second — but 30s
+                          # gives transient slowness room without ever surfacing
+                          # a fake "post failed" to the user.
 SLOW_TIMEOUT_S = 30.0  # for tools that may hit external APIs (search_web, consult_external_ai)
 
 

--- a/services/gateway/src/routes/intents.ts
+++ b/services/gateway/src/routes/intents.ts
@@ -320,19 +320,28 @@ router.post('/', requireAuth, requireTenant, async (req: Request, res: Response)
     });
   }
 
-  // VTID-01992: Embedding path is now flag-controlled.
-  //   FEATURE_INTENT_EMBEDDING_ASYNC=true  → skip inline; the embedding
-  //                                         worker (intent-embedding-worker.ts)
-  //                                         will pick up the row within ~5s.
-  //   default (unset / false)              → keep inline behavior. Worker
-  //                                         still runs as a safety net for
-  //                                         rows that slip past inline.
-  if (process.env.FEATURE_INTENT_EMBEDDING_ASYNC !== 'true') {
-    const embedding = await embedIntent({ intent_kind: intentKind, category, title, scope, kind_payload: kindPayload });
-    if (embedding) {
-      await supabase.from('user_intents').update({ embedding: embedding as any }).eq('intent_id', (inserted as any).intent_id);
+  // VTID-01992 / VTID-02863: Embedding is now ALWAYS fire-and-forget. The
+  // inline-await path used to hold the POST response for the duration of an
+  // OpenAI embedding call (1-3s typical, longer under provider load), which
+  // pushed total response time past the LiveKit agent's 10s HTTP timeout.
+  // The agent then returned `{ok:false, error:'timeout'}` to the LLM, and the
+  // LLM apologized — "there was a problem creating your post" — even though
+  // the row was already in user_intents. The embedding worker
+  // (intent-embedding-worker.ts) picks up rows with NULL embedding within ~5s.
+  void (async () => {
+    try {
+      const embedding = await embedIntent({ intent_kind: intentKind, category, title, scope, kind_payload: kindPayload });
+      if (embedding) {
+        const { error: embedUpdErr } = await supabase
+          .from('user_intents')
+          .update({ embedding: embedding as any })
+          .eq('intent_id', (inserted as any).intent_id);
+        if (embedUpdErr) console.warn(`[VTID-01973] inline embedding update failed: ${embedUpdErr.message}`);
+      }
+    } catch (err: any) {
+      console.warn(`[VTID-01973] inline embedding non-fatal: ${err?.message}`);
     }
-  }
+  })();
 
   // VTID-01975 (P2-B): kind-discriminated Memory Garden write hooks.
   // Fire-and-forget so the post path is never blocked by memory persistence.
@@ -346,20 +355,30 @@ router.post('/', requireAuth, requireTenant, async (req: Request, res: Response)
     kind_payload: kindPayload,
   }).catch((err) => console.warn(`[VTID-01975] writeIntentFacts non-fatal: ${err?.message}`));
 
-  // Compute matches now (best-effort; daily recompute catches misses).
-  let matchCount = 0;
-  try {
-    matchCount = await computeForIntent((inserted as any).intent_id);
-    if (matchCount > 0) {
-      const top = await surfaceTopMatches((inserted as any).intent_id, 5);
-      // VTID-01975 (P2-B): real push fan-out replaces P2-A audit-only stub.
-      for (const m of top) {
-        await notifyMatchSurfaced({ match: m, kind: intentKind });
+  // VTID-02863: match compute + notify fan-out also moved fire-and-forget.
+  // computeForIntent + surfaceTopMatches + N×notifyMatchSurfaced was the second
+  // multi-second blocker before the response — combined with embedding it
+  // routinely pushed total response past 10s. The voice/REST clients get
+  // match_count: 0 in the immediate response and rely on
+  // GET /api/v1/intents/:id/matchmaker (polled by get_matchmaker_result) for
+  // the polished re-rank. cold_start UX in the voice tool description handles
+  // the "0 matches" case gracefully.
+  void (async () => {
+    try {
+      const matchCount = await computeForIntent((inserted as any).intent_id);
+      if (matchCount > 0) {
+        const top = await surfaceTopMatches((inserted as any).intent_id, 5);
+        for (const m of top) {
+          await notifyMatchSurfaced({ match: m, kind: intentKind });
+        }
       }
+    } catch (err: any) {
+      console.warn(`[VTID-01973] post-insert match compute failed: ${err.message}`);
     }
-  } catch (err: any) {
-    console.warn(`[VTID-01973] post-insert match compute failed: ${err.message}`);
-  }
+  })();
+  // The response carries match_count: 0 immediately. The matchmaker poll
+  // endpoint surfaces the actual count once the async compute lands.
+  const matchCount = 0;
 
   // VTID-DANCE-D12 — Layer 2 matchmaker agent (Gemini 2.5 Pro), async.
   // Kicks off a background re-rank. Clients poll
@@ -372,7 +391,9 @@ router.post('/', requireAuth, requireTenant, async (req: Request, res: Response)
     console.warn(`[VTID-DANCE-D12] matchmaker async kick failed (non-fatal): ${err?.message}`);
   }
 
-  await emitOasisEvent({
+  // VTID-02863: emitOasisEvent moved fire-and-forget. OASIS persistence is
+  // best-effort and must never block the user-visible POST response.
+  void emitOasisEvent({
     vtid: 'VTID-01973',
     type: 'voice.message.sent',
     source: 'intents-route',
@@ -389,7 +410,7 @@ router.post('/', requireAuth, requireTenant, async (req: Request, res: Response)
     actor_role: 'user',
     surface: 'api',
     vitana_id: identity.vitana_id ?? undefined,
-  });
+  }).catch((err: any) => console.warn(`[VTID-01973] post-insert oasis emit failed: ${err?.message}`));
 
   return res.status(201).json({
     ok: true,

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -3531,9 +3531,16 @@ function buildLiveApiTools(
           description: [
             'After post_intent, the matchmaker agent runs ASYNC (~20s) re-ranking + writing a voice readback.',
             'Call this 3 seconds after post_intent to fetch the polished result. status will be:',
-            '  pending/running — call again in 3 seconds',
+            '  pending/running/not_started — call again in 3 seconds',
             '  complete — read back voice_readback verbatim, then offer next steps',
             '  error — fall back to the SQL match summary already returned by post_intent',
+            '',
+            'CRITICAL (VTID-02861): this tool ALWAYS reports success at the wire level. The post_intent',
+            'row is already in user_intents — nothing this tool returns means the post failed.',
+            'NEVER say "I had a problem", "there was an issue", "I couldn\'t post", or any apologetic phrase',
+            'about the post based on this tool\'s response. status:"error" / "not_started" / "not_found"',
+            'just means the polish is unavailable; the post is still live. Use the SQL match summary from',
+            'post_intent and continue normally.',
             '',
             'The polished result includes counter_questions when the user gave a vague intent.',
             'If counter_questions is non-empty, ASK them progressively (variety → time → location)',
@@ -6682,25 +6689,98 @@ async function executeLiveApiToolInner(
       }
 
       // VTID-DANCE-D12 — poll the async matchmaker agent's polished result.
+      // VTID-02861 (2026-05-07): query intent_match_recommendations directly via
+      // service-role Supabase. The previous self-HTTP call to /api/v1/intents/:id/matchmaker
+      // always 401'd because session.access_token is never populated on the WebSocket
+      // session (same root cause as VTID-02754 for find_community_member). The 401 made
+      // this tool return success:false right after a successful post_intent, and Gemini
+      // misattributed that to the post itself — apologizing "I had a problem making the
+      // post" while the row was already in user_intents. Now we always return success:true
+      // with the polished status inside the result; the voice tool description already
+      // tells the model how to react to status:'error' / status:'not_started'.
       case 'get_matchmaker_result': {
         const intentId = String(args.intent_id || '').trim();
-        if (!intentId) return { success: false, result: '', error: 'intent_id is required' };
+        if (!intentId) {
+          return {
+            success: true,
+            result: JSON.stringify({ ok: false, status: 'error', error: 'intent_id is required' }),
+          };
+        }
 
         try {
-          const url = `${process.env.GATEWAY_INTERNAL_URL || 'http://localhost:8080'}/api/v1/intents/${encodeURIComponent(intentId)}/matchmaker`;
-          const jwt = (session as any).access_token || (session as any).jwt;
-          const res = await fetch(url, {
-            headers: jwt ? { Authorization: `Bearer ${jwt}` } : {},
+          const SUPABASE_URL = process.env.SUPABASE_URL;
+          const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
+          if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
+            return {
+              success: true,
+              result: JSON.stringify({ ok: false, status: 'error', error: 'supabase_unavailable' }),
+            };
+          }
+          const { createClient } = await import('@supabase/supabase-js');
+          const adminSb = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE, {
+            auth: { autoRefreshToken: false, persistSession: false },
           });
-          const data = await res.json();
+
+          // Visibility gate: requester owns the intent OR intent is public.
+          const { data: src } = await adminSb
+            .from('user_intents')
+            .select('intent_id, requester_user_id, visibility')
+            .eq('intent_id', intentId)
+            .maybeSingle();
+          if (!src) {
+            return {
+              success: true,
+              result: JSON.stringify({ ok: false, status: 'error', error: 'intent_not_found' }),
+            };
+          }
+          const isOwner = (src as any).requester_user_id === session.identity?.user_id;
+          const visibility = String((src as any).visibility || 'public');
+          if (!isOwner && visibility !== 'public') {
+            return {
+              success: true,
+              result: JSON.stringify({ ok: false, status: 'error', error: 'forbidden' }),
+            };
+          }
+
+          const { data: rec } = await adminSb
+            .from('intent_match_recommendations')
+            .select('intent_id, status, mode, pool_size, candidates, counter_questions, voice_readback, reasoning_summary, used_fallback, model, latency_ms, error, computed_at, updated_at')
+            .eq('intent_id', intentId)
+            .maybeSingle();
+
+          if (!rec) {
+            return {
+              success: true,
+              result: JSON.stringify({ ok: true, status: 'not_started', poll_again_ms: 2000 }),
+            };
+          }
+
+          const status = String((rec as any).status);
           return {
-            success: res.ok,
-            result: JSON.stringify(data),
-            error: res.ok ? undefined : (data as any)?.error || 'poll_failed',
+            success: true,
+            result: JSON.stringify({
+              ok: true,
+              status,
+              mode: (rec as any).mode,
+              pool_size: (rec as any).pool_size,
+              candidates: (rec as any).candidates ?? [],
+              counter_questions: (rec as any).counter_questions ?? [],
+              voice_readback: (rec as any).voice_readback,
+              reasoning_summary: (rec as any).reasoning_summary,
+              used_fallback: (rec as any).used_fallback,
+              model: (rec as any).model,
+              latency_ms: (rec as any).latency_ms,
+              error: (rec as any).error,
+              computed_at: (rec as any).computed_at,
+              poll_again_ms: status === 'pending' || status === 'running' ? 3000 : null,
+            }),
           };
         } catch (err: any) {
           console.error('[VTID-DANCE-D12] get_matchmaker_result error:', err?.message);
-          return { success: false, result: '', error: err?.message || 'unknown' };
+          return {
+            success: true,
+            result: JSON.stringify({ ok: false, status: 'error', error: err?.message || 'unknown' }),
+          };
         }
       }
 


### PR DESCRIPTION
## Real root cause

User repeatedly reported: **"Vitana says there was a problem creating your post, but the post is in the list."**

PR #2022 (get_matchmaker_result self-HTTP 401 fix) addressed one apology path but not the dominant one. The actual chain of events:

1. LiveKit orb-agent's HTTP client times out at **10 seconds** (services/agents/orb-agent/src/orb_agent/gateway_client.py:16).
2. POST /api/v1/intents was awaiting **embedIntent()** inline (1-3s typical, longer under OpenAI provider load) **AND** awaiting computeForIntent + N×notifyMatchSurfaced **AND** awaiting emitOasisEvent — all serial, all *after* the row was already inserted.
3. Under load this routinely pushed total response past 10s. The agent saw a timeout, returned `{ok:False, error:'<timeout>', transport:'exception'}` to the LLM, and the LLM apologized — even though the request continued running server-side and the row landed in user_intents.

## Fix

**services/gateway/src/routes/intents.ts** — POST now returns in well under a second:

- Inline embedding wrapped in `void (async () => { try {...} catch {...} })()` — always fire-and-forget. The flag-controlled inline path is gone; the embedding worker (intent-embedding-worker.ts) picks up NULL-embedding rows within ~5s.
- Match compute + notifyMatchSurfaced fan-out moved fire-and-forget. Response carries `match_count: 0` immediately; `get_matchmaker_result` polls the proper count later. Voice tool's `cold_start` UX already handles \"0 matches\" gracefully.
- emitOasisEvent moved fire-and-forget with .catch — OASIS persistence is best-effort and must never block the user-visible response.

**services/agents/orb-agent/src/orb_agent/gateway_client.py** — defense in depth:

- DEFAULT_TIMEOUT_S 10s → 30s. Even with server fire-and-forget, transient slowness shouldn't surface a fake \"post failed\" to the user.

## Test plan

- [ ] EXEC-DEPLOY runs on merge for gateway (VTID-02863 in commit + branch)
- [ ] orb-agent gets redeployed (LiveKit agent service)
- [ ] Voice ORB on iPhone/LiveKit: dictate \"find me a match for X\" → confirm verbally → voice no longer says \"there was a problem creating your post\" / \"etwas ging schief\"
- [ ] user_intents row appears AND voice confirms the post