### PR TITLE
revert PR #2128 + add gateway.vitanaland.com to orb-live ALLOWED_ORIGINS (VTID-03000, DEV-COMHU-03000)

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -36070,21 +36070,9 @@ function renderLivekitTestView() {
         var ctx = ensureAudioCtx();
         if (!ctx || !track) return;
         try {
-            // VTID-02999: clone the MediaStreamTrack before feeding it to Web
-            // Audio. `track.attach()` already put the original track on an
-            // <audio> element for playback; passing the SAME MediaStream to
-            // createMediaStreamSource diverts the audio into Web Audio's
-            // graph and silences the <audio> element (Web Audio "consumes"
-            // the stream). The analyser graph isn't connected to
-            // ctx.destination, so the diverted audio is dropped — that's
-            // why the operator hears nothing even though .play() succeeds
-            // and the agent has actually published audio. Cloning gives
-            // Web Audio its own independent copy of the audio frames so
-            // playback through the <audio> element keeps working.
-            var rawTrack = track.mediaStreamTrack;
-            if (!rawTrack || typeof rawTrack.clone !== 'function') return;
-            var cloned = rawTrack.clone();
-            var stream = new MediaStream([cloned]);
+            var stream = track.mediaStream
+                || (track.mediaStreamTrack ? new MediaStream([track.mediaStreamTrack]) : null);
+            if (!stream) return;
             var src = ctx.createMediaStreamSource(stream);
             var analyser = ctx.createAnalyser();
             analyser.fftSize = 512;

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -30,7 +30,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260504-vtid-02710-ios-ctx-keepalive"></script>
-  <script src="/command-hub/app.js?v=20260515-vtid-02999-meter-track-clone"></script>
+  <script src="/command-hub/app.js?v=20260515-vtid-02997-audio-unlock"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
 </body>

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -331,6 +331,11 @@ const ALLOWED_ORIGINS = [
   'https://id-preview--vitana-v1.lovable.app',
   'https://vitanaland.com',                            // Production custom domain (mobile app)
   'https://www.vitanaland.com',                        // Production custom domain (www)
+  // VTID-03000: gateway custom-domain origin. Without this, the production
+  // ORB widget on every command-hub page served from gateway.vitanaland.com
+  // gets 403 "Origin not allowed" on /orb/live/session/* — voice path
+  // completely broken for operators using the gateway custom domain.
+  'https://gateway.vitanaland.com',
   'http://localhost:8080',
   'http://localhost:8081',  // VTID-01225: Mobile dev server
   'http://localhost:3000',


### PR DESCRIPTION
Two narrow, independent fixes bundled.

## 1. Revert PR #2128 (track-clone)

PR #2128 cloned the remote audio track before feeding it to `attachRemoteAudioMeter()` — the theory was that `createMediaStreamSource` was diverting audio away from the `<audio>` element returned by `track.attach()`. The fix shipped, deployed, and made no audible difference. Reverting so the codebase stops accumulating dead patches on an unresolved bug.

The real LiveKit playback issue is still unknown. Need browser-side ground truth (DevTools `<audio>` element state + `chrome://webrtc-internals` inbound `audioLevel`) before another attempt.

## 2. Add `gateway.vitanaland.com` to orb-live `ALLOWED_ORIGINS`

Separately broken: the production Vertex ORB widget on every command-hub page served from `https://gateway.vitanaland.com` gets `403 Origin not allowed` on `POST /orb/live/session/start`. The allowlist in `services/gateway/src/routes/orb-live.ts` had `vitanaland.com`, `www.vitanaland.com`, and three Cloud Run direct URLs, but NOT the gateway custom-domain origin.

The gap predates today's #2125-#2128 chain (allowlist last touched by VTID-02914 / PR #2047). One-line addition restores voice for operators using the gateway custom domain.

## Test plan
- [ ] Merge → EXEC-DEPLOY
- [ ] Hard-reload `gateway.vitanaland.com/command-hub/*` → the production ORB widget should open a Vertex session without `403 Origin not allowed`
- [ ] LiveKit Test Bench: unchanged (the revert removes #2128's dead-code track-clone; the underlying playback bug is still open and unrelated to this PR)

🤖 Generated with [Claude Code](https://claude.com/claude-code)