### PR TITLE
feat(orb): A7 — extract UpstreamLiveClient + Vertex impl (VTID-02956)

### DIFF
--- a/services/gateway/src/orb/live/upstream/types.ts
+++ b/services/gateway/src/orb/live/upstream/types.ts
@@ -1,0 +1,254 @@
+/**
+ * A7 (orb-live-refactor / VTID-02956): provider-neutral upstream Live client
+ * boundary.
+ *
+ * Every realtime/voice provider (Vertex AI Live, LiveKit, future…) implements
+ * `UpstreamLiveClient`. Session-level orchestration (orb-live.ts, A8 session
+ * lifecycle, A9 transport handlers) talks ONLY to this interface — never to
+ * provider WebSocket payloads.
+ *
+ * Hard rules:
+ *   1. The interface is provider-neutral. Vendor JSON shapes (snake_case vs
+ *      camelCase, `media_chunks` vs `audio_data`) never leak past the client.
+ *   2. Events flow callback-style — no global emitter, no event bus. Each
+ *      `on*` registers a single handler; replace by re-registering.
+ *   3. State is observable but not directly mutable. Implementations transition
+ *      through the states in order: `idle → connecting → open → closing → closed`,
+ *      with `error` reachable from any state.
+ *   4. `close()` and `getState()` are idempotent.
+ *
+ * Behavior contract (verified by characterization tests):
+ *   - `connect()` resolves only after the provider's setup handshake completes
+ *     (Vertex: receipt of `setup_complete`).
+ *   - `sendAudioChunk()` returns false (not throws) when the client is not
+ *     `open`. Callers handle backpressure.
+ *   - `onError` fires once per distinct error; `onClose` fires exactly once.
+ *   - After `close()`, no further events are emitted.
+ */
+
+/**
+ * Lifecycle states for an upstream live connection.
+ *
+ * Transitions:
+ *   idle      → connecting   (via `connect()`)
+ *   connecting → open        (provider handshake completed)
+ *   connecting → error       (handshake failed)
+ *   open      → closing      (via `close()` or remote close frame)
+ *   closing   → closed       (socket fully closed)
+ *   *         → error        (any unrecoverable failure)
+ *   error     → closed       (after cleanup)
+ */
+export type UpstreamConnectionState =
+  | 'idle'
+  | 'connecting'
+  | 'open'
+  | 'closing'
+  | 'closed'
+  | 'error';
+
+/**
+ * Options provided to `connect()`. Provider-neutral — implementations map
+ * these onto their own setup envelopes (Vertex: `setup` message).
+ */
+export interface UpstreamConnectOptions {
+  /** Provider-qualified model identifier (e.g. `gemini-live-2.5-flash-native-audio`). */
+  model: string;
+  /** GCP project (or equivalent tenant identifier for non-Vertex providers). */
+  projectId: string;
+  /** Provider region (Vertex: `us-central1`). */
+  location: string;
+  /** Voice ID to use for TTS output (provider-specific name). */
+  voiceName: string;
+  /** Response modalities. Vertex maps `'audio'` → `['AUDIO']`, `'text'` → `['TEXT']`. */
+  responseModalities: ReadonlyArray<'audio' | 'text'>;
+  /** Silence-duration VAD threshold in ms before treating user pause as turn-end. */
+  vadSilenceMs: number;
+  /** System instruction (already-composed prompt text). */
+  systemInstruction: string;
+  /** Tool function declarations (provider passes through as-is). */
+  tools?: ReadonlyArray<Record<string, unknown>>;
+  /** Enable input audio transcription stream. Vertex default: true. */
+  enableInputTranscription?: boolean;
+  /** Enable output audio transcription stream. Vertex default: true. */
+  enableOutputTranscription?: boolean;
+  /** Connection timeout for the initial handshake. Default 15 000 ms. */
+  connectTimeoutMs?: number;
+  /**
+   * Async credential supplier. Vertex implementation calls this once per
+   * `connect()` to obtain an OAuth access token. Other providers may use it
+   * for API keys / JWTs.
+   */
+  getAccessToken: () => Promise<string>;
+}
+
+/**
+ * Audio output chunk decoded from the provider stream.
+ *
+ * Vertex Live emits 24kHz mono PCM as base64 inline_data parts inside
+ * `server_content.model_turn.parts[]`. Implementations normalize to this
+ * single shape regardless of provider envelope.
+ */
+export interface AudioOutputEvent {
+  /** Base64-encoded audio payload. */
+  dataB64: string;
+  /** MIME type (e.g. `audio/pcm;rate=24000`). */
+  mimeType: string;
+}
+
+/**
+ * Incremental transcript event (either direction).
+ *
+ * Vertex Live emits separate `input_transcription` and `output_transcription`
+ * fields under `server_content`. Both arrive as text deltas — accumulate
+ * on the caller side.
+ */
+export interface TranscriptEvent {
+  /** `'input'` = user speech transcript, `'output'` = model speech transcript. */
+  direction: 'input' | 'output';
+  /** Text delta. May be a single word or a longer fragment. */
+  text: string;
+}
+
+/**
+ * Tool/function-call request from the model.
+ *
+ * Each entry corresponds to one `function_calls[]` item in Vertex's
+ * `tool_call` payload. The client passes arguments through unchanged —
+ * the session-level tool dispatcher interprets them.
+ */
+export interface ToolCallEvent {
+  calls: ReadonlyArray<{
+    /** Function name as declared in the tools schema. */
+    name: string;
+    /** Function arguments object (provider passes through as-is). */
+    args: Record<string, unknown>;
+    /** Provider-issued call ID for response correlation. */
+    id?: string;
+  }>;
+}
+
+/**
+ * Signals the model finished a complete turn.
+ *
+ * Vertex emits this as `server_content.turn_complete: true`. After this
+ * event, the session may send a new turn or close the connection.
+ */
+export interface TurnCompleteEvent {
+  /** Provider-reported turn duration in ms, when available. */
+  durationMs?: number;
+}
+
+/**
+ * The model was interrupted mid-turn (user spoke, or VAD detected
+ * conflicting input).
+ *
+ * Vertex emits this as `server_content.interrupted: true`. The client
+ * must stop playback of any buffered audio.
+ */
+export interface InterruptedEvent {
+  /** Provider-issued interrupt timestamp, when available. */
+  atMs?: number;
+}
+
+/**
+ * Connection / protocol error.
+ */
+export interface UpstreamErrorEvent {
+  /** Error code (provider-specific or `network` / `timeout` / `setup`). */
+  code: string;
+  /** Human-readable error message. */
+  message: string;
+  /** Underlying error object, when known. */
+  cause?: unknown;
+}
+
+/**
+ * Final close event. Emitted exactly once per `UpstreamLiveClient` instance.
+ */
+export interface UpstreamCloseEvent {
+  /** WebSocket close code, when available. */
+  code?: number;
+  /** Close reason text, when available. */
+  reason?: string;
+  /** True if the close was initiated by the local side (via `close()`). */
+  initiatedLocally: boolean;
+}
+
+/**
+ * Provider-neutral live upstream client.
+ *
+ * Implementations:
+ *   - `VertexLiveClient` (Vertex AI Live API via BidiGenerateContent WS)
+ *   - future: LiveKit, OpenAI Realtime, …
+ *
+ * Construction is provider-specific. Once constructed, callers MUST register
+ * the events they care about BEFORE calling `connect()` — events fired
+ * during the handshake (rare but possible) are dropped if no handler is set.
+ */
+export interface UpstreamLiveClient {
+  /**
+   * Open the upstream connection and complete the provider handshake.
+   *
+   * Resolves when the provider signals the session is ready to accept
+   * audio/text input. Rejects on timeout, auth failure, or transport error.
+   *
+   * Calling `connect()` on a client that is not `idle` rejects with
+   * `code: 'invalid_state'`.
+   */
+  connect(options: UpstreamConnectOptions): Promise<void>;
+
+  /**
+   * Forward a base64-encoded audio chunk from the user.
+   *
+   * Returns `true` if the chunk was sent, `false` if the socket is not in
+   * the `open` state. Does NOT throw on a closed socket — callers detect
+   * via the return value.
+   */
+  sendAudioChunk(audioB64: string, mimeType?: string): boolean;
+
+  /**
+   * Send a user text turn (alternative to streaming audio for text-only
+   * input). Marks the turn complete by default.
+   *
+   * Returns `true` if sent, `false` if not `open`.
+   */
+  sendTextTurn(text: string, turnComplete?: boolean): boolean;
+
+  /**
+   * Signal end-of-turn after streaming audio. Tells the provider to stop
+   * waiting for more user input and start generating a response.
+   *
+   * Returns `true` if sent, `false` if not `open`.
+   */
+  sendEndOfTurn(): boolean;
+
+  /** Register a handler for audio chunks streamed back from the model. */
+  onAudioOutput(handler: (event: AudioOutputEvent) => void): void;
+
+  /** Register a handler for transcript deltas (input or output). */
+  onTranscript(handler: (event: TranscriptEvent) => void): void;
+
+  /** Register a handler for tool/function-call requests from the model. */
+  onToolCall(handler: (event: ToolCallEvent) => void): void;
+
+  /** Register a handler for turn-complete events. */
+  onTurnComplete(handler: (event: TurnCompleteEvent) => void): void;
+
+  /** Register a handler for model-interrupted events. */
+  onInterrupted(handler: (event: InterruptedEvent) => void): void;
+
+  /** Register a handler for transport / protocol errors. */
+  onError(handler: (event: UpstreamErrorEvent) => void): void;
+
+  /** Register a handler for the (single) connection-close event. */
+  onClose(handler: (event: UpstreamCloseEvent) => void): void;
+
+  /**
+   * Close the upstream connection. Idempotent — calling on a closed client
+   * is a no-op. Emits a final `onClose` event with `initiatedLocally: true`.
+   */
+  close(): Promise<void>;
+
+  /** Current lifecycle state. Always reflects the last transition. */
+  getState(): UpstreamConnectionState;
+}

