### PR TITLE
feat(orb): L2.2b.1 — gateway /oasis/emit + orb-agent lifecycle telemetry (VTID-02987)

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/oasis.py
+++ b/services/agents/orb-agent/src/orb_agent/oasis.py
@@ -70,3 +70,14 @@ TOPIC_HANDOFF_START = "voice.handoff.start"
 TOPIC_HANDOFF_COMPLETE = "voice.handoff.complete"
 TOPIC_HANDOFF_FAILED = "voice.handoff.failed"
 TOPIC_PERSONA_SWAP = "agent.voice.persona_swap"
+
+# L2.2b.1 (VTID-02987): backend orb-agent lifecycle observability. Emitted at
+# the earliest possible points in `agent_entrypoint` so any failure joining
+# the LiveKit room is visible in OASIS without needing logs. These 5 topics
+# are also added to the gateway's CicdEventType union; the gateway's
+# POST /api/v1/oasis/emit route allowlists the `orb.livekit.` prefix.
+TOPIC_AGENT_STARTING = "orb.livekit.agent.starting"
+TOPIC_AGENT_ROOM_JOIN_STARTED = "orb.livekit.agent.room_join_started"
+TOPIC_AGENT_ROOM_JOIN_SUCCEEDED = "orb.livekit.agent.room_join_succeeded"
+TOPIC_AGENT_ROOM_JOIN_FAILED = "orb.livekit.agent.room_join_failed"
+TOPIC_AGENT_DISCONNECTED = "orb.livekit.agent.disconnected"

--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -37,6 +37,11 @@ from .instructions import (
     build_live_system_instruction,
 )
 from .oasis import (
+    TOPIC_AGENT_DISCONNECTED,
+    TOPIC_AGENT_ROOM_JOIN_FAILED,
+    TOPIC_AGENT_ROOM_JOIN_STARTED,
+    TOPIC_AGENT_ROOM_JOIN_SUCCEEDED,
+    TOPIC_AGENT_STARTING,
     TOPIC_HANDOFF_COMPLETE,
     TOPIC_HANDOFF_START,
     TOPIC_PERSONA_SWAP,
@@ -124,10 +129,58 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
         gateway_url=cfg.gateway_url, service_token=cfg.gateway_service_token
     )
 
+    # L2.2b.1 (VTID-02987): emit agent-lifecycle telemetry at the earliest
+    # possible points so any failure joining the LiveKit room is visible
+    # in OASIS without scraping logs. The 5 events are: starting →
+    # room_join_started → (room_join_succeeded | room_join_failed) →
+    # disconnected (from the shutdown_callback below). Every emit is
+    # fire-and-forget; OasisEmitter swallows network errors so telemetry
+    # never blocks the voice path.
+    _room_name = None
+    try:
+        _room_name = getattr(getattr(ctx, "room", None), "name", None)
+    except Exception:  # noqa: BLE001
+        pass
+    _agent_lifecycle_base = {
+        "room_name": _room_name,
+        "code_version": CODE_VERSION,
+        "vtid": "VTID-02987",
+    }
+    await oasis.emit(
+        topic=TOPIC_AGENT_STARTING,
+        payload=dict(_agent_lifecycle_base, phase="starting"),
+        vtid="VTID-02987",
+    )
+    await oasis.emit(
+        topic=TOPIC_AGENT_ROOM_JOIN_STARTED,
+        payload=dict(_agent_lifecycle_base, phase="room_join_started"),
+        vtid="VTID-02987",
+    )
+
     # Connect to the room first — required to read remote participant
     # metadata. The orb-agent itself does not publish; the user is the
     # publisher.
-    await ctx.connect()
+    try:
+        await ctx.connect()
+    except Exception as _join_exc:  # noqa: BLE001
+        await oasis.emit(
+            topic=TOPIC_AGENT_ROOM_JOIN_FAILED,
+            payload=dict(
+                _agent_lifecycle_base,
+                phase="room_join_failed",
+                error=str(_join_exc),
+                error_type=type(_join_exc).__name__,
+            ),
+            vtid="VTID-02987",
+        )
+        # Re-raise so the worker dispatcher knows the job failed; no audio
+        # path is wired yet so there's nothing to clean up here.
+        raise
+    await oasis.emit(
+        topic=TOPIC_AGENT_ROOM_JOIN_SUCCEEDED,
+        payload=dict(_agent_lifecycle_base, phase="room_join_succeeded"),
+        vtid="VTID-02987",
+    )
 
     # ── Identity metadata lives on the USER PARTICIPANT, not the room. ──
     # The gateway's /api/v1/orb/livekit/token mints a LiveKit AccessToken
