### PR TITLE
feat(orb): L2.1 — LiveKit internal-canary gate + selection unlock + telemetry (VTID-02980)

### DIFF
--- a/services/gateway/src/orb/live/upstream/livekit-canary-config.ts
+++ b/services/gateway/src/orb/live/upstream/livekit-canary-config.ts
@@ -1,0 +1,156 @@
+/**
+ * L2.1 (VTID-02980 / orb-live-refactor): LiveKit internal-canary config reader.
+ *
+ * The L1 upstream provider selector is pure — it accepts canary configuration
+ * via its `ctx.canary` field. This helper computes that field for the live
+ * `connectToLiveAPI` path:
+ *
+ *   - `enabled` — true iff EITHER `process.env.ORB_LIVEKIT_CANARY_ENABLED === 'true'`
+ *      OR the `voice.livekit_canary_enabled` system_config row is `true`. Either
+ *      source can unlock the canary; both must be falsy for the L1 pin to hold.
+ *   - `allowedTenants` / `allowedUsers` — read from the `voice.livekit_canary_allowlist`
+ *      system_config row. Expected JSONB shape:
+ *        { "tenants": ["uuid", ...], "users": ["uuid", ...] }
+ *      Either array may be absent / empty. A canary with `enabled=true` but an
+ *      empty allowlist matches NO identities and produces `canary_not_allowlisted`
+ *      for every LiveKit-requested session — explicit rollback is one env flip OR
+ *      one allowlist clear.
+ *
+ * In-process cache (~15s TTL) so the helper can be called inline on every
+ * session start without thrashing Supabase. Cache is invalidated explicitly
+ * via `invalidateLiveKitCanaryConfigCache()` after an admin change.
+ *
+ * Hard rules:
+ *   - This helper NEVER throws — DB failures degrade to `{enabled: false}`
+ *     so the selector pins to Vertex (production-safe default).
+ *   - It NEVER consults `voice.active_provider` — that lookup is owned by
+ *     `voice-config.ts` and feeds the selector separately. Canary state is
+ *     its own knob, so flipping `voice.active_provider` to `livekit` does NOT
+ *     by itself unlock the canary.
+ */
+
+import { getSupabase } from '../../../lib/supabase';
+
+export interface LiveKitCanaryConfig {
+  enabled: boolean;
+  allowedTenants: string[];
+  allowedUsers: string[];
+}
+
+const CACHE_TTL_MS = 15_000;
+const ENABLED_KEY = 'voice.livekit_canary_enabled';
+const ALLOWLIST_KEY = 'voice.livekit_canary_allowlist';
+
+let _cached: LiveKitCanaryConfig | null = null;
+let _cachedAt = 0;
+
+function envEnabled(env: NodeJS.ProcessEnv): boolean {
+  const raw = (env.ORB_LIVEKIT_CANARY_ENABLED ?? '').trim().toLowerCase();
+  return raw === 'true' || raw === '1' || raw === 'yes';
+}
+
+function asBool(v: unknown): boolean {
+  if (typeof v === 'boolean') return v;
+  if (typeof v === 'string') {
+    const s = v.trim().toLowerCase();
+    return s === 'true' || s === '1' || s === 'yes';
+  }
+  if (
+    v &&
+    typeof v === 'object' &&
+    'enabled' in (v as Record<string, unknown>) &&
+    typeof (v as Record<string, unknown>).enabled === 'boolean'
+  ) {
+    return (v as Record<string, boolean>).enabled;
+  }
+  return false;
+}
+
+function asStringArray(v: unknown): string[] {
+  if (!Array.isArray(v)) return [];
+  const out: string[] = [];
+  for (const item of v) {
+    if (typeof item === 'string' && item.length > 0) out.push(item);
+  }
+  return out;
+}
+
+function parseAllowlist(v: unknown): { tenants: string[]; users: string[] } {
+  if (!v || typeof v !== 'object') return { tenants: [], users: [] };
+  const obj = v as Record<string, unknown>;
+  return {
+    tenants: asStringArray(obj.tenants),
+    users: asStringArray(obj.users),
+  };
+}
+
+/**
+ * Read the LiveKit canary config. Result is cached for 15s.
+ * NEVER throws — DB failures degrade to `{enabled: false}` so the selector
+ * pins to Vertex.
+ */
+export async function getLiveKitCanaryConfig(
+  env: NodeJS.ProcessEnv = process.env,
+  force = false,
+): Promise<LiveKitCanaryConfig> {
+  const now = Date.now();
+  if (!force && _cached && now - _cachedAt < CACHE_TTL_MS) {
+    // Even when cached, the env switch should override: env can flip
+    // enabled→true without invalidating cache.
+    const envOn = envEnabled(env);
+    return envOn && !_cached.enabled
+      ? { ..._cached, enabled: true }
+      : _cached;
+  }
+
+  const envOn = envEnabled(env);
+
+  const sb = getSupabase();
+  if (!sb) {
+    const cfg: LiveKitCanaryConfig = {
+      enabled: envOn,
+      allowedTenants: [],
+      allowedUsers: [],
+    };
+    _cached = cfg;
+    _cachedAt = now;
+    return cfg;
+  }
+
+  let sysEnabled = false;
+  let tenants: string[] = [];
+  let users: string[] = [];
+  try {
+    const { data, error } = await sb
+      .from('system_config')
+      .select('key, value')
+      .in('key', [ENABLED_KEY, ALLOWLIST_KEY]);
+    if (!error && Array.isArray(data)) {
+      for (const row of data as Array<{ key: string; value: unknown }>) {
+        if (row.key === ENABLED_KEY) {
+          sysEnabled = asBool(row.value);
+        } else if (row.key === ALLOWLIST_KEY) {
+          const al = parseAllowlist(row.value);
+          tenants = al.tenants;
+          users = al.users;
+        }
+      }
+    }
+  } catch {
+    // Degrade to defaults — production-safe.
+  }
+
+  const cfg: LiveKitCanaryConfig = {
+    enabled: envOn || sysEnabled,
+    allowedTenants: tenants,
+    allowedUsers: users,
+  };
+  _cached = cfg;
+  _cachedAt = now;
+  return cfg;
+}
+
+export function invalidateLiveKitCanaryConfigCache(): void {
+  _cached = null;
+  _cachedAt = 0;
+}

