### PR TITLE
hotfix(voice): restore real session_id for send_chat_message rate-limit key (VTID-02963)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -4234,6 +4234,10 @@ async function executeLiveApiToolInner(
 
       case 'send_chat_message': {
         // PR B-6: lifted to services/orb-tools-shared.ts.
+        // VTID-02963: thread session.sessionId through identity so the
+        // shared tool can scope its rate-limit key per real voice session
+        // (the lift originally dropped it and used a synthetic per-user
+        // key, breaking per-conversation isolation).
         const SUPABASE_URL = process.env.SUPABASE_URL;
         const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
         if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
@@ -4250,6 +4254,7 @@ async function executeLiveApiToolInner(
             tenant_id: lens.tenant_id ?? null,
             role: session.identity?.role ?? null,
             vitana_id: session.identity?.vitana_id ?? null,
+            session_id: session.sessionId ?? null,
           },
           supabase,
         );

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -1701,15 +1701,58 @@ export async function tool_send_chat_message(
       }
     }
 
+    // VTID-02963: Restore per-voice-session rate-limit isolation.
+    // PR B-6 (VTID-02817) lifted this function from orb-live.ts inline and
+    // replaced `session.sessionId` with the synthetic key
+    // `${id.user_id}:send_chat_message`. That made the 5-send cap shared
+    // across every orb open for a user until the 30-min TTL expired —
+    // users who'd hit the cap once couldn't send via voice again for half
+    // an hour, even from a brand-new session. Restore the real session id
+    // as the key; fall back to a clearly-tagged synthetic key only when
+    // the session id is genuinely missing (LiveKit identity may not yet
+    // populate it during early bootstrap), and emit telemetry when that
+    // happens so we can see fallback usage.
+    const realSessionId = (id.session_id ?? '').trim();
+    const usingFallbackKey = !realSessionId;
+    const rateLimitKey = usingFallbackKey
+      ? `${id.user_id}:send_chat_message:no_session`
+      : realSessionId;
+    const keyType = usingFallbackKey ? 'missing_session_fallback' : 'real_session';
+    if (usingFallbackKey) {
+      try {
+        const { emitOasisEvent } = await import('./oasis-event-service');
+        await emitOasisEvent({
+          vtid: 'VTID-02963',
+          type: 'voice.chat_message.missing_session_fallback',
+          source: 'orb-tools-shared',
+          status: 'warning',
+          message:
+            'send_chat_message called without OrbToolIdentity.session_id; rate-limit key fell back to per-user synthetic',
+          payload: {
+            fallback_key: rateLimitKey,
+            recipient_user_id: recipientUserId,
+            tool: 'send_chat_message',
+          },
+          actor_id: id.user_id,
+          actor_role: 'user',
+          surface: 'orb',
+          vitana_id: id.vitana_id ?? undefined,
+        });
+      } catch {
+        // Telemetry must not break voice flow.
+      }
+    }
+
     const recipientVitanaId = await resolveVitanaId(recipientUserId);
     const quota = await checkVoiceSendQuota({
-      session_id: `${id.user_id}:send_chat_message`,
+      session_id: rateLimitKey,
       actor_id: id.user_id,
       vitana_id: id.vitana_id ?? null,
       recipient_user_id: recipientUserId,
       recipient_vitana_id: recipientVitanaId,
       kind: 'message',
       body_length: body.length,
+      key_type: keyType,
     });
     if (!quota.allowed) {
       return {
@@ -1729,7 +1772,8 @@ export async function tool_send_chat_message(
       ...(recipientVitanaId && { receiver_vitana_id: recipientVitanaId }),
       metadata: {
         source: 'voice',
-        session_id: `${id.user_id}:send_chat_message`,
+        session_id: rateLimitKey,
+        key_type: keyType,
         recipient_label: recipientLabel || recipientVitanaId,
       },
     });

--- a/services/gateway/src/services/voice-message-guard.ts
+++ b/services/gateway/src/services/voice-message-guard.ts
@@ -35,6 +35,8 @@ function sweepExpired(): void {
  * { allowed: true } when the cap hasn't been hit, { allowed: false, reason }
  * when it has. Emits OASIS audit events on every call.
  */
+export type VoiceQuotaKeyType = 'real_session' | 'missing_session_fallback';
+
 export async function checkVoiceSendQuota(args: {
   session_id: string;
   actor_id: string;
@@ -44,11 +46,20 @@ export async function checkVoiceSendQuota(args: {
   kind: 'message' | 'share_link';
   body_length?: number;
   target_url?: string;
+  /**
+   * VTID-02963: provenance of the rate-limit key. Lets the cockpit see
+   * whether voice sends are being scoped to a real Gemini Live session
+   * (per-conversation isolation, the intended behavior) or to the
+   * synthetic per-user fallback (degraded mode — every send across every
+   * orb open shares one counter until TTL expires).
+   */
+  key_type?: VoiceQuotaKeyType;
 }): Promise<{ allowed: boolean; reason?: string; remaining: number }> {
   sweepExpired();
 
   const existing = sendCounters.get(args.session_id);
   const count = existing?.count ?? 0;
+  const keyType: VoiceQuotaKeyType = args.key_type ?? 'real_session';
 
   if (count >= SEND_CAP_PER_SESSION) {
     await emitOasisEvent({
@@ -59,6 +70,7 @@ export async function checkVoiceSendQuota(args: {
       message: `Voice send quota exceeded for session ${args.session_id} (${count}/${SEND_CAP_PER_SESSION})`,
       payload: {
         session_id: args.session_id,
+        key_type: keyType,
         recipient_user_id: args.recipient_user_id,
         recipient_vitana_id: args.recipient_vitana_id,
         kind: args.kind,
@@ -89,6 +101,7 @@ export async function checkVoiceSendQuota(args: {
     message: `Voice ${args.kind === 'share_link' ? 'link share' : 'message'} sent to @${args.recipient_vitana_id ?? args.recipient_user_id}`,
     payload: {
       session_id: args.session_id,
+      key_type: keyType,
       recipient_user_id: args.recipient_user_id,
       recipient_vitana_id: args.recipient_vitana_id,
       kind: args.kind,
@@ -107,6 +120,15 @@ export async function checkVoiceSendQuota(args: {
     allowed: true,
     remaining: SEND_CAP_PER_SESSION - (count + 1),
   };
+}
+
+/**
+ * VTID-02963: Test-only reset helper. Lets tests verify per-key isolation
+ * without leaking counter state between cases. Not exported through any
+ * index file; production callers must not use this.
+ */
+export function _resetSendCountersForTests(): void {
+  sendCounters.clear();
 }
 
 /**

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -755,6 +755,7 @@ export type CicdEventType =
   | 'voice.message.misroute'
   | 'voice.message.share_link_sent'
   | 'voice.chat_message.send_failed'
+  | 'voice.chat_message.missing_session_fallback'
   | 'vitana_id.confirmed'
   // VTID-02047: Unified Feedback Pipeline events
   | 'feedback.ticket.created'

--- a/services/gateway/test/voice-send-chat-rate-limit-isolation.test.ts
+++ b/services/gateway/test/voice-send-chat-rate-limit-isolation.test.ts
@@ -1,0 +1,313 @@
+/**
+ * VTID-02963: per-voice-session rate-limit isolation for tool_send_chat_message.
+ *
+ * Regression: PR B-6 (VTID-02817) lifted send_chat_message from
+ * orb-live.ts into the shared dispatcher and replaced `session.sessionId`
+ * with the synthetic key `${id.user_id}:send_chat_message`. That made the
+ * 5-send cap shared across every orb open for a user until the 30-min
+ * TTL expired. Users who hit the cap once couldn't voice-send again for
+ * half an hour, even from a brand-new session — symptom was a generic
+ * apology from Gemini.
+ *
+ * These tests pin the contract so the regression cannot reappear silently:
+ *   1. Two different real session_id values for the same user do not
+ *      share the 5-message counter.
+ *   2. Same session_id still rate-limits after 5 sends.
+ *   3. Missing session_id path is explicit and tested (synthetic key
+ *      with key_type='missing_session_fallback' + OASIS event emitted).
+ *   4. Regression guard: rate-limit key is NOT the literal
+ *      `${user_id}:send_chat_message` when session_id is present.
+ *   5. Existing #2086 fixes remain green:
+ *      - UUID-invalid recipient_user_id triggers label recovery.
+ *      - Tenant backfill from app_users when identity.tenant_id is null.
+ *      - Voice-friendly error text on insert failure.
+ */
+
+process.env.NODE_ENV = 'test';
+process.env.SUPABASE_URL = 'http://supabase.test';
+process.env.SUPABASE_SERVICE_ROLE = 'test-service-role';
+
+import {
+  checkVoiceSendQuota,
+  _resetSendCountersForTests,
+} from '../src/services/voice-message-guard';
+import { tool_send_chat_message } from '../src/services/orb-tools-shared';
+import * as oasisEventService from '../src/services/oasis-event-service';
+
+jest.mock('../src/middleware/auth-supabase-jwt', () => ({
+  resolveVitanaId: jest.fn(async (userId: string) => `vit_${userId.slice(0, 4)}`),
+}));
+
+const REAL_UUID_A = '11111111-1111-4111-8111-111111111111';
+const REAL_UUID_B = '22222222-2222-4222-8222-222222222222';
+const SENDER_UUID = '33333333-3333-4333-8333-333333333333';
+const RECIPIENT_UUID = '44444444-4444-4444-8444-444444444444';
+const RECIPIENT_UUID_2 = '55555555-5555-4555-8555-555555555555';
+
+interface CapturedInsert {
+  table: string;
+  row: Record<string, unknown>;
+}
+
+function makeStubSupabase(opts: {
+  inserts: CapturedInsert[];
+  rpcResponses?: Record<string, { data: unknown; error?: unknown }>;
+  appUsersTenantId?: string | null;
+  insertError?: { message: string } | null;
+}) {
+  const inserts = opts.inserts;
+  return {
+    from(table: string) {
+      if (table === 'app_users') {
+        return {
+          select: () => ({
+            eq: () => ({
+              maybeSingle: async () => ({
+                data: opts.appUsersTenantId ? { tenant_id: opts.appUsersTenantId } : null,
+              }),
+            }),
+          }),
+        } as unknown;
+      }
+      return {
+        insert: async (row: Record<string, unknown>) => {
+          inserts.push({ table, row });
+          return { error: opts.insertError ?? null };
+        },
+      } as unknown;
+    },
+    rpc: async (name: string) => {
+      const resp = opts.rpcResponses?.[name] ?? { data: [], error: null };
+      return resp;
+    },
+  } as never;
+}
+
+describe('VTID-02963 — send_chat_message rate-limit key uses real session id', () => {
+  let emitSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    _resetSendCountersForTests();
+    emitSpy = jest
+      .spyOn(oasisEventService, 'emitOasisEvent')
+      .mockResolvedValue({ ok: true, event_id: 'evt-stub' });
+  });
+
+  afterEach(() => {
+    emitSpy.mockRestore();
+  });
+
+  // ─── Test 1: two real session ids do not share the counter ───────────────
+  test('two different real session_id values for the same user do not share the cap', async () => {
+    const baseArgs = {
+      actor_id: SENDER_UUID,
+      vitana_id: 'vit_send',
+      recipient_user_id: RECIPIENT_UUID,
+      recipient_vitana_id: 'vit_recv',
+      kind: 'message' as const,
+    };
+    // Fill session A to the cap (5 sends).
+    for (let i = 0; i < 5; i++) {
+      const r = await checkVoiceSendQuota({ ...baseArgs, session_id: REAL_UUID_A, key_type: 'real_session' });
+      expect(r.allowed).toBe(true);
+    }
+    // 6th send on A must be rate-limited.
+    const sixthA = await checkVoiceSendQuota({ ...baseArgs, session_id: REAL_UUID_A, key_type: 'real_session' });
+    expect(sixthA.allowed).toBe(false);
+    expect(sixthA.reason).toBe('rate_limited');
+
+    // First send on B must STILL be allowed — separate counter.
+    const firstB = await checkVoiceSendQuota({ ...baseArgs, session_id: REAL_UUID_B, key_type: 'real_session' });
+    expect(firstB.allowed).toBe(true);
+    expect(firstB.remaining).toBe(4);
+  });
+
+  // ─── Test 2: same session id rate-limits after 5 ────────────────────────
+  test('same session_id rate-limits after 5 sends', async () => {
+    const args = {
+      session_id: REAL_UUID_A,
+      actor_id: SENDER_UUID,
+      vitana_id: 'vit_send',
+      recipient_user_id: RECIPIENT_UUID,
+      recipient_vitana_id: 'vit_recv',
+      kind: 'message' as const,
+      key_type: 'real_session' as const,
+    };
+    const remainings: number[] = [];
+    for (let i = 0; i < 5; i++) {
+      const r = await checkVoiceSendQuota(args);
+      expect(r.allowed).toBe(true);
+      remainings.push(r.remaining);
+    }
+    expect(remainings).toEqual([4, 3, 2, 1, 0]);
+
+    const sixth = await checkVoiceSendQuota(args);
+    expect(sixth.allowed).toBe(false);
+    expect(sixth.reason).toBe('rate_limited');
+    expect(sixth.remaining).toBe(0);
+  });
+
+  // ─── Test 3: missing session_id path is explicit ───────────────────────
+  test('missing session_id triggers explicit fallback path + telemetry', async () => {
+    const inserts: CapturedInsert[] = [];
+    const sb = makeStubSupabase({ inserts });
+
+    const result = await tool_send_chat_message(
+      { recipient_user_id: RECIPIENT_UUID, recipient_label: 'recv', body: 'hello' },
+      {
+        user_id: SENDER_UUID,
+        tenant_id: 'tenant-1',
+        role: 'user',
+        vitana_id: 'vit_send',
+        // session_id intentionally omitted
+      },
+      sb,
+    );
+
+    expect(result.ok).toBe(true);
+    // OASIS missing_session_fallback event must fire.
+    const fallbackEvents = emitSpy.mock.calls
+      .map((c) => c[0])
+      .filter((e: { type?: string }) => e.type === 'voice.chat_message.missing_session_fallback');
+    expect(fallbackEvents.length).toBe(1);
+    expect(fallbackEvents[0]).toMatchObject({
+      status: 'warning',
+      payload: {
+        fallback_key: `${SENDER_UUID}:send_chat_message:no_session`,
+        tool: 'send_chat_message',
+      },
+    });
+
+    // The persisted chat_messages row records key_type='missing_session_fallback'
+    // so analysts can see whether a send was scoped to a real voice session
+    // or to the degraded synthetic key.
+    expect(inserts).toHaveLength(1);
+    expect((inserts[0].row.metadata as { key_type: string }).key_type).toBe('missing_session_fallback');
+  });
+
+  // ─── Test 4: regression guard — key MUST be real session when present ──
+  test('regression: rate-limit key is NOT `${user_id}:send_chat_message` when session_id is present', async () => {
+    const inserts: CapturedInsert[] = [];
+    const sb = makeStubSupabase({ inserts });
+
+    const result = await tool_send_chat_message(
+      { recipient_user_id: RECIPIENT_UUID_2, recipient_label: 'recv', body: 'hello' },
+      {
+        user_id: SENDER_UUID,
+        tenant_id: 'tenant-1',
+        role: 'user',
+        vitana_id: 'vit_send',
+        session_id: REAL_UUID_A,
+      },
+      sb,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(inserts).toHaveLength(1);
+    const meta = inserts[0].row.metadata as { session_id: string; key_type: string };
+    // The metadata.session_id must equal the real session UUID, not the
+    // synthetic per-user constant from the regression.
+    expect(meta.session_id).toBe(REAL_UUID_A);
+    expect(meta.session_id).not.toBe(`${SENDER_UUID}:send_chat_message`);
+    expect(meta.key_type).toBe('real_session');
+
+    // The voice-message-guard event must also carry key_type='real_session'.
+    const sentEvents = emitSpy.mock.calls
+      .map((c) => c[0])
+      .filter((e: { type?: string }) => e.type === 'voice.message.sent');
+    expect(sentEvents.length).toBeGreaterThanOrEqual(1);
+    expect((sentEvents[0].payload as { session_id: string; key_type: string }).session_id).toBe(REAL_UUID_A);
+    expect((sentEvents[0].payload as { session_id: string; key_type: string }).key_type).toBe('real_session');
+
+    // Belt-and-suspenders: no fallback event should fire on the happy path.
+    const fallbackEvents = emitSpy.mock.calls
+      .map((c) => c[0])
+      .filter((e: { type?: string }) => e.type === 'voice.chat_message.missing_session_fallback');
+    expect(fallbackEvents.length).toBe(0);
+  });
+
+  // ─── Test 5: existing #2086 defensive layers remain green ──────────────
+  describe('PR #2086 fixes remain green', () => {
+    test('UUID-invalid recipient triggers label recovery via resolve_recipient_candidates', async () => {
+      const inserts: CapturedInsert[] = [];
+      const sb = makeStubSupabase({
+        inserts,
+        rpcResponses: {
+          resolve_recipient_candidates: {
+            data: [{ user_id: RECIPIENT_UUID, vitana_id: 'vit_recv', score: 0.95 }],
+            error: null,
+          },
+        },
+      });
+
+      const result = await tool_send_chat_message(
+        // recipient_user_id is a spoken name, NOT a UUID — Gemini dropped it.
+        { recipient_user_id: 'Dragan Red', recipient_label: 'Dragan Red', body: 'hi' },
+        {
+          user_id: SENDER_UUID,
+          tenant_id: 'tenant-1',
+          role: 'user',
+          vitana_id: 'vit_send',
+          session_id: REAL_UUID_A,
+        },
+        sb,
+      );
+
+      expect(result.ok).toBe(true);
+      expect(inserts).toHaveLength(1);
+      expect(inserts[0].row.receiver_id).toBe(RECIPIENT_UUID);
+    });
+
+    test('tenant backfill from app_users when identity.tenant_id is null', async () => {
+      const inserts: CapturedInsert[] = [];
+      const sb = makeStubSupabase({ inserts, appUsersTenantId: 'tenant-backfilled' });
+
+      const result = await tool_send_chat_message(
+        { recipient_user_id: RECIPIENT_UUID, recipient_label: 'recv', body: 'hi' },
+        {
+          user_id: SENDER_UUID,
+          tenant_id: null,
+          role: 'user',
+          vitana_id: 'vit_send',
+          session_id: REAL_UUID_A,
+        },
+        sb,
+      );
+
+      expect(result.ok).toBe(true);
+      expect(inserts[0].row.tenant_id).toBe('tenant-backfilled');
+    });
+
+    test('chat_messages insert error returns voice-friendly text + send_failed OASIS', async () => {
+      const inserts: CapturedInsert[] = [];
+      const sb = makeStubSupabase({
+        inserts,
+        insertError: { message: 'simulated db failure' },
+      });
+
+      const result = await tool_send_chat_message(
+        { recipient_user_id: RECIPIENT_UUID, recipient_label: 'recv', body: 'hi' },
+        {
+          user_id: SENDER_UUID,
+          tenant_id: 'tenant-1',
+          role: 'user',
+          vitana_id: 'vit_send',
+          session_id: REAL_UUID_A,
+        },
+        sb,
+      );
+
+      expect(result.ok).toBe(false);
+      if (result.ok === false) {
+        // Voice-friendly error, NOT the raw db error string.
+        expect(result.error).toMatch(/try once more/);
+        expect(result.error).not.toMatch(/simulated db failure/);
+      }
+      const failEvents = emitSpy.mock.calls
+        .map((c) => c[0])
+        .filter((e: { type?: string }) => e.type === 'voice.chat_message.send_failed');
+      expect(failEvents.length).toBe(1);
+      expect((failEvents[0].payload as { reason: string }).reason).toBe('chat_messages_insert_error');
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Regression introduced by PR #1934 / VTID-02817 / 2026-05-07. The B-6 lift replaced `session.sessionId` with the synthetic per-user constant `${id.user_id}:send_chat_message` in the voice-message-guard call. The guard caps at 5 sends per session_id with a 30-min TTL, so any user who hit the cap was blocked from voice-sending for half an hour — even from a brand-new orb session. Symptom: Gemini reads "Couldn't send (rate-limited)" and paraphrases to "I'm sorry, I have some issues" on confirm.

## Fix scope (VTID-02963 hotfix contract)

- `tool_send_chat_message` now reads `OrbToolIdentity.session_id` and uses it as the rate-limit key. Restores per-voice-session isolation.
- If session_id is genuinely missing (early LiveKit bootstrap, etc.), fall back to a clearly-tagged synthetic key `${user_id}:send_chat_message:no_session` AND emit a `voice.chat_message.missing_session_fallback` OASIS event. No silent fallback — the degraded mode is observable.
- `voice-message-guard.checkVoiceSendQuota` gains a `key_type` field (`real_session | missing_session_fallback`) threaded into both the `rate_limited` and `sent` OASIS event payloads, plus into the persisted `chat_messages.metadata`.
- `orb-live.ts` `send_chat_message` dispatch passes `session.sessionId` through `identity.session_id`.

## Tests (all 5 required + 2 sub-cases for PR #2086 regression coverage — all green locally)

1. Two different real session_id values for the same user do not share the 5-message counter.
2. Same session_id still rate-limits after 5 sends.
3. Missing session_id path is explicit — fallback key derived AND OASIS missing_session_fallback event emitted AND metadata records `key_type='missing_session_fallback'`.
4. Regression guard — when session_id present, the rate-limit key is the real UUID, NOT the literal `${user_id}:send_chat_message`.
5. Existing PR #2086 fixes remain green: UUID-invalid recipient recovery, tenant backfill, voice-friendly insert-error text.

## Out of scope (queued follow-ups, per hotfix contract)

- **F-SH1**: daily voice self-healing routine for resolve_recipient → send_chat_message → row-exists → cleanup.
- **F-CHAR1**: B-track characterization suite for the 6 lifted tool functions, modeled on the A-track A0.1/A0.2 pattern. The B-track lifts had no characterization tests — that's the structural gap that let this regression ship silently.

## Merge criteria (from contract)

- [x] user-impact bug is fixed
- [x] tests prove per-session isolation
- [x] build green (npm run build clean)
- [ ] production smoke: voice/chat send succeeds in a new ORB session after the same user previously hit the cap

🤖 Generated with [Claude Code](https://claude.com/claude-code)