### PR TITLE
diag(orb-agent): expose identity.client_ip + bootstrap geo + ENV block in startup trace (VTID-03015)

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -632,6 +632,32 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
             "tools_first_name_in_first_chars": bool(
                 bootstrap.first_name and bootstrap.first_name.lower() in sys_prompt[:600].lower()
             ),
+            # VTID-03015: diagnostic — directly expose the values needed to
+            # debug "ENVIRONMENT CONTEXT still says United States" after
+            # VTID-03014 wired client_ip end-to-end. Three questions to
+            # answer from one trace:
+            #   1. Did the gateway embed client_ip in LiveKit metadata?
+            #      → identity_client_ip non-null = yes; null = gateway gap.
+            #   2. Did the agent forward X-Real-IP to bootstrap?
+            #      → bootstrap.fetch is called with identity.client_ip already
+            #        (verified in code); this just records what got sent.
+            #   3. Did the gateway's bootstrap geo-resolve correctly?
+            #      → bootstrap_client_context_{city,country,timezone}.
+            "identity_client_ip": identity.client_ip,
+            "bootstrap_client_context_city": (bootstrap.client_context or {}).get("city"),
+            "bootstrap_client_context_country": (bootstrap.client_context or {}).get("country"),
+            "bootstrap_client_context_timezone": (bootstrap.client_context or {}).get("timezone"),
+            # Full ENVIRONMENT CONTEXT block from the rendered system_instruction.
+            # This is the literal text the LLM sees. If it says "United States"
+            # the geo resolved to us-central1; if it says the user's real city
+            # the X-Real-IP forwarding worked.
+            "system_prompt_env_context_excerpt": (
+                (sys_prompt[sys_prompt.find("ENVIRONMENT CONTEXT"):sys_prompt.find("ENVIRONMENT CONTEXT") + 500]
+                 if "ENVIRONMENT CONTEXT" in sys_prompt else "")
+            ),
+            # Full bootstrap_context so we can see the full ENV block even
+            # when it's past the first 1500 chars (which truncates).
+            "bootstrap_context_full": bootstrap.bootstrap_context or "",
         }
         # VTID-03012: fire-and-forget — this trace is observability-only,
         # nothing downstream blocks on it. Awaiting it was adding 200-500ms


### PR DESCRIPTION
## Summary
VTID-03014 (#2140) wired client_ip end-to-end and individually curl-verified each link, but the user's real Test Bench session still reports "User location: United States" in Vitana's spoken responses. The existing agent startup trace doesn't carry the fields needed to tell *where* in the chain the value is lost.

This PR adds 6 diagnostic fields to `services/agents/orb-agent/src/orb_agent/session.py` `trace_payload` so one real-session run pinpoints the broken link:

- `identity_client_ip` — did LiveKit metadata reach the agent's Identity dataclass?
- `bootstrap_client_context_city` / `_country` / `_timezone` — did the gateway's geo-IP resolve correctly when called with the forwarded X-Real-IP?
- `system_prompt_env_context_excerpt` — what does the rendered ENVIRONMENT CONTEXT block in the system_instruction actually say (this is the literal text the LLM speaks from)?
- `bootstrap_context_full` — full bootstrap_context (no 1500-char truncation).

## Behavior change
None. Pure diagnostic addition inside the existing try/except trace-post block.

## Test plan
- [ ] DEPLOY-ORB-AGENT auto-fires.
- [ ] User runs the Test Bench in German one more time.
- [ ] I read the new fields from `livekit.agent.session.trace` OASIS topic and identify which link is broken (metadata gap / geo-IP failure / ENV-block stale).

🤖 Generated with [Claude Code](https://claude.com/claude-code)