### PR TITLE
fix(feedback): bump LLM draft cap from 1500 → 8000 tokens (VTID-03034)

### DIFF
--- a/services/gateway/src/services/feedback-llm-resolvers.ts
+++ b/services/gateway/src/services/feedback-llm-resolvers.ts
@@ -26,7 +26,12 @@ import type { LLMStage } from '../constants/llm-defaults';
 
 const STAGE: LLMStage = 'triage';
 const SERVICE_TAG = 'feedback-llm-resolvers';
-const MAX_TOKENS = 1500;
+// VTID-03034: Gemini 2.5 Pro (current triage primary) burns 1-3k tokens on
+// chain-of-thought before emitting visible output, so a 1500 cap truncates
+// the spec mid-sentence — the very first call against
+// FB-2026-05-000083 stored a 328-char draft ending at "Alternatively, `services".
+// Give the model headroom for thinking + a full one-page spec.
+const MAX_TOKENS = 8000;
 
 interface FeedbackTicketSnapshot {
   id: string;


### PR DESCRIPTION
## Summary

End-to-end testing the "Generate spec → Activate" flow against ticket **FB-2026-05-000083** (first live run after the admin Feedback drawer was unblocked in `vitana-v1#467`) exposed a draft truncation: Devon's spec stored exactly 328 chars ending mid-word at ``"… Alternatively, `services"``. The drawer advanced to `spec_ready` with a malformed spec the autopilot couldn't act on.

**Root cause**: `MAX_TOKENS = 1500` in `feedback-llm-resolvers.ts`. The `triage` stage routes to Gemini 2.5 Pro (`constants/llm-defaults.ts:109-113`), whose reasoning mode burns 1-3k tokens of chain-of-thought before emitting visible output. With a 1500 cap, the model spent nearly the whole budget thinking and produced ~80 tokens of spec — far short of the one-page structured format the DEVON / SAGE / ATLAS / MIRA system prompts require.

**Fix**: bump the cap to 8000, matching the default the router adapters fall back to when no explicit cap is passed (`llm-router.ts:207, 287, 386, 466, 541, 628`).

No prompt / provider / fallback / parsing changes. Just the budget.

## Test plan

- [ ] Build is green
- [ ] After deploy, re-call `POST /api/v1/admin/tenants/:tenantId/tickets/FB-2026-05-000083/draft-spec` and verify the returned `markdown` is the full multi-section spec
- [ ] Subsequent `POST /…/activate` accepts the spec and dispatches to the dev autopilot

🤖 Generated with [Claude Code](https://claude.com/claude-code)