### PR TITLE
feat(orb-agent): per-turn latency telemetry (VTID-03046)

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/oasis.py
+++ b/services/agents/orb-agent/src/orb_agent/oasis.py
@@ -143,3 +143,11 @@ TOPIC_AGENT_DISCONNECTED = "orb.livekit.agent.disconnected"
 TOPIC_AGENT_MODEL_REQUEST_STARTED = "orb.livekit.agent.model_request_started"
 TOPIC_AGENT_MODEL_REQUEST_SUCCEEDED = "orb.livekit.agent.model_request_succeeded"
 TOPIC_AGENT_MODEL_REQUEST_FAILED = "orb.livekit.agent.model_request_failed"
+
+# VTID-03046: per-turn diagnostic. Captures the gap between STT-finalize
+# (user_input_transcribed) and the agent's speech_created event — the
+# wall-clock "wait after the user stops talking" the user actually feels.
+# Payload also carries `system_instruction_chars` so we can correlate
+# per-turn latency with prompt size and prove (or disprove) that
+# system_instruction growth is what slowed the cascade after 2026-05-16.
+TOPIC_AGENT_TURN_MEASURED = "orb.livekit.agent.turn.measured"

--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -43,6 +43,7 @@ from .oasis import (
     TOPIC_AGENT_ROOM_JOIN_STARTED,
     TOPIC_AGENT_ROOM_JOIN_SUCCEEDED,
     TOPIC_AGENT_STARTING,
+    TOPIC_AGENT_TURN_MEASURED,
     TOPIC_HANDOFF_COMPLETE,
     TOPIC_HANDOFF_START,
     TOPIC_PERSONA_SWAP,
@@ -108,7 +109,7 @@ def _get_vad() -> Any:
     return _SHARED_VAD
 
 
-CODE_VERSION = "agent-2026-05-16-vtid-03014-localized-greeting"
+CODE_VERSION = "agent-2026-05-17-vtid-03046-turn-telemetry"
 
 
 # VTID-03014: localized first-greeting templates. session.say() speaks the
@@ -797,6 +798,22 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     model_turns_counter = {"n": 0}
     stall_count = {"n": 0}
 
+    # VTID-03046: per-turn latency state. user_input_transcribed sets
+    # `user_done_at` and `user_text_len`; the next speech_created reads them,
+    # computes the wait gap, and emits orb.livekit.agent.turn.measured. We
+    # carry `system_instruction_chars` (the rendered prompt size) as a
+    # constant so every emit can correlate latency with prompt size — that's
+    # the whole point of this diagnostic. Cleared on emit so a duplicate
+    # speech_created (handover etc.) doesn't re-fire with stale numbers.
+    turn_state: dict[str, Any] = {
+        "index": 0,
+        "user_done_at": None,
+        "user_text_len": 0,
+        "system_instruction_chars": len(
+            getattr(bootstrap, "system_instruction", None) or ""
+        ),
+    }
+
     async def _teardown() -> None:
         # L2.2b.1: emit the lifecycle `disconnected` event FIRST (it pairs
         # with the room_join_succeeded event from session start). The
@@ -1100,6 +1117,32 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
                     },
                 )
             )
+            # VTID-03046: per-turn measurement. Only emit if we have a
+            # paired user_input_transcribed timestamp — skips the initial
+            # greeting (session.say at room-join, no preceding user turn).
+            # Null the timestamp on read so a follow-up speech_created in
+            # the same turn (e.g. tool-loop continuation) doesn't re-fire.
+            user_done = turn_state.get("user_done_at")
+            if user_done is not None:
+                wait_ms = int((time.monotonic() - user_done) * 1000)
+                turn_state["index"] += 1
+                payload = {
+                    "user_id": identity.user_id or "unknown",
+                    "code_version": CODE_VERSION,
+                    "room_name": _room_name or "",
+                    "orb_session_id": orb_session_id,
+                    "turn_index": turn_state["index"],
+                    "user_text_len": turn_state.get("user_text_len", 0),
+                    "stt_done_to_speech_created_ms": wait_ms,
+                    "system_instruction_chars": turn_state.get(
+                        "system_instruction_chars", 0,
+                    ),
+                }
+                turn_state["user_done_at"] = None
+                turn_state["user_text_len"] = 0
+                asyncio.create_task(
+                    oasis.emit(topic=TOPIC_AGENT_TURN_MEASURED, payload=payload),
+                )
     except Exception as exc:  # noqa: BLE001
         logger.warning("could not hook speech_created: %s", exc)
 
