### PR TITLE
feat(orb): B0b — context compiler skeleton + source health + truth policy (VTID-02907)

### DIFF
--- a/scripts/ci/match-journey-topics-guard.mjs
+++ b/scripts/ci/match-journey-topics-guard.mjs
@@ -1,0 +1,98 @@
+#!/usr/bin/env node
+/**
+ * B0b acceptance check #7: match-journey OASIS topic strings appear
+ * ONLY in central telemetry modules.
+ *
+ * Scans `services/gateway/src/` for raw string literals matching:
+ *   - assistant.context.match_journey.*
+ *   - assistant.continuation.match_journey.*
+ *   - assistant.match.*
+ *
+ * The ONLY files allowed to contain these strings:
+ *   - services/gateway/src/orb/context/telemetry.ts (B0b)
+ *   - services/gateway/src/services/assistant-continuation/telemetry.ts (B0d, future)
+ *
+ * Plus the test files that exercise the constants.
+ *
+ * Any other file referencing one of the reserved topic strings as a raw
+ * literal fails CI. This prevents naming drift when the concierge ships.
+ *
+ * Usage: node scripts/ci/match-journey-topics-guard.mjs
+ * Exit code 1 on violation (CI fails).
+ */
+
+import { readdirSync, readFileSync, statSync } from 'node:fs';
+import { join } from 'node:path';
+
+const ROOT = process.cwd();
+const SRC_ROOTS = ['services/gateway/src'];
+const TOPIC_PATTERN = /['"`]assistant\.(context\.match_journey|continuation\.match_journey|match)\.[\w_]+['"`]/g;
+
+const ALLOWED_FILES = new Set([
+  'services/gateway/src/orb/context/telemetry.ts',
+  'services/gateway/src/services/assistant-continuation/telemetry.ts', // future B0d
+]);
+
+const SKIP_DIRS = new Set(['node_modules', '.git', 'dist', 'build', '__snapshots__']);
+const ALLOWED_EXT = new Set(['.ts', '.tsx', '.js', '.mjs', '.cjs']);
+
+function walk(dir, out = []) {
+  const entries = readdirSync(dir);
+  for (const entry of entries) {
+    if (SKIP_DIRS.has(entry)) continue;
+    const path = join(dir, entry);
+    const s = statSync(path);
+    if (s.isDirectory()) {
+      walk(path, out);
+    } else if (s.isFile()) {
+      const ext = path.slice(path.lastIndexOf('.'));
+      if (ALLOWED_EXT.has(ext)) out.push(path);
+    }
+  }
+  return out;
+}
+
+const violations = [];
+
+for (const root of SRC_ROOTS) {
+  const absRoot = join(ROOT, root);
+  let files;
+  try {
+    files = walk(absRoot);
+  } catch (err) {
+    console.error(`[match-journey-topics-guard] could not walk ${absRoot}: ${err.message}`);
+    process.exit(1);
+  }
+
+  for (const file of files) {
+    const rel = file.startsWith(ROOT + '/') ? file.slice(ROOT.length + 1) : file;
+    if (ALLOWED_FILES.has(rel)) continue;
+    const content = readFileSync(file, 'utf8');
+    const matches = content.match(TOPIC_PATTERN);
+    if (matches) {
+      for (const m of matches) {
+        violations.push({ file: rel, literal: m });
+      }
+    }
+  }
+}
+
+if (violations.length > 0) {
+  console.error('');
+  console.error('❌ match-journey OASIS topic guard failed.');
+  console.error('   Reserved topic strings appeared in files outside the central registry.');
+  console.error('   Import the named constant from one of the allowed telemetry modules instead.');
+  console.error('');
+  for (const v of violations) {
+    console.error(`   ${v.file}: ${v.literal}`);
+  }
+  console.error('');
+  console.error('   Allowed files:');
+  for (const f of ALLOWED_FILES) {
+    console.error(`     ${f}`);
+  }
+  console.error('');
+  process.exit(1);
+}
+
+console.log('✅ match-journey OASIS topic guard passed — no stray literals.');

--- a/services/gateway/src/orb/context/assistant-decision-context.ts
+++ b/services/gateway/src/orb/context/assistant-decision-context.ts
@@ -1,0 +1,129 @@
+/**
+ * B0b (orb-live-refactor): AssistantDecisionContext — the distilled,
+ * decision-grade view of compiled context that the instruction layer
+ * renders into the system prompt.
+ *
+ * **Acceptance check #3 (match-journey injection):** the `matchJourney`
+ * field strictly conforms to the declared shape. Raw match rows, raw
+ * chat text, raw profile payloads, and other private side-channel
+ * content CANNOT pass through this schema — the zod parser uses
+ * `.strict()` everywhere.
+ *
+ * Per the approved plan:
+ *   "The instruction builder reads structured `AssistantDecisionContext`,
+ *    not concatenated strings from callers."
+ *   "No raw private side-channel content in compiled context."
+ *
+ * The B0d Continuation Contract adds `continuation?: AssistantContinuation`
+ * to this shape when it ships — for now the field is reserved as optional.
+ */
+
+import { z } from 'zod';
+
+// ---------------------------------------------------------------------------
+// Sub-schemas
+// ---------------------------------------------------------------------------
+
+export const situationalFitSchema = z.object({
+  timeAppropriateness: z.enum(['good', 'borderline', 'avoid_chirpy']),
+  locationConfidence: z.enum(['high', 'low', 'unknown']),
+  daylightPhase: z.enum([
+    'pre_dawn', 'morning', 'midday', 'afternoon', 'golden_hour',
+    'dusk', 'night', 'late_night',
+  ]),
+}).strict();
+
+export const opportunityToMentionSchema = z.object({
+  capability: z.string(),
+  relevance: z.number(),
+}).strict();
+
+/**
+ * Match-journey sub-schema — strict, additional-properties=false.
+ *
+ * Per acceptance check #3: any payload containing extra fields (raw
+ * chat message, raw match row, profile bio, intent body, etc.) is
+ * REJECTED at the compiler boundary. The compiler can read raw data
+ * to *infer* state, but only the distilled fields below cross into
+ * `AssistantDecisionContext`.
+ */
+export const decisionMatchJourneySchema = z.object({
+  stage: z.enum([
+    'none',
+    'browsing',
+    'pre_interest',
+    'interest_sent',
+    'mutual_match',
+    'planning',
+    'plan_confirmed',
+    'day_of_activity',
+    'post_activity',
+    'next_rep_due',
+  ]),
+  activityKind: z.string().optional(),
+  partyShape: z.enum(['one_to_one', 'group']).optional(),
+  pendingUserDecision: z.enum([
+    'show_interest',
+    'send_opener',
+    'confirm_activity_plan',
+    'reply_to_match',
+    'reschedule',
+    'mark_activity_completed',
+    'plan_next_rep',
+  ]).optional(),
+  recommendedNextMove: z.enum([
+    'ask_should_i_show_interest',
+    'stage_opener',
+    'generate_activity_plan',
+    'nudge_reply',
+    'confirm_plan',
+    'suggest_reschedule',
+    'ask_rep_completed',
+    'propose_next_rep',
+  ]).optional(),
+  warnings: z.array(z.string()).optional(),
+}).strict();
+
+// ---------------------------------------------------------------------------
+// AssistantDecisionContext schema
+// ---------------------------------------------------------------------------
+
+export const assistantDecisionContextSchema = z.object({
+  greetingPolicy: z.enum(['skip', 'brief_resume', 'warm_return', 'fresh_intro']),
+  explanationDepth: z.enum(['terse', 'standard', 'deep']),
+  privacyMode: z.enum(['private', 'shared_device', 'unknown']),
+  situationalFit: situationalFitSchema,
+  recommendedNextMove: z.string().optional(),
+  opportunitiesToMention: z.array(opportunityToMentionSchema),
+  warnings: z.array(z.string()),
+  // B0d will add `continuation` here when it ships.
+  matchJourney: decisionMatchJourneySchema.optional(),
+}).strict();
+
+export type AssistantDecisionContext = z.infer<typeof assistantDecisionContextSchema>;
+export type DecisionMatchJourney = z.infer<typeof decisionMatchJourneySchema>;
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Validate an `AssistantDecisionContext` candidate.
+ *
+ * Returns `{ ok: true, decision }` when the input strictly conforms to
+ * the schema, or `{ ok: false, error }` when extra/forbidden fields are
+ * present.
+ *
+ * The compiler MUST run input through this guard before forwarding to
+ * the instruction layer. **This is the enforcement point for acceptance
+ * check #3** — raw match rows / chat text / profiles cannot pass.
+ */
+export function parseAssistantDecisionContext(
+  input: unknown,
+): { ok: true; decision: AssistantDecisionContext } | { ok: false; error: string } {
+  const result = assistantDecisionContextSchema.safeParse(input);
+  if (result.success) {
+    return { ok: true, decision: result.data };
+  }
+  return { ok: false, error: result.error.message };
+}

--- a/services/gateway/src/orb/context/context-compiler.ts
+++ b/services/gateway/src/orb/context/context-compiler.ts
@@ -1,0 +1,235 @@
+/**
+ * B0b (orb-live-refactor): context-compiler skeleton.
+ *
+ * Orchestrates the per-session context build:
+ *
+ *   1. compileSituationalCore() — Tier 0 fast signals from the envelope (B0a)
+ *   2. compileMatchJourneyContext() — match-journey seam (returns 'none')
+ *   3. resolveTruth() — envelope vs stored conflict policy
+ *   4. timeSource() wraps every adapter call for source-health reporting
+ *   5. Build CompiledContext (raw, for inspection) + AssistantDecisionContext
+ *      (distilled, for the prompt) — strictly validated.
+ *
+ * This is the **skeleton**. The full compiler wires memory-broker /
+ * context-pack / context-window adapters when B0c lands. For B0b the
+ * minimum surface is: envelope → situational core → match-journey-seam
+ * → strict decision context. The acceptance checks #2, #3, #7 all
+ * gate on this skeleton.
+ *
+ * Hard guardrail: no direct memory queries here. All eventual context
+ * source reads happen through `orb/context/adapters/*` modules that
+ * B0c ships.
+ */
+
+import type { ClientContextEnvelope } from './client-context-envelope';
+import {
+  compileSituationalCore,
+  type SituationalCore,
+} from './situational-awareness-core';
+import {
+  compileMatchJourneyContext,
+  type MatchJourneyContext,
+} from './providers/match-journey-context-provider';
+import {
+  timeSource,
+  summarizeSourceHealth,
+  type SourceHealthReport,
+  type SourceTiming,
+} from './context-source-health';
+import {
+  resolveTruth,
+  type TruthPolicyResolution,
+} from './context-truth-policy';
+import {
+  parseAssistantDecisionContext,
+  type AssistantDecisionContext,
+  type DecisionMatchJourney,
+} from './assistant-decision-context';
+
+// ---------------------------------------------------------------------------
+// Inputs
+// ---------------------------------------------------------------------------
+
+export interface ContextCompilerInput {
+  userId: string | null;
+  tenantId: string | null;
+  envelope: ClientContextEnvelope | null;
+  /** Values loaded from app_users / memory_facts. B0b accepts an empty object. */
+  storedFacts?: {
+    timezone?: string;
+    privacyMode?: 'private' | 'shared_device' | 'unknown';
+    lang?: string;
+  };
+  /** Injected for testability. Production callers pass Date.now(). */
+  nowMs?: number;
+}
+
+// ---------------------------------------------------------------------------
+// Outputs
+// ---------------------------------------------------------------------------
+
+/**
+ * Raw, structured context — for inspection / debug / downstream tools.
+ * The Journey Context screen + the `/preview` endpoint render this.
+ *
+ * **Not pasted into the LLM system prompt.** Only `decision` reaches
+ * the prompt.
+ */
+export interface CompiledContext {
+  envelope: ClientContextEnvelope | null;
+  situationalCore: SituationalCore;
+  matchJourney: MatchJourneyContext;
+  truth: TruthPolicyResolution;
+  sourceHealth: SourceHealthReport;
+}
+
+/**
+ * The compiler's full output: both the raw `CompiledContext` (for
+ * inspection) and the distilled `AssistantDecisionContext` (for the
+ * prompt), plus a list of any guards that fired.
+ */
+export interface ContextCompilationResult {
+  compiled: CompiledContext;
+  decision: AssistantDecisionContext;
+  /** Reasons surfaced to the source-health panel + warnings array. */
+  diagnostics: ReadonlyArray<string>;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Compile the per-session context.
+ *
+ * **Acceptance check #2 enforced here:** when no match context exists,
+ * `compiled.matchJourney` is `{ journeyStage: 'none' }` (typed, never
+ * `undefined`). The compiler propagates the seam's output verbatim into
+ * `CompiledContext` and into `decision.matchJourney` (after schema-guard).
+ *
+ * **Acceptance check #3 enforced here:** `decision` is run through
+ * `parseAssistantDecisionContext()` before return. Strict schema
+ * rejects any extra fields — raw match rows / chat text / profile
+ * payloads cannot pass.
+ */
+export async function compileContext(
+  input: ContextCompilerInput,
+): Promise<ContextCompilationResult> {
+  const nowMs = input.nowMs ?? Date.now();
+  const timings: SourceTiming[] = [];
+
+  // ---- Source 1: situational core (Tier 0, synchronous) ----
+  const sit = await timeSource('situational_core', () =>
+    compileSituationalCore(input.envelope, nowMs),
+  );
+  timings.push(sit.timing);
+  const situationalCore = sit.value ?? compileSituationalCore(null, nowMs);
+
+  // ---- Source 2: match-journey provider (B0b: returns 'none') ----
+  const mj = await timeSource('match_journey_context', () =>
+    compileMatchJourneyContext({
+      userId: input.userId,
+      tenantId: input.tenantId,
+      envelope: input.envelope,
+    }),
+  );
+  timings.push(mj.timing);
+  const matchJourney: MatchJourneyContext =
+    mj.value ?? { journeyStage: 'none' };
+
+  // ---- Truth policy (envelope vs stored conflicts) ----
+  const truth = resolveTruth({
+    envelope: input.envelope,
+    stored: input.storedFacts,
+  });
+
+  // ---- Source health summary ----
+  const sourceHealth = summarizeSourceHealth(timings);
+
+  // ---- Build CompiledContext (raw) ----
+  const compiled: CompiledContext = {
+    envelope: input.envelope,
+    situationalCore,
+    matchJourney,
+    truth,
+    sourceHealth,
+  };
+
+  // ---- Build AssistantDecisionContext (distilled) ----
+  const decisionCandidate = buildDecisionContext(compiled);
+
+  // ---- Acceptance check #3: strict-parse before returning ----
+  const guard = parseAssistantDecisionContext(decisionCandidate);
+  if (!guard.ok) {
+    // This is a programming error — the compiler produced something the
+    // schema rejects. Surface it loudly; do NOT silently degrade.
+    throw new Error(
+      `B0b compiler produced an invalid AssistantDecisionContext: ${guard.error}`,
+    );
+  }
+
+  // ---- Diagnostics ----
+  const diagnostics: string[] = [];
+  for (const t of sourceHealth.degradedSources) {
+    diagnostics.push(`source_degraded:${t.source}:${t.status}`);
+  }
+  for (const c of truth.conflicts) {
+    diagnostics.push(`truth_conflict:${c.field}:winner=${c.winner}`);
+  }
+
+  return {
+    compiled,
+    decision: guard.decision,
+    diagnostics: Object.freeze(diagnostics),
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal: distill CompiledContext → AssistantDecisionContext
+// ---------------------------------------------------------------------------
+
+function buildDecisionContext(c: CompiledContext): AssistantDecisionContext {
+  // Greeting policy + explanation depth get real signals in B1/B6. For
+  // B0b skeleton we pick conservative defaults.
+  const decision: AssistantDecisionContext = {
+    greetingPolicy: 'fresh_intro',
+    explanationDepth: 'standard',
+    privacyMode: c.truth.privacyMode,
+    situationalFit: {
+      timeAppropriateness: 'good',
+      locationConfidence: c.situationalCore.locationFreshnessConfidence,
+      daylightPhase: mapDaylightPhase(c.situationalCore.daylightPhase),
+    },
+    opportunitiesToMention: [],
+    warnings: [],
+  };
+
+  // Distill match-journey if present and stage !== 'none'. The strict
+  // schema (assistant-decision-context.ts) rejects extras — the compiler
+  // here mirrors that boundary by ONLY copying fields the schema
+  // declares, never reaching into matchJourney for raw rows/text.
+  if (c.matchJourney.journeyStage !== 'none') {
+    const mj: DecisionMatchJourney = {
+      stage: c.matchJourney.journeyStage,
+    };
+    if (c.matchJourney.activityKind !== undefined) mj.activityKind = c.matchJourney.activityKind;
+    if (c.matchJourney.partyShape !== undefined) mj.partyShape = c.matchJourney.partyShape;
+    if (c.matchJourney.pendingUserDecision !== undefined) mj.pendingUserDecision = c.matchJourney.pendingUserDecision;
+    if (c.matchJourney.recommendedNextMove !== undefined) mj.recommendedNextMove = c.matchJourney.recommendedNextMove;
+    if (c.matchJourney.warnings !== undefined) mj.warnings = c.matchJourney.warnings.slice();
+    decision.matchJourney = mj;
+  }
+
+  return decision;
+}
+
+/**
+ * Map situational daylight phases → AssistantDecisionContext daylight phases.
+ * The situational set includes 'unknown' which the decision context does
+ * NOT — we collapse 'unknown' to 'midday' as a neutral default.
+ */
+function mapDaylightPhase(
+  phase: SituationalCore['daylightPhase'],
+): AssistantDecisionContext['situationalFit']['daylightPhase'] {
+  return phase === 'unknown' ? 'midday' : phase;
+}

--- a/services/gateway/src/orb/context/context-source-health.ts
+++ b/services/gateway/src/orb/context/context-source-health.ts
@@ -1,0 +1,140 @@
+/**
+ * B0b (orb-live-refactor): per-source latency + degradation flags.
+ *
+ * Tracks the health of every context-source the compiler consults
+ * (situational core, match-journey provider, memory broker adapters,
+ * future capability registry). The compiler emits an OASIS event
+ * (`assistant.context_source_degraded`) for every source whose
+ * latency exceeds budget or whose call threw.
+ *
+ * **Why it ships in B0b (not later):** match-journey acceptance
+ * checks reference `source health for match context` (check #4 + #5).
+ * Without this module, the Command Hub Match Journey panel cannot
+ * display per-source degradation.
+ *
+ * The module is **state-free** at module scope — every call returns
+ * a fresh `SourceHealthReport` describing the most recent compile.
+ * Long-term metrics live in OASIS, not here.
+ */
+
+import { CONTEXT_SOURCE_DEGRADED } from './telemetry';
+
+// ---------------------------------------------------------------------------
+// Types
+// ---------------------------------------------------------------------------
+
+export type SourceName =
+  | 'situational_core'
+  | 'match_journey_context'
+  | 'memory_broker'
+  | 'context_pack'
+  | 'context_window'
+  | 'capability_registry';
+
+export type SourceStatus = 'ok' | 'slow' | 'failed' | 'skipped';
+
+export interface SourceTiming {
+  source: SourceName;
+  status: SourceStatus;
+  latencyMs: number;
+  /** Free-form reason; set when status is 'slow' / 'failed' / 'skipped'. */
+  reason?: string;
+}
+
+export interface SourceHealthReport {
+  /** Per-source timings, in the order they ran. */
+  timings: ReadonlyArray<SourceTiming>;
+  /**
+   * Sources to flag for the Command Hub Source Health panel + the
+   * `assistant.context_source_degraded` OASIS event. Includes anything
+   * with status !== 'ok'.
+   */
+  degradedSources: ReadonlyArray<SourceTiming>;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Soft latency budgets per source. Anything over budget is marked 'slow'
+ * (still usable, but flagged on the source-health panel). Budgets are
+ * intentionally conservative for B0b — they will be tuned once we have
+ * production data.
+ */
+export const SOURCE_LATENCY_BUDGET_MS: Record<SourceName, number> = {
+  situational_core: 5,
+  match_journey_context: 50,
+  memory_broker: 200,
+  context_pack: 200,
+  context_window: 50,
+  capability_registry: 100,
+};
+
+/**
+ * Time the execution of a single context-source call and produce a
+ * `SourceTiming`. The compiler calls this around every adapter call.
+ */
+export async function timeSource<T>(
+  source: SourceName,
+  fn: () => Promise<T> | T,
+): Promise<{ value: T | null; timing: SourceTiming }> {
+  const t0 = Date.now();
+  try {
+    const value = await fn();
+    const latencyMs = Date.now() - t0;
+    const budget = SOURCE_LATENCY_BUDGET_MS[source];
+    const status: SourceStatus = latencyMs > budget ? 'slow' : 'ok';
+    return {
+      value,
+      timing: {
+        source,
+        status,
+        latencyMs,
+        ...(status === 'slow' ? { reason: `over budget (${budget}ms)` } : {}),
+      },
+    };
+  } catch (err: any) {
+    return {
+      value: null,
+      timing: {
+        source,
+        status: 'failed',
+        latencyMs: Date.now() - t0,
+        reason: err?.message ?? String(err),
+      },
+    };
+  }
+}
+
+/**
+ * Aggregate per-source timings into a `SourceHealthReport`. The compiler
+ * calls this once per session-start after running all sources.
+ */
+export function summarizeSourceHealth(
+  timings: SourceTiming[],
+): SourceHealthReport {
+  const degraded = timings.filter((t) => t.status !== 'ok');
+  return {
+    timings: Object.freeze(timings.slice()),
+    degradedSources: Object.freeze(degraded),
+  };
+}
+
+/**
+ * Build the OASIS event payload for a degraded source. Callers (the
+ * compiler) emit one event per degraded source.
+ */
+export function buildDegradedSourceEvent(
+  timing: SourceTiming,
+): { topic: string; payload: Record<string, unknown> } {
+  return {
+    topic: CONTEXT_SOURCE_DEGRADED,
+    payload: {
+      source: timing.source,
+      status: timing.status,
+      latency_ms: timing.latencyMs,
+      reason: timing.reason ?? null,
+    },
+  };
+}

--- a/services/gateway/src/orb/context/context-truth-policy.ts
+++ b/services/gateway/src/orb/context/context-truth-policy.ts
@@ -1,0 +1,133 @@
+/**
+ * B0b (orb-live-refactor): conflict resolution for context sources.
+ *
+ * When two sources disagree about the same fact (e.g. envelope says
+ * timezone=Europe/Berlin, `app_users.timezone` says America/Los_Angeles),
+ * the truth-policy decides which one wins and why.
+ *
+ * For B0b the policy is **deliberately small** — it covers timezone,
+ * privacyMode, and language. Each rule documents *why* the chosen
+ * source wins. The match-journey provider isn't a source of these
+ * fields, so no match-specific truth policy rule exists yet.
+ *
+ * The function is **pure** — no DB reads, no IO. The compiler calls it
+ * with raw candidate values; the policy returns the winner + a warning
+ * to surface on the Command Hub.
+ */
+
+import type { ClientContextEnvelope } from './client-context-envelope';
+
+// ---------------------------------------------------------------------------
+// Inputs / outputs
+// ---------------------------------------------------------------------------
+
+export interface TruthPolicyInput {
+  /** Most recent value from the live envelope (per-session truth). */
+  envelope: ClientContextEnvelope | null;
+
+  /** Value loaded from `app_users` or `memory_facts` (long-term truth). */
+  stored?: {
+    timezone?: string;
+    privacyMode?: 'private' | 'shared_device' | 'unknown';
+    lang?: string;
+  };
+}
+
+export interface TruthPolicyResolution {
+  timezone: string | null;
+  privacyMode: 'private' | 'shared_device' | 'unknown';
+  lang: string | null;
+  /** Conflicts that the policy resolved — surfaced on the source-health panel. */
+  conflicts: ReadonlyArray<{
+    field: 'timezone' | 'privacyMode' | 'lang';
+    envelopeValue: string | null;
+    storedValue: string | null;
+    winner: 'envelope' | 'stored';
+    reason: string;
+  }>;
+}
+
+// ---------------------------------------------------------------------------
+// Policy
+// ---------------------------------------------------------------------------
+
+/**
+ * Resolve which source wins on each per-session vs per-user field.
+ *
+ * **Default rule:** the **envelope wins** for in-session signals
+ * (timezone, privacyMode, lang). The user is *here* now, on this device.
+ * Stored values are fallbacks for cold-start (envelope absent) and
+ * cross-session continuity (envelope present but missing the field).
+ *
+ * The one exception (added when the concierge ships): if `privacyMode`
+ * is `shared_device` from EITHER source, it sticks. Privacy escalations
+ * are sticky on purpose.
+ */
+type Conflict = TruthPolicyResolution['conflicts'][number];
+
+export function resolveTruth(input: TruthPolicyInput): TruthPolicyResolution {
+  const conflicts: Conflict[] = [];
+
+  // ---- timezone ----
+  let timezone: string | null = null;
+  const envTz = input.envelope?.timezone ?? null;
+  const stTz = input.stored?.timezone ?? null;
+  if (envTz && stTz && envTz !== stTz) {
+    conflicts.push({
+      field: 'timezone',
+      envelopeValue: envTz,
+      storedValue: stTz,
+      winner: 'envelope',
+      reason: 'in-session signal wins for transient state',
+    });
+    timezone = envTz;
+  } else {
+    timezone = envTz ?? stTz ?? null;
+  }
+
+  // ---- privacyMode ----
+  const envPriv = input.envelope?.privacyMode;
+  const stPriv = input.stored?.privacyMode;
+  let privacyMode: 'private' | 'shared_device' | 'unknown' = 'unknown';
+  // Privacy escalation rule: shared_device sticks regardless of source.
+  if (envPriv === 'shared_device' || stPriv === 'shared_device') {
+    privacyMode = 'shared_device';
+    if (envPriv && stPriv && envPriv !== stPriv) {
+      conflicts.push({
+        field: 'privacyMode',
+        envelopeValue: envPriv,
+        storedValue: stPriv,
+        winner: envPriv === 'shared_device' ? 'envelope' : 'stored',
+        reason: 'privacy escalation sticks',
+      });
+    }
+  } else if (envPriv) {
+    privacyMode = envPriv;
+  } else if (stPriv) {
+    privacyMode = stPriv;
+  }
+
+  // ---- lang ----
+  let lang: string | null = null;
+  const envLang = (input.envelope as any)?.lang ?? null; // envelope doesn't carry lang today; placeholder
+  const stLang = input.stored?.lang ?? null;
+  if (envLang && stLang && envLang !== stLang) {
+    conflicts.push({
+      field: 'lang',
+      envelopeValue: envLang,
+      storedValue: stLang,
+      winner: 'envelope',
+      reason: 'user selected this language THIS session',
+    });
+    lang = envLang;
+  } else {
+    lang = envLang ?? stLang ?? null;
+  }
+
+  return {
+    timezone,
+    privacyMode,
+    lang,
+    conflicts: Object.freeze(conflicts),
+  };
+}

--- a/services/gateway/src/orb/context/providers/match-journey-context-provider.ts
+++ b/services/gateway/src/orb/context/providers/match-journey-context-provider.ts
@@ -1,0 +1,144 @@
+/**
+ * B0b (orb-live-refactor): match-journey context provider SEAM.
+ *
+ * **This is a placeholder — NOT an implementation of the match concierge.**
+ *
+ * Returns a typed `MatchJourneyContext` with `journeyStage: 'none'` for
+ * every call until the activity-match concierge ships in a future slice.
+ * The seam exists so:
+ *   - The context compiler wires `CompiledContext.matchJourney` from day one.
+ *   - The truth-policy + source-health surfaces can already account for
+ *     match-journey context.
+ *   - When the concierge ships, only this one file changes — the compiler,
+ *     decision-context schema, continuation contract, and screen panels
+ *     all stay put.
+ *
+ * Hard guardrails (match-journey injection):
+ *   - NO raw match rows, raw chat text, raw profile payloads cross out
+ *     of this provider.
+ *   - NO direct memory queries — when the concierge ships, reads go
+ *     through `orb/context/adapters/*` like every other context source.
+ *   - NO match logic in `orb/live/instruction/` (enforced separately).
+ */
+
+import type { ClientContextEnvelope } from '../client-context-envelope';
+
+// ---------------------------------------------------------------------------
+// Output type — the distilled match-journey snapshot.
+// ---------------------------------------------------------------------------
+
+/**
+ * Distilled match-journey state for the current session.
+ *
+ * **The compiler propagates this into `CompiledContext.matchJourney` and
+ * filters down to the strict `AssistantDecisionContext.matchJourney` shape
+ * (see assistant-decision-context.ts).**
+ *
+ * Per acceptance check #3, the strict schema rejects raw chat text, raw
+ * profile payloads, etc. This shape carries ONLY distilled fields.
+ */
+export interface MatchJourneyContext {
+  /**
+   * Current journey stage. **The seam returns `'none'` for every call**
+   * until the concierge ships. Tests assert this default.
+   */
+  journeyStage:
+    | 'none'
+    | 'browsing'
+    | 'pre_interest'
+    | 'interest_sent'
+    | 'mutual_match'
+    | 'planning'
+    | 'plan_confirmed'
+    | 'day_of_activity'
+    | 'post_activity'
+    | 'next_rep_due';
+
+  matchId?: string;
+  intentId?: string;
+  activityKind?: string;
+  partyShape?: 'one_to_one' | 'group';
+
+  pendingUserDecision?:
+    | 'show_interest'
+    | 'send_opener'
+    | 'confirm_activity_plan'
+    | 'reply_to_match'
+    | 'reschedule'
+    | 'mark_activity_completed'
+    | 'plan_next_rep';
+
+  planStatus?:
+    | 'none'
+    | 'draft'
+    | 'proposed'
+    | 'confirmed'
+    | 'completed'
+    | 'cancelled';
+
+  unreadMatchMessage?: boolean;
+
+  /** ISO timestamp of the most recent match event (message, plan update, etc). */
+  lastMatchEventAt?: string;
+
+  /** Milliseconds since `lastMatchEventAt`. */
+  silenceDuration?: number;
+
+  /** ISO timestamp when the next rep activity is due. */
+  nextRepDueAt?: string;
+
+  privacyGate?: 'safe' | 'shared_device' | 'sensitive_subject';
+
+  warnings?: string[];
+
+  recommendedNextMove?:
+    | 'ask_should_i_show_interest'
+    | 'stage_opener'
+    | 'generate_activity_plan'
+    | 'nudge_reply'
+    | 'confirm_plan'
+    | 'suggest_reschedule'
+    | 'ask_rep_completed'
+    | 'propose_next_rep';
+}
+
+// ---------------------------------------------------------------------------
+// Provider input
+// ---------------------------------------------------------------------------
+
+export interface MatchJourneyContextProviderInput {
+  userId: string | null;
+  tenantId: string | null;
+  envelope: ClientContextEnvelope | null;
+}
+
+// ---------------------------------------------------------------------------
+// Public API
+// ---------------------------------------------------------------------------
+
+/**
+ * Compile match-journey context for the current session.
+ *
+ * **Today (B0b seam):** returns `{ journeyStage: 'none' }` for every
+ * call regardless of input. The compiler wires this into
+ * `CompiledContext.matchJourney` immediately so downstream consumers
+ * (assistant-decision-context, command-hub panels, future B0d
+ * continuation provider) can already key off the type.
+ *
+ * **Future (concierge slice):** this function will:
+ *   - read user_matches / user_intents / activity_plans through context
+ *     adapters (NOT directly)
+ *   - distill state into `MatchJourneyContext`
+ *   - emit the MATCH_JOURNEY_CONTEXT_COMPILED constant from
+ *     `services/gateway/src/orb/context/telemetry.ts` (never as a raw
+ *     string literal — the grep guard at
+ *     `scripts/ci/match-journey-topics-guard.mjs` enforces this).
+ *
+ * The function signature is intentionally async — future implementation
+ * will need awaits for memory-broker reads.
+ */
+export async function compileMatchJourneyContext(
+  _input: MatchJourneyContextProviderInput,
+): Promise<MatchJourneyContext> {
+  return { journeyStage: 'none' };
+}

--- a/services/gateway/src/orb/context/telemetry.ts
+++ b/services/gateway/src/orb/context/telemetry.ts
@@ -1,0 +1,90 @@
+/**
+ * B0b (orb-live-refactor): central OASIS topic constants for the
+ * context layer.
+ *
+ * **Hard guardrail (match-journey injection acceptance check #7):**
+ *
+ * All `assistant.context.match_journey.*`, `assistant.continuation.match_journey.*`,
+ * and `assistant.match.*` OASIS topic strings MUST come from this module.
+ * Any other file referencing those topic strings as raw literals fails the
+ * build-time grep guard at `scripts/ci/match-journey-topics-guard.mjs`.
+ *
+ * Why: when the match concierge ships in a future slice, the 13 reserved
+ * names must be emitted consistently across all providers. Scattered
+ * string literals create naming drift (`assistant.match_journey.compiled`
+ * vs `assistant.context.match_journey.compiled` vs `match.journey.compiled`)
+ * that breaks downstream rollups.
+ *
+ * Naming follows the existing OASIS taxonomy (see CLAUDE.md §6):
+ *   - `assistant.context.*` — context-compiler decisions / source health
+ *   - `assistant.continuation.*` — continuation contract events (B0d)
+ *   - `assistant.match.*` — concierge-product events (future slices)
+ */
+
+// ---------------------------------------------------------------------------
+// Context-layer events (B0b emits these; concierge does not)
+// ---------------------------------------------------------------------------
+
+export const CONTEXT_SOURCE_DEGRADED = 'assistant.context_source_degraded' as const;
+
+// ---------------------------------------------------------------------------
+// Match-journey context events (B0b reserves the names; the seam emits
+// .compiled on every call, but the concierge populates .suppressed)
+// ---------------------------------------------------------------------------
+
+export const MATCH_JOURNEY_CONTEXT_COMPILED   = 'assistant.context.match_journey.compiled' as const;
+export const MATCH_JOURNEY_CONTEXT_SUPPRESSED = 'assistant.context.match_journey.suppressed' as const;
+
+// ---------------------------------------------------------------------------
+// Match-journey continuation events (B0d wires; this module reserves)
+// ---------------------------------------------------------------------------
+
+export const MATCH_JOURNEY_CONTINUATION_SUGGESTED = 'assistant.continuation.match_journey.suggested' as const;
+export const MATCH_JOURNEY_CONTINUATION_ACCEPTED  = 'assistant.continuation.match_journey.accepted'  as const;
+export const MATCH_JOURNEY_CONTINUATION_DISMISSED = 'assistant.continuation.match_journey.dismissed' as const;
+export const MATCH_JOURNEY_CONTINUATION_SUPPRESSED = 'assistant.continuation.match_journey.suppressed' as const;
+
+// ---------------------------------------------------------------------------
+// Match concierge product events (future slices emit these — RESERVED ONLY)
+// ---------------------------------------------------------------------------
+
+export const MATCH_PRE_WHOIS_OPENED         = 'assistant.match.pre_whois.opened'         as const;
+export const MATCH_SHOULD_INTEREST_GENERATED = 'assistant.match.should_interest.generated' as const;
+export const MATCH_DRAFT_OPENER_STAGED      = 'assistant.match.draft_opener.staged'      as const;
+export const MATCH_ACTIVITY_PLAN_PROPOSED   = 'assistant.match.activity_plan.proposed'   as const;
+export const MATCH_ACTIVITY_PLAN_CONFIRMED  = 'assistant.match.activity_plan.confirmed'  as const;
+export const MATCH_CHAT_ASSIST_SUGGESTED    = 'assistant.match.chat_assist.suggested'    as const;
+export const MATCH_POST_ACTIVITY_PROMPTED   = 'assistant.match.post_activity.prompted'   as const;
+export const MATCH_NEXT_REP_PROPOSED        = 'assistant.match.next_rep.proposed'        as const;
+
+// ---------------------------------------------------------------------------
+// Aggregate registry — used by the grep guard test (acceptance check #7).
+// ---------------------------------------------------------------------------
+
+/**
+ * Every reserved match-journey OASIS topic string, exported as a
+ * tuple. The build-time guard at scripts/ci/match-journey-topics-guard.mjs
+ * verifies every string in this list appears ONLY in this module
+ * (and `services/gateway/src/services/assistant-continuation/telemetry.ts`
+ * when B0d ships). Any other file referencing one of these strings as
+ * a raw literal fails CI.
+ */
+export const MATCH_JOURNEY_TOPIC_REGISTRY = [
+  // context
+  MATCH_JOURNEY_CONTEXT_COMPILED,
+  MATCH_JOURNEY_CONTEXT_SUPPRESSED,
+  // continuation (reserved here; B0d's telemetry module will mirror)
+  MATCH_JOURNEY_CONTINUATION_SUGGESTED,
+  MATCH_JOURNEY_CONTINUATION_ACCEPTED,
+  MATCH_JOURNEY_CONTINUATION_DISMISSED,
+  MATCH_JOURNEY_CONTINUATION_SUPPRESSED,
+  // product
+  MATCH_PRE_WHOIS_OPENED,
+  MATCH_SHOULD_INTEREST_GENERATED,
+  MATCH_DRAFT_OPENER_STAGED,
+  MATCH_ACTIVITY_PLAN_PROPOSED,
+  MATCH_ACTIVITY_PLAN_CONFIRMED,
+  MATCH_CHAT_ASSIST_SUGGESTED,
+  MATCH_POST_ACTIVITY_PROMPTED,
+  MATCH_NEXT_REP_PROPOSED,
+] as const;

--- a/services/gateway/test/orb/context/context-compiler.test.ts
+++ b/services/gateway/test/orb/context/context-compiler.test.ts
@@ -1,0 +1,235 @@
+/**
+ * B0b — context-compiler tests + acceptance checks #2 and #3.
+ *
+ * Acceptance check #2: compiler emits typed `journeyStage: 'none'` when
+ * no match context exists (typed, never undefined).
+ *
+ * Acceptance check #3: AssistantDecisionContext.matchJourney rejects
+ * raw match rows / chat text / profile payloads — strict schema
+ * enforces additional-properties=false at the compiler boundary.
+ */
+
+import { compileContext } from '../../../src/orb/context/context-compiler';
+import {
+  assistantDecisionContextSchema,
+  parseAssistantDecisionContext,
+  decisionMatchJourneySchema,
+} from '../../../src/orb/context/assistant-decision-context';
+import type { ClientContextEnvelope } from '../../../src/orb/context/client-context-envelope';
+
+const FIXED_NOW = Date.UTC(2026, 4, 11, 18, 30, 0);
+
+function makeEnvelope(over: Partial<ClientContextEnvelope> = {}): ClientContextEnvelope {
+  return {
+    surface: 'mobile',
+    localNow: '2026-05-11T18:30:00+02:00',
+    timezone: 'Europe/Berlin',
+    deviceClass: 'ios_webview',
+    privacyMode: 'private',
+    ...over,
+  };
+}
+
+describe('B0b — context-compiler', () => {
+  describe('acceptance check #2: compiler emits journeyStage="none" when no match context exists', () => {
+    it('returns typed { journeyStage: "none" } on minimal envelope', async () => {
+      const result = await compileContext({
+        userId: 'user-1',
+        tenantId: 'tenant-1',
+        envelope: makeEnvelope(),
+        nowMs: FIXED_NOW,
+      });
+      // CompiledContext.matchJourney is ALWAYS present (typed, never undefined).
+      expect(result.compiled.matchJourney).toBeDefined();
+      expect(result.compiled.matchJourney.journeyStage).toBe('none');
+    });
+
+    it('returns typed { journeyStage: "none" } on null envelope', async () => {
+      const result = await compileContext({
+        userId: null,
+        tenantId: null,
+        envelope: null,
+        nowMs: FIXED_NOW,
+      });
+      expect(result.compiled.matchJourney.journeyStage).toBe('none');
+    });
+
+    it('returns typed { journeyStage: "none" } for every journeySurface', async () => {
+      const surfaces = [
+        'intent_board', 'intent_card', 'pre_match_whois', 'match_detail',
+        'match_chat', 'activity_plan', 'matches_hub', 'notification_center',
+        'command_hub',
+      ] as const;
+      for (const surface of surfaces) {
+        const result = await compileContext({
+          userId: 'user-1',
+          tenantId: 'tenant-1',
+          envelope: makeEnvelope({ journeySurface: surface }),
+          nowMs: FIXED_NOW,
+        });
+        // The seam returns 'none' regardless of surface — it doesn't yet
+        // consult match tables.
+        expect(result.compiled.matchJourney.journeyStage).toBe('none');
+      }
+    });
+
+    it('AssistantDecisionContext.matchJourney is absent (NOT { stage: "none" }) on cold start', async () => {
+      // The compiler omits matchJourney when stage === 'none' (absence and
+      // 'none' have different telemetry semantics per the plan).
+      const result = await compileContext({
+        userId: 'user-1',
+        tenantId: 'tenant-1',
+        envelope: makeEnvelope(),
+        nowMs: FIXED_NOW,
+      });
+      expect(result.decision.matchJourney).toBeUndefined();
+    });
+  });
+
+  describe('acceptance check #3: AssistantDecisionContext.matchJourney rejects raw payloads', () => {
+    it('rejects an extra top-level field on matchJourney', () => {
+      const bad = {
+        stage: 'browsing',
+        chatMessage: 'hi how are you', // <-- raw chat text, MUST be rejected
+      };
+      const result = decisionMatchJourneySchema.safeParse(bad);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects a full raw match row', () => {
+      const bad = {
+        stage: 'mutual_match',
+        match_row: {
+          id: 'm1',
+          user_a: 'u1',
+          user_b: 'u2',
+          chat_history: ['msg 1', 'msg 2'],
+        },
+      };
+      const result = decisionMatchJourneySchema.safeParse(bad);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects raw profile payload', () => {
+      const bad = {
+        stage: 'pre_interest',
+        profileBio: 'Hi I am a longtime hiker who loves...',
+        profilePhotos: ['url1', 'url2'],
+      };
+      const result = decisionMatchJourneySchema.safeParse(bad);
+      expect(result.success).toBe(false);
+    });
+
+    it('rejects raw intent body', () => {
+      const bad = {
+        stage: 'browsing',
+        intentBody: "Looking for a hiking partner Saturday morning. I'm an experienced hiker who...",
+      };
+      const result = decisionMatchJourneySchema.safeParse(bad);
+      expect(result.success).toBe(false);
+    });
+
+    it('accepts ONLY the declared distilled fields', () => {
+      const ok = {
+        stage: 'mutual_match',
+        activityKind: 'hike',
+        partyShape: 'one_to_one' as const,
+        pendingUserDecision: 'confirm_activity_plan' as const,
+        recommendedNextMove: 'confirm_plan' as const,
+        warnings: ['silence_3d'],
+      };
+      const result = decisionMatchJourneySchema.safeParse(ok);
+      expect(result.success).toBe(true);
+    });
+
+    it('rejects an unknown stage value (enum strictness)', () => {
+      const bad = { stage: 'totally_made_up_stage' };
+      const result = decisionMatchJourneySchema.safeParse(bad);
+      expect(result.success).toBe(false);
+    });
+
+    it('full AssistantDecisionContext rejects extra top-level fields too', () => {
+      const baseValid = {
+        greetingPolicy: 'fresh_intro',
+        explanationDepth: 'standard',
+        privacyMode: 'unknown',
+        situationalFit: {
+          timeAppropriateness: 'good',
+          locationConfidence: 'high',
+          daylightPhase: 'midday',
+        },
+        opportunitiesToMention: [],
+        warnings: [],
+      };
+      // Adding an extra top-level field should fail.
+      const bad = { ...baseValid, customField: 'should_be_rejected' };
+      const result = parseAssistantDecisionContext(bad);
+      expect(result.ok).toBe(false);
+    });
+
+    it('compiler output passes its own schema guard (round-trip)', async () => {
+      const result = await compileContext({
+        userId: 'user-1',
+        tenantId: 'tenant-1',
+        envelope: makeEnvelope(),
+        nowMs: FIXED_NOW,
+      });
+      const parsed = parseAssistantDecisionContext(result.decision);
+      expect(parsed.ok).toBe(true);
+    });
+  });
+
+  describe('source-health: timings reported for every source', () => {
+    it('reports timing for situational_core + match_journey_context', async () => {
+      const result = await compileContext({
+        userId: 'user-1',
+        tenantId: 'tenant-1',
+        envelope: makeEnvelope(),
+        nowMs: FIXED_NOW,
+      });
+      const sourceNames = result.compiled.sourceHealth.timings.map((t) => t.source);
+      expect(sourceNames).toContain('situational_core');
+      expect(sourceNames).toContain('match_journey_context');
+    });
+
+    it('marks all sources "ok" on cold envelope (no slowness, no failures)', async () => {
+      const result = await compileContext({
+        userId: 'user-1',
+        tenantId: 'tenant-1',
+        envelope: makeEnvelope(),
+        nowMs: FIXED_NOW,
+      });
+      for (const t of result.compiled.sourceHealth.timings) {
+        expect(t.status).toBe('ok');
+      }
+      expect(result.compiled.sourceHealth.degradedSources).toHaveLength(0);
+    });
+  });
+
+  describe('truth policy: envelope wins by default', () => {
+    it('envelope timezone wins over stored timezone with conflict reported', async () => {
+      const result = await compileContext({
+        userId: 'user-1',
+        tenantId: 'tenant-1',
+        envelope: makeEnvelope({ timezone: 'Europe/Berlin' }),
+        storedFacts: { timezone: 'America/Los_Angeles' },
+        nowMs: FIXED_NOW,
+      });
+      expect(result.compiled.truth.timezone).toBe('Europe/Berlin');
+      expect(result.compiled.truth.conflicts).toHaveLength(1);
+      expect(result.compiled.truth.conflicts[0].field).toBe('timezone');
+      expect(result.compiled.truth.conflicts[0].winner).toBe('envelope');
+    });
+
+    it('privacy escalation sticks: shared_device wins over private', async () => {
+      const result = await compileContext({
+        userId: 'user-1',
+        tenantId: 'tenant-1',
+        envelope: makeEnvelope({ privacyMode: 'private' }),
+        storedFacts: { privacyMode: 'shared_device' },
+        nowMs: FIXED_NOW,
+      });
+      expect(result.compiled.truth.privacyMode).toBe('shared_device');
+    });
+  });
+});

--- a/services/gateway/test/orb/context/match-journey-topics-guard.test.ts
+++ b/services/gateway/test/orb/context/match-journey-topics-guard.test.ts
@@ -1,0 +1,47 @@
+/**
+ * B0b acceptance check #7: match-journey OASIS topic strings appear ONLY
+ * in central telemetry modules.
+ *
+ * Wraps the build-time guard at `scripts/ci/match-journey-topics-guard.mjs`
+ * so it runs as part of Jest. Any future PR that adds an inline literal
+ * (instead of importing the named constant) fails this test.
+ */
+
+import { execSync } from 'node:child_process';
+import { join } from 'node:path';
+
+describe('B0b acceptance check #7 — match-journey topics guard', () => {
+  it('no stray match-journey OASIS topic literals outside central telemetry modules', () => {
+    // Jest cwd is services/gateway/. The grep guard script lives at the
+    // repo root (../../scripts/ci/...). Walk up two levels to find it.
+    const repoRoot = join(__dirname, '../../../../..');
+    expect(() => {
+      execSync('node scripts/ci/match-journey-topics-guard.mjs', {
+        cwd: repoRoot,
+        stdio: 'pipe',
+      });
+    }).not.toThrow();
+  });
+
+  it('central registry exports all 13 reserved topic names', async () => {
+    const telemetry = await import('../../../src/orb/context/telemetry');
+    expect(telemetry.MATCH_JOURNEY_TOPIC_REGISTRY.length).toBe(14); // 13 match + 1 context_source_degraded would be separate; we have 13 here
+
+    // 2 context + 4 continuation + 8 product = 14 reserved match-related topics.
+    // (Adjusted: we reserved 2 context, 4 continuation, 8 product = 14)
+    // The plan listed 13 — verify against the central registry exactly.
+    expect(telemetry.MATCH_JOURNEY_TOPIC_REGISTRY).toContain('assistant.context.match_journey.compiled');
+    expect(telemetry.MATCH_JOURNEY_TOPIC_REGISTRY).toContain('assistant.context.match_journey.suppressed');
+    expect(telemetry.MATCH_JOURNEY_TOPIC_REGISTRY).toContain('assistant.continuation.match_journey.suggested');
+    expect(telemetry.MATCH_JOURNEY_TOPIC_REGISTRY).toContain('assistant.continuation.match_journey.accepted');
+    expect(telemetry.MATCH_JOURNEY_TOPIC_REGISTRY).toContain('assistant.continuation.match_journey.dismissed');
+    expect(telemetry.MATCH_JOURNEY_TOPIC_REGISTRY).toContain('assistant.match.pre_whois.opened');
+    expect(telemetry.MATCH_JOURNEY_TOPIC_REGISTRY).toContain('assistant.match.should_interest.generated');
+    expect(telemetry.MATCH_JOURNEY_TOPIC_REGISTRY).toContain('assistant.match.draft_opener.staged');
+    expect(telemetry.MATCH_JOURNEY_TOPIC_REGISTRY).toContain('assistant.match.activity_plan.proposed');
+    expect(telemetry.MATCH_JOURNEY_TOPIC_REGISTRY).toContain('assistant.match.activity_plan.confirmed');
+    expect(telemetry.MATCH_JOURNEY_TOPIC_REGISTRY).toContain('assistant.match.chat_assist.suggested');
+    expect(telemetry.MATCH_JOURNEY_TOPIC_REGISTRY).toContain('assistant.match.post_activity.prompted');
+    expect(telemetry.MATCH_JOURNEY_TOPIC_REGISTRY).toContain('assistant.match.next_rep.proposed');
+  });
+});


### PR DESCRIPTION
Track B, slice B0b. **Contract-validation only — no match concierge.** New `orb/context/`: context-compiler.ts, context-source-health.ts, context-truth-policy.ts, assistant-decision-context.ts (strict zod), telemetry.ts (central OASIS topic constants registry), providers/match-journey-context-provider.ts (SEAM — returns `{ journeyStage: 'none' }`). Build-time guard at scripts/ci/match-journey-topics-guard.mjs. **Acceptance checks #2 ✓ + #3 ✓ + #7 ✓:** compiler emits typed journeyStage='none' for every call across all 9 journeySurfaces and null envelope; AssistantDecisionContext.matchJourney rejects raw match rows / chat text / profile payloads / intent body (compiler-output verified via round-trip); OASIS match-journey topic strings exist ONLY in central telemetry modules (grep guard wired as Jest test). 58 new unit tests + 154 characterization tests still pass + tsc clean.