### PR TITLE
fix(test-bench): clone audio track for analyser — restore agent audio playback (VTID-02999)

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -36070,9 +36070,21 @@ function renderLivekitTestView() {
         var ctx = ensureAudioCtx();
         if (!ctx || !track) return;
         try {
-            var stream = track.mediaStream
-                || (track.mediaStreamTrack ? new MediaStream([track.mediaStreamTrack]) : null);
-            if (!stream) return;
+            // VTID-02999: clone the MediaStreamTrack before feeding it to Web
+            // Audio. `track.attach()` already put the original track on an
+            // <audio> element for playback; passing the SAME MediaStream to
+            // createMediaStreamSource diverts the audio into Web Audio's
+            // graph and silences the <audio> element (Web Audio "consumes"
+            // the stream). The analyser graph isn't connected to
+            // ctx.destination, so the diverted audio is dropped — that's
+            // why the operator hears nothing even though .play() succeeds
+            // and the agent has actually published audio. Cloning gives
+            // Web Audio its own independent copy of the audio frames so
+            // playback through the <audio> element keeps working.
+            var rawTrack = track.mediaStreamTrack;
+            if (!rawTrack || typeof rawTrack.clone !== 'function') return;
+            var cloned = rawTrack.clone();
+            var stream = new MediaStream([cloned]);
             var src = ctx.createMediaStreamSource(stream);
             var analyser = ctx.createAnalyser();
             analyser.fftSize = 512;

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -30,7 +30,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260504-vtid-02710-ios-ctx-keepalive"></script>
-  <script src="/command-hub/app.js?v=20260515-vtid-02997-audio-unlock"></script>
+  <script src="/command-hub/app.js?v=20260515-vtid-02999-meter-track-clone"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
 </body>


### PR DESCRIPTION
## Root cause

The agent IS speaking — `oasis_events` `agent-trace.phase=speech_created` fires every turn — but the operator hears nothing. The "AGENT SPEAKING" indicator added in PR #2126 (app.js:36069) calls `ctx.createMediaStreamSource()` on the **same** `MediaStream` that `track.attach()` just bound to a hidden `<audio>` element. Per Web Audio behavior, this diverts the audio into the AudioContext's graph and detaches it from the `<audio>` element. The analyser graph isn't wired to `ctx.destination`, so the audio is dropped on the floor.

PR #2127's audio-unlock (silent-buffer prime + `room.startAudio()` + force-play + always-visible "Enable audio" button) was a red herring: every one of those paths runs *before* the meter attach, so they appear to succeed. The mute happens a few lines later when `attachRemoteAudioMeter` pulls the stream into Web Audio.

## Fix

Clone the `MediaStreamTrack` before feeding it to `createMediaStreamSource`. Web Audio gets its own independent copy for the RMS analyser; the original track stays on the `<audio>` element and plays normally. Standard pattern from MDN's "Using the Web Audio API with WebRTC."

`attachLocalMicMeter` uses the same pattern but the local mic isn't played back to the user, so the original code there is fine — left unchanged.

## Test plan
- [ ] Merge → wait for EXEC-DEPLOY
- [ ] Open the LiveKit Test Bench, hard-reload to pick up the new bundle (verify URL ends with `?v=20260515-vtid-02999-meter-track-clone`)
- [ ] Click **Connect & Talk** → expect to hear the agent's greeting within ~2s
- [ ] Speak into the mic → expect a spoken response
- [ ] Verify the "AGENT SPEAKING" indicator still flips green/red on each agent turn
- [ ] Verify `oasis_events` still shows `agent-trace.phase=speech_created` (server-side TTS is unchanged)

🤖 Generated with [Claude Code](https://claude.com/claude-code)