### PR TITLE
feat(orb): A8.1 — session controller shell + registry seam (VTID-02959)

### DIFF
--- a/services/gateway/src/orb/live/session/live-session-registry.ts
+++ b/services/gateway/src/orb/live/session/live-session-registry.ts
@@ -1,0 +1,67 @@
+/**
+ * A8.1 (orb-live-refactor / VTID-02959): session lifecycle controller shell —
+ * registry of session Maps.
+ *
+ * What this owns:
+ *   - `sessions` (legacy `OrbLiveSession` Map; pre-VTID-01155 path)
+ *   - `liveSessions` (current `GeminiLiveSession` Map; ORB voice path)
+ *   - `wsClientSessions` (WebSocket client tracking Map)
+ *
+ * What this does NOT own (yet — moves in A8.2 / A8.3):
+ *   - Session start / create logic
+ *   - Session attach / detach / close lifecycle
+ *   - LiveAPI message handling that writes SSE events
+ *   - `/live/stream/send` + `/live/stream/end-turn` action handlers
+ *   - Replacement of `connectToLiveAPI` with `VertexLiveClient`
+ *
+ * A8.1 is the SHELL only — moving the Map declarations into this module
+ * makes the controller the canonical owner of session state. A8.2 + A8.3
+ * fill in the lifecycle methods that operate on these Maps. orb-live.ts
+ * imports the Map values from here and continues to mutate them in
+ * place; the Map instances themselves are unchanged (same identity).
+ *
+ * Hard rules (carried from A7 / A9.1 / A9.2):
+ *   1. No behavior change. The Map instances exported here are the same
+ *      Map instances that orb-live.ts used to declare locally — just
+ *      sourced from a different module.
+ *   2. Type definitions stay in `routes/orb-live.ts` for A8.1 (they
+ *      reference deep coupling with the rest of the route file —
+ *      `ContextPack`, `SupabaseIdentity`, `ClientContext`, etc.). The
+ *      registry uses `import type` so runtime has no cycle.
+ *   3. No imports from `orb-live.ts` other than the type-only Map
+ *      generics. Runtime behavior is fully decoupled.
+ */
+
+import type {
+  OrbLiveSession,
+  GeminiLiveSession,
+  WsClientSession,
+} from '../../../routes/orb-live';
+
+/**
+ * Legacy `OrbLiveSession` registry — keyed by session ID.
+ *
+ * Used by the pre-VTID-01155 `/orb/live` SSE path (`GET /live`,
+ * `POST /start`, `POST /audio`, `POST /text`, `POST /mute`,
+ * `POST /stop`). Newer ORB voice traffic flows through `liveSessions`.
+ */
+export const sessions = new Map<string, OrbLiveSession>();
+
+/**
+ * Active Gemini Live API session registry — keyed by session ID.
+ *
+ * Current ORB voice path. Created by `POST /api/v1/orb/live/session/start`,
+ * consumed by `/live/stream` SSE, `/live/stream/send` REST,
+ * `/live/stream/end-turn` REST, the WebSocket `start` message, and
+ * `POST /api/v1/orb/live/session/stop`.
+ */
+export const liveSessions = new Map<string, GeminiLiveSession>();
+
+/**
+ * Per-WebSocket-client tracking — keyed by WS-bound session ID.
+ *
+ * Distinct from `liveSessions` because a WebSocket client may exist
+ * before a Gemini Live session is started (`{type:'start'}` message)
+ * and may outlive it (`{type:'stop'}` then a new `{type:'start'}`).
+ */
+export const wsClientSessions = new Map<string, WsClientSession>();

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -266,7 +266,7 @@ const router = Router();
 // Types & Constants
 // =============================================================================
 
