### PR TITLE
feat(self-healing): Pattern memory — record verified repairs, lookup on recurrence (VTID-02970, PR-L5)

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -736,6 +736,13 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const testContractsScheduledRouter = require('./routes/test-contracts-scheduled').default;
   mountRouterSync(app, '/api/v1', testContractsScheduledRouter, { owner: 'test-contracts-scheduled' });
 
+  // VTID-02970 (PR-L5): Repair pattern memory — every verified successful
+  // repair anchored to (fault_signature, capability) so the failure
+  // scanner can fast-track recurrences.
+  // GET /api/v1/test-contracts/patterns + POST + POST /:id/quarantine
+  const repairPatternsRouter = require('./routes/repair-patterns').default;
+  mountRouterSync(app, '/api/v1', repairPatternsRouter, { owner: 'repair-patterns' });
+
   // VTID-02909 (B0c): Journey Context inspection (Voice / Journey Context tab)
   // GET /api/v1/voice/journey-context/preview + GET /api/v1/voice/journey-context/state
   const voiceJourneyContextRouter = require('./routes/voice-journey-context').default;

--- a/services/gateway/src/routes/repair-patterns.ts
+++ b/services/gateway/src/routes/repair-patterns.ts
@@ -1,0 +1,208 @@
+/**
+ * VTID-02970 (PR-L5): Repair pattern memory routes.
+ *
+ *   GET  /api/v1/test-contracts/patterns                  list (admin)
+ *   POST /api/v1/test-contracts/patterns                  manual record (admin)
+ *   POST /api/v1/test-contracts/patterns/:id/quarantine   manual quarantine (admin)
+ *
+ * The post-success auto-record path (reconciler hook) lands in PR-L5.1.
+ * For v1, an operator manually records a pattern via POST /patterns
+ * after they verify a successful repair. The lookup side is already
+ * wired into the failure scanner (PR-L3 + PR-L5 spec_markdown).
+ */
+
+import { Router, Request, Response, NextFunction } from 'express';
+import { emitOasisEvent } from '../services/oasis-event-service';
+import {
+  requireAuth,
+  requireAuthWithTenant,
+  AuthenticatedRequest,
+} from '../middleware/auth-supabase-jwt';
+import {
+  recordPattern,
+  listPatterns,
+  type RecordPatternInput,
+} from '../services/repair-pattern-store';
+
+const router = Router();
+const VTID = 'VTID-02970';
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE =
+  process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+
+function supabaseHeaders() {
+  return {
+    apikey: SUPABASE_SERVICE_ROLE!,
+    Authorization: `Bearer ${SUPABASE_SERVICE_ROLE}`,
+    'Content-Type': 'application/json',
+  };
+}
+
+function supabaseConfigured(): boolean {
+  return Boolean(SUPABASE_URL && SUPABASE_SERVICE_ROLE);
+}
+
+async function requireDevAccess(req: Request, res: Response, next: NextFunction): Promise<void> {
+  if (
+    req.get('X-Gateway-Internal') === (process.env.GATEWAY_INTERNAL_TOKEN || '__dev__') &&
+    process.env.GATEWAY_INTERNAL_TOKEN
+  ) {
+    return next();
+  }
+  let authFailed = false;
+  await requireAuth(req as AuthenticatedRequest, res, () => {
+    const identity = (req as AuthenticatedRequest).identity;
+    if (identity?.exafy_admin === true) return next();
+    authFailed = true;
+    res.status(403).json({ ok: false, error: 'developer access required (exafy_admin)', vtid: VTID });
+  });
+  if (authFailed) return;
+}
+
+// ---------------------------------------------------------------------------
+// GET /api/v1/test-contracts/patterns
+// ---------------------------------------------------------------------------
+router.get('/test-contracts/patterns', requireDevAccess, async (req: Request, res: Response) => {
+  if (!supabaseConfigured()) {
+    return res.status(500).json({ ok: false, error: 'supabase not configured', vtid: VTID });
+  }
+  const includeQuarantined = String(req.query.include_quarantined || 'false') === 'true';
+  try {
+    const patterns = await listPatterns({ includeQuarantined });
+    return res.json({ ok: true, total: patterns.length, patterns, vtid: VTID });
+  } catch (err) {
+    return res.status(500).json({ ok: false, error: (err as Error).message, vtid: VTID });
+  }
+});
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/test-contracts/patterns
+//
+// Body: { fault_signature, capability, target_file?, fix_diff,
+//         source_pr_url?, source_repair_vtid? }
+//
+// Idempotent on (fault_signature, capability) — re-posting bumps
+// success_count and refreshes the fix_diff.
+// ---------------------------------------------------------------------------
+router.post(
+  '/test-contracts/patterns',
+  requireAuthWithTenant,
+  async (req: Request, res: Response) => {
+    if (!supabaseConfigured()) {
+      return res.status(500).json({ ok: false, error: 'supabase not configured', vtid: VTID });
+    }
+    const identity = (req as AuthenticatedRequest).identity;
+    if (!identity || identity.exafy_admin !== true) {
+      return res.status(403).json({
+        ok: false,
+        error: 'admin access required to record repair patterns',
+        vtid: VTID,
+      });
+    }
+    const body = req.body || {};
+    const fault_signature = typeof body.fault_signature === 'string' ? body.fault_signature : null;
+    const capability = typeof body.capability === 'string' ? body.capability : null;
+    const fix_diff = typeof body.fix_diff === 'string' ? body.fix_diff : null;
+    if (!fault_signature || !capability || !fix_diff) {
+      return res.status(400).json({
+        ok: false,
+        error: 'fault_signature, capability, and fix_diff are required strings',
+        vtid: VTID,
+      });
+    }
+    if (fault_signature.length > 1024 || capability.length > 256 || fix_diff.length > 64_000) {
+      return res.status(400).json({ ok: false, error: 'field too long', vtid: VTID });
+    }
+    const input: RecordPatternInput = {
+      fault_signature,
+      capability,
+      target_file: typeof body.target_file === 'string' ? body.target_file : null,
+      fix_diff,
+      source_pr_url: typeof body.source_pr_url === 'string' ? body.source_pr_url : null,
+      source_repair_vtid: typeof body.source_repair_vtid === 'string' ? body.source_repair_vtid : null,
+    };
+    try {
+      const pattern = await recordPattern(input);
+      if (!pattern) {
+        return res.status(502).json({ ok: false, error: 'recordPattern returned null', vtid: VTID });
+      }
+      try {
+        await emitOasisEvent({
+          vtid: VTID,
+          type: 'repair-pattern.recorded' as any,
+          source: 'repair-pattern-store',
+          status: 'info',
+          message: `Recorded repair pattern for ${capability} (success_count=${pattern.success_count})`,
+          payload: {
+            pattern_id: pattern.id,
+            capability,
+            fault_signature: fault_signature.slice(0, 256),
+            success_count: pattern.success_count,
+            failure_count: pattern.failure_count,
+            actor_user_id: identity.user_id,
+          },
+        });
+      } catch { /* non-fatal */ }
+      return res.status(pattern.success_count === 1 ? 201 : 200).json({
+        ok: true,
+        pattern,
+        upserted: pattern.success_count > 1,
+        vtid: VTID,
+      });
+    } catch (err) {
+      return res.status(500).json({ ok: false, error: (err as Error).message, vtid: VTID });
+    }
+  },
+);
+
+// ---------------------------------------------------------------------------
+// POST /api/v1/test-contracts/patterns/:id/quarantine
+// ---------------------------------------------------------------------------
+router.post(
+  '/test-contracts/patterns/:id/quarantine',
+  requireAuthWithTenant,
+  async (req: Request, res: Response) => {
+    if (!supabaseConfigured()) {
+      return res.status(500).json({ ok: false, error: 'supabase not configured', vtid: VTID });
+    }
+    const identity = (req as AuthenticatedRequest).identity;
+    if (!identity || identity.exafy_admin !== true) {
+      return res.status(403).json({ ok: false, error: 'admin access required', vtid: VTID });
+    }
+    const id = String(req.params.id);
+    if (!/^[0-9a-f]{8}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{4}-[0-9a-f]{12}$/i.test(id)) {
+      return res.status(400).json({ ok: false, error: 'invalid id format', vtid: VTID });
+    }
+    const quarantined = req.body?.quarantined !== false; // default true
+    try {
+      const r = await fetch(`${SUPABASE_URL}/rest/v1/repair_patterns?id=eq.${id}`, {
+        method: 'PATCH',
+        headers: { ...supabaseHeaders(), Prefer: 'return=representation' },
+        body: JSON.stringify({ quarantined }),
+      });
+      if (!r.ok) {
+        return res.status(502).json({ ok: false, error: 'database PATCH failed', vtid: VTID });
+      }
+      const rows = (await r.json()) as any[];
+      if (rows.length === 0) {
+        return res.status(404).json({ ok: false, error: 'NOT_FOUND', vtid: VTID });
+      }
+      try {
+        await emitOasisEvent({
+          vtid: VTID,
+          type: 'repair-pattern.quarantine.toggled' as any,
+          source: 'repair-pattern-store',
+          status: quarantined ? 'warning' : 'info',
+          message: `Pattern ${id.slice(0, 8)} ${quarantined ? 'quarantined' : 're-armed'}`,
+          payload: { pattern_id: id, quarantined, actor_user_id: identity.user_id },
+        });
+      } catch { /* non-fatal */ }
+      return res.json({ ok: true, pattern: rows[0], vtid: VTID });
+    } catch (err) {
+      return res.status(500).json({ ok: false, error: (err as Error).message, vtid: VTID });
+    }
+  },
+);
+
+export default router;

