### PR TITLE
feat(orb): A9.1 — extract WebSocket transport boundary (VTID-02957)

### DIFF
--- a/services/gateway/src/orb/live/transport/types.ts
+++ b/services/gateway/src/orb/live/transport/types.ts
@@ -1,0 +1,96 @@
+/**
+ * A9.1 (orb-live-refactor / VTID-02957): transport-neutral handler boundary.
+ *
+ * Each ORB transport (WebSocket today; SSE + REST-stream next in A9.2)
+ * attaches to the shared HTTP server, accepts a client, and forwards each
+ * accepted connection into the per-connection handler that lives in
+ * `routes/orb-live.ts`. Transport modules own ONLY the attach/upgrade and
+ * server-level error glue. Session state, message dispatch, and lifecycle
+ * stay with orb-live.ts and move into `orb/live/session/*` under A8.
+ *
+ * Hard rules:
+ *   1. Transport modules are stateless. No `Map`s of sessions live here.
+ *   2. Wire protocol is byte-for-byte identical to the legacy path —
+ *      same upgrade URL, same JSON envelope, same close codes.
+ *   3. Dependencies are injected via the deps object. Transport modules
+ *      do NOT import session-level helpers (`cleanupWsSession`,
+ *      `liveSessions`, etc.).
+ */
+
+import type { Server as HttpServer, IncomingMessage } from 'http';
+import type WebSocket from 'ws';
+import type { WebSocketServer } from 'ws';
+
+/**
+ * Per-connection handler. Called once per upgraded WebSocket.
+ *
+ * Implementations own the per-connection state machine (auth extraction,
+ * `ws.on('message')` registration, ping interval, close cleanup). The
+ * transport module guarantees only that this function is called for every
+ * new connection and that the (ws, req) tuple is forwarded unchanged.
+ */
+export type OrbWebSocketConnectionHandler = (
+  ws: WebSocket,
+  req: IncomingMessage,
+) => void | Promise<void>;
+
+/**
+ * Dependencies for `mountOrbWebSocketTransport`.
+ *
+ * Typed deps replace the legacy reliance on file-scoped helpers in
+ * `routes/orb-live.ts`. Tests can pass any handler; orb-live.ts injects
+ * the real `handleWebSocketConnection`.
+ */
+export interface OrbWebSocketTransportDeps {
+  /**
+   * Per-connection handler. Receives every upgraded socket + upgrade
+   * request. The transport module does not interpret message frames —
+   * those flow through this handler's own `ws.on('message')`.
+   */
+  handleConnection: OrbWebSocketConnectionHandler;
+
+  /**
+   * Mount path for the WebSocket upgrade. Defaults to the legacy
+   * `/api/v1/orb/live/ws`. Override only for tests or alternate
+   * deployments — production clients connect to the default.
+   */
+  path?: string;
+
+  /**
+   * Server-level error sink. Called when the underlying WebSocketServer
+   * emits an `error` event (distinct from per-connection errors, which
+   * surface inside `handleConnection`). Defaults to `console.error`.
+   */
+  onServerError?: (err: Error) => void;
+}
+
+/**
+ * Handle returned by `mountOrbWebSocketTransport`. Exposes the underlying
+ * server for diagnostics + a tear-down hook. Idempotent.
+ */
+export interface OrbWebSocketTransport {
+  /** The underlying `ws` WebSocketServer. Mainly for tests + diagnostics. */
+  readonly server: WebSocketServer;
+
+  /**
+   * Mount path the transport is listening on (post-default resolution).
+   */
+  readonly path: string;
+
+  /**
+   * Tear down the transport. Closes the WebSocketServer; safe to call
+   * multiple times.
+   */
+  close(): Promise<void>;
+}
+
+/**
+ * Mount the WebSocket transport on the supplied HTTP server. The transport
+ * shares the HTTP listener — no separate port, no separate `listen()`.
+ *
+ * Implementations: `orb/live/transport/websocket-handler.ts`.
+ */
+export type MountOrbWebSocketTransport = (
+  httpServer: HttpServer,
+  deps: OrbWebSocketTransportDeps,
+) => OrbWebSocketTransport;

