### PR TITLE
feat(orb-agent): provision Deepgram secret + add as 3rd STT fallback (VTID-03040)

### DIFF
--- a/.github/workflows/DEPLOY-ORB-AGENT.yml
+++ b/.github/workflows/DEPLOY-ORB-AGENT.yml
@@ -62,6 +62,49 @@ jobs:
       - name: Configure Docker for Artifact Registry
         run: gcloud auth configure-docker us-central1-docker.pkg.dev --quiet
 
+      # VTID-03040: provision DEEPGRAM_API_KEY in Secret Manager so the orb-agent
+      # can mount it as Cloud Run runtime env. Sync from the GH Actions secret
+      # of the same name (one source of truth). Idempotent — creates the secret
+      # on first run, adds a new version only when the GH value differs from
+      # what's in Secret Manager. The agent's _build_stt picks up the env at
+      # session start and adds Deepgram as the 3rd entry in the FallbackAdapter
+      # chain (after primary Google STT + same-provider mirror), breaking the
+      # all-Google correlation that produced the 50+ stalls in session
+      # 0adc6ff6 at 11:54-12:06 UTC on 2026-05-17.
+      - name: Sync DEEPGRAM_API_KEY into Secret Manager
+        env:
+          DEEPGRAM_API_KEY: ${{ secrets.DEEPGRAM_API_KEY }}
+        run: |
+          set -uo pipefail
+          if [ -z "${DEEPGRAM_API_KEY:-}" ]; then
+            echo "::warning::DEEPGRAM_API_KEY GH secret not set — skipping Secret Manager sync. Cross-provider STT fallback will NOT be active."
+            exit 0
+          fi
+          if ! gcloud secrets describe DEEPGRAM_API_KEY \
+               --project="$GCP_PROJECT_ID" >/dev/null 2>&1; then
+            echo "Secret DEEPGRAM_API_KEY does not exist — creating."
+            printf '%s' "$DEEPGRAM_API_KEY" | \
+              gcloud secrets create DEEPGRAM_API_KEY \
+                --data-file=- \
+                --replication-policy=automatic \
+                --project="$GCP_PROJECT_ID"
+          else
+            CURRENT_HASH=$(gcloud secrets versions access latest \
+              --secret=DEEPGRAM_API_KEY \
+              --project="$GCP_PROJECT_ID" 2>/dev/null \
+              | sha256sum | cut -d' ' -f1 || echo "absent")
+            NEW_HASH=$(printf '%s' "$DEEPGRAM_API_KEY" | sha256sum | cut -d' ' -f1)
+            if [ "$CURRENT_HASH" != "$NEW_HASH" ]; then
+              echo "DEEPGRAM_API_KEY value changed — adding new version."
+              printf '%s' "$DEEPGRAM_API_KEY" | \
+                gcloud secrets versions add DEEPGRAM_API_KEY \
+                  --data-file=- \
+                  --project="$GCP_PROJECT_ID"
+            else
+              echo "DEEPGRAM_API_KEY already in sync — no new version needed."
+            fi
+          fi
+
       - name: Build image
         working-directory: services/agents/orb-agent
         run: |
@@ -90,7 +133,7 @@ jobs:
             --ingress=all \
             --allow-unauthenticated \
             --labels=vtid=vtid-livekit-foundation,vt_layer=aicor,vt_module=voice \
-            --update-secrets=LIVEKIT_URL=LIVEKIT_URL:latest,LIVEKIT_API_KEY=LIVEKIT_API_KEY:latest,LIVEKIT_API_SECRET=LIVEKIT_API_SECRET:latest,GATEWAY_SERVICE_TOKEN=GATEWAY_SERVICE_TOKEN:latest \
+            --update-secrets=LIVEKIT_URL=LIVEKIT_URL:latest,LIVEKIT_API_KEY=LIVEKIT_API_KEY:latest,LIVEKIT_API_SECRET=LIVEKIT_API_SECRET:latest,GATEWAY_SERVICE_TOKEN=GATEWAY_SERVICE_TOKEN:latest,DEEPGRAM_API_KEY=DEEPGRAM_API_KEY:latest \
             --set-env-vars=GATEWAY_URL=https://gateway-q74ibpv6ia-uc.a.run.app,AGENT_LOG_LEVEL=INFO,AGENT_ENABLE_WORKER=1,GOOGLE_CLOUD_PROJECT=lovable-vitana-vers1,VERTEX_AI_LOCATION=us-central1,ORB_AGENT_TEXT_ONLY=false
 
       - name: Delete prior revisions (force only-latest worker connects to LiveKit)


### PR DESCRIPTION
## Summary

- Adds Deepgram as the 3rd entry in the FallbackAdapter chain so STT failover crosses vendors instead of relying on two correlated Google instances.
- Provisions DEEPGRAM_API_KEY in Secret Manager from the GH Actions secret of the same name (idempotent: create-or-add-version based on hash).
- Mounts the secret into the orb-agent Cloud Run via --update-secrets.

## Why

User session 0adc6ff6 at 11:54-12:06 UTC on 2026-05-17 showed 50+ stalls AFTER 4 healthy turns. cascade_built confirmed the VTID-03038 FallbackAdapter was wrapped, but with only 2 Google STT instances. Both share the same Cloud Speech endpoint + project quota + ADC — when Google rate-limits or hiccups, both fail together. FallbackAdapter has no working option to swap to.

A different vendor breaks the correlation.

## What changes
- services/agents/orb-agent/src/orb_agent/providers.py — NO CODE CHANGE. The agent's _build_stt already conditionally adds Deepgram when DEEPGRAM_API_KEY env is present (shipped in VTID-03038). This PR just lights up that path.
- .github/workflows/DEPLOY-ORB-AGENT.yml — new Sync DEEPGRAM_API_KEY step + --update-secrets mounts it into Cloud Run.

## Test plan
- [ ] Auto-deploy on merge runs without permission errors on Secret Manager.
- [ ] Cloud Run revision lists DEEPGRAM_API_KEY=DEEPGRAM_API_KEY:latest in its secret mounts.
- [ ] Next LiveKit session's cascade_built trace shows: `stt_fallback: added cross-provider deepgram` AND `stt_fallback: wrapped 3 instances in FallbackAdapter`.
- [ ] Long conversation completes without falling into the stall→loop after a successful first few turns.

## Known unknown
WIF service account may lack secretmanager.admin. If the Sync step fails, the step's error log tells the operator to grant the role; subsequent deploys then succeed. Fallback: the existing 2-instance Google chain stays active (no regression).

🤖 Generated with [Claude Code](https://claude.com/claude-code)