### PR TITLE
feat(orb): B6 — interaction-style decision integration (VTID-02962)

### DIFF
--- a/services/gateway/src/orb/context/compile-assistant-decision-context.ts
+++ b/services/gateway/src/orb/context/compile-assistant-decision-context.ts
@@ -3,6 +3,7 @@
  * VTID-02950 (F2)     — adds conceptMastery provider.
  * VTID-02954 (F3)     — adds journeyStage provider.
  * VTID-02955 (B5)     — adds pillarMomentum provider.
+ * VTID-02962 (B6)     — adds interactionStyle provider.
  *
  * The orchestrator. Calls each registered provider, collects their
  * distilled output, and produces ONE `AssistantDecisionContext` the
@@ -27,6 +28,8 @@ import { defaultJourneyStageFetcher } from '../../services/journey-stage/journey
 import { compileJourneyStageContext } from '../../services/journey-stage/compile-journey-stage-context';
 import { defaultPillarMomentumFetcher } from '../../services/pillar-momentum/pillar-momentum-fetcher';
 import { compilePillarMomentumContext } from '../../services/pillar-momentum/compile-pillar-momentum-context';
+import { defaultInteractionStyleFetcher } from '../../services/interaction-style/interaction-style-fetcher';
+import { compileInteractionStyleContext } from '../../services/interaction-style/compile-interaction-style-context';
 import {
   distillContinuityForDecision,
 } from './providers/continuity-decision-provider';
