### PR TITLE
fix(autopilot): widen dispatcher source_type allowlist to admit test-contract scanner recommendations (VTID-02984, PR-M1.x)

### DIFF
--- a/services/gateway/src/services/autopilot-executable-source-types.ts
+++ b/services/gateway/src/services/autopilot-executable-source-types.ts
@@ -1,0 +1,62 @@
+/**
+ * VTID-02984 (PR-M1.x): shared allowlist for executable Autopilot
+ * recommendation source_types.
+ *
+ * Before this PR, dev-autopilot-execute.ts hard-coded `source_type` checks
+ * to only `dev_autopilot` / `dev_autopilot_impact`. Recommendations from
+ * the test-contract autonomy spine (PR-L2 missing-test-scanner, PR-L3
+ * failure-scanner) sat at status='new' forever — autoApproveTick's
+ * polling filter excluded them, and the two executeRecommendation
+ * guards rejected them outright. Discovered live during the M1
+ * worker-runner canary smoke (VTID-02977).
+ *
+ * This file is the SINGLE place that lists which source_types are
+ * eligible to enter the executor lane. Adding a new scanner that
+ * produces auto-executable recommendations means adding its
+ * source_type here in a code-reviewed PR. Unknown source_types stay
+ * rejected.
+ */
+
+/**
+ * Executable source_types. Order is not significant; both PostgREST
+ * `in.()` filters and TypeScript guard checks treat this as a set.
+ */
+export const EXECUTABLE_RECOMMENDATION_SOURCE_TYPES = [
+  // PR-L2 — Missing-Test Scanner (write a test file + register a contract)
+  'missing-test-scanner',
+  // PR-L3 — Failure Scanner (fix the failing assertion / restore the
+  // capability the contract guarantees)
+  'test-contract-failure-scanner',
+  // Legacy dev-autopilot baseline scan (twice-daily codebase smell detectors)
+  'dev_autopilot',
+  // PR-1234 lineage — diff-aware impact rules
+  'dev_autopilot_impact',
+] as const;
+
+export type ExecutableRecommendationSourceType =
+  (typeof EXECUTABLE_RECOMMENDATION_SOURCE_TYPES)[number];
+
+/**
+ * Guard: is this source_type eligible for the executor lane?
+ *
+ * Use in executeRecommendation()-style entry points. Returns false for
+ * unknown source_types so a typo in a future scanner or a misrouted
+ * row stays rejected.
+ */
+export function isExecutableSourceType(
+  source_type: string | null | undefined,
+): source_type is ExecutableRecommendationSourceType {
+  if (!source_type) return false;
+  return (EXECUTABLE_RECOMMENDATION_SOURCE_TYPES as readonly string[]).includes(source_type);
+}
+
+/**
+ * Render the allowlist as a PostgREST `in.(...)` value: `"a","b","c"`.
+ * URL-encodes each value defensively. Used by autoApproveTick to poll
+ * `autopilot_recommendations?source_type=in.(...)`.
+ */
+export function executableSourceTypesPostgrestIn(): string {
+  return EXECUTABLE_RECOMMENDATION_SOURCE_TYPES.map(
+    (t) => `"${encodeURIComponent(t)}"`,
+  ).join(',');
+}

