### PR TITLE
feat(orb): L2.2b.2 — Gemini-via-Vertex text/model loop in orb-agent (no STT/TTS, no new API keys) (VTID-02990)

### DIFF
--- a/.github/workflows/DEPLOY-ORB-AGENT.yml
+++ b/.github/workflows/DEPLOY-ORB-AGENT.yml
@@ -91,7 +91,7 @@ jobs:
             --allow-unauthenticated \
             --labels=vtid=vtid-livekit-foundation,vt_layer=aicor,vt_module=voice \
             --update-secrets=LIVEKIT_URL=LIVEKIT_URL:latest,LIVEKIT_API_KEY=LIVEKIT_API_KEY:latest,LIVEKIT_API_SECRET=LIVEKIT_API_SECRET:latest \
-            --set-env-vars=GATEWAY_URL=https://gateway-q74ibpv6ia-uc.a.run.app,AGENT_LOG_LEVEL=INFO,AGENT_ENABLE_WORKER=1,GOOGLE_CLOUD_PROJECT=lovable-vitana-vers1,VERTEX_AI_LOCATION=global
+            --set-env-vars=GATEWAY_URL=https://gateway-q74ibpv6ia-uc.a.run.app,AGENT_LOG_LEVEL=INFO,AGENT_ENABLE_WORKER=1,GOOGLE_CLOUD_PROJECT=lovable-vitana-vers1,VERTEX_AI_LOCATION=us-central1,ORB_AGENT_TEXT_ONLY=true
 
       - name: Delete prior revisions (force only-latest worker connects to LiveKit)
         run: |

--- a/services/agents/orb-agent/src/orb_agent/oasis.py
+++ b/services/agents/orb-agent/src/orb_agent/oasis.py
@@ -130,3 +130,16 @@ TOPIC_AGENT_ROOM_JOIN_STARTED = "orb.livekit.agent.room_join_started"
 TOPIC_AGENT_ROOM_JOIN_SUCCEEDED = "orb.livekit.agent.room_join_succeeded"
 TOPIC_AGENT_ROOM_JOIN_FAILED = "orb.livekit.agent.room_join_failed"
 TOPIC_AGENT_DISCONNECTED = "orb.livekit.agent.disconnected"
+
+# L2.2b.2 (VTID-02990): Gemini-via-Vertex text/model loop telemetry.
+# Emitted by the agent's text-only self-test path (`ORB_AGENT_TEXT_ONLY=true`)
+# so the agent/model boundary is provable without any STT/TTS providers and
+# without any new API keys (Cloud Run's default service account provides
+# Vertex ADC). The 3 events fire in order:
+#   model_request_started → (model_request_succeeded | model_request_failed)
+# Failure payload includes a typed `reason` (genai_sdk_not_installed,
+# vertex_client_init_error, vertex_api_error, timeout) plus the underlying
+# error string.
+TOPIC_AGENT_MODEL_REQUEST_STARTED = "orb.livekit.agent.model_request_started"
+TOPIC_AGENT_MODEL_REQUEST_SUCCEEDED = "orb.livekit.agent.model_request_succeeded"
+TOPIC_AGENT_MODEL_REQUEST_FAILED = "orb.livekit.agent.model_request_failed"

--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -183,6 +183,80 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
         vtid="VTID-02987",
     )
 
