### PR TITLE
fix(self-healing): no terminal success without completed autopilot execution (VTID-02931, PR-E/Gap-1)

### DIFF
--- a/services/gateway/src/routes/vtid-terminalize.ts
+++ b/services/gateway/src/routes/vtid-terminalize.ts
@@ -433,6 +433,88 @@ router.post('/api/v1/oasis/vtid/terminalize', async (req: Request, res: Response
       });
     }
 
+    // PR-E (VTID-02931, Gap 1): self-healing VTIDs cannot be terminalized
+    // 'success' unless their linked dev_autopilot_executions row reached
+    // status='completed'. This is the authoritative gate — the worker-runner
+    // already refuses local LLM fallback for self-healing without a bridge,
+    // and the self-healing reconciler is the only legitimate path that sets
+    // terminal_outcome='success' (via direct vtid_ledger PATCH, bypassing
+    // this endpoint). Any other caller trying to mark a self-healing VTID
+    // 'success' through this endpoint is misbehaving and gets rejected.
+    if (outcome === 'success' && task.metadata?.source === 'self-healing') {
+      const execId = typeof task.metadata?.autopilot_execution_id === 'string'
+        ? task.metadata.autopilot_execution_id
+        : null;
+
+      if (!execId) {
+        console.warn(
+          `[${VTID}] BLOCKED: self-healing VTID ${vtid} has no autopilot_execution_id in metadata — refusing terminal_outcome='success'`,
+        );
+        await emitOasisEvent(supabaseUrl, svcKey, {
+          vtid,
+          topic: 'self-healing.terminalize.blocked',
+          status: 'warning',
+          message: `Refusing terminal_outcome='success' for ${vtid}: no autopilot execution linkage (bridge failed upstream)`,
+          metadata: {
+            vtid,
+            outcome,
+            actor,
+            reason: 'missing_autopilot_execution_id',
+            healing_state: task.metadata?.healing_state || null,
+            blocked_at: new Date().toISOString(),
+            governance_vtid: 'VTID-02931',
+          },
+        });
+        return res.status(400).json({
+          ok: false,
+          error: 'SELF_HEALING_NO_AUTOPILOT_BRIDGE',
+          message: `Refusing terminal_outcome='success' for self-healing VTID ${vtid}: no autopilot execution linkage. See self-healing.execution.bridge_failed in oasis_events.`,
+          vtid,
+        });
+      }
+
+      const execResp = await fetch(
+        `${supabaseUrl}/rest/v1/dev_autopilot_executions?id=eq.${encodeURIComponent(execId)}&select=id,status,pr_url,pr_number&limit=1`,
+        {
+          headers: {
+            apikey: svcKey,
+            Authorization: `Bearer ${svcKey}`,
+          },
+        },
+      );
+      const execRows = execResp.ok ? ((await execResp.json()) as Array<{ id: string; status: string; pr_url: string | null; pr_number: number | null }>) : [];
+      const execStatus = execRows[0]?.status || 'missing';
+
+      if (execStatus !== 'completed') {
+        console.warn(
+          `[${VTID}] BLOCKED: self-healing VTID ${vtid} terminalize 'success' refused — dev_autopilot_executions.status='${execStatus}' (need 'completed')`,
+        );
+        await emitOasisEvent(supabaseUrl, svcKey, {
+          vtid,
+          topic: 'self-healing.terminalize.blocked',
+          status: 'warning',
+          message: `Refusing terminal_outcome='success' for ${vtid}: autopilot execution status='${execStatus}', not 'completed'`,
+          metadata: {
+            vtid,
+            outcome,
+            actor,
+            reason: 'autopilot_not_completed',
+            autopilot_execution_id: execId,
+            autopilot_status: execStatus,
+            blocked_at: new Date().toISOString(),
+            governance_vtid: 'VTID-02931',
+          },
+        });
+        return res.status(400).json({
+          ok: false,
+          error: 'SELF_HEALING_AUTOPILOT_NOT_COMPLETED',
+          message: `Refusing terminal_outcome='success' for ${vtid}: autopilot execution ${execId.slice(0, 8)} status='${execStatus}', not 'completed'. The self-healing reconciler is the only authorized writer of success for self-healing VTIDs.`,
+          vtid,
+          autopilot_status: execStatus,
+        });
+      }
+    }
+
     // VTID-01204: Pipeline Integrity Gate - Check for full pipeline completion
     const bypassCheck = canBypassPipelineGates(req, outcome);
     if (!bypassCheck.allowed) {

--- a/services/gateway/test/self-healing-terminalize-gate.test.ts
+++ b/services/gateway/test/self-healing-terminalize-gate.test.ts
@@ -1,0 +1,218 @@
+/**
+ * PR-E (VTID-02931, Gap 1): the /api/v1/oasis/vtid/terminalize endpoint
+ * must hard-block terminal_outcome='success' for self-healing VTIDs
+ * unless their linked dev_autopilot_executions row has reached
+ * status='completed'.
+ *
+ * Healing definition: no PR → not healed; PR opened but CI/deploy/verify
+ * in flight → not healed; only execution.status='completed' (CI green +
+ * deploy + live probe) counts as healed. The self-healing reconciler is
+ * the only authorized writer of success for self-healing VTIDs, and it
+ * goes through a direct Supabase PATCH (bypassing this endpoint). Any
+ * other caller — including a misbehaving worker-runner — gets blocked
+ * here with 400.
+ *
+ * Non-self-healing VTIDs are unaffected — they continue through the
+ * normal VTID-01204 pipeline-integrity gate.
+ */
+
+import express from 'express';
+import request from 'supertest';
+import router from '../src/routes/vtid-terminalize';
+
+const ORIGINAL_FETCH = global.fetch;
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  return app;
+}
+
+beforeEach(() => {
+  process.env.SUPABASE_URL = 'https://supabase.test';
+  process.env.SUPABASE_SERVICE_ROLE = 'svc-role';
+});
+
+afterEach(() => {
+  global.fetch = ORIGINAL_FETCH;
+});
+
+interface MockState {
+  ledgerTask: any;
+  executionStatus: string | 'missing';
+  patches: any[];
+}
+
+function mockFetch(state: MockState) {
+  global.fetch = jest.fn().mockImplementation(async (url: string, init?: any) => {
+    if (url.includes('/rest/v1/vtid_ledger') && (!init?.method || init.method === 'GET')) {
+      return { ok: true, status: 200, json: () => Promise.resolve(state.ledgerTask ? [state.ledgerTask] : []) };
+    }
+    if (url.includes('/rest/v1/vtid_ledger') && init?.method === 'PATCH') {
+      state.patches.push({ url, body: JSON.parse(init.body) });
+      return { ok: true, status: 200, json: () => Promise.resolve([]) };
+    }
+    if (url.includes('/rest/v1/dev_autopilot_executions?id=eq.')) {
+      if (state.executionStatus === 'missing') {
+        return { ok: true, status: 200, json: () => Promise.resolve([]) };
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve([{ id: 'exec-1', status: state.executionStatus, pr_url: 'https://x/y/pull/1', pr_number: 1 }]),
+      };
+    }
+    // OASIS event POSTs + Supabase RPC catch-all
+    return { ok: true, status: 200, json: () => Promise.resolve({}), text: () => Promise.resolve('') };
+  }) as unknown as typeof fetch;
+}
+
+const baseSelfHealingTask = {
+  vtid: 'VTID-00001',
+  status: 'in_progress',
+  is_terminal: false,
+  metadata: {
+    source: 'self-healing',
+    autopilot_execution_id: 'exec-uuid-1',
+  },
+};
+
+describe('POST /api/v1/oasis/vtid/terminalize — self-healing gate (PR-E)', () => {
+  it('400 when self-healing VTID has NO autopilot_execution_id and outcome=success', async () => {
+    const state: MockState = {
+      ledgerTask: {
+        ...baseSelfHealingTask,
+        metadata: { source: 'self-healing' }, // no execution_id
+      },
+      executionStatus: 'missing',
+      patches: [],
+    };
+    mockFetch(state);
+
+    const res = await request(buildApp())
+      .post('/api/v1/oasis/vtid/terminalize')
+      .send({ vtid: 'VTID-00001', outcome: 'success', actor: 'autodeploy' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('SELF_HEALING_NO_AUTOPILOT_BRIDGE');
+    expect(state.patches.length).toBe(0); // no terminal patch happened
+  });
+
+  it('400 when self-healing VTID has bridge but execution.status is in flight', async () => {
+    const inflightStatuses = ['queued', 'cooling', 'running', 'ci', 'merging', 'deploying', 'verifying'];
+    for (const status of inflightStatuses) {
+      const state: MockState = {
+        ledgerTask: baseSelfHealingTask,
+        executionStatus: status,
+        patches: [],
+      };
+      mockFetch(state);
+
+      const res = await request(buildApp())
+        .post('/api/v1/oasis/vtid/terminalize')
+        .send({ vtid: 'VTID-00001', outcome: 'success', actor: 'autodeploy' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('SELF_HEALING_AUTOPILOT_NOT_COMPLETED');
+      expect(res.body.autopilot_status).toBe(status);
+      expect(state.patches.length).toBe(0);
+    }
+  });
+
+  it('400 when self-healing VTID has bridge but execution.status is failed', async () => {
+    const state: MockState = {
+      ledgerTask: baseSelfHealingTask,
+      executionStatus: 'failed',
+      patches: [],
+    };
+    mockFetch(state);
+
+    const res = await request(buildApp())
+      .post('/api/v1/oasis/vtid/terminalize')
+      .send({ vtid: 'VTID-00001', outcome: 'success', actor: 'autodeploy' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('SELF_HEALING_AUTOPILOT_NOT_COMPLETED');
+    expect(res.body.autopilot_status).toBe('failed');
+  });
+
+  it('allows success when self-healing VTID has bridge AND execution.status=completed', async () => {
+    const state: MockState = {
+      ledgerTask: baseSelfHealingTask,
+      executionStatus: 'completed',
+      patches: [],
+    };
+    mockFetch(state);
+
+    // The endpoint will then go through the existing VTID-01204 pipeline
+    // gate, which may also block (no real PR events) — that's fine, we're
+    // only asserting OUR gate doesn't fire for execution.status=completed.
+    const res = await request(buildApp())
+      .post('/api/v1/oasis/vtid/terminalize')
+      .send({ vtid: 'VTID-00001', outcome: 'success', actor: 'autodeploy' });
+
+    // The PR-E gate should pass; downstream pipeline-integrity may still
+    // reject (it requires PR-created + merged + deploy events too).
+    expect(['SELF_HEALING_NO_AUTOPILOT_BRIDGE', 'SELF_HEALING_AUTOPILOT_NOT_COMPLETED'])
+      .not.toContain(res.body.error);
+  });
+
+  it('allows outcome=failed for self-healing VTID regardless of autopilot status', async () => {
+    const state: MockState = {
+      ledgerTask: baseSelfHealingTask,
+      executionStatus: 'failed',
+      patches: [],
+    };
+    mockFetch(state);
+
+    const res = await request(buildApp())
+      .post('/api/v1/oasis/vtid/terminalize')
+      .send({ vtid: 'VTID-00001', outcome: 'failed', actor: 'autodeploy' });
+
+    expect(['SELF_HEALING_NO_AUTOPILOT_BRIDGE', 'SELF_HEALING_AUTOPILOT_NOT_COMPLETED'])
+      .not.toContain(res.body.error);
+  });
+
+  it('does NOT apply the self-healing gate to non-self-healing VTIDs', async () => {
+    const state: MockState = {
+      ledgerTask: {
+        vtid: 'VTID-00002',
+        status: 'in_progress',
+        is_terminal: false,
+        metadata: { source: 'dev_autopilot' }, // not self-healing
+      },
+      executionStatus: 'missing',
+      patches: [],
+    };
+    mockFetch(state);
+
+    const res = await request(buildApp())
+      .post('/api/v1/oasis/vtid/terminalize')
+      .send({ vtid: 'VTID-00002', outcome: 'success', actor: 'autodeploy' });
+
+    expect(['SELF_HEALING_NO_AUTOPILOT_BRIDGE', 'SELF_HEALING_AUTOPILOT_NOT_COMPLETED'])
+      .not.toContain(res.body.error);
+  });
+
+  it('idempotent: already-terminal self-healing VTIDs return 200 without re-running the gate', async () => {
+    const state: MockState = {
+      ledgerTask: {
+        ...baseSelfHealingTask,
+        is_terminal: true,
+        terminal_outcome: 'success',
+        completed_at: '2026-05-11T20:00:00Z',
+      },
+      executionStatus: 'missing', // wouldn't matter — gate is skipped
+      patches: [],
+    };
+    mockFetch(state);
+
+    const res = await request(buildApp())
+      .post('/api/v1/oasis/vtid/terminalize')
+      .send({ vtid: 'VTID-00001', outcome: 'success', actor: 'autodeploy' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.already_terminal).toBe(true);
+  });
+});

--- a/services/worker-runner/src/services/execution-service-delegation.test.ts
+++ b/services/worker-runner/src/services/execution-service-delegation.test.ts
@@ -176,8 +176,14 @@ describe('executeTask — self-healing delegation', () => {
     expect(result.error).toContain('ANTHROPIC_API_KEY');
   });
 
-  it('falls back to local LLM path when self-healing flag set but execution_id missing', async () => {
-    delete process.env.ANTHROPIC_API_KEY;
+  // PR-E (VTID-02931, Gap 1): self-healing tasks without an autopilot
+  // bridge MUST NOT fall back to the local LLM path. The repair-evidence
+  // gate from PR #2045 was a weak check — Claude can hallucinate file
+  // paths in its describe-only output and slip past `files_changed.length
+  // > 0`. The worker-runner now refuses the fallback entirely.
+  it('REFUSES local LLM fallback when self-healing flag set but execution_id missing (Gap 1)', async () => {
+    process.env.ANTHROPIC_API_KEY = 'fake-key-that-should-NEVER-be-used';
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     const partialTask: PendingTask = {
       ...selfHealingTask(),
       metadata: { source: 'self-healing' }, // no autopilot_execution_id
@@ -187,6 +193,13 @@ describe('executeTask — self-healing delegation', () => {
 
     expect(mockAwait).not.toHaveBeenCalled();
     expect(result.ok).toBe(false);
+    expect(result.error).toContain('refusing legacy LLM fallback');
+    expect(result.healing_state).toBe('execution_failed');
+    expect(result.provider).toBe('self-healing-guard');
+    // The model field must NOT be claude-* — confirms no Claude call.
+    expect(result.model).toBe('none');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Refusing legacy LLM fallback'));
+    warnSpy.mockRestore();
   });
 
   it('surfaces gateway errors instead of silently treating as success', async () => {

--- a/services/worker-runner/src/services/execution-service.ts
+++ b/services/worker-runner/src/services/execution-service.ts
@@ -340,6 +340,31 @@ export async function executeTask(
     );
     return await delegateToAutopilot(config, task, autopilotExecutionId, modelName, provider, startTime);
   }
+  // PR-E (VTID-02931, Gap 1): never fall through to the local LLM for
+  // self-healing tasks. The repair-evidence gate from PR #2045 is a weak
+  // check — Claude can hallucinate file paths in its describe-only output,
+  // which slips past the `files_changed.length > 0` check and produces a
+  // false success. Worker-runner must refuse to even attempt the local
+  // path when the autopilot bridge linkage is missing; the task fails
+  // hard, the reconciler tombstones it, and the operator sees the bridge
+  // failure that needs root-cause attention (safety-gate block, scope
+  // mismatch, etc.) instead of a silently-fake "fixed" claim.
+  if (isSelfHealing && !autopilotExecutionId) {
+    console.warn(
+      `[${VTID}] Refusing legacy LLM fallback for self-healing task ${task.vtid}: ` +
+        `metadata.autopilot_execution_id is missing (bridge failed upstream). ` +
+        `See self-healing.execution.bridge_failed in oasis_events for the root cause.`,
+    );
+    return {
+      ok: false,
+      error:
+        'self-healing requires autopilot bridge — refusing legacy LLM fallback (see self-healing.execution.bridge_failed)',
+      duration_ms: Date.now() - startTime,
+      model: 'none',
+      provider: 'self-healing-guard',
+      healing_state: 'execution_failed',
+    };
+  }
 
   if (!initClaude()) {
     return {


### PR DESCRIPTION
## Summary
Closes the contract gap surfaced by the PR-A live smoke (VTID-02928, 2026-05-11 20:08Z): when the autopilot bridge fails, worker-runner falls back to the local Claude path, Claude hallucinates file paths, and the existing repair-evidence check passes — VTID gets marked `terminal_outcome='success'` with no real PR.

Two layers of defense:

### Layer 1 — `services/worker-runner/src/services/execution-service.ts`
`executeTask()` now hard-refuses the local LLM path when `metadata.source==='self-healing'` AND `metadata.autopilot_execution_id` is missing. Returns `{ok:false, healing_state:'execution_failed', provider:'self-healing-guard', model:'none'}`. No Claude call, no DeepSeek fallback, no hallucinated file paths to slip past the repair-evidence gate.

### Layer 2 — `services/gateway/src/routes/vtid-terminalize.ts`
The `/api/v1/oasis/vtid/terminalize` endpoint hard-blocks `outcome='success'` for self-healing VTIDs unless:
- `metadata.autopilot_execution_id` is set, **AND**
- `dev_autopilot_executions[execution_id].status === 'completed'`

Two distinct error codes (`SELF_HEALING_NO_AUTOPILOT_BRIDGE`, `SELF_HEALING_AUTOPILOT_NOT_COMPLETED`), distinct OASIS event (`self-healing.terminalize.blocked`), and a 400 response that points operators at the upstream `self-healing.execution.bridge_failed` event.

The self-healing reconciler — which writes `terminal_outcome='success'` via direct Supabase PATCH — bypasses this endpoint, so the canonical success path is unaffected. Only direct callers (a misbehaving worker, a manual API call) get blocked here.

## Contract enforced
> A self-healing VTID reaches `terminal_outcome='success'` **only** when `dev_autopilot_executions.status='completed'`. Bridge failure, in-flight autopilot, or terminal autopilot failure → never success.

## Test plan
- [x] `npm run build` (gateway + worker-runner) — clean except pre-existing `sharp` / `yaml`
- [x] `test/self-healing-terminalize-gate.test.ts` — 7/7 (no bridge → 400; 7 in-flight statuses → 400; failed → 400; completed → allowed; outcome=failed always allowed; non-self-healing unaffected; idempotency preserved)
- [x] `src/services/execution-service-delegation.test.ts` — 7/7 including the rewritten "REFUSES local LLM fallback" assertion (now checks `model='none'`, `provider='self-healing-guard'`, `healing_state='execution_failed'`, console.warn fired)
- [x] Full regression: `test/self-healing-pre-probe.test.ts` (12) + `self-healing-diagnosis-github-fallback.test.ts` (9) + `self-healing-injector-autopilot-bridge.test.ts` (4) + `worker-orchestrator-await-autopilot.test.ts` (11) + `self-healing-reconciler-autopilot-link.test.ts` (12) + `self-healing-terminalize-gate.test.ts` (7) + `voice-self-healing-adapter.test.ts` (13) = **68/68 pass**
- [ ] After merge: dispatch EXEC-DEPLOY for both gateway and worker-runner, re-arm canary, confirm a self-healing VTID with a failed bridge gets `terminal_outcome='failed'` (not success), and verify reconciler is the only path that can write success

## Plan reference
Gap 1 of the post-merge smoke findings. Gap 2 (diagnosis route_file mapping pointing at index.ts) is a separate follow-up.

🤖 Generated with [Claude Code](https://claude.com/claude-code)