### PR TITLE
fix(voice-lab): parallel-batch eval to fit Cloud Run 5min request timeout (VTID-03025)

### DIFF
--- a/services/gateway/src/services/voice-lab/livekit-test-runner.ts
+++ b/services/gateway/src/services/voice-lab/livekit-test-runner.ts
@@ -128,11 +128,23 @@ export async function runLiveKitTestSuite(
   }
   const runId: string = (insertRun.data as { id: string }).id;
 
-  // 3. Execute cases serially.
+  // 3. Execute cases in parallel batches. 45+ cases × 3-8s/case ran serially
+  // exceeds Cloud Run's 5-min upstream request timeout; batching keeps the
+  // POST /tests/run round-trip under ~90s even as the suite grows toward
+  // 150 cases. Vertex generateContent handles concurrent calls; each case
+  // writes its own livekit_test_results row — no DB contention.
+  const concurrencyRaw = Number(process.env.LIVEKIT_TESTS_CONCURRENCY);
+  const concurrency =
+    Number.isFinite(concurrencyRaw) && concurrencyRaw > 0
+      ? Math.min(concurrencyRaw, 16)
+      : 5;
   const results: PersistedResult[] = [];
-  for (const c of cases) {
-    const persisted = await runOneCase(c, runId, opts.identity);
-    results.push(persisted);
+  for (let i = 0; i < cases.length; i += concurrency) {
+    const batch = cases.slice(i, i + concurrency);
+    const settled = await Promise.all(
+      batch.map((c) => runOneCase(c, runId, opts.identity)),
+    );
+    results.push(...settled);
   }
 
   // 4. Aggregate + finalize.


### PR DESCRIPTION
45-case smoke hit Cloud Run's upstream request timeout (5min) running serially. Switch to Promise.all batches of 5 (env-overridable via LIVEKIT_TESTS_CONCURRENCY, capped 16). Expected wall time at 45 cases ≈ 45-60s; headroom to 150.

🤖 Generated with [Claude Code](https://claude.com/claude-code)