+    # L2.2b.2 (VTID-02990): text-only model loop. When `ORB_AGENT_TEXT_ONLY`
+    # is true (default during the L2.2b.2 phase), skip the STT/LLM/TTS
+    # cascade build + AgentSession start — those need Deepgram + Cartesia
+    # secrets which haven't been populated yet. Instead, run a single
+    # Anthropic round-trip self-test to prove the agent/model boundary
+    # works from canary room context, emit the 3 model_request_* lifecycle
+    # events, and idle until the room disconnects.
+    #
+    # When ops flips `ORB_AGENT_TEXT_ONLY=false` (after Deepgram + Cartesia
+    # secrets land in L2.2b.3), this branch is skipped and the existing
+    # cascade path below runs.
+    from .text_only_loop import run_text_only_self_test, text_only_mode_enabled
+
+    if text_only_mode_enabled():
+        logger.info(
+            "L2.2b.2: ORB_AGENT_TEXT_ONLY enabled — running Anthropic self-test, "
+            "skipping cascade build"
+        )
+
+        # Register a small teardown for the text-only path that mirrors the
+        # L2.2b.1 disconnected-event semantics — emit `agent.disconnected`
+        # then close OasisEmitter + ctx_fetcher. The full cascade teardown
+        # (GatewayClient, AgentSession finalization) is NOT needed here
+        # because those resources are never created in text-only mode.
+        async def _text_only_teardown() -> None:
+            try:
+                await oasis.emit(
+                    topic=TOPIC_AGENT_DISCONNECTED,
+                    payload=dict(
+                        _agent_lifecycle_base,
+                        phase="disconnected",
+                        mode="text_only",
+                    ),
+                    vtid="VTID-02987",
+                )
+            except Exception as exc:  # noqa: BLE001
+                logger.warning("L2.2b.2: agent.disconnected emit failed: %s", exc)
+            try:
+                await oasis.aclose()
+            except Exception:  # noqa: BLE001
+                pass
+            try:
+                await ctx_fetcher.aclose()
+            except Exception:  # noqa: BLE001
+                pass
+
+        try:
+            ctx.add_shutdown_callback(_text_only_teardown)  # type: ignore[attr-defined]
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "L2.2b.2: add_shutdown_callback unavailable; disconnect event "
+                "may not fire. err=%s",
+                exc,
+            )
+
+        try:
+            result = await run_text_only_self_test(
+                oasis=oasis,
+                room_name=_room_name,
+                code_version=CODE_VERSION,
+            )
+            logger.info("L2.2b.2: self-test result=%s", result)
+        except Exception as exc:  # noqa: BLE001
+            # run_text_only_self_test should NEVER raise (it catches its own
+            # errors and emits typed failure events). This guard is purely
+            # defensive — if something does escape, log it and continue so
+            # the agent doesn't fail the room dispatch.
+            logger.exception("L2.2b.2: unexpected self-test exception: %s", exc)
+
+        # Stay in the room until LiveKit disconnects us (the shutdown_callback
+        # above emits `agent.disconnected` on teardown). The agent worker
+        # process tears itself down when the SFU closes the room.
+        return
+
     # ── Identity metadata lives on the USER PARTICIPANT, not the room. ──
     # The gateway's /api/v1/orb/livekit/token mints a LiveKit AccessToken
     # with `metadata: JSON.stringify({user_id, tenant_id, vitana_id,

