### PR TITLE
feat(orb): B2 - conversation continuity preview (VTID-02932, DEV-COMHU-02932)

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -42514,6 +42514,10 @@ function renderJourneyContextView() {
     // VTID-02930 (B1): Greeting Decay panel — simulated policy decision
     // + reason + evidence + signal source-health. Read-only.
     grid.appendChild(renderJourneyContextGreetingDecayPanel(jc.greetingDecay));
+    // VTID-02932 (B2): Conversation Continuity panel — open threads,
+    // owed promises, recently-kept promises, counts, source-health.
+    // Read-only.
+    grid.appendChild(renderJourneyContextContinuityPanel(jc.continuity));
 
     c.appendChild(grid);
     return c;
@@ -42561,6 +42565,9 @@ function loadJourneyContext() {
         fetch('/api/v1/voice/feature-discovery/preview' + fdQs, { headers: buildContextHeaders() }).then(function (r) { return r.json(); }).catch(function () { return { ok: false }; }),
         fetch('/api/v1/voice/wake-timeline/analysis'  + raQs, { headers: buildContextHeaders() }).then(function (r) { return r.json(); }).catch(function () { return { ok: false }; }),
         fetch('/api/v1/voice/greeting-policy/preview' + gdQs, { headers: buildContextHeaders() }).then(function (r) { return r.json(); }).catch(function () { return { ok: false }; }),
+        // VTID-02932 (B2): conversation continuity preview — open threads
+        // + promises + distilled context. Keyed on user/tenant.
+        fetch('/api/v1/voice/continuity/preview' + qs, { headers: buildContextHeaders() }).then(function (r) { return r.json(); }).catch(function () { return { ok: false }; }),
     ]).then(function (results) {
         jc.loading = false;
         if (results[0] && results[0].ok) {
@@ -42590,6 +42597,11 @@ function loadJourneyContext() {
             jc.greetingDecay = results[5];
         } else {
             jc.greetingDecay = null;
+        }
+        if (results[6] && results[6].ok) {
+            jc.continuity = results[6];
+        } else {
+            jc.continuity = null;
         }
         renderApp();
     }).catch(function (err) {
@@ -42881,6 +42893,124 @@ function renderJourneyContextGreetingDecayPanel(gd) {
     Object.keys(inp).forEach(function (k) {
         panel.appendChild(renderJourneyContextEmptyRow(k, String(inp[k])));
     });
+
+    return panel;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// VTID-02932 (B2): Conversation Continuity panel.
+//
+// Read-only inspection surface for the B2 continuity context the
+// assistant decision layer reads from. Operators read:
+//   - open threads (most recently mentioned first)
+//   - owed promises (oldest due first)
+//   - recently-kept promises (for credit acknowledgement)
+//   - aggregate counts used by the cadence layer
+//   - per-table source-health
+//
+// Wall (B2): NO mutation, NO POST, NO buttons. Selection is read-only;
+// state advancement (creating threads / marking promises) lives in a
+// follow-up slice with its own dedicated event endpoint.
+// ─────────────────────────────────────────────────────────────────────────
+function renderJourneyContextContinuityPanel(co) {
+    var panel = renderJourneyContextPanel(
+        'Conversation Continuity (B2)',
+        'Open threads + owed/kept promises — read-only, no mutation',
+    );
+
+    if (!co) {
+        panel.appendChild(renderJourneyContextEmptyRow('status', 'no data — load a user above'));
+        return panel;
+    }
+
+    var ctx = co.context || {};
+    var counts = ctx.counts || {};
+    var sh = ctx.source_health || {};
+
+    // ---- Counts ----
+    panel.appendChild(renderJourneyContextEmptyRow('open_threads_total', String(counts.open_threads_total || 0)));
+    panel.appendChild(renderJourneyContextEmptyRow('promises_owed_total', String(counts.promises_owed_total || 0)));
+    panel.appendChild(renderJourneyContextEmptyRow('promises_overdue', String(counts.promises_overdue || 0)));
+    panel.appendChild(renderJourneyContextEmptyRow('threads_mentioned_today', String(counts.threads_mentioned_today || 0)));
+
+    // ---- Source health ----
+    var shHeader = document.createElement('div');
+    shHeader.style.cssText = 'margin-top:0.75rem;font-size:0.85rem;font-weight:600;color:var(--color-text-primary);';
+    shHeader.textContent = 'Source health';
+    panel.appendChild(shHeader);
+    var threadsHealth = sh.user_open_threads || { ok: false, reason: 'unknown' };
+    var promisesHealth = sh.assistant_promises || { ok: false, reason: 'unknown' };
+    panel.appendChild(renderJourneyContextEmptyRow(
+        'user_open_threads',
+        threadsHealth.ok ? 'ok' : ('failed: ' + (threadsHealth.reason || 'unknown')),
+    ));
+    panel.appendChild(renderJourneyContextEmptyRow(
+        'assistant_promises',
+        promisesHealth.ok ? 'ok' : ('failed: ' + (promisesHealth.reason || 'unknown')),
+    ));
+
+    // ---- Open threads ----
+    var otHeader = document.createElement('div');
+    otHeader.style.cssText = 'margin-top:0.75rem;font-size:0.85rem;font-weight:600;color:var(--color-text-primary);';
+    otHeader.textContent = 'Open threads (most recent first, capped at 5)';
+    panel.appendChild(otHeader);
+    var openThreads = Array.isArray(ctx.open_threads) ? ctx.open_threads : [];
+    if (openThreads.length === 0) {
+        panel.appendChild(renderJourneyContextEmptyRow('open_threads', 'no open threads'));
+    } else {
+        openThreads.forEach(function (t) {
+            var ageLabel = (t.days_since_last_mention === null || t.days_since_last_mention === undefined)
+                ? '?d'
+                : (t.days_since_last_mention + 'd');
+            panel.appendChild(renderJourneyContextEmptyRow(
+                t.topic + ' [' + ageLabel + ']',
+                t.summary || '(no summary)',
+            ));
+        });
+    }
+
+    // ---- Owed promises ----
+    var opHeader = document.createElement('div');
+    opHeader.style.cssText = 'margin-top:0.75rem;font-size:0.85rem;font-weight:600;color:var(--color-text-primary);';
+    opHeader.textContent = 'Promises owed (oldest due first, capped at 5)';
+    panel.appendChild(opHeader);
+    var promisesOwed = Array.isArray(ctx.promises_owed) ? ctx.promises_owed : [];
+    if (promisesOwed.length === 0) {
+        panel.appendChild(renderJourneyContextEmptyRow('promises_owed', 'no promises owed'));
+    } else {
+        promisesOwed.forEach(function (p) {
+            var dueLabel;
+            if (p.due_at === null || p.due_at === undefined) {
+                dueLabel = 'no due_at';
+            } else if (p.days_overdue === null || p.days_overdue === undefined) {
+                dueLabel = 'due ' + p.due_at;
+            } else if (p.days_overdue > 0) {
+                dueLabel = p.days_overdue + 'd overdue';
+            } else if (p.days_overdue < 0) {
+                dueLabel = 'due in ' + Math.abs(p.days_overdue) + 'd';
+            } else {
+                dueLabel = 'due today';
+            }
+            panel.appendChild(renderJourneyContextEmptyRow(
+                p.promise_text + ' [' + dueLabel + ']',
+                p.decision_id ? ('decision=' + p.decision_id) : '(no decision_id)',
+            ));
+        });
+    }
+
+    // ---- Recently-kept promises ----
+    var kpHeader = document.createElement('div');
+    kpHeader.style.cssText = 'margin-top:0.75rem;font-size:0.85rem;font-weight:600;color:var(--color-text-primary);';
+    kpHeader.textContent = 'Promises kept (last 7 days, capped at 3)';
+    panel.appendChild(kpHeader);
+    var promisesKept = Array.isArray(ctx.promises_kept_recently) ? ctx.promises_kept_recently : [];
+    if (promisesKept.length === 0) {
+        panel.appendChild(renderJourneyContextEmptyRow('promises_kept_recently', 'no promises kept in last 7 days'));
+    } else {
+        promisesKept.forEach(function (p) {
+            panel.appendChild(renderJourneyContextEmptyRow(p.promise_text, 'kept ' + p.kept_at));
+        });
+    }
 
     return panel;
 }

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -30,7 +30,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260504-vtid-02710-ios-ctx-keepalive"></script>
-  <script src="/command-hub/app.js?v=20260511-vtid-02934-mission-alignment"></script>
+  <script src="/command-hub/app.js?v=20260513-b2-continuity-vtid-02932"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
 </body>

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -747,6 +747,11 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const voiceGreetingPolicyRouter = require('./routes/voice-greeting-policy').default;
   mountRouterSync(app, '/api/v1', voiceGreetingPolicyRouter, { owner: 'voice-greeting-policy' });
 
+  // VTID-02932 (B2): Conversation Continuity preview (read-only).
+  // GET /api/v1/voice/continuity/preview
+  const voiceContinuityRouter = require('./routes/voice-continuity').default;
+  mountRouterSync(app, '/api/v1', voiceContinuityRouter, { owner: 'voice-continuity' });
+
   // AI Personality Configuration API
   mountRouterSync(app, '/api/v1/ai-personality', aiPersonalityRouter, { owner: 'ai-personality' });
 

--- a/services/gateway/src/routes/voice-continuity.ts
+++ b/services/gateway/src/routes/voice-continuity.ts
@@ -1,0 +1,69 @@
+/**
+ * VTID-02932 (B2) — Conversation Continuity preview API.
+ *
+ *   GET /api/v1/voice/continuity/preview?userId=…&tenantId=…
+ *
+ * Returns the compiled ContinuityContext + the raw threads/promises
+ * rows the assistant decision layer would see. Read-only.
+ *
+ * Auth: requireExafyAdmin (same as B0c/B0d/B0e/R0/B1 inspection
+ * surfaces).
+ *
+ * Wall: zero mutation paths. Selection is read-only; state
+ * advancement is a follow-up slice with its own dedicated event
+ * endpoint.
+ */
+
+import { Router, Response } from 'express';
+import {
+  requireAuthWithTenant,
+  requireExafyAdmin,
+  AuthenticatedRequest,
+} from '../middleware/auth-supabase-jwt';
+import { defaultContinuityFetcher } from '../services/continuity/continuity-fetcher';
+import { compileContinuityContext } from '../services/continuity/compile-continuity-context';
+
+const router = Router();
+const VTID = 'VTID-02932';
+
+router.get(
+  '/voice/continuity/preview',
+  requireAuthWithTenant,
+  requireExafyAdmin,
+  async (req: AuthenticatedRequest, res: Response) => {
+    try {
+      const userId = typeof req.query.userId === 'string' ? req.query.userId : '';
+      const tenantId = typeof req.query.tenantId === 'string' ? req.query.tenantId : '';
+      if (!userId || !tenantId) {
+        return res.status(400).json({
+          ok: false,
+          error: 'userId and tenantId are required',
+          vtid: VTID,
+        });
+      }
+
+      const [threadsResult, promisesResult] = await Promise.all([
+        defaultContinuityFetcher.listOpenThreads({ tenantId, userId, limit: 50 }),
+        defaultContinuityFetcher.listPromises({ tenantId, userId, limit: 50 }),
+      ]);
+
+      const context = compileContinuityContext({ threadsResult, promisesResult });
+
+      return res.json({
+        ok: true,
+        vtid: VTID,
+        threads: threadsResult.rows,
+        promises: promisesResult.rows,
+        context,
+      });
+    } catch (e) {
+      return res.status(500).json({
+        ok: false,
+        error: (e as Error).message,
+        vtid: VTID,
+      });
+    }
+  },
+);
+
+export default router;

--- a/services/gateway/src/services/continuity/compile-continuity-context.ts
+++ b/services/gateway/src/services/continuity/compile-continuity-context.ts
@@ -1,0 +1,147 @@
+/**
+ * VTID-02932 (B2) — compileContinuityContext.
+ *
+ * Pure function over raw rows. Produces the distilled
+ * ContinuityContext the assistant decision layer reads from:
+ *
+ *   open_threads          — top-N open threads, oldest-touched-first cap
+ *   promises_owed         — owed promises, due-soonest first
+ *   promises_kept_recently — last 7 days of kept promises (for credit)
+ *   counts                — aggregate signals the cadence layer uses
+ *   source_health         — per-table read status
+ *
+ * No IO. No mutation. No clock side-effects (now is injected).
+ */
+
+import type {
+  AssistantPromiseRow,
+  ContinuityContext,
+  OpenThreadRow,
+} from './types';
+
+export interface CompileContinuityContextInputs {
+  threadsResult: { ok: boolean; rows: OpenThreadRow[]; reason?: string };
+  promisesResult: { ok: boolean; rows: AssistantPromiseRow[]; reason?: string };
+  /** Injected for testability. Production passes Date.now(). */
+  nowMs?: number;
+  /** Max open threads to surface to the assistant. Default 5. */
+  openThreadLimit?: number;
+  /** Max owed promises to surface. Default 5. */
+  promisesOwedLimit?: number;
+  /** Max recently-kept promises to surface. Default 3. */
+  promisesKeptLimit?: number;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const RECENT_KEPT_WINDOW_MS = 7 * DAY_MS;
+
+export function compileContinuityContext(
+  input: CompileContinuityContextInputs,
+): ContinuityContext {
+  const now = input.nowMs ?? Date.now();
+  const openLimit = input.openThreadLimit ?? 5;
+  const owedLimit = input.promisesOwedLimit ?? 5;
+  const keptLimit = input.promisesKeptLimit ?? 3;
+
+  const threadsRows = input.threadsResult.ok ? input.threadsResult.rows : [];
+  const promisesRows = input.promisesResult.ok ? input.promisesResult.rows : [];
+
+  const openThreads = threadsRows
+    .filter((t) => t.status === 'open')
+    .sort((a, b) => Date.parse(b.last_mentioned_at) - Date.parse(a.last_mentioned_at))
+    .slice(0, openLimit)
+    .map((t) => ({
+      thread_id: t.thread_id,
+      topic: t.topic,
+      summary: t.summary,
+      last_mentioned_at: t.last_mentioned_at,
+      days_since_last_mention: daysBetween(now, Date.parse(t.last_mentioned_at)),
+    }));
+
+  const owed = promisesRows.filter((p) => p.status === 'owed');
+  const promises_owed = [...owed]
+    .sort((a, b) => sortByDueAtAsc(a.due_at, b.due_at))
+    .slice(0, owedLimit)
+    .map((p) => ({
+      promise_id: p.promise_id,
+      promise_text: p.promise_text,
+      due_at: p.due_at,
+      days_overdue: p.due_at ? daysBetween(now, Date.parse(p.due_at), 'overdue') : null,
+      decision_id: p.decision_id,
+    }));
+
+  const promises_kept_recently = promisesRows
+    .filter((p) => p.status === 'kept' && p.kept_at)
+    .filter((p) => {
+      const t = Date.parse(p.kept_at as string);
+      return Number.isFinite(t) && now - t <= RECENT_KEPT_WINDOW_MS;
+    })
+    .sort((a, b) => Date.parse(b.kept_at as string) - Date.parse(a.kept_at as string))
+    .slice(0, keptLimit)
+    .map((p) => ({
+      promise_id: p.promise_id,
+      promise_text: p.promise_text,
+      kept_at: p.kept_at as string,
+    }));
+
+  // Counts.
+  const todayStart = startOfUtcDay(now);
+  const threads_mentioned_today = threadsRows.filter((t) => {
+    const at = Date.parse(t.last_mentioned_at);
+    return Number.isFinite(at) && at >= todayStart;
+  }).length;
+  const promises_overdue = owed.filter((p) => {
+    if (!p.due_at) return false;
+    const t = Date.parse(p.due_at);
+    return Number.isFinite(t) && t < now;
+  }).length;
+
+  return {
+    open_threads: openThreads,
+    promises_owed,
+    promises_kept_recently,
+    counts: {
+      open_threads_total: threadsRows.filter((t) => t.status === 'open').length,
+      promises_owed_total: owed.length,
+      promises_overdue,
+      threads_mentioned_today,
+    },
+    source_health: {
+      user_open_threads: input.threadsResult.ok
+        ? { ok: true }
+        : { ok: false, reason: input.threadsResult.reason ?? 'unknown_failure' },
+      assistant_promises: input.promisesResult.ok
+        ? { ok: true }
+        : { ok: false, reason: input.promisesResult.reason ?? 'unknown_failure' },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — exported for tests
+// ---------------------------------------------------------------------------
+
+function daysBetween(nowMs: number, thenMs: number, mode: 'ago' | 'overdue' = 'ago'): number | null {
+  if (!Number.isFinite(thenMs)) return null;
+  const diffMs = mode === 'overdue' ? nowMs - thenMs : nowMs - thenMs;
+  if (diffMs < 0) {
+    // For "overdue" semantics, a future due_at means NOT overdue → return negative
+    // days (caller can render "due in N days"). For "ago", a future "then"
+    // shouldn't happen but we still return a negative count rather than crash.
+    return Math.ceil(diffMs / DAY_MS);
+  }
+  return Math.floor(diffMs / DAY_MS);
+}
+
+function sortByDueAtAsc(a: string | null, b: string | null): number {
+  // null due_at sorts AFTER any present due_at (less urgent).
+  if (a === null && b === null) return 0;
+  if (a === null) return 1;
+  if (b === null) return -1;
+  return Date.parse(a) - Date.parse(b);
+}
+
+function startOfUtcDay(nowMs: number): number {
+  const d = new Date(nowMs);
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+}

--- a/services/gateway/src/services/continuity/continuity-fetcher.ts
+++ b/services/gateway/src/services/continuity/continuity-fetcher.ts
@@ -1,0 +1,163 @@
+/**
+ * VTID-02932 (B2) — Supabase-backed continuity fetcher.
+ *
+ * Read-only by design. NO write/mutator methods on the interface —
+ * state advancement (creating threads / marking promises kept/broken)
+ * lives in a follow-up slice behind dedicated event paths. Even
+ * adding an `upsert*` method here would violate the B2 wall.
+ *
+ * Failure policy: any Supabase error returns empty arrays + source-
+ * health flagged. We never throw upward — the continuity context is
+ * an enrichment layer, never a wake-blocker.
+ */
+
+import { getSupabase } from '../../lib/supabase';
+import type {
+  OpenThreadRow,
+  AssistantPromiseRow,
+  OpenThreadStatus,
+  PromiseStatus,
+} from './types';
+
+export interface ContinuityFetcher {
+  listOpenThreads(args: {
+    tenantId: string;
+    userId: string;
+    /** Default 20. Capped at 50. */
+    limit?: number;
+  }): Promise<{ ok: boolean; rows: OpenThreadRow[]; reason?: string }>;
+  listPromises(args: {
+    tenantId: string;
+    userId: string;
+    /** Default 20. Capped at 50. */
+    limit?: number;
+    /** Filter by status. When absent, returns all statuses. */
+    status?: PromiseStatus;
+  }): Promise<{ ok: boolean; rows: AssistantPromiseRow[]; reason?: string }>;
+}
+
+export interface SupabaseContinuityFetcherOptions {
+  getDb?: typeof getSupabase;
+}
+
+export function createSupabaseContinuityFetcher(
+  opts: SupabaseContinuityFetcherOptions = {},
+): ContinuityFetcher {
+  const getDb = opts.getDb ?? getSupabase;
+
+  return {
+    async listOpenThreads(args) {
+      const limit = clampLimit(args.limit);
+      const sb = getDb();
+      if (!sb) {
+        return { ok: false, rows: [], reason: 'supabase_unconfigured' };
+      }
+      try {
+        const { data, error } = await sb
+          .from('user_open_threads')
+          .select(
+            'thread_id, topic, summary, status, session_id_first, session_id_last, last_mentioned_at, resolved_at, created_at, updated_at',
+          )
+          .eq('tenant_id', args.tenantId)
+          .eq('user_id', args.userId)
+          .order('last_mentioned_at', { ascending: false })
+          .limit(limit);
+        if (error) {
+          return { ok: false, rows: [], reason: error.message };
+        }
+        if (!Array.isArray(data)) {
+          return { ok: true, rows: [] };
+        }
+        return { ok: true, rows: data.map(mapThreadRow) };
+      } catch (e) {
+        return { ok: false, rows: [], reason: (e as Error).message };
+      }
+    },
+
+    async listPromises(args) {
+      const limit = clampLimit(args.limit);
+      const sb = getDb();
+      if (!sb) {
+        return { ok: false, rows: [], reason: 'supabase_unconfigured' };
+      }
+      try {
+        let q = sb
+          .from('assistant_promises')
+          .select(
+            'promise_id, thread_id, session_id, promise_text, due_at, status, decision_id, kept_at, created_at, updated_at',
+          )
+          .eq('tenant_id', args.tenantId)
+          .eq('user_id', args.userId)
+          .order('created_at', { ascending: false })
+          .limit(limit);
+        if (args.status) q = q.eq('status', args.status);
+        const { data, error } = await q;
+        if (error) {
+          return { ok: false, rows: [], reason: error.message };
+        }
+        if (!Array.isArray(data)) {
+          return { ok: true, rows: [] };
+        }
+        return { ok: true, rows: data.map(mapPromiseRow) };
+      } catch (e) {
+        return { ok: false, rows: [], reason: (e as Error).message };
+      }
+    },
+  };
+}
+
+export const defaultContinuityFetcher = createSupabaseContinuityFetcher();
+
+// ---------------------------------------------------------------------------
+// Row mappers — exported for tests
+// ---------------------------------------------------------------------------
+
+function clampLimit(raw: number | undefined): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) return 20;
+  return Math.max(1, Math.min(50, Math.trunc(raw)));
+}
+
+const KNOWN_THREAD_STATUSES: ReadonlySet<OpenThreadStatus> = new Set<OpenThreadStatus>([
+  'open', 'resolved', 'abandoned',
+]);
+const KNOWN_PROMISE_STATUSES: ReadonlySet<PromiseStatus> = new Set<PromiseStatus>([
+  'owed', 'kept', 'broken', 'cancelled',
+]);
+
+export function mapThreadRow(row: Record<string, unknown>): OpenThreadRow {
+  const statusRaw = typeof row.status === 'string' ? row.status : 'open';
+  const status: OpenThreadStatus = KNOWN_THREAD_STATUSES.has(statusRaw as OpenThreadStatus)
+    ? (statusRaw as OpenThreadStatus)
+    : 'open';
+  return {
+    thread_id: String(row.thread_id ?? ''),
+    topic: String(row.topic ?? ''),
+    summary: typeof row.summary === 'string' ? row.summary : null,
+    status,
+    session_id_first: typeof row.session_id_first === 'string' ? row.session_id_first : null,
+    session_id_last: typeof row.session_id_last === 'string' ? row.session_id_last : null,
+    last_mentioned_at: String(row.last_mentioned_at ?? ''),
+    resolved_at: typeof row.resolved_at === 'string' ? row.resolved_at : null,
+    created_at: String(row.created_at ?? ''),
+    updated_at: String(row.updated_at ?? ''),
+  };
+}
+
+export function mapPromiseRow(row: Record<string, unknown>): AssistantPromiseRow {
+  const statusRaw = typeof row.status === 'string' ? row.status : 'owed';
+  const status: PromiseStatus = KNOWN_PROMISE_STATUSES.has(statusRaw as PromiseStatus)
+    ? (statusRaw as PromiseStatus)
+    : 'owed';
+  return {
+    promise_id: String(row.promise_id ?? ''),
+    thread_id: typeof row.thread_id === 'string' ? row.thread_id : null,
+    session_id: typeof row.session_id === 'string' ? row.session_id : null,
+    promise_text: String(row.promise_text ?? ''),
+    due_at: typeof row.due_at === 'string' ? row.due_at : null,
+    status,
+    decision_id: typeof row.decision_id === 'string' ? row.decision_id : null,
+    kept_at: typeof row.kept_at === 'string' ? row.kept_at : null,
+    created_at: String(row.created_at ?? ''),
+    updated_at: String(row.updated_at ?? ''),
+  };
+}

--- a/services/gateway/src/services/continuity/types.ts
+++ b/services/gateway/src/services/continuity/types.ts
@@ -1,0 +1,92 @@
+/**
+ * VTID-02932 (B2) — conversation continuity types.
+ *
+ * These shapes drive signals 40–45 of the AssistantDecisionContext:
+ *   #40 last_session_topic_summary
+ *   #41 recurring_topics_last_30d
+ *   #42 open_threads
+ *   #43 vitana_promises
+ *   #44 last_unresolved_intent       (deferred — needs intents table read)
+ *   #45 topics_discussed_today
+ *
+ * Wall: pure types. No IO, no mutation. The fetcher is read-only;
+ * state advancement (creating threads / marking promises) lives in
+ * a follow-up slice and never goes through this module.
+ */
+
+export type OpenThreadStatus = 'open' | 'resolved' | 'abandoned';
+export type PromiseStatus = 'owed' | 'kept' | 'broken' | 'cancelled';
+
+export interface OpenThreadRow {
+  thread_id: string;
+  topic: string;
+  summary: string | null;
+  status: OpenThreadStatus;
+  session_id_first: string | null;
+  session_id_last: string | null;
+  last_mentioned_at: string;
+  resolved_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AssistantPromiseRow {
+  promise_id: string;
+  thread_id: string | null;
+  session_id: string | null;
+  promise_text: string;
+  due_at: string | null;
+  status: PromiseStatus;
+  decision_id: string | null;
+  kept_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * Compiled continuity context — what the assistant decision layer
+ * consumes. Distilled from the raw rows; never carries the rows
+ * themselves.
+ *
+ * Mirrors the AssistantDecisionContext spirit from B0b: the prompt
+ * sees the distilled view, never the raw DB rows.
+ */
+export interface ContinuityContext {
+  /** Signal #42 (open) — most recently-touched first, capped. */
+  open_threads: Array<{
+    thread_id: string;
+    topic: string;
+    summary: string | null;
+    last_mentioned_at: string;
+    days_since_last_mention: number | null;
+  }>;
+  /** Signal #43 — owed promises, oldest-due first. */
+  promises_owed: Array<{
+    promise_id: string;
+    promise_text: string;
+    due_at: string | null;
+    days_overdue: number | null;
+    decision_id: string | null;
+  }>;
+  /** Recently-kept promises (for credit acknowledgement). Capped. */
+  promises_kept_recently: Array<{
+    promise_id: string;
+    promise_text: string;
+    kept_at: string;
+  }>;
+  /** Counts the assistant uses for cadence decisions. */
+  counts: {
+    open_threads_total: number;
+    promises_owed_total: number;
+    promises_overdue: number;
+    threads_mentioned_today: number;
+  };
+  /**
+   * Source-health view — empty arrays + a `reason` is "user has no
+   * continuity state yet", not a failure. Failures surface here.
+   */
+  source_health: {
+    user_open_threads: { ok: boolean; reason?: string };
+    assistant_promises: { ok: boolean; reason?: string };
+  };
+}

--- a/services/gateway/test/routes/voice-continuity.test.ts
+++ b/services/gateway/test/routes/voice-continuity.test.ts
@@ -1,0 +1,114 @@
+/**
+ * VTID-02932 (B2) — GET /api/v1/voice/continuity/preview tests.
+ *
+ * Verifies:
+ *   - Validates userId + tenantId (400 when missing).
+ *   - Calls the default fetcher with the provided ids.
+ *   - Returns ok:true with threads + promises + compiled context.
+ *   - Returns 500 with vtid when the fetcher throws unexpectedly.
+ */
+
+import express from 'express';
+import request from 'supertest';
+
+jest.mock('../../src/middleware/auth-supabase-jwt', () => ({
+  requireAuthWithTenant: (_req: any, _res: any, next: any) => next(),
+  requireExafyAdmin: (_req: any, _res: any, next: any) => next(),
+  optionalAuth: (_req: any, _res: any, next: any) => next(),
+}));
+
+const listOpenThreads = jest.fn();
+const listPromises = jest.fn();
+
+jest.mock('../../src/services/continuity/continuity-fetcher', () => ({
+  defaultContinuityFetcher: {
+    listOpenThreads: (args: any) => listOpenThreads(args),
+    listPromises: (args: any) => listPromises(args),
+  },
+}));
+
+function buildApp() {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const router = require('../../src/routes/voice-continuity').default;
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1', router);
+  return app;
+}
+
+describe('B2 — GET /api/v1/voice/continuity/preview', () => {
+  beforeEach(() => {
+    listOpenThreads.mockReset();
+    listPromises.mockReset();
+  });
+
+  it('returns 400 when userId is missing', async () => {
+    const app = buildApp();
+    const res = await request(app).get('/api/v1/voice/continuity/preview?tenantId=t');
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.vtid).toBe('VTID-02932');
+  });
+
+  it('returns 400 when tenantId is missing', async () => {
+    const app = buildApp();
+    const res = await request(app).get('/api/v1/voice/continuity/preview?userId=u');
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+  });
+
+  it('returns ok:true with rows + compiled context', async () => {
+    listOpenThreads.mockResolvedValueOnce({ ok: true, rows: [] });
+    listPromises.mockResolvedValueOnce({ ok: true, rows: [] });
+
+    const app = buildApp();
+    const res = await request(app).get('/api/v1/voice/continuity/preview?userId=u&tenantId=t');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.vtid).toBe('VTID-02932');
+    expect(Array.isArray(res.body.threads)).toBe(true);
+    expect(Array.isArray(res.body.promises)).toBe(true);
+    expect(res.body.context).toBeDefined();
+    expect(res.body.context.open_threads).toEqual([]);
+    expect(res.body.context.promises_owed).toEqual([]);
+    expect(res.body.context.source_health.user_open_threads.ok).toBe(true);
+    expect(res.body.context.source_health.assistant_promises.ok).toBe(true);
+  });
+
+  it('passes userId + tenantId through to the fetcher', async () => {
+    listOpenThreads.mockResolvedValueOnce({ ok: true, rows: [] });
+    listPromises.mockResolvedValueOnce({ ok: true, rows: [] });
+
+    const app = buildApp();
+    await request(app).get('/api/v1/voice/continuity/preview?userId=alice&tenantId=acme');
+    expect(listOpenThreads).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'alice', tenantId: 'acme', limit: 50 }),
+    );
+    expect(listPromises).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'alice', tenantId: 'acme', limit: 50 }),
+    );
+  });
+
+  it('reflects fetcher source-health failures in the compiled context', async () => {
+    listOpenThreads.mockResolvedValueOnce({ ok: false, rows: [], reason: 'supabase_unconfigured' });
+    listPromises.mockResolvedValueOnce({ ok: true, rows: [] });
+
+    const app = buildApp();
+    const res = await request(app).get('/api/v1/voice/continuity/preview?userId=u&tenantId=t');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.context.source_health.user_open_threads.ok).toBe(false);
+    expect(res.body.context.source_health.user_open_threads.reason).toBe('supabase_unconfigured');
+  });
+
+  it('returns 500 with vtid when the fetcher throws unexpectedly', async () => {
+    listOpenThreads.mockRejectedValueOnce(new Error('boom'));
+    listPromises.mockResolvedValueOnce({ ok: true, rows: [] });
+
+    const app = buildApp();
+    const res = await request(app).get('/api/v1/voice/continuity/preview?userId=u&tenantId=t');
+    expect(res.status).toBe(500);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.vtid).toBe('VTID-02932');
+  });
+});

