### PR TITLE
feat(command-hub): Mission Alignment cockpit (DEV-COMHU-02934, VTID-02934)

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -2817,7 +2817,8 @@ const NAVIGATION_CONFIG = [
             { "key": "runs", "path": "/command-hub/autopilot/runs/" },
             { "key": "live", "path": "/command-hub/autopilot/live/" },
             { "key": "engine", "path": "/command-hub/autopilot/engine/" },
-            { "key": "growth", "path": "/command-hub/autopilot/growth/" }
+            { "key": "growth", "path": "/command-hub/autopilot/growth/" },
+            { "key": "mission-alignment", "path": "/command-hub/autopilot/mission-alignment/" }
         ]
     },
     {
@@ -6439,6 +6440,8 @@ function renderModuleContent(moduleKey, tab) {
         container.appendChild(renderAutopilotEngineView());
     } else if (moduleKey === 'autopilot' && tab === 'growth') {
         container.appendChild(renderAutopilotGrowthView());
+    } else if (moduleKey === 'autopilot' && tab === 'mission-alignment') {
+        container.appendChild(renderAutopilotMissionAlignmentView());
 
     } else {
         // Fallback placeholder for any unmapped screens
@@ -44548,6 +44551,7 @@ if (!state.autopilot) {
         live: { loading: false, activeRuns: null, recentRuns: null, engineStatus: null },
         engine: { loading: false, loopStatus: null, cronJobs: null },
         growth: { loading: false, metrics: null, period: '7d' },
+        missionAlignment: { loading: false, recs: null, error: null, lastFetchAt: null, statusFilter: 'new' },
         selectedAutomation: null,
         drawerOpen: false,
     };
@@ -46197,6 +46201,289 @@ function renderAutopilotGrowthView() {
         topCard.appendChild(empty);
     }
     container.appendChild(topCard);
+
+    return container;
+}
+
+// =============================================================================
+// VTID-02934 — Mission Alignment cockpit
+// =============================================================================
+// Reads the existing /api/v1/autopilot/recommendations endpoint (no new API
+// surface). Aggregates the queue along the three contract dimensions:
+//   - Pillar impact     (5 health pillars + 'none')
+//   - Economic axis     (4 axes + 'none')
+//   - Autonomy level    (manual / assisted / auto_approved / self_healing)
+// Each dimension answers a separate supervisor question:
+//   pillar  → which longevity pillars is the queue actually serving?
+//   axis    → is the longevity economy axis represented at all?
+//   level   → what fraction is auto-executed vs human-gated?
+// See docs/GOVERNANCE/ULTIMATE-GOAL.md.
+// =============================================================================
+
+const MISSION_ALIGNMENT_PILLARS = ['nutrition', 'hydration', 'exercise', 'sleep', 'mental'];
+const MISSION_ALIGNMENT_ECONOMIC_AXES = ['find_match', 'marketplace', 'income_generation', 'business_formation'];
+const MISSION_ALIGNMENT_AUTONOMY_LEVELS = ['manual', 'assisted', 'auto_approved', 'self_healing'];
+
+function fetchMissionAlignmentRecs() {
+    var ma = state.autopilot.missionAlignment;
+    ma.loading = true;
+    ma.error = null;
+    renderApp();
+    var status = ma.statusFilter || 'new';
+    var url = '/api/v1/autopilot/recommendations?limit=500&status=' + encodeURIComponent(status);
+    fetch(url, { credentials: 'include', headers: buildContextHeaders() })
+        .then(function (r) { return r.json(); })
+        .then(function (j) {
+            ma.loading = false;
+            if (j && j.ok) {
+                ma.recs = j.recommendations || [];
+                ma.lastFetchAt = new Date().toISOString();
+            } else {
+                ma.recs = null;
+                ma.error = (j && j.error) || 'Fetch failed';
+            }
+            renderApp();
+        })
+        .catch(function (err) {
+            ma.loading = false;
+            ma.recs = null;
+            ma.error = String(err);
+            renderApp();
+        });
+}
+
+function aggregateMissionAlignment(recs) {
+    var pillarCounts = { nutrition: 0, hydration: 0, exercise: 0, sleep: 0, mental: 0, none: 0 };
+    var axisCounts = { find_match: 0, marketplace: 0, income_generation: 0, business_formation: 0, none: 0 };
+    var levelCounts = { manual: 0, assisted: 0, auto_approved: 0, self_healing: 0 };
+    var total = recs.length;
+    var mission_served = 0;
+
+    recs.forEach(function (r) {
+        var pi = r.pillar_impact || {};
+        var primary = pi.primary_pillar;
+        if (primary && Object.prototype.hasOwnProperty.call(pillarCounts, primary)) {
+            pillarCounts[primary] += 1;
+        } else {
+            pillarCounts.none += 1;
+        }
+        var axis = (r.economic_axis || 'none');
+        if (!Object.prototype.hasOwnProperty.call(axisCounts, axis)) axis = 'none';
+        axisCounts[axis] += 1;
+        var level = (r.autonomy_level || 'manual');
+        if (!Object.prototype.hasOwnProperty.call(levelCounts, level)) level = 'manual';
+        levelCounts[level] += 1;
+        if (primary || (axis !== 'none')) mission_served += 1;
+    });
+
+    return {
+        total: total,
+        mission_served: mission_served,
+        mission_served_pct: total > 0 ? Math.round((mission_served / total) * 100) : 0,
+        pillarCounts: pillarCounts,
+        axisCounts: axisCounts,
+        levelCounts: levelCounts,
+    };
+}
+
+function formatPillarLabel(p) {
+    var labels = { nutrition: 'Nutrition', hydration: 'Hydration', exercise: 'Exercise', sleep: 'Sleep', mental: 'Mental Health', none: 'Not pillar-aligned' };
+    return labels[p] || p;
+}
+function formatAxisLabel(a) {
+    var labels = { find_match: 'Find a Match', marketplace: 'Marketplace', income_generation: 'Income generation', business_formation: 'Business formation', none: 'Not economy-aligned' };
+    return labels[a] || a;
+}
+function formatLevelLabel(l) {
+    var labels = { manual: 'Manual', assisted: 'Assisted', auto_approved: 'Auto-approved', self_healing: 'Self-healing' };
+    return labels[l] || l;
+}
+
+function renderMissionAlignmentBreakdown(title, keys, counts, total, formatter, modifier) {
+    var card = document.createElement('div');
+    card.className = 'mission-alignment-card';
+
+    var h = document.createElement('h3');
+    h.className = 'mission-alignment-card-title';
+    h.textContent = title;
+    card.appendChild(h);
+
+    if (total === 0) {
+        var empty = document.createElement('div');
+        empty.className = 'mission-alignment-empty';
+        empty.textContent = 'No recommendations in the current queue.';
+        card.appendChild(empty);
+        return card;
+    }
+
+    keys.forEach(function (key) {
+        var count = counts[key] || 0;
+        var pct = total > 0 ? Math.round((count / total) * 100) : 0;
+        var row = document.createElement('div');
+        row.className = 'mission-alignment-row';
+
+        var labelEl = document.createElement('span');
+        labelEl.className = 'mission-alignment-row-label';
+        labelEl.textContent = formatter(key);
+        row.appendChild(labelEl);
+
+        var barWrap = document.createElement('div');
+        barWrap.className = 'mission-alignment-bar-track';
+        var bar = document.createElement('div');
+        bar.className = 'mission-alignment-bar-fill' + (modifier ? ' ' + modifier(key) : '');
+        bar.style.width = pct + '%';
+        barWrap.appendChild(bar);
+        row.appendChild(barWrap);
+
+        var stats = document.createElement('span');
+        stats.className = 'mission-alignment-row-stats';
+        stats.textContent = count + ' (' + pct + '%)';
+        row.appendChild(stats);
+
+        card.appendChild(row);
+    });
+
+    return card;
+}
+
+function renderAutopilotMissionAlignmentView() {
+    var container = document.createElement('div');
+    container.className = 'mission-alignment-container';
+
+    var header = document.createElement('div');
+    header.className = 'mission-alignment-header';
+
+    var titleBlock = document.createElement('div');
+    var title = document.createElement('h2');
+    title.textContent = 'Mission Alignment';
+    titleBlock.appendChild(title);
+    var subtitle = document.createElement('p');
+    subtitle.className = 'section-subtitle';
+    subtitle.textContent = 'Does the autopilot queue advance the Vitana Ultimate Goal? Reads the live recommendation queue and groups it across the three contract dimensions.';
+    titleBlock.appendChild(subtitle);
+    header.appendChild(titleBlock);
+
+    var contractLink = document.createElement('a');
+    contractLink.href = 'https://github.com/exafyltd/vitana-platform/blob/main/docs/GOVERNANCE/ULTIMATE-GOAL.md';
+    contractLink.target = '_blank';
+    contractLink.rel = 'noopener';
+    contractLink.className = 'mission-alignment-contract-link';
+    contractLink.textContent = 'View the Ultimate Goal contract →';
+    header.appendChild(contractLink);
+
+    container.appendChild(header);
+
+    var ma = state.autopilot.missionAlignment;
+
+    var filterRow = document.createElement('div');
+    filterRow.className = 'mission-alignment-filter-row';
+    var filterLabel = document.createElement('span');
+    filterLabel.className = 'mission-alignment-filter-label';
+    filterLabel.textContent = 'Queue:';
+    filterRow.appendChild(filterLabel);
+    ['new', 'activated', 'rejected', 'snoozed'].forEach(function (s) {
+        var btn = document.createElement('button');
+        btn.type = 'button';
+        btn.textContent = s;
+        btn.className = 'mission-alignment-filter-btn' + (ma.statusFilter === s ? ' is-active' : '');
+        btn.onclick = function () {
+            if (ma.statusFilter === s) return;
+            ma.statusFilter = s;
+            ma.recs = null;
+            fetchMissionAlignmentRecs();
+        };
+        filterRow.appendChild(btn);
+    });
+    var refreshBtn = document.createElement('button');
+    refreshBtn.type = 'button';
+    refreshBtn.className = 'mission-alignment-refresh-btn';
+    refreshBtn.textContent = 'Refresh';
+    refreshBtn.onclick = function () { fetchMissionAlignmentRecs(); };
+    filterRow.appendChild(refreshBtn);
+    container.appendChild(filterRow);
+
+    if (ma.recs === null && !ma.loading && !ma.error) {
+        setTimeout(function () { fetchMissionAlignmentRecs(); }, 0);
+    }
+
+    if (ma.loading) {
+        var loader = document.createElement('div');
+        loader.className = 'loading-indicator';
+        loader.textContent = 'Loading mission alignment...';
+        container.appendChild(loader);
+        return container;
+    }
+
+    if (ma.error) {
+        var errBox = document.createElement('div');
+        errBox.className = 'mission-alignment-error';
+        errBox.textContent = 'Could not load: ' + ma.error;
+        container.appendChild(errBox);
+        return container;
+    }
+
+    if (!ma.recs) return container;
+
+    var agg = aggregateMissionAlignment(ma.recs);
+
+    var summary = document.createElement('div');
+    summary.className = 'mission-alignment-summary';
+    var totalCard = document.createElement('div');
+    totalCard.className = 'mission-alignment-summary-card';
+    totalCard.innerHTML = '<div class="mission-alignment-summary-value">' + agg.total + '</div>' +
+        '<div class="mission-alignment-summary-label">recommendations in queue</div>';
+    summary.appendChild(totalCard);
+
+    var servedCard = document.createElement('div');
+    servedCard.className = 'mission-alignment-summary-card';
+    servedCard.innerHTML = '<div class="mission-alignment-summary-value">' + agg.mission_served_pct + '%</div>' +
+        '<div class="mission-alignment-summary-label">advance the mission</div>';
+    summary.appendChild(servedCard);
+
+    var unalignedCard = document.createElement('div');
+    unalignedCard.className = 'mission-alignment-summary-card';
+    var unaligned = agg.total - agg.mission_served;
+    unalignedCard.innerHTML = '<div class="mission-alignment-summary-value">' + unaligned + '</div>' +
+        '<div class="mission-alignment-summary-label">not yet aligned</div>';
+    summary.appendChild(unalignedCard);
+    container.appendChild(summary);
+
+    var breakdowns = document.createElement('div');
+    breakdowns.className = 'mission-alignment-breakdowns';
+
+    breakdowns.appendChild(renderMissionAlignmentBreakdown(
+        'Pillar impact',
+        ['nutrition', 'hydration', 'exercise', 'sleep', 'mental', 'none'],
+        agg.pillarCounts,
+        agg.total,
+        formatPillarLabel,
+        function (k) { return k === 'none' ? 'is-muted' : 'is-pillar-' + k; }
+    ));
+
+    breakdowns.appendChild(renderMissionAlignmentBreakdown(
+        'Economic axis',
+        ['find_match', 'marketplace', 'income_generation', 'business_formation', 'none'],
+        agg.axisCounts,
+        agg.total,
+        formatAxisLabel,
+        function (k) { return k === 'none' ? 'is-muted' : 'is-economy'; }
+    ));
+
+    breakdowns.appendChild(renderMissionAlignmentBreakdown(
+        'Autonomy level',
+        ['manual', 'assisted', 'auto_approved', 'self_healing'],
+        agg.levelCounts,
+        agg.total,
+        formatLevelLabel,
+        function (k) { return 'is-autonomy-' + k.replace('_', '-'); }
+    ));
+
+    container.appendChild(breakdowns);
+
+    var foot = document.createElement('div');
+    foot.className = 'mission-alignment-footnote';
+    foot.textContent = 'Pillar impact is derived from contribution_vector. Economic axis is set at insert time (deriveEconomicAxis). Autonomy level is derived by the BEFORE INSERT trigger for dev_autopilot paths. Last refreshed: ' + (ma.lastFetchAt || 'never');
+    container.appendChild(foot);
 
     return container;
 }

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -22,7 +22,7 @@
       } catch (e) { /* never block on a redirect failure */ }
     })();
   </script>