--- a/services/agents/orb-agent/src/orb_agent/text_only_loop.py
+++ b/services/agents/orb-agent/src/orb_agent/text_only_loop.py
@@ -1,0 +1,243 @@
+"""L2.2b.2 (VTID-02990): Gemini-via-Vertex text/model loop for the agent's
+text-only mode.
+
+What this is
+============
+The agent's "no STT, no TTS, no audio" proof of life. When
+`ORB_AGENT_TEXT_ONLY=true` (default during L2.2b.2), `agent_entrypoint`
+skips the full STT/LLM/TTS cascade build + AgentSession start and calls
+`run_text_only_self_test` instead. The self-test:
+
+  1. Reads `GOOGLE_CLOUD_PROJECT` + `VERTEX_AI_LOCATION` (or sensible
+     defaults). Cloud Run's default service account provides ADC for
+     Vertex AI — no API key required.
+  2. If the `google-genai` SDK is unavailable → emits
+     `model_request_failed` with reason `genai_sdk_not_installed`.
+  3. Emits `model_request_started`, calls Gemini with a fixed canary
+     prompt at 15s timeout, emits `model_request_succeeded` or
+     `_failed` based on outcome.
+  4. NEVER raises. Telemetry never blocks the room.
+
+Why Gemini-via-Vertex (not Anthropic)
+=====================================
+The gateway's Vertex pipeline already uses Google ADC via Cloud Run's
+default service account — the same auth path is available to this
+service. No new secrets in Secret Manager. Operationally cheaper than
+Anthropic for the canary proof. L2.2b.3+ may add Anthropic as an
+alternate provider; the boundary in this file makes that drop-in.
+
+Hard rules
+==========
+- This module NEVER touches STT/TTS/AudioSession code paths. L2.2b.3
+  reintroduces those when Deepgram + Cartesia secrets are in place.
+- Gemini call uses `google.genai.Client(vertexai=True, ...)`. The
+  client lib comes transitively via `livekit-plugins-google`.
+- All emits are fire-and-forget. Gemini failures NEVER raise out of
+  this function.
+- The canary prompt is a fixed short string that doesn't depend on
+  conversation state — proves the boundary only.
+"""
+from __future__ import annotations
+
+import asyncio
+import logging
+import os
+import time
+from typing import Any
+
+from .oasis import (
+    OasisEmitter,
+    TOPIC_AGENT_MODEL_REQUEST_FAILED,
+    TOPIC_AGENT_MODEL_REQUEST_STARTED,
+    TOPIC_AGENT_MODEL_REQUEST_SUCCEEDED,
+)
+
+logger = logging.getLogger(__name__)
+
+
+VTID = "VTID-02990"
+
+# Fixed canary prompt — proves the boundary without depending on any
+# conversation state. Short on purpose so a slow/failing model call
+# fails fast rather than hanging the room for a real prompt.
+CANARY_PROMPT = (
+    "Reply in one short sentence to confirm you are online. "
+    "Say: 'L2.2b.2 canary online.'"
+)
+
+# Default model. Override via env `ORB_AGENT_L22B2_MODEL`. The fast/cheap
+# Gemini lite variant is fine for a one-shot canary call.
+DEFAULT_MODEL = "gemini-2.5-flash-lite"
+
+# Hard cap on model call latency. The agent should fail loud rather
+# than hang the room indefinitely on a stuck request.
+MODEL_TIMEOUT_S = 15.0
+
+
+async def run_text_only_self_test(
+    *,
+    oasis: OasisEmitter,
+    room_name: str | None,
+    code_version: str,
+) -> dict[str, Any]:
+    """Run one Gemini-via-Vertex round-trip + emit the 3 lifecycle events.
+
+    Returns a small dict describing the outcome (for caller logging /
+    optional data-channel publish). NEVER raises.
+    """
+    project = (os.getenv("GOOGLE_CLOUD_PROJECT") or "lovable-vitana-vers1").strip()
+    location = (os.getenv("VERTEX_AI_LOCATION") or "us-central1").strip()
+    model = (os.getenv("ORB_AGENT_L22B2_MODEL") or DEFAULT_MODEL).strip()
+    base_payload: dict[str, Any] = {
+        "room_name": room_name,
+        "model": model,
+        "provider": "gemini-vertex",
+        "project": project,
+        "location": location,
+        "vtid": VTID,
+        "code_version": code_version,
+        "prompt_len": len(CANARY_PROMPT),
+    }
+
+    # Gate 1: google-genai SDK not installed → typed failure. The lib
+    # ships as a transitive dep of livekit-plugins-google in
+    # requirements.txt, but this guard exists so import-time smoke
+    # checks + non-prod environments never crash.
+    try:
+        from google import genai  # type: ignore[import-not-found]
+    except ImportError as exc:
+        logger.warning("L2.2b.2: google-genai SDK not installed: %s", exc)
+        await oasis.emit(
+            topic=TOPIC_AGENT_MODEL_REQUEST_FAILED,
+            payload=dict(
+                base_payload,
+                reason="genai_sdk_not_installed",
+                error=str(exc),
+            ),
+            vtid=VTID,
+        )
+        return {"ok": False, "reason": "genai_sdk_not_installed"}
+
+    await oasis.emit(
+        topic=TOPIC_AGENT_MODEL_REQUEST_STARTED,
+        payload=dict(base_payload, phase="started"),
+        vtid=VTID,
+    )
+
+    started_at = time.monotonic()
+    try:
+        client = genai.Client(vertexai=True, project=project, location=location)
+    except Exception as exc:  # noqa: BLE001
+        latency_ms = int((time.monotonic() - started_at) * 1000)
+        logger.warning(
+            "L2.2b.2: Gemini client init failed: type=%s err=%s",
+            type(exc).__name__,
+            exc,
+        )
+        await oasis.emit(
+            topic=TOPIC_AGENT_MODEL_REQUEST_FAILED,
+            payload=dict(
+                base_payload,
+                reason="vertex_client_init_error",
+                latency_ms=latency_ms,
+                error=str(exc),
+                error_type=type(exc).__name__,
+            ),
+            vtid=VTID,
+        )
+        return {"ok": False, "reason": "vertex_client_init_error", "latency_ms": latency_ms}
+
+    try:
+        # `generate_content` may be sync; wrap in `asyncio.to_thread` so
+        # we don't block the asyncio loop, AND wrap in `wait_for` so the
+        # canary fails loud at 15s rather than hanging.
+        response = await asyncio.wait_for(
+            asyncio.to_thread(
+                client.models.generate_content,
+                model=model,
+                contents=CANARY_PROMPT,
+            ),
+            timeout=MODEL_TIMEOUT_S,
+        )
+    except asyncio.TimeoutError:
+        latency_ms = int((time.monotonic() - started_at) * 1000)
+        logger.warning("L2.2b.2: Gemini call timed out after %dms", latency_ms)
+        await oasis.emit(
+            topic=TOPIC_AGENT_MODEL_REQUEST_FAILED,
+            payload=dict(
+                base_payload,
+                reason="timeout",
+                latency_ms=latency_ms,
+                error=f"Gemini call exceeded {MODEL_TIMEOUT_S}s",
+            ),
+            vtid=VTID,
+        )
+        return {"ok": False, "reason": "timeout", "latency_ms": latency_ms}
+    except Exception as exc:  # noqa: BLE001
+        latency_ms = int((time.monotonic() - started_at) * 1000)
+        logger.warning(
+            "L2.2b.2: Gemini call failed: type=%s err=%s",
+            type(exc).__name__,
+            exc,
+        )
+        await oasis.emit(
+            topic=TOPIC_AGENT_MODEL_REQUEST_FAILED,
+            payload=dict(
+                base_payload,
+                reason="vertex_api_error",
+                latency_ms=latency_ms,
+                error=str(exc),
+                error_type=type(exc).__name__,
+            ),
+            vtid=VTID,
+        )
+        return {"ok": False, "reason": "vertex_api_error", "latency_ms": latency_ms}
+
+    latency_ms = int((time.monotonic() - started_at) * 1000)
+    # Best-effort extract of the response text. google-genai returns
+    # responses with a `.text` accessor; defensive against shape changes.
+    response_text = ""
+    try:
+        text_attr = getattr(response, "text", None)
+        if isinstance(text_attr, str):
+            response_text = text_attr
+        else:
+            # Fall back to walking candidates → content → parts.
+            candidates = getattr(response, "candidates", None) or []
+            for cand in candidates:
+                content = getattr(cand, "content", None)
+                parts = getattr(content, "parts", None) or []
+                for part in parts:
+                    t = getattr(part, "text", None)
+                    if isinstance(t, str):
+                        response_text += t
+    except Exception:  # noqa: BLE001
+        response_text = ""
+
+    await oasis.emit(
+        topic=TOPIC_AGENT_MODEL_REQUEST_SUCCEEDED,
+        payload=dict(
+            base_payload,
+            phase="succeeded",
+            latency_ms=latency_ms,
+            response_len=len(response_text),
+            response_preview=response_text[:200],
+        ),
+        vtid=VTID,
+    )
+    return {
+        "ok": True,
+        "response_text": response_text,
+        "latency_ms": latency_ms,
+        "model": model,
+        "provider": "gemini-vertex",
+    }
+
+
+def text_only_mode_enabled(env: dict[str, str] | None = None) -> bool:
+    """Read `ORB_AGENT_TEXT_ONLY` env flag. Defaults to True during the
+    L2.2b.2 phase so the agent never tries to build the STT/TTS cascade
+    against missing Deepgram/Cartesia secrets."""
+    src = env if env is not None else os.environ
+    raw = (src.get("ORB_AGENT_TEXT_ONLY") or "true").strip().lower()
+    return raw in ("true", "1", "yes")

