### PR TITLE
fix(orb-livekit): correct life_compass schema + agent X-Forwarded-For (VTID-03022)

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/bootstrap.py
+++ b/services/agents/orb-agent/src/orb_agent/bootstrap.py
@@ -145,14 +145,30 @@ class ContextBootstrap:
         # LLM keeps responding in English even when the user speaks German.
         if lang:
             request_headers["Accept-Language"] = lang
-        # VTID-03014: forward the user's real client IP captured at token
-        # mint time. The gateway's /orb/context-bootstrap calls
-        # buildClientContext(req), which runs orb-live.ts:getClientIP that
-        # already reads X-Real-IP. Without this header the bootstrap geo-IP
-        # resolves the AGENT's us-central1 Cloud Run egress IP, producing
-        # "ENVIRONMENT CONTEXT: User location: United States" for every
-        # session regardless of where the user actually is.
+        # VTID-03014 + VTID-03022: forward the user's real client IP captured
+        # at token mint time. Sent via BOTH X-Forwarded-For AND X-Real-IP.
+        #
+        # Why both:
+        # The agent→gateway hop traverses Cloud Run's internal load balancer,
+        # which AUTOMATICALLY adds an X-Forwarded-For header on every request
+        # naming the AGENT's us-central1 egress IP. The gateway's
+        # orb-live.ts:getClientIP reads X-Forwarded-For FIRST (splits on
+        # comma, takes [0]):
+        #
+        #   - X-Real-IP only: Cloud Run synthesizes XFF = "<agent_google_ip>"
+        #     and X-Real-IP gets ignored by getClientIP precedence
+        #     → gateway resolves "Council Bluffs, United States"
+        #       (us-central1 datacenter, observed in VTID-03021 traces).
+        #
+        #   - X-Forwarded-For set explicitly: Cloud Run preserves and
+        #     APPENDS its IP → XFF = "<user_ip>, <agent_google_ip>".
+        #     getClientIP splits on comma, takes [0] = user's IP.
+        #     → gateway resolves the user's real city.
+        #
+        # X-Real-IP stays as a redundant fallback for environments where
+        # XFF gets stripped or rewritten.
         if client_ip:
