### PR TITLE
feat(self-healing): M1.0 — worker-runner contract coverage + operator-armed canary (VTID-02978, PR-M1.0)

### DIFF
--- a/services/gateway/src/services/missing-test-scanner.ts
+++ b/services/gateway/src/services/missing-test-scanner.ts
@@ -23,26 +23,40 @@
 
 import { ENDPOINT_FILE_MAP } from '../types/self-healing';
 
+/**
+ * VTID-02978 (M1): worker-runner endpoints the scanner should consider.
+ * Mirrors the shape of gateway's ENDPOINT_FILE_MAP but lives here in
+ * the scanner (worker-runner doesn't share a types package with gateway,
+ * and the surface is small enough not to warrant one).
+ */
+export const WORKER_RUNNER_ENDPOINT_FILE_MAP: Record<string, string> = {
+  '/alive': 'services/worker-runner/src/index.ts',
+  '/ready': 'services/worker-runner/src/index.ts',
+  '/live': 'services/worker-runner/src/index.ts',
+  '/metrics': 'services/worker-runner/src/index.ts',
+  '/api/v1/canary-target/health': 'services/worker-runner/src/routes/canary-target.ts',
+};
+
 export interface CapabilityGap {
   /** Stable dedupe key: capability:service:contract_type — matches the
    *  composite UNIQUE on test_contracts so a duplicate row is impossible. */
   dedupe_key: string;
-  /** Suggested capability slug (snake_case, derived from endpoint path). */
+  /** Suggested capability slug (snake_case, derived from endpoint path,
+   *  prefixed by service when not 'gateway'). */
   capability: string;
   /** Always 'live_probe' in PR-L2; jest/typecheck contracts are scanned
    *  in PR-L3 via a separate discovery (test/*.test.ts files). */
   contract_type: 'live_probe';
-  /** Service the endpoint lives in. Currently always 'gateway' since the
-   *  scanner only reads gateway routes. */
-  service: 'gateway';
+  /** Service the endpoint lives in. M1 added worker-runner alongside gateway. */
+  service: 'gateway' | 'worker-runner';
   /** Default environment for newly discovered capabilities. */
   environment: 'dev';
   /** The endpoint path, e.g. '/api/v1/auth/health'. */
   target_endpoint: string;
-  /** The source file from ENDPOINT_FILE_MAP. */
+  /** The source file from the endpoint map. */
   target_file: string;
   /** Suggested command_key for the allowlist entry the LLM will need to
-   *  add (e.g. 'gateway.auth_health'). Always 'gateway.<capability>'. */
+   *  add (e.g. 'gateway.auth_health' or 'worker_runner.alive'). */
   suggested_command_key: string;
 }
 
@@ -70,8 +84,21 @@ export function deriveCapability(endpoint: string): string {
     .toLowerCase();
 }
 
