### PR TITLE
DEV-AUTOPILOT: Implement SWR and concurrent coalescing for persona registry

### DIFF
--- a/services/gateway/src/services/persona-registry.ts
+++ b/services/gateway/src/services/persona-registry.ts
@@ -14,6 +14,8 @@
 
 import { createClient } from '@supabase/supabase-js';
 
+const FF_OPTIMIZE_PERSONA_REGISTRY = process.env.FF_OPTIMIZE_PERSONA_REGISTRY === 'true';
+
 export interface PersonaRecord {
   id: string;
   key: string;
@@ -42,6 +44,9 @@ const CACHE_TTL_MS = 60_000;
 let cache: { at: number; map: Map<string, PersonaRecord> } | null = null;
 let inFlight: Promise<Map<string, PersonaRecord>> | null = null;
 
+const tenantCache = new Map<string, { at: number; map: Map<string, TenantPersonaRecord> }>();
+const tenantInFlight = new Map<string, Promise<Map<string, TenantPersonaRecord>>>();
+
 function getServiceClient() {
   const url = process.env.SUPABASE_URL;
   const key = process.env.SUPABASE_SERVICE_ROLE;
@@ -68,10 +73,7 @@ async function loadFromDB(): Promise<Map<string, PersonaRecord>> {
   return map;
 }
 
-export async function loadPersonaRegistry(forceRefresh = false): Promise<Map<string, PersonaRecord>> {
-  if (!forceRefresh && cache && Date.now() - cache.at < CACHE_TTL_MS) {
-    return cache.map;
-  }
+function triggerPlatformReload(): Promise<Map<string, PersonaRecord>> {
   if (inFlight) return inFlight;
   inFlight = (async () => {
     try {
@@ -83,6 +85,25 @@ export async function loadPersonaRegistry(forceRefresh = false): Promise<Map<str
     }
   })();
   return inFlight;
+}
+
+export async function loadPersonaRegistry(forceRefresh = false): Promise<Map<string, PersonaRecord>> {
+  if (forceRefresh) {
+    return triggerPlatformReload();
+  }
+  if (cache) {
+    const isStale = Date.now() - cache.at >= CACHE_TTL_MS;
+    if (!isStale) {
+      return cache.map;
+    }
+    if (FF_OPTIMIZE_PERSONA_REGISTRY) {
+      triggerPlatformReload().catch(e => {
+        console.error('[persona-registry] SWR platform fetch failed:', e);
+      });
+      return cache.map;
+    }
+  }
+  return triggerPlatformReload();
 }
 
 export function clearPersonaRegistryCache(): void {
@@ -226,8 +247,6 @@ export interface TenantPersonaRecord extends PersonaRecord {
   intake_schema_extras: Record<string, unknown>;
 }
 
-const tenantCache = new Map<string, { at: number; map: Map<string, TenantPersonaRecord> }>();
-
 async function loadTenantOverrides(tenantId: string): Promise<Map<string, TenantOverridesRecord>> {
   const supabase = getServiceClient();
   const { data, error } = await supabase
@@ -244,6 +263,42 @@ async function loadTenantOverrides(tenantId: string): Promise<Map<string, Tenant
     map.set(r.persona_id, r);
   }
   return map;
+}
+
+function triggerTenantReload(tenantId: string, forceRefresh: boolean): Promise<Map<string, TenantPersonaRecord>> {
+  if (tenantInFlight.has(tenantId)) {
+    return tenantInFlight.get(tenantId)!;
+  }
+  const promise = (async () => {
+    try {
+      const [platform, overrides] = await Promise.all([
+        loadPersonaRegistry(forceRefresh),
+        loadTenantOverrides(tenantId),
+      ]);
+      const merged = new Map<string, TenantPersonaRecord>();
+      for (const [k, p] of platform) {
+        const ov = overrides.get(p.id);
+        const tenant_enabled = ov ? ov.enabled : true;
+        // Merge greeting templates: tenant custom wins over platform per-language
+        const greeting_templates =
+          ov?.custom_greeting_templates && Object.keys(ov.custom_greeting_templates).length > 0
+            ? { ...p.greeting_templates, ...ov.custom_greeting_templates }
+            : p.greeting_templates;
+        merged.set(k, {
+          ...p,
+          greeting_templates,
+          tenant_enabled,
+          intake_schema_extras: ov?.intake_schema_extras ?? {},
+        });
+      }
+      tenantCache.set(tenantId, { at: Date.now(), map: merged });
+      return merged;
+    } finally {
+      tenantInFlight.delete(tenantId);
+    }
+  })();
+  tenantInFlight.set(tenantId, promise);
+  return promise;
 }
 
 /**
@@ -263,32 +318,26 @@ export async function loadPersonaRegistryForTenant(
     }
     return merged;
   }
+
+  if (forceRefresh) {
+    return triggerTenantReload(tenantId, true);
+  }
+
   const cached = tenantCache.get(tenantId);
-  if (!forceRefresh && cached && Date.now() - cached.at < CACHE_TTL_MS) {
-    return cached.map;
+  if (cached) {
+    const isStale = Date.now() - cached.at >= CACHE_TTL_MS;
+    if (!isStale) {
+      return cached.map;
+    }
+    if (FF_OPTIMIZE_PERSONA_REGISTRY) {
+      triggerTenantReload(tenantId, false).catch(e => {
+        console.error(`[persona-registry] SWR tenant fetch failed for ${tenantId}:`, e);
+      });
+      return cached.map;
+    }
   }
-  const [platform, overrides] = await Promise.all([
-    loadPersonaRegistry(forceRefresh),
-    loadTenantOverrides(tenantId),
-  ]);
-  const merged = new Map<string, TenantPersonaRecord>();
-  for (const [k, p] of platform) {
-    const ov = overrides.get(p.id);
-    const tenant_enabled = ov ? ov.enabled : true;
-    // Merge greeting templates: tenant custom wins over platform per-language
-    const greeting_templates =
-      ov?.custom_greeting_templates && Object.keys(ov.custom_greeting_templates).length > 0
-        ? { ...p.greeting_templates, ...ov.custom_greeting_templates }
-        : p.greeting_templates;
-    merged.set(k, {
-      ...p,
-      greeting_templates,
-      tenant_enabled,
-      intake_schema_extras: ov?.intake_schema_extras ?? {},
-    });
-  }
-  tenantCache.set(tenantId, { at: Date.now(), map: merged });
-  return merged;
+
+  return triggerTenantReload(tenantId, false);
 }
 
 export function clearTenantPersonaCache(tenantId?: string): void {

--- a/services/gateway/test/persona-registry.test.ts
+++ b/services/gateway/test/persona-registry.test.ts
@@ -1,0 +1,157 @@
+import { createClient } from '@supabase/supabase-js';
+
+jest.mock('@supabase/supabase-js', () => ({
+  createClient: jest.fn(),
+}));
+
+describe('Persona Registry', () => {
+  let originalEnv: NodeJS.ProcessEnv;
+
+  beforeEach(() => {
+    jest.useFakeTimers();
+    originalEnv = { ...process.env };
+    process.env.SUPABASE_URL = 'http://localhost';
+    process.env.SUPABASE_SERVICE_ROLE = 'key';
+  });
+
+  afterEach(() => {
+    process.env = originalEnv;
+    jest.useRealTimers();
+    jest.clearAllMocks();
+  });
+
+  it('coalesces concurrent loadPersonaRegistryForTenant requests', async () => {
+    process.env.FF_OPTIMIZE_PERSONA_REGISTRY = 'false';
+    let loadPersonaRegistryForTenant: any;
+    let clearTenantPersonaCache: any;
+    let clearPersonaRegistryCache: any;
+    
+    jest.isolateModules(() => {
+      const mod = require('../src/services/persona-registry');
+      loadPersonaRegistryForTenant = mod.loadPersonaRegistryForTenant;
+      clearTenantPersonaCache = mod.clearTenantPersonaCache;
+      clearPersonaRegistryCache = mod.clearPersonaRegistryCache;
+    });
+
+    let platformResolvers: any[] = [];
+    let tenantResolvers: any[] = [];
+
+    const mockSupabase = {
+      from: jest.fn((table: string) => {
+        if (table === 'agent_personas_registry') {
+          return {
+            select: () => new Promise(resolve => platformResolvers.push(resolve))
+          };
+        }
+        if (table === 'agent_personas_tenant_overrides') {
+          return {
+            select: () => ({
+              eq: () => new Promise(resolve => tenantResolvers.push(resolve))
+            })
+          };
+        }
+      })
+    };
+
+    (createClient as jest.Mock).mockReturnValue(mockSupabase);
+
+    clearPersonaRegistryCache();
+    clearTenantPersonaCache();
+
+    // Trigger two concurrent requests (thundering herd simulation)
+    const p1 = loadPersonaRegistryForTenant('tenant-1');
+    const p2 = loadPersonaRegistryForTenant('tenant-1');
+
+    // Wait for the promises to be registered
+    await Promise.resolve();
+
+    // They should have only hit the DB once per table (one for platform registry, one for tenant overrides)
+    expect(mockSupabase.from).toHaveBeenCalledTimes(2);
+
+    // Resolve the single background query
+    platformResolvers.forEach(r => r({ data: [], error: null }));
+    tenantResolvers.forEach(r => r({ data: [], error: null }));
+
+    const results = await Promise.all([p1, p2]);
+    // Both returned maps should be the identical instance since they coalesce
+    expect(results[0]).toBe(results[1]); 
+  });
+
+  it('instantly returns stale cache and fetches in background when FF is true', async () => {
+    process.env.FF_OPTIMIZE_PERSONA_REGISTRY = 'true';
+    let loadPersonaRegistryForTenant: any;
+    let clearTenantPersonaCache: any;
+    let clearPersonaRegistryCache: any;
+    
+    jest.isolateModules(() => {
+      const mod = require('../src/services/persona-registry');
+      loadPersonaRegistryForTenant = mod.loadPersonaRegistryForTenant;
+      clearTenantPersonaCache = mod.clearTenantPersonaCache;
+      clearPersonaRegistryCache = mod.clearPersonaRegistryCache;
+    });
+
+    let dbCallCount = 0;
+    let platformResolvers: any[] = [];
+    let tenantResolvers: any[] = [];
+
+    const mockSupabase = {
+      from: jest.fn((table: string) => {
+        dbCallCount++;
+        if (table === 'agent_personas_registry') {
+          return {
+            select: () => new Promise(resolve => platformResolvers.push(resolve))
+          };
+        }
+        if (table === 'agent_personas_tenant_overrides') {
+          return {
+            select: () => ({
+              eq: () => new Promise(resolve => tenantResolvers.push(resolve))
+            })
+          };
+        }
+      })
+    };
+
+    (createClient as jest.Mock).mockReturnValue(mockSupabase);
+
+    clearPersonaRegistryCache();
+    clearTenantPersonaCache();
+
+    // 1. Initial request (blocks and fetches)
+    const p1 = loadPersonaRegistryForTenant('tenant-2');
+    await Promise.resolve();
+    
+    expect(dbCallCount).toBe(2);
+    
+    const mockPlatformData = [{ id: 'p1', key: 'test', greeting_templates: {} }];
+    platformResolvers.forEach(r => r({ data: mockPlatformData, error: null }));
+    tenantResolvers.forEach(r => r({ data: [], error: null }));
+    platformResolvers = [];
+    tenantResolvers = [];
+    
+    const initialMap = await p1;
+    expect(initialMap.has('test')).toBe(true);
+
+    // 2. Advance time past CACHE_TTL_MS (60s) to make cache stale
+    jest.setSystemTime(Date.now() + 65_000);
+
+    // 3. Second request should hit SWR flow and return instantly with stale map
+    let secondResolved = false;
+    let returnedMap: any = null;
+    const p2 = loadPersonaRegistryForTenant('tenant-2').then((res: any) => {
+      secondResolved = true;
+      returnedMap = res;
+    });
+    
+    await Promise.resolve(); 
+    expect(secondResolved).toBe(true);
+    expect(returnedMap).toBe(initialMap);
+    
+    // 4. Background update should have triggered new DB calls without blocking returning value
+    expect(dbCallCount).toBe(4);
+    
+    // Resolve background fetches cleanly
+    platformResolvers.forEach(r => r({ data: mockPlatformData, error: null }));
+    tenantResolvers.forEach(r => r({ data: [], error: null }));
+  });
+});


### PR DESCRIPTION
Addresses high Time To First Byte (TTFB) latency in live voice interactions caused by synchronously blocking database lookups when the 60s persona cache expires. 

This PR:
- Introduces `FF_OPTIMIZE_PERSONA_REGISTRY` to gate the new cache behavior.
- Implements the Stale-While-Revalidate (SWR) pattern: if the cache is stale and the feature flag is active, it immediately returns the stale response while updating the cache asynchronously.
- Implements concurrent request coalescing (using `tenantInFlight`) for tenant configurations, eliminating the "thundering herd" database query spike.
- Maintains backwards compatibility when the feature flag is off or on initial cold starts.
- Includes unit tests to verify both concurrency deduplication and the zero-latency SWR path.

Files updated:
- `services/gateway/src/services/persona-registry.ts`
- `services/gateway/test/persona-registry.test.ts`