### PR TITLE
feat(orb): B0d.4-event-ingest - POST wake-timeline/event endpoint (VTID-02919)

### DIFF
--- a/services/gateway/src/routes/voice-wake-timeline.ts
+++ b/services/gateway/src/routes/voice-wake-timeline.ts
@@ -8,23 +8,44 @@
  *       Recent wakes (most-recent-first). Used by the Command Hub
  *       "ORB Wake Timeline" panel on the Journey Context screen.
  *
- * Auth: exafy_admin required. Both endpoints expose session-level
+ * Auth (GET): exafy_admin required. Both endpoints expose session-level
  * latency + disconnect telemetry that crosses tenant boundaries.
  *
- * B0d.3 hard rule: read-only. No tuning, no thresholds, no alerting
- * here. Surface only.
+ * B0d.3 hard rule: GETs are read-only — no tuning, no thresholds, no
+ * alerting. Surface only.
+ *
+ * VTID-02919 (B0d.4-event-ingest):
+ *
+ *   POST /api/v1/voice/wake-timeline/event
+ *       Frontend-emitted timeline event. Body:
+ *         { sessionId, name, metadata?, at? }
+ *       Validation:
+ *         - name MUST be a known WAKE_TIMELINE_EVENT_NAMES value.
+ *         - sessionId required + non-empty.
+ *       Auth: optional. The frontend may be anonymous (ORB widget on
+ *       a public page) or authenticated. The event is forwarded to the
+ *       default recorder; downstream tenant_id is whatever the gateway
+ *       already attached to the session via /live/session/start.
+ *       Origin must validate. CSRF surface is low (event ingest only;
+ *       no PII echoed back).
  */
 
-import { Router, Response } from 'express';
+import { Router, Request, Response } from 'express';
 import {
   requireAuthWithTenant,
   requireExafyAdmin,
   AuthenticatedRequest,
+  optionalAuth,
 } from '../middleware/auth-supabase-jwt';
 import { defaultWakeTimelineRecorder } from '../services/wake-timeline/wake-timeline-recorder';
+import {
+  isWakeTimelineEventName,
+  type WakeTimelineEventName,
+} from '../services/wake-timeline/timeline-events';
 
 const router = Router();
 const VTID = 'VTID-02917';
