### PR TITLE
fix(self-healing): close third terminal-write bypass — autopilot-controller (VTID-02952, PR-J)

### DIFF
--- a/services/gateway/src/services/autopilot-controller.ts
+++ b/services/gateway/src/services/autopilot-controller.ts
@@ -818,13 +818,94 @@ async function updateLedgerStatus(vtid: string, status: string): Promise<void> {
 /**
  * Update vtid_ledger to terminal state
  */
-async function updateLedgerTerminal(vtid: string, outcome: 'success' | 'failed'): Promise<void> {
+export async function updateLedgerTerminal(vtid: string, outcome: 'success' | 'failed'): Promise<void> {
   const supabaseUrl = process.env.SUPABASE_URL;
   const supabaseKey = process.env.SUPABASE_SERVICE_ROLE;
 
   if (!supabaseUrl || !supabaseKey) {
     console.warn(`[VTID-01178] Cannot update ledger terminal: missing Supabase credentials`);
     return;
+  }
+
+  // PR-J (VTID-02952): self-healing terminal-write gate.
+  // The autopilot run state machine's `verification_passed` step fires
+  // on `/api/v1/autopilot/controller/runs/:vtid/verify`, which uses a
+  // generic /alive probe — NOT the actual self-healed endpoint. For
+  // self-healing VTIDs the only authorized writer of terminal_outcome
+  // is the self-healing reconciler, AFTER dev_autopilot_executions
+  // reaches status='completed' (CI green + merge + EXEC-DEPLOY + live
+  // probe). PR-E gated the worker-runner's /api/v1/oasis/vtid/terminalize
+  // path. PR-J closes the third bypass: this function, called by
+  // markCompleted/markFailed in this controller. Without this gate,
+  // autopilot can mark a self-healing VTID 'success' before its repair
+  // PR has even been opened (observed live on VTID-02951 at 00:40:39
+  // when dev_autopilot_executions.status was still 'running').
+  if (outcome === 'success') {
+    try {
+      const ledgerResp = await fetch(
+        `${supabaseUrl}/rest/v1/vtid_ledger?vtid=eq.${encodeURIComponent(vtid)}&select=metadata&limit=1`,
+        {
+          headers: {
+            'Content-Type': 'application/json',
+            apikey: supabaseKey,
+            Authorization: `Bearer ${supabaseKey}`,
+          },
+        },
+      );
+      if (ledgerResp.ok) {
+        const rows = (await ledgerResp.json()) as Array<{ metadata?: Record<string, unknown> | null }>;
+        const metadata = rows[0]?.metadata || {};
+        if (metadata.source === 'self-healing') {
+          const execId =
+            typeof metadata.autopilot_execution_id === 'string'
+              ? metadata.autopilot_execution_id
+              : null;
+          let execStatus: string = 'missing';
+          if (execId) {
+            const execResp = await fetch(
+              `${supabaseUrl}/rest/v1/dev_autopilot_executions?id=eq.${encodeURIComponent(execId)}&select=status&limit=1`,
+              {
+                headers: {
+                  apikey: supabaseKey,
+                  Authorization: `Bearer ${supabaseKey}`,
+                },
+              },
+            );
+            if (execResp.ok) {
+              const execRows = (await execResp.json()) as Array<{ status: string }>;
+              execStatus = execRows[0]?.status || 'missing';
+            }
+          }
+          if (execStatus !== 'completed') {
+            console.warn(
+              `[VTID-01178] BLOCKED (PR-J/VTID-02952): refusing to write terminal_outcome='success' for self-healing VTID ${vtid} via autopilot-controller — execution status='${execStatus}', need 'completed'. Reconciler is the only authorized writer.`,
+            );
+            try {
+              await emitOasisEvent({
+                vtid,
+                type: 'self-healing.terminalize.blocked',
+                source: 'autopilot-controller',
+                status: 'warning',
+                message: `Refusing terminal_outcome='success' for ${vtid} via autopilot-controller.updateLedgerTerminal: execution status='${execStatus}', not 'completed'`,
+                payload: {
+                  vtid,
+                  outcome,
+                  caller: 'autopilot-controller.updateLedgerTerminal',
+                  reason: execId ? 'autopilot_not_completed' : 'missing_autopilot_execution_id',
+                  autopilot_execution_id: execId,
+                  autopilot_status: execStatus,
+                  blocked_at: new Date().toISOString(),
+                  governance_vtid: 'VTID-02952',
+                },
+              });
+            } catch { /* non-fatal */ }
+            return;
+          }
+        }
+      }
+    } catch (gateErr) {
+      console.warn(`[VTID-01178] PR-J gate check failed for ${vtid} (allowing through): ${gateErr}`);
+    }
   }
 
   const timestamp = new Date().toISOString();

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -598,6 +598,13 @@ export type CicdEventType =
   | 'self-healing.execution.bridge_failed'
   | 'self-healing.execution.deferred'
   | 'self-healing.execution.failed'
+  // PR-J (VTID-02952): close the third terminal-write bypass.
+  // Emitted by autopilot-controller.updateLedgerTerminal when it
+  // refuses to mark a self-healing VTID success because the linked
+  // dev_autopilot_executions row has not reached status='completed'.
+  // (vtid-terminalize.ts emits the same topic via a local fetch helper,
+  // so it didn't need the type-system entry.)
+  | 'self-healing.terminalize.blocked'
   | 'self-healing.completed'
   | 'self-healing.snapshot.pre_fix'
   | 'self-healing.snapshot.post_fix'

--- a/services/gateway/test/autopilot-controller-self-healing-gate.test.ts
+++ b/services/gateway/test/autopilot-controller-self-healing-gate.test.ts
@@ -1,0 +1,221 @@
+/**
+ * PR-J (VTID-02952): autopilot-controller terminal-write gate.
+ *
+ * The autopilot run state machine in `autopilot-controller.ts` has its
+ * own `markCompleted` path that calls `updateLedgerTerminal` to PATCH
+ * `vtid_ledger.terminal_outcome='success'` directly — independently
+ * from the `/api/v1/oasis/vtid/terminalize` endpoint (PR-E gate). Its
+ * verification trigger fires from `/api/v1/autopilot/controller/runs/
+ * :vtid/verify`, which uses a generic /alive probe — NOT the actual
+ * self-healed endpoint. So for self-healing VTIDs the controller can
+ * mark them success while their repair PR is still in CI, has not
+ * merged, and the actual healed endpoint has not been verified.
+ *
+ * Observed live on VTID-02951 at 00:40:39 UTC 2026-05-13:
+ *   - dev_autopilot_executions.status='running' (Cloud Run Job mid-flight)
+ *   - PR not yet opened (pr_url=null)
+ *   - /health still returning 500 (canary armed)
+ *   - vtid_ledger.terminal_outcome flipped to 'success' anyway
+ *
+ * PR-J adds the same gate as PR-E: refuse to write 'success' for any
+ * self-healing VTID unless its linked dev_autopilot_executions row has
+ * reached status='completed'. Failed terminations and non-self-healing
+ * VTIDs go through unchanged.
+ */
+
+import { updateLedgerTerminal } from '../src/services/autopilot-controller';
+
+const ORIGINAL_FETCH = global.fetch;
+
+interface MockState {
+  ledgerMetadata: Record<string, unknown> | null;
+  executionStatus: string | 'missing' | null;
+  patches: any[];
+  blockedEvents: any[];
+}
+
+function mockFetch(state: MockState) {
+  global.fetch = jest.fn().mockImplementation(async (url: string, init?: any) => {
+    // SELECT vtid_ledger.metadata for the gate's source check
+    if (url.includes('/rest/v1/vtid_ledger') && url.includes('select=metadata')) {
+      return {
+        ok: true,
+        status: 200,
+        json: () =>
+          Promise.resolve(
+            state.ledgerMetadata !== null ? [{ metadata: state.ledgerMetadata }] : [],
+          ),
+      };
+    }
+    // SELECT dev_autopilot_executions for the gate's status check
+    if (url.includes('/rest/v1/dev_autopilot_executions?id=eq.')) {
+      if (state.executionStatus === 'missing' || state.executionStatus === null) {
+        return { ok: true, status: 200, json: () => Promise.resolve([]) };
+      }
+      return {
+        ok: true,
+        status: 200,
+        json: () => Promise.resolve([{ status: state.executionStatus }]),
+      };
+    }
+    // PATCH vtid_ledger — this is what we're gating against
+    if (url.includes('/rest/v1/vtid_ledger') && init?.method === 'PATCH') {
+      state.patches.push({ url, body: JSON.parse(init.body) });
+      return { ok: true, status: 200, json: () => Promise.resolve([]) };
+    }
+    // POST oasis_events — capture only the blocked-by-gate events
+    if (url.includes('/rest/v1/oasis_events') && init?.method === 'POST') {
+      try {
+        const body = JSON.parse(init.body);
+        if (body?.topic === 'self-healing.terminalize.blocked') {
+          state.blockedEvents.push(body);
+        }
+      } catch { /* ignore */ }
+      return { ok: true, status: 200, json: () => Promise.resolve({}) };
+    }
+    return { ok: true, status: 200, json: () => Promise.resolve({}), text: () => Promise.resolve('') };
+  }) as unknown as typeof fetch;
+}
+
+beforeEach(() => {
+  process.env.SUPABASE_URL = 'https://supabase.test';
+  process.env.SUPABASE_SERVICE_ROLE = 'svc-role';
+});
+
+afterEach(() => {
+  global.fetch = ORIGINAL_FETCH;
+});
+
+describe('autopilot-controller updateLedgerTerminal — PR-J self-healing gate', () => {
+  it('BLOCKS success for self-healing VTID when execution.status="running"', async () => {
+    const state: MockState = {
+      ledgerMetadata: { source: 'self-healing', autopilot_execution_id: 'exec-uuid-running' },
+      executionStatus: 'running',
+      patches: [],
+      blockedEvents: [],
+    };
+    mockFetch(state);
+
+    await updateLedgerTerminal('VTID-02951', 'success');
+
+    expect(state.patches).toEqual([]);
+    expect(state.blockedEvents).toHaveLength(1);
+    expect(state.blockedEvents[0].metadata.reason).toBe('autopilot_not_completed');
+    expect(state.blockedEvents[0].metadata.autopilot_status).toBe('running');
+    expect(state.blockedEvents[0].metadata.governance_vtid).toBe('VTID-02952');
+  });
+
+  it('BLOCKS success for self-healing VTID when execution.status="ci" (PR open, CI running)', async () => {
+    const state: MockState = {
+      ledgerMetadata: { source: 'self-healing', autopilot_execution_id: 'exec-uuid-ci' },
+      executionStatus: 'ci',
+      patches: [],
+      blockedEvents: [],
+    };
+    mockFetch(state);
+
+    await updateLedgerTerminal('VTID-02951', 'success');
+
+    expect(state.patches).toEqual([]);
+    expect(state.blockedEvents).toHaveLength(1);
+    expect(state.blockedEvents[0].metadata.autopilot_status).toBe('ci');
+  });
+
+  it('BLOCKS success for self-healing VTID when autopilot_execution_id is missing from metadata', async () => {
+    const state: MockState = {
+      ledgerMetadata: { source: 'self-healing' /* no autopilot_execution_id */ },
+      executionStatus: null,
+      patches: [],
+      blockedEvents: [],
+    };
+    mockFetch(state);
+
+    await updateLedgerTerminal('VTID-02951', 'success');
+
+    expect(state.patches).toEqual([]);
+    expect(state.blockedEvents).toHaveLength(1);
+    expect(state.blockedEvents[0].metadata.reason).toBe('missing_autopilot_execution_id');
+  });
+
+  it('BLOCKS success for self-healing VTID when linked execution row is gone', async () => {
+    const state: MockState = {
+      ledgerMetadata: { source: 'self-healing', autopilot_execution_id: 'exec-deleted' },
+      executionStatus: 'missing',
+      patches: [],
+      blockedEvents: [],
+    };
+    mockFetch(state);
+
+    await updateLedgerTerminal('VTID-02951', 'success');
+
+    expect(state.patches).toEqual([]);
+    expect(state.blockedEvents).toHaveLength(1);
+    expect(state.blockedEvents[0].metadata.reason).toBe('autopilot_not_completed');
+    expect(state.blockedEvents[0].metadata.autopilot_status).toBe('missing');
+  });
+
+  it('ALLOWS success for self-healing VTID when execution.status="completed"', async () => {
+    const state: MockState = {
+      ledgerMetadata: { source: 'self-healing', autopilot_execution_id: 'exec-uuid-done' },
+      executionStatus: 'completed',
+      patches: [],
+      blockedEvents: [],
+    };
+    mockFetch(state);
+
+    await updateLedgerTerminal('VTID-02951', 'success');
+
+    expect(state.patches).toHaveLength(1);
+    expect(state.patches[0].body.terminal_outcome).toBe('success');
+    expect(state.patches[0].body.is_terminal).toBe(true);
+    expect(state.blockedEvents).toEqual([]);
+  });
+
+  it('ALLOWS success for non-self-healing VTID regardless of execution state', async () => {
+    const state: MockState = {
+      ledgerMetadata: { source: 'autopilot-recommendation' /* not self-healing */ },
+      executionStatus: 'running',
+      patches: [],
+      blockedEvents: [],
+    };
+    mockFetch(state);
+
+    await updateLedgerTerminal('VTID-02000', 'success');
+
+    expect(state.patches).toHaveLength(1);
+    expect(state.patches[0].body.terminal_outcome).toBe('success');
+    expect(state.blockedEvents).toEqual([]);
+  });
+
+  it('ALLOWS success for VTID with no metadata at all (legacy autopilot run)', async () => {
+    const state: MockState = {
+      ledgerMetadata: {},
+      executionStatus: null,
+      patches: [],
+      blockedEvents: [],
+    };
+    mockFetch(state);
+
+    await updateLedgerTerminal('VTID-01999', 'success');
+
+    expect(state.patches).toHaveLength(1);
+    expect(state.patches[0].body.terminal_outcome).toBe('success');
+  });
+
+  it('ALLOWS failed termination for self-healing VTID without checking execution (failure path is not gated)', async () => {
+    const state: MockState = {
+      ledgerMetadata: { source: 'self-healing', autopilot_execution_id: 'exec-uuid-running' },
+      executionStatus: 'running',
+      patches: [],
+      blockedEvents: [],
+    };
+    mockFetch(state);
+
+    await updateLedgerTerminal('VTID-02951', 'failed');
+
+    expect(state.patches).toHaveLength(1);
+    expect(state.patches[0].body.terminal_outcome).toBe('failed');
+    expect(state.patches[0].body.status).toBe('rejected');
+    expect(state.blockedEvents).toEqual([]);
+  });
+});


### PR DESCRIPTION
## Summary

Smoke testing PR-I (canary redesign) surfaced that the self-healing terminal-success contract still has a hole. There are **three writers** to `vtid_ledger.terminal_outcome`:

1. `POST /api/v1/oasis/vtid/terminalize` — gated in PR-E (vtid-terminalize.ts) ✅
2. `self-healing-reconciler.ts` — gated by `exec.status === 'completed'` ✅
3. `autopilot-controller.ts updateLedgerTerminal()` — **UNGATED** ❌

The autopilot run state machine in `autopilot-controller.ts` has its own `markCompleted` path that PATCHes `vtid_ledger.terminal_outcome='success'` directly. Its verification trigger fires from the legacy `/api/v1/autopilot/controller/runs/:vtid/verify` endpoint, which uses a generic `/alive` probe — not the actual self-healed endpoint.

**Observed live on VTID-02951 at 00:40:39 UTC 2026-05-13:**
- `dev_autopilot_executions.status='running'` (Cloud Run Job mid-flight)
- PR not yet opened (`pr_url=null`)
- `/health` still returning 500 (canary still armed)
- `vtid_ledger.terminal_outcome` flipped to `'success'` anyway

This was a false positive — the contract was supposed to make this impossible. PR-J closes it.

## What changed

- `autopilot-controller.ts updateLedgerTerminal()` now refuses `outcome='success'` for any VTID with `metadata.source='self-healing'` unless its linked `dev_autopilot_executions[id].status === 'completed'`.
- Emits `self-healing.terminalize.blocked` OASIS event with `governance_vtid='VTID-02952'` so the block is observable in the same query that already surfaces PR-E blocks.
- Failed terminations and non-self-healing VTIDs go through unchanged.
- Gate-check errors fail open (matches the existing silent-failure pattern in this function — better than blocking legitimate writes if Supabase momentarily errors).
- `updateLedgerTerminal` is now exported so the unit test can target it directly without the heavyweight `markCompleted` setup (active-runs map + spec snapshots).

## Test plan

- [x] `test/autopilot-controller-self-healing-gate.test.ts` — 8/8 (blocks for running/ci/missing_id/missing_row, allows for completed/non-self-healing/legacy/failed)
- [x] Full self-healing regression: 86/86 across 10 suites
- [x] `npm run build` clean (only pre-existing unrelated `sharp` error)
- [ ] After merge + EXEC-DEPLOY: re-arm canary, confirm `terminal_outcome` is no longer written before `dev_autopilot_executions.status='completed'`. The reconciler is now the only writer of self-healing success.

## Why ship this even though PR #2076 (the canary repair) is mid-flight

The substance of the green path is already proven by PR #2076 — diagnosis correctly identified `canary-target.ts`, the autopilot bridge dispatched, and the LLM produced a textbook narrow repair (`if (err instanceof CanaryArmedFault)` + exact degraded shape, used `it.skip` on the pre-repair test and added a new describe block for the repaired behavior). What's NOT yet safe is the contract — Layer 2 had a bypass. PR-J makes the contract actually safe.

🤖 Generated with [Claude Code](https://claude.com/claude-code)