### PR TITLE
feat(orb): L1 — upstream provider-selection wiring (VTID-02976)

### DIFF
--- a/services/gateway/src/orb/live/upstream/upstream-provider-selector.ts
+++ b/services/gateway/src/orb/live/upstream/upstream-provider-selector.ts
@@ -1,0 +1,192 @@
+/**
+ * L1 (VTID-02976 / orb-live-refactor): pure provider-selection policy for
+ * the ORB upstream live client.
+ *
+ * Inputs:
+ *   - `ORB_LIVE_PROVIDER` env (highest priority override): `'vertex' | 'livekit' | ''`
+ *   - `voice.active_provider` system_config row (read via voice-config.ts before
+ *     calling this selector): `'vertex' | 'livekit'`
+ *   - LiveKit credentials in env: `LIVEKIT_URL`, `LIVEKIT_API_KEY`,
+ *     `LIVEKIT_API_SECRET`
+ *
+ * Output:
+ *   - `provider` — the upstream client implementation the consumer SHOULD use.
+ *     L1 caps this at `'vertex'` because the LiveKit client is not yet wired
+ *     into `connectToLiveAPI`; L2 (canary) flips this to honor `'livekit'`.
+ *   - `requested` — what the caller asked for (or `null` if no override).
+ *   - `reason` — why `provider` was chosen (drives the OASIS event).
+ *   - `error` — populated only when the request was `'livekit'` but a gate
+ *     failed (config missing, not enabled, or `pinned_to_vertex_l1`).
+ *
+ * Selection rules:
+ *   1. If `ORB_LIVE_PROVIDER` is explicitly `'vertex'` → Vertex (reason
+ *      `env_explicit`).
+ *   2. If `ORB_LIVE_PROVIDER` is explicitly `'livekit'`:
+ *        a. require `LIVEKIT_URL`, `LIVEKIT_API_KEY`, `LIVEKIT_API_SECRET`.
+ *           If any missing → Vertex (reason `livekit_config_invalid`).
+ *        b. all gates pass → LiveKit *would* be selected, but L1 pins to
+ *           Vertex (reason `pinned_to_vertex_l1`) because the LiveKit
+ *           upstream client isn't wired yet. L2 lifts this pin.
+ *   3. Else if `ORB_LIVE_PROVIDER` is unset, fall back to
+ *      `voice.active_provider` system_config with the same gating logic
+ *      (reason prefix `system_config` instead of `env_explicit`).
+ *   4. No request signal anywhere → Vertex (reason `default`).
+ *
+ * The selector is PURE — it never reads env, never queries DB, never emits
+ * OASIS. The caller supplies all inputs via the `UpstreamSelectorContext`
+ * and emits OASIS events based on the returned decision. This keeps unit
+ * tests trivial (no mocks of process.env / Supabase / OASIS).
+ *
+ * Hard rules:
+ *   - LiveKit cannot reach `provider: 'livekit'` in L1. The selector may
+ *     compute a `livekit_ready: true` flag, but `provider` stays
+ *     `'vertex'` and `reason` becomes `pinned_to_vertex_l1`.
+ *   - Selection NEVER throws. Invalid inputs degrade to Vertex with a
+ *     typed `error` field on the decision.
+ */
+
+export type UpstreamProviderName = 'vertex' | 'livekit';
+
+export type SelectionReason =
+  | 'default'                  // no override anywhere → vertex
+  | 'env_explicit_vertex'      // ORB_LIVE_PROVIDER=vertex
+  | 'env_explicit_livekit'     // ORB_LIVE_PROVIDER=livekit; would be livekit (but L1 pins, see below)
+  | 'system_config_vertex'     // voice.active_provider=vertex (env unset)
+  | 'system_config_livekit'    // voice.active_provider=livekit (env unset); would be livekit (but L1 pins)
+  | 'livekit_config_invalid'   // livekit requested, creds missing → vertex
+  | 'pinned_to_vertex_l1';     // livekit requested AND creds present → still pinned to vertex in L1
+
+export interface UpstreamSelectorContext {
+  /** `process.env.ORB_LIVE_PROVIDER` — `'vertex' | 'livekit' | ''` (or unset). */
+  envProviderOverride?: string;
+  /** From `voice.active_provider` system_config row. `undefined` if unread. */
+  systemConfigActiveProvider?: UpstreamProviderName;
+  /** LiveKit creds — passed in explicitly so the selector stays pure. */
+  livekitCredentials?: {
+    url?: string;
+    apiKey?: string;
+    apiSecret?: string;
+  };
+}
+
+export interface UpstreamSelectionDecision {
+  /** What the consumer should actually instantiate. L1 always pins to `'vertex'`. */
+  provider: UpstreamProviderName;
+  /** What was requested. `null` if no override was provided. */
+  requested: UpstreamProviderName | null;
+  /** Why `provider` was chosen. Drives OASIS event payload. */
+  reason: SelectionReason;
+  /**
+   * Whether LiveKit would have been selected if L1 weren't pinning to Vertex.
+   * Useful for the L2 cutover and for the Improve cockpit's "rollout readiness"
+   * indicator. False when LiveKit wasn't requested or creds are incomplete.
+   */
+  livekitReady: boolean;
+  /**
+   * Typed error when the LiveKit path was requested but a gate failed.
+   * Empty/undefined on the happy Vertex path.
+   */
+  error?: string;
+}
+
+const LIVEKIT_CRED_FIELDS = ['url', 'apiKey', 'apiSecret'] as const;
+
+function normalizeOverride(raw: string | undefined): UpstreamProviderName | null {
+  if (typeof raw !== 'string') return null;
+  const trimmed = raw.trim().toLowerCase();
+  if (trimmed === 'vertex') return 'vertex';
+  if (trimmed === 'livekit') return 'livekit';
+  return null;
+}
+
+function livekitCredsMissing(
+  creds: UpstreamSelectorContext['livekitCredentials'],
+): string[] {
+  const missing: string[] = [];
+  const c = creds ?? {};
+  for (const key of LIVEKIT_CRED_FIELDS) {
+    const v = (c as Record<string, string | undefined>)[key];
+    if (typeof v !== 'string' || v.length === 0) missing.push(key);
+  }
+  return missing;
+}
+
+/**
+ * Pure selector. Never throws. Never reads env. Never queries DB.
+ * The caller is responsible for emitting an OASIS event based on the
+ * returned decision (see `connectToLiveAPI`).
+ */
+export function selectUpstreamProvider(
+  ctx: UpstreamSelectorContext,
+): UpstreamSelectionDecision {
+  const envChoice = normalizeOverride(ctx.envProviderOverride);
+  const sysChoice =
+    ctx.systemConfigActiveProvider === 'vertex' ||
+    ctx.systemConfigActiveProvider === 'livekit'
+      ? ctx.systemConfigActiveProvider
+      : null;
+
+  // Highest-priority signal: env override.
+  if (envChoice === 'vertex') {
+    return {
+      provider: 'vertex',
+      requested: 'vertex',
+      reason: 'env_explicit_vertex',
+      livekitReady: false,
+    };
+  }
+  if (envChoice === 'livekit') {
+    return evaluateLiveKitRequest(ctx, 'livekit', 'env_explicit_livekit');
+  }
+
+  // Fallback: voice.active_provider system_config.
+  if (sysChoice === 'vertex') {
+    return {
+      provider: 'vertex',
+      requested: 'vertex',
+      reason: 'system_config_vertex',
+      livekitReady: false,
+    };
+  }
+  if (sysChoice === 'livekit') {
+    return evaluateLiveKitRequest(ctx, 'livekit', 'system_config_livekit');
+  }
+
+  // Nothing requested → default.
+  return {
+    provider: 'vertex',
+    requested: null,
+    reason: 'default',
+    livekitReady: false,
+  };
+}
+
+function evaluateLiveKitRequest(
+  ctx: UpstreamSelectorContext,
+  requested: UpstreamProviderName,
+  happyReason: SelectionReason,
+): UpstreamSelectionDecision {
+  const missing = livekitCredsMissing(ctx.livekitCredentials);
+  if (missing.length > 0) {
+    return {
+      provider: 'vertex',
+      requested,
+      reason: 'livekit_config_invalid',
+      livekitReady: false,
+      error: `LiveKit credentials missing: ${missing.join(', ')}`,
+    };
+  }
+  // Creds are valid; L1 pins to Vertex (the LiveKit upstream client is
+  // not yet wired into connectToLiveAPI). `happyReason` is preserved on
+  // `livekitReady=true` for operator-side rollout monitoring, but `reason`
+  // is `pinned_to_vertex_l1` to signal the deliberate L1 cap.
+  return {
+    provider: 'vertex',
+    requested,
+    reason: 'pinned_to_vertex_l1',
+    livekitReady: true,
+    error:
+      'LiveKit upstream client not wired in L1; pinning to Vertex. ' +
+      `Would-have-selected reason: ${happyReason}.`,
+  };
+}

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1164,6 +1164,15 @@ import { createUpstreamLiveMessageHandler } from '../orb/live/session/upstream-m
 // A8.3b.2 will rename / remove this adapter; for now it remains the active
 // call path so frontends + transparent reconnect see no behavior change.
 import { VertexLiveClient } from '../orb/live/upstream/vertex-live-client';
