### PR TITLE
fix(notifications): parse Appilix JSON response so silent failures surface in logs

### DIFF
--- a/services/gateway/src/services/notification-service.ts
+++ b/services/gateway/src/services/notification-service.ts
@@ -288,9 +288,25 @@ export async function sendAppilixPush(
       body: params.toString(),
     });
 
+    const text = await res.text().catch(() => '');
+
     if (!res.ok) {
-      const text = await res.text().catch(() => '');
       console.warn(`[Notifications] Appilix push failed (${res.status}):`, text);
+      return false;
+    }
+
+    // Appilix returns HTTP 200 with { status: false, message: "No devices..." }
+    // when delivery fails (e.g. no device registered for that user_identity).
+    // Parse the JSON body and treat status:false as failure so the log
+    // accurately reflects what Appilix did.
+    let parsed: { status?: boolean | string; message?: string } | null = null;
+    try { parsed = JSON.parse(text); } catch { /* not JSON */ }
+    const ok = parsed?.status === true || parsed?.status === 'true';
+    if (!ok) {
+      console.warn(
+        `[Notifications] Appilix push DROPPED for user=${userId.slice(0, 8)}…: ` +
+        `${parsed?.message || text}`
+      );
       return false;
     }
     console.log(`[Notifications] Appilix push sent for user=${userId.slice(0, 8)}…`);


### PR DESCRIPTION
## Summary

Companion to `exafyltd/vitana-v1` PR (Edge Function + drop-trigger migration).

Appilix returns HTTP 200 with `{ status: false, message: "No devices found..." }` when delivery fails (e.g. no device registered for the `user_identity` sent). The previous `sendAppilixPush()` code only checked `res.ok` and logged `[Notifications] Appilix push sent` on HTTP 200, masking these failures.

This was the source of significant debugging confusion: gateway logs were showing hundreds of `Appilix push sent for user=...` lines while iPhone users weren't actually receiving anything, because Appilix had no device registered for the `user_identity` we were sending.

## Changes

`services/gateway/src/services/notification-service.ts:285-305` — parse the Appilix JSON response body. Treat `status: false` (or `"false"` string) as failure and emit:

```
[Notifications] Appilix push DROPPED for user=<8>...: <message>
```

instead of the false-success log. Return value remains `boolean` (`true` only on actual delivery).

## Why this matters

When the next time we (or a future agent) investigate Appilix delivery issues, the logs will tell the truth. No more chasing problems that the gateway thought it had already solved.

## Test plan

- [ ] Verify the merged build deploys via EXEC-DEPLOY (BOOTSTRAP-APPILIX-RESPONSE-PARSING in commit message)
- [ ] Send a chat message from Android to an iPhone user whose Appilix `user_identity` is registered → expect `[Notifications] Appilix push sent for user=...` (existing log)
- [ ] Send a chat message to a user whose `user_identity` is NOT registered with Appilix → expect new `[Notifications] Appilix push DROPPED for user=...: No devices found...` log
- [ ] Confirm no `sendAppilixPush` regressions in regular notification flow

## Related

- Companion PR in `vitana-v1`: drops duplicate `trg_appilix_push` Postgres trigger + same JSON parsing fix in `supabase/functions/appilix-push/index.ts`
- Earlier PRs: `vitana-v1#429`, `#430`, `#439` (frontend identity registration via cookie + reload)

https://claude.ai/code/session_01AABjoZDKaA2XxXP5t9715a

---
_Generated by [Claude Code](https://claude.ai/code/session_01AABjoZDKaA2XxXP5t9715a)_