### PR TITLE
fix(orb-livekit): lift save_diary_entry to shared dispatcher (VTID-03042)

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/tools.py
+++ b/services/agents/orb-agent/src/orb_agent/tools.py
@@ -780,8 +780,21 @@ async def create_index_improvement_plan(context: RunContext, target_pillar: str)
 
 @function_tool
 async def save_diary_entry(context: RunContext, text: str) -> str:
-    """Save a diary entry. Triggers Vitana Index recompute via /memory/diary/sync-index (VTID-01983)."""
-    body = await _gw(context).post("/api/v1/memory/diary/sync-index", {"raw_text": text})
+    """Save a diary entry.
+
+    VTID-03042: switched from the legacy `/memory/diary/sync-index` call —
+    which runs the Vitana Index recompute pipeline but does NOT write the
+    user-visible `diary_entries` row — to the shared orb-tool dispatcher
+    so both pipelines:
+      1) insert the diary_entries row the user sees in their daily diary,
+      2) extract health features + recompute the Index,
+      3) celebrate any diary streak.
+
+    Without this, voice "log a diary entry" silently dropped the visible
+    row even though Vitana announced "I've logged it." (parity bug
+    surfaced in the L2.2b.7 real-mic German session, check #5.)
+    """
+    body = await _dispatch(context, "save_diary_entry", {"raw_text": text})
     return summarize(body)
 
 

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -3838,115 +3838,32 @@ async function executeLiveApiToolInner(
       }
 
       // ─── VTID-01983 — save_diary_entry: log a diary entry on user's behalf ───
