### PR TITLE
fix(orb-agent): replace non-existent Gemini model name (VTID-03002)

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/providers.py
+++ b/services/agents/orb-agent/src/orb_agent/providers.py
@@ -227,7 +227,7 @@ def build_cascade(
         logger.warning("build_cascade: no voice_config — falling back to hardcoded Google cascade")
         voice_config = {
             "stt_provider": "google_stt",  "stt_model": "latest_long", "stt_options": {},
-            "llm_provider": "google_llm",  "llm_model": "gemini-3.1-flash-lite-preview", "llm_options": {},
+            "llm_provider": "google_llm",  "llm_model": "gemini-2.5-flash", "llm_options": {},
             "tts_provider": "google_tts",  "tts_model": "en-US-Chirp3-HD-Aoede", "tts_options": {},
         }
 
@@ -346,8 +346,27 @@ def _build_llm(provider: str | None, model: str | None, options: dict[str, Any],
             # access, so no extra secret needed.
             project = os.environ.get("GOOGLE_CLOUD_PROJECT", "lovable-vitana-vers1")
             location = os.environ.get("VERTEX_AI_LOCATION", "us-central1")
+            # VTID-03002: defensive remap. The previous hardcoded fallback
+            # AND the agent_voice_configs.orb-agent row both shipped with
+            # `gemini-3.1-flash-lite-preview` — a model name that does NOT
+            # exist on Vertex AI. The Gemini call returns nothing,
+            # session.generate_reply produces no audio, agent goes
+            # idle → thinking → listening without ever speaking. We
+            # explicitly remap any known-bad Gemini 3.x preview names to
+            # the current realtime default so the row doesn't need a
+            # migration to recover. The fallback below covers the
+            # voice_config=None branch.
+            _KNOWN_BAD_GEMINI = {"gemini-3.1-flash-lite-preview"}
+            _DEFAULT_GEMINI = "gemini-2.5-flash"
+            effective_model = model or _DEFAULT_GEMINI
+            if effective_model in _KNOWN_BAD_GEMINI:
+                notes.append(
+                    f"LLM provider 'google_llm': remapped non-existent model "
+                    f"'{effective_model}' → '{_DEFAULT_GEMINI}'"
+                )
+                effective_model = _DEFAULT_GEMINI
             return google.LLM(
-                model=model or "gemini-3.1-flash-lite-preview",
+                model=effective_model,
                 vertexai=True,
                 project=project,
                 location=location,


### PR DESCRIPTION
Root cause of "agent doesn't greet, doesn't respond" — pinpointed via VTID-03001 diagnostic.

## Evidence

The VTID-03001 diagnostic `session.say("LiveKit diagnostic test one two three")` plays clearly in the browser. TTS publish + WebRTC + browser playback all work end-to-end.

Trace after `diagnostic_say_after`:
```
speech_created                                 ← greeting attempt
agent_state_changed: thinking                  ← LLM invoked
agent_state_changed: listening                 ← back to listening, NO speaking
(no conversation_item_added with role=assistant)
```

The LLM produced zero output. Both the hardcoded fallback in `providers.py` AND the row in `agent_voice_configs` shipped with `gemini-3.1-flash-lite-preview` — a model name that does NOT exist on Vertex AI. The `livekit-plugins-google` LLM constructor accepts it without validation; the Vertex API returns empty/not-found at request time, the plugin swallows the error, and the agent silently fails every turn.

## Fix

Single chokepoint in `_build_llm`:

1. **Hardcoded fallback** (when `voice_config is None`): `gemini-3.1-flash-lite-preview` → `gemini-2.5-flash`
2. **Defensive remap**: any caller (including the DB row) passing `gemini-3.1-flash-lite-preview` gets remapped to `gemini-2.5-flash` with a cascade note. No DB migration required to recover.

`gemini-2.5-flash` is the current general-purpose realtime Gemini on Vertex AI — low latency, sufficient quality for conversational voice.

## Test plan
- [ ] Merge → DEPLOY-ORB-AGENT auto-fires
- [ ] LiveKit Test Bench: disconnect, reconnect
- [ ] Hear the VTID-03001 diagnostic phrase (unchanged)
- [ ] **Hear the greeting**: agent says "Hi [name]" within 1-2s after diagnostic
- [ ] Speak → hear the agent respond
- [ ] Verify trace shows `agent_state_changed: speaking` and `conversation_item_added` with `role=assistant, text_len>0`

After this is confirmed working, the VTID-03001 diagnostic patch will be removed in a follow-up PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)