### PR TITLE
feat(orb): LiveKit context-parity — call buildBootstrapContextPack so bootstrap_context carries the same history-aware layers Vertex does (VTID-03036)

### DIFF
--- a/services/gateway/src/routes/orb-livekit.ts
+++ b/services/gateway/src/routes/orb-livekit.ts
@@ -43,7 +43,13 @@ import { getSupabase } from '../lib/supabase';
 // country, timezone, localTime, UTC, device) that Vertex's authenticated
 // system prompt has. Without this, LiveKit's LLM has no location/time
 // awareness and answers "where am I?" / "what time is it?" with garbage.
+// VTID-03036: reuse Vertex's buildBootstrapContextPack so the LiveKit
+// prompt carries the SAME memoryContext.formatted_context + last-3 user
+// turns + USER CONTEXT PROFILE (activity/routines/tenure) block Vertex
+// injects via session.contextInstruction. Closes parity gaps like
+// "how long have I been a member" + "what did I ask last?".
 import {
+  buildBootstrapContextPack,
   buildClientContext,
   formatClientContextForInstruction,
 } from './orb-live';
@@ -834,6 +840,10 @@ router.get(
     ];
 
     let envContext: import('./orb-live').ClientContext | null = null;
+    // VTID-03036: result of buildBootstrapContextPack (memory preamble +
+    // last-3 user turns + USER CONTEXT PROFILE). Held outside the batch
+    // closure so the post-batch ctxParts push can read it.
+    let historyContextPack: Awaited<ReturnType<typeof buildBootstrapContextPack>> | null = null;
 
     if (sb && userId) {
       const [
@@ -843,6 +853,7 @@ router.get(
         indexData,
         lifeCompassData,
         envContextResolved,
+        historyContextPackResolved,
       ] = await Promise.all([
         // memory_items top-5
         (async () => {
@@ -936,6 +947,24 @@ router.get(
             return null as import('./orb-live').ClientContext | null;
           }
         })(),
+        // VTID-03036: history-aware context pack (memory preamble + last-3
+        // user turns + USER CONTEXT PROFILE). Reuses Vertex's exported
+        // buildBootstrapContextPack so both pipelines compose the same
+        // contextInstruction layer. Best-effort; any throw is swallowed
+        // and the LiveKit bootstrap falls back to the prior (thinner)
+        // identity-only context.
+        (async () => {
+          try {
+            if (!req.identity) return null;
+            const sessionId = `livekit-bootstrap-${agentId}-${userId.slice(0, 8)}`;
+            return await buildBootstrapContextPack(req.identity, sessionId);
+          } catch (exc) {
+            console.warn(
+              `[${VTID}] buildBootstrapContextPack failed: ${(exc as Error).message}`,
+            );
+            return null;
+          }
+        })(),
       ]);
 
       // Memory items → flat objects (filter empty content).
@@ -994,6 +1023,9 @@ router.get(
 
       // envContext — already resolved above, just save into closure scope
       envContext = envContextResolved;
+      // VTID-03036: history-aware context pack — saved for the post-
+      // batch ctxParts push below.
+      historyContextPack = historyContextPackResolved;
     } else {
       // Anonymous/no-userId path: still run buildClientContext (no DB queries
       // needed since they're all user-scoped).
@@ -1095,6 +1127,27 @@ router.get(
           .map((m) => `- ${m.text.slice(0, 300)}`)
           .join('\n')}`,
       );
+    }
+
+    // VTID-03036: history-aware context block — the same contextInstruction
+    // Vertex builds via session.contextInstruction (memoryContext.formatted_context
+    // + last-3 user turns + USER CONTEXT PROFILE). Closes parity gaps that the
+    // identity-only bootstrap left open:
+    //   - "how long am I a member of Maxina?" / tenure questions
+    //     → USER CONTEXT PROFILE block carries onboarding/activity-tenure data
+    //   - "what did I ask you last?" / "what were we talking about?"
+    //     → recent-turns block carries the last 3 raw user utterances
+    //   - implicit fact recall ("you said I do walks in the mornings")
+    //     → memoryContext.formatted_context fact preamble
+    // Best-effort: when historyContextPack is null (anonymous, fetch failed)
+    // or its contextInstruction is empty/missing, push nothing — never block
+    // the bootstrap response.
+    if (
+      historyContextPack &&
+      typeof historyContextPack.contextInstruction === 'string' &&
+      historyContextPack.contextInstruction.trim().length > 0
+    ) {
+      ctxParts.push(historyContextPack.contextInstruction);
     }
 
     // Extract first name from display_name OR memory_facts.user_name fact.
@@ -1326,6 +1379,22 @@ router.get(
       // inlined into `bootstrap_context`; this field is for tooling.
       // null on anonymous sessions or when compile failed.
       decision_context: decisionContext,
+      // VTID-03036: structured meta on the history-aware context pack.
+      // The rendered contextInstruction is already inlined into
+      // `bootstrap_context`; this object is for cockpit/operator
+      // inspection (latency timing + skipped-reason for degraded
+      // sources). null on anonymous sessions or when the call failed.
+      context_pack: historyContextPack
+        ? {
+            ok: typeof historyContextPack.contextInstruction === 'string'
+              && historyContextPack.contextInstruction.trim().length > 0,
+            latency_ms: historyContextPack.latencyMs,
+            skipped_reason: historyContextPack.skippedReason ?? null,
+            chars: typeof historyContextPack.contextInstruction === 'string'
+              ? historyContextPack.contextInstruction.length
+              : 0,
+          }
+        : null,
     };
 
     // VTID-03035: populate cache for the next 60s. Only authenticated full

--- a/services/gateway/test/orb/routes/livekit-context-parity.test.ts
+++ b/services/gateway/test/orb/routes/livekit-context-parity.test.ts
@@ -1,0 +1,87 @@
+/**
+ * VTID-03036 — LiveKit context parity static-wire-up test.
+ *
+ * Locks the source-text wire-up that makes the LiveKit
+ * /api/v1/orb/context-bootstrap call Vertex's shared
+ * `buildBootstrapContextPack` and inline its `contextInstruction`
+ * (memoryContext.formatted_context + last-3 user turns + USER CONTEXT
+ * PROFILE) into the bootstrap response.
+ *
+ * The Live path was previously identity-only, which is why the agent
+ * could not answer "how long have I been a member?" or "what did I ask
+ * last?" — Vertex injects those facts through the shared bootstrap pack
+ * but the LiveKit route did not consume it.
+ *
+ * The wire-up is verified at source level (rather than via a full HTTP
+ * integration test) for the same reason the surrounding suite locks
+ * other route invariants this way: integration setup for `optionalAuth`
+ * + Supabase + the L2.2b.4 dynamic-import spine is heavy, while the
+ * wire-up itself is the load-bearing contract.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ORB_LIVEKIT_PATH = path.resolve(
+  __dirname,
+  '../../../src/routes/orb-livekit.ts',
+);
+
+let source: string;
+
+beforeAll(() => {
+  source = fs.readFileSync(ORB_LIVEKIT_PATH, 'utf8');
+});
+
+describe('VTID-03036 LiveKit context parity wire-up', () => {
+  it('imports buildBootstrapContextPack from ./orb-live', () => {
+    // The import lives alongside buildClientContext +
+    // formatClientContextForInstruction so all three Vertex helpers
+    // are loaded from a single statement. If a future refactor moves
+    // it, the corresponding usage assertion below will fail too.
+    expect(source).toMatch(/import\s*{[^}]*\bbuildBootstrapContextPack\b[^}]*}\s*from\s*['"]\.\/orb-live['"]/);
+  });
+
+  it('invokes buildBootstrapContextPack inside the parallel batch', () => {
+    // The pack call sits inside the existing Promise.all alongside the
+    // 6 user-scoped queries. Running it in parallel is required so the
+    // history-aware fetch does not regress bootstrap latency.
+    expect(source).toMatch(/await\s+buildBootstrapContextPack\(\s*req\.identity\s*,\s*sessionId\s*\)/);
+  });
+
+  it('passes a LiveKit-scoped synthetic sessionId to the pack', () => {
+    // The sessionId is only used for log correlation by the pack itself
+    // but the literal prefix lets ops greps tell apart Live and
+    // Live-via-LiveKit bootstrap log lines.
+    expect(source).toMatch(/livekit-bootstrap-\$\{agentId\}-/);
+  });
+
+  it('pushes the resolved contextInstruction into ctxParts when non-empty', () => {
+    // The push is guarded so anonymous / missing-identity / fetch-failed
+    // results never inject an empty string into the prompt.
+    expect(source).toMatch(/historyContextPack\.contextInstruction[\s\S]{0,200}ctxParts\.push\(historyContextPack\.contextInstruction\)/);
+  });
+
+  it('skips the push when contextInstruction is empty or missing', () => {
+    // The guard MUST check non-empty content; an empty string would
+    // still pass `typeof === 'string'` and pollute the prompt with
+    // bare newlines.
+    expect(source).toMatch(/historyContextPack\.contextInstruction\.trim\(\)\.length\s*>\s*0/);
+  });
+
+  it('surfaces a structured context_pack field on the response', () => {
+    // Operator/cockpit inspection — mirrors how decision_context is
+    // exposed for the spine. The renderer flows through bootstrap_context;
+    // this field carries timing + skipped reason for triage.
+    expect(source).toMatch(/context_pack:\s*historyContextPack/);
+    expect(source).toMatch(/latency_ms:\s*historyContextPack\.latencyMs/);
+    expect(source).toMatch(/skipped_reason:\s*historyContextPack\.skippedReason/);
+  });
+
+  it('handles failure best-effort with a [VTID-LIVEKIT-FOUNDATION] warn', () => {
+    // The promise body must swallow throws so a pack failure never
+    // blocks the bootstrap response. The Vertex production path is
+    // unaffected by anything inside this best-effort closure.
+    expect(source).toMatch(/buildBootstrapContextPack failed:/);
+  });
+});


### PR DESCRIPTION
## Summary

- LiveKit `/api/v1/orb/context-bootstrap` now calls Vertex's exported `buildBootstrapContextPack(identity, sessionId)` and inlines its `contextInstruction` (memory preamble + last-3 user turns + USER CONTEXT PROFILE) into `bootstrap_context`.
- Closes the parity gap that made LiveKit answer "how long have I been a member?" / "what did I ask last?" worse than Vertex: the same fact layers Vertex injects through `session.contextInstruction` are now in the LiveKit prompt by construction, not by hand-rolled patch.
- Additive only: +69 lines in `orb-livekit.ts`, +87 lines new test, zero `orb-live.ts` diff, zero spine diff, zero `buildLiveSystemInstruction` diff.

## Why this change (architecture, not whack-a-mole)

The user-reported symptom was "LiveKit doesn't know how long I've been a member of the Maxina community." The tempting fix is a one-line `Member since: X days` patch inside the LiveKit route. We rejected that because future missing signals would just trigger another patch — same pattern that produced the divergence in the first place.

Root cause: `services/gateway/src/routes/orb-live.ts:1877` exports `buildBootstrapContextPack` (already reused by the Vertex session lifecycle, voice-lab evaluator, and admin-scanner briefing). It returns the rich `contextInstruction` = `memoryContext.formatted_context` + `recentTurnsBlock` + USER CONTEXT PROFILE block. The LiveKit route built its own `ctxParts` but never called this function — its `bootstrap_context` carried identity facts + Vitana Index + spine + Life Compass + env only.

This PR calls the same exported function from the LiveKit route. Both pipelines now read a single source of truth for the history-aware context layer. Future enrichments to the pack benefit both paths automatically.

## Change

`services/gateway/src/routes/orb-livekit.ts` (+69, additive):

1. Import `buildBootstrapContextPack` alongside the existing `buildClientContext` / `formatClientContextForInstruction` imports.
2. Add a 7th branch to the bootstrap's parallel `Promise.all` batch (the VTID-03030 perf path) — runs in parallel with the existing 6 user-scoped queries, no measurable latency regression.
3. Push `historyContextPack.contextInstruction` onto `ctxParts` only when non-empty (guarded by `typeof === 'string' && .trim().length > 0` so empty-string never pollutes the prompt).
4. Surface structured `context_pack: { ok, latency_ms, skipped_reason, chars }` on the JSON response for cockpit/operator inspection — mirrors how `decision_context` is surfaced.
5. Best-effort: throws caught and logged as `[VTID-LIVEKIT-FOUNDATION] buildBootstrapContextPack failed: <msg>` — Vertex production users unaffected.

## What this PR does NOT do

- No tenure-only / "Member since X days" prompt line inside the LiveKit route. Tenure knowledge enters the prompt because the SAME pack Vertex uses carries it through the profile block.
- No change to the L2.2b.4 decision-contract spine — it remains enum-only by contract; raw timestamps are NOT smuggled into the spine.
- No change to L2.2b.6 `buildLiveSystemInstruction` — same arguments, same rendered prompt.
- No `voice.livekit_agent_enabled` flip. Canary gate independent.
- No agent-side change (`session.py` / `bootstrap.py` / `instructions.py` untouched).

## Acceptance

1. Vertex production path: untouched (no diff in `orb-live.ts`).
2. `/orb/chat` smoke: unchanged.
3. Authenticated `/api/v1/orb/context-bootstrap`:
   - `bootstrap_context` carries the `## USER CONTEXT PROFILE (recent activity, routines, preferences)` header plus recent-turn lines plus `memoryContext.formatted_context`.
   - `context_pack.ok = true`, `latency_ms` reasonable, `skipped_reason: null`, `chars > 0`.
   - `decision_context` still rendered by the spine (no regression).
4. Anonymous `/api/v1/orb/context-bootstrap`: `context_pack: null`, prior behavior preserved.
5. `?greeting_only=true` fast path: unchanged — slow context fetch still skipped.

## Tests

- `npm run build` green (the stricter bar than `tsc --noEmit`).
- 713 / 713 orb tests passing (40 suites) — includes 7 new static wire-up assertions in `test/orb/routes/livekit-context-parity.test.ts` that lock: import statement, parallel-batch call, sessionId shape, non-empty-guard push, structured response field, best-effort warn.

## Test plan

- [ ] CI green on this PR.
- [ ] EXEC-DEPLOY succeeds + post-deploy production smoke: `curl GET /api/v1/orb/context-bootstrap` as `e2e-test@vitana.dev` → response includes `context_pack.ok=true` AND `bootstrap_context` contains `USER CONTEXT PROFILE`.
- [ ] Manual LiveKit Test Bench: voice question "how long have I been a member?" — agent answers grounded in profile data (no hallucination).
- [ ] No regression on "who am I?" / Vitana Index / Life Compass questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
