### PR TITLE
feat(self-healing): Test Contract Registry + safe run surface + 6 seed contracts (VTID-02954, DEV-COMHU-02954, PR-L1)

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -2743,6 +2743,7 @@ const NAVIGATION_CONFIG = [
             { "key": "journey-context", "label": "Journey Context",    "path": "/command-hub/voice/journey-context/" },
             { "key": "tools",           "label": "Tool Catalog",       "path": "/command-hub/voice/tools/" },
             { "key": "self-healing",    "label": "Self-Healing",       "path": "/command-hub/voice/self-healing/" },
+            { "key": "test-contracts",  "label": "Test Contracts",     "path": "/command-hub/voice/test-contracts/" },
             { "key": "livekit-test",    "label": "LiveKit Test Bench", "path": "/command-hub/voice/livekit-test/" },
             { "key": "orb-ui-monitor",  "label": "Orb UI Monitor",     "path": "/command-hub/voice/orb-ui-monitor/" }
         ]
@@ -6185,6 +6186,9 @@ function renderModuleContent(moduleKey, tab) {
     } else if (moduleKey === 'voice' && tab === 'self-healing') {
         // Voice slice extracted from autonomy/self-healing
         container.appendChild(renderVoiceSelfHealingPanel());
+    } else if (moduleKey === 'voice' && tab === 'test-contracts') {
+        // VTID-02954 (PR-L1): Test Contract Registry — read-only status panel
+        container.appendChild(renderTestContractsPanel());
     } else if (moduleKey === 'voice' && tab === 'livekit-test') {
         container.appendChild(renderLivekitTestView());
     } else if (moduleKey === 'voice' && tab === 'orb-ui-monitor') {
@@ -43826,6 +43830,157 @@ function renderVoiceSelfHealingPanel() {
     });
 
     return panel;
