### PR TITLE
DEV-AUTOPILOT: Fix /health endpoint canary armed fault handling (VTID-02951)

### DIFF
--- a/services/gateway/src/routes/canary-target.ts
+++ b/services/gateway/src/routes/canary-target.ts
@@ -112,6 +112,14 @@ canaryTargetRouter.get('/health', async (_req: Request, res: Response, next: (er
     }
     return res.status(200).json({ ok: true, armed: false });
   } catch (err) {
+    if (err instanceof CanaryArmedFault) {
+      return res.status(200).json({
+        ok: true,
+        degraded: true,
+        fault_class: 'CANARY_ARMED',
+        remediation: 'Canary armed fault handled gracefully.'
+      });
+    }
     return next(err);
   }
 });

--- a/services/gateway/test/canary-target.test.ts
+++ b/services/gateway/test/canary-target.test.ts
@@ -89,11 +89,25 @@ describe('canary-target — armed fault (current behavior; SELF-HEALING REPAIR T
   // ADD a test below this `describe` block that asserts the degraded
   // shape after the repair is applied. The LLM should NOT remove this
   // describe block — it documents the pre-repair behavior.
-  it('armed → /health throws CanaryArmedFault (handled as 500 by Express)', async () => {
+  it.skip('armed → /health throws CanaryArmedFault (handled as 500 by Express)', async () => {
     mockSupabaseConfig(true);
     const res = await request(buildApp(freshRouter())).get('/api/v1/canary-target/health');
     expect(res.status).toBe(500);
     expect(res.body.name).toBe('CanaryArmedFault');
     expect(res.body.code).toBe('CANARY_ARMED');
+  });
+});
+
+describe('canary-target — armed fault (repaired behavior)', () => {
+  it('armed → /health catches CanaryArmedFault and returns 200 with degraded state', async () => {
+    mockSupabaseConfig(true);
+    const res = await request(buildApp(freshRouter())).get('/api/v1/canary-target/health');
+    expect(res.status).toBe(200);
+    expect(res.body).toEqual({
+      ok: true,
+      degraded: true,
+      fault_class: 'CANARY_ARMED',
+      remediation: 'Canary armed fault handled gracefully.'
+    });
   });
 });


### PR DESCRIPTION
Fixes an issue where the `/api/v1/canary-target/health` endpoint throws an unhandled `CanaryArmedFault` when the self-healing canary is armed, resulting in a 500 Internal Server Error.
The fault is now explicitly caught, allowing the endpoint to return a graceful degraded HTTP 200 JSON response rather than bubbling to Express's error handler.

**Changes:**
- `services/gateway/src/routes/canary-target.ts`: Update `catch` block to handle `CanaryArmedFault`.
- `services/gateway/test/canary-target.test.ts`: Add test case for the degraded response while marking the old failure case as `.skip` to preserve historical behavior documentation without failing CI.