### PR TITLE
feat(self-healing): Known-Good Recovery context for failing-test repairs (VTID-02967, DEV-COMHU-02967, PR-L4)

### DIFF
--- a/services/gateway/src/routes/test-contracts-scheduled.ts
+++ b/services/gateway/src/routes/test-contracts-scheduled.ts
@@ -30,6 +30,11 @@ import {
   type RecentRunRow,
 } from '../services/test-contract-failure-scanner';
 import { allocateVtid } from '../services/operator-service';
+import { getDeployedSha } from '../services/self-healing-diagnosis-service';
+import {
+  buildRepairContext,
+  renderRepairContextMarkdown,
+} from '../services/test-contract-repair-context';
 
 const router = Router();
 const VTID = 'VTID-02958';
@@ -170,6 +175,18 @@ router.post(
               repairVtid = alloc.vtid;
               repairRecommendationId = randomUUID();
               const expectedExcerpt = JSON.stringify(contract.expected_behavior).slice(0, 500);
+
+              // VTID-02967 (PR-L4): Known-good recovery context. Fetches
+              // the file at last_passing_sha + current main and embeds
+              // both versions + a diff summary into the spec_markdown so
+              // the repair LLM can choose between revert / compensate /
+              // investigate instead of guessing from scratch.
+              const repairContext = await buildRepairContext({
+                targetFile: contract.target_file,
+                lastPassingSha: contract.last_passing_sha,
+              });
+              const knownGoodMd = renderRepairContextMarkdown(repairContext);
+
               const specMarkdown = `# Failing test contract: ${contract.capability}
 
 The contract \`${contract.capability}\` (\`${contract.command_key}\`, live_probe) is failing in production.
@@ -187,6 +204,8 @@ The contract \`${contract.capability}\` (\`${contract.command_key}\`, live_probe
 \`\`\`json
 ${expectedExcerpt}
 \`\`\`
+
+${knownGoodMd}
 
 ## Repair contract — HARD RULES (worker-runner enforces)
 
@@ -307,12 +326,22 @@ ${expectedExcerpt}
           });
 
           // PATCH test_contracts.{status, last_status, last_failure_signature, last_run_at}
+          // VTID-02967 (PR-L4): on a passing run, stamp last_passing_sha
+          // so the next failure can pull a real diff vs the known-good
+          // version. Source: BUILD_INFO / DEPLOYED_GIT_SHA per PR-C.
           const patchBody: Record<string, unknown> = {
             status: decision.new_status,
             last_run_at: result.ran_at,
             last_status: contract.status,
             last_failure_signature: result.passed ? null : decision.failure_signature,
           };
+          if (result.passed) {
+            const sha = getDeployedSha();
+            if (sha) {
+              patchBody.last_passing_sha = sha;
+              patchBody.branch_or_sha = sha;
+            }
+          }
           await fetch(`${SUPABASE_URL}/rest/v1/test_contracts?id=eq.${contract.id}`, {
             method: 'PATCH',
             headers: { ...supabaseHeaders(), Prefer: 'return=minimal' },

--- a/services/gateway/src/routes/test-contracts.ts
+++ b/services/gateway/src/routes/test-contracts.ts
@@ -27,6 +27,7 @@ import {
   AuthenticatedRequest,
 } from '../middleware/auth-supabase-jwt';
 import { resolveCommand } from '../services/test-contract-commands';
+import { getDeployedSha } from '../services/self-healing-diagnosis-service';
 
 const router = Router();
 const VTID = 'VTID-02954';
@@ -246,10 +247,14 @@ router.post(
       last_failure_signature: failureSignature,
     };
     if (result.passed) {
-      // Last-passing SHA tracking requires a known SHA. PR-L1 doesn't have
-      // that yet — Phase 3's failure scanner runs against deployed revisions
-      // and will pass in the deployed SHA. For now we leave last_passing_sha
-      // alone and only update it when the caller provides it.
+      // VTID-02967 (PR-L4): stamp last_passing_sha from BUILD_INFO so
+      // any future failure can fetch the file at this SHA via known-good
+      // recovery context.
+      const sha = getDeployedSha();
+      if (sha) {
+        patchBody.last_passing_sha = sha;
+        patchBody.branch_or_sha = sha;
+      }
     }
     await fetch(`${SUPABASE_URL}/rest/v1/test_contracts?id=eq.${id}`, {
       method: 'PATCH',

--- a/services/gateway/src/services/self-healing-diagnosis-service.ts
+++ b/services/gateway/src/services/self-healing-diagnosis-service.ts
@@ -59,7 +59,9 @@ function githubAuthEnv(): { owner: string; repo: string; token: string } {
 
 // Read every call so tests + operators can override at runtime; the work
 // is cheap (env read + at most one fs.readFileSync of a tiny JSON file).
-function getDeployedSha(): string | null {
+// VTID-02967 (PR-L4): exported so the test-contract scheduled-runner can
+// stamp last_passing_sha on every passing run.
+export function getDeployedSha(): string | null {
   // 1. Explicit env override (set by EXEC-DEPLOY.yml when known).
   if (process.env.DEPLOYED_GIT_SHA) return process.env.DEPLOYED_GIT_SHA;
   if (process.env.BUILD_SHA) return process.env.BUILD_SHA;
@@ -90,7 +92,9 @@ interface LoadedSource {
   source: 'fs' | 'github_deployed_sha' | 'github_main';
 }
 
-async function fetchFromGithub(
+// VTID-02967 (PR-L4): export so test-contract-repair-context can fetch a
+// file at a specific last_passing_sha. Same auth + same encoding rules.
+export async function fetchFromGithub(
   relativeFile: string,
   ref: string,
 ): Promise<{ ok: boolean; content?: string; sha?: string }> {

--- a/services/gateway/src/services/test-contract-repair-context.ts
+++ b/services/gateway/src/services/test-contract-repair-context.ts
@@ -1,0 +1,249 @@
+/**
+ * VTID-02967 (PR-L4): Test Contract Known-Good Recovery context builder.
+ *
+ * Phase 4 of the Test Contract Backbone plan. When the failure scanner
+ * is about to allocate a repair VTID for a failing contract, it asks
+ * this builder for "what did the file look like the last time the test
+ * passed?" — and includes both versions in the LLM repair spec. The
+ * LLM goes from "guess at a fix" to "explain why this diff broke the
+ * contract, then revert / compensate / propose a deliberate behavior
+ * change".
+ *
+ * The recommendation field tells the LLM whether the diff is small
+ * enough that direct revert (`recover_to_last_passing_sha`) is the
+ * obvious choice, or whether the change is large and needs investigation.
+ */
+
+import { fetchFromGithub, getDeployedSha } from './self-healing-diagnosis-service';
+
+export type RepairRecommendedAction =
+  /** Tiny diff that's clearly the regression — propose a revert first. */
+  | 'recover_to_last_passing_sha'
+  /** Medium diff or new code added — propose a compensating fix. */
+  | 'compensate'
+  /** Large diff or no last_passing_content — needs full investigation. */
+  | 'investigate'
+  /** No SHA / no file — nothing to recover from; LLM works from scratch. */
+  | 'no_known_good';
+
+export interface RepairContext {
+  has_known_good: boolean;
+  target_file: string | null;
+  last_passing_sha: string | null;
+  current_sha: string | null;
+
+  last_passing_content: string | null;
+  current_content: string | null;
+
+  // Cheap diff stats for the spec_markdown summary (and the
+  // recommendation heuristic). The LLM does the actual semantic diff.
+  last_passing_line_count: number | null;
+  current_line_count: number | null;
+  delta_lines: number | null;
+
+  recommended_action: RepairRecommendedAction;
+  recommendation_rationale: string;
+
+  fetch_errors: string[];
+}
+
+/**
+ * Tiny, capped fetch — keeps the spec_markdown bounded.
+ *
+ * The full file content goes into `spec_snapshot.spec_markdown` which
+ * eventually rides on an autopilot_recommendations row read by the
+ * Cloud Run autopilot job. We cap at 16 KB per side to keep the
+ * recommendation row size reasonable; large files get truncated with
+ * a marker the LLM can read.
+ */
+const MAX_CONTENT_BYTES = 16 * 1024;
+
+function truncate(content: string | null): string | null {
+  if (!content) return content;
+  if (content.length <= MAX_CONTENT_BYTES) return content;
+  return content.slice(0, MAX_CONTENT_BYTES) +
+    `\n\n... [truncated to ${MAX_CONTENT_BYTES} bytes; original was ${content.length} bytes]`;
+}
+
+function lineCount(content: string | null): number | null {
+  if (content === null) return null;
+  if (content === '') return 0;
+  return content.split('\n').length;
+}
+
+/**
+ * Decide which action to suggest to the repair LLM.
+ *
+ *   no SHA / no file     → no_known_good (work from scratch)
+ *   no last_passing      → investigate (we know the SHA but couldn't fetch)
+ *   delta ≤ 10 lines     → recover_to_last_passing_sha
+ *   delta ≤ 60 lines     → compensate (small enough to reason about)
+ *   otherwise            → investigate
+ */
+export function recommendAction(
+  hasTargetFile: boolean,
+  hasLastPassingSha: boolean,
+  hasLastPassingContent: boolean,
+  hasCurrentContent: boolean,
+  deltaLines: number | null,
+): { action: RepairRecommendedAction; rationale: string } {
+  if (!hasTargetFile || !hasLastPassingSha) {
+    return {
+      action: 'no_known_good',
+      rationale: hasTargetFile
+        ? 'no last_passing_sha recorded yet — first failure cycle for this contract'
+        : 'contract has no target_file — known-good recovery not applicable',
+    };
+  }
+  if (!hasLastPassingContent) {
+    return {
+      action: 'investigate',
+      rationale: 'last_passing_sha known but file content unfetchable (GitHub API miss)',
+    };
+  }
+  if (!hasCurrentContent) {
+    return {
+      action: 'investigate',
+      rationale: 'current file content unfetchable — diff cannot be computed',
+    };
+  }
+  if (deltaLines === null) {
+    return { action: 'investigate', rationale: 'delta could not be computed' };
+  }
+  const abs = Math.abs(deltaLines);
+  if (abs <= 10) {
+    return {
+      action: 'recover_to_last_passing_sha',
+      rationale: `tiny diff (${deltaLines} lines) — direct revert is the safe default; LLM may compensate if revert would lose intentional change`,
+    };
+  }
+  if (abs <= 60) {
+    return {
+      action: 'compensate',
+      rationale: `moderate diff (${deltaLines} lines) — too large to blindly revert; LLM should explain the regression then write a targeted fix`,
+    };
+  }
+  return {
+    action: 'investigate',
+    rationale: `large diff (${deltaLines} lines) — major refactor since last_passing_sha; LLM may need additional context (callers, tests) before proposing a fix`,
+  };
+}
+
+/**
+ * Build the repair context for a contract failure. Pure-ish: depends on
+ * GitHub Contents API + env (BUILD_INFO/DEPLOYED_GIT_SHA). Tests inject
+ * mocks via process.env + jest.mock as needed.
+ */
+export async function buildRepairContext(args: {
+  targetFile: string | null;
+  lastPassingSha: string | null;
+}): Promise<RepairContext> {
+  const errors: string[] = [];
+  const targetFile = args.targetFile;
+  const lastPassingSha = args.lastPassingSha;
+  const currentSha = getDeployedSha();
+
+  if (!targetFile || !lastPassingSha) {
+    const rec = recommendAction(Boolean(targetFile), Boolean(lastPassingSha), false, false, null);
+    return {
+      has_known_good: false,
+      target_file: targetFile,
+      last_passing_sha: lastPassingSha,
+      current_sha: currentSha,
+      last_passing_content: null,
+      current_content: null,
+      last_passing_line_count: null,
+      current_line_count: null,
+      delta_lines: null,
+      recommended_action: rec.action,
+      recommendation_rationale: rec.rationale,
+      fetch_errors: errors,
+    };
+  }
+
+  // Fetch in parallel — both call GitHub Contents API; one round-trip each.
+  const [lastPassing, current] = await Promise.all([
+    fetchFromGithub(targetFile, lastPassingSha),
+    currentSha
+      ? fetchFromGithub(targetFile, currentSha)
+      : fetchFromGithub(targetFile, 'main'),
+  ]);
+
+  if (!lastPassing.ok) errors.push(`fetch_last_passing_failed:${lastPassingSha.slice(0, 7)}`);
+  if (!current.ok) errors.push(`fetch_current_failed:${currentSha?.slice(0, 7) || 'main'}`);
+
+  const lastPassingContent = lastPassing.ok && lastPassing.content !== undefined
+    ? lastPassing.content
+    : null;
+  const currentContent = current.ok && current.content !== undefined
+    ? current.content
+    : null;
+
+  const lpLines = lineCount(lastPassingContent);
+  const curLines = lineCount(currentContent);
+  const delta = lpLines !== null && curLines !== null ? curLines - lpLines : null;
+
+  const rec = recommendAction(
+    true,
+    true,
+    lastPassingContent !== null,
+    currentContent !== null,
+    delta,
+  );
+
+  return {
+    has_known_good: lastPassingContent !== null,
+    target_file: targetFile,
+    last_passing_sha: lastPassingSha,
+    current_sha: currentSha,
+    last_passing_content: truncate(lastPassingContent),
+    current_content: truncate(currentContent),
+    last_passing_line_count: lpLines,
+    current_line_count: curLines,
+    delta_lines: delta,
+    recommended_action: rec.action,
+    recommendation_rationale: rec.rationale,
+    fetch_errors: errors,
+  };
+}
+
+/**
+ * Render the repair context into a markdown section the LLM gets in
+ * its spec_markdown. Designed to slot into the existing failure-scanner
+ * spec template after the "## Repair contract" block.
+ */
+export function renderRepairContextMarkdown(ctx: RepairContext): string {
+  if (!ctx.has_known_good) {
+    return `## Known-good recovery context
+
+_Not available._ ${ctx.recommendation_rationale}
+
+Suggested action: \`${ctx.recommended_action}\`.
+`;
+  }
+  return `## Known-good recovery context
+
+The contract last passed at SHA \`${ctx.last_passing_sha}\` ${ctx.current_sha ? `against the current SHA \`${ctx.current_sha}\`` : ''}.
+
+**Diff summary**: ${ctx.last_passing_line_count} → ${ctx.current_line_count} lines (delta ${ctx.delta_lines! >= 0 ? '+' : ''}${ctx.delta_lines}).
+
+**Recommended action**: \`${ctx.recommended_action}\` — ${ctx.recommendation_rationale}.
+
+### Last passing content (\`${ctx.target_file}\` @ \`${ctx.last_passing_sha?.slice(0, 7)}\`)
+
+\`\`\`
+${ctx.last_passing_content}
+\`\`\`
+
+### Current content (\`${ctx.target_file}\`${ctx.current_sha ? ` @ \`${ctx.current_sha.slice(0, 7)}\`` : ''})
+
+\`\`\`
+${ctx.current_content}
+\`\`\`
+
+**Repair guidance**:
+- If \`recommended_action == 'recover_to_last_passing_sha'\`: revert is the safe default. Only deviate if the diff contains intentional behavior changes that should be preserved.
+- If \`recommended_action == 'compensate'\`: explain in the PR description why the diff broke the contract, then write a targeted fix that keeps the intentional changes.
+- If \`recommended_action == 'investigate'\`: the diff is too large to reason about in isolation. Read the failing test, read the immediate callers of \`${ctx.target_file}\`, and decide whether the regression is in this file or somewhere upstream.
+`;
+}

