### PR TITLE
feat(orb-livekit): B0d-real Xa — Contextual Next Action provider skeleton (VTID-03056)

### DIFF
--- a/services/gateway/src/services/assistant-continuation/providers/next-action/composer.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/next-action/composer.ts
@@ -1,0 +1,178 @@
+/**
+ * VTID-03056 (B0d-real slice Xa) — Next Action composer.
+ *
+ * Iterates the registered NextActionSources in parallel, normalizes
+ * their `NextActionSourceResult`s, and picks the highest-priority
+ * candidate. Ties are broken by registration order so the result is
+ * deterministic.
+ *
+ * Empty-sources-registry / all-sources-skipped / all-sources-errored
+ * paths all return a `chosen: null` result with a typed `suppressReason`
+ * — never throws upward. The framework's decideContinuation orchestrator
+ * also tolerates throws, but B0d-real never relies on that — the
+ * composer is the source of truth for "why nothing fired".
+ *
+ * Subsequent slices (Xb-Xe) ADD sources to the registry without
+ * touching this file. Acceptance criteria #1-#6 from the B0d-real spec
+ * are all about which source can win — that's the composer's job here.
+ */
+
+import type {
+  NextActionComposer,
+  NextActionComposeResult,
+  NextActionSource,
+  NextActionSourceContext,
+  NextActionSourceKey,
+  NextActionSourceResult,
+  ScoredCandidate,
+} from './types';
+
+class CompositeNextActionComposer implements NextActionComposer {
+  /**
+   * Insertion-ordered map. JS Maps preserve insertion order, which is
+   * exactly the tie-breaker we want — the registration order of the
+   * production wiring determines which source wins on equal priority.
+   */
+  private readonly sources = new Map<NextActionSourceKey, NextActionSource>();
+
+  register(source: NextActionSource): void {
+    this.sources.set(source.key, source);
+  }
+
+  reset(): void {
+    this.sources.clear();
+  }
+
+  registeredKeys(): readonly NextActionSourceKey[] {
+    return Array.from(this.sources.keys());
+  }
+
+  async compose(
+    surface: 'orb_wake' | 'orb_turn_end',
+    ctx: NextActionSourceContext,
+  ): Promise<NextActionComposeResult> {
+    const composeStartedAt = new Date().toISOString();
+
+    if (this.sources.size === 0) {
+      return {
+        chosen: null,
+        candidates: [],
+        suppressReason: 'no_sources_registered',
+        composeStartedAt,
+        composeFinishedAt: new Date().toISOString(),
+      };
+    }
+
+    const eligible: NextActionSource[] = [];
+    for (const source of this.sources.values()) {
+      if (source.serves(surface)) eligible.push(source);
+    }
+
+    const t0 = Date.now();
+    const results = await Promise.all(
+      eligible.map((source) => invokeSourceSafely(source, ctx, t0)),
+    );
+    const composeFinishedAt = new Date().toISOString();
+
+    return {
+      ...rank(results),
+      candidates: results,
+      composeStartedAt,
+      composeFinishedAt,
+    };
+  }
+}
+
+async function invokeSourceSafely(
+  source: NextActionSource,
+  ctx: NextActionSourceContext,
+  startMs: number,
+): Promise<NextActionSourceResult> {
+  try {
+    const result = await source.produce(ctx);
+    const latencyMs = Math.max(0, Date.now() - startMs);
+    // Defensive: collapse mutual-exclusion violation (candidate AND
+    // skippedReason) to an errored row. Sources should never do this, but
+    // a buggy source MUST NOT propagate inconsistent state into the
+    // ranker.
+    if (result.candidate && result.skippedReason) {
+      return {
+        source: source.key,
+        candidate: null,
+        skippedReason: 'errored',
+        latencyMs,
+      };
+    }
+    return { ...result, latencyMs };
+  } catch (err) {
+    return {
+      source: source.key,
+      candidate: null,
+      skippedReason: 'errored',
+      latencyMs: Math.max(0, Date.now() - startMs),
+    };
+  }
+}
+
+/**
+ * Pick the winning candidate across all sources.
+ *
+ * Rules:
+ *   1. Drop results without a candidate.
+ *   2. Sort by priority descending. Stable sort preserves registration
+ *      order, which is the deterministic tie-breaker.
+ *   3. Apply the cross-source threshold (50). Below that, the composer
+ *      reports `tied_below_threshold` so the wake-brief fallback can
+ *      still fire its generic line.
+ *   4. Return chosen + suppress reason (when null).
+ */
+export function rank(
+  results: ReadonlyArray<NextActionSourceResult>,
+): Pick<NextActionComposeResult, 'chosen' | 'suppressReason'> {
+  const withCandidates = results.filter(
+    (r): r is NextActionSourceResult & { candidate: ScoredCandidate } =>
+      r.candidate !== null && r.candidate !== undefined,
+  );
+
+  if (withCandidates.length === 0) {
+    // Distinguish "every source errored" from "all skipped"; both
+    // matter for the Command Hub Inspector but only the former is a
+    // health signal.
+    const erroredAll =
+      results.length > 0 && results.every((r) => r.skippedReason === 'errored');
+    return {
+      chosen: null,
+      suppressReason: erroredAll ? 'all_sources_errored' : 'all_sources_skipped',
+    };
+  }
+
+  // Stable sort: JS Array.prototype.sort is spec'd stable since ES2019.
+  const sorted = [...withCandidates].sort(
+    (a, b) => b.candidate.priority - a.candidate.priority,
+  );
+  const top = sorted[0].candidate;
+
+  if (top.priority < CROSS_SOURCE_THRESHOLD) {
+    return { chosen: null, suppressReason: 'tied_below_threshold' };
+  }
+
+  return { chosen: top };
+}
+
+/**
+ * Below this priority, the composer suppresses and the framework's
+ * fallback voice-wake-brief provider (the B0d-mini hardcoded path)
+ * gets to fire instead. Above it, B0d-real has something real to say.
+ *
+ * Keep this constant exported so the per-source rankers can tune
+ * against a single known threshold.
+ */
+export const CROSS_SOURCE_THRESHOLD = 50;
+
+/**
+ * Module-level composer used by the production provider. Tests build
+ * their own instances; production wiring registers sources here once
+ * at import time (in the source files themselves).
+ */
+export const defaultNextActionComposer: NextActionComposer =
+  new CompositeNextActionComposer();

