### PR TITLE
feat(orb): A8.3b.1 — connectToLiveAPI uses VertexLiveClient via UpstreamLiveClient boundary (VTID-02971)

### DIFF
--- a/services/gateway/src/orb/live/upstream/types.ts
+++ b/services/gateway/src/orb/live/upstream/types.ts
@@ -79,6 +79,25 @@ export interface UpstreamConnectOptions {
    * for API keys / JWTs.
    */
   getAccessToken: () => Promise<string>;
+
+  /**
+   * A8.3b.1 (VTID-02971) — optional custom setup-message builder. When set,
+   * the implementation calls this inside `ws.on('open')` (awaiting the
+   * returned promise) and sends the produced envelope INSTEAD OF the
+   * default `buildSetupMessage(options)` envelope.
+   *
+   * Used by orb-live.ts's `connectToLiveAPI` adapter to produce the legacy
+   * orb-specific setup envelope (persona swap, tools, transcription
+   * config, system instruction overrides) without VertexLiveClient
+   * needing to know any of that surface area.
+   *
+   * The builder can be sync or async. The handshake-completion gate is
+   * still the upstream `setup_complete` reply, regardless of envelope
+   * shape.
+   */
+  customSetupMessage?: () =>
+    | Record<string, unknown>
+    | Promise<Record<string, unknown>>;
 }
 
 /**

--- a/services/gateway/src/orb/live/upstream/vertex-live-client.ts
+++ b/services/gateway/src/orb/live/upstream/vertex-live-client.ts
@@ -104,6 +104,24 @@ export class VertexLiveClient implements UpstreamLiveClient {
     return this.state;
   }
 
+  /**
+   * A8.3b.1 (VTID-02971) — accessor for the underlying raw WebSocket.
+   *
+   * Returns `null` before `connect()` has been called, the raw socket
+   * after construction. Used by the orb-live.ts adapter to register
+   * additional ws-level handlers (error / close / message) so the
+   * existing connectToLiveAPI consumers keep getting back a
+   * `Promise<WebSocket>` with all legacy lifecycle callbacks attached.
+   *
+   * Cast through `unknown` because internally the mock test path uses
+   * `VertexWebSocketLike` while production uses the real `ws.WebSocket`
+   * instance — both satisfy the runtime shape callers depend on
+   * (`readyState`, `send`, `close`, `on`).
+   */
+  getSocket(): WebSocket | null {
+    return this.ws as unknown as WebSocket | null;
+  }
+
   onAudioOutput(handler: (event: AudioOutputEvent) => void): void {
     this.audioOutputHandler = handler;
   }
@@ -167,9 +185,19 @@ export class VertexLiveClient implements UpstreamLiveClient {
         reject(new Error('Live API connection timeout'));
       }, timeoutMs);
 
