### PR TITLE
feat(orb): L2.2b.3 — flip ORB_AGENT_TEXT_ONLY=false; agent runs all-Google cascade (VTID-02993)

### DIFF
--- a/.github/workflows/DEPLOY-ORB-AGENT.yml
+++ b/.github/workflows/DEPLOY-ORB-AGENT.yml
@@ -91,7 +91,7 @@ jobs:
             --allow-unauthenticated \
             --labels=vtid=vtid-livekit-foundation,vt_layer=aicor,vt_module=voice \
             --update-secrets=LIVEKIT_URL=LIVEKIT_URL:latest,LIVEKIT_API_KEY=LIVEKIT_API_KEY:latest,LIVEKIT_API_SECRET=LIVEKIT_API_SECRET:latest,GATEWAY_SERVICE_TOKEN=GATEWAY_SERVICE_TOKEN:latest \
-            --set-env-vars=GATEWAY_URL=https://gateway-q74ibpv6ia-uc.a.run.app,AGENT_LOG_LEVEL=INFO,AGENT_ENABLE_WORKER=1,GOOGLE_CLOUD_PROJECT=lovable-vitana-vers1,VERTEX_AI_LOCATION=us-central1,ORB_AGENT_TEXT_ONLY=true
+            --set-env-vars=GATEWAY_URL=https://gateway-q74ibpv6ia-uc.a.run.app,AGENT_LOG_LEVEL=INFO,AGENT_ENABLE_WORKER=1,GOOGLE_CLOUD_PROJECT=lovable-vitana-vers1,VERTEX_AI_LOCATION=us-central1,ORB_AGENT_TEXT_ONLY=false
 
       - name: Delete prior revisions (force only-latest worker connects to LiveKit)
         run: |


### PR DESCRIPTION
## Summary

**One-line change** in `.github/workflows/DEPLOY-ORB-AGENT.yml`: `ORB_AGENT_TEXT_ONLY` env var flips from `true` → `false`. Removes the L2.2b.2 text-only short-circuit so `agent_entrypoint` runs the existing cascade build + AgentSession instead.

**Vertex production path: untouched.** `voice.livekit_agent_enabled` remains false. NO user routed to LiveKit automatically; the LiveKit Test Bench admin page is the smoke surface.

## Why this works without new providers / new code

`agent_voice_configs` has **NO row** for `agent_id='vitana'` (confirmed via `GET /api/v1/orb/context-bootstrap?agent_id=vitana → voice_config: null`). When `voice_config=None`, `providers.build_cascade()` falls back to the hardcoded all-Google trio:

```python
stt_provider:  google_stt   → google.STT(model="latest_long", languages=[bcp47])
llm_provider:  google_llm   → google.LLM(vertexai=True, project, location)
tts_provider:  google_tts   → google.TTS(voice_name="en-US-Chirp3-HD-Aoede", ...)
```

All three plugins ship via `livekit-plugins-google` (already in `requirements.txt`) and authenticate via Cloud Run service-account ADC — the same auth path proven by L2.2b.2's Vertex Gemini self-test.

**Zero new providers. Zero new secrets. Zero frontend change.**

## Smoke plan (post-merge)

LiveKit Test Bench at `/command-hub/voice/livekit-test/`:
1. Open page (admin authenticated).
2. Click Connect → mints token → joins room → publishes mic.
3. Speak a short phrase.
4. Watch the on-screen log + OASIS events:
   - `orb.livekit.agent.room_join_succeeded` (existing L2.2b.1)
   - `livekit.session.start` (existing L2.2b.1, payload should now include cascade_summary with stt/llm/tts all present)
   - STT transcript event
   - LLM response generated
   - TTS audio published → frontend plays it back

## What this does NOT include

- No Deepgram or Cartesia. Hardcoded Google fallback handles STT/TTS.
- No frontend change. LiveKit Test Bench is pre-existing.
- No `voice.livekit_agent_enabled` flip. Only the admin Test Bench page exercises this cascade today.
- No agent_voice_configs seed row. The `voice_config=None` path is the production-safe default.

## Rollback

Single env-var flip back to `ORB_AGENT_TEXT_ONLY=true` + re-deploy → agent returns to L2.2b.2 self-test mode. No code rollback needed.

🤖 Generated with [Claude Code](https://claude.com/claude-code)