### PR TITLE
feat(orb): B0c - user_assistant_state + Journey Context screen + Match Journey panel (VTID-02909, DEV-COMHU-02909)

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -2740,6 +2740,7 @@ const NAVIGATION_CONFIG = [
             { "key": "orb-live",        "label": "Orb LIVE",           "path": "/command-hub/voice/orb-live/" },
             { "key": "providers",       "label": "Providers & Voice",  "path": "/command-hub/voice/providers/" },
             { "key": "awareness",       "label": "Awareness",          "path": "/command-hub/voice/awareness/" },
+            { "key": "journey-context", "label": "Journey Context",    "path": "/command-hub/voice/journey-context/" },
             { "key": "tools",           "label": "Tool Catalog",       "path": "/command-hub/voice/tools/" },
             { "key": "self-healing",    "label": "Self-Healing",       "path": "/command-hub/voice/self-healing/" },
             { "key": "livekit-test",    "label": "LiveKit Test Bench", "path": "/command-hub/voice/livekit-test/" },
@@ -6175,6 +6176,9 @@ function renderModuleContent(moduleKey, tab) {
     } else if (moduleKey === 'voice' && tab === 'awareness') {
         // Sub-tab strip for Registry / Test / Watchdogs
         container.appendChild(renderVoiceAwarenessView());
+    } else if (moduleKey === 'voice' && tab === 'journey-context') {
+        // VTID-02909 (B0c): durable assistant state + match-journey panel
+        container.appendChild(renderJourneyContextView());
     } else if (moduleKey === 'voice' && tab === 'tools') {
         container.appendChild(renderVoiceToolsCatalogView());
     } else if (moduleKey === 'voice' && tab === 'self-healing') {
@@ -42389,6 +42393,286 @@ function renderVoiceAwarenessView() {
     }
     c.appendChild(body);
     return c;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// VTID-02909 (B0c): Journey Context view.
+//
+// Operator-facing inspection screen for the B0b context-compiler output
+// + the B0c `user_assistant_state` table.
+//
+// Panels (rendered top → bottom):
+//   1. User picker        — userId / tenantId inputs (sticky in state)
+//   2. Decision Preview   — the distilled AssistantDecisionContext the
+//                            LLM actually sees
+//   3. Match Journey      — REQUIRED VISIBLE even at journeyStage='none'.
+//                            Empty-state rows: current surface, "none"
+//                            stage, "no recommended next move", privacy
+//                            mode/gate, source health for
+//                            match_journey_context, suppression reason
+//                            placeholder ("none yet — B0d not shipped").
+//   4. Source Health      — per-source latency + degradation flags
+//   5. Durable State      — rows from user_assistant_state (ephemeral
+//                            route/surface state is NEVER stored here)
+//
+// Hard rule (carried from the plan): the Match Journey panel MUST NOT be
+// hidden when journeyStage='none'. Empty IS the state to render.
+// ─────────────────────────────────────────────────────────────────────────
+function renderJourneyContextView() {
+    var c = document.createElement('div');
+    c.style.cssText = 'padding:1.5rem;';
+
+    if (!state.journeyContext) {
+        state.journeyContext = {
+            userId: '',
+            tenantId: '',
+            loading: false,
+            error: null,
+            preview: null,
+            stateRows: null,
+        };
+    }
+    var jc = state.journeyContext;
+
+    // ---- Header ----
+    var header = document.createElement('div');
+    header.style.cssText = 'margin-bottom:1rem;';
+    var title = document.createElement('h2');
+    title.textContent = 'Journey Context';
+    title.style.cssText = 'margin:0 0 0.25rem 0;font-size:1.25rem;color:var(--color-text-primary);';
+    header.appendChild(title);
+    var subtitle = document.createElement('div');
+    subtitle.textContent = 'B0c — durable assistant state + B0b decision-context preview. VTID-02909.';
+    subtitle.style.cssText = 'font-size:0.8rem;color:var(--color-text-secondary);';
+    header.appendChild(subtitle);
+    c.appendChild(header);
+
+    // ---- User picker ----
+    var picker = document.createElement('div');
+    picker.style.cssText = 'display:flex;gap:0.5rem;align-items:center;margin-bottom:1rem;padding:0.75rem;background:#0f172a;border:1px solid #1e293b;border-radius:6px;';
+
+    var uidLabel = document.createElement('label');
+    uidLabel.textContent = 'userId';
+    uidLabel.style.cssText = 'font-size:0.8rem;color:var(--color-text-secondary);';
+    var uidInput = document.createElement('input');
+    uidInput.type = 'text';
+    uidInput.placeholder = 'UUID';
+    uidInput.value = jc.userId;
+    uidInput.style.cssText = 'flex:1;min-width:280px;padding:0.4rem 0.6rem;background:#020617;border:1px solid #334155;border-radius:4px;color:var(--color-text-primary);font-size:0.85rem;font-family:monospace;';
+    uidInput.oninput = function () { jc.userId = uidInput.value.trim(); };
+
+    var tidLabel = document.createElement('label');
+    tidLabel.textContent = 'tenantId';
+    tidLabel.style.cssText = 'font-size:0.8rem;color:var(--color-text-secondary);';
+    var tidInput = document.createElement('input');
+    tidInput.type = 'text';
+    tidInput.placeholder = 'UUID';
+    tidInput.value = jc.tenantId;
+    tidInput.style.cssText = 'flex:1;min-width:280px;padding:0.4rem 0.6rem;background:#020617;border:1px solid #334155;border-radius:4px;color:var(--color-text-primary);font-size:0.85rem;font-family:monospace;';
+    tidInput.oninput = function () { jc.tenantId = tidInput.value.trim(); };
+
+    var loadBtn = document.createElement('button');
+    loadBtn.textContent = jc.loading ? 'Loading…' : 'Load';
+    loadBtn.disabled = jc.loading;
+    loadBtn.style.cssText = 'padding:0.45rem 1rem;background:#2563eb;color:#fff;border:none;border-radius:4px;cursor:pointer;font-size:0.85rem;';
+    loadBtn.onclick = function () { loadJourneyContext(); };
+
+    picker.appendChild(uidLabel);
+    picker.appendChild(uidInput);
+    picker.appendChild(tidLabel);
+    picker.appendChild(tidInput);
+    picker.appendChild(loadBtn);
+    c.appendChild(picker);
+
+    if (jc.error) {
+        var errBox = document.createElement('div');
+        errBox.textContent = 'Error: ' + jc.error;
+        errBox.style.cssText = 'padding:0.75rem;margin-bottom:1rem;background:#7f1d1d;color:#fee2e2;border-radius:6px;font-size:0.85rem;';
+        c.appendChild(errBox);
+    }
+
+    // ---- Panels ----
+    var grid = document.createElement('div');
+    grid.style.cssText = 'display:grid;grid-template-columns:1fr;gap:1rem;';
+
+    grid.appendChild(renderJourneyContextDecisionPanel(jc.preview));
+    grid.appendChild(renderJourneyContextMatchJourneyPanel(jc.preview));
+    grid.appendChild(renderJourneyContextSourceHealthPanel(jc.preview));
+    grid.appendChild(renderJourneyContextStatePanel(jc.stateRows));
+
+    c.appendChild(grid);
+    return c;
+}
+
+function loadJourneyContext() {
+    var jc = state.journeyContext;
+    if (!jc.userId || !jc.tenantId) {
+        jc.error = 'userId and tenantId are required';
+        renderApp();
+        return;
+    }
+    jc.loading = true;
+    jc.error = null;
+    renderApp();
+
+    var qs = '?userId=' + encodeURIComponent(jc.userId) + '&tenantId=' + encodeURIComponent(jc.tenantId);
+    Promise.all([
+        fetch('/api/v1/voice/journey-context/preview' + qs, { headers: buildContextHeaders() }).then(function (r) { return r.json(); }),
+        fetch('/api/v1/voice/journey-context/state'   + qs, { headers: buildContextHeaders() }).then(function (r) { return r.json(); }),
+    ]).then(function (results) {
+        jc.loading = false;
+        if (results[0] && results[0].ok) {
+            jc.preview = results[0];
+        } else {
+            jc.error = (results[0] && results[0].error) || 'preview failed';
+        }
+        if (results[1] && results[1].ok) {
+            jc.stateRows = results[1];
+        }
+        renderApp();
+    }).catch(function (err) {
+        jc.loading = false;
+        jc.error = String(err && err.message ? err.message : err);
+        renderApp();
+    });
+}
+
+function renderJourneyContextPanel(titleText, subtitleText) {
+    var panel = document.createElement('div');
+    panel.style.cssText = 'background:#0f172a;border:1px solid #1e293b;border-radius:6px;padding:1rem;';
+    var h = document.createElement('div');
+    h.style.cssText = 'display:flex;align-items:baseline;gap:0.5rem;margin-bottom:0.5rem;';
+    var t = document.createElement('div');
+    t.textContent = titleText;
+    t.style.cssText = 'font-weight:600;font-size:0.95rem;color:var(--color-text-primary);';
+    h.appendChild(t);
+    if (subtitleText) {
+        var s = document.createElement('div');
+        s.textContent = subtitleText;
+        s.style.cssText = 'font-size:0.75rem;color:var(--color-text-secondary);';
+        h.appendChild(s);
+    }
+    panel.appendChild(h);
+    return panel;
+}
+
+function renderJourneyContextEmptyRow(label, valueText) {
+    var row = document.createElement('div');
+    row.style.cssText = 'display:flex;justify-content:space-between;padding:0.35rem 0;border-bottom:1px solid #1e293b;font-size:0.85rem;';
+    var l = document.createElement('span');
+    l.textContent = label;
+    l.style.cssText = 'color:var(--color-text-secondary);';
+    var v = document.createElement('span');
+    v.textContent = valueText;
+    v.style.cssText = 'color:var(--color-text-primary);font-family:monospace;';
+    row.appendChild(l);
+    row.appendChild(v);
+    return row;
+}
+
+function renderJourneyContextDecisionPanel(preview) {
+    var panel = renderJourneyContextPanel(
+        'Decision Preview',
+        'AssistantDecisionContext — what the LLM actually sees',
+    );
+    if (!preview || !preview.decision) {
+        panel.appendChild(renderJourneyContextEmptyRow('status', 'no data — load a user above'));
+        return panel;
+    }
+    var d = preview.decision;
+    panel.appendChild(renderJourneyContextEmptyRow('greetingPolicy',       String(d.greetingPolicy)));
+    panel.appendChild(renderJourneyContextEmptyRow('explanationDepth',     String(d.explanationDepth)));
+    panel.appendChild(renderJourneyContextEmptyRow('privacyMode',          String(d.privacyMode)));
+    panel.appendChild(renderJourneyContextEmptyRow('situationalFit.time',
+        (d.situationalFit && d.situationalFit.timeAppropriateness) || '—'));
+    panel.appendChild(renderJourneyContextEmptyRow('situationalFit.daylight',
+        (d.situationalFit && d.situationalFit.daylightPhase) || '—'));
+    panel.appendChild(renderJourneyContextEmptyRow('warnings.count',       String((d.warnings || []).length)));
+    return panel;
+}
+
+function renderJourneyContextMatchJourneyPanel(preview) {
+    // ── B0c acceptance check #4 + match-journey acceptance check #4: this
+    //    panel MUST be visible regardless of whether match-journey is
+    //    populated. Empty-state rows are the contract.
+    var panel = renderJourneyContextPanel(
+        'Match Journey',
+        'B0b seam — empty until the activity-match concierge ships',
+    );
+    var compiled = preview && preview.compiled;
+    var mj = compiled && compiled.matchJourney;
+    var stage = (mj && mj.journeyStage) || 'none';
+    var envelope = compiled && compiled.envelope;
+    var currentSurface = (envelope && envelope.journeySurface) || 'unknown';
+    var privacyMode = (envelope && envelope.privacyMode) || 'unknown';
+    var privacyGate = (mj && mj.privacyGate) || 'safe';
+    var nextMove = (mj && mj.recommendedNextMove) || 'no recommended next move';
+    var pendingDecision = (mj && mj.pendingUserDecision) || '—';
+
+    panel.appendChild(renderJourneyContextEmptyRow('current surface',          String(currentSurface)));
+    panel.appendChild(renderJourneyContextEmptyRow('journey stage',            String(stage)));
+    panel.appendChild(renderJourneyContextEmptyRow('recommended next move',    String(nextMove)));
+    panel.appendChild(renderJourneyContextEmptyRow('pending user decision',    String(pendingDecision)));
+    panel.appendChild(renderJourneyContextEmptyRow('privacyMode',              String(privacyMode)));
+    panel.appendChild(renderJourneyContextEmptyRow('privacyGate',              String(privacyGate)));
+
+    // Source health row specific to match_journey_context
+    var sh = compiled && compiled.sourceHealth;
+    var mjSrc = sh && sh.timings && sh.timings.filter(function (t) { return t.source === 'match_journey_context'; })[0];
+    panel.appendChild(renderJourneyContextEmptyRow(
+        'source health',
+        mjSrc ? (mjSrc.status + ' (latency ' + (mjSrc.latencyMs != null ? mjSrc.latencyMs + 'ms' : '—') + ')') : '—',
+    ));
+
+    // Suppression reason — placeholder until B0d ships (continuation contract).
+    panel.appendChild(renderJourneyContextEmptyRow(
+        'suppression reason',
+        'none yet — continuation contract not shipped (B0d gated on B0c)',
+    ));
+    return panel;
+}
+
+function renderJourneyContextSourceHealthPanel(preview) {
+    var panel = renderJourneyContextPanel('Source Health', 'per-source latency + degradation flags');
+    var sh = preview && preview.compiled && preview.compiled.sourceHealth;
+    if (!sh || !sh.timings) {
+        panel.appendChild(renderJourneyContextEmptyRow('status', 'no data'));
+        return panel;
+    }
+    sh.timings.forEach(function (t) {
+        panel.appendChild(renderJourneyContextEmptyRow(
+            t.source,
+            (t.status || '—') + ' (' + (t.latencyMs != null ? t.latencyMs + 'ms' : '—') + ')' + (t.reason ? ' — ' + t.reason : ''),
+        ));
+    });
+    return panel;
+}
+
+function renderJourneyContextStatePanel(stateRows) {
+    var panel = renderJourneyContextPanel(
+        'Durable Assistant State',
+        'user_assistant_state — durable signals only, no ephemeral route/surface',
+    );
+    if (!stateRows) {
+        panel.appendChild(renderJourneyContextEmptyRow('status', 'no data — load a user above'));
+        return panel;
+    }
+    if (stateRows.source_health && stateRows.source_health.user_assistant_state && !stateRows.source_health.user_assistant_state.available) {
+        panel.appendChild(renderJourneyContextEmptyRow('status', 'unavailable — ' + (stateRows.source_health.user_assistant_state.reason || 'unknown')));
+        return panel;
+    }
+    var rows = stateRows.rows || [];
+    if (rows.length === 0) {
+        panel.appendChild(renderJourneyContextEmptyRow('rows', '0 (empty — user has no durable signals yet)'));
+        return panel;
+    }
+    rows.forEach(function (r) {
+        var lbl = r.signal_name + (r.count ? ' (' + r.count + ')' : '');
+        var val = (typeof r.value === 'object') ? JSON.stringify(r.value) : String(r.value);
+        if (val.length > 80) val = val.slice(0, 80) + '…';
+        panel.appendChild(renderJourneyContextEmptyRow(lbl, val));
+    });
+    return panel;
 }
 
 // VTID-02867: Inline expandable "Open architecture reports (N)" section.

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -30,7 +30,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260504-vtid-02710-ios-ctx-keepalive"></script>
-  <script src="/command-hub/app.js?v=20260509-livekit-parity-three-fixes"></script>
+  <script src="/command-hub/app.js?v=20260511-vtid-02909-journey-context"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
 </body>

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -713,6 +713,11 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const voiceImproveRouter = require('./routes/voice-improve').default;
   mountRouterSync(app, '/api/v1', voiceImproveRouter, { owner: 'voice-improve' });
 
+  // VTID-02909 (B0c): Journey Context inspection (Voice / Journey Context tab)
+  // GET /api/v1/voice/journey-context/preview + GET /api/v1/voice/journey-context/state
+  const voiceJourneyContextRouter = require('./routes/voice-journey-context').default;
+  mountRouterSync(app, '/api/v1', voiceJourneyContextRouter, { owner: 'voice-journey-context' });
+
   // AI Personality Configuration API
   mountRouterSync(app, '/api/v1/ai-personality', aiPersonalityRouter, { owner: 'ai-personality' });
 

--- a/services/gateway/src/routes/voice-journey-context.ts
+++ b/services/gateway/src/routes/voice-journey-context.ts
@@ -1,0 +1,166 @@
+/**
+ * VTID-02909 (B0c): Journey Context inspection endpoints.
+ *
+ *   GET /api/v1/voice/journey-context/preview?userId=…&tenantId=…
+ *       Returns { compiled, decision, diagnostics } from the B0b
+ *       context-compiler. Read-only; no DB writes. Used by the Command
+ *       Hub Journey Context screen + the Match Journey panel.
+ *
+ *   GET /api/v1/voice/journey-context/state?userId=…&tenantId=…
+ *       Returns rows from `user_assistant_state` for the given user.
+ *       Strictly durable signals (no ephemeral route/surface state).
+ *
+ * Auth: exafy_admin required. Both endpoints expose sensitive inferred
+ * context across tenants.
+ *
+ * B0c hard rule: this route is read-only inspection. It does NOT mutate
+ * `user_assistant_state` or compile anything that touches the LLM prompt.
+ */
+
+import { Router, Response } from 'express';
+import { getSupabase } from '../lib/supabase';
+import {
+  requireAuthWithTenant,
+  requireExafyAdmin,
+  AuthenticatedRequest,
+} from '../middleware/auth-supabase-jwt';
+import { compileContext } from '../orb/context/context-compiler';
+import {
+  parseClientContextEnvelope,
+  type ClientContextEnvelope,
+} from '../orb/context/client-context-envelope';
+
+const router = Router();
+const VTID = 'VTID-02909';
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/voice/journey-context/preview
+//
+// Query params:
+//   userId    UUID (required)
+//   tenantId  UUID (required)
+//   envelope  optional JSON-stringified ClientContextEnvelope. When absent
+//             we compile against `null` — that's the "no envelope yet"
+//             state which is itself a valid B0c inspection scenario.
+// ---------------------------------------------------------------------------
+router.get(
+  '/voice/journey-context/preview',
+  requireAuthWithTenant,
+  requireExafyAdmin,
+  async (req: AuthenticatedRequest, res: Response) => {
+    try {
+      const userId = typeof req.query.userId === 'string' ? req.query.userId : '';
+      const tenantId = typeof req.query.tenantId === 'string' ? req.query.tenantId : '';
+      if (!userId || !tenantId) {
+        return res.status(400).json({
+          ok: false,
+          error: 'userId and tenantId are required',
+          vtid: VTID,
+        });
+      }
+
+      let envelope: ClientContextEnvelope | null = null;
+      if (typeof req.query.envelope === 'string' && req.query.envelope.length > 0) {
+        try {
+          const parsedJson = JSON.parse(req.query.envelope);
+          const guard = parseClientContextEnvelope(parsedJson);
+          if (guard.ok) envelope = guard.envelope;
+        } catch {
+          // Invalid envelope JSON → compile as if absent.
+        }
+      }
+
+      const result = await compileContext({
+        userId,
+        tenantId,
+        envelope,
+      });
+
+      return res.json({
+        ok: true,
+        vtid: VTID,
+        compiled: result.compiled,
+        decision: result.decision,
+        diagnostics: result.diagnostics,
+      });
+    } catch (e) {
+      return res.status(500).json({
+        ok: false,
+        error: (e as Error).message,
+        vtid: VTID,
+      });
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/voice/journey-context/state
+//
+// Lists the durable assistant-state rows for one user. Ephemeral signals
+// (current_route, journey_surface, match_id, …) are NOT stored here —
+// the migration's CHECK is "durable signals only".
+// ---------------------------------------------------------------------------
+router.get(
+  '/voice/journey-context/state',
+  requireAuthWithTenant,
+  requireExafyAdmin,
+  async (req: AuthenticatedRequest, res: Response) => {
+    try {
+      const userId = typeof req.query.userId === 'string' ? req.query.userId : '';
+      const tenantId = typeof req.query.tenantId === 'string' ? req.query.tenantId : '';
+      if (!userId || !tenantId) {
+        return res.status(400).json({
+          ok: false,
+          error: 'userId and tenantId are required',
+          vtid: VTID,
+        });
+      }
+
+      const sb = getSupabase();
+      if (!sb) {
+        // B0c can ship without a live DB connection — the screen
+        // renders the empty state. Source-health surfaces the gap.
+        return res.json({
+          ok: true,
+          vtid: VTID,
+          rows: [],
+          source_health: {
+            user_assistant_state: { available: false, reason: 'supabase_unconfigured' },
+          },
+        });
+      }
+
+      const { data, error } = await sb
+        .from('user_assistant_state')
+        .select('signal_name, value, count, confidence, source, expires_at, last_seen_at, created_at, updated_at')
+        .eq('tenant_id', tenantId)
+        .eq('user_id', userId)
+        .order('updated_at', { ascending: false });
+
+      if (error) {
+        return res.status(500).json({
+          ok: false,
+          error: error.message,
+          vtid: VTID,
+        });
+      }
+
+      return res.json({
+        ok: true,
+        vtid: VTID,
+        rows: data ?? [],
+        source_health: {
+          user_assistant_state: { available: true },
+        },
+      });
+    } catch (e) {
+      return res.status(500).json({
+        ok: false,
+        error: (e as Error).message,
+        vtid: VTID,
+      });
+    }
+  },
+);
+
+export default router;

--- a/services/gateway/test/orb/context/b0c-journey-context-panel.test.ts
+++ b/services/gateway/test/orb/context/b0c-journey-context-panel.test.ts
@@ -1,0 +1,136 @@
+/**
+ * B0c acceptance check #4 — Match Journey panel renders even at journeyStage='none'.
+ *
+ * The plan's hard rule: "Command Hub renders the Match Journey panel with
+ * journeyStage: 'none', source health for match_journey_context, and
+ * suppression / none state visible. The panel MUST be visible — never
+ * hidden because the journey is empty."
+ *
+ * This test is structural / source-level. The Command Hub renderer is
+ * pure DOM JS inside app.js (no React, no JSX) and isn't easily mounted
+ * inside Jest. We assert the source-level contract instead:
+ *
+ *   1. The renderJourneyContextMatchJourneyPanel function exists.
+ *   2. It accepts `preview` and tolerates `preview === null/undefined`
+ *      (no early return on missing data — the empty state IS the state).
+ *   3. It references each required row label, so an operator can read:
+ *      - current surface
+ *      - journey stage
+ *      - recommended next move
+ *      - privacyMode + privacyGate
+ *      - source health for match_journey_context
+ *      - suppression reason placeholder
+ *
+ * Plus the route-level contract:
+ *
+ *   4. The compiler returns `compiled.matchJourney.journeyStage === 'none'`
+ *      when no match context exists (acceptance check #2, re-validated
+ *      here in the B0c file so the test passes on its own).
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import { compileContext } from '../../../src/orb/context/context-compiler';
+import type { ClientContextEnvelope } from '../../../src/orb/context/client-context-envelope';
+
+const APP_JS_PATH = join(
+  __dirname,
+  '../../../src/frontend/command-hub/app.js',
+);
+
+function readAppJs(): string {
+  return readFileSync(APP_JS_PATH, 'utf8');
+}
+
+describe('B0c — Journey Context Match Journey panel', () => {
+  describe('source-level (Command Hub renderer)', () => {
+    let src: string;
+    beforeAll(() => {
+      src = readAppJs();
+    });
+
+    it('defines renderJourneyContextMatchJourneyPanel', () => {
+      expect(src).toContain('function renderJourneyContextMatchJourneyPanel');
+    });
+
+    it('does NOT early-return when match journey is absent (panel always renders)', () => {
+      // The function must not contain a guard like `if (!mj) return;` that
+      // would suppress the panel when context is empty.
+      const fnMatch = src.match(
+        /function renderJourneyContextMatchJourneyPanel\(preview\)\s*\{[\s\S]*?\n\}/,
+      );
+      expect(fnMatch).toBeTruthy();
+      const fnBody = fnMatch![0];
+      // Defensive: must accept missing data via fallbacks, not bail out.
+      expect(fnBody).not.toMatch(/if\s*\(\s*!mj\s*\)\s*return/);
+      expect(fnBody).not.toMatch(/if\s*\(\s*!preview\s*\)\s*return/);
+      // Must explicitly default the stage to 'none' when missing.
+      expect(fnBody).toContain("'none'");
+    });
+
+    it('renders every required row label', () => {
+      const fnMatch = src.match(
+        /function renderJourneyContextMatchJourneyPanel\(preview\)\s*\{[\s\S]*?\n\}/,
+      );
+      const fnBody = fnMatch![0];
+      const requiredRows = [
+        'current surface',
+        'journey stage',
+        'recommended next move',
+        'pending user decision',
+        'privacyMode',
+        'privacyGate',
+        'source health',
+        'suppression reason',
+      ];
+      for (const label of requiredRows) {
+        expect(fnBody).toContain(label);
+      }
+    });
+
+    it('is wired into the voice section tab handler', () => {
+      // The Voice → Journey Context tab must be wired so navigating to
+      // /command-hub/voice/journey-context/ actually renders this panel.
+      expect(src).toContain("'journey-context'");
+      expect(src).toContain('/command-hub/voice/journey-context/');
+      expect(src).toContain('renderJourneyContextView');
+    });
+  });
+
+  describe('compiler contract (B0c acceptance check restated)', () => {
+    function makeEnvelope(
+      over: Partial<ClientContextEnvelope> = {},
+    ): ClientContextEnvelope {
+      return {
+        surface: 'mobile',
+        localNow: '2026-05-11T18:30:00+02:00',
+        timezone: 'Europe/Berlin',
+        deviceClass: 'ios_webview',
+        privacyMode: 'private',
+        ...over,
+      };
+    }
+
+    it('returns matchJourney.journeyStage="none" when no match context exists', async () => {
+      const result = await compileContext({
+        userId: 'user-b0c',
+        tenantId: 'tenant-b0c',
+        envelope: makeEnvelope(),
+        nowMs: Date.UTC(2026, 4, 11, 18, 30, 0),
+      });
+      expect(result.compiled.matchJourney).toBeDefined();
+      expect(result.compiled.matchJourney.journeyStage).toBe('none');
+    });
+
+    it('source health includes match_journey_context (panel can render it)', async () => {
+      const result = await compileContext({
+        userId: 'user-b0c',
+        tenantId: 'tenant-b0c',
+        envelope: makeEnvelope(),
+        nowMs: Date.UTC(2026, 4, 11, 18, 30, 0),
+      });
+      const sources = result.compiled.sourceHealth.timings.map((t) => t.source);
+      expect(sources).toContain('match_journey_context');
+    });
+  });
+});

--- a/services/gateway/test/orb/context/b0c-user-assistant-state-migration.test.ts
+++ b/services/gateway/test/orb/context/b0c-user-assistant-state-migration.test.ts
@@ -1,0 +1,62 @@
+/**
+ * B0c — `user_assistant_state` migration shape guard.
+ *
+ * Hard rule from the plan: this table stores DURABLE signals only.
+ * Ephemeral route / journey_surface / current match context must NOT
+ * live here.
+ *
+ * This source-level test asserts the migration:
+ *   - Creates the `user_assistant_state` table with the documented PK.
+ *   - Documents the forbidden ephemeral signals so future maintainers
+ *     understand the boundary (the comment is load-bearing).
+ *   - Enables tenant-scoped RLS.
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const MIGRATION_PATH = join(
+  __dirname,
+  '../../../../../supabase/migrations/20260516000000_VTID_02909_user_assistant_state.sql',
+);
+
+describe('B0c — user_assistant_state migration', () => {
+  let sql: string;
+  beforeAll(() => {
+    sql = readFileSync(MIGRATION_PATH, 'utf8');
+  });
+
+  it('creates the user_assistant_state table', () => {
+    expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS user_assistant_state/);
+  });
+
+  it('uses the documented composite primary key', () => {
+    expect(sql).toMatch(/PRIMARY KEY \(tenant_id, user_id, signal_name\)/);
+  });
+
+  it('enables RLS for tenant isolation', () => {
+    expect(sql).toMatch(/ALTER TABLE user_assistant_state ENABLE ROW LEVEL SECURITY/);
+    expect(sql).toMatch(/tenant_id IN/);
+    expect(sql).toMatch(/user_tenants/);
+  });
+
+  it('documents the forbidden ephemeral signals', () => {
+    // The migration's comment block is load-bearing — it tells future
+    // maintainers that current_route / journey_surface / current_match_id
+    // are NEVER persisted here. Without this, B0d/B0e maintainers may
+    // accidentally store ephemeral session state long-term.
+    expect(sql).toMatch(/Forbidden signals/);
+    expect(sql).toMatch(/current_route/);
+    expect(sql).toMatch(/journey_surface/);
+    expect(sql).toMatch(/current_match_id/);
+  });
+
+  it('has a touch trigger so updated_at advances on mutation', () => {
+    expect(sql).toMatch(/CREATE OR REPLACE FUNCTION user_assistant_state_touch_updated_at/);
+    expect(sql).toMatch(/BEFORE UPDATE ON user_assistant_state/);
+  });
+
+  it('indexes expires_at for time-based sweeps', () => {
+    expect(sql).toMatch(/user_assistant_state_expires_at_idx/);
+  });
+});

--- a/supabase/migrations/20260516000000_VTID_02909_user_assistant_state.sql
+++ b/supabase/migrations/20260516000000_VTID_02909_user_assistant_state.sql
@@ -1,0 +1,86 @@
+-- B0c (orb-live-refactor) — user_assistant_state table.
+--
+-- Persists DURABLE assistant state per (tenant, user, signal_name).
+-- Per the approved plan (Cross-Cutting Implementation Notes):
+--   "Match-journey state in user_assistant_state is durable signals only.
+--    Ephemeral surface/route stays in compiled context, NEVER in the
+--    long-term state table."
+--
+-- Examples of durable signals:
+--   - `concepts_explained_count` per concept (B3 repetition suppression)
+--   - `greeting_style_last_used` (B1 cadence)
+--   - `dyk_cards_seen` per card (B0e onboarding)
+--   - `last_greeted_at_today` (B1 cadence)
+--   - `concept_mastery:vitana_index` (B3 mastery ladder)
+--   - `feature_discovery_dismissed:pre_match_whois` (B0e onboarding)
+--
+-- Forbidden signals (these are ephemeral, never persisted here):
+--   - current_route, journey_surface, current_match_id, current_intent_id
+--   - any per-session transient state that resets on session-start
+--
+-- RLS: tenant-scoped read/write — only the session's own tenant can
+-- see/mutate its rows.
+
+CREATE TABLE IF NOT EXISTS user_assistant_state (
+  tenant_id      UUID NOT NULL,
+  user_id        UUID NOT NULL,
+  signal_name    TEXT NOT NULL,
+  value          JSONB NOT NULL,
+  count          INT NOT NULL DEFAULT 0,
+  confidence     NUMERIC(4,3),               -- 0.000–1.000
+  source         TEXT,                       -- 'envelope', 'inferred', 'manual', etc.
+  expires_at     TIMESTAMPTZ,
+  last_seen_at   TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at     TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (tenant_id, user_id, signal_name)
+);
+
+-- Index for time-based sweeps (expired rows reaped by a future job).
+CREATE INDEX IF NOT EXISTS user_assistant_state_expires_at_idx
+  ON user_assistant_state (expires_at)
+  WHERE expires_at IS NOT NULL;
+
+-- Index for per-user lookups (most common access pattern).
+CREATE INDEX IF NOT EXISTS user_assistant_state_user_idx
+  ON user_assistant_state (tenant_id, user_id);
+
+-- Auto-update `updated_at` on row mutation.
+CREATE OR REPLACE FUNCTION user_assistant_state_touch_updated_at()
+  RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS user_assistant_state_updated_at_trigger ON user_assistant_state;
+CREATE TRIGGER user_assistant_state_updated_at_trigger
+  BEFORE UPDATE ON user_assistant_state
+  FOR EACH ROW
+  EXECUTE FUNCTION user_assistant_state_touch_updated_at();
+
+-- Row-level security: tenant isolation.
+ALTER TABLE user_assistant_state ENABLE ROW LEVEL SECURITY;
+
+-- Service role bypasses RLS implicitly. Anon role gets no access.
+-- Authenticated users see only their own tenant's rows.
+DROP POLICY IF EXISTS user_assistant_state_tenant_isolation ON user_assistant_state;
+CREATE POLICY user_assistant_state_tenant_isolation
+  ON user_assistant_state
+  FOR ALL
+  TO authenticated
+  USING (
+    tenant_id IN (
+      SELECT tenant_id FROM user_tenants WHERE user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    tenant_id IN (
+      SELECT tenant_id FROM user_tenants WHERE user_id = auth.uid()
+    )
+  );
+
+COMMENT ON TABLE user_assistant_state IS
+  'B0c (orb-live-refactor): durable assistant state keyed by (tenant, user, signal_name). '
+  'Ephemeral route/surface/match-context state belongs in compiled context, NOT here.';


### PR DESCRIPTION
## B0c slice — orb-live-refactor (Track B)

Durable assistant-state table, operator-facing Journey Context inspection surface, and the Match Journey panel that **renders even at journeyStage='none'**.

## What ships

- **Migration** \`user_assistant_state\` (durable signals only): tenant + user + signal_name PK, JSONB value, count/confidence/source/expires_at, auto-touch trigger, RLS tenant isolation via \`user_tenants\`. Comment block lists forbidden ephemeral signals (\`current_route\`, \`journey_surface\`, \`current_match_id\`) so future maintainers don't accidentally persist session state long-term.

- **Gateway route** \`GET /api/v1/voice/journey-context/{preview,state}\` (exafy_admin gated). Preview returns full B0b compiler output (compiled + decision + diagnostics); state lists rows from \`user_assistant_state\`.

- **Command Hub screen** at \`/command-hub/voice/journey-context/\`, inserted as a new tab in the existing Voice section (Awareness → **Journey Context** → Tool Catalog). Five panels: user picker, Decision Preview, **Match Journey**, Source Health, Durable Assistant State.

- **Match Journey panel is always visible.** Per the plan's hard rule, empty-state rows render when no match context exists: current surface, \`'none'\` stage, no recommended next move, privacyMode/privacyGate, source health for \`match_journey_context\`, suppression placeholder. **Never hidden because the journey is empty.**

## Tests

- **2 new suites, 12 new tests, all passing.**
  - \`b0c-user-assistant-state-migration.test.ts\` — validates table shape, composite PK, RLS via \`user_tenants\`, touch trigger, \`expires_at\` index, and the forbidden-signal comment.
  - \`b0c-journey-context-panel.test.ts\` — structural test that the Match Journey panel function exists, does NOT early-return on missing data, renders every required row label, and is wired into the voice tab handler. Plus a compiler-contract test re-validating \`journeyStage: 'none'\` for fresh users.
- **237/237 orb-suite tests pass.** (Was 225 before — +12.)
- \`npm run build\` clean. The pre-existing \`sharp\` type error in \`cover-image-outpaint.ts\` is unrelated to this slice.

## Sequencing

- Plan reference: \`.claude/plans/for-an-intelligent-context-aware-fluttering-mango.md\` → B0c.
- Match-journey acceptance check #4 enforced.
- **This PR does NOT start B0d.** The Continuation Contract is gated on B0c merging first.

## Test plan

- [x] Migration shape + RLS + touch trigger asserted via SQL-level test
- [x] Match Journey panel structural test (always renders)
- [x] Compiler contract test (\`journeyStage: 'none'\`)
- [x] \`npm run build\` clean
- [x] Full orb suite passes (237/237)
- [ ] Manual: open \`/command-hub/voice/journey-context/\` post-deploy and confirm panel renders for a fresh user

🤖 Generated with [Claude Code](https://claude.com/claude-code)