### PR TITLE
feat(orb): F2 - B3 concept mastery decision integration (VTID-02950)

### DIFF
--- a/services/gateway/src/orb/context/compile-assistant-decision-context.ts
+++ b/services/gateway/src/orb/context/compile-assistant-decision-context.ts
@@ -1,20 +1,16 @@
 /**
  * VTID-02941 (B0b-min) — compileAssistantDecisionContext.
+ * VTID-02950 (F2)     — adds conceptMastery provider.
  *
  * The orchestrator. Calls each registered provider, collects their
  * distilled output, and produces ONE `AssistantDecisionContext` the
  * instruction layer can read.
  *
- * In this slice ONLY continuity is wired. The signature is designed so
- * future slices can plug in additional providers (matchJourney,
- * conceptMastery, journeyStage, etc.) WITHOUT changing the orchestrator
- * surface — they each become an optional injected provider.
- *
- * Failure policy: every provider runs in its own try/catch boundary. A
- * thrown error or a Supabase failure becomes `source_health.<source>.ok =
- * false` with a reason; the field on the context becomes `null`. The
- * orchestrator NEVER throws upward — a broken provider must not block
- * prompt assembly (acceptance #6).
+ * Providers run in parallel via `Promise.all`. Each runs in its own
+ * try/catch boundary. A thrown error or a Supabase failure becomes
+ * `source_health.<source>.ok = false` with a reason; the field on the
+ * context becomes `null`. The orchestrator NEVER throws upward — a
+ * broken provider must not block prompt assembly.
  *
  * Pure with respect to clock side-effects (now is injected) but does
  * call providers (which may do IO). Providers are responsible for
@@ -23,11 +19,17 @@
 
 import { defaultContinuityFetcher } from '../../services/continuity/continuity-fetcher';
 import { compileContinuityContext } from '../../services/continuity/compile-continuity-context';
+import { defaultConceptMasteryFetcher } from '../../services/concept-mastery/concept-mastery-fetcher';
+import { compileConceptMasteryContext } from '../../services/concept-mastery/compile-concept-mastery-context';
 import {
   distillContinuityForDecision,
 } from './providers/continuity-decision-provider';
+import {
+  distillConceptMasteryForDecision,
+} from './providers/concept-mastery-decision-provider';
 import type {
   AssistantDecisionContext,
+  DecisionConceptMastery,
   DecisionContinuity,
 } from './types';
 
@@ -38,28 +40,34 @@ export interface CompileAssistantDecisionContextInputs {
   nowMs?: number;
   /**
    * Provider overrides for tests. Production passes nothing and we use
-   * the defaults wired into `services/continuity/*`.
+   * the defaults wired into the per-feature services.
    */
   providers?: Partial<{
     continuity: () => Promise<DecisionContinuity | null>;
+    conceptMastery: () => Promise<DecisionConceptMastery | null>;
   }>;
   /**
    * Source-health reporter override for tests — when the provider
    * returns null, this lets a test stub a reason without monkey-patching
    * the default fetcher.
    */
-  reasons?: Partial<{ continuity: string }>;
+  reasons?: Partial<{ continuity: string; conceptMastery: string }>;
 }
 
 export async function compileAssistantDecisionContext(
   input: CompileAssistantDecisionContextInputs,
 ): Promise<AssistantDecisionContext> {
-  const continuityRun = await runContinuityProvider(input);
+  const [continuityRun, conceptMasteryRun] = await Promise.all([
+    runContinuityProvider(input),
+    runConceptMasteryProvider(input),
+  ]);
 
   return {
     continuity: continuityRun.value,
+    concept_mastery: conceptMasteryRun.value,
     source_health: {
       continuity: continuityRun.health,
+      concept_mastery: conceptMasteryRun.health,
     },
   };
 }
@@ -119,6 +127,47 @@ async function runContinuityProvider(
     return { value: decisionView, health: { ok: true } };
   } catch (e) {
     const reason = input.reasons?.continuity ?? (e as Error).message;
+    return { value: null, health: { ok: false, reason } };
+  }
+}
+
+async function runConceptMasteryProvider(
+  input: CompileAssistantDecisionContextInputs,
+): Promise<ProviderRun<DecisionConceptMastery>> {
+  const override = input.providers?.conceptMastery;
+  if (override) {
+    try {
+      const value = await override();
+      return { value, health: { ok: true } };
+    } catch (e) {
+      return {
+        value: null,
+        health: { ok: false, reason: (e as Error).message },
+      };
+    }
+  }
+
+  try {
+    const fetchResult = await defaultConceptMasteryFetcher.listConceptState({
+      tenantId: input.tenantId,
+      userId: input.userId,
+      limit: 500,
+    });
+
+    if (!fetchResult.ok) {
+      const reason = fetchResult.reason ?? 'concept_mastery_unavailable';
+      return { value: null, health: { ok: false, reason } };
+    }
+
+    const conceptMastery = compileConceptMasteryContext({
+      fetchResult,
+      nowMs: input.nowMs,
+    });
+
+    const decisionView = distillConceptMasteryForDecision({ conceptMastery });
+    return { value: decisionView, health: { ok: true } };
+  } catch (e) {
+    const reason = input.reasons?.conceptMastery ?? (e as Error).message;
     return { value: null, health: { ok: false, reason } };
   }
 }

