### PR TITLE
fix(test-bench): survive renderApp() re-mounts (VTID-03029, follow-up to VTID-03023)

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -35103,6 +35103,28 @@ async function triggerOrbMonitor(btn) {
  * "Disconnect" tears down the Room + microphone.
  */
 function renderLivekitTestView() {
+    // VTID-03029: Survive renderApp() re-mounts.
+    //
+    // _renderAppCore() does `root.innerHTML = ''` (line ~5234) before
+    // rebuilding the tree from every render*View(). Anything that touches
+    // global state and re-renders mid-session — showToast() at line 5136
+    // and 5141 is the loudest culprit, but every background poll / role
+    // switch / notification dispatch does it too — wipes this view's DOM
+    // off-screen. The original closures keep running (Room stays alive,
+    // mic stays published, audio keeps playing) but the listener's
+    // stateEl reference is now detached, so setState('connected') paints
+    // a node nobody sees. The freshly-rendered DOM shows the initial
+    // "disconnected" HTML, and `room` in the new closure is null — so a
+    // second Connect click spawns a parallel WebRTC session on top of the
+    // first.
+    //
+    // Fix: while a LiveKit session is alive, cache this view's container
+    // on `window` and return the same DOM node on subsequent renders.
+    // Original closures + listener refs + audio elements stay intact;
+    // on-screen state matches the live session truthfully.
+    if (window._lktSurviveContainer && window._lktSurviveContainer._lktActive) {
+        return window._lktSurviveContainer;
+    }
     var container = document.createElement('div');
     container.className = 'livekit-test-view';
     container.style.cssText = 'padding:24px;max-width:1100px;margin:0 auto;font-family:system-ui,-apple-system,sans-serif;color:#e5e7eb;';
@@ -36370,6 +36392,11 @@ function renderLivekitTestView() {
             // disconnect/reconnect cycle.
             if (pre && pre.consumeAndRearm) pre.consumeAndRearm();
             room = new LivekitClient.Room({ adaptiveStream: true, dynacast: true });
+            // VTID-03029: mark this container as having a live session so
+            // subsequent renderApp() re-mounts (showToast, polls, etc.)
+            // return this DOM node instead of building a fresh one.
+            container._lktActive = true;
+            window._lktSurviveContainer = container;
 
             room.on(LivekitClient.RoomEvent.ConnectionStateChanged, function (s) {
                 log('event', 'ConnectionStateChanged', { state: s });
@@ -36392,6 +36419,10 @@ function renderLivekitTestView() {
                     attachedAudio.forEach(function (el) { try { el.remove(); } catch (_) {} });
                     attachedAudio = [];
                     room = null;
+                    // VTID-03029: session is gone; release the survival
+                    // cache so the next renderApp() rebuilds the view fresh.
+                    container._lktActive = false;
+                    if (window._lktSurviveContainer === container) window._lktSurviveContainer = null;
                 } else if (s === 'reconnecting' || s === 'signalReconnecting') {
                     setState(s);
                 }
@@ -36530,6 +36561,9 @@ function renderLivekitTestView() {
             }
             attachedAudio.forEach(function (el) { try { el.remove(); } catch (_) {} });
             attachedAudio = [];
+            // VTID-03029: connect truly failed; release the survival cache.
+            container._lktActive = false;
+            if (window._lktSurviveContainer === container) window._lktSurviveContainer = null;
         }
     }
 
@@ -36540,6 +36574,10 @@ function renderLivekitTestView() {
         }
         attachedAudio.forEach(function (el) { try { el.remove(); } catch (e) {} });
         attachedAudio = [];
+        // VTID-03029: user-initiated tear-down; release the survival cache
+        // so the next renderApp() rebuilds the view fresh.
+        container._lktActive = false;
+        if (window._lktSurviveContainer === container) window._lktSurviveContainer = null;
         stopAudioMeters(); // VTID-02996: tear down analysers + reset meter UI
         hideMicPermissionBanner();
         hideAudioGateBanner(); // VTID-02997: hide re-play button when session ends

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -30,7 +30,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260516-vtid-03019-vad-850"></script>
-  <script src="/command-hub/app.js?v=20260516-lkt-parallel-connect-guard"></script>
+  <script src="/command-hub/app.js?v=20260516-lkt-survive-renderapp"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
 </body>


### PR DESCRIPTION
## Summary

Follow-up to #2148 (VTID-03023). After that fix shipped, the user still saw the original symptoms:

- CONNECTION flipped to "disconnected" while the conversation was alive
- A second Connect click spawned a parallel WebRTC session

The previous fix addressed a layer that wasn't the root cause.

## Real root cause (one layer deeper)

`_renderAppCore()` at `app.js` line ~5234 does `root.innerHTML = ''` before re-mounting every view from its corresponding `render*View()` function. Anything that touches global state and re-renders mid-session — loudest culprit is `showToast()` at lines 5136 / 5141, but every background poll, role switch, and notification dispatch does it too — wipes the test-bench's DOM off-screen.

The original closures keep running: the `Room` stays alive, the mic stays published, the agent's audio elements keep playing. But:

- The listener's captured `stateEl` reference is now detached, so `setState('connected')` paints a node nobody sees.
- The freshly-rebuilt DOM has the initial `disconnected` HTML literal.
- `room` in the new closure is `null`, so my previous parallel-connect guard releases. Click Connect again → new `Room` → two overlapping sessions.

This pattern is explicitly documented in user memory ("CRITICAL: showToast() Button Pattern — `showToast()` calls `renderApp()` which does `root.innerHTML = ''` — ALL DOM refs become detached").

## Fix

While a LiveKit session is alive, cache the test-bench container on `window._lktSurviveContainer` and return the same DOM node on subsequent renders. The original closures + listener refs + audio elements stay intact; on-screen state matches the live session truthfully.

Five surgical insertions inside `renderLivekitTestView()`:

1. Top of function: `if (window._lktSurviveContainer && window._lktSurviveContainer._lktActive) return window._lktSurviveContainer;`
2. After `room = new ...Room(...)`: flag the container + cache globally
3. Listener `Disconnected` branch: clear flag + cache
4. Outer `connect()` catch (when truly failed): clear flag + cache
5. `disconnect()` function: clear flag + cache

Cache-bust bump: `lkt-parallel-connect-guard` → `lkt-survive-renderapp`.

Net diff: +38/-0 in `app.js`, +1/-1 in `index.html`.

## Test plan

- [ ] Hard-refresh `/command-hub/voice/livekit-test/` (cache-bust string changed)
- [ ] Click Connect once → CONNECTION green `connected`, stays green during conversation
- [ ] Make the agent talk (greeting / a reply) — any showToast that fires server-side or upon role/notification changes should NOT flip CONNECTION back to disconnected
- [ ] Connect button stays disabled the entire time
- [ ] Click Disconnect → CONNECTION neutral, Connect re-enabled, no leftover audio
- [ ] Repeat Connect → fresh session, no overlap
- [ ] In DevTools console: `window._lktSurviveContainer` should be truthy mid-session, null after disconnect

🤖 Generated with [Claude Code](https://claude.com/claude-code)
