### PR TITLE
feat(orb): B0a — ClientContextEnvelope + Situational Awareness Core (VTID-02905)

### DIFF
--- a/services/gateway/src/orb/context/client-context-envelope.ts
+++ b/services/gateway/src/orb/context/client-context-envelope.ts
@@ -1,0 +1,153 @@
+/**
+ * B0a (orb-live-refactor): ClientContextEnvelope — the shared frontend ↔
+ * gateway contract.
+ *
+ * Every UI surface (vitana-v1, Command Hub orb-widget, mobile WebView)
+ * MUST populate this envelope on `POST /api/v1/orb/live/session/start`
+ * (and on significant transitions: route change, surface handoff,
+ * visibility change).
+ *
+ * The gateway parses + validates the envelope here, then feeds it to
+ * `compileSituationalCore()` to produce the Tier 0 `SituationalCore`
+ * signals that the context compiler (B0b) consumes.
+ *
+ * This module is the **single source of truth** for the envelope shape.
+ * The vitana-v1 mirror lives at
+ * `vitana-v1/src/shared/orb/clientContextEnvelope.ts` and must stay in
+ * sync. The match-journey injection (2026-05-11) added `journeySurface`
+ * to support 9 surfaces for the future activity-match concierge — see
+ * `.claude/plans/for-an-intelligent-context-aware-fluttering-mango.md`
+ * Match-Journey Hooks section.
+ */
+
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// journeySurface — what kind of screen the user is on RIGHT NOW.
+// ---------------------------------------------------------------------------
+// Match-journey injection (2026-05-11): the 9 surfaces below must be
+// populatable by the vitana-v1 populator and pass through the zod schema
+// unchanged. B0a acceptance check #1 verifies the round-trip.
+
+export const JOURNEY_SURFACE_VALUES = [
+  'intent_board',
+  'intent_card',
+  'pre_match_whois',
+  'match_detail',
+  'match_chat',
+  'activity_plan',
+  'matches_hub',
+  'notification_center',
+  'command_hub',
+  'unknown',
+] as const;
+
+export type JourneySurface = (typeof JOURNEY_SURFACE_VALUES)[number];
+
+// ---------------------------------------------------------------------------
+// ClientContextEnvelope — the shared contract.
+// ---------------------------------------------------------------------------
+
+export interface ClientContextEnvelope {
+  /** Device surface (separate from journeySurface). */
+  surface: 'mobile' | 'desktop' | 'command_hub' | 'unknown';
+
+  /**
+   * Journey surface — match-journey injection.
+   * Populated by the vitana-v1 populator from the current React route.
+   * Backend providers key off this enum, NOT the raw `route` string.
+   */
+  journeySurface?: JourneySurface;
+
+  /** Raw React-Router path; kept for fallback + audit. */
+  route?: string;
+
+  /** IANA timezone, e.g. "Europe/Berlin". */
+  timezone?: string;
+
+  /** ISO 8601 timestamp with offset. */
+  localNow?: string;
+
+  wakeOrigin?:
+    | 'orb_tap'
+    | 'wake_word'
+    | 'push_tap'
+    | 'proactive_opener'
+    | 'deep_link'
+    | 'unknown';
+
+  deviceClass?:
+    | 'ios_webview'
+    | 'android_webview'
+    | 'desktop_browser'
+    | 'command_hub'
+    | 'unknown';
+
+  visibilityState?: 'visible' | 'hidden' | 'prerender';
+
+  networkRttMs?: number;
+
+  location?: {
+    lat?: number;
+    lng?: number;
+    accuracyMeters?: number;
+    permissionState?: 'granted' | 'denied' | 'prompt' | 'unknown';
+    /** ISO 8601 — used for freshness. */
+    capturedAt?: string;
+  };
+
+  privacyMode?: 'private' | 'shared_device' | 'unknown';
+}
+
+// ---------------------------------------------------------------------------
+// Zod schema — runtime validation at the gateway ingest boundary.
+// ---------------------------------------------------------------------------
+// The schema mirrors the TypeScript shape exactly. We use `.passthrough()`
+// nowhere — `additional-properties: false` is the contract.
+
+export const clientContextEnvelopeSchema = z.object({
+  surface: z.enum(['mobile', 'desktop', 'command_hub', 'unknown']),
+  journeySurface: z.enum(JOURNEY_SURFACE_VALUES).optional(),
+  route: z.string().optional(),
+  timezone: z.string().optional(),
+  localNow: z.string().optional(),
+  wakeOrigin: z
+    .enum(['orb_tap', 'wake_word', 'push_tap', 'proactive_opener', 'deep_link', 'unknown'])
+    .optional(),
+  deviceClass: z
+    .enum(['ios_webview', 'android_webview', 'desktop_browser', 'command_hub', 'unknown'])
+    .optional(),
+  visibilityState: z.enum(['visible', 'hidden', 'prerender']).optional(),
+  networkRttMs: z.number().optional(),
+  location: z
+    .object({
+      lat: z.number().optional(),
+      lng: z.number().optional(),
+      accuracyMeters: z.number().optional(),
+      permissionState: z.enum(['granted', 'denied', 'prompt', 'unknown']).optional(),
+      capturedAt: z.string().optional(),
+    })
+    .strict()
+    .optional(),
+  privacyMode: z.enum(['private', 'shared_device', 'unknown']).optional(),
+}).strict();
+
+/**
+ * Parse an unknown payload as a `ClientContextEnvelope`.
+ *
+ * Returns `{ ok: true, envelope }` when the input matches the schema, or
+ * `{ ok: false, error }` when it doesn't. Callers (the session-start
+ * route, the Continuation Inspector preview endpoint) should treat
+ * `ok: false` as a recoverable degradation — `compileSituationalCore`
+ * tolerates a `null` envelope and emits a `client_envelope_completeness`
+ * warning on the source-health panel.
+ */
+export function parseClientContextEnvelope(
+  input: unknown,
+): { ok: true; envelope: ClientContextEnvelope } | { ok: false; error: string } {
+  const result = clientContextEnvelopeSchema.safeParse(input);
+  if (result.success) {
+    return { ok: true, envelope: result.data as ClientContextEnvelope };
+  }
+  return { ok: false, error: result.error.message };
+}