-interface OrbLiveSession {
+export interface OrbLiveSession {
   sessionId: string;
   tenant: string;
   role: string;
@@ -308,8 +308,9 @@ interface StopMessage {
   sessionId: string;
 }
 
-// In-memory session store (dev sandbox only)
-const sessions = new Map<string, OrbLiveSession>();
+// In-memory session store (dev sandbox only).
+// A8.1: declaration moved to orb/live/session/live-session-registry.ts;
+// the `sessions` symbol used below is imported at the top of this file.
 
 // A2 (orb-live-refactor): SESSION_TIMEOUT_MS lifted to orb/live/config.ts.
 import { SESSION_TIMEOUT_MS } from '../orb/live/config';
@@ -754,7 +755,7 @@ import { SUPPORTED_LIVE_LANGUAGES } from '../orb/live/config';
  * VTID-01155: Gemini Live session state
  * VTID-01224: Extended with identity and context fields for intelligence stack
  */
-interface GeminiLiveSession {
+export interface GeminiLiveSession {
   sessionId: string;
   lang: string;
   voiceStyle?: string;
@@ -957,8 +958,9 @@ import type {
 } from '../orb/live/types';
 export type { ClientContext } from '../orb/live/types';
 
-// VTID-01155: In-memory Live session store
-const liveSessions = new Map<string, GeminiLiveSession>();
+// VTID-01155: In-memory Live session store.
+// A8.1: declaration moved to orb/live/session/live-session-registry.ts;
+// the `liveSessions` symbol used below is imported at the top of this file.
 
 // VTID-SESSION-LEAK-FIX: Periodic sweep to purge zombie sessions.
 // Safety net in case SSE/WS close handlers miss cleanup (e.g. abrupt process kill).
@@ -1125,6 +1127,16 @@ import {
   writeSseEvent,
   startSseHeartbeat,
 } from '../orb/live/transport/sse-handler';
+// A8.1 (orb-live-refactor / VTID-02959): session registries lifted to
+// orb/live/session/live-session-registry.ts. Same Map instances, same
+// identity — only the declaration location moves. orb-live.ts continues
+// to mutate `sessions`, `liveSessions`, `wsClientSessions` in place;
+// A8.2 + A8.3 lift the lifecycle methods that operate on these Maps.
+import {
+  sessions,
+  liveSessions,
+  wsClientSessions,
+} from '../orb/live/session/live-session-registry';
 // A3 (orb-live-refactor): system instruction builder + its private helpers
 // (describeTimeSince, describeRoute, buildTemporalJourneyContextSection,
 // TemporalBucket type) lifted to orb/live/instruction/live-system-instruction.ts.
@@ -12888,7 +12900,7 @@ interface WsClientMessage {
  * VTID-01222: WebSocket session state
  * VTID-01224: Added identity for context retrieval
  */
-interface WsClientSession {
+export interface WsClientSession {
   sessionId: string;
   clientWs: WebSocket;
   liveSession: GeminiLiveSession | null;
@@ -12902,8 +12914,9 @@ interface WsClientSession {
   originUrl: string | null;
 }
 
-// Track WebSocket client sessions
-const wsClientSessions = new Map<string, WsClientSession>();
+// Track WebSocket client sessions.
+// A8.1: declaration moved to orb/live/session/live-session-registry.ts;
+// the `wsClientSessions` symbol used below is imported at the top of this file.
 
 /**
  * VTID-01222: Initialize WebSocket server for ORB client connections

--- a/services/gateway/test/orb/live/characterization/websocket-setup.characterization.test.ts
+++ b/services/gateway/test/orb/live/characterization/websocket-setup.characterization.test.ts
@@ -18,10 +18,10 @@ import * as path from 'path';
 const ORB_LIVE_PATH = path.resolve(__dirname, '../../../../src/routes/orb-live.ts');
 
 let setupBody: string;
-let registryDecl: string;
+let source: string;
 
 beforeAll(() => {
-  const source = fs.readFileSync(ORB_LIVE_PATH, 'utf8');
+  source = fs.readFileSync(ORB_LIVE_PATH, 'utf8');
 
   const setupStart = source.indexOf('export function initializeOrbWebSocket');
   expect(setupStart).toBeGreaterThan(0);
@@ -30,10 +30,6 @@ beforeAll(() => {
   setupBody = nextExport >= 0
     ? source.slice(setupStart, setupStart + 1 + nextExport)
     : source.slice(setupStart);
-
-  const registryStart = source.indexOf('wsClientSessions = new Map');
-  expect(registryStart).toBeGreaterThan(0);
-  registryDecl = source.slice(Math.max(0, registryStart - 100), registryStart + 200);
 });
 
 describe('A9.1 characterization: initializeOrbWebSocket delegates to the transport module', () => {
@@ -69,11 +65,18 @@ describe('A9.1 characterization: initializeOrbWebSocket delegates to the transpo
   });
 });
 
-describe('A9.1 characterization: per-session registry remains in orb-live.ts', () => {
-  it('declares wsClientSessions as a Map', () => {
-    // The Map type matters — the cleanup interval iterates over it.
-    // Per-session state moves to orb/live/session/* under A8, NOT A9.1.
-    expect(registryDecl).toMatch(/wsClientSessions\s*=\s*new\s+Map\s*</);
+describe('A8.1 update: per-session registry now lives in orb/live/session/live-session-registry.ts', () => {
+  it('orb-live.ts imports wsClientSessions from the registry module (not a local declaration)', () => {
+    expect(source).toMatch(
+      /from\s*['"`][^'"`]*\/orb\/live\/session\/live-session-registry['"`]/,
+    );
+    expect(source).toMatch(/\bwsClientSessions\b/);
+  });
+
+  it('orb-live.ts no longer declares wsClientSessions = new Map(...) locally', () => {
+    expect(source).not.toMatch(
+      /^\s*(const|let|var)\s+wsClientSessions\s*=\s*new\s+Map\s*</m,
+    );
   });
 });
 

--- a/services/gateway/test/orb/live/session/live-session-registry.test.ts
+++ b/services/gateway/test/orb/live/session/live-session-registry.test.ts
@@ -1,0 +1,95 @@
+/**
+ * A8.1 (orb-live-refactor / VTID-02959): tests for the session controller
+ * shell — `orb/live/session/live-session-registry.ts`.
+ *
+ * A8.1 is intentionally minimal: lift the 3 Map declarations into the new
+ * module, leave every other ownership concern (start/stop/cleanup/dispatch)
+ * in `routes/orb-live.ts` for A8.2 + A8.3. These tests lock the contract:
+ *
+ *   1. The registry exports the 3 Maps with the legacy names.
+ *   2. Each Map is a real `Map` (the cleanup interval + ownership iteration
+ *      in orb-live.ts depend on `Map.entries()` / `Map.delete()`).
+ *   3. The Maps are SINGLETONS — orb-live.ts and any future consumer
+ *      (A8.2 controller methods) MUST observe the same identity.
+ *   4. orb-live.ts no longer declares the Maps locally (anti-regression on
+ *      a future `const liveSessions = new Map(...)` slipping back in).
+ *   5. orb-live.ts imports the Maps from the registry module.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  sessions,
+  liveSessions,
+  wsClientSessions,
+} from '../../../../src/orb/live/session/live-session-registry';
+
+const ORB_LIVE_PATH = path.resolve(__dirname, '../../../../src/routes/orb-live.ts');
+
+describe('A8.1: live-session-registry exports', () => {
+  it('exports `sessions` as a Map', () => {
+    expect(sessions).toBeInstanceOf(Map);
+  });
+
+  it('exports `liveSessions` as a Map', () => {
+    expect(liveSessions).toBeInstanceOf(Map);
+  });
+
+  it('exports `wsClientSessions` as a Map', () => {
+    expect(wsClientSessions).toBeInstanceOf(Map);
+  });
+
+  it('Maps are singletons — re-importing returns the same instance', async () => {
+    const reimport = await import(
+      '../../../../src/orb/live/session/live-session-registry'
+    );
+    expect(reimport.sessions).toBe(sessions);
+    expect(reimport.liveSessions).toBe(liveSessions);
+    expect(reimport.wsClientSessions).toBe(wsClientSessions);
+  });
+
+  it('Maps support the operations orb-live.ts performs (get / set / delete / entries)', () => {
+    // We don't put real session shapes here — just verify the Map API
+    // surface the legacy code depends on.
+    const probe = { sessionId: 'a8.1-probe' } as any;
+    sessions.set('a8.1-probe', probe);
+    expect(sessions.get('a8.1-probe')).toBe(probe);
+    expect(Array.from(sessions.entries())).toContainEqual(['a8.1-probe', probe]);
+    sessions.delete('a8.1-probe');
+    expect(sessions.has('a8.1-probe')).toBe(false);
+  });
+});
+
+describe('A8.1 anti-regression: orb-live.ts is a consumer, not a declarer', () => {
+  let source: string;
+  beforeAll(() => {
+    source = fs.readFileSync(ORB_LIVE_PATH, 'utf8');
+  });
+
+  it('imports the Maps from the session registry', () => {
+    expect(source).toMatch(
+      /from\s*['"`][^'"`]*\/orb\/live\/session\/live-session-registry['"`]/,
+    );
+    expect(source).toMatch(/\bsessions\b/);
+    expect(source).toMatch(/\bliveSessions\b/);
+    expect(source).toMatch(/\bwsClientSessions\b/);
+  });
+
+  it('does NOT declare `sessions = new Map<` locally', () => {
+    expect(source).not.toMatch(/^\s*(const|let|var)\s+sessions\s*=\s*new\s+Map\s*</m);
+  });
+
+  it('does NOT declare `liveSessions = new Map<` locally', () => {
+    expect(source).not.toMatch(/^\s*(const|let|var)\s+liveSessions\s*=\s*new\s+Map\s*</m);
+  });
+
+  it('does NOT declare `wsClientSessions = new Map<` locally', () => {
+    expect(source).not.toMatch(/^\s*(const|let|var)\s+wsClientSessions\s*=\s*new\s+Map\s*</m);
+  });
+
+  it('exports the OrbLiveSession / GeminiLiveSession / WsClientSession interfaces (so the registry can type-import them)', () => {
+    expect(source).toMatch(/export\s+interface\s+OrbLiveSession\b/);
+    expect(source).toMatch(/export\s+interface\s+GeminiLiveSession\b/);
+    expect(source).toMatch(/export\s+interface\s+WsClientSession\b/);
+  });
+});


### PR DESCRIPTION
## Summary

Track A / A8 split per the spec's risk-warning into A8.1 / A8.2 / A8.3. This is **A8.1 — the smallest possible slice**: lift only the 3 session Map declarations into a new module so future controller methods (A8.2, A8.3) have a canonical home.

**Zero behavior change.** The Map instances are physically the same objects (same identity); only the module that declares them moves. orb-live.ts continues to mutate them in place exactly as before.

## What lands

- **services/gateway/src/orb/live/session/live-session-registry.ts** — declares + exports the 3 Maps (`sessions`, `liveSessions`, `wsClientSessions`). Uses `import type` for the Map generics — no runtime cycle.
- **routes/orb-live.ts** —
  - `OrbLiveSession`, `GeminiLiveSession`, `WsClientSession` interfaces now `export interface`.
  - Three local `const X = new Map(...)` declarations replaced by `import { sessions, liveSessions, wsClientSessions } from '../orb/live/session/live-session-registry'`.
- **test/orb/live/session/live-session-registry.test.ts** — 9 new tests (registry exports, Map type, singleton identity, get/set/delete, anti-regression on orb-live.ts).
- **test/orb/live/characterization/websocket-setup.characterization.test.ts** — updated the registry slice (previously anchored on the inline `wsClientSessions = new Map<` line A8.1 just removed; now asserts the seam holds).

## Acceptance checks (A8 spec)

1. ✅ Existing A0 session-start characterization green.
2. ✅ A9.1 WS + A9.2 SSE structural tests green (1 updated to follow the seam).
3. ✅ New controller tests cover registry contract (9 tests; A8.2/A8.3 will add lifecycle method tests).
4. ✅ Vertex remains default upstream (no upstream changes in A8.1).
5. ✅ No LiveKit implementation yet.
6. ✅ No contextual intelligence changes.
7. ✅ No reliability tuning.
8. ⏳ Production /orb/chat smoke after deploy.

## What this PR does NOT touch (deferred to A8.2 / A8.3)

- Session start / create / attach / detach / close lifecycle methods — A8.2.
- `/live/stream/send` + `/live/stream/end-turn` action handlers — A8.2.
- LiveAPI message handler that writes SSE events — A8.3.
- `connectToLiveAPI` → `VertexLiveClient` migration — A8.3.
- The ~25 per-event `session.sseResponse.write(...)` writes — A8.3 (will migrate to `writeSseEvent` from A9.2).

## Test plan

- [x] 9 new tests on `live-session-registry`
- [x] 2 updated structural assertions on the WS char test (registry seam)
- [x] 534 tests green across `test/orb/**` (no regression). A7 / A9.1 / A9.2 transport tests + decision-contract spine tests + all characterization suites still green.
- [x] TypeScript clean.
- [ ] Post-merge: EXEC-DEPLOY + /orb/chat production smoke.

🤖 Generated with [Claude Code](https://claude.com/claude-code)