### PR TITLE
feat(voice-lab): accept GCP SA id_token in /tests/* gate + WIF smoke (VTID-03025)

### DIFF
--- a/.github/workflows/SMOKE-LIVEKIT-TESTS.yml
+++ b/.github/workflows/SMOKE-LIVEKIT-TESTS.yml
@@ -45,7 +45,7 @@ jobs:
       - name: Set up gcloud CLI
         uses: google-github-actions/setup-gcloud@v2
 
-      - name: Fetch GATEWAY_SERVICE_TOKEN from Secret Manager + run smoke
+      - name: Mint a Google id_token for the gateway audience + run smoke
         env:
           PROJECT: lovable-vitana-vers1
           GATEWAY_URL: https://gateway-86804897789.us-central1.run.app
@@ -54,12 +54,13 @@ jobs:
         run: |
           set -euo pipefail
 
-          # Source of truth: Secret Manager. Same secret the gateway mounts
-          # as env GATEWAY_SERVICE_TOKEN at boot.
-          SERVICE_TOKEN=$(gcloud secrets versions access latest \
-            --secret=GATEWAY_SERVICE_TOKEN --project="$PROJECT")
+          # The gateway accepts EITHER an app-level service token OR a fresh
+          # Google id_token from any *.iam.gserviceaccount.com SA whose audience
+          # matches its own URL. We use the latter so the smoke is robust to
+          # the GH-Actions secret being out of sync with Secret Manager.
+          SERVICE_TOKEN=$(gcloud auth print-identity-token --audiences="$GATEWAY_URL")
           if [ -z "$SERVICE_TOKEN" ]; then
-            echo "::error::Failed to fetch GATEWAY_SERVICE_TOKEN from Secret Manager"
+            echo "::error::Failed to mint Google id_token (gcloud auth print-identity-token returned empty)"
             exit 1
           fi
 

--- a/services/gateway/src/routes/voice-lab.ts
+++ b/services/gateway/src/routes/voice-lab.ts
@@ -103,6 +103,8 @@ function livekitTestsAuthGate(
     return;
   }
 
+  // Path 1: app-level service-token compare — cheapest path, used by Cloud
+  // Shell + by future hourly cron when the GH-Actions secret is in sync.
   const serviceToken = process.env.GATEWAY_SERVICE_TOKEN ?? '';
   if (serviceToken.length > 0 && token === serviceToken) {
     (req as AuthenticatedRequest).identity = undefined;
@@ -112,21 +114,53 @@ function livekitTestsAuthGate(
     return;
   }
 
-  // JWT path → must be exafy_admin.
-  optionalAuth(req as AuthenticatedRequest, res, () => {
-    const id = (req as AuthenticatedRequest).identity;
-    if (id && id.exafy_admin === true) {
-      (req as Request & { __livekit_tests_actor?: string }).__livekit_tests_actor =
-        `admin:${id.user_id ?? 'unknown'}`;
-      next();
-      return;
+  // Path 2: Google id_token from a GCP service account (Workload Identity
+  // Federation, Cloud Scheduler with OIDC, etc.). Robust to the GH-secret /
+  // Secret-Manager value drifting out of sync because the caller mints a
+  // fresh id_token each call. Audience must match this gateway's URL.
+  // Email is required to end in .iam.gserviceaccount.com so user OAuth
+  // tokens can never satisfy this path.
+  void (async (): Promise<void> => {
+    try {
+      const { OAuth2Client } = await import('google-auth-library');
+      const audience =
+        process.env.LIVEKIT_TESTS_GCP_AUDIENCE ??
+        process.env.GATEWAY_SELF_URL ??
+        'https://gateway-86804897789.us-central1.run.app';
+      const client = new OAuth2Client();
+      const ticket = await client.verifyIdToken({ idToken: token, audience });
+      const payload = ticket.getPayload();
+      if (
+        payload?.email &&
+        payload.email_verified === true &&
+        /\.iam\.gserviceaccount\.com$/i.test(payload.email)
+      ) {
+        (req as AuthenticatedRequest).identity = undefined;
+        (req as Request & { __livekit_tests_actor?: string }).__livekit_tests_actor =
+          `gcp_sa:${payload.email}`;
+        next();
+        return;
+      }
+    } catch {
+      // Not a valid Google id_token / audience mismatch — fall through to JWT.
     }
-    res.status(401).json({
-      ok: false,
-      error: 'unauthorized — service token or exafy_admin JWT required',
-      vtid: LIVEKIT_TESTS_VTID,
+
+    // Path 3: exafy_admin Supabase JWT (Command Hub operators).
+    optionalAuth(req as AuthenticatedRequest, res, () => {
+      const id = (req as AuthenticatedRequest).identity;
+      if (id && id.exafy_admin === true) {
+        (req as Request & { __livekit_tests_actor?: string }).__livekit_tests_actor =
+          `admin:${id.user_id ?? 'unknown'}`;
+        next();
+        return;
+      }
+      res.status(401).json({
+        ok: false,
+        error: 'unauthorized — service token, GCP SA id_token, or exafy_admin JWT required',
+        vtid: LIVEKIT_TESTS_VTID,
+      });
     });
-  });
+  })();
 }
 
 const RunPostSchema = z.object({


### PR DESCRIPTION
Resolves the smoke-can't-auth gap end-to-end.

**Gateway change** (`voice-lab.ts livekitTestsAuthGate`): add third authn path — Google id_token from any `*.iam.gserviceaccount.com` with audience matching the gateway URL. Verified via `google-auth-library`. Email + email_verified required. Existing service-token + exafy-admin-JWT paths intact.

**Workflow change**: mint a fresh id_token via `gcloud auth print-identity-token --audiences=$GATEWAY_URL` instead of trying to read Secret Manager (WIF SA lacks permission). Self-healing forever — token is fresh each call.

## Test plan
- [x] npm run build clean
- [x] 30/30 (scorer 28 + voice-lab auth 2) green
- [ ] After merge + deploy: `gh workflow run SMOKE-LIVEKIT-TESTS.yml` → non-401 + actual run results

🤖 Generated with [Claude Code](https://claude.com/claude-code)