-  <link rel="stylesheet" href="/command-hub/styles.css?v=20260424-dev-comhu-0411-docs-screens-num" />
+  <link rel="stylesheet" href="/command-hub/styles.css?v=20260511-vtid-02934-mission-alignment" />
 </head>
 <body>
   <div id="root"></div>
@@ -30,7 +30,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260504-vtid-02710-ios-ctx-keepalive"></script>
-  <script src="/command-hub/app.js?v=20260511-vtid-02930-greeting-decay"></script>
+  <script src="/command-hub/app.js?v=20260511-vtid-02934-mission-alignment"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
 </body>

--- a/services/gateway/src/frontend/command-hub/styles.css
+++ b/services/gateway/src/frontend/command-hub/styles.css
@@ -17,6 +17,16 @@
   --color-task-progress: #f59e0b;
   --color-task-completed: #10b981;
 
+  /* Vitana Index Pillar Colors — used by Mission Alignment (VTID-02934) and
+     anywhere we visualize per-pillar contribution. Five distinct hues so the
+     five longevity pillars are visually distinguishable in stacked/grouped
+     charts. */
+  --color-pillar-nutrition: #84cc16;
+  --color-pillar-hydration: #38bdf8;
+  --color-pillar-exercise:  #f97316;
+  --color-pillar-sleep:     #a855f7;
+  --color-pillar-mental:    #ec4899;
+
   /* Overview / Command Hub Card Tokens
      Use these in .overview-* classes — do NOT hardcode in element.style.cssText. */
   --overview-grid-gap: 0.45rem;
