### PR TITLE
fix(gateway): allow vtid.live.* prefix in /api/v1/oasis/emit (VTID-02992)

### DIFF
--- a/services/gateway/src/routes/oasis-emit.ts
+++ b/services/gateway/src/routes/oasis-emit.ts
@@ -11,9 +11,11 @@
  *
  * Hard rules:
  *   - NO unauthenticated access. The route is service+admin only.
- *   - Topic prefix allowlist: ONLY `orb.livekit.` and `livekit.` topics are
- *     accepted. Arbitrary topics would let the agent forge events from other
- *     surfaces (gateway, autopilot, etc.) — refuse them.
+ *   - Topic prefix allowlist: ONLY `orb.livekit.`, `livekit.`, and
+ *     `vtid.live.` (VTID-02992: matches Vertex's vtid.live.session.*
+ *     namespace so the agent's session-lifecycle emits land in the same
+ *     Voice Lab query) topics are accepted. Arbitrary topics would let
+ *     the agent forge events from other surfaces — refuse them.
  *   - Body size cap (16 KiB) — telemetry payloads are tiny by design.
  *   - The route delegates to `emitOasisEvent` (the same function the gateway
  *     uses internally), so OASIS persistence stays unified.
@@ -41,7 +43,15 @@ const VTID = 'VTID-02987';
 const MAX_BODY_BYTES = 16 * 1024;
 
 // Allowed topic prefixes — refuse everything else.
-const ALLOWED_PREFIXES = ['orb.livekit.', 'livekit.'] as const;
+// VTID-02992: `vtid.live.` added so the orb-agent's session-lifecycle
+// emits from VTID-02986 (vtid.live.session.start/stop +
+// vtid.live.stall_detected) reach oasis_events. Voice Lab's
+// /api/v1/voice-lab/live/sessions query filters on the same prefix to
+// surface LiveKit sessions next to Vertex's vtid.live.session.* rows in
+// the same panel. Without this entry the topics 400 here and silently
+// disappear — Voice Lab stays empty for LiveKit, and the failure
+// classifier sees no session-stop metrics.
+const ALLOWED_PREFIXES = ['orb.livekit.', 'livekit.', 'vtid.live.'] as const;
 
 function isAllowedTopic(topic: unknown): topic is string {
   if (typeof topic !== 'string') return false;

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -501,6 +501,10 @@ export type CicdEventType =
   | 'orb.live.connection_failed'
   // VTID-WATCHDOG: ORB stall detection events
   | 'orb.live.stall_detected'
+  // VTID-02986: LiveKit (orb-agent) stall detection, namespaced under
+  // vtid.live.* so Voice Lab's /api/v1/voice-lab/live/sessions query
+  // surfaces it next to Vertex's stall events.
+  | 'vtid.live.stall_detected'
   // VTID-TOOLGUARD: Tool loop guard activation
   | 'orb.live.tool_loop_guard_activated'
   // BOOTSTRAP-ORB-HOTFIX-1: pre-greeting latency gauge (time from session-start

--- a/services/gateway/test/routes/oasis-emit.test.ts
+++ b/services/gateway/test/routes/oasis-emit.test.ts
@@ -139,6 +139,21 @@ describe('POST /api/v1/oasis/emit — topic allowlist', () => {
     expect(mockEmit).toHaveBeenCalledTimes(1);
   });
 
+  // VTID-02992: vtid.live.* matches Vertex's session-lifecycle namespace,
+  // which Voice Lab's /api/v1/voice-lab/live/sessions query already filters
+  // on. The orb-agent (VTID-02986) emits vtid.live.session.start/stop and
+  // vtid.live.stall_detected through this route — they must NOT 400.
+  it('3c. service token + `vtid.live.*` topic also allowed (VTID-02992)', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/oasis/emit')
+      .set('Authorization', 'Bearer svc-secret-token-xyz')
+      .send({ topic: 'vtid.live.session.start', payload: { transport: 'livekit' } });
+    expect(res.status).toBe(200);
+    expect(mockEmit).toHaveBeenCalledTimes(1);
+    expect(mockEmit.mock.calls[0][0].type).toBe('vtid.live.session.start');
+  });
+
   it('4. service token + disallowed topic (orb.live.*) → 400, NOT emitted', async () => {
     const app = buildApp();
     const res = await request(app)


### PR DESCRIPTION
## Why
PR-B (VTID-02986) renamed orb-agent's session-lifecycle topics to `vtid.live.session.start/stop` + `vtid.live.stall_detected` to match Voice Lab's query filter. But the gateway's `/api/v1/oasis/emit` route allowlist (added in VTID-02987) only accepted `orb.livekit.` and `livekit.` prefixes, so every `vtid.live.*` emit returned 400.

After PR-C (#2121) mounted the service token on vitana-orb-agent, `orb.livekit.agent.*` events started landing in oasis_events (10:23:39 UTC). But `vtid.live.session.*` rows are still empty — the failure classifier has no data, Voice Lab shows nothing for LiveKit.

## What
- `oasis-emit.ts`: add `vtid.live.` to `ALLOWED_PREFIXES`.
- `cicd.ts`: add `vtid.live.stall_detected` to `CicdEventType` union (session.start/stop already present).
- `oasis-emit.test.ts`: new test 3c asserts the `vtid.live.*` path is accepted.

All 17 oasis-emit tests pass.

## Test plan
- [ ] Merge → gateway redeploy.
- [ ] Wait for next LiveKit session.
- [ ] `SELECT topic, vtid, created_at FROM oasis_events WHERE vtid='VTID-LIVEKIT-AGENT' ORDER BY created_at DESC LIMIT 10` — confirm `vtid.live.session.start/stop` rows present.
- [ ] Voice LAB → Orb Live: confirm LiveKit session appears with transport='livekit', counters populated, failure_class showing.

🤖 Generated with [Claude Code](https://claude.com/claude-code)