### PR TITLE
feat(orb): L2.2a — per-identity active-provider gate with no-empty-room safety pin (VTID-02982)

### DIFF
--- a/services/gateway/src/orb/live/upstream/active-provider-resolver.ts
+++ b/services/gateway/src/orb/live/upstream/active-provider-resolver.ts
@@ -1,0 +1,190 @@
+/**
+ * L2.2a (VTID-02982 / orb-live-refactor): pure per-caller active-provider
+ * resolution policy.
+ *
+ * Purpose
+ * -------
+ * The frontend ORB stack pivots between Vertex (gateway-proxied WS/SSE) and
+ * LiveKit (frontend-driven WebRTC) by reading `GET /api/v1/orb/active-provider`.
+ * Today that endpoint returns ONE tenant-wide flag — flipping it to `livekit`
+ * sends every user onto LiveKit. That's incompatible with a narrow canary.
+ *
+ * This resolver makes the endpoint per-identity AND adds a hard safety pin:
+ * even if a canary user is fully allowlisted AND LiveKit credentials are
+ * valid, the effective provider stays `vertex` until the backend LiveKit
+ * Agent is explicitly enabled (`voice.livekit_agent_enabled`). The agent
+ * doesn't exist yet, so by construction NO caller can reach LiveKit through
+ * this endpoint until the agent ships in L2.2b.
+ *
+ * Hard rule (from the L2.2a brief)
+ * --------------------------------
+ *   Do NOT make the frontend join an empty LiveKit room.
+ *   Do NOT return effectiveProvider=livekit until the backend LiveKit Agent
+ *   exists and is enabled.
+ *
+ * Selection rules
+ * ---------------
+ *   1. `globalActiveProvider === 'vertex'` → vertex (`default_vertex`).
+ *   2. `globalActiveProvider === 'livekit'`:
+ *        a. `!livekitCredsValid`        → vertex (`livekit_config_invalid`)
+ *        b. `!canary.enabled`           → vertex (`canary_disabled`)
+ *        c. identity not in allowlist   → vertex (`canary_not_allowlisted`)
+ *        d. `!agentReady`               → vertex (`pinned_until_agent_ready`)
+ *                                          [the L2.2a safety pin]
+ *        e. ALL above pass              → LIVEKIT (`livekit_all_gates_pass`)
+ *
+ * The resolver is PURE — it never reads env, never queries DB, never emits
+ * OASIS. The caller (the `/orb/active-provider` route) gathers inputs and
+ * calls this function, then emits OASIS based on the returned reason.
+ * NEVER throws.
+ */
+
+export type ActiveProviderName = 'vertex' | 'livekit';
+
+export type ResolutionReason =
+  | 'default_vertex'              // globalActiveProvider=vertex
+  | 'canary_disabled'             // global=livekit but canary not enabled
+  | 'canary_not_allowlisted'      // global=livekit + canary on + identity not in list
+  | 'livekit_config_invalid'      // creds missing (URL / api key / api secret)
+  | 'pinned_until_agent_ready'    // all canary gates pass BUT agent not enabled (L2.2a pin)
+  | 'livekit_all_gates_pass';     // effective=livekit
+
+export interface ResolverCanaryInput {
+  enabled: boolean;
+  allowedTenants?: ReadonlyArray<string>;
+  allowedUsers?: ReadonlyArray<string>;
+}
+
+export interface ResolverContext {
+  /** From `voice.active_provider` system_config. The tenant-wide intent. */
+  globalActiveProvider: ActiveProviderName;
+  /** From `livekit-canary-config.ts`. */
+  canary: ResolverCanaryInput;
+  /** Whether LIVEKIT_URL + LIVEKIT_API_KEY + LIVEKIT_API_SECRET are all non-empty. */
+  livekitCredsValid: boolean;
+  /** Backend LiveKit Agent is enabled (env `ORB_LIVEKIT_AGENT_ENABLED` or
+   *  system_config `voice.livekit_agent_enabled`). Default `false` in L2.2a. */
+  agentReady: boolean;
+  /** Caller identity from `optionalAuth`. `null` for unauthenticated callers. */
+  identity: { tenantId?: string | null; userId?: string | null } | null;
+}
+
+export interface ActiveProviderResolution {
+  /** What the global `voice.active_provider` flag asked for. */
+  requestedProvider: ActiveProviderName;
+  /** What the caller should actually route to (legacy `active_provider` field). */
+  effectiveProvider: ActiveProviderName;
+  /** Creds present. */
+  livekitReady: boolean;
+  /** Canary enabled AND caller identity matches allowlist. */
+  canaryEligible: boolean;
+  /** Backend agent flipped on. */
+  agentReady: boolean;
+  /** Why `effectiveProvider` was chosen. */
+  reason: ResolutionReason;
+}
+
+function isIdentityAllowlisted(
+  canary: ResolverCanaryInput,
+  identity: ResolverContext['identity'],
+): boolean {
+  if (!canary.enabled || !identity) return false;
+  const tenants = canary.allowedTenants ?? [];
+  const users = canary.allowedUsers ?? [];
+  if (identity.tenantId && tenants.includes(identity.tenantId)) return true;
+  if (identity.userId && users.includes(identity.userId)) return true;
+  return false;
+}
+
+/**
+ * Pure resolver. Never throws. Never reads env. Never queries DB.
+ * The caller is responsible for emitting OASIS events based on the
+ * returned reason.
+ */
+export function resolveActiveProviderForCaller(
+  ctx: ResolverContext,
+): ActiveProviderResolution {
+  const requestedProvider: ActiveProviderName =
+    ctx.globalActiveProvider === 'livekit' ? 'livekit' : 'vertex';
+  const livekitReady = ctx.livekitCredsValid === true;
+  const canaryEligible =
+    ctx.canary?.enabled === true && isIdentityAllowlisted(ctx.canary, ctx.identity);
+  const agentReady = ctx.agentReady === true;
+
+  // Rule 1: global flag says vertex → vertex.
+  if (requestedProvider === 'vertex') {
+    return {
+      requestedProvider,
+      effectiveProvider: 'vertex',
+      livekitReady,
+      canaryEligible,
+      agentReady,
+      reason: 'default_vertex',
+    };
+  }
+
+  // Rule 2: global flag says livekit — walk the gates in order. Earlier gates
+  // beat later ones so the `reason` always names the FIRST gate that failed.
+
+  // 2a. creds invalid
+  if (!livekitReady) {
+    return {
+      requestedProvider,
+      effectiveProvider: 'vertex',
+      livekitReady,
+      canaryEligible: false, // creds-invalid means the canary path was never
+                             // reached; report eligibility false to avoid
+                             // surfacing "you're allowlisted!" when the path
+                             // is structurally broken.
+      agentReady,
+      reason: 'livekit_config_invalid',
+    };
+  }
+
+  // 2b. canary not enabled
+  if (ctx.canary?.enabled !== true) {
+    return {
+      requestedProvider,
+      effectiveProvider: 'vertex',
+      livekitReady,
+      canaryEligible: false,
+      agentReady,
+      reason: 'canary_disabled',
+    };
+  }
+
+  // 2c. canary enabled but identity not in allowlist
+  if (!canaryEligible) {
+    return {
+      requestedProvider,
+      effectiveProvider: 'vertex',
+      livekitReady,
+      canaryEligible: false,
+      agentReady,
+      reason: 'canary_not_allowlisted',
+    };
+  }
+
+  // 2d. L2.2a safety pin: all canary gates pass BUT agent not yet enabled.
+  // This is the no-empty-room invariant.
+  if (!agentReady) {
+    return {
+      requestedProvider,
+      effectiveProvider: 'vertex',
+      livekitReady,
+      canaryEligible: true,
+      agentReady: false,
+      reason: 'pinned_until_agent_ready',
+    };
+  }
+
+  // 2e. All gates pass.
+  return {
+    requestedProvider,
+    effectiveProvider: 'livekit',
+    livekitReady: true,
+    canaryEligible: true,
+    agentReady: true,
+    reason: 'livekit_all_gates_pass',
+  };
+}