--- a/services/gateway/test/test-contract-repair-context.test.ts
+++ b/services/gateway/test/test-contract-repair-context.test.ts
@@ -1,0 +1,294 @@
+/**
+ * VTID-02967 (PR-L4): Unit tests for the known-good recovery context
+ * builder. Pure logic + recommendation thresholds.
+ *
+ * The networked GitHub Contents API path is exercised by mocking
+ * fetchFromGithub; the recommendation heuristic is tested directly.
+ */
+
+import {
+  recommendAction,
+  buildRepairContext,
+  renderRepairContextMarkdown,
+} from '../src/services/test-contract-repair-context';
+
+const ORIGINAL_FETCH = global.fetch;
+
+beforeEach(() => {
+  process.env.SUPABASE_URL = 'https://supabase.test';
+  process.env.SUPABASE_SERVICE_ROLE = 'svc-role';
+  process.env.GITHUB_SAFE_MERGE_TOKEN = 'gh-token';
+  process.env.GITHUB_REPO_OWNER = 'exafyltd';
+  process.env.GITHUB_REPO_NAME = 'vitana-platform';
+  delete process.env.DEPLOYED_GIT_SHA;
+  delete process.env.BUILD_SHA;
+});
+
+afterEach(() => {
+  global.fetch = ORIGINAL_FETCH;
+});
+
+// =============================================================================
+// recommendAction — pure heuristic
+// =============================================================================
+
+describe('recommendAction', () => {
+  it('no target_file → no_known_good', () => {
+    const r = recommendAction(false, true, false, false, null);
+    expect(r.action).toBe('no_known_good');
+    expect(r.rationale).toContain('no target_file');
+  });
+
+  it('no last_passing_sha → no_known_good (first failure cycle)', () => {
+    const r = recommendAction(true, false, false, false, null);
+    expect(r.action).toBe('no_known_good');
+    expect(r.rationale).toContain('no last_passing_sha');
+  });
+
+  it('SHA known but content unfetchable → investigate', () => {
+    const r = recommendAction(true, true, false, false, null);
+    expect(r.action).toBe('investigate');
+    expect(r.rationale).toContain('unfetchable');
+  });
+
+  it('tiny diff (≤ 10 lines) → recover_to_last_passing_sha (revert is safe default)', () => {
+    const r = recommendAction(true, true, true, true, 3);
+    expect(r.action).toBe('recover_to_last_passing_sha');
+    expect(r.rationale).toContain('tiny diff');
+  });
+
+  it('moderate diff (11–60 lines) → compensate', () => {
+    const r = recommendAction(true, true, true, true, 25);
+    expect(r.action).toBe('compensate');
+    expect(r.rationale).toContain('moderate diff');
+  });
+
+  it('large diff (> 60 lines) → investigate', () => {
+    const r = recommendAction(true, true, true, true, 120);
+    expect(r.action).toBe('investigate');
+    expect(r.rationale).toContain('large diff');
+  });
+
+  it('uses absolute value for delta — file SHRINKING by N lines is the same as growing by N for revert decision', () => {
+    expect(recommendAction(true, true, true, true, -5).action).toBe('recover_to_last_passing_sha');
+    expect(recommendAction(true, true, true, true, -25).action).toBe('compensate');
+  });
+
+  it('boundary: delta=10 → recover (≤ 10), delta=11 → compensate', () => {
+    expect(recommendAction(true, true, true, true, 10).action).toBe('recover_to_last_passing_sha');
+    expect(recommendAction(true, true, true, true, 11).action).toBe('compensate');
+  });
+
+  it('boundary: delta=60 → compensate, delta=61 → investigate', () => {
+    expect(recommendAction(true, true, true, true, 60).action).toBe('compensate');
+    expect(recommendAction(true, true, true, true, 61).action).toBe('investigate');
+  });
+});
+
+// =============================================================================
+// buildRepairContext — uses fetch mock to simulate GitHub Contents API
+// =============================================================================
+
+describe('buildRepairContext', () => {
+  function mockGithub(
+    files: Record<string, { content: string; sha: string }>,
+  ) {
+    global.fetch = jest.fn().mockImplementation(async (url: string) => {
+      // GitHub Contents API URL format:
+      //   https://api.github.com/repos/<owner>/<repo>/contents/<path>?ref=<ref>
+      const m = url.match(/\/contents\/([^?]+)\?ref=([^&]+)/);
+      if (!m) return new Response('{}', { status: 404 });
+      const filePath = decodeURIComponent(m[1].split('/').map(decodeURIComponent).join('/'));
+      const ref = decodeURIComponent(m[2]);
+      const key = `${ref}:${filePath}`;
+      const file = files[key];
+      if (!file) return new Response(JSON.stringify({}), { status: 404 });
+      return new Response(
+        JSON.stringify({
+          content: Buffer.from(file.content, 'utf-8').toString('base64'),
+          encoding: 'base64',
+          sha: file.sha,
+        }),
+        { status: 200, headers: { 'content-type': 'application/json' } },
+      );
+    }) as unknown as typeof fetch;
+  }
+
+  it('returns has_known_good=false + no_known_good action when last_passing_sha is null', async () => {
+    const ctx = await buildRepairContext({
+      targetFile: 'services/gateway/src/routes/auth.ts',
+      lastPassingSha: null,
+    });
+    expect(ctx.has_known_good).toBe(false);
+    expect(ctx.recommended_action).toBe('no_known_good');
+    expect(ctx.last_passing_content).toBeNull();
+    expect(ctx.current_content).toBeNull();
+  });
+
+  it('returns has_known_good=false + no_known_good action when target_file is null', async () => {
+    const ctx = await buildRepairContext({ targetFile: null, lastPassingSha: 'abc1234' });
+    expect(ctx.has_known_good).toBe(false);
+    expect(ctx.recommended_action).toBe('no_known_good');
+  });
+
+  it('fetches last_passing + current and recommends recover when diff is tiny', async () => {
+    process.env.DEPLOYED_GIT_SHA = 'currentsha';
+    const lp = 'line1\nline2\nline3\nline4\nline5';
+    const cur = 'line1\nline2\nline3-CHANGED\nline4\nline5';
+    mockGithub({
+      'oldsha:src/x.ts': { content: lp, sha: 'oldsha' },
+      'currentsha:src/x.ts': { content: cur, sha: 'currentsha' },
+    });
+    const ctx = await buildRepairContext({ targetFile: 'src/x.ts', lastPassingSha: 'oldsha' });
+    expect(ctx.has_known_good).toBe(true);
+    expect(ctx.last_passing_content).toBe(lp);
+    expect(ctx.current_content).toBe(cur);
+    expect(ctx.delta_lines).toBe(0); // same line count, just edited
+    expect(ctx.recommended_action).toBe('recover_to_last_passing_sha');
+  });
+
+  it('falls back to ref=main when DEPLOYED_GIT_SHA is unset', async () => {
+    // Mock getDeployedSha to actually return null. (Without this the
+    // BUILD_INFO file in services/gateway/ would be read by the
+    // re-imported module, returning a real SHA.)
+    jest.resetModules();
+    jest.doMock('../src/services/self-healing-diagnosis-service', () => ({
+      __esModule: true,
+      getDeployedSha: () => null,
+      fetchFromGithub: jest.fn().mockImplementation(async (rel: string, ref: string) => {
+        const map: Record<string, string> = { 'oldsha:f.ts': 'old', 'main:f.ts': 'new' };
+        const content = map[`${ref}:${rel}`];
+        if (!content) return { ok: false };
+        return { ok: true, content, sha: ref };
+      }),
+    }));
+    const reloaded = require('../src/services/test-contract-repair-context');
+    const ctx = await reloaded.buildRepairContext({ targetFile: 'f.ts', lastPassingSha: 'oldsha' });
+    expect(ctx.has_known_good).toBe(true);
+    expect(ctx.current_content).toBe('new');
+    expect(ctx.current_sha).toBeNull(); // no DEPLOYED_GIT_SHA
+  });
+
+  it('records fetch_errors when last_passing fetch misses', async () => {
+    process.env.DEPLOYED_GIT_SHA = 'currentsha';
+    mockGithub({
+      // last_passing missing
+      'currentsha:f.ts': { content: 'cur', sha: 'currentsha' },
+    });
+    const ctx = await buildRepairContext({ targetFile: 'f.ts', lastPassingSha: 'oldsha' });
+    expect(ctx.has_known_good).toBe(false);
+    expect(ctx.recommended_action).toBe('investigate');
+    expect(ctx.fetch_errors).toEqual(['fetch_last_passing_failed:oldsha']);
+    expect(ctx.last_passing_content).toBeNull();
+    expect(ctx.current_content).toBe('cur');
+  });
+
+  it('truncates content over 16 KB to keep spec_markdown bounded', async () => {
+    process.env.DEPLOYED_GIT_SHA = 'currentsha';
+    const huge = 'x'.repeat(40_000);
+    mockGithub({
+      'oldsha:big.ts': { content: huge, sha: 'oldsha' },
+      'currentsha:big.ts': { content: 'small', sha: 'currentsha' },
+    });
+    const ctx = await buildRepairContext({ targetFile: 'big.ts', lastPassingSha: 'oldsha' });
+    expect(ctx.last_passing_content!.length).toBeLessThan(17_000);
+    expect(ctx.last_passing_content!).toContain('truncated to 16384 bytes');
+  });
+
+  it('computes delta_lines correctly when current adds lines', async () => {
+    process.env.DEPLOYED_GIT_SHA = 'currentsha';
+    mockGithub({
+      'oldsha:f.ts': { content: 'a\nb\nc', sha: 'oldsha' },
+      'currentsha:f.ts': { content: 'a\nb\nc\nd\ne\nf\ng\nh', sha: 'currentsha' },
+    });
+    const ctx = await buildRepairContext({ targetFile: 'f.ts', lastPassingSha: 'oldsha' });
+    expect(ctx.last_passing_line_count).toBe(3);
+    expect(ctx.current_line_count).toBe(8);
+    expect(ctx.delta_lines).toBe(5);
+    // 5 lines is still ≤ 10 → recover
+    expect(ctx.recommended_action).toBe('recover_to_last_passing_sha');
+  });
+
+  it('large diff promotes investigate action', async () => {
+    process.env.DEPLOYED_GIT_SHA = 'currentsha';
+    const small = Array(5).fill('line').join('\n');
+    const huge = Array(200).fill('line').join('\n');
+    mockGithub({
+      'oldsha:f.ts': { content: small, sha: 'oldsha' },
+      'currentsha:f.ts': { content: huge, sha: 'currentsha' },
+    });
+    const ctx = await buildRepairContext({ targetFile: 'f.ts', lastPassingSha: 'oldsha' });
+    expect(ctx.delta_lines).toBe(195);
+    expect(ctx.recommended_action).toBe('investigate');
+  });
+});
+
+// =============================================================================
+// renderRepairContextMarkdown — section heading + structure
+// =============================================================================
+
+describe('renderRepairContextMarkdown', () => {
+  it('produces a "_Not available._" stub when has_known_good=false', () => {
+    const md = renderRepairContextMarkdown({
+      has_known_good: false,
+      target_file: null,
+      last_passing_sha: null,
+      current_sha: null,
+      last_passing_content: null,
+      current_content: null,
+      last_passing_line_count: null,
+      current_line_count: null,
+      delta_lines: null,
+      recommended_action: 'no_known_good',
+      recommendation_rationale: 'no last_passing_sha recorded yet',
+      fetch_errors: [],
+    });
+    expect(md).toContain('Known-good recovery context');
+    expect(md).toContain('_Not available._');
+    expect(md).toContain('no_known_good');
+  });
+
+  it('renders both file versions + diff summary when has_known_good=true', () => {
+    const md = renderRepairContextMarkdown({
+      has_known_good: true,
+      target_file: 'src/x.ts',
+      last_passing_sha: 'abcdef0123',
+      current_sha: 'fedcba9876',
+      last_passing_content: 'old code',
+      current_content: 'new code',
+      last_passing_line_count: 1,
+      current_line_count: 1,
+      delta_lines: 0,
+      recommended_action: 'recover_to_last_passing_sha',
+      recommendation_rationale: 'tiny diff',
+      fetch_errors: [],
+    });
+    expect(md).toContain('1 → 1 lines');
+    expect(md).toContain('delta +0');
+    expect(md).toContain('Last passing content');
+    expect(md).toContain('Current content');
+    expect(md).toContain('old code');
+    expect(md).toContain('new code');
+    expect(md).toContain('recover_to_last_passing_sha');
+  });
+
+  it('renders negative delta with the minus sign (file shrunk)', () => {
+    const md = renderRepairContextMarkdown({
+      has_known_good: true,
+      target_file: 'src/x.ts',
+      last_passing_sha: 'abc',
+      current_sha: 'def',
+      last_passing_content: 'a\nb\nc',
+      current_content: 'a',
+      last_passing_line_count: 3,
+      current_line_count: 1,
+      delta_lines: -2,
+      recommended_action: 'recover_to_last_passing_sha',
+      recommendation_rationale: 'tiny',
+      fetch_errors: [],
+    });
+    // Should NOT have a leading + on negative numbers
+    expect(md).toContain('delta -2');
+    expect(md).not.toContain('delta +-2');
+  });
+});


