### PR TITLE
feat(orb): Vertex-parity report_to_specialist with full persona rebuild on LiveKit (VTID-03027)

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/bootstrap.py
+++ b/services/agents/orb-agent/src/orb_agent/bootstrap.py
@@ -103,6 +103,7 @@ class ContextBootstrap:
         last_n_turns: int = 0,
         lang: str | None = None,
         client_ip: str | None = None,
+        handoff_summary: str | None = None,
     ) -> BootstrapResult:
         return await self._do_fetch(
             user_jwt=user_jwt,
@@ -112,6 +113,7 @@ class ContextBootstrap:
             is_reconnect=is_reconnect,
             last_n_turns=last_n_turns,
             greeting_only=False,
+            handoff_summary=handoff_summary,
         )
 
     async def _do_fetch(
@@ -124,6 +126,7 @@ class ContextBootstrap:
         is_reconnect: bool,
         last_n_turns: int,
         greeting_only: bool,
+        handoff_summary: str | None = None,
     ) -> BootstrapResult:
         params: dict[str, str | int | bool] = {
             "agent_id": agent_id,
@@ -132,6 +135,14 @@ class ContextBootstrap:
         }
         if greeting_only:
             params["greeting_only"] = True
+        # VTID-03027: when the agent is rebuilding the session for a
+        # specialist persona after a report_to_specialist handoff, pass
+        # the user's brief through to the gateway so the persona's
+        # rendered system_instruction includes a [HANDOFF NOTE] section.
+        # Without this, Devon would have to ask "what's the issue?" again,
+        # since he wouldn't know what Vitana already heard.
+        if handoff_summary:
+            params["handoff_summary"] = handoff_summary[:2000]
         # VTID-LIVEKIT-AGENT-JWT: prefer the per-session user JWT in the
         # standard Authorization header (the gateway's optionalAuth checks
         # only Bearer). Fall back to the service-token header pre-built in

--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -736,6 +736,24 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     gw.is_mobile = bool(identity.is_mobile)
     gw.is_anonymous = bool(identity.is_anonymous)
 
+    # VTID-03027: stash everything the report_to_specialist tool body
+    # needs to SIGNAL a persona rebuild (handoff_event). The main loop
+    # below watches the event; on set, it gracefully stops the current
+    # session, fetches the persona's bootstrap, and starts a fresh
+    # AgentSession in the same room. Vertex-parity flow.
+    gw.oasis_emitter = oasis
+    gw.ctx_fetcher = ctx_fetcher
+    gw.user_jwt = user_jwt or ""
+    gw.user_id = identity.user_id or ""
+    gw.orb_session_id = orb_session_id
+    gw.identity_lang = identity.lang
+    gw.identity_client_ip = identity.client_ip
+    gw.current_agent_id = agent_id
+    gw.handoff_event = asyncio.Event()
+    gw.handoff_target = None
+    gw.handoff_summary = None
+    gw.handoff_reason = None
+
     # VTID-03003: wire Silero VAD so the cascade-pipeline can detect turn
     # boundaries reliably. VTID-03012: VAD is now module-level cached
     # (loaded once, reused across sessions) so first-time PyTorch model
@@ -754,6 +772,9 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     if vad_instance is not None:
         session_kwargs["vad"] = vad_instance
     session = AgentSession(**session_kwargs)
+    # VTID-03027: live session reference for the handoff main loop below.
+    # The loop replaces this when a persona rebuild fires.
+    gw.live_session = session
 
     # Wire teardown for AFTER the room disconnects, not for after start()
     # returns. AgentSession.start() exits as soon as the room IO and the
@@ -1247,11 +1268,169 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     # above — no runtime swap needed, no SDK-API research needed, no
     # `applied_instructions:false` failure mode. Correctness > 500ms latency.
 
