### PR TITLE
fix(self-healing): pre-probe gate (VTID-02914, PR-B/3)

### DIFF
--- a/services/gateway/src/routes/self-healing.ts
+++ b/services/gateway/src/routes/self-healing.ts
@@ -29,6 +29,7 @@ import {
   notifyGChat,
 } from '../services/self-healing-snapshot-service';
 import { spawnTriageAgent } from '../services/self-healing-triage-service';
+import { probeEndpoint, isJsonHealthy } from '../services/self-healing-probe';
 import {
   HealthReport,
   ServiceStatus,
@@ -163,7 +164,7 @@ async function shouldBeginDiagnosis(endpoint: string): Promise<{ proceed: boolea
 export async function processFailingService(
   failure: ServiceStatus,
   autonomyLevel: AutonomyLevel,
-): Promise<{ action: 'created' | 'skipped' | 'escalated' | 'disabled'; vtid?: string; reason?: string }> {
+): Promise<{ action: 'created' | 'skipped' | 'escalated' | 'disabled' | 'recovered_externally'; vtid?: string; reason?: string }> {
   // Dedup + circuit breaker
   const check = await shouldBeginDiagnosis(failure.endpoint);
   if (!check.proceed) {
@@ -176,6 +177,38 @@ export async function processFailingService(
       payload: { endpoint: failure.endpoint, reason: check.reason },
     });
     return { action: 'skipped', reason: check.reason };
+  }
+
+  // Pre-probe gate (PR-B): the scanner snapshot may already be stale by the
+  // time we get here. Real-HTTP endpoints get a 5s re-probe; if they answer
+  // with 2xx + application/json, the endpoint has recovered between snapshot
+  // and processing — bail out without allocating a VTID or writing a
+  // self_healing_log row. Voice synthetic endpoints (voice-error://) are
+  // skipped here; they have their own Synthetic Voice Probe path.
+  if (!failure.endpoint.startsWith('voice-error://')) {
+    const probe = await probeEndpoint(failure.endpoint);
+    if (isJsonHealthy(probe)) {
+      await emitOasisEvent({
+        type: 'self-healing.preflight.recovered',
+        vtid: 'SYSTEM',
+        source: 'self-healing',
+        status: 'info',
+        message: `Pre-probe found ${failure.endpoint} healthy (HTTP ${probe.http_status}, ${probe.latency_ms}ms)`,
+        payload: {
+          endpoint: failure.endpoint,
+          http_status: probe.http_status,
+          latency_ms: probe.latency_ms,
+          content_type: probe.content_type,
+          probed_at: new Date().toISOString(),
+          scanner_http_status: failure.http_status,
+          scanner_response_time_ms: failure.response_time_ms,
+        },
+      });
+      return {
+        action: 'recovered_externally',
+        reason: `endpoint healthy at pre-probe (HTTP ${probe.http_status}, ${probe.latency_ms}ms)`,
+      };
+    }
   }
 
   // Level 0: Observe only — log but don't act
@@ -381,6 +414,7 @@ router.post('/report', async (req: Request, res: Response) => {
     const details: SelfHealingReportResponse['details'] = [];
     let vtidsCreated = 0;
     let skipped = 0;
+    let recoveredExternally = 0;
 
     // Known-endpoint allowlist: only process endpoints that exist in the
     // gateway route map. Test/phantom endpoints (e.g. /api/v1/final-test/health,
@@ -425,6 +459,7 @@ router.post('/report', async (req: Request, res: Response) => {
         });
         if (result.action === 'created') vtidsCreated++;
         if (result.action === 'skipped') skipped++;
+        if (result.action === 'recovered_externally') recoveredExternally++;
       } catch (err: any) {
         console.error(`[self-healing] Error processing ${failure.name}: ${err.message}`);
         details.push({
@@ -441,6 +476,7 @@ router.post('/report', async (req: Request, res: Response) => {
       processed: downServices.length,
       vtids_created: vtidsCreated,
       skipped,
+      recovered_externally: recoveredExternally,
       details,
     } satisfies SelfHealingReportResponse);
   } catch (err: any) {

--- a/services/gateway/src/services/self-healing-probe.ts
+++ b/services/gateway/src/services/self-healing-probe.ts
@@ -1,0 +1,82 @@
+/**
+ * Self-healing endpoint probe — shared between the report-time pre-probe gate
+ * (services/gateway/src/routes/self-healing.ts) and the periodic reconciler
+ * (services/gateway/src/services/self-healing-reconciler.ts).
+ *
+ * Voice synthetic endpoints (voice-error://<class>) are intentionally reported
+ * as not-healthy so reconciler/preflight callers keep them in the queue and
+ * let the dedicated Synthetic Voice Probe verify them instead.
+ */
+
+const DEFAULT_GATEWAY_URL =
+  process.env.GATEWAY_URL || 'https://gateway.vitanaland.com';
+const DEFAULT_TIMEOUT_MS = 5_000;
+
+export interface ProbeResult {
+  healthy: boolean;
+  http_status: number | null;
+  latency_ms: number;
+  content_type?: string;
+}
+
+export interface ProbeOptions {
+  timeoutMs?: number;
+  /** Override base URL (mainly for tests). Defaults to env GATEWAY_URL. */
+  gatewayUrl?: string;
+}
+
+function isVoiceSyntheticEndpoint(endpoint: string): boolean {
+  return endpoint.startsWith('voice-error://');
+}
+
+function buildProbeUrl(endpoint: string, gatewayUrl: string): string {
+  if (/^https?:\/\//i.test(endpoint)) return endpoint;
+  if (endpoint.startsWith('/')) return `${gatewayUrl}${endpoint}`;
+  return `${gatewayUrl}/${endpoint}`;
+}
+
+export async function probeEndpoint(
+  endpoint: string,
+  opts: ProbeOptions = {},
+): Promise<ProbeResult> {
+  if (isVoiceSyntheticEndpoint(endpoint)) {
+    return { healthy: false, http_status: null, latency_ms: 0 };
+  }
+
+  const timeoutMs = opts.timeoutMs ?? DEFAULT_TIMEOUT_MS;
+  const gatewayUrl = opts.gatewayUrl ?? DEFAULT_GATEWAY_URL;
+  const url = buildProbeUrl(endpoint, gatewayUrl);
+  const started = Date.now();
+
+  try {
+    const res = await fetch(url, { signal: AbortSignal.timeout(timeoutMs) });
+    const latency_ms = Date.now() - started;
+    const content_type = res.headers.get('content-type') || undefined;
+    return {
+      healthy: res.ok,
+      http_status: res.status,
+      latency_ms,
+      content_type,
+    };
+  } catch {
+    return {
+      healthy: false,
+      http_status: null,
+      latency_ms: Date.now() - started,
+    };
+  }
+}
+
+/**
+ * Stricter check used by the pre-probe gate: an endpoint is only "already
+ * healed" if it returned 2xx AND a JSON content-type. HTML 2xx (e.g. an SPA
+ * catch-all returning index.html for a missing API route) does NOT count.
+ */
+export function isJsonHealthy(result: ProbeResult): boolean {
+  if (!result.healthy) return false;
+  if (result.http_status === null || result.http_status < 200 || result.http_status >= 300) {
+    return false;
+  }
+  if (!result.content_type) return false;
+  return result.content_type.toLowerCase().includes('application/json');
+}

--- a/services/gateway/src/services/self-healing-reconciler.ts
+++ b/services/gateway/src/services/self-healing-reconciler.ts
@@ -31,6 +31,7 @@ import { triggerRollbackRecommendation } from './voice-auto-rollback';
 import { recordSpecMemory } from './voice-spec-memory';
 import { getVoiceSpecHint, parseVoiceClassFromEndpoint } from './voice-spec-hints';
 import { appendVerdict, evaluateAndQuarantine } from './voice-recurrence-sentinel';
+import { probeEndpoint as sharedProbeEndpoint } from './self-healing-probe';
 
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
@@ -95,25 +96,11 @@ async function fetchStaleRows(thresholdMs: number): Promise<StaleRow[]> {
 async function probeEndpoint(
   endpoint: string,
 ): Promise<{ healthy: boolean; http_status: number | null }> {
-  // Voice synthetic endpoints (voice-error://<class>) have no HTTP path —
-  // they're a routing convention so the Voice→SelfHealing Adapter can flow
-  // through the same dedup/diagnose/inject pipeline. Verification for voice
-  // rows happens via the Synthetic Voice Probe (programmatic SSE session
-  // against /api/v1/orb/live/session/start with semantic-token check),
-  // which lands in PR #4. For now we report voice rows as not-healthy so
-  // the reconciler keeps them in the queue and does not falsely transition
-  // them to recovered_externally.
-  if (endpoint.startsWith('voice-error://')) {
-    return { healthy: false, http_status: null };
-  }
-  try {
-    const res = await fetch(`${GATEWAY_URL}${endpoint}`, {
-      signal: AbortSignal.timeout(PROBE_TIMEOUT_MS),
-    });
-    return { healthy: res.ok, http_status: res.status };
-  } catch {
-    return { healthy: false, http_status: null };
-  }
+  const result = await sharedProbeEndpoint(endpoint, {
+    timeoutMs: PROBE_TIMEOUT_MS,
+    gatewayUrl: GATEWAY_URL,
+  });
+  return { healthy: result.healthy, http_status: result.http_status };
 }
 
 /**

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -576,6 +576,7 @@ export type CicdEventType =
   | 'match.proactive.batch.completed'
   // Self-Healing System Events
   | 'self-healing.report.received'
+  | 'self-healing.preflight.recovered'
   | 'self-healing.diagnosis.started'
   | 'self-healing.diagnosis.completed'
   | 'self-healing.spec.generated'

--- a/services/gateway/src/types/self-healing.ts
+++ b/services/gateway/src/types/self-healing.ts
@@ -165,10 +165,13 @@ export interface SelfHealingReportResponse {
   processed: number;
   vtids_created: number;
   skipped: number;
+  /** Count of failures that the pre-probe found already healthy at report
+   * time — no VTID allocated, no self_healing_log row written. */
+  recovered_externally?: number;
   details: Array<{
     service: string;
     endpoint: string;
-    action: 'created' | 'skipped' | 'escalated' | 'disabled';
+    action: 'created' | 'skipped' | 'escalated' | 'disabled' | 'recovered_externally';
     vtid?: string;
     reason?: string;
   }>;

--- a/services/gateway/test/self-healing-pre-probe.test.ts
+++ b/services/gateway/test/self-healing-pre-probe.test.ts
@@ -1,0 +1,250 @@
+/**
+ * PR-B (VTID-02914): pre-probe gate.
+ *
+ * The gate prevents `processFailingService` from allocating a VTID + writing
+ * a self_healing_log row when the failing endpoint has already recovered
+ * between the scanner snapshot and our processing of it. The contract is:
+ *
+ *   1. `probeEndpoint` honors voice synthetic endpoints (no HTTP fetch).
+ *   2. `probeEndpoint` returns latency, status, and content-type.
+ *   3. `isJsonHealthy` is strict: 2xx alone is not enough, the response
+ *      must also be application/json (an SPA catch-all returning index.html
+ *      with HTTP 200 must NOT count as healed).
+ *   4. `processFailingService` short-circuits with action='recovered_externally'
+ *      when the pre-probe passes, and never calls `beginDiagnosis` /
+ *      `injectIntoAutopilotPipeline`.
+ */
+
+import { probeEndpoint, isJsonHealthy } from '../src/services/self-healing-probe';
+
+const ORIGINAL_FETCH = global.fetch;
+
+afterEach(() => {
+  global.fetch = ORIGINAL_FETCH;
+  jest.resetModules();
+});
+
+describe('probeEndpoint (shared helper)', () => {
+  it('returns not-healthy with no fetch for voice synthetic endpoints', async () => {
+    const fetchSpy = jest.fn();
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    const result = await probeEndpoint('voice-error://no_audio_in');
+
+    expect(fetchSpy).not.toHaveBeenCalled();
+    expect(result.healthy).toBe(false);
+    expect(result.http_status).toBeNull();
+    expect(result.latency_ms).toBe(0);
+  });
+
+  it('returns healthy=true with status + content-type on 200 JSON', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: (k: string) => (k === 'content-type' ? 'application/json; charset=utf-8' : null) },
+    } as unknown as Response) as unknown as typeof fetch;
+
+    const result = await probeEndpoint('/api/v1/availability/health');
+
+    expect(result.healthy).toBe(true);
+    expect(result.http_status).toBe(200);
+    expect(result.content_type).toContain('application/json');
+    expect(typeof result.latency_ms).toBe('number');
+  });
+
+  it('returns not-healthy when fetch throws (timeout / network)', async () => {
+    global.fetch = jest.fn().mockRejectedValue(new Error('AbortError')) as unknown as typeof fetch;
+
+    const result = await probeEndpoint('/api/v1/availability/health', { timeoutMs: 50 });
+
+    expect(result.healthy).toBe(false);
+    expect(result.http_status).toBeNull();
+  });
+
+  it('returns healthy=false on 503', async () => {
+    global.fetch = jest.fn().mockResolvedValue({
+      ok: false,
+      status: 503,
+      headers: { get: () => 'application/json' },
+    } as unknown as Response) as unknown as typeof fetch;
+
+    const result = await probeEndpoint('/api/v1/availability/health');
+
+    expect(result.healthy).toBe(false);
+    expect(result.http_status).toBe(503);
+  });
+
+  it('uses absolute URLs verbatim instead of prepending gateway base', async () => {
+    const fetchSpy = jest.fn().mockResolvedValue({
+      ok: true,
+      status: 200,
+      headers: { get: () => 'application/json' },
+    } as unknown as Response);
+    global.fetch = fetchSpy as unknown as typeof fetch;
+
+    await probeEndpoint('https://example.com/health');
+
+    expect(fetchSpy).toHaveBeenCalledTimes(1);
+    expect((fetchSpy.mock.calls[0] as any[])[0]).toBe('https://example.com/health');
+  });
+});
+
+describe('isJsonHealthy', () => {
+  it('accepts 200 + application/json as healed', () => {
+    expect(
+      isJsonHealthy({ healthy: true, http_status: 200, latency_ms: 50, content_type: 'application/json' }),
+    ).toBe(true);
+  });
+
+  it('rejects 200 + text/html (SPA catch-all)', () => {
+    expect(
+      isJsonHealthy({ healthy: true, http_status: 200, latency_ms: 50, content_type: 'text/html; charset=utf-8' }),
+    ).toBe(false);
+  });
+
+  it('rejects 503 even with JSON content-type', () => {
+    expect(
+      isJsonHealthy({ healthy: false, http_status: 503, latency_ms: 50, content_type: 'application/json' }),
+    ).toBe(false);
+  });
+
+  it('rejects when content-type is missing', () => {
+    expect(isJsonHealthy({ healthy: true, http_status: 200, latency_ms: 50 })).toBe(false);
+  });
+
+  it('accepts content-types like application/json; charset=utf-8', () => {
+    expect(
+      isJsonHealthy({ healthy: true, http_status: 200, latency_ms: 50, content_type: 'Application/JSON; charset=utf-8' }),
+    ).toBe(true);
+  });
+});
+
+describe('processFailingService — pre-probe gate', () => {
+  const baseFailure = {
+    name: 'Availability Health',
+    endpoint: '/api/v1/availability/health',
+    status: 'down' as const,
+    http_status: 503,
+    response_body: '',
+    response_time_ms: 100,
+    error_message: 'snapshot showed 503',
+  };
+
+  function loadRouteWithMocks() {
+    // Reset module registry so mocks take effect on every reload.
+    jest.resetModules();
+    jest.doMock('../src/services/oasis-event-service', () => ({
+      emitOasisEvent: jest.fn().mockResolvedValue(undefined),
+    }));
+    jest.doMock('../src/services/self-healing-diagnosis-service', () => ({
+      beginDiagnosis: jest.fn(),
+    }));
+    jest.doMock('../src/services/self-healing-spec-service', () => ({
+      generateAndStoreFixSpec: jest.fn(),
+    }));
+    jest.doMock('../src/services/self-healing-injector-service', () => ({
+      injectIntoAutopilotPipeline: jest.fn(),
+    }));
+    jest.doMock('../src/services/self-healing-snapshot-service', () => ({
+      captureHealthSnapshot: jest.fn(),
+      verifyFixWithBlastRadiusCheck: jest.fn(),
+      executeRollback: jest.fn(),
+      notifyGChat: jest.fn().mockResolvedValue(undefined),
+    }));
+    jest.doMock('../src/services/self-healing-triage-service', () => ({
+      spawnTriageAgent: jest.fn(),
+    }));
+
+    // Bypass the dedup/circuit-breaker check (queries Supabase) by
+    // returning proceed=true on every call.
+    const route = require('../src/routes/self-healing');
+    return route;
+  }
+
+  it('short-circuits with recovered_externally when pre-probe is JSON-healthy', async () => {
+    global.fetch = jest.fn().mockImplementation((url: string) => {
+      // Supabase dedup queries respond with empty arrays (no active VTID, 0 attempts)
+      if (url.includes('/rest/v1/vtid_ledger')) {
+        return Promise.resolve({
+          ok: true,
+          headers: { get: () => null },
+          json: () => Promise.resolve([]),
+        });
+      }
+      if (url.includes('/rest/v1/self_healing_log')) {
+        return Promise.resolve({
+          ok: true,
+          headers: { get: (k: string) => (k === 'content-range' ? '0-0/0' : null) },
+          json: () => Promise.resolve([]),
+        });
+      }
+      // Pre-probe call → healthy
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: { get: (k: string) => (k === 'content-type' ? 'application/json' : null) },
+      });
+    }) as unknown as typeof fetch;
+
+    process.env.SUPABASE_URL = 'https://supabase.test';
+    process.env.SUPABASE_SERVICE_ROLE = 'svc-role';
+
+    const route = loadRouteWithMocks();
+    const beginDiagnosis = require('../src/services/self-healing-diagnosis-service').beginDiagnosis;
+    const inject = require('../src/services/self-healing-injector-service').injectIntoAutopilotPipeline;
+
+    const result = await route.processFailingService(baseFailure, /* AUTO_FIX_SIMPLE */ 3);
+
+    expect(result.action).toBe('recovered_externally');
+    expect(result.vtid).toBeUndefined();
+    expect(beginDiagnosis).not.toHaveBeenCalled();
+    expect(inject).not.toHaveBeenCalled();
+  });
+
+  it('skips the pre-probe entirely for voice synthetic endpoints', async () => {
+    let probeCalled = false;
+    global.fetch = jest.fn().mockImplementation((url: string) => {
+      if (url.includes('/rest/v1/vtid_ledger')) {
+        return Promise.resolve({ ok: true, headers: { get: () => null }, json: () => Promise.resolve([]) });
+      }
+      if (url.includes('/rest/v1/self_healing_log')) {
+        return Promise.resolve({
+          ok: true,
+          headers: { get: (k: string) => (k === 'content-range' ? '0-0/0' : null) },
+          json: () => Promise.resolve([]),
+        });
+      }
+      // Any non-supabase fetch == probe call
+      probeCalled = true;
+      return Promise.resolve({
+        ok: true,
+        status: 200,
+        headers: { get: () => 'application/json' },
+      });
+    }) as unknown as typeof fetch;
+
+    process.env.SUPABASE_URL = 'https://supabase.test';
+    process.env.SUPABASE_SERVICE_ROLE = 'svc-role';
+
+    const route = loadRouteWithMocks();
+    require('../src/services/self-healing-diagnosis-service').beginDiagnosis.mockResolvedValue({
+      vtid: 'VTID-99999',
+      diagnosis: { service_name: 'voice', failure_class: 'no_audio_in', confidence: 0.9, root_cause: 'r', auto_fixable: true, files_to_modify: [], files_read: [], evidence: [] },
+    });
+    require('../src/services/self-healing-spec-service').generateAndStoreFixSpec.mockResolvedValue({
+      spec: 'spec',
+      spec_hash: 'hash',
+      quality_score: 0.9,
+    });
+    require('../src/services/self-healing-injector-service').injectIntoAutopilotPipeline.mockResolvedValue({
+      success: true,
+    });
+
+    await route.processFailingService(
+      { ...baseFailure, endpoint: 'voice-error://no_audio_in' },
+      /* AUTO_FIX_SIMPLE */ 3,
+    );
+
+    expect(probeCalled).toBe(false); // pre-probe must not fire for voice
+  });
+});


### PR DESCRIPTION
## Summary
- Pre-probe at `/api/v1/self-healing/report` so endpoints that recovered between scanner snapshot and processing don't get a VTID + autopilot run
- Extracted `probeEndpoint` into shared `services/gateway/src/services/self-healing-probe.ts` (used by both the report-time gate and the periodic reconciler)
- Strict 2xx + `application/json` check (SPA HTML 200 does NOT count as healed); voice synthetic endpoints bypass

## Why
First of three PRs implementing the self-healing 100% plan in `.claude/plans/synthetic-crafting-twilight.md`. VTID-02912 smoke run found `/api/v1/availability/health` was actually healthy when self-healing reported it down, but a task got opened anyway and burned the autonomy loop. This eliminates that class of fake failure.

## Healing definition reminder
This PR ONLY adds the pre-injection gate. It does not change what counts as "healed" downstream. PR-A (the patch-workspace bridge) is where the worker-runner stops being able to mark `terminal_outcome='success'` without real CI + deploy + live probe — that's separate and lands after PR-C.

## Test plan
- [x] `npm run build` — clean except pre-existing `sharp` module error (verified by stashing diff and rebuilding main)
- [x] `npx jest test/self-healing-pre-probe.test.ts` — 12/12 pass (helper, isJsonHealthy, route short-circuit, voice bypass)
- [x] `npx jest test/voice-self-healing-adapter.test.ts` — 13/13 pass (no regression from probeEndpoint extraction)
- [ ] After merge: dispatch EXEC-DEPLOY for gateway, then curl POST /api/v1/self-healing/report with a healthy endpoint and verify response includes recovered_externally count and no VTID was allocated

## Plan reference
.claude/plans/synthetic-crafting-twilight.md § PR-B

🤖 Generated with [Claude Code](https://claude.com/claude-code)