@@ -405,6 +458,24 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     disconnected_evt = asyncio.Event()
 
     async def _teardown() -> None:
+        # L2.2b.1: emit the lifecycle `disconnected` event FIRST (it pairs
+        # with the room_join_succeeded event from session start). The
+        # legacy `livekit.session.stop` event follows for back-compat with
+        # consumers that already filter on it.
+        try:
+            await oasis.emit(
+                topic=TOPIC_AGENT_DISCONNECTED,
+                payload=dict(
+                    _agent_lifecycle_base,
+                    phase="disconnected",
+                    user_id=identity.user_id,
+                    agent_id=agent_id,
+                    orb_session_id=orb_session_id,
+                ),
+                vtid="VTID-02987",
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("agent.disconnected oasis emit failed: %s", exc)
         try:
             await oasis.emit(
                 topic=TOPIC_SESSION_STOP,

--- a/services/agents/orb-agent/tests/test_smoke.py
+++ b/services/agents/orb-agent/tests/test_smoke.py
@@ -27,6 +27,55 @@ def test_oasis_imports() -> None:
     assert TOPIC_PERSONA_SWAP == "agent.voice.persona_swap"
 
 
+def test_l22b1_lifecycle_topics() -> None:
+    """L2.2b.1 (VTID-02987): the 5 new lifecycle topics MUST exist as
+    module-level string literals, MUST use the `orb.livekit.agent.*` prefix,
+    and MUST match the gateway-side CicdEventType union exactly."""
+    from src.orb_agent.oasis import (
+        TOPIC_AGENT_DISCONNECTED,
+        TOPIC_AGENT_ROOM_JOIN_FAILED,
+        TOPIC_AGENT_ROOM_JOIN_STARTED,
+        TOPIC_AGENT_ROOM_JOIN_SUCCEEDED,
+        TOPIC_AGENT_STARTING,
+    )
+
+    assert TOPIC_AGENT_STARTING == "orb.livekit.agent.starting"
+    assert TOPIC_AGENT_ROOM_JOIN_STARTED == "orb.livekit.agent.room_join_started"
+    assert TOPIC_AGENT_ROOM_JOIN_SUCCEEDED == "orb.livekit.agent.room_join_succeeded"
+    assert TOPIC_AGENT_ROOM_JOIN_FAILED == "orb.livekit.agent.room_join_failed"
+    assert TOPIC_AGENT_DISCONNECTED == "orb.livekit.agent.disconnected"
+
+    # All 5 share the orb.livekit.agent.* prefix (gateway allowlist).
+    for topic in [
+        TOPIC_AGENT_STARTING,
+        TOPIC_AGENT_ROOM_JOIN_STARTED,
+        TOPIC_AGENT_ROOM_JOIN_SUCCEEDED,
+        TOPIC_AGENT_ROOM_JOIN_FAILED,
+        TOPIC_AGENT_DISCONNECTED,
+    ]:
+        assert topic.startswith("orb.livekit.agent."), topic
+
+
+def test_l22b1_session_wires_lifecycle_topics() -> None:
+    """session.py must reference all 5 lifecycle topics (the room-join
+    proof loop) so they fire from the entrypoint. Structural / grep-style
+    assertion — no livekit-agents SDK is invoked."""
+    import pathlib
+
+    session_src = (
+        pathlib.Path(__file__).resolve().parent.parent
+        / "src" / "orb_agent" / "session.py"
+    ).read_text(encoding="utf-8")
+    for topic_const in [
+        "TOPIC_AGENT_STARTING",
+        "TOPIC_AGENT_ROOM_JOIN_STARTED",
+        "TOPIC_AGENT_ROOM_JOIN_SUCCEEDED",
+        "TOPIC_AGENT_ROOM_JOIN_FAILED",
+        "TOPIC_AGENT_DISCONNECTED",
+    ]:
+        assert topic_const in session_src, f"session.py is missing {topic_const}"
+
+
 def test_instructions_signatures() -> None:
     """The signatures of build_live / build_anonymous match the parity spec."""
     import inspect

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -88,6 +88,10 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const orbLiveRouter = require('./routes/orb-live').default;
   // VTID-LIVEKIT-FOUNDATION: ORB LiveKit pipeline (parallel/standby to Vertex orb-live).
   const orbLivekitRouter = require('./routes/orb-livekit').default;
+  // L2.2b.1 (VTID-02987): /api/v1/oasis/emit — service-token + admin-JWT
+  // gated proxy so the Python orb-agent can emit lifecycle telemetry via the
+  // same OASIS pipeline the gateway uses.
+  const oasisEmitRouter = require('./routes/oasis-emit').default;
   const vitanaIndexRouter = require('./routes/vitana-index').default;
   const orbToolRouter = require('./routes/orb-tool').default;
   const orbAgentTraceRouter = require('./routes/orb-agent-trace').default;
@@ -679,6 +683,7 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   // Mounted at /api/v1 because its routes span /orb/*, /voice-providers/*,
   // /agents/*/voice-config — the leaf paths inside the router carry the prefix.
   mountRouterSync(app, '/api/v1', orbLivekitRouter, { owner: 'orb-livekit' });
+  mountRouterSync(app, '/api/v1', oasisEmitRouter, { owner: 'oasis-emit' });
 
   // VTID-LIVEKIT-TOOLS: Vitana Index endpoints used by the LiveKit tool catalogue
   // (get_vitana_index, get_index_improvement_suggestions). Lifted from the

--- a/services/gateway/src/routes/oasis-emit.ts
+++ b/services/gateway/src/routes/oasis-emit.ts
@@ -1,0 +1,199 @@
+/**
+ * L2.2b.1 (VTID-02987): minimal OASIS-emit proxy for the LiveKit orb-agent
+ * service (and other future service-token holders).
+ *
+ * The Python `services/agents/orb-agent` worker POSTs lifecycle telemetry to
+ * `/api/v1/oasis/emit` so the agent's room-join + tool-dispatch state is
+ * visible in OASIS without giving the agent a direct Supabase write surface.
+ * The agent uses `Authorization: Bearer ${GATEWAY_SERVICE_TOKEN}`; admins
+ * can also call this route from CLI/Cmd-Hub using their normal JWT (must be
+ * `exafy_admin`).
+ *
+ * Hard rules:
+ *   - NO unauthenticated access. The route is service+admin only.
+ *   - Topic prefix allowlist: ONLY `orb.livekit.` and `livekit.` topics are
+ *     accepted. Arbitrary topics would let the agent forge events from other
+ *     surfaces (gateway, autopilot, etc.) — refuse them.
+ *   - Body size cap (16 KiB) — telemetry payloads are tiny by design.
+ *   - The route delegates to `emitOasisEvent` (the same function the gateway
+ *     uses internally), so OASIS persistence stays unified.
+ *   - Failures here NEVER affect the voice/data path — they return 4xx and
+ *     the agent's `OasisEmitter` logs + drops them.
+ *
+ * L2.2b.2+ may extend the allowlist as additional `livekit.*` topics are
+ * emitted. The list intentionally starts narrow.
+ */
+
+import { Router, Request, Response, NextFunction } from 'express';
+import { z } from 'zod';
+import { emitOasisEvent } from '../services/oasis-event-service';
+import {
+  optionalAuth,
+  AuthenticatedRequest,
+} from '../middleware/auth-supabase-jwt';
+import type { CicdEventType } from '../types/cicd';
+
+const router = Router();
+
+const VTID = 'VTID-02987';
+
+// Cap body at 16 KiB. Telemetry payloads are small by design.
+const MAX_BODY_BYTES = 16 * 1024;
+
+// Allowed topic prefixes — refuse everything else.
+const ALLOWED_PREFIXES = ['orb.livekit.', 'livekit.'] as const;
+
+function isAllowedTopic(topic: unknown): topic is string {
+  if (typeof topic !== 'string') return false;
+  if (topic.length === 0 || topic.length > 256) return false;
+  return ALLOWED_PREFIXES.some((p) => topic.startsWith(p));
+}
+
+const BodySchema = z.object({
+  topic: z.string().min(1).max(256),
+  payload: z.record(z.unknown()).optional(),
+  vtid: z.string().max(64).optional(),
+});
+
+type ParsedBody = z.infer<typeof BodySchema>;
+
+/**
+ * Auth middleware: accept EITHER
+ *   - `Authorization: Bearer <GATEWAY_SERVICE_TOKEN>` (the orb-agent path), OR
+ *   - `Authorization: Bearer <JWT>` where the validated JWT has
+ *     `exafy_admin === true` (operator CLI / Command Hub path).
+ *
+ * Service-token path is checked FIRST so an unauthenticated request never
+ * triggers JWT validation overhead, and so a malformed JWT can't accidentally
+ * match the service-token comparison.
+ */
+function emitAuthGate(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  const header = req.header('authorization') ?? req.header('Authorization');
+  if (!header || !header.toLowerCase().startsWith('bearer ')) {
+    res.status(401).json({ ok: false, error: 'missing bearer token', vtid: VTID });
+    return;
+  }
+  const token = header.slice('bearer '.length).trim();
+  if (!token) {
+    res.status(401).json({ ok: false, error: 'empty bearer token', vtid: VTID });
+    return;
+  }
+
+  // Path 1: service-token match.
+  const serviceToken = process.env.GATEWAY_SERVICE_TOKEN ?? '';
+  if (serviceToken.length > 0 && token === serviceToken) {
+    (req as AuthenticatedRequest).identity = undefined;
+    (req as Request & { __emit_actor?: string }).__emit_actor = 'service:orb-agent';
+    next();
+    return;
+  }
+
+  // Path 2: JWT — must be exafy_admin. Defer to optionalAuth to populate
+  // req.identity, then assert exafy_admin.
+  optionalAuth(req as AuthenticatedRequest, res, () => {
+    const id = (req as AuthenticatedRequest).identity;
+    if (id && id.exafy_admin === true) {
+      (req as Request & { __emit_actor?: string }).__emit_actor =
+        `admin:${id.user_id ?? 'unknown'}`;
+      next();
+      return;
+    }
+    res.status(401).json({
+      ok: false,
+      error: 'unauthorized — service token or exafy_admin JWT required',
+      vtid: VTID,
+    });
+  });
+}
+
+/**
+ * Body-size guard. Express's default JSON parser already enforces a global
+ * limit, but we want a tighter telemetry-specific cap so the agent can't
+ * accidentally pump large payloads through this surface.
+ */
+function bodySizeGuard(req: Request, res: Response, next: NextFunction): void {
+  const lenHeader = req.header('content-length');
+  if (lenHeader && Number(lenHeader) > MAX_BODY_BYTES) {
+    res
+      .status(413)
+      .json({ ok: false, error: 'payload too large', max_bytes: MAX_BODY_BYTES, vtid: VTID });
+    return;
+  }
+  next();
+}
+
+router.post(
+  '/oasis/emit',
+  bodySizeGuard,
+  emitAuthGate,
+  async (req: Request, res: Response) => {
+    const parsed = BodySchema.safeParse(req.body);
+    if (!parsed.success) {
+      res.status(400).json({
+        ok: false,
+        error: 'invalid request body',
+        issues: parsed.error.issues,
+        vtid: VTID,
+      });
+      return;
+    }
+    const body: ParsedBody = parsed.data;
+
+    if (!isAllowedTopic(body.topic)) {
+      res.status(400).json({
+        ok: false,
+        error: `topic must start with one of: ${ALLOWED_PREFIXES.join(', ')}`,
+        topic: body.topic,
+        vtid: VTID,
+      });
+      return;
+    }
+
+    // Body-size post-parse check (covers chunked requests without
+    // content-length).
+    try {
+      const serialized = JSON.stringify(body);
+      if (serialized.length > MAX_BODY_BYTES) {
+        res
+          .status(413)
+          .json({ ok: false, error: 'payload too large', max_bytes: MAX_BODY_BYTES, vtid: VTID });
+        return;
+      }
+    } catch {
+      // Shouldn't happen — Zod already parsed the body, so JSON.stringify
+      // will succeed. Defensive only.
+      res.status(400).json({ ok: false, error: 'payload not serializable', vtid: VTID });
+      return;
+    }
+
+    const actor = (req as Request & { __emit_actor?: string }).__emit_actor ?? 'service:unknown';
+    const emitVtid = body.vtid && body.vtid.length > 0 ? body.vtid : VTID;
+
+    const result = await emitOasisEvent({
+      vtid: emitVtid,
+      type: body.topic as CicdEventType,
+      source: 'orb-agent',
+      status: 'info',
+      message: `[${body.topic}] emitted via /api/v1/oasis/emit`,
+      payload: body.payload ?? {},
+      actor_role: actor.startsWith('admin:') ? 'admin' : 'agent',
+      surface: 'api',
+    });
+
+    if (!result.ok) {
+      res.status(500).json({
+        ok: false,
+        error: result.error ?? 'emit failed',
+        vtid: VTID,
+      });
+      return;
+    }
+    res.json({ ok: true, event_id: result.event_id, vtid: VTID });
+  },
+);
+
+export default router;

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -541,6 +541,16 @@ export type CicdEventType =
   // the caller on Vertex — this event tells operators "you have a canary
   // user waiting; flip `voice.livekit_agent_enabled` once L2.2b lands."
   | 'orb.upstream.active_provider.pinned_until_agent_ready'
+  // L2.2b.1 (VTID-02987): backend orb-agent lifecycle observability.
+  // Emitted by the Python `services/agents/orb-agent` worker via
+  // POST /api/v1/oasis/emit. These 5 events form the room-join proof loop
+  // for the canary path. Audio / LLM / tool events are deferred to
+  // subsequent L2.2b.x phases.
+  | 'orb.livekit.agent.starting'
+  | 'orb.livekit.agent.room_join_started'
+  | 'orb.livekit.agent.room_join_succeeded'
+  | 'orb.livekit.agent.room_join_failed'
+  | 'orb.livekit.agent.disconnected'
   // VTID-DIAG: Pipeline diagnostics
   | 'orb.live.diag'
   // VTID-FALLBACK: Chat-TTS fallback events

--- a/services/gateway/test/routes/oasis-emit.test.ts
+++ b/services/gateway/test/routes/oasis-emit.test.ts
@@ -1,0 +1,262 @@
+/**
+ * L2.2b.1 (VTID-02987): tests for the `POST /api/v1/oasis/emit` route.
+ *
+ * Coverage matrix:
+ *   1. Missing / malformed Authorization header → 401.
+ *   2. Wrong service token → falls back to JWT path → 401.
+ *   3. Correct service token + allowed topic → 200, emitOasisEvent called.
+ *   4. Correct service token + disallowed topic → 400, NOT emitted.
+ *   5. JWT path: optionalAuth identity with `exafy_admin=true` → 200.
+ *   6. JWT path: identity present but NOT exafy_admin → 401.
+ *   7. Oversized payload (Content-Length above cap) → 413.
+ *   8. Invalid body shape (missing topic) → 400.
+ *   9. Empty bearer token → 401.
+ */
+
+import request from 'supertest';
+import express from 'express';
+
+// Mock `emitOasisEvent` BEFORE importing the router so the route picks up
+// the mock.
+const mockEmit = jest.fn(async () => ({ ok: true, event_id: 'evt-test-1' }));
+jest.mock('../../src/services/oasis-event-service', () => ({
+  emitOasisEvent: (...args: unknown[]) => (mockEmit as any)(...args),
+}));
+
+// Mock `optionalAuth` so the JWT-path tests can inject identity directly via
+// the `Authorization` header value (a simple convention: `Bearer admin-jwt`
+// = exafy_admin; `Bearer user-jwt` = ordinary user).
+jest.mock('../../src/middleware/auth-supabase-jwt', () => ({
+  optionalAuth: (req: any, _res: any, next: any) => {
+    const header = String(req.headers?.authorization ?? '');
+    if (header === 'Bearer admin-jwt') {
+      req.identity = { user_id: 'admin-uid', exafy_admin: true };
+    } else if (header === 'Bearer user-jwt') {
+      req.identity = { user_id: 'user-uid', exafy_admin: false };
+    }
+    // Any other value: identity stays undefined (the route returns 401).
+    next();
+  },
+}));
+
+import oasisEmitRouter from '../../src/routes/oasis-emit';
+
+const VALID_TOPIC = 'orb.livekit.agent.starting';
+const ALLOWED_LIVEKIT_TOPIC = 'livekit.session.start';
+const DISALLOWED_TOPIC = 'orb.live.context.bootstrap'; // wrong prefix
+
+function buildApp(): express.Express {
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1', oasisEmitRouter);
+  return app;
+}
+
+beforeEach(() => {
+  mockEmit.mockClear();
+  mockEmit.mockResolvedValue({ ok: true, event_id: 'evt-test-1' });
+  process.env.GATEWAY_SERVICE_TOKEN = 'svc-secret-token-xyz';
+});
+
+afterAll(() => {
+  delete process.env.GATEWAY_SERVICE_TOKEN;
+});
+
+describe('POST /api/v1/oasis/emit — auth gate', () => {
+  it('1. missing Authorization → 401, NOT emitted', async () => {
+    const app = buildApp();
+    const res = await request(app).post('/api/v1/oasis/emit').send({ topic: VALID_TOPIC });
+    expect(res.status).toBe(401);
+    expect(res.body.ok).toBe(false);
+    expect(mockEmit).not.toHaveBeenCalled();
+  });
+
+  it('1b. malformed Authorization (no Bearer prefix) → 401', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/oasis/emit')
+      .set('Authorization', 'NotBearer foo')
+      .send({ topic: VALID_TOPIC });
+    expect(res.status).toBe(401);
+    expect(mockEmit).not.toHaveBeenCalled();
+  });
+
+  it('9. empty bearer token → 401', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/oasis/emit')
+      .set('Authorization', 'Bearer ')
+      .send({ topic: VALID_TOPIC });
+    expect(res.status).toBe(401);
+    expect(mockEmit).not.toHaveBeenCalled();
+  });
+
+  it('2. wrong service token AND not a known JWT → 401', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/oasis/emit')
+      .set('Authorization', 'Bearer wrong-token')
+      .send({ topic: VALID_TOPIC });
+    expect(res.status).toBe(401);
+    expect(mockEmit).not.toHaveBeenCalled();
+  });
+
+  it('6. JWT path: optionalAuth identity NOT exafy_admin → 401', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/oasis/emit')
+      .set('Authorization', 'Bearer user-jwt')
+      .send({ topic: VALID_TOPIC });
+    expect(res.status).toBe(401);
+    expect(mockEmit).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/v1/oasis/emit — topic allowlist', () => {
+  it('3. service token + allowed topic → 200, emitOasisEvent called', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/oasis/emit')
+      .set('Authorization', 'Bearer svc-secret-token-xyz')
+      .send({ topic: VALID_TOPIC, payload: { room_name: 'orb-test' } });
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.event_id).toBe('evt-test-1');
+    expect(mockEmit).toHaveBeenCalledTimes(1);
+    const call = mockEmit.mock.calls[0][0];
+    expect(call.type).toBe(VALID_TOPIC);
+    expect(call.source).toBe('orb-agent');
+    expect(call.payload).toEqual({ room_name: 'orb-test' });
+  });
+
+  it('3b. service token + `livekit.*` topic also allowed', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/oasis/emit')
+      .set('Authorization', 'Bearer svc-secret-token-xyz')
+      .send({ topic: ALLOWED_LIVEKIT_TOPIC });
+    expect(res.status).toBe(200);
+    expect(mockEmit).toHaveBeenCalledTimes(1);
+  });
+
+  it('4. service token + disallowed topic (orb.live.*) → 400, NOT emitted', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/oasis/emit')
+      .set('Authorization', 'Bearer svc-secret-token-xyz')
+      .send({ topic: DISALLOWED_TOPIC });
+    expect(res.status).toBe(400);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toMatch(/orb\.livekit\.|livekit\./);
+    expect(mockEmit).not.toHaveBeenCalled();
+  });
+
+  it('4b. service token + arbitrary topic → 400', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/oasis/emit')
+      .set('Authorization', 'Bearer svc-secret-token-xyz')
+      .send({ topic: 'arbitrary.forged.event' });
+    expect(res.status).toBe(400);
+    expect(mockEmit).not.toHaveBeenCalled();
+  });
+
+  it('4c. service token + empty topic → 400', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/oasis/emit')
+      .set('Authorization', 'Bearer svc-secret-token-xyz')
+      .send({ topic: '' });
+    expect(res.status).toBe(400);
+    expect(mockEmit).not.toHaveBeenCalled();
+  });
+});
+
+describe('POST /api/v1/oasis/emit — admin-JWT happy path', () => {
+  it('5. exafy_admin JWT + allowed topic → 200', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/oasis/emit')
+      .set('Authorization', 'Bearer admin-jwt')
+      .send({ topic: VALID_TOPIC, vtid: 'VTID-OPS' });
+    expect(res.status).toBe(200);
+    expect(mockEmit).toHaveBeenCalledTimes(1);
+    const call = mockEmit.mock.calls[0][0];
+    expect(call.actor_role).toBe('admin');
+    expect(call.vtid).toBe('VTID-OPS'); // caller-supplied vtid passes through
+  });
+});
+
+describe('POST /api/v1/oasis/emit — body shape + size', () => {
+  it('8. missing topic → 400', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/oasis/emit')
+      .set('Authorization', 'Bearer svc-secret-token-xyz')
+      .send({ payload: {} });
+    expect(res.status).toBe(400);
+    expect(mockEmit).not.toHaveBeenCalled();
+  });
+
+  it('7. payload above 16 KiB cap → 413', async () => {
+    // Send a real ~20 KiB body. Express's body parser passes it through (its
+    // default cap is 100 KiB), then either the content-length guard OR the
+    // post-parse JSON.stringify size check returns 413.
+    const app = buildApp();
+    const bigPayload = { big: 'x'.repeat(20 * 1024) };
+    const res = await request(app)
+      .post('/api/v1/oasis/emit')
+      .set('Authorization', 'Bearer svc-secret-token-xyz')
+      .send({ topic: VALID_TOPIC, payload: bigPayload });
+    expect(res.status).toBe(413);
+    expect(mockEmit).not.toHaveBeenCalled();
+  });
+
+  it('7b. payload below cap → 200', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/oasis/emit')
+      .set('Authorization', 'Bearer svc-secret-token-xyz')
+      .send({
+        topic: VALID_TOPIC,
+        payload: { tiny: 'ok' },
+      });
+    expect(res.status).toBe(200);
+  });
+});
+
+describe('POST /api/v1/oasis/emit — emit failure surfaced as 500', () => {
+  it('emitOasisEvent returning ok:false → 500', async () => {
+    mockEmit.mockResolvedValueOnce({ ok: false, error: 'supabase exploded' });
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/oasis/emit')
+      .set('Authorization', 'Bearer svc-secret-token-xyz')
+      .send({ topic: VALID_TOPIC });
+    expect(res.status).toBe(500);
+    expect(res.body.ok).toBe(false);
+    expect(res.body.error).toMatch(/supabase exploded/);
+  });
+});
+
+describe('POST /api/v1/oasis/emit — env-misconfig edge', () => {
+  it('GATEWAY_SERVICE_TOKEN unset → service-token path NEVER matches (only admin JWT works)', async () => {
+    delete process.env.GATEWAY_SERVICE_TOKEN;
+    const app = buildApp();
+    // svc-secret-token-xyz must NOT be accepted when env is unset
+    const res = await request(app)
+      .post('/api/v1/oasis/emit')
+      .set('Authorization', 'Bearer svc-secret-token-xyz')
+      .send({ topic: VALID_TOPIC });
+    expect(res.status).toBe(401);
+    expect(mockEmit).not.toHaveBeenCalled();
+
+    // But admin JWT still works
+    const res2 = await request(app)
+      .post('/api/v1/oasis/emit')
+      .set('Authorization', 'Bearer admin-jwt')
+      .send({ topic: VALID_TOPIC });
+    expect(res2.status).toBe(200);
+    expect(mockEmit).toHaveBeenCalledTimes(1);
+  });
+});


