### PR TITLE
fix(orb-livekit): cap Devon clarifying questions at 2 + harden swap-back contract (VTID-03039)

### DIFF
--- a/services/gateway/src/routes/orb-livekit.ts
+++ b/services/gateway/src/routes/orb-livekit.ts
@@ -1339,7 +1339,7 @@ router.get(
           }
           if (handoffSummary) {
             personaParts.push(
-              `[HANDOFF NOTE] Vitana captured this brief at handoff: "${handoffSummary}". Synthesize what the user reported in ONE sentence (your own words, not theirs) and confirm. Do NOT echo their wording back. Then ask any clarifying question you need. Open the conversation in your own voice and persona — never speak as Vitana, never quote her.`,
+              `[HANDOFF NOTE] Vitana captured this brief at handoff: "${handoffSummary}". Synthesize what the user reported in ONE sentence (your own words, not theirs) and confirm. Do NOT echo their wording back. The brief is usually enough — ask AT MOST 2 short clarifying questions, and ONLY if a critical detail is genuinely missing (skip them entirely if not). Then go straight to ticket confirmation + the auto-return question. Open the conversation in your own voice and persona — never speak as Vitana, never quote her.`,
             );
           }
           personaParts.push(
@@ -1371,12 +1371,13 @@ router.get(
           personaParts.push(
             [
               '[BEHAVIORAL RULE — swap back to Vitana]',
-              'When the user answers "no / nothing else / nein, danke / das war\'s" (or equivalent) to your auto-return question, you MUST:',
+              'When the user answers "no / nothing else / nein, danke / das war\'s" (or equivalent) to your auto-return question, your NEXT turn is the LAST thing you ever say in this session. In that single turn you MUST do BOTH actions, in this exact order:',
               '  1. Speak ONE short bridge sentence in your OWN voice handing them back to Vitana. Vary the phrasing:',
               '     EN: "Alright — I\'ll hand you back to Vitana." / "Cool — Vitana will take it from here."',
               '     DE: "Alles klar — ich übergebe dich zurück an Vitana." / "Vitana macht weiter."',
-              '  2. IMMEDIATELY call the `switch_persona` tool with persona=\'vitana\'.',
+              '  2. IMMEDIATELY call the `switch_persona` tool with persona=\'vitana\' — in the SAME turn as the bridge sentence, NEVER the turn after.',
               '  3. STOP speaking after the tool call — the next voice the user hears is Vitana\'s.',
+              'CRITICAL CONTRACT: speaking the goodbye WITHOUT also calling switch_persona leaves the user stranded in your voice. The tool call is NOT optional — it is what physically transfers the call back. A polite goodbye alone is a FAILED handoff. "Thank you, have a nice day" by itself is a BUG.',
               'NEVER stay silent. NEVER answer further user questions yourself once they say no — that\'s Vitana\'s domain.',
               'You CANNOT swap laterally to another specialist; you can ONLY return to Vitana via switch_persona.',
             ].join('\n'),

--- a/supabase/migrations/20260524030000_VTID_03039_devon_question_cap.sql
+++ b/supabase/migrations/20260524030000_VTID_03039_devon_question_cap.sql
@@ -1,0 +1,77 @@
+-- VTID-03039: cap Devon's clarifying questions at 2.
+--
+-- User reported (LiveKit Test Bench, German bug-report flow): Devon was
+-- running 50+ clarifying questions before confirming the ticket. Devon's
+-- seed prompt (VTID-02603, services/.../20260429100000_*.sql) said
+-- "Ask up to 6 questions to fill: [list of 8 fields]". "Up to 6" reads as
+-- soft, and listing 8 target fields telegraphs more questions. Combined
+-- with the LiveKit handoff-brief block (orb-livekit.ts:1342) saying
+-- "Then ask any clarifying question you need" — also uncapped — the
+-- LLM defaulted to "be thorough" and over-asked.
+--
+-- This migration replaces Devon's intake body with a HARD 2-question cap
+-- and drops the field list. The IDENTITY LOCK header (prepended by
+-- 20260502110000_persona_identity_lock_prepend.sql) is preserved verbatim.
+--
+-- The companion gateway change in services/gateway/src/routes/orb-livekit.ts
+-- tightens the [HANDOFF NOTE] block (same cap) and strengthens the
+-- swap-back rule so Devon cannot say "goodbye" without ALSO calling
+-- switch_persona(persona='vitana').
+--
+-- Snapshot: agent_persona_versions captures pre-change state for one-click
+-- rollback in the admin UI.
+
+DO $$
+DECLARE
+  r RECORD;
+  v_lock TEXT;
+  v_body_new TEXT;
+BEGIN
+  SELECT id, key, display_name, role, voice_id, system_prompt, version
+  INTO r
+  FROM public.agent_personas
+  WHERE key = 'devon';
+
+  IF r.id IS NULL THEN
+    RAISE NOTICE 'VTID-03039: Devon persona row not found; skipping.';
+    RETURN;
+  END IF;
+
+  -- Preserve the IDENTITY LOCK header (prepended 2026-05-02). Body that
+  -- follows is what we replace.
+  IF position('=== END IDENTITY LOCK ===' IN r.system_prompt) > 0 THEN
+    v_lock := substring(
+      r.system_prompt
+      FROM 1
+      FOR position('=== END IDENTITY LOCK ===' IN r.system_prompt) + length('=== END IDENTITY LOCK ===') - 1
+    ) || E'\n\n';
+  ELSE
+    v_lock := '';
+  END IF;
+
+  v_body_new := $BODY$You are Devon — Vitana's tech-support colleague. You handle bug reports and UX issues. You are calm, technical, focused.
+
+INTAKE CONTRACT (HARD RULES — re-read every turn):
+- Vitana ALREADY captured the user's bug brief BEFORE handing them to you. The brief is in the [HANDOFF NOTE] block of this prompt. Do NOT restart intake.
+- Ask AT MOST 2 short clarifying questions in this entire session. Two is the absolute ceiling — fewer is better, ZERO is best when the brief is clear.
+- Skip clarifying questions entirely if the brief already says what happened. Do NOT ask just to "be thorough." Do NOT walk through a checklist (repro steps, when first seen, frequency, screen, last action). The fix pipeline reads the ticket — your job is acknowledgement, not engineering interview.
+- After your at-most-2 questions (or immediately, if you ask none), confirm the ticket is logged, then ask the auto-return question.
+
+NEVER promise a fix timeline. NEVER debug code in front of the user. NEVER say "I'm creating a ticket" — the ticket already exists.$BODY$;
+
+  -- Snapshot before mutating.
+  INSERT INTO public.agent_persona_versions (persona_id, version, snapshot, change_note, created_by)
+  VALUES (
+    r.id,
+    r.version,
+    to_jsonb(r),
+    'VTID-03039: cap Devon clarifying questions at 2',
+    NULL
+  );
+
+  UPDATE public.agent_personas
+  SET system_prompt = v_lock || v_body_new,
+      version = version + 1,
+      updated_at = NOW()
+  WHERE id = r.id;
+END $$;


### PR DESCRIPTION
## Summary

Two user-reported bugs in the LiveKit Devon handover (German bug-report flow, 2026-05-17):

1. **Devon asked 50+ clarifying questions** before confirming the ticket. Three layers all under-specified the cap (DB seed "up to 6", uncapped handoff-brief block, unused `max_questions` column).
2. **Devon said a polite goodbye but never called `switch_persona`**, leaving the user stranded in Devon's voice. Plumbing is fine — the LLM treated "speak bridge + call tool" as either/or and picked the speech.

## What changed (Devon-scoped — Sage/Atlas/Mira deliberately untouched)

- `services/gateway/src/routes/orb-livekit.ts:1342` — `[HANDOFF NOTE]` block: replace "Then ask any clarifying question you need" with "AT MOST 2 short clarifying questions, ONLY if a critical detail is genuinely missing (skip them entirely if not)".
- `services/gateway/src/routes/orb-livekit.ts:1371-1383` — `[BEHAVIORAL RULE — swap back to Vitana]`: bridge sentence + `switch_persona` tool call are now stated as inseparable actions in a single turn. Adds a CRITICAL CONTRACT line with the anti-example `'"Thank you, have a nice day" by itself is a BUG'` to defeat the polite-goodbye-only failure mode.
- `supabase/migrations/20260524030000_VTID_03039_devon_question_cap.sql` — rewrite Devon's DB `system_prompt` body. IDENTITY LOCK header preserved verbatim. New body leans on Vitana's pre-handoff brief, hard-caps at 2 questions, drops the 8-field checklist. Snapshot captured to `agent_persona_versions` for one-click rollback.

## Test plan

- [x] `npm run build` (gateway) — green
- [x] `npm test -- --testPathPattern='orb'` — 713/713 pass
- [ ] **Post-merge — needs human voice smoke (mic required):** Re-run the German bug-report flow on LiveKit Test Bench:
  1. "Ich möchte einen Bug melden" + describe a real bug (≥12 words) + agree to Devon.
  2. Expect Devon to ask ≤ 2 clarifying questions (often 0).
  3. Expect Devon to confirm ticket + ask "Kann ich noch was für dich tun?"
  4. Say "Nein, danke."
  5. Expect Devon to say bridge sentence AND call `switch_persona('vitana')` in the same turn — Vitana's voice resumes.
- [ ] Verify oasis events after smoke: `orb.livekit.tool.switch_persona.called` + `voice.handoff.complete` (Devon → Vitana) should appear.

## Deploy order

1. Merge to `main`
2. Run `RUN-MIGRATION.yml` for `20260524030000_VTID_03039_devon_question_cap.sql` (grep logs for `ROLLBACK` before trusting — known silent-failure mode per memory).
3. Verify Devon's `system_prompt` in `agent_personas` starts with `=== IDENTITY LOCK ===` followed by the new INTAKE CONTRACT body.
4. `EXEC-DEPLOY` (gateway) — orb-livekit.ts changes go live.
5. No agent rebuild needed — agent reads `system_instruction` from `/orb/context-bootstrap` on every persona swap, so the new prompt flows in on the next handoff.

🤖 Generated with [Claude Code](https://claude.com/claude-code)