--- a/services/gateway/src/services/assistant-continuation/providers/next-action/index.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/next-action/index.ts
@@ -1,0 +1,235 @@
+/**
+ * VTID-03056 (B0d-real slice Xa) — Next Action provider entry point.
+ *
+ * The "Contextual Next Action Provider" the user asked for. It composes
+ * across the registered NextActionSources (autopilot, reminders,
+ * calendar, life-compass, pillar-momentum, diary, journey-stage, match,
+ * continuity) and produces ONE AssistantContinuation per surface.
+ *
+ * This slice (Xa) ships the SKELETON only:
+ *   - `makeNextActionProvider()` factory wired to the composer.
+ *   - The composer's source registry is EMPTY by default; production
+ *     wiring under `sources/` will register concrete sources in
+ *     Xb-Xe slices.
+ *   - When no sources are registered or no source returns a candidate,
+ *     the provider returns `status: 'suppressed'` with a typed reason —
+ *     not `status: 'returned'`. This lets the framework's existing
+ *     voice-wake-brief provider (B0d-mini hardcoded path) still produce
+ *     the fallback greeting line.
+ *   - Priority defaults to 90 (above voice-wake-brief's 80) so a real
+ *     B0d-real candidate beats the hardcoded fallback. Per-source
+ *     priorities live INSIDE each source — this 90 is the
+ *     provider-level priority the framework sees.
+ *
+ * The provider is registered in `services/wake-brief-wiring.ts` next
+ * to voice-wake-brief so both fire on `orb_wake`. When a real source
+ * has a candidate, the framework picks this one (priority 90 > 80);
+ * when no source has anything, the framework picks voice-wake-brief
+ * (which has its own hardcoded line). Either way the orb has a first
+ * spoken line.
+ */
+
+import { randomUUID } from 'crypto';
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+import type {
+  AssistantContinuation,
+  ContinuationDecisionContext,
+  ContinuationProvider,
+  ProviderResult,
+} from '../../types';
+
+import {
+  defaultNextActionComposer,
+} from './composer';
+import type {
+  NextActionComposer,
+  NextActionSourceContext,
+  ScoredCandidate,
+  NextActionComposeResult,
+} from './types';
+
+// ---------------------------------------------------------------------------
+// Inputs the wiring passes via ctx.extra.nextAction
+// ---------------------------------------------------------------------------
+
+/**
+ * The slim view the next-action provider needs from the wiring layer.
+ * The wiring code (e.g. orb-livekit.ts bootstrap, ai-chat turn-end) is
+ * responsible for plumbing the supabase client + decisionContext.
+ *
+ * decisionContext stays opaque to the composer; each source casts what
+ * it needs from it (e.g. pillar_momentum, continuity).
+ */
+export interface NextActionInputs {
+  supabase: SupabaseClient;
+  decisionContext: unknown;
+}
+
+export const NEXT_ACTION_EXTRA_KEY = 'nextAction' as const;
+export const NEXT_ACTION_PROVIDER_KEY = 'contextual_next_action' as const;
+const DEFAULT_PRIORITY = 90;
+
+// ---------------------------------------------------------------------------
+// Provider factory
+// ---------------------------------------------------------------------------
+
+export interface NextActionProviderOptions {
+  /** Override the default module-level composer (used by tests). */
+  composer?: NextActionComposer;
+  /** Deterministic id generator for tests. */
+  newId?: () => string;
+  /** Provider-level priority. Default 90 (above voice-wake-brief's 80). */
+  priority?: number;
+}
+
+/**
+ * Build the Contextual Next Action provider. Exported as a factory so
+ * tests can pass a fresh composer with stubbed sources and prod wiring
+ * uses the module-level singleton with whatever sources have registered.
+ */
+export function makeNextActionProvider(
+  opts: NextActionProviderOptions = {},
+): ContinuationProvider {
+  const composer = opts.composer ?? defaultNextActionComposer;
+  const newId = opts.newId ?? randomUUID;
+  const priority = opts.priority ?? DEFAULT_PRIORITY;
+
+  return {
+    key: NEXT_ACTION_PROVIDER_KEY,
+    surfaces: ['orb_wake', 'orb_turn_end'],
+    async produce(ctx: ContinuationDecisionContext): Promise<ProviderResult> {
+      const t0 = Date.now();
+
+      const inputs = readInputs(ctx);
+      if (!inputs) {
+        return {
+          providerKey: NEXT_ACTION_PROVIDER_KEY,
+          status: 'skipped',
+          latencyMs: Math.max(0, Date.now() - t0),
+          reason: 'no_next_action_inputs',
+        };
+      }
+
+      if (!ctx.userId || !ctx.tenantId) {
+        return {
+          providerKey: NEXT_ACTION_PROVIDER_KEY,
+          status: 'skipped',
+          latencyMs: Math.max(0, Date.now() - t0),
+          reason: 'anonymous_caller',
+        };
+      }
+
+      const surface = ctx.surface;
+      if (surface !== 'orb_wake' && surface !== 'orb_turn_end') {
+        return {
+          providerKey: NEXT_ACTION_PROVIDER_KEY,
+          status: 'skipped',
+          latencyMs: Math.max(0, Date.now() - t0),
+          reason: 'unsupported_surface',
+        };
+      }
+
+      // Always invoke the composer, even with zero sources — it returns
+      // a typed `no_sources_registered` suppression in that case which
+      // the Command Hub Inspector can render.
+      let result: NextActionComposeResult;
+      try {
+        result = await composer.compose(surface, {
+          userId: ctx.userId,
+          tenantId: ctx.tenantId,
+          lang: 'lang' in (inputs as object) ? (inputs as { lang?: string }).lang ?? 'en' : 'en',
+          nowIso: new Date().toISOString(),
+          decisionContext: inputs.decisionContext,
+          supabase: inputs.supabase,
+        });
+      } catch (err) {
+        return {
+          providerKey: NEXT_ACTION_PROVIDER_KEY,
+          status: 'errored',
+          latencyMs: Math.max(0, Date.now() - t0),
+          reason: err instanceof Error ? err.message : String(err),
+        };
+      }
+
+      if (!result.chosen) {
+        return {
+          providerKey: NEXT_ACTION_PROVIDER_KEY,
+          status: 'suppressed',
+          latencyMs: Math.max(0, Date.now() - t0),
+          reason: result.suppressReason ?? 'no_chosen_candidate',
+        };
+      }
+
+      const candidate = renderCandidateAsContinuation(result.chosen, surface, priority, newId);
+      return {
+        providerKey: NEXT_ACTION_PROVIDER_KEY,
+        status: 'returned',
+        latencyMs: Math.max(0, Date.now() - t0),
+        candidate,
+      };
+    },
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Internal helpers
+// ---------------------------------------------------------------------------
+
+function readInputs(ctx: ContinuationDecisionContext): NextActionInputs | null {
+  const extra = ctx.extra;
+  if (!extra || typeof extra !== 'object') return null;
+  const raw = (extra as Record<string, unknown>)[NEXT_ACTION_EXTRA_KEY];
+  if (!raw || typeof raw !== 'object') return null;
+  const obj = raw as Record<string, unknown>;
+  const supabase = obj.supabase;
+  // Best-effort duck-typing of the Supabase client — it MUST have .from
+  // and .rpc methods for sources to query their tables.
+  if (
+    !supabase ||
+    typeof supabase !== 'object' ||
+    typeof (supabase as Record<string, unknown>).from !== 'function' ||
+    typeof (supabase as Record<string, unknown>).rpc !== 'function'
+  ) {
+    return null;
+  }
+  return {
+    supabase: supabase as SupabaseClient,
+    decisionContext: obj.decisionContext,
+  };
+}
+
+function renderCandidateAsContinuation(
+  c: ScoredCandidate,
+  surface: 'orb_wake' | 'orb_turn_end',
+  priority: number,
+  newId: () => string,
+): AssistantContinuation {
+  // Per-language pick. The composer already picked the line for the
+  // caller's lang in normal flow, so userFacingLine is authoritative.
+  const userFacingLine = c.userFacingLine.trim();
+  return {
+    id: `next-action-${newId()}`,
+    surface,
+    // The continuation kind is `next_step` per the framework enum — the
+    // composite "B0d-real" winner is, by definition, a next-step
+    // recommendation.
+    kind: 'next_step',
+    priority,
+    userFacingLine,
+    cta: c.cta ?? { type: 'explain' },
+    evidence: [
+      {
+        kind: `source:${c.source}`,
+        detail: `priority=${c.priority} confidence=${c.confidence}`,
+        weight: c.confidence === 'high' ? 1 : c.confidence === 'medium' ? 0.6 : 0.3,
+      },
+      ...c.reasons.map((r) => ({
+        kind: r.kind,
+        detail: r.detail,
+      })),
+    ],
+    dedupeKey: c.dedupeKey,
+    privacyMode: 'safe_to_speak',
+  };
+}

--- a/services/gateway/src/services/assistant-continuation/providers/next-action/types.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/next-action/types.ts
@@ -1,0 +1,272 @@
+/**
+ * VTID-03056 (B0d-real slice Xa) — Contextual Next Action Provider types.
+ *
+ * The wake-brief v0 (B0d-mini, VTID-03052/03053/03054) shipped ONE
+ * hardcoded pillar-momentum line. B0d-real composes the user's full
+ * context — Life Compass, Vitana Index, diary, journey stage, Autopilot
+ * recommendations, calendar, reminders, matches/intents/activity plans,
+ * pending threads/promises, continuity — and picks ONE next-best action.
+ *
+ * Architecture: ONE composite provider with a pluggable per-source
+ * registry. The framework's existing decideContinuation ranks providers;
+ * inside THIS provider, the composer ranks SOURCES. Cross-source
+ * comparisons happen here so we can break ties deterministically and
+ * surface candidate-vs-winner evidence to the Command Hub.
+ *
+ * Each source file under `sources/` exposes a `NextActionSource` and
+ * receives a `NextActionSourceContext` derived from the framework's
+ * `ContinuationDecisionContext`. Sources NEVER throw — failures surface
+ * as a `failed` candidate in the inspector trail.
+ *
+ * This slice ships the types + an empty composer + tests; concrete
+ * sources land in follow-up slices Xb-Xe.
+ */
+
+import type { AssistantContinuationDecision, ContinuationCta } from '../../types';
+
+// ---------------------------------------------------------------------------
+// Source identity
+// ---------------------------------------------------------------------------
+
+/**
+ * Stable identifier for each source. Used in OASIS payloads, the Command
+ * Hub Candidate Inspector, and the per-source flag gates. Keep this enum
+ * as the single source of truth — adding a source means adding here AND
+ * registering the source file with the composer.
+ *
+ * The list mirrors the 11 input categories from the B0d-real scope:
+ *   - autopilot_recommendation
+ *   - reminder_due
+ *   - calendar_upcoming
+ *   - life_compass_alignment
+ *   - vitana_index_pillar
+ *   - diary_missing_relevant
+ *   - journey_stage_nudge
+ *   - match_activity_plan
+ *   - continuity_pending_thread
+ *   - continuity_promise_owed
+ *
+ * "Pillar momentum" is now ONE source (vitana_index_pillar), not the
+ * whole system — that's the central scope correction from B0d-mini.
+ */
+export type NextActionSourceKey =
+  | 'autopilot_recommendation'
+  | 'reminder_due'
+  | 'calendar_upcoming'
+  | 'life_compass_alignment'
+  | 'vitana_index_pillar'
+  | 'diary_missing_relevant'
+  | 'journey_stage_nudge'
+  | 'match_activity_plan'
+  | 'continuity_pending_thread'
+  | 'continuity_promise_owed';
+
+/**
+ * The closed set of source keys for runtime iteration / validation.
+ */
+export const NEXT_ACTION_SOURCE_KEYS: readonly NextActionSourceKey[] = [
+  'autopilot_recommendation',
+  'reminder_due',
+  'calendar_upcoming',
+  'life_compass_alignment',
+  'vitana_index_pillar',
+  'diary_missing_relevant',
+  'journey_stage_nudge',
+  'match_activity_plan',
+  'continuity_pending_thread',
+  'continuity_promise_owed',
+] as const;
+
+// ---------------------------------------------------------------------------
+// Candidate
+// ---------------------------------------------------------------------------
+
+/**
+ * Confidence bands the LLM can compare across sources. Sources MUST map
+ * their internal scores to this enum — the composer compares enum
+ * positions, never raw provider scores.
+ */
+export type NextActionConfidence = 'low' | 'medium' | 'high';
+
+/**
+ * Reason that justifies a candidate. Multiple reasons may attach per
+ * candidate (e.g. autopilot rec linked to weak pillar). Each reason
+ * shows up in the Command Hub Candidate Inspector verbatim, so the
+ * detail string should be short + operator-readable, NEVER medical
+ * interpretation, NEVER PII beyond what's already on screen.
+ */
+export interface NextActionReason {
+  /** Stable enum tag — e.g. 'reminder_due_within_30min'. */
+  kind: string;
+  /** One-line human readable. */
+  detail: string;
+}
+
+/**
+ * A scored candidate from a single source. The composer collects these
+ * from every enabled source, ranks by priority (descending), breaks ties
+ * deterministically (source key alphabetical), and renders the winner
+ * as an AssistantContinuation.
+ *
+ * Priority is INTEGER on a 0..100 scale. Source-specific scorers map
+ * their internal heuristics to this range — the composer compares
+ * priorities directly, so the scale MUST be stable.
+ *
+ * Recommended priority bands:
+ *   90+  — urgent (reminder firing within 10min, safety/medical flag)
+ *   70-89  — strong (autopilot accepted yesterday + due today, mutual match)
+ *   50-69  — medium (Life Compass nudge, weak pillar)
+ *   30-49  — light (DYK, feature discovery — these belong in B0e, not here)
+ *    0-29 — only when nothing else has a candidate
+ */
+export interface ScoredCandidate {
+  source: NextActionSourceKey;
+  /** Numeric priority on a 0..100 scale (see banding above). */
+  priority: number;
+  confidence: NextActionConfidence;
+  /** The line Vitana will speak. Source produces it; composer renders. */
+  userFacingLine: string;
+  /** Per-language variants. The composer picks by ctx.lang. */
+  perLang?: Record<string, string>;
+  reasons: NextActionReason[];
+  /** Stable key for dedupe across turns. Source MUST make this collision-
+   *  proof — e.g. `reminder_due:<reminder_id>` not `reminder_due:current`. */
+  dedupeKey: string;
+  /**
+   * Optional CTA that the composer will attach to the rendered
+   * AssistantContinuation. When omitted the composer attaches a default
+   * `explain` CTA. Discriminated union matches the framework's
+   * ContinuationCta exactly so renderers don't need a translation layer.
+   */
+  cta?: ContinuationCta;
+}
+
+// ---------------------------------------------------------------------------
+// Source interface
+// ---------------------------------------------------------------------------
+
+/**
+ * Context a source receives. Identity + the framework decision context
+ * (already-compiled spine signals) + a Supabase client for direct
+ * source-specific reads. Sources MUST NOT recompile the spine — read
+ * from decisionContext only.
+ */
+export interface NextActionSourceContext {
+  userId: string;
+  tenantId: string;
+  lang: string;
+  /** ISO 8601 server-side now — sources use this for freshness math. */
+  nowIso: string;
+  /** Read-only view of the compiled AssistantDecisionContext. Sources
+   *  reading continuity/journey/pillar should consume this, NOT re-query. */
+  decisionContext: unknown;
+  /** Supabase service-role client for direct source-specific reads
+   *  (reminders, autopilot_recommendations, calendar_events, etc.). */
+  supabase: import('@supabase/supabase-js').SupabaseClient;
+}
+
+/**
+ * Source contract. Each source file under `sources/` exports one of
+ * these. The composer iterates the enabled set, calls `produce()` in
+ * parallel, and collects the results.
+ *
+ * Sources MUST NOT throw. Any internal failure → return null with a
+ * structured `failedReason` on the trace.
+ */
+export interface NextActionSource {
+  readonly key: NextActionSourceKey;
+  /** Whether this source can serve the given surface. The composer
+   *  filters before invocation. */
+  serves(surface: 'orb_wake' | 'orb_turn_end'): boolean;
+  /** Produce zero or one candidate. Sources MAY produce multiple internal
+   *  candidates; they MUST collapse to one before returning. The composer
+   *  ranks ACROSS sources. */
+  produce(ctx: NextActionSourceContext): Promise<NextActionSourceResult>;
+}
+
+/**
+ * What a source returns. `candidate` is set when the source has
+ * something to offer; `skippedReason` carries why when it doesn't.
+ * Both populated together is invalid (composer will treat as `errored`).
+ */
+export interface NextActionSourceResult {
+  source: NextActionSourceKey;
+  candidate: ScoredCandidate | null;
+  /** Required when candidate === null. Closed enum, NOT free text. */
+  skippedReason?: NextActionSkipReason;
+  /** Latency from the composer's perspective (ms). Populated by the composer. */
+  latencyMs?: number;
+}
+
+/**
+ * Why a source declined. Closed enum; new reasons land via a code change
+ * (and a matching Inspector visualization, deliberately).
+ */
+export type NextActionSkipReason =
+  | 'no_data'
+  | 'no_eligible_record'
+  | 'dedup_window'
+  | 'low_confidence'
+  | 'feature_disabled'
+  | 'source_unavailable'
+  | 'errored';
+
+// ---------------------------------------------------------------------------
+// Composer
+// ---------------------------------------------------------------------------
+
+/**
+ * The result of composing across all enabled sources. Mirrors the
+ * framework's AssistantContinuationDecision shape but with NextAction-
+ * specific evidence — the composer's own caller (the
+ * `next-action.ts` provider) wraps `chosen` into an AssistantContinuation
+ * for the framework to consume.
+ */
+export interface NextActionComposeResult {
+  /** The winning candidate, or null when none qualifies. */
+  chosen: ScoredCandidate | null;
+  /** Every source's result, in registration order. The Command Hub
+   *  Candidate Inspector renders this verbatim. */
+  candidates: NextActionSourceResult[];
+  /** When chosen === null, why the composer picked nothing. */
+  suppressReason?: NextActionSuppressReason;
+  /** ISO timestamps for latency math. */
+  composeStartedAt: string;
+  composeFinishedAt: string;
+}
+
+/**
+ * Composer-level suppression reasons. These are DIFFERENT from per-source
+ * skip reasons — these say "all sources combined produced nothing", not
+ * "this one source declined".
+ */
+export type NextActionSuppressReason =
+  | 'no_sources_registered'
+  | 'all_sources_skipped'
+  | 'all_sources_errored'
+  | 'tied_below_threshold'
+  | 'privacy_shared_device';
+
+/**
+ * The composer's public API. Stays small on purpose so callers (the
+ * `next-action.ts` provider, tests, and the Command Hub preview route)
+ * have one well-known entry point.
+ */
+export interface NextActionComposer {
+  /** Register a source. Idempotent on key; second registration replaces. */
+  register(source: NextActionSource): void;
+  /** Drop all sources. Used by tests; production wiring registers once. */
+  reset(): void;
+  /** Listed source keys, in registration order. Stable for tie-breaking. */
+  registeredKeys(): readonly NextActionSourceKey[];
+  /** Produce one candidate across all enabled sources. */
+  compose(
+    surface: 'orb_wake' | 'orb_turn_end',
+    ctx: NextActionSourceContext,
+  ): Promise<NextActionComposeResult>;
+}
+
+// ---------------------------------------------------------------------------
+// Re-export the framework decision type so consumers don't need two imports.
+// ---------------------------------------------------------------------------
+export type { AssistantContinuationDecision };

--- a/services/gateway/test/services/assistant-continuation/providers/next-action/skeleton.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/next-action/skeleton.test.ts
@@ -1,0 +1,367 @@
+/**
+ * VTID-03056 (B0d-real slice Xa) — Contextual Next Action provider
+ * SKELETON tests.
+ *
+ * Scope: types + composer + provider entry point. NO concrete sources
+ * yet — those land in slices Xb-Xe. This suite pins the contract that
+ * concrete sources will rely on.
+ */
+
+import {
+  makeNextActionProvider,
+  NEXT_ACTION_EXTRA_KEY,
+  NEXT_ACTION_PROVIDER_KEY,
+} from '../../../../../src/services/assistant-continuation/providers/next-action';
+import {
+  rank,
+  CROSS_SOURCE_THRESHOLD,
+} from '../../../../../src/services/assistant-continuation/providers/next-action/composer';
+import type {
+  NextActionComposer,
+  NextActionSource,
+  NextActionSourceContext,
+  NextActionSourceResult,
+  ScoredCandidate,
+} from '../../../../../src/services/assistant-continuation/providers/next-action/types';
+import {
+  NEXT_ACTION_SOURCE_KEYS,
+} from '../../../../../src/services/assistant-continuation/providers/next-action/types';
+import type { ContinuationDecisionContext } from '../../../../../src/services/assistant-continuation/types';
+
+// ---------------------------------------------------------------------------
+// Fakes
+// ---------------------------------------------------------------------------
+
+function fakeSupabase(): import('@supabase/supabase-js').SupabaseClient {
+  return {
+    from: () => ({}) as never,
+    rpc: async () => ({ data: null, error: null }),
+  } as unknown as import('@supabase/supabase-js').SupabaseClient;
+}
+
+function makeCtx(
+  over: Partial<ContinuationDecisionContext> = {},
+): ContinuationDecisionContext {
+  return {
+    surface: 'orb_wake',
+    sessionId: 's1',
+    userId: 'u1',
+    tenantId: 't1',
+    extra: {
+      [NEXT_ACTION_EXTRA_KEY]: {
+        supabase: fakeSupabase(),
+        decisionContext: null,
+      },
+    },
+    ...over,
+  };
+}
+
+function makeSource(opts: {
+  key: NextActionSource['key'];
+  candidate?: ScoredCandidate | null;
+  skippedReason?: NextActionSourceResult['skippedReason'];
+  surfaces?: ('orb_wake' | 'orb_turn_end')[];
+  throws?: boolean;
+}): NextActionSource {
+  const surfaces = opts.surfaces ?? ['orb_wake', 'orb_turn_end'];
+  return {
+    key: opts.key,
+    serves: (s) => surfaces.includes(s),
+    produce: async () => {
+      if (opts.throws) {
+        throw new Error('boom');
+      }
+      const result: NextActionSourceResult = {
+        source: opts.key,
+        candidate: opts.candidate ?? null,
+      };
+      if (opts.skippedReason !== undefined) {
+        result.skippedReason = opts.skippedReason;
+      }
+      return result;
+    },
+  };
+}
+
+function makeCandidate(
+  source: NextActionSource['key'],
+  priority: number,
+  over: Partial<ScoredCandidate> = {},
+): ScoredCandidate {
+  return {
+    source,
+    priority,
+    confidence: 'high',
+    userFacingLine: `Candidate from ${source}`,
+    reasons: [{ kind: `${source}_ready`, detail: 'fake' }],
+    dedupeKey: `${source}:1`,
+    ...over,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Source-key inventory
+// ---------------------------------------------------------------------------
+
+describe('VTID-03056 (Xa) — source key inventory', () => {
+  test('NEXT_ACTION_SOURCE_KEYS covers the 10 B0d-real inputs', () => {
+    expect(NEXT_ACTION_SOURCE_KEYS.length).toBe(10);
+    const expected = new Set([
+      'autopilot_recommendation',
+      'reminder_due',
+      'calendar_upcoming',
+      'life_compass_alignment',
+      'vitana_index_pillar',
+      'diary_missing_relevant',
+      'journey_stage_nudge',
+      'match_activity_plan',
+      'continuity_pending_thread',
+      'continuity_promise_owed',
+    ]);
+    for (const k of NEXT_ACTION_SOURCE_KEYS) expect(expected.has(k)).toBe(true);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Composer rank() pure function
+// ---------------------------------------------------------------------------
+
+describe('VTID-03056 (Xa) — composer rank()', () => {
+  test('returns chosen:null + all_sources_skipped when no candidates', () => {
+    const r = rank([
+      { source: 'reminder_due', candidate: null, skippedReason: 'no_data' },
+      { source: 'autopilot_recommendation', candidate: null, skippedReason: 'no_data' },
+    ]);
+    expect(r.chosen).toBeNull();
+    expect(r.suppressReason).toBe('all_sources_skipped');
+  });
+
+  test('returns chosen:null + all_sources_errored when EVERY source errored', () => {
+    const r = rank([
+      { source: 'reminder_due', candidate: null, skippedReason: 'errored' },
+      { source: 'autopilot_recommendation', candidate: null, skippedReason: 'errored' },
+    ]);
+    expect(r.chosen).toBeNull();
+    expect(r.suppressReason).toBe('all_sources_errored');
+  });
+
+  test('picks highest-priority candidate', () => {
+    const reminders = makeCandidate('reminder_due', 80);
+    const autopilot = makeCandidate('autopilot_recommendation', 95);
+    const r = rank([
+      { source: 'reminder_due', candidate: reminders },
+      { source: 'autopilot_recommendation', candidate: autopilot },
+    ]);
+    expect(r.chosen).toBe(autopilot);
+    expect(r.suppressReason).toBeUndefined();
+  });
+
+  test('breaks ties by registration order (stable sort)', () => {
+    const a = makeCandidate('reminder_due', 75);
+    const b = makeCandidate('autopilot_recommendation', 75);
+    const r = rank([
+      { source: 'reminder_due', candidate: a },
+      { source: 'autopilot_recommendation', candidate: b },
+    ]);
+    expect(r.chosen).toBe(a); // first registered wins
+  });
+
+  test('suppresses below CROSS_SOURCE_THRESHOLD with tied_below_threshold', () => {
+    const c = makeCandidate('vitana_index_pillar', CROSS_SOURCE_THRESHOLD - 1);
+    const r = rank([{ source: 'vitana_index_pillar', candidate: c }]);
+    expect(r.chosen).toBeNull();
+    expect(r.suppressReason).toBe('tied_below_threshold');
+  });
+
+  test('returns at threshold (>= boundary fires)', () => {
+    const c = makeCandidate('reminder_due', CROSS_SOURCE_THRESHOLD);
+    const r = rank([{ source: 'reminder_due', candidate: c }]);
+    expect(r.chosen).toBe(c);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Composer.compose end-to-end
+// ---------------------------------------------------------------------------
+
+describe('VTID-03056 (Xa) — composer.compose()', () => {
+  function freshComposer(): NextActionComposer {
+    // Build a fresh composer per test so registrations don't leak.
+    const {
+      defaultNextActionComposer,
+    } = require('../../../../../src/services/assistant-continuation/providers/next-action/composer');
+    defaultNextActionComposer.reset();
+    return defaultNextActionComposer;
+  }
+
+  test('empty registry → chosen:null + no_sources_registered', async () => {
+    const composer = freshComposer();
+    const r = await composer.compose('orb_wake', {
+      userId: 'u1',
+      tenantId: 't1',
+      lang: 'en',
+      nowIso: '2026-05-18T08:00:00Z',
+      decisionContext: null,
+      supabase: fakeSupabase(),
+    });
+    expect(r.chosen).toBeNull();
+    expect(r.suppressReason).toBe('no_sources_registered');
+    expect(r.candidates).toEqual([]);
+    expect(typeof r.composeStartedAt).toBe('string');
+    expect(typeof r.composeFinishedAt).toBe('string');
+  });
+
+  test('one source returns a candidate → chosen is that candidate', async () => {
+    const composer = freshComposer();
+    const cand = makeCandidate('reminder_due', 80);
+    composer.register(makeSource({ key: 'reminder_due', candidate: cand }));
+    const r = await composer.compose('orb_wake', {
+      userId: 'u1',
+      tenantId: 't1',
+      lang: 'en',
+      nowIso: '2026-05-18T08:00:00Z',
+      decisionContext: null,
+      supabase: fakeSupabase(),
+    });
+    expect(r.chosen).toBe(cand);
+    expect(r.candidates).toHaveLength(1);
+    expect(r.candidates[0].latencyMs).toBeDefined();
+  });
+
+  test('source that throws is captured as errored, never propagates', async () => {
+    const composer = freshComposer();
+    composer.register(makeSource({ key: 'reminder_due', throws: true }));
+    const r = await composer.compose('orb_wake', {
+      userId: 'u1',
+      tenantId: 't1',
+      lang: 'en',
+      nowIso: '2026-05-18T08:00:00Z',
+      decisionContext: null,
+      supabase: fakeSupabase(),
+    });
+    expect(r.chosen).toBeNull();
+    expect(r.candidates).toHaveLength(1);
+    expect(r.candidates[0].skippedReason).toBe('errored');
+    expect(r.suppressReason).toBe('all_sources_errored');
+  });
+
+  test('source that BOTH returns a candidate AND a skippedReason is treated as errored', async () => {
+    const composer = freshComposer();
+    composer.register({
+      key: 'reminder_due',
+      serves: () => true,
+      produce: async () => ({
+        source: 'reminder_due',
+        candidate: makeCandidate('reminder_due', 80),
+        skippedReason: 'no_data', // forbidden mix
+      }),
+    });
+    const r = await composer.compose('orb_wake', {
+      userId: 'u1',
+      tenantId: 't1',
+      lang: 'en',
+      nowIso: '2026-05-18T08:00:00Z',
+      decisionContext: null,
+      supabase: fakeSupabase(),
+    });
+    expect(r.chosen).toBeNull();
+    expect(r.candidates[0].skippedReason).toBe('errored');
+  });
+
+  test('source not serving the surface is filtered out before invocation', async () => {
+    const composer = freshComposer();
+    composer.register(
+      makeSource({
+        key: 'reminder_due',
+        candidate: makeCandidate('reminder_due', 80),
+        surfaces: ['orb_turn_end'], // does NOT serve orb_wake
+      }),
+    );
+    const r = await composer.compose('orb_wake', {
+      userId: 'u1',
+      tenantId: 't1',
+      lang: 'en',
+      nowIso: '2026-05-18T08:00:00Z',
+      decisionContext: null,
+      supabase: fakeSupabase(),
+    });
+    expect(r.candidates).toHaveLength(0);
+    expect(r.suppressReason).toBe('all_sources_skipped');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Provider integration
+// ---------------------------------------------------------------------------
+
+describe('VTID-03056 (Xa) — makeNextActionProvider()', () => {
+  test('provider serves both orb_wake AND orb_turn_end', () => {
+    const provider = makeNextActionProvider();
+    expect(provider.surfaces).toContain('orb_wake');
+    expect(provider.surfaces).toContain('orb_turn_end');
+  });
+
+  test('skipped when no inputs in ctx.extra', async () => {
+    const provider = makeNextActionProvider();
+    const r = await provider.produce({
+      surface: 'orb_wake',
+      sessionId: 's1',
+      userId: 'u1',
+      tenantId: 't1',
+      // No extra.
+    });
+    expect(r.status).toBe('skipped');
+    if (r.status === 'skipped') expect(r.reason).toBe('no_next_action_inputs');
+  });
+
+  test('skipped when anonymous (no userId or tenantId)', async () => {
+    const provider = makeNextActionProvider();
+    const r = await provider.produce(makeCtx({ userId: undefined }));
+    expect(r.status).toBe('skipped');
+    if (r.status === 'skipped') expect(r.reason).toBe('anonymous_caller');
+  });
+
+  test('suppressed when composer registry is empty', async () => {
+    const {
+      defaultNextActionComposer,
+    } = require('../../../../../src/services/assistant-continuation/providers/next-action/composer');
+    defaultNextActionComposer.reset();
+    const provider = makeNextActionProvider();
+    const r = await provider.produce(makeCtx());
+    expect(r.status).toBe('suppressed');
+    if (r.status === 'suppressed') expect(r.reason).toBe('no_sources_registered');
+  });
+
+  test('returns a candidate when composer picks one — rendered evidence carries source key', async () => {
+    const {
+      defaultNextActionComposer,
+    } = require('../../../../../src/services/assistant-continuation/providers/next-action/composer');
+    defaultNextActionComposer.reset();
+    defaultNextActionComposer.register(
+      makeSource({
+        key: 'reminder_due',
+        candidate: makeCandidate('reminder_due', 80, {
+          userFacingLine: 'Your magnesium reminder is due in 28 minutes.',
+        }),
+      }),
+    );
+    const provider = makeNextActionProvider({
+      newId: () => 'fixed-id',
+    });
+    const r = await provider.produce(makeCtx());
+    expect(r.status).toBe('returned');
+    if (r.status !== 'returned') return;
+    const c = r.candidate!;
+    expect(c.kind).toBe('next_step');
+    expect(c.userFacingLine).toBe('Your magnesium reminder is due in 28 minutes.');
+    expect(c.priority).toBe(90); // provider-level default
+    expect(c.evidence.some((e) => e.kind === 'source:reminder_due')).toBe(true);
+    expect(c.dedupeKey).toBe('reminder_due:1');
+  });
+
+  test('provider key + extra key are stable strings (registration contract)', () => {
+    expect(NEXT_ACTION_PROVIDER_KEY).toBe('contextual_next_action');
+    expect(NEXT_ACTION_EXTRA_KEY).toBe('nextAction');
+  });
+});


### PR DESCRIPTION
## Summary

Scope correction shipped 2026-05-18 — B0d-mini (the pillar-momentum-only wake-brief) was renamed in memory. **This is the FIRST slice of B0d-real**: the Contextual Next Action provider skeleton.

## What ships (skeleton only)

- 10-source registry contract (NextActionSourceKey enum: autopilot_recommendation, reminder_due, calendar_upcoming, life_compass_alignment, vitana_index_pillar, diary_missing_relevant, journey_stage_nudge, match_activity_plan, continuity_pending_thread, continuity_promise_owed)
- CompositeNextActionComposer with parallel source invocation, deterministic tie-break, cross-source threshold (50), full error isolation
- makeNextActionProvider() factory — priority 90 (above voice-wake-brief's 80), serves orb_wake + orb_turn_end
- 18 hermetic tests covering rank, compose, source filter, provider skip paths, candidate rendering
- 921 orb + continuation tests green

## Hard scope limits

- **NO concrete sources yet** — empty registry → provider returns suppressed → framework falls back to voice-wake-brief. Zero user-visible change in prod.
- **NOT wired into orb-livekit.ts** yet — wiring lands with Xb (first concrete source).
- **NOT registered in defaultProviderRegistry** yet — same reason.

## Follow-up slices

| Slice | Sources |
|---|---|
| Xb | reminders-due + autopilot-recommendation + wiring |
| Xc | calendar-upcoming + life-compass-alignment |
| Xd | diary-missing-relevant + vitana-index-pillar (replaces hardcoded B0d-mini path) |
| Xe | match-activity-plan + continuity (pending threads + promises owed) |
| Xf | Command Hub Candidate Inspector + OASIS accepted/dismissed events |

🤖 Generated with [Claude Code](https://claude.com/claude-code)