--- a/services/gateway/src/orb/context/providers/concept-mastery-decision-provider.ts
+++ b/services/gateway/src/orb/context/providers/concept-mastery-decision-provider.ts
@@ -1,0 +1,128 @@
+/**
+ * VTID-02950 (F2) — ConceptMastery → AssistantDecisionContext adapter.
+ *
+ * The B3 read-only inspection slice already produced
+ * `ConceptMasteryContext`, a richer shape designed for the Command Hub
+ * operator. The assistant decision layer reads a NARROWER shape
+ * (`DecisionConceptMastery`) that strips:
+ *   - raw last_explained_at / last_observed_at / last_seen_at timestamps
+ *   - raw 0..1 confidence floats (bucketed to low / medium / high)
+ *   - raw integer counts (bucketed via FrequencyBucket)
+ *
+ * Kept: stable identifiers (concept_key, card_key) so the LLM can
+ * refer back, plus pre-derived RepetitionHint and days_since_*
+ * recency hints.
+ *
+ * Pure function. No IO. The caller is responsible for invoking the
+ * concept-mastery compiler + passing its output here.
+ */
+
+import type { ConceptMasteryContext } from '../../../services/concept-mastery/types';
+import type {
+  DecisionConceptMastery,
+  FrequencyBucket,
+  MasteryConfidenceBucket,
+} from '../types';
+
+export interface DistillConceptMasteryInputs {
+  /**
+   * Output of `compileConceptMasteryContext` from B3. Read-only.
+   */
+  conceptMastery: ConceptMasteryContext;
+}
+
+/**
+ * Distills `ConceptMasteryContext` into the decision-grade
+ * `DecisionConceptMastery`.
+ *
+ * Always returns a typed shape (never undefined). The caller decides
+ * whether to attach it to `AssistantDecisionContext.concept_mastery` or
+ * set the field to `null` based on source health.
+ */
+export function distillConceptMasteryForDecision(
+  input: DistillConceptMasteryInputs,
+): DecisionConceptMastery {
+  const { conceptMastery } = input;
+
+  const concepts_explained = conceptMastery.concepts_explained.map((c) => ({
+    concept_key: c.concept_key,
+    frequency: bucketFrequency(c.count),
+    days_since_last_explained: c.days_since_last_explained,
+    repetition_hint: c.repetition_hint,
+  }));
+
+  const concepts_mastered = conceptMastery.concepts_mastered.map((c) => ({
+    concept_key: c.concept_key,
+    confidence: bucketMasteryConfidence(c.confidence),
+  }));
+
+  const dyk_cards_seen = conceptMastery.dyk_cards_seen.map((d) => ({
+    card_key: d.card_key,
+    frequency: bucketFrequency(d.count),
+    days_since_last_seen: d.days_since_last_seen,
+  }));
+
+  const counts = {
+    concepts_explained_total: conceptMastery.counts.concepts_explained_total,
+    concepts_mastered_total: conceptMastery.counts.concepts_mastered_total,
+    dyk_cards_seen_total: conceptMastery.counts.dyk_cards_seen_total,
+    concepts_explained_in_last_24h:
+      conceptMastery.counts.concepts_explained_in_last_24h,
+  };
+
+  const recommended_cadence = pickRecommendedCadence(concepts_explained);
+
+  return {
+    concepts_explained,
+    concepts_mastered,
+    dyk_cards_seen,
+    counts,
+    recommended_cadence,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — exported for tests
+// ---------------------------------------------------------------------------
+
+/**
+ * Buckets a raw integer count into a coarse frequency band. The LLM
+ * doesn't need to know "5 times" vs "8 times" — only the band that
+ * drives cadence policy.
+ */
+export function bucketFrequency(count: number): FrequencyBucket {
+  if (!Number.isFinite(count) || count <= 0) return 'none';
+  if (count === 1) return 'once';
+  if (count === 2) return 'twice';
+  return 'many';
+}
+
+/**
+ * Buckets a raw 0..1 confidence float into a coarse band. The LLM
+ * doesn't need to know "0.72" vs "0.81" — only "high" vs "medium".
+ */
+export function bucketMasteryConfidence(
+  confidence: number | null,
+): MasteryConfidenceBucket | 'unknown' {
+  if (confidence === null || !Number.isFinite(confidence)) return 'unknown';
+  if (confidence < 0.4) return 'low';
+  if (confidence < 0.7) return 'medium';
+  return 'high';
+}
+
+/**
+ * Picks the single recommended cadence action from the distilled set
+ * of explained concepts.
+ *
+ * Priority: suppress_over_explained > use_one_liner > introduce_fresh > none.
+ */
+export function pickRecommendedCadence(
+  concepts_explained: ReadonlyArray<{ repetition_hint: 'first_time' | 'one_liner' | 'skip' }>,
+): DecisionConceptMastery['recommended_cadence'] {
+  if (concepts_explained.length === 0) return 'none';
+  const hints = concepts_explained.map((c) => c.repetition_hint);
+  if (hints.includes('skip')) return 'suppress_over_explained';
+  if (hints.includes('one_liner')) return 'use_one_liner';
+  if (hints.every((h) => h === 'first_time')) return 'introduce_fresh';
+  return 'none';
+}

--- a/services/gateway/src/orb/context/types.ts
+++ b/services/gateway/src/orb/context/types.ts
@@ -1,22 +1,19 @@
 /**
  * VTID-02941 (B0b-min) — AssistantDecisionContext: the decision contract.
+ * VTID-02950 (F2)     — adds conceptMastery field.
  *
  * This is the SINGLE typed shape the instruction layer reads to assemble
- * a prompt. Raw rows (memory, threads, messages, promises, profiles)
- * MUST NOT cross this boundary. The compiler distills; the renderer
- * formats. No exceptions.
+ * a prompt. Raw rows (memory, threads, messages, promises, profiles,
+ * concept rows, scores, transcripts) MUST NOT cross this boundary. The
+ * compiler distills; the renderer formats. No exceptions.
  *
- * Wall (B0b-min):
- *   - Forbidden in this slice: match journey, feature discovery, wake
- *     brief, continuation contract, greeting decay rewrite, repetition
- *     suppression, journey stage modulation, reliability tuning.
- *   - Only `continuity` is wired through this contract in this PR.
+ * Wall:
+ *   - Forbidden: match journey, feature discovery, wake brief,
+ *     continuation contract, greeting decay rewrite, journey stage
+ *     modulation, reliability tuning. Each gets its own slice.
+ *   - Continuity (B2) + conceptMastery (B3) are wired through this
+ *     contract.
  *   - Adding new fields later is fine; pushing raw rows into them is not.
- *
- * Why this file is in `services/gateway/src/orb/context/`:
- *   The plan's target module layout puts the context spine under
- *   `services/gateway/src/orb/context/`. We honor that path so future
- *   slices land in the same place rather than creating a parallel tree.
  */
 
 /**
@@ -70,19 +67,99 @@ export interface DecisionContinuity {
 }
 
 /**
+ * Frequency bucket — bucketed integer counts. The decision layer reads
+ * the bucket name, never the raw count value.
+ */
+export type FrequencyBucket = 'none' | 'once' | 'twice' | 'many';
+
+/**
+ * Mastery confidence bucket — bucketed mastery-confidence score. We
+ * deliberately do NOT pass the raw 0..1 score through the contract:
+ * the LLM doesn't need to know "0.72" vs "0.81", only the band.
+ */
+export type MasteryConfidenceBucket = 'low' | 'medium' | 'high';
+
+/**
+ * Repetition hint that the assistant decision layer reads to suppress
+ * over-explanation. Identical to B3's `compileConceptMasteryContext`
+ * output — that enum is already decision-grade, no need to re-derive.
+ */
+export type RepetitionHint = 'first_time' | 'one_liner' | 'skip';
+
+/**
+ * Distilled concept-mastery view. Mirrors `ConceptMasteryContext` from
+ * `services/concept-mastery/types.ts` but strips:
+ *   - raw last_explained_at / last_observed_at / last_seen_at timestamps
+ *   - raw 0..1 confidence floats (bucketed to low / medium / high)
+ *   - raw integer counts (bucketed via FrequencyBucket)
+ *
+ * Kept: concept_key and card_key (stable identifiers the LLM can refer
+ * to), repetition_hint (already decision-grade), and days_since_*
+ * recency hints.
+ */
+export interface DecisionConceptMastery {
+  /** Concepts the assistant has explained (capped at 10), recency first. */
+  concepts_explained: ReadonlyArray<{
+    /** Stable key for the concept, e.g. 'vitana_index'. */
+    concept_key: string;
+    /** Bucketed explanation frequency. Replaces raw count. */
+    frequency: FrequencyBucket;
+    /** Recency hint. Days are coarse enough to share. */
+    days_since_last_explained: number | null;
+    /** Pre-computed repetition hint from B3's compiler. */
+    repetition_hint: RepetitionHint;
+  }>;
+  /** Concepts the user has demonstrated mastery of (capped at 10). */
+  concepts_mastered: ReadonlyArray<{
+    concept_key: string;
+    /** Bucketed confidence. Replaces raw 0..1 score. */
+    confidence: MasteryConfidenceBucket | 'unknown';
+  }>;
+  /** DYK cards already surfaced (capped at 10). */
+  dyk_cards_seen: ReadonlyArray<{
+    /** Stable card key. */
+    card_key: string;
+    /** Bucketed surface frequency. */
+    frequency: FrequencyBucket;
+    days_since_last_seen: number | null;
+  }>;
+  /** Aggregate counts the cadence layer uses (integers — these are totals, not raw rows). */
+  counts: {
+    concepts_explained_total: number;
+    concepts_mastered_total: number;
+    dyk_cards_seen_total: number;
+    concepts_explained_in_last_24h: number;
+  };
+  /**
+   * Single recommended cadence action.
+   *   - 'suppress_over_explained' → at least one explained concept has hint=skip
+   *   - 'use_one_liner'           → at least one has hint=one_liner, none skip
+   *   - 'introduce_fresh'         → only first_time hints OR no explained concepts
+   *   - 'none'                    → no actionable concept-mastery state
+   */
+  recommended_cadence:
+    | 'suppress_over_explained'
+    | 'use_one_liner'
+    | 'introduce_fresh'
+    | 'none';
+}
+
+/**
  * Per-source health view. Empty/missing rows are not failures — they
- * just mean the user has no continuity state yet. Failures (Supabase
- * down, schema mismatch, etc.) surface here with a `reason`.
+ * just mean the user has no state yet. Failures (Supabase down, schema
+ * mismatch, etc.) surface here with a `reason`.
  */
 export interface DecisionSourceHealth {
   continuity: { ok: boolean; reason?: string };
+  /** F2: concept-mastery source health. */
+  concept_mastery: { ok: boolean; reason?: string };
 }
 
 /**
  * The single typed contract the instruction layer reads.
  *
- * Future slices add fields (matchJourney, conceptMastery, journeyStage,
- * etc.) — they MUST land here as distilled shapes, never raw rows.
+ * Future slices add fields (matchJourney, journeyStage, etc.) — they
+ * MUST land here as distilled shapes, never raw rows.
  *
  * `additionalProperties=false` semantics are enforced by tests + the
  * renderer's behavior: any unrecognized field is silently dropped.
@@ -91,9 +168,15 @@ export interface AssistantDecisionContext {
   /**
    * Continuity decision view. `null` when the compiler had no input or
    * source-health is degraded — the renderer must emit no continuity
-   * section in that case (acceptance #1 + #6).
+   * section in that case.
    */
   continuity: DecisionContinuity | null;
+  /**
+   * F2: Concept-mastery decision view. `null` when the compiler had no
+   * input or source-health is degraded — the renderer must emit no
+   * concept-mastery section in that case.
+   */
+  concept_mastery: DecisionConceptMastery | null;
   /** Per-source health. Always present, even when fields are null. */
   source_health: DecisionSourceHealth;
 }

--- a/services/gateway/src/orb/live/instruction/decision-contract-renderer.ts
+++ b/services/gateway/src/orb/live/instruction/decision-contract-renderer.ts
@@ -1,5 +1,6 @@
 /**
  * VTID-02941 (B0b-min) — decision-contract-renderer.
+ * VTID-02950 (F2)     — adds concept-mastery section.
  *
  * Single responsibility: take an `AssistantDecisionContext` and
  * produce a prompt section string the static system instruction can
@@ -10,17 +11,17 @@
  *   - query the database
  *   - read memory tables
  *   - touch Supabase directly
- *   - import from `services/continuity/*` or any compiler module
+ *   - import from `services/continuity/*`, `services/concept-mastery/*`,
+ *     or any compiler module
  *
  * Type-level enforcement: the only argument is `AssistantDecisionContext`.
  * A test asserts the renderer source file contains no `import` from
  * `services/`, `lib/supabase`, or `fetch`.
  *
  * Empty / degraded handling:
- *   - `decision.continuity === null` → no continuity section is emitted
- *     (acceptance #1 + #6).
- *   - `source_health.continuity.ok === false` → a small "[continuity:
- *     source degraded — <reason>]" hint appears so the prompt remains
+ *   - `decision.<field> === null` → no section for that field is emitted.
+ *   - `source_health.<field>.ok === false` → a small "[<field>: source
+ *     degraded — <reason>]" hint appears so the prompt remains
  *     informative without inventing data.
  *   - Empty arrays → that subsection is omitted, but the overall
  *     section still renders if any subsection has content.
@@ -28,6 +29,7 @@
 
 import type {
   AssistantDecisionContext,
+  DecisionConceptMastery,
   DecisionContinuity,
 } from '../../context/types';
 
@@ -62,6 +64,18 @@ export function renderDecisionContract(
   } else if (continuityHealth && continuityHealth.ok === false) {
     lines.push(
       `[continuity: source degraded — ${continuityHealth.reason ?? 'unknown_reason'}]`,
+    );
+  }
+
+  // ---- concept mastery (F2) ----
+  const conceptSection = renderConceptMastery(decision.concept_mastery);
+  const conceptHealth = decision.source_health.concept_mastery;
+
+  if (conceptSection) {
+    lines.push(conceptSection);
+  } else if (conceptHealth && conceptHealth.ok === false) {
+    lines.push(
+      `[concept_mastery: source degraded — ${conceptHealth.reason ?? 'unknown_reason'}]`,
     );
   }
 
@@ -112,4 +126,48 @@ function renderContinuity(continuity: DecisionContinuity | null): string {
 
   if (subs.length === 0) return '';
   return ['Continuity:', ...subs].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Concept Mastery sub-section (F2)
+// ---------------------------------------------------------------------------
+
+function renderConceptMastery(cm: DecisionConceptMastery | null): string {
+  if (!cm) return '';
+
+  const subs: string[] = [];
+
+  if (cm.concepts_explained.length > 0) {
+    const lines = cm.concepts_explained.map((c) => {
+      const age = c.days_since_last_explained === null
+        ? ''
+        : ` (${c.days_since_last_explained}d ago)`;
+      return `  - ${c.concept_key} [${c.frequency}, hint=${c.repetition_hint}]${age}`;
+    });
+    subs.push(['Concepts explained:', ...lines].join('\n'));
+  }
+
+  if (cm.concepts_mastered.length > 0) {
+    const lines = cm.concepts_mastered.map(
+      (c) => `  - ${c.concept_key} [confidence=${c.confidence}]`,
+    );
+    subs.push(['Concepts mastered:', ...lines].join('\n'));
+  }
+
+  if (cm.dyk_cards_seen.length > 0) {
+    const lines = cm.dyk_cards_seen.map((d) => {
+      const age = d.days_since_last_seen === null
+        ? ''
+        : ` (${d.days_since_last_seen}d ago)`;
+      return `  - ${d.card_key} [${d.frequency}]${age}`;
+    });
+    subs.push(['DYK cards seen:', ...lines].join('\n'));
+  }
+
+  if (cm.recommended_cadence !== 'none') {
+    subs.push(`Recommended cadence: ${cm.recommended_cadence}`);
+  }
+
+  if (subs.length === 0) return '';
+  return ['Concept mastery:', ...subs].join('\n');
 }

--- a/services/gateway/test/orb/context/compile-assistant-decision-context.test.ts
+++ b/services/gateway/test/orb/context/compile-assistant-decision-context.test.ts
@@ -1,95 +1,193 @@
 /**
- * VTID-02941 (B0b-min) — compileAssistantDecisionContext orchestrator tests.
+ * VTID-02941 (B0b-min) + VTID-02950 (F2) — compileAssistantDecisionContext.
  *
  * Acceptance:
- *   #1 — empty continuity produces a valid AssistantDecisionContext with
- *        safe empty defaults
- *   #6 — if the continuity compiler throws, prompt still renders with
- *        sourceHealth=degraded and no crash
+ *   #1 — empty providers produce a valid AssistantDecisionContext with
+ *        safe empty defaults for ALL fields (continuity + concept_mastery)
+ *   #6 — if any provider throws, the prompt still renders with
+ *        sourceHealth=degraded and no crash; the other provider continues
  *
  * The orchestrator MUST:
  *   - never throw upward
- *   - attach reason on source_health when the provider fails
- *   - return continuity:null when source health is degraded
- *   - accept provider overrides for tests
+ *   - attach reason on source_health when a provider fails
+ *   - return field:null when that source health is degraded
+ *   - accept provider overrides per-field for tests
+ *   - run providers in parallel — one throwing must not block the other
  */
 
 import { compileAssistantDecisionContext } from '../../../src/orb/context/compile-assistant-decision-context';
-import type { DecisionContinuity } from '../../../src/orb/context/types';
+import type {
+  DecisionConceptMastery,
+  DecisionContinuity,
+} from '../../../src/orb/context/types';
 
-describe('B0b-min — compileAssistantDecisionContext', () => {
-  describe('happy path with provider override', () => {
-    it('attaches the provider output to .continuity', async () => {
-      const stub: DecisionContinuity = {
-        open_threads: [],
-        promises_owed: [],
-        promises_kept_recently: [],
-        counts: {
-          open_threads_total: 0,
-          promises_owed_total: 0,
-          promises_overdue: 0,
-          threads_mentioned_today: 0,
-        },
-        recommended_follow_up: 'none',
-      };
+const stubContinuity: DecisionContinuity = {
+  open_threads: [],
+  promises_owed: [],
+  promises_kept_recently: [],
+  counts: {
+    open_threads_total: 0,
+    promises_owed_total: 0,
+    promises_overdue: 0,
+    threads_mentioned_today: 0,
+  },
+  recommended_follow_up: 'none',
+};
+
+const stubConceptMastery: DecisionConceptMastery = {
+  concepts_explained: [],
+  concepts_mastered: [],
+  dyk_cards_seen: [],
+  counts: {
+    concepts_explained_total: 0,
+    concepts_mastered_total: 0,
+    dyk_cards_seen_total: 0,
+    concepts_explained_in_last_24h: 0,
+  },
+  recommended_cadence: 'none',
+};
+
+describe('compileAssistantDecisionContext', () => {
+  describe('happy path with both provider overrides', () => {
+    it('attaches each provider output to its field', async () => {
       const out = await compileAssistantDecisionContext({
         userId: 'u',
         tenantId: 't',
-        providers: { continuity: async () => stub },
+        providers: {
+          continuity: async () => stubContinuity,
+          conceptMastery: async () => stubConceptMastery,
+        },
       });
-      expect(out.continuity).toEqual(stub);
+      expect(out.continuity).toEqual(stubContinuity);
+      expect(out.concept_mastery).toEqual(stubConceptMastery);
       expect(out.source_health.continuity.ok).toBe(true);
+      expect(out.source_health.concept_mastery.ok).toBe(true);
     });
   });
 
-  describe('provider throws (acceptance #6)', () => {
-    it('returns continuity:null + source_health.ok=false + reason', async () => {
+  describe('per-provider throw (acceptance #6)', () => {
+    it('continuity throws → continuity null + concept_mastery still flows', async () => {
       const out = await compileAssistantDecisionContext({
         userId: 'u',
         tenantId: 't',
         providers: {
           continuity: async () => {
-            throw new Error('boom');
+            throw new Error('continuity_boom');
           },
+          conceptMastery: async () => stubConceptMastery,
         },
       });
       expect(out.continuity).toBeNull();
       expect(out.source_health.continuity.ok).toBe(false);
-      expect(out.source_health.continuity.reason).toBe('boom');
+      expect(out.source_health.continuity.reason).toBe('continuity_boom');
+      expect(out.concept_mastery).toEqual(stubConceptMastery);
+      expect(out.source_health.concept_mastery.ok).toBe(true);
+    });
+
+    it('concept_mastery throws → concept_mastery null + continuity still flows', async () => {
+      const out = await compileAssistantDecisionContext({
+        userId: 'u',
+        tenantId: 't',
+        providers: {
+          continuity: async () => stubContinuity,
+          conceptMastery: async () => {
+            throw new Error('concept_boom');
+          },
+        },
+      });
+      expect(out.concept_mastery).toBeNull();
+      expect(out.source_health.concept_mastery.ok).toBe(false);
+      expect(out.source_health.concept_mastery.reason).toBe('concept_boom');
+      expect(out.continuity).toEqual(stubContinuity);
+      expect(out.source_health.continuity.ok).toBe(true);
+    });
+
+    it('both providers throw → both null but no crash', async () => {
+      const out = await compileAssistantDecisionContext({
+        userId: 'u',
+        tenantId: 't',
+        providers: {
+          continuity: async () => { throw new Error('c_boom'); },
+          conceptMastery: async () => { throw new Error('m_boom'); },
+        },
+      });
+      expect(out.continuity).toBeNull();
+      expect(out.concept_mastery).toBeNull();
+      expect(out.source_health.continuity.reason).toBe('c_boom');
+      expect(out.source_health.concept_mastery.reason).toBe('m_boom');
     });
   });
 
   describe('provider returns null (acceptance #1)', () => {
-    it('attaches null + ok:true (provider deliberately suppressed)', async () => {
+    it('attaches null + ok:true for both (provider deliberately suppressed)', async () => {
       const out = await compileAssistantDecisionContext({
         userId: 'u',
         tenantId: 't',
-        providers: { continuity: async () => null },
+        providers: {
+          continuity: async () => null,
+          conceptMastery: async () => null,
+        },
       });
       expect(out.continuity).toBeNull();
+      expect(out.concept_mastery).toBeNull();
       expect(out.source_health.continuity.ok).toBe(true);
+      expect(out.source_health.concept_mastery.ok).toBe(true);
     });
   });
 
   describe('always returns a typed shape', () => {
-    it('source_health.continuity is always present', async () => {
+    it('source_health.continuity AND source_health.concept_mastery are always present', async () => {
       const out = await compileAssistantDecisionContext({
         userId: 'u',
         tenantId: 't',
-        providers: { continuity: async () => null },
+        providers: {
+          continuity: async () => null,
+          conceptMastery: async () => null,
+        },
       });
       expect(out.source_health).toBeDefined();
       expect(out.source_health.continuity).toBeDefined();
+      expect(out.source_health.concept_mastery).toBeDefined();
     });
 
-    it('result has only known top-level keys (no leakage)', async () => {
+    it('result has exactly three top-level keys (no leakage, no extras)', async () => {
       const out = await compileAssistantDecisionContext({
         userId: 'u',
         tenantId: 't',
-        providers: { continuity: async () => null },
+        providers: {
+          continuity: async () => null,
+          conceptMastery: async () => null,
+        },
       });
       const keys = Object.keys(out).sort();
-      expect(keys).toEqual(['continuity', 'source_health']);
+      expect(keys).toEqual(['concept_mastery', 'continuity', 'source_health']);
+    });
+  });
+
+  describe('parallel execution', () => {
+    it('runs both providers concurrently (one slow does not serialize the other)', async () => {
+      const order: string[] = [];
+      const out = await compileAssistantDecisionContext({
+        userId: 'u',
+        tenantId: 't',
+        providers: {
+          continuity: async () => {
+            await new Promise(r => setTimeout(r, 20));
+            order.push('continuity');
+            return stubContinuity;
+          },
+          conceptMastery: async () => {
+            await new Promise(r => setTimeout(r, 5));
+            order.push('concept');
+            return stubConceptMastery;
+          },
+        },
+      });
+      // concept_mastery finishes first because its delay is shorter,
+      // proving the providers ran in parallel (not sequential).
+      expect(order).toEqual(['concept', 'continuity']);
+      expect(out.continuity).toEqual(stubContinuity);
+      expect(out.concept_mastery).toEqual(stubConceptMastery);
     });
   });
 });

--- a/services/gateway/test/orb/context/concept-mastery-decision-provider.test.ts
+++ b/services/gateway/test/orb/context/concept-mastery-decision-provider.test.ts
@@ -1,0 +1,188 @@
+/**
+ * VTID-02950 (F2) — concept-mastery-decision-provider adapter tests.
+ *
+ * Wall: the adapter MUST distill to decision-grade fields and drop:
+ *   - raw last_explained_at / last_observed_at / last_seen_at timestamps
+ *   - raw 0..1 confidence floats (must bucket to low/medium/high/unknown)
+ *   - raw integer counts (must bucket to none/once/twice/many)
+ * Kept: stable identifiers (concept_key, card_key), recency hints
+ * (days_since_*), and the pre-derived RepetitionHint.
+ */
+
+import {
+  bucketFrequency,
+  bucketMasteryConfidence,
+  distillConceptMasteryForDecision,
+  pickRecommendedCadence,
+} from '../../../src/orb/context/providers/concept-mastery-decision-provider';
+import type { ConceptMasteryContext } from '../../../src/services/concept-mastery/types';
+
+function makeContext(over: Partial<ConceptMasteryContext> = {}): ConceptMasteryContext {
+  return {
+    concepts_explained: [],
+    concepts_mastered: [],
+    dyk_cards_seen: [],
+    counts: {
+      concepts_explained_total: 0,
+      concepts_mastered_total: 0,
+      dyk_cards_seen_total: 0,
+      concepts_explained_in_last_24h: 0,
+    },
+    source_health: {
+      user_assistant_state: { ok: true },
+    },
+    ...over,
+  };
+}
+
+describe('F2 — distillConceptMasteryForDecision', () => {
+  describe('forbidden raw fields are NOT surfaced', () => {
+    it('drops last_explained_at from concepts_explained', () => {
+      const out = distillConceptMasteryForDecision({
+        conceptMastery: makeContext({
+          concepts_explained: [{
+            concept_key: 'vitana_index',
+            count: 2,
+            last_explained_at: '2026-05-12T12:00:00Z',
+            days_since_last_explained: 1,
+            repetition_hint: 'one_liner',
+          }],
+        }),
+      });
+      const keys = Object.keys(out.concepts_explained[0]).sort();
+      expect(keys).toEqual([
+        'concept_key',
+        'days_since_last_explained',
+        'frequency',
+        'repetition_hint',
+      ]);
+      // count is replaced by frequency bucket
+      expect((out.concepts_explained[0] as any).count).toBeUndefined();
+      expect((out.concepts_explained[0] as any).last_explained_at).toBeUndefined();
+    });
+
+    it('drops last_observed_at + raw confidence float from concepts_mastered', () => {
+      const out = distillConceptMasteryForDecision({
+        conceptMastery: makeContext({
+          concepts_mastered: [{
+            concept_key: 'vitana_index',
+            confidence: 0.85,
+            last_observed_at: '2026-05-12T08:00:00Z',
+            source: 'inferred',
+          }],
+        }),
+      });
+      const keys = Object.keys(out.concepts_mastered[0]).sort();
+      expect(keys).toEqual(['concept_key', 'confidence']);
+      expect((out.concepts_mastered[0] as any).last_observed_at).toBeUndefined();
+      expect((out.concepts_mastered[0] as any).source).toBeUndefined();
+      // confidence is a bucket string, never a float
+      expect(typeof out.concepts_mastered[0].confidence).toBe('string');
+    });
+
+    it('drops last_seen_at from dyk_cards_seen', () => {
+      const out = distillConceptMasteryForDecision({
+        conceptMastery: makeContext({
+          dyk_cards_seen: [{
+            card_key: 'dyk_index_intro',
+            count: 3,
+            last_seen_at: '2026-05-10T20:00:00Z',
+            days_since_last_seen: 2,
+          }],
+        }),
+      });
+      const keys = Object.keys(out.dyk_cards_seen[0]).sort();
+      expect(keys).toEqual(['card_key', 'days_since_last_seen', 'frequency']);
+      expect((out.dyk_cards_seen[0] as any).last_seen_at).toBeUndefined();
+      expect((out.dyk_cards_seen[0] as any).count).toBeUndefined();
+    });
+  });
+
+  describe('bucketFrequency', () => {
+    it('0 / negative → none', () => {
+      expect(bucketFrequency(0)).toBe('none');
+      expect(bucketFrequency(-5)).toBe('none');
+      expect(bucketFrequency(NaN)).toBe('none');
+    });
+
+    it('1 → once', () => {
+      expect(bucketFrequency(1)).toBe('once');
+    });
+
+    it('2 → twice', () => {
+      expect(bucketFrequency(2)).toBe('twice');
+    });
+
+    it('3+ → many', () => {
+      expect(bucketFrequency(3)).toBe('many');
+      expect(bucketFrequency(50)).toBe('many');
+    });
+  });
+
+  describe('bucketMasteryConfidence', () => {
+    it('null / NaN → unknown', () => {
+      expect(bucketMasteryConfidence(null)).toBe('unknown');
+      expect(bucketMasteryConfidence(NaN)).toBe('unknown');
+    });
+
+    it.each([
+      [0,    'low'],
+      [0.39, 'low'],
+      [0.4,  'medium'],
+      [0.69, 'medium'],
+      [0.7,  'high'],
+      [1,    'high'],
+    ])('%f → %s', (c, expected) => {
+      expect(bucketMasteryConfidence(c)).toBe(expected);
+    });
+  });
+
+  describe('pickRecommendedCadence priority', () => {
+    it('empty → none', () => {
+      expect(pickRecommendedCadence([])).toBe('none');
+    });
+
+    it('any "skip" → suppress_over_explained', () => {
+      expect(pickRecommendedCadence([
+        { repetition_hint: 'first_time' },
+        { repetition_hint: 'skip' },
+        { repetition_hint: 'one_liner' },
+      ])).toBe('suppress_over_explained');
+    });
+
+    it('any "one_liner" + no "skip" → use_one_liner', () => {
+      expect(pickRecommendedCadence([
+        { repetition_hint: 'first_time' },
+        { repetition_hint: 'one_liner' },
+      ])).toBe('use_one_liner');
+    });
+
+    it('all "first_time" → introduce_fresh', () => {
+      expect(pickRecommendedCadence([
+        { repetition_hint: 'first_time' },
+        { repetition_hint: 'first_time' },
+      ])).toBe('introduce_fresh');
+    });
+  });
+
+  describe('counts pass through (totals, not raw rows)', () => {
+    it('preserves the four aggregate counts', () => {
+      const out = distillConceptMasteryForDecision({
+        conceptMastery: makeContext({
+          counts: {
+            concepts_explained_total: 12,
+            concepts_mastered_total: 3,
+            dyk_cards_seen_total: 7,
+            concepts_explained_in_last_24h: 2,
+          },
+        }),
+      });
+      expect(out.counts).toEqual({
+        concepts_explained_total: 12,
+        concepts_mastered_total: 3,
+        dyk_cards_seen_total: 7,
+        concepts_explained_in_last_24h: 2,
+      });
+    });
+  });
+});

--- a/services/gateway/test/orb/context/decision-context-types.test.ts
+++ b/services/gateway/test/orb/context/decision-context-types.test.ts
@@ -68,4 +68,56 @@ describe('B0b-min — AssistantDecisionContext type guards', () => {
     // The type must allow null to enable empty-degrades.
     expect(typesSrc).toMatch(/continuity:\s*DecisionContinuity\s*\|\s*null/);
   });
+
+  // F2: concept-mastery type guards.
+  describe('forbidden raw fields are NOT declared in DecisionConceptMastery', () => {
+    // These fields exist in the underlying ConceptMasteryContext but MUST
+    // NOT appear in DecisionConceptMastery. If a future change adds any
+    // of them, this test fails — that's the wall.
+    const forbiddenConceptFields = [
+      'last_explained_at',
+      'last_observed_at',
+      'last_seen_at',
+    ];
+
+    it.each(forbiddenConceptFields)('does not declare %s anywhere', (field) => {
+      const decl = new RegExp(`\\b${field}\\s*\\??:`, 'g');
+      expect(typesSrc).not.toMatch(decl);
+    });
+
+    it('declares frequency as a bucket type, NEVER as a raw number', () => {
+      // The bucket types are FrequencyBucket / MasteryConfidenceBucket.
+      // Searching for `frequency: number` would be a regression.
+      expect(typesSrc).not.toMatch(/frequency\s*:\s*number/);
+      expect(typesSrc).toMatch(/frequency:\s*FrequencyBucket/);
+    });
+
+    it('declares confidence as a bucket type, NEVER as a raw number', () => {
+      // Confidence in DecisionConceptMastery is bucketed; the underlying
+      // ConceptMasteryRow type is in services/ and can keep the raw
+      // float, but THIS shape must not expose it.
+      expect(typesSrc).toMatch(/confidence:\s*MasteryConfidenceBucket\s*\|\s*'unknown'/);
+      // No `confidence: number` on the decision shape.
+      const decisionShape = typesSrc.slice(
+        typesSrc.indexOf('export interface DecisionConceptMastery'),
+        typesSrc.indexOf('export interface DecisionSourceHealth'),
+      );
+      expect(decisionShape).not.toMatch(/confidence\s*:\s*number/);
+    });
+  });
+
+  it('declares the concept-mastery surfaces + recommended_cadence', () => {
+    expect(typesSrc).toContain('concepts_explained');
+    expect(typesSrc).toContain('concepts_mastered');
+    expect(typesSrc).toContain('dyk_cards_seen');
+    expect(typesSrc).toContain('recommended_cadence');
+  });
+
+  it('AssistantDecisionContext.concept_mastery is optional null', () => {
+    expect(typesSrc).toMatch(/concept_mastery:\s*DecisionConceptMastery\s*\|\s*null/);
+  });
+
+  it('DecisionSourceHealth declares concept_mastery health entry', () => {
+    expect(typesSrc).toMatch(/concept_mastery:\s*\{\s*ok:\s*boolean/);
+  });
 });

--- a/services/gateway/test/orb/context/spine-end-to-end.test.ts
+++ b/services/gateway/test/orb/context/spine-end-to-end.test.ts
@@ -95,7 +95,11 @@ describe('B0b-min — end-to-end spine', () => {
 
     const decision: AssistantDecisionContext = {
       continuity: distillContinuityForDecision({ continuity: continuityCtx }),
-      source_health: { continuity: { ok: true } },
+      concept_mastery: null,
+      source_health: {
+        continuity: { ok: true },
+        concept_mastery: { ok: true },
+      },
     };
     const rendered = renderDecisionContract(decision);
 
@@ -132,7 +136,11 @@ describe('B0b-min — end-to-end spine', () => {
     });
     const decision: AssistantDecisionContext = {
       continuity: distillContinuityForDecision({ continuity: continuityCtx }),
-      source_health: { continuity: { ok: true } },
+      concept_mastery: null,
+      source_health: {
+        continuity: { ok: true },
+        concept_mastery: { ok: true },
+      },
     };
     expect(renderDecisionContract(decision)).toBe('');
   });
@@ -148,7 +156,11 @@ describe('B0b-min — end-to-end spine', () => {
     // pass a degraded shape directly.
     const decision: AssistantDecisionContext = {
       continuity: null,
-      source_health: { continuity: { ok: false, reason: 'supabase_unconfigured' } },
+      concept_mastery: null,
+      source_health: {
+        continuity: { ok: false, reason: 'supabase_unconfigured' },
+        concept_mastery: { ok: true },
+      },
     };
     const rendered = renderDecisionContract(decision);
     expect(rendered).toContain('continuity: source degraded');

--- a/services/gateway/test/orb/live/instruction/decision-contract-renderer.test.ts
+++ b/services/gateway/test/orb/live/instruction/decision-contract-renderer.test.ts
@@ -46,7 +46,11 @@ function emptyContinuity(): DecisionContinuity {
 function emptyContext(over: Partial<AssistantDecisionContext> = {}): AssistantDecisionContext {
   return {
     continuity: null,
-    source_health: { continuity: { ok: true } },
+    concept_mastery: null,
+    source_health: {
+      continuity: { ok: true },
+      concept_mastery: { ok: true },
+    },
     ...over,
   };
 }
@@ -96,7 +100,10 @@ describe('B0b-min — decision-contract-renderer', () => {
     it('emits a degraded hint when continuity is null AND source_health is degraded', () => {
       const out = renderDecisionContract(
         emptyContext({
-          source_health: { continuity: { ok: false, reason: 'supabase_unconfigured' } },
+          source_health: {
+            continuity: { ok: false, reason: 'supabase_unconfigured' },
+            concept_mastery: { ok: true },
+          },
         }),
       );
       expect(out).toContain('continuity: source degraded');
@@ -242,6 +249,219 @@ describe('B0b-min — decision-contract-renderer', () => {
       expect(out).not.toContain('2026-05-10T12:00:00Z');
       expect(out).not.toContain('sess-A');
       expect(out).not.toContain('user said this exact sentence');
+    });
+  });
+
+  // F2: concept-mastery rendering + degraded handling + raw-field ignorance.
+  describe('concept mastery (F2)', () => {
+    function emptyConcept() {
+      return {
+        concepts_explained: [] as any[],
+        concepts_mastered: [] as any[],
+        dyk_cards_seen: [] as any[],
+        counts: {
+          concepts_explained_total: 0,
+          concepts_mastered_total: 0,
+          dyk_cards_seen_total: 0,
+          concepts_explained_in_last_24h: 0,
+        },
+        recommended_cadence: 'none' as const,
+      };
+    }
+
+    it('returns empty string when both fields null and both sources healthy', () => {
+      expect(renderDecisionContract(emptyContext())).toBe('');
+    });
+
+    it('emits degraded hint when concept_mastery null AND source degraded', () => {
+      const out = renderDecisionContract(
+        emptyContext({
+          source_health: {
+            continuity: { ok: true },
+            concept_mastery: { ok: false, reason: 'supabase_unconfigured' },
+          },
+        }),
+      );
+      expect(out).toContain('concept_mastery: source degraded');
+      expect(out).toContain('supabase_unconfigured');
+    });
+
+    it('renders explained concepts with bucket + hint + recency', () => {
+      const out = renderDecisionContract(
+        emptyContext({
+          concept_mastery: {
+            ...emptyConcept(),
+            concepts_explained: [{
+              concept_key: 'vitana_index',
+              frequency: 'twice',
+              days_since_last_explained: 2,
+              repetition_hint: 'one_liner',
+            }],
+          },
+        }),
+      );
+      expect(out).toContain('Concept mastery:');
+      expect(out).toContain('Concepts explained:');
+      expect(out).toContain('vitana_index [twice, hint=one_liner] (2d ago)');
+    });
+
+    it('renders mastered concepts with bucketed confidence', () => {
+      const out = renderDecisionContract(
+        emptyContext({
+          concept_mastery: {
+            ...emptyConcept(),
+            concepts_mastered: [{
+              concept_key: 'life_compass',
+              confidence: 'high',
+            }],
+          },
+        }),
+      );
+      expect(out).toContain('Concepts mastered:');
+      expect(out).toContain('life_compass [confidence=high]');
+    });
+
+    it('renders DYK cards with bucket + recency', () => {
+      const out = renderDecisionContract(
+        emptyContext({
+          concept_mastery: {
+            ...emptyConcept(),
+            dyk_cards_seen: [{
+              card_key: 'dyk_index_intro',
+              frequency: 'once',
+              days_since_last_seen: 5,
+            }],
+          },
+        }),
+      );
+      expect(out).toContain('DYK cards seen:');
+      expect(out).toContain('dyk_index_intro [once] (5d ago)');
+    });
+
+    it('renders recommended_cadence when non-none', () => {
+      const out = renderDecisionContract(
+        emptyContext({
+          concept_mastery: {
+            ...emptyConcept(),
+            concepts_explained: [{
+              concept_key: 'x',
+              frequency: 'many',
+              days_since_last_explained: 1,
+              repetition_hint: 'skip',
+            }],
+            recommended_cadence: 'suppress_over_explained',
+          },
+        }),
+      );
+      expect(out).toContain('Recommended cadence: suppress_over_explained');
+    });
+
+    it('omits cadence line when "none"', () => {
+      const out = renderDecisionContract(
+        emptyContext({
+          concept_mastery: {
+            ...emptyConcept(),
+            concepts_explained: [{
+              concept_key: 'x',
+              frequency: 'once',
+              days_since_last_explained: null,
+              repetition_hint: 'one_liner',
+            }],
+            recommended_cadence: 'none',
+          },
+        }),
+      );
+      expect(out).not.toContain('Recommended cadence');
+    });
+
+    it('raw-field ignorance: smuggled raw fields are NOT in output', () => {
+      const sneakyConcept = {
+        concepts_explained: [{
+          concept_key: 'vitana_index',
+          frequency: 'once',
+          days_since_last_explained: 1,
+          repetition_hint: 'one_liner',
+          // smuggled raw fields:
+          last_explained_at: '2026-05-12T12:00:00Z',
+          count: 42,
+          raw_score: 0.851234,
+        }],
+        concepts_mastered: [{
+          concept_key: 'm',
+          confidence: 'medium',
+          // smuggled:
+          last_observed_at: '2026-05-11T08:00:00Z',
+          raw_confidence_float: 0.85,
+        }],
+        dyk_cards_seen: [{
+          card_key: 'd',
+          frequency: 'many',
+          days_since_last_seen: 3,
+          // smuggled:
+          last_seen_at: '2026-05-09T20:00:00Z',
+        }],
+        counts: {
+          concepts_explained_total: 1,
+          concepts_mastered_total: 1,
+          dyk_cards_seen_total: 1,
+          concepts_explained_in_last_24h: 0,
+        },
+        recommended_cadence: 'use_one_liner' as const,
+      };
+      const out = renderDecisionContract(
+        emptyContext({ concept_mastery: sneakyConcept as any }),
+      );
+      expect(out).not.toContain('2026-05-12T12:00:00Z');
+      expect(out).not.toContain('2026-05-11T08:00:00Z');
+      expect(out).not.toContain('2026-05-09T20:00:00Z');
+      expect(out).not.toContain('0.851234');
+      expect(out).not.toContain('0.85');
+      expect(out).not.toContain('42'); // raw count
+    });
+  });
+
+  describe('both sections coexist', () => {
+    it('renders continuity then concept_mastery, in that order', () => {
+      const out = renderDecisionContract(
+        emptyContext({
+          continuity: {
+            open_threads: [
+              { thread_id: 't1', topic: 'magnesium', summary: null, days_since_last_mention: 1 },
+            ],
+            promises_owed: [],
+            promises_kept_recently: [],
+            counts: {
+              open_threads_total: 1,
+              promises_owed_total: 0,
+              promises_overdue: 0,
+              threads_mentioned_today: 0,
+            },
+            recommended_follow_up: 'mention_open_thread',
+          },
+          concept_mastery: {
+            concepts_explained: [{
+              concept_key: 'vitana_index',
+              frequency: 'once',
+              days_since_last_explained: 2,
+              repetition_hint: 'one_liner',
+            }],
+            concepts_mastered: [],
+            dyk_cards_seen: [],
+            counts: {
+              concepts_explained_total: 1,
+              concepts_mastered_total: 0,
+              dyk_cards_seen_total: 0,
+              concepts_explained_in_last_24h: 0,
+            },
+            recommended_cadence: 'use_one_liner',
+          },
+        }),
+      );
+      const continuityIdx = out.indexOf('Continuity:');
+      const conceptIdx = out.indexOf('Concept mastery:');
+      expect(continuityIdx).toBeGreaterThan(-1);
+      expect(conceptIdx).toBeGreaterThan(-1);
+      expect(continuityIdx).toBeLessThan(conceptIdx);
     });
   });
 });


### PR DESCRIPTION
## Summary

Wires **B3 concept-mastery through the decision-contract spine** shipped in #2072. The instruction layer renders the typed contract; the compiler distills. Raw rows never cross the boundary.

## Path through the contract

```
compileConceptMasteryContext  (existing B3 read-only compiler, now on main)
  → distillConceptMasteryForDecision  (new adapter — strips raw fields, buckets numeric scores)
  → AssistantDecisionContext.concept_mastery  (new typed field on the existing contract)
  → renderDecisionContract  (extended renderer — same wall)
  → already appended to systemInstruction at orb-live.ts:9091 (no change needed)
```

## What changes

- `services/gateway/src/orb/context/types.ts` — adds `DecisionConceptMastery` (concepts_explained / concepts_mastered / dyk_cards_seen + counts + recommended_cadence). Adds `FrequencyBucket` (`none | once | twice | many`) and `MasteryConfidenceBucket` (`low | medium | high`) and `RepetitionHint` type aliases. **Forbidden raw fields are explicitly NOT declared**: `last_explained_at`, `last_observed_at`, `last_seen_at`, raw confidence floats, raw integer counts.
- `services/gateway/src/orb/context/providers/concept-mastery-decision-provider.ts` — pure adapter. Bucketing helpers exported for tests.
- `services/gateway/src/orb/context/compile-assistant-decision-context.ts` — orchestrator runs continuity + conceptMastery providers in **parallel** via `Promise.all`. Per-provider try/catch; one throwing doesn't block the other.
- `services/gateway/src/orb/live/instruction/decision-contract-renderer.ts` — adds `renderConceptMastery`. Same wall: reads only `AssistantDecisionContext`, no `services/`, no supabase, no fetch.

## Integration

**NO change to `orb-live.ts`**. The single call site at line 9091 already invokes `compileAssistantDecisionContext` + `renderDecisionContract` — extending the type contract and renderer is enough.

## Wall (non-negotiable)

- No raw concept rows / raw scores / raw transcripts / raw memory rows.
- Frequencies are **bucketed integers** (`none | once | twice | many`), never raw counts.
- Mastery confidence is a **bucketed enum** (`low | medium | high | unknown`), never the raw 0..1 float.
- Recency hints (`days_since_*`) are coarse enough to share; raw `last_*_at` timestamps stay out.
- Renderer accepts only `AssistantDecisionContext`. Source-level wall test asserts no `services/` / `supabase` / `fetch` imports.
- No R-lane touches.

## Tests (191 green, 13 suites — was 152 in spine PR)

- **decision-context-types.test.ts** — F2 type guards (forbidden fields not declared; `frequency` MUST be bucket type, `confidence` MUST be bucket type; `concept_mastery` health entry present)
- **concept-mastery-decision-provider.test.ts** — drops raw timestamps, drops raw confidence float, drops raw count; `bucketFrequency` + `bucketMasteryConfidence` boundaries; `pickRecommendedCadence` priority
- **compile-assistant-decision-context.test.ts** — rewritten for two-provider contract: happy path, per-provider throws (one fails, other keeps flowing), both providers null, exactly three top-level keys, parallel execution proof
- **decision-contract-renderer.test.ts** — concept-mastery section rendering, degraded hint, raw-field ignorance (smuggled `last_explained_at` / raw `0.851234` confidence / raw `42` count NOT in output), both sections coexist in order
- **spine-end-to-end.test.ts** — updated to the new shape; byte-for-byte same rendered prompt

## Production gate

The spine #2072 ORB smoke passed before F2 started:
- `/orb/chat` POST as authed user → HTTP 200 application/json, normal Gemini-2.5-pro reply ("Hello! I can help you manage your Autopilot tasks...")
- No regression on conversation handler
- Defensive integration (try/catch + identity guard) means F2 inherits the same safety

## Follow-up

After this lands + production smoke confirms /orb/chat still responds normally: **F3 (B4 journey-stage decision integration)** is unblocked, same narrow pattern. Per direction: stop for review before F3 wiring.

🤖 Generated with [Claude Code](https://claude.com/claude-code)