### PR TITLE
feat(orb): A9.2 — extract SSE transport boundary (VTID-02958)

### DIFF
--- a/services/gateway/src/orb/live/transport/sse-handler.ts
+++ b/services/gateway/src/orb/live/transport/sse-handler.ts
@@ -1,0 +1,151 @@
+/**
+ * A9.2 (orb-live-refactor / VTID-02958): SSE transport boundary.
+ *
+ * Pure helpers for the Server-Sent Events transport used by the ORB voice
+ * pipeline. Two SSE upgrade points exist in `routes/orb-live.ts` today
+ * (`GET /orb/live` legacy + `GET /orb/live/stream` current). Both share
+ * the same wire format: a four-header upgrade + `data: ${JSON}\n\n`
+ * events + a 10 s data heartbeat.
+ *
+ * This module owns ONLY the transport mechanics. It does NOT:
+ *   - Reach into session state (`liveSessions`, `session.sseResponse = res`
+ *     assignment, transcript buffers, etc.). Those stay in orb-live.ts and
+ *     move under A8 (session lifecycle controller).
+ *   - Build payloads. Callers decide which events to send; this module just
+ *     encodes + writes them.
+ *   - Know about Live API connection state, context-pack rebuilds, or
+ *     greeting policy.
+ *
+ * Wire protocol parity with the legacy inline impl:
+ *   - 4 SSE headers: `Content-Type: text/event-stream`,
+ *     `Cache-Control: no-cache`, `Connection: keep-alive`,
+ *     `X-Accel-Buffering: no`. Plus `flushHeaders()`.
+ *   - Events: `data: ${JSON.stringify(payload)}\n\n`.
+ *   - Heartbeat: `{ type: 'heartbeat', ts: <ms> }` every 10 s (data event,
+ *     NOT an SSE comment — comments don't trigger EventSource.onmessage,
+ *     which is the legacy `[VTID-HEARTBEAT-FIX]` reason).
+ *   - No retry hint, no event name (only `data:`), no id.
+ */
+
+import type {
+  SseEventPayload,
+  SseHeartbeatHandle,
+  SseHeartbeatOptions,
+  SseResponseLike,
+} from './types';
+
+/**
+ * Canonical SSE upgrade headers. Exported as a frozen array so tests can
+ * assert on the exact set + value pairs without relying on the helper
+ * having been called.
+ */
+export const SSE_HEADERS: ReadonlyArray<readonly [string, string]> = Object.freeze([
+  ['Content-Type', 'text/event-stream'],
+  ['Cache-Control', 'no-cache'],
+  ['Connection', 'keep-alive'],
+  ['X-Accel-Buffering', 'no'],
+] as const);
+
+/** Default heartbeat interval — matches the legacy `[VTID-HEARTBEAT-FIX]`. */
+export const SSE_DEFAULT_HEARTBEAT_MS = 10_000;
+
+/**
+ * Apply the canonical SSE upgrade headers + flush. After this returns the
+ * response is in streaming-SSE mode and the first `data:` frame may be
+ * written.
+ *
+ * Idempotent header writes: if `setHeader` is called twice with the same
+ * key Express overwrites silently — no-op for the caller.
+ *
+ * Does NOT write a status code: SSE responses are always `200 OK`, which
+ * is the Express default. Calling `res.status(...)` before this is the
+ * caller's choice (e.g., the legacy handlers return `403`/`404` BEFORE
+ * upgrading; only `200` reaches this function).
+ */
+export function attachSseHeaders(res: SseResponseLike): void {
+  for (const [name, value] of SSE_HEADERS) {
+    res.setHeader(name, value);
+  }
+  res.flushHeaders?.();
+}
+
+/**
+ * Encode an SSE event payload into the wire format.
+ *
+ * Format: `data: ${JSON.stringify(payload)}\n\n` — exactly what the
+ * legacy inline writes use.
+ */
+export function encodeSseEvent(payload: SseEventPayload): string {
+  return `data: ${JSON.stringify(payload)}\n\n`;
+}
+
+/**
+ * Safely write an SSE event. Returns true if the frame was queued for the
+ * socket, false if the socket is already closed or `res.write` threw.
+ *
+ * Mirrors the legacy `try { sse.write(...) } catch { /* SSE closed *\/ }`
+ * pattern that appears ~25× in `routes/orb-live.ts`.
+ */
+export function writeSseEvent(res: SseResponseLike, payload: SseEventPayload): boolean {
+  if (res.writableEnded) return false;
+  try {
+    return res.write(encodeSseEvent(payload));
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Start the data-message heartbeat on an SSE response.
+ *
+ * The heartbeat is a real `data:` event (NOT an SSE `:` comment) so the
+ * client's EventSource.onmessage fires and resets its watchdog. The
+ * legacy code at line ~12086 of `routes/orb-live.ts` documents WHY:
+ * a comment-style keepalive keeps the HTTP connection alive but does
+ * NOT reset the client watchdog, so the user-visible "No response from
+ * server" disconnects continued.
+ *
+ * The handle's `clear()` is idempotent. The interval auto-clears the
+ * first time `writeSseEvent` returns false (i.e., the socket is gone),
+ * matching the legacy `clearInterval(...)` in the catch arm.
+ */
+export function startSseHeartbeat(
+  res: SseResponseLike,
+  options: SseHeartbeatOptions = {},
+): SseHeartbeatHandle {
+  const intervalMs = options.intervalMs ?? SSE_DEFAULT_HEARTBEAT_MS;
+  const type = options.type ?? 'heartbeat';
+  const extend = options.extend;
+
+  let cleared = false;
+  const timer = setInterval(() => {
+    const base: SseEventPayload = { type, ts: Date.now() };
+    const payload: SseEventPayload = extend ? { ...base, ...extend() } : base;
+    const ok = writeSseEvent(res, payload);
+    if (!ok) {
+      // Match legacy behavior: stop heartbeating the moment the
+      // socket is gone. The caller's `req.on('close', ...)` may also
+      // call `clear()` — both paths converge.
+      cleared = true;
+      clearInterval(timer);
+    }
+  }, intervalMs);
+
+  // Don't keep the process alive just for heartbeats — matches the
+  // implicit Node default for setInterval inside an HTTP request
+  // handler, but be explicit so tests that exit early don't hang.
+  if (typeof (timer as any).unref === 'function') {
+    (timer as any).unref();
+  }
+
+  return {
+    clear: () => {
+      if (cleared) return;
+      cleared = true;
+      clearInterval(timer);
+    },
+    get active() {
+      return !cleared;
+    },
+  };
+}

--- a/services/gateway/src/orb/live/transport/types.ts
+++ b/services/gateway/src/orb/live/transport/types.ts
@@ -94,3 +94,63 @@ export type MountOrbWebSocketTransport = (
   httpServer: HttpServer,
   deps: OrbWebSocketTransportDeps,
 ) => OrbWebSocketTransport;
+
+// =============================================================================
+// A9.2 (orb-live-refactor / VTID-02958): SSE transport
+// =============================================================================
+
+/**
+ * Minimal Express-Response surface the SSE helpers touch. Declared instead of
+ * importing the full `express` type so the transport module compiles in
+ * test contexts that mock Response without dragging in the express type
+ * graph.
+ *
+ * `setHeader` / `write` / `flushHeaders` mirror the real Response shape.
+ * `writableEnded` is consulted to short-circuit writes after the client
+ * disconnected — Express' Response inherits that from ServerResponse.
+ */
+export interface SseResponseLike {
+  setHeader(name: string, value: string): void;
+  write(chunk: string): boolean;
+  flushHeaders?: () => void;
+  writableEnded?: boolean;
+}
+
+/**
+ * SSE event payload. Sent as `data: ${JSON.stringify(payload)}\n\n`.
+ *
+ * The ORB protocol uses a flat envelope with `type` discriminator —
+ * `{ type: 'ready' | 'heartbeat' | 'audio' | 'transcript' | ... }`.
+ * Transport modules do not interpret `type`; the per-route handler in
+ * orb-live.ts (and later orb/live/session/*) decides which to send.
+ */
+export type SseEventPayload = Record<string, unknown>;
+
+/**
+ * Handle returned by `startSseHeartbeat`. Idempotent — calling `clear()`
+ * more than once is a no-op.
+ */
+export interface SseHeartbeatHandle {
+  /** Clear the heartbeat interval. Safe to call multiple times. */
+  clear(): void;
+  /** Whether the heartbeat is still ticking. */
+  readonly active: boolean;
+}
+
+/**
+ * Options for `startSseHeartbeat`. The default interval (10 000 ms) matches
+ * the legacy `[VTID-HEARTBEAT-FIX]` cadence — change it on a per-call
+ * basis only.
+ */
+export interface SseHeartbeatOptions {
+  /** Heartbeat interval in ms. Default: 10 000. */
+  intervalMs?: number;
+  /** Event type discriminator. Default: `'heartbeat'`. */
+  type?: string;
+  /**
+   * Optional payload extender. Called each tick to merge additional
+   * fields into the heartbeat event (e.g., a sequence counter).
+   * The default heartbeat sends `{ type, ts: Date.now() }`.
+   */
+  extend?: () => SseEventPayload;
+}

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1111,6 +1111,20 @@ import { VERTEX_LIVE_MODEL, VERTEX_TTS_MODEL } from '../orb/live/protocol';
 // below now delegates the WSS construction + connection dispatch to the
 // new module. Wire protocol byte-for-byte identical; mount path unchanged.
 import { mountOrbWebSocketTransport } from '../orb/live/transport/websocket-handler';
+// A9.2 (orb-live-refactor / VTID-02958): SSE transport helpers lifted to
+// orb/live/transport/sse-handler.ts. The two SSE upgrade points below
+// (`GET /orb/live`, `GET /orb/live/stream`) call attachSseHeaders +
+// writeSseEvent + startSseHeartbeat. Wire format byte-for-byte identical:
+// 4 SSE headers + flushHeaders, `data: ${JSON}\n\n` events, 10 s data
+// heartbeat (NOT an SSE comment — that's the legacy [VTID-HEARTBEAT-FIX]).
+// Session-lifecycle (session.sseResponse = res, context-pack rebuild,
+// upstream WS connect, transcript extract on disconnect) stays here and
+// moves under A8.
+import {
+  attachSseHeaders,
+  writeSseEvent,
+  startSseHeartbeat,
+} from '../orb/live/transport/sse-handler';
 // A3 (orb-live-refactor): system instruction builder + its private helpers
 // (describeTimeSince, describeRoute, buildTemporalJourneyContextSection,
 // TemporalBucket type) lifted to orb/live/instruction/live-system-instruction.ts.
@@ -8574,12 +8588,9 @@ router.get('/live', (req: Request, res: Response) => {
     return res.status(404).json({ ok: false, error: 'Session not found' });
   }
 
-  // Setup SSE
-  res.setHeader('Content-Type', 'text/event-stream');
-  res.setHeader('Cache-Control', 'no-cache');
-  res.setHeader('Connection', 'keep-alive');
-  res.setHeader('X-Accel-Buffering', 'no');
-  res.flushHeaders();
+  // A9.2 (VTID-02958): SSE upgrade lifted to orb/live/transport/sse-handler.ts.
+  // Same 4 headers + flushHeaders + ready event + 10 s data heartbeat.
+  attachSseHeaders(res);
 
   // Track connection
   incrementConnection(clientIP);
@@ -8587,22 +8598,16 @@ router.get('/live', (req: Request, res: Response) => {
   session.lastActivity = new Date();
 
   // Send ready event
-  res.write(`data: ${JSON.stringify({ type: 'ready', meta: { model: GEMINI_MODEL } })}\n\n`);
+  writeSseEvent(res, { type: 'ready', meta: { model: GEMINI_MODEL } });
 
-  // VTID-HEARTBEAT-FIX: Send actual data heartbeats (not SSE comments) so client
-  // watchdog resets properly. SSE comments don't trigger EventSource.onmessage.
-  const heartbeatInterval = setInterval(() => {
-    try {
-      res.write(`data: ${JSON.stringify({ type: 'heartbeat', ts: Date.now() })}\n\n`);
-    } catch (e) {
-      clearInterval(heartbeatInterval);
-    }
-  }, 10000);
+  // VTID-HEARTBEAT-FIX: data-message heartbeat (NOT an SSE comment) so
+  // client EventSource.onmessage fires and resets its watchdog.
+  const heartbeat = startSseHeartbeat(res);
 
   // Handle client disconnect
   req.on('close', () => {
     console.log(`[ORB-LIVE] SSE connection closed for session: ${sessionId}`);
-    clearInterval(heartbeatInterval);
+    heartbeat.clear();
     decrementConnection(clientIP);
     if (session.sseResponse === res) {
       session.sseResponse = null;
@@ -11875,12 +11880,10 @@ router.get('/live/stream', optionalAuth, async (req: AuthenticatedRequest, res: 
     return res.status(429).json({ ok: false, error: 'Too many connections' });
   }
 
-  // Setup SSE
-  res.setHeader('Content-Type', 'text/event-stream');
-  res.setHeader('Cache-Control', 'no-cache');
-  res.setHeader('Connection', 'keep-alive');
-  res.setHeader('X-Accel-Buffering', 'no');
-  res.flushHeaders();
+  // A9.2 (VTID-02958): SSE upgrade lifted to orb/live/transport/sse-handler.ts.
+  // Same 4 SSE headers + flushHeaders. Session-lifecycle assignment of
+  // session.sseResponse stays here (A8 territory).
+  attachSseHeaders(res);
 
   // Track connection
   incrementConnection(clientIP);
@@ -11921,7 +11924,7 @@ router.get('/live/stream', optionalAuth, async (req: AuthenticatedRequest, res: 
 
   // VTID-INSTANT-FEEDBACK: Send ready event IMMEDIATELY so client transitions UI
   // and can play the activation chime before Live API connects.
-  res.write(`data: ${JSON.stringify({
+  writeSseEvent(res, {
     type: 'ready',
     session_id: sessionId,
     live_api_connected: false, // Live API connects in parallel
@@ -11930,9 +11933,9 @@ router.get('/live/stream', optionalAuth, async (req: AuthenticatedRequest, res: 
       lang: session.lang,
       voice: LIVE_API_VOICES[session.lang] || LIVE_API_VOICES['en'] || getVoiceForLang(session.lang),
       audio_out_rate: 24000,
-      audio_in_rate: 16000
-    }
-  })}\n\n`);
+      audio_in_rate: 16000,
+    },
+  });
 
   // VTID-01219: Connect to Vertex AI Live API WebSocket IN PARALLEL (non-blocking).
   // The ready event is already sent so the client gets instant visual + audio feedback
@@ -12075,24 +12078,16 @@ router.get('/live/stream', optionalAuth, async (req: AuthenticatedRequest, res: 
     });
   }
 
-  // VTID-HEARTBEAT-FIX: Send actual data heartbeats, not SSE comments.
-  // SSE comments (`:heartbeat`) keep the HTTP connection alive but do NOT trigger
-  // EventSource.onmessage on the client. The client watchdog only resets on
-  // onmessage events, so after the greeting turn_complete, if the user doesn't
-  // speak for 12s the watchdog fires → "No response from server" → disconnect.
-  // Sending { type: 'heartbeat' } as a data message fixes this.
-  const heartbeatInterval = setInterval(() => {
-    try {
-      res.write(`data: ${JSON.stringify({ type: 'heartbeat', ts: Date.now() })}\n\n`);
-    } catch (e) {
-      clearInterval(heartbeatInterval);
-    }
-  }, 10000);
+  // VTID-HEARTBEAT-FIX: 10 s data-message heartbeat (NOT an SSE comment) so
+  // client EventSource.onmessage fires and resets its watchdog. A9.2 lifted
+  // the implementation into orb/live/transport/sse-handler.ts; same cadence,
+  // same payload shape, same auto-clear-on-write-failure behavior.
+  const heartbeat = startSseHeartbeat(res);
 
   // Handle client disconnect
   req.on('close', () => {
     console.log(`[VTID-01155] Live stream disconnected: ${sessionId}`);
-    clearInterval(heartbeatInterval);
+    heartbeat.clear();
     decrementConnection(clientIP);
     if (session.sseResponse === res) {
       session.sseResponse = null;

--- a/services/gateway/test/orb/live/characterization/sse-stream.characterization.test.ts
+++ b/services/gateway/test/orb/live/characterization/sse-stream.characterization.test.ts
@@ -1,21 +1,15 @@
 /**
- * A0.3 — Characterization test for the /live/stream SSE transport contract.
+ * Originally A0.3 — structural characterization for the `/live/stream` SSE
+ * handler in `routes/orb-live.ts`. Replaced 2026-05-13 (A9.2 / VTID-02958)
+ * when the SSE upgrade headers, event encoding, and heartbeat were lifted
+ * into `orb/live/transport/sse-handler.ts`.
  *
- * Purpose: lock the SSE wire format the orb client depends on, before
- * step A9 splits transport into orb/live/transport/sse-handler.ts.
+ * Now: structural check that orb-live.ts is a thin delegator over the new
+ * SSE transport helpers + the wire-format invariants the orb-widget
+ * depends on (event names + payload fields) still live in the handler.
  *
- * Approach: structural over orb-live.ts source. The handler is too coupled
- * with Express + Vertex Live API + audio streaming to runtime-mock cleanly
- * in a tests-only PR. Per the plan's strict rule, A0 freezes the unchanged
- * file; runtime transport tests come in A9.
- *
- * Scope: assertions are made against the SSE-handler block only (sliced
- * from `router.get('/live/stream'` to the next route registration), not
- * file-wide grep, so unrelated SSE writes elsewhere in orb-live.ts can't
- * accidentally satisfy them.
- *
- * Will be replaced/augmented by A9 with a runtime test against
- * orb/live/transport/sse-handler.ts.
+ * Runtime assertions on the transport behavior live in
+ * `test/orb/live/transport/sse-handler.test.ts`.
  */
 
 import * as fs from 'fs';
@@ -36,137 +30,96 @@ beforeAll(() => {
   handlerBody = source.slice(startIdx, stopIdx);
 });
 
-describe('A0.3 characterization: /live/stream SSE transport contract', () => {
-  describe('response headers (SSE handshake)', () => {
-    // The orb-widget polls the stream and expects an EventSource-shaped
-    // connection. These three headers are the contract.
-    it('sets Content-Type: text/event-stream', () => {
-      expect(handlerBody).toMatch(
-        /res\.setHeader\(\s*['"`]Content-Type['"`]\s*,\s*['"`]text\/event-stream['"`]\s*\)/
-      );
-    });
-
-    it('sets Cache-Control: no-cache', () => {
-      expect(handlerBody).toMatch(
-        /res\.setHeader\(\s*['"`]Cache-Control['"`]\s*,\s*['"`]no-cache['"`]\s*\)/
-      );
-    });
-
-    it('sets Connection: keep-alive', () => {
-      expect(handlerBody).toMatch(
-        /res\.setHeader\(\s*['"`]Connection['"`]\s*,\s*['"`]keep-alive['"`]\s*\)/
-      );
-    });
+describe('A9.2 characterization: /live/stream delegates SSE setup to the transport module', () => {
+  it('calls attachSseHeaders(res) for the SSE upgrade', () => {
+    // A9.2: 4-header upgrade + flushHeaders lifted to sse-handler.ts.
+    expect(handlerBody).toMatch(/\battachSseHeaders\s*\(\s*res\s*\)/);
   });
 
-  describe('SSE wire framing', () => {
-    // Every event the SSE handler emits must use `data: ${json}\n\n` —
-    // EventSource only parses that exact format. Any drift breaks the
-    // browser's parsing.
-    //
-    // Approach: locate every `res.write(` call site in the handler. Look
-    // at the chars immediately after the opening paren — they must begin
-    // with a string/template literal whose first content is `data: `. We
-    // do NOT try to capture the full multi-line template body (some are
-    // 10+ lines with nested ${...} expressions); we only assert the
-    // prefix anchor, which is the SSE-framing contract.
-    it('every res.write in this handler starts with the "data: " SSE prefix', () => {
-      const writeRe = /res\.write\s*\(\s*/g;
-      const startPositions: number[] = [];
-      let m: RegExpExecArray | null;
-      while ((m = writeRe.exec(handlerBody)) !== null) {
-        startPositions.push(m.index + m[0].length);
-      }
-      expect(startPositions.length).toBeGreaterThan(0);
-
-      for (const pos of startPositions) {
-        const window = handlerBody.slice(pos, pos + 40);
-        if (!/^[`'"]\s*data:\s/.test(window)) {
-          throw new Error(
-            `Non-SSE res.write inside /live/stream handler — every event must start with 'data: ' (SSE wire prefix).\nWindow: ${JSON.stringify(window)}`
-          );
-        }
-      }
-    });
-
-    it('every SSE event payload terminates with \\n\\n (or its escaped form)', () => {
-      // EventSource requires the double-newline terminator to dispatch the
-      // event. Coarse contract: at least one terminator per res.write
-      // call in the handler. Parsing each multi-line template's tail
-      // exactly is fragile across formatter changes; this is the cheaper
-      // anchor that still flags a missing terminator.
-      const writeCount = (handlerBody.match(/res\.write\s*\(/g) ?? []).length;
-      expect(writeCount).toBeGreaterThan(0);
-
-      const literalTerminators = (handlerBody.match(/\n\n/g) ?? []).length;
-      const escapedTerminators = (handlerBody.match(/\\n\\n/g) ?? []).length;
-      expect(literalTerminators + escapedTerminators).toBeGreaterThanOrEqual(writeCount);
-    });
+  it('does NOT inline raw res.setHeader calls for the SSE headers', () => {
+    // Anti-regression: the legacy inline pattern is what A9.2 lifted out.
+    expect(handlerBody).not.toMatch(
+      /res\.setHeader\(\s*['"`]Content-Type['"`]\s*,\s*['"`]text\/event-stream['"`]\s*\)/,
+    );
+    expect(handlerBody).not.toMatch(
+      /res\.setHeader\(\s*['"`]Cache-Control['"`]\s*,\s*['"`]no-cache['"`]\s*\)/,
+    );
+    expect(handlerBody).not.toMatch(
+      /res\.setHeader\(\s*['"`]Connection['"`]\s*,\s*['"`]keep-alive['"`]\s*\)/,
+    );
+    // X-Accel-Buffering was the 4th legacy inline header.
+    expect(handlerBody).not.toMatch(
+      /res\.setHeader\(\s*['"`]X-Accel-Buffering['"`]\s*,/,
+    );
   });
 
-  describe('initial "ready" event payload', () => {
-    // VTID-INSTANT-FEEDBACK: the client transitions UI and plays the
-    // activation chime as soon as it receives this event. The four meta
-    // fields below are read by the widget; dropping any of them breaks
-    // chime timing or audio init.
-    it('emits an event with type: "ready"', () => {
-      expect(handlerBody).toMatch(/type\s*:\s*['"`]ready['"`]/);
-    });
-
-    it('includes session_id in the ready payload', () => {
-      expect(handlerBody).toMatch(/session_id\s*:/);
-    });
-
-    it('includes live_api_connected boolean in the ready payload', () => {
-      expect(handlerBody).toMatch(/live_api_connected\s*:/);
-    });
-
-    it('includes meta.model in the ready payload', () => {
-      expect(handlerBody).toMatch(/\bmodel\s*:/);
-    });
-
-    it('includes meta.lang in the ready payload', () => {
-      expect(handlerBody).toMatch(/\blang\s*:/);
-    });
-
-    it('includes meta.voice in the ready payload', () => {
-      expect(handlerBody).toMatch(/\bvoice\s*:/);
-    });
-
-    it('declares audio_out_rate (server → client TTS sample rate)', () => {
-      expect(handlerBody).toMatch(/audio_out_rate\s*:\s*\d+/);
-    });
-
-    it('declares audio_in_rate (client → server mic sample rate)', () => {
-      expect(handlerBody).toMatch(/audio_in_rate\s*:\s*\d+/);
-    });
+  it('starts the heartbeat through startSseHeartbeat (NOT setInterval)', () => {
+    expect(handlerBody).toMatch(/\bstartSseHeartbeat\s*\(\s*res\s*\)/);
+    // Anti-regression: no inline setInterval inside this handler.
+    expect(handlerBody).not.toMatch(/setInterval\s*\(/);
   });
 
-  describe('heartbeat event', () => {
-    // The client uses heartbeat events to detect connection death. Without
-    // them, an idle session looks alive even when the upstream Live API
-    // socket has dropped. The framing must match the wire-framing rule
-    // above so EventSource fires its message handler.
-    it('emits a heartbeat event with a timestamp', () => {
-      expect(handlerBody).toMatch(/type\s*:\s*['"`]heartbeat['"`]/);
-      // Timestamp surface — currently `ts: Date.now()`, but lock only the
-      // field name so a future ISO-string switch wouldn't false-fail.
-      expect(handlerBody).toMatch(/\bts\s*:/);
-    });
+  it('writes the ready event through writeSseEvent (NOT raw res.write)', () => {
+    expect(handlerBody).toMatch(/\bwriteSseEvent\s*\(\s*res\s*,/);
+  });
+});
+
+describe('A9.2 characterization: ready event payload contract (unchanged)', () => {
+  // The orb-widget reads these exact field names from the first SSE event.
+  // The fields are now passed as an object literal into writeSseEvent —
+  // the field names themselves remain the contract.
+  it('emits an event with type: "ready"', () => {
+    expect(handlerBody).toMatch(/type\s*:\s*['"`]ready['"`]/);
   });
 
-  describe('session id parameter', () => {
-    it('reads session_id from query string', () => {
-      expect(handlerBody).toMatch(/req\.query\.session_id/);
-    });
+  it('includes session_id in the ready payload', () => {
+    expect(handlerBody).toMatch(/session_id\s*:/);
+  });
 
-    it('rejects request with 400 when session_id is missing', () => {
-      // The handler returns res.status(400) when sessionId is falsy.
-      // Lock the response shape — the orb-widget treats a 4xx differently
-      // from a transport disconnect, and "session_id required" is the
-      // contract.
-      expect(handlerBody).toMatch(/status\(\s*400\s*\)/);
-      expect(handlerBody).toMatch(/session_id\s+required/);
-    });
+  it('includes live_api_connected boolean in the ready payload', () => {
+    expect(handlerBody).toMatch(/live_api_connected\s*:/);
+  });
+
+  it('includes meta.model in the ready payload', () => {
+    expect(handlerBody).toMatch(/\bmodel\s*:/);
+  });
+
+  it('includes meta.lang in the ready payload', () => {
+    expect(handlerBody).toMatch(/\blang\s*:/);
+  });
+
+  it('includes meta.voice in the ready payload', () => {
+    expect(handlerBody).toMatch(/\bvoice\s*:/);
+  });
+
+  it('declares audio_out_rate (server → client TTS sample rate)', () => {
+    expect(handlerBody).toMatch(/audio_out_rate\s*:\s*\d+/);
+  });
+
+  it('declares audio_in_rate (client → server mic sample rate)', () => {
+    expect(handlerBody).toMatch(/audio_in_rate\s*:\s*\d+/);
+  });
+});
+
+describe('A9.2 characterization: session id parameter (unchanged)', () => {
+  it('reads session_id from query string', () => {
+    expect(handlerBody).toMatch(/req\.query\.session_id/);
+  });
+
+  it('rejects request with 400 when session_id is missing', () => {
+    expect(handlerBody).toMatch(/status\(\s*400\s*\)/);
+    expect(handlerBody).toMatch(/session_id\s+required/);
+  });
+});
+
+describe('A9.2 characterization: import wiring', () => {
+  it('imports the SSE helpers from the transport module', () => {
+    const source = fs.readFileSync(ORB_LIVE_PATH, 'utf8');
+    expect(source).toMatch(
+      /from\s*['"`][^'"`]*\/orb\/live\/transport\/sse-handler['"`]/,
+    );
+    expect(source).toMatch(/\battachSseHeaders\b/);
+    expect(source).toMatch(/\bwriteSseEvent\b/);
+    expect(source).toMatch(/\bstartSseHeartbeat\b/);
   });
 });

--- a/services/gateway/test/orb/live/transport/sse-handler.test.ts
+++ b/services/gateway/test/orb/live/transport/sse-handler.test.ts
@@ -1,0 +1,249 @@
+/**
+ * A9.2 (orb-live-refactor / VTID-02958): runtime tests for the SSE transport
+ * helpers — `orb/live/transport/sse-handler.ts`.
+ *
+ * Covers the legacy wire format byte-for-byte:
+ *   - 4 SSE upgrade headers
+ *   - `data: ${JSON.stringify(payload)}\n\n` event encoding
+ *   - 10 s data heartbeat (NOT an SSE `:` comment)
+ *   - Safe-write swallows errors / closed sockets
+ *   - Heartbeat clear() is idempotent
+ *   - Heartbeat auto-clears on write failure (matches legacy catch arm)
+ */
+
+import {
+  SSE_HEADERS,
+  SSE_DEFAULT_HEARTBEAT_MS,
+  attachSseHeaders,
+  encodeSseEvent,
+  writeSseEvent,
+  startSseHeartbeat,
+} from '../../../../src/orb/live/transport/sse-handler';
+import type { SseResponseLike } from '../../../../src/orb/live/transport/types';
+
+function makeMockRes(opts: {
+  flushHeaders?: boolean;
+  throwOnWrite?: boolean;
+  writableEnded?: boolean;
+} = {}): SseResponseLike & {
+  headers: Record<string, string>;
+  writes: string[];
+  flushedHeaders: number;
+} {
+  const headers: Record<string, string> = {};
+  const writes: string[] = [];
+  let flushedHeaders = 0;
+
+  return {
+    headers,
+    writes,
+    get flushedHeaders() {
+      return flushedHeaders;
+    },
+    writableEnded: opts.writableEnded === true,
+    setHeader(name: string, value: string) {
+      headers[name] = value;
+    },
+    write(chunk: string): boolean {
+      if (opts.throwOnWrite) {
+        throw new Error('socket closed');
+      }
+      writes.push(chunk);
+      return true;
+    },
+    flushHeaders: opts.flushHeaders === false ? undefined : () => {
+      flushedHeaders++;
+    },
+  };
+}
+
+describe('A9.2: SSE transport helpers', () => {
+  describe('SSE_HEADERS constant', () => {
+    it('declares the 4 canonical SSE upgrade headers in order', () => {
+      expect(SSE_HEADERS).toEqual([
+        ['Content-Type', 'text/event-stream'],
+        ['Cache-Control', 'no-cache'],
+        ['Connection', 'keep-alive'],
+        ['X-Accel-Buffering', 'no'],
+      ]);
+    });
+
+    it('is frozen (anti-mutation)', () => {
+      expect(Object.isFrozen(SSE_HEADERS)).toBe(true);
+    });
+  });
+
+  describe('SSE_DEFAULT_HEARTBEAT_MS', () => {
+    it('matches the legacy 10s cadence', () => {
+      expect(SSE_DEFAULT_HEARTBEAT_MS).toBe(10_000);
+    });
+  });
+
+  describe('attachSseHeaders', () => {
+    it('sets the 4 SSE headers and calls flushHeaders', () => {
+      const res = makeMockRes();
+      attachSseHeaders(res);
+      expect(res.headers['Content-Type']).toBe('text/event-stream');
+      expect(res.headers['Cache-Control']).toBe('no-cache');
+      expect(res.headers['Connection']).toBe('keep-alive');
+      expect(res.headers['X-Accel-Buffering']).toBe('no');
+      expect(res.flushedHeaders).toBe(1);
+    });
+
+    it('is a no-op when flushHeaders is missing (some Response shims)', () => {
+      const res = makeMockRes({ flushHeaders: false });
+      expect(() => attachSseHeaders(res)).not.toThrow();
+      expect(res.headers['Content-Type']).toBe('text/event-stream');
+    });
+
+    it('does not write to the body during header attach', () => {
+      const res = makeMockRes();
+      attachSseHeaders(res);
+      expect(res.writes).toHaveLength(0);
+    });
+  });
+
+  describe('encodeSseEvent', () => {
+    it('encodes a payload as `data: ${json}\\n\\n`', () => {
+      expect(encodeSseEvent({ type: 'ready' })).toBe('data: {"type":"ready"}\n\n');
+    });
+
+    it('preserves nested objects + arrays', () => {
+      const payload = { type: 'ready', meta: { model: 'gemini', items: [1, 2] } };
+      expect(encodeSseEvent(payload)).toBe(
+        'data: {"type":"ready","meta":{"model":"gemini","items":[1,2]}}\n\n',
+      );
+    });
+
+    it('matches the heartbeat payload format used by the legacy handlers', () => {
+      const out = encodeSseEvent({ type: 'heartbeat', ts: 1234567890 });
+      expect(out).toBe('data: {"type":"heartbeat","ts":1234567890}\n\n');
+    });
+  });
+
+  describe('writeSseEvent', () => {
+    it('writes the encoded event to the response', () => {
+      const res = makeMockRes();
+      const ok = writeSseEvent(res, { type: 'ready' });
+      expect(ok).toBe(true);
+      expect(res.writes).toEqual(['data: {"type":"ready"}\n\n']);
+    });
+
+    it('returns false (without throwing) when the socket is already ended', () => {
+      const res = makeMockRes({ writableEnded: true });
+      const ok = writeSseEvent(res, { type: 'ready' });
+      expect(ok).toBe(false);
+      expect(res.writes).toHaveLength(0);
+    });
+
+    it('returns false (without throwing) when res.write throws', () => {
+      const res = makeMockRes({ throwOnWrite: true });
+      const ok = writeSseEvent(res, { type: 'audio' });
+      expect(ok).toBe(false);
+    });
+  });
+
+  describe('startSseHeartbeat', () => {
+    beforeEach(() => {
+      jest.useFakeTimers();
+    });
+    afterEach(() => {
+      jest.useRealTimers();
+    });
+
+    it('ticks every 10s by default with { type: "heartbeat", ts }', () => {
+      const res = makeMockRes();
+      const h = startSseHeartbeat(res);
+      try {
+        expect(res.writes).toHaveLength(0);
+        jest.advanceTimersByTime(10_000);
+        expect(res.writes).toHaveLength(1);
+        const parsed = JSON.parse(res.writes[0].replace(/^data: /, '').trim());
+        expect(parsed.type).toBe('heartbeat');
+        expect(typeof parsed.ts).toBe('number');
+
+        jest.advanceTimersByTime(10_000);
+        expect(res.writes).toHaveLength(2);
+      } finally {
+        h.clear();
+      }
+    });
+
+    it('honors a custom intervalMs', () => {
+      const res = makeMockRes();
+      const h = startSseHeartbeat(res, { intervalMs: 1_000 });
+      try {
+        jest.advanceTimersByTime(2_500);
+        expect(res.writes).toHaveLength(2);
+      } finally {
+        h.clear();
+      }
+    });
+
+    it('honors a custom type label', () => {
+      const res = makeMockRes();
+      const h = startSseHeartbeat(res, { type: 'keepalive' });
+      try {
+        jest.advanceTimersByTime(10_000);
+        const parsed = JSON.parse(res.writes[0].replace(/^data: /, '').trim());
+        expect(parsed.type).toBe('keepalive');
+      } finally {
+        h.clear();
+      }
+    });
+
+    it('merges extend() output into each heartbeat payload', () => {
+      const res = makeMockRes();
+      let counter = 0;
+      const h = startSseHeartbeat(res, { extend: () => ({ seq: ++counter }) });
+      try {
+        jest.advanceTimersByTime(20_000);
+        const p1 = JSON.parse(res.writes[0].replace(/^data: /, '').trim());
+        const p2 = JSON.parse(res.writes[1].replace(/^data: /, '').trim());
+        expect(p1.seq).toBe(1);
+        expect(p2.seq).toBe(2);
+        expect(p1.type).toBe('heartbeat');
+      } finally {
+        h.clear();
+      }
+    });
+
+    it('clear() is idempotent', () => {
+      const res = makeMockRes();
+      const h = startSseHeartbeat(res, { intervalMs: 1_000 });
+      h.clear();
+      h.clear();
+      h.clear();
+      jest.advanceTimersByTime(5_000);
+      expect(res.writes).toHaveLength(0);
+      expect(h.active).toBe(false);
+    });
+
+    it('auto-clears on the first failed write (matches legacy catch arm)', () => {
+      const res = makeMockRes({ throwOnWrite: true });
+      const h = startSseHeartbeat(res, { intervalMs: 1_000 });
+      jest.advanceTimersByTime(1_000);
+      // First tick wrote nothing (write threw); heartbeat self-cleared.
+      expect(h.active).toBe(false);
+      // Subsequent ticks do not produce any further attempts.
+      jest.advanceTimersByTime(5_000);
+      expect(res.writes).toHaveLength(0);
+    });
+
+    it('auto-clears when the socket has already ended (writableEnded=true)', () => {
+      const res = makeMockRes({ writableEnded: true });
+      const h = startSseHeartbeat(res, { intervalMs: 1_000 });
+      jest.advanceTimersByTime(1_000);
+      expect(h.active).toBe(false);
+      expect(res.writes).toHaveLength(0);
+    });
+
+    it('active getter reflects the lifecycle', () => {
+      const res = makeMockRes();
+      const h = startSseHeartbeat(res, { intervalMs: 1_000 });
+      expect(h.active).toBe(true);
+      h.clear();
+      expect(h.active).toBe(false);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Track A / A9.2 — SSE transport boundary. Lifts the 4 SSE upgrade headers + `data: ${JSON}\n\n` event encoding + 10s data heartbeat into `orb/live/transport/sse-handler.ts`. orb-live.ts's two SSE upgrade points (`GET /orb/live`, `GET /orb/live/stream`) now use the helpers.

**REST-stream finding:** `/live/stream/send` and `/live/stream/end-turn` are session-action POSTs (regular JSON request/response), NOT streaming responses. They are not a transport in the SSE sense — they're A8 session-lifecycle endpoints. A9.2 therefore lifts SSE only.

Wire protocol byte-for-byte identical. Same headers, same framing, same heartbeat cadence/payload, same ready-event field set. Frontend ORB contract unchanged.

## What lands

- **services/gateway/src/orb/live/transport/types.ts** — SSE types: `SseResponseLike`, `SseEventPayload`, `SseHeartbeatHandle`, `SseHeartbeatOptions`.
- **services/gateway/src/orb/live/transport/sse-handler.ts** — `SSE_HEADERS` (frozen), `SSE_DEFAULT_HEARTBEAT_MS = 10_000`, `attachSseHeaders`, `encodeSseEvent`, `writeSseEvent` (safe write), `startSseHeartbeat` (idempotent clear, auto-clear on failed write).
- **routes/orb-live.ts** — both SSE upgrade points use the helpers. `session.sseResponse = res`, `req.on('close', ...)` cleanup, Live API connect, context-pack rebuild, deduplicated-extract on disconnect all STAY (A8 territory).
- **test/orb/live/characterization/sse-stream.characterization.test.ts** — updated structural assertions follow the seam (delegation + anti-regression on the legacy inline shape). Ready-event field contract kept verbatim.
- **test/orb/live/transport/sse-handler.test.ts** — 20 new runtime tests using mock Response + Jest fake timers.

## Acceptance checks (A9.2 spec)

1. ✅ Existing SSE structural characterization tests green (9 updated to follow the seam).
2. ✅ REST-stream behavior unchanged — it's session-action POSTs, not a transport (A8 territory).
3. ✅ Wire event names, payload shape, close semantics, retry semantics, and headers unchanged.
4. ✅ Transport handler receives typed dependencies (`SseResponseLike`, `SseHeartbeatOptions`).
5. ✅ orb-live.ts delegates without changing behavior.
6. ✅ No contextual-intelligence changes.
7. ✅ No R-lane tuning.
8. ⏳ Production /orb/chat smoke after deploy.

## What this PR does NOT touch

- `session.sseResponse = res` assignment — A8.
- The ~25 per-event `session.sseResponse.write(...)` writes inside the LiveAPI message handler — A8 will migrate them to `writeSseEvent` as part of the controller lift.
- REST-stream POSTs — session-action endpoints, not transports.
- WS transport (A9.1), upstream client (A7), decision-contract spine, B6/B7, frontend behavior, reliability tuning.

## Test plan

- [x] 20 new runtime tests on `sse-handler` (mock Response + fake timers)
- [x] 9 updated structural tests on the SSE handler delegation
- [x] 523 tests green across `test/orb/**` (no regression; A9.1 WS suites still green)
- [x] TypeScript clean for A9.2 files (pre-existing `sharp` error on main, unrelated)
- [ ] Post-merge: EXEC-DEPLOY + /orb/chat production smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)