### PR DESCRIPTION
## Summary

**Phase 4 of the Test Contract Backbone plan.** When the failure scanner allocates a repair VTID, the spec_markdown now carries the target file at `last_passing_sha` + current main + a diff summary + a recommended action (revert / compensate / investigate). The repair LLM goes from "guess at a fix" to "explain why this diff broke the contract, then act".

| Phase | PR | Status |
|---|---|---|
| L1 / L1.1: Registry | #2088 / #2090 | live |
| L1.5: Pulse + Trace | #2092 | live |
| L2: Missing-Test Scanner | #2094 | live |
| L3: Failure Scanner + scheduled runner | #2097 | live |
| **L4: Known-Good Recovery** | **THIS** | open |
| L5: Pattern memory | next | pending |

## What changed

**`services/gateway/src/services/test-contract-repair-context.ts`** — `buildRepairContext({targetFile, lastPassingSha})` fetches both file versions in parallel via GitHub Contents API (reusing PR-C's `fetchFromGithub` + `getDeployedSha`, now exported). Truncates content >16 KB so autopilot_recommendations rows stay bounded.

**`recommendAction(...)` heuristic** (pure, tested directly):
| Delta lines | Action | Rationale |
|---|---|---|
| ≤10 | `recover_to_last_passing_sha` | Tiny diff — revert is the safe default unless intentional |
| 11–60 | `compensate` | Small enough to reason about; explain regression then targeted fix |
| >60 | `investigate` | Callers/tests need consideration |
| no SHA / no content | `no_known_good` | Work from scratch |

**`renderRepairContextMarkdown(ctx)`** — slots a "## Known-good recovery context" section into the failure scanner's `spec_markdown` after the "Repair contract" block. Includes both file versions clearly labeled by SHA prefix + repair guidance per action.

**`services/gateway/src/routes/test-contracts-scheduled.ts`** —
- Calls `buildRepairContext` just before composing `spec_markdown` when `should_allocate_repair=true`
- On passing runs, stamps `test_contracts.last_passing_sha` + `branch_or_sha` from `getDeployedSha()` so the next failure has a real SHA to diff against

**`services/gateway/src/routes/test-contracts.ts`** — manual `/run` endpoint also stamps `last_passing_sha` on success (parity with scheduled-run).

**`services/gateway/src/services/self-healing-diagnosis-service.ts`** — exported `fetchFromGithub` and `getDeployedSha` (previously module-private). No behavior change in the existing diagnosis path.

## What this does NOT change

- No schema changes
- No frontend changes
- No new endpoints
- PR-L4 is a pure repair-quality improvement that plugs into PR-L3's existing allocation path

## Test plan

- [x] `test/test-contract-repair-context.test.ts` — 20/20 covering all 4 recommend-action paths, boundary cases (10/11, 60/61), absolute-value handling, fallback to ref=main, fetch error capture, 16 KB truncation, delta arithmetic, large-diff promotion, negative-delta rendering, markdown structure
- [x] Full self-healing + autonomy regression: 213/214 across 17 suites (1 skip is pre-existing)
- [x] `npm run build` clean
- [ ] **After merge + EXEC-DEPLOY**: a passing run will stamp `last_passing_sha` from BUILD_INFO. The NEXT failure of the same contract should embed both file versions + diff summary in the repair VTID's `autopilot_recommendations.spec_snapshot.spec_markdown`. Verify by inspecting a real repair VTID after a synthetic break.

🤖 Generated with [Claude Code](https://claude.com/claude-code)