-export function suggestedCommandKey(capability: string): string {
-  return `gateway.${capability}`;
+/**
+ * VTID-02978 (M1): command_key prefix follows the service to keep keys
+ * aligned with the allowlist convention (gateway.X vs worker_runner.X).
+ * Service slug uses underscores so the prefix stays a valid JS
+ * identifier-shape; the migration uses the same convention.
+ */
+export function suggestedCommandKey(capability: string, service: 'gateway' | 'worker-runner' = 'gateway'): string {
+  const prefix = service === 'worker-runner' ? 'worker_runner' : 'gateway';
+  // Strip the service prefix from the capability if it already starts
+  // with it (e.g. capability='worker_runner_alive' → key='worker_runner.alive')
+  const trimmed =
+    service === 'worker-runner' && capability.startsWith('worker_runner_')
+      ? capability.slice('worker_runner_'.length)
+      : capability;
+  return `${prefix}.${trimmed}`;
 }
 
 export function gapDedupeKey(capability: string, service: string, contract_type: string): string {
@@ -89,15 +116,21 @@ export interface ExistingContractRef {
 }
 
 /**
- * Pure scanner. Given the current ENDPOINT_FILE_MAP entries + the set
+ * Pure scanner. Given an endpoint map for a specific service + the set
  * of existing contracts (by capability:service:contract_type), returns
  * every endpoint that does not yet have a `live_probe` contract.
  *
  * Sorted by endpoint path so the cockpit renders deterministically.
+ *
+ * VTID-02978 (M1): added `service` parameter. Capability slugs are
+ * namespaced by service ('worker_runner_alive' vs 'gateway_alive') so
+ * worker-runner and gateway can both have an /alive endpoint without
+ * dedupe collision.
  */
 export function scanMissingContracts(
   endpointMap: Record<string, string>,
   existing: ExistingContractRef[],
+  service: 'gateway' | 'worker-runner' = 'gateway',
 ): CapabilityGap[] {
   const covered = new Set<string>();
   for (const c of existing) {
@@ -106,18 +139,25 @@ export function scanMissingContracts(
 
   const gaps: CapabilityGap[] = [];
   for (const [endpoint, file] of Object.entries(endpointMap)) {
-    const capability = deriveCapability(endpoint);
-    const dedupe_key = gapDedupeKey(capability, 'gateway', 'live_probe');
+    const baseCapability = deriveCapability(endpoint);
+    // Namespace by service so `/alive` on worker-runner doesn't collide
+    // with `/alive` on gateway. Gateway keeps its bare slug for backward
+    // compatibility with PR-L2 contracts already in the registry.
+    const capability =
+      service === 'worker-runner'
+        ? `worker_runner_${baseCapability}`
+        : baseCapability;
+    const dedupe_key = gapDedupeKey(capability, service, 'live_probe');
     if (covered.has(dedupe_key)) continue;
     gaps.push({
       dedupe_key,
       capability,
       contract_type: 'live_probe',
-      service: 'gateway',
+      service,
       environment: 'dev',
       target_endpoint: endpoint,
       target_file: file,
-      suggested_command_key: suggestedCommandKey(capability),
+      suggested_command_key: suggestedCommandKey(capability, service),
     });
   }
 
@@ -126,12 +166,20 @@ export function scanMissingContracts(
 }
 
 /**
- * Convenience: read the canonical ENDPOINT_FILE_MAP. Lets route handlers
- * call `scanMissingContractsAgainstLiveRegistry(existing)` without
- * importing self-healing types directly.
+ * Convenience: walk gateway's ENDPOINT_FILE_MAP and worker-runner's
+ * analog in one call. The route handler uses this to produce a single
+ * list of gaps across both services.
  */
 export function scanMissingContractsAgainstLiveRegistry(
   existing: ExistingContractRef[],
 ): CapabilityGap[] {
-  return scanMissingContracts(ENDPOINT_FILE_MAP, existing);
+  const gatewayGaps = scanMissingContracts(ENDPOINT_FILE_MAP, existing, 'gateway');
+  const workerRunnerGaps = scanMissingContracts(
+    WORKER_RUNNER_ENDPOINT_FILE_MAP,
+    existing,
+    'worker-runner',
+  );
+  return [...gatewayGaps, ...workerRunnerGaps].sort((a, b) =>
+    a.target_endpoint < b.target_endpoint ? -1 : 1,
+  );
 }

--- a/services/gateway/src/services/test-contract-commands.ts
+++ b/services/gateway/src/services/test-contract-commands.ts
@@ -12,7 +12,7 @@
  * for jest/typecheck contracts (long-running; need async execution).
  */
 
-import { contractGatewayBaseUrl } from './test-contract-config';
+import { contractGatewayBaseUrl, contractWorkerRunnerBaseUrl } from './test-contract-config';
 
 export type TestContractDispatchKind = 'sync_http' | 'cloud_run_job' | 'workflow_dispatch';
 
@@ -70,8 +70,11 @@ async function probeHttp(
   path: string,
   expected: ExpectedHttp,
   body?: Record<string, unknown>,
+  // VTID-02978 (M1): per-service base URL. Defaults to gateway for
+  // backward compat with PR-L1 allowlist entries.
+  baseUrl: () => string = contractGatewayBaseUrl,
 ): Promise<TestContractRunResult> {
-  const url = `${contractGatewayBaseUrl()}${path}`;
+  const url = `${baseUrl()}${path}`;
   const t0 = Date.now();
   const ran_at = new Date().toISOString();
   try {
@@ -215,6 +218,78 @@ export const COMMAND_ALLOWLIST: Record<string, AllowlistedCommand> = {
         '/api/v1/worker/orchestrator/await-autopilot-execution',
         isExpectedHttp(expected) ? expected : {},
         {},
+      ),
+  },
+
+  // VTID-02978 (M1): worker-runner contract coverage. Targets the
+  // worker-runner Cloud Run service instead of gateway.
+  'worker_runner.alive': {
+    command_key: 'worker_runner.alive',
+    contract_type: 'live_probe',
+    dispatch: 'sync_http',
+    resolve: (expected) =>
+      probeHttp(
+        'GET',
+        '/alive',
+        isExpectedHttp(expected) ? expected : {},
+        undefined,
+        contractWorkerRunnerBaseUrl,
+      ),
+  },
+  'worker_runner.ready': {
+    command_key: 'worker_runner.ready',
+    contract_type: 'live_probe',
+    dispatch: 'sync_http',
+    resolve: (expected) =>
+      probeHttp(
+        'GET',
+        '/ready',
+        isExpectedHttp(expected) ? expected : {},
+        undefined,
+        contractWorkerRunnerBaseUrl,
+      ),
+  },
+  'worker_runner.live': {
+    command_key: 'worker_runner.live',
+    contract_type: 'live_probe',
+    dispatch: 'sync_http',
+    resolve: (expected) =>
+      probeHttp(
+        'GET',
+        '/live',
+        isExpectedHttp(expected) ? expected : {},
+        undefined,
+        contractWorkerRunnerBaseUrl,
+      ),
+  },
+  'worker_runner.metrics': {
+    command_key: 'worker_runner.metrics',
+    contract_type: 'live_probe',
+    dispatch: 'sync_http',
+    resolve: (expected) =>
+      probeHttp(
+        'GET',
+        '/metrics',
+        isExpectedHttp(expected) ? expected : {},
+        undefined,
+        contractWorkerRunnerBaseUrl,
+      ),
+  },
+  // Operator-armed canary on worker-runner. Mirrors the gateway canary
+  // pattern (PR-I) — when system_config.worker_runner_canary_armed=true,
+  // the route throws WorkerRunnerCanaryArmedFault which surfaces as 500.
+  // Used to prove the M1 repair-loop green path end-to-end.
+  'worker_runner.canary_target_health': {
+    command_key: 'worker_runner.canary_target_health',
+    contract_type: 'live_probe',
+    dispatch: 'sync_http',
+    resolve: (expected) =>
+      probeHttp(
+        'GET',
+        '/api/v1/canary-target/health',
+        isExpectedHttp(expected) ? expected : {},
+        undefined,
+        contractWorkerRunnerBaseUrl,
       ),
   },
 };

--- a/services/gateway/src/services/test-contract-config.ts
+++ b/services/gateway/src/services/test-contract-config.ts
@@ -1,14 +1,15 @@
 /**
- * VTID-02954 (PR-L1): Gateway base URL used by test-contract probes.
- * Tests can override via process.env.GATEWAY_INTERNAL_BASE_URL.
+ * VTID-02954 (PR-L1): Test-contract probe URLs per service.
  *
- * Default is the production Cloud Run URL. The probes go through the
- * public URL so they exercise the same Cloud Run routing layer real
- * traffic uses (TLS termination, load balancer, etc.) — running probes
- * via localhost would miss those failure modes.
+ * Each test_contracts row carries a `service` column. The allowlist
+ * looks the base URL up here so a single probe helper can target any
+ * Cloud Run service. Tests override via env so beforeEach can swap.
  *
- * Read at call time (not module-load) so env overrides in tests take
- * effect when beforeEach runs after the import has already happened.
+ * Read at call time so overrides set after import still take effect.
+ *
+ * VTID-02978 (M1): added worker-runner so the failure scanner can
+ * probe worker-runner's /alive, /metrics, /ready, /live, and a future
+ * operator-armed canary endpoint.
  */
 
 export function contractGatewayBaseUrl(): string {
@@ -17,4 +18,28 @@ export function contractGatewayBaseUrl(): string {
     process.env.GATEWAY_PUBLIC_URL ||
     'https://gateway-86804897789.us-central1.run.app'
   );
+}
+
+export function contractWorkerRunnerBaseUrl(): string {
+  return (
+    process.env.WORKER_RUNNER_INTERNAL_BASE_URL ||
+    process.env.WORKER_RUNNER_PUBLIC_URL ||
+    'https://worker-runner-86804897789.us-central1.run.app'
+  );
+}
+
+/**
+ * Generic per-service URL lookup. Returns null for unknown services so
+ * a typo in the migration (e.g. service='worker-runer') surfaces at
+ * runtime as a 502 instead of silently probing gateway.
+ */
+export function contractServiceBaseUrl(service: string): string | null {
+  switch (service) {
+    case 'gateway':
+      return contractGatewayBaseUrl();
+    case 'worker-runner':
+      return contractWorkerRunnerBaseUrl();
+    default:
+      return null;
+  }
 }

--- a/services/gateway/test/missing-test-scanner.test.ts
+++ b/services/gateway/test/missing-test-scanner.test.ts
@@ -141,3 +141,72 @@ describe('scanMissingContracts', () => {
     expect(a).toEqual(b);
   });
 });
+
+// VTID-02978 (M1): worker-runner namespacing.
+describe('scanMissingContracts(service)', () => {
+  it('namespaces capability slugs with the worker_runner_ prefix when service=worker-runner', () => {
+    const gaps = scanMissingContracts(
+      { '/alive': 'services/worker-runner/src/index.ts' },
+      [],
+      'worker-runner',
+    );
+    expect(gaps).toHaveLength(1);
+    expect(gaps[0].capability).toBe('worker_runner_alive');
+    expect(gaps[0].service).toBe('worker-runner');
+    expect(gaps[0].suggested_command_key).toBe('worker_runner.alive');
+    expect(gaps[0].dedupe_key).toBe('worker_runner_alive:worker-runner:live_probe');
+  });
+
+  it('worker-runner /alive does NOT collide with gateway /alive (different services in the dedupe triple)', () => {
+    const existing: ExistingContractRef[] = [
+      // Gateway already has 'alive'
+      { capability: 'alive', service: 'gateway', contract_type: 'live_probe' },
+    ];
+    const gaps = scanMissingContracts(
+      { '/alive': 'services/worker-runner/src/index.ts' },
+      existing,
+      'worker-runner',
+    );
+    // Worker-runner /alive should still be a gap — different (capability, service).
+    expect(gaps).toHaveLength(1);
+    expect(gaps[0].service).toBe('worker-runner');
+  });
+
+  it('default service argument is gateway (backward compat with PR-L2 callers)', () => {
+    const [gap] = scanMissingContracts({ '/foo': 'src/foo.ts' }, []);
+    expect(gap.service).toBe('gateway');
+    expect(gap.capability).toBe('foo');
+  });
+});
+
+describe('suggestedCommandKey', () => {
+  it('returns gateway.<slug> by default', () => {
+    expect(suggestedCommandKey('auth_health')).toBe('gateway.auth_health');
+  });
+
+  it('returns worker_runner.<slug> when service=worker-runner (strips the namespace prefix)', () => {
+    expect(suggestedCommandKey('worker_runner_alive', 'worker-runner')).toBe('worker_runner.alive');
+    expect(suggestedCommandKey('worker_runner_metrics', 'worker-runner')).toBe('worker_runner.metrics');
+  });
+
+  it('handles bare slugs gracefully when service=worker-runner but capability has no prefix', () => {
+    expect(suggestedCommandKey('something', 'worker-runner')).toBe('worker_runner.something');
+  });
+});
+
+describe('scanMissingContractsAgainstLiveRegistry (M1)', () => {
+  // Re-imports the module to access the live ENDPOINT_FILE_MAP +
+  // WORKER_RUNNER_ENDPOINT_FILE_MAP so we don't drift if either changes.
+  it('walks BOTH gateway and worker-runner endpoint maps + sorts by endpoint path', () => {
+    const { scanMissingContractsAgainstLiveRegistry, WORKER_RUNNER_ENDPOINT_FILE_MAP } = require('../src/services/missing-test-scanner');
+    const gaps = scanMissingContractsAgainstLiveRegistry([]);
+    // We expect AT LEAST every worker-runner endpoint to appear (5 of them
+    // in the M1 seed). The gateway side has ~50 endpoints from PR-L2,
+    // so just check the worker-runner ones are present.
+    for (const endpoint of Object.keys(WORKER_RUNNER_ENDPOINT_FILE_MAP)) {
+      const g = gaps.find((x: any) => x.target_endpoint === endpoint && x.service === 'worker-runner');
+      expect(g).toBeDefined();
+      expect(g.capability.startsWith('worker_runner_')).toBe(true);
+    }
+  });
+});

--- a/services/gateway/test/test-contracts.test.ts
+++ b/services/gateway/test/test-contracts.test.ts
@@ -45,7 +45,7 @@ describe('test-contract-commands resolveCommand', () => {
     expect(typeof cmd!.resolve).toBe('function');
   });
 
-  it('exposes the 6 PR-L1 seed contracts', () => {
+  it('exposes the 6 PR-L1 seed contracts + 5 M1 worker-runner entries', () => {
     const keys = listAllowlistedKeys().sort();
     expect(keys).toEqual([
       'canary_target.disarmed_health',
@@ -53,7 +53,13 @@ describe('test-contract-commands resolveCommand', () => {
       'gateway.alive',
       'oasis.vtid_terminalize_validates_payload',
       'self_healing.active_route_mounted',
+      // M1: worker-runner targets
       'worker_orchestrator.await_autopilot_requires_auth',
+      'worker_runner.alive',
+      'worker_runner.canary_target_health',
+      'worker_runner.live',
+      'worker_runner.metrics',
+      'worker_runner.ready',
     ]);
   });
 

--- a/services/worker-runner/src/index.ts
+++ b/services/worker-runner/src/index.ts
@@ -16,6 +16,9 @@ import express, { Request, Response } from 'express';
 import { config as dotenvConfig } from 'dotenv';
 import { WorkerRunner, createRunnerFromEnv } from './services/runner-service';
 import { startAgentRegistration } from './lib/agents-registry-client';
+// VTID-02978 (M1): operator-armed canary that mirrors the gateway PR-I
+// canary, used to prove the M1 worker-runner repair-loop green path.
+import canaryTargetRouter from './routes/canary-target';
 
 // Load environment variables
 dotenvConfig();
@@ -26,6 +29,10 @@ const PORT = parseInt(process.env.PORT || '8080', 10);
 // Express app for health checks
 const app = express();
 app.use(express.json());
+
+// VTID-02978 (M1): canary mounted at the conventional path so the
+// gateway's failure scanner can probe worker-runner.canary_target_health.
+app.use('/api/v1/canary-target', canaryTargetRouter);
 
 // Runner instance
 let runner: WorkerRunner | null = null;

--- a/services/worker-runner/src/routes/canary-target.ts
+++ b/services/worker-runner/src/routes/canary-target.ts
@@ -1,0 +1,106 @@
+/**
+ * VTID-02978 (M1): worker-runner canary target.
+ *
+ * Mirrors the gateway canary (PR-I) for the M1 worker-runner green-path
+ * proof. Operator flips `system_config.worker_runner_canary_armed=true`
+ * to deliberately fail `/api/v1/canary-target/health`. The test contract
+ * for this endpoint then fails, the gateway failure scanner allocates a
+ * repair VTID, the dev_autopilot pipeline writes the fix (catch the
+ * typed fault, return degraded shape), CI/deploy lands, and the next
+ * scheduled scan flips the contract back to pass.
+ *
+ * Repeatability caveat (same as the gateway canary): after the LLM's
+ * narrow-catch lands, re-arming returns 200 with the degraded shape
+ * directly. Acceptable for proving the green path once.
+ */
+
+import { Router, Request, Response } from 'express';
+
+const canaryTargetRouter = Router();
+
+const SUPABASE_URL = process.env.SUPABASE_URL;
+const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
+const CONFIG_KEY = 'worker_runner_canary_armed';
+
+let cachedArmed: boolean | null = null;
+let cachedAt = 0;
+const CACHE_TTL_MS = 5_000;
+
+/**
+ * Typed fault thrown when the canary is armed. The repair contract is:
+ * catch ONLY this error class (not generic Error) and return a degraded
+ * JSON response. Catching `Error` broadly would mask real bugs and is
+ * the wrong autonomy habit.
+ */
+export class WorkerRunnerCanaryArmedFault extends Error {
+  readonly code = 'WORKER_RUNNER_CANARY_ARMED';
+  constructor() {
+    super('worker-runner canary is armed via system_config[worker_runner_canary_armed]=true');
+    this.name = 'WorkerRunnerCanaryArmedFault';
+  }
+}
+
+export async function isWorkerRunnerCanaryArmed(): Promise<boolean> {
+  const now = Date.now();
+  if (cachedArmed !== null && now - cachedAt < CACHE_TTL_MS) {
+    return cachedArmed;
+  }
+  cachedArmed = false;
+  cachedAt = now;
+  if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) return false;
+  try {
+    const resp = await fetch(
+      `${SUPABASE_URL}/rest/v1/system_config?key=eq.${CONFIG_KEY}&select=value`,
+      {
+        headers: {
+          apikey: SUPABASE_SERVICE_ROLE,
+          Authorization: `Bearer ${SUPABASE_SERVICE_ROLE}`,
+        },
+        signal: AbortSignal.timeout(3_000),
+      },
+    );
+    if (!resp.ok) return false;
+    const rows = (await resp.json()) as Array<{ value: unknown }>;
+    if (rows.length === 0) return false;
+    const v = rows[0].value;
+    cachedArmed = v === true || v === 'true' || v === 1 || v === '1';
+    return cachedArmed;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * GET /api/v1/canary-target/health
+ *
+ * Disarmed → 200 with { ok: true, armed: false }.
+ * Armed    → throws WorkerRunnerCanaryArmedFault, surfaced as 500 by
+ *            Express's default error handler. The failure scanner sees
+ *            the 500 and allocates a repair VTID.
+ *
+ * The repair contract — same shape as the gateway canary:
+ *   - catch WorkerRunnerCanaryArmedFault specifically (NOT generic Error)
+ *   - return 200 with { ok:true, degraded:true, fault_class:
+ *     'WORKER_RUNNER_CANARY_ARMED', remediation:'...' }
+ */
+canaryTargetRouter.get('/health', async (_req: Request, res: Response, next: (err?: any) => void) => {
+  try {
+    const armed = await isWorkerRunnerCanaryArmed();
+    if (armed) {
+      throw new WorkerRunnerCanaryArmedFault();
+    }
+    return res.status(200).json({ ok: true, armed: false });
+  } catch (err) {
+    return next(err);
+  }
+});
+
+/**
+ * GET /api/v1/canary-target/status — operator-facing read-only.
+ */
+canaryTargetRouter.get('/status', async (_req: Request, res: Response) => {
+  const armed = await isWorkerRunnerCanaryArmed();
+  return res.json({ ok: true, armed, config_key: CONFIG_KEY });
+});
+
+export default canaryTargetRouter;

--- a/supabase/migrations/20260521000004_VTID_02978_worker_runner_contracts.sql
+++ b/supabase/migrations/20260521000004_VTID_02978_worker_runner_contracts.sql
@@ -1,0 +1,80 @@
+-- VTID-02978 (M1): worker-runner contract coverage.
+--
+-- Seeds 5 contracts for the worker-runner Cloud Run service:
+--   - /alive   (canonical health)
+--   - /ready   (kubernetes-style readiness)
+--   - /live    (kubernetes-style liveness)
+--   - /metrics (runner metrics + active VTID)
+--   - /api/v1/canary-target/health (operator-armed canary for the
+--     M1 repair-loop green-path proof)
+--
+-- These mirror gateway's PR-L1 seeds. Failure scanner picks up the new
+-- rows automatically (it filters by contract_type=live_probe, agnostic
+-- to service). Per-service URL routing lives in
+-- services/gateway/src/services/test-contract-config.ts:contractServiceBaseUrl.
+
+INSERT INTO test_contracts (
+  capability, contract_type, command_key, service, environment,
+  target_file, target_endpoint, expected_behavior, owner, repairable
+) VALUES
+  (
+    'worker_runner_alive',
+    'live_probe',
+    'worker_runner.alive',
+    'worker-runner',
+    'dev',
+    'services/worker-runner/src/index.ts',
+    '/alive',
+    '{"status": [200, 503], "content_type_prefix": "application/json", "notes": "503 with status=unhealthy is acceptable — proves the route is mounted + runner state is being reported. text/html 404 means the route is gone."}'::jsonb,
+    'worker-runner-core',
+    true
+  ),
+  (
+    'worker_runner_ready',
+    'live_probe',
+    'worker_runner.ready',
+    'worker-runner',
+    'dev',
+    'services/worker-runner/src/index.ts',
+    '/ready',
+    '{"status": [200, 503], "content_type_prefix": "application/json"}'::jsonb,
+    'worker-runner-core',
+    true
+  ),
+  (
+    'worker_runner_live',
+    'live_probe',
+    'worker_runner.live',
+    'worker-runner',
+    'dev',
+    'services/worker-runner/src/index.ts',
+    '/live',
+    '{"status": [200, 503], "content_type_prefix": "application/json"}'::jsonb,
+    'worker-runner-core',
+    true
+  ),
+  (
+    'worker_runner_metrics',
+    'live_probe',
+    'worker_runner.metrics',
+    'worker-runner',
+    'dev',
+    'services/worker-runner/src/index.ts',
+    '/metrics',
+    '{"status": [200, 503], "content_type_prefix": "application/json"}'::jsonb,
+    'worker-runner-core',
+    true
+  ),
+  (
+    'worker_runner_canary_target_health',
+    'live_probe',
+    'worker_runner.canary_target_health',
+    'worker-runner',
+    'dev',
+    'services/worker-runner/src/routes/canary-target.ts',
+    '/api/v1/canary-target/health',
+    '{"status": 200, "content_type_prefix": "application/json", "json_must_contain": {"ok": true}, "notes": "Disarmed path. When system_config.worker_runner_canary_armed=true the route throws WorkerRunnerCanaryArmedFault and Express surfaces 500 — the failure scanner picks it up. The repair contract is: catch the typed fault, return 200 with degraded shape."}'::jsonb,
+    'self-healing',
+    true
+  )
+ON CONFLICT (capability) DO NOTHING;


### PR DESCRIPTION
## Summary

First step of the **M1 lane**: extend the Test Contract Backbone to a second service. Adds 5 live_probe contracts for worker-runner (alive/ready/live/metrics + operator-armed canary), per-service URL routing, namespaced capability slugs so worker-runner doesn't collide with gateway, and a typed-fault canary endpoint we can flip via `system_config` to prove the green-path repair loop end-to-end.

Per the user's M1 brief:
| Goal | Status |
|---|---|
| Seed worker-runner health contracts | ✅ (4 + canary) |
| Missing-test scanner sees worker-runner | ✅ namespaced |
| Failure scanner can repair worker-runner failures | ✅ per-service URL routing |
| Known-good diff works for worker-runner files | ✅ PR-L4's GitHub fetch is path-agnostic |
| One controlled canary green-path proof | ⏸ post-deploy smoke (see below) |

## Deliberately NOT in M1.0

**Build/test contracts.** They need Cloud Run Job dispatch (PR-L3.1) which is parked. The user wants the green-path proof BEFORE expanding to voice — sync_http live_probes are enough to prove it. PR-M1.1 (if needed) adds jest/typecheck after.

## Files

- **Migration** `20260521000004_VTID_02978_worker_runner_contracts.sql` — 5 contracts under `service='worker-runner'`. `ON CONFLICT (capability) DO NOTHING` so re-runs are idempotent.

- **Gateway: per-service URL routing** in `test-contract-config.ts`: `contractWorkerRunnerBaseUrl()` + generic `contractServiceBaseUrl(service)`. `probeHttp` in `test-contract-commands.ts` now takes an optional base-URL getter (defaults to gateway for PR-L1 backward compat). 5 new allowlist entries bind to `contractWorkerRunnerBaseUrl`.

- **Gateway: missing-test scanner generalized.** `WORKER_RUNNER_ENDPOINT_FILE_MAP` (5 entries). `scanMissingContracts` now takes a service param; capability slugs namespace (`worker_runner_alive` vs `gateway_alive`). `suggestedCommandKey` emits `worker_runner.<slug>` when service='worker-runner'. `scanMissingContractsAgainstLiveRegistry` walks BOTH maps.

- **Worker-runner: canary route** (NEW `services/worker-runner/src/routes/canary-target.ts`) — `WorkerRunnerCanaryArmedFault` typed error (mirrors gateway PR-I), reads `system_config.worker_runner_canary_armed` with 5s cache. Mounted under `/api/v1/canary-target` in `services/worker-runner/src/index.ts`.

- **Tests**: 6 new in `missing-test-scanner.test.ts` covering worker-runner namespacing, dedupe non-collision, default service, `suggestedCommandKey` per service, `scanMissingContractsAgainstLiveRegistry` walking both maps. Allowlist roster test updated to 11 entries.

## Test plan

- [x] 220/221 across 18 suites (1 skip pre-existing)
- [x] Gateway `npm run build` clean
- [ ] **After merge**: gateway + worker-runner BOTH auto-deploy via their respective AUTO-DEPLOY workflows
- [ ] Dispatch `RUN-MIGRATION.yml` for `20260521000004_VTID_02978_worker_runner_contracts.sql` — **grep `ERROR:`/`ROLLBACK` BEFORE trusting REST per memory rule**
- [ ] Click "Run scheduled scan" in cockpit — 4 new worker-runner contracts should flip from UNKNOWN to PASS

## Green-path smoke (after deploys)

1. PATCH `system_config.worker_runner_canary_armed=true` via Supabase REST
2. Wait 6s for the 5s cache to expire
3. Click "Run scheduled scan" — canary contract flips to FAIL (signature `worker_runner.canary_target_health:status_mismatch`)
4. Click again — 2nd consecutive same-signature failure triggers the failure scanner to allocate a repair VTID with `repair_kind='fix_failing_test'` + known-good context for `services/worker-runner/src/routes/canary-target.ts`
5. Dev autopilot picks up the VTID, writes the typed-catch fix, CI green, deploy, scheduled scan re-runs, contract returns to PASS
6. PATCH `worker_runner_canary_armed=false` to clean up

🤖 Generated with [Claude Code](https://claude.com/claude-code)