### PR TITLE
feat(voice-lab): full LiveKit test parity + coverage endpoint (VTID-03025)

### DIFF
--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -3896,6 +3896,7 @@ const state = {
         recentRuns: [],
         latestRun: null,           // { run, results: [...] }
         cases: [],
+        coverage: null,            // CoverageReport from /tests/coverage
         loading: false,
         triggering: false,
         error: null,
@@ -35113,17 +35114,20 @@ function renderLivekitHourlyTestsPanel() {
         'Layer-A dry-run via gateway tool-routing · VTID-03025</span>';
     section.appendChild(titleRow);
 
-    // Lazy-fetch latest run + cases on first render.
+    // Lazy-fetch latest run + cases + coverage on first render.
     if (!state.livekitTests.fetched && !state.livekitTests.loading) {
         state.livekitTests.loading = true;
         Promise.all([
             fetch('/api/v1/voice-lab/tests/runs?limit=10', { headers: buildContextHeaders() }).then(function (r) { return r.json(); }),
             fetch('/api/v1/voice-lab/tests/cases', { headers: buildContextHeaders() }).then(function (r) { return r.json(); }),
+            fetch('/api/v1/voice-lab/tests/coverage', { headers: buildContextHeaders() }).then(function (r) { return r.json(); }),
         ]).then(function (results) {
             var runsResp = results[0];
             var casesResp = results[1];
+            var covResp = results[2];
             state.livekitTests.recentRuns = (runsResp && runsResp.runs) || [];
             state.livekitTests.cases = (casesResp && casesResp.cases) || [];
+            state.livekitTests.coverage = (covResp && covResp.ok) ? covResp.coverage : null;
             state.livekitTests.loading = false;
             state.livekitTests.fetched = true;
             // Chain-load the latest run's detail.
@@ -35170,6 +35174,57 @@ function renderLivekitHourlyTestsPanel() {
     var recent = state.livekitTests.recentRuns || [];
     var latest = state.livekitTests.latestRun;
     var cases = state.livekitTests.cases || [];
+    var coverage = state.livekitTests.coverage;
+
+    // Parity coverage banner. Renders ONLY when the coverage endpoint
+    // returned a report — drops silently on first deploys before the
+    // tool-manifest read is wired into the prod image.
+    if (coverage) {
+        var covBanner = document.createElement('div');
+        var pct = coverage.coverage_pct || 0;
+        var bannerColor = pct >= 100 ? 'var(--color-bg-secondary)' :
+                          pct >= 80 ? '#3b2f0f' :
+                          '#3b1f1f';
+        var bannerTextColor = pct >= 100 ? 'var(--color-text-secondary)' :
+                              pct >= 80 ? '#fbbf24' :
+                              '#f87171';
+        covBanner.style.cssText = 'display:flex;align-items:center;gap:0.75rem;flex-wrap:wrap;margin-bottom:0.85rem;padding:0.5rem 0.75rem;background:' + bannerColor +
+            ';border:1px solid var(--color-border);border-radius:6px;font-size:0.8rem;color:' + bannerTextColor + ';';
+
+        var covSummary = document.createElement('span');
+        covSummary.style.fontWeight = '600';
+        covSummary.textContent = 'Parity: ' + coverage.tested_total + ' / ' + coverage.live_total + ' live tools tested (' + pct + '%)';
+        covBanner.appendChild(covSummary);
+
+        if (coverage.manifest_generated_at) {
+            var manifestStamp = document.createElement('span');
+            manifestStamp.style.cssText = 'font-size:0.7rem;color:var(--color-text-secondary);';
+            manifestStamp.textContent = '· manifest ' + coverage.manifest_generated_at;
+            covBanner.appendChild(manifestStamp);
+        }
+
+        if (coverage.uncovered_total > 0) {
+            var missingDetails = document.createElement('details');
+            missingDetails.style.cssText = 'margin-left:auto;font-size:0.75rem;';
+            var summary = document.createElement('summary');
+            summary.style.cssText = 'cursor:pointer;color:' + bannerTextColor + ';';
+            summary.textContent = coverage.uncovered_total + ' missing';
+            missingDetails.appendChild(summary);
+
+            var missingList = document.createElement('div');
+            missingList.style.cssText = 'margin-top:0.5rem;padding:0.5rem;background:var(--color-bg-primary);border:1px solid var(--color-border);border-radius:4px;max-height:180px;overflow-y:auto;font-family:var(--font-mono);font-size:0.7rem;color:var(--color-text-secondary);min-width:280px;';
+            (coverage.uncovered || []).forEach(function (u) {
+                var row = document.createElement('div');
+                row.style.padding = '1px 0';
+                row.textContent = u.name + (u.surface ? '  (' + u.surface + ')' : '');
+                missingList.appendChild(row);
+            });
+            missingDetails.appendChild(missingList);
+            covBanner.appendChild(missingDetails);
+        }
+
+        card.appendChild(covBanner);
+    }
 
     if (recent.length === 0) {
         var noRuns = document.createElement('div');

--- a/services/gateway/src/frontend/command-hub/index.html
+++ b/services/gateway/src/frontend/command-hub/index.html
@@ -30,7 +30,7 @@
   <div id="intel-toggle-container"></div>
   <div id="intel-panel-container"></div>
   <script src="/command-hub/orb-widget.js?v=20260516-vtid-03019-vad-850"></script>
-  <script src="/command-hub/app.js?v=20260517-vtid-03025-livekit-tests-panel"></script>
+  <script src="/command-hub/app.js?v=20260517-vtid-03025-livekit-tests-full-coverage"></script>
   <!-- VTID-01216: Intelligence Panels (Context Pack, Retrieval Trace, Tool Calls) -->
   <script src="/command-hub/intelligence-panels.js?v=20260420-intel-showtoast-recursion-fix"></script>
 </body>

--- a/services/gateway/src/routes/voice-lab.ts
+++ b/services/gateway/src/routes/voice-lab.ts
@@ -40,6 +40,7 @@ import {
 import {
   evaluateLiveKitDryRun,
 } from '../services/voice-lab/livekit-test-eval';
+import { getCoverage as getLivekitTestCoverage } from '../services/voice-lab/livekit-test-coverage';
 
 const router = Router();
 
@@ -288,6 +289,26 @@ router.get(
     try {
       const cases = await listLivekitTestCases();
       return res.status(200).json({ ok: true, vtid: LIVEKIT_TESTS_VTID, cases });
+    } catch (err) {
+      return res.status(500).json({
+        ok: false,
+        error: (err as Error).message ?? String(err),
+        vtid: LIVEKIT_TESTS_VTID,
+      });
+    }
+  },
+);
+
+// Parity coverage: which live tools in `tool-manifest.json` are NOT yet
+// covered by an enabled test case. Drives the "X / N tools tested" header
+// + "Missing" list in the UI panel. Used by Slice 1c parity guard.
+router.get(
+  '/tests/coverage',
+  livekitTestsAuthGate,
+  async (_req: Request, res: Response) => {
+    try {
+      const coverage = await getLivekitTestCoverage();
+      return res.status(200).json({ ok: true, vtid: LIVEKIT_TESTS_VTID, coverage });
     } catch (err) {
       return res.status(500).json({
         ok: false,

--- a/services/gateway/src/services/voice-lab/livekit-test-coverage.ts
+++ b/services/gateway/src/services/voice-lab/livekit-test-coverage.ts
@@ -1,0 +1,154 @@
+/**
+ * VTID-03025: parity coverage between `tool-manifest.json` (live tools)
+ * and `livekit_test_cases` (tests covering those tools).
+ *
+ * The hourly suite must keep parity with the live catalog — as new tools
+ * land (50 → 70 → 147 over the next couple of weeks), this endpoint
+ * exposes the gap so the Voice LAB panel can flag uncovered tools.
+ *
+ * "Tested" means the tool name appears in EITHER `expected.tools[]` OR
+ * `expected.tools_any[]` on an enabled case row. Cases scoped to
+ * `intent: 'free_text'` cover NO tool by definition and are excluded.
+ */
+
+import fs from 'fs';
+import path from 'path';
+
+import { getSupabase } from '../../lib/supabase';
+
+export interface ToolManifestEntry {
+  name: string;
+  surface?: string;
+  category?: string;
+  status?: 'live' | 'wip' | 'planned' | string;
+  description?: string;
+  wired_in?: string[];
+  role?: string[];
+  owner_vtid?: string | null;
+}
+
+interface ToolManifestFile {
+  generated_at?: string;
+  total?: number;
+  tools: ToolManifestEntry[];
+}
+
+export interface CoverageReport {
+  manifest_generated_at: string | null;
+  manifest_total: number;
+  live_total: number;
+  tested_total: number;
+  uncovered_total: number;
+  coverage_pct: number;
+  surfaces: Array<{ surface: string; live: number; tested: number }>;
+  uncovered: Array<{ name: string; surface: string; wired_in: string[] }>;
+  // Tests whose tool names aren't in the manifest live set — informative
+  // (e.g. `get_life_compass` exists in the catalog but not in this manifest).
+  orphan_tested: string[];
+}
+
+let cached: { manifest: ToolManifestFile; loadedAt: number } | null = null;
+const MANIFEST_TTL_MS = 60_000;
+
+/**
+ * Read `tool-manifest.json` from disk with a 60s cache. The file lives at
+ * `services/gateway/src/services/tool-manifest.json` and is copied to
+ * `dist/services/tool-manifest.json` by the build's `copy-data` step.
+ */
+export function loadToolManifest(): ToolManifestFile {
+  if (cached && Date.now() - cached.loadedAt < MANIFEST_TTL_MS) {
+    return cached.manifest;
+  }
+  // __dirname at runtime is .../dist/services/voice-lab/ — go up one to
+  // reach .../dist/services/tool-manifest.json. In dev (tsx) __dirname
+  // points at src/, where the file sits one level up too.
+  const candidates = [
+    path.resolve(__dirname, '..', 'tool-manifest.json'),
+    path.resolve(__dirname, '..', '..', 'services', 'tool-manifest.json'),
+  ];
+  for (const p of candidates) {
+    try {
+      if (fs.existsSync(p)) {
+        const raw = fs.readFileSync(p, 'utf-8');
+        const parsed = JSON.parse(raw) as ToolManifestFile;
+        cached = { manifest: parsed, loadedAt: Date.now() };
+        return parsed;
+      }
+    } catch {
+      // try the next candidate
+    }
+  }
+  // Fail open with empty manifest so the endpoint can still respond.
+  return { tools: [] };
+}
+
+/**
+ * Compute parity coverage by joining the manifest live-tool set with the
+ * union of `expected.tools[]` + `expected.tools_any[]` across all enabled
+ * test cases.
+ */
+export async function getCoverage(): Promise<CoverageReport> {
+  const sb = getSupabase();
+  if (!sb) throw new Error('getCoverage: Supabase client not configured');
+
+  const manifest = loadToolManifest();
+  const liveTools = manifest.tools.filter((t) => t.status === 'live');
+
+  const { data: rows, error } = await sb
+    .from('livekit_test_cases')
+    .select('expected, enabled')
+    .eq('enabled', true);
+  if (error) throw new Error(`getCoverage: ${error.message}`);
+
+  const tested = new Set<string>();
+  for (const row of rows ?? []) {
+    const exp = (row as { expected?: unknown }).expected as Record<string, unknown> | null;
+    if (!exp || typeof exp !== 'object') continue;
+    const tools = exp.tools;
+    const toolsAny = (exp as Record<string, unknown>).tools_any;
+    if (Array.isArray(tools)) for (const t of tools) if (typeof t === 'string') tested.add(t);
+    if (Array.isArray(toolsAny)) for (const t of toolsAny) if (typeof t === 'string') tested.add(t);
+  }
+
+  const liveNames = new Set(liveTools.map((t) => t.name));
+
+  const uncovered = liveTools
+    .filter((t) => !tested.has(t.name))
+    .map((t) => ({
+      name: t.name,
+      surface: t.surface ?? '',
+      wired_in: t.wired_in ?? [],
+    }));
+
+  const orphanTested = Array.from(tested).filter((t) => !liveNames.has(t));
+
+  // Per-surface aggregation.
+  const surfaceCounts = new Map<string, { live: number; tested: number }>();
+  for (const t of liveTools) {
+    const s = t.surface ?? '(none)';
+    const entry = surfaceCounts.get(s) ?? { live: 0, tested: 0 };
+    entry.live += 1;
+    if (tested.has(t.name)) entry.tested += 1;
+    surfaceCounts.set(s, entry);
+  }
+  const surfaces = Array.from(surfaceCounts.entries())
+    .map(([surface, counts]) => ({ surface, ...counts }))
+    .sort((a, b) => b.live - a.live);
+
+  const testedLiveCount = liveTools.filter((t) => tested.has(t.name)).length;
+  const coveragePct = liveTools.length === 0
+    ? 0
+    : Math.round((testedLiveCount / liveTools.length) * 100);
+
+  return {
+    manifest_generated_at: manifest.generated_at ?? null,
+    manifest_total: manifest.tools.length,
+    live_total: liveTools.length,
+    tested_total: testedLiveCount,
+    uncovered_total: uncovered.length,
+    coverage_pct: coveragePct,
+    surfaces,
+    uncovered,
+    orphan_tested: orphanTested,
+  };
+}

--- a/supabase/migrations/20260524010000_VTID_03025_livekit_tests_full_coverage.sql
+++ b/supabase/migrations/20260524010000_VTID_03025_livekit_tests_full_coverage.sql
@@ -1,0 +1,254 @@
+-- VTID-03025: expand the LiveKit hourly test grid to cover ALL currently-live
+-- tools in `tool-manifest.json` (50 live as of 2026-05-17).
+--
+-- The original 13-case seed (migration 20260522000001) covered 18 distinct
+-- live tools. This migration adds 32 new cases — one per remaining live
+-- tool — so the suite has parity with the catalog. Future tools (147 total
+-- in manifest, 50 currently live) will be flagged by the new coverage
+-- endpoint (`/api/v1/voice-lab/tests/coverage`) until cases are added.
+
+BEGIN;
+
+INSERT INTO public.livekit_test_cases (key, label, prompt, expected, notes) VALUES
+
+-- ============================================================================
+-- Calendar (2 new)
+-- ============================================================================
+('search_calendar_next_tuesday',
+ 'Search calendar — next Tuesday',
+ 'Do I have anything scheduled for next Tuesday?',
+ '{"tools":["search_calendar"]}'::jsonb,
+ 'Calendar lookup for a specific day.'),
+
+('get_schedule_today',
+ 'Get today''s schedule',
+ 'What''s on my agenda for today?',
+ '{"tools_any":["get_schedule","search_calendar"]}'::jsonb,
+ 'Today/agenda query — either get_schedule or search_calendar may fire.'),
+
+-- ============================================================================
+-- Autopilot (2 new)
+-- ============================================================================
+('autopilot_get_recommendations',
+ 'List autopilot recommendations',
+ 'Show me my autopilot recommendations.',
+ '{"tools":["get_recommendations"]}'::jsonb,
+ 'Read-only fetch of pending autopilot recs.'),
+
+('autopilot_activate_morning_walk',
+ 'Activate an autopilot recommendation',
+ 'Activate the recommendation about taking a morning walk.',
+ '{"tools":["activate_recommendation"]}'::jsonb,
+ 'Activation requires the LLM to ID and act on the relevant rec.'),
+
+-- ============================================================================
+-- Health logging + index (6 new)
+-- ============================================================================
+('health_index_improvement_plan',
+ 'Create Vitana Index improvement plan',
+ 'Create a 30-day plan to improve my Vitana Index, focusing on my weakest pillar.',
+ '{"tools":["create_index_improvement_plan"]}'::jsonb,
+ 'Multi-step planning tool — explicit "create a plan" wording.'),
+
+('health_ask_pillar_agent_sleep',
+ 'Ask Sleep pillar agent',
+ 'Ask my Sleep pillar agent what trends it sees in my sleep this past week.',
+ '{"tools":["ask_pillar_agent"]}'::jsonb,
+ 'Pillar-specific delegation prompt.'),
+
+('health_get_pillar_subscores',
+ 'Get pillar subscores',
+ 'Show me my detailed Sleep pillar subscores.',
+ '{"tools":["get_pillar_subscores"]}'::jsonb,
+ 'Lower-level breakdown of a single pillar.'),
+
+('health_log_water',
+ 'Log water intake',
+ 'I just drank a big glass of water, about 500ml.',
+ '{"tools_any":["log_water","save_diary_entry"]}'::jsonb,
+ 'log_water is the explicit tool; save_diary_entry also handles water as the extractor catches "500ml". tools_any keeps the contract honest about either route.'),
+
+('health_log_sleep',
+ 'Log sleep',
+ 'Last night I slept seven and a half hours, woke up at 6:30 AM feeling rested.',
+ '{"tools_any":["log_sleep","save_diary_entry"]}'::jsonb,
+ 'log_sleep direct, or save_diary_entry which forwards to the extractor.'),
+
+('health_log_exercise',
+ 'Log exercise',
+ 'I just finished a 30 minute run in the park.',
+ '{"tools_any":["log_exercise","save_diary_entry"]}'::jsonb,
+ 'Exercise logging.'),
+
+('health_log_meditation',
+ 'Log meditation',
+ 'I just finished a 10 minute meditation session, feeling calm.',
+ '{"tools_any":["log_meditation","save_diary_entry"]}'::jsonb,
+ 'Meditation logging.'),
+
+-- ============================================================================
+-- Reminders (3 new)
+-- ============================================================================
+('reminders_set',
+ 'Set a reminder',
+ 'Remind me to call Mom on Saturday at 11 AM.',
+ '{"tools":["set_reminder"]}'::jsonb,
+ 'Standard reminder set.'),
+
+('reminders_find',
+ 'Find this week''s reminders',
+ 'What reminders do I have for this week?',
+ '{"tools":["find_reminders"]}'::jsonb,
+ 'Read-only reminder lookup.'),
+
+('reminders_delete_dentist',
+ 'Delete a reminder',
+ 'Delete my reminder about the dentist appointment.',
+ '{"tools":["delete_reminder"]}'::jsonb,
+ 'Deletion by topic — LLM must identify the right reminder.'),
+
+-- ============================================================================
+-- Intents / matchmaking (5 new)
+-- ============================================================================
+('intents_list_my',
+ 'List my intents',
+ 'What intents have I posted recently?',
+ '{"tools":["list_my_intents"]}'::jsonb,
+ 'Read-only intent list.'),
+
+('intents_get_matchmaker_result',
+ 'Get matchmaker result',
+ 'Show me the matchmaker result for my tennis partner search.',
+ '{"tools":["get_matchmaker_result"]}'::jsonb,
+ 'Matchmaker output lookup.'),
+
+('intents_mark_fulfilled',
+ 'Mark intent fulfilled',
+ 'Mark my tennis partner intent as fulfilled — I found someone.',
+ '{"tools":["mark_intent_fulfilled"]}'::jsonb,
+ 'State transition on an existing intent.'),
+
+('intents_share_post',
+ 'Share an intent post',
+ 'Share my tennis partner intent on the community feed.',
+ '{"tools":["share_intent_post"]}'::jsonb,
+ 'Cross-surface share action.'),
+
+('intents_respond_to_match',
+ 'Respond to a match',
+ 'Accept the match Maria sent me for tennis.',
+ '{"tools":["respond_to_match"]}'::jsonb,
+ 'Affirmative response to an incoming match.'),
+
+-- ============================================================================
+-- Memory (2 new)
+-- ============================================================================
+('memory_search_routine',
+ 'Search memory for past routine',
+ 'What did I tell you about my work routine last week?',
+ '{"tools":["search_memory"]}'::jsonb,
+ 'Memory recall — distinct from search_knowledge (personal-history trigger).'),
+
+('memory_recall_conversation',
+ 'Recall conversation at a time',
+ 'What did we talk about yesterday evening around 8 PM?',
+ '{"tools":["recall_conversation_at_time"]}'::jsonb,
+ 'Time-anchored conversation recall.'),
+
+-- ============================================================================
+-- Persona / Specialist (1 new — report_to_specialist already covered)
+-- ============================================================================
+('persona_switch_energetic',
+ 'Switch persona to energetic',
+ 'Switch to a more energetic coaching tone for the next few minutes.',
+ '{"tools":["switch_persona"]}'::jsonb,
+ 'Within-Vitana style switch — NOT specialist handoff (that''s report_to_specialist).'),
+
+-- ============================================================================
+-- Community (1 new)
+-- ============================================================================
+('community_find_member',
+ 'Find a community member',
+ 'Find a community member named Anna who lives in Berlin.',
+ '{"tools":["find_community_member"]}'::jsonb,
+ 'Community-member directory search.'),
+
+-- ============================================================================
+-- Settings (1 new)
+-- ============================================================================
+('settings_set_capability_preference',
+ 'Set a capability preference',
+ 'When I''m talking about meditation, always respond to me in Spanish.',
+ '{"tools":["set_capability_preference"]}'::jsonb,
+ 'Persistent user-preference write.'),
+
+-- ============================================================================
+-- Email (1 new)
+-- ============================================================================
+('email_read_latest',
+ 'Read latest email',
+ 'Read me my latest email.',
+ '{"tools":["read_email"]}'::jsonb,
+ 'Connected-provider email read.'),
+
+-- ============================================================================
+-- Contacts (1 new)
+-- ============================================================================
+('contacts_find_sarah',
+ 'Find a contact by name',
+ 'What''s Sarah''s phone number?',
+ '{"tools":["find_contact"]}'::jsonb,
+ 'Contact lookup by name.'),
+
+-- ============================================================================
+-- External AI (1 new)
+-- ============================================================================
+('ai_consult_external_claude',
+ 'Consult external AI',
+ 'Ask Claude to help me draft a polite email declining a meeting invitation.',
+ '{"tools":["consult_external_ai"]}'::jsonb,
+ 'Forward to user-connected ChatGPT/Claude/Gemini account.'),
+
+-- ============================================================================
+-- Help (1 new)
+-- ============================================================================
+('help_explain_autopilot',
+ 'Explain a feature',
+ 'How does the Autopilot feature work, and what does it do for me?',
+ '{"tools_any":["explain_feature","search_knowledge"]}'::jsonb,
+ 'Feature explanation may route via search_knowledge or explain_feature.'),
+
+-- ============================================================================
+-- Chat (1 new — send_chat_message + resolve_recipient already covered)
+-- ============================================================================
+('chat_share_link',
+ 'Share a link',
+ 'Share this article link with Maria: https://example.com/longevity-tips',
+ '{"tools":["share_link"]}'::jsonb,
+ 'Link-share to another user.'),
+
+-- ============================================================================
+-- Navigation (1 new — navigate + navigate_to_screen already covered)
+-- ============================================================================
+('nav_get_current_screen',
+ 'What screen am I on',
+ 'What screen am I on right now?',
+ '{"tools":["get_current_screen"]}'::jsonb,
+ 'Current-route lookup.'),
+
+-- ============================================================================
+-- Marketplace (2 new, vertex-only — may not fire in LiveKit path)
+-- ============================================================================
+('marketplace_find_product_vitamin_d',
+ 'Find a product',
+ 'Help me find a good vitamin D supplement.',
+ '{"tools":["find_perfect_product"]}'::jsonb,
+ 'Vertex-only tool. May fail in LiveKit path until parity is reached.'),
+
+('marketplace_find_practitioner_berlin',
+ 'Find a practitioner',
+ 'Find me a meditation coach in Berlin.',
+ '{"tools":["find_perfect_practitioner"]}'::jsonb,
+ 'Vertex-only tool. May fail in LiveKit path until parity is reached.');
+
+COMMIT;


### PR DESCRIPTION
Grows the LiveKit hourly test grid from 13 cases (~18 tools) to **45 cases covering all 50 currently-live tools**, and adds a parity endpoint that auto-flags new tools as the manifest grows toward 147.

## Schema
`20260524010000_VTID_03025_livekit_tests_full_coverage.sql` inserts 32 new cases (one per previously-uncovered live tool across Calendar, Autopilot, Health logging, Reminders, Intents, Memory, Persona, Community, Settings, Email, Contacts, External AI, Help, Chat, Navigation, Marketplace).

## Backend
- New `livekit-test-coverage.ts` reads `tool-manifest.json` (cached 60s), joins with enabled `livekit_test_cases` (union of `expected.tools[]` + `expected.tools_any[]`), returns `CoverageReport` with manifest age, live_total / tested_total / uncovered, per-surface breakdown, and orphan list.
- New route: `GET /api/v1/voice-lab/tests/coverage` (same dual-auth gate).

## UI
Voice → Orb UI Monitor: parity banner above the case grid — "X / N live tools tested (P%)" with a clickable details disclosure of every uncovered tool + surface. Green ≥100, amber ≥80, red below.

## Future tools
When the manifest goes from 50 → 70 → 147, the panel will keep showing the gap until cases are added. Each tool flagged here is one line of SQL to add.

## Test plan
- [x] npm run build clean
- [x] 30/30 (scorer 28 + voice-lab auth 2) green
- [ ] Apply migration via RUN-MIGRATION.yml
- [ ] After deploy + migration: dispatch SMOKE-LIVEKIT-TESTS.yml → expect ~45/45 (some Vertex-only tools may fail on LiveKit path; banner will show which)

🤖 Generated with [Claude Code](https://claude.com/claude-code)