### PR TITLE
fix(self-healing): drop nonexistent 'author' column from plan_versions (VTID-02926, hotfix on PR-A)

### DIFF
--- a/services/gateway/src/services/self-healing-injector-service.ts
+++ b/services/gateway/src/services/self-healing-injector-service.ts
@@ -177,7 +177,10 @@ async function bridgeToAutopilotExecution(
 
   // Step 3: Insert the plan_version row directly. runExecutionSession reads
   // plan_markdown + files_referenced from here, so this is the actual
-  // execution-driving spec for the LLM.
+  // execution-driving spec for the LLM. Note: dev_autopilot_plan_versions
+  // has no `author` column (the original migration didn't include one); the
+  // spec_snapshot.scanner='self-healing' marker on the recommendation is
+  // how we identify origin downstream.
   const planResp = await fetch(`${SUPABASE_URL}/rest/v1/dev_autopilot_plan_versions`, {
     method: 'POST',
     headers: { ...supabaseHeaders(), Prefer: 'return=minimal' },
@@ -186,7 +189,6 @@ async function bridgeToAutopilotExecution(
       version: 1,
       plan_markdown: spec,
       files_referenced: filesReferenced,
-      author: 'self-healing-injector',
     }),
   });
   if (!planResp.ok) {


### PR DESCRIPTION
## Summary
PR-A (#2054) live smoke surfaced a real bug: the injector tried to write `author: 'self-healing-injector'` into `dev_autopilot_plan_versions`, but that column doesn't exist in the migration. Bridge fired \`self-healing.execution.bridge_failed\` warning instead of dispatching the execution.

## Evidence
VTID-02925 (smoke run on the canary at 2026-05-11 19:48Z) — `oasis_events`:
\`\`\`
topic=self-healing.execution.bridge_failed
message="Autopilot execution bridge failed: dev_autopilot_plan_versions insert failed:
  400 {\"code\":\"PGRST204\", message: 'Could not find the author column'}"
\`\`\`

This is the contract working as designed — the injector's PATCH guard correctly skipped the autopilot_execution_id linkage and emitted the warning event so the failure was loud, not silent. Worker-runner then fell back to the local LLM path (no execution_id present) and the repair-evidence gate from PR #2045 will refuse to mark VTID-02925 succeeded.

## Fix
Remove `author` from the INSERT body. Provenance is already captured on `autopilot_recommendations.spec_snapshot.scanner='self-healing'`.

## Test plan
- [x] `npm run build` — clean except pre-existing `sharp`
- [x] `npx jest test/self-healing-injector-autopilot-bridge.test.ts` — 4/4 still pass (no test asserted on `author`)
- [ ] After merge + EXEC-DEPLOY: re-arm canary, expect autopilot_execution_id to land in vtid_ledger.metadata and `dev_autopilot_executions` row to progress

🤖 Generated with [Claude Code](https://claude.com/claude-code)