### PR TITLE
feat(self-healing): patch-workspace via Dev Autopilot bridge + reconciler-owned success (VTID-02922, PR-A/3)

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -394,6 +394,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const automationsRouter = require('./routes/automations').default;
   // Self-Healing System — Autonomous detection, diagnosis, fix, and verification pipeline
   const selfHealingRouter = require('./routes/self-healing').default;
+  // PR-A (VTID-02922): operator-armed canary for end-to-end self-healing smoke tests
+  const selfHealingCanaryRouter = require('./routes/self-healing-canary').default;
   // VTID-02031: Ops "Action Required" — pull surface mirroring Gchat pings
   const opsActionRequiredRouter = require('./routes/ops-action-required').default;
 
@@ -972,6 +974,11 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
 
   // Self-Healing System — Autonomous detection, diagnosis, fix, and verification
   mountRouterSync(app, '/api/v1/self-healing', selfHealingRouter, { owner: 'self-healing' });
+  // PR-A (VTID-02922): canary route mounted at root so its paths
+  // (/api/v1/self-healing/canary/*) sit alongside the main self-healing
+  // router but in a separate module — keeps deliberate-fault code out of
+  // the lifecycle path's blast radius.
+  mountRouterSync(app, '/', selfHealingCanaryRouter, { owner: 'self-healing' });
 
   // VTID-02031: Ops Action Required — pull surface for Command Hub Overview
   mountRouterSync(app, '/api/v1/ops/action-required', opsActionRequiredRouter, { owner: 'ops-action-required' });

--- a/services/gateway/src/routes/self-healing-canary.ts
+++ b/services/gateway/src/routes/self-healing-canary.ts
@@ -1,0 +1,101 @@
+/**
+ * Self-Healing Canary Route — PR-A (VTID-02922)
+ *
+ * A deliberate, operator-armed fault inside the same production gateway so
+ * the end-to-end self-healing pipeline can be smoke-tested without inducing
+ * a real production outage (e.g. pushing a syntax error). The endpoint:
+ *
+ *   - returns HTTP 500 with content-type application/json (so the
+ *     scanner picks it up + the pre-probe gate's JSON-healthy check
+ *     correctly classifies it as down) IFF
+ *     system_config['self_healing_canary_armed'] === true.
+ *   - returns 200 OK otherwise.
+ *
+ * To smoke-test the full pipeline:
+ *   1. PATCH system_config { self_healing_canary_armed: true }
+ *   2. POST /api/v1/self-healing/report with the canary endpoint listed as
+ *      down (or wait for the scheduled scanner to detect).
+ *   3. Watch self_healing_log → vtid_ledger → dev_autopilot_executions
+ *      transition through pr_open → ci → merging → deploying → verifying →
+ *      completed. The autopilot-generated fix typically flips
+ *      self_healing_canary_armed back to false.
+ *   4. Reconciler terminalizes the VTID success when the live probe
+ *      returns 200.
+ */
+
+import { Router, Request, Response } from 'express';
+
+export const selfHealingCanaryRouter = Router();
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
+const CONFIG_KEY = 'self_healing_canary_armed';
+
+let cachedArmed: boolean | null = null;
+let cachedAt = 0;
+const CACHE_TTL_MS = 5_000;
+
+async function isCanaryArmed(): Promise<boolean> {
+  const now = Date.now();
+  if (cachedArmed !== null && now - cachedAt < CACHE_TTL_MS) {
+    return cachedArmed;
+  }
+  cachedArmed = false;
+  cachedAt = now;
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) return false;
+  try {
+    const resp = await fetch(
+      `${SUPABASE_URL}/rest/v1/system_config?key=eq.${CONFIG_KEY}&select=value`,
+      {
+        headers: {
+          apikey: SUPABASE_SERVICE_ROLE,
+          Authorization: `Bearer ${SUPABASE_SERVICE_ROLE}`,
+        },
+        signal: AbortSignal.timeout(3_000),
+      },
+    );
+    if (!resp.ok) return false;
+    const rows = (await resp.json()) as Array<{ value: unknown }>;
+    if (rows.length === 0) return false;
+    const v = rows[0].value;
+    cachedArmed = v === true || v === 'true' || v === 1 || v === '1';
+    return cachedArmed;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * GET /api/v1/self-healing/canary/failing-health
+ *
+ * - 200 OK (canary disarmed — baseline state)
+ * - 500 with JSON body (canary armed — feeds the self-healing pipeline)
+ */
+selfHealingCanaryRouter.get('/api/v1/self-healing/canary/failing-health', async (_req: Request, res: Response) => {
+  const armed = await isCanaryArmed();
+  if (armed) {
+    return res.status(500).json({
+      ok: false,
+      error: 'self_healing_canary_armed=true — deliberate fault for smoke-testing the self-healing pipeline',
+      armed: true,
+      remediation: 'flip system_config self_healing_canary_armed to false',
+    });
+  }
+  return res.status(200).json({
+    ok: true,
+    armed: false,
+    description: 'canary disarmed; flip system_config[self_healing_canary_armed]=true to arm',
+  });
+});
+
+/**
+ * GET /api/v1/self-healing/canary/status
+ *
+ * Operator-facing read-only check. Always 200; reports current armed state.
+ */
+selfHealingCanaryRouter.get('/api/v1/self-healing/canary/status', async (_req: Request, res: Response) => {
+  const armed = await isCanaryArmed();
+  return res.json({ ok: true, armed, config_key: CONFIG_KEY });
+});
+
+export default selfHealingCanaryRouter;

--- a/services/gateway/src/routes/worker-orchestrator.ts
+++ b/services/gateway/src/routes/worker-orchestrator.ts
@@ -1318,6 +1318,220 @@ workerOrchestratorRouter.get('/api/v1/worker/orchestrator/stats', async (_req: R
   }
 });
 
