### PR TITLE
feat(orb): A8.3b.2 — remove legacy raw-WebSocket scaffolding from connectToLiveAPI (VTID-02972)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -5532,16 +5532,10 @@ async function connectToLiveAPI(
     throw new Error('Missing VERTEX_PROJECT_ID or VERTEX_LOCATION');
   }
 
-  // Get access token
-  const accessToken = await getAccessToken();
-  console.log(`[VTID-01219] Got access token (length: ${accessToken.length})`);
-
-  // Build WebSocket URL for Vertex AI Live API
-  // VTID-01222: Correct endpoint per Google documentation
-  // https://github.com/GoogleCloudPlatform/generative-ai/blob/main/gemini/multimodal-live-api/intro_multimodal_live_api.ipynb
-  const wsUrl = `wss://${VERTEX_LOCATION}-aiplatform.googleapis.com/ws/google.cloud.aiplatform.v1.LlmBidiService/BidiGenerateContent`;
-
-  console.log(`[VTID-01219] Connecting to Live API: ${wsUrl}`);
+  // A8.3b.2 (VTID-02972): the legacy raw-WebSocket scaffolding is gone.
+  // `VertexLiveClient.connect()` owns the access-token fetch, the WSS URL
+  // construction, the headers attach, and the open-handshake. We only need
+  // to log what we're about to ask it to do.
   console.log(`[VTID-01219] Using model: ${VERTEX_LIVE_MODEL}`);
   console.log(`[VTID-01219] Project: ${VERTEX_PROJECT_ID}, Location: ${VERTEX_LOCATION}`);
 
@@ -5794,9 +5788,8 @@ async function connectToLiveAPI(
         responseModalities: session.responseModalities.includes('audio') ? ['audio'] : ['text'],
         vadSilenceMs: session.vadSilenceMs,
         systemInstruction: 'overridden',
-        // Reuse the already-fetched OAuth token for this connect; the
-        // builder type expects a `() => Promise<string>` shape.
-        getAccessToken: async () => accessToken,
+        // A8.3b.2: VertexLiveClient.connect() invokes this directly.
+        getAccessToken,
         connectTimeoutMs: 15000,
         customSetupMessage: buildOrbVertexSetupEnvelope,
       });

--- a/services/gateway/test/orb/live/characterization/upstream-message-handler.characterization.test.ts
+++ b/services/gateway/test/orb/live/characterization/upstream-message-handler.characterization.test.ts
@@ -173,4 +173,32 @@ describe('A8.3a.2: orb-live.ts is a thin consumer of the factory', () => {
     const fnBody = orbLiveSrc.slice(fnStart, fnEnd >= 0 ? fnEnd : undefined);
     expect(fnBody).not.toMatch(/new\s+WebSocket\s*\(\s*wsUrl/);
   });
+
+  it('A8.3b.2: legacy raw-WebSocket scaffolding is removed from connectToLiveAPI', () => {
+    // A8.3b.2 (VTID-02972): with VertexLiveClient owning the entire
+    // open-handshake (auth-token fetch, URL build, headers attach,
+    // ws.on('open') envelope send, setup_complete gate), the outer
+    // connectToLiveAPI body no longer needs to fetch the token or
+    // construct the WSS URL itself. Those three artifacts must NOT
+    // reappear inside the function body:
+    //
+    //   1. `const wsUrl = ...`  — URL is internal to VertexLiveClient.
+    //   2. `const accessToken = await getAccessToken()` — VertexLiveClient
+    //      invokes `options.getAccessToken()` itself.
+    //   3. `async () => accessToken` closure — the function reference is
+    //      passed directly instead.
+    //
+    // VertexLiveClient.connect() must still be called (sanity check), and
+    // getAccessToken must still appear inside it (as the option's value).
+    const fnStart = orbLiveSrc.indexOf('async function connectToLiveAPI');
+    expect(fnStart).toBeGreaterThan(0);
+    const fnEnd = orbLiveSrc.indexOf('\nasync function ', fnStart + 1);
+    const fnBody = orbLiveSrc.slice(fnStart, fnEnd >= 0 ? fnEnd : undefined);
+    expect(fnBody).not.toMatch(/const\s+wsUrl\s*=/);
+    expect(fnBody).not.toMatch(/const\s+accessToken\s*=\s*await\s+getAccessToken\s*\(/);
+    expect(fnBody).not.toMatch(/async\s*\(\s*\)\s*=>\s*accessToken\b/);
+    // Sanity: the seam is still wired.
+    expect(fnBody).toMatch(/vertex\.connect\s*\(/);
+    expect(fnBody).toMatch(/getAccessToken\b/);
+  });
 });


### PR DESCRIPTION
## Summary

Slice 2 of 2 in A8.3b. A8.3b.1 (PR #2104) shipped the VertexLiveClient compatibility adapter inside `connectToLiveAPI`. Now that VertexLiveClient owns the entire open-handshake (auth-token fetch, WSS URL construction, headers attach, `ws.on('open')` envelope send, `setup_complete` gate), three artifacts in the outer body are dead scaffolding. This PR removes them.

## What moves

`services/gateway/src/routes/orb-live.ts` — inside `connectToLiveAPI`:

1. **`const wsUrl = …`** — gone. The WSS URL is constructed internally by VertexLiveClient.
2. **`const accessToken = await getAccessToken()`** — gone. VertexLiveClient invokes `options.getAccessToken()` itself.
3. **`async () => accessToken`** closure on the connect options — replaced by passing the `getAccessToken` function reference directly.

The connect-options shape is otherwise unchanged (`model` / `projectId` / `location` / `voiceName` / `responseModalities` / `vadSilenceMs` / `systemInstruction` / `connectTimeoutMs` / `customSetupMessage`), so the wire protocol is **byte-identical**.

## What does NOT move

- All call sites of `connectToLiveAPI` keep their existing signature.
- The orb-specific setup envelope builder (`buildOrbVertexSetupEnvelope`) is unchanged.
- The message + error + close handler wiring on the raw socket returned by `vertex.getSocket()` is unchanged.
- Production `/orb/chat` flow (Vitana Index 172 + Sleep weakest pillar) is preserved.

## Tests

- 655 orb tests green (was 654; +1 = the new anti-regression test below).
- Build clean (`npm run build`).
- New characterization assertion in `test/orb/live/characterization/upstream-message-handler.characterization.test.ts` — proves the three removed patterns do NOT reappear in `connectToLiveAPI` body, and that the seam (`vertex.connect(`, `getAccessToken`) is still wired.
- CRLF line-endings preserved (orb-live.ts diff is 6 ins / 13 del — actual semantic change, no whitespace noise).

## Next

- **L1** — provider-selection wiring (Vertex stays default, LiveKit becomes selectable behind explicit config). The Vertex adapter is now production-stable; L1 introduces a registry/factory pattern in `orb/live/upstream/` so `connectToLiveAPI` can ask for the configured provider instead of hard-coding `new VertexLiveClient()`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)