### PR TITLE
fix(orb-agent): mount GATEWAY_SERVICE_TOKEN secret on Cloud Run (VTID-02991)

### DIFF
--- a/.github/workflows/DEPLOY-ORB-AGENT.yml
+++ b/.github/workflows/DEPLOY-ORB-AGENT.yml
@@ -90,7 +90,7 @@ jobs:
             --ingress=all \
             --allow-unauthenticated \
             --labels=vtid=vtid-livekit-foundation,vt_layer=aicor,vt_module=voice \
-            --update-secrets=LIVEKIT_URL=LIVEKIT_URL:latest,LIVEKIT_API_KEY=LIVEKIT_API_KEY:latest,LIVEKIT_API_SECRET=LIVEKIT_API_SECRET:latest \
+            --update-secrets=LIVEKIT_URL=LIVEKIT_URL:latest,LIVEKIT_API_KEY=LIVEKIT_API_KEY:latest,LIVEKIT_API_SECRET=LIVEKIT_API_SECRET:latest,GATEWAY_SERVICE_TOKEN=GATEWAY_SERVICE_TOKEN:latest \
             --set-env-vars=GATEWAY_URL=https://gateway-q74ibpv6ia-uc.a.run.app,AGENT_LOG_LEVEL=INFO,AGENT_ENABLE_WORKER=1,GOOGLE_CLOUD_PROJECT=lovable-vitana-vers1,VERTEX_AI_LOCATION=us-central1,ORB_AGENT_TEXT_ONLY=true
 
       - name: Delete prior revisions (force only-latest worker connects to LiveKit)


### PR DESCRIPTION
## Summary
- DEPLOY-ORB-AGENT.yml's `--update-secrets` list was missing `GATEWAY_SERVICE_TOKEN`, so `vitana-orb-agent` runs with that env var empty.
- Gateway side is already wired (revision `gateway-03236-wgl` has the secret mounted; `/api/v1/oasis/emit` from VTID-02987 validates `Bearer GATEWAY_SERVICE_TOKEN`).
- Without this fix, the agent's `OasisEmitter` (PR-B's loud-failure path) logs `oasis emit skipped (token_missing)` on every emit and **zero** `vtid.live.session.*` / `vtid.live.stall_detected` / `orb.livekit.agent.*` events land in `oasis_events`.

## Change
One-liner: add `GATEWAY_SERVICE_TOKEN=GATEWAY_SERVICE_TOKEN:latest` to the existing `--update-secrets` list. The Secret Manager entry already exists.

## Test plan
- [ ] Merge → wait for `DEPLOY-ORB-AGENT.yml` to complete.
- [ ] Start a LiveKit conversation via the Test Bench.
- [ ] Cloud Run logs for `vitana-orb-agent`: confirm the `OasisEmitter: GATEWAY_SERVICE_TOKEN not set` WARN at boot is **gone**.
- [ ] Supabase: `SELECT topic, created_at FROM oasis_events WHERE topic IN ('vtid.live.session.start','vtid.live.session.stop','vtid.live.stall_detected','orb.livekit.agent.starting','orb.livekit.agent.disconnected') ORDER BY created_at DESC LIMIT 10` — confirm rows land.
- [ ] Voice LAB → Orb Live tab: confirm LiveKit session appears with `transport: livekit` and a populated `failure_class` (or null if healthy).

🤖 Generated with [Claude Code](https://claude.com/claude-code)