+const INGEST_VTID = 'VTID-02919';
 
 router.get(
   '/voice/wake-timeline',
@@ -80,6 +101,80 @@ router.get(
         ok: false,
         error: (e as Error).message,
         vtid: VTID,
+      });
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/voice/wake-timeline/event (VTID-02919, B0d.4-event-ingest)
+//
+// Accepts a single frontend-emitted timeline event. The 4 events the
+// frontend is uniquely positioned to emit:
+//   - wake_clicked            user tapped ORB
+//   - client_context_received envelope built on the FE
+//   - ws_opened               WebSocket handshake completed on the FE
+//   - first_audio_output      first audio frame rendered to speakers
+//
+// Other event names are accepted too (any from WAKE_TIMELINE_EVENT_NAMES)
+// so the same endpoint can serve future B0d frontend events without a
+// schema change.
+//
+// Best-effort: recorder errors do NOT surface as 5xx — the endpoint
+// returns 200 with `recorded: false` + a reason, so the frontend never
+// fails the wake path on telemetry.
+// ---------------------------------------------------------------------------
+router.post(
+  '/voice/wake-timeline/event',
+  optionalAuth,
+  (req: Request, res: Response) => {
+    try {
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      const sessionId = typeof body.sessionId === 'string' ? body.sessionId.trim() : '';
+      const name = typeof body.name === 'string' ? body.name : '';
+      if (!sessionId) {
+        return res.status(400).json({
+          ok: false,
+          error: 'sessionId is required',
+          vtid: INGEST_VTID,
+        });
+      }
+      if (!isWakeTimelineEventName(name)) {
+        return res.status(400).json({
+          ok: false,
+          error: `unknown wake-timeline event name: ${String(name)}`,
+          vtid: INGEST_VTID,
+        });
+      }
+      const at = typeof body.at === 'string' && body.at.length > 0 ? body.at : undefined;
+      const metadata =
+        body.metadata && typeof body.metadata === 'object' && !Array.isArray(body.metadata)
+          ? (body.metadata as Record<string, unknown>)
+          : undefined;
+
+      try {
+        defaultWakeTimelineRecorder.recordEvent({
+          sessionId,
+          name: name as WakeTimelineEventName,
+          ...(metadata ? { metadata } : {}),
+          ...(at ? { at } : {}),
+        });
+      } catch (e) {
+        // Recorder failure must not break the frontend wake path.
+        return res.json({
+          ok: true,
+          recorded: false,
+          reason: (e as Error).message,
+          vtid: INGEST_VTID,
+        });
+      }
+
+      return res.json({ ok: true, recorded: true, vtid: INGEST_VTID });
+    } catch (e) {
+      return res.status(500).json({
+        ok: false,
+        error: (e as Error).message,
+        vtid: INGEST_VTID,
       });
     }
   },

--- a/services/gateway/test/routes/voice-wake-timeline-ingest.test.ts
+++ b/services/gateway/test/routes/voice-wake-timeline-ingest.test.ts
@@ -1,0 +1,189 @@
+/**
+ * VTID-02919 (B0d.4-event-ingest) — POST /api/v1/voice/wake-timeline/event tests.
+ *
+ * Pure request handler tests via supertest against an Express app
+ * mounting just the wake-timeline router. No DB; the default
+ * recorder operates in DB-less mode so events land in its in-memory
+ * map and we can assert from there.
+ */
+
+import express from 'express';
+import request from 'supertest';
+
+// Bypass auth middleware for the route tests — we just want to verify
+// the handler logic. The route file imports `optionalAuth` lazily so
+// we mock the module at top-level before the router is required.
+jest.mock('../../src/middleware/auth-supabase-jwt', () => ({
+  optionalAuth: (_req: any, _res: any, next: any) => next(),
+  requireAuthWithTenant: (_req: any, _res: any, next: any) => next(),
+  requireExafyAdmin: (_req: any, _res: any, next: any) => next(),
+}));
+
+import { defaultWakeTimelineRecorder } from '../../src/services/wake-timeline/wake-timeline-recorder';
+
+function buildApp() {
+  // Require fresh after mocks are in place.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const router = require('../../src/routes/voice-wake-timeline').default;
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1', router);
+  return app;
+}
+
+describe('B0d.4-event-ingest — POST /api/v1/voice/wake-timeline/event', () => {
+  beforeEach(() => {
+    defaultWakeTimelineRecorder.reset();
+  });
+
+  it('records a known event for a valid request', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/voice/wake-timeline/event')
+      .send({
+        sessionId: 'live-ingest-1',
+        name: 'wake_clicked',
+        metadata: { wakeOrigin: 'orb_tap' },
+      });
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      recorded: true,
+      vtid: 'VTID-02919',
+    });
+    const row = await defaultWakeTimelineRecorder.getTimeline('live-ingest-1');
+    expect(row?.events).toHaveLength(1);
+    expect(row?.events[0].name).toBe('wake_clicked');
+    expect(row?.events[0].metadata).toEqual({ wakeOrigin: 'orb_tap' });
+  });
+
+  it('rejects missing sessionId', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/voice/wake-timeline/event')
+      .send({ name: 'wake_clicked' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/sessionId is required/);
+  });
+
+  it('rejects whitespace-only sessionId', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/voice/wake-timeline/event')
+      .send({ sessionId: '   ', name: 'wake_clicked' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/sessionId is required/);
+  });
+
+  it('rejects unknown event name with a specific reason', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/voice/wake-timeline/event')
+      .send({ sessionId: 'live-1', name: 'made_up_event' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/unknown wake-timeline event name: made_up_event/);
+  });
+
+  it('rejects missing event name', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/voice/wake-timeline/event')
+      .send({ sessionId: 'live-1' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/unknown wake-timeline event name/);
+  });
+
+  it('accepts an explicit at timestamp', async () => {
+    const app = buildApp();
+    const atIso = '2026-05-11T16:00:00.000Z';
+    const res = await request(app)
+      .post('/api/v1/voice/wake-timeline/event')
+      .send({
+        sessionId: 'live-ingest-at',
+        name: 'first_audio_output',
+        at: atIso,
+      });
+    expect(res.status).toBe(200);
+    const row = await defaultWakeTimelineRecorder.getTimeline('live-ingest-at');
+    expect(row?.events[0].at).toBe(atIso);
+  });
+
+  it('drops non-object metadata silently (does not record garbage)', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/voice/wake-timeline/event')
+      .send({
+        sessionId: 'live-bad-md',
+        name: 'ws_opened',
+        metadata: 'not-an-object',
+      });
+    expect(res.status).toBe(200);
+    const row = await defaultWakeTimelineRecorder.getTimeline('live-bad-md');
+    expect(row?.events[0].metadata).toBeUndefined();
+  });
+
+  it('drops array metadata (not a real key/value bag)', async () => {
+    const app = buildApp();
+    await request(app)
+      .post('/api/v1/voice/wake-timeline/event')
+      .send({
+        sessionId: 'live-array-md',
+        name: 'ws_opened',
+        metadata: ['a', 'b'],
+      });
+    const row = await defaultWakeTimelineRecorder.getTimeline('live-array-md');
+    expect(row?.events[0].metadata).toBeUndefined();
+  });
+
+  it('accepts every locked event name (16 in total)', async () => {
+    const app = buildApp();
+    const names = [
+      'wake_clicked',
+      'client_context_received',
+      'ws_opened',
+      'session_start_received',
+      'session_context_built',
+      'continuation_decision_started',
+      'continuation_decision_finished',
+      'wake_brief_selected',
+      'upstream_live_connect_started',
+      'upstream_live_connected',
+      'first_model_output',
+      'first_audio_output',
+      'disconnect',
+      'reconnect_attempt',
+      'reconnect_success',
+      'manual_restart_required',
+    ];
+    for (const name of names) {
+      const res = await request(app)
+        .post('/api/v1/voice/wake-timeline/event')
+        .send({ sessionId: `live-${name}`, name });
+      expect(res.status).toBe(200);
+      expect(res.body.recorded).toBe(true);
+    }
+  });
+
+  it('returns 200 ok:true recorded:false when the recorder throws', async () => {
+    // Patch the recorder to throw, restore after.
+    const original = defaultWakeTimelineRecorder.recordEvent;
+    defaultWakeTimelineRecorder.recordEvent = (() => {
+      throw new Error('synthetic-failure');
+    }) as any;
+    try {
+      const app = buildApp();
+      const res = await request(app)
+        .post('/api/v1/voice/wake-timeline/event')
+        .send({ sessionId: 'live-explode', name: 'wake_clicked' });
+      expect(res.status).toBe(200);
+      expect(res.body).toEqual({
+        ok: true,
+        recorded: false,
+        reason: 'synthetic-failure',
+        vtid: 'VTID-02919',
+      });
+    } finally {
+      defaultWakeTimelineRecorder.recordEvent = original;
+    }
+  });
+});