+}
+
+// ─────────────────────────────────────────────────────────────────────────
+// VTID-02954 (PR-L1): Test Contract Registry — read-only status panel.
+//
+// Fetches /api/v1/test-contracts and renders a table of (capability, status,
+// last_run_at, owner). Each row has a manual "Run now" button (admin-only;
+// the backend rejects non-admins). PR-L1 is read+run only — no edit/delete
+// from this surface yet.
+// ─────────────────────────────────────────────────────────────────────────
+function renderTestContractsPanel() {
+    var container = document.createElement('div');
+    container.style.cssText = 'padding:16px;';
+
+    var tcState = state.testContracts || (state.testContracts = { rows: null, error: null, running: {} });
+
+    var header = document.createElement('div');
+    header.style.cssText = 'margin-bottom:16px;';
+    header.innerHTML =
+        '<h2 style="margin:0;color:var(--color-text-primary);">Test Contracts</h2>' +
+        '<p style="margin:4px 0 0 0;color:var(--color-text-secondary);font-size:0.85rem;">' +
+        'The autonomy spine. Every capability has a contract defining "healthy". If a contract fails, self-healing repairs the system back to known-good behavior. ' +
+        '<strong>VTID-02954 (PR-L1)</strong> — read-only registry + sync_http run surface. ' +
+        'Missing-test scanner (PR-L2), failure scanner (PR-L3), and known-good recovery (PR-L4) plug into this same table.' +
+        '</p>';
+    container.appendChild(header);
+
+    if (tcState.rows === null && tcState.error === null) {
+        fetch('/api/v1/test-contracts', { headers: buildContextHeaders() })
+            .then(function (r) {
+                if (!r.ok) throw new Error('HTTP ' + r.status);
+                return r.json();
+            })
+            .then(function (data) {
+                tcState.rows = data.contracts || [];
+                tcState.error = null;
+                renderApp();
+            })
+            .catch(function (e) {
+                tcState.error = e.message;
+                tcState.rows = [];
+                renderApp();
+            });
+        var loading = document.createElement('div');
+        loading.style.cssText = 'padding:24px;text-align:center;color:var(--color-text-secondary);';
+        loading.textContent = 'Loading test contracts...';
+        container.appendChild(loading);
+        return container;
+    }
+
+    if (tcState.error) {
+        var err = document.createElement('div');
+        err.style.cssText = 'padding:24px;background:rgba(220,38,38,0.1);border:1px solid #dc2626;border-radius:6px;color:#fca5a5;';
+        err.textContent = 'Failed to load test contracts: ' + tcState.error;
+        container.appendChild(err);
+        return container;
+    }
+
+    if (!tcState.rows || tcState.rows.length === 0) {
+        var none = document.createElement('div');
+        none.style.cssText = 'padding:24px;text-align:center;color:var(--color-text-secondary);';
+        none.textContent = 'No test contracts registered yet. Migration 20260521000000 seeds 6 contracts.';
+        container.appendChild(none);
+        return container;
+    }
+
+    // Summary band
+    var summary = document.createElement('div');
+    summary.style.cssText = 'display:flex;gap:16px;margin-bottom:16px;padding:12px;background:var(--color-surface);border:1px solid var(--color-border);border-radius:6px;';
+    var byStatus = { pass: 0, fail: 0, pending: 0, unknown: 0, quarantined: 0 };
+    tcState.rows.forEach(function (r) {
+        if (byStatus.hasOwnProperty(r.status)) byStatus[r.status] += 1;
+    });
+    summary.innerHTML =
+        '<div><strong style="color:var(--color-text-primary);">' + tcState.rows.length + '</strong> contracts</div>' +
+        '<div style="color:#16a34a;"><strong>' + byStatus.pass + '</strong> passing</div>' +
+        '<div style="color:#dc2626;"><strong>' + byStatus.fail + '</strong> failing</div>' +
+        '<div style="color:#94a3b8;"><strong>' + byStatus.unknown + '</strong> never run</div>' +
+        '<div style="color:#fbbf24;"><strong>' + byStatus.pending + '</strong> pending</div>' +
+        '<div style="color:#f87171;"><strong>' + byStatus.quarantined + '</strong> quarantined</div>';
+    container.appendChild(summary);
+
+    // Rows
+    tcState.rows.forEach(function (row) {
+        var card = document.createElement('section');
+        var statusColor = row.status === 'pass' ? '#16a34a' : row.status === 'fail' ? '#dc2626' : row.status === 'quarantined' ? '#f87171' : row.status === 'pending' ? '#fbbf24' : '#94a3b8';
+        var regressed = row.status === 'fail' && row.last_status === 'pass';
+        card.style.cssText = 'margin-bottom:8px;padding:12px 14px;background:var(--color-surface);border:1px solid var(--color-border);border-left:4px solid ' + statusColor + ';border-radius:6px;display:flex;justify-content:space-between;align-items:center;gap:12px;';
+
+        var info = document.createElement('div');
+        info.style.cssText = 'flex:1;min-width:0;';
+        var statusBadge = '<span style="display:inline-block;font-size:0.65rem;font-weight:700;padding:0.1rem 0.4rem;border-radius:4px;color:' + statusColor + ';background:' + statusColor + '22;text-transform:uppercase;margin-right:0.4rem;">' + row.status + '</span>';
+        var regressedBadge = regressed ? '<span style="display:inline-block;font-size:0.6rem;font-weight:700;padding:0.1rem 0.35rem;border-radius:4px;color:#dc2626;background:#dc262622;margin-right:0.4rem;">REGRESSED</span>' : '';
+        info.innerHTML =
+            '<div style="font-weight:600;font-size:0.9rem;">' + statusBadge + regressedBadge + escapeHtml(row.capability) + '</div>' +
+            '<div style="font-size:0.75rem;color:var(--color-text-secondary);margin-top:0.2rem;">' +
+                escapeHtml(row.contract_type) + ' · ' +
+                escapeHtml(row.service) + '/' + escapeHtml(row.environment) + ' · ' +
+                'owner: ' + escapeHtml(row.owner) +
+                (row.target_endpoint ? ' · ' + escapeHtml(row.target_endpoint) : '') +
+            '</div>' +
+            '<div style="font-size:0.7rem;color:var(--color-text-secondary);margin-top:0.2rem;">' +
+                'last run: ' + (row.last_run_at ? new Date(row.last_run_at).toLocaleString() : 'never') +
+                (row.last_failure_signature ? ' · <span style="color:#dc2626;">' + escapeHtml(row.last_failure_signature).slice(0, 120) + '</span>' : '') +
+            '</div>';
+        card.appendChild(info);
+
+        var actions = document.createElement('div');
+        actions.style.cssText = 'display:flex;gap:6px;flex-shrink:0;';
+        var runBtn = document.createElement('button');
+        runBtn.style.cssText = 'padding:6px 12px;font-size:0.75rem;border-radius:4px;border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text-primary);cursor:pointer;';
+        runBtn.disabled = tcState.running[row.id] === true;
+        runBtn.textContent = runBtn.disabled ? 'Running...' : 'Run now';
+        runBtn.onclick = function () {
+            tcState.running[row.id] = true;
+            renderApp();
+            fetch('/api/v1/test-contracts/' + encodeURIComponent(row.id) + '/run', {
+                method: 'POST',
+                headers: buildContextHeaders(),
+            })
+                .then(function (r) { return r.json(); })
+                .then(function (data) {
+                    tcState.running[row.id] = false;
+                    if (data.ok && data.result) {
+                        // Update row in place
+                        for (var i = 0; i < tcState.rows.length; i++) {
+                            if (tcState.rows[i].id === row.id) {
+                                tcState.rows[i].status = data.new_status;
+                                tcState.rows[i].last_status = data.previous_status;
+                                tcState.rows[i].last_run_at = data.result.ran_at;
+                                tcState.rows[i].last_failure_signature = data.result.failure_reason
+                                    ? row.command_key + ':' + data.result.failure_reason
+                                    : null;
+                            }
+                        }
+                    }
+                    renderApp();
+                })
+                .catch(function (e) {
+                    tcState.running[row.id] = false;
+                    alert('Run failed: ' + e.message);
+                    renderApp();
+                });
+        };
+        actions.appendChild(runBtn);
+        card.appendChild(actions);
+
+        container.appendChild(card);
+    });
+
+    return container;
 }
 
 function renderSelfHealingView() {

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -30,7 +30,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260504-vtid-02710-ios-ctx-keepalive"></script>
-  <script src="/command-hub/app.js?v=20260513-vtid-02953-pr-k-cockpit"></script>
+  <script src="/command-hub/app.js?v=20260513-vtid-02954-pr-l1-test-contracts"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
 </body>

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -718,6 +718,11 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const voiceImproveRouter = require('./routes/voice-improve').default;
   mountRouterSync(app, '/api/v1', voiceImproveRouter, { owner: 'voice-improve' });
 
+  // VTID-02954 (PR-L1): Test Contract Registry — autonomy spine for self-healing
+  // GET /api/v1/test-contracts + /:id + /by-capability/:cap + POST /:id/run
+  const testContractsRouter = require('./routes/test-contracts').default;
+  mountRouterSync(app, '/api/v1', testContractsRouter, { owner: 'test-contracts' });
+
   // VTID-02909 (B0c): Journey Context inspection (Voice / Journey Context tab)
   // GET /api/v1/voice/journey-context/preview + GET /api/v1/voice/journey-context/state
   const voiceJourneyContextRouter = require('./routes/voice-journey-context').default;

--- a/services/gateway/src/routes/test-contracts.ts
+++ b/services/gateway/src/routes/test-contracts.ts
@@ -1,0 +1,303 @@
+/**
+ * VTID-02954 (PR-L1): Test Contract Registry routes.
+ *
+ *   GET  /api/v1/test-contracts                 list + filter
+ *   GET  /api/v1/test-contracts/:id             one row
+ *   GET  /api/v1/test-contracts/by-capability/:capability
+ *   POST /api/v1/test-contracts/:id/run         admin-only; allowlist-resolved
+ *
+ * Auth posture (explicit):
+ *   - GET  → requireDevAccess (exafy_admin OR X-Gateway-Internal)
+ *   - POST → stricter: requireAuthWithTenant + req.identity.exafy_admin.
+ *     Run dispatch is admin-mutating (writes status='pending', then 'pass'/'fail').
+ *
+ * Safety:
+ *   - The DB stores `command_key` (a string key), NOT a shell command.
+ *   - /run resolves command_key against COMMAND_ALLOWLIST. Unknown key
+ *     → 400. Never executes the database value as shell.
+ *   - PR-L1 only dispatches `sync_http` allowlist entries. Other dispatch
+ *     kinds (cloud_run_job, workflow_dispatch) are added in PR-L3.
+ */
+
+import { Router, Request, Response, NextFunction } from 'express';
+import { emitOasisEvent } from '../services/oasis-event-service';
+import {
+  requireAuth,
+  requireAuthWithTenant,
+  AuthenticatedRequest,
+} from '../middleware/auth-supabase-jwt';
+import { resolveCommand } from '../services/test-contract-commands';
+
+const router = Router();
+const VTID = 'VTID-02954';
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE =
+  process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+
+function supabaseHeaders() {
+  return {
+    apikey: SUPABASE_SERVICE_ROLE!,
+    Authorization: `Bearer ${SUPABASE_SERVICE_ROLE}`,
+    'Content-Type': 'application/json',
+  };
+}
+
+function supabaseConfigured(): boolean {
+  return Boolean(SUPABASE_URL && SUPABASE_SERVICE_ROLE);
+}
+
+// ---------------------------------------------------------------------------
+// Local auth helper — same pattern as voice-improve.ts. Duplicated to keep
+// routers loosely coupled; the logic is small.
+// ---------------------------------------------------------------------------
+async function requireDevAccess(req: Request, res: Response, next: NextFunction): Promise<void> {
+  if (
+    req.get('X-Gateway-Internal') === (process.env.GATEWAY_INTERNAL_TOKEN || '__dev__') &&
+    process.env.GATEWAY_INTERNAL_TOKEN
+  ) {
+    return next();
+  }
+  let authFailed = false;
+  await requireAuth(req as AuthenticatedRequest, res, () => {
+    const identity = (req as AuthenticatedRequest).identity;
+    if (!identity) {
+      authFailed = true;
+      res.status(401).json({ ok: false, error: 'UNAUTHENTICATED', vtid: VTID });
+      return;
+    }
+    if (identity.exafy_admin === true) return next();
+    authFailed = true;
+    res.status(403).json({
+      ok: false,
+      error: 'Test Contracts requires developer access (exafy_admin)',
+      vtid: VTID,
+    });
+  });
+  if (authFailed) return;
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/test-contracts
+// Filters (query): service, environment, owner, status, contract_type
+// ---------------------------------------------------------------------------
+router.get('/test-contracts', requireDevAccess, async (req: Request, res: Response) => {
+  if (!supabaseConfigured()) {
+    return res.status(500).json({ ok: false, error: 'supabase not configured', vtid: VTID });
+  }
+  const filters: string[] = [];
+  if (req.query.service) filters.push(`service=eq.${encodeURIComponent(String(req.query.service))}`);
+  if (req.query.environment)
+    filters.push(`environment=eq.${encodeURIComponent(String(req.query.environment))}`);
+  if (req.query.owner) filters.push(`owner=eq.${encodeURIComponent(String(req.query.owner))}`);
+  if (req.query.status) filters.push(`status=eq.${encodeURIComponent(String(req.query.status))}`);
+  if (req.query.contract_type)
+    filters.push(`contract_type=eq.${encodeURIComponent(String(req.query.contract_type))}`);
+  const query = filters.length > 0 ? '?' + filters.join('&') + '&order=capability.asc' : '?order=capability.asc';
+  try {
+    const r = await fetch(`${SUPABASE_URL}/rest/v1/test_contracts${query}`, {
+      headers: supabaseHeaders(),
+    });
+    if (!r.ok) {
+      return res.status(502).json({ ok: false, error: 'database query failed', status: r.status, vtid: VTID });
+    }
+    const rows = await r.json();
+    return res.json({ ok: true, contracts: rows, vtid: VTID });
+  } catch (err) {
+    return res.status(500).json({ ok: false, error: (err as Error).message, vtid: VTID });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/test-contracts/:id
+// ---------------------------------------------------------------------------
+router.get('/test-contracts/:id', requireDevAccess, async (req: Request, res: Response) => {
+  if (!supabaseConfigured()) {
+    return res.status(500).json({ ok: false, error: 'supabase not configured', vtid: VTID });
+  }
+  const id = String(req.params.id);
+  // Basic UUID shape check to keep the URL out of being a query-injection vector
+  if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id)) {
+    return res.status(400).json({ ok: false, error: 'invalid id format', vtid: VTID });
+  }
+  try {
+    const r = await fetch(
+      `${SUPABASE_URL}/rest/v1/test_contracts?id=eq.${id}&limit=1`,
+      { headers: supabaseHeaders() },
+    );
+    if (!r.ok) {
+      return res.status(502).json({ ok: false, error: 'database query failed', vtid: VTID });
+    }
+    const rows = (await r.json()) as any[];
+    if (rows.length === 0) {
+      return res.status(404).json({ ok: false, error: 'NOT_FOUND', vtid: VTID });
+    }
+    return res.json({ ok: true, contract: rows[0], vtid: VTID });
+  } catch (err) {
+    return res.status(500).json({ ok: false, error: (err as Error).message, vtid: VTID });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/test-contracts/by-capability/:capability
+// ---------------------------------------------------------------------------
+router.get(
+  '/test-contracts/by-capability/:capability',
+  requireDevAccess,
+  async (req: Request, res: Response) => {
+    if (!supabaseConfigured()) {
+      return res.status(500).json({ ok: false, error: 'supabase not configured', vtid: VTID });
+    }
+    const capability = String(req.params.capability);
+    if (!/^[a-z0-9_]{3,128}$/.test(capability)) {
+      return res.status(400).json({ ok: false, error: 'invalid capability format', vtid: VTID });
+    }
+    try {
+      const r = await fetch(
+        `${SUPABASE_URL}/rest/v1/test_contracts?capability=eq.${encodeURIComponent(capability)}&limit=1`,
+        { headers: supabaseHeaders() },
+      );
+      if (!r.ok) {
+        return res.status(502).json({ ok: false, error: 'database query failed', vtid: VTID });
+      }
+      const rows = (await r.json()) as any[];
+      if (rows.length === 0) {
+        return res.status(404).json({ ok: false, error: 'NOT_FOUND', vtid: VTID });
+      }
+      return res.json({ ok: true, contract: rows[0], vtid: VTID });
+    } catch (err) {
+      return res.status(500).json({ ok: false, error: (err as Error).message, vtid: VTID });
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/test-contracts/:id/run
+// Admin-only. Resolves command_key against COMMAND_ALLOWLIST. PR-L1
+// supports sync_http dispatch only; other dispatch kinds return 501.
+// ---------------------------------------------------------------------------
+router.post(
+  '/test-contracts/:id/run',
+  requireAuthWithTenant,
+  async (req: Request, res: Response) => {
+    if (!supabaseConfigured()) {
+      return res.status(500).json({ ok: false, error: 'supabase not configured', vtid: VTID });
+    }
+    const identity = (req as AuthenticatedRequest).identity;
+    if (!identity || identity.exafy_admin !== true) {
+      return res.status(403).json({
+        ok: false,
+        error: 'admin access required to run test contracts',
+        vtid: VTID,
+      });
+    }
+    const id = String(req.params.id);
+    if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id)) {
+      return res.status(400).json({ ok: false, error: 'invalid id format', vtid: VTID });
+    }
+    // Step 1: load the contract
+    const fetchResp = await fetch(
+      `${SUPABASE_URL}/rest/v1/test_contracts?id=eq.${id}&limit=1`,
+      { headers: supabaseHeaders() },
+    );
+    if (!fetchResp.ok) {
+      return res.status(502).json({ ok: false, error: 'database query failed', vtid: VTID });
+    }
+    const rows = (await fetchResp.json()) as any[];
+    if (rows.length === 0) {
+      return res.status(404).json({ ok: false, error: 'NOT_FOUND', vtid: VTID });
+    }
+    const contract = rows[0];
+
+    // Step 2: resolve the command_key against the allowlist
+    const command = resolveCommand(contract.command_key);
+    if (!command) {
+      return res.status(400).json({
+        ok: false,
+        error: 'COMMAND_KEY_NOT_ALLOWLISTED',
+        message: `command_key '${contract.command_key}' is not in COMMAND_ALLOWLIST. Add an entry in services/gateway/src/services/test-contract-commands.ts first.`,
+        vtid: VTID,
+      });
+    }
+
+    // Step 3: PR-L1 only supports sync_http
+    if (command.dispatch !== 'sync_http') {
+      return res.status(501).json({
+        ok: false,
+        error: 'DISPATCH_NOT_IMPLEMENTED_IN_PR_L1',
+        message: `dispatch='${command.dispatch}' lands in PR-L3 (test_contract_runs table + Cloud Run Job)`,
+        vtid: VTID,
+      });
+    }
+
+    // Step 4: run the resolved typed function. Never an exec/spawn.
+    const result = await command.resolve(contract.expected_behavior);
+
+    // Step 5: persist run state
+    const newStatus = result.passed ? 'pass' : 'fail';
+    const previousStatus = contract.status as string;
+    const failureSignature = result.passed
+      ? null
+      : `${command.command_key}:${result.failure_reason || 'unknown'}`;
+    const patchBody: Record<string, unknown> = {
+      status: newStatus,
+      last_run_at: result.ran_at,
+      last_status: previousStatus,
+      last_failure_signature: failureSignature,
+    };
+    if (result.passed) {
+      // Last-passing SHA tracking requires a known SHA. PR-L1 doesn't have
+      // that yet — Phase 3's failure scanner runs against deployed revisions
+      // and will pass in the deployed SHA. For now we leave last_passing_sha
+      // alone and only update it when the caller provides it.
+    }
+    await fetch(`${SUPABASE_URL}/rest/v1/test_contracts?id=eq.${id}`, {
+      method: 'PATCH',
+      headers: { ...supabaseHeaders(), Prefer: 'return=minimal' },
+      body: JSON.stringify(patchBody),
+    }).catch((err) => {
+      // Persistence failure is non-fatal for the response — return the
+      // result; the cockpit will see the stale row on next refresh.
+      console.warn(`[${VTID}] failed to persist run result for ${id}: ${err}`);
+    });
+
+    // Step 6: emit OASIS event for state transition observability
+    try {
+      await emitOasisEvent({
+        vtid: VTID,
+        type: result.passed
+          ? ('test-contract.run.passed' as any)
+          : ('test-contract.run.failed' as any),
+        source: 'test-contracts',
+        status: result.passed ? 'success' : 'warning',
+        message: `Contract ${contract.capability} ${result.passed ? 'passed' : 'failed'}: ${
+          result.failure_reason || `status=${result.status_code}`
+        }`,
+        payload: {
+          contract_id: id,
+          capability: contract.capability,
+          command_key: command.command_key,
+          passed: result.passed,
+          status_code: result.status_code,
+          duration_ms: result.duration_ms,
+          failure_reason: result.failure_reason,
+          actor_user_id: identity.user_id,
+        },
+      });
+    } catch {
+      /* non-fatal */
+    }
+
+    return res.json({
+      ok: true,
+      contract_id: id,
+      capability: contract.capability,
+      result,
+      previous_status: previousStatus,
+      new_status: newStatus,
+      vtid: VTID,
+    });
+  },
+);
+
+export default router;

--- a/services/gateway/src/services/test-contract-commands.ts
+++ b/services/gateway/src/services/test-contract-commands.ts
@@ -1,0 +1,237 @@
+/**
+ * VTID-02954 (PR-L1): Test Contract Command Allowlist.
+ *
+ * The `test_contracts.command_key` column is a string key, NOT a shell
+ * command. This file is the SINGLE place that maps keys to typed
+ * dispatchers. No exec(), no spawn(), no user-controllable args. Adding
+ * a new testable surface = adding an entry here in a code-reviewed PR.
+ *
+ * PR-L1 ships only `sync_http` dispatchers — they're cheap, fast, and
+ * safe to run inline in a gateway request handler.
+ * PR-L3 will add `cloud_run_job` and `workflow_dispatch` dispatchers
+ * for jest/typecheck contracts (long-running; need async execution).
+ */
+
+import { contractGatewayBaseUrl } from './test-contract-config';
+
+export type TestContractDispatchKind = 'sync_http' | 'cloud_run_job' | 'workflow_dispatch';
+
+export interface TestContractRunResult {
+  passed: boolean;
+  status_code: number | null;
+  content_type: string | null;
+  body_excerpt: string;
+  duration_ms: number;
+  ran_at: string;
+  failure_reason?: string;
+}
+
+export interface AllowlistedCommand {
+  command_key: string;
+  contract_type: 'jest' | 'typecheck' | 'live_probe' | 'workflow_check';
+  dispatch: TestContractDispatchKind;
+  // Typed resolver. Receives the contract's `expected_behavior` JSONB
+  // so the resolver can validate against the contract's own asserts
+  // instead of hard-coding them in the allowlist.
+  resolve: (expected: unknown) => Promise<TestContractRunResult>;
+}
+
+// =============================================================================
+// Sync HTTP probe helper
+// =============================================================================
+
+interface ExpectedHttp {
+  status?: number | number[];
+  content_type_prefix?: string;
+  json_must_contain?: Record<string, unknown>;
+}
+
+function isExpectedHttp(v: unknown): v is ExpectedHttp {
+  return typeof v === 'object' && v !== null;
+}
+
+function statusMatches(actual: number, expected: number | number[] | undefined): boolean {
+  if (expected === undefined) return actual >= 200 && actual < 500;
+  if (Array.isArray(expected)) return expected.includes(actual);
+  return actual === expected;
+}
+
+function jsonContains(haystack: unknown, needle: Record<string, unknown>): boolean {
+  if (typeof haystack !== 'object' || haystack === null) return false;
+  const obj = haystack as Record<string, unknown>;
+  for (const [k, expected] of Object.entries(needle)) {
+    if (obj[k] !== expected) return false;
+  }
+  return true;
+}
+
+async function probeHttp(
+  method: 'GET' | 'POST',
+  path: string,
+  expected: ExpectedHttp,
+  body?: Record<string, unknown>,
+): Promise<TestContractRunResult> {
+  const url = `${contractGatewayBaseUrl()}${path}`;
+  const t0 = Date.now();
+  const ran_at = new Date().toISOString();
+  try {
+    const resp = await fetch(url, {
+      method,
+      headers: body ? { 'Content-Type': 'application/json' } : {},
+      body: body ? JSON.stringify(body) : undefined,
+      signal: AbortSignal.timeout(7_000),
+    });
+    const status_code = resp.status;
+    const content_type = resp.headers.get('content-type');
+    const text = await resp.text();
+    const body_excerpt = text.slice(0, 500);
+
+    if (!statusMatches(status_code, expected.status)) {
+      return {
+        passed: false,
+        status_code,
+        content_type,
+        body_excerpt,
+        duration_ms: Date.now() - t0,
+        ran_at,
+        failure_reason: `status_mismatch: got ${status_code}, expected ${JSON.stringify(expected.status)}`,
+      };
+    }
+    if (expected.content_type_prefix && !(content_type || '').startsWith(expected.content_type_prefix)) {
+      return {
+        passed: false,
+        status_code,
+        content_type,
+        body_excerpt,
+        duration_ms: Date.now() - t0,
+        ran_at,
+        failure_reason: `content_type_mismatch: got "${content_type}", expected prefix "${expected.content_type_prefix}"`,
+      };
+    }
+    if (expected.json_must_contain) {
+      let parsed: unknown;
+      try {
+        parsed = JSON.parse(text);
+      } catch {
+        return {
+          passed: false,
+          status_code,
+          content_type,
+          body_excerpt,
+          duration_ms: Date.now() - t0,
+          ran_at,
+          failure_reason: 'json_parse_failed',
+        };
+      }
+      if (!jsonContains(parsed, expected.json_must_contain)) {
+        return {
+          passed: false,
+          status_code,
+          content_type,
+          body_excerpt,
+          duration_ms: Date.now() - t0,
+          ran_at,
+          failure_reason: `json_must_contain_mismatch: did not find ${JSON.stringify(expected.json_must_contain)}`,
+        };
+      }
+    }
+    return {
+      passed: true,
+      status_code,
+      content_type,
+      body_excerpt,
+      duration_ms: Date.now() - t0,
+      ran_at,
+    };
+  } catch (err) {
+    return {
+      passed: false,
+      status_code: null,
+      content_type: null,
+      body_excerpt: '',
+      duration_ms: Date.now() - t0,
+      ran_at,
+      failure_reason: `fetch_failed: ${(err as Error).message}`,
+    };
+  }
+}
+
+// =============================================================================
+// Allowlist
+// =============================================================================
+
+export const COMMAND_ALLOWLIST: Record<string, AllowlistedCommand> = {
+  'gateway.alive': {
+    command_key: 'gateway.alive',
+    contract_type: 'live_probe',
+    dispatch: 'sync_http',
+    resolve: (expected) => probeHttp('GET', '/alive', isExpectedHttp(expected) ? expected : {}),
+  },
+  'canary_target.disarmed_health': {
+    command_key: 'canary_target.disarmed_health',
+    contract_type: 'live_probe',
+    dispatch: 'sync_http',
+    resolve: (expected) =>
+      probeHttp('GET', '/api/v1/canary-target/health', isExpectedHttp(expected) ? expected : {}),
+  },
+  'canary_target.status': {
+    command_key: 'canary_target.status',
+    contract_type: 'live_probe',
+    dispatch: 'sync_http',
+    resolve: (expected) =>
+      probeHttp('GET', '/api/v1/canary-target/status', isExpectedHttp(expected) ? expected : {}),
+  },
+  'self_healing.active_route_mounted': {
+    command_key: 'self_healing.active_route_mounted',
+    contract_type: 'live_probe',
+    dispatch: 'sync_http',
+    resolve: (expected) =>
+      probeHttp('GET', '/api/v1/self-healing/active', isExpectedHttp(expected) ? expected : {}),
+  },
+  'oasis.vtid_terminalize_validates_payload': {
+    command_key: 'oasis.vtid_terminalize_validates_payload',
+    contract_type: 'live_probe',
+    dispatch: 'sync_http',
+    // Probes with an intentionally-malformed VTID. The gate MUST reject
+    // with 400 (zod validation) or 404 (VTID not found). If it returns
+    // 200, the gate is broken — exact failure mode that hit us before PR-J.
+    resolve: (expected) =>
+      probeHttp('POST', '/api/v1/oasis/vtid/terminalize', isExpectedHttp(expected) ? expected : {}, {
+        vtid: 'VTID-CONTRACT-PROBE-INVALID',
+        outcome: 'success',
+        actor: 'test-contract-probe',
+      }),
+  },
+  'worker_orchestrator.await_autopilot_requires_auth': {
+    command_key: 'worker_orchestrator.await_autopilot_requires_auth',
+    contract_type: 'live_probe',
+    dispatch: 'sync_http',
+    // Probes with empty body. Auth gate must reject: 400 (missing vtid /
+    // autopilot_execution_id) or 401 (missing worker_id). A 200 here
+    // would mean the auth gate is gone — security regression.
+    resolve: (expected) =>
+      probeHttp(
+        'POST',
+        '/api/v1/worker/orchestrator/await-autopilot-execution',
+        isExpectedHttp(expected) ? expected : {},
+        {},
+      ),
+  },
+};
+
+/**
+ * Resolve a command_key against the allowlist. Returns null if the key
+ * is not in the allowlist — callers must treat that as a hard reject
+ * (400), not as "run it anyway".
+ */
+export function resolveCommand(command_key: string): AllowlistedCommand | null {
+  return COMMAND_ALLOWLIST[command_key] ?? null;
+}
+
+/**
+ * Exported for tests + the missing-test scanner (Phase 2) to discover
+ * which command_keys are available.
+ */
+export function listAllowlistedKeys(): string[] {
+  return Object.keys(COMMAND_ALLOWLIST);
+}

--- a/services/gateway/src/services/test-contract-config.ts
+++ b/services/gateway/src/services/test-contract-config.ts
@@ -1,0 +1,20 @@
+/**
+ * VTID-02954 (PR-L1): Gateway base URL used by test-contract probes.
+ * Tests can override via process.env.GATEWAY_INTERNAL_BASE_URL.
+ *
+ * Default is the production Cloud Run URL. The probes go through the
+ * public URL so they exercise the same Cloud Run routing layer real
+ * traffic uses (TLS termination, load balancer, etc.) — running probes
+ * via localhost would miss those failure modes.
+ *
+ * Read at call time (not module-load) so env overrides in tests take
+ * effect when beforeEach runs after the import has already happened.
+ */
+
+export function contractGatewayBaseUrl(): string {
+  return (
+    process.env.GATEWAY_INTERNAL_BASE_URL ||
+    process.env.GATEWAY_PUBLIC_URL ||
+    'https://gateway-86804897789.us-central1.run.app'
+  );
+}

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -605,6 +605,13 @@ export type CicdEventType =
   // (vtid-terminalize.ts emits the same topic via a local fetch helper,
   // so it didn't need the type-system entry.)
   | 'self-healing.terminalize.blocked'
+  // PR-L1 (VTID-02954): Test Contract Registry run events. Emitted by
+  // /api/v1/test-contracts/:id/run for every contract execution so the
+  // cockpit can show pass/fail history and Phase 3's failure scanner
+  // can detect regressions from the event stream.
+  | 'test-contract.run.passed'
+  | 'test-contract.run.failed'
+  | 'test-contract.run.dispatched'
   | 'self-healing.completed'
   | 'self-healing.snapshot.pre_fix'
   | 'self-healing.snapshot.post_fix'

--- a/services/gateway/test/test-contracts.test.ts
+++ b/services/gateway/test/test-contracts.test.ts
@@ -1,0 +1,356 @@
+/**
+ * VTID-02954 (PR-L1): Test Contract Registry — unit tests for the
+ * safety-critical paths.
+ *
+ * The allowlist resolver MUST reject unknown command_key. The /run
+ * endpoint MUST never execute the database value as shell. The
+ * dispatch kind gate MUST refuse non-sync_http until PR-L3 lands.
+ */
+
+import express from 'express';
+import request from 'supertest';
+import { resolveCommand, listAllowlistedKeys, COMMAND_ALLOWLIST } from '../src/services/test-contract-commands';
+
+const ORIGINAL_FETCH = global.fetch;
+
+beforeEach(() => {
+  process.env.SUPABASE_URL = 'https://supabase.test';
+  process.env.SUPABASE_SERVICE_ROLE = 'svc-role';
+  process.env.GATEWAY_INTERNAL_BASE_URL = 'https://gateway.test';
+});
+
+afterEach(() => {
+  global.fetch = ORIGINAL_FETCH;
+  jest.resetModules();
+});
+
+// =============================================================================
+// Allowlist resolver — the safety boundary.
+// =============================================================================
+
+describe('test-contract-commands resolveCommand', () => {
+  it('returns null for an unknown command_key (NEVER fall through to exec)', () => {
+    expect(resolveCommand('arbitrary; rm -rf /')).toBeNull();
+    expect(resolveCommand('gateway.alive; rm -rf /')).toBeNull();
+    expect(resolveCommand('')).toBeNull();
+    expect(resolveCommand('GATEWAY.ALIVE')).toBeNull(); // case-sensitive
+  });
+
+  it('returns the typed dispatcher for an allowlisted key', () => {
+    const cmd = resolveCommand('gateway.alive');
+    expect(cmd).not.toBeNull();
+    expect(cmd!.command_key).toBe('gateway.alive');
+    expect(cmd!.contract_type).toBe('live_probe');
+    expect(cmd!.dispatch).toBe('sync_http');
+    expect(typeof cmd!.resolve).toBe('function');
+  });
+
+  it('exposes the 6 PR-L1 seed contracts', () => {
+    const keys = listAllowlistedKeys().sort();
+    expect(keys).toEqual([
+      'canary_target.disarmed_health',
+      'canary_target.status',
+      'gateway.alive',
+      'oasis.vtid_terminalize_validates_payload',
+      'self_healing.active_route_mounted',
+      'worker_orchestrator.await_autopilot_requires_auth',
+    ]);
+  });
+
+  it('every allowlisted command is sync_http in PR-L1 (no cloud_run_job / workflow_dispatch yet)', () => {
+    for (const cmd of Object.values(COMMAND_ALLOWLIST)) {
+      expect(cmd.dispatch).toBe('sync_http');
+    }
+  });
+
+  it('every allowlisted command is a live_probe in PR-L1 (jest/typecheck/workflow_check land in PR-L3)', () => {
+    for (const cmd of Object.values(COMMAND_ALLOWLIST)) {
+      expect(cmd.contract_type).toBe('live_probe');
+    }
+  });
+});
+
+// =============================================================================
+// sync_http dispatcher — validates contract assertion shapes.
+// =============================================================================
+
+describe('sync_http dispatcher (gateway.alive resolve)', () => {
+  function mockFetch(impl: (url: string, init?: any) => Promise<Response>) {
+    global.fetch = jest.fn().mockImplementation(impl) as unknown as typeof fetch;
+  }
+
+  it('passes when status=200 and json_must_contain matches', async () => {
+    mockFetch(async (url) => {
+      expect(url).toBe('https://gateway.test/alive');
+      return new Response(JSON.stringify({ status: 'ok', service: 'gateway' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json; charset=utf-8' },
+      });
+    });
+    const cmd = resolveCommand('gateway.alive')!;
+    const result = await cmd.resolve({
+      status: 200,
+      content_type_prefix: 'application/json',
+      json_must_contain: { status: 'ok', service: 'gateway' },
+    });
+    expect(result.passed).toBe(true);
+    expect(result.status_code).toBe(200);
+    expect(result.failure_reason).toBeUndefined();
+  });
+
+  it('fails when status mismatches', async () => {
+    mockFetch(async () => new Response('{}', { status: 500 }));
+    const cmd = resolveCommand('gateway.alive')!;
+    const result = await cmd.resolve({ status: 200 });
+    expect(result.passed).toBe(false);
+    expect(result.failure_reason).toContain('status_mismatch');
+    expect(result.status_code).toBe(500);
+  });
+
+  it('fails when content_type mismatches', async () => {
+    mockFetch(async () =>
+      new Response('<html>Cannot GET /alive</html>', {
+        status: 200,
+        headers: { 'content-type': 'text/html; charset=utf-8' },
+      }),
+    );
+    const cmd = resolveCommand('gateway.alive')!;
+    const result = await cmd.resolve({ status: 200, content_type_prefix: 'application/json' });
+    expect(result.passed).toBe(false);
+    expect(result.failure_reason).toContain('content_type_mismatch');
+  });
+
+  it('fails when json_must_contain does not match', async () => {
+    mockFetch(async () =>
+      new Response(JSON.stringify({ status: 'degraded' }), {
+        status: 200,
+        headers: { 'content-type': 'application/json' },
+      }),
+    );
+    const cmd = resolveCommand('gateway.alive')!;
+    const result = await cmd.resolve({
+      status: 200,
+      json_must_contain: { status: 'ok' },
+    });
+    expect(result.passed).toBe(false);
+    expect(result.failure_reason).toContain('json_must_contain_mismatch');
+  });
+
+  it('accepts a list of acceptable status codes (e.g. 200|401 for "route mounted")', async () => {
+    mockFetch(async () => new Response(JSON.stringify({}), { status: 401, headers: { 'content-type': 'application/json' } }));
+    const cmd = resolveCommand('self_healing.active_route_mounted')!;
+    const result = await cmd.resolve({ status: [200, 401], content_type_prefix: 'application/json' });
+    expect(result.passed).toBe(true);
+  });
+
+  it('rejects text/html 404 — the canonical "route not deployed" signal', async () => {
+    mockFetch(async () =>
+      new Response('<!DOCTYPE html><html>Cannot GET /api/v1/canary-target/health</html>', {
+        status: 404,
+        headers: { 'content-type': 'text/html; charset=utf-8' },
+      }),
+    );
+    const cmd = resolveCommand('canary_target.disarmed_health')!;
+    const result = await cmd.resolve({
+      status: 200,
+      content_type_prefix: 'application/json',
+      json_must_contain: { ok: true },
+    });
+    expect(result.passed).toBe(false);
+    expect(result.failure_reason).toContain('status_mismatch');
+  });
+
+  it('captures duration_ms and ran_at on every run', async () => {
+    mockFetch(async () => new Response('{}', { status: 200, headers: { 'content-type': 'application/json' } }));
+    const cmd = resolveCommand('gateway.alive')!;
+    const result = await cmd.resolve({ status: 200 });
+    expect(typeof result.duration_ms).toBe('number');
+    expect(result.duration_ms).toBeGreaterThanOrEqual(0);
+    expect(result.ran_at).toMatch(/^\d{4}-\d{2}-\d{2}T/);
+  });
+
+  it('handles fetch failures gracefully (timeout / network) — passed=false, no throw', async () => {
+    mockFetch(async () => {
+      throw new Error('connect ETIMEDOUT');
+    });
+    const cmd = resolveCommand('gateway.alive')!;
+    const result = await cmd.resolve({ status: 200 });
+    expect(result.passed).toBe(false);
+    expect(result.failure_reason).toContain('fetch_failed');
+    expect(result.failure_reason).toContain('ETIMEDOUT');
+  });
+});
+
+// =============================================================================
+// POST /:id/run endpoint — auth + allowlist gate + dispatch gate.
+// =============================================================================
+
+describe('POST /api/v1/test-contracts/:id/run', () => {
+  // Build a minimal app that mounts ONLY the test-contracts router with a
+  // mock auth middleware. We can't import the real auth-supabase-jwt
+  // middleware in unit tests (it hits Supabase) — so we install a small
+  // shim that mimics req.identity assignment.
+
+  function buildApp(asAdmin: boolean = true): express.Express {
+    jest.resetModules();
+    process.env.SUPABASE_URL = 'https://supabase.test';
+    process.env.SUPABASE_SERVICE_ROLE = 'svc-role';
+    // Pre-mock the auth middleware module so the router picks it up.
+    jest.doMock('../src/middleware/auth-supabase-jwt', () => ({
+      requireAuth: (_req: any, _res: any, next: any) => next(),
+      requireAuthWithTenant: (req: any, _res: any, next: any) => {
+        req.identity = { exafy_admin: asAdmin, user_id: 'test-user-uuid' };
+        next();
+      },
+    }));
+    jest.doMock('../src/services/oasis-event-service', () => ({
+      emitOasisEvent: jest.fn().mockResolvedValue(undefined),
+    }));
+    const router = require('../src/routes/test-contracts').default;
+    const app = express();
+    app.use(express.json());
+    app.use('/api/v1', router);
+    return app;
+  }
+
+  function mockSupabaseFetch(contractRow: any, captureUpdates: any[] = []) {
+    global.fetch = jest.fn().mockImplementation(async (url: string, init?: any) => {
+      // SELECT test_contracts?id=eq.X
+      if (typeof url === 'string' && url.includes('/rest/v1/test_contracts?id=eq.')) {
+        if (!init?.method || init.method === 'GET') {
+          return new Response(JSON.stringify(contractRow ? [contractRow] : []), {
+            status: 200,
+            headers: { 'content-type': 'application/json' },
+          });
+        }
+        if (init.method === 'PATCH') {
+          captureUpdates.push(JSON.parse(init.body));
+          return new Response('', { status: 204 });
+        }
+      }
+      // The live_probe target (when allowlist resolver fires)
+      if (typeof url === 'string' && url.endsWith('/alive')) {
+        return new Response(JSON.stringify({ status: 'ok', service: 'gateway' }), {
+          status: 200,
+          headers: { 'content-type': 'application/json' },
+        });
+      }
+      // OASIS event POST
+      if (typeof url === 'string' && url.includes('/rest/v1/oasis_events')) {
+        return new Response('{}', { status: 201 });
+      }
+      return new Response('{}', { status: 200 });
+    }) as unknown as typeof fetch;
+  }
+
+  const VALID_UUID = '11111111-2222-3333-4444-555555555555';
+
+  it('returns 400 for malformed id (rejects shell-injection-shaped paths)', async () => {
+    const app = buildApp(true);
+    mockSupabaseFetch(null);
+    const res = await request(app).post('/api/v1/test-contracts/not-a-uuid/run');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('invalid id format');
+  });
+
+  it('returns 403 when caller is not exafy_admin', async () => {
+    const app = buildApp(false);
+    mockSupabaseFetch(null);
+    const res = await request(app).post(`/api/v1/test-contracts/${VALID_UUID}/run`);
+    expect(res.status).toBe(403);
+    expect(res.body.error).toContain('admin access required');
+  });
+
+  it('returns 404 when the contract id is unknown', async () => {
+    const app = buildApp(true);
+    mockSupabaseFetch(null);
+    const res = await request(app).post(`/api/v1/test-contracts/${VALID_UUID}/run`);
+    expect(res.status).toBe(404);
+    expect(res.body.error).toBe('NOT_FOUND');
+  });
+
+  it('returns 400 COMMAND_KEY_NOT_ALLOWLISTED when contract.command_key is not in the allowlist (the safety gate)', async () => {
+    const app = buildApp(true);
+    mockSupabaseFetch({
+      id: VALID_UUID,
+      capability: 'rogue',
+      command_key: 'rm -rf /', // intentionally a shell-shaped string
+      status: 'unknown',
+      expected_behavior: {},
+    });
+    const res = await request(app).post(`/api/v1/test-contracts/${VALID_UUID}/run`);
+    expect(res.status).toBe(400);
+    expect(res.body.error).toBe('COMMAND_KEY_NOT_ALLOWLISTED');
+  });
+
+  it('runs sync_http and persists status=pass on success', async () => {
+    const updates: any[] = [];
+    const app = buildApp(true);
+    mockSupabaseFetch(
+      {
+        id: VALID_UUID,
+        capability: 'gateway_alive',
+        command_key: 'gateway.alive',
+        status: 'unknown',
+        expected_behavior: {
+          status: 200,
+          content_type_prefix: 'application/json',
+          json_must_contain: { status: 'ok' },
+        },
+      },
+      updates,
+    );
+    const res = await request(app).post(`/api/v1/test-contracts/${VALID_UUID}/run`);
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.result.passed).toBe(true);
+    expect(res.body.new_status).toBe('pass');
+    expect(res.body.previous_status).toBe('unknown');
+    // The PATCH body to test_contracts must update status, last_run_at, last_status, last_failure_signature
+    expect(updates.length).toBe(1);
+    expect(updates[0].status).toBe('pass');
+    expect(updates[0].last_failure_signature).toBeNull();
+    expect(updates[0].last_status).toBe('unknown');
+  });
+
+  it('persists status=fail + last_failure_signature on probe failure', async () => {
+    const updates: any[] = [];
+    const app = buildApp(true);
+    // Override the /alive mock to return 500
+    global.fetch = jest.fn().mockImplementation(async (url: string, init?: any) => {
+      if (typeof url === 'string' && url.includes('/rest/v1/test_contracts?id=eq.')) {
+        if (!init?.method || init.method === 'GET') {
+          return new Response(
+            JSON.stringify([
+              {
+                id: VALID_UUID,
+                capability: 'gateway_alive',
+                command_key: 'gateway.alive',
+                status: 'pass',
+                expected_behavior: { status: 200 },
+              },
+            ]),
+            { status: 200, headers: { 'content-type': 'application/json' } },
+          );
+        }
+        if (init.method === 'PATCH') {
+          updates.push(JSON.parse(init.body));
+          return new Response('', { status: 204 });
+        }
+      }
+      if (typeof url === 'string' && url.endsWith('/alive')) {
+        return new Response('boom', { status: 500 });
+      }
+      return new Response('{}', { status: 200 });
+    }) as unknown as typeof fetch;
+    const res = await request(app).post(`/api/v1/test-contracts/${VALID_UUID}/run`);
+    expect(res.status).toBe(200);
+    expect(res.body.result.passed).toBe(false);
+    expect(res.body.new_status).toBe('fail');
+    expect(updates[0].status).toBe('fail');
+    expect(updates[0].last_failure_signature).toBe('gateway.alive:status_mismatch: got 500, expected 200');
+    // Regression detection: last_status records the previous status so the
+    // cockpit can show "regressed: pass→fail".
+    expect(updates[0].last_status).toBe('pass');
+  });
+});

--- a/supabase/migrations/20260521000000_VTID_02954_test_contracts.sql
+++ b/supabase/migrations/20260521000000_VTID_02954_test_contracts.sql
@@ -1,0 +1,204 @@
+-- VTID-02954 (PR-L1): Test Contract Registry — the autonomy spine.
+--
+-- A capability has a test contract. If the contract fails, self-healing
+-- repairs the system back to known-good behavior. If the contract is
+-- missing, self-healing first creates the missing contract. This table
+-- is the source of truth for what "healthy" means per capability.
+--
+-- PR-L1 ships this schema + read-only CRUD + sync_http run surface.
+-- PR-L2 (missing-test scanner) reads from here.
+-- PR-L3 (failure scanner) writes status here on every cycle.
+-- PR-L4 (known-good recovery) uses last_passing_sha for repair context.
+-- PR-L5 (pattern memory) is gated on the prior phases.
+
+-- ============================================================
+-- Enums
+-- ============================================================
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'test_contract_type') THEN
+    CREATE TYPE test_contract_type AS ENUM (
+      'jest',
+      'typecheck',
+      'live_probe',
+      'workflow_check'
+    );
+  END IF;
+END $$;
+
+DO $$
+BEGIN
+  IF NOT EXISTS (SELECT 1 FROM pg_type WHERE typname = 'test_contract_status') THEN
+    CREATE TYPE test_contract_status AS ENUM (
+      'unknown',
+      'pass',
+      'fail',
+      'pending',
+      'quarantined'
+    );
+  END IF;
+END $$;
+
+-- ============================================================
+-- test_contracts
+-- ============================================================
+
+CREATE TABLE IF NOT EXISTS test_contracts (
+  id                       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- Identity
+  capability               TEXT NOT NULL UNIQUE,
+  contract_type            test_contract_type NOT NULL,
+  command_key              TEXT NOT NULL,
+
+  -- Target scope
+  service                  TEXT NOT NULL,
+  environment              TEXT NOT NULL DEFAULT 'dev',
+  target_file              TEXT,
+  target_endpoint          TEXT,
+
+  -- Contract definition
+  expected_behavior        JSONB NOT NULL,
+  owner                    TEXT NOT NULL,
+
+  -- Lifecycle state
+  status                   test_contract_status NOT NULL DEFAULT 'unknown',
+  branch_or_sha            TEXT,
+  last_passing_sha         TEXT,
+  last_failure_signature   TEXT,
+  last_run_at              TIMESTAMPTZ,
+  last_status              test_contract_status,
+
+  -- Self-healing posture
+  repairable               BOOLEAN NOT NULL DEFAULT true,
+
+  -- Dedupe for missing-test-scanner (Phase 2)
+  -- sha256(capability:service:contract_type) is unique. Stored as a
+  -- generated column so the scanner cannot create duplicates and any
+  -- direct INSERT must produce a fresh dedupe_key automatically.
+  dedupe_key               TEXT NOT NULL UNIQUE
+    GENERATED ALWAYS AS (
+      capability || ':' || service || ':' || contract_type::text
+    ) STORED,
+
+  -- Audit
+  created_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at               TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_test_contracts_status        ON test_contracts (status);
+CREATE INDEX IF NOT EXISTS idx_test_contracts_service_env   ON test_contracts (service, environment);
+CREATE INDEX IF NOT EXISTS idx_test_contracts_owner         ON test_contracts (owner);
+CREATE INDEX IF NOT EXISTS idx_test_contracts_last_run_at   ON test_contracts (last_run_at DESC);
+
+-- updated_at trigger
+CREATE OR REPLACE FUNCTION test_contracts_set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_test_contracts_set_updated_at ON test_contracts;
+CREATE TRIGGER trg_test_contracts_set_updated_at
+BEFORE UPDATE ON test_contracts
+FOR EACH ROW EXECUTE FUNCTION test_contracts_set_updated_at();
+
+-- ============================================================
+-- Seed: 6 high-confidence contracts the platform already depends on.
+-- All sync_http only in PR-L1. command_key MUST match an entry in
+-- services/gateway/src/services/test-contract-commands.ts COMMAND_ALLOWLIST.
+-- ============================================================
+
+INSERT INTO test_contracts (
+  capability, contract_type, command_key, service, environment,
+  target_file, target_endpoint, expected_behavior, owner, repairable
+) VALUES
+  (
+    'gateway_alive',
+    'live_probe',
+    'gateway.alive',
+    'gateway',
+    'dev',
+    'services/gateway/src/index.ts',
+    '/alive',
+    '{"status": 200, "content_type_prefix": "application/json", "json_must_contain": {"status": "ok", "service": "gateway"}}'::jsonb,
+    'gateway-core',
+    true
+  ),
+  (
+    'canary_target_disarmed_health',
+    'live_probe',
+    'canary_target.disarmed_health',
+    'gateway',
+    'dev',
+    'services/gateway/src/routes/canary-target.ts',
+    '/api/v1/canary-target/health',
+    '{"status": 200, "content_type_prefix": "application/json", "json_must_contain": {"ok": true}, "notes": "Asserts the route is mounted and the disarmed path works. Armed-path behavior is exercised via jest, not via live_probe."}'::jsonb,
+    'self-healing',
+    true
+  ),
+  (
+    'canary_target_status',
+    'live_probe',
+    'canary_target.status',
+    'gateway',
+    'dev',
+    'services/gateway/src/routes/canary-target.ts',
+    '/api/v1/canary-target/status',
+    '{"status": 200, "content_type_prefix": "application/json", "json_must_contain": {"ok": true, "config_key": "self_healing_canary_armed"}}'::jsonb,
+    'self-healing',
+    true
+  ),
+  (
+    'self_healing_active_route_mounted',
+    'live_probe',
+    'self_healing.active_route_mounted',
+    'gateway',
+    'dev',
+    'services/gateway/src/routes/self-healing.ts',
+    '/api/v1/self-healing/active',
+    '{"status": [200, 401], "content_type_prefix": "application/json", "notes": "401 is acceptable (auth required) — proves the route is mounted. text/html 404 means the route is NOT mounted."}'::jsonb,
+    'self-healing',
+    true
+  ),
+  (
+    'oasis_vtid_terminalize_validates_payload',
+    'live_probe',
+    'oasis.vtid_terminalize_validates_payload',
+    'gateway',
+    'dev',
+    'services/gateway/src/routes/vtid-terminalize.ts',
+    '/api/v1/oasis/vtid/terminalize',
+    '{"status": [400, 404], "content_type_prefix": "application/json", "notes": "Probed with an intentionally invalid VTID. We assert the gate validates: 400 (VALIDATION_FAILED / INVALID_VTID_FORMAT) or 404 (NOT_FOUND). A 200 here would mean the gate is broken — exact failure mode that hit us today before PR-J."}'::jsonb,
+    'self-healing',
+    true
+  ),
+  (
+    'worker_orchestrator_await_autopilot_requires_auth',
+    'live_probe',
+    'worker_orchestrator.await_autopilot_requires_auth',
+    'gateway',
+    'dev',
+    'services/gateway/src/routes/worker-orchestrator.ts',
+    '/api/v1/worker/orchestrator/await-autopilot-execution',
+    '{"status": [400, 401], "content_type_prefix": "application/json", "notes": "Probed with missing worker_id. We assert auth gating: 400 (missing vtid/exec_id) or 401 (missing worker_id). A 200 would mean the auth gate dropped — security regression."}'::jsonb,
+    'self-healing',
+    true
+  )
+ON CONFLICT (capability) DO NOTHING;
+
+-- ============================================================
+-- Permissions: service_role only. RLS is OFF (operational table,
+-- service_role accesses directly; no per-user reads).
+-- ============================================================
+
+ALTER TABLE test_contracts ENABLE ROW LEVEL SECURITY;
+
+-- Service role bypasses RLS automatically; no policies needed for
+-- authenticated/anon (they should never reach this table).
+
+COMMENT ON TABLE test_contracts IS
+  'VTID-02954: Test Contract Registry — the autonomy spine. Every capability has a contract; failures trigger self-healing; missing contracts are scanned and filled.';


### PR DESCRIPTION
## Summary

The autonomy spine for self-healing. **Every capability has a contract defining "healthy"; failures trigger self-healing; missing contracts are scanned and filled.** PR-L1 ships the registry surface only — boring on purpose.

Plan: `/home/dstev/.claude/plans/test-contract-backbone-knowing-healthy-curie.md`

Phase 1-5 sequence:
- **PR-L1 (this)** — Test Contract Registry + safe run surface
- **PR-L2** — Missing-test scanner (allocates VTIDs for capabilities with no contract)
- **PR-L3** — Failure scanner (scheduled runs → repair VTIDs anchored to failing tests)
- **PR-L4** — Known-good recovery (last_passing_sha diff as repair LLM context)
- **PR-L5** — Pattern memory (only learns from contract-anchored verified repairs)

## What's in this PR

- **Migration** `20260521000000_VTID_02954_test_contracts.sql`:
  - `test_contract_type` ENUM: `jest | typecheck | live_probe | workflow_check`
  - `test_contract_status` ENUM: `unknown | pass | fail | pending | quarantined`
  - `test_contracts` table with all amendments from the plan: structured `expected_behavior` JSONB, `environment`/`service`/`branch_or_sha`/`last_passing_sha`/`last_failure_signature`, `last_status` for regression detection, `dedupe_key` as a stored generated column so the missing-test scanner can never create duplicates
  - 6 seed contracts: `gateway_alive`, `canary_target_disarmed_health`, `canary_target_status`, `self_healing_active_route_mounted`, `oasis_vtid_terminalize_validates_payload`, `worker_orchestrator_await_autopilot_requires_auth`
  - The terminalize-validates-payload contract intentionally probes with an invalid VTID — a 200 there would mean the gate is broken (exactly the failure mode that bit us before PR-J)

- **`services/gateway/src/services/test-contract-commands.ts` — THE SAFETY BOUNDARY**:
  - `COMMAND_ALLOWLIST` maps `command_key` strings to typed dispatchers. The DB stores only the key; this file resolves it to a typed function. **No `exec()`, no `spawn()`, no user-controllable args.**
  - 6 `sync_http` `live_probe` entries matching the seed contracts
  - Schema-driven assertions — the contract's `expected_behavior` JSONB drives validation; the allowlist entry doesn't hard-code assertions

- **`services/gateway/src/routes/test-contracts.ts`**:
  - `GET /api/v1/test-contracts` (dev access; filter by service/env/owner/status/type)
  - `GET /api/v1/test-contracts/:id` (UUID-shape gate, 404 if not found)
  - `GET /api/v1/test-contracts/by-capability/:cap` (capability regex gate)
  - `POST /api/v1/test-contracts/:id/run` (**admin only**; allowlist-resolved; sync_http only in L1)
  - Flow: load → resolve → reject if not allowlisted → reject if dispatch ≠ sync_http (L3 ships cloud_run_job / workflow_dispatch) → run typed function → persist `status` + `last_status` + `last_failure_signature` → emit OASIS event
  - `last_status` preserved on every PATCH so the cockpit can show "regressed: pass→fail" distinct from "still failing: fail→fail"

- **OASIS event types** added: `test-contract.run.passed`, `.failed`, `.dispatched`

- **`test/test-contracts.test.ts`** — 19 tests including:
  - `resolveCommand` rejects shell-shaped strings (`"arbitrary; rm -rf /"`, `"gateway.alive; rm -rf /"`, case-mismatched keys)
  - exposes exactly the 6 PR-L1 seed contracts
  - every allowlist entry is `sync_http + live_probe` in L1 (jest/typecheck deliberately deferred)
  - sync_http dispatcher: pass on shape-match, fail on status/ct/json mismatch, accepts status arrays (200|401 = "route mounted"), rejects text/html 404 ("route not deployed"), handles fetch timeouts
  - `/run` endpoint: 400 invalid id, 403 non-admin, 404 unknown id, **400 `COMMAND_KEY_NOT_ALLOWLISTED` for shell-shaped command_key**, 200 pass persists `status=pass + last_failure_signature=null`, 200 fail persists `status=fail + last_failure_signature + last_status=previous`

- **Command Hub**: new "Test Contracts" sub-tab under Voice. **Read-only status panel** — per-contract status pill, regression badge, last_run timestamp, last_failure_signature, owner, target_endpoint. "Run now" button per row (backend rejects non-admins). Cache-buster bumped.

## What's deliberately NOT in this PR (per plan)

- No CRUD writes via API (mutation surface lands after registry is observably stable)
- No `cloud_run_job` dispatch (jest/typecheck) — PR-L3
- No missing-test scanner — PR-L2
- No failure scanner / scheduled runner — PR-L3
- No known-good recovery — PR-L4
- No pattern memory — PR-L5

## Test plan

- [x] Migration applies cleanly (syntax verified)
- [x] `test/test-contracts.test.ts` — 19/19
- [x] Full self-healing regression: 121/122 across 12 suites (1 skip is the pre-existing `it.skip` from PR #2076 documenting pre-repair canary behavior)
- [x] `npm run build` clean
- [ ] **After merge**: run `RUN-MIGRATION.yml` workflow for `20260521000000_VTID_02954_test_contracts.sql`
- [ ] After EXEC-DEPLOY: open `/command-hub/voice/test-contracts/` — should show 6 contracts at status=unknown; clicking "Run now" on each should flip them to pass (proves the live-probe loop works against deployed code)

## Why this PR is boring on purpose

The safety properties of the registry depend on the schema being right. If we shipped allowlist + CRUD write + scheduled runner + pattern memory all at once, any bug in any layer would be much harder to isolate. PR-L1's only job is: define the truth surface, prove the run loop on six known-good capabilities, and leave the door open for PRs L2–L5 to plug in without schema changes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)