### PR TITLE
feat(orb): A8.2 — session controller + cleanup helpers + end-turn handler (VTID-02961)

### DIFF
--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -1,0 +1,270 @@
+/**
+ * A8.2 (orb-live-refactor / VTID-02961): session lifecycle controller —
+ * slice 2 of 3.
+ *
+ * A8 is split per the spec's risk warning:
+ *   A8.1 (shipped) — registry shell (Maps + types).
+ *   A8.2 (this slice) — lifecycle/cleanup helpers + smallest session-action
+ *                       handler (`/live/stream/end-turn`). Establishes the
+ *                       controller module + deps-bag pattern. Per the
+ *                       direction's "Keep scope tight" rule, the larger
+ *                       handlers (`/live/session/start`, `/live/session/stop`,
+ *                       `/live/stream/send`) follow in subsequent slices
+ *                       using the same pattern.
+ *   A8.3 (next)   — LiveAPI message-handler closure migration to
+ *                   VertexLiveClient (A7); migrates per-event SSE writes to
+ *                   `writeSseEvent` from A9.2; lifts remaining handlers.
+ *
+ * Hard rules (carried from A7 / A9.1 / A9.2 / A8.1):
+ *   1. Zero behavior change. The lifted helpers operate on the SAME Map
+ *      instances that orb-live.ts mutates, via the A8.1 registry.
+ *   2. Deps are injected once via `configureLiveSessionController`. Helpers
+ *      that read deps after configuration call `getDeps()`. Configuring twice
+ *      is an explicit error (caught early so misconfigured tests / wiring
+ *      fail loudly).
+ *   3. No LiveAPI message-handler closure here — that's A8.3.
+ *   4. No LiveKit adapter, no provider selection — those are L-lane work.
+ */
+
+import type { Response } from 'express';
+import type WebSocket from 'ws';
+import WebSocketPkg from 'ws';
+import type {
+  AuthenticatedRequest,
+  SupabaseIdentity,
+} from '../../../middleware/auth-supabase-jwt';
+import type { GeminiLiveSession } from '../../../routes/orb-live';
+import { SESSION_TIMEOUT_MS } from '../config';
+import { destroySessionBuffer } from '../../../services/session-memory-buffer';
+import {
+  deduplicatedExtract,
+  clearExtractionState,
+} from '../../../services/extraction-dedup-manager';
+import { DEV_IDENTITY } from '../../../services/orb-memory-bridge';
+import {
+  sessions,
+  liveSessions,
+  wsClientSessions,
+} from './live-session-registry';
+
+/**
+ * Dependencies that live as locals inside `routes/orb-live.ts` and which
+ * the lifted helpers need. Passed in once via
+ * `configureLiveSessionController` so the controller module has no
+ * runtime import cycle with orb-live.ts.
+ *
+ * Each dep maps 1:1 to a private function in orb-live.ts that A8.3 (or
+ * later) will lift out independently:
+ *   - `resolveOrbIdentity` lives at routes/orb-live.ts:~458.
+ *   - `clearResponseWatchdog` lives at routes/orb-live.ts:~7201.
+ *   - `sendEndOfTurn` lives at routes/orb-live.ts:~7104.
+ */
+export interface LiveSessionControllerDeps {
+  resolveOrbIdentity: (req: AuthenticatedRequest) => Promise<SupabaseIdentity | null>;
+  clearResponseWatchdog: (session: GeminiLiveSession) => void;
+  sendEndOfTurn: (ws: WebSocket) => boolean;
+}
+
+let configuredDeps: LiveSessionControllerDeps | null = null;
+
+/**
+ * Wire orb-live.ts locals into the controller. MUST be called exactly
+ * once at gateway module-load before any handler fires.
+ */
+export function configureLiveSessionController(deps: LiveSessionControllerDeps): void {
+  if (configuredDeps) {
+    throw new Error('live-session-controller already configured');
+  }
+  configuredDeps = deps;
+}
+
+/**
+ * Test-only escape hatch. Production never calls this. Lets tests start
+ * with a clean slate without mutating module state across tests.
+ */
+export function __resetLiveSessionControllerForTests(): void {
+  configuredDeps = null;
+}
+
+function getDeps(): LiveSessionControllerDeps {
+  if (!configuredDeps) {
+    throw new Error('live-session-controller not configured — call configureLiveSessionController() at boot');
+  }
+  return configuredDeps;
+}
+
+// =============================================================================
+// Lifecycle / cleanup helpers
+// =============================================================================
+
+/**
+ * Sweep expired legacy `OrbLiveSession` entries. Originally inline in
+ * orb-live.ts (line ~8384) with a `setInterval(..., 5 * 60 * 1000)`.
+ *
+ * orb-live.ts now imports this + still owns the `setInterval` schedule
+ * so reload order is unchanged. Body is byte-identical to the legacy.
+ */
+export function cleanupExpiredSessions(): void {
+  const now = Date.now();
+  for (const [sessionId, session] of sessions.entries()) {
+    if (now - session.lastActivity.getTime() > SESSION_TIMEOUT_MS) {
+      console.log(`[ORB-LIVE] Session expired: ${sessionId}`);
+      if (session.sseResponse) {
+        try {
+          session.sseResponse.end();
+        } catch (e) {
+          // Ignore
+        }
+      }
+      sessions.delete(sessionId);
+    }
+  }
+}
+
+/**
+ * Close + clean up a WebSocket client session. Originally inline at
+ * orb-live.ts:~13931.
+ *
+ * Behavior parity:
+ *   - VTID-01230 deduplicated extraction on disconnect if transcript exists.
+ *   - VTID-STREAM-KEEPALIVE: clears upstream ping + silence keepalive intervals.
+ *   - VTID-WATCHDOG: clears the response watchdog.
+ *   - Closes upstream Vertex WS if open; closes client WS with code 1000.
+ *   - Removes the entry from both `liveSessions` and `wsClientSessions`.
+ */
+export function cleanupWsSession(sessionId: string): void {
+  const deps = getDeps();
+  const clientSession = wsClientSessions.get(sessionId);
+  if (!clientSession) return;
+
+  // Close Live API session if active
+  if (clientSession.liveSession) {
+    // VTID-01230: Deduplicated extraction on WebSocket disconnect
+    const ls = clientSession.liveSession;
+    if (ls.identity && ls.identity.tenant_id && ls.transcriptTurns.length > 0) {
+      const fullTranscript = ls.transcriptTurns
+        .map((t) => `${t.role === 'user' ? 'User' : 'Assistant'}: ${t.text}`)
+        .join('\n');
+      deduplicatedExtract({
+        conversationText: fullTranscript,
+        tenant_id: ls.identity.tenant_id,
+        user_id: ls.identity.user_id,
+        session_id: sessionId,
+        force: true,
+      });
+      destroySessionBuffer(sessionId);
+      clearExtractionState(sessionId);
+    }
+
+    clientSession.liveSession.active = false;
+
+    // VTID-STREAM-KEEPALIVE: Clear upstream ping interval on cleanup
+    if (clientSession.liveSession.upstreamPingInterval) {
+      clearInterval(clientSession.liveSession.upstreamPingInterval);
+      clientSession.liveSession.upstreamPingInterval = undefined;
+    }
+    if (clientSession.liveSession.silenceKeepaliveInterval) {
+      clearInterval(clientSession.liveSession.silenceKeepaliveInterval);
+      clientSession.liveSession.silenceKeepaliveInterval = undefined;
+    }
+    // VTID-WATCHDOG: Clear response watchdog on cleanup
+    deps.clearResponseWatchdog(clientSession.liveSession);
+
+    if (clientSession.liveSession.upstreamWs) {
+      try {
+        clientSession.liveSession.upstreamWs.close();
+      } catch (e) {
+        // Ignore
+      }
+    }
+
+    liveSessions.delete(sessionId);
+  }
+
+  // Close client WebSocket if open
+  if (clientSession.clientWs.readyState === WebSocketPkg.OPEN) {
+    try {
+      clientSession.clientWs.close(1000, 'Session cleanup');
+    } catch (e) {
+      // Ignore
+    }
+  }
+
+  wsClientSessions.delete(sessionId);
+  console.log(`[VTID-01222] WebSocket session cleaned up: ${sessionId}`);
+}
+
+// =============================================================================
+// Session-action handlers
+// =============================================================================
+
+/**
+ * `POST /api/v1/orb/live/stream/end-turn` — signal the Vertex Live API
+ * that the user has finished speaking. Originally inline at
+ * orb-live.ts:~12416.
+ *
+ * Behavior parity:
+ *   - 400 when `session_id` is missing (from query OR body).
+ *   - 404 when the session is not in `liveSessions`.
+ *   - 400 when `session.active === false`.
+ *   - VTID-ORBC ownership-mismatch warning (allowed through; UUIDs are
+ *     unguessable).
+ *   - VTID-01219: forwards `client_content.turn_complete:true` to upstream
+ *     when the Vertex WS is OPEN.
+ *   - Always 200 (success path message differs by whether Vertex was
+ *     signaled or not).
+ *
+ * The other session-action handlers (`/live/session/start`,
+ * `/live/session/stop`, `/live/stream/send`) follow in subsequent slices
+ * using this same pattern.
+ */
+export async function handleLiveStreamEndTurn(
+  req: AuthenticatedRequest,
+  res: Response,
+): Promise<Response> {
+  const deps = getDeps();
+  const { session_id } = req.query;
+  const body = req.body as { session_id?: string };
+  const effectiveSessionId = (session_id as string) || body.session_id;
+
+  // VTID-ORBC: Resolve identity - JWT if present, DEV_IDENTITY in dev-sandbox, or anonymous.
+  // Allow anonymous requests for lovable/external frontends.
+  const identity = await deps.resolveOrbIdentity(req);
+
+  if (!effectiveSessionId) {
+    return res.status(400).json({ ok: false, error: 'session_id required' });
+  }
+
+  const session = liveSessions.get(effectiveSessionId);
+  if (!session) {
+    return res.status(404).json({ ok: false, error: 'Session not found' });
+  }
+
+  if (!session.active) {
+    return res.status(400).json({ ok: false, error: 'Session not active' });
+  }
+
+  // VTID-ORBC: Log ownership mismatch but allow through — session IDs are UUIDs (unguessable).
+  if (
+    identity &&
+    session.identity &&
+    session.identity.user_id !== DEV_IDENTITY.USER_ID &&
+    session.identity.user_id !== identity.user_id
+  ) {
+    console.warn(
+      `[VTID-ORBC] /end-turn ownership mismatch (allowed): session_user=${session.identity.user_id}, request_user=${identity.user_id}, sessionId=${effectiveSessionId}`,
+    );
+  }
+
+  // VTID-01219: Send end of turn to Live API
+  if (session.upstreamWs && session.upstreamWs.readyState === WebSocketPkg.OPEN) {
+    const sent = deps.sendEndOfTurn(session.upstreamWs);
+    if (sent) {
+      console.log(`[VTID-01219] End of turn sent to Live API: session=${effectiveSessionId}`);
+      return res.status(200).json({ ok: true, message: 'End of turn signaled' });
+    }
+  }
+
+  console.log(`[VTID-01219] End of turn (no Live API): session=${effectiveSessionId}`);
+  return res.status(200).json({ ok: true, message: 'End of turn acknowledged (no Live API)' });
+}

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1137,6 +1137,18 @@ import {
   liveSessions,
   wsClientSessions,
 } from '../orb/live/session/live-session-registry';