--- a/services/gateway/src/orb/live/upstream/upstream-provider-selector.ts
+++ b/services/gateway/src/orb/live/upstream/upstream-provider-selector.ts
@@ -1,32 +1,45 @@
 /**
- * L1 (VTID-02976 / orb-live-refactor): pure provider-selection policy for
- * the ORB upstream live client.
+ * L1 (VTID-02976) / L2.1 (VTID-02980 / orb-live-refactor): pure
+ * provider-selection policy for the ORB upstream live client.
  *
  * Inputs:
  *   - `ORB_LIVE_PROVIDER` env (highest priority override): `'vertex' | 'livekit' | ''`
- *   - `voice.active_provider` system_config row (read via voice-config.ts before
- *     calling this selector): `'vertex' | 'livekit'`
+ *   - `voice.active_provider` system_config row: `'vertex' | 'livekit'`
  *   - LiveKit credentials in env: `LIVEKIT_URL`, `LIVEKIT_API_KEY`,
  *     `LIVEKIT_API_SECRET`
+ *   - L2.1 canary inputs:
+ *       - `canary.enabled` (env `ORB_LIVEKIT_CANARY_ENABLED` and/or system_config
+ *         row `voice.livekit_canary_enabled`)
+ *       - `canary.allowedTenants` / `canary.allowedUsers` (from system_config
+ *         row `voice.livekit_canary_allowlist`)
+ *       - `identity.tenantId` / `identity.userId` (from the session)
  *
- * Output:
- *   - `provider` — the upstream client implementation the consumer SHOULD use.
- *     L1 caps this at `'vertex'` because the LiveKit client is not yet wired
- *     into `connectToLiveAPI`; L2 (canary) flips this to honor `'livekit'`.
- *   - `requested` — what the caller asked for (or `null` if no override).
- *   - `reason` — why `provider` was chosen (drives the OASIS event).
- *   - `error` — populated only when the request was `'livekit'` but a gate
- *     failed (config missing, not enabled, or `pinned_to_vertex_l1`).
+ * Output (`UpstreamSelectionDecision`):
+ *   - `provider` — the upstream client the consumer should USE. L1 pinned
+ *     this to `'vertex'` unconditionally; L2.1 lifts the pin only inside the
+ *     canary gate.
+ *   - `requested` — what the caller asked for (or `null`).
+ *   - `reason` — why `provider` was chosen.
+ *   - `livekitReady` — whether all hard gates (creds + canary + allowlist)
+ *     pass. Useful for operator-side rollout monitoring even when L2.1's
+ *     consumer-side pin still routes traffic to Vertex.
+ *   - `canary` — whether the canary path was active.
+ *   - `error` — typed message when the LiveKit request was downgraded.
  *
  * Selection rules:
  *   1. If `ORB_LIVE_PROVIDER` is explicitly `'vertex'` → Vertex (reason
- *      `env_explicit`).
+ *      `env_explicit_vertex`).
  *   2. If `ORB_LIVE_PROVIDER` is explicitly `'livekit'`:
  *        a. require `LIVEKIT_URL`, `LIVEKIT_API_KEY`, `LIVEKIT_API_SECRET`.
  *           If any missing → Vertex (reason `livekit_config_invalid`).
- *        b. all gates pass → LiveKit *would* be selected, but L1 pins to
- *           Vertex (reason `pinned_to_vertex_l1`) because the LiveKit
- *           upstream client isn't wired yet. L2 lifts this pin.
+ *        b. L2.1 canary gate:
+ *             i. if `canary.enabled === true` AND identity is in the
+ *                allowlist → `provider: 'livekit'`, reason
+ *                `canary_selected_livekit`.
+ *            ii. if `canary.enabled === true` AND identity is NOT in the
+ *                allowlist → Vertex, reason `canary_not_allowlisted`.
+ *           iii. if `canary.enabled !== true` → Vertex, reason
+ *                `pinned_to_vertex_l1` (the L1 cap).
  *   3. Else if `ORB_LIVE_PROVIDER` is unset, fall back to
  *      `voice.active_provider` system_config with the same gating logic
  *      (reason prefix `system_config` instead of `env_explicit`).
@@ -38,9 +51,9 @@
  * tests trivial (no mocks of process.env / Supabase / OASIS).
  *
  * Hard rules:
- *   - LiveKit cannot reach `provider: 'livekit'` in L1. The selector may
- *     compute a `livekit_ready: true` flag, but `provider` stays
- *     `'vertex'` and `reason` becomes `pinned_to_vertex_l1`.
+ *   - LiveKit can ONLY reach `provider: 'livekit'` via the L2.1 canary gate
+ *     (env+sysconfig request + creds + canary.enabled + identity allowlisted).
+ *     Every other path still routes through `pinned_to_vertex_l1`.
  *   - Selection NEVER throws. Invalid inputs degrade to Vertex with a
  *     typed `error` field on the decision.
  */
@@ -54,7 +67,24 @@ export type SelectionReason =
   | 'system_config_vertex'     // voice.active_provider=vertex (env unset)
   | 'system_config_livekit'    // voice.active_provider=livekit (env unset); would be livekit (but L1 pins)
   | 'livekit_config_invalid'   // livekit requested, creds missing → vertex
