### PR TITLE
fix(voice-improve): zombie filter + autonomous-heal wins panel (VTID-02953, DEV-COMHU-02953, PR-K)

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -41423,7 +41423,20 @@ function renderVoiceImproveView() {
 
     items.forEach(function (it) {
         var card = document.createElement('section');
-        var sevColor = it.severity === 'critical' ? '#dc2626' : it.severity === 'warning' ? '#f59e0b' : '#3b82f6';
+        // VTID-02953 (PR-K): self_healing_win gets a distinct green visual so
+        // autonomous fixes are recognizably WINS, not yet-another-info-item.
+        var isWin = it.source === 'self_healing_win';
+        var sevColor = isWin
+            ? '#16a34a'
+            : it.severity === 'critical' ? '#dc2626'
+            : it.severity === 'warning' ? '#f59e0b'
+            : '#3b82f6';
+        var badgeRgb = isWin
+            ? '22,163,74'
+            : it.severity === 'critical' ? '220,38,38'
+            : it.severity === 'warning' ? '245,158,11'
+            : '59,130,246';
+        var badgeLabel = isWin ? 'HEALED' : it.severity;
         card.style.cssText = 'margin-bottom:0.5rem;padding:0.85rem 1rem;background:var(--color-surface);border:1px solid var(--color-border);border-left:4px solid ' + sevColor + ';border-radius:6px;';
         if (vi.busyRowId === it.id) card.style.opacity = '0.55';
 
@@ -41432,7 +41445,7 @@ function renderVoiceImproveView() {
 
         var titleBlock = document.createElement('div');
         titleBlock.style.cssText = 'flex:1;';
-        var sevBadge = '<span style="display:inline-block;font-size:0.6rem;font-weight:600;padding:0.1rem 0.35rem;border-radius:4px;color:' + sevColor + ';background:rgba(' + (it.severity === 'critical' ? '220,38,38' : it.severity === 'warning' ? '245,158,11' : '59,130,246') + ',0.12);text-transform:uppercase;margin-right:0.4rem;">' + it.severity + '</span>';
+        var sevBadge = '<span style="display:inline-block;font-size:0.6rem;font-weight:600;padding:0.1rem 0.35rem;border-radius:4px;color:' + sevColor + ';background:rgba(' + badgeRgb + ',0.12);text-transform:uppercase;margin-right:0.4rem;">' + badgeLabel + '</span>';
         titleBlock.innerHTML =
             '<div style="font-weight:600;font-size:0.9rem;">' + sevBadge + escapeHtml(it.title) + '</div>'
             + '<div style="font-size:0.78rem;color:var(--color-text-secondary);margin-top:0.15rem;">' + escapeHtml(it.description || '') + '</div>';

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -30,7 +30,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260504-vtid-02710-ios-ctx-keepalive"></script>
-  <script src="/command-hub/app.js?v=20260513-vtid-02937-journey-stage"></script>
+  <script src="/command-hub/app.js?v=20260513-vtid-02953-pr-k-cockpit"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
 </body>

--- a/services/gateway/src/services/voice-improvement-aggregator.ts
+++ b/services/gateway/src/services/voice-improvement-aggregator.ts
@@ -26,9 +26,35 @@ import {
 } from './awareness-watchdogs';
 import { getManifest as getAwarenessManifest } from './awareness-registry';
 import { IMPLEMENTED_TTS_PROVIDERS, IMPLEMENTED_STT_PROVIDERS } from './voice-config';
+import { ENDPOINT_FILE_MAP } from '../types/self-healing';
 
 const ITEM_LOOKBACK_HOURS = 24;
 const MAX_ITEMS_DEFAULT = 20;
+
+// VTID-02953 (PR-K): zombie filter for the Improve cockpit.
+// Escalations against endpoints that are no longer registered (route retired
+// in a PR, e.g. PR-I deleted /api/v1/self-healing/canary/failing-health) show
+// up as `route_not_registered` forever and pollute the actionable queue.
+// Skip them: the underlying endpoint is gone, so manual investigation is
+// pointless. Real route_not_registered escalations (against endpoints still
+// in ENDPOINT_FILE_MAP) still surface — the deletion is the legitimate fix.
+export function isZombieEscalation(endpoint: string, failureClass: string | null): boolean {
+  if (failureClass === 'route_not_registered' && !ENDPOINT_FILE_MAP[endpoint]) {
+    return true;
+  }
+  // dev_autopilot_safety_gate_blocked against synthetic autopilot.* endpoints
+  // (not real route paths) — these are dev-autopilot finding artifacts that
+  // tend to accumulate when the safety gate refuses a bridge. They have no
+  // route to fix; surface them via the dev-autopilot recommendations panel
+  // instead, not the self-healing escalation list.
+  if (
+    failureClass === 'dev_autopilot_safety_gate_blocked' &&
+    endpoint.startsWith('autopilot.')
+  ) {
+    return true;
+  }
+  return false;
+}
 
 export type ActionSeverity = 'critical' | 'warning' | 'info';
 
@@ -39,6 +65,7 @@ export type ActionSource =
   | 'watchdog_unknown'
   | 'awareness_not_wired'
   | 'self_healing_escalation'
+  | 'self_healing_win' // VTID-02953 (PR-K): positive surface for completed autonomous self-heals
   | 'autopilot_recommendation'
   | 'provider_drift'
   | 'failure_class_no_rule';
@@ -339,28 +366,104 @@ async function fetchRecentEscalations(cfg: SupabaseConfig): Promise<ActionItem[]
       created_at: string;
       diagnosis: any;
     }>;
+    return rows
+      // VTID-02953 (PR-K): drop zombie escalations against retired endpoints
+      // and dev_autopilot finding noise — those endpoints aren't actionable
+      // from this surface.
+      .filter((row) => !isZombieEscalation(row.endpoint, row.failure_class))
+      .map((row) => {
+        const reason = row.diagnosis?.reason ?? row.diagnosis?.tombstone_reason ?? row.outcome;
+        return {
+          id: `self_healing_escalation:${row.vtid}`,
+          source: 'self_healing_escalation' as const,
+          severity: (row.outcome === 'rolled_back' ? 'critical' : 'warning') as ActionSeverity,
+          title: `Self-healing ${row.outcome}: ${row.endpoint}`,
+          description: `VTID ${row.vtid} (${row.failure_class ?? 'unknown class'}) — ${reason}.`,
+          evidence: [
+            { kind: 'vtid', ref: row.vtid },
+            { kind: 'endpoint', ref: row.endpoint },
+            { kind: 'failure_class', ref: row.failure_class ?? '(none)' },
+          ],
+          affected_sessions: null,
+          affected_cohort: null,
+          likely_owner: 'self-healing',
+          source_files: [],
+          confidence: 0.8,
+          recommended_action: 'Endpoint requires manual investigation.',
+          available_actions: ['investigate', 'open_in_self_healing'],
+          source_ref: { table: 'self_healing_log', id: row.vtid },
+          detected_at: row.created_at,
+        };
+      });
+  } catch {
+    return [];
+  }
+}
+
+// ---------------------------------------------------------------------------
+// Source 5b (VTID-02953 / PR-K): self_healing_log — recent wins (last 24h)
+//
+// Surfaces autonomous self-heals that reached outcome='fixed' so the cockpit
+// reflects what actually worked, not just what's still on fire. Joins
+// vtid_ledger to pull the autopilot PR url + merged sha for evidence.
+// ---------------------------------------------------------------------------
+interface SelfHealWinRow {
+  vtid: string;
+  endpoint: string;
+  failure_class: string | null;
+  outcome: string;
+  resolved_at: string | null;
+  created_at: string;
+}
+
+async function fetchRecentSelfHeals(cfg: SupabaseConfig): Promise<ActionItem[]> {
+  try {
+    const since = new Date(Date.now() - ITEM_LOOKBACK_HOURS * 3600_000).toISOString();
+    const r = await fetch(
+      `${cfg.url}/rest/v1/self_healing_log?outcome=eq.fixed&created_at=gte.${encodeURIComponent(since)}&select=vtid,endpoint,failure_class,outcome,resolved_at,created_at&order=created_at.desc&limit=50`,
+      { headers: authHeaders(cfg) },
+    );
+    if (!r.ok) return [];
+    const rows = (await r.json()) as SelfHealWinRow[];
+    if (rows.length === 0) return [];
+    // Pull PR url + merged sha from vtid_ledger.metadata for evidence.
+    const vtidList = rows.map((row) => row.vtid).join(',');
+    const ledgerResp = await fetch(
+      `${cfg.url}/rest/v1/vtid_ledger?vtid=in.(${vtidList})&select=vtid,metadata`,
+      { headers: authHeaders(cfg) },
+    );
+    const ledgerRows = ledgerResp.ok
+      ? ((await ledgerResp.json()) as Array<{ vtid: string; metadata: any }>)
+      : [];
+    const metaByVtid = new Map<string, any>();
+    for (const l of ledgerRows) metaByVtid.set(l.vtid, l.metadata || {});
     return rows.map((row) => {
-      const reason = row.diagnosis?.reason ?? row.diagnosis?.tombstone_reason ?? row.outcome;
+      const meta = metaByVtid.get(row.vtid) || {};
+      const prUrl = (meta.pr_url ?? meta.autopilot_pr_url ?? null) as string | null;
+      const prNumber = (meta.pr_number ?? null) as number | null;
+      const evidence: ActionItem['evidence'] = [
+        { kind: 'vtid', ref: row.vtid },
+        { kind: 'endpoint', ref: row.endpoint },
+        { kind: 'failure_class', ref: row.failure_class ?? '(none)' },
+      ];
+      if (prUrl) evidence.push({ kind: 'pr', ref: prUrl });
+      const prSuffix = prNumber ? ` (PR #${prNumber})` : '';
       return {
-        id: `self_healing_escalation:${row.vtid}`,
-        source: 'self_healing_escalation' as const,
-        severity: (row.outcome === 'rolled_back' ? 'critical' : 'warning') as ActionSeverity,
-        title: `Self-healing ${row.outcome}: ${row.endpoint}`,
-        description: `VTID ${row.vtid} (${row.failure_class ?? 'unknown class'}) — ${reason}.`,
-        evidence: [
-          { kind: 'vtid', ref: row.vtid },
-          { kind: 'endpoint', ref: row.endpoint },
-          { kind: 'failure_class', ref: row.failure_class ?? '(none)' },
-        ],
+        id: `self_healing_win:${row.vtid}`,
+        source: 'self_healing_win' as const,
+        severity: 'info' as ActionSeverity,
+        title: `Self-healed: ${row.endpoint}${prSuffix}`,
+        description: `VTID ${row.vtid} (${row.failure_class ?? 'unknown class'}) — autonomous fix landed${prUrl ? ` via ${prUrl}` : ''}.`,
+        evidence,
         affected_sessions: null,
         affected_cohort: null,
         likely_owner: 'self-healing',
         source_files: [],
-        confidence: 0.8,
-        recommended_action: 'Endpoint requires manual investigation.',
-        available_actions: ['investigate', 'open_in_self_healing'],
+        confidence: 1.0,
+        recommended_action: 'Recently completed — no action needed.',
+        available_actions: ['investigate'],
         source_ref: { table: 'self_healing_log', id: row.vtid },
-        detected_at: row.created_at,
+        detected_at: row.resolved_at || row.created_at,
       };
     });
   } catch {
@@ -611,6 +714,7 @@ export async function buildVoiceImprovementBriefing(opts?: { max?: number }): Pr
     watchdogIssues,
     notWired,
     escalations,
+    selfHealWins,
     autopilot,
     providerDrift,
     classesNoRule,
@@ -621,6 +725,7 @@ export async function buildVoiceImprovementBriefing(opts?: { max?: number }): Pr
     fetchWatchdogIssues(cfg),
     Promise.resolve(fetchAwarenessNotWired()),
     fetchRecentEscalations(cfg),
+    fetchRecentSelfHeals(cfg), // VTID-02953 (PR-K): positive surface
     fetchAutopilotVoiceFindings(cfg),
     fetchProviderDrift(cfg),
     fetchFailureClassesNoRule(cfg),
@@ -633,6 +738,7 @@ export async function buildVoiceImprovementBriefing(opts?: { max?: number }): Pr
     ...watchdogIssues,
     ...notWired,
     ...escalations,
+    ...selfHealWins,
     ...autopilot,
     ...providerDrift,
     ...classesNoRule,

--- a/services/gateway/test/services/voice-improvement-aggregator.test.ts
+++ b/services/gateway/test/services/voice-improvement-aggregator.test.ts
@@ -8,6 +8,7 @@ import {
   composeQualityScore,
   sortActionItems,
   dedupeActionItems,
+  isZombieEscalation,
   type ActionItem,
 } from '../../src/services/voice-improvement-aggregator';
 
@@ -124,5 +125,47 @@ describe('dedupeActionItems', () => {
 
   it('returns empty array for empty input', () => {
     expect(dedupeActionItems([])).toEqual([]);
+  });
+});
+
+// VTID-02953 (PR-K): zombie-filter unit tests.
+describe('isZombieEscalation', () => {
+  it('marks route_not_registered against a retired endpoint as zombie', () => {
+    // PR-I deleted /api/v1/self-healing/canary/failing-health — escalations
+    // against it from before that deletion are zombies (endpoint cannot be
+    // investigated; it no longer exists).
+    expect(
+      isZombieEscalation('/api/v1/self-healing/canary/failing-health', 'route_not_registered'),
+    ).toBe(true);
+  });
+
+  it('does NOT mark route_not_registered against a currently-registered endpoint as zombie', () => {
+    // The new canary IS in ENDPOINT_FILE_MAP — a real route_not_registered
+    // here would be a genuine deploy regression and must surface.
+    expect(
+      isZombieEscalation('/api/v1/canary-target/health', 'route_not_registered'),
+    ).toBe(false);
+  });
+
+  it('marks dev_autopilot_safety_gate_blocked against synthetic autopilot.* endpoints as zombie', () => {
+    expect(isZombieEscalation('autopilot.approve_safety', 'dev_autopilot_safety_gate_blocked')).toBe(true);
+  });
+
+  it('does NOT mark dev_autopilot_safety_gate_blocked against a real route as zombie', () => {
+    expect(
+      isZombieEscalation('/api/v1/canary-target/health', 'dev_autopilot_safety_gate_blocked'),
+    ).toBe(false);
+  });
+
+  it('does NOT mark handler_crash escalations as zombie even on retired endpoints', () => {
+    // Other failure classes must keep showing — they may reference real
+    // bugs even if the specific endpoint moved.
+    expect(
+      isZombieEscalation('/api/v1/self-healing/canary/failing-health', 'handler_crash'),
+    ).toBe(false);
+  });
+
+  it('does NOT mark null failure_class as zombie (preserve everything we cannot categorize)', () => {
+    expect(isZombieEscalation('/api/v1/self-healing/canary/failing-health', null)).toBe(false);
   });
 });


### PR DESCRIPTION
## Summary

The Improve cockpit was showing **stale escalations from before PR-I as if they were today's todo list**, while completely hiding today's successful autonomous self-heal (VTID-02951 / PR #2076). User correctly called this out: a lot of work done, no visible progress in the surface they actually look at.

PR-K fixes both.

### What's wrong now

Looking at `self_healing_log` in last 24h (10 escalated rows):
- 5 × `route_not_registered` against `/api/v1/self-healing/canary/failing-health` — **PR-I deleted that endpoint**. Zombies.
- 5 × `dev_autopilot_safety_gate_blocked` against synthetic `autopilot.*` endpoints — dev-autopilot finding artifacts; no route to fix.
- 0 visible mentions of VTID-02951 (today's autonomous heal that produced PR #2076, merged + deployed; armed `/health` now returns `{ok:true,degraded:true,fault_class:'CANARY_ARMED',...}`).

### What changes

1. **`isZombieEscalation()` filter in `fetchRecentEscalations`:**
   - Drops `route_not_registered` escalations whose endpoint isn't in `ENDPOINT_FILE_MAP` (route retired in a PR — the deletion IS the fix).
   - Drops `dev_autopilot_safety_gate_blocked` against synthetic `autopilot.*` endpoints.
   - Real `route_not_registered` regressions (against endpoints still in the map) keep surfacing.

2. **New `fetchRecentSelfHeals` source:**
   - Reads `self_healing_log` where `outcome='fixed'` in last 24h.
   - Joins `vtid_ledger` to pull PR url + number for evidence chips.
   - Emits `ActionItem` with `source='self_healing_win'`, `severity='info'`.

3. **Frontend renders `self_healing_win` distinctly:**
   - Green `#16a34a` left border + green badge labeled `HEALED` instead of the generic blue `INFO`.
   - Same card layout, evidence chips include the PR url.

4. **History stays accurate.** Tried backfilling stale rows to `outcome='superseded'` but `self_healing_log.valid_outcome` CHECK rejects anything outside `pending/fixed/escalated/rolled_back/recovered_externally`. Code-level filter is the right answer — auto-corrects for future zombies without lying about history.

## Test plan

- [x] `test/services/voice-improvement-aggregator.test.ts` — 16/16 (10 existing pure-helper + 6 new `isZombieEscalation` cases)
- [x] `npm run build` clean (only pre-existing unrelated `sharp` error)
- [ ] After merge + EXEC-DEPLOY: open `/command-hub/voice/improve/` — the 10 stale escalations should be gone; VTID-02951 should appear with green HEALED badge.

🤖 Generated with [Claude Code](https://claude.com/claude-code)