### PR TITLE
feat(orb): B0b-min spine + B2 continuity decision integration (VTID-02941)

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -42511,6 +42511,10 @@ function renderJourneyContextView() {
     // VTID-02930 (B1): Greeting Decay panel — simulated policy decision
     // + reason + evidence + signal source-health. Read-only.
     grid.appendChild(renderJourneyContextGreetingDecayPanel(jc.greetingDecay));
+    // VTID-02932 (B2): Conversation Continuity panel — open threads,
+    // owed promises, recently-kept promises, counts, source-health.
+    // Read-only.
+    grid.appendChild(renderJourneyContextContinuityPanel(jc.continuity));
 
     c.appendChild(grid);
     return c;
@@ -42558,6 +42562,9 @@ function loadJourneyContext() {
         fetch('/api/v1/voice/feature-discovery/preview' + fdQs, { headers: buildContextHeaders() }).then(function (r) { return r.json(); }).catch(function () { return { ok: false }; }),
         fetch('/api/v1/voice/wake-timeline/analysis'  + raQs, { headers: buildContextHeaders() }).then(function (r) { return r.json(); }).catch(function () { return { ok: false }; }),
         fetch('/api/v1/voice/greeting-policy/preview' + gdQs, { headers: buildContextHeaders() }).then(function (r) { return r.json(); }).catch(function () { return { ok: false }; }),
+        // VTID-02932 (B2): conversation continuity preview — open threads
+        // + promises + distilled context. Keyed on user/tenant.
+        fetch('/api/v1/voice/continuity/preview' + qs, { headers: buildContextHeaders() }).then(function (r) { return r.json(); }).catch(function () { return { ok: false }; }),
     ]).then(function (results) {
         jc.loading = false;
         if (results[0] && results[0].ok) {
@@ -42587,6 +42594,11 @@ function loadJourneyContext() {
             jc.greetingDecay = results[5];
         } else {
             jc.greetingDecay = null;
+        }
+        if (results[6] && results[6].ok) {
+            jc.continuity = results[6];
+        } else {
+            jc.continuity = null;
         }
         renderApp();
     }).catch(function (err) {
@@ -42878,6 +42890,124 @@ function renderJourneyContextGreetingDecayPanel(gd) {
     Object.keys(inp).forEach(function (k) {
         panel.appendChild(renderJourneyContextEmptyRow(k, String(inp[k])));
     });
+
+    return panel;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// VTID-02932 (B2): Conversation Continuity panel.
+//
+// Read-only inspection surface for the B2 continuity context the
+// assistant decision layer reads from. Operators read:
+//   - open threads (most recently mentioned first)
+//   - owed promises (oldest due first)
+//   - recently-kept promises (for credit acknowledgement)
+//   - aggregate counts used by the cadence layer
+//   - per-table source-health
+//
+// Wall (B2): NO mutation, NO POST, NO buttons. Selection is read-only;
+// state advancement (creating threads / marking promises) lives in a
+// follow-up slice with its own dedicated event endpoint.
+// ─────────────────────────────────────────────────────────────────────────
+function renderJourneyContextContinuityPanel(co) {
+    var panel = renderJourneyContextPanel(
+        'Conversation Continuity (B2)',
+        'Open threads + owed/kept promises — read-only, no mutation',
+    );
+
+    if (!co) {
+        panel.appendChild(renderJourneyContextEmptyRow('status', 'no data — load a user above'));
+        return panel;
+    }
+
+    var ctx = co.context || {};
+    var counts = ctx.counts || {};
+    var sh = ctx.source_health || {};
+
+    // ---- Counts ----
+    panel.appendChild(renderJourneyContextEmptyRow('open_threads_total', String(counts.open_threads_total || 0)));
+    panel.appendChild(renderJourneyContextEmptyRow('promises_owed_total', String(counts.promises_owed_total || 0)));
+    panel.appendChild(renderJourneyContextEmptyRow('promises_overdue', String(counts.promises_overdue || 0)));
+    panel.appendChild(renderJourneyContextEmptyRow('threads_mentioned_today', String(counts.threads_mentioned_today || 0)));
+
+    // ---- Source health ----
+    var shHeader = document.createElement('div');
+    shHeader.style.cssText = 'margin-top:0.75rem;font-size:0.85rem;font-weight:600;color:var(--color-text-primary);';
+    shHeader.textContent = 'Source health';
+    panel.appendChild(shHeader);
+    var threadsHealth = sh.user_open_threads || { ok: false, reason: 'unknown' };
+    var promisesHealth = sh.assistant_promises || { ok: false, reason: 'unknown' };
+    panel.appendChild(renderJourneyContextEmptyRow(
+        'user_open_threads',
+        threadsHealth.ok ? 'ok' : ('failed: ' + (threadsHealth.reason || 'unknown')),
+    ));
+    panel.appendChild(renderJourneyContextEmptyRow(
+        'assistant_promises',
+        promisesHealth.ok ? 'ok' : ('failed: ' + (promisesHealth.reason || 'unknown')),
+    ));
+
+    // ---- Open threads ----
+    var otHeader = document.createElement('div');
+    otHeader.style.cssText = 'margin-top:0.75rem;font-size:0.85rem;font-weight:600;color:var(--color-text-primary);';
+    otHeader.textContent = 'Open threads (most recent first, capped at 5)';
+    panel.appendChild(otHeader);
+    var openThreads = Array.isArray(ctx.open_threads) ? ctx.open_threads : [];
+    if (openThreads.length === 0) {
+        panel.appendChild(renderJourneyContextEmptyRow('open_threads', 'no open threads'));
+    } else {
+        openThreads.forEach(function (t) {
+            var ageLabel = (t.days_since_last_mention === null || t.days_since_last_mention === undefined)
+                ? '?d'
+                : (t.days_since_last_mention + 'd');
+            panel.appendChild(renderJourneyContextEmptyRow(
+                t.topic + ' [' + ageLabel + ']',
+                t.summary || '(no summary)',
+            ));
+        });
+    }
+
+    // ---- Owed promises ----
+    var opHeader = document.createElement('div');
+    opHeader.style.cssText = 'margin-top:0.75rem;font-size:0.85rem;font-weight:600;color:var(--color-text-primary);';
+    opHeader.textContent = 'Promises owed (oldest due first, capped at 5)';
+    panel.appendChild(opHeader);
+    var promisesOwed = Array.isArray(ctx.promises_owed) ? ctx.promises_owed : [];
+    if (promisesOwed.length === 0) {
+        panel.appendChild(renderJourneyContextEmptyRow('promises_owed', 'no promises owed'));
+    } else {
+        promisesOwed.forEach(function (p) {
+            var dueLabel;
+            if (p.due_at === null || p.due_at === undefined) {
+                dueLabel = 'no due_at';
+            } else if (p.days_overdue === null || p.days_overdue === undefined) {
+                dueLabel = 'due ' + p.due_at;
+            } else if (p.days_overdue > 0) {
+                dueLabel = p.days_overdue + 'd overdue';
+            } else if (p.days_overdue < 0) {
+                dueLabel = 'due in ' + Math.abs(p.days_overdue) + 'd';
+            } else {
+                dueLabel = 'due today';
+            }
+            panel.appendChild(renderJourneyContextEmptyRow(
+                p.promise_text + ' [' + dueLabel + ']',
+                p.decision_id ? ('decision=' + p.decision_id) : '(no decision_id)',
+            ));
+        });
+    }
+
+    // ---- Recently-kept promises ----
+    var kpHeader = document.createElement('div');
+    kpHeader.style.cssText = 'margin-top:0.75rem;font-size:0.85rem;font-weight:600;color:var(--color-text-primary);';
+    kpHeader.textContent = 'Promises kept (last 7 days, capped at 3)';
+    panel.appendChild(kpHeader);
+    var promisesKept = Array.isArray(ctx.promises_kept_recently) ? ctx.promises_kept_recently : [];
+    if (promisesKept.length === 0) {
+        panel.appendChild(renderJourneyContextEmptyRow('promises_kept_recently', 'no promises kept in last 7 days'));
+    } else {
+        promisesKept.forEach(function (p) {
+            panel.appendChild(renderJourneyContextEmptyRow(p.promise_text, 'kept ' + p.kept_at));
+        });
+    }
 
     return panel;
 }

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -30,7 +30,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260504-vtid-02710-ios-ctx-keepalive"></script>
-  <script src="/command-hub/app.js?v=20260511-vtid-02930-greeting-decay"></script>
+  <script src="/command-hub/app.js?v=20260511-vtid-02932-continuity"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
 </body>

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -747,6 +747,11 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const voiceGreetingPolicyRouter = require('./routes/voice-greeting-policy').default;
   mountRouterSync(app, '/api/v1', voiceGreetingPolicyRouter, { owner: 'voice-greeting-policy' });
 
+  // VTID-02932 (B2): Conversation Continuity preview (read-only).
+  // GET /api/v1/voice/continuity/preview
+  const voiceContinuityRouter = require('./routes/voice-continuity').default;
+  mountRouterSync(app, '/api/v1', voiceContinuityRouter, { owner: 'voice-continuity' });
+
   // AI Personality Configuration API
   mountRouterSync(app, '/api/v1/ai-personality', aiPersonalityRouter, { owner: 'ai-personality' });
 

--- a/services/gateway/src/orb/context/compile-assistant-decision-context.ts
+++ b/services/gateway/src/orb/context/compile-assistant-decision-context.ts
@@ -1,0 +1,124 @@
+/**
+ * VTID-02941 (B0b-min) — compileAssistantDecisionContext.
+ *
+ * The orchestrator. Calls each registered provider, collects their
+ * distilled output, and produces ONE `AssistantDecisionContext` the
+ * instruction layer can read.
+ *
+ * In this slice ONLY continuity is wired. The signature is designed so
+ * future slices can plug in additional providers (matchJourney,
+ * conceptMastery, journeyStage, etc.) WITHOUT changing the orchestrator
+ * surface — they each become an optional injected provider.
+ *
+ * Failure policy: every provider runs in its own try/catch boundary. A
+ * thrown error or a Supabase failure becomes `source_health.<source>.ok =
+ * false` with a reason; the field on the context becomes `null`. The
+ * orchestrator NEVER throws upward — a broken provider must not block
+ * prompt assembly (acceptance #6).
+ *
+ * Pure with respect to clock side-effects (now is injected) but does
+ * call providers (which may do IO). Providers are responsible for
+ * their own retries; the orchestrator just passes results through.
+ */
+
+import { defaultContinuityFetcher } from '../../services/continuity/continuity-fetcher';
+import { compileContinuityContext } from '../../services/continuity/compile-continuity-context';
+import {
+  distillContinuityForDecision,
+} from './providers/continuity-decision-provider';
+import type {
+  AssistantDecisionContext,
+  DecisionContinuity,
+} from './types';
+
+export interface CompileAssistantDecisionContextInputs {
+  userId: string;
+  tenantId: string;
+  /** Injected for testability. Production passes Date.now(). */
+  nowMs?: number;
+  /**
+   * Provider overrides for tests. Production passes nothing and we use
+   * the defaults wired into `services/continuity/*`.
+   */
+  providers?: Partial<{
+    continuity: () => Promise<DecisionContinuity | null>;
+  }>;
+  /**
+   * Source-health reporter override for tests — when the provider
+   * returns null, this lets a test stub a reason without monkey-patching
+   * the default fetcher.
+   */
+  reasons?: Partial<{ continuity: string }>;
+}
+
+export async function compileAssistantDecisionContext(
+  input: CompileAssistantDecisionContextInputs,
+): Promise<AssistantDecisionContext> {
+  const continuityRun = await runContinuityProvider(input);
+
+  return {
+    continuity: continuityRun.value,
+    source_health: {
+      continuity: continuityRun.health,
+    },
+  };
+}
+
+interface ProviderRun<T> {
+  value: T | null;
+  health: { ok: boolean; reason?: string };
+}
+
+async function runContinuityProvider(
+  input: CompileAssistantDecisionContextInputs,
+): Promise<ProviderRun<DecisionContinuity>> {
+  const override = input.providers?.continuity;
+  if (override) {
+    try {
+      const value = await override();
+      return { value, health: { ok: true } };
+    } catch (e) {
+      return {
+        value: null,
+        health: { ok: false, reason: (e as Error).message },
+      };
+    }
+  }
+
+  try {
+    const [threadsResult, promisesResult] = await Promise.all([
+      defaultContinuityFetcher.listOpenThreads({
+        tenantId: input.tenantId,
+        userId: input.userId,
+        limit: 50,
+      }),
+      defaultContinuityFetcher.listPromises({
+        tenantId: input.tenantId,
+        userId: input.userId,
+        limit: 50,
+      }),
+    ]);
+
+    // If BOTH fetchers failed, treat the source as degraded. If one
+    // succeeded, the compiler builds a partial-but-typed view and the
+    // adapter can still distill it.
+    const anyOk = threadsResult.ok || promisesResult.ok;
+    if (!anyOk) {
+      const reason =
+        threadsResult.reason || promisesResult.reason || 'continuity_unavailable';
+      return { value: null, health: { ok: false, reason } };
+    }
+
+    const continuity = compileContinuityContext({
+      threadsResult,
+      promisesResult,
+      nowMs: input.nowMs,
+    });
+
+    const decisionView = distillContinuityForDecision({ continuity });
+    return { value: decisionView, health: { ok: true } };
+  } catch (e) {
+    const reason = input.reasons?.continuity ?? (e as Error).message;
+    return { value: null, health: { ok: false, reason } };
+  }
+}

--- a/services/gateway/src/orb/context/providers/continuity-decision-provider.ts
+++ b/services/gateway/src/orb/context/providers/continuity-decision-provider.ts
@@ -1,0 +1,110 @@
+/**
+ * VTID-02941 (B0b-min) — Continuity → AssistantDecisionContext adapter.
+ *
+ * The B2 read-only inspection slice already produced `ContinuityContext`,
+ * a richer shape designed for the Command Hub operator. The assistant
+ * decision layer reads a NARROWER shape (`DecisionContinuity`) that
+ * strips:
+ *   - raw timestamps (kept as boolean `overdue` or `null`)
+ *   - raw last_mentioned_at strings (kept as `days_since_last_mention`)
+ *   - raw kept_at strings (dropped entirely; the LLM only cares the
+ *     promise was kept recently)
+ *
+ * Truncation happens here, NOT in the renderer. By the time data
+ * crosses the adapter boundary, every string is short enough to render
+ * directly into a prompt section.
+ *
+ * Pure function. No IO. The caller is responsible for invoking the
+ * continuity compiler + passing its output here.
+ */
+
+import type { ContinuityContext } from '../../../services/continuity/types';
+import type { DecisionContinuity } from '../types';
+
+const TOPIC_MAX_CHARS = 60;
+const SUMMARY_MAX_CHARS = 120;
+const PROMISE_TEXT_MAX_CHARS = 120;
+
+export interface DistillContinuityInputs {
+  /**
+   * Output of `compileContinuityContext` from B2. Read-only.
+   */
+  continuity: ContinuityContext;
+}
+
+/**
+ * Distills `ContinuityContext` into the decision-grade `DecisionContinuity`.
+ *
+ * Always returns a typed shape (never undefined). The caller decides
+ * whether to attach it to `AssistantDecisionContext.continuity` or set
+ * the field to `null` based on source health.
+ */
+export function distillContinuityForDecision(
+  input: DistillContinuityInputs,
+): DecisionContinuity {
+  const { continuity } = input;
+
+  const open_threads = continuity.open_threads.map((t) => ({
+    thread_id: t.thread_id,
+    topic: truncate(t.topic, TOPIC_MAX_CHARS),
+    summary: t.summary ? truncate(t.summary, SUMMARY_MAX_CHARS) : null,
+    days_since_last_mention: t.days_since_last_mention,
+  }));
+
+  const promises_owed = continuity.promises_owed.map((p) => ({
+    promise_id: p.promise_id,
+    promise_text: truncate(p.promise_text, PROMISE_TEXT_MAX_CHARS),
+    overdue: typeof p.days_overdue === 'number' && p.days_overdue > 0,
+    decision_id: p.decision_id,
+  }));
+
+  const promises_kept_recently = continuity.promises_kept_recently.map((p) => ({
+    promise_id: p.promise_id,
+    promise_text: truncate(p.promise_text, PROMISE_TEXT_MAX_CHARS),
+  }));
+
+  const counts = {
+    open_threads_total: continuity.counts.open_threads_total,
+    promises_owed_total: continuity.counts.promises_owed_total,
+    promises_overdue: continuity.counts.promises_overdue,
+    threads_mentioned_today: continuity.counts.threads_mentioned_today,
+  };
+
+  const recommended_follow_up = pickRecommendedFollowUp({
+    overdue: counts.promises_overdue,
+    owed: counts.promises_owed_total,
+    keptRecently: promises_kept_recently.length,
+    openThreads: counts.open_threads_total,
+  });
+
+  return {
+    open_threads,
+    promises_owed,
+    promises_kept_recently,
+    counts,
+    recommended_follow_up,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — exported for tests
+// ---------------------------------------------------------------------------
+
+export function truncate(s: string, max: number): string {
+  if (typeof s !== 'string') return '';
+  if (s.length <= max) return s;
+  return s.slice(0, Math.max(0, max - 1)) + '…';
+}
+
+export function pickRecommendedFollowUp(args: {
+  overdue: number;
+  owed: number;
+  keptRecently: number;
+  openThreads: number;
+}): DecisionContinuity['recommended_follow_up'] {
+  // Priority: overdue debt > recent credit > open thread mention > nothing.
+  if (args.overdue > 0) return 'address_overdue_promise';
+  if (args.keptRecently > 0) return 'acknowledge_kept_promise';
+  if (args.openThreads > 0) return 'mention_open_thread';
+  return 'none';
+}

--- a/services/gateway/src/orb/context/types.ts
+++ b/services/gateway/src/orb/context/types.ts
@@ -1,0 +1,99 @@
+/**
+ * VTID-02941 (B0b-min) — AssistantDecisionContext: the decision contract.
+ *
+ * This is the SINGLE typed shape the instruction layer reads to assemble
+ * a prompt. Raw rows (memory, threads, messages, promises, profiles)
+ * MUST NOT cross this boundary. The compiler distills; the renderer
+ * formats. No exceptions.
+ *
+ * Wall (B0b-min):
+ *   - Forbidden in this slice: match journey, feature discovery, wake
+ *     brief, continuation contract, greeting decay rewrite, repetition
+ *     suppression, journey stage modulation, reliability tuning.
+ *   - Only `continuity` is wired through this contract in this PR.
+ *   - Adding new fields later is fine; pushing raw rows into them is not.
+ *
+ * Why this file is in `services/gateway/src/orb/context/`:
+ *   The plan's target module layout puts the context spine under
+ *   `services/gateway/src/orb/context/`. We honor that path so future
+ *   slices land in the same place rather than creating a parallel tree.
+ */
+
+/**
+ * Distilled continuity view that the assistant decision layer reads.
+ *
+ * Mirrors `ContinuityContext` from `services/continuity/types.ts` but
+ * narrower — only the fields the LLM needs to make a "should I bring
+ * this up?" decision. NEVER includes raw thread rows, raw promise rows,
+ * raw memory items, message bodies, or profile payloads.
+ */
+export interface DecisionContinuity {
+  /** Top-N open threads, most-recently-mentioned first (capped at 5). */
+  open_threads: ReadonlyArray<{
+    /** Stable thread id (so the LLM can refer to the same thread later). */
+    thread_id: string;
+    /** Short label — already truncated by the compiler. */
+    topic: string;
+    /** Optional one-line summary. NEVER the original message text. */
+    summary: string | null;
+    /** Recency hint. */
+    days_since_last_mention: number | null;
+  }>;
+  /** Owed promises, oldest-due first (capped at 5). */
+  promises_owed: ReadonlyArray<{
+    promise_id: string;
+    /** Short label — already truncated by the compiler. */
+    promise_text: string;
+    /** Boolean is enough for the decision layer; raw timestamps stay out. */
+    overdue: boolean;
+    /** Decision-id linkage when the promise traces back to a ranker decision. */
+    decision_id: string | null;
+  }>;
+  /** Recently-kept promises (capped at 3) — for credit acknowledgement. */
+  promises_kept_recently: ReadonlyArray<{
+    promise_id: string;
+    promise_text: string;
+  }>;
+  /** Aggregate counts the cadence layer uses. */
+  counts: {
+    open_threads_total: number;
+    promises_owed_total: number;
+    promises_overdue: number;
+    threads_mentioned_today: number;
+  };
+  /** Single recommended follow-up KIND (not copy). The renderer formats it. */
+  recommended_follow_up:
+    | 'mention_open_thread'
+    | 'acknowledge_kept_promise'
+    | 'address_overdue_promise'
+    | 'none';
+}
+
+/**
+ * Per-source health view. Empty/missing rows are not failures — they
+ * just mean the user has no continuity state yet. Failures (Supabase
+ * down, schema mismatch, etc.) surface here with a `reason`.
+ */
+export interface DecisionSourceHealth {
+  continuity: { ok: boolean; reason?: string };
+}
+
+/**
+ * The single typed contract the instruction layer reads.
+ *
+ * Future slices add fields (matchJourney, conceptMastery, journeyStage,
+ * etc.) — they MUST land here as distilled shapes, never raw rows.
+ *
+ * `additionalProperties=false` semantics are enforced by tests + the
+ * renderer's behavior: any unrecognized field is silently dropped.
+ */
+export interface AssistantDecisionContext {
+  /**
+   * Continuity decision view. `null` when the compiler had no input or
+   * source-health is degraded — the renderer must emit no continuity
+   * section in that case (acceptance #1 + #6).
+   */
+  continuity: DecisionContinuity | null;
+  /** Per-source health. Always present, even when fields are null. */
+  source_health: DecisionSourceHealth;
+}

--- a/services/gateway/src/orb/live/instruction/decision-contract-renderer.ts
+++ b/services/gateway/src/orb/live/instruction/decision-contract-renderer.ts
@@ -1,0 +1,115 @@
+/**
+ * VTID-02941 (B0b-min) — decision-contract-renderer.
+ *
+ * Single responsibility: take an `AssistantDecisionContext` and
+ * produce a prompt section string the static system instruction can
+ * append.
+ *
+ * The renderer ONLY reads `AssistantDecisionContext`. It MUST NOT:
+ *   - call providers
+ *   - query the database
+ *   - read memory tables
+ *   - touch Supabase directly
+ *   - import from `services/continuity/*` or any compiler module
+ *
+ * Type-level enforcement: the only argument is `AssistantDecisionContext`.
+ * A test asserts the renderer source file contains no `import` from
+ * `services/`, `lib/supabase`, or `fetch`.
+ *
+ * Empty / degraded handling:
+ *   - `decision.continuity === null` → no continuity section is emitted
+ *     (acceptance #1 + #6).
+ *   - `source_health.continuity.ok === false` → a small "[continuity:
+ *     source degraded — <reason>]" hint appears so the prompt remains
+ *     informative without inventing data.
+ *   - Empty arrays → that subsection is omitted, but the overall
+ *     section still renders if any subsection has content.
+ */
+
+import type {
+  AssistantDecisionContext,
+  DecisionContinuity,
+} from '../../context/types';
+
+export interface RenderDecisionContractOptions {
+  /**
+   * When true (default), the renderer prefixes a stable section header
+   * so logs/tests can find the appended block. When false, it omits
+   * the header (useful for inline tests).
+   */
+  withHeader?: boolean;
+}
+
+/**
+ * Renders `decision` as a prompt section string. Returns `''` when the
+ * decision context has no signal to surface AND no source health to
+ * report — i.e., when appending an empty string would just be noise.
+ */
+export function renderDecisionContract(
+  decision: AssistantDecisionContext,
+  opts: RenderDecisionContractOptions = {},
+): string {
+  const withHeader = opts.withHeader !== false;
+
+  const lines: string[] = [];
+
+  // ---- continuity ----
+  const continuitySection = renderContinuity(decision.continuity);
+  const continuityHealth = decision.source_health.continuity;
+
+  if (continuitySection) {
+    lines.push(continuitySection);
+  } else if (continuityHealth && continuityHealth.ok === false) {
+    lines.push(
+      `[continuity: source degraded — ${continuityHealth.reason ?? 'unknown_reason'}]`,
+    );
+  }
+
+  if (lines.length === 0) return '';
+
+  const body = lines.join('\n');
+  return withHeader ? `Assistant decision contract:\n${body}` : body;
+}
+
+// ---------------------------------------------------------------------------
+// Continuity sub-section
+// ---------------------------------------------------------------------------
+
+function renderContinuity(continuity: DecisionContinuity | null): string {
+  if (!continuity) return '';
+
+  const subs: string[] = [];
+
+  if (continuity.open_threads.length > 0) {
+    const lines = continuity.open_threads.map((t) => {
+      const age = t.days_since_last_mention === null
+        ? ''
+        : ` (${t.days_since_last_mention}d since last mention)`;
+      const summary = t.summary ? ` — ${t.summary}` : '';
+      return `  - ${t.topic}${age}${summary}`;
+    });
+    subs.push(['Open threads:', ...lines].join('\n'));
+  }
+
+  if (continuity.promises_owed.length > 0) {
+    const lines = continuity.promises_owed.map((p) => {
+      const overdueTag = p.overdue ? ' [overdue]' : '';
+      return `  - ${p.promise_text}${overdueTag}`;
+    });
+    subs.push(['Promises owed:', ...lines].join('\n'));
+  }
+
+  if (continuity.promises_kept_recently.length > 0) {
+    const lines = continuity.promises_kept_recently.map(
+      (p) => `  - ${p.promise_text}`,
+    );
+    subs.push(['Promises kept recently:', ...lines].join('\n'));
+  }
+
+  if (continuity.recommended_follow_up !== 'none') {
+    subs.push(`Recommended follow-up: ${continuity.recommended_follow_up}`);
+  }
+
+  if (subs.length === 0) return '';
+  return ['Continuity:', ...subs].join('\n');
+}

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -54,6 +54,11 @@ import { defaultWakeTimelineRecorder } from '../services/wake-timeline/wake-time
 // `decideWakeBriefForSession` runs the continuation decision and emits
 // the 3 continuation_decision_* timeline events.
 import { decideWakeBriefForSession } from '../services/wake-brief-wiring';
+// VTID-02941 (B0b-min + B2 decision integration): minimal decision-contract
+// spine. The instruction layer renders the typed contract; the compiler
+// distills. NO raw rows cross this boundary.
+import { compileAssistantDecisionContext } from '../orb/context/compile-assistant-decision-context';
+import { renderDecisionContract } from '../orb/live/instruction/decision-contract-renderer';
 // BOOTSTRAP-VOICE-DEMO: real heartbeats from voice call sites so the agents
 // dashboard reflects live usage instead of fake startup status.
 import { recordAgentHeartbeat } from './agents-registry';
@@ -9088,9 +9093,34 @@ router.post('/chat', optionalAuth, async (req: AuthenticatedRequest, res: Respon
 
     // VTID-01118: Inject cross-turn state context into system instruction
     const stateContext = stateEngine.generateContextString();
-    const systemInstruction = stateContext
+    let systemInstruction = stateContext
       ? `${baseSystemInstruction}\n\n${stateContext}`
       : baseSystemInstruction;
+
+    // VTID-02941 (B0b-min + B2 decision integration): append the decision-
+    // contract section. Continuity is the only signal flowing through the
+    // spine in this slice; future slices add more fields to
+    // AssistantDecisionContext via the same renderer.
+    //
+    // Wall: a thrown error here MUST NOT break the prompt — the contract
+    // is an enrichment layer, never required. We log and continue with the
+    // unaugmented instruction (acceptance #6).
+    if (identity?.tenant_id && identity?.user_id) {
+      try {
+        const decision = await compileAssistantDecisionContext({
+          tenantId: identity.tenant_id,
+          userId: identity.user_id,
+        });
+        const contractSection = renderDecisionContract(decision);
+        if (contractSection) {
+          systemInstruction = `${systemInstruction}\n\n${contractSection}`;
+        }
+      } catch (e) {
+        console.warn(
+          `[VTID-02941] decision contract render failed: ${(e as Error).message}`,
+        );
+      }
+    }
 
     // VTID-01106: Emit memory context injection event
     if (memoryContext && memoryContext.ok && memoryContext.items.length > 0) {

--- a/services/gateway/src/routes/voice-continuity.ts
+++ b/services/gateway/src/routes/voice-continuity.ts
@@ -1,0 +1,69 @@
+/**
+ * VTID-02932 (B2) — Conversation Continuity preview API.
+ *
+ *   GET /api/v1/voice/continuity/preview?userId=…&tenantId=…
+ *
+ * Returns the compiled ContinuityContext + the raw threads/promises
+ * rows the assistant decision layer would see. Read-only.
+ *
+ * Auth: requireExafyAdmin (same as B0c/B0d/B0e/R0/B1 inspection
+ * surfaces).
+ *
+ * Wall: zero mutation paths. Selection is read-only; state
+ * advancement is a follow-up slice with its own dedicated event
+ * endpoint.
+ */
+
+import { Router, Response } from 'express';
+import {
+  requireAuthWithTenant,
+  requireExafyAdmin,
+  AuthenticatedRequest,
+} from '../middleware/auth-supabase-jwt';
+import { defaultContinuityFetcher } from '../services/continuity/continuity-fetcher';
+import { compileContinuityContext } from '../services/continuity/compile-continuity-context';
+
+const router = Router();
+const VTID = 'VTID-02932';
+
+router.get(
+  '/voice/continuity/preview',
+  requireAuthWithTenant,
+  requireExafyAdmin,
+  async (req: AuthenticatedRequest, res: Response) => {
+    try {
+      const userId = typeof req.query.userId === 'string' ? req.query.userId : '';
+      const tenantId = typeof req.query.tenantId === 'string' ? req.query.tenantId : '';
+      if (!userId || !tenantId) {
+        return res.status(400).json({
+          ok: false,
+          error: 'userId and tenantId are required',
+          vtid: VTID,
+        });
+      }
+
+      const [threadsResult, promisesResult] = await Promise.all([
+        defaultContinuityFetcher.listOpenThreads({ tenantId, userId, limit: 50 }),
+        defaultContinuityFetcher.listPromises({ tenantId, userId, limit: 50 }),
+      ]);
+
+      const context = compileContinuityContext({ threadsResult, promisesResult });
+
+      return res.json({
+        ok: true,
+        vtid: VTID,
+        threads: threadsResult.rows,
+        promises: promisesResult.rows,
+        context,
+      });
+    } catch (e) {
+      return res.status(500).json({
+        ok: false,
+        error: (e as Error).message,
+        vtid: VTID,
+      });
+    }
+  },
+);
+
+export default router;

--- a/services/gateway/src/routes/vtid-terminalize.ts
+++ b/services/gateway/src/routes/vtid-terminalize.ts
@@ -433,6 +433,88 @@ router.post('/api/v1/oasis/vtid/terminalize', async (req: Request, res: Response
       });
     }
 
+    // PR-E (VTID-02931, Gap 1): self-healing VTIDs cannot be terminalized
+    // 'success' unless their linked dev_autopilot_executions row reached
+    // status='completed'. This is the authoritative gate — the worker-runner
+    // already refuses local LLM fallback for self-healing without a bridge,
+    // and the self-healing reconciler is the only legitimate path that sets
+    // terminal_outcome='success' (via direct vtid_ledger PATCH, bypassing
+    // this endpoint). Any other caller trying to mark a self-healing VTID
+    // 'success' through this endpoint is misbehaving and gets rejected.
+    if (outcome === 'success' && task.metadata?.source === 'self-healing') {
+      const execId = typeof task.metadata?.autopilot_execution_id === 'string'
+        ? task.metadata.autopilot_execution_id
+        : null;
+
+      if (!execId) {
+        console.warn(
+          `[${VTID}] BLOCKED: self-healing VTID ${vtid} has no autopilot_execution_id in metadata — refusing terminal_outcome='success'`,
+        );
+        await emitOasisEvent(supabaseUrl, svcKey, {
+          vtid,
+          topic: 'self-healing.terminalize.blocked',
+          status: 'warning',
+          message: `Refusing terminal_outcome='success' for ${vtid}: no autopilot execution linkage (bridge failed upstream)`,
+          metadata: {
+            vtid,
+            outcome,
+            actor,
+            reason: 'missing_autopilot_execution_id',
+            healing_state: task.metadata?.healing_state || null,
+            blocked_at: new Date().toISOString(),
+            governance_vtid: 'VTID-02931',
+          },
+        });
+        return res.status(400).json({
+          ok: false,
+          error: 'SELF_HEALING_NO_AUTOPILOT_BRIDGE',
+          message: `Refusing terminal_outcome='success' for self-healing VTID ${vtid}: no autopilot execution linkage. See self-healing.execution.bridge_failed in oasis_events.`,
+          vtid,
+        });
+      }
+
+      const execResp = await fetch(
+        `${supabaseUrl}/rest/v1/dev_autopilot_executions?id=eq.${encodeURIComponent(execId)}&select=id,status,pr_url,pr_number&limit=1`,
+        {
+          headers: {
+            apikey: svcKey,
+            Authorization: `Bearer ${svcKey}`,
+          },
+        },
+      );
+      const execRows = execResp.ok ? ((await execResp.json()) as Array<{ id: string; status: string; pr_url: string | null; pr_number: number | null }>) : [];
+      const execStatus = execRows[0]?.status || 'missing';
+
+      if (execStatus !== 'completed') {
+        console.warn(
+          `[${VTID}] BLOCKED: self-healing VTID ${vtid} terminalize 'success' refused — dev_autopilot_executions.status='${execStatus}' (need 'completed')`,
+        );
+        await emitOasisEvent(supabaseUrl, svcKey, {
+          vtid,
+          topic: 'self-healing.terminalize.blocked',
+          status: 'warning',
+          message: `Refusing terminal_outcome='success' for ${vtid}: autopilot execution status='${execStatus}', not 'completed'`,
+          metadata: {
+            vtid,
+            outcome,
+            actor,
+            reason: 'autopilot_not_completed',
+            autopilot_execution_id: execId,
+            autopilot_status: execStatus,
+            blocked_at: new Date().toISOString(),
+            governance_vtid: 'VTID-02931',
+          },
+        });
+        return res.status(400).json({
+          ok: false,
+          error: 'SELF_HEALING_AUTOPILOT_NOT_COMPLETED',
+          message: `Refusing terminal_outcome='success' for ${vtid}: autopilot execution ${execId.slice(0, 8)} status='${execStatus}', not 'completed'. The self-healing reconciler is the only authorized writer of success for self-healing VTIDs.`,
+          vtid,
+          autopilot_status: execStatus,
+        });
+      }
+    }
+
     // VTID-01204: Pipeline Integrity Gate - Check for full pipeline completion
     const bypassCheck = canBypassPipelineGates(req, outcome);
     if (!bypassCheck.allowed) {

--- a/services/gateway/src/services/continuity/compile-continuity-context.ts
+++ b/services/gateway/src/services/continuity/compile-continuity-context.ts
@@ -1,0 +1,147 @@
+/**
+ * VTID-02932 (B2) — compileContinuityContext.
+ *
+ * Pure function over raw rows. Produces the distilled
+ * ContinuityContext the assistant decision layer reads from:
+ *
+ *   open_threads          — top-N open threads, oldest-touched-first cap
+ *   promises_owed         — owed promises, due-soonest first
+ *   promises_kept_recently — last 7 days of kept promises (for credit)
+ *   counts                — aggregate signals the cadence layer uses
+ *   source_health         — per-table read status
+ *
+ * No IO. No mutation. No clock side-effects (now is injected).
+ */
+
+import type {
+  AssistantPromiseRow,
+  ContinuityContext,
+  OpenThreadRow,
+} from './types';
+
+export interface CompileContinuityContextInputs {
+  threadsResult: { ok: boolean; rows: OpenThreadRow[]; reason?: string };
+  promisesResult: { ok: boolean; rows: AssistantPromiseRow[]; reason?: string };
+  /** Injected for testability. Production passes Date.now(). */
+  nowMs?: number;
+  /** Max open threads to surface to the assistant. Default 5. */
+  openThreadLimit?: number;
+  /** Max owed promises to surface. Default 5. */
+  promisesOwedLimit?: number;
+  /** Max recently-kept promises to surface. Default 3. */
+  promisesKeptLimit?: number;
+}
+
+const DAY_MS = 24 * 60 * 60 * 1000;
+const RECENT_KEPT_WINDOW_MS = 7 * DAY_MS;
+
+export function compileContinuityContext(
+  input: CompileContinuityContextInputs,
+): ContinuityContext {
+  const now = input.nowMs ?? Date.now();
+  const openLimit = input.openThreadLimit ?? 5;
+  const owedLimit = input.promisesOwedLimit ?? 5;
+  const keptLimit = input.promisesKeptLimit ?? 3;
+
+  const threadsRows = input.threadsResult.ok ? input.threadsResult.rows : [];
+  const promisesRows = input.promisesResult.ok ? input.promisesResult.rows : [];
+
+  const openThreads = threadsRows
+    .filter((t) => t.status === 'open')
+    .sort((a, b) => Date.parse(b.last_mentioned_at) - Date.parse(a.last_mentioned_at))
+    .slice(0, openLimit)
+    .map((t) => ({
+      thread_id: t.thread_id,
+      topic: t.topic,
+      summary: t.summary,
+      last_mentioned_at: t.last_mentioned_at,
+      days_since_last_mention: daysBetween(now, Date.parse(t.last_mentioned_at)),
+    }));
+
+  const owed = promisesRows.filter((p) => p.status === 'owed');
+  const promises_owed = [...owed]
+    .sort((a, b) => sortByDueAtAsc(a.due_at, b.due_at))
+    .slice(0, owedLimit)
+    .map((p) => ({
+      promise_id: p.promise_id,
+      promise_text: p.promise_text,
+      due_at: p.due_at,
+      days_overdue: p.due_at ? daysBetween(now, Date.parse(p.due_at), 'overdue') : null,
+      decision_id: p.decision_id,
+    }));
+
+  const promises_kept_recently = promisesRows
+    .filter((p) => p.status === 'kept' && p.kept_at)
+    .filter((p) => {
+      const t = Date.parse(p.kept_at as string);
+      return Number.isFinite(t) && now - t <= RECENT_KEPT_WINDOW_MS;
+    })
+    .sort((a, b) => Date.parse(b.kept_at as string) - Date.parse(a.kept_at as string))
+    .slice(0, keptLimit)
+    .map((p) => ({
+      promise_id: p.promise_id,
+      promise_text: p.promise_text,
+      kept_at: p.kept_at as string,
+    }));
+
+  // Counts.
+  const todayStart = startOfUtcDay(now);
+  const threads_mentioned_today = threadsRows.filter((t) => {
+    const at = Date.parse(t.last_mentioned_at);
+    return Number.isFinite(at) && at >= todayStart;
+  }).length;
+  const promises_overdue = owed.filter((p) => {
+    if (!p.due_at) return false;
+    const t = Date.parse(p.due_at);
+    return Number.isFinite(t) && t < now;
+  }).length;
+
+  return {
+    open_threads: openThreads,
+    promises_owed,
+    promises_kept_recently,
+    counts: {
+      open_threads_total: threadsRows.filter((t) => t.status === 'open').length,
+      promises_owed_total: owed.length,
+      promises_overdue,
+      threads_mentioned_today,
+    },
+    source_health: {
+      user_open_threads: input.threadsResult.ok
+        ? { ok: true }
+        : { ok: false, reason: input.threadsResult.reason ?? 'unknown_failure' },
+      assistant_promises: input.promisesResult.ok
+        ? { ok: true }
+        : { ok: false, reason: input.promisesResult.reason ?? 'unknown_failure' },
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — exported for tests
+// ---------------------------------------------------------------------------
+
+function daysBetween(nowMs: number, thenMs: number, mode: 'ago' | 'overdue' = 'ago'): number | null {
+  if (!Number.isFinite(thenMs)) return null;
+  const diffMs = mode === 'overdue' ? nowMs - thenMs : nowMs - thenMs;
+  if (diffMs < 0) {
+    // For "overdue" semantics, a future due_at means NOT overdue → return negative
+    // days (caller can render "due in N days"). For "ago", a future "then"
+    // shouldn't happen but we still return a negative count rather than crash.
+    return Math.ceil(diffMs / DAY_MS);
+  }
+  return Math.floor(diffMs / DAY_MS);
+}
+
+function sortByDueAtAsc(a: string | null, b: string | null): number {
+  // null due_at sorts AFTER any present due_at (less urgent).
+  if (a === null && b === null) return 0;
+  if (a === null) return 1;
+  if (b === null) return -1;
+  return Date.parse(a) - Date.parse(b);
+}
+
+function startOfUtcDay(nowMs: number): number {
+  const d = new Date(nowMs);
+  return Date.UTC(d.getUTCFullYear(), d.getUTCMonth(), d.getUTCDate());
+}

--- a/services/gateway/src/services/continuity/continuity-fetcher.ts
+++ b/services/gateway/src/services/continuity/continuity-fetcher.ts
@@ -1,0 +1,163 @@
+/**
+ * VTID-02932 (B2) — Supabase-backed continuity fetcher.
+ *
+ * Read-only by design. NO write/mutator methods on the interface —
+ * state advancement (creating threads / marking promises kept/broken)
+ * lives in a follow-up slice behind dedicated event paths. Even
+ * adding an `upsert*` method here would violate the B2 wall.
+ *
+ * Failure policy: any Supabase error returns empty arrays + source-
+ * health flagged. We never throw upward — the continuity context is
+ * an enrichment layer, never a wake-blocker.
+ */
+
+import { getSupabase } from '../../lib/supabase';
+import type {
+  OpenThreadRow,
+  AssistantPromiseRow,
+  OpenThreadStatus,
+  PromiseStatus,
+} from './types';
+
+export interface ContinuityFetcher {
+  listOpenThreads(args: {
+    tenantId: string;
+    userId: string;
+    /** Default 20. Capped at 50. */
+    limit?: number;
+  }): Promise<{ ok: boolean; rows: OpenThreadRow[]; reason?: string }>;
+  listPromises(args: {
+    tenantId: string;
+    userId: string;
+    /** Default 20. Capped at 50. */
+    limit?: number;
+    /** Filter by status. When absent, returns all statuses. */
+    status?: PromiseStatus;
+  }): Promise<{ ok: boolean; rows: AssistantPromiseRow[]; reason?: string }>;
+}
+
+export interface SupabaseContinuityFetcherOptions {
+  getDb?: typeof getSupabase;
+}
+
+export function createSupabaseContinuityFetcher(
+  opts: SupabaseContinuityFetcherOptions = {},
+): ContinuityFetcher {
+  const getDb = opts.getDb ?? getSupabase;
+
+  return {
+    async listOpenThreads(args) {
+      const limit = clampLimit(args.limit);
+      const sb = getDb();
+      if (!sb) {
+        return { ok: false, rows: [], reason: 'supabase_unconfigured' };
+      }
+      try {
+        const { data, error } = await sb
+          .from('user_open_threads')
+          .select(
+            'thread_id, topic, summary, status, session_id_first, session_id_last, last_mentioned_at, resolved_at, created_at, updated_at',
+          )
+          .eq('tenant_id', args.tenantId)
+          .eq('user_id', args.userId)
+          .order('last_mentioned_at', { ascending: false })
+          .limit(limit);
+        if (error) {
+          return { ok: false, rows: [], reason: error.message };
+        }
+        if (!Array.isArray(data)) {
+          return { ok: true, rows: [] };
+        }
+        return { ok: true, rows: data.map(mapThreadRow) };
+      } catch (e) {
+        return { ok: false, rows: [], reason: (e as Error).message };
+      }
+    },
+
+    async listPromises(args) {
+      const limit = clampLimit(args.limit);
+      const sb = getDb();
+      if (!sb) {
+        return { ok: false, rows: [], reason: 'supabase_unconfigured' };
+      }
+      try {
+        let q = sb
+          .from('assistant_promises')
+          .select(
+            'promise_id, thread_id, session_id, promise_text, due_at, status, decision_id, kept_at, created_at, updated_at',
+          )
+          .eq('tenant_id', args.tenantId)
+          .eq('user_id', args.userId)
+          .order('created_at', { ascending: false })
+          .limit(limit);
+        if (args.status) q = q.eq('status', args.status);
+        const { data, error } = await q;
+        if (error) {
+          return { ok: false, rows: [], reason: error.message };
+        }
+        if (!Array.isArray(data)) {
+          return { ok: true, rows: [] };
+        }
+        return { ok: true, rows: data.map(mapPromiseRow) };
+      } catch (e) {
+        return { ok: false, rows: [], reason: (e as Error).message };
+      }
+    },
+  };
+}
+
+export const defaultContinuityFetcher = createSupabaseContinuityFetcher();
+
+// ---------------------------------------------------------------------------
+// Row mappers — exported for tests
+// ---------------------------------------------------------------------------
+
+function clampLimit(raw: number | undefined): number {
+  if (typeof raw !== 'number' || !Number.isFinite(raw)) return 20;
+  return Math.max(1, Math.min(50, Math.trunc(raw)));
+}
+
+const KNOWN_THREAD_STATUSES: ReadonlySet<OpenThreadStatus> = new Set<OpenThreadStatus>([
+  'open', 'resolved', 'abandoned',
+]);
+const KNOWN_PROMISE_STATUSES: ReadonlySet<PromiseStatus> = new Set<PromiseStatus>([
+  'owed', 'kept', 'broken', 'cancelled',
+]);
+
+export function mapThreadRow(row: Record<string, unknown>): OpenThreadRow {
+  const statusRaw = typeof row.status === 'string' ? row.status : 'open';
+  const status: OpenThreadStatus = KNOWN_THREAD_STATUSES.has(statusRaw as OpenThreadStatus)
+    ? (statusRaw as OpenThreadStatus)
+    : 'open';
+  return {
+    thread_id: String(row.thread_id ?? ''),
+    topic: String(row.topic ?? ''),
+    summary: typeof row.summary === 'string' ? row.summary : null,
+    status,
+    session_id_first: typeof row.session_id_first === 'string' ? row.session_id_first : null,
+    session_id_last: typeof row.session_id_last === 'string' ? row.session_id_last : null,
+    last_mentioned_at: String(row.last_mentioned_at ?? ''),
+    resolved_at: typeof row.resolved_at === 'string' ? row.resolved_at : null,
+    created_at: String(row.created_at ?? ''),
+    updated_at: String(row.updated_at ?? ''),
+  };
+}
+
+export function mapPromiseRow(row: Record<string, unknown>): AssistantPromiseRow {
+  const statusRaw = typeof row.status === 'string' ? row.status : 'owed';
+  const status: PromiseStatus = KNOWN_PROMISE_STATUSES.has(statusRaw as PromiseStatus)
+    ? (statusRaw as PromiseStatus)
+    : 'owed';
+  return {
+    promise_id: String(row.promise_id ?? ''),
+    thread_id: typeof row.thread_id === 'string' ? row.thread_id : null,
+    session_id: typeof row.session_id === 'string' ? row.session_id : null,
+    promise_text: String(row.promise_text ?? ''),
+    due_at: typeof row.due_at === 'string' ? row.due_at : null,
+    status,
+    decision_id: typeof row.decision_id === 'string' ? row.decision_id : null,
+    kept_at: typeof row.kept_at === 'string' ? row.kept_at : null,
+    created_at: String(row.created_at ?? ''),
+    updated_at: String(row.updated_at ?? ''),
+  };
+}

--- a/services/gateway/src/services/continuity/types.ts
+++ b/services/gateway/src/services/continuity/types.ts
@@ -1,0 +1,92 @@
+/**
+ * VTID-02932 (B2) — conversation continuity types.
+ *
+ * These shapes drive signals 40–45 of the AssistantDecisionContext:
+ *   #40 last_session_topic_summary
+ *   #41 recurring_topics_last_30d
+ *   #42 open_threads
+ *   #43 vitana_promises
+ *   #44 last_unresolved_intent       (deferred — needs intents table read)
+ *   #45 topics_discussed_today
+ *
+ * Wall: pure types. No IO, no mutation. The fetcher is read-only;
+ * state advancement (creating threads / marking promises) lives in
+ * a follow-up slice and never goes through this module.
+ */
+
+export type OpenThreadStatus = 'open' | 'resolved' | 'abandoned';
+export type PromiseStatus = 'owed' | 'kept' | 'broken' | 'cancelled';
+
+export interface OpenThreadRow {
+  thread_id: string;
+  topic: string;
+  summary: string | null;
+  status: OpenThreadStatus;
+  session_id_first: string | null;
+  session_id_last: string | null;
+  last_mentioned_at: string;
+  resolved_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface AssistantPromiseRow {
+  promise_id: string;
+  thread_id: string | null;
+  session_id: string | null;
+  promise_text: string;
+  due_at: string | null;
+  status: PromiseStatus;
+  decision_id: string | null;
+  kept_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/**
+ * Compiled continuity context — what the assistant decision layer
+ * consumes. Distilled from the raw rows; never carries the rows
+ * themselves.
+ *
+ * Mirrors the AssistantDecisionContext spirit from B0b: the prompt
+ * sees the distilled view, never the raw DB rows.
+ */
+export interface ContinuityContext {
+  /** Signal #42 (open) — most recently-touched first, capped. */
+  open_threads: Array<{
+    thread_id: string;
+    topic: string;
+    summary: string | null;
+    last_mentioned_at: string;
+    days_since_last_mention: number | null;
+  }>;
+  /** Signal #43 — owed promises, oldest-due first. */
+  promises_owed: Array<{
+    promise_id: string;
+    promise_text: string;
+    due_at: string | null;
+    days_overdue: number | null;
+    decision_id: string | null;
+  }>;
+  /** Recently-kept promises (for credit acknowledgement). Capped. */
+  promises_kept_recently: Array<{
+    promise_id: string;
+    promise_text: string;
+    kept_at: string;
+  }>;
+  /** Counts the assistant uses for cadence decisions. */
+  counts: {
+    open_threads_total: number;
+    promises_owed_total: number;
+    promises_overdue: number;
+    threads_mentioned_today: number;
+  };
+  /**
+   * Source-health view — empty arrays + a `reason` is "user has no
+   * continuity state yet", not a failure. Failures surface here.
+   */
+  source_health: {
+    user_open_threads: { ok: boolean; reason?: string };
+    assistant_promises: { ok: boolean; reason?: string };
+  };
+}

--- a/services/gateway/src/services/notification-service.ts
+++ b/services/gateway/src/services/notification-service.ts
@@ -537,30 +537,23 @@ export async function notifyUser(
   }
 
   // ── 5. Send push — FCM first, Appilix as fallback ──────
-  // Only send ONE push per user to avoid duplicate notifications.
-  // FCM covers desktop Chrome + mobile Chrome; Appilix covers Maxina app
-  // users who have no FCM tokens registered.
+  // Single dispatch policy: FCM first, Appilix fallback.
   //
-  // Appilix native push honors open_link_url (deep-links into the app).
-  // FCM in the Appilix WebView does NOT support deep-links (no service
-  // worker / Notification API). So when the payload has a URL, prefer
-  // Appilix for mobile users, with FCM as fallback for desktop browsers.
-  // For desktop-only users, Appilix fails silently → FCM delivers.
+  // Historically chat-category notifications routed through Appilix first
+  // because we only had web-push FCM tokens (which open the browser, not
+  // the app). Per Appilix support, their iOS wrapper exposes the native
+  // FCM token via a JS bridge (appilix.postMessage({type:"firebase_token"}))
+  // which the frontend now registers in user_device_tokens. With native
+  // tokens stored, Firebase Admin SDK delivers via APNs straight to the
+  // installed app — bypassing Appilix's user_identity routing layer
+  // entirely. Appilix remains as fallback for users whose token isn't
+  // registered yet.
   let pushed = 0;
   let appilixSent = false;
   if (shouldSendPush) {
-    if (payload.data?.url) {
-      // Notification with deep-link URL → Appilix first
+    pushed = await sendPushToUser(userId, tenantId, payload, supabase);
+    if (pushed === 0) {
       appilixSent = await sendAppilixPush(userId, payload);
-      if (!appilixSent) {
-        pushed = await sendPushToUser(userId, tenantId, payload, supabase);
-      }
-    } else {
-      // Notification without URL → FCM first, Appilix fallback
-      pushed = await sendPushToUser(userId, tenantId, payload, supabase);
-      if (pushed === 0) {
-        appilixSent = await sendAppilixPush(userId, payload);
-      }
     }
   }
 

--- a/services/gateway/src/services/self-healing-diagnosis-service.ts
+++ b/services/gateway/src/services/self-healing-diagnosis-service.ts
@@ -46,9 +46,16 @@ const INDEX_PATH = path.join(REPO_ROOT, 'services/gateway/src/index.ts');
 // reports "route file does not exist". We fall back to GitHub at the SHA the
 // running container was built from (BUILD_INFO.sha) and only as last resort
 // to ref=main, which may have drifted ahead of the deployed revision.
-const GITHUB_OWNER = process.env.GITHUB_REPO_OWNER || 'exafyltd';
-const GITHUB_REPO = process.env.GITHUB_REPO_NAME || 'vitana-platform';
-const GITHUB_TOKEN = process.env.GITHUB_SAFE_MERGE_TOKEN || process.env.GITHUB_TOKEN || '';
+// Env reads at module load are brittle — tests + operators can override
+// at runtime via DEPLOYED_GIT_SHA / BUILD_SHA / GITHUB_SAFE_MERGE_TOKEN,
+// and the values must be honored even if they're set AFTER imports.
+function githubAuthEnv(): { owner: string; repo: string; token: string } {
+  return {
+    owner: process.env.GITHUB_REPO_OWNER || 'exafyltd',
+    repo: process.env.GITHUB_REPO_NAME || 'vitana-platform',
+    token: process.env.GITHUB_SAFE_MERGE_TOKEN || process.env.GITHUB_TOKEN || '',
+  };
+}
 
 // Read every call so tests + operators can override at runtime; the work
 // is cheap (env read + at most one fs.readFileSync of a tiny JSON file).
@@ -87,15 +94,16 @@ async function fetchFromGithub(
   relativeFile: string,
   ref: string,
 ): Promise<{ ok: boolean; content?: string; sha?: string }> {
-  if (!GITHUB_TOKEN) {
+  const { owner, repo, token } = githubAuthEnv();
+  if (!token) {
     return { ok: false };
   }
   const encoded = relativeFile.split('/').map(encodeURIComponent).join('/');
-  const url = `https://api.github.com/repos/${GITHUB_OWNER}/${GITHUB_REPO}/contents/${encoded}?ref=${encodeURIComponent(ref)}`;
+  const url = `https://api.github.com/repos/${owner}/${repo}/contents/${encoded}?ref=${encodeURIComponent(ref)}`;
   try {
     const res = await fetch(url, {
       headers: {
-        Authorization: `Bearer ${GITHUB_TOKEN}`,
+        Authorization: `Bearer ${token}`,
         Accept: 'application/vnd.github+json',
         'X-GitHub-Api-Version': '2022-11-28',
       },
@@ -297,8 +305,10 @@ export async function runDeepDiagnosis(
   // Layer 4 — Dependency Analysis
   const dependencyAnalysis = analyzeDependencies(codebaseAnalysis, evidence);
 
-  // Layer 5 — Workflow Analysis
-  const workflowAnalysis = analyzeWorkflow(failure, codebaseAnalysis, evidence, filesRead);
+  // Layer 5 — Workflow Analysis (PR-F: GitHub-fallback aware so Cloud Run
+  // can see whether routes are mounted in index.ts even without the source
+  // tree on disk; shares the same sourceCache as Layer 2).
+  const workflowAnalysis = await analyzeWorkflow(failure, codebaseAnalysis, evidence, filesRead, sourceCache);
 
   // Layer 6 — OASIS Correlation
   const { oasisEvidence, priorAttempts } = await correlateOasis(failure, vtid, evidence);
@@ -746,12 +756,13 @@ function analyzeDependencies(
 // Layer 5: Workflow Analysis
 // ---------------------------------------------------------------------------
 
-function analyzeWorkflow(
+async function analyzeWorkflow(
   failure: ServiceStatus,
   codebase: CodebaseAnalysis,
   evidence: string[],
   filesRead: string[],
-): WorkflowAnalysis {
+  sourceCache?: Map<string, LoadedSource>,
+): Promise<WorkflowAnalysis> {
   const result: WorkflowAnalysis = {
     route_mounted_in_index: false,
     mount_path: null,
@@ -763,12 +774,28 @@ function analyzeWorkflow(
     evidence: [],
   };
 
-  // Read index.ts to check route mounting
+  // PR-F (VTID-02933, Gap 2): Cloud Run revisions don't carry the source
+  // tree under REPO_ROOT, so the old fs-only read of index.ts ENOENT-failed
+  // on every live diagnosis. That falsely synthesized route_mounted_in_index
+  // = false on EVERY endpoint and tipped the synthesizer into proposing
+  // `files_to_modify=['services/gateway/src/index.ts']`. The autopilot
+  // safety gate then (correctly) blocked edits to that high-blast-radius
+  // file at "safety gate blocked approval", which surfaced as Gap 1 in the
+  // VTID-02928 smoke run. Routing the same loadSourceFile() PR-C uses
+  // fixes it: fs → deployed SHA → ref=main, with the same redaction
+  // contract.
   let indexContent: string | null = null;
   try {
-    if (fs.existsSync(INDEX_PATH)) {
-      indexContent = fs.readFileSync(INDEX_PATH, 'utf-8');
+    const loaded = await loadSourceFile('services/gateway/src/index.ts', sourceCache);
+    if (loaded.found && loaded.content) {
+      indexContent = loaded.content;
       filesRead.push('services/gateway/src/index.ts');
+      if (loaded.source !== 'fs') {
+        result.evidence.push(
+          `index.ts loaded via ${loaded.source}` +
+            (loaded.sha ? ` (sha=${loaded.sha.substring(0, 7)})` : ''),
+        );
+      }
     }
   } catch (err: any) {
     result.evidence.push(`Cannot read index.ts: ${err.message}`);
@@ -777,7 +804,7 @@ function analyzeWorkflow(
   }
 
   if (!indexContent) {
-    result.evidence.push('index.ts not found — cannot verify route mounting');
+    result.evidence.push('index.ts not found via fs OR GitHub — cannot verify route mounting');
     return result;
   }
 

--- a/services/gateway/test/orb/context/compile-assistant-decision-context.test.ts
+++ b/services/gateway/test/orb/context/compile-assistant-decision-context.test.ts
@@ -1,0 +1,95 @@
+/**
+ * VTID-02941 (B0b-min) — compileAssistantDecisionContext orchestrator tests.
+ *
+ * Acceptance:
+ *   #1 — empty continuity produces a valid AssistantDecisionContext with
+ *        safe empty defaults
+ *   #6 — if the continuity compiler throws, prompt still renders with
+ *        sourceHealth=degraded and no crash
+ *
+ * The orchestrator MUST:
+ *   - never throw upward
+ *   - attach reason on source_health when the provider fails
+ *   - return continuity:null when source health is degraded
+ *   - accept provider overrides for tests
+ */
+
+import { compileAssistantDecisionContext } from '../../../src/orb/context/compile-assistant-decision-context';
+import type { DecisionContinuity } from '../../../src/orb/context/types';
+
+describe('B0b-min — compileAssistantDecisionContext', () => {
+  describe('happy path with provider override', () => {
+    it('attaches the provider output to .continuity', async () => {
+      const stub: DecisionContinuity = {
+        open_threads: [],
+        promises_owed: [],
+        promises_kept_recently: [],
+        counts: {
+          open_threads_total: 0,
+          promises_owed_total: 0,
+          promises_overdue: 0,
+          threads_mentioned_today: 0,
+        },
+        recommended_follow_up: 'none',
+      };
+      const out = await compileAssistantDecisionContext({
+        userId: 'u',
+        tenantId: 't',
+        providers: { continuity: async () => stub },
+      });
+      expect(out.continuity).toEqual(stub);
+      expect(out.source_health.continuity.ok).toBe(true);
+    });
+  });
+
+  describe('provider throws (acceptance #6)', () => {
+    it('returns continuity:null + source_health.ok=false + reason', async () => {
+      const out = await compileAssistantDecisionContext({
+        userId: 'u',
+        tenantId: 't',
+        providers: {
+          continuity: async () => {
+            throw new Error('boom');
+          },
+        },
+      });
+      expect(out.continuity).toBeNull();
+      expect(out.source_health.continuity.ok).toBe(false);
+      expect(out.source_health.continuity.reason).toBe('boom');
+    });
+  });
+
+  describe('provider returns null (acceptance #1)', () => {
+    it('attaches null + ok:true (provider deliberately suppressed)', async () => {
+      const out = await compileAssistantDecisionContext({
+        userId: 'u',
+        tenantId: 't',
+        providers: { continuity: async () => null },
+      });
+      expect(out.continuity).toBeNull();
+      expect(out.source_health.continuity.ok).toBe(true);
+    });
+  });
+
+  describe('always returns a typed shape', () => {
+    it('source_health.continuity is always present', async () => {
+      const out = await compileAssistantDecisionContext({
+        userId: 'u',
+        tenantId: 't',
+        providers: { continuity: async () => null },
+      });
+      expect(out.source_health).toBeDefined();
+      expect(out.source_health.continuity).toBeDefined();
+    });
+
+    it('result has only known top-level keys (no leakage)', async () => {
+      const out = await compileAssistantDecisionContext({
+        userId: 'u',
+        tenantId: 't',
+        providers: { continuity: async () => null },
+      });
+      const keys = Object.keys(out).sort();
+      expect(keys).toEqual(['continuity', 'source_health']);
+    });
+  });
+});

--- a/services/gateway/test/orb/context/continuity-decision-provider.test.ts
+++ b/services/gateway/test/orb/context/continuity-decision-provider.test.ts
@@ -1,0 +1,204 @@
+/**
+ * VTID-02941 (B0b-min) — continuity-decision-provider adapter tests.
+ *
+ * Acceptance #2: continuity data is distilled (allowed: counts, short
+ * labels, due/overdue flags, recommended follow-up kind, source
+ * health). Forbidden: raw messages, raw promises, raw memory rows,
+ * raw profile payloads.
+ *
+ * The adapter MUST:
+ *   - drop raw timestamps in favor of booleans/short hints
+ *   - truncate long strings (topic / summary / promise_text)
+ *   - keep IDs (thread_id / promise_id / decision_id) for reference
+ *   - never surface kept_at / due_at / last_mentioned_at / resolved_at
+ */
+
+import {
+  distillContinuityForDecision,
+  pickRecommendedFollowUp,
+  truncate,
+} from '../../../src/orb/context/providers/continuity-decision-provider';
+import type { ContinuityContext } from '../../../src/services/continuity/types';
+
+function makeContext(over: Partial<ContinuityContext> = {}): ContinuityContext {
+  return {
+    open_threads: [],
+    promises_owed: [],
+    promises_kept_recently: [],
+    counts: {
+      open_threads_total: 0,
+      promises_owed_total: 0,
+      promises_overdue: 0,
+      threads_mentioned_today: 0,
+    },
+    source_health: {
+      user_open_threads: { ok: true },
+      assistant_promises: { ok: true },
+    },
+    ...over,
+  };
+}
+
+describe('B0b-min — distillContinuityForDecision', () => {
+  describe('forbidden raw fields are NOT surfaced', () => {
+    it('drops last_mentioned_at, resolved_at, created_at, updated_at on threads', () => {
+      const ctx = makeContext({
+        open_threads: [
+          {
+            thread_id: 't1',
+            topic: 'magnesium',
+            summary: 'follow-up',
+            last_mentioned_at: '2026-05-10T12:00:00Z',
+            days_since_last_mention: 3,
+          },
+        ],
+      });
+      const out = distillContinuityForDecision({ continuity: ctx });
+      expect(out.open_threads[0]).toEqual({
+        thread_id: 't1',
+        topic: 'magnesium',
+        summary: 'follow-up',
+        days_since_last_mention: 3,
+      });
+      const keys = Object.keys(out.open_threads[0]).sort();
+      expect(keys).toEqual([
+        'days_since_last_mention',
+        'summary',
+        'thread_id',
+        'topic',
+      ]);
+    });
+
+    it('drops due_at, days_overdue, kept_at on promises (overdue becomes a boolean)', () => {
+      const ctx = makeContext({
+        promises_owed: [
+          {
+            promise_id: 'p1',
+            promise_text: 'remind me at 8pm',
+            due_at: '2026-05-10T20:00:00Z',
+            days_overdue: 2,
+            decision_id: 'd1',
+          },
+        ],
+      });
+      const out = distillContinuityForDecision({ continuity: ctx });
+      expect(out.promises_owed[0]).toEqual({
+        promise_id: 'p1',
+        promise_text: 'remind me at 8pm',
+        overdue: true,
+        decision_id: 'd1',
+      });
+      const keys = Object.keys(out.promises_owed[0]).sort();
+      expect(keys).toEqual(['decision_id', 'overdue', 'promise_id', 'promise_text']);
+    });
+
+    it('drops kept_at on promises_kept_recently', () => {
+      const ctx = makeContext({
+        promises_kept_recently: [
+          {
+            promise_id: 'k1',
+            promise_text: 'sent that doc',
+            kept_at: '2026-05-09T10:00:00Z',
+          },
+        ],
+      });
+      const out = distillContinuityForDecision({ continuity: ctx });
+      expect(out.promises_kept_recently[0]).toEqual({
+        promise_id: 'k1',
+        promise_text: 'sent that doc',
+      });
+      const keys = Object.keys(out.promises_kept_recently[0]).sort();
+      expect(keys).toEqual(['promise_id', 'promise_text']);
+    });
+  });
+
+  describe('overdue boolean', () => {
+    it('true when days_overdue > 0', () => {
+      const out = distillContinuityForDecision({
+        continuity: makeContext({
+          promises_owed: [
+            { promise_id: 'p', promise_text: 't', due_at: null, days_overdue: 5, decision_id: null },
+          ],
+        }),
+      });
+      expect(out.promises_owed[0].overdue).toBe(true);
+    });
+
+    it('false when days_overdue is null', () => {
+      const out = distillContinuityForDecision({
+        continuity: makeContext({
+          promises_owed: [
+            { promise_id: 'p', promise_text: 't', due_at: null, days_overdue: null, decision_id: null },
+          ],
+        }),
+      });
+      expect(out.promises_owed[0].overdue).toBe(false);
+    });
+
+    it('false when days_overdue is negative (future-due)', () => {
+      const out = distillContinuityForDecision({
+        continuity: makeContext({
+          promises_owed: [
+            { promise_id: 'p', promise_text: 't', due_at: null, days_overdue: -2, decision_id: null },
+          ],
+        }),
+      });
+      expect(out.promises_owed[0].overdue).toBe(false);
+    });
+  });
+
+  describe('truncation', () => {
+    it('truncates long topics to 60 chars', () => {
+      const long = 'a'.repeat(200);
+      const out = distillContinuityForDecision({
+        continuity: makeContext({
+          open_threads: [
+            { thread_id: 't', topic: long, summary: null, last_mentioned_at: '', days_since_last_mention: 0 },
+          ],
+        }),
+      });
+      expect(out.open_threads[0].topic.length).toBeLessThanOrEqual(60);
+      expect(out.open_threads[0].topic.endsWith('…')).toBe(true);
+    });
+
+    it('truncates long summaries to 120 chars', () => {
+      const long = 'b'.repeat(500);
+      const out = distillContinuityForDecision({
+        continuity: makeContext({
+          open_threads: [
+            { thread_id: 't', topic: 'x', summary: long, last_mentioned_at: '', days_since_last_mention: 0 },
+          ],
+        }),
+      });
+      expect((out.open_threads[0].summary ?? '').length).toBeLessThanOrEqual(120);
+    });
+
+    it('truncates long promise_text to 120 chars', () => {
+      const long = 'c'.repeat(500);
+      const out = distillContinuityForDecision({
+        continuity: makeContext({
+          promises_owed: [
+            { promise_id: 'p', promise_text: long, due_at: null, days_overdue: null, decision_id: null },
+          ],
+        }),
+      });
+      expect(out.promises_owed[0].promise_text.length).toBeLessThanOrEqual(120);
+    });
+
+    it('truncate helper preserves short strings byte-for-byte', () => {
+      expect(truncate('abc', 60)).toBe('abc');
+      expect(truncate('exactly_60_chars_______________________________________exact', 60)).toBe(
+        'exactly_60_chars_______________________________________exact',
+      );
+    });
+  });
+
+  describe('pickRecommendedFollowUp priority', () => {
+    it('overdue beats kept beats threads beats none', () => {
+      expect(pickRecommendedFollowUp({ overdue: 1, owed: 1, keptRecently: 1, openThreads: 1 })).toBe('address_overdue_promise');
+      expect(pickRecommendedFollowUp({ overdue: 0, owed: 0, keptRecently: 1, openThreads: 1 })).toBe('acknowledge_kept_promise');
+      expect(pickRecommendedFollowUp({ overdue: 0, owed: 0, keptRecently: 0, openThreads: 1 })).toBe('mention_open_thread');
+      expect(pickRecommendedFollowUp({ overdue: 0, owed: 0, keptRecently: 0, openThreads: 0 })).toBe('none');
+    });
+  });
+});

--- a/services/gateway/test/orb/context/decision-context-types.test.ts
+++ b/services/gateway/test/orb/context/decision-context-types.test.ts
@@ -1,0 +1,71 @@
+/**
+ * VTID-02941 (B0b-min) — type-level enforcement of the decision contract.
+ *
+ * Acceptance #2 + #7: raw fields MUST NOT pass through the schema.
+ *
+ * We can't enforce TypeScript structural typing at runtime, so we use
+ * the renderer's output as the observable boundary: when fed a stub
+ * decision with raw-looking extra fields, the renderer must NOT
+ * surface them (and the type system will reject them at compile time,
+ * which we assert by structural inspection of the types file).
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const TYPES_PATH = join(__dirname, '../../../src/orb/context/types.ts');
+
+describe('B0b-min — AssistantDecisionContext type guards', () => {
+  let typesSrc: string;
+  beforeAll(() => {
+    typesSrc = readFileSync(TYPES_PATH, 'utf8');
+  });
+
+  describe('forbidden raw fields are NOT declared in DecisionContinuity', () => {
+    // These fields exist in the underlying ContinuityContext / Supabase
+    // rows but MUST NOT appear in DecisionContinuity. If a future change
+    // adds any of them, this test fails — that's the wall.
+    const forbiddenFields = [
+      'session_id_first',
+      'session_id_last',
+      'last_mentioned_at',
+      'resolved_at',
+      'created_at',
+      'updated_at',
+      'due_at',
+      'kept_at',
+      'days_overdue',
+      'days_since_last_mention', // intentionally allowed on open_threads (recency hint)
+    ];
+
+    // days_since_last_mention is ALLOWED. Re-filter.
+    const trulyForbidden = forbiddenFields.filter(
+      (f) => f !== 'days_since_last_mention',
+    );
+
+    it.each(trulyForbidden)('does not declare %s anywhere', (field) => {
+      // Match field-name as a TypeScript declaration: `<name>:` or `<name>?:`
+      const decl = new RegExp(`\\b${field}\\s*\\??:`, 'g');
+      expect(typesSrc).not.toMatch(decl);
+    });
+  });
+
+  it('declares the four required surfaces and source_health', () => {
+    expect(typesSrc).toContain('open_threads');
+    expect(typesSrc).toContain('promises_owed');
+    expect(typesSrc).toContain('promises_kept_recently');
+    expect(typesSrc).toContain('counts');
+    expect(typesSrc).toContain('source_health');
+    expect(typesSrc).toContain('recommended_follow_up');
+  });
+
+  it('declares overdue as a boolean, NEVER a raw timestamp', () => {
+    expect(typesSrc).toMatch(/overdue:\s*boolean/);
+    expect(typesSrc).not.toMatch(/overdue\s*\??:\s*string/);
+  });
+
+  it('AssistantDecisionContext.continuity is optional null', () => {
+    // The type must allow null to enable empty-degrades.
+    expect(typesSrc).toMatch(/continuity:\s*DecisionContinuity\s*\|\s*null/);
+  });
+});

--- a/services/gateway/test/orb/context/spine-end-to-end.test.ts
+++ b/services/gateway/test/orb/context/spine-end-to-end.test.ts
@@ -1,0 +1,157 @@
+/**
+ * VTID-02941 (B0b-min) — end-to-end through the minimal spine.
+ *
+ * Compose: stub continuity-fetcher → compileContinuityContext (real) →
+ * distill (real) → render (real). Proves the full pipeline produces a
+ * stable, distilled prompt section from raw Supabase-shaped rows
+ * without leaking any of those rows into the rendered string.
+ *
+ * Acceptance #8 (operator parity): Command Hub preview and actual
+ * prompt contract use the same compiler path. The Command Hub preview
+ * is `compileContinuityContext` → JSON. The prompt contract is
+ * `compileContinuityContext` → distillContinuityForDecision →
+ * renderDecisionContract. Both paths start at the same compiler with
+ * the same input, satisfying the parity check.
+ */
+
+import { compileContinuityContext } from '../../../src/services/continuity/compile-continuity-context';
+import { distillContinuityForDecision } from '../../../src/orb/context/providers/continuity-decision-provider';
+import { renderDecisionContract } from '../../../src/orb/live/instruction/decision-contract-renderer';
+import type { AssistantDecisionContext } from '../../../src/orb/context/types';
+import type {
+  AssistantPromiseRow,
+  OpenThreadRow,
+} from '../../../src/services/continuity/types';
+
+const NOW = Date.parse('2026-05-13T12:00:00Z');
+const DAY = 24 * 60 * 60 * 1000;
+
+function thread(over: Partial<OpenThreadRow>): OpenThreadRow {
+  return {
+    thread_id: 't',
+    topic: 'topic',
+    summary: null,
+    status: 'open',
+    session_id_first: 'sess-FIRST',
+    session_id_last: 'sess-LAST',
+    last_mentioned_at: new Date(NOW - 1 * DAY).toISOString(),
+    resolved_at: null,
+    created_at: new Date(NOW - 5 * DAY).toISOString(),
+    updated_at: new Date(NOW - 1 * DAY).toISOString(),
+    ...over,
+  };
+}
+
+function promise(over: Partial<AssistantPromiseRow>): AssistantPromiseRow {
+  return {
+    promise_id: 'p',
+    thread_id: null,
+    session_id: 'sess-PROMISE-RAW',
+    promise_text: 'text',
+    due_at: null,
+    status: 'owed',
+    decision_id: null,
+    kept_at: null,
+    created_at: new Date(NOW - 3 * DAY).toISOString(),
+    updated_at: new Date(NOW - 1 * DAY).toISOString(),
+    ...over,
+  };
+}
+
+describe('B0b-min — end-to-end spine', () => {
+  it('renders a coherent prompt section AND drops every raw row field', () => {
+    const continuityCtx = compileContinuityContext({
+      threadsResult: {
+        ok: true,
+        rows: [
+          thread({
+            thread_id: 'thread-A',
+            topic: 'magnesium routine',
+            summary: 'discussed dosage after dinner',
+            last_mentioned_at: new Date(NOW - 2 * DAY).toISOString(),
+          }),
+        ],
+      },
+      promisesResult: {
+        ok: true,
+        rows: [
+          promise({
+            promise_id: 'promise-A',
+            promise_text: "I'll send the supplement comparison",
+            due_at: new Date(NOW - 1 * DAY).toISOString(),
+            status: 'owed',
+            decision_id: 'dec-42',
+          }),
+          promise({
+            promise_id: 'promise-B',
+            promise_text: 'shared the article on circadian rhythm',
+            status: 'kept',
+            kept_at: new Date(NOW - 2 * DAY).toISOString(),
+          }),
+        ],
+      },
+      nowMs: NOW,
+    });
+
+    const decision: AssistantDecisionContext = {
+      continuity: distillContinuityForDecision({ continuity: continuityCtx }),
+      source_health: { continuity: { ok: true } },
+    };
+    const rendered = renderDecisionContract(decision);
+
+    // ---- Coherent prompt section ----
+    expect(rendered).toContain('Assistant decision contract:');
+    expect(rendered).toContain('Continuity:');
+    expect(rendered).toContain('Open threads:');
+    expect(rendered).toContain('magnesium routine');
+    expect(rendered).toContain('Promises owed:');
+    expect(rendered).toContain("I'll send the supplement comparison [overdue]");
+    expect(rendered).toContain('Promises kept recently:');
+    expect(rendered).toContain('shared the article on circadian rhythm');
+    expect(rendered).toContain('Recommended follow-up: address_overdue_promise');
+
+    // ---- Raw row fields MUST NOT appear ----
+    // Session ids
+    expect(rendered).not.toContain('sess-FIRST');
+    expect(rendered).not.toContain('sess-LAST');
+    expect(rendered).not.toContain('sess-PROMISE-RAW');
+    // Raw timestamps
+    expect(rendered).not.toContain('2026-05-');
+    expect(rendered).not.toContain('T12:00:00');
+    expect(rendered).not.toContain('T00:00:00');
+    // Status values (we said "owed/kept/broken/cancelled" — the renderer
+    // expresses them as [overdue] tag or section header only)
+    expect(rendered).not.toMatch(/\bstatus:\s*"?\w+"?/i);
+  });
+
+  it('empty fetcher results render to empty string (acceptance #1 — safe defaults)', () => {
+    const continuityCtx = compileContinuityContext({
+      threadsResult: { ok: true, rows: [] },
+      promisesResult: { ok: true, rows: [] },
+      nowMs: NOW,
+    });
+    const decision: AssistantDecisionContext = {
+      continuity: distillContinuityForDecision({ continuity: continuityCtx }),
+      source_health: { continuity: { ok: true } },
+    };
+    expect(renderDecisionContract(decision)).toBe('');
+  });
+
+  it('degraded source produces a hint section, no crash (acceptance #6)', () => {
+    const continuityCtx = compileContinuityContext({
+      threadsResult: { ok: false, rows: [], reason: 'supabase_unconfigured' },
+      promisesResult: { ok: false, rows: [], reason: 'supabase_unconfigured' },
+      nowMs: NOW,
+    });
+    // Even though continuityCtx has empty surfaces, source_health came back
+    // degraded. The renderer reads source_health from the decision, so we
+    // pass a degraded shape directly.
+    const decision: AssistantDecisionContext = {
+      continuity: null,
+      source_health: { continuity: { ok: false, reason: 'supabase_unconfigured' } },
+    };
+    const rendered = renderDecisionContract(decision);
+    expect(rendered).toContain('continuity: source degraded');
+    expect(rendered).toContain('supabase_unconfigured');
+  });
+});

--- a/services/gateway/test/orb/live/instruction/decision-contract-renderer.test.ts
+++ b/services/gateway/test/orb/live/instruction/decision-contract-renderer.test.ts
@@ -1,0 +1,247 @@
+/**
+ * VTID-02941 (B0b-min) — decision-contract-renderer tests.
+ *
+ * Acceptance:
+ *   #3 — renderer ONLY accepts AssistantDecisionContext, never raw
+ *        compiler output. Enforced by source-level scan + by behavior:
+ *        any unrecognized field on the input is ignored (typescript
+ *        rejects it at compile time; runtime ignores extras).
+ *   #4 — generateSystemInstruction does NOT query memory directly. The
+ *        renderer file MUST NOT import from supabase, services, or call
+ *        fetch.
+ *   #6 — if continuity is null, renderer emits no continuity section.
+ *        When source_health is degraded, renderer emits a short hint.
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import {
+  renderDecisionContract,
+} from '../../../../src/orb/live/instruction/decision-contract-renderer';
+import type {
+  AssistantDecisionContext,
+  DecisionContinuity,
+} from '../../../../src/orb/context/types';
+
+const RENDERER_PATH = join(
+  __dirname,
+  '../../../../src/orb/live/instruction/decision-contract-renderer.ts',
+);
+
+function emptyContinuity(): DecisionContinuity {
+  return {
+    open_threads: [],
+    promises_owed: [],
+    promises_kept_recently: [],
+    counts: {
+      open_threads_total: 0,
+      promises_owed_total: 0,
+      promises_overdue: 0,
+      threads_mentioned_today: 0,
+    },
+    recommended_follow_up: 'none',
+  };
+}
+
+function emptyContext(over: Partial<AssistantDecisionContext> = {}): AssistantDecisionContext {
+  return {
+    continuity: null,
+    source_health: { continuity: { ok: true } },
+    ...over,
+  };
+}
+
+describe('B0b-min — decision-contract-renderer', () => {
+  describe('purity — wall enforcement (acceptance #4)', () => {
+    let src: string;
+    beforeAll(() => {
+      src = readFileSync(RENDERER_PATH, 'utf8');
+    });
+
+    it('does not import from services/', () => {
+      expect(src).not.toMatch(/from\s+['"][^'"]*\.\.\/\.\.\/\.\.\/services\//);
+      expect(src).not.toMatch(/from\s+['"][^'"]*services\/continuity/);
+    });
+
+    it('does not import supabase or any DB client', () => {
+      // Walk only non-comment lines so the wall-comment doesn't trip
+      // the source-level guard (the comment mentions "Supabase" by
+      // name precisely BECAUSE it must not be imported).
+      const nonComment = src
+        .split('\n')
+        .filter((l) => !/^\s*(\*|\/\*|\/\/)/.test(l))
+        .join('\n');
+      expect(nonComment).not.toMatch(/\bgetSupabase\b/);
+      expect(nonComment).not.toMatch(/from\s+['"][^'"]*lib\/supabase/);
+    });
+
+    it('does not call fetch / axios / rpc', () => {
+      expect(src).not.toMatch(/\bfetch\(/);
+      expect(src).not.toMatch(/\baxios\b/);
+      expect(src).not.toMatch(/\.rpc\(/);
+    });
+
+    it('only imports types from orb/context', () => {
+      // Renderer must depend on the contract, never on the implementation.
+      expect(src).toMatch(/from\s+['"]\.\.\/\.\.\/context\/types['"]/);
+    });
+  });
+
+  describe('empty/degrades safely (acceptance #1 + #6)', () => {
+    it('returns empty string when continuity is null and source is healthy', () => {
+      const out = renderDecisionContract(emptyContext());
+      expect(out).toBe('');
+    });
+
+    it('emits a degraded hint when continuity is null AND source_health is degraded', () => {
+      const out = renderDecisionContract(
+        emptyContext({
+          source_health: { continuity: { ok: false, reason: 'supabase_unconfigured' } },
+        }),
+      );
+      expect(out).toContain('continuity: source degraded');
+      expect(out).toContain('supabase_unconfigured');
+    });
+
+    it('emits empty string when continuity surfaces are all empty AND source is healthy', () => {
+      const out = renderDecisionContract(
+        emptyContext({ continuity: emptyContinuity() }),
+      );
+      expect(out).toBe('');
+    });
+  });
+
+  describe('renders distilled surfaces', () => {
+    it('renders open threads with age + summary', () => {
+      const out = renderDecisionContract(
+        emptyContext({
+          continuity: {
+            ...emptyContinuity(),
+            open_threads: [
+              {
+                thread_id: 't1',
+                topic: 'magnesium dosage',
+                summary: 'follow-up on the new bottle',
+                days_since_last_mention: 3,
+              },
+            ],
+          },
+        }),
+      );
+      expect(out).toContain('Open threads:');
+      expect(out).toContain('magnesium dosage');
+      expect(out).toContain('3d since last mention');
+      expect(out).toContain('follow-up on the new bottle');
+    });
+
+    it('renders promises_owed with overdue tag', () => {
+      const out = renderDecisionContract(
+        emptyContext({
+          continuity: {
+            ...emptyContinuity(),
+            promises_owed: [
+              {
+                promise_id: 'p1',
+                promise_text: 'send the doc',
+                overdue: true,
+                decision_id: null,
+              },
+            ],
+          },
+        }),
+      );
+      expect(out).toContain('Promises owed:');
+      expect(out).toContain('send the doc [overdue]');
+    });
+
+    it('renders recommended_follow_up when not "none"', () => {
+      const out = renderDecisionContract(
+        emptyContext({
+          continuity: {
+            ...emptyContinuity(),
+            open_threads: [
+              { thread_id: 't', topic: 'x', summary: null, days_since_last_mention: 1 },
+            ],
+            recommended_follow_up: 'mention_open_thread',
+          },
+        }),
+      );
+      expect(out).toContain('Recommended follow-up: mention_open_thread');
+    });
+
+    it('omits recommended_follow_up when "none"', () => {
+      const out = renderDecisionContract(
+        emptyContext({
+          continuity: {
+            ...emptyContinuity(),
+            open_threads: [
+              { thread_id: 't', topic: 'x', summary: null, days_since_last_mention: 1 },
+            ],
+            recommended_follow_up: 'none',
+          },
+        }),
+      );
+      expect(out).not.toContain('Recommended follow-up');
+    });
+  });
+
+  describe('header behavior', () => {
+    it('emits header by default', () => {
+      const out = renderDecisionContract(
+        emptyContext({
+          continuity: {
+            ...emptyContinuity(),
+            open_threads: [
+              { thread_id: 't', topic: 'x', summary: null, days_since_last_mention: 0 },
+            ],
+          },
+        }),
+      );
+      expect(out.startsWith('Assistant decision contract:\n')).toBe(true);
+    });
+
+    it('omits header when withHeader=false', () => {
+      const out = renderDecisionContract(
+        emptyContext({
+          continuity: {
+            ...emptyContinuity(),
+            open_threads: [
+              { thread_id: 't', topic: 'x', summary: null, days_since_last_mention: 0 },
+            ],
+          },
+        }),
+        { withHeader: false },
+      );
+      expect(out.startsWith('Assistant decision contract:\n')).toBe(false);
+      expect(out).toContain('Continuity:');
+    });
+  });
+
+  describe('raw-field ignorance (acceptance #3 + #7)', () => {
+    it('extra unknown fields injected at runtime are NOT surfaced in output', () => {
+      // TypeScript would reject this at compile time; we cast to test
+      // runtime behavior. The renderer reads only declared fields.
+      const sneakyContinuity = {
+        ...emptyContinuity(),
+        open_threads: [
+          {
+            thread_id: 't',
+            topic: 'short topic',
+            summary: null,
+            days_since_last_mention: 0,
+            // raw fields a future bug might forward:
+            last_mentioned_at: '2026-05-10T12:00:00Z',
+            session_id_first: 'sess-A',
+            session_id_last: 'sess-B',
+            raw_message: 'user said this exact sentence',
+          },
+        ],
+      } as unknown as DecisionContinuity;
+
+      const out = renderDecisionContract(emptyContext({ continuity: sneakyContinuity }));
+      expect(out).not.toContain('2026-05-10T12:00:00Z');
+      expect(out).not.toContain('sess-A');
+      expect(out).not.toContain('user said this exact sentence');
+    });
+  });
+});

--- a/services/gateway/test/routes/voice-continuity.test.ts
+++ b/services/gateway/test/routes/voice-continuity.test.ts
@@ -1,0 +1,114 @@
+/**
+ * VTID-02932 (B2) — GET /api/v1/voice/continuity/preview tests.
+ *
+ * Verifies:
+ *   - Validates userId + tenantId (400 when missing).
+ *   - Calls the default fetcher with the provided ids.
+ *   - Returns ok:true with threads + promises + compiled context.
+ *   - Returns 500 with vtid when the fetcher throws unexpectedly.
+ */
+
+import express from 'express';
+import request from 'supertest';
+
+jest.mock('../../src/middleware/auth-supabase-jwt', () => ({
+  requireAuthWithTenant: (_req: any, _res: any, next: any) => next(),
+  requireExafyAdmin: (_req: any, _res: any, next: any) => next(),
+  optionalAuth: (_req: any, _res: any, next: any) => next(),
+}));
+
+const listOpenThreads = jest.fn();
+const listPromises = jest.fn();
+
+jest.mock('../../src/services/continuity/continuity-fetcher', () => ({
+  defaultContinuityFetcher: {
+    listOpenThreads: (args: any) => listOpenThreads(args),
+    listPromises: (args: any) => listPromises(args),
+  },
+}));
+
+function buildApp() {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const router = require('../../src/routes/voice-continuity').default;
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1', router);
+  return app;
+}
+
+describe('B2 — GET /api/v1/voice/continuity/preview', () => {
+  beforeEach(() => {
+    listOpenThreads.mockReset();
+    listPromises.mockReset();
+  });
+
+  it('returns 400 when userId is missing', async () => {
+    const app = buildApp();
+    const res = await request(app).get('/api/v1/voice/continuity/preview?tenantId=t');
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.vtid).toBe('VTID-02932');
+  });
+
+  it('returns 400 when tenantId is missing', async () => {
+    const app = buildApp();
+    const res = await request(app).get('/api/v1/voice/continuity/preview?userId=u');
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+  });
+
+  it('returns ok:true with rows + compiled context', async () => {
+    listOpenThreads.mockResolvedValueOnce({ ok: true, rows: [] });
+    listPromises.mockResolvedValueOnce({ ok: true, rows: [] });
+
+    const app = buildApp();
+    const res = await request(app).get('/api/v1/voice/continuity/preview?userId=u&tenantId=t');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.vtid).toBe('VTID-02932');
+    expect(Array.isArray(res.body.threads)).toBe(true);
+    expect(Array.isArray(res.body.promises)).toBe(true);
+    expect(res.body.context).toBeDefined();
+    expect(res.body.context.open_threads).toEqual([]);
+    expect(res.body.context.promises_owed).toEqual([]);
+    expect(res.body.context.source_health.user_open_threads.ok).toBe(true);
+    expect(res.body.context.source_health.assistant_promises.ok).toBe(true);
+  });
+
+  it('passes userId + tenantId through to the fetcher', async () => {
+    listOpenThreads.mockResolvedValueOnce({ ok: true, rows: [] });
+    listPromises.mockResolvedValueOnce({ ok: true, rows: [] });
+
+    const app = buildApp();
+    await request(app).get('/api/v1/voice/continuity/preview?userId=alice&tenantId=acme');
+    expect(listOpenThreads).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'alice', tenantId: 'acme', limit: 50 }),
+    );
+    expect(listPromises).toHaveBeenCalledWith(
+      expect.objectContaining({ userId: 'alice', tenantId: 'acme', limit: 50 }),
+    );
+  });
+
+  it('reflects fetcher source-health failures in the compiled context', async () => {
+    listOpenThreads.mockResolvedValueOnce({ ok: false, rows: [], reason: 'supabase_unconfigured' });
+    listPromises.mockResolvedValueOnce({ ok: true, rows: [] });
+
+    const app = buildApp();
+    const res = await request(app).get('/api/v1/voice/continuity/preview?userId=u&tenantId=t');
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.context.source_health.user_open_threads.ok).toBe(false);
+    expect(res.body.context.source_health.user_open_threads.reason).toBe('supabase_unconfigured');
+  });
+
+  it('returns 500 with vtid when the fetcher throws unexpectedly', async () => {
+    listOpenThreads.mockRejectedValueOnce(new Error('boom'));
+    listPromises.mockResolvedValueOnce({ ok: true, rows: [] });
+
+    const app = buildApp();
+    const res = await request(app).get('/api/v1/voice/continuity/preview?userId=u&tenantId=t');
+    expect(res.status).toBe(500);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.vtid).toBe('VTID-02932');
+  });
+});

--- a/services/gateway/test/self-healing-terminalize-gate.test.ts
+++ b/services/gateway/test/self-healing-terminalize-gate.test.ts
@@ -1,0 +1,218 @@
+/**
+ * PR-E (VTID-02931, Gap 1): the /api/v1/oasis/vtid/terminalize endpoint
+ * must hard-block terminal_outcome='success' for self-healing VTIDs
+ * unless their linked dev_autopilot_executions row has reached
+ * status='completed'.
+ *
+ * Healing definition: no PR → not healed; PR opened but CI/deploy/verify
+ * in flight → not healed; only execution.status='completed' (CI green +
+ * deploy + live probe) counts as healed. The self-healing reconciler is
+ * the only authorized writer of success for self-healing VTIDs, and it
+ * goes through a direct Supabase PATCH (bypassing this endpoint). Any
+ * other caller — including a misbehaving worker-runner — gets blocked
+ * here with 400.
+ *
+ * Non-self-healing VTIDs are unaffected — they continue through the
+ * normal VTID-01204 pipeline-integrity gate.
+ */
+
+import express from 'express';
+import request from 'supertest';
+import router from '../src/routes/vtid-terminalize';
+
+const ORIGINAL_FETCH = global.fetch;
+
+function buildApp() {
+  const app = express();
+  app.use(express.json());
+  app.use(router);
+  return app;
+}
+
+beforeEach(() => {
+  process.env.SUPABASE_URL = 'https://supabase.test';
+  process.env.SUPABASE_SERVICE_ROLE = 'svc-role';
+});
+
+afterEach(() => {
+  global.fetch = ORIGINAL_FETCH;
+});
+
+interface MockState {
+  ledgerTask: any;
+  executionStatus: string | 'missing';
+  patches: any[];
+}
+
+function mockFetch(state: MockState) {
+  global.fetch = jest.fn().mockImplementation(async (url: string, init?: any) => {
+    if (url.includes('/rest/v1/vtid_ledger') && (!init?.method || init.method === 'GET')) {
+      return { ok: true, status: 200, json: () => Promise.resolve(state.ledgerTask ? [state.ledgerTask] : []) };
+    }
+    if (url.includes('/rest/v1/vtid_ledger') && init?.method === 'PATCH') {
+      state.patches.push({ url, body: JSON.parse(init.body) });
+      return { ok: true, status: 200, json: () => Promise.resolve([]) };
+    }
+    if (url.includes('/rest/v1/dev_autopilot_executions?id=eq.')) {
+      if (state.executionStatus === 'missing') {
+        return { ok: true, status: 200, json: () => Promise.resolve([]) };
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve([{ id: 'exec-1', status: state.executionStatus, pr_url: 'https://x/y/pull/1', pr_number: 1 }]),
+      };
+    }
+    // OASIS event POSTs + Supabase RPC catch-all
+    return { ok: true, status: 200, json: () => Promise.resolve({}), text: () => Promise.resolve('') };
+  }) as unknown as typeof fetch;
+}
+
+const baseSelfHealingTask = {
+  vtid: 'VTID-00001',
+  status: 'in_progress',
+  is_terminal: false,
+  metadata: {
+    source: 'self-healing',
+    autopilot_execution_id: 'exec-uuid-1',
+  },
+};
+
+describe('POST /api/v1/oasis/vtid/terminalize — self-healing gate (PR-E)', () => {
+  it('400 when self-healing VTID has NO autopilot_execution_id and outcome=success', async () => {
+    const state: MockState = {
+      ledgerTask: {
+        ...baseSelfHealingTask,
+        metadata: { source: 'self-healing' }, // no execution_id
+      },
+      executionStatus: 'missing',
+      patches: [],
+    };
+    mockFetch(state);
+
+    const res = await request(buildApp())
+      .post('/api/v1/oasis/vtid/terminalize')
+      .send({ vtid: 'VTID-00001', outcome: 'success', actor: 'autodeploy' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('SELF_HEALING_NO_AUTOPILOT_BRIDGE');
+    expect(state.patches.length).toBe(0); // no terminal patch happened
+  });
+
+  it('400 when self-healing VTID has bridge but execution.status is in flight', async () => {
+    const inflightStatuses = ['queued', 'cooling', 'running', 'ci', 'merging', 'deploying', 'verifying'];
+    for (const status of inflightStatuses) {
+      const state: MockState = {
+        ledgerTask: baseSelfHealingTask,
+        executionStatus: status,
+        patches: [],
+      };
+      mockFetch(state);
+
+      const res = await request(buildApp())
+        .post('/api/v1/oasis/vtid/terminalize')
+        .send({ vtid: 'VTID-00001', outcome: 'success', actor: 'autodeploy' });
+
+      expect(res.status).toBe(400);
+      expect(res.body.error).toBe('SELF_HEALING_AUTOPILOT_NOT_COMPLETED');
+      expect(res.body.autopilot_status).toBe(status);
+      expect(state.patches.length).toBe(0);
+    }
+  });
+
+  it('400 when self-healing VTID has bridge but execution.status is failed', async () => {
+    const state: MockState = {
+      ledgerTask: baseSelfHealingTask,
+      executionStatus: 'failed',
+      patches: [],
+    };
+    mockFetch(state);
+
+    const res = await request(buildApp())
+      .post('/api/v1/oasis/vtid/terminalize')
+      .send({ vtid: 'VTID-00001', outcome: 'success', actor: 'autodeploy' });
+
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('SELF_HEALING_AUTOPILOT_NOT_COMPLETED');
+    expect(res.body.autopilot_status).toBe('failed');
+  });
+
+  it('allows success when self-healing VTID has bridge AND execution.status=completed', async () => {
+    const state: MockState = {
+      ledgerTask: baseSelfHealingTask,
+      executionStatus: 'completed',
+      patches: [],
+    };
+    mockFetch(state);
+
+    // The endpoint will then go through the existing VTID-01204 pipeline
+    // gate, which may also block (no real PR events) — that's fine, we're
+    // only asserting OUR gate doesn't fire for execution.status=completed.
+    const res = await request(buildApp())
+      .post('/api/v1/oasis/vtid/terminalize')
+      .send({ vtid: 'VTID-00001', outcome: 'success', actor: 'autodeploy' });
+
+    // The PR-E gate should pass; downstream pipeline-integrity may still
+    // reject (it requires PR-created + merged + deploy events too).
+    expect(['SELF_HEALING_NO_AUTOPILOT_BRIDGE', 'SELF_HEALING_AUTOPILOT_NOT_COMPLETED'])
+      .not.toContain(res.body.error);
+  });
+
+  it('allows outcome=failed for self-healing VTID regardless of autopilot status', async () => {
+    const state: MockState = {
+      ledgerTask: baseSelfHealingTask,
+      executionStatus: 'failed',
+      patches: [],
+    };
+    mockFetch(state);
+
+    const res = await request(buildApp())
+      .post('/api/v1/oasis/vtid/terminalize')
+      .send({ vtid: 'VTID-00001', outcome: 'failed', actor: 'autodeploy' });
+
+    expect(['SELF_HEALING_NO_AUTOPILOT_BRIDGE', 'SELF_HEALING_AUTOPILOT_NOT_COMPLETED'])
+      .not.toContain(res.body.error);
+  });
+
+  it('does NOT apply the self-healing gate to non-self-healing VTIDs', async () => {
+    const state: MockState = {
+      ledgerTask: {
+        vtid: 'VTID-00002',
+        status: 'in_progress',
+        is_terminal: false,
+        metadata: { source: 'dev_autopilot' }, // not self-healing
+      },
+      executionStatus: 'missing',
+      patches: [],
+    };
+    mockFetch(state);
+
+    const res = await request(buildApp())
+      .post('/api/v1/oasis/vtid/terminalize')
+      .send({ vtid: 'VTID-00002', outcome: 'success', actor: 'autodeploy' });
+
+    expect(['SELF_HEALING_NO_AUTOPILOT_BRIDGE', 'SELF_HEALING_AUTOPILOT_NOT_COMPLETED'])
+      .not.toContain(res.body.error);
+  });
+
+  it('idempotent: already-terminal self-healing VTIDs return 200 without re-running the gate', async () => {
+    const state: MockState = {
+      ledgerTask: {
+        ...baseSelfHealingTask,
+        is_terminal: true,
+        terminal_outcome: 'success',
+        completed_at: '2026-05-11T20:00:00Z',
+      },
+      executionStatus: 'missing', // wouldn't matter — gate is skipped
+      patches: [],
+    };
+    mockFetch(state);
+
+    const res = await request(buildApp())
+      .post('/api/v1/oasis/vtid/terminalize')
+      .send({ vtid: 'VTID-00001', outcome: 'success', actor: 'autodeploy' });
+
+    expect(res.status).toBe(200);
+    expect(res.body.already_terminal).toBe(true);
+  });
+});

--- a/services/gateway/test/services/continuity/b2-migration.test.ts
+++ b/services/gateway/test/services/continuity/b2-migration.test.ts
@@ -1,0 +1,130 @@
+/**
+ * VTID-02932 (B2) — continuity tables migration shape guard.
+ *
+ * Asserts the migration:
+ *   - Creates user_open_threads + assistant_promises with the
+ *     documented columns + status CHECK constraints.
+ *   - Tenant-scopes both via RLS through user_tenants.
+ *   - Indexes both for the hot-path queries the fetcher runs
+ *     (last_mentioned_at DESC for open threads, due_at NULLS LAST
+ *     for owed promises).
+ *   - Has touch triggers on updated_at for both tables.
+ *   - Does NOT contain any state-advancement RPC. State advancement
+ *     ships in a follow-up slice with its own dedicated event endpoint
+ *     (B2 wall).
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const MIGRATION_PATH = join(
+  __dirname,
+  '../../../../../supabase/migrations/20260520000000_VTID_02932_continuity_tables.sql',
+);
+
+describe('B2 — continuity tables migration', () => {
+  let sql: string;
+  beforeAll(() => {
+    sql = readFileSync(MIGRATION_PATH, 'utf8');
+  });
+
+  describe('user_open_threads table', () => {
+    it('creates the table', () => {
+      expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS user_open_threads/);
+    });
+
+    it('keys on thread_id UUID PRIMARY KEY', () => {
+      expect(sql).toMatch(/thread_id\s+UUID[\s\S]*?PRIMARY KEY/);
+    });
+
+    it('has the 3-state status CHECK constraint locked', () => {
+      const states = ['open', 'resolved', 'abandoned'];
+      for (const s of states) {
+        expect(sql).toContain(`'${s}'`);
+      }
+    });
+
+    it('tracks session_id_first + session_id_last for cross-session linkage', () => {
+      expect(sql).toContain('session_id_first');
+      expect(sql).toContain('session_id_last');
+    });
+
+    it('tracks last_mentioned_at for recency ordering', () => {
+      expect(sql).toContain('last_mentioned_at');
+    });
+
+    it('enables RLS with tenant isolation via user_tenants', () => {
+      expect(sql).toMatch(/ALTER TABLE user_open_threads ENABLE ROW LEVEL SECURITY/);
+      expect(sql).toMatch(/user_open_threads_tenant_isolation/);
+      expect(sql).toMatch(/user_tenants/);
+    });
+
+    it('indexes (tenant_id, user_id, last_mentioned_at DESC) for recency reads', () => {
+      expect(sql).toMatch(/user_open_threads_user_idx/);
+      expect(sql).toMatch(/last_mentioned_at\s+DESC/);
+    });
+
+    it('has a partial index WHERE status = open for hot-path lookups', () => {
+      expect(sql).toMatch(/WHERE\s+status\s*=\s*'open'/);
+    });
+
+    it('has a touch trigger on updated_at', () => {
+      expect(sql).toMatch(/CREATE TRIGGER user_open_threads_updated_at_trigger/);
+    });
+  });
+
+  describe('assistant_promises table', () => {
+    it('creates the table', () => {
+      expect(sql).toMatch(/CREATE TABLE IF NOT EXISTS assistant_promises/);
+    });
+
+    it('keys on promise_id UUID PRIMARY KEY', () => {
+      expect(sql).toMatch(/promise_id\s+UUID[\s\S]*?PRIMARY KEY/);
+    });
+
+    it('has the 4-state status CHECK constraint locked', () => {
+      const states = ['owed', 'kept', 'broken', 'cancelled'];
+      for (const s of states) {
+        expect(sql).toContain(`'${s}'`);
+      }
+    });
+
+    it('references user_open_threads via FK ON DELETE SET NULL (not CASCADE)', () => {
+      expect(sql).toMatch(
+        /REFERENCES user_open_threads\(thread_id\)\s+ON DELETE SET NULL/,
+      );
+    });
+
+    it('tracks decision_id for ranker-trace linkage', () => {
+      expect(sql).toContain('decision_id');
+    });
+
+    it('tracks kept_at for credit-acknowledgement window', () => {
+      expect(sql).toContain('kept_at');
+    });
+
+    it('enables RLS with tenant isolation via user_tenants', () => {
+      expect(sql).toMatch(/ALTER TABLE assistant_promises ENABLE ROW LEVEL SECURITY/);
+      expect(sql).toMatch(/assistant_promises_tenant_isolation/);
+      expect(sql).toMatch(/user_tenants/);
+    });
+
+    it('has a partial index WHERE status = owed for due-soonest reads', () => {
+      expect(sql).toMatch(/WHERE\s+status\s*=\s*'owed'/);
+    });
+
+    it('has a touch trigger on updated_at', () => {
+      expect(sql).toMatch(/CREATE TRIGGER assistant_promises_updated_at_trigger/);
+    });
+  });
+
+  describe('B2 wall — no state advancement in this migration', () => {
+    it('does NOT introduce any state-advancement RPC (mutation lives in a follow-up slice)', () => {
+      // Any RPC starting with create_thread / mark_promise / advance_*
+      // would violate B2's read-only wall.
+      expect(sql).not.toMatch(/CREATE OR REPLACE FUNCTION\s+(?:public\.)?create_open_thread/i);
+      expect(sql).not.toMatch(/CREATE OR REPLACE FUNCTION\s+(?:public\.)?mark_promise/i);
+      expect(sql).not.toMatch(/CREATE OR REPLACE FUNCTION\s+(?:public\.)?advance_/i);
+    });
+  });
+});

--- a/services/gateway/test/services/continuity/b2-walls.test.ts
+++ b/services/gateway/test/services/continuity/b2-walls.test.ts
@@ -1,0 +1,147 @@
+/**
+ * VTID-02932 (B2) — wall-integrity tests.
+ *
+ * B2 is conversation continuity (open threads + promises) ONLY.
+ * Asserts:
+ *   - Command Hub Continuity panel renders even when no data exists.
+ *   - Panel has NO mutation surface (no buttons, no onclick, no
+ *     POST/PUT/PATCH/DELETE fetches).
+ *   - Preview route is GET-only, admin-gated, performs no DB mutation.
+ *   - ContinuityFetcher source has no write methods (no upsert/insert/
+ *     update/delete/rpc) — state advancement lives in a follow-up slice.
+ *   - The pure compiler does no IO (no supabase / fetch / axios / timers).
+ *   - B2 does NOT touch ORB transport, audio, reconnect, Live API,
+ *     timeout, or wake-brief-timing code paths.
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const APP_JS_PATH = join(__dirname, '../../../src/frontend/command-hub/app.js');
+const ROUTE_PATH = join(__dirname, '../../../src/routes/voice-continuity.ts');
+const FETCHER_PATH = join(__dirname, '../../../src/services/continuity/continuity-fetcher.ts');
+const COMPILER_PATH = join(__dirname, '../../../src/services/continuity/compile-continuity-context.ts');
+const TYPES_PATH = join(__dirname, '../../../src/services/continuity/types.ts');
+
+describe('B2 — wall integrity', () => {
+  let appJs: string;
+  let routeSrc: string;
+  let fetcherSrc: string;
+  let compilerSrc: string;
+  let typesSrc: string;
+  beforeAll(() => {
+    appJs = readFileSync(APP_JS_PATH, 'utf8');
+    routeSrc = readFileSync(ROUTE_PATH, 'utf8');
+    fetcherSrc = readFileSync(FETCHER_PATH, 'utf8');
+    compilerSrc = readFileSync(COMPILER_PATH, 'utf8');
+    typesSrc = readFileSync(TYPES_PATH, 'utf8');
+  });
+
+  describe('panel renders without data', () => {
+    it('defines renderJourneyContextContinuityPanel', () => {
+      expect(appJs).toContain('function renderJourneyContextContinuityPanel');
+    });
+
+    it('panel handles missing co argument (empty-state branch)', () => {
+      const fnMatch = appJs.match(
+        /function renderJourneyContextContinuityPanel\(co\)\s*\{[\s\S]*?\n\}/,
+      );
+      expect(fnMatch).toBeTruthy();
+      const body = fnMatch![0];
+      expect(body).toMatch(/if\s*\(\s*!co\s*\)/);
+      expect(body).toMatch(/no data — load a user above/);
+    });
+
+    it('panel is wired into the journey-context grid', () => {
+      expect(appJs).toContain('renderJourneyContextContinuityPanel(jc.continuity)');
+    });
+
+    it('panel loader fetches the preview endpoint', () => {
+      expect(appJs).toContain("'/api/v1/voice/continuity/preview'");
+    });
+  });
+
+  describe('no mutation from preview/panel', () => {
+    it('panel has NO mutation surface', () => {
+      const fnMatch = appJs.match(
+        /function renderJourneyContextContinuityPanel\(co\)\s*\{[\s\S]*?\n\}/,
+      );
+      const body = fnMatch![0];
+      expect(body).not.toMatch(/createElement\(['"]button['"]\)/);
+      expect(body).not.toMatch(/\.onclick\s*=/);
+      expect(body).not.toMatch(/addEventListener\(['"]click['"]/);
+      expect(body).not.toMatch(/method\s*:\s*['"](?:POST|PUT|PATCH|DELETE)['"]/);
+    });
+
+    it('preview route is GET-only', () => {
+      const startIdx = routeSrc.indexOf("'/voice/continuity/preview'");
+      expect(startIdx).toBeGreaterThan(-1);
+      const before = routeSrc.slice(Math.max(0, startIdx - 200), startIdx);
+      expect(before).toMatch(/router\.get\(/);
+    });
+
+    it('preview route has NO DB-mutation calls', () => {
+      expect(routeSrc).not.toMatch(/\.insert\(/);
+      expect(routeSrc).not.toMatch(/\.update\(/);
+      expect(routeSrc).not.toMatch(/\.upsert\(/);
+      expect(routeSrc).not.toMatch(/\.delete\(/);
+      expect(routeSrc).not.toMatch(/\.rpc\(/);
+    });
+
+    it('preview route requires exafy_admin', () => {
+      expect(routeSrc).toContain('requireExafyAdmin');
+    });
+  });
+
+  describe('fetcher has no mutator methods', () => {
+    it('ContinuityFetcher interface declares only listOpenThreads + listPromises', () => {
+      // The interface declaration is the source of truth; later additions
+      // would land in this same block.
+      const ifaceMatch = fetcherSrc.match(/export interface ContinuityFetcher\s*\{[\s\S]*?\n\}/);
+      expect(ifaceMatch).toBeTruthy();
+      const iface = ifaceMatch![0];
+      expect(iface).toMatch(/listOpenThreads/);
+      expect(iface).toMatch(/listPromises/);
+      expect(iface).not.toMatch(/upsert|insert|update|delete|markPromise|createThread/);
+    });
+
+    it('fetcher source has no Supabase write calls', () => {
+      expect(fetcherSrc).not.toMatch(/\.insert\(/);
+      expect(fetcherSrc).not.toMatch(/\.update\(/);
+      expect(fetcherSrc).not.toMatch(/\.upsert\(/);
+      expect(fetcherSrc).not.toMatch(/\.delete\(/);
+      expect(fetcherSrc).not.toMatch(/\.rpc\(/);
+    });
+  });
+
+  describe('compiler is pure', () => {
+    it('compileContinuityContext source has NO IO / DB / fetch / timers', () => {
+      expect(compilerSrc).not.toMatch(/supabase|getSupabase/);
+      expect(compilerSrc).not.toMatch(/\bfetch\(/);
+      expect(compilerSrc).not.toMatch(/axios/);
+      expect(compilerSrc).not.toMatch(/\.rpc\(/);
+      expect(compilerSrc).not.toMatch(/setTimeout\(|setInterval\(/);
+    });
+
+    it('compiler accepts an injected nowMs for testability (no implicit Date.now coupling)', () => {
+      expect(compilerSrc).toMatch(/nowMs\?:\s*number/);
+    });
+  });
+
+  describe('B2 does NOT touch reliability-lane code paths', () => {
+    it('types module is pure types (no IO, no value exports beyond types/interfaces)', () => {
+      expect(typesSrc).not.toMatch(/supabase|getSupabase/);
+      expect(typesSrc).not.toMatch(/\bfetch\(/);
+      expect(typesSrc).not.toMatch(/\bconst\s+\w+\s*=\s*(?!.*\btype\b)/);
+    });
+
+    it('fetcher does NOT reference transport / audio / reconnect / Live API', () => {
+      expect(fetcherSrc).not.toMatch(/EventSource|WebSocket|new AudioContext|playAudio|geminiLive\.|liveSessions\./);
+      expect(fetcherSrc).not.toMatch(/reconnect_attempt\(|attemptReconnect\(/);
+    });
+
+    it('route does NOT reference transport / audio / reconnect / Live API', () => {
+      expect(routeSrc).not.toMatch(/EventSource|WebSocket|new AudioContext|playAudio|geminiLive\.|liveSessions\./);
+    });
+  });
+});

--- a/services/gateway/test/services/continuity/compile-continuity-context.test.ts
+++ b/services/gateway/test/services/continuity/compile-continuity-context.test.ts
@@ -1,0 +1,388 @@
+/**
+ * VTID-02932 (B2) — compileContinuityContext tests.
+ *
+ * Pure function. Verifies:
+ *   - Open thread sorting (newest mentioned first) + cap.
+ *   - Owed promise sorting (due-soonest first, nulls last) + cap.
+ *   - Kept-recently window = 7 days, ordered newest-first, capped.
+ *   - Counts (open_threads_total, promises_owed_total, promises_overdue,
+ *     threads_mentioned_today) computed correctly with UTC day boundary.
+ *   - source_health reflects the input fetch results.
+ *   - days_since_last_mention / days_overdue math.
+ */
+
+import { compileContinuityContext } from '../../../src/services/continuity/compile-continuity-context';
+import type {
+  AssistantPromiseRow,
+  OpenThreadRow,
+} from '../../../src/services/continuity/types';
+
+const NOW = Date.parse('2026-05-11T12:00:00Z');
+const DAY = 24 * 60 * 60 * 1000;
+
+function thread(over: Partial<OpenThreadRow>): OpenThreadRow {
+  return {
+    thread_id: 't',
+    topic: 'topic',
+    summary: null,
+    status: 'open',
+    session_id_first: null,
+    session_id_last: null,
+    last_mentioned_at: '2026-05-11T00:00:00Z',
+    resolved_at: null,
+    created_at: '2026-05-01T00:00:00Z',
+    updated_at: '2026-05-11T00:00:00Z',
+    ...over,
+  };
+}
+
+function promise(over: Partial<AssistantPromiseRow>): AssistantPromiseRow {
+  return {
+    promise_id: 'p',
+    thread_id: null,
+    session_id: null,
+    promise_text: 'text',
+    due_at: null,
+    status: 'owed',
+    decision_id: null,
+    kept_at: null,
+    created_at: '2026-05-01T00:00:00Z',
+    updated_at: '2026-05-11T00:00:00Z',
+    ...over,
+  };
+}
+
+describe('B2 — compileContinuityContext', () => {
+  describe('open threads', () => {
+    it('returns only status=open threads', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: {
+          ok: true,
+          rows: [
+            thread({ thread_id: 'a', status: 'open' }),
+            thread({ thread_id: 'b', status: 'resolved' }),
+            thread({ thread_id: 'c', status: 'abandoned' }),
+          ],
+        },
+        promisesResult: { ok: true, rows: [] },
+        nowMs: NOW,
+      });
+      expect(ctx.open_threads.map(t => t.thread_id)).toEqual(['a']);
+    });
+
+    it('sorts by last_mentioned_at DESC (newest first)', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: {
+          ok: true,
+          rows: [
+            thread({ thread_id: 'a', last_mentioned_at: '2026-05-09T00:00:00Z' }),
+            thread({ thread_id: 'b', last_mentioned_at: '2026-05-11T00:00:00Z' }),
+            thread({ thread_id: 'c', last_mentioned_at: '2026-05-10T00:00:00Z' }),
+          ],
+        },
+        promisesResult: { ok: true, rows: [] },
+        nowMs: NOW,
+      });
+      expect(ctx.open_threads.map(t => t.thread_id)).toEqual(['b', 'c', 'a']);
+    });
+
+    it('caps to openThreadLimit (default 5)', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: {
+          ok: true,
+          rows: Array.from({ length: 12 }, (_, i) => thread({
+            thread_id: 't' + i,
+            last_mentioned_at: new Date(NOW - i * 1000).toISOString(),
+          })),
+        },
+        promisesResult: { ok: true, rows: [] },
+        nowMs: NOW,
+      });
+      expect(ctx.open_threads).toHaveLength(5);
+    });
+
+    it('respects custom openThreadLimit', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: {
+          ok: true,
+          rows: [
+            thread({ thread_id: 'a' }),
+            thread({ thread_id: 'b' }),
+            thread({ thread_id: 'c' }),
+          ],
+        },
+        promisesResult: { ok: true, rows: [] },
+        nowMs: NOW,
+        openThreadLimit: 2,
+      });
+      expect(ctx.open_threads).toHaveLength(2);
+    });
+
+    it('computes days_since_last_mention from now', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: {
+          ok: true,
+          rows: [
+            thread({ thread_id: 'a', last_mentioned_at: new Date(NOW - 3 * DAY).toISOString() }),
+          ],
+        },
+        promisesResult: { ok: true, rows: [] },
+        nowMs: NOW,
+      });
+      expect(ctx.open_threads[0].days_since_last_mention).toBe(3);
+    });
+  });
+
+  describe('promises owed', () => {
+    it('returns only status=owed promises', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: { ok: true, rows: [] },
+        promisesResult: {
+          ok: true,
+          rows: [
+            promise({ promise_id: 'a', status: 'owed' }),
+            promise({ promise_id: 'b', status: 'kept', kept_at: '2026-05-11T00:00:00Z' }),
+            promise({ promise_id: 'c', status: 'broken' }),
+            promise({ promise_id: 'd', status: 'cancelled' }),
+          ],
+        },
+        nowMs: NOW,
+      });
+      expect(ctx.promises_owed.map(p => p.promise_id)).toEqual(['a']);
+    });
+
+    it('sorts owed by due_at ASC (soonest first)', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: { ok: true, rows: [] },
+        promisesResult: {
+          ok: true,
+          rows: [
+            promise({ promise_id: 'a', due_at: '2026-05-13T00:00:00Z' }),
+            promise({ promise_id: 'b', due_at: '2026-05-11T00:00:00Z' }),
+            promise({ promise_id: 'c', due_at: '2026-05-12T00:00:00Z' }),
+          ],
+        },
+        nowMs: NOW,
+      });
+      expect(ctx.promises_owed.map(p => p.promise_id)).toEqual(['b', 'c', 'a']);
+    });
+
+    it('places null due_at AFTER any present due_at', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: { ok: true, rows: [] },
+        promisesResult: {
+          ok: true,
+          rows: [
+            promise({ promise_id: 'a', due_at: null }),
+            promise({ promise_id: 'b', due_at: '2026-05-15T00:00:00Z' }),
+            promise({ promise_id: 'c', due_at: null }),
+          ],
+        },
+        nowMs: NOW,
+      });
+      expect(ctx.promises_owed.map(p => p.promise_id)).toEqual(['b', 'a', 'c']);
+    });
+
+    it('computes days_overdue (positive when overdue)', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: { ok: true, rows: [] },
+        promisesResult: {
+          ok: true,
+          rows: [
+            promise({ promise_id: 'a', due_at: new Date(NOW - 2 * DAY).toISOString() }),
+          ],
+        },
+        nowMs: NOW,
+      });
+      expect(ctx.promises_owed[0].days_overdue).toBe(2);
+    });
+
+    it('returns negative days_overdue when due_at is in the future', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: { ok: true, rows: [] },
+        promisesResult: {
+          ok: true,
+          rows: [
+            promise({ promise_id: 'a', due_at: new Date(NOW + 2 * DAY).toISOString() }),
+          ],
+        },
+        nowMs: NOW,
+      });
+      expect(ctx.promises_owed[0].days_overdue).toBeLessThanOrEqual(0);
+    });
+
+    it('caps to promisesOwedLimit (default 5)', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: { ok: true, rows: [] },
+        promisesResult: {
+          ok: true,
+          rows: Array.from({ length: 10 }, (_, i) =>
+            promise({ promise_id: 'p' + i, due_at: new Date(NOW + i * DAY).toISOString() }),
+          ),
+        },
+        nowMs: NOW,
+      });
+      expect(ctx.promises_owed).toHaveLength(5);
+    });
+  });
+
+  describe('promises kept recently', () => {
+    it('returns only status=kept promises with kept_at in last 7 days', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: { ok: true, rows: [] },
+        promisesResult: {
+          ok: true,
+          rows: [
+            promise({ promise_id: 'recent', status: 'kept', kept_at: new Date(NOW - 2 * DAY).toISOString() }),
+            promise({ promise_id: 'old',    status: 'kept', kept_at: new Date(NOW - 30 * DAY).toISOString() }),
+            promise({ promise_id: 'no_ts',  status: 'kept', kept_at: null }),
+            promise({ promise_id: 'owed',   status: 'owed' }),
+          ],
+        },
+        nowMs: NOW,
+      });
+      expect(ctx.promises_kept_recently.map(p => p.promise_id)).toEqual(['recent']);
+    });
+
+    it('sorts by kept_at DESC', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: { ok: true, rows: [] },
+        promisesResult: {
+          ok: true,
+          rows: [
+            promise({ promise_id: 'a', status: 'kept', kept_at: new Date(NOW - 1 * DAY).toISOString() }),
+            promise({ promise_id: 'b', status: 'kept', kept_at: new Date(NOW - 3 * DAY).toISOString() }),
+            promise({ promise_id: 'c', status: 'kept', kept_at: new Date(NOW - 2 * DAY).toISOString() }),
+          ],
+        },
+        nowMs: NOW,
+      });
+      expect(ctx.promises_kept_recently.map(p => p.promise_id)).toEqual(['a', 'c', 'b']);
+    });
+
+    it('caps to promisesKeptLimit (default 3)', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: { ok: true, rows: [] },
+        promisesResult: {
+          ok: true,
+          rows: Array.from({ length: 8 }, (_, i) =>
+            promise({
+              promise_id: 'k' + i,
+              status: 'kept',
+              kept_at: new Date(NOW - i * 60 * 1000).toISOString(),
+            }),
+          ),
+        },
+        nowMs: NOW,
+      });
+      expect(ctx.promises_kept_recently).toHaveLength(3);
+    });
+  });
+
+  describe('counts', () => {
+    it('open_threads_total counts all open threads (not just the capped surface)', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: {
+          ok: true,
+          rows: Array.from({ length: 12 }, (_, i) => thread({ thread_id: 't' + i })),
+        },
+        promisesResult: { ok: true, rows: [] },
+        nowMs: NOW,
+        openThreadLimit: 3,
+      });
+      expect(ctx.counts.open_threads_total).toBe(12);
+      expect(ctx.open_threads).toHaveLength(3);
+    });
+
+    it('promises_owed_total counts all owed (not just the surfaced 5)', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: { ok: true, rows: [] },
+        promisesResult: {
+          ok: true,
+          rows: Array.from({ length: 8 }, (_, i) => promise({ promise_id: 'p' + i })),
+        },
+        nowMs: NOW,
+      });
+      expect(ctx.counts.promises_owed_total).toBe(8);
+    });
+
+    it('promises_overdue counts owed promises with due_at < now', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: { ok: true, rows: [] },
+        promisesResult: {
+          ok: true,
+          rows: [
+            promise({ promise_id: 'a', due_at: new Date(NOW - 1 * DAY).toISOString() }),
+            promise({ promise_id: 'b', due_at: new Date(NOW + 1 * DAY).toISOString() }),
+            promise({ promise_id: 'c', due_at: new Date(NOW - 5 * DAY).toISOString() }),
+            promise({ promise_id: 'd', due_at: null }),
+          ],
+        },
+        nowMs: NOW,
+      });
+      expect(ctx.counts.promises_overdue).toBe(2);
+    });
+
+    it('threads_mentioned_today uses UTC day boundary', () => {
+      // 2026-05-11T12:00:00Z → UTC day starts 2026-05-11T00:00:00Z.
+      const ctx = compileContinuityContext({
+        threadsResult: {
+          ok: true,
+          rows: [
+            thread({ thread_id: 'today_early', last_mentioned_at: '2026-05-11T00:01:00Z' }),
+            thread({ thread_id: 'today_late',  last_mentioned_at: '2026-05-11T11:59:00Z' }),
+            thread({ thread_id: 'yesterday',   last_mentioned_at: '2026-05-10T23:59:00Z' }),
+          ],
+        },
+        promisesResult: { ok: true, rows: [] },
+        nowMs: NOW,
+      });
+      expect(ctx.counts.threads_mentioned_today).toBe(2);
+    });
+  });
+
+  describe('source_health', () => {
+    it('passes through ok:true when both fetches succeed', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: { ok: true, rows: [] },
+        promisesResult: { ok: true, rows: [] },
+        nowMs: NOW,
+      });
+      expect(ctx.source_health.user_open_threads.ok).toBe(true);
+      expect(ctx.source_health.assistant_promises.ok).toBe(true);
+    });
+
+    it('reflects failure with reason when threads fetch failed', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: { ok: false, rows: [], reason: 'supabase_unconfigured' },
+        promisesResult: { ok: true, rows: [] },
+        nowMs: NOW,
+      });
+      expect(ctx.source_health.user_open_threads.ok).toBe(false);
+      expect(ctx.source_health.user_open_threads.reason).toBe('supabase_unconfigured');
+      expect(ctx.source_health.assistant_promises.ok).toBe(true);
+    });
+
+    it('treats !ok inputs as empty rows for surface arrays', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: { ok: false, rows: [], reason: 'boom' },
+        promisesResult: { ok: false, rows: [], reason: 'boom' },
+        nowMs: NOW,
+      });
+      expect(ctx.open_threads).toEqual([]);
+      expect(ctx.promises_owed).toEqual([]);
+      expect(ctx.promises_kept_recently).toEqual([]);
+      expect(ctx.counts.open_threads_total).toBe(0);
+    });
+
+    it('defaults reason to "unknown_failure" when an !ok result omits one', () => {
+      const ctx = compileContinuityContext({
+        threadsResult: { ok: false, rows: [] },
+        promisesResult: { ok: false, rows: [] },
+        nowMs: NOW,
+      });
+      expect(ctx.source_health.user_open_threads.reason).toBe('unknown_failure');
+      expect(ctx.source_health.assistant_promises.reason).toBe('unknown_failure');
+    });
+  });
+});