--- a/services/gateway/test/services/continuity/b2-migration.test.ts
+++ b/services/gateway/test/services/continuity/b2-migration.test.ts
@@ -1,0 +1,130 @@
+/**
+ * VTID-02932 (B2) — continuity tables migration shape guard.
+ *
+ * Asserts the migration:
+ *   - Creates user_open_threads + assistant_promises with the
+ *     documented columns + status CHECK constraints.
+ *   - Tenant-scopes both via RLS through user_tenants.
+ *   - Indexes both for the hot-path queries the fetcher runs
+ *     (last_mentioned_at DESC for open threads, due_at NULLS LAST
+ *     for owed promises).
+ *   - Has touch triggers on updated_at for both tables.
+ *   - Does NOT contain any state-advancement RPC. State advancement
+ *     ships in a follow-up slice with its own dedicated event endpoint
+ *     (B2 wall).
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const MIGRATION_PATH = join(
+  __dirname,
+  '../../../../../supabase/migrations/20260520000000_VTID_02932_continuity_tables.sql',
+);
+
+describe('B2 — continuity tables migration', () => {
+  let sql: string;
+  beforeAll(() => {
+    sql = readFileSync(MIGRATION_PATH, 'utf8');
+  });
+
+  describe('user_open_threads table', () => {
+    it('creates the table', () => {
+      expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS user_open_threads/);
+    });
+
+    it('keys on thread_id UUID PRIMARY KEY', () => {
+      expect(sql).toMatch(/thread_id\s+UUID[\s\S]*?PRIMARY KEY/);
+    });
+
+    it('has the 3-state status CHECK constraint locked', () => {
+      const states = ['open', 'resolved', 'abandoned'];
+      for (const s of states) {
+        expect(sql).toContain(`'${s}'`);
+      }
+    });
+
+    it('tracks session_id_first + session_id_last for cross-session linkage', () => {
+      expect(sql).toContain('session_id_first');
+      expect(sql).toContain('session_id_last');
+    });
+
+    it('tracks last_mentioned_at for recency ordering', () => {
+      expect(sql).toContain('last_mentioned_at');
+    });
+
+    it('enables RLS with tenant isolation via user_tenants', () => {
+      expect(sql).toMatch(/ALTER TABLE user_open_threads ENABLE ROW LEVEL SECURITY/);
+      expect(sql).toMatch(/user_open_threads_tenant_isolation/);
+      expect(sql).toMatch(/user_tenants/);
+    });
+
+    it('indexes (tenant_id, user_id, last_mentioned_at DESC) for recency reads', () => {
+      expect(sql).toMatch(/user_open_threads_user_idx/);
+      expect(sql).toMatch(/last_mentioned_at\s+DESC/);
+    });
+
+    it('has a partial index WHERE status = open for hot-path lookups', () => {
+      expect(sql).toMatch(/WHERE\s+status\s*=\s*'open'/);
+    });
+
+    it('has a touch trigger on updated_at', () => {
+      expect(sql).toMatch(/CREATE TRIGGER user_open_threads_updated_at_trigger/);
+    });
+  });
+
+  describe('assistant_promises table', () => {
+    it('creates the table', () => {
+      expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS assistant_promises/);
+    });
+
+    it('keys on promise_id UUID PRIMARY KEY', () => {
+      expect(sql).toMatch(/promise_id\s+UUID[\s\S]*?PRIMARY KEY/);
+    });
+
+    it('has the 4-state status CHECK constraint locked', () => {
+      const states = ['owed', 'kept', 'broken', 'cancelled'];
+      for (const s of states) {
+        expect(sql).toContain(`'${s}'`);
+      }
+    });
+
+    it('references user_open_threads via FK ON DELETE SET NULL (not CASCADE)', () => {
+      expect(sql).toMatch(
+        /REFERENCES user_open_threads\(thread_id\)\s+ON DELETE SET NULL/,
+      );
+    });
+
+    it('tracks decision_id for ranker-trace linkage', () => {
+      expect(sql).toContain('decision_id');
+    });
+
+    it('tracks kept_at for credit-acknowledgement window', () => {
+      expect(sql).toContain('kept_at');
+    });
+
+    it('enables RLS with tenant isolation via user_tenants', () => {
+      expect(sql).toMatch(/ALTER TABLE assistant_promises ENABLE ROW LEVEL SECURITY/);
+      expect(sql).toMatch(/assistant_promises_tenant_isolation/);
+      expect(sql).toMatch(/user_tenants/);
+    });
+
+    it('has a partial index WHERE status = owed for due-soonest reads', () => {
+      expect(sql).toMatch(/WHERE\s+status\s*=\s*'owed'/);
+    });
+
+    it('has a touch trigger on updated_at', () => {
+      expect(sql).toMatch(/CREATE TRIGGER assistant_promises_updated_at_trigger/);
+    });
+  });
+
+  describe('B2 wall — no state advancement in this migration', () => {
+    it('does NOT introduce any state-advancement RPC (mutation lives in a follow-up slice)', () => {
+      // Any RPC starting with create_thread / mark_promise / advance_*
+      // would violate B2's read-only wall.
+      expect(sql).not.toMatch(/CREATE OR REPLACE FUNCTION\s+(?:public\.)?create_open_thread/i);
+      expect(sql).not.toMatch(/CREATE OR REPLACE FUNCTION\s+(?:public\.)?mark_promise/i);
+      expect(sql).not.toMatch(/CREATE OR REPLACE FUNCTION\s+(?:public\.)?advance_/i);
+    });
+  });
+});

--- a/services/gateway/test/services/continuity/b2-walls.test.ts
+++ b/services/gateway/test/services/continuity/b2-walls.test.ts
@@ -1,0 +1,147 @@
+/**
+ * VTID-02932 (B2) — wall-integrity tests.
+ *
+ * B2 is conversation continuity (open threads + promises) ONLY.
+ * Asserts:
+ *   - Command Hub Continuity panel renders even when no data exists.
+ *   - Panel has NO mutation surface (no buttons, no onclick, no
+ *     POST/PUT/PATCH/DELETE fetches).
+ *   - Preview route is GET-only, admin-gated, performs no DB mutation.
+ *   - ContinuityFetcher source has no write methods (no upsert/insert/
+ *     update/delete/rpc) — state advancement lives in a follow-up slice.
+ *   - The pure compiler does no IO (no supabase / fetch / axios / timers).
+ *   - B2 does NOT touch ORB transport, audio, reconnect, Live API,
+ *     timeout, or wake-brief-timing code paths.
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const APP_JS_PATH = join(__dirname, '../../../src/frontend/command-hub/app.js');
+const ROUTE_PATH = join(__dirname, '../../../src/routes/voice-continuity.ts');
+const FETCHER_PATH = join(__dirname, '../../../src/services/continuity/continuity-fetcher.ts');
+const COMPILER_PATH = join(__dirname, '../../../src/services/continuity/compile-continuity-context.ts');
+const TYPES_PATH = join(__dirname, '../../../src/services/continuity/types.ts');
+
+describe('B2 — wall integrity', () => {
+  let appJs: string;
+  let routeSrc: string;
+  let fetcherSrc: string;
+  let compilerSrc: string;
+  let typesSrc: string;
+  beforeAll(() => {
+    appJs = readFileSync(APP_JS_PATH, 'utf8');
+    routeSrc = readFileSync(ROUTE_PATH, 'utf8');
+    fetcherSrc = readFileSync(FETCHER_PATH, 'utf8');
+    compilerSrc = readFileSync(COMPILER_PATH, 'utf8');
+    typesSrc = readFileSync(TYPES_PATH, 'utf8');
+  });
+
+  describe('panel renders without data', () => {
+    it('defines renderJourneyContextContinuityPanel', () => {
+      expect(appJs).toContain('function renderJourneyContextContinuityPanel');
+    });
+
+    it('panel handles missing co argument (empty-state branch)', () => {
+      const fnMatch = appJs.match(
+        /function renderJourneyContextContinuityPanel\(co\)\s*\{[\s\S]*?\n\}/,
+      );
+      expect(fnMatch).toBeTruthy();
+      const body = fnMatch![0];
+      expect(body).toMatch(/if\s*\(\s*!co\s*\)/);
+      expect(body).toMatch(/no data — load a user above/);
+    });
+
+    it('panel is wired into the journey-context grid', () => {
+      expect(appJs).toContain('renderJourneyContextContinuityPanel(jc.continuity)');
+    });
+
+    it('panel loader fetches the preview endpoint', () => {
+      expect(appJs).toContain("'/api/v1/voice/continuity/preview'");
+    });
+  });
+
+  describe('no mutation from preview/panel', () => {
+    it('panel has NO mutation surface', () => {
+      const fnMatch = appJs.match(
+        /function renderJourneyContextContinuityPanel\(co\)\s*\{[\s\S]*?\n\}/,
+      );
+      const body = fnMatch![0];
+      expect(body).not.toMatch(/createElement\(['"]button['"]\)/);
+      expect(body).not.toMatch(/\.onclick\s*=/);
+      expect(body).not.toMatch(/addEventListener\(['"]click['"]/);
+      expect(body).not.toMatch(/method\s*:\s*['"](?:POST|PUT|PATCH|DELETE)['"]/);
+    });
+
+    it('preview route is GET-only', () => {
+      const startIdx = routeSrc.indexOf("'/voice/continuity/preview'");
+      expect(startIdx).toBeGreaterThan(-1);
+      const before = routeSrc.slice(Math.max(0, startIdx - 200), startIdx);
+      expect(before).toMatch(/router\.get\(/);
+    });
+
+    it('preview route has NO DB-mutation calls', () => {
+      expect(routeSrc).not.toMatch(/\.insert\(/);
+      expect(routeSrc).not.toMatch(/\.update\(/);
+      expect(routeSrc).not.toMatch(/\.upsert\(/);
+      expect(routeSrc).not.toMatch(/\.delete\(/);
+      expect(routeSrc).not.toMatch(/\.rpc\(/);
+    });
+
+    it('preview route requires exafy_admin', () => {
+      expect(routeSrc).toContain('requireExafyAdmin');
+    });
+  });
+
+  describe('fetcher has no mutator methods', () => {
+    it('ContinuityFetcher interface declares only listOpenThreads + listPromises', () => {
+      // The interface declaration is the source of truth; later additions
+      // would land in this same block.
+      const ifaceMatch = fetcherSrc.match(/export interface ContinuityFetcher\s*\{[\s\S]*?\n\}/);
+      expect(ifaceMatch).toBeTruthy();
+      const iface = ifaceMatch![0];
+      expect(iface).toMatch(/listOpenThreads/);
+      expect(iface).toMatch(/listPromises/);
+      expect(iface).not.toMatch(/upsert|insert|update|delete|markPromise|createThread/);
+    });
+
+    it('fetcher source has no Supabase write calls', () => {
+      expect(fetcherSrc).not.toMatch(/\.insert\(/);
+      expect(fetcherSrc).not.toMatch(/\.update\(/);
+      expect(fetcherSrc).not.toMatch(/\.upsert\(/);
+      expect(fetcherSrc).not.toMatch(/\.delete\(/);
+      expect(fetcherSrc).not.toMatch(/\.rpc\(/);
+    });
+  });
+
+  describe('compiler is pure', () => {
+    it('compileContinuityContext source has NO IO / DB / fetch / timers', () => {
+      expect(compilerSrc).not.toMatch(/supabase|getSupabase/);
+      expect(compilerSrc).not.toMatch(/\bfetch\(/);
+      expect(compilerSrc).not.toMatch(/axios/);
+      expect(compilerSrc).not.toMatch(/\.rpc\(/);
+      expect(compilerSrc).not.toMatch(/setTimeout\(|setInterval\(/);
+    });
+
+    it('compiler accepts an injected nowMs for testability (no implicit Date.now coupling)', () => {
+      expect(compilerSrc).toMatch(/nowMs\?:\s*number/);
+    });
+  });
+
+  describe('B2 does NOT touch reliability-lane code paths', () => {
+    it('types module is pure types (no IO, no value exports beyond types/interfaces)', () => {
+      expect(typesSrc).not.toMatch(/supabase|getSupabase/);
+      expect(typesSrc).not.toMatch(/\bfetch\(/);
+      expect(typesSrc).not.toMatch(/\bconst\s+\w+\s*=\s*(?!.*\btype\b)/);
+    });
+
+    it('fetcher does NOT reference transport / audio / reconnect / Live API', () => {
+      expect(fetcherSrc).not.toMatch(/EventSource|WebSocket|new AudioContext|playAudio|geminiLive\.|liveSessions\./);
+      expect(fetcherSrc).not.toMatch(/reconnect_attempt\(|attemptReconnect\(/);
+    });
+
+    it('route does NOT reference transport / audio / reconnect / Live API', () => {
+      expect(routeSrc).not.toMatch(/EventSource|WebSocket|new AudioContext|playAudio|geminiLive\.|liveSessions\./);
+    });
+  });
+});

--- a/services/gateway/test/services/continuity/compile-continuity-context.test.ts
+++ b/services/gateway/test/services/continuity/compile-continuity-context.test.ts
@@ -1,0 +1,388 @@
+/**
+ * VTID-02932 (B2) — compileContinuityContext tests.
+ *
+ * Pure function. Verifies:
+ *   - Open thread sorting (newest mentioned first) + cap.
+ *   - Owed promise sorting (due-soonest first, nulls last) + cap.
+ *   - Kept-recently window = 7 days, ordered newest-first, capped.
+ *   - Counts (open_threads_total, promises_owed_total, promises_overdue,
+ *     threads_mentioned_today) computed correctly with UTC day boundary.
+ *   - source_health reflects the input fetch results.
+ *   - days_since_last_mention / days_overdue math.
+ */
+
+import { compileContinuityContext } from '../../../src/services/continuity/compile-continuity-context';
+import type {
+  AssistantPromiseRow,
+  OpenThreadRow,
+} from '../../../src/services/continuity/types';
+
+const NOW = Date.parse('2026-05-11T12:00:00Z');
+const DAY = 24 * 60 * 60 * 1000;
+
+function thread(over: Partial<OpenThreadRow>): OpenThreadRow {
+  return {
+    thread_id: 't',
+    topic: 'topic',
+    summary: null,
+    status: 'open',
+    session_id_first: null,
+    session_id_last: null,
+    last_mentioned_at: '2026-05-11T00:00:00Z',
+    resolved_at: null,
+    created_at: '2026-05-01T00:00:00Z',
+    updated_at: '2026-05-11T00:00:00Z',
+    ...over,
+  };
+}
+
+function promise(over: Partial<AssistantPromiseRow>): AssistantPromiseRow {
+  return {
+    promise_id: 'p',
+    thread_id: null,
+    session_id: null,
+    promise_text: 'text',
+    due_at: null,
+    status: 'owed',
+    decision_id: null,
+    kept_at: null,
+    created_at: '2026-05-01T00:00:00Z',
+    updated_at: '2026-05-11T00:00:00Z',
+    ...over,
+  };
+}
+
+describe('B2 — compileContinuityContext', () => {
+  describe('open threads', () => {
+    it('returns only status=open threads', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: {
+          ok: true,
+          rows: [
+            thread({ thread_id: 'a', status: 'open' }),
+            thread({ thread_id: 'b', status: 'resolved' }),
+            thread({ thread_id: 'c', status: 'abandoned' }),
+          ],
+        },
+        promisesResult: { ok: true, rows: [] },
+        nowMs: NOW,
+      });
+      expect(ctx.open_threads.map(t => t.thread_id)).toEqual(['a']);
+    });
+
+    it('sorts by last_mentioned_at DESC (newest first)', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: {
+          ok: true,
+          rows: [
+            thread({ thread_id: 'a', last_mentioned_at: '2026-05-09T00:00:00Z' }),
+            thread({ thread_id: 'b', last_mentioned_at: '2026-05-11T00:00:00Z' }),
+            thread({ thread_id: 'c', last_mentioned_at: '2026-05-10T00:00:00Z' }),
+          ],
+        },
+        promisesResult: { ok: true, rows: [] },
+        nowMs: NOW,
+      });
+      expect(ctx.open_threads.map(t => t.thread_id)).toEqual(['b', 'c', 'a']);
+    });
+
+    it('caps to openThreadLimit (default 5)', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: {
+          ok: true,
+          rows: Array.from({ length: 12 }, (_, i) => thread({
+            thread_id: 't' + i,
+            last_mentioned_at: new Date(NOW - i * 1000).toISOString(),
+          })),
+        },
+        promisesResult: { ok: true, rows: [] },
+        nowMs: NOW,
+      });
+      expect(ctx.open_threads).toHaveLength(5);
+    });
+
+    it('respects custom openThreadLimit', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: {
+          ok: true,
+          rows: [
+            thread({ thread_id: 'a' }),
+            thread({ thread_id: 'b' }),
+            thread({ thread_id: 'c' }),
+          ],
+        },
+        promisesResult: { ok: true, rows: [] },
+        nowMs: NOW,
+        openThreadLimit: 2,
+      });
+      expect(ctx.open_threads).toHaveLength(2);
+    });
+
+    it('computes days_since_last_mention from now', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: {
+          ok: true,
+          rows: [
+            thread({ thread_id: 'a', last_mentioned_at: new Date(NOW - 3 * DAY).toISOString() }),
+          ],
+        },
+        promisesResult: { ok: true, rows: [] },
+        nowMs: NOW,
+      });
+      expect(ctx.open_threads[0].days_since_last_mention).toBe(3);
+    });
+  });
+
+  describe('promises owed', () => {
+    it('returns only status=owed promises', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: { ok: true, rows: [] },
+        promisesResult: {
+          ok: true,
+          rows: [
+            promise({ promise_id: 'a', status: 'owed' }),
+            promise({ promise_id: 'b', status: 'kept', kept_at: '2026-05-11T00:00:00Z' }),
+            promise({ promise_id: 'c', status: 'broken' }),
+            promise({ promise_id: 'd', status: 'cancelled' }),
+          ],
+        },
+        nowMs: NOW,
+      });
+      expect(ctx.promises_owed.map(p => p.promise_id)).toEqual(['a']);
+    });
+
+    it('sorts owed by due_at ASC (soonest first)', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: { ok: true, rows: [] },
+        promisesResult: {
+          ok: true,
+          rows: [
+            promise({ promise_id: 'a', due_at: '2026-05-13T00:00:00Z' }),
+            promise({ promise_id: 'b', due_at: '2026-05-11T00:00:00Z' }),
+            promise({ promise_id: 'c', due_at: '2026-05-12T00:00:00Z' }),
+          ],
+        },
+        nowMs: NOW,
+      });
+      expect(ctx.promises_owed.map(p => p.promise_id)).toEqual(['b', 'c', 'a']);
+    });
+
+    it('places null due_at AFTER any present due_at', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: { ok: true, rows: [] },
+        promisesResult: {
+          ok: true,
+          rows: [
+            promise({ promise_id: 'a', due_at: null }),
+            promise({ promise_id: 'b', due_at: '2026-05-15T00:00:00Z' }),
+            promise({ promise_id: 'c', due_at: null }),
+          ],
+        },
+        nowMs: NOW,
+      });
+      expect(ctx.promises_owed.map(p => p.promise_id)).toEqual(['b', 'a', 'c']);
+    });
+
+    it('computes days_overdue (positive when overdue)', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: { ok: true, rows: [] },
+        promisesResult: {
+          ok: true,
+          rows: [
+            promise({ promise_id: 'a', due_at: new Date(NOW - 2 * DAY).toISOString() }),
+          ],
+        },
+        nowMs: NOW,
+      });
+      expect(ctx.promises_owed[0].days_overdue).toBe(2);
+    });
+
+    it('returns negative days_overdue when due_at is in the future', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: { ok: true, rows: [] },
+        promisesResult: {
+          ok: true,
+          rows: [
+            promise({ promise_id: 'a', due_at: new Date(NOW + 2 * DAY).toISOString() }),
+          ],
+        },
+        nowMs: NOW,
+      });
+      expect(ctx.promises_owed[0].days_overdue).toBeLessThanOrEqual(0);
+    });
+
+    it('caps to promisesOwedLimit (default 5)', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: { ok: true, rows: [] },
+        promisesResult: {
+          ok: true,
+          rows: Array.from({ length: 10 }, (_, i) =>
+            promise({ promise_id: 'p' + i, due_at: new Date(NOW + i * DAY).toISOString() }),
+          ),
+        },
+        nowMs: NOW,
+      });
+      expect(ctx.promises_owed).toHaveLength(5);
+    });
+  });
+
+  describe('promises kept recently', () => {
+    it('returns only status=kept promises with kept_at in last 7 days', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: { ok: true, rows: [] },
+        promisesResult: {
+          ok: true,
+          rows: [
+            promise({ promise_id: 'recent', status: 'kept', kept_at: new Date(NOW - 2 * DAY).toISOString() }),
+            promise({ promise_id: 'old',    status: 'kept', kept_at: new Date(NOW - 30 * DAY).toISOString() }),
+            promise({ promise_id: 'no_ts',  status: 'kept', kept_at: null }),
+            promise({ promise_id: 'owed',   status: 'owed' }),
+          ],
+        },
+        nowMs: NOW,
+      });
+      expect(ctx.promises_kept_recently.map(p => p.promise_id)).toEqual(['recent']);
+    });
+
+    it('sorts by kept_at DESC', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: { ok: true, rows: [] },
+        promisesResult: {
+          ok: true,
+          rows: [
+            promise({ promise_id: 'a', status: 'kept', kept_at: new Date(NOW - 1 * DAY).toISOString() }),
+            promise({ promise_id: 'b', status: 'kept', kept_at: new Date(NOW - 3 * DAY).toISOString() }),
+            promise({ promise_id: 'c', status: 'kept', kept_at: new Date(NOW - 2 * DAY).toISOString() }),
+          ],
+        },
+        nowMs: NOW,
+      });
+      expect(ctx.promises_kept_recently.map(p => p.promise_id)).toEqual(['a', 'c', 'b']);
+    });
+
+    it('caps to promisesKeptLimit (default 3)', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: { ok: true, rows: [] },
+        promisesResult: {
+          ok: true,
+          rows: Array.from({ length: 8 }, (_, i) =>
+            promise({
+              promise_id: 'k' + i,
+              status: 'kept',
+              kept_at: new Date(NOW - i * 60 * 1000).toISOString(),
+            }),
+          ),
+        },
+        nowMs: NOW,
+      });
+      expect(ctx.promises_kept_recently).toHaveLength(3);
+    });
+  });
+
+  describe('counts', () => {
+    it('open_threads_total counts all open threads (not just the capped surface)', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: {
+          ok: true,
+          rows: Array.from({ length: 12 }, (_, i) => thread({ thread_id: 't' + i })),
+        },
+        promisesResult: { ok: true, rows: [] },
+        nowMs: NOW,
+        openThreadLimit: 3,
+      });
+      expect(ctx.counts.open_threads_total).toBe(12);
+      expect(ctx.open_threads).toHaveLength(3);
+    });
+
+    it('promises_owed_total counts all owed (not just the surfaced 5)', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: { ok: true, rows: [] },
+        promisesResult: {
+          ok: true,
+          rows: Array.from({ length: 8 }, (_, i) => promise({ promise_id: 'p' + i })),
+        },
+        nowMs: NOW,
+      });
+      expect(ctx.counts.promises_owed_total).toBe(8);
+    });
+
+    it('promises_overdue counts owed promises with due_at < now', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: { ok: true, rows: [] },
+        promisesResult: {
+          ok: true,
+          rows: [
+            promise({ promise_id: 'a', due_at: new Date(NOW - 1 * DAY).toISOString() }),
+            promise({ promise_id: 'b', due_at: new Date(NOW + 1 * DAY).toISOString() }),
+            promise({ promise_id: 'c', due_at: new Date(NOW - 5 * DAY).toISOString() }),
+            promise({ promise_id: 'd', due_at: null }),
+          ],
+        },
+        nowMs: NOW,
+      });
+      expect(ctx.counts.promises_overdue).toBe(2);
+    });
+
+    it('threads_mentioned_today uses UTC day boundary', () => {
+      // 2026-05-11T12:00:00Z → UTC day starts 2026-05-11T00:00:00Z.
+      const ctx = compileContinuityContext({
+        threadsResult: {
+          ok: true,
+          rows: [
+            thread({ thread_id: 'today_early', last_mentioned_at: '2026-05-11T00:01:00Z' }),
+            thread({ thread_id: 'today_late',  last_mentioned_at: '2026-05-11T11:59:00Z' }),
+            thread({ thread_id: 'yesterday',   last_mentioned_at: '2026-05-10T23:59:00Z' }),
+          ],
+        },
+        promisesResult: { ok: true, rows: [] },
+        nowMs: NOW,
+      });
+      expect(ctx.counts.threads_mentioned_today).toBe(2);
+    });
+  });
+
+  describe('source_health', () => {
+    it('passes through ok:true when both fetches succeed', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: { ok: true, rows: [] },
+        promisesResult: { ok: true, rows: [] },
+        nowMs: NOW,
+      });
+      expect(ctx.source_health.user_open_threads.ok).toBe(true);
+      expect(ctx.source_health.assistant_promises.ok).toBe(true);
+    });
+
+    it('reflects failure with reason when threads fetch failed', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: { ok: false, rows: [], reason: 'supabase_unconfigured' },
+        promisesResult: { ok: true, rows: [] },
+        nowMs: NOW,
+      });
+      expect(ctx.source_health.user_open_threads.ok).toBe(false);
+      expect(ctx.source_health.user_open_threads.reason).toBe('supabase_unconfigured');
+      expect(ctx.source_health.assistant_promises.ok).toBe(true);
+    });
+
+    it('treats !ok inputs as empty rows for surface arrays', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: { ok: false, rows: [], reason: 'boom' },
+        promisesResult: { ok: false, rows: [], reason: 'boom' },
+        nowMs: NOW,
+      });
+      expect(ctx.open_threads).toEqual([]);
+      expect(ctx.promises_owed).toEqual([]);
+      expect(ctx.promises_kept_recently).toEqual([]);
+      expect(ctx.counts.open_threads_total).toBe(0);
+    });
+
+    it('defaults reason to "unknown_failure" when an !ok result omits one', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: { ok: false, rows: [] },
+        promisesResult: { ok: false, rows: [] },
+        nowMs: NOW,
+      });
+      expect(ctx.source_health.user_open_threads.reason).toBe('unknown_failure');
+      expect(ctx.source_health.assistant_promises.reason).toBe('unknown_failure');
+    });
+  });
+});

