### PR TITLE
fix(orb): lift report_to_specialist shared core — bug-reporting parity on LiveKit (VTID-03024)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -2779,36 +2779,13 @@ async function executeLiveApiToolInner(
           };
         }
 
-        // v2e: server-side block on vague summaries. The LLM tool description
-        // forbids placeholder summaries like "user wants to report a bug",
-        // but we enforce server-side too. A vague summary causes the receiving
-        // specialist to invent the issue (the user's most-recent complaint:
-        // Devon hallucinated a "language switch" bug because Vitana's summary
-        // was just "user wants to report a technical bug").
-        //
-        // Heuristics: too short OR matches a placeholder pattern.
-        const wordCount = summary.split(/\s+/).filter(Boolean).length;
-        const VAGUE_PATTERNS = [
-          /^user (wants|would like|wishes) to report (a|an|the)?\s*(technical |bug|issue|problem|claim|complaint|account|support)?\s*(report|issue|problem|claim|bug|complaint|question|something)\.?$/i,
-          /^user has (a|an|the)?\s*(bug|issue|problem|claim|complaint|account|support|technical)\s*(report|issue|problem|claim|bug|complaint|question|matter)\.?$/i,
-          /^report a (bug|issue|problem|claim|complaint|technical)\s*\.?$/i,
-          /^bug report\.?$/i,
-          /^something is broken\.?$/i,
-          /^(user|customer)\s+(needs help|wants help|has a question)\.?$/i,
-        ];
-        const isVague = wordCount < 12 || VAGUE_PATTERNS.some(re => re.test(summary));
-        if (isVague) {
-          console.log(`[VTID-02670] report_to_specialist blocked — vague summary ("${summary}", ${wordCount} words). Asking model to collect specifics.`);
-          return {
-            success: true,
-            result: `ASK_FOR_SPECIFICS: Your summary "${summary}" is too vague. Do NOT call this tool again until you have a concrete description. Speak ONE follow-up question to the user IN THEIR LANGUAGE asking what specifically broke (which screen / feature / error message / what they were doing). Vary your phrasing every call. Then wait for their answer. Only after you have specifics, call this tool again with a real description (>= 12 words, in the user's own words). Do NOT mention this internal routing — just ask the question naturally.`,
-          };
-        }
-
         // Loop guard: hard cap of 1 forward per conversation. Once swap count
         // hits 2 (one forward + one return), block re-forward regardless of
         // what the LLM decides. Also a cooldown period after swap-back-to-
         // Vitana — prevents the immediate re-forward loop the user reported.