--- a/services/gateway/test/services/continuity/continuity-fetcher.test.ts
+++ b/services/gateway/test/services/continuity/continuity-fetcher.test.ts
@@ -1,0 +1,259 @@
+/**
+ * VTID-02932 (B2) — Supabase-backed ContinuityFetcher tests.
+ *
+ * Verifies:
+ *   - Read-only interface — no mutator methods exposed (B2 wall).
+ *   - DB unavailable / error → empty arrays + source_health flag.
+ *   - Row mapping handles missing / wrong-type columns defensively.
+ *   - Limit clamping (1..50).
+ *   - Status filter passes through when provided.
+ */
+
+import {
+  createSupabaseContinuityFetcher,
+  mapThreadRow,
+  mapPromiseRow,
+} from '../../../src/services/continuity/continuity-fetcher';
+
+function makeFakeClient(behavior: {
+  threadsRows?: unknown[];
+  promisesRows?: unknown[];
+  threadsError?: unknown;
+  promisesError?: unknown;
+  captureStatusEq?: (table: string, status: string) => void;
+  captureLimit?: (table: string, limit: number) => void;
+}) {
+  const client = {
+    from(table: string) {
+      const isThreads = table === 'user_open_threads';
+      const builder: any = {
+        select() { return builder; },
+        eq(col: string, val: string) {
+          if (col === 'status' && behavior.captureStatusEq) {
+            behavior.captureStatusEq(table, val);
+          }
+          return builder;
+        },
+        order() { return builder; },
+        limit(n: number) {
+          if (behavior.captureLimit) behavior.captureLimit(table, n);
+          return builder;
+        },
+        async then(resolve: (v: unknown) => void) {
+          if (isThreads) {
+            resolve({
+              data: behavior.threadsError ? null : (behavior.threadsRows ?? []),
+              error: behavior.threadsError ?? null,
+            });
+          } else {
+            resolve({
+              data: behavior.promisesError ? null : (behavior.promisesRows ?? []),
+              error: behavior.promisesError ?? null,
+            });
+          }
+        },
+      };
+      return builder;
+    },
+  };
+  return client;
+}
+
+describe('B2 — Supabase-backed ContinuityFetcher', () => {
+  describe('read-only contract (B2 wall)', () => {
+    it('ContinuityFetcher interface exposes ONLY listOpenThreads + listPromises', () => {
+      const fetcher = createSupabaseContinuityFetcher({ getDb: (() => null) as any });
+      const keys = Object.keys(fetcher).sort();
+      expect(keys).toEqual(['listOpenThreads', 'listPromises']);
+    });
+  });
+
+  describe('DB unavailable', () => {
+    it('returns ok:false + empty rows + reason when getSupabase returns null', async () => {
+      const fetcher = createSupabaseContinuityFetcher({ getDb: (() => null) as any });
+      const t = await fetcher.listOpenThreads({ tenantId: 't', userId: 'u' });
+      const p = await fetcher.listPromises({ tenantId: 't', userId: 'u' });
+      expect(t.ok).toBe(false);
+      expect(t.rows).toEqual([]);
+      expect(t.reason).toBe('supabase_unconfigured');
+      expect(p.ok).toBe(false);
+      expect(p.rows).toEqual([]);
+      expect(p.reason).toBe('supabase_unconfigured');
+    });
+
+    it('returns ok:false + empty rows + reason on Supabase error', async () => {
+      const client = makeFakeClient({
+        threadsError: { message: 'boom-threads' },
+        promisesError: { message: 'boom-promises' },
+      });
+      const fetcher = createSupabaseContinuityFetcher({ getDb: (() => client) as any });
+      const t = await fetcher.listOpenThreads({ tenantId: 't', userId: 'u' });
+      const p = await fetcher.listPromises({ tenantId: 't', userId: 'u' });
+      expect(t.ok).toBe(false);
+      expect(t.rows).toEqual([]);
+      expect(t.reason).toBe('boom-threads');
+      expect(p.ok).toBe(false);
+      expect(p.rows).toEqual([]);
+      expect(p.reason).toBe('boom-promises');
+    });
+  });
+
+  describe('happy path', () => {
+    it('maps thread rows', async () => {
+      const client = makeFakeClient({
+        threadsRows: [{
+          thread_id: 't1',
+          topic: 'magnesium',
+          summary: 'follow up on dosage',
+          status: 'open',
+          session_id_first: 's1',
+          session_id_last: 's2',
+          last_mentioned_at: '2026-05-10T12:00:00Z',
+          resolved_at: null,
+          created_at: '2026-05-01T12:00:00Z',
+          updated_at: '2026-05-10T12:00:00Z',
+        }],
+      });
+      const fetcher = createSupabaseContinuityFetcher({ getDb: (() => client) as any });
+      const t = await fetcher.listOpenThreads({ tenantId: 't', userId: 'u' });
+      expect(t.ok).toBe(true);
+      expect(t.rows).toHaveLength(1);
+      expect(t.rows[0].thread_id).toBe('t1');
+      expect(t.rows[0].topic).toBe('magnesium');
+      expect(t.rows[0].status).toBe('open');
+    });
+
+    it('maps promise rows', async () => {
+      const client = makeFakeClient({
+        promisesRows: [{
+          promise_id: 'p1',
+          thread_id: 't1',
+          session_id: 's2',
+          promise_text: 'remind me at 8pm',
+          due_at: '2026-05-11T20:00:00Z',
+          status: 'owed',
+          decision_id: 'd1',
+          kept_at: null,
+          created_at: '2026-05-10T12:00:00Z',
+          updated_at: '2026-05-10T12:00:00Z',
+        }],
+      });
+      const fetcher = createSupabaseContinuityFetcher({ getDb: (() => client) as any });
+      const p = await fetcher.listPromises({ tenantId: 't', userId: 'u' });
+      expect(p.ok).toBe(true);
+      expect(p.rows).toHaveLength(1);
+      expect(p.rows[0].promise_id).toBe('p1');
+      expect(p.rows[0].status).toBe('owed');
+    });
+  });
+
+  describe('limit clamping', () => {
+    it('clamps undefined → 20', async () => {
+      let captured = -1;
+      const client = makeFakeClient({
+        threadsRows: [],
+        captureLimit: (_table, n) => { captured = n; },
+      });
+      const fetcher = createSupabaseContinuityFetcher({ getDb: (() => client) as any });
+      await fetcher.listOpenThreads({ tenantId: 't', userId: 'u' });
+      expect(captured).toBe(20);
+    });
+
+    it('clamps > 50 to 50', async () => {
+      let captured = -1;
+      const client = makeFakeClient({
+        threadsRows: [],
+        captureLimit: (_table, n) => { captured = n; },
+      });
+      const fetcher = createSupabaseContinuityFetcher({ getDb: (() => client) as any });
+      await fetcher.listOpenThreads({ tenantId: 't', userId: 'u', limit: 999 });
+      expect(captured).toBe(50);
+    });
+
+    it('clamps < 1 to 1', async () => {
+      let captured = -1;
+      const client = makeFakeClient({
+        promisesRows: [],
+        captureLimit: (_table, n) => { captured = n; },
+      });
+      const fetcher = createSupabaseContinuityFetcher({ getDb: (() => client) as any });
+      await fetcher.listPromises({ tenantId: 't', userId: 'u', limit: 0 });
+      expect(captured).toBe(1);
+    });
+  });
+
+  describe('status filter on listPromises', () => {
+    it('passes status through to supabase when provided', async () => {
+      let captured = '';
+      const client = makeFakeClient({
+        promisesRows: [],
+        captureStatusEq: (_table, s) => { captured = s; },
+      });
+      const fetcher = createSupabaseContinuityFetcher({ getDb: (() => client) as any });
+      await fetcher.listPromises({ tenantId: 't', userId: 'u', status: 'owed' });
+      expect(captured).toBe('owed');
+    });
+
+    it('omits status filter when status is absent', async () => {
+      const captured: string[] = [];
+      const client = makeFakeClient({
+        promisesRows: [],
+        captureStatusEq: (_table, s) => { captured.push(s); },
+      });
+      const fetcher = createSupabaseContinuityFetcher({ getDb: (() => client) as any });
+      await fetcher.listPromises({ tenantId: 't', userId: 'u' });
+      expect(captured).toEqual([]);
+    });
+  });
+
+  describe('mapThreadRow defensives', () => {
+    it('handles a completely empty row', () => {
+      const r = mapThreadRow({});
+      expect(r.thread_id).toBe('');
+      expect(r.topic).toBe('');
+      expect(r.summary).toBeNull();
+      expect(r.status).toBe('open');
+      expect(r.session_id_first).toBeNull();
+      expect(r.session_id_last).toBeNull();
+      expect(r.last_mentioned_at).toBe('');
+      expect(r.resolved_at).toBeNull();
+    });
+
+    it('coerces unknown status to "open"', () => {
+      const r = mapThreadRow({ status: 'gibberish' });
+      expect(r.status).toBe('open');
+    });
+
+    it('keeps known status values', () => {
+      expect(mapThreadRow({ status: 'open' }).status).toBe('open');
+      expect(mapThreadRow({ status: 'resolved' }).status).toBe('resolved');
+      expect(mapThreadRow({ status: 'abandoned' }).status).toBe('abandoned');
+    });
+  });
+
+  describe('mapPromiseRow defensives', () => {
+    it('handles a completely empty row', () => {
+      const r = mapPromiseRow({});
+      expect(r.promise_id).toBe('');
+      expect(r.thread_id).toBeNull();
+      expect(r.session_id).toBeNull();
+      expect(r.promise_text).toBe('');
+      expect(r.due_at).toBeNull();
+      expect(r.status).toBe('owed');
+      expect(r.decision_id).toBeNull();
+      expect(r.kept_at).toBeNull();
+    });
+
+    it('coerces unknown status to "owed"', () => {
+      const r = mapPromiseRow({ status: 'pending' });
+      expect(r.status).toBe('owed');
+    });
+
+    it('keeps known status values', () => {
+      expect(mapPromiseRow({ status: 'owed' }).status).toBe('owed');
+      expect(mapPromiseRow({ status: 'kept' }).status).toBe('kept');
+      expect(mapPromiseRow({ status: 'broken' }).status).toBe('broken');
+      expect(mapPromiseRow({ status: 'cancelled' }).status).toBe('cancelled');
+    });
+  });
+});

