### PR TITLE
fix(voice-lab): send auth headers on /voice-lab/live/sessions fetches (VTID-02983, DEV-COMHU-02983)

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -16273,7 +16273,10 @@ function fetchVoiceLabSessions(append) {
     }
 
     var offset = append ? state.voiceLab.sessions.length : 0;
-    fetch('/api/v1/voice-lab/live/sessions?offset=' + offset)
+    // VTID-02983: requireAuth on /voice-lab/* reads Bearer-only — without
+    // buildContextHeaders the request 401s and the catch silently empties
+    // the list. Same fix applies to /:id, /:id/turns, /:id/diagnostics below.
+    fetch('/api/v1/voice-lab/live/sessions?offset=' + offset, { headers: buildContextHeaders() })
         .then(function (resp) {
             if (!resp.ok) throw new Error('Failed to fetch sessions');
             return resp.json();
@@ -16335,10 +16338,12 @@ function fetchVoiceLabSessionDetails(sessionId) {
     renderApp();
 
     // Fetch session details, turns, and pipeline diagnostics in parallel
+    // VTID-02983: same auth requirement as fetchVoiceLabSessions above.
+    var vlHeaders = { headers: buildContextHeaders() };
     Promise.all([
-        fetch('/api/v1/voice-lab/live/sessions/' + sessionId).then(function (r) { return r.json(); }),
-        fetch('/api/v1/voice-lab/live/sessions/' + sessionId + '/turns').then(function (r) { return r.json(); }),
-        fetch('/api/v1/voice-lab/live/sessions/' + sessionId + '/diagnostics').then(function (r) { return r.json(); }).catch(function () { return null; })
+        fetch('/api/v1/voice-lab/live/sessions/' + sessionId, vlHeaders).then(function (r) { return r.json(); }),
+        fetch('/api/v1/voice-lab/live/sessions/' + sessionId + '/turns', vlHeaders).then(function (r) { return r.json(); }),
+        fetch('/api/v1/voice-lab/live/sessions/' + sessionId + '/diagnostics', vlHeaders).then(function (r) { return r.json(); }).catch(function () { return null; })
     ])
         .then(function (results) {
             var detailsResp = results[0];
@@ -16414,7 +16419,8 @@ function stopVoiceLabAutoRefresh() {
  * VTID-01218B: Silent fetch (no loading state, for auto-refresh)
  */
 function fetchVoiceLabSessionsSilent() {
-    fetch('/api/v1/voice-lab/live/sessions')
+    // VTID-02983: auth headers required — see fetchVoiceLabSessions.
+    fetch('/api/v1/voice-lab/live/sessions', { headers: buildContextHeaders() })
         .then(function (resp) {
             if (!resp.ok) throw new Error('Failed to fetch sessions');
             return resp.json();

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -30,7 +30,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260504-vtid-02710-ios-ctx-keepalive"></script>
-  <script src="/command-hub/app.js?v=20260513-vtid-02958-pr-l3-failure-scanner"></script>
+  <script src="/command-hub/app.js?v=20260514-vtid-02983-voice-lab-auth"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
 </body>


### PR DESCRIPTION
## Summary
- Voice LAB's Orb Live panel was always empty ("No active voice sessions") because the 5 fetch call sites that hit `/api/v1/voice-lab/live/sessions*` in `command-hub/app.js` skipped `buildContextHeaders()`, returning 401 from `requireAuth` middleware and silently emptying the sessions list.
- Adds `{ headers: buildContextHeaders() }` to all 5 calls (list, silent auto-refresh, detail, turns, diagnostics). Bumps the app.js cache-bust.
- No backend change. The UI + endpoints + classifier were already wired — only the front-end auth headers were missing.

## Test plan
- [ ] Open `/command-hub/diagnostics/voice-lab/` (Voice LAB → Orb Live tab) and confirm recent Vertex sessions appear in the table.
- [ ] Click "Details" on a session — drawer opens with turns + diagnostics, not blank.
- [ ] Confirm `Class` column shows failure_class badge for sessions that match a quality class.
- [ ] DevTools Network: confirm `/voice-lab/live/sessions*` requests carry `Authorization: Bearer` and return 200 (not 401).

🤖 Generated with [Claude Code](https://claude.com/claude-code)