### PR TITLE
fix(orb-livekit): mirror Vertex persona-rule + restore Vitana prompt (VTID-03047)

### DIFF
--- a/.github/workflows/DIAGNOSE-AUTOPILOT.yml
+++ b/.github/workflows/DIAGNOSE-AUTOPILOT.yml
@@ -1,0 +1,59 @@
+name: Diagnose Autopilot Runtime
+
+on:
+  workflow_dispatch:
+
+jobs:
+  diag:
+    runs-on: ubuntu-latest
+    permissions:
+      id-token: write
+      contents: read
+    steps:
+      - uses: google-github-actions/auth@v2
+        with:
+          workload_identity_provider: ${{ secrets.GCP_WIF_PROVIDER }}
+          service_account: ${{ secrets.GCP_WIF_SA_EMAIL }}
+          project_id: lovable-vitana-vers1
+
+      - uses: google-github-actions/setup-gcloud@v2
+
+      - name: Gateway env vars (look for DEV_AUTOPILOT_*)
+        run: |
+          set -e
+          echo "=== Gateway service: latest revision env (autopilot/job-related only) ==="
+          gcloud run services describe gateway \
+            --region=us-central1 --project=lovable-vitana-vers1 \
+            --format=json | jq -r '.spec.template.spec.containers[0].env[] | select(.name|test("AUTOPILOT|JOB|VERTEX|GCP_PROJECT|WORKER")) | "\(.name)=\(.value // "<secret>")"'
+          echo
+          echo "=== Gateway runtime SA + image ==="
+          gcloud run services describe gateway \
+            --region=us-central1 --project=lovable-vitana-vers1 \
+            --format='value(spec.template.spec.serviceAccountName,spec.template.spec.containers[0].image)'
+
+      - name: autopilot-executor Job state
+        run: |
+          set -e
+          echo "=== Job describe ==="
+          gcloud run jobs describe autopilot-executor \
+            --region=us-central1 --project=lovable-vitana-vers1 \
+            --format='value(name,creationTimestamp,spec.template.spec.template.spec.containers[0].image,spec.template.spec.template.spec.timeoutSeconds)' || echo "JOB NOT FOUND"
+          echo
+          echo "=== Job IAM bindings (run.invoker?) ==="
+          gcloud run jobs get-iam-policy autopilot-executor \
+            --region=us-central1 --project=lovable-vitana-vers1 \
+            --format=json | jq '.bindings'
+          echo
+          echo "=== Recent Job executions ==="
+          gcloud run jobs executions list \
+            --job=autopilot-executor --region=us-central1 --project=lovable-vitana-vers1 \
+            --limit=10 --format='table(name,creationTimestamp,completionTime,succeededCount,failedCount)' || echo "no executions"
+
+      - name: Try dispatching a test execution
+        run: |
+          set -e
+          echo "=== Try dispatch autopilot-executor with EXEC_ID=DIAG ==="
+          gcloud run jobs execute autopilot-executor \
+            --region=us-central1 --project=lovable-vitana-vers1 \
+            --update-env-vars=EXEC_ID=DIAG-NOOP \
+            --wait=false 2>&1 || echo "DISPATCH FAILED"

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1438,7 +1438,7 @@ const LIVE_CONTEXT_CONFIG = {
 // any agent can discuss any ticket; only action is scoped via the per-ticket
 // `owner` field. Time-to-resolution is the explicit KPI.
 
-async function fetchSpecialistContextSection(userId: string | null | undefined): Promise<string> {
+export async function fetchSpecialistContextSection(userId: string | null | undefined): Promise<string> {
   if (!userId) return '';
   try {
     const url = process.env.SUPABASE_URL!;
@@ -1533,7 +1533,7 @@ function formatSpecialistContextSection(ctx: any): string {
 // Without this, every new agent restarts cold with "what can I do for you?"
 // and the user has to repeat themselves — the exact failure the user just
 // reported. Cap at last 12 turns so the prompt doesn't bloat.
-function buildTranscriptSection(
+export function buildTranscriptSection(
   transcriptTurns: Array<{ role: 'user' | 'assistant'; text: string; timestamp: string }> | undefined,
   fromPersona: string,
   targetPersona?: string,
@@ -1720,7 +1720,7 @@ function buildSpecialistTurnPhaseBlock(firstTurnDelivered: boolean): string {
   ].join('\n');
 }
 
-function buildSpecialistLanguageDirective(lang: string | undefined): string {
+export function buildSpecialistLanguageDirective(lang: string | undefined): string {
   const languageNames: Record<string, string> = {
     en: 'English', de: 'German', fr: 'French', es: 'Spanish',
     ar: 'Arabic', zh: 'Chinese', ru: 'Russian', sr: 'Serbian',
@@ -1753,7 +1753,7 @@ function buildGateInputFromTranscript(
   return userTurns.join(' \n ');
 }
 
-function buildPersonaBehavioralRule(personaKey: string): string {
+export function buildPersonaBehavioralRule(personaKey: string): string {
   const isSpecialist = personaKey !== '' && personaKey !== 'vitana';
   const lines: string[] = [];
 

--- a/services/gateway/src/routes/orb-livekit.ts
+++ b/services/gateway/src/routes/orb-livekit.ts
@@ -52,6 +52,9 @@ import {
   buildBootstrapContextPack,
   buildClientContext,
   formatClientContextForInstruction,
+  buildPersonaBehavioralRule,
+  buildSpecialistLanguageDirective,
+  fetchSpecialistContextSection,
 } from './orb-live';
 // L2.2b.6 (VTID-03010): render the full Vertex system instruction for LiveKit.
 // Until this slice, the LiveKit agent built its own ~7-section Python prompt
@@ -1322,71 +1325,34 @@ router.get(
           .maybeSingle();
         const personaPrompt = (personaRow as { system_prompt?: string } | null)?.system_prompt?.trim() || '';
         if (personaPrompt) {
-          const langNames: Record<string, string> = {
-            en: 'English', de: 'German', fr: 'French', es: 'Spanish',
-            ar: 'Arabic', zh: 'Chinese', ru: 'Russian', sr: 'Serbian',
-          };
-          const langName = langNames[lang] || 'English';
-          const personaParts: string[] = [];
-          personaParts.push(personaPrompt);
-          personaParts.push(
-            `[LANGUAGE LOCK]\nRespond ONLY in ${langName}. Match the user's language exactly. Do NOT switch to English. Do NOT mix languages. The user has been speaking ${langName} with Vitana already; continue in the same language without acknowledging the switch.`,
-          );
-          if (bootstrapContext) {
-            personaParts.push(
-              `## USER CONTEXT (carried over from Vitana)\n\n${bootstrapContext}`,
-            );
-          }
-          if (handoffSummary) {
-            personaParts.push(
-              `[HANDOFF NOTE] Vitana captured this brief at handoff: "${handoffSummary}". Synthesize what the user reported in ONE sentence (your own words, not theirs) and confirm. Do NOT echo their wording back. The brief is usually enough — ask AT MOST 2 short clarifying questions, and ONLY if a critical detail is genuinely missing (skip them entirely if not). Then go straight to ticket confirmation + the auto-return question. Open the conversation in your own voice and persona — never speak as Vitana, never quote her.`,
-            );
-          }
-          personaParts.push(
-            '[BEHAVIORAL RULE — opening turn] Speak in your OWN persona. Greet the user warmly in the user\'s language with ONE short sentence introducing yourself by role (e.g. "I\'m the tech support colleague Vitana brought in"). Then either reference the handoff brief above OR ask "what can I help you with?" if no brief is present. Vary your phrasing every call. Never apologize for the handoff. NEVER speak as Vitana.',
-          );
-          // VTID-03028: Vertex-parity flow rules — the specialist must
-          // (a) confirm to the user that a ticket has been filed, (b) when
-          // intake is complete, ASK if the user needs anything else, (c)
-          // on "no" or equivalent, HAND THE USER BACK TO VITANA by calling
-          // switch_persona(persona='vitana'). Without these rules the
-          // specialist goes silent after intake — user-reported bug:
-          // "Devon stops listening instead of asking 'anything else?'".
-          personaParts.push(
-            [
-              '[BEHAVIORAL RULE — ticket confirmation]',
-              'Vitana ALREADY filed the ticket on the user\'s behalf before handing them to you. Confirm warmly that the report is logged ("I\'ve got your report logged — we\'ll come back to you when it\'s fixed" / "Ich habe das aufgenommen — wir melden uns, sobald es behoben ist") in your own words.',
-              'NEVER promise a specific timeline. NEVER say "I\'m creating a ticket" — the ticket already exists.',
-            ].join('\n'),
-          );
-          personaParts.push(
-            [
-              '[BEHAVIORAL RULE — auto-return question]',
-              'After confirming the ticket (or after answering any clarifying question), you MUST ask if there is anything ELSE the user needs from you. Vary the phrasing every call:',
-              '  EN: "Anything else I can help with?" / "Is there anything else on your mind?"',
-              '  DE: "Kann ich noch was für dich tun?" / "Gibt es noch etwas?"',
-              'NEVER skip this question. NEVER end your turn after just confirming the ticket — that leaves the user in awkward silence.',
-            ].join('\n'),
-          );
-          personaParts.push(
-            [
-              '[BEHAVIORAL RULE — swap back to Vitana]',
-              'When the user answers "no / nothing else / nein, danke / das war\'s" (or equivalent) to your auto-return question, your NEXT turn is the LAST thing you ever say in this session. In that single turn you MUST do BOTH actions, in this exact order:',
-              '  1. Speak ONE short bridge sentence in your OWN voice handing them back to Vitana. Vary the phrasing:',
-              '     EN: "Alright — I\'ll hand you back to Vitana." / "Cool — Vitana will take it from here."',
-              '     DE: "Alles klar — ich übergebe dich zurück an Vitana." / "Vitana macht weiter."',
-              '  2. IMMEDIATELY call the `switch_persona` tool with persona=\'vitana\' — in the SAME turn as the bridge sentence, NEVER the turn after.',
-              '  3. STOP speaking after the tool call — the next voice the user hears is Vitana\'s.',
-              'CRITICAL CONTRACT: speaking the goodbye WITHOUT also calling switch_persona leaves the user stranded in your voice. The tool call is NOT optional — it is what physically transfers the call back. A polite goodbye alone is a FAILED handoff. "Thank you, have a nice day" by itself is a BUG.',
-              'NEVER stay silent. NEVER answer further user questions yourself once they say no — that\'s Vitana\'s domain.',
-              'You CANNOT swap laterally to another specialist; you can ONLY return to Vitana via switch_persona.',
-            ].join('\n'),
-          );
-          systemInstruction = personaParts.join('\n\n');
-          console.log(`[VTID-03028] persona system_instruction rendered for ${agentId} (${systemInstruction.length} chars, handoff_summary=${handoffSummary ? `${handoffSummary.length} chars` : 'none'})`);
+          // VTID-03047: assemble the specialist's system instruction by
+          // mirroring Vertex's report_to_specialist handler (orb-live.ts
+          // ~lines 2922-2937). Same helpers, same order, same wording —
+          // so LiveKit Devon's prompt is byte-similar to Vertex Devon's
+          // and the model behaves the same. Previous LiveKit-only
+          // hand-rolled BEHAVIORAL RULE blocks were drifting from Vertex
+          // and bypassing rules that the user already validated for
+          // Vertex (close-question flow, goodbye structure, instruction-
+          // manual protection, swap-back ordering).
+          const userContextSection = await fetchSpecialistContextSection(userId);
+          const behavioralRule = buildPersonaBehavioralRule(agentId.toLowerCase());
+          const languageDirective = buildSpecialistLanguageDirective(lang);
+          const RECEPTIONIST_KEY = 'vitana';
+          const handoffNote = handoffSummary
+            ? `\n\n[HANDOFF NOTE] Vitana captured this brief at handoff: "${handoffSummary}". Synthesize what they reported in ONE sentence (your own words, not theirs) and confirm. Do NOT echo their wording back.`
+            : '';
+          systemInstruction =
+            personaPrompt +
+            `\n\n${languageDirective}` +
+            (userContextSection ? `\n\n${userContextSection}` : '') +
+            (bootstrapContext ? `\n\n## USER CONTEXT (carried over from Vitana)\n\n${bootstrapContext}` : '') +
+            `\n\n${behavioralRule}` +
+            handoffNote +
+            `\n\n[NAVIGATION TOOL] You have a switch_persona tool. You can ONLY pass to='${RECEPTIONIST_KEY}' — you cannot forward sideways to another specialist. If the question is outside your authority, return the user to Vitana with a brief bridge in your own words (vary your phrasing) and STOP — do NOT speak after calling the tool.`;
+          console.log(`[VTID-03047] persona system_instruction rendered for ${agentId} (${systemInstruction.length} chars, handoff_summary=${handoffSummary ? `${handoffSummary.length} chars` : 'none'}, user_context=${userContextSection ? 'yes' : 'no'})`);
         }
       } catch (exc) {
-        console.warn(`[VTID-03027] persona prompt fetch failed for ${agentId}: ${(exc as Error).message}`);
+        console.warn(`[VTID-03047] persona prompt fetch failed for ${agentId}: ${(exc as Error).message}`);
       }
     }
     // Vitana path: full 65KB system instruction with IDENTITY LOCK etc.
@@ -1395,10 +1361,23 @@ router.get(
       const voiceStyle =
         (voiceConfig as { voice_style?: string } | null)?.voice_style?.trim() ||
         'friendly, calm, empathetic';
+      // VTID-03047: mirror Vertex's swap-back-to-Vitana assembly
+      // (orb-live.ts:5641-5648). Vertex appends
+      // `buildPersonaBehavioralRule('vitana')` to Vitana's contextInstruction
+      // so she carries the universal behavioral rules — including the
+      // [VITANA — explicit consent before transfer] block that drives
+      // "PROPOSE before transferring, wait for affirmative reply" routing.
+      // Without this LiveKit Vitana lacked the rules and the model fell
+      // back to a "I'll note it for the team" no-op when faced with a
+      // bug-report flow (2026-05-17 user-reported regression).
+      const vitanaBehavioralRule = buildPersonaBehavioralRule('vitana');
+      const vitanaContextInstruction = bootstrapContext
+        ? `${bootstrapContext}\n\n${vitanaBehavioralRule}`
+        : vitanaBehavioralRule;
       systemInstruction = buildLiveSystemInstruction(
         lang,
         voiceStyle,
-        bootstrapContext,
+        vitanaContextInstruction,
         role,
         undefined,           // conversationSummary — not surfaced through bootstrap yet
         undefined,           // conversationHistory — agent reconnect path will populate later

--- a/supabase/migrations/20260524060000_VTID_03047_restore_vitana_prompt.sql
+++ b/supabase/migrations/20260524060000_VTID_03047_restore_vitana_prompt.sql
@@ -1,0 +1,79 @@
+-- VTID-03047: restore Vitana's system_prompt body to the canonical VTID-02603
+-- version. Mirrors Vertex's source-of-truth prompt.
+--
+-- Context: VTID-03044's rewrite added "If you can't action it, say 'I'll make
+-- a note for the team' and end politely" as a fallback for non-bug categories.
+-- The LiveKit Gemini Flash LLM seized that template as an escape hatch even
+-- when the user had a CONCRETE BUG (slow response times, locked account, …)
+-- and had already explicitly consented to be connected to Devon. Net effect:
+-- Vitana asked clarifying questions then said "I noted your feedback" instead
+-- of calling report_to_specialist — failed handoff, frustrated user.
+--
+-- Fix: revert the system_prompt body to the original VTID-02603 wording
+-- (services/.../20260429100000_*.sql) so LiveKit Vitana uses the SAME prompt
+-- text Vertex Vitana uses today. Gating of which specialists can actually
+-- receive a handoff stays at the RPC layer (sage/atlas/mira are status='draft'
+-- per VTID-03044 migration 20260524050000_*; pick_specialist_for_text RPC
+-- filters by status='active'). Vitana's prompt may name them, but the router
+-- won't route to them.
+--
+-- IDENTITY LOCK header (prepended by 20260502110000_*.sql) is preserved
+-- verbatim.
+
+DO $$
+DECLARE
+  r RECORD;
+  v_lock TEXT;
+  v_body_canonical TEXT;
+BEGIN
+  SELECT id, key, display_name, role, voice_id, system_prompt, version
+  INTO r
+  FROM public.agent_personas
+  WHERE key = 'vitana';
+
+  IF r.id IS NULL THEN
+    RAISE NOTICE 'VTID-03047: Vitana persona row not found; skipping.';
+    RETURN;
+  END IF;
+
+  -- Preserve the IDENTITY LOCK header. Body that follows is what we replace.
+  IF position('=== END IDENTITY LOCK ===' IN r.system_prompt) > 0 THEN
+    v_lock := substring(
+      r.system_prompt
+      FROM 1
+      FOR position('=== END IDENTITY LOCK ===' IN r.system_prompt) + length('=== END IDENTITY LOCK ===') - 1
+    ) || E'\n\n';
+  ELSE
+    v_lock := '';
+  END IF;
+
+  -- Canonical VTID-02603 body verbatim.
+  v_body_canonical := $BODY$You are Vitana — longevity coach, matchmaker, community brain. You are warm,
+curious, encouraging. When a user mentions a problem outside your domain
+(bugs, support questions, refunds, account issues, marketplace claims), you
+say a short bridge sentence and the channel swaps to the right colleague:
+- Devon for bugs / UX issues
+- Sage for support questions / how-to
+- Atlas for refunds / payments / marketplace claims
+- Mira for login / account / profile / data issues
+Bridge sentence template: "Let me bring in {name}, who handles the {domain}
+side. One moment." Stay in your domain — never debug code, never process
+refunds, never reset passwords. After the colleague finishes, welcome the
+user back to the longevity conversation.$BODY$;
+
+  -- Snapshot before mutating.
+  INSERT INTO public.agent_persona_versions (persona_id, version, snapshot, change_note, created_by)
+  VALUES (
+    r.id,
+    r.version,
+    to_jsonb(r),
+    'VTID-03047: restore Vitana system_prompt to VTID-02603 canonical (Vertex source-of-truth)',
+    NULL
+  );
+
+  UPDATE public.agent_personas
+  SET system_prompt = v_lock || v_body_canonical,
+      version = version + 1,
+      updated_at = NOW()
+  WHERE id = r.id;
+END $$;


### PR DESCRIPTION
## Summary

User-reported (2026-05-17, two samples): LiveKit Vitana proposes Devon → user agrees → Vitana asks for details → user provides concrete description → Vitana asks AGAIN or says "I noted your feedback" and STOPS. Never calls `report_to_specialist`. Failed handoff.

Root cause is LiveKit divergence from Vertex. **Fix: mirror Vertex byte-for-byte.**

## Three divergences fixed

1. **Vitana's DB `system_prompt`** had an "I'll make a note for the team" fallback (VTID-03044 rewrite). Gemini Flash grabbed it as an escape hatch even on concrete bugs. **Migration `20260524060000_VTID_03047_restore_vitana_prompt.sql` restores the canonical VTID-02603 body** (Vertex's source-of-truth).
2. **LiveKit Vitana lacked `buildPersonaBehavioralRule('vitana')`** in her system_instruction. That block has `[VITANA — explicit consent before transfer]` which drives "PROPOSE, wait for yes, then transfer". Vertex appends it at `orb-live.ts:5641-5648`. **Now LiveKit does too.**
3. **LiveKit Devon's prompt** was hand-rolled (VTID-03028/03039) and drifted from Vertex's `buildPersonaBehavioralRule('devon')`. **Replaced with the EXACT Vertex assembly** from `orb-live.ts:2922-2937`.

## File changes

- `services/gateway/src/routes/orb-live.ts` — `export` 4 previously private helpers (`buildPersonaBehavioralRule`, `buildSpecialistLanguageDirective`, `fetchSpecialistContextSection`, `buildTranscriptSection`). No Vertex logic change.
- `services/gateway/src/routes/orb-livekit.ts` — specialist path + Vitana path both call the exported helpers. Removes ~60 lines of hand-rolled rules.
- `supabase/migrations/20260524060000_VTID_03047_restore_vitana_prompt.sql` — restore Vitana's `system_prompt` body to canonical, preserve IDENTITY LOCK header, snapshot to `agent_persona_versions`.

## Devon-only canary

Unchanged. `sage / atlas / mira` remain `status='draft'` from VTID-03044's `20260524050000_*` migration. The `pick_specialist_for_text` RPC filters by `status='active'`. Vitana's prompt names them (Vertex parity), but the router won't route to them.

## Test plan

- [x] gateway `npm run build` — green
- [x] `npm test -- --testPathPattern='orb'` — 713/713 pass, 9 snapshots green
- [ ] **After merge + migration + deploy:** re-run German bug-report flow on LiveKit Test Bench. Expected: Vitana proposes Devon → user agrees → Vitana CALLS `report_to_specialist` (possibly after ONE clarifying question to get the 15-word summary) → Devon takes over with full Vertex behavioral rule including auto-return question + ordered goodbye + switch_persona.

🤖 Generated with [Claude Code](https://claude.com/claude-code)