+// A8.2 (orb-live-refactor / VTID-02961): session lifecycle helpers +
+// smallest session-action handler lifted into the controller module.
+// `cleanupExpiredSessions`, `cleanupWsSession`, `handleLiveStreamEndTurn`
+// now live in orb/live/session/live-session-controller.ts. orb-live.ts
+// configures the controller with its locals (resolveOrbIdentity,
+// clearResponseWatchdog, sendEndOfTurn) at module-init below.
+import {
+  configureLiveSessionController,
+  cleanupExpiredSessions,
+  cleanupWsSession,
+  handleLiveStreamEndTurn,
+} from '../orb/live/session/live-session-controller';
 // A3 (orb-live-refactor): system instruction builder + its private helpers
 // (describeTimeSince, describeRoute, buildTemporalJourneyContextSection,
 // TemporalBucket type) lifted to orb/live/instruction/live-system-instruction.ts.
@@ -8381,24 +8393,20 @@ You KNOW this user. You REMEMBER their name, their hometown, their family, and t
   }
 }
 
-function cleanupExpiredSessions(): void {
-  const now = Date.now();
-  for (const [sessionId, session] of sessions.entries()) {
-    if (now - session.lastActivity.getTime() > SESSION_TIMEOUT_MS) {
-      console.log(`[ORB-LIVE] Session expired: ${sessionId}`);
-      if (session.sseResponse) {
-        try {
-          session.sseResponse.end();
-        } catch (e) {
-          // Ignore
-        }
-      }
-      sessions.delete(sessionId);
-    }
-  }
-}
+// A8.2 (VTID-02961): wire orb-live.ts locals into the session controller.
+// MUST happen before any session-action handler fires. Function
+// declarations (resolveOrbIdentity / clearResponseWatchdog / sendEndOfTurn)
+// are hoisted, so the references resolve at this module-load point even
+// though the bodies appear later in the file.
+configureLiveSessionController({
+  resolveOrbIdentity,
+  clearResponseWatchdog,
+  sendEndOfTurn,
+});
 
