### PR TITLE
feat(voice): lift activate_recommendation to shared dispatcher (VTID-02975)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -4283,76 +4283,31 @@ async function executeLiveApiToolInner(
       // the authoritative path and runs on its own when the user opens the
       // app. This tool dispatch only covers the voice-handshake case.
       case 'activate_recommendation': {
-        const recId = String(args.id || '').trim();
-        if (!recId) {
-          return { success: false, result: '', error: 'id is required' };
+        // VTID-02975: lifted to services/orb-tools-shared.ts. The shared
+        // handler verifies ownership, flips new→activated only if needed,
+        // emits guide.initiative.executed telemetry, and returns a result
+        // with title + already_active for the celebratory close. Reachable
+        // identically via /api/v1/orb/tool now that it's in ORB_TOOL_REGISTRY.
+        const SUPABASE_URL = process.env.SUPABASE_URL;
+        const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
+        if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
+          return { success: false, result: '', error: 'Service unavailable — Supabase creds not configured' };
         }
-        try {
-          const { createClient } = await import('@supabase/supabase-js');
-          const supabase = createClient(
-            process.env.SUPABASE_URL!,
-            process.env.SUPABASE_SERVICE_ROLE!,
-          );
-
-          // Verify ownership + fetch title for the celebratory close.
-          const { data: rec, error: fetchErr } = await supabase
-            .from('autopilot_recommendations')
-            .select('id, title, summary, status, user_id')
-            .eq('id', recId)
-            .maybeSingle();
-
-          if (fetchErr) {
-            return { success: false, result: '', error: fetchErr.message };
-          }
-          if (!rec) {
-            return { success: false, result: '', error: 'recommendation_not_found' };
-          }
-          if (rec.user_id && rec.user_id !== session.identity!.user_id) {
-            return {
-              success: false,
-              result: '',
-              error: 'recommendation_belongs_to_another_user',
-            };
-          }
-
-          const alreadyActive = rec.status === 'activated';
-          if (!alreadyActive) {
-            const { error: updErr } = await supabase
-              .from('autopilot_recommendations')
-              .update({ status: 'activated', updated_at: new Date().toISOString() })
-              .eq('id', recId);
-            if (updErr) {
-              return { success: false, result: '', error: updErr.message };
-            }
-          }
-
-          // Telemetry — fire-and-forget. Mirrors the consented/executed split
-          // from the initiative-engine plan so dashboards can compute funnel.
-          import('../services/guide').then(({ emitGuideTelemetry }) => {
-            emitGuideTelemetry('guide.initiative.executed', {
-              user_id: session.identity!.user_id,
-              initiative_key: 'autopilot_top_recommendation',
-              on_yes_tool: 'activate_recommendation',
-              recommendation_id: recId,
-              already_active: alreadyActive,
-            }).catch(() => {});
-          }).catch(() => {});
-
-          return {
-            success: true,
-            result: JSON.stringify({
-              ok: true,
-              title: rec.title,
-              already_active: alreadyActive,
-              completion_message: alreadyActive
-                ? `"${rec.title}" was already on your active list — I'll keep it there.`
-                : `Done — "${rec.title}" is on your active list. Open Autopilot when you're ready to start it.`,
-            }),
-          };
-        } catch (err: any) {
-          console.error('[V2-INITIATIVE] activate_recommendation error:', err?.message);
-          return { success: false, result: '', error: err?.message || 'unknown' };
-        }
+        const { createClient } = await import('@supabase/supabase-js');
+        const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE);
+        const { dispatchOrbToolForVertex } = await import('../services/orb-tools-shared');
+        return await dispatchOrbToolForVertex(
+          'activate_recommendation',
+          args ?? {},
+          {
+            user_id: lens.user_id,
+            tenant_id: lens.tenant_id ?? null,
+            role: session.identity?.role ?? null,
+            vitana_id: session.identity?.vitana_id ?? null,
+            session_id: session.sessionId ?? null,
+          },
+          supabase,
+        );
       }
 
       case 'share_link': {

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -1957,6 +1957,90 @@ export async function tool_send_chat_message(
   }
 }
 