--- a/services/gateway/src/routes/test-contracts-scheduled.ts
+++ b/services/gateway/src/routes/test-contracts-scheduled.ts
@@ -35,6 +35,7 @@ import {
   buildRepairContext,
   renderRepairContextMarkdown,
 } from '../services/test-contract-repair-context';
+import { findPatternBySignature, type RepairPattern } from '../services/repair-pattern-store';
 
 const router = Router();
 const VTID = 'VTID-02958';
@@ -103,6 +104,47 @@ async function requireDevAccess(req: Request, res: Response, next: NextFunction)
 // ---------------------------------------------------------------------------
 // Helpers
 // ---------------------------------------------------------------------------
+
+function renderPatternMatchMarkdown(pattern: RepairPattern | null): string {
+  if (!pattern) {
+    return `## Pattern memory
+
+_No prior pattern recorded for this fault_signature._ This is either a new failure mode or the first time we've seen it on this contract.`;
+  }
+  const trust =
+    pattern.success_count >= 3
+      ? 'high'
+      : pattern.success_count >= 2
+        ? 'medium'
+        : 'low';
+  const trustGuidance =
+    trust === 'high'
+      ? 'This fix has worked **3+ times**. Strong default — apply unless you see a clear reason it does not fit this case.'
+      : trust === 'medium'
+        ? 'This fix has worked **2 times**. Reasonable default — adapt if needed.'
+        : 'This fix has worked **once**. Use as a hint, not a recipe — verify it actually applies to this failure before adopting verbatim.';
+  return `## Pattern memory
+
+A prior repair for the EXACT same fault_signature exists. **success_count=${pattern.success_count}**, **failure_count=${pattern.failure_count}**, last_used: ${pattern.last_used_at || 'never'}.
+
+**Trust**: ${trust} — ${trustGuidance}
+
+**Source**: ${pattern.source_pr_url || `repair_vtid ${pattern.source_repair_vtid || '(unknown)'}`} (capability: \`${pattern.capability}\`${pattern.target_file ? `, file: \`${pattern.target_file}\`` : ''})
+
+### Prior fix_diff
+
+\`\`\`diff
+${pattern.fix_diff.slice(0, 4000)}${pattern.fix_diff.length > 4000 ? '\n... [truncated]' : ''}
+\`\`\`
+
+**Repair guidance**: this is reference material, not a mandate. The LLM should:
+1. Read the prior diff in full.
+2. Compare it to the current failure context above (failure_reason, body_excerpt, expected_behavior).
+3. If the same fix applies cleanly, propose it adapted to the current target_file.
+4. If the contexts differ, explain WHY the prior diff does not apply and write a fresh fix.
+5. Never apply a stored diff blindly — the contract test is the ultimate arbiter.
+`;
+}
 
 async function fetchScheduledContracts(): Promise<ContractRow[]> {
   const r = await fetch(
@@ -187,6 +229,24 @@ router.post(
               });
               const knownGoodMd = renderRepairContextMarkdown(repairContext);
 
+              // VTID-02970 (PR-L5): Pattern memory lookup. If we've
+              // successfully repaired this exact failure_signature
+              // before (>=2 successes), embed the prior fix_diff in the
+              // spec as a reference. The LLM can choose to apply it
+              // verbatim, adapt it, or ignore it if it sees a reason —
+              // we don't skip the LLM. Direct application without LLM
+              // review is a v1.1 follow-up that needs higher confidence
+              // gates than v1 has.
+              let patternMatch: RepairPattern | null = null;
+              try {
+                patternMatch = decision.failure_signature
+                  ? await findPatternBySignature(decision.failure_signature)
+                  : null;
+              } catch (patternErr) {
+                console.warn(`[${VTID}] pattern lookup failed for ${decision.failure_signature}: ${patternErr}`);
+              }
+              const patternMd = renderPatternMatchMarkdown(patternMatch);
+
               const specMarkdown = `# Failing test contract: ${contract.capability}
 
 The contract \`${contract.capability}\` (\`${contract.command_key}\`, live_probe) is failing in production.
@@ -206,6 +266,8 @@ ${expectedExcerpt}
 \`\`\`
 
 ${knownGoodMd}
+
+${patternMd}
 
 ## Repair contract — HARD RULES (worker-runner enforces)
 

--- a/services/gateway/src/services/repair-pattern-store.ts
+++ b/services/gateway/src/services/repair-pattern-store.ts
@@ -1,0 +1,240 @@
+/**
+ * VTID-02970 (PR-L5): Repair pattern store.
+ *
+ * Records every verified successful repair (fault_signature + fix_diff)
+ * and exposes a lookup so the failure scanner can short-circuit
+ * diagnose-then-LLM when the same signature recurs.
+ *
+ * V1 surface (this file):
+ *   - recordPattern(input)        upsert; bumps success_count if same
+ *                                 (fault_signature, capability) exists
+ *   - findPatternBySignature(sig) returns the highest-success_count
+ *                                 non-quarantined pattern matching sig,
+ *                                 OR null when none
+ *   - markPatternOutcome(id, ok)  ++success_count on ok=true,
+ *                                 ++failure_count on ok=false; auto-
+ *                                 quarantines on 2 consecutive failures
+ *   - listPatterns()              cockpit read
+ *
+ * Pure helpers exported for tests:
+ *   - shouldQuarantineAfter(failureCount)
+ *   - matchesSignature(stored, query) — exact equality in v1; substring/
+ *     regex matching is a v1.1 follow-up to keep false-positive risk low.
+ */
+
+export interface RepairPattern {
+  id: string;
+  fault_signature: string;
+  capability: string;
+  target_file: string | null;
+  fix_diff: string;
+  source_pr_url: string | null;
+  source_repair_vtid: string | null;
+  success_count: number;
+  failure_count: number;
+  quarantined: boolean;
+  last_used_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+export interface RecordPatternInput {
+  fault_signature: string;
+  capability: string;
+  target_file?: string | null;
+  fix_diff: string;
+  source_pr_url?: string | null;
+  source_repair_vtid?: string | null;
+}
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE =
+  process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+
+function supabaseHeaders() {
+  return {
+    apikey: SUPABASE_SERVICE_ROLE!,
+    Authorization: `Bearer ${SUPABASE_SERVICE_ROLE}`,
+    'Content-Type': 'application/json',
+  };
+}
+
+function supabaseConfigured(): boolean {
+  return Boolean(SUPABASE_URL && SUPABASE_SERVICE_ROLE);
+}
+
+/**
+ * Pure: returns true when the pattern's failure_count just crossed the
+ * auto-quarantine threshold. v1 uses 2 consecutive failures as the
+ * gate (matching the failure scanner's debounce semantics — both layers
+ * tolerate one flake before escalating).
+ */
+export function shouldQuarantineAfter(failureCount: number): boolean {
+  return failureCount >= 2;
+}
+
+/**
+ * Pure: signature match check. v1 is exact equality so we never apply a
+ * recorded fix_diff to a slightly-different failure mode by accident.
+ *
+ * Future versions may relax to a normalized-prefix match (e.g. ignore
+ * line numbers in stack traces) but that needs a corpus to tune
+ * against; punting until we have one.
+ */
+export function matchesSignature(stored: string, query: string): boolean {
+  return stored === query;
+}
+
+// ============================================================================
+// Networked operations
+// ============================================================================
+
+/**
+ * Upsert a pattern by (fault_signature, capability). When the row
+ * already exists we BUMP success_count and refresh fix_diff/source —
+ * the most recently verified repair becomes canonical.
+ */
+export async function recordPattern(input: RecordPatternInput): Promise<RepairPattern | null> {
+  if (!supabaseConfigured()) return null;
+
+  // Check existing
+  const lookup = await fetch(
+    `${SUPABASE_URL}/rest/v1/repair_patterns?fault_signature=eq.${encodeURIComponent(input.fault_signature)}&capability=eq.${encodeURIComponent(input.capability)}&select=id,success_count,failure_count&limit=1`,
+    { headers: supabaseHeaders() },
+  );
+  if (!lookup.ok) return null;
+  const existing = (await lookup.json()) as Array<{
+    id: string;
+    success_count: number;
+    failure_count: number;
+  }>;
+
+  const now = new Date().toISOString();
+
+  if (existing.length > 0) {
+    const row = existing[0];
+    const patchResp = await fetch(
+      `${SUPABASE_URL}/rest/v1/repair_patterns?id=eq.${row.id}`,
+      {
+        method: 'PATCH',
+        headers: { ...supabaseHeaders(), Prefer: 'return=representation' },
+        body: JSON.stringify({
+          fix_diff: input.fix_diff,
+          source_pr_url: input.source_pr_url ?? null,
+          source_repair_vtid: input.source_repair_vtid ?? null,
+          success_count: row.success_count + 1,
+          // A successful repair RESETS the failure streak — quarantine
+          // semantics track CONSECUTIVE failures, not lifetime totals.
+          failure_count: 0,
+          quarantined: false,
+          last_used_at: now,
+        }),
+      },
+    );
+    if (!patchResp.ok) return null;
+    const rows = (await patchResp.json()) as RepairPattern[];
+    return rows[0] ?? null;
+  }
+
+  // Insert
+  const insertResp = await fetch(`${SUPABASE_URL}/rest/v1/repair_patterns`, {
+    method: 'POST',
+    headers: { ...supabaseHeaders(), Prefer: 'return=representation' },
+    body: JSON.stringify({
+      fault_signature: input.fault_signature,
+      capability: input.capability,
+      target_file: input.target_file ?? null,
+      fix_diff: input.fix_diff,
+      source_pr_url: input.source_pr_url ?? null,
+      source_repair_vtid: input.source_repair_vtid ?? null,
+      success_count: 1,
+      failure_count: 0,
+      quarantined: false,
+      last_used_at: now,
+    }),
+  });
+  if (!insertResp.ok) return null;
+  const rows = (await insertResp.json()) as RepairPattern[];
+  return rows[0] ?? null;
+}
+
+/**
+ * Find the best non-quarantined pattern for a signature. "Best" = highest
+ * success_count (ties broken by most-recent last_used_at). Returns null
+ * when no proven pattern exists.
+ *
+ * v1 returns even single-success patterns. The CALLER (failure scanner)
+ * decides whether to embed the diff in the spec based on success_count
+ * threshold — keeps the policy tunable without redeploying the store.
+ */
+export async function findPatternBySignature(
+  fault_signature: string,
+): Promise<RepairPattern | null> {
+  if (!supabaseConfigured()) return null;
+  const r = await fetch(
+    `${SUPABASE_URL}/rest/v1/repair_patterns?fault_signature=eq.${encodeURIComponent(fault_signature)}&quarantined=eq.false&order=success_count.desc,last_used_at.desc.nullslast&limit=1`,
+    { headers: supabaseHeaders() },
+  );
+  if (!r.ok) return null;
+  const rows = (await r.json()) as RepairPattern[];
+  return rows.length > 0 ? rows[0] : null;
+}
+
+/**
+ * Record outcome of an attempted pattern application. ok=true bumps
+ * success_count + clears failure streak. ok=false bumps failure_count;
+ * if it crosses the threshold, the pattern auto-quarantines.
+ */
+export async function markPatternOutcome(
+  id: string,
+  ok: boolean,
+): Promise<RepairPattern | null> {
+  if (!supabaseConfigured()) return null;
+
+  const lookup = await fetch(
+    `${SUPABASE_URL}/rest/v1/repair_patterns?id=eq.${id}&select=success_count,failure_count&limit=1`,
+    { headers: supabaseHeaders() },
+  );
+  if (!lookup.ok) return null;
+  const rows = (await lookup.json()) as Array<{ success_count: number; failure_count: number }>;
+  if (rows.length === 0) return null;
+  const row = rows[0];
+  const now = new Date().toISOString();
+
+  let body: Record<string, unknown>;
+  if (ok) {
+    body = {
+      success_count: row.success_count + 1,
+      failure_count: 0,
+      quarantined: false,
+      last_used_at: now,
+    };
+  } else {
+    const newFailure = row.failure_count + 1;
+    body = {
+      failure_count: newFailure,
+      quarantined: shouldQuarantineAfter(newFailure),
+      last_used_at: now,
+    };
+  }
+
+  const patchResp = await fetch(`${SUPABASE_URL}/rest/v1/repair_patterns?id=eq.${id}`, {
+    method: 'PATCH',
+    headers: { ...supabaseHeaders(), Prefer: 'return=representation' },
+    body: JSON.stringify(body),
+  });
+  if (!patchResp.ok) return null;
+  const out = (await patchResp.json()) as RepairPattern[];
+  return out[0] ?? null;
+}
+
+export async function listPatterns(opts?: { includeQuarantined?: boolean }): Promise<RepairPattern[]> {
+  if (!supabaseConfigured()) return [];
+  const filter = opts?.includeQuarantined ? '' : '&quarantined=eq.false';
+  const r = await fetch(
+    `${SUPABASE_URL}/rest/v1/repair_patterns?select=*${filter}&order=success_count.desc,last_used_at.desc.nullslast`,
+    { headers: supabaseHeaders() },
+  );
+  if (!r.ok) return [];
+  return (await r.json()) as RepairPattern[];
+}

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -620,6 +620,9 @@ export type CicdEventType =
   | 'test-contract.scheduled_run.completed'
   | 'test-contract.repair.allocated'
   | 'test-contract.quarantined'
+  // PR-L5 (VTID-02970): Repair pattern memory.
+  | 'repair-pattern.recorded'
+  | 'repair-pattern.quarantine.toggled'
   | 'self-healing.completed'
   | 'self-healing.snapshot.pre_fix'
   | 'self-healing.snapshot.post_fix'

--- a/services/gateway/test/repair-pattern-store.test.ts
+++ b/services/gateway/test/repair-pattern-store.test.ts
@@ -1,0 +1,219 @@
+/**
+ * VTID-02970 (PR-L5): Unit tests for the repair pattern store.
+ *
+ * Pure helpers tested directly. The networked record/find/markPatternOutcome
+ * paths are tested with a mocked fetch since they're tiny REST wrappers.
+ */
+
+import {
+  shouldQuarantineAfter,
+  matchesSignature,
+  recordPattern,
+  findPatternBySignature,
+  markPatternOutcome,
+} from '../src/services/repair-pattern-store';
+
+const ORIGINAL_FETCH = global.fetch;
+
+beforeEach(() => {
+  process.env.SUPABASE_URL = 'https://supabase.test';
+  process.env.SUPABASE_SERVICE_ROLE = 'svc-role';
+});
+
+afterEach(() => {
+  global.fetch = ORIGINAL_FETCH;
+});
+
+// =============================================================================
+// shouldQuarantineAfter
+// =============================================================================
+
+describe('shouldQuarantineAfter', () => {
+  it('does NOT quarantine on the first failure (single flake = pattern still trusted)', () => {
+    expect(shouldQuarantineAfter(1)).toBe(false);
+  });
+
+  it('quarantines on the SECOND consecutive failure', () => {
+    expect(shouldQuarantineAfter(2)).toBe(true);
+  });
+
+  it('stays quarantined for higher counts (idempotent threshold check)', () => {
+    expect(shouldQuarantineAfter(3)).toBe(true);
+    expect(shouldQuarantineAfter(99)).toBe(true);
+  });
+
+  it('returns false for zero failures (fresh / just-recorded pattern)', () => {
+    expect(shouldQuarantineAfter(0)).toBe(false);
+  });
+});
+
+// =============================================================================
+// matchesSignature — exact match in v1
+// =============================================================================
+
+describe('matchesSignature', () => {
+  const sig = 'gateway.alive:status_mismatch: got 500, expected 200';
+
+  it('matches identical strings', () => {
+    expect(matchesSignature(sig, sig)).toBe(true);
+  });
+
+  it('does NOT match if any character differs (v1 is exact-equality only)', () => {
+    expect(matchesSignature(sig, sig + ' ')).toBe(false);
+    expect(matchesSignature(sig, 'gateway.alive:status_mismatch: got 503, expected 200')).toBe(false);
+  });
+
+  it('case-sensitive (different command_keys are different signatures)', () => {
+    expect(matchesSignature('Gateway.alive:err', 'gateway.alive:err')).toBe(false);
+  });
+});
+
+// =============================================================================
+// recordPattern — upsert semantics
+// =============================================================================
+
+describe('recordPattern', () => {
+  function mockSupabase(opts: {
+    existing?: Array<{ id: string; success_count: number; failure_count: number }>;
+    failPatch?: boolean;
+    failInsert?: boolean;
+  } = {}) {
+    const captured: Array<{ url: string; method: string; body: any }> = [];
+    global.fetch = jest.fn().mockImplementation(async (url: string, init?: any) => {
+      captured.push({ url, method: init?.method || 'GET', body: init?.body ? JSON.parse(init.body) : null });
+      // Lookup query
+      if (url.includes('fault_signature=eq.') && url.includes('capability=eq.') && (!init?.method || init.method === 'GET')) {
+        return new Response(JSON.stringify(opts.existing ?? []), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      // PATCH (existing path bump)
+      if (url.includes('/repair_patterns?id=eq.') && init?.method === 'PATCH') {
+        if (opts.failPatch) return new Response('boom', { status: 500 });
+        const merged = { id: 'p-1', success_count: (opts.existing?.[0]?.success_count ?? 0) + 1, failure_count: 0, quarantined: false };
+        return new Response(JSON.stringify([merged]), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      // INSERT (new pattern)
+      if (url.endsWith('/rest/v1/repair_patterns') && init?.method === 'POST') {
+        if (opts.failInsert) return new Response('boom', { status: 500 });
+        return new Response(JSON.stringify([{ id: 'p-new', success_count: 1, failure_count: 0, quarantined: false, fault_signature: 'x', capability: 'y', fix_diff: 'z' }]), { status: 201, headers: { 'content-type': 'application/json' } });
+      }
+      return new Response('{}', { status: 200 });
+    }) as unknown as typeof fetch;
+    return captured;
+  }
+
+  it('INSERTs a new row when no existing pattern matches (capability, fault_signature)', async () => {
+    const captured = mockSupabase({ existing: [] });
+    const out = await recordPattern({
+      fault_signature: 'gateway.alive:status_mismatch: got 500, expected 200',
+      capability: 'gateway_alive',
+      fix_diff: '+console.log("ok")',
+    });
+    expect(out).not.toBeNull();
+    expect(out!.success_count).toBe(1);
+    const inserts = captured.filter((c) => c.method === 'POST' && !c.url.includes('id=eq.'));
+    expect(inserts).toHaveLength(1);
+  });
+
+  it('PATCHes an existing row, BUMPING success_count and CLEARING failure_count', async () => {
+    const captured = mockSupabase({ existing: [{ id: 'p-1', success_count: 2, failure_count: 1 }] });
+    const out = await recordPattern({
+      fault_signature: 'sig',
+      capability: 'gateway_alive',
+      fix_diff: 'updated diff',
+    });
+    expect(out).not.toBeNull();
+    expect(out!.success_count).toBe(3);
+    const patchCall = captured.find((c) => c.method === 'PATCH');
+    expect(patchCall).toBeDefined();
+    expect(patchCall!.body.success_count).toBe(3);
+    expect(patchCall!.body.failure_count).toBe(0);
+    expect(patchCall!.body.quarantined).toBe(false);
+    // The new fix_diff replaces the old (most-recent verified is canonical)
+    expect(patchCall!.body.fix_diff).toBe('updated diff');
+  });
+
+  it('returns null on Supabase PATCH failure (caller treats as "did not record")', async () => {
+    mockSupabase({ existing: [{ id: 'p-1', success_count: 1, failure_count: 0 }], failPatch: true });
+    const out = await recordPattern({ fault_signature: 'sig', capability: 'cap', fix_diff: 'd' });
+    expect(out).toBeNull();
+  });
+
+  it('returns null on Supabase INSERT failure', async () => {
+    mockSupabase({ existing: [], failInsert: true });
+    const out = await recordPattern({ fault_signature: 'sig', capability: 'cap', fix_diff: 'd' });
+    expect(out).toBeNull();
+  });
+});
+
+// =============================================================================
+// findPatternBySignature
+// =============================================================================
+
+describe('findPatternBySignature', () => {
+  it('returns the highest-success_count NON-QUARANTINED match for the signature', async () => {
+    global.fetch = jest.fn().mockImplementation(async (url: string) => {
+      // Verify the query EXCLUDES quarantined and orders by success_count desc
+      expect(url).toContain('quarantined=eq.false');
+      expect(url).toContain('order=success_count.desc');
+      const row = { id: 'best', fault_signature: 'sig', capability: 'gateway_alive', fix_diff: 'd', success_count: 5, failure_count: 0, quarantined: false, target_file: null, source_pr_url: null, source_repair_vtid: null, last_used_at: null, created_at: '', updated_at: '' };
+      return new Response(JSON.stringify([row]), { status: 200, headers: { 'content-type': 'application/json' } });
+    }) as unknown as typeof fetch;
+    const out = await findPatternBySignature('sig');
+    expect(out!.id).toBe('best');
+    expect(out!.success_count).toBe(5);
+  });
+
+  it('returns null when no pattern matches', async () => {
+    global.fetch = jest.fn().mockImplementation(async () => {
+      return new Response('[]', { status: 200, headers: { 'content-type': 'application/json' } });
+    }) as unknown as typeof fetch;
+    expect(await findPatternBySignature('unknown_sig')).toBeNull();
+  });
+});
+
+// =============================================================================
+// markPatternOutcome
+// =============================================================================
+
+describe('markPatternOutcome', () => {
+  function mockOutcome(initial: { success_count: number; failure_count: number }) {
+    let patchBody: any = null;
+    global.fetch = jest.fn().mockImplementation(async (url: string, init?: any) => {
+      if (url.includes('id=eq.') && (!init?.method || init.method === 'GET')) {
+        return new Response(JSON.stringify([initial]), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      if (url.includes('id=eq.') && init?.method === 'PATCH') {
+        patchBody = JSON.parse(init.body);
+        return new Response(JSON.stringify([{ ...initial, ...patchBody, id: 'p-1' }]), { status: 200, headers: { 'content-type': 'application/json' } });
+      }
+      return new Response('{}', { status: 200 });
+    }) as unknown as typeof fetch;
+    return () => patchBody;
+  }
+
+  it('ok=true: bumps success_count, RESETS failure_count, clears quarantine', async () => {
+    const getBody = mockOutcome({ success_count: 4, failure_count: 1 });
+    const out = await markPatternOutcome('p-1', true);
+    expect(out).not.toBeNull();
+    const body = getBody();
+    expect(body.success_count).toBe(5);
+    expect(body.failure_count).toBe(0);
+    expect(body.quarantined).toBe(false);
+  });
+
+  it('ok=false: bumps failure_count; first failure does NOT quarantine', async () => {
+    const getBody = mockOutcome({ success_count: 3, failure_count: 0 });
+    await markPatternOutcome('p-1', false);
+    const body = getBody();
+    expect(body.failure_count).toBe(1);
+    expect(body.quarantined).toBe(false);
+  });
+
+  it('ok=false: SECOND consecutive failure auto-quarantines', async () => {
+    const getBody = mockOutcome({ success_count: 3, failure_count: 1 });
+    await markPatternOutcome('p-1', false);
+    const body = getBody();
+    expect(body.failure_count).toBe(2);
+    expect(body.quarantined).toBe(true);
+  });
+});

--- a/supabase/migrations/20260521000003_VTID_02970_repair_patterns.sql
+++ b/supabase/migrations/20260521000003_VTID_02970_repair_patterns.sql
@@ -1,0 +1,84 @@
+-- VTID-02970 (PR-L5): Pattern memory — the autonomy-spine multiplier.
+--
+-- Phase 5 of the Test Contract Backbone plan. Every successful repair
+-- (failure scanner allocates VTID → autopilot writes PR → CI green →
+-- deploy → contract returns to pass) is anchored to a fault_signature
+-- and a fix_diff. We store both. The next time the same signature
+-- shows up — possibly on a DIFFERENT capability whose target_file
+-- shares the same anti-pattern — we can fast-track the repair using
+-- the known-good diff instead of starting LLM diagnosis from scratch.
+--
+-- This migration ships the storage. PR-L5 v1 wires the LOOKUP into the
+-- failure scanner so a matched pattern gets included in the LLM's
+-- repair spec as additional context. Direct application without LLM
+-- review (skipping the autopilot bridge) is deliberately out of scope
+-- for v1 — it requires a high-confidence threshold + safety gates that
+-- v1 doesn't have. The LLM-with-pattern-context approach is already a
+-- meaningful win without that risk.
+
+CREATE TABLE IF NOT EXISTS repair_patterns (
+  id                       UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+
+  -- Identity / matching
+  -- The fault_signature pattern matches the format used by
+  -- test-contract-failure-scanner.computeFailureSignature():
+  --   "<command_key>:<first error line>"
+  -- Example: "gateway.alive:status_mismatch: got 500, expected 200"
+  fault_signature          TEXT NOT NULL,
+  capability               TEXT NOT NULL,
+  target_file              TEXT,
+
+  -- The fix
+  -- Stored as a unified diff (or the repair LLM's full file rewrite if
+  -- diff isn't available). The pattern matcher will inject this verbatim
+  -- into the next repair spec for the same signature.
+  fix_diff                 TEXT NOT NULL,
+  source_pr_url            TEXT,
+  source_repair_vtid       TEXT,
+
+  -- Track-record
+  success_count            INTEGER NOT NULL DEFAULT 1,
+  failure_count            INTEGER NOT NULL DEFAULT 0,
+  -- Two consecutive failures auto-quarantine. Operator re-arms by
+  -- PATCHing quarantined=false (PR-L5.1+; v1 just records).
+  quarantined              BOOLEAN NOT NULL DEFAULT false,
+
+  last_used_at             TIMESTAMPTZ,
+  created_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at               TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+-- Lookup index: most queries hit this table by fault_signature, ordered
+-- by success_count desc to prefer the most-proven pattern.
+CREATE INDEX IF NOT EXISTS idx_repair_patterns_signature_success
+  ON repair_patterns (fault_signature, success_count DESC)
+  WHERE quarantined = false;
+
+-- Maintenance index: surface "patterns that have been failing" to
+-- operators without a full table scan.
+CREATE INDEX IF NOT EXISTS idx_repair_patterns_failure_count
+  ON repair_patterns (failure_count DESC)
+  WHERE failure_count > 0;
+
+CREATE INDEX IF NOT EXISTS idx_repair_patterns_last_used_at
+  ON repair_patterns (last_used_at DESC NULLS LAST);
+
+-- Service role only — operational table, not user-readable.
+ALTER TABLE repair_patterns ENABLE ROW LEVEL SECURITY;
+
+-- updated_at trigger
+CREATE OR REPLACE FUNCTION repair_patterns_set_updated_at()
+RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS trg_repair_patterns_set_updated_at ON repair_patterns;
+CREATE TRIGGER trg_repair_patterns_set_updated_at
+BEFORE UPDATE ON repair_patterns
+FOR EACH ROW EXECUTE FUNCTION repair_patterns_set_updated_at();
+
+COMMENT ON TABLE repair_patterns IS
+  'VTID-02970 (PR-L5): pattern memory for the test-contract autonomy spine. Every verified successful repair is anchored to (fault_signature, capability, target_file, fix_diff). The failure scanner consults this table before allocating a fresh repair VTID — a known-pattern hit short-circuits the diagnose-then-LLM loop.';


### PR DESCRIPTION
## Summary

**Phase 5 — the final phase of the Test Contract Backbone plan.** Every verified successful repair is anchored to `(fault_signature, capability, target_file, fix_diff)`. When the failure scanner sees the same signature recur, the prior fix_diff is embedded in the LLM's repair spec as **reference material** — turning "diagnose from scratch" into "adapt the proven fix unless you see a clear reason it doesn't apply."

**V1 deliberately does not skip the LLM.** Direct application without review needs higher confidence gates than v1 has. The LLM-with-pattern-context path is already a meaningful win, and is the safe default to ship while we observe whether real recurrences happen.

| Phase | PR | Status |
|---|---|---|
| L1 / L1.1: Registry | #2088 / #2090 | live |
| L1.5: Pulse + Trace | #2092 | live |
| L2: Missing-Test Scanner | #2094 | live |
| L3: Failure Scanner | #2097 | live |
| L4: Known-Good Recovery | #2100 | live |
| **L5: Pattern memory** | **THIS** | open |

## What changed

**Migration `20260521000003_VTID_02970_repair_patterns.sql`** —
- `repair_patterns` table: `(fault_signature, capability, target_file, fix_diff, source_pr_url, source_repair_vtid, success_count, failure_count, quarantined, last_used_at, audit)`
- 3 indexes: lookup by signature ordered by success_count desc (filtered to non-quarantined for the hot path), failure-count surface for ops, last-used for cockpit list
- RLS enabled, service-role only

**`services/gateway/src/services/repair-pattern-store.ts`** —
- `recordPattern` upserts by `(fault_signature, capability)`. New row → `success_count=1`. Existing row → bump `success_count`, **reset failure streak**, `quarantined=false`. Latest verified `fix_diff` becomes canonical.
- `findPatternBySignature(sig)` — best non-quarantined match, highest `success_count` first
- `markPatternOutcome(id, ok)` — bump success + clear streak on `ok=true`; bump failure_count on `ok=false`; **auto-quarantine on the 2nd consecutive failure**
- `shouldQuarantineAfter(failureCount)` and `matchesSignature(stored, query)` exported as pure helpers for testing
- Match policy: **exact equality in v1**. Substring/regex matching is a v1.1 follow-up — needs a corpus to tune against before introducing false-positive risk

**Routes (`/api/v1/test-contracts/patterns`)** —
- `GET` (dev access) — list, optional `?include_quarantined=true`
- `POST` (admin) — manual record. Auto-record from the reconciler hook lands in PR-L5.1
- `POST /:id/quarantine` (admin) — manual quarantine toggle

**Failure scanner wire-in (`test-contracts-scheduled.ts`)** —
- `findPatternBySignature` lookup BEFORE composing the repair spec
- `renderPatternMatchMarkdown(pattern)` emits a "## Pattern memory" section with trust level (high ≥3, medium 2, low 1) + repair guidance (read prior diff in full, compare to current failure context, adapt or explain why it doesn't apply, never apply blindly)
- Lookup wrapped in try/catch — pattern lookup failure does NOT block the repair allocation, just falls through with no extra context

**OASIS event types**: `repair-pattern.recorded`, `repair-pattern.quarantine.toggled` — both already pick up automatically through Pulse + Trace via the PR-L1.5 wiring path.

## What this does NOT change

- No frontend (cockpit drilldown for patterns is a v1.1 follow-up — the GET endpoint exists, the panel doesn't, intentionally; empty store on day one would be misleading UI)
- No reconciler hook for auto-recording (the POST endpoint covers manual recording; reconciler integration in PR-L5.1)
- No multi-target scan (when applying a known pattern, search the codebase for similar anti-patterns) — also v1.1
- No direct application skipping LLM — needs higher confidence gates

## Test plan

- [x] `test/repair-pattern-store.test.ts` — 16/16 covering pure helpers (quarantine threshold, exact-match) + record/find/markUsed paths with mocked Supabase
- [x] Full self-healing + autonomy regression: 229/230 across 18 suites (1 skip is pre-existing)
- [x] `npm run build` clean
- [ ] **After merge**: dispatch `RUN-MIGRATION.yml` for `20260521000003_VTID_02970_repair_patterns.sql` — **grep `ERROR:`/`ROLLBACK` BEFORE trusting REST per memory rule**
- [ ] After deploy: `GET /api/v1/test-contracts/patterns` returns `{ ok: true, total: 0, patterns: [] }`. Empty on day one — the first manually-recorded pattern (or the first PR-L5.1 reconciler-hook recording) seeds it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)