### PR TITLE
feat(orb): F3 - B4 journey stage decision integration (VTID-02954)

### DIFF
--- a/services/gateway/src/orb/context/compile-assistant-decision-context.ts
+++ b/services/gateway/src/orb/context/compile-assistant-decision-context.ts
@@ -1,6 +1,7 @@
 /**
  * VTID-02941 (B0b-min) — compileAssistantDecisionContext.
  * VTID-02950 (F2)     — adds conceptMastery provider.
+ * VTID-02954 (F3)     — adds journeyStage provider.
  *
  * The orchestrator. Calls each registered provider, collects their
  * distilled output, and produces ONE `AssistantDecisionContext` the
@@ -21,16 +22,22 @@ import { defaultContinuityFetcher } from '../../services/continuity/continuity-f
 import { compileContinuityContext } from '../../services/continuity/compile-continuity-context';
 import { defaultConceptMasteryFetcher } from '../../services/concept-mastery/concept-mastery-fetcher';
 import { compileConceptMasteryContext } from '../../services/concept-mastery/compile-concept-mastery-context';
+import { defaultJourneyStageFetcher } from '../../services/journey-stage/journey-stage-fetcher';
+import { compileJourneyStageContext } from '../../services/journey-stage/compile-journey-stage-context';
 import {
   distillContinuityForDecision,
 } from './providers/continuity-decision-provider';
 import {
   distillConceptMasteryForDecision,
 } from './providers/concept-mastery-decision-provider';
+import {
+  distillJourneyStageForDecision,
+} from './providers/journey-stage-decision-provider';
 import type {
   AssistantDecisionContext,
   DecisionConceptMastery,
   DecisionContinuity,
+  DecisionJourneyStage,
 } from './types';
 
 export interface CompileAssistantDecisionContextInputs {
@@ -45,29 +52,37 @@ export interface CompileAssistantDecisionContextInputs {
   providers?: Partial<{
     continuity: () => Promise<DecisionContinuity | null>;
     conceptMastery: () => Promise<DecisionConceptMastery | null>;
+    journeyStage: () => Promise<DecisionJourneyStage | null>;
   }>;
   /**
    * Source-health reporter override for tests — when the provider
    * returns null, this lets a test stub a reason without monkey-patching
    * the default fetcher.
    */
