### PR TITLE
feat(autopilot): alignment-warning OASIS events on activation (VTID-02935)

### DIFF
--- a/services/gateway/src/routes/autopilot-recommendations.ts
+++ b/services/gateway/src/routes/autopilot-recommendations.ts
@@ -27,6 +27,61 @@ import { generateRecommendations, generatePersonalRecommendations, SourceType } 
 import { notifyUserAsync } from '../services/notification-service';
 import { DEFAULT_WAVE_CONFIG, buildTemplateToWaveMap } from '../services/wave-defaults';
 import { derivePillarImpact } from '../services/recommendation-engine/pillar-impact';
+import { evaluateRecAlignment } from '../services/recommendation-engine/alignment-evaluator';
+
+/**
+ * Phase 5 of the Ultimate Goal hardening (VTID-02935): when a recommendation
+ * graduates to a VTID, emit an OASIS event reporting whether the rec advances
+ * any mission dimension. The rec is "aligned" if it has a primary pillar OR a
+ * non-'none' economic_axis. Pillar impact is derived from contribution_vector.
+ *
+ * NOT a hard block — visibility only. Future: graduation to a block once ≥80%
+ * of activations in a 14-day window carry alignment fields. See
+ * docs/GOVERNANCE/ULTIMATE-GOAL.md.
+ */
+async function emitAlignmentEventForActivation(params: {
+  vtid: string;
+  recId: string;
+  recTitle: string;
+  userId: string | null;
+  supabaseUrl: string;
+  svcKey: string;
+}): Promise<void> {
+  try {
+    const recResp = await fetch(
+      `${params.supabaseUrl}/rest/v1/autopilot_recommendations?id=eq.${params.recId}&select=economic_axis,autonomy_level,contribution_vector,source_type,source_ref,domain&limit=1`,
+      { headers: { apikey: params.svcKey, Authorization: `Bearer ${params.svcKey}` } },
+    );
+    if (!recResp.ok) return;
+    const rows = await recResp.json() as any[];
+    const rec = rows[0];
+    if (!rec) return;
+
+    const evaluation = evaluateRecAlignment(rec);
+
+    await emitOasisEvent({
+      vtid: params.vtid,
+      type: evaluation.topic,
+      source: 'autopilot-recommendations',
+      status: evaluation.status,
+      message: evaluation.message,
+      payload: {
+        recommendation_id: params.recId,
+        recommendation_title: params.recTitle,
+        user_id: params.userId,
+        pillar_impact: evaluation.pillar_impact,
+        economic_axis: evaluation.economic_axis,
+        autonomy_level: evaluation.autonomy_level,
+        source_type: rec.source_type || null,
+        source_ref: rec.source_ref || null,
+        domain: rec.domain || null,
+      },
+    });
+  } catch (err: any) {
+    // Never let alignment telemetry break the activation path.
+    console.warn(`[VTID-02935] emitAlignmentEventForActivation failed (non-fatal): ${err?.message || err}`);
+  }
+}
 
 /**
  * Annotate an array of recommendation rows from get_autopilot_recommendations
@@ -936,7 +991,7 @@ router.post('/:id/activate', async (req: Request, res: Response) => {
     // Emit OASIS event for tracking
     await emitOasisEvent({
       vtid: response.vtid || 'SYSTEM',
-      type: 'autopilot.recommendation.activated' as any,
+      type: 'autopilot.recommendation.activated',
       source: 'autopilot-recommendations',
       status: 'info',
       message: `Recommendation activated: ${response.title}`,
@@ -947,6 +1002,24 @@ router.post('/:id/activate', async (req: Request, res: Response) => {
         already_activated: response.already_activated,
       },
     });
+
+    // VTID-02935 Phase 5: emit alignment telemetry for fresh activations only.
+    // Skip already-activated calls (idempotent re-tries don't change alignment
+    // state). Pillar impact is derived from contribution_vector at read time.
+    if (!response.already_activated && response.vtid) {
+      const supabaseUrlForAlign = process.env.SUPABASE_URL;
+      const svcKeyForAlign = process.env.SUPABASE_SERVICE_ROLE;
+      if (supabaseUrlForAlign && svcKeyForAlign) {
+        await emitAlignmentEventForActivation({
+          vtid: response.vtid,
+          recId: id,
+          recTitle: response.title || '',
+          userId: userId || null,
+          supabaseUrl: supabaseUrlForAlign,
+          svcKey: svcKeyForAlign,
+        });
+      }
+    }
 
     // Create draft spec in oasis_specs from recommendation data so the task
     // enters the spec pipeline with content ready for validate → approve flow

--- a/services/gateway/src/services/recommendation-engine/alignment-evaluator.ts
+++ b/services/gateway/src/services/recommendation-engine/alignment-evaluator.ts
@@ -1,0 +1,66 @@
+/**
+ * Pure evaluator for "does this recommendation declare a mission dimension?"
+ *
+ * Phase 5 of the Ultimate Goal hardening (docs/GOVERNANCE/ULTIMATE-GOAL.md):
+ * extracted so the activation-time alignment-warning logic is unit-testable
+ * without standing up HTTP mocks for the Supabase REST call.
+ *
+ * A rec is "served" if it advances any mission dimension:
+ *   - has a primary pillar (derived from contribution_vector), OR
+ *   - has a non-'none' economic_axis.
+ *
+ * "Unclear" recs are the ones we want to flag — the queue is shipping work
+ * that doesn't connect to the contract. NOT a hard block; just visibility.
+ */
+
+import { derivePillarImpact, type PillarImpact } from './pillar-impact';
+
+export interface AlignmentEvaluationInput {
+  contribution_vector?: Record<string, unknown> | null;
+  economic_axis?: string | null;
+  autonomy_level?: string | null;
+}
+
+export interface AlignmentEvaluation {
+  pillar_impact: PillarImpact;
+  economic_axis: string;
+  autonomy_level: string;
+  has_pillar: boolean;
+  has_economy: boolean;
+  aligned: boolean;
+  topic: 'autopilot.alignment.served' | 'autopilot.alignment.unclear';
+  status: 'info' | 'warning';
+  message: string;
+}
+
+export function evaluateRecAlignment(rec: AlignmentEvaluationInput): AlignmentEvaluation {
+  const pillarImpact = derivePillarImpact(rec.contribution_vector);
+  const economicAxis = rec.economic_axis || 'none';
+  const autonomyLevel = rec.autonomy_level || 'manual';
+
+  const hasPillar = pillarImpact.primary_pillar !== null;
+  const hasEconomy = economicAxis !== 'none';
+  const aligned = hasPillar || hasEconomy;
+
+  let message: string;
+  if (aligned) {
+    const parts: string[] = [];
+    if (hasPillar && pillarImpact.primary_pillar) parts.push(pillarImpact.primary_pillar);
+    if (hasEconomy) parts.push(economicAxis);
+    message = `Activated VTID advances ${parts.join(' + ')}`;
+  } else {
+    message = 'Activated VTID has no declared mission dimension (pillar_impact=none, economic_axis=none). See docs/GOVERNANCE/ULTIMATE-GOAL.md.';
+  }
+
+  return {
+    pillar_impact: pillarImpact,
+    economic_axis: economicAxis,
+    autonomy_level: autonomyLevel,
+    has_pillar: hasPillar,
+    has_economy: hasEconomy,
+    aligned,
+    topic: aligned ? 'autopilot.alignment.served' : 'autopilot.alignment.unclear',
+    status: aligned ? 'info' : 'warning',
+    message,
+  };
+}

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -569,6 +569,15 @@ export type CicdEventType =
   | 'dev.recommendation.presented'
   | 'dev.recommendation.selected'
   | 'dev.fallback.tool_used'
