### PR TITLE
fix(orb-livekit): localized greeting + first-name-only + forward client_ip (VTID-03014)

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/bootstrap.py
+++ b/services/agents/orb-agent/src/orb_agent/bootstrap.py
@@ -69,6 +69,7 @@ class ContextBootstrap:
         is_reconnect: bool = False,
         last_n_turns: int = 0,
         lang: str | None = None,
+        client_ip: str | None = None,
     ) -> BootstrapResult:
         params: dict[str, str | int | bool] = {
             "agent_id": agent_id,
@@ -88,6 +89,15 @@ class ContextBootstrap:
         # LLM keeps responding in English even when the user speaks German.
         if lang:
             request_headers["Accept-Language"] = lang
+        # VTID-03014: forward the user's real client IP captured at token
+        # mint time. The gateway's /orb/context-bootstrap calls
+        # buildClientContext(req), which runs orb-live.ts:getClientIP that
+        # already reads X-Real-IP. Without this header the bootstrap geo-IP
+        # resolves the AGENT's us-central1 Cloud Run egress IP, producing
+        # "ENVIRONMENT CONTEXT: User location: United States" for every
+        # session regardless of where the user actually is.
+        if client_ip:
+            request_headers["X-Real-IP"] = client_ip
         try:
             r = await self._client.get(
                 self._endpoint,

--- a/services/agents/orb-agent/src/orb_agent/identity.py
+++ b/services/agents/orb-agent/src/orb_agent/identity.py
@@ -26,6 +26,14 @@ class Identity:
     vitana_id: str | None
     is_mobile: bool
     is_anonymous: bool
+    # VTID-03014: user's real client IP captured by the gateway's token-mint
+    # route (both /orb/livekit/token AND /agents/:id/voice-config/test-session)
+    # and embedded in LiveKit participant metadata. The agent forwards this
+    # as `X-Real-IP` to /orb/context-bootstrap so geo-IP resolves the user's
+    # actual location instead of the agent's us-central1 Cloud Run egress.
+    # None on older gateway revisions or when the gateway couldn't determine
+    # a real IP (private/localhost).
+    client_ip: str | None = None
 
 
 def resolve_identity_from_room_metadata(
@@ -50,6 +58,9 @@ def resolve_identity_from_room_metadata(
     vitana_id = metadata.get("vitana_id")
     is_mobile = bool(metadata.get("is_mobile", False))
     is_anonymous = bool(metadata.get("is_anonymous", False))
+    # VTID-03014: user's real IP, captured at token-mint time.
+    raw_client_ip = metadata.get("client_ip")
+    client_ip = str(raw_client_ip) if raw_client_ip else None
 
     # Mobile-community coercion (defense-in-depth, mirrors
     # feedback_mobile_community_only.md and orb-live.ts BOOTSTRAP-ORB-ROLE-SYNC-2)
@@ -70,6 +81,7 @@ def resolve_identity_from_room_metadata(
         vitana_id=str(vitana_id) if vitana_id else None,
         is_mobile=is_mobile,
         is_anonymous=is_anonymous,
+        client_ip=client_ip,
     )
 
 

--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -108,7 +108,83 @@ def _get_vad() -> Any:
     return _SHARED_VAD
 
 
-CODE_VERSION = "agent-2026-05-07-name-and-facts"
+CODE_VERSION = "agent-2026-05-16-vtid-03014-localized-greeting"
+
+
+# VTID-03014: localized first-greeting templates. session.say() speaks the
+# literal string we pass — there is NO LLM translation between us and TTS,
+# so the greeting MUST be in the user's language at the source. The system
+# instruction's "LANGUAGE: Respond ONLY in <lang>" only governs LLM-generated
+# turns; it can't translate a hardcoded English string after we've already
+# handed it to TTS.
+#
+# Language coverage matches voice-pipeline-spec/spec.json.supported_languages
+# ("en", "de", "fr", "es", "ar", "zh", "ru", "sr"). Unknown lang falls back
+# to English so the agent never goes silent.
+def _localized_greeting(
+    lang: str,
+    *,
+    first_name: str = "",
+    vitana_handle: str = "",
+) -> str:
+    """Return the agent's first-turn greeting in the user's language.
+
+    Preference order: first_name (drops the @handle so Gemini sees one
+    addressing signal, not two) → @handle → generic.
+    """
+    name = first_name.strip()
+    handle = vitana_handle.strip()
+    code = (lang or "en").lower()[:2]
+    if name:
+        templates = {
+            "en": f"Hi {name}! What can I help with today?",
+            "de": f"Hallo {name}! Womit kann ich dir heute helfen?",
+            "fr": f"Salut {name} ! Comment puis-je t'aider aujourd'hui ?",
+            "es": f"¡Hola {name}! ¿En qué puedo ayudarte hoy?",
+            "ar": f"مرحباً يا {name}! كيف يمكنني مساعدتك اليوم؟",
+            "zh": f"你好 {name}！今天我能为你做些什么？",
+            "ru": f"Привет, {name}! Чем могу помочь сегодня?",
+            "sr": f"Zdravo {name}! Kako mogu da ti pomognem danas?",
+        }
+        return templates.get(code, templates["en"])
+    if handle:
+        templates = {
+            "en": f"Hi @{handle}! What can I help with today?",
+            "de": f"Hallo @{handle}! Womit kann ich dir heute helfen?",
+            "fr": f"Salut @{handle} ! Comment puis-je t'aider aujourd'hui ?",
+            "es": f"¡Hola @{handle}! ¿En qué puedo ayudarte hoy?",
+            "ar": f"مرحباً @{handle}! كيف يمكنني مساعدتك اليوم؟",
+            "zh": f"你好 @{handle}！今天我能为你做些什么？",
+            "ru": f"Привет, @{handle}! Чем могу помочь сегодня?",
+            "sr": f"Zdravo @{handle}! Kako mogu da ti pomognem danas?",
+        }
+        return templates.get(code, templates["en"])
+    templates = {
+        "en": "Hi there! What can I help with today?",
+        "de": "Hallo! Womit kann ich dir heute helfen?",
+        "fr": "Bonjour ! Comment puis-je vous aider aujourd'hui ?",
+        "es": "¡Hola! ¿En qué puedo ayudarte hoy?",
+        "ar": "مرحباً! كيف يمكنني مساعدتك اليوم؟",
+        "zh": "你好！今天我能为你做些什么？",
+        "ru": "Здравствуйте! Чем могу помочь сегодня?",
+        "sr": "Zdravo! Kako mogu da ti pomognem danas?",
+    }
+    return templates.get(code, templates["en"])
+
+
+def _localized_anonymous_greeting(lang: str) -> str:
+    code = (lang or "en").lower()[:2]
+    templates = {
+        "en": "Hi! How can I help today?",
+        "de": "Hallo! Wie kann ich heute helfen?",
+        "fr": "Bonjour ! Comment puis-je aider aujourd'hui ?",
+        "es": "¡Hola! ¿En qué puedo ayudar hoy?",
+        "ar": "مرحباً! كيف يمكنني المساعدة اليوم؟",
+        "zh": "你好！今天我能帮上什么忙？",
+        "ru": "Здравствуйте! Чем могу помочь?",
+        "sr": "Zdravo! Kako mogu danas da pomognem?",
+    }
+    return templates.get(code, templates["en"])
 
 
 async def _early_trace_heartbeat(gateway_url: str, payload: dict) -> None:
@@ -381,6 +457,10 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
         is_reconnect=False,
         last_n_turns=0,
         lang=identity.lang,
+        # VTID-03014: forward the user's real IP captured by the gateway
+        # at token-mint time. Without this header /orb/context-bootstrap
+        # geo-IPs the agent's own Cloud Run egress IP (us-central1 → US).
+        client_ip=identity.client_ip,
     )
 
     # System instruction.
@@ -1048,24 +1128,26 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
 
     ctx.add_shutdown_callback(_stop_stall_on_shutdown)
 
-    # Initial greeting — VTID-03012: use session.say() directly with a
-    # templated string instead of session.generate_reply(). The greeting
-    # was already heavily constrained ("ONE short sentence + brief 'What
-    # can I help with today?'") so the LLM was just rendering a template
-    # — a 1–2s round-trip we don't need. Direct TTS skips straight to
-    # the audio. session.say() defaults to add_to_chat_ctx=True so the
-    # greeting remains part of the conversation history for follow-ups.
+    # Initial greeting — VTID-03014: localize the greeting text to
+    # identity.lang. Before this fix the greeting was always English even
+    # when the user picked German in the Test Bench, because session.say()
+    # speaks the literal string we pass — there is no LLM translation
+    # step between us and TTS. The system_instruction's "LANGUAGE:
+    # Respond ONLY in <lang>" rule only governs LLM-generated turns,
+    # not direct session.say() output.
+    #
+    # Also drops the "@handle as fallback" path when a first_name is
+    # present, so Gemini never sees two competing addressing signals.
     if not identity.is_anonymous:
         vid = (bootstrap.vitana_id or "").strip()
         first_name = (bootstrap.first_name or "").strip()
-        if first_name:
-            greeting_text = f"Hi {first_name}! What can I help with today?"
-        elif vid:
-            greeting_text = f"Hi @{vid}! What can I help with today?"
-        else:
-            greeting_text = "Hi there! What can I help with today?"
+        greeting_text = _localized_greeting(
+            identity.lang,
+            first_name=first_name,
+            vitana_handle=vid,
+        )
     else:
-        greeting_text = "Hi! How can I help today?"
+        greeting_text = _localized_anonymous_greeting(identity.lang)
     try:
         await session.say(greeting_text)
     except Exception as exc:  # noqa: BLE001
@@ -1110,6 +1192,7 @@ async def perform_handoff(
     reason: str,
     context_summary: str,
     lang: str = "en",
+    client_ip: str | None = None,
 ) -> None:
     """Swap to a new specialist mid-session. STT/mic continue; LLM+TTS swap.
 
@@ -1141,7 +1224,13 @@ async def perform_handoff(
 
     # Fetch new agent's context + voice config.
     new_bootstrap = await ctx_fetcher.fetch(
-        user_jwt=user_jwt, agent_id=to_agent_id, is_reconnect=True, last_n_turns=10, lang=lang,
+        user_jwt=user_jwt,
+        agent_id=to_agent_id,
+        is_reconnect=True,
+        last_n_turns=10,
+        lang=lang,
+        # VTID-03014: keep geo accurate through specialist swaps too.
+        client_ip=client_ip,
     )
     new_cascade = build_cascade(new_bootstrap.voice_config, lang=lang)
 

--- a/services/gateway/src/routes/orb-livekit.ts
+++ b/services/gateway/src/routes/orb-livekit.ts
@@ -70,6 +70,28 @@ import { getLiveKitAgentReadiness } from '../orb/live/upstream/livekit-agent-con
 const router = Router();
 
 const VTID = 'VTID-LIVEKIT-FOUNDATION';
+
+// VTID-03014: extract the user's real client IP from the request and embed
+// it in LiveKit token metadata. Without this, the orb-agent (running in
+// Cloud Run us-central1) calls /orb/context-bootstrap from its OWN egress
+// IP, so buildClientContext()'s geo-IP lookup returns "United States" no
+// matter where the user actually is. Mirrors the precedence used by
+// orb-live.ts:getClientIP — x-forwarded-for first (Cloud Run sets this
+// with the real client IP), then x-real-ip, then x-appengine-user-ip,
+// then req.ip as a last resort.
+function getRequestClientIP(req: Request): string | null {
+  const xff = req.get('x-forwarded-for');
+  const xri = req.get('x-real-ip');
+  const xaui = req.get('x-appengine-user-ip');
+  const ip = (xff?.split(',')[0]?.trim()) || xri || xaui || req.ip || '';
+  // Skip obviously-local/private addresses so the agent doesn't try to
+  // geo-resolve 127.0.0.1 (which the gateway's bootstrap already filters,
+  // but trimming early keeps the metadata clean).
+  if (!ip || ip === 'unknown' || ip === '::1' || ip.startsWith('127.')) {
+    return null;
+  }
+  return ip;
+}
 const ACTIVE_PROVIDER_KEY = 'voice.active_provider';
 const FLIP_COOLDOWN_SECONDS = 60 * 60; // 1 hour anti-flap
 const TEST_SESSION_TOKEN_TTL_SECONDS = 5 * 60;
@@ -436,6 +458,11 @@ router.post(
     // anonymous traffic anyway).
     const agentUserJwt = req.identity ? await mintAgentSessionJwt(req.identity) : null;
 
+    // VTID-03014: capture user's real client IP at mint time so the agent
+    // can forward it to /orb/context-bootstrap and geo-IP resolves the
+    // actual user location, not the agent's us-central1 Cloud Run IP.
+    const clientIp = getRequestClientIP(req);
+
     const at = new AccessToken(apiKey, apiSecret, {
       identity: userId,
       ttl: 60 * 60, // 1 hour session
@@ -455,6 +482,8 @@ router.post(
         // user's normal JWT — existing optionalAuth/requireAuth middleware
         // validates it transparently.
         user_jwt: agentUserJwt,
+        // VTID-03014: forward the user's real IP through to the agent.
+        client_ip: clientIp,
       }),
     });
     at.addGrant({
@@ -712,15 +741,41 @@ router.get(
 
     const vitanaId = req.identity?.vitana_id ?? null;
 
+    // VTID-03014: extract first_name preferring app_users.display_name, then
+    // memory_facts.user_name (the canonical Cognee-extracted name). Without
+    // this, users whose display_name is null but whose user_name fact IS
+    // populated got greeted by @handle instead of their actual name —
+    // exactly the failure mode the L2.2b.6 smoke surfaced.
+    const userNameFactForPrompt = identityFacts.find((f) => f.fact_key === 'user_name');
+    const promptFullName = (
+      (displayName || '').trim() ||
+      (userNameFactForPrompt?.fact_value || '').trim()
+    );
+    const promptFirstName = promptFullName ? promptFullName.split(/\s+/)[0] : '';
+
     const ctxParts: string[] = [];
     // Authoritative identity header — pinned at top so the LLM treats it
     // as ground truth, mirrors the role/vitana-id headers Vertex pins.
-    if (displayName) {
-      ctxParts.push(`The user's first name is ${displayName}. Greet them by this name.`);
-    }
-    if (vitanaId) {
+    //
+    // VTID-03014: when a first_name exists, ONLY emit the first-name line.
+    // The previous "Address them as @handle" line ran alongside it and
+    // gave Gemini two competing addressing signals — sometimes it picked
+    // the handle ("Hi @e2etest33!") instead of the name ("Hi Dragan!").
+    // The handle stays in the AUTHORITATIVE USER VITANA ID block (rendered
+    // by buildLiveSystemInstruction) for when the user explicitly asks
+    // "what's my handle?", but it MUST NOT be promoted as preferred address.
+    if (promptFirstName) {
       ctxParts.push(
-        `The user's Vitana handle is @${vitanaId}. Address them as @${vitanaId}.`,
+        `The user's first name is ${promptFirstName}. ` +
+        `Greet them by this name. Use the first name in conversation, ` +
+        `not their Vitana handle.`,
+      );
+    } else if (vitanaId) {
+      // Fallback: no first_name on file. Handle becomes the preferred
+      // address since there's nothing better.
+      ctxParts.push(
+        `The user has no first name on file. Their Vitana handle is ` +
+        `@${vitanaId} — use it for greetings until they tell you their name.`,
       );
     }
     // Note: deliberately do NOT include the raw UUID — small models read
@@ -1159,6 +1214,13 @@ router.post(
 
     const agentUserJwt = req.identity ? await mintAgentSessionJwt(req.identity) : null;
 
+    // VTID-03014: capture user's real client IP at mint time so the agent
+    // can forward it to /orb/context-bootstrap on the test path too. The
+    // Test Bench is precisely the surface the user has been hitting, so
+    // missing this here would leave the US-location bug intact even
+    // after the production-token fix.
+    const clientIp = getRequestClientIP(req);
+
     const at = new AccessToken(apiKey, apiSecret, {
       identity: userId,
       ttl: TEST_SESSION_TOKEN_TTL_SECONDS,
@@ -1173,6 +1235,9 @@ router.post(
         vitana_id: req.identity?.vitana_id ?? null,
         voice_override: voiceOverride,
         user_jwt: agentUserJwt,
+        // VTID-03014: same shape as /orb/livekit/token — the agent reads
+        // metadata.client_ip and forwards it as X-Real-IP to bootstrap.
+        client_ip: clientIp,
       }),
     });
     at.addGrant({


### PR DESCRIPTION
## Summary
Three user-reported LiveKit Test Bench failures caught in real-session telemetry from 11:01:37 UTC today — symptoms L2.2b.6 (#2137) didn't address because that PR only proved system_instruction BYTES reached the agent, not that the user-facing BEHAVIOR matched the prompt.

What L2.2b.6 actually proved (still true after this PR):
- 65KB system_instruction with `## AVAILABLE TOOLS` reaches the agent.
- `lang=de` propagates end-to-end from the Test Bench picker.
- `bootstrap_first_name=Dragan` extracted correctly from memory_facts.

What L2.2b.6 didn't fix (this PR fixes):

### 1. English greeting even when German selected
`session.py` greeting was a HARDCODED English `session.say(...)` string. `session.say()` speaks the literal text we pass — no LLM translation step between the agent and TTS. The system_instruction's "Respond ONLY in <lang>" rule only governs LLM-generated turns. **Fix**: new `_localized_greeting(lang, first_name, vitana_handle)` helper covers all 8 supported languages.

### 2. Greeting with `@handle` instead of first_name even though `bootstrap_first_name=Dragan`
Two sources of competing addressing signal:
- `orb-livekit.ts` pushed both "first name is X" AND "address them as @handle" lines into bootstrap_context.
- `session.py` greeting fell through to `@handle` path because the check only looked at `bootstrap.first_name`, but first_name was actually populated correctly.
**Fix**: extract first_name from app_users.display_name OR memory_facts.user_name in the gateway bootstrap; emit ONLY the first-name line when present; remove `@handle` fallback path from greeting when `first_name` is present.

### 3. "User location: United States" for a Europe user
`/orb/context-bootstrap` does geo-IP on `req.ip`. The agent calls it from its **us-central1 Cloud Run egress IP**, not the user's IP, so ENVIRONMENT CONTEXT bakes in "United States" into the 65KB prompt every time. **Fix**: forward `client_ip` end-to-end:
- Gateway captures `getRequestClientIP(req)` at token-mint time (both `/orb/livekit/token` AND `/agents/:id/voice-config/test-session`) and embeds it in LiveKit metadata.
- Agent's `Identity` dataclass + resolver parse `metadata.client_ip`.
- `ContextBootstrap.fetch(..., client_ip=...)` forwards `X-Real-IP` to the gateway. `orb-live.ts:getClientIP` already accepts `X-Real-IP` as one of its 4 inputs — no gateway route change needed.
- `perform_handoff` threads the same client_ip through so geo stays accurate across persona swaps.

## Out of scope (explicit)
- Devon audible TTS voice swap (pre-existing roadmap stub on BOTH pipelines).
- LiveKit canary broad enablement; `voice.livekit_agent_enabled` untouched.
- Tool catalogue changes.
- Vertex `/orb/chat` (unaffected — token-mint changes are additive metadata fields Vertex never reads).

## Verification
- Gateway build green; 706 orb tests still pass.
- `_localized_greeting` smoke: DE+Dragan → "Hallo Dragan! Womit kann ich dir heute helfen?"
- Python syntax check on agent files green.

## Test plan
- [ ] DEPLOY-ORB-AGENT auto-fires after merge.
- [ ] EXEC-DEPLOY-GATEWAY auto-fires after merge.
- [ ] After both deploys: user runs the Test Bench in German → greeting is German.
- [ ] First greeting says "Dragan", not "@e2etest33".
- [ ] Agent-trace startup row shows `bootstrap_first_1500_chars` contains ENVIRONMENT CONTEXT with user's real location, not "United States".
- [ ] Vertex `/orb/chat` smoke unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)