--- a/services/gateway/src/orb/context/situational-awareness-core.ts
+++ b/services/gateway/src/orb/context/situational-awareness-core.ts
@@ -1,0 +1,213 @@
+/**
+ * B0a (orb-live-refactor): Situational Awareness Core — Tier 0 signals.
+ *
+ * Takes a `ClientContextEnvelope` (parsed at the session-start route)
+ * and emits a typed `SituationalCore` object that the context compiler
+ * (B0b) consumes as one of its highest-priority inputs.
+ *
+ * Tier 0 = synchronous or hot-cache-only. No DB reads, no external
+ * APIs, no async waits. Compilation must complete inside the voice-start
+ * latency budget so the ORB never blocks on situational signals.
+ *
+ * Signals derived here (per the approved plan, Category L):
+ *   - day_part_label              (from local time + timezone)
+ *   - daylight_phase              (from local time + month, approximate)
+ *   - location_freshness_confidence (from envelope.location.capturedAt age)
+ *   - device_class                (from envelope.deviceClass)
+ *   - privacy_speaking_mode       (from envelope.privacyMode)
+ *   - current_route + journey_surface (from envelope.route + journeySurface)
+ *   - client_envelope_completeness (which envelope fields the UI sent vs missing)
+ *
+ * Match-journey injection note: `journeySurface` is carried through
+ * verbatim. This module does NOT interpret match semantics — that's the
+ * job of `orb/context/providers/match-journey-context-provider.ts` (B0b).
+ * Here we only surface the fact "the user is on intent_board" without
+ * deciding what to do about it.
+ */
+
+import type { ClientContextEnvelope, JourneySurface } from './client-context-envelope';
+
+// ---------------------------------------------------------------------------
+// Output types
+// ---------------------------------------------------------------------------
+
+export type DayPartLabel = 'morning' | 'afternoon' | 'evening' | 'night' | 'late_night' | 'unknown';
+
+export type DaylightPhase =
+  | 'pre_dawn'
+  | 'morning'
+  | 'midday'
+  | 'afternoon'
+  | 'golden_hour'
+  | 'dusk'
+  | 'night'
+  | 'late_night'
+  | 'unknown';
+
+export type LocationFreshnessConfidence = 'high' | 'low' | 'unknown';
+
+export type PrivacySpeakingMode = 'private' | 'shared_device' | 'unknown';
+
+export interface SituationalCore {
+  dayPartLabel: DayPartLabel;
+  daylightPhase: DaylightPhase;
+  locationFreshnessConfidence: LocationFreshnessConfidence;
+  deviceClass: ClientContextEnvelope['deviceClass'] | 'unknown';
+  privacySpeakingMode: PrivacySpeakingMode;
+  /** Raw React-Router path (for audit + fallback). */
+  currentRoute: string | null;
+  /** Match-journey injection: which kind of screen the user is on. Always present (defaults to 'unknown'). */
+  journeySurface: JourneySurface;
+  /**
+   * Which envelope fields the UI did NOT send. Powers the source-health
+   * panel's degradation signals and the `assistant.context_source_degraded`
+   * OASIS event.
+   */
+  envelopeCompleteness: {
+    surfaceMissing: boolean;
+    journeySurfaceMissing: boolean;
+    routeMissing: boolean;
+    timezoneMissing: boolean;
+    localNowMissing: boolean;
+    deviceClassMissing: boolean;
+    privacyModeMissing: boolean;
+    locationMissing: boolean;
+    locationStale: boolean;
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Constants
+// ---------------------------------------------------------------------------
+
+/** Location data older than this is treated as "low confidence". */
+const LOCATION_FRESHNESS_THRESHOLD_MS = 15 * 60 * 1000; // 15 minutes
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Compile Tier 0 situational core from the envelope.
+ *
+ * `nowMs` is injectable for testability (and to avoid `Date.now()`
+ * coupling). Production callers pass `Date.now()`.
+ *
+ * Tolerates a `null` envelope — the function returns a degraded-but-
+ * typed `SituationalCore` with `envelopeCompleteness` flags all set to
+ * `true`. The compiler MUST handle this gracefully.
+ */
+export function compileSituationalCore(
+  envelope: ClientContextEnvelope | null,
+  nowMs: number,
+): SituationalCore {
+  if (!envelope) {
+    return emptySituationalCore();
+  }
+
+  const dayPartLabel = deriveDayPartLabel(envelope.localNow);
+  const daylightPhase = deriveDaylightPhase(envelope.localNow);
+  const locationFreshnessConfidence = deriveLocationFreshness(envelope, nowMs);
+
+  return {
+    dayPartLabel,
+    daylightPhase,
+    locationFreshnessConfidence,
+    deviceClass: envelope.deviceClass ?? 'unknown',
+    privacySpeakingMode: envelope.privacyMode ?? 'unknown',
+    currentRoute: envelope.route ?? null,
+    journeySurface: envelope.journeySurface ?? 'unknown',
+    envelopeCompleteness: {
+      surfaceMissing: !envelope.surface || envelope.surface === 'unknown',
+      journeySurfaceMissing: !envelope.journeySurface || envelope.journeySurface === 'unknown',
+      routeMissing: !envelope.route,
+      timezoneMissing: !envelope.timezone,
+      localNowMissing: !envelope.localNow,
+      deviceClassMissing: !envelope.deviceClass || envelope.deviceClass === 'unknown',
+      privacyModeMissing: !envelope.privacyMode || envelope.privacyMode === 'unknown',
+      locationMissing: !envelope.location,
+      locationStale: isLocationStale(envelope, nowMs),
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function emptySituationalCore(): SituationalCore {
+  return {
+    dayPartLabel: 'unknown',
+    daylightPhase: 'unknown',
+    locationFreshnessConfidence: 'unknown',
+    deviceClass: 'unknown',
+    privacySpeakingMode: 'unknown',
+    currentRoute: null,
+    journeySurface: 'unknown',
+    envelopeCompleteness: {
+      surfaceMissing: true,
+      journeySurfaceMissing: true,
+      routeMissing: true,
+      timezoneMissing: true,
+      localNowMissing: true,
+      deviceClassMissing: true,
+      privacyModeMissing: true,
+      locationMissing: true,
+      locationStale: true,
+    },
+  };
+}
+
+function deriveDayPartLabel(localNow: string | undefined): DayPartLabel {
+  if (!localNow) return 'unknown';
+  const hour = extractLocalHour(localNow);
+  if (hour === null) return 'unknown';
+  if (hour >= 5 && hour < 12) return 'morning';
+  if (hour >= 12 && hour < 17) return 'afternoon';
+  if (hour >= 17 && hour < 22) return 'evening';
+  if (hour >= 22 || hour < 2) return 'night';
+  return 'late_night'; // 2-5am
+}
+
+function deriveDaylightPhase(localNow: string | undefined): DaylightPhase {
+  if (!localNow) return 'unknown';
+  const hour = extractLocalHour(localNow);
+  if (hour === null) return 'unknown';
+  // Coarse approximation — proper sunrise/sunset tables ship in B8 (K-category).
+  if (hour >= 4 && hour < 6) return 'pre_dawn';
+  if (hour >= 6 && hour < 11) return 'morning';
+  if (hour >= 11 && hour < 15) return 'midday';
+  if (hour >= 15 && hour < 18) return 'afternoon';
+  if (hour >= 18 && hour < 20) return 'golden_hour';
+  if (hour >= 20 && hour < 22) return 'dusk';
+  if (hour >= 22 || hour < 2) return 'night';
+  return 'late_night';
+}
+
+function extractLocalHour(localNow: string): number | null {
+  // ISO 8601 — parse hour from the string directly to honor the offset
+  // the client sent. Avoid `new Date()` which would interpret the offset
+  // and convert to host time.
+  const match = /T(\d{2}):/.exec(localNow);
+  if (!match) return null;
+  const h = parseInt(match[1], 10);
+  return Number.isFinite(h) && h >= 0 && h < 24 ? h : null;
+}
+
+function deriveLocationFreshness(
+  envelope: ClientContextEnvelope,
+  nowMs: number,
+): LocationFreshnessConfidence {
+  if (!envelope.location?.capturedAt) return 'unknown';
+  const capturedMs = Date.parse(envelope.location.capturedAt);
+  if (!Number.isFinite(capturedMs)) return 'unknown';
+  const ageMs = nowMs - capturedMs;
+  return ageMs < LOCATION_FRESHNESS_THRESHOLD_MS ? 'high' : 'low';
+}
+
+function isLocationStale(envelope: ClientContextEnvelope, nowMs: number): boolean {
+  if (!envelope.location?.capturedAt) return true;
+  const capturedMs = Date.parse(envelope.location.capturedAt);
+  if (!Number.isFinite(capturedMs)) return true;
+  return nowMs - capturedMs >= LOCATION_FRESHNESS_THRESHOLD_MS;
+}

--- a/services/gateway/test/orb/context/client-context-envelope.test.ts
+++ b/services/gateway/test/orb/context/client-context-envelope.test.ts
@@ -1,0 +1,140 @@
+/**
+ * B0a acceptance check #1: `ClientContextEnvelope` round-trips all 9
+ * `journeySurface` values from vitana-v1 to the gateway without coercion
+ * or rename.
+ *
+ * Per the match-journey injection (plan, 2026-05-11): the 9 surfaces
+ * MUST pass through the zod parser unchanged. Any coercion (e.g.
+ * accepting `intent-board` and normalizing to `intent_board`) is a
+ * contract violation — the populator and the gateway must agree on
+ * the EXACT enum.
+ *
+ * This test is the "contract validation" gate. It does NOT verify any
+ * match-concierge behavior — only that the rails accept the reserved
+ * surface values.
+ */
+
+import {
+  JOURNEY_SURFACE_VALUES,
+  parseClientContextEnvelope,
+  ClientContextEnvelope,
+} from '../../../src/orb/context/client-context-envelope';
+
+describe('B0a — ClientContextEnvelope contract', () => {
+  describe('acceptance check #1: 9 journeySurface values round-trip without coercion', () => {
+    const MATCH_JOURNEY_SURFACES = [
+      'intent_board',
+      'intent_card',
+      'pre_match_whois',
+      'match_detail',
+      'match_chat',
+      'activity_plan',
+      'matches_hub',
+      'notification_center',
+      'command_hub',
+    ] as const;
+
+    it.each(MATCH_JOURNEY_SURFACES)(
+      'journeySurface=%s round-trips through the zod parser unchanged',
+      (surface) => {
+        const input: ClientContextEnvelope = {
+          surface: 'mobile',
+          journeySurface: surface,
+        };
+        const result = parseClientContextEnvelope(input);
+        expect(result.ok).toBe(true);
+        if (result.ok) {
+          expect(result.envelope.journeySurface).toBe(surface);
+        }
+      },
+    );
+
+    it('all 9 match-journey surfaces are members of JOURNEY_SURFACE_VALUES (plus "unknown")', () => {
+      for (const s of MATCH_JOURNEY_SURFACES) {
+        expect(JOURNEY_SURFACE_VALUES).toContain(s);
+      }
+      expect(JOURNEY_SURFACE_VALUES).toContain('unknown');
+      // Total enum cardinality: 9 match surfaces + 'unknown' = 10.
+      expect(JOURNEY_SURFACE_VALUES.length).toBe(10);
+    });
+
+    it('rejects coerced surface variants (e.g. kebab-case, capitalized)', () => {
+      const badInputs = [
+        { surface: 'mobile', journeySurface: 'intent-board' },
+        { surface: 'mobile', journeySurface: 'Intent_board' },
+        { surface: 'mobile', journeySurface: 'INTENT_BOARD' },
+        { surface: 'mobile', journeySurface: 'matchDetail' }, // camelCase
+        { surface: 'mobile', journeySurface: 'random_surface' },
+      ];
+      for (const bad of badInputs) {
+        const result = parseClientContextEnvelope(bad);
+        expect(result.ok).toBe(false);
+      }
+    });
+  });
+
+  describe('schema strictness — no additional properties leak through', () => {
+    it('rejects extra top-level properties', () => {
+      const input = {
+        surface: 'mobile',
+        journeySurface: 'intent_board',
+        extraField: 'should_be_rejected',
+      };
+      const result = parseClientContextEnvelope(input);
+      expect(result.ok).toBe(false);
+    });
+
+    it('rejects extra location properties', () => {
+      const input = {
+        surface: 'mobile',
+        location: {
+          lat: 52.5,
+          lng: 13.4,
+          extraField: 'should_be_rejected',
+        },
+      };
+      const result = parseClientContextEnvelope(input);
+      expect(result.ok).toBe(false);
+    });
+  });
+
+  describe('schema validation — required + optional fields', () => {
+    it('accepts a minimal envelope with only `surface`', () => {
+      const result = parseClientContextEnvelope({ surface: 'mobile' });
+      expect(result.ok).toBe(true);
+    });
+
+    it('rejects an envelope missing `surface`', () => {
+      const result = parseClientContextEnvelope({ journeySurface: 'intent_board' });
+      expect(result.ok).toBe(false);
+    });
+
+    it('accepts a fully-populated envelope', () => {
+      const input: ClientContextEnvelope = {
+        surface: 'mobile',
+        journeySurface: 'match_detail',
+        route: '/matches/abc-123',
+        timezone: 'Europe/Berlin',
+        localNow: '2026-05-11T18:30:00+02:00',
+        wakeOrigin: 'orb_tap',
+        deviceClass: 'ios_webview',
+        visibilityState: 'visible',
+        networkRttMs: 45,
+        location: {
+          lat: 52.52,
+          lng: 13.405,
+          accuracyMeters: 25,
+          permissionState: 'granted',
+          capturedAt: '2026-05-11T18:29:50+02:00',
+        },
+        privacyMode: 'private',
+      };
+      const result = parseClientContextEnvelope(input);
+      expect(result.ok).toBe(true);
+      if (result.ok) {
+        // Round-trip equality — every field survives the parse.
+        expect(result.envelope).toEqual(input);
+      }
+    });
+  });
+});

--- a/services/gateway/test/orb/context/situational-awareness-core.test.ts
+++ b/services/gateway/test/orb/context/situational-awareness-core.test.ts
@@ -1,0 +1,184 @@
+/**
+ * B0a — Situational Awareness Core unit tests.
+ *
+ * Verifies the Tier 0 compiler:
+ *   - tolerates null envelope (returns degraded-but-typed defaults)
+ *   - derives day_part_label + daylight_phase from localNow
+ *   - flags missing envelope fields in envelopeCompleteness
+ *   - propagates journeySurface verbatim (does NOT interpret it)
+ *   - location freshness flips at the 15-minute boundary
+ */
+
+import {
+  compileSituationalCore,
+  SituationalCore,
+} from '../../../src/orb/context/situational-awareness-core';
+import type { ClientContextEnvelope } from '../../../src/orb/context/client-context-envelope';
+
+const FIXED_NOW = Date.UTC(2026, 4, 11, 18, 30, 0); // 2026-05-11T18:30:00Z
+
+describe('B0a — compileSituationalCore', () => {
+  describe('null envelope tolerance', () => {
+    it('returns a fully-typed degraded SituationalCore when envelope is null', () => {
+      const core = compileSituationalCore(null, FIXED_NOW);
+      expect(core.dayPartLabel).toBe('unknown');
+      expect(core.daylightPhase).toBe('unknown');
+      expect(core.locationFreshnessConfidence).toBe('unknown');
+      expect(core.deviceClass).toBe('unknown');
+      expect(core.privacySpeakingMode).toBe('unknown');
+      expect(core.currentRoute).toBeNull();
+      expect(core.journeySurface).toBe('unknown');
+      // Every completeness flag is true (everything missing).
+      for (const flag of Object.values(core.envelopeCompleteness)) {
+        expect(flag).toBe(true);
+      }
+    });
+  });
+
+  describe('day_part_label derivation', () => {
+    it.each([
+      ['2026-05-11T07:00:00+02:00', 'morning'],
+      ['2026-05-11T13:30:00+02:00', 'afternoon'],
+      ['2026-05-11T19:15:00+02:00', 'evening'],
+      ['2026-05-11T23:00:00+02:00', 'night'],
+      ['2026-05-11T01:30:00+02:00', 'night'], // before 2am
+      ['2026-05-11T03:30:00+02:00', 'late_night'], // 2-5am
+    ])('localNow=%s → dayPartLabel=%s', (localNow, expected) => {
+      const env: ClientContextEnvelope = { surface: 'mobile', localNow };
+      const core = compileSituationalCore(env, FIXED_NOW);
+      expect(core.dayPartLabel).toBe(expected);
+    });
+
+    it('returns "unknown" when localNow is missing', () => {
+      const core = compileSituationalCore({ surface: 'mobile' }, FIXED_NOW);
+      expect(core.dayPartLabel).toBe('unknown');
+    });
+
+    it('returns "unknown" when localNow is malformed', () => {
+      const core = compileSituationalCore(
+        { surface: 'mobile', localNow: 'not-an-iso-date' },
+        FIXED_NOW,
+      );
+      expect(core.dayPartLabel).toBe('unknown');
+    });
+  });
+
+  describe('location freshness', () => {
+    it('marks location as "high" when captured under 15 minutes ago', () => {
+      const fiveMinAgo = new Date(FIXED_NOW - 5 * 60 * 1000).toISOString();
+      const core = compileSituationalCore(
+        {
+          surface: 'mobile',
+          location: { lat: 52.5, lng: 13.4, capturedAt: fiveMinAgo },
+        },
+        FIXED_NOW,
+      );
+      expect(core.locationFreshnessConfidence).toBe('high');
+      expect(core.envelopeCompleteness.locationStale).toBe(false);
+    });
+
+    it('marks location as "low" past 15 minutes', () => {
+      const twentyMinAgo = new Date(FIXED_NOW - 20 * 60 * 1000).toISOString();
+      const core = compileSituationalCore(
+        {
+          surface: 'mobile',
+          location: { lat: 52.5, lng: 13.4, capturedAt: twentyMinAgo },
+        },
+        FIXED_NOW,
+      );
+      expect(core.locationFreshnessConfidence).toBe('low');
+      expect(core.envelopeCompleteness.locationStale).toBe(true);
+    });
+
+    it('marks location as "unknown" when no capturedAt is provided', () => {
+      const core = compileSituationalCore(
+        {
+          surface: 'mobile',
+          location: { lat: 52.5, lng: 13.4 },
+        },
+        FIXED_NOW,
+      );
+      expect(core.locationFreshnessConfidence).toBe('unknown');
+    });
+  });
+
+  describe('match-journey injection: journeySurface propagates verbatim', () => {
+    const surfaces = [
+      'intent_board',
+      'intent_card',
+      'pre_match_whois',
+      'match_detail',
+      'match_chat',
+      'activity_plan',
+      'matches_hub',
+      'notification_center',
+      'command_hub',
+    ] as const;
+
+    it.each(surfaces)('journeySurface=%s passes through verbatim (no interpretation)', (surface) => {
+      const core = compileSituationalCore(
+        { surface: 'mobile', journeySurface: surface },
+        FIXED_NOW,
+      );
+      expect(core.journeySurface).toBe(surface);
+      // The core MUST NOT add match-related fields. Snapshot the SituationalCore
+      // shape and verify there's no `matchJourney`, `matchId`, etc.
+      const allowedKeys: Array<keyof SituationalCore> = [
+        'dayPartLabel',
+        'daylightPhase',
+        'locationFreshnessConfidence',
+        'deviceClass',
+        'privacySpeakingMode',
+        'currentRoute',
+        'journeySurface',
+        'envelopeCompleteness',
+      ];
+      expect(Object.keys(core).sort()).toEqual([...allowedKeys].sort());
+    });
+
+    it('journeySurface defaults to "unknown" when omitted', () => {
+      const core = compileSituationalCore({ surface: 'mobile' }, FIXED_NOW);
+      expect(core.journeySurface).toBe('unknown');
+      expect(core.envelopeCompleteness.journeySurfaceMissing).toBe(true);
+    });
+  });
+
+  describe('envelope completeness flags', () => {
+    it('flags every missing field', () => {
+      const core = compileSituationalCore({ surface: 'mobile' }, FIXED_NOW);
+      expect(core.envelopeCompleteness.journeySurfaceMissing).toBe(true);
+      expect(core.envelopeCompleteness.routeMissing).toBe(true);
+      expect(core.envelopeCompleteness.timezoneMissing).toBe(true);
+      expect(core.envelopeCompleteness.localNowMissing).toBe(true);
+      expect(core.envelopeCompleteness.deviceClassMissing).toBe(true);
+      expect(core.envelopeCompleteness.privacyModeMissing).toBe(true);
+      expect(core.envelopeCompleteness.locationMissing).toBe(true);
+    });
+
+    it('marks fields present when envelope is fully populated', () => {
+      const fullEnvelope: ClientContextEnvelope = {
+        surface: 'mobile',
+        journeySurface: 'match_detail',
+        route: '/matches/abc',
+        timezone: 'Europe/Berlin',
+        localNow: '2026-05-11T18:30:00+02:00',
+        deviceClass: 'ios_webview',
+        privacyMode: 'private',
+        location: {
+          lat: 52.52,
+          lng: 13.405,
+          capturedAt: new Date(FIXED_NOW - 60 * 1000).toISOString(),
+        },
+      };
+      const core = compileSituationalCore(fullEnvelope, FIXED_NOW);
+      expect(core.envelopeCompleteness.journeySurfaceMissing).toBe(false);
+      expect(core.envelopeCompleteness.routeMissing).toBe(false);
+      expect(core.envelopeCompleteness.timezoneMissing).toBe(false);
+      expect(core.envelopeCompleteness.localNowMissing).toBe(false);
+      expect(core.envelopeCompleteness.deviceClassMissing).toBe(false);
+      expect(core.envelopeCompleteness.privacyModeMissing).toBe(false);
+      expect(core.envelopeCompleteness.locationMissing).toBe(false);
+      expect(core.envelopeCompleteness.locationStale).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
Track B, slice B0a. **Contract-validation only — no match concierge.** Adds `services/gateway/src/orb/context/client-context-envelope.ts` (zod-validated shared contract with 9 match-journey surfaces) and `situational-awareness-core.ts` (Tier 0 compiler — derives day_part_label, daylight_phase, locationFreshnessConfidence, deviceClass, privacySpeakingMode, currentRoute, journeySurface, envelopeCompleteness). 40 unit tests pass. tsc clean. **B0a acceptance check #1 included**: all 9 journeySurface values round-trip through the zod parser unchanged; coerced variants rejected; additional-properties=false enforced. Additive only — does not touch orb-live.ts (compiler wire-up lands in B0b).