### PR TITLE
fix(orb-agent): audible Devon voice swap on LiveKit (VTID-03026)

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -736,6 +736,20 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     gw.is_mobile = bool(identity.is_mobile)
     gw.is_anonymous = bool(identity.is_anonymous)
 
+    # VTID-03026: stash everything the report_to_specialist @function_tool
+    # needs to trigger perform_handoff() (audible Devon voice swap on
+    # LiveKit). Without this the tool body can't reach the AgentSession,
+    # OasisEmitter, ContextBootstrap, or identity values.
+    gw.oasis_emitter = oasis
+    gw.ctx_fetcher = ctx_fetcher
+    gw.user_jwt = user_jwt or ""
+    gw.user_id = identity.user_id or ""
+    gw.orb_session_id = orb_session_id
+    gw.identity_lang = identity.lang
+    gw.identity_client_ip = identity.client_ip
+    # The live AgentSession reference is stashed AFTER session = AgentSession(...)
+    # is constructed below (gw.live_session = session).
+
     # VTID-03003: wire Silero VAD so the cascade-pipeline can detect turn
     # boundaries reliably. VTID-03012: VAD is now module-level cached
     # (loaded once, reused across sessions) so first-time PyTorch model
@@ -754,6 +768,10 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     if vad_instance is not None:
         session_kwargs["vad"] = vad_instance
     session = AgentSession(**session_kwargs)
+    # VTID-03026: report_to_specialist @function_tool reaches the live
+    # AgentSession through gw.live_session to invoke perform_handoff().
+    gw.live_session = session
+    gw.current_agent_id = agent_id
 
     # Wire teardown for AFTER the room disconnects, not for after start()
     # returns. AgentSession.start() exits as soon as the room IO and the