-      ws.on('open', () => {
+      ws.on('open', async () => {
         try {
-          ws.send(JSON.stringify(buildSetupMessage(options)));
+          // A8.3b.1 (VTID-02971): if the caller provided a custom setup-
+          // message builder (e.g. orb-live.ts's persona-aware envelope),
+          // await it and send that envelope instead of the default
+          // buildSetupMessage(options). Sync builders return the envelope
+          // directly; async builders are awaited (used by the orb
+          // adapter to wait for the context-build promise before
+          // shaping the system instruction).
+          const envelope = options.customSetupMessage
+            ? await Promise.resolve(options.customSetupMessage())
+            : buildSetupMessage(options);
+          ws.send(JSON.stringify(envelope));
         } catch (err) {
           if (settled) return;
           settled = true;

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1157,6 +1157,13 @@ import {
 // / resolve) via onSetupComplete + isSetupComplete callbacks, and forwards
 // every orb-live.ts-local helper through the deps bag.
 import { createUpstreamLiveMessageHandler } from '../orb/live/session/upstream-message-handler';
+// A8.3b.1 (VTID-02971): connectToLiveAPI now uses the A7 UpstreamLiveClient
+// boundary via VertexLiveClient. The orb-specific persona/tools/context
+// envelope is supplied through the new `customSetupMessage` option so the
+// payload remains byte-for-byte identical to the pre-A8.3b.1 path.
+// A8.3b.2 will rename / remove this adapter; for now it remains the active
+// call path so frontends + transparent reconnect see no behavior change.
+import { VertexLiveClient } from '../orb/live/upstream/vertex-live-client';
 // A3 (orb-live-refactor): system instruction builder + its private helpers
 // (describeTimeSince, describeRoute, buildTemporalJourneyContextSection,
 // TemporalBucket type) lifted to orb/live/instruction/live-system-instruction.ts.
@@ -5538,27 +5545,32 @@ async function connectToLiveAPI(
   console.log(`[VTID-01219] Using model: ${VERTEX_LIVE_MODEL}`);
   console.log(`[VTID-01219] Project: ${VERTEX_PROJECT_ID}, Location: ${VERTEX_LOCATION}`);
 
-  return new Promise((resolve, reject) => {
-    // VTID-01222: Connect WITHOUT subprotocol - Google's official examples don't use one
-    // Only Authorization header is required per documentation
-    const ws = new WebSocket(wsUrl, {
-      headers: {
-        'Authorization': `Bearer ${accessToken}`,
-        'Content-Type': 'application/json'
-      }
-    });
+  // A8.3b.1 (VTID-02971): the WS lifecycle now flows through the A7
+  // UpstreamLiveClient boundary via VertexLiveClient. The orb-specific
+  // persona/tools/context envelope is supplied via `customSetupMessage`
+  // so the wire payload remains byte-for-byte identical to the pre-A8.3b.1
+  // path. Error/close handlers continue to register on the raw socket
+  // returned by `vertex.getSocket()`, preserving the transparent-reconnect
+  // path and all VTID-02637 connection-issue dedupe behavior.
+  return new Promise<WebSocket>(async (resolve, reject) => {
+    const vertex = new VertexLiveClient();
 
     let setupComplete = false;
     const connectionTimeout = setTimeout(() => {
       if (!setupComplete) {
         console.error(`[VTID-01219] Live API connection timeout for session ${session.sessionId}`);
-        ws.close();
+        vertex.close().catch(() => { /* swallow */ });
         reject(new Error('Live API connection timeout'));
       }
     }, 15000); // 15 second timeout
 
-    // Connection opened - send setup message
-    ws.on('open', async () => {
+    // Build the orb-specific Vertex setup envelope. Identical body to the
+    // pre-A8.3b.1 ws.on('open') handler — returns the {setup: {...}}
+    // envelope object instead of calling ws.send() directly.
+    // VertexLiveClient awaits this builder and sends the envelope inside
+    // its own ws.on('open'), then resolves connect() when setup_complete
+    // arrives.
+    const buildOrbVertexSetupEnvelope = async (): Promise<Record<string, unknown>> => {
       console.log(`[VTID-01219] Live API WebSocket connected for session ${session.sessionId}`);
 
       // BOOTSTRAP-ORB-CRITICAL-PATH: If /live/session/start kicked off a
@@ -5760,24 +5772,71 @@ async function connectToLiveAPI(
       console.log(`[VTID-01219] Sending setup message:`, setupPreview);
       console.log(`[VTID-01224] Setup includes: tools=${session.identity ? 3 : 0}, contextChars=${session.contextInstruction?.length || 0}`);
       console.log(`[VTID-RESPONSE-DELAY] VAD silence_duration_ms=${session.vadSilenceMs}`);
-      ws.send(JSON.stringify(setupMessage));
-      console.log(`[VTID-01219] Setup message sent for session ${session.sessionId}`);
-    });
+      console.log(`[VTID-01219] Setup envelope built for session ${session.sessionId} — VertexLiveClient will send`);
+      return setupMessage as unknown as Record<string, unknown>;
+    };
 
-    // A8.3a.1 (VTID-02965): The upstream message dispatcher is now a NAMED
-    // A8.3a.2 (VTID-02968): the named function body lifted to
-    // orb/live/session/upstream-message-handler.ts. Factory binds the
-    // Promise-closure state (setupComplete / connectionTimeout / resolve /
-    // reject) via onSetupComplete + isSetupComplete callbacks, and
-    // forwards every orb-live.ts-local helper through the deps bag.
+    // A8.3b.1 (VTID-02971): open the upstream connection through the A7
+    // UpstreamLiveClient boundary. `vertex.connect()` performs the auth
+    // header attach, the ws.on('open') handshake, awaits our custom
+    // envelope builder, sends the envelope, and resolves on setup_complete.
+    // After it resolves, the raw ws is available via `vertex.getSocket()`
+    // so the legacy message + error + close handlers attach as before.
+    let ws: WebSocket;
+    try {
+      await vertex.connect({
+        model: VERTEX_LIVE_MODEL,
+        projectId: VERTEX_PROJECT_ID,
+        location: VERTEX_LOCATION,
+        // The next four fields are overridden by `customSetupMessage`.
+        // VertexLiveClient's default `buildSetupMessage` is not used.
+        voiceName: 'overridden',
+        responseModalities: session.responseModalities.includes('audio') ? ['audio'] : ['text'],
+        vadSilenceMs: session.vadSilenceMs,
+        systemInstruction: 'overridden',
+        // Reuse the already-fetched OAuth token for this connect; the
+        // builder type expects a `() => Promise<string>` shape.
+        getAccessToken: async () => accessToken,
+        connectTimeoutMs: 15000,
+        customSetupMessage: buildOrbVertexSetupEnvelope,
+      });
+    } catch (err) {
+      clearTimeout(connectionTimeout);
+      reject(err as Error);
+      return;
+    }
+
+    // setup_complete arrived → connect() resolved. Mark the legacy flag
+    // (preserves any code-path that reads `setupComplete`) and clear the
+    // outer connection timeout. The connect Promise is the source of
+    // truth from here on.
+    setupComplete = true;
+    clearTimeout(connectionTimeout);
+
+    const socket = vertex.getSocket();
+    if (!socket) {
+      reject(new Error('VertexLiveClient.getSocket() returned null after connect()'));
+      return;
+    }
+    ws = socket;
+
+    // A8.3a.2 (VTID-02968): the upstream message handler lives in
+    // orb/live/session/upstream-message-handler.ts. After A8.3b.1 the
+    // setup_complete branch inside it is unreachable (VertexLiveClient
+    // consumed that frame), but the handler still owns every
+    // post-setup dispatch (audio, transcripts, tool calls, turn-complete,
+    // interrupted, ANON-NUDGE, identity intercept, NAV directive, chat
+    // bridge — see the handler file for the full list).
     const handleUpstreamLiveMessage = createUpstreamLiveMessageHandler({
       session,
       ws,
       callbacks: { onAudioResponse, onTextResponse, onError, onTurnComplete, onInterrupted },
+      // setup_complete is consumed by VertexLiveClient now; this hook is a
+      // no-op for the Vertex path but stays wired so the handler keeps
+      // working unchanged if a future provider needs caller-side
+      // handshake plumbing.
       onSetupComplete: () => {
-        setupComplete = true;
-        clearTimeout(connectionTimeout);
-        resolve(ws);
+        /* no-op: VertexLiveClient already resolved connect() */
       },
       isSetupComplete: () => setupComplete,
       deps: {
@@ -6017,6 +6076,11 @@ async function connectToLiveAPI(
         }
       }
     });
+
+    // A8.3b.1: resolve the outer Promise — connect() already settled when
+    // setup_complete arrived, and the message/error/close handlers are
+    // wired up. Legacy consumers expect Promise<WebSocket>.
+    resolve(ws);
   });
 }
 

--- a/services/gateway/test/orb/live/characterization/upstream-message-handler.characterization.test.ts
+++ b/services/gateway/test/orb/live/characterization/upstream-message-handler.characterization.test.ts
@@ -137,16 +137,40 @@ describe('A8.3a.2: orb-live.ts is a thin consumer of the factory', () => {
     );
   });
 
-  it('passes the connectToLiveAPI Promise-closure state through onSetupComplete (setupComplete + clearTimeout + resolve)', () => {
-    // The wiring callback in orb-live.ts must still mutate setupComplete,
-    // clear the connectionTimeout, and resolve(ws). The lifted body no
-    // longer touches these directly — only the wiring does.
-    const wiring = orbLiveSrc.slice(
-      orbLiveSrc.indexOf('onSetupComplete:'),
-      orbLiveSrc.indexOf('isSetupComplete:'),
-    );
-    expect(wiring).toMatch(/setupComplete\s*=\s*true/);
-    expect(wiring).toMatch(/clearTimeout\s*\(\s*connectionTimeout\s*\)/);
-    expect(wiring).toMatch(/resolve\s*\(\s*ws\s*\)/);
+  it('preserves the connectToLiveAPI Promise-closure state semantics (setupComplete + clearTimeout + resolve)', () => {
+    // A8.3a.2: the wiring originally mutated setupComplete + cleared
+    // connectionTimeout + called resolve(ws) inside the `onSetupComplete`
+    // callback passed to createUpstreamLiveMessageHandler.
+    //
+    // A8.3b.1: those three mutations move OUT of the `onSetupComplete`
+    // callback (which is now a no-op for the Vertex path because
+    // VertexLiveClient consumes setup_complete) and into the post-
+    // `vertex.connect()` block. Observable behavior is unchanged: when
+    // setup_complete arrives, setupComplete flips true, the timeout
+    // clears, and the outer Promise resolves with ws.
+    //
+    // This test asserts the three mutations still exist SOMEWHERE in
+    // connectToLiveAPI's body — the seam is preserved, just relocated.
+    const fnStart = orbLiveSrc.indexOf('async function connectToLiveAPI');
+    expect(fnStart).toBeGreaterThan(0);
+    const fnEnd = orbLiveSrc.indexOf('\nasync function ', fnStart + 1);
+    const fnBody = orbLiveSrc.slice(fnStart, fnEnd >= 0 ? fnEnd : undefined);
+    expect(fnBody).toMatch(/setupComplete\s*=\s*true/);
+    expect(fnBody).toMatch(/clearTimeout\s*\(\s*connectionTimeout\s*\)/);
+    expect(fnBody).toMatch(/resolve\s*\(\s*ws\s*\)/);
+    // A8.3b.1: VertexLiveClient is the active path.
+    expect(fnBody).toMatch(/new\s+VertexLiveClient\s*\(\s*\)/);
+    expect(fnBody).toMatch(/vertex\.connect\s*\(/);
+    expect(fnBody).toMatch(/vertex\.getSocket\s*\(\s*\)/);
+    expect(fnBody).toMatch(/customSetupMessage/);
+  });
+
+  it('does NOT inline `new WebSocket(wsUrl, { headers: ... })` anymore', () => {
+    // Anti-regression: pre-A8.3b.1 connectToLiveAPI constructed the raw
+    // WebSocket inline. After A8.3b.1, VertexLiveClient owns that path.
+    const fnStart = orbLiveSrc.indexOf('async function connectToLiveAPI');
+    const fnEnd = orbLiveSrc.indexOf('\nasync function ', fnStart + 1);
+    const fnBody = orbLiveSrc.slice(fnStart, fnEnd >= 0 ? fnEnd : undefined);
+    expect(fnBody).not.toMatch(/new\s+WebSocket\s*\(\s*wsUrl/);
   });
 });

--- a/services/gateway/test/orb/live/upstream/vertex-live-client.test.ts
+++ b/services/gateway/test/orb/live/upstream/vertex-live-client.test.ts
@@ -556,3 +556,81 @@ describe('A7 characterization: VertexLiveClient', () => {
     });
   });
 });
+
+// =============================================================================
+// A8.3b.1 (VTID-02971): customSetupMessage + getSocket() extensions
+// =============================================================================
+
+describe('A8.3b.1: customSetupMessage override + getSocket() accessor', () => {
+  it('uses customSetupMessage when provided (skips default buildSetupMessage envelope)', async () => {
+    const socket = new MockSocket();
+    const client = new VertexLiveClient({ createSocket: () => socket });
+    const customEnvelope = {
+      setup: {
+        model: 'projects/orb-custom/locations/us-central1/publishers/google/models/foo',
+        marker: 'A8.3b.1-custom',
+      },
+    };
+    await connectClient(client, socket, baseOptions({
+      customSetupMessage: () => customEnvelope,
+    }));
+    expect(socket.sent.length).toBeGreaterThanOrEqual(1);
+    const sent = JSON.parse(socket.sent[0]);
+    expect(sent).toEqual(customEnvelope);
+    // Anti-regression: default envelope's model path must NOT appear when
+    // customSetupMessage is set.
+    expect(sent.setup.model).not.toContain('gemini-live-2.5-flash-native-audio');
+  });
+
+  it('awaits an async customSetupMessage before sending', async () => {
+    const socket = new MockSocket();
+    const client = new VertexLiveClient({ createSocket: () => socket });
+    let resolveBuilder!: (envelope: Record<string, unknown>) => void;
+    const builderPromise = new Promise<Record<string, unknown>>((r) => {
+      resolveBuilder = r;
+    });
+    const connectPromise = client.connect(baseOptions({
+      customSetupMessage: () => builderPromise,
+    }));
+    // Allow the async getAccessToken + factory call to settle.
+    await new Promise((resolve) => setImmediate(resolve));
+    socket.fireOpen();
+    await new Promise((resolve) => setImmediate(resolve));
+    // Builder has NOT resolved yet — no setup envelope should have been
+    // sent.
+    expect(socket.sent).toHaveLength(0);
+    // Resolve the builder. The handler awaits it inside ws.on('open').
+    resolveBuilder({ setup: { marker: 'A8.3b.1-async' } });
+    await new Promise((resolve) => setImmediate(resolve));
+    expect(socket.sent).toHaveLength(1);
+    const sent = JSON.parse(socket.sent[0]);
+    expect(sent).toEqual({ setup: { marker: 'A8.3b.1-async' } });
+    socket.fireMessage({ setup_complete: {} });
+    await connectPromise;
+  });
+
+  it('getSocket() returns null before connect()', () => {
+    const client = new VertexLiveClient({ createSocket: () => new MockSocket() });
+    expect(client.getSocket()).toBeNull();
+  });
+
+  it('getSocket() returns the underlying socket after connect() opens it', async () => {
+    const socket = new MockSocket();
+    const client = new VertexLiveClient({ createSocket: () => socket });
+    await connectClient(client, socket);
+    // The factory returned the mock; getSocket() must hand the same
+    // instance back so orb-live.ts's adapter can attach the legacy
+    // message/error/close handlers to it.
+    expect(client.getSocket()).toBe(socket);
+  });
+
+  it('default buildSetupMessage path still works when customSetupMessage is omitted', async () => {
+    const socket = new MockSocket();
+    const client = new VertexLiveClient({ createSocket: () => socket });
+    await connectClient(client, socket);
+    const sent = JSON.parse(socket.sent[0]);
+    // Default builder includes the canonical Vertex model path + AUDIO modality.
+    expect(sent.setup.model).toContain('gemini-live-2.5-flash-native-audio');
+    expect(sent.setup.generation_config.response_modalities).toEqual(['AUDIO']);
+  });
+});


### PR DESCRIPTION
## Summary

A8.3b.1 of the orb-live.ts refactor. Switches the active upstream path inside `connectToLiveAPI()` to route through the A7 `UpstreamLiveClient` / `VertexLiveClient` boundary — behind a compatibility adapter that keeps wire protocol and call-site signatures **byte-identical**.

Vertex remains the only active provider. No LiveKit selection yet (that's A8.3b.2 cleanup + L1 provider-selection).

## What moves

- `services/gateway/src/orb/live/upstream/types.ts` — adds optional `customSetupMessage` to `UpstreamConnectOptions` so callers can override the default Vertex setup envelope with an orb-specific one.
- `services/gateway/src/orb/live/upstream/vertex-live-client.ts` — `ws.on('open')` becomes async; awaits `options.customSetupMessage()` when set, falls back to default `buildSetupMessage(options)` otherwise. New `getSocket()` accessor exposes the underlying `WebSocket` for callers that need to register their own message/error/close handlers (the orb wire-protocol handlers).
- `services/gateway/src/routes/orb-live.ts` — `connectToLiveAPI()` now:
  1. Constructs a `VertexLiveClient`.
  2. Calls `vertex.connect({...})` with a `customSetupMessage` builder that produces the legacy orb-specific setup envelope (persona swap, tools, transcription, system instruction overrides).
  3. Retrieves the raw socket via `vertex.getSocket()` after handshake.
  4. Registers the existing message/error/close handlers on it (no change to handler bodies).
- `test/orb/live/upstream/vertex-live-client.test.ts` — 5 new tests:
  - `customSetupMessage` overrides default envelope
  - async `customSetupMessage` is awaited
  - `getSocket()` returns null before connect, the socket after open
  - default `buildSetupMessage` path still works when `customSetupMessage` is omitted
- `test/orb/live/characterization/upstream-message-handler.characterization.test.ts` — repointed:
  - The closure-state mutations (`setupComplete = true` / `clearTimeout(connectionTimeout)` / `resolve(ws)`) now live in the `connectToLiveAPI` body after `vertex.connect()` resolves (instead of inside the `onSetupComplete` callback). Test asserts those three mutations still exist anywhere in the function body — the seam is preserved, just relocated.
  - New anti-regression assertions: `new VertexLiveClient()`, `vertex.connect()`, `vertex.getSocket()`, `customSetupMessage`.
  - New anti-regression: `does NOT inline new WebSocket(wsUrl, { headers: ... })` anymore — Vertex client owns that path.

## What does NOT move

- The 3 callers of `connectToLiveAPI()` (`/live/stream` SSE, WS `{type:'start'}`, `attemptTransparentReconnect`) keep the same `(session, audioCb, textCb, errCb, turnCb?, interruptCb?)` signature.
- Wire protocol is byte-identical: same setup envelope contents, same message-handler bodies, same SSE writes through `writeSseEvent`, same WS frames.
- `createUpstreamLiveMessageHandler` factory (A8.3a.2) is unchanged.
- Production `/orb/chat` smoke flow (Vitana Index 172 + Sleep weakest pillar) preserved.

## Tests

- 654 orb tests green locally.
- Build clean (`npm run build`).
- CRLF line-endings preserved (`orb-live.ts` diff is the actual semantic change, not whitespace noise).

## Next

- **A8.3b.2** — remove the legacy inline raw-WebSocket scaffolding now that the Vertex adapter owns it.
- **L1** — provider-selection wiring (Vertex stays default, LiveKit becomes selectable behind explicit config).

🤖 Generated with [Claude Code](https://claude.com/claude-code)