@@ -39,10 +42,14 @@ import {
 import {
   distillPillarMomentumForDecision,
 } from './providers/pillar-momentum-decision-provider';
+import {
+  distillInteractionStyleForDecision,
+} from './providers/interaction-style-decision-provider';
 import type {
   AssistantDecisionContext,
   DecisionConceptMastery,
   DecisionContinuity,
+  DecisionInteractionStyle,
   DecisionJourneyStage,
   DecisionPillarMomentum,
 } from './types';
@@ -61,6 +68,7 @@ export interface CompileAssistantDecisionContextInputs {
     conceptMastery: () => Promise<DecisionConceptMastery | null>;
     journeyStage: () => Promise<DecisionJourneyStage | null>;
     pillarMomentum: () => Promise<DecisionPillarMomentum | null>;
+    interactionStyle: () => Promise<DecisionInteractionStyle | null>;
   }>;
   /**
    * Source-health reporter override for tests — when the provider
@@ -72,17 +80,25 @@ export interface CompileAssistantDecisionContextInputs {
     conceptMastery: string;
     journeyStage: string;
     pillarMomentum: string;
+    interactionStyle: string;
   }>;
 }
 
 export async function compileAssistantDecisionContext(
   input: CompileAssistantDecisionContextInputs,
 ): Promise<AssistantDecisionContext> {
-  const [continuityRun, conceptMasteryRun, journeyStageRun, pillarMomentumRun] = await Promise.all([
+  const [
+    continuityRun,
+    conceptMasteryRun,
+    journeyStageRun,
+    pillarMomentumRun,
+    interactionStyleRun,
+  ] = await Promise.all([
     runContinuityProvider(input),
     runConceptMasteryProvider(input),
     runJourneyStageProvider(input),
     runPillarMomentumProvider(input),
+    runInteractionStyleProvider(input),
   ]);
 
   return {
@@ -90,11 +106,13 @@ export async function compileAssistantDecisionContext(
     concept_mastery: conceptMasteryRun.value,
     journey_stage: journeyStageRun.value,
     pillar_momentum: pillarMomentumRun.value,
+    interaction_style: interactionStyleRun.value,
     source_health: {
       continuity: continuityRun.health,
       concept_mastery: conceptMasteryRun.health,
       journey_stage: journeyStageRun.health,
       pillar_momentum: pillarMomentumRun.health,
+      interaction_style: interactionStyleRun.health,
     },
   };
 }
@@ -289,6 +307,42 @@ async function runPillarMomentumProvider(
     return { value: decisionView, health: { ok: true } };
   } catch (e) {
     const reason = input.reasons?.pillarMomentum ?? (e as Error).message;
+    return { value: null, health: { ok: false, reason } };
+  }
+}
+
+async function runInteractionStyleProvider(
+  input: CompileAssistantDecisionContextInputs,
+): Promise<ProviderRun<DecisionInteractionStyle>> {
+  const override = input.providers?.interactionStyle;
+  if (override) {
+    try {
+      const value = await override();
+      return { value, health: { ok: true } };
+    } catch (e) {
+      return {
+        value: null,
+        health: { ok: false, reason: (e as Error).message },
+      };
+    }
+  }
+
+  try {
+    const fetchResult = await defaultInteractionStyleFetcher.fetchInteractionStyleRow({
+      tenantId: input.tenantId,
+      userId: input.userId,
+    });
+
+    if (!fetchResult.ok) {
+      const reason = fetchResult.reason ?? 'interaction_style_unavailable';
+      return { value: null, health: { ok: false, reason } };
+    }
+
+    const interactionStyle = compileInteractionStyleContext({ fetchResult });
+    const decisionView = distillInteractionStyleForDecision({ interactionStyle });
+    return { value: decisionView, health: { ok: true } };
+  } catch (e) {
+    const reason = input.reasons?.interactionStyle ?? (e as Error).message;
     return { value: null, health: { ok: false, reason } };
   }
 }

--- a/services/gateway/src/orb/context/providers/interaction-style-decision-provider.ts
+++ b/services/gateway/src/orb/context/providers/interaction-style-decision-provider.ts
@@ -1,0 +1,100 @@
+/**
+ * VTID-02962 (B6) — InteractionStyle → AssistantDecisionContext adapter.
+ *
+ * The B6 read-only compile slice produced `InteractionStyleContext`,
+ * a richer shape designed for the Command Hub operator. The assistant
+ * decision layer reads a NARROWER shape (`DecisionInteractionStyle`)
+ * that strips:
+ *   - raw `last_updated_at` ISO timestamp
+ *   - operator-only `source_health` envelope (the orchestrator
+ *     re-builds source-health at the AssistantDecisionContext level)
+ *   - anything that could leak chat-message bodies, raw transcripts,
+ *     raw memory rows, route history, or free-text psychological
+ *     summary into the prompt
+ *
+ * Kept: bucketed enum preferences, explanation-depth hint already
+ * decision-grade, coarse confidence band, and enum-only warnings.
+ *
+ * NEVER carries:
+ *   - medical interpretation
+ *   - mental-health inference
+ *   - diagnostic-feeling personality labels
+ *   - free-text psychological summaries
+ *
+ * Pure function. No IO. The caller is responsible for invoking the
+ * interaction-style compiler + passing its output here.
+ */
+
+import type { InteractionStyleContext } from '../../../services/interaction-style/types';
+import type {
+  DecisionInteractionStyle,
+  InteractionStyleWarning,
+} from '../types';
+
+export interface DistillInteractionStyleInputs {
+  /**
+   * Output of `compileInteractionStyleContext` from B6. Read-only.
+   */
+  interactionStyle: InteractionStyleContext;
+}
+
+/**
+ * Distills `InteractionStyleContext` into the decision-grade
+ * `DecisionInteractionStyle`.
+ *
+ * Always returns a typed shape (never undefined). The caller decides
+ * whether to attach it to `AssistantDecisionContext.interaction_style`
+ * or set the field to `null` based on source health.
+ */
+export function distillInteractionStyleForDecision(
+  input: DistillInteractionStyleInputs,
+): DecisionInteractionStyle {
+  const { interactionStyle } = input;
+
+  const warnings = computeDecisionWarnings(interactionStyle);
+
+  return {
+    preferred_response_style: interactionStyle.preferred_response_style,
+    interaction_pace: interactionStyle.interaction_pace,
+    tone_preference: interactionStyle.tone_preference,
+    explanation_depth_hint: interactionStyle.explanation_depth_hint,
+    confidence_bucket: interactionStyle.confidence_bucket,
+    warnings,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — exported for tests
+// ---------------------------------------------------------------------------
+
+/**
+ * Computes the enum-only warning list. NEVER free-text strings,
+ * NEVER diagnostic labels, NEVER medical interpretation.
+ *
+ * `no_recorded_preferences` fires when EVERY preference enum
+ *  resolves to 'unknown' — i.e., the user has no stored signal.
+ *  Note that `explanation_depth_hint` is excluded from this check
+ *  because the compiler defaults it to 'normal' even with no input.
+ *
+ * `low_signal_confidence` fires when the bucketed confidence is
+ *  'low' or 'unknown'.
+ */
+export function computeDecisionWarnings(
+  ctx: InteractionStyleContext,
+): ReadonlyArray<InteractionStyleWarning> {
+  const out: InteractionStyleWarning[] = [];
+
+  const allUnknown =
+    ctx.preferred_response_style === 'unknown' &&
+    ctx.interaction_pace === 'unknown' &&
+    ctx.tone_preference === 'unknown';
+  if (allUnknown) {
+    out.push('no_recorded_preferences');
+  }
+
+  if (ctx.confidence_bucket === 'low' || ctx.confidence_bucket === 'unknown') {
+    out.push('low_signal_confidence');
+  }
+
+  return out;
+}

--- a/services/gateway/src/orb/context/types.ts
+++ b/services/gateway/src/orb/context/types.ts
@@ -3,6 +3,7 @@
  * VTID-02950 (F2)     — adds conceptMastery field.
  * VTID-02954 (F3)     — adds journeyStage field.
  * VTID-02955 (B5)     — adds pillarMomentum field.
+ * VTID-02962 (B6)     — adds interactionStyle field.
  *
  * This is the SINGLE typed shape the instruction layer reads to assemble
  * a prompt. Raw rows (memory, threads, messages, promises, profiles,
@@ -15,9 +16,12 @@
  *     continuation contract, greeting decay rewrite, reliability tuning.
  *     Each gets its own slice.
  *   - Continuity (B2) + conceptMastery (B3) + journeyStage (B4) +
- *     pillarMomentum (B5) are wired through this contract.
+ *     pillarMomentum (B5) + interactionStyle (B6) are wired through
+ *     this contract.
  *   - Adding new fields later is fine; pushing raw rows into them is not.
  *   - No medical interpretation. No diagnoses. No treatment advice.
+ *   - No free-text psychological summaries. No diagnostic-feeling
+ *     personality labels. No mental-health inference.
  */
 
 /**
@@ -339,6 +343,103 @@ export interface DecisionPillarMomentum {
   warnings: ReadonlyArray<PillarMomentumWarning>;
 }
 
+// ---------------------------------------------------------------------------
+// B6 — Interaction Style (VTID-02962)
+// ---------------------------------------------------------------------------
+
+/**
+ * Preferred verbosity of the assistant's answers. Coarse band, NEVER
+ * derived from word counts or free-text classification. The compiler
+ * either reads it from a stored user preference or returns 'unknown'.
+ */
+export type PreferredResponseStyle =
+  | 'concise'
+  | 'balanced'
+  | 'detailed'
+  | 'unknown';
+
+/**
+ * How fast the user wants the conversation to move. Coarse band; the
+ * adapter MUST NOT pass raw response latencies or turn timestamps.
+ */
+export type InteractionPace = 'slow' | 'normal' | 'fast' | 'unknown';
+
+/**
+ * Tone the user prefers from the assistant. Enum-only — never a free-
+ * text descriptor and NEVER diagnostic-sounding (no
+ * "anxious / depressive / avoidant" etc.).
+ */
+export type TonePreference =
+  | 'direct'
+  | 'warm'
+  | 'coaching'
+  | 'neutral'
+  | 'unknown';
+
+/**
+ * Hint for how deep the assistant's explanations should go. Tighter
+ * than B4's `ExplanationDepthHint` because it captures the user's own
+ * preference rather than the stage-derived default. The renderer uses
+ * 'normal' as the no-signal fallback so callers can rely on a
+ * non-degenerate value without inspecting source_health.
+ */
+export type InteractionExplanationDepth = 'minimal' | 'normal' | 'expanded';
+
+/**
+ * Coarse confidence band for the interaction-style signal as a whole.
+ * Replaces any raw 0..1 numeric score the underlying store may carry.
+ */
+export type InteractionStyleConfidenceBucket =
+  | 'low'
+  | 'medium'
+  | 'high'
+  | 'unknown';
+
+/**
+ * Allowed warnings on the interaction-style signal. Enums only —
+ * NEVER free-text, NEVER diagnostic, NEVER medical.
+ */
+export type InteractionStyleWarning =
+  | 'no_recorded_preferences'
+  | 'low_signal_confidence';
+
+/**
+ * Distilled interaction-style view. Mirrors `InteractionStyleContext`
+ * from `services/interaction-style/types.ts` but strips:
+ *   - raw user preference rows
+ *   - raw timestamps (`last_updated_at`, `last_seen_at`)
+ *   - raw chat-message or transcript-derived counts
+ *   - raw confidence floats (bucketed to low / medium / high / unknown)
+ *   - any free-text personality / psychological summary
+ *
+ * Kept: bucketed preference enums, an explanation-depth hint the
+ * renderer can read directly, and an enum-only warnings list.
+ *
+ * NEVER carries:
+ *   - medical interpretation
+ *   - mental-health inference
+ *   - diagnostic-feeling personality labels
+ *   - free-text psychological summaries
+ */
+export interface DecisionInteractionStyle {
+  /** Preferred verbosity. Enum-only. */
+  preferred_response_style: PreferredResponseStyle;
+  /** Preferred conversational pace. Enum-only. */
+  interaction_pace: InteractionPace;
+  /** Preferred tone from the assistant. Enum-only. */
+  tone_preference: TonePreference;
+  /**
+   * Explanation depth hint derived from the user's recorded preference.
+   * Defaults to 'normal' when no signal is available so the prompt
+   * always reads a usable value.
+   */
+  explanation_depth_hint: InteractionExplanationDepth;
+  /** Coarse confidence band the LLM can use to weight the signal. */
+  confidence_bucket: InteractionStyleConfidenceBucket;
+  /** Warnings as enums. NEVER free-text. NEVER diagnostic. */
+  warnings: ReadonlyArray<InteractionStyleWarning>;
+}
+
 /**
  * Per-source health view. Empty/missing rows are not failures — they
  * just mean the user has no state yet. Failures (Supabase down, schema
@@ -352,6 +453,8 @@ export interface DecisionSourceHealth {
   journey_stage: { ok: boolean; reason?: string };
   /** B5: pillar-momentum source health. */
   pillar_momentum: { ok: boolean; reason?: string };
+  /** B6: interaction-style source health. */
+  interaction_style: { ok: boolean; reason?: string };
 }
 
 /**
@@ -388,6 +491,12 @@ export interface AssistantDecisionContext {
    * no pillar-momentum section in that case.
    */
   pillar_momentum: DecisionPillarMomentum | null;
+  /**
+   * B6: Interaction-style decision view. `null` when the compiler had
+   * no input or source-health is degraded — the renderer must emit
+   * no interaction-style section in that case.
+   */
+  interaction_style: DecisionInteractionStyle | null;
   /** Per-source health. Always present, even when fields are null. */
   source_health: DecisionSourceHealth;
 }

--- a/services/gateway/src/orb/live/instruction/decision-contract-renderer.ts
+++ b/services/gateway/src/orb/live/instruction/decision-contract-renderer.ts
@@ -3,6 +3,7 @@
  * VTID-02950 (F2)     — adds concept-mastery section.
  * VTID-02954 (F3)     — adds journey-stage section.
  * VTID-02955 (B5)     — adds pillar-momentum section.
+ * VTID-02962 (B6)     — adds interaction-style section.
  *
  * Single responsibility: take an `AssistantDecisionContext` and
  * produce a prompt section string the static system instruction can
@@ -15,7 +16,7 @@
  *   - touch Supabase directly
  *   - import from `services/continuity/*`, `services/concept-mastery/*`,
  *     `services/journey-stage/*`, `services/pillar-momentum/*`,
- *     or any compiler module
+ *     `services/interaction-style/*`, or any compiler module
  *
  * Type-level enforcement: the only argument is `AssistantDecisionContext`.
  * A test asserts the renderer source file contains no `import` from
@@ -24,6 +25,10 @@
  * NEVER carries medical interpretation, diagnoses, or treatment
  * advice through the pillar-momentum section. Pillars are coaching
  * axes, not clinical categories.
+ *
+ * NEVER carries free-text psychological summaries, diagnostic-feeling
+ * personality labels, or mental-health inference through the
+ * interaction-style section. Preferences are coarse enums only.
  *
  * Empty / degraded handling:
  *   - `decision.<field> === null` → no section for that field is emitted.
@@ -38,6 +43,7 @@ import type {
   AssistantDecisionContext,
   DecisionConceptMastery,
   DecisionContinuity,
+  DecisionInteractionStyle,
   DecisionJourneyStage,
   DecisionPillarMomentum,
 } from '../../context/types';
@@ -109,6 +115,18 @@ export function renderDecisionContract(
   } else if (pillarHealth && pillarHealth.ok === false) {
     lines.push(
       `[pillar_momentum: source degraded — ${pillarHealth.reason ?? 'unknown_reason'}]`,
+    );
+  }
+
+  // ---- interaction style (B6) ----
+  const interactionSection = renderInteractionStyle(decision.interaction_style);
+  const interactionHealth = decision.source_health.interaction_style;
+
+  if (interactionSection) {
+    lines.push(interactionSection);
+  } else if (interactionHealth && interactionHealth.ok === false) {
+    lines.push(
+      `[interaction_style: source degraded — ${interactionHealth.reason ?? 'unknown_reason'}]`,
     );
   }
 
@@ -291,4 +309,48 @@ function renderPillarMomentum(pm: DecisionPillarMomentum | null): string {
   if (!hasAnyContent && pm.warnings.length === 0) return '';
 
   return ['Pillar momentum:', ...lines].join('\n');
+}
+
+// ---------------------------------------------------------------------------
+// Interaction Style sub-section (B6)
+// ---------------------------------------------------------------------------
+
+function renderInteractionStyle(is: DecisionInteractionStyle | null): string {
+  if (!is) return '';
+
+  // Compact line list — pure enums, no raw numbers, no timestamps.
+  // 'unknown' enums are deliberately omitted so the section doesn't
+  // pad the prompt with no-information rows.
+  const lines: string[] = [];
+
+  if (is.preferred_response_style !== 'unknown') {
+    lines.push(`  - response style: ${is.preferred_response_style}`);
+  }
+  if (is.interaction_pace !== 'unknown') {
+    lines.push(`  - pace: ${is.interaction_pace}`);
+  }
+  if (is.tone_preference !== 'unknown') {
+    lines.push(`  - tone: ${is.tone_preference}`);
+  }
+  // explanation_depth_hint always has a usable value ('normal' is the
+  // no-signal default), so it's always informative.
+  lines.push(`  - explanation depth: ${is.explanation_depth_hint}`);
+  lines.push(`  - confidence: ${is.confidence_bucket}`);
+
+  if (is.warnings.length > 0) {
+    lines.push(`  - warnings: ${is.warnings.join(', ')}`);
+  }
+
+  // If only the always-on lines (depth + confidence) plus warnings
+  // remain AND warnings include 'no_recorded_preferences', the section
+  // adds no real signal — suppress it to keep the prompt tight.
+  const hasPreferenceContent =
+    is.preferred_response_style !== 'unknown' ||
+    is.interaction_pace !== 'unknown' ||
+    is.tone_preference !== 'unknown';
+  if (!hasPreferenceContent && is.confidence_bucket === 'unknown') {
+    return '';
+  }
+
+  return ['Interaction style:', ...lines].join('\n');
 }

--- a/services/gateway/src/services/interaction-style/compile-interaction-style-context.ts
+++ b/services/gateway/src/services/interaction-style/compile-interaction-style-context.ts
@@ -1,0 +1,170 @@
+/**
+ * VTID-02962 (B6) — compileInteractionStyleContext.
+ *
+ * Pure function over an optional `InteractionStyleSignalRow`. Produces
+ * the distilled `InteractionStyleContext` the Command Hub preview
+ * consumes (and the decision adapter narrows further).
+ *
+ * Distillation policy:
+ *   - Each enum field is read from `row.value.*`. Missing → 'unknown',
+ *     except `explanation_depth` which defaults to 'normal' so the
+ *     renderer always reads a usable value.
+ *   - `confidence` is bucketed via two thresholds (low <0.5, medium
+ *     <0.8, high otherwise). The compiler prefers `value.confidence`
+ *     when present, else the row-level `confidence` column, else
+ *     'unknown'.
+ *   - When the row is absent (user has no recorded preference yet)
+ *     the compiler returns an all-'unknown' shape with
+ *     `last_updated_at: null` and `source_health.user_assistant_state.ok = true`
+ *     — that's the steady-state default, NOT a failure.
+ *
+ * No IO. No mutation. No clock side-effects (the row arrives with
+ * `updated_at` already pre-formatted by the fetcher).
+ */
+
+import type {
+  InteractionExplanationDepth,
+  InteractionPace,
+  InteractionStyleConfidenceBucket,
+  PreferredResponseStyle,
+  TonePreference,
+} from '../../orb/context/types';
+import type {
+  InteractionStyleContext,
+  InteractionStyleSignalRow,
+} from './types';
+
+export interface CompileInteractionStyleContextInputs {
+  fetchResult: {
+    ok: boolean;
+    /** Null when no row exists; that's not a failure. */
+    row: InteractionStyleSignalRow | null;
+    reason?: string;
+  };
+}
+
+/** Confidence thresholds — bucketed at compile time, never exported in shape. */
+const CONFIDENCE_MEDIUM_THRESHOLD = 0.5;
+const CONFIDENCE_HIGH_THRESHOLD = 0.8;
+
+const RESPONSE_STYLES: ReadonlySet<PreferredResponseStyle> = new Set([
+  'concise',
+  'balanced',
+  'detailed',
+  'unknown',
+]);
+const PACES: ReadonlySet<InteractionPace> = new Set([
+  'slow',
+  'normal',
+  'fast',
+  'unknown',
+]);
+const TONES: ReadonlySet<TonePreference> = new Set([
+  'direct',
+  'warm',
+  'coaching',
+  'neutral',
+  'unknown',
+]);
+const DEPTHS: ReadonlySet<InteractionExplanationDepth> = new Set([
+  'minimal',
+  'normal',
+  'expanded',
+]);
+
+export function compileInteractionStyleContext(
+  input: CompileInteractionStyleContextInputs,
+): InteractionStyleContext {
+  const fetchOk = input.fetchResult.ok;
+  const row = fetchOk ? input.fetchResult.row : null;
+
+  if (!fetchOk) {
+    return makeEmpty({
+      ok: false,
+      reason: input.fetchResult.reason ?? 'unknown_failure',
+    });
+  }
+
+  if (!row) {
+    return makeEmpty({ ok: true });
+  }
+
+  const value = row.value ?? {};
+
+  const preferred_response_style = pickEnum(
+    RESPONSE_STYLES,
+    value.response_style,
+    'unknown',
+  ) as PreferredResponseStyle;
+
+  const interaction_pace = pickEnum(
+    PACES,
+    value.pace,
+    'unknown',
+  ) as InteractionPace;
+
+  const tone_preference = pickEnum(
+    TONES,
+    value.tone,
+    'unknown',
+  ) as TonePreference;
+
+  const explanation_depth_hint = pickEnum(
+    DEPTHS,
+    value.explanation_depth,
+    'normal',
+  ) as InteractionExplanationDepth;
+
+  const confidence_bucket = bucketConfidence(
+    value.confidence ?? row.confidence,
+  );
+
+  return {
+    preferred_response_style,
+    interaction_pace,
+    tone_preference,
+    explanation_depth_hint,
+    confidence_bucket,
+    last_updated_at: row.updated_at ?? null,
+    source_health: { user_assistant_state: { ok: true } },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Helpers — exported for tests
+// ---------------------------------------------------------------------------
+
+function makeEmpty(
+  health: { ok: boolean; reason?: string },
+): InteractionStyleContext {
+  return {
+    preferred_response_style: 'unknown',
+    interaction_pace: 'unknown',
+    tone_preference: 'unknown',
+    explanation_depth_hint: 'normal',
+    confidence_bucket: 'unknown',
+    last_updated_at: null,
+    source_health: {
+      user_assistant_state: health,
+    },
+  };
+}
+
+function pickEnum<T extends string>(
+  allowed: ReadonlySet<T>,
+  raw: T | undefined,
+  fallback: T,
+): T {
+  if (raw === undefined || raw === null) return fallback;
+  return allowed.has(raw) ? raw : fallback;
+}
+
+export function bucketConfidence(
+  raw: number | null | undefined,
+): InteractionStyleConfidenceBucket {
+  if (raw === null || raw === undefined || !Number.isFinite(raw)) return 'unknown';
+  if (raw < 0) return 'unknown';
+  if (raw < CONFIDENCE_MEDIUM_THRESHOLD) return 'low';
+  if (raw < CONFIDENCE_HIGH_THRESHOLD) return 'medium';
+  return 'high';
+}

--- a/services/gateway/src/services/interaction-style/interaction-style-fetcher.ts
+++ b/services/gateway/src/services/interaction-style/interaction-style-fetcher.ts
@@ -1,0 +1,99 @@
+/**
+ * VTID-02962 (B6) — Supabase-backed interaction-style fetcher.
+ *
+ * Reads ONE row of `user_assistant_state` for
+ * `signal_name = 'interaction_style_v1'`. Read-only by design — writing
+ * the preference is a UI concern that lands in a later phase. Adding an
+ * `upsert*` here would violate the B6 wall.
+ *
+ * Failure policy: any Supabase error returns `row: null` + source-
+ * health flagged. We never throw upward — interaction-style is an
+ * enrichment layer, never a wake-blocker. A missing row (PGRST116 from
+ * `.single()`) is NOT a failure; it just means the user has no recorded
+ * preference yet.
+ */
+
+import { getSupabase } from '../../lib/supabase';
+import type { InteractionStyleSignalRow, InteractionStyleSignalValue } from './types';
+
+/** Canonical signal name for B6. Versioned so a future schema bump can
+ *  coexist without overwriting. */
+export const INTERACTION_STYLE_SIGNAL_NAME = 'interaction_style_v1';
+
+export interface InteractionStyleFetcher {
+  fetchInteractionStyleRow(args: {
+    tenantId: string;
+    userId: string;
+  }): Promise<{
+    ok: boolean;
+    /** Null when no row exists (steady-state default for new users). */
+    row: InteractionStyleSignalRow | null;
+    reason?: string;
+  }>;
+}
+
+export interface SupabaseInteractionStyleFetcherOptions {
+  getDb?: typeof getSupabase;
+}
+
+export function createSupabaseInteractionStyleFetcher(
+  opts: SupabaseInteractionStyleFetcherOptions = {},
+): InteractionStyleFetcher {
+  const getDb = opts.getDb ?? getSupabase;
+
+  return {
+    async fetchInteractionStyleRow(args) {
+      const sb = getDb();
+      if (!sb) return { ok: false, row: null, reason: 'supabase_unconfigured' };
+      try {
+        const { data, error } = await sb
+          .from('user_assistant_state')
+          .select('value, confidence, updated_at, last_seen_at')
+          .eq('tenant_id', args.tenantId)
+          .eq('user_id', args.userId)
+          .eq('signal_name', INTERACTION_STYLE_SIGNAL_NAME)
+          .maybeSingle();
+        if (error) return { ok: false, row: null, reason: error.message };
+        if (!data) return { ok: true, row: null };
+        return { ok: true, row: mapRow(data as Record<string, unknown>) };
+      } catch (e) {
+        return { ok: false, row: null, reason: (e as Error).message };
+      }
+    },
+  };
+}
+
+export const defaultInteractionStyleFetcher = createSupabaseInteractionStyleFetcher();
+
+// ---------------------------------------------------------------------------
+// Row mapping — exported for tests
+// ---------------------------------------------------------------------------
+
+export function mapRow(
+  row: Record<string, unknown>,
+): InteractionStyleSignalRow {
+  const rawValue = row.value;
+  const value: InteractionStyleSignalValue =
+    rawValue && typeof rawValue === 'object' && !Array.isArray(rawValue)
+      ? (rawValue as InteractionStyleSignalValue)
+      : {};
+  const confidence = coerceConfidence(row.confidence);
+  const updated_at = coerceIso(row.updated_at);
+  const last_seen_at = coerceIso(row.last_seen_at);
+  return { value, confidence, updated_at, last_seen_at };
+}
+
+function coerceConfidence(raw: unknown): number | null {
+  if (raw === null || raw === undefined) return null;
+  let n: number;
+  if (typeof raw === 'number') n = raw;
+  else if (typeof raw === 'string') n = Number.parseFloat(raw);
+  else return null;
+  if (!Number.isFinite(n)) return null;
+  return Math.max(0, Math.min(1, n));
+}
+
+function coerceIso(raw: unknown): string | null {
+  if (typeof raw !== 'string' || raw.length === 0) return null;
+  return raw;
+}

--- a/services/gateway/src/services/interaction-style/types.ts
+++ b/services/gateway/src/services/interaction-style/types.ts
@@ -1,0 +1,107 @@
+/**
+ * VTID-02962 (B6) — interaction-style types.
+ *
+ * Drives the user's stable preferences for how the assistant talks
+ * to them: response verbosity, pace, tone, explanation depth, and a
+ * confidence band. Kept deliberately coarse — never raw chat metrics,
+ * never psychological labels, never anything that reads as a
+ * diagnosis.
+ *
+ * Source: a single row of `user_assistant_state` with
+ * `signal_name = 'interaction_style_v1'`. The JSONB `value` carries
+ * the preference fields below. The row may be absent (user has no
+ * recorded preference yet) — that is the steady-state default.
+ *
+ * Wall (B6): pure types. No IO, no mutation. Decision-grade shape
+ * is in `orb/context/types.ts` — this richer shape is for the
+ * Command Hub operator preview AND as the input the decision
+ * adapter narrows.
+ */
+
+import type {
+  InteractionExplanationDepth,
+  InteractionPace,
+  InteractionStyleConfidenceBucket,
+  PreferredResponseStyle,
+  TonePreference,
+} from '../../orb/context/types';
+
+/**
+ * Allowed sources of the interaction-style signal. Useful in the
+ * operator preview to distinguish user-set from inferred state, but
+ * dropped from the decision contract — the LLM doesn't need to know.
+ */
+export type InteractionStyleSource = 'user_set' | 'inferred' | 'admin';
+
+/**
+ * Raw JSONB payload stored under
+ * `user_assistant_state.value` for `signal_name = 'interaction_style_v1'`.
+ *
+ * Every field is optional — partial writes are fine, the compiler
+ * fills the gaps with 'unknown'. Numbers (`confidence`) are bucketed
+ * by the compiler so the decision contract never sees raw floats.
+ */
+export interface InteractionStyleSignalValue {
+  response_style?: Exclude<PreferredResponseStyle, 'unknown'>;
+  pace?: Exclude<InteractionPace, 'unknown'>;
+  tone?: Exclude<TonePreference, 'unknown'>;
+  explanation_depth?: InteractionExplanationDepth;
+  /** 0..1 — bucketed by the compiler. */
+  confidence?: number;
+  source?: InteractionStyleSource;
+}
+
+/**
+ * Narrowed `user_assistant_state` row. The fetcher returns this shape
+ * (not the raw Supabase row) so the compiler is decoupled from the
+ * physical table layout.
+ */
+export interface InteractionStyleSignalRow {
+  /** JSONB payload — may be missing fields. */
+  value: InteractionStyleSignalValue;
+  /** Stored confidence on the row itself (separate from value.confidence). */
+  confidence: number | null;
+  /** When the row was last touched. Operator-view only; the decision
+   *  adapter drops this — the LLM doesn't read raw timestamps. */
+  updated_at: string | null;
+  /** When the signal was last observed/written. Operator-view only. */
+  last_seen_at: string | null;
+}
+
+/**
+ * Compiled interaction-style context — what the Command Hub preview
+ * surface consumes, and what the decision adapter distills further.
+ *
+ * Compared to `DecisionInteractionStyle`, the compiled shape additionally
+ * carries `last_updated_at` for the operator view. The decision adapter
+ * DROPS that field — the LLM has no use for a raw timestamp.
+ */
+export interface InteractionStyleContext {
+  /** Preferred verbosity. Enum-only. */
+  preferred_response_style: PreferredResponseStyle;
+  /** Preferred conversational pace. Enum-only. */
+  interaction_pace: InteractionPace;
+  /** Preferred tone from the assistant. Enum-only. */
+  tone_preference: TonePreference;
+  /**
+   * Explanation depth hint. Defaults to 'normal' when no signal is
+   * available — the renderer treats this as a usable steady-state
+   * value, not as a degraded one.
+   */
+  explanation_depth_hint: InteractionExplanationDepth;
+  /** Coarse confidence band. */
+  confidence_bucket: InteractionStyleConfidenceBucket;
+  /**
+   * ISO timestamp of the last preference write. Operator-view only;
+   * the decision adapter drops it.
+   */
+  last_updated_at: string | null;
+  /**
+   * Source-health view — empty row + a `reason` of
+   * 'no_interaction_style_row' is "user has no recorded preference yet",
+   * not a failure. Failures (table missing, supabase down) surface here.
+   */
+  source_health: {
+    user_assistant_state: { ok: boolean; reason?: string };
+  };
+}

--- a/services/gateway/test/orb/context/compile-assistant-decision-context.test.ts
+++ b/services/gateway/test/orb/context/compile-assistant-decision-context.test.ts
@@ -1,6 +1,6 @@
 /**
  * VTID-02941 (B0b-min) + VTID-02950 (F2) + VTID-02954 (F3) +
- * VTID-02955 (B5) — compileAssistantDecisionContext.
+ * VTID-02955 (B5) + VTID-02962 (B6) — compileAssistantDecisionContext.
  *
  * Acceptance:
  *   #1 — empty providers produce a valid AssistantDecisionContext with
@@ -20,6 +20,7 @@ import { compileAssistantDecisionContext } from '../../../src/orb/context/compil
 import type {
   DecisionConceptMastery,
   DecisionContinuity,
+  DecisionInteractionStyle,
   DecisionJourneyStage,
   DecisionPillarMomentum,
 } from '../../../src/orb/context/types';
@@ -78,8 +79,17 @@ const stubPillarMomentum: DecisionPillarMomentum = {
   warnings: ['low_pillar_confidence', 'no_recent_pillar_data'],
 };
 
+const stubInteractionStyle: DecisionInteractionStyle = {
+  preferred_response_style: 'unknown',
+  interaction_pace: 'unknown',
+  tone_preference: 'unknown',
+  explanation_depth_hint: 'normal',
+  confidence_bucket: 'unknown',
+  warnings: ['no_recorded_preferences', 'low_signal_confidence'],
+};
+
 describe('compileAssistantDecisionContext', () => {
-  describe('happy path with all four provider overrides', () => {
+  describe('happy path with all five provider overrides', () => {
     it('attaches each provider output to its field', async () => {
       const out = await compileAssistantDecisionContext({
         userId: 'u',
@@ -89,16 +99,19 @@ describe('compileAssistantDecisionContext', () => {
           conceptMastery: async () => stubConceptMastery,
           journeyStage: async () => stubJourneyStage,
           pillarMomentum: async () => stubPillarMomentum,
+          interactionStyle: async () => stubInteractionStyle,
         },
       });
       expect(out.continuity).toEqual(stubContinuity);
       expect(out.concept_mastery).toEqual(stubConceptMastery);
       expect(out.journey_stage).toEqual(stubJourneyStage);
       expect(out.pillar_momentum).toEqual(stubPillarMomentum);
+      expect(out.interaction_style).toEqual(stubInteractionStyle);
       expect(out.source_health.continuity.ok).toBe(true);
       expect(out.source_health.concept_mastery.ok).toBe(true);
       expect(out.source_health.journey_stage.ok).toBe(true);
       expect(out.source_health.pillar_momentum.ok).toBe(true);
+      expect(out.source_health.interaction_style.ok).toBe(true);
     });
   });
 
@@ -114,6 +127,7 @@ describe('compileAssistantDecisionContext', () => {
           pillarMomentum: async () => {
             throw new Error('pillar_boom');
           },
+          interactionStyle: async () => stubInteractionStyle,
         },
       });
       expect(out.pillar_momentum).toBeNull();
@@ -122,9 +136,31 @@ describe('compileAssistantDecisionContext', () => {
       expect(out.continuity).toEqual(stubContinuity);
       expect(out.concept_mastery).toEqual(stubConceptMastery);
       expect(out.journey_stage).toEqual(stubJourneyStage);
+      expect(out.interaction_style).toEqual(stubInteractionStyle);
     });
 
-    it('all four providers throw → all null but no crash', async () => {
+    it('interaction_style throws → null + others still flow (acceptance: B6)', async () => {
+      const out = await compileAssistantDecisionContext({
+        userId: 'u',
+        tenantId: 't',
+        providers: {
+          continuity: async () => stubContinuity,
+          conceptMastery: async () => stubConceptMastery,
+          journeyStage: async () => stubJourneyStage,
+          pillarMomentum: async () => stubPillarMomentum,
+          interactionStyle: async () => { throw new Error('interaction_boom'); },
+        },
+      });
+      expect(out.interaction_style).toBeNull();
+      expect(out.source_health.interaction_style.ok).toBe(false);
+      expect(out.source_health.interaction_style.reason).toBe('interaction_boom');
+      expect(out.continuity).toEqual(stubContinuity);
+      expect(out.concept_mastery).toEqual(stubConceptMastery);
+      expect(out.journey_stage).toEqual(stubJourneyStage);
+      expect(out.pillar_momentum).toEqual(stubPillarMomentum);
+    });
+
+    it('all five providers throw → all null but no crash', async () => {
       const out = await compileAssistantDecisionContext({
         userId: 'u',
         tenantId: 't',
@@ -133,16 +169,19 @@ describe('compileAssistantDecisionContext', () => {
           conceptMastery: async () => { throw new Error('m_boom'); },
           journeyStage: async () => { throw new Error('j_boom'); },
           pillarMomentum: async () => { throw new Error('p_boom'); },
+          interactionStyle: async () => { throw new Error('i_boom'); },
         },
       });
       expect(out.continuity).toBeNull();
       expect(out.concept_mastery).toBeNull();
       expect(out.journey_stage).toBeNull();
       expect(out.pillar_momentum).toBeNull();
+      expect(out.interaction_style).toBeNull();
       expect(out.source_health.continuity.reason).toBe('c_boom');
       expect(out.source_health.concept_mastery.reason).toBe('m_boom');
       expect(out.source_health.journey_stage.reason).toBe('j_boom');
       expect(out.source_health.pillar_momentum.reason).toBe('p_boom');
+      expect(out.source_health.interaction_style.reason).toBe('i_boom');
     });
 
     it('one provider throws does not block the rest (continuity case)', async () => {
@@ -154,17 +193,19 @@ describe('compileAssistantDecisionContext', () => {
           conceptMastery: async () => stubConceptMastery,
           journeyStage: async () => stubJourneyStage,
           pillarMomentum: async () => stubPillarMomentum,
+          interactionStyle: async () => stubInteractionStyle,
         },
       });
       expect(out.continuity).toBeNull();
       expect(out.concept_mastery).toEqual(stubConceptMastery);
       expect(out.journey_stage).toEqual(stubJourneyStage);
       expect(out.pillar_momentum).toEqual(stubPillarMomentum);
+      expect(out.interaction_style).toEqual(stubInteractionStyle);
     });
   });
 
   describe('provider returns null (acceptance #1)', () => {
-    it('attaches null + ok:true for all four (provider deliberately suppressed)', async () => {
+    it('attaches null + ok:true for all five (provider deliberately suppressed)', async () => {
       const out = await compileAssistantDecisionContext({
         userId: 'u',
         tenantId: 't',
@@ -173,21 +214,24 @@ describe('compileAssistantDecisionContext', () => {
           conceptMastery: async () => null,
           journeyStage: async () => null,
           pillarMomentum: async () => null,
+          interactionStyle: async () => null,
         },
       });
       expect(out.continuity).toBeNull();
       expect(out.concept_mastery).toBeNull();
       expect(out.journey_stage).toBeNull();
       expect(out.pillar_momentum).toBeNull();
+      expect(out.interaction_style).toBeNull();
       expect(out.source_health.continuity.ok).toBe(true);
       expect(out.source_health.concept_mastery.ok).toBe(true);
       expect(out.source_health.journey_stage.ok).toBe(true);
       expect(out.source_health.pillar_momentum.ok).toBe(true);
+      expect(out.source_health.interaction_style.ok).toBe(true);
     });
   });
 
   describe('always returns a typed shape', () => {
-    it('all four source_health entries are always present', async () => {
+    it('all five source_health entries are always present', async () => {
       const out = await compileAssistantDecisionContext({
         userId: 'u',
         tenantId: 't',
@@ -196,6 +240,7 @@ describe('compileAssistantDecisionContext', () => {
           conceptMastery: async () => null,
           journeyStage: async () => null,
           pillarMomentum: async () => null,
+          interactionStyle: async () => null,
         },
       });
       expect(out.source_health).toBeDefined();
@@ -203,9 +248,10 @@ describe('compileAssistantDecisionContext', () => {
       expect(out.source_health.concept_mastery).toBeDefined();
       expect(out.source_health.journey_stage).toBeDefined();
       expect(out.source_health.pillar_momentum).toBeDefined();
+      expect(out.source_health.interaction_style).toBeDefined();
     });
 
-    it('result has exactly five top-level keys (no leakage, no extras)', async () => {
+    it('result has exactly six top-level keys (no leakage, no extras)', async () => {
       const out = await compileAssistantDecisionContext({
         userId: 'u',
         tenantId: 't',
@@ -214,12 +260,14 @@ describe('compileAssistantDecisionContext', () => {
           conceptMastery: async () => null,
           journeyStage: async () => null,
           pillarMomentum: async () => null,
+          interactionStyle: async () => null,
         },
       });
       const keys = Object.keys(out).sort();
       expect(keys).toEqual([
         'concept_mastery',
         'continuity',
+        'interaction_style',
         'journey_stage',
         'pillar_momentum',
         'source_health',
@@ -228,14 +276,14 @@ describe('compileAssistantDecisionContext', () => {
   });
 
   describe('parallel execution', () => {
-    it('runs all four providers concurrently (slowest determines total time)', async () => {
+    it('runs all five providers concurrently (slowest determines total time)', async () => {
       const order: string[] = [];
       const out = await compileAssistantDecisionContext({
         userId: 'u',
         tenantId: 't',
         providers: {
           continuity: async () => {
-            await new Promise(r => setTimeout(r, 20));
+            await new Promise(r => setTimeout(r, 25));
             order.push('continuity');
             return stubContinuity;
           },
@@ -254,15 +302,22 @@ describe('compileAssistantDecisionContext', () => {
             order.push('pillar');
             return stubPillarMomentum;
           },
+          interactionStyle: async () => {
+            await new Promise(r => setTimeout(r, 20));
+            order.push('interaction');
+            return stubInteractionStyle;
+          },
         },
       });
-      // Order: concept (5ms) → journey (10ms) → pillar (15ms) → continuity (20ms),
-      // proving all four providers ran in parallel.
-      expect(order).toEqual(['concept', 'journey', 'pillar', 'continuity']);
+      // Order: concept (5ms) → journey (10ms) → pillar (15ms) →
+      // interaction (20ms) → continuity (25ms), proving all five
+      // providers ran in parallel.
+      expect(order).toEqual(['concept', 'journey', 'pillar', 'interaction', 'continuity']);
       expect(out.continuity).toEqual(stubContinuity);
       expect(out.concept_mastery).toEqual(stubConceptMastery);
       expect(out.journey_stage).toEqual(stubJourneyStage);
       expect(out.pillar_momentum).toEqual(stubPillarMomentum);
+      expect(out.interaction_style).toEqual(stubInteractionStyle);
     });
   });
 });

--- a/services/gateway/test/orb/context/decision-context-types.test.ts
+++ b/services/gateway/test/orb/context/decision-context-types.test.ts
@@ -258,4 +258,93 @@ describe('B0b-min — AssistantDecisionContext type guards', () => {
       expect(enumBody.toLowerCase()).not.toContain(word);
     }
   });
+
+  // B6: interaction-style type guards.
+  describe('forbidden raw fields are NOT declared in DecisionInteractionStyle', () => {
+    const forbiddenInteractionFields = [
+      'last_updated_at',
+      'last_seen_at',
+      'updated_at',
+      'created_at',
+      'raw_messages',
+      'transcript',
+      'route_history',
+      'behavioral_history',
+      'profile_payload',
+      'psychological_summary',
+      'personality',
+    ];
+
+    it.each(forbiddenInteractionFields)(
+      'does not declare %s in DecisionInteractionStyle',
+      (field) => {
+        const ifaceMatch = typesSrc.match(
+          /export interface DecisionInteractionStyle\s*\{([\s\S]*?)\n\}/,
+        );
+        expect(ifaceMatch).toBeTruthy();
+        const ifaceBody = ifaceMatch![1];
+        const decl = new RegExp(`\\b${field}\\s*\\??:`, 'g');
+        expect(ifaceBody).not.toMatch(decl);
+      },
+    );
+
+    it('declares interaction-style fields as bucketed enums, NEVER raw numbers', () => {
+      const ifaceMatch = typesSrc.match(
+        /export interface DecisionInteractionStyle\s*\{([\s\S]*?)\n\}/,
+      );
+      const ifaceBody = ifaceMatch![1];
+      expect(ifaceBody).not.toMatch(/:\s*number/);
+      expect(ifaceBody).toMatch(/preferred_response_style:\s*PreferredResponseStyle/);
+      expect(ifaceBody).toMatch(/interaction_pace:\s*InteractionPace/);
+      expect(ifaceBody).toMatch(/tone_preference:\s*TonePreference/);
+      expect(ifaceBody).toMatch(/explanation_depth_hint:\s*InteractionExplanationDepth/);
+      expect(ifaceBody).toMatch(/confidence_bucket:\s*InteractionStyleConfidenceBucket/);
+    });
+
+    it('warnings are an enum-only ReadonlyArray', () => {
+      const ifaceMatch = typesSrc.match(
+        /export interface DecisionInteractionStyle\s*\{([\s\S]*?)\n\}/,
+      );
+      const ifaceBody = ifaceMatch![1];
+      expect(ifaceBody).toMatch(/warnings:\s*ReadonlyArray<InteractionStyleWarning>/);
+      expect(ifaceBody).not.toMatch(/warnings:\s*ReadonlyArray<string>/);
+      expect(ifaceBody).not.toMatch(/warnings:\s*string\[\]/);
+    });
+  });
+
+  it('AssistantDecisionContext.interaction_style is optional null', () => {
+    expect(typesSrc).toMatch(/interaction_style:\s*DecisionInteractionStyle\s*\|\s*null/);
+  });
+
+  it('DecisionSourceHealth declares interaction_style health entry', () => {
+    expect(typesSrc).toMatch(/interaction_style:\s*\{\s*ok:\s*boolean/);
+  });
+
+  it('InteractionStyleWarning enum does NOT include diagnostic / medical labels', () => {
+    const enumMatch = typesSrc.match(/export type InteractionStyleWarning\s*=([\s\S]*?);/);
+    expect(enumMatch).toBeTruthy();
+    const enumBody = enumMatch![1];
+    const banned = [
+      'diagnos', 'symptom', 'disease', 'illness', 'treatment',
+      'prescription', 'medication', 'clinical', 'anxious', 'depress',
+      'avoidant', 'narcissist', 'borderline', 'bipolar', 'mania',
+      'trauma', 'addict',
+    ];
+    for (const word of banned) {
+      expect(enumBody.toLowerCase()).not.toContain(word);
+    }
+  });
+
+  it('TonePreference enum does NOT include diagnostic personality labels', () => {
+    const enumMatch = typesSrc.match(/export type TonePreference\s*=([\s\S]*?);/);
+    expect(enumMatch).toBeTruthy();
+    const enumBody = enumMatch![1];
+    const banned = [
+      'anxious', 'depress', 'avoidant', 'narcissist',
+      'borderline', 'bipolar', 'paranoid',
+    ];
+    for (const word of banned) {
+      expect(enumBody.toLowerCase()).not.toContain(word);
+    }
+  });
 });

--- a/services/gateway/test/orb/context/interaction-style-decision-provider.test.ts
+++ b/services/gateway/test/orb/context/interaction-style-decision-provider.test.ts
@@ -1,0 +1,280 @@
+/**
+ * VTID-02962 (B6) — interaction-style-decision-provider adapter tests.
+ *
+ * Wall: the adapter MUST distill to decision-grade enums and drop:
+ *   - raw `last_updated_at` ISO timestamp
+ *   - operator-only `source_health` envelope
+ *   - any free-text or psychological summary
+ *
+ * Kept: bucketed enums + warnings.
+ *
+ * NEVER carries medical interpretation, mental-health inference,
+ * diagnostic-feeling personality labels, or free-text psychological
+ * summaries.
+ */
+
+import {
+  computeDecisionWarnings,
+  distillInteractionStyleForDecision,
+} from '../../../src/orb/context/providers/interaction-style-decision-provider';
+import {
+  bucketConfidence,
+  compileInteractionStyleContext,
+} from '../../../src/services/interaction-style/compile-interaction-style-context';
+import type { InteractionStyleContext } from '../../../src/services/interaction-style/types';
+
+function makeContext(over: Partial<InteractionStyleContext> = {}): InteractionStyleContext {
+  return {
+    preferred_response_style: 'unknown',
+    interaction_pace: 'unknown',
+    tone_preference: 'unknown',
+    explanation_depth_hint: 'normal',
+    confidence_bucket: 'unknown',
+    last_updated_at: null,
+    source_health: {
+      user_assistant_state: { ok: true },
+    },
+    ...over,
+  };
+}
+
+describe('B6 — distillInteractionStyleForDecision', () => {
+  describe('forbidden raw fields are NOT surfaced', () => {
+    it('drops last_updated_at and source_health envelope from output', () => {
+      const out = distillInteractionStyleForDecision({
+        interactionStyle: makeContext({
+          preferred_response_style: 'concise',
+          interaction_pace: 'normal',
+          tone_preference: 'direct',
+          explanation_depth_hint: 'minimal',
+          confidence_bucket: 'high',
+          last_updated_at: '2026-05-13T10:00:00Z',
+        }),
+      });
+      expect((out as any).last_updated_at).toBeUndefined();
+      expect((out as any).source_health).toBeUndefined();
+    });
+
+    it('top-level shape is exactly the decision-grade keys', () => {
+      const out = distillInteractionStyleForDecision({
+        interactionStyle: makeContext({
+          preferred_response_style: 'balanced',
+          interaction_pace: 'normal',
+          tone_preference: 'warm',
+          explanation_depth_hint: 'normal',
+          confidence_bucket: 'medium',
+        }),
+      });
+      const keys = Object.keys(out).sort();
+      expect(keys).toEqual([
+        'confidence_bucket',
+        'explanation_depth_hint',
+        'interaction_pace',
+        'preferred_response_style',
+        'tone_preference',
+        'warnings',
+      ]);
+    });
+  });
+
+  describe('enum pass-through', () => {
+    it('preserves the compiler-assigned enums verbatim', () => {
+      const ctx = makeContext({
+        preferred_response_style: 'detailed',
+        interaction_pace: 'slow',
+        tone_preference: 'coaching',
+        explanation_depth_hint: 'expanded',
+        confidence_bucket: 'high',
+      });
+      const out = distillInteractionStyleForDecision({ interactionStyle: ctx });
+      expect(out.preferred_response_style).toBe('detailed');
+      expect(out.interaction_pace).toBe('slow');
+      expect(out.tone_preference).toBe('coaching');
+      expect(out.explanation_depth_hint).toBe('expanded');
+      expect(out.confidence_bucket).toBe('high');
+    });
+  });
+
+  describe('computeDecisionWarnings', () => {
+    it('emits no_recorded_preferences when every preference is unknown', () => {
+      expect(computeDecisionWarnings(makeContext({})))
+        .toContain('no_recorded_preferences');
+    });
+
+    it('does NOT emit no_recorded_preferences when one preference is set', () => {
+      const ws = computeDecisionWarnings(makeContext({
+        preferred_response_style: 'concise',
+        confidence_bucket: 'medium',
+      }));
+      expect(ws).not.toContain('no_recorded_preferences');
+    });
+
+    it('emits low_signal_confidence when confidence is low', () => {
+      expect(computeDecisionWarnings(makeContext({
+        preferred_response_style: 'balanced',
+        confidence_bucket: 'low',
+      }))).toContain('low_signal_confidence');
+    });
+
+    it('emits low_signal_confidence when confidence is unknown', () => {
+      expect(computeDecisionWarnings(makeContext({
+        preferred_response_style: 'balanced',
+        confidence_bucket: 'unknown',
+      }))).toContain('low_signal_confidence');
+    });
+
+    it('does NOT emit low_signal_confidence when confidence is high', () => {
+      expect(computeDecisionWarnings(makeContext({
+        preferred_response_style: 'concise',
+        interaction_pace: 'normal',
+        tone_preference: 'warm',
+        confidence_bucket: 'high',
+      }))).not.toContain('low_signal_confidence');
+    });
+
+    it('warnings are enum-only (no free-text leaks)', () => {
+      const out = distillInteractionStyleForDecision({
+        interactionStyle: makeContext({}),
+      });
+      for (const w of out.warnings) {
+        expect(['no_recorded_preferences', 'low_signal_confidence']).toContain(w);
+      }
+    });
+  });
+});
+
+describe('B6 — compileInteractionStyleContext', () => {
+  it('returns all-unknown shape when fetch returns no row (steady state)', () => {
+    const out = compileInteractionStyleContext({
+      fetchResult: { ok: true, row: null },
+    });
+    expect(out.preferred_response_style).toBe('unknown');
+    expect(out.interaction_pace).toBe('unknown');
+    expect(out.tone_preference).toBe('unknown');
+    expect(out.explanation_depth_hint).toBe('normal');
+    expect(out.confidence_bucket).toBe('unknown');
+    expect(out.last_updated_at).toBeNull();
+    expect(out.source_health.user_assistant_state.ok).toBe(true);
+  });
+
+  it('returns degraded health when fetch fails', () => {
+    const out = compileInteractionStyleContext({
+      fetchResult: { ok: false, row: null, reason: 'supabase_unconfigured' },
+    });
+    expect(out.source_health.user_assistant_state.ok).toBe(false);
+    expect(out.source_health.user_assistant_state.reason).toBe('supabase_unconfigured');
+    expect(out.confidence_bucket).toBe('unknown');
+  });
+
+  it('reads enum fields from row.value verbatim when present', () => {
+    const out = compileInteractionStyleContext({
+      fetchResult: {
+        ok: true,
+        row: {
+          value: {
+            response_style: 'concise',
+            pace: 'fast',
+            tone: 'direct',
+            explanation_depth: 'minimal',
+            confidence: 0.92,
+          },
+          confidence: 0.92,
+          updated_at: '2026-05-13T10:00:00Z',
+          last_seen_at: '2026-05-13T10:00:00Z',
+        },
+      },
+    });
+    expect(out.preferred_response_style).toBe('concise');
+    expect(out.interaction_pace).toBe('fast');
+    expect(out.tone_preference).toBe('direct');
+    expect(out.explanation_depth_hint).toBe('minimal');
+    expect(out.confidence_bucket).toBe('high');
+    expect(out.last_updated_at).toBe('2026-05-13T10:00:00Z');
+  });
+
+  it('coerces unknown enum values to unknown (defensive)', () => {
+    const out = compileInteractionStyleContext({
+      fetchResult: {
+        ok: true,
+        row: {
+          value: {
+            // Cast bypasses TS — proves runtime defensiveness.
+            response_style: 'rambling' as any,
+            pace: 'glacial' as any,
+            tone: 'anxious' as any,
+            explanation_depth: 'novel' as any,
+          },
+          confidence: 0.7,
+          updated_at: '2026-05-13T10:00:00Z',
+          last_seen_at: '2026-05-13T10:00:00Z',
+        },
+      },
+    });
+    expect(out.preferred_response_style).toBe('unknown');
+    expect(out.interaction_pace).toBe('unknown');
+    expect(out.tone_preference).toBe('unknown');
+    expect(out.explanation_depth_hint).toBe('normal');
+    expect(out.confidence_bucket).toBe('medium');
+  });
+
+  it('falls back to row-level confidence when value.confidence is missing', () => {
+    const out = compileInteractionStyleContext({
+      fetchResult: {
+        ok: true,
+        row: {
+          value: {
+            response_style: 'balanced',
+          },
+          confidence: 0.45,
+          updated_at: null,
+          last_seen_at: null,
+        },
+      },
+    });
+    expect(out.confidence_bucket).toBe('low');
+  });
+});
+
+describe('B6 — bucketConfidence', () => {
+  it.each<[unknown, ReturnType<typeof bucketConfidence>]>([
+    [null,         'unknown'],
+    [undefined,    'unknown'],
+    [Number.NaN,   'unknown'],
+    [-0.1,         'unknown'],
+    [0,            'low'],
+    [0.3,          'low'],
+    [0.49,         'low'],
+    [0.5,          'medium'],
+    [0.79,         'medium'],
+    [0.8,          'high'],
+    [1,            'high'],
+  ])('bucketConfidence(%p) === %p', (raw, expected) => {
+    expect(bucketConfidence(raw as any)).toBe(expected);
+  });
+});
+
+describe('B6 — wall: no diagnostic / medical labels in shape', () => {
+  // The decision shape must not allow strings that read like mental-
+  // health diagnoses. We assert by scanning the shipped TS source of
+  // the types module.
+  it('DecisionInteractionStyle warning enum has no diagnostic terms', () => {
+    const { readFileSync } = require('fs');
+    const { join } = require('path');
+    const typesSrc = readFileSync(
+      join(__dirname, '../../../src/orb/context/types.ts'),
+      'utf8',
+    );
+    const enumMatch = typesSrc.match(/export type InteractionStyleWarning\s*=([\s\S]*?);/);
+    expect(enumMatch).toBeTruthy();
+    const enumBody = enumMatch![1];
+    const banned = [
+      'diagnos', 'symptom', 'disease', 'illness', 'treatment',
+      'prescription', 'medication', 'clinical', 'anxious', 'depress',
+      'avoidant', 'narcissist', 'borderline', 'bipolar', 'mania',
+      'trauma', 'addict',
+    ];
+    for (const word of banned) {
+      expect(enumBody.toLowerCase()).not.toContain(word);
+    }
+  });
+});

--- a/services/gateway/test/orb/context/spine-end-to-end.test.ts
+++ b/services/gateway/test/orb/context/spine-end-to-end.test.ts
@@ -15,7 +15,9 @@
  */
 
 import { compileContinuityContext } from '../../../src/services/continuity/compile-continuity-context';
+import { compileInteractionStyleContext } from '../../../src/services/interaction-style/compile-interaction-style-context';
 import { distillContinuityForDecision } from '../../../src/orb/context/providers/continuity-decision-provider';
+import { distillInteractionStyleForDecision } from '../../../src/orb/context/providers/interaction-style-decision-provider';
 import { renderDecisionContract } from '../../../src/orb/live/instruction/decision-contract-renderer';
 import type { AssistantDecisionContext } from '../../../src/orb/context/types';
 import type {
@@ -98,11 +100,13 @@ describe('B0b-min — end-to-end spine', () => {
       concept_mastery: null,
       journey_stage: null,
       pillar_momentum: null,
+      interaction_style: null,
       source_health: {
         continuity: { ok: true },
         concept_mastery: { ok: true },
         journey_stage: { ok: true },
         pillar_momentum: { ok: true },
+        interaction_style: { ok: true },
       },
     };
     const rendered = renderDecisionContract(decision);
@@ -143,11 +147,13 @@ describe('B0b-min — end-to-end spine', () => {
       concept_mastery: null,
       journey_stage: null,
       pillar_momentum: null,
+      interaction_style: null,
       source_health: {
         continuity: { ok: true },
         concept_mastery: { ok: true },
         journey_stage: { ok: true },
         pillar_momentum: { ok: true },
+        interaction_style: { ok: true },
       },
     };
     expect(renderDecisionContract(decision)).toBe('');
@@ -167,15 +173,89 @@ describe('B0b-min — end-to-end spine', () => {
       concept_mastery: null,
       journey_stage: null,
       pillar_momentum: null,
+      interaction_style: null,
       source_health: {
         continuity: { ok: false, reason: 'supabase_unconfigured' },
         concept_mastery: { ok: true },
         journey_stage: { ok: true },
         pillar_momentum: { ok: true },
+        interaction_style: { ok: true },
       },
     };
     const rendered = renderDecisionContract(decision);
     expect(rendered).toContain('continuity: source degraded');
+    expect(rendered).toContain('supabase_unconfigured');
+  });
+
+  it('B6: interaction_style renders only distilled enums + drops timestamps', () => {
+    const interactionCtx = compileInteractionStyleContext({
+      fetchResult: {
+        ok: true,
+        row: {
+          value: {
+            response_style: 'concise',
+            pace: 'normal',
+            tone: 'direct',
+            explanation_depth: 'minimal',
+            confidence: 0.91,
+          },
+          confidence: 0.91,
+          updated_at: '2026-05-13T10:00:00Z',
+          last_seen_at: '2026-05-13T10:00:00Z',
+        },
+      },
+    });
+    const decision: AssistantDecisionContext = {
+      continuity: null,
+      concept_mastery: null,
+      journey_stage: null,
+      pillar_momentum: null,
+      interaction_style: distillInteractionStyleForDecision({
+        interactionStyle: interactionCtx,
+      }),
+      source_health: {
+        continuity: { ok: true },
+        concept_mastery: { ok: true },
+        journey_stage: { ok: true },
+        pillar_momentum: { ok: true },
+        interaction_style: { ok: true },
+      },
+    };
+    const rendered = renderDecisionContract(decision);
+
+    // Distilled section present
+    expect(rendered).toContain('Interaction style:');
+    expect(rendered).toContain('response style: concise');
+    expect(rendered).toContain('pace: normal');
+    expect(rendered).toContain('tone: direct');
+    expect(rendered).toContain('explanation depth: minimal');
+    expect(rendered).toContain('confidence: high');
+
+    // Forbidden raw fields MUST NOT leak through the renderer.
+    expect(rendered).not.toContain('2026-05-13');
+    expect(rendered).not.toContain('T10:00:00');
+    expect(rendered).not.toContain('0.91');
+    expect(rendered).not.toContain('last_updated_at');
+    expect(rendered).not.toContain('last_seen_at');
+  });
+
+  it('B6: degraded interaction_style source produces a hint, no crash', () => {
+    const decision: AssistantDecisionContext = {
+      continuity: null,
+      concept_mastery: null,
+      journey_stage: null,
+      pillar_momentum: null,
+      interaction_style: null,
+      source_health: {
+        continuity: { ok: true },
+        concept_mastery: { ok: true },
+        journey_stage: { ok: true },
+        pillar_momentum: { ok: true },
+        interaction_style: { ok: false, reason: 'supabase_unconfigured' },
+      },
+    };
+    const rendered = renderDecisionContract(decision);
+    expect(rendered).toContain('interaction_style: source degraded');
     expect(rendered).toContain('supabase_unconfigured');
   });
 });

--- a/services/gateway/test/orb/live/instruction/decision-contract-renderer.test.ts
+++ b/services/gateway/test/orb/live/instruction/decision-contract-renderer.test.ts
@@ -49,11 +49,13 @@ function emptyContext(over: Partial<AssistantDecisionContext> = {}): AssistantDe
     concept_mastery: null,
     journey_stage: null,
     pillar_momentum: null,
+    interaction_style: null,
     source_health: {
       continuity: { ok: true },
       concept_mastery: { ok: true },
       journey_stage: { ok: true },
       pillar_momentum: { ok: true },
+      interaction_style: { ok: true },
     },
     ...over,
   };
@@ -109,6 +111,7 @@ describe('B0b-min — decision-contract-renderer', () => {
             concept_mastery: { ok: true },
             journey_stage: { ok: true },
             pillar_momentum: { ok: true },
+            interaction_style: { ok: true },
           },
         }),
       );
@@ -287,6 +290,7 @@ describe('B0b-min — decision-contract-renderer', () => {
             concept_mastery: { ok: false, reason: 'supabase_unconfigured' },
             journey_stage: { ok: true },
             pillar_momentum: { ok: true },
+            interaction_style: { ok: true },
           },
         }),
       );
