### PR TITLE
feat(orb): B0b-min spine + B2 continuity decision integration (VTID-02941)

### DIFF
--- a/services/gateway/src/orb/context/compile-assistant-decision-context.ts
+++ b/services/gateway/src/orb/context/compile-assistant-decision-context.ts
@@ -1,0 +1,124 @@
+/**
+ * VTID-02941 (B0b-min) — compileAssistantDecisionContext.
+ *
+ * The orchestrator. Calls each registered provider, collects their
+ * distilled output, and produces ONE `AssistantDecisionContext` the
+ * instruction layer can read.
+ *
+ * In this slice ONLY continuity is wired. The signature is designed so
+ * future slices can plug in additional providers (matchJourney,
+ * conceptMastery, journeyStage, etc.) WITHOUT changing the orchestrator
+ * surface — they each become an optional injected provider.
+ *
+ * Failure policy: every provider runs in its own try/catch boundary. A
+ * thrown error or a Supabase failure becomes `source_health.<source>.ok =
+ * false` with a reason; the field on the context becomes `null`. The
+ * orchestrator NEVER throws upward — a broken provider must not block
+ * prompt assembly (acceptance #6).
+ *
+ * Pure with respect to clock side-effects (now is injected) but does
+ * call providers (which may do IO). Providers are responsible for
+ * their own retries; the orchestrator just passes results through.
+ */
+
+import { defaultContinuityFetcher } from '../../services/continuity/continuity-fetcher';
+import { compileContinuityContext } from '../../services/continuity/compile-continuity-context';
+import {
+  distillContinuityForDecision,
+} from './providers/continuity-decision-provider';
+import type {
+  AssistantDecisionContext,
+  DecisionContinuity,
+} from './types';
+
+export interface CompileAssistantDecisionContextInputs {
+  userId: string;
+  tenantId: string;
+  /** Injected for testability. Production passes Date.now(). */
+  nowMs?: number;
+  /**
+   * Provider overrides for tests. Production passes nothing and we use
+   * the defaults wired into `services/continuity/*`.
+   */
+  providers?: Partial<{
+    continuity: () => Promise<DecisionContinuity | null>;
+  }>;
+  /**
+   * Source-health reporter override for tests — when the provider
+   * returns null, this lets a test stub a reason without monkey-patching
+   * the default fetcher.
+   */
+  reasons?: Partial<{ continuity: string }>;
+}
+
+export async function compileAssistantDecisionContext(
+  input: CompileAssistantDecisionContextInputs,
+): Promise<AssistantDecisionContext> {
+  const continuityRun = await runContinuityProvider(input);
+
+  return {
+    continuity: continuityRun.value,
+    source_health: {
+      continuity: continuityRun.health,
+    },
+  };
+}
+
+interface ProviderRun<T> {
+  value: T | null;
+  health: { ok: boolean; reason?: string };
+}
+
+async function runContinuityProvider(
+  input: CompileAssistantDecisionContextInputs,
+): Promise<ProviderRun<DecisionContinuity>> {
+  const override = input.providers?.continuity;
+  if (override) {
+    try {
+      const value = await override();
+      return { value, health: { ok: true } };
+    } catch (e) {
+      return {
+        value: null,
+        health: { ok: false, reason: (e as Error).message },
+      };
+    }
+  }
+
+  try {
+    const [threadsResult, promisesResult] = await Promise.all([
+      defaultContinuityFetcher.listOpenThreads({
+        tenantId: input.tenantId,
+        userId: input.userId,
+        limit: 50,
+      }),
+      defaultContinuityFetcher.listPromises({
+        tenantId: input.tenantId,
+        userId: input.userId,
+        limit: 50,
+      }),
+    ]);
+
+    // If BOTH fetchers failed, treat the source as degraded. If one
+    // succeeded, the compiler builds a partial-but-typed view and the
+    // adapter can still distill it.
+    const anyOk = threadsResult.ok || promisesResult.ok;
+    if (!anyOk) {
+      const reason =
+        threadsResult.reason || promisesResult.reason || 'continuity_unavailable';
+      return { value: null, health: { ok: false, reason } };
+    }
+
+    const continuity = compileContinuityContext({
+      threadsResult,
+      promisesResult,
+      nowMs: input.nowMs,
+    });
+
+    const decisionView = distillContinuityForDecision({ continuity });
+    return { value: decisionView, health: { ok: true } };
+  } catch (e) {
+    const reason = input.reasons?.continuity ?? (e as Error).message;
+    return { value: null, health: { ok: false, reason } };
+  }
+}