--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -41,6 +41,12 @@ import { isWorkerQueueEnabled, isWorkerOwnsPrEnabled, runWorkerTask, reclaimStuc
 import { writeAutopilotFailure, writeAutopilotSuccess } from './dev-autopilot-self-heal-log';
 import { recordOutcome, recordExecOutcome } from './dev-autopilot-outcomes';
 import { loadAutopilotContext } from './dev-autopilot/context-loader';
+// VTID-02984 (PR-M1.x): shared allowlist for executable source_types so
+// test-contract scanner recommendations (PR-L2/L3) reach the executor.
+import {
+  isExecutableSourceType,
+  executableSourceTypesPostgrestIn,
+} from './autopilot-executable-source-types';
 
 const LOG_PREFIX = '[dev-autopilot-execute]';
 const EXEC_VTID = 'VTID-DEV-AUTOPILOT';
@@ -333,10 +339,12 @@ export async function approveAutoExecute(input: ApprovalInput): Promise<Approval
   if (!recR.ok || !recR.data) return { ok: false, error: recR.error || 'finding lookup failed' };
   const rec = recR.data[0];
   if (!rec) return { ok: false, error: 'finding not found' };
-  // Accept both baseline and impact-scan findings — both flow through the
-  // same plan→approve→execute path. Reject anything else (community, system).
-  if (rec.source_type !== 'dev_autopilot' && rec.source_type !== 'dev_autopilot_impact') {
-    return { ok: false, error: `not a dev_autopilot finding (source_type=${rec.source_type})` };
+  // Accept any source_type from the shared executor allowlist
+  // (autopilot-executable-source-types.ts). Reject anything else
+  // (community, system, or future scanner shapes that haven't been
+  // code-reviewed into the allowlist).
+  if (!isExecutableSourceType(rec.source_type)) {
+    return { ok: false, error: `not an executable source_type (source_type=${rec.source_type})` };
   }
   // VTID-02639 defense-in-depth: refuse to re-approve a finding that has
   // already shipped (status='completed') or been manually closed
@@ -636,8 +644,9 @@ export async function bridgeActivationToExecution(
   const s = getSupabase();
   if (!s) return { ok: false, error: 'Supabase not configured' };
 
-  // 1. Verify this is a dev_autopilot* finding (the activate route only
-  //    bridges those — community recs don't go through the executor).
+  // 1. Verify this source_type is in the executor allowlist (the
+  //    activate route only bridges allowlisted recs — community / system
+  //    rows don't go through the executor).
   const recR = await supa<Array<{ id: string; source_type: string; status: string }>>(
     s,
     `/rest/v1/autopilot_recommendations?id=eq.${findingId}&select=id,source_type,status&limit=1`,
@@ -646,7 +655,7 @@ export async function bridgeActivationToExecution(
     return { ok: false, error: 'finding lookup failed' };
   }
   const rec = recR.data[0];
-  if (rec.source_type !== 'dev_autopilot' && rec.source_type !== 'dev_autopilot_impact') {
+  if (!isExecutableSourceType(rec.source_type)) {
     return { ok: false, skipped: `source_type=${rec.source_type} not bridgeable` };
   }
 
@@ -2538,7 +2547,11 @@ export async function autoApproveTick(): Promise<void> {
     spec_snapshot: { scanner?: string } | null;
   }>>(
     s,
-    `/rest/v1/autopilot_recommendations?source_type=eq.dev_autopilot&status=eq.new`
+    // VTID-02984 (PR-M1.x): widen the source_type filter from
+    // `eq.dev_autopilot` to the shared executor allowlist so PR-L2 /
+    // PR-L3 / M1 test-contract scanners flow through. Unknown
+    // source_types stay rejected via the executor's per-row guards.
+    `/rest/v1/autopilot_recommendations?source_type=in.(${executableSourceTypesPostgrestIn()})&status=eq.new`
       + `&risk_class=in.(${riskList})`
       + `&effort_score=lte.${maxEffort}`
       + `&spec_snapshot->>scanner=in.(${scannerList})`

--- a/services/gateway/test/autopilot-executable-source-types.test.ts
+++ b/services/gateway/test/autopilot-executable-source-types.test.ts
@@ -1,0 +1,84 @@
+/**
+ * VTID-02984 (PR-M1.x): unit tests for the shared executor-source-type
+ * allowlist. The whole point of this module is to be a single answer
+ * to "is this source_type allowed to enter the executor lane?" — these
+ * tests pin that answer down before any caller relies on it.
+ */
+
+import {
+  EXECUTABLE_RECOMMENDATION_SOURCE_TYPES,
+  isExecutableSourceType,
+  executableSourceTypesPostgrestIn,
+} from '../src/services/autopilot-executable-source-types';
+
+describe('isExecutableSourceType — the executor gate', () => {
+  it('accepts dev_autopilot (legacy baseline scan source) — backward compat preserved', () => {
+    expect(isExecutableSourceType('dev_autopilot')).toBe(true);
+  });
+
+  it('accepts dev_autopilot_impact (impact-rule findings) — backward compat preserved', () => {
+    expect(isExecutableSourceType('dev_autopilot_impact')).toBe(true);
+  });
+
+  it('accepts test-contract-failure-scanner (PR-L3 recurring contract failures)', () => {
+    expect(isExecutableSourceType('test-contract-failure-scanner')).toBe(true);
+  });
+
+  it('accepts missing-test-scanner (PR-L2 capabilities without contracts)', () => {
+    expect(isExecutableSourceType('missing-test-scanner')).toBe(true);
+  });
+
+  it('REJECTS unrelated source types so misrouted rows stay out of the executor', () => {
+    expect(isExecutableSourceType('community-recommendation')).toBe(false);
+    expect(isExecutableSourceType('orb-voice-scanner')).toBe(false);
+    expect(isExecutableSourceType('voice-experience-scanner-v1')).toBe(false);
+    expect(isExecutableSourceType('system')).toBe(false);
+  });
+
+  it('REJECTS empty / null / undefined / whitespace inputs', () => {
+    expect(isExecutableSourceType('')).toBe(false);
+    expect(isExecutableSourceType(null)).toBe(false);
+    expect(isExecutableSourceType(undefined)).toBe(false);
+    expect(isExecutableSourceType(' dev_autopilot ')).toBe(false); // whitespace must not slip through
+  });
+
+  it('is case-sensitive — typos like DEV_AUTOPILOT must not be accepted', () => {
+    expect(isExecutableSourceType('DEV_AUTOPILOT')).toBe(false);
+    expect(isExecutableSourceType('Test-Contract-Failure-Scanner')).toBe(false);
+  });
+
+  it('exports the canonical list with exactly the four current entries (lock in scope)', () => {
+    const sorted = [...EXECUTABLE_RECOMMENDATION_SOURCE_TYPES].sort();
+    expect(sorted).toEqual([
+      'dev_autopilot',
+      'dev_autopilot_impact',
+      'missing-test-scanner',
+      'test-contract-failure-scanner',
+    ]);
+  });
+});
+
+describe('executableSourceTypesPostgrestIn — PostgREST in.() value renderer', () => {
+  it('produces a comma-separated list of double-quoted, URL-encoded values', () => {
+    const rendered = executableSourceTypesPostgrestIn();
+    // Every member of the allowlist must appear (encoded if needed)
+    for (const t of EXECUTABLE_RECOMMENDATION_SOURCE_TYPES) {
+      expect(rendered).toContain(`"${encodeURIComponent(t)}"`);
+    }
+    // Comma-separated structure: one fewer comma than there are entries
+    const commaCount = (rendered.match(/,/g) || []).length;
+    expect(commaCount).toBe(EXECUTABLE_RECOMMENDATION_SOURCE_TYPES.length - 1);
+  });
+
+  it('URL-encodes hyphenated source types (test-contract-failure-scanner) without breaking the in.() syntax', () => {
+    const rendered = executableSourceTypesPostgrestIn();
+    // Hyphen is safe in URLs so no actual encoding needed, but
+    // encodeURIComponent must still leave the value intact
+    expect(rendered).toContain('"test-contract-failure-scanner"');
+    expect(rendered).toContain('"missing-test-scanner"');
+  });
+
+  it('is deterministic (same call → same output) so PostgREST filter stays cacheable', () => {
+    expect(executableSourceTypesPostgrestIn()).toEqual(executableSourceTypesPostgrestIn());
+  });
+});


### PR DESCRIPTION
## Blocker discovered during the M1 worker-runner canary smoke

Despite PR-L2 (missing-test-scanner) and PR-L3 (test-contract-failure-scanner) producing well-formed `autopilot_recommendations` rows, the dispatcher in `dev-autopilot-execute.ts` hard-restricted `source_type` to `'dev_autopilot'` / `'dev_autopilot_impact'` in **three places**:

1. `autoApproveTick` polling filter (line 2541): `source_type=eq.dev_autopilot`
2. `executeRecommendation` guard at line 338-339 (auto-approve path)
3. `executeRecommendation` guard at line 649-650 (operator-activate path)

Test-contract recommendations sat at `status='new'` forever — never polled, never claimed. The recommendation for VTID-02977 (worker-runner canary repair) wrote correctly but never moved.

## Fix — narrow, per the user's spec

Shared allowlist module so the gate has **one answer** for every caller.

**`services/gateway/src/services/autopilot-executable-source-types.ts` (new):**
- `EXECUTABLE_RECOMMENDATION_SOURCE_TYPES`: `dev_autopilot`, `dev_autopilot_impact`, `test-contract-failure-scanner`, `missing-test-scanner`
- `isExecutableSourceType(source_type)`: boolean type guard
- `executableSourceTypesPostgrestIn()`: renders the allowlist as a PostgREST `in.()` value, URL-encoded + double-quoted

**`services/gateway/src/services/dev-autopilot-execute.ts`:**
- Both `executeRecommendation` guards swap the hard-coded check for `isExecutableSourceType()`. Error message updated.
- `autoApproveTick` polling filter swaps `source_type=eq.dev_autopilot` for `source_type=in.(${executableSourceTypesPostgrestIn()})`.

## Test plan

- [x] `test/autopilot-executable-source-types.test.ts` — 11 tests
  - 4 known-good source_types accepted (dev_autopilot, dev_autopilot_impact, test-contract-failure-scanner, missing-test-scanner)
  - 4 unknown source_types rejected (community / orb / voice / system)
  - Empty / null / undefined / whitespace rejected
  - Case-sensitive (DEV_AUTOPILOT rejected)
  - Allowlist locked to exactly the 4 entries
  - PostgREST renderer: structure, encoding, determinism
- [x] 94 tests across affected suites (allowlist + dev-autopilot-execute + test-contract scanners) — all green
- [x] `npm run build` clean
- [ ] **After merge + EXEC-DEPLOY**: VTID-02977's existing recommendation row gets picked up on the next `autoApproveTick` (≤60s) without any data mutation; M1 green-path watch resumes.

## What this is NOT

- Not a concurrent change to PR-M1.2 (`hasInFlightRepairAttempt` cross-check). Those are orthogonal — PR-M1.2 ships AFTER the green-path proof completes (success or clear failure).
- Not a data patch. VTID-02977's row stays honest. The fix moves the gate, not the row.
- Not a backward-incompatible change. `dev_autopilot` + `dev_autopilot_impact` behavior unchanged; the allowlist is a strict superset.

🤖 Generated with [Claude Code](https://claude.com/claude-code)