@@ -503,6 +507,7 @@ describe('B0b-min — decision-contract-renderer', () => {
             concept_mastery: { ok: true },
             journey_stage: { ok: false, reason: 'supabase_unconfigured' },
             pillar_momentum: { ok: true },
+            interaction_style: { ok: true },
           },
         }),
       );
@@ -700,6 +705,7 @@ describe('B0b-min — decision-contract-renderer', () => {
             concept_mastery: { ok: true },
             journey_stage: { ok: true },
             pillar_momentum: { ok: false, reason: 'supabase_unconfigured' },
+            interaction_style: { ok: true },
           },
         }),
       );


### PR DESCRIPTION
## Summary

Adds the B6 Interaction Style signal to the `AssistantDecisionContext` spine, mirroring the B2/B3/B4/B5 pattern. Decision-grade only — no raw chat / transcripts / memory / timestamps / behavioral history / route history / profile payloads cross the boundary.

## What ships

- **Types** (`services/gateway/src/orb/context/types.ts`)
  - `DecisionInteractionStyle` interface + sub-enums (`PreferredResponseStyle`, `InteractionPace`, `TonePreference`, `InteractionExplanationDepth`, `InteractionStyleConfidenceBucket`, `InteractionStyleWarning`)
  - `AssistantDecisionContext.interaction_style` field + `source_health.interaction_style` entry