+      // VTID-03042: lifted to services/orb-tools-shared.ts so the LiveKit
+      // pipeline writes the user-visible diary_entries row AND runs the
+      // extractor+index recompute through the same code path Vertex uses.
       case 'save_diary_entry': {
-        try {
-          const rawText = String(args.raw_text || '').trim();
-          const argDate = args.entry_date as string | undefined;
-          const entryDate = argDate && /^\d{4}-\d{2}-\d{2}$/.test(argDate)
-            ? argDate
-            : new Date().toISOString().slice(0, 10);
-          if (!rawText) {
-            return { success: false, result: '', error: 'INVALID_RAW_TEXT' };
-          }
-
-          const { extractHealthFeaturesFromDiary, persistDiaryHealthFeatures } = await import(
-            '../services/diary-health-extractor'
-          );
-          const { createClient } = await import('@supabase/supabase-js');
-          const url = process.env.SUPABASE_URL;
-          const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
-          if (!url || !key) return { success: false, result: '', error: 'Supabase not configured' };
-          const admin = createClient(url, key, { auth: { autoRefreshToken: false, persistSession: false } });
-
-          // 1) Insert into diary_entries (frontend-readable table). Best-effort —
-          //    if the row exists, we still proceed with the extractor.
-          try {
-            await admin.from('diary_entries').insert({
-              user_id: lens.user_id,
-              text: rawText,
-              source: 'voice',
-              tags: ['diary', 'voice', 'orb'],
-            });
-          } catch (insertErr: any) {
-            console.warn(`[save_diary_entry] diary_entries insert failed (non-fatal): ${insertErr?.message}`);
-          }
-
-          // 2) Read pre-recompute Index for delta math.
-          const { data: beforeRow } = await admin
-            .from('vitana_index_scores')
-            .select('score_total, score_nutrition, score_hydration, score_exercise, score_sleep, score_mental')
-            .eq('user_id', lens.user_id)
-            .eq('date', entryDate)
-            .maybeSingle();
-          const before = beforeRow as Record<string, number | null> | null;
-
-          // 3) Run extractor + persist.
-          const writes = extractHealthFeaturesFromDiary(rawText);
-          const tenantId = lens.tenant_id || '00000000-0000-0000-0000-000000000000';
-          let health_features_written = 0;
-          if (writes.length > 0) {
-            const { written } = await persistDiaryHealthFeatures(
-              admin,
-              lens.user_id,
-              tenantId,
-              entryDate,
-              writes,
-            );
-            health_features_written = written;
-          }
-
-          // 4) Recompute Index.
-          let pillars_after: Record<string, number> | null = null;
-          try {
-            const { data: rec } = await admin.rpc('health_compute_vitana_index_for_user', {
-              p_user_id: lens.user_id,
-              p_date: entryDate,
-            });
-            const r = rec as any;
-            if (r && r.ok !== false) {
-              pillars_after = {
-                total:     Number(r.score_total     ?? 0),
-                nutrition: Number(r.score_nutrition ?? 0),
-                hydration: Number(r.score_hydration ?? 0),
-                exercise:  Number(r.score_exercise  ?? 0),
-                sleep:     Number(r.score_sleep     ?? 0),
-                mental:    Number(r.score_mental    ?? 0),
-              };
-            }
-          } catch (recErr: any) {
-            console.warn(`[save_diary_entry] Index recompute failed: ${recErr?.message}`);
-          }
-
-          const index_delta = pillars_after ? {
-            total:     pillars_after.total     - Number(before?.score_total     ?? 0),
-            nutrition: pillars_after.nutrition - Number(before?.score_nutrition ?? 0),
-            hydration: pillars_after.hydration - Number(before?.score_hydration ?? 0),
-            exercise:  pillars_after.exercise  - Number(before?.score_exercise  ?? 0),
-            sleep:     pillars_after.sleep     - Number(before?.score_sleep     ?? 0),
-            mental:    pillars_after.mental    - Number(before?.score_mental    ?? 0),
-          } : null;
-
-          // H.5 — diary streak celebration (best-effort, non-blocking).
-          const { celebrateDiaryStreak } = await import('../services/diary-streak-celebrator');
-          const streak = await celebrateDiaryStreak(admin, lens.user_id, tenantId);
-
-          console.log(`[save_diary_entry] user=${lens.user_id.slice(0, 8)} features=${health_features_written} delta_total=${index_delta?.total ?? 0} streak=${streak ? streak.tier_days : '-'}`);
-
-          return {
-            success: true,
-            result: JSON.stringify({
-              ok: true,
-              entry_date: entryDate,
-              health_features_written,
-              pillars_after,
-              index_delta,
-              streak,
-            }),
-          };
-        } catch (err: any) {
-          console.error('[save_diary_entry] error:', err?.message);
-          return { success: false, result: '', error: err?.message || 'unknown' };
+        const SUPABASE_URL = process.env.SUPABASE_URL;
+        const SUPABASE_SERVICE_ROLE =
+          process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+        if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
+          return { success: false, result: '', error: 'Service unavailable — Supabase creds not configured' };
         }
+        const { createClient } = await import('@supabase/supabase-js');
+        const supabase = createClient(SUPABASE_URL, SUPABASE_SERVICE_ROLE, {
+          auth: { autoRefreshToken: false, persistSession: false },
+        });
+        const { dispatchOrbToolForVertex } = await import('../services/orb-tools-shared');
+        return await dispatchOrbToolForVertex(
+          'save_diary_entry',
+          args ?? {},
+          {
+            user_id: lens.user_id,
+            tenant_id: lens.tenant_id ?? null,
+            role: session.identity?.role ?? null,
+            vitana_id: session.identity?.vitana_id ?? null,
+          },
+          supabase,
+        );
       }
 
       // ─── VTID-02601 — set_reminder: voice-create a one-shot reminder ───

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -3189,6 +3189,167 @@ async function tool_get_pillar_subscores(
 }
 
 // ---------------------------------------------------------------------------