--- a/services/gateway/test/services/continuity/continuity-fetcher.test.ts
+++ b/services/gateway/test/services/continuity/continuity-fetcher.test.ts
@@ -1,0 +1,259 @@
+/**
+ * VTID-02932 (B2) — Supabase-backed ContinuityFetcher tests.
+ *
+ * Verifies:
+ *   - Read-only interface — no mutator methods exposed (B2 wall).
+ *   - DB unavailable / error → empty arrays + source_health flag.
+ *   - Row mapping handles missing / wrong-type columns defensively.
+ *   - Limit clamping (1..50).
+ *   - Status filter passes through when provided.
+ */
+
+import {
+  createSupabaseContinuityFetcher,
+  mapThreadRow,
+  mapPromiseRow,
+} from '../../../src/services/continuity/continuity-fetcher';
+
+function makeFakeClient(behavior: {
+  threadsRows?: unknown[];
+  promisesRows?: unknown[];
+  threadsError?: unknown;
+  promisesError?: unknown;
+  captureStatusEq?: (table: string, status: string) => void;
+  captureLimit?: (table: string, limit: number) => void;
+}) {
+  const client = {
+    from(table: string) {
+      const isThreads = table === 'user_open_threads';
+      const builder: any = {
+        select() { return builder; },
+        eq(col: string, val: string) {
+          if (col === 'status' && behavior.captureStatusEq) {
+            behavior.captureStatusEq(table, val);
+          }
+          return builder;
+        },
+        order() { return builder; },
+        limit(n: number) {
+          if (behavior.captureLimit) behavior.captureLimit(table, n);
+          return builder;
+        },
+        async then(resolve: (v: unknown) => void) {
+          if (isThreads) {
+            resolve({
+              data: behavior.threadsError ? null : (behavior.threadsRows ?? []),
+              error: behavior.threadsError ?? null,
+            });
+          } else {
+            resolve({
+              data: behavior.promisesError ? null : (behavior.promisesRows ?? []),
+              error: behavior.promisesError ?? null,
+            });
+          }
+        },
+      };
+      return builder;
+    },
+  };
+  return client;
+}
+
+describe('B2 — Supabase-backed ContinuityFetcher', () => {
+  describe('read-only contract (B2 wall)', () => {
+    it('ContinuityFetcher interface exposes ONLY listOpenThreads + listPromises', () => {
+      const fetcher = createSupabaseContinuityFetcher({ getDb: (() => null) as any });
+      const keys = Object.keys(fetcher).sort();
+      expect(keys).toEqual(['listOpenThreads', 'listPromises']);
+    });
+  });
+
+  describe('DB unavailable', () => {
+    it('returns ok:false + empty rows + reason when getSupabase returns null', async () => {
+      const fetcher = createSupabaseContinuityFetcher({ getDb: (() => null) as any });
+      const t = await fetcher.listOpenThreads({ tenantId: 't', userId: 'u' });
+      const p = await fetcher.listPromises({ tenantId: 't', userId: 'u' });
+      expect(t.ok).toBe(false);
+      expect(t.rows).toEqual([]);
+      expect(t.reason).toBe('supabase_unconfigured');
+      expect(p.ok).toBe(false);
+      expect(p.rows).toEqual([]);
+      expect(p.reason).toBe('supabase_unconfigured');
+    });
+
+    it('returns ok:false + empty rows + reason on Supabase error', async () => {
+      const client = makeFakeClient({
+        threadsError: { message: 'boom-threads' },
+        promisesError: { message: 'boom-promises' },
+      });
+      const fetcher = createSupabaseContinuityFetcher({ getDb: (() => client) as any });
+      const t = await fetcher.listOpenThreads({ tenantId: 't', userId: 'u' });
+      const p = await fetcher.listPromises({ tenantId: 't', userId: 'u' });
+      expect(t.ok).toBe(false);
+      expect(t.rows).toEqual([]);
+      expect(t.reason).toBe('boom-threads');
+      expect(p.ok).toBe(false);
+      expect(p.rows).toEqual([]);
+      expect(p.reason).toBe('boom-promises');
+    });
+  });
+
+  describe('happy path', () => {
+    it('maps thread rows', async () => {
+      const client = makeFakeClient({
+        threadsRows: [{
+          thread_id: 't1',
+          topic: 'magnesium',
+          summary: 'follow up on dosage',
+          status: 'open',
+          session_id_first: 's1',
+          session_id_last: 's2',
+          last_mentioned_at: '2026-05-10T12:00:00Z',
+          resolved_at: null,
+          created_at: '2026-05-01T12:00:00Z',
+          updated_at: '2026-05-10T12:00:00Z',
+        }],
+      });
+      const fetcher = createSupabaseContinuityFetcher({ getDb: (() => client) as any });
+      const t = await fetcher.listOpenThreads({ tenantId: 't', userId: 'u' });
+      expect(t.ok).toBe(true);
+      expect(t.rows).toHaveLength(1);
+      expect(t.rows[0].thread_id).toBe('t1');
+      expect(t.rows[0].topic).toBe('magnesium');
+      expect(t.rows[0].status).toBe('open');
+    });
+
+    it('maps promise rows', async () => {
+      const client = makeFakeClient({
+        promisesRows: [{
+          promise_id: 'p1',
+          thread_id: 't1',
+          session_id: 's2',
+          promise_text: 'remind me at 8pm',
+          due_at: '2026-05-11T20:00:00Z',
+          status: 'owed',
+          decision_id: 'd1',
+          kept_at: null,
+          created_at: '2026-05-10T12:00:00Z',
+          updated_at: '2026-05-10T12:00:00Z',
+        }],
+      });
+      const fetcher = createSupabaseContinuityFetcher({ getDb: (() => client) as any });
+      const p = await fetcher.listPromises({ tenantId: 't', userId: 'u' });
+      expect(p.ok).toBe(true);
+      expect(p.rows).toHaveLength(1);
+      expect(p.rows[0].promise_id).toBe('p1');
+      expect(p.rows[0].status).toBe('owed');
+    });
+  });
+
+  describe('limit clamping', () => {
+    it('clamps undefined → 20', async () => {
+      let captured = -1;
+      const client = makeFakeClient({
+        threadsRows: [],
+        captureLimit: (_table, n) => { captured = n; },
+      });
+      const fetcher = createSupabaseContinuityFetcher({ getDb: (() => client) as any });
+      await fetcher.listOpenThreads({ tenantId: 't', userId: 'u' });
+      expect(captured).toBe(20);
+    });
+
+    it('clamps > 50 to 50', async () => {
+      let captured = -1;
+      const client = makeFakeClient({
+        threadsRows: [],
+        captureLimit: (_table, n) => { captured = n; },
+      });
+      const fetcher = createSupabaseContinuityFetcher({ getDb: (() => client) as any });
+      await fetcher.listOpenThreads({ tenantId: 't', userId: 'u', limit: 999 });
+      expect(captured).toBe(50);
+    });
+
+    it('clamps < 1 to 1', async () => {
+      let captured = -1;
+      const client = makeFakeClient({
+        promisesRows: [],
+        captureLimit: (_table, n) => { captured = n; },
+      });
+      const fetcher = createSupabaseContinuityFetcher({ getDb: (() => client) as any });
+      await fetcher.listPromises({ tenantId: 't', userId: 'u', limit: 0 });
+      expect(captured).toBe(1);
+    });
+  });
+
+  describe('status filter on listPromises', () => {
+    it('passes status through to supabase when provided', async () => {
+      let captured = '';
+      const client = makeFakeClient({
+        promisesRows: [],
+        captureStatusEq: (_table, s) => { captured = s; },
+      });
+      const fetcher = createSupabaseContinuityFetcher({ getDb: (() => client) as any });
+      await fetcher.listPromises({ tenantId: 't', userId: 'u', status: 'owed' });
+      expect(captured).toBe('owed');
+    });
+
+    it('omits status filter when status is absent', async () => {
+      const captured: string[] = [];
+      const client = makeFakeClient({
+        promisesRows: [],
+        captureStatusEq: (_table, s) => { captured.push(s); },
+      });
+      const fetcher = createSupabaseContinuityFetcher({ getDb: (() => client) as any });
+      await fetcher.listPromises({ tenantId: 't', userId: 'u' });
+      expect(captured).toEqual([]);
+    });
+  });
+
+  describe('mapThreadRow defensives', () => {
+    it('handles a completely empty row', () => {
+      const r = mapThreadRow({});
+      expect(r.thread_id).toBe('');
+      expect(r.topic).toBe('');
+      expect(r.summary).toBeNull();
+      expect(r.status).toBe('open');
+      expect(r.session_id_first).toBeNull();
+      expect(r.session_id_last).toBeNull();
+      expect(r.last_mentioned_at).toBe('');
+      expect(r.resolved_at).toBeNull();
+    });
+
+    it('coerces unknown status to "open"', () => {
+      const r = mapThreadRow({ status: 'gibberish' });
+      expect(r.status).toBe('open');
+    });
+
+    it('keeps known status values', () => {
+      expect(mapThreadRow({ status: 'open' }).status).toBe('open');
+      expect(mapThreadRow({ status: 'resolved' }).status).toBe('resolved');
+      expect(mapThreadRow({ status: 'abandoned' }).status).toBe('abandoned');
+    });
+  });
+
+  describe('mapPromiseRow defensives', () => {
+    it('handles a completely empty row', () => {
+      const r = mapPromiseRow({});
+      expect(r.promise_id).toBe('');
+      expect(r.thread_id).toBeNull();
+      expect(r.session_id).toBeNull();
+      expect(r.promise_text).toBe('');
+      expect(r.due_at).toBeNull();
+      expect(r.status).toBe('owed');
+      expect(r.decision_id).toBeNull();
+      expect(r.kept_at).toBeNull();
+    });
+
+    it('coerces unknown status to "owed"', () => {
+      const r = mapPromiseRow({ status: 'pending' });
+      expect(r.status).toBe('owed');
+    });
+
+    it('keeps known status values', () => {
+      expect(mapPromiseRow({ status: 'owed' }).status).toBe('owed');
+      expect(mapPromiseRow({ status: 'kept' }).status).toBe('kept');
+      expect(mapPromiseRow({ status: 'broken' }).status).toBe('broken');
+      expect(mapPromiseRow({ status: 'cancelled' }).status).toBe('cancelled');
+    });
+  });
+});