+        // VTID-03024: stays Vertex-only because it relies on
+        // session.swapCount + session.swapCooldownUntil (WebSocket state).
+        // LiveKit has no per-session swap counter yet.
         const swapCountForReport = ((session as any).swapCount as number | undefined) ?? 0;
         const swapCooldownUntil = ((session as any).swapCooldownUntil as number | undefined) ?? 0;
         if (swapCountForReport >= 2) {
@@ -2828,152 +2805,82 @@ async function executeLiveApiToolInner(
         }
 
         try {
-          const url = process.env.SUPABASE_URL!;
-          const key = process.env.SUPABASE_SERVICE_ROLE!;
-
-          // Resolve specialist via keyword router unless hinted explicitly.
-          // VTID-02653 Phase 6: when the session has a tenant context, use
-          // the tenant-aware RPC pick_specialist_for_text_tenant which
-          // UNIONs platform handoff_keywords with the tenant's own routing
-          // keywords (and respects tenant disable). Falls back to the
-          // platform-only RPC when no tenant context (anonymous sessions).
-          let pickedPersona = specialistHint;
-          let matchedKeyword: string | null = null;
-          let confidence: number | null = null;
-          let rpcDecision: string | null = null;
-          let rpcGate: string | null = null;
+          // VTID-03024: lift the SHARED data-layer work (vague block + gate
+          // RPC + feedback_tickets insert + handoff event + OASIS emit) into
+          // a helper both Vertex and LiveKit call. Below the helper call,
+          // Vertex layers its session-state mutations (pendingPersonaSwap,
+          // personaSystemOverride, SSE/WS notify, swapCount increment) on
+          // top — those stay here because they touch the live WebSocket
+          // session.
           const _reportTenantId = session.identity?.tenant_id;
-          if (!pickedPersona) {
-            try {
-              const rpcName = _reportTenantId
-                ? 'pick_specialist_for_text_tenant'
-                : 'pick_specialist_for_text';
-              // Gate A reads the user's RAW transcript, not the LLM-rewritten
-              // summary. The LLM compresses "how does X work?" into business-
-              // language like "user is asking about X feature", which bypasses
-              // stay-inline phrases. Raw user words preserve "how does", etc.
-              const gateInput = buildGateInputFromTranscript(session.transcriptTurns, summary);
-              const rpcBody = _reportTenantId
-                ? { p_text: gateInput, p_tenant_id: _reportTenantId }
-                : { p_text: gateInput };
-              const rpcResp = await fetch(`${url}/rest/v1/rpc/${rpcName}`, {
-                method: 'POST',
-                headers: { 'Content-Type': 'application/json', apikey: key, Authorization: `Bearer ${key}` },
-                body: JSON.stringify(rpcBody),
-              });
-              const rpcJson = await rpcResp.json().catch(() => null);
-              const row = Array.isArray(rpcJson) ? rpcJson[0] : rpcJson;
-              rpcDecision = row?.decision ?? null;
-              rpcGate = row?.gate ?? null;
-              if (row?.persona_key) {
-                pickedPersona = row.persona_key;
-                // Two-gate RPC returns matched_phrase; legacy/tenant variant returns matched_keyword.
-                matchedKeyword = row.matched_phrase ?? row.matched_keyword ?? null;
-                confidence = row.confidence ?? null;
-              }
-            } catch { /* keep empty hint, fall through */ }
+          const sbForReport = getSupabase();
+          if (!sbForReport) {
+            return { success: false, result: '', error: 'supabase_not_configured' };
           }
-
-          // Two-gate routing: if Gate A said stay-inline, OR Gate A failed
-          // (no explicit forward-request signal), Vitana keeps the user.
-          // No ticket. No swap. The model already received the user's words —
-          // it just needs to answer them.
-          if (rpcDecision === 'answer_inline') {
-            const gateLabel = rpcGate === 'stay_inline'
-              ? 'stay-inline override'
-              : (rpcGate === 'unrouted' ? 'no enabled specialist' : 'no explicit forward request');
-            console.log(`[VTID-02660] report_to_specialist suppressed (gate=${rpcGate}) — answering inline`);
-            return {
-              success: true,
-              result: `Stay with the user — this is not a customer-support handoff (${gateLabel}). Answer the question yourself as Vitana, the user's life companion. Do NOT mention this routing decision out loud.`,
-            };
-          }
-          // VTID-02651: kind→persona mapping is data-driven from
-          // agent_personas.handles_kinds. VTID-02653: tenant variant skips
-          // personas the tenant has disabled. Falls back to '' (caller
-          // skips swap) if no active persona claims the kind.
-          if (!pickedPersona) {
-            pickedPersona = _reportTenantId
-              ? ((await registryPickPersonaForKindForTenant(kind, _reportTenantId)) ?? '')
-              : ((await registryPickPersonaForKind(kind)) ?? '');
-          }
-
-          const insertResp = await fetch(`${url}/rest/v1/feedback_tickets`, {
-            method: 'POST',
-            headers: {
-              'Content-Type': 'application/json',
-              apikey: key,
-              Authorization: `Bearer ${key}`,
-              Prefer: 'return=representation',
-            },
-            body: JSON.stringify({
+          const { executeReportToSpecialist } = await import('../services/report-to-specialist-core');
+          // Gate A reads the user's RAW transcript, not the LLM-rewritten
+          // summary. The LLM compresses "how does X work?" into business-
+          // language like "user is asking about X feature", which bypasses
+          // stay-inline phrases. Raw user words preserve "how does", etc.
+          const gateInput = buildGateInputFromTranscript(session.transcriptTurns, summary);
+          const helperResult = await executeReportToSpecialist(
+            { kind, summary, specialist_hint: specialistHint },
+            {
               user_id: session.identity.user_id,
+              tenant_id: _reportTenantId ?? null,
               vitana_id: session.identity.vitana_id ?? null,
-              kind,
-              status: pickedPersona ? 'triaged' : 'new',
-              raw_transcript: summary,
-              intake_messages: [
-                { agent: 'vitana', role: 'user', content: summary, ts: new Date().toISOString() },
-              ],
-              structured_fields: {
-                specialist_hint: specialistHint || null,
-                voice_origin: true,
-              },
-              screen_path: '/orb/voice',
-              resolver_agent: pickedPersona || null,
-              triaged_at: pickedPersona ? new Date().toISOString() : null,
-            }),
-          });
-          if (!insertResp.ok) {
-            const errText = await insertResp.text().catch(() => '');
-            console.error(`[VTID-02047] feedback_tickets insert failed:`, insertResp.status, errText);
-            return { success: false, result: '', error: `insert failed: ${insertResp.status}` };
-          }
-          const created = await insertResp.json().catch(() => null);
-          const ticket = Array.isArray(created) ? created[0] : created;
-
-          // Log handoff event for Live Handoffs panel
-          if (pickedPersona) {
-            await fetch(`${url}/rest/v1/feedback_handoff_events`, {
-              method: 'POST',
-              headers: { 'Content-Type': 'application/json', apikey: key, Authorization: `Bearer ${key}` },
-              body: JSON.stringify({
-                conversation_id: session.sessionId,
-                ticket_id: ticket?.id,
-                user_id: session.identity.user_id,
-                vitana_id: session.identity.vitana_id ?? null,
-                from_agent: 'vitana',
-                to_agent: pickedPersona,
-                reason: 'off_domain_intent',
-                detected_intent: kind,
-                matched_keyword: matchedKeyword,
-                confidence: confidence,
-              }),
-            }).catch(() => undefined);
-          }
-
-          // Emit OASIS event so it shows in the inbox + KPIs
-          try {
-            const { emitOasisEvent } = await import('../services/oasis-event-service');
-            await emitOasisEvent({
-              vtid: 'VTID-02047',
-              type: 'feedback.ticket.created' as any,
+              lang: session.lang ?? null,
+            },
+            sbForReport,
+            {
+              gate_input: gateInput,
               source: 'orb-voice-tool',
-              status: 'info',
-              message: `Voice tool report_to_specialist created ticket ${ticket?.ticket_number} (${kind}) → ${pickedPersona || 'unrouted'}`,
-              payload: {
-                ticket_id: ticket?.id,
-                ticket_number: ticket?.ticket_number,
-                kind,
-                specialist: pickedPersona,
-                voice_origin: true,
+              screen_path: '/orb/voice',
+            },
+          );
+
+          // Branch on the helper's decision. vague + stay_inline both
+          // return the LLM instruction the model speaks; failed surfaces
+          // as a tool error; created continues to the session-state work.
+          if (helperResult.decision === 'failed') {
+            console.error(`[VTID-02047] report_to_specialist failed: ${helperResult.error}`);
+            return { success: false, result: '', error: helperResult.error };
+          }
+          if (helperResult.decision === 'vague') {
+            console.log(`[VTID-02670] report_to_specialist blocked — vague summary ("${summary}", ${helperResult.word_count} words). Asking model to collect specifics.`);
+            return { success: true, result: helperResult.llm_instruction };
+          }
+          if (helperResult.decision === 'stay_inline') {
+            console.log(`[VTID-02660] report_to_specialist suppressed (gate=${helperResult.rpc_gate}) — answering inline`);
+            return { success: true, result: helperResult.llm_instruction };
+          }
+
+          // helperResult.decision === 'created' — proceed with session-state swap.
+          const ticket = {
+            id: helperResult.ticket.id,
+            ticket_number: helperResult.ticket.ticket_number,
+          };
+          const pickedPersona = helperResult.persona ?? '';
+          // Vertex augments the helper's handoff_event insert with
+          // conversation_id (tied to the WebSocket session) so the Live
+          // Handoffs panel can correlate handoff → live session.
+          // The helper can't see session.sessionId; PATCH adds it after.
+          if (pickedPersona && session.sessionId) {
+            const url = process.env.SUPABASE_URL!;
+            const key = process.env.SUPABASE_SERVICE_ROLE!;
+            await fetch(
+              `${url}/rest/v1/feedback_handoff_events?ticket_id=eq.${encodeURIComponent(ticket.id)}`,
+              {
+                method: 'PATCH',
+                headers: {
+                  'Content-Type': 'application/json',
+                  apikey: key,
+                  Authorization: `Bearer ${key}`,
+                },
+                body: JSON.stringify({ conversation_id: session.sessionId }),
               },
-              actor_id: session.identity.user_id,
-              actor_role: 'user',
-              surface: 'orb',
-              vitana_id: session.identity.vitana_id ?? undefined,
-            });
-          } catch { /* non-blocking */ }
+            ).catch(() => undefined);
+          }
 
           const personaLabel: Record<string, string> = {
             devon: 'Devon (tech support)',

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -321,18 +321,88 @@ export async function tool_switch_persona(args: OrbToolArgs): Promise<OrbToolRes
   };
 }
 
-export async function tool_report_to_specialist(args: OrbToolArgs): Promise<OrbToolResult> {
-  const specialist = String(args.specialist ?? '').trim();
-  const reason = String(args.reason ?? '').trim();
-  return {
-    ok: true,
-    result: { specialist, reason, status: 'acknowledged' },
-    text:
-      `Handoff to ${specialist || 'a specialist'} acknowledged. The full ` +
-      `live persona swap (audible voice change) lands in a follow-up; for ` +
-      `now, please continue with me and I'll pass the context forward when ` +
-      `that ships.`,
-  };
+// VTID-03024: real ticket creation for LiveKit. Was previously a stub
+// that returned "acknowledged" and dropped the user's report on the
+// floor — Vertex's case arm in orb-live.ts did all the actual work.
+// The shared helper `executeReportToSpecialist` lifts the DATA layer
+// (vague block + gate RPC + feedback_tickets insert + handoff event +
+// OASIS emit) so both pipelines create real tickets.
+//
+// The audible Devon voice swap on LiveKit is a separate concern handled
+// by the orb-agent's `perform_handoff` function — wired in a follow-up
+// VTID. This handler returns the persona key in the result so the agent
+// can decide whether to invoke that handoff.
+export async function tool_report_to_specialist(
+  args: OrbToolArgs,
+  identity: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const { executeReportToSpecialist } = await import('./report-to-specialist-core');
+  const result = await executeReportToSpecialist(
+    {
+      kind: typeof args.kind === 'string' ? args.kind : undefined,
+      summary: typeof args.summary === 'string' ? args.summary : undefined,
+      specialist_hint:
+        typeof args.specialist_hint === 'string' ? args.specialist_hint : undefined,
+    },
+    {
+      user_id: identity.user_id,
+      tenant_id: identity.tenant_id ?? null,
+      vitana_id: identity.vitana_id ?? null,
+      lang: identity.lang ?? null,
+    },
+    sb,
+    {
+      source: 'orb-livekit-tool',
+      screen_path: '/orb/livekit-voice',
+    },
+  );
+
+  switch (result.decision) {
+    case 'failed':
+      return { ok: false, error: result.error };
+    case 'vague':
+      return {
+        ok: true,
+        result: { decision: 'vague', word_count: result.word_count },
+        text: result.llm_instruction,
+      };
+    case 'stay_inline':
+      return {
+        ok: true,
+        result: { decision: 'stay_inline', rpc_gate: result.rpc_gate },
+        text: result.llm_instruction,
+      };
+    case 'created': {
+      const personaLabel: Record<string, string> = {
+        devon: 'tech support',
+        sage: 'customer support',
+        atlas: 'finance / marketplace',
+        mira: 'account',
+      };
+      const roleLabel = result.persona
+        ? personaLabel[result.persona] ?? 'a specialist colleague'
+        : 'our team';
+      const ticketNum = result.ticket.ticket_number ?? '(pending)';
+      const llmInstruction = result.persona
+        ? `Ticket ${ticketNum} created. Speak ONE short bridge sentence in the user's language announcing the ROLE — "${roleLabel}". NEVER speak the persona's internal name (Devon, Sage, Atlas, Mira) out loud — the user has no context for those names. Examples (vary every call): "I'll connect you with ${roleLabel}." / "Let me bring ${roleLabel} in." / "Einen Moment, ${roleLabel} übernimmt." Then STOP — do NOT introduce the colleague yourself.`
+        : `Ticket ${ticketNum} created. Our team will look at this. Tell the user warmly that you've filed the report and they'll hear back — vary your phrasing. Then STOP.`;
+      return {
+        ok: true,
+        result: {
+          decision: 'created',
+          ticket_id: result.ticket.id,
+          ticket_number: result.ticket.ticket_number,
+          persona: result.persona,
+          matched_keyword: result.matched_keyword,
+          confidence: result.confidence,
+          rpc_decision: result.rpc_decision,
+          rpc_gate: result.rpc_gate,
+        },
+        text: llmInstruction,
+      };
+    }
+  }
 }
 
 export async function tool_search_events(
@@ -3522,7 +3592,7 @@ export const ORB_TOOL_REGISTRY: Record<string, OrbToolHandler> = {
   search_web: tool_search_web,
   recall_conversation_at_time: tool_recall_conversation_at_time,
   switch_persona: (args) => tool_switch_persona(args),
-  report_to_specialist: (args) => tool_report_to_specialist(args),
+  report_to_specialist: tool_report_to_specialist,
   search_events: tool_search_events,
   search_community: tool_search_community,
   // VTID-02754 — auto-redirecting community member search (PR 1.B-1)

--- a/services/gateway/src/services/report-to-specialist-core.ts
+++ b/services/gateway/src/services/report-to-specialist-core.ts
@@ -1,0 +1,304 @@
+/**
+ * VTID-03024 — shared core of the `report_to_specialist` voice tool.
+ *
+ * Vertex's orb-live.ts case arm and the LiveKit shared dispatcher
+ * (orb-tools-shared.ts:tool_report_to_specialist) both need IDENTICAL
+ * behaviour for the ticket-creation half of bug-reporting:
+ *
+ *   - vague-summary block (the LLM tried to file with a 6-word placeholder)
+ *   - two-gate routing via pick_specialist_for_text[_tenant] RPC
+ *   - kind → persona fallback via persona registry
+ *   - INSERT into `feedback_tickets`
+ *   - INSERT into `feedback_handoff_events` (so the Live Handoffs panel sees it)
+ *   - OASIS `feedback.ticket.created` event
+ *
+ * What stays out of this module (Vertex-only, WebSocket-state-coupled):
+ *   - swapCount + swapCooldownUntil loop guards
+ *   - persona swap onto the live session (pendingPersonaSwap,
+ *     personaSystemOverride, personaVoiceOverride, SSE/WS persona_swap
+ *     message to the frontend)
+ *   - transcript-based gate input construction
+ *   - persona-first-utterance flag reset
+ *
+ * The audible persona/voice swap on LiveKit (Devon answers in Devon's
+ * voice) is a separate concern — handled by `perform_handoff` in the
+ * orb-agent's session.py and gated behind the next VTID. This file is
+ * the DATA layer only.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  pickPersonaForKind as registryPickPersonaForKind,
+  pickPersonaForKindForTenant as registryPickPersonaForKindForTenant,
+} from './persona-registry';
+import { emitOasisEvent } from './oasis-event-service';
+
+export interface ReportToSpecialistArgs {
+  kind?: string;
+  summary?: string;
+  specialist_hint?: string;
+}
+
+export interface ReportToSpecialistIdentity {
+  user_id: string;
+  tenant_id: string | null;
+  vitana_id?: string | null;
+  lang?: string | null;
+}
+
+export interface ReportToSpecialistOptions {
+  /**
+   * Text fed to the `pick_specialist_for_text[_tenant]` two-gate RPC.
+   * Vertex passes a transcript-enhanced string (raw user words) so the
+   * gate can see phrases like "how does X work" that the LLM compresses
+   * out of `summary`. LiveKit has no equivalent transcript yet, so it
+   * defaults to `summary`.
+   */
+  gate_input?: string;
+  /**
+   * Source identifier surfaced in OASIS event metadata + Live Handoffs
+   * panel. Use 'orb-voice-tool' (Vertex), 'orb-livekit-tool' (LiveKit),
+   * or 'text-chat' if a future caller wires it up.
+   */
+  source?: string;
+  /**
+   * Screen the user was on when they hit "report a bug". '/orb/voice'
+   * for Vertex, '/orb/livekit-voice' for LiveKit.
+   */
+  screen_path?: string;
+}
+
+export type ReportToSpecialistResult =
+  | {
+      decision: 'vague';
+      llm_instruction: string;
+      word_count: number;
+    }
+  | {
+      decision: 'stay_inline';
+      llm_instruction: string;
+      rpc_gate: string | null;
+    }
+  | {
+      decision: 'created';
+      ticket: {
+        id: string;
+        ticket_number: string | null;
+      };
+      persona: string | null; // 'devon' | 'sage' | 'atlas' | 'mira' | null when unrouted
+      matched_keyword: string | null;
+      confidence: number | null;
+      rpc_decision: string | null;
+      rpc_gate: string | null;
+    }
+  | {
+      decision: 'failed';
+      error: string;
+    };
+
+const VAGUE_PATTERNS: RegExp[] = [
+  /^user (wants|would like|wishes) to report (a|an|the)?\s*(technical |bug|issue|problem|claim|complaint|account|support)?\s*(report|issue|problem|claim|bug|complaint|question|something)\.?$/i,
+  /^user has (a|an|the)?\s*(bug|issue|problem|claim|complaint|account|support|technical)\s*(report|issue|problem|claim|bug|complaint|question|matter)\.?$/i,
+  /^report a (bug|issue|problem|claim|complaint|technical)\s*\.?$/i,
+  /^bug report\.?$/i,
+  /^something is broken\.?$/i,
+  /^(user|customer)\s+(needs help|wants help|has a question)\.?$/i,
+];
+
+const VAGUE_INSTRUCTION = (summary: string) =>
+  `ASK_FOR_SPECIFICS: Your summary "${summary}" is too vague. Do NOT call this tool again until you have a concrete description. Speak ONE follow-up question to the user IN THEIR LANGUAGE asking what specifically broke (which screen / feature / error message / what they were doing). Vary your phrasing every call. Then wait for their answer. Only after you have specifics, call this tool again with a real description (>= 12 words, in the user's own words). Do NOT mention this internal routing — just ask the question naturally.`;
+
+function buildStayInlineInstruction(rpcGate: string | null): string {
+  const gateLabel = rpcGate === 'stay_inline'
+    ? 'stay-inline override'
+    : rpcGate === 'unrouted'
+      ? 'no enabled specialist'
+      : 'no explicit forward request';
+  return `Stay with the user — this is not a customer-support handoff (${gateLabel}). Answer the question yourself as Vitana, the user's life companion. Do NOT mention this routing decision out loud.`;
+}
+
+export async function executeReportToSpecialist(
+  args: ReportToSpecialistArgs,
+  identity: ReportToSpecialistIdentity,
+  sb: SupabaseClient,
+  options: ReportToSpecialistOptions = {},
+): Promise<ReportToSpecialistResult> {
+  const kind = String(args.kind ?? 'feedback').trim() || 'feedback';
+  const summary = String(args.summary ?? '').trim();
+  const specialistHint = String(args.specialist_hint ?? '').trim();
+
+  if (!summary) {
+    return { decision: 'failed', error: 'summary is required' };
+  }
+
+  const wordCount = summary.split(/\s+/).filter(Boolean).length;
+  const isVague =
+    wordCount < 12 || VAGUE_PATTERNS.some((re) => re.test(summary));
+  if (isVague) {
+    return {
+      decision: 'vague',
+      llm_instruction: VAGUE_INSTRUCTION(summary),
+      word_count: wordCount,
+    };
+  }
+
+  // Two-gate routing. Tenant-aware variant when we have tenant context.
+  const gateInput = options.gate_input ?? summary;
+  let pickedPersona = specialistHint;
+  let matchedKeyword: string | null = null;
+  let confidence: number | null = null;
+  let rpcDecision: string | null = null;
+  let rpcGate: string | null = null;
+  const tenantId = identity.tenant_id;
+
+  if (!pickedPersona) {
+    try {
+      const rpcName = tenantId
+        ? 'pick_specialist_for_text_tenant'
+        : 'pick_specialist_for_text';
+      const rpcArgs: Record<string, unknown> = { p_text: gateInput };
+      if (tenantId) rpcArgs.p_tenant_id = tenantId;
+      const { data: rpcData, error: rpcError } = await sb.rpc(
+        rpcName,
+        rpcArgs as never,
+      );
+      if (rpcError) {
+        // Gate failure isn't fatal — fall through to the kind→persona
+        // fallback. We log on the caller side; here we just surface
+        // null gate metadata in the result so traces stay honest.
+      } else {
+        const row = Array.isArray(rpcData) ? rpcData[0] : rpcData;
+        rpcDecision = row?.decision ?? null;
+        rpcGate = row?.gate ?? null;
+        if (row?.persona_key) {
+          pickedPersona = row.persona_key;
+          // The two-gate RPC returns `matched_phrase`; legacy/tenant
+          // variant returns `matched_keyword`.
+          matchedKeyword = row.matched_phrase ?? row.matched_keyword ?? null;
+          confidence = row.confidence ?? null;
+        }
+      }
+    } catch {
+      /* keep empty hint, fall through to kind-based fallback */
+    }
+  }
+
+  // Gate A says stay-inline → don't file a ticket, don't swap. Vitana
+  // keeps the user. Return the LLM the instruction string Vertex used.
+  if (rpcDecision === 'answer_inline') {
+    return {
+      decision: 'stay_inline',
+      llm_instruction: buildStayInlineInstruction(rpcGate),
+      rpc_gate: rpcGate,
+    };
+  }
+
+  // Kind→persona fallback when gate didn't pick one.
+  if (!pickedPersona) {
+    try {
+      pickedPersona = tenantId
+        ? ((await registryPickPersonaForKindForTenant(kind, tenantId)) ?? '')
+        : ((await registryPickPersonaForKind(kind)) ?? '');
+    } catch {
+      pickedPersona = '';
+    }
+  }
+
+  // Ticket insert.
+  const source = options.source ?? 'orb-voice-tool';
+  const screenPath = options.screen_path ?? '/orb/voice';
+  const triagedAt = pickedPersona ? new Date().toISOString() : null;
+  const { data: created, error: insertError } = await sb
+    .from('feedback_tickets')
+    .insert({
+      user_id: identity.user_id,
+      vitana_id: identity.vitana_id ?? null,
+      kind,
+      status: pickedPersona ? 'triaged' : 'new',
+      raw_transcript: summary,
+      intake_messages: [
+        {
+          agent: 'vitana',
+          role: 'user',
+          content: summary,
+          ts: new Date().toISOString(),
+        },
+      ],
+      structured_fields: {
+        specialist_hint: specialistHint || null,
+        voice_origin: true,
+        source,
+      },
+      screen_path: screenPath,
+      resolver_agent: pickedPersona || null,
+      triaged_at: triagedAt,
+    })
+    .select('id, ticket_number')
+    .single();
+
+  if (insertError || !created) {
+    return {
+      decision: 'failed',
+      error: `feedback_tickets insert failed: ${insertError?.message ?? 'no row returned'}`,
+    };
+  }
+
+  const ticket = created as { id: string; ticket_number: string | null };
+
+  // Live Handoffs panel event — only when a specialist was picked.
+  if (pickedPersona) {
+    try {
+      await sb.from('feedback_handoff_events').insert({
+        ticket_id: ticket.id,
+        user_id: identity.user_id,
+        vitana_id: identity.vitana_id ?? null,
+        from_agent: 'vitana',
+        to_agent: pickedPersona,
+        reason: 'off_domain_intent',
+        detected_intent: kind,
+        matched_keyword: matchedKeyword,
+        confidence,
+      });
+    } catch {
+      /* non-blocking — the ticket is the source of truth */
+    }
+  }
+
+  // OASIS event so cockpit Feedback Inbox + KPIs pick it up.
+  try {
+    await emitOasisEvent({
+      vtid: 'VTID-02047',
+      type: 'feedback.ticket.created' as never,
+      source,
+      status: 'info',
+      message: `Voice tool report_to_specialist created ticket ${ticket.ticket_number ?? '(pending)'} (${kind}) → ${pickedPersona || 'unrouted'}`,
+      payload: {
+        ticket_id: ticket.id,
+        ticket_number: ticket.ticket_number,
+        kind,
+        specialist: pickedPersona,
+        voice_origin: true,
+        source,
+      },
+      actor_id: identity.user_id,
+      actor_role: 'user',
+      surface: 'orb',
+      vitana_id: identity.vitana_id ?? undefined,
+    });
+  } catch {
+    /* non-blocking */
+  }
+
+  return {
+    decision: 'created',
+    ticket: {
+      id: ticket.id,
+      ticket_number: ticket.ticket_number,
+    },
+    persona: pickedPersona || null,
+    matched_keyword: matchedKeyword,
+    confidence,
+    rpc_decision: rpcDecision,
+    rpc_gate: rpcGate,
+  };
+}


### PR DESCRIPTION
## Summary
Bug-reporting (\"I want to report a bug\") works on Vertex but is silently broken on LiveKit. Vertex's `report_to_specialist` case arm in `orb-live.ts` is a 250-line inline that creates a real `feedback_tickets` row, logs the handoff event, and emits OASIS telemetry. The LiveKit shared dispatcher's `tool_report_to_specialist` in `orb-tools-shared.ts` was a 10-line stub that returned \"acknowledged\" and dropped the user's report on the floor — no ticket ever filed.

This PR lifts the DATA layer into a new shared helper. Both pipelines now create real tickets via the same code. Vertex retains its WebSocket-state-coupled work on top.

## Changes
- **NEW** `services/gateway/src/services/report-to-specialist-core.ts` — `executeReportToSpecialist(args, identity, sb, opts)` returns `{ decision: 'vague' | 'stay_inline' | 'created' | 'failed' }` plus ticket / persona / gate metadata. Owns: vague-summary block, two-gate RPC, feedback_tickets insert, feedback_handoff_events insert, OASIS `feedback.ticket.created` emit.
- `orb-tools-shared.ts:tool_report_to_specialist` — stub → real impl calling the helper. Returns the right LLM-facing instruction per decision. Registered with full `(args, identity, sb)` signature.
- `orb-live.ts` Vertex case arm — removes ~150 lines of inline ticket machinery, calls helper instead. Session-state mutation block (pendingPersonaSwap, personaSystemOverride, SSE/WS notify, swapCount++) STAYS UNCHANGED — it's the Vertex-only audible persona swap. PATCH adds `conversation_id` to the handoff_event row after the helper insert.

## What this DOES NOT do
- Audible Devon voice swap on LiveKit. `perform_handoff()` exists in `services/agents/orb-agent/src/orb_agent/session.py:1264` but is never invoked. Wiring it from the tool dispatch path is the next ticket. Risk noted: livekit-agents may not allow runtime `session.llm` / `session.tts` mutation (same way it didn't allow `.instructions` in VTID-03017). Will instrument that separately.

## Test plan
- [ ] DEPLOY-EXEC-GATEWAY auto-fires (touches gateway only — no agent deploy needed for .a).
- [ ] LiveKit Test Bench: \"I want to report a bug. The settings page doesn't save my changes.\" → Vitana asks specifics → user details → Vitana files real ticket → confirms.
- [ ] Cockpit Feedback Inbox: new ticket appears with `voice_origin: true`, `source: 'orb-livekit-tool'`.
- [ ] Live Handoffs panel: new handoff event row.
- [ ] Vertex `/orb/chat` smoke: ticket-creation behavior unchanged.
- [ ] 706 orb tests still green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)