-// Cleanup expired sessions every 5 minutes
+// A8.2: cleanupExpiredSessions body lifted to
+// orb/live/session/live-session-controller.ts. The setInterval schedule
+// stays here — orb-live.ts owns the cleanup timer lifecycle.
 setInterval(cleanupExpiredSessions, 5 * 60 * 1000);
 
 /**
@@ -12413,45 +12421,9 @@ router.post('/live/stream/send', optionalAuth, async (req: AuthenticatedRequest,
  * - 400 TENANT_REQUIRED: No active_tenant_id in JWT app_metadata
  * - 403 FORBIDDEN: User doesn't own this session
  */
+// A8.2: handler body lifted to orb/live/session/live-session-controller.ts.
 router.post('/live/stream/end-turn', optionalAuth, async (req: AuthenticatedRequest, res: Response) => {
-  const { session_id } = req.query;
-  const body = req.body as { session_id?: string };
-  const effectiveSessionId = (session_id as string) || body.session_id;
-
-  // VTID-ORBC: Resolve identity - JWT if present, DEV_IDENTITY in dev-sandbox, or anonymous.
-  // Allow anonymous requests for lovable/external frontends.
-  const identity = await resolveOrbIdentity(req);
-
-  if (!effectiveSessionId) {
-    return res.status(400).json({ ok: false, error: 'session_id required' });
-  }
-
-  const session = liveSessions.get(effectiveSessionId);
-  if (!session) {
-    return res.status(404).json({ ok: false, error: 'Session not found' });
-  }
-
-  if (!session.active) {
-    return res.status(400).json({ ok: false, error: 'Session not active' });
-  }
-
-  // VTID-ORBC: Log ownership mismatch but allow through — session IDs are UUIDs (unguessable).
-  if (identity && session.identity && session.identity.user_id !== DEV_IDENTITY.USER_ID &&
-      session.identity.user_id !== identity.user_id) {
-    console.warn(`[VTID-ORBC] /end-turn ownership mismatch (allowed): session_user=${session.identity.user_id}, request_user=${identity.user_id}, sessionId=${effectiveSessionId}`);
-  }
-
-  // VTID-01219: Send end of turn to Live API
-  if (session.upstreamWs && session.upstreamWs.readyState === WebSocket.OPEN) {
-    const sent = sendEndOfTurn(session.upstreamWs);
-    if (sent) {
-      console.log(`[VTID-01219] End of turn sent to Live API: session=${effectiveSessionId}`);
-      return res.status(200).json({ ok: true, message: 'End of turn signaled' });
-    }
-  }
-
-  console.log(`[VTID-01219] End of turn (no Live API): session=${effectiveSessionId}`);
-  return res.status(200).json({ ok: true, message: 'End of turn acknowledged (no Live API)' });
+  await handleLiveStreamEndTurn(req, res);
 });
 
 /**
@@ -13925,69 +13897,9 @@ function handleWsStopSession(clientSession: WsClientSession): void {
   });
 }
 
-/**
- * VTID-01222: Cleanup WebSocket session
- */
-function cleanupWsSession(sessionId: string): void {
-  const clientSession = wsClientSessions.get(sessionId);
-  if (!clientSession) return;
-
-  // Close Live API session if active
-  if (clientSession.liveSession) {
-    // VTID-01230: Deduplicated extraction on WebSocket disconnect
-    const ls = clientSession.liveSession;
-    if (ls.identity && ls.identity.tenant_id && ls.transcriptTurns.length > 0) {
-      const fullTranscript = ls.transcriptTurns
-        .map(t => `${t.role === 'user' ? 'User' : 'Assistant'}: ${t.text}`)
-        .join('\n');
-      deduplicatedExtract({
-        conversationText: fullTranscript,
-        tenant_id: ls.identity.tenant_id,
-        user_id: ls.identity.user_id,
-        session_id: sessionId,
-        force: true,
-      });
-      destroySessionBuffer(sessionId);
-      clearExtractionState(sessionId);
-    }
-
-    clientSession.liveSession.active = false;
-
-    // VTID-STREAM-KEEPALIVE: Clear upstream ping interval on cleanup
-    if (clientSession.liveSession.upstreamPingInterval) {
-      clearInterval(clientSession.liveSession.upstreamPingInterval);
-      clientSession.liveSession.upstreamPingInterval = undefined;
-    }
-    if (clientSession.liveSession.silenceKeepaliveInterval) {
-      clearInterval(clientSession.liveSession.silenceKeepaliveInterval);
-      clientSession.liveSession.silenceKeepaliveInterval = undefined;
-    }
-    // VTID-WATCHDOG: Clear response watchdog on cleanup
-    clearResponseWatchdog(clientSession.liveSession);
-
-    if (clientSession.liveSession.upstreamWs) {
-      try {
-        clientSession.liveSession.upstreamWs.close();
-      } catch (e) {
-        // Ignore
-      }
-    }
-
-    liveSessions.delete(sessionId);
-  }
-
-  // Close client WebSocket if open
-  if (clientSession.clientWs.readyState === WebSocket.OPEN) {
-    try {
-      clientSession.clientWs.close(1000, 'Session cleanup');
-    } catch (e) {
-      // Ignore
-    }
-  }
-
-  wsClientSessions.delete(sessionId);
-  console.log(`[VTID-01222] WebSocket session cleaned up: ${sessionId}`);
-}
+// VTID-01222: Cleanup WebSocket session
+// A8.2: body lifted to orb/live/session/live-session-controller.ts.
+// cleanupWsSession is imported above and called from the same sites.
 
 /**
  * VTID-01222: Send message to WebSocket client

--- a/services/gateway/test/orb/live/characterization/stream-lifecycle.characterization.test.ts
+++ b/services/gateway/test/orb/live/characterization/stream-lifecycle.characterization.test.ts
@@ -1,29 +1,33 @@
 /**
- * A0.3 — Characterization test for transport lifecycle cleanup.
+ * Originally A0.3 — characterization for transport lifecycle cleanup.
+ * Updated 2026-05-13 (A8.2 / VTID-02961): `cleanupWsSession` body was
+ * lifted from `routes/orb-live.ts` into
+ * `orb/live/session/live-session-controller.ts`. Cleanup parity
+ * assertions now read from BOTH files:
+ *   - SSE-handler block in orb-live.ts (req.on('close')) — unchanged.
+ *   - WebSocket setup + cleanup-interval-call-site in orb-live.ts.
+ *   - `cleanupWsSession` body in the controller module.
  *
- * Purpose: lock the cleanup contract for both transports — every stream
- * that holds resources must release them when the client disconnects.
- * Without these handlers, an orb session that drops mid-call leaks the
- * upstream Live API socket + the audio context.
- *
- * Scope: assertions are made against the SSE-handler block AND the
- * WebSocket cleanup function in isolation, so unrelated handlers can't
- * accidentally satisfy them.
- *
- * Will be replaced/augmented by A9 with a runtime test against the
- * extracted transport modules + a lifecycle integration test.
+ * Runtime-level cleanup behavior is also covered by
+ * `test/orb/live/session/live-session-controller.test.ts`.
  */
 
 import * as fs from 'fs';
 import * as path from 'path';
 
 const ORB_LIVE_PATH = path.resolve(__dirname, '../../../../src/routes/orb-live.ts');
