### PR TITLE
feat(orb): B0d.2 - Voice Wake Brief provider (VTID-02915)

### DIFF
--- a/services/gateway/src/services/assistant-continuation/providers/voice-wake-brief.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/voice-wake-brief.ts
@@ -1,0 +1,237 @@
+/**
+ * VTID-02915 (B0d.2) — Voice Wake Brief continuation provider.
+ *
+ * The first real provider in the Central Continuation Contract framework
+ * (B0d.1). Produces the backend-owned first spoken line after ORB
+ * activation — the replacement for the passive
+ * `vitana-v1/src/lib/instantGreeting.ts` ("I'm here, I'm listening").
+ *
+ * Scope (B0d.2):
+ *   - Pure provider file. NO orb-live.ts wiring (that lands in B0d.4).
+ *   - NO module-load side-effects: the factory is exported and tests
+ *     register fakes; production wiring registers the provider explicitly.
+ *   - Inputs flow through `ContinuationDecisionContext.extra.voiceWakeBrief`.
+ *     The orchestrator caller (B0d.4) computes `greetingPolicy` via the
+ *     existing A4 `decideGreetingPolicy()` and forwards it.
+ *
+ * Behavior:
+ *   - `greetingPolicy === 'skip'` → `status: 'suppressed'` with reason
+ *     `greeting_policy_skip`. The orb stays silent; this is the
+ *     transparent-reconnect path (VTID-02637 lesson).
+ *   - Other policies → returned `wake_brief` candidate with a rendered
+ *     line. The renderer is injectable so future slices can grow it
+ *     without reshaping the provider.
+ *   - Missing inputs → `status: 'skipped'` with reason
+ *     `no_voice_wake_brief_inputs`. The orchestrator records this so the
+ *     B0d.3 reliability timeline can see "wake-brief was not even
+ *     consulted because the upstream caller did not pass inputs".
+ *
+ * Priority: 80. High enough to beat generic feature-discovery on the
+ * wake surface, low enough that a future urgent-reminder provider
+ * (priority 95+) can win when relevant. The plan documents this
+ * priority order; we don't bake a global priority registry here yet.
+ */
+
+import { randomUUID } from 'crypto';
+import type {
+  AssistantContinuation,
+  ContinuationProvider,
+  ContinuationDecisionContext,
+  ProviderResult,
+} from '../types';
+import type { GreetingPolicy } from '../../../orb/live/instruction/greeting-policy';
+
+// ---------------------------------------------------------------------------
+// Inputs the orchestrator caller forwards via ctx.extra.voiceWakeBrief
+// ---------------------------------------------------------------------------
+
+/**
+ * Inputs the provider consumes. The orchestrator caller (B0d.4) attaches
+ * an object of this shape to `ContinuationDecisionContext.extra` under
+ * the key `'voiceWakeBrief'`.
+ *
+ * Future slices may extend this with:
+ *   - vitanaId        (for "@alex3700, welcome back" personalization)
+ *   - lastSessionTopic (for warm-return continuity)
+ *   - reminderDueIn   (when an imminent reminder should color the brief)
+ *
+ * The shape is intentionally minimal in B0d.2 to keep the slice tight.
+ */
+export interface VoiceWakeBriefInputs {
+  /** From A4's `decideGreetingPolicy()`. The provider gates on this. */
+  greetingPolicy: GreetingPolicy;
+  /** ISO 639-1 language code. Defaults to `'en'` when absent. */
+  lang?: string;
+}
+
+export const VOICE_WAKE_BRIEF_EXTRA_KEY = 'voiceWakeBrief' as const;
+
+// ---------------------------------------------------------------------------
+// Renderer — pure function, injectable for tests
+// ---------------------------------------------------------------------------
+
+export interface VoiceWakeBriefRenderer {
+  render(inputs: VoiceWakeBriefInputs, ctx: ContinuationDecisionContext): string;
+}
+
+const DEFAULT_LINES: Record<GreetingPolicy, Record<string, string>> = {
+  // Suppressed at provider boundary; never reaches the renderer.
+  skip: { en: '', de: '' },
+  brief_resume: {
+    en: 'Back already? What did you want to follow up on?',
+    de: 'Schon zurück? Worauf wolltest du zurückkommen?',
+  },
+  warm_return: {
+    en: 'Welcome back. What is on your mind?',
+    de: 'Schön, dass du wieder da bist. Was steht an?',
+  },
+  fresh_intro: {
+    en: 'Hello! How can I help today?',
+    de: 'Hallo! Wie kann ich heute helfen?',
+  },
+};
+
+export const defaultVoiceWakeBriefRenderer: VoiceWakeBriefRenderer = {
+  render(inputs) {
+    const lang = inputs.lang && inputs.lang.length > 0 ? inputs.lang : 'en';
+    const byLang = DEFAULT_LINES[inputs.greetingPolicy];
+    return byLang[lang] ?? byLang.en ?? '';
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export interface VoiceWakeBriefProviderOptions {
+  /** Replace the default renderer (used by tests + future signal-driven slices). */
+  renderer?: VoiceWakeBriefRenderer;
+  /** Injected for deterministic ids in tests. */
+  newId?: () => string;
+  /** Injected for deterministic latencies in tests. */
+  now?: () => number;
+  /** Override the default priority (80). Future slices may tune. */
+  priority?: number;
+}
+
+export const VOICE_WAKE_BRIEF_PROVIDER_KEY = 'voice_wake_brief' as const;
+const DEFAULT_PRIORITY = 80;
+
+/**
+ * Build a Voice Wake Brief provider. Exported as a factory (not a
+ * pre-built singleton) so production wiring can pass real dependencies
+ * and tests can pass fakes.
+ */
+export function makeVoiceWakeBriefProvider(
+  opts: VoiceWakeBriefProviderOptions = {},
+): ContinuationProvider {
+  const renderer = opts.renderer ?? defaultVoiceWakeBriefRenderer;
+  const newId = opts.newId ?? randomUUID;
+  const now = opts.now ?? (() => Date.now());
+  const priority = opts.priority ?? DEFAULT_PRIORITY;
+
+  return {
+    key: VOICE_WAKE_BRIEF_PROVIDER_KEY,
+    surfaces: ['orb_wake'],
+    produce(ctx: ContinuationDecisionContext): ProviderResult {
+      const t0 = now();
+
+      const inputs = readInputs(ctx);
+      if (!inputs) {
+        return {
+          providerKey: VOICE_WAKE_BRIEF_PROVIDER_KEY,
+          status: 'skipped',
+          latencyMs: Math.max(0, now() - t0),
+          reason: 'no_voice_wake_brief_inputs',
+        };
+      }
+
+      if (inputs.greetingPolicy === 'skip') {
+        return {
+          providerKey: VOICE_WAKE_BRIEF_PROVIDER_KEY,
+          status: 'suppressed',
+          latencyMs: Math.max(0, now() - t0),
+          reason: 'greeting_policy_skip',
+        };
+      }
+
+      let line: string;
+      try {
+        line = renderer.render(inputs, ctx);
+      } catch (err) {
+        return {
+          providerKey: VOICE_WAKE_BRIEF_PROVIDER_KEY,
+          status: 'errored',
+          latencyMs: Math.max(0, now() - t0),
+          reason: err instanceof Error ? err.message : String(err),
+        };
+      }
+
+      if (typeof line !== 'string' || line.trim().length === 0) {
+        return {
+          providerKey: VOICE_WAKE_BRIEF_PROVIDER_KEY,
+          status: 'errored',
+          latencyMs: Math.max(0, now() - t0),
+          reason: 'renderer_produced_empty_line',
+        };
+      }
+
+      const candidate: AssistantContinuation = {
+        id: `wake-brief-${newId()}`,
+        surface: 'orb_wake',
+        kind: 'wake_brief',
+        priority,
+        userFacingLine: line,
+        cta: { type: 'explain' },
+        evidence: [
+          {
+            kind: 'greeting_policy',
+            detail: inputs.greetingPolicy,
+          },
+        ],
+        dedupeKey: `wake-brief-${inputs.greetingPolicy}`,
+        privacyMode: 'safe_to_speak',
+      };
+
+      return {
+        providerKey: VOICE_WAKE_BRIEF_PROVIDER_KEY,
+        status: 'returned',
+        latencyMs: Math.max(0, now() - t0),
+        candidate,
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+/**
+ * Pull `VoiceWakeBriefInputs` out of `ContinuationDecisionContext.extra`.
+ * Defensive — tolerates `extra` being absent or shaped wrong. Returns
+ * `null` when the inputs are missing or unusable; the caller turns that
+ * into a `status: 'skipped'` result.
+ */
+function readInputs(
+  ctx: ContinuationDecisionContext,
+): VoiceWakeBriefInputs | null {
+  const extra = ctx.extra;
+  if (!extra || typeof extra !== 'object') return null;
+  const raw = (extra as Record<string, unknown>)[VOICE_WAKE_BRIEF_EXTRA_KEY];
+  if (!raw || typeof raw !== 'object') return null;
+  const obj = raw as Record<string, unknown>;
+  const policy = obj.greetingPolicy;
+  if (
+    policy !== 'skip' &&
+    policy !== 'brief_resume' &&
+    policy !== 'warm_return' &&
+    policy !== 'fresh_intro'
+  ) {
+    return null;
+  }
+  return {
+    greetingPolicy: policy,
+    lang: typeof obj.lang === 'string' ? obj.lang : undefined,
+  };
+}

--- a/services/gateway/test/services/assistant-continuation/providers/voice-wake-brief.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/voice-wake-brief.test.ts
@@ -1,0 +1,422 @@
+/**
+ * VTID-02915 (B0d.2) — Voice Wake Brief provider tests.
+ *
+ * Coverage matrix:
+ *   - Each `greetingPolicy` value:
+ *       skip          → suppressed
+ *       brief_resume  → returned (terse line)
+ *       warm_return   → returned (warm line)
+ *       fresh_intro   → returned (intro line)
+ *   - Missing inputs → skipped (with reason `no_voice_wake_brief_inputs`).
+ *   - Malformed inputs → skipped (defensive — typo'd policy, wrong types).
+ *   - Renderer that throws → errored (no exception escapes the provider).
+ *   - Renderer that returns empty/whitespace → errored.
+ *   - Language fallback: missing/unknown lang → English.
+ *   - Candidate shape is contract-conformant (id non-empty, dedupeKey
+ *     stable, evidence carries the policy, priority captured).
+ *   - End-to-end: registered with a real registry, decideContinuation
+ *     selects the candidate and the result passes the runtime validator.
+ */
+
+import {
+  makeVoiceWakeBriefProvider,
+  defaultVoiceWakeBriefRenderer,
+  VOICE_WAKE_BRIEF_PROVIDER_KEY,
+  VOICE_WAKE_BRIEF_EXTRA_KEY,
+  type VoiceWakeBriefInputs,
+  type VoiceWakeBriefRenderer,
+} from '../../../../src/services/assistant-continuation/providers/voice-wake-brief';
+import {
+  validateContinuationCandidate,
+  type ContinuationDecisionContext,
+  type ProviderResult,
+  type AssistantContinuation,
+} from '../../../../src/services/assistant-continuation/types';
+import { decideContinuation } from '../../../../src/services/assistant-continuation/decide-continuation';
+import { createProviderRegistry } from '../../../../src/services/assistant-continuation/provider-registry';
+
+function makeCtx(
+  inputs: VoiceWakeBriefInputs | undefined,
+  over: Partial<ContinuationDecisionContext> = {},
+): ContinuationDecisionContext {
+  const ctx: ContinuationDecisionContext = {
+    surface: 'orb_wake',
+    sessionId: 's1',
+    userId: 'u1',
+    tenantId: 't1',
+    ...over,
+  };
+  if (inputs !== undefined) {
+    ctx.extra = { ...(ctx.extra ?? {}), [VOICE_WAKE_BRIEF_EXTRA_KEY]: inputs };
+  }
+  return ctx;
+}
+
+function frozenNewId(prefix = 'id') {
+  let i = 0;
+  return () => `${prefix}-${++i}`;
+}
+
+function frozenNow(start = 1_700_000_000_000) {
+  let t = start;
+  return () => {
+    const v = t;
+    t += 5;
+    return v;
+  };
+}
+
+describe('B0d.2 — Voice Wake Brief provider', () => {
+  describe('greeting-policy gating', () => {
+    it('suppresses on policy="skip" with reason greeting_policy_skip', async () => {
+      const provider = makeVoiceWakeBriefProvider({
+        now: frozenNow(),
+        newId: frozenNewId(),
+      });
+      const result = (await provider.produce(
+        makeCtx({ greetingPolicy: 'skip' }),
+      )) as ProviderResult;
+      expect(result.status).toBe('suppressed');
+      expect(result.reason).toBe('greeting_policy_skip');
+      expect(result.candidate).toBeUndefined();
+    });
+
+    it.each(['brief_resume', 'warm_return', 'fresh_intro'] as const)(
+      'returns a candidate on policy="%s"',
+      async (policy) => {
+        const provider = makeVoiceWakeBriefProvider({
+          now: frozenNow(),
+          newId: frozenNewId(),
+        });
+        const result = (await provider.produce(
+          makeCtx({ greetingPolicy: policy }),
+        )) as ProviderResult;
+        expect(result.status).toBe('returned');
+        expect(result.candidate).toBeDefined();
+        expect(result.candidate?.kind).toBe('wake_brief');
+        expect(result.candidate?.userFacingLine.length).toBeGreaterThan(0);
+      },
+    );
+  });
+
+  describe('input handling', () => {
+    it('skips when ctx.extra is absent', async () => {
+      const provider = makeVoiceWakeBriefProvider({
+        now: frozenNow(),
+        newId: frozenNewId(),
+      });
+      const result = (await provider.produce({
+        surface: 'orb_wake',
+      })) as ProviderResult;
+      expect(result.status).toBe('skipped');
+      expect(result.reason).toBe('no_voice_wake_brief_inputs');
+    });
+
+    it('skips when extra.voiceWakeBrief is missing the policy', async () => {
+      const provider = makeVoiceWakeBriefProvider({
+        now: frozenNow(),
+        newId: frozenNewId(),
+      });
+      const result = (await provider.produce({
+        surface: 'orb_wake',
+        extra: { [VOICE_WAKE_BRIEF_EXTRA_KEY]: {} },
+      })) as ProviderResult;
+      expect(result.status).toBe('skipped');
+      expect(result.reason).toBe('no_voice_wake_brief_inputs');
+    });
+
+    it('skips when greetingPolicy is a bogus value', async () => {
+      const provider = makeVoiceWakeBriefProvider({
+        now: frozenNow(),
+        newId: frozenNewId(),
+      });
+      const result = (await provider.produce({
+        surface: 'orb_wake',
+        extra: { [VOICE_WAKE_BRIEF_EXTRA_KEY]: { greetingPolicy: 'made_up' } },
+      })) as ProviderResult;
+      expect(result.status).toBe('skipped');
+      expect(result.reason).toBe('no_voice_wake_brief_inputs');
+    });
+
+    it('ignores a non-string lang field', async () => {
+      const provider = makeVoiceWakeBriefProvider({
+        now: frozenNow(),
+        newId: frozenNewId(),
+      });
+      const result = (await provider.produce({
+        surface: 'orb_wake',
+        extra: {
+          [VOICE_WAKE_BRIEF_EXTRA_KEY]: {
+            greetingPolicy: 'fresh_intro',
+            lang: 42,
+          },
+        },
+      })) as ProviderResult;
+      expect(result.status).toBe('returned');
+      // English fallback when lang is unusable.
+      expect(result.candidate?.userFacingLine).toMatch(/Hello/);
+    });
+  });
+
+  describe('language selection', () => {
+    it('renders German when lang="de"', async () => {
+      const provider = makeVoiceWakeBriefProvider({
+        now: frozenNow(),
+        newId: frozenNewId(),
+      });
+      const result = (await provider.produce(
+        makeCtx({ greetingPolicy: 'fresh_intro', lang: 'de' }),
+      )) as ProviderResult;
+      expect(result.candidate?.userFacingLine).toBe('Hallo! Wie kann ich heute helfen?');
+    });
+
+    it('falls back to English for an unknown lang', async () => {
+      const provider = makeVoiceWakeBriefProvider({
+        now: frozenNow(),
+        newId: frozenNewId(),
+      });
+      const result = (await provider.produce(
+        makeCtx({ greetingPolicy: 'fresh_intro', lang: 'xx' }),
+      )) as ProviderResult;
+      expect(result.candidate?.userFacingLine).toBe('Hello! How can I help today?');
+    });
+
+    it('defaults to English when lang is absent', async () => {
+      const provider = makeVoiceWakeBriefProvider({
+        now: frozenNow(),
+        newId: frozenNewId(),
+      });
+      const result = (await provider.produce(
+        makeCtx({ greetingPolicy: 'warm_return' }),
+      )) as ProviderResult;
+      expect(result.candidate?.userFacingLine).toBe('Welcome back. What is on your mind?');
+    });
+  });
+
+  describe('renderer injection + error paths', () => {
+    it('uses the injected renderer when supplied', async () => {
+      const customRenderer: VoiceWakeBriefRenderer = {
+        render: () => 'CUSTOM LINE',
+      };
+      const provider = makeVoiceWakeBriefProvider({
+        renderer: customRenderer,
+        now: frozenNow(),
+        newId: frozenNewId(),
+      });
+      const result = (await provider.produce(
+        makeCtx({ greetingPolicy: 'fresh_intro' }),
+      )) as ProviderResult;
+      expect(result.candidate?.userFacingLine).toBe('CUSTOM LINE');
+    });
+
+    it('reports renderer throws as status=errored (no exception escapes)', async () => {
+      const exploding: VoiceWakeBriefRenderer = {
+        render: () => {
+          throw new Error('kaboom');
+        },
+      };
+      const provider = makeVoiceWakeBriefProvider({
+        renderer: exploding,
+        now: frozenNow(),
+        newId: frozenNewId(),
+      });
+      const result = (await provider.produce(
+        makeCtx({ greetingPolicy: 'fresh_intro' }),
+      )) as ProviderResult;
+      expect(result.status).toBe('errored');
+      expect(result.reason).toBe('kaboom');
+    });
+
+    it('reports empty renderer output as status=errored', async () => {
+      const emptyRenderer: VoiceWakeBriefRenderer = { render: () => '   ' };
+      const provider = makeVoiceWakeBriefProvider({
+        renderer: emptyRenderer,
+        now: frozenNow(),
+        newId: frozenNewId(),
+      });
+      const result = (await provider.produce(
+        makeCtx({ greetingPolicy: 'fresh_intro' }),
+      )) as ProviderResult;
+      expect(result.status).toBe('errored');
+      expect(result.reason).toBe('renderer_produced_empty_line');
+    });
+  });
+
+  describe('candidate shape', () => {
+    it('produces a candidate that passes the runtime validator', async () => {
+      const provider = makeVoiceWakeBriefProvider({
+        now: frozenNow(),
+        newId: frozenNewId(),
+      });
+      const result = (await provider.produce(
+        makeCtx({ greetingPolicy: 'warm_return' }),
+      )) as ProviderResult;
+      expect(result.status).toBe('returned');
+      const validation = validateContinuationCandidate(result.candidate);
+      expect(validation).toEqual({ ok: true });
+    });
+
+    it('carries evidence pointing back to the greeting policy', async () => {
+      const provider = makeVoiceWakeBriefProvider({
+        now: frozenNow(),
+        newId: frozenNewId(),
+      });
+      const result = (await provider.produce(
+        makeCtx({ greetingPolicy: 'warm_return' }),
+      )) as ProviderResult;
+      expect(result.candidate?.evidence).toEqual([
+        { kind: 'greeting_policy', detail: 'warm_return' },
+      ]);
+    });
+
+    it('uses a stable dedupeKey per policy (same policy → same key)', async () => {
+      const provider = makeVoiceWakeBriefProvider({
+        now: frozenNow(),
+        newId: frozenNewId(),
+      });
+      const r1 = (await provider.produce(
+        makeCtx({ greetingPolicy: 'fresh_intro' }),
+      )) as ProviderResult;
+      const r2 = (await provider.produce(
+        makeCtx({ greetingPolicy: 'fresh_intro' }),
+      )) as ProviderResult;
+      expect(r1.candidate?.dedupeKey).toBe('wake-brief-fresh_intro');
+      expect(r2.candidate?.dedupeKey).toBe(r1.candidate?.dedupeKey);
+    });
+
+    it('honors an overridden priority', async () => {
+      const provider = makeVoiceWakeBriefProvider({
+        priority: 5,
+        now: frozenNow(),
+        newId: frozenNewId(),
+      });
+      const result = (await provider.produce(
+        makeCtx({ greetingPolicy: 'warm_return' }),
+      )) as ProviderResult;
+      expect(result.candidate?.priority).toBe(5);
+    });
+
+    it('default priority is 80', async () => {
+      const provider = makeVoiceWakeBriefProvider({
+        now: frozenNow(),
+        newId: frozenNewId(),
+      });
+      const result = (await provider.produce(
+        makeCtx({ greetingPolicy: 'warm_return' }),
+      )) as ProviderResult;
+      expect(result.candidate?.priority).toBe(80);
+    });
+  });
+
+  describe('provider identity', () => {
+    it('exports the canonical key', () => {
+      const provider = makeVoiceWakeBriefProvider();
+      expect(provider.key).toBe(VOICE_WAKE_BRIEF_PROVIDER_KEY);
+      expect(VOICE_WAKE_BRIEF_PROVIDER_KEY).toBe('voice_wake_brief');
+    });
+
+    it('services the orb_wake surface only', () => {
+      const provider = makeVoiceWakeBriefProvider();
+      expect(provider.surfaces).toEqual(['orb_wake']);
+    });
+  });
+
+  describe('latency capture (B0d.3 dependency)', () => {
+    it('reports a non-negative latency', async () => {
+      const provider = makeVoiceWakeBriefProvider({ now: frozenNow() });
+      const result = (await provider.produce(
+        makeCtx({ greetingPolicy: 'fresh_intro' }),
+      )) as ProviderResult;
+      expect(typeof result.latencyMs).toBe('number');
+      expect(result.latencyMs).toBeGreaterThanOrEqual(0);
+    });
+  });
+});
+
+// ──────────────────────────────────────────────────────────────────────
+// End-to-end integration with decideContinuation. Confirms the
+// provider plugs into the B0d.1 orchestrator without surprises.
+// ──────────────────────────────────────────────────────────────────────
+
+describe('B0d.2 — end-to-end through decideContinuation', () => {
+  it('a registered wake-brief provider gets selected on orb_wake', async () => {
+    const registry = createProviderRegistry();
+    registry.register(
+      makeVoiceWakeBriefProvider({
+        now: frozenNow(),
+        newId: frozenNewId('wb'),
+      }),
+    );
+
+    const decision = await decideContinuation({
+      surface: 'orb_wake',
+      context: {
+        sessionId: 's1',
+        userId: 'u1',
+        tenantId: 't1',
+        extra: {
+          [VOICE_WAKE_BRIEF_EXTRA_KEY]: {
+            greetingPolicy: 'fresh_intro',
+            lang: 'en',
+          } satisfies VoiceWakeBriefInputs,
+        },
+      },
+      registry,
+    });
+
+    expect(decision.selectedContinuation).not.toBeNull();
+    expect(decision.selectedContinuation?.kind).toBe('wake_brief');
+    expect(decision.selectedContinuation?.userFacingLine).toMatch(/Hello/);
+    expect(decision.suppressionReason).toBeUndefined();
+    // sourceProviderResults still carries the provider's row (B0d.3 dep).
+    expect(decision.sourceProviderResults).toHaveLength(1);
+    expect(decision.sourceProviderResults[0].status).toBe('returned');
+    expect(decision.sourceProviderResults[0].providerKey).toBe(
+      VOICE_WAKE_BRIEF_PROVIDER_KEY,
+    );
+  });
+
+  it('a registered provider on skip greeting policy → decision is none_with_reason path', async () => {
+    const registry = createProviderRegistry();
+    registry.register(
+      makeVoiceWakeBriefProvider({
+        now: frozenNow(),
+        newId: frozenNewId('wb'),
+      }),
+    );
+
+    const decision = await decideContinuation({
+      surface: 'orb_wake',
+      context: {
+        sessionId: 's1',
+        extra: {
+          [VOICE_WAKE_BRIEF_EXTRA_KEY]: {
+            greetingPolicy: 'skip',
+          } satisfies VoiceWakeBriefInputs,
+        },
+      },
+      registry,
+    });
+
+    expect(decision.selectedContinuation).toBeNull();
+    expect(decision.suppressionReason).toBe('all_providers_suppressed');
+    // The provider's specific reason lives in sourceProviderResults.
+    expect(decision.sourceProviderResults[0].status).toBe('suppressed');
+    expect(decision.sourceProviderResults[0].reason).toBe('greeting_policy_skip');
+  });
+
+  it('the default renderer produces a contract-conformant candidate for every non-skip policy', () => {
+    const policies: Array<'brief_resume' | 'warm_return' | 'fresh_intro'> = [
+      'brief_resume',
+      'warm_return',
+      'fresh_intro',
+    ];
+    for (const policy of policies) {
+      const line = defaultVoiceWakeBriefRenderer.render(
+        { greetingPolicy: policy, lang: 'en' },
+        { surface: 'orb_wake' },
+      );
+      expect(line.length).toBeGreaterThan(0);
+    }
+  });
+});


### PR DESCRIPTION
## B0d.2 slice — first real continuation provider

Produces the backend-owned first spoken line after ORB activation — the eventual replacement for the passive \`vitana-v1/src/lib/instantGreeting.ts\` (\"I'm here, I'm listening\"). Plugs into the B0d.1 contract; no orchestrator changes.

**Scope freeze respected:** pure provider file. NO \`orb-live.ts\` wiring (that lands in B0d.4), NO module-load side-effects (production wires explicitly), NO personalization (vitanaId, last session topic) — those land in later slices.

## Module

\`services/gateway/src/services/assistant-continuation/providers/voice-wake-brief.ts\`

- \`makeVoiceWakeBriefProvider(opts)\` factory — opts: \`renderer\`, \`newId\`, \`now\`, \`priority\` (all injectable).
- \`VoiceWakeBriefInputs\` type carries \`greetingPolicy\` (from A4's \`decideGreetingPolicy\`) + optional \`lang\`. Inputs ride on \`ContinuationDecisionContext.extra[VOICE_WAKE_BRIEF_EXTRA_KEY]\`.
- \`VoiceWakeBriefRenderer\` injectable; default supports \`en\` + \`de\`.
- Provider key \`voice_wake_brief\`, surface \`['orb_wake']\`, default priority \`80\`.

## Behavior matrix

| Input                                | status      | reason                              |
|--------------------------------------|-------------|-------------------------------------|
| greetingPolicy = 'skip'              | suppressed  | \`greeting_policy_skip\`            |
| greetingPolicy ∈ {brief_resume,...}  | returned    | (candidate with wake_brief kind)    |
| extra missing / typo'd policy        | skipped     | \`no_voice_wake_brief_inputs\`      |
| renderer throws                      | errored     | (underlying message)                |
| renderer empty/whitespace            | errored     | \`renderer_produced_empty_line\`    |

## Tests

- **+25 new tests** covering every behavior-matrix row + language fallback + candidate-shape contract conformance + end-to-end through \`decideContinuation\`.
- **128/128** \`assistant-continuation\` tests pass (was 103, +25).
- **379/379** orb-suite + assistant-continuation tests pass — no regression.
- \`npm run build\` clean (pre-existing \`sharp\` error unrelated).

## Sequencing

Next: **B0d.3** (reliability timeline) — wire wake-to-first-audio + disconnect/reconnect trail through Command Hub. The provider's \`latencyMs\` + \`sourceProviderResults\` rows are already emitted in shape; B0d.3 only surfaces them.

After B0d.3 lands: B0d.4 (vitana-v1 integration — silence instantGreeting, consume the backend continuation).

## Test plan

- [x] All 25 new tests pass
- [x] No regression in 354 prior orb + B0d.1 tests
- [x] TypeScript build clean
- [x] Candidate output passes \`validateContinuationCandidate()\` (B0d.1 P1 fix)
- [x] Latency capture verified (B0d.3 dependency)

🤖 Generated with [Claude Code](https://claude.com/claude-code)