+  // VTID-02934: Autopilot recommendation activation
+  | 'autopilot.recommendation.activated'
+  // VTID-02935: Mission Alignment warnings — fired when a recommendation
+  // graduates to a VTID without declaring how it serves the Ultimate Goal.
+  // See docs/GOVERNANCE/ULTIMATE-GOAL.md. NOT a hard block — visibility only.
+  // Future: graduation to a block once ≥80% of activations in a 14-day
+  // window carry alignment fields without operator intervention.
+  | 'autopilot.alignment.unclear'
+  | 'autopilot.alignment.served'
   // VTID-01270: Proactive Match Messenger Events
   | 'match.proactive.sent'
   | 'match.proactive.skipped'

--- a/services/gateway/test/alignment-evaluator.test.ts
+++ b/services/gateway/test/alignment-evaluator.test.ts
@@ -1,0 +1,90 @@
+/**
+ * Tests for evaluateRecAlignment — the pure evaluator behind the activation-
+ * time alignment-warning OASIS event (VTID-02935).
+ *
+ * Contract (docs/GOVERNANCE/ULTIMATE-GOAL.md):
+ *   - "served"  = rec advances a pillar OR the economic axis.
+ *   - "unclear" = rec advances neither.
+ */
+
+import { evaluateRecAlignment } from '../src/services/recommendation-engine/alignment-evaluator';
+
+describe('evaluateRecAlignment', () => {
+  test('returns unclear when both pillar and economic axis are absent', () => {
+    const result = evaluateRecAlignment({
+      contribution_vector: {},
+      economic_axis: 'none',
+      autonomy_level: 'manual',
+    });
+    expect(result.aligned).toBe(false);
+    expect(result.topic).toBe('autopilot.alignment.unclear');
+    expect(result.status).toBe('warning');
+    expect(result.has_pillar).toBe(false);
+    expect(result.has_economy).toBe(false);
+  });
+
+  test('returns served when only a pillar is advanced', () => {
+    const result = evaluateRecAlignment({
+      contribution_vector: { sleep: 0.6 },
+      economic_axis: 'none',
+      autonomy_level: 'manual',
+    });
+    expect(result.aligned).toBe(true);
+    expect(result.topic).toBe('autopilot.alignment.served');
+    expect(result.status).toBe('info');
+    expect(result.has_pillar).toBe(true);
+    expect(result.has_economy).toBe(false);
+    expect(result.message).toContain('sleep');
+  });
+
+  test('returns served when only the economic axis is advanced', () => {
+    const result = evaluateRecAlignment({
+      contribution_vector: {},
+      economic_axis: 'marketplace',
+      autonomy_level: 'auto_approved',
+    });
+    expect(result.aligned).toBe(true);
+    expect(result.topic).toBe('autopilot.alignment.served');
+    expect(result.status).toBe('info');
+    expect(result.has_pillar).toBe(false);
+    expect(result.has_economy).toBe(true);
+    expect(result.message).toContain('marketplace');
+    expect(result.autonomy_level).toBe('auto_approved');
+  });
+
+  test('returns served when both pillar and economic axis are advanced', () => {
+    const result = evaluateRecAlignment({
+      contribution_vector: { mental: 0.5 },
+      economic_axis: 'find_match',
+      autonomy_level: 'assisted',
+    });
+    expect(result.aligned).toBe(true);
+    expect(result.topic).toBe('autopilot.alignment.served');
+    expect(result.has_pillar).toBe(true);
+    expect(result.has_economy).toBe(true);
+    expect(result.message).toMatch(/mental.*\+.*find_match/);
+  });
+
+  test('handles null / missing inputs by defaulting safely', () => {
+    const result = evaluateRecAlignment({});
+    expect(result.aligned).toBe(false);
+    expect(result.economic_axis).toBe('none');
+    expect(result.autonomy_level).toBe('manual');
+    expect(result.topic).toBe('autopilot.alignment.unclear');
+  });
+
+  test('ignores below-band pillar weights (no false positives at low magnitudes)', () => {
+    // max weight 0.04 → below 0.05 low band → magnitude 'none' → not a pillar advance
+    const result = evaluateRecAlignment({
+      contribution_vector: { nutrition: 0.04 },
+      economic_axis: 'none',
+    });
+    expect(result.aligned).toBe(false);
+    expect(result.has_pillar).toBe(false);
+  });
+
+  test('message contains the path to the contract on unclear', () => {
+    const result = evaluateRecAlignment({ economic_axis: 'none' });
+    expect(result.message).toContain('docs/GOVERNANCE/ULTIMATE-GOAL.md');
+  });
+});