- **Compiler** (`services/gateway/src/services/interaction-style/`)
  - `types.ts`, `compile-interaction-style-context.ts`, `interaction-style-fetcher.ts`
  - Reads ONE row of `user_assistant_state` where `signal_name = 'interaction_style_v1'`
  - Missing row = steady-state default (all 'unknown'), NOT a failure
- **Adapter** (`services/gateway/src/orb/context/providers/interaction-style-decision-provider.ts`)
  - `distillInteractionStyleForDecision` drops `last_updated_at` + operator-only `source_health` envelope, keeps only the decision-grade enums + warnings
- **Orchestrator** (`compile-assistant-decision-context.ts`)
  - New `runInteractionStyleProvider` runs in parallel via `Promise.all`, isolated try/catch — never blocks other providers
- **Renderer** (`decision-contract-renderer.ts`)
  - New `renderInteractionStyle` section, enum-only output. Suppresses no-signal sections; `explanation_depth_hint` defaults to 'normal' so the prompt always reads a usable value.

## Wall enforced

- No raw rows / transcripts / messages / memory / timestamps / route history / profile payloads cross the decision contract.
- No medical / mental-health inference. No diagnostic-feeling personality labels. No free-text psychological summaries.
- Type-guard tests scan the `InteractionStyleWarning` + `TonePreference` enum bodies for banned diagnostic terms (`diagnos`, `anxious`, `depress`, `avoidant`, `bipolar`, `trauma`, ...).
- Renderer accepts ONLY `AssistantDecisionContext` — existing wall test still passes.