--- a/services/gateway/src/orb/context/providers/continuity-decision-provider.ts
+++ b/services/gateway/src/orb/context/providers/continuity-decision-provider.ts
@@ -1,0 +1,110 @@
+/**
+ * VTID-02941 (B0b-min) — Continuity → AssistantDecisionContext adapter.
+ *
+ * The B2 read-only inspection slice already produced `ContinuityContext`,
+ * a richer shape designed for the Command Hub operator. The assistant
+ * decision layer reads a NARROWER shape (`DecisionContinuity`) that
+ * strips:
+ *   - raw timestamps (kept as boolean `overdue` or `null`)
+ *   - raw last_mentioned_at strings (kept as `days_since_last_mention`)
+ *   - raw kept_at strings (dropped entirely; the LLM only cares the
+ *     promise was kept recently)
+ *
+ * Truncation happens here, NOT in the renderer. By the time data
+ * crosses the adapter boundary, every string is short enough to render
+ * directly into a prompt section.
+ *
+ * Pure function. No IO. The caller is responsible for invoking the
+ * continuity compiler + passing its output here.
+ */
+
+import type { ContinuityContext } from '../../../services/continuity/types';
+import type { DecisionContinuity } from '../types';
+
+const TOPIC_MAX_CHARS = 60;
+const SUMMARY_MAX_CHARS = 120;
+const PROMISE_TEXT_MAX_CHARS = 120;
+
+export interface DistillContinuityInputs {
+  /**
+   * Output of `compileContinuityContext` from B2. Read-only.
+   */
+  continuity: ContinuityContext;
+}
+
+/**
+ * Distills `ContinuityContext` into the decision-grade `DecisionContinuity`.
+ *
+ * Always returns a typed shape (never undefined). The caller decides
+ * whether to attach it to `AssistantDecisionContext.continuity` or set
+ * the field to `null` based on source health.
+ */
+export function distillContinuityForDecision(
+  input: DistillContinuityInputs,
+): DecisionContinuity {
+  const { continuity } = input;
+
+  const open_threads = continuity.open_threads.map((t) => ({
+    thread_id: t.thread_id,
+    topic: truncate(t.topic, TOPIC_MAX_CHARS),
+    summary: t.summary ? truncate(t.summary, SUMMARY_MAX_CHARS) : null,
+    days_since_last_mention: t.days_since_last_mention,
+  }));
+
+  const promises_owed = continuity.promises_owed.map((p) => ({
+    promise_id: p.promise_id,
+    promise_text: truncate(p.promise_text, PROMISE_TEXT_MAX_CHARS),
+    overdue: typeof p.days_overdue === 'number' && p.days_overdue > 0,
+    decision_id: p.decision_id,
+  }));
+
+  const promises_kept_recently = continuity.promises_kept_recently.map((p) => ({
+    promise_id: p.promise_id,
+    promise_text: truncate(p.promise_text, PROMISE_TEXT_MAX_CHARS),
+  }));
+
+  const counts = {
+    open_threads_total: continuity.counts.open_threads_total,
+    promises_owed_total: continuity.counts.promises_owed_total,
+    promises_overdue: continuity.counts.promises_overdue,
+    threads_mentioned_today: continuity.counts.threads_mentioned_today,
+  };
+
+  const recommended_follow_up = pickRecommendedFollowUp({
+    overdue: counts.promises_overdue,
+    owed: counts.promises_owed_total,
+    keptRecently: promises_kept_recently.length,
+    openThreads: counts.open_threads_total,
+  });
+
+  return {
+    open_threads,
+    promises_owed,
+    promises_kept_recently,
+    counts,
+    recommended_follow_up,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — exported for tests
+// ---------------------------------------------------------------------------
+
+export function truncate(s: string, max: number): string {
+  if (typeof s !== 'string') return '';
+  if (s.length <= max) return s;
+  return s.slice(0, Math.max(0, max - 1)) + '…';
+}
+
+export function pickRecommendedFollowUp(args: {
+  overdue: number;
+  owed: number;
+  keptRecently: number;
+  openThreads: number;
+}): DecisionContinuity['recommended_follow_up'] {
+  // Priority: overdue debt > recent credit > open thread mention > nothing.
+  if (args.overdue > 0) return 'address_overdue_promise';
+  if (args.keptRecently > 0) return 'acknowledge_kept_promise';
+  if (args.openThreads > 0) return 'mention_open_thread';
+  return 'none';
+}

--- a/services/gateway/src/orb/context/types.ts
+++ b/services/gateway/src/orb/context/types.ts
@@ -1,0 +1,99 @@
+/**
+ * VTID-02941 (B0b-min) — AssistantDecisionContext: the decision contract.
+ *
+ * This is the SINGLE typed shape the instruction layer reads to assemble
+ * a prompt. Raw rows (memory, threads, messages, promises, profiles)
+ * MUST NOT cross this boundary. The compiler distills; the renderer
+ * formats. No exceptions.
+ *
+ * Wall (B0b-min):
+ *   - Forbidden in this slice: match journey, feature discovery, wake
+ *     brief, continuation contract, greeting decay rewrite, repetition
+ *     suppression, journey stage modulation, reliability tuning.
+ *   - Only `continuity` is wired through this contract in this PR.
+ *   - Adding new fields later is fine; pushing raw rows into them is not.
+ *
+ * Why this file is in `services/gateway/src/orb/context/`:
+ *   The plan's target module layout puts the context spine under
+ *   `services/gateway/src/orb/context/`. We honor that path so future
+ *   slices land in the same place rather than creating a parallel tree.
+ */
+
+/**
+ * Distilled continuity view that the assistant decision layer reads.
+ *
+ * Mirrors `ContinuityContext` from `services/continuity/types.ts` but
+ * narrower — only the fields the LLM needs to make a "should I bring
+ * this up?" decision. NEVER includes raw thread rows, raw promise rows,
+ * raw memory items, message bodies, or profile payloads.
+ */
+export interface DecisionContinuity {
+  /** Top-N open threads, most-recently-mentioned first (capped at 5). */
+  open_threads: ReadonlyArray<{
+    /** Stable thread id (so the LLM can refer to the same thread later). */
+    thread_id: string;
+    /** Short label — already truncated by the compiler. */
+    topic: string;
+    /** Optional one-line summary. NEVER the original message text. */
+    summary: string | null;
+    /** Recency hint. */
+    days_since_last_mention: number | null;
+  }>;
+  /** Owed promises, oldest-due first (capped at 5). */
+  promises_owed: ReadonlyArray<{
+    promise_id: string;
+    /** Short label — already truncated by the compiler. */
+    promise_text: string;
+    /** Boolean is enough for the decision layer; raw timestamps stay out. */
+    overdue: boolean;
+    /** Decision-id linkage when the promise traces back to a ranker decision. */
+    decision_id: string | null;
+  }>;
+  /** Recently-kept promises (capped at 3) — for credit acknowledgement. */
+  promises_kept_recently: ReadonlyArray<{
+    promise_id: string;
+    promise_text: string;
+  }>;
+  /** Aggregate counts the cadence layer uses. */
+  counts: {
+    open_threads_total: number;
+    promises_owed_total: number;
+    promises_overdue: number;
+    threads_mentioned_today: number;
+  };
+  /** Single recommended follow-up KIND (not copy). The renderer formats it. */
+  recommended_follow_up:
+    | 'mention_open_thread'
+    | 'acknowledge_kept_promise'
+    | 'address_overdue_promise'
+    | 'none';
+}
+
+/**
+ * Per-source health view. Empty/missing rows are not failures — they
+ * just mean the user has no continuity state yet. Failures (Supabase
+ * down, schema mismatch, etc.) surface here with a `reason`.
+ */
+export interface DecisionSourceHealth {
+  continuity: { ok: boolean; reason?: string };
+}
+
+/**
+ * The single typed contract the instruction layer reads.
+ *
+ * Future slices add fields (matchJourney, conceptMastery, journeyStage,
+ * etc.) — they MUST land here as distilled shapes, never raw rows.
+ *
+ * `additionalProperties=false` semantics are enforced by tests + the
+ * renderer's behavior: any unrecognized field is silently dropped.
+ */
+export interface AssistantDecisionContext {
+  /**
+   * Continuity decision view. `null` when the compiler had no input or
+   * source-health is degraded — the renderer must emit no continuity
+   * section in that case (acceptance #1 + #6).
+   */
+  continuity: DecisionContinuity | null;
+  /** Per-source health. Always present, even when fields are null. */
+  source_health: DecisionSourceHealth;
+}

--- a/services/gateway/src/orb/live/instruction/decision-contract-renderer.ts
+++ b/services/gateway/src/orb/live/instruction/decision-contract-renderer.ts
@@ -1,0 +1,115 @@
+/**
+ * VTID-02941 (B0b-min) — decision-contract-renderer.
+ *
+ * Single responsibility: take an `AssistantDecisionContext` and
+ * produce a prompt section string the static system instruction can
+ * append.
+ *
+ * The renderer ONLY reads `AssistantDecisionContext`. It MUST NOT:
+ *   - call providers
+ *   - query the database
+ *   - read memory tables
+ *   - touch Supabase directly
+ *   - import from `services/continuity/*` or any compiler module
+ *
+ * Type-level enforcement: the only argument is `AssistantDecisionContext`.
+ * A test asserts the renderer source file contains no `import` from
+ * `services/`, `lib/supabase`, or `fetch`.
+ *
+ * Empty / degraded handling:
+ *   - `decision.continuity === null` → no continuity section is emitted
+ *     (acceptance #1 + #6).
+ *   - `source_health.continuity.ok === false` → a small "[continuity:
+ *     source degraded — <reason>]" hint appears so the prompt remains
+ *     informative without inventing data.
+ *   - Empty arrays → that subsection is omitted, but the overall
+ *     section still renders if any subsection has content.
+ */
+
+import type {
+  AssistantDecisionContext,
+  DecisionContinuity,
+} from '../../context/types';
+
+export interface RenderDecisionContractOptions {
+  /**
+   * When true (default), the renderer prefixes a stable section header
+   * so logs/tests can find the appended block. When false, it omits
+   * the header (useful for inline tests).
+   */
+  withHeader?: boolean;
+}
+
+/**
+ * Renders `decision` as a prompt section string. Returns `''` when the
+ * decision context has no signal to surface AND no source health to
+ * report — i.e., when appending an empty string would just be noise.
+ */
+export function renderDecisionContract(
+  decision: AssistantDecisionContext,
+  opts: RenderDecisionContractOptions = {},
+): string {
+  const withHeader = opts.withHeader !== false;
+
+  const lines: string[] = [];
+
+  // ---- continuity ----
+  const continuitySection = renderContinuity(decision.continuity);
+  const continuityHealth = decision.source_health.continuity;
+
+  if (continuitySection) {
+    lines.push(continuitySection);
+  } else if (continuityHealth && continuityHealth.ok === false) {
+    lines.push(
+      `[continuity: source degraded — ${continuityHealth.reason ?? 'unknown_reason'}]`,
+    );
+  }
+
+  if (lines.length === 0) return '';
+
+  const body = lines.join('\n');
+  return withHeader ? `Assistant decision contract:\n${body}` : body;
+}
+
+// ---------------------------------------------------------------------------
+// Continuity sub-section
+// ---------------------------------------------------------------------------
+
+function renderContinuity(continuity: DecisionContinuity | null): string {
+  if (!continuity) return '';
+
+  const subs: string[] = [];
+
+  if (continuity.open_threads.length > 0) {
+    const lines = continuity.open_threads.map((t) => {
+      const age = t.days_since_last_mention === null
+        ? ''
+        : ` (${t.days_since_last_mention}d since last mention)`;
+      const summary = t.summary ? ` — ${t.summary}` : '';
+      return `  - ${t.topic}${age}${summary}`;
+    });
+    subs.push(['Open threads:', ...lines].join('\n'));
+  }
+
+  if (continuity.promises_owed.length > 0) {
+    const lines = continuity.promises_owed.map((p) => {
+      const overdueTag = p.overdue ? ' [overdue]' : '';
+      return `  - ${p.promise_text}${overdueTag}`;
+    });
+    subs.push(['Promises owed:', ...lines].join('\n'));
+  }
+
+  if (continuity.promises_kept_recently.length > 0) {
+    const lines = continuity.promises_kept_recently.map(
+      (p) => `  - ${p.promise_text}`,
+    );
+    subs.push(['Promises kept recently:', ...lines].join('\n'));
+  }
+
+  if (continuity.recommended_follow_up !== 'none') {
+    subs.push(`Recommended follow-up: ${continuity.recommended_follow_up}`);
+  }
+
+  if (subs.length === 0) return '';
+  return ['Continuity:', ...subs].join('\n');
+}

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -54,6 +54,11 @@ import { defaultWakeTimelineRecorder } from '../services/wake-timeline/wake-time
 // `decideWakeBriefForSession` runs the continuation decision and emits
 // the 3 continuation_decision_* timeline events.
 import { decideWakeBriefForSession } from '../services/wake-brief-wiring';
+// VTID-02941 (B0b-min + B2 decision integration): minimal decision-contract
+// spine. The instruction layer renders the typed contract; the compiler
+// distills. NO raw rows cross this boundary.
+import { compileAssistantDecisionContext } from '../orb/context/compile-assistant-decision-context';
+import { renderDecisionContract } from '../orb/live/instruction/decision-contract-renderer';
 // BOOTSTRAP-VOICE-DEMO: real heartbeats from voice call sites so the agents
 // dashboard reflects live usage instead of fake startup status.
 import { recordAgentHeartbeat } from './agents-registry';
@@ -9088,9 +9093,34 @@ router.post('/chat', optionalAuth, async (req: AuthenticatedRequest, res: Respon
 
     // VTID-01118: Inject cross-turn state context into system instruction
     const stateContext = stateEngine.generateContextString();
-    const systemInstruction = stateContext
+    let systemInstruction = stateContext
       ? `${baseSystemInstruction}\n\n${stateContext}`
       : baseSystemInstruction;
+
+    // VTID-02941 (B0b-min + B2 decision integration): append the decision-
+    // contract section. Continuity is the only signal flowing through the
+    // spine in this slice; future slices add more fields to
+    // AssistantDecisionContext via the same renderer.
+    //
+    // Wall: a thrown error here MUST NOT break the prompt — the contract
+    // is an enrichment layer, never required. We log and continue with the
+    // unaugmented instruction (acceptance #6).
+    if (identity?.tenant_id && identity?.user_id) {
+      try {
+        const decision = await compileAssistantDecisionContext({
+          tenantId: identity.tenant_id,
+          userId: identity.user_id,
+        });
+        const contractSection = renderDecisionContract(decision);
+        if (contractSection) {
+          systemInstruction = `${systemInstruction}\n\n${contractSection}`;
+        }
+      } catch (e) {
+        console.warn(
+          `[VTID-02941] decision contract render failed: ${(e as Error).message}`,
+        );
+      }
+    }
 
     // VTID-01106: Emit memory context injection event
     if (memoryContext && memoryContext.ok && memoryContext.items.length > 0) {

--- a/services/gateway/test/orb/context/compile-assistant-decision-context.test.ts
+++ b/services/gateway/test/orb/context/compile-assistant-decision-context.test.ts
@@ -1,0 +1,95 @@
+/**
+ * VTID-02941 (B0b-min) — compileAssistantDecisionContext orchestrator tests.
+ *
+ * Acceptance:
+ *   #1 — empty continuity produces a valid AssistantDecisionContext with
+ *        safe empty defaults
+ *   #6 — if the continuity compiler throws, prompt still renders with
+ *        sourceHealth=degraded and no crash
+ *
+ * The orchestrator MUST:
+ *   - never throw upward
+ *   - attach reason on source_health when the provider fails
+ *   - return continuity:null when source health is degraded
+ *   - accept provider overrides for tests
+ */
+
+import { compileAssistantDecisionContext } from '../../../src/orb/context/compile-assistant-decision-context';
+import type { DecisionContinuity } from '../../../src/orb/context/types';
+
+describe('B0b-min — compileAssistantDecisionContext', () => {
+  describe('happy path with provider override', () => {
+    it('attaches the provider output to .continuity', async () => {
+      const stub: DecisionContinuity = {
+        open_threads: [],
+        promises_owed: [],
+        promises_kept_recently: [],
+        counts: {
+          open_threads_total: 0,
+          promises_owed_total: 0,
+          promises_overdue: 0,
+          threads_mentioned_today: 0,
+        },
+        recommended_follow_up: 'none',
+      };
+      const out = await compileAssistantDecisionContext({
+        userId: 'u',
+        tenantId: 't',
+        providers: { continuity: async () => stub },
+      });
+      expect(out.continuity).toEqual(stub);
+      expect(out.source_health.continuity.ok).toBe(true);
+    });
+  });
+
+  describe('provider throws (acceptance #6)', () => {
+    it('returns continuity:null + source_health.ok=false + reason', async () => {
+      const out = await compileAssistantDecisionContext({
+        userId: 'u',
+        tenantId: 't',
+        providers: {
+          continuity: async () => {
+            throw new Error('boom');
+          },
+        },
+      });
+      expect(out.continuity).toBeNull();
+      expect(out.source_health.continuity.ok).toBe(false);
+      expect(out.source_health.continuity.reason).toBe('boom');
+    });
+  });
+
+  describe('provider returns null (acceptance #1)', () => {
+    it('attaches null + ok:true (provider deliberately suppressed)', async () => {
+      const out = await compileAssistantDecisionContext({
+        userId: 'u',
+        tenantId: 't',
+        providers: { continuity: async () => null },
+      });
+      expect(out.continuity).toBeNull();
+      expect(out.source_health.continuity.ok).toBe(true);
+    });
+  });
+
+  describe('always returns a typed shape', () => {
+    it('source_health.continuity is always present', async () => {
+      const out = await compileAssistantDecisionContext({
+        userId: 'u',
+        tenantId: 't',
+        providers: { continuity: async () => null },
+      });
+      expect(out.source_health).toBeDefined();
+      expect(out.source_health.continuity).toBeDefined();
+    });
+
+    it('result has only known top-level keys (no leakage)', async () => {
+      const out = await compileAssistantDecisionContext({
+        userId: 'u',
+        tenantId: 't',
+        providers: { continuity: async () => null },
+      });
+      const keys = Object.keys(out).sort();
+      expect(keys).toEqual(['continuity', 'source_health']);
+    });
+  });
+});

--- a/services/gateway/test/orb/context/continuity-decision-provider.test.ts
+++ b/services/gateway/test/orb/context/continuity-decision-provider.test.ts
@@ -1,0 +1,204 @@
+/**
+ * VTID-02941 (B0b-min) — continuity-decision-provider adapter tests.
+ *
+ * Acceptance #2: continuity data is distilled (allowed: counts, short
+ * labels, due/overdue flags, recommended follow-up kind, source
+ * health). Forbidden: raw messages, raw promises, raw memory rows,
+ * raw profile payloads.
+ *
+ * The adapter MUST:
+ *   - drop raw timestamps in favor of booleans/short hints
+ *   - truncate long strings (topic / summary / promise_text)
+ *   - keep IDs (thread_id / promise_id / decision_id) for reference
+ *   - never surface kept_at / due_at / last_mentioned_at / resolved_at
+ */
+
+import {
+  distillContinuityForDecision,
+  pickRecommendedFollowUp,
+  truncate,
+} from '../../../src/orb/context/providers/continuity-decision-provider';
+import type { ContinuityContext } from '../../../src/services/continuity/types';
+
+function makeContext(over: Partial<ContinuityContext> = {}): ContinuityContext {
+  return {
+    open_threads: [],
+    promises_owed: [],
+    promises_kept_recently: [],
+    counts: {
+      open_threads_total: 0,
+      promises_owed_total: 0,
+      promises_overdue: 0,
+      threads_mentioned_today: 0,
+    },
+    source_health: {
+      user_open_threads: { ok: true },
+      assistant_promises: { ok: true },
+    },
+    ...over,
+  };
+}
+
+describe('B0b-min — distillContinuityForDecision', () => {
+  describe('forbidden raw fields are NOT surfaced', () => {
+    it('drops last_mentioned_at, resolved_at, created_at, updated_at on threads', () => {
+      const ctx = makeContext({
+        open_threads: [
+          {
+            thread_id: 't1',
+            topic: 'magnesium',
+            summary: 'follow-up',
+            last_mentioned_at: '2026-05-10T12:00:00Z',
+            days_since_last_mention: 3,
+          },
+        ],
+      });
+      const out = distillContinuityForDecision({ continuity: ctx });
+      expect(out.open_threads[0]).toEqual({
+        thread_id: 't1',
+        topic: 'magnesium',
+        summary: 'follow-up',
+        days_since_last_mention: 3,
+      });
+      const keys = Object.keys(out.open_threads[0]).sort();
+      expect(keys).toEqual([
+        'days_since_last_mention',
+        'summary',
+        'thread_id',
+        'topic',
+      ]);
+    });
+
+    it('drops due_at, days_overdue, kept_at on promises (overdue becomes a boolean)', () => {
+      const ctx = makeContext({
+        promises_owed: [
+          {
+            promise_id: 'p1',
+            promise_text: 'remind me at 8pm',
+            due_at: '2026-05-10T20:00:00Z',
+            days_overdue: 2,
+            decision_id: 'd1',
+          },
+        ],
+      });
+      const out = distillContinuityForDecision({ continuity: ctx });
+      expect(out.promises_owed[0]).toEqual({
+        promise_id: 'p1',
+        promise_text: 'remind me at 8pm',
+        overdue: true,
+        decision_id: 'd1',
+      });
+      const keys = Object.keys(out.promises_owed[0]).sort();
+      expect(keys).toEqual(['decision_id', 'overdue', 'promise_id', 'promise_text']);
+    });
+
+    it('drops kept_at on promises_kept_recently', () => {
+      const ctx = makeContext({
+        promises_kept_recently: [
+          {
+            promise_id: 'k1',
+            promise_text: 'sent that doc',
+            kept_at: '2026-05-09T10:00:00Z',
+          },
+        ],
+      });
+      const out = distillContinuityForDecision({ continuity: ctx });
+      expect(out.promises_kept_recently[0]).toEqual({
+        promise_id: 'k1',
+        promise_text: 'sent that doc',
+      });
+      const keys = Object.keys(out.promises_kept_recently[0]).sort();
+      expect(keys).toEqual(['promise_id', 'promise_text']);
+    });
+  });
+
+  describe('overdue boolean', () => {
+    it('true when days_overdue > 0', () => {
+      const out = distillContinuityForDecision({
+        continuity: makeContext({
+          promises_owed: [
+            { promise_id: 'p', promise_text: 't', due_at: null, days_overdue: 5, decision_id: null },
+          ],
+        }),
+      });
+      expect(out.promises_owed[0].overdue).toBe(true);
+    });
+
+    it('false when days_overdue is null', () => {
+      const out = distillContinuityForDecision({
+        continuity: makeContext({
+          promises_owed: [
+            { promise_id: 'p', promise_text: 't', due_at: null, days_overdue: null, decision_id: null },
+          ],
+        }),
+      });
+      expect(out.promises_owed[0].overdue).toBe(false);
+    });
+
+    it('false when days_overdue is negative (future-due)', () => {
+      const out = distillContinuityForDecision({
+        continuity: makeContext({
+          promises_owed: [
+            { promise_id: 'p', promise_text: 't', due_at: null, days_overdue: -2, decision_id: null },
+          ],
+        }),
+      });
+      expect(out.promises_owed[0].overdue).toBe(false);
+    });
+  });
+
+  describe('truncation', () => {
+    it('truncates long topics to 60 chars', () => {
+      const long = 'a'.repeat(200);
+      const out = distillContinuityForDecision({
+        continuity: makeContext({
+          open_threads: [
+            { thread_id: 't', topic: long, summary: null, last_mentioned_at: '', days_since_last_mention: 0 },
+          ],
+        }),
+      });
+      expect(out.open_threads[0].topic.length).toBeLessThanOrEqual(60);
+      expect(out.open_threads[0].topic.endsWith('…')).toBe(true);
+    });
+
+    it('truncates long summaries to 120 chars', () => {
+      const long = 'b'.repeat(500);
+      const out = distillContinuityForDecision({
+        continuity: makeContext({
+          open_threads: [
+            { thread_id: 't', topic: 'x', summary: long, last_mentioned_at: '', days_since_last_mention: 0 },
+          ],
+        }),
+      });
+      expect((out.open_threads[0].summary ?? '').length).toBeLessThanOrEqual(120);
+    });
+
+    it('truncates long promise_text to 120 chars', () => {
+      const long = 'c'.repeat(500);
+      const out = distillContinuityForDecision({
+        continuity: makeContext({
+          promises_owed: [
+            { promise_id: 'p', promise_text: long, due_at: null, days_overdue: null, decision_id: null },
+          ],
+        }),
+      });
+      expect(out.promises_owed[0].promise_text.length).toBeLessThanOrEqual(120);
+    });
+
+    it('truncate helper preserves short strings byte-for-byte', () => {
+      expect(truncate('abc', 60)).toBe('abc');
+      expect(truncate('exactly_60_chars_______________________________________exact', 60)).toBe(
+        'exactly_60_chars_______________________________________exact',
+      );
+    });
+  });
+
+  describe('pickRecommendedFollowUp priority', () => {
+    it('overdue beats kept beats threads beats none', () => {
+      expect(pickRecommendedFollowUp({ overdue: 1, owed: 1, keptRecently: 1, openThreads: 1 })).toBe('address_overdue_promise');
+      expect(pickRecommendedFollowUp({ overdue: 0, owed: 0, keptRecently: 1, openThreads: 1 })).toBe('acknowledge_kept_promise');
+      expect(pickRecommendedFollowUp({ overdue: 0, owed: 0, keptRecently: 0, openThreads: 1 })).toBe('mention_open_thread');
+      expect(pickRecommendedFollowUp({ overdue: 0, owed: 0, keptRecently: 0, openThreads: 0 })).toBe('none');
+    });
+  });
+});

--- a/services/gateway/test/orb/context/decision-context-types.test.ts
+++ b/services/gateway/test/orb/context/decision-context-types.test.ts
@@ -1,0 +1,71 @@
+/**
+ * VTID-02941 (B0b-min) — type-level enforcement of the decision contract.
+ *
+ * Acceptance #2 + #7: raw fields MUST NOT pass through the schema.
+ *
+ * We can't enforce TypeScript structural typing at runtime, so we use
+ * the renderer's output as the observable boundary: when fed a stub
+ * decision with raw-looking extra fields, the renderer must NOT
+ * surface them (and the type system will reject them at compile time,
+ * which we assert by structural inspection of the types file).
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+
+const TYPES_PATH = join(__dirname, '../../../src/orb/context/types.ts');
+
+describe('B0b-min — AssistantDecisionContext type guards', () => {
+  let typesSrc: string;
+  beforeAll(() => {
+    typesSrc = readFileSync(TYPES_PATH, 'utf8');
+  });
+
+  describe('forbidden raw fields are NOT declared in DecisionContinuity', () => {
+    // These fields exist in the underlying ContinuityContext / Supabase
+    // rows but MUST NOT appear in DecisionContinuity. If a future change
+    // adds any of them, this test fails — that's the wall.
+    const forbiddenFields = [
+      'session_id_first',
+      'session_id_last',
+      'last_mentioned_at',
+      'resolved_at',
+      'created_at',
+      'updated_at',
+      'due_at',
+      'kept_at',
+      'days_overdue',
+      'days_since_last_mention', // intentionally allowed on open_threads (recency hint)
+    ];
+
+    // days_since_last_mention is ALLOWED. Re-filter.
+    const trulyForbidden = forbiddenFields.filter(
+      (f) => f !== 'days_since_last_mention',
+    );
+
+    it.each(trulyForbidden)('does not declare %s anywhere', (field) => {
+      // Match field-name as a TypeScript declaration: `<name>:` or `<name>?:`
+      const decl = new RegExp(`\\b${field}\\s*\\??:`, 'g');
+      expect(typesSrc).not.toMatch(decl);
+    });
+  });
+
+  it('declares the four required surfaces and source_health', () => {
+    expect(typesSrc).toContain('open_threads');
+    expect(typesSrc).toContain('promises_owed');
+    expect(typesSrc).toContain('promises_kept_recently');
+    expect(typesSrc).toContain('counts');
+    expect(typesSrc).toContain('source_health');
+    expect(typesSrc).toContain('recommended_follow_up');
+  });
+
+  it('declares overdue as a boolean, NEVER a raw timestamp', () => {
+    expect(typesSrc).toMatch(/overdue:\s*boolean/);
+    expect(typesSrc).not.toMatch(/overdue\s*\??:\s*string/);
+  });
+
+  it('AssistantDecisionContext.continuity is optional null', () => {
+    // The type must allow null to enable empty-degrades.
+    expect(typesSrc).toMatch(/continuity:\s*DecisionContinuity\s*\|\s*null/);
+  });
+});

--- a/services/gateway/test/orb/context/spine-end-to-end.test.ts
+++ b/services/gateway/test/orb/context/spine-end-to-end.test.ts
@@ -1,0 +1,157 @@
+/**
+ * VTID-02941 (B0b-min) — end-to-end through the minimal spine.
+ *
+ * Compose: stub continuity-fetcher → compileContinuityContext (real) →
+ * distill (real) → render (real). Proves the full pipeline produces a
+ * stable, distilled prompt section from raw Supabase-shaped rows
+ * without leaking any of those rows into the rendered string.
+ *
+ * Acceptance #8 (operator parity): Command Hub preview and actual
+ * prompt contract use the same compiler path. The Command Hub preview
+ * is `compileContinuityContext` → JSON. The prompt contract is
+ * `compileContinuityContext` → distillContinuityForDecision →
+ * renderDecisionContract. Both paths start at the same compiler with
+ * the same input, satisfying the parity check.
+ */
+
+import { compileContinuityContext } from '../../../src/services/continuity/compile-continuity-context';
+import { distillContinuityForDecision } from '../../../src/orb/context/providers/continuity-decision-provider';
+import { renderDecisionContract } from '../../../src/orb/live/instruction/decision-contract-renderer';
+import type { AssistantDecisionContext } from '../../../src/orb/context/types';
+import type {
+  AssistantPromiseRow,
+  OpenThreadRow,
+} from '../../../src/services/continuity/types';
+
+const NOW = Date.parse('2026-05-13T12:00:00Z');
+const DAY = 24 * 60 * 60 * 1000;
+
+function thread(over: Partial<OpenThreadRow>): OpenThreadRow {
+  return {
+    thread_id: 't',
+    topic: 'topic',
+    summary: null,
+    status: 'open',
+    session_id_first: 'sess-FIRST',
+    session_id_last: 'sess-LAST',
+    last_mentioned_at: new Date(NOW - 1 * DAY).toISOString(),
+    resolved_at: null,
+    created_at: new Date(NOW - 5 * DAY).toISOString(),
+    updated_at: new Date(NOW - 1 * DAY).toISOString(),
+    ...over,
+  };
+}
+
+function promise(over: Partial<AssistantPromiseRow>): AssistantPromiseRow {
+  return {
+    promise_id: 'p',
+    thread_id: null,
+    session_id: 'sess-PROMISE-RAW',
+    promise_text: 'text',
+    due_at: null,
+    status: 'owed',
+    decision_id: null,
+    kept_at: null,
+    created_at: new Date(NOW - 3 * DAY).toISOString(),
+    updated_at: new Date(NOW - 1 * DAY).toISOString(),
+    ...over,
+  };
+}
+
+describe('B0b-min — end-to-end spine', () => {
+  it('renders a coherent prompt section AND drops every raw row field', () => {
+    const continuityCtx = compileContinuityContext({
+      threadsResult: {
+        ok: true,
+        rows: [
+          thread({
+            thread_id: 'thread-A',
+            topic: 'magnesium routine',
+            summary: 'discussed dosage after dinner',
+            last_mentioned_at: new Date(NOW - 2 * DAY).toISOString(),
+          }),
+        ],
+      },
+      promisesResult: {
+        ok: true,
+        rows: [
+          promise({
+            promise_id: 'promise-A',
+            promise_text: "I'll send the supplement comparison",
+            due_at: new Date(NOW - 1 * DAY).toISOString(),
+            status: 'owed',
+            decision_id: 'dec-42',
+          }),
+          promise({
+            promise_id: 'promise-B',
+            promise_text: 'shared the article on circadian rhythm',
+            status: 'kept',
+            kept_at: new Date(NOW - 2 * DAY).toISOString(),
+          }),
+        ],
+      },
+      nowMs: NOW,
+    });
+
+    const decision: AssistantDecisionContext = {
+      continuity: distillContinuityForDecision({ continuity: continuityCtx }),
+      source_health: { continuity: { ok: true } },
+    };
+    const rendered = renderDecisionContract(decision);
+
+    // ---- Coherent prompt section ----
+    expect(rendered).toContain('Assistant decision contract:');
+    expect(rendered).toContain('Continuity:');
+    expect(rendered).toContain('Open threads:');
+    expect(rendered).toContain('magnesium routine');
+    expect(rendered).toContain('Promises owed:');
+    expect(rendered).toContain("I'll send the supplement comparison [overdue]");
+    expect(rendered).toContain('Promises kept recently:');
+    expect(rendered).toContain('shared the article on circadian rhythm');
+    expect(rendered).toContain('Recommended follow-up: address_overdue_promise');
+
+    // ---- Raw row fields MUST NOT appear ----
+    // Session ids
+    expect(rendered).not.toContain('sess-FIRST');
+    expect(rendered).not.toContain('sess-LAST');
+    expect(rendered).not.toContain('sess-PROMISE-RAW');
+    // Raw timestamps
+    expect(rendered).not.toContain('2026-05-');
+    expect(rendered).not.toContain('T12:00:00');
+    expect(rendered).not.toContain('T00:00:00');
+    // Status values (we said "owed/kept/broken/cancelled" — the renderer
+    // expresses them as [overdue] tag or section header only)
+    expect(rendered).not.toMatch(/\bstatus:\s*"?\w+"?/i);
+  });
+
+  it('empty fetcher results render to empty string (acceptance #1 — safe defaults)', () => {
+    const continuityCtx = compileContinuityContext({
+      threadsResult: { ok: true, rows: [] },
+      promisesResult: { ok: true, rows: [] },
+      nowMs: NOW,
+    });
+    const decision: AssistantDecisionContext = {
+      continuity: distillContinuityForDecision({ continuity: continuityCtx }),
+      source_health: { continuity: { ok: true } },
+    };
+    expect(renderDecisionContract(decision)).toBe('');
+  });
+
+  it('degraded source produces a hint section, no crash (acceptance #6)', () => {
+    const continuityCtx = compileContinuityContext({
+      threadsResult: { ok: false, rows: [], reason: 'supabase_unconfigured' },
+      promisesResult: { ok: false, rows: [], reason: 'supabase_unconfigured' },
+      nowMs: NOW,
+    });
+    // Even though continuityCtx has empty surfaces, source_health came back
+    // degraded. The renderer reads source_health from the decision, so we
+    // pass a degraded shape directly.
+    const decision: AssistantDecisionContext = {
+      continuity: null,
+      source_health: { continuity: { ok: false, reason: 'supabase_unconfigured' } },
+    };
+    const rendered = renderDecisionContract(decision);
+    expect(rendered).toContain('continuity: source degraded');
+    expect(rendered).toContain('supabase_unconfigured');
+  });
+});

--- a/services/gateway/test/orb/live/instruction/decision-contract-renderer.test.ts
+++ b/services/gateway/test/orb/live/instruction/decision-contract-renderer.test.ts
@@ -1,0 +1,247 @@
+/**
+ * VTID-02941 (B0b-min) — decision-contract-renderer tests.
+ *
+ * Acceptance:
+ *   #3 — renderer ONLY accepts AssistantDecisionContext, never raw
+ *        compiler output. Enforced by source-level scan + by behavior:
+ *        any unrecognized field on the input is ignored (typescript
+ *        rejects it at compile time; runtime ignores extras).
+ *   #4 — generateSystemInstruction does NOT query memory directly. The
+ *        renderer file MUST NOT import from supabase, services, or call
+ *        fetch.
+ *   #6 — if continuity is null, renderer emits no continuity section.
+ *        When source_health is degraded, renderer emits a short hint.
+ */
+
+import { readFileSync } from 'fs';
+import { join } from 'path';
+import {
+  renderDecisionContract,
+} from '../../../../src/orb/live/instruction/decision-contract-renderer';
+import type {
+  AssistantDecisionContext,
+  DecisionContinuity,
+} from '../../../../src/orb/context/types';
+
+const RENDERER_PATH = join(
+  __dirname,
+  '../../../../src/orb/live/instruction/decision-contract-renderer.ts',
+);
+
+function emptyContinuity(): DecisionContinuity {
+  return {
+    open_threads: [],
+    promises_owed: [],
+    promises_kept_recently: [],
+    counts: {
+      open_threads_total: 0,
+      promises_owed_total: 0,
+      promises_overdue: 0,
+      threads_mentioned_today: 0,
+    },
+    recommended_follow_up: 'none',
+  };
+}
+
+function emptyContext(over: Partial<AssistantDecisionContext> = {}): AssistantDecisionContext {
+  return {
+    continuity: null,
+    source_health: { continuity: { ok: true } },
+    ...over,
+  };
+}
+
+describe('B0b-min — decision-contract-renderer', () => {
+  describe('purity — wall enforcement (acceptance #4)', () => {
+    let src: string;
+    beforeAll(() => {
+      src = readFileSync(RENDERER_PATH, 'utf8');
+    });
+
+    it('does not import from services/', () => {
+      expect(src).not.toMatch(/from\s+['"][^'"]*\.\.\/\.\.\/\.\.\/services\//);
+      expect(src).not.toMatch(/from\s+['"][^'"]*services\/continuity/);
+    });
+
+    it('does not import supabase or any DB client', () => {
+      // Walk only non-comment lines so the wall-comment doesn't trip
+      // the source-level guard (the comment mentions "Supabase" by
+      // name precisely BECAUSE it must not be imported).
+      const nonComment = src
+        .split('\n')
+        .filter((l) => !/^\s*(\*|\/\*|\/\/)/.test(l))
+        .join('\n');
+      expect(nonComment).not.toMatch(/\bgetSupabase\b/);
+      expect(nonComment).not.toMatch(/from\s+['"][^'"]*lib\/supabase/);
+    });
+
+    it('does not call fetch / axios / rpc', () => {
+      expect(src).not.toMatch(/\bfetch\(/);
+      expect(src).not.toMatch(/\baxios\b/);
+      expect(src).not.toMatch(/\.rpc\(/);
+    });
+
+    it('only imports types from orb/context', () => {
+      // Renderer must depend on the contract, never on the implementation.
+      expect(src).toMatch(/from\s+['"]\.\.\/\.\.\/context\/types['"]/);
+    });
+  });
+
+  describe('empty/degrades safely (acceptance #1 + #6)', () => {
+    it('returns empty string when continuity is null and source is healthy', () => {
+      const out = renderDecisionContract(emptyContext());
+      expect(out).toBe('');
+    });
+
+    it('emits a degraded hint when continuity is null AND source_health is degraded', () => {
+      const out = renderDecisionContract(
+        emptyContext({
+          source_health: { continuity: { ok: false, reason: 'supabase_unconfigured' } },
+        }),
+      );
+      expect(out).toContain('continuity: source degraded');
+      expect(out).toContain('supabase_unconfigured');
+    });
+
+    it('emits empty string when continuity surfaces are all empty AND source is healthy', () => {
+      const out = renderDecisionContract(
+        emptyContext({ continuity: emptyContinuity() }),
+      );
+      expect(out).toBe('');
+    });
+  });
+
+  describe('renders distilled surfaces', () => {
+    it('renders open threads with age + summary', () => {
+      const out = renderDecisionContract(
+        emptyContext({
+          continuity: {
+            ...emptyContinuity(),
+            open_threads: [
+              {
+                thread_id: 't1',
+                topic: 'magnesium dosage',
+                summary: 'follow-up on the new bottle',
+                days_since_last_mention: 3,
+              },
+            ],
+          },
+        }),
+      );
+      expect(out).toContain('Open threads:');
+      expect(out).toContain('magnesium dosage');
+      expect(out).toContain('3d since last mention');
+      expect(out).toContain('follow-up on the new bottle');
+    });
+
+    it('renders promises_owed with overdue tag', () => {
+      const out = renderDecisionContract(
+        emptyContext({
+          continuity: {
+            ...emptyContinuity(),
+            promises_owed: [
+              {
+                promise_id: 'p1',
+                promise_text: 'send the doc',
+                overdue: true,
+                decision_id: null,
+              },
+            ],
+          },
+        }),
+      );
+      expect(out).toContain('Promises owed:');
+      expect(out).toContain('send the doc [overdue]');
+    });
+
+    it('renders recommended_follow_up when not "none"', () => {
+      const out = renderDecisionContract(
+        emptyContext({
+          continuity: {
+            ...emptyContinuity(),
+            open_threads: [
+              { thread_id: 't', topic: 'x', summary: null, days_since_last_mention: 1 },
+            ],
+            recommended_follow_up: 'mention_open_thread',
+          },
+        }),
+      );
+      expect(out).toContain('Recommended follow-up: mention_open_thread');
+    });
+
+    it('omits recommended_follow_up when "none"', () => {
+      const out = renderDecisionContract(
+        emptyContext({
+          continuity: {
+            ...emptyContinuity(),
+            open_threads: [
+              { thread_id: 't', topic: 'x', summary: null, days_since_last_mention: 1 },
+            ],
+            recommended_follow_up: 'none',
+          },
+        }),
+      );
+      expect(out).not.toContain('Recommended follow-up');
+    });
+  });
+
+  describe('header behavior', () => {
+    it('emits header by default', () => {
+      const out = renderDecisionContract(
+        emptyContext({
+          continuity: {
+            ...emptyContinuity(),
+            open_threads: [
+              { thread_id: 't', topic: 'x', summary: null, days_since_last_mention: 0 },
+            ],
+          },
+        }),
+      );
+      expect(out.startsWith('Assistant decision contract:\n')).toBe(true);
+    });
+
+    it('omits header when withHeader=false', () => {
+      const out = renderDecisionContract(
+        emptyContext({
+          continuity: {
+            ...emptyContinuity(),
+            open_threads: [
+              { thread_id: 't', topic: 'x', summary: null, days_since_last_mention: 0 },
+            ],
+          },
+        }),
+        { withHeader: false },
+      );
+      expect(out.startsWith('Assistant decision contract:\n')).toBe(false);
+      expect(out).toContain('Continuity:');
+    });
+  });
+
+  describe('raw-field ignorance (acceptance #3 + #7)', () => {
+    it('extra unknown fields injected at runtime are NOT surfaced in output', () => {
+      // TypeScript would reject this at compile time; we cast to test
+      // runtime behavior. The renderer reads only declared fields.
+      const sneakyContinuity = {
+        ...emptyContinuity(),
+        open_threads: [
+          {
+            thread_id: 't',
+            topic: 'short topic',
+            summary: null,
+            days_since_last_mention: 0,
+            // raw fields a future bug might forward:
+            last_mentioned_at: '2026-05-10T12:00:00Z',
+            session_id_first: 'sess-A',
+            session_id_last: 'sess-B',
+            raw_message: 'user said this exact sentence',
+          },
+        ],
+      } as unknown as DecisionContinuity;
+
+      const out = renderDecisionContract(emptyContext({ continuity: sneakyContinuity }));
+      expect(out).not.toContain('2026-05-10T12:00:00Z');
+      expect(out).not.toContain('sess-A');
+      expect(out).not.toContain('user said this exact sentence');
+    });
+  });
+});


### PR DESCRIPTION
**Re-opened from #2071** after #2063 (B2 continuity preview) merged to main and auto-closed #2071. Same code, same VTID, retargeted to main.

## Summary

Stands up the **minimal** `AssistantDecisionContext` spine and wires **only continuity** through it. The instruction layer renders the typed contract; the compiler distills. Raw rows never cross the boundary.

## Path through the contract

```
compileContinuityContext           (existing B2 read-only compiler — now on main)
  → distillContinuityForDecision   (new adapter — strips raw fields)
  → AssistantDecisionContext.continuity   (new typed contract)
  → renderDecisionContract         (new renderer)
  → appended to systemInstruction in orb-live.ts:9091
```

Future signals (concept mastery, journey stage, match journey, feature discovery, wake brief, etc.) plug in by:
1. Adding a typed field to `AssistantDecisionContext`
2. Registering a provider in `compileAssistantDecisionContext`
3. Extending `renderDecisionContract` to format the new field

**No raw context can ever cross the boundary again** because the renderer reads only the typed contract.

## Files

**New (4 src + 5 test):**
- [`services/gateway/src/orb/context/types.ts`](services/gateway/src/orb/context/types.ts)
- [`services/gateway/src/orb/context/providers/continuity-decision-provider.ts`](services/gateway/src/orb/context/providers/continuity-decision-provider.ts)
- [`services/gateway/src/orb/context/compile-assistant-decision-context.ts`](services/gateway/src/orb/context/compile-assistant-decision-context.ts)
- [`services/gateway/src/orb/live/instruction/decision-contract-renderer.ts`](services/gateway/src/orb/live/instruction/decision-contract-renderer.ts)

**Modified (1):**
- [`services/gateway/src/routes/orb-live.ts`](services/gateway/src/routes/orb-live.ts) — single insertion at the `/conversation` handler (line 9091). `generateSystemInstruction(session)` is byte-for-byte unchanged. The other 3 fallback call sites stay on the old helper (out of scope — follow-up tracked).

## Acceptance check matrix

- [x] **#1** Empty continuity produces a valid `AssistantDecisionContext` with safe empty defaults
- [x] **#2** Continuity data is distilled (counts, short labels, overdue boolean, follow-up kind, source health). Forbidden: raw messages / promises / memory rows / profile payloads
- [x] **#3** Renderer only accepts `AssistantDecisionContext`, never raw compiler output
- [x] **#4** `generateSystemInstruction()` does not query memory directly. Renderer has no imports from `services/`, no supabase, no `fetch()`
- [x] **#5** Existing system instruction text remains byte-for-byte stable except for the new appended section
- [x] **#6** If continuity compiler fails, prompt still renders with `sourceHealth=degraded` and no crash
- [x] **#7** Tests prove raw fields cannot pass through the context schema
- [x] **#8** Command Hub preview and actual prompt contract use the same compiler path

## Test plan

- [x] **152 tests green** in touched suites (37 new + 115 existing in `orb/context`, `orb/live/instruction`, and the B2 continuity suites)
- [x] `npm run build` clean (only the pre-existing `sharp` error in `cover-image-outpaint.ts` remains)
- [x] No raw row fields leak into rendered output (asserted by `spine-end-to-end.test.ts`)
- [x] Wall test enforces renderer has no service/supabase/fetch imports
- [ ] Smoke test on dev after merge: hit `/api/v1/orb/live/conversation` for a user with continuity state; verify `Assistant decision contract:` section appears in the system instruction log

## Follow-up (out of scope for this PR)

Unify the 3 fallback `generateSystemInstruction(session)` call sites at `orb-live.ts:8397 / 8485 / 8764` onto the same decision-contract renderer path — but only after the main `/conversation` path is proven stable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)