### PR TITLE
perf(orb-agent+gateway): greeting-critical fast path + bg context hydration (VTID-03017, DEV-COMHU-03017)

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/bootstrap.py
+++ b/services/agents/orb-agent/src/orb_agent/bootstrap.py
@@ -61,6 +61,39 @@ class ContextBootstrap:
             self._headers["Authorization"] = f"Bearer {service_token}"
         self._client = httpx.AsyncClient(timeout=CONTEXT_BOOTSTRAP_TIMEOUT_S)
 
+    async def fetch_greeting(
+        self,
+        *,
+        user_jwt: str,
+        agent_id: str = "vitana",
+        lang: str | None = None,
+        client_ip: str | None = None,
+    ) -> BootstrapResult:
+        """VTID-03017: greeting-critical fast path.
+
+        Calls /orb/context-bootstrap?greeting_only=true so the gateway skips
+        the slow render work (bootstrap_context compile, system_instruction
+        render, identity_facts compile, life_compass, decision_context).
+        Returns a BootstrapResult populated with ONLY:
+          - voice_config (per-agent STT/LLM/TTS row, needed for cascade)
+          - first_name + display_name + vitana_id (for the templated greeting)
+          - active_role (for the placeholder system prompt)
+        Slow-context fields are left empty; caller is expected to background
+        a separate `.fetch(...)` call to hydrate them post-greeting.
+
+        Total cost: ~150–300ms (2 Supabase row lookups). Compare to the full
+        fetch at 500ms–1s.
+        """
+        return await self._do_fetch(
+            user_jwt=user_jwt,
+            agent_id=agent_id,
+            lang=lang,
+            client_ip=client_ip,
+            is_reconnect=False,
+            last_n_turns=0,
+            greeting_only=True,
+        )
+
     async def fetch(
         self,
         *,
@@ -71,11 +104,34 @@ class ContextBootstrap:
         lang: str | None = None,
         client_ip: str | None = None,
     ) -> BootstrapResult:
+        return await self._do_fetch(
+            user_jwt=user_jwt,
+            agent_id=agent_id,
+            lang=lang,
+            client_ip=client_ip,
+            is_reconnect=is_reconnect,
+            last_n_turns=last_n_turns,
+            greeting_only=False,
+        )
+
+    async def _do_fetch(
+        self,
+        *,
+        user_jwt: str,
+        agent_id: str,
+        lang: str | None,
+        client_ip: str | None,
+        is_reconnect: bool,
+        last_n_turns: int,
+        greeting_only: bool,
+    ) -> BootstrapResult:
         params: dict[str, str | int | bool] = {
             "agent_id": agent_id,
             "is_reconnect": is_reconnect,
             "last_n_turns": last_n_turns,
         }
+        if greeting_only:
+            params["greeting_only"] = True
         # VTID-LIVEKIT-AGENT-JWT: prefer the per-session user JWT in the
         # standard Authorization header (the gateway's optionalAuth checks
         # only Bearer). Fall back to the service-token header pre-built in

--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -447,21 +447,59 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
         active_role=identity.role or None,
     )
 
-    # Fetch the merged context (memory + role + agent voice config).
-    # PR 1.B-Lang-4: pass identity.lang so the system prompt is built in
-    # the user's language. Without this the gateway falls back to 'en'
-    # and the LLM keeps responding in English even for German users.
-    bootstrap = await ctx_fetcher.fetch(
-        user_jwt=user_jwt or "",
-        agent_id=agent_id,
-        is_reconnect=False,
-        last_n_turns=0,
-        lang=identity.lang,
-        # VTID-03014: forward the user's real IP captured by the gateway
-        # at token-mint time. Without this header /orb/context-bootstrap
-        # geo-IPs the agent's own Cloud Run egress IP (us-central1 → US).
-        client_ip=identity.client_ip,
+    # VTID-03017: greeting-critical fast path + background full-context hydration.
+    #
+    # Old:  await ctx_fetcher.fetch()           # 500–1000ms blocking
+    #       → build cascade, sys_prompt, agent
+    #       → session.start, session.say(LLM-generated greeting)
+    #
+    # New:  bootstrap_task = create_task(fetch()) # full, in background
+    #       greeting_ctx = await fetch_greeting() # ~150–300ms
+    #       → build cascade (real voice_config from greeting_ctx)
+    #       → minimal sys_prompt (template; full one overwrites on hydration)
+    #       → agent + session.start
+    #       → session.say(deterministic template, add_to_chat_ctx=False)
+    #       → background task awaits bootstrap_task and updates
+    #         agent.instructions with the rendered system_instruction so
+    #         subsequent turns get the full context.
+    #
+    # Net: greeting fires ~1s sooner; the LLM never blocks the greeting.
+    bootstrap_task = asyncio.create_task(
+        ctx_fetcher.fetch(
+            user_jwt=user_jwt or "",
+            agent_id=agent_id,
+            is_reconnect=False,
+            last_n_turns=0,
+            lang=identity.lang,
+            client_ip=identity.client_ip,
+        )
     )
+    try:
+        bootstrap = await ctx_fetcher.fetch_greeting(
+            user_jwt=user_jwt or "",
+            agent_id=agent_id,
+            lang=identity.lang,
+            client_ip=identity.client_ip,
+        )
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("VTID-03017: greeting-critical fetch failed, using degraded fallback: %s", exc)
+        # Build a minimal in-memory BootstrapResult so cascade/agent setup
+        # can proceed; voice_config=None triggers the hardcoded Google
+        # cascade in providers.build_cascade.
+        from .bootstrap import BootstrapResult
+        bootstrap = BootstrapResult(
+            bootstrap_context="",
+            active_role=None,
+            conversation_summary=None,
+            last_turns=None,
+            last_session_info=None,
+            current_route=None,
+            recent_routes=[],
+            client_context={},
+            vitana_id=identity.vitana_id,
+            voice_config=None,
+            is_degraded=True,
+        )
 
     # System instruction.
     #
@@ -1149,7 +1187,12 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     else:
         greeting_text = _localized_anonymous_greeting(identity.lang)
     try:
-        await session.say(greeting_text)
+        # VTID-03017: add_to_chat_ctx=False — the greeting is a deterministic
+        # template, not an LLM turn, so it shouldn't pollute chat_ctx as if
+        # the model authored it. The LLM still knows the user is freshly
+        # greeted via the placeholder system prompt + (after hydration) the
+        # rendered system_instruction.
+        await session.say(greeting_text, add_to_chat_ctx=False)
     except Exception as exc:  # noqa: BLE001
         logger.warning("initial greeting session.say failed: %s", exc)
         asyncio.create_task(
@@ -1164,6 +1207,66 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
                 },
             )
         )
