### PR TITLE
feat(voice-lab): wire LiveKit sessions into unified Voice Lab pipeline (VTID-02986)

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/oasis.py
+++ b/services/agents/orb-agent/src/orb_agent/oasis.py
@@ -4,6 +4,14 @@ Topic naming follows the parity contract in voice-pipeline-spec/spec.json.
 The libcst extractor walks every `oasis.emit(topic=...)` call site and feeds
 it to the parity scanner — so use string literals, not f-strings or
 variables, for the topic argument when you want it visible to the scanner.
+
+VTID-02986 (LiveKit Voice Lab parity): session-lifecycle topics renamed
+from `livekit.*` → `vtid.live.*` so Voice Lab's `/live/sessions` route
+(which filters on `topic IN ('voice.live.session.started', 'vtid.live.session.start', ...)`
+plus `vtid IN ('VTID-01218A', 'VTID-01155', 'VTID-LIVEKIT-AGENT', ...)`)
+surfaces LiveKit sessions next to Vertex ones in the same panel. The
+emitter also now logs a WARNING on missing GATEWAY_SERVICE_TOKEN
+instead of silently returning — telemetry must fail LOUD, not silent.
 """
 from __future__ import annotations
 
@@ -13,6 +21,11 @@ from typing import Any
 import httpx
 
 logger = logging.getLogger(__name__)
+
+# VTID-02986: default VTID stamped on every emit so Voice Lab's vtid IN
+# filter (voice-lab.ts:166) returns the row. Keep this stable — adding it
+# to a new allowlist entry is a one-line change there.
+DEFAULT_VTID = "VTID-LIVEKIT-AGENT"
 
 
 class OasisEmitter:
@@ -25,6 +38,18 @@ class OasisEmitter:
             self._headers["Authorization"] = f"Bearer {service_token}"
         self._token_present = bool(service_token)
         self._client = httpx.AsyncClient(timeout=timeout_s)
+        # VTID-02986: log the missing-token state ONCE at construction so
+        # the operator sees it in Cloud Run logs immediately, not buried in
+        # per-emit warnings. Still fail loud on each emit too — silent
+        # telemetry is how the LiveKit stall_detected signal disappeared.
+        self._missing_token_warned = False
+        if not self._token_present:
+            logger.warning(
+                "OasisEmitter: GATEWAY_SERVICE_TOKEN not set — every emit will be "
+                "skipped and logged as 'token_missing'. Set the env var on the "
+                "orb-agent Cloud Run service to restore session telemetry "
+                "(vtid.live.session.start/stop, vtid.live.stall_detected, etc.).",
+            )
 
     async def emit(
         self,
@@ -34,32 +59,56 @@ class OasisEmitter:
         vtid: str | None = None,
     ) -> None:
         """Fire-and-log emit. Errors are logged, never raised — telemetry must
-        never break the voice path."""
-        body = {"topic": topic, "payload": payload or {}, "vtid": vtid}
+        never break the voice path.
+
+        VTID-02986: when GATEWAY_SERVICE_TOKEN is unset, log a WARNING per
+        emit (not a silent return). The previous silent path is why the
+        LiveKit pipeline appeared functional while session.start/stop and
+        stall_detected events never landed in oasis_events — Voice Lab had
+        no signal to display, and operators had no way to know.
+        """
+        effective_vtid = vtid or DEFAULT_VTID
+        body = {"topic": topic, "payload": payload or {}, "vtid": effective_vtid}
         if not self._token_present:
-            # No service token configured — skip the network call entirely
-            # rather than spamming logs every time. Telemetry comes back
-            # online when GATEWAY_SERVICE_TOKEN is set.
+            logger.warning(
+                "oasis emit skipped (token_missing): topic=%s vtid=%s",
+                topic,
+                effective_vtid,
+            )
             return
         try:
             r = await self._client.post(self._endpoint, json=body, headers=self._headers)
             if r.status_code >= 400:
-                logger.warning("oasis emit failed: topic=%s status=%s", topic, r.status_code)
+                logger.warning(
+                    "oasis emit failed: topic=%s vtid=%s status=%s body=%s",
+                    topic,
+                    effective_vtid,
+                    r.status_code,
+                    (r.text or "")[:200],
+                )
         except Exception as exc:
