### PR TITLE
feat(orb-agent): expose find_perfect_practitioner + find_perfect_product to LiveKit (VTID-03048)

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/tools.py
+++ b/services/agents/orb-agent/src/orb_agent/tools.py
@@ -1525,6 +1525,95 @@ async def get_matchmaker_result(context: RunContext, intent_id: str) -> str:  # 
     return summarize(body)
 
 
+# VTID-03048: matchmaker parity — surface Vertex's `find_perfect_product` and
+# `find_perfect_practitioner` tools to the LiveKit agent. Until this slice,
+# only Vertex registered them in its function_declarations catalog
+# (services/gateway/src/orb/live/tools/live-tool-catalog.ts:424-477), even
+# though the shared dispatcher already implemented them
+# (services/gateway/src/services/orb-tools-shared.ts:tool_find_perfect_product,
+# :tool_find_perfect_practitioner). Result: when a LiveKit user asked
+# "find me a tennis partner" / "recommend a supplement", the LLM had only
+# `post_intent` / `share_intent_post` available and skipped straight to
+# posting an intent instead of running the search-first matchmaker flow.
+# Both wrappers _dispatch to the shared registry which already enforces
+# the fact-fusing logic (weakest pillar + Life Compass goal + filters).
+@function_tool
+async def find_perfect_product(
+    context: RunContext,
+    goal_text: str = "",
+    pillar: str = "",
+    max_price: float | None = None,
+    exclude_ingredients: list[str] | None = None,
+) -> str:
+    """Recommend the perfect product for the user (supplement / gear / food).
+
+    Fuses the user's weakest Vitana Index pillar + active Life Compass goal
+    with a free-form ask + optional filters (price cap, ingredients to
+    avoid). Returns top-3 with rationale.
+
+    Use this for PRODUCTS. For services or practitioners use
+    `find_perfect_practitioner`. For people / community matches use
+    `find_community_member`.
+
+    Args:
+        goal_text: Free-form description of what the user wants the product
+            to help with.
+        pillar: OPTIONAL — nutrition / hydration / exercise / sleep / mental.
+            Defaults to the user's weakest pillar.
+        max_price: OPTIONAL — price cap.
+        exclude_ingredients: OPTIONAL — list of ingredient names to avoid.
+    """
+    args: dict[str, Any] = {"goal_text": goal_text}
+    if pillar:
+        args["pillar"] = pillar
+    if max_price is not None:
+        args["max_price"] = max_price
+    if exclude_ingredients:
+        args["exclude_ingredients"] = exclude_ingredients
+    body = await _dispatch(context, "find_perfect_product", args)
+    return summarize(body)
+
+
+@function_tool
+async def find_perfect_practitioner(
+    context: RunContext,
+    specialty: str = "",
+    goal_text: str = "",
+    language: str = "",
+    telehealth_ok: bool | None = None,
+    max_price: float | None = None,
+) -> str:
+    """Recommend the perfect practitioner / coach / doctor for the user.
+
+    Multi-criteria search: specialty, language, telehealth-ok, price cap,
+    fused with the active Life Compass goal. Returns top-3 with rationale.
+
+    Use for: "find me a functional medicine doc who takes telehealth",
+    "who can coach me on sleep?", "I need a German-speaking nutritionist".
+
+    Args:
+        specialty: e.g. "functional medicine", "nutrition", "therapy".
+        goal_text: Free-form description of what the user is working on.
+        language: OPTIONAL — language code or name, e.g. "en", "de".
+        telehealth_ok: OPTIONAL — restrict to practitioners offering
+            telehealth.
+        max_price: OPTIONAL — price cap.
+    """
+    args: dict[str, Any] = {}
+    if specialty:
+        args["specialty"] = specialty
+    if goal_text:
+        args["goal_text"] = goal_text
+    if language:
+        args["language"] = language
+    if telehealth_ok is not None:
+        args["telehealth_ok"] = telehealth_ok
+    if max_price is not None:
+        args["max_price"] = max_price
+    body = await _dispatch(context, "find_perfect_practitioner", args)
+    return summarize(body)
+
+
 # ---------------------------------------------------------------------------
 # Navigation
 # ---------------------------------------------------------------------------
@@ -1702,6 +1791,11 @@ def all_tool_names() -> list[str]:
         "post_intent", "view_intent_matches", "list_my_intents", "respond_to_match",
         "mark_intent_fulfilled", "share_intent_post", "scan_existing_matches",
         "get_matchmaker_result",
+        # VTID-03048: matchmaker parity — Vertex-catalog tools now exposed
+        # on LiveKit. Implementations live in
+        # services/gateway/src/services/orb-tools-shared.ts (tool_find_perfect_*)
+        # and are reached through the shared dispatcher.
+        "find_perfect_product", "find_perfect_practitioner",
         # Navigation (3)
         "navigate", "navigate_to_screen", "get_current_screen",
     ]

--- a/voice-pipeline-spec/spec.json
+++ b/voice-pipeline-spec/spec.json
@@ -67,6 +67,9 @@
     { "name": "scan_existing_matches",        "implementations": ["vertex"], "safety_critical": false, "owner_vtid": null },
     { "name": "get_matchmaker_result",        "implementations": ["vertex"], "safety_critical": false, "owner_vtid": null },
 
