### PR TITLE
fix(self-healing): add metadata to pending-tasks SELECT (VTID-02940, Gap 1 enablement)

### DIFF
--- a/services/gateway/src/routes/worker-orchestrator.ts
+++ b/services/gateway/src/routes/worker-orchestrator.ts
@@ -1019,7 +1019,13 @@ workerOrchestratorRouter.get('/api/v1/worker/orchestrator/tasks/pending', async 
       `/rest/v1/vtid_ledger?` +
       `status=in.(scheduled,in_progress)&` +
       `spec_status=eq.approved&` +
-      `select=vtid,title,summary,status,layer,module,created_at,updated_at,claimed_by,claim_expires_at,claim_started_at,is_terminal,spec_status&` +
+      // PR-G (VTID-02940): metadata is REQUIRED for hydratePendingTask to
+      // expose source/autopilot_execution_id to the worker-runner. Without
+      // it, the Gap 1 guard in worker-runner/execution-service.ts can't
+      // detect self-healing tasks and falls through to the local LLM,
+      // hallucinating success. PR #2045's draft included this column; lost
+      // in the squash-merge that landed PR-A.
+      `select=vtid,title,summary,status,layer,module,metadata,created_at,updated_at,claimed_by,claim_expires_at,claim_started_at,is_terminal,spec_status&` +
       `order=created_at.asc&` +
       `limit=${limit * 2}` // Fetch extra to allow for filtering
     );


### PR DESCRIPTION
## Summary
PR-A's `hydratePendingTask` reads `task.metadata` to expose `source` + `autopilot_execution_id` to the worker-runner. The SQL SELECT was missing the `metadata` column, so `task.metadata` was always undefined when the worker received it. PR-E's Gap 1 guard (worker-runner refusing self-healing without bridge) could never fire because `task.metadata?.source === 'self-healing'` was always false.

VTID-02939 third smoke run (2026-05-12 22:30Z) confirmed: bridge failed at "safety gate blocked approval", but worker-runner ran Claude anyway. PR-E's terminalize gate kept the VTID from being marked success, but the upstream guard was bypassed by this missing column.

## Root cause
PR #2045's draft included `metadata` in the pending-tasks SELECT alongside `hydratePendingTask`. When I ported PR-A onto main without first merging #2045, I copied `hydratePendingTask` but lost the SELECT widening. One-character fix, blast radius zero.

## Fix
Add `metadata,` to the column list at line 1022 of `worker-orchestrator.ts`, with a comment pointing at the Gap 1 contract that depends on it.

## Test plan
- [x] `npm run build` — clean except pre-existing `sharp`
- [ ] After merge + EXEC-DEPLOY: re-arm canary, confirm:
  - Worker-runner emits its "Refusing legacy LLM fallback for self-healing task" warning
  - No `worker_runner.exec_started` event for the self-healing VTID
  - VTID terminalizes `failed` (not the lying `success` from before)

## Plan reference
Enables PR-E (#2062) Gap 1 to actually take effect.

🤖 Generated with [Claude Code](https://claude.com/claude-code)