### PR TITLE
test(orb-live): A0.3 characterization suite (SSE + WebSocket + lifecycle)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -27,3 +27,6 @@ Thumbs.db
 .env.local
 .env.production
 .claude/settings.local.json
+
+# Local git worktrees (used by parallel Claude Code sessions)
+.worktrees/

--- a/services/gateway/test/orb/live/characterization/sse-stream.characterization.test.ts
+++ b/services/gateway/test/orb/live/characterization/sse-stream.characterization.test.ts
@@ -1,0 +1,172 @@
+/**
+ * A0.3 — Characterization test for the /live/stream SSE transport contract.
+ *
+ * Purpose: lock the SSE wire format the orb client depends on, before
+ * step A9 splits transport into orb/live/transport/sse-handler.ts.
+ *
+ * Approach: structural over orb-live.ts source. The handler is too coupled
+ * with Express + Vertex Live API + audio streaming to runtime-mock cleanly
+ * in a tests-only PR. Per the plan's strict rule, A0 freezes the unchanged
+ * file; runtime transport tests come in A9.
+ *
+ * Scope: assertions are made against the SSE-handler block only (sliced
+ * from `router.get('/live/stream'` to the next route registration), not
+ * file-wide grep, so unrelated SSE writes elsewhere in orb-live.ts can't
+ * accidentally satisfy them.
+ *
+ * Will be replaced/augmented by A9 with a runtime test against
+ * orb/live/transport/sse-handler.ts.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ORB_LIVE_PATH = path.resolve(__dirname, '../../../../src/routes/orb-live.ts');
+
+let handlerBody: string;
+
+beforeAll(() => {
+  const source = fs.readFileSync(ORB_LIVE_PATH, 'utf8');
+  // Slice the SSE handler block. The next route registration is the
+  // natural terminator — `router.post('/live/stream/send'`.
+  const startIdx = source.indexOf("router.get('/live/stream'");
+  const stopIdx = source.indexOf("router.post('/live/stream/send'");
+  expect(startIdx).toBeGreaterThan(0);
+  expect(stopIdx).toBeGreaterThan(startIdx);
+  handlerBody = source.slice(startIdx, stopIdx);
+});
+
+describe('A0.3 characterization: /live/stream SSE transport contract', () => {
+  describe('response headers (SSE handshake)', () => {
+    // The orb-widget polls the stream and expects an EventSource-shaped
+    // connection. These three headers are the contract.
+    it('sets Content-Type: text/event-stream', () => {
+      expect(handlerBody).toMatch(
+        /res\.setHeader\(\s*['"`]Content-Type['"`]\s*,\s*['"`]text\/event-stream['"`]\s*\)/
+      );
+    });
+
+    it('sets Cache-Control: no-cache', () => {
+      expect(handlerBody).toMatch(
+        /res\.setHeader\(\s*['"`]Cache-Control['"`]\s*,\s*['"`]no-cache['"`]\s*\)/
+      );
+    });
+
+    it('sets Connection: keep-alive', () => {
+      expect(handlerBody).toMatch(
+        /res\.setHeader\(\s*['"`]Connection['"`]\s*,\s*['"`]keep-alive['"`]\s*\)/
+      );
+    });
+  });
+
+  describe('SSE wire framing', () => {
+    // Every event the SSE handler emits must use `data: ${json}\n\n` —
+    // EventSource only parses that exact format. Any drift breaks the
+    // browser's parsing.
+    //
+    // Approach: locate every `res.write(` call site in the handler. Look
+    // at the chars immediately after the opening paren — they must begin
+    // with a string/template literal whose first content is `data: `. We
+    // do NOT try to capture the full multi-line template body (some are
+    // 10+ lines with nested ${...} expressions); we only assert the
+    // prefix anchor, which is the SSE-framing contract.
+    it('every res.write in this handler starts with the "data: " SSE prefix', () => {
+      const writeRe = /res\.write\s*\(\s*/g;
+      const startPositions: number[] = [];
+      let m: RegExpExecArray | null;
+      while ((m = writeRe.exec(handlerBody)) !== null) {
+        startPositions.push(m.index + m[0].length);
+      }
+      expect(startPositions.length).toBeGreaterThan(0);
+
+      for (const pos of startPositions) {
+        const window = handlerBody.slice(pos, pos + 40);
+        if (!/^[`'"]\s*data:\s/.test(window)) {
+          throw new Error(
+            `Non-SSE res.write inside /live/stream handler — every event must start with 'data: ' (SSE wire prefix).\nWindow: ${JSON.stringify(window)}`
+          );
+        }
+      }
+    });
+
+    it('every SSE event payload terminates with \\n\\n (or its escaped form)', () => {
+      // EventSource requires the double-newline terminator to dispatch the
+      // event. Coarse contract: at least one terminator per res.write
+      // call in the handler. Parsing each multi-line template's tail
+      // exactly is fragile across formatter changes; this is the cheaper
+      // anchor that still flags a missing terminator.
+      const writeCount = (handlerBody.match(/res\.write\s*\(/g) ?? []).length;
+      expect(writeCount).toBeGreaterThan(0);
+
+      const literalTerminators = (handlerBody.match(/\n\n/g) ?? []).length;
+      const escapedTerminators = (handlerBody.match(/\\n\\n/g) ?? []).length;
+      expect(literalTerminators + escapedTerminators).toBeGreaterThanOrEqual(writeCount);
+    });
+  });
+
+  describe('initial "ready" event payload', () => {
+    // VTID-INSTANT-FEEDBACK: the client transitions UI and plays the
+    // activation chime as soon as it receives this event. The four meta
+    // fields below are read by the widget; dropping any of them breaks
+    // chime timing or audio init.
+    it('emits an event with type: "ready"', () => {
+      expect(handlerBody).toMatch(/type\s*:\s*['"`]ready['"`]/);
+    });
+
+    it('includes session_id in the ready payload', () => {
+      expect(handlerBody).toMatch(/session_id\s*:/);
+    });
+
+    it('includes live_api_connected boolean in the ready payload', () => {
+      expect(handlerBody).toMatch(/live_api_connected\s*:/);
+    });
+
+    it('includes meta.model in the ready payload', () => {
+      expect(handlerBody).toMatch(/\bmodel\s*:/);
+    });
+
+    it('includes meta.lang in the ready payload', () => {
+      expect(handlerBody).toMatch(/\blang\s*:/);
+    });
+
+    it('includes meta.voice in the ready payload', () => {
+      expect(handlerBody).toMatch(/\bvoice\s*:/);
+    });
+
+    it('declares audio_out_rate (server → client TTS sample rate)', () => {
+      expect(handlerBody).toMatch(/audio_out_rate\s*:\s*\d+/);
+    });
+
+    it('declares audio_in_rate (client → server mic sample rate)', () => {
+      expect(handlerBody).toMatch(/audio_in_rate\s*:\s*\d+/);
+    });
+  });
+
+  describe('heartbeat event', () => {
+    // The client uses heartbeat events to detect connection death. Without
+    // them, an idle session looks alive even when the upstream Live API
+    // socket has dropped. The framing must match the wire-framing rule
+    // above so EventSource fires its message handler.
+    it('emits a heartbeat event with a timestamp', () => {
+      expect(handlerBody).toMatch(/type\s*:\s*['"`]heartbeat['"`]/);
+      // Timestamp surface — currently `ts: Date.now()`, but lock only the
+      // field name so a future ISO-string switch wouldn't false-fail.
+      expect(handlerBody).toMatch(/\bts\s*:/);
+    });
+  });
+
+  describe('session id parameter', () => {
+    it('reads session_id from query string', () => {
+      expect(handlerBody).toMatch(/req\.query\.session_id/);
+    });
+
+    it('rejects request with 400 when session_id is missing', () => {
+      // The handler returns res.status(400) when sessionId is falsy.
+      // Lock the response shape — the orb-widget treats a 4xx differently
+      // from a transport disconnect, and "session_id required" is the
+      // contract.
+      expect(handlerBody).toMatch(/status\(\s*400\s*\)/);
+      expect(handlerBody).toMatch(/session_id\s+required/);
+    });
+  });
+});

