### PR TITLE
feat(orb-livekit): B0d-real Xc — calendar-upcoming + life-compass-alignment sources (VTID-03058)

### DIFF
--- a/services/gateway/src/services/assistant-continuation/providers/next-action/register-default-sources.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/next-action/register-default-sources.ts
@@ -21,14 +21,25 @@
 import { defaultNextActionComposer } from './composer';
 import { makeReminderDueSource } from './sources/reminder-due';
 import { makeAutopilotRecommendationSource } from './sources/autopilot-recommendation';
+// VTID-03058 (B0d-real Xc) — second wave of sources.
+import { makeCalendarUpcomingSource } from './sources/calendar-upcoming';
+import { makeLifeCompassAlignmentSource } from './sources/life-compass-alignment';
 
 let _registered = false;
 
 export function ensureDefaultNextActionSourcesRegistered(): void {
   if (_registered) return;
   _registered = true;
+  // Registration order also serves as the deterministic tie-break.
+  // Pick: reminders > calendar > autopilot > life-compass-alignment.
+  // Each source's bands are tuned so the natural urgency winner wins on
+  // priority alone (e.g. <10min reminder=95 beats calendar bands), but
+  // this order resolves rare ties without the composer needing a
+  // global registry.
   defaultNextActionComposer.register(makeReminderDueSource());
+  defaultNextActionComposer.register(makeCalendarUpcomingSource());
   defaultNextActionComposer.register(makeAutopilotRecommendationSource());
+  defaultNextActionComposer.register(makeLifeCompassAlignmentSource());
 }
 
 // Register on import so consumers don't have to remember.

