### PR TITLE
fix(notifications): dispatch via Appilix when user has no native mobile token (Codex P1 follow-up)

### DIFF
--- a/services/gateway/src/services/notification-service.ts
+++ b/services/gateway/src/services/notification-service.ts
@@ -537,22 +537,38 @@ export async function notifyUser(
   }
 
   // ── 5. Send push — FCM first, Appilix as fallback ──────
-  // Single dispatch policy: FCM first, Appilix fallback.
-  //
-  // Historically chat-category notifications routed through Appilix first
-  // because we only had web-push FCM tokens (which open the browser, not
-  // the app). Per Appilix support, their iOS wrapper exposes the native
-  // FCM token via a JS bridge (appilix.postMessage({type:"firebase_token"}))
-  // which the frontend now registers in user_device_tokens. With native
-  // tokens stored, Firebase Admin SDK delivers via APNs straight to the
-  // installed app — bypassing Appilix's user_identity routing layer
-  // entirely. Appilix remains as fallback for users whose token isn't
-  // registered yet.
+  // Dispatch policy:
+  //   1. Always try FCM first via user_device_tokens (covers Android native
+  //      app, iOS native app once bridge captures token, web push).
+  //   2. If the notification has a deep-link URL AND we have no
+  //      Appilix-wrapped (native mobile) token registered for the user,
+  //      ALSO fire Appilix legacy user_identity push so the installed app
+  //      receives it. Web-push FCM tokens open the browser, not the app,
+  //      so without this branch users whose iOS/Android bridge hasn't
+  //      captured the native token yet would silently miss chat pushes.
+  //      Frontend registerAppilixDevice() tags native tokens with a
+  //      "Appilix " prefix on device_label — that's our detection signal.
+  //   3. If FCM delivered to zero tokens overall, also try Appilix as a
+  //      last-resort fallback (original behavior).
   let pushed = 0;
   let appilixSent = false;
   if (shouldSendPush) {
     pushed = await sendPushToUser(userId, tenantId, payload, supabase);
-    if (pushed === 0) {
+
+    if (payload.data?.url) {
+      const { count: nativeMobileCount } = await supabase
+        .from('user_device_tokens')
+        .select('*', { count: 'exact', head: true })
+        .eq('user_id', userId)
+        .eq('tenant_id', tenantId)
+        .like('device_label', 'Appilix %');
+
+      if (!nativeMobileCount) {
+        appilixSent = await sendAppilixPush(userId, payload);
+      }
+    }
+
+    if (pushed === 0 && !appilixSent) {
       appilixSent = await sendAppilixPush(userId, payload);
     }
   }


### PR DESCRIPTION
## Summary

Resolves the Codex P1 regression flagged on #2068. Confirmed in production today: an iPhone user (Jovana Tadic, `bc34a5ca-...`) has FCM tokens for Android Chrome + Windows desktop but no native iOS bridge-captured token. Gateway logged `push=2 appilix=false` — meaning FCM "delivered" to her two web browsers, Appilix was skipped, and her installed Maxina iOS app received nothing.

## What was broken

After #2068's "FCM first, Appilix only if FCM=0" policy, users in this state silently miss deep-link pushes:

```
sendPushToUser → push=2 (web tokens)  → looks successful
sendAppilixPush → skipped (because push > 0)
result: iPhone app gets nothing, web push opens browser only
```

This is the exact pattern Codex flagged when #2068 shipped.

## Fix

When the payload carries a deep-link URL (`data.url`), check whether any of the user's stored tokens is **native-mobile** — detected via `device_label LIKE 'Appilix %'` (the frontend's `registerAppilixDevice` adds that prefix). If none, fire Appilix in addition to FCM so the installed app receives via the legacy `user_identity` route.

```ts
pushed = await sendPushToUser(...);

if (payload.data?.url) {
  const { count: nativeMobileCount } = await supabase
    .from('user_device_tokens')
    .select('*', { count: 'exact', head: true })
    .eq('user_id', userId)
    .eq('tenant_id', tenantId)
    .like('device_label', 'Appilix %');

  if (!nativeMobileCount) {
    appilixSent = await sendAppilixPush(userId, payload);
  }
}

// Original last-resort fallback preserved
if (pushed === 0 && !appilixSent) {
  appilixSent = await sendAppilixPush(userId, payload);
}
```

## Behaviour matrix

| User's token state | What fires | Why |
|---|---|---|
| Has native (Appilix-prefixed) token | FCM only | FCM delivers to installed app; no duplicate |
| Has only web/desktop tokens, deep-link push | FCM + Appilix | Web tokens open browser, Appilix opens app |
| No tokens at all | Appilix only (existing fallback) | Last resort, unchanged |
| Notification has no `data.url` | FCM only | No deep-link means no app-routing concern |

## Why this is safe

- **Double-delivery risk**: minimal. Native-mobile users (the only ones who might double-receive) are explicitly skipped by the `like 'Appilix %'` filter — they get FCM only.
- **Performance**: one extra `count(*)` query per deep-link push (~1-3 ms). Negligible.
- **Reversibility**: single function, single file, easy to revert if needed.

## Test plan

- [ ] Merge → confirm EXEC-DEPLOY runs (commit message has `BOOTSTRAP-FCM-APPILIX-COEXIST`)
- [ ] Verify gateway is updated (curl `/alive` or check Cloud Run revisions list)
- [ ] From Android (any sender), send a chat to Jovana (`bc34a5ca-6966-44f6-9507-3bed98e3e1d5`)
- [ ] Gateway log should now show `push=2 appilix=true` (FCM hits her web tokens AND Appilix routes to her iPhone)
- [ ] Jovana's iPhone receives the notification on the lock screen
- [ ] Repeat for a user with native iOS token captured (e.g. one of the working Android-app users) — verify `push>=1 appilix=false` still applies (no Appilix duplicate)

## Related

- vitana-platform #2068 — flipped to FCM-first (introduced regression Codex caught)
- vitana-v1 #463 — broader iOS bridge listener (still useful for users whose token IS eventually captured)
- vitana-v1 #455 — initial bridge call
- All earlier `vitana-v1` and `vitana-platform` PRs in this session

https://claude.ai/code/session_01AABjoZDKaA2XxXP5t9715a

---
_Generated by [Claude Code](https://claude.ai/code/session_01AABjoZDKaA2XxXP5t9715a)_