-            logger.warning("oasis emit exception: topic=%s err=%s", topic, exc)
+            logger.warning(
+                "oasis emit exception: topic=%s vtid=%s err=%s", topic, effective_vtid, exc,
+            )
 
     async def aclose(self) -> None:
         await self._client.aclose()
 
 
 # Common topic constants — keep these as module-level string literals so the
-# libcst extractor can walk them. Topics not in this list are also valid;
-# this list is just for readability / IDE autocomplete.
-TOPIC_SESSION_START = "livekit.session.start"
-TOPIC_SESSION_STOP = "livekit.session.stop"
+# libcst extractor can walk them.
+#
+# VTID-02986: session-lifecycle topics moved to `vtid.live.*` namespace
+# (matching Vertex's orb-live.ts emitter at orb-live.ts:11838 / 12207)
+# so Voice Lab's /api/v1/voice-lab/live/sessions endpoint surfaces both
+# providers in the same panel. Non-lifecycle topics stay on `livekit.*`
+# because they're LiveKit-specific (stall, tool execution, provider
+# events) and don't have a Vertex counterpart in the Voice Lab query.
+TOPIC_SESSION_START = "vtid.live.session.start"
+TOPIC_SESSION_STOP = "vtid.live.session.stop"
+TOPIC_STALL_DETECTED = "vtid.live.stall_detected"
 TOPIC_TOOL_EXECUTED = "livekit.tool.executed"
 TOPIC_TOOL_LOOP_GUARD = "livekit.tool_loop_guard_activated"
-TOPIC_STALL_DETECTED = "livekit.stall_detected"
 TOPIC_CONNECTION_FAILED = "livekit.connection_failed"
 TOPIC_CONFIG_MISSING = "livekit.config_missing"
 TOPIC_PROVIDER_QUOTA_EXCEEDED = "livekit.provider_quota_exceeded"

--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -26,6 +26,7 @@ import asyncio
 import json
 import logging
 import os
+import time
 from typing import Any
 
 from .bootstrap import ContextBootstrap
@@ -327,18 +328,36 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     )
 
     # OASIS session start.
+    # VTID-02986: payload shape mirrors Vertex's orb-live.ts:11838 emit so
+    # Voice Lab's /api/v1/voice-lab/live/sessions can build a unified
+    # LiveSessionSummary from a single query. Key fields the route reads:
+    # session_id, transport, lang, user_id, tenant_id, email, user_agent,
+    # origin, is_mobile, voice. `transport: 'livekit'` is the new value the
+    # UI badges to distinguish LiveKit vs Vertex (websocket/sse) sessions.
+    session_started_at_ms = int(time.time() * 1000)
+    voice_cfg = bootstrap.voice_config or {}
     await oasis.emit(
         topic=TOPIC_SESSION_START,
         payload={
+            "session_id": orb_session_id,
+            "transport": "livekit",
             "user_id": identity.user_id,
             "tenant_id": identity.tenant_id,
             "agent_id": agent_id,
             "lang": identity.lang,
             "is_mobile": identity.is_mobile,
+            "is_anonymous": identity.is_anonymous,
+            "vitana_id": bootstrap.vitana_id or identity.vitana_id,
+            "email": getattr(identity, "email", None),
             "orb_session_id": orb_session_id,
-            "stt": (bootstrap.voice_config or {}).get("stt_provider"),
-            "llm": (bootstrap.voice_config or {}).get("llm_provider"),
-            "tts": (bootstrap.voice_config or {}).get("tts_provider"),
+            "stt_provider": voice_cfg.get("stt_provider"),
+            "stt_model": voice_cfg.get("stt_model"),
+            "llm_provider": voice_cfg.get("llm_provider"),
+            "llm_model": voice_cfg.get("llm_model"),
+            "tts_provider": voice_cfg.get("tts_provider"),
+            "tts_model": voice_cfg.get("tts_model"),
+            "voice": voice_cfg.get("tts_model"),  # Vertex parity: `voice` = TTS model name
+            "active_role": bootstrap.active_role,
         },
     )
 
@@ -457,11 +476,23 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     # cleanup to ctx.add_shutdown_callback so it fires when the room ends.
     disconnected_evt = asyncio.Event()
 