--- a/services/gateway/test/orb/live/characterization/stream-lifecycle.characterization.test.ts
+++ b/services/gateway/test/orb/live/characterization/stream-lifecycle.characterization.test.ts
@@ -1,0 +1,103 @@
+/**
+ * A0.3 — Characterization test for transport lifecycle cleanup.
+ *
+ * Purpose: lock the cleanup contract for both transports — every stream
+ * that holds resources must release them when the client disconnects.
+ * Without these handlers, an orb session that drops mid-call leaks the
+ * upstream Live API socket + the audio context.
+ *
+ * Scope: assertions are made against the SSE-handler block AND the
+ * WebSocket cleanup function in isolation, so unrelated handlers can't
+ * accidentally satisfy them.
+ *
+ * Will be replaced/augmented by A9 with a runtime test against the
+ * extracted transport modules + a lifecycle integration test.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ORB_LIVE_PATH = path.resolve(__dirname, '../../../../src/routes/orb-live.ts');
+
+let sseHandlerBody: string;
+let wsCleanupSection: string;
+
+beforeAll(() => {
+  const source = fs.readFileSync(ORB_LIVE_PATH, 'utf8');
+
+  // Slice the SSE handler block.
+  const sseStart = source.indexOf("router.get('/live/stream'");
+  const sseStop = source.indexOf("router.post('/live/stream/send'");
+  expect(sseStart).toBeGreaterThan(0);
+  expect(sseStop).toBeGreaterThan(sseStart);
+  sseHandlerBody = source.slice(sseStart, sseStop);
+
+  // Slice a wider section starting at the WebSocket setup function
+  // through the file end. The cleanup logic lives in helpers below
+  // initializeOrbWebSocket (cleanupWsSession, the connection close handler,
+  // and the periodic timeout sweep).
+  const wsStart = source.indexOf('export function initializeOrbWebSocket');
+  expect(wsStart).toBeGreaterThan(0);
+  wsCleanupSection = source.slice(wsStart);
+});
+
+describe('A0.3 characterization: transport lifecycle cleanup', () => {
+  describe('SSE: client-disconnect cleanup', () => {
+    it("registers a req.on('close', ...) handler", () => {
+      // EventSource on the browser side fires onclose (or just stops
+      // pinging) when the user closes the tab. Without req.on('close')
+      // the server-side res object stays open forever.
+      expect(sseHandlerBody).toMatch(/req\.on\(\s*['"`]close['"`]\s*,/);
+    });
+  });
+
+  describe('WebSocket: connection lifecycle', () => {
+    it('removes sessions from wsClientSessions on cleanup', () => {
+      // Leak guard: if cleanup doesn't .delete from the map, the periodic
+      // sweep iterates over zombies indefinitely and memory grows.
+      expect(wsCleanupSection).toMatch(/wsClientSessions\.delete\s*\(/);
+    });
+
+    it('clears intervals on cleanup (upstream ping + silence keepalive)', () => {
+      // Two intervals run per session (upstream Vertex Live ping +
+      // silence keepalive). Both must be cleared on disconnect.
+      expect(wsCleanupSection).toMatch(/clearInterval\s*\(/);
+    });
+
+    it('attempts to close the upstream websocket on cleanup', () => {
+      // The upstream Vertex Live socket is the real resource. Forgetting
+      // to close it leaks both bandwidth and Vertex billing time.
+      expect(wsCleanupSection).toMatch(/upstreamWs[\s\S]{0,80}?\.close\s*\(/);
+    });
+
+    it('attempts to close the client websocket on cleanup (if still OPEN)', () => {
+      // Symmetric to the upstream close — the client side must be told
+      // explicitly so its onclose handler fires with the expected code.
+      expect(wsCleanupSection).toMatch(/clientWs\.close\s*\(/);
+    });
+
+    it('runs a periodic timeout sweep over wsClientSessions', () => {
+      // The sweep is what catches sessions whose close events never
+      // arrived (network drop, mobile background, etc.). It must
+      // remain — without it, ghost sessions accumulate.
+      expect(wsCleanupSection).toMatch(/setInterval\s*\(/);
+      expect(wsCleanupSection).toMatch(/wsClientSessions\.entries\s*\(\s*\)/);
+    });
+
+    it('uses a session timeout constant (not an inline magic number)', () => {
+      // SESSION_TIMEOUT_MS is the canonical name. A refactor that inlines
+      // a literal here would lose the single source of truth.
+      expect(wsCleanupSection).toMatch(/SESSION_TIMEOUT_MS/);
+    });
+  });
+
+  describe('cleanup symmetry across transports', () => {
+    it('both SSE and WS cleanup paths exist (parity)', () => {
+      // The two transports must each have their own cleanup story.
+      // Catching this mismatch early — if one path silently goes away
+      // during refactor — is the whole point of this test.
+      expect(sseHandlerBody).toMatch(/req\.on\(\s*['"`]close['"`]/);
+      expect(wsCleanupSection).toMatch(/wsClientSessions\.delete/);
+    });
+  });
+});

--- a/services/gateway/test/orb/live/characterization/websocket-setup.characterization.test.ts
+++ b/services/gateway/test/orb/live/characterization/websocket-setup.characterization.test.ts
@@ -1,0 +1,98 @@
+/**
+ * A0.3 — Characterization test for the WebSocket transport setup.
+ *
+ * Purpose: lock the WebSocket initialization contract — registry, upgrade
+ * path, connection + error handler registration — before step A9 splits
+ * transport into orb/live/transport/websocket-handler.ts.
+ *
+ * Approach: structural over orb-live.ts, scoped to the
+ * `initializeOrbWebSocket` function block only.
+ *
+ * Will be replaced/augmented by A9 with a runtime test against
+ * orb/live/transport/websocket-handler.ts.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ORB_LIVE_PATH = path.resolve(__dirname, '../../../../src/routes/orb-live.ts');
+
+let setupBody: string;
+let registryDecl: string;
+
+beforeAll(() => {
+  const source = fs.readFileSync(ORB_LIVE_PATH, 'utf8');
+
+  // Slice the WebSocket setup function. It is the only `export function`
+  // whose name begins with `initializeOrb`, so the next `export function`
+  // (or end-of-file) is a safe terminator.
+  const setupStart = source.indexOf('export function initializeOrbWebSocket');
+  expect(setupStart).toBeGreaterThan(0);
+  const afterStart = source.slice(setupStart + 1);
+  const nextExport = afterStart.search(/\nexport\s+(function|const|class)\s/);
+  setupBody = nextExport >= 0
+    ? source.slice(setupStart, setupStart + 1 + nextExport)
+    : source.slice(setupStart);
+
+  // Find the registry declaration. It is module-level, not inside the
+  // setup function, so we capture it separately.
+  const registryStart = source.indexOf('wsClientSessions = new Map');
+  expect(registryStart).toBeGreaterThan(0);
+  // Take ~500 chars around the declaration as context.
+  registryDecl = source.slice(Math.max(0, registryStart - 100), registryStart + 200);
+});
+
+describe('A0.3 characterization: WebSocket transport setup contract', () => {
+  describe('initializeOrbWebSocket() function', () => {
+    it('is exported (so the gateway entrypoint can wire it)', () => {
+      // Already implied by the slice succeeding, but assert explicitly so
+      // a refactor that drops the export breaks loudly.
+      expect(setupBody).toMatch(/^export\s+function\s+initializeOrbWebSocket/);
+    });
+
+    it('accepts an HttpServer parameter (Express HTTP server instance)', () => {
+      expect(setupBody).toMatch(/initializeOrbWebSocket\s*\(\s*server\s*:\s*HttpServer\s*\)/);
+    });
+
+    it('mounts the WebSocket server at /api/v1/orb/live/ws', () => {
+      // The orb-widget reconnects to this exact path. Any change to the
+      // path breaks every existing client.
+      expect(setupBody).toMatch(
+        /path\s*:\s*['"`]\/api\/v1\/orb\/live\/ws['"`]/
+      );
+    });
+
+    it('attaches the WebSocketServer to the HTTP server (single-port, not separate)', () => {
+      // `server: <param>` in the WebSocketServer options means it shares
+      // the HTTP listener — no separate port, no separate listen() call.
+      // A1+ refactor must preserve the same attachment model.
+      expect(setupBody).toMatch(/new\s+WebSocketServer\s*\(\s*\{[\s\S]*?\bserver\b[\s\S]*?\}\s*\)/);
+    });
+
+    it("registers a 'connection' handler", () => {
+      expect(setupBody).toMatch(/wss\.on\(\s*['"`]connection['"`]\s*,/);
+    });
+
+    it("registers an 'error' handler (server-level error, separate from per-connection errors)", () => {
+      expect(setupBody).toMatch(/wss\.on\(\s*['"`]error['"`]\s*,/);
+    });
+  });
+
+  describe('per-session registry', () => {
+    it('declares wsClientSessions as a Map', () => {
+      // The Map type matters — the cleanup interval iterates over it.
+      // A switch to a different container (Set, plain object, WeakMap)
+      // would silently break iteration semantics.
+      expect(registryDecl).toMatch(/wsClientSessions\s*=\s*new\s+Map\s*</);
+    });
+  });
+
+  describe('connection handler delegates to handleWebSocketConnection', () => {
+    // The setup function should NOT inline the per-connection logic —
+    // that lives in handleWebSocketConnection, which A9 will move.
+    // Lock the delegation so an inline rewrite doesn't sneak in here.
+    it('forwards the (ws, req) tuple to handleWebSocketConnection', () => {
+      expect(setupBody).toMatch(/handleWebSocketConnection\s*\(\s*ws\s*,\s*req\s*\)/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Final slice of the **orb-live.ts refactor characterization phase** (Track A of [the assistant-intelligence plan](.claude/plans/for-an-intelligent-context-aware-fluttering-mango.md)). Tests-only — locks the SSE + WebSocket + lifecycle contracts inside [orb-live.ts](services/gateway/src/routes/orb-live.ts) before step **A9 (transport split)**.

**These are structural characterization tests by design; A8/A9 will replace/augment them with runtime tests after transport extraction.**

**Independent of #2023 and #2025** — this PR can merge in any order relative to the other two A0 sub-PRs.

## What lands here (A0.3)

Three structural test files under [services/gateway/test/orb/live/characterization/](services/gateway/test/orb/live/characterization/):

| Target | Test file | Coverage |
|---|---|---|
| `/live/stream` SSE handler (will move in A9) | `sse-stream.characterization.test.ts` | Response headers (the EventSource handshake), `data: ...\n\n` wire framing, VTID-INSTANT-FEEDBACK `ready` event payload (`type`, `session_id`, `live_api_connected`, `meta.{model, lang, voice}`, `audio_out_rate`, `audio_in_rate`), heartbeat event, session_id query param + 400 path. |
| `initializeOrbWebSocket` setup function (will move in A9) | `websocket-setup.characterization.test.ts` | Exported with `HttpServer` parameter, mounted at `/api/v1/orb/live/ws`, attached to existing HTTP server, connection + error handlers, `wsClientSessions` Map registry, delegation to `handleWebSocketConnection`. |
| Transport lifecycle cleanup (will move in A9) | `stream-lifecycle.characterization.test.ts` | SSE: `req.on('close', ...)` cleanup. WS: registry `.delete()`, interval clears, upstream + client WS close, periodic timeout sweep, `SESSION_TIMEOUT_MS` constant. Symmetry: both transports have a cleanup story. |

## Production-source change

**None.** This PR adds zero production code. No `export` plumbing, no helper extraction. The transport handlers are too coupled with Express + Vertex Live API + audio streaming to runtime-mock cleanly, and per the plan's strict rule, even a tiny helper extraction would already be production refactor work.

## Scope discipline (per the plan's guardrails)

- Each test slices the **relevant handler block** out of `orb-live.ts` source text and asserts against that slice only — never file-wide grep.
- **No line-number anchors** — assertions are on structural names (function names, route paths, header names, payload field names).
- Only **observable contracts** are locked: response headers, payload field names, framing prefix/terminator, cleanup function calls.

## Other changes

- `.gitignore`: ignore `.worktrees/` (parallel to #2023 and #2025 — keeps this PR independent).

## Run locally

```bash
cd services/gateway
npx jest test/orb/live/characterization/
```

Expected: **32 passed, 0 snapshots (structural-only), 0 failures.**

## Test plan

- [x] All 32 characterization tests pass on this branch (structural-only)
- [x] No production-source diff in this PR (only tests + `.gitignore`)
- [ ] CI green before merge
- [ ] After merge of A0.1 + A0.2 + A0.3: A1 (extract types/protocol) opens on the same `orb-live-refactor/*` branch family

## Plan reference

`.claude/plans/for-an-intelligent-context-aware-fluttering-mango.md` — Track A, step A0.3 (final A0 sub-PR before extraction begins).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
