### PR TITLE
feat(self-healing): Missing-Test Scanner + per-gap VTID allocation (VTID-02957, DEV-COMHU-02957, PR-L2)

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -43980,7 +43980,146 @@ function renderTestContractsPanel() {
         container.appendChild(card);
     });
 
+    // VTID-02957 (PR-L2): missing-contract gaps appended below the existing
+    // contracts. Each row has an "Allocate VTID" button that kicks off the
+    // dev_autopilot pipeline to write the test + allowlist entry.
+    container.appendChild(renderMissingContractsSection());
+
     return container;
+}
+
+function renderMissingContractsSection() {
+    var section = document.createElement('div');
+    section.style.cssText = 'margin-top:32px;padding-top:24px;border-top:1px solid var(--color-border);';
+
+    var mState = state.missingContracts || (state.missingContracts = { gaps: null, error: null, allocating: {}, allocated: {} });
+
+    var header = document.createElement('div');
+    header.style.cssText = 'margin-bottom:16px;';
+    header.innerHTML =
+        '<h3 style="margin:0;color:var(--color-text-primary);">Missing Contracts</h3>' +
+        '<p style="margin:4px 0 0 0;color:var(--color-text-secondary);font-size:0.85rem;">' +
+        'Endpoints with NO contract row. Self-healing cannot detect regressions on these capabilities until contracts exist. ' +
+        'Click "Allocate VTID" to dispatch the dev_autopilot pipeline to write a test + allowlist entry. ' +
+        '<strong>VTID-02957 (PR-L2)</strong> — discovery only, no auto-allocation yet.' +
+        '</p>';
+    section.appendChild(header);
+
+    if (mState.gaps === null && mState.error === null) {
+        fetch('/api/v1/test-contracts/missing', { headers: buildContextHeaders() })
+            .then(function (r) { if (!r.ok) throw new Error('HTTP ' + r.status); return r.json(); })
+            .then(function (data) {
+                mState.gaps = data.gaps || [];
+                mState.totals = { total: data.total_endpoints, covered: data.covered, missing: data.missing };
+                mState.error = null;
+                renderApp();
+            })
+            .catch(function (e) {
+                mState.error = e.message;
+                mState.gaps = [];
+                renderApp();
+            });
+        var loading = document.createElement('div');
+        loading.style.cssText = 'padding:16px;text-align:center;color:var(--color-text-secondary);';
+        loading.textContent = 'Scanning for missing contracts...';
+        section.appendChild(loading);
+        return section;
+    }
+
+    if (mState.error) {
+        var err = document.createElement('div');
+        err.style.cssText = 'padding:16px;background:rgba(220,38,38,0.1);border:1px solid #dc2626;border-radius:6px;color:#fca5a5;';
+        err.textContent = 'Scan failed: ' + mState.error;
+        section.appendChild(err);
+        return section;
+    }
+
+    if (!mState.gaps || mState.gaps.length === 0) {
+        var none = document.createElement('div');
+        none.style.cssText = 'padding:16px;text-align:center;color:#16a34a;';
+        none.textContent = '✓ Every registered endpoint has a contract. Nothing to scan.';
+        section.appendChild(none);
+        return section;
+    }
+
+    var summary = document.createElement('div');
+    summary.style.cssText = 'display:flex;gap:16px;margin-bottom:16px;padding:12px;background:var(--color-surface);border:1px solid var(--color-border);border-radius:6px;font-size:0.8rem;';
+    var t = mState.totals || { total: 0, covered: 0, missing: 0 };
+    summary.innerHTML =
+        '<div><strong style="color:var(--color-text-primary);">' + t.total + '</strong> endpoints in ENDPOINT_FILE_MAP</div>' +
+        '<div style="color:#16a34a;"><strong>' + t.covered + '</strong> have contracts</div>' +
+        '<div style="color:#f59e0b;"><strong>' + t.missing + '</strong> missing</div>';
+    section.appendChild(summary);
+
+    mState.gaps.forEach(function (gap) {
+        var card = document.createElement('section');
+        var alreadyAllocated = mState.allocated[gap.dedupe_key];
+        var sevColor = alreadyAllocated ? '#16a34a' : '#f59e0b';
+        card.style.cssText = 'margin-bottom:8px;padding:12px 14px;background:var(--color-surface);border:1px solid var(--color-border);border-left:4px solid ' + sevColor + ';border-radius:6px;display:flex;justify-content:space-between;align-items:center;gap:12px;';
+
+        var info = document.createElement('div');
+        info.style.cssText = 'flex:1;min-width:0;';
+        var statusBadge = alreadyAllocated
+            ? '<span style="display:inline-block;font-size:0.65rem;font-weight:700;padding:0.1rem 0.4rem;border-radius:4px;color:#16a34a;background:rgba(22,163,74,0.12);text-transform:uppercase;margin-right:0.4rem;">VTID ALLOCATED</span>'
+            : '<span style="display:inline-block;font-size:0.65rem;font-weight:700;padding:0.1rem 0.4rem;border-radius:4px;color:#f59e0b;background:rgba(245,158,11,0.12);text-transform:uppercase;margin-right:0.4rem;">MISSING</span>';
+        info.innerHTML =
+            '<div style="font-weight:600;font-size:0.9rem;">' + statusBadge + escapeHtml(gap.capability) + '</div>' +
+            '<div style="font-size:0.75rem;color:var(--color-text-secondary);margin-top:0.2rem;">' +
+                escapeHtml(gap.contract_type) + ' · ' +
+                escapeHtml(gap.service) + '/' + escapeHtml(gap.environment) + ' · ' +
+                escapeHtml(gap.target_endpoint) +
+            '</div>' +
+            '<div style="font-size:0.7rem;color:var(--color-text-secondary);margin-top:0.2rem;font-family:ui-monospace,monospace;">' +
+                'file: ' + escapeHtml(gap.target_file) + ' · ' +
+                'suggested command_key: ' + escapeHtml(gap.suggested_command_key) +
+                (alreadyAllocated ? ' · VTID: ' + escapeHtml(alreadyAllocated) : '') +
+            '</div>';
+        card.appendChild(info);
+
+        var actions = document.createElement('div');
+        actions.style.cssText = 'display:flex;gap:6px;flex-shrink:0;';
+        var allocBtn = document.createElement('button');
+        allocBtn.style.cssText = 'padding:6px 12px;font-size:0.75rem;border-radius:4px;border:1px solid var(--color-border);background:var(--color-bg);color:var(--color-text-primary);cursor:pointer;';
+        var busy = mState.allocating[gap.dedupe_key] === true;
+        allocBtn.disabled = busy || !!alreadyAllocated;
+        allocBtn.textContent = busy ? 'Allocating...' : alreadyAllocated ? 'Open VTID' : 'Allocate VTID';
+        allocBtn.onclick = function () {
+            if (alreadyAllocated) {
+                history.pushState(null, '', '/command-hub/oasis/vtid-ledger/?vtid=' + encodeURIComponent(alreadyAllocated));
+                renderApp();
+                return;
+            }
+            mState.allocating[gap.dedupe_key] = true;
+            renderApp();
+            fetch('/api/v1/test-contracts/missing/' + encodeURIComponent(gap.dedupe_key) + '/allocate', {
+                method: 'POST',
+                headers: buildContextHeaders(),
+            })
+                .then(function (r) { return r.json().then(function (b) { return { status: r.status, body: b }; }); })
+                .then(function (resp) {
+                    mState.allocating[gap.dedupe_key] = false;
+                    if (resp.status === 201 && resp.body.allocated_vtid) {
+                        mState.allocated[gap.dedupe_key] = resp.body.allocated_vtid;
+                    } else if (resp.status === 200 && resp.body.deduped && resp.body.existing_vtid) {
+                        mState.allocated[gap.dedupe_key] = resp.body.existing_vtid;
+                    } else {
+                        alert('Allocation failed: ' + (resp.body.error || resp.body.message || resp.status));
+                    }
+                    renderApp();
+                })
+                .catch(function (e) {
+                    mState.allocating[gap.dedupe_key] = false;
+                    alert('Allocation error: ' + e.message);
+                    renderApp();
+                });
+        };
+        actions.appendChild(allocBtn);
+        card.appendChild(actions);
+
+        section.appendChild(card);
+    });
+
+    return section;
 }
 
 function renderSelfHealingView() {

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -30,7 +30,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260504-vtid-02710-ios-ctx-keepalive"></script>
-  <script src="/command-hub/app.js?v=20260513-vtid-02954-pr-l1-test-contracts"></script>
+  <script src="/command-hub/app.js?v=20260513-vtid-02957-pr-l2-missing-test-scanner"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
 </body>

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -723,6 +723,11 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const testContractsRouter = require('./routes/test-contracts').default;
   mountRouterSync(app, '/api/v1', testContractsRouter, { owner: 'test-contracts' });
 
+  // VTID-02957 (PR-L2): Missing-Test Scanner — discover capabilities with no contract
+  // GET /api/v1/test-contracts/missing + POST /api/v1/test-contracts/missing/:key/allocate
+  const testContractsMissingRouter = require('./routes/test-contracts-missing').default;
+  mountRouterSync(app, '/api/v1', testContractsMissingRouter, { owner: 'test-contracts-missing' });
+
   // VTID-02909 (B0c): Journey Context inspection (Voice / Journey Context tab)
   // GET /api/v1/voice/journey-context/preview + GET /api/v1/voice/journey-context/state
   const voiceJourneyContextRouter = require('./routes/voice-journey-context').default;

--- a/services/gateway/src/routes/test-contracts-missing.ts
+++ b/services/gateway/src/routes/test-contracts-missing.ts
@@ -1,0 +1,367 @@
+/**
+ * VTID-02957 (PR-L2): Missing-Test Scanner routes.
+ *
+ *   GET  /api/v1/test-contracts/missing
+ *        list every endpoint that does NOT yet have a test_contracts row
+ *
+ *   POST /api/v1/test-contracts/missing/:dedupe_key/allocate
+ *        allocate one VTID for a specific gap and write an
+ *        autopilot_recommendations row so the existing dev_autopilot
+ *        pipeline can pick it up and produce a real PR. Idempotent by
+ *        dedupe_key (no duplicate VTIDs on re-run).
+ *
+ * Auth: GET requires dev access (exafy_admin OR X-Gateway-Internal).
+ *       POST requires admin. Allocation writes to vtid_ledger +
+ *       autopilot_recommendations + emits OASIS events — admin-only is
+ *       the right bar.
+ */
+
+import { Router, Request, Response, NextFunction } from 'express';
+import { emitOasisEvent } from '../services/oasis-event-service';
+import {
+  requireAuth,
+  requireAuthWithTenant,
+  AuthenticatedRequest,
+} from '../middleware/auth-supabase-jwt';
+import {
+  scanMissingContractsAgainstLiveRegistry,
+  type CapabilityGap,
+  type ExistingContractRef,
+} from '../services/missing-test-scanner';
+import { allocateVtid } from '../services/operator-service';
+
+const router = Router();
+const VTID = 'VTID-02957';
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE =
+  process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+
+function supabaseHeaders() {
+  return {
+    apikey: SUPABASE_SERVICE_ROLE!,
+    Authorization: `Bearer ${SUPABASE_SERVICE_ROLE}`,
+    'Content-Type': 'application/json',
+  };
+}
+
+function supabaseConfigured(): boolean {
+  return Boolean(SUPABASE_URL && SUPABASE_SERVICE_ROLE);
+}
+
+// ---------------------------------------------------------------------------
+// Local auth helpers — same pattern as test-contracts.ts / voice-improve.ts.
+// ---------------------------------------------------------------------------
+async function requireDevAccess(req: Request, res: Response, next: NextFunction): Promise<void> {
+  if (
+    req.get('X-Gateway-Internal') === (process.env.GATEWAY_INTERNAL_TOKEN || '__dev__') &&
+    process.env.GATEWAY_INTERNAL_TOKEN
+  ) {
+    return next();
+  }
+  let authFailed = false;
+  await requireAuth(req as AuthenticatedRequest, res, () => {
+    const identity = (req as AuthenticatedRequest).identity;
+    if (!identity) {
+      authFailed = true;
+      res.status(401).json({ ok: false, error: 'UNAUTHENTICATED', vtid: VTID });
+      return;
+    }
+    if (identity.exafy_admin === true) return next();
+    authFailed = true;
+    res.status(403).json({
+      ok: false,
+      error: 'Missing-Test Scanner requires developer access (exafy_admin)',
+      vtid: VTID,
+    });
+  });
+  if (authFailed) return;
+}
+
+// ---------------------------------------------------------------------------
+// Helpers
+// ---------------------------------------------------------------------------
+
+async function fetchExistingContracts(): Promise<ExistingContractRef[]> {
+  if (!supabaseConfigured()) return [];
+  try {
+    const r = await fetch(
+      `${SUPABASE_URL}/rest/v1/test_contracts?select=capability,service,contract_type`,
+      { headers: supabaseHeaders() },
+    );
+    if (!r.ok) return [];
+    return (await r.json()) as ExistingContractRef[];
+  } catch {
+    return [];
+  }
+}
+
+interface ActiveDuplicate {
+  vtid: string;
+  status: string;
+  is_terminal: boolean;
+}
+
+/**
+ * Check vtid_ledger for an existing in-flight VTID with the same
+ * dedupe_key. The missing-test scanner sets metadata.dedupe_key on
+ * every VTID it allocates so re-runs are idempotent.
+ */
+async function findActiveVtidByDedupeKey(dedupe_key: string): Promise<ActiveDuplicate | null> {
+  if (!supabaseConfigured()) return null;
+  try {
+    const r = await fetch(
+      `${SUPABASE_URL}/rest/v1/vtid_ledger?metadata->>dedupe_key=eq.${encodeURIComponent(dedupe_key)}` +
+      `&select=vtid,status,is_terminal&limit=1`,
+      { headers: supabaseHeaders() },
+    );
+    if (!r.ok) return null;
+    const rows = (await r.json()) as ActiveDuplicate[];
+    if (rows.length === 0) return null;
+    const row = rows[0];
+    // Only treat as "duplicate" if it's still in-flight. Terminal VTIDs
+    // (success/failed/cancelled) shouldn't block re-allocation — the
+    // capability still needs a contract.
+    return row.is_terminal ? null : row;
+  } catch {
+    return null;
+  }
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/test-contracts/missing
+// ---------------------------------------------------------------------------
+router.get('/test-contracts/missing', requireDevAccess, async (_req: Request, res: Response) => {
+  if (!supabaseConfigured()) {
+    return res.status(500).json({ ok: false, error: 'supabase not configured', vtid: VTID });
+  }
+  try {
+    const existing = await fetchExistingContracts();
+    const gaps = scanMissingContractsAgainstLiveRegistry(existing);
+    return res.json({
+      ok: true,
+      total_endpoints: gaps.length + existing.length,
+      covered: existing.length,
+      missing: gaps.length,
+      gaps,
+      vtid: VTID,
+    });
+  } catch (err) {
+    return res.status(500).json({ ok: false, error: (err as Error).message, vtid: VTID });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/test-contracts/missing/:dedupe_key/allocate
+// ---------------------------------------------------------------------------
+router.post(
+  '/test-contracts/missing/:dedupe_key/allocate',
+  requireAuthWithTenant,
+  async (req: Request, res: Response) => {
+    if (!supabaseConfigured()) {
+      return res.status(500).json({ ok: false, error: 'supabase not configured', vtid: VTID });
+    }
+    const identity = (req as AuthenticatedRequest).identity;
+    if (!identity || identity.exafy_admin !== true) {
+      return res.status(403).json({
+        ok: false,
+        error: 'admin access required to allocate VTIDs',
+        vtid: VTID,
+      });
+    }
+    const dedupe_key = String(req.params.dedupe_key);
+    if (!/^[a-z0-9_:.\-]+$/i.test(dedupe_key) || dedupe_key.length > 256) {
+      return res.status(400).json({ ok: false, error: 'invalid dedupe_key format', vtid: VTID });
+    }
+
+    // Step 1: re-scan to confirm this dedupe_key is still a real gap.
+    // Avoids races where a contract was added between the cockpit GET and
+    // this POST.
+    const existing = await fetchExistingContracts();
+    const gaps = scanMissingContractsAgainstLiveRegistry(existing);
+    const gap = gaps.find((g: CapabilityGap) => g.dedupe_key === dedupe_key);
+    if (!gap) {
+      return res.status(404).json({
+        ok: false,
+        error: 'NOT_A_GAP',
+        message: `dedupe_key '${dedupe_key}' is not in the current missing-contracts set — either it was just allocated, or the contract already exists.`,
+        vtid: VTID,
+      });
+    }
+
+    // Step 2: dedupe vs in-flight VTIDs.
+    const duplicate = await findActiveVtidByDedupeKey(dedupe_key);
+    if (duplicate) {
+      return res.status(200).json({
+        ok: true,
+        deduped: true,
+        existing_vtid: duplicate.vtid,
+        existing_status: duplicate.status,
+        message: `Active VTID ${duplicate.vtid} already covers this gap (status=${duplicate.status}). Re-allocation skipped.`,
+        gap,
+        vtid: VTID,
+      });
+    }
+
+    // Step 3: allocate a fresh VTID.
+    const alloc = await allocateVtid('missing-test-scanner', 'INFRA', 'GATEWAY');
+    if (!alloc.ok || !alloc.vtid) {
+      return res.status(502).json({
+        ok: false,
+        error: 'VTID_ALLOCATION_FAILED',
+        message: alloc.message || 'allocator did not return a VTID',
+        vtid: VTID,
+      });
+    }
+    const newVtid = alloc.vtid;
+
+    // Step 4: write an autopilot_recommendations row so the existing
+    // dev_autopilot pipeline can pick it up. The spec instructs the LLM
+    // to write the test file AND add the COMMAND_ALLOWLIST entry in the
+    // same PR — both are required for the contract to actually run.
+    const spec_markdown = `# Missing Test Contract: ${gap.capability}
+
+The capability \`${gap.capability}\` (endpoint \`${gap.target_endpoint}\`, file \`${gap.target_file}\`) does not yet have a row in the \`test_contracts\` registry. Self-healing cannot detect runtime regressions on this capability until a contract exists.
+
+## What to do
+
+1. **Add a typed dispatcher** to \`services/gateway/src/services/test-contract-commands.ts\` \`COMMAND_ALLOWLIST\`:
+
+   \`\`\`typescript
+   '${gap.suggested_command_key}': {
+     command_key: '${gap.suggested_command_key}',
+     contract_type: 'live_probe',
+     dispatch: 'sync_http',
+     resolve: (expected) => probeHttp('GET', '${gap.target_endpoint}', isExpectedHttp(expected) ? expected : {}),
+   },
+   \`\`\`
+
+2. **Add a follow-up migration** under \`supabase/migrations/\` that INSERTs a row into \`test_contracts\`:
+
+   \`\`\`sql
+   INSERT INTO test_contracts (
+     capability, contract_type, command_key, service, environment,
+     target_file, target_endpoint, expected_behavior, owner, repairable
+   ) VALUES (
+     '${gap.capability}',
+     'live_probe',
+     '${gap.suggested_command_key}',
+     '${gap.service}',
+     '${gap.environment}',
+     '${gap.target_file}',
+     '${gap.target_endpoint}',
+     '{"status": [200, 401], "content_type_prefix": "application/json"}'::jsonb,
+     'gateway-core',
+     true
+   ) ON CONFLICT (capability) DO NOTHING;
+   \`\`\`
+
+   Use \`status: [200, 401]\` (auth-gated routes legitimately return 401 when unauthenticated; that still proves the route is mounted). Tighten to \`status: 200\` only when you know the endpoint is public.
+
+3. **Add a unit test** at \`services/gateway/test/test-contract-commands-${gap.capability}.test.ts\` that mocks fetch and verifies the new dispatcher returns \`passed: true\` for a 200 JSON response and \`passed: false\` for a 500.
+
+## Dedupe key
+
+\`${gap.dedupe_key}\` — the missing-test scanner uses this to avoid creating duplicate VTIDs for the same gap on re-run.
+`;
+
+    const recommendationId = crypto.randomUUID();
+    const recInsertResp = await fetch(`${SUPABASE_URL}/rest/v1/autopilot_recommendations`, {
+      method: 'POST',
+      headers: { ...supabaseHeaders(), Prefer: 'return=minimal' },
+      body: JSON.stringify({
+        id: recommendationId,
+        title: `Write missing test contract: ${gap.capability}`,
+        summary: `Endpoint ${gap.target_endpoint} (file ${gap.target_file}) has no test contract. Add a typed dispatcher + seed row + unit test.`,
+        source_type: 'missing-test-scanner',
+        status: 'new',
+        risk_class: 'low',
+        impact_score: 6,
+        effort_score: 3,
+        auto_exec_eligible: true,
+        domain: 'gateway',
+        scanner: 'missing-test-scanner',
+        spec_snapshot: {
+          spec_markdown,
+          files_referenced: [
+            'services/gateway/src/services/test-contract-commands.ts',
+            gap.target_file,
+          ],
+          scanner: 'missing-test-scanner',
+          dedupe_key: dedupe_key,
+          capability: gap.capability,
+          target_endpoint: gap.target_endpoint,
+        },
+      }),
+    });
+    if (!recInsertResp.ok) {
+      const errBody = await recInsertResp.text();
+      console.warn(`[${VTID}] recommendation INSERT failed: ${errBody}`);
+      // VTID was already allocated; we can still return success on the
+      // allocation but flag the recommendation gap. The caller can retry.
+      return res.status(502).json({
+        ok: false,
+        error: 'RECOMMENDATION_INSERT_FAILED',
+        message: errBody,
+        vtid: VTID,
+        allocated_vtid: newVtid,
+      });
+    }
+
+    // Step 5: write the VTID metadata so dedupe queries find this row.
+    // The allocator's vtid_ledger row exists but won't have our
+    // dedupe_key / repair_kind metadata yet.
+    await fetch(`${SUPABASE_URL}/rest/v1/vtid_ledger?vtid=eq.${newVtid}`, {
+      method: 'PATCH',
+      headers: { ...supabaseHeaders(), Prefer: 'return=minimal' },
+      body: JSON.stringify({
+        metadata: {
+          source: 'missing-test-scanner',
+          repair_kind: 'write_test',
+          capability: gap.capability,
+          dedupe_key,
+          target_endpoint: gap.target_endpoint,
+          target_file: gap.target_file,
+          autopilot_finding_id: recommendationId,
+          allocated_at: new Date().toISOString(),
+          allocated_by: identity.user_id,
+        },
+      }),
+    }).catch((err) => {
+      console.warn(`[${VTID}] vtid_ledger metadata PATCH failed for ${newVtid}: ${err}`);
+    });
+
+    // Step 6: emit OASIS event
+    try {
+      await emitOasisEvent({
+        vtid: newVtid,
+        type: 'missing-test.scanner.allocated' as any,
+        source: 'missing-test-scanner',
+        status: 'info',
+        message: `Allocated ${newVtid} to write missing test for ${gap.capability}`,
+        payload: {
+          dedupe_key,
+          capability: gap.capability,
+          target_endpoint: gap.target_endpoint,
+          target_file: gap.target_file,
+          recommendation_id: recommendationId,
+          actor_user_id: identity.user_id,
+          governance_vtid: 'VTID-02957',
+        },
+      });
+    } catch {
+      /* non-fatal */
+    }
+
+    return res.status(201).json({
+      ok: true,
+      allocated_vtid: newVtid,
+      recommendation_id: recommendationId,
+      dedupe_key,
+      gap,
+      vtid: VTID,
+    });
+  },
+);
+
+export default router;

--- a/services/gateway/src/services/missing-test-scanner.ts
+++ b/services/gateway/src/services/missing-test-scanner.ts
@@ -1,0 +1,137 @@
+/**
+ * VTID-02957 (PR-L2): Missing-Test Scanner.
+ *
+ * Walks the registered set of HTTP capabilities (ENDPOINT_FILE_MAP) and
+ * reports every endpoint that does NOT yet have a row in test_contracts.
+ * For each gap, the scanner derives a suggested capability key + command
+ * key so the LLM bridge can write both a test file AND the allowlist
+ * entry in one PR.
+ *
+ * PR-L2 scope:
+ *   - Pure scanner logic (this file) — testable without DB
+ *   - GET /api/v1/test-contracts/missing — list gaps
+ *   - POST /api/v1/test-contracts/missing/:dedupe_key/allocate — allocate
+ *     one VTID for a specific gap with metadata.repair_kind='write_test'
+ *   - Dedupe vs existing in-flight VTIDs so re-runs don't multiply
+ *
+ * Out of scope for PR-L2 (lands in PR-L3):
+ *   - Automatic scheduled run (cron / scheduler)
+ *   - Bulk allocation of all gaps in one call
+ *   - Bridging to the autopilot Cloud Run Job (the existing self-healing
+ *     injector handles the bridge once a VTID + recommendation exist)
+ */
+
+import { ENDPOINT_FILE_MAP } from '../types/self-healing';
+
+export interface CapabilityGap {
+  /** Stable dedupe key: capability:service:contract_type — matches the
+   *  composite UNIQUE on test_contracts so a duplicate row is impossible. */
+  dedupe_key: string;
+  /** Suggested capability slug (snake_case, derived from endpoint path). */
+  capability: string;
+  /** Always 'live_probe' in PR-L2; jest/typecheck contracts are scanned
+   *  in PR-L3 via a separate discovery (test/*.test.ts files). */
+  contract_type: 'live_probe';
+  /** Service the endpoint lives in. Currently always 'gateway' since the
+   *  scanner only reads gateway routes. */
+  service: 'gateway';
+  /** Default environment for newly discovered capabilities. */
+  environment: 'dev';
+  /** The endpoint path, e.g. '/api/v1/auth/health'. */
+  target_endpoint: string;
+  /** The source file from ENDPOINT_FILE_MAP. */
+  target_file: string;
+  /** Suggested command_key for the allowlist entry the LLM will need to
+   *  add (e.g. 'gateway.auth_health'). Always 'gateway.<capability>'. */
+  suggested_command_key: string;
+}
+
+/**
+ * Convert an endpoint path to a snake_case capability slug.
+ *
+ *   /api/v1/auth/health              → 'auth_health'
+ *   /api/v1/canary-target/health     → 'canary_target_health'
+ *   /api/v1/scheduled-notifications/health
+ *                                    → 'scheduled_notifications_health'
+ *
+ * Pure / deterministic. Strips the common '/api/v1/' prefix because
+ * every gateway capability shares it, leaves anything else alone. The
+ * LLM repair PR can rename the capability if it prefers something
+ * shorter — the dedupe key only ties to this specific capability
+ * spelling, so a future rename would simply create a new contract row
+ * (no orphaning).
+ */
+export function deriveCapability(endpoint: string): string {
+  return endpoint
+    .replace(/^\/api\/v\d+\//, '')
+    .replace(/^\//, '')
+    .replace(/[/-]/g, '_')
+    .replace(/[^a-z0-9_]/gi, '')
+    .toLowerCase();
+}
+
+export function suggestedCommandKey(capability: string): string {
+  return `gateway.${capability}`;
+}
+
+export function gapDedupeKey(capability: string, service: string, contract_type: string): string {
+  return `${capability}:${service}:${contract_type}`;
+}
+
+/**
+ * Existing contract minimal shape — the scanner only needs these three
+ * columns to compute "already covered".
+ */
+export interface ExistingContractRef {
+  capability: string;
+  service: string;
+  contract_type: string;
+}
+
+/**
+ * Pure scanner. Given the current ENDPOINT_FILE_MAP entries + the set
+ * of existing contracts (by capability:service:contract_type), returns
+ * every endpoint that does not yet have a `live_probe` contract.
+ *
+ * Sorted by endpoint path so the cockpit renders deterministically.
+ */
+export function scanMissingContracts(
+  endpointMap: Record<string, string>,
+  existing: ExistingContractRef[],
+): CapabilityGap[] {
+  const covered = new Set<string>();
+  for (const c of existing) {
+    covered.add(gapDedupeKey(c.capability, c.service, c.contract_type));
+  }
+
+  const gaps: CapabilityGap[] = [];
+  for (const [endpoint, file] of Object.entries(endpointMap)) {
+    const capability = deriveCapability(endpoint);
+    const dedupe_key = gapDedupeKey(capability, 'gateway', 'live_probe');
+    if (covered.has(dedupe_key)) continue;
+    gaps.push({
+      dedupe_key,
+      capability,
+      contract_type: 'live_probe',
+      service: 'gateway',
+      environment: 'dev',
+      target_endpoint: endpoint,
+      target_file: file,
+      suggested_command_key: suggestedCommandKey(capability),
+    });
+  }
+
+  gaps.sort((a, b) => (a.target_endpoint < b.target_endpoint ? -1 : 1));
+  return gaps;
+}
+
+/**
+ * Convenience: read the canonical ENDPOINT_FILE_MAP. Lets route handlers
+ * call `scanMissingContractsAgainstLiveRegistry(existing)` without
+ * importing self-healing types directly.
+ */
+export function scanMissingContractsAgainstLiveRegistry(
+  existing: ExistingContractRef[],
+): CapabilityGap[] {
+  return scanMissingContracts(ENDPOINT_FILE_MAP, existing);
+}

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -612,6 +612,9 @@ export type CicdEventType =
   | 'test-contract.run.passed'
   | 'test-contract.run.failed'
   | 'test-contract.run.dispatched'
+  // PR-L2 (VTID-02957): Missing-Test Scanner. Emitted when the scanner
+  // allocates a VTID for a capability that has no test_contracts row.
+  | 'missing-test.scanner.allocated'
   | 'self-healing.completed'
   | 'self-healing.snapshot.pre_fix'
   | 'self-healing.snapshot.post_fix'

--- a/services/gateway/test/missing-test-scanner.test.ts
+++ b/services/gateway/test/missing-test-scanner.test.ts
@@ -1,0 +1,143 @@
+/**
+ * VTID-02957 (PR-L2): Unit tests for the pure missing-test-scanner logic.
+ *
+ * The networked allocate path is tested via the route layer separately;
+ * these tests cover only the pure derivation + dedupe logic so a bug in
+ * capability spelling or gap detection is caught locally.
+ */
+
+import {
+  deriveCapability,
+  suggestedCommandKey,
+  gapDedupeKey,
+  scanMissingContracts,
+  type ExistingContractRef,
+} from '../src/services/missing-test-scanner';
+
+describe('deriveCapability', () => {
+  it('strips the /api/v1/ prefix and snake_cases the path', () => {
+    expect(deriveCapability('/api/v1/auth/health')).toBe('auth_health');
+    expect(deriveCapability('/api/v1/orb/health')).toBe('orb_health');
+  });
+
+  it('replaces hyphens with underscores for snake_case parity with allowlist keys', () => {
+    expect(deriveCapability('/api/v1/canary-target/health')).toBe('canary_target_health');
+    expect(deriveCapability('/api/v1/scheduled-notifications/health')).toBe(
+      'scheduled_notifications_health',
+    );
+  });
+
+  it('preserves multi-segment paths', () => {
+    expect(deriveCapability('/api/v1/operator/deployments/health')).toBe(
+      'operator_deployments_health',
+    );
+    expect(deriveCapability('/api/v1/conversation/tool-health')).toBe(
+      'conversation_tool_health',
+    );
+  });
+
+  it('strips any non [a-z0-9_] characters defensively', () => {
+    // Bizarre / future endpoints — the scanner should never produce
+    // invalid capability strings that would later fail the route regex.
+    expect(deriveCapability('/api/v1/foo.bar/health')).toBe('foobar_health');
+    expect(deriveCapability('/api/v1/X.Y/health')).toBe('xy_health');
+  });
+
+  it('handles non /api/v1/ prefixed paths (e.g. /alive, /command-hub/...)', () => {
+    expect(deriveCapability('/alive')).toBe('alive');
+    expect(deriveCapability('/command-hub/health')).toBe('command_hub_health');
+  });
+});
+
+describe('suggestedCommandKey', () => {
+  it('prefixes with gateway. matching the allowlist convention', () => {
+    expect(suggestedCommandKey('auth_health')).toBe('gateway.auth_health');
+    expect(suggestedCommandKey('canary_target_health')).toBe('gateway.canary_target_health');
+  });
+});
+
+describe('gapDedupeKey', () => {
+  it('joins capability:service:contract_type — matches the test_contracts composite UNIQUE', () => {
+    expect(gapDedupeKey('auth_health', 'gateway', 'live_probe')).toBe(
+      'auth_health:gateway:live_probe',
+    );
+  });
+});
+
+describe('scanMissingContracts', () => {
+  const sampleMap: Record<string, string> = {
+    '/alive': 'services/gateway/src/index.ts',
+    '/api/v1/auth/health': 'services/gateway/src/routes/auth.ts',
+    '/api/v1/canary-target/health': 'services/gateway/src/routes/canary-target.ts',
+  };
+
+  it('returns ALL endpoints as gaps when no contracts exist yet', () => {
+    const gaps = scanMissingContracts(sampleMap, []);
+    expect(gaps).toHaveLength(3);
+    expect(gaps.map((g) => g.capability).sort()).toEqual([
+      'alive',
+      'auth_health',
+      'canary_target_health',
+    ]);
+  });
+
+  it('excludes endpoints that already have a matching capability:service:live_probe contract', () => {
+    const existing: ExistingContractRef[] = [
+      { capability: 'auth_health', service: 'gateway', contract_type: 'live_probe' },
+    ];
+    const gaps = scanMissingContracts(sampleMap, existing);
+    expect(gaps.map((g) => g.capability)).not.toContain('auth_health');
+    expect(gaps.map((g) => g.capability).sort()).toEqual(['alive', 'canary_target_health']);
+  });
+
+  it('does NOT exclude when only the capability matches but service or contract_type differ (dedupe is the full triple)', () => {
+    // A contract for 'auth_health' on a DIFFERENT service should not cover
+    // the gateway live_probe gap. The dedupe is the composite UNIQUE, not
+    // just the capability slug.
+    const existing: ExistingContractRef[] = [
+      { capability: 'auth_health', service: 'worker-runner', contract_type: 'live_probe' },
+      { capability: 'auth_health', service: 'gateway', contract_type: 'jest' },
+    ];
+    const gaps = scanMissingContracts(sampleMap, existing);
+    expect(gaps.map((g) => g.capability)).toContain('auth_health');
+  });
+
+  it('every gap carries the four fields the LLM needs to write both the test + the allowlist entry', () => {
+    const [gap] = scanMissingContracts(
+      { '/api/v1/orb/health': 'services/gateway/src/routes/orb-live.ts' },
+      [],
+    );
+    expect(gap).toMatchObject({
+      capability: 'orb_health',
+      contract_type: 'live_probe',
+      service: 'gateway',
+      environment: 'dev',
+      target_endpoint: '/api/v1/orb/health',
+      target_file: 'services/gateway/src/routes/orb-live.ts',
+      suggested_command_key: 'gateway.orb_health',
+      dedupe_key: 'orb_health:gateway:live_probe',
+    });
+  });
+
+  it('returns an empty list when every endpoint is already covered', () => {
+    const existing: ExistingContractRef[] = [
+      { capability: 'alive', service: 'gateway', contract_type: 'live_probe' },
+      { capability: 'auth_health', service: 'gateway', contract_type: 'live_probe' },
+      { capability: 'canary_target_health', service: 'gateway', contract_type: 'live_probe' },
+    ];
+    expect(scanMissingContracts(sampleMap, existing)).toEqual([]);
+  });
+
+  it('sorts gaps deterministically by endpoint path (so the cockpit renders consistently)', () => {
+    const gaps = scanMissingContracts(sampleMap, []);
+    const endpoints = gaps.map((g) => g.target_endpoint);
+    const sorted = [...endpoints].sort();
+    expect(endpoints).toEqual(sorted);
+  });
+
+  it('is pure — same inputs produce same outputs across invocations', () => {
+    const a = scanMissingContracts(sampleMap, []);
+    const b = scanMissingContracts(sampleMap, []);
+    expect(a).toEqual(b);
+  });
+});


### PR DESCRIPTION
## Summary

**Phase 2 of the Test Contract Backbone plan.** Walks the registered `ENDPOINT_FILE_MAP` and reports every endpoint without a `test_contracts` row. The operator clicks "Allocate VTID" and the existing `dev_autopilot` pipeline produces a real PR adding the test file + `COMMAND_ALLOWLIST` entry + seed migration in one shot.

Plan: `/home/dstev/.claude/plans/test-contract-backbone-knowing-healthy-curie.md`

| Phase | PR | Status |
|---|---|---|
| L1: Registry + safe run surface | #2088 + #2090 | merged + live |
| L1.5: Pulse + Trace integration | #2092 | merged + live |
| **L2: Missing-Test Scanner** | **THIS** | open |
| L3: Failure scanner + scheduled runner | next | pending |
| L4: Known-good recovery | after L3 | pending |
| L5: Pattern memory | after L4 | pending |

## What changed

- **`services/gateway/src/services/missing-test-scanner.ts`** — pure functions (no DB) for capability derivation, dedupe key construction, and gap detection. Capability rule: snake_case from path (`/api/v1/canary-target/health` → `canary_target_health`). Dedupe matches the test_contracts composite UNIQUE on `(capability, service, contract_type)`.

- **`services/gateway/src/routes/test-contracts-missing.ts`** —
  - `GET /api/v1/test-contracts/missing` (dev access) returns `{ total_endpoints, covered, missing, gaps[] }`
  - `POST /api/v1/test-contracts/missing/:dedupe_key/allocate` (admin) re-scans → checks `vtid_ledger` for existing in-flight VTID with same `dedupe_key` (idempotent) → calls `allocateVtid('missing-test-scanner','INFRA','GATEWAY')` → INSERTs `autopilot_recommendations` with full `spec_markdown` (typed dispatcher snippet, INSERT SQL, test path) → PATCHes `vtid_ledger.metadata` with `repair_kind='write_test'`, `dedupe_key`, `capability` → emits `missing-test.scanner.allocated` OASIS event

- **OASIS event type** registered: `missing-test.scanner.allocated`

- **`test/missing-test-scanner.test.ts`** — 14 tests covering every pure function

- **Command Hub** — appends a "Missing Contracts" section below the existing Test Contracts panel. Auto-scans on load; per-row "Allocate VTID" button. Already-allocated rows go green and switch to "Open VTID" deep-linking the VTID ledger.

## What this does NOT change

- No schema changes (PR-L1.1's `test_contracts` table is unmodified)
- No frontend regression — the existing PR-L1 panel renders identically
- No break to PR-L1's `GET /api/v1/test-contracts*` routes
- Idempotent: re-clicking "Allocate" on the same gap returns 200 with `deduped=true` and surfaces the existing VTID, no extra rows

## Test plan

- [x] `test/missing-test-scanner.test.ts` — 14/14
- [x] Full self-healing + autonomy regression: 169/170 across 15 suites (1 skip is pre-existing)
- [x] `npm run build` clean
- [ ] **After merge + EXEC-DEPLOY**: open `/command-hub/voice/test-contracts/`. Below the 6 contracts you'll see ~50 "Missing Contracts" — every endpoint in `ENDPOINT_FILE_MAP` without a contract. Pick one (e.g. `auth_health`), click "Allocate VTID" — should return a fresh VTID-XXXXX and an autopilot_recommendations row. The existing dev_autopilot pipeline picks it up on its next tick.

🤖 Generated with [Claude Code](https://claude.com/claude-code)