+    # VTID-02986: per-session counters feed the gateway's session-stop
+    # metrics so classifyQualityFromSessionStop (voice-failure-taxonomy.ts)
+    # can return a failure_class for LiveKit sessions identical to Vertex.
+    # Counters are read at _teardown time below. Defined here (not inside
+    # the hook closures) so both the user_input_transcribed handler AND
+    # the speech_created handler can mutate them. `stall_count` is hoisted
+    # too so _teardown can include it in the stop payload — the watchdog
+    # binds the same dict instance later via stall_count["n"] += 1.
+    user_turns_counter = {"n": 0}
+    model_turns_counter = {"n": 0}
+    stall_count = {"n": 0}
+
     async def _teardown() -> None:
         # L2.2b.1: emit the lifecycle `disconnected` event FIRST (it pairs
         # with the room_join_succeeded event from session start). The
-        # legacy `livekit.session.stop` event follows for back-compat with
-        # consumers that already filter on it.
+        # vtid.live.session.stop event follows with the full quality-metrics
+        # payload that the Voice Lab classifier needs.
         try:
             await oasis.emit(
                 topic=TOPIC_AGENT_DISCONNECTED,
@@ -476,13 +507,40 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
             )
         except Exception as exc:  # noqa: BLE001
             logger.warning("agent.disconnected oasis emit failed: %s", exc)
+        # VTID-02986: full session-stop payload — same shape Vertex emits
+        # at orb-live.ts:12207 so the Voice Lab quality classifier picks
+        # the right failure_class. audio_in_chunks / audio_out_chunks are
+        # approximations from turn counts (livekit-agents doesn't expose
+        # raw frame counts on AgentSession). The classifier thresholds
+        # (ai>=20 for no_engagement, ai>=100 for model_under_responds,
+        # ai>=50 for low_turn_progression) still trigger correctly with
+        # turn-derived approximations.
+        duration_ms = max(0, int(time.time() * 1000) - session_started_at_ms)
+        user_turns = user_turns_counter["n"]
+        model_turns = model_turns_counter["n"]
+        turn_count = user_turns + model_turns
+        # ~50 chunks per turn = ~1s of 20ms-frame audio. Conservative; real
+        # utterances are longer but the classifier only checks lower bounds.
+        approx_in_chunks = user_turns * 50
+        approx_out_chunks = model_turns * 50
         try:
             await oasis.emit(
                 topic=TOPIC_SESSION_STOP,
                 payload={
+                    "session_id": orb_session_id,
+                    "transport": "livekit",
                     "user_id": identity.user_id,
+                    "tenant_id": identity.tenant_id,
                     "agent_id": agent_id,
                     "orb_session_id": orb_session_id,
+                    "duration_ms": duration_ms,
+                    "turn_count": turn_count,
+                    "user_turns": user_turns,
+                    "model_turns": model_turns,
+                    "audio_in_chunks": approx_in_chunks,
+                    "audio_out_chunks": approx_out_chunks,
+                    "video_frames": 0,
+                    "stall_count": stall_count["n"],
                 },
             )
         except Exception as exc:  # noqa: BLE001
@@ -576,7 +634,7 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     # 1-2 min recovery the user observed before my watchdog) handle it.
     # Future option: add a soft pipeline-reset path that resets STT/LLM
     # without dropping the room. For now: telemetry-only.
-    stall_count = {"n": 0}
+    # stall_count was hoisted above _teardown so the stop-payload sees it.
     stall = StallWatchdog(threshold_ms=STALL_THRESHOLD_MS)
 
     async def _on_stall() -> None:
@@ -607,6 +665,10 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     try:
         @session.on("speech_created")  # type: ignore[misc]
         def _on_speech(ev: Any) -> None:  # noqa: ARG001
