### PR TITLE
feat(orb-livekit): B0d-real Xb — reminder-due + autopilot sources + bootstrap wiring (VTID-03057)

### DIFF
--- a/services/gateway/src/routes/orb-livekit.ts
+++ b/services/gateway/src/routes/orb-livekit.ts
@@ -1449,6 +1449,14 @@ router.get(
           // the generic "Hello! How can I help today?" line. Already
           // compiled earlier in this handler at the spine step.
           pillarMomentum: decisionContext?.pillar_momentum ?? null,
+          // VTID-03057 (B0d-real Xb): forward supabase client +
+          // decisionContext so the Contextual Next Action provider can
+          // query its sources (reminders, autopilot_recommendations).
+          // Best-effort: when supabase is null (rare), the next-action
+          // provider skips and voice-wake-brief still fires its
+          // hardcoded fallback line.
+          supabase: sb ?? undefined,
+          decisionContext: decisionContext ?? null,
         });
       } catch (exc) {
         console.warn(

--- a/services/gateway/src/services/assistant-continuation/providers/next-action/register-default-sources.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/next-action/register-default-sources.ts
@@ -1,0 +1,35 @@
+/**
+ * VTID-03057 (B0d-real slice Xb) — register the default sources with the
+ * module-level composer.
+ *
+ * Sources are registered IN ORDER OF the tie-break preference. The
+ * composer sorts by priority (descending) but ties keep registration
+ * order; so when two sources produce equal priority, the EARLIER
+ * registered one wins. The chosen order:
+ *
+ *   1. reminder_due              — time-sensitive, beats coaching
+ *   2. autopilot_recommendation  — second strongest signal
+ *
+ * Later slices Xc-Xe extend this list. The cross-source threshold (50)
+ * lives in composer.ts; each source's priority bands are chosen so
+ * "no real signal" sources stay below it and "real next action"
+ * sources stay above.
+ *
+ * Idempotent: re-imports during hot-reload don't throw or duplicate.
+ */
+
+import { defaultNextActionComposer } from './composer';
+import { makeReminderDueSource } from './sources/reminder-due';
+import { makeAutopilotRecommendationSource } from './sources/autopilot-recommendation';
+
+let _registered = false;
+
+export function ensureDefaultNextActionSourcesRegistered(): void {
+  if (_registered) return;
+  _registered = true;
+  defaultNextActionComposer.register(makeReminderDueSource());
+  defaultNextActionComposer.register(makeAutopilotRecommendationSource());
+}
+
+// Register on import so consumers don't have to remember.
+ensureDefaultNextActionSourcesRegistered();

--- a/services/gateway/src/services/assistant-continuation/providers/next-action/sources/autopilot-recommendation.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/next-action/sources/autopilot-recommendation.ts
@@ -1,0 +1,176 @@
+/**
+ * VTID-03057 (B0d-real slice Xb) — Autopilot-recommendation NextActionSource.
+ *
+ * Reads from `autopilot_recommendations` (the canonical table the
+ * milestone service + dev-autopilot synthesis + voice-improvement
+ * aggregator all write to). Picks the user's most-relevant `new`
+ * recommendation as the next-action candidate.
+ *
+ * Source priority bands:
+ *   - confidence='high'   → 88
+ *   - confidence='medium' → 78
+ *   - confidence='low'    → 60
+ *   - confidence missing  → 55 (still above CROSS_SOURCE_THRESHOLD=50)
+ *
+ * Recency boost: +3 if last_seen_at within 24 hours. Caps at the band ceiling.
+ *
+ * Acceptance #1 (strong Autopilot recommendation can win): with band
+ * 88 + recency boost up to 91, this source beats a 75-priority reminder
+ * 30-60min out, but loses to a sub-10min "urgent" reminder. That's the
+ * intended ranking — a fire-imminent reminder beats a coaching nudge.
+ */
+
+import type {
+  NextActionSource,
+  NextActionSourceContext,
+  NextActionSourceResult,
+  ScoredCandidate,
+  NextActionConfidence,
+} from '../types';
+
+const KEY = 'autopilot_recommendation' as const;
+
+export function makeAutopilotRecommendationSource(): NextActionSource {
+  return {
+    key: KEY,
+    serves: () => true, // Both orb_wake AND orb_turn_end.
+    produce: produceAutopilotRecommendation,
+  };
+}
+
+export async function produceAutopilotRecommendation(
+  ctx: NextActionSourceContext,
+): Promise<NextActionSourceResult> {
+  let row: AutopilotRecLike | null = null;
+  try {
+    // Order: high confidence first, then most recent. The composer
+    // breaks ties; this source just supplies one candidate.
+    const { data, error } = await ctx.supabase
+      .from('autopilot_recommendations')
+      .select('id, title, summary, confidence, last_seen_at, created_at, domain')
+      .eq('user_id', ctx.userId)
+      .eq('status', 'new')
+      // Drop milestone celebrations — those have their own surface.
+      .neq('source_type', 'milestone')
+      .order('confidence', { ascending: false, nullsFirst: false })
+      .order('last_seen_at', { ascending: false, nullsFirst: false })
+      .order('created_at', { ascending: false })
+      .limit(1);
+    if (error) {
+      return { source: KEY, candidate: null, skippedReason: 'source_unavailable' };
+    }
+    row = (data && data[0]) ? (data[0] as AutopilotRecLike) : null;
+  } catch {
+    return { source: KEY, candidate: null, skippedReason: 'errored' };
+  }
+
+  if (!row) {
+    return { source: KEY, candidate: null, skippedReason: 'no_eligible_record' };
+  }
+
+  const title = (row.title || '').trim();
+  if (!title) {
+    return { source: KEY, candidate: null, skippedReason: 'no_eligible_record' };
+  }
+
+  const confidence = normalizeConfidence(row.confidence);
+  let priority = priorityForConfidence(confidence);
+  const recencyBoost = recencyBoostForLastSeen(row.last_seen_at, ctx.nowIso);
+  priority = Math.min(95, priority + recencyBoost);
+
+  const userFacingLine = renderLine(title, row.summary, ctx.lang);
+
+  const reasons: ScoredCandidate['reasons'] = [
+    {
+      kind: 'autopilot_rec_new',
+      detail: `confidence=${confidence}${row.domain ? ` domain=${row.domain}` : ''}`,
+    },
+  ];
+  if (recencyBoost > 0) {
+    reasons.push({
+      kind: 'autopilot_rec_recent',
+      detail: `seen within 24h (boost=${recencyBoost})`,
+    });
+  }
+
+  const candidate: ScoredCandidate = {
+    source: KEY,
+    priority,
+    confidence,
+    userFacingLine,
+    reasons,
+    dedupeKey: `autopilot_recommendation:${row.id}`,
+    cta: {
+      type: 'ask_permission',
+      payload: { recommendation_id: row.id, domain: row.domain ?? null },
+    },
+  };
+  return { source: KEY, candidate };
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers — exported for tests
+// ---------------------------------------------------------------------------
+
+interface AutopilotRecLike {
+  id: string;
+  title: string | null;
+  summary: string | null;
+  confidence: string | number | null;
+  last_seen_at: string | null;
+  created_at: string;
+  domain: string | null;
+}
+
+export function normalizeConfidence(raw: unknown): NextActionConfidence {
+  if (typeof raw === 'string') {
+    const s = raw.toLowerCase();
+    if (s === 'high' || s === 'medium' || s === 'low') return s;
+  }
+  if (typeof raw === 'number') {
+    if (raw >= 0.8) return 'high';
+    if (raw >= 0.5) return 'medium';
+    return 'low';
+  }
+  // Unknown shape — treat as low so this source doesn't outscore a
+  // typed source on a malformed row.
+  return 'low';
+}
+
+export function priorityForConfidence(confidence: NextActionConfidence): number {
+  if (confidence === 'high') return 88;
+  if (confidence === 'medium') return 78;
+  return 60;
+}
+
+export function recencyBoostForLastSeen(
+  lastSeenAt: string | null | undefined,
+  nowIso: string,
+): number {
+  if (!lastSeenAt) return 0;
+  const seen = Date.parse(lastSeenAt);
+  const now = Date.parse(nowIso);
+  if (!Number.isFinite(seen) || !Number.isFinite(now)) return 0;
+  const hoursAgo = (now - seen) / 3_600_000;
+  if (hoursAgo >= 0 && hoursAgo <= 24) return 3;
+  return 0;
+}
+
+export function renderLine(
+  title: string,
+  summary: string | null,
+  lang: string,
+): string {
+  const isDe = (lang || 'en').toLowerCase().startsWith('de');
+  const cleanSummary = (summary || '').trim();
+  if (isDe) {
+    if (cleanSummary) {
+      return `Eine Empfehlung von mir: ${title}. ${cleanSummary} Sollen wir das jetzt angehen?`;
+    }
+    return `Eine Empfehlung von mir: ${title}. Wollen wir das anschauen?`;
+  }
+  if (cleanSummary) {
+    return `One thing I want to flag: ${title}. ${cleanSummary} Want to work on it now?`;
+  }
+  return `One thing I want to flag: ${title}. Want to take a look?`;
+}

--- a/services/gateway/src/services/assistant-continuation/providers/next-action/sources/reminder-due.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/next-action/sources/reminder-due.ts
@@ -1,0 +1,146 @@
+/**
+ * VTID-03057 (B0d-real slice Xb) — Reminder-due NextActionSource.
+ *
+ * Reads from the canonical `reminders` table (same one
+ * reminders-service.ts owns). Picks the user's most-imminent pending
+ * reminder when it fires within the next 2 hours; turns it into a
+ * proactive opener.
+ *
+ * Source priority bands (mapped from minutes-until-fire):
+ *   - < 10 min    → 95 (urgent)
+ *   - 10-30 min   → 85
+ *   - 30-60 min   → 75
+ *   - 60-120 min  → 65
+ *   - > 120 min   → skipped (no_eligible_record)
+ *
+ * Confidence is derived: high under 30min, medium otherwise.
+ *
+ * Acceptance #2 (calendar/reminder due soon can win): this source
+ * produces priority ≥ 65 for any reminder due in the next 2 hours,
+ * comfortably above CROSS_SOURCE_THRESHOLD=50. The composer's
+ * cross-source ranker handles the comparison; this file just supplies
+ * the candidate.
+ */
+
+import type {
+  NextActionSource,
+  NextActionSourceContext,
+  NextActionSourceResult,
+  ScoredCandidate,
+} from '../types';
+
+const KEY = 'reminder_due' as const;
+const HORIZON_MINUTES = 120;
+
+export function makeReminderDueSource(): NextActionSource {
+  return {
+    key: KEY,
+    serves: () => true, // Both orb_wake AND orb_turn_end.
+    produce: produceReminderDue,
+  };
+}
+
+export async function produceReminderDue(
+  ctx: NextActionSourceContext,
+): Promise<NextActionSourceResult> {
+  // Read the user's nearest pending reminder. Active statuses match the
+  // canonical reminders-service.findReminders() default: pending + dispatching.
+  const horizonIso = new Date(
+    Date.parse(ctx.nowIso) + HORIZON_MINUTES * 60 * 1000,
+  ).toISOString();
+
+  let row: ReminderLike | null = null;
+  try {
+    const { data, error } = await ctx.supabase
+      .from('reminders')
+      .select('id, action_text, spoken_message, next_fire_at, status')
+      .eq('user_id', ctx.userId)
+      .in('status', ['pending', 'dispatching'])
+      .gte('next_fire_at', ctx.nowIso)
+      .lte('next_fire_at', horizonIso)
+      .order('next_fire_at', { ascending: true })
+      .limit(1);
+    if (error) {
+      return { source: KEY, candidate: null, skippedReason: 'source_unavailable' };
+    }
+    row = (data && data[0]) ? (data[0] as ReminderLike) : null;
+  } catch {
+    return { source: KEY, candidate: null, skippedReason: 'errored' };
+  }
+
+  if (!row) {
+    return { source: KEY, candidate: null, skippedReason: 'no_eligible_record' };
+  }
+
+  const minutesUntilFire = computeMinutesUntil(row.next_fire_at, ctx.nowIso);
+  if (minutesUntilFire < 0 || minutesUntilFire > HORIZON_MINUTES) {
+    return { source: KEY, candidate: null, skippedReason: 'no_eligible_record' };
+  }
+
+  const priority = priorityForMinutes(minutesUntilFire);
+  const confidence = minutesUntilFire <= 30 ? 'high' : 'medium';
+
+  const actionText = (row.action_text || '').trim() || 'reminder';
+  const userFacingLine = renderLine(actionText, minutesUntilFire, ctx.lang);
+
+  const candidate: ScoredCandidate = {
+    source: KEY,
+    priority,
+    confidence,
+    userFacingLine,
+    reasons: [
+      {
+        kind: 'reminder_due_within_horizon',
+        detail: `${minutesUntilFire} min until "${actionText}"`,
+      },
+    ],
+    dedupeKey: `reminder_due:${row.id}`,
+    cta: { type: 'ask_permission', payload: { reminder_id: row.id } },
+  };
+  return { source: KEY, candidate };
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers — exported for tests
+// ---------------------------------------------------------------------------
+
+interface ReminderLike {
+  id: string;
+  action_text: string | null;
+  spoken_message: string | null;
+  next_fire_at: string;
+  status: string;
+}
+
+export function priorityForMinutes(minutes: number): number {
+  if (minutes < 10) return 95;
+  if (minutes < 30) return 85;
+  if (minutes < 60) return 75;
+  if (minutes <= HORIZON_MINUTES) return 65;
+  return 0;
+}
+
+export function computeMinutesUntil(fireAtIso: string, nowIso: string): number {
+  const fireAt = Date.parse(fireAtIso);
+  const now = Date.parse(nowIso);
+  if (!Number.isFinite(fireAt) || !Number.isFinite(now)) return Number.NaN;
+  return Math.round((fireAt - now) / 60_000);
+}
+
+export function renderLine(actionText: string, minutes: number, lang: string): string {
+  const isDe = (lang || 'en').toLowerCase().startsWith('de');
+  if (minutes < 10) {
+    return isDe
+      ? `Du hast in ${minutes} Minuten einen Termin: ${actionText}. Soll ich dich gleich erinnern, oder willst du jetzt darüber sprechen?`
+      : `You have something coming up in ${minutes} minutes: ${actionText}. Want me to nudge you, or talk about it now?`;
+  }
+  if (minutes < 60) {
+    return isDe
+      ? `In ${minutes} Minuten steht ${actionText} an. Sollen wir das vorbereiten?`
+      : `${actionText} is coming up in ${minutes} minutes. Want help getting ready?`;
+  }
+  const hours = Math.round(minutes / 60);
+  return isDe
+    ? `In etwa ${hours} Stunde${hours === 1 ? '' : 'n'} steht ${actionText} an. Soll ich dir vorher Bescheid geben?`
+    : `${actionText} is in about ${hours} hour${hours === 1 ? '' : 's'}. Want me to remind you closer to it?`;
+}

--- a/services/gateway/src/services/wake-brief-wiring.ts
+++ b/services/gateway/src/services/wake-brief-wiring.ts
@@ -33,9 +33,21 @@ import {
   VOICE_WAKE_BRIEF_PROVIDER_KEY,
   type VoiceWakeBriefInputs,
 } from './assistant-continuation/providers/voice-wake-brief';
+// VTID-03057 (B0d-real slice Xb): import the Contextual Next Action
+// provider + its default-source registration side-effect. The side-effect
+// import registers reminder_due + autopilot_recommendation with the
+// composer; the named import lets us register the provider itself with
+// the framework's defaultProviderRegistry.
+import {
+  makeNextActionProvider,
+  NEXT_ACTION_EXTRA_KEY,
+  NEXT_ACTION_PROVIDER_KEY,
+} from './assistant-continuation/providers/next-action';
+import './assistant-continuation/providers/next-action/register-default-sources';
 import { decideGreetingPolicy } from '../orb/live/instruction/greeting-policy';
 import { defaultWakeTimelineRecorder } from './wake-timeline/wake-timeline-recorder';
 import type { AssistantContinuationDecision } from './assistant-continuation/types';
+import type { SupabaseClient } from '@supabase/supabase-js';
 
 // ---------------------------------------------------------------------------
 // One-time provider registration. The default registry started empty in
@@ -46,11 +58,19 @@ import type { AssistantContinuationDecision } from './assistant-continuation/typ
 let _registered = false;
 export function ensureWakeBriefProviderRegistered(): void {
   if (_registered) return;
-  if (defaultProviderRegistry.get(VOICE_WAKE_BRIEF_PROVIDER_KEY)) {
-    _registered = true;
-    return;
+  // voice-wake-brief — the B0d-mini fallback (pillar-momentum-only line
+  // when nothing else fires). Priority 80.
+  if (!defaultProviderRegistry.get(VOICE_WAKE_BRIEF_PROVIDER_KEY)) {
+    defaultProviderRegistry.register(makeVoiceWakeBriefProvider());
   }
-  defaultProviderRegistry.register(makeVoiceWakeBriefProvider());
+  // VTID-03057 (B0d-real): the Contextual Next Action provider —
+  // priority 90, so when ANY registered source produces a candidate
+  // above CROSS_SOURCE_THRESHOLD (50), this one beats the fallback.
+  // When nothing fires, this provider returns `suppressed` and the
+  // framework's decideContinuation picks voice-wake-brief instead.
+  if (!defaultProviderRegistry.get(NEXT_ACTION_PROVIDER_KEY)) {
+    defaultProviderRegistry.register(makeNextActionProvider());
+  }
   _registered = true;
 }
 
@@ -78,6 +98,25 @@ export interface DecideWakeBriefArgs {
   lang: string;
   /** journeySurface from the ClientContextEnvelope, if any. */
   envelopeJourneySurface?: string;
+  /**
+   * VTID-03057 (B0d-real slice Xb): supabase service-role client for
+   * the Contextual Next Action provider's source queries (reminders,
+   * autopilot_recommendations, etc.). When omitted, the next-action
+   * provider returns `skipped:no_next_action_inputs` and the framework
+   * falls back to voice-wake-brief.
+   *
+   * Required for B0d-real candidates to fire. Optional in this slice
+   * so existing Vertex wiring (which doesn't yet pass it) keeps working
+   * with no change.
+   */
+  supabase?: SupabaseClient;
+  /**
+   * VTID-03057 (B0d-real slice Xb): full AssistantDecisionContext for
+   * sources that read continuity / journey_stage / pillar_momentum
+   * (Xd+ sources) without re-querying. Optional — sources gate on
+   * presence.
+   */
+  decisionContext?: unknown;
   /**
    * VTID-03053 — Distilled pillar-momentum view from the compiled
    * AssistantDecisionContext. When passed, the wake-brief renderer may
@@ -149,6 +188,20 @@ export async function decideWakeBriefForSession(
     lang: args.lang,
   });
 
+  // VTID-03057 (B0d-real Xb): build the next-action extras when the
+  // caller supplied a Supabase client. Without it the Contextual Next
+  // Action provider returns skipped:no_next_action_inputs and the
+  // framework falls back to voice-wake-brief — same as before this slice.
+  const extra: Record<string, unknown> = {
+    [VOICE_WAKE_BRIEF_EXTRA_KEY]: wakeBriefInputs,
+  };
+  if (args.supabase) {
+    extra[NEXT_ACTION_EXTRA_KEY] = {
+      supabase: args.supabase,
+      decisionContext: args.decisionContext ?? null,
+    };
+  }
+
   const t0 = now();
   const decision = await decideContinuation({
     surface: 'orb_wake',
@@ -157,7 +210,7 @@ export async function decideWakeBriefForSession(
       userId: args.userId ?? undefined,
       tenantId: args.tenantId ?? undefined,
       envelopeJourneySurface: args.envelopeJourneySurface,
-      extra: { [VOICE_WAKE_BRIEF_EXTRA_KEY]: wakeBriefInputs },
+      extra,
     },
   });
 

--- a/services/gateway/test/services/assistant-continuation/providers/next-action/autopilot-recommendation.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/next-action/autopilot-recommendation.test.ts
@@ -1,0 +1,193 @@
+/**
+ * VTID-03057 (B0d-real slice Xb) — autopilot-recommendation source tests.
+ */
+
+import {
+  produceAutopilotRecommendation,
+  normalizeConfidence,
+  priorityForConfidence,
+  recencyBoostForLastSeen,
+  renderLine,
+} from '../../../../../src/services/assistant-continuation/providers/next-action/sources/autopilot-recommendation';
+import type { NextActionSourceContext } from '../../../../../src/services/assistant-continuation/providers/next-action/types';
+
+function fakeSupabase(
+  rows: unknown[] | null,
+  err: { message: string } | null = null,
+  shouldThrow = false,
+): import('@supabase/supabase-js').SupabaseClient {
+  // Chain mirrors the actual query:
+  //   .from('autopilot_recommendations').select(...).eq(...).eq(...).neq(...).order(...).order(...).order(...).limit(...)
+  const finalResult = err ? { data: null, error: err } : { data: rows, error: null };
+  const chain = {
+    eq: () => chain,
+    neq: () => chain,
+    order: () => chain,
+    limit: () => (shouldThrow ? Promise.reject(new Error('boom')) : Promise.resolve(finalResult)),
+  };
+  return {
+    from: () => ({
+      select: () => chain,
+    }),
+    rpc: async () => ({ data: null, error: null }),
+  } as unknown as import('@supabase/supabase-js').SupabaseClient;
+}
+
+function ctxWith(sb: import('@supabase/supabase-js').SupabaseClient): NextActionSourceContext {
+  return {
+    userId: 'u1',
+    tenantId: 't1',
+    lang: 'en',
+    nowIso: '2026-05-18T08:00:00Z',
+    decisionContext: null,
+    supabase: sb,
+  };
+}
+
+describe('autopilot-recommendation pure helpers', () => {
+  test('normalizeConfidence', () => {
+    expect(normalizeConfidence('high')).toBe('high');
+    expect(normalizeConfidence('Medium')).toBe('medium');
+    expect(normalizeConfidence('LOW')).toBe('low');
+    expect(normalizeConfidence(0.9)).toBe('high');
+    expect(normalizeConfidence(0.5)).toBe('medium');
+    expect(normalizeConfidence(0.4)).toBe('low');
+    expect(normalizeConfidence(null)).toBe('low');
+    expect(normalizeConfidence(undefined)).toBe('low');
+    expect(normalizeConfidence({})).toBe('low');
+  });
+
+  test('priorityForConfidence', () => {
+    expect(priorityForConfidence('high')).toBe(88);
+    expect(priorityForConfidence('medium')).toBe(78);
+    expect(priorityForConfidence('low')).toBe(60);
+  });
+
+  test('recencyBoostForLastSeen', () => {
+    // Within 24h
+    expect(recencyBoostForLastSeen('2026-05-17T08:30:00Z', '2026-05-18T08:00:00Z')).toBe(3);
+    // 25h+ ago
+    expect(recencyBoostForLastSeen('2026-05-17T06:00:00Z', '2026-05-18T08:00:00Z')).toBe(0);
+    // Missing → 0
+    expect(recencyBoostForLastSeen(null, '2026-05-18T08:00:00Z')).toBe(0);
+    // Garbage timestamp → 0
+    expect(recencyBoostForLastSeen('not-a-date', '2026-05-18T08:00:00Z')).toBe(0);
+  });
+
+  test('renderLine', () => {
+    expect(renderLine('Try water tracking', 'A small step on hydration.', 'en'))
+      .toContain('water tracking');
+    expect(renderLine('Beweg dich kurz', 'Kleiner Schritt.', 'de'))
+      .toContain('Beweg dich kurz');
+    // No summary path
+    expect(renderLine('Title only', null, 'en')).toMatch(/take a look/);
+    expect(renderLine('Nur Titel', null, 'de')).toMatch(/anschauen/);
+  });
+});
+
+describe('produceAutopilotRecommendation source', () => {
+  test('no rows → skipped:no_eligible_record', async () => {
+    const r = await produceAutopilotRecommendation(ctxWith(fakeSupabase([])));
+    expect(r.candidate).toBeNull();
+    expect(r.skippedReason).toBe('no_eligible_record');
+  });
+
+  test('Supabase error → skipped:source_unavailable', async () => {
+    const r = await produceAutopilotRecommendation(
+      ctxWith(fakeSupabase(null, { message: 'rls denied' })),
+    );
+    expect(r.candidate).toBeNull();
+    expect(r.skippedReason).toBe('source_unavailable');
+  });
+
+  test('throw → skipped:errored', async () => {
+    const r = await produceAutopilotRecommendation(
+      ctxWith(fakeSupabase(null, null, true)),
+    );
+    expect(r.candidate).toBeNull();
+    expect(r.skippedReason).toBe('errored');
+  });
+
+  test('empty title → skipped:no_eligible_record', async () => {
+    const r = await produceAutopilotRecommendation(
+      ctxWith(
+        fakeSupabase([
+          {
+            id: 'rec-1',
+            title: '',
+            summary: 'some summary',
+            confidence: 'high',
+            last_seen_at: null,
+            created_at: '2026-05-18T07:00:00Z',
+            domain: 'voice',
+          },
+        ]),
+      ),
+    );
+    expect(r.candidate).toBeNull();
+    expect(r.skippedReason).toBe('no_eligible_record');
+  });
+
+  test('high-confidence recent rec → priority 91 (88 + 3 boost)', async () => {
+    const r = await produceAutopilotRecommendation(
+      ctxWith(
+        fakeSupabase([
+          {
+            id: 'rec-2',
+            title: 'Try a 5-minute walk before lunch',
+            summary: 'Easier than scheduled exercise; counts for the day.',
+            confidence: 'high',
+            last_seen_at: '2026-05-17T20:00:00Z', // 12h ago
+            created_at: '2026-05-15T00:00:00Z',
+            domain: 'exercise',
+          },
+        ]),
+      ),
+    );
+    expect(r.candidate?.priority).toBe(91);
+    expect(r.candidate?.confidence).toBe('high');
+    expect(r.candidate?.dedupeKey).toBe('autopilot_recommendation:rec-2');
+    expect(r.candidate?.userFacingLine).toContain('Try a 5-minute walk');
+    expect(r.candidate?.reasons.length).toBe(2); // base + recency
+  });
+
+  test('high-confidence non-recent rec → priority 88 (no boost)', async () => {
+    const r = await produceAutopilotRecommendation(
+      ctxWith(
+        fakeSupabase([
+          {
+            id: 'rec-3',
+            title: 'Hydration check-in',
+            summary: null,
+            confidence: 'high',
+            last_seen_at: '2026-05-15T08:00:00Z', // 3 days ago
+            created_at: '2026-05-15T00:00:00Z',
+            domain: 'hydration',
+          },
+        ]),
+      ),
+    );
+    expect(r.candidate?.priority).toBe(88);
+    expect(r.candidate?.reasons.length).toBe(1); // base only
+  });
+
+  test('low-confidence rec → priority 60, still above threshold', async () => {
+    const r = await produceAutopilotRecommendation(
+      ctxWith(
+        fakeSupabase([
+          {
+            id: 'rec-4',
+            title: 'Some weak suggestion',
+            summary: null,
+            confidence: 'low',
+            last_seen_at: null,
+            created_at: '2026-05-15T00:00:00Z',
+            domain: null,
+          },
+        ]),
+      ),
+    );
+    expect(r.candidate?.priority).toBe(60);
+    expect(r.candidate?.confidence).toBe('low');
+  });
+});

--- a/services/gateway/test/services/assistant-continuation/providers/next-action/reminder-due.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/next-action/reminder-due.test.ts
@@ -1,0 +1,172 @@
+/**
+ * VTID-03057 (B0d-real slice Xb) — reminder-due source tests.
+ *
+ * Coverage:
+ *   - Pure helpers: priorityForMinutes, computeMinutesUntil, renderLine
+ *   - Source: produceReminderDue
+ *     * No rows → skipped:no_eligible_record
+ *     * Supabase error → skipped:source_unavailable
+ *     * Exception → skipped:errored
+ *     * One row within horizon → candidate with right priority + dedupeKey
+ *     * Row beyond horizon (shouldn't happen given the .lte filter, but
+ *       defensive computeMinutesUntil branch is also covered)
+ */
+
+import {
+  produceReminderDue,
+  priorityForMinutes,
+  computeMinutesUntil,
+  renderLine,
+} from '../../../../../src/services/assistant-continuation/providers/next-action/sources/reminder-due';
+import type { NextActionSourceContext } from '../../../../../src/services/assistant-continuation/providers/next-action/types';
+
+function fakeSupabase(
+  rows: unknown[] | null,
+  err: { message: string } | null = null,
+  shouldThrow = false,
+): import('@supabase/supabase-js').SupabaseClient {
+  // Chain mirrors the actual query:
+  //   .from('reminders').select(...).eq(...).in(...).gte(...).lte(...).order(...).limit(...)
+  const finalResult = err ? { data: null, error: err } : { data: rows, error: null };
+  const chain = {
+    eq: () => chain,
+    in: () => chain,
+    gte: () => chain,
+    lte: () => chain,
+    order: () => chain,
+    limit: () => (shouldThrow ? Promise.reject(new Error('boom')) : Promise.resolve(finalResult)),
+  };
+  return {
+    from: () => ({
+      select: () => chain,
+    }),
+    rpc: async () => ({ data: null, error: null }),
+  } as unknown as import('@supabase/supabase-js').SupabaseClient;
+}
+
+function ctxWith(sb: import('@supabase/supabase-js').SupabaseClient, lang = 'en'): NextActionSourceContext {
+  return {
+    userId: 'u1',
+    tenantId: 't1',
+    lang,
+    nowIso: '2026-05-18T08:00:00Z',
+    decisionContext: null,
+    supabase: sb,
+  };
+}
+
+describe('reminder-due pure helpers', () => {
+  test('priorityForMinutes — banding', () => {
+    expect(priorityForMinutes(5)).toBe(95);
+    expect(priorityForMinutes(9)).toBe(95);
+    expect(priorityForMinutes(10)).toBe(85);
+    expect(priorityForMinutes(29)).toBe(85);
+    expect(priorityForMinutes(30)).toBe(75);
+    expect(priorityForMinutes(59)).toBe(75);
+    expect(priorityForMinutes(60)).toBe(65);
+    expect(priorityForMinutes(120)).toBe(65);
+    expect(priorityForMinutes(121)).toBe(0);
+  });
+
+  test('computeMinutesUntil — direction + bad input', () => {
+    expect(computeMinutesUntil('2026-05-18T08:30:00Z', '2026-05-18T08:00:00Z')).toBe(30);
+    expect(computeMinutesUntil('2026-05-18T07:30:00Z', '2026-05-18T08:00:00Z')).toBe(-30);
+    expect(Number.isNaN(computeMinutesUntil('not-a-date', '2026-05-18T08:00:00Z'))).toBe(true);
+  });
+
+  test('renderLine — picks EN/DE based on lang', () => {
+    expect(renderLine('hydrate', 5, 'en')).toMatch(/coming up in 5 minutes/);
+    expect(renderLine('Wasser trinken', 5, 'de')).toMatch(/in 5 Minuten/);
+    expect(renderLine('walk', 90, 'en')).toMatch(/about 2 hours/);
+    expect(renderLine('Spaziergang', 90, 'de')).toMatch(/2 Stunden/);
+  });
+});
+
+describe('produceReminderDue source', () => {
+  test('no rows → skipped:no_eligible_record', async () => {
+    const r = await produceReminderDue(ctxWith(fakeSupabase([])));
+    expect(r.candidate).toBeNull();
+    expect(r.skippedReason).toBe('no_eligible_record');
+  });
+
+  test('null rows → skipped:no_eligible_record', async () => {
+    const r = await produceReminderDue(ctxWith(fakeSupabase(null)));
+    expect(r.candidate).toBeNull();
+    expect(r.skippedReason).toBe('no_eligible_record');
+  });
+
+  test('Supabase error → skipped:source_unavailable', async () => {
+    const r = await produceReminderDue(
+      ctxWith(fakeSupabase(null, { message: 'rls denied' })),
+    );
+    expect(r.candidate).toBeNull();
+    expect(r.skippedReason).toBe('source_unavailable');
+  });
+
+  test('thrown exception → skipped:errored (never propagates)', async () => {
+    const r = await produceReminderDue(ctxWith(fakeSupabase(null, null, true)));
+    expect(r.candidate).toBeNull();
+    expect(r.skippedReason).toBe('errored');
+  });
+
+  test('one row 28min ahead → priority 85, confidence high, dedupe by id', async () => {
+    const r = await produceReminderDue(
+      ctxWith(
+        fakeSupabase([
+          {
+            id: 'r-123',
+            action_text: 'magnesium',
+            spoken_message: 'take magnesium',
+            next_fire_at: '2026-05-18T08:28:00Z',
+            status: 'pending',
+          },
+        ]),
+      ),
+    );
+    expect(r.candidate).not.toBeNull();
+    if (!r.candidate) return;
+    expect(r.candidate.source).toBe('reminder_due');
+    expect(r.candidate.priority).toBe(85);
+    expect(r.candidate.confidence).toBe('high');
+    expect(r.candidate.dedupeKey).toBe('reminder_due:r-123');
+    expect(r.candidate.userFacingLine).toContain('magnesium');
+    expect(r.candidate.userFacingLine).toContain('28');
+    expect(r.candidate.cta?.type).toBe('ask_permission');
+    expect(r.candidate.reasons[0].kind).toBe('reminder_due_within_horizon');
+  });
+
+  test('one row 90min ahead → priority 65, confidence medium', async () => {
+    const r = await produceReminderDue(
+      ctxWith(
+        fakeSupabase([
+          {
+            id: 'r-456',
+            action_text: 'walk',
+            spoken_message: null,
+            next_fire_at: '2026-05-18T09:30:00Z',
+            status: 'pending',
+          },
+        ]),
+      ),
+    );
+    expect(r.candidate?.priority).toBe(65);
+    expect(r.candidate?.confidence).toBe('medium');
+  });
+
+  test('empty action_text falls back to generic "reminder" label', async () => {
+    const r = await produceReminderDue(
+      ctxWith(
+        fakeSupabase([
+          {
+            id: 'r-789',
+            action_text: '',
+            spoken_message: null,
+            next_fire_at: '2026-05-18T08:15:00Z',
+            status: 'pending',
+          },
+        ]),
+      ),
+    );
+    expect(r.candidate?.userFacingLine.toLowerCase()).toContain('reminder');
+  });
+});

--- a/services/gateway/test/services/wake-brief-wiring.test.ts
+++ b/services/gateway/test/services/wake-brief-wiring.test.ts
@@ -83,11 +83,21 @@ describe('B0d.4 — wake-brief-wiring', () => {
         { recorder },
       );
       expect(decision.selectedContinuation).toBeNull();
-      expect(decision.suppressionReason).toBe('all_providers_suppressed');
-      // The provider's specific reason is preserved on the row.
-      const row = decision.sourceProviderResults[0];
-      expect(row.status).toBe('suppressed');
-      expect(row.reason).toBe('greeting_policy_skip');
+      // VTID-03057 (B0d-real Xb): two providers now register on
+      // orb_wake (voice-wake-brief + contextual_next_action). The
+      // wake-brief test doesn't pass the next-action supabase input,
+      // so next-action returns `skipped:no_next_action_inputs` while
+      // voice-wake-brief returns `suppressed:greeting_policy_skip` —
+      // mixed → rolled-up to `no_provider_returned_a_candidate`. The
+      // important assertion is `selectedContinuation === null` (the
+      // transparent-reconnect silence rule) plus the wake-brief row's
+      // specific reason for diagnosability.
+      expect(decision.suppressionReason).toBe('no_provider_returned_a_candidate');
+      const wakeBriefRow = decision.sourceProviderResults.find(
+        (r) => r.providerKey === VOICE_WAKE_BRIEF_PROVIDER_KEY,
+      );
+      expect(wakeBriefRow?.status).toBe('suppressed');
+      expect(wakeBriefRow?.reason).toBe('greeting_policy_skip');
     });
 
     it('maps bucket=long to fresh_intro (warm new-day greeting)', async () => {
@@ -213,7 +223,10 @@ describe('B0d.4 — wake-brief-wiring', () => {
       const timeline = await recorder.getTimeline('live-ev-none');
       const selected = timeline?.events.find((e) => e.name === 'wake_brief_selected');
       expect(selected?.metadata?.selected_continuation_kind).toBe('none_with_reason');
-      expect(selected?.metadata?.none_with_reason).toBe('all_providers_suppressed');
+      // VTID-03057: two providers now register; voice-wake-brief
+      // suppresses on policy=skip while contextual_next_action skips on
+      // missing inputs → rolled-up to `no_provider_returned_a_candidate`.
+      expect(selected?.metadata?.none_with_reason).toBe('no_provider_returned_a_candidate');
     });
 
     it('continuation_decision_finished carries providerResults summary', async () => {


### PR DESCRIPTION
## Summary

First two real NextActionSources land. The Contextual Next Action provider (VTID-03056 skeleton) now produces a candidate when the user has either a pending reminder due ≤120min OR a fresh autopilot recommendation.

## Sources

| Source | Priority bands | Notes |
|---|---|---|
| reminder_due | <10min=95, 10-30=85, 30-60=75, 60-120=65 | EN+DE lines. Beyond horizon → skipped. |
| autopilot_recommendation | high=88, medium=78, low=60 (+3 recency boost ≤24h) | EN+DE lines. Excludes milestone source_type. |

CROSS_SOURCE_THRESHOLD=50 means everything above fires. Tie-break = registration order (reminders first).

## Wiring
- next-action provider registered in defaultProviderRegistry @ priority 90 (beats voice-wake-brief's 80 when a real candidate exists)
- DecideWakeBriefArgs gains optional supabase + decisionContext
- orb-livekit.ts forwards both into the wake-brief decision

## Tests
- +20 new source tests
- 2 wake-brief-wiring tests updated (rolled-up suppression reason changed from `all_providers_suppressed` to `no_provider_returned_a_candidate` once two providers register)
- 240 continuation tests + 713 orb tests green

## Acceptance criteria
- [x] #1 strong Autopilot recommendation can win
- [x] #2 reminder due soon can win
- [ ] #3 match/activity plan opportunity → next slice
- [ ] #4 Life Compass + weak pillar → next slice
- [ ] #5 diary missing relevant → next slice
- [x] #6 pillar momentum is ONE candidate, not the whole system (voice-wake-brief fallback still uses it, but next-action provider can override)
- [ ] #7 Command Hub Candidate Inspector → Xf
- [ ] #8 OASIS accepted/dismissed → Xf

🤖 Generated with [Claude Code](https://claude.com/claude-code)