### PR DESCRIPTION
## Summary

Closes Gate 4 from the L2.2b design audit. Adds a service-token-gated gateway proxy at ``POST /api/v1/oasis/emit`` so the deployed Python orb-agent worker can emit lifecycle telemetry via the same OASIS pipeline the gateway uses internally. Wires **5 new agent lifecycle events** into ``session.py`` at the earliest possible hook points.

**Vertex production path: untouched.** ``voice.livekit_agent_enabled`` remains ``false``. NO user routed to LiveKit.

## Gateway changes

**New** — ``services/gateway/src/routes/oasis-emit.ts``:
- ``POST /api/v1/oasis/emit``
- **Auth (NO unauthenticated access):** ``Bearer GATEWAY_SERVICE_TOKEN`` (service path) OR ``Bearer JWT`` where ``optionalAuth`` produces ``identity.exafy_admin === true``. Service-token check happens first; admin-JWT is the fallback.
- **Topic allowlist:** must start with ``orb.livekit.`` or ``livekit.``. Arbitrary topics rejected.
- **Body cap:** 16 KiB. Both Content-Length pre-parse guard AND post-parse JSON.stringify size check.
- Delegates to existing ``emitOasisEvent`` so OASIS persistence stays unified.

**Modified** — ``services/gateway/src/index.ts``: mounts the new router under ``/api/v1``.