@@ -19073,4 +19083,173 @@ border-bottom: 1px solid var(--color-border, #333);
   background: rgba(59, 130, 246, 0.15);
   color: #bfdbfe;
   border: 1px solid rgba(59, 130, 246, 0.35);
+}
+
+/* =============================================================================
+   VTID-02934 — Mission Alignment cockpit
+   docs/GOVERNANCE/ULTIMATE-GOAL.md
+   ========================================================================== */
+.mission-alignment-container {
+  padding: 1.5rem;
+  color: var(--color-text-primary);
+}
+.mission-alignment-header {
+  display: flex;
+  justify-content: space-between;
+  align-items: flex-start;
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+.mission-alignment-header h2 {
+  margin: 0 0 0.25rem;
+}
+.mission-alignment-contract-link {
+  color: var(--color-accent);
+  text-decoration: none;
+  font-size: 0.85rem;
+  white-space: nowrap;
+}
+.mission-alignment-contract-link:hover {
+  color: var(--color-accent-hover);
+  text-decoration: underline;
+}
+.mission-alignment-filter-row {
+  display: flex;
+  align-items: center;
+  gap: 0.5rem;
+  margin-bottom: 1.5rem;
+  flex-wrap: wrap;
+}
+.mission-alignment-filter-label {
+  color: var(--color-text-secondary);
+  font-size: 0.85rem;
+  margin-right: 0.25rem;
+}
+.mission-alignment-filter-btn,
+.mission-alignment-refresh-btn {
+  padding: 6px 14px;
+  border-radius: 6px;
+  cursor: pointer;
+  font-size: 0.85rem;
+  background: var(--color-sidebar-bg);
+  color: var(--color-text-secondary);
+  border: 1px solid var(--color-border);
+}
+.mission-alignment-filter-btn:hover,
+.mission-alignment-refresh-btn:hover {
+  color: var(--color-text-primary);
+  border-color: var(--color-accent);
+}
+.mission-alignment-filter-btn.is-active {
+  background: var(--color-accent);
+  color: var(--color-text-primary);
+  border-color: var(--color-accent);
+}
+.mission-alignment-refresh-btn {
+  margin-left: auto;
+}
+.mission-alignment-error {
+  background: rgba(239, 68, 68, 0.12);
+  border: 1px solid rgba(239, 68, 68, 0.4);
+  color: #fecaca;
+  padding: 0.75rem 1rem;
+  border-radius: 6px;
+  font-size: 0.9rem;
+}
+.mission-alignment-summary {
+  display: flex;
+  gap: 1rem;
+  flex-wrap: wrap;
+  margin-bottom: 1.5rem;
+}
+.mission-alignment-summary-card {
+  flex: 1 1 180px;
+  background: var(--color-sidebar-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+}
+.mission-alignment-summary-value {
+  font-size: 1.75rem;
+  font-weight: 600;
+  color: var(--color-text-primary);
+}
+.mission-alignment-summary-label {
+  font-size: 0.85rem;
+  color: var(--color-text-secondary);
+  margin-top: 0.25rem;
+}
+.mission-alignment-breakdowns {
+  display: grid;
+  grid-template-columns: repeat(auto-fit, minmax(320px, 1fr));
+  gap: 1rem;
+  margin-bottom: 1rem;
+}
+.mission-alignment-card {
+  background: var(--color-sidebar-bg);
+  border: 1px solid var(--color-border);
+  border-radius: 8px;
+  padding: 1rem 1.25rem;
+}
+.mission-alignment-card-title {
+  margin: 0 0 0.75rem;
+  font-size: 1rem;
+  color: var(--color-text-primary);
+}
+.mission-alignment-row {
+  display: grid;
+  grid-template-columns: 8rem 1fr 5rem;
+  align-items: center;
+  gap: 0.5rem;
+  padding: 0.35rem 0;
+  font-size: 0.85rem;
+}
+.mission-alignment-row-label {
+  color: var(--color-text-secondary);
+  white-space: nowrap;
+  overflow: hidden;
+  text-overflow: ellipsis;
+}
+.mission-alignment-row-stats {
+  color: var(--color-text-primary);
+  text-align: right;
+  font-variant-numeric: tabular-nums;
+}
+.mission-alignment-bar-track {
+  background: rgba(148, 163, 184, 0.18);
+  border-radius: 3px;
+  height: 10px;
+  width: 100%;
+  overflow: hidden;
+}
+.mission-alignment-bar-fill {
+  height: 100%;
+  background: var(--color-accent);
+  border-radius: 3px;
+  transition: width 0.2s ease;
+}
+.mission-alignment-bar-fill.is-muted {
+  background: rgba(148, 163, 184, 0.5);
+}
+.mission-alignment-bar-fill.is-economy {
+  background: var(--color-operator);
+}
+.mission-alignment-bar-fill.is-pillar-nutrition { background: var(--color-pillar-nutrition); }
+.mission-alignment-bar-fill.is-pillar-hydration { background: var(--color-pillar-hydration); }
+.mission-alignment-bar-fill.is-pillar-exercise  { background: var(--color-pillar-exercise); }
+.mission-alignment-bar-fill.is-pillar-sleep     { background: var(--color-pillar-sleep); }
+.mission-alignment-bar-fill.is-pillar-mental    { background: var(--color-pillar-mental); }
+.mission-alignment-bar-fill.is-autonomy-manual         { background: rgba(148, 163, 184, 0.6); }
+.mission-alignment-bar-fill.is-autonomy-assisted       { background: var(--color-accent); }
+.mission-alignment-bar-fill.is-autonomy-auto-approved  { background: var(--color-task-completed); }
+.mission-alignment-bar-fill.is-autonomy-self-healing   { background: var(--color-operator); }
+.mission-alignment-empty {
+  color: var(--color-text-secondary);
+  font-size: 0.85rem;
+  padding: 0.5rem 0;
+}
+.mission-alignment-footnote {
+  margin-top: 0.5rem;
+  font-size: 0.75rem;
+  color: var(--color-text-secondary);
 }


### PR DESCRIPTION
## Summary

Phase 4 of the Ultimate Goal hardening. PRs #2057 + #2060 made every recommendation declare HOW it serves the mission. This PR makes that visible + actionable to supervisors.

New sub-tab under the Autopilot module: **Mission Alignment**. Read-only surface; no backend or schema changes. Reads `GET /api/v1/autopilot/recommendations` and aggregates the queue across the three contract dimensions.

## What it shows

| Dimension | Question it answers |
|---|---|
| Pillar impact | Which 5 longevity pillars is the queue actually serving? (nutrition / hydration / exercise / sleep / mental / not pillar-aligned) |
| Economic axis | Is the longevity economy axis represented at all? (find_match / marketplace / income_generation / business_formation / not economy-aligned) |
| Autonomy level | What fraction is auto-executed vs human-gated? (manual / assisted / auto_approved / self_healing) |

Plus a queue-level alignment summary: total recs, % that advance the mission, count not yet aligned. Status filter (new / activated / rejected / snoozed) lets the supervisor inspect any slice. Manual refresh button.

## Path

`/command-hub/autopilot/mission-alignment/`

No module/tab reorders (per CLAUDE.md ALWAYS rule 31) — added as the 9th tab inside the existing Autopilot section.

## Compliance notes

- **CSP-clean**: all event handlers via `element.onclick`; no inline `<script>` / `style` attributes (per ALWAYS 36 / NEVER 24).
- **Design tokens**: 5 new `--color-pillar-*` tokens added to `:root`. New CSS classes only reference `var(--color-*)` — no hex literals outside `:root` (per ALWAYS 38 / NEVER 28).
- **Cache-bust**: bumped CSS + app.js `?v=` on `index.html` (per IF-THEN 25).
- **External JS**: all new code lives in `app.js` — no inline scripts.
- **Build**: `npm run build` clean (per ALWAYS 24, not just `tsc --noEmit`).

## Files

| File | Lines | Purpose |
|---|---|---|
| `services/gateway/src/frontend/command-hub/app.js` | +260 | NAVIGATION_CONFIG tab, state slot, fetch + aggregate + render helpers |
| `services/gateway/src/frontend/command-hub/styles.css` | +130 | 5 pillar tokens in `:root`, mission-alignment-* component classes |
| `services/gateway/src/frontend/command-hub/index.html` | +0 / -0 | Cache-bust bump |

## Verification

- [ ] After deploy, open `/command-hub/autopilot/mission-alignment/` in Command Hub
- [ ] Confirm three breakdown cards render (Pillar / Economic / Autonomy) with bar widths matching counts
- [ ] Toggle status filter: new vs activated should produce different aggregates
- [ ] Click the contract link → opens `docs/GOVERNANCE/ULTIMATE-GOAL.md` on GitHub
- [ ] Mobile 390×844 + desktop 1400×900 (Targeted Visual Verification protocol)

## Out of scope (later phases)

- Phase 5: VTID/dev-autopilot alignment warnings + 80% graduation gate (corrective surface — "flag this rec as misaligned")
- Phase 6: Mission Alignment in vitana-v1 user surfaces (My Journey, Calendar, Business Hub)

🤖 Generated with [Claude Code](https://claude.com/claude-code)