### PR TITLE
fix(self-healing): paired test-path derivation + refuse-to-bridge (VTID-02947, PR-H)

### DIFF
--- a/services/gateway/src/services/self-healing-injector-service.ts
+++ b/services/gateway/src/services/self-healing-injector-service.ts
@@ -10,6 +10,7 @@ import { createHash } from 'crypto';
 import { Diagnosis } from '../types/self-healing';
 import { emitOasisEvent } from './oasis-event-service';
 import { bridgeActivationToExecution } from './dev-autopilot-execute';
+import { loadSourceFile } from './self-healing-diagnosis-service';
 
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
@@ -56,6 +57,146 @@ function confidenceToRiskClass(confidence: number): 'low' | 'medium' | 'high' {
   if (confidence >= 0.9) return 'low';
   if (confidence >= 0.7) return 'medium';
   return 'high';
+}
+
+/**
+ * PR-H (VTID-02947): derive a paired test-file path for a source path.
+ *
+ * The autopilot safety gate's `tests_missing` rule (services/gateway/src/
+ * services/dev-autopilot-safety.ts:221) refuses any plan that has
+ * non-deletion edits without at least one test file in `files_to_modify`.
+ * Self-healing diagnoses never propose tests on their own — so every
+ * self-healing plan was being blocked at the safety gate, dead-ending
+ * the green path even with PR-A's bridge wired.
+ *
+ * Strategy (existence-aware flat default):
+ *   1. Only handle source paths under `services/gateway/src/**`. Anything
+ *      else is "underived" — the caller MUST refuse the bridge so we
+ *      never feed Dev Autopilot a knowingly gate-failing plan.
+ *   2. Derive the basename (e.g. `availability` from `routes/availability.ts`).
+ *   3. Probe three candidate test paths IN ORDER and use the first one
+ *      that exists in the repo (via fs OR GitHub fallback — same
+ *      loadSourceFile() helper PR-C added):
+ *        a. services/gateway/test/<basename>.test.ts                (flat — most common)
+ *        b. services/gateway/test/routes/<basename>.test.ts         (mirror — when source is /routes/)
+ *        c. services/gateway/test/services/<basename>.test.ts       (mirror — when source is /services/)
+ *   4. If none exists: fall back to the flat path (a). The autopilot LLM
+ *      will create it. The plan footer makes the create-vs-modify
+ *      contract explicit so the LLM doesn't try to modify a nonexistent
+ *      file.
+ *
+ * Returns `null` for source paths the deriver cannot handle (outside
+ * services/gateway/src/, no recognizable basename, etc.). The caller
+ * uses `null` as the signal to refuse the bridge.
+ */
+async function deriveTestPathForSource(
+  sourcePath: string,
+  cache?: Map<string, any>,
+): Promise<{ testPath: string; existing: boolean } | null> {
+  // Only services/gateway/src/** is supported. The autopilot safety gate
+  // also restricts edits to that tree (see allow_scope), so anything
+  // else can't be auto-fixed regardless.
+  if (!sourcePath.startsWith('services/gateway/src/')) return null;
+
+  const fileName = sourcePath.split('/').pop() || '';
+  const basename = fileName.replace(/\.(ts|tsx|js|jsx)$/, '');
+  if (!basename || basename === fileName) return null; // no extension stripped → not a TS/JS source
+
+  // index.ts is the gateway mounter — don't try to write a paired test for
+  // it. The diagnosis layer should be redirected toward the actual route
+  // file (Gap 2 / PR-F territory), not patched in index.ts.
+  if (basename === 'index') return null;
+
+  const candidates = [
+    `services/gateway/test/${basename}.test.ts`,
+    `services/gateway/test/routes/${basename}.test.ts`,
+    `services/gateway/test/services/${basename}.test.ts`,
+  ];
+
+  for (const candidate of candidates) {
+    try {
+      const loaded = await loadSourceFile(candidate, cache);
+      if (loaded.found) {
+        return { testPath: candidate, existing: true };
+      }
+    } catch {
+      // Continue to next candidate — don't let a transient GitHub error
+      // mask a path that does exist via the next probe.
+    }
+  }
+
+  // No paired test exists yet — default to the flat path; the autopilot
+  // LLM will create it, and the plan footer says so explicitly.
+  return { testPath: candidates[0], existing: false };
+}
+
+/**
+ * PR-H (VTID-02947): turn a list of source paths into source+test pairs.
+ *
+ * Returns the augmented `files_referenced` list AND a list of the source
+ * paths the deriver couldn't handle. If `underived` is non-empty, the
+ * caller MUST refuse the bridge (refuse-to-bridge contract).
+ */
+async function deriveTestPathsForPlan(
+  sourcePaths: string[],
+): Promise<{
+  files_referenced: string[];
+  pairs: Array<{ source: string; test: string; test_existing: boolean }>;
+  underived: string[];
+}> {
+  const cache = new Map<string, any>();
+  const pairs: Array<{ source: string; test: string; test_existing: boolean }> = [];
+  const underived: string[] = [];
+
+  for (const source of sourcePaths) {
+    const derived = await deriveTestPathForSource(source, cache);
+    if (!derived) {
+      underived.push(source);
+      continue;
+    }
+    pairs.push({ source, test: derived.testPath, test_existing: derived.existing });
+  }
+
+  // De-duplicate test paths: two source files in the same module may map
+  // to the same flat test path. Keep the order deterministic (sources
+  // first, then tests in their natural order).
+  const seen = new Set<string>();
+  const files: string[] = [];
+  for (const p of pairs) {
+    if (!seen.has(p.source)) { files.push(p.source); seen.add(p.source); }
+  }
+  for (const p of pairs) {
+    if (!seen.has(p.test)) { files.push(p.test); seen.add(p.test); }
+  }
+
+  return { files_referenced: files, pairs, underived };
+}
+
+/**
+ * PR-H (VTID-02947): append a "Required deliverables" footer to the
+ * spec markdown so the autopilot LLM emits BOTH the source fix AND a
+ * paired test, and the plan-diff coverage check (validatePlanDiffCoverage
+ * in dev-autopilot-execute.ts) gets a real assertion in the test file.
+ *
+ * Footer is appended (not replacing the diagnosis spec) so the LLM
+ * still sees the original root-cause context. The wording is explicit
+ * about create-vs-modify because the test file may not exist yet.
+ */
+function buildTestPathFooter(
+  pairs: Array<{ source: string; test: string; test_existing: boolean }>,
+): string {
+  if (pairs.length === 0) return '';
+  const lines: string[] = ['', '---', '', '## Required repair deliverables (autopilot safety gate enforces this)', ''];
+  lines.push('Every PR for this self-healing task MUST include both a source change AND a test change. The autopilot safety gate refuses plans without a test file, and the plan-diff coverage check refuses PRs that ship only a placeholder. Concretely:');
+  lines.push('');
+  for (const { source, test, test_existing } of pairs) {
+    const verb = test_existing ? 'modify' : 'create';
+    lines.push(`- **${source}** — apply the fix that resolves the failing endpoint.`);
+    lines.push(`  - **${test} (${verb})** — add or update a test that asserts the failure mode (described above) is now fixed. The test must call the same code path the failure exercised; passing-but-unrelated tests will be rejected by the executor's diff-coverage check.`);
+  }
+  lines.push('');
+  lines.push('PRs that ship only one side of any pair will be auto-rejected.');
+  return lines.join('\n');
 }
 
 /**
@@ -127,12 +268,45 @@ async function bridgeToAutopilotExecution(
     console.warn(`[self-healing-injector] Dedupe check failed: ${err.message} — proceeding with fresh insert`);
   }
 
+  // PR-H (VTID-02947): derive paired test paths BEFORE we touch any
+  // autopilot table. If the deriver can't find a test path for any
+  // source file, we refuse to bridge — feeding Dev Autopilot a plan
+  // we know will fail the safety gate's `tests_missing` rule wastes
+  // an LLM run AND surfaces as a cryptic safety-gate rejection
+  // instead of a clear "we couldn't auto-fix this" signal.
+  const sourcePaths = (diagnosis.files_to_modify || []).slice(0, 30);
+  const derivation = await deriveTestPathsForPlan(sourcePaths);
+  if (derivation.underived.length > 0) {
+    const reason = `SELF_HEALING_TEST_PATH_UNDERIVED: cannot derive paired test path for ${derivation.underived.join(', ')}`;
+    await emitOasisEvent({
+      type: 'self-healing.execution.bridge_failed',
+      vtid,
+      source: 'self-healing-injector',
+      status: 'warning',
+      message: reason,
+      payload: {
+        endpoint: diagnosis.endpoint,
+        failure_class: diagnosis.failure_class,
+        confidence: diagnosis.confidence,
+        underived_sources: derivation.underived,
+        reason_code: 'SELF_HEALING_TEST_PATH_UNDERIVED',
+      },
+    });
+    return { ok: false, error: reason };
+  }
+
   // Step 2: Create the autopilot_recommendations row. source_type stays
   // 'dev_autopilot' (the existing allowlist value); spec_snapshot.scanner
   // marks the origin so the Self-Healing screen can filter.
   const title = `SELF-HEAL: ${diagnosis.service_name} — ${diagnosis.failure_class}`;
   const summary = diagnosis.root_cause.substring(0, 1000);
-  const filesReferenced = (diagnosis.files_to_modify || []).slice(0, 30);
+  // PR-H: files_referenced now includes BOTH source files AND their
+  // derived test paths. The autopilot safety gate will see a test file
+  // and pass the `tests_missing` check.
+  const filesReferenced = derivation.files_referenced;
+  // PR-H: append a "Required deliverables" footer so the LLM emits both
+  // the fix AND the test (verb = create vs modify based on existence).
+  const specWithFooter = spec + buildTestPathFooter(derivation.pairs);
   const recBody = {
     title,
     summary,
@@ -152,7 +326,7 @@ async function bridgeToAutopilotExecution(
       endpoint: diagnosis.endpoint,
       failure_class: diagnosis.failure_class,
       confidence: diagnosis.confidence,
-      spec_markdown: spec,
+      spec_markdown: specWithFooter,
       files_referenced: filesReferenced,
       suggested_fix: diagnosis.suggested_fix,
       root_cause: diagnosis.root_cause,
@@ -187,7 +361,7 @@ async function bridgeToAutopilotExecution(
     body: JSON.stringify({
       finding_id: findingId,
       version: 1,
-      plan_markdown: spec,
+      plan_markdown: specWithFooter,
       files_referenced: filesReferenced,
     }),
   });

--- a/services/gateway/test/self-healing-injector-autopilot-bridge.test.ts
+++ b/services/gateway/test/self-healing-injector-autopilot-bridge.test.ts
@@ -143,11 +143,18 @@ describe('injectIntoAutopilotPipeline — autopilot bridge', () => {
     expect(typeof rec.spec_snapshot.dedupe_key).toBe('string');
     expect(rec.spec_snapshot.dedupe_key.length).toBe(64); // sha256 hex
 
-    // Plan version carries the spec markdown.
-    expect(state.planVersionInserts[0].plan_markdown).toBe('spec markdown');
-    expect(state.planVersionInserts[0].files_referenced).toEqual([
+    // PR-H (VTID-02947): plan markdown is the original spec PLUS a
+    // "Required repair deliverables" footer with paired source+test
+    // paths. The footer is appended (not replacing the diagnosis).
+    expect(state.planVersionInserts[0].plan_markdown).toMatch(/^spec markdown/);
+    expect(state.planVersionInserts[0].plan_markdown).toContain('Required repair deliverables');
+    // PR-H: files_referenced now includes both source AND derived test path.
+    expect(state.planVersionInserts[0].files_referenced).toContain(
       'services/gateway/src/routes/availability.ts',
-    ]);
+    );
+    expect(state.planVersionInserts[0].files_referenced).toContain(
+      'services/gateway/test/availability.test.ts',
+    );
 
     // Ledger is patched twice: once initially (status=scheduled), then post-bridge
     // with autopilot_execution_id in metadata.

--- a/services/gateway/test/self-healing-test-path-derivation.test.ts
+++ b/services/gateway/test/self-healing-test-path-derivation.test.ts
@@ -1,0 +1,286 @@
+/**
+ * PR-H (VTID-02947): the injector must augment self-healing plans with
+ * paired test-file paths before bridging to Dev Autopilot.
+ *
+ * The autopilot safety gate (services/gateway/src/services/dev-autopilot-
+ * safety.ts:221) refuses any plan with non-deletion edits and no test
+ * file. Self-healing diagnoses never propose tests on their own — so
+ * every self-healing plan was being blocked at the safety gate, which
+ * surfaced live as "bridgeActivationToExecution failed: safety gate
+ * blocked approval" on VTID-02928 / VTID-02939 / VTID-02942 / VTID-02945.
+ *
+ * Contract enforced by these tests:
+ *
+ *   1. For source paths under services/gateway/src/**, derive a paired
+ *      test path. Existence-aware: prefer the actual existing test file
+ *      (flat / mirror-routes / mirror-services), fall back to flat for
+ *      not-yet-existing tests.
+ *   2. Source paths the deriver can't handle (services/gateway/src/index.ts,
+ *      anything outside services/gateway/src/, files without an
+ *      extension we recognize) → REFUSE to bridge with reason
+ *      SELF_HEALING_TEST_PATH_UNDERIVED. Never feed Dev Autopilot a
+ *      plan we know will fail the safety gate.
+ *   3. The plan_markdown gets a "Required deliverables" footer with
+ *      explicit source+test pairs and create-vs-modify verbs.
+ *   4. files_referenced (passed to the autopilot safety gate as
+ *      files_to_modify) includes both the source files AND the test
+ *      files — the gate's hasTestFile check passes.
+ */
+
+jest.mock('../src/services/dev-autopilot-execute', () => ({
+  bridgeActivationToExecution: jest.fn(),
+}));
+
+jest.mock('../src/services/self-healing-diagnosis-service', () => ({
+  loadSourceFile: jest.fn(),
+}));
+
+import { bridgeActivationToExecution } from '../src/services/dev-autopilot-execute';
+import { loadSourceFile } from '../src/services/self-healing-diagnosis-service';
+import { injectIntoAutopilotPipeline } from '../src/services/self-healing-injector-service';
+import type { Diagnosis } from '../src/types/self-healing';
+
+const bridgeMock = bridgeActivationToExecution as unknown as jest.Mock;
+const loadSourceMock = loadSourceFile as unknown as jest.Mock;
+const ORIGINAL_FETCH = global.fetch;
+
+function makeDiagnosis(filesToModify: string[], overrides: Partial<Diagnosis> = {}): Diagnosis {
+  return {
+    service_name: 'Test Service',
+    endpoint: '/api/v1/test/health',
+    vtid: 'VTID-99999',
+    failure_class: 'route_not_registered' as any,
+    confidence: 0.9,
+    root_cause: 'route file is missing the health handler',
+    suggested_fix: 'add a GET /health route',
+    auto_fixable: true,
+    evidence: ['handler not found'],
+    codebase_analysis: null,
+    git_analysis: null,
+    dependency_analysis: null,
+    workflow_analysis: null,
+    files_to_modify: filesToModify,
+    files_read: [],
+    ...overrides,
+  };
+}
+
+interface InjectorCalls {
+  recommendationInserts: any[];
+  planVersionInserts: any[];
+  ledgerPatches: any[];
+  oasisEvents: any[];
+}
+
+function setupGatewayMocks(state: InjectorCalls) {
+  global.fetch = jest.fn().mockImplementation(async (url: string, init?: any) => {
+    const method = init?.method || 'GET';
+    const body = init?.body ? JSON.parse(init.body) : null;
+
+    // Dedupe lookup → no existing recommendations (so each test sees fresh insert path).
+    if (url.includes('/rest/v1/autopilot_recommendations?') && url.includes('spec_snapshot->>dedupe_key=eq.')) {
+      return { ok: true, json: () => Promise.resolve([]) };
+    }
+    if (url.includes('/rest/v1/dev_autopilot_executions?finding_id=eq.')) {
+      return { ok: true, json: () => Promise.resolve([]) };
+    }
+    if (url.endsWith('/rest/v1/autopilot_recommendations') && method === 'POST') {
+      state.recommendationInserts.push(body);
+      return {
+        ok: true,
+        text: () => Promise.resolve('[{"id":"finding-uuid"}]'),
+        json: () => Promise.resolve([{ id: 'finding-uuid' }]),
+      };
+    }
+    if (url.endsWith('/rest/v1/dev_autopilot_plan_versions') && method === 'POST') {
+      state.planVersionInserts.push(body);
+      return { ok: true, text: () => Promise.resolve(''), json: () => Promise.resolve([]) };
+    }
+    if (url.includes('/rest/v1/vtid_ledger?vtid=eq.') && method === 'PATCH') {
+      state.ledgerPatches.push(body);
+      return { ok: true, text: () => Promise.resolve(''), json: () => Promise.resolve([]) };
+    }
+    if (url.endsWith('/rest/v1/self_healing_log') && method === 'POST') {
+      return { ok: true, text: () => Promise.resolve(''), json: () => Promise.resolve([]) };
+    }
+    if (url.endsWith('/rest/v1/oasis_events') && method === 'POST') {
+      state.oasisEvents.push(body);
+      return { ok: true, text: () => Promise.resolve(''), json: () => Promise.resolve([]) };
+    }
+    return { ok: true, text: () => Promise.resolve(''), json: () => Promise.resolve([]) };
+  }) as any;
+}
+
+beforeEach(() => {
+  process.env.SUPABASE_URL = 'https://supabase.test';
+  process.env.SUPABASE_SERVICE_ROLE = 'svc-role';
+  bridgeMock.mockReset();
+  bridgeMock.mockResolvedValue({ ok: true, execution_id: 'exec-uuid', skipped: undefined });
+  loadSourceMock.mockReset();
+});
+
+afterEach(() => {
+  global.fetch = ORIGINAL_FETCH;
+});
+
+describe('PR-H — test-path derivation in self-healing injector', () => {
+  it('uses an existing test file when one is present (flat default)', async () => {
+    // Diagnosis proposes a route file. Test exists at the flat path.
+    loadSourceMock.mockImplementation(async (path: string) => {
+      if (path === 'services/gateway/test/availability.test.ts') {
+        return { found: true, content: '// existing', source: 'fs' };
+      }
+      return { found: false, source: 'fs' };
+    });
+    const state: InjectorCalls = { recommendationInserts: [], planVersionInserts: [], ledgerPatches: [], oasisEvents: [] };
+    setupGatewayMocks(state);
+
+    await injectIntoAutopilotPipeline(
+      'VTID-99999',
+      makeDiagnosis(['services/gateway/src/routes/availability.ts']),
+      'spec body',
+      'hash-flat',
+    );
+
+    expect(bridgeMock).toHaveBeenCalledTimes(1);
+    expect(state.planVersionInserts.length).toBe(1);
+    const plan = state.planVersionInserts[0];
+    // Both source AND test in files_referenced.
+    expect(plan.files_referenced).toEqual([
+      'services/gateway/src/routes/availability.ts',
+      'services/gateway/test/availability.test.ts',
+    ]);
+    // Footer was appended; LLM is told to MODIFY the existing test.
+    expect(plan.plan_markdown).toContain('Required repair deliverables');
+    expect(plan.plan_markdown).toContain('services/gateway/test/availability.test.ts (modify)');
+  });
+
+  it('prefers test/routes/<name>.test.ts when that mirror path exists', async () => {
+    loadSourceMock.mockImplementation(async (path: string) => {
+      // Flat doesn't exist; mirror does.
+      if (path === 'services/gateway/test/routes/admin-autopilot.test.ts') {
+        return { found: true, content: '// existing mirror', source: 'fs' };
+      }
+      return { found: false, source: 'fs' };
+    });
+    const state: InjectorCalls = { recommendationInserts: [], planVersionInserts: [], ledgerPatches: [], oasisEvents: [] };
+    setupGatewayMocks(state);
+
+    await injectIntoAutopilotPipeline(
+      'VTID-99999',
+      makeDiagnosis(['services/gateway/src/routes/admin-autopilot.ts']),
+      'spec body',
+      'hash-mirror-routes',
+    );
+
+    const plan = state.planVersionInserts[0];
+    expect(plan.files_referenced).toContain('services/gateway/test/routes/admin-autopilot.test.ts');
+    expect(plan.files_referenced).not.toContain('services/gateway/test/admin-autopilot.test.ts');
+    expect(plan.plan_markdown).toContain('test/routes/admin-autopilot.test.ts (modify)');
+  });
+
+  it('falls back to the flat test path with create verb when no test exists', async () => {
+    loadSourceMock.mockResolvedValue({ found: false, source: 'fs' });
+    const state: InjectorCalls = { recommendationInserts: [], planVersionInserts: [], ledgerPatches: [], oasisEvents: [] };
+    setupGatewayMocks(state);
+
+    await injectIntoAutopilotPipeline(
+      'VTID-99999',
+      makeDiagnosis(['services/gateway/src/services/new-helper.ts']),
+      'spec body',
+      'hash-create',
+    );
+
+    const plan = state.planVersionInserts[0];
+    expect(plan.files_referenced).toEqual([
+      'services/gateway/src/services/new-helper.ts',
+      'services/gateway/test/new-helper.test.ts',
+    ]);
+    expect(plan.plan_markdown).toContain('test/new-helper.test.ts (create)');
+  });
+
+  it('REFUSES the bridge when source is services/gateway/src/index.ts', async () => {
+    loadSourceMock.mockResolvedValue({ found: false, source: 'fs' });
+    const state: InjectorCalls = { recommendationInserts: [], planVersionInserts: [], ledgerPatches: [], oasisEvents: [] };
+    setupGatewayMocks(state);
+
+    await injectIntoAutopilotPipeline(
+      'VTID-99999',
+      makeDiagnosis(['services/gateway/src/index.ts']),
+      'spec body',
+      'hash-index',
+    );
+
+    expect(bridgeMock).not.toHaveBeenCalled();
+    expect(state.recommendationInserts.length).toBe(0);
+    expect(state.planVersionInserts.length).toBe(0);
+    const refusalEvent = state.oasisEvents.find(e =>
+      e.topic === 'self-healing.execution.bridge_failed' &&
+      String(e.metadata?.reason_code || '').includes('SELF_HEALING_TEST_PATH_UNDERIVED')
+    );
+    expect(refusalEvent).toBeDefined();
+    expect(String(refusalEvent.metadata.underived_sources)).toContain('services/gateway/src/index.ts');
+  });
+
+  it('REFUSES the bridge for paths outside services/gateway/src/**', async () => {
+    loadSourceMock.mockResolvedValue({ found: false, source: 'fs' });
+    const state: InjectorCalls = { recommendationInserts: [], planVersionInserts: [], ledgerPatches: [], oasisEvents: [] };
+    setupGatewayMocks(state);
+
+    await injectIntoAutopilotPipeline(
+      'VTID-99999',
+      makeDiagnosis(['services/agents/orb-agent/src/whatever.py']),
+      'spec body',
+      'hash-outside',
+    );
+
+    expect(bridgeMock).not.toHaveBeenCalled();
+    const refusalEvent = state.oasisEvents.find(e =>
+      e.topic === 'self-healing.execution.bridge_failed' &&
+      String(e.metadata?.reason_code || '').includes('SELF_HEALING_TEST_PATH_UNDERIVED')
+    );
+    expect(refusalEvent).toBeDefined();
+  });
+
+  it('REFUSES the bridge if any one of multiple sources is underived', async () => {
+    loadSourceMock.mockResolvedValue({ found: false, source: 'fs' });
+    const state: InjectorCalls = { recommendationInserts: [], planVersionInserts: [], ledgerPatches: [], oasisEvents: [] };
+    setupGatewayMocks(state);
+
+    await injectIntoAutopilotPipeline(
+      'VTID-99999',
+      makeDiagnosis([
+        'services/gateway/src/routes/good.ts',
+        'services/gateway/src/index.ts', // underived
+      ]),
+      'spec body',
+      'hash-mixed',
+    );
+
+    expect(bridgeMock).not.toHaveBeenCalled();
+    expect(state.planVersionInserts.length).toBe(0);
+  });
+
+  it('handles two sources mapping to the same test path without duplicating', async () => {
+    loadSourceMock.mockResolvedValue({ found: false, source: 'fs' });
+    const state: InjectorCalls = { recommendationInserts: [], planVersionInserts: [], ledgerPatches: [], oasisEvents: [] };
+    setupGatewayMocks(state);
+
+    await injectIntoAutopilotPipeline(
+      'VTID-99999',
+      makeDiagnosis([
+        'services/gateway/src/routes/foo.ts',
+        'services/gateway/src/services/foo.ts', // same basename → same flat test path
+      ]),
+      'spec body',
+      'hash-dedupe',
+    );
+
+    const plan = state.planVersionInserts[0];
+    // Two source files, one test file (deduped).
+    expect(plan.files_referenced.length).toBe(3);
+    expect(plan.files_referenced).toContain('services/gateway/src/routes/foo.ts');
+    expect(plan.files_referenced).toContain('services/gateway/src/services/foo.ts');
+    expect(plan.files_referenced).toContain('services/gateway/test/foo.test.ts');
+  });
+});


