### PR TITLE
feat(orb): profile-block ACCOUNT section — surface community-membership tenure for "how long am I a member" parity (VTID-03037)

### DIFF
--- a/services/gateway/src/services/user-context-profiler.ts
+++ b/services/gateway/src/services/user-context-profiler.ts
@@ -188,6 +188,36 @@ async function fetchRoutines(client: SupabaseClient, userId: string): Promise<Ro
   return (data || []) as RoutineRow[];
 }
 
+// VTID-03037: surface community-membership tenure into the profile block so
+// the LiveKit / brain-OFF Vertex paths can answer "how long have I been a
+// member?" without a tool call. Sourced from app_users.created_at which is
+// the canonical registration timestamp (mirrored from profiles by Release A
+// trigger). Returns null on miss so buildAccountSection can skip cleanly.
+export interface AccountRow {
+  createdAt: Date | null;
+}
+
+async function fetchAppUsersAccount(
+  client: SupabaseClient,
+  userId: string,
+): Promise<AccountRow> {
+  try {
+    const { data, error } = await client
+      .from('app_users')
+      .select('created_at')
+      .eq('user_id', userId)
+      .maybeSingle();
+    if (error || !data) return { createdAt: null };
+    const raw = (data as { created_at?: string | null }).created_at;
+    if (!raw) return { createdAt: null };
+    const parsed = new Date(raw);
+    if (Number.isNaN(parsed.getTime())) return { createdAt: null };
+    return { createdAt: parsed };
+  } catch {
+    return { createdAt: null };
+  }
+}
+
 async function fetchPreferences(client: SupabaseClient, userId: string): Promise<PreferenceRow[]> {
   const out: PreferenceRow[] = [];
   const explicit = await client
@@ -855,6 +885,35 @@ function buildFactsSection(facts: { fact_key: string; fact_value: string; proven
   return `[FACTS]\n${top.join('\n')}`;
 }
 
+// VTID-03037: account/tenure section. Rendered at the TOP of the profile so
+// the LLM reads it before activity data. Emits "" when createdAt is missing
+// (anonymous, fetch failed, or a row without created_at) so the rest of the
+// summary degrades gracefully.
+//
+// Phrasing rationale:
+//   - "Joined the Vitana community on ${YYYY-MM-DD}" is the canonical
+//     anchor — date is unambiguous regardless of timezone.
+//   - "Tenure: ${N} days" is the literal answer to "how long have I been a
+//     member?". Phrasing chosen to align with Vertex's brain-path
+//     `Tenure: ${stage} (registered ${N} days ago …)` so the LLM treats
+//     them as the same fact when both blocks are present.
+//   - Tenure cap at 0 handles the rare clock-drift case where created_at
+//     parses to a future timestamp.
+//
+// Exported for unit testing — pure function, no side effects.
+export function buildAccountSection(account: AccountRow, nowMs: number): string {
+  if (!account.createdAt) return '';
+  const ts = account.createdAt.getTime();
+  if (!Number.isFinite(ts)) return '';
+  const days = Math.max(0, Math.floor((nowMs - ts) / 86_400_000));
+  const dateIso = account.createdAt.toISOString().slice(0, 10);
+  return [
+    '[ACCOUNT]',
+    `- Joined the Vitana community on ${dateIso}.`,
+    `- Tenure: ${days} day${days === 1 ? '' : 's'} as a community member.`,
+  ].join('\n');
+}
+
 export async function getUserContextSummary(
   userId: string,
   opts: GetProfileOptions = {}
@@ -915,15 +974,27 @@ export async function getUserContextSummary(
     ? Promise.resolve({ ok: true, facts: [] as any[] })
     : getCurrentFacts({ tenant_id: opts.tenantId, user_id: userId });
 
-  const [activities, routines, prefs, vitana, factsResult] = await Promise.all([
+  // VTID-03037: account/tenure fetch. Always in the batch — no awareness-
+  // registry gate yet; the section itself self-skips when created_at is
+  // missing. The query is cheap (single-row lookup on a PK) and adds no
+  // measurable latency because it parallelizes with the existing five.
+  const fetchAccountPromise = fetchAppUsersAccount(client, userId);
+
+  const [activities, routines, prefs, vitana, factsResult, account] = await Promise.all([
     fetchActivitiesIfWanted,
     fetchRoutinesIfWanted,
     fetchPrefsIfWanted,
     fetchVitanaIfWanted,
     fetchFactsIfWanted,
+    fetchAccountPromise,
   ]);
 
   const sections = [
+    // VTID-03037: account/tenure goes FIRST so the LLM reads "joined on
+    // YYYY-MM-DD, tenure N days" before activity data. Mirrors the brain
+    // path's USER AWARENESS positioning (tenure line at top of awareness
+    // block) so both pipelines agree on the high-signal placement.
+    buildAccountSection(account, now),
     (!cfg || cfg.isEnabled('activity.summary.enabled')) ? buildActivitySummarySection(activities) : '',
     (!cfg || cfg.isEnabled('routines.enabled'))         ? buildRoutinesSection(routines, activities) : '',
     (!cfg || cfg.isEnabled('preferences.explicit.enabled') || cfg.isEnabled('preferences.inferred.enabled'))

--- a/services/gateway/test/services/user-context-profiler-account.test.ts
+++ b/services/gateway/test/services/user-context-profiler-account.test.ts
@@ -1,0 +1,135 @@
+/**
+ * VTID-03037 — user-context-profiler ACCOUNT section.
+ *
+ * Locks the pure renderer (`buildAccountSection`) + the wire-up that
+ * places the section at the top of the profile output. The renderer is
+ * load-bearing for the LiveKit / brain-OFF Vertex answer to
+ * "how long have I been a member?" since these paths consume the
+ * profile block via `buildBootstrapContextPack(...)`.
+ *
+ * Integration coverage (getUserContextSummary end-to-end) is left for a
+ * separate test once the profiler suite is established — the wire-up
+ * assertion below is enough to catch a regression where the fetch or
+ * section insertion is silently removed.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+import { buildAccountSection, AccountRow } from '../../src/services/user-context-profiler';
+
+const PROFILER_PATH = path.resolve(
+  __dirname,
+  '../../src/services/user-context-profiler.ts',
+);
+
+let profilerSource: string;
+
+beforeAll(() => {
+  profilerSource = fs.readFileSync(PROFILER_PATH, 'utf8');
+});
+
+describe('VTID-03037 buildAccountSection (pure renderer)', () => {
+  const NOW = new Date('2026-05-17T10:30:00Z').getTime();
+
+  it('returns "" when createdAt is null', () => {
+    const account: AccountRow = { createdAt: null };
+    expect(buildAccountSection(account, NOW)).toBe('');
+  });
+
+  it('returns "" when createdAt is an invalid Date', () => {
+    const account: AccountRow = { createdAt: new Date('not-a-real-date') };
+    expect(buildAccountSection(account, NOW)).toBe('');
+  });
+
+  it('renders single-day tenure with singular "day"', () => {
+    const account: AccountRow = {
+      createdAt: new Date('2026-05-16T10:30:00Z'),
+    };
+    const out = buildAccountSection(account, NOW);
+    expect(out).toContain('[ACCOUNT]');
+    expect(out).toContain('Joined the Vitana community on 2026-05-16.');
+    expect(out).toContain('Tenure: 1 day as a community member.');
+  });
+
+  it('renders multi-day tenure with plural "days"', () => {
+    const account: AccountRow = {
+      createdAt: new Date('2024-12-15T10:30:00Z'),
+    };
+    const out = buildAccountSection(account, NOW);
+    expect(out).toContain('Joined the Vitana community on 2024-12-15.');
+    // Floor((2026-05-17 - 2024-12-15) / 86400_000) = 518 days.
+    expect(out).toContain('Tenure: 518 days as a community member.');
+  });
+
+  it('clamps future createdAt to 0 days (clock-drift safety)', () => {
+    const account: AccountRow = {
+      createdAt: new Date('2026-05-20T10:30:00Z'),
+    };
+    const out = buildAccountSection(account, NOW);
+    expect(out).toContain('Tenure: 0 days as a community member.');
+    // The date line still shows the future ISO (DB is the source of
+    // truth — the LLM seeing "joined on 2026-05-20" lets a human notice
+    // a clock issue, rather than silently dropping the row).
+    expect(out).toContain('Joined the Vitana community on 2026-05-20.');
+  });
+
+  it('renders day 0 as "0 days" (just-joined edge)', () => {
+    const account: AccountRow = {
+      createdAt: new Date(NOW),
+    };
+    const out = buildAccountSection(account, NOW);
+    expect(out).toContain('Tenure: 0 days as a community member.');
+  });
+
+  it('uses a stable line order: header → joined → tenure', () => {
+    const account: AccountRow = {
+      createdAt: new Date('2025-11-01T00:00:00Z'),
+    };
+    const lines = buildAccountSection(account, NOW).split('\n');
+    expect(lines[0]).toBe('[ACCOUNT]');
+    expect(lines[1].startsWith('- Joined the Vitana community on ')).toBe(true);
+    expect(lines[2].startsWith('- Tenure: ')).toBe(true);
+  });
+});
+
+describe('VTID-03037 profiler wire-up (source-text characterization)', () => {
+  it('fetches app_users.created_at via fetchAppUsersAccount', () => {
+    // The fetch must live in the profiler and read created_at from
+    // app_users. A regression that moves the source column (e.g. to a
+    // mirror table) or drops the fetch will trip this assertion before
+    // any LLM behavior change is observable.
+    expect(profilerSource).toMatch(/async\s+function\s+fetchAppUsersAccount/);
+    expect(profilerSource).toMatch(/from\(['"]app_users['"]\)[\s\S]{0,60}select\(['"]created_at['"]\)/);
+  });
+
+  it('runs the account fetch inside the existing parallel Promise.all batch', () => {
+    // Sequential placement would tack ~30-80ms onto bootstrap latency,
+    // which matters on the LiveKit click→greeting path. The batch
+    // destructure must include `account` so a future refactor can’t
+    // silently drop it.
+    expect(profilerSource).toMatch(/const\s+\[[^\]]*account[^\]]*\]\s*=\s*await\s+Promise\.all/);
+    expect(profilerSource).toMatch(/fetchAccountPromise/);
+  });
+
+  it('inserts the ACCOUNT section at the TOP of the sections list', () => {
+    // Top placement is intentional — the LLM reads the tenure line
+    // before activity data. The brain path positions tenure at the top
+    // of USER AWARENESS for the same reason; profiler mirrors it.
+    //
+    // Anchor on the sections-array opener, then walk forward by line
+    // until we reach the first non-comment, non-blank line — that must
+    // be the buildAccountSection call. This shape is robust to any
+    // number of intervening comment lines explaining the placement.
+    const anchor = profilerSource.indexOf('const sections = [');
+    expect(anchor).toBeGreaterThan(0);
+    const tail = profilerSource.slice(anchor);
+    const lines = tail.split('\n').slice(1); // skip "const sections = ["
+    const firstMeaningful = lines.find((l) => {
+      const trimmed = l.trim();
+      return trimmed.length > 0 && !trimmed.startsWith('//');
+    });
+    expect(firstMeaningful).toBeDefined();
+    expect(firstMeaningful!.trim()).toBe('buildAccountSection(account, now),');
+  });
+});


### PR DESCRIPTION
## Summary

- Follow-up to VTID-03036 (PR #2169). That slice wired LiveKit's bootstrap to call Vertex's exported `buildBootstrapContextPack`. Post-deploy voice smoke confirmed the wire-up but exposed the next gap: the profile block it delivers **never carried tenure data**. The LiveKit agent answered with correct identity but said "ich kann in meinen Erinnerungen keine Information darüber finden, wie lange du schon Mitglied … bist."
- This PR adds an `[ACCOUNT]` section to `getUserContextSummary` that reads `app_users.created_at` and renders `Joined the Vitana community on YYYY-MM-DD` + `Tenure: N days as a community member`.
- Additive only: +72 lines in one service file, +1 new test file. Zero LiveKit route diff, zero Vertex route diff, zero brain diff.

## Why this is the right layer

Vertex's brain path covers the gap via `vitana-brain.ts:1079` (`buildAwarenessBlock` → "Tenure: stage (registered N days ago, on YYYY-MM-DD)") — but only when `vitana_brain_orb_enabled` is on. The legacy fallback path that **both** Vertex (flag off) and LiveKit (always) consume — `buildBootstrapContextPack` → `getUserContextSummary` — has never carried tenure. Fixing it at the profiler closes the gap on **both** pipelines in one change instead of patching the LiveKit route.

This is the architectural follow-up the prior PR's diagnostic flagged: "Future enrichments to the pack benefit ALL consumers by construction." Tenure is the first such enrichment.

## Change

`services/gateway/src/services/user-context-profiler.ts` (+72, additive):

1. **`fetchAppUsersAccount(client, userId)`** — single-row PK lookup on `app_users.created_at`. Returns `{ createdAt: null }` on miss / parse failure.
2. **`buildAccountSection(account, nowMs)`** (exported pure renderer) emitting:
   ```
   [ACCOUNT]
   - Joined the Vitana community on YYYY-MM-DD.
   - Tenure: N day(s) as a community member.
   ```
   Tenure clamps to >= 0 (clock-drift safety).
3. Adds the fetch as a 6th parallel branch in the existing `Promise.all` — overlaps with the slower scans, no measurable latency regression.
4. Inserts the section at the **top** of the sections list so the LLM reads tenure before activity data. Mirrors brain's USER AWARENESS positioning.

No awareness-registry flag added. The section self-skips when `createdAt` is missing; account/tenure is small, deterministic, and high-signal — always-on is the simpler contract.

## What this PR does NOT do

- No change to `orb-livekit.ts` or `orb-live.ts` (route handlers untouched).
- No change to `vitana-brain.ts` (brain path already carries tenure).
- No agent-side code change (`session.py` / `bootstrap.py` / `instructions.py` untouched).
- No `voice.livekit_agent_enabled` flip.

## Acceptance

1. `getUserContextSummary(userId)` summary begins with `[ACCOUNT]` when `app_users.created_at` is populated.
2. LiveKit / brain-OFF Vertex `bootstrap_context` carries the ACCOUNT block via `buildBootstrapContextPack` → `getUserContextSummary`.
3. The LiveKit voice agent, asked "how long have I been a member?", answers with the literal joined date + tenure days.
4. Brain-ON Vertex behavior unchanged.
5. Anonymous / missing-identity users: no section emitted, summary shape preserved.

## Tests

- `npm run build` (gateway) — green.
- **10 / 10** new tests in `test/services/user-context-profiler-account.test.ts`:
  - 7 pure-renderer cases (null, invalid Date, singular/plural, clock drift, day 0, stable line order).
  - 3 wire-up character assertions (fetch shape, parallel-batch destructure, top-of-sections insertion).
- **713 / 713** orb tests still green (40 suites). No collateral.

## Test plan

- [ ] CI green on this PR.
- [ ] EXEC-DEPLOY succeeds.
- [ ] LiveKit Test Bench voice question "wie lange bin ich schon Mitglied?" / "how long have I been a member?" — agent answers grounded in `app_users.created_at` (date + tenure days, no apology).
- [ ] No regression on "who am I?" / Vitana Index / Life Compass questions.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
