### PR TITLE
fix(voice-lab): harden livekit-tests identity resolution + add smoke workflow (VTID-03025)

### DIFF
--- a/.github/workflows/SMOKE-LIVEKIT-TESTS.yml
+++ b/.github/workflows/SMOKE-LIVEKIT-TESTS.yml
@@ -1,0 +1,91 @@
+name: Smoke — LiveKit hourly tests (manual)
+
+# VTID-03025 (Slice 1a follow-up): operator-dispatchable smoke for the
+# voice-lab livekit dry-run suite. NOT the hourly cron — that lands in
+# Slice 1b. This workflow exists so the suite can be executed from CI
+# (where GATEWAY_SERVICE_TOKEN is in secrets) without needing Cloud Shell.
+
+on:
+  workflow_dispatch:
+    inputs:
+      case_key:
+        description: 'Restrict to a single case key (optional, e.g. life_compass_query). Leave blank for full suite.'
+        required: false
+        default: ''
+      trigger:
+        description: 'trigger field stored on the run row'
+        required: false
+        default: 'admin'
+
+concurrency:
+  group: smoke-livekit-tests
+  cancel-in-progress: false
+
+jobs:
+  smoke:
+    runs-on: ubuntu-latest
+    timeout-minutes: 5
+    steps:
+      - name: Run /api/v1/voice-lab/tests/run + dump full per-case results
+        env:
+          SERVICE_TOKEN: ${{ secrets.GATEWAY_SERVICE_TOKEN }}
+          GATEWAY_URL: https://gateway.vitanaland.com
+          CASE_KEY: ${{ inputs.case_key }}
+          TRIGGER: ${{ inputs.trigger }}
+        run: |
+          set -euo pipefail
+          if [ -z "${SERVICE_TOKEN:-}" ]; then
+            echo "::error::GATEWAY_SERVICE_TOKEN secret is not set"
+            exit 1
+          fi
+
+          # Build request body
+          if [ -n "${CASE_KEY}" ]; then
+            BODY="$(jq -nc --arg t "$TRIGGER" --arg k "$CASE_KEY" '{trigger:$t,case_key:$k}')"
+          else
+            BODY="$(jq -nc --arg t "$TRIGGER" '{trigger:$t}')"
+          fi
+          echo "::group::Request body"
+          echo "$BODY"
+          echo "::endgroup::"
+
+          # Invoke /tests/run
+          echo "::group::POST /api/v1/voice-lab/tests/run"
+          HTTP_CODE=$(curl -sS -o /tmp/run.json -w '%{http_code}' \
+            -X POST "$GATEWAY_URL/api/v1/voice-lab/tests/run" \
+            -H "Authorization: Bearer $SERVICE_TOKEN" \
+            -H "Content-Type: application/json" \
+            -d "$BODY")
+          echo "HTTP $HTTP_CODE"
+          echo "::endgroup::"
+
+          echo "::group::Run summary"
+          jq '.summary | {run_id, total, passed, failed, errored, duration_ms}' /tmp/run.json
+          echo "::endgroup::"
+
+          echo "::group::Per-case results (full detail incl. error + tool_calls)"
+          jq '.summary.results[] | {case_key, status, error, failure_reasons, tool_calls, latency_ms, instruction_chars, retried, reply_text: (.reply_text // "" | .[0:300])}' /tmp/run.json
+          echo "::endgroup::"
+
+          # Also fetch the persisted run row (proves DB writes worked)
+          RUN_ID=$(jq -r '.summary.run_id' /tmp/run.json)
+          if [ "$RUN_ID" != "null" ] && [ -n "$RUN_ID" ]; then
+            echo "::group::GET /api/v1/voice-lab/tests/runs/$RUN_ID"
+            curl -sS "$GATEWAY_URL/api/v1/voice-lab/tests/runs/$RUN_ID" \
+              -H "Authorization: Bearer $SERVICE_TOKEN" \
+            | jq '.run, (.results[] | {case_key, status, error, failure_reasons})'
+            echo "::endgroup::"
+          fi
+
+          # Surface a clear PASS/FAIL summary for the workflow log
+          PASSED=$(jq -r '.summary.passed' /tmp/run.json)
+          FAILED=$(jq -r '.summary.failed' /tmp/run.json)
+          ERRORED=$(jq -r '.summary.errored' /tmp/run.json)
+          TOTAL=$(jq -r '.summary.total' /tmp/run.json)
+          echo "================================================="
+          echo "Smoke result: $PASSED/$TOTAL passed, $FAILED failed, $ERRORED errored"
+          echo "================================================="
+          if [ "$ERRORED" != "0" ]; then
+            echo "::error::$ERRORED case(s) errored — see per-case detail above"
+            exit 1
+          fi

