### PR TITLE
Fix self-healing worker reliability gates

### DIFF
--- a/.github/workflows/EXEC-DEPLOY.yml
+++ b/.github/workflows/EXEC-DEPLOY.yml
@@ -434,6 +434,12 @@ jobs:
             SECRETS_ARGS+=(--update-secrets=SUPABASE_URL=SUPABASE_URL:latest)
             SECRETS_ARGS+=(--update-secrets=SUPABASE_SERVICE_ROLE=SUPABASE_SERVICE_ROLE:latest)
             SECRETS_ARGS+=(--update-secrets=ANTHROPIC_API_KEY=ANTHROPIC_API_KEY:latest)
+            # BOOTSTRAP-WORKER-DS: worker-runner execution falls back to
+            # DeepSeek when the Anthropic primary is unavailable. Gateway
+            # already binds this GitHub secret; bind it here too so live
+            # self-healing VTIDs do not fail after claim with "fallback key
+            # missing".
+            EXTRA_ENV_ARGS+=(--update-env-vars=DEEPSEEK_API_KEY=${{ secrets.DEEPSEEK_API_KEY }})
           fi
 
           # VTID-01175: Vitana Verification Engine — needs gateway URL for agents registry heartbeat

--- a/docs/superpowers/plans/2026-05-10-self-healing-reliability.md
+++ b/docs/superpowers/plans/2026-05-10-self-healing-reliability.md
@@ -1,0 +1,845 @@
+# Self-Healing Reliability Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the current speculative self-healing loop with a closed-loop repair system that can detect, diagnose, patch, verify, deploy, rollback, and learn without falsely marking unresolved incidents as fixed.
+
+**Architecture:** The system should treat "100% self-healing" as "all safe, known classes are repaired automatically; unsafe, ambiguous, or repeatedly failing classes are escalated with complete evidence." Self-healing becomes a state-machine-backed pipeline: incident intake -> diagnosis -> spec -> real patch artifact -> test/verification -> PR/deploy/canary -> production verification -> rollback or terminal success. Every terminal state must be backed by evidence, not by an LLM success claim.
+
+**Tech Stack:** TypeScript/Node gateway and worker-runner, Supabase/Postgres, OASIS events, Git/GitHub Actions, Cloud Run, Playwright/Jest, existing Command Hub frontend.
+
+---
+
+## Current Failure Summary
+
+The codebase already contains most of the parts of a self-healing system, but the parts do not form a trustworthy repair loop.
+
+1. The worker execution prompt tells the LLM: `DO NOT actually modify files - describe what changes would be made.` See `services/worker-runner/src/services/execution-service.ts`.
+2. The worker then reports success from JSON and terminalizes the VTID even though no patch, branch, commit, PR, deployment, or production change is guaranteed.
+3. The worker always sends `skip_verification: true`, while the gateway usually rejects that bypass. The runner does not treat that rejection as fatal before terminalization.
+4. The pending-task API does not hydrate `spec_content`, so self-healing workers can execute with "No specification provided."
+5. OASIS event replay is timestamp-only and can skip same-timestamp events or discard unprocessed events when execution is disarmed.
+6. E2E failure reports use `/api/v1/e2e/health`, but self-healing rejects endpoints that are not in `ENDPOINT_FILE_MAP`, so important failures are skipped at intake.
+7. Rollback records events but does not actually shift Cloud Run traffic or dispatch the rollback workflow required by the original spec.
+8. Snapshot verification has no git SHA or Cloud Run revision, so it cannot prove what code was fixed or rolled back.
+9. The Command Hub canonical URL moved to `/command-hub/autonomy/self-healing/`, but backend notifications still default to `/command-hub/infrastructure/self-healing`.
+10. There are only peripheral tests for autonomy/voice self-healing, not a complete end-to-end contract test for detect -> patch -> verify -> terminalize.
+
+---
+
+## File Structure
+
+Modify:
+- `services/gateway/src/routes/self-healing.ts` - report intake, URL defaults, approval semantics, verification endpoints.
+- `services/gateway/src/services/self-healing-diagnosis-service.ts` - richer diagnosis inputs and repo/runtime evidence.
+- `services/gateway/src/services/self-healing-spec-service.ts` - spec acceptance criteria and executable repair metadata.
+- `services/gateway/src/services/self-healing-injector-service.ts` - injected task metadata, target paths, spec linkage.
+- `services/gateway/src/services/self-healing-reconciler.ts` - outcome semantics, redispatch rules, stale state handling.
+- `services/gateway/src/services/self-healing-snapshot-service.ts` - git SHA, Cloud Run revision, canary/rollback execution.
+- `services/gateway/src/services/autopilot-event-loop.ts` - durable cursor and replay rules.
+- `services/gateway/src/services/autopilot-event-mapper.ts` - terminal-state mapping backed by verified evidence.
+- `services/gateway/src/routes/worker-orchestrator.ts` - pending-task hydration and completion-gate behavior.
+- `services/worker-runner/src/services/execution-service.ts` - replace dry-run description with real patch generation/application.
+- `services/worker-runner/src/services/gateway-client.ts` - remove unconditional verification bypass and return fatal completion errors.
+- `services/worker-runner/src/services/runner-service.ts` - terminalize only after accepted verification.
+- `services/worker-runner/src/types.ts` - add patch, artifact, verification, and spec-required types.
+- `services/gateway/src/frontend/command-hub/app.js` - show truthful pipeline states and canonical self-healing route.
+- `services/gateway/specs/dev-screen-inventory-v1.json` - keep screen inventory aligned with canonical route.
+- `.github/workflows/E2E-TEST-RUN.yml` - report E2E failures as accepted incident classes.
+- `.github/workflows/E2E-ORB-MONITOR.yml` - include run evidence and artifact links.
+- `.github/workflows/SELF-HEALING-ROLLBACK.yml` - add or wire rollback workflow dispatch.
+- `scripts/ci/collect-status.py` - include canonical incident type and evidence fields.
+
+Create:
+- `services/gateway/src/services/self-healing-incident-normalizer.ts` - converts endpoint/test/workflow failures into canonical incident signatures.
+- `services/gateway/src/services/self-healing-state-machine.ts` - allowed transitions and evidence requirements.
+- `services/gateway/src/services/self-healing-repair-evidence.ts` - common evidence writer/reader for specs, patches, tests, deploys, verification.
+- `services/worker-runner/src/services/patch-workspace-service.ts` - isolated worktree setup, patch apply, git diff, cleanup.
+- `services/worker-runner/src/services/patch-contract.ts` - JSON schema for LLM patch plans and execution artifacts.
+- `services/gateway/test/self-healing-report-intake.test.ts` - intake normalization and skip behavior.
+- `services/gateway/test/self-healing-event-cursor.test.ts` - cursor replay and disarmed behavior.
+- `services/gateway/test/self-healing-pending-task-hydration.test.ts` - spec hydration contract.
+- `services/gateway/test/self-healing-verification-state-machine.test.ts` - terminal-state evidence rules.
+- `services/worker-runner/test/patch-workspace-service.test.ts` - real patch application behavior.
+- `services/worker-runner/test/runner-completion-gates.test.ts` - no false terminal success.
+- `docs/specs/SELF-HEALING-RUNTIME-CONTRACT.md` - production contract and safety boundaries.
+
+---
+
+## Task 1: Establish Failing Contract Tests
+
+**Files:**
+- Create: `services/gateway/test/self-healing-report-intake.test.ts`
+- Create: `services/gateway/test/self-healing-pending-task-hydration.test.ts`
+- Create: `services/worker-runner/test/runner-completion-gates.test.ts`
+- Modify: package test config only if the new worker-runner test folder is not already included.
+
+- [ ] **Step 1: Write intake tests for accepted E2E incidents**
+
+Add tests that POST a health report containing endpoint `/api/v1/e2e/health` and assert the route does not return `reason: "Unknown endpoint - not in gateway route map"`. The expected normalized incident should have:
+
+```ts
+{
+  kind: 'workflow_failure',
+  source: 'github_actions',
+  endpoint: '/api/v1/e2e/health',
+  failure_class: 'e2e_regression',
+}
+```
+
+- [ ] **Step 2: Write pending-task hydration tests**
+
+Mock Supabase responses for `vtid_ledger` and `vtid_specs`. Assert `GET /api/v1/worker/orchestrator/tasks/pending` returns `spec_content`, `metadata`, `task_domain`, and `target_paths` for a self-healing VTID.
+
+- [ ] **Step 3: Write completion-gate tests**
+
+Mock `reportSubagentComplete` and `reportOrchestratorComplete` returning HTTP 403 for `skip_verification`. Assert `runner-service` marks the task failed and does not call `terminalizeTask(..., 'success', ...)`.
+
+- [ ] **Step 4: Run tests and confirm the current failures**
+
+Run:
+
+```bash
+npm test -- --runInBand self-healing-report-intake self-healing-pending-task-hydration runner-completion-gates
+```
+
+Expected: tests fail for unknown endpoint skipping, missing spec hydration, and false terminal success.
+
+- [ ] **Step 5: Commit tests**
+
+Run:
+
+```bash
+git add services/gateway/test services/worker-runner/test
+git commit -m "test: capture self-healing reliability gaps"
+```
+
+---
+
+## Task 2: Normalize Incidents Instead Of Dropping Them
+
+**Files:**
+- Create: `services/gateway/src/services/self-healing-incident-normalizer.ts`
+- Modify: `services/gateway/src/routes/self-healing.ts`
+- Modify: `.github/workflows/E2E-TEST-RUN.yml`
+- Modify: `.github/workflows/E2E-ORB-MONITOR.yml`
+- Modify: `scripts/ci/collect-status.py`
+- Test: `services/gateway/test/self-healing-report-intake.test.ts`
+
+- [ ] **Step 1: Implement canonical incident normalization**
+
+`normalizeSelfHealingIncident(reportService)` should return:
+
+```ts
+type SelfHealingIncidentKind =
+  | 'endpoint_health'
+  | 'workflow_failure'
+  | 'voice_synthetic'
+  | 'routine_incident';
+
+interface SelfHealingIncident {
+  accepted: boolean;
+  kind: SelfHealingIncidentKind;
+  endpoint: string;
+  service_name: string;
+  failure_class_hint: string;
+  evidence: Record<string, unknown>;
+  skip_reason?: string;
+}
+```
+
+Rules:
+- Known `ENDPOINT_FILE_MAP` endpoints become `endpoint_health`.
+- `voice-error://...` becomes `voice_synthetic`.
+- `routine-incident://...` becomes `routine_incident`.
+- `/api/v1/e2e/health` becomes `workflow_failure`, not skipped.
+- Unknown HTTP endpoints are skipped unless the report contains `source: 'github_actions'` or `workflow_url`.
+
+- [ ] **Step 2: Replace inline allowlist logic**
+
+In `routes/self-healing.ts`, replace the local `knownEndpoints` loop with `normalizeSelfHealingIncident`. Preserve the existing skip response shape, but make skips evidence-backed and machine-readable.
+
+- [ ] **Step 3: Enrich CI reports**
+
+Update E2E workflows and `collect-status.py` to send:
+
+```json
+{
+  "source": "github_actions",
+  "workflow": "E2E-TEST-RUN",
+  "run_id": "${{ github.run_id }}",
+  "run_url": "https://github.com/${{ github.repository }}/actions/runs/${{ github.run_id }}"
+}
+```
+
+- [ ] **Step 4: Run intake tests**
+
+Run:
+
+```bash
+npm test -- --runInBand self-healing-report-intake
+```
+
+Expected: `/api/v1/e2e/health` creates or dedupes an incident instead of being skipped.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+git add services/gateway/src/services/self-healing-incident-normalizer.ts services/gateway/src/routes/self-healing.ts .github/workflows/E2E-TEST-RUN.yml .github/workflows/E2E-ORB-MONITOR.yml scripts/ci/collect-status.py services/gateway/test/self-healing-report-intake.test.ts
+git commit -m "fix: normalize self-healing incident intake"
+```
+
+---
+
+## Task 3: Make OASIS Event Consumption Durable
+
+**Files:**
+- Modify: `services/gateway/src/services/autopilot-event-loop.ts`
+- Create: `services/gateway/test/self-healing-event-cursor.test.ts`
+- Optional migration: add a processed-event table if tuple cursor storage is not enough.
+
+- [ ] **Step 1: Write cursor replay tests**
+
+Cover these cases:
+- Two events have the same `created_at`; both are processed in `id.asc` order.
+- Execution is disarmed; actionable events are not marked consumed.
+- A stale cursor does not jump to "one minute ago" without storing skipped events as intentionally abandoned.
+
+- [ ] **Step 2: Replace timestamp-only cursor**
+
+Use a cursor with both timestamp and id:
+
+```ts
+interface OasisCursor {
+  created_at: string;
+  id: string;
+}
+```
+
+Fetch with:
+- `created_at > cursor.created_at`, or
+- `created_at = cursor.created_at AND id > cursor.id`.
+
+If Supabase REST cannot express this cleanly, add an RPC `fetch_oasis_events_after_cursor(p_created_at timestamptz, p_id uuid, p_limit int)`.
+
+- [ ] **Step 3: Do not advance the cursor while disarmed**
+
+When execution is disarmed, record an `execution_blocked` event or backlog metric, but leave the cursor before the unprocessed actionable event.
+
+- [ ] **Step 4: Add replay command**
+
+Add an admin-safe method to replay self-healing events by VTID or time range without duplicating terminal state transitions.
+
+- [ ] **Step 5: Run tests**
+
+Run:
+
+```bash
+npm test -- --runInBand self-healing-event-cursor
+```
+
+Expected: all cursor replay scenarios pass.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add services/gateway/src/services/autopilot-event-loop.ts services/gateway/test/self-healing-event-cursor.test.ts supabase/migrations
+git commit -m "fix: make autopilot event cursor durable"
+```
+
+---
+
+## Task 4: Hydrate Specs And Require Them For Self-Healing Execution
+
+**Files:**
+- Modify: `services/gateway/src/routes/worker-orchestrator.ts`
+- Modify: `services/worker-runner/src/types.ts`
+- Modify: `services/worker-runner/src/services/runner-service.ts`
+- Test: `services/gateway/test/self-healing-pending-task-hydration.test.ts`
+
+- [ ] **Step 1: Return executable spec content from pending tasks**
+
+Extend the pending-task route to include:
+
+```ts
+{
+  spec_content: string;
+  metadata: Record<string, unknown>;
+  task_domain: 'frontend' | 'backend' | 'infra' | 'ai' | 'memory';
+  target_paths: string[];
+  spec_hash: string;
+}
+```
+
+Read `vtid_specs` by VTID and prefer its canonical markdown/content over `vtid_ledger.summary`.
+
+- [ ] **Step 2: Fail closed when self-healing has no spec**
+
+In `runner-service.ts`, before routing a task:
+
+```ts
+const isSelfHealing = task.metadata?.source === 'self-healing';
+if (isSelfHealing && !task.spec_content?.trim()) {
+  throw new Error(`Self-healing task ${task.vtid} has no hydrated spec_content`);
+}
+```
+
+- [ ] **Step 3: Pass target paths into governance**
+
+Ensure `routeTask` receives `target_paths` and uses them in `runPreflightChain`.
+
+- [ ] **Step 4: Run hydration tests**
+
+Run:
+
+```bash
+npm test -- --runInBand self-healing-pending-task-hydration
+```
+
+Expected: self-healing tasks include spec content and fail closed when it is missing.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+git add services/gateway/src/routes/worker-orchestrator.ts services/worker-runner/src/types.ts services/worker-runner/src/services/runner-service.ts services/gateway/test/self-healing-pending-task-hydration.test.ts
+git commit -m "fix: hydrate self-healing specs for workers"
+```
+
+---
+
+## Task 5: Replace Dry-Run LLM Output With Real Patch Artifacts
+
+**Files:**
+- Create: `services/worker-runner/src/services/patch-contract.ts`
+- Create: `services/worker-runner/src/services/patch-workspace-service.ts`
+- Modify: `services/worker-runner/src/services/execution-service.ts`
+- Modify: `services/worker-runner/src/types.ts`
+- Create: `services/worker-runner/test/patch-workspace-service.test.ts`
+
+- [ ] **Step 1: Define the patch contract**
+
+The LLM response must validate to this shape before any terminal success:
+
+```ts
+interface PatchPlan {
+  ok: boolean;
+  summary: string;
+  unified_diff: string;
+  files_changed: string[];
+  files_created: string[];
+  tests_to_run: string[];
+  risk_level: 'low' | 'medium' | 'high';
+  rollback_plan: string[];
+  error?: string;
+}
+```
+
+- [ ] **Step 2: Remove the dry-run instruction**
+
+Replace `DO NOT actually modify files - describe what changes would be made` with instructions to produce a minimal unified diff constrained to `target_paths` and the spec.
+
+- [ ] **Step 3: Apply patches in an isolated workspace**
+
+`patch-workspace-service.ts` should:
+- create a clean worktree for the VTID,
+- apply the unified diff with `git apply --check`,
+- apply the patch,
+- run `git diff --name-only`,
+- reject changes outside `target_paths`,
+- return patch evidence containing diff hash and changed files.
+
+- [ ] **Step 4: Run the declared tests**
+
+For self-healing tasks, run the tests declared by the patch contract plus a service-specific minimum:
+- gateway route/service changes: `npm test -- --runInBand <relevant-tests>`
+- TypeScript changes: `npm run typecheck` if available for that package
+- frontend Command Hub changes: existing frontend smoke tests or Playwright smoke where available
+
+- [ ] **Step 5: Persist artifacts**
+
+Persist:
+- patch diff,
+- changed files,
+- test commands,
+- test outputs,
+- worktree branch,
+- commit SHA if committed,
+- PR URL if opened.
+
+Use `self-healing-repair-evidence.ts` from Task 9 if that task has already landed; otherwise store evidence in VTID metadata and OASIS event payloads.
+
+- [ ] **Step 6: Run patch tests**
+
+Run:
+
+```bash
+npm test -- --runInBand patch-workspace-service
+```
+
+Expected: valid diffs apply, invalid diffs fail, out-of-scope paths fail.
+
+- [ ] **Step 7: Commit**
+
+Run:
+
+```bash
+git add services/worker-runner/src/services/patch-contract.ts services/worker-runner/src/services/patch-workspace-service.ts services/worker-runner/src/services/execution-service.ts services/worker-runner/src/types.ts services/worker-runner/test/patch-workspace-service.test.ts
+git commit -m "feat: execute self-healing patches in isolated workspaces"
+```
+
+---
+
+## Task 6: Stop False Terminal Success
+
+**Files:**
+- Modify: `services/worker-runner/src/services/gateway-client.ts`
+- Modify: `services/worker-runner/src/services/runner-service.ts`
+- Modify: `services/gateway/src/routes/worker-orchestrator.ts`
+- Create or modify: `services/worker-runner/test/runner-completion-gates.test.ts`
+- Create: `services/gateway/test/self-healing-verification-state-machine.test.ts`
+
+- [ ] **Step 1: Remove unconditional `skip_verification: true`**
+
+`gateway-client.ts` must send `skip_verification` only when explicitly configured for test/CI and accompanied by a valid governance override.
+
+- [ ] **Step 2: Make gateway completion failures fatal**
+
+Change `reportSubagentComplete` and `reportOrchestratorComplete` to return typed results and throw on non-2xx responses.
+
+- [ ] **Step 3: Terminalize only after accepted completion**
+
+In `runner-service.ts`, terminal success requires:
+- patch artifact exists,
+- changed files match the patch contract,
+- declared tests passed,
+- gateway accepted subagent completion,
+- gateway accepted orchestrator completion,
+- self-healing verification accepted or has moved to deployment/canary stage.
+
+- [ ] **Step 4: Add gateway guardrails**
+
+In `worker-orchestrator.ts`, reject successful self-healing completion if:
+- `files_changed` and `files_created` are both empty,
+- no patch artifact or commit SHA is present,
+- no test evidence is present,
+- `skip_verification` is requested without approval.
+
+- [ ] **Step 5: Run completion tests**
+
+Run:
+
+```bash
+npm test -- --runInBand runner-completion-gates self-healing-verification-state-machine
+```
+
+Expected: no self-healing VTID reaches terminal success without evidence.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add services/worker-runner/src/services/gateway-client.ts services/worker-runner/src/services/runner-service.ts services/gateway/src/routes/worker-orchestrator.ts services/worker-runner/test/runner-completion-gates.test.ts services/gateway/test/self-healing-verification-state-machine.test.ts
+git commit -m "fix: require evidence before self-healing terminal success"
+```
+
+---
+
+## Task 7: Add Real Deployment, Canary Verification, And Rollback
+
+**Files:**
+- Modify: `services/gateway/src/services/self-healing-snapshot-service.ts`
+- Modify: `services/gateway/src/services/autopilot-event-loop.ts`
+- Create: `.github/workflows/SELF-HEALING-ROLLBACK.yml`
+- Modify: docs/specs if the runtime contract changes.
+- Test: `services/gateway/test/self-healing-verification-state-machine.test.ts`
+
+- [ ] **Step 1: Capture deploy identity**
+
+Snapshots must include:
+
+```ts
+{
+  git_sha: string;
+  cloud_run_revision: string;
+  traffic_percent: number;
+  deployment_url: string;
+}
+```
+
+Read these from environment, Cloud Run metadata, or a deploy-manifest table written by deployment workflows.
+
+- [ ] **Step 2: Verify the target endpoint by current state, not only transition delta**
+
+Target fixed should mean the target endpoint is healthy in the post-fix snapshot. Keep `newlyFixed` for diagnostics, but do not require a down->up transition if the pre snapshot was late.
+
+- [ ] **Step 3: Gate rollout**
+
+For code fixes:
+- deploy to a new revision,
+- route 10% traffic,
+- run target health and blast-radius checks,
+- route 100% traffic only after canary passes,
+- record every traffic shift as OASIS events.
+
+- [ ] **Step 4: Dispatch actual rollback**
+
+`executeRollback` must call the rollback workflow or Cloud Run traffic API. It must not emit `rollback.completed` until traffic has actually shifted and post-rollback health is verified.
+
+- [ ] **Step 5: Run verification tests**
+
+Run:
+
+```bash
+npm test -- --runInBand self-healing-verification-state-machine
+```
+
+Expected: rollback remains `requested` until actual rollback evidence exists; successful fix requires healthy target plus no blast radius.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add services/gateway/src/services/self-healing-snapshot-service.ts services/gateway/src/services/autopilot-event-loop.ts .github/workflows/SELF-HEALING-ROLLBACK.yml services/gateway/test/self-healing-verification-state-machine.test.ts
+git commit -m "feat: add evidence-backed self-healing rollout and rollback"
+```
+
+---
+
+## Task 8: Improve Diagnosis With Repo And Runtime Context
+
+**Files:**
+- Modify: `services/gateway/src/services/self-healing-diagnosis-service.ts`
+- Modify: `services/gateway/src/services/self-healing-triage-service.ts`
+- Modify: `services/gateway/src/services/self-healing-spec-service.ts`
+- Modify: `services/gateway/src/services/self-healing-injector-service.ts`
+- Add tests near existing gateway service tests.
+
+- [ ] **Step 1: Restore code-aware triage for hard failures**
+
+When confidence is below auto-fix threshold, triage must receive:
+- route file path,
+- target paths,
+- last deploy SHA,
+- relevant logs,
+- workflow run URL,
+- recent self-healing attempts for same signature,
+- current spec and previous failed spec hashes.
+
+- [ ] **Step 2: Replace manual VTID increments**
+
+`createFreshVtidFromTriageReport` must use the existing VTID allocation RPC or a sequence-backed insert. It must not select the latest row and add one.
+
+- [ ] **Step 3: Generate executable metadata**
+
+Specs must include:
+- target paths,
+- test commands,
+- rollback commands,
+- expected health assertions,
+- disallowed changes,
+- risk level,
+- auto-merge eligibility.
+
+- [ ] **Step 4: Remove nonexistent acceptance signals**
+
+Replace `self-healing.fix.applied` acceptance criteria unless Task 5 emits that event after a patch is actually applied. The acceptance signal should be tied to real patch evidence.
+
+- [ ] **Step 5: Run diagnosis/spec tests**
+
+Run:
+
+```bash
+npm test -- --runInBand self-healing
+```
+
+Expected: diagnosis produces target paths and executable metadata; low-confidence triage includes code/runtime evidence.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add services/gateway/src/services/self-healing-diagnosis-service.ts services/gateway/src/services/self-healing-triage-service.ts services/gateway/src/services/self-healing-spec-service.ts services/gateway/src/services/self-healing-injector-service.ts services/gateway/test
+git commit -m "feat: enrich self-healing diagnosis and specs"
+```
+
+---
+
+## Task 9: Fix Outcome Semantics And Command Hub Truthfulness
+
+**Files:**
+- Create: `services/gateway/src/services/self-healing-state-machine.ts`
+- Modify: `services/gateway/src/services/self-healing-reconciler.ts`
+- Modify: `services/gateway/src/routes/self-healing.ts`
+- Modify: `services/gateway/src/frontend/command-hub/app.js`
+- Modify: `services/gateway/specs/dev-screen-inventory-v1.json`
+- Modify: `docs/specs/SELF-HEALING-TEST-PLAN.md`
+
+- [ ] **Step 1: Define terminal outcomes**
+
+Use explicit outcomes:
+- `fixed` - production verified after repair.
+- `recovered_externally` - endpoint healthy, no repair evidence.
+- `rolled_back` - rollback executed and verified.
+- `failed` - attempted repair failed with evidence.
+- `escalated` - human action required.
+- `skipped` - intentionally not acted on.
+- `paused` - kill switch or governance hold.
+
+- [ ] **Step 2: Stop marking success-ish reconciler states as escalated**
+
+`probe_verified` and `recovered_externally` should not write `outcome: 'escalated'`. They should use the explicit outcome above and preserve the reason in `diagnosis.reconciled_reason`.
+
+- [ ] **Step 3: Align canonical URL**
+
+Set `COMMAND_HUB_SH_URL` defaults to:
+
+```text
+https://gateway-q74ibpv6ia-uc.a.run.app/command-hub/autonomy/self-healing/
+```
+
+Keep frontend redirects for old infrastructure links.
+
+- [ ] **Step 4: Make the UI show evidence, not only status**
+
+Command Hub should show:
+- incident source,
+- current stage,
+- blocking reason,
+- patch artifact or "no patch yet",
+- test status,
+- deploy revision,
+- verification snapshot IDs,
+- rollback state.
+
+- [ ] **Step 5: Run frontend and gateway tests**
+
+Run:
+
+```bash
+npm test -- --runInBand autonomy-pulse autonomy-trace self-healing
+```
+
+Expected: history rows distinguish fixed, external recovery, rollback, failed, and escalated.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add services/gateway/src/services/self-healing-state-machine.ts services/gateway/src/services/self-healing-reconciler.ts services/gateway/src/routes/self-healing.ts services/gateway/src/frontend/command-hub/app.js services/gateway/specs/dev-screen-inventory-v1.json docs/specs/SELF-HEALING-TEST-PLAN.md
+git commit -m "fix: show truthful self-healing outcomes"
+```
+
+---
+
+## Task 10: Add Repair Memory And Anti-Loop Controls
+
+**Files:**
+- Create: `services/gateway/src/services/self-healing-repair-evidence.ts`
+- Add migration for `self_healing_repair_attempts` or extend existing tables with evidence columns.
+- Modify: `services/gateway/src/services/self-healing-reconciler.ts`
+- Modify: `services/gateway/src/services/self-healing-spec-service.ts`
+- Modify: `services/gateway/src/routes/self-healing.ts`
+
+- [ ] **Step 1: Store every repair attempt**
+
+Persist:
+
+```ts
+interface SelfHealingRepairAttempt {
+  vtid: string;
+  incident_signature: string;
+  spec_hash: string;
+  patch_hash?: string;
+  changed_files: string[];
+  test_commands: string[];
+  test_passed: boolean;
+  deploy_revision?: string;
+  verification_outcome: string;
+  failure_reason?: string;
+}
+```
+
+- [ ] **Step 2: Block repeated failed fixes**
+
+Before generating or dispatching a spec, check recent attempts with the same `incident_signature` and `spec_hash`. If the same fix failed twice in 72 hours, require human approval and include the previous evidence.
+
+- [ ] **Step 3: Rank known-good fixes higher**
+
+If a spec hash fixed the same signature previously and no regression happened, allow auto-fix at a higher confidence within the same risk class.
+
+- [ ] **Step 4: Add recurring failure alerts**
+
+If the same endpoint/signature fails after a verified fix, escalate as recurrence instead of creating another generic repair.
+
+- [ ] **Step 5: Run repair-memory tests**
+
+Run:
+
+```bash
+npm test -- --runInBand self-healing-repair-memory self-healing
+```
+
+Expected: repeated bad fixes are blocked; known-good fixes are reused only within guardrails.
+
+- [ ] **Step 6: Commit**
+
+Run:
+
+```bash
+git add services/gateway/src/services/self-healing-repair-evidence.ts services/gateway/src/services/self-healing-reconciler.ts services/gateway/src/services/self-healing-spec-service.ts services/gateway/src/routes/self-healing.ts supabase/migrations services/gateway/test
+git commit -m "feat: add self-healing repair memory"
+```
+
+---
+
+## Task 11: End-To-End Chaos Harness
+
+**Files:**
+- Create: `services/gateway/test/self-healing-e2e-harness.test.ts`
+- Create: `services/worker-runner/test/self-healing-worker-e2e.test.ts`
+- Modify: CI workflow to run these tests before self-healing auto-mode can be enabled.
+- Modify: `docs/specs/SELF-HEALING-RUNTIME-CONTRACT.md`
+
+- [ ] **Step 1: Build a fake incident flow**
+
+The harness should simulate:
+- a failing endpoint report,
+- diagnosis,
+- spec generation,
+- injection,
+- worker pickup,
+- patch artifact,
+- test pass,
+- deploy/canary event,
+- post-fix health success,
+- terminal success.
+
+- [ ] **Step 2: Build negative flows**
+
+Cover:
+- unknown endpoint with no evidence -> skipped,
+- E2E failure with evidence -> accepted,
+- missing spec -> fail closed,
+- LLM says ok with no diff -> rejected,
+- gateway rejects completion -> no terminal success,
+- blast radius -> rollback requested and then verified,
+- rollback workflow fails -> escalated.
+
+- [ ] **Step 3: Add CI gate**
+
+Self-healing autonomous mode cannot be set above `diagnose_only` unless the chaos harness passes on the target branch.
+
+- [ ] **Step 4: Run harness**
+
+Run:
+
+```bash
+npm test -- --runInBand self-healing-e2e-harness self-healing-worker-e2e
+```
+
+Expected: happy path passes and every negative case avoids false success.
+
+- [ ] **Step 5: Commit**
+
+Run:
+
+```bash
+git add services/gateway/test/self-healing-e2e-harness.test.ts services/worker-runner/test/self-healing-worker-e2e.test.ts .github/workflows docs/specs/SELF-HEALING-RUNTIME-CONTRACT.md
+git commit -m "test: add self-healing end-to-end chaos harness"
+```
+
+---
+
+## Task 12: Operational Rollout
+
+**Files:**
+- Modify: `docs/specs/SELF-HEALING-RUNTIME-CONTRACT.md`
+- Modify: deployment/config docs for `self_healing_autonomy_level`.
+- Modify: Command Hub config copy if needed.
+
+- [ ] **Step 1: Define autonomy levels**
+
+Use these levels:
+- `observe_only` - log and display only.
+- `diagnose_only` - produce diagnosis and spec, no execution.
+- `patch_pr_only` - create patch PRs, no auto-merge.
+- `auto_fix_low_risk` - auto-merge/deploy only low-risk known classes with rollback ready.
+- `auto_fix_canary` - low-risk auto-deploy through 10% canary.
+- `full_auto_bounded` - all eligible known classes auto-repair; unknown and high-risk classes escalate.
+
+- [ ] **Step 2: Stage rollout**
+
+Roll out in this order:
+1. `diagnose_only` for 48 hours with no skipped accepted incident classes.
+2. `patch_pr_only` until 10 consecutive correct patch PRs.
+3. `auto_fix_low_risk` for route-map/config/env-var failures.
+4. `auto_fix_canary` once rollback workflow is proven.
+5. `full_auto_bounded` only after the chaos harness is required in CI.
+
+- [ ] **Step 3: Define success metrics**
+
+Track:
+- incident acceptance rate,
+- false skip rate,
+- diagnosis accuracy,
+- patch apply success,
+- test pass rate,
+- verified production fix rate,
+- rollback rate,
+- false terminal success count,
+- recurrence within 72 hours.
+
+The false terminal success count must stay at zero.
+
+- [ ] **Step 4: Commit docs**
+
+Run:
+
+```bash
+git add docs/specs/SELF-HEALING-RUNTIME-CONTRACT.md docs/specs/SELF-HEALING-TEST-PLAN.md
+git commit -m "docs: define self-healing rollout contract"
+```
+
+---
+
+## Verification Before Enabling Full Auto Mode
+
+Run:
+
+```bash
+npm test -- --runInBand self-healing-report-intake self-healing-pending-task-hydration self-healing-event-cursor self-healing-verification-state-machine runner-completion-gates patch-workspace-service self-healing-e2e-harness self-healing-worker-e2e
+```
+
+Expected:
+- no accepted incident is silently skipped,
+- no self-healing task executes without spec content,
+- no LLM-only success can terminalize a VTID,
+- every fixed outcome has patch/test/deploy/verification evidence,
+- rollback is real and verified,
+- Command Hub shows accurate outcome semantics.
+
+Only after this command passes should `self_healing_autonomy_level` be allowed above `patch_pr_only`.
+
+---
+
+## Self-Review
+
+Spec coverage:
+- Intake, diagnosis, spec, injection, execution, verification, rollback, UI, repair memory, and rollout are all covered by tasks.
+- The plan explicitly handles the observed failures: dry-run worker, skipped E2E endpoint, missing spec hydration, event cursor loss, verification bypass, fake rollback completion, outcome confusion, and stale Command Hub links.
+
+Placeholder scan:
+- No task relies on "implement later" or unspecified behavior. Each task names files, exact expected behavior, and verification commands.
+
+Type consistency:
+- `spec_content`, `target_paths`, `metadata.source`, patch artifacts, and terminal evidence are used consistently across gateway and worker-runner tasks.

--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -44055,6 +44055,76 @@ function renderAutopilotAutoApproveView() {
     cfgSection.appendChild(cfgRules);
     container.appendChild(cfgSection);
 
+    // Self-healing readiness ladder
+    if (data.self_healing && data.self_healing.summary && Array.isArray(data.self_healing.gates)) {
+        var sh = data.self_healing;
+        var shSection = document.createElement('section');
+        shSection.style.cssText = 'background:#101521;border:1px solid #334155;border-radius:8px;padding:1rem 1.25rem;margin-bottom:1.5rem;';
+
+        var shHeader = document.createElement('div');
+        shHeader.style.cssText = 'display:flex;justify-content:space-between;align-items:flex-start;gap:1rem;flex-wrap:wrap;margin-bottom:0.75rem;';
+        var shTitleWrap = document.createElement('div');
+        var shTitle = document.createElement('h3');
+        shTitle.textContent = 'SELF-HEALING READINESS';
+        shTitle.style.cssText = 'color:#cbd5e1;font-size:0.8rem;letter-spacing:0.08em;margin:0 0 0.35rem 0;';
+        shTitleWrap.appendChild(shTitle);
+        var shHelp = document.createElement('div');
+        shHelp.style.cssText = 'color:#94a3b8;font-size:0.78rem;line-height:1.45;';
+        shHelp.textContent = 'Autonomy gates for safe repair: spec, evidence, patch, tests, deploy, verification, rollback, and memory.';
+        shTitleWrap.appendChild(shHelp);
+        shHeader.appendChild(shTitleWrap);
+
+        var shPct = document.createElement('div');
+        shPct.style.cssText = 'color:#4ade80;font-size:1.35rem;font-weight:700;font-variant-numeric:tabular-nums;';
+        shPct.textContent = sh.summary.autonomy_percent + '%';
+        shHeader.appendChild(shPct);
+        shSection.appendChild(shHeader);
+
+        var shTrack = document.createElement('div');
+        shTrack.style.cssText = 'background:#0f172a;border:1px solid #334155;border-radius:999px;height:8px;overflow:hidden;margin-bottom:0.75rem;';
+        var shFill = document.createElement('div');
+        shFill.style.cssText = 'background:linear-gradient(90deg,#22c55e,#06b6d4);height:100%;width:' + sh.summary.autonomy_percent + '%;';
+        shTrack.appendChild(shFill);
+        shSection.appendChild(shTrack);
+
+        var shNext = document.createElement('div');
+        shNext.style.cssText = 'color:#cbd5e1;font-size:0.82rem;margin-bottom:0.75rem;';
+        var nextGate = sh.summary.next_gate;
+        shNext.textContent = nextGate
+            ? 'Next gate: ' + nextGate.title + ' — ' + (nextGate.next_step || nextGate.description)
+            : 'All self-healing gates are ready for full bounded autonomy.';
+        shSection.appendChild(shNext);
+
+        (sh.gates || []).forEach(function (gate) {
+            var row = document.createElement('div');
+            var color = gate.status === 'ready' ? '#4ade80' : gate.status === 'blocked' ? '#f97316' : '#94a3b8';
+            row.style.cssText = 'display:flex;gap:0.75rem;align-items:flex-start;border-top:1px solid #1f2937;padding:0.65rem 0;';
+
+            var badge = document.createElement('span');
+            badge.textContent = gate.status === 'ready' ? 'ready' : gate.status;
+            badge.style.cssText = 'background:' + color + '20;color:' + color + ';border:1px solid ' + color + '55;padding:2px 9px;border-radius:999px;font-size:0.72rem;min-width:68px;text-align:center;text-transform:uppercase;';
+            row.appendChild(badge);
+
+            var body = document.createElement('div');
+            body.style.cssText = 'flex:1;min-width:0;';
+            var gateTitle = document.createElement('div');
+            gateTitle.style.cssText = 'color:#e5e7eb;font-weight:600;font-size:0.86rem;';
+            gateTitle.textContent = gate.title;
+            body.appendChild(gateTitle);
+            var gateDesc = document.createElement('div');
+            gateDesc.style.cssText = 'color:#94a3b8;font-size:0.76rem;line-height:1.4;margin-top:2px;';
+            gateDesc.textContent = gate.status === 'ready'
+                ? ((gate.evidence || []).join(' · ') || gate.description)
+                : (gate.next_step || gate.description);
+            body.appendChild(gateDesc);
+            row.appendChild(body);
+
+            shSection.appendChild(row);
+        });
+
+        container.appendChild(shSection);
+    }
+
     // Helper: one row per surface.
     function renderSurfaceRow(s, idField, type) {
         var card = document.createElement('div');

--- a/services/gateway/src/routes/dev-autopilot.ts
+++ b/services/gateway/src/routes/dev-autopilot.ts
@@ -486,6 +486,128 @@ router.get('/impact-rules', requireDevRole, async (_req: Request, res: Response)
 });
 
 // =============================================================================
+// Self-healing autonomy readiness
+// =============================================================================
+
+type SelfHealingGateStatus = 'ready' | 'blocked' | 'pending';
+
+interface SelfHealingAutonomyGate {
+  id: string;
+  title: string;
+  status: SelfHealingGateStatus;
+  description: string;
+  evidence: string[];
+  next_step?: string;
+  command_hub_target?: string;
+}
+
+interface SelfHealingAutonomyReadiness {
+  summary: {
+    ready_gates: number;
+    total_gates: number;
+    autonomy_percent: number;
+    next_gate: SelfHealingAutonomyGate | null;
+  };
+  gates: SelfHealingAutonomyGate[];
+}
+
+export function buildSelfHealingAutonomyReadiness(): SelfHealingAutonomyReadiness {
+  const gates: SelfHealingAutonomyGate[] = [
+    {
+      id: 'spec_hydration',
+      title: 'Hydrated worker specs',
+      status: 'ready',
+      description: 'Self-healing VTIDs must reach workers with canonical spec text, metadata, task domain, target paths, and spec hash.',
+      evidence: [
+        'pending tasks include spec_content from vtid_specs',
+        'self-healing workers fail closed without hydrated specs',
+        'target_paths are forwarded into governance routing',
+      ],
+      command_hub_target: '/command-hub/autonomy/self-healing/',
+    },
+    {
+      id: 'completion_evidence',
+      title: 'No false terminal success',
+      status: 'ready',
+      description: 'A self-healing task cannot terminalize success from an LLM claim or a verification bypass.',
+      evidence: [
+        'worker-runner removed unconditional skip_verification',
+        'gateway rejects self-healing success without repair evidence',
+        'worker terminalizes success only after gateway completion acceptance',
+      ],
+      command_hub_target: '/command-hub/autonomy/self-healing/',
+    },
+    {
+      id: 'patch_artifacts',
+      title: 'Real patch artifacts',
+      status: 'blocked',
+      description: 'The worker must apply a validated diff in an isolated workspace before reporting a repair.',
+      evidence: [],
+      next_step: 'Create patch-contract.ts and patch-workspace-service.ts, then require diff hash, changed files, and test output before ok=true.',
+      command_hub_target: '/command-hub/autopilot/auto-approve/',
+    },
+    {
+      id: 'test_execution',
+      title: 'Declared tests executed',
+      status: 'pending',
+      description: 'Every repair must run the tests declared by the patch contract plus package-level minimum checks.',
+      evidence: [],
+      next_step: 'Persist test commands, exit codes, and output snippets as repair evidence.',
+      command_hub_target: '/command-hub/autopilot/runs/',
+    },
+    {
+      id: 'deploy_canary',
+      title: 'Canary deploy identity',
+      status: 'pending',
+      description: 'A fix is not production-healed until the deployed revision and traffic split are known.',
+      evidence: [],
+      next_step: 'Record git SHA, Cloud Run revision, deployment URL, and 10% canary traffic before full rollout.',
+      command_hub_target: '/command-hub/operations/deployments/',
+    },
+    {
+      id: 'production_verification',
+      title: 'Production health verification',
+      status: 'pending',
+      description: 'Terminal fixed requires a healthy post-fix snapshot for the target and no blast-radius regression.',
+      evidence: [],
+      next_step: 'Tie self-healing snapshots to patch/deploy evidence and require target health before fixed.',
+      command_hub_target: '/command-hub/autonomy/self-healing/',
+    },
+    {
+      id: 'rollback_execution',
+      title: 'Actual rollback',
+      status: 'pending',
+      description: 'Rollback events must reflect real traffic movement, not only an emitted status event.',
+      evidence: [],
+      next_step: 'Dispatch the rollback workflow or Cloud Run traffic API, then verify the previous revision is serving.',
+      command_hub_target: '/command-hub/operations/deployments/',
+    },
+    {
+      id: 'repair_memory',
+      title: 'Repair memory and anti-loop controls',
+      status: 'pending',
+      description: 'The system must remember failed and known-good fixes per incident signature.',
+      evidence: [],
+      next_step: 'Persist repair attempts by incident signature, spec hash, patch hash, test result, deploy revision, and recurrence outcome.',
+      command_hub_target: '/command-hub/autonomy/self-healing/',
+    },
+  ];
+
+  const readyGates = gates.filter(g => g.status === 'ready').length;
+  const nextGate = gates.find(g => g.status !== 'ready') || null;
+
+  return {
+    summary: {
+      ready_gates: readyGates,
+      total_gates: gates.length,
+      autonomy_percent: gates.length > 0 ? Math.round((readyGates / gates.length) * 100) : 0,
+      next_gate: nextGate,
+    },
+    gates,
+  };
+}
+
+// =============================================================================
 // GET /auto-approve — aggregated view of the auto-approve registry
 // =============================================================================
 // One call for the Command Hub Auto-Approve tab. Returns:
@@ -594,6 +716,7 @@ router.get('/auto-approve', requireDevRole, async (_req: Request, res: Response)
       total_surfaces: totalSurfaces,
       autonomy_percent: autonomyProgress,
     },
+    self_healing: buildSelfHealingAutonomyReadiness(),
     scanners,
     rules,
   });

--- a/services/gateway/src/routes/worker-orchestrator.ts
+++ b/services/gateway/src/routes/worker-orchestrator.ts
@@ -29,6 +29,12 @@ import {
 } from '../services/worker-orchestrator-service';
 import { runPreflightChain, listSkills, getPreflightChains } from '../services/skills/preflight-runner';
 import { fetchServiceTierAgents } from './agents-registry';
+import {
+  getSpecDomain,
+  getSpecTargetPaths,
+  getSpecText,
+  getVtidSpec,
+} from '../services/vtid-spec-service';
 
 // ---------------------------------------------------------------------------
 // Self-healing log sync: when a self-healing VTID completes or fails in the
@@ -371,6 +377,19 @@ workerOrchestratorRouter.post('/api/v1/worker/subagent/complete', async (req: Re
     const startedAtDate = started_at ? new Date(started_at) : undefined;
 
     if (result?.ok) {
+      if (!hasRepairEvidence(result) && await isSelfHealingVtid(vtid)) {
+        await emitMissingRepairEvidenceEvent(vtid, run_id, 'subagent/complete', domain);
+        return res.status(400).json({
+          ok: false,
+          error: 'self-healing completion requires repair evidence',
+          reason: 'missing_repair_evidence',
+          vtid,
+          domain,
+          run_id,
+          event: `vtid.stage.worker_${domain}.failed`,
+        });
+      }
+
       // VTID-01175: Run verification before marking success (unless skipped with governance approval)
       if (skip_verification) {
         // Governance check: is skip_verification allowed?
@@ -504,6 +523,19 @@ workerOrchestratorRouter.post('/api/v1/worker/orchestrator/complete', async (req
     const startedAtDate = started_at ? new Date(started_at) : undefined;
 
     if (success) {
+      if (!hasRepairEvidence(result) && await isSelfHealingVtid(vtid)) {
+        await emitMissingRepairEvidenceEvent(vtid, run_id, 'orchestrator/complete', domain);
+        return res.status(400).json({
+          ok: false,
+          error: 'self-healing completion requires repair evidence',
+          reason: 'missing_repair_evidence',
+          vtid,
+          run_id,
+          verified: false,
+          event: 'vtid.stage.worker_orchestrator.failed',
+        });
+      }
+
       // VTID-01175: Run verification before marking success (unless skipped with governance approval)
       const needsSkip = skip_verification || !domain || !result;
       if (needsSkip) {
@@ -733,6 +765,148 @@ workerOrchestratorRouter.get('/api/v1/worker/skills', (_req: Request, res: Respo
 // =============================================================================
 
 const LOG_PREFIX = '[VTID-01183]';
+const TASK_DOMAINS: TaskDomain[] = ['frontend', 'backend', 'memory', 'infra', 'ai', 'mixed'];
+
+function asRecord(value: unknown): Record<string, unknown> {
+  if (!value || typeof value !== 'object' || Array.isArray(value)) {
+    return {};
+  }
+  return value as Record<string, unknown>;
+}
+
+function asStringArray(value: unknown): string[] {
+  return Array.isArray(value)
+    ? value.filter((item): item is string => typeof item === 'string' && item.trim().length > 0)
+    : [];
+}
+
+function asTaskDomain(value: unknown): TaskDomain | undefined {
+  return typeof value === 'string' && TASK_DOMAINS.includes(value as TaskDomain)
+    ? value as TaskDomain
+    : undefined;
+}
+
+function hasRepairEvidence(result?: { files_changed?: string[]; files_created?: string[] }): boolean {
+  return ((result?.files_changed?.length || 0) + (result?.files_created?.length || 0)) > 0;
+}
+
+async function isSelfHealingVtid(vtid: string): Promise<boolean> {
+  const result = await supabaseRequest<any[]>(
+    `/rest/v1/vtid_ledger?vtid=eq.${encodeURIComponent(vtid)}&select=metadata`
+  );
+  if (!result.ok) {
+    console.warn(`${LOG_PREFIX} Could not load metadata for ${vtid}: ${result.error}`);
+    return false;
+  }
+
+  const metadata = asRecord(result.data?.[0]?.metadata);
+  return metadata.source === 'self-healing';
+}
+
+async function emitMissingRepairEvidenceEvent(
+  vtid: string,
+  runId: string,
+  stage: 'subagent/complete' | 'orchestrator/complete',
+  domain?: string
+): Promise<void> {
+  await emitOasisEvent({
+    vtid,
+    type: 'self-healing.verification.rejected' as any,
+    source: 'worker-orchestrator',
+    status: 'error',
+    message: `Self-healing completion rejected at ${stage}: missing repair evidence`,
+    payload: {
+      vtid,
+      run_id: runId,
+      domain,
+      stage,
+      reason: 'missing_repair_evidence',
+      required: ['files_changed', 'files_created'],
+      emitted_at: new Date().toISOString(),
+    },
+  });
+}
+
+type LegacyVtidSpecRow = {
+  vtid: string;
+  title?: string | null;
+  spec_markdown?: string | null;
+  spec_hash?: string | null;
+  status?: string | null;
+  created_by?: string | null;
+  created_at?: string | null;
+};
+
+async function fetchLegacyVtidSpec(vtid: string): Promise<LegacyVtidSpecRow | null> {
+  const result = await supabaseRequest<LegacyVtidSpecRow[]>(
+    `/rest/v1/vtid_specs?vtid=eq.${encodeURIComponent(vtid)}` +
+      `&select=vtid,title,spec_markdown,spec_hash,status,created_by,created_at` +
+      `&order=created_at.desc&limit=1`
+  );
+
+  if (!result.ok) {
+    console.warn(`${LOG_PREFIX} Legacy spec lookup failed for ${vtid}: ${result.error}`);
+    return null;
+  }
+
+  const row = result.data?.[0];
+  return row?.spec_markdown ? row : null;
+}
+
+function inferTaskDomainFromPaths(paths: string[]): TaskDomain | undefined {
+  if (paths.some((p) => p.includes('/frontend/') || p.endsWith('.css') || p.endsWith('.html'))) {
+    return 'frontend';
+  }
+  if (paths.some((p) => p.startsWith('supabase/') || p.endsWith('.sql'))) {
+    return 'memory';
+  }
+  if (paths.some((p) => p.includes('/agents/') || p.includes('agent') || p.includes('llm'))) {
+    return 'ai';
+  }
+  if (paths.some((p) => p.includes('/routes/') || p.includes('/services/') || p.endsWith('.ts'))) {
+    return 'backend';
+  }
+  return undefined;
+}
+
+async function hydratePendingTask(task: any) {
+  const metadata = asRecord(task.metadata);
+  const spec = await getVtidSpec(task.vtid, { bypassCache: true });
+  const legacySpec = spec ? null : await fetchLegacyVtidSpec(task.vtid);
+  const specTargetPaths = spec ? getSpecTargetPaths(spec) : [];
+  const metadataTargetPaths = asStringArray(metadata.target_paths).length > 0
+    ? asStringArray(metadata.target_paths)
+    : asStringArray(metadata.files_to_modify);
+  const targetPaths = specTargetPaths.length > 0 ? specTargetPaths : metadataTargetPaths;
+  const specContent = spec ? getSpecText(spec) : legacySpec?.spec_markdown;
+  const specHash = spec?.spec_checksum ||
+    legacySpec?.spec_hash ||
+    (typeof metadata.spec_hash === 'string' ? metadata.spec_hash : undefined);
+
+  return {
+    vtid: task.vtid,
+    title: task.title,
+    summary: task.summary,
+    status: task.status,
+    spec_status: task.spec_status,
+    spec_content: specContent,
+    task_domain:
+      asTaskDomain(spec ? getSpecDomain(spec) : undefined) ||
+      asTaskDomain(metadata.task_domain) ||
+      inferTaskDomainFromPaths(targetPaths),
+    target_paths: targetPaths,
+    spec_hash: specHash,
+    metadata,
+    is_terminal: task.is_terminal || false,
+    layer: task.layer,
+    module: task.module,
+    created_at: task.created_at,
+    updated_at: task.updated_at,
+    claimed_by: task.claimed_by || null,
+    claim_expires_at: task.claim_expires_at || null,
+    claim_started_at: task.claim_started_at || null,
+  };
+}
 
 // Helper: Supabase request
 async function supabaseRequest<T>(
@@ -1019,7 +1193,7 @@ workerOrchestratorRouter.get('/api/v1/worker/orchestrator/tasks/pending', async 
       `/rest/v1/vtid_ledger?` +
       `status=in.(scheduled,in_progress)&` +
       `spec_status=eq.approved&` +
-      `select=vtid,title,summary,status,layer,module,created_at,updated_at,claimed_by,claim_expires_at,claim_started_at,is_terminal,spec_status&` +
+      `select=vtid,title,summary,status,layer,module,metadata,created_at,updated_at,claimed_by,claim_expires_at,claim_started_at,is_terminal,spec_status&` +
       `order=created_at.asc&` +
       `limit=${limit * 2}` // Fetch extra to allow for filtering
     );
@@ -1035,7 +1209,7 @@ workerOrchestratorRouter.get('/api/v1/worker/orchestrator/tasks/pending', async 
     //   - claimed_by IS NULL (unclaimed)
     //   - OR claimed_by = worker_id (requesting worker's own claimed task)
     //   - OR claim_expires_at < now (expired claim)
-    const claimableTasks = (queryResult.data || [])
+    const claimableRows = (queryResult.data || [])
       .filter(task => {
         // is_terminal must be false or null
         if (task.is_terminal === true) return false;
@@ -1047,22 +1221,9 @@ workerOrchestratorRouter.get('/api/v1/worker/orchestrator/tasks/pending', async 
 
         return isUnclaimed || isClaimedByWorker || isExpired;
       })
-      .slice(0, limit)
-      .map(task => ({
-        vtid: task.vtid,
-        title: task.title,
-        summary: task.summary,
-        status: task.status,
-        spec_status: task.spec_status,
-        is_terminal: task.is_terminal || false,
-        layer: task.layer,
-        module: task.module,
-        created_at: task.created_at,
-        updated_at: task.updated_at,
-        claimed_by: task.claimed_by || null,
-        claim_expires_at: task.claim_expires_at || null,
-        claim_started_at: task.claim_started_at || null,
-      }));
+      .slice(0, limit);
+
+    const claimableTasks = await Promise.all(claimableRows.map(hydratePendingTask));
 
     // Telemetry only — no OASIS event (polling ≠ progress)
     console.log(`${LOG_VTID} Pending tasks query: ${claimableTasks.length} eligible tasks found (worker_id=${workerId || 'none'})`);

--- a/services/gateway/test/dev-autopilot-self-healing-readiness.test.ts
+++ b/services/gateway/test/dev-autopilot-self-healing-readiness.test.ts
@@ -1,0 +1,41 @@
+import { buildSelfHealingAutonomyReadiness } from '../src/routes/dev-autopilot';
+
+describe('dev autopilot self-healing autonomy readiness', () => {
+  it('exposes completed reliability gates and the next blocked step toward full autonomy', () => {
+    const readiness = buildSelfHealingAutonomyReadiness();
+
+    expect(readiness.summary).toMatchObject({
+      ready_gates: 2,
+      total_gates: 8,
+      autonomy_percent: 25,
+      next_gate: {
+        id: 'patch_artifacts',
+        status: 'blocked',
+      },
+    });
+
+    expect(readiness.gates).toEqual(expect.arrayContaining([
+      expect.objectContaining({
+        id: 'spec_hydration',
+        status: 'ready',
+        evidence: expect.arrayContaining([
+          'pending tasks include spec_content from vtid_specs',
+          'self-healing workers fail closed without hydrated specs',
+        ]),
+      }),
+      expect.objectContaining({
+        id: 'completion_evidence',
+        status: 'ready',
+        evidence: expect.arrayContaining([
+          'worker-runner removed unconditional skip_verification',
+          'gateway rejects self-healing success without repair evidence',
+        ]),
+      }),
+      expect.objectContaining({
+        id: 'patch_artifacts',
+        status: 'blocked',
+        next_step: expect.stringContaining('patch-workspace-service'),
+      }),
+    ]));
+  });
+});

--- a/services/gateway/test/self-healing-pending-task-hydration.test.ts
+++ b/services/gateway/test/self-healing-pending-task-hydration.test.ts
@@ -1,0 +1,256 @@
+import express from 'express';
+import request from 'supertest';
+import { workerOrchestratorRouter } from '../src/routes/worker-orchestrator';
+import { computeSpecChecksum, VtidSpecContent } from '../src/services/vtid-spec-service';
+
+const app = express();
+app.use(express.json());
+app.use(workerOrchestratorRouter);
+
+function mockJsonResponse(data: unknown, status = 200) {
+  return Promise.resolve({
+    ok: status >= 200 && status < 300,
+    status,
+    statusText: status >= 200 && status < 300 ? 'OK' : 'Error',
+    headers: new Headers(),
+    json: async () => data,
+    text: async () => JSON.stringify(data),
+    blob: async () => new Blob(),
+    arrayBuffer: async () => new ArrayBuffer(0),
+    formData: async () => new FormData(),
+  } as Response);
+}
+
+describe('self-healing pending task hydration', () => {
+  const fetchMock = global.fetch as jest.Mock;
+
+  it('hydrates self-healing tasks with spec content, metadata, domain, target paths, and spec hash', async () => {
+    const specContent: VtidSpecContent = {
+      vtid: 'VTID-09001',
+      title: 'Repair ORB health endpoint',
+      spec_text: 'Patch the ORB health route and run the endpoint smoke test.',
+      task_domain: 'backend',
+      target_paths: ['services/gateway/src/routes/orb-live.ts'],
+      acceptance_criteria: ['Health endpoint returns 200'],
+      snapshot_created_at: '2026-05-11T00:00:00.000Z',
+    };
+    const specChecksum = computeSpecChecksum(specContent);
+
+    fetchMock.mockImplementation((url: string | Request) => {
+      const urlString = typeof url === 'string' ? url : url.url;
+
+      if (urlString.includes('/rest/v1/vtid_ledger?')) {
+        return mockJsonResponse([
+          {
+            vtid: 'VTID-09001',
+            title: 'SELF-HEAL: ORB health endpoint',
+            summary: 'Legacy summary should not replace canonical spec text',
+            status: 'scheduled',
+            spec_status: 'approved',
+            layer: 'INFRA',
+            module: 'GATEWAY',
+            metadata: {
+              source: 'self-healing',
+              endpoint: '/api/v1/orb/health',
+              failure_class: 'endpoint_health',
+              files_to_modify: ['fallback/path.ts'],
+              spec_hash: 'legacy-hash',
+            },
+            created_at: '2026-05-11T00:00:00.000Z',
+            updated_at: '2026-05-11T00:01:00.000Z',
+            claimed_by: null,
+            claim_expires_at: null,
+            claim_started_at: null,
+            is_terminal: false,
+          },
+        ]);
+      }
+
+      if (urlString.includes('/rest/v1/vtid_specs?vtid=eq.VTID-09001')) {
+        return mockJsonResponse([
+          {
+            vtid: 'VTID-09001',
+            tenant_id: 'default',
+            spec_version: 1,
+            spec_content: specContent,
+            spec_checksum: specChecksum,
+            primary_domain: 'backend',
+            system_surface: ['gateway'],
+            created_at: '2026-05-11T00:00:00.000Z',
+            locked_at: '2026-05-11T00:00:00.000Z',
+            created_by: 'self-healing',
+            metadata: { source: 'self-healing' },
+          },
+        ]);
+      }
+
+      if (urlString.includes('/rest/v1/oasis_events')) {
+        return mockJsonResponse([]);
+      }
+
+      return mockJsonResponse([]);
+    });
+
+    const response = await request(app)
+      .get('/api/v1/worker/orchestrator/tasks/pending')
+      .query({ worker_id: 'worker-runner-1', limit: 1 })
+      .expect(200);
+
+    expect(response.body.ok).toBe(true);
+    expect(response.body.count).toBe(1);
+    expect(response.body.tasks[0]).toMatchObject({
+      vtid: 'VTID-09001',
+      title: 'SELF-HEAL: ORB health endpoint',
+      spec_content: 'Patch the ORB health route and run the endpoint smoke test.',
+      task_domain: 'backend',
+      target_paths: ['services/gateway/src/routes/orb-live.ts'],
+      spec_hash: specChecksum,
+      metadata: {
+        source: 'self-healing',
+        endpoint: '/api/v1/orb/health',
+        failure_class: 'endpoint_health',
+      },
+    });
+  });
+
+  it('hydrates self-healing tasks from legacy markdown specs when canonical spec content is unavailable', async () => {
+    const specMarkdown = '# Legacy self-healing spec\n\nPatch the availability route and verify health.';
+
+    fetchMock.mockImplementation((url: string | Request) => {
+      const urlString = typeof url === 'string' ? url : url.url;
+
+      if (urlString.includes('/rest/v1/vtid_ledger?')) {
+        return mockJsonResponse([
+          {
+            vtid: 'VTID-09003',
+            title: 'SELF-HEAL: availability health',
+            summary: 'Legacy summary',
+            status: 'scheduled',
+            spec_status: 'approved',
+            layer: 'INFRA',
+            module: 'GATEWAY',
+            metadata: {
+              source: 'self-healing',
+              endpoint: '/api/v1/availability/health',
+              failure_class: 'import_error',
+              files_to_modify: ['services/gateway/src/routes/availability-readiness.ts'],
+              spec_hash: 'metadata-hash',
+            },
+            created_at: '2026-05-11T00:00:00.000Z',
+            updated_at: '2026-05-11T00:01:00.000Z',
+            claimed_by: null,
+            claim_expires_at: null,
+            claim_started_at: null,
+            is_terminal: false,
+          },
+        ]);
+      }
+
+      if (
+        urlString.includes('/rest/v1/vtid_specs?vtid=eq.VTID-09003') &&
+        urlString.includes('select=vtid,title,spec_markdown')
+      ) {
+        return mockJsonResponse([
+          {
+            vtid: 'VTID-09003',
+            title: 'SELF-HEAL: VTID-09003',
+            spec_markdown: specMarkdown,
+            spec_hash: 'legacy-hash',
+            status: 'validated',
+            created_by: 'self-healing',
+            created_at: '2026-05-11T00:00:00.000Z',
+          },
+        ]);
+      }
+
+      if (urlString.includes('/rest/v1/vtid_specs?vtid=eq.VTID-09003')) {
+        return mockJsonResponse([]);
+      }
+
+      if (urlString.includes('/rest/v1/oasis_events')) {
+        return mockJsonResponse([]);
+      }
+
+      return mockJsonResponse([]);
+    });
+
+    const response = await request(app)
+      .get('/api/v1/worker/orchestrator/tasks/pending')
+      .query({ worker_id: 'worker-runner-1', limit: 1 })
+      .expect(200);
+
+    expect(response.body.tasks[0]).toMatchObject({
+      vtid: 'VTID-09003',
+      spec_content: specMarkdown,
+      task_domain: 'backend',
+      target_paths: ['services/gateway/src/routes/availability-readiness.ts'],
+      spec_hash: 'legacy-hash',
+    });
+  });
+
+  it('rejects self-healing success without repair evidence at gateway completion gates', async () => {
+    fetchMock.mockImplementation((url: string | Request) => {
+      const urlString = typeof url === 'string' ? url : url.url;
+
+      if (urlString.includes('/rest/v1/vtid_ledger?vtid=eq.VTID-09002')) {
+        return mockJsonResponse([
+          {
+            vtid: 'VTID-09002',
+            metadata: {
+              source: 'self-healing',
+              endpoint: '/api/v1/orb/health',
+            },
+          },
+        ]);
+      }
+
+      if (urlString.includes('/rest/v1/oasis_events')) {
+        return mockJsonResponse([]);
+      }
+
+      return mockJsonResponse([]);
+    });
+
+    const subagentResponse = await request(app)
+      .post('/api/v1/worker/subagent/complete')
+      .send({
+        vtid: 'VTID-09002',
+        domain: 'backend',
+        run_id: 'run_missing_evidence',
+        result: {
+          ok: true,
+          files_changed: [],
+          files_created: [],
+          summary: 'Claimed fixed without patch evidence',
+        },
+      })
+      .expect(400);
+
+    expect(subagentResponse.body).toMatchObject({
+      ok: false,
+      reason: 'missing_repair_evidence',
+      error: 'self-healing completion requires repair evidence',
+    });
+
+    const orchestratorResponse = await request(app)
+      .post('/api/v1/worker/orchestrator/complete')
+      .send({
+        vtid: 'VTID-09002',
+        run_id: 'run_missing_evidence',
+        domain: 'backend',
+        success: true,
+        summary: 'Claimed fixed without patch evidence',
+        result: {
+          files_changed: [],
+          files_created: [],
+        },
+      })
+      .expect(400);
+
+    expect(orchestratorResponse.body).toMatchObject({
+      ok: false,
+      reason: 'missing_repair_evidence',
+      error: 'self-healing completion requires repair evidence',
+    });
+  });
+});

--- a/services/worker-runner/.env.example
+++ b/services/worker-runner/.env.example
@@ -23,6 +23,13 @@ GOOGLE_CLOUD_PROJECT=lovable-vitana-vers1
 VERTEX_LOCATION=us-central1
 VERTEX_MODEL=gemini-3.1-pro-preview
 
+# Optional: worker execution LLMs
+ANTHROPIC_API_KEY=xxxx
+DEEPSEEK_API_KEY=xxxx
+WORKER_LLM_MODEL=claude-opus-4-6
+WORKER_FALLBACK_MODEL=deepseek-reasoner
+WORKER_DEEPSEEK_FALLBACK=true
+
 # Optional: Logging
 LOG_LEVEL=info
 

--- a/services/worker-runner/manifest.json
+++ b/services/worker-runner/manifest.json
@@ -33,7 +33,12 @@
       "AUTOPILOT_LOOP_ENABLED",
       "GOOGLE_CLOUD_PROJECT",
       "VERTEX_LOCATION",
-      "VERTEX_MODEL"
+      "VERTEX_MODEL",
+      "ANTHROPIC_API_KEY",
+      "DEEPSEEK_API_KEY",
+      "WORKER_LLM_MODEL",
+      "WORKER_FALLBACK_MODEL",
+      "WORKER_DEEPSEEK_FALLBACK"
     ]
   },
   "resources": {

--- a/services/worker-runner/src/services/gateway-client.ts
+++ b/services/worker-runner/src/services/gateway-client.ts
@@ -177,7 +177,8 @@ export async function routeTask(
   vtid: string,
   title: string,
   domain?: TaskDomain,
-  specContent?: string
+  specContent?: string,
+  targetPaths?: string[]
 ): Promise<RoutingResult> {
   console.log(`[${VTID}] Routing task: ${vtid}`);
 
@@ -191,6 +192,7 @@ export async function routeTask(
         title,
         task_domain: domain,
         spec_content: specContent,
+        target_paths: targetPaths,
         worker_id: config.workerId,
       }),
     }
@@ -262,7 +264,6 @@ export async function reportSubagentComplete(
         vtid,
         domain,
         run_id: runId,
-        skip_verification: true, // For worker-runner, we trust the LLM result
         result: {
           ok: result.ok,
           files_changed: result.files_changed || [],
@@ -309,11 +310,13 @@ export async function reportOrchestratorComplete(
         success,
         summary: summary || (success ? 'Task completed successfully' : 'Task failed'),
         error,
-        skip_verification: true, // For worker-runner, we trust the LLM result
         result: result
           ? {
+              ok: result.ok,
               files_changed: result.files_changed || [],
               files_created: result.files_created || [],
+              summary: result.summary,
+              error: result.error,
             }
           : undefined,
       }),

--- a/services/worker-runner/src/services/runner-service.test.ts
+++ b/services/worker-runner/src/services/runner-service.test.ts
@@ -65,7 +65,17 @@ jest.mock('./event-emitter', () => ({
 }));
 
 import { WorkerRunner } from './runner-service';
-import { registerWorker, pollPendingTasks, claimTask } from './gateway-client';
+import {
+  registerWorker,
+  pollPendingTasks,
+  claimTask,
+  routeTask,
+  reportSubagentComplete,
+  reportOrchestratorComplete,
+  releaseTask,
+  terminalizeTask,
+} from './gateway-client';
+import { executeTask } from './execution-service';
 import { runnerEvents } from './event-emitter';
 
 describe('WorkerRunner', () => {
@@ -229,6 +239,202 @@ describe('WorkerRunner', () => {
 
       // Should have claimed the eligible task
       expect(claimTask).toHaveBeenCalledWith(testConfig, 'VTID-01001');
+
+      await runner.stop();
+    });
+  });
+
+  describe('self-healing completion gates', () => {
+    const selfHealingTask = {
+      vtid: 'VTID-02001',
+      title: 'SELF-HEAL: repair ORB health endpoint',
+      status: 'scheduled',
+      spec_status: 'approved',
+      is_terminal: false,
+      claimed_by: null,
+      created_at: new Date().toISOString(),
+      updated_at: new Date().toISOString(),
+      metadata: { source: 'self-healing', endpoint: '/api/v1/orb/health' },
+      task_domain: 'backend' as const,
+      target_paths: ['services/gateway/src/routes/orb-live.ts'],
+    };
+
+    it('fails closed when a self-healing task has no hydrated spec content', async () => {
+      (pollPendingTasks as jest.Mock).mockResolvedValueOnce({
+        tasks: [selfHealingTask],
+        count: 1,
+      });
+
+      const runner = new WorkerRunner(testConfig);
+      await runner.start();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(executeTask).not.toHaveBeenCalled();
+      expect(reportSubagentComplete).toHaveBeenCalledWith(
+        testConfig,
+        'VTID-02001',
+        'backend',
+        expect.any(String),
+        expect.objectContaining({
+          ok: false,
+          error: expect.stringContaining('no hydrated spec_content'),
+        }),
+      );
+      expect(terminalizeTask).toHaveBeenCalledWith(
+        testConfig,
+        'VTID-02001',
+        'failed',
+        expect.any(String),
+      );
+      expect(terminalizeTask).not.toHaveBeenCalledWith(
+        testConfig,
+        'VTID-02001',
+        'success',
+        expect.any(String),
+      );
+      expect(releaseTask).toHaveBeenCalledWith(testConfig, 'VTID-02001', 'failed');
+
+      await runner.stop();
+    });
+
+    it('does not terminalize success when gateway verification rejects completion', async () => {
+      (pollPendingTasks as jest.Mock).mockResolvedValueOnce({
+        tasks: [{ ...selfHealingTask, spec_content: 'Fix the ORB health route and run tests.' }],
+        count: 1,
+      });
+      (executeTask as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        files_changed: ['services/gateway/src/routes/orb-live.ts'],
+        files_created: [],
+        summary: 'Patched ORB health route and verified health check.',
+        duration_ms: 1000,
+        model: 'test-model',
+        provider: 'test-provider',
+      });
+      (reportSubagentComplete as jest.Mock).mockResolvedValueOnce({
+        ok: false,
+        reason: 'skip_verification not allowed',
+      });
+      (reportOrchestratorComplete as jest.Mock).mockResolvedValueOnce({ ok: true });
+
+      const runner = new WorkerRunner(testConfig);
+      await runner.start();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(reportSubagentComplete).toHaveBeenCalledWith(
+        testConfig,
+        'VTID-02001',
+        'backend',
+        'run_test123',
+        expect.objectContaining({
+          ok: true,
+          files_changed: ['services/gateway/src/routes/orb-live.ts'],
+        }),
+      );
+      expect(reportOrchestratorComplete).toHaveBeenCalledWith(
+        testConfig,
+        'VTID-02001',
+        'run_test123',
+        'backend',
+        false,
+        expect.stringContaining('completion rejected'),
+        expect.stringContaining('skip_verification not allowed'),
+        expect.objectContaining({
+          ok: false,
+        }),
+      );
+      expect(terminalizeTask).toHaveBeenCalledWith(
+        testConfig,
+        'VTID-02001',
+        'failed',
+        'run_test123',
+      );
+      expect(terminalizeTask).not.toHaveBeenCalledWith(
+        testConfig,
+        'VTID-02001',
+        'success',
+        'run_test123',
+      );
+      expect(releaseTask).toHaveBeenCalledWith(testConfig, 'VTID-02001', 'failed');
+
+      await runner.stop();
+    });
+
+    it('runs a synthetic self-healing task through the local success path with repair evidence', async () => {
+      (pollPendingTasks as jest.Mock).mockResolvedValueOnce({
+        tasks: [{ ...selfHealingTask, spec_content: 'Fix the ORB health route and run tests.' }],
+        count: 1,
+      });
+      (executeTask as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        files_changed: ['services/gateway/src/routes/orb-live.ts'],
+        files_created: [],
+        summary: 'Patched ORB health route and verified health check.',
+        duration_ms: 1000,
+        model: 'test-model',
+        provider: 'test-provider',
+      });
+      (reportSubagentComplete as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        verified: true,
+      });
+      (reportOrchestratorComplete as jest.Mock).mockResolvedValueOnce({
+        ok: true,
+        verified: true,
+      });
+
+      const runner = new WorkerRunner(testConfig);
+      await runner.start();
+      await new Promise((resolve) => setTimeout(resolve, 100));
+
+      expect(executeTask).toHaveBeenCalledWith(
+        testConfig,
+        expect.objectContaining({
+          vtid: 'VTID-02001',
+          spec_content: 'Fix the ORB health route and run tests.',
+        }),
+        expect.objectContaining({ ok: true }),
+        'backend',
+      );
+      expect(routeTask).toHaveBeenCalledWith(
+        testConfig,
+        'VTID-02001',
+        'SELF-HEAL: repair ORB health endpoint',
+        'backend',
+        'Fix the ORB health route and run tests.',
+        ['services/gateway/src/routes/orb-live.ts'],
+      );
+      expect(reportSubagentComplete).toHaveBeenCalledWith(
+        testConfig,
+        'VTID-02001',
+        'backend',
+        'run_test123',
+        expect.objectContaining({
+          ok: true,
+          files_changed: ['services/gateway/src/routes/orb-live.ts'],
+          summary: 'Patched ORB health route and verified health check.',
+        }),
+      );
+      expect(reportOrchestratorComplete).toHaveBeenCalledWith(
+        testConfig,
+        'VTID-02001',
+        'run_test123',
+        'backend',
+        true,
+        'Patched ORB health route and verified health check.',
+        undefined,
+        expect.objectContaining({
+          ok: true,
+          files_changed: ['services/gateway/src/routes/orb-live.ts'],
+        }),
+      );
+      expect(terminalizeTask).toHaveBeenCalledWith(
+        testConfig,
+        'VTID-02001',
+        'success',
+        'run_test123',
+      );
+      expect(releaseTask).toHaveBeenCalledWith(testConfig, 'VTID-02001', 'completed');
 
       await runner.stop();
     });

--- a/services/worker-runner/src/services/runner-service.ts
+++ b/services/worker-runner/src/services/runner-service.ts
@@ -41,6 +41,14 @@ const VTID = 'VTID-01200';
 const HEARTBEAT_INTERVAL_MS = 30000; // 30 seconds
 const MAX_CLAIM_RETRIES = 3;
 
+function isSelfHealingTask(task: PendingTask): boolean {
+  return task.metadata?.source === 'self-healing';
+}
+
+function hasRepairEvidence(result: ExecutionResult): boolean {
+  return (result.files_changed?.length || 0) + (result.files_created?.length || 0) > 0;
+}
+
 /**
  * Worker Runner Service
  */
@@ -254,6 +262,10 @@ export class WorkerRunner {
     let executionResult: ExecutionResult = { ok: false, error: 'Not executed', duration_ms: 0 };
 
     try {
+      if (isSelfHealingTask(task) && !task.spec_content?.trim()) {
+        throw new Error(`Self-healing task ${vtid} has no hydrated spec_content`);
+      }
+
       // Step 2: Route through governance
       this.metrics.state = 'executing';
       const routingResult = await routeTask(
@@ -261,7 +273,8 @@ export class WorkerRunner {
         vtid,
         task.title,
         task.task_domain,
-        task.spec_content
+        task.spec_content,
+        task.target_paths
       );
 
       if (!routingResult.ok) {
@@ -269,7 +282,7 @@ export class WorkerRunner {
         await runnerEvents.error(this.config, `Routing failed: ${routingResult.error}`, vtid);
 
         // Mark as failed
-        await this.completeTask(vtid, runId, domain, false, routingResult.error);
+        executionSuccess = await this.completeTask(vtid, runId, domain, false, routingResult.error);
         return;
       }
 
@@ -334,6 +347,9 @@ export class WorkerRunner {
         if (!anyStageSucceeded) {
           executionResult = { ok: false, error: lastError || 'All stages failed', duration_ms: 0 };
         }
+
+        executionResult = this.applySelfHealingEvidenceGate(task, executionResult);
+        executionSuccess = executionResult.ok;
       } else {
         // Single domain: original behavior
         domain = (routingResult.dispatched_to?.replace('worker-', '') || 'backend') as TaskDomain;
@@ -375,11 +391,12 @@ export class WorkerRunner {
           executionResult.summary
         );
 
+        executionResult = this.applySelfHealingEvidenceGate(task, executionResult);
         executionSuccess = executionResult.ok;
       }
 
       // Step 5: Complete the task
-      await this.completeTask(
+      executionSuccess = await this.completeTask(
         vtid,
         runId,
         domain,
@@ -393,13 +410,30 @@ export class WorkerRunner {
       await runnerEvents.error(this.config, `Processing error: ${errorMessage}`, vtid);
 
       // Attempt to complete as failed
-      await this.completeTask(vtid, runId, domain, false, errorMessage);
+      executionSuccess = await this.completeTask(vtid, runId, domain, false, errorMessage);
     } finally {
       // Always release claim and cleanup
       await releaseTask(this.config, vtid, executionSuccess ? 'completed' : 'failed');
       this.activeVtid = null;
       this.metrics.state = 'idle';
     }
+  }
+
+  private applySelfHealingEvidenceGate(task: PendingTask, result: ExecutionResult): ExecutionResult {
+    if (!isSelfHealingTask(task) || !result.ok) {
+      return result;
+    }
+
+    if (hasRepairEvidence(result)) {
+      return result;
+    }
+
+    return {
+      ...result,
+      ok: false,
+      error: `Self-healing task ${task.vtid} reported success without repair evidence`,
+      summary: result.summary || 'Self-healing success rejected: no files changed or created',
+    };
   }
 
   /**
@@ -439,34 +473,59 @@ export class WorkerRunner {
     domain: TaskDomain,
     success: boolean,
     error?: string,
-    result?: { ok: boolean; files_changed?: string[]; files_created?: string[]; summary?: string }
-  ): Promise<void> {
+    result?: { ok: boolean; files_changed?: string[]; files_created?: string[]; summary?: string; error?: string }
+  ): Promise<boolean> {
     this.metrics.state = 'completing';
 
     try {
-      // Report subagent completion
-      await reportSubagentComplete(this.config, vtid, domain, runId, {
+      let finalSuccess = success;
+      let finalError = error;
+      const completionPayload: ExecutionResult = {
         ok: success,
         files_changed: result?.files_changed || [],
         files_created: result?.files_created || [],
         summary: result?.summary || (success ? 'Task completed' : error),
         error: success ? undefined : error,
-      });
+      };
+
+      // Report subagent completion
+      const subagentCompletion = await reportSubagentComplete(this.config, vtid, domain, runId, completionPayload);
+
+      if (!subagentCompletion.ok) {
+        finalSuccess = false;
+        finalError = `Subagent completion rejected: ${subagentCompletion.reason || 'unknown reason'}`;
+        await runnerEvents.error(this.config, finalError, vtid);
+      }
+
+      const orchestratorPayload: ExecutionResult = finalSuccess
+        ? completionPayload
+        : {
+            ...completionPayload,
+            ok: false,
+            summary: 'Worker completion rejected by verification',
+            error: finalError,
+          };
 
       // Report orchestrator completion
-      await reportOrchestratorComplete(
+      const orchestratorCompletion = await reportOrchestratorComplete(
         this.config,
         vtid,
         runId,
         domain,
-        success,
-        result?.summary,
-        error,
-        result as any
+        finalSuccess,
+        finalSuccess ? result?.summary : 'Worker completion rejected by verification',
+        finalSuccess ? error : finalError,
+        orchestratorPayload
       );
 
+      if (!orchestratorCompletion.ok) {
+        finalSuccess = false;
+        finalError = `Orchestrator completion rejected: ${orchestratorCompletion.reason || 'unknown reason'}`;
+        await runnerEvents.error(this.config, finalError, vtid);
+      }
+
       // Update metrics
-      if (success) {
+      if (finalSuccess) {
         this.metrics.tasks_completed++;
       } else {
         this.metrics.tasks_failed++;
@@ -474,23 +533,27 @@ export class WorkerRunner {
 
       // Step 6: Terminalize the VTID
       this.metrics.state = 'terminalizing';
-      const outcome: TerminalOutcome = success ? 'success' : 'failed';
+      const outcome: TerminalOutcome = finalSuccess ? 'success' : 'failed';
       const termResult = await terminalizeTask(this.config, vtid, outcome, runId);
 
       if (termResult.ok) {
         await runnerEvents.terminalized(this.config, vtid, outcome, runId);
         console.log(`[${VTID}] Task ${vtid} terminalized: ${outcome}`);
+        return finalSuccess;
       } else if (!termResult.already_terminal) {
         console.error(`[${VTID}] Failed to terminalize ${vtid}: ${termResult.error}`);
         await runnerEvents.error(this.config, `Terminalization failed: ${termResult.error}`, vtid);
       } else {
         console.log(`[${VTID}] Task ${vtid} already terminal (idempotent)`);
+        return finalSuccess;
       }
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       console.error(`[${VTID}] Completion error for ${vtid}: ${errorMessage}`);
       await runnerEvents.error(this.config, `Completion error: ${errorMessage}`, vtid);
     }
+
+    return false;
   }
 
   /**

--- a/services/worker-runner/src/types.ts
+++ b/services/worker-runner/src/types.ts
@@ -31,10 +31,13 @@ export type RunnerState = 'idle' | 'polling' | 'claiming' | 'executing' | 'compl
 export interface PendingTask {
   vtid: string;
   title: string;
+  summary?: string;
   status: string;
   spec_status: string;
   spec_content?: string;
   task_domain?: TaskDomain;
+  target_paths?: string[];
+  spec_hash?: string;
   created_at: string;
   updated_at: string;
   is_terminal: boolean;
@@ -42,6 +45,8 @@ export interface PendingTask {
   claim_expires_at?: string | null;
   claim_started_at?: string | null;
   metadata?: Record<string, unknown>;
+  layer?: string;
+  module?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
- Hydrate worker pending tasks with self-healing spec content, including legacy vtid_specs spec_markdown/spec_hash rows currently used in production.
- Fail closed when self-healing workers try to run without a hydrated spec.
- Reject self-healing success without concrete repair evidence.
- Surface self-healing autonomy readiness on the Auto-Approve Command Hub screen.
- Bind DEEPSEEK_API_KEY into worker-runner deploys so fallback execution can work when Anthropic is unavailable.

## Live smoke evidence
- VTID-02904: intake/spec/injection worked; worker failed on Anthropic credit + missing DeepSeek fallback.
- VTID-02910: fallback deploy worked; worker failed closed on missing hydrated spec_content.
- VTID-02912: spec hydration worked; worker executed and attempted completion; verification rejected because claimed files do not exist in a real patch workspace.

## Verification
- Gateway focused Jest: test/self-healing-pending-task-hydration.test.ts passed.
- Gateway typecheck: node node_modules/typescript/bin/tsc --noEmit passed.
- Earlier in this branch: worker runner tests and typecheck passed before the deploy-config patch.

## Remaining blocker
The self-healing loop is still not truly autonomous: worker-runner only produces claimed file changes, but there is no patch workspace that actually edits repo files, runs tests, opens a PR, deploys, and verifies production health.