### PR TITLE
feat(notifications): register AP-0510 daily cron for upcoming_event_today

### DIFF
--- a/scripts/setup-cloud-scheduler.sh
+++ b/scripts/setup-cloud-scheduler.sh
@@ -62,6 +62,7 @@ JOBS=(
   "AP-0210|creator-digest|0 18 * * 0|Europe/Berlin"
   "AP-0305|trending-events|0 18 * * 0|Europe/Berlin"
   "AP-0604|wellness-check-in|0 10 * * 3|Europe/Berlin"
+  "AP-0510|upcoming-events-today|0 8 * * *|Europe/Berlin"
 )
 
 for JOB in "${JOBS[@]}"; do

--- a/services/gateway/src/services/automation-handlers/engagement-events.ts
+++ b/services/gateway/src/services/automation-handlers/engagement-events.ts
@@ -511,6 +511,39 @@ async function runMilestoneScanner(ctx: AutomationContext) {
 }
 
 // =============================================================================
+// AP-0510: Upcoming Events Today Push (BOOTSTRAP-NOTIF-SYSTEM-EVENTS)
+// Daily cron — delegates to /scheduled-notifications/upcoming-events which
+// dispatches the `upcoming_event_today` push for each user's first
+// calendar_events entry of the day.
+// =============================================================================
+
+async function runUpcomingEventsToday(ctx: AutomationContext) {
+  ctx.log('Upcoming events today — dispatching via scheduled-notifications');
+  const { tenantId } = ctx;
+
+  try {
+    const gatewayUrl = process.env.GATEWAY_INTERNAL_URL || `http://localhost:${process.env.PORT || 3000}`;
+    const resp = await fetch(`${gatewayUrl}/api/v1/scheduled-notifications/upcoming-events`, {
+      method: 'POST',
+      headers: { 'Content-Type': 'application/json' },
+      body: JSON.stringify({ tenant_id: tenantId }),
+    });
+
+    if (!resp.ok) {
+      ctx.log(`Upcoming events endpoint failed: ${resp.status}`);
+      return { usersAffected: 0, actionsTaken: 0 };
+    }
+
+    const result = await resp.json() as any;
+    ctx.log(`Upcoming events dispatched to ${result.dispatched || 0} users`);
+    return { usersAffected: result.dispatched || 0, actionsTaken: result.dispatched || 0 };
+  } catch (err: any) {
+    ctx.log(`Upcoming events error: ${err.message}`);
+    return { usersAffected: 0, actionsTaken: 0 };
+  }
+}
+
+// =============================================================================
 // AP-1000: Platform Operations
 // =============================================================================
 
@@ -546,6 +579,7 @@ export function registerEngagementEventsHandlers(): void {
   registerHandler('runWeeklyReflection', runWeeklyReflection);
   registerHandler('runConversationContinuityNudge', runConversationContinuityNudge);
   registerHandler('runMilestoneScanner', runMilestoneScanner);
+  registerHandler('runUpcomingEventsToday', runUpcomingEventsToday);
 
   // Platform Operations (AP-1000)
   registerHandler('runVtidLifecycle', runVtidLifecycle);

--- a/services/gateway/src/services/automation-registry.ts
+++ b/services/gateway/src/services/automation-registry.ts
@@ -387,6 +387,16 @@ const ENGAGEMENT_LOOPS: AutomationDefinition[] = [
     targetRoles: [...MEMBER_ROLES],
     handler: 'runMilestoneScanner',
   },
+  {
+    // BOOTSTRAP-NOTIF-SYSTEM-EVENTS: pairs with `upcoming_event_today`
+    // (channel='push' in TYPE_META). Fires once per user per day for their
+    // first calendar_events entry of the day.
+    id: 'AP-0510', name: 'Upcoming Events Today Push', domain: 'engagement-loops',
+    status: 'IMPLEMENTED', priority: 'P1', triggerType: 'cron',
+    triggerConfig: { cronExpression: '0 8 * * *' },
+    targetRoles: [...MEMBER_ROLES],
+    handler: 'runUpcomingEventsToday',
+  },
 ];
 
 // =============================================================================


### PR DESCRIPTION
## Summary

Companion to #2120. The `upcoming_event_today` push trigger exists end-to-end on the deployed gateway (verified via curl returning `200 {"ok":true,"dispatched":0}` against tenant `bc34a5ca-…`), but it needs a Cloud Scheduler entry to fire daily.

Following the canonical pattern used by sibling engagement-loops crons (AP-0501 morning briefing, AP-0502 weekly digest, AP-0505 diary reminder, AP-0506 weekly reflection):
1. Cloud Scheduler POSTs to `/api/v1/automations/cron/AP-0510`
2. The automation handler delegates to `/api/v1/scheduled-notifications/upcoming-events`

## Changes

- `services/gateway/src/services/automation-registry.ts` — register **AP-0510** "Upcoming Events Today Push", daily `0 8 * * *` Europe/Berlin, member roles
- `services/gateway/src/services/automation-handlers/engagement-events.ts` — `runUpcomingEventsToday` handler that POSTs to `/scheduled-notifications/upcoming-events` with the tenant_id (mirrors `runMorningBriefing` exactly)
- `scripts/setup-cloud-scheduler.sh` — add `AP-0510|upcoming-events-today|0 8 * * *|Europe/Berlin` entry so one `bash setup-cloud-scheduler.sh` run from Cloud Shell registers the new cron alongside the existing 10

## Test plan

- [ ] After merge + EXEC-DEPLOY, hit `POST /api/v1/automations/cron/AP-0510` with a tenant_id body — expect `[Notifications] upcoming_event_today → ...` for each user with a `calendar_events` row today
- [ ] Run `DEFAULT_TENANT_ID=<tenant> bash scripts/setup-cloud-scheduler.sh` from Cloud Shell — confirm `autopilot-upcoming-events-today` job appears in `gcloud scheduler jobs list --location=us-central1`
- [ ] Wait 24h or manually `gcloud scheduler jobs run autopilot-upcoming-events-today --location=us-central1` — confirm gateway logs show the dispatch line


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xjx8cwuphmFBKT1n16eSEw)_