+// VTID-03042 — save_diary_entry
+//
+// Lifted from orb-live.ts case 'save_diary_entry' (VTID-01983) so the
+// LiveKit pipeline can call the canonical write flow instead of the agent's
+// previous direct hit to /memory/diary/sync-index. The sync-index endpoint
+// only runs the health-feature extractor + Index recompute — it explicitly
+// does NOT write the user-visible `diary_entries` row (memory.ts:1776 says
+// so). LiveKit's tool therefore had Vitana announce "I logged it" while no
+// diary row was ever created, so the user saw nothing in the daily diary.
+//
+// This shared handler does the full Vertex flow:
+//   1) insert diary_entries (user-visible)
+//   2) read pre-recompute Index for delta math
+//   3) extract health features + persist
+//   4) recompute Vitana Index
+//   5) compute per-pillar delta
+//   6) celebrate diary streak (non-blocking)
+// ---------------------------------------------------------------------------
+export async function tool_save_diary_entry(
+  args: OrbToolArgs,
+  identity: OrbToolIdentity,
+  sb: SupabaseClient,
+): Promise<OrbToolResult> {
+  const rawText = typeof args.raw_text === 'string' ? args.raw_text.trim() : '';
+  if (!rawText) {
+    return { ok: false, error: 'raw_text is required' };
+  }
+  if (!identity.user_id) {
+    return { ok: false, error: 'user_id is required' };
+  }
+
+  const argDate = typeof args.entry_date === 'string' ? args.entry_date : undefined;
+  const entryDate = argDate && /^\d{4}-\d{2}-\d{2}$/.test(argDate)
+    ? argDate
+    : new Date().toISOString().slice(0, 10);
+
+  // 1) diary_entries insert — best-effort. If it fails we still proceed with
+  // the extractor/index so the Index reflects the user's words.
+  let diary_entry_written = true;
+  try {
+    const { error: insertErr } = await sb.from('diary_entries').insert({
+      user_id: identity.user_id,
+      text: rawText,
+      source: 'voice',
+      tags: ['diary', 'voice', 'orb'],
+    });
+    if (insertErr) {
+      diary_entry_written = false;
+      console.warn(
+        `[save_diary_entry] diary_entries insert failed (non-fatal): ${insertErr.message}`,
+      );
+    }
+  } catch (insertErr) {
+    diary_entry_written = false;
+    console.warn(
+      `[save_diary_entry] diary_entries insert exception (non-fatal): ${(insertErr as Error).message}`,
+    );
+  }
+
+  // 2) Pre-recompute Index for delta math.
+  const { data: beforeRow } = await sb
+    .from('vitana_index_scores')
+    .select('score_total, score_nutrition, score_hydration, score_exercise, score_sleep, score_mental')
+    .eq('user_id', identity.user_id)
+    .eq('date', entryDate)
+    .maybeSingle();
+  const before = beforeRow as Record<string, number | null> | null;
+
+  // 3) Extract health features + persist.
+  const { extractHealthFeaturesFromDiary, persistDiaryHealthFeatures } = await import(
+    './diary-health-extractor'
+  );
+  const writes = extractHealthFeaturesFromDiary(rawText);
+  const tenantId = identity.tenant_id || '00000000-0000-0000-0000-000000000000';
+  let health_features_written = 0;
+  if (writes.length > 0) {
+    const { written } = await persistDiaryHealthFeatures(
+      sb,
+      identity.user_id,
+      tenantId,
+      entryDate,
+      writes,
+    );
+    health_features_written = written;
+  }
+
+  // 4) Recompute Index.
+  let pillars_after: Record<string, number> | null = null;
+  try {
+    const { data: rec } = await sb.rpc('health_compute_vitana_index_for_user', {
+      p_user_id: identity.user_id,
+      p_date: entryDate,
+    });
+    const r = rec as { ok?: boolean; [k: string]: unknown } | null;
+    if (r && r.ok !== false) {
+      pillars_after = {
+        total: Number(r.score_total ?? 0),
+        nutrition: Number(r.score_nutrition ?? 0),
+        hydration: Number(r.score_hydration ?? 0),
+        exercise: Number(r.score_exercise ?? 0),
+        sleep: Number(r.score_sleep ?? 0),
+        mental: Number(r.score_mental ?? 0),
+      };
+    }
+  } catch (recErr) {
+    console.warn(
+      `[save_diary_entry] Index recompute failed (non-fatal): ${(recErr as Error).message}`,
+    );
+  }
+
+  // 5) Per-pillar delta.
+  const index_delta = pillars_after
+    ? {
+        total: pillars_after.total - Number(before?.score_total ?? 0),
+        nutrition: pillars_after.nutrition - Number(before?.score_nutrition ?? 0),
+        hydration: pillars_after.hydration - Number(before?.score_hydration ?? 0),
+        exercise: pillars_after.exercise - Number(before?.score_exercise ?? 0),
+        sleep: pillars_after.sleep - Number(before?.score_sleep ?? 0),
+        mental: pillars_after.mental - Number(before?.score_mental ?? 0),
+      }
+    : null;
+
+  // 6) Streak celebration (best-effort).
+  let streak: Awaited<ReturnType<typeof import('./diary-streak-celebrator').celebrateDiaryStreak>> | null = null;
+  try {
+    const { celebrateDiaryStreak } = await import('./diary-streak-celebrator');
+    streak = await celebrateDiaryStreak(sb, identity.user_id, tenantId);
+  } catch (streakErr) {
+    console.warn(
+      `[save_diary_entry] streak celebrate failed (non-fatal): ${(streakErr as Error).message}`,
+    );
+  }
+
+  console.log(
+    `[save_diary_entry] user=${identity.user_id.slice(0, 8)} features=${health_features_written} delta_total=${index_delta?.total ?? 0} diary_row=${diary_entry_written}`,
+  );
+
+  // Voice-friendly text. The LLM hears this; the structured fields are
+  // available on `result` for non-spoken consumers (cockpit / orb-tool route).
+  const deltaPhrase =
+    index_delta && index_delta.total > 0
+      ? ` Your Vitana Index moved up ${index_delta.total}.`
+      : '';
+  const text = `Diary entry logged for ${entryDate}.${deltaPhrase}`;
+
+  return {
+    ok: true,
+    result: {
+      ok: true,
+      entry_date: entryDate,
+      diary_entry_written,
+      health_features_written,
+      pillars_after,
+      index_delta,
+      streak,
+    },
+    text,
+  };
+}
+
+// ---------------------------------------------------------------------------
 // VTID-02830 — Find Perfect flagships (deep marketplace + practitioner search)
 //
 // Both tools fuse the user's weakest Vitana Index pillar + active Life Compass