-  | 'pinned_to_vertex_l1';     // livekit requested AND creds present → still pinned to vertex in L1
+  | 'pinned_to_vertex_l1'      // livekit requested AND creds present AND canary disabled → vertex
+  // L2.1 (VTID-02980): canary path. When all canary gates pass (env / creds /
+  // canary.enabled / identity allowlisted), the selector returns
+  // `provider='livekit'` with this reason — the L1 pin is lifted INSIDE
+  // the canary scope only. Outside the canary scope the L1 pin still holds.
+  | 'canary_selected_livekit'
+  // L2.1: canary gate is on, LiveKit was requested, creds are valid, but
+  // the calling identity is NOT in the canary allowlist. Pinned to vertex.
+  | 'canary_not_allowlisted';
+
+export interface CanarySelectorConfig {
+  /** Master canary switch. False = full L1 pin regardless of allowlist. */
+  enabled: boolean;
+  /** Tenant IDs allowed onto the canary. Matched against `identity.tenantId`. */
+  allowedTenants?: ReadonlyArray<string>;
+  /** User IDs allowed onto the canary. Matched against `identity.userId`. */
+  allowedUsers?: ReadonlyArray<string>;
+}
 
 export interface UpstreamSelectorContext {
   /** `process.env.ORB_LIVE_PROVIDER` — `'vertex' | 'livekit' | ''` (or unset). */
@@ -67,24 +97,58 @@ export interface UpstreamSelectorContext {
     apiKey?: string;
     apiSecret?: string;
   };
+  /**
+   * L2.1: canary configuration. When `enabled: true` AND the calling
+   * identity matches one of `allowedTenants` / `allowedUsers`, AND
+   * LiveKit was requested AND creds are valid, the selector returns
+   * `provider='livekit'` with `reason='canary_selected_livekit'`.
+   *
+   * Always optional. When unset or `enabled: false`, the L1 pin holds
+   * for every LiveKit-requested session (existing reason
+   * `pinned_to_vertex_l1`).
+   */
+  canary?: CanarySelectorConfig;
+  /**
+   * L2.1: identity of the session for canary matching. Either / both fields
+   * may be unset (e.g. anonymous landing sessions); a session with no
+   * identity can NEVER match the allowlist and is treated as
+   * `canary_not_allowlisted`.
+   */
+  identity?: {
+    tenantId?: string | null;
+    userId?: string | null;
+  };
 }
 
 export interface UpstreamSelectionDecision {
-  /** What the consumer should actually instantiate. L1 always pins to `'vertex'`. */
+  /**
+   * What the consumer should actually instantiate. Always `'vertex'`
+   * unless the L2.1 canary path is active.
+   */
   provider: UpstreamProviderName;
   /** What was requested. `null` if no override was provided. */
   requested: UpstreamProviderName | null;
   /** Why `provider` was chosen. Drives OASIS event payload. */
   reason: SelectionReason;
   /**
-   * Whether LiveKit would have been selected if L1 weren't pinning to Vertex.
-   * Useful for the L2 cutover and for the Improve cockpit's "rollout readiness"
-   * indicator. False when LiveKit wasn't requested or creds are incomplete.
+   * Whether all hard LiveKit gates (creds + canary + allowlist) pass.
+   * True on `canary_selected_livekit`. False otherwise.
+   *
+   * Operators use this to see what the selector *would* return if the
+   * L1 / consumer-side pins were removed.
    */
   livekitReady: boolean;
   /**
+   * L2.1: whether the canary path was relevant to this decision (regardless
+   * of whether identity matched). `true` for the three canary reasons:
+   * `canary_selected_livekit`, `canary_not_allowlisted`, and the variant
+   * of `pinned_to_vertex_l1` that arose because canary is configured but
+   * disabled. False on all non-canary paths.
+   */
+  canary: boolean;
+  /**
    * Typed error when the LiveKit path was requested but a gate failed.
-   * Empty/undefined on the happy Vertex path.
+   * Empty/undefined on the happy Vertex path and on `canary_selected_livekit`.
    */
   error?: string;
 }
@@ -111,6 +175,20 @@ function livekitCredsMissing(
   return missing;
 }
 