**Modified** — ``services/gateway/src/types/cicd.ts``: adds 5 lifecycle event types.

## Agent changes (``services/agents/orb-agent/``)

**``src/orb_agent/oasis.py``**: 5 new module-level topic constants matching the gateway union (``TOPIC_AGENT_STARTING`` / ``ROOM_JOIN_STARTED`` / ``ROOM_JOIN_SUCCEEDED`` / ``ROOM_JOIN_FAILED`` / ``DISCONNECTED``).

**``src/orb_agent/session.py`` (``agent_entrypoint``)**:
- Emits ``agent.starting`` immediately after ``OasisEmitter`` is constructed (BEFORE ``ctx.connect``, BEFORE any other side effect).
- Emits ``agent.room_join_started`` immediately before ``ctx.connect()``.
- Wraps ``ctx.connect()`` in try/except: success → emit ``room_join_succeeded``; failure → emit ``room_join_failed`` (with error + error_type) then **re-raise** so the worker dispatcher sees the failure.
- In the existing ``_teardown`` shutdown callback, emits ``agent.disconnected`` BEFORE the legacy ``livekit.session.stop`` — symmetric pair (succeeded ↔ disconnected). The old ``session.stop`` event stays for back-compat.
- Every emit carries ``room_name``, ``code_version``, ``vtid=VTID-02987``.
- Every emit is **fire-and-forget** — ``OasisEmitter`` swallows network errors. Telemetry NEVER blocks the voice path.