+const CONTROLLER_PATH = path.resolve(
+  __dirname,
+  '../../../../src/orb/live/session/live-session-controller.ts',
+);
 
 let sseHandlerBody: string;
 let wsCleanupSection: string;
+let controllerSrc: string;
 
 beforeAll(() => {
   const source = fs.readFileSync(ORB_LIVE_PATH, 'utf8');
+  controllerSrc = fs.readFileSync(CONTROLLER_PATH, 'utf8');
 
   // Slice the SSE handler block.
   const sseStart = source.indexOf("router.get('/live/stream'");
@@ -32,10 +36,9 @@ beforeAll(() => {
   expect(sseStop).toBeGreaterThan(sseStart);
   sseHandlerBody = source.slice(sseStart, sseStop);
 
-  // Slice a wider section starting at the WebSocket setup function
-  // through the file end. The cleanup logic lives in helpers below
-  // initializeOrbWebSocket (cleanupWsSession, the connection close handler,
-  // and the periodic timeout sweep).
+  // Wide section from the WebSocket setup to end-of-file. A8.2 moved the
+  // cleanup body to the controller; the call sites + interval scheduling
+  // remain in this slice.
   const wsStart = source.indexOf('export function initializeOrbWebSocket');
   expect(wsStart).toBeGreaterThan(0);
   wsCleanupSection = source.slice(wsStart);
@@ -51,53 +54,47 @@ describe('A0.3 characterization: transport lifecycle cleanup', () => {
     });
   });
 
-  describe('WebSocket: connection lifecycle', () => {
-    it('removes sessions from wsClientSessions on cleanup', () => {
+  describe('WebSocket: connection lifecycle (cleanup body lives in controller)', () => {
+    it('controller removes sessions from wsClientSessions on cleanup', () => {
+      // A8.2: assertion follows the body into the controller module.
       // Leak guard: if cleanup doesn't .delete from the map, the periodic
       // sweep iterates over zombies indefinitely and memory grows.
-      expect(wsCleanupSection).toMatch(/wsClientSessions\.delete\s*\(/);
+      expect(controllerSrc).toMatch(/wsClientSessions\.delete\s*\(/);
     });
 
-    it('clears intervals on cleanup (upstream ping + silence keepalive)', () => {
-      // Two intervals run per session (upstream Vertex Live ping +
-      // silence keepalive). Both must be cleared on disconnect.
-      expect(wsCleanupSection).toMatch(/clearInterval\s*\(/);
+    it('controller clears intervals on cleanup (upstream ping + silence keepalive)', () => {
+      expect(controllerSrc).toMatch(/clearInterval\s*\(/);
     });
 
-    it('attempts to close the upstream websocket on cleanup', () => {
-      // The upstream Vertex Live socket is the real resource. Forgetting
-      // to close it leaks both bandwidth and Vertex billing time.
-      expect(wsCleanupSection).toMatch(/upstreamWs[\s\S]{0,80}?\.close\s*\(/);
+    it('controller attempts to close the upstream websocket on cleanup', () => {
+      expect(controllerSrc).toMatch(/upstreamWs[\s\S]{0,80}?\.close\s*\(/);
     });
 
-    it('attempts to close the client websocket on cleanup (if still OPEN)', () => {
-      // Symmetric to the upstream close — the client side must be told
-      // explicitly so its onclose handler fires with the expected code.
-      expect(wsCleanupSection).toMatch(/clientWs\.close\s*\(/);
+    it('controller attempts to close the client websocket on cleanup (if still OPEN)', () => {
+      expect(controllerSrc).toMatch(/clientWs\.close\s*\(/);
     });
 
-    it('runs a periodic timeout sweep over wsClientSessions', () => {
-      // The sweep is what catches sessions whose close events never
-      // arrived (network drop, mobile background, etc.). It must
-      // remain — without it, ghost sessions accumulate.
+    it('orb-live.ts runs a periodic timeout sweep over the WS session map (interval-only; body in controller)', () => {
+      // A8.2 left the setInterval schedule in orb-live.ts (in
+      // initializeOrbWebSocket) and lifted the per-session iteration
+      // helper to the controller. The setInterval must remain — without
+      // it, ghost sessions accumulate.
       expect(wsCleanupSection).toMatch(/setInterval\s*\(/);
       expect(wsCleanupSection).toMatch(/wsClientSessions\.entries\s*\(\s*\)/);
     });
 
     it('uses a session timeout constant (not an inline magic number)', () => {
-      // SESSION_TIMEOUT_MS is the canonical name. A refactor that inlines
-      // a literal here would lose the single source of truth.
       expect(wsCleanupSection).toMatch(/SESSION_TIMEOUT_MS/);
     });
   });
 
   describe('cleanup symmetry across transports', () => {
-    it('both SSE and WS cleanup paths exist (parity)', () => {
+    it('both SSE and WS cleanup paths exist (parity; WS body now in controller)', () => {
       // The two transports must each have their own cleanup story.
-      // Catching this mismatch early — if one path silently goes away
-      // during refactor — is the whole point of this test.
+      // SSE close handler stays inline; WS cleanup body moved to the
+      // controller in A8.2.
       expect(sseHandlerBody).toMatch(/req\.on\(\s*['"`]close['"`]/);
-      expect(wsCleanupSection).toMatch(/wsClientSessions\.delete/);
+      expect(controllerSrc).toMatch(/wsClientSessions\.delete/);
     });
   });
 });

--- a/services/gateway/test/orb/live/session/live-session-controller.test.ts
+++ b/services/gateway/test/orb/live/session/live-session-controller.test.ts
@@ -1,0 +1,371 @@
+/**
+ * A8.2 (orb-live-refactor / VTID-02961): runtime tests for the session
+ * controller module — `orb/live/session/live-session-controller.ts`.
+ *
+ * Covers the three things A8.2 lifts:
+ *   1. `cleanupExpiredSessions` — expiry sweep over the `sessions` registry.
+ *   2. `cleanupWsSession` — WS session teardown (state mutations + Map
+ *      removals + dep callbacks).
+ *   3. `handleLiveStreamEndTurn` — request validation, ownership-mismatch
+ *      log, and Vertex WS forwarding via the `sendEndOfTurn` dep.
+ *
+ * Plus the deps-bag plumbing:
+ *   - `configureLiveSessionController` is required before any handler fires.
+ *   - Double-configure throws (catches mis-wired tests / boot loudly).
+ *   - `__resetLiveSessionControllerForTests` clears state for clean tests.
+ */
+
+import {
+  configureLiveSessionController,
+  cleanupExpiredSessions,
+  cleanupWsSession,
+  handleLiveStreamEndTurn,
+  __resetLiveSessionControllerForTests,
+} from '../../../../src/orb/live/session/live-session-controller';
+import {
+  sessions,
+  liveSessions,
+  wsClientSessions,
+} from '../../../../src/orb/live/session/live-session-registry';
+import { SESSION_TIMEOUT_MS } from '../../../../src/orb/live/config';
+
+// Mock WebSocket OPEN constant from `ws`.
+const WS_OPEN = 1;
+const WS_CLOSED = 3;
+
+beforeEach(() => {
+  __resetLiveSessionControllerForTests();
+  sessions.clear();
+  liveSessions.clear();
+  wsClientSessions.clear();
+});
+
+afterAll(() => {
+  __resetLiveSessionControllerForTests();
+  sessions.clear();
+  liveSessions.clear();
+  wsClientSessions.clear();
+});
+
+describe('A8.2: configureLiveSessionController', () => {
+  it('throws if a handler runs before configure', async () => {
+    await expect(
+      handleLiveStreamEndTurn({} as any, {} as any),
+    ).rejects.toThrow(/not configured/);
+  });
+
+  it('throws if configured twice', () => {
+    configureLiveSessionController({
+      resolveOrbIdentity: async () => null,
+      clearResponseWatchdog: () => undefined,
+      sendEndOfTurn: () => true,
+    });
+    expect(() =>
+      configureLiveSessionController({
+        resolveOrbIdentity: async () => null,
+        clearResponseWatchdog: () => undefined,
+        sendEndOfTurn: () => true,
+      }),
+    ).toThrow(/already configured/);
+  });
+
+  it('reset escape hatch allows reconfiguration', () => {
+    configureLiveSessionController({
+      resolveOrbIdentity: async () => null,
+      clearResponseWatchdog: () => undefined,
+      sendEndOfTurn: () => true,
+    });
+    __resetLiveSessionControllerForTests();
+    expect(() =>
+      configureLiveSessionController({
+        resolveOrbIdentity: async () => null,
+        clearResponseWatchdog: () => undefined,
+        sendEndOfTurn: () => true,
+      }),
+    ).not.toThrow();
+  });
+});
+
+describe('A8.2: cleanupExpiredSessions', () => {
+  it('removes sessions whose lastActivity is older than SESSION_TIMEOUT_MS', () => {
+    const oldTimestamp = new Date(Date.now() - SESSION_TIMEOUT_MS - 1000);
+    const fresh = new Date();
+    sessions.set('expired', { lastActivity: oldTimestamp, sseResponse: null } as any);
+    sessions.set('fresh', { lastActivity: fresh, sseResponse: null } as any);
+
+    cleanupExpiredSessions();
+
+    expect(sessions.has('expired')).toBe(false);
+    expect(sessions.has('fresh')).toBe(true);
+  });
+
+  it('ends the SSE response on expiry (best-effort, swallows errors)', () => {
+    const oldTimestamp = new Date(Date.now() - SESSION_TIMEOUT_MS - 1000);
+    const endSpy = jest.fn();
+    sessions.set('expired', {
+      lastActivity: oldTimestamp,
+      sseResponse: { end: endSpy },
+    } as any);
+
+    cleanupExpiredSessions();
+
+    expect(endSpy).toHaveBeenCalledTimes(1);
+    expect(sessions.has('expired')).toBe(false);
+  });
+
+  it('does not throw when sse.end throws', () => {
+    const oldTimestamp = new Date(Date.now() - SESSION_TIMEOUT_MS - 1000);
+    sessions.set('expired', {
+      lastActivity: oldTimestamp,
+      sseResponse: {
+        end: () => {
+          throw new Error('socket gone');
+        },
+      },
+    } as any);
+
+    expect(() => cleanupExpiredSessions()).not.toThrow();
+    expect(sessions.has('expired')).toBe(false);
+  });
+});
+
+describe('A8.2: cleanupWsSession', () => {
+  beforeEach(() => {
+    configureLiveSessionController({
+      resolveOrbIdentity: async () => null,
+      clearResponseWatchdog: jest.fn(),
+      sendEndOfTurn: () => true,
+    });
+  });
+
+  it('is a no-op when the sessionId is unknown', () => {
+    expect(() => cleanupWsSession('does-not-exist')).not.toThrow();
+  });
+
+  it('clears keepalive intervals + watchdog and removes both registry entries', () => {
+    const clearWatchdog = jest.fn();
+    __resetLiveSessionControllerForTests();
+    configureLiveSessionController({
+      resolveOrbIdentity: async () => null,
+      clearResponseWatchdog: clearWatchdog,
+      sendEndOfTurn: () => true,
+    });
+
+    const pingInterval = setInterval(() => {}, 1_000_000);
+    const silenceInterval = setInterval(() => {}, 1_000_000);
+
+    const upstreamWs = { close: jest.fn() };
+    const clientWs = { readyState: WS_OPEN, close: jest.fn() };
+    const liveSession: any = {
+      identity: null,
+      transcriptTurns: [],
+      active: true,
+      upstreamPingInterval: pingInterval,
+      silenceKeepaliveInterval: silenceInterval,
+      upstreamWs,
+    };
+    liveSessions.set('s1', liveSession);
+    wsClientSessions.set('s1', { liveSession, clientWs } as any);
+
+    cleanupWsSession('s1');
+
+    expect(liveSession.active).toBe(false);
+    expect(liveSession.upstreamPingInterval).toBeUndefined();
+    expect(liveSession.silenceKeepaliveInterval).toBeUndefined();
+    expect(clearWatchdog).toHaveBeenCalledWith(liveSession);
+    expect(upstreamWs.close).toHaveBeenCalled();
+    expect(clientWs.close).toHaveBeenCalledWith(1000, 'Session cleanup');
+    expect(liveSessions.has('s1')).toBe(false);
+    expect(wsClientSessions.has('s1')).toBe(false);
+  });
+
+  it('skips client WS close when readyState is not OPEN', () => {
+    const clientWs = { readyState: WS_CLOSED, close: jest.fn() };
+    wsClientSessions.set('s1', { liveSession: null, clientWs } as any);
+    cleanupWsSession('s1');
+    expect(clientWs.close).not.toHaveBeenCalled();
+    expect(wsClientSessions.has('s1')).toBe(false);
+  });
+
+  it('handles a session that has no liveSession (WS-only entry)', () => {
+    const clientWs = { readyState: WS_OPEN, close: jest.fn() };
+    wsClientSessions.set('s1', { liveSession: null, clientWs } as any);
+    expect(() => cleanupWsSession('s1')).not.toThrow();
+    expect(clientWs.close).toHaveBeenCalledWith(1000, 'Session cleanup');
+    expect(wsClientSessions.has('s1')).toBe(false);
+  });
+});
+
+describe('A8.2: handleLiveStreamEndTurn', () => {
+  beforeEach(() => {
+    configureLiveSessionController({
+      resolveOrbIdentity: async () => null,
+      clearResponseWatchdog: () => undefined,
+      sendEndOfTurn: () => true,
+    });
+  });
+
+  function makeRes() {
+    const res: any = {};
+    res.status = jest.fn().mockReturnValue(res);
+    res.json = jest.fn().mockReturnValue(res);
+    return res;
+  }
+
+  it('400 when session_id is missing from both query and body', async () => {
+    const req: any = { query: {}, body: {} };
+    const res = makeRes();
+    await handleLiveStreamEndTurn(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ ok: false, error: 'session_id required' });
+  });
+
+  it('404 when session is not in liveSessions', async () => {
+    const req: any = { query: { session_id: 'nope' }, body: {} };
+    const res = makeRes();
+    await handleLiveStreamEndTurn(req, res);
+    expect(res.status).toHaveBeenCalledWith(404);
+    expect(res.json).toHaveBeenCalledWith({ ok: false, error: 'Session not found' });
+  });
+
+  it('400 when session is not active', async () => {
+    liveSessions.set('s1', { active: false } as any);
+    const req: any = { query: { session_id: 's1' }, body: {} };
+    const res = makeRes();
+    await handleLiveStreamEndTurn(req, res);
+    expect(res.status).toHaveBeenCalledWith(400);
+    expect(res.json).toHaveBeenCalledWith({ ok: false, error: 'Session not active' });
+  });
+
+  it('falls back to body.session_id when query is empty', async () => {
+    liveSessions.set('s1', { active: false } as any);
+    const req: any = { query: {}, body: { session_id: 's1' } };
+    const res = makeRes();
+    await handleLiveStreamEndTurn(req, res);
+    expect(res.status).toHaveBeenCalledWith(400); // session not active
+  });
+
+  it('calls sendEndOfTurn + responds "End of turn signaled" when upstream WS is open and sendEndOfTurn returns true', async () => {
+    const sendSpy = jest.fn().mockReturnValue(true);
+    __resetLiveSessionControllerForTests();
+    configureLiveSessionController({
+      resolveOrbIdentity: async () => null,
+      clearResponseWatchdog: () => undefined,
+      sendEndOfTurn: sendSpy,
+    });
+
+    const upstreamWs = { readyState: WS_OPEN };
+    liveSessions.set('s1', { active: true, upstreamWs } as any);
+    const req: any = { query: { session_id: 's1' }, body: {} };
+    const res = makeRes();
+
+    await handleLiveStreamEndTurn(req, res);
+
+    expect(sendSpy).toHaveBeenCalledWith(upstreamWs);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      ok: true,
+      message: 'End of turn signaled',
+    });
+  });
+
+  it('responds "acknowledged (no Live API)" when no upstream WS exists', async () => {
+    liveSessions.set('s1', { active: true, upstreamWs: null } as any);
+    const req: any = { query: { session_id: 's1' }, body: {} };
+    const res = makeRes();
+    await handleLiveStreamEndTurn(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      ok: true,
+      message: 'End of turn acknowledged (no Live API)',
+    });
+  });
+
+  it('responds "acknowledged (no Live API)" when upstream WS is not in OPEN state', async () => {
+    const upstreamWs = { readyState: WS_CLOSED };
+    liveSessions.set('s1', { active: true, upstreamWs } as any);
+    const req: any = { query: { session_id: 's1' }, body: {} };
+    const res = makeRes();
+    await handleLiveStreamEndTurn(req, res);
+    expect(res.status).toHaveBeenCalledWith(200);
+    expect(res.json).toHaveBeenCalledWith({
+      ok: true,
+      message: 'End of turn acknowledged (no Live API)',
+    });
+  });
+
+  it('logs ownership mismatch but still processes the request', async () => {
+    const warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+    __resetLiveSessionControllerForTests();
+    configureLiveSessionController({
+      resolveOrbIdentity: async () => ({
+        user_id: 'req-user',
+        tenant_id: 't1',
+      }) as any,
+      clearResponseWatchdog: () => undefined,
+      sendEndOfTurn: () => true,
+    });
+
+    const upstreamWs = { readyState: WS_OPEN };
+    liveSessions.set('s1', {
+      active: true,
+      upstreamWs,
+      identity: { user_id: 'session-user' },
+    } as any);
+    const req: any = { query: { session_id: 's1' }, body: {} };
+    const res = makeRes();
+
+    await handleLiveStreamEndTurn(req, res);
+
+    expect(warnSpy).toHaveBeenCalledWith(
+      expect.stringContaining('ownership mismatch (allowed)'),
+    );
+    expect(res.status).toHaveBeenCalledWith(200);
+    warnSpy.mockRestore();
+  });
+});
+
+describe('A8.2 anti-regression: orb-live.ts is a consumer of the controller', () => {
+  let source: string;
+  beforeAll(() => {
+    const fs = require('fs');
+    const path = require('path');
+    source = fs.readFileSync(
+      path.resolve(__dirname, '../../../../src/routes/orb-live.ts'),
+      'utf8',
+    );
+  });
+
+  it('imports the controller (configure + cleanup helpers + end-turn handler)', () => {
+    expect(source).toMatch(
+      /from\s*['"`][^'"`]*\/orb\/live\/session\/live-session-controller['"`]/,
+    );
+    expect(source).toMatch(/\bconfigureLiveSessionController\b/);
+    expect(source).toMatch(/\bcleanupExpiredSessions\b/);
+    expect(source).toMatch(/\bcleanupWsSession\b/);
+    expect(source).toMatch(/\bhandleLiveStreamEndTurn\b/);
+  });
+
+  it('calls configureLiveSessionController exactly once at module init with the three deps', () => {
+    const calls = source.match(/configureLiveSessionController\s*\(/g) ?? [];
+    expect(calls.length).toBe(1);
+    expect(source).toMatch(/resolveOrbIdentity\s*,/);
+    expect(source).toMatch(/clearResponseWatchdog\s*,/);
+    expect(source).toMatch(/sendEndOfTurn\s*,?\s*\}\)/);
+  });
+
+  it('does NOT declare cleanupExpiredSessions / cleanupWsSession locally anymore', () => {
+    expect(source).not.toMatch(/^\s*function\s+cleanupExpiredSessions\s*\(/m);
+    expect(source).not.toMatch(/^\s*function\s+cleanupWsSession\s*\(/m);
+  });
+
+  it('end-turn route is now a thin delegator (single await call)', () => {
+    const handlerSlice = source.slice(
+      source.indexOf("router.post('/live/stream/end-turn'"),
+      source.indexOf("router.post('/live/stream/end-turn'") + 400,
+    );
+    expect(handlerSlice).toMatch(/await\s+handleLiveStreamEndTurn\s*\(\s*req\s*,\s*res\s*\)/);
+    // Anti-regression: no inline `liveSessions.get(` inside this slice.
+    expect(handlerSlice).not.toMatch(/liveSessions\.get\(/);
+  });
+});


### PR DESCRIPTION
## Summary

Track A / A8 split, slice 2 of 3. Per the spec's "keep scope tight" rule + A8 high-risk warning, A8.2 lifts the smallest cohesive slice that establishes the controller-with-deps pattern: cleanup helpers + the smallest session-action handler. The larger handlers (`/live/session/start`, `/stop`, `/stream/send` — ~972 lines combined) follow in subsequent slices using the same pattern.

**Zero behavior change.** Same JSON envelopes, same 400/404 paths, same response messages.

## What lands

- **services/gateway/src/orb/live/session/live-session-controller.ts** — controller module:
  - `LiveSessionControllerDeps` interface (3 orb-live.ts locals: `resolveOrbIdentity`, `clearResponseWatchdog`, `sendEndOfTurn`).
  - `configureLiveSessionController(deps)` — one-shot init; double-configure throws.
  - `__resetLiveSessionControllerForTests()` — test escape hatch.
  - `cleanupExpiredSessions()` — body lifted verbatim from orb-live.ts:~8384.
  - `cleanupWsSession(sessionId)` — body lifted verbatim from orb-live.ts:~13931 (VTID-01230 dedup extract + VTID-STREAM-KEEPALIVE interval clears + VTID-WATCHDOG clear + WS closes + registry removes).
  - `handleLiveStreamEndTurn(req, res)` — body lifted verbatim from orb-live.ts:~12416.
- **routes/orb-live.ts** — imports the controller, calls `configureLiveSessionController(...)` once at module-init, route handler shrinks to a 1-line delegator, two local helper bodies removed.
- **test/orb/live/session/live-session-controller.test.ts** — 22 new runtime tests (configure + cleanup helpers + end-turn handler + anti-regression on orb-live.ts).
- **test/orb/live/characterization/stream-lifecycle.characterization.test.ts** — updated assertions follow the cleanup body into the controller; orb-live.ts retains the `setInterval` schedule.

## Why slice further

Total potential A8.2 lift = ~1132 lines (start 515 + stop 200 + send 257 + end-turn 41 + cleanups 117). The spec warned "A8 is high-risk. Do not combine." and "keep scope tight." A 1100-line move in one PR is the failure mode that warning called out. This PR ships ~160 lines moved (cleanups + end-turn) + 270 lines of new controller scaffolding + 371 lines of tests, totaling a reviewable ~709-line diff. Each followup slice uses the same `LiveSessionControllerDeps` + `configureLiveSessionController` pattern with new deps added as needed.

## Acceptance checks (A8 spec)

1. ✅ Existing A0 session-start characterization green.
2. ✅ A9.1 WS + A9.2 SSE structural tests green. stream-lifecycle char test updated to follow the seam.
3. ✅ New controller tests cover cleanup + end-turn. Start/stop/send tests come with their respective slices.
4. ✅ Vertex remains default upstream (no upstream changes in A8.2).
5. ✅ No LiveKit implementation yet.
6. ✅ No contextual intelligence changes.
7. ✅ No reliability tuning.
8. ⏳ Production /orb/chat smoke after deploy.

## What this PR does NOT touch (deferred)

- `/live/session/start` body (~515 lines, includes inline `connectToLiveAPI` call) — followup slice.
- `/live/session/stop` body (~200 lines) — followup slice.
- `/live/stream/send` body (~257 lines) — followup slice.
- LiveAPI message-handler closure (~700-line `ws.on('message')` parser) + `connectToLiveAPI` → `VertexLiveClient` migration + per-event SSE writes → A8.3.
- LiveKit adapter, L1 provider selection, F1/F4, B6/B7, R-lane.

## Test plan

- [x] 22 new runtime tests on the controller
- [x] 6 updated structural tests (3 of 6 now read from the controller module)
- [x] 556 tests green across `test/orb/**` (no regression)
- [x] TypeScript clean
- [ ] Post-merge: EXEC-DEPLOY + /orb/chat production smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)