--- a/services/gateway/src/orb/live/transport/websocket-handler.ts
+++ b/services/gateway/src/orb/live/transport/websocket-handler.ts
@@ -1,0 +1,84 @@
+/**
+ * A9.1 (orb-live-refactor / VTID-02957): WebSocket transport boundary.
+ *
+ * Mounts the ORB WebSocket upgrade endpoint on the shared HTTP server and
+ * forwards each accepted connection to the per-connection handler supplied
+ * by the caller (today: `handleWebSocketConnection` in `routes/orb-live.ts`).
+ *
+ * This module owns ONLY the attach + dispatch glue. It does NOT:
+ *   - Hold per-session state (sessions live in `routes/orb-live.ts`; will move
+ *     to `orb/live/session/*` under A8).
+ *   - Read or write the JSON message envelope (per-connection handler does
+ *     that; transport is wire-protocol-neutral inside the upgrade).
+ *   - Close session-level resources (close handlers in the connection
+ *     handler own those).
+ *
+ * Wire protocol parity with the legacy inline impl in `routes/orb-live.ts`:
+ *   - Mount path: `/api/v1/orb/live/ws`
+ *   - Attached to the existing HTTP listener (no separate port).
+ *   - `connection` and `error` listeners registered on the `WebSocketServer`.
+ */
+
+import type { Server as HttpServer } from 'http';
+import { WebSocketServer } from 'ws';
+import type {
+  OrbWebSocketTransport,
+  OrbWebSocketTransportDeps,
+} from './types';
+
+/**
+ * Canonical mount path. ORB widgets reconnect to this exact URL — never
+ * change without coordinating a v1 release.
+ */
+export const ORB_WS_MOUNT_PATH = '/api/v1/orb/live/ws';
+
+function defaultErrorSink(err: Error): void {
+  console.error('[orb-transport-ws] WebSocketServer error:', err);
+}
+
+/**
+ * Mount the ORB WebSocket transport on the supplied HTTP server.
+ *
+ * Behavior-identical to the legacy inline impl: shared HTTP listener,
+ * same mount path, `connection` + `error` handlers, no separate port.
+ */
+export function mountOrbWebSocketTransport(
+  httpServer: HttpServer,
+  deps: OrbWebSocketTransportDeps,
+): OrbWebSocketTransport {
+  const path = deps.path ?? ORB_WS_MOUNT_PATH;
+  const onServerError = deps.onServerError ?? defaultErrorSink;
+
+  const wss = new WebSocketServer({
+    server: httpServer,
+    path,
+  });
+
+  wss.on('connection', (ws, req) => {
+    // Fire-and-forget: the per-connection handler is async, but errors
+    // it throws are its own to surface (typically through OASIS events
+    // or by closing the socket with an error frame).
+    Promise.resolve(deps.handleConnection(ws, req)).catch((err) => {
+      console.error('[orb-transport-ws] handleConnection threw:', err);
+    });
+  });
+
+  wss.on('error', (err) => {
+    onServerError(err);
+  });
+
+  console.log(`[orb-transport-ws] mounted at ${path}`);
+
+  let closed = false;
+  return {
+    server: wss,
+    path,
+    close: async () => {
+      if (closed) return;
+      closed = true;
+      await new Promise<void>((resolve) => {
+        wss.close(() => resolve());
+      });
+    },
+  };
+}

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1106,6 +1106,11 @@ import { VERTEX_PROJECT_ID, VERTEX_LOCATION } from '../orb/live/config';
 // orb/live/protocol.ts. Same values, same callers; the constants now live
 // in a shared module so A3/A7/A9 don't have to re-declare them.
 import { VERTEX_LIVE_MODEL, VERTEX_TTS_MODEL } from '../orb/live/protocol';
+// A9.1 (orb-live-refactor / VTID-02957): WebSocket transport attach lifted
+// to orb/live/transport/websocket-handler.ts. `initializeOrbWebSocket`
+// below now delegates the WSS construction + connection dispatch to the
+// new module. Wire protocol byte-for-byte identical; mount path unchanged.
+import { mountOrbWebSocketTransport } from '../orb/live/transport/websocket-handler';
 // A3 (orb-live-refactor): system instruction builder + its private helpers
 // (describeTimeSince, describeRoute, buildTemporalJourneyContextSection,
 // TemporalBucket type) lifted to orb/live/instruction/live-system-instruction.ts.