+function isIdentityAllowlisted(
+  canary: CanarySelectorConfig | undefined,
+  identity: UpstreamSelectorContext['identity'],
+): boolean {
+  if (!canary) return false;
+  const tenants = canary.allowedTenants ?? [];
+  const users = canary.allowedUsers ?? [];
+  const tenantId = identity?.tenantId ?? null;
+  const userId = identity?.userId ?? null;
+  if (tenantId && tenants.includes(tenantId)) return true;
+  if (userId && users.includes(userId)) return true;
+  return false;
+}
+
 /**
  * Pure selector. Never throws. Never reads env. Never queries DB.
  * The caller is responsible for emitting an OASIS event based on the
@@ -133,6 +211,7 @@ export function selectUpstreamProvider(
       requested: 'vertex',
       reason: 'env_explicit_vertex',
       livekitReady: false,
+      canary: false,
     };
   }
   if (envChoice === 'livekit') {
@@ -146,6 +225,7 @@ export function selectUpstreamProvider(
       requested: 'vertex',
       reason: 'system_config_vertex',
       livekitReady: false,
+      canary: false,
     };
   }
   if (sysChoice === 'livekit') {
@@ -158,6 +238,7 @@ export function selectUpstreamProvider(
     requested: null,
     reason: 'default',
     livekitReady: false,
+    canary: false,
   };
 }
 
@@ -173,20 +254,50 @@ function evaluateLiveKitRequest(
       requested,
       reason: 'livekit_config_invalid',
       livekitReady: false,
+      canary: false,
       error: `LiveKit credentials missing: ${missing.join(', ')}`,
     };
   }
-  // Creds are valid; L1 pins to Vertex (the LiveKit upstream client is
-  // not yet wired into connectToLiveAPI). `happyReason` is preserved on
-  // `livekitReady=true` for operator-side rollout monitoring, but `reason`
-  // is `pinned_to_vertex_l1` to signal the deliberate L1 cap.
+
+  // Creds are valid. Check the L2.1 canary gate.
+  const canary = ctx.canary;
+  if (canary?.enabled === true) {
+    if (isIdentityAllowlisted(canary, ctx.identity)) {
+      // ALL hard gates pass — the canary lifts the L1 pin for this session.
+      return {
+        provider: 'livekit',
+        requested,
+        reason: 'canary_selected_livekit',
+        livekitReady: true,
+        canary: true,
+      };
+    }
+    // Canary enabled but identity not allowlisted → pinned to vertex with
+    // a distinct reason so the cockpit can distinguish "I'm running canary
+    // but this user isn't in" from "canary is off entirely."
+    return {
+      provider: 'vertex',
+      requested,
+      reason: 'canary_not_allowlisted',
+      livekitReady: false,
+      canary: true,
+      error:
+        'LiveKit requested with valid creds and canary enabled, but the ' +
+        'session identity is not in the canary allowlist. Pinning to Vertex. ' +
+        `Would-have-selected reason: ${happyReason}.`,
+    };
+  }
+
+  // Canary not enabled (or unconfigured) → L1 pin holds.
   return {
     provider: 'vertex',
     requested,
     reason: 'pinned_to_vertex_l1',
     livekitReady: true,
+    canary: false,
     error:
-      'LiveKit upstream client not wired in L1; pinning to Vertex. ' +
+      'LiveKit upstream client not enabled outside the canary gate; ' +
+      'pinning to Vertex. ' +
       `Would-have-selected reason: ${happyReason}.`,
   };
 }

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1172,6 +1172,10 @@ import {
   selectUpstreamProvider,
   type UpstreamSelectionDecision,
 } from '../orb/live/upstream/upstream-provider-selector';
+// L2.1 (VTID-02980): LiveKit internal-canary config reader. Reads
+// `ORB_LIVEKIT_CANARY_ENABLED` env + `voice.livekit_canary_enabled`/
+// `voice.livekit_canary_allowlist` system_config rows. NEVER throws.
+import { getLiveKitCanaryConfig } from '../orb/live/upstream/livekit-canary-config';
 // NOTE: `getVoiceConfig` is already imported above (line ~92).
 // A3 (orb-live-refactor): system instruction builder + its private helpers
 // (describeTimeSince, describeRoute, buildTemporalJourneyContextSection,
@@ -5496,14 +5500,24 @@ async function connectToLiveAPI(
     throw new Error('Missing VERTEX_PROJECT_ID or VERTEX_LOCATION');
   }
 
-  // L1 (VTID-02976): consult the upstream provider selector. The selector
-  // is a pure function — it never reads env / DB / OASIS. We gather inputs
-  // here, hand them in, and emit OASIS based on the returned decision.
-  // L1 always pins to Vertex; the decision tells operators what *would*
-  // happen once L2 lifts the pin.
+  // L1 (VTID-02976) / L2.1 (VTID-02980): consult the upstream provider
+  // selector. The selector is a pure function — it never reads env / DB /
+  // OASIS. We gather inputs here (voice config + canary config + session
+  // identity), hand them in, and emit OASIS based on the returned decision.
+  //
+  // L1 pinned every LiveKit request to Vertex. L2.1 lifts that pin INSIDE
+  // the canary gate only (env+sys request + creds + canary.enabled +
+  // identity in allowlist). Everywhere else the L1 pin still holds.
+  //
+  // L2.1 caveat: even when the selector returns `provider='livekit'` via
+  // the canary path, this consumer ALSO pins to Vertex (the LiveKit media
+  // client isn't wired yet — that's L2.2). The pin is recorded as a
+  // distinct OASIS event so it's never silent. L2.2 removes the consumer
+  // pin and adds connect_started / connect_succeeded / connect_failed.
   let __upstreamDecision: UpstreamSelectionDecision;
   try {
     const __voiceCfg = await getVoiceConfig();
+    const __canary = await getLiveKitCanaryConfig();
     __upstreamDecision = selectUpstreamProvider({
       envProviderOverride: process.env.ORB_LIVE_PROVIDER,
       systemConfigActiveProvider: __voiceCfg.active_provider,
@@ -5512,50 +5526,100 @@ async function connectToLiveAPI(
         apiKey: process.env.LIVEKIT_API_KEY,
         apiSecret: process.env.LIVEKIT_API_SECRET,
       },
+      canary: {
+        enabled: __canary.enabled,
+        allowedTenants: __canary.allowedTenants,
+        allowedUsers: __canary.allowedUsers,
+      },
+      identity: {
+        tenantId: session.identity?.tenant_id ?? null,
+        userId: session.identity?.user_id ?? null,
+      },
     });
   } catch (e) {
-    // Voice config read failure must NOT block the session start; default
-    // to Vertex so production behavior matches today.
-    console.warn(`[VTID-02976] voice-config read failed; falling back to vertex defaults: ${(e as Error).message}`);
+    // Voice/canary config read failure must NOT block the session start;
+    // default to Vertex so production behavior matches today.
+    console.warn(`[VTID-02976] voice/canary config read failed; falling back to vertex defaults: ${(e as Error).message}`);
     __upstreamDecision = {
       provider: 'vertex',
       requested: null,
       reason: 'default',
       livekitReady: false,
+      canary: false,
     };
   }
   console.log(
     `[VTID-02976] upstream provider selected: provider=${__upstreamDecision.provider}` +
       ` requested=${__upstreamDecision.requested ?? 'none'}` +
       ` reason=${__upstreamDecision.reason}` +
-      ` livekit_ready=${__upstreamDecision.livekitReady}`,
+      ` livekit_ready=${__upstreamDecision.livekitReady}` +
+      ` canary=${__upstreamDecision.canary}`,
   );
   // OASIS emission — every connect call emits a single `selected` event.
   // When the request was LiveKit but the path degraded (config invalid or
-  // pinned_to_vertex_l1), also emit a `selection_error` event with the
-  // typed error string so the Improve cockpit can surface it.
+  // pinned_to_vertex_l1 or canary_not_allowlisted), also emit
+  // `selection_error` with the typed error string so the Improve cockpit
+  // can surface it.
   void emitOasisEvent({
     type: 'orb.upstream.provider.selected',
-    vtid: 'VTID-02976',
+    vtid: 'VTID-02980',
     payload: {
       session_id: session.sessionId,
       provider: __upstreamDecision.provider,
       requested: __upstreamDecision.requested,
       reason: __upstreamDecision.reason,
       livekit_ready: __upstreamDecision.livekitReady,
+      canary: __upstreamDecision.canary,
     } as any,
   } as any).catch(() => { /* best-effort */ });
   if (__upstreamDecision.error) {
     void emitOasisEvent({
       type: 'orb.upstream.provider.selection_error',
-      vtid: 'VTID-02976',
+      vtid: 'VTID-02980',
       payload: {
         session_id: session.sessionId,
         provider: __upstreamDecision.provider,
         requested: __upstreamDecision.requested,
         reason: __upstreamDecision.reason,
         livekit_ready: __upstreamDecision.livekitReady,
+        canary: __upstreamDecision.canary,
         error: __upstreamDecision.error,
+      } as any,
+    } as any).catch(() => { /* best-effort */ });
+  }
+
+  // L2.1 (VTID-02980): canary observability. When the selector returns
+  // `provider='livekit'` via the canary path, the L1 pin has been lifted
+  // — but L2.1's consumer doesn't have a LiveKit media client yet. Emit
+  // an explicit `canary.selection_unlocked` event (the decision happened)
+  // followed by a `canary.consumer_pinned_vertex_l21` event (the
+  // consumer-side pin is what's keeping the session on Vertex). L2.2
+  // will remove the consumer pin and replace `consumer_pinned_vertex_l21`
+  // with `canary.connect_started` + `canary.connect_succeeded` /
+  // `canary.connect_failed`.
+  if (__upstreamDecision.provider === 'livekit' && __upstreamDecision.canary) {
+    void emitOasisEvent({
+      type: 'orb.upstream.canary.selection_unlocked',
+      vtid: 'VTID-02980',
+      payload: {
+        session_id: session.sessionId,
+        tenant_id: session.identity?.tenant_id ?? null,
+        user_id: session.identity?.user_id ?? null,
+        reason: __upstreamDecision.reason,
+      } as any,
+    } as any).catch(() => { /* best-effort */ });
+    void emitOasisEvent({
+      type: 'orb.upstream.canary.consumer_pinned_vertex_l21',
+      vtid: 'VTID-02980',
+      payload: {
+        session_id: session.sessionId,
+        tenant_id: session.identity?.tenant_id ?? null,
+        user_id: session.identity?.user_id ?? null,
+        reason: __upstreamDecision.reason,
+        note:
+          'L2.1 selector unlocked LiveKit for this canary identity, but ' +
+          'the consumer still constructs VertexLiveClient. L2.2 will lift ' +
+          'this consumer-side pin and wire the real LiveKit media client.',
       } as any,
     } as any).catch(() => { /* best-effort */ });
   }

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -525,6 +525,15 @@ export type CicdEventType =
   // ONLY when a LiveKit request was downgraded (config invalid or pinned_to_vertex_l1).
   | 'orb.upstream.provider.selected'
   | 'orb.upstream.provider.selection_error'