--- a/services/gateway/src/services/voice-lab/livekit-test-eval.ts
+++ b/services/gateway/src/services/voice-lab/livekit-test-eval.ts
@@ -81,6 +81,11 @@ export interface DryRunEvalResult {
 /** UUID hardcoded in CLAUDE.md as the canonical Vitana platform test user. */
 const FALLBACK_TEST_USER_ID = 'a27552a3-0257-4305-8ed0-351a80fd3701';
 
+/** Email of the canonical test account (CLAUDE.md). Used as a 2nd-tier
+ *  fallback when the UUID lookup misses (e.g. the user_id changed but the
+ *  email account still exists). */
+const FALLBACK_TEST_EMAIL = 'e2e-test@vitana.dev';
+
 /**
  * Run one dry-run case end-to-end. Throws on unrecoverable assembly
  * failures (missing test user, no Gemini credentials, etc.). Recoverable
@@ -225,45 +230,72 @@ export async function evaluateLiveKitDryRun(
 
 /**
  * Resolve a complete identity for the dry-run from the caller's partial
- * input + env + DB. Falls back to the hardcoded CLAUDE.md test user.
- * Looks up tenant_id via `app_users` if not supplied.
+ * input + env + DB. Three-tier fallback against `app_users`:
+ *
+ *   1. caller-supplied / env / hardcoded UUID
+ *   2. canonical test EMAIL (`e2e-test@vitana.dev`) — survives UUID rotation
+ *   3. any user with `vitana_id IS NOT NULL` (oldest row) — last resort so
+ *      the eval has *some* real bootstrap to render, even on an unfamiliar
+ *      Supabase project where neither the UUID nor the test email exist
+ *
+ * Throws only if all three tiers miss AND no `VOICE_LAB_TEST_TENANT_ID` is
+ * set — that means the deployed environment genuinely has no usable user.
  */
 async function resolveDryRunIdentity(
   partial?: Partial<DryRunIdentity>,
 ): Promise<DryRunIdentity> {
-  const userId =
+  const requestedUserId =
     partial?.user_id ??
     process.env.VOICE_LAB_TEST_USER_ID ??
     FALLBACK_TEST_USER_ID;
 
+  let userId = requestedUserId;
   let tenantId = partial?.tenant_id ?? process.env.VOICE_LAB_TEST_TENANT_ID ?? null;
   let vitanaId = partial?.vitana_id ?? null;
   let email = partial?.email ?? null;
   let activeRole = partial?.active_role;
 
-  if (!tenantId || !vitanaId || !email) {
-    const sb = getSupabase();
-    if (sb) {
-      const { data } = await sb
+  const sb = getSupabase();
+  const cols = 'user_id, tenant_id, vitana_id, email, role';
+
+  const apply = (data: Record<string, unknown>): void => {
+    userId = (data.user_id as string) ?? userId;
+    if (!tenantId) tenantId = (data.tenant_id as string | null | undefined) ?? null;
+    if (!vitanaId) vitanaId = (data.vitana_id as string | null | undefined) ?? null;
+    if (!email) email = (data.email as string | null | undefined) ?? null;
+    if (!activeRole) activeRole = (data.role as string | undefined) ?? undefined;
+  };
+
+  if (sb && (!tenantId || !vitanaId || !email)) {
+    // Tier 1: by user_id
+    const t1 = await sb.from('app_users').select(cols).eq('user_id', requestedUserId).maybeSingle();
+    if (t1.data) apply(t1.data as Record<string, unknown>);
+
+    // Tier 2: by canonical email
+    if (!tenantId) {
+      const t2 = await sb.from('app_users').select(cols).eq('email', FALLBACK_TEST_EMAIL).maybeSingle();
+      if (t2.data) apply(t2.data as Record<string, unknown>);
+    }
+
+    // Tier 3: any user with a vitana handle (deterministic — oldest row first)
+    if (!tenantId) {
+      const t3 = await sb
         .from('app_users')
-        .select('user_id, tenant_id, vitana_id, email, role')
-        .eq('user_id', userId)
+        .select(cols)
+        .not('vitana_id', 'is', null)
+        .order('created_at', { ascending: true })
+        .limit(1)
         .maybeSingle();
-      if (data) {
-        if (!tenantId) tenantId = (data as { tenant_id?: string | null }).tenant_id ?? null;
-        if (!vitanaId) vitanaId = (data as { vitana_id?: string | null }).vitana_id ?? null;
-        if (!email) email = (data as { email?: string | null }).email ?? null;
-        if (!activeRole) {
-          activeRole = (data as { role?: string | null }).role ?? undefined;
-        }
-      }
+      if (t3.data) apply(t3.data as Record<string, unknown>);
     }
   }
 
   if (!tenantId) {
     throw new Error(
-      `evaluateLiveKitDryRun: tenant_id unresolved for user ${userId} — ` +
-        'pass identity.tenant_id explicitly or set VOICE_LAB_TEST_TENANT_ID',
+      'evaluateLiveKitDryRun: no usable test identity in app_users ' +
+        `(tried user_id=${requestedUserId}, email=${FALLBACK_TEST_EMAIL}, ` +
+        'and oldest vitana_id user). ' +
+        'Set VOICE_LAB_TEST_USER_ID + VOICE_LAB_TEST_TENANT_ID to override.',
     );
   }
 


### PR DESCRIPTION
Slice 1a follow-up. First smoke after PR #2150 errored 13/13 at ~350ms — root cause: hardcoded test UUID has no \`app_users\` row in production Supabase, so identity resolution threw before reaching Vertex.

## Fix

Three-tier fallback in \`resolveDryRunIdentity\`:
1. UUID lookup (existing behavior)
2. Canonical email \`e2e-test@vitana.dev\`
3. Oldest user with \`vitana_id IS NOT NULL\`

Only throws if all three miss AND \`VOICE_LAB_TEST_TENANT_ID\` unset.

## Also: smoke workflow

\`SMOKE-LIVEKIT-TESTS.yml\` (workflow_dispatch only — NOT the hourly cron, that's Slice 1b). Uses \`secrets.GATEWAY_SERVICE_TOKEN\`, POSTs to \`/api/v1/voice-lab/tests/run\`, then GETs \`/tests/runs/:id\` and dumps full per-case detail (error, tool_calls, failure_reasons) into the workflow log.

Inputs: optional \`case_key\` for single-case runs, optional \`trigger\` label.

## Test plan

- [x] \`npm run build\` clean
- [x] 30/30 (scorer 28 + voice-lab auth 2) green
- [ ] CI green
- [ ] After merge + deploy: \`gh workflow run SMOKE-LIVEKIT-TESTS.yml\` and watch the result

🤖 Generated with [Claude Code](https://claude.com/claude-code)