### PR TITLE
perf(orb-livekit): shared bootstrap cache via Supabase — fix cross-instance miss (VTID-03036)

### DIFF
--- a/services/gateway/src/routes/orb-livekit.ts
+++ b/services/gateway/src/routes/orb-livekit.ts
@@ -120,6 +120,64 @@ function setCachedBootstrap(key: string, value: Record<string, unknown>): void {
   BOOTSTRAP_CACHE.set(key, { value, cachedAt: Date.now() });
 }
 
+// ---------------------------------------------------------------------------
+// VTID-03036: shared cross-instance cache via Supabase `bootstrap_cache` table.
+// ---------------------------------------------------------------------------
+// The VTID-03035 in-memory cache only hits when both the token-mint and the
+// agent's bootstrap.fetch() land on the same Cloud Run gateway instance. In
+// production the LB routes those requests across multiple instances, so
+// real-session hit-rate stayed low and bootstrap_latency_ms stuck at ~700ms.
+//
+// This layer mirrors every write to a Supabase row keyed by the same string.
+// On miss the handler checks Supabase before doing the full work; on hit it
+// re-populates the in-memory cache so subsequent same-instance reads are
+// instant.
+//
+// Defensive: ALL Supabase calls are wrapped in try/catch and return
+// null/undefined on any error (table missing, network blip, etc.). The
+// handler always falls back to the existing in-memory + full-work path —
+// no behavior regression if the migration hasn't been applied yet.
+// ---------------------------------------------------------------------------
+
+async function getSharedCachedBootstrap(
+  key: string,
+): Promise<Record<string, unknown> | null> {
+  const sb = getSupabase();
+  if (!sb) return null;
+  try {
+    const { data, error } = await sb
+      .from('bootstrap_cache')
+      .select('payload, expires_at')
+      .eq('cache_key', key)
+      .gt('expires_at', new Date().toISOString())
+      .maybeSingle();
+    if (error || !data) return null;
+    const row = data as { payload: unknown; expires_at: string };
+    return (row.payload as Record<string, unknown>) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+async function setSharedCachedBootstrap(
+  key: string,
+  value: Record<string, unknown>,
+): Promise<void> {
+  const sb = getSupabase();
+  if (!sb) return;
+  try {
+    const expiresAt = new Date(Date.now() + BOOTSTRAP_CACHE_TTL_MS).toISOString();
+    await sb
+      .from('bootstrap_cache')
+      .upsert(
+        { cache_key: key, payload: value, expires_at: expiresAt },
+        { onConflict: 'cache_key' },
+      );
+  } catch {
+    /* best-effort */
+  }
+}
+
 /**
  * Fire-and-forget bootstrap pre-warm. Called from token-mint endpoints to
  * fill the cache while the LiveKit client + WebRTC handshake are still
@@ -674,19 +732,35 @@ router.get(
       .split(',')[0]
       .split('-')[0];
 
-    // VTID-03035: cache hit short-circuit. Only the full (non-greeting-only)
-    // path is cached — greeting_only is already fast (~150-300ms) and its
-    // freshness matters less. Anonymous sessions skip the cache (key
-    // would collide across visitors).
+    // VTID-03035 + VTID-03036: two-layer cache hit short-circuit.
+    //  - L1 in-memory (per Cloud Run instance) — ~0ms when hit
+    //  - L2 Supabase `bootstrap_cache` (shared across instances) — ~30-80ms
+    // Only the full (non-greeting-only) path is cached — greeting_only is
+    // already fast (~150-300ms) and its freshness matters less. Anonymous
+    // sessions skip the cache (key would collide across visitors).
     const greetingOnly = String(req.query.greeting_only ?? 'false') === 'true';
     const cacheKey = userId ? bootstrapCacheKey(userId, agentId, lang) : null;
     if (cacheKey && !greetingOnly) {
-      const cached = getCachedBootstrap(cacheKey);
-      if (cached) {
+      // L1: in-memory
+      const l1Cached = getCachedBootstrap(cacheKey);
+      if (l1Cached) {
         return res.json({
-          ...cached,
+          ...l1Cached,
           cached: true,
+          cache_layer: 'l1_memory',
           cache_age_ms: Date.now() - (BOOTSTRAP_CACHE.get(cacheKey)?.cachedAt ?? Date.now()),
+        });
+      }
+      // L2: shared Supabase (VTID-03036). Best-effort; on any error this
+      // returns null and we fall through to the normal handler work.
+      const l2Cached = await getSharedCachedBootstrap(cacheKey);
+      if (l2Cached) {
+        // Re-populate L1 so the same instance hits in-memory next time.
+        setCachedBootstrap(cacheKey, l2Cached);
+        return res.json({
+          ...l2Cached,
+          cached: true,
+          cache_layer: 'l2_supabase',
         });
       }
     }
@@ -1328,11 +1402,15 @@ router.get(
       decision_context: decisionContext,
     };
 
-    // VTID-03035: populate cache for the next 60s. Only authenticated full
-    // (non-greeting-only) bootstraps are cached — anonymous keys would
-    // collide across visitors, and greeting_only is already fast enough.
+    // VTID-03035 + VTID-03036: populate both cache layers for the next 60s.
+    //  - L1 in-memory: instant hit on same Cloud Run instance.
+    //  - L2 Supabase (fire-and-forget upsert): hit on any instance via the
+    //    `bootstrap_cache` table — required for prewarm→agent to land
+    //    cross-instance under load.
     if (cacheKey) {
       setCachedBootstrap(cacheKey, responsePayload);
+      // Fire-and-forget — don't block the response on the Supabase write.
+      void setSharedCachedBootstrap(cacheKey, responsePayload);
     }
 
     res.json(responsePayload);

--- a/supabase/migrations/20260524000000_VTID_03036_bootstrap_cache.sql
+++ b/supabase/migrations/20260524000000_VTID_03036_bootstrap_cache.sql
@@ -1,0 +1,50 @@
+-- VTID-03036: shared bootstrap_cache table for /orb/context-bootstrap.
+--
+-- Background
+-- ==========
+-- VTID-03035 added an in-memory per-instance cache for the bootstrap
+-- response. It worked for same-instance requests (probe verified
+-- `cached: true, age_ms=946`) but the agent worker's HTTP call from
+-- us-central1 Cloud Run lands on the gateway's load balancer, which
+-- can route to a different gateway instance than the one that handled
+-- the token mint. Result: cache miss rate ~50% in production traces;
+-- bootstrap_latency_ms stayed at 600-800ms instead of dropping to ~50ms.
+--
+-- This table moves the cache to a shared store so every gateway instance
+-- sees the same warm entries. Token-mint endpoints write here; bootstrap
+-- handler reads here when its local in-memory layer misses.
+--
+-- Schema
+-- ======
+-- cache_key   : "{user_id}|{agent_id}|{lang}" — matches gateway's
+--               bootstrapCacheKey() function.
+-- payload     : full /orb/context-bootstrap response body, JSON.
+-- expires_at  : NOW() + 60s (mirrors the in-memory TTL).
+-- created_at  : audit-only.
+--
+-- TTL is enforced at read time (WHERE expires_at > NOW()). A periodic
+-- vacuum/delete is NOT strictly required — stale rows are harmless and
+-- get overwritten on the next mint for the same key. If table growth
+-- becomes a concern, add a daily DELETE WHERE expires_at < NOW() job.
+
+CREATE TABLE IF NOT EXISTS bootstrap_cache (
+  cache_key   TEXT        PRIMARY KEY,
+  payload     JSONB       NOT NULL,
+  expires_at  TIMESTAMPTZ NOT NULL,
+  created_at  TIMESTAMPTZ NOT NULL DEFAULT NOW()
+);
+
+-- Reads filter by `WHERE cache_key = ? AND expires_at > NOW()`. The PK
+-- already covers the equality on cache_key; an additional index on
+-- expires_at is only useful for the optional cleanup job below.
+CREATE INDEX IF NOT EXISTS bootstrap_cache_expires_idx
+  ON bootstrap_cache (expires_at);
+
+-- This table is gateway-internal infrastructure; never touched by user
+-- workflows. RLS off, accessed only by the service role.
+ALTER TABLE bootstrap_cache DISABLE ROW LEVEL SECURITY;
+
+COMMENT ON TABLE bootstrap_cache IS
+  'VTID-03036 — shared response cache for /orb/context-bootstrap. 60s TTL. ' ||
+  'Token-mint endpoints write here; the bootstrap handler reads here after ' ||
+  'an in-memory miss to serve cross-instance cache hits in the Cloud Run fleet.';


### PR DESCRIPTION
VTID-03035 added an in-memory bootstrap cache. The probe verified it worked (`cached:true, age_ms=946`), but real-session `bootstrap_latency_ms≈666ms` showed the LB routes the agent's `bootstrap.fetch()` from us-central1 to a different gateway instance than the one that handled the token mint — the in-memory cache misses cross-instance.

This PR adds a second cache layer in a shared Supabase table.

## Architecture

```
agent.bootstrap.fetch()
      ↓
GET /orb/context-bootstrap
      ├─ L1: in-memory Map (VTID-03035, ~0ms when hit)
      │      ↓ miss
      ├─ L2: Supabase bootstrap_cache (NEW, ~30-80ms when hit)
      │      ↓ miss
      └─ Full handler work (~600-800ms)
```

Writes hit both layers. L1 is synchronous; L2 is `void setShared...` fire-and-forget so the response isn't blocked.

## Schema

```sql
CREATE TABLE bootstrap_cache (
  cache_key   TEXT PRIMARY KEY,  -- "{user_id}|{agent_id}|{lang}"
  payload     JSONB,
  expires_at  TIMESTAMPTZ,
  created_at  TIMESTAMPTZ
);
```

Read filter: `WHERE cache_key=? AND expires_at > NOW()`. RLS off — gateway-internal infra.

## Defensive

All Supabase calls wrapped in try/catch returning null/undefined. If the migration hasn't applied yet (table missing), helpers fall through silently → handler runs existing full-work path. **Zero behavior regression.**

Response includes `cache_layer: "l1_memory" | "l2_supabase"` on hits so traces show the speedup source.

## Stability

Touches only the gateway's bootstrap endpoint. No changes to:
- agent worker (services/agents/orb-agent/**)
- LiveKit room / dispatch / token contracts
- STT / LLM / TTS pipelines
- active-session lifecycle code

A mid-conversation disconnect cannot originate here.

## Expected impact

| | Before | After |
|---|---|---|
| `bootstrap_latency_ms` (cross-instance) | 666ms | ~50-100ms |
| Click → audible greeting (typical) | 4.6s | ~4.0-4.2s |

## Test plan
- [ ] Apply migration via `RUN-MIGRATION.yml` workflow first
- [ ] Merge → EXEC-DEPLOY auto-fires
- [ ] Real session: check trace shows `cache_layer: "l2_supabase"` on the agent's bootstrap call
- [ ] `bootstrap_latency_ms` drops to <150ms when cache is warm

🤖 Generated with [Claude Code](https://claude.com/claude-code)