+            # VTID-02986: increment model_turns counter for the session.stop
+            # quality classifier in addition to feeding the watchdog +
+            # firehose trace.
+            model_turns_counter["n"] += 1
             stall.feed()
             asyncio.create_task(
                 _early_trace_heartbeat(
@@ -627,7 +689,20 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     # watchdog, and a long silent agent (waiting for user input) doesn't
     # either. We don't know which exact event names AgentSession emits in
     # this version of livekit-agents, so subscribe defensively.
-    for ev_name in ("user_state_changed", "agent_state_changed", "user_input_transcribed"):
+    #
+    # VTID-02986: user_input_transcribed also increments user_turns counter
+    # so the quality classifier sees both sides of the conversation. Other
+    # hooks stay watchdog-only.
+    def _on_user_transcribed(_ev: Any = None) -> None:
+        user_turns_counter["n"] += 1
+        stall.feed()
+
+    try:
+        session.on("user_input_transcribed")(_on_user_transcribed)  # type: ignore[misc]
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("could not hook user_input_transcribed: %s", exc)
+
+    for ev_name in ("user_state_changed", "agent_state_changed"):
         try:
             session.on(ev_name)(lambda _ev=None: stall.feed())  # type: ignore[misc]
         except Exception as exc:  # noqa: BLE001

--- a/services/agents/orb-agent/tests/test_smoke.py
+++ b/services/agents/orb-agent/tests/test_smoke.py
@@ -10,21 +10,52 @@ def test_config_imports() -> None:
 
 def test_oasis_imports() -> None:
     from src.orb_agent.oasis import (
+        DEFAULT_VTID,
         TOPIC_HANDOFF_COMPLETE,
         TOPIC_HANDOFF_START,
         TOPIC_PERSONA_SWAP,
         TOPIC_SESSION_START,
         TOPIC_SESSION_STOP,
+        TOPIC_STALL_DETECTED,
         OasisEmitter,
     )
 
     assert OasisEmitter is not None
-    # Topic strings must be the canonical literals from the parity spec.
-    assert TOPIC_SESSION_START == "livekit.session.start"
-    assert TOPIC_SESSION_STOP == "livekit.session.stop"
+    # VTID-02986: session-lifecycle topics aligned to Vertex's vtid.live.*
+    # namespace so Voice Lab's /api/v1/voice-lab/live/sessions endpoint
+    # surfaces LiveKit sessions in the same panel as Vertex sessions.
+    assert TOPIC_SESSION_START == "vtid.live.session.start"
+    assert TOPIC_SESSION_STOP == "vtid.live.session.stop"
+    assert TOPIC_STALL_DETECTED == "vtid.live.stall_detected"
     assert TOPIC_HANDOFF_START == "voice.handoff.start"
     assert TOPIC_HANDOFF_COMPLETE == "voice.handoff.complete"
     assert TOPIC_PERSONA_SWAP == "agent.voice.persona_swap"
+    # VTID-02986: default VTID stamped on every emit so Voice Lab's vtid
+    # IN-filter (voice-lab.ts:197) returns the row.
+    assert DEFAULT_VTID == "VTID-LIVEKIT-AGENT"
+
+
+def test_oasis_emitter_loud_on_missing_token(caplog) -> None:  # type: ignore[no-untyped-def]
+    """VTID-02986: emitter must log WARN (not silent-return) when token is
+    unset, so the missing-telemetry failure mode is visible in Cloud Run
+    logs. The silent path is how livekit.stall_detected events disappeared
+    during the 2026-05-14 disconnect investigation."""
+    import asyncio
+    import logging
+
+    from src.orb_agent.oasis import OasisEmitter
+
+    with caplog.at_level(logging.WARNING, logger="src.orb_agent.oasis"):
+        emitter = OasisEmitter(gateway_url="https://example.test", service_token="")
+        # Constructor-time WARN — operator sees this immediately at boot.
+        assert any("GATEWAY_SERVICE_TOKEN not set" in r.message for r in caplog.records)
+        caplog.clear()
+
+        asyncio.run(emitter.emit(topic="vtid.live.session.start", payload={"x": 1}))
+        # Per-emit WARN with the skipped topic name + reason.
+        records = [r.message for r in caplog.records]
+        assert any("oasis emit skipped (token_missing)" in m for m in records), records
+        assert any("vtid.live.session.start" in m for m in records), records
 
 
 def test_l22b1_lifecycle_topics() -> None:

--- a/services/gateway/src/routes/voice-lab.ts
+++ b/services/gateway/src/routes/voice-lab.ts
@@ -72,7 +72,10 @@ interface LiveSessionSummary {
   audio_in_chunks: number;
   audio_out_chunks: number;
   lang?: string;
-  transport: 'websocket' | 'sse';
+  // VTID-02986: 'livekit' added so orb-agent sessions can ship through the
+  // same shape. Vertex still emits 'websocket' or 'sse'; the UI badges by
+  // value so 'livekit' is distinguishable from those.
+  transport: 'websocket' | 'sse' | 'livekit';
   error_count: number;
   interrupted_count: number;
   user_id?: string;
@@ -194,7 +197,10 @@ async function queryVoiceLabEvents(
     // VTID filter: VTID-01218A (legacy voice-lab) + VTID-01155 (orb-live emitter)
     // + VTID-VOICE-HEALING (autonomous self-healing loop events: dispatched,
     // verdict, rollback, suppressed, spec_memory.blocked, investigation.completed)
-    params.push(`vtid=in.("VTID-01218A","VTID-01155","VTID-VOICE-HEALING")`);
+    // + VTID-LIVEKIT-AGENT (VTID-02986: orb-agent emits vtid.live.session.start/stop
+    //   with this VTID; required for LiveKit sessions to appear next to Vertex
+    //   in the unified Voice Lab list).
+    params.push(`vtid=in.("VTID-01218A","VTID-01155","VTID-VOICE-HEALING","VTID-LIVEKIT-AGENT")`);
 
     // Ordering and pagination
     params.push('order=created_at.desc');


### PR DESCRIPTION
## Summary
LiveKit (orb-agent) sessions never appeared in Voice Lab because of three independent breaks:
1. **Wrong topic namespace** — agent emitted `livekit.session.start/stop`; Voice Lab queried `vtid.live.session.*`.
2. **Silent emitter** on missing auth token — `GATEWAY_SERVICE_TOKEN` unset on orb-agent Cloud Run made every emit a no-op without a log line, hiding the failure.
3. **No session-stop metrics** — without `audio_in_chunks` / `audio_out_chunks` / `turn_count` / `duration_ms`, the quality classifier (`classifyQualityFromSessionStop`) returned null for every LiveKit session.

This PR fixes all three.

### orb-agent (oasis.py)
- Renamed session-lifecycle topic constants → `vtid.live.session.start/stop` + `vtid.live.stall_detected`.
- Stamps `DEFAULT_VTID="VTID-LIVEKIT-AGENT"` on every emit so Voice Lab's vtid IN-filter returns the rows.
- Fails LOUD when `GATEWAY_SERVICE_TOKEN` is unset: WARN at construction AND WARN per emit with topic + skip reason.

### orb-agent (session.py)
- Tracks `user_turns` (`user_input_transcribed`), `model_turns` (`speech_created`), `duration_ms`, `stall_count`.
- session.start payload mirrors Vertex (orb-live.ts:11838): session_id, transport='livekit', user_id, tenant_id, lang, email, vitana_id, is_mobile, is_anonymous, stt/llm/tts provider+model.
- session.stop payload includes `audio_in_chunks` / `audio_out_chunks` approximated from turn counts (~50 chunks/turn ≈ 1s of 20ms-frame audio) so the quality classifier triggers correctly (it checks lower bounds only).

### gateway (voice-lab.ts)
- Adds `VTID-LIVEKIT-AGENT` to the vtid IN-filter allowlist.
- Widens `LiveSessionSummary.transport` type to include `'livekit'` so the UI badge can distinguish from `websocket`/`sse`.

### tests
- `test_oasis_imports` updated for renamed topic literals + DEFAULT_VTID.
- New `test_oasis_emitter_loud_on_missing_token` asserts the construction + per-emit WARN logs fire when token is unset.

## Action required (out-of-band)
**Set `GATEWAY_SERVICE_TOKEN` on the orb-agent Cloud Run revision.** Without it, the per-emit WARN will fire on every session start/stop/stall but no events will land in `oasis_events`. The new loud-failure path makes this state visible in Cloud Run logs immediately at boot and on every emit.

## Test plan
- [ ] Set `GATEWAY_SERVICE_TOKEN` on orb-agent Cloud Run.
- [ ] Start a LiveKit conversation via the Test Bench.
- [ ] In Supabase: `SELECT topic, metadata FROM oasis_events WHERE topic LIKE 'vtid.live.session.%' ORDER BY created_at DESC LIMIT 5` — confirm session.start / session.stop rows present with the new payload shape.
- [ ] In Voice LAB → Orb Live tab: confirm the LiveKit session appears in the list (transport badge = 'livekit', user fields populated, failure_class column shows result of the classifier).
- [ ] Click "Details" — drawer opens with turns + diagnostics.
- [ ] Force a 30-second silence during a session — confirm `vtid.live.stall_detected` row lands in oasis_events.

🤖 Generated with [Claude Code](https://claude.com/claude-code)