### PR TITLE
PR-M1.x' (VTID-02988): extend executor-source-type allowlist to lazyPlanTick + activationReaperTick

### DIFF
--- a/services/gateway/src/services/dev-autopilot-execute.ts
+++ b/services/gateway/src/services/dev-autopilot-execute.ts
@@ -2801,10 +2801,14 @@ export async function lazyPlanTick(): Promise<void> {
   if (pendingR.ok && pendingR.data && pendingR.data.length > 0) return;
 
   // Find planless findings ordered by impact_score desc.
+  // VTID-02988 (PR-M1.x'): filter through the shared executor-source-type
+  // allowlist so test-contract-failure-scanner / missing-test-scanner recs
+  // also receive lazy plans. Without this, autoApproveTick can never approve
+  // them — they sit at status='new' with no plan forever.
   const riskFilter = `(${LAZY_PLAN_RISK_CLASSES.map(r => `"${r}"`).join(',')})`;
   const findingsR = await supa<Array<{ id: string }>>(
     s,
-    `/rest/v1/autopilot_recommendations?source_type=in.(dev_autopilot,dev_autopilot_impact)`
+    `/rest/v1/autopilot_recommendations?source_type=in.(${executableSourceTypesPostgrestIn()})`
     + `&status=eq.new&risk_class=in.${riskFilter}`
     + `&order=impact_score.desc&limit=${LAZY_PLAN_BATCH_SIZE * 4}&select=id`,
   );
@@ -2872,9 +2876,12 @@ async function activationReaperTick(): Promise<void> {
   const cutoff = new Date(Date.now() - REAPER_GRACE_MS).toISOString();
   // Pull a small batch — we want to recover steadily, not flood the LLM
   // budget with weeks of accumulated activations on the first tick.
+  // VTID-02988 (PR-M1.x'): scope through the shared executor-source-type
+  // allowlist so orphaned activations from any executable scanner can be
+  // recovered, not just dev_autopilot lineage.
   const orphanedR = await supa<Array<{ id: string; activated_vtid: string | null; activated_at: string }>>(
     s,
-    `/rest/v1/autopilot_recommendations?source_type=in.(dev_autopilot,dev_autopilot_impact)` +
+    `/rest/v1/autopilot_recommendations?source_type=in.(${executableSourceTypesPostgrestIn()})` +
     `&status=eq.activated&activated_at=lt.${cutoff}` +
     `&select=id,activated_vtid,activated_at&order=activated_at.asc&limit=5`,
   );

--- a/services/gateway/test/autopilot-source-type-filter-call-sites.test.ts
+++ b/services/gateway/test/autopilot-source-type-filter-call-sites.test.ts
@@ -1,0 +1,97 @@
+/**
+ * VTID-02988 (PR-M1.x'): structural lock-in for the executor-source-type
+ * allowlist call sites in dev-autopilot-execute.ts.
+ *
+ * PR-M1.x (VTID-02984) extended the allowlist into autoApproveTick + the
+ * two executeRecommendation guards. It missed two more sites:
+ *
+ *   - lazyPlanTick (line ~2807) — without coverage, test-contract-
+ *     failure-scanner recs never receive a plan, so autoApproveTick can
+ *     never approve them. This was the actual blocker for VTID-02977.
+ *   - activationReaperTick (line ~2877) — without coverage, orphaned
+ *     status='activated' rows from new scanners stay orphaned forever.
+ *
+ * PR-M1.x' fixes both by routing them through
+ * executableSourceTypesPostgrestIn(). These tests assert the dead
+ * hard-coded list cannot return without a code review noticing.
+ *
+ * Pure-string assertions against the source file — no runtime needed.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+const FILE = path.resolve(
+  __dirname,
+  '../src/services/dev-autopilot-execute.ts',
+);
+const source = fs.readFileSync(FILE, 'utf8');
+
+describe('dev-autopilot-execute.ts — executor-source-type allowlist call sites', () => {
+  it('imports the shared allowlist module', () => {
+    expect(source).toMatch(
+      /from '\.\/autopilot-executable-source-types'/,
+    );
+    expect(source).toMatch(/executableSourceTypesPostgrestIn/);
+  });
+
+  it('does NOT re-introduce the hard-coded source_type=in.(dev_autopilot,dev_autopilot_impact) filter', () => {
+    // Anchored on the literal that PR-M1.x' replaced. If anyone
+    // reintroduces this string, the test fails — they have to either
+    // add a new entry to EXECUTABLE_RECOMMENDATION_SOURCE_TYPES or
+    // justify a narrow eq./in.() filter elsewhere.
+    expect(source).not.toContain(
+      'source_type=in.(dev_autopilot,dev_autopilot_impact)',
+    );
+  });
+
+  it('lazyPlanTick filters recommendations through executableSourceTypesPostgrestIn()', () => {
+    const lazyPlanFn = extractFunctionBody(source, 'lazyPlanTick');
+    expect(lazyPlanFn).toMatch(/autopilot_recommendations\?source_type=in\.\(\$\{executableSourceTypesPostgrestIn\(\)\}\)/);
+  });
+
+  it('activationReaperTick filters recommendations through executableSourceTypesPostgrestIn()', () => {
+    const reaperFn = extractFunctionBody(source, 'activationReaperTick');
+    expect(reaperFn).toMatch(/autopilot_recommendations\?source_type=in\.\(\$\{executableSourceTypesPostgrestIn\(\)\}\)/);
+  });
+
+  it('autoApproveTick (PR-M1.x baseline) still filters through executableSourceTypesPostgrestIn()', () => {
+    // Regression guard for PR-M1.x — make sure PR-M1.x' did not
+    // accidentally revert the baseline allowlist coverage.
+    const autoApproveFn = extractFunctionBody(source, 'autoApproveTick');
+    expect(autoApproveFn).toMatch(/autopilot_recommendations\?source_type=in\.\(\$\{executableSourceTypesPostgrestIn\(\)\}\)/);
+  });
+
+  it('preserves the narrow impact-only filter inside autoApproveTick (intentional, not a regression)', () => {
+    // The impact-only branch deliberately uses eq.dev_autopilot_impact
+    // because it's scoped to impact rules — adding non-impact scanners
+    // there would be wrong. Lock this in so we don't "fix" it later.
+    expect(source).toContain(
+      'source_type=eq.dev_autopilot_impact&status=eq.new',
+    );
+  });
+});
+
+/**
+ * Extracts the body of a top-level function by name. Returns the substring
+ * between the `function <name>` opener and the matching closing brace
+ * at column 0. Good enough for lock-in assertions; not a real parser.
+ */
+function extractFunctionBody(src: string, name: string): string {
+  const re = new RegExp(
+    `(?:export\\s+)?(?:async\\s+)?function\\s+${name}\\b[\\s\\S]*?\\{`,
+    'm',
+  );
+  const m = re.exec(src);
+  if (!m) throw new Error(`could not locate function ${name} in source`);
+  const start = m.index + m[0].length;
+  let depth = 1;
+  let i = start;
+  while (i < src.length && depth > 0) {
+    const c = src[i];
+    if (c === '{') depth++;
+    else if (c === '}') depth--;
+    i++;
+  }
+  return src.slice(start, i);
+}


### PR DESCRIPTION
## Summary
- PR-M1.x missed the planner gate: `lazyPlanTick` still hard-coded `source_type=in.(dev_autopilot,dev_autopilot_impact)`, so test-contract-failure-scanner / missing-test-scanner recs never received a plan and `autoApproveTick` could never approve them.
- This is the actual upstream blocker for the VTID-02977 green-path proof — the dispatcher gate + both executor guards opened in PR-M1.x are still gated by the planner.
- Routes both remaining call sites (`lazyPlanTick`, `activationReaperTick`) through the shared `executableSourceTypesPostgrestIn()` renderer.
- Adds a structural test that fails if the dead hard-coded list returns or any of the three executor call sites stop using the shared renderer.

## Scope
- **Modified**: `services/gateway/src/services/dev-autopilot-execute.ts` (2 filter lines + comments)
- **Added**: `services/gateway/test/autopilot-source-type-filter-call-sites.test.ts` (6 lock-in assertions)
- **Intentionally untouched**: the narrow `eq.dev_autopilot_impact` branch inside `autoApproveTick` — impact-rule-scoped, not allowlist-scoped. Test pins this in.

## Tests
- 6/6 new structural tests green
- 11/11 existing source-types tests still green
- `npm run build` clean

## Test plan
- [x] `npm run build` succeeds
- [x] 17/17 jest tests across both files pass
- [ ] Merge → EXEC-DEPLOY succeeds
- [ ] Re-apply narrow proof config (auto_approve_enabled=true, scanners=['test-contract-failure-scanner']; worker-runner stays in allow_scope)
- [ ] Watch VTID-02977 reaches dev_autopilot_executions.status=completed + real PR + CI green + deploy + contract flips PASS + vtid_ledger.terminal_outcome=success
- [ ] Restore proof-only config after terminal (worker-runner stays permanent)

🤖 Generated with [Claude Code](https://claude.com/claude-code)