### PR TITLE
fix(voice-improve): drain false positives + mark deferred awareness signals (VTID-02899)

### DIFF
--- a/services/gateway/src/services/awareness-registry.ts
+++ b/services/gateway/src/services/awareness-registry.ts
@@ -305,9 +305,13 @@ const M: AwarenessSignal[] = [
   { key: 'context.client.accept_language',tier: 'context', subcategory: 'Client context (IP + device)', label: 'Accept-Language',description: 'Browser-preferred language.', default_on: true, wired: 'live' },
   { key: 'context.last_session_info',     tier: 'context', subcategory: 'Session continuity',           label: 'Last session info', description: 'When the user was last in voice + whether it failed.', default_on: true, wired: 'partial' },
   // VTID-02858 wired-mapping: user's #8 (Conversation Summary) — not_wired (returns null).
-  { key: 'context.conversation_summary',  tier: 'context', subcategory: 'Session continuity',           label: 'Conversation summary', description: 'Returning-user bridge summary text.', default_on: true, wired: 'not_wired' },
+  // VTID-02899: deferred-by-design — marked enforcement_status: 'pending'
+  // so the Voice Improve briefing doesn't surface this as an urgent action
+  // item. Wired badge in the Registry still shows ✗ (status reflects reality).
+  { key: 'context.conversation_summary',  tier: 'context', subcategory: 'Session continuity',           label: 'Conversation summary', description: 'Returning-user bridge summary text.', default_on: true, wired: 'not_wired', enforcement_status: 'pending' },
   // VTID-02858 wired-mapping: user's #10 (Last-10-turns conversation history) — not_wired.
-  { key: 'context.conversation_history',  tier: 'context', subcategory: 'Session continuity',           label: 'Conversation history (reconnect)', description: 'Last N turns when reconnecting.', default_on: true, wired: 'not_wired', params: [
+  // VTID-02899: deferred-by-design (see above).
+  { key: 'context.conversation_history',  tier: 'context', subcategory: 'Session continuity',           label: 'Conversation history (reconnect)', description: 'Last N turns when reconnecting.', default_on: true, wired: 'not_wired', enforcement_status: 'pending', params: [
       { key: 'max_turns', label: 'Max turns', type: 'int', default: 10, min: 1, max: 50, step: 1 },
   ]},
   { key: 'context.journey_stage',         tier: 'context', subcategory: 'Session continuity',           label: 'Journey stage', description: '90-day wave / wave_name / day_number.', default_on: true, wired: 'live' },
@@ -342,9 +346,12 @@ const M: AwarenessSignal[] = [
 
   // ─── 12. OVERRIDES (high-priority, append-last blocks) ───────────────────
   // VTID-02858 wired-mapping: user's #16 (Proactive Opener Override matrix) — not_wired.
-  { key: 'overrides.proactive_opener',    tier: 'overrides', subcategory: 'High-priority overrides', label: 'PROACTIVE OPENER OVERRIDE', description: 'VTID-01927 — appended after temporal journey to override greeting reflexes.', default_on: true, wired: 'not_wired' },
+  // VTID-02899: deferred-by-design — enforcement_status: 'pending' excludes
+  // from Voice Improve briefing as actionable; Registry still shows ✗.
+  { key: 'overrides.proactive_opener',    tier: 'overrides', subcategory: 'High-priority overrides', label: 'PROACTIVE OPENER OVERRIDE', description: 'VTID-01927 — appended after temporal journey to override greeting reflexes.', default_on: true, wired: 'not_wired', enforcement_status: 'pending' },
   // VTID-02858 wired-mapping: user's #17 (Activity awareness override) — not_wired.
-  { key: 'overrides.activity_awareness',  tier: 'overrides', subcategory: 'High-priority overrides', label: 'ACTIVITY AWARENESS OVERRIDE', description: 'BOOTSTRAP-HISTORY-AWARE-TIMELINE — re-asserts USER CONTEXT PROFILE at end of prompt with hard rules.', default_on: true, wired: 'not_wired' },
+  // VTID-02899: deferred-by-design (see above).
+  { key: 'overrides.activity_awareness',  tier: 'overrides', subcategory: 'High-priority overrides', label: 'ACTIVITY AWARENESS OVERRIDE', description: 'BOOTSTRAP-HISTORY-AWARE-TIMELINE — re-asserts USER CONTEXT PROFILE at end of prompt with hard rules.', default_on: true, wired: 'not_wired', enforcement_status: 'pending' },
   // VTID-02858 wired-mapping: user's #6 (Navigator policy section) — partial (gates wired, prose section missing).
   { key: 'overrides.navigator_policy',    tier: 'overrides', subcategory: 'High-priority overrides', label: 'Navigator policy',           description: 'Navigator tool routing rules section.', default_on: true, enforcement_status: 'pending', wired: 'partial' },
   // VTID-02858 wired-mapping: user's #7 (Temporal/journey context) — live.

--- a/services/gateway/src/services/awareness-watchdogs.ts
+++ b/services/gateway/src/services/awareness-watchdogs.ts
@@ -148,14 +148,14 @@ export async function getWatchdogStatuses(): Promise<WatchdogStatus[]> {
     const since = new Date(Date.now() - PASS_WINDOW_HOURS * 60 * 60 * 1000).toISOString();
     const { data } = await sb
       .from('oasis_events')
-      .select('topic, occurred_at')
+      .select('topic, created_at')
       .in('topic', topics)
-      .gte('occurred_at', since)
-      .order('occurred_at', { ascending: false })
+      .gte('created_at', since)
+      .order('created_at', { ascending: false })
       .limit(500);
-    for (const row of (data || []) as Array<{ topic: string; occurred_at: string }>) {
+    for (const row of (data || []) as Array<{ topic: string; created_at: string }>) {
       if (!mostRecentByTopic[row.topic]) {
-        mostRecentByTopic[row.topic] = row.occurred_at;
+        mostRecentByTopic[row.topic] = row.created_at;
       }
     }
   }

--- a/services/gateway/src/services/voice-improvement-aggregator.ts
+++ b/services/gateway/src/services/voice-improvement-aggregator.ts
@@ -225,6 +225,20 @@ async function fetchWatchdogIssues(cfg: SupabaseConfig): Promise<ActionItem[]> {
   } catch {
     return [];
   }
+  // VTID-02899: a watchdog whose every watched signal is wired='not_wired'
+  // is by design unable to observe — surfacing it as a blind spot duplicates
+  // the awareness_not_wired finding for the same signal. Filter those out so
+  // the operator sees one row per gap, not two.
+  const manifest = getAwarenessManifest();
+  const notWired = new Set<string>();
+  for (const sig of manifest) {
+    if (sig.wired === 'not_wired') notWired.add(sig.key);
+  }
+  const allWatchedNotWired = (w: typeof statuses[number]['watchdog']): boolean => {
+    if (!w.watches || w.watches.length === 0) return false;
+    return w.watches.every((k) => notWired.has(k));
+  };
+
   for (const s of statuses) {
     if (s.verdict === 'fail') {
       out.push({
@@ -248,6 +262,8 @@ async function fetchWatchdogIssues(cfg: SupabaseConfig): Promise<ActionItem[]> {
         detected_at: new Date().toISOString(),
       });
     } else if (s.verdict === 'unknown') {
+      // VTID-02899: suppress if all watched signals are not_wired by design.
+      if (allWatchedNotWired(s.watchdog)) continue;
       out.push({
         id: `watchdog_unknown:${s.watchdog.id}`,
         source: 'watchdog_unknown' as const,
@@ -457,10 +473,16 @@ async function fetchProviderDrift(cfg: SupabaseConfig): Promise<ActionItem[]> {
 async function fetchFailureClassesNoRule(cfg: SupabaseConfig): Promise<ActionItem[]> {
   try {
     // Lazy-import so taxonomy file isn't pulled during testing if not needed.
+    // VTID-02899: the export is `VOICE_FAILURE_CLASSES` (array), not
+    // `FAILURE_CLASSES` (which doesn't exist). Original lookup never
+    // populated knownClasses → every class with an open report was
+    // reported as "no rule", producing false-positive findings on classes
+    // that already had taxonomy entries (e.g. voice.model_under_responds).
     const taxonomy = await import('./voice-failure-taxonomy').catch(() => null);
     const knownClasses = new Set<string>();
-    if (taxonomy && typeof (taxonomy as any).FAILURE_CLASSES === 'object') {
-      for (const k of Object.keys((taxonomy as any).FAILURE_CLASSES || {})) knownClasses.add(k);
+    const arr = taxonomy && (taxonomy as any).VOICE_FAILURE_CLASSES;
+    if (Array.isArray(arr)) {
+      for (const k of arr) if (typeof k === 'string') knownClasses.add(k);
     }
 
     const r = await fetch(
@@ -514,11 +536,11 @@ async function fetchVoiceSessionHealth(cfg: SupabaseConfig): Promise<VoiceImprov
   try {
     const since = new Date(Date.now() - 24 * 3600_000).toISOString();
     const r = await fetch(
-      `${cfg.url}/rest/v1/oasis_events?topic=in.(vtid.live.session.stop,voice.live.session.ended)&occurred_at=gte.${encodeURIComponent(since)}&select=topic,metadata,occurred_at&order=occurred_at.desc&limit=500`,
+      `${cfg.url}/rest/v1/oasis_events?topic=in.(vtid.live.session.stop,voice.live.session.ended)&created_at=gte.${encodeURIComponent(since)}&select=topic,metadata,created_at&order=created_at.desc&limit=500`,
       { headers: authHeaders(cfg) },
     );
     if (!r.ok) return empty;
-    const rows = (await r.json()) as Array<{ topic: string; metadata: any; occurred_at: string }>;
+    const rows = (await r.json()) as Array<{ topic: string; metadata: any; created_at: string }>;
     let total = 0,
       audioInZero = 0,
       oneWay = 0;


### PR DESCRIPTION
## Summary

Code-side cleanup paired with an operator-led drain of the Voice / Improve cockpit. Found two real aggregator bugs plus one duplication and one deferred-by-design backlog.

## Bugs fixed

1. **oasis_events column name** — both `services/voice-improvement-aggregator.ts` and `services/awareness-watchdogs.ts` queried `occurred_at`, but the column is `created_at`. Every awareness watchdog returned `fail`/`unknown` even when its topic was emitting normally → 7 false-positive `watchdog_failed` items. `s/occurred_at/created_at/g` fixes both.

2. **FAILURE_CLASSES typo** — `fetchFailureClassesNoRule` looked up `FAILURE_CLASSES` from `voice-failure-taxonomy`; the actual export is `VOICE_FAILURE_CLASSES` (an array). Every class with an open architecture report tripped "no rule" because `knownClasses` stayed empty. Switched to the correct export.

3. **watchdog_unknown duplication** — when every signal a watchdog watches is `wired='not_wired'`, the watchdog is by-design unable to observe; surfacing it duplicates the `awareness_not_wired` finding. Filtered out in `fetchWatchdogIssues`.

4. **Deferred awareness signals** — marked 4 deliberately-deferred entries `enforcement_status: 'pending'` so the briefing excludes them as actionable. Wired badge in the Registry stays `✗` — status reflects reality, just no longer flagged urgent:
   - `context.conversation_summary`
   - `context.conversation_history`
   - `overrides.proactive_opener`
   - `overrides.activity_awareness`

## Expected drain after deploy

Operator already drained 41 → 18 via the API (8 architecture reports `/execute`'d, 15 unimplemented providers `enabled=false`'d). This PR completes the drain:

| Source | Before this PR | After this PR |
|---|---|---|
| healing_quarantine | 3 | 3 (real state — clears when scheduled fixes ship) |
| watchdog_failed | 7 | 0 (false positives — column fix) |
| failure_class_no_rule | 1 | 0 (typo fix) |
| watchdog_unknown | 3 | 0 (suppress when all signals not_wired) |
| awareness_not_wired | 4 | 0 (enforcement_status='pending') |
| **Total** | **18** | **3** |

The 3 remaining are voice.model_under_responds quarantines. They reflect production state and should clear once the scheduled architecture-report VTIDs ship the fixes.

## Tests

Existing 10 unit tests on aggregator pure helpers all pass (composeQualityScore, sortActionItems, dedupeActionItems).

## Risk

Low. Three are bug fixes that strictly reduce false positives. The fourth is a deliberate `pending` marker that does NOT change the underlying signal state — the Registry still shows the wired status accurately. No schema migration, no new endpoints.

## Test plan

- [ ] `GET /api/v1/voice/improvement/briefing` returns ≤ 3 action items after deploy
- [ ] `quality_score` improves from 8 toward ≥ 50
- [ ] Awareness Registry still shows ✗ on the 4 marked signals (wired field unchanged)
- [ ] /api/v1/voice/awareness/watchdogs now returns `verdict: 'pass'` for watchdogs whose topics are emitting

Generated with Claude Code