### PR TITLE
fix(smoke): use direct Cloud Run URL in SMOKE-LIVEKIT-TESTS workflow (VTID-03025)

### DIFF
--- a/.github/workflows/SMOKE-LIVEKIT-TESTS.yml
+++ b/.github/workflows/SMOKE-LIVEKIT-TESTS.yml
@@ -29,7 +29,12 @@ jobs:
       - name: Run /api/v1/voice-lab/tests/run + dump full per-case results
         env:
           SERVICE_TOKEN: ${{ secrets.GATEWAY_SERVICE_TOKEN }}
-          GATEWAY_URL: https://gateway.vitanaland.com
+          # Direct Cloud Run URL (bypasses Cloudflare). Same URL resolves
+          # from `gcloud run services describe gateway`. The public domain
+          # gateway.vitanaland.com sometimes wraps the token in a way that
+          # the bearer-comparison gate rejects — direct URL is the safe path
+          # for service-to-service calls.
+          GATEWAY_URL: https://gateway-86804897789.us-central1.run.app
           CASE_KEY: ${{ inputs.case_key }}
           TRIGGER: ${{ inputs.trigger }}
         run: |


### PR DESCRIPTION
First smoke dispatch returned 401 because `gateway.vitanaland.com` (Cloudflare) interferes with bearer-token compare. Switch to direct Cloud Run URL.

Workflow-only change; no gateway redeploy.

🤖 Generated with [Claude Code](https://claude.com/claude-code)