### PR DESCRIPTION
## Summary

Phase 5 of the Ultimate Goal hardening. When a recommendation graduates to a VTID, emit an OASIS event that reports whether the rec advances any mission dimension (5 health pillars + longevity economy axis).

**NOT a hard block — visibility only.** Future: graduation to a block once ≥80% of activations in a 14-day window carry alignment fields without operator intervention.

## What changes on the wire

| Event topic | Status | Fires when |
|---|---|---|
| `autopilot.recommendation.activated` | `info` | Existing — formalized into the `CicdEventType` union (was `as any`) |
| `autopilot.alignment.served` | `info` | Activated VTID has primary_pillar OR non-`none` economic_axis |
| `autopilot.alignment.unclear` | `warning` | Activated VTID has neither — "we just shipped unaligned work" |

Payload includes pillar_impact, economic_axis, autonomy_level, source_type, source_ref, domain. Operators can pivot the warnings stream by any of those to find structural gaps in labelling.

## Why a pure evaluator

The activation route does a Supabase REST fetch then calls `evaluateRecAlignment`. The evaluator is pure (no I/O) so tests don't need to mock the REST call. The route wraps it in try/catch — telemetry failure never breaks the activation path (per NEVER rule 19: never silence errors silently — we `console.warn` with a non-fatal prefix).

## Files

| Path | Kind | Lines |
|---|---|---|
| `services/gateway/src/services/recommendation-engine/alignment-evaluator.ts` | new (pure logic) | ~60 |
| `services/gateway/test/alignment-evaluator.test.ts` | new (7 tests) | ~80 |
| `services/gateway/src/routes/autopilot-recommendations.ts` | edit (helper + call site) | ~50 |
| `services/gateway/src/types/cicd.ts` | edit (3 new event topics) | +10 |

## Scope

- Hooked into the developer/admin activation path only — community activations don't create VTIDs and don't graduate to the spec pipeline.
- Skips `already_activated` calls (idempotent re-tries don't change alignment state).

## Verification

- [x] 7/7 new tests pass
- [x] `npm run build` clean (per ALWAYS rule 24)
- [ ] Post-deploy: activate a dev_autopilot rec with contribution_vector={} and economic_axis='none' → confirm `autopilot.alignment.unclear` event appears in `oasis_events` under the new VTID
- [ ] Post-deploy: activate a community rec with a pillar contribution → confirm `autopilot.alignment.served` event with `pillar_impact` in payload

## Out of scope (still later)

- Phase 6: Mission Alignment surfaces in vitana-v1 (My Journey, Calendar, Business Hub) — **different repo**
- Graduation gate: tracking the 14-day window rate + flipping warnings to blocks
- Cron sweep to emit alignment events for historical activations

🤖 Generated with [Claude Code](https://claude.com/claude-code)