### PR TITLE
fix(smoke): bump smoke timeout 5 → 20 min (VTID-03025)

### DIFF
--- a/.github/workflows/SMOKE-LIVEKIT-TESTS.yml
+++ b/.github/workflows/SMOKE-LIVEKIT-TESTS.yml
@@ -34,7 +34,9 @@ permissions:
 jobs:
   smoke:
     runs-on: ubuntu-latest
-    timeout-minutes: 5
+    # 45 cases × ~5s/case + per-case retry on flap = up to ~10min worst case.
+    # Set to 20 to give comfortable headroom as the suite grows past 50.
+    timeout-minutes: 20
     steps:
       - name: Authenticate to GCP via Workload Identity Federation (mint id_token)
         id: gcp-auth


### PR DESCRIPTION
45-case smoke run got cancelled at the 5-min GH Actions timeout. Bump to 20 min for comfortable headroom through 150 cases as the manifest grows toward 147 live tools.

🤖 Generated with [Claude Code](https://claude.com/claude-code)