### PR TITLE
feat(orb-livekit): wake-brief renderer reads pillar_momentum for proactive opener (VTID-03053)

### DIFF
--- a/services/gateway/src/routes/orb-livekit.ts
+++ b/services/gateway/src/routes/orb-livekit.ts
@@ -1444,6 +1444,11 @@ router.get(
           lang,
           envelopeJourneySurface:
             (envContext as { journeySurface?: string } | undefined)?.journeySurface,
+          // VTID-03053: forward distilled pillar-momentum so the renderer
+          // can emit a proactive opener for slipping pillars instead of
+          // the generic "Hello! How can I help today?" line. Already
+          // compiled earlier in this handler at the spine step.
+          pillarMomentum: decisionContext?.pillar_momentum ?? null,
         });
       } catch (exc) {
         console.warn(

--- a/services/gateway/src/services/assistant-continuation/providers/voice-wake-brief.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/voice-wake-brief.ts
@@ -40,6 +40,10 @@ import type {
   ProviderResult,
 } from '../types';
 import type { GreetingPolicy } from '../../../orb/live/instruction/greeting-policy';
+import type {
+  DecisionPillarMomentum,
+  PillarKey,
+} from '../../../orb/context/types';
 
 // ---------------------------------------------------------------------------
 // Inputs the orchestrator caller forwards via ctx.extra.voiceWakeBrief
@@ -62,6 +66,16 @@ export interface VoiceWakeBriefInputs {
   greetingPolicy: GreetingPolicy;
   /** ISO 639-1 language code. Defaults to `'en'` when absent. */
   lang?: string;
+  /**
+   * VTID-03053 — Distilled pillar-momentum from the AssistantDecisionContext.
+   * When present AND confidence is medium/high AND the suggested focus
+   * pillar has slipping/unknown momentum, the renderer produces a
+   * proactive observation instead of the generic greeting. Null/missing →
+   * the renderer falls through to the generic policy-keyed line.
+   *
+   * Enum-only by contract; no raw scores, no medical interpretation.
+   */
+  pillarMomentum?: DecisionPillarMomentum | null;
 }
 
 export const VOICE_WAKE_BRIEF_EXTRA_KEY = 'voiceWakeBrief' as const;
@@ -91,9 +105,72 @@ const DEFAULT_LINES: Record<GreetingPolicy, Record<string, string>> = {
   },
 };
 
+/**
+ * VTID-03053 — Per-pillar proactive observation. ONLY used when:
+ *   - pillarMomentum is present
+ *   - confidence is medium or high (low confidence + unknown both fall
+ *     through to the generic line so the orb doesn't speculate)
+ *   - suggested_focus is set AND its momentum band is 'slipping' or
+ *     'unknown' (steady/improving pillars don't warrant proactive nudge)
+ *
+ * Output is ONE short sentence + ONE open question — never a list, never
+ * medical interpretation, never a number. Mirrors the "one next-best
+ * action, not multiple" rule from the original B0d/B0e scope.
+ */
+const PILLAR_PROACTIVE_LINES: Record<PillarKey, Record<string, string>> = {
+  sleep: {
+    en: 'Your sleep pillar has been slipping lately. Want to look at what is getting in the way?',
+    de: 'Deine Schlaf-Säule sackt in letzter Zeit etwas ab. Wollen wir uns anschauen, was da hineinspielt?',
+  },
+  nutrition: {
+    en: 'Your nutrition pillar has been slipping lately. Want help getting it back on track?',
+    de: 'Deine Ernährungs-Säule sackt in letzter Zeit etwas ab. Sollen wir das gemeinsam wieder aufbauen?',
+  },
+  exercise: {
+    en: 'Your exercise pillar has been slipping lately. Want to set up something light for today?',
+    de: 'Deine Bewegungs-Säule sackt in letzter Zeit etwas ab. Sollen wir heute etwas Leichtes einplanen?',
+  },
+  hydration: {
+    en: 'Your hydration pillar has been slipping lately. Want a small step to lift it back up?',
+    de: 'Deine Hydrations-Säule sackt in letzter Zeit etwas ab. Wollen wir einen kleinen Schritt einbauen?',
+  },
+  mental: {
+    en: 'Your mental pillar has been slipping lately. What is weighing on you right now?',
+    de: 'Deine Mental-Säule sackt in letzter Zeit etwas ab. Was beschäftigt dich gerade?',
+  },
+};
+
+/**
+ * Whether the pillar-momentum signal warrants a proactive opener vs the
+ * generic policy-keyed line. Pure; no IO. Exported for tests.
+ */
+export function shouldUsePillarProactiveLine(
+  pm: DecisionPillarMomentum | null | undefined,
+  policy: GreetingPolicy,
+): boolean {
+  // Skip is handled at the provider boundary; never reaches the renderer.
+  // brief_resume keeps its tight "back already?" line — proactive context
+  // would feel out of place mid-thread.
+  if (policy === 'skip' || policy === 'brief_resume') return false;
+  if (!pm) return false;
+  if (pm.confidence === 'low') return false;
+  if (!pm.suggested_focus) return false;
+  const row = pm.per_pillar.find((p) => p.pillar === pm.suggested_focus);
+  if (!row) return false;
+  return row.momentum === 'slipping' || row.momentum === 'unknown';
+}
+
 export const defaultVoiceWakeBriefRenderer: VoiceWakeBriefRenderer = {
   render(inputs) {
     const lang = inputs.lang && inputs.lang.length > 0 ? inputs.lang : 'en';
+
+    if (shouldUsePillarProactiveLine(inputs.pillarMomentum, inputs.greetingPolicy)) {
+      const focus = inputs.pillarMomentum!.suggested_focus as PillarKey;
+      const byLang = PILLAR_PROACTIVE_LINES[focus];
+      const line = byLang[lang] ?? byLang.en;
+      if (line && line.length > 0) return line;
+    }
+
     const byLang = DEFAULT_LINES[inputs.greetingPolicy];
     return byLang[lang] ?? byLang.en ?? '';
   },
@@ -176,6 +253,29 @@ export function makeVoiceWakeBriefProvider(
         };
       }
 
+      const usedPillarProactive = shouldUsePillarProactiveLine(
+        inputs.pillarMomentum,
+        inputs.greetingPolicy,
+      );
+      const evidence: AssistantContinuation['evidence'] = [
+        {
+          kind: 'greeting_policy',
+          detail: inputs.greetingPolicy,
+        },
+      ];
+      let dedupeKey = `wake-brief-${inputs.greetingPolicy}`;
+      if (usedPillarProactive && inputs.pillarMomentum) {
+        evidence.push({
+          kind: 'pillar_momentum_slipping',
+          detail: inputs.pillarMomentum.suggested_focus ?? 'unknown',
+          weight: inputs.pillarMomentum.confidence === 'high' ? 1 : 0.6,
+        });
+        // Distinct dedupe key when the proactive variant fires — same
+        // greeting policy with a different observation should NOT
+        // collide with the generic-line dedupe row.
+        dedupeKey = `wake-brief-${inputs.greetingPolicy}-pillar-${inputs.pillarMomentum.suggested_focus}`;
+      }
+
       const candidate: AssistantContinuation = {
         id: `wake-brief-${newId()}`,
         surface: 'orb_wake',
@@ -183,13 +283,8 @@ export function makeVoiceWakeBriefProvider(
         priority,
         userFacingLine: line,
         cta: { type: 'explain' },
-        evidence: [
-          {
-            kind: 'greeting_policy',
-            detail: inputs.greetingPolicy,
-          },
-        ],
-        dedupeKey: `wake-brief-${inputs.greetingPolicy}`,
+        evidence,
+        dedupeKey,
         privacyMode: 'safe_to_speak',
       };
 
@@ -230,8 +325,17 @@ function readInputs(
   ) {
     return null;
   }
+  // VTID-03053: forward pillarMomentum when present. Defensive: only
+  // accept it as a structured object (the wiring helper always passes
+  // either a DecisionPillarMomentum or null/undefined).
+  const pillarMomentumRaw = obj.pillarMomentum;
+  const pillarMomentum =
+    pillarMomentumRaw && typeof pillarMomentumRaw === 'object'
+      ? (pillarMomentumRaw as VoiceWakeBriefInputs['pillarMomentum'])
+      : null;
   return {
     greetingPolicy: policy,
     lang: typeof obj.lang === 'string' ? obj.lang : undefined,
+    pillarMomentum,
   };
 }

--- a/services/gateway/src/services/wake-brief-wiring.ts
+++ b/services/gateway/src/services/wake-brief-wiring.ts
@@ -78,6 +78,20 @@ export interface DecideWakeBriefArgs {
   lang: string;
   /** journeySurface from the ClientContextEnvelope, if any. */
   envelopeJourneySurface?: string;
+  /**
+   * VTID-03053 — Distilled pillar-momentum view from the compiled
+   * AssistantDecisionContext. When passed, the wake-brief renderer may
+   * fold it into a proactive observation (one short sentence + one
+   * question) for slipping pillars. Enum-only by contract; no raw scores
+   * or medical interpretation cross into this arg.
+   *
+   * Both pipelines have access to this on the bootstrap path — Vertex
+   * via session.contextInstruction's compiler run, LiveKit via
+   * `/orb/context-bootstrap`'s `compileAssistantDecisionContext` call.
+   * Wiring sites pass it; the field stays optional so anonymous sessions
+   * (no spine) and provider-disabled tests don't need to mock it.
+   */
+  pillarMomentum?: import('../orb/context/types').DecisionPillarMomentum | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -121,6 +135,10 @@ export async function decideWakeBriefForSession(
   const wakeBriefInputs: VoiceWakeBriefInputs = {
     greetingPolicy,
     lang: args.lang,
+    // VTID-03053: forward pillar momentum for proactive opener variants.
+    // When null/missing the renderer falls back to the generic
+    // policy-keyed line — same behavior as before this slice.
+    pillarMomentum: args.pillarMomentum ?? null,
   };
 
   safeRecord(recorder, args.sessionId, 'continuation_decision_started', {

--- a/services/gateway/test/services/assistant-continuation/providers/voice-wake-brief-pillar-momentum.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/voice-wake-brief-pillar-momentum.test.ts
@@ -1,0 +1,245 @@
+/**
+ * VTID-03053 — voice-wake-brief pillar_momentum integration tests.
+ *
+ * The renderer must fold in distilled pillar_momentum signals when the
+ * confidence is medium/high and the suggested focus pillar is slipping
+ * or unknown. Other paths MUST fall through to the existing generic
+ * greeting line (no behavior regression).
+ *
+ * Coverage:
+ *   - shouldUsePillarProactiveLine boolean matrix
+ *     × policy ∈ {skip, brief_resume, warm_return, fresh_intro}
+ *     × confidence ∈ {low, medium, high}
+ *     × momentum ∈ {improving, steady, slipping, unknown}
+ *     × suggested_focus null vs set
+ *   - Per-language pillar lines emit when conditions are met
+ *   - Evidence carries the pillar focus + a confidence weight
+ *   - DedupeKey differentiates proactive vs generic variants
+ *   - Generic path unchanged when pillarMomentum is null/undefined
+ */
+
+import {
+  makeVoiceWakeBriefProvider,
+  defaultVoiceWakeBriefRenderer,
+  shouldUsePillarProactiveLine,
+  VOICE_WAKE_BRIEF_EXTRA_KEY,
+  type VoiceWakeBriefInputs,
+} from '../../../../src/services/assistant-continuation/providers/voice-wake-brief';
+import type { ContinuationDecisionContext } from '../../../../src/services/assistant-continuation/types';
+import type { DecisionPillarMomentum, PillarKey, PillarMomentumBand, PillarMomentumConfidence } from '../../../../src/orb/context/types';
+
+function makePm(over: Partial<DecisionPillarMomentum> = {}): DecisionPillarMomentum {
+  // Distinguish "key explicitly set to null" from "key absent" — the
+  // helper must support PM rows where suggested_focus or weakest_pillar
+  // are intentionally null (the null/no-data case).
+  const explicitSuggested = 'suggested_focus' in over ? over.suggested_focus : 'nutrition';
+  const focus: PillarKey = explicitSuggested ?? 'nutrition';
+  const momentum: PillarMomentumBand =
+    over.per_pillar?.find((p) => p.pillar === focus)?.momentum ?? 'slipping';
+  return {
+    per_pillar: over.per_pillar ?? [
+      { pillar: 'sleep', momentum: 'steady' },
+      { pillar: 'nutrition', momentum },
+      { pillar: 'exercise', momentum: 'steady' },
+      { pillar: 'hydration', momentum: 'steady' },
+      { pillar: 'mental', momentum: 'steady' },
+    ],
+    weakest_pillar: 'weakest_pillar' in over ? over.weakest_pillar! : focus,
+    strongest_pillar: over.strongest_pillar ?? 'sleep',
+    suggested_focus: explicitSuggested as PillarKey | null,
+    confidence: over.confidence ?? 'high',
+    warnings: over.warnings ?? [],
+  };
+}
+
+function makeCtx(inputs: VoiceWakeBriefInputs): ContinuationDecisionContext {
+  return {
+    surface: 'orb_wake',
+    sessionId: 's1',
+    userId: 'u1',
+    tenantId: 't1',
+    extra: { [VOICE_WAKE_BRIEF_EXTRA_KEY]: inputs },
+  };
+}
+
+describe('VTID-03053 — shouldUsePillarProactiveLine', () => {
+  test('returns false when pillarMomentum is null/undefined', () => {
+    expect(shouldUsePillarProactiveLine(null, 'fresh_intro')).toBe(false);
+    expect(shouldUsePillarProactiveLine(undefined, 'fresh_intro')).toBe(false);
+  });
+
+  test('returns false on policy=skip even with high-confidence slipping pillar', () => {
+    expect(
+      shouldUsePillarProactiveLine(makePm({ confidence: 'high' }), 'skip'),
+    ).toBe(false);
+  });
+
+  test('returns false on policy=brief_resume (tight follow-up line beats proactive)', () => {
+    expect(
+      shouldUsePillarProactiveLine(makePm({ confidence: 'high' }), 'brief_resume'),
+    ).toBe(false);
+  });
+
+  test('returns false when confidence is low', () => {
+    expect(
+      shouldUsePillarProactiveLine(makePm({ confidence: 'low' }), 'fresh_intro'),
+    ).toBe(false);
+  });
+
+  test('returns false when suggested_focus is null', () => {
+    expect(
+      shouldUsePillarProactiveLine(
+        makePm({ suggested_focus: null, weakest_pillar: null }),
+        'fresh_intro',
+      ),
+    ).toBe(false);
+  });
+
+  test('returns false when the suggested-focus pillar is steady or improving', () => {
+    for (const momentum of ['steady', 'improving'] as PillarMomentumBand[]) {
+      const pm = makePm({
+        per_pillar: [
+          { pillar: 'sleep', momentum: 'steady' },
+          { pillar: 'nutrition', momentum },
+          { pillar: 'exercise', momentum: 'steady' },
+          { pillar: 'hydration', momentum: 'steady' },
+          { pillar: 'mental', momentum: 'steady' },
+        ],
+      });
+      expect(shouldUsePillarProactiveLine(pm, 'fresh_intro')).toBe(false);
+    }
+  });
+
+  test('returns TRUE when focus pillar is slipping with medium+ confidence', () => {
+    for (const confidence of ['medium', 'high'] as PillarMomentumConfidence[]) {
+      const pm = makePm({ confidence });
+      expect(shouldUsePillarProactiveLine(pm, 'fresh_intro')).toBe(true);
+      expect(shouldUsePillarProactiveLine(pm, 'warm_return')).toBe(true);
+    }
+  });
+
+  test('returns TRUE when focus pillar momentum is unknown (gap-filling)', () => {
+    const pm = makePm({
+      per_pillar: [
+        { pillar: 'sleep', momentum: 'steady' },
+        { pillar: 'nutrition', momentum: 'unknown' },
+        { pillar: 'exercise', momentum: 'steady' },
+        { pillar: 'hydration', momentum: 'steady' },
+        { pillar: 'mental', momentum: 'steady' },
+      ],
+    });
+    expect(shouldUsePillarProactiveLine(pm, 'fresh_intro')).toBe(true);
+  });
+});
+
+describe('VTID-03053 — defaultVoiceWakeBriefRenderer emits pillar-specific lines', () => {
+  test('emits English nutrition line when conditions met', () => {
+    const line = defaultVoiceWakeBriefRenderer.render(
+      { greetingPolicy: 'fresh_intro', lang: 'en', pillarMomentum: makePm() },
+      makeCtx({ greetingPolicy: 'fresh_intro', lang: 'en' }),
+    );
+    expect(line).toContain('nutrition');
+    expect(line.toLowerCase()).toContain('slipping');
+  });
+
+  test('emits German nutrition line when conditions met', () => {
+    const line = defaultVoiceWakeBriefRenderer.render(
+      { greetingPolicy: 'fresh_intro', lang: 'de', pillarMomentum: makePm() },
+      makeCtx({ greetingPolicy: 'fresh_intro', lang: 'de' }),
+    );
+    expect(line.toLowerCase()).toContain('ernährungs-säule');
+    // German line says "sackt … etwas ab" (split verb), not "absackt".
+    expect(line.toLowerCase()).toContain('sackt');
+  });
+
+  test('emits per-pillar line for each PillarKey', () => {
+    const pillars: PillarKey[] = ['sleep', 'nutrition', 'exercise', 'hydration', 'mental'];
+    for (const pillar of pillars) {
+      const pm = makePm({
+        suggested_focus: pillar,
+        weakest_pillar: pillar,
+        per_pillar: [
+          { pillar: 'sleep', momentum: pillar === 'sleep' ? 'slipping' : 'steady' },
+          { pillar: 'nutrition', momentum: pillar === 'nutrition' ? 'slipping' : 'steady' },
+          { pillar: 'exercise', momentum: pillar === 'exercise' ? 'slipping' : 'steady' },
+          { pillar: 'hydration', momentum: pillar === 'hydration' ? 'slipping' : 'steady' },
+          { pillar: 'mental', momentum: pillar === 'mental' ? 'slipping' : 'steady' },
+        ],
+      });
+      const line = defaultVoiceWakeBriefRenderer.render(
+        { greetingPolicy: 'fresh_intro', lang: 'en', pillarMomentum: pm },
+        makeCtx({ greetingPolicy: 'fresh_intro', lang: 'en' }),
+      );
+      expect(line.length).toBeGreaterThan(0);
+      // The pillar name should appear in the rendered text (English).
+      expect(line.toLowerCase()).toContain(pillar);
+    }
+  });
+
+  test('falls through to generic greeting when pillarMomentum is null', () => {
+    const line = defaultVoiceWakeBriefRenderer.render(
+      { greetingPolicy: 'fresh_intro', lang: 'en', pillarMomentum: null },
+      makeCtx({ greetingPolicy: 'fresh_intro', lang: 'en' }),
+    );
+    expect(line).toBe('Hello! How can I help today?');
+  });
+
+  test('falls through to generic greeting when pillarMomentum is omitted', () => {
+    const line = defaultVoiceWakeBriefRenderer.render(
+      { greetingPolicy: 'warm_return', lang: 'de' },
+      makeCtx({ greetingPolicy: 'warm_return', lang: 'de' }),
+    );
+    expect(line).toContain('Schön, dass du wieder da bist');
+  });
+
+  test('falls through to generic greeting when policy is brief_resume', () => {
+    const line = defaultVoiceWakeBriefRenderer.render(
+      { greetingPolicy: 'brief_resume', lang: 'en', pillarMomentum: makePm() },
+      makeCtx({ greetingPolicy: 'brief_resume', lang: 'en' }),
+    );
+    expect(line).toBe('Back already? What did you want to follow up on?');
+  });
+});
+
+describe('VTID-03053 — provider candidate carries pillar evidence', () => {
+  test('returned candidate evidence + dedupeKey reflect the proactive variant', () => {
+    const provider = makeVoiceWakeBriefProvider({
+      newId: () => 'fixed-id',
+      now: () => 1_700_000_000_000,
+    });
+    const ctx = makeCtx({
+      greetingPolicy: 'fresh_intro',
+      lang: 'en',
+      pillarMomentum: makePm({ suggested_focus: 'nutrition', confidence: 'high' }),
+    });
+    const r = provider.produce(ctx);
+    expect(r.status).toBe('returned');
+    if (r.status !== 'returned') return;
+    const c = r.candidate!;
+    expect(c.evidence.some((e) => e.kind === 'greeting_policy')).toBe(true);
+    expect(c.evidence.some((e) => e.kind === 'pillar_momentum_slipping')).toBe(true);
+    const pillarEvidence = c.evidence.find((e) => e.kind === 'pillar_momentum_slipping')!;
+    expect(pillarEvidence.detail).toBe('nutrition');
+    expect(pillarEvidence.weight).toBe(1); // high confidence
+    // DedupeKey differentiates proactive from generic.
+    expect(c.dedupeKey).toBe('wake-brief-fresh_intro-pillar-nutrition');
+    expect(c.userFacingLine.toLowerCase()).toContain('nutrition');
+  });
+
+  test('generic candidate dedupeKey is unchanged when pillarMomentum is null', () => {
+    const provider = makeVoiceWakeBriefProvider({
+      newId: () => 'fixed-id',
+      now: () => 1_700_000_000_000,
+    });
+    const ctx = makeCtx({
+      greetingPolicy: 'fresh_intro',
+      lang: 'en',
+      pillarMomentum: null,
+    });
+    const r = provider.produce(ctx);
+    expect(r.status).toBe('returned');
+    if (r.status !== 'returned') return;
+    expect(r.candidate!.dedupeKey).toBe('wake-brief-fresh_intro');
+    expect(r.candidate!.evidence.some((e) => e.kind === 'pillar_momentum_slipping')).toBe(false);
+  });
+});


### PR DESCRIPTION
Replaces the generic 'Hello! How can I help today?' line with a data-driven proactive observation drawn from the decision-context spine (weakest pillar + trend + confidence). EN + DE coverage for all 5 pillars. Generic fallback unchanged. 16 new hermetic tests + 713 orb tests green.