### PR TITLE
fix(orb-agent): cap persona-rebuild aclose at 3s to unblock handoff (VTID-03045)

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -1340,12 +1340,29 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
             pass
 
         # Close the current session so its audio stream stops cleanly.
+        # VTID-03045: bounded wait. Session 0adc6ff6 on 2026-05-17 14:23 UTC
+        # hit a 9-minute aclose() hang on a healthy multi-instance FallbackAdapter
+        # session after Devon handoff signal — the old session never returned
+        # from close, the new session never started, the room was effectively
+        # dead. asyncio.wait_for caps the cleanup window at 3s; on timeout we
+        # forfeit graceful tear-down and move on. The room's audio-track
+        # cleanup is handled by LiveKit regardless of whether the AgentSession
+        # closed cleanly, so the worst case is a couple of orphaned coroutines
+        # for the rest of this entrypoint's lifetime (which ends shortly when
+        # the user disconnects). Better than a frozen room.
         try:
             close_method = getattr(session, "aclose", None) or getattr(session, "close", None)
             if close_method is not None:
                 res = close_method()
                 if asyncio.iscoroutine(res):
-                    await res
+                    try:
+                        await asyncio.wait_for(res, timeout=3.0)
+                    except asyncio.TimeoutError:
+                        logger.warning(
+                            "agent_entrypoint: session.aclose did not return in 3s — "
+                            "continuing with persona rebuild, leaving the old session "
+                            "to be reclaimed by GC (VTID-03045 mitigation)"
+                        )
         except Exception as exc:  # noqa: BLE001
             logger.warning("agent_entrypoint: session.aclose failed: %s", exc)
 


### PR DESCRIPTION
## Summary
- 5-minute mitigation for the handoff hang seen in session 0adc6ff6 at 14:23 UTC.
- Wraps await session.aclose() in asyncio.wait_for(timeout=3s) inside the persona-rebuild loop.
- On timeout we proceed to build the new session anyway; LiveKit handles audio-track cleanup at the room level.

## Why
After VTID-03038/41 made the in-session STT cascade resilient, conversations now reach further into the flow before breaking — exposing this downstream rebuild hang more visibly. The pre-fix sessions died on STT correlation before reaching specialist handoffs.

## Follow-up
Architectural fix in a separate PR: replace the full session-rebuild with an in-place Agent swap (no aclose needed at all).

## Test plan
- [ ] Auto-deploy succeeds
- [ ] Next session with specialist handoff completes without 9-minute hang; voice.handoff.start + voice.handoff.complete events emit

🤖 Generated with [Claude Code](https://claude.com/claude-code)