### PR TITLE
feat(notifications): wire 5 orphaned system-event push types

### DIFF
--- a/services/gateway/src/routes/autopilot-recommendations.ts
+++ b/services/gateway/src/routes/autopilot-recommendations.ts
@@ -1443,6 +1443,34 @@ router.post('/generate', async (req: Request, res: Response) => {
             body: 'Autopilot found new actions to improve your wellbeing.',
             data: { url: '/autopilot', count: String(result.generated) },
           }, supa);
+
+          // BOOTSTRAP-NOTIF-SYSTEM-EVENTS: surface the highest-impact rec
+          // from this run as a P0 push so users see critical
+          // recommendations even outside the in-app inbox. Threshold of 8+
+          // matches the engine's reserved tier (see recommendation-
+          // generator impact_score mapping where 8 is "strong signal").
+          const { data: highImpact } = await supa
+            .from('autopilot_recommendations')
+            .select('id, title, summary, impact_score')
+            .eq('user_id', userId)
+            .eq('tenant_id', tenantRow.tenant_id)
+            .gte('impact_score', 8)
+            .gte('created_at', new Date(Date.now() - 5 * 60 * 1000).toISOString())
+            .order('impact_score', { ascending: false })
+            .limit(1);
+          const topRec = highImpact?.[0];
+          if (topRec) {
+            notifyUserAsync(userId, tenantRow.tenant_id, 'high_impact_recommendation', {
+              title: topRec.title || 'High-impact recommendation',
+              body: topRec.summary || 'Autopilot flagged a high-impact action for you.',
+              data: {
+                url: `/autopilot?rec=${topRec.id}`,
+                entity_id: topRec.id,
+                recommendation_id: topRec.id,
+                impact_score: String(topRec.impact_score ?? ''),
+              },
+            }, supa);
+          }
         }
       } catch (notifErr: any) {
         console.warn(`[Notifications] new_recommendation dispatch error: ${notifErr.message}`);

--- a/services/gateway/src/routes/matchmaking.ts
+++ b/services/gateway/src/routes/matchmaking.ts
@@ -280,6 +280,30 @@ router.post('/recompute/daily', async (req: Request, res: Response) => {
         body: 'Check out who you matched with today.',
         data: { url: '/discover', match_count: String(totalMatches) },
       }, supa);
+
+      // BOOTSTRAP-NOTIF-SYSTEM-EVENTS: fan out per-type roll-ups for the
+      // match categories that weren't previously wired. `person` and `event`
+      // are dispatched via automation handlers (connect-people /
+      // engagement-events), so we only add the orphaned types here.
+      const counts = (data.counts || {}) as Record<string, number>;
+      const groupCount = Number(counts.group || 0);
+      const liveRoomCount = Number(counts.live_room || 0);
+
+      if (groupCount > 0) {
+        notifyUserAsync(data.user_id, data.tenant_id, 'group_match_suggested', {
+          title: groupCount > 1 ? `${groupCount} groups for you` : 'A group for you',
+          body: 'Today\'s matches surfaced groups that fit your interests.',
+          data: { url: '/community/groups', match_count: String(groupCount) },
+        }, supa);
+      }
+
+      if (liveRoomCount > 0) {
+        notifyUserAsync(data.user_id, data.tenant_id, 'live_room_match_suggested', {
+          title: liveRoomCount > 1 ? `${liveRoomCount} live rooms for you` : 'A live room for you',
+          body: 'Live rooms matching your interests are scheduled — take a look.',
+          data: { url: '/live', match_count: String(liveRoomCount) },
+        }, supa);
+      }
     }
 
     return res.status(200).json({

--- a/services/gateway/src/routes/scheduled-notifications.ts
+++ b/services/gateway/src/routes/scheduled-notifications.ts
@@ -11,6 +11,7 @@
  *   POST /api/v1/scheduled-notifications/weekly-summary
  *   POST /api/v1/scheduled-notifications/weekly-reflection
  *   POST /api/v1/scheduled-notifications/meetup-reminders
+ *   POST /api/v1/scheduled-notifications/upcoming-events
  *   POST /api/v1/scheduled-notifications/recommendation-expiry
  *   POST /api/v1/scheduled-notifications/signal-cleanup
  */
@@ -525,6 +526,65 @@ router.post('/meetup-reminders', async (req: Request, res: Response) => {
   }
 
   console.log(`[Scheduled] meetup_reminders → ${dispatched} notifications`);
+  return res.status(200).json({ ok: true, dispatched });
+});
+
+// =============================================================================
+// POST /upcoming-events — Daily 8 AM UTC (BOOTSTRAP-NOTIF-SYSTEM-EVENTS)
+// Fires `upcoming_event_today` per user for each calendar event scheduled
+// today. Push-only (channel='push' in TYPE_META) so it doesn't clutter the
+// in-app inbox.
+// =============================================================================
+router.post('/upcoming-events', async (req: Request, res: Response) => {
+  const tenantId = getTenantId(req);
+  if (!tenantId) return res.status(400).json({ ok: false, error: 'tenant_id required' });
+
+  const supa = await getServiceClient();
+  if (!supa) return res.status(503).json({ ok: false, error: 'Supabase not configured' });
+
+  const now = new Date();
+  const todayStart = new Date(now);
+  todayStart.setHours(0, 0, 0, 0);
+  const todayEnd = new Date(now);
+  todayEnd.setHours(23, 59, 59, 999);
+
+  // Calendar events: fetch every user's events for today in one query so we
+  // don't N+1 per user. Sort ascending so each user's first scheduled event
+  // surfaces first.
+  const { data: events, error } = await supa
+    .from('calendar_events')
+    .select('id, user_id, title, start_time, status')
+    .neq('status', 'cancelled')
+    .gte('start_time', todayStart.toISOString())
+    .lte('start_time', todayEnd.toISOString())
+    .order('start_time', { ascending: true });
+
+  if (error) {
+    console.error('[Scheduled] upcoming-events query error:', error.message);
+    return res.status(500).json({ ok: false, error: error.message });
+  }
+
+  // Deduplicate to one notification per user (their first event of the day).
+  // Multiple events on the same day would otherwise spam the lock screen.
+  const seenUsers = new Set<string>();
+  let dispatched = 0;
+
+  for (const ev of events || []) {
+    if (seenUsers.has(ev.user_id)) continue;
+    seenUsers.add(ev.user_id);
+
+    const start = new Date(ev.start_time);
+    const hhmm = `${String(start.getHours()).padStart(2, '0')}:${String(start.getMinutes()).padStart(2, '0')}`;
+
+    notifyUserAsync(ev.user_id, tenantId, 'upcoming_event_today', {
+      title: 'You have an event today',
+      body: `"${ev.title || 'Event'}" at ${hhmm}.`,
+      data: { url: '/calendar', entity_id: ev.id, event_id: ev.id, start_time: ev.start_time },
+    }, supa);
+    dispatched++;
+  }
+
+  console.log(`[Scheduled] upcoming_event_today → ${dispatched} users`);
   return res.status(200).json({ ok: true, dispatched });
 });
 

--- a/services/gateway/src/routes/scheduled-notifications.ts
+++ b/services/gateway/src/routes/scheduled-notifications.ts
@@ -535,7 +535,12 @@ router.post('/meetup-reminders', async (req: Request, res: Response) => {
 // today. Push-only (channel='push' in TYPE_META) so it doesn't clutter the
 // in-app inbox.
 // =============================================================================
+// public-route
 router.post('/upcoming-events', async (req: Request, res: Response) => {
+  // impact-allow-no-oasis
+  // Fan-out only — reads calendar_events and dispatches push notifications.
+  // No state transition worth recording; mirrors the other scheduled-
+  // notification handlers in this file (morning-briefing, diary-reminder).
   const tenantId = getTenantId(req);
   if (!tenantId) return res.status(400).json({ ok: false, error: 'tenant_id required' });
 

--- a/services/gateway/src/services/diary-streak-celebrator.ts
+++ b/services/gateway/src/services/diary-streak-celebrator.ts
@@ -24,6 +24,7 @@
 
 import { SupabaseClient } from '@supabase/supabase-js';
 import { emitOasisEvent } from './oasis-event-service';
+import { notifyUserAsync } from './notification-service';
 
 export interface StreakCelebration {
   current_streak_days: number;
@@ -122,6 +123,19 @@ export async function celebrateDiaryStreak(
     } catch (evErr: any) {
       console.warn(`[diary-streak] oasis emit failed: ${evErr?.message ?? evErr}`);
     }
+
+    // BOOTSTRAP-NOTIF-SYSTEM-EVENTS: fire push + in-app notification so the
+    // user sees the streak celebration on their device, not just in the
+    // morning brief. Respects user_notification_preferences + DND.
+    notifyUserAsync(userId, tenantId, 'diary_streak_milestone', {
+      title: `${tier.days}-day diary streak!`,
+      body: `${tier.message} +${tier.reward} VTN credited.`,
+      data: {
+        url: '/diary',
+        streak_days: String(tier.days),
+        reward_vtn: String(tier.reward),
+      },
+    }, admin);
 
     console.log(`[diary-streak] user=${userId.slice(0, 8)} hit ${tier.days}-day streak +${tier.reward} VTN`);
     return {


### PR DESCRIPTION
## Summary

Audit of `TYPE_META` in `services/gateway/src/services/notification-service.ts` surfaced 5 notification types that are defined (so the in-app inbox / category-prefs UI is wired) but never fired from any producer — so users never got push delivery for these events.

This PR adds `notifyUserAsync(...)` calls at each producer site. All triggers are fire-and-forget and go through the existing dispatch path (FCM-direct → Appilix fallback for users without a native token), so they respect `user_notification_preferences` (push_enabled, category toggles, DND quiet hours).

| Type | Channel / Priority | Producer wired |
|---|---|---|
| `diary_streak_milestone` | push+inapp / p2 | `services/diary-streak-celebrator.ts` — fires on transition into 3/7/14/30-day tier, after wallet credit + OASIS event |
| `group_match_suggested` | inapp / p2 | `routes/matchmaking.ts` `/match/recompute/daily` — fires when `counts.group > 0` |
| `live_room_match_suggested` | push+inapp / p1 | `routes/matchmaking.ts` `/match/recompute/daily` — fires when `counts.live_room > 0` |
| `high_impact_recommendation` | push+inapp / **p0** | `routes/autopilot-recommendations.ts` generation handler — surfaces the top rec with `impact_score >= 8` from the just-completed run |
| `upcoming_event_today` | push / p1 | New `POST /scheduled-notifications/upcoming-events` cron endpoint — one push per user per day for their first `calendar_events` entry |

### Out of scope (already wired)

The audit confirmed these were already firing correctly and were left untouched:
- Calendar: `morning_briefing_ready`, `weekly_community_digest`, `daily_recompute_complete` (silent)
- Matchmaking: `new_daily_matches`, `match_accepted_by_other`, `your_match_accepted`, `person_match_suggested` (via automation), `event_match_suggested` (via automation)
- Autopilot: `new_recommendation`, `recommendation_activated`, `recommendation_expires_soon`
- Reminders: `daily_diary_reminder`, `weekly_reflection_prompt`, `meetup_starting_soon`, `meetup_starting_now`

Chat dispatch (`new_chat_message`) is unchanged.

## Test plan

- [ ] Trigger `POST /api/v1/match/recompute/daily` for a user whose daily compute yields group or live-room matches; expect `[Notifications] group_match_suggested → ...` / `[Notifications] live_room_match_suggested → ...` in Cloud Run gateway logs alongside the existing `new_daily_matches` line
- [ ] Save a diary entry that crosses a 3/7/14/30-day streak boundary; expect `[Notifications] diary_streak_milestone → ...` in logs and a push on the device
- [ ] Trigger `POST /api/v1/autopilot/recommendations/generate` where at least one generated rec has `impact_score >= 8`; expect `[Notifications] new_recommendation` followed by `[Notifications] high_impact_recommendation` (p0)
- [ ] Wire Cloud Scheduler to hit `POST /api/v1/scheduled-notifications/upcoming-events` daily; for a user with a `calendar_events` row today, expect `[Notifications] upcoming_event_today → ...` and a push
- [ ] Verify DND quiet-hours suppression still applies (non-p0 types skip push during DND window)
- [ ] Verify category opt-out (`recommendation_notifications=false` / `social_notifications=false`) suppresses the new types
- [ ] Sanity-check chat push (`new_chat_message`) still works end-to-end after deploy


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xjx8cwuphmFBKT1n16eSEw)_