### PR TITLE
feat(voice-lab): hourly LiveKit dry-run test framework — Slice 1a foundation (VTID-03025)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1871,7 +1871,10 @@ function buildPersonaBehavioralRule(personaKey: string): string {
   return lines.join('\n');
 }
 
-async function buildBootstrapContextPack(
+// VTID-03025: exported so the voice-lab dry-run evaluator can mirror the
+// exact bootstrap-context fetch the live session uses. No behavior change —
+// only the visibility modifier was added.
+export async function buildBootstrapContextPack(
   identity: SupabaseIdentity,
   sessionId: string
 ): Promise<{

--- a/services/gateway/src/routes/voice-lab.ts
+++ b/services/gateway/src/routes/voice-lab.ts
@@ -9,9 +9,9 @@
  * - GET /api/v1/voice-lab/live/sessions/:sessionId/turns - Get session turns
  */
 
-import { Router, Request, Response } from 'express';
+import { Router, Request, Response, NextFunction } from 'express';
 import { z } from 'zod';
-import { requireAuth } from '../middleware/auth-supabase-jwt';
+import { requireAuth, optionalAuth, type AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
 import { analyzeSessionEvents } from '../services/voice-session-analyzer';
 import { runVoiceProbe } from '../services/voice-synthetic-probe';
 import {
@@ -30,6 +30,16 @@ import {
   buildShadowComparison,
   buildLiveMonitor,
 } from '../services/voice-healing-summary';
+// VTID-03025: LiveKit hourly tests — Slice 1a foundation.
+import {
+  runLiveKitTestSuite,
+  listRecentRuns as listLivekitTestRuns,
+  getRunDetail as getLivekitTestRunDetail,
+  listCases as listLivekitTestCases,
+} from '../services/voice-lab/livekit-test-runner';
+import {
+  evaluateLiveKitDryRun,
+} from '../services/voice-lab/livekit-test-eval';
 
 const router = Router();
 
@@ -52,6 +62,207 @@ router.get('/health', (_req: Request, res: Response) => {
     timestamp: new Date().toISOString(),
   });
 });
+
+// =============================================================================
+// VTID-03025: LiveKit hourly tests — Slice 1a foundation.
+//
+// Routes registered BEFORE `router.use(requireAuth)` because they accept
+// EITHER the GitHub Actions cron's service token OR an admin Supabase JWT.
+// The same dual gate is used by `routes/oasis-emit.ts`.
+//
+// POST /tests/run    — execute all enabled cases serially, return summary
+// POST /tests/eval   — execute ONE ad-hoc prompt; for debug/admin probing
+// GET  /tests/runs   — list recent run summaries
+// GET  /tests/runs/:id — full results for one run
+// GET  /tests/cases  — list registered cases
+// =============================================================================
+
+const LIVEKIT_TESTS_VTID = 'VTID-03025';
+
+function livekitTestsAuthGate(
+  req: Request,
+  res: Response,
+  next: NextFunction,
+): void {
+  const header = req.header('authorization') ?? req.header('Authorization');
+  if (!header || !header.toLowerCase().startsWith('bearer ')) {
+    res.status(401).json({
+      ok: false,
+      error: 'missing bearer token',
+      vtid: LIVEKIT_TESTS_VTID,
+    });
+    return;
+  }
+  const token = header.slice('bearer '.length).trim();
+  if (!token) {
+    res.status(401).json({
+      ok: false,
+      error: 'empty bearer token',
+      vtid: LIVEKIT_TESTS_VTID,
+    });
+    return;
+  }
+
+  const serviceToken = process.env.GATEWAY_SERVICE_TOKEN ?? '';
+  if (serviceToken.length > 0 && token === serviceToken) {
+    (req as AuthenticatedRequest).identity = undefined;
+    (req as Request & { __livekit_tests_actor?: string }).__livekit_tests_actor =
+      'service:cron';
+    next();
+    return;
+  }
+
+  // JWT path → must be exafy_admin.
+  optionalAuth(req as AuthenticatedRequest, res, () => {
+    const id = (req as AuthenticatedRequest).identity;
+    if (id && id.exafy_admin === true) {
+      (req as Request & { __livekit_tests_actor?: string }).__livekit_tests_actor =
+        `admin:${id.user_id ?? 'unknown'}`;
+      next();
+      return;
+    }
+    res.status(401).json({
+      ok: false,
+      error: 'unauthorized — service token or exafy_admin JWT required',
+      vtid: LIVEKIT_TESTS_VTID,
+    });
+  });
+}
+
+const RunPostSchema = z.object({
+  trigger: z.enum(['manual', 'cron', 'admin', 'test']).default('manual'),
+  case_key: z.string().min(1).max(128).optional(),
+  layer: z.enum(['A', 'B']).default('A'),
+});
+
+router.post(
+  '/tests/run',
+  livekitTestsAuthGate,
+  async (req: Request, res: Response) => {
+    const parsed = RunPostSchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      return res.status(400).json({
+        ok: false,
+        error: 'invalid request body',
+        issues: parsed.error.issues,
+        vtid: LIVEKIT_TESTS_VTID,
+      });
+    }
+    try {
+      const summary = await runLiveKitTestSuite({
+        trigger: parsed.data.trigger,
+        caseKey: parsed.data.case_key,
+        layer: parsed.data.layer,
+      });
+      return res.status(200).json({ ok: true, vtid: LIVEKIT_TESTS_VTID, summary });
+    } catch (err) {
+      return res.status(500).json({
+        ok: false,
+        error: (err as Error).message ?? String(err),
+        vtid: LIVEKIT_TESTS_VTID,
+      });
+    }
+  },
+);
+
+const EvalPostSchema = z.object({
+  prompt: z.string().min(1).max(4000),
+  language: z.string().min(2).max(8).optional(),
+  current_route: z.string().max(256).nullable().optional(),
+  active_role: z.string().max(64).optional(),
+});
+
+router.post(
+  '/tests/eval',
+  livekitTestsAuthGate,
+  async (req: Request, res: Response) => {
+    const parsed = EvalPostSchema.safeParse(req.body ?? {});
+    if (!parsed.success) {
+      return res.status(400).json({
+        ok: false,
+        error: 'invalid request body',
+        issues: parsed.error.issues,
+        vtid: LIVEKIT_TESTS_VTID,
+      });
+    }
+    try {
+      const result = await evaluateLiveKitDryRun({
+        prompt: parsed.data.prompt,
+        language: parsed.data.language,
+        currentRoute: parsed.data.current_route,
+        activeRole: parsed.data.active_role,
+      });
+      return res.status(200).json({ ok: true, vtid: LIVEKIT_TESTS_VTID, result });
+    } catch (err) {
+      return res.status(500).json({
+        ok: false,
+        error: (err as Error).message ?? String(err),
+        vtid: LIVEKIT_TESTS_VTID,
+      });
+    }
+  },
+);
+
+router.get(
+  '/tests/runs',
+  livekitTestsAuthGate,
+  async (req: Request, res: Response) => {
+    const limitRaw = req.query.limit;
+    const limit = typeof limitRaw === 'string' ? Number(limitRaw) : 50;
+    const safeLimit = Number.isFinite(limit) && limit > 0 ? Math.min(limit, 200) : 50;
+    try {
+      const runs = await listLivekitTestRuns(safeLimit);
+      return res.status(200).json({ ok: true, vtid: LIVEKIT_TESTS_VTID, runs });
+    } catch (err) {
+      return res.status(500).json({
+        ok: false,
+        error: (err as Error).message ?? String(err),
+        vtid: LIVEKIT_TESTS_VTID,
+      });
+    }
+  },
+);
+
+router.get(
+  '/tests/runs/:id',
+  livekitTestsAuthGate,
+  async (req: Request, res: Response) => {
+    try {
+      const detail = await getLivekitTestRunDetail(req.params.id);
+      if (!detail) {
+        return res.status(404).json({
+          ok: false,
+          error: 'run not found',
+          vtid: LIVEKIT_TESTS_VTID,
+        });
+      }
+      return res.status(200).json({ ok: true, vtid: LIVEKIT_TESTS_VTID, ...detail });
+    } catch (err) {
+      return res.status(500).json({
+        ok: false,
+        error: (err as Error).message ?? String(err),
+        vtid: LIVEKIT_TESTS_VTID,
+      });
+    }
+  },
+);
+
+router.get(
+  '/tests/cases',
+  livekitTestsAuthGate,
+  async (_req: Request, res: Response) => {
+    try {
+      const cases = await listLivekitTestCases();
+      return res.status(200).json({ ok: true, vtid: LIVEKIT_TESTS_VTID, cases });
+    } catch (err) {
+      return res.status(500).json({
+        ok: false,
+        error: (err as Error).message ?? String(err),
+        vtid: LIVEKIT_TESTS_VTID,
+      });
+    }
+  },
+);
 
 router.use(requireAuth);
 

--- a/services/gateway/src/services/voice-lab/livekit-test-eval.ts
+++ b/services/gateway/src/services/voice-lab/livekit-test-eval.ts
@@ -27,12 +27,19 @@
 import { randomUUID } from 'crypto';
 
 import { getSupabase } from '../../lib/supabase';
-import {
-  buildBootstrapContextPack,
-  buildLiveApiTools,
-} from '../../routes/orb-live';
-import { buildLiveSystemInstruction } from '../../orb/live/instruction/live-system-instruction';
 import type { SupabaseIdentity } from '../../middleware/auth-supabase-jwt';
+
+// NB: `buildBootstrapContextPack` / `buildLiveApiTools` (from routes/orb-live)
+// AND `buildLiveSystemInstruction` (from orb/live/instruction/, which itself
+// re-imports buildNavigatorPolicySection from routes/orb-live) are all
+// imported LAZILY inside `evaluateLiveKitDryRun()` rather than statically
+// here. Pulling them in at module-load time drags ALL of `routes/orb-live.ts`
+// (14k+ lines, 30+ middleware/route registrations) into the dependency
+// graph, which then breaks any test that mocks `auth-supabase-jwt`
+// (e.g. `test/routes/voice-lab.test.ts`) — express barfs at module-init
+// with "Route.post() requires a callback function but got a [object
+// Undefined]" because the mock doesn't supply `optionalAuth`. Lazy import
+// defers the load until first eval call, leaving existing test mocks alone.
 
 export interface DryRunIdentity {
   user_id: string;
@@ -110,6 +117,14 @@ export async function evaluateLiveKitDryRun(
     iat: null,
     vitana_id: identity.vitana_id ?? null,
   };
+
+  // Lazy load — see file header for the reason.
+  const [orbLiveModule, instructionModule] = await Promise.all([
+    import('../../routes/orb-live'),
+    import('../../orb/live/instruction/live-system-instruction'),
+  ]);
+  const { buildBootstrapContextPack, buildLiveApiTools } = orbLiveModule;
+  const { buildLiveSystemInstruction } = instructionModule;
 
   const bootstrapResult = await buildBootstrapContextPack(
     supabaseIdentity,

--- a/services/gateway/src/services/voice-lab/livekit-test-eval.ts
+++ b/services/gateway/src/services/voice-lab/livekit-test-eval.ts
@@ -1,0 +1,294 @@
+/**
+ * VTID-03025: LiveKit hourly tests — Layer-A dry-run evaluator.
+ *
+ * Sends a synthetic user prompt through the same prompt assembly the
+ * LiveKit voice agent uses, captures what Gemini WOULD call, and returns
+ * the tool_calls + reply text WITHOUT executing any tool. Used by the
+ * hourly runner to verify tool routing without side effects.
+ *
+ * Faithfully mirrors the live agent:
+ *   - bootstrap context via `buildBootstrapContextPack(identity, sessionId)`
+ *   - system instruction via `buildLiveSystemInstruction(...)`
+ *   - tool catalog via `buildLiveApiTools('authenticated', ...)`
+ *
+ * Bypasses (declared out-of-scope, Layer B):
+ *   - LiveKit room / audio / STT / TTS
+ *   - Vertex AI Live API WebSocket transport (uses REST generateContent)
+ *   - livekit-plugins-google SDK internal tool transforms
+ *   - Tool execution (dry-run; no side effects)
+ *
+ * Drift risk: gateway hand-builds function_declarations; the live agent's
+ * SDK auto-derives them from Python @function_tool decorators. Tool NAMES
+ * match by construction (spec.json contract); parameter schemas may
+ * differ subtly. Acceptable for tool-routing tests; not for arg-level
+ * schema validation.
+ */
+
+import { randomUUID } from 'crypto';
+
+import { getSupabase } from '../../lib/supabase';
+import {
+  buildBootstrapContextPack,
+  buildLiveApiTools,
+} from '../../routes/orb-live';
+import { buildLiveSystemInstruction } from '../../orb/live/instruction/live-system-instruction';
+import type { SupabaseIdentity } from '../../middleware/auth-supabase-jwt';
+
+export interface DryRunIdentity {
+  user_id: string;
+  tenant_id: string;
+  vitana_id?: string | null;
+  email?: string | null;
+  active_role?: string;
+}
+
+export interface DryRunEvalInput {
+  prompt: string;
+  /** Identity to bootstrap. If omitted, falls back to the default test user
+   *  resolved from VOICE_LAB_TEST_USER_ID env or the CLAUDE.md test UUID. */
+  identity?: Partial<DryRunIdentity>;
+  language?: string;
+  voiceStyle?: string;
+  currentRoute?: string | null;
+  activeRole?: string;
+  /** Defaults to `process.env.VOICE_LAB_TEST_MODEL` or `gemini-2.5-pro`. */
+  model?: string;
+}
+
+export interface DryRunToolCall {
+  name: string;
+  args: Record<string, unknown>;
+}
+
+export interface DryRunEvalResult {
+  tool_calls: DryRunToolCall[];
+  reply_text: string;
+  latency_ms: number;
+  instruction_chars: number;
+  tool_count: number;
+  model: string;
+  resolved_identity: DryRunIdentity;
+  warnings?: string[];
+}
+
+/** UUID hardcoded in CLAUDE.md as the canonical Vitana platform test user. */
+const FALLBACK_TEST_USER_ID = 'a27552a3-0257-4305-8ed0-351a80fd3701';
+
+/**
+ * Run one dry-run case end-to-end. Throws on unrecoverable assembly
+ * failures (missing test user, no Gemini credentials, etc.). Recoverable
+ * issues (bootstrap fetch returned `skippedReason`) are reported via the
+ * `warnings` field on the result.
+ */
+export async function evaluateLiveKitDryRun(
+  input: DryRunEvalInput,
+): Promise<DryRunEvalResult> {
+  const warnings: string[] = [];
+
+  const identity = await resolveDryRunIdentity(input.identity);
+
+  const language = input.language ?? 'en';
+  const voiceStyle = input.voiceStyle ?? 'friendly, calm, empathetic';
+  const activeRole = input.activeRole ?? identity.active_role ?? 'patient';
+  const currentRoute = input.currentRoute ?? null;
+  const model =
+    input.model ??
+    process.env.VOICE_LAB_TEST_MODEL ??
+    process.env.VERTEX_MODEL ??
+    'gemini-2.5-pro';
+
+  // Bootstrap context — same call the live session does at session start.
+  const sessionId = `voicelab-test-${randomUUID()}`;
+  const supabaseIdentity: SupabaseIdentity = {
+    user_id: identity.user_id,
+    email: identity.email ?? null,
+    tenant_id: identity.tenant_id,
+    exafy_admin: false,
+    role: 'authenticated',
+    aud: null,
+    exp: null,
+    iat: null,
+    vitana_id: identity.vitana_id ?? null,
+  };
+
+  const bootstrapResult = await buildBootstrapContextPack(
+    supabaseIdentity,
+    sessionId,
+  );
+  if (bootstrapResult.skippedReason) {
+    warnings.push(`bootstrap_skipped:${bootstrapResult.skippedReason}`);
+  }
+
+  const systemInstruction = buildLiveSystemInstruction(
+    language,
+    voiceStyle,
+    bootstrapResult.contextInstruction ?? undefined,
+    activeRole,
+    /* conversationSummary */ undefined,
+    /* conversationHistory */ undefined,
+    /* isReconnect */ false,
+    /* lastSessionInfo */ null,
+    currentRoute,
+    /* recentRoutes */ null,
+    /* clientContext */ undefined,
+    identity.vitana_id ?? null,
+  );
+
+  // Tool catalog — Live API shape is `[{ function_declarations: [...] }]`
+  // (snake_case via the BidiGenerate setup message). The Vertex SDK's
+  // generateContent expects `[{ functionDeclarations: [...] }]` (camelCase).
+  // Names + parameter schemas are byte-identical between the two; only the
+  // wrapper key name differs.
+  const liveTools = buildLiveApiTools('authenticated', currentRoute ?? undefined, activeRole);
+  const sdkTools = adaptToolsForVertexSdk(liveTools);
+  const toolCount = countDeclarations(sdkTools);
+
+  const startedAt = Date.now();
+
+  const { VertexAI } = await import('@google-cloud/vertexai');
+  const projectId =
+    process.env.GOOGLE_CLOUD_PROJECT ?? process.env.GCP_PROJECT ?? null;
+  if (!projectId) {
+    throw new Error(
+      'evaluateLiveKitDryRun: GOOGLE_CLOUD_PROJECT not set — cannot reach Vertex',
+    );
+  }
+  const location = process.env.VERTEX_LOCATION ?? 'us-central1';
+  const vertex = new VertexAI({ project: projectId, location });
+
+  // Same shape llm-router.ts uses; `as any` mirrors that pattern so the
+  // Node SDK's narrow tool typings don't reject our adapted catalog.
+  const generativeModel = vertex.getGenerativeModel({
+    model,
+    systemInstruction: { role: 'system', parts: [{ text: systemInstruction }] },
+    tools: sdkTools,
+    generationConfig: { maxOutputTokens: 1024 },
+  } as any);
+
+  const result = await generativeModel.generateContent({
+    contents: [
+      {
+        role: 'user',
+        parts: [{ text: input.prompt }],
+      },
+    ],
+  });
+
+  const latencyMs = Date.now() - startedAt;
+
+  const candidate = result.response?.candidates?.[0];
+  const parts =
+    (candidate?.content?.parts as Array<{
+      text?: string;
+      functionCall?: { name?: string; args?: Record<string, unknown> };
+    }>) ?? [];
+
+  const tool_calls: DryRunToolCall[] = [];
+  let reply_text = '';
+  for (const p of parts) {
+    if (p.functionCall?.name) {
+      tool_calls.push({
+        name: p.functionCall.name,
+        args: (p.functionCall.args ?? {}) as Record<string, unknown>,
+      });
+    } else if (typeof p.text === 'string') {
+      reply_text += p.text;
+    }
+  }
+
+  return {
+    tool_calls,
+    reply_text: reply_text.trim(),
+    latency_ms: latencyMs,
+    instruction_chars: systemInstruction.length,
+    tool_count: toolCount,
+    model,
+    resolved_identity: identity,
+    warnings: warnings.length > 0 ? warnings : undefined,
+  };
+}
+
+/**
+ * Resolve a complete identity for the dry-run from the caller's partial
+ * input + env + DB. Falls back to the hardcoded CLAUDE.md test user.
+ * Looks up tenant_id via `app_users` if not supplied.
+ */
+async function resolveDryRunIdentity(
+  partial?: Partial<DryRunIdentity>,
+): Promise<DryRunIdentity> {
+  const userId =
+    partial?.user_id ??
+    process.env.VOICE_LAB_TEST_USER_ID ??
+    FALLBACK_TEST_USER_ID;
+
+  let tenantId = partial?.tenant_id ?? process.env.VOICE_LAB_TEST_TENANT_ID ?? null;
+  let vitanaId = partial?.vitana_id ?? null;
+  let email = partial?.email ?? null;
+  let activeRole = partial?.active_role;
+
+  if (!tenantId || !vitanaId || !email) {
+    const sb = getSupabase();
+    if (sb) {
+      const { data } = await sb
+        .from('app_users')
+        .select('user_id, tenant_id, vitana_id, email, role')
+        .eq('user_id', userId)
+        .maybeSingle();
+      if (data) {
+        if (!tenantId) tenantId = (data as { tenant_id?: string | null }).tenant_id ?? null;
+        if (!vitanaId) vitanaId = (data as { vitana_id?: string | null }).vitana_id ?? null;
+        if (!email) email = (data as { email?: string | null }).email ?? null;
+        if (!activeRole) {
+          activeRole = (data as { role?: string | null }).role ?? undefined;
+        }
+      }
+    }
+  }
+
+  if (!tenantId) {
+    throw new Error(
+      `evaluateLiveKitDryRun: tenant_id unresolved for user ${userId} — ` +
+        'pass identity.tenant_id explicitly or set VOICE_LAB_TEST_TENANT_ID',
+    );
+  }
+
+  return {
+    user_id: userId,
+    tenant_id: tenantId,
+    vitana_id: vitanaId,
+    email,
+    active_role: activeRole,
+  };
+}
+
+/**
+ * Translate the Live API tool catalog (snake_case `function_declarations`)
+ * into the Vertex SDK shape (camelCase `functionDeclarations`).
+ *
+ * The Live catalog is `Array<{ function_declarations: Decl[] }>` so it
+ * always returns at most ONE wrapper today, but we iterate defensively
+ * in case the catalog ever splits into multiple wrappers.
+ */
+function adaptToolsForVertexSdk(
+  liveTools: object[],
+): Array<{ functionDeclarations: object[] }> {
+  const out: Array<{ functionDeclarations: object[] }> = [];
+  for (const entry of liveTools as Array<Record<string, unknown>>) {
+    const decls = (entry as { function_declarations?: unknown }).function_declarations;
+    if (Array.isArray(decls)) {
+      out.push({ functionDeclarations: decls as object[] });
+    } else {
+      const camel = (entry as { functionDeclarations?: unknown }).functionDeclarations;
+      if (Array.isArray(camel)) {
+        out.push({ functionDeclarations: camel as object[] });
+      }
+    }
+  }
+  return out;
+}
+
+function countDeclarations(
+  sdkTools: Array<{ functionDeclarations: object[] }>,
+): number {
+  return sdkTools.reduce((sum, w) => sum + (w.functionDeclarations?.length ?? 0), 0);
+}

--- a/services/gateway/src/services/voice-lab/livekit-test-runner.ts
+++ b/services/gateway/src/services/voice-lab/livekit-test-runner.ts
@@ -1,0 +1,461 @@
+/**
+ * VTID-03025: LiveKit hourly tests — orchestrator.
+ *
+ * Loads enabled cases from `livekit_test_cases`, evaluates each via the
+ * dry-run evaluator, scores against the golden contract, and writes one
+ * row per case to `livekit_test_results` plus a summary row to
+ * `livekit_test_runs`.
+ *
+ * Behavior:
+ *   - Cases are evaluated SERIALLY. Hourly cadence × ~13 cases × ~3-5s
+ *     each = ~40-65s end-to-end. Acceptable for synchronous cron POSTs.
+ *   - One automatic retry per case when the first attempt fails
+ *     (status='failed', not 'errored'). The second attempt's outcome is
+ *     authoritative; the result row carries `retried=true`.
+ *   - Errors during evaluation (network, auth, throw) → status='errored'
+ *     with the error message captured. No retry on errored — those need
+ *     human diagnosis.
+ *   - The run row is created BEFORE the first case so partial progress
+ *     is observable. Totals are updated at the end.
+ *
+ * No tool execution. Side-effect free at the tool layer. The only DB
+ * writes are the runner's own bookkeeping rows in `livekit_test_*`.
+ */
+
+import { getSupabase } from '../../lib/supabase';
+import {
+  evaluateLiveKitDryRun,
+  type DryRunEvalResult,
+  type DryRunIdentity,
+} from './livekit-test-eval';
+import {
+  scoreResult,
+  type ExpectedContract,
+  type ScoreOutcome,
+} from './livekit-test-scorer';
+
+export type RunTrigger = 'manual' | 'cron' | 'admin' | 'test';
+
+export interface RunOptions {
+  trigger: RunTrigger;
+  /** Restrict to a single case by key (debug / one-off). */
+  caseKey?: string;
+  /** Override identity for the run (e.g. admin testing as another user). */
+  identity?: Partial<DryRunIdentity>;
+  /** Layer filter. Slice 1a only ships Layer A. */
+  layer?: 'A' | 'B';
+}
+
+export interface CaseRow {
+  id: string;
+  key: string;
+  label: string;
+  prompt: string;
+  expected: ExpectedContract;
+  layer: 'A' | 'B';
+  enabled: boolean;
+}
+
+export interface PersistedResult {
+  case_id: string;
+  case_key: string;
+  status: 'passed' | 'failed' | 'errored';
+  tool_calls: DryRunEvalResult['tool_calls'] | null;
+  reply_text: string | null;
+  failure_reasons: string[] | null;
+  error: string | null;
+  latency_ms: number | null;
+  instruction_chars: number | null;
+  retried: boolean;
+}
+
+export interface RunSummary {
+  run_id: string;
+  trigger: RunTrigger;
+  layer: 'A' | 'B';
+  started_at: string;
+  finished_at: string;
+  total: number;
+  passed: number;
+  failed: number;
+  errored: number;
+  duration_ms: number;
+  results: PersistedResult[];
+}
+
+/**
+ * Run all enabled cases (or a single case if `caseKey` is provided).
+ * Throws if Supabase is not configured or the run cannot be created;
+ * per-case errors are captured and stored, not thrown.
+ */
+export async function runLiveKitTestSuite(
+  opts: RunOptions,
+): Promise<RunSummary> {
+  const sb = getSupabase();
+  if (!sb) {
+    throw new Error('runLiveKitTestSuite: Supabase client not configured');
+  }
+  const layer = opts.layer ?? 'A';
+
+  // 1. Load cases.
+  const cases = await loadCases(opts.caseKey, layer);
+  if (cases.length === 0) {
+    throw new Error(
+      opts.caseKey
+        ? `runLiveKitTestSuite: no enabled case with key="${opts.caseKey}"`
+        : `runLiveKitTestSuite: no enabled cases for layer="${layer}"`,
+    );
+  }
+
+  // 2. Create the run row (so partial progress is observable).
+  const startedAtIso = new Date().toISOString();
+  const startedAtMs = Date.now();
+  const insertRun = await sb
+    .from('livekit_test_runs')
+    .insert({
+      started_at: startedAtIso,
+      layer,
+      trigger: opts.trigger,
+      total: cases.length,
+    })
+    .select('id')
+    .single();
+
+  if (insertRun.error || !insertRun.data) {
+    throw new Error(
+      `runLiveKitTestSuite: failed to create run row: ${insertRun.error?.message ?? 'unknown'}`,
+    );
+  }
+  const runId: string = (insertRun.data as { id: string }).id;
+
+  // 3. Execute cases serially.
+  const results: PersistedResult[] = [];
+  for (const c of cases) {
+    const persisted = await runOneCase(c, runId, opts.identity);
+    results.push(persisted);
+  }
+
+  // 4. Aggregate + finalize.
+  const passed = results.filter((r) => r.status === 'passed').length;
+  const failed = results.filter((r) => r.status === 'failed').length;
+  const errored = results.filter((r) => r.status === 'errored').length;
+  const finishedAtMs = Date.now();
+  const durationMs = finishedAtMs - startedAtMs;
+  const finishedAtIso = new Date(finishedAtMs).toISOString();
+
+  await sb
+    .from('livekit_test_runs')
+    .update({
+      finished_at: finishedAtIso,
+      passed,
+      failed,
+      errored,
+      duration_ms: durationMs,
+    })
+    .eq('id', runId);
+
+  return {
+    run_id: runId,
+    trigger: opts.trigger,
+    layer,
+    started_at: startedAtIso,
+    finished_at: finishedAtIso,
+    total: cases.length,
+    passed,
+    failed,
+    errored,
+    duration_ms: durationMs,
+    results,
+  };
+}
+
+async function runOneCase(
+  c: CaseRow,
+  runId: string,
+  identity: Partial<DryRunIdentity> | undefined,
+): Promise<PersistedResult> {
+  const sb = getSupabase();
+  if (!sb) {
+    throw new Error('runOneCase: Supabase client not configured');
+  }
+
+  const caseStartedAtIso = new Date().toISOString();
+
+  // Attempt 1
+  const attempt1 = await safeEvalAndScore(c.prompt, c.expected, identity);
+
+  let final = attempt1;
+  let retried = false;
+
+  // Retry once on 'failed' (not 'errored'). One retry buys us a flake buffer
+  // for LLM variance without doubling cost across the whole grid.
+  if (attempt1.kind === 'scored' && attempt1.outcome.status === 'failed') {
+    retried = true;
+    const attempt2 = await safeEvalAndScore(c.prompt, c.expected, identity);
+    final = attempt2;
+  }
+
+  const finishedAtIso = new Date().toISOString();
+
+  const row = projectToPersisted(c, final, retried);
+
+  await sb.from('livekit_test_results').insert({
+    run_id: runId,
+    case_id: c.id,
+    case_key: c.key,
+    status: row.status,
+    tool_calls: row.tool_calls,
+    reply_text: row.reply_text,
+    expected: c.expected,
+    failure_reasons: row.failure_reasons,
+    error: row.error,
+    latency_ms: row.latency_ms,
+    instruction_chars: row.instruction_chars,
+    retried: row.retried,
+    started_at: caseStartedAtIso,
+    finished_at: finishedAtIso,
+  });
+
+  return row;
+}
+
+type AttemptOutcome =
+  | { kind: 'scored'; evalResult: DryRunEvalResult; outcome: ScoreOutcome }
+  | { kind: 'errored'; error: string };
+
+async function safeEvalAndScore(
+  prompt: string,
+  expected: ExpectedContract,
+  identity: Partial<DryRunIdentity> | undefined,
+): Promise<AttemptOutcome> {
+  try {
+    const evalResult = await evaluateLiveKitDryRun({ prompt, identity });
+    const outcome = scoreResult(
+      { tool_calls: evalResult.tool_calls, reply_text: evalResult.reply_text },
+      expected,
+    );
+    return { kind: 'scored', evalResult, outcome };
+  } catch (err) {
+    return {
+      kind: 'errored',
+      error: (err as Error).message ?? String(err),
+    };
+  }
+}
+
+function projectToPersisted(
+  c: CaseRow,
+  final: AttemptOutcome,
+  retried: boolean,
+): PersistedResult {
+  if (final.kind === 'errored') {
+    return {
+      case_id: c.id,
+      case_key: c.key,
+      status: 'errored',
+      tool_calls: null,
+      reply_text: null,
+      failure_reasons: null,
+      error: final.error,
+      latency_ms: null,
+      instruction_chars: null,
+      retried,
+    };
+  }
+
+  return {
+    case_id: c.id,
+    case_key: c.key,
+    status: final.outcome.status,
+    tool_calls: final.evalResult.tool_calls,
+    reply_text: final.evalResult.reply_text,
+    failure_reasons:
+      final.outcome.failure_reasons.length > 0
+        ? final.outcome.failure_reasons
+        : null,
+    error: null,
+    latency_ms: final.evalResult.latency_ms,
+    instruction_chars: final.evalResult.instruction_chars,
+    retried,
+  };
+}
+
+async function loadCases(
+  caseKey: string | undefined,
+  layer: 'A' | 'B',
+): Promise<CaseRow[]> {
+  const sb = getSupabase();
+  if (!sb) throw new Error('loadCases: Supabase client not configured');
+
+  let query = sb
+    .from('livekit_test_cases')
+    .select('id, key, label, prompt, expected, layer, enabled')
+    .eq('enabled', true)
+    .eq('layer', layer);
+
+  if (caseKey) {
+    query = query.eq('key', caseKey);
+  }
+
+  const { data, error } = await query.order('key', { ascending: true });
+
+  if (error) {
+    throw new Error(`loadCases: ${error.message}`);
+  }
+
+  return (data ?? []).map((r: Record<string, unknown>) => ({
+    id: r.id as string,
+    key: r.key as string,
+    label: r.label as string,
+    prompt: r.prompt as string,
+    expected: r.expected as ExpectedContract,
+    layer: r.layer as 'A' | 'B',
+    enabled: r.enabled as boolean,
+  }));
+}
+
+/**
+ * Read API for the monitor panel: recent runs (paginated).
+ */
+export async function listRecentRuns(limit = 50): Promise<Array<{
+  id: string;
+  started_at: string;
+  finished_at: string | null;
+  trigger: RunTrigger;
+  layer: string;
+  total: number;
+  passed: number;
+  failed: number;
+  errored: number;
+  duration_ms: number | null;
+}>> {
+  const sb = getSupabase();
+  if (!sb) throw new Error('listRecentRuns: Supabase client not configured');
+  const { data, error } = await sb
+    .from('livekit_test_runs')
+    .select('id, started_at, finished_at, trigger, layer, total, passed, failed, errored, duration_ms')
+    .order('started_at', { ascending: false })
+    .limit(Math.min(limit, 200));
+  if (error) throw new Error(`listRecentRuns: ${error.message}`);
+  return (data ?? []) as Array<{
+    id: string;
+    started_at: string;
+    finished_at: string | null;
+    trigger: RunTrigger;
+    layer: string;
+    total: number;
+    passed: number;
+    failed: number;
+    errored: number;
+    duration_ms: number | null;
+  }>;
+}
+
+/**
+ * Read API for the monitor panel: full results for one run.
+ */
+export async function getRunDetail(runId: string): Promise<{
+  run: {
+    id: string;
+    started_at: string;
+    finished_at: string | null;
+    trigger: RunTrigger;
+    layer: string;
+    total: number;
+    passed: number;
+    failed: number;
+    errored: number;
+    duration_ms: number | null;
+  };
+  results: Array<{
+    case_key: string;
+    status: 'passed' | 'failed' | 'errored';
+    tool_calls: unknown;
+    reply_text: string | null;
+    expected: unknown;
+    failure_reasons: string[] | null;
+    error: string | null;
+    latency_ms: number | null;
+    retried: boolean;
+    started_at: string;
+    finished_at: string | null;
+  }>;
+} | null> {
+  const sb = getSupabase();
+  if (!sb) throw new Error('getRunDetail: Supabase client not configured');
+
+  const { data: runRow, error: runErr } = await sb
+    .from('livekit_test_runs')
+    .select('id, started_at, finished_at, trigger, layer, total, passed, failed, errored, duration_ms')
+    .eq('id', runId)
+    .maybeSingle();
+  if (runErr) throw new Error(`getRunDetail: ${runErr.message}`);
+  if (!runRow) return null;
+
+  const { data: resultRows, error: resErr } = await sb
+    .from('livekit_test_results')
+    .select(
+      'case_key, status, tool_calls, reply_text, expected, failure_reasons, error, latency_ms, retried, started_at, finished_at',
+    )
+    .eq('run_id', runId)
+    .order('case_key', { ascending: true });
+  if (resErr) throw new Error(`getRunDetail: ${resErr.message}`);
+
+  return {
+    run: runRow as {
+      id: string;
+      started_at: string;
+      finished_at: string | null;
+      trigger: RunTrigger;
+      layer: string;
+      total: number;
+      passed: number;
+      failed: number;
+      errored: number;
+      duration_ms: number | null;
+    },
+    results: (resultRows ?? []) as Array<{
+      case_key: string;
+      status: 'passed' | 'failed' | 'errored';
+      tool_calls: unknown;
+      reply_text: string | null;
+      expected: unknown;
+      failure_reasons: string[] | null;
+      error: string | null;
+      latency_ms: number | null;
+      retried: boolean;
+      started_at: string;
+      finished_at: string | null;
+    }>,
+  };
+}
+
+/**
+ * Read API for the monitor panel: list cases (for showing what's enabled).
+ */
+export async function listCases(): Promise<Array<{
+  id: string;
+  key: string;
+  label: string;
+  prompt: string;
+  layer: string;
+  enabled: boolean;
+  notes: string | null;
+}>> {
+  const sb = getSupabase();
+  if (!sb) throw new Error('listCases: Supabase client not configured');
+  const { data, error } = await sb
+    .from('livekit_test_cases')
+    .select('id, key, label, prompt, layer, enabled, notes')
+    .order('key', { ascending: true });
+  if (error) throw new Error(`listCases: ${error.message}`);
+  return (data ?? []) as Array<{
+    id: string;
+    key: string;
+    label: string;
+    prompt: string;
+    layer: string;
+    enabled: boolean;
+    notes: string | null;
+  }>;
+}

--- a/services/gateway/src/services/voice-lab/livekit-test-scorer.ts
+++ b/services/gateway/src/services/voice-lab/livekit-test-scorer.ts
@@ -1,0 +1,249 @@
+/**
+ * VTID-03025: LiveKit hourly tests — golden-contract scorer.
+ *
+ * Pure function. Takes the captured `tool_calls` + `reply_text` from a
+ * dry-run eval (see livekit-test-eval.ts) and the expected JSONB from
+ * the case row, returns `{ status, failure_reasons }`.
+ *
+ * Scoring rules (matcher schema):
+ *
+ *   tools             — string[]; ALL must appear in tool_calls (name match).
+ *   tools_any         — string[]; AT LEAST ONE must appear.
+ *   forbidden_tools   — string[]; NONE may appear.
+ *   args_match        — { [tool_name]: { [arg_name]: ArgMatcher } }
+ *                       Only checked when the tool actually fired. Argument
+ *                       absence does NOT fail the matcher unless explicitly
+ *                       required by the matcher (regex/exact/enum imply the
+ *                       arg must exist; non_empty also requires existence).
+ *   intent: "free_text" — assert ZERO tool calls AND reply_text non-empty.
+ *
+ * ArgMatcher shapes:
+ *   { type: "regex",     pattern: string }
+ *   { type: "exact",     value: unknown }       (deep-equality on JSON-coercible values)
+ *   { type: "enum",      values: unknown[] }    (membership check)
+ *   { type: "non_empty" }                       (string: trimmed non-empty;
+ *                                               arrays/objects: length > 0)
+ *
+ * Failure reasons use a stable `category:detail` shape so a downstream
+ * monitor can aggregate by category without parsing free text:
+ *
+ *   missing_tool:<tool_name>
+ *   none_of_required_tools:<name1,name2,...>
+ *   forbidden_tool_called:<tool_name>
+ *   args_mismatch:<tool_name>.<arg>:<matcher_type>
+ *   args_missing:<tool_name>.<arg>:<matcher_type>
+ *   unexpected_tool_call:<tool_name>            (intent=free_text)
+ *   empty_reply_for_free_text_intent
+ *   invalid_expected:<reason>                   (defensive — bad seed)
+ *
+ * No side effects, no I/O. Easy to unit-test.
+ */
+
+export interface ToolCall {
+  name: string;
+  args: Record<string, unknown>;
+}
+
+export interface EvalResult {
+  tool_calls: ToolCall[];
+  reply_text: string;
+}
+
+export type ArgMatcher =
+  | { type: 'regex'; pattern: string }
+  | { type: 'exact'; value: unknown }
+  | { type: 'enum'; values: unknown[] }
+  | { type: 'non_empty' };
+
+export interface ExpectedContract {
+  tools?: string[];
+  tools_any?: string[];
+  forbidden_tools?: string[];
+  args_match?: Record<string, Record<string, ArgMatcher>>;
+  intent?: 'free_text';
+}
+
+export interface ScoreOutcome {
+  status: 'passed' | 'failed';
+  failure_reasons: string[];
+}
+
+/**
+ * Pure scorer. Returns `passed` only when every constraint in `expected`
+ * is satisfied; otherwise `failed` with a list of stable reason codes.
+ */
+export function scoreResult(
+  result: EvalResult,
+  expected: ExpectedContract,
+): ScoreOutcome {
+  const reasons: string[] = [];
+
+  // Defensive: empty expected = vacuously pass. (Catches malformed seed
+  // rows so a typo doesn't silently fail every run.)
+  if (!expected || typeof expected !== 'object') {
+    return { status: 'failed', failure_reasons: ['invalid_expected:not_an_object'] };
+  }
+
+  const calledNames = new Set(result.tool_calls.map((c) => c.name));
+
+  // intent: "free_text" — short-circuit. No tools allowed; reply must be present.
+  if (expected.intent === 'free_text') {
+    for (const call of result.tool_calls) {
+      reasons.push(`unexpected_tool_call:${call.name}`);
+    }
+    if (!result.reply_text || result.reply_text.trim().length === 0) {
+      reasons.push('empty_reply_for_free_text_intent');
+    }
+    return {
+      status: reasons.length === 0 ? 'passed' : 'failed',
+      failure_reasons: reasons,
+    };
+  }
+
+  // tools (all required)
+  if (Array.isArray(expected.tools)) {
+    for (const tool of expected.tools) {
+      if (typeof tool !== 'string') {
+        reasons.push('invalid_expected:tools_entry_not_string');
+        continue;
+      }
+      if (!calledNames.has(tool)) {
+        reasons.push(`missing_tool:${tool}`);
+      }
+    }
+  }
+
+  // tools_any (at least one required)
+  if (Array.isArray(expected.tools_any) && expected.tools_any.length > 0) {
+    const hit = expected.tools_any.some(
+      (t) => typeof t === 'string' && calledNames.has(t),
+    );
+    if (!hit) {
+      reasons.push(`none_of_required_tools:${expected.tools_any.join(',')}`);
+    }
+  }
+
+  // forbidden_tools
+  if (Array.isArray(expected.forbidden_tools)) {
+    for (const tool of expected.forbidden_tools) {
+      if (typeof tool === 'string' && calledNames.has(tool)) {
+        reasons.push(`forbidden_tool_called:${tool}`);
+      }
+    }
+  }
+
+  // args_match — per tool, per arg
+  if (expected.args_match && typeof expected.args_match === 'object') {
+    for (const [toolName, argSpecs] of Object.entries(expected.args_match)) {
+      if (!argSpecs || typeof argSpecs !== 'object') continue;
+      const calls = result.tool_calls.filter((c) => c.name === toolName);
+      // Skip arg matchers entirely if the tool wasn't called. The
+      // `tools` / `tools_any` matchers cover required-ness; args_match
+      // only fires when the call exists, so contracts can be permissive
+      // about which-tool while still enforcing arg shape if it fires.
+      if (calls.length === 0) continue;
+
+      for (const [argName, matcher] of Object.entries(argSpecs)) {
+        // Run the matcher against EACH call of this tool. If any call
+        // satisfies the matcher, the contract is met for that arg.
+        const anyOk = calls.some((call) => matchArg(call.args, argName, matcher).ok);
+        if (!anyOk) {
+          const firstCall = calls[0];
+          const detail = matchArg(firstCall.args, argName, matcher);
+          reasons.push(
+            `${detail.missing ? 'args_missing' : 'args_mismatch'}:${toolName}.${argName}:${matcher.type}`,
+          );
+        }
+      }
+    }
+  }
+
+  return {
+    status: reasons.length === 0 ? 'passed' : 'failed',
+    failure_reasons: reasons,
+  };
+}
+
+/** Single-arg matcher. Returns `{ ok, missing }` so callers can distinguish
+ *  "arg not present" from "arg present but didn't match". */
+function matchArg(
+  args: Record<string, unknown>,
+  argName: string,
+  matcher: ArgMatcher,
+): { ok: boolean; missing: boolean } {
+  const hasOwn = Object.prototype.hasOwnProperty.call(args, argName);
+  const value = hasOwn ? args[argName] : undefined;
+
+  // For `non_empty`, missing implies fail-missing.
+  if (matcher.type === 'non_empty') {
+    if (!hasOwn || value === null || value === undefined) {
+      return { ok: false, missing: true };
+    }
+    if (typeof value === 'string') return { ok: value.trim().length > 0, missing: false };
+    if (Array.isArray(value)) return { ok: value.length > 0, missing: false };
+    if (typeof value === 'object') return { ok: Object.keys(value as object).length > 0, missing: false };
+    return { ok: true, missing: false }; // numbers, booleans → present, count as non-empty
+  }
+
+  if (matcher.type === 'regex') {
+    if (!hasOwn || typeof value !== 'string') return { ok: false, missing: !hasOwn };
+    try {
+      const re = compileRegexWithInlineFlags(matcher.pattern);
+      return { ok: re.test(value), missing: false };
+    } catch {
+      return { ok: false, missing: false };
+    }
+  }
+
+  if (matcher.type === 'exact') {
+    if (!hasOwn) return { ok: false, missing: true };
+    return { ok: deepEqual(value, matcher.value), missing: false };
+  }
+
+  if (matcher.type === 'enum') {
+    if (!hasOwn) return { ok: false, missing: true };
+    if (!Array.isArray(matcher.values)) return { ok: false, missing: false };
+    return { ok: matcher.values.some((v) => deepEqual(v, value)), missing: false };
+  }
+
+  // Unknown matcher type — fail closed.
+  return { ok: false, missing: false };
+}
+
+/**
+ * Translate PCRE-style inline flags like `(?i)foo` or `(?ims)foo` into the
+ * JS `RegExp(pattern, flags)` form. JS doesn't support inline flag groups
+ * natively, but the seed JSONB uses them — strip the prefix and pass the
+ * flag letters as the second argument.
+ *
+ * Supported flag letters: i, m, s, u, y. Unknown letters fall through (JS
+ * RegExp throws and the caller catches it; we fail closed).
+ */
+function compileRegexWithInlineFlags(pattern: string): RegExp {
+  const m = pattern.match(/^\(\?([imsuy]+)\)/);
+  if (m) {
+    return new RegExp(pattern.slice(m[0].length), m[1]);
+  }
+  return new RegExp(pattern);
+}
+
+function deepEqual(a: unknown, b: unknown): boolean {
+  if (a === b) return true;
+  if (typeof a !== typeof b) return false;
+  if (a === null || b === null) return a === b;
+  if (typeof a !== 'object') return false;
+  if (Array.isArray(a) !== Array.isArray(b)) return false;
+  if (Array.isArray(a) && Array.isArray(b)) {
+    if (a.length !== b.length) return false;
+    return a.every((v, i) => deepEqual(v, b[i]));
+  }
+  const ak = Object.keys(a as object);
+  const bk = Object.keys(b as object);
+  if (ak.length !== bk.length) return false;
+  return ak.every((k) =>
+    deepEqual(
+      (a as Record<string, unknown>)[k],
+      (b as Record<string, unknown>)[k],
+    ),
+  );
+}

--- a/services/gateway/test/voice-lab/livekit-test-scorer.test.ts
+++ b/services/gateway/test/voice-lab/livekit-test-scorer.test.ts
@@ -1,0 +1,338 @@
+/**
+ * VTID-03025: Unit tests for the LiveKit hourly tests scorer.
+ *
+ * Pure function — no Supabase, no Vertex, no network. Locks the matcher
+ * semantics so the hourly grid behaves predictably even as cases evolve.
+ */
+
+import {
+  scoreResult,
+  type ExpectedContract,
+  type EvalResult,
+} from '../../src/services/voice-lab/livekit-test-scorer';
+
+function evalOf(
+  tool_calls: Array<{ name: string; args?: Record<string, unknown> }>,
+  reply_text = '',
+): EvalResult {
+  return {
+    tool_calls: tool_calls.map((c) => ({ name: c.name, args: c.args ?? {} })),
+    reply_text,
+  };
+}
+
+describe('scoreResult — tools (all required)', () => {
+  test('passes when every required tool is called', () => {
+    const out = scoreResult(
+      evalOf([{ name: 'save_diary_entry' }]),
+      { tools: ['save_diary_entry'] },
+    );
+    expect(out.status).toBe('passed');
+    expect(out.failure_reasons).toEqual([]);
+  });
+
+  test('fails with missing_tool when a required tool is not called', () => {
+    const out = scoreResult(
+      evalOf([{ name: 'search_memory' }]),
+      { tools: ['save_diary_entry'] },
+    );
+    expect(out.status).toBe('failed');
+    expect(out.failure_reasons).toContain('missing_tool:save_diary_entry');
+  });
+
+  test('passes when required tool is called among extras', () => {
+    const out = scoreResult(
+      evalOf([{ name: 'resolve_recipient' }, { name: 'send_chat_message' }]),
+      { tools: ['send_chat_message'] },
+    );
+    expect(out.status).toBe('passed');
+  });
+});
+
+describe('scoreResult — tools_any (at least one)', () => {
+  test('passes when one of the candidates fires', () => {
+    const out = scoreResult(
+      evalOf([{ name: 'navigate' }]),
+      { tools_any: ['navigate', 'navigate_to_screen'] },
+    );
+    expect(out.status).toBe('passed');
+  });
+
+  test('fails when none of the candidates fire', () => {
+    const out = scoreResult(
+      evalOf([{ name: 'search_web' }]),
+      { tools_any: ['navigate', 'navigate_to_screen'] },
+    );
+    expect(out.status).toBe('failed');
+    expect(out.failure_reasons[0]).toMatch(/^none_of_required_tools:/);
+  });
+
+  test('empty tools_any array is ignored (no constraint)', () => {
+    const out = scoreResult(evalOf([{ name: 'anything' }]), { tools_any: [] });
+    expect(out.status).toBe('passed');
+  });
+});
+
+describe('scoreResult — forbidden_tools', () => {
+  test('passes when no forbidden tool is called', () => {
+    const out = scoreResult(
+      evalOf([{ name: 'save_diary_entry' }]),
+      { forbidden_tools: ['set_reminder'] },
+    );
+    expect(out.status).toBe('passed');
+  });
+
+  test('fails when a forbidden tool is called', () => {
+    const out = scoreResult(
+      evalOf([{ name: 'set_reminder' }, { name: 'save_diary_entry' }]),
+      { tools: ['save_diary_entry'], forbidden_tools: ['set_reminder'] },
+    );
+    expect(out.status).toBe('failed');
+    expect(out.failure_reasons).toContain('forbidden_tool_called:set_reminder');
+  });
+});
+
+describe('scoreResult — args_match: regex', () => {
+  test('regex match passes', () => {
+    const out = scoreResult(
+      evalOf([{ name: 'search_web', args: { query: 'Maria Maksina latest show' } }]),
+      {
+        tools: ['search_web'],
+        args_match: {
+          search_web: { query: { type: 'regex', pattern: '(?i)maria' } },
+        },
+      },
+    );
+    expect(out.status).toBe('passed');
+  });
+
+  test('regex mismatch fails with args_mismatch', () => {
+    const out = scoreResult(
+      evalOf([{ name: 'search_web', args: { query: 'weather in mallorca' } }]),
+      {
+        tools: ['search_web'],
+        args_match: {
+          search_web: { query: { type: 'regex', pattern: '(?i)maria' } },
+        },
+      },
+    );
+    expect(out.status).toBe('failed');
+    expect(out.failure_reasons).toContain('args_mismatch:search_web.query:regex');
+  });
+
+  test('missing arg with regex fails with args_missing', () => {
+    const out = scoreResult(
+      evalOf([{ name: 'search_web', args: {} }]),
+      {
+        tools: ['search_web'],
+        args_match: {
+          search_web: { query: { type: 'regex', pattern: '(?i)maria' } },
+        },
+      },
+    );
+    expect(out.status).toBe('failed');
+    expect(out.failure_reasons).toContain('args_missing:search_web.query:regex');
+  });
+
+  test('invalid regex pattern fails closed', () => {
+    const out = scoreResult(
+      evalOf([{ name: 'search_web', args: { query: 'maria' } }]),
+      {
+        tools: ['search_web'],
+        args_match: {
+          search_web: { query: { type: 'regex', pattern: '([' } },
+        },
+      },
+    );
+    expect(out.status).toBe('failed');
+  });
+});
+
+describe('scoreResult — args_match: non_empty', () => {
+  test('non-empty string passes', () => {
+    const out = scoreResult(
+      evalOf([{ name: 'save_diary_entry', args: { entry: 'coffee + water' } }]),
+      {
+        tools: ['save_diary_entry'],
+        args_match: { save_diary_entry: { entry: { type: 'non_empty' } } },
+      },
+    );
+    expect(out.status).toBe('passed');
+  });
+
+  test('empty string fails', () => {
+    const out = scoreResult(
+      evalOf([{ name: 'save_diary_entry', args: { entry: '   ' } }]),
+      {
+        tools: ['save_diary_entry'],
+        args_match: { save_diary_entry: { entry: { type: 'non_empty' } } },
+      },
+    );
+    expect(out.status).toBe('failed');
+  });
+
+  test('absent arg fails as args_missing', () => {
+    const out = scoreResult(
+      evalOf([{ name: 'save_diary_entry', args: {} }]),
+      {
+        tools: ['save_diary_entry'],
+        args_match: { save_diary_entry: { entry: { type: 'non_empty' } } },
+      },
+    );
+    expect(out.status).toBe('failed');
+    expect(out.failure_reasons).toContain('args_missing:save_diary_entry.entry:non_empty');
+  });
+
+  test('empty array fails', () => {
+    const out = scoreResult(
+      evalOf([{ name: 'foo', args: { xs: [] } }]),
+      { tools: ['foo'], args_match: { foo: { xs: { type: 'non_empty' } } } },
+    );
+    expect(out.status).toBe('failed');
+  });
+});
+
+describe('scoreResult — args_match: exact + enum', () => {
+  test('exact match', () => {
+    const out = scoreResult(
+      evalOf([{ name: 'switch_persona', args: { persona: 'devon' } }]),
+      {
+        tools: ['switch_persona'],
+        args_match: {
+          switch_persona: { persona: { type: 'exact', value: 'devon' } },
+        },
+      },
+    );
+    expect(out.status).toBe('passed');
+  });
+
+  test('exact mismatch', () => {
+    const out = scoreResult(
+      evalOf([{ name: 'switch_persona', args: { persona: 'sage' } }]),
+      {
+        tools: ['switch_persona'],
+        args_match: {
+          switch_persona: { persona: { type: 'exact', value: 'devon' } },
+        },
+      },
+    );
+    expect(out.status).toBe('failed');
+  });
+
+  test('enum member passes', () => {
+    const out = scoreResult(
+      evalOf([{ name: 'foo', args: { kind: 'bug' } }]),
+      {
+        tools: ['foo'],
+        args_match: {
+          foo: { kind: { type: 'enum', values: ['bug', 'ux_issue'] } },
+        },
+      },
+    );
+    expect(out.status).toBe('passed');
+  });
+
+  test('enum non-member fails', () => {
+    const out = scoreResult(
+      evalOf([{ name: 'foo', args: { kind: 'feature_request' } }]),
+      {
+        tools: ['foo'],
+        args_match: {
+          foo: { kind: { type: 'enum', values: ['bug', 'ux_issue'] } },
+        },
+      },
+    );
+    expect(out.status).toBe('failed');
+  });
+});
+
+describe('scoreResult — multiple calls of same tool', () => {
+  test('any matching call satisfies the matcher', () => {
+    const out = scoreResult(
+      evalOf([
+        { name: 'navigate', args: { route: '/wallet' } },
+        { name: 'navigate', args: { route: '/journey' } },
+      ]),
+      {
+        tools_any: ['navigate'],
+        args_match: {
+          navigate: { route: { type: 'regex', pattern: '/journey' } },
+        },
+      },
+    );
+    expect(out.status).toBe('passed');
+  });
+
+  test('no matching call → args_mismatch reported once', () => {
+    const out = scoreResult(
+      evalOf([
+        { name: 'navigate', args: { route: '/wallet' } },
+        { name: 'navigate', args: { route: '/calendar' } },
+      ]),
+      {
+        tools_any: ['navigate'],
+        args_match: {
+          navigate: { route: { type: 'regex', pattern: '/journey' } },
+        },
+      },
+    );
+    expect(out.status).toBe('failed');
+    expect(out.failure_reasons.filter((r) => r.startsWith('args_mismatch:'))).toHaveLength(1);
+  });
+});
+
+describe('scoreResult — intent: free_text', () => {
+  test('zero tools + reply_text passes', () => {
+    const out = scoreResult(evalOf([], 'You are in Berlin and it is 15:42.'), {
+      intent: 'free_text',
+    });
+    expect(out.status).toBe('passed');
+  });
+
+  test('tool call when intent is free_text fails', () => {
+    const out = scoreResult(
+      evalOf([{ name: 'search_web' }], 'searching now'),
+      { intent: 'free_text' },
+    );
+    expect(out.status).toBe('failed');
+    expect(out.failure_reasons).toContain('unexpected_tool_call:search_web');
+  });
+
+  test('empty reply with free_text intent fails', () => {
+    const out = scoreResult(evalOf([], '   '), { intent: 'free_text' });
+    expect(out.status).toBe('failed');
+    expect(out.failure_reasons).toContain('empty_reply_for_free_text_intent');
+  });
+});
+
+describe('scoreResult — defensive', () => {
+  test('non-object expected returns invalid_expected', () => {
+    const out = scoreResult(evalOf([]), null as unknown as ExpectedContract);
+    expect(out.status).toBe('failed');
+    expect(out.failure_reasons[0]).toMatch(/^invalid_expected:/);
+  });
+
+  test('empty expected is vacuously passing', () => {
+    const out = scoreResult(evalOf([{ name: 'anything' }]), {});
+    expect(out.status).toBe('passed');
+  });
+
+  test('args_match for an uncalled tool is skipped (no false failure)', () => {
+    // The case requires search_web; the model called save_diary_entry. The
+    // args_match for save_diary_entry SHOULD NOT fail just because the call
+    // doesn't carry the expected arg — the missing_tool failure is the one
+    // we want, not a confusing arg_mismatch noise.
+    const out = scoreResult(
+      evalOf([{ name: 'save_diary_entry', args: {} }]),
+      {
+        tools: ['search_web'],
+        args_match: {
+          search_web: { query: { type: 'non_empty' } },
+        },
+      },
+    );
+    expect(out.status).toBe('failed');
+    expect(out.failure_reasons).toContain('missing_tool:search_web');
+    expect(out.failure_reasons.filter((r) => r.startsWith('args_'))).toHaveLength(0);
+  });
+});

--- a/supabase/migrations/20260522000001_VTID_03025_livekit_hourly_tests.sql
+++ b/supabase/migrations/20260522000001_VTID_03025_livekit_hourly_tests.sql
@@ -1,0 +1,182 @@
+-- VTID-03025: LiveKit hourly tests — foundation (Slice 1a)
+--
+-- Adds three tables backing the hourly Layer-A dry-run test suite that
+-- evaluates the LiveKit voice agent's tool-routing behavior against
+-- golden contracts. No tool execution happens — the runner only inspects
+-- which tool Gemini chose given the same system instruction + tool
+-- catalog the live agent sees.
+--
+-- See: services/gateway/src/services/voice-lab/livekit-test-{eval,scorer,runner}.ts
+
+BEGIN;
+
+-- ============================================================================
+-- livekit_test_cases — golden contracts. Seeded with 13 cases; tweakable
+-- via direct SQL or a future admin route. The expected JSONB drives the
+-- scorer (see livekit-test-scorer.ts).
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS public.livekit_test_cases (
+  id          UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  key         TEXT NOT NULL UNIQUE,
+  label       TEXT NOT NULL,
+  prompt      TEXT NOT NULL,
+  expected    JSONB NOT NULL,
+  layer       TEXT NOT NULL DEFAULT 'A' CHECK (layer IN ('A','B')),
+  enabled     BOOLEAN NOT NULL DEFAULT TRUE,
+  notes       TEXT,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  updated_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+CREATE INDEX IF NOT EXISTS livekit_test_cases_enabled_idx
+  ON public.livekit_test_cases (enabled);
+CREATE INDEX IF NOT EXISTS livekit_test_cases_layer_idx
+  ON public.livekit_test_cases (layer);
+
+COMMENT ON COLUMN public.livekit_test_cases.expected IS
+  'Golden contract. Keys: tools (all required), tools_any (any one required), forbidden_tools (none allowed), args_match (per-tool arg matchers: regex|exact|enum|non_empty), intent (free_text to assert zero tool calls). See livekit-test-scorer.ts for full schema.';
+
+-- ============================================================================
+-- livekit_test_runs — one row per scheduled or ad-hoc run.
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS public.livekit_test_runs (
+  id           UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  started_at   TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  finished_at  TIMESTAMPTZ,
+  layer        TEXT NOT NULL DEFAULT 'A' CHECK (layer IN ('A','B')),
+  trigger      TEXT NOT NULL DEFAULT 'manual'
+                 CHECK (trigger IN ('manual','cron','admin','test')),
+  total        INT NOT NULL DEFAULT 0,
+  passed       INT NOT NULL DEFAULT 0,
+  failed       INT NOT NULL DEFAULT 0,
+  errored      INT NOT NULL DEFAULT 0,
+  duration_ms  INT,
+  meta         JSONB
+);
+
+CREATE INDEX IF NOT EXISTS livekit_test_runs_started_at_idx
+  ON public.livekit_test_runs (started_at DESC);
+CREATE INDEX IF NOT EXISTS livekit_test_runs_trigger_idx
+  ON public.livekit_test_runs (trigger);
+
+-- ============================================================================
+-- livekit_test_results — one row per case per run.
+-- ============================================================================
+CREATE TABLE IF NOT EXISTS public.livekit_test_results (
+  id                 UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  run_id             UUID NOT NULL REFERENCES public.livekit_test_runs(id) ON DELETE CASCADE,
+  case_id            UUID NOT NULL REFERENCES public.livekit_test_cases(id) ON DELETE CASCADE,
+  case_key           TEXT NOT NULL,
+  status             TEXT NOT NULL CHECK (status IN ('passed','failed','errored')),
+  tool_calls         JSONB,
+  reply_text         TEXT,
+  expected           JSONB NOT NULL,
+  failure_reasons    TEXT[],
+  error              TEXT,
+  latency_ms         INT,
+  instruction_chars  INT,
+  retried            BOOLEAN NOT NULL DEFAULT FALSE,
+  started_at         TIMESTAMPTZ NOT NULL DEFAULT NOW(),
+  finished_at        TIMESTAMPTZ
+);
+
+CREATE INDEX IF NOT EXISTS livekit_test_results_run_id_idx
+  ON public.livekit_test_results (run_id);
+CREATE INDEX IF NOT EXISTS livekit_test_results_case_started_idx
+  ON public.livekit_test_results (case_id, started_at DESC);
+CREATE INDEX IF NOT EXISTS livekit_test_results_status_idx
+  ON public.livekit_test_results (status);
+
+COMMENT ON COLUMN public.livekit_test_results.failure_reasons IS
+  'Structured reasons (e.g. "missing_tool:save_diary_entry", "args_mismatch:save_diary_entry.entry:non_empty"). See livekit-test-scorer.ts.';
+
+-- ============================================================================
+-- Seed: the original 13 cases.
+--
+-- Each case mirrors a real user utterance. Prompts are kept close to the
+-- user's verbatim phrasing — the test surface reflects production language,
+-- not gamed-for-LLM strings. Where a prompt would otherwise trip the
+-- propose-first / multi-step gates in the live system instruction, the
+-- prompt is minimally extended to encode the consent the user would have
+-- already given in a real conversation.
+-- ============================================================================
+INSERT INTO public.livekit_test_cases (key, label, prompt, expected, notes) VALUES
+('tech_support_devon',
+ 'Tech support → Devon handoff',
+ 'Connect me to Devon — I have a bug to report. The diary save button is broken on mobile and the entry is lost when I tap it.',
+ '{"tools":["report_to_specialist"],"args_match":{"report_to_specialist":{"specialist_hint":{"type":"regex","pattern":"(?i)devon"},"summary":{"type":"non_empty"}}}}'::jsonb,
+ 'Tests report_to_specialist routing. Prompt includes consent + concrete bug so the propose-first gate is satisfied.'),
+
+('send_message_maria',
+ 'Send chat message to Maria Maksina',
+ 'Send a message to Maria Maksina with user id maria6 saying I will be a few minutes late.',
+ '{"tools_any":["send_chat_message","resolve_recipient"],"args_match":{"send_chat_message":{"message":{"type":"non_empty"}}}}'::jsonb,
+ 'Multi-step flow: model may call resolve_recipient first or send_chat_message directly. tools_any accepts either.'),
+
+('diary_coffee_water',
+ 'Add diary entry: coffee + water',
+ 'Add to my daily diary: I just had one coffee and a big glass of water about 500ml.',
+ '{"tools":["save_diary_entry"],"args_match":{"save_diary_entry":{"entry":{"type":"regex","pattern":"(?i)(coffee|water|500)"}}}}'::jsonb,
+ 'save_diary_entry triggers Vitana Index recompute. Args check looks for coffee/water/500 in the entry text.'),
+
+('life_compass_query',
+ 'What is my life compass',
+ 'What is my life compass?',
+ '{"tools":["get_life_compass"]}'::jsonb,
+ 'Read-only Life Compass fetch.'),
+
+('web_search_maria_news',
+ 'Web search Maria Maksina news',
+ 'Check the news on the web about what is new with Maria Maksina and her show performance yesterday.',
+ '{"tools":["search_web"],"args_match":{"search_web":{"query":{"type":"regex","pattern":"(?i)maria"}}}}'::jsonb,
+ 'Web search routing. Query must mention Maria.'),
+
+('vitana_drop_explanation',
+ 'Why did my Vitana drop, explain',
+ 'Why did my Vitana drop since yesterday? Explain the reason.',
+ '{"tools_any":["get_vitana_index","get_index_improvement_suggestions"]}'::jsonb,
+ 'Could route to either tool. Both are read-only Vitana Index introspection. tools_any accepts either.'),
+
+('maxina_community_query',
+ 'What is the Maxina community',
+ 'What is the Maxina community?',
+ '{"tools_any":["search_community","search_knowledge"]}'::jsonb,
+ 'Knowledge-or-community lookup. Either is acceptable.'),
+
+('maxina_event_july_mallorca',
+ 'First Maxina event July 2026 in Mallorca',
+ 'Which Maxina experience event is the first event in July 2026 in Mallorca?',
+ '{"tools":["search_events"],"args_match":{"search_events":{}}}'::jsonb,
+ 'Event search. Args left unconstrained for v1 — args structure varies by date encoding.'),
+
+('tennis_partner_mallorca',
+ 'Find tennis partner in Mallorca this week',
+ 'I am looking for a partner to play tennis with this coming week in Mallorca.',
+ '{"tools_any":["post_intent","scan_existing_matches","view_intent_matches"]}'::jsonb,
+ 'Matchmaker entry point — model may post a new intent or scan existing matches first.'),
+
+('play_song_youtube',
+ 'Play All at Once by Whitney Houston on YouTube Music',
+ 'Play the song "All at Once" by Whitney Houston on YouTube Music.',
+ '{"tools":["play_music"],"args_match":{"play_music":{}}}'::jsonb,
+ 'Music playback routing. Args unconstrained — title/artist/source layout varies.'),
+
+('calendar_jovana_tomorrow',
+ 'Calendar event: call Jovana tomorrow at 15:00',
+ 'Add to my calendar a meeting tomorrow at 15:00 to call Jovana.',
+ '{"tools_any":["create_calendar_event","add_to_calendar"],"args_match":{"create_calendar_event":{"title":{"type":"regex","pattern":"(?i)jovana"}},"add_to_calendar":{"title":{"type":"regex","pattern":"(?i)jovana"}}}}'::jsonb,
+ 'Calendar create. Either canonical tool acceptable; args check requires Jovana in the title when matched.'),
+
+('location_time_query',
+ 'What is my location and the time at my location',
+ 'What is my location and the time at my location?',
+ '{"intent":"free_text"}'::jsonb,
+ 'User timezone + location land in bootstrap_context already — the model should answer inline without a tool call.'),
+
+('triple_navigate',
+ 'Open wallet, My Journey, podcasts',
+ 'Open my wallet. Then open My Journey. Then open the screen with podcasts.',
+ '{"tools_any":["navigate","navigate_to_screen"]}'::jsonb,
+ 'Triple navigation. Slice 1a only requires at least one navigate call — multi-tool capture comes in a later slice.');
+
+COMMIT;


### PR DESCRIPTION
## Summary

Slice 1a of the LiveKit hourly test program. Backend foundation only — no cron, no UI yet (those land in Slices 1b and 1c).

The evaluator mirrors the live LiveKit voice agent end-to-end and dry-runs the prompt through Vertex Gemini, capturing what tool Gemini *would* call without executing anything. Scored against per-case golden contracts.

## What's included

**New tables** (under `livekit_*` to match house style):
- `livekit_test_cases` — golden contracts (key, label, prompt, expected JSONB)
- `livekit_test_runs` — one row per scheduled or ad-hoc run
- `livekit_test_results` — one row per case per run

Apply via `RUN-MIGRATION.yml` with file `supabase/migrations/20260522000001_VTID_03025_livekit_hourly_tests.sql` before routes can serve traffic.

**New services** under `services/gateway/src/services/voice-lab/`:
- `livekit-test-eval.ts` — Layer-A dry-run evaluator (mirrors `buildBootstrapContextPack` + `buildLiveSystemInstruction` + `buildLiveApiTools('authenticated')` + calls Vertex Gemini `generateContent`)
- `livekit-test-scorer.ts` — pure golden-contract scorer (`tools`, `tools_any`, `forbidden_tools`, `args_match` with `regex|exact|enum|non_empty`, `intent: free_text`)
- `livekit-test-runner.ts` — orchestrator (serial execution, 1-retry buffer on flake, 3 read APIs for the future monitor panel)

**New routes** under `/api/v1/voice-lab/tests/*` (dual-auth: `GATEWAY_SERVICE_TOKEN` for cron OR exafy-admin JWT for Command Hub):
- `POST /tests/run` — execute all enabled cases or a single case
- `POST /tests/eval` — ad-hoc single prompt (admin debug)
- `GET  /tests/runs?limit=N` — recent run summaries
- `GET  /tests/runs/:id` — full per-case results
- `GET  /tests/cases` — registered case catalog

**13 seed cases** mirror the original spec verbatim where the live agent's gates allow. The Devon handoff prompt was minimally extended to satisfy the propose-first gate that the live system instruction enforces (concrete bug + screen + explicit consent).

**Single-line additive change** to `services/gateway/src/routes/orb-live.ts`: exports `buildBootstrapContextPack` so the evaluator can call it directly. No behavior change — function was already deps-injected into `LiveSessionControllerDeps`, now also a named export.

**28/28 scorer unit tests** in `services/gateway/test/voice-lab/livekit-test-scorer.test.ts`.

## What's explicitly out-of-scope (later slices)

- **LiveKit transport, audio, STT, TTS** — Layer B (daily 5-case canary, later slice)
- **livekit-plugins-google SDK internal tool-schema transforms** — accepted gap (tool *names* match by spec.json construction; schemas may differ subtly)
- **Tool execution** — this is a dry-run; only \`tool_calls\` are captured
- **Hourly cron + OASIS failure events** — Slice 1b
- **Voice LAB monitor panel UI** — Slice 1c

## Test plan

- [x] \`npm run build\` clean
- [x] \`npx jest test/voice-lab/livekit-test-scorer.test.ts\` — 28/28 passing
- [ ] Apply migration via \`RUN-MIGRATION.yml\` (manual step before EXEC-DEPLOY)
- [ ] After deploy: \`curl -X POST https://gateway.vitanaland.com/api/v1/voice-lab/tests/run -H "Authorization: Bearer \$GATEWAY_SERVICE_TOKEN" -d '{"trigger":"manual"}'\` — expect \`{ok:true, summary:{total:13, passed:N, failed:M, errored:K}}\`
- [ ] Spot-check one failing case via \`GET /tests/runs/:id\` to confirm \`failure_reasons\` shape

## Risks / notes

- **Drift risk** (documented): the gateway hand-builds Gemini \`function_declarations\`; the agent's SDK auto-derives them from Python \`@function_tool\` decorators. Tool **names** match by construction (spec.json contract). Parameter **schemas** may differ subtly. Acceptable for tool-routing tests, not for arg-level schema validation.
- **No safety nets in the runner yet** (concurrent runs / rate limits). For Slice 1a the cron isn't wired; admins can manually trigger only.
- **Test user**: defaults to the CLAUDE.md test UUID \`a27552a3-0257-4305-8ed0-351a80fd3701\` (resolves tenant_id via \`app_users\`). Override via \`VOICE_LAB_TEST_USER_ID\` / \`VOICE_LAB_TEST_TENANT_ID\` env vars.

🤖 Generated with [Claude Code](https://claude.com/claude-code)