+            request_headers["X-Forwarded-For"] = client_ip
             request_headers["X-Real-IP"] = client_ip
         try:
             r = await self._client.get(

--- a/services/gateway/src/orb/live/tools/live-tool-catalog.ts
+++ b/services/gateway/src/orb/live/tools/live-tool-catalog.ts
@@ -924,9 +924,8 @@ export function buildLiveApiTools(
           description: [
             "Return the user's active Life Compass — the one-sentence long-term",
             'direction they set in Settings. Includes:',
-            '  - goal: the current long-term goal text',
-            '  - why: motivation / reasoning',
-            '  - target_date: optional deadline / horizon',
+            '  - goal: the current primary_goal text (the one-sentence direction)',
+            '  - category: the life domain (e.g. longevity, business, family)',
             '',
             'CALL THIS WHEN the user asks any variation of:',
             '  - "What is my Life Compass?" / "Was ist mein Life Compass?"',

--- a/services/gateway/src/routes/orb-livekit.ts
+++ b/services/gateway/src/routes/orb-livekit.ts
@@ -679,10 +679,11 @@ router.get(
     // target_date) and inline it into bootstrap_context so the Vertex prompt
     // renderer's [HEALTH] / activity-awareness blocks have ground truth for
     // "what am I working toward?" questions without requiring a tool call.
+    // VTID-03022: corrected shape — life_compass actually has primary_goal +
+    // category + is_active + created_at, not goal/why/target_date.
     let lifeCompass: {
       goal: string | null;
-      why: string | null;
-      target_date: string | null;
+      category: string | null;
     } | null = null;
 
     if (sb && userId) {
@@ -794,23 +795,27 @@ router.get(
         /* best-effort */
       }
 
-      // L2.2b.6 (VTID-03010): Life Compass row. Surfaces the user's
-      // long-term goal verbatim into the system prompt. The table may
-      // legitimately be missing or empty for users who haven't set one
-      // up yet — both cases degrade silently.
+      // L2.2b.6 (VTID-03010) + VTID-03022: Life Compass row. Live schema:
+      // `primary_goal`, `category`, `is_active`, `created_at`. Earlier
+      // VTID-03010 read `current_goal/why/target_date` — none of those
+      // columns exist; every fetch returned a row with all-null fields,
+      // so the Life Compass block was never rendered into the system
+      // instruction. Confirmed canonical shape via guide/awareness-context.ts
+      // and recommendation-engine/ranking/index-pillar-weighter.ts.
       try {
         const { data: lc } = await sb
           .from('life_compass')
-          .select('*')
+          .select('id, primary_goal, category, is_active, created_at')
           .eq('user_id', userId)
+          .eq('is_active', true)
+          .order('created_at', { ascending: false })
+          .limit(1)
           .maybeSingle();
         if (lc) {
-          const row = lc as Record<string, unknown>;
+          const row = lc as { primary_goal: string | null; category: string | null };
           lifeCompass = {
-            goal: (row.current_goal as string | null) ?? null,
-            why: (row.why as string | null) ?? (row.motivation as string | null) ?? null,
-            target_date:
-              (row.target_date as string | null) ?? (row.deadline as string | null) ?? null,
+            goal: (row.primary_goal || '').trim() || null,
+            category: (row.category || '').trim() || null,
           };
         }
       } catch {
@@ -894,11 +899,10 @@ router.get(
     // long-term direction is visible to the model before transient recent
     // turns. The `goal` line is the high-signal one — the model uses it for
     // "what am I working toward?" answers and as a frame for activity nudges.
-    if (lifeCompass && (lifeCompass.goal || lifeCompass.why || lifeCompass.target_date)) {
+    if (lifeCompass && (lifeCompass.goal || lifeCompass.category)) {
       const lcLines: string[] = [];
       if (lifeCompass.goal) lcLines.push(`Goal: ${lifeCompass.goal}`);
-      if (lifeCompass.why) lcLines.push(`Why: ${lifeCompass.why}`);
-      if (lifeCompass.target_date) lcLines.push(`Target date: ${lifeCompass.target_date}`);
+      if (lifeCompass.category) lcLines.push(`Category: ${lifeCompass.category}`);
       ctxParts.push(`## Life Compass\n${lcLines.join('\n')}`);
     }
 

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -3149,10 +3149,22 @@ export async function tool_get_life_compass(
     return { ok: false, error: 'get_life_compass requires an authenticated user.' };
   }
   try {
+    // VTID-03022: corrected schema. Earlier VTID-03010 guessed at column
+    // names (`current_goal`, `why`/`motivation`, `target_date`/`deadline`)
+    // — none of those columns actually exist on `life_compass`. Confirmed
+    // canonical shape from services/gateway/src/services/guide/
+    // awareness-context.ts and services/gateway/src/services/
+    // recommendation-engine/ranking/index-pillar-weighter.ts: the live
+    // columns are `primary_goal`, `category`, `is_active`, `created_at`.
+    // A user can have multiple historical rows; exactly one has
+    // is_active=true and is the current Life Compass.
     const { data, error } = await sb
       .from('life_compass')
-      .select('*')
+      .select('id, primary_goal, category, is_active, created_at')
       .eq('user_id', identity.user_id)
+      .eq('is_active', true)
+      .order('created_at', { ascending: false })
+      .limit(1)
       .maybeSingle();
     if (error) {
       if (/relation .* does not exist/i.test(error.message)) {
@@ -3176,27 +3188,30 @@ export async function tool_get_life_compass(
           'Life Compass, or I can walk you through it now.',
       };
     }
-    const row = data as Record<string, unknown>;
-    const goal = (row.current_goal as string | null) ?? null;
-    const why = (row.why as string | null) ?? (row.motivation as string | null) ?? null;
-    const targetDate =
-      (row.target_date as string | null) ?? (row.deadline as string | null) ?? null;
-    const fields: string[] = [];
-    if (goal) fields.push(`Goal: ${goal}`);
-    if (why) fields.push(`Why: ${why}`);
-    if (targetDate) fields.push(`Target date: ${targetDate}`);
-    const text = fields.length
-      ? `Your Life Compass — ${fields.join('. ')}.`
-      : 'Your Life Compass row exists but has no goal text yet.';
+    const row = data as {
+      id: string;
+      primary_goal: string | null;
+      category: string | null;
+      is_active: boolean | null;
+      created_at: string | null;
+    };
+    const goal = (row.primary_goal || '').trim() || null;
+    const category = (row.category || '').trim() || null;
+    if (!goal) {
+      return {
+        ok: true,
+        result: { available: true, goal: null, category, raw: row },
+        text:
+          'You have a Life Compass row but no primary goal text in it — ' +
+          'want me to take you to Settings → Life Compass to fill it in?',
+      };
+    }
+    const text = category
+      ? `Your Life Compass — ${goal}. (Category: ${category}.)`
+      : `Your Life Compass — ${goal}.`;
     return {
       ok: true,
-      result: {
-        available: true,
-        goal,
-        why,
-        target_date: targetDate,
-        raw: row,
-      },
+      result: { available: true, goal, category, raw: row },
       text,
     };
   } catch (e) {

--- a/services/gateway/test/orb/live/characterization/__snapshots__/system-instruction.characterization.test.ts.snap
+++ b/services/gateway/test/orb/live/characterization/__snapshots__/system-instruction.characterization.test.ts.snap
@@ -889,9 +889,8 @@ connected an external AI yet") and answer yourself.
 ### get_life_compass
 Return the user's active Life Compass — the one-sentence long-term
 direction they set in Settings. Includes:
-  - goal: the current long-term goal text
-  - why: motivation / reasoning
-  - target_date: optional deadline / horizon
+  - goal: the current primary_goal text (the one-sentence direction)
+  - category: the life domain (e.g. longevity, business, family)
 
 CALL THIS WHEN the user asks any variation of:
   - "What is my Life Compass?" / "Was ist mein Life Compass?"
@@ -2057,9 +2056,8 @@ connected an external AI yet") and answer yourself.
 ### get_life_compass
 Return the user's active Life Compass — the one-sentence long-term
 direction they set in Settings. Includes:
-  - goal: the current long-term goal text
-  - why: motivation / reasoning
-  - target_date: optional deadline / horizon
+  - goal: the current primary_goal text (the one-sentence direction)
+  - category: the life domain (e.g. longevity, business, family)
 
 CALL THIS WHEN the user asks any variation of:
   - "What is my Life Compass?" / "Was ist mein Life Compass?"

--- a/services/gateway/test/orb/live/characterization/__snapshots__/tool-catalog.characterization.test.ts.snap
+++ b/services/gateway/test/orb/live/characterization/__snapshots__/tool-catalog.characterization.test.ts.snap
@@ -931,9 +931,8 @@ connected an external AI yet") and answer yourself.",
       {
         "description": "Return the user's active Life Compass — the one-sentence long-term
 direction they set in Settings. Includes:
-  - goal: the current long-term goal text
-  - why: motivation / reasoning
-  - target_date: optional deadline / horizon
+  - goal: the current primary_goal text (the one-sentence direction)
+  - category: the life domain (e.g. longevity, business, family)
 
 CALL THIS WHEN the user asks any variation of:
   - "What is my Life Compass?" / "Was ist mein Life Compass?"
@@ -3020,9 +3019,8 @@ connected an external AI yet") and answer yourself.",
       {
         "description": "Return the user's active Life Compass — the one-sentence long-term
 direction they set in Settings. Includes:
-  - goal: the current long-term goal text
-  - why: motivation / reasoning
-  - target_date: optional deadline / horizon
+  - goal: the current primary_goal text (the one-sentence direction)
+  - category: the life domain (e.g. longevity, business, family)
 
 CALL THIS WHEN the user asks any variation of:
   - "What is my Life Compass?" / "Was ist mein Life Compass?"


### PR DESCRIPTION
## Summary
Two distinct bugs both surfaced in the user's real LiveKit Test Bench session at 13:34:41 UTC. VTID-03015 diagnostics showed the chain was correct but the wire data was being clobbered + the wrong DB column read.

### Bug 1 — Geo always resolves to Council Bluffs (us-central1)
Trace showed `identity_client_ip = 31.216.188.57` correctly reached the agent, but `bootstrap_client_context_city = Council Bluffs` and `bootstrap_client_context_country = United States`. Root cause: **Cloud Run auto-injects X-Forwarded-For on every internal hop** naming the agent's us-central1 egress IP. The gateway's `orb-live.ts:getClientIP` reads X-Forwarded-For FIRST (splits on comma, takes [0]). The agent's explicit X-Real-IP got ignored.

Fix: bootstrap.py forwards BOTH `X-Forwarded-For` AND `X-Real-IP` with the user's client_ip. Cloud Run preserves user-supplied XFF and APPENDS its IP, so `xff.split(',')[0]` returns the user's IP.

### Bug 2 — `get_life_compass` always returns null
VTID-03010 (#2137) guessed at column names. The actual `life_compass` schema is `primary_goal`, `category`, `is_active`, `created_at` — NOT `current_goal/why/target_date`. Every fetch returned a row with all-null fields, so the `## Life Compass` block never rendered into the system instruction. Confirmed canonical shape from two pre-existing readers: `services/gateway/src/services/guide/awareness-context.ts:267-272` and `services/gateway/src/services/recommendation-engine/ranking/index-pillar-weighter.ts:173`.

Fix:
- `tool_get_life_compass` selects the correct columns + filters `is_active=true` (users have multiple historical rows; one active).
- `/orb/context-bootstrap` Life Compass fetch uses the same corrected shape.
- Vertex catalog declaration's description now lists `goal` + `category`, not the imaginary `why`/`target_date`.

## Behavior change
- Agent voice sessions now resolve the user's actual geo for ENVIRONMENT CONTEXT.
- `get_life_compass` tool returns the user's real primary_goal text.
- `## Life Compass` block appears in `bootstrap_context` when the user has an active row.
- Vertex production path: unchanged. Vertex calls life_compass via the same shared tool, so it ALSO benefits from the fix (previously broken on Vertex too — explains why nobody flagged Life Compass on Vertex either: tool said "no goal text" for everyone).

## Test impact
- 2 snapshots updated (tool-catalog characterization + system-instruction characterization) for the new description text.
- **706/706 orb tests pass.**

## Acceptance
- [ ] User asks "where am I?" in German Test Bench → answer is their actual European city.
- [ ] User asks "what is my Life Compass?" → tool returns actual primary_goal text + category.
- [ ] ENVIRONMENT CONTEXT block in system_instruction shows correct city/country/timezone.
- [ ] `## Life Compass` block appears in bootstrap_context when user has an active row.
- [ ] Vertex `/orb/chat` smoke unchanged.

🤖 Generated with [Claude Code](https://claude.com/claude-code)