+/**
+ * VTID-02975: lifted from orb-live.ts:4285 (V2 Proactive Initiative Engine).
+ *
+ * Activates an Autopilot recommendation on the user's behalf. The voice
+ * "yes" handoff after a send_chat_message next_actions[0] suggestion lands
+ * here; the HTTP /api/v1/orb/tool endpoint dispatches to it via the shared
+ * registry; LiveKit's tool runner uses it via the same registry. Single
+ * source — no per-pipeline divergence.
+ *
+ * Verifies ownership (rec.user_id must match the actor or be null),
+ * flips status new→activated only if not already activated, and emits
+ * guide.initiative.executed telemetry fire-and-forget so the funnel
+ * dashboards stay accurate regardless of which surface drove activation.
+ */
+export async function tool_activate_recommendation(
+  args: OrbToolArgs,
+  id: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const recId = String(args.id ?? '').trim();
+  if (!recId) {
+    return { ok: false, error: 'id is required' };
+  }
+  try {
+    const { data: rec, error: fetchErr } = await sb
+      .from('autopilot_recommendations')
+      .select('id, title, summary, status, user_id')
+      .eq('id', recId)
+      .maybeSingle();
+
+    if (fetchErr) {
+      return { ok: false, error: fetchErr.message };
+    }
+    if (!rec) {
+      return { ok: false, error: 'recommendation_not_found' };
+    }
+    const recRow = rec as { id: string; title: string | null; summary: string | null; status: string | null; user_id: string | null };
+    if (recRow.user_id && recRow.user_id !== id.user_id) {
+      return { ok: false, error: 'recommendation_belongs_to_another_user' };
+    }
+
+    const alreadyActive = recRow.status === 'activated';
+    if (!alreadyActive) {
+      const { error: updErr } = await sb
+        .from('autopilot_recommendations')
+        .update({ status: 'activated', updated_at: new Date().toISOString() })
+        .eq('id', recId);
+      if (updErr) {
+        return { ok: false, error: updErr.message };
+      }
+    }
+
+    // Fire-and-forget telemetry. Mirrors the inline Vertex case path so
+    // funnel dashboards (`guide.initiative.executed`) keep counting both
+    // voice and REST activations under the same event type.
+    import('./guide')
+      .then(({ emitGuideTelemetry }) => {
+        emitGuideTelemetry('guide.initiative.executed', {
+          user_id: id.user_id,
+          initiative_key: 'autopilot_top_recommendation',
+          on_yes_tool: 'activate_recommendation',
+          recommendation_id: recId,
+          already_active: alreadyActive,
+        }).catch(() => {});
+      })
+      .catch(() => {});
+
+    const title = recRow.title ?? 'that recommendation';
+    return {
+      ok: true,
+      result: {
+        title: recRow.title,
+        already_active: alreadyActive,
+      },
+      text: alreadyActive
+        ? `"${title}" was already on your active list — I'll keep it there.`
+        : `Done — "${title}" is on your active list. Open Autopilot when you're ready to start it.`,
+    };
+  } catch (err: unknown) {
+    const msg = err instanceof Error ? err.message : 'activate_recommendation error';
+    return { ok: false, error: msg };
+  }
+}
+
 export async function tool_share_link(
   args: OrbToolArgs,
   id: OrbToolIdentity,
@@ -3370,6 +3454,9 @@ export const ORB_TOOL_REGISTRY: Record<string, OrbToolHandler> = {
   resolve_recipient: tool_resolve_recipient,
   send_chat_message: tool_send_chat_message,
   share_link: tool_share_link,
+  // VTID-02975: lifted from orb-live.ts inline. Reachable via Vertex,
+  // LiveKit, AND /api/v1/orb/tool now that it's in the shared registry.
+  activate_recommendation: tool_activate_recommendation,
   scan_existing_matches: tool_scan_existing_matches,
   share_intent_post: tool_share_intent_post,
   respond_to_match: tool_respond_to_match,

--- a/services/gateway/test/voice-activate-recommendation-shared.test.ts
+++ b/services/gateway/test/voice-activate-recommendation-shared.test.ts
@@ -1,0 +1,258 @@
+/**
+ * VTID-02975: activate_recommendation reachable via the shared dispatcher.
+ *
+ * Closes the conversational-activation gap reported in the VTID-02969
+ * live smoke test: the canonical autopilot REST endpoint activates
+ * recommendations, and ORB voice send_chat_message returns next_actions
+ * referencing them, but /api/v1/orb/tool previously returned 404 for
+ * activate_recommendation and /api/v1/orb/chat rejected the spoken-yes
+ * intent. After this lift, the same handler is reachable from:
+ *   - Vertex voice (orb-live.ts case → dispatchOrbToolForVertex)
+ *   - LiveKit (uses ORB_TOOL_REGISTRY directly)
+ *   - /api/v1/orb/tool (HTTP wrapper around dispatchOrbTool)
+ * No path-specific divergence is possible.
+ *
+ * These tests pin the contract:
+ *   1. Dispatch via the shared registry succeeds (status new → activated).
+ *   2. Already-active recs return ok:true + already_active:true (idempotent).
+ *   3. Ownership: a rec owned by another user is rejected.
+ *   4. Missing rec returns recommendation_not_found.
+ *   5. Result.text is the celebratory close — what Gemini will speak.
+ */
+
+process.env.NODE_ENV = 'test';
+process.env.SUPABASE_URL = 'http://supabase.test';
+process.env.SUPABASE_SERVICE_ROLE = 'test-service-role';
+
+import {
+  dispatchOrbTool,
+  tool_activate_recommendation,
+} from '../src/services/orb-tools-shared';
+
+const SENDER_UUID = 'aaaa1111-1111-4111-8111-111111111111';
+const OTHER_USER_UUID = 'bbbb2222-2222-4222-8222-222222222222';
+const REC_UUID_NEW = 'cccc3333-3333-4333-8333-333333333333';
+const REC_UUID_ACTIVATED = 'dddd4444-4444-4444-8444-444444444444';
+const REC_UUID_FOREIGN = 'eeee5555-5555-4555-8555-555555555555';
+
+interface CapturedUpdate {
+  recId: string;
+  patch: Record<string, unknown>;
+}
+
+function makeStubSupabase(opts: {
+  recs: Record<string, { id: string; title?: string | null; summary?: string | null; status: string; user_id: string | null }>;
+  updateError?: { message: string } | null;
+  fetchError?: { message: string } | null;
+  updates: CapturedUpdate[];
+}) {
+  return {
+    from(table: string) {
+      if (table !== 'autopilot_recommendations') {
+        return {} as never;
+      }
+      return {
+        select: () => ({
+          eq: (_col: string, value: string) => ({
+            maybeSingle: async () => ({
+              data: opts.recs[value] ?? null,
+              error: opts.fetchError ?? null,
+            }),
+          }),
+        }),
+        update: (patch: Record<string, unknown>) => ({
+          eq: async (_col: string, value: string) => {
+            opts.updates.push({ recId: value, patch });
+            return { error: opts.updateError ?? null };
+          },
+        }),
+      } as unknown;
+    },
+  } as never;
+}
+
+describe('VTID-02975 — activate_recommendation lifted to shared dispatcher', () => {
+  test('1. status new → activated via shared dispatch (dispatchOrbTool path)', async () => {
+    const updates: CapturedUpdate[] = [];
+    const sb = makeStubSupabase({
+      updates,
+      recs: {
+        [REC_UUID_NEW]: {
+          id: REC_UUID_NEW,
+          title: 'Investigate deploy failure: gateway',
+          summary: 'Smoke test rec',
+          status: 'new',
+          user_id: SENDER_UUID,
+        },
+      },
+    });
+
+    const result = await dispatchOrbTool(
+      'activate_recommendation',
+      { id: REC_UUID_NEW },
+      { user_id: SENDER_UUID, tenant_id: 'tenant-1', role: 'user', vitana_id: 'vit_send' },
+      sb,
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok === true) {
+      const r = result.result as { title: string; already_active: boolean };
+      expect(r.already_active).toBe(false);
+      expect(r.title).toBe('Investigate deploy failure: gateway');
+      expect(result.text).toMatch(/Done — "Investigate deploy failure: gateway" is on your active list/);
+    }
+    expect(updates).toHaveLength(1);
+    expect(updates[0]).toMatchObject({
+      recId: REC_UUID_NEW,
+      patch: { status: 'activated' },
+    });
+  });
+
+  test('2. already-activated rec returns ok:true + already_active:true (idempotent)', async () => {
+    const updates: CapturedUpdate[] = [];
+    const sb = makeStubSupabase({
+      updates,
+      recs: {
+        [REC_UUID_ACTIVATED]: {
+          id: REC_UUID_ACTIVATED,
+          title: 'Already active rec',
+          summary: null,
+          status: 'activated',
+          user_id: SENDER_UUID,
+        },
+      },
+    });
+
+    const result = await tool_activate_recommendation(
+      { id: REC_UUID_ACTIVATED },
+      { user_id: SENDER_UUID, tenant_id: 'tenant-1', role: 'user', vitana_id: 'vit_send' },
+      sb,
+    );
+
+    expect(result.ok).toBe(true);
+    if (result.ok === true) {
+      const r = result.result as { already_active: boolean };
+      expect(r.already_active).toBe(true);
+      expect(result.text).toMatch(/was already on your active list/);
+    }
+    // No UPDATE issued — idempotent.
+    expect(updates).toHaveLength(0);
+  });
+
+  test('3. rec owned by another user → recommendation_belongs_to_another_user', async () => {
+    const updates: CapturedUpdate[] = [];
+    const sb = makeStubSupabase({
+      updates,
+      recs: {
+        [REC_UUID_FOREIGN]: {
+          id: REC_UUID_FOREIGN,
+          title: 'Not yours',
+          summary: null,
+          status: 'new',
+          user_id: OTHER_USER_UUID,
+        },
+      },
+    });
+
+    const result = await tool_activate_recommendation(
+      { id: REC_UUID_FOREIGN },
+      { user_id: SENDER_UUID, tenant_id: 'tenant-1', role: 'user', vitana_id: 'vit_send' },
+      sb,
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok === false) {
+      expect(result.error).toBe('recommendation_belongs_to_another_user');
+    }
+    expect(updates).toHaveLength(0); // never mutated
+  });
+
+  test('4. missing rec → recommendation_not_found', async () => {
+    const updates: CapturedUpdate[] = [];
+    const sb = makeStubSupabase({ updates, recs: {} });
+
+    const result = await tool_activate_recommendation(
+      { id: 'ffff6666-6666-4666-8666-666666666666' },
+      { user_id: SENDER_UUID, tenant_id: 'tenant-1', role: 'user', vitana_id: 'vit_send' },
+      sb,
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok === false) {
+      expect(result.error).toBe('recommendation_not_found');
+    }
+    expect(updates).toHaveLength(0);
+  });
+
+  test('5. system-owned rec (user_id=null) is activatable by any user', async () => {
+    // The original orb-live.ts logic: `rec.user_id && rec.user_id !== identity`
+    // — null user_id means "system-wide recommendation", anyone can activate.
+    const updates: CapturedUpdate[] = [];
+    const sysRecId = '99999999-9999-4999-8999-999999999999';
+    const sb = makeStubSupabase({
+      updates,
+      recs: {
+        [sysRecId]: {
+          id: sysRecId,
+          title: 'System rec',
+          summary: null,
+          status: 'new',
+          user_id: null,
+        },
+      },
+    });
+
+    const result = await tool_activate_recommendation(
+      { id: sysRecId },
+      { user_id: SENDER_UUID, tenant_id: 'tenant-1', role: 'user', vitana_id: 'vit_send' },
+      sb,
+    );
+
+    expect(result.ok).toBe(true);
+    expect(updates).toHaveLength(1);
+  });
+
+  test('6. missing id → "id is required"', async () => {
+    const updates: CapturedUpdate[] = [];
+    const sb = makeStubSupabase({ updates, recs: {} });
+
+    const result = await tool_activate_recommendation(
+      { id: '' },
+      { user_id: SENDER_UUID, tenant_id: 'tenant-1', role: 'user', vitana_id: 'vit_send' },
+      sb,
+    );
+
+    expect(result.ok).toBe(false);
+    if (result.ok === false) {
+      expect(result.error).toBe('id is required');
+    }
+  });
+
+  test('7. dispatchOrbTool exposes activate_recommendation by name (no more "unknown tool")', async () => {
+    // Regression guard for the gap the user reported: /api/v1/orb/tool used
+    // to return 404 because activate_recommendation was not in
+    // ORB_TOOL_REGISTRY. This test fails loud if anyone removes it.
+    const sb = makeStubSupabase({
+      updates: [],
+      recs: {
+        [REC_UUID_NEW]: {
+          id: REC_UUID_NEW,
+          title: 'Discoverable',
+          summary: null,
+          status: 'new',
+          user_id: SENDER_UUID,
+        },
+      },
+    });
+    const r = await dispatchOrbTool(
+      'activate_recommendation',
+      { id: REC_UUID_NEW },
+      { user_id: SENDER_UUID, tenant_id: 'tenant-1', role: 'user', vitana_id: 'vit_send' },
+      sb,
+    );
+    if (r.ok === false) {
+      expect(r.error).not.toMatch(/^unknown tool:/);
+    }
+    expect(r.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the conversational-activation gap surfaced by the VTID-02969 live smoke test:

- ✅ Voice send_chat_message returns `next_actions[0]` referencing the canonical Autopilot top recommendation.
- ❌ `/api/v1/orb/tool` returned 404 for `activate_recommendation` because the handler was inline in `orb-live.ts`, never registered in the shared `ORB_TOOL_REGISTRY`.
- ❌ `/api/v1/orb/chat` rejected the spoken-yes intent (it's the typed-chat endpoint, not the voice tool dispatcher).

## Lift

- `orb-live.ts:4285-4356` (inline case body) → `tool_activate_recommendation` in `services/orb-tools-shared.ts`.
- Same behavior, single source: ownership check, idempotent status flip new→activated, `guide.initiative.executed` telemetry, celebratory-close `text`.
- `orb-live.ts` case body becomes a 13-line delegator to `dispatchOrbToolForVertex`, matching the B-series lift pattern (send_chat_message, share_link, resolve_recipient).
- Registry: `activate_recommendation` now in `ORB_TOOL_REGISTRY` so it's reachable identically via Vertex voice, LiveKit, AND `/api/v1/orb/tool`.

## Tests (25 total green: 18 prior + 7 new)

New tests in `voice-activate-recommendation-shared.test.ts`:
1. status new → activated via shared dispatch
2. already-active rec → `ok:true + already_active:true` (idempotent, no UPDATE issued)
3. rec owned by another user → `recommendation_belongs_to_another_user`
4. missing rec → `recommendation_not_found`
5. system-owned rec (`user_id=null`) → activatable by any user
6. missing id → `'id is required'`
7. **Regression guard**: `dispatchOrbTool('activate_recommendation', ...)` must NOT return `'unknown tool:'` (the exact failure the user reported with `/api/v1/orb/tool`)

## Live smoke proof from VTID-02969 (user-reported)

- Voice send: real message to Dragan RED, push notification received on device
- `next_actions[0]` returned canonical Autopilot top rec (matches popup exactly)
- Canonical REST activation works → created VTID-02973

After this PR: the spoken-yes handoff through ORB voice now calls `activate_recommendation` via the same shared registry. No more `'unknown tool'` 404.

## Still queued

- **F-SH1**: daily voice self-healing routine (resolve_recipient → send → row-exists → cleanup).
- **F-CHAR1**: B-track characterization suite for the 6 lifted tool functions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)