### PR TITLE
feat(orb): Session B — LiveKit skeleton + upstream provider-selection seam (VTID-02959)

### DIFF
--- a/docs/plans/livekit-migration.md
+++ b/docs/plans/livekit-migration.md
@@ -1,0 +1,200 @@
+# LiveKit migration plan
+
+**Status:** Skeleton landed. No production traffic on LiveKit. Vertex is the only path that actually carries voice.
+
+This doc describes how the ORB Live voice path can be migrated from Vertex AI Live (the current single provider) to LiveKit, using the provider-neutral `UpstreamLiveClient` boundary introduced by A7. It is intentionally written as a *gap analysis* so the next implementer can see what is and is not modeled by the current interface.
+
+---
+
+## 1. Current Vertex path (what exists today)
+
+End-to-end shape:
+
+```
+client browser/app
+   │  WSS (or SSE/REST stream — A9.x)
+   ▼
+gateway: services/gateway/src/routes/orb-live.ts
+   │  per-session: connectToLiveAPI(...)        ← single call site, still inline
+   ▼
+Vertex AI Live API
+   wss://${location}-aiplatform.googleapis.com/.../BidiGenerateContent
+```
+
+Key behaviors of the Vertex path:
+
+- **Single bidi WebSocket** per session. Setup envelope sent once; everything else flows over the same socket.
+- **Server-driven VAD.** Vertex detects end-of-speech via `silence_duration_ms`. The client streams raw audio chunks (`realtime_input.media_chunks[]`) and Vertex decides when the turn ends.
+- **Audio-out as inline base64** under `server_content.model_turn.parts[].inline_data` (24 kHz PCM mono).
+- **Transcripts** as text deltas under `server_content.input_transcription` and `output_transcription`.
+- **Tool calls** as `tool_call.function_calls[]`.
+- **Auth** via Google OAuth access token (one per `connect()`), passed as `Authorization: Bearer …`.
+- **Session lifecycle, watchdogs, persona, memory context, OASIS events** all live in `routes/orb-live.ts` — outside the upstream boundary.
+
+A7 (PR #2081, VTID-02956) extracted the wire-shape work into `VertexLiveClient` (in `services/gateway/src/orb/live/upstream/vertex-live-client.ts`). The legacy inline `connectToLiveAPI` in `routes/orb-live.ts` is still the production call site; the swap is A8/A9 work.
+
+## 2. Intended LiveKit path
+
+End-to-end shape:
+
+```
+client browser/app                    ┐
+   │  WebRTC (or WS for media)        │
+   ▼                                  │
+LiveKit SFU (Cloud or self-hosted)    │  same room
+   ▲                                  │
+   │  agent participant               │
+gateway: dispatched LiveKit Agent     ┘
+   │  internally calls LLM + TTS providers
+   ▼
+LLM provider (e.g. Gemini, Claude, OpenAI)
+TTS provider (Google, ElevenLabs, …)
+STT provider (Deepgram, Google, …)
+```
+
+Key shape differences from Vertex:
+
+- **Room + tracks**, not a single bidi socket. The gateway joins the room as an agent participant and publishes/subscribes audio tracks.
+- **Client-side participant** publishes the user's mic audio to the room directly. The gateway no longer relays raw audio chunks — that path goes browser → SFU → agent.
+- **VAD lives in the agent**, not the model. LiveKit Agents bundle Silero VAD + STT + LLM + TTS in a turn-detector loop the gateway implements.
+- **Auth via short-lived participant JWT** signed with `LIVEKIT_API_SECRET`. The gateway mints tokens for both itself (agent) and the user.
+- **Tool calls / events ride a data channel** alongside the audio tracks (or are handled entirely server-side inside the agent loop).
+- **Reconnect = re-publish track**, not re-open a socket.
+
+What LiveKit gives us in exchange:
+
+- WebRTC reliability + congestion control + jitter buffering (vs. raw WS audio).
+- Pluggable LLM / STT / TTS providers (we are no longer locked to Vertex's model+voice combo).
+- Multi-participant capability (e.g. listen-in, hand-off, recording) without rewiring the audio path.
+
+## 3. What `UpstreamLiveClient` already supports
+
+The interface (in `services/gateway/src/orb/live/upstream/types.ts`) cleanly models the Vertex shape:
+
+| Capability | Interface surface | LiveKit fit |
+|---|---|---|
+| Connect / handshake | `connect(options) → Promise<void>` | ✅ — maps to `Room.connect()` after token mint. |
+| Lifecycle states | `getState()` over `idle / connecting / open / closing / closed / error` | ✅ — Room emits matching connection-state changes. |
+| Forward user audio | `sendAudioChunk(b64, mime)` | ⚠️ — Wrong direction. With LiveKit, the *client* publishes audio to the SFU; the gateway subscribes. See gap §4.1. |
+| End-of-turn signal | `sendEndOfTurn()` | ⚠️ — Vertex has explicit end-of-turn; LiveKit's agent loop infers turn end from VAD. Becomes a no-op or maps to a data-channel hint. |
+| Text turn fallback | `sendTextTurn(text, complete)` | ✅ — maps to data-channel message into the agent. |
+| Audio output | `onAudioOutput({ dataB64, mimeType })` | ⚠️ — LiveKit publishes audio as a *track*. Either (a) the gateway subscribes and re-emits chunked audio over its own WS to the browser (preserves current frontend contract), or (b) the browser subscribes directly to the agent's track (changes the frontend contract). See gap §4.4. |
+| Transcripts | `onTranscript({ direction, text })` | ✅ — STT/TTS plugins emit transcript events the agent can forward via data channel. |
+| Tool calls | `onToolCall({ calls })` | ✅ — agent surfaces LLM tool calls to the gateway via data channel. |
+| Turn complete | `onTurnComplete({ durationMs })` | ✅ — agent emits at end of TTS playback. |
+| Interrupted | `onInterrupted({ atMs })` | ✅ — VAD-driven barge-in maps cleanly. |
+| Errors / close | `onError`, `onClose` | ✅ — Room disconnect / failure events map directly. |
+
+## 4. Gaps the interface does not yet model
+
+The skeleton `LiveKitLiveClient` honors the *contract* of `UpstreamLiveClient` (lifecycle, idempotency, send-returns-false-when-not-open). It does not implement provider behavior because the items below have no home in the current interface.
+
+**Rule for the next implementer:** do NOT mutate `types.ts` opportunistically. Each gap below should be a discrete, reviewable change with an explicit migration note added to this doc.
+
+### 4.1 Audio direction & track lifecycle
+
+`UpstreamLiveClient.sendAudioChunk()` assumes the gateway forwards raw audio chunks from the user to the model. LiveKit inverts that: the user joins the room and publishes audio directly; the agent subscribes.
+
+Options:
+- **A.** Add `subscribeToParticipantAudio(identity)` and demote `sendAudioChunk` to optional. Cleanest, but a real interface change.
+- **B.** Keep `sendAudioChunk` and have the LiveKit client open a server-side audio publication on the gateway's behalf, re-encoding chunks. Preserves the interface but adds latency and a useless re-encode step.
+
+A is the right answer when the time comes. The skeleton does not pick.
+
+### 4.2 Room + participant identity
+
+`UpstreamConnectOptions.projectId` and `location` are Vertex-specific. LiveKit needs:
+- **room name** (typically derived from `sessionId`),
+- **participant identity** (gateway-side and, separately, a token to hand back to the user),
+- optional **room metadata** (locale, persona, debug toggles).
+
+Today these are stored on the `LiveKitClientConfig` passed at construction time. That is correct for the skeleton (caller picks them) but the interface should grow a `roomContext?: { name, identity, metadata? }` field on `UpstreamConnectOptions` so the same call site can drive both providers without a discriminated union.
+
+### 4.3 Token minting
+
+`getAccessToken: () => Promise<string>` returns a Google OAuth token. LiveKit needs a participant JWT, not OAuth — different signing key (`LIVEKIT_API_SECRET`), different claims (`video`, `roomJoin`, `roomCreate`), different TTL story (typically 10 minutes; renewal happens by reconnecting).
+
+Options:
+- Generalize the contract to "credential supplier" with a provider-neutral string return, and let each implementation decide how to use it. (Cheap.)
+- Add a typed credential discriminator (`{ kind: 'oauth_bearer', token } | { kind: 'jwt', token }`). (More honest, easier to typo-proof.)
+
+Either works. The skeleton does not pick.
+
+### 4.4 Audio output to the browser
+
+The current frontend contract (in both the gateway-served `orb-widget.js` and the orb-live SSE/REST/WS transports the A9.x track is splitting out) expects base64 PCM audio chunks delivered over the gateway's own WS/SSE channel. `onAudioOutput({ dataB64, mimeType })` is shaped for that.
+
+For LiveKit, two end-states:
+- **Bridge mode (default).** Gateway subscribes to the agent's audio track, decodes/re-encodes to base64 PCM, and emits via `onAudioOutput`. Frontend stays unchanged. Costs latency + CPU.
+- **Direct WebRTC mode.** Browser joins the room directly and subscribes to the agent's track. Removes the gateway hop entirely. Requires changes in `vitana-v1` and the gateway-served orb widget — out of scope for the gateway-only migration.
+
+The skeleton assumes bridge mode is the first cut.
+
+### 4.5 Reconnect + resume
+
+Vertex reconnect = open a new bidi socket and re-send the setup envelope. The current orb-live.ts owns this (transparent reconnect logic, mic resume, audio-out resume).
+
+LiveKit reconnect = LiveKit SDK has its own reconnect with token refresh. The interface has no concept of "reconnected to the same logical session" — it just exposes `onClose` and the caller decides to construct a new client.
+
+Either:
+- The selection seam constructs a fresh `LiveKitLiveClient` per reconnect (matches today's Vertex flow; loses the SDK's built-in resume).
+- We introduce `connect()` semantics that distinguish first connect from reconnect (real interface change).
+
+Decide when reconnect storms are observed in dogfood — not before.
+
+### 4.6 Disconnect classification
+
+Today's classifier in orb-live.ts (forwarding watchdog, response watchdog, transparent reconnect bucket) reads close codes from the Vertex socket. LiveKit reports disconnect *reasons* (`SIGNAL_FAILED`, `SERVER_LEAVE`, `PARTICIPANT_REMOVED`, …) with no overlap to WebSocket close codes.
+
+`UpstreamCloseEvent.code?: number` is too narrow. Add `reasonClass?: 'transient' | 'auth' | 'server' | 'local' | 'unknown'` so callers can keep the same recovery logic without learning two vocabularies.
+
+### 4.7 Frontend contract
+
+The frontend currently expects:
+- Initial greeting audio within ~2 s (iOS keep-alive depends on this).
+- Transcript stream interleaved with audio.
+- WS or SSE endpoint per `sessionId`.
+- Reconnect via the same `sessionId` is transparent (same greeting suppression, same continuation).
+
+In bridge mode (§4.4), the contract is preserved. In direct WebRTC mode, the frontend learns to:
+- Mint participant tokens via a new gateway endpoint (`/api/v1/orb/livekit/token`).
+- Subscribe to the agent participant's audio track instead of decoding `data` events.
+- Receive transcripts/tool-call notifications via LiveKit data channel rather than SSE/WS frames.
+
+Bridge mode first; direct WebRTC behind an explicit per-tenant flag once parity is proven.
+
+## 5. Selection rules (shipped in this PR)
+
+`services/gateway/src/orb/live/upstream/provider-selection.ts`:
+
+```
+ORB_LIVE_PROVIDER unset   → vertex   (source: 'default')
+ORB_LIVE_PROVIDER=vertex  → vertex   (source: 'env')
+ORB_LIVE_PROVIDER=livekit AND LIVEKIT_URL/API_KEY/API_SECRET set
+                          → livekit  (source: 'env')
+ORB_LIVE_PROVIDER=livekit AND any cred missing
+                          → vertex   (source: 'fallback', warning lists missing vars)
+ORB_LIVE_PROVIDER=<other> → vertex   (source: 'fallback', warning names value)
+```
+
+The `warnings[]` field is the contract for telemetry. When the call site wires this in, it must emit one OASIS event per warning so a misconfigured rollout cannot fail silently.
+
+Selection is per-session (the function is pure). When tenant-level overrides land (e.g. `tenant_settings.voice_provider`), wrap or replace `selectUpstreamProvider` — do not mutate it to read from the database; that breaks the unit-test contract.
+
+## 6. Risks
+
+- **Audio latency in bridge mode.** Gateway becomes a transcoder. Dogfood before flipping any tenant.
+- **Token leakage.** LiveKit JWTs grant room access. The mint endpoint must be authenticated and the JWT must be short-lived.
+- **Cost shape changes.** Vertex bills per audio second; LiveKit Cloud bills per participant minute. Provider-by-tenant means cost analytics must split per provider.
+- **Two reconnect mental models.** Dual-running both providers in production multiplies the disconnect-classification surface — keep `LIVEKIT_*` traffic on a small canary cohort until §4.6 lands.
+- **Skeleton drift.** If A8/A9 evolve `UpstreamLiveClient` to fit Vertex more tightly (e.g. add Vertex-only fields), the LiveKit gap list grows. Each interface change should re-review §4 and update the gap.
+
+## 7. Out of scope for the skeleton
+
+The following are explicitly NOT touched by this PR:
+- `routes/orb-live.ts` and the inline `connectToLiveAPI` (still the production call site).
+- `orb/live/transport/*` (WS / SSE / REST stream — A9.x territory).
+- `orb/live/instruction/*` (decision-contract renderer / system instruction composition).
+- Frontend orb widget audio playback path.
+- Reliability tuning (timeouts, watchdogs, reconnect cadence).
+- Any behavior change for the Vertex path.

--- a/services/gateway/src/orb/live/upstream/livekit-live-client.ts
+++ b/services/gateway/src/orb/live/upstream/livekit-live-client.ts
@@ -1,0 +1,274 @@
+/**
+ * Session B (orb-live-refactor): LiveKit skeleton implementation of
+ * `UpstreamLiveClient`.
+ *
+ * STATUS: skeleton only. `connect()` deliberately rejects with
+ * `code: 'not_implemented'`. No production call site uses this client yet —
+ * the selection layer (`provider-selection.ts`) defaults to Vertex and only
+ * picks LiveKit when both `ORB_LIVE_PROVIDER=livekit` AND the LiveKit
+ * credential triple is present.
+ *
+ * Why a skeleton (not a stub returning success):
+ *   - The `UpstreamLiveClient` contract was designed against the Vertex Live
+ *     API wire shape (single bidi WebSocket, server-driven VAD, model returns
+ *     audio inline as base64 PCM). LiveKit's model is different (room +
+ *     subscribed tracks, agent dispatched as a participant, audio published
+ *     as media tracks). The mapping is non-trivial and is documented in
+ *     `docs/plans/livekit-migration.md`.
+ *   - Shipping the skeleton lets us land the provider-selection seam,
+ *     interface-conformance tests, and the migration doc WITHOUT a partial
+ *     implementation that could be accidentally enabled in production.
+ *
+ * What this file DOES:
+ *   - Implements every method on the `UpstreamLiveClient` interface.
+ *   - Honors the lifecycle state machine (idle → error after a refused
+ *     connect, idle → closing → closed after close()).
+ *   - Stores event handlers as the interface requires.
+ *   - close() is idempotent; onClose fires exactly once with
+ *     `initiatedLocally: true`.
+ *   - Send methods return `false` (per contract) when not in `open` state.
+ *
+ * What this file DOES NOT do (yet):
+ *   - Mint a participant token (LIVEKIT_API_KEY / LIVEKIT_API_SECRET → JWT).
+ *   - Connect to a room via the LiveKit server SDK.
+ *   - Publish/subscribe audio tracks.
+ *   - Dispatch the LiveKit agent (turn handling, VAD, tool dispatch).
+ *   - Bridge LiveKit data-channel events to onTranscript / onToolCall /
+ *     onTurnComplete / onInterrupted.
+ *
+ * Interface gaps (documented in `docs/plans/livekit-migration.md`):
+ *   - `UpstreamConnectOptions.projectId`/`location` mean nothing for LiveKit;
+ *     LiveKit needs a room name + participant identity instead.
+ *   - `getAccessToken()` returns a Google OAuth token; LiveKit needs a
+ *     short-lived participant JWT signed with `LIVEKIT_API_SECRET`.
+ *   - `sendAudioChunk(audioB64)` assumes a single push channel; LiveKit
+ *     wants a published audio track that the agent subscribes to.
+ *   - There is no `ToolCallResult` send path on the interface — Vertex
+ *     accepts tool results inline in the next `client_content`; LiveKit
+ *     uses data channel messages.
+ */
+
+import type {
+  AudioOutputEvent,
+  InterruptedEvent,
+  ToolCallEvent,
+  TranscriptEvent,
+  TurnCompleteEvent,
+  UpstreamCloseEvent,
+  UpstreamConnectOptions,
+  UpstreamConnectionState,
+  UpstreamErrorEvent,
+  UpstreamLiveClient,
+} from './types';
+
+/**
+ * Configuration the LiveKit implementation needs that the
+ * provider-neutral interface does NOT model. Caller-supplied so this
+ * file does not reach into `process.env` directly.
+ *
+ * The skeleton does not consume these yet, but the shape is fixed so the
+ * provider-selection layer and future implementation can both rely on it.
+ */
+export interface LiveKitClientConfig {
+  /** wss://… room URL (e.g. LiveKit Cloud or self-hosted SFU). */
+  url: string;
+  /** API key used to mint participant tokens. */
+  apiKey: string;
+  /** API secret used to sign participant tokens. Server-only. */
+  apiSecret: string;
+  /** Room name to join. Defaults to per-session generation when absent. */
+  roomName?: string;
+  /** Participant identity for the gateway side of the session. */
+  participantIdentity?: string;
+}
+
+/**
+ * Hooks for tests to inject behavior without depending on a real LiveKit
+ * server. Mirrors `VertexLiveClientDeps` shape so the skeleton can be
+ * fleshed out without changing the construction surface.
+ */
+export interface LiveKitLiveClientDeps {
+  /** Tests can substitute the config-validation pre-check. */
+  validateConfig?: (config: LiveKitClientConfig) => UpstreamErrorEvent | null;
+}
+
+/**
+ * LiveKit upstream client — skeleton.
+ *
+ * @see docs/plans/livekit-migration.md for the gap list and intended
+ *      mapping of LiveKit room/track lifecycle onto the
+ *      `UpstreamLiveClient` interface.
+ */
+export class LiveKitLiveClient implements UpstreamLiveClient {
+  private state: UpstreamConnectionState = 'idle';
+  private readonly config: LiveKitClientConfig;
+  private readonly validateConfig: NonNullable<
+    LiveKitLiveClientDeps['validateConfig']
+  >;
+
+  private audioOutputHandler: ((e: AudioOutputEvent) => void) | null = null;
+  private transcriptHandler: ((e: TranscriptEvent) => void) | null = null;
+  private toolCallHandler: ((e: ToolCallEvent) => void) | null = null;
+  private turnCompleteHandler: ((e: TurnCompleteEvent) => void) | null = null;
+  private interruptedHandler: ((e: InterruptedEvent) => void) | null = null;
+  private errorHandler: ((e: UpstreamErrorEvent) => void) | null = null;
+  private closeHandler: ((e: UpstreamCloseEvent) => void) | null = null;
+
+  private closeEmitted = false;
+
+  constructor(config: LiveKitClientConfig, deps: LiveKitLiveClientDeps = {}) {
+    this.config = config;
+    this.validateConfig = deps.validateConfig ?? defaultValidateConfig;
+  }
+
+  getState(): UpstreamConnectionState {
+    return this.state;
+  }
+
+  onAudioOutput(handler: (event: AudioOutputEvent) => void): void {
+    this.audioOutputHandler = handler;
+  }
+
+  onTranscript(handler: (event: TranscriptEvent) => void): void {
+    this.transcriptHandler = handler;
+  }
+
+  onToolCall(handler: (event: ToolCallEvent) => void): void {
+    this.toolCallHandler = handler;
+  }
+
+  onTurnComplete(handler: (event: TurnCompleteEvent) => void): void {
+    this.turnCompleteHandler = handler;
+  }
+
+  onInterrupted(handler: (event: InterruptedEvent) => void): void {
+    this.interruptedHandler = handler;
+  }
+
+  onError(handler: (event: UpstreamErrorEvent) => void): void {
+    this.errorHandler = handler;
+  }
+
+  onClose(handler: (event: UpstreamCloseEvent) => void): void {
+    this.closeHandler = handler;
+  }
+
+  /**
+   * Skeleton: validates config, then refuses to connect with a typed
+   * `not_implemented` error. Does not open a socket, mint a token, or
+   * touch the LiveKit server.
+   *
+   * Production callers MUST NOT reach this path — provider-selection
+   * defaults to Vertex and the selection layer treats LiveKit as
+   * opt-in only.
+   */
+  async connect(_options: UpstreamConnectOptions): Promise<void> {
+    if (this.state !== 'idle') {
+      throw new Error(`invalid_state: cannot connect from state '${this.state}'`);
+    }
+
+    this.state = 'connecting';
+
+    const configError = this.validateConfig(this.config);
+    if (configError) {
+      this.transitionToError(configError);
+      throw new Error(`${configError.code}: ${configError.message}`);
+    }
+
+    const err: UpstreamErrorEvent = {
+      code: 'not_implemented',
+      message:
+        'LiveKitLiveClient is a skeleton. See docs/plans/livekit-migration.md ' +
+        'for the room/track/agent wiring still required.',
+    };
+    this.transitionToError(err);
+    throw new Error(`${err.code}: ${err.message}`);
+  }
+
+  // The skeleton never reaches `open`, so the contract requires these to
+  // return `false` rather than throw. Once the implementation lands, these
+  // bodies will publish to a LiveKit audio track / data channel.
+  sendAudioChunk(_audioB64: string, _mimeType?: string): boolean {
+    return this.state === 'open';
+  }
+
+  sendTextTurn(_text: string, _turnComplete: boolean = true): boolean {
+    return this.state === 'open';
+  }
+
+  sendEndOfTurn(): boolean {
+    return this.state === 'open';
+  }
+
+  async close(): Promise<void> {
+    if (this.state === 'closed' || this.state === 'closing') return;
+    this.state = 'closing';
+    if (!this.closeEmitted) {
+      this.finalizeClose({ initiatedLocally: true });
+    }
+  }
+
+  private finalizeClose(event: UpstreamCloseEvent): void {
+    this.closeEmitted = true;
+    this.state = 'closed';
+    try {
+      this.closeHandler?.(event);
+    } catch {
+      /* swallow handler exceptions */
+    }
+  }
+
+  private transitionToError(err: UpstreamErrorEvent): void {
+    this.state = 'error';
+    try {
+      this.errorHandler?.(err);
+    } catch {
+      /* swallow handler exceptions */
+    }
+  }
+
+  // Reserved for the post-skeleton implementation. Listed here so the
+  // unused-handler stores above are obvious to future readers.
+  private get _futureBridges() {
+    return {
+      audioOutputHandler: this.audioOutputHandler,
+      transcriptHandler: this.transcriptHandler,
+      toolCallHandler: this.toolCallHandler,
+      turnCompleteHandler: this.turnCompleteHandler,
+      interruptedHandler: this.interruptedHandler,
+    };
+  }
+}
+
+/**
+ * Default config validator. Returns a typed error event when required
+ * fields are missing/blank; null when the config looks usable.
+ *
+ * Intentionally cheap — does NOT verify the URL is reachable or that the
+ * key/secret pair is valid. That happens once the real implementation
+ * mints a token.
+ */
+export function defaultValidateConfig(
+  config: LiveKitClientConfig,
+): UpstreamErrorEvent | null {
+  const missing: string[] = [];
+  if (!config.url || !config.url.trim()) missing.push('url');
+  if (!config.apiKey || !config.apiKey.trim()) missing.push('apiKey');
+  if (!config.apiSecret || !config.apiSecret.trim()) missing.push('apiSecret');
+
+  if (missing.length > 0) {
+    return {
+      code: 'invalid_config',
+      message: `LiveKit config missing required field(s): ${missing.join(', ')}`,
+    };
+  }
+
+  if (!/^wss?:\/\//i.test(config.url)) {
+    return {
+      code: 'invalid_config',
+      message: `LiveKit url must start with ws:// or wss:// (got "${config.url}")`,
+    };
+  }
+
+  return null;
+}

--- a/services/gateway/src/orb/live/upstream/provider-selection.ts
+++ b/services/gateway/src/orb/live/upstream/provider-selection.ts
@@ -1,0 +1,160 @@
+/**
+ * Session B (orb-live-refactor): provider-selection seam for the
+ * `UpstreamLiveClient`.
+ *
+ * Selects which provider implementation to construct for a new ORB Live
+ * session. Pure functions — no side effects, no globals — so it can be
+ * unit-tested with synthetic env objects and reused per-session if/when
+ * tenant-level overrides land.
+ *
+ * Selection rules (checked in order):
+ *   1. If `ORB_LIVE_PROVIDER` is unset → vertex (the default).
+ *   2. If `ORB_LIVE_PROVIDER=vertex` → vertex.
+ *   3. If `ORB_LIVE_PROVIDER=livekit` AND all of `LIVEKIT_URL`,
+ *      `LIVEKIT_API_KEY`, `LIVEKIT_API_SECRET` are set → livekit.
+ *   4. If `ORB_LIVE_PROVIDER=livekit` but the credential triple is
+ *      incomplete → vertex, with a warning describing what was missing.
+ *   5. Any other value of `ORB_LIVE_PROVIDER` → vertex, with a warning
+ *      naming the unrecognized value.
+ *
+ * Why fall back to vertex (not throw):
+ *   - The whole point of the seam is that a misconfigured rollout cannot
+ *     accidentally take voice down. Vertex is the proven path. Failures
+ *     are surfaced via the `warnings` field so the caller can emit OASIS
+ *     telemetry — they are NOT silent.
+ *   - Matches the existing `services/gateway/src/orb/live/config.ts`
+ *     pattern: read env, default sensibly, no result-type wrappers.
+ *
+ * Production note:
+ *   - At time of writing, no production call site invokes this module.
+ *     `routes/orb-live.ts` still calls its in-file `connectToLiveAPI`. The
+ *     selection seam ships ahead of the call-site swap so the LiveKit
+ *     skeleton can be exercised independently.
+ */
+
+import type { UpstreamLiveClient } from './types';
+import { VertexLiveClient } from './vertex-live-client';
+import {
+  LiveKitLiveClient,
+  type LiveKitClientConfig,
+} from './livekit-live-client';
+
+/** Recognized provider names. */
+export type UpstreamProviderName = 'vertex' | 'livekit';
+
+/**
+ * Subset of `process.env` that the selector reads. Tests pass synthetic
+ * objects; production callers pass `process.env` directly.
+ */
+export interface UpstreamProviderEnv {
+  ORB_LIVE_PROVIDER?: string;
+  LIVEKIT_URL?: string;
+  LIVEKIT_API_KEY?: string;
+  LIVEKIT_API_SECRET?: string;
+}
+
+/**
+ * Outcome of the selection. `provider` is always a recognized name —
+ * even on fallback the caller gets a usable value. `warnings` lists
+ * problems the caller should surface (typically via OASIS event).
+ */
+export interface UpstreamProviderSelection {
+  /** Selected provider — always usable, never an error sentinel. */
+  provider: UpstreamProviderName;
+  /**
+   * Where the choice came from. `'default'` = no env override applied;
+   * `'env'` = an explicit ORB_LIVE_PROVIDER value was honored;
+   * `'fallback'` = an env value was rejected and we substituted vertex.
+   */
+  source: 'default' | 'env' | 'fallback';
+  /** Warnings the caller should log / emit as OASIS telemetry. */
+  warnings: string[];
+}
+
+/**
+ * Decide which upstream provider to use for the next session.
+ *
+ * Pure: same env in → same selection out. Safe to call per-session.
+ */
+export function selectUpstreamProvider(
+  env: UpstreamProviderEnv = process.env as UpstreamProviderEnv,
+): UpstreamProviderSelection {
+  const raw = (env.ORB_LIVE_PROVIDER || '').trim().toLowerCase();
+
+  if (raw === '' || raw === 'vertex') {
+    return {
+      provider: 'vertex',
+      source: raw === '' ? 'default' : 'env',
+      warnings: [],
+    };
+  }
+
+  if (raw === 'livekit') {
+    const missing: string[] = [];
+    if (!env.LIVEKIT_URL || !env.LIVEKIT_URL.trim()) missing.push('LIVEKIT_URL');
+    if (!env.LIVEKIT_API_KEY || !env.LIVEKIT_API_KEY.trim())
+      missing.push('LIVEKIT_API_KEY');
+    if (!env.LIVEKIT_API_SECRET || !env.LIVEKIT_API_SECRET.trim())
+      missing.push('LIVEKIT_API_SECRET');
+
+    if (missing.length === 0) {
+      return { provider: 'livekit', source: 'env', warnings: [] };
+    }
+
+    return {
+      provider: 'vertex',
+      source: 'fallback',
+      warnings: [
+        `ORB_LIVE_PROVIDER=livekit but missing required env: ${missing.join(', ')} — falling back to vertex`,
+      ],
+    };
+  }
+
+  return {
+    provider: 'vertex',
+    source: 'fallback',
+    warnings: [
+      `ORB_LIVE_PROVIDER=${env.ORB_LIVE_PROVIDER} is not a recognized provider (expected 'vertex' or 'livekit') — falling back to vertex`,
+    ],
+  };
+}
+
+/**
+ * Read LiveKit config out of an env object. Exported so the LiveKit
+ * skeleton's interface-conformance tests can construct a client without
+ * duplicating the env→config mapping.
+ */
+export function readLiveKitConfigFromEnv(
+  env: UpstreamProviderEnv = process.env as UpstreamProviderEnv,
+): LiveKitClientConfig {
+  return {
+    url: env.LIVEKIT_URL ?? '',
+    apiKey: env.LIVEKIT_API_KEY ?? '',
+    apiSecret: env.LIVEKIT_API_SECRET ?? '',
+  };
+}
+
+/**
+ * Construct an upstream client for the given selection.
+ *
+ * Vertex needs no extra config at construction time (it reads OAuth
+ * credentials per-`connect()` via the `getAccessToken` callback in
+ * `UpstreamConnectOptions`). LiveKit needs URL + credentials at
+ * construction time so the skeleton can validate them up front.
+ */
+export function createUpstreamLiveClient(
+  selection: UpstreamProviderSelection,
+  env: UpstreamProviderEnv = process.env as UpstreamProviderEnv,
+): UpstreamLiveClient {
+  switch (selection.provider) {
+    case 'vertex':
+      return new VertexLiveClient();
+    case 'livekit':
+      return new LiveKitLiveClient(readLiveKitConfigFromEnv(env));
+    default: {
+      // Exhaustiveness check — the type system already guarantees this.
+      const _never: never = selection.provider;
+      throw new Error(`unreachable provider: ${_never}`);
+    }
+  }
+}

--- a/services/gateway/test/orb/live/upstream/livekit-live-client.test.ts
+++ b/services/gateway/test/orb/live/upstream/livekit-live-client.test.ts
@@ -1,0 +1,200 @@
+/**
+ * Session B (orb-live-refactor): tests for the `LiveKitLiveClient`
+ * skeleton.
+ *
+ * Two purposes:
+ *   1. Interface conformance — the skeleton must satisfy every method on
+ *      `UpstreamLiveClient` with the right signature, lifecycle, and
+ *      idempotency rules. This locks in the contract so when the real
+ *      implementation lands, behavior cannot regress silently.
+ *   2. Skeleton honesty — `connect()` must reject (with a typed error)
+ *      so a misconfigured rollout cannot produce silent no-audio
+ *      sessions. No production call site is allowed to rely on this
+ *      client succeeding.
+ *
+ * The "no production call site uses LiveKit yet" assertion lives in
+ * `provider-selection-no-production-wiring.test.ts`.
+ */
+
+import {
+  LiveKitLiveClient,
+  defaultValidateConfig,
+  type LiveKitClientConfig,
+} from '../../../../src/orb/live/upstream/livekit-live-client';
+import type { UpstreamConnectOptions } from '../../../../src/orb/live/upstream/types';
+
+const VALID_CONFIG: LiveKitClientConfig = {
+  url: 'wss://livekit.example.com',
+  apiKey: 'test-key',
+  apiSecret: 'test-secret',
+};
+
+function baseConnectOptions(
+  overrides: Partial<UpstreamConnectOptions> = {},
+): UpstreamConnectOptions {
+  return {
+    model: 'gemini-live-2.5-flash-native-audio',
+    projectId: 'lovable-vitana-vers1',
+    location: 'us-central1',
+    voiceName: 'Aoede',
+    responseModalities: ['audio'],
+    vadSilenceMs: 1200,
+    systemInstruction: 'You are Vitana.',
+    getAccessToken: async () => 'unused-by-skeleton',
+    connectTimeoutMs: 1000,
+    ...overrides,
+  };
+}
+
+describe('LiveKitLiveClient — interface conformance', () => {
+  it('implements every method on UpstreamLiveClient', () => {
+    const client = new LiveKitLiveClient(VALID_CONFIG);
+    const required = [
+      'connect',
+      'sendAudioChunk',
+      'sendTextTurn',
+      'sendEndOfTurn',
+      'onAudioOutput',
+      'onTranscript',
+      'onToolCall',
+      'onTurnComplete',
+      'onInterrupted',
+      'onError',
+      'onClose',
+      'close',
+      'getState',
+    ];
+    for (const method of required) {
+      expect(typeof (client as any)[method]).toBe('function');
+    }
+  });
+
+  it('starts in the idle lifecycle state', () => {
+    const client = new LiveKitLiveClient(VALID_CONFIG);
+    expect(client.getState()).toBe('idle');
+  });
+
+  it('send* methods return false before connect (per UpstreamLiveClient contract)', () => {
+    const client = new LiveKitLiveClient(VALID_CONFIG);
+    expect(client.sendAudioChunk('AAAA')).toBe(false);
+    expect(client.sendTextTurn('hello')).toBe(false);
+    expect(client.sendEndOfTurn()).toBe(false);
+  });
+
+  it('on* registration accepts handlers without throwing', () => {
+    const client = new LiveKitLiveClient(VALID_CONFIG);
+    expect(() => {
+      client.onAudioOutput(() => {});
+      client.onTranscript(() => {});
+      client.onToolCall(() => {});
+      client.onTurnComplete(() => {});
+      client.onInterrupted(() => {});
+      client.onError(() => {});
+      client.onClose(() => {});
+    }).not.toThrow();
+  });
+});
+
+describe('LiveKitLiveClient — connect() (skeleton refusal)', () => {
+  it('rejects with a typed not_implemented error when config is valid', async () => {
+    const client = new LiveKitLiveClient(VALID_CONFIG);
+    const errors: any[] = [];
+    client.onError((e) => errors.push(e));
+
+    await expect(client.connect(baseConnectOptions())).rejects.toThrow(/not_implemented/);
+    expect(client.getState()).toBe('error');
+    expect(errors).toHaveLength(1);
+    expect(errors[0].code).toBe('not_implemented');
+    expect(errors[0].message).toMatch(/skeleton/i);
+  });
+
+  it('rejects with invalid_config (not not_implemented) when url is missing', async () => {
+    const client = new LiveKitLiveClient({ ...VALID_CONFIG, url: '' });
+    const errors: any[] = [];
+    client.onError((e) => errors.push(e));
+
+    await expect(client.connect(baseConnectOptions())).rejects.toThrow(/invalid_config/);
+    expect(client.getState()).toBe('error');
+    expect(errors[0].code).toBe('invalid_config');
+    expect(errors[0].message).toContain('url');
+  });
+
+  it('rejects with invalid_config when apiKey or apiSecret is missing', async () => {
+    const noKey = new LiveKitLiveClient({ ...VALID_CONFIG, apiKey: '' });
+    await expect(noKey.connect(baseConnectOptions())).rejects.toThrow(/invalid_config/);
+
+    const noSecret = new LiveKitLiveClient({ ...VALID_CONFIG, apiSecret: '' });
+    await expect(noSecret.connect(baseConnectOptions())).rejects.toThrow(/invalid_config/);
+  });
+
+  it('rejects with invalid_config when url uses a non-ws scheme', async () => {
+    const client = new LiveKitLiveClient({
+      ...VALID_CONFIG,
+      url: 'https://livekit.example.com',
+    });
+    await expect(client.connect(baseConnectOptions())).rejects.toThrow(/invalid_config/);
+  });
+
+  it('refuses a second connect() from a non-idle state', async () => {
+    const client = new LiveKitLiveClient(VALID_CONFIG);
+    await expect(client.connect(baseConnectOptions())).rejects.toThrow();
+    // Now in 'error' state — second connect must be refused with invalid_state.
+    await expect(client.connect(baseConnectOptions())).rejects.toThrow(/invalid_state/);
+  });
+});
+
+describe('LiveKitLiveClient — close() lifecycle', () => {
+  it('transitions to closed and fires onClose exactly once', async () => {
+    const client = new LiveKitLiveClient(VALID_CONFIG);
+    const closes: any[] = [];
+    client.onClose((e) => closes.push(e));
+
+    await client.close();
+    expect(client.getState()).toBe('closed');
+    expect(closes).toHaveLength(1);
+    expect(closes[0].initiatedLocally).toBe(true);
+  });
+
+  it('is idempotent — repeated close() does not re-fire onClose', async () => {
+    const client = new LiveKitLiveClient(VALID_CONFIG);
+    const closes: any[] = [];
+    client.onClose((e) => closes.push(e));
+
+    await client.close();
+    await client.close();
+    await client.close();
+
+    expect(closes).toHaveLength(1);
+    expect(client.getState()).toBe('closed');
+  });
+});
+
+describe('defaultValidateConfig', () => {
+  it('returns null for a fully populated config', () => {
+    expect(defaultValidateConfig(VALID_CONFIG)).toBeNull();
+  });
+
+  it('lists every missing required field', () => {
+    const err = defaultValidateConfig({ url: '', apiKey: '', apiSecret: '' });
+    expect(err).not.toBeNull();
+    expect(err!.code).toBe('invalid_config');
+    expect(err!.message).toContain('url');
+    expect(err!.message).toContain('apiKey');
+    expect(err!.message).toContain('apiSecret');
+  });
+
+  it('rejects URLs that are not ws:// or wss://', () => {
+    const err = defaultValidateConfig({
+      ...VALID_CONFIG,
+      url: 'http://livekit.example.com',
+    });
+    expect(err!.code).toBe('invalid_config');
+    expect(err!.message).toMatch(/ws:\/\/.*wss:\/\//);
+  });
+
+  it('accepts ws:// (insecure) for local/dev', () => {
+    expect(
+      defaultValidateConfig({ ...VALID_CONFIG, url: 'ws://localhost:7880' }),
+    ).toBeNull();
+  });
+});

--- a/services/gateway/test/orb/live/upstream/no-production-livekit-wiring.test.ts
+++ b/services/gateway/test/orb/live/upstream/no-production-livekit-wiring.test.ts
@@ -1,0 +1,74 @@
+/**
+ * Session B (orb-live-refactor): structural guard — no production call site
+ * is allowed to switch to LiveKit yet.
+ *
+ * This test is intentionally narrow:
+ *   - The only files in `services/gateway/src/` that may reference
+ *     `LiveKitLiveClient` are the skeleton itself and the provider-selection
+ *     seam.
+ *   - `routes/orb-live.ts` (the Vertex call site) must NOT import the
+ *     skeleton or the selection layer.
+ *   - The selection seam itself must continue to default to vertex.
+ *
+ * If a future PR wires LiveKit into a real session, that PR should DELETE
+ * this test (or split it) as part of the wiring step — not just amend the
+ * allow-list silently.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  selectUpstreamProvider,
+} from '../../../../src/orb/live/upstream/provider-selection';
+
+const SRC_ROOT = path.resolve(__dirname, '../../../../src');
+
+const ALLOWED_SRC_IMPORTERS = new Set([
+  path.join(SRC_ROOT, 'orb/live/upstream/livekit-live-client.ts'),
+  path.join(SRC_ROOT, 'orb/live/upstream/provider-selection.ts'),
+]);
+
+function walk(dir: string): string[] {
+  const out: string[] = [];
+  for (const entry of fs.readdirSync(dir, { withFileTypes: true })) {
+    const full = path.join(dir, entry.name);
+    if (entry.isDirectory()) {
+      // Skip generated / vendored dirs.
+      if (entry.name === 'node_modules' || entry.name === 'dist') continue;
+      out.push(...walk(full));
+    } else if (entry.isFile() && entry.name.endsWith('.ts')) {
+      out.push(full);
+    }
+  }
+  return out;
+}
+
+describe('LiveKit production wiring guard', () => {
+  it('no production src file outside the upstream seam imports LiveKitLiveClient', () => {
+    const offenders: string[] = [];
+    for (const file of walk(SRC_ROOT)) {
+      if (ALLOWED_SRC_IMPORTERS.has(file)) continue;
+      const text = fs.readFileSync(file, 'utf8');
+      if (text.includes('LiveKitLiveClient')) {
+        offenders.push(path.relative(SRC_ROOT, file));
+      }
+    }
+    expect(offenders).toEqual([]);
+  });
+
+  it('routes/orb-live.ts does not import the upstream selection seam (still uses inline connectToLiveAPI)', () => {
+    const file = path.join(SRC_ROOT, 'routes/orb-live.ts');
+    const text = fs.readFileSync(file, 'utf8');
+
+    // The seam ships ahead of the call-site swap. When the swap lands,
+    // delete these assertions in the same PR that wires it.
+    expect(text).not.toMatch(/from\s+['"][^'"]*upstream\/provider-selection['"]/);
+    expect(text).not.toMatch(/from\s+['"][^'"]*upstream\/livekit-live-client['"]/);
+    expect(text).not.toMatch(/createUpstreamLiveClient/);
+    expect(text).not.toMatch(/selectUpstreamProvider/);
+  });
+
+  it('default selection (no env override) is vertex — production rollouts cannot accidentally pick LiveKit', () => {
+    expect(selectUpstreamProvider({}).provider).toBe('vertex');
+  });
+});

--- a/services/gateway/test/orb/live/upstream/provider-selection.test.ts
+++ b/services/gateway/test/orb/live/upstream/provider-selection.test.ts
@@ -1,0 +1,147 @@
+/**
+ * Session B (orb-live-refactor): tests for the upstream provider-selection
+ * seam.
+ *
+ * Covers:
+ *   - default = vertex (no env flag)
+ *   - explicit ORB_LIVE_PROVIDER=vertex
+ *   - explicit ORB_LIVE_PROVIDER=livekit selects LiveKit only when the
+ *     credential triple is present
+ *   - missing credentials → safe fallback to vertex with a typed warning
+ *   - unknown provider name → safe fallback to vertex with a typed warning
+ *   - createUpstreamLiveClient returns the right concrete class for each
+ *     selection
+ */
+
+import {
+  selectUpstreamProvider,
+  createUpstreamLiveClient,
+  readLiveKitConfigFromEnv,
+  type UpstreamProviderEnv,
+} from '../../../../src/orb/live/upstream/provider-selection';
+import { VertexLiveClient } from '../../../../src/orb/live/upstream/vertex-live-client';
+import { LiveKitLiveClient } from '../../../../src/orb/live/upstream/livekit-live-client';
+
+const FULL_LIVEKIT_ENV: UpstreamProviderEnv = {
+  ORB_LIVE_PROVIDER: 'livekit',
+  LIVEKIT_URL: 'wss://livekit.example.com',
+  LIVEKIT_API_KEY: 'test-key',
+  LIVEKIT_API_SECRET: 'test-secret',
+};
+
+describe('selectUpstreamProvider', () => {
+  it('defaults to vertex when no env flag is set', () => {
+    const sel = selectUpstreamProvider({});
+    expect(sel.provider).toBe('vertex');
+    expect(sel.source).toBe('default');
+    expect(sel.warnings).toEqual([]);
+  });
+
+  it('defaults to vertex when ORB_LIVE_PROVIDER is empty/whitespace', () => {
+    const sel = selectUpstreamProvider({ ORB_LIVE_PROVIDER: '   ' });
+    expect(sel.provider).toBe('vertex');
+    expect(sel.source).toBe('default');
+    expect(sel.warnings).toEqual([]);
+  });
+
+  it('selects vertex when ORB_LIVE_PROVIDER=vertex (explicit opt-in)', () => {
+    const sel = selectUpstreamProvider({ ORB_LIVE_PROVIDER: 'vertex' });
+    expect(sel.provider).toBe('vertex');
+    expect(sel.source).toBe('env');
+    expect(sel.warnings).toEqual([]);
+  });
+
+  it('is case-insensitive on the provider name', () => {
+    const sel = selectUpstreamProvider({ ORB_LIVE_PROVIDER: 'Vertex' });
+    expect(sel.provider).toBe('vertex');
+
+    const sel2 = selectUpstreamProvider({
+      ...FULL_LIVEKIT_ENV,
+      ORB_LIVE_PROVIDER: 'LiveKit',
+    });
+    expect(sel2.provider).toBe('livekit');
+  });
+
+  it('selects livekit only when ORB_LIVE_PROVIDER=livekit AND all creds are set', () => {
+    const sel = selectUpstreamProvider(FULL_LIVEKIT_ENV);
+    expect(sel.provider).toBe('livekit');
+    expect(sel.source).toBe('env');
+    expect(sel.warnings).toEqual([]);
+  });
+
+  it('falls back to vertex with a typed warning when LIVEKIT_URL is missing', () => {
+    const sel = selectUpstreamProvider({
+      ...FULL_LIVEKIT_ENV,
+      LIVEKIT_URL: undefined,
+    });
+    expect(sel.provider).toBe('vertex');
+    expect(sel.source).toBe('fallback');
+    expect(sel.warnings).toHaveLength(1);
+    expect(sel.warnings[0]).toContain('LIVEKIT_URL');
+    expect(sel.warnings[0]).toContain('falling back to vertex');
+  });
+
+  it('lists every missing credential in the warning', () => {
+    const sel = selectUpstreamProvider({ ORB_LIVE_PROVIDER: 'livekit' });
+    expect(sel.provider).toBe('vertex');
+    expect(sel.source).toBe('fallback');
+    expect(sel.warnings[0]).toContain('LIVEKIT_URL');
+    expect(sel.warnings[0]).toContain('LIVEKIT_API_KEY');
+    expect(sel.warnings[0]).toContain('LIVEKIT_API_SECRET');
+  });
+
+  it('treats blank-string credentials as missing', () => {
+    const sel = selectUpstreamProvider({
+      ...FULL_LIVEKIT_ENV,
+      LIVEKIT_API_SECRET: '   ',
+    });
+    expect(sel.provider).toBe('vertex');
+    expect(sel.source).toBe('fallback');
+    expect(sel.warnings[0]).toContain('LIVEKIT_API_SECRET');
+  });
+
+  it('falls back to vertex with a warning naming the unknown value', () => {
+    const sel = selectUpstreamProvider({ ORB_LIVE_PROVIDER: 'openai' });
+    expect(sel.provider).toBe('vertex');
+    expect(sel.source).toBe('fallback');
+    expect(sel.warnings).toHaveLength(1);
+    expect(sel.warnings[0]).toContain('openai');
+    expect(sel.warnings[0]).toContain('not a recognized provider');
+  });
+});
+
+describe('readLiveKitConfigFromEnv', () => {
+  it('maps env vars onto the LiveKitClientConfig shape', () => {
+    expect(readLiveKitConfigFromEnv(FULL_LIVEKIT_ENV)).toEqual({
+      url: 'wss://livekit.example.com',
+      apiKey: 'test-key',
+      apiSecret: 'test-secret',
+    });
+  });
+
+  it('substitutes empty strings for missing env vars', () => {
+    expect(readLiveKitConfigFromEnv({})).toEqual({
+      url: '',
+      apiKey: '',
+      apiSecret: '',
+    });
+  });
+});
+
+describe('createUpstreamLiveClient', () => {
+  it('returns a VertexLiveClient instance for the vertex selection', () => {
+    const client = createUpstreamLiveClient(
+      { provider: 'vertex', source: 'default', warnings: [] },
+      {},
+    );
+    expect(client).toBeInstanceOf(VertexLiveClient);
+  });
+
+  it('returns a LiveKitLiveClient instance for the livekit selection', () => {
+    const client = createUpstreamLiveClient(
+      { provider: 'livekit', source: 'env', warnings: [] },
+      FULL_LIVEKIT_ENV,
+    );
+    expect(client).toBeInstanceOf(LiveKitLiveClient);
+  });
+});


### PR DESCRIPTION
## Summary

Track A — refactor / **Session B** (sibling of A7 / A9.1 / A9.2). Adds the LiveKit adapter beside the existing Vertex/Gemini upstream path **without wiring it into production**.

- **`LiveKitLiveClient`** (`services/gateway/src/orb/live/upstream/livekit-live-client.ts`) — implements `UpstreamLiveClient` (the A7 boundary) end-to-end, but `connect()` deliberately rejects with a typed `code: 'not_implemented'` error. A misconfigured rollout cannot silently produce a no-audio session. Config validation rejects missing/blank credentials and non-`ws[s]://` URLs ahead of the not-implemented refusal.
- **`provider-selection.ts`** — pure `selectUpstreamProvider(env)` + `createUpstreamLiveClient(selection)`. Default = vertex. LiveKit is opt-in via `ORB_LIVE_PROVIDER=livekit` AND the full `LIVEKIT_URL` / `LIVEKIT_API_KEY` / `LIVEKIT_API_SECRET` triple. Anything else (missing creds, unknown name) falls back to vertex with a typed warning the call-site should emit as OASIS telemetry.
- **`docs/plans/livekit-migration.md`** — gap analysis: what `UpstreamLiveClient` already supports cleanly vs. 7 gaps the interface does not yet model (audio direction, room/participant identity, token minting, audio-out to browser, reconnect/resume, disconnect classification, frontend contract). Selection rules + risks + explicit out-of-scope list.

## What this PR explicitly does NOT do

- Edit `routes/orb-live.ts` or `orb/live/transport/*` (A8/A9 territory).
- Change Vertex behavior anywhere.
- Wire LiveKit into any production call site — the third test file (`no-production-livekit-wiring.test.ts`) is a **structural guard** that fails if a future PR imports `LiveKitLiveClient` outside the seam, or wires `selectUpstreamProvider` / `createUpstreamLiveClient` into `orb-live.ts`. Any wiring PR should delete that file in the same change.
- Mutate the `UpstreamLiveClient` interface — every gap is documented as a future change.
- Touch reliability tuning, decision-contract, or contextual intelligence.

## Tests

- `provider-selection.test.ts` (13 cases) — default, explicit vertex, livekit happy path, every missing-cred combination, blank strings, case-insensitivity, unknown-name fallback, factory returns the right concrete class.
- `livekit-live-client.test.ts` (15 cases) — interface method presence, lifecycle states, send-returns-false-before-connect, handler registration, connect rejection (valid config → `not_implemented`; broken config → `invalid_config`), `invalid_state` on second connect, close lifecycle + idempotency, `defaultValidateConfig` matrix.
- `no-production-livekit-wiring.test.ts` (3 cases) — no src file outside the seam imports `LiveKitLiveClient`; `routes/orb-live.ts` does not import the seam; default selection is vertex.

64/64 green in `test/orb/live/upstream/` (33 prior A7 tests + 31 new). `npm run build` (gateway) green.

## Test plan

- [ ] Reviewer reads `docs/plans/livekit-migration.md` and confirms the gap list matches the eventual implementation strategy
- [ ] Reviewer confirms `LiveKitLiveClient.connect()` failing loud (rather than no-op success) is the desired skeleton behavior
- [ ] Reviewer confirms `provider-selection` fallback-to-vertex (rather than throw) is the desired safety stance
- [ ] After merge: NO EXEC-DEPLOY behavior change expected — selection seam has no production caller. The wiring PR should backfill OASIS event emission for `selection.warnings`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)