## Out of scope (per the brief)

- `services/gateway/src/routes/orb-live.ts` — untouched
- `services/gateway/src/orb/live/transport/*` — untouched
- `services/gateway/src/orb/live/session/*` — untouched
- `services/gateway/src/orb/live/upstream/*` — untouched
- LiveKit files — untouched
- B7, F4, match-journey, feature-discovery, wake-brief, continuation-contract, reliability tuning — explicitly deferred
- Write path for `interaction_style_v1` row — read-only by design (writes are a later phase)
- Command Hub preview surface — no existing decision-contract preview to extend yet

## Test plan

- [x] Unit: `distillInteractionStyleForDecision` drops timestamps + source_health envelope
- [x] Unit: top-level shape is exactly the 6 decision-grade keys
- [x] Unit: enum pass-through (all 5 enums)
- [x] Unit: `computeDecisionWarnings` (no_recorded_preferences + low_signal_confidence, enum-only)
- [x] Unit: `compileInteractionStyleContext` (missing row, degraded fetch, full row, defensive enum coercion, row-level confidence fallback)
- [x] Unit: `bucketConfidence` (null/NaN/negative/0/0.49/0.5/0.79/0.8/1)
- [x] Type-guard: forbidden raw fields not declared in `DecisionInteractionStyle`
- [x] Type-guard: bucketed enums only, never raw `number`
- [x] Type-guard: warnings is `ReadonlyArray<InteractionStyleWarning>`, never string
- [x] Type-guard: warning enum + tone enum scan for diagnostic terms
- [x] Orchestrator: 5-provider happy path
- [x] Orchestrator: B6 throws → null + others still flow
- [x] Orchestrator: all 5 throw → no crash
- [x] Orchestrator: parallel execution (concept → journey → pillar → interaction → continuity)
- [x] Orchestrator: 6 top-level keys total (no leakage)
- [x] Spine-end-to-end: distilled B6 section renders + raw timestamps/scores don't leak
- [x] Spine-end-to-end: degraded B6 source produces a hint, no crash
- [x] Renderer test: extended `emptyContext` + 4 `source_health` override literals

143 B6-touching tests green. Full suite: 3397 pass / 2 pre-existing flaky `governance.test.ts` timeouts (unrelated to B6; confirmed standalone-pass on both main and B6 worktree). Build clean.

## Stop point

Per the brief: B6 only. No B7. No F4. Stopping for review.

🤖 Generated with [Claude Code](https://claude.com/claude-code)