### PR TITLE
ops(autopilot-job): auto-trigger on gateway changes + docker-login retry + diag --async (VTID-03055)

### DIFF
--- a/.github/workflows/DEPLOY-AUTOPILOT-JOB.yml
+++ b/.github/workflows/DEPLOY-AUTOPILOT-JOB.yml
@@ -18,7 +18,18 @@
 
 name: Deploy Autopilot Job (VTID-02703)
 
+# Triggers:
+#   1. Manual: workflow_dispatch with overridable knobs (memory/cpu/timeout).
+#   2. Auto: every push to main that touches services/gateway/** or this
+#      workflow file. Without auto-trigger, the Job image silently drifts —
+#      we shipped 12 days of gateway changes (2026-05-05 → 2026-05-17) while
+#      the Job ran stale code and every dispatched execution hung.
 on:
+  push:
+    branches: [main]
+    paths:
+      - 'services/gateway/**'
+      - '.github/workflows/DEPLOY-AUTOPILOT-JOB.yml'
   workflow_dispatch:
     inputs:
       vtid:
@@ -59,8 +70,21 @@ jobs:
         # WIF gives us a short-lived OAuth token; gcloud configure-docker
         # only sets a credential helper that isn't honored here. Explicit
         # docker login with the access token works.
+        #
+        # Retry: 2026-05-17 saw a real-deal transient "context deadline
+        # exceeded" against pkg.dev's token endpoint that failed the whole
+        # workflow. Three attempts with a 10s pause cleanly absorbs that.
         run: |
-          gcloud auth print-access-token | docker login -u oauth2accesstoken --password-stdin us-central1-docker.pkg.dev
+          for attempt in 1 2 3; do
+            if gcloud auth print-access-token | docker login -u oauth2accesstoken --password-stdin us-central1-docker.pkg.dev; then
+              echo "docker login ok on attempt $attempt"
+              exit 0
+            fi
+            echo "docker login attempt $attempt failed — sleeping 10s"
+            sleep 10
+          done
+          echo "docker login failed after 3 attempts" >&2
+          exit 1
 
       - name: Build container with Dockerfile.job (local docker)
         env:
@@ -90,6 +114,12 @@ jobs:
           PROJECT: lovable-vitana-vers1
           REGION: us-central1
           JOB_NAME: autopilot-executor
+          # On push triggers `inputs.*` is empty; fall back to the same
+          # defaults the workflow_dispatch form declares so the gcloud
+          # flags stay valid either way.
+          TIMEOUT_SECONDS: ${{ github.event.inputs.timeout_seconds || '3600' }}
+          MEMORY: ${{ github.event.inputs.memory || '2Gi' }}
+          CPU: ${{ github.event.inputs.cpu || '2' }}
         run: |
           set -e
           IMAGE_URI="$REGION-docker.pkg.dev/$PROJECT/cloud-run-source-deploy/autopilot-executor:${{ github.sha }}"
@@ -98,9 +128,9 @@ jobs:
             --image="$IMAGE_URI" \
             --region="$REGION" \
             --project="$PROJECT" \
-            --task-timeout="${{ github.event.inputs.timeout_seconds }}s" \
-            --memory="${{ github.event.inputs.memory }}" \
-            --cpu="${{ github.event.inputs.cpu }}" \
+            --task-timeout="${TIMEOUT_SECONDS}s" \
+            --memory="$MEMORY" \
+            --cpu="$CPU" \
             --max-retries=0 \
             --parallelism=1 \
             --tasks=1 \

--- a/.github/workflows/DIAGNOSE-AUTOPILOT.yml
+++ b/.github/workflows/DIAGNOSE-AUTOPILOT.yml
@@ -50,10 +50,12 @@ jobs:
             --limit=10 --format='table(name,creationTimestamp,completionTime,succeededCount,failedCount)' || echo "no executions"
 
       - name: Try dispatching a test execution
+        # --wait=false is rejected by gcloud (boolean flag, no explicit value
+        # allowed). Use --async, which is the supported way to fire-and-forget.
         run: |
           set -e
           echo "=== Try dispatch autopilot-executor with EXEC_ID=DIAG ==="
           gcloud run jobs execute autopilot-executor \
             --region=us-central1 --project=lovable-vitana-vers1 \
             --update-env-vars=EXEC_ID=DIAG-NOOP \
-            --wait=false 2>&1 || echo "DISPATCH FAILED"
+            --async 2>&1 || echo "DISPATCH FAILED"


### PR DESCRIPTION
## Why

Three small ops fixes surfaced while running the feedback pipeline end-to-end on **FB-2026-05-000092** earlier today. All three are workflow-only — no code changes.

## What

### 1. Auto-trigger `DEPLOY-AUTOPILOT-JOB.yml` on push to `main` for `services/gateway/**`

The autopilot-executor Cloud Run Job image silently drifted from **2026-05-05** to **2026-05-17** (12 days, ~80 gateway commits) because every `EXEC-DEPLOY` only refreshes the gateway *service*. The Job, which shares the same source tree, stayed pinned at `f916e09c`. Every dispatched execution from **2026-05-14** onward ran 12-day-stale code that hung silently — none of them completed; jobs from 3 days ago still show no `completion_time` in `gcloud run jobs executions list`.

Tying the Job rebuild to the same path filter (`services/gateway/**`) the service uses means they stay in lockstep.

### 2. Docker-login retry (3 attempts, 10s pause)

Today's first manual rebuild failed at `docker login -u oauth2accesstoken` with:
```
Error response from daemon: ... context deadline exceeded ...
```
Pure transient Artifact Registry token-mint slowness. The rerun worked. A 3-attempt retry absorbs that without manual intervention.

### 3. `DIAGNOSE-AUTOPILOT.yml`: `--wait=false` → `--async`

`gcloud run jobs execute --wait` is a boolean flag and rejects explicit values:
```
ERROR: argument --wait: ignored explicit argument 'false'
```
The test-dispatch step has always failed. The supported escape hatch is `--async`.

## Risk

Workflow-only. The new path-filter trigger only fires for changes touching `services/gateway/**` and is idempotent (Cloud Run Job deploy overwrites). The retry only kicks in when the underlying `docker login` returns a non-zero exit. The diag fix is a syntax correction.

🤖 Generated with [Claude Code](https://claude.com/claude-code)