@@ -1317,16 +1335,24 @@ async def perform_handoff(
     new_cascade = build_cascade(new_bootstrap.voice_config, lang=lang)
 
     # Swap LLM + TTS instances. STT untouched.
+    # VTID-03026: track whether the in-place swap actually took (Python
+    # `setattr` succeeds even when livekit-agents internally caches the
+    # original reference; a False applied_* flag means the swap silently
+    # failed and the next turn will still use the previous voice).
+    applied_llm = False
+    applied_tts = False
     if new_cascade.llm is not None:
         try:
             session.llm = new_cascade.llm  # type: ignore[assignment]
-        except Exception:
-            pass
+            applied_llm = True
+        except Exception as _exc_llm:  # noqa: BLE001
+            logger.warning("VTID-03026: session.llm setattr failed: %s", _exc_llm)
     if new_cascade.tts is not None:
         try:
             session.tts = new_cascade.tts  # type: ignore[assignment]
-        except Exception:
-            pass
+            applied_tts = True
+        except Exception as _exc_tts:  # noqa: BLE001
+            logger.warning("VTID-03026: session.tts setattr failed: %s", _exc_tts)
 
     await oasis.emit(
         topic=TOPIC_PERSONA_SWAP,
@@ -1335,6 +1361,9 @@ async def perform_handoff(
             "agent_id": to_agent_id,
             "tts_provider": (new_bootstrap.voice_config or {}).get("tts_provider"),
             "tts_model": (new_bootstrap.voice_config or {}).get("tts_model"),
+            # VTID-03026: diagnostic — proves whether the audible swap took.
+            "applied_llm_swap": applied_llm,
+            "applied_tts_swap": applied_tts,
         },
     )
     await oasis.emit(

--- a/services/agents/orb-agent/src/orb_agent/tools.py
+++ b/services/agents/orb-agent/src/orb_agent/tools.py
@@ -207,23 +207,94 @@ async def switch_persona(context: RunContext, persona: str) -> str:
 
 @function_tool
 async def report_to_specialist(
-    context: RunContext, specialist: str, reason: str, context_summary: str
+    context: RunContext,
+    kind: str,
+    summary: str,
+    specialist_hint: str | None = None,
 ) -> str:
-    """Hand off to a specialist (Sage / Devon / Atlas / Mira / Vitana).
+    """File a customer-support ticket and hand the call to a specialist.
 
-    Triggers the persona-swap flow in session.py. Each specialist has its own
-    voice configured in agent_voice_configs.
+    Mirrors Vertex's tool schema (voice-pipeline-spec/spec.json). The
+    gateway helper creates a real feedback_tickets row + handoff event
+    + OASIS emit. If the response includes a `persona`, this wrapper
+    then swaps the LiveKit AgentSession's LLM + TTS to the specialist's
+    voice (so Devon answers in Devon's voice — matches the Vertex
+    transparent-reconnect behavior).
 
     Args:
-        specialist: One of: 'sage' | 'devon' | 'atlas' | 'mira' | 'vitana'.
-        reason: Why the user is being handed off.
-        context_summary: Short summary the specialist needs to pick up the conversation.
+        kind: Best classification of what's being reported. One of:
+            'bug', 'ux_issue', 'support_question', 'account_issue',
+            'marketplace_claim', 'feature_request', 'feedback'.
+        summary: Concrete description in the user's own words (>= 15
+            words). Must include what broke, on which screen/feature,
+            with specifics. NO placeholder summaries.
+        specialist_hint: Optional persona key — backend re-checks via
+            the keyword router and falls back to a kind→persona match.
     """
-    body = await _dispatch(
-        context,
-        "report_to_specialist",
-        {"specialist": specialist, "reason": reason, "context_summary": context_summary},
-    )
+    args: dict[str, Any] = {"kind": kind, "summary": summary}
+    if specialist_hint:
+        args["specialist_hint"] = specialist_hint
+    body = await _dispatch(context, "report_to_specialist", args)
+
+    # VTID-03026: audible Devon voice swap on LiveKit. Vertex achieves
+    # the same effect via session.pendingPersonaSwap + transparent
+    # reconnect (orb-live.ts). On LiveKit we use perform_handoff() in
+    # session.py: emits handoff_start telemetry, plays a bridge cue in
+    # Vitana's voice, fetches Devon's voice_config from agent_voice_configs,
+    # builds Devon's cascade, swaps session.llm + session.tts in place.
+    #
+    # Only swap when the gateway helper returned decision='created'
+    # with a non-empty `persona`. vague / stay_inline / failed → no
+    # swap; Vitana keeps the user.
+    try:
+        result = body.get("result") if isinstance(body, dict) else None
+        decision = result.get("decision") if isinstance(result, dict) else None
+        persona = result.get("persona") if isinstance(result, dict) else None
+        if decision == "created" and persona and persona in {"devon", "sage", "atlas", "mira"}:
+            gw = _gw(context)
+            session_ref = getattr(gw, "live_session", None)
+            oasis_ref = getattr(gw, "oasis_emitter", None)
+            ctx_fetcher_ref = getattr(gw, "ctx_fetcher", None)
+            current_agent_id = getattr(gw, "current_agent_id", "vitana") or "vitana"
+            if session_ref is not None and oasis_ref is not None and ctx_fetcher_ref is not None:
+                # Import inside the wrapper to avoid the tools.py → session.py
+                # import cycle at module load.
+                from .session import perform_handoff
+
+                await perform_handoff(
+                    session=session_ref,
+                    oasis=oasis_ref,
+                    ctx_fetcher=ctx_fetcher_ref,
+                    user_jwt=getattr(gw, "user_jwt", "") or "",
+                    user_id=getattr(gw, "user_id", "") or "",
+                    orb_session_id=getattr(gw, "orb_session_id", "") or "",
+                    from_agent_id=current_agent_id,
+                    to_agent_id=persona,
+                    reason=f"user reported {kind}",
+                    context_summary=summary,
+                    lang=(getattr(gw, "identity_lang", "en") or "en"),
+                    client_ip=getattr(gw, "identity_client_ip", None),
+                )
+                gw.current_agent_id = persona
+                logger.info(
+                    "report_to_specialist: audible persona swap fired %s → %s",
+                    current_agent_id,
+                    persona,
+                )
+            else:
+                logger.warning(
+                    "report_to_specialist: missing handoff plumbing on gw "
+                    "(session=%s, oasis=%s, ctx_fetcher=%s) — ticket filed but no voice swap",
+                    session_ref is not None,
+                    oasis_ref is not None,
+                    ctx_fetcher_ref is not None,
+                )
+    except Exception as exc:  # noqa: BLE001
+        # Never let the swap failure mask the ticket-creation success.
+        # The LLM-facing response from the gateway is already correct;
+        # we just log so the trace shows what happened.
+        logger.warning("report_to_specialist: perform_handoff failed: %s", exc)
+
     return summarize(body)
 
 


### PR DESCRIPTION
## Summary
VTID-03024 made the tool create real `feedback_tickets`, but parity with Vertex needs the **audible persona swap** too — Devon answers in Devon's voice, not Vitana's. Two pre-existing breakages prevented that.

### Bug 1 — wrong tool schema on LiveKit
The agent's `@function_tool` wrapper exposed `(specialist, reason, context_summary)` to the LLM. Vertex's `voice-pipeline-spec/spec.json` schema is `(kind, summary, specialist_hint)`. The LLM couldn't construct a valid call — even the ticket-creation flow shipped in #2149 was unreachable until this wrapper matched.

### Bug 2 — `perform_handoff()` exists but is never called
`services/agents/orb-agent/src/orb_agent/session.py:1264` has a fully implemented persona-swap function. Nothing in the tool dispatch path triggers it.

## Changes
- **`session.py`**: stash on `gw` (RunContext.userdata) — `oasis_emitter`, `ctx_fetcher`, `user_jwt`, `user_id`, `orb_session_id`, `identity_lang`, `identity_client_ip`, `current_agent_id`, `live_session`. The tool wrapper needs all of these to invoke `perform_handoff`.
- **`session.py`**: `perform_handoff` now records `applied_llm_swap` + `applied_tts_swap` booleans in the `TOPIC_PERSONA_SWAP` OASIS payload. Same instrumentation pattern VTID-03015 used to diagnose VTID-03017's silent instruction-swap failure.
- **`tools.py`**: `report_to_specialist` signature now `(kind, summary, specialist_hint?)` matching Vertex's schema. After `_dispatch`, if `response.result.decision == 'created'` AND `response.result.persona ∈ {devon, sage, atlas, mira}`, the wrapper invokes `perform_handoff(...)`. Failures are logged but don't mask ticket-creation success.

## Expected Vertex-parity flow on LiveKit
1. User: "Ich möchte einen Bug melden" / "I want to report a bug"
2. Vitana asks for specifics, user describes, Vitana proposes bringing in tech support, user agrees.
3. Tool fires with `(kind='bug', summary='<concrete description>')`.
4. Gateway helper creates `feedback_tickets` row → returns `decision='created', persona='devon'`.
5. Vitana speaks ONE bridge sentence in HER voice.
6. `perform_handoff`: emits `handoff_start` telemetry; plays "transferring you to tech support" in Vitana's voice; fetches Devon's `agent_voice_configs` row; builds Devon's STT/LLM/TTS cascade; swaps `session.llm` / `session.tts` in place.
7. Devon's first turn fires in Devon's voice. Devon already has the summary in `context_summary` (handed off through the new bootstrap fetch with `agent_id='devon'`).

## Risk noted in code + commit
livekit-agents may not allow runtime `setattr` on `session.llm` / `session.tts` — same class of issue we hit with `.instructions` in VTID-03017. The new `applied_*_swap` diagnostic will tell us in the next real session whether the audible swap actually fires. If `applied_llm_swap=False` or `applied_tts_swap=False`, we iterate with a session-restart approach.

## Test plan
- [ ] DEPLOY-ORB-AGENT auto-fires (gateway untouched — no gateway deploy).
- [ ] Test Bench in German: say "Ich möchte einen Bug melden" → describe a real bug → Vitana proposes Devon → user agrees → bridge sentence in Vitana's voice → **Devon answers in male voice** with reference to the summary.
- [ ] Inspect the new OASIS event `orb.livekit.agent.persona_swap` for `applied_llm_swap: true` + `applied_tts_swap: true`. If either is false, the swap silently failed and we iterate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)