### PR TITLE
feat(orb): B0d.4 - wire wake-brief decision + 3 timeline events (VTID-02918)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -49,6 +49,11 @@ import { emitOasisEvent } from '../services/oasis-event-service';
 // VTID-02917 (B0d.3): wake reliability timeline — emit + record only,
 // never block the wake path. The recorder is best-effort by design.
 import { defaultWakeTimelineRecorder } from '../services/wake-timeline/wake-timeline-recorder';
+// VTID-02918 (B0d.4): wake-brief decision wiring. Side-effect import
+// registers the voice-wake-brief provider with the default registry;
+// `decideWakeBriefForSession` runs the continuation decision and emits
+// the 3 continuation_decision_* timeline events.
+import { decideWakeBriefForSession } from '../services/wake-brief-wiring';
 // BOOTSTRAP-VOICE-DEMO: real heartbeats from voice call sites so the agents
 // dashboard reflects live usage instead of fake startup status.
 import { recordAgentHeartbeat } from './agents-registry';
@@ -11428,7 +11433,7 @@ router.post('/live/session/start', optionalAuth, async (req: AuthenticatedReques
 
   // VTID-02917 (B0d.3): record the session_start_received event in the
   // wake timeline. This is the backend's earliest signal — frontend will
-  // emit wake_clicked separately in B0d.4.
+  // emit wake_clicked separately in B0d.4-frontend (vitana-v1).
   try {
     defaultWakeTimelineRecorder.startSession({
       sessionId,
@@ -11448,6 +11453,37 @@ router.post('/live/session/start', optionalAuth, async (req: AuthenticatedReques
     });
   } catch {
     // Best-effort; never block the wake path on telemetry.
+  }
+
+  // VTID-02918 (B0d.4): wake-brief continuation decision. Decides which
+  // backend-owned line (if any) Vitana should speak first. The selected
+  // continuation is attached to the response + session for observability;
+  // it does NOT yet drive the spoken greeting — that swap-in waits for
+  // the vitana-v1 frontend coordination AFTER timeline data confirms
+  // the path is healthy. Best-effort: any failure inside the decision
+  // path leaves `wakeBriefDecision` null without breaking the wake.
+  let wakeBriefDecision: Awaited<ReturnType<typeof decideWakeBriefForSession>> | null = null;
+  try {
+    const temporal = describeTimeSince(session.lastSessionInfo);
+    wakeBriefDecision = await decideWakeBriefForSession({
+      sessionId,
+      tenantId: orbIdentity?.tenant_id ?? null,
+      userId: orbIdentity?.user_id ?? null,
+      bucket: temporal.bucket,
+      wasFailure: temporal.wasFailure,
+      isReconnect: isReconnectStart,
+      lang,
+      // envelopeJourneySurface will be populated once the legacy
+      // ClientContext is replaced by the B0a ClientContextEnvelope on
+      // the orb-live path. Until then the wake-brief decision proceeds
+      // without it — the existing greetingPolicy/lang inputs are
+      // sufficient for B0d.2's renderer.
+    });
+    (session as any).wakeBriefDecision = wakeBriefDecision;
+  } catch (e) {
+    console.warn(
+      `[VTID-02918] wake-brief decision failed for ${sessionId}: ${(e as Error).message}`,
+    );
   }
 
   // Emit OASIS event with identity context
@@ -11492,7 +11528,24 @@ router.post('/live/session/start', optionalAuth, async (req: AuthenticatedReques
         context_chars: null,
         skipped_reason: contextBootstrapSkippedReason || null,
         deferred: !!contextReadyPromise,
-      }
+      },
+      // VTID-02918 (B0d.4): wake-brief continuation decision (read-only).
+      // The frontend can consume this in a future slice (vitana-v1) to
+      // replace the passive instantGreeting line. NULL until then is
+      // a valid + expected state — the orb chime/visual still plays.
+      wake_brief: wakeBriefDecision
+        ? {
+            decision_id: wakeBriefDecision.decisionId,
+            selected_kind:
+              wakeBriefDecision.selectedContinuation?.kind ?? 'none_with_reason',
+            user_facing_line:
+              wakeBriefDecision.selectedContinuation?.userFacingLine ?? '',
+            suppression_reason:
+              wakeBriefDecision.selectedContinuation?.kind === 'none_with_reason'
+                ? wakeBriefDecision.selectedContinuation.suppressReason
+                : wakeBriefDecision.suppressionReason ?? null,
+          }
+        : null,
     }
   });
 });