--- a/services/agents/orb-agent/tests/test_smoke.py
+++ b/services/agents/orb-agent/tests/test_smoke.py
@@ -107,6 +107,124 @@ def test_l22b1_session_wires_lifecycle_topics() -> None:
         assert topic_const in session_src, f"session.py is missing {topic_const}"
 
 
+def test_l22b2_model_request_topics() -> None:
+    """L2.2b.2 (VTID-02990): the 3 model_request_* topics MUST exist as
+    module-level string literals and MUST share the `orb.livekit.agent.*`
+    prefix so the gateway's POST /api/v1/oasis/emit allowlist accepts
+    them. Strings MUST match the gateway-side CicdEventType union."""
+    from src.orb_agent.oasis import (
+        TOPIC_AGENT_MODEL_REQUEST_FAILED,
+        TOPIC_AGENT_MODEL_REQUEST_STARTED,
+        TOPIC_AGENT_MODEL_REQUEST_SUCCEEDED,
+    )
+
+    assert TOPIC_AGENT_MODEL_REQUEST_STARTED == "orb.livekit.agent.model_request_started"
+    assert TOPIC_AGENT_MODEL_REQUEST_SUCCEEDED == "orb.livekit.agent.model_request_succeeded"
+    assert TOPIC_AGENT_MODEL_REQUEST_FAILED == "orb.livekit.agent.model_request_failed"
+    for topic in [
+        TOPIC_AGENT_MODEL_REQUEST_STARTED,
+        TOPIC_AGENT_MODEL_REQUEST_SUCCEEDED,
+        TOPIC_AGENT_MODEL_REQUEST_FAILED,
+    ]:
+        assert topic.startswith("orb.livekit.agent."), topic
+
+
+def test_l22b2_session_wires_text_only_loop() -> None:
+    """session.py must import + branch on `text_only_mode_enabled` so the
+    Anthropic self-test runs INSTEAD of the cascade when the flag is on.
+    Structural / grep-style assertion — no livekit-agents SDK is invoked."""
+    import pathlib
+
+    session_src = (
+        pathlib.Path(__file__).resolve().parent.parent
+        / "src" / "orb_agent" / "session.py"
+    ).read_text(encoding="utf-8")
+    assert "from .text_only_loop import" in session_src
+    assert "text_only_mode_enabled" in session_src
+    assert "run_text_only_self_test" in session_src
+
+
+def test_l22b2_text_only_mode_flag_parsing() -> None:
+    """L2.2b.2: `text_only_mode_enabled()` is the env-flag reader. Default
+    is True during the L2.2b.2 phase so the agent never tries to build the
+    full STT/TTS cascade against missing Deepgram/Cartesia secrets."""
+    from src.orb_agent.text_only_loop import text_only_mode_enabled
+
+    # Default ON (no env set).
+    assert text_only_mode_enabled(env={}) is True
+
+    # Truthy variants ON.
+    for v in ["true", "True", "TRUE", "1", "yes", "  true  "]:
+        assert text_only_mode_enabled(env={"ORB_AGENT_TEXT_ONLY": v}) is True, v
+
+    # Explicit OFF (anything other than truthy variants).
+    for v in ["false", "False", "0", "no", "off", ""]:
+        assert (
+            text_only_mode_enabled(env={"ORB_AGENT_TEXT_ONLY": v}) is False
+        ), v
+
+
+def test_l22b2_self_test_genai_missing_emits_typed_failure() -> None:
+    """L2.2b.2: `run_text_only_self_test` MUST emit a typed
+    `model_request_failed` event with `reason='genai_sdk_not_installed'`
+    when the `google-genai` SDK is unavailable, NOT raise an exception.
+    Production-safe default: the agent stays in the room, telemetry
+    shows the cause, no crash.
+
+    Strategy: insert `None` into sys.modules for `google.genai` so the
+    in-function `from google import genai` lookup raises ImportError.
+    """
+    import asyncio
+    import sys
+
+    # Stash + sabotage the import so the test is hermetic regardless of
+    # whether google-genai is installed in the test env.
+    saved_genai = sys.modules.get("google.genai")
+    saved_google = sys.modules.get("google")
+    sys.modules["google.genai"] = None  # type: ignore[assignment]
+    # If `google` package isn't already imported, leaving it absent makes
+    # `from google import genai` raise ImportError on the parent.
+    try:
+        from src.orb_agent.text_only_loop import run_text_only_self_test
+
+        captured: list[dict] = []
+
+        class _StubOasis:
+            async def emit(self, *, topic: str, payload: dict, vtid: str) -> None:
+                captured.append({"topic": topic, "payload": payload, "vtid": vtid})
+
+        loop = asyncio.new_event_loop()
+        try:
+            result = loop.run_until_complete(
+                run_text_only_self_test(
+                    oasis=_StubOasis(),  # type: ignore[arg-type]
+                    room_name="test-room",
+                    code_version="test-version",
+                )
+            )
+        finally:
+            loop.close()
+
+        assert result["ok"] is False
+        assert result["reason"] == "genai_sdk_not_installed"
+        # Exactly ONE event fired: the failure. No started/succeeded.
+        assert len(captured) == 1, captured
+        assert captured[0]["topic"] == "orb.livekit.agent.model_request_failed"
+        assert captured[0]["payload"]["reason"] == "genai_sdk_not_installed"
+        assert captured[0]["payload"]["room_name"] == "test-room"
+        assert captured[0]["payload"]["provider"] == "gemini-vertex"
+        assert captured[0]["vtid"] == "VTID-02990"
+    finally:
+        # Restore sys.modules so we don't poison sibling tests.
+        if saved_genai is not None:
+            sys.modules["google.genai"] = saved_genai
+        else:
+            sys.modules.pop("google.genai", None)
+        if saved_google is None:
+            sys.modules.pop("google", None)
+
+
+
 def test_instructions_signatures() -> None:
     """The signatures of build_live / build_anonymous match the parity spec."""
     import inspect

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -551,6 +551,16 @@ export type CicdEventType =
   | 'orb.livekit.agent.room_join_succeeded'
   | 'orb.livekit.agent.room_join_failed'
   | 'orb.livekit.agent.disconnected'