+// L1 (VTID-02976): provider-selection plumbing for the upstream live client.
+// Pure selector — `connectToLiveAPI` reads env + voice.active_provider, then
+// asks the selector which provider to use, then emits OASIS events for the
+// decision. L1 always pins to Vertex; L2 (canary) will honor LiveKit.
+import {
+  selectUpstreamProvider,
+  type UpstreamSelectionDecision,
+} from '../orb/live/upstream/upstream-provider-selector';
+// NOTE: `getVoiceConfig` is already imported above (line ~92).
 // A3 (orb-live-refactor): system instruction builder + its private helpers
 // (describeTimeSince, describeRoute, buildTemporalJourneyContextSection,
 // TemporalBucket type) lifted to orb/live/instruction/live-system-instruction.ts.
@@ -5530,6 +5539,70 @@ async function connectToLiveAPI(
   // VTID-01222: Fail fast if project/location missing
   if (!VERTEX_PROJECT_ID || !VERTEX_LOCATION) {
     throw new Error('Missing VERTEX_PROJECT_ID or VERTEX_LOCATION');
+  }
+
+  // L1 (VTID-02976): consult the upstream provider selector. The selector
+  // is a pure function — it never reads env / DB / OASIS. We gather inputs
+  // here, hand them in, and emit OASIS based on the returned decision.
+  // L1 always pins to Vertex; the decision tells operators what *would*
+  // happen once L2 lifts the pin.
+  let __upstreamDecision: UpstreamSelectionDecision;
+  try {
+    const __voiceCfg = await getVoiceConfig();
+    __upstreamDecision = selectUpstreamProvider({
+      envProviderOverride: process.env.ORB_LIVE_PROVIDER,
+      systemConfigActiveProvider: __voiceCfg.active_provider,
+      livekitCredentials: {
+        url: process.env.LIVEKIT_URL,
+        apiKey: process.env.LIVEKIT_API_KEY,
+        apiSecret: process.env.LIVEKIT_API_SECRET,
+      },
+    });
+  } catch (e) {
+    // Voice config read failure must NOT block the session start; default
+    // to Vertex so production behavior matches today.
+    console.warn(`[VTID-02976] voice-config read failed; falling back to vertex defaults: ${(e as Error).message}`);
+    __upstreamDecision = {
+      provider: 'vertex',
+      requested: null,
+      reason: 'default',
+      livekitReady: false,
+    };
+  }
+  console.log(
+    `[VTID-02976] upstream provider selected: provider=${__upstreamDecision.provider}` +
+      ` requested=${__upstreamDecision.requested ?? 'none'}` +
+      ` reason=${__upstreamDecision.reason}` +
+      ` livekit_ready=${__upstreamDecision.livekitReady}`,
+  );
+  // OASIS emission — every connect call emits a single `selected` event.
+  // When the request was LiveKit but the path degraded (config invalid or
+  // pinned_to_vertex_l1), also emit a `selection_error` event with the
+  // typed error string so the Improve cockpit can surface it.
+  void emitOasisEvent({
+    type: 'orb.upstream.provider.selected',
+    vtid: 'VTID-02976',
+    payload: {
+      session_id: session.sessionId,
+      provider: __upstreamDecision.provider,
+      requested: __upstreamDecision.requested,
+      reason: __upstreamDecision.reason,
+      livekit_ready: __upstreamDecision.livekitReady,
+    } as any,
+  } as any).catch(() => { /* best-effort */ });
+  if (__upstreamDecision.error) {
+    void emitOasisEvent({
+      type: 'orb.upstream.provider.selection_error',
+      vtid: 'VTID-02976',
+      payload: {
+        session_id: session.sessionId,
+        provider: __upstreamDecision.provider,
+        requested: __upstreamDecision.requested,
+        reason: __upstreamDecision.reason,
+        livekit_ready: __upstreamDecision.livekitReady,
+        error: __upstreamDecision.error,
+      } as any,
+    } as any).catch(() => { /* best-effort */ });
   }
 
   // A8.3b.2 (VTID-02972): the legacy raw-WebSocket scaffolding is gone.

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -520,6 +520,11 @@ export type CicdEventType =
   | 'tenant.weekly.review.ready'
   // BOOTSTRAP-ADMIN-DD: admin voice tool side-effects
   | 'admin.autopilot.pause_requested'
+  // L1 (VTID-02976): upstream provider selection — pure-selector decisions.
+  // `selected` fires once per `connectToLiveAPI` call; `selection_error` fires
+  // ONLY when a LiveKit request was downgraded (config invalid or pinned_to_vertex_l1).
+  | 'orb.upstream.provider.selected'
+  | 'orb.upstream.provider.selection_error'
   // VTID-DIAG: Pipeline diagnostics
   | 'orb.live.diag'
   // VTID-FALLBACK: Chat-TTS fallback events

--- a/services/gateway/test/orb/live/characterization/upstream-message-handler.characterization.test.ts
+++ b/services/gateway/test/orb/live/characterization/upstream-message-handler.characterization.test.ts
@@ -201,4 +201,28 @@ describe('A8.3a.2: orb-live.ts is a thin consumer of the factory', () => {
     expect(fnBody).toMatch(/vertex\.connect\s*\(/);
     expect(fnBody).toMatch(/getAccessToken\b/);
   });
+
+  it('L1: connectToLiveAPI calls selectUpstreamProvider before constructing the upstream client', () => {
+    // L1 (VTID-02976): the upstream provider must flow through the pure
+    // selector, NOT be hard-coded to Vertex inline. The selector returns
+    // a decision the consumer emits to OASIS via
+    // `orb.upstream.provider.selected` and (when LiveKit was requested
+    // and downgraded) `orb.upstream.provider.selection_error`.
+    //
+    // Anti-regression: assert the wiring exists inside connectToLiveAPI's
+    // body. The selector itself is unit-tested by
+    // test/orb/live/upstream/upstream-provider-selector.test.ts — this
+    // test ONLY proves the consumer is wired through it.
+    const fnStart = orbLiveSrc.indexOf('async function connectToLiveAPI');
+    expect(fnStart).toBeGreaterThan(0);
+    const fnEnd = orbLiveSrc.indexOf('\nasync function ', fnStart + 1);
+    const fnBody = orbLiveSrc.slice(fnStart, fnEnd >= 0 ? fnEnd : undefined);
+    expect(fnBody).toMatch(/selectUpstreamProvider\s*\(/);
+    expect(fnBody).toMatch(/orb\.upstream\.provider\.selected/);
+    expect(fnBody).toMatch(/orb\.upstream\.provider\.selection_error/);
+    // The selector reads env override + system_config + LiveKit creds.
+    expect(fnBody).toMatch(/envProviderOverride\s*:\s*process\.env\.ORB_LIVE_PROVIDER/);
+    expect(fnBody).toMatch(/systemConfigActiveProvider\s*:/);
+    expect(fnBody).toMatch(/livekitCredentials\s*:/);
+  });
 });

--- a/services/gateway/test/orb/live/upstream/upstream-provider-selector.test.ts
+++ b/services/gateway/test/orb/live/upstream/upstream-provider-selector.test.ts
@@ -1,0 +1,214 @@
+/**
+ * L1 (VTID-02976): pure-selector tests for `selectUpstreamProvider`.
+ *
+ * The selector is a pure function — these tests never touch process.env,
+ * Supabase, or OASIS. Every input is passed explicitly via the context bag.
+ *
+ * Acceptance matrix:
+ *   1. Default (no signal anywhere) → Vertex, reason=`default`.
+ *   2. `ORB_LIVE_PROVIDER=vertex` → Vertex, reason=`env_explicit_vertex`.
+ *   3. `ORB_LIVE_PROVIDER=livekit` + creds present → Vertex (pinned),
+ *      reason=`pinned_to_vertex_l1`, livekitReady=true, error populated.
+ *   4. `ORB_LIVE_PROVIDER=livekit` + creds missing → Vertex, reason=
+ *      `livekit_config_invalid`, error names the missing fields.
+ *   5. `voice.active_provider=vertex` (env unset) → Vertex, reason=
+ *      `system_config_vertex`.
+ *   6. `voice.active_provider=livekit` (env unset) + creds → Vertex pinned,
+ *      reason=`pinned_to_vertex_l1`, livekitReady=true.
+ *   7. `voice.active_provider=livekit` (env unset) + creds missing → Vertex,
+ *      reason=`livekit_config_invalid`.
+ *   8. Env override beats system_config (env=vertex vs sys=livekit).
+ *   9. Unknown/garbage env value → falls through to system_config logic.
+ *  10. Whitespace + uppercase env values normalize correctly.
+ */
+
+import {
+  selectUpstreamProvider,
+  type UpstreamSelectorContext,
+} from '../../../../src/orb/live/upstream/upstream-provider-selector';
+
+const FULL_LIVEKIT_CREDS = {
+  url: 'wss://livekit.example',
+  apiKey: 'ak_test',
+  apiSecret: 'as_test',
+};
+
+function ctx(over: Partial<UpstreamSelectorContext> = {}): UpstreamSelectorContext {
+  return {
+    envProviderOverride: undefined,
+    systemConfigActiveProvider: undefined,
+    livekitCredentials: undefined,
+    ...over,
+  };
+}
+
+describe('L1 selectUpstreamProvider — pure selection policy', () => {
+  it('1. default (no signal anywhere) → vertex/default', () => {
+    const d = selectUpstreamProvider(ctx());
+    expect(d.provider).toBe('vertex');
+    expect(d.requested).toBeNull();
+    expect(d.reason).toBe('default');
+    expect(d.livekitReady).toBe(false);
+    expect(d.error).toBeUndefined();
+  });
+
+  it('2. ORB_LIVE_PROVIDER=vertex → vertex/env_explicit_vertex', () => {
+    const d = selectUpstreamProvider(ctx({ envProviderOverride: 'vertex' }));
+    expect(d.provider).toBe('vertex');
+    expect(d.requested).toBe('vertex');
+    expect(d.reason).toBe('env_explicit_vertex');
+    expect(d.livekitReady).toBe(false);
+  });
+
+  it('3. ORB_LIVE_PROVIDER=livekit + creds present → vertex (pinned), livekitReady=true', () => {
+    const d = selectUpstreamProvider(
+      ctx({
+        envProviderOverride: 'livekit',
+        livekitCredentials: FULL_LIVEKIT_CREDS,
+      }),
+    );
+    expect(d.provider).toBe('vertex');
+    expect(d.requested).toBe('livekit');
+    expect(d.reason).toBe('pinned_to_vertex_l1');
+    expect(d.livekitReady).toBe(true);
+    expect(d.error).toMatch(/pinning to Vertex/);
+    expect(d.error).toMatch(/env_explicit_livekit/);
+  });
+
+  it('4. ORB_LIVE_PROVIDER=livekit + creds missing → vertex/livekit_config_invalid', () => {
+    const d = selectUpstreamProvider(
+      ctx({
+        envProviderOverride: 'livekit',
+        livekitCredentials: { url: 'wss://livekit.example' /* apiKey + apiSecret missing */ },
+      }),
+    );
+    expect(d.provider).toBe('vertex');
+    expect(d.requested).toBe('livekit');
+    expect(d.reason).toBe('livekit_config_invalid');
+    expect(d.livekitReady).toBe(false);
+    expect(d.error).toMatch(/apiKey/);
+    expect(d.error).toMatch(/apiSecret/);
+  });
+
+  it('5. voice.active_provider=vertex (env unset) → vertex/system_config_vertex', () => {
+    const d = selectUpstreamProvider(ctx({ systemConfigActiveProvider: 'vertex' }));
+    expect(d.provider).toBe('vertex');
+    expect(d.requested).toBe('vertex');
+    expect(d.reason).toBe('system_config_vertex');
+  });
+
+  it('6. voice.active_provider=livekit (env unset) + creds → vertex (pinned), livekitReady=true', () => {
+    const d = selectUpstreamProvider(
+      ctx({
+        systemConfigActiveProvider: 'livekit',
+        livekitCredentials: FULL_LIVEKIT_CREDS,
+      }),
+    );
+    expect(d.provider).toBe('vertex');
+    expect(d.requested).toBe('livekit');
+    expect(d.reason).toBe('pinned_to_vertex_l1');
+    expect(d.livekitReady).toBe(true);
+    expect(d.error).toMatch(/system_config_livekit/);
+  });
+
+  it('7. voice.active_provider=livekit (env unset) + creds missing → vertex/livekit_config_invalid', () => {
+    const d = selectUpstreamProvider(
+      ctx({
+        systemConfigActiveProvider: 'livekit',
+        livekitCredentials: {},
+      }),
+    );
+    expect(d.provider).toBe('vertex');
+    expect(d.requested).toBe('livekit');
+    expect(d.reason).toBe('livekit_config_invalid');
+    expect(d.error).toMatch(/url/);
+    expect(d.error).toMatch(/apiKey/);
+    expect(d.error).toMatch(/apiSecret/);
+  });
+
+  it('8. env override beats system_config (env=vertex vs sys=livekit)', () => {
+    const d = selectUpstreamProvider(
+      ctx({
+        envProviderOverride: 'vertex',
+        systemConfigActiveProvider: 'livekit',
+        livekitCredentials: FULL_LIVEKIT_CREDS,
+      }),
+    );
+    expect(d.provider).toBe('vertex');
+    expect(d.requested).toBe('vertex');
+    expect(d.reason).toBe('env_explicit_vertex');
+    expect(d.livekitReady).toBe(false);
+  });
+
+  it('9. unknown/garbage env value falls through to system_config', () => {
+    const d = selectUpstreamProvider(
+      ctx({
+        envProviderOverride: 'gemini-direct',
+        systemConfigActiveProvider: 'vertex',
+      }),
+    );
+    expect(d.provider).toBe('vertex');
+    expect(d.reason).toBe('system_config_vertex');
+  });
+
+  it('9b. unknown env + unknown system_config → default', () => {
+    const d = selectUpstreamProvider(
+      ctx({
+        envProviderOverride: 'mistral',
+        // @ts-expect-error — testing runtime tolerance to bad input
+        systemConfigActiveProvider: 'openai',
+      }),
+    );
+    expect(d.provider).toBe('vertex');
+    expect(d.requested).toBeNull();
+    expect(d.reason).toBe('default');
+  });
+
+  it('10. whitespace + uppercase env values normalize', () => {
+    const d1 = selectUpstreamProvider(ctx({ envProviderOverride: '  VERTEX  ' }));
+    expect(d1.reason).toBe('env_explicit_vertex');
+    const d2 = selectUpstreamProvider(
+      ctx({
+        envProviderOverride: ' LiveKit\n',
+        livekitCredentials: FULL_LIVEKIT_CREDS,
+      }),
+    );
+    expect(d2.requested).toBe('livekit');
+    expect(d2.reason).toBe('pinned_to_vertex_l1');
+  });
+
+  it('selector NEVER throws on malformed input', () => {
+    expect(() =>
+      selectUpstreamProvider(
+        ctx({
+          // @ts-expect-error — testing runtime tolerance
+          envProviderOverride: null,
+          // @ts-expect-error — testing runtime tolerance
+          systemConfigActiveProvider: 42,
+          // @ts-expect-error — testing runtime tolerance
+          livekitCredentials: 'not-an-object',
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it('selector NEVER selects provider=livekit in L1 (the L1 pin)', () => {
+    // Every viable LiveKit request path must still return provider='vertex'.
+    const decisions = [
+      selectUpstreamProvider(
+        ctx({ envProviderOverride: 'livekit', livekitCredentials: FULL_LIVEKIT_CREDS }),
+      ),
+      selectUpstreamProvider(
+        ctx({
+          systemConfigActiveProvider: 'livekit',
+          livekitCredentials: FULL_LIVEKIT_CREDS,
+        }),
+      ),
+      selectUpstreamProvider(ctx({ envProviderOverride: 'livekit' })),
+      selectUpstreamProvider(ctx({ systemConfigActiveProvider: 'livekit' })),
+    ];
+    for (const d of decisions) {
+      expect(d.provider).toBe('vertex');
+    }
+  });
+});


### PR DESCRIPTION
## Summary

Routes `connectToLiveAPI` through a pure provider-selection policy without changing observable behavior. Vertex stays the production default; LiveKit cannot activate in L1. L2 (canary) lifts the cap.

## What moves

**New** — `services/gateway/src/orb/live/upstream/upstream-provider-selector.ts`:
- Pure function `selectUpstreamProvider(ctx)` — never reads env / DB / OASIS.
- Reads `ORB_LIVE_PROVIDER` env (highest priority), then `voice.active_provider` system_config, then default vertex.
- LiveKit gating: requires `LIVEKIT_URL` + `LIVEKIT_API_KEY` + `LIVEKIT_API_SECRET`. Missing → Vertex with `livekit_config_invalid` reason + typed error.
- L1 INVARIANT: even with valid LiveKit creds, ``provider`` is pinned to ``vertex`` with reason ``pinned_to_vertex_l1``. The decision carries ``livekitReady=true`` + an error string explaining the pin so operators can see "if I lift the L1 cap, LiveKit would be selected." L2 lifts the cap.
- Reasons: ``default | env_explicit_vertex | env_explicit_livekit | system_config_vertex | system_config_livekit | livekit_config_invalid | pinned_to_vertex_l1``.
- Selector NEVER throws.

**Modified** — `services/gateway/src/routes/orb-live.ts` (`connectToLiveAPI`):
- Reads `getVoiceConfig()` (already imported).
- Calls `selectUpstreamProvider({envProviderOverride, systemConfigActiveProvider, livekitCredentials})` early in the body, BEFORE constructing `VertexLiveClient`.
- Voice-config read failures degrade silently to ``default → vertex`` (production behavior preserved).
- Emits ``orb.upstream.provider.selected`` OASIS event with provider / requested / reason / livekit_ready / session_id. Best-effort; never blocks the session.
- Emits ``orb.upstream.provider.selection_error`` ONLY when the decision has a typed error (LiveKit requested but config invalid OR pinned in L1).
- Construction of `VertexLiveClient` is unchanged.

**Modified** — `services/gateway/src/types/cicd.ts`:
- Adds two event types: ``orb.upstream.provider.selected``, ``orb.upstream.provider.selection_error``.

## Tests

- 13 new pure-selector tests covering the full acceptance matrix: default, env=vertex, env=livekit + creds (pinned), env=livekit + missing creds, system_config equivalents, env-beats-sys, unknown values, whitespace normalization, never-throws, never-livekit-in-L1.
- 1 new characterization assertion proving the consumer is wired through the selector (selectUpstreamProvider call site, OASIS event-type literals, ORB_LIVE_PROVIDER read, livekit-creds bag construction).
- 668 orb tests green (was 655; +13).
- Build clean. orb-live.ts CRLF preserved; diff is +73 / -0.

## Acceptance vs the brief

| # | Criterion | Status |
|---|---|---|
| 1 | Default production config selects Vertex | ✓ (reason=default) |
| 2 | Explicit vertex config selects Vertex | ✓ (env_explicit_vertex) |
| 3 | LiveKit cannot activate without explicit config | ✓ (livekitReady=false unless creds + request) |
| 4 | Invalid LiveKit config handled safely + tested | ✓ (livekit_config_invalid + tests) |
| 5 | Production /orb/chat smoke passes with default config | pending merge |
| 6 | Existing Vertex behavior unchanged | ✓ (Vertex path untouched; pure additive wiring) |
| 7 | OASIS exposes selected upstream provider | ✓ (selected + selection_error events) |
| 8 | No frontend contract change | ✓ |

## Next

**L2 — LiveKit canary wiring.** Lifts the L1 pin for one tenant/user/device class, adds Vertex rollback flag, replays R0 timeline events for comparison.

🤖 Generated with [Claude Code](https://claude.com/claude-code)