--- a/services/gateway/src/services/wake-brief-wiring.ts
+++ b/services/gateway/src/services/wake-brief-wiring.ts
@@ -1,0 +1,187 @@
+/**
+ * VTID-02918 (B0d.4) — Wake-brief wiring.
+ *
+ * Glue between the B0a session-cadence inputs already computed inside
+ * orb-live.ts's `/live/session/start` handler and the B0d.1 continuation
+ * orchestrator. Producing the wake-brief decision in a tiny dedicated
+ * module (instead of inlining 60 more lines into orb-live.ts) keeps
+ * the route file's diff small and makes the wiring unit-testable.
+ *
+ * Wiring rule (measure-before-optimize):
+ *   - Compute greetingPolicy from existing decideGreetingPolicy().
+ *   - Call decideContinuation() on the orb_wake surface.
+ *   - Emit the 3 continuation_decision_* timeline events.
+ *   - RETURN the decision so the caller can attach it to the session +
+ *     response payload.
+ *
+ * **No prompt rewiring in B0d.4.** The selected continuation is
+ * observable (timeline events, response payload, session state) but it
+ * does NOT yet drive the spoken greeting — that change waits for the
+ * vitana-v1 frontend integration AFTER a week of timeline data confirms
+ * the path is healthy. Premature swap-in would hide the failure mode
+ * the way instantGreeting.ts did for 6 months (see
+ * orb_ios_greeting_silent_root_cause.md).
+ */
+
+import { decideContinuation } from './assistant-continuation/decide-continuation';
+import {
+  defaultProviderRegistry,
+} from './assistant-continuation/provider-registry';
+import {
+  makeVoiceWakeBriefProvider,
+  VOICE_WAKE_BRIEF_EXTRA_KEY,
+  VOICE_WAKE_BRIEF_PROVIDER_KEY,
+  type VoiceWakeBriefInputs,
+} from './assistant-continuation/providers/voice-wake-brief';
+import { decideGreetingPolicy } from '../orb/live/instruction/greeting-policy';
+import { defaultWakeTimelineRecorder } from './wake-timeline/wake-timeline-recorder';
+import type { AssistantContinuationDecision } from './assistant-continuation/types';
+
+// ---------------------------------------------------------------------------
+// One-time provider registration. The default registry started empty in
+// B0d.1 by design; B0d.2+ providers register here. Idempotent so
+// re-imports during hot-reload don't throw the "duplicate key" error.
+// ---------------------------------------------------------------------------
+
+let _registered = false;
+export function ensureWakeBriefProviderRegistered(): void {
+  if (_registered) return;
+  if (defaultProviderRegistry.get(VOICE_WAKE_BRIEF_PROVIDER_KEY)) {
+    _registered = true;
+    return;
+  }
+  defaultProviderRegistry.register(makeVoiceWakeBriefProvider());
+  _registered = true;
+}
+
+// Register on import so the orb-live.ts caller doesn't need to remember.
+ensureWakeBriefProviderRegistered();
+
+// ---------------------------------------------------------------------------
+// Inputs from orb-live.ts session-start. Kept narrow on purpose: these
+// are the variables already computed at the wiring point. Adding more
+// inputs is a future-slice concern (B1 cadence signals will extend
+// GreetingPolicyInput, which flows through here naturally).
+// ---------------------------------------------------------------------------
+
+export interface DecideWakeBriefArgs {
+  sessionId: string;
+  tenantId: string | null;
+  userId: string | null;
+  /** From `describeTimeSince(session.lastSessionInfo).bucket`. */
+  bucket: string;
+  /** From describeTimeSince's wasFailure (or `false` for anonymous sessions). */
+  wasFailure?: boolean;
+  /** From orb-live.ts isReconnectStart (transparent reconnect = skip). */
+  isReconnect: boolean;
+  /** Resolved language for the session (post-anonymous browser-lang resolve). */
+  lang: string;
+  /** journeySurface from the ClientContextEnvelope, if any. */
+  envelopeJourneySurface?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Main wiring entry point.
+// ---------------------------------------------------------------------------
+
+export interface DecideWakeBriefOptions {
+  /** Injected for tests. Production uses module-level singletons. */
+  recorder?: typeof defaultWakeTimelineRecorder;
+  /** Injected for tests. Defaults to Date.now. */
+  now?: () => number;
+}
+
+/**
+ * Run the wake-brief decision for the given session-start. Returns the
+ * full `AssistantContinuationDecision` carrier so the caller can attach
+ * it to the response + session for downstream observability.
+ *
+ * The 3 wake-timeline events fire from inside this function:
+ *   - continuation_decision_started (carries surface + lang + bucket)
+ *   - wake_brief_selected           (carries the chosen kind OR none_with_reason)
+ *   - continuation_decision_finished (carries decisionId + duration)
+ *
+ * Best-effort: timeline emission never throws upward. The decision
+ * itself always succeeds — providers errors flow through as
+ * `status: 'errored'` rows on the decision carrier.
+ */
+export async function decideWakeBriefForSession(
+  args: DecideWakeBriefArgs,
+  opts: DecideWakeBriefOptions = {},
+): Promise<AssistantContinuationDecision> {
+  const recorder = opts.recorder ?? defaultWakeTimelineRecorder;
+  const now = opts.now ?? (() => Date.now());
+
+  const greetingPolicy = decideGreetingPolicy({
+    bucket: args.bucket,
+    isReconnect: args.isReconnect,
+    wasFailure: args.wasFailure ?? false,
+  });
+
+  const wakeBriefInputs: VoiceWakeBriefInputs = {
+    greetingPolicy,
+    lang: args.lang,
+  };
+
+  safeRecord(recorder, args.sessionId, 'continuation_decision_started', {
+    surface: 'orb_wake',
+    bucket: args.bucket,
+    isReconnect: args.isReconnect,
+    greetingPolicy,
+    lang: args.lang,
+  });
+
+  const t0 = now();
+  const decision = await decideContinuation({
+    surface: 'orb_wake',
+    context: {
+      sessionId: args.sessionId,
+      userId: args.userId ?? undefined,
+      tenantId: args.tenantId ?? undefined,
+      envelopeJourneySurface: args.envelopeJourneySurface,
+      extra: { [VOICE_WAKE_BRIEF_EXTRA_KEY]: wakeBriefInputs },
+    },
+  });
+
+  // wake_brief_selected — fires once per wake. Carries either the
+  // selected kind OR none_with_reason. B0d.3's aggregator reads
+  // `selected_continuation_kind` + `none_with_reason` from this event.
+  const selectedKind = decision.selectedContinuation?.kind ?? 'none_with_reason';
+  const noneWithReason =
+    decision.selectedContinuation === null ? decision.suppressionReason : undefined;
+  safeRecord(recorder, args.sessionId, 'wake_brief_selected', {
+    decisionId: decision.decisionId,
+    selected_continuation_kind: selectedKind,
+    ...(noneWithReason ? { none_with_reason: noneWithReason } : {}),
+  });
+
+  safeRecord(recorder, args.sessionId, 'continuation_decision_finished', {
+    decisionId: decision.decisionId,
+    durationMs: Math.max(0, now() - t0),
+    providerResults: decision.sourceProviderResults.map((r) => ({
+      key: r.providerKey,
+      status: r.status,
+      latencyMs: r.latencyMs,
+      reason: r.reason,
+    })),
+  });
+
+  return decision;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+function safeRecord(
+  recorder: typeof defaultWakeTimelineRecorder,
+  sessionId: string,
+  name: Parameters<typeof defaultWakeTimelineRecorder.recordEvent>[0]['name'],
+  metadata: Record<string, unknown>,
+): void {
+  try {
+    recorder.recordEvent({ sessionId, name, metadata });
+  } catch {
+    // never block the wake path on telemetry
+  }
+}

--- a/services/gateway/test/services/wake-brief-wiring.test.ts
+++ b/services/gateway/test/services/wake-brief-wiring.test.ts
@@ -1,0 +1,275 @@
+/**
+ * VTID-02918 (B0d.4) — wake-brief-wiring tests.
+ *
+ * Covers:
+ *   - The wiring registers the voice-wake-brief provider exactly once
+ *     (idempotent across imports).
+ *   - decideWakeBriefForSession maps bucket+isReconnect → greetingPolicy
+ *     via the existing A4 seam, then invokes decideContinuation.
+ *   - The 3 continuation_decision_* timeline events fire in order with
+ *     the expected metadata payloads.
+ *   - On a non-skip greeting: returns a wake_brief continuation;
+ *     wake_brief_selected event carries selected_continuation_kind.
+ *   - On a skip greeting: provider suppresses, decision returns null,
+ *     wake_brief_selected carries none_with_reason.
+ *   - Recorder errors never escape (best-effort policy).
+ */
+
+import { decideWakeBriefForSession, ensureWakeBriefProviderRegistered } from '../../src/services/wake-brief-wiring';
+import { createWakeTimelineRecorder } from '../../src/services/wake-timeline/wake-timeline-recorder';
+import { defaultProviderRegistry } from '../../src/services/assistant-continuation/provider-registry';
+import { VOICE_WAKE_BRIEF_PROVIDER_KEY } from '../../src/services/assistant-continuation/providers/voice-wake-brief';
+
+describe('B0d.4 — wake-brief-wiring', () => {
+  describe('provider registration', () => {
+    it('voice-wake-brief is registered with the default registry on import', () => {
+      const provider = defaultProviderRegistry.get(VOICE_WAKE_BRIEF_PROVIDER_KEY);
+      expect(provider).toBeDefined();
+      expect(provider?.surfaces).toEqual(['orb_wake']);
+    });
+
+    it('ensureWakeBriefProviderRegistered is idempotent', () => {
+      // Calling twice must not throw (it would on duplicate-key register).
+      expect(() => ensureWakeBriefProviderRegistered()).not.toThrow();
+      expect(() => ensureWakeBriefProviderRegistered()).not.toThrow();
+    });
+  });
+
+  describe('decideWakeBriefForSession', () => {
+    function freshRecorder() {
+      return createWakeTimelineRecorder({
+        now: (() => {
+          let t = 1_700_000_000_000;
+          return () => {
+            const d = new Date(t);
+            t += 5;
+            return d;
+          };
+        })(),
+        getDb: () => null,
+      });
+    }
+
+    it('returns a wake_brief continuation for a non-skip greeting', async () => {
+      const recorder = freshRecorder();
+      const decision = await decideWakeBriefForSession(
+        {
+          sessionId: 'live-test-1',
+          tenantId: 't1',
+          userId: 'u1',
+          bucket: 'first',
+          isReconnect: false,
+          lang: 'en',
+        },
+        { recorder },
+      );
+      expect(decision.selectedContinuation).not.toBeNull();
+      expect(decision.selectedContinuation?.kind).toBe('wake_brief');
+      expect(decision.selectedContinuation?.surface).toBe('orb_wake');
+      expect(decision.selectedContinuation?.userFacingLine.length).toBeGreaterThan(0);
+    });
+
+    it('suppresses on transparent reconnect (greeting policy = skip)', async () => {
+      const recorder = freshRecorder();
+      const decision = await decideWakeBriefForSession(
+        {
+          sessionId: 'live-reconnect',
+          tenantId: 't1',
+          userId: 'u1',
+          bucket: 'recent',
+          isReconnect: true,
+          lang: 'en',
+        },
+        { recorder },
+      );
+      expect(decision.selectedContinuation).toBeNull();
+      expect(decision.suppressionReason).toBe('all_providers_suppressed');
+      // The provider's specific reason is preserved on the row.
+      const row = decision.sourceProviderResults[0];
+      expect(row.status).toBe('suppressed');
+      expect(row.reason).toBe('greeting_policy_skip');
+    });
+
+    it('maps bucket=long to fresh_intro (warm new-day greeting)', async () => {
+      const recorder = freshRecorder();
+      const decision = await decideWakeBriefForSession(
+        {
+          sessionId: 'live-long-gap',
+          tenantId: 't1',
+          userId: 'u1',
+          bucket: 'long',
+          isReconnect: false,
+          lang: 'en',
+        },
+        { recorder },
+      );
+      expect(decision.selectedContinuation?.userFacingLine).toMatch(/Hello/);
+    });
+
+    it('honors lang for the wake-brief line (de = German)', async () => {
+      const recorder = freshRecorder();
+      const decision = await decideWakeBriefForSession(
+        {
+          sessionId: 'live-de',
+          tenantId: 't1',
+          userId: 'u1',
+          bucket: 'first',
+          isReconnect: false,
+          lang: 'de',
+        },
+        { recorder },
+      );
+      expect(decision.selectedContinuation?.userFacingLine).toBe('Hallo! Wie kann ich heute helfen?');
+    });
+  });
+
+  describe('timeline events', () => {
+    it('emits the 3 continuation_decision_* events in order', async () => {
+      const recorder = createWakeTimelineRecorder({
+        now: (() => {
+          let t = 1_700_000_000_000;
+          return () => {
+            const d = new Date(t);
+            t += 5;
+            return d;
+          };
+        })(),
+        getDb: () => null,
+      });
+      recorder.startSession({ sessionId: 'live-events' });
+      await decideWakeBriefForSession(
+        {
+          sessionId: 'live-events',
+          tenantId: 't1',
+          userId: 'u1',
+          bucket: 'today',
+          isReconnect: false,
+          lang: 'en',
+        },
+        { recorder },
+      );
+      const timeline = await recorder.getTimeline('live-events');
+      const names = (timeline?.events ?? []).map((e) => e.name);
+      // Order matters: started → wake_brief_selected → finished.
+      expect(names).toEqual([
+        'continuation_decision_started',
+        'wake_brief_selected',
+        'continuation_decision_finished',
+      ]);
+    });
+
+    it('wake_brief_selected carries selected_continuation_kind on a returned candidate', async () => {
+      const recorder = createWakeTimelineRecorder({
+        now: (() => {
+          let t = 1_700_000_000_000;
+          return () => {
+            const d = new Date(t);
+            t += 5;
+            return d;
+          };
+        })(),
+        getDb: () => null,
+      });
+      await decideWakeBriefForSession(
+        {
+          sessionId: 'live-ev-kind',
+          tenantId: 't1',
+          userId: 'u1',
+          bucket: 'first',
+          isReconnect: false,
+          lang: 'en',
+        },
+        { recorder },
+      );
+      const timeline = await recorder.getTimeline('live-ev-kind');
+      const selected = timeline?.events.find((e) => e.name === 'wake_brief_selected');
+      expect(selected?.metadata?.selected_continuation_kind).toBe('wake_brief');
+      expect(selected?.metadata?.none_with_reason).toBeUndefined();
+    });
+
+    it('wake_brief_selected carries none_with_reason on full suppression', async () => {
+      const recorder = createWakeTimelineRecorder({
+        now: (() => {
+          let t = 1_700_000_000_000;
+          return () => {
+            const d = new Date(t);
+            t += 5;
+            return d;
+          };
+        })(),
+        getDb: () => null,
+      });
+      await decideWakeBriefForSession(
+        {
+          sessionId: 'live-ev-none',
+          tenantId: 't1',
+          userId: 'u1',
+          bucket: 'recent',
+          isReconnect: true,
+          lang: 'en',
+        },
+        { recorder },
+      );
+      const timeline = await recorder.getTimeline('live-ev-none');
+      const selected = timeline?.events.find((e) => e.name === 'wake_brief_selected');
+      expect(selected?.metadata?.selected_continuation_kind).toBe('none_with_reason');
+      expect(selected?.metadata?.none_with_reason).toBe('all_providers_suppressed');
+    });
+
+    it('continuation_decision_finished carries providerResults summary', async () => {
+      const recorder = createWakeTimelineRecorder({
+        now: (() => {
+          let t = 1_700_000_000_000;
+          return () => {
+            const d = new Date(t);
+            t += 5;
+            return d;
+          };
+        })(),
+        getDb: () => null,
+      });
+      await decideWakeBriefForSession(
+        {
+          sessionId: 'live-ev-final',
+          tenantId: 't1',
+          userId: 'u1',
+          bucket: 'first',
+          isReconnect: false,
+          lang: 'en',
+        },
+        { recorder },
+      );
+      const timeline = await recorder.getTimeline('live-ev-final');
+      const finished = timeline?.events.find((e) => e.name === 'continuation_decision_finished');
+      const results = (finished?.metadata?.providerResults as Array<{ key: string; status: string }>) ?? [];
+      expect(results.length).toBeGreaterThan(0);
+      expect(results.find((r) => r.key === 'voice_wake_brief')).toBeDefined();
+    });
+  });
+
+  describe('best-effort policy', () => {
+    it('returns the decision even when the recorder throws on every call', async () => {
+      const exploding = {
+        startSession: () => { throw new Error('boom'); },
+        recordEvent: () => { throw new Error('boom'); },
+        endSession: async () => { throw new Error('boom'); },
+        getTimeline: async () => null,
+        listRecent: async () => [],
+        reset: () => {},
+      };
+      const decision = await decideWakeBriefForSession(
+        {
+          sessionId: 'live-explode',
+          tenantId: 't1',
+          userId: 'u1',
+          bucket: 'first',
+          isReconnect: false,
+          lang: 'en',
+        },
+        { recorder: exploding as any },
+      );
+      expect(decision).toBeDefined();
+      expect(decision.selectedContinuation?.kind).toBe('wake_brief');
+    });
+  });
+});


### PR DESCRIPTION
## B0d.4 (gateway-side) — activate the wake-brief decision path

Closes the loop on the B0d framework: the voice-wake-brief provider from B0d.2 now actually fires on every ORB session-start, the 3 continuation_decision_* timeline events from B0d.3 now actually emit, and the decision is exposed to the frontend via a new \`meta.wake_brief\` response field.

**This PR is additive and read-only from the user's perspective.** The selected continuation does NOT yet drive the spoken greeting — that swap-in is the **vitana-v1 follow-up PR** (B0d.4-frontend), gated on a week of timeline data per the measure-before-optimize discipline.

## Module

\`services/gateway/src/services/wake-brief-wiring.ts\`

- One-time **idempotent registration** of voice-wake-brief with \`defaultProviderRegistry\` (safe across hot-reloads).
- \`decideWakeBriefForSession(args)\` runs \`decideGreetingPolicy()\` (the A4 seam) → \`decideContinuation()\` with \`VoiceWakeBriefInputs\` on \`ctx.extra\`.
- Emits the 3 wake-timeline events the user locked in spec:
  - \`continuation_decision_started\` (surface, bucket, isReconnect, policy, lang)
  - \`wake_brief_selected\` (decisionId, selected_continuation_kind; \`none_with_reason\` on full suppression)
  - \`continuation_decision_finished\` (decisionId, durationMs, providerResults summary)
- Returns the full \`AssistantContinuationDecision\` so the caller attaches it to session + response. **Best-effort recorder calls — even an exploding recorder doesn't break the decision.**

## orb-live.ts integration

- Side-effect import registers the provider.
- In \`/live/session/start\` right after \`session_start_received\` is recorded, calls \`decideWakeBriefForSession\` with existing variables (\`lastSessionInfo.bucket\`, \`isReconnectStart\`, \`lang\`).
- Decision attached to the session as \`(session as any).wakeBriefDecision\` for downstream observability.
- Response payload gains optional \`meta.wake_brief\`:
  \`\`\`json
  {
    \"decision_id\": \"…\",
    \"selected_kind\": \"wake_brief\" | \"none_with_reason\",
    \"user_facing_line\": \"Welcome back.\" | \"\",
    \"suppression_reason\": \"all_providers_suppressed\" | null
  }
  \`\`\`
  Frontend consumes this in the vitana-v1 follow-up. \`null\` is a valid expected state until then.
- **No prompt rewiring.** The continuation is observable but does NOT yet drive the spoken greeting — premature swap-in would hide the failure mode the way \`instantGreeting.ts\` did for 6 months ([orb_ios_greeting_silent_root_cause.md](https://github.com/exafyltd/vitana-platform/blob/main/.claude/projects/-home-dstev/memory/orb_ios_greeting_silent_root_cause.md)).

## Tests

- **+11 new tests:**
  - Provider auto-registered with default registry on import; idempotent.
  - \`decideWakeBriefForSession\` returns wake_brief on bucket=first/long; honors lang=de.
  - Transparent reconnect → all_providers_suppressed; provider row carries \`greeting_policy_skip\`.
  - 3 timeline events fire in documented order; metadata payloads verified.
  - \`wake_brief_selected\` carries \`selected_continuation_kind\` on returned + \`none_with_reason\` on suppression.
  - \`continuation_decision_finished\` carries providerResults summary.
  - Best-effort: exploding recorder still returns a valid decision.
- **430/430** orb-suite + assistant-continuation + wake-timeline + wake-brief-wiring tests pass.
- \`npm run build\` clean.

## What's next

- **B0d.4-frontend (vitana-v1 PR):** silence \`instantGreeting.ts\`'s spoken fallback, consume \`meta.wake_brief.user_facing_line\` as the first spoken sentence when present, emit frontend-side timeline events (\`wake_clicked\`, \`client_context_received\`, \`ws_opened\`, \`first_audio_output\` from the renderer's perspective).
- **After a week of timeline data:** investigate where wake latency actually lives and tune ONLY the slowest source. No tuning until measurement confirms the bottleneck.

## Test plan

- [x] 11 new tests pass
- [x] No regression in 419 prior tests
- [x] TypeScript build clean
- [x] Decision call is wrapped in try/catch — wake path never broken by telemetry
- [x] Response \`meta.wake_brief\` is additive; null is valid

🤖 Generated with [Claude Code](https://claude.com/claude-code)