@@ -3603,6 +3764,10 @@ export const ORB_TOOL_REGISTRY: Record<string, OrbToolHandler> = {
   log_exercise:     (args, id, sb) => tool_log_health('log_exercise', args, id),
   log_meditation:   (args, id, sb) => tool_log_health('log_meditation', args, id),
   get_pillar_subscores: tool_get_pillar_subscores,
+  // VTID-03042 — save_diary_entry: writes diary_entries (user-visible) +
+  // runs the health-feature extractor + Vitana Index recompute. Both
+  // pipelines now go through this shared handler.
+  save_diary_entry: tool_save_diary_entry,
   play_music: tool_play_music,
   set_capability_preference: tool_set_capability_preference,
   read_email: tool_read_email,

--- a/services/gateway/test/save-diary-entry-shared.test.ts
+++ b/services/gateway/test/save-diary-entry-shared.test.ts
@@ -1,0 +1,243 @@
+/**
+ * VTID-03042: save_diary_entry lifted to shared dispatcher.
+ *
+ * Closes the L2.2b.7 parity gap reported during the German real-mic test
+ * (check #5): LiveKit's agent tool was calling /memory/diary/sync-index,
+ * which ONLY runs the health-feature extractor + Vitana Index recompute
+ * — it does NOT write the user-visible `diary_entries` row. So Vitana
+ * announced "I logged your diary" while the user saw no entry in their
+ * daily diary. This handler ports Vertex's inline flow into the shared
+ * dispatcher so both pipelines:
+ *   1) insert diary_entries (the row the user actually sees),
+ *   2) extract health features + persist,
+ *   3) recompute the Vitana Index,
+ *   4) celebrate any streak.
+ *
+ * These tests pin the contract:
+ *   1. Happy path: diary_entries insert called, RPC called, OK returned.
+ *   2. Insert failure is non-fatal — the extractor + RPC still run.
+ *   3. Empty raw_text returns ok:false without touching the DB.
+ *   4. Missing user_id returns ok:false.
+ *   5. Result text is voice-friendly and mentions the entry_date.
+ *   6. Index delta calculation uses pre-row vs post-RPC pillars.
+ *   7. Registered in ORB_TOOL_REGISTRY so dispatchOrbTool routes to it.
+ */
+
+process.env.NODE_ENV = 'test';
+process.env.SUPABASE_URL = 'http://supabase.test';
+process.env.SUPABASE_SERVICE_ROLE = 'test-service-role';
+
+// Mock the diary-health-extractor + streak-celebrator BEFORE the import so
+// the dynamic `await import('./diary-health-extractor')` inside the handler
+// picks up the stubs.
+jest.mock('../src/services/diary-health-extractor', () => ({
+  extractHealthFeaturesFromDiary: jest.fn(() => []),
+  persistDiaryHealthFeatures: jest.fn(async () => ({ written: 0 })),
+}));
+jest.mock('../src/services/diary-streak-celebrator', () => ({
+  celebrateDiaryStreak: jest.fn(async () => null),
+}));
+
+import {
+  ORB_TOOL_REGISTRY,
+  dispatchOrbTool,
+  tool_save_diary_entry,
+} from '../src/services/orb-tools-shared';
+
+const USER_UUID = '11111111-1111-4111-8111-111111111111';
+const TENANT_UUID = '22222222-2222-4222-8222-222222222222';
+
+interface DbCall {
+  table: string;
+  op: 'insert' | 'select' | 'rpc';
+  payload?: unknown;
+}
+
+function makeStubSupabase(opts: {
+  diaryInsertError?: { message: string } | null;
+  preIndexRow?: Record<string, number> | null;
+  rpcReturn?: { data: unknown; error?: { message: string } | null };
+}) {
+  const calls: DbCall[] = [];
+  return {
+    from(table: string) {
+      if (table === 'diary_entries') {
+        return {
+          insert: async (row: Record<string, unknown>) => {
+            calls.push({ table, op: 'insert', payload: row });
+            return { error: opts.diaryInsertError ?? null };
+          },
+        };
+      }
+      if (table === 'vitana_index_scores') {
+        return {
+          select: () => ({
+            eq: () => ({
+              eq: () => ({
+                maybeSingle: async () => {
+                  calls.push({ table, op: 'select' });
+                  return { data: opts.preIndexRow ?? null, error: null };
+                },
+              }),
+            }),
+          }),
+        };
+      }
+      return {} as never;
+    },
+    async rpc(name: string, args: unknown) {
+      calls.push({ table: 'rpc', op: 'rpc', payload: { name, args } });
+      return opts.rpcReturn ?? { data: null, error: null };
+    },
+    _calls: calls,
+  };
+}
+
+const identity = {
+  user_id: USER_UUID,
+  tenant_id: TENANT_UUID,
+  role: 'community',
+  vitana_id: null,
+};
+
+describe('VTID-03042 — save_diary_entry lifted to shared dispatcher', () => {
+  test('1. happy path: inserts diary_entries + calls index RPC + returns ok', async () => {
+    const sb = makeStubSupabase({
+      preIndexRow: {
+        score_total: 100,
+        score_nutrition: 20,
+        score_hydration: 20,
+        score_exercise: 20,
+        score_sleep: 20,
+        score_mental: 20,
+      },
+      rpcReturn: {
+        data: {
+          ok: true,
+          score_total: 120,
+          score_nutrition: 24,
+          score_hydration: 24,
+          score_exercise: 24,
+          score_sleep: 24,
+          score_mental: 24,
+        },
+      },
+    });
+    const result = await tool_save_diary_entry(
+      { raw_text: 'I meditated for twenty minutes and drank two liters of water.' },
+      identity,
+      sb as never,
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok !== true) return;
+    expect(sb._calls.some((c) => c.table === 'diary_entries' && c.op === 'insert')).toBe(true);
+    expect(sb._calls.some((c) => c.op === 'rpc')).toBe(true);
+    const r = result.result as { entry_date: string; diary_entry_written: boolean; index_delta: { total: number } | null };
+    expect(r.diary_entry_written).toBe(true);
+    expect(r.index_delta?.total).toBe(20); // 120 - 100
+    // YYYY-MM-DD pattern, computed from today.
+    expect(r.entry_date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+  });
+
+  test('2. diary_entries insert failure is non-fatal — RPC still runs, result still ok', async () => {
+    const sb = makeStubSupabase({
+      diaryInsertError: { message: 'RLS denied' },
+      preIndexRow: null,
+      rpcReturn: { data: { ok: true, score_total: 100 } },
+    });
+    const result = await tool_save_diary_entry(
+      { raw_text: 'Walked for thirty minutes this afternoon, felt great.' },
+      identity,
+      sb as never,
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok !== true) return;
+    const r = result.result as { diary_entry_written: boolean };
+    expect(r.diary_entry_written).toBe(false);
+    expect(sb._calls.some((c) => c.op === 'rpc')).toBe(true); // still called
+  });
+
+  test('3. empty raw_text returns ok:false without touching the DB', async () => {
+    const sb = makeStubSupabase({});
+    const result = await tool_save_diary_entry({ raw_text: '   ' }, identity, sb as never);
+    expect(result.ok).toBe(false);
+    if (result.ok !== false) return;
+    expect(result.error).toMatch(/raw_text/i);
+    expect(sb._calls).toHaveLength(0);
+  });
+
+  test('4. missing user_id returns ok:false without touching the DB', async () => {
+    const sb = makeStubSupabase({});
+    const result = await tool_save_diary_entry(
+      { raw_text: 'A reasonable diary entry of the right length.' },
+      { ...identity, user_id: '' },
+      sb as never,
+    );
+    expect(result.ok).toBe(false);
+    if (result.ok !== false) return;
+    expect(result.error).toMatch(/user_id/i);
+    expect(sb._calls).toHaveLength(0);
+  });
+
+  test('5. text is voice-friendly and mentions the entry_date', async () => {
+    const sb = makeStubSupabase({
+      preIndexRow: null,
+      rpcReturn: { data: { ok: true, score_total: 50 } },
+    });
+    const result = await tool_save_diary_entry(
+      { raw_text: 'Slept seven hours, well rested.' },
+      identity,
+      sb as never,
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok !== true) return;
+    expect(typeof result.text).toBe('string');
+    expect(result.text).toMatch(/Diary entry logged for \d{4}-\d{2}-\d{2}/);
+  });
+
+  test('6. entry_date arg passes through when valid; otherwise defaults to today', async () => {
+    const sb = makeStubSupabase({
+      preIndexRow: null,
+      rpcReturn: { data: { ok: true, score_total: 50 } },
+    });
+    const result = await tool_save_diary_entry(
+      { raw_text: 'A solid entry for yesterday.', entry_date: '2026-04-01' },
+      identity,
+      sb as never,
+    );
+    expect(result.ok).toBe(true);
+    if (result.ok !== true) return;
+    const r = result.result as { entry_date: string };
+    expect(r.entry_date).toBe('2026-04-01');
+
+    // Invalid format falls back to today.
+    const sb2 = makeStubSupabase({
+      preIndexRow: null,
+      rpcReturn: { data: { ok: true, score_total: 50 } },
+    });
+    const result2 = await tool_save_diary_entry(
+      { raw_text: 'Another entry.', entry_date: 'not-a-date' },
+      identity,
+      sb2 as never,
+    );
+    if (result2.ok !== true) return;
+    const r2 = result2.result as { entry_date: string };
+    expect(r2.entry_date).toMatch(/^\d{4}-\d{2}-\d{2}$/);
+    expect(r2.entry_date).not.toBe('not-a-date');
+  });
+
+  test('7. registered in ORB_TOOL_REGISTRY and routes via dispatchOrbTool', async () => {
+    expect(ORB_TOOL_REGISTRY.save_diary_entry).toBe(tool_save_diary_entry);
+    const sb = makeStubSupabase({
+      preIndexRow: null,
+      rpcReturn: { data: { ok: true, score_total: 50 } },
+    });
+    const result = await dispatchOrbTool(
+      'save_diary_entry',
+      { raw_text: 'Did some yoga and meditation today, twenty minutes total.' },
+      identity,
+      sb as never,
+    );
+    expect(result.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Summary

Closes the L2.2b.7 parity gap surfaced in the German real-mic test (check #5: "said it entered, but no entry in my daily diary").

## Root cause

LiveKit's agent `save_diary_entry` called `POST /api/v1/memory/diary/sync-index` — a lightweight "companion" endpoint frontends use AFTER they've already written the `diary_entries` row. Its docstring at [memory.ts:1776](services/gateway/src/routes/memory.ts#L1776) explicitly says it runs the extractor + Index recompute **without** writing `diary_entries`. Vertex's tool writes the row inline first; LiveKit's didn't write it at all. So "I logged your entry" landed only the Index update — the row in the user's daily diary never existed.

## Fix

Lift Vertex's inline handler (`orb-live.ts` case 'save_diary_entry') into `tool_save_diary_entry` in `services/orb-tools-shared.ts` and register it in `ORB_TOOL_REGISTRY`. Both pipelines now run the same five steps:

1. insert `diary_entries` (user-visible row, voice/orb-tagged)
2. read pre-recompute Index for delta math
3. extract health features + persist
4. recompute Vitana Index
5. celebrate any diary streak (non-blocking)

Vertex's case arm becomes a one-line `dispatchOrbToolForVertex` call. The agent's tool body switches from `/memory/diary/sync-index` to `/api/v1/orb/tool` with `name=save_diary_entry`.

Reinforces the VTID-03037 architectural rule: fix parity gaps at the deepest shared layer, not at the route — both pipelines benefit by construction.

## Test plan
- [x] +7 unit tests on `tool_save_diary_entry` (happy path, non-fatal insert failure, empty raw_text guard, missing user_id guard, voice-friendly text, entry_date validation, registry routing) all pass
- [x] 713 orb tests still green
- [x] Pre-existing diary.test.ts flake ("extraction result with relationship signals") confirmed failing on main too — unrelated
- [ ] Post-deploy: real-mic German session, say "trag bitte ein dass ich heute meditiert habe" → verify a new row appears in the user's daily diary

🤖 Generated with [Claude Code](https://claude.com/claude-code)