-    # Park here until the room disconnects. The AgentSession keeps running
-    # autonomously via the tasks it spawned in start(); we just need to
-    # keep the entrypoint alive so the shutdown callback above fires at
-    # the right moment.
-    await disconnected_evt.wait()
+    # VTID-03027: PERSONA REBUILD LOOP — Vertex-parity for report_to_specialist.
+    #
+    # Vertex's transparent-reconnect approach: when user reports a bug,
+    # Vitana files the ticket and triggers attemptTransparentReconnect
+    # with Devon's system_prompt + Devon's voice config. The Gemini Live
+    # WebSocket is torn down and rebuilt with the new persona — same
+    # room, new identity, new voice.
+    #
+    # LiveKit equivalent: the tool wrapper sets gw.handoff_event with
+    # gw.handoff_target = 'devon' + gw.handoff_summary = <bug_brief>.
+    # The loop here:
+    #   1. Waits for EITHER disconnect OR handoff event.
+    #   2. On disconnect: break out, normal cleanup runs.
+    #   3. On handoff: stops the current AgentSession (so the current
+    #      voice's audio frame queue drains), fetches the new persona's
+    #      bootstrap with handoff_summary= so the gateway renders
+    #      Devon's system_instruction with [HANDOFF NOTE] injected,
+    #      builds Devon's cascade, starts a fresh AgentSession in the
+    #      same room. Then calls session.generate_reply(...) to trigger
+    #      Devon's first turn in Devon's voice referencing the brief.
+    #   4. Loop back — Devon's session can also handoff (e.g. back to
+    #      Vitana, or laterally), or eventually the user disconnects.
+    while True:
+        disc_task = asyncio.create_task(disconnected_evt.wait())
+        handoff_task = asyncio.create_task(gw.handoff_event.wait())
+        done, pending = await asyncio.wait(
+            {disc_task, handoff_task},
+            return_when=asyncio.FIRST_COMPLETED,
+        )
+        for t in pending:
+            t.cancel()
+
+        if disconnected_evt.is_set():
+            break
+
+        # Handoff signal fired. Capture targets, clear event, run rebuild.
+        target = (gw.handoff_target or "").strip().lower()
+        handoff_brief = (gw.handoff_summary or "").strip()
+        reason = (gw.handoff_reason or "").strip() or "handoff"
+        gw.handoff_event.clear()
+        gw.handoff_target = None
+        gw.handoff_summary = None
+        gw.handoff_reason = None
+        if not target or target not in {"devon", "sage", "atlas", "mira", "vitana"}:
+            logger.warning(
+                "agent_entrypoint: handoff signal with invalid target %r — ignored",
+                target,
+            )
+            continue
+
+        from_agent_id = gw.current_agent_id
+        logger.info(
+            "agent_entrypoint: rebuilding session for handoff %s → %s",
+            from_agent_id,
+            target,
+        )
+        try:
+            await oasis.emit(
+                topic=TOPIC_HANDOFF_START,
+                payload={
+                    "from_agent_id": from_agent_id,
+                    "to_agent_id": target,
+                    "reason": reason,
+                    "context_summary": handoff_brief,
+                    "user_id": identity.user_id,
+                    "orb_session_id": orb_session_id,
+                },
+            )
+        except Exception:  # noqa: BLE001
+            pass
+
+        # Close the current session so its audio stream stops cleanly.
+        try:
+            close_method = getattr(session, "aclose", None) or getattr(session, "close", None)
+            if close_method is not None:
+                res = close_method()
+                if asyncio.iscoroutine(res):
+                    await res
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("agent_entrypoint: session.aclose failed: %s", exc)
+
+        # Fetch the new persona's bootstrap. handoff_summary injects the
+        # [HANDOFF NOTE] into the gateway-rendered persona system_instruction.
+        try:
+            new_bootstrap = await ctx_fetcher.fetch(
+                user_jwt=user_jwt or "",
+                agent_id=target,
+                is_reconnect=True,
+                last_n_turns=10,
+                lang=identity.lang,
+                client_ip=identity.client_ip,
+                handoff_summary=handoff_brief or None,
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("agent_entrypoint: new persona bootstrap fetch failed: %s", exc)
+            break
+
+        # Build Devon's cascade (STT/LLM/TTS) — Devon's voice is in
+        # bootstrap.voice_config (agent_voice_configs row for agent_id=devon).
+        new_cascade = build_cascade(
+            new_bootstrap.voice_config,
+            lang=identity.lang,
+            voice_override=voice_override,
+        )
+        new_sys_prompt = new_bootstrap.system_instruction or (
+            "You are a Vitana specialist. The gateway did not render your "
+            "system instruction. Greet the user and help them as best you can."
+        )
+        new_tool_list = all_tools()
+        if (new_bootstrap.voice_config or {}).get("llm_provider") == "google_llm":
+            try:
+                from livekit.plugins.google.tools import GoogleSearch  # type: ignore[import-not-found]
+                new_tool_list.append(GoogleSearch())
+            except ImportError:
+                pass
+        new_agent = Agent(instructions=new_sys_prompt, tools=new_tool_list)
+        new_session_kwargs: dict[str, Any] = {
+            "stt": new_cascade.stt,
+            "llm": new_cascade.llm,
+            "tts": new_cascade.tts,
+            "userdata": gw,
+            "max_tool_steps": MAX_TOOL_STEPS,
+        }
+        if vad_instance is not None:
+            new_session_kwargs["vad"] = vad_instance
+        session = AgentSession(**new_session_kwargs)
+        gw.live_session = session
+        gw.current_agent_id = target
+
+        try:
+            await session.start(agent=new_agent, room=ctx.room)
+        except Exception as exc:  # noqa: BLE001
+            logger.exception("agent_entrypoint: new session.start failed: %s", exc)
+            break
+
+        # Trigger persona's first turn — the LLM speaks as the persona,
+        # referencing the handoff brief from its system_instruction.
+        try:
+            await session.generate_reply(
+                instructions=(
+                    "Open this conversation as yourself (the persona described in your "
+                    "system instruction). Greet the user warmly in their language with "
+                    "ONE short sentence introducing yourself by role. If a HANDOFF NOTE "
+                    "is present in your system instruction, synthesize it in ONE sentence "
+                    "in your own words and confirm. If not, ask the user what you can help "
+                    "with. Vary your phrasing. NEVER speak as Vitana."
+                ),
+            )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("agent_entrypoint: persona first turn failed: %s", exc)
+
+        try:
+            await oasis.emit(
+                topic=TOPIC_HANDOFF_COMPLETE,
+                payload={
+                    "from_agent_id": from_agent_id,
+                    "to_agent_id": target,
+                    "user_id": identity.user_id,
+                    "orb_session_id": orb_session_id,
+                },
+            )
+        except Exception:  # noqa: BLE001
+            pass
 
 
 # ---------------------------------------------------------------------------

--- a/services/agents/orb-agent/src/orb_agent/tools.py
+++ b/services/agents/orb-agent/src/orb_agent/tools.py
@@ -207,23 +207,74 @@ async def switch_persona(context: RunContext, persona: str) -> str:
 
 @function_tool
 async def report_to_specialist(
-    context: RunContext, specialist: str, reason: str, context_summary: str
+    context: RunContext,
+    kind: str,
+    summary: str,
+    specialist_hint: str | None = None,
 ) -> str:
-    """Hand off to a specialist (Sage / Devon / Atlas / Mira / Vitana).
+    """File a customer-support ticket and hand the call to a specialist.
 
-    Triggers the persona-swap flow in session.py. Each specialist has its own
-    voice configured in agent_voice_configs.
+    Mirrors Vertex's tool schema (voice-pipeline-spec/spec.json). The
+    gateway creates a real feedback_tickets row + handoff event + OASIS
+    emit. If the response includes a `persona`, this wrapper SIGNALS the
+    agent's main loop to rebuild the AgentSession for that persona —
+    Devon answers in Devon's voice with Devon's system_instruction.
 
     Args:
-        specialist: One of: 'sage' | 'devon' | 'atlas' | 'mira' | 'vitana'.
-        reason: Why the user is being handed off.
-        context_summary: Short summary the specialist needs to pick up the conversation.
+        kind: Best classification of what's being reported. One of:
+            'bug', 'ux_issue', 'support_question', 'account_issue',
+            'marketplace_claim', 'feature_request', 'feedback'.
+        summary: Concrete description in the user's own words (>= 15
+            words). What broke, on which screen/feature, with specifics.
+        specialist_hint: Optional persona key.
     """
-    body = await _dispatch(
-        context,
-        "report_to_specialist",
-        {"specialist": specialist, "reason": reason, "context_summary": context_summary},
-    )
+    args: dict[str, Any] = {"kind": kind, "summary": summary}
+    if specialist_hint:
+        args["specialist_hint"] = specialist_hint
+    body = await _dispatch(context, "report_to_specialist", args)
+
+    # VTID-03027: signal the agent main loop to rebuild the AgentSession
+    # for the new persona. We DON'T call perform_handoff() here (that did
+    # an in-place setattr swap which can't change the LLM's bound
+    # system_instruction — VTID-03017 lesson). Instead the main loop in
+    # session.py:agent_entrypoint watches gw.handoff_event; when it
+    # fires, it gracefully stops the current session, fetches the
+    # persona's bootstrap (gateway returns persona-specific system
+    # instruction with [HANDOFF NOTE] injected via handoff_summary
+    # query param), builds Devon's full cascade (STT/LLM/TTS), and
+    # restarts AgentSession in the same room. From the user's
+    # perspective: Vitana's bridge sentence in her voice, brief gap,
+    # Devon answers in Devon's voice with the brief in his prompt.
+    try:
+        result = body.get("result") if isinstance(body, dict) else None
+        decision = result.get("decision") if isinstance(result, dict) else None
+        persona = result.get("persona") if isinstance(result, dict) else None
+        if (
+            decision == "created"
+            and persona
+            and persona in {"devon", "sage", "atlas", "mira"}
+        ):
+            gw = _gw(context)
+            handoff_event = getattr(gw, "handoff_event", None)
+            if handoff_event is not None:
+                gw.handoff_target = persona
+                gw.handoff_summary = summary
+                gw.handoff_reason = f"user reported {kind}"
+                handoff_event.set()
+                logger.info(
+                    "report_to_specialist: handoff signal set → %s "
+                    "(main loop will rebuild AgentSession)",
+                    persona,
+                )
+            else:
+                logger.warning(
+                    "report_to_specialist: gw.handoff_event missing — "
+                    "ticket filed but no persona rebuild will fire",
+                )
+    except Exception as exc:  # noqa: BLE001
+        # Never let the signal failure mask the ticket-creation success.
+        logger.warning("report_to_specialist: handoff signal failed: %s", exc)
+
     return summarize(body)
 
 

--- a/services/gateway/src/routes/orb-livekit.ts
+++ b/services/gateway/src/routes/orb-livekit.ts
@@ -991,8 +991,60 @@ router.get(
     // Best-effort: if rendering throws, the agent still gets the structured
     // bootstrap_context + identity fields and can fall back to its
     // pre-L2.2b.6 builder. Never block the bootstrap on a render error.
+    // VTID-03027: when agent_id is a SPECIALIST persona (devon/sage/atlas/
+    // mira), the agent is asking for the persona-specific system
+    // instruction — not Vitana's. Mirror Vertex's persona-swap path which
+    // loads `agent_personas.system_prompt` for the target persona and
+    // composes the persona's full prompt with language directive +
+    // optional handoff brief. Without this, LiveKit handoff returns
+    // Vitana's 65KB IDENTITY-LOCK'd prompt for Devon — costume Devon.
+    const SPECIALIST_PERSONAS = new Set(['devon', 'sage', 'atlas', 'mira']);
+    const handoffSummary = typeof req.query.handoff_summary === 'string'
+      ? (req.query.handoff_summary as string).trim()
+      : '';
     let systemInstruction: string | null = null;
+    if (SPECIALIST_PERSONAS.has(agentId.toLowerCase())) {
+      try {
+        const { data: personaRow } = await sb!
+          .from('agent_personas')
+          .select('system_prompt, display_name')
+          .eq('key', agentId.toLowerCase())
+          .maybeSingle();
+        const personaPrompt = (personaRow as { system_prompt?: string } | null)?.system_prompt?.trim() || '';
+        if (personaPrompt) {
+          const langNames: Record<string, string> = {
+            en: 'English', de: 'German', fr: 'French', es: 'Spanish',
+            ar: 'Arabic', zh: 'Chinese', ru: 'Russian', sr: 'Serbian',
+          };
+          const langName = langNames[lang] || 'English';
+          const personaParts: string[] = [];
+          personaParts.push(personaPrompt);
+          personaParts.push(
+            `[LANGUAGE LOCK]\nRespond ONLY in ${langName}. Match the user's language exactly. Do NOT switch to English. Do NOT mix languages. The user has been speaking ${langName} with Vitana already; continue in the same language without acknowledging the switch.`,
+          );
+          if (bootstrapContext) {
+            personaParts.push(
+              `## USER CONTEXT (carried over from Vitana)\n\n${bootstrapContext}`,
+            );
+          }
+          if (handoffSummary) {
+            personaParts.push(
+              `[HANDOFF NOTE] Vitana captured this brief at handoff: "${handoffSummary}". Synthesize what the user reported in ONE sentence (your own words, not theirs) and confirm. Do NOT echo their wording back. Then ask any clarifying question you need. Open the conversation in your own voice and persona — never speak as Vitana, never quote her.`,
+            );
+          }
+          personaParts.push(
+            '[BEHAVIORAL RULE] Speak in your OWN persona. Greet the user warmly in the user\'s language with ONE short sentence introducing yourself by role (e.g. "I\'m the tech support colleague Vitana brought in"). Then either reference the handoff brief above OR ask "what can I help you with?" if no brief is present. Vary your phrasing every call. Never apologize for the handoff.',
+          );
+          systemInstruction = personaParts.join('\n\n');
+          console.log(`[VTID-03027] persona system_instruction rendered for ${agentId} (${systemInstruction.length} chars, handoff_summary=${handoffSummary ? `${handoffSummary.length} chars` : 'none'})`);
+        }
+      } catch (exc) {
+        console.warn(`[VTID-03027] persona prompt fetch failed for ${agentId}: ${(exc as Error).message}`);
+      }
+    }
+    // Vitana path: full 65KB system instruction with IDENTITY LOCK etc.
     try {
+      if (systemInstruction === null) {
       const voiceStyle =
         (voiceConfig as { voice_style?: string } | null)?.voice_style?.trim() ||
         'friendly, calm, empathetic';
@@ -1010,6 +1062,7 @@ router.get(
         envContext ?? undefined,
         req.identity?.vitana_id ?? null,
       );
+      }
     } catch (exc) {
       console.warn(
         `[${VTID}] system_instruction render failed (agent falls back to its own builder): ${(exc as Error).message}`,


### PR DESCRIPTION
## Summary
True Vertex parity for bug-reporting on LiveKit. Vertex achieves it via `attemptTransparentReconnect` — tears down the Gemini Live WebSocket and rebuilds with the persona's `system_prompt` + voice config. LiveKit can't do in-place mutation (VTID-03017 / VTID-03021 lesson: livekit-agents doesn't expose runtime instruction swap). The equivalent is **session rebuild**.

## Vertex-parity user journey after this PR
1. User: \"Ich möchte einen Bug melden.\"
2. Vitana asks for specifics. User describes the bug.
3. Vitana proposes bringing in tech support. User agrees.
4. `report_to_specialist` fires.
5. Gateway creates real `feedback_tickets` row → returns `decision='created', persona='devon'`.
6. Vitana speaks ONE bridge sentence in HER voice.
7. `agent_entrypoint` main loop picks up the handoff signal, stops Vitana's session, fetches Devon's bootstrap (gateway returns Devon's persona-specific `system_instruction` with the bug summary injected as `[HANDOFF NOTE]`), starts Devon's session in the same room.
8. Brief gap (~1–2s).
9. Devon's first turn fires in **DEVON'S VOICE** (male, from his `agent_voice_configs` row). Devon's prompt contains the bug brief — he synthesizes it and confirms before asking clarifying questions.

## Changes
**Gateway** (`services/gateway/src/routes/orb-livekit.ts`)
- When `/orb/context-bootstrap` is called with `agent_id ∈ {devon, sage, atlas, mira}`, load `agent_personas.system_prompt` and compose persona-specific `system_instruction` = persona_prompt + language directive + carried-over user context + `[HANDOFF NOTE]` + behavioral rule.
- New `handoff_summary` query param injected into the `[HANDOFF NOTE]` section.

**Agent** (`services/agents/orb-agent/src/orb_agent/`)
- `bootstrap.py`: `fetch(..., handoff_summary=None)` parameter; forwarded as query param.
- `session.py`: stash on `gw` everything the rebuild needs (`oasis_emitter`, `ctx_fetcher`, `user_jwt`, `user_id`, `orb_session_id`, `identity_lang`, `identity_client_ip`, `current_agent_id`, `handoff_event`, `handoff_target`, `handoff_summary`, `handoff_reason`, `live_session`).
- `session.py`: replace `await disconnected_evt.wait()` at end of `agent_entrypoint` with a **persona-rebuild LOOP**:
  1. Wait for EITHER disconnect OR handoff signal.
  2. On disconnect: break (normal cleanup).
  3. On handoff: emit `handoff.start`, `session.aclose()`, fetch new persona bootstrap with brief, build new cascade, new `Agent(instructions=persona_sys_prompt)`, new `AgentSession`, `session.start(agent=new_agent, room=ctx.room)` in same room, `generate_reply(...)` to trigger persona first turn, emit `handoff.complete`.
  4. Loop — persona's session can also handoff or disconnect.
- `tools.py`: `report_to_specialist(kind, summary, specialist_hint?)` matching Vertex's spec.json schema. Signals handoff via `gw.handoff_event.set()` instead of in-place mutation. **Removes the broken `perform_handoff()` invocation** (the deprecated approach that tried `setattr(session, 'llm', …)` — would silently fail).

## Out of scope
- Devon → Vitana swap-back via `switch_persona` (loop supports it structurally, tool wrapper needs the same signal pattern — separate VTID).
- Specialist intake tools (file ticket updates, close ticket etc.).
- Loop guard / swap cooldown on LiveKit (Vertex tracks `swapCount`; equivalent for LiveKit needed if loops become an issue).

## Test plan
- [ ] PR CI green.
- [ ] Both deploys green — touches both gateway (persona prompt) AND agent (session loop).
- [ ] User runs the full Vertex-parity flow in German Test Bench:
  - Says \"Ich möchte einen Bug melden\" → describes bug → agrees to Devon.
  - Hears Vitana's bridge in HER voice.
  - Hears Devon answer in a DIFFERENT (male) voice.
  - Devon references the bug summary.
- [ ] Inspect `oasis_events` for `orb.livekit.agent.handoff.start` + `.complete`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)