### PR TITLE
feat(orb): B0e.2 - Feature Discovery provider (VTID-02921)

### DIFF
--- a/services/gateway/src/services/assistant-continuation/providers/feature-discovery.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/feature-discovery.ts
@@ -1,0 +1,459 @@
+/**
+ * VTID-02921 (B0e.2) — Feature Discovery continuation provider.
+ *
+ * Picks EXACTLY ONE unexplored capability per decision OR suppresses
+ * with a concrete reason. Never lists. Never advances awareness state
+ * inside selection — that is a separate event/update path (an explicit
+ * FEATURE_DISCOVERY_OFFERED event in B0e.3+ wiring will trigger the
+ * state advance to `introduced`).
+ *
+ * Scope guardrails (from the user's locked B0e.2 spec):
+ *   - Provider kind: `feature_discovery`.
+ *   - Picks EXACTLY ONE capability per decision. Returning multiple is
+ *     a test failure.
+ *   - Never hardcodes copy in `orb/live/instruction/*`. All user-facing
+ *     text comes from the capability's display_name + description
+ *     (which lives in `system_capabilities`).
+ *   - Respects the 7-state ladder: dismissed / mastered / completed
+ *     never resurfaced casually.
+ *   - Surfaces: `orb_turn_end`, `text_turn_end`, `home`.
+ *     **NOT `orb_wake`** — wake stays clean + fast. The provider does
+ *     not even register itself for that surface unless explicitly
+ *     opted in via `opts.includeOrbWake`.
+ *   - Priority 30 (lower than wake_brief 80, reminder, match_journey).
+ *
+ * Match-related capability rule:
+ *   - The 7 deferred match-concierge capabilities (pre_match_whois,
+ *     should_i_show_interest, draft_opener, activity_plan_card,
+ *     match_chat_assist, post_activity_reflection, next_rep_suggestion)
+ *     PLUS the seeded `activity_match` are flagged as match-related.
+ *   - Match-related capabilities ONLY appear when the current
+ *     `envelopeJourneySurface` is a match surface (intent_board,
+ *     intent_card, pre_match_whois, match_detail, match_chat,
+ *     activity_plan, matches_hub).
+ *   - Non-match surfaces NEVER get match-related candidates.
+ *
+ * Data inputs (read-only):
+ *   - `system_capabilities` — global catalog of features (B0e.1).
+ *   - `user_capability_awareness` — per-user state ladder (B0e.1).
+ *
+ * The provider is purely a SELECTION function. State advancement
+ * (introduced → seen → tried → completed → mastered, or → dismissed)
+ * happens through dedicated event/RPC paths that B0e.3+ wires. Doing
+ * mutation inside selection would couple the ranker to a side-effect
+ * surface that B0d.3's reliability timeline can't observe.
+ */
+
+import { randomUUID } from 'crypto';
+import type {
+  AssistantContinuation,
+  ContinuationProvider,
+  ContinuationDecisionContext,
+  ContinuationSurface,
+  ProviderResult,
+} from '../types';
+import { defaultProviderRegistry } from '../provider-registry';
+
+// ---------------------------------------------------------------------------
+// Public types
+// ---------------------------------------------------------------------------
+
+export type AwarenessState =
+  | 'unknown'
+  | 'introduced'
+  | 'seen'
+  | 'tried'
+  | 'completed'
+  | 'dismissed'
+  | 'mastered';
+
+export interface CapabilityRow {
+  capability_key: string;
+  display_name: string;
+  description: string;
+  required_role: string | null;
+  required_tenant_features: string[] | null;
+  required_integrations: string[] | null;
+  helpful_for_intents: string[] | null;
+  enabled: boolean;
+}
+
+export interface AwarenessRow {
+  capability_key: string;
+  awareness_state: AwarenessState;
+  first_introduced_at: string | null;
+  last_introduced_at: string | null;
+  first_used_at: string | null;
+  last_used_at: string | null;
+  use_count: number;
+  dismiss_count: number;
+  mastery_confidence: number | null;
+  last_surface: string | null;
+}
+
+/**
+ * Read-only data source for the feature-discovery ranker. Injectable
+ * so tests can pass canned data and the production binding can hit
+ * Supabase.
+ */
+export interface CapabilityFetcher {
+  listCapabilities(): Promise<CapabilityRow[]>;
+  listAwareness(args: { tenantId: string; userId: string }): Promise<AwarenessRow[]>;
+}
+
+// ---------------------------------------------------------------------------
+// Surface + capability classifications
+// ---------------------------------------------------------------------------
+
+export const FEATURE_DISCOVERY_PROVIDER_KEY = 'feature_discovery' as const;
+const DEFAULT_PRIORITY = 30;
+
+/** Default surfaces (orb_wake intentionally excluded — wake stays fast). */
+export const DEFAULT_FEATURE_DISCOVERY_SURFACES: ReadonlyArray<ContinuationSurface> = [
+  'orb_turn_end',
+  'text_turn_end',
+  'home',
+];
+
+/** Match-related journey surfaces from the B0a envelope. */
+export const MATCH_JOURNEY_SURFACES: ReadonlySet<string> = new Set([
+  'intent_board',
+  'intent_card',
+  'pre_match_whois',
+  'match_detail',
+  'match_chat',
+  'activity_plan',
+  'matches_hub',
+]);
+
+/**
+ * Capability keys flagged as match-related. Includes the 7 deferred
+ * match-concierge capabilities (which will be seeded by a future slice)
+ * plus the already-seeded `activity_match`. A capability in this set
+ * is ONLY surfaced when the current envelope surface is in
+ * MATCH_JOURNEY_SURFACES.
+ */
+export const MATCH_RELATED_CAPABILITY_KEYS: ReadonlySet<string> = new Set([
+  // Deferred (B0e.1 does NOT seed these — they ship with the concierge).
+  'pre_match_whois',
+  'should_i_show_interest',
+  'draft_opener',
+  'activity_plan_card',
+  'match_chat_assist',
+  'post_activity_reflection',
+  'next_rep_suggestion',
+  // Seeded in B0e.1.
+  'activity_match',
+]);
+
+/**
+ * Awareness states that disqualify a capability from being surfaced
+ * casually. Each is a hard-skip in the ranker.
+ */
+const TERMINAL_AWARENESS_STATES: ReadonlySet<AwarenessState> = new Set([
+  'dismissed',
+  'completed',
+  'mastered',
+]);
+
+/** Threshold beyond which the user has clearly said "stop". */
+const DISMISS_HARD_BACKOFF = 2;
+
+/** Dampen recently-introduced capabilities for this many days. */
+const RECENT_INTRODUCTION_WINDOW_MS = 7 * 24 * 60 * 60 * 1000;
+
+// ---------------------------------------------------------------------------
+// Ranker — pure function over (capability, awareness, ctx) → score | null
+// ---------------------------------------------------------------------------
+
+export interface RankerInputs {
+  capability: CapabilityRow;
+  awareness: AwarenessRow | null;
+  surface: ContinuationSurface;
+  envelopeJourneySurface?: string;
+  nowMs: number;
+}
+
+export interface RankerResult {
+  /** Higher = more relevant. `null` = ineligible. */
+  score: number | null;
+  /** Set when `score === null` — names which guard rejected the candidate. */
+  rejectionReason?: string;
+}
+
+export interface FeatureDiscoveryRanker {
+  score(inputs: RankerInputs): RankerResult;
+}
+
+export const defaultFeatureDiscoveryRanker: FeatureDiscoveryRanker = {
+  score(inputs: RankerInputs): RankerResult {
+    const { capability, awareness, envelopeJourneySurface, nowMs } = inputs;
+
+    if (!capability.enabled) {
+      return { score: null, rejectionReason: 'capability_disabled' };
+    }
+
+    // Match-related capability gate: only surface on match-journey surfaces.
+    const isMatchRelated = MATCH_RELATED_CAPABILITY_KEYS.has(capability.capability_key);
+    if (isMatchRelated) {
+      if (!envelopeJourneySurface || !MATCH_JOURNEY_SURFACES.has(envelopeJourneySurface)) {
+        return { score: null, rejectionReason: 'match_capability_on_non_match_surface' };
+      }
+    }
+
+    const state: AwarenessState = awareness?.awareness_state ?? 'unknown';
+
+    // Hard skip: dismissed / completed / mastered. The user already
+    // either said no or has the capability under their belt. State
+    // advancement happens through explicit events (B0e.3+), never as a
+    // side effect of selection.
+    if (TERMINAL_AWARENESS_STATES.has(state)) {
+      return { score: null, rejectionReason: `awareness_state_terminal_${state}` };
+    }
+
+    // Hard backoff: twice-dismissed = never resurface here. Another
+    // future slice can re-introduce after a long cool-down; B0e.2 does
+    // not.
+    if ((awareness?.dismiss_count ?? 0) >= DISMISS_HARD_BACKOFF) {
+      return {
+        score: null,
+        rejectionReason: `dismiss_hard_backoff_${awareness?.dismiss_count ?? 0}`,
+      };
+    }
+
+    // Recent-introduction dampener.
+    const lastIntroducedMs = awareness?.last_introduced_at
+      ? Date.parse(awareness.last_introduced_at)
+      : null;
+    if (
+      lastIntroducedMs !== null &&
+      Number.isFinite(lastIntroducedMs) &&
+      nowMs - lastIntroducedMs < RECENT_INTRODUCTION_WINDOW_MS
+    ) {
+      return { score: null, rejectionReason: 'recently_introduced_within_7d' };
+    }
+
+    // Score by state — `unknown` is the highest-value introduction.
+    let score: number;
+    switch (state) {
+      case 'unknown':    score = 100; break;
+      case 'introduced': score = 50;  break;
+      case 'seen':       score = 30;  break;
+      case 'tried':      score = 10;  break;
+      // dismissed / completed / mastered already returned null above.
+      default:           score = 0;   break;
+    }
+
+    // Mild dismiss penalty (1 dismissal = -10).
+    score -= 10 * (awareness?.dismiss_count ?? 0);
+
+    return { score };
+  },
+};
+
+// ---------------------------------------------------------------------------
+// User-facing line rendering — backend-owned, NEVER from instruction/*
+// ---------------------------------------------------------------------------
+
+export interface FeatureDiscoveryRenderer {
+  render(capability: CapabilityRow, ctx: ContinuationDecisionContext): string;
+}
+
+export const defaultFeatureDiscoveryRenderer: FeatureDiscoveryRenderer = {
+  render(capability) {
+    // Short hook only — the renderer never writes a multi-sentence
+    // marketing blurb. The capability's display_name + a one-line
+    // hook from the description is the entire line.
+    const hook = capability.description.split('. ')[0].replace(/\.$/, '');
+    return `One thing you may not have explored yet — ${capability.display_name}. ${hook}.`;
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Factory
+// ---------------------------------------------------------------------------
+
+export interface FeatureDiscoveryProviderOptions {
+  fetcher: CapabilityFetcher;
+  /** Replace the default ranker (tests + future signal-driven slices). */
+  ranker?: FeatureDiscoveryRanker;
+  /** Replace the default renderer. */
+  renderer?: FeatureDiscoveryRenderer;
+  /** Injected for tests. */
+  newId?: () => string;
+  /** Injected for tests. */
+  now?: () => number;
+  /** Default 30. */
+  priority?: number;
+  /**
+   * Opt-in to register on `orb_wake`. Default: false. Wake stays clean
+   * and fast; feature-discovery only fires on turn-end / text-turn-end
+   * / home surfaces unless an explicit experiment turns this on.
+   */
+  includeOrbWake?: boolean;
+}
+
+export function makeFeatureDiscoveryProvider(
+  opts: FeatureDiscoveryProviderOptions,
+): ContinuationProvider {
+  const ranker = opts.ranker ?? defaultFeatureDiscoveryRanker;
+  const renderer = opts.renderer ?? defaultFeatureDiscoveryRenderer;
+  const newId = opts.newId ?? (() => randomUUID());
+  const now = opts.now ?? (() => Date.now());
+  const priority = opts.priority ?? DEFAULT_PRIORITY;
+  const surfaces: ContinuationSurface[] = [...DEFAULT_FEATURE_DISCOVERY_SURFACES];
+  if (opts.includeOrbWake) surfaces.push('orb_wake');
+
+  return {
+    key: FEATURE_DISCOVERY_PROVIDER_KEY,
+    surfaces,
+    async produce(ctx: ContinuationDecisionContext): Promise<ProviderResult> {
+      const t0 = now();
+
+      // Defensive skip — never run on orb_wake even if the registry
+      // erroneously routed us here without includeOrbWake.
+      if (ctx.surface === 'orb_wake' && !opts.includeOrbWake) {
+        return {
+          providerKey: FEATURE_DISCOVERY_PROVIDER_KEY,
+          status: 'skipped',
+          latencyMs: Math.max(0, now() - t0),
+          reason: 'feature_discovery_disabled_on_orb_wake',
+        };
+      }
+
+      // Need tenant + user to read user_capability_awareness.
+      if (!ctx.tenantId || !ctx.userId) {
+        return {
+          providerKey: FEATURE_DISCOVERY_PROVIDER_KEY,
+          status: 'skipped',
+          latencyMs: Math.max(0, now() - t0),
+          reason: 'feature_discovery_requires_identified_session',
+        };
+      }
+
+      let capabilities: CapabilityRow[];
+      let awareness: AwarenessRow[];
+      try {
+        [capabilities, awareness] = await Promise.all([
+          opts.fetcher.listCapabilities(),
+          opts.fetcher.listAwareness({ tenantId: ctx.tenantId, userId: ctx.userId }),
+        ]);
+      } catch (err) {
+        return {
+          providerKey: FEATURE_DISCOVERY_PROVIDER_KEY,
+          status: 'errored',
+          latencyMs: Math.max(0, now() - t0),
+          reason: err instanceof Error ? err.message : String(err),
+        };
+      }
+
+      const awarenessByKey = new Map<string, AwarenessRow>();
+      for (const a of awareness) awarenessByKey.set(a.capability_key, a);
+
+      // Score every candidate; track per-key rejection reasons for the
+      // suppression payload so operators can see WHY no feature was
+      // offered (key contract from the user's locked spec).
+      const scored: Array<{ capability: CapabilityRow; score: number }> = [];
+      const rejections: Record<string, string> = {};
+      const nowMs = now();
+      for (const cap of capabilities) {
+        const result = ranker.score({
+          capability: cap,
+          awareness: awarenessByKey.get(cap.capability_key) ?? null,
+          surface: ctx.surface,
+          envelopeJourneySurface: ctx.envelopeJourneySurface,
+          nowMs,
+        });
+        if (result.score === null) {
+          rejections[cap.capability_key] = result.rejectionReason ?? 'unscored';
+        } else {
+          scored.push({ capability: cap, score: result.score });
+        }
+      }
+
+      if (scored.length === 0) {
+        return {
+          providerKey: FEATURE_DISCOVERY_PROVIDER_KEY,
+          status: 'suppressed',
+          latencyMs: Math.max(0, now() - t0),
+          reason: `no_eligible_capability (catalog_size=${capabilities.length}, all_rejected)`,
+        };
+      }
+
+      // Pick ONE — highest score wins. Stable tie-break: catalog
+      // order (Map preserves insertion order from the fetcher).
+      scored.sort((a, b) => b.score - a.score);
+      const winner = scored[0].capability;
+
+      let line: string;
+      try {
+        line = renderer.render(winner, ctx);
+      } catch (err) {
+        return {
+          providerKey: FEATURE_DISCOVERY_PROVIDER_KEY,
+          status: 'errored',
+          latencyMs: Math.max(0, now() - t0),
+          reason: err instanceof Error ? err.message : String(err),
+        };
+      }
+      if (typeof line !== 'string' || line.trim().length === 0) {
+        return {
+          providerKey: FEATURE_DISCOVERY_PROVIDER_KEY,
+          status: 'errored',
+          latencyMs: Math.max(0, now() - t0),
+          reason: 'renderer_produced_empty_line',
+        };
+      }
+
+      const candidate: AssistantContinuation = {
+        id: `feature-discovery-${newId()}`,
+        surface: ctx.surface,
+        kind: 'feature_discovery',
+        priority,
+        userFacingLine: line,
+        cta: { type: 'explain' },
+        evidence: [
+          {
+            kind: 'capability_key',
+            detail: winner.capability_key,
+          },
+          {
+            kind: 'awareness_state',
+            detail:
+              awarenessByKey.get(winner.capability_key)?.awareness_state ?? 'unknown',
+          },
+        ],
+        dedupeKey: `feature-discovery-${winner.capability_key}`,
+        privacyMode: 'safe_to_speak',
+      };
+
+      return {
+        providerKey: FEATURE_DISCOVERY_PROVIDER_KEY,
+        status: 'returned',
+        latencyMs: Math.max(0, now() - t0),
+        candidate,
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Default registration — production calls `ensureFeatureDiscoveryRegistered`
+// (idempotent). Tests use the factory directly with a fake fetcher.
+// ---------------------------------------------------------------------------
+
+let _registered = false;
+export function ensureFeatureDiscoveryRegistered(
+  fetcher: CapabilityFetcher,
+  opts: Omit<FeatureDiscoveryProviderOptions, 'fetcher'> = {},
+): void {
+  if (_registered) return;
+  if (defaultProviderRegistry.get(FEATURE_DISCOVERY_PROVIDER_KEY)) {
+    _registered = true;
+    return;
+  }
+  defaultProviderRegistry.register(
+    makeFeatureDiscoveryProvider({ fetcher, ...opts }),
+  );
+  _registered = true;
+}

--- a/services/gateway/src/services/assistant-continuation/telemetry.ts
+++ b/services/gateway/src/services/assistant-continuation/telemetry.ts
@@ -1,0 +1,46 @@
+/**
+ * VTID-02921 (B0e.2): central OASIS topic constants for the
+ * assistant-continuation layer.
+ *
+ * Mirrors the pattern set by `orb/context/telemetry.ts` (B0b match-
+ * journey topics): every event topic this module emits MUST come from
+ * here, never from a raw string literal in the provider code.
+ *
+ * Why a central registry: when a future slice extends the provider
+ * roster (B0d, reminders, opportunity-awareness, journey-guidance,
+ * etc.), inconsistent topic names (`assistant.feature_discovery.offered`
+ * vs `feature.discovery.offered` vs `assistant.continuation.feature_discovery.offered`)
+ * silently break downstream rollups + Command Hub panels. The registry
+ * makes the canonical name discoverable in one place.
+ *
+ * Naming follows the existing OASIS taxonomy (CLAUDE.md §6):
+ *   - `assistant.continuation.*`        — continuation contract events (B0d)
+ *   - `feature.discovery.*`             — feature-discovery product events (B0e)
+ */
+
+// ---------------------------------------------------------------------------
+// Feature Discovery (B0e.2)
+// ---------------------------------------------------------------------------
+
+/** Provider returned a candidate (the ranker picked one). */
+export const FEATURE_DISCOVERY_OFFERED   = 'feature.discovery.offered'   as const;
+/** Provider suppressed (no eligible capability). */
+export const FEATURE_DISCOVERY_SUPPRESSED = 'feature.discovery.suppressed' as const;
+/** User accepted the offered capability (followed the CTA). */
+export const FEATURE_DISCOVERY_ACCEPTED   = 'feature.discovery.accepted'   as const;
+/** User dismissed the offered capability. */
+export const FEATURE_DISCOVERY_DISMISSED  = 'feature.discovery.dismissed'  as const;
+/** User completed the meaningful flow tied to the capability. */
+export const FEATURE_DISCOVERY_COMPLETED  = 'feature.discovery.completed'  as const;
+
+/**
+ * Aggregate registry for the feature-discovery topic family. Future
+ * grep guards (if scope expands) reference this list.
+ */
+export const FEATURE_DISCOVERY_TOPIC_REGISTRY = [
+  FEATURE_DISCOVERY_OFFERED,
+  FEATURE_DISCOVERY_SUPPRESSED,
+  FEATURE_DISCOVERY_ACCEPTED,
+  FEATURE_DISCOVERY_DISMISSED,
+  FEATURE_DISCOVERY_COMPLETED,
+] as const;

--- a/services/gateway/test/services/assistant-continuation/providers/feature-discovery.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/feature-discovery.test.ts
@@ -1,0 +1,674 @@
+/**
+ * VTID-02921 (B0e.2) — Feature Discovery provider tests.
+ *
+ * Maps directly to the 10 acceptance checks the user locked:
+ *   1. Selects one eligible capability, never multiple.
+ *   2. Suppresses with a concrete reason when no eligible capability.
+ *   3. Respects user state: dismissed/mastered not resurfaced casually.
+ *   4. Awareness state advances ONLY through explicit event paths.
+ *   5. Provider output passes validateContinuationCandidate().
+ *   6. Tests cover all 7 ladder states.
+ *   7. Match-related capabilities only on match-related surfaces.
+ *   8. Non-match surfaces never get match feature discovery.
+ *   9. No provider runs on orb_wake unless intentionally enabled.
+ *  10. Telemetry uses central constants; no stray topic strings.
+ */
+
+import {
+  makeFeatureDiscoveryProvider,
+  defaultFeatureDiscoveryRanker,
+  defaultFeatureDiscoveryRenderer,
+  ensureFeatureDiscoveryRegistered,
+  FEATURE_DISCOVERY_PROVIDER_KEY,
+  DEFAULT_FEATURE_DISCOVERY_SURFACES,
+  MATCH_RELATED_CAPABILITY_KEYS,
+  type CapabilityFetcher,
+  type CapabilityRow,
+  type AwarenessRow,
+  type AwarenessState,
+} from '../../../../src/services/assistant-continuation/providers/feature-discovery';
+import {
+  FEATURE_DISCOVERY_OFFERED,
+  FEATURE_DISCOVERY_SUPPRESSED,
+  FEATURE_DISCOVERY_ACCEPTED,
+  FEATURE_DISCOVERY_DISMISSED,
+  FEATURE_DISCOVERY_COMPLETED,
+  FEATURE_DISCOVERY_TOPIC_REGISTRY,
+} from '../../../../src/services/assistant-continuation/telemetry';
+import {
+  validateContinuationCandidate,
+  type ContinuationDecisionContext,
+  type ProviderResult,
+} from '../../../../src/services/assistant-continuation/types';
+import { decideContinuation } from '../../../../src/services/assistant-continuation/decide-continuation';
+import { createProviderRegistry } from '../../../../src/services/assistant-continuation/provider-registry';
+
+// ---------------------------------------------------------------------------
+// Test helpers
+// ---------------------------------------------------------------------------
+
+function capability(over: Partial<CapabilityRow> = {}): CapabilityRow {
+  return {
+    capability_key: over.capability_key ?? 'life_compass',
+    display_name: over.display_name ?? 'Life Compass',
+    description:
+      over.description ??
+      'Define your single active longevity goal — feeds every recommendation Vitana makes.',
+    required_role: over.required_role ?? 'community',
+    required_tenant_features: over.required_tenant_features ?? null,
+    required_integrations: over.required_integrations ?? null,
+    helpful_for_intents: over.helpful_for_intents ?? null,
+    enabled: over.enabled ?? true,
+  };
+}
+
+function awareness(
+  capabilityKey: string,
+  state: AwarenessState,
+  over: Partial<AwarenessRow> = {},
+): AwarenessRow {
+  return {
+    capability_key: capabilityKey,
+    awareness_state: state,
+    first_introduced_at: over.first_introduced_at ?? null,
+    last_introduced_at: over.last_introduced_at ?? null,
+    first_used_at: over.first_used_at ?? null,
+    last_used_at: over.last_used_at ?? null,
+    use_count: over.use_count ?? 0,
+    dismiss_count: over.dismiss_count ?? 0,
+    mastery_confidence: over.mastery_confidence ?? null,
+    last_surface: over.last_surface ?? null,
+  };
+}
+
+function makeFakeFetcher(
+  capabilities: CapabilityRow[],
+  awarenessRows: AwarenessRow[] = [],
+): CapabilityFetcher {
+  return {
+    listCapabilities: async () => capabilities,
+    listAwareness: async () => awarenessRows,
+  };
+}
+
+function ctx(over: Partial<ContinuationDecisionContext> = {}): ContinuationDecisionContext {
+  return {
+    surface: 'orb_turn_end',
+    sessionId: 's1',
+    userId: 'u1',
+    tenantId: 't1',
+    ...over,
+  };
+}
+
+function fixedNow(start = 1_700_000_000_000) {
+  let t = start;
+  return () => {
+    const v = t;
+    t += 1;
+    return v;
+  };
+}
+
+function fixedId(prefix = 'fd') {
+  let i = 0;
+  return () => `${prefix}-${++i}`;
+}
+
+// ---------------------------------------------------------------------------
+// Acceptance check #1 — selects one, never multiple.
+// ---------------------------------------------------------------------------
+
+describe('B0e.2 acceptance check #1: selects EXACTLY ONE eligible capability', () => {
+  it('returns a single candidate when many are eligible', async () => {
+    const fetcher = makeFakeFetcher([
+      capability({ capability_key: 'life_compass', display_name: 'Life Compass', description: 'Goal' }),
+      capability({ capability_key: 'vitana_index', display_name: 'Vitana Index', description: 'Score' }),
+      capability({ capability_key: 'diary_entry', display_name: 'Diary', description: 'Log' }),
+    ]);
+    const provider = makeFeatureDiscoveryProvider({ fetcher, now: fixedNow(), newId: fixedId() });
+    const result = (await provider.produce(ctx())) as ProviderResult;
+    expect(result.status).toBe('returned');
+    expect(result.candidate).toBeDefined();
+    expect(result.candidate?.kind).toBe('feature_discovery');
+    // The shape returned is a single AssistantContinuation, never an array.
+    expect(Array.isArray(result.candidate)).toBe(false);
+  });
+
+  it('end-to-end through decideContinuation also returns ONE selected continuation', async () => {
+    const fetcher = makeFakeFetcher([
+      capability({ capability_key: 'a', display_name: 'A', description: 'A' }),
+      capability({ capability_key: 'b', display_name: 'B', description: 'B' }),
+      capability({ capability_key: 'c', display_name: 'C', description: 'C' }),
+    ]);
+    const registry = createProviderRegistry();
+    registry.register(makeFeatureDiscoveryProvider({ fetcher, now: fixedNow(), newId: fixedId() }));
+    const decision = await decideContinuation({
+      surface: 'orb_turn_end',
+      context: { sessionId: 's', userId: 'u', tenantId: 't' },
+      registry,
+    });
+    expect(decision.selectedContinuation).not.toBeNull();
+    expect(decision.selectedContinuation?.kind).toBe('feature_discovery');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Acceptance check #2 — suppresses with a concrete reason.
+// ---------------------------------------------------------------------------
+
+describe('B0e.2 acceptance check #2: suppresses with a concrete reason', () => {
+  it('suppresses when the catalog is empty', async () => {
+    const fetcher = makeFakeFetcher([], []);
+    const provider = makeFeatureDiscoveryProvider({ fetcher, now: fixedNow(), newId: fixedId() });
+    const result = (await provider.produce(ctx())) as ProviderResult;
+    expect(result.status).toBe('suppressed');
+    expect(result.reason).toMatch(/^no_eligible_capability/);
+    expect(result.candidate).toBeUndefined();
+  });
+
+  it('suppresses when every capability is rejected (all dismissed)', async () => {
+    const fetcher = makeFakeFetcher(
+      [
+        capability({ capability_key: 'a', description: 'A' }),
+        capability({ capability_key: 'b', description: 'B' }),
+      ],
+      [
+        awareness('a', 'dismissed'),
+        awareness('b', 'mastered'),
+      ],
+    );
+    const provider = makeFeatureDiscoveryProvider({ fetcher, now: fixedNow(), newId: fixedId() });
+    const result = (await provider.produce(ctx())) as ProviderResult;
+    expect(result.status).toBe('suppressed');
+    expect(result.reason).toMatch(/no_eligible_capability/);
+    expect(result.reason).toMatch(/all_rejected/);
+  });
+
+  it('reports skip when tenant/user identity is missing', async () => {
+    const fetcher = makeFakeFetcher([capability()]);
+    const provider = makeFeatureDiscoveryProvider({ fetcher, now: fixedNow(), newId: fixedId() });
+    const result = (await provider.produce(ctx({ tenantId: undefined, userId: undefined }))) as ProviderResult;
+    expect(result.status).toBe('skipped');
+    expect(result.reason).toBe('feature_discovery_requires_identified_session');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Acceptance check #3 — dismissed / mastered / completed not resurfaced.
+// ---------------------------------------------------------------------------
+
+describe('B0e.2 acceptance check #3: respects terminal awareness states', () => {
+  it.each(['dismissed', 'completed', 'mastered'] as const)(
+    'skips capabilities in state=%s',
+    async (state) => {
+      const fetcher = makeFakeFetcher(
+        [capability({ capability_key: 'x', description: 'X' })],
+        [awareness('x', state)],
+      );
+      const provider = makeFeatureDiscoveryProvider({ fetcher, now: fixedNow(), newId: fixedId() });
+      const result = (await provider.produce(ctx())) as ProviderResult;
+      expect(result.status).toBe('suppressed');
+    },
+  );
+
+  it('hard-backs off after dismiss_count >= 2', async () => {
+    const fetcher = makeFakeFetcher(
+      [capability({ capability_key: 'x', description: 'X' })],
+      [awareness('x', 'introduced', { dismiss_count: 2 })],
+    );
+    const provider = makeFeatureDiscoveryProvider({ fetcher, now: fixedNow(), newId: fixedId() });
+    const result = (await provider.produce(ctx())) as ProviderResult;
+    expect(result.status).toBe('suppressed');
+  });
+
+  it('dampens recently-introduced capabilities (within 7 days)', async () => {
+    const recent = new Date(1_700_000_000_000 - 3 * 24 * 60 * 60 * 1000).toISOString();
+    const fetcher = makeFakeFetcher(
+      [capability({ capability_key: 'x', description: 'X' })],
+      [awareness('x', 'introduced', { last_introduced_at: recent })],
+    );
+    const provider = makeFeatureDiscoveryProvider({ fetcher, now: fixedNow(), newId: fixedId() });
+    const result = (await provider.produce(ctx())) as ProviderResult;
+    expect(result.status).toBe('suppressed');
+  });
+
+  it('accepts an introduced capability after the 7-day window elapses', async () => {
+    const oldIntro = new Date(1_700_000_000_000 - 10 * 24 * 60 * 60 * 1000).toISOString();
+    const fetcher = makeFakeFetcher(
+      [capability({ capability_key: 'x', display_name: 'X', description: 'Hook' })],
+      [awareness('x', 'introduced', { last_introduced_at: oldIntro })],
+    );
+    const provider = makeFeatureDiscoveryProvider({ fetcher, now: fixedNow(), newId: fixedId() });
+    const result = (await provider.produce(ctx())) as ProviderResult;
+    expect(result.status).toBe('returned');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Acceptance check #4 — selection never mutates awareness state.
+// ---------------------------------------------------------------------------
+
+describe('B0e.2 acceptance check #4: selection is read-only', () => {
+  it('listAwareness is the only DB-read function the provider calls', async () => {
+    const listAwareness = jest.fn(async () => [awareness('x', 'unknown')]);
+    const listCapabilities = jest.fn(async () => [capability({ capability_key: 'x', description: 'X' })]);
+    const fetcher: CapabilityFetcher = {
+      listCapabilities,
+      listAwareness,
+      // Defensive: if the provider tried to call an update method, it
+      // wouldn't even compile against the interface — but we also
+      // verify the fetcher mock has zero other call surface.
+    };
+    const provider = makeFeatureDiscoveryProvider({ fetcher, now: fixedNow(), newId: fixedId() });
+    await provider.produce(ctx());
+    // Both reads happen exactly once per produce() call.
+    expect(listCapabilities).toHaveBeenCalledTimes(1);
+    expect(listAwareness).toHaveBeenCalledTimes(1);
+    // Awareness state remains untouched at the source (no write seam exposed).
+    // CapabilityFetcher interface has no mutator methods by design — type-level guard.
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Acceptance check #5 — candidate passes validateContinuationCandidate.
+// ---------------------------------------------------------------------------
+
+describe('B0e.2 acceptance check #5: candidate passes runtime validator', () => {
+  it('returned candidate passes validateContinuationCandidate', async () => {
+    const fetcher = makeFakeFetcher([
+      capability({ capability_key: 'life_compass', display_name: 'Life Compass', description: 'Goal hook' }),
+    ]);
+    const provider = makeFeatureDiscoveryProvider({ fetcher, now: fixedNow(), newId: fixedId() });
+    const result = (await provider.produce(ctx())) as ProviderResult;
+    expect(result.status).toBe('returned');
+    const validation = validateContinuationCandidate(result.candidate);
+    expect(validation).toEqual({ ok: true });
+  });
+
+  it('candidate evidence carries the capability_key + awareness_state', async () => {
+    const fetcher = makeFakeFetcher(
+      [capability({ capability_key: 'diary_entry', display_name: 'Diary', description: 'Log' })],
+      [awareness('diary_entry', 'seen')],
+    );
+    const provider = makeFeatureDiscoveryProvider({ fetcher, now: fixedNow(), newId: fixedId() });
+    const result = (await provider.produce(ctx())) as ProviderResult;
+    expect(result.candidate?.evidence).toEqual([
+      { kind: 'capability_key', detail: 'diary_entry' },
+      { kind: 'awareness_state', detail: 'seen' },
+    ]);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Acceptance check #6 — all 7 ladder states covered.
+// ---------------------------------------------------------------------------
+
+describe('B0e.2 acceptance check #6: all 7 ladder states', () => {
+  const eligibleStates: AwarenessState[] = ['unknown', 'introduced', 'seen', 'tried'];
+  const terminalStates: AwarenessState[] = ['dismissed', 'completed', 'mastered'];
+
+  it.each(eligibleStates)('%s state is eligible (not terminal)', async (state) => {
+    const fetcher = makeFakeFetcher(
+      [capability({ capability_key: 'x', display_name: 'X', description: 'Hook' })],
+      [awareness('x', state)],
+    );
+    const provider = makeFeatureDiscoveryProvider({ fetcher, now: fixedNow(), newId: fixedId() });
+    const result = (await provider.produce(ctx())) as ProviderResult;
+    expect(result.status).toBe('returned');
+  });
+
+  it.each(terminalStates)('%s state is rejected', async (state) => {
+    const fetcher = makeFakeFetcher(
+      [capability({ capability_key: 'x', display_name: 'X', description: 'Hook' })],
+      [awareness('x', state)],
+    );
+    const provider = makeFeatureDiscoveryProvider({ fetcher, now: fixedNow(), newId: fixedId() });
+    const result = (await provider.produce(ctx())) as ProviderResult;
+    expect(result.status).toBe('suppressed');
+  });
+
+  it('ranks unknown > introduced > seen > tried', async () => {
+    const fetcher = makeFakeFetcher(
+      [
+        capability({ capability_key: 'unknown_one', display_name: 'U', description: 'U' }),
+        capability({ capability_key: 'introduced_one', display_name: 'I', description: 'I' }),
+        capability({ capability_key: 'seen_one', display_name: 'S', description: 'S' }),
+        capability({ capability_key: 'tried_one', display_name: 'T', description: 'T' }),
+      ],
+      [
+        awareness('introduced_one', 'introduced'),
+        awareness('seen_one', 'seen'),
+        awareness('tried_one', 'tried'),
+        // no row for unknown_one → state defaults to 'unknown'
+      ],
+    );
+    const provider = makeFeatureDiscoveryProvider({ fetcher, now: fixedNow(), newId: fixedId() });
+    const result = (await provider.produce(ctx())) as ProviderResult;
+    expect(result.candidate?.evidence[0].detail).toBe('unknown_one');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Acceptance check #7 — match-related capabilities only on match surfaces.
+// ---------------------------------------------------------------------------
+
+describe('B0e.2 acceptance check #7: match-related capabilities on match surfaces', () => {
+  // Use activity_match (seeded) to exercise the match-related path.
+  it('surfaces activity_match when envelopeJourneySurface is a match surface', async () => {
+    const fetcher = makeFakeFetcher([
+      capability({
+        capability_key: 'activity_match',
+        display_name: 'Activity Match',
+        description: 'Find a partner',
+      }),
+    ]);
+    const provider = makeFeatureDiscoveryProvider({ fetcher, now: fixedNow(), newId: fixedId() });
+    const result = (await provider.produce(
+      ctx({ envelopeJourneySurface: 'intent_board' }),
+    )) as ProviderResult;
+    expect(result.status).toBe('returned');
+    expect(result.candidate?.evidence[0].detail).toBe('activity_match');
+  });
+
+  it('MATCH_RELATED_CAPABILITY_KEYS contains all 7 deferred capabilities + activity_match', () => {
+    expect(MATCH_RELATED_CAPABILITY_KEYS.has('pre_match_whois')).toBe(true);
+    expect(MATCH_RELATED_CAPABILITY_KEYS.has('should_i_show_interest')).toBe(true);
+    expect(MATCH_RELATED_CAPABILITY_KEYS.has('draft_opener')).toBe(true);
+    expect(MATCH_RELATED_CAPABILITY_KEYS.has('activity_plan_card')).toBe(true);
+    expect(MATCH_RELATED_CAPABILITY_KEYS.has('match_chat_assist')).toBe(true);
+    expect(MATCH_RELATED_CAPABILITY_KEYS.has('post_activity_reflection')).toBe(true);
+    expect(MATCH_RELATED_CAPABILITY_KEYS.has('next_rep_suggestion')).toBe(true);
+    expect(MATCH_RELATED_CAPABILITY_KEYS.has('activity_match')).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Acceptance check #8 — non-match surfaces NEVER get match feature discovery.
+// ---------------------------------------------------------------------------
+
+describe('B0e.2 acceptance check #8: non-match surfaces never get match capabilities', () => {
+  const nonMatchSurfaces: Array<string | undefined> = [
+    undefined,                      // no envelope at all
+    'unknown',                      // explicit unknown
+    'command_hub',                  // operator surface
+    'notification_center',          // notifications
+  ];
+
+  it.each(nonMatchSurfaces)(
+    'rejects activity_match when envelopeJourneySurface=%s (skipped or fallback to non-match)',
+    async (surface) => {
+      const fetcher = makeFakeFetcher([
+        capability({
+          capability_key: 'activity_match',
+          display_name: 'Activity Match',
+          description: 'Find a partner',
+        }),
+        // Provide a non-match alternative so the provider has SOMETHING
+        // to surface; the test asserts activity_match is NOT chosen.
+        capability({
+          capability_key: 'diary_entry',
+          display_name: 'Diary',
+          description: 'Log',
+        }),
+      ]);
+      const provider = makeFeatureDiscoveryProvider({ fetcher, now: fixedNow(), newId: fixedId() });
+      const result = (await provider.produce(
+        ctx({ envelopeJourneySurface: surface as string | undefined }),
+      )) as ProviderResult;
+      if (result.status === 'returned') {
+        // If anything was returned, it MUST be the non-match alternative.
+        expect(result.candidate?.evidence[0].detail).toBe('diary_entry');
+      } else {
+        // Or suppressed (also acceptable).
+        expect(result.status).toBe('suppressed');
+      }
+    },
+  );
+
+  it('only the match-only catalog suppresses on non-match surface', async () => {
+    const fetcher = makeFakeFetcher([
+      capability({
+        capability_key: 'activity_match',
+        display_name: 'Activity Match',
+        description: 'Find a partner',
+      }),
+    ]);
+    const provider = makeFeatureDiscoveryProvider({ fetcher, now: fixedNow(), newId: fixedId() });
+    const result = (await provider.produce(ctx({ envelopeJourneySurface: 'command_hub' }))) as ProviderResult;
+    expect(result.status).toBe('suppressed');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Acceptance check #9 — no run on orb_wake unless intentionally enabled.
+// ---------------------------------------------------------------------------
+
+describe('B0e.2 acceptance check #9: orb_wake gated off by default', () => {
+  it('default surfaces array does NOT include orb_wake', () => {
+    expect(DEFAULT_FEATURE_DISCOVERY_SURFACES).not.toContain('orb_wake');
+    expect(DEFAULT_FEATURE_DISCOVERY_SURFACES).toEqual(['orb_turn_end', 'text_turn_end', 'home']);
+  });
+
+  it('factory does not register provider on orb_wake without includeOrbWake', () => {
+    const fetcher = makeFakeFetcher([capability()]);
+    const provider = makeFeatureDiscoveryProvider({ fetcher });
+    expect(provider.surfaces).not.toContain('orb_wake');
+  });
+
+  it('factory registers provider on orb_wake ONLY when includeOrbWake=true', () => {
+    const fetcher = makeFakeFetcher([capability()]);
+    const provider = makeFeatureDiscoveryProvider({ fetcher, includeOrbWake: true });
+    expect(provider.surfaces).toContain('orb_wake');
+  });
+
+  it('defensive: if mis-routed to orb_wake without the flag, returns skipped', async () => {
+    const fetcher = makeFakeFetcher([capability()]);
+    const provider = makeFeatureDiscoveryProvider({ fetcher, now: fixedNow(), newId: fixedId() });
+    const result = (await provider.produce(ctx({ surface: 'orb_wake' }))) as ProviderResult;
+    expect(result.status).toBe('skipped');
+    expect(result.reason).toBe('feature_discovery_disabled_on_orb_wake');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Acceptance check #10 — telemetry uses central constants only.
+// ---------------------------------------------------------------------------
+
+describe('B0e.2 acceptance check #10: telemetry uses central constants', () => {
+  it('FEATURE_DISCOVERY_* constants exist and are namespaced', () => {
+    expect(FEATURE_DISCOVERY_OFFERED).toBe('feature.discovery.offered');
+    expect(FEATURE_DISCOVERY_SUPPRESSED).toBe('feature.discovery.suppressed');
+    expect(FEATURE_DISCOVERY_ACCEPTED).toBe('feature.discovery.accepted');
+    expect(FEATURE_DISCOVERY_DISMISSED).toBe('feature.discovery.dismissed');
+    expect(FEATURE_DISCOVERY_COMPLETED).toBe('feature.discovery.completed');
+  });
+
+  it('FEATURE_DISCOVERY_TOPIC_REGISTRY enumerates all 5 events', () => {
+    expect(FEATURE_DISCOVERY_TOPIC_REGISTRY).toHaveLength(5);
+    expect(new Set(FEATURE_DISCOVERY_TOPIC_REGISTRY).size).toBe(5);
+  });
+
+  it('provider source file does not contain raw feature.discovery.* literals', () => {
+    // Source-level grep: the provider must reference constants, not
+    // raw topic strings. The telemetry.ts file is the only legitimate
+    // home for those literals.
+    const fs = require('fs');
+    const path = require('path');
+    const src = fs.readFileSync(
+      path.join(__dirname, '../../../../src/services/assistant-continuation/providers/feature-discovery.ts'),
+      'utf8',
+    );
+    expect(src).not.toMatch(/['"`]feature\.discovery\./);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Extra coverage — capability_disabled, render errors, ranker injection
+// ---------------------------------------------------------------------------
+
+describe('B0e.2 — extra coverage', () => {
+  it('disabled capabilities are skipped', async () => {
+    const fetcher = makeFakeFetcher([
+      capability({ capability_key: 'a', enabled: false, description: 'A' }),
+    ]);
+    const provider = makeFeatureDiscoveryProvider({ fetcher, now: fixedNow(), newId: fixedId() });
+    const result = (await provider.produce(ctx())) as ProviderResult;
+    expect(result.status).toBe('suppressed');
+  });
+
+  it('errored fetcher → status=errored, no exception escapes', async () => {
+    const fetcher: CapabilityFetcher = {
+      listCapabilities: async () => {
+        throw new Error('db_down');
+      },
+      listAwareness: async () => [],
+    };
+    const provider = makeFeatureDiscoveryProvider({ fetcher, now: fixedNow(), newId: fixedId() });
+    const result = (await provider.produce(ctx())) as ProviderResult;
+    expect(result.status).toBe('errored');
+    expect(result.reason).toBe('db_down');
+  });
+
+  it('custom ranker is honored', async () => {
+    const fetcher = makeFakeFetcher([
+      capability({ capability_key: 'low', display_name: 'L', description: 'L' }),
+      capability({ capability_key: 'high', display_name: 'H', description: 'H' }),
+    ]);
+    const customRanker = {
+      score(inputs: any) {
+        return {
+          score: inputs.capability.capability_key === 'high' ? 999 : 1,
+        };
+      },
+    };
+    const provider = makeFeatureDiscoveryProvider({
+      fetcher,
+      ranker: customRanker,
+      now: fixedNow(),
+      newId: fixedId(),
+    });
+    const result = (await provider.produce(ctx())) as ProviderResult;
+    expect(result.candidate?.evidence[0].detail).toBe('high');
+  });
+
+  it('custom renderer is honored', async () => {
+    const fetcher = makeFakeFetcher([
+      capability({ capability_key: 'x', display_name: 'X', description: 'X' }),
+    ]);
+    const renderer = { render: () => 'CUSTOM TEXT' };
+    const provider = makeFeatureDiscoveryProvider({
+      fetcher,
+      renderer,
+      now: fixedNow(),
+      newId: fixedId(),
+    });
+    const result = (await provider.produce(ctx())) as ProviderResult;
+    expect(result.candidate?.userFacingLine).toBe('CUSTOM TEXT');
+  });
+
+  it('renderer that throws → errored', async () => {
+    const fetcher = makeFakeFetcher([
+      capability({ capability_key: 'x', display_name: 'X', description: 'X' }),
+    ]);
+    const renderer = {
+      render: () => {
+        throw new Error('renderer_kaboom');
+      },
+    };
+    const provider = makeFeatureDiscoveryProvider({
+      fetcher,
+      renderer,
+      now: fixedNow(),
+      newId: fixedId(),
+    });
+    const result = (await provider.produce(ctx())) as ProviderResult;
+    expect(result.status).toBe('errored');
+    expect(result.reason).toBe('renderer_kaboom');
+  });
+
+  it('priority defaults to 30 (below wake_brief 80)', async () => {
+    const fetcher = makeFakeFetcher([
+      capability({ capability_key: 'x', display_name: 'X', description: 'X' }),
+    ]);
+    const provider = makeFeatureDiscoveryProvider({ fetcher, now: fixedNow(), newId: fixedId() });
+    const result = (await provider.produce(ctx())) as ProviderResult;
+    expect(result.candidate?.priority).toBe(30);
+  });
+
+  it('priority can be overridden via opts', async () => {
+    const fetcher = makeFakeFetcher([
+      capability({ capability_key: 'x', display_name: 'X', description: 'X' }),
+    ]);
+    const provider = makeFeatureDiscoveryProvider({
+      fetcher,
+      priority: 50,
+      now: fixedNow(),
+      newId: fixedId(),
+    });
+    const result = (await provider.produce(ctx())) as ProviderResult;
+    expect(result.candidate?.priority).toBe(50);
+  });
+
+  it('ensureFeatureDiscoveryRegistered is idempotent', () => {
+    const fetcher = makeFakeFetcher([]);
+    expect(() => ensureFeatureDiscoveryRegistered(fetcher)).not.toThrow();
+    expect(() => ensureFeatureDiscoveryRegistered(fetcher)).not.toThrow();
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Wake-brief priority interaction (priority ordering check)
+// ---------------------------------------------------------------------------
+
+describe('B0e.2 — priority ordering with wake_brief', () => {
+  it('feature_discovery (30) loses to a higher-priority candidate (80)', async () => {
+    const fetcher = makeFakeFetcher([
+      capability({ capability_key: 'x', display_name: 'X', description: 'X' }),
+    ]);
+    const registry = createProviderRegistry();
+    registry.register(makeFeatureDiscoveryProvider({ fetcher, now: fixedNow(), newId: fixedId() }));
+    // Add a high-priority fake provider as a stand-in for wake_brief
+    // / reminder / match_journey_next_move.
+    registry.register({
+      key: 'fake_urgent',
+      surfaces: ['orb_turn_end'],
+      produce: (): ProviderResult => ({
+        providerKey: 'fake_urgent',
+        status: 'returned',
+        latencyMs: 1,
+        candidate: {
+          id: 'urgent-1',
+          surface: 'orb_turn_end',
+          kind: 'reminder',
+          priority: 80,
+          userFacingLine: 'Urgent reminder.',
+          cta: { type: 'ask_permission' },
+          evidence: [{ kind: 'reminder_due', detail: 'now' }],
+          dedupeKey: 'urgent-1',
+          privacyMode: 'safe_to_speak',
+        },
+      }),
+    });
+    const decision = await decideContinuation({
+      surface: 'orb_turn_end',
+      context: { sessionId: 's', userId: 'u', tenantId: 't' },
+      registry,
+    });
+    expect(decision.selectedContinuation?.kind).toBe('reminder');
+  });
+
+  it('feature_discovery (30) wins when no higher-priority candidate exists', async () => {
+    const fetcher = makeFakeFetcher([
+      capability({ capability_key: 'x', display_name: 'X', description: 'X' }),
+    ]);
+    const registry = createProviderRegistry();
+    registry.register(makeFeatureDiscoveryProvider({ fetcher, now: fixedNow(), newId: fixedId() }));
+    const decision = await decideContinuation({
+      surface: 'orb_turn_end',
+      context: { sessionId: 's', userId: 'u', tenantId: 't' },
+      registry,
+    });
+    expect(decision.selectedContinuation?.kind).toBe('feature_discovery');
+  });
+});


### PR DESCRIPTION
## B0e.2 — Feature Discovery provider (implementation only)

Plugs into the B0d continuation contract. Reads B0e.1's \`system_capabilities\` + \`user_capability_awareness\`. Picks **EXACTLY ONE** unexplored capability per decision OR suppresses with a concrete reason. **Never lists. Never hardcodes copy in \`orb/live/instruction/*\`.**

## Files

- **NEW** \`src/services/assistant-continuation/telemetry.ts\` — central registry for continuation-layer OASIS topics. Exports \`FEATURE_DISCOVERY_{OFFERED,SUPPRESSED,ACCEPTED,DISMISSED,COMPLETED}\` + \`FEATURE_DISCOVERY_TOPIC_REGISTRY\`.
- **NEW** \`src/services/assistant-continuation/providers/feature-discovery.ts\` — provider factory + ranker + renderer.
- **NEW** \`src/services/assistant-continuation/providers/feature-discovery.test.ts\` — 46 tests across the 10 acceptance checks + extra coverage.

## Provider behavior

| Concern | Behavior |
|---|---|
| **Provider key** | \`feature_discovery\` |
| **Default priority** | \`30\` (below wake_brief 80, reminder, match_journey_next_move) |
| **Default surfaces** | \`orb_turn_end\`, \`text_turn_end\`, \`home\` (NOT \`orb_wake\`) |
| **Selection** | Read-only — \`CapabilityFetcher\` exposes only \`listCapabilities\` + \`listAwareness\`; no mutator methods |
| **Ranker** | 7-state ladder aware (see below) |
| **Renderer** | Short hook from \`capability.description\`; copy NEVER lives in instruction layer |

### Ranker scoring matrix

| State | Score | Notes |
|---|---|---|
| \`unknown\` | 100 | Highest-value introduction |
| \`introduced\` | 50 | Gentle re-mention after 7d cool-down |
| \`seen\` | 30 | Encourage trying |
| \`tried\` | 10 | Encourage completion |
| \`completed\` | REJECTED | \`awareness_state_terminal_completed\` |
| \`dismissed\` | REJECTED | \`awareness_state_terminal_dismissed\` |
| \`mastered\` | REJECTED | \`awareness_state_terminal_mastered\` |

Plus hard backoffs:
- \`dismiss_count >= 2\` → REJECTED (\`dismiss_hard_backoff_N\`)
- \`last_introduced_at within 7d\` → REJECTED (\`recently_introduced_within_7d\`)
- non-match surface + match-related capability → REJECTED (\`match_capability_on_non_match_surface\`)
- penalty: \`-10 × dismiss_count\`

## 10 acceptance checks (all green)

| # | Check | Coverage |
|---|---|---|
| 1 | Selects exactly one capability, never multiple | Single \`AssistantContinuation\` returned + end-to-end through \`decideContinuation\` |
| 2 | Suppresses with concrete reason | \`no_eligible_capability (catalog_size=N, all_rejected)\` + per-capability rejection reasons |
| 3 | Respects user state (dismissed/mastered not resurfaced) | All 3 terminal states tested; \`dismiss_count >= 2\` hard backoff; 7d dampener |
| 4 | Selection is read-only | \`CapabilityFetcher\` interface has no mutator methods; tests verify both reads happen exactly once |
| 5 | Output passes \`validateContinuationCandidate()\` | Direct assertion + evidence carries \`capability_key\` + \`awareness_state\` |
| 6 | All 7 ladder states covered | \`it.each\` for eligible (4) + terminal (3); ranking order verified |
| 7 | Match-related capabilities only on match surfaces | \`activity_match\` surfaces when \`envelopeJourneySurface\` ∈ match surfaces; \`MATCH_RELATED_CAPABILITY_KEYS\` contains all 7 deferred concierge + \`activity_match\` |
| 8 | Non-match surfaces never get match capabilities | Tested with \`undefined\`/\`unknown\`/\`command_hub\`/\`notification_center\`; \`activity_match\` always rejected |
| 9 | No provider runs on orb_wake unless intentionally enabled | \`DEFAULT_FEATURE_DISCOVERY_SURFACES\` excludes \`orb_wake\`; \`includeOrbWake: true\` required; defensive in-produce skip catches mis-routing |
| 10 | Telemetry uses central constants | Source-grep test asserts no raw \`feature.discovery.*\` literals in provider source |

Plus extra coverage: capability_disabled skip, errored fetcher, custom ranker/renderer injection, renderer-throws → errored, default priority 30, priority override, idempotent registration, priority interaction with higher-priority providers (feature_discovery loses to priority=80 candidate, wins when alone).

## Tests

- **46 new tests** in the feature-discovery suite.
- **520/520** across orb + assistant-continuation + wake-timeline + wake-brief-wiring + capability-awareness + ingest test suites.
- \`npm run build\` clean.

## What's next

- **B0e.3**: Supabase-backed \`CapabilityFetcher\` implementation + registration wiring at startup + Command Hub Feature Discovery panel on the Journey Context screen.
- **B0e.4**: state-advancement event handlers (\`introduced → seen → tried → completed → mastered\`, or \`dismissed\`). Selection stays read-only; mutation happens through dedicated event paths.

## Test plan

- [x] 46 new tests pass
- [x] No regression in 474 prior tests
- [x] TypeScript build clean
- [x] No raw topic strings in provider source (grep-asserted)
- [x] orb_wake stays gated off by default (defensive in-produce + factory + test)

🤖 Generated with [Claude Code](https://claude.com/claude-code)