--- a/services/gateway/src/orb/live/upstream/livekit-agent-config.ts
+++ b/services/gateway/src/orb/live/upstream/livekit-agent-config.ts
@@ -1,0 +1,111 @@
+/**
+ * L2.2a (VTID-02982 / orb-live-refactor): backend LiveKit Agent readiness flag.
+ *
+ * The L2.2a safety pin: even when a canary user is fully allowlisted AND
+ * LiveKit credentials are valid, the per-identity active-provider resolver
+ * keeps `effectiveProvider=vertex` until THIS flag is true. The flag means
+ * "a backend LiveKit Agent (the room participant that runs Gemini and
+ * publishes audio back to the LiveKit room) is running and ready to serve."
+ *
+ * L2.2a ships with the agent NOT YET BUILT — the flag is off by default and
+ * stays off in production. When L2.2b ships the agent service, ops flips
+ * the flag and canary users start routing to LiveKit via the existing
+ * `/orb/active-provider` endpoint, no frontend redeploy needed.
+ *
+ * Inputs (either unlocks the agent):
+ *   - env  `ORB_LIVEKIT_AGENT_ENABLED` (`true | 1 | yes` case-insensitive)
+ *   - sys  `voice.livekit_agent_enabled` (boolean) system_config row
+ *
+ * Hard rules:
+ *   - This helper NEVER throws. DB failures degrade to `enabled: false`
+ *     (production-safe default — pins to Vertex).
+ *   - It is a discrete knob from the canary config in
+ *     `livekit-canary-config.ts`. Mixing them would conflate "WHO is on the
+ *     canary" with "is the backend AGENT itself ready" — different
+ *     decisions, different flip cadences.
+ */
+
+import { getSupabase } from '../../../lib/supabase';
+
+export interface LiveKitAgentReadiness {
+  enabled: boolean;
+}
+
+const CACHE_TTL_MS = 15_000;
+const AGENT_ENABLED_KEY = 'voice.livekit_agent_enabled';
+
+let _cached: LiveKitAgentReadiness | null = null;
+let _cachedAt = 0;
+
+function envEnabled(env: NodeJS.ProcessEnv): boolean {
+  const raw = (env.ORB_LIVEKIT_AGENT_ENABLED ?? '').trim().toLowerCase();
+  return raw === 'true' || raw === '1' || raw === 'yes';
+}
+
+function asBool(v: unknown): boolean {
+  if (typeof v === 'boolean') return v;
+  if (typeof v === 'string') {
+    const s = v.trim().toLowerCase();
+    return s === 'true' || s === '1' || s === 'yes';
+  }
+  if (
+    v &&
+    typeof v === 'object' &&
+    'enabled' in (v as Record<string, unknown>) &&
+    typeof (v as Record<string, unknown>).enabled === 'boolean'
+  ) {
+    return (v as Record<string, boolean>).enabled;
+  }
+  return false;
+}
+
+/**
+ * Read the LiveKit Agent readiness flag. Cached 15s.
+ * NEVER throws — DB failures degrade to `{enabled:false}` so the resolver
+ * pins to Vertex.
+ */
+export async function getLiveKitAgentReadiness(
+  env: NodeJS.ProcessEnv = process.env,
+  force = false,
+): Promise<LiveKitAgentReadiness> {
+  const now = Date.now();
+  if (!force && _cached && now - _cachedAt < CACHE_TTL_MS) {
+    // Env flag always overrides cache (operator can flip it without
+    // invalidating the cached system_config row).
+    const envOn = envEnabled(env);
+    return envOn && !_cached.enabled ? { enabled: true } : _cached;
+  }
+
+  const envOn = envEnabled(env);
+  const sb = getSupabase();
+  if (!sb) {
+    const cfg: LiveKitAgentReadiness = { enabled: envOn };
+    _cached = cfg;
+    _cachedAt = now;
+    return cfg;
+  }
+
+  let sysEnabled = false;
+  try {
+    const { data, error } = await sb
+      .from('system_config')
+      .select('key, value')
+      .eq('key', AGENT_ENABLED_KEY)
+      .maybeSingle();
+    if (!error && data) {
+      sysEnabled = asBool((data as { value: unknown }).value);
+    }
+  } catch {
+    // Degrade to env-only (or false) — production-safe.
+  }
+
+  const cfg: LiveKitAgentReadiness = { enabled: envOn || sysEnabled };
+  _cached = cfg;
+  _cachedAt = now;
+  return cfg;
+}
+
+export function invalidateLiveKitAgentConfigCache(): void {
+  _cached = null;
+  _cachedAt = 0;
+}