### PR DESCRIPTION
## Summary
The autopilot safety gate's \`tests_missing\` rule refuses any plan with non-deletion edits and no test file (services/gateway/src/services/dev-autopilot-safety.ts:221). Self-healing diagnoses never propose tests on their own — so every self-healing plan was being blocked at \"safety gate blocked approval\" (VTID-02928, VTID-02939, VTID-02942, VTID-02945).

PR-H is the architecturally-clean fix: derive paired test paths in the injector, refuse the bridge if no path can be derived, amend the spec with explicit deliverables.

## What changed

**Existence-aware test-path derivation** for source paths under \`services/gateway/src/**\`:
- Probe 3 candidates via \`loadSourceFile()\` (fs → deployed SHA → ref=main): flat → mirror-routes → mirror-services. Use the first existing one.
- If none exists, default to flat with \`existing: false\` so the LLM creates it.

**Refuse-to-bridge** when ANY source is underived (returns \`null\`):
- \`services/gateway/src/index.ts\` → underived (mounter; Gap 2 territory)
- Anything outside \`services/gateway/src/**\` → underived
- Emits \`self-healing.execution.bridge_failed\` with reason code \`SELF_HEALING_TEST_PATH_UNDERIVED\`
- No recommendation/plan_versions row, no LLM call. Layer 2 terminalize gate (PR-E) catches the no-success contract downstream.

**Footer-amended plan markdown** with create-vs-modify verbs per pair. Original spec text preserved; footer appended. The LLM gets unambiguous instructions: ship both halves of every pair or the PR is auto-rejected.

## Test plan
- [x] \`npm run build\` — clean except pre-existing \`sharp\`
- [x] \`test/self-healing-test-path-derivation.test.ts\` — 7/7 pass (existing flat / mirror / fall-back-to-flat / refuse on index.ts / refuse on non-services/gateway / mixed underived → refuse / dedupe)
- [x] \`test/self-healing-injector-autopilot-bridge.test.ts\` — 4/4 still pass (assertion updated for footer-appended plan_markdown)
- [x] Full regression: **75/75** across all 8 self-healing test suites
- [ ] After merge: arm canary, expect bridge to either succeed (if derivation produces a viable plan) or refuse cleanly with \`SELF_HEALING_TEST_PATH_UNDERIVED\` (no fake success, no Claude run on a doomed plan)

## Contract
Combined with the prior 7 PRs, self-healing now has the structural pieces to ship a real PR for gateway code that includes both the fix AND a test for it. Real green path is now achievable.

🤖 Generated with [Claude Code](https://claude.com/claude-code)