### PR TITLE
perf(orb-livekit): drop GREETING POLICY from system_instruction (VTID-03046)

### DIFF
--- a/services/gateway/src/orb/live/instruction/live-system-instruction.ts
+++ b/services/gateway/src/orb/live/instruction/live-system-instruction.ts
@@ -138,6 +138,17 @@ function buildTemporalJourneyContextSection(
   recentRoutes: string[] | null | undefined,
   isReconnect: boolean,
   timeOfDay?: string,
+  // VTID-03046 step 2 — when true, omit the GREETING POLICY / RECONNECT
+  // FINAL OVERRIDE / HARD ANTI-PATTERNS blocks. These ~37 KB of rules only
+  // govern the LLM's FIRST utterance after room-join. The LiveKit cascade
+  // never lets the LLM produce that utterance — `session.say(...)` plays a
+  // pre-rendered localized greeting at room-join (see orb-agent
+  // session.py:_localized_greeting, VTID-03014). For LiveKit those rules
+  // are dead text the LLM has to chew through on every single turn.
+  // Vertex Live still needs them (Gemini Live API does generate the
+  // greeting) so this stays opt-in. TONE RULES + JOURNEY AWARENESS are
+  // kept because they shape ongoing conversation, not just the opener.
+  omitGreetingPolicy?: boolean,
 ): string {
   const temporal = describeTimeSince(lastSessionInfo);
   const current = describeRoute(currentRoute, lang);
@@ -193,6 +204,30 @@ function buildTemporalJourneyContextSection(
     lines.push(`- Journey before opening ORB (newest → oldest): ${trailStr}`);
   } else {
     lines.push('- Journey before opening ORB: (no prior screens reported this session)');
+  }
+
+  // VTID-03046 step 2: skip the entire greeting-policy stack on LiveKit
+  // (caller passes omitGreetingPolicy=true). The early-return jumps over
+  // the GREETING POLICY block (until ## TONE RULES below), the RECONNECT
+  // FINAL OVERRIDE block, and the HARD ANTI-PATTERNS block — all of which
+  // exist solely to constrain the LLM's FIRST utterance. LiveKit's
+  // pre-rendered session.say() greeting bypasses them entirely.
+  if (omitGreetingPolicy) {
+    lines.push('');
+    lines.push('## TONE RULES (CRITICAL)');
+    lines.push('- Your voice must always be WARM, POLITE, and KIND. Never cold, never curt, never robotic.');
+    lines.push('- Baseline register: "how can I help", "what\'s on your mind", "I am listening", "how can I support you". When a candidate IS provided in the brain context below, lead with it instead.');
+    lines.push('- NEVER use filler phrases as greeting openers: NO "of course", NO "happy to", NO "lovely to hear from you", NO "sure". Get straight to the point with warmth.');
+    lines.push('- Even your shortest responses must feel genuinely kind. A single phrase can still be warm.');
+    lines.push('');
+    lines.push('## JOURNEY AWARENESS (CRITICAL — how to answer "where am I?" correctly)');
+    lines.push('- The "Current screen" field above is a SNAPSHOT from session start. It can become stale the moment any navigation happens (including navigation YOU just triggered via navigate_to_screen).');
+    lines.push('- Whenever the user asks any form of "where am I?" / "which screen is this?" / "what page am I on?" / "what am I looking at?" / "wo bin ich?" / "welcher Bildschirm ist das?", you MUST call the `get_current_screen` tool to get the FRESH answer. Never answer from memory or from the snapshot above — always call the tool.');
+    lines.push('- The get_current_screen tool is also the right call for any follow-up like "what is this screen for?" or "what can I do here?" — it returns a short description of the screen in the user\'s language.');
+    lines.push('- If the user asks "where was I before?" or similar, you may list the journey trail above in a natural sentence, OR call get_current_screen which also returns recent_screens.');
+    lines.push('- NEVER tell the user "I don\'t know which screen you\'re on" without calling get_current_screen first. That is always wrong.');
+    lines.push('- NEVER read raw URL paths aloud. Always speak the friendly screen title instead.');
+    return '\n\n' + lines.join('\n');
   }
 
   lines.push('');
@@ -404,6 +439,11 @@ export function buildLiveSystemInstruction(
   // model may emit when asked "what is my user ID?". Null/undefined for
   // sessions where the handle hasn't been provisioned yet.
   vitanaId?: string | null,
+  // VTID-03046 step 2: drop the ~37 KB greeting-policy stack from the
+  // rendered prompt. See buildTemporalJourneyContextSection's parameter
+  // comment for the full rationale. Only LiveKit callers pass true —
+  // Vertex still needs it because Gemini Live generates the greeting.
+  omitGreetingPolicy?: boolean,
 ): string {
   const languageNames: Record<string, string> = {
     'en': 'English',
@@ -597,6 +637,7 @@ ${trimmedHistory}
     recentRoutes,
     !!isReconnect,
     clientContext?.timeOfDay,
+    omitGreetingPolicy,
   );
 
   // BOOTSTRAP-AWARENESS-REGISTRY: gate the override blocks below on admin

--- a/services/gateway/src/routes/orb-livekit.ts
+++ b/services/gateway/src/routes/orb-livekit.ts
@@ -1387,6 +1387,14 @@ router.get(
         null,                // recentRoutes
         envContext ?? undefined,
         req.identity?.vitana_id ?? null,
+        true,                // VTID-03046 step 2 — LiveKit's session.say()
+                             // plays a pre-rendered localized greeting at
+                             // room-join; the LLM never generates the first
+                             // utterance, so the ~37 KB GREETING POLICY +
+                             // RECONNECT FINAL OVERRIDE + HARD ANTI-PATTERNS
+                             // blocks are dead text on every per-turn LLM
+                             // call. omitGreetingPolicy=true drops them
+                             // (~107 KB → ~70 KB system_instruction).
       );
       }
     } catch (exc) {

--- a/services/gateway/src/services/voice-lab/livekit-test-eval.ts
+++ b/services/gateway/src/services/voice-lab/livekit-test-eval.ts
@@ -152,6 +152,7 @@ export async function evaluateLiveKitDryRun(
     /* recentRoutes */ null,
     /* clientContext */ undefined,
     identity.vitana_id ?? null,
+    /* omitGreetingPolicy */ true, // VTID-03046 step 2 — eval mirrors prod LiveKit
   );
 
   // Tool catalog — Live API shape is `[{ function_declarations: [...] }]`


### PR DESCRIPTION
## Summary

Drops the 39 KB GREETING POLICY stack from the LiveKit-rendered system_instruction. Total system_instruction goes ~107 KB → ~70 KB on every per-turn cascade call. Gemini Flash TTFT scales with input size.

The block exists to constrain the **LLM's first utterance** after room-join. LiveKit's cascade never lets the LLM produce that utterance — `session.say(...)` plays a pre-rendered localized greeting (VTID-03014). So the 39 KB is dead text on every turn.

## Section sizes (before)

| Section | Bytes |
|---|---:|
| preamble + bootstrap_context | 10,885 |
| Recent memory items | 2,606 |
| USER CONTEXT PROFILE | 8,920 |
| TEMPORAL / JOURNEY | 432 |
| **GREETING POLICY (dropped)** | **38,981** |
| AVAILABLE TOOLS | 45,050 |
| **TOTAL** | **106,874** |

## Scope

- ✓ LiveKit prod path (`orb-livekit.ts`)
- ✓ Voice Lab LiveKit eval (`livekit-test-eval.ts`) — mirrors prod so the eval doesn't measure a different prompt
- ✗ Vertex Live (`orb-live.ts`) — untouched. Gemini Live API generates its own first greeting and still needs these rules.

## Stability

- `npm run build` clean.
- 27/27 buildLiveSystemInstruction characterization tests pass; the 3 stable snapshots (`day-1-anonymous-landing`, `day-30-warm-german`, `day-180-veteran-reconnect`) are byte-identical to before because the new param defaults off and only LiveKit passes it.
- Agent rebuild is NOT required — agent uses `bootstrap.system_instruction` verbatim. Gateway-only deploy ships the change.
- Same blast-radius statement as VTID-03036 cache PR: a mid-conversation disconnect cannot originate here.

## Verification after deploy

1. Probe `/api/v1/orb/context-bootstrap?agent_id=vitana&lang=en` and confirm `system_instruction.length` drops to ~70 KB.
2. User runs a normal LiveKit session; per-turn answering feels faster.

## What this does NOT do

- Does NOT trim the 45 KB AVAILABLE TOOLS catalog. That requires confirming the Python cascade can drop the prose block in favor of function_tool decorators alone (per L2.2b.6 / VTID-03010 comments, this is NOT safe today). Separate PR if needed.
- Does NOT touch the agent runtime, dispatch, token mint, STT/LLM/TTS providers, or any disconnect-adjacent code.

## Test plan

- [x] `npm run build` green locally
- [x] Characterization snapshots locked (Vertex output byte-identical)
- [ ] After EXEC-DEPLOY: probe bootstrap and confirm size drops
- [ ] User confirms answering speed in a real LiveKit session

🤖 Generated with [Claude Code](https://claude.com/claude-code)