--- a/services/worker-runner/src/services/execution-service-delegation.test.ts
+++ b/services/worker-runner/src/services/execution-service-delegation.test.ts
@@ -176,8 +176,14 @@ describe('executeTask — self-healing delegation', () => {
     expect(result.error).toContain('ANTHROPIC_API_KEY');
   });
 
-  it('falls back to local LLM path when self-healing flag set but execution_id missing', async () => {
-    delete process.env.ANTHROPIC_API_KEY;
+  // PR-E (VTID-02931, Gap 1): self-healing tasks without an autopilot
+  // bridge MUST NOT fall back to the local LLM path. The repair-evidence
+  // gate from PR #2045 was a weak check — Claude can hallucinate file
+  // paths in its describe-only output and slip past `files_changed.length
+  // > 0`. The worker-runner now refuses the fallback entirely.
+  it('REFUSES local LLM fallback when self-healing flag set but execution_id missing (Gap 1)', async () => {
+    process.env.ANTHROPIC_API_KEY = 'fake-key-that-should-NEVER-be-used';
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
     const partialTask: PendingTask = {
       ...selfHealingTask(),
       metadata: { source: 'self-healing' }, // no autopilot_execution_id
@@ -187,6 +193,13 @@ describe('executeTask — self-healing delegation', () => {
 
     expect(mockAwait).not.toHaveBeenCalled();
     expect(result.ok).toBe(false);
+    expect(result.error).toContain('refusing legacy LLM fallback');
+    expect(result.healing_state).toBe('execution_failed');
+    expect(result.provider).toBe('self-healing-guard');
+    // The model field must NOT be claude-* — confirms no Claude call.
+    expect(result.model).toBe('none');
+    expect(warnSpy).toHaveBeenCalledWith(expect.stringContaining('Refusing legacy LLM fallback'));
+    warnSpy.mockRestore();
   });
 
   it('surfaces gateway errors instead of silently treating as success', async () => {

--- a/services/worker-runner/src/services/execution-service.ts
+++ b/services/worker-runner/src/services/execution-service.ts
@@ -340,6 +340,31 @@ export async function executeTask(
     );
     return await delegateToAutopilot(config, task, autopilotExecutionId, modelName, provider, startTime);
   }
+  // PR-E (VTID-02931, Gap 1): never fall through to the local LLM for
+  // self-healing tasks. The repair-evidence gate from PR #2045 is a weak
+  // check — Claude can hallucinate file paths in its describe-only output,
+  // which slips past the `files_changed.length > 0` check and produces a
+  // false success. Worker-runner must refuse to even attempt the local
+  // path when the autopilot bridge linkage is missing; the task fails
+  // hard, the reconciler tombstones it, and the operator sees the bridge
+  // failure that needs root-cause attention (safety-gate block, scope
+  // mismatch, etc.) instead of a silently-fake "fixed" claim.
+  if (isSelfHealing && !autopilotExecutionId) {
+    console.warn(
+      `[${VTID}] Refusing legacy LLM fallback for self-healing task ${task.vtid}: ` +
+        `metadata.autopilot_execution_id is missing (bridge failed upstream). ` +
+        `See self-healing.execution.bridge_failed in oasis_events for the root cause.`,
+    );
+    return {
+      ok: false,
+      error:
+        'self-healing requires autopilot bridge — refusing legacy LLM fallback (see self-healing.execution.bridge_failed)',
+      duration_ms: Date.now() - startTime,
+      model: 'none',
+      provider: 'self-healing-guard',
+      healing_state: 'execution_failed',
+    };
+  }
 
   if (!initClaude()) {
     return {

--- a/supabase/migrations/20260520000000_VTID_02932_continuity_tables.sql
+++ b/supabase/migrations/20260520000000_VTID_02932_continuity_tables.sql
@@ -1,0 +1,163 @@
+-- B2 (orb-live-refactor) — conversation continuity tables.
+--
+-- VTID-02932. Two tables that feed signals 40–45 of the assistant
+-- decision context:
+--
+--   user_open_threads   — durable conversation threads the user
+--                         left unfinished. Vitana can later say
+--                         "I owe you a follow-up about X" without
+--                         re-deriving the topic from scratch.
+--   assistant_promises  — concrete things Vitana said it would do
+--                         or follow up on. Vitana can later say
+--                         "last time I promised to remind you
+--                         about magnesium — here it is."
+--
+-- Wall (B2 lane):
+--   Selection is read-only. State advancement (creating threads,
+--   marking promises kept/broken) happens through dedicated event
+--   paths in a follow-up slice — NOT inside the preview/panel
+--   routes. Mirrors the B0e wall pattern.
+--
+-- RLS: tenant-scoped read/write via user_tenants (same pattern as
+-- B0c user_assistant_state and B0e.1 awareness tables).
+
+-- ---------------------------------------------------------------
+-- user_open_threads — durable unfinished conversations
+-- ---------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS user_open_threads (
+  thread_id            UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id            UUID NOT NULL,
+  user_id              UUID NOT NULL,
+  topic                TEXT NOT NULL,
+  summary              TEXT,
+  status               TEXT NOT NULL DEFAULT 'open'
+    CHECK (status IN ('open', 'resolved', 'abandoned')),
+  -- Sessions where the thread first appeared and was last mentioned.
+  -- Live-session ids are text (e.g. "live-<uuid>"), not UUIDs.
+  session_id_first     TEXT,
+  session_id_last      TEXT,
+  last_mentioned_at    TIMESTAMPTZ NOT NULL DEFAULT now(),
+  resolved_at          TIMESTAMPTZ,
+  created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at           TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS user_open_threads_user_idx
+  ON user_open_threads (tenant_id, user_id, last_mentioned_at DESC);
+
+CREATE INDEX IF NOT EXISTS user_open_threads_open_idx
+  ON user_open_threads (tenant_id, user_id, last_mentioned_at DESC)
+  WHERE status = 'open';
+
+CREATE OR REPLACE FUNCTION user_open_threads_touch_updated_at()
+  RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS user_open_threads_updated_at_trigger ON user_open_threads;
+CREATE TRIGGER user_open_threads_updated_at_trigger
+  BEFORE UPDATE ON user_open_threads
+  FOR EACH ROW
+  EXECUTE FUNCTION user_open_threads_touch_updated_at();
+
+ALTER TABLE user_open_threads ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS user_open_threads_tenant_isolation ON user_open_threads;
+CREATE POLICY user_open_threads_tenant_isolation
+  ON user_open_threads
+  FOR ALL
+  TO authenticated
+  USING (
+    tenant_id IN (
+      SELECT tenant_id FROM user_tenants WHERE user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    tenant_id IN (
+      SELECT tenant_id FROM user_tenants WHERE user_id = auth.uid()
+    )
+  );
+
+-- ---------------------------------------------------------------
+-- assistant_promises — Vitana's owed follow-ups
+-- ---------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS assistant_promises (
+  promise_id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id            UUID NOT NULL,
+  user_id              UUID NOT NULL,
+  session_id           TEXT,
+  thread_id            UUID REFERENCES user_open_threads(thread_id) ON DELETE SET NULL,
+  promise_text         TEXT NOT NULL,
+  due_at               TIMESTAMPTZ,
+  status               TEXT NOT NULL DEFAULT 'owed'
+    CHECK (status IN ('owed', 'kept', 'broken', 'cancelled')),
+  -- Tying the promise back to a continuation decision lets the
+  -- Continuation Inspector trace promised follow-ups end-to-end.
+  decision_id          TEXT,
+  kept_at              TIMESTAMPTZ,
+  created_at           TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at           TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS assistant_promises_user_idx
+  ON assistant_promises (tenant_id, user_id, created_at DESC);
+
+-- Owed promises are the hot-path query — they drive the continuity
+-- nudge "I still owe you X". A partial index keeps it small even
+-- when the table grows large.
+CREATE INDEX IF NOT EXISTS assistant_promises_owed_idx
+  ON assistant_promises (tenant_id, user_id, due_at NULLS LAST)
+  WHERE status = 'owed';
+
+CREATE OR REPLACE FUNCTION assistant_promises_touch_updated_at()
+  RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS assistant_promises_updated_at_trigger ON assistant_promises;
+CREATE TRIGGER assistant_promises_updated_at_trigger
+  BEFORE UPDATE ON assistant_promises
+  FOR EACH ROW
+  EXECUTE FUNCTION assistant_promises_touch_updated_at();
+
+ALTER TABLE assistant_promises ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS assistant_promises_tenant_isolation ON assistant_promises;
+CREATE POLICY assistant_promises_tenant_isolation
+  ON assistant_promises
+  FOR ALL
+  TO authenticated
+  USING (
+    tenant_id IN (
+      SELECT tenant_id FROM user_tenants WHERE user_id = auth.uid()
+    )
+  )
+  WITH CHECK (
+    tenant_id IN (
+      SELECT tenant_id FROM user_tenants WHERE user_id = auth.uid()
+    )
+  );
+
+-- ---------------------------------------------------------------
+-- Documentation
+-- ---------------------------------------------------------------
+
+COMMENT ON TABLE user_open_threads IS
+  'B2 (orb-live-refactor): durable record of unfinished conversation '
+  'topics. Selection is read-only — state advancement (open→resolved/'
+  'abandoned) happens through dedicated event paths in a follow-up '
+  'slice, never inside preview/panel routes.';
+
+COMMENT ON TABLE assistant_promises IS
+  'B2 (orb-live-refactor): concrete things Vitana said it would do or '
+  'follow up on. status: owed | kept | broken | cancelled. decision_id '
+  'links back to the AssistantContinuationDecision that produced the '
+  'promise, so the Continuation Inspector can trace follow-ups end-to-end.';


### PR DESCRIPTION
## Summary

Stands up the **minimal** `AssistantDecisionContext` spine and wires **only continuity** through it. The instruction layer renders the typed contract; the compiler distills. Raw rows never cross the boundary.

The decision-contract spine did not exist in code before this PR. The B-slice read-only Command Hub previews (B0e capability awareness, R0 wake timeline, B1 greeting decay, B2 continuity, B3 concept mastery, B4 journey stage) all shipped self-contained compilers and operator panels — but none of them connected to actual prompt assembly. This PR is the spine that lets future signals plug in via the same path.

## Path through the contract

```
compileContinuityContext           (existing B2 read-only compiler)
  → distillContinuityForDecision   (new adapter — strips raw fields)
  → AssistantDecisionContext.continuity   (new typed contract)
  → renderDecisionContract         (new renderer)
  → appended to systemInstruction in orb-live.ts:9091
```

Future signals (concept mastery, journey stage, match journey, feature discovery, wake brief, etc.) plug in by:
1. Adding a typed field to `AssistantDecisionContext`
2. Registering a provider in `compileAssistantDecisionContext`
3. Extending `renderDecisionContract` to format the new field

**No raw context can ever cross the boundary again** because the renderer reads only the typed contract.

## Files

**New (4 src + 5 test):**
- [`services/gateway/src/orb/context/types.ts`](services/gateway/src/orb/context/types.ts) — `AssistantDecisionContext`, `DecisionContinuity`, `DecisionSourceHealth`
- [`services/gateway/src/orb/context/providers/continuity-decision-provider.ts`](services/gateway/src/orb/context/providers/continuity-decision-provider.ts) — `distillContinuityForDecision()` + `truncate()` + `pickRecommendedFollowUp()`
- [`services/gateway/src/orb/context/compile-assistant-decision-context.ts`](services/gateway/src/orb/context/compile-assistant-decision-context.ts) — orchestrator with per-provider try/catch
- [`services/gateway/src/orb/live/instruction/decision-contract-renderer.ts`](services/gateway/src/orb/live/instruction/decision-contract-renderer.ts) — accepts only `AssistantDecisionContext`, emits prompt section string

**Modified (1):**
- [`services/gateway/src/routes/orb-live.ts`](services/gateway/src/routes/orb-live.ts) — single insertion at the `/conversation` handler (line 9091). `generateSystemInstruction(session)` is byte-for-byte unchanged. The other 3 fallback call sites stay on the old helper (out of scope for this minimal slice).

## Acceptance check matrix

- [x] **#1** Empty continuity produces a valid `AssistantDecisionContext` with safe empty defaults — `compile-assistant-decision-context.test.ts` "provider returns null"
- [x] **#2** Continuity data is distilled (counts, short labels, overdue boolean, follow-up kind, source health). Forbidden: raw messages / promises / memory rows / profile payloads — `continuity-decision-provider.test.ts` "forbidden raw fields are NOT surfaced"
- [x] **#3** Renderer only accepts `AssistantDecisionContext`, never raw compiler output — `decision-contract-renderer.test.ts` "raw-field ignorance"
- [x] **#4** `generateSystemInstruction()` does not query memory directly. Renderer file has no imports from `services/`, no supabase, no `fetch()` — `decision-contract-renderer.test.ts` "purity — wall enforcement"
- [x] **#5** Existing system instruction text remains byte-for-byte stable except for the new appended section — `generateSystemInstruction(session)` is unchanged; the appendage happens at one call site after the existing instruction is built
- [x] **#6** If continuity compiler fails, prompt still renders with `sourceHealth=degraded` and no crash — `compile-assistant-decision-context.test.ts` "provider throws"
- [x] **#7** Tests prove raw fields cannot pass through the context schema — `decision-context-types.test.ts` "forbidden raw fields are NOT declared in DecisionContinuity"
- [x] **#8** Command Hub preview and actual prompt contract use the same compiler path — both start at `compileContinuityContext`; the preview consumes it as JSON, the prompt path adds the distill+render pipeline — `spine-end-to-end.test.ts` exercises the full chain

## Test plan

- [x] **152 tests green** in touched suites (37 new + 115 existing in `orb/context`, `orb/live/instruction`, and the B2 continuity suites)
- [x] `npx tsc --noEmit --skipLibCheck` clean (only the pre-existing `sharp` error in `cover-image-outpaint.ts` remains)
- [x] No raw row fields (session ids, timestamps, status strings) leak into rendered output (asserted by `spine-end-to-end.test.ts`)
- [x] Wall test enforces renderer has no service/supabase/fetch imports
- [ ] Smoke test on dev: hit `/api/v1/orb/live/conversation` for a user with continuity state; verify rendered `Assistant decision contract:` section appears in the system instruction log

## Out of scope (explicitly NOT in this PR)

Per direction: match journey, feature discovery, wake brief, continuation contract, greeting decay rewrite, repetition suppression, journey stage modulation, reliability tuning. Each gets its own slice that plugs into the spine via the same pattern.

## Dependency

This PR rebases on `orb-live-refactor/B2-conversation-continuity` (PR #2063), which ships the underlying continuity fetcher + compiler. Once #2063 merges to main, this PR's base resets to main automatically.

🤖 Generated with [Claude Code](https://claude.com/claude-code)