### PR DESCRIPTION
## B0d.4-event-ingest — frontend timeline-event ingest endpoint

Closes the loop on B0d.3: the gateway now accepts frontend-emitted wake-timeline events so the four FE-uniquely-known events (\`wake_clicked\`, \`client_context_received\`, \`ws_opened\`, \`first_audio_output\`) can land on the same per-session row as the gateway-emitted ones. With B0d.4 (PR #2050) just merged, this is the small follow-up that lets the upcoming vitana-v1 PR be self-contained.

## Endpoint

\`POST /api/v1/voice/wake-timeline/event\`

| Field      | Required | Notes                                                  |
|------------|----------|--------------------------------------------------------|
| sessionId  | yes      | Non-empty trimmed string                               |
| name       | yes      | MUST ∈ \`WAKE_TIMELINE_EVENT_NAMES\` (16 locked names)   |
| metadata   | no       | Plain object only; arrays / strings silently dropped   |
| at         | no       | ISO 8601; recorder injects \`Date.now()\` if absent      |

Auth: \`optionalAuth\` — the ORB widget runs on public pages where the user may be anonymous. The gateway already attached \`tenant_id\` / \`user_id\` to the session via \`/live/session/start\` so the timeline row is correctly scoped.

## Best-effort policy

Recorder failures return \`200 ok:true recorded:false reason:…\`. The frontend must never fail the wake path because telemetry crashed — matches the policy used in orb-live.ts's gateway-side emissions.

## Tests (+10)

- Valid happy-path request → 200 recorded:true.
- Missing / whitespace-only sessionId → 400.
- Unknown name → 400, with reason echoing the bad value.
- Missing name → 400.
- Explicit \`at\` timestamp preserved on the stored event.
- Non-object / array metadata silently dropped.
- All 16 locked event names accepted.
- Recorder failure → 200 \`recorded:false\` with reason.
- **440/440** orb-suite + assistant-continuation + wake-timeline + wake-brief-wiring + ingest tests pass.
- \`npm run build\` clean.

## What's next

- **B0d.4-frontend (vitana-v1 PR):** silence instantGreeting.ts spoken fallback, consume \`meta.wake_brief.user_facing_line\` from \`/live/session/start\`, and POST the 4 frontend-side timeline events to this endpoint.

## Test plan

- [x] 10 new tests pass
- [x] No regression in 430 prior tests
- [x] TypeScript build clean

🤖 Generated with [Claude Code](https://claude.com/claude-code)