+  // L2.2b.2 (VTID-02990): Gemini-via-Vertex text/model loop — proves the
+  // agent can reach a model from canary room context using Cloud Run's
+  // default service account (ADC, no API key). Emitted by the orb-agent's
+  // text-only self-test path (`ORB_AGENT_TEXT_ONLY=true`). No STT/TTS yet
+  // — that's L2.2b.3. Failure reason (e.g. `genai_sdk_not_installed`,
+  // `vertex_client_init_error`, `vertex_api_error`, `timeout`) is carried
+  // in the payload.
+  | 'orb.livekit.agent.model_request_started'
+  | 'orb.livekit.agent.model_request_succeeded'
+  | 'orb.livekit.agent.model_request_failed'
   // VTID-DIAG: Pipeline diagnostics
   | 'orb.live.diag'
   // VTID-FALLBACK: Chat-TTS fallback events


### PR DESCRIPTION
## Summary

Proves the **agent/model boundary** works from canary room context using **Cloud Run's default service account (Vertex ADC)** — no API key required. When ``ORB_AGENT_TEXT_ONLY=true`` (default for this phase), the agent skips the full STT/LLM/TTS cascade build and runs a single Gemini round-trip self-test on dispatch, emitting 3 new lifecycle events.

**Vertex production path: untouched.** ``voice.livekit_agent_enabled`` remains false. NO user routed to LiveKit.

