### PR TITLE
fix(self-healing): drop bogus top-level 'scanner' field from autopilot_recommendations INSERTs (VTID-02979, PR-M1.1)

### DIFF
--- a/services/gateway/src/routes/test-contracts-missing.ts
+++ b/services/gateway/src/routes/test-contracts-missing.ts
@@ -280,7 +280,10 @@ The capability \`${gap.capability}\` (endpoint \`${gap.target_endpoint}\`, file 
         effort_score: 3,
         auto_exec_eligible: true,
         domain: 'gateway',
-        scanner: 'missing-test-scanner',
+        // VTID-02979 (PR-M1.1 hotfix): `scanner` is NOT a column on
+        // autopilot_recommendations — it lives in spec_snapshot.scanner.
+        // The top-level field caused PostgREST to reject the entire INSERT
+        // with PGRST204, leaving allocated VTIDs orphaned without a recommendation.
         spec_snapshot: {
           spec_markdown,
           files_referenced: [

--- a/services/gateway/src/routes/test-contracts-scheduled.ts
+++ b/services/gateway/src/routes/test-contracts-scheduled.ts
@@ -300,7 +300,10 @@ ${patternMd}
                   effort_score: 4,
                   auto_exec_eligible: true,
                   domain: 'gateway',
-                  scanner: 'test-contract-failure-scanner',
+                  // VTID-02979 (PR-M1.1 hotfix): `scanner` is NOT a column on
+                  // autopilot_recommendations — it lives in spec_snapshot.scanner.
+                  // The top-level field caused PostgREST to reject the entire
+                  // INSERT with PGRST204, leaving repair VTIDs orphaned.
                   spec_snapshot: {
                     spec_markdown: specMarkdown,
                     files_referenced: [


### PR DESCRIPTION
## Summary

Hotfix found during the M1 worker-runner canary smoke. PR-L2 + PR-L3 both INSERT into `autopilot_recommendations` with a top-level `scanner` field. PostgREST rejects with PGRST204 because **`scanner` is NOT a column on that table** — it lives nested inside `spec_snapshot.scanner`. The INSERT silently fails, but VTID allocation has ALREADY happened, so the route reports `repair_vtid: VTID-XXXXX` while the recommendation never lands. The autopilot pipeline can't pick up an orphaned VTID, so the loop silently dies after the allocation step.

## Observed live (VTID-02974, M1.0 smoke)

- Failure scanner ran, debounced, then on 2nd consecutive same-signature failure allocated VTID-02974
- Route reported `repairs_allocated=1` to the caller
- `vtid_ledger` row had only the bare allocator metadata (no `autopilot_finding_id`, no `repair_kind`, no `failure_signature`)
- `autopilot_recommendations` had **no row** for that finding_id
- Canary loop went silent after the allocation

## Fix

Remove the top-level `scanner` field from both INSERT bodies (`test-contracts-scheduled.ts` + `test-contracts-missing.ts`). The nested `spec_snapshot.scanner` stays — that's the correct location.

## Why tests didn't catch this

The unit tests mock `fetch` and accept any JSON — there's no live-PostgREST contract check. PostgREST's column rejection only manifests against the real schema. Worth considering for a follow-up: a smoke test that hits a real Supabase REST endpoint with a schema-typed payload.

## Test plan

- [x] `npm run build` clean
- [x] Existing tests still pass (no behavior change, just remove a bad field)
- [ ] **After merge + EXEC-DEPLOY**: re-run the M1.0 canary smoke. Arm `worker_runner_canary_armed=true`. Click "Run scheduled scan" twice. Second scan's `repair_vtid` should now ALSO have a populated `autopilot_recommendations` row + enriched `vtid_ledger.metadata` + an emitted `test-contract.repair.allocated` event.

🤖 Generated with [Claude Code](https://claude.com/claude-code)