### PR TITLE
fix(awareness-watchdogs): use real OASIS topic names (VTID-02903)

### DIFF
--- a/services/gateway/src/services/awareness-watchdogs.ts
+++ b/services/gateway/src/services/awareness-watchdogs.ts
@@ -45,7 +45,7 @@ const WATCHDOGS: AwarenessWatchdog[] = [
     description: 'Authoritative role + tenant headers are flowing into orb-live for every session.',
     watches: ['identity.user_id', 'identity.tenant_id', 'identity.active_role'],
     source_hint: 'services/gateway/src/routes/orb-live.ts',
-    oasis_topic: 'orb.session.started',
+    oasis_topic: 'vtid.live.session.start',
   },
   {
     id: 'environment_context_geo',
@@ -53,7 +53,7 @@ const WATCHDOGS: AwarenessWatchdog[] = [
     description: 'IP geo + timezone + time-of-day sections are present in the bootstrap context.',
     watches: ['context.client.city', 'context.client.country', 'context.client.timezone', 'context.client.time_of_day'],
     source_hint: 'services/gateway/src/routes/orb-live.ts',
-    oasis_topic: 'orb.session.started',
+    oasis_topic: 'vtid.live.session.start',
   },
   {
     id: 'memory_facts_injected',
@@ -61,7 +61,11 @@ const WATCHDOGS: AwarenessWatchdog[] = [
     description: 'High-confidence memory_facts rows are being injected into ORB sessions.',
     watches: ['memory.facts.enabled'],
     source_hint: 'services/gateway/src/routes/orb-live.ts',
-    oasis_topic: 'orb.memory.context_injected',
+    // VTID-02903: orb.memory.context_injected isn't a real topic. Memory
+    // facts are injected at session start, so we lean on vtid.live.session.start
+    // as the proxy. A more granular topic could be added later if/when memory
+    // injection becomes a separate emit.
+    oasis_topic: 'vtid.live.session.start',
   },
   {
     id: 'temporal_journey_block',
@@ -69,7 +73,7 @@ const WATCHDOGS: AwarenessWatchdog[] = [
     description: 'currentRoute + recentRoutes ring + journey_stage are present in the prompt.',
     watches: ['context.current_route', 'context.recent_routes', 'context.journey_stage', 'overrides.temporal_journey'],
     source_hint: 'services/gateway/src/routes/orb-live.ts',
-    oasis_topic: 'orb.session.started',
+    oasis_topic: 'vtid.live.session.start',
   },
   {
     id: 'navigator_policy_section',
@@ -106,7 +110,7 @@ const WATCHDOGS: AwarenessWatchdog[] = [
     description: 'Health pillars + Vitana Index score sections are present in the prompt.',
     watches: [],
     source_hint: 'services/gateway/src/routes/orb-live.ts',
-    oasis_topic: 'orb.session.started',
+    oasis_topic: 'vtid.live.session.start',
   },
   {
     id: 'surface_scoping',
@@ -114,7 +118,8 @@ const WATCHDOGS: AwarenessWatchdog[] = [
     description: 'Surface header + mobile-community role coercion gate every tool call.',
     watches: ['identity.surface'],
     source_hint: 'services/gateway/src/middleware/auth-supabase-jwt.ts',
-    oasis_topic: 'orb.tool.invoked',
+    // VTID-02903: real topic is orb.live.tool.executed (not orb.tool.invoked).
+    oasis_topic: 'orb.live.tool.executed',
   },
 ];
 


### PR DESCRIPTION
## Summary

Final drain step for the Voice / Improve cockpit. PR #2034 fixed the `occurred_at` → `created_at` column bug; that exposed a second issue: 7 of the 10 watchdog entries from PR #2019 (VTID-02859) reference topic names that the gateway has never emitted.

Real topic names — sampled from `oasis_events` over the last 200 voice events:

```
vtid.live.session.start    (11 hits — session-start)
vtid.live.session.stop     (12 hits — session-stop)
vtid.live.audio.in.chunk   (26 hits)
orb.live.diag              (139 hits)
orb.live.greeting.delivered (4 hits)
orb.live.tool.executed     (4 hits — tool invocation)
orb.navigator.consulted    (2 hits)
```

Watchdog manifest before/after:

| Watchdog | Was | Now |
|---|---|---|
| identity_lock_active | orb.session.started | vtid.live.session.start |
| environment_context_geo | orb.session.started | vtid.live.session.start |
| memory_facts_injected | orb.memory.context_injected | vtid.live.session.start (proxy) |
| temporal_journey_block | orb.session.started | vtid.live.session.start |
| health_pillar_data | orb.session.started | vtid.live.session.start |
| surface_scoping | orb.tool.invoked | orb.live.tool.executed |
| navigator_policy_section | orb.navigator.consulted | unchanged ✓ |

## Expected drain after deploy

Voice / Improve briefing: **9 → 3** (the 3 voice.model_under_responds quarantines reflect real production state and clear when the architecture-report-VTIDs ship fixes).

## Risk

Low. One-file change to a static manifest. No schema, no endpoints, no behavioral change beyond watchdog topic match.

Generated with Claude Code