### PR TITLE
refactor(orb-live): A2 — extract config/env (VTID-02870)

### DIFF
--- a/services/gateway/src/orb/live/config.ts
+++ b/services/gateway/src/orb/live/config.ts
@@ -1,0 +1,75 @@
+/**
+ * A2 (orb-live-refactor): env-derived and lifecycle config constants.
+ *
+ * Lifted verbatim from services/gateway/src/routes/orb-live.ts.
+ * Identical values + identical env fallbacks — no behavior change.
+ * orb-live.ts now imports these instead of declaring them locally so
+ * subsequent extraction steps (A7 upstream client, A8 session lifecycle)
+ * share the same Vertex project/location resolution and lifecycle
+ * timeouts.
+ *
+ * What lives here: top-level configuration that
+ *   (a) reads process.env at module-load time, OR
+ *   (b) sets a lifecycle/timing boundary the whole route file depends on.
+ *
+ * What does NOT live here: in-function env reads (those stay with their
+ * function), CORS origin allow-lists (coupled with the CORS handler),
+ * legacy `GEMINI_*` direct-API constants (legacy path, separate concern),
+ * regex patterns for auth-intent detection (coupled with classifier).
+ */
+
+// VTID-01155: Vertex AI Live API configuration.
+// Cloud Run does NOT auto-set GOOGLE_CLOUD_PROJECT env var, so we fall back
+// to the hardcoded project ID. Same fallback as before the lift.
+export const VERTEX_PROJECT_ID =
+  process.env.GOOGLE_CLOUD_PROJECT
+  || process.env.GCP_PROJECT_ID
+  || 'lovable-vitana-vers1';
+
+export const VERTEX_LOCATION = process.env.VERTEX_AI_LOCATION || 'us-central1';
+
+/**
+ * Live (ORB voice) session timeout. After 30 minutes of inactivity the
+ * periodic session sweep purges the entry from `liveSessions`. SSE/WS
+ * cleanup handlers handle the happy path; this is the safety net.
+ */
+export const SESSION_TIMEOUT_MS = 30 * 60 * 1000;
+
+/**
+ * Conversation (text-chat) timeout. Conversations live longer than voice
+ * sessions because text turns happen on human timescales.
+ */
+export const CONVERSATION_TIMEOUT_MS = 24 * 60 * 60 * 1000;
+
+/**
+ * Maximum concurrent ORB connections from a single IP. Higher values
+ * invite abuse; lower values break shared offices/NAT exits.
+ */
+export const MAX_CONNECTIONS_PER_IP = 5;
+
+/**
+ * Maximum auto-reconnects per session before the client is forced to
+ * start a fresh session. 10 reconnects ≈ 50 minutes of session continuity.
+ */
+export const MAX_RECONNECTS = 10;
+
+/**
+ * Languages the Live API officially supports. New languages must land
+ * here AND in the voice + greeting lookup tables.
+ *
+ * NOTE: typed as `string[]` (not `readonly ['en', 'de', ...]`) on purpose:
+ * existing callsites pass arbitrary strings into `.includes()` for runtime
+ * checks, and narrowing the type would force casts at every callsite.
+ * A later cleanup can introduce a typed `SupportedLiveLanguage` union if
+ * we want to refactor those callsites to a typed gate.
+ */
+export const SUPPORTED_LIVE_LANGUAGES: string[] = [
+  'en',
+  'de',
+  'fr',
+  'es',
+  'ar',
+  'zh',
+  'sr',
+  'ru',
+];

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -298,8 +298,8 @@ interface StopMessage {
 // In-memory session store (dev sandbox only)
 const sessions = new Map<string, OrbLiveSession>();
 
-// Session timeout: 30 minutes
-const SESSION_TIMEOUT_MS = 30 * 60 * 1000;
+// A2 (orb-live-refactor): SESSION_TIMEOUT_MS lifted to orb/live/config.ts.
+import { SESSION_TIMEOUT_MS } from '../orb/live/config';
 
 // Allowed origins (dev sandbox)
 // VTID-01226: Added Lovable dynamic origins for frontend integration
@@ -335,8 +335,8 @@ const ALLOWED_ORIGIN_PATTERNS = [
   /^https:\/\/community-app[a-z0-9-]*\.us-central1\.run\.app$/,
 ];
 
-// Connection limit per IP (dev sandbox)
-const MAX_CONNECTIONS_PER_IP = 5;
+// A2 (orb-live-refactor): MAX_CONNECTIONS_PER_IP lifted to orb/live/config.ts.
+import { MAX_CONNECTIONS_PER_IP } from '../orb/live/config';
 const connectionCountByIP = new Map<string, number>();
 
 // Gemini API configuration
@@ -674,7 +674,8 @@ const orbConversations = new Map<string, OrbConversation>();
 
 // VTID-0135: Conversation timeout
 // VTID-01109: Extended from 30 minutes to 24 hours for better conversation continuity
-const CONVERSATION_TIMEOUT_MS = 24 * 60 * 60 * 1000; // 24 hours
+// A2 (orb-live-refactor): CONVERSATION_TIMEOUT_MS lifted to orb/live/config.ts.
+import { CONVERSATION_TIMEOUT_MS } from '../orb/live/config';
 
 // =============================================================================
 // VTID-01039: ORB Session Transcript Store
@@ -733,7 +734,8 @@ const LIVE_LANGUAGE_VOICES: Record<string, string> = {
   'ru': 'Gacrux'
 };
 
-const SUPPORTED_LIVE_LANGUAGES = ['en', 'de', 'fr', 'es', 'ar', 'zh', 'sr', 'ru'];
+// A2 (orb-live-refactor): SUPPORTED_LIVE_LANGUAGES lifted to orb/live/config.ts.
+import { SUPPORTED_LIVE_LANGUAGES } from '../orb/live/config';
 
 /**
  * VTID-01155: Gemini Live session state
@@ -1085,8 +1087,8 @@ function terminateExistingSessionsForUser(userId: string, excludeSessionId?: str
 // VTID-01155: Vertex AI Live API configuration
 // Cloud Run does NOT auto-set GOOGLE_CLOUD_PROJECT env var.
 // Fallback to hardcoded project ID for Cloud Run deployments.
-const VERTEX_PROJECT_ID = process.env.GOOGLE_CLOUD_PROJECT || process.env.GCP_PROJECT_ID || 'lovable-vitana-vers1';
-const VERTEX_LOCATION = process.env.VERTEX_AI_LOCATION || 'us-central1';
+// A2 (orb-live-refactor): VERTEX_PROJECT_ID + VERTEX_LOCATION lifted to orb/live/config.ts.
+import { VERTEX_PROJECT_ID, VERTEX_LOCATION } from '../orb/live/config';
 // A1 (orb-live-refactor): VERTEX_LIVE_MODEL + VERTEX_TTS_MODEL lifted to
 // orb/live/protocol.ts. Same values, same callers; the constants now live
 // in a shared module so A3/A7/A9 don't have to re-declare them.
@@ -9837,7 +9839,8 @@ async function connectToLiveAPI(
  *
  * MAX_RECONNECTS prevents infinite reconnection loops.
  */
-const MAX_RECONNECTS = 10; // Max reconnections per session (~50 min total)
+// A2 (orb-live-refactor): MAX_RECONNECTS lifted to orb/live/config.ts.
+import { MAX_RECONNECTS } from '../orb/live/config';
 
 async function attemptTransparentReconnect(
   session: GeminiLiveSession,


### PR DESCRIPTION
Tests-only-foundation extraction; A2 lifts env-derived + lifecycle config to `services/gateway/src/orb/live/config.ts`. Targets: VERTEX_PROJECT_ID, VERTEX_LOCATION, SESSION_TIMEOUT_MS, CONVERSATION_TIMEOUT_MS, MAX_CONNECTIONS_PER_IP, MAX_RECONNECTS, SUPPORTED_LIVE_LANGUAGES. 133 characterization tests pass, 9 snapshots match. tsc clean. Part of Track A, step A2.