+
+    # VTID-03017: hydrate the full system instruction in the background.
+    # The greeting already fired with the placeholder prompt; subsequent
+    # user turns get the full Vertex-rendered system_instruction once
+    # bootstrap_task resolves (~500ms-1s after click). Best-effort: if the
+    # livekit-agents Agent class doesn't accept attribute reassignment on
+    # `instructions`, the placeholder stays for the session; conversation
+    # still works, just without the memory-rich context.
+    async def _hydrate_full_context_in_background() -> None:
+        try:
+            full = await bootstrap_task
+            full_sys_prompt: str | None = full.system_instruction
+            if not full_sys_prompt and not identity.is_anonymous:
+                try:
+                    full_sys_prompt = build_live_system_instruction(
+                        lang=identity.lang,
+                        voice_style="warm",
+                        bootstrap_context=full.bootstrap_context,
+                        active_role=full.active_role or identity.role,
+                        conversation_summary=full.conversation_summary,
+                        conversation_history=full.last_turns,
+                        is_reconnect=False,
+                        last_session_info=None,
+                        current_route=full.current_route,
+                        recent_routes=full.recent_routes,
+                        client_context=full.client_context,
+                        vitana_id=full.vitana_id or identity.vitana_id,
+                        first_name=full.first_name,
+                        display_name=full.display_name,
+                    )
+                except Exception as exc:  # noqa: BLE001
+                    logger.warning("VTID-03017: full sys_prompt build failed: %s", exc)
+            applied = False
+            if full_sys_prompt:
+                try:
+                    setattr(agent, "instructions", full_sys_prompt)
+                    applied = True
+                except Exception:
+                    try:
+                        object.__setattr__(agent, "instructions", full_sys_prompt)
+                        applied = True
+                    except Exception:
+                        pass
+            asyncio.create_task(
+                _early_trace_heartbeat(
+                    cfg.gateway_url,
+                    {
+                        "user_id": identity.user_id or "unknown",
+                        "code_version": CODE_VERSION,
+                        "phase": "context_hydrated",
+                        "orb_session_id": orb_session_id,
+                        "applied_instructions": applied,
+                        "system_prompt_length": len(full_sys_prompt or ""),
+                    },
+                )
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("VTID-03017: background context hydration failed: %s", exc)
+
+    asyncio.create_task(_hydrate_full_context_in_background())
 
     # Park here until the room disconnects. The AgentSession keeps running
     # autonomously via the tasks it spawned in start(); we just need to

--- a/services/gateway/src/routes/orb-livekit.ts
+++ b/services/gateway/src/routes/orb-livekit.ts
@@ -580,6 +580,85 @@ router.get(
       voiceConfig = (data as Record<string, unknown> | null) ?? null;
     }
 
+    // VTID-03017: greeting-critical fast path. When the agent calls with
+    // ?greeting_only=true, return ONLY the fields needed to build the cascade
+    // and emit a deterministic templated greeting:
+    //   - voice_config        (per-agent STT/LLM/TTS row)
+    //   - first_name          (preferred address — from app_users.display_name,
+    //                          falling back to memory_facts.user_name)
+    //   - display_name        (full name for fallback)
+    //   - vitana_id           (handle, as a fallback greeting form)
+    //   - active_role         (so the placeholder prompt knows the role)
+    //   - lang                (echo back for the agent)
+    // Skips the slow work: memory_items, identity_facts compile, life_compass,
+    // bootstrap_context render, decision_context compile, system_instruction
+    // render. The agent runs this in the click→greeting path and runs the full
+    // /orb/context-bootstrap (without the flag) as a background task to
+    // hydrate the system instruction for subsequent turns.
+    const greetingOnly = String(req.query.greeting_only ?? 'false') === 'true';
+    if (greetingOnly) {
+      let goDisplayName: string | null = null;
+      if (sb && userId) {
+        try {
+          const { data: app } = await sb
+            .from('app_users')
+            .select('display_name')
+            .eq('user_id', userId)
+            .maybeSingle();
+          goDisplayName =
+            ((app as Record<string, unknown> | null)?.display_name as string | null) ?? null;
+        } catch {
+          /* best-effort */
+        }
+        if (!goDisplayName) {
+          // Fallback: memory_facts.user_name (the Cognee-extracted canonical name)
+          try {
+            const { data: fact } = await sb
+              .from('memory_facts')
+              .select('fact_value')
+              .eq('user_id', userId)
+              .eq('fact_key', 'user_name')
+              .order('updated_at', { ascending: false })
+              .limit(1)
+              .maybeSingle();
+            const userName = (fact as Record<string, unknown> | null)?.fact_value as
+              | string
+              | undefined;
+            if (userName) goDisplayName = userName;
+          } catch {
+            /* best-effort */
+          }
+        }
+      }
+      const goFirstName = goDisplayName ? goDisplayName.split(/\s+/)[0] : null;
+      return res.json({
+        // Greeting-critical fields (populated)
+        voice_config: voiceConfig,
+        active_role: role,
+        vitana_id: req.identity?.vitana_id ?? null,
+        display_name: goDisplayName,
+        first_name: goFirstName,
+        // Echoed back so the agent has lang in one place
+        lang,
+        greeting_only: true,
+        // Slow-context fields (left empty — agent will get them from a
+        // second non-greeting-only call)
+        bootstrap_context: '',
+        system_instruction: null,
+        identity_facts: [],
+        identity_facts_count: 0,
+        memory_items: [],
+        life_compass: null,
+        decision_context: null,
+        conversation_summary: null,
+        last_turns: null,
+        last_session_info: null,
+        current_route: null,
+        recent_routes: [],
+        client_context: { user_agent: req.headers['user-agent'] ?? null },
+      });
+    }
+
     // VTID-LIVEKIT-BOOTSTRAP-IDENTITY: enrich the bootstrap context with the
     // user's identity facts so the agent's system prompt can answer "do you
     // know who I am?" correctly. Vertex's full system instruction builder


### PR DESCRIPTION
Item 2 of the ordered greeting-latency plan. The click → first-audible-greeting path no longer waits for memory/identity_facts/life_compass/decision_context/system_instruction rendering.

## Gateway

New `?greeting_only=true` query param on `GET /api/v1/orb/context-bootstrap`. Short-circuits after fetching:
- `agent_voice_configs` row (cascade-critical)
- `app_users.display_name` → `first_name` (greeting text)
- `memory_facts.user_name` fallback when display_name is null
- vitana_id + active_role from `req.identity`

Skips the heavy work. Returns the same response shape with slow fields empty so the agent deserializer keeps working unchanged. Cost: **~150-300ms** (2 Supabase row lookups) vs ~500-1000ms for the full bootstrap.

## Agent

- New `ContextBootstrap.fetch_greeting()` method.
- `agent_entrypoint` refactor:
  1. `bootstrap_task = asyncio.create_task(ctx_fetcher.fetch(...))` — full bootstrap in background
  2. `bootstrap = await ctx_fetcher.fetch_greeting(...)` — fast blocking path (~200ms)
  3. Build cascade with real voice_config from fast path
  4. Build minimal sys_prompt (placeholder)
  5. session.start + `session.say(greeting_text, add_to_chat_ctx=False)`
  6. Background `_hydrate_full_context_in_background()` awaits the full task and tries `setattr(agent, 'instructions', full_sys_prompt)` → falls back to `object.__setattr__`. Telemetry phase `context_hydrated` reports `applied_instructions` so we see in oasis_events whether the in-place swap took.

Degraded mode: if `fetch_greeting` errors, a minimal in-memory BootstrapResult lets cascade setup continue with `voice_config=None`, which falls back to the hardcoded Google cascade in `providers.build_cascade`.

## Expected timing

| Before | After |
|---|---|
| click → 3-5s | click → ~2-3s |

Combined with Items 1, 3, 4, 5: target 1-2s.

## Test plan
- [ ] Merge → DEPLOY-ORB-AGENT (agent change) + EXEC-DEPLOY (gateway change). Both trigger from the same merge commit.
- [ ] Test bench: click Connect → greeting plays noticeably faster
- [ ] Trace `context_hydrated` phase fires with `applied_instructions=true` (or false if SDK rejects the swap)
- [ ] Continue conversation: subsequent turns produce contextually-rich responses (the LLM sees the full system_instruction post-hydration)

🤖 Generated with [Claude Code](https://claude.com/claude-code)