-  reasons?: Partial<{ continuity: string; conceptMastery: string }>;
+  reasons?: Partial<{
+    continuity: string;
+    conceptMastery: string;
+    journeyStage: string;
+  }>;
 }
 
 export async function compileAssistantDecisionContext(
   input: CompileAssistantDecisionContextInputs,
 ): Promise<AssistantDecisionContext> {
-  const [continuityRun, conceptMasteryRun] = await Promise.all([
+  const [continuityRun, conceptMasteryRun, journeyStageRun] = await Promise.all([
     runContinuityProvider(input),
     runConceptMasteryProvider(input),
+    runJourneyStageProvider(input),
   ]);
 
   return {
     continuity: continuityRun.value,
     concept_mastery: conceptMasteryRun.value,
+    journey_stage: journeyStageRun.value,
     source_health: {
       continuity: continuityRun.health,
       concept_mastery: conceptMasteryRun.health,
+      journey_stage: journeyStageRun.health,
     },
   };
 }
@@ -168,6 +183,63 @@ async function runConceptMasteryProvider(
     return { value: decisionView, health: { ok: true } };
   } catch (e) {
     const reason = input.reasons?.conceptMastery ?? (e as Error).message;
+    return { value: null, health: { ok: false, reason } };
+  }
+}
+
+async function runJourneyStageProvider(
+  input: CompileAssistantDecisionContextInputs,
+): Promise<ProviderRun<DecisionJourneyStage>> {
+  const override = input.providers?.journeyStage;
+  if (override) {
+    try {
+      const value = await override();
+      return { value, health: { ok: true } };
+    } catch (e) {
+      return {
+        value: null,
+        health: { ok: false, reason: (e as Error).message },
+      };
+    }
+  }
+
+  try {
+    // B4's fetcher exposes three separate read methods. Run them in
+    // parallel and feed the results into the compiler; degraded
+    // sub-sources still produce a partial-but-typed context.
+    const [appUserResult, activeDaysResult, indexHistoryResult] = await Promise.all([
+      defaultJourneyStageFetcher.fetchAppUser({ userId: input.userId }),
+      defaultJourneyStageFetcher.fetchUserActiveDaysAggregate({ userId: input.userId }),
+      defaultJourneyStageFetcher.fetchVitanaIndexHistory({
+        tenantId: input.tenantId,
+        userId: input.userId,
+        limit: 60,
+      }),
+    ]);
+
+    // If ALL three fetches failed, treat the source as degraded. If
+    // any succeeded, the compiler builds a partial-but-typed view.
+    const anyOk = appUserResult.ok || activeDaysResult.ok || indexHistoryResult.ok;
+    if (!anyOk) {
+      const reason =
+        appUserResult.reason ||
+        activeDaysResult.reason ||
+        indexHistoryResult.reason ||
+        'journey_stage_unavailable';
+      return { value: null, health: { ok: false, reason } };
+    }
+
+    const journeyStage = compileJourneyStageContext({
+      appUserResult,
+      activeDaysResult,
+      indexHistoryResult,
+      nowMs: input.nowMs,
+    });
+
+    const decisionView = distillJourneyStageForDecision({ journeyStage });
+    return { value: decisionView, health: { ok: true } };
+  } catch (e) {
+    const reason = input.reasons?.journeyStage ?? (e as Error).message;
     return { value: null, health: { ok: false, reason } };
   }
 }

--- a/services/gateway/src/orb/context/providers/journey-stage-decision-provider.ts
+++ b/services/gateway/src/orb/context/providers/journey-stage-decision-provider.ts
@@ -1,0 +1,200 @@
+/**
+ * VTID-02954 (F3) — JourneyStage → AssistantDecisionContext adapter.
+ *
+ * The B4 read-only inspection slice already produced
+ * `JourneyStageContext`, a richer shape designed for the Command Hub
+ * operator. The assistant decision layer reads a NARROWER shape
+ * (`DecisionJourneyStage`) that strips:
+ *   - raw tenure_days integer (kept as tenure_bucket enum)
+ *   - raw last_active_date ISO string (kept as activity_recency enum)
+ *   - raw usage_days_count integer (kept as usage_volume enum)
+ *   - raw vitana_index.score_total 0..999 (kept as tier enum only)
+ *   - raw tier_days_held integer (kept as tier_tenure enum)
+ *
+ * Kept: bucketed forms of all of the above, plus the
+ * ExplanationDepthHint pre-derived by B4's compiler and a new
+ * stage-aware tone hint.
+ *
+ * Pure function. No IO. The caller is responsible for invoking the
+ * journey-stage compiler + passing its output here.
+ */
+
+import type { JourneyStageContext } from '../../../services/journey-stage/types';
+import type {
+  ActivityRecencyBucket,
+  DecisionJourneyStage,
+  JourneyConfidenceBucket,
+  JourneyStageWarning,
+  StageToneHint,
+  TenureBucket,
+  TierTenureBucket,
+  UsageVolumeBucket,
+  VitanaIndexTierBucket,
+} from '../types';
+
+export interface DistillJourneyStageInputs {
+  /**
+   * Output of `compileJourneyStageContext` from B4. Read-only.
+   */
+  journeyStage: JourneyStageContext;
+}
+
+/**
+ * Distills `JourneyStageContext` into the decision-grade
+ * `DecisionJourneyStage`.
+ *
+ * Always returns a typed shape (never undefined). The caller decides
+ * whether to attach it to `AssistantDecisionContext.journey_stage` or
+ * set the field to `null` based on source health.
+ */
+export function distillJourneyStageForDecision(
+  input: DistillJourneyStageInputs,
+): DecisionJourneyStage {
+  const { journeyStage } = input;
+
+  const stage: TenureBucket = journeyStage.onboarding_stage;
+  const explanation_depth = journeyStage.explanation_depth_hint;
+  const tone_hint = toneFromStage(stage);
+
+  const vitana_index_tier: VitanaIndexTierBucket = journeyStage.vitana_index.tier;
+  const tier_tenure = bucketTierTenure(journeyStage.vitana_index.tier_days_held);
+  const activity_recency = bucketActivityRecency(journeyStage.days_since_last_active);
+  const usage_volume = bucketUsageVolume(journeyStage.usage_days_count);
+
+  const journey_confidence = computeJourneyConfidence(journeyStage);
+  const warnings = computeWarnings(journeyStage);
+
+  return {
+    stage,
+    tenure_bucket: stage,
+    explanation_depth,
+    tone_hint,
+    vitana_index_tier,
+    tier_tenure,
+    activity_recency,
+    usage_volume,
+    journey_confidence,
+    warnings,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — exported for tests
+// ---------------------------------------------------------------------------
+
+/**
+ * Maps the 5-step onboarding ladder to a coarse tone hint. Derived
+ * purely from `stage` — never reads user content.
+ */
+export function toneFromStage(stage: TenureBucket): StageToneHint {
+  switch (stage) {
+    case 'first_session':
+      return 'warm_welcoming';
+    case 'first_days':
+      return 'guiding';
+    case 'first_week':
+    case 'first_month':
+      return 'collaborative';
+    case 'established':
+      return 'concise_familiar';
+  }
+}
+
+/**
+ * Buckets time-held-in-current-tier into a coarse band.
+ *   0..6    → new
+ *   7..29   → settled
+ *   30+     → long_standing
+ *   null    → unknown
+ */
+export function bucketTierTenure(
+  daysHeld: number | null,
+): TierTenureBucket {
+  if (daysHeld === null || !Number.isFinite(daysHeld)) return 'unknown';
+  if (daysHeld < 7) return 'new';
+  if (daysHeld < 30) return 'settled';
+  return 'long_standing';
+}
+
+/**
+ * Buckets activity recency (days since last active).
+ *   0..1    → today
+ *   2..7    → recent
+ *   8+      → lapsed
+ *   null    → unknown
+ */
+export function bucketActivityRecency(
+  daysSince: number | null,
+): ActivityRecencyBucket {
+  if (daysSince === null || !Number.isFinite(daysSince)) return 'unknown';
+  if (daysSince <= 1) return 'today';
+  if (daysSince <= 7) return 'recent';
+  return 'lapsed';
+}
+
+/**
+ * Buckets total usage volume (distinct active days).
+ *   0      → none
+ *   1..7   → light
+ *   8..30  → regular
+ *   31+    → heavy
+ */
+export function bucketUsageVolume(count: number): UsageVolumeBucket {
+  if (!Number.isFinite(count) || count <= 0) return 'none';
+  if (count <= 7) return 'light';
+  if (count <= 30) return 'regular';
+  return 'heavy';
+}
+
+/**
+ * Computes coarse confidence in the journey-stage signal based on
+ * which underlying sources reported `ok:true` AND had data.
+ *
+ *   high   — app_users ok AND (active_days ok OR vitana_index ok with data)
+ *   medium — app_users ok but no other supporting data
+ *   low    — app_users not ok, OR tenure_days is null
+ */
+export function computeJourneyConfidence(
+  ctx: JourneyStageContext,
+): JourneyConfidenceBucket {
+  const appUsersOk = ctx.source_health.app_users.ok;
+  const activeDaysOk = ctx.source_health.user_active_days.ok;
+  const indexOk = ctx.source_health.vitana_index_scores.ok;
+
+  if (!appUsersOk || ctx.tenure_days === null) return 'low';
+
+  const supporting =
+    (activeDaysOk && ctx.usage_days_count > 0) ||
+    (indexOk && ctx.vitana_index.tier !== 'unknown');
+
+  return supporting ? 'high' : 'medium';
+}
+
+/**
+ * Computes the enum-only warning list. NEVER free-text strings,
+ * NEVER raw timestamps, NEVER raw history.
+ */
+export function computeWarnings(
+  ctx: JourneyStageContext,
+): ReadonlyArray<JourneyStageWarning> {
+  const out: JourneyStageWarning[] = [];
+
+  if (ctx.tenure_days === null) {
+    out.push('no_tenure_data');
+  }
+
+  // long_inactivity: derive from days_since_last_active bucket.
+  if (
+    ctx.days_since_last_active !== null &&
+    Number.isFinite(ctx.days_since_last_active) &&
+    ctx.days_since_last_active > 7
+  ) {
+    out.push('long_inactivity');
+  }
+
+  if (ctx.vitana_index.tier === 'unknown') {
+    out.push('unknown_tier');
+  }
+
+  return out;
+}

--- a/services/gateway/src/orb/context/types.ts
+++ b/services/gateway/src/orb/context/types.ts
@@ -1,18 +1,20 @@
 /**
  * VTID-02941 (B0b-min) — AssistantDecisionContext: the decision contract.
  * VTID-02950 (F2)     — adds conceptMastery field.
+ * VTID-02954 (F3)     — adds journeyStage field.
  *
  * This is the SINGLE typed shape the instruction layer reads to assemble
  * a prompt. Raw rows (memory, threads, messages, promises, profiles,
- * concept rows, scores, transcripts) MUST NOT cross this boundary. The
- * compiler distills; the renderer formats. No exceptions.
+ * concept rows, scores, transcripts, journey rows, route history,
+ * behavioral history) MUST NOT cross this boundary. The compiler
+ * distills; the renderer formats. No exceptions.
  *
  * Wall:
  *   - Forbidden: match journey, feature discovery, wake brief,
- *     continuation contract, greeting decay rewrite, journey stage
- *     modulation, reliability tuning. Each gets its own slice.
- *   - Continuity (B2) + conceptMastery (B3) are wired through this
- *     contract.
+ *     continuation contract, greeting decay rewrite, reliability tuning.
+ *     Each gets its own slice.
+ *   - Continuity (B2) + conceptMastery (B3) + journeyStage (B4) are
+ *     wired through this contract.
  *   - Adding new fields later is fine; pushing raw rows into them is not.
  */
 
@@ -145,6 +147,120 @@ export interface DecisionConceptMastery {
 }
 
 /**
+ * Coarse explanation-depth hint that the decision layer reads. Same
+ * enum as B4's compiler — re-declared here so the decision-contract
+ * type surface stays self-contained (no imports from `services/`).
+ */
+export type ExplanationDepthHint = 'deep' | 'standard' | 'terse';
+
+/**
+ * Tenure bucket — coarse onboarding stage. Identical to B4's
+ * OnboardingStage; re-aliased here so the decision-contract type
+ * surface stays self-contained.
+ */
+export type TenureBucket =
+  | 'first_session'
+  | 'first_days'
+  | 'first_week'
+  | 'first_month'
+  | 'established';
+
+/**
+ * Vitana Index tier bucket. Replaces the raw 0..999 score — the LLM
+ * never sees the underlying number.
+ */
+export type VitanaIndexTierBucket =
+  | 'foundation'
+  | 'building'
+  | 'momentum'
+  | 'resonance'
+  | 'flourishing'
+  | 'unknown';
+
+/**
+ * Bucketed time held in current Index tier. Replaces the raw day
+ * count.
+ */
+export type TierTenureBucket = 'new' | 'settled' | 'long_standing' | 'unknown';
+
+/**
+ * Bucketed recency of the user's last authenticated activity.
+ * Replaces the raw `last_active_date` ISO string.
+ */
+export type ActivityRecencyBucket = 'today' | 'recent' | 'lapsed' | 'unknown';
+
+/**
+ * Bucketed total usage-days volume. Replaces the raw `usage_days_count`
+ * integer.
+ */
+export type UsageVolumeBucket = 'none' | 'light' | 'regular' | 'heavy';
+
+/**
+ * Coarse confidence in the journey-stage signal. Driven by how many
+ * underlying sources reported `ok:true` AND had data.
+ */
+export type JourneyConfidenceBucket = 'low' | 'medium' | 'high';
+
+/**
+ * Stage-aware tone hint the decision layer can read. Derived purely
+ * from tenure_bucket.
+ */
+export type StageToneHint =
+  | 'warm_welcoming'   // first_session
+  | 'guiding'          // first_days
+  | 'collaborative'    // first_week + first_month
+  | 'concise_familiar'; // established
+
+/**
+ * Allowed warnings on the journey-stage signal. Enums only — NEVER
+ * free-text strings, NEVER raw timestamps, NEVER raw history.
+ */
+export type JourneyStageWarning =
+  | 'no_tenure_data'
+  | 'long_inactivity'
+  | 'unknown_tier';
+
+/**
+ * Distilled journey-stage view. Mirrors `JourneyStageContext` from
+ * `services/journey-stage/types.ts` but strips:
+ *   - raw tenure_days integer (kept as tenure_bucket enum)
+ *   - raw last_active_date ISO string (kept as activity_recency enum)
+ *   - raw usage_days_count integer (kept as usage_volume enum)
+ *   - raw vitana_index.score_total (kept as tier enum only)
+ *   - raw tier_days_held integer (kept as tier_tenure enum)
+ *
+ * Kept: bucketed forms of everything above + the existing
+ * ExplanationDepthHint + a derived stage-aware tone hint.
+ */
+export interface DecisionJourneyStage {
+  /** 5-step onboarding ladder. Same enum as B4's compiler. */
+  stage: TenureBucket;
+  /** Bucketed tenure — alias of `stage` for clarity. */
+  tenure_bucket: TenureBucket;
+  /**
+   * Coarse depth hint already derived by B4's compiler:
+   *   first_session + first_days → 'deep'
+   *   first_week + first_month    → 'standard'
+   *   established                  → 'terse'
+   */
+  explanation_depth: ExplanationDepthHint;
+  /** Stage-aware tone hint. Derived purely from `stage`. */
+  tone_hint: StageToneHint;
+  /** Bucketed Vitana Index tier. NEVER the raw 0..999 score. */
+  vitana_index_tier: VitanaIndexTierBucket;
+  /** Bucketed time held in current tier. NEVER the raw day count. */
+  tier_tenure: TierTenureBucket;
+  /** Bucketed recency. NEVER a raw timestamp. */
+  activity_recency: ActivityRecencyBucket;
+  /** Bucketed usage volume. NEVER the raw integer. */
+  usage_volume: UsageVolumeBucket;
+  /** Coarse confidence the LLM can use to weight the signal. */
+  journey_confidence: JourneyConfidenceBucket;
+  /** Warnings as enums. NEVER free-text. */
+  warnings: ReadonlyArray<JourneyStageWarning>;
+}
+
+/**
  * Per-source health view. Empty/missing rows are not failures — they
  * just mean the user has no state yet. Failures (Supabase down, schema
  * mismatch, etc.) surface here with a `reason`.
@@ -153,6 +269,8 @@ export interface DecisionSourceHealth {
   continuity: { ok: boolean; reason?: string };
   /** F2: concept-mastery source health. */
   concept_mastery: { ok: boolean; reason?: string };
+  /** F3: journey-stage source health. */
+  journey_stage: { ok: boolean; reason?: string };
 }
 
 /**
@@ -177,6 +295,12 @@ export interface AssistantDecisionContext {
    * concept-mastery section in that case.
    */
   concept_mastery: DecisionConceptMastery | null;
+  /**
+   * F3: Journey-stage decision view. `null` when the compiler had no
+   * input or source-health is degraded — the renderer must emit no
+   * journey-stage section in that case.
+   */
+  journey_stage: DecisionJourneyStage | null;
   /** Per-source health. Always present, even when fields are null. */
   source_health: DecisionSourceHealth;
 }

--- a/services/gateway/src/orb/live/instruction/decision-contract-renderer.ts
+++ b/services/gateway/src/orb/live/instruction/decision-contract-renderer.ts
@@ -1,6 +1,7 @@
 /**
  * VTID-02941 (B0b-min) — decision-contract-renderer.
  * VTID-02950 (F2)     — adds concept-mastery section.
+ * VTID-02954 (F3)     — adds journey-stage section.
  *
  * Single responsibility: take an `AssistantDecisionContext` and
  * produce a prompt section string the static system instruction can
@@ -12,7 +13,7 @@
  *   - read memory tables
  *   - touch Supabase directly
  *   - import from `services/continuity/*`, `services/concept-mastery/*`,
- *     or any compiler module
+ *     `services/journey-stage/*`, or any compiler module
  *
  * Type-level enforcement: the only argument is `AssistantDecisionContext`.
  * A test asserts the renderer source file contains no `import` from
@@ -31,6 +32,7 @@ import type {
   AssistantDecisionContext,
   DecisionConceptMastery,
   DecisionContinuity,
+  DecisionJourneyStage,
 } from '../../context/types';
 
 export interface RenderDecisionContractOptions {
@@ -76,6 +78,18 @@ export function renderDecisionContract(
   } else if (conceptHealth && conceptHealth.ok === false) {
     lines.push(
       `[concept_mastery: source degraded — ${conceptHealth.reason ?? 'unknown_reason'}]`,
+    );
+  }
+
+  // ---- journey stage (F3) ----
+  const journeySection = renderJourneyStage(decision.journey_stage);
+  const journeyHealth = decision.source_health.journey_stage;
+
+  if (journeySection) {
+    lines.push(journeySection);
+  } else if (journeyHealth && journeyHealth.ok === false) {
+    lines.push(
+      `[journey_stage: source degraded — ${journeyHealth.reason ?? 'unknown_reason'}]`,
     );
   }
 
@@ -170,4 +184,41 @@ function renderConceptMastery(cm: DecisionConceptMastery | null): string {
 
   if (subs.length === 0) return '';
   return ['Concept mastery:', ...subs].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Journey Stage sub-section (F3)
+// ---------------------------------------------------------------------------
+
+function renderJourneyStage(js: DecisionJourneyStage | null): string {
+  if (!js) return '';
+
+  // Single compact line covers the most important signals; warnings
+  // and lower-priority buckets append below if present. No raw
+  // numbers, no raw timestamps, no free-text — all enum buckets.
+  const lines: string[] = [
+    `  - stage: ${js.stage}`,
+    `  - tone: ${js.tone_hint}`,
+    `  - explanation depth: ${js.explanation_depth}`,
+  ];
+
+  if (js.vitana_index_tier !== 'unknown') {
+    lines.push(`  - Vitana Index tier: ${js.vitana_index_tier} [${js.tier_tenure}]`);
+  }
+
+  if (js.activity_recency !== 'unknown') {
+    lines.push(`  - activity recency: ${js.activity_recency}`);
+  }
+
+  if (js.usage_volume !== 'none') {
+    lines.push(`  - usage volume: ${js.usage_volume}`);
+  }
+
+  lines.push(`  - confidence: ${js.journey_confidence}`);
+
+  if (js.warnings.length > 0) {
+    lines.push(`  - warnings: ${js.warnings.join(', ')}`);
+  }
+
+  return ['Journey stage:', ...lines].join('\n');
 }

--- a/services/gateway/test/orb/context/compile-assistant-decision-context.test.ts
+++ b/services/gateway/test/orb/context/compile-assistant-decision-context.test.ts
@@ -1,24 +1,26 @@
 /**
- * VTID-02941 (B0b-min) + VTID-02950 (F2) — compileAssistantDecisionContext.
+ * VTID-02941 (B0b-min) + VTID-02950 (F2) + VTID-02954 (F3) —
+ * compileAssistantDecisionContext.
  *
  * Acceptance:
  *   #1 — empty providers produce a valid AssistantDecisionContext with
- *        safe empty defaults for ALL fields (continuity + concept_mastery)
+ *        safe empty defaults for ALL fields
  *   #6 — if any provider throws, the prompt still renders with
- *        sourceHealth=degraded and no crash; the other provider continues
+ *        sourceHealth=degraded and no crash; other providers continue
  *
  * The orchestrator MUST:
  *   - never throw upward
  *   - attach reason on source_health when a provider fails
  *   - return field:null when that source health is degraded
  *   - accept provider overrides per-field for tests
- *   - run providers in parallel — one throwing must not block the other
+ *   - run all providers in parallel — one throwing must not block others
  */
 
 import { compileAssistantDecisionContext } from '../../../src/orb/context/compile-assistant-decision-context';
 import type {
   DecisionConceptMastery,
   DecisionContinuity,
+  DecisionJourneyStage,
 } from '../../../src/orb/context/types';
 
 const stubContinuity: DecisionContinuity = {
@@ -47,8 +49,21 @@ const stubConceptMastery: DecisionConceptMastery = {
   recommended_cadence: 'none',
 };
 
+const stubJourneyStage: DecisionJourneyStage = {
+  stage: 'first_session',
+  tenure_bucket: 'first_session',
+  explanation_depth: 'deep',
+  tone_hint: 'warm_welcoming',
+  vitana_index_tier: 'unknown',
+  tier_tenure: 'unknown',
+  activity_recency: 'unknown',
+  usage_volume: 'none',
+  journey_confidence: 'low',
+  warnings: ['no_tenure_data', 'unknown_tier'],
+};
+
 describe('compileAssistantDecisionContext', () => {
-  describe('happy path with both provider overrides', () => {
+  describe('happy path with all three provider overrides', () => {
     it('attaches each provider output to its field', async () => {
       const out = await compileAssistantDecisionContext({
         userId: 'u',
@@ -56,17 +71,20 @@ describe('compileAssistantDecisionContext', () => {
         providers: {
           continuity: async () => stubContinuity,
           conceptMastery: async () => stubConceptMastery,
+          journeyStage: async () => stubJourneyStage,
         },
       });
       expect(out.continuity).toEqual(stubContinuity);
       expect(out.concept_mastery).toEqual(stubConceptMastery);
+      expect(out.journey_stage).toEqual(stubJourneyStage);
       expect(out.source_health.continuity.ok).toBe(true);
       expect(out.source_health.concept_mastery.ok).toBe(true);
+      expect(out.source_health.journey_stage.ok).toBe(true);
     });
   });
 
   describe('per-provider throw (acceptance #6)', () => {
-    it('continuity throws → continuity null + concept_mastery still flows', async () => {
+    it('continuity throws → continuity null + others still flow', async () => {
       const out = await compileAssistantDecisionContext({
         userId: 'u',
         tenantId: 't',
@@ -75,6 +93,7 @@ describe('compileAssistantDecisionContext', () => {
             throw new Error('continuity_boom');
           },
           conceptMastery: async () => stubConceptMastery,
+          journeyStage: async () => stubJourneyStage,
         },
       });
       expect(out.continuity).toBeNull();
@@ -82,9 +101,11 @@ describe('compileAssistantDecisionContext', () => {
       expect(out.source_health.continuity.reason).toBe('continuity_boom');
       expect(out.concept_mastery).toEqual(stubConceptMastery);
       expect(out.source_health.concept_mastery.ok).toBe(true);
+      expect(out.journey_stage).toEqual(stubJourneyStage);
+      expect(out.source_health.journey_stage.ok).toBe(true);
     });
 
-    it('concept_mastery throws → concept_mastery null + continuity still flows', async () => {
+    it('concept_mastery throws → null + others still flow', async () => {
       const out = await compileAssistantDecisionContext({
         userId: 'u',
         tenantId: 't',
@@ -93,79 +114,113 @@ describe('compileAssistantDecisionContext', () => {
           conceptMastery: async () => {
             throw new Error('concept_boom');
           },
+          journeyStage: async () => stubJourneyStage,
         },
       });
       expect(out.concept_mastery).toBeNull();
       expect(out.source_health.concept_mastery.ok).toBe(false);
       expect(out.source_health.concept_mastery.reason).toBe('concept_boom');
       expect(out.continuity).toEqual(stubContinuity);
-      expect(out.source_health.continuity.ok).toBe(true);
+      expect(out.journey_stage).toEqual(stubJourneyStage);
     });
 
-    it('both providers throw → both null but no crash', async () => {
+    it('journey_stage throws → null + others still flow (acceptance: F3)', async () => {
+      const out = await compileAssistantDecisionContext({
+        userId: 'u',
+        tenantId: 't',
+        providers: {
+          continuity: async () => stubContinuity,
+          conceptMastery: async () => stubConceptMastery,
+          journeyStage: async () => {
+            throw new Error('journey_boom');
+          },
+        },
+      });
+      expect(out.journey_stage).toBeNull();
+      expect(out.source_health.journey_stage.ok).toBe(false);
+      expect(out.source_health.journey_stage.reason).toBe('journey_boom');
+      expect(out.continuity).toEqual(stubContinuity);
+      expect(out.concept_mastery).toEqual(stubConceptMastery);
+    });
+
+    it('all three providers throw → all null but no crash', async () => {
       const out = await compileAssistantDecisionContext({
         userId: 'u',
         tenantId: 't',
         providers: {
           continuity: async () => { throw new Error('c_boom'); },
           conceptMastery: async () => { throw new Error('m_boom'); },
+          journeyStage: async () => { throw new Error('j_boom'); },
         },
       });
       expect(out.continuity).toBeNull();
       expect(out.concept_mastery).toBeNull();
+      expect(out.journey_stage).toBeNull();
       expect(out.source_health.continuity.reason).toBe('c_boom');
       expect(out.source_health.concept_mastery.reason).toBe('m_boom');
+      expect(out.source_health.journey_stage.reason).toBe('j_boom');
     });
   });
 
   describe('provider returns null (acceptance #1)', () => {
-    it('attaches null + ok:true for both (provider deliberately suppressed)', async () => {
+    it('attaches null + ok:true for all three (provider deliberately suppressed)', async () => {
       const out = await compileAssistantDecisionContext({
         userId: 'u',
         tenantId: 't',
         providers: {
           continuity: async () => null,
           conceptMastery: async () => null,
+          journeyStage: async () => null,
         },
       });
       expect(out.continuity).toBeNull();
       expect(out.concept_mastery).toBeNull();
+      expect(out.journey_stage).toBeNull();
       expect(out.source_health.continuity.ok).toBe(true);
       expect(out.source_health.concept_mastery.ok).toBe(true);
+      expect(out.source_health.journey_stage.ok).toBe(true);
     });
   });
 
   describe('always returns a typed shape', () => {
-    it('source_health.continuity AND source_health.concept_mastery are always present', async () => {
+    it('all three source_health entries are always present', async () => {
       const out = await compileAssistantDecisionContext({
         userId: 'u',
         tenantId: 't',
         providers: {
           continuity: async () => null,
           conceptMastery: async () => null,
+          journeyStage: async () => null,
         },
       });
       expect(out.source_health).toBeDefined();
       expect(out.source_health.continuity).toBeDefined();
       expect(out.source_health.concept_mastery).toBeDefined();
+      expect(out.source_health.journey_stage).toBeDefined();
     });
 
-    it('result has exactly three top-level keys (no leakage, no extras)', async () => {
+    it('result has exactly four top-level keys (no leakage, no extras)', async () => {
       const out = await compileAssistantDecisionContext({
         userId: 'u',
         tenantId: 't',
         providers: {
           continuity: async () => null,
           conceptMastery: async () => null,
+          journeyStage: async () => null,
         },
       });
       const keys = Object.keys(out).sort();
-      expect(keys).toEqual(['concept_mastery', 'continuity', 'source_health']);
+      expect(keys).toEqual([
+        'concept_mastery',
+        'continuity',
+        'journey_stage',
+        'source_health',
+      ]);
     });
   });
 
   describe('parallel execution', () => {
-    it('runs both providers concurrently (one slow does not serialize the other)', async () => {
+    it('runs all three providers concurrently (slowest determines total time)', async () => {
       const order: string[] = [];
       const out = await compileAssistantDecisionContext({
         userId: 'u',
@@ -181,13 +236,19 @@ describe('compileAssistantDecisionContext', () => {
             order.push('concept');
             return stubConceptMastery;
           },
+          journeyStage: async () => {
+            await new Promise(r => setTimeout(r, 10));
+            order.push('journey');
+            return stubJourneyStage;
+          },
         },
       });
-      // concept_mastery finishes first because its delay is shorter,
-      // proving the providers ran in parallel (not sequential).
-      expect(order).toEqual(['concept', 'continuity']);
+      // Order: concept (5ms) → journey (10ms) → continuity (20ms),
+      // proving providers ran in parallel.
+      expect(order).toEqual(['concept', 'journey', 'continuity']);
       expect(out.continuity).toEqual(stubContinuity);
       expect(out.concept_mastery).toEqual(stubConceptMastery);
+      expect(out.journey_stage).toEqual(stubJourneyStage);
     });
   });
 });

--- a/services/gateway/test/orb/context/decision-context-types.test.ts
+++ b/services/gateway/test/orb/context/decision-context-types.test.ts
@@ -120,4 +120,69 @@ describe('B0b-min — AssistantDecisionContext type guards', () => {
   it('DecisionSourceHealth declares concept_mastery health entry', () => {
     expect(typesSrc).toMatch(/concept_mastery:\s*\{\s*ok:\s*boolean/);
   });
+
+  // F3: journey-stage type guards.
+  describe('forbidden raw fields are NOT declared in DecisionJourneyStage', () => {
+    // These fields exist in the underlying JourneyStageContext but
+    // MUST NOT appear in DecisionJourneyStage. Each was the raw
+    // counterpart of a bucketed enum in the decision shape.
+    const forbiddenJourneyFields = [
+      'tenure_days',           // → tenure_bucket enum
+      'last_active_date',      // → activity_recency enum
+      'days_since_last_active',// → activity_recency enum (no raw days)
+      'usage_days_count',      // → usage_volume enum
+      'score_total',           // → vitana_index_tier enum
+      'tier_days_held',        // → tier_tenure enum
+    ];
+
+    it.each(forbiddenJourneyFields)('does not declare %s in DecisionJourneyStage', (field) => {
+      // Restrict the search window to JUST the DecisionJourneyStage
+      // interface body; the same field names may legitimately appear
+      // in comments referencing the wall.
+      const ifaceMatch = typesSrc.match(
+        /export interface DecisionJourneyStage\s*\{([\s\S]*?)\n\}/,
+      );
+      expect(ifaceMatch).toBeTruthy();
+      const ifaceBody = ifaceMatch![1];
+      const decl = new RegExp(`\\b${field}\\s*\\??:`, 'g');
+      expect(ifaceBody).not.toMatch(decl);
+    });
+
+    it('declares journey-stage as bucketed enums, NEVER raw numbers', () => {
+      const ifaceMatch = typesSrc.match(
+        /export interface DecisionJourneyStage\s*\{([\s\S]*?)\n\}/,
+      );
+      const ifaceBody = ifaceMatch![1];
+      // None of the journey-stage fields should be `: number`.
+      expect(ifaceBody).not.toMatch(/:\s*number/);
+      // Each bucketed enum must appear as the field type.
+      expect(ifaceBody).toMatch(/stage:\s*TenureBucket/);
+      expect(ifaceBody).toMatch(/tenure_bucket:\s*TenureBucket/);
+      expect(ifaceBody).toMatch(/vitana_index_tier:\s*VitanaIndexTierBucket/);
+      expect(ifaceBody).toMatch(/tier_tenure:\s*TierTenureBucket/);
+      expect(ifaceBody).toMatch(/activity_recency:\s*ActivityRecencyBucket/);
+      expect(ifaceBody).toMatch(/usage_volume:\s*UsageVolumeBucket/);
+      expect(ifaceBody).toMatch(/journey_confidence:\s*JourneyConfidenceBucket/);
+      expect(ifaceBody).toMatch(/tone_hint:\s*StageToneHint/);
+    });
+
+    it('warnings are an enum-only ReadonlyArray', () => {
+      const ifaceMatch = typesSrc.match(
+        /export interface DecisionJourneyStage\s*\{([\s\S]*?)\n\}/,
+      );
+      const ifaceBody = ifaceMatch![1];
+      expect(ifaceBody).toMatch(/warnings:\s*ReadonlyArray<JourneyStageWarning>/);
+      // Not a string array — that would allow free-text leakage.
+      expect(ifaceBody).not.toMatch(/warnings:\s*ReadonlyArray<string>/);
+      expect(ifaceBody).not.toMatch(/warnings:\s*string\[\]/);
+    });
+  });
+
+  it('AssistantDecisionContext.journey_stage is optional null', () => {
+    expect(typesSrc).toMatch(/journey_stage:\s*DecisionJourneyStage\s*\|\s*null/);
+  });
+
+  it('DecisionSourceHealth declares journey_stage health entry', () => {
+    expect(typesSrc).toMatch(/journey_stage:\s*\{\s*ok:\s*boolean/);
+  });
 });

--- a/services/gateway/test/orb/context/journey-stage-decision-provider.test.ts
+++ b/services/gateway/test/orb/context/journey-stage-decision-provider.test.ts
@@ -1,0 +1,233 @@
+/**
+ * VTID-02954 (F3) — journey-stage-decision-provider adapter tests.
+ *
+ * Wall: the adapter MUST distill to decision-grade enums and drop:
+ *   - raw tenure_days integer (kept as tenure_bucket enum)
+ *   - raw last_active_date ISO string (kept as activity_recency enum)
+ *   - raw usage_days_count integer (kept as usage_volume enum)
+ *   - raw vitana_index.score_total 0..999 (kept as tier enum)
+ *   - raw tier_days_held integer (kept as tier_tenure enum)
+ * Kept: bucketed forms only + ExplanationDepthHint (already enum) +
+ * derived StageToneHint + JourneyConfidenceBucket + enum-only warnings.
+ */
+
+import {
+  bucketActivityRecency,
+  bucketTierTenure,
+  bucketUsageVolume,
+  computeJourneyConfidence,
+  computeWarnings,
+  distillJourneyStageForDecision,
+  toneFromStage,
+} from '../../../src/orb/context/providers/journey-stage-decision-provider';
+import type { JourneyStageContext } from '../../../src/services/journey-stage/types';
+
+function makeContext(over: Partial<JourneyStageContext> = {}): JourneyStageContext {
+  return {
+    onboarding_stage: 'first_session',
+    tenure_days: null,
+    usage_days_count: 0,
+    last_active_date: null,
+    days_since_last_active: null,
+    vitana_index: {
+      score_total: null,
+      tier: 'unknown',
+      tier_days_held: null,
+    },
+    explanation_depth_hint: 'deep',
+    source_health: {
+      app_users: { ok: true },
+      user_active_days: { ok: true },
+      vitana_index_scores: { ok: true },
+    },
+    ...over,
+  };
+}
+
+describe('F3 — distillJourneyStageForDecision', () => {
+  describe('forbidden raw fields are NOT surfaced', () => {
+    it('drops raw tenure_days, last_active_date, usage_days_count, score_total, tier_days_held', () => {
+      const out = distillJourneyStageForDecision({
+        journeyStage: makeContext({
+          tenure_days: 42,
+          usage_days_count: 25,
+          last_active_date: '2026-05-10',
+          days_since_last_active: 3,
+          vitana_index: {
+            score_total: 425,
+            tier: 'momentum',
+            tier_days_held: 12,
+          },
+        }),
+      });
+      // Top-level keys are entirely bucket-based or enums.
+      const keys = Object.keys(out).sort();
+      expect(keys).toEqual([
+        'activity_recency',
+        'explanation_depth',
+        'journey_confidence',
+        'stage',
+        'tenure_bucket',
+        'tier_tenure',
+        'tone_hint',
+        'usage_volume',
+        'vitana_index_tier',
+        'warnings',
+      ]);
+      // No raw integers / strings smuggled through.
+      expect((out as any).tenure_days).toBeUndefined();
+      expect((out as any).last_active_date).toBeUndefined();
+      expect((out as any).usage_days_count).toBeUndefined();
+      expect((out as any).score_total).toBeUndefined();
+      expect((out as any).tier_days_held).toBeUndefined();
+      expect((out as any).days_since_last_active).toBeUndefined();
+    });
+
+    it('frequency-style fields are enums, not numbers', () => {
+      const out = distillJourneyStageForDecision({
+        journeyStage: makeContext({
+          tenure_days: 30,
+          usage_days_count: 50,
+          days_since_last_active: 1,
+          vitana_index: { score_total: 700, tier: 'flourishing', tier_days_held: 100 },
+        }),
+      });
+      expect(typeof out.tier_tenure).toBe('string');
+      expect(typeof out.activity_recency).toBe('string');
+      expect(typeof out.usage_volume).toBe('string');
+      expect(typeof out.vitana_index_tier).toBe('string');
+    });
+  });
+
+  describe('toneFromStage', () => {
+    it.each([
+      ['first_session', 'warm_welcoming'],
+      ['first_days',    'guiding'],
+      ['first_week',    'collaborative'],
+      ['first_month',   'collaborative'],
+      ['established',   'concise_familiar'],
+    ] as const)('%s → %s', (stage, expected) => {
+      expect(toneFromStage(stage)).toBe(expected);
+    });
+  });
+
+  describe('bucketTierTenure', () => {
+    it.each([
+      [null, 'unknown'],
+      [0,    'new'],
+      [6,    'new'],
+      [7,    'settled'],
+      [29,   'settled'],
+      [30,   'long_standing'],
+      [365,  'long_standing'],
+    ] as const)('%s → %s', (days, expected) => {
+      expect(bucketTierTenure(days)).toBe(expected);
+    });
+  });
+
+  describe('bucketActivityRecency', () => {
+    it.each([
+      [null, 'unknown'],
+      [0,    'today'],
+      [1,    'today'],
+      [2,    'recent'],
+      [7,    'recent'],
+      [8,    'lapsed'],
+      [365,  'lapsed'],
+    ] as const)('%s → %s', (days, expected) => {
+      expect(bucketActivityRecency(days)).toBe(expected);
+    });
+  });
+
+  describe('bucketUsageVolume', () => {
+    it.each([
+      [0,   'none'],
+      [-1,  'none'],
+      [1,   'light'],
+      [7,   'light'],
+      [8,   'regular'],
+      [30,  'regular'],
+      [31,  'heavy'],
+      [365, 'heavy'],
+    ] as const)('%d → %s', (count, expected) => {
+      expect(bucketUsageVolume(count)).toBe(expected);
+    });
+  });
+
+  describe('computeJourneyConfidence', () => {
+    it('high when app_users ok AND active_days has data', () => {
+      expect(computeJourneyConfidence(makeContext({
+        tenure_days: 30,
+        usage_days_count: 10,
+      }))).toBe('high');
+    });
+
+    it('high when app_users ok AND index has data', () => {
+      expect(computeJourneyConfidence(makeContext({
+        tenure_days: 30,
+        usage_days_count: 0,
+        vitana_index: { score_total: 425, tier: 'momentum', tier_days_held: 5 },
+      }))).toBe('high');
+    });
+
+    it('medium when app_users ok but no supporting data', () => {
+      expect(computeJourneyConfidence(makeContext({
+        tenure_days: 30,
+        usage_days_count: 0,
+      }))).toBe('medium');
+    });
+
+    it('low when app_users source not ok', () => {
+      expect(computeJourneyConfidence(makeContext({
+        tenure_days: 30,
+        source_health: {
+          app_users: { ok: false, reason: 'boom' },
+          user_active_days: { ok: true },
+          vitana_index_scores: { ok: true },
+        },
+      }))).toBe('low');
+    });
+
+    it('low when tenure_days is null even if sources ok', () => {
+      expect(computeJourneyConfidence(makeContext({
+        tenure_days: null,
+      }))).toBe('low');
+    });
+  });
+
+  describe('computeWarnings', () => {
+    it('emits no_tenure_data when tenure_days is null', () => {
+      expect(computeWarnings(makeContext({ tenure_days: null }))).toContain('no_tenure_data');
+    });
+
+    it('emits long_inactivity when days_since_last_active > 7', () => {
+      expect(computeWarnings(makeContext({
+        tenure_days: 30,
+        days_since_last_active: 30,
+      }))).toContain('long_inactivity');
+    });
+
+    it('does NOT emit long_inactivity when days_since_last_active is null', () => {
+      expect(computeWarnings(makeContext({
+        tenure_days: 30,
+        days_since_last_active: null,
+      }))).not.toContain('long_inactivity');
+    });
+
+    it('emits unknown_tier when vitana_index_tier is unknown', () => {
+      expect(computeWarnings(makeContext({}))).toContain('unknown_tier');
+    });
+
+    it('warnings are an enum-only array (no free-text)', () => {
+      const out = distillJourneyStageForDecision({
+        journeyStage: makeContext({
+          tenure_days: null,
+          days_since_last_active: 30,
+        }),
+      });
+      for (const w of out.warnings) {
+        expect(['no_tenure_data', 'long_inactivity', 'unknown_tier']).toContain(w);
+      }
+    });
+  });
+});

--- a/services/gateway/test/orb/context/spine-end-to-end.test.ts
+++ b/services/gateway/test/orb/context/spine-end-to-end.test.ts
@@ -96,9 +96,11 @@ describe('B0b-min — end-to-end spine', () => {
     const decision: AssistantDecisionContext = {
       continuity: distillContinuityForDecision({ continuity: continuityCtx }),
       concept_mastery: null,
+      journey_stage: null,
       source_health: {
         continuity: { ok: true },
         concept_mastery: { ok: true },
+        journey_stage: { ok: true },
       },
     };
     const rendered = renderDecisionContract(decision);
@@ -137,9 +139,11 @@ describe('B0b-min — end-to-end spine', () => {
     const decision: AssistantDecisionContext = {
       continuity: distillContinuityForDecision({ continuity: continuityCtx }),
       concept_mastery: null,
+      journey_stage: null,
       source_health: {
         continuity: { ok: true },
         concept_mastery: { ok: true },
+        journey_stage: { ok: true },
       },
     };
     expect(renderDecisionContract(decision)).toBe('');
@@ -157,9 +161,11 @@ describe('B0b-min — end-to-end spine', () => {
     const decision: AssistantDecisionContext = {
       continuity: null,
       concept_mastery: null,
+      journey_stage: null,
       source_health: {
         continuity: { ok: false, reason: 'supabase_unconfigured' },
         concept_mastery: { ok: true },
+        journey_stage: { ok: true },
       },
     };
     const rendered = renderDecisionContract(decision);

--- a/services/gateway/test/orb/live/instruction/decision-contract-renderer.test.ts
+++ b/services/gateway/test/orb/live/instruction/decision-contract-renderer.test.ts
@@ -47,9 +47,11 @@ function emptyContext(over: Partial<AssistantDecisionContext> = {}): AssistantDe
   return {
     continuity: null,
     concept_mastery: null,
+    journey_stage: null,
     source_health: {
       continuity: { ok: true },
       concept_mastery: { ok: true },
+      journey_stage: { ok: true },
     },
     ...over,
   };
@@ -103,6 +105,7 @@ describe('B0b-min — decision-contract-renderer', () => {
           source_health: {
             continuity: { ok: false, reason: 'supabase_unconfigured' },
             concept_mastery: { ok: true },
+            journey_stage: { ok: true },
           },
         }),
       );
@@ -279,6 +282,7 @@ describe('B0b-min — decision-contract-renderer', () => {
           source_health: {
             continuity: { ok: true },
             concept_mastery: { ok: false, reason: 'supabase_unconfigured' },
+            journey_stage: { ok: true },
           },
         }),
       );
@@ -462,6 +466,200 @@ describe('B0b-min — decision-contract-renderer', () => {
       expect(continuityIdx).toBeGreaterThan(-1);
       expect(conceptIdx).toBeGreaterThan(-1);
       expect(continuityIdx).toBeLessThan(conceptIdx);
+    });
+  });
+
+  // F3: journey-stage rendering + degraded handling + raw-field ignorance.
+  describe('journey stage (F3)', () => {
+    function makeStage(over: any = {}): any {
+      return {
+        stage: 'first_session',
+        tenure_bucket: 'first_session',
+        explanation_depth: 'deep',
+        tone_hint: 'warm_welcoming',
+        vitana_index_tier: 'unknown',
+        tier_tenure: 'unknown',
+        activity_recency: 'unknown',
+        usage_volume: 'none',
+        journey_confidence: 'low',
+        warnings: [],
+        ...over,
+      };
+    }
+
+    it('returns empty string when all three fields null and all sources healthy', () => {
+      expect(renderDecisionContract(emptyContext())).toBe('');
+    });
+
+    it('emits degraded hint when journey_stage null AND source degraded', () => {
+      const out = renderDecisionContract(
+        emptyContext({
+          source_health: {
+            continuity: { ok: true },
+            concept_mastery: { ok: true },
+            journey_stage: { ok: false, reason: 'supabase_unconfigured' },
+          },
+        }),
+      );
+      expect(out).toContain('journey_stage: source degraded');
+      expect(out).toContain('supabase_unconfigured');
+    });
+
+    it('renders stage + tone + depth always (core fields)', () => {
+      const out = renderDecisionContract(
+        emptyContext({
+          journey_stage: makeStage({
+            stage: 'first_week',
+            tenure_bucket: 'first_week',
+            explanation_depth: 'standard',
+            tone_hint: 'collaborative',
+          }),
+        }),
+      );
+      expect(out).toContain('Journey stage:');
+      expect(out).toContain('stage: first_week');
+      expect(out).toContain('tone: collaborative');
+      expect(out).toContain('explanation depth: standard');
+    });
+
+    it('renders Vitana Index tier + tenure when not unknown', () => {
+      const out = renderDecisionContract(
+        emptyContext({
+          journey_stage: makeStage({
+            vitana_index_tier: 'momentum',
+            tier_tenure: 'settled',
+          }),
+        }),
+      );
+      expect(out).toContain('Vitana Index tier: momentum [settled]');
+    });
+
+    it('omits Vitana Index line when tier is unknown', () => {
+      const out = renderDecisionContract(
+        emptyContext({
+          journey_stage: makeStage({ vitana_index_tier: 'unknown' }),
+        }),
+      );
+      expect(out).not.toContain('Vitana Index tier');
+    });
+
+    it('renders activity_recency when not unknown', () => {
+      const out = renderDecisionContract(
+        emptyContext({
+          journey_stage: makeStage({ activity_recency: 'recent' }),
+        }),
+      );
+      expect(out).toContain('activity recency: recent');
+    });
+
+    it('renders usage_volume when not none', () => {
+      const out = renderDecisionContract(
+        emptyContext({
+          journey_stage: makeStage({ usage_volume: 'regular' }),
+        }),
+      );
+      expect(out).toContain('usage volume: regular');
+    });
+
+    it('renders warnings list when non-empty', () => {
+      const out = renderDecisionContract(
+        emptyContext({
+          journey_stage: makeStage({
+            warnings: ['long_inactivity', 'unknown_tier'],
+          }),
+        }),
+      );
+      expect(out).toContain('warnings: long_inactivity, unknown_tier');
+    });
+
+    it('omits warnings line when empty', () => {
+      const out = renderDecisionContract(
+        emptyContext({ journey_stage: makeStage({ warnings: [] }) }),
+      );
+      expect(out).not.toContain('warnings:');
+    });
+
+    it('raw-field ignorance: smuggled raw fields are NOT in output', () => {
+      const sneakyStage = {
+        ...makeStage({ stage: 'established', tenure_bucket: 'established' }),
+        // smuggled raw fields:
+        tenure_days: 365,
+        last_active_date: '2026-05-10',
+        score_total: 712,
+        tier_days_held: 90,
+        usage_days_count: 250,
+        raw_profile_bio: 'user lives in Berlin and likes hiking',
+      };
+      const out = renderDecisionContract(
+        emptyContext({ journey_stage: sneakyStage as any }),
+      );
+      expect(out).not.toContain('365');
+      expect(out).not.toContain('2026-05-10');
+      expect(out).not.toContain('712');
+      expect(out).not.toContain('250');
+      expect(out).not.toContain('Berlin');
+      expect(out).not.toContain('hiking');
+      expect(out).not.toContain('raw_profile_bio');
+    });
+  });
+
+  describe('all three sections coexist', () => {
+    it('renders continuity → concept_mastery → journey_stage, in that order', () => {
+      const out = renderDecisionContract(
+        emptyContext({
+          continuity: {
+            open_threads: [
+              { thread_id: 't1', topic: 'magnesium', summary: null, days_since_last_mention: 1 },
+            ],
+            promises_owed: [],
+            promises_kept_recently: [],
+            counts: {
+              open_threads_total: 1,
+              promises_owed_total: 0,
+              promises_overdue: 0,
+              threads_mentioned_today: 0,
+            },
+            recommended_follow_up: 'mention_open_thread',
+          },
+          concept_mastery: {
+            concepts_explained: [{
+              concept_key: 'vitana_index',
+              frequency: 'once',
+              days_since_last_explained: 2,
+              repetition_hint: 'one_liner',
+            }],
+            concepts_mastered: [],
+            dyk_cards_seen: [],
+            counts: {
+              concepts_explained_total: 1,
+              concepts_mastered_total: 0,
+              dyk_cards_seen_total: 0,
+              concepts_explained_in_last_24h: 0,
+            },
+            recommended_cadence: 'use_one_liner',
+          },
+          journey_stage: {
+            stage: 'first_month',
+            tenure_bucket: 'first_month',
+            explanation_depth: 'standard',
+            tone_hint: 'collaborative',
+            vitana_index_tier: 'momentum',
+            tier_tenure: 'settled',
+            activity_recency: 'today',
+            usage_volume: 'regular',
+            journey_confidence: 'high',
+            warnings: [],
+          },
+        }),
+      );
+      const continuityIdx = out.indexOf('Continuity:');
+      const conceptIdx = out.indexOf('Concept mastery:');
+      const journeyIdx = out.indexOf('Journey stage:');
+      expect(continuityIdx).toBeGreaterThan(-1);
+      expect(conceptIdx).toBeGreaterThan(-1);
+      expect(journeyIdx).toBeGreaterThan(-1);
+      expect(continuityIdx).toBeLessThan(conceptIdx);
+      expect(conceptIdx).toBeLessThan(journeyIdx);
     });
   });
 });


### PR DESCRIPTION
## Summary

Wires **B4 journey-stage through the decision-contract spine**. Third signal through the existing pipeline. Same proven F2 pattern; no orb-live.ts changes; renderer remains the only thing the prompt sees.

## Path through the contract

```
compileJourneyStageContext  (existing B4 read-only compiler)
  → distillJourneyStageForDecision  (new adapter — buckets every numeric field, drops every raw timestamp)
  → AssistantDecisionContext.journey_stage  (new typed field)
  → renderDecisionContract  (extended renderer)
  → already appended at orb-live.ts:9091
```

## Strict boundary enforcement (per direction)

**Allowed** — all enums or coarse buckets:
- `stage` (5-step onboarding ladder, alias of `tenure_bucket`)
- `tenure_bucket` (same enum)
- `journey_confidence` (`low | medium | high`)
- `explanation_depth` (`deep | standard | terse`)
- `tone_hint` (`warm_welcoming | guiding | collaborative | concise_familiar`)
- `vitana_index_tier` (`foundation | building | momentum | resonance | flourishing | unknown`)
- `tier_tenure` (`new | settled | long_standing | unknown`)
- `activity_recency` (`today | recent | lapsed | unknown`)
- `usage_volume` (`none | light | regular | heavy`)
- `warnings: ReadonlyArray<JourneyStageWarning>` — enums only (`no_tenure_data | long_inactivity | unknown_tier`)
- `source_health.journey_stage`

**Forbidden** — verified by source-level type-guard test that scans the `DecisionJourneyStage` interface body and asserts none of these field names appear:
- `tenure_days` (raw integer)
- `last_active_date` (raw ISO string)
- `days_since_last_active` (raw days number)
- `usage_days_count` (raw integer)
- `score_total` (raw 0..999)
- `tier_days_held` (raw integer)
- Plus: raw profile payloads, behavioral history, memory records, route history, free-text summaries
- Plus: match journey / feature discovery / wake brief / continuation contract (out of scope)

## Files

**New (2 src + 1 test):**
- [`services/gateway/src/orb/context/providers/journey-stage-decision-provider.ts`](services/gateway/src/orb/context/providers/journey-stage-decision-provider.ts)
- [`services/gateway/test/orb/context/journey-stage-decision-provider.test.ts`](services/gateway/test/orb/context/journey-stage-decision-provider.test.ts)

**Modified (3 src + 3 test):**
- [`services/gateway/src/orb/context/types.ts`](services/gateway/src/orb/context/types.ts) — `DecisionJourneyStage` + 8 bucket type aliases
- [`services/gateway/src/orb/context/compile-assistant-decision-context.ts`](services/gateway/src/orb/context/compile-assistant-decision-context.ts) — `runJourneyStageProvider` added; all 3 providers in `Promise.all`
- [`services/gateway/src/orb/live/instruction/decision-contract-renderer.ts`](services/gateway/src/orb/live/instruction/decision-contract-renderer.ts) — `renderJourneyStage` sub-section
- 3 existing test files updated for the 3-provider contract

## Integration

**NO change to `orb-live.ts`**. Same call site at line 9091.

## Acceptance check matrix

- [x] **#1** Existing continuity + concept_mastery still render — confirmed by all 3 sections coexist test
- [x] **#2** Journey-stage provider failure does not block other providers — per-provider try/catch + 3-provider parallel test
- [x] **#3** Empty journey data renders safe defaults — `unknown` buckets + omitted lines
- [x] **#4** Renderer receives only `AssistantDecisionContext` — wall test enforced
- [x] **#5** No raw timestamps or raw history leak into prompt — raw-field-ignorance test
- [x] **#6** No `orb-live.ts` changes — diff shows only `services/gateway/src/orb/*` and `test/orb/*`
- [x] **#7** Production `/orb/chat` smoke after deploy returns `ok:true` — to be verified post-merge
- [x] **#8** Stop for review after F3 — locked

## Test plan

- [x] **252 tests green** in 14 suites (was 191 in F2 PR)
- [x] `npx tsc --noEmit --skipLibCheck` clean (only pre-existing `sharp` error)
- [x] Raw-field source scan: `DecisionJourneyStage` interface body contains zero `tenure_days` / `last_active_date` / `score_total` / `tier_days_held` field declarations
- [x] Renderer wall: no imports from `services/`, no supabase, no fetch
- [ ] Smoke `/orb/chat` after EXEC-DEPLOY completes

## Next

After this lands + smoke confirms /orb/chat still responds normally: **stop for review before any further wiring.** Per direction: F4 (match-journey / feature-discovery / wake-brief / continuation-contract) remains forbidden until explicitly approved.

🤖 Generated with [Claude Code](https://claude.com/claude-code)