### PR TITLE
fix(orb-tools): chain explain_feature to search_knowledge server-side (VTID-03051)

### DIFF
--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -1517,12 +1517,41 @@ export async function tool_explain_feature(args: OrbToolArgs): Promise<OrbToolRe
   const result = explainFeature(topic);
 
   if (!result.found) {
-    // Vertex's not-found path returns guidance text steering voice to
-    // search_knowledge with KB instructions. Mirror that exactly so both
-    // pipelines produce identical fallback behaviour.
+    // VTID-03051: chain to search_knowledge server-side so the LLM never
+    // sees a "tool returned not_found + here's some guidance text"
+    // pattern. The prior contract was: emit `found:false` + guidance and
+    // expect the LLM to make a second tool call to `search_knowledge` on
+    // its own. Gemini Live frequently mis-handled this and narrated the
+    // first response as a definitive "I couldn't find it" — user had to
+    // re-ask the same question to coax the chain.
+    //
+    // Server-side fallback makes both pipelines produce a useful answer
+    // in a single tool round trip: when the pattern matcher misses, we
+    // run the Knowledge Hub search inline and put its answer in `text`.
+    // dispatchOrbToolForVertex prefers `text` over the stringified
+    // result, so Vertex sends the KB answer to Gemini directly; the
+    // LiveKit `summarize()` reads `text` first too. Behavior parity
+    // is preserved: callers that need to distinguish the two paths can
+    // still read `result.knowledge_fallback` + `result.docs`.
+    let knowledgeAnswer = '';
+    let knowledgeDocs: Array<Record<string, unknown>> = [];
+    try {
+      const { searchKnowledge } = await import('./knowledge-hub');
+      const kb = await searchKnowledge({ query: topic, maxResults: 5 });
+      if (kb.ok && Array.isArray(kb.docs) && kb.docs.length > 0) {
+        knowledgeAnswer = (kb.answer ?? '').trim();
+        knowledgeDocs = (kb.docs as unknown) as Array<Record<string, unknown>>;
+      }
+    } catch {
+      // Best-effort: KB failure must never block the explain_feature
+      // tool — the guidance text remains as the LLM-visible fallback.
+    }
+
     const payload = {
       found: false as const,
       reason: result.reason ?? 'no_pattern_match',
+      knowledge_fallback: knowledgeAnswer.length > 0,
+      docs: knowledgeDocs,
       guidance:
         'Voice should fall back to search_knowledge. Search the Maxina ' +
         'Instruction Manual (kb/instruction-manual/maxina/*) first — it covers ' +
@@ -1533,11 +1562,12 @@ export async function tool_explain_feature(args: OrbToolArgs): Promise<OrbToolRe
     return {
       ok: true,
       result: payload,
-      // Vertex returned JSON.stringify(payload) as `result` (string). For voice
-      // it doesn't actually speak this — the LLM sees the structured fall-back
-      // signal and chooses the next tool. dispatchOrbToolForVertex will
-      // stringify the structured result for Vertex callers.
-      text: '',
+      // When the KB returned a real answer, surface it as `text`.
+      // dispatchOrbToolForVertex prefers `text` over stringified
+      // `result`, and the LiveKit agent's summarize() does the same.
+      // Empty string falls through to the structured-result path
+      // (guidance + the LLM's prior chain-to-search_knowledge behavior).
+      text: knowledgeAnswer,
     };
   }
 

--- a/services/gateway/test/services/explain-feature-kb-fallback.test.ts
+++ b/services/gateway/test/services/explain-feature-kb-fallback.test.ts
@@ -1,0 +1,166 @@
+/**
+ * VTID-03051 — explain_feature KB fallback unit tests.
+ *
+ * Locks the server-side chain behaviour added in this PR. Before this
+ * slice, `tool_explain_feature` on a pattern miss returned `found:false`
+ * plus a guidance string and expected the LLM to make a second tool
+ * call to `search_knowledge`. Gemini Live frequently narrated the first
+ * response as a final "I couldn't find it" answer — user had to re-ask
+ * to coax the second call.
+ *
+ * The fix: when explainFeature() misses, the tool now calls
+ * searchKnowledge inline and puts the answer in `text`. Both the
+ * dispatchOrbToolForVertex path and the LiveKit `summarize()` path
+ * prefer `text` over the structured result, so the LLM receives a
+ * usable answer in a single tool round trip.
+ *
+ * The three cases covered:
+ *   1. Pattern match — KB chain is NOT called (unchanged behavior).
+ *   2. Pattern miss + KB has results — answer surfaced in `text`,
+ *      `result.knowledge_fallback=true`, docs in `result.docs`.
+ *   3. Pattern miss + KB returns no docs — `text:''`, the structured
+ *      `result.knowledge_fallback=false`, guidance preserved.
+ *   4. Pattern miss + KB throws — same as case 3 (silent fallback).
+ */
+
+import { tool_explain_feature } from '../../src/services/orb-tools-shared';
+
+jest.mock('../../src/services/explain-feature-service', () => ({
+  explainFeature: jest.fn(),
+}));
+
+jest.mock('../../src/services/knowledge-hub', () => ({
+  searchKnowledge: jest.fn(),
+}));
+
+import { explainFeature as mockExplainFeature } from '../../src/services/explain-feature-service';
+import { searchKnowledge as mockSearchKnowledge } from '../../src/services/knowledge-hub';
+
+const explainMock = mockExplainFeature as jest.Mock;
+const kbMock = mockSearchKnowledge as jest.Mock;
+
+beforeEach(() => {
+  explainMock.mockReset();
+  kbMock.mockReset();
+});
+
+describe('VTID-03051 tool_explain_feature KB fallback', () => {
+  it('returns the pattern-match payload when found and does NOT call searchKnowledge', async () => {
+    explainMock.mockReturnValue({
+      found: true,
+      topic_canonical: 'maxina_community',
+      pillar_lift: null,
+      summary_voice_en: 'Maxina is your community.',
+      summary_voice_de: 'Maxina ist deine Community.',
+      steps_voice_en: [],
+      steps_voice_de: [],
+      redirect_route: '/community',
+      redirect_offer_en: '',
+      redirect_offer_de: '',
+      citation: 'kb/...',
+    });
+
+    const out = await tool_explain_feature({ feature: 'Maxina Community' });
+
+    expect(out.ok).toBe(true);
+    expect(out.text).toBe('');
+    const r = out.result as { found: boolean; topic_canonical: string };
+    expect(r.found).toBe(true);
+    expect(r.topic_canonical).toBe('maxina_community');
+    // Critical: KB fallback only fires on pattern miss. Pattern match
+    // must NOT incur the extra search round trip.
+    expect(kbMock).not.toHaveBeenCalled();
+  });
+
+  it('chains to searchKnowledge on pattern miss + surfaces answer as text', async () => {
+    explainMock.mockReturnValue({
+      found: false,
+      reason: 'no_pattern_match',
+    });
+    kbMock.mockResolvedValue({
+      ok: true,
+      answer: 'Maxina is your community on Vitanaland — a tenant-scoped longevity space.',
+      docs: [
+        { id: '1', title: 'What Is Maxina?', path: 'kb/01-foundation/01-what-is-maxina.md' },
+        { id: '2', title: 'Maxina Across Vitanaland', path: 'kb/07-maxina-experience/01-maxina-across-vitanaland.md' },
+      ],
+    });
+
+    const out = await tool_explain_feature({ topic: 'Maxina Community' });
+
+    expect(out.ok).toBe(true);
+    expect(out.text).toContain('Maxina is your community on Vitanaland');
+    expect(kbMock).toHaveBeenCalledWith({ query: 'Maxina Community', maxResults: 5 });
+
+    const r = out.result as {
+      found: boolean;
+      reason: string;
+      knowledge_fallback: boolean;
+      docs: Array<{ title: string }>;
+    };
+    expect(r.found).toBe(false);
+    expect(r.reason).toBe('no_pattern_match');
+    expect(r.knowledge_fallback).toBe(true);
+    expect(r.docs).toHaveLength(2);
+    expect(r.docs[0].title).toBe('What Is Maxina?');
+  });
+
+  it('preserves the guidance fallback when KB returns no docs', async () => {
+    explainMock.mockReturnValue({ found: false, reason: 'no_pattern_match' });
+    kbMock.mockResolvedValue({ ok: true, answer: '', docs: [] });
+
+    const out = await tool_explain_feature({ topic: 'completely-unknown-thing' });
+
+    expect(out.ok).toBe(true);
+    // text is empty so dispatchOrbToolForVertex / summarize() fall through
+    // to the structured result, where the LLM can read `guidance` and
+    // make its own chain decision (the prior contract).
+    expect(out.text).toBe('');
+
+    const r = out.result as {
+      knowledge_fallback: boolean;
+      docs: unknown[];
+      guidance: string;
+    };
+    expect(r.knowledge_fallback).toBe(false);
+    expect(r.docs).toHaveLength(0);
+    expect(r.guidance).toContain('search_knowledge');
+    expect(r.guidance).toContain('Maxina Instruction Manual');
+  });
+
+  it('silently degrades to the guidance fallback when searchKnowledge throws', async () => {
+    explainMock.mockReturnValue({ found: false, reason: 'no_pattern_match' });
+    kbMock.mockRejectedValue(new Error('Supabase RPC timed out'));
+
+    const out = await tool_explain_feature({ topic: 'Maxina Community' });
+
+    // KB failure must NEVER turn into a tool error — the explain_feature
+    // contract is "always ok:true with structured result"; otherwise the
+    // LLM treats the call as a hard error.
+    expect(out.ok).toBe(true);
+    expect(out.text).toBe('');
+
+    const r = out.result as { knowledge_fallback: boolean; docs: unknown[] };
+    expect(r.knowledge_fallback).toBe(false);
+    expect(r.docs).toHaveLength(0);
+  });
+
+  it('rejects an empty topic up-front (unchanged contract)', async () => {
+    const out = await tool_explain_feature({});
+    expect(out.ok).toBe(false);
+    expect(out.error).toBe('topic is required');
+    // Critical: no exploratory KB call for empty input.
+    expect(kbMock).not.toHaveBeenCalled();
+    expect(explainMock).not.toHaveBeenCalled();
+  });
+
+  it('accepts the legacy `feature` argument the LiveKit agent sends', async () => {
+    explainMock.mockReturnValue({ found: false, reason: 'no_pattern_match' });
+    kbMock.mockResolvedValue({ ok: true, answer: 'doc body', docs: [{ id: 'x', title: 't' }] });
+
+    const out = await tool_explain_feature({ feature: 'Diary' });
+
+    expect(out.ok).toBe(true);
+    expect(kbMock).toHaveBeenCalledWith({ query: 'Diary', maxResults: 5 });
+  });
+});


### PR DESCRIPTION
## Summary

- LiveKit agent answered "Es tut mir leid, ich konnte keine spezifische Erklärung für 'Maxina Community' finden" on the first turn instead of just answering. User had to repeat the question before the agent finally produced the KB answer. Vertex doesn't show the same hesitation.
- Root cause: `tool_explain_feature` returns `{found:false, guidance:"fall back to search_knowledge..."}` on a pattern miss and expects the LLM to make a SECOND tool call. Vertex's Gemini Live mostly chains; LiveKit's Gemini Pro frequently narrates the first response as final and waits for the user to re-ask.
- Direct verification: `POST /api/v1/assistant/knowledge/search` with `{query:"Maxina Community"}` returns 5 docs + a 966-char answer. **The content is there; the chain was the problem.**
- Fix: chain server-side. On pattern miss, `tool_explain_feature` now calls `searchKnowledge` inline and surfaces the answer in the `text` field. Both `dispatchOrbToolForVertex` and the LiveKit `summarize()` prefer `text` over the structured result, so both pipelines now receive the KB answer in a single tool round trip.

## Change

`services/gateway/src/services/orb-tools-shared.ts` (+~25 lines, modifies the `found:false` branch of `tool_explain_feature`):

1. On `found:false`, dynamically import `searchKnowledge` and run it with `{query: topic, maxResults: 5}`.
2. If the KB returned any docs, the answer goes into `text` and `result.knowledge_fallback:true` + `result.docs` are populated.
3. If the KB returned no docs OR threw, `text` stays empty and the original guidance string is preserved so the LLM can still chain manually if it wants.
4. KB failure NEVER turns into a tool error — `ok:true` always.

## Why this is the right layer

The system instruction already tells the LLM "If explain_feature returns found=false, fall back to search_knowledge". The rule didn't reliably fire on LiveKit. Rather than tune the prompt further (fragile), this PR removes the prerequisite chain: the tool always returns a usable answer when one exists. The structured `result.knowledge_fallback` flag preserves observability for cockpit/telemetry.

## What this PR does NOT do

- No change to `explain-feature-service.ts` pattern table.
- No change to the system instruction.
- No change to `search_knowledge` tool itself.
- No change to LiveKit route handlers or the agent.

## Acceptance

1. `explain_feature(topic='Diary')` (pattern match) — unchanged. `text:''`, `result.found:true`, KB NOT called.
2. `explain_feature(topic='Maxina Community')` (pattern miss + KB hit) — `text` carries the KB answer.
3. `explain_feature(topic='nonexistent-xyz')` (pattern miss + KB miss) — `text:''`, guidance preserved.
4. KB timeout / throw — silent fallback to case 3 shape, never tool error.
5. Empty topic — `ok:false, error:'topic is required'` (unchanged).
6. Legacy `feature` argument from LiveKit agent — accepted equivalently.

## Tests

- `npm run build` (gateway) — green.
- **6 / 6** new tests in `test/services/explain-feature-kb-fallback.test.ts` covering all 6 acceptance cases.
- **713 / 713** orb tests still green (40 suites). No collateral.

## VTID note

Originally allocated VTID-03050 — collided with PR #2196 ("B0c-minimal schema") shipped in parallel; re-allocated to VTID-03051 before push per the "re-check VTID at merge" rule.

## Test plan

- [ ] CI green.
- [ ] EXEC-DEPLOY succeeds.
- [ ] LiveKit Test Bench: "Was ist die Maxina Community?" — agent answers grounded in KB content on the FIRST turn (no apology, no offer to search, no re-ask).
- [ ] Vertex production: unchanged on pattern-match topics (Diary, Five Pillars, Vitana Index, Life Compass).

🤖 Generated with [Claude Code](https://claude.com/claude-code)