+    { "name": "find_perfect_product",         "implementations": ["vertex", "livekit"], "safety_critical": false, "owner_vtid": "VTID-03048", "notes": "Recommends a product (supplement/gear/food) fusing weakest pillar + Life Compass goal. Shared dispatcher tool_find_perfect_product. Surfaced to LiveKit in VTID-03048 (previously Vertex-only catalog despite shared impl)." },
+    { "name": "find_perfect_practitioner",    "implementations": ["vertex", "livekit"], "safety_critical": false, "owner_vtid": "VTID-03048", "notes": "Recommends a practitioner/coach/doctor (specialty + language + telehealth + price). Shared dispatcher tool_find_perfect_practitioner. Surfaced to LiveKit in VTID-03048 (previously Vertex-only catalog despite shared impl)." },
+
     { "name": "navigate_to_screen",           "implementations": ["vertex"], "safety_critical": true,  "owner_vtid": null,         "notes": "Surface-aware navigation. Cross-surface routes (vitanaland→/admin or /command-hub) MUST be rejected per feedback_navigator_surface_scoping memory rule." }
   ],
 


### PR DESCRIPTION
## Summary

- LiveKit user said "Ich suche jemand mit dem ich zusammen Tennis spielen kann" and the agent **immediately posted a new intent** instead of searching existing community members first (Vertex's flow).
- Root cause: `tool_find_perfect_practitioner` + `tool_find_perfect_product` exist in the shared dispatcher (`services/gateway/src/services/orb-tools-shared.ts`) and in Vertex's catalog (`services/gateway/src/orb/live/tools/live-tool-catalog.ts:424-477`), but the **LiveKit agent never wrapped them in `@function_tool`**, so Gemini never saw them as callable. The only matchmaker tool in scope was `post_intent` — and that's what got called.
- Documented gap from L2.2b.5 (VTID-03009, memory `project_l2_2b_5_tool_parity_sweep_shipped.md`): "find_perfect_product / find_perfect_practitioner are Vertex-catalog-only (gap in tools.py to close before L2.2b.6 canary)". This PR closes it.

## Diagnosis from prod data

Verified via direct Supabase query on `user_intents` / `intent_matches` / `oasis_events`:

- `@dragan1` has 39 intents total (16 open, 18 closed, 5 fulfilled).
- The tennis intent created at 16:36 has `match_count=5` — all 5 candidate matches scored 0.434 and were `intent.notification.low_score_skipped`.
- The agent reported "1 Post mit 5 Matches" because it looked at the just-created intent's stored counter, not the user's full intent history.
- No tool-call telemetry for `find_perfect_practitioner` because the wrapper didn't exist.

## Change

`services/agents/orb-agent/src/orb_agent/tools.py` (+94, additive):

1. New `@function_tool find_perfect_product(goal_text, pillar, max_price, exclude_ingredients)` — recommends a product (supplement / gear / food). Fuses weakest Vitana Index pillar + Life Compass goal + filters. Delegates to the shared dispatcher.
2. New `@function_tool find_perfect_practitioner(specialty, goal_text, language, telehealth_ok, max_price)` — recommends a practitioner / coach / doctor. Multi-criteria. Same delegation pattern.
3. Both signatures + docstrings mirror Vertex's catalog descriptions so the LLM sees identical guidance on both pipelines.
4. `all_tool_names()` grows from 49 → 51.

`voice-pipeline-spec/spec.json` (+3 lines):

- Two new tool rows in the matchmaker section, both `implementations: ["vertex", "livekit"]` reflecting post-PR state. Notes link back to VTID-03048 + the shared dispatcher.

## What this PR does NOT do

- No change to `orb-tools-shared.ts` or `live-tool-catalog.ts` — the implementations and Vertex catalog were already correct.
- No change to the 8 other already-drifted spec.json entries (`find_community_member`, `navigate`, `log_*`, etc.) — separate cleanup.
- No `voice.livekit_agent_enabled` flip.

## Acceptance

1. Agent `tools.all_tool_names()` returns 51 names (49 + 2 new).
2. `tools.all_tools()` resolves both new names as callable `@function_tool`.
3. LiveKit voice query "find me a tennis partner" / "find me a German-speaking nutritionist" — agent is now allowed to call `find_perfect_practitioner` first.
4. Vertex production: unchanged.

## Tests

- `npm run build` (gateway) — green.
- 713 / 713 orb tests still green (40 suites).
- `pytest tests/test_tools_catalogue.py` — green; both new wrappers callable.

## Test plan

- [ ] CI green.
- [ ] DEPLOY-ORB-AGENT.yml succeeds (this PR touches `services/agents/orb-agent/**` so it auto-triggers).
- [ ] LiveKit Test Bench: "Ich suche einen Tennispartner" — agent calls `find_perfect_practitioner(specialty='tennis')` BEFORE `post_intent`.
- [ ] No regression on existing matchmaker tools (`post_intent`, `view_intent_matches`, `scan_existing_matches`).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