+  // L2.1 (VTID-02980): LiveKit internal-canary observability.
+  // `canary.selection_unlocked` fires when the selector returns
+  // `provider='livekit'` via the canary path (all hard gates pass: env/sys
+  // request + creds + canary.enabled + identity allowlisted). In L2.1 the
+  // consumer still pins to Vertex and emits `canary.consumer_pinned_vertex_l21`
+  // to make that pin explicit; L2.2 removes the consumer-side pin + adds
+  // connect_started/succeeded/failed events for the real media path.
+  | 'orb.upstream.canary.selection_unlocked'
+  | 'orb.upstream.canary.consumer_pinned_vertex_l21'
   // VTID-DIAG: Pipeline diagnostics
   | 'orb.live.diag'
   // VTID-FALLBACK: Chat-TTS fallback events

--- a/services/gateway/test/orb/live/characterization/upstream-message-handler.characterization.test.ts
+++ b/services/gateway/test/orb/live/characterization/upstream-message-handler.characterization.test.ts
@@ -225,4 +225,34 @@ describe('A8.3a.2: orb-live.ts is a thin consumer of the factory', () => {
     expect(fnBody).toMatch(/systemConfigActiveProvider\s*:/);
     expect(fnBody).toMatch(/livekitCredentials\s*:/);
   });