## Tests

- **Gateway:** 16 tests covering the full auth + allowlist + body-cap + emit-failure matrix:
  - 1/1b/9: missing/malformed/empty Authorization → 401
  - 2: wrong service token AND no known JWT → 401
  - 3/3b: correct service token + allowed ``orb.livekit.*`` or ``livekit.*`` topic → 200
  - 4/4b/4c: service token + disallowed/arbitrary/empty topic → 400
  - 5: admin JWT (``exafy_admin=true``) + allowed topic → 200
  - 6: JWT identity present but NOT exafy_admin → 401
  - 7/7b: >16 KiB payload → 413; small payload → 200
  - 8: missing topic → 400
  - emit-failure (``ok:false``) → 500
  - env-misconfig: ``GATEWAY_SERVICE_TOKEN`` unset → service-token path NEVER matches; admin JWT still works.
- **722 gateway tests green** (was 706 after L2.2a; +16 new).
- Build clean.
- **Agent Python:** both files parse via ``ast.parse``; constants + structural grep checks pass locally; full pytest runs in agent CI.

## Acceptance vs the brief

| # | Criterion | Status |
|---|---|---|
| 1 | ``/api/v1/oasis/emit`` rejects unauthenticated requests | ✓ |
| 2 | Service-token request for allowed ``orb.livekit.*`` topic → 200 | ✓ |
| 3 | Disallowed topic → 4xx | ✓ |
| 4 | Agent emits lifecycle telemetry through the route | ✓ (5 events wired) |
| 5 | Agent joins a test LiveKit room or emits typed join failure | ✓ (try/except → ``room_join_succeeded`` or ``room_join_failed`` then re-raise) |
| 6 | Production Vertex /orb/chat smoke still passes after deploy | pending merge |
| 7 | ``voice.livekit_agent_enabled`` remains false | ✓ (this PR does NOT flip the flag) |

## What's NOT in this PR (deferred per the L2.2b design)

- No STT / LLM / TTS wiring (L2.2b.2 + L2.2b.3).
- No tool dispatch (L2.2b.4).
- No frontend change (L2.2b.5).
- Provider API keys (Anthropic, Deepgram, Cartesia, ElevenLabs, AssemblyAI, OpenAI) **NOT yet populated** in Secret Manager. Pre-flight task for L2.2b.2.

🤖 Generated with [Claude Code](https://claude.com/claude-code)