--- a/services/gateway/src/orb/live/upstream/vertex-live-client.ts
+++ b/services/gateway/src/orb/live/upstream/vertex-live-client.ts
@@ -1,0 +1,467 @@
+/**
+ * A7 (orb-live-refactor / VTID-02956): Vertex AI Live API implementation of
+ * `UpstreamLiveClient`.
+ *
+ * This is the provider-specific seam. Vendor JSON shapes (snake_case
+ * `realtime_input.media_chunks`, `server_content.model_turn.parts[].inline_data`,
+ * etc.) live inside this file and never leak past the interface.
+ *
+ * Behavior parity with the legacy `connectToLiveAPI` in `routes/orb-live.ts`:
+ *   - Connects via `wss://${location}-aiplatform.googleapis.com/ws/google.cloud.aiplatform.v1.LlmBidiService/BidiGenerateContent`.
+ *   - Sends `setup` envelope with model, generation config, VAD config,
+ *     input/output transcription, system instruction, and (optionally) tools.
+ *   - Audio out: `server_content.model_turn.parts[].inline_data` (24kHz PCM b64).
+ *   - Transcripts: `server_content.input_transcription` / `output_transcription`.
+ *   - Tool calls: `tool_call.function_calls[]`.
+ *   - Turn complete: `server_content.turn_complete: true`.
+ *   - Interrupted: `server_content.interrupted: true` (or `grounding_metadata.interrupted`).
+ *   - Audio in: `realtime_input.media_chunks[]` with `mime_type` + base64 `data`.
+ *   - End-of-turn: `client_content.turn_complete: true`.
+ *
+ * What this file does NOT do:
+ *   - Persona/voice swap (session-level concern, stays in orb-live.ts).
+ *   - Watchdog timers (session-level concern).
+ *   - Transcript buffering / OASIS event emission (session-level concern).
+ *   - Identity / memory context build (session-level concern).
+ *
+ * Those orchestration layers consume this client through the
+ * `UpstreamLiveClient` interface in A8/A9.
+ */
+
+import WebSocket from 'ws';
+import type {
+  AudioOutputEvent,
+  InterruptedEvent,
+  ToolCallEvent,
+  TranscriptEvent,
+  TurnCompleteEvent,
+  UpstreamCloseEvent,
+  UpstreamConnectOptions,
+  UpstreamConnectionState,
+  UpstreamErrorEvent,
+  UpstreamLiveClient,
+} from './types';
+import { AUDIO_OUT_RATE_HZ } from '../protocol';
+
+/**
+ * Minimal subset of the `ws` API this client touches. Tests inject a mock
+ * to exercise the message-parsing logic without opening a real socket.
+ */
+export interface VertexWebSocketLike {
+  readyState: number;
+  send(data: string): void;
+  close(code?: number, reason?: string): void;
+  on(event: 'open', listener: () => void): void;
+  on(event: 'message', listener: (data: WebSocket.Data) => void): void;
+  on(event: 'error', listener: (err: Error) => void): void;
+  on(event: 'close', listener: (code: number, reason: Buffer) => void): void;
+}
+
+export interface VertexLiveClientDeps {
+  /**
+   * Factory for the underlying socket. Defaults to opening a real `ws`
+   * connection to the supplied URL with the given Authorization header.
+   * Tests pass a factory returning a mock that mirrors the `VertexWebSocketLike`
+   * surface.
+   */
+  createSocket?: (url: string, headers: Record<string, string>) => VertexWebSocketLike;
+}
+
+const DEFAULT_CONNECT_TIMEOUT_MS = 15_000;
+const DEFAULT_INPUT_MIME = 'audio/pcm;rate=16000';
+const DEFAULT_OUTPUT_MIME = `audio/pcm;rate=${AUDIO_OUT_RATE_HZ}`;
+
+/**
+ * Vertex AI Live API client.
+ *
+ * Construct → register event handlers → `connect()` → audio/text → `close()`.
+ */
+export class VertexLiveClient implements UpstreamLiveClient {
+  private state: UpstreamConnectionState = 'idle';
+  private ws: VertexWebSocketLike | null = null;
+  private readonly createSocket: NonNullable<VertexLiveClientDeps['createSocket']>;
+
+  private audioOutputHandler: ((e: AudioOutputEvent) => void) | null = null;
+  private transcriptHandler: ((e: TranscriptEvent) => void) | null = null;
+  private toolCallHandler: ((e: ToolCallEvent) => void) | null = null;
+  private turnCompleteHandler: ((e: TurnCompleteEvent) => void) | null = null;
+  private interruptedHandler: ((e: InterruptedEvent) => void) | null = null;
+  private errorHandler: ((e: UpstreamErrorEvent) => void) | null = null;
+  private closeHandler: ((e: UpstreamCloseEvent) => void) | null = null;
+
+  private closeEmitted = false;
+  private connectTimeout: NodeJS.Timeout | null = null;
+  private localCloseRequested = false;
+
+  constructor(deps: VertexLiveClientDeps = {}) {
+    this.createSocket =
+      deps.createSocket ??
+      ((url, headers) =>
+        new WebSocket(url, { headers }) as unknown as VertexWebSocketLike);
+  }
+
+  getState(): UpstreamConnectionState {
+    return this.state;
+  }
+
+  onAudioOutput(handler: (event: AudioOutputEvent) => void): void {
+    this.audioOutputHandler = handler;
+  }
+
+  onTranscript(handler: (event: TranscriptEvent) => void): void {
+    this.transcriptHandler = handler;
+  }
+
+  onToolCall(handler: (event: ToolCallEvent) => void): void {
+    this.toolCallHandler = handler;
+  }
+
+  onTurnComplete(handler: (event: TurnCompleteEvent) => void): void {
+    this.turnCompleteHandler = handler;
+  }
+
+  onInterrupted(handler: (event: InterruptedEvent) => void): void {
+    this.interruptedHandler = handler;
+  }
+
+  onError(handler: (event: UpstreamErrorEvent) => void): void {
+    this.errorHandler = handler;
+  }
+
+  onClose(handler: (event: UpstreamCloseEvent) => void): void {
+    this.closeHandler = handler;
+  }
+
+  async connect(options: UpstreamConnectOptions): Promise<void> {
+    if (this.state !== 'idle') {
+      throw new Error(`invalid_state: cannot connect from state '${this.state}'`);
+    }
+
+    this.state = 'connecting';
+
+    const accessToken = await options.getAccessToken();
+    const url = buildBidiGenerateContentUrl(options.location);
+    const ws = this.createSocket(url, {
+      Authorization: `Bearer ${accessToken}`,
+      'Content-Type': 'application/json',
+    });
+    this.ws = ws;
+
+    const timeoutMs = options.connectTimeoutMs ?? DEFAULT_CONNECT_TIMEOUT_MS;
+
+    return new Promise<void>((resolve, reject) => {
+      let settled = false;
+
+      this.connectTimeout = setTimeout(() => {
+        if (settled) return;
+        settled = true;
+        this.transitionToError({
+          code: 'timeout',
+          message: `Live API connection timeout after ${timeoutMs}ms`,
+        });
+        try {
+          ws.close();
+        } catch {
+          /* ignore */
+        }
+        reject(new Error('Live API connection timeout'));
+      }, timeoutMs);
+
+      ws.on('open', () => {
+        try {
+          ws.send(JSON.stringify(buildSetupMessage(options)));
+        } catch (err) {
+          if (settled) return;
+          settled = true;
+          this.clearConnectTimeout();
+          this.transitionToError({
+            code: 'setup_send_failed',
+            message: (err as Error).message,
+            cause: err,
+          });
+          reject(err);
+        }
+      });
+
+      ws.on('message', (data: WebSocket.Data) => {
+        let parsed: any;
+        try {
+          parsed = JSON.parse(data.toString());
+        } catch {
+          // Vertex always sends JSON. Non-JSON is a protocol error we
+          // surface but do not retry on.
+          this.emitError({ code: 'parse_error', message: 'Non-JSON message from upstream' });
+          return;
+        }
+
+        if (parsed.setup_complete || parsed.setupComplete) {
+          if (!settled) {
+            settled = true;
+            this.clearConnectTimeout();
+            this.state = 'open';
+            resolve();
+          }
+          return;
+        }
+
+        // After handshake: dispatch the message to typed handlers.
+        if (this.state === 'open') {
+          this.dispatchServerMessage(parsed);
+        }
+      });
+
+      ws.on('error', (err: Error) => {
+        if (!settled) {
+          settled = true;
+          this.clearConnectTimeout();
+          this.transitionToError({
+            code: 'transport_error',
+            message: err.message,
+            cause: err,
+          });
+          reject(err);
+          return;
+        }
+        this.emitError({
+          code: 'transport_error',
+          message: err.message,
+          cause: err,
+        });
+      });
+
+      ws.on('close', (code: number, reason: Buffer) => {
+        this.handleSocketClose(code, reason);
+        if (!settled) {
+          settled = true;
+          this.clearConnectTimeout();
+          reject(new Error(`Live API closed during handshake (code=${code})`));
+        }
+      });
+    });
+  }
+
+  sendAudioChunk(audioB64: string, mimeType: string = DEFAULT_INPUT_MIME): boolean {
+    if (this.state !== 'open' || !this.ws) return false;
+    if (this.ws.readyState !== WebSocket.OPEN) return false;
+
+    const message = {
+      realtime_input: {
+        media_chunks: [{ mime_type: mimeType, data: audioB64 }],
+      },
+    };
+
+    try {
+      this.ws.send(JSON.stringify(message));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  sendTextTurn(text: string, turnComplete: boolean = true): boolean {
+    if (this.state !== 'open' || !this.ws) return false;
+    if (this.ws.readyState !== WebSocket.OPEN) return false;
+
+    const message = {
+      client_content: {
+        turns: [{ role: 'user', parts: [{ text }] }],
+        turn_complete: turnComplete,
+      },
+    };
+
+    try {
+      this.ws.send(JSON.stringify(message));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  sendEndOfTurn(): boolean {
+    if (this.state !== 'open' || !this.ws) return false;
+    if (this.ws.readyState !== WebSocket.OPEN) return false;
+
+    const message = { client_content: { turn_complete: true } };
+
+    try {
+      this.ws.send(JSON.stringify(message));
+      return true;
+    } catch {
+      return false;
+    }
+  }
+
+  async close(): Promise<void> {
+    if (this.state === 'closed' || this.state === 'closing') return;
+    this.localCloseRequested = true;
+    this.state = 'closing';
+    this.clearConnectTimeout();
+    try {
+      this.ws?.close();
+    } catch {
+      /* ignore */
+    }
+    // The underlying socket's 'close' event triggers final state + onClose.
+    // For mocks that never emit, the caller's test expects the explicit
+    // transition path — handle here as well.
+    if (!this.closeEmitted) {
+      this.finalizeClose({ initiatedLocally: true });
+    }
+  }
+
+  /**
+   * Dispatch a parsed server message to the typed event handlers.
+   *
+   * Vertex emits messages in snake_case AND occasionally camelCase
+   * (depending on SDK path). We accept both spellings for every field.
+   */
+  private dispatchServerMessage(message: any): void {
+    const serverContent = message.server_content || message.serverContent;
+    if (serverContent) {
+      const interrupted =
+        serverContent.interrupted ||
+        serverContent.grounding_metadata?.interrupted ||
+        serverContent.groundingMetadata?.interrupted;
+      if (interrupted) {
+        this.interruptedHandler?.({});
+      }
+
+      // Audio chunks live under model_turn.parts[].inline_data
+      const modelTurn = serverContent.model_turn || serverContent.modelTurn;
+      const parts: any[] = modelTurn?.parts || [];
+      for (const part of parts) {
+        const inlineData = part.inline_data || part.inlineData;
+        if (inlineData?.data) {
+          this.audioOutputHandler?.({
+            dataB64: inlineData.data,
+            mimeType: inlineData.mime_type || inlineData.mimeType || DEFAULT_OUTPUT_MIME,
+          });
+        }
+      }
+
+      const inputTransObj = serverContent.input_transcription || serverContent.inputTranscription;
+      const outputTransObj = serverContent.output_transcription || serverContent.outputTranscription;
+
+      const inputText = typeof inputTransObj === 'string' ? inputTransObj : inputTransObj?.text;
+      const outputText = typeof outputTransObj === 'string' ? outputTransObj : outputTransObj?.text;
+
+      if (inputText) {
+        this.transcriptHandler?.({ direction: 'input', text: inputText });
+      }
+      if (outputText) {
+        this.transcriptHandler?.({ direction: 'output', text: outputText });
+      }
+
+      if (serverContent.turn_complete || serverContent.turnComplete) {
+        this.turnCompleteHandler?.({});
+      }
+    }
+
+    const toolCall = message.tool_call || message.toolCall;
+    if (toolCall) {
+      const fnCalls = toolCall.function_calls || toolCall.functionCalls || [];
+      const calls = fnCalls.map((fc: any) => ({
+        name: fc.name,
+        args: fc.args || {},
+        id: fc.id,
+      }));
+      if (calls.length > 0) {
+        this.toolCallHandler?.({ calls });
+      }
+    }
+  }
+
+  private handleSocketClose(code: number, reason: Buffer): void {
+    if (this.closeEmitted) return;
+    this.finalizeClose({
+      code,
+      reason: reason?.toString?.() || undefined,
+      initiatedLocally: this.localCloseRequested,
+    });
+  }
+
+  private finalizeClose(event: UpstreamCloseEvent): void {
+    this.closeEmitted = true;
+    this.state = 'closed';
+    this.clearConnectTimeout();
+    try {
+      this.closeHandler?.(event);
+    } catch {
+      /* swallow handler exceptions */
+    }
+  }
+
+  private transitionToError(err: UpstreamErrorEvent): void {
+    this.state = 'error';
+    this.emitError(err);
+  }
+
+  private emitError(err: UpstreamErrorEvent): void {
+    try {
+      this.errorHandler?.(err);
+    } catch {
+      /* swallow handler exceptions */
+    }
+  }
+
+  private clearConnectTimeout(): void {
+    if (this.connectTimeout) {
+      clearTimeout(this.connectTimeout);
+      this.connectTimeout = null;
+    }
+  }
+}
+
+/**
+ * Build the Vertex AI Live API WebSocket URL.
+ *
+ * Exposed for tests + direct construction by adapters.
+ */
+export function buildBidiGenerateContentUrl(location: string): string {
+  return `wss://${location}-aiplatform.googleapis.com/ws/google.cloud.aiplatform.v1.LlmBidiService/BidiGenerateContent`;
+}
+
+/**
+ * Build the Vertex `setup` message envelope from connection options.
+ *
+ * Exposed for tests so the snake_case wire format is verifiable without
+ * opening a socket.
+ */
+export function buildSetupMessage(options: UpstreamConnectOptions): Record<string, unknown> {
+  const modalities = options.responseModalities.includes('audio') ? ['AUDIO'] : ['TEXT'];
+
+  const setup: Record<string, unknown> = {
+    model: `projects/${options.projectId}/locations/${options.location}/publishers/google/models/${options.model}`,
+    generation_config: {
+      response_modalities: modalities,
+      speech_config: {
+        voice_config: {
+          prebuilt_voice_config: {
+            voice_name: options.voiceName,
+          },
+        },
+      },
+    },
+    realtime_input_config: {
+      automatic_activity_detection: {
+        silence_duration_ms: options.vadSilenceMs,
+      },
+    },
+    system_instruction: {
+      parts: [{ text: options.systemInstruction }],
+    },
+  };
+
+  if (options.enableInputTranscription !== false) {
+    setup.input_audio_transcription = {};
+  }
+  if (options.enableOutputTranscription !== false) {
+    setup.output_audio_transcription = {};
+  }
+
+  if (options.tools && options.tools.length > 0) {
+    setup.tools = options.tools;
+  }
+
+  return { setup };
+}

--- a/services/gateway/test/orb/live/upstream/vertex-live-client.test.ts
+++ b/services/gateway/test/orb/live/upstream/vertex-live-client.test.ts
@@ -1,0 +1,558 @@
+/**
+ * A7 (VTID-02956): Characterization tests for `VertexLiveClient`.
+ *
+ * Covers the seven boundary behaviors specified for the upstream extraction:
+ *   1. Session connect (URL, headers, setup envelope, resolves on setup_complete)
+ *   2. First audio path (server_content.model_turn.parts[].inline_data → onAudioOutput)
+ *   3. Audio input forwarding (realtime_input.media_chunks wire shape)
+ *   4. Model output events (transcript in/out, turn-complete, interrupted)
+ *   5. Tool-call event forwarding (tool_call.function_calls[] → onToolCall)
+ *   6. Disconnect/error propagation (transport errors, parse errors, premature close)
+ *   7. Close/finalize behavior (idempotent close(), single onClose, no events after close)
+ *
+ * Uses a hand-rolled WebSocket mock — no real network access.
+ */
+
+import {
+  VertexLiveClient,
+  buildBidiGenerateContentUrl,
+  buildSetupMessage,
+  type VertexWebSocketLike,
+} from '../../../../src/orb/live/upstream/vertex-live-client';
+import type { UpstreamConnectOptions } from '../../../../src/orb/live/upstream/types';
+
+// Mirror the value of `WebSocket.OPEN` (1) from the `ws` package so the
+// mock can satisfy the readyState gate.
+const WS_OPEN = 1;
+const WS_CLOSED = 3;
+
+class MockSocket implements VertexWebSocketLike {
+  readyState = WS_OPEN;
+  sent: string[] = [];
+
+  private openListeners: Array<() => void> = [];
+  private messageListeners: Array<(data: any) => void> = [];
+  private errorListeners: Array<(err: Error) => void> = [];
+  private closeListeners: Array<(code: number, reason: Buffer) => void> = [];
+
+  on(event: 'open', listener: () => void): void;
+  on(event: 'message', listener: (data: any) => void): void;
+  on(event: 'error', listener: (err: Error) => void): void;
+  on(event: 'close', listener: (code: number, reason: Buffer) => void): void;
+  on(event: string, listener: (...args: any[]) => void): void {
+    if (event === 'open') this.openListeners.push(listener as () => void);
+    else if (event === 'message') this.messageListeners.push(listener as (d: any) => void);
+    else if (event === 'error') this.errorListeners.push(listener as (e: Error) => void);
+    else if (event === 'close')
+      this.closeListeners.push(listener as (c: number, r: Buffer) => void);
+  }
+
+  send(data: string): void {
+    this.sent.push(data);
+  }
+
+  close(): void {
+    this.readyState = WS_CLOSED;
+  }
+
+  // Test-only triggers.
+  fireOpen(): void {
+    this.openListeners.forEach((l) => l());
+  }
+
+  fireMessage(payload: unknown): void {
+    const str = typeof payload === 'string' ? payload : JSON.stringify(payload);
+    this.messageListeners.forEach((l) => l(Buffer.from(str)));
+  }
+
+  fireError(err: Error): void {
+    this.errorListeners.forEach((l) => l(err));
+  }
+
+  fireClose(code: number = 1000, reason: string = 'normal'): void {
+    this.readyState = WS_CLOSED;
+    this.closeListeners.forEach((l) => l(code, Buffer.from(reason)));
+  }
+}
+
+function baseOptions(overrides: Partial<UpstreamConnectOptions> = {}): UpstreamConnectOptions {
+  return {
+    model: 'gemini-live-2.5-flash-native-audio',
+    projectId: 'lovable-vitana-vers1',
+    location: 'us-central1',
+    voiceName: 'Aoede',
+    responseModalities: ['audio'],
+    vadSilenceMs: 2000,
+    systemInstruction: 'You are Vitana.',
+    getAccessToken: async () => 'test-token',
+    connectTimeoutMs: 1000,
+    ...overrides,
+  };
+}
+
+async function connectClient(
+  client: VertexLiveClient,
+  socket: MockSocket,
+  options: UpstreamConnectOptions = baseOptions(),
+): Promise<void> {
+  const connectPromise = client.connect(options);
+  // Allow the async getAccessToken + factory call to settle.
+  await new Promise((resolve) => setImmediate(resolve));
+  socket.fireOpen();
+  await new Promise((resolve) => setImmediate(resolve));
+  socket.fireMessage({ setup_complete: {} });
+  await connectPromise;
+}
+
+describe('A7 characterization: VertexLiveClient', () => {
+  describe('1. Session connect', () => {
+    it('builds the BidiGenerateContent URL for the given location', () => {
+      expect(buildBidiGenerateContentUrl('us-central1')).toBe(
+        'wss://us-central1-aiplatform.googleapis.com/ws/google.cloud.aiplatform.v1.LlmBidiService/BidiGenerateContent',
+      );
+    });
+
+    it('builds a Vertex setup envelope with snake_case fields + AUDIO modality', () => {
+      const setup = buildSetupMessage(baseOptions()) as any;
+      expect(setup.setup.model).toBe(
+        'projects/lovable-vitana-vers1/locations/us-central1/publishers/google/models/gemini-live-2.5-flash-native-audio',
+      );
+      expect(setup.setup.generation_config.response_modalities).toEqual(['AUDIO']);
+      expect(setup.setup.generation_config.speech_config.voice_config.prebuilt_voice_config.voice_name).toBe(
+        'Aoede',
+      );
+      expect(setup.setup.realtime_input_config.automatic_activity_detection.silence_duration_ms).toBe(
+        2000,
+      );
+      expect(setup.setup.system_instruction.parts[0].text).toBe('You are Vitana.');
+      expect(setup.setup.input_audio_transcription).toEqual({});
+      expect(setup.setup.output_audio_transcription).toEqual({});
+    });
+
+    it('omits transcription envelopes when explicitly disabled', () => {
+      const setup = buildSetupMessage(
+        baseOptions({ enableInputTranscription: false, enableOutputTranscription: false }),
+      ) as any;
+      expect(setup.setup.input_audio_transcription).toBeUndefined();
+      expect(setup.setup.output_audio_transcription).toBeUndefined();
+    });
+
+    it('switches modality to TEXT when responseModalities does not include audio', () => {
+      const setup = buildSetupMessage(baseOptions({ responseModalities: ['text'] })) as any;
+      expect(setup.setup.generation_config.response_modalities).toEqual(['TEXT']);
+    });
+
+    it('passes tools through as-is when supplied', () => {
+      const tools = [{ function_declarations: [{ name: 'navigate_to_screen' }] }];
+      const setup = buildSetupMessage(baseOptions({ tools })) as any;
+      expect(setup.setup.tools).toEqual(tools);
+    });
+
+    it('opens the socket with the Authorization Bearer header from getAccessToken', async () => {
+      const sockets: MockSocket[] = [];
+      const headersCaptured: Array<Record<string, string>> = [];
+      const client = new VertexLiveClient({
+        createSocket: (_url, headers) => {
+          const s = new MockSocket();
+          sockets.push(s);
+          headersCaptured.push(headers);
+          return s;
+        },
+      });
+
+      const connectPromise = client.connect(baseOptions());
+      await new Promise((resolve) => setImmediate(resolve));
+      sockets[0].fireOpen();
+      await new Promise((resolve) => setImmediate(resolve));
+      sockets[0].fireMessage({ setup_complete: {} });
+      await connectPromise;
+
+      expect(headersCaptured[0].Authorization).toBe('Bearer test-token');
+      expect(headersCaptured[0]['Content-Type']).toBe('application/json');
+    });
+
+    it('sends the setup envelope as the first WS frame after `open`', async () => {
+      const socket = new MockSocket();
+      const client = new VertexLiveClient({ createSocket: () => socket });
+      await connectClient(client, socket);
+
+      expect(socket.sent.length).toBeGreaterThanOrEqual(1);
+      const setup = JSON.parse(socket.sent[0]);
+      expect(setup.setup).toBeDefined();
+      expect(setup.setup.model).toContain('gemini-live-2.5-flash-native-audio');
+    });
+
+    it('transitions idle → connecting → open across the handshake', async () => {
+      const socket = new MockSocket();
+      const client = new VertexLiveClient({ createSocket: () => socket });
+
+      expect(client.getState()).toBe('idle');
+      const p = client.connect(baseOptions());
+      // After the async factory dispatch:
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(client.getState()).toBe('connecting');
+
+      socket.fireOpen();
+      await new Promise((resolve) => setImmediate(resolve));
+      socket.fireMessage({ setup_complete: {} });
+      await p;
+      expect(client.getState()).toBe('open');
+    });
+
+    it('rejects a second connect() call', async () => {
+      const socket = new MockSocket();
+      const client = new VertexLiveClient({ createSocket: () => socket });
+      await connectClient(client, socket);
+
+      await expect(client.connect(baseOptions())).rejects.toThrow(/invalid_state/);
+    });
+  });
+
+  describe('2. First audio path', () => {
+    it('emits onAudioOutput for inline_data audio in server_content.model_turn.parts[]', async () => {
+      const socket = new MockSocket();
+      const client = new VertexLiveClient({ createSocket: () => socket });
+      const audioEvents: Array<{ dataB64: string; mimeType: string }> = [];
+      client.onAudioOutput((e) => audioEvents.push(e));
+
+      await connectClient(client, socket);
+
+      socket.fireMessage({
+        server_content: {
+          model_turn: {
+            parts: [{ inline_data: { mime_type: 'audio/pcm;rate=24000', data: 'AAAA' } }],
+          },
+        },
+      });
+
+      expect(audioEvents).toHaveLength(1);
+      expect(audioEvents[0]).toEqual({ dataB64: 'AAAA', mimeType: 'audio/pcm;rate=24000' });
+    });
+
+    it('also accepts camelCase variants (serverContent.modelTurn.parts[].inlineData)', async () => {
+      const socket = new MockSocket();
+      const client = new VertexLiveClient({ createSocket: () => socket });
+      const audioEvents: Array<{ dataB64: string; mimeType: string }> = [];
+      client.onAudioOutput((e) => audioEvents.push(e));
+
+      await connectClient(client, socket);
+
+      socket.fireMessage({
+        serverContent: {
+          modelTurn: {
+            parts: [{ inlineData: { mimeType: 'audio/pcm;rate=24000', data: 'BBBB' } }],
+          },
+        },
+      });
+
+      expect(audioEvents).toHaveLength(1);
+      expect(audioEvents[0].dataB64).toBe('BBBB');
+    });
+  });
+
+  describe('3. Audio input forwarding', () => {
+    it('sendAudioChunk encodes realtime_input.media_chunks with mime + b64 data', async () => {
+      const socket = new MockSocket();
+      const client = new VertexLiveClient({ createSocket: () => socket });
+      await connectClient(client, socket);
+      socket.sent.length = 0; // clear setup
+
+      const result = client.sendAudioChunk('AUDIOB64', 'audio/pcm;rate=16000');
+      expect(result).toBe(true);
+      expect(socket.sent).toHaveLength(1);
+      const parsed = JSON.parse(socket.sent[0]);
+      expect(parsed.realtime_input.media_chunks).toEqual([
+        { mime_type: 'audio/pcm;rate=16000', data: 'AUDIOB64' },
+      ]);
+    });
+
+    it('sendAudioChunk returns false when socket is not open', () => {
+      const socket = new MockSocket();
+      const client = new VertexLiveClient({ createSocket: () => socket });
+      // Never connected.
+      expect(client.sendAudioChunk('AAA')).toBe(false);
+      expect(socket.sent).toHaveLength(0);
+    });
+
+    it('sendEndOfTurn sends client_content.turn_complete: true', async () => {
+      const socket = new MockSocket();
+      const client = new VertexLiveClient({ createSocket: () => socket });
+      await connectClient(client, socket);
+      socket.sent.length = 0;
+
+      expect(client.sendEndOfTurn()).toBe(true);
+      const parsed = JSON.parse(socket.sent[0]);
+      expect(parsed.client_content.turn_complete).toBe(true);
+    });
+
+    it('sendTextTurn wraps text into client_content.turns[].parts[].text with turn_complete=true by default', async () => {
+      const socket = new MockSocket();
+      const client = new VertexLiveClient({ createSocket: () => socket });
+      await connectClient(client, socket);
+      socket.sent.length = 0;
+
+      expect(client.sendTextTurn('hello there')).toBe(true);
+      const parsed = JSON.parse(socket.sent[0]);
+      expect(parsed.client_content.turns).toEqual([
+        { role: 'user', parts: [{ text: 'hello there' }] },
+      ]);
+      expect(parsed.client_content.turn_complete).toBe(true);
+    });
+  });
+
+  describe('4. Model output events (transcript, turn_complete, interrupted)', () => {
+    it('emits onTranscript with direction="input" for input_transcription', async () => {
+      const socket = new MockSocket();
+      const client = new VertexLiveClient({ createSocket: () => socket });
+      const events: Array<{ direction: string; text: string }> = [];
+      client.onTranscript((e) => events.push(e));
+      await connectClient(client, socket);
+
+      socket.fireMessage({
+        server_content: { input_transcription: { text: 'hello vitana' } },
+      });
+      expect(events).toEqual([{ direction: 'input', text: 'hello vitana' }]);
+    });
+
+    it('emits onTranscript with direction="output" for output_transcription', async () => {
+      const socket = new MockSocket();
+      const client = new VertexLiveClient({ createSocket: () => socket });
+      const events: Array<{ direction: string; text: string }> = [];
+      client.onTranscript((e) => events.push(e));
+      await connectClient(client, socket);
+
+      socket.fireMessage({
+        server_content: { output_transcription: { text: 'hi dragan' } },
+      });
+      expect(events).toEqual([{ direction: 'output', text: 'hi dragan' }]);
+    });
+
+    it('accepts transcription as a bare string (legacy shape)', async () => {
+      const socket = new MockSocket();
+      const client = new VertexLiveClient({ createSocket: () => socket });
+      const events: Array<{ direction: string; text: string }> = [];
+      client.onTranscript((e) => events.push(e));
+      await connectClient(client, socket);
+
+      socket.fireMessage({
+        server_content: { input_transcription: 'just words' },
+      });
+      expect(events).toEqual([{ direction: 'input', text: 'just words' }]);
+    });
+
+    it('emits onTurnComplete for server_content.turn_complete=true', async () => {
+      const socket = new MockSocket();
+      const client = new VertexLiveClient({ createSocket: () => socket });
+      let fired = false;
+      client.onTurnComplete(() => {
+        fired = true;
+      });
+      await connectClient(client, socket);
+
+      socket.fireMessage({ server_content: { turn_complete: true } });
+      expect(fired).toBe(true);
+    });
+
+    it('emits onInterrupted for server_content.interrupted=true', async () => {
+      const socket = new MockSocket();
+      const client = new VertexLiveClient({ createSocket: () => socket });
+      let fired = false;
+      client.onInterrupted(() => {
+        fired = true;
+      });
+      await connectClient(client, socket);
+
+      socket.fireMessage({ server_content: { interrupted: true } });
+      expect(fired).toBe(true);
+    });
+  });
+
+  describe('5. Tool-call event forwarding', () => {
+    it('emits onToolCall with parsed calls[] for tool_call.function_calls', async () => {
+      const socket = new MockSocket();
+      const client = new VertexLiveClient({ createSocket: () => socket });
+      const events: Array<{ calls: any[] }> = [];
+      client.onToolCall((e) => events.push(e));
+      await connectClient(client, socket);
+
+      socket.fireMessage({
+        tool_call: {
+          function_calls: [
+            { id: 'call-1', name: 'navigate_to_screen', args: { route: '/diary' } },
+          ],
+        },
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0].calls).toEqual([
+        { name: 'navigate_to_screen', args: { route: '/diary' }, id: 'call-1' },
+      ]);
+    });
+
+    it('also accepts camelCase toolCall.functionCalls', async () => {
+      const socket = new MockSocket();
+      const client = new VertexLiveClient({ createSocket: () => socket });
+      const events: Array<{ calls: any[] }> = [];
+      client.onToolCall((e) => events.push(e));
+      await connectClient(client, socket);
+
+      socket.fireMessage({
+        toolCall: {
+          functionCalls: [{ name: 'save_diary_entry', args: { content: 'hi' } }],
+        },
+      });
+
+      expect(events).toHaveLength(1);
+      expect(events[0].calls[0].name).toBe('save_diary_entry');
+    });
+
+    it('does not emit onToolCall for empty function_calls array', async () => {
+      const socket = new MockSocket();
+      const client = new VertexLiveClient({ createSocket: () => socket });
+      let fired = false;
+      client.onToolCall(() => {
+        fired = true;
+      });
+      await connectClient(client, socket);
+
+      socket.fireMessage({ tool_call: { function_calls: [] } });
+      expect(fired).toBe(false);
+    });
+  });
+
+  describe('6. Disconnect/error propagation', () => {
+    it('connect() rejects on socket error during handshake', async () => {
+      const socket = new MockSocket();
+      const client = new VertexLiveClient({ createSocket: () => socket });
+      const errors: any[] = [];
+      client.onError((e) => errors.push(e));
+
+      const p = client.connect(baseOptions());
+      await new Promise((resolve) => setImmediate(resolve));
+      socket.fireError(new Error('boom'));
+
+      await expect(p).rejects.toThrow('boom');
+      expect(client.getState()).toBe('error');
+      expect(errors).toHaveLength(1);
+      expect(errors[0].code).toBe('transport_error');
+    });
+
+    it('connect() rejects on socket close during handshake', async () => {
+      const socket = new MockSocket();
+      const client = new VertexLiveClient({ createSocket: () => socket });
+
+      const p = client.connect(baseOptions());
+      await new Promise((resolve) => setImmediate(resolve));
+      socket.fireClose(1006, 'abnormal');
+
+      await expect(p).rejects.toThrow(/closed during handshake/);
+    });
+
+    it('connect() rejects on timeout if no setup_complete arrives', async () => {
+      const socket = new MockSocket();
+      const client = new VertexLiveClient({ createSocket: () => socket });
+
+      const p = client.connect(baseOptions({ connectTimeoutMs: 10 }));
+      await new Promise((resolve) => setImmediate(resolve));
+      socket.fireOpen();
+      // Deliberately do not fire setup_complete.
+
+      await expect(p).rejects.toThrow(/timeout/);
+      expect(client.getState()).toBe('error');
+    });
+
+    it('emits onError for post-handshake transport errors (not via reject)', async () => {
+      const socket = new MockSocket();
+      const client = new VertexLiveClient({ createSocket: () => socket });
+      const errors: any[] = [];
+      client.onError((e) => errors.push(e));
+
+      await connectClient(client, socket);
+      socket.fireError(new Error('stream broke'));
+
+      expect(errors).toHaveLength(1);
+      expect(errors[0].code).toBe('transport_error');
+      expect(errors[0].message).toBe('stream broke');
+    });
+
+    it('emits onError with code="parse_error" for non-JSON messages', async () => {
+      const socket = new MockSocket();
+      const client = new VertexLiveClient({ createSocket: () => socket });
+      const errors: any[] = [];
+      client.onError((e) => errors.push(e));
+      await connectClient(client, socket);
+
+      socket.fireMessage('not-json-at-all');
+      expect(errors).toHaveLength(1);
+      expect(errors[0].code).toBe('parse_error');
+    });
+  });
+
+  describe('7. Close/finalize behavior', () => {
+    it('close() transitions to closed and emits onClose exactly once', async () => {
+      const socket = new MockSocket();
+      const client = new VertexLiveClient({ createSocket: () => socket });
+      const closeEvents: any[] = [];
+      client.onClose((e) => closeEvents.push(e));
+      await connectClient(client, socket);
+
+      await client.close();
+      expect(client.getState()).toBe('closed');
+      expect(closeEvents).toHaveLength(1);
+      expect(closeEvents[0].initiatedLocally).toBe(true);
+    });
+
+    it('close() is idempotent', async () => {
+      const socket = new MockSocket();
+      const client = new VertexLiveClient({ createSocket: () => socket });
+      const closeEvents: any[] = [];
+      client.onClose((e) => closeEvents.push(e));
+      await connectClient(client, socket);
+
+      await client.close();
+      await client.close();
+      await client.close();
+      expect(closeEvents).toHaveLength(1);
+    });
+
+    it('remote close emits onClose with initiatedLocally=false', async () => {
+      const socket = new MockSocket();
+      const client = new VertexLiveClient({ createSocket: () => socket });
+      const closeEvents: any[] = [];
+      client.onClose((e) => closeEvents.push(e));
+      await connectClient(client, socket);
+
+      socket.fireClose(1006, 'remote-bye');
+      expect(closeEvents).toHaveLength(1);
+      expect(closeEvents[0].initiatedLocally).toBe(false);
+      expect(closeEvents[0].code).toBe(1006);
+      expect(closeEvents[0].reason).toBe('remote-bye');
+    });
+
+    it('sendAudioChunk returns false after close', async () => {
+      const socket = new MockSocket();
+      const client = new VertexLiveClient({ createSocket: () => socket });
+      await connectClient(client, socket);
+      await client.close();
+
+      expect(client.sendAudioChunk('AAA')).toBe(false);
+    });
+
+    it('does not emit data events after close', async () => {
+      const socket = new MockSocket();
+      const client = new VertexLiveClient({ createSocket: () => socket });
+      const audioEvents: any[] = [];
+      client.onAudioOutput((e) => audioEvents.push(e));
+      await connectClient(client, socket);
+      await client.close();
+
+      // The mock fires after close — implementation must filter.
+      socket.fireMessage({
+        server_content: {
+          model_turn: { parts: [{ inline_data: { data: 'XXX' } }] },
+        },
+      });
+      expect(audioEvents).toHaveLength(0);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Track A / A7 — extract provider-neutral upstream Live client boundary. First step of the LiveKit readiness pivot: orb-live.ts orchestration will talk to `UpstreamLiveClient` instead of WebSocket JSON, so a future LiveKit adapter slots in beside Vertex without touching the assistant intelligence spine.

Behavior is identical. orb-live.ts is unchanged — A8 (session lifecycle) + A9 (transport handlers) will switch the call sites onto the new interface.

## What lands

- **services/gateway/src/orb/live/upstream/types.ts** — UpstreamLiveClient interface (connect / sendAudioChunk / sendTextTurn / sendEndOfTurn / onAudioOutput / onTranscript / onToolCall / onTurnComplete / onInterrupted / onError / onClose / close / getState) + typed event payloads + UpstreamConnectionState state machine.
- **services/gateway/src/orb/live/upstream/vertex-live-client.ts** — Vertex AI Live API implementation. Encapsulates the BidiGenerateContent URL, setup envelope construction, snake/camelCase wire format, and the dispatcher that maps server_content + tool_call payloads to typed events. Mirrors the legacy connectToLiveAPI wire format exactly.
- **services/gateway/test/orb/live/upstream/vertex-live-client.test.ts** — 33 characterization tests using a hand-rolled mock socket, covering the 7 boundary behaviors specified for the A7 lift.

## Acceptance checks

1. Session connect — URL builder, snake_case setup envelope, Authorization Bearer header, idle→connecting→open walk, setup_complete gate, second-connect rejection
2. First audio path — inline_data → onAudioOutput, snake + camelCase variants
3. Audio input forwarding — realtime_input.media_chunks wire shape, sendEndOfTurn, sendTextTurn, returns-false-when-closed
4. Model output events — input + output transcription (object + bare string), turn_complete, interrupted
5. Tool-call forwarding — function_calls / functionCalls, empty-array suppression
6. Disconnect / error propagation — transport error during handshake, socket close during handshake, timeout, post-handshake errors, parse_error on non-JSON
7. Close / finalize — idempotent close, single onClose, remote vs local, no events after close

## What this PR does NOT touch

- routes/orb-live.ts — orchestration stays intact.
- Decision-contract spine, B6/B7, feedback-pipeline, reliability tuning, frontend behavior.

## Test plan

- [x] 33 new tests green (vertex-live-client.test.ts)
- [x] 495 tests green across test/orb/live + test/orb/context + test/orb/instruction (no regression)
- [x] TypeScript clean for A7 files (only pre-existing sharp error on main, unrelated)

🤖 Generated with [Claude Code](https://claude.com/claude-code)