@@ -12914,23 +12919,19 @@ const wsClientSessions = new Map<string, WsClientSession>();
 export function initializeOrbWebSocket(server: HttpServer): void {
   console.log('[VTID-01222] Initializing ORB WebSocket server...');
 
-  // Create WebSocket server attached to HTTP server
-  const wss = new WebSocketServer({
-    server,
-    path: '/api/v1/orb/live/ws'
-  });
-
-  wss.on('connection', (ws: WebSocket, req: IncomingMessage) => {
-    handleWebSocketConnection(ws, req);
-  });
-
-  wss.on('error', (error) => {
-    console.error('[VTID-01222] WebSocket server error:', error);
+  // A9.1 (VTID-02957): WSS attach + connection/error dispatch lifted to
+  // orb/live/transport/websocket-handler.ts. Wire protocol unchanged —
+  // same mount path, same single-port attachment, same handler signature.
+  mountOrbWebSocketTransport(server, {
+    handleConnection: (ws, req) => handleWebSocketConnection(ws, req),
+    onServerError: (err) => console.error('[VTID-01222] WebSocket server error:', err),
   });
 
   console.log('[VTID-01222] ORB WebSocket server initialized at /api/v1/orb/live/ws');
 
-  // Cleanup expired WebSocket sessions every 5 minutes
+  // Cleanup expired WebSocket sessions every 5 minutes.
+  // (Stays here for A9.1 — iterates over session-level state that
+  // moves into orb/live/session/* under A8.)
   setInterval(() => {
     const now = Date.now();
     for (const [sessionId, session] of wsClientSessions.entries()) {

--- a/services/gateway/test/orb/live/characterization/websocket-setup.characterization.test.ts
+++ b/services/gateway/test/orb/live/characterization/websocket-setup.characterization.test.ts
@@ -1,15 +1,15 @@
 /**
- * A0.3 — Characterization test for the WebSocket transport setup.
+ * Originally A0.3 — structural characterization for `initializeOrbWebSocket`
+ * in `routes/orb-live.ts`. Replaced 2026-05-13 (A9.1 / VTID-02957) when the
+ * WSS attach + connection/error dispatch was lifted into
+ * `orb/live/transport/websocket-handler.ts`.
  *
- * Purpose: lock the WebSocket initialization contract — registry, upgrade
- * path, connection + error handler registration — before step A9 splits
- * transport into orb/live/transport/websocket-handler.ts.
+ * Now: structural check that orb-live.ts is a thin delegator over the new
+ * transport module + the per-session registry remains a Map (the cleanup
+ * interval depends on Map iteration semantics).
  *
- * Approach: structural over orb-live.ts, scoped to the
- * `initializeOrbWebSocket` function block only.
- *
- * Will be replaced/augmented by A9 with a runtime test against
- * orb/live/transport/websocket-handler.ts.
+ * Runtime assertions on the transport behavior live in
+ * `test/orb/live/transport/websocket-handler.test.ts`.
  */
 
 import * as fs from 'fs';
@@ -23,9 +23,6 @@ let registryDecl: string;
 beforeAll(() => {
   const source = fs.readFileSync(ORB_LIVE_PATH, 'utf8');
 
-  // Slice the WebSocket setup function. It is the only `export function`
-  // whose name begins with `initializeOrb`, so the next `export function`
-  // (or end-of-file) is a safe terminator.
   const setupStart = source.indexOf('export function initializeOrbWebSocket');
   expect(setupStart).toBeGreaterThan(0);
   const afterStart = source.slice(setupStart + 1);
@@ -34,65 +31,57 @@ beforeAll(() => {
     ? source.slice(setupStart, setupStart + 1 + nextExport)
     : source.slice(setupStart);
 
-  // Find the registry declaration. It is module-level, not inside the
-  // setup function, so we capture it separately.
   const registryStart = source.indexOf('wsClientSessions = new Map');
   expect(registryStart).toBeGreaterThan(0);
-  // Take ~500 chars around the declaration as context.
   registryDecl = source.slice(Math.max(0, registryStart - 100), registryStart + 200);
 });
 
-describe('A0.3 characterization: WebSocket transport setup contract', () => {
-  describe('initializeOrbWebSocket() function', () => {
-    it('is exported (so the gateway entrypoint can wire it)', () => {
-      // Already implied by the slice succeeding, but assert explicitly so
-      // a refactor that drops the export breaks loudly.
-      expect(setupBody).toMatch(/^export\s+function\s+initializeOrbWebSocket/);
-    });
-
-    it('accepts an HttpServer parameter (Express HTTP server instance)', () => {
-      expect(setupBody).toMatch(/initializeOrbWebSocket\s*\(\s*server\s*:\s*HttpServer\s*\)/);
-    });
-
-    it('mounts the WebSocket server at /api/v1/orb/live/ws', () => {
-      // The orb-widget reconnects to this exact path. Any change to the
-      // path breaks every existing client.
-      expect(setupBody).toMatch(
-        /path\s*:\s*['"`]\/api\/v1\/orb\/live\/ws['"`]/
-      );
-    });
-
-    it('attaches the WebSocketServer to the HTTP server (single-port, not separate)', () => {
-      // `server: <param>` in the WebSocketServer options means it shares
-      // the HTTP listener — no separate port, no separate listen() call.
-      // A1+ refactor must preserve the same attachment model.
-      expect(setupBody).toMatch(/new\s+WebSocketServer\s*\(\s*\{[\s\S]*?\bserver\b[\s\S]*?\}\s*\)/);
-    });
-
-    it("registers a 'connection' handler", () => {
-      expect(setupBody).toMatch(/wss\.on\(\s*['"`]connection['"`]\s*,/);
-    });
-
-    it("registers an 'error' handler (server-level error, separate from per-connection errors)", () => {
-      expect(setupBody).toMatch(/wss\.on\(\s*['"`]error['"`]\s*,/);
-    });
+describe('A9.1 characterization: initializeOrbWebSocket delegates to the transport module', () => {
+  it('is exported (so the gateway entrypoint can wire it)', () => {
+    expect(setupBody).toMatch(/^export\s+function\s+initializeOrbWebSocket/);
   });
 
-  describe('per-session registry', () => {
-    it('declares wsClientSessions as a Map', () => {
-      // The Map type matters — the cleanup interval iterates over it.
-      // A switch to a different container (Set, plain object, WeakMap)
-      // would silently break iteration semantics.
-      expect(registryDecl).toMatch(/wsClientSessions\s*=\s*new\s+Map\s*</);
-    });
+  it('accepts an HttpServer parameter (Express HTTP server instance)', () => {
+    expect(setupBody).toMatch(/initializeOrbWebSocket\s*\(\s*server\s*:\s*HttpServer\s*\)/);
   });
 
-  describe('connection handler delegates to handleWebSocketConnection', () => {
-    // The setup function should NOT inline the per-connection logic —
-    // that lives in handleWebSocketConnection, which A9 will move.
-    // Lock the delegation so an inline rewrite doesn't sneak in here.
-    it('forwards the (ws, req) tuple to handleWebSocketConnection', () => {
-      expect(setupBody).toMatch(/handleWebSocketConnection\s*\(\s*ws\s*,\s*req\s*\)/);
-    });
+  it('delegates WSS setup to mountOrbWebSocketTransport', () => {
+    // The body must call mountOrbWebSocketTransport — that is the seam.
+    expect(setupBody).toMatch(/mountOrbWebSocketTransport\s*\(\s*server\s*,/);
+  });
+
+  it('passes a handleConnection wrapper that forwards to handleWebSocketConnection', () => {
+    expect(setupBody).toMatch(
+      /handleConnection\s*:\s*\([^)]*\)\s*=>\s*handleWebSocketConnection\s*\(/,
+    );
+  });
+
+  it('passes an onServerError hook for server-level WebSocket errors', () => {
+    expect(setupBody).toMatch(/onServerError\s*:/);
+  });
+
+  it('does NOT inline `new WebSocketServer(`, `wss.on(`, or a literal mount path', () => {
+    // Anti-regression: the legacy inline impl is what A9.1 lifted out.
+    // If a future refactor re-inlines it here, this test fails loudly.
+    expect(setupBody).not.toMatch(/new\s+WebSocketServer\s*\(/);
+    expect(setupBody).not.toMatch(/wss\.on\(/);
+    expect(setupBody).not.toMatch(/['"`]\/api\/v1\/orb\/live\/ws['"`]/);
+  });
+});
+
+describe('A9.1 characterization: per-session registry remains in orb-live.ts', () => {
+  it('declares wsClientSessions as a Map', () => {
+    // The Map type matters — the cleanup interval iterates over it.
+    // Per-session state moves to orb/live/session/* under A8, NOT A9.1.
+    expect(registryDecl).toMatch(/wsClientSessions\s*=\s*new\s+Map\s*</);
+  });
+});
+
+describe('A9.1 characterization: import wiring', () => {
+  it('imports mountOrbWebSocketTransport from the transport module', () => {
+    const source = fs.readFileSync(ORB_LIVE_PATH, 'utf8');
+    expect(source).toMatch(
+      /import\s*\{\s*mountOrbWebSocketTransport\s*\}\s*from\s*['"`][^'"`]*\/orb\/live\/transport\/websocket-handler['"`]/,
+    );
   });
 });

--- a/services/gateway/test/orb/live/transport/websocket-handler.test.ts
+++ b/services/gateway/test/orb/live/transport/websocket-handler.test.ts
@@ -1,0 +1,211 @@
+/**
+ * A9.1 (orb-live-refactor / VTID-02957): runtime tests for the WebSocket
+ * transport module — `orb/live/transport/websocket-handler.ts`.
+ *
+ * Replaces the inline structural assertions from the prior A0.3 test —
+ * those assertions are now exercised against the real module here.
+ *
+ * Approach: spin up a real HTTP server on an ephemeral port, mount the
+ * transport, and connect a real `ws` client. Every assertion exercises
+ * the actual wire path — same as production.
+ */
+
+import * as http from 'http';
+import { AddressInfo } from 'net';
+import WebSocket from 'ws';
+import { IncomingMessage } from 'http';
+import {
+  mountOrbWebSocketTransport,
+  ORB_WS_MOUNT_PATH,
+} from '../../../../src/orb/live/transport/websocket-handler';
+
+interface FixtureHandle {
+  server: http.Server;
+  url: string;
+  transport: ReturnType<typeof mountOrbWebSocketTransport>;
+  connectionCalls: Array<{ url: string | undefined; headers: http.IncomingHttpHeaders }>;
+  cleanup: () => Promise<void>;
+}
+
+async function startFixture(
+  pathOverride?: string,
+  onServerError?: (err: Error) => void,
+): Promise<FixtureHandle> {
+  const httpServer = http.createServer();
+  await new Promise<void>((resolve) => httpServer.listen(0, '127.0.0.1', resolve));
+  const { port } = httpServer.address() as AddressInfo;
+
+  const connectionCalls: Array<{ url: string | undefined; headers: http.IncomingHttpHeaders }> = [];
+
+  const transport = mountOrbWebSocketTransport(httpServer, {
+    handleConnection: (_ws: WebSocket, req: IncomingMessage) => {
+      connectionCalls.push({ url: req.url, headers: req.headers });
+    },
+    path: pathOverride,
+    onServerError,
+  });
+
+  const url = `ws://127.0.0.1:${port}${transport.path}`;
+
+  return {
+    server: httpServer,
+    url,
+    transport,
+    connectionCalls,
+    cleanup: async () => {
+      await transport.close();
+      await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+    },
+  };
+}
+
+function waitForOpen(ws: WebSocket): Promise<void> {
+  return new Promise((resolve, reject) => {
+    ws.once('open', () => resolve());
+    ws.once('error', (e) => reject(e));
+  });
+}
+
+describe('A9.1: mountOrbWebSocketTransport', () => {
+  it('mounts at the canonical /api/v1/orb/live/ws path by default', () => {
+    expect(ORB_WS_MOUNT_PATH).toBe('/api/v1/orb/live/ws');
+  });
+
+  it('attaches to the supplied HTTP server (single-port, no separate listen)', async () => {
+    const fx = await startFixture();
+    try {
+      const { port } = fx.server.address() as AddressInfo;
+      // The HTTP server's port is the only listener; the WS upgrade
+      // shares it. Connect using that port to prove it.
+      const client = new WebSocket(`ws://127.0.0.1:${port}/api/v1/orb/live/ws`);
+      await waitForOpen(client);
+      expect(client.readyState).toBe(WebSocket.OPEN);
+      client.close();
+    } finally {
+      await fx.cleanup();
+    }
+  });
+
+  it('forwards each accepted connection (ws, req) into handleConnection', async () => {
+    const fx = await startFixture();
+    try {
+      const client = new WebSocket(fx.url, {
+        headers: { 'x-test-header': 'a9.1' },
+      });
+      await waitForOpen(client);
+      // Give the server a tick to dispatch.
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(fx.connectionCalls).toHaveLength(1);
+      expect(fx.connectionCalls[0].url).toBe('/api/v1/orb/live/ws');
+      expect(fx.connectionCalls[0].headers['x-test-header']).toBe('a9.1');
+      client.close();
+    } finally {
+      await fx.cleanup();
+    }
+  });
+
+  it('returns a handle that exposes the underlying WebSocketServer + path', async () => {
+    const fx = await startFixture();
+    try {
+      expect(fx.transport.path).toBe('/api/v1/orb/live/ws');
+      expect(fx.transport.server).toBeDefined();
+      expect(typeof fx.transport.server.on).toBe('function');
+    } finally {
+      await fx.cleanup();
+    }
+  });
+
+  it('honors a path override (test-only / alternate deployments)', async () => {
+    const fx = await startFixture('/test/path/ws');
+    try {
+      expect(fx.transport.path).toBe('/test/path/ws');
+      const { port } = fx.server.address() as AddressInfo;
+      const client = new WebSocket(`ws://127.0.0.1:${port}/test/path/ws`);
+      await waitForOpen(client);
+      expect(client.readyState).toBe(WebSocket.OPEN);
+      client.close();
+    } finally {
+      await fx.cleanup();
+    }
+  });
+
+  it('rejects upgrade requests on other paths (does not bind everything)', async () => {
+    const fx = await startFixture();
+    try {
+      const { port } = fx.server.address() as AddressInfo;
+      const wrongPath = new WebSocket(`ws://127.0.0.1:${port}/some/other/path`);
+      const result = await new Promise<'opened' | 'rejected'>((resolve) => {
+        wrongPath.once('open', () => resolve('opened'));
+        wrongPath.once('unexpected-response', () => resolve('rejected'));
+        wrongPath.once('error', () => resolve('rejected'));
+      });
+      expect(result).toBe('rejected');
+      try {
+        wrongPath.close();
+      } catch {
+        /* already errored */
+      }
+    } finally {
+      await fx.cleanup();
+    }
+  });
+
+  it('allows multiple concurrent connections', async () => {
+    const fx = await startFixture();
+    try {
+      const c1 = new WebSocket(fx.url);
+      const c2 = new WebSocket(fx.url);
+      const c3 = new WebSocket(fx.url);
+      await Promise.all([waitForOpen(c1), waitForOpen(c2), waitForOpen(c3)]);
+      await new Promise((resolve) => setImmediate(resolve));
+      expect(fx.connectionCalls).toHaveLength(3);
+      c1.close();
+      c2.close();
+      c3.close();
+    } finally {
+      await fx.cleanup();
+    }
+  });
+
+  it('async handleConnection rejections are caught (do not crash the process)', async () => {
+    const httpServer = http.createServer();
+    await new Promise<void>((resolve) => httpServer.listen(0, '127.0.0.1', resolve));
+    const { port } = httpServer.address() as AddressInfo;
+
+    const errorSpy = jest.spyOn(console, 'error').mockImplementation(() => {});
+    const transport = mountOrbWebSocketTransport(httpServer, {
+      handleConnection: async () => {
+        throw new Error('boom from handler');
+      },
+    });
+
+    try {
+      const client = new WebSocket(`ws://127.0.0.1:${port}${transport.path}`);
+      await waitForOpen(client);
+      await new Promise((resolve) => setImmediate(resolve));
+      // Give the rejection a microtask to surface.
+      await new Promise((resolve) => setImmediate(resolve));
+      const sawHandlerError = errorSpy.mock.calls.some(
+        (c) =>
+          typeof c[0] === 'string' &&
+          c[0].includes('handleConnection threw') &&
+          c[1] instanceof Error &&
+          (c[1] as Error).message === 'boom from handler',
+      );
+      expect(sawHandlerError).toBe(true);
+      client.close();
+    } finally {
+      errorSpy.mockRestore();
+      await transport.close();
+      await new Promise<void>((resolve) => httpServer.close(() => resolve()));
+    }
+  });
+
+  it('close() is idempotent', async () => {
+    const fx = await startFixture();
+    await fx.transport.close();
+    await fx.transport.close();
+    await fx.transport.close();
+    await new Promise<void>((resolve) => fx.server.close(() => resolve()));
+  });
+});


### PR DESCRIPTION
## Summary

Track A / A9.1 — extract the WebSocket transport boundary. orb-live.ts's `initializeOrbWebSocket` becomes a thin delegator over a new transport-neutral module. The seam is what LiveKit + future transports attach to — no LiveKit code here yet.

Wire protocol byte-for-byte identical. Same mount path, same JSON envelope, same close codes. Frontend ORB contract unchanged.

## What lands

- **services/gateway/src/orb/live/transport/types.ts** — transport-neutral handler interface (`OrbWebSocketConnectionHandler`, `OrbWebSocketTransportDeps`, `OrbWebSocketTransport`, `MountOrbWebSocketTransport`). Each transport owns ONLY attach/upgrade + server-level error glue — no session state, no message dispatch.
- **services/gateway/src/orb/live/transport/websocket-handler.ts** — `mountOrbWebSocketTransport(httpServer, deps)` implementation. Behavior identical to the legacy inline impl: same mount path (`/api/v1/orb/live/ws`), shared HTTP listener, `connection` + `error` handlers, no separate port. Exports `ORB_WS_MOUNT_PATH` + a tear-down hook.
- **routes/orb-live.ts** — `initializeOrbWebSocket` now delegates to `mountOrbWebSocketTransport`. Injects `handleWebSocketConnection` as the per-connection handler. Cleanup interval over `wsClientSessions` STAYS in orb-live.ts — session-lifecycle = A8.
- **test/orb/live/characterization/websocket-setup.characterization.test.ts** — structural assertions updated to follow the seam (delegation pattern + anti-regression on the legacy inline shape).
- **test/orb/live/transport/websocket-handler.test.ts** — 9 new runtime tests against the real module with a real HTTP server + real `ws` client.

## Acceptance checks (A9.1 spec)

1. ✅ Existing WebSocket structural characterization tests remain green (8 updated to follow the seam).
2. ✅ Extracted handler receives typed dependencies (`OrbWebSocketTransportDeps`), not raw global state.
3. ✅ Wire events + message shapes byte-for-byte compatible (same mount path, same JSON envelope; per-connection handler unchanged).
4. ✅ Error/close behavior preserved (`onServerError` hook, idempotent `close()`).
5. ✅ No contextual-intelligence changes.
6. ✅ No R-lane tuning.
7. ✅ orb-live.ts shrinks AND becomes a thin delegator for the WS attach path (the body of `initializeOrbWebSocket` no longer contains `new WebSocketServer`, `wss.on(...)`, or the literal mount path).
8. ⏳ Production /orb/chat smoke after deploy.

## What this PR does NOT touch

- `handleWebSocketConnection` body — A8 (session lifecycle).
- `wsClientSessions` Map / `cleanupWsSession` — A8.
- SSE / REST-stream paths — A9.2.
- Decision-contract spine, B6/B7, frontend behavior, reliability tuning.

## Test plan

- [x] 9 new runtime tests on `mountOrbWebSocketTransport` (with real HTTP + ws client)
- [x] 8 updated structural tests on `initializeOrbWebSocket` (delegation pattern)
- [x] 504 tests green across `test/orb/**` (no regression)
- [x] TypeScript clean for A9.1 files (pre-existing `sharp` error on main, unrelated)
- [ ] Post-merge: EXEC-DEPLOY + /orb/chat production smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)