## Why Gemini (not Anthropic)

The gateway's Vertex pipeline already uses Google ADC via Cloud Run's default service account — the same auth path is available to the agent service. **No new secrets in Secret Manager.** Operationally cheaper than Anthropic for the canary proof. L2.2b.3+ may add Anthropic as an alternate provider; the boundary in ``text_only_loop.py`` makes that drop-in.

## Changes

**``.github/workflows/DEPLOY-ORB-AGENT.yml``**:
- Adds ``ORB_AGENT_TEXT_ONLY=true`` to ``--set-env-vars``.
- Normalizes ``VERTEX_AI_LOCATION`` from ``global`` → ``us-central1`` (Gemini doesn't accept ``global``).
- **NO new secrets mounted.** ADC handles Vertex auth.

**``services/gateway/src/types/cicd.ts``**: adds 3 ``model_request_*`` event types.

**``services/agents/orb-agent/src/orb_agent/oasis.py``**: 3 topic constants matching the gateway union.

**``services/agents/orb-agent/src/orb_agent/text_only_loop.py`` (NEW)**:
- ``run_text_only_self_test()``:
  1. Reads ``GOOGLE_CLOUD_PROJECT`` + ``VERTEX_AI_LOCATION`` (defaults: ``lovable-vitana-vers1``, ``us-central1``).
  2. Imports ``google.genai`` (transitive dep of ``livekit-plugins-google``). If unavailable → typed failure with reason ``genai_sdk_not_installed``.
  3. Emits ``model_request_started``.
  4. Constructs ``genai.Client(vertexai=True, project, location)``. On init failure → typed ``vertex_client_init_error``.
  5. Calls ``client.models.generate_content(model, contents)`` via ``asyncio.to_thread`` at 15s timeout.
  6. Success → ``model_request_succeeded`` with latency_ms + response_len + response_preview.
  7. Timeout → ``model_request_failed`` reason ``timeout``.
  8. Other exception → ``model_request_failed`` reason ``vertex_api_error``.
  9. NEVER raises.
- Default model: ``gemini-2.5-flash-lite``. Override via ``ORB_AGENT_L22B2_MODEL`` env.

**``services/agents/orb-agent/src/orb_agent/session.py``**: after ``room_join_succeeded`` (L2.2b.1), branches on ``text_only_mode_enabled()``. When true: runs the self-test once, leaves the room open until SFU disconnects. Skips the cascade entirely.

## Tests

- **Gateway TypeScript**: ``tsc --noEmit`` clean.
- **Gateway oasis-emit.test.ts**: 16/16 green (unchanged).
- **4 new agent smoke tests**:
  - 3 constants exist + ``orb.livekit.agent.*`` prefix.
  - session.py imports + branches on the new module.
  - env-flag parser default-on + truthy/falsy variants.
  - hermetic asyncio test that sabotages ``google.genai`` import via ``sys.modules`` and confirms typed failure event.

## Acceptance vs the brief

| # | Criterion | Status |
|---|---|---|
| 1 | ``anthropic_configured=true`` in health | superseded — agent uses Gemini via Vertex ADC. Boundary proven via 3 OASIS events instead. |
| 2 | Agent can call a model from canary room context | ✓ ``run_text_only_self_test`` calls ``google.genai`` with Vertex ADC. |
| 3 | Agent emits ``model_request_started`` / ``succeeded`` / ``failed`` | ✓ all 3 wired. |
| 4 | No user routed to LiveKit voice yet | ✓ ``voice.livekit_agent_enabled`` remains false. |
| 5 | ``voice.livekit_agent_enabled`` stays false | ✓ not flipped by this PR. |
| 6 | Vertex production default | ✓ no orb-live.ts touched. |

## What this does NOT include

- No mic STT (Deepgram) — L2.2b.3.
- No TTS audio output (Cartesia) — L2.2b.3.
- No real voice conversation — L2.2b.3.
- No data-channel user-prompt path. The self-test runs once on dispatch with a fixed canary prompt.

🤖 Generated with [Claude Code](https://claude.com/claude-code)