--- a/supabase/migrations/20260520000000_VTID_02932_continuity_tables.sql
+++ b/supabase/migrations/20260520000000_VTID_02932_continuity_tables.sql
@@ -1,0 +1,163 @@
+-- B2 (orb-live-refactor) — conversation continuity tables.
+--
+-- VTID-02932. Two tables that feed signals 40–45 of the assistant
+-- decision context:
+--
+--   user_open_threads   — durable conversation threads the user
+--                         left unfinished. Vitana can later say
+--                         "I owe you a follow-up about X" without
+--                         re-deriving the topic from scratch.
+--   assistant_promises  — concrete things Vitana said it would do
+--                         or follow up on. Vitana can later say
+--                         "last time I promised to remind you
+--                         about magnesium — here it is."
+--
+-- Wall (B2 lane):
+--   Selection is read-only. State advancement (creating threads,
+--   marking promises kept/broken) happens through dedicated event
+--   paths in a follow-up slice — NOT inside the preview/panel
+--   routes. Mirrors the B0e wall pattern.
+--
+-- RLS: tenant-scoped read/write via user_tenants (same pattern as
+-- B0c user_assistant_state and B0e.1 awareness tables).
+
+-- ---------------------------------------------------------------
+-- user_open_threads — durable unfinished conversations
+-- ---------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS user_open_threads (
+  thread_id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id            UUID NOT NULL,
+  user_id              UUID NOT NULL,
+  topic                TEXT NOT NULL,
+  summary              TEXT,
+  status               TEXT NOT NULL DEFAULT 'open'
+    CHECK (status IN ('open', 'resolved', 'abandoned')),
+  -- Sessions where the thread first appeared and was last mentioned.
+  -- Live-session ids are text (e.g. "live-<uuid>"), not UUIDs.
+  session_id_first     TEXT,
+  session_id_last      TEXT,
+  last_mentioned_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  resolved_at          TIMESTAMPTZ,
+  created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at           TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS user_open_threads_user_idx
+  ON user_open_threads (tenant_id, user_id, last_mentioned_at DESC);
+
+CREATE INDEX IF NOT EXISTS user_open_threads_open_idx
+  ON user_open_threads (tenant_id, user_id, last_mentioned_at DESC)
+  WHERE status = 'open';
+
+CREATE OR REPLACE FUNCTION user_open_threads_touch_updated_at()
+  RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS user_open_threads_updated_at_trigger ON user_open_threads;
+CREATE TRIGGER user_open_threads_updated_at_trigger
+  BEFORE UPDATE ON user_open_threads
+  FOR EACH ROW
+  EXECUTE FUNCTION user_open_threads_touch_updated_at();
+
+ALTER TABLE user_open_threads ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS user_open_threads_tenant_isolation ON user_open_threads;
+CREATE POLICY user_open_threads_tenant_isolation
+  ON user_open_threads
+  FOR ALL
+  TO authenticated
+  USING (
+    tenant_id IN (
+      SELECT tenant_id FROM user_tenants WHERE user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    tenant_id IN (
+      SELECT tenant_id FROM user_tenants WHERE user_id = auth.uid()
+    )
+  );
+
+-- ---------------------------------------------------------------
+-- assistant_promises — Vitana's owed follow-ups
+-- ---------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS assistant_promises (
+  promise_id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id            UUID NOT NULL,
+  user_id              UUID NOT NULL,
+  session_id           TEXT,
+  thread_id            UUID REFERENCES user_open_threads(thread_id) ON DELETE SET NULL,
+  promise_text         TEXT NOT NULL,
+  due_at               TIMESTAMPTZ,
+  status               TEXT NOT NULL DEFAULT 'owed'
+    CHECK (status IN ('owed', 'kept', 'broken', 'cancelled')),
+  -- Tying the promise back to a continuation decision lets the
+  -- Continuation Inspector trace promised follow-ups end-to-end.
+  decision_id          TEXT,
+  kept_at              TIMESTAMPTZ,
+  created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at           TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS assistant_promises_user_idx
+  ON assistant_promises (tenant_id, user_id, created_at DESC);
+
+-- Owed promises are the hot-path query — they drive the continuity
+-- nudge "I still owe you X". A partial index keeps it small even
+-- when the table grows large.
+CREATE INDEX IF NOT EXISTS assistant_promises_owed_idx
+  ON assistant_promises (tenant_id, user_id, due_at NULLS LAST)
+  WHERE status = 'owed';
+
+CREATE OR REPLACE FUNCTION assistant_promises_touch_updated_at()
+  RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS assistant_promises_updated_at_trigger ON assistant_promises;
+CREATE TRIGGER assistant_promises_updated_at_trigger
+  BEFORE UPDATE ON assistant_promises
+  FOR EACH ROW
+  EXECUTE FUNCTION assistant_promises_touch_updated_at();
+
+ALTER TABLE assistant_promises ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS assistant_promises_tenant_isolation ON assistant_promises;
+CREATE POLICY assistant_promises_tenant_isolation
+  ON assistant_promises
+  FOR ALL
+  TO authenticated
+  USING (
+    tenant_id IN (
+      SELECT tenant_id FROM user_tenants WHERE user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    tenant_id IN (
+      SELECT tenant_id FROM user_tenants WHERE user_id = auth.uid()
+    )
+  );
+
+-- ---------------------------------------------------------------
+-- Documentation
+-- ---------------------------------------------------------------
+
+COMMENT ON TABLE user_open_threads IS
+  'B2 (orb-live-refactor): durable record of unfinished conversation '
+  'topics. Selection is read-only — state advancement (open→resolved/'
+  'abandoned) happens through dedicated event paths in a follow-up '
+  'slice, never inside preview/panel routes.';
+
+COMMENT ON TABLE assistant_promises IS
+  'B2 (orb-live-refactor): concrete things Vitana said it would do or '
+  'follow up on. status: owed | kept | broken | cancelled. decision_id '
+  'links back to the AssistantContinuationDecision that produced the '
+  'promise, so the Continuation Inspector can trace follow-ups end-to-end.';


### PR DESCRIPTION
## Summary

B2 slice of the Assistant Intelligence Refactor — adds **conversation continuity** as a read-only journey-context signal.

- New tables: `user_open_threads` + `assistant_promises` (tenant-scoped RLS via `user_tenants`, partial indexes for hot-path reads, touch triggers on `updated_at`). No state-advancement RPC — mutation lives in a follow-up slice.
- New service: `services/gateway/src/services/continuity/` — read-only Supabase fetcher (`listOpenThreads` + `listPromises` only), pure compiler (`compileContinuityContext`) producing distilled context for the assistant decision layer.
- New route: `GET /api/v1/voice/continuity/preview` (admin-gated, GET-only).
- New Command Hub panel: "Conversation Continuity (B2)" on the Journey Context screen — counts, source-health, open threads, owed promises, recently-kept promises. Read-only.

## B2 wall (non-negotiable)

- ContinuityFetcher interface exposes ONLY `listOpenThreads` + `listPromises` — no upsert/insert/update/delete/rpc anywhere.
- Compiler is a pure function — no IO, no DB, no fetch, no timers. Injectable `nowMs` for testability.
- Preview route is GET-only and `requireExafyAdmin`.
- Panel has no buttons, no `onclick`, no POST/PUT/PATCH/DELETE fetches.
- Reliability lane (R-lane) untouched — zero changes to transport, audio, reconnect, Live API retry, timeout, or wake-brief timing.

## Test plan

- [x] `b2-migration.test.ts` — migration shape, CHECK constraints, RLS, indexes, FK ON DELETE SET NULL, no state-advancement RPCs
- [x] `continuity-fetcher.test.ts` — read-only contract, DB-down + error fallback, limit clamping (1..50), status filter pass-through, defensive row mapping
- [x] `compile-continuity-context.test.ts` — sort/cap/day-boundary/source_health propagation, days_since_last_mention + days_overdue math
- [x] `voice-continuity.test.ts` — validation (400s), fetcher wiring, response shape, error handling
- [x] `b2-walls.test.ts` — structural integrity (panel/route GET-only, no mutation surface, fetcher iface has no writers, compiler is pure, no transport/audio/reconnect refs)
- [x] **78 B2 tests green; pre-existing `sharp` import failures in unrelated suites are not regressions.**

## Acceptance check (panel renders with no data)

The Continuity panel renders an empty-state row when `jc.continuity` is `null`, mirroring the B0c/B0e/R0/B1 pattern. No data → no error — just an explicit "no data — load a user above" row.

🤖 Generated with [Claude Code](https://claude.com/claude-code)