@@ -1115,6 +1158,23 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     def _on_user_transcribed(_ev: Any = None) -> None:
         user_turns_counter["n"] += 1
         stall.feed()
+        # VTID-03046: mark the moment STT considered the user's turn
+        # complete. Paired with the next speech_created in _on_speech
+        # above. Capture transcript length defensively — the field name
+        # varies across livekit-agents versions.
+        turn_state["user_done_at"] = time.monotonic()
+        text_len = 0
+        try:
+            t = (
+                getattr(_ev, "transcript", None)
+                or getattr(_ev, "text", None)
+                or ""
+            )
+            if isinstance(t, str):
+                text_len = len(t)
+        except Exception:  # noqa: BLE001
+            pass
+        turn_state["user_text_len"] = text_len
         # VTID-03001: also surface the event in the trace firehose so we
         # can see STT completing user turns even when no audible agent
         # response follows. Pairs with agent_state_changed below to map

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -565,6 +565,12 @@ export type CicdEventType =
   | 'orb.livekit.agent.model_request_started'
   | 'orb.livekit.agent.model_request_succeeded'
   | 'orb.livekit.agent.model_request_failed'
+  // VTID-03046: per-turn LiveKit-agent latency telemetry. Fires once per
+  // user-then-assistant exchange, with `stt_done_to_speech_created_ms`
+  // (wall-clock wait after the user stops talking) and
+  // `system_instruction_chars` so we can correlate latency with prompt
+  // size. Pure additive — no behavior change to the voice path.
+  | 'orb.livekit.agent.turn.measured'
   // VTID-DIAG: Pipeline diagnostics
   | 'orb.live.diag'
   // VTID-FALLBACK: Chat-TTS fallback events


### PR DESCRIPTION
## Summary

Diagnostic precursor to step 2 (per-turn LLM-prompt trim). User reported on 2026-05-17 that LiveKit answering responses arrive later than ever. The likely cause is the rendered `system_instruction` growing from ~65KB → ~100KB across the last 48h via PR #2137 (LiveKit prompt parity) and PR #2169 (memory + last-3 turns + USER CONTEXT PROFILE added to bootstrap_context). Gemini Flash TTFT scales with input size.

**This PR adds telemetry only.** Voice path is untouched.

## What it emits

Topic `orb.livekit.agent.turn.measured`, one event per user→assistant exchange. Payload:
- `stt_done_to_speech_created_ms` — wall-clock wait the user feels
- `system_instruction_chars` — the constant that correlates with TTFB
- `turn_index`, `user_text_len`, `user_id`, `code_version`, `room_name`, `orb_session_id`

Signal flow:
1. STT finalizes → `user_input_transcribed` stamps `time.monotonic()` into `turn_state`.
2. Agent speaks → `speech_created` reads the stamp, computes the gap, fires `oasis.emit(...)`, nulls the stamp so handover / tool-loop continuations don't re-emit. Initial `session.say()` greeting is skipped (no preceding user turn).

## Stability

- Fire-and-forget emit; the emitter swallows network errors and never raises.
- Same closure-over-dict pattern as the existing `user_turns_counter` / `model_turns_counter`.
- No dispatch / token / STT / LLM / TTS code touched.
- **A mid-conversation disconnect cannot originate here.**

## Verification

1. EXEC-DEPLOY (gateway type union) + DEPLOY-ORB-AGENT (agent image) green.
2. New `code_version` stamp `agent-2026-05-17-vtid-03046-turn-telemetry` visible on next lifecycle event.
3. User runs a LiveKit session, asks ~3 questions.
4. `GET /api/v1/oasis/events?topic=orb.livekit.agent.turn.measured&limit=20` returns one event per question with `stt_done_to_speech_created_ms` and `system_instruction_chars ≈ 100864`.

## Test plan
- [ ] Gateway tsc green (verified locally)
- [ ] Python syntax clean (verified locally via `python -m py_compile`)
- [ ] After DEPLOY-ORB-AGENT, query `orb.livekit.agent.turn.measured` events and confirm payload shape

🤖 Generated with [Claude Code](https://claude.com/claude-code)