+// =============================================================================
+// PR-A (VTID-02922): /await-autopilot-execution
+// =============================================================================
+// Self-healing VTIDs are bridged into the Dev Autopilot execution pipeline
+// (see self-healing-injector-service bridgeToAutopilotExecution). The
+// worker-runner detects metadata.autopilot_execution_id and calls this
+// endpoint instead of running its describe-only LLM call. The four-state
+// contract is intentional: 'pr_ready' clears the repair-evidence gate at
+// /complete (real files_changed list from the PR), but the VTID is NOT
+// terminalized — the reconciler owns final terminal_outcome='success' only
+// after dev_autopilot_executions.status='completed' (which means CI passed,
+// merge happened, EXEC-DEPLOY ran, and the live probe verified).
+
+const AWAIT_POLL_INTERVAL_MS = 5_000;
+const AWAIT_DEFAULT_TIMEOUT_MS = 15 * 60_000;
+const AWAIT_HARD_TIMEOUT_MS = 30 * 60_000;
+
+interface PrFileChange {
+  path: string;
+  action: 'created' | 'changed';
+}
+
+async function fetchPrFileChanges(prNumber: number): Promise<PrFileChange[]> {
+  // Read env at call-time so the token can be set after module load
+  // (matters for tests + late-binding deployments).
+  const token = process.env.GITHUB_SAFE_MERGE_TOKEN || process.env.GITHUB_TOKEN || '';
+  if (!token) return [];
+  const owner = process.env.GITHUB_REPO_OWNER || 'exafyltd';
+  const repo = process.env.GITHUB_REPO_NAME || 'vitana-platform';
+  try {
+    const res = await fetch(
+      `https://api.github.com/repos/${owner}/${repo}/pulls/${prNumber}/files?per_page=100`,
+      {
+        headers: {
+          Authorization: `Bearer ${token}`,
+          Accept: 'application/vnd.github+json',
+          'X-GitHub-Api-Version': '2022-11-28',
+        },
+        signal: AbortSignal.timeout(15_000),
+      },
+    );
+    if (!res.ok) return [];
+    const body = (await res.json()) as Array<{ filename: string; status: string }>;
+    return body.map(f => ({
+      path: f.filename,
+      action: f.status === 'added' ? 'created' : 'changed',
+    }));
+  } catch {
+    return [];
+  }
+}
+
+interface AutopilotExecRow {
+  id: string;
+  status: string;
+  pr_url: string | null;
+  pr_number: number | null;
+  branch: string | null;
+  metadata: Record<string, unknown> | null;
+  completed_at: string | null;
+}
+
+async function fetchExecutionRow(executionId: string): Promise<AutopilotExecRow | null> {
+  const r = await supabaseRequest<AutopilotExecRow[]>(
+    `/rest/v1/dev_autopilot_executions?id=eq.${encodeURIComponent(executionId)}&select=id,status,pr_url,pr_number,branch,metadata,completed_at&limit=1`,
+  );
+  if (!r.ok || !r.data || r.data.length === 0) return null;
+  return r.data[0];
+}
+
+async function isWorkerClaimingVtid(vtid: string, workerId: string): Promise<boolean> {
+  const r = await supabaseRequest<Array<{ claimed_by: string | null; claim_expires_at: string | null }>>(
+    `/rest/v1/vtid_ledger?vtid=eq.${encodeURIComponent(vtid)}&select=claimed_by,claim_expires_at&limit=1`,
+  );
+  if (!r.ok || !r.data || r.data.length === 0) return false;
+  const row = r.data[0];
+  if (row.claimed_by !== workerId) return false;
+  if (!row.claim_expires_at) return true;
+  return new Date(row.claim_expires_at) > new Date();
+}
+
+/**
+ * POST /api/v1/worker/orchestrator/await-autopilot-execution
+ *
+ * Worker-only endpoint. The caller must:
+ *  - present a worker_id that exists in worker_registry
+ *  - hold a current claim on the VTID it's polling for
+ *
+ * Body: { vtid, autopilot_execution_id, worker_id, timeout_ms? }
+ *
+ * Polls dev_autopilot_executions every 5s until one of the four states
+ * is reached. See module comment above for the contract.
+ */
+workerOrchestratorRouter.post(
+  '/api/v1/worker/orchestrator/await-autopilot-execution',
+  async (req: Request, res: Response) => {
+    try {
+      const { vtid, autopilot_execution_id, worker_id, timeout_ms } = req.body || {};
+
+      if (!vtid || typeof vtid !== 'string') {
+        return res.status(400).json({ ok: false, error: 'vtid is required' });
+      }
+      if (!autopilot_execution_id || typeof autopilot_execution_id !== 'string') {
+        return res.status(400).json({ ok: false, error: 'autopilot_execution_id is required' });
+      }
+      if (!worker_id || typeof worker_id !== 'string') {
+        return res.status(401).json({ ok: false, error: 'worker_id is required' });
+      }
+
+      // Auth gate 1: confirm worker is registered.
+      const regCheck = await supabaseRequest<Array<{ worker_id: string }>>(
+        `/rest/v1/worker_registry?worker_id=eq.${encodeURIComponent(worker_id)}&select=worker_id&limit=1`,
+      );
+      if (!regCheck.ok || !regCheck.data || regCheck.data.length === 0) {
+        return res.status(401).json({ ok: false, error: 'worker not registered' });
+      }
+
+      // Auth gate 2: confirm worker is the current claim holder on this VTID.
+      const owns = await isWorkerClaimingVtid(vtid, worker_id);
+      if (!owns) {
+        return res.status(403).json({
+          ok: false,
+          error: 'worker does not hold an active claim on this VTID',
+        });
+      }
+
+      const cap = Math.min(
+        Math.max(60_000, Number(timeout_ms) || AWAIT_DEFAULT_TIMEOUT_MS),
+        AWAIT_HARD_TIMEOUT_MS,
+      );
+      const deadline = Date.now() + cap;
+
+      let lastStatus: string = 'unknown';
+      let lastRow: AutopilotExecRow | null = null;
+
+      while (Date.now() < deadline) {
+        const row = await fetchExecutionRow(autopilot_execution_id);
+        if (!row) {
+          return res.json({
+            state: 'failed',
+            error: 'autopilot execution row not found',
+            execution_status: 'unknown',
+          });
+        }
+        lastRow = row;
+        lastStatus = row.status;
+
+        if (row.status === 'failed' || row.status === 'failed_escalated' || row.status === 'reverted') {
+          const errMsg = (row.metadata as any)?.error
+            || `autopilot execution reached terminal status '${row.status}'`;
+          return res.json({
+            state: 'failed',
+            error: errMsg,
+            execution_status: row.status,
+          });
+        }
+
+        if (row.status === 'completed') {
+          const files = row.pr_number ? await fetchPrFileChanges(row.pr_number) : [];
+          return res.json({
+            state: 'completed',
+            pr_url: row.pr_url,
+            pr_number: row.pr_number,
+            branch: row.branch,
+            files_changed: files.filter(f => f.action === 'changed').map(f => f.path),
+            files_created: files.filter(f => f.action === 'created').map(f => f.path),
+            execution_status: row.status,
+          });
+        }
+
+        if (row.pr_url && row.pr_number && (
+          row.status === 'ci' || row.status === 'merging' ||
+          row.status === 'deploying' || row.status === 'verifying'
+        )) {
+          const files = await fetchPrFileChanges(row.pr_number);
+          return res.json({
+            state: 'pr_ready',
+            pr_url: row.pr_url,
+            pr_number: row.pr_number,
+            branch: row.branch,
+            files_changed: files.filter(f => f.action === 'changed').map(f => f.path),
+            files_created: files.filter(f => f.action === 'created').map(f => f.path),
+            execution_status: row.status,
+          });
+        }
+
+        await new Promise(r => setTimeout(r, AWAIT_POLL_INTERVAL_MS));
+      }
+
+      await emitOasisEvent({
+        type: 'self-healing.execution.deferred',
+        vtid,
+        source: 'worker-orchestrator',
+        status: 'info',
+        message: `Worker-runner await timed out after ${Math.round(cap / 1000)}s; autopilot execution ${autopilot_execution_id.slice(0, 8)} still in '${lastStatus}'`,
+        payload: {
+          autopilot_execution_id,
+          execution_status: lastStatus,
+          pr_url: lastRow?.pr_url || null,
+          worker_id,
+        },
+      });
+      return res.json({
+        state: 'deferred',
+        reason: 'timeout',
+        execution_status: lastStatus,
+      });
+    } catch (error: any) {
+      console.error(`${LOG_PREFIX} await-autopilot-execution error:`, error);
+      return res.status(500).json({ ok: false, error: error.message || 'unknown error' });
+    }
+  },
+);
+
 /**
  * POST /api/v1/worker/orchestrator/cleanup
  *

--- a/services/gateway/src/services/self-healing-injector-service.ts
+++ b/services/gateway/src/services/self-healing-injector-service.ts
@@ -9,6 +9,7 @@
 import { createHash } from 'crypto';
 import { Diagnosis } from '../types/self-healing';
 import { emitOasisEvent } from './oasis-event-service';
+import { bridgeActivationToExecution } from './dev-autopilot-execute';
 
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
@@ -26,6 +27,15 @@ function computeSpecHash(spec: string): string {
 }
 
 /**
+ * PR-A dedupe key: identifies a (endpoint, failure_class, spec_hash) tuple so
+ * the same incident isn't injected twice while an autopilot execution is in
+ * flight. Stored in autopilot_recommendations.spec_snapshot.dedupe_key.
+ */
+function computeDedupeKey(endpoint: string, failureClass: string, specHash: string): string {
+  return createHash('sha256').update(`${endpoint}:${failureClass}:${specHash}`).digest('hex');
+}
+
+/**
  * Map service display name to vtid_ledger module value.
  */
 function mapServiceToModule(serviceName: string): string {
@@ -37,6 +47,182 @@ function mapServiceToModule(serviceName: string): string {
     'Visual Interactive': 'GATEWAY', 'Conversation Intelligence': 'AGENTS',
   };
   return map[serviceName] || 'GATEWAY';
+}
+
+/**
+ * Map self-healing confidence to autopilot risk_class.
+ */
+function confidenceToRiskClass(confidence: number): 'low' | 'medium' | 'high' {
+  if (confidence >= 0.9) return 'low';
+  if (confidence >= 0.7) return 'medium';
+  return 'high';
+}
+
+/**
+ * PR-A (VTID-02922): Bridge a self-healing VTID into the Dev Autopilot
+ * execution pipeline so the proven runExecutionSession() patch-workspace
+ * path actually edits files, opens a real PR, watches CI, and verifies
+ * the live endpoint. Worker-runner no longer produces "claimed" file
+ * changes — it polls the execution this function creates.
+ *
+ * Idempotency: if an active autopilot execution already exists for the
+ * same dedupe_key (endpoint + failure_class + spec_hash), this function
+ * skips insertion and reuses the existing execution_id.
+ *
+ * Returns the execution_id so the caller can record it on vtid_ledger.metadata.
+ */
+async function bridgeToAutopilotExecution(
+  vtid: string,
+  diagnosis: Diagnosis,
+  spec: string,
+  specHash: string,
+): Promise<{ ok: boolean; execution_id?: string; deduped?: boolean; finding_id?: string; error?: string }> {
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
+    return { ok: false, error: 'supabase_not_configured' };
+  }
+
+  const dedupeKey = computeDedupeKey(diagnosis.endpoint, diagnosis.failure_class, specHash);
+
+  // Step 1: Look for an existing active recommendation with the same
+  // dedupe_key. Active = its linked execution isn't terminal.
+  try {
+    const existingResp = await fetch(
+      `${SUPABASE_URL}/rest/v1/autopilot_recommendations?` +
+        `spec_snapshot->>dedupe_key=eq.${dedupeKey}` +
+        `&select=id,status&limit=5`,
+      { headers: supabaseHeaders() },
+    );
+    if (existingResp.ok) {
+      const existing = (await existingResp.json()) as Array<{ id: string; status: string }>;
+      for (const rec of existing) {
+        const execResp = await fetch(
+          `${SUPABASE_URL}/rest/v1/dev_autopilot_executions?` +
+            `finding_id=eq.${rec.id}` +
+            `&status=not.in.(completed,failed,failed_escalated,reverted,cancelled,auto_archived,self_healed)` +
+            `&select=id,status&order=created_at.desc&limit=1`,
+          { headers: supabaseHeaders() },
+        );
+        if (execResp.ok) {
+          const execs = (await execResp.json()) as Array<{ id: string; status: string }>;
+          if (execs.length > 0) {
+            await emitOasisEvent({
+              type: 'self-healing.injection.deduped',
+              vtid,
+              source: 'self-healing-injector',
+              status: 'info',
+              message: `Reusing in-flight autopilot execution ${execs[0].id.slice(0, 8)} (status=${execs[0].status}) for dedupe_key ${dedupeKey.slice(0, 8)}`,
+              payload: {
+                dedupe_key: dedupeKey,
+                existing_execution_id: execs[0].id,
+                existing_finding_id: rec.id,
+                existing_status: execs[0].status,
+              },
+            });
+            return { ok: true, execution_id: execs[0].id, finding_id: rec.id, deduped: true };
+          }
+        }
+      }
+    }
+  } catch (err: any) {
+    console.warn(`[self-healing-injector] Dedupe check failed: ${err.message} — proceeding with fresh insert`);
+  }
+
+  // Step 2: Create the autopilot_recommendations row. source_type stays
+  // 'dev_autopilot' (the existing allowlist value); spec_snapshot.scanner
+  // marks the origin so the Self-Healing screen can filter.
+  const title = `SELF-HEAL: ${diagnosis.service_name} — ${diagnosis.failure_class}`;
+  const summary = diagnosis.root_cause.substring(0, 1000);
+  const filesReferenced = (diagnosis.files_to_modify || []).slice(0, 30);
+  const recBody = {
+    title,
+    summary,
+    domain: 'general',
+    risk_level: 'medium',
+    impact_score: 7,
+    effort_score: 4,
+    source_type: 'dev_autopilot',
+    risk_class: confidenceToRiskClass(diagnosis.confidence),
+    auto_exec_eligible: diagnosis.confidence >= 0.8,
+    status: 'new',
+    activated_vtid: vtid,
+    spec_snapshot: {
+      scanner: 'self-healing',
+      vtid,
+      dedupe_key: dedupeKey,
+      endpoint: diagnosis.endpoint,
+      failure_class: diagnosis.failure_class,
+      confidence: diagnosis.confidence,
+      spec_markdown: spec,
+      files_referenced: filesReferenced,
+      suggested_fix: diagnosis.suggested_fix,
+      root_cause: diagnosis.root_cause,
+    },
+    spec_checksum: specHash,
+  };
+
+  const recResp = await fetch(`${SUPABASE_URL}/rest/v1/autopilot_recommendations`, {
+    method: 'POST',
+    headers: { ...supabaseHeaders(), Prefer: 'return=representation' },
+    body: JSON.stringify(recBody),
+  });
+  if (!recResp.ok) {
+    const errText = await recResp.text();
+    return { ok: false, error: `autopilot_recommendations insert failed: ${recResp.status} ${errText.slice(0, 300)}` };
+  }
+  const recRows = (await recResp.json()) as Array<{ id: string }>;
+  if (!recRows || recRows.length === 0) {
+    return { ok: false, error: 'autopilot_recommendations insert returned no row' };
+  }
+  const findingId = recRows[0].id;
+
+  // Step 3: Insert the plan_version row directly. runExecutionSession reads
+  // plan_markdown + files_referenced from here, so this is the actual
+  // execution-driving spec for the LLM.
+  const planResp = await fetch(`${SUPABASE_URL}/rest/v1/dev_autopilot_plan_versions`, {
+    method: 'POST',
+    headers: { ...supabaseHeaders(), Prefer: 'return=minimal' },
+    body: JSON.stringify({
+      finding_id: findingId,
+      version: 1,
+      plan_markdown: spec,
+      files_referenced: filesReferenced,
+      author: 'self-healing-injector',
+    }),
+  });
+  if (!planResp.ok) {
+    const errText = await planResp.text();
+    return { ok: false, error: `dev_autopilot_plan_versions insert failed: ${planResp.status} ${errText.slice(0, 300)}` };
+  }
+
+  // Step 4: Bridge to execution. bridgeActivationToExecution handles the
+  // in-flight guard, calls approveAutoExecute (which creates the cooling
+  // row), and patches execute_after to NOW so backgroundExecutorTick
+  // picks it up on the next tick.
+  const bridge = await bridgeActivationToExecution(findingId, null);
+  if (!bridge.ok || !bridge.execution_id) {
+    return {
+      ok: false,
+      error: `bridgeActivationToExecution failed: ${bridge.error || bridge.skipped || 'unknown'}`,
+    };
+  }
+
+  await emitOasisEvent({
+    type: 'self-healing.execution.bridged',
+    vtid,
+    source: 'self-healing-injector',
+    status: 'info',
+    message: `Self-healing bridged to autopilot execution ${bridge.execution_id.slice(0, 8)} for ${diagnosis.endpoint}`,
+    payload: {
+      dedupe_key: dedupeKey,
+      finding_id: findingId,
+      execution_id: bridge.execution_id,
+      endpoint: diagnosis.endpoint,
+      failure_class: diagnosis.failure_class,
+      confidence: diagnosis.confidence,
+    },
+  });
+
+  return { ok: true, execution_id: bridge.execution_id, finding_id: findingId, deduped: false };
 }
 
 /**
@@ -133,6 +319,66 @@ export async function injectIntoAutopilotPipeline(
         payload: { auto_approved: true, source: 'self-healing' },
       });
       console.log(`[self-healing-injector] ${vtid} auto-approved and injected into autopilot pipeline`);
+
+      // Step 3b (PR-A): also bridge to the Dev Autopilot execution pipeline so
+      // worker-runner's "describe-only" LLM call gets replaced with a real
+      // patch-workspace + PR via runExecutionSession. Worker-runner detects
+      // metadata.autopilot_execution_id and polls the execution status via the
+      // new /await-autopilot-execution endpoint. Skipped if the bridge fails;
+      // worker-runner's repair-evidence gate (PR #2045) will then correctly
+      // refuse to mark the VTID succeeded without files_changed.
+      if (!isVoiceSyntheticSource) {
+        try {
+          const bridge = await bridgeToAutopilotExecution(vtid, diagnosis, spec, specHash);
+          if (bridge.ok && bridge.execution_id) {
+            await fetch(`${SUPABASE_URL}/rest/v1/vtid_ledger?vtid=eq.${vtid}`, {
+              method: 'PATCH',
+              headers: { ...supabaseHeaders(), Prefer: 'return=minimal' },
+              body: JSON.stringify({
+                metadata: {
+                  source: 'self-healing',
+                  phase: 'injected',
+                  failure_class: diagnosis.failure_class,
+                  confidence: diagnosis.confidence,
+                  endpoint: diagnosis.endpoint,
+                  priority: 'critical',
+                  auto_approved: autoApproved,
+                  files_to_modify: diagnosis.files_to_modify,
+                  files_analyzed: diagnosis.files_read.length,
+                  evidence_count: diagnosis.evidence.length,
+                  max_attempts: 2,
+                  spec_hash: specHash,
+                  // PR-A linkage so worker-runner + reconciler can find it.
+                  autopilot_execution_id: bridge.execution_id,
+                  autopilot_finding_id: bridge.finding_id,
+                  autopilot_deduped: bridge.deduped === true,
+                  healing_state: 'execution_dispatched',
+                },
+                updated_at: new Date().toISOString(),
+              }),
+            });
+            console.log(
+              `[self-healing-injector] ${vtid} bridged to autopilot execution ${bridge.execution_id.slice(0, 8)}` +
+                (bridge.deduped ? ' (deduped, reused existing)' : ''),
+            );
+          } else {
+            console.warn(
+              `[self-healing-injector] ${vtid} autopilot bridge failed: ${bridge.error || 'unknown'} — ` +
+                `worker-runner will see no execution_id and the repair-evidence gate will refuse completion.`,
+            );
+            await emitOasisEvent({
+              type: 'self-healing.execution.bridge_failed',
+              vtid,
+              source: 'self-healing-injector',
+              status: 'warning',
+              message: `Autopilot execution bridge failed: ${bridge.error || 'unknown'}`,
+              payload: { error: bridge.error, endpoint: diagnosis.endpoint },
+            });
+          }
+        } catch (bridgeErr: any) {
+          console.error(`[self-healing-injector] ${vtid} autopilot bridge threw: ${bridgeErr.message}`);
+        }
+      }
     } else {
       // Level 2: Requires human approval — task appears in Command Hub approvals
       console.log(`[self-healing-injector] ${vtid} requires human approval (confidence ${(diagnosis.confidence * 100).toFixed(0)}%)`);

--- a/services/gateway/src/services/self-healing-reconciler.ts
+++ b/services/gateway/src/services/self-healing-reconciler.ts
@@ -406,10 +406,188 @@ async function reconcileVoiceRow(
   }
 }
 
+// PR-A (VTID-02922): owner of final terminal_outcome for self-healing VTIDs
+// that were bridged into the Dev Autopilot execution pipeline. Worker-runner
+// returns a 'pr_ready' (PR opened but CI/deploy/verify still in flight) or
+// 'deferred' (autopilot still running past worker-runner await window) and
+// MUST NOT terminalize the VTID itself. This scan runs every reconciler
+// cycle and:
+//   - terminalizes 'success' when dev_autopilot_executions.status='completed'
+//     (which means CI green + deploy verified + live probe passed)
+//   - terminalizes 'failed' when status in (failed, failed_escalated, reverted)
+//   - leaves in-flight statuses alone (cooling/running/ci/merging/...)
+export async function reconcileAutopilotLinkedSelfHealingVtids(): Promise<void> {
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) return;
+  try {
+    // Pull self-healing VTIDs that have a linked autopilot execution and are
+    // not terminal yet. Filter via metadata.source + metadata.autopilot_execution_id.
+    const ledgerUrl =
+      `${SUPABASE_URL}/rest/v1/vtid_ledger` +
+      `?metadata->>source=eq.self-healing` +
+      `&metadata->>autopilot_execution_id=not.is.null` +
+      `&is_terminal=eq.false` +
+      `&select=vtid,metadata,claimed_by,claim_expires_at` +
+      `&order=updated_at.asc&limit=50`;
+    const ledgerRes = await fetch(ledgerUrl, { headers: supabaseHeaders() });
+    if (!ledgerRes.ok) {
+      const txt = await ledgerRes.text().catch(() => '');
+      console.warn(`${LOG_PREFIX} autopilot-linked scan: ledger fetch ${ledgerRes.status} ${txt.slice(0, 200)}`);
+      return;
+    }
+    const ledgerRows = (await ledgerRes.json()) as Array<{
+      vtid: string;
+      metadata: Record<string, unknown> | null;
+    }>;
+    if (ledgerRows.length === 0) return;
+
+    for (const lrow of ledgerRows) {
+      const execId = lrow.metadata?.autopilot_execution_id as string | undefined;
+      if (!execId) continue;
+
+      const execRes = await fetch(
+        `${SUPABASE_URL}/rest/v1/dev_autopilot_executions?id=eq.${encodeURIComponent(execId)}` +
+          `&select=id,status,pr_url,pr_number,branch,metadata,completed_at&limit=1`,
+        { headers: supabaseHeaders() },
+      );
+      if (!execRes.ok) continue;
+      const execRows = (await execRes.json()) as Array<{
+        id: string;
+        status: string;
+        pr_url: string | null;
+        pr_number: number | null;
+        branch: string | null;
+        metadata: Record<string, unknown> | null;
+        completed_at: string | null;
+      }>;
+      if (execRows.length === 0) continue;
+      const exec = execRows[0];
+
+      // Final success: autopilot says CI green + deploy verified + live probe.
+      if (exec.status === 'completed') {
+        const newMeta = {
+          ...(lrow.metadata || {}),
+          healing_state: 'verified_healed',
+          pr_url: exec.pr_url,
+          pr_number: exec.pr_number,
+          branch: exec.branch,
+          terminalized_by: 'self-healing-reconciler',
+          terminalized_at: new Date().toISOString(),
+        };
+        await fetch(`${SUPABASE_URL}/rest/v1/vtid_ledger?vtid=eq.${encodeURIComponent(lrow.vtid)}`, {
+          method: 'PATCH',
+          headers: { ...supabaseHeaders(), Prefer: 'return=minimal' },
+          body: JSON.stringify({
+            status: 'completed',
+            is_terminal: true,
+            terminal_outcome: 'success',
+            metadata: newMeta,
+            updated_at: new Date().toISOString(),
+          }),
+        }).catch(err => console.warn(`${LOG_PREFIX} vtid_ledger PATCH failed for ${lrow.vtid}:`, err));
+
+        await fetch(
+          `${SUPABASE_URL}/rest/v1/self_healing_log?vtid=eq.${encodeURIComponent(lrow.vtid)}&outcome=eq.pending`,
+          {
+            method: 'PATCH',
+            headers: { ...supabaseHeaders(), Prefer: 'return=minimal' },
+            body: JSON.stringify({
+              outcome: 'fixed',
+              resolved_at: new Date().toISOString(),
+            }),
+          },
+        ).catch(err => console.warn(`${LOG_PREFIX} self_healing_log PATCH failed for ${lrow.vtid}:`, err));
+
+        try {
+          await emitOasisEvent({
+            vtid: lrow.vtid,
+            type: 'self-healing.completed',
+            source: 'self-healing-reconciler',
+            status: 'success',
+            message: `Self-healing verified-healed for ${lrow.vtid}: autopilot execution ${execId.slice(0, 8)} reached 'completed' (PR ${exec.pr_url || '?'})`,
+            payload: {
+              autopilot_execution_id: execId,
+              pr_url: exec.pr_url,
+              pr_number: exec.pr_number,
+              branch: exec.branch,
+            },
+          });
+        } catch { /* non-fatal */ }
+        console.log(`${LOG_PREFIX} ${lrow.vtid} terminalized success via autopilot execution ${execId.slice(0, 8)}`);
+        continue;
+      }
+
+      // Terminal failure on the autopilot side → propagate to the VTID.
+      if (exec.status === 'failed' || exec.status === 'failed_escalated' || exec.status === 'reverted') {
+        const errMsg =
+          (exec.metadata as any)?.error ||
+          `autopilot execution reached terminal status '${exec.status}'`;
+        const newMeta = {
+          ...(lrow.metadata || {}),
+          healing_state: 'execution_failed',
+          execution_failure_status: exec.status,
+          execution_failure_error: errMsg,
+          terminalized_by: 'self-healing-reconciler',
+          terminalized_at: new Date().toISOString(),
+        };
+        await fetch(`${SUPABASE_URL}/rest/v1/vtid_ledger?vtid=eq.${encodeURIComponent(lrow.vtid)}`, {
+          method: 'PATCH',
+          headers: { ...supabaseHeaders(), Prefer: 'return=minimal' },
+          body: JSON.stringify({
+            is_terminal: true,
+            terminal_outcome: 'failed',
+            metadata: newMeta,
+            updated_at: new Date().toISOString(),
+          }),
+        }).catch(err => console.warn(`${LOG_PREFIX} vtid_ledger PATCH failed for ${lrow.vtid}:`, err));
+
+        await fetch(
+          `${SUPABASE_URL}/rest/v1/self_healing_log?vtid=eq.${encodeURIComponent(lrow.vtid)}&outcome=eq.pending`,
+          {
+            method: 'PATCH',
+            headers: { ...supabaseHeaders(), Prefer: 'return=minimal' },
+            body: JSON.stringify({
+              outcome: 'escalated',
+              resolved_at: new Date().toISOString(),
+            }),
+          },
+        ).catch(err => console.warn(`${LOG_PREFIX} self_healing_log PATCH failed for ${lrow.vtid}:`, err));
+
+        try {
+          await emitOasisEvent({
+            vtid: lrow.vtid,
+            type: 'self-healing.execution.failed',
+            source: 'self-healing-reconciler',
+            status: 'error',
+            message: `Self-healing execution failed for ${lrow.vtid}: ${errMsg}`,
+            payload: {
+              autopilot_execution_id: execId,
+              execution_status: exec.status,
+              error: errMsg,
+            },
+          });
+        } catch { /* non-fatal */ }
+        console.log(`${LOG_PREFIX} ${lrow.vtid} terminalized failed via autopilot execution ${execId.slice(0, 8)} (${exec.status})`);
+        continue;
+      }
+
+      // Otherwise: cooling / queued / running / ci / merging / deploying /
+      // verifying — the autopilot reconciler is still progressing this row.
+      // Leave it alone; we'll re-check on the next cycle.
+    }
+  } catch (err) {
+    console.warn(`${LOG_PREFIX} autopilot-linked scan error:`, err);
+  }
+}
+
 async function runReconcileCycle(thresholdMs: number): Promise<void> {
   if (cycleInFlight) return;
   cycleInFlight = true;
   try {
+    // PR-A (VTID-02922): terminalize self-healing VTIDs whose autopilot
+    // execution has reached a terminal state. Runs before the legacy stale
+    // scan so successful autopilot runs clear quickly.
+    await reconcileAutopilotLinkedSelfHealingVtids();
+
     const rows = await fetchStaleRows(thresholdMs);
     if (rows.length === 0) return;
     console.log(`${LOG_PREFIX} Found ${rows.length} stale row(s) to reconcile`);

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -581,6 +581,14 @@ export type CicdEventType =
   | 'self-healing.spec.generated'
   | 'self-healing.task.injected'
   | 'self-healing.task.skipped'
+  // PR-A (VTID-02922): bridge into Dev Autopilot execution pipeline + the
+  // four-state contract events from worker-runner / reconciler.
+  | 'self-healing.injection.deduped'
+  | 'self-healing.execution.bridged'
+  | 'self-healing.execution.bridge_failed'
+  | 'self-healing.execution.deferred'
+  | 'self-healing.execution.failed'
+  | 'self-healing.completed'
   | 'self-healing.snapshot.pre_fix'
   | 'self-healing.snapshot.post_fix'
   | 'self-healing.verification.success'

--- a/services/gateway/src/types/self-healing.ts
+++ b/services/gateway/src/types/self-healing.ts
@@ -190,6 +190,9 @@ export const ENDPOINT_FILE_MAP: Record<string, string> = {
   '/api/v1/assistant/health': 'services/gateway/src/routes/assistant.ts',
   '/api/v1/assistant/knowledge/health': 'services/gateway/src/routes/assistant.ts',
   '/api/v1/orb/health': 'services/gateway/src/routes/orb-live.ts',
+  // PR-A (VTID-02922): operator-armed canary for end-to-end self-healing
+  // smoke tests. Endpoint returns 500 iff system_config.self_healing_canary_armed=true.
+  '/api/v1/self-healing/canary/failing-health': 'services/gateway/src/routes/self-healing-canary.ts',
   '/api/v1/voice-lab/health': 'services/gateway/src/routes/voice-lab.ts',
   '/api/v1/conversation/health': 'services/gateway/src/routes/conversation.ts',
   '/api/v1/conversation/tool-health': 'services/gateway/src/routes/conversation.ts',

--- a/services/gateway/test/self-healing-injector-autopilot-bridge.test.ts
+++ b/services/gateway/test/self-healing-injector-autopilot-bridge.test.ts
@@ -1,0 +1,232 @@
+/**
+ * PR-A (VTID-02922): self-healing injector bridges into Dev Autopilot
+ * executions so the proven patch-workspace + real-PR pipeline runs instead
+ * of worker-runner's describe-only LLM call. Tests cover:
+ *
+ *   1. First injection writes both autopilot_recommendations and
+ *      dev_autopilot_executions rows and records execution_id on
+ *      vtid_ledger.metadata.
+ *   2. A second injection with the same dedupe key (endpoint + failure_class
+ *      + spec_hash) DOES NOT write a new recommendation/execution — it
+ *      reuses the existing in-flight execution_id.
+ *   3. Voice synthetic endpoints skip the autopilot bridge entirely (they
+ *      have their own Synthetic Voice Probe path).
+ */
+
+jest.mock('../src/services/dev-autopilot-execute', () => ({
+  bridgeActivationToExecution: jest.fn(),
+}));
+
+import { bridgeActivationToExecution } from '../src/services/dev-autopilot-execute';
+import { injectIntoAutopilotPipeline } from '../src/services/self-healing-injector-service';
+import type { Diagnosis } from '../src/types/self-healing';
+
+const bridgeMock = bridgeActivationToExecution as unknown as jest.Mock;
+const ORIGINAL_FETCH = global.fetch;
+
+function makeDiagnosis(overrides: Partial<Diagnosis> = {}): Diagnosis {
+  return {
+    service_name: 'Availability Health',
+    endpoint: '/api/v1/availability/health',
+    vtid: 'VTID-99999',
+    failure_class: 'route_not_registered' as any,
+    confidence: 0.9,
+    root_cause: 'Route file missing on disk',
+    suggested_fix: 'Add health handler',
+    auto_fixable: true,
+    evidence: ['handler not found'],
+    codebase_analysis: null,
+    git_analysis: null,
+    dependency_analysis: null,
+    workflow_analysis: null,
+    files_to_modify: ['services/gateway/src/routes/availability.ts'],
+    files_read: [],
+    ...overrides,
+  };
+}
+
+interface MockState {
+  existingRecommendations: Array<{ id: string; status: string }>;
+  existingActiveExecution: { id: string; status: string } | null;
+  recommendationInserts: any[];
+  planVersionInserts: any[];
+  ledgerPatches: any[];
+}
+
+function setupFetchMock(state: MockState): void {
+  global.fetch = jest.fn().mockImplementation(async (url: string, init?: any) => {
+    const method = init?.method || 'GET';
+    const body = init?.body ? JSON.parse(init.body) : null;
+
+    // 1. Dedupe lookup against autopilot_recommendations
+    if (url.includes('/rest/v1/autopilot_recommendations?') && url.includes('spec_snapshot->>dedupe_key=eq.')) {
+      return {
+        ok: true,
+        json: () => Promise.resolve(state.existingRecommendations),
+      };
+    }
+
+    // 2. In-flight execution check for an existing recommendation
+    if (url.includes('/rest/v1/dev_autopilot_executions?finding_id=eq.')) {
+      return {
+        ok: true,
+        json: () => Promise.resolve(state.existingActiveExecution ? [state.existingActiveExecution] : []),
+      };
+    }
+
+    // 3. Recommendation INSERT
+    if (url.endsWith('/rest/v1/autopilot_recommendations') && method === 'POST') {
+      state.recommendationInserts.push(body);
+      return {
+        ok: true,
+        text: () => Promise.resolve('[{"id":"finding-uuid-001"}]'),
+        json: () => Promise.resolve([{ id: 'finding-uuid-001' }]),
+      };
+    }
+
+    // 4. Plan version INSERT
+    if (url.endsWith('/rest/v1/dev_autopilot_plan_versions') && method === 'POST') {
+      state.planVersionInserts.push(body);
+      return { ok: true, text: () => Promise.resolve(''), json: () => Promise.resolve([]) };
+    }
+
+    // 5. vtid_ledger PATCHes (initial + post-bridge metadata write)
+    if (url.includes('/rest/v1/vtid_ledger?vtid=eq.') && method === 'PATCH') {
+      state.ledgerPatches.push(body);
+      return { ok: true, text: () => Promise.resolve(''), json: () => Promise.resolve([]) };
+    }
+
+    // 6. self_healing_log insert (best-effort, ignored)
+    if (url.endsWith('/rest/v1/self_healing_log') && method === 'POST') {
+      return { ok: true, text: () => Promise.resolve(''), json: () => Promise.resolve([]) };
+    }
+
+    return { ok: true, text: () => Promise.resolve(''), json: () => Promise.resolve([]) };
+  }) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  process.env.SUPABASE_URL = 'https://supabase.test';
+  process.env.SUPABASE_SERVICE_ROLE = 'svc-role';
+  bridgeMock.mockReset();
+  bridgeMock.mockResolvedValue({ ok: true, execution_id: 'exec-uuid-abc12345', skipped: undefined });
+});
+
+afterEach(() => {
+  global.fetch = ORIGINAL_FETCH;
+});
+
+describe('injectIntoAutopilotPipeline — autopilot bridge', () => {
+  it('first injection writes recommendation + plan_version + execution link', async () => {
+    const state: MockState = {
+      existingRecommendations: [],
+      existingActiveExecution: null,
+      recommendationInserts: [],
+      planVersionInserts: [],
+      ledgerPatches: [],
+    };
+    setupFetchMock(state);
+    const diagnosis = makeDiagnosis();
+
+    const result = await injectIntoAutopilotPipeline('VTID-99999', diagnosis, 'spec markdown', 'hash-abc');
+
+    expect(result.success).toBe(true);
+    expect(state.recommendationInserts.length).toBe(1);
+    expect(state.planVersionInserts.length).toBe(1);
+    expect(bridgeMock).toHaveBeenCalledTimes(1);
+    expect(bridgeMock.mock.calls[0][0]).toBe('finding-uuid-001');
+
+    // Recommendation carries the self-healing scanner marker.
+    const rec = state.recommendationInserts[0];
+    expect(rec.source_type).toBe('dev_autopilot');
+    expect(rec.spec_snapshot.scanner).toBe('self-healing');
+    expect(typeof rec.spec_snapshot.dedupe_key).toBe('string');
+    expect(rec.spec_snapshot.dedupe_key.length).toBe(64); // sha256 hex
+
+    // Plan version carries the spec markdown.
+    expect(state.planVersionInserts[0].plan_markdown).toBe('spec markdown');
+    expect(state.planVersionInserts[0].files_referenced).toEqual([
+      'services/gateway/src/routes/availability.ts',
+    ]);
+
+    // Ledger is patched twice: once initially (status=scheduled), then post-bridge
+    // with autopilot_execution_id in metadata.
+    expect(state.ledgerPatches.length).toBeGreaterThanOrEqual(2);
+    const lastPatch = state.ledgerPatches[state.ledgerPatches.length - 1];
+    expect(lastPatch.metadata.autopilot_execution_id).toBe('exec-uuid-abc12345');
+    expect(lastPatch.metadata.autopilot_finding_id).toBe('finding-uuid-001');
+    expect(lastPatch.metadata.healing_state).toBe('execution_dispatched');
+  });
+
+  it('second injection with same dedupe key reuses the existing execution', async () => {
+    const state: MockState = {
+      existingRecommendations: [{ id: 'finding-uuid-existing', status: 'new' }],
+      existingActiveExecution: { id: 'exec-uuid-existing', status: 'running' },
+      recommendationInserts: [],
+      planVersionInserts: [],
+      ledgerPatches: [],
+    };
+    setupFetchMock(state);
+    const diagnosis = makeDiagnosis();
+
+    const result = await injectIntoAutopilotPipeline('VTID-99999', diagnosis, 'spec markdown', 'hash-abc');
+
+    expect(result.success).toBe(true);
+    // No new recommendation / plan_version / execution.
+    expect(state.recommendationInserts.length).toBe(0);
+    expect(state.planVersionInserts.length).toBe(0);
+    expect(bridgeMock).not.toHaveBeenCalled();
+    // Ledger should be patched with the existing execution_id.
+    const patchedWithExec = state.ledgerPatches.some(
+      p => p.metadata?.autopilot_execution_id === 'exec-uuid-existing',
+    );
+    expect(patchedWithExec).toBe(true);
+  });
+
+  it('voice synthetic endpoints skip the autopilot bridge entirely', async () => {
+    const state: MockState = {
+      existingRecommendations: [],
+      existingActiveExecution: null,
+      recommendationInserts: [],
+      planVersionInserts: [],
+      ledgerPatches: [],
+    };
+    setupFetchMock(state);
+    const diagnosis = makeDiagnosis({ endpoint: 'voice-error://no_audio_in' });
+
+    const result = await injectIntoAutopilotPipeline('VTID-99998', diagnosis, 'voice spec', 'hash-voice');
+
+    expect(result.success).toBe(true);
+    // Voice still PATCHes vtid_ledger initially but NEVER writes
+    // autopilot_recommendations / plan_versions / calls the bridge.
+    expect(state.recommendationInserts.length).toBe(0);
+    expect(state.planVersionInserts.length).toBe(0);
+    expect(bridgeMock).not.toHaveBeenCalled();
+    // No PATCH carries autopilot_execution_id.
+    const carriesExecId = state.ledgerPatches.some(p => p.metadata?.autopilot_execution_id);
+    expect(carriesExecId).toBe(false);
+  });
+
+  it('bridge failure does not break the injector (worker-runner gate catches it)', async () => {
+    const state: MockState = {
+      existingRecommendations: [],
+      existingActiveExecution: null,
+      recommendationInserts: [],
+      planVersionInserts: [],
+      ledgerPatches: [],
+    };
+    setupFetchMock(state);
+    bridgeMock.mockResolvedValue({ ok: false, error: 'plan generation failed' });
+    const diagnosis = makeDiagnosis();
+
+    const result = await injectIntoAutopilotPipeline('VTID-99997', diagnosis, 'spec', 'hash-fail');
+
+    // Injection itself succeeds (vtid_ledger initial PATCH worked).
+    expect(result.success).toBe(true);
+    // Bridge was attempted and failed.
+    expect(bridgeMock).toHaveBeenCalledTimes(1);
+    // No PATCH carried autopilot_execution_id (the bridge failed).
+    const carriesExecId = state.ledgerPatches.some(p => p.metadata?.autopilot_execution_id);
+    expect(carriesExecId).toBe(false);
+  });
+});

--- a/services/gateway/test/self-healing-reconciler-autopilot-link.test.ts
+++ b/services/gateway/test/self-healing-reconciler-autopilot-link.test.ts
@@ -1,0 +1,253 @@
+/**
+ * PR-A (VTID-02922): the self-healing reconciler — NOT the worker-runner —
+ * owns final terminal_outcome for self-healing VTIDs that were bridged into
+ * the Dev Autopilot execution pipeline. This scan reads
+ * dev_autopilot_executions.status for each linked row and:
+ *
+ *   - status='completed'                              → terminalize 'success'
+ *   - status in (failed, failed_escalated, reverted)  → terminalize 'failed'
+ *   - any in-flight status (cooling/running/ci/...)    → leave alone
+ *
+ * Worker-runner's 'pr_ready' completion only clears the repair-evidence
+ * gate; this scan is what flips terminal_outcome=success after CI green
+ * + deploy + live probe. Verified by inspecting which PATCH bodies hit
+ * vtid_ledger / self_healing_log.
+ */
+
+import { reconcileAutopilotLinkedSelfHealingVtids } from '../src/services/self-healing-reconciler';
+
+const ORIGINAL_FETCH = global.fetch;
+
+interface MockState {
+  ledgerRows: Array<{
+    vtid: string;
+    metadata: any;
+  }>;
+  executionRowsById: Record<string, {
+    id: string;
+    status: string;
+    pr_url: string | null;
+    pr_number: number | null;
+    branch: string | null;
+    metadata: any;
+    completed_at: string | null;
+  }>;
+  ledgerPatches: Array<{ vtid: string; body: any }>;
+  selfHealingLogPatches: Array<{ vtid: string; body: any }>;
+}
+
+function setupFetchMock(state: MockState) {
+  global.fetch = jest.fn().mockImplementation(async (url: string, init?: any) => {
+    const method = init?.method || 'GET';
+    const body = init?.body ? JSON.parse(init.body) : null;
+
+    // 1. Scan for self-healing VTIDs with autopilot_execution_id
+    if (url.includes('/rest/v1/vtid_ledger?metadata->>source=eq.self-healing')) {
+      return { ok: true, json: () => Promise.resolve(state.ledgerRows) };
+    }
+
+    // 2. Per-execution lookup
+    const execMatch = url.match(/dev_autopilot_executions\?id=eq\.([^&]+)/);
+    if (execMatch && method === 'GET') {
+      const id = decodeURIComponent(execMatch[1]);
+      const row = state.executionRowsById[id];
+      return { ok: true, json: () => Promise.resolve(row ? [row] : []) };
+    }
+
+    // 3. vtid_ledger PATCH (terminalize)
+    const ledgerPatchMatch = url.match(/vtid_ledger\?vtid=eq\.([^&]+)/);
+    if (ledgerPatchMatch && method === 'PATCH') {
+      state.ledgerPatches.push({ vtid: decodeURIComponent(ledgerPatchMatch[1]), body });
+      return { ok: true, text: () => Promise.resolve('') };
+    }
+
+    // 4. self_healing_log PATCH
+    const shLogPatchMatch = url.match(/self_healing_log\?vtid=eq\.([^&]+)/);
+    if (shLogPatchMatch && method === 'PATCH') {
+      state.selfHealingLogPatches.push({ vtid: decodeURIComponent(shLogPatchMatch[1]), body });
+      return { ok: true, text: () => Promise.resolve('') };
+    }
+
+    return { ok: true, json: () => Promise.resolve([]) };
+  }) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  process.env.SUPABASE_URL = 'https://supabase.test';
+  process.env.SUPABASE_SERVICE_ROLE = 'svc-role';
+});
+
+afterEach(() => {
+  global.fetch = ORIGINAL_FETCH;
+});
+
+describe('reconcileAutopilotLinkedSelfHealingVtids', () => {
+  it('terminalizes success when execution.status=completed', async () => {
+    const state: MockState = {
+      ledgerRows: [{
+        vtid: 'VTID-90001',
+        metadata: { source: 'self-healing', autopilot_execution_id: 'exec-good-001' },
+      }],
+      executionRowsById: {
+        'exec-good-001': {
+          id: 'exec-good-001',
+          status: 'completed',
+          pr_url: 'https://github.com/exafyltd/vitana-platform/pull/9999',
+          pr_number: 9999,
+          branch: 'fix/canary',
+          metadata: { merged_sha: 'abc1234567' },
+          completed_at: new Date().toISOString(),
+        },
+      },
+      ledgerPatches: [],
+      selfHealingLogPatches: [],
+    };
+    setupFetchMock(state);
+
+    await reconcileAutopilotLinkedSelfHealingVtids();
+
+    expect(state.ledgerPatches.length).toBe(1);
+    const ledger = state.ledgerPatches[0];
+    expect(ledger.vtid).toBe('VTID-90001');
+    expect(ledger.body.status).toBe('completed');
+    expect(ledger.body.is_terminal).toBe(true);
+    expect(ledger.body.terminal_outcome).toBe('success');
+    expect(ledger.body.metadata.healing_state).toBe('verified_healed');
+    expect(ledger.body.metadata.pr_url).toBe('https://github.com/exafyltd/vitana-platform/pull/9999');
+
+    expect(state.selfHealingLogPatches.length).toBe(1);
+    expect(state.selfHealingLogPatches[0].body.outcome).toBe('fixed');
+  });
+
+  it('terminalizes failed when execution.status=failed', async () => {
+    const state: MockState = {
+      ledgerRows: [{
+        vtid: 'VTID-90002',
+        metadata: { source: 'self-healing', autopilot_execution_id: 'exec-bad-002' },
+      }],
+      executionRowsById: {
+        'exec-bad-002': {
+          id: 'exec-bad-002',
+          status: 'failed',
+          pr_url: null,
+          pr_number: null,
+          branch: null,
+          metadata: { error: 'jest validation failed across 3 attempts' },
+          completed_at: new Date().toISOString(),
+        },
+      },
+      ledgerPatches: [],
+      selfHealingLogPatches: [],
+    };
+    setupFetchMock(state);
+
+    await reconcileAutopilotLinkedSelfHealingVtids();
+
+    expect(state.ledgerPatches.length).toBe(1);
+    const ledger = state.ledgerPatches[0];
+    expect(ledger.body.is_terminal).toBe(true);
+    expect(ledger.body.terminal_outcome).toBe('failed');
+    expect(ledger.body.metadata.healing_state).toBe('execution_failed');
+    expect(ledger.body.metadata.execution_failure_error).toContain('jest validation failed');
+
+    expect(state.selfHealingLogPatches[0].body.outcome).toBe('escalated');
+  });
+
+  it('terminalizes failed when execution.status=failed_escalated', async () => {
+    const state: MockState = {
+      ledgerRows: [{
+        vtid: 'VTID-90003',
+        metadata: { source: 'self-healing', autopilot_execution_id: 'exec-esc-003' },
+      }],
+      executionRowsById: {
+        'exec-esc-003': {
+          id: 'exec-esc-003',
+          status: 'failed_escalated',
+          pr_url: null,
+          pr_number: null,
+          branch: null,
+          metadata: {},
+          completed_at: new Date().toISOString(),
+        },
+      },
+      ledgerPatches: [],
+      selfHealingLogPatches: [],
+    };
+    setupFetchMock(state);
+
+    await reconcileAutopilotLinkedSelfHealingVtids();
+
+    expect(state.ledgerPatches.length).toBe(1);
+    expect(state.ledgerPatches[0].body.terminal_outcome).toBe('failed');
+  });
+
+  it.each([
+    ['cooling'], ['queued'], ['running'], ['ci'], ['merging'], ['deploying'], ['verifying'],
+  ])('leaves VTID alone when execution.status=%s (still in flight)', async (status) => {
+    const state: MockState = {
+      ledgerRows: [{
+        vtid: 'VTID-90099',
+        metadata: { source: 'self-healing', autopilot_execution_id: 'exec-inflight' },
+      }],
+      executionRowsById: {
+        'exec-inflight': {
+          id: 'exec-inflight',
+          status,
+          pr_url: status === 'ci' || status === 'merging' ? 'https://github.com/x/y/pull/1' : null,
+          pr_number: status === 'ci' || status === 'merging' ? 1 : null,
+          branch: null,
+          metadata: {},
+          completed_at: null,
+        },
+      },
+      ledgerPatches: [],
+      selfHealingLogPatches: [],
+    };
+    setupFetchMock(state);
+
+    await reconcileAutopilotLinkedSelfHealingVtids();
+
+    expect(state.ledgerPatches.length).toBe(0);
+    expect(state.selfHealingLogPatches.length).toBe(0);
+  });
+
+  it('handles multiple rows in one scan (success + failure mixed)', async () => {
+    const state: MockState = {
+      ledgerRows: [
+        { vtid: 'VTID-A', metadata: { source: 'self-healing', autopilot_execution_id: 'exec-A' } },
+        { vtid: 'VTID-B', metadata: { source: 'self-healing', autopilot_execution_id: 'exec-B' } },
+        { vtid: 'VTID-C', metadata: { source: 'self-healing', autopilot_execution_id: 'exec-C' } },
+      ],
+      executionRowsById: {
+        'exec-A': { id: 'exec-A', status: 'completed', pr_url: 'a', pr_number: 1, branch: 'a', metadata: {}, completed_at: null },
+        'exec-B': { id: 'exec-B', status: 'running', pr_url: null, pr_number: null, branch: null, metadata: {}, completed_at: null },
+        'exec-C': { id: 'exec-C', status: 'reverted', pr_url: null, pr_number: null, branch: null, metadata: {}, completed_at: null },
+      },
+      ledgerPatches: [],
+      selfHealingLogPatches: [],
+    };
+    setupFetchMock(state);
+
+    await reconcileAutopilotLinkedSelfHealingVtids();
+
+    expect(state.ledgerPatches.map(p => p.vtid).sort()).toEqual(['VTID-A', 'VTID-C']);
+    const aPatch = state.ledgerPatches.find(p => p.vtid === 'VTID-A')!;
+    expect(aPatch.body.terminal_outcome).toBe('success');
+    const cPatch = state.ledgerPatches.find(p => p.vtid === 'VTID-C')!;
+    expect(cPatch.body.terminal_outcome).toBe('failed');
+  });
+
+  it('no-op when no autopilot-linked self-healing rows exist', async () => {
+    const state: MockState = {
+      ledgerRows: [],
+      executionRowsById: {},
+      ledgerPatches: [],
+      selfHealingLogPatches: [],
+    };
+    setupFetchMock(state);
+
+    await reconcileAutopilotLinkedSelfHealingVtids();
+
+    expect(state.ledgerPatches.length).toBe(0);
+  });
+});

--- a/services/gateway/test/worker-orchestrator-await-autopilot.test.ts
+++ b/services/gateway/test/worker-orchestrator-await-autopilot.test.ts
@@ -1,0 +1,273 @@
+/**
+ * PR-A (VTID-02922): /api/v1/worker/orchestrator/await-autopilot-execution
+ *
+ * Four-state contract: pr_ready | completed | failed | deferred.
+ *
+ *   - pr_ready  → autopilot opened a PR; CI/deploy/verify still in flight.
+ *                  Worker-runner reports completion w/ files_changed so the
+ *                  repair-evidence gate clears, BUT the reconciler — not
+ *                  the worker — terminalizes success.
+ *   - completed → autopilot reached status='completed' (CI green + deploy +
+ *                  live probe). Reconciler will set terminal_outcome='success'.
+ *   - failed    → autopilot reached failed/failed_escalated/reverted.
+ *   - deferred  → autopilot still running past the worker-runner await
+ *                  window. Worker releases the claim; reconciler finishes.
+ *
+ * Auth:
+ *   - 400 when vtid / autopilot_execution_id missing
+ *   - 401 when worker_id missing or unregistered
+ *   - 403 when caller does not hold the claim on the VTID
+ */
+
+import express from 'express';
+import request from 'supertest';
+import { workerOrchestratorRouter } from '../src/routes/worker-orchestrator';
+
+const ORIGINAL_FETCH = global.fetch;
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(workerOrchestratorRouter);
+  return app;
+}
+
+beforeEach(() => {
+  process.env.SUPABASE_URL = 'https://supabase.test';
+  process.env.SUPABASE_SERVICE_ROLE = 'svc-role';
+});
+
+afterEach(() => {
+  global.fetch = ORIGINAL_FETCH;
+});
+
+interface FetchHandlers {
+  workerExists?: boolean;
+  ledgerOwner?: { claimed_by: string; claim_expires_at: string | null } | null;
+  executionRows?: Array<{
+    id: string;
+    status: string;
+    pr_url: string | null;
+    pr_number: number | null;
+    branch: string | null;
+    metadata: any;
+    completed_at: string | null;
+  }>;
+  prFiles?: Array<{ filename: string; status: string }>;
+}
+
+function mockFetch(h: FetchHandlers) {
+  global.fetch = jest.fn().mockImplementation(async (url: string) => {
+    // 1. worker_registry presence check
+    if (url.includes('/rest/v1/worker_registry')) {
+      const data = h.workerExists ? [{ worker_id: 'wk-1' }] : [];
+      return { ok: true, status: 200, json: () => Promise.resolve(data) };
+    }
+
+    // 2. vtid_ledger claim check
+    if (url.includes('/rest/v1/vtid_ledger?vtid=eq.')) {
+      const data = h.ledgerOwner ? [h.ledgerOwner] : [];
+      return { ok: true, status: 200, json: () => Promise.resolve(data) };
+    }
+
+    // 3. dev_autopilot_executions polling
+    if (url.includes('/rest/v1/dev_autopilot_executions?id=eq.')) {
+      return { ok: true, status: 200, json: () => Promise.resolve(h.executionRows || []) };
+    }
+
+    // 4. GitHub PR files
+    if (url.includes('api.github.com/repos/') && url.includes('/pulls/') && url.includes('/files')) {
+      return { ok: true, status: 200, json: () => Promise.resolve(h.prFiles || []) };
+    }
+
+    return { ok: true, status: 200, json: () => Promise.resolve({}) };
+  }) as unknown as typeof fetch;
+}
+
+describe('POST /api/v1/worker/orchestrator/await-autopilot-execution — auth', () => {
+  it('400 when vtid is missing', async () => {
+    mockFetch({ workerExists: true });
+    const res = await request(buildApp())
+      .post('/api/v1/worker/orchestrator/await-autopilot-execution')
+      .send({ worker_id: 'wk-1', autopilot_execution_id: 'exec-1' });
+    expect(res.status).toBe(400);
+  });
+
+  it('400 when autopilot_execution_id is missing', async () => {
+    mockFetch({ workerExists: true });
+    const res = await request(buildApp())
+      .post('/api/v1/worker/orchestrator/await-autopilot-execution')
+      .send({ vtid: 'VTID-00001', worker_id: 'wk-1' });
+    expect(res.status).toBe(400);
+  });
+
+  it('401 when worker_id is missing', async () => {
+    mockFetch({ workerExists: true });
+    const res = await request(buildApp())
+      .post('/api/v1/worker/orchestrator/await-autopilot-execution')
+      .send({ vtid: 'VTID-00001', autopilot_execution_id: 'exec-1' });
+    expect(res.status).toBe(401);
+  });
+
+  it('401 when worker is NOT in worker_registry', async () => {
+    mockFetch({ workerExists: false });
+    const res = await request(buildApp())
+      .post('/api/v1/worker/orchestrator/await-autopilot-execution')
+      .send({ vtid: 'VTID-00001', autopilot_execution_id: 'exec-1', worker_id: 'wk-x' });
+    expect(res.status).toBe(401);
+  });
+
+  it('403 when worker does not hold the claim', async () => {
+    mockFetch({
+      workerExists: true,
+      ledgerOwner: { claimed_by: 'wk-other', claim_expires_at: new Date(Date.now() + 60_000).toISOString() },
+    });
+    const res = await request(buildApp())
+      .post('/api/v1/worker/orchestrator/await-autopilot-execution')
+      .send({ vtid: 'VTID-00001', autopilot_execution_id: 'exec-1', worker_id: 'wk-1' });
+    expect(res.status).toBe(403);
+  });
+
+  it('403 when claim has expired (claim_expires_at in the past)', async () => {
+    mockFetch({
+      workerExists: true,
+      ledgerOwner: { claimed_by: 'wk-1', claim_expires_at: new Date(Date.now() - 60_000).toISOString() },
+    });
+    const res = await request(buildApp())
+      .post('/api/v1/worker/orchestrator/await-autopilot-execution')
+      .send({ vtid: 'VTID-00001', autopilot_execution_id: 'exec-1', worker_id: 'wk-1' });
+    expect(res.status).toBe(403);
+  });
+});
+
+describe('POST /api/v1/worker/orchestrator/await-autopilot-execution — four-state contract', () => {
+  const validClaim = {
+    workerExists: true,
+    ledgerOwner: { claimed_by: 'wk-1', claim_expires_at: new Date(Date.now() + 600_000).toISOString() },
+  };
+
+  it('returns completed with files_changed from PR diff when status=completed', async () => {
+    mockFetch({
+      ...validClaim,
+      executionRows: [{
+        id: 'exec-1',
+        status: 'completed',
+        pr_url: 'https://github.com/exafyltd/vitana-platform/pull/9999',
+        pr_number: 9999,
+        branch: 'fix/canary-bug-VTID-99999',
+        metadata: {},
+        completed_at: new Date().toISOString(),
+      }],
+      prFiles: [
+        { filename: 'services/gateway/src/routes/availability.ts', status: 'modified' },
+        { filename: 'services/gateway/src/routes/availability.test.ts', status: 'added' },
+      ],
+    });
+    process.env.GITHUB_SAFE_MERGE_TOKEN = 'gh-token-fake';
+
+    const res = await request(buildApp())
+      .post('/api/v1/worker/orchestrator/await-autopilot-execution')
+      .send({ vtid: 'VTID-00001', autopilot_execution_id: 'exec-1', worker_id: 'wk-1' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.state).toBe('completed');
+    expect(res.body.pr_number).toBe(9999);
+    expect(res.body.files_changed).toEqual(['services/gateway/src/routes/availability.ts']);
+    expect(res.body.files_created).toEqual(['services/gateway/src/routes/availability.test.ts']);
+  });
+
+  it('returns pr_ready with files when status=ci (PR opened, CI in flight)', async () => {
+    mockFetch({
+      ...validClaim,
+      executionRows: [{
+        id: 'exec-1',
+        status: 'ci',
+        pr_url: 'https://github.com/exafyltd/vitana-platform/pull/9998',
+        pr_number: 9998,
+        branch: 'fix/canary-bug',
+        metadata: {},
+        completed_at: null,
+      }],
+      prFiles: [{ filename: 'services/gateway/src/routes/x.ts', status: 'modified' }],
+    });
+    process.env.GITHUB_SAFE_MERGE_TOKEN = 'gh-token-fake';
+
+    const res = await request(buildApp())
+      .post('/api/v1/worker/orchestrator/await-autopilot-execution')
+      .send({ vtid: 'VTID-00002', autopilot_execution_id: 'exec-1', worker_id: 'wk-1' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.state).toBe('pr_ready');
+    expect(res.body.execution_status).toBe('ci');
+    expect(res.body.files_changed.length).toBe(1);
+  });
+
+  it('returns failed when status=failed', async () => {
+    mockFetch({
+      ...validClaim,
+      executionRows: [{
+        id: 'exec-1',
+        status: 'failed',
+        pr_url: null,
+        pr_number: null,
+        branch: null,
+        metadata: { error: 'plan validation failed' },
+        completed_at: new Date().toISOString(),
+      }],
+    });
+
+    const res = await request(buildApp())
+      .post('/api/v1/worker/orchestrator/await-autopilot-execution')
+      .send({ vtid: 'VTID-00003', autopilot_execution_id: 'exec-1', worker_id: 'wk-1' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.state).toBe('failed');
+    expect(res.body.error).toContain('plan validation failed');
+    expect(res.body.execution_status).toBe('failed');
+  });
+
+  it('returns deferred (NOT failed) when timeout elapses while status=running', async () => {
+    mockFetch({
+      ...validClaim,
+      executionRows: [{
+        id: 'exec-1',
+        status: 'running',
+        pr_url: null,
+        pr_number: null,
+        branch: null,
+        metadata: {},
+        completed_at: null,
+      }],
+    });
+
+    // 60_000ms is the minimum cap; use it so the test completes quickly.
+    const res = await request(buildApp())
+      .post('/api/v1/worker/orchestrator/await-autopilot-execution')
+      .send({
+        vtid: 'VTID-00004',
+        autopilot_execution_id: 'exec-1',
+        worker_id: 'wk-1',
+        timeout_ms: 60_000,
+      });
+
+    expect(res.status).toBe(200);
+    expect(res.body.state).toBe('deferred');
+    expect(res.body.reason).toBe('timeout');
+    expect(res.body.execution_status).toBe('running');
+  }, 120_000);
+
+  it('returns failed (NOT deferred) when execution row is missing entirely', async () => {
+    mockFetch({
+      ...validClaim,
+      executionRows: [],
+    });
+
+    const res = await request(buildApp())
+      .post('/api/v1/worker/orchestrator/await-autopilot-execution')
+      .send({ vtid: 'VTID-00005', autopilot_execution_id: 'exec-missing', worker_id: 'wk-1' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.state).toBe('failed');
+    expect(res.body.error).toContain('not found');
+  });
+});

--- a/services/worker-runner/src/services/execution-service-delegation.test.ts
+++ b/services/worker-runner/src/services/execution-service-delegation.test.ts
@@ -1,0 +1,201 @@
+/**
+ * PR-A (VTID-02922): worker-runner delegation contract.
+ *
+ * Self-healing tasks bridged to a Dev Autopilot execution have
+ * `metadata.source === 'self-healing'` AND `metadata.autopilot_execution_id`
+ * set. The worker-runner MUST skip its own describe-only LLM call for these
+ * tasks and instead poll the gateway's /await-autopilot-execution endpoint.
+ *
+ * The four-state contract maps to ExecutionResult flavors:
+ *   - 'pr_ready'  → ok=true, healing_state='patched_pending_deploy',
+ *                   real files_changed (clears the repair-evidence gate at
+ *                   /complete, but the VTID is NOT yet terminalized — the
+ *                   reconciler owns that)
+ *   - 'completed' → ok=true, healing_state='verified_healed'
+ *   - 'failed'    → ok=false, healing_state='execution_failed'
+ *   - 'deferred'  → ok=true, defer=true (runner releases the claim without
+ *                   calling /complete or /terminalize; the reconciler
+ *                   finishes the VTID lifecycle when the autopilot
+ *                   execution reaches a terminal state)
+ *
+ * Non-self-healing tasks fall through to the existing Claude/DeepSeek path.
+ */
+
+// Mock the gateway-client call the delegation path uses BEFORE importing the
+// execution service so the inner reference is replaced.
+jest.mock('./gateway-client', () => ({
+  awaitAutopilotExecution: jest.fn(),
+}));
+
+import { awaitAutopilotExecution } from './gateway-client';
+import { executeTask } from './execution-service';
+import type { PendingTask, RoutingResult, RunnerConfig } from '../types';
+
+const mockAwait = awaitAutopilotExecution as unknown as jest.Mock;
+
+const baseConfig: RunnerConfig = {
+  workerId: 'test-worker-001',
+  gatewayUrl: 'http://gateway.test',
+  supabaseUrl: 'http://supabase.test',
+  supabaseKey: 'svc-role',
+  pollIntervalMs: 5000,
+  autopilotEnabled: true,
+  maxConcurrent: 1,
+};
+
+const baseRouting: RoutingResult = {
+  ok: true,
+  dispatched_to: 'worker-backend',
+  run_id: 'run-abc',
+  identity: {
+    repo: 'vitana-platform',
+    project: 'test',
+    region: 'us-central1',
+    environment: 'test',
+    tenant: 'vitana',
+  },
+};
+
+function selfHealingTask(extra: Partial<PendingTask> = {}): PendingTask {
+  return {
+    vtid: 'VTID-99999',
+    title: 'SELF-HEAL test',
+    status: 'in_progress',
+    spec_status: 'approved',
+    spec_content: 'spec md',
+    task_domain: 'backend',
+    created_at: new Date().toISOString(),
+    updated_at: new Date().toISOString(),
+    is_terminal: false,
+    metadata: {
+      source: 'self-healing',
+      autopilot_execution_id: 'exec-uuid-123',
+    },
+    ...extra,
+  };
+}
+
+beforeEach(() => {
+  mockAwait.mockReset();
+});
+
+describe('executeTask — self-healing delegation', () => {
+  it('skips local LLM call and returns pr_ready as patched_pending_deploy', async () => {
+    mockAwait.mockResolvedValue({
+      ok: true,
+      result: {
+        state: 'pr_ready',
+        pr_url: 'https://github.com/exafyltd/vitana-platform/pull/9999',
+        pr_number: 9999,
+        branch: 'fix/canary',
+        files_changed: ['services/gateway/src/routes/availability.ts'],
+        files_created: [],
+        execution_status: 'ci',
+      },
+    });
+
+    const result = await executeTask(baseConfig, selfHealingTask(), baseRouting, 'backend');
+
+    expect(mockAwait).toHaveBeenCalledTimes(1);
+    expect(mockAwait.mock.calls[0][1]).toBe('VTID-99999');
+    expect(mockAwait.mock.calls[0][2]).toBe('exec-uuid-123');
+    expect(result.ok).toBe(true);
+    expect(result.healing_state).toBe('patched_pending_deploy');
+    expect(result.files_changed).toEqual(['services/gateway/src/routes/availability.ts']);
+    expect(result.pr_url).toBe('https://github.com/exafyltd/vitana-platform/pull/9999');
+    expect(result.defer).toBeUndefined();
+  });
+
+  it('returns completed as verified_healed', async () => {
+    mockAwait.mockResolvedValue({
+      ok: true,
+      result: {
+        state: 'completed',
+        pr_url: 'https://github.com/exafyltd/vitana-platform/pull/9998',
+        pr_number: 9998,
+        branch: 'fix/canary',
+        files_changed: ['x.ts'],
+        files_created: ['y.ts'],
+        execution_status: 'completed',
+      },
+    });
+
+    const result = await executeTask(baseConfig, selfHealingTask(), baseRouting, 'backend');
+
+    expect(result.ok).toBe(true);
+    expect(result.healing_state).toBe('verified_healed');
+    expect(result.files_changed).toEqual(['x.ts']);
+    expect(result.files_created).toEqual(['y.ts']);
+  });
+
+  it('returns failed with healing_state=execution_failed', async () => {
+    mockAwait.mockResolvedValue({
+      ok: true,
+      result: {
+        state: 'failed',
+        error: 'plan validation exhausted 3 attempts',
+        execution_status: 'failed',
+      },
+    });
+
+    const result = await executeTask(baseConfig, selfHealingTask(), baseRouting, 'backend');
+
+    expect(result.ok).toBe(false);
+    expect(result.healing_state).toBe('execution_failed');
+    expect(result.error).toContain('plan validation exhausted');
+  });
+
+  it('returns deferred with defer=true on timeout', async () => {
+    mockAwait.mockResolvedValue({
+      ok: true,
+      result: { state: 'deferred', reason: 'timeout', execution_status: 'running' },
+    });
+
+    const result = await executeTask(baseConfig, selfHealingTask(), baseRouting, 'backend');
+
+    expect(result.ok).toBe(true);
+    expect(result.defer).toBe(true);
+    expect(result.healing_state).toBeUndefined();
+    expect(result.files_changed).toBeUndefined();
+  });
+
+  it('falls back to the local LLM path when task.metadata.source is NOT self-healing', async () => {
+    // Without a self-healing marker, the runner should NOT call await-autopilot;
+    // it should attempt the normal Anthropic path. Force initClaude to fail
+    // by leaving ANTHROPIC_API_KEY unset so we can verify the call path.
+    delete process.env.ANTHROPIC_API_KEY;
+    const nonHealingTask: PendingTask = {
+      ...selfHealingTask(),
+      metadata: { source: 'dev_autopilot' },
+    };
+
+    const result = await executeTask(baseConfig, nonHealingTask, baseRouting, 'backend');
+
+    expect(mockAwait).not.toHaveBeenCalled();
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('ANTHROPIC_API_KEY');
+  });
+
+  it('falls back to local LLM path when self-healing flag set but execution_id missing', async () => {
+    delete process.env.ANTHROPIC_API_KEY;
+    const partialTask: PendingTask = {
+      ...selfHealingTask(),
+      metadata: { source: 'self-healing' }, // no autopilot_execution_id
+    };
+
+    const result = await executeTask(baseConfig, partialTask, baseRouting, 'backend');
+
+    expect(mockAwait).not.toHaveBeenCalled();
+    expect(result.ok).toBe(false);
+  });
+
+  it('surfaces gateway errors instead of silently treating as success', async () => {
+    mockAwait.mockResolvedValue({ ok: false, error: 'gateway 502' });
+
+    const result = await executeTask(baseConfig, selfHealingTask(), baseRouting, 'backend');
+
+    expect(result.ok).toBe(false);
+    expect(result.error).toContain('gateway 502');
+    expect(result.autopilot_execution_id).toBe('exec-uuid-123');
+  });
+});

--- a/services/worker-runner/src/services/execution-service.ts
+++ b/services/worker-runner/src/services/execution-service.ts
@@ -15,6 +15,7 @@ import Anthropic from '@anthropic-ai/sdk';
 import { randomUUID } from 'crypto';
 import { RunnerConfig, TaskDomain, ExecutionResult, PendingTask, RoutingResult } from '../types';
 import { validateLLMResponse, formatViolationsForReprompt } from './contract-validator';
+import { awaitAutopilotExecution } from './gateway-client';
 
 const VTID = 'VTID-01200';
 
@@ -324,6 +325,22 @@ export async function executeTask(
 
   console.log(`[${VTID}] Executing task ${task.vtid} (domain=${domain}, run_id=${runId}, model=${modelName})`);
 
+  // PR-A (VTID-02922): self-healing tasks bridged into the Dev Autopilot
+  // pipeline delegate execution to the autopilot Cloud Run Job, which
+  // actually edits files, opens a real PR, runs CI, and verifies deploy.
+  // The worker-runner's own describe-only LLM call is bypassed for these.
+  const isSelfHealing = task.metadata?.source === 'self-healing';
+  const autopilotExecutionId =
+    typeof task.metadata?.autopilot_execution_id === 'string'
+      ? (task.metadata.autopilot_execution_id as string)
+      : undefined;
+  if (isSelfHealing && autopilotExecutionId) {
+    console.log(
+      `[${VTID}] Self-healing task ${task.vtid} delegating to autopilot execution ${autopilotExecutionId.slice(0, 8)} — skipping local LLM call`,
+    );
+    return await delegateToAutopilot(config, task, autopilotExecutionId, modelName, provider, startTime);
+  }
+
   if (!initClaude()) {
     return {
       ok: false,
@@ -395,6 +412,110 @@ export async function executeTask(
       model: modelName,
       provider,
     };
+  }
+}
+
+/**
+ * PR-A (VTID-02922): poll the gateway's /await-autopilot-execution endpoint
+ * and translate the four-state contract into an ExecutionResult.
+ *
+ *   'pr_ready'  → ok=true, files_changed populated, healing_state=
+ *                 'patched_pending_deploy'. Worker reports completion so the
+ *                 repair-evidence gate clears, but the reconciler — NOT the
+ *                 worker — owns final terminal_outcome='success' after CI +
+ *                 deploy + live probe pass.
+ *   'completed' → ok=true, files_changed populated, healing_state=
+ *                 'verified_healed'. Reconciler will set terminal_outcome=
+ *                 'success' on the next cycle.
+ *   'failed'    → ok=false, terminal_outcome will be 'failed'.
+ *   'deferred'  → ok=true (so the runner doesn't fall into the failure
+ *                 path), defer=true so the caller releases the claim
+ *                 WITHOUT calling /complete or /terminalize. The
+ *                 self-healing reconciler finishes the lifecycle.
+ */
+async function delegateToAutopilot(
+  config: RunnerConfig,
+  task: PendingTask,
+  autopilotExecutionId: string,
+  modelName: string,
+  provider: string,
+  startTime: number,
+): Promise<ExecutionResult> {
+  const awaited = await awaitAutopilotExecution(config, task.vtid, autopilotExecutionId);
+  const duration_ms = Date.now() - startTime;
+
+  if (!awaited.ok || !awaited.result) {
+    return {
+      ok: false,
+      error: awaited.error || 'await-autopilot-execution failed with no body',
+      duration_ms,
+      model: modelName,
+      provider,
+      autopilot_execution_id: autopilotExecutionId,
+    };
+  }
+
+  const r = awaited.result;
+  switch (r.state) {
+    case 'pr_ready':
+      return {
+        ok: true,
+        files_changed: r.files_changed || [],
+        files_created: r.files_created || [],
+        summary: `Autopilot opened PR ${r.pr_url} (status=${r.execution_status}); CI + deploy + live probe pending — reconciler owns final healed state.`,
+        duration_ms,
+        model: 'autopilot-executor',
+        provider: 'dev-autopilot',
+        healing_state: 'patched_pending_deploy',
+        pr_url: r.pr_url,
+        pr_number: r.pr_number,
+        branch: r.branch || undefined,
+        autopilot_execution_id: autopilotExecutionId,
+      };
+    case 'completed':
+      return {
+        ok: true,
+        files_changed: r.files_changed || [],
+        files_created: r.files_created || [],
+        summary: `Autopilot execution completed: PR ${r.pr_url} merged, deployed, and live probe verified.`,
+        duration_ms,
+        model: 'autopilot-executor',
+        provider: 'dev-autopilot',
+        healing_state: 'verified_healed',
+        pr_url: r.pr_url,
+        pr_number: r.pr_number,
+        branch: r.branch || undefined,
+        autopilot_execution_id: autopilotExecutionId,
+      };
+    case 'failed':
+      return {
+        ok: false,
+        error: r.error || `autopilot execution failed (status=${r.execution_status})`,
+        duration_ms,
+        model: 'autopilot-executor',
+        provider: 'dev-autopilot',
+        healing_state: 'execution_failed',
+        autopilot_execution_id: autopilotExecutionId,
+      };
+    case 'deferred':
+      return {
+        ok: true,
+        defer: true,
+        summary: `Autopilot execution still in '${r.execution_status}' after worker-runner await window; reconciler will finish.`,
+        duration_ms,
+        model: 'autopilot-executor',
+        provider: 'dev-autopilot',
+        autopilot_execution_id: autopilotExecutionId,
+      };
+    default:
+      return {
+        ok: false,
+        error: `unknown await-autopilot-execution state: ${(r as any).state}`,
+        duration_ms,
+        model: 'autopilot-executor',
+        provider: 'dev-autopilot',
+        autopilot_execution_id: autopilotExecutionId,
+      };
   }
 }
 

--- a/services/worker-runner/src/services/gateway-client.ts
+++ b/services/worker-runner/src/services/gateway-client.ts
@@ -420,3 +420,74 @@ export async function reportProgress(
 
   return result.ok;
 }
+
+/**
+ * PR-A (VTID-02922): Four-state contract the worker-runner uses when a
+ * self-healing task is bridged into the Dev Autopilot execution pipeline.
+ * Worker-runner doesn't make its own describe-only LLM call for these
+ * tasks — it polls the gateway endpoint which proxies the real autopilot
+ * execution row.
+ */
+export type AwaitAutopilotResult =
+  | {
+      state: 'pr_ready';
+      pr_url: string;
+      pr_number: number;
+      branch: string | null;
+      files_changed: string[];
+      files_created: string[];
+      execution_status: string;
+    }
+  | {
+      state: 'completed';
+      pr_url: string;
+      pr_number: number;
+      branch: string | null;
+      files_changed: string[];
+      files_created: string[];
+      execution_status: 'completed';
+    }
+  | {
+      state: 'failed';
+      error: string;
+      execution_status: string;
+    }
+  | {
+      state: 'deferred';
+      reason: 'timeout' | 'still_running';
+      execution_status: string;
+    };
+
+/**
+ * Block-poll the gateway for an autopilot execution outcome. Returns
+ * 'deferred' on the gateway-side timeout instead of failing — the
+ * self-healing reconciler picks up the lifecycle from there.
+ */
+export async function awaitAutopilotExecution(
+  config: RunnerConfig,
+  vtid: string,
+  autopilotExecutionId: string,
+  timeoutMs?: number,
+): Promise<{ ok: boolean; result?: AwaitAutopilotResult; error?: string }> {
+  const result = await gatewayRequest<AwaitAutopilotResult>(
+    config,
+    '/api/v1/worker/orchestrator/await-autopilot-execution',
+    {
+      method: 'POST',
+      body: JSON.stringify({
+        vtid,
+        autopilot_execution_id: autopilotExecutionId,
+        worker_id: config.workerId,
+        timeout_ms: timeoutMs,
+      }),
+    },
+  );
+
+  if (!result.ok) {
+    return { ok: false, error: result.error || 'await-autopilot-execution call failed' };
+  }
+  if (!result.data || typeof (result.data as any).state !== 'string') {
+    return { ok: false, error: 'await-autopilot-execution returned malformed body' };
+  }
+  return { ok: true, result: result.data };
+}

--- a/services/worker-runner/src/services/runner-service.ts
+++ b/services/worker-runner/src/services/runner-service.ts
@@ -378,15 +378,27 @@ export class WorkerRunner {
         executionSuccess = executionResult.ok;
       }
 
-      // Step 5: Complete the task
-      await this.completeTask(
-        vtid,
-        runId,
-        domain,
-        executionSuccess,
-        executionResult.error,
-        executionResult
-      );
+      // PR-A (VTID-02922): self-healing tasks delegated to the autopilot
+      // pipeline may come back `defer=true` (autopilot still running past
+      // the worker-runner await window). In that case we MUST NOT call
+      // /complete or /terminalize — the self-healing reconciler watches
+      // dev_autopilot_executions and will finish the VTID lifecycle when
+      // the execution reaches a terminal state. Just release the claim.
+      if (executionResult.defer === true) {
+        console.log(
+          `[${VTID}] Self-healing ${vtid} deferred to reconciler (autopilot_execution_id=${executionResult.autopilot_execution_id?.slice(0, 8) || 'n/a'})`,
+        );
+      } else {
+        // Step 5: Complete the task
+        await this.completeTask(
+          vtid,
+          runId,
+          domain,
+          executionSuccess,
+          executionResult.error,
+          executionResult
+        );
+      }
     } catch (error) {
       const errorMessage = error instanceof Error ? error.message : 'Unknown error';
       console.error(`[${VTID}] Task processing error for ${vtid}: ${errorMessage}`);
@@ -395,8 +407,13 @@ export class WorkerRunner {
       // Attempt to complete as failed
       await this.completeTask(vtid, runId, domain, false, errorMessage);
     } finally {
-      // Always release claim and cleanup
-      await releaseTask(this.config, vtid, executionSuccess ? 'completed' : 'failed');
+      // Always release claim and cleanup. For deferred self-healing tasks
+      // we release with 'deferred' so the reconciler picks them up; for
+      // everything else use the legacy completed/failed reason.
+      const releaseReason = executionResult.defer === true
+        ? 'deferred'
+        : executionSuccess ? 'completed' : 'failed';
+      await releaseTask(this.config, vtid, releaseReason);
       this.activeVtid = null;
       this.metrics.state = 'idle';
     }

--- a/services/worker-runner/src/types.ts
+++ b/services/worker-runner/src/types.ts
@@ -99,6 +99,19 @@ export interface ExecutionResult {
   fallback_used?: boolean;
   fallback_from?: string;
   fallback_reason?: string;
+  // PR-A (VTID-02922): populated when the runner delegated to an autopilot
+  // execution. healing_state tells downstream consumers what kind of success
+  // this is: 'patched_pending_deploy' = PR opened but NOT yet healed (CI +
+  // deploy still pending); 'verified_healed' = execution.status=completed.
+  // When `defer=true`, the runner should release the claim WITHOUT calling
+  // /complete or /terminalize — the self-healing reconciler will finish the
+  // VTID lifecycle when the autopilot execution reaches a terminal state.
+  healing_state?: 'patched_pending_deploy' | 'verified_healed' | 'execution_failed';
+  defer?: boolean;
+  pr_url?: string;
+  pr_number?: number;
+  branch?: string;
+  autopilot_execution_id?: string;
 }
 
 /**


### PR DESCRIPTION
## Summary
The architectural piece: route self-healing's execute step through the proven Dev Autopilot pipeline so real files get edited, real PRs get opened, CI runs, deploy lands, and the live endpoint actually heals — instead of worker-runner's describe-only LLM call.

- **Injector bridge** — writes `autopilot_recommendations` + `dev_autopilot_plan_versions` + calls `bridgeActivationToExecution()`. Idempotent via `dedupe_key = sha256(endpoint:failure_class:spec_hash)`; second injection reuses any in-flight execution.
- **New `/api/v1/worker/orchestrator/await-autopilot-execution`** — two auth gates (worker_registry + active claim). Four-state contract: `pr_ready | completed | failed | deferred`.
- **Worker-runner delegation** — `executeTask` detects `metadata.source='self-healing'` + `autopilot_execution_id`, skips local LLM, polls the new endpoint, returns `healing_state='patched_pending_deploy' | 'verified_healed' | 'execution_failed'` or `defer=true`.
- **Reconciler owns final success** — new scan path terminalizes `vtid_ledger.terminal_outcome='success'` **only when** `dev_autopilot_executions.status='completed'`. Worker-runner can no longer claim success.
- **Canary route** — `/api/v1/self-healing/canary/failing-health` returns 500 iff `system_config.self_healing_canary_armed=true`. Smoke-test the full pipeline without breaking production.

## Healing definition
A self-healing VTID reaches `terminal_outcome='success'` ONLY after CI green + deploy via EXEC-DEPLOY + live `/alive` probe pass. "PR opened" is NOT healing. "LLM said it fixed something" is NOT healing.

## Why the reconciler, not the worker
Worker-runner can hold a claim for ~15 minutes. CI + deploy + verify can take 20–40. Returning `failed` on a healthy in-flight execution would be wrong; returning `success` when a PR is just open would be the original bug rephrased. So the worker returns `pr_ready` (clears the repair-evidence gate so the VTID doesn't tombstone) OR `deferred` (releases the claim, no `/complete`, no `/terminalize`), and the reconciler — which can take as long as it needs — flips `terminal_outcome` once the autopilot pipeline actually reaches `completed`.

## Idempotency
Same `dedupe_key` while an active execution exists → no new recommendation/plan/execution row. Emits `self-healing.injection.deduped`. Existing `autopilot_execution_id` is reused in `vtid_ledger.metadata`.

## Auth on the new endpoint
- 400 when `vtid` or `autopilot_execution_id` missing
- 401 when `worker_id` missing or unregistered
- 403 when worker does not hold an active claim (or claim has expired)
- Body-only auth matches the existing worker-orchestrator pattern; the implicit gate is that you can't await on a VTID you haven't claimed via `/claim` first.

## Test plan
- [x] `npm run build` (gateway) — clean except pre-existing `sharp`
- [x] `npm run build` (worker-runner) — clean except pre-existing `yaml`
- [x] `test/self-healing-injector-autopilot-bridge.test.ts` — 4/4 (idempotency, voice bypass, bridge-failure-degraded-but-safe)
- [x] `test/worker-orchestrator-await-autopilot.test.ts` — 11/11 (six auth gates + five contract states)
- [x] `test/self-healing-reconciler-autopilot-link.test.ts` — 12/12 (success/failed/failed_escalated terminalize; all in-flight statuses leave alone; multi-row mix; empty)
- [x] `src/services/execution-service-delegation.test.ts` — 7/7 (4 states + 2 fall-through cases + gateway-error surfacing)
- [x] `test/voice-self-healing-adapter.test.ts` — 13/13 (no regression)
- [ ] After merge: dispatch EXEC-DEPLOY for `gateway` and `worker-runner`. Flip `system_config.self_healing_canary_armed=true` via Supabase MCP, watch `self_healing_log` → `vtid_ledger.metadata.autopilot_execution_id` → `dev_autopilot_executions` progress through cooling → running → ci → merging → deploying → verifying → completed. Confirm reconciler terminalizes `terminal_outcome='success'` and the canary returns 2xx again.
- [ ] Idempotency live check: hit the canary twice while the first execution is still running; expect `self-healing.injection.deduped` and no new execution row.
- [ ] Auth live check: `curl POST /api/v1/worker/orchestrator/await-autopilot-execution` without a registered worker → 401.

## Plan reference
`.claude/plans/synthetic-crafting-twilight.md` § PR-A. Sequenced after PR-B (#2047 pre-probe) and PR-C (#2048 source fallback).

🤖 Generated with [Claude Code](https://claude.com/claude-code)