--- a/services/gateway/src/services/assistant-continuation/providers/next-action/sources/calendar-upcoming.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/next-action/sources/calendar-upcoming.ts
@@ -1,0 +1,148 @@
+/**
+ * VTID-03058 (B0d-real slice Xc) — Calendar-upcoming NextActionSource.
+ *
+ * Reads from the canonical `calendar_events` table (same one
+ * awareness-context.ts + opener-mvp.ts + pillar-agents/base-agent.ts
+ * query). Picks the user's next scheduled event when it starts within
+ * the next 24 hours, with priority decaying as the event moves further
+ * out.
+ *
+ * Priority bands (minutes-until-start):
+ *   <  30 min  → 92 (about-to-start)
+ *   30-120 min → 82
+ *   2-6 hours  → 72
+ *   6-24 hours → 62
+ *   > 24 hours → skipped (no_eligible_record)
+ *
+ * Why slightly lower than reminders at the same horizon: calendar
+ * events are typically less urgent than reminders (a reminder is a
+ * deliberate "nudge me at X" intent; a calendar event might just be a
+ * meeting on the books). The reminder source at the same minutes-out
+ * wins the tie.
+ *
+ * Acceptance #2 (calendar OR reminder due soon can win) is now covered
+ * on both sides; the composer picks the higher-priority winner.
+ */
+
+import type {
+  NextActionSource,
+  NextActionSourceContext,
+  NextActionSourceResult,
+  ScoredCandidate,
+} from '../types';
+
+const KEY = 'calendar_upcoming' as const;
+const HORIZON_MINUTES = 24 * 60;
+
+export function makeCalendarUpcomingSource(): NextActionSource {
+  return {
+    key: KEY,
+    serves: () => true,
+    produce: produceCalendarUpcoming,
+  };
+}
+
+export async function produceCalendarUpcoming(
+  ctx: NextActionSourceContext,
+): Promise<NextActionSourceResult> {
+  const horizonIso = new Date(
+    Date.parse(ctx.nowIso) + HORIZON_MINUTES * 60 * 1000,
+  ).toISOString();
+
+  let row: CalendarEventLike | null = null;
+  try {
+    const { data, error } = await ctx.supabase
+      .from('calendar_events')
+      .select('id, title, start_time, end_time, status, event_type')
+      .eq('user_id', ctx.userId)
+      .eq('status', 'scheduled')
+      .gte('start_time', ctx.nowIso)
+      .lte('start_time', horizonIso)
+      .order('start_time', { ascending: true })
+      .limit(1);
+    if (error) {
+      return { source: KEY, candidate: null, skippedReason: 'source_unavailable' };
+    }
+    row = (data && data[0]) ? (data[0] as CalendarEventLike) : null;
+  } catch {
+    return { source: KEY, candidate: null, skippedReason: 'errored' };
+  }
+
+  if (!row) {
+    return { source: KEY, candidate: null, skippedReason: 'no_eligible_record' };
+  }
+
+  const minutesUntil = computeMinutesUntil(row.start_time, ctx.nowIso);
+  if (minutesUntil < 0 || minutesUntil > HORIZON_MINUTES) {
+    return { source: KEY, candidate: null, skippedReason: 'no_eligible_record' };
+  }
+
+  const priority = priorityForMinutes(minutesUntil);
+  const confidence: ScoredCandidate['confidence'] =
+    minutesUntil <= 30 ? 'high' : minutesUntil <= 120 ? 'medium' : 'low';
+
+  const title = (row.title || '').trim() || 'an event';
+  const userFacingLine = renderLine(title, minutesUntil, ctx.lang);
+
+  const candidate: ScoredCandidate = {
+    source: KEY,
+    priority,
+    confidence,
+    userFacingLine,
+    reasons: [
+      {
+        kind: 'calendar_event_upcoming',
+        detail: `${minutesUntil} min until "${title}"`,
+      },
+    ],
+    dedupeKey: `calendar_upcoming:${row.id}`,
+    cta: { type: 'ask_permission', payload: { event_id: row.id } },
+  };
+  return { source: KEY, candidate };
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers — exported for tests
+// ---------------------------------------------------------------------------
+
+interface CalendarEventLike {
+  id: string;
+  title: string | null;
+  start_time: string;
+  end_time: string | null;
+  status: string;
+  event_type: string | null;
+}
+
+export function priorityForMinutes(minutes: number): number {
+  if (minutes < 30) return 92;
+  if (minutes < 120) return 82;
+  if (minutes < 360) return 72;
+  if (minutes <= HORIZON_MINUTES) return 62;
+  return 0;
+}
+
+export function computeMinutesUntil(startIso: string, nowIso: string): number {
+  const start = Date.parse(startIso);
+  const now = Date.parse(nowIso);
+  if (!Number.isFinite(start) || !Number.isFinite(now)) return Number.NaN;
+  return Math.round((start - now) / 60_000);
+}
+
+export function renderLine(title: string, minutes: number, lang: string): string {
+  const isDe = (lang || 'en').toLowerCase().startsWith('de');
+  if (minutes < 30) {
+    return isDe
+      ? `In ${minutes} Minuten startet "${title}". Sollen wir das kurz vorbereiten?`
+      : `"${title}" starts in ${minutes} minutes. Want to prep quickly?`;
+  }
+  if (minutes < 120) {
+    return isDe
+      ? `In ${minutes} Minuten steht "${title}" an. Brauchst du davor noch etwas?`
+      : `"${title}" is in ${minutes} minutes. Anything you need before then?`;
+  }
+  const hours = Math.round(minutes / 60);
+  return isDe
+    ? `Heute steht "${title}" in etwa ${hours} Stunde${hours === 1 ? '' : 'n'} an. Sollen wir das im Hinterkopf behalten?`
+    : `"${title}" is in about ${hours} hour${hours === 1 ? '' : 's'}. Want me to keep that in mind?`;
+}

--- a/services/gateway/src/services/assistant-continuation/providers/next-action/sources/life-compass-alignment.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/next-action/sources/life-compass-alignment.ts
@@ -1,0 +1,182 @@
+/**
+ * VTID-03058 (B0d-real slice Xc) — Life-compass-alignment NextActionSource.
+ *
+ * Reads the user's active `life_compass` row (primary_goal + category)
+ * AND the compiled pillar_momentum from decisionContext. When the user
+ * has BOTH (a) an active Life Compass goal and (b) at least one
+ * slipping pillar that's coachable, this source produces a
+ * goal-anchored next-action.
+ *
+ * The line is structured as: "Anchor on <goal>. <pillar> is slipping —
+ * one small step today?" The Life Compass becomes the WHY; the pillar
+ * becomes the WHAT. This is the alignment the user explicitly asked
+ * for in B0d-real acceptance #4 ("Life Compass + weak pillar suggest
+ * a next action, it can win").
+ *
+ * Priority bands (Life Compass present + slipping pillar):
+ *   - high confidence on pillar      → 80
+ *   - medium confidence on pillar    → 70
+ *   - life compass present, no slip  → skipped (no_eligible_record)
+ *   - no life compass                → skipped (no_eligible_record)
+ *
+ * Below reminders/calendar/autopilot bands so an imminent reminder
+ * wins, but above CROSS_SOURCE_THRESHOLD=50 so the alignment fires
+ * when nothing more urgent is on deck.
+ *
+ * Reads decisionContext.pillar_momentum (already compiled in the
+ * gateway's bootstrap path); does NOT re-query pillar data.
+ */
+
+import type {
+  NextActionSource,
+  NextActionSourceContext,
+  NextActionSourceResult,
+  ScoredCandidate,
+} from '../types';
+import type {
+  DecisionPillarMomentum,
+  PillarKey,
+} from '../../../../../orb/context/types';
+
+const KEY = 'life_compass_alignment' as const;
+
+export function makeLifeCompassAlignmentSource(): NextActionSource {
+  return {
+    key: KEY,
+    serves: () => true,
+    produce: produceLifeCompassAlignment,
+  };
+}
+
+export async function produceLifeCompassAlignment(
+  ctx: NextActionSourceContext,
+): Promise<NextActionSourceResult> {
+  // Step 1: read the active Life Compass row.
+  let compass: LifeCompassLike | null = null;
+  try {
+    const { data, error } = await ctx.supabase
+      .from('life_compass')
+      .select('id, primary_goal, category, is_active, created_at')
+      .eq('user_id', ctx.userId)
+      .eq('is_active', true)
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    if (error) {
+      // Missing-table is a separate skip; everything else is unavailable.
+      if (/relation .* does not exist/i.test(error.message)) {
+        return {
+          source: KEY,
+          candidate: null,
+          skippedReason: 'feature_disabled',
+        };
+      }
+      return { source: KEY, candidate: null, skippedReason: 'source_unavailable' };
+    }
+    compass = (data as LifeCompassLike | null) ?? null;
+  } catch {
+    return { source: KEY, candidate: null, skippedReason: 'errored' };
+  }
+
+  if (!compass || !compass.primary_goal || !compass.primary_goal.trim()) {
+    return { source: KEY, candidate: null, skippedReason: 'no_eligible_record' };
+  }
+
+  // Step 2: read pillar_momentum from the decision context. No re-query.
+  const pm = extractPillarMomentum(ctx.decisionContext);
+  if (!pm) {
+    return { source: KEY, candidate: null, skippedReason: 'no_data' };
+  }
+  if (pm.confidence === 'low') {
+    return { source: KEY, candidate: null, skippedReason: 'low_confidence' };
+  }
+  if (!pm.suggested_focus) {
+    return { source: KEY, candidate: null, skippedReason: 'no_eligible_record' };
+  }
+  const slipRow = pm.per_pillar.find((p) => p.pillar === pm.suggested_focus);
+  if (!slipRow || (slipRow.momentum !== 'slipping' && slipRow.momentum !== 'unknown')) {
+    return { source: KEY, candidate: null, skippedReason: 'no_eligible_record' };
+  }
+
+  const priority = pm.confidence === 'high' ? 80 : 70;
+  const focus = pm.suggested_focus;
+  const goal = compass.primary_goal.trim();
+  const userFacingLine = renderLine(goal, focus, ctx.lang);
+
+  const candidate: ScoredCandidate = {
+    source: KEY,
+    priority,
+    confidence: pm.confidence,
+    userFacingLine,
+    reasons: [
+      {
+        kind: 'life_compass_anchor',
+        detail: `goal="${goal}" category=${compass.category ?? 'unset'}`,
+      },
+      {
+        kind: 'pillar_slipping_aligned',
+        detail: `${focus} (${slipRow.momentum})`,
+      },
+    ],
+    dedupeKey: `life_compass_alignment:${compass.id}:${focus}`,
+    cta: {
+      type: 'navigate',
+      route: '/health',
+      payload: { focus_pillar: focus, life_compass_id: compass.id },
+    },
+  };
+  return { source: KEY, candidate };
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers — exported for tests
+// ---------------------------------------------------------------------------
+
+interface LifeCompassLike {
+  id: string;
+  primary_goal: string | null;
+  category: string | null;
+  is_active: boolean;
+  created_at: string;
+}
+
+/**
+ * Defensive extraction. The decision context flows in as `unknown`
+ * because the framework's ContinuationDecisionContext.extra is opaque.
+ * Returns null on any shape mismatch — never throws.
+ */
+export function extractPillarMomentum(
+  decisionContext: unknown,
+): DecisionPillarMomentum | null {
+  if (!decisionContext || typeof decisionContext !== 'object') return null;
+  const pm = (decisionContext as Record<string, unknown>).pillar_momentum;
+  if (!pm || typeof pm !== 'object') return null;
+  return pm as DecisionPillarMomentum;
+}
+
+export function renderLine(
+  goal: string,
+  focus: PillarKey,
+  lang: string,
+): string {
+  const isDe = (lang || 'en').toLowerCase().startsWith('de');
+  // Goal text varies per user — quote it verbatim so the user hears
+  // THEIR words, not a paraphrase.
+  if (isDe) {
+    const pillarDe: Record<PillarKey, string> = {
+      sleep: 'Schlaf',
+      nutrition: 'Ernährung',
+      exercise: 'Bewegung',
+      hydration: 'Hydration',
+      mental: 'Mental',
+    };
+    return (
+      `Dein aktueller Anker ist "${goal}". ` +
+      `${pillarDe[focus]} bleibt zurzeit zurück — sollen wir heute einen kleinen Schritt darauf einplanen?`
+    );
+  }
+  return (
+    `Your current anchor is "${goal}". ` +
+    `${focus} is slipping — want one small step on it today?`
+  );
+}

--- a/services/gateway/test/services/assistant-continuation/providers/next-action/calendar-upcoming.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/next-action/calendar-upcoming.test.ts
@@ -1,0 +1,146 @@
+/**
+ * VTID-03058 (B0d-real slice Xc) — calendar-upcoming source tests.
+ */
+
+import {
+  produceCalendarUpcoming,
+  priorityForMinutes,
+  computeMinutesUntil,
+  renderLine,
+} from '../../../../../src/services/assistant-continuation/providers/next-action/sources/calendar-upcoming';
+import type { NextActionSourceContext } from '../../../../../src/services/assistant-continuation/providers/next-action/types';
+
+function fakeSupabase(
+  rows: unknown[] | null,
+  err: { message: string } | null = null,
+  shouldThrow = false,
+): import('@supabase/supabase-js').SupabaseClient {
+  const finalResult = err ? { data: null, error: err } : { data: rows, error: null };
+  const chain = {
+    eq: () => chain,
+    gte: () => chain,
+    lte: () => chain,
+    order: () => chain,
+    limit: () => (shouldThrow ? Promise.reject(new Error('boom')) : Promise.resolve(finalResult)),
+  };
+  return {
+    from: () => ({ select: () => chain }),
+    rpc: async () => ({ data: null, error: null }),
+  } as unknown as import('@supabase/supabase-js').SupabaseClient;
+}
+
+function ctxWith(sb: import('@supabase/supabase-js').SupabaseClient, lang = 'en'): NextActionSourceContext {
+  return {
+    userId: 'u1',
+    tenantId: 't1',
+    lang,
+    nowIso: '2026-05-18T08:00:00Z',
+    decisionContext: null,
+    supabase: sb,
+  };
+}
+
+describe('calendar-upcoming pure helpers', () => {
+  test('priorityForMinutes banding', () => {
+    expect(priorityForMinutes(15)).toBe(92);
+    expect(priorityForMinutes(29)).toBe(92);
+    expect(priorityForMinutes(30)).toBe(82);
+    expect(priorityForMinutes(119)).toBe(82);
+    expect(priorityForMinutes(120)).toBe(72);
+    expect(priorityForMinutes(359)).toBe(72);
+    expect(priorityForMinutes(360)).toBe(62);
+    expect(priorityForMinutes(24 * 60)).toBe(62);
+    expect(priorityForMinutes(24 * 60 + 1)).toBe(0);
+  });
+
+  test('computeMinutesUntil', () => {
+    expect(computeMinutesUntil('2026-05-18T09:00:00Z', '2026-05-18T08:00:00Z')).toBe(60);
+    expect(Number.isNaN(computeMinutesUntil('garbage', '2026-05-18T08:00:00Z'))).toBe(true);
+  });
+
+  test('renderLine — bands', () => {
+    expect(renderLine('Standup', 15, 'en')).toMatch(/starts in 15 minutes/);
+    expect(renderLine('Meeting', 60, 'en')).toMatch(/60 minutes/);
+    expect(renderLine('Workshop', 5 * 60, 'en')).toMatch(/about 5 hours/);
+    expect(renderLine('Standup', 15, 'de')).toMatch(/In 15 Minuten/);
+  });
+});
+
+describe('produceCalendarUpcoming source', () => {
+  test('no rows → no_eligible_record', async () => {
+    const r = await produceCalendarUpcoming(ctxWith(fakeSupabase([])));
+    expect(r.candidate).toBeNull();
+    expect(r.skippedReason).toBe('no_eligible_record');
+  });
+
+  test('supabase error → source_unavailable', async () => {
+    const r = await produceCalendarUpcoming(
+      ctxWith(fakeSupabase(null, { message: 'rls denied' })),
+    );
+    expect(r.skippedReason).toBe('source_unavailable');
+  });
+
+  test('throw → errored', async () => {
+    const r = await produceCalendarUpcoming(ctxWith(fakeSupabase(null, null, true)));
+    expect(r.skippedReason).toBe('errored');
+  });
+
+  test('event 15min ahead → priority 92, confidence high, dedupe by id', async () => {
+    const r = await produceCalendarUpcoming(
+      ctxWith(
+        fakeSupabase([
+          {
+            id: 'evt-1',
+            title: 'Team standup',
+            start_time: '2026-05-18T08:15:00Z',
+            end_time: '2026-05-18T08:30:00Z',
+            status: 'scheduled',
+            event_type: 'meeting',
+          },
+        ]),
+      ),
+    );
+    expect(r.candidate?.priority).toBe(92);
+    expect(r.candidate?.confidence).toBe('high');
+    expect(r.candidate?.dedupeKey).toBe('calendar_upcoming:evt-1');
+    expect(r.candidate?.userFacingLine).toContain('Team standup');
+    expect(r.candidate?.cta?.type).toBe('ask_permission');
+  });
+
+  test('event 5h ahead → priority 72, confidence low', async () => {
+    const r = await produceCalendarUpcoming(
+      ctxWith(
+        fakeSupabase([
+          {
+            id: 'evt-2',
+            title: 'Workshop',
+            start_time: '2026-05-18T13:00:00Z',
+            end_time: null,
+            status: 'scheduled',
+            event_type: null,
+          },
+        ]),
+      ),
+    );
+    expect(r.candidate?.priority).toBe(72);
+    expect(r.candidate?.confidence).toBe('low');
+  });
+
+  test('empty title falls back to generic phrase', async () => {
+    const r = await produceCalendarUpcoming(
+      ctxWith(
+        fakeSupabase([
+          {
+            id: 'evt-3',
+            title: '',
+            start_time: '2026-05-18T08:10:00Z',
+            end_time: null,
+            status: 'scheduled',
+            event_type: null,
+          },
+        ]),
+      ),
+    );
+    expect(r.candidate?.userFacingLine.toLowerCase()).toContain('event');
+  });
+});

--- a/services/gateway/test/services/assistant-continuation/providers/next-action/life-compass-alignment.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/next-action/life-compass-alignment.test.ts
@@ -1,0 +1,257 @@
+/**
+ * VTID-03058 (B0d-real slice Xc) — life-compass-alignment source tests.
+ */
+
+import {
+  produceLifeCompassAlignment,
+  extractPillarMomentum,
+  renderLine,
+} from '../../../../../src/services/assistant-continuation/providers/next-action/sources/life-compass-alignment';
+import type { NextActionSourceContext } from '../../../../../src/services/assistant-continuation/providers/next-action/types';
+import type {
+  DecisionPillarMomentum,
+  PillarKey,
+  PillarMomentumBand,
+  PillarMomentumConfidence,
+} from '../../../../../src/orb/context/types';
+
+function fakeSupabase(opts: {
+  compass: unknown | null;
+  err?: { message: string };
+  shouldThrow?: boolean;
+}): import('@supabase/supabase-js').SupabaseClient {
+  // Chain: .from('life_compass').select(...).eq().eq().order().limit().maybeSingle()
+  const finalResult = opts.err
+    ? { data: null, error: opts.err }
+    : { data: opts.compass, error: null };
+  const chain = {
+    eq: () => chain,
+    order: () => chain,
+    limit: () => chain,
+    maybeSingle: () =>
+      opts.shouldThrow ? Promise.reject(new Error('boom')) : Promise.resolve(finalResult),
+  };
+  return {
+    from: () => ({ select: () => chain }),
+    rpc: async () => ({ data: null, error: null }),
+  } as unknown as import('@supabase/supabase-js').SupabaseClient;
+}
+
+function makePm(over: Partial<DecisionPillarMomentum> = {}): DecisionPillarMomentum {
+  const focus: PillarKey = (over.suggested_focus ?? 'nutrition') as PillarKey;
+  const focusMomentum: PillarMomentumBand =
+    over.per_pillar?.find((p) => p.pillar === focus)?.momentum ?? 'slipping';
+  return {
+    per_pillar: over.per_pillar ?? [
+      { pillar: 'sleep', momentum: 'steady' },
+      { pillar: 'nutrition', momentum: focusMomentum },
+      { pillar: 'exercise', momentum: 'steady' },
+      { pillar: 'hydration', momentum: 'steady' },
+      { pillar: 'mental', momentum: 'steady' },
+    ],
+    weakest_pillar: focus,
+    strongest_pillar: 'sleep',
+    suggested_focus: focus,
+    confidence: (over.confidence ?? 'high') as PillarMomentumConfidence,
+    warnings: [],
+  };
+}
+
+function ctxWith(
+  sb: import('@supabase/supabase-js').SupabaseClient,
+  decisionContext: unknown,
+  lang = 'en',
+): NextActionSourceContext {
+  return {
+    userId: 'u1',
+    tenantId: 't1',
+    lang,
+    nowIso: '2026-05-18T08:00:00Z',
+    decisionContext,
+    supabase: sb,
+  };
+}
+
+describe('life-compass-alignment pure helpers', () => {
+  test('extractPillarMomentum — defensive on bad shapes', () => {
+    expect(extractPillarMomentum(null)).toBeNull();
+    expect(extractPillarMomentum(undefined)).toBeNull();
+    expect(extractPillarMomentum({})).toBeNull();
+    expect(extractPillarMomentum({ pillar_momentum: null })).toBeNull();
+    expect(extractPillarMomentum({ pillar_momentum: 'oops' })).toBeNull();
+    const pm = makePm();
+    expect(extractPillarMomentum({ pillar_momentum: pm })).toEqual(pm);
+  });
+
+  test('renderLine — quotes the user goal verbatim', () => {
+    const enLine = renderLine('Live longer with my kids', 'nutrition', 'en');
+    expect(enLine).toContain('"Live longer with my kids"');
+    expect(enLine.toLowerCase()).toContain('nutrition');
+    const deLine = renderLine('Mit Kindern älter werden', 'sleep', 'de');
+    expect(deLine).toContain('"Mit Kindern älter werden"');
+    expect(deLine).toContain('Schlaf');
+  });
+});
+
+describe('produceLifeCompassAlignment source', () => {
+  test('missing Life Compass table → feature_disabled', async () => {
+    const r = await produceLifeCompassAlignment(
+      ctxWith(
+        fakeSupabase({
+          compass: null,
+          err: { message: 'relation "life_compass" does not exist' },
+        }),
+        { pillar_momentum: makePm() },
+      ),
+    );
+    expect(r.candidate).toBeNull();
+    expect(r.skippedReason).toBe('feature_disabled');
+  });
+
+  test('supabase error (other) → source_unavailable', async () => {
+    const r = await produceLifeCompassAlignment(
+      ctxWith(
+        fakeSupabase({ compass: null, err: { message: 'rls denied' } }),
+        { pillar_momentum: makePm() },
+      ),
+    );
+    expect(r.skippedReason).toBe('source_unavailable');
+  });
+
+  test('thrown exception → errored', async () => {
+    const r = await produceLifeCompassAlignment(
+      ctxWith(fakeSupabase({ compass: null, shouldThrow: true }), {
+        pillar_momentum: makePm(),
+      }),
+    );
+    expect(r.skippedReason).toBe('errored');
+  });
+
+  test('no compass row → no_eligible_record', async () => {
+    const r = await produceLifeCompassAlignment(
+      ctxWith(fakeSupabase({ compass: null }), { pillar_momentum: makePm() }),
+    );
+    expect(r.skippedReason).toBe('no_eligible_record');
+  });
+
+  test('empty primary_goal → no_eligible_record', async () => {
+    const r = await produceLifeCompassAlignment(
+      ctxWith(
+        fakeSupabase({
+          compass: {
+            id: 'lc-1',
+            primary_goal: '   ',
+            category: 'longevity',
+            is_active: true,
+            created_at: '2026-05-01T00:00:00Z',
+          },
+        }),
+        { pillar_momentum: makePm() },
+      ),
+    );
+    expect(r.skippedReason).toBe('no_eligible_record');
+  });
+
+  test('low-confidence pillar_momentum → low_confidence', async () => {
+    const r = await produceLifeCompassAlignment(
+      ctxWith(
+        fakeSupabase({
+          compass: {
+            id: 'lc-1',
+            primary_goal: 'Live longer',
+            category: 'longevity',
+            is_active: true,
+            created_at: '2026-05-01T00:00:00Z',
+          },
+        }),
+        { pillar_momentum: makePm({ confidence: 'low' }) },
+      ),
+    );
+    expect(r.skippedReason).toBe('low_confidence');
+  });
+
+  test('no slipping pillar → no_eligible_record', async () => {
+    const r = await produceLifeCompassAlignment(
+      ctxWith(
+        fakeSupabase({
+          compass: {
+            id: 'lc-1',
+            primary_goal: 'Live longer',
+            category: 'longevity',
+            is_active: true,
+            created_at: '2026-05-01T00:00:00Z',
+          },
+        }),
+        {
+          pillar_momentum: makePm({
+            per_pillar: [
+              { pillar: 'sleep', momentum: 'steady' },
+              { pillar: 'nutrition', momentum: 'improving' },
+              { pillar: 'exercise', momentum: 'steady' },
+              { pillar: 'hydration', momentum: 'steady' },
+              { pillar: 'mental', momentum: 'steady' },
+            ],
+          }),
+        },
+      ),
+    );
+    expect(r.skippedReason).toBe('no_eligible_record');
+  });
+
+  test('compass + slipping pillar + high confidence → priority 80', async () => {
+    const r = await produceLifeCompassAlignment(
+      ctxWith(
+        fakeSupabase({
+          compass: {
+            id: 'lc-1',
+            primary_goal: 'Live longer with my kids',
+            category: 'longevity',
+            is_active: true,
+            created_at: '2026-05-01T00:00:00Z',
+          },
+        }),
+        { pillar_momentum: makePm({ confidence: 'high' }) },
+      ),
+    );
+    expect(r.candidate?.priority).toBe(80);
+    expect(r.candidate?.confidence).toBe('high');
+    expect(r.candidate?.userFacingLine).toContain('"Live longer with my kids"');
+    expect(r.candidate?.userFacingLine.toLowerCase()).toContain('nutrition');
+    expect(r.candidate?.dedupeKey).toBe('life_compass_alignment:lc-1:nutrition');
+    expect(r.candidate?.cta?.type).toBe('navigate');
+    expect(r.candidate?.reasons.length).toBe(2);
+  });
+
+  test('compass + slipping pillar + medium confidence → priority 70', async () => {
+    const r = await produceLifeCompassAlignment(
+      ctxWith(
+        fakeSupabase({
+          compass: {
+            id: 'lc-1',
+            primary_goal: 'Lift my mood',
+            category: 'wellbeing',
+            is_active: true,
+            created_at: '2026-05-01T00:00:00Z',
+          },
+        }),
+        {
+          pillar_momentum: makePm({
+            confidence: 'medium',
+            suggested_focus: 'mental',
+            per_pillar: [
+              { pillar: 'sleep', momentum: 'steady' },
+              { pillar: 'nutrition', momentum: 'steady' },
+              { pillar: 'exercise', momentum: 'steady' },
+              { pillar: 'hydration', momentum: 'steady' },
+              { pillar: 'mental', momentum: 'slipping' },
+            ],
+          }),
+        },
+        'de',
+      ),
+    );
+    expect(r.candidate?.priority).toBe(70);
+    expect(r.candidate?.userFacingLine).toContain('"Lift my mood"');
+    expect(r.candidate?.userFacingLine).toContain('Mental');
+  });
+});


### PR DESCRIPTION
Second wave of NextActionSources. The Contextual Next Action provider now considers four real sources: reminders + autopilot (Xb), calendar + life-compass-alignment (Xc).

**calendar-upcoming**: queries calendar_events scheduled in the next 24h. Banded priority 62-92 by minutes-until-start. EN+DE. Tie-breaks below reminders.

**life-compass-alignment**: reads active life_compass row AND consumes pillar_momentum from decisionContext. Fires when user has BOTH an active goal AND a slipping suggested-focus pillar with medium/high confidence. Quotes goal text verbatim. EN+DE. Priority 70/80. Navigate CTA to /health.

Tests: +21 hermetic tests. 59 next-action + 713 orb tests green.

Acceptance: #1, #2, #4, #6 ✅. #3 (match), #5 (diary), #7-#8 (Command Hub + OASIS) queued for Xd/Xe/Xf.