--- a/services/gateway/src/routes/orb-livekit.ts
+++ b/services/gateway/src/routes/orb-livekit.ts
@@ -53,6 +53,12 @@ import {
   AuthenticatedRequest,
   SupabaseIdentity,
 } from '../middleware/auth-supabase-jwt';
+// L2.2a (VTID-02982): per-identity active-provider resolution + LiveKit
+// Agent readiness flag. The resolver pins to Vertex unless the backend
+// agent is enabled (the no-empty-room invariant).
+import { resolveActiveProviderForCaller } from '../orb/live/upstream/active-provider-resolver';
+import { getLiveKitCanaryConfig } from '../orb/live/upstream/livekit-canary-config';
+import { getLiveKitAgentReadiness } from '../orb/live/upstream/livekit-agent-config';
 
 const router = Router();
 
@@ -223,14 +229,85 @@ async function writeActiveProvider(
   return { ok: true, previous: current.active_provider };
 }
 
-router.get('/orb/active-provider', async (_req: Request, res: Response) => {
-  try {
-    const state = await readActiveProvider();
-    res.json({ ok: true, ...state, vtid: VTID });
-  } catch (e) {
-    res.status(500).json({ ok: false, error: (e as Error).message, vtid: VTID });
-  }
-});
+// L2.2a (VTID-02982): `/orb/active-provider` is now per-identity canary-aware.
+//
+// Legacy field `active_provider` carries the EFFECTIVE provider for the
+// caller — the existing frontend `useActiveVoiceProvider()` hook reads only
+// that field, so this change is back-compat without any frontend edit.
+//
+// Hard pin: until `voice.livekit_agent_enabled` is true (the L2.2b backend
+// agent isn't built yet), the resolver returns `effectiveProvider=vertex`
+// for EVERY caller regardless of allowlist. No empty LiveKit rooms.
+router.get(
+  '/orb/active-provider',
+  optionalAuth,
+  async (req: AuthenticatedRequest, res: Response) => {
+    try {
+      const state = await readActiveProvider();
+      const canary = await getLiveKitCanaryConfig();
+      const agent = await getLiveKitAgentReadiness();
+      const livekitCredsValid = !!(
+        process.env.LIVEKIT_URL &&
+        process.env.LIVEKIT_API_KEY &&
+        process.env.LIVEKIT_API_SECRET
+      );
+
+      const resolution = resolveActiveProviderForCaller({
+        globalActiveProvider: state.active_provider,
+        canary: {
+          enabled: canary.enabled,
+          allowedTenants: canary.allowedTenants,
+          allowedUsers: canary.allowedUsers,
+        },
+        livekitCredsValid,
+        agentReady: agent.enabled,
+        identity: req.identity
+          ? {
+              tenantId: req.identity.tenant_id ?? null,
+              userId: req.identity.user_id ?? null,
+            }
+          : null,
+      });
+
+      // Emit OASIS when a canary user reaches the agent-pinned state — this
+      // is the signal "we have someone we'd flip if the agent were ready."
+      if (resolution.reason === 'pinned_until_agent_ready') {
+        void emitOasisEvent({
+          type: 'orb.upstream.active_provider.pinned_until_agent_ready',
+          vtid: 'VTID-02982',
+          payload: {
+            tenant_id: req.identity?.tenant_id ?? null,
+            user_id: req.identity?.user_id ?? null,
+            requested_provider: resolution.requestedProvider,
+            livekit_ready: resolution.livekitReady,
+            canary_eligible: resolution.canaryEligible,
+            agent_ready: resolution.agentReady,
+          },
+        } as never).catch(() => { /* best-effort */ });
+      }
+
+      res.json({
+        ok: true,
+        // Legacy fields (backwards-compatible with useActiveVoiceProvider).
+        // `active_provider` now carries the per-caller effective provider.
+        active_provider: resolution.effectiveProvider,
+        last_flipped_at: state.last_flipped_at,
+        flipped_by: state.flipped_by,
+        cooldown_remaining_s: state.cooldown_remaining_s,
+        // L2.2a additions — diagnostic fields for ops + Improve cockpit.
+        requestedProvider: resolution.requestedProvider,
+        effectiveProvider: resolution.effectiveProvider,
+        livekitReady: resolution.livekitReady,
+        canaryEligible: resolution.canaryEligible,
+        agentReady: resolution.agentReady,
+        reason: resolution.reason,
+        vtid: VTID,
+      });
+    } catch (e) {
+      res.status(500).json({ ok: false, error: (e as Error).message, vtid: VTID });
+    }
+  },
+);
 
 router.post(
   '/orb/active-provider',

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -534,6 +534,13 @@ export type CicdEventType =
   // connect_started/succeeded/failed events for the real media path.
   | 'orb.upstream.canary.selection_unlocked'
   | 'orb.upstream.canary.consumer_pinned_vertex_l21'
+  // L2.2a (VTID-02982): per-identity active-provider gate.
+  // Fires from `GET /api/v1/orb/active-provider` when a caller would have
+  // routed to LiveKit (creds valid, canary enabled, identity allowlisted)
+  // BUT the backend LiveKit Agent flag is off. The L2.2a safety pin keeps
+  // the caller on Vertex — this event tells operators "you have a canary
+  // user waiting; flip `voice.livekit_agent_enabled` once L2.2b lands."
+  | 'orb.upstream.active_provider.pinned_until_agent_ready'
   // VTID-DIAG: Pipeline diagnostics
   | 'orb.live.diag'
   // VTID-FALLBACK: Chat-TTS fallback events

--- a/services/gateway/test/orb/live/upstream/active-provider-resolver.test.ts
+++ b/services/gateway/test/orb/live/upstream/active-provider-resolver.test.ts
@@ -1,0 +1,275 @@
+/**
+ * L2.2a (VTID-02982): pure-resolver tests for `resolveActiveProviderForCaller`.
+ *
+ * The resolver is pure — these tests never touch process.env, Supabase, or
+ * OASIS. Every input is passed explicitly via the context bag.
+ *
+ * Acceptance matrix (the gate stack walked top-down):
+ *   1. global=vertex → vertex/`default_vertex` (no canary fields consulted).
+ *   2. global=livekit + creds invalid → vertex/`livekit_config_invalid`.
+ *   3. global=livekit + creds + canary disabled → vertex/`canary_disabled`.
+ *   4. global=livekit + creds + canary enabled + identity not in allowlist
+ *      → vertex/`canary_not_allowlisted`.
+ *   5. global=livekit + creds + canary on + identity matched + agent OFF
+ *      → vertex/`pinned_until_agent_ready` (the L2.2a safety pin).
+ *   6. global=livekit + all gates pass + agent ON → LIVEKIT/`livekit_all_gates_pass`.
+ *
+ * The resolver NEVER throws.
+ */
+
+import {
+  resolveActiveProviderForCaller,
+  type ResolverContext,
+} from '../../../../src/orb/live/upstream/active-provider-resolver';
+
+const TENANT_A = '11111111-aaaa-aaaa-aaaa-111111111111';
+const TENANT_B = '22222222-bbbb-bbbb-bbbb-222222222222';
+const USER_A = '33333333-cccc-cccc-cccc-333333333333';
+const USER_B = '44444444-dddd-dddd-dddd-444444444444';
+
+function ctx(over: Partial<ResolverContext> = {}): ResolverContext {
+  return {
+    globalActiveProvider: 'vertex',
+    canary: { enabled: false },
+    livekitCredsValid: false,
+    agentReady: false,
+    identity: null,
+    ...over,
+  };
+}
+
+describe('L2.2a resolveActiveProviderForCaller — pure resolution policy', () => {
+  it('1. global=vertex → vertex/default_vertex (other fields irrelevant)', () => {
+    const d = resolveActiveProviderForCaller(
+      ctx({
+        globalActiveProvider: 'vertex',
+        canary: { enabled: true, allowedTenants: [TENANT_A] },
+        livekitCredsValid: true,
+        agentReady: true,
+        identity: { tenantId: TENANT_A },
+      }),
+    );
+    expect(d.effectiveProvider).toBe('vertex');
+    expect(d.requestedProvider).toBe('vertex');
+    expect(d.reason).toBe('default_vertex');
+  });
+
+  it('2. global=livekit + creds invalid → vertex/livekit_config_invalid (beats canary)', () => {
+    // Even a perfectly allowlisted canary user with agent ready cannot
+    // route past invalid LiveKit creds.
+    const d = resolveActiveProviderForCaller(
+      ctx({
+        globalActiveProvider: 'livekit',
+        livekitCredsValid: false,
+        canary: { enabled: true, allowedUsers: [USER_A] },
+        agentReady: true,
+        identity: { userId: USER_A },
+      }),
+    );
+    expect(d.effectiveProvider).toBe('vertex');
+    expect(d.reason).toBe('livekit_config_invalid');
+    expect(d.canaryEligible).toBe(false);
+    expect(d.livekitReady).toBe(false);
+  });
+
+  it('3. global=livekit + creds + canary disabled → vertex/canary_disabled', () => {
+    const d = resolveActiveProviderForCaller(
+      ctx({
+        globalActiveProvider: 'livekit',
+        livekitCredsValid: true,
+        canary: { enabled: false, allowedTenants: [TENANT_A] },
+        agentReady: true,
+        identity: { tenantId: TENANT_A },
+      }),
+    );
+    expect(d.effectiveProvider).toBe('vertex');
+    expect(d.reason).toBe('canary_disabled');
+    expect(d.canaryEligible).toBe(false);
+    expect(d.livekitReady).toBe(true);
+  });
+
+  it('4. global=livekit + creds + canary on + identity NOT in allowlist → vertex/canary_not_allowlisted', () => {
+    const d = resolveActiveProviderForCaller(
+      ctx({
+        globalActiveProvider: 'livekit',
+        livekitCredsValid: true,
+        canary: { enabled: true, allowedTenants: [TENANT_A] },
+        agentReady: true,
+        identity: { tenantId: TENANT_B, userId: USER_B },
+      }),
+    );
+    expect(d.effectiveProvider).toBe('vertex');
+    expect(d.reason).toBe('canary_not_allowlisted');
+    expect(d.canaryEligible).toBe(false);
+  });
+
+  it('4b. global=livekit + creds + canary on + no identity → vertex/canary_not_allowlisted', () => {
+    const d = resolveActiveProviderForCaller(
+      ctx({
+        globalActiveProvider: 'livekit',
+        livekitCredsValid: true,
+        canary: { enabled: true, allowedUsers: [USER_A] },
+        agentReady: true,
+        identity: null,
+      }),
+    );
+    expect(d.effectiveProvider).toBe('vertex');
+    expect(d.reason).toBe('canary_not_allowlisted');
+    expect(d.canaryEligible).toBe(false);
+  });
+
+  it('5. global=livekit + creds + canary on + matched + agent OFF → vertex/pinned_until_agent_ready (L2.2a safety pin)', () => {
+    const d = resolveActiveProviderForCaller(
+      ctx({
+        globalActiveProvider: 'livekit',
+        livekitCredsValid: true,
+        canary: { enabled: true, allowedTenants: [TENANT_A] },
+        agentReady: false, // ← the pin
+        identity: { tenantId: TENANT_A, userId: USER_B },
+      }),
+    );
+    expect(d.effectiveProvider).toBe('vertex');
+    expect(d.reason).toBe('pinned_until_agent_ready');
+    expect(d.canaryEligible).toBe(true);
+    expect(d.livekitReady).toBe(true);
+    expect(d.agentReady).toBe(false);
+  });
+
+  it('5b. same as 5 but match via allowedUsers → still pinned_until_agent_ready', () => {
+    const d = resolveActiveProviderForCaller(
+      ctx({
+        globalActiveProvider: 'livekit',
+        livekitCredsValid: true,
+        canary: { enabled: true, allowedUsers: [USER_A] },
+        agentReady: false,
+        identity: { tenantId: TENANT_B, userId: USER_A },
+      }),
+    );
+    expect(d.effectiveProvider).toBe('vertex');
+    expect(d.reason).toBe('pinned_until_agent_ready');
+    expect(d.canaryEligible).toBe(true);
+  });
+
+  it('6. global=livekit + ALL gates pass + agent ON → LIVEKIT/livekit_all_gates_pass', () => {
+    const d = resolveActiveProviderForCaller(
+      ctx({
+        globalActiveProvider: 'livekit',
+        livekitCredsValid: true,
+        canary: { enabled: true, allowedTenants: [TENANT_A] },
+        agentReady: true,
+        identity: { tenantId: TENANT_A },
+      }),
+    );
+    expect(d.effectiveProvider).toBe('livekit');
+    expect(d.requestedProvider).toBe('livekit');
+    expect(d.reason).toBe('livekit_all_gates_pass');
+    expect(d.livekitReady).toBe(true);
+    expect(d.canaryEligible).toBe(true);
+    expect(d.agentReady).toBe(true);
+  });
+
+  // ----- L2.2a hard invariants -----
+
+  it('invariant: NEVER returns effectiveProvider=livekit when agentReady=false', () => {
+    // Sweep every conceivable input combination with agentReady=false and
+    // assert effectiveProvider stays vertex.
+    const cases: ResolverContext[] = [];
+    for (const global of ['vertex', 'livekit'] as const) {
+      for (const creds of [true, false]) {
+        for (const canEn of [true, false]) {
+          for (const idMatch of [true, false]) {
+            cases.push({
+              globalActiveProvider: global,
+              livekitCredsValid: creds,
+              canary: { enabled: canEn, allowedTenants: [TENANT_A] },
+              agentReady: false, // ← the safety pin
+              identity: idMatch ? { tenantId: TENANT_A } : { tenantId: TENANT_B },
+            });
+          }
+        }
+      }
+    }
+    for (const c of cases) {
+      expect(resolveActiveProviderForCaller(c).effectiveProvider).toBe('vertex');
+    }
+  });
+
+  it('invariant: NEVER returns effectiveProvider=livekit when canary disabled', () => {
+    const d = resolveActiveProviderForCaller(
+      ctx({
+        globalActiveProvider: 'livekit',
+        livekitCredsValid: true,
+        canary: { enabled: false, allowedTenants: [TENANT_A], allowedUsers: [USER_A] },
+        agentReady: true,
+        identity: { tenantId: TENANT_A, userId: USER_A },
+      }),
+    );
+    expect(d.effectiveProvider).toBe('vertex');
+  });
+
+  it('invariant: NEVER returns effectiveProvider=livekit when identity unmatched', () => {
+    const d = resolveActiveProviderForCaller(
+      ctx({
+        globalActiveProvider: 'livekit',
+        livekitCredsValid: true,
+        canary: { enabled: true, allowedTenants: [TENANT_A] },
+        agentReady: true,
+        identity: { tenantId: TENANT_B },
+      }),
+    );
+    expect(d.effectiveProvider).toBe('vertex');
+  });
+
+  it('rollback: flipping global=vertex bypasses ALL canary/agent gates → default_vertex', () => {
+    // The "Vertex rollback as a config-only switch" guarantee. Even if
+    // every other knob says "go LiveKit," flipping the global flag to
+    // vertex restores the old path with no code change.
+    const d = resolveActiveProviderForCaller(
+      ctx({
+        globalActiveProvider: 'vertex',
+        livekitCredsValid: true,
+        canary: { enabled: true, allowedTenants: [TENANT_A], allowedUsers: [USER_A] },
+        agentReady: true,
+        identity: { tenantId: TENANT_A, userId: USER_A },
+      }),
+    );
+    expect(d.effectiveProvider).toBe('vertex');
+    expect(d.reason).toBe('default_vertex');
+  });
+
+  it('resolver NEVER throws on malformed input', () => {
+    expect(() =>
+      resolveActiveProviderForCaller(
+        ctx({
+          // @ts-expect-error — testing runtime tolerance
+          globalActiveProvider: 'openai',
+          // @ts-expect-error — testing runtime tolerance
+          canary: 'not-an-object',
+          // @ts-expect-error — testing runtime tolerance
+          livekitCredsValid: 'yes',
+          // @ts-expect-error — testing runtime tolerance
+          agentReady: 'sure',
+          // @ts-expect-error — testing runtime tolerance
+          identity: 42,
+        }),
+      ),
+    ).not.toThrow();
+  });
+
+  it('rollback path 2: flipping agentReady false also restores everyone to vertex', () => {
+    // L2.2a is the safety: if the agent service breaks, ops flips
+    // `voice.livekit_agent_enabled=false` and every canary user flows
+    // back through Vertex on next /orb/active-provider refresh.
+    const baseCanaryCtx: ResolverContext = ctx({
+      globalActiveProvider: 'livekit',
+      livekitCredsValid: true,
+      canary: { enabled: true, allowedTenants: [TENANT_A] },
+      identity: { tenantId: TENANT_A },
+    });
+    const withAgent = resolveActiveProviderForCaller({ ...baseCanaryCtx, agentReady: true });
+    const withoutAgent = resolveActiveProviderForCaller({ ...baseCanaryCtx, agentReady: false });
+    expect(withAgent.effectiveProvider).toBe('livekit');
+    expect(withoutAgent.effectiveProvider).toBe('vertex');
+    expect(withoutAgent.reason).toBe('pinned_until_agent_ready');
+  });
+});

--- a/services/gateway/test/orb/live/upstream/livekit-agent-config.test.ts
+++ b/services/gateway/test/orb/live/upstream/livekit-agent-config.test.ts
@@ -1,0 +1,67 @@
+/**
+ * L2.2a (VTID-02982): `livekit-agent-config` unit tests.
+ *
+ * The helper reads:
+ *   - env  `ORB_LIVEKIT_AGENT_ENABLED`
+ *   - sys  `voice.livekit_agent_enabled`
+ *
+ * Default in production is `{enabled: false}` — the L2.2a safety pin. These
+ * tests focus on the env parser + graceful-degradation contract.
+ */
+
+import {
+  getLiveKitAgentReadiness,
+  invalidateLiveKitAgentConfigCache,
+} from '../../../../src/orb/live/upstream/livekit-agent-config';
+
+const ORIGINAL_ENV = { ...process.env };
+
+function resetEnv(): void {
+  delete process.env.ORB_LIVEKIT_AGENT_ENABLED;
+}
+
+beforeEach(() => {
+  invalidateLiveKitAgentConfigCache();
+  resetEnv();
+});
+
+afterAll(() => {
+  process.env = { ...ORIGINAL_ENV };
+});
+
+describe('L2.2a getLiveKitAgentReadiness — env handling', () => {
+  it('ORB_LIVEKIT_AGENT_ENABLED unset → enabled=false (the safety default)', async () => {
+    const cfg = await getLiveKitAgentReadiness(process.env, true);
+    expect(cfg.enabled).toBe(false);
+  });
+
+  it('ORB_LIVEKIT_AGENT_ENABLED=true → enabled=true', async () => {
+    process.env.ORB_LIVEKIT_AGENT_ENABLED = 'true';
+    const cfg = await getLiveKitAgentReadiness(process.env, true);
+    expect(cfg.enabled).toBe(true);
+  });
+
+  it('truthy variants (1 / yes / TRUE / Yes / whitespace) → enabled=true', async () => {
+    for (const v of ['1', 'yes', 'TRUE', 'Yes', '  TRUE  ']) {
+      process.env.ORB_LIVEKIT_AGENT_ENABLED = v;
+      invalidateLiveKitAgentConfigCache();
+      const cfg = await getLiveKitAgentReadiness(process.env, true);
+      expect(cfg.enabled).toBe(true);
+    }
+  });
+
+  it('falsy variants (false / 0 / off / "") → enabled=false', async () => {
+    for (const v of ['false', '0', 'off', '']) {
+      process.env.ORB_LIVEKIT_AGENT_ENABLED = v;
+      invalidateLiveKitAgentConfigCache();
+      const cfg = await getLiveKitAgentReadiness(process.env, true);
+      expect(cfg.enabled).toBe(false);
+    }
+  });
+
+  it('NEVER throws — even with garbage env values', async () => {
+    // @ts-expect-error — testing runtime tolerance
+    process.env.ORB_LIVEKIT_AGENT_ENABLED = 42 as unknown as string;
+    await expect(getLiveKitAgentReadiness(process.env, true)).resolves.toBeTruthy();
+  });
+});


### PR DESCRIPTION
## Summary

Makes ``GET /api/v1/orb/active-provider`` per-identity canary-aware. Adds a **hard safety pin**: even when a canary user is fully allowlisted AND LiveKit credentials are valid, the effective provider stays vertex until the backend LiveKit Agent flag is on (``voice.livekit_agent_enabled``). The agent doesn't exist yet (L2.2b territory), so by construction no caller can reach LiveKit through this endpoint in L2.2a. Production behavior is **unchanged for every user**.

## Architecture finding (closed loop)

L2.1's selector + ``connectToLiveAPI`` is the Vertex-only path. LiveKit is a **frontend-driven** WebRTC pipeline — vitana-v1's ``useLiveKitVoice.ts`` already joins LiveKit rooms via the client SDK and pivots on the global flag from ``useActiveVoiceProvider() → /orb/active-provider``. The blocker for a real canary is:
- (a) per-identity scoping at that endpoint
- (b) a backend LiveKit Agent service

L2.2a fixes (a) AND adds a safety pin so (b) is not silently bypassed.

## What moves

**New** — ``services/gateway/src/orb/live/upstream/active-provider-resolver.ts``:
- Pure ``resolveActiveProviderForCaller(ctx)`` — never reads env / DB / OASIS.
- Walks the gate stack top-down; the ``reason`` names the FIRST gate that failed.
- Reasons: ``default_vertex | livekit_config_invalid | canary_disabled | canary_not_allowlisted | pinned_until_agent_ready | livekit_all_gates_pass``.
- Output shape: ``{requestedProvider, effectiveProvider, livekitReady, canaryEligible, agentReady, reason}``.
- NEVER throws.

**New** — ``services/gateway/src/orb/live/upstream/livekit-agent-config.ts``:
- ``getLiveKitAgentReadiness(env)`` reads env ``ORB_LIVEKIT_AGENT_ENABLED`` OR system_config ``voice.livekit_agent_enabled`` (either unlocks).
- 15s cache. Graceful-degrade to ``{enabled:false}`` on DB failure. NEVER throws.
- Default in production: ``{enabled:false}`` — the safety pin holds.

**Modified** — ``services/gateway/src/routes/orb-livekit.ts`` (+85 / -8):
- ``GET /orb/active-provider`` becomes auth-aware via ``optionalAuth``.
- Reads canary config (from L2.1) + agent readiness + LiveKit creds env.
- Calls the resolver with identity from ``req.identity``.
- Legacy field ``active_provider`` now carries the EFFECTIVE provider — so the existing ``useActiveVoiceProvider`` hook on vitana-v1 inherits the canary-safe behavior without any frontend change.
- Adds diagnostic fields: ``requestedProvider``, ``effectiveProvider``, ``livekitReady``, ``canaryEligible``, ``agentReady``, ``reason``.
- Emits ``orb.upstream.active_provider.pinned_until_agent_ready`` OASIS event when a canary user reaches the agent-pinned state.

**Modified** — ``services/gateway/src/types/cicd.ts``: adds 1 new event-type literal.

## Tests

- **14 new resolver tests** covering the full gate matrix + 3 hard invariants (never-livekit-when-agent-off / never-when-canary-disabled / never-when-identity-unmatched) + rollback paths (flip global=vertex OR flip agentReady=false — either reverses).
- **5 new agent-config tests**: env parsing variants, default safety, never-throws.
- **706 orb tests green** (was 687 after L2.1).
- Build clean.

## Acceptance vs the brief

| # | Criterion | Status |
|---|---|---|
| 1 | /orb/active-provider auth-aware | ✓ |
| 2 | Reads voice.active_provider + canary cfg + creds + agent flag | ✓ |
| 3 | Returns vertex by default for everyone | ✓ |
| 4 | For allowlisted canary users, returns full diagnostic metadata | ✓ |
| 5 | Returns effectiveProvider=livekit ONLY when ALL 5 gates pass | ✓ (active=livekit + canary on + allowlisted + creds + agent_ready) |
| 6 | Tests for all branches | ✓ (14 + 5) |
| 7 | **Hard rule — no empty LiveKit room** | ✓ (agentReady=false pins to vertex regardless of canary state) |

## Rollback

Two independent one-config knobs:
- flip ``voice.active_provider=vertex`` → everyone Vertex
- flip ``voice.livekit_agent_enabled=false`` (or unset) → everyone Vertex

Either restores the pre-L2.2a path without code revert.

## Next

**L2.2b — design doc for the backend LiveKit Agent service:**
- runtime (Node/TS or Python)
- deployment target
- room join flow + token/room lifecycle
- STT / Gemini / TTS pipeline
- tool-call parity with Vertex path
- decision-contract prompt input
- telemetry + rollback path

🤖 Generated with [Claude Code](https://claude.com/claude-code)