### PR TITLE
feat(orb): A8.3a.1 — name upstream message-handler closure + migrate SSE writes to writeSseEvent (VTID-02965)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -5758,8 +5758,18 @@ async function connectToLiveAPI(
       console.log(`[VTID-01219] Setup message sent for session ${session.sessionId}`);
     });
 
-    // Handle incoming messages from Gemini
-    ws.on('message', (data: WebSocket.Data) => {
+    // A8.3a.1 (VTID-02965): The upstream message dispatcher is now a NAMED
+    // function rather than an anonymous arrow. Behavior is unchanged — the
+    // function still closes over `setupComplete`, `connectionTimeout`,
+    // `resolve` / `reject`, `onAudioResponse`, `onTextResponse`, `onError`,
+    // `onTurnComplete`, `onInterrupted`, and `session`. Naming it gives
+    // A8.3a.2 a locatable seam to move to `orb/live/session/` and A8.3b a
+    // single function body to swap from `connectToLiveAPI`'s callback
+    // pattern to `VertexLiveClient`'s typed-event pattern. Inline
+    // `session.sseResponse.write(...)` calls inside this function were
+    // migrated to `writeSseEvent` (from A9.2) so the wire format is owned
+    // by one helper everywhere.
+    function handleUpstreamLiveMessage(data: WebSocket.Data): void {
       try {
         const rawData = data.toString();
         const message = JSON.parse(rawData);
@@ -5842,7 +5852,7 @@ async function connectToLiveAPI(
             session.pendingEventLinks = [];
             // Notify SSE client
             if (session.sseResponse) {
-              session.sseResponse.write(`data: ${JSON.stringify({ type: 'interrupted' })}\n\n`);
+              writeSseEvent(session.sseResponse, { type: 'interrupted' });
             }
             // Notify WS client via callback
             onInterrupted?.();
@@ -5947,7 +5957,7 @@ async function connectToLiveAPI(
                   }
                   const limitMsg = JSON.stringify(payload);
                   if (session.sseResponse) {
-                    session.sseResponse.write(`data: ${limitMsg}\n\n`);
+                    writeSseEvent(session.sseResponse, payload);
                   }
                   if ((session as any).clientWs && (session as any).clientWs.readyState === WebSocket.OPEN) {
                     try { sendWsMessage((session as any).clientWs, JSON.parse(limitMsg)); } catch (_e) { /* ignore */ }
@@ -6006,17 +6016,17 @@ async function connectToLiveAPI(
                   );
                   // Push the redirect-target event to the connected client so the
                   // frontend opens the right screen and focuses the right field.
-                  const redirectMsg = JSON.stringify({
+                  const redirectPayload = {
                     type: 'identity_redirect',
                     redirect_target: result.redirect_target,
                     fact_key: result.detected_fact_key,
                     pattern: result.detected_pattern,
-                  });
+                  };
                   if (session.sseResponse) {
-                    try { session.sseResponse.write(`data: ${redirectMsg}\n\n`); } catch (_e) { /* socket closing */ }
+                    writeSseEvent(session.sseResponse, redirectPayload);
                   }
                   if ((session as any).clientWs && (session as any).clientWs.readyState === WebSocket.OPEN) {
-                    try { sendWsMessage((session as any).clientWs, JSON.parse(redirectMsg)); } catch (_e) { /* ignore */ }
+                    try { sendWsMessage((session as any).clientWs, redirectPayload); } catch (_e) { /* ignore */ }
                   }
                 }).catch((err) => {
                   console.warn('[VTID-01953] handleIdentityIntent failed (non-fatal):', err);
@@ -6110,7 +6120,7 @@ async function connectToLiveAPI(
 
               // Send the formatted block as a single output_transcript SSE event
               if (session.sseResponse) {
-                try { session.sseResponse.write(`data: ${JSON.stringify({ type: 'output_transcript', text: formattedBlock })}\n\n`); } catch (_e) { /* SSE closed */ }
+                writeSseEvent(session.sseResponse, { type: 'output_transcript', text: formattedBlock });
               }
               if (session.clientWs && session.clientWs.readyState === WebSocket.OPEN) {
                 try { sendWsMessage(session.clientWs, { type: 'output_transcript', text: formattedBlock }); } catch (_e) { /* WS closed */ }
@@ -6344,9 +6354,8 @@ async function connectToLiveAPI(
                 reason: nav.reason,
                 vtid: 'VTID-NAV-01',
               };
-              const directiveJson = JSON.stringify(directive);
               if (session.sseResponse) {
-                try { session.sseResponse.write(`data: ${directiveJson}\n\n`); } catch (_e) { /* SSE closed */ }
+                writeSseEvent(session.sseResponse, directive);
               }
               if ((session as any).clientWs && (session as any).clientWs.readyState === WebSocket.OPEN) {
                 try { sendWsMessage((session as any).clientWs, directive); } catch (_e) { /* WS closed */ }
@@ -6380,10 +6389,10 @@ async function connectToLiveAPI(
 
             // Notify client that response is complete
             if (session.sseResponse) {
-              session.sseResponse.write(`data: ${JSON.stringify({
+              writeSseEvent(session.sseResponse, {
                 type: 'turn_complete',
-                is_greeting: isGreetingTurn
-              })}\n\n`);
+                is_greeting: isGreetingTurn,
+              });
             }
             // Notify WS client via callback
             onTurnComplete?.();
@@ -6511,7 +6520,7 @@ async function connectToLiveAPI(
               session.vertexHasShownLife = true;
               emitDiag(session, 'input_transcription', { text_preview: inputTranscription.substring(0, 80) });
               if (session.sseResponse) {
-                session.sseResponse.write(`data: ${JSON.stringify({ type: 'input_transcript', text: inputTranscription })}\n\n`);
+                writeSseEvent(session.sseResponse, { type: 'input_transcript', text: inputTranscription });
               }
               // VTID-01225-THROTTLE: Buffer user input transcription instead of writing per-fragment.
               // Vertex Live API sends transcription incrementally (multiple fragments per utterance).
@@ -6547,7 +6556,7 @@ async function connectToLiveAPI(
               if (!session.isModelSpeaking) {
                 const thinkingMsg = { type: 'thinking' };
                 if (session.sseResponse) {
-                  try { session.sseResponse.write(`data: ${JSON.stringify(thinkingMsg)}\n\n`); } catch (_e) { /* SSE closed */ }
+                  writeSseEvent(session.sseResponse, thinkingMsg);
                 }
                 if (session.clientWs && session.clientWs.readyState === WebSocket.OPEN) {
                   try { sendWsMessage(session.clientWs, thinkingMsg); } catch (_e) { /* WS closed */ }
@@ -6564,7 +6573,7 @@ async function connectToLiveAPI(
             } else {
               console.log(`[VTID-01219] Output transcription: ${outputTranscription}`);
               if (session.sseResponse) {
-                session.sseResponse.write(`data: ${JSON.stringify({ type: 'output_transcript', text: outputTranscription })}\n\n`);
+                writeSseEvent(session.sseResponse, { type: 'output_transcript', text: outputTranscription });
               }
               // VTID-01225: Accumulate output transcription chunks in buffer (will be written on turnComplete)
               session.outputTranscriptBuffer += outputTranscription;
@@ -6584,7 +6593,7 @@ async function connectToLiveAPI(
           // Shows "Thinking..." while memory search, event search etc. execute.
           const toolThinkingMsg = { type: 'thinking', reason: 'tool_call', tools: toolNames };
           if (session.sseResponse) {
-            try { session.sseResponse.write(`data: ${JSON.stringify(toolThinkingMsg)}\n\n`); } catch (_e) { /* SSE closed */ }
+            writeSseEvent(session.sseResponse, toolThinkingMsg);
           }
           if (session.clientWs && session.clientWs.readyState === WebSocket.OPEN) {
             try { sendWsMessage(session.clientWs, toolThinkingMsg); } catch (_e) { /* WS closed */ }
@@ -6666,7 +6675,7 @@ async function connectToLiveAPI(
                     for (const { url } of linkPairs) {
                       const linkMsg = { type: 'link', url, tool: toolName };
                       if (session.sseResponse) {
-                        try { session.sseResponse.write(`data: ${JSON.stringify(linkMsg)}\n\n`); } catch (_e) { /* SSE closed */ }
+                        writeSseEvent(session.sseResponse, linkMsg);
                       }
                       if (session.clientWs && session.clientWs.readyState === WebSocket.OPEN) {
                         try { sendWsMessage(session.clientWs, linkMsg); } catch (_e) { /* WS closed */ }
@@ -6720,7 +6729,10 @@ async function connectToLiveAPI(
       } catch (err) {
         console.error(`[VTID-01219] Error parsing Live API message:`, err);
       }
-    });
+    }
+
+    // A8.3a.1: register the named handler.
+    ws.on('message', handleUpstreamLiveMessage);
 
     // Handle WebSocket errors
     ws.on('error', (error) => {

--- a/services/gateway/test/orb/live/characterization/upstream-message-handler.characterization.test.ts
+++ b/services/gateway/test/orb/live/characterization/upstream-message-handler.characterization.test.ts
@@ -1,0 +1,104 @@
+/**
+ * A8.3a.1 (VTID-02965): structural characterization for the upstream Live
+ * message-handler closure.
+ *
+ * Purpose: lock the seam created when the anonymous `ws.on('message', ...)`
+ * arrow inside `connectToLiveAPI` was named `handleUpstreamLiveMessage`.
+ * This is the entry point that A8.3a.2 moves to
+ * `orb/live/session/upstream-message-handler.ts` and A8.3b swaps from
+ * `connectToLiveAPI`'s callback pattern to `VertexLiveClient`'s typed-event
+ * pattern.
+ *
+ * Why structural rather than runtime: the function closes over
+ * `setupComplete`, `connectionTimeout`, `resolve` / `reject`, and the
+ * `onAudioResponse` / `onTextResponse` / `onError` / `onTurnComplete` /
+ * `onInterrupted` callbacks defined inside `connectToLiveAPI`. Runtime
+ * tests against the function require also reproducing that closure, which
+ * is exactly the surface A8.3a.2 + A8.3b refactor. Until then, the
+ * structural lock is the right boundary.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ORB_LIVE_PATH = path.resolve(__dirname, '../../../../src/routes/orb-live.ts');
+
+let source: string;
+let functionBody: string;
+
+beforeAll(() => {
+  source = fs.readFileSync(ORB_LIVE_PATH, 'utf8');
+
+  // Slice the named function body. The function declaration sits inside
+  // the `new Promise((resolve, reject) => { ... })` body of
+  // `connectToLiveAPI`, terminated by the `ws.on('message', ...)`
+  // registration line.
+  const fnStart = source.indexOf('function handleUpstreamLiveMessage');
+  expect(fnStart).toBeGreaterThan(0);
+
+  // The function is followed by `ws.on('message', handleUpstreamLiveMessage)`
+  // — slice up to that registration.
+  const registration = source.indexOf("ws.on('message', handleUpstreamLiveMessage)", fnStart);
+  expect(registration).toBeGreaterThan(fnStart);
+
+  functionBody = source.slice(fnStart, registration);
+});
+
+describe('A8.3a.1: handleUpstreamLiveMessage named function', () => {
+  it('is declared as a named function (not an anonymous arrow)', () => {
+    expect(functionBody).toMatch(
+      /function\s+handleUpstreamLiveMessage\s*\(\s*data\s*:\s*WebSocket\.Data\s*\)/,
+    );
+  });
+
+  it('is registered via ws.on("message", handleUpstreamLiveMessage)', () => {
+    expect(source).toMatch(
+      /ws\.on\(\s*['"`]message['"`]\s*,\s*handleUpstreamLiveMessage\s*\)/,
+    );
+  });
+
+  it('does NOT register an anonymous arrow as the message handler', () => {
+    // Anti-regression: a future drift back to inline anon arrow would
+    // erase the seam A8.3a.2 / A8.3b consume.
+    expect(source).not.toMatch(
+      /ws\.on\(\s*['"`]message['"`]\s*,\s*\(\s*data\s*:\s*WebSocket\.Data\s*\)\s*=>/,
+    );
+  });
+
+  it('still handles every event the closure dispatched (setup_complete, server_content, tool_call, interruption, turn_complete, transcripts)', () => {
+    // These are the upstream-event paths the function MUST keep dispatching.
+    expect(functionBody).toMatch(/setup_complete\b/);
+    expect(functionBody).toMatch(/server_content\b/);
+    expect(functionBody).toMatch(/tool_call\b/);
+    expect(functionBody).toMatch(/interrupted\b/);
+    expect(functionBody).toMatch(/turn_complete\b/);
+    expect(functionBody).toMatch(/input_transcription\b/);
+    expect(functionBody).toMatch(/output_transcription\b/);
+  });
+
+  it('still invokes the connectToLiveAPI callbacks (closure preservation)', () => {
+    // The function closes over onAudioResponse / onTextResponse / onError /
+    // onTurnComplete / onInterrupted. Removing any of these calls would
+    // break the legacy connectToLiveAPI consumer.
+    expect(functionBody).toMatch(/\bonAudioResponse\s*\(/);
+    expect(functionBody).toMatch(/\bonInterrupted\s*\?\.\s*\(/);
+    expect(functionBody).toMatch(/\bonTurnComplete\s*\?\.\s*\(/);
+    // setup_complete path mutates the outer `setupComplete` let-binding.
+    expect(functionBody).toMatch(/\bsetupComplete\s*=\s*true/);
+  });
+
+  it('uses writeSseEvent for SSE output (A9.2 wire helper), not inline res.write', () => {
+    // Anti-regression: a future drift back to inline
+    // `session.sseResponse.write(\`data: ${JSON.stringify(...)}\n\n\`)`
+    // would re-fragment the wire-format ownership we just consolidated.
+    expect(functionBody).not.toMatch(/session\.sseResponse\.write\s*\(/);
+    expect(functionBody).toMatch(/writeSseEvent\s*\(\s*session\.sseResponse\s*,/);
+  });
+
+  it('orb-live.ts imports writeSseEvent from the A9.2 transport helper', () => {
+    expect(source).toMatch(
+      /from\s*['"`][^'"`]*\/orb\/live\/transport\/sse-handler['"`]/,
+    );
+    expect(source).toMatch(/\bwriteSseEvent\b/);
+  });
+});


### PR DESCRIPTION
## Summary

Track A / A8.3 sub-split, slice 1 of 3.

**A8.3 was authorized to split (A8.3a + A8.3b).** A8.3a turns out to be still too big — the upstream message-handler closure is ~965 lines with deep coupling to orb-live.ts locals. Lifting it to a new file + migrating SSE writes + wiring deps all in one PR is exactly the failure mode the high-risk warning called out. So I'm sub-splitting A8.3a itself:

| Slice | Status | Scope |
|---|---|---|
| **A8.3a.1 (this PR)** | this PR | structural — name the closure + consolidate wire format |
| A8.3a.2 | next | move named function to `orb/live/session/upstream-message-handler.ts` (with deps bag) |
| A8.3b | after | swap `connectToLiveAPI` for `VertexLiveClient` (A7) inside the controller |

This PR does ONLY:
1. Names the inline `ws.on('message', (data: WebSocket.Data) => {...})` arrow as `function handleUpstreamLiveMessage(data)` inside `connectToLiveAPI`. The function still closes over every outer binding (`setupComplete`, `connectionTimeout`, `resolve`/`reject`, `onAudioResponse`/`onTextResponse`/`onError`/`onTurnComplete`/`onInterrupted`). `ws.on('message', handleUpstreamLiveMessage)` registers it.
2. Migrates every inline `session.sseResponse.write(\`data: ${JSON.stringify(...)}\n\n\`)` inside the named function (11 call sites) to `writeSseEvent(session.sseResponse, payload)` from A9.2. Wire format byte-for-byte identical.

**Zero behavior change.** Same JSON envelopes, same `data: ${json}\n\n` framing, same try/catch socket-closed swallow.

## What lands

- **services/gateway/src/routes/orb-live.ts**
  - Anonymous arrow at line ~5762 becomes named `function handleUpstreamLiveMessage(data: WebSocket.Data)` declaration.
  - `ws.on('message', handleUpstreamLiveMessage)` registration line.
  - 11 inline `session.sseResponse.write(...)` calls migrated to `writeSseEvent(session.sseResponse, payload)`.
- **test/orb/live/characterization/upstream-message-handler.characterization.test.ts** — 7 structural assertions:
  - Function is declared with the canonical name + signature.
  - Registered correctly via `ws.on('message', handleUpstreamLiveMessage)`.
  - Anti-regression on anonymous-arrow drift.
  - All upstream event paths present: setup_complete / server_content / tool_call / interrupted / turn_complete / input_transcription / output_transcription.
  - Closure callbacks still invoked (onAudioResponse / onInterrupted / onTurnComplete / setupComplete mutation).
  - `writeSseEvent` used inside the function; no inline `session.sseResponse.write`.
  - `writeSseEvent` import from sse-handler present.

## Acceptance checks (A8.3 spec — partial; full set across A8.3a.1 / A8.3a.2 / A8.3b)

1. ✅ Existing WebSocket/SSE/session characterization tests remain green.
2. ✅ Upstream events still dispatch (verified structurally — all event paths still present in the renamed function).
3. ✅ SSE wire output byte-compatible (`writeSseEvent` emits the same `data: ${json}\n\n` envelope as the legacy inline writes; safe-write try/catch behavior preserved).
4. ✅ OASIS/diag event payloads unchanged.
5. ⏳ `connectToLiveAPI` still owns the active message loop (A8.3b will swap to `VertexLiveClient`).
6. ⏳ `VertexLiveClient` integration deferred to A8.3b.
7. ⏳ Production /orb/chat smoke after deploy.
8. ✅ No LiveKit activation.
9. ✅ No R-lane tuning.
10. ✅ No contextual-intelligence changes.

## What this PR does NOT touch

- Move to `orb/live/session/upstream-message-handler.ts` — A8.3a.2.
- `connectToLiveAPI` → `VertexLiveClient` migration — A8.3b.
- LiveKit adapter, L1 provider selection, F1/F4, B6/B7, R-lane.

## Test plan

- [x] 7 new structural assertions on the named function
- [x] 643 tests green across `test/orb/**` (no regression)
- [x] TypeScript clean
- [ ] Post-merge: EXEC-DEPLOY + /orb/chat production smoke

🤖 Generated with [Claude Code](https://claude.com/claude-code)