### PR TITLE
feat(orb): L2.2b.4 — context-parity LITE: enrich /orb/context-bootstrap with decision-contract spine (VTID-03008)

### DIFF
--- a/services/gateway/src/routes/orb-livekit.ts
+++ b/services/gateway/src/routes/orb-livekit.ts
@@ -746,6 +746,49 @@ router.get(
       console.warn(`[${VTID}] buildClientContext failed: ${(exc as Error).message}`);
     }
 
+    // L2.2b.4 (VTID-03008): context-parity LITE. Compile the same
+    // `AssistantDecisionContext` the Vertex path renders into its
+    // system instruction (continuity / concept_mastery / journey_stage /
+    // pillar_momentum / interaction_style) and append the rendered
+    // section to bootstrap_context so the LiveKit agent's prompt
+    // inherits identical decision-contract intelligence. Anonymous
+    // sessions (userId/tenantId null) skip the compile entirely.
+    //
+    // Architectural rule (matches the L2.2b master design Section 2.5):
+    //   - Compile happens in the gateway, NOT in the agent.
+    //   - The renderer is a pure function — no provider/DB calls here.
+    //   - Agent reads `bootstrap_context` unchanged; no agent code
+    //     change is needed for this slice.
+    //
+    // Best-effort: any compile failure degrades to the pre-L2.2b.4
+    // bootstrap (identity + facts + index + memory + env) without
+    // blocking the session start.
+    let decisionContext: import('../orb/context/types').AssistantDecisionContext | null = null;
+    if (userId && tenantId) {
+      try {
+        const { compileAssistantDecisionContext } = await import(
+          '../orb/context/compile-assistant-decision-context'
+        );
+        decisionContext = await compileAssistantDecisionContext({
+          userId,
+          tenantId,
+        });
+        const { renderDecisionContract } = await import(
+          '../orb/live/instruction/decision-contract-renderer'
+        );
+        const decisionBlock = renderDecisionContract(decisionContext);
+        if (decisionBlock) {
+          ctxParts.push(decisionBlock);
+        }
+      } catch (exc) {
+        // Compile/render failure must NEVER block the bootstrap.
+        // Vertex production users are unaffected by anything here.
+        console.warn(
+          `[${VTID}] decision-context compile failed (LiveKit path falls back to identity-only bootstrap): ${(exc as Error).message}`,
+        );
+      }
+    }
+
     res.json({
       ok: true,
       vtid: VTID,
@@ -770,6 +813,11 @@ router.get(
       identity_facts_count: identityFacts.length,
       voice_config: voiceConfig,
       memory_items: memoryItems,
+      // L2.2b.4 (VTID-03008): structured decision-contract output for
+      // cockpit/operator inspection. The rendered version is already
+      // inlined into `bootstrap_context`; this field is for tooling.
+      // null on anonymous sessions or when compile failed.
+      decision_context: decisionContext,
     });
   },
 );


### PR DESCRIPTION
## Summary

Closes the **intelligence-parity gap** between Vertex and LiveKit voice paths. Before this PR, the agent's bootstrap context carried only identity facts + Vitana Index + 5 memory items + env. The decision-contract spine outputs (continuity / concept_mastery / journey_stage / pillar_momentum / interaction_style) — the same B0b / F2 / F3 / B5 / B6 signals Vertex renders into its system instruction — were **NOT** plumbed through to LiveKit.

A canary user on LiveKit would have experienced a noticeably "thinner" Vitana: re-explained Vitana Index every session, no journey-stage modulation, no continuity from prior sessions, no interaction-style preference. This slice fixes that.

## Change

`services/gateway/src/routes/orb-livekit.ts` (`/orb/context-bootstrap` route, **+48 lines additive**):

1. After the existing identity / Vitana Index / memory_items / env blocks are appended to `ctxParts`, call ``compileAssistantDecisionContext({ userId, tenantId })``.
2. Call ``renderDecisionContract(decision)`` — the renderer is a pure function (no DB/provider calls) that already exists at [orb/live/instruction/decision-contract-renderer.ts](services/gateway/src/orb/live/instruction/decision-contract-renderer.ts).
3. Push the rendered string onto `ctxParts` so it joins the `bootstrap_context` the agent reads verbatim.
4. Also expose ``decision_context`` as a **structured field** on the response (cockpit/operator inspection; agent doesn't need this field — it reads `bootstrap_context`).

Anonymous sessions (`userId`/`tenantId` null) skip the compile entirely. Any compile/render failure degrades silently to the pre-L2.2b.4 bootstrap — **never blocks session start**.

## Vertex production path: untouched

This PR only adds a new fetch path inside the LiveKit route. The Vertex `orb-live.ts` renders decision-contract in-process via the **same** renderer + compiler. Both paths now produce the same decision-context sections in the prompt.

## What this slice does NOT cover

- No agent code change. The agent's `bootstrap.py` already hands `bootstrap_context` to `AgentSession(instructions=...)`.
- No ``voice.livekit_agent_enabled`` flip. Canary remains gated.
- No full system-instruction builder lift. That's the "Option A" full-parity version; this is the LITE version that gets the decision-contract intelligence into LiveKit fast. Full parity (per-persona tool catalog, full instruction builder lift, navigator policy section, diary/streak signals, proactive guide) is a follow-up if LITE proves insufficient.

## Acceptance

| # | Criterion | Status |
|---|---|---|
| 1 | Vertex production path: untouched | ✓ (no orb-live.ts touched) |
| 2 | `/orb/chat` smoke still green | pending post-merge |
| 3 | `/orb/context-bootstrap` for authenticated user carries `decision_context` + rendered sections | pending post-merge |
| 4 | Anonymous bootstrap unchanged (`decision_context: null`) | ✓ by code inspection |
| 5 | `voice.livekit_agent_enabled` remains false | ✓ |
| 6 | Agent revision unchanged; next dispatch picks up new bootstrap response | ✓ no agent change required |

## Tests

- TypeScript ``npx tsc --noEmit`` clean.
- 104 prior tests (oasis-emit + orb/live/upstream suites) still green.
- Production smoke after deploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)