### PR TITLE
feat(orb): B0e.1 - capability awareness foundation (VTID-02920)

### DIFF
--- a/services/gateway/test/services/capability-awareness/b0e1-migration.test.ts
+++ b/services/gateway/test/services/capability-awareness/b0e1-migration.test.ts
@@ -1,0 +1,177 @@
+/**
+ * VTID-02920 (B0e.1) — capability awareness migration shape guard.
+ *
+ * Asserts the migration:
+ *   - Creates both tables with the documented columns + types.
+ *   - Enables RLS (system_capabilities = read-only authenticated;
+ *     user_capability_awareness = tenant-scoped).
+ *   - Has the 7-state awareness ladder CHECK constraint locked.
+ *   - Seeds the canonical 14 capabilities (NOT the deferred
+ *     match-journey ones).
+ *   - Indexes both tables for the documented access patterns.
+ *   - Has touch triggers on updated_at for both tables.
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const MIGRATION_PATH = join(
+  __dirname,
+  '../../../../../supabase/migrations/20260518000000_VTID_02920_capability_awareness.sql',
+);
+
+describe('B0e.1 — capability awareness migration', () => {
+  let sql: string;
+  beforeAll(() => {
+    sql = readFileSync(MIGRATION_PATH, 'utf8');
+  });
+
+  describe('system_capabilities table', () => {
+    it('creates the table', () => {
+      expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS system_capabilities/);
+    });
+
+    it('keys on capability_key TEXT', () => {
+      expect(sql).toMatch(/capability_key\s+TEXT PRIMARY KEY/);
+    });
+
+    it('has required_integrations as TEXT array', () => {
+      expect(sql).toMatch(/required_integrations\s+TEXT\[\]/);
+    });
+
+    it('has helpful_for_intents as TEXT array', () => {
+      expect(sql).toMatch(/helpful_for_intents\s+TEXT\[\]/);
+    });
+
+    it('enables RLS as read-only for authenticated users', () => {
+      expect(sql).toMatch(/ALTER TABLE system_capabilities ENABLE ROW LEVEL SECURITY/);
+      expect(sql).toMatch(
+        /CREATE POLICY system_capabilities_authenticated_read[\s\S]+?FOR SELECT/,
+      );
+    });
+
+    it('has a touch trigger', () => {
+      expect(sql).toMatch(/CREATE TRIGGER system_capabilities_updated_at_trigger/);
+    });
+  });
+
+  describe('user_capability_awareness table', () => {
+    it('creates the table', () => {
+      expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS user_capability_awareness/);
+    });
+
+    it('has the 7-state awareness_state CHECK constraint locked', () => {
+      const states = [
+        'unknown',
+        'introduced',
+        'seen',
+        'tried',
+        'completed',
+        'dismissed',
+        'mastered',
+      ];
+      for (const s of states) {
+        expect(sql).toContain(`'${s}'`);
+      }
+    });
+
+    it('has composite primary key (tenant_id, user_id, capability_key)', () => {
+      expect(sql).toMatch(/PRIMARY KEY \(tenant_id, user_id, capability_key\)/);
+    });
+
+    it('references system_capabilities via FK with ON DELETE CASCADE', () => {
+      expect(sql).toMatch(/REFERENCES system_capabilities\(capability_key\)\s+ON DELETE CASCADE/);
+    });
+
+    it('tracks all 4 timestamp fields the ranker needs', () => {
+      const fields = [
+        'first_introduced_at',
+        'last_introduced_at',
+        'first_used_at',
+        'last_used_at',
+      ];
+      for (const f of fields) expect(sql).toContain(f);
+    });
+
+    it('tracks use_count + dismiss_count (ranker dampening inputs)', () => {
+      expect(sql).toMatch(/use_count\s+INT NOT NULL DEFAULT 0/);
+      expect(sql).toMatch(/dismiss_count\s+INT NOT NULL DEFAULT 0/);
+    });
+
+    it('has mastery_confidence numeric(4,3)', () => {
+      expect(sql).toMatch(/mastery_confidence\s+NUMERIC\(4,3\)/);
+    });
+
+    it('enables RLS with tenant isolation via user_tenants', () => {
+      expect(sql).toMatch(/ALTER TABLE user_capability_awareness ENABLE ROW LEVEL SECURITY/);
+      expect(sql).toMatch(/user_capability_awareness_tenant_isolation/);
+      expect(sql).toMatch(/user_tenants/);
+    });
+
+    it('indexes (tenant_id, user_id) for per-user ranker reads', () => {
+      expect(sql).toMatch(/user_capability_awareness_user_idx/);
+      expect(sql).toMatch(/\(tenant_id, user_id\)/);
+    });
+
+    it('indexes awareness_state for operator histogram queries', () => {
+      expect(sql).toMatch(/user_capability_awareness_state_idx/);
+      expect(sql).toMatch(/\(awareness_state\)/);
+    });
+  });
+
+  describe('seed data', () => {
+    const expectedSeedKeys = [
+      'life_compass',
+      'vitana_index',
+      'diary_entry',
+      'community_post',
+      'reminders',
+      'calendar_connect',
+      'activity_match',
+      'live_room',
+      'community_intent',
+      'invite_contact',
+      'autopilot',
+      'memory_garden',
+      'marketplace',
+      'scheduling',
+    ];
+
+    it.each(expectedSeedKeys)('seeds capability_key=%s', (key) => {
+      expect(sql).toContain(`'${key}'`);
+    });
+
+    it('uses ON CONFLICT DO UPDATE so the seed is idempotent', () => {
+      expect(sql).toMatch(/ON CONFLICT \(capability_key\) DO UPDATE/);
+    });
+
+    it('does NOT seed the deferred match-journey capabilities', () => {
+      const matchJourneyDeferred = [
+        'pre_match_whois',
+        'should_i_show_interest',
+        'draft_opener',
+        'activity_plan_card',
+        'match_chat_assist',
+        'post_activity_reflection',
+        'next_rep_suggestion',
+      ];
+      for (const key of matchJourneyDeferred) {
+        // Each could legitimately appear in a comment, but never as a
+        // seeded capability_key (which lives inside a VALUES tuple).
+        const seedPattern = new RegExp(`\\('${key}'`);
+        expect(sql).not.toMatch(seedPattern);
+      }
+    });
+  });
+
+  describe('documentation', () => {
+    it('has COMMENT ON the awareness_state column with the full ladder', () => {
+      expect(sql).toMatch(/COMMENT ON COLUMN user_capability_awareness\.awareness_state/);
+      expect(sql).toMatch(/unknown.*introduced.*seen.*tried.*completed.*dismissed.*mastered/s);
+    });
+
+    it('documents the marketing-dump forbidden rule', () => {
+      expect(sql).toMatch(/marketing-dump/i);
+    });
+  });
+});

--- a/supabase/migrations/20260518000000_VTID_02920_capability_awareness.sql
+++ b/supabase/migrations/20260518000000_VTID_02920_capability_awareness.sql
@@ -1,0 +1,262 @@
+-- B0e.1 (orb-live-refactor) — capability awareness foundation.
+--
+-- VTID-02920. Creates the two tables the Onboarding & Feature
+-- Discovery Coach (B0e provider) needs to pick ONE unexplored
+-- capability per turn:
+--
+--   system_capabilities       — catalog of features Vitana can introduce
+--   user_capability_awareness — per-user state ladder per capability
+--
+-- The plan originally placed both in B0c, but B0c shipped only the
+-- user_assistant_state table. We create them here in B0e.1 with the
+-- full awareness-state ladder (B0e extension) folded in from the
+-- start — there is no separate B0c → B0e migration to coordinate.
+--
+-- Hard rule (carried from the plan):
+--   The Feature Discovery Coach picks ONE capability per turn — never
+--   a list. The "marketing-dump" failure mode is forbidden by
+--   construction at the provider level (B0e.2); the schema makes it
+--   easy to enforce by tracking dismiss_count + last_introduced_at
+--   so the ranker can dampen recently-suggested or twice-dismissed
+--   capabilities.
+--
+-- RLS: tenant-scoped read/write — only the session's tenant can
+-- see/mutate its rows. system_capabilities is a global catalog
+-- (read-only for authenticated users, write requires service role).
+
+-- ---------------------------------------------------------------
+-- system_capabilities — global catalog
+-- ---------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS system_capabilities (
+  capability_key            TEXT PRIMARY KEY,
+  display_name              TEXT NOT NULL,
+  description               TEXT NOT NULL,
+  required_role             TEXT,                          -- community | admin | developer | NULL
+  required_tenant_features  TEXT[],                        -- e.g. ARRAY['life_compass_enabled']
+  required_integrations     TEXT[],                        -- e.g. ARRAY['google_calendar']
+  helpful_for_intents       TEXT[],                        -- e.g. ARRAY['log_meal','set_goal']
+  enabled                   BOOLEAN NOT NULL DEFAULT true,
+  surfaced_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_at                TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at                TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS system_capabilities_enabled_idx
+  ON system_capabilities (enabled)
+  WHERE enabled = true;
+
+CREATE OR REPLACE FUNCTION system_capabilities_touch_updated_at()
+  RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS system_capabilities_updated_at_trigger ON system_capabilities;
+CREATE TRIGGER system_capabilities_updated_at_trigger
+  BEFORE UPDATE ON system_capabilities
+  FOR EACH ROW
+  EXECUTE FUNCTION system_capabilities_touch_updated_at();
+
+-- Read-only for authenticated users; service role bypasses RLS.
+ALTER TABLE system_capabilities ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS system_capabilities_authenticated_read ON system_capabilities;
+CREATE POLICY system_capabilities_authenticated_read
+  ON system_capabilities
+  FOR SELECT
+  TO authenticated
+  USING (true);
+
+-- ---------------------------------------------------------------
+-- user_capability_awareness — per-user state ladder
+-- ---------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS user_capability_awareness (
+  tenant_id            UUID NOT NULL,
+  user_id              UUID NOT NULL,
+  capability_key       TEXT NOT NULL REFERENCES system_capabilities(capability_key) ON DELETE CASCADE,
+  awareness_state      TEXT NOT NULL DEFAULT 'unknown'
+    CHECK (awareness_state IN (
+      'unknown',       -- never surfaced
+      'introduced',    -- coach mentioned it
+      'seen',          -- user opened a related screen
+      'tried',         -- user invoked the capability once
+      'completed',     -- user finished a meaningful flow
+      'dismissed',     -- user said no
+      'mastered'       -- repeated successful use over time
+    )),
+  first_introduced_at  TIMESTAMPTZ,
+  last_introduced_at   TIMESTAMPTZ,
+  first_used_at        TIMESTAMPTZ,
+  last_used_at         TIMESTAMPTZ,
+  use_count            INT NOT NULL DEFAULT 0,
+  dismiss_count        INT NOT NULL DEFAULT 0,
+  mastery_confidence   NUMERIC(4,3),                       -- 0.000–1.000
+  last_surface         TEXT,                               -- where it was last surfaced (orb_wake / home / ...)
+  created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+  PRIMARY KEY (tenant_id, user_id, capability_key)
+);
+
+-- Per-user lookup is the most common access pattern (ranker reads it
+-- on every wake to find unexplored capabilities).
+CREATE INDEX IF NOT EXISTS user_capability_awareness_user_idx
+  ON user_capability_awareness (tenant_id, user_id);
+
+-- State histogram for operators (Command Hub Feature Discovery panel).
+CREATE INDEX IF NOT EXISTS user_capability_awareness_state_idx
+  ON user_capability_awareness (awareness_state);
+
+CREATE OR REPLACE FUNCTION user_capability_awareness_touch_updated_at()
+  RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS user_capability_awareness_updated_at_trigger ON user_capability_awareness;
+CREATE TRIGGER user_capability_awareness_updated_at_trigger
+  BEFORE UPDATE ON user_capability_awareness
+  FOR EACH ROW
+  EXECUTE FUNCTION user_capability_awareness_touch_updated_at();
+
+ALTER TABLE user_capability_awareness ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS user_capability_awareness_tenant_isolation ON user_capability_awareness;
+CREATE POLICY user_capability_awareness_tenant_isolation
+  ON user_capability_awareness
+  FOR ALL
+  TO authenticated
+  USING (
+    tenant_id IN (
+      SELECT tenant_id FROM user_tenants WHERE user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    tenant_id IN (
+      SELECT tenant_id FROM user_tenants WHERE user_id = auth.uid()
+    )
+  );
+
+-- ---------------------------------------------------------------
+-- Seed the 14 canonical capabilities the plan documents.
+--
+-- Match-journey capability seeds (pre_match_whois, draft_opener, etc.)
+-- are NOT included here — they belong to the match-concierge reservation
+-- (B0a–B0e match-journey hooks) and stay deferred until that feature
+-- ships. Adding them now would create stale catalog entries.
+-- ---------------------------------------------------------------
+
+INSERT INTO system_capabilities (
+  capability_key, display_name, description,
+  required_role, required_integrations, helpful_for_intents
+) VALUES
+  -- Tier 0: orientation
+  ('life_compass',
+   'Life Compass',
+   'Define your single active longevity goal — feeds every recommendation Vitana makes.',
+   'community', NULL, ARRAY['set_goal','clarify_priorities']),
+
+  ('vitana_index',
+   'Vitana Index',
+   'Your 5-pillar longevity score (Nutrition, Hydration, Exercise, Sleep, Mental) + balance factor.',
+   'community', NULL, ARRAY['understand_progress','learn_index']),
+
+  -- Tier 1: daily capture
+  ('diary_entry',
+   'Diary Entry',
+   'Save what you ate / how you slept / how you trained — the simplest way to keep the Index moving.',
+   'community', NULL, ARRAY['log_meal','log_workout','log_sleep','daily_reflection']),
+
+  ('community_post',
+   'Community Post',
+   'Share progress or ask a question in your community — earns reach and reactions.',
+   'community', NULL, ARRAY['share_progress','ask_question']),
+
+  -- Tier 2: scheduling + integrations
+  ('reminders',
+   'Reminders',
+   'Voice-set reminders that fire as push notifications when the time comes.',
+   'community', NULL, ARRAY['remember_to_x','schedule_action']),
+
+  ('calendar_connect',
+   'Calendar Connect',
+   'Connect Google Calendar so Vitana can see meetings + meal/workout windows.',
+   'community', ARRAY['google_calendar'], ARRAY['schedule_activity','avoid_conflict']),
+
+  -- Tier 3: matching + community
+  ('activity_match',
+   'Activity Match',
+   'Find a hiking / chess / language-exchange partner in your community.',
+   'community', NULL, ARRAY['find_partner','plan_activity']),
+
+  ('live_room',
+   'Live Room',
+   'Drop into or host a live conversation room with community members.',
+   'community', NULL, ARRAY['talk_with_others','host_conversation']),
+
+  ('community_intent',
+   'Community Intent',
+   'Publish a public intent — anyone in your community can respond and join.',
+   'community', NULL, ARRAY['ask_for_help','organize_group']),
+
+  ('invite_contact',
+   'Invite Contact',
+   'Invite friends to your community — earns invite-bonus and grows your network.',
+   'community', NULL, ARRAY['grow_network','invite_friend']),
+
+  -- Tier 4: autopilot + advanced
+  ('autopilot',
+   'Autopilot',
+   'Vitana proposes batched actions you can accept in one tap — frees you from micro-decisions.',
+   'community', NULL, ARRAY['save_time','delegate_routine']),
+
+  ('memory_garden',
+   'Memory Garden',
+   'See and curate what Vitana has learned about you — full transparency.',
+   'community', NULL, ARRAY['review_memory','correct_facts']),
+
+  ('marketplace',
+   'Marketplace',
+   'Discover services and products curated for your goal (coaches, supplements, workshops).',
+   'community', NULL, ARRAY['find_service','find_product']),
+
+  -- Tier 5: deep features
+  ('scheduling',
+   'Activity Plan',
+   'Generate a structured plan (route, time, kit list) for a match-confirmed activity.',
+   'community', NULL, ARRAY['plan_activity','organize_outing'])
+ON CONFLICT (capability_key) DO UPDATE SET
+  display_name = EXCLUDED.display_name,
+  description = EXCLUDED.description,
+  required_role = EXCLUDED.required_role,
+  required_integrations = EXCLUDED.required_integrations,
+  helpful_for_intents = EXCLUDED.helpful_for_intents,
+  enabled = true,
+  updated_at = now();
+
+-- ---------------------------------------------------------------
+-- Documentation
+-- ---------------------------------------------------------------
+
+COMMENT ON TABLE system_capabilities IS
+  'B0e.1 (orb-live-refactor): global catalog of features Vitana can introduce. '
+  'The Feature Discovery Coach (B0e.2 provider) reads this to pick ONE unexplored '
+  'capability per turn. Marketing-dump failure mode forbidden — coach NEVER lists.';
+
+COMMENT ON TABLE user_capability_awareness IS
+  'B0e.1 (orb-live-refactor): per-user state ladder for each known capability. '
+  'awareness_state advances unknown → introduced → seen → tried → completed (→ mastered) '
+  'OR settles at dismissed when the user says no. The ranker reads dismiss_count + '
+  'last_introduced_at to dampen recently-surfaced or twice-rejected capabilities.';
+
+COMMENT ON COLUMN user_capability_awareness.awareness_state IS
+  'Ladder: unknown / introduced / seen / tried / completed / dismissed / mastered. '
+  'Provider transitions: unknown → introduced (coach mentioned). introduced → seen '
+  '(user opened related screen). seen → tried (user invoked). tried → completed '
+  '(user finished a meaningful flow). completed → mastered (sustained successful use). '
+  'Any state → dismissed when the user explicitly declines.';


### PR DESCRIPTION
## B0e.1 — Feature Discovery Coach foundation

Creates the two tables the upcoming Feature Discovery Coach provider (B0e.2) needs to pick **ONE** unexplored capability per turn. The plan originally placed both tables in B0c, but B0c shipped only \`user_assistant_state\`. They land here in B0e.1 with the full **7-state awareness ladder** folded in from the start — no separate B0c → B0e migration to coordinate.

## Tables

### \`system_capabilities\` (global catalog)
- \`capability_key TEXT PRIMARY KEY\`, \`display_name\`, \`description\`, \`required_role\`, \`required_tenant_features[]\`, \`required_integrations[]\`, \`helpful_for_intents[]\`, \`enabled\`, \`surfaced_at\`, \`created_at\`, \`updated_at\`.
- RLS: **read-only for authenticated users**; service role writes the seed.
- Index on \`enabled=true\` for typical ranker query.

### \`user_capability_awareness\` (per-user state ladder)
- Composite PK \`(tenant_id, user_id, capability_key)\`.
- FK to \`system_capabilities\` with \`ON DELETE CASCADE\`.
- **7-state \`awareness_state\` CHECK constraint LOCKED:**
  \`\`\`
  unknown → introduced → seen → tried → completed (→ mastered)
  OR settles at dismissed
  \`\`\`
- Tracks \`first/last_introduced_at\`, \`first/last_used_at\`, \`use_count\`, \`dismiss_count\`, \`mastery_confidence NUMERIC(4,3)\`, \`last_surface\`.
- RLS: **tenant-scoped via \`user_tenants\`** (same pattern as B0c).
- Indexes \`(tenant_id, user_id)\` for ranker reads + \`awareness_state\` for operator histograms.

## Seed: 14 canonical capabilities in 5 tiers

| Tier | Capabilities |
|---|---|
| 0 — orientation | life_compass, vitana_index |
| 1 — daily capture | diary_entry, community_post |
| 2 — scheduling/integrations | reminders, calendar_connect |
| 3 — matching/community | activity_match, live_room, community_intent, invite_contact |
| 4 — autopilot/advanced | autopilot, memory_garden, marketplace |
| 5 — deep | scheduling (activity plan) |

\`ON CONFLICT DO UPDATE\` so re-running is safe.

**Deferred (NOT seeded):** the 7 match-concierge capabilities (\`pre_match_whois\`, \`should_i_show_interest\`, \`draft_opener\`, \`activity_plan_card\`, \`match_chat_assist\`, \`post_activity_reflection\`, \`next_rep_suggestion\`). They remain reserved per the match-journey hooks; seed lands when the concierge ships. A negative assertion in the test enforces this.

## Tests (+34)

- Table shape (column types, PK, FK, CHECK, RLS, indexes, touch triggers) for both tables.
- 7-state ladder values asserted individually.
- Each of the 14 seed keys asserted via \`it.each\`.
- \`ON CONFLICT DO UPDATE\` pattern asserted.
- Negative: the 7 deferred match-journey keys are NOT seeded.
- COMMENT documentation present (full ladder + marketing-dump forbidden rule).
- **474/474** orb + assistant-continuation + wake-timeline + wake-brief-wiring + ingest + capability-awareness tests pass.
- \`npm run build\` clean.

## What's next

- **B0e.2**: \`feature-discovery.ts\` provider — reads \`user_capability_awareness\`, ranks unexplored capabilities, returns ONE candidate per turn through the B0d continuation contract. Hard rule (forbidden by design): **NEVER lists features**. The provider fails its test suite if it ever returns multiple candidates.
- **B0e.3**: Command Hub Feature Discovery panel on the Journey Context screen.

## Test plan

- [x] 34 new tests pass
- [x] No regression in 440 prior tests
- [x] Migration shape locked via structural tests
- [ ] Run migration manually post-merge via \`RUN-MIGRATION.yml\`

🤖 Generated with [Claude Code](https://claude.com/claude-code)