### PR TITLE
feat(orb): B1 - greeting decay via A4 seam + 7 cadence signals (VTID-02930, DEV-COMHU-02930)

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -42508,6 +42508,9 @@ function renderJourneyContextView() {
     // VTID-02923 (B0e.3): Feature Discovery panel — catalog + awareness
     // ladder + provider state (selected / suppressed / errored).
     grid.appendChild(renderJourneyContextFeatureDiscoveryPanel(jc.featureDiscovery));
+    // VTID-02930 (B1): Greeting Decay panel — simulated policy decision
+    // + reason + evidence + signal source-health. Read-only.
+    grid.appendChild(renderJourneyContextGreetingDecayPanel(jc.greetingDecay));
 
     c.appendChild(grid);
     return c;
@@ -42534,12 +42537,27 @@ function loadJourneyContext() {
     // Global view (no userId/tenantId filter — the operator wants the
     // full picture). Limit caps server-side at 500.
     var raQs = '?limit=200';
+    // VTID-02930 (B1): greeting policy preview — pure simulator using
+    // operator-supplied query knobs from state.greetingDecaySim, or
+    // sensible defaults when unset. NO user-specific data; pure decision.
+    var sim = state.greetingDecaySim || {};
+    var gdQs = '?bucket=' + encodeURIComponent(sim.bucket || 'today');
+    if (sim.isReconnect !== undefined) gdQs += '&isReconnect=' + (sim.isReconnect ? 'true' : 'false');
+    if (sim.wasFailure !== undefined) gdQs += '&wasFailure=' + (sim.wasFailure ? 'true' : 'false');
+    if (sim.seconds_since_last_turn_anywhere !== undefined) gdQs += '&seconds_since_last_turn_anywhere=' + encodeURIComponent(sim.seconds_since_last_turn_anywhere);
+    if (sim.sessions_today_count !== undefined) gdQs += '&sessions_today_count=' + encodeURIComponent(sim.sessions_today_count);
+    if (sim.is_transparent_reconnect !== undefined) gdQs += '&is_transparent_reconnect=' + (sim.is_transparent_reconnect ? 'true' : 'false');
+    if (sim.time_since_last_greeting_today_ms !== undefined) gdQs += '&time_since_last_greeting_today_ms=' + encodeURIComponent(sim.time_since_last_greeting_today_ms);
+    if (sim.greeting_style_last_used) gdQs += '&greeting_style_last_used=' + encodeURIComponent(sim.greeting_style_last_used);
+    if (sim.wake_origin) gdQs += '&wake_origin=' + encodeURIComponent(sim.wake_origin);
+    if (sim.device_handoff_signal !== undefined) gdQs += '&device_handoff_signal=' + (sim.device_handoff_signal ? 'true' : 'false');
     Promise.all([
         fetch('/api/v1/voice/journey-context/preview' + qs, { headers: buildContextHeaders() }).then(function (r) { return r.json(); }),
         fetch('/api/v1/voice/journey-context/state'   + qs, { headers: buildContextHeaders() }).then(function (r) { return r.json(); }),
         fetch('/api/v1/voice/wake-timeline/recent'    + wakeQs, { headers: buildContextHeaders() }).then(function (r) { return r.json(); }).catch(function () { return { ok: false }; }),
         fetch('/api/v1/voice/feature-discovery/preview' + fdQs, { headers: buildContextHeaders() }).then(function (r) { return r.json(); }).catch(function () { return { ok: false }; }),
         fetch('/api/v1/voice/wake-timeline/analysis'  + raQs, { headers: buildContextHeaders() }).then(function (r) { return r.json(); }).catch(function () { return { ok: false }; }),
+        fetch('/api/v1/voice/greeting-policy/preview' + gdQs, { headers: buildContextHeaders() }).then(function (r) { return r.json(); }).catch(function () { return { ok: false }; }),
     ]).then(function (results) {
         jc.loading = false;
         if (results[0] && results[0].ok) {
@@ -42564,6 +42582,11 @@ function loadJourneyContext() {
             jc.reliabilityAnalysis = results[4].analysis;
         } else {
             jc.reliabilityAnalysis = null;
+        }
+        if (results[5] && results[5].ok) {
+            jc.greetingDecay = results[5];
+        } else {
+            jc.greetingDecay = null;
         }
         renderApp();
     }).catch(function (err) {
@@ -42782,6 +42805,78 @@ function renderJourneyContextWakeTimelinePanel(timelines) {
         });
 
         panel.appendChild(entry);
+    });
+
+    return panel;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// VTID-02930 (B1): Greeting Decay panel.
+//
+// Read-only inspection surface for the A4 greeting-policy seam with the
+// 7 B1 cadence signals layered on. Operators read:
+//   - the simulated decision (policy + reason)
+//   - the evidence list (which signals influenced which way)
+//   - signal source-health (present / missing) so operators can tell
+//     when the decision is degraded due to absent inputs
+//
+// Wall (B1): NO mutation, NO POST, NO tuning controls. The route the
+// loader hits (GET /voice/greeting-policy/preview) is a pure simulator
+// — query params drive the input, the response is the decision.
+// ─────────────────────────────────────────────────────────────────────────
+function renderJourneyContextGreetingDecayPanel(gd) {
+    var panel = renderJourneyContextPanel(
+        'Greeting Decay (B1)',
+        'A4 seam + 7 cadence signals — pure simulator, no mutation',
+    );
+
+    if (!gd) {
+        // Acceptance #5: panel renders even when no cadence data exists.
+        panel.appendChild(renderJourneyContextEmptyRow('status', 'no data — set state.greetingDecaySim or load a user above'));
+        return panel;
+    }
+
+    var d = (gd && gd.decision) || {};
+    var inp = (gd && gd.input) || {};
+
+    panel.appendChild(renderJourneyContextEmptyRow('policy', d.policy || '—'));
+    panel.appendChild(renderJourneyContextEmptyRow('reason', d.reason || '—'));
+    panel.appendChild(renderJourneyContextEmptyRow('fell back to bucket', String(d.fellBackToBucket === true)));
+
+    // ---- Signal source-health ----
+    var shHeader = document.createElement('div');
+    shHeader.style.cssText = 'margin-top:0.75rem;font-size:0.85rem;font-weight:600;color:var(--color-text-primary);';
+    shHeader.textContent = 'Signal source-health';
+    panel.appendChild(shHeader);
+    var present = Array.isArray(d.signalsPresent) ? d.signalsPresent : [];
+    var missing = Array.isArray(d.signalsMissing) ? d.signalsMissing : [];
+    panel.appendChild(renderJourneyContextEmptyRow('present (' + present.length + ')', present.length > 0 ? present.join(', ') : '—'));
+    panel.appendChild(renderJourneyContextEmptyRow('missing (' + missing.length + ')', missing.length > 0 ? missing.join(', ') : '—'));
+
+    // ---- Evidence ----
+    var evHeader = document.createElement('div');
+    evHeader.style.cssText = 'margin-top:0.75rem;font-size:0.85rem;font-weight:600;color:var(--color-text-primary);';
+    evHeader.textContent = 'Evidence (which signals influenced the decision)';
+    panel.appendChild(evHeader);
+    var evidence = Array.isArray(d.evidence) ? d.evidence : [];
+    if (evidence.length === 0) {
+        panel.appendChild(renderJourneyContextEmptyRow('evidence', 'no signals participated'));
+    } else {
+        evidence.forEach(function (e) {
+            panel.appendChild(renderJourneyContextEmptyRow(
+                e.signal + ' [' + e.influence + ']',
+                String(e.value),
+            ));
+        });
+    }
+
+    // ---- Input simulator echo ----
+    var inHeader = document.createElement('div');
+    inHeader.style.cssText = 'margin-top:0.75rem;font-size:0.85rem;font-weight:600;color:var(--color-text-primary);';
+    inHeader.textContent = 'Input';
+    panel.appendChild(inHeader);
+    Object.keys(inp).forEach(function (k) {
+        panel.appendChild(renderJourneyContextEmptyRow(k, String(inp[k])));
     });
 
     return panel;

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -30,7 +30,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260504-vtid-02710-ios-ctx-keepalive"></script>
-  <script src="/command-hub/app.js?v=20260511-vtid-02927-reliability-analysis"></script>
+  <script src="/command-hub/app.js?v=20260511-vtid-02930-greeting-decay"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
 </body>

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -742,6 +742,11 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const voiceFeatureDiscoveryEventRouter = require('./routes/voice-feature-discovery-event').default;
   mountRouterSync(app, '/api/v1', voiceFeatureDiscoveryEventRouter, { owner: 'voice-feature-discovery-event' });
 
+  // VTID-02930 (B1): Greeting Decay preview (read-only simulator).
+  // GET /api/v1/voice/greeting-policy/preview
+  const voiceGreetingPolicyRouter = require('./routes/voice-greeting-policy').default;
+  mountRouterSync(app, '/api/v1', voiceGreetingPolicyRouter, { owner: 'voice-greeting-policy' });
+
   // AI Personality Configuration API
   mountRouterSync(app, '/api/v1/ai-personality', aiPersonalityRouter, { owner: 'ai-personality' });
 

--- a/services/gateway/src/orb/live/instruction/greeting-policy.ts
+++ b/services/gateway/src/orb/live/instruction/greeting-policy.ts
@@ -83,7 +83,98 @@ export interface GreetingPolicyInput {
    * instead of a silent brief-resume.
    */
   wasFailure?: boolean;
+
+  // ─────────────────────────────────────────────────────────────────
+  // B1 (VTID-02930): cadence + repetition signals (33–39).
+  // All optional — when absent, the policy degrades to the A4 truth
+  // table. None of these touch transport, audio, reconnect, or Live
+  // API behavior. Pure read-side signals.
+  // ─────────────────────────────────────────────────────────────────
+
+  /** Signal #33: cross-device, cross-surface continuity. */
+  seconds_since_last_turn_anywhere?: number;
+  /** Signal #34: how many sessions the user has had today (UTC). */
+  sessions_today_count?: number;
+  /**
+   * Signal #35: orthogonal to `isReconnect` but more precise. Set when
+   * the gateway can prove the resume is server-side transparent (the
+   * 5-min Vertex limit, an iOS visibility blip, etc.). Always collapses
+   * to `skip`.
+   */
+  is_transparent_reconnect?: boolean;
+  /** Signal #36: ms since the last greeting we emitted today. */
+  time_since_last_greeting_today_ms?: number;
+  /** Signal #37: last greeting style emitted (any value of `GreetingPolicy`). */
+  greeting_style_last_used?: GreetingPolicy;
+  /**
+   * Signal #38: how this session was activated.
+   *   `orb_tap`            — user pressed the orb button.
+   *   `wake_word`          — wake-word triggered.
+   *   `push_tap`           — notification deep-link.
+   *   `proactive_opener`   — Vitana-initiated.
+   *   `deep_link`          — landed on a route that auto-opens orb.
+   *   `unknown`            — envelope didn't say.
+   */
+  wake_origin?:
+    | 'orb_tap'
+    | 'wake_word'
+    | 'push_tap'
+    | 'proactive_opener'
+    | 'deep_link'
+    | 'unknown';
+  /**
+   * Signal #39: device handoff signal — `true` when the gateway can
+   * prove this session is the same user continuing on a new device
+   * within a short window.
+   */
+  device_handoff_signal?: boolean;
 }
+
+// ─────────────────────────────────────────────────────────────────────
+// B1: typed decision carrier with reason + evidence + signals used.
+// `decideGreetingPolicy()` stays backwards-compatible (returns the
+// string union); `decideGreetingPolicyWithEvidence()` is the new
+// caller-facing surface for richer consumers (the Command Hub panel
+// + tests + future telemetry).
+// ─────────────────────────────────────────────────────────────────────
+
+export interface GreetingPolicyEvidence {
+  signal: string;
+  value: string | number | boolean | null;
+  influence: 'forced' | 'dampened' | 'preferred' | 'ignored';
+}
+
+export interface GreetingPolicyDecision {
+  /** The policy decision. */
+  policy: GreetingPolicy;
+  /** Short reason code — stable string for telemetry + tests. */
+  reason: string;
+  /** Per-signal evidence list (which signals participated in the decision). */
+  evidence: GreetingPolicyEvidence[];
+  /** Names of signals present in the input (source-health view). */
+  signalsPresent: string[];
+  /** Names of signals absent from the input (source-health view). */
+  signalsMissing: string[];
+  /** True when the decision falls back to the A4 bucket-only truth table. */
+  fellBackToBucket: boolean;
+}
+
+/**
+ * Thresholds for cadence decay. Pulled out as constants so future tuning
+ * (R-track, evidence-backed) has one place to land.
+ */
+const TURN_CONTINUITY_WINDOW_MS = 5 * 60 * 1000;          // 5 min cross-surface continuation
+const RECENT_GREETING_WINDOW_MS = 15 * 60 * 1000;         // 15 min greet-once cap
+const HEAVY_DAY_THRESHOLD = 3;                             // sessions today before we soften
+const ALL_SIGNAL_KEYS = [
+  'seconds_since_last_turn_anywhere',
+  'sessions_today_count',
+  'is_transparent_reconnect',
+  'time_since_last_greeting_today_ms',
+  'greeting_style_last_used',
+  'wake_origin',
+  'device_handoff_signal',
+] as const;
 
 /**
  * Map the temporal bucket + reconnect flag to a greeting policy.
@@ -110,36 +201,213 @@ export interface GreetingPolicyInput {
  *   any other                     → fresh_intro     (conservative default)
  */
 export function decideGreetingPolicy(input: GreetingPolicyInput): GreetingPolicy {
-  // Reconnect overrides everything — the user did not perceive any pause.
+  return decideGreetingPolicyWithEvidence(input).policy;
+}
+
+/**
+ * B1 (VTID-02930): full greeting-policy decision with evidence.
+ *
+ * Layered decision (top wins):
+ *   1. `is_transparent_reconnect` or `isReconnect`      → skip (forced)
+ *   2. `bucket === 'reconnect'`                          → skip (forced)
+ *   3. `seconds_since_last_turn_anywhere` < 5min         → skip (cross-surface continuation)
+ *   4. `time_since_last_greeting_today_ms` < 15min       → skip (greet-once-per-window cap)
+ *   5. `device_handoff_signal === true`                  → brief_resume (cross-device pickup)
+ *   6. A4 bucket-based default (unchanged)
+ *   7. Decay layer on top of the bucket result:
+ *      - same `greeting_style_last_used` twice in a row → downgrade one tier
+ *      - `sessions_today_count >= 3`                    → cap intensity at brief_resume
+ *      - `wake_origin === 'push_tap'`                   → prefer warm_return over fresh_intro
+ *        (push-tap implies user just acted on a notification — fresh_intro feels strange)
+ *
+ * Pure function. No DB, no IO, no clock — everything is read from the
+ * input. Out-of-range values (negative numbers, unknown strings) degrade
+ * to "ignore this signal" rather than throwing.
+ */
+export function decideGreetingPolicyWithEvidence(
+  input: GreetingPolicyInput,
+): GreetingPolicyDecision {
+  const evidence: GreetingPolicyEvidence[] = [];
+  const signalsPresent = signalsPresentIn(input);
+  const signalsMissing = ALL_SIGNAL_KEYS.filter((k) => !signalsPresent.includes(k));
+  let fellBackToBucket = false;
+
+  // ---- Forced skips (safety overrides) ----
   if (input.isReconnect === true) {
-    return 'skip';
+    return finalize('skip', 'isReconnect_forces_skip', evidenceFor(evidence, 'isReconnect', true, 'forced'), signalsPresent, signalsMissing, false);
+  }
+  if (input.is_transparent_reconnect === true) {
+    return finalize('skip', 'transparent_reconnect_forces_skip',
+      evidenceFor(evidence, 'is_transparent_reconnect', true, 'forced'),
+      signalsPresent, signalsMissing, false);
+  }
+  if (input.bucket === 'reconnect') {
+    return finalize('skip', 'bucket_reconnect_forces_skip',
+      evidenceFor(evidence, 'bucket', input.bucket, 'forced'),
+      signalsPresent, signalsMissing, false);
   }
 
+  // ---- Cross-surface continuation (signal #33) ----
+  if (
+    typeof input.seconds_since_last_turn_anywhere === 'number' &&
+    Number.isFinite(input.seconds_since_last_turn_anywhere) &&
+    input.seconds_since_last_turn_anywhere >= 0 &&
+    input.seconds_since_last_turn_anywhere * 1000 < TURN_CONTINUITY_WINDOW_MS
+  ) {
+    return finalize(
+      'skip',
+      'recent_turn_continues_thread',
+      evidenceFor(evidence, 'seconds_since_last_turn_anywhere', input.seconds_since_last_turn_anywhere, 'forced'),
+      signalsPresent,
+      signalsMissing,
+      false,
+    );
+  }
+
+  // ---- Greet-once-per-window cap (signal #36) ----
+  if (
+    typeof input.time_since_last_greeting_today_ms === 'number' &&
+    Number.isFinite(input.time_since_last_greeting_today_ms) &&
+    input.time_since_last_greeting_today_ms >= 0 &&
+    input.time_since_last_greeting_today_ms < RECENT_GREETING_WINDOW_MS
+  ) {
+    return finalize(
+      'skip',
+      'greeted_recently_within_window',
+      evidenceFor(evidence, 'time_since_last_greeting_today_ms', input.time_since_last_greeting_today_ms, 'forced'),
+      signalsPresent,
+      signalsMissing,
+      false,
+    );
+  }
+
+  // ---- Device handoff (signal #39) ----
+  if (input.device_handoff_signal === true) {
+    return finalize(
+      'brief_resume',
+      'device_handoff_continues_thread',
+      evidenceFor(evidence, 'device_handoff_signal', true, 'forced'),
+      signalsPresent,
+      signalsMissing,
+      false,
+    );
+  }
+
+  // ---- A4 bucket-based default ----
+  let policy: GreetingPolicy = bucketDefault(input);
+  fellBackToBucket = true;
+  evidenceFor(evidence, 'bucket', input.bucket, 'preferred');
+  if (input.wasFailure === true && input.bucket === 'recent') {
+    evidenceFor(evidence, 'wasFailure', true, 'preferred');
+  }
+
+  // ---- Decay layer ----
+
+  // wake_origin: push_tap → user JUST acted on a notification.
+  // fresh_intro is too cold; nudge to warm_return.
+  if (input.wake_origin === 'push_tap' && policy === 'fresh_intro') {
+    policy = 'warm_return';
+    evidenceFor(evidence, 'wake_origin', input.wake_origin, 'preferred');
+  } else if (input.wake_origin) {
+    evidenceFor(evidence, 'wake_origin', input.wake_origin, 'ignored');
+  }
+
+  // Heavy day: 3+ sessions today softens intensity.
+  if (
+    typeof input.sessions_today_count === 'number' &&
+    Number.isFinite(input.sessions_today_count) &&
+    input.sessions_today_count >= HEAVY_DAY_THRESHOLD
+  ) {
+    if (policy === 'fresh_intro' || policy === 'warm_return') {
+      policy = 'brief_resume';
+      evidenceFor(evidence, 'sessions_today_count', input.sessions_today_count, 'dampened');
+    } else {
+      evidenceFor(evidence, 'sessions_today_count', input.sessions_today_count, 'ignored');
+    }
+  } else if (typeof input.sessions_today_count === 'number') {
+    evidenceFor(evidence, 'sessions_today_count', input.sessions_today_count, 'ignored');
+  }
+
+  // Style avoidance: same style twice in a row → downgrade one tier.
+  if (input.greeting_style_last_used && input.greeting_style_last_used === policy) {
+    const downgraded = downgradeTier(policy);
+    if (downgraded !== policy) {
+      policy = downgraded;
+      evidenceFor(evidence, 'greeting_style_last_used', input.greeting_style_last_used, 'dampened');
+    } else {
+      evidenceFor(evidence, 'greeting_style_last_used', input.greeting_style_last_used, 'ignored');
+    }
+  } else if (input.greeting_style_last_used) {
+    evidenceFor(evidence, 'greeting_style_last_used', input.greeting_style_last_used, 'ignored');
+  }
+
+  return finalize(policy, 'bucket_with_decay_layer', evidence, signalsPresent, signalsMissing, fellBackToBucket);
+}
+
+// ─────────────────────────────────────────────────────────────────────
+// Helpers
+// ─────────────────────────────────────────────────────────────────────
+
+function bucketDefault(input: GreetingPolicyInput): GreetingPolicy {
   switch (input.bucket) {
-    case 'reconnect':
-      return 'skip';
-
     case 'recent':
-      // VTID-02637: a true new session 2-15min after a FAILED session
-      // deserves an apology-warm-return, not a silent brief-resume.
       return input.wasFailure === true ? 'warm_return' : 'brief_resume';
-
     case 'same_day':
       return 'brief_resume';
-
     case 'today':
     case 'yesterday':
     case 'week':
       return 'warm_return';
-
     case 'long':
     case 'first':
-      // 'first' here is "no telemetry found", treated as returning user
-      // with unknown recency. The new-day greeting is the safe default.
       return 'fresh_intro';
-
     default:
-      // Unknown bucket — conservative default is the full intro shape.
       return 'fresh_intro';
   }
+}
+
+/**
+ * Downgrade one tier toward `skip` for style-decay. The tiers are:
+ *   fresh_intro > warm_return > brief_resume > skip
+ * `skip` cannot be downgraded further; we keep `skip` rather than
+ * silently flip to a louder greeting.
+ */
+function downgradeTier(p: GreetingPolicy): GreetingPolicy {
+  if (p === 'fresh_intro') return 'warm_return';
+  if (p === 'warm_return') return 'brief_resume';
+  if (p === 'brief_resume') return 'skip';
+  return p; // skip
+}
+
+function signalsPresentIn(input: GreetingPolicyInput): string[] {
+  const present: string[] = [];
+  if (input.seconds_since_last_turn_anywhere !== undefined) present.push('seconds_since_last_turn_anywhere');
+  if (input.sessions_today_count !== undefined) present.push('sessions_today_count');
+  if (input.is_transparent_reconnect !== undefined) present.push('is_transparent_reconnect');
+  if (input.time_since_last_greeting_today_ms !== undefined) present.push('time_since_last_greeting_today_ms');
+  if (input.greeting_style_last_used !== undefined) present.push('greeting_style_last_used');
+  if (input.wake_origin !== undefined) present.push('wake_origin');
+  if (input.device_handoff_signal !== undefined) present.push('device_handoff_signal');
+  return present;
+}
+
+function evidenceFor(
+  evidence: GreetingPolicyEvidence[],
+  signal: string,
+  value: string | number | boolean | null,
+  influence: GreetingPolicyEvidence['influence'],
+): GreetingPolicyEvidence[] {
+  evidence.push({ signal, value, influence });
+  return evidence;
+}
+
+function finalize(
+  policy: GreetingPolicy,
+  reason: string,
+  evidence: GreetingPolicyEvidence[],
+  signalsPresent: string[],
+  signalsMissing: string[],
+  fellBackToBucket: boolean,
+): GreetingPolicyDecision {
+  return { policy, reason, evidence, signalsPresent, signalsMissing, fellBackToBucket };
 }

--- a/services/gateway/src/routes/voice-greeting-policy.ts
+++ b/services/gateway/src/routes/voice-greeting-policy.ts
@@ -1,0 +1,123 @@
+/**
+ * VTID-02930 (B1): Greeting Decay preview API.
+ *
+ *   GET /api/v1/voice/greeting-policy/preview
+ *
+ * Query params (all optional — pure simulator; the policy itself is a
+ * pure function and degrades safely when signals are absent):
+ *   bucket=…                             (default 'first')
+ *   isReconnect=true|false
+ *   wasFailure=true|false
+ *   seconds_since_last_turn_anywhere=N
+ *   sessions_today_count=N
+ *   is_transparent_reconnect=true|false
+ *   time_since_last_greeting_today_ms=N
+ *   greeting_style_last_used=skip|brief_resume|warm_return|fresh_intro
+ *   wake_origin=orb_tap|wake_word|push_tap|proactive_opener|deep_link|unknown
+ *   device_handoff_signal=true|false
+ *
+ * Auth: requireExafyAdmin. Same gating as the other B0c/B0d/B0e/R0
+ * inspection endpoints.
+ *
+ * Wall (B1): read-only. NO state mutation. NO transport/audio/Live-API
+ * tuning. Just the policy decision + evidence + signal source-health.
+ */
+
+import { Router, Response } from 'express';
+import {
+  requireAuthWithTenant,
+  requireExafyAdmin,
+  AuthenticatedRequest,
+} from '../middleware/auth-supabase-jwt';
+import {
+  decideGreetingPolicyWithEvidence,
+  type GreetingPolicy,
+  type GreetingPolicyInput,
+} from '../orb/live/instruction/greeting-policy';
+
+const router = Router();
+const VTID = 'VTID-02930';
+
+const KNOWN_BUCKETS: ReadonlySet<string> = new Set([
+  'reconnect', 'recent', 'same_day', 'today', 'yesterday', 'week', 'long', 'first',
+]);
+const KNOWN_STYLES: ReadonlySet<GreetingPolicy> = new Set([
+  'skip', 'brief_resume', 'warm_return', 'fresh_intro',
+]);
+const KNOWN_WAKE_ORIGINS: ReadonlySet<NonNullable<GreetingPolicyInput['wake_origin']>> = new Set([
+  'orb_tap', 'wake_word', 'push_tap', 'proactive_opener', 'deep_link', 'unknown',
+]);
+
+function parseBool(v: unknown): boolean | undefined {
+  if (v === 'true') return true;
+  if (v === 'false') return false;
+  return undefined;
+}
+
+function parseNum(v: unknown): number | undefined {
+  if (typeof v !== 'string' || v.length === 0) return undefined;
+  const n = Number(v);
+  return Number.isFinite(n) ? n : undefined;
+}
+
+router.get(
+  '/voice/greeting-policy/preview',
+  requireAuthWithTenant,
+  requireExafyAdmin,
+  (req: AuthenticatedRequest, res: Response) => {
+    try {
+      const q = req.query;
+
+      const bucketRaw = typeof q.bucket === 'string' && KNOWN_BUCKETS.has(q.bucket) ? q.bucket : 'first';
+      const greetingStyleRaw =
+        typeof q.greeting_style_last_used === 'string' &&
+        KNOWN_STYLES.has(q.greeting_style_last_used as GreetingPolicy)
+          ? (q.greeting_style_last_used as GreetingPolicy)
+          : undefined;
+      const wakeOriginRaw =
+        typeof q.wake_origin === 'string' &&
+        KNOWN_WAKE_ORIGINS.has(q.wake_origin as NonNullable<GreetingPolicyInput['wake_origin']>)
+          ? (q.wake_origin as NonNullable<GreetingPolicyInput['wake_origin']>)
+          : undefined;
+
+      const input: GreetingPolicyInput = {
+        bucket: bucketRaw,
+        ...(parseBool(q.isReconnect) !== undefined ? { isReconnect: parseBool(q.isReconnect) } : {}),
+        ...(parseBool(q.wasFailure) !== undefined ? { wasFailure: parseBool(q.wasFailure) } : {}),
+        ...(parseNum(q.seconds_since_last_turn_anywhere) !== undefined
+          ? { seconds_since_last_turn_anywhere: parseNum(q.seconds_since_last_turn_anywhere) }
+          : {}),
+        ...(parseNum(q.sessions_today_count) !== undefined
+          ? { sessions_today_count: parseNum(q.sessions_today_count) }
+          : {}),
+        ...(parseBool(q.is_transparent_reconnect) !== undefined
+          ? { is_transparent_reconnect: parseBool(q.is_transparent_reconnect) }
+          : {}),
+        ...(parseNum(q.time_since_last_greeting_today_ms) !== undefined
+          ? { time_since_last_greeting_today_ms: parseNum(q.time_since_last_greeting_today_ms) }
+          : {}),
+        ...(greetingStyleRaw ? { greeting_style_last_used: greetingStyleRaw } : {}),
+        ...(wakeOriginRaw ? { wake_origin: wakeOriginRaw } : {}),
+        ...(parseBool(q.device_handoff_signal) !== undefined
+          ? { device_handoff_signal: parseBool(q.device_handoff_signal) }
+          : {}),
+      };
+
+      const decision = decideGreetingPolicyWithEvidence(input);
+      return res.json({
+        ok: true,
+        vtid: VTID,
+        input,
+        decision,
+      });
+    } catch (e) {
+      return res.status(500).json({
+        ok: false,
+        error: (e as Error).message,
+        vtid: VTID,
+      });
+    }
+  },
+);
+
+export default router;

--- a/services/gateway/test/orb/live/instruction/b1-greeting-decay.test.ts
+++ b/services/gateway/test/orb/live/instruction/b1-greeting-decay.test.ts
@@ -1,0 +1,297 @@
+/**
+ * VTID-02930 (B1) — greeting decay tests.
+ *
+ * Direct mapping to the 7 acceptance checks the user locked:
+ *   1. Repeated greetings decay across recent sessions.
+ *   2. Reconnects do not behave like fresh first-time greetings.
+ *   3. Greeting policy returns a typed decision with reason/evidence.
+ *   4. Empty/unknown cadence data degrades safely.
+ *   5. Command Hub panel renders even when no cadence data exists.
+ *      (structural test in b1-walls.test.ts)
+ *   6. No mutation from preview/panel routes.
+ *      (structural test in b1-walls.test.ts)
+ *   7. Tests prove B1 does not alter B0d continuation behavior except
+ *      through the intended greeting-policy seam.
+ *      (regression test below — decideGreetingPolicy still returns
+ *      the same string union for the legacy bucket-only inputs.)
+ */
+
+import {
+  decideGreetingPolicy,
+  decideGreetingPolicyWithEvidence,
+} from '../../../../src/orb/live/instruction/greeting-policy';
+
+describe('B1 acceptance check #1: repeated greetings decay', () => {
+  it('same greeting style twice in a row → downgrades one tier', () => {
+    // bucket=today → default warm_return. last_used=warm_return →
+    // should decay to brief_resume.
+    const r = decideGreetingPolicyWithEvidence({
+      bucket: 'today',
+      greeting_style_last_used: 'warm_return',
+    });
+    expect(r.policy).toBe('brief_resume');
+    expect(r.reason).toBe('bucket_with_decay_layer');
+    expect(r.evidence.find((e) => e.signal === 'greeting_style_last_used')?.influence).toBe('dampened');
+  });
+
+  it('fresh_intro twice in a row → downgrades to warm_return', () => {
+    const r = decideGreetingPolicyWithEvidence({
+      bucket: 'long',
+      greeting_style_last_used: 'fresh_intro',
+    });
+    expect(r.policy).toBe('warm_return');
+  });
+
+  it('brief_resume twice in a row → downgrades to skip', () => {
+    const r = decideGreetingPolicyWithEvidence({
+      bucket: 'same_day',
+      greeting_style_last_used: 'brief_resume',
+    });
+    expect(r.policy).toBe('skip');
+  });
+
+  it('skip → stays skip when last_used was also skip (no flip up)', () => {
+    const r = decideGreetingPolicyWithEvidence({
+      bucket: 'reconnect',
+      greeting_style_last_used: 'skip',
+    });
+    // reconnect bucket forces skip BEFORE the decay layer evaluates;
+    // the result is still skip, but for the bucket reason, not the
+    // style avoidance.
+    expect(r.policy).toBe('skip');
+  });
+
+  it('different style last → no downgrade', () => {
+    const r = decideGreetingPolicyWithEvidence({
+      bucket: 'today',
+      greeting_style_last_used: 'brief_resume',
+    });
+    expect(r.policy).toBe('warm_return'); // unchanged
+  });
+
+  it('sessions_today_count >= 3 with bucket=today caps intensity at brief_resume', () => {
+    const r = decideGreetingPolicyWithEvidence({
+      bucket: 'today',
+      sessions_today_count: 4,
+    });
+    expect(r.policy).toBe('brief_resume');
+    expect(r.evidence.find((e) => e.signal === 'sessions_today_count')?.influence).toBe('dampened');
+  });
+
+  it('sessions_today_count < 3 does not dampen', () => {
+    const r = decideGreetingPolicyWithEvidence({
+      bucket: 'today',
+      sessions_today_count: 2,
+    });
+    expect(r.policy).toBe('warm_return');
+    expect(r.evidence.find((e) => e.signal === 'sessions_today_count')?.influence).toBe('ignored');
+  });
+
+  it('time_since_last_greeting_today_ms < 15min → skip', () => {
+    const r = decideGreetingPolicyWithEvidence({
+      bucket: 'today',
+      time_since_last_greeting_today_ms: 5 * 60 * 1000,
+    });
+    expect(r.policy).toBe('skip');
+    expect(r.reason).toBe('greeted_recently_within_window');
+  });
+
+  it('time_since_last_greeting_today_ms > 15min → does NOT skip', () => {
+    const r = decideGreetingPolicyWithEvidence({
+      bucket: 'today',
+      time_since_last_greeting_today_ms: 30 * 60 * 1000,
+    });
+    expect(r.policy).toBe('warm_return');
+  });
+});
+
+describe('B1 acceptance check #2: reconnects do not behave like first-time greetings', () => {
+  it('isReconnect=true → skip regardless of bucket', () => {
+    for (const bucket of ['first', 'long', 'week', 'today']) {
+      const r = decideGreetingPolicyWithEvidence({ bucket, isReconnect: true });
+      expect(r.policy).toBe('skip');
+      expect(r.reason).toBe('isReconnect_forces_skip');
+    }
+  });
+
+  it('is_transparent_reconnect=true → skip with the transparent_reconnect reason', () => {
+    const r = decideGreetingPolicyWithEvidence({
+      bucket: 'first',
+      is_transparent_reconnect: true,
+    });
+    expect(r.policy).toBe('skip');
+    expect(r.reason).toBe('transparent_reconnect_forces_skip');
+  });
+
+  it('bucket=reconnect → skip even without the boolean flag', () => {
+    const r = decideGreetingPolicyWithEvidence({ bucket: 'reconnect' });
+    expect(r.policy).toBe('skip');
+    expect(r.reason).toBe('bucket_reconnect_forces_skip');
+  });
+
+  it('cross-surface continuation (turn within 5min) → skip', () => {
+    const r = decideGreetingPolicyWithEvidence({
+      bucket: 'first', // would otherwise be fresh_intro
+      seconds_since_last_turn_anywhere: 60, // 1 minute
+    });
+    expect(r.policy).toBe('skip');
+    expect(r.reason).toBe('recent_turn_continues_thread');
+  });
+
+  it('device handoff → brief_resume, not fresh_intro', () => {
+    const r = decideGreetingPolicyWithEvidence({
+      bucket: 'first',
+      device_handoff_signal: true,
+    });
+    expect(r.policy).toBe('brief_resume');
+    expect(r.reason).toBe('device_handoff_continues_thread');
+  });
+});
+
+describe('B1 acceptance check #3: typed decision with reason + evidence', () => {
+  it('returns the full envelope shape on every call', () => {
+    const r = decideGreetingPolicyWithEvidence({
+      bucket: 'today',
+      greeting_style_last_used: 'warm_return',
+      sessions_today_count: 5,
+    });
+    expect(r).toHaveProperty('policy');
+    expect(r).toHaveProperty('reason');
+    expect(r).toHaveProperty('evidence');
+    expect(r).toHaveProperty('signalsPresent');
+    expect(r).toHaveProperty('signalsMissing');
+    expect(r).toHaveProperty('fellBackToBucket');
+  });
+
+  it('evidence items have stable shape (signal + value + influence)', () => {
+    const r = decideGreetingPolicyWithEvidence({
+      bucket: 'today',
+      greeting_style_last_used: 'warm_return',
+    });
+    for (const e of r.evidence) {
+      expect(typeof e.signal).toBe('string');
+      expect(['forced', 'dampened', 'preferred', 'ignored']).toContain(e.influence);
+    }
+  });
+
+  it('signalsPresent / signalsMissing add up to the full 7-signal set', () => {
+    const allSignals = [
+      'seconds_since_last_turn_anywhere',
+      'sessions_today_count',
+      'is_transparent_reconnect',
+      'time_since_last_greeting_today_ms',
+      'greeting_style_last_used',
+      'wake_origin',
+      'device_handoff_signal',
+    ];
+    const r = decideGreetingPolicyWithEvidence({
+      bucket: 'today',
+      sessions_today_count: 2,
+      wake_origin: 'orb_tap',
+    });
+    expect(r.signalsPresent.sort()).toEqual(['sessions_today_count', 'wake_origin']);
+    expect(r.signalsPresent.length + r.signalsMissing.length).toBe(allSignals.length);
+    expect([...r.signalsPresent, ...r.signalsMissing].sort()).toEqual(allSignals.sort());
+  });
+
+  it('fellBackToBucket=true when only bucket is provided', () => {
+    const r = decideGreetingPolicyWithEvidence({ bucket: 'today' });
+    expect(r.fellBackToBucket).toBe(true);
+  });
+
+  it('fellBackToBucket=false when a forced override fires', () => {
+    const r = decideGreetingPolicyWithEvidence({ bucket: 'today', isReconnect: true });
+    expect(r.fellBackToBucket).toBe(false);
+  });
+});
+
+describe('B1 acceptance check #4: empty/unknown cadence data degrades safely', () => {
+  it('no cadence signals → falls back to A4 bucket logic', () => {
+    expect(decideGreetingPolicyWithEvidence({ bucket: 'today' }).policy).toBe('warm_return');
+    expect(decideGreetingPolicyWithEvidence({ bucket: 'long' }).policy).toBe('fresh_intro');
+    expect(decideGreetingPolicyWithEvidence({ bucket: 'same_day' }).policy).toBe('brief_resume');
+  });
+
+  it('unknown bucket → fresh_intro (conservative default)', () => {
+    expect(decideGreetingPolicyWithEvidence({ bucket: 'made_up' }).policy).toBe('fresh_intro');
+  });
+
+  it('NaN / Infinity / negative numeric signals are ignored, not crash', () => {
+    const cases = [
+      { seconds_since_last_turn_anywhere: NaN },
+      { seconds_since_last_turn_anywhere: Number.POSITIVE_INFINITY },
+      { seconds_since_last_turn_anywhere: -1 },
+      { time_since_last_greeting_today_ms: NaN },
+      { time_since_last_greeting_today_ms: -100 },
+      { sessions_today_count: NaN },
+    ];
+    for (const c of cases) {
+      const r = decideGreetingPolicyWithEvidence({ bucket: 'today', ...c });
+      expect(r.policy).toBe('warm_return'); // bucket default
+    }
+  });
+
+  it('unknown wake_origin string is ignored (not stored as evidence influence=forced)', () => {
+    const r = decideGreetingPolicyWithEvidence({
+      bucket: 'today',
+      wake_origin: 'unknown',
+    });
+    // 'unknown' is a known value but should NOT trigger push_tap path.
+    expect(r.policy).toBe('warm_return');
+  });
+
+  it('wake_origin=push_tap on fresh_intro path nudges to warm_return', () => {
+    const r = decideGreetingPolicyWithEvidence({
+      bucket: 'long',
+      wake_origin: 'push_tap',
+    });
+    expect(r.policy).toBe('warm_return');
+  });
+
+  it('wake_origin=push_tap on brief_resume path is left alone', () => {
+    const r = decideGreetingPolicyWithEvidence({
+      bucket: 'same_day',
+      wake_origin: 'push_tap',
+    });
+    expect(r.policy).toBe('brief_resume');
+  });
+});
+
+describe('B1 acceptance check #7: B0d behavior unchanged via the seam', () => {
+  // The wake-brief-wiring (B0d.4) calls decideGreetingPolicy(input) and
+  // uses the string return value. The function must keep that signature
+  // and continue returning the same string values for the legacy A4
+  // inputs (bucket + isReconnect + wasFailure).
+
+  it('decideGreetingPolicy still returns a string (not the envelope)', () => {
+    const result = decideGreetingPolicy({ bucket: 'today' });
+    expect(typeof result).toBe('string');
+    expect(['skip', 'brief_resume', 'warm_return', 'fresh_intro']).toContain(result);
+  });
+
+  const a4TruthTable: Array<[string, boolean | undefined, boolean | undefined, string]> = [
+    ['reconnect', false, false, 'skip'],
+    ['recent', false, false, 'brief_resume'],
+    ['recent', false, true, 'warm_return'],          // wasFailure override
+    ['same_day', false, false, 'brief_resume'],
+    ['today', false, false, 'warm_return'],
+    ['yesterday', false, false, 'warm_return'],
+    ['week', false, false, 'warm_return'],
+    ['long', false, false, 'fresh_intro'],
+    ['first', false, false, 'fresh_intro'],
+    ['anything-unknown', false, false, 'fresh_intro'],
+    ['today', true, false, 'skip'],                  // isReconnect=true forces skip
+  ];
+
+  it.each(a4TruthTable)(
+    'A4 truth table: bucket=%s isReconnect=%s wasFailure=%s → %s',
+    (bucket, isReconnect, wasFailure, expected) => {
+      const result = decideGreetingPolicy({
+        bucket,
+        ...(isReconnect !== undefined ? { isReconnect } : {}),
+        ...(wasFailure !== undefined ? { wasFailure } : {}),
+      });
+      expect(result).toBe(expected);
+    },
+  );
+});

--- a/services/gateway/test/routes/voice-greeting-policy.test.ts
+++ b/services/gateway/test/routes/voice-greeting-policy.test.ts
@@ -1,0 +1,109 @@
+/**
+ * VTID-02930 (B1) — GET /api/v1/voice/greeting-policy/preview tests.
+ *
+ * The route is a pure simulator. Verify query parsing + response shape +
+ * admin gating.
+ */
+
+import express from 'express';
+import request from 'supertest';
+
+jest.mock('../../src/middleware/auth-supabase-jwt', () => ({
+  requireAuthWithTenant: (_req: any, _res: any, next: any) => next(),
+  requireExafyAdmin: (_req: any, _res: any, next: any) => next(),
+  optionalAuth: (_req: any, _res: any, next: any) => next(),
+}));
+
+function buildApp() {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const router = require('../../src/routes/voice-greeting-policy').default;
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1', router);
+  return app;
+}
+
+describe('B1 — GET /api/v1/voice/greeting-policy/preview', () => {
+  it('returns decision with reason + evidence for the default (bucket=first, no signals)', async () => {
+    const app = buildApp();
+    const res = await request(app).get('/api/v1/voice/greeting-policy/preview');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.vtid).toBe('VTID-02930');
+    expect(res.body.decision.policy).toBe('fresh_intro');
+    expect(res.body.decision.reason).toBe('bucket_with_decay_layer');
+    expect(res.body.decision.fellBackToBucket).toBe(true);
+  });
+
+  it('parses isReconnect=true → skip', async () => {
+    const app = buildApp();
+    const res = await request(app).get(
+      '/api/v1/voice/greeting-policy/preview?bucket=today&isReconnect=true',
+    );
+    expect(res.body.decision.policy).toBe('skip');
+    expect(res.body.decision.reason).toBe('isReconnect_forces_skip');
+  });
+
+  it('parses numeric cadence signals correctly', async () => {
+    const app = buildApp();
+    const res = await request(app).get(
+      '/api/v1/voice/greeting-policy/preview?bucket=today&seconds_since_last_turn_anywhere=60',
+    );
+    expect(res.body.decision.policy).toBe('skip');
+    expect(res.body.decision.reason).toBe('recent_turn_continues_thread');
+  });
+
+  it('parses greeting_style_last_used and applies decay', async () => {
+    const app = buildApp();
+    const res = await request(app).get(
+      '/api/v1/voice/greeting-policy/preview?bucket=today&greeting_style_last_used=warm_return',
+    );
+    expect(res.body.decision.policy).toBe('brief_resume');
+  });
+
+  it('rejects unknown bucket by falling back to first', async () => {
+    const app = buildApp();
+    const res = await request(app).get(
+      '/api/v1/voice/greeting-policy/preview?bucket=made_up_bucket',
+    );
+    expect(res.status).toBe(200);
+    // Unknown buckets get rewritten to 'first', which yields fresh_intro.
+    expect(res.body.input.bucket).toBe('first');
+    expect(res.body.decision.policy).toBe('fresh_intro');
+  });
+
+  it('rejects unknown greeting_style_last_used silently (treats as absent)', async () => {
+    const app = buildApp();
+    const res = await request(app).get(
+      '/api/v1/voice/greeting-policy/preview?bucket=today&greeting_style_last_used=invented',
+    );
+    expect(res.body.input.greeting_style_last_used).toBeUndefined();
+    expect(res.body.decision.policy).toBe('warm_return');
+  });
+
+  it('rejects unknown wake_origin silently (treats as absent)', async () => {
+    const app = buildApp();
+    const res = await request(app).get(
+      '/api/v1/voice/greeting-policy/preview?bucket=long&wake_origin=made_up',
+    );
+    expect(res.body.input.wake_origin).toBeUndefined();
+    expect(res.body.decision.policy).toBe('fresh_intro');
+  });
+
+  it('returns input echo so the panel can show what was simulated', async () => {
+    const app = buildApp();
+    const res = await request(app).get(
+      '/api/v1/voice/greeting-policy/preview?bucket=today&sessions_today_count=5',
+    );
+    expect(res.body.input).toEqual({ bucket: 'today', sessions_today_count: 5 });
+  });
+
+  it('returns signalsPresent / signalsMissing for source-health', async () => {
+    const app = buildApp();
+    const res = await request(app).get(
+      '/api/v1/voice/greeting-policy/preview?bucket=today&sessions_today_count=2',
+    );
+    expect(res.body.decision.signalsPresent).toEqual(['sessions_today_count']);
+    expect(res.body.decision.signalsMissing.length).toBe(6);
+  });
+});

--- a/services/gateway/test/services/greeting-decay/b1-walls.test.ts
+++ b/services/gateway/test/services/greeting-decay/b1-walls.test.ts
@@ -1,0 +1,111 @@
+/**
+ * VTID-02930 (B1) — wall-integrity tests.
+ *
+ * B1 is cadence/repetition/greeting policy ONLY. Asserts:
+ *   - Acceptance #5: Command Hub panel renders even when no cadence data exists.
+ *   - Acceptance #6: NO mutation from preview/panel routes.
+ *   - B1 does NOT touch ORB transport, audio, reconnect, Live API,
+ *     timeout, or wake-brief-timing code paths.
+ *   - B0d wake-brief-wiring still calls decideGreetingPolicy()
+ *     unchanged.
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const APP_JS_PATH = join(__dirname, '../../../src/frontend/command-hub/app.js');
+const ROUTE_PATH = join(__dirname, '../../../src/routes/voice-greeting-policy.ts');
+const POLICY_PATH = join(__dirname, '../../../src/orb/live/instruction/greeting-policy.ts');
+const WAKE_BRIEF_WIRING_PATH = join(__dirname, '../../../src/services/wake-brief-wiring.ts');
+
+describe('B1 — wall integrity', () => {
+  let appJs: string;
+  let routeSrc: string;
+  let policySrc: string;
+  let wakeBriefSrc: string;
+  beforeAll(() => {
+    appJs = readFileSync(APP_JS_PATH, 'utf8');
+    routeSrc = readFileSync(ROUTE_PATH, 'utf8');
+    policySrc = readFileSync(POLICY_PATH, 'utf8');
+    wakeBriefSrc = readFileSync(WAKE_BRIEF_WIRING_PATH, 'utf8');
+  });
+
+  describe('Acceptance #5: panel renders without data', () => {
+    it('defines renderJourneyContextGreetingDecayPanel', () => {
+      expect(appJs).toContain('function renderJourneyContextGreetingDecayPanel');
+    });
+
+    it('panel handles missing gd argument (empty-state branch)', () => {
+      const fnMatch = appJs.match(
+        /function renderJourneyContextGreetingDecayPanel\(gd\)\s*\{[\s\S]*?\n\}/,
+      );
+      expect(fnMatch).toBeTruthy();
+      const body = fnMatch![0];
+      // Renders an empty-state row when gd is falsy.
+      expect(body).toMatch(/if\s*\(\s*!gd\s*\)/);
+      expect(body).toMatch(/no data — set state\.greetingDecaySim/);
+    });
+
+    it('panel is wired into the journey-context grid', () => {
+      expect(appJs).toContain('renderJourneyContextGreetingDecayPanel(jc.greetingDecay)');
+    });
+  });
+
+  describe('Acceptance #6: no mutation from preview/panel routes', () => {
+    it('panel has NO mutation surface', () => {
+      const fnMatch = appJs.match(
+        /function renderJourneyContextGreetingDecayPanel\(gd\)\s*\{[\s\S]*?\n\}/,
+      );
+      const body = fnMatch![0];
+      expect(body).not.toMatch(/createElement\(['"]button['"]\)/);
+      expect(body).not.toMatch(/\.onclick\s*=/);
+      expect(body).not.toMatch(/addEventListener\(['"]click['"]/);
+      expect(body).not.toMatch(/method\s*:\s*['"](?:POST|PUT|PATCH|DELETE)['"]/);
+    });
+
+    it('preview route is GET-only', () => {
+      const startIdx = routeSrc.indexOf("'/voice/greeting-policy/preview'");
+      expect(startIdx).toBeGreaterThan(-1);
+      // The block surrounding the route registration must be router.get(.
+      const before = routeSrc.slice(Math.max(0, startIdx - 200), startIdx);
+      expect(before).toMatch(/router\.get\(/);
+    });
+
+    it('preview route has NO DB-mutation calls', () => {
+      expect(routeSrc).not.toMatch(/\.insert\(/);
+      expect(routeSrc).not.toMatch(/\.update\(/);
+      expect(routeSrc).not.toMatch(/\.upsert\(/);
+      expect(routeSrc).not.toMatch(/\.delete\(/);
+      expect(routeSrc).not.toMatch(/\.rpc\(/);
+    });
+
+    it('preview route requires exafy_admin', () => {
+      expect(routeSrc).toContain('requireExafyAdmin');
+    });
+  });
+
+  describe('B1 does NOT touch reliability-lane code paths', () => {
+    it('greeting-policy.ts is a pure module (no IO, no DB, no fetch)', () => {
+      expect(policySrc).not.toMatch(/supabase|getSupabase/);
+      expect(policySrc).not.toMatch(/\bfetch\(/);
+      expect(policySrc).not.toMatch(/axios/);
+      expect(policySrc).not.toMatch(/\.rpc\(/);
+    });
+
+    it('greeting-policy.ts does NOT reference transport / audio / reconnect / Live API', () => {
+      // The cadence signals discuss transparent_reconnect / wake_origin /
+      // device_handoff as INPUTS, but the policy must not call out to
+      // transport code or audio code or Live API timeout settings.
+      expect(policySrc).not.toMatch(/eventSource|EventSource|WebSocket|new AudioContext|playAudio|geminiLive\.|liveSessions\./);
+      expect(policySrc).not.toMatch(/reconnect_attempt\(|attemptReconnect\(/);
+      expect(policySrc).not.toMatch(/setTimeout\(|setInterval\(/);
+    });
+
+    it('B0d wake-brief-wiring still calls decideGreetingPolicy with the same signature', () => {
+      // Acceptance #7: B0d continuation behavior unchanged except via the
+      // intended seam.
+      expect(wakeBriefSrc).toContain('decideGreetingPolicy');
+      expect(wakeBriefSrc).toMatch(/decideGreetingPolicy\(\{[\s\S]*?bucket:/);
+    });
+  });
+});


### PR DESCRIPTION
## B1 — greeting decay only. R-lane untouched.

Fills the A4 \`greeting-policy.ts\` stub with cadence-aware decay logic using the 7 B1 signals (33-39). Pure function; no IO, no transport, no audio, no reconnect, no Live API. Read-only inspection surface in the Command Hub.

**Wall (B1 lane, locked by user):**
- \`decideGreetingPolicy()\` signature stays backwards-compatible — B0d.4 wake-brief-wiring continues to call it unchanged.
- New \`decideGreetingPolicyWithEvidence()\` returns the typed envelope for richer consumers.
- 7 cadence signals are OPTIONAL inputs. When absent, the policy degrades to the A4 bucket-only truth table.
- Preview route + Command Hub panel are pure simulator / inspection surfaces. **No DB writes, no POST/PUT/PATCH/DELETE.**

## Decision layers (top wins)

1. \`isReconnect=true\` → skip (forced)
2. \`is_transparent_reconnect=true\` → skip (forced)
3. \`bucket=reconnect\` → skip (forced)
4. \`seconds_since_last_turn_anywhere < 5min\` → skip (cross-surface continuation)
5. \`time_since_last_greeting_today_ms < 15min\` → skip (greet-once cap)
6. \`device_handoff_signal=true\` → brief_resume
7. A4 bucket default
8. Decay layer:
   - \`wake_origin=push_tap\` + fresh_intro → warm_return
   - \`sessions_today_count >= 3\` → cap at brief_resume
   - \`greeting_style_last_used == policy\` → downgrade one tier

## 7 acceptance checks (all green)

| # | Check | Coverage |
|---|---|---|
| 1 | Repeated greetings decay | 9 tests on style avoidance, sessions-today cap, recent-greeting window |
| 2 | Reconnects don't behave like first-time | 5 tests covering all 5 reconnect signals |
| 3 | Typed decision with reason + evidence | Envelope shape; evidence items have stable shape; signalsPresent + signalsMissing add up |
| 4 | Empty/unknown cadence data degrades safely | No-signal fallback, unknown bucket → fresh_intro, NaN/Infinity/negative ignored |
| 5 | Command Hub panel renders without data | Empty-state branch asserted by structural test |
| 6 | No mutation from preview/panel routes | Structural tests on panel + route + module (no insert/update/upsert/delete/rpc, no buttons, no onclick, no non-GET) |
| 7 | B0d behavior unchanged via the seam | A4 truth table re-asserted via \`it.each\` over 11 historical cases |

## R-lane guardrail (asserted by structural test)

\`greeting-policy.ts\` does NOT reference: \`EventSource\` / \`WebSocket\` / \`AudioContext\` / \`liveSessions\` / \`reconnect_attempt\` / \`setTimeout\` / \`setInterval\` / \`supabase\` / \`fetch\` / \`rpc\`.

The cadence signals discuss \`transparent_reconnect\` / \`wake_origin\` / \`device_handoff\` as INPUTS only — the policy never calls reliability code paths.

## Tests

- **+56 new tests** (32 policy + 9 route + 15 wall)
- **793/793** across the full B0d+B0e+R0+B1 stack
- \`npm run build\` clean

## Test plan

- [x] 56 new tests pass
- [x] No regression in 737 prior tests
- [x] TypeScript build clean
- [x] B0d.4 wake-brief-wiring still calls \`decideGreetingPolicy\` unchanged
- [x] Wall: no transport/audio/reconnect/Live-API references in greeting-policy.ts
- [x] Preview route + panel have no mutation surface

🤖 Generated with [Claude Code](https://claude.com/claude-code)