### PR TITLE
fix(test-bench): parallel-connect guard + truthful state on connect() reject (VTID-03023)

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -36327,6 +36327,16 @@ function renderLivekitTestView() {
             log('error', 'Production LiveKit is disabled (active=' + lktActiveProvider + '). Switch to Test-session mode or enable LiveKit canary in Voice Lab.');
             return;
         }
+        // Parallel-connect guard: if a Room already exists, refuse to spawn
+        // a second one. Without this guard, a stale Connect button (e.g.
+        // because room.connect() rejected even though the room is alive,
+        // see the catch block below) lets the user start a second
+        // WebRTC session on top of the first — both rooms publish the mic
+        // and play remote audio, producing two overlapping conversations.
+        if (room) {
+            log('warn', 'connect ignored — a session is already active. Click Disconnect first.');
+            return;
+        }
         connectBtn.disabled = true;
         setState('connecting');
         try {
@@ -36363,15 +36373,27 @@ function renderLivekitTestView() {
 
             room.on(LivekitClient.RoomEvent.ConnectionStateChanged, function (s) {
                 log('event', 'ConnectionStateChanged', { state: s });
-                if (s === LivekitClient.ConnectionState.Connected) {
+                // String compare (not the enum) so the listener stays correct
+                // even if a future bundle update relocates ConnectionState.
+                // Bundle values verified: 'connected' / 'connecting' /
+                // 'disconnected' / 'reconnecting' / 'signalReconnecting'.
+                if (s === 'connected') {
                     setState('connected');
                     disconnectBtn.disabled = false;
-                } else if (s === LivekitClient.ConnectionState.Disconnected) {
+                } else if (s === 'disconnected') {
                     setState('disconnected');
                     setMic(false);
                     setSpeaking(false);
                     connectBtn.disabled = false;
                     disconnectBtn.disabled = true;
+                    // Server-initiated tear-down: drop attached audio and
+                    // null the room reference so the parallel-connect guard
+                    // releases for the next Connect click.
+                    attachedAudio.forEach(function (el) { try { el.remove(); } catch (_) {} });
+                    attachedAudio = [];
+                    room = null;
+                } else if (s === 'reconnecting' || s === 'signalReconnecting') {
+                    setState(s);
                 }
             });
 
@@ -36488,9 +36510,26 @@ function renderLivekitTestView() {
             }
         } catch (e) {
             log('error', e.message || String(e));
+            // If room.connect() rejected but the room actually reached the
+            // Connected state (post-connect setup hiccup — late timeout,
+            // track-publish race, etc.), don't lie to the user about the
+            // state. The ConnectionStateChanged listener already painted
+            // 'connected'; keep it. The session is usable.
+            if (room && room.state === 'connected') {
+                log('warn', 'connect() rejected but room.state === connected; leaving session active', { err: e && e.message });
+                return;
+            }
             setState('disconnected');
             connectBtn.disabled = false;
             disconnectBtn.disabled = true;
+            // Tear down a partially-created room so the parallel-connect
+            // guard releases and the next click starts from a clean slate.
+            if (room) {
+                try { room.disconnect().catch(function () {}); } catch (_) {}
+                room = null;
+            }
+            attachedAudio.forEach(function (el) { try { el.remove(); } catch (_) {} });
+            attachedAudio = [];
         }
     }
 

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -30,7 +30,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260516-vtid-03019-vad-850"></script>
-  <script src="/command-hub/app.js?v=20260516-vtid-03018-prewarm"></script>
+  <script src="/command-hub/app.js?v=20260516-lkt-parallel-connect-guard"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
 </body>


### PR DESCRIPTION
## Summary

The LiveKit test bench had two linked bugs that the user could trigger with two clicks:

1. **CONNECTION display flipped to "disconnected" after a successful connect** — even though the room was alive and the agent was reachable.
2. **A second Connect click spawned a parallel WebRTC session on top of the first** — both rooms published the mic and played remote audio simultaneously, producing two overlapping conversations.

## Root cause

`room.connect()` can reject *after* the room has internally transitioned to the Connected state (post-connect setup hiccup — late timeout, track-publish race, transient WS blip). The previous flow then ran the outer catch block, which:
- Called `setState('disconnected')` — overwriting the listener's correct `'connected'` paint.
- Re-enabled the Connect button.
- Left the `room` variable pointing at a live, working Room.

A second click then ran `room = new LivekitClient.Room(...)`, orphaning the first Room (still publishing mic + playing audio) and starting a second session in parallel.

## Changes (one function, `renderLivekitTestView()`)

1. **Parallel-connect guard** at the top of `connect()`: if `room` is non-null, log a warning and return early.
2. **Honest catch block**: if `room.state === 'connected'` despite the rejection, leave the connected UI in place — the listener already painted it correctly, the session is usable. Otherwise tear down the partial room + clear `attachedAudio` before nulling.
3. **`ConnectionStateChanged` listener** now string-compares (`'connected'` / `'disconnected'` / `'reconnecting'` / `'signalReconnecting'`) instead of using `LivekitClient.ConnectionState.X`. The Disconnected branch also clears `attachedAudio` and nulls `room` so the parallel-connect guard releases for a clean reconnect.
4. **Cache-bust** bump: `20260516-vtid-03018-prewarm` → `20260516-lkt-parallel-connect-guard`.

Net diff: +41/-2 in `app.js`, +1/-1 in `index.html`.

## Test plan

- [ ] After deploy: open `/command-hub/voice/livekit-test/`, sign in, click Connect & Talk once → CONNECTION shows green `connected`, Disconnect enabled, Connect disabled.
- [ ] While connected, attempting a second Connect must be blocked (button stays disabled).
- [ ] Mid-session network kick → listener clears `room` and re-enables Connect.
- [ ] Click Disconnect, then Connect again → fresh session, no leftover audio elements.
- [ ] EVENT LOG never shows two parallel `ConnectionStateChanged { state: "connected" }` events for different rooms.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