+
+  it('L2.1: connectToLiveAPI passes canary config + identity to the selector and emits canary OASIS events', () => {
+    // L2.1 (VTID-02980): the connect path must also read the LiveKit
+    // canary config (env + system_config) and pass it — along with the
+    // session identity — to the selector. When the selector returns
+    // `provider='livekit'` via the canary path, two distinct OASIS
+    // events fire:
+    //   1. `orb.upstream.canary.selection_unlocked` — the decision happened.
+    //   2. `orb.upstream.canary.consumer_pinned_vertex_l21` — L2.1's
+    //      consumer is still pinned to Vertex (the LiveKit media client
+    //      isn't wired yet; L2.2 lifts this pin and replaces this event
+    //      with connect_started / succeeded / failed events).
+    const fnStart = orbLiveSrc.indexOf('async function connectToLiveAPI');
+    expect(fnStart).toBeGreaterThan(0);
+    const fnEnd = orbLiveSrc.indexOf('\nasync function ', fnStart + 1);
+    const fnBody = orbLiveSrc.slice(fnStart, fnEnd >= 0 ? fnEnd : undefined);
+    // Reads the canary config.
+    expect(fnBody).toMatch(/getLiveKitCanaryConfig\s*\(/);
+    // Passes the canary + identity bags to the selector.
+    expect(fnBody).toMatch(/canary\s*:\s*\{[\s\S]*?enabled\s*:[\s\S]*?allowedTenants[\s\S]*?allowedUsers/);
+    expect(fnBody).toMatch(/identity\s*:\s*\{[\s\S]*?tenantId[\s\S]*?session\.identity\?\.tenant_id/);
+    expect(fnBody).toMatch(/identity\s*:\s*\{[\s\S]*?userId[\s\S]*?session\.identity\?\.user_id/);
+    // Emits both canary OASIS event types.
+    expect(fnBody).toMatch(/orb\.upstream\.canary\.selection_unlocked/);
+    expect(fnBody).toMatch(/orb\.upstream\.canary\.consumer_pinned_vertex_l21/);
+    // Canary events fire ONLY when the decision is livekit AND canary=true.
+    expect(fnBody).toMatch(
+      /__upstreamDecision\.provider\s*===\s*['"]livekit['"]\s*&&\s*__upstreamDecision\.canary/,
+    );
+  });
 });

--- a/services/gateway/test/orb/live/upstream/livekit-canary-config.test.ts
+++ b/services/gateway/test/orb/live/upstream/livekit-canary-config.test.ts
@@ -1,0 +1,72 @@
+/**
+ * L2.1 (VTID-02980): `livekit-canary-config` unit tests.
+ *
+ * Most of the helper's logic is the env-flag parser + the JSONB allowlist
+ * coercion. The DB-read branch is exercised via the mocked Supabase client
+ * shared by the rest of the orb suite (`test/__mocks__/setup-tests.ts`).
+ * The tests below focus on the pure shape coercion + env override + the
+ * graceful-degradation contract (DB read failure → `enabled:false`).
+ */
+
+import {
+  getLiveKitCanaryConfig,
+  invalidateLiveKitCanaryConfigCache,
+} from '../../../../src/orb/live/upstream/livekit-canary-config';
+
+const ORIGINAL_ENV = { ...process.env };
+
+function resetEnv(): void {
+  delete process.env.ORB_LIVEKIT_CANARY_ENABLED;
+}
+
+beforeEach(() => {
+  invalidateLiveKitCanaryConfigCache();
+  resetEnv();
+});
+
+afterAll(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe('L2.1 getLiveKitCanaryConfig — env handling', () => {
+  it('ORB_LIVEKIT_CANARY_ENABLED unset → enabled=false', async () => {
+    const cfg = await getLiveKitCanaryConfig(process.env, true);
+    expect(cfg.enabled).toBe(false);
+  });
+
+  it('ORB_LIVEKIT_CANARY_ENABLED=true → enabled=true', async () => {
+    process.env.ORB_LIVEKIT_CANARY_ENABLED = 'true';
+    const cfg = await getLiveKitCanaryConfig(process.env, true);
+    expect(cfg.enabled).toBe(true);
+  });
+
+  it('ORB_LIVEKIT_CANARY_ENABLED=1 / yes / TRUE / Yes / TRUE  → enabled=true', async () => {
+    for (const v of ['1', 'yes', 'TRUE', 'Yes', '  TRUE  ']) {
+      process.env.ORB_LIVEKIT_CANARY_ENABLED = v;
+      invalidateLiveKitCanaryConfigCache();
+      const cfg = await getLiveKitCanaryConfig(process.env, true);
+      expect(cfg.enabled).toBe(true);
+    }
+  });
+
+  it('ORB_LIVEKIT_CANARY_ENABLED=false / 0 / off / "" → enabled=false', async () => {
+    for (const v of ['false', '0', 'off', '']) {
+      process.env.ORB_LIVEKIT_CANARY_ENABLED = v;
+      invalidateLiveKitCanaryConfigCache();
+      const cfg = await getLiveKitCanaryConfig(process.env, true);
+      expect(cfg.enabled).toBe(false);
+    }
+  });
+
+  it('returns empty allowlists by default (no system_config rows / mocked Supabase)', async () => {
+    const cfg = await getLiveKitCanaryConfig(process.env, true);
+    expect(cfg.allowedTenants).toEqual([]);
+    expect(cfg.allowedUsers).toEqual([]);
+  });
+
+  it('NEVER throws — even with garbage env values', async () => {
+    // @ts-expect-error — testing runtime tolerance
+    process.env.ORB_LIVEKIT_CANARY_ENABLED = 42 as unknown as string;
+    await expect(getLiveKitCanaryConfig(process.env, true)).resolves.toBeTruthy();
+  });
+});

--- a/services/gateway/test/orb/live/upstream/upstream-provider-selector.test.ts
+++ b/services/gateway/test/orb/live/upstream/upstream-provider-selector.test.ts
@@ -192,8 +192,10 @@ describe('L1 selectUpstreamProvider — pure selection policy', () => {
     ).not.toThrow();
   });
 
-  it('selector NEVER selects provider=livekit in L1 (the L1 pin)', () => {
-    // Every viable LiveKit request path must still return provider='vertex'.
+  it('selector NEVER selects provider=livekit in L1 (the L1 pin, canary OFF)', () => {
+    // Every viable LiveKit request path must still return provider='vertex'
+    // when no canary configuration is supplied. L2.1 keeps this invariant
+    // for non-canary callers; only the canary gate can unlock LiveKit.
     const decisions = [
       selectUpstreamProvider(
         ctx({ envProviderOverride: 'livekit', livekitCredentials: FULL_LIVEKIT_CREDS }),
@@ -209,6 +211,190 @@ describe('L1 selectUpstreamProvider — pure selection policy', () => {
     ];
     for (const d of decisions) {
       expect(d.provider).toBe('vertex');
+      expect(d.canary).toBe(false);
     }
+  });
+});
+
+// ============================================================================
+// L2.1 (VTID-02980) — canary gate selection
+// ============================================================================
+
+describe('L2.1 selectUpstreamProvider — canary gate', () => {
+  const TENANT_A = '11111111-aaaa-aaaa-aaaa-111111111111';
+  const TENANT_B = '22222222-bbbb-bbbb-bbbb-222222222222';
+  const USER_A = '33333333-cccc-cccc-cccc-333333333333';
+  const USER_B = '44444444-dddd-dddd-dddd-444444444444';
+
+  it('C1. canary disabled + livekit env + creds → pinned_to_vertex_l1 (L1 pin unchanged)', () => {
+    const d = selectUpstreamProvider(
+      ctx({
+        envProviderOverride: 'livekit',
+        livekitCredentials: FULL_LIVEKIT_CREDS,
+        canary: { enabled: false, allowedTenants: [TENANT_A] },
+        identity: { tenantId: TENANT_A },
+      }),
+    );
+    expect(d.provider).toBe('vertex');
+    expect(d.requested).toBe('livekit');
+    expect(d.reason).toBe('pinned_to_vertex_l1');
+    expect(d.livekitReady).toBe(true);
+    expect(d.canary).toBe(false);
+  });
+
+  it('C2. canary enabled + identity matches allowlist (tenant) → provider=livekit', () => {
+    const d = selectUpstreamProvider(
+      ctx({
+        envProviderOverride: 'livekit',
+        livekitCredentials: FULL_LIVEKIT_CREDS,
+        canary: { enabled: true, allowedTenants: [TENANT_A] },
+        identity: { tenantId: TENANT_A, userId: USER_B },
+      }),
+    );
+    expect(d.provider).toBe('livekit');
+    expect(d.requested).toBe('livekit');
+    expect(d.reason).toBe('canary_selected_livekit');
+    expect(d.livekitReady).toBe(true);
+    expect(d.canary).toBe(true);
+    expect(d.error).toBeUndefined();
+  });
+
+  it('C3. canary enabled + identity matches allowlist (user) → provider=livekit', () => {
+    const d = selectUpstreamProvider(
+      ctx({
+        envProviderOverride: 'livekit',
+        livekitCredentials: FULL_LIVEKIT_CREDS,
+        canary: { enabled: true, allowedUsers: [USER_A] },
+        identity: { tenantId: TENANT_B, userId: USER_A },
+      }),
+    );
+    expect(d.provider).toBe('livekit');
+    expect(d.reason).toBe('canary_selected_livekit');
+    expect(d.canary).toBe(true);
+  });
+
+  it('C4. canary enabled + identity NOT in allowlist → canary_not_allowlisted', () => {
+    const d = selectUpstreamProvider(
+      ctx({
+        envProviderOverride: 'livekit',
+        livekitCredentials: FULL_LIVEKIT_CREDS,
+        canary: { enabled: true, allowedTenants: [TENANT_A], allowedUsers: [USER_A] },
+        identity: { tenantId: TENANT_B, userId: USER_B },
+      }),
+    );
+    expect(d.provider).toBe('vertex');
+    expect(d.requested).toBe('livekit');
+    expect(d.reason).toBe('canary_not_allowlisted');
+    expect(d.livekitReady).toBe(false);
+    expect(d.canary).toBe(true);
+    expect(d.error).toMatch(/not in the canary allowlist/);
+  });
+
+  it('C5. canary enabled + no identity at all → canary_not_allowlisted', () => {
+    const d = selectUpstreamProvider(
+      ctx({
+        envProviderOverride: 'livekit',
+        livekitCredentials: FULL_LIVEKIT_CREDS,
+        canary: { enabled: true, allowedTenants: [TENANT_A] },
+        identity: { tenantId: null, userId: null },
+      }),
+    );
+    expect(d.provider).toBe('vertex');
+    expect(d.reason).toBe('canary_not_allowlisted');
+    expect(d.canary).toBe(true);
+  });
+
+  it('C6. canary enabled + livekit creds INVALID → livekit_config_invalid (NOT canary)', () => {
+    // Config invalidity must beat the canary path — a canary user with
+    // missing creds gets the same `livekit_config_invalid` reason as
+    // anyone else, and the canary flag stays false.
+    const d = selectUpstreamProvider(
+      ctx({
+        envProviderOverride: 'livekit',
+        livekitCredentials: { url: 'wss://x' /* apiKey + apiSecret missing */ },
+        canary: { enabled: true, allowedTenants: [TENANT_A] },
+        identity: { tenantId: TENANT_A },
+      }),
+    );
+    expect(d.provider).toBe('vertex');
+    expect(d.reason).toBe('livekit_config_invalid');
+    expect(d.canary).toBe(false);
+    expect(d.error).toMatch(/apiKey/);
+  });
+
+  it('C7. canary enabled + no LiveKit request anywhere → default, NOT canary', () => {
+    // If nothing requests LiveKit, the canary gate is irrelevant — the
+    // selector returns the unchanged default path.
+    const d = selectUpstreamProvider(
+      ctx({
+        canary: { enabled: true, allowedTenants: [TENANT_A] },
+        identity: { tenantId: TENANT_A },
+      }),
+    );
+    expect(d.provider).toBe('vertex');
+    expect(d.reason).toBe('default');
+    expect(d.canary).toBe(false);
+  });
+
+  it('C8. system_config=livekit + canary allowlist match → canary_selected_livekit', () => {
+    // The canary gate works for the system_config path too, not just env.
+    const d = selectUpstreamProvider(
+      ctx({
+        systemConfigActiveProvider: 'livekit',
+        livekitCredentials: FULL_LIVEKIT_CREDS,
+        canary: { enabled: true, allowedUsers: [USER_A] },
+        identity: { userId: USER_A },
+      }),
+    );
+    expect(d.provider).toBe('livekit');
+    expect(d.reason).toBe('canary_selected_livekit');
+  });
+
+  it('C9. env=vertex never reaches the canary gate (Vertex stays the rollback)', () => {
+    // Explicit ORB_LIVE_PROVIDER=vertex is the rollback path: it must
+    // NEVER reach the canary even with a perfectly allowlisted identity.
+    const d = selectUpstreamProvider(
+      ctx({
+        envProviderOverride: 'vertex',
+        livekitCredentials: FULL_LIVEKIT_CREDS,
+        canary: { enabled: true, allowedTenants: [TENANT_A] },
+        identity: { tenantId: TENANT_A },
+      }),
+    );
+    expect(d.provider).toBe('vertex');
+    expect(d.reason).toBe('env_explicit_vertex');
+    expect(d.canary).toBe(false);
+  });
+
+  it('C10. canary enabled but empty allowlist → no identity ever matches → canary_not_allowlisted', () => {
+    // Clearing the allowlist while keeping `enabled=true` is a valid
+    // "pause without disabling" state. Every LiveKit request degrades
+    // to canary_not_allowlisted; rollback is one config change.
+    const d = selectUpstreamProvider(
+      ctx({
+        envProviderOverride: 'livekit',
+        livekitCredentials: FULL_LIVEKIT_CREDS,
+        canary: { enabled: true, allowedTenants: [], allowedUsers: [] },
+        identity: { tenantId: TENANT_A, userId: USER_A },
+      }),
+    );
+    expect(d.provider).toBe('vertex');
+    expect(d.reason).toBe('canary_not_allowlisted');
+    expect(d.canary).toBe(true);
+  });
+
+  it('C11. canary still NEVER throws on malformed canary input', () => {
+    expect(() =>
+      selectUpstreamProvider(
+        ctx({
+          envProviderOverride: 'livekit',
+          livekitCredentials: FULL_LIVEKIT_CREDS,
+          // @ts-expect-error — testing runtime tolerance
+          canary: { enabled: 'yes', allowedTenants: 'tenant-a' },
+          // @ts-expect-error — testing runtime tolerance
+          identity: 'identity-string',
+        }),
+      ),
+    ).not.toThrow();
   });
 });


### PR DESCRIPTION
## Summary

Lifts the L1 pin only inside the canary gate. Vertex remains the production default and the rollback path. L2.1 ships **selection + observability only** — the consumer still constructs `VertexLiveClient` even when the selector unlocks LiveKit. **L2.2 lifts the consumer-side pin and wires the real LiveKit media client.**

## What moves

**Extended** — `services/gateway/src/orb/live/upstream/upstream-provider-selector.ts`:
- New optional context: ``canary: { enabled, allowedTenants?, allowedUsers? }`` + ``identity: { tenantId?, userId? }``.
- New reasons: ``canary_selected_livekit`` (provider=livekit), ``canary_not_allowlisted`` (provider=vertex).
- Decision shape grows a ``canary: boolean`` field.
- Selection rules:
  1. ``env=vertex`` → vertex (rollback path; canary never reached)
  2. ``env=livekit`` + invalid creds → vertex / ``livekit_config_invalid``
  3. ``env=livekit`` + creds + ``canary.enabled`` + identity match → **LIVEKIT** / ``canary_selected_livekit``
  4. ``env=livekit`` + creds + ``canary.enabled`` + no match → vertex / ``canary_not_allowlisted``
  5. ``env=livekit`` + creds + canary disabled → vertex / ``pinned_to_vertex_l1`` (the L1 cap)
  6. ``system_config=livekit`` path → same gating
  7. nothing requested → vertex / ``default``
- Selector NEVER throws on malformed canary input.

**New** — `services/gateway/src/orb/live/upstream/livekit-canary-config.ts`:
- ``getLiveKitCanaryConfig()`` reads ``ORB_LIVEKIT_CANARY_ENABLED`` env + ``voice.livekit_canary_enabled`` + ``voice.livekit_canary_allowlist`` (JSONB ``{tenants, users}``) system_config rows.
- ``enabled = env || sys``; either source unlocks. Empty allowlist with ``enabled=true`` is a valid "pause without disable" state — no identity ever matches.
- 15s in-process cache. DB read failure degrades silently to ``{enabled:false}``. NEVER throws.

**Modified** — `services/gateway/src/routes/orb-live.ts` (``connectToLiveAPI``, +90 / -13):
- Reads ``getLiveKitCanaryConfig()`` alongside ``getVoiceConfig()``.
- Passes canary + identity to selector.
- ``orb.upstream.provider.selected`` payload grows ``canary: bool``.
- When selector returns ``provider='livekit'`` via canary path, emits TWO new events:
  - ``orb.upstream.canary.selection_unlocked`` — the decision happened.
  - ``orb.upstream.canary.consumer_pinned_vertex_l21`` — L2.1 still uses Vertex (the LiveKit media client isn't wired yet).
- Consumer **still** constructs ``new VertexLiveClient()``. Production behavior unchanged everywhere.

**Modified** — `services/gateway/src/types/cicd.ts`: adds 2 new event-type literals.

## Tests

- **11 new canary selector tests (C1–C11)**: disabled / enabled, tenant match, user match, no identity, invalid creds beat canary, no LiveKit request beats canary, system_config path, env=vertex never reaches canary, empty allowlist, never-throws.
- **6 new canary-config helper tests**: env parsing variants, default empties, graceful-degradation contract.
- **1 new characterization assertion** in upstream-message-handler.characterization.test: ``connectToLiveAPI`` calls ``getLiveKitCanaryConfig``, passes canary + identity bags to the selector, emits both new OASIS event types, and gates the canary events on ``provider==='livekit' && canary``.
- **687 orb tests green** (was 668 after L1).
- Build clean. orb-live.ts CRLF preserved.

## Acceptance vs the brief

| # | Criterion | Status |
|---|---|---|
| 1 | Default production path still selects Vertex | ✓ (``default``) |
| 2 | ``ORB_LIVE_PROVIDER=livekit`` without canary allowlist still selects Vertex | ✓ (``pinned_to_vertex_l1``) |
| 3 | Allowlisted internal identity selects LiveKit | ✓ (``canary_selected_livekit`` at selector layer; consumer remains on Vertex in L2.1 with explicit telemetry — L2.2 lifts) |
| 4 | Missing/invalid LiveKit config does not select LiveKit | ✓ (``livekit_config_invalid``) |
| 5 | LiveKit connect success/failure visible in telemetry | **partial** — L2.1 emits ``selection_unlocked`` + ``consumer_pinned_vertex_l21``. ``connect_started/succeeded/failed`` land in L2.2 |
| 6 | Vertex rollback is one config change | ✓ (flip ``ORB_LIVEKIT_CANARY_ENABLED`` OR clear allowlist) |
| 7 | /orb/chat smoke still passes on Vertex | pending merge |
| 8 | No broad rollout | ✓ (consumer-side pin holds) |

## Next

**L2.2** — Lift the L2.1 consumer-side pin. Implement ``LiveKitLiveClient`` (UpstreamLiveClient impl) with real WebRTC/LiveKit room media. Replace ``consumer_pinned_vertex_l21`` event with ``canary.connect_started`` / ``canary.connect_succeeded`` / ``canary.connect_failed``.

🤖 Generated with [Claude Code](https://claude.com/claude-code)