### PR TITLE
feat(orb-livekit): B0d-real Xd — diary + pillar sources (VTID-03059)

### DIFF
--- a/services/gateway/src/services/assistant-continuation/providers/next-action/register-default-sources.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/next-action/register-default-sources.ts
@@ -24,6 +24,9 @@ import { makeAutopilotRecommendationSource } from './sources/autopilot-recommend
 // VTID-03058 (B0d-real Xc) — second wave of sources.
 import { makeCalendarUpcomingSource } from './sources/calendar-upcoming';
 import { makeLifeCompassAlignmentSource } from './sources/life-compass-alignment';
+// VTID-03059 (B0d-real Xd) — third wave of sources.
+import { makeDiaryMissingRelevantSource } from './sources/diary-missing-relevant';
+import { makeVitanaIndexPillarSource } from './sources/vitana-index-pillar';
 
 let _registered = false;
 
@@ -31,15 +34,19 @@ export function ensureDefaultNextActionSourcesRegistered(): void {
   if (_registered) return;
   _registered = true;
   // Registration order also serves as the deterministic tie-break.
-  // Pick: reminders > calendar > autopilot > life-compass-alignment.
+  // Pick (urgency-first): reminders > calendar > autopilot > diary >
+  // life-compass-alignment > vitana-index-pillar.
   // Each source's bands are tuned so the natural urgency winner wins on
-  // priority alone (e.g. <10min reminder=95 beats calendar bands), but
-  // this order resolves rare ties without the composer needing a
-  // global registry.
+  // priority alone (e.g. <10min reminder=95 beats calendar bands). This
+  // order resolves rare ties without the composer needing a global
+  // registry. Pillar momentum is LAST — the weakest proactive lever
+  // unless nothing more concrete fires.
   defaultNextActionComposer.register(makeReminderDueSource());
   defaultNextActionComposer.register(makeCalendarUpcomingSource());
   defaultNextActionComposer.register(makeAutopilotRecommendationSource());
+  defaultNextActionComposer.register(makeDiaryMissingRelevantSource());
   defaultNextActionComposer.register(makeLifeCompassAlignmentSource());
+  defaultNextActionComposer.register(makeVitanaIndexPillarSource());
 }
 
 // Register on import so consumers don't have to remember.

--- a/services/gateway/src/services/assistant-continuation/providers/next-action/sources/diary-missing-relevant.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/next-action/sources/diary-missing-relevant.ts
@@ -1,0 +1,200 @@
+/**
+ * VTID-03059 (B0d-real slice Xd) — Diary-missing-relevant NextActionSource.
+ *
+ * Reads from `user_diary_streak` (the canonical streak view —
+ * same shape diary-streak-celebrator.ts uses). Detects two coachable
+ * states:
+ *
+ *   STREAK_AT_RISK
+ *     Current streak >= 2 days AND last_day is yesterday (local). The
+ *     user has built momentum; one more entry today preserves it. This
+ *     is the highest-priority diary nudge — momentum loss is psych-
+ *     ologically costly.
+ *
+ *   STREAK_BROKEN_RESTART
+ *     last_day is >= 3 days ago AND was previously >= 3 days in a row.
+ *     The streak has lapsed but a restart is meaningful. Lower priority
+ *     than at-risk (no immediate loss) but above CROSS_SOURCE_THRESHOLD.
+ *
+ * Anything else (no rows / first-day user / fresh entry already today)
+ * → skipped:no_eligible_record.
+ *
+ * Priority bands:
+ *   streak_at_risk          → 78
+ *   streak_broken_restart   → 58 (above threshold 50; below most others)
+ *
+ * Sits below reminders/calendar/autopilot at the same urgency level so
+ * those imminent items win. Above CROSS_SOURCE_THRESHOLD so when nothing
+ * else qualifies, the diary nudge fires.
+ *
+ * Covers B0d-real acceptance #5 ("If diary is missing and relevant, it
+ * can win"). The "relevant" qualifier is the (streak >= 2) gate — we
+ * don't nag first-day users who haven't built any pattern yet.
+ */
+
+import type {
+  NextActionSource,
+  NextActionSourceContext,
+  NextActionSourceResult,
+  ScoredCandidate,
+} from '../types';
+
+const KEY = 'diary_missing_relevant' as const;
+
+export function makeDiaryMissingRelevantSource(): NextActionSource {
+  return {
+    key: KEY,
+    serves: () => true,
+    produce: produceDiaryMissingRelevant,
+  };
+}
+
+export async function produceDiaryMissingRelevant(
+  ctx: NextActionSourceContext,
+): Promise<NextActionSourceResult> {
+  let row: DiaryStreakLike | null = null;
+  try {
+    const { data, error } = await ctx.supabase
+      .from('user_diary_streak')
+      .select('current_streak_days, last_day, longest_streak_days')
+      .eq('user_id', ctx.userId)
+      .maybeSingle();
+    if (error) {
+      if (/relation .* does not exist/i.test(error.message)) {
+        return { source: KEY, candidate: null, skippedReason: 'feature_disabled' };
+      }
+      return { source: KEY, candidate: null, skippedReason: 'source_unavailable' };
+    }
+    row = (data as DiaryStreakLike | null) ?? null;
+  } catch {
+    return { source: KEY, candidate: null, skippedReason: 'errored' };
+  }
+
+  if (!row) {
+    return { source: KEY, candidate: null, skippedReason: 'no_eligible_record' };
+  }
+
+  const state = classifyDiaryState(row, ctx.nowIso);
+  if (state.kind === 'none') {
+    return { source: KEY, candidate: null, skippedReason: state.reason };
+  }
+
+  const userFacingLine = renderLine(state, ctx.lang);
+  const priority = state.kind === 'streak_at_risk' ? 78 : 58;
+  const confidence: ScoredCandidate['confidence'] =
+    state.kind === 'streak_at_risk' ? 'high' : 'medium';
+
+  const candidate: ScoredCandidate = {
+    source: KEY,
+    priority,
+    confidence,
+    userFacingLine,
+    reasons: [
+      {
+        kind: state.kind,
+        detail:
+          state.kind === 'streak_at_risk'
+            ? `current_streak=${state.currentStreak} days`
+            : `last entry ${state.daysSinceLast} days ago, longest=${state.longestStreak}`,
+      },
+    ],
+    dedupeKey: `diary_missing_relevant:${state.kind}`,
+    cta: { type: 'navigate', route: '/diary' },
+  };
+  return { source: KEY, candidate };
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers — exported for tests
+// ---------------------------------------------------------------------------
+
+interface DiaryStreakLike {
+  current_streak_days: number | null;
+  last_day: string | null; // YYYY-MM-DD
+  longest_streak_days: number | null;
+}
+
+export type DiaryState =
+  | { kind: 'streak_at_risk'; currentStreak: number; daysSinceLast: number }
+  | { kind: 'streak_broken_restart'; daysSinceLast: number; longestStreak: number }
+  | { kind: 'none'; reason: 'no_eligible_record' | 'no_data' };
+
+/**
+ * Classify the current diary state. Pure; exported for tests.
+ *
+ * Date math uses UTC-day boundaries — the underlying view stores
+ * `last_day` as YYYY-MM-DD (no timezone). Per the user's
+ * "All user-facing time is CET" memory, a follow-up slice can swap to
+ * Europe/Berlin date diffing; for now UTC keeps the math deterministic
+ * across the parallel-deployed gateway instances. The mis-classification
+ * window is at most ~2 hours per user per day — acceptable for a
+ * coaching nudge.
+ */
+export function classifyDiaryState(
+  row: DiaryStreakLike,
+  nowIso: string,
+): DiaryState {
+  const currentStreak = Number(row.current_streak_days ?? 0);
+  const longestStreak = Number(row.longest_streak_days ?? 0);
+  const lastDay = (row.last_day ?? '').trim();
+
+  if (!lastDay) {
+    return { kind: 'none', reason: 'no_data' };
+  }
+
+  const lastTs = Date.parse(`${lastDay}T00:00:00Z`);
+  const now = Date.parse(nowIso);
+  if (!Number.isFinite(lastTs) || !Number.isFinite(now)) {
+    return { kind: 'none', reason: 'no_data' };
+  }
+
+  const today = Math.floor(now / 86_400_000);
+  const lastDayN = Math.floor(lastTs / 86_400_000);
+  const daysSinceLast = today - lastDayN;
+
+  if (daysSinceLast <= 0) {
+    // Entry already today (or future-dated row) → no nudge.
+    return { kind: 'none', reason: 'no_eligible_record' };
+  }
+
+  if (daysSinceLast === 1 && currentStreak >= 2) {
+    return { kind: 'streak_at_risk', currentStreak, daysSinceLast };
+  }
+
+  if (daysSinceLast >= 3 && longestStreak >= 3) {
+    return { kind: 'streak_broken_restart', daysSinceLast, longestStreak };
+  }
+
+  // Day-2 gap with no streak, or short historical longest → don't nag.
+  return { kind: 'none', reason: 'no_eligible_record' };
+}
+
+export function renderLine(
+  state: Exclude<DiaryState, { kind: 'none' }>,
+  lang: string,
+): string {
+  const isDe = (lang || 'en').toLowerCase().startsWith('de');
+  if (state.kind === 'streak_at_risk') {
+    if (isDe) {
+      return (
+        `Du hast ${state.currentStreak} Tage in Folge ins Tagebuch geschrieben. ` +
+        `Soll ich dir helfen, heute den nächsten Eintrag zu machen, bevor die Serie reißt?`
+      );
+    }
+    return (
+      `You've journaled ${state.currentStreak} days in a row. ` +
+      `Want help making today's entry so the streak stays alive?`
+    );
+  }
+  // streak_broken_restart
+  if (isDe) {
+    return (
+      `Dein letzter Tagebucheintrag liegt ${state.daysSinceLast} Tage zurück — ` +
+      `deine längste Serie war ${state.longestStreak} Tage. Wollen wir heute neu anfangen?`
+    );
+  }
+  return (
+    `Your last diary entry was ${state.daysSinceLast} days ago — your longest streak was ` +
+    `${state.longestStreak} days. Want to start a new one today?`
+  );
+}

--- a/services/gateway/src/services/assistant-continuation/providers/next-action/sources/vitana-index-pillar.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/next-action/sources/vitana-index-pillar.ts
@@ -1,0 +1,135 @@
+/**
+ * VTID-03059 (B0d-real slice Xd) — Vitana-Index-Pillar NextActionSource.
+ *
+ * The "Pillar momentum is ONE candidate, not the whole system" source.
+ * B0d-mini (voice-wake-brief renderer) hardcoded a per-pillar line as
+ * the only proactive surface. This file lifts the same signal — pillar
+ * momentum from decisionContext — into a proper NextActionSource so it
+ * competes with reminders, calendar, autopilot, and Life Compass on
+ * equal footing.
+ *
+ * Trigger: pillar_momentum present + confidence medium/high +
+ * suggested_focus has 'slipping' or 'unknown' momentum.
+ *
+ * Priority bands (intentionally lower than life-compass-alignment so
+ * the goal-anchored variant wins when both qualify):
+ *   high confidence    → 68
+ *   medium confidence  → 58
+ *
+ * Both are above CROSS_SOURCE_THRESHOLD=50; below reminders/calendar/
+ * autopilot urgency bands so any time-sensitive item wins.
+ *
+ * Hard scope: this source produces a candidate ABOVE the threshold but
+ * BELOW most other sources. It only wins when nothing else has a real
+ * signal. That's the central correction from B0d-mini — pillar momentum
+ * alone is the WEAKEST proactive lever; the user's spec was explicit.
+ *
+ * Reads decisionContext.pillar_momentum only — no DB queries (the
+ * compiler already ran).
+ */
+
+import type {
+  NextActionSource,
+  NextActionSourceContext,
+  NextActionSourceResult,
+  ScoredCandidate,
+} from '../types';
+import type {
+  DecisionPillarMomentum,
+  PillarKey,
+} from '../../../../../orb/context/types';
+
+const KEY = 'vitana_index_pillar' as const;
+
+export function makeVitanaIndexPillarSource(): NextActionSource {
+  return {
+    key: KEY,
+    serves: () => true,
+    produce: produceVitanaIndexPillar,
+  };
+}
+
+export async function produceVitanaIndexPillar(
+  ctx: NextActionSourceContext,
+): Promise<NextActionSourceResult> {
+  const pm = extractPillarMomentum(ctx.decisionContext);
+  if (!pm) {
+    return { source: KEY, candidate: null, skippedReason: 'no_data' };
+  }
+  if (pm.confidence === 'low') {
+    return { source: KEY, candidate: null, skippedReason: 'low_confidence' };
+  }
+  if (!pm.suggested_focus) {
+    return { source: KEY, candidate: null, skippedReason: 'no_eligible_record' };
+  }
+  const slipRow = pm.per_pillar.find((p) => p.pillar === pm.suggested_focus);
+  if (!slipRow || (slipRow.momentum !== 'slipping' && slipRow.momentum !== 'unknown')) {
+    return { source: KEY, candidate: null, skippedReason: 'no_eligible_record' };
+  }
+
+  const focus = pm.suggested_focus;
+  const priority = pm.confidence === 'high' ? 68 : 58;
+  const userFacingLine = renderLine(focus, ctx.lang);
+
+  const candidate: ScoredCandidate = {
+    source: KEY,
+    priority,
+    confidence: pm.confidence,
+    userFacingLine,
+    reasons: [
+      {
+        kind: 'pillar_momentum_slipping',
+        detail: `${focus} (${slipRow.momentum}, confidence=${pm.confidence})`,
+      },
+    ],
+    dedupeKey: `vitana_index_pillar:${focus}`,
+    cta: {
+      type: 'navigate',
+      route: '/health',
+      payload: { focus_pillar: focus },
+    },
+  };
+  return { source: KEY, candidate };
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers — exported for tests
+// ---------------------------------------------------------------------------
+
+export function extractPillarMomentum(
+  decisionContext: unknown,
+): DecisionPillarMomentum | null {
+  if (!decisionContext || typeof decisionContext !== 'object') return null;
+  const pm = (decisionContext as Record<string, unknown>).pillar_momentum;
+  if (!pm || typeof pm !== 'object') return null;
+  return pm as DecisionPillarMomentum;
+}
+
+const LINES: Record<PillarKey, Record<string, string>> = {
+  sleep: {
+    en: 'Your sleep pillar has been slipping lately. Want to look at what is getting in the way?',
+    de: 'Deine Schlaf-Säule sackt in letzter Zeit etwas ab. Wollen wir uns anschauen, was da hineinspielt?',
+  },
+  nutrition: {
+    en: 'Your nutrition pillar has been slipping lately. Want help getting it back on track?',
+    de: 'Deine Ernährungs-Säule sackt in letzter Zeit etwas ab. Sollen wir das gemeinsam wieder aufbauen?',
+  },
+  exercise: {
+    en: 'Your exercise pillar has been slipping lately. Want to set up something light for today?',
+    de: 'Deine Bewegungs-Säule sackt in letzter Zeit etwas ab. Sollen wir heute etwas Leichtes einplanen?',
+  },
+  hydration: {
+    en: 'Your hydration pillar has been slipping lately. Want a small step to lift it back up?',
+    de: 'Deine Hydrations-Säule sackt in letzter Zeit etwas ab. Wollen wir einen kleinen Schritt einbauen?',
+  },
+  mental: {
+    en: 'Your mental pillar has been slipping lately. What is weighing on you right now?',
+    de: 'Deine Mental-Säule sackt in letzter Zeit etwas ab. Was beschäftigt dich gerade?',
+  },
+};
+
+export function renderLine(focus: PillarKey, lang: string): string {
+  const isDe = (lang || 'en').toLowerCase().startsWith('de');
+  const row = LINES[focus];
+  return row[isDe ? 'de' : 'en'] ?? row.en;
+}

--- a/services/gateway/test/services/assistant-continuation/providers/next-action/diary-missing-relevant.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/next-action/diary-missing-relevant.test.ts
@@ -1,0 +1,198 @@
+/**
+ * VTID-03059 (B0d-real slice Xd) — diary-missing-relevant source tests.
+ */
+
+import {
+  produceDiaryMissingRelevant,
+  classifyDiaryState,
+  renderLine,
+} from '../../../../../src/services/assistant-continuation/providers/next-action/sources/diary-missing-relevant';
+import type { NextActionSourceContext } from '../../../../../src/services/assistant-continuation/providers/next-action/types';
+
+function fakeSupabase(opts: {
+  row: unknown | null;
+  err?: { message: string };
+  shouldThrow?: boolean;
+}): import('@supabase/supabase-js').SupabaseClient {
+  // Chain: .from('user_diary_streak').select(...).eq().maybeSingle()
+  const finalResult = opts.err
+    ? { data: null, error: opts.err }
+    : { data: opts.row, error: null };
+  const chain = {
+    eq: () => chain,
+    maybeSingle: () =>
+      opts.shouldThrow ? Promise.reject(new Error('boom')) : Promise.resolve(finalResult),
+  };
+  return {
+    from: () => ({ select: () => chain }),
+    rpc: async () => ({ data: null, error: null }),
+  } as unknown as import('@supabase/supabase-js').SupabaseClient;
+}
+
+function ctxWith(
+  sb: import('@supabase/supabase-js').SupabaseClient,
+  lang = 'en',
+  nowIso = '2026-05-18T08:00:00Z',
+): NextActionSourceContext {
+  return {
+    userId: 'u1',
+    tenantId: 't1',
+    lang,
+    nowIso,
+    decisionContext: null,
+    supabase: sb,
+  };
+}
+
+describe('classifyDiaryState — pure', () => {
+  test('no last_day → none:no_data', () => {
+    expect(
+      classifyDiaryState(
+        { current_streak_days: 0, last_day: null, longest_streak_days: 0 },
+        '2026-05-18T08:00:00Z',
+      ),
+    ).toEqual({ kind: 'none', reason: 'no_data' });
+  });
+
+  test('garbage last_day → none:no_data', () => {
+    expect(
+      classifyDiaryState(
+        { current_streak_days: 5, last_day: 'not-a-date', longest_streak_days: 5 },
+        '2026-05-18T08:00:00Z',
+      ),
+    ).toEqual({ kind: 'none', reason: 'no_data' });
+  });
+
+  test('entry already today → none:no_eligible_record', () => {
+    expect(
+      classifyDiaryState(
+        { current_streak_days: 7, last_day: '2026-05-18', longest_streak_days: 7 },
+        '2026-05-18T08:00:00Z',
+      ),
+    ).toEqual({ kind: 'none', reason: 'no_eligible_record' });
+  });
+
+  test('yesterday + streak>=2 → streak_at_risk', () => {
+    expect(
+      classifyDiaryState(
+        { current_streak_days: 5, last_day: '2026-05-17', longest_streak_days: 5 },
+        '2026-05-18T08:00:00Z',
+      ),
+    ).toEqual({ kind: 'streak_at_risk', currentStreak: 5, daysSinceLast: 1 });
+  });
+
+  test('yesterday + streak=1 → none (no momentum to lose)', () => {
+    expect(
+      classifyDiaryState(
+        { current_streak_days: 1, last_day: '2026-05-17', longest_streak_days: 1 },
+        '2026-05-18T08:00:00Z',
+      ),
+    ).toEqual({ kind: 'none', reason: 'no_eligible_record' });
+  });
+
+  test('5 days ago + longest 7 → streak_broken_restart', () => {
+    expect(
+      classifyDiaryState(
+        { current_streak_days: 0, last_day: '2026-05-13', longest_streak_days: 7 },
+        '2026-05-18T08:00:00Z',
+      ),
+    ).toEqual({ kind: 'streak_broken_restart', daysSinceLast: 5, longestStreak: 7 });
+  });
+
+  test('3 days ago + longest 2 → none (no significant history)', () => {
+    expect(
+      classifyDiaryState(
+        { current_streak_days: 0, last_day: '2026-05-15', longest_streak_days: 2 },
+        '2026-05-18T08:00:00Z',
+      ),
+    ).toEqual({ kind: 'none', reason: 'no_eligible_record' });
+  });
+});
+
+describe('renderLine — pure', () => {
+  test('EN streak_at_risk', () => {
+    expect(
+      renderLine({ kind: 'streak_at_risk', currentStreak: 5, daysSinceLast: 1 }, 'en'),
+    ).toMatch(/5 days in a row.*streak stays alive/);
+  });
+  test('DE streak_at_risk', () => {
+    expect(
+      renderLine({ kind: 'streak_at_risk', currentStreak: 5, daysSinceLast: 1 }, 'de'),
+    ).toMatch(/5 Tage in Folge/);
+  });
+  test('EN streak_broken_restart', () => {
+    expect(
+      renderLine({ kind: 'streak_broken_restart', daysSinceLast: 4, longestStreak: 7 }, 'en'),
+    ).toMatch(/4 days ago.*longest streak was 7/);
+  });
+});
+
+describe('produceDiaryMissingRelevant', () => {
+  test('missing view → feature_disabled', async () => {
+    const r = await produceDiaryMissingRelevant(
+      ctxWith(
+        fakeSupabase({
+          row: null,
+          err: { message: 'relation "user_diary_streak" does not exist' },
+        }),
+      ),
+    );
+    expect(r.candidate).toBeNull();
+    expect(r.skippedReason).toBe('feature_disabled');
+  });
+
+  test('supabase error → source_unavailable', async () => {
+    const r = await produceDiaryMissingRelevant(
+      ctxWith(fakeSupabase({ row: null, err: { message: 'rls denied' } })),
+    );
+    expect(r.skippedReason).toBe('source_unavailable');
+  });
+
+  test('throw → errored', async () => {
+    const r = await produceDiaryMissingRelevant(
+      ctxWith(fakeSupabase({ row: null, shouldThrow: true })),
+    );
+    expect(r.skippedReason).toBe('errored');
+  });
+
+  test('no row → no_eligible_record', async () => {
+    const r = await produceDiaryMissingRelevant(ctxWith(fakeSupabase({ row: null })));
+    expect(r.skippedReason).toBe('no_eligible_record');
+  });
+
+  test('streak_at_risk → priority 78, confidence high, dedupe by kind', async () => {
+    const r = await produceDiaryMissingRelevant(
+      ctxWith(
+        fakeSupabase({
+          row: {
+            current_streak_days: 6,
+            last_day: '2026-05-17',
+            longest_streak_days: 6,
+          },
+        }),
+      ),
+    );
+    expect(r.candidate?.priority).toBe(78);
+    expect(r.candidate?.confidence).toBe('high');
+    expect(r.candidate?.dedupeKey).toBe('diary_missing_relevant:streak_at_risk');
+    expect(r.candidate?.userFacingLine).toContain('6 days');
+    expect(r.candidate?.cta?.type).toBe('navigate');
+  });
+
+  test('streak_broken_restart → priority 58, confidence medium', async () => {
+    const r = await produceDiaryMissingRelevant(
+      ctxWith(
+        fakeSupabase({
+          row: {
+            current_streak_days: 0,
+            last_day: '2026-05-14',
+            longest_streak_days: 8,
+          },
+        }),
+      ),
+    );
+    expect(r.candidate?.priority).toBe(58);
+    expect(r.candidate?.confidence).toBe('medium');
+    expect(r.candidate?.dedupeKey).toBe('diary_missing_relevant:streak_broken_restart');
+  });
+});

--- a/services/gateway/test/services/assistant-continuation/providers/next-action/vitana-index-pillar.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/next-action/vitana-index-pillar.test.ts
@@ -1,0 +1,150 @@
+/**
+ * VTID-03059 (B0d-real slice Xd) — vitana-index-pillar source tests.
+ */
+
+import {
+  produceVitanaIndexPillar,
+  extractPillarMomentum,
+  renderLine,
+} from '../../../../../src/services/assistant-continuation/providers/next-action/sources/vitana-index-pillar';
+import type { NextActionSourceContext } from '../../../../../src/services/assistant-continuation/providers/next-action/types';
+import type {
+  DecisionPillarMomentum,
+  PillarKey,
+  PillarMomentumBand,
+  PillarMomentumConfidence,
+} from '../../../../../src/orb/context/types';
+
+function fakeSupabase(): import('@supabase/supabase-js').SupabaseClient {
+  return {
+    from: () => ({}) as never,
+    rpc: async () => ({ data: null, error: null }),
+  } as unknown as import('@supabase/supabase-js').SupabaseClient;
+}
+
+function makePm(over: Partial<DecisionPillarMomentum> = {}): DecisionPillarMomentum {
+  const focus: PillarKey = (over.suggested_focus ?? 'nutrition') as PillarKey;
+  const focusMomentum: PillarMomentumBand =
+    over.per_pillar?.find((p) => p.pillar === focus)?.momentum ?? 'slipping';
+  return {
+    per_pillar: over.per_pillar ?? [
+      { pillar: 'sleep', momentum: 'steady' },
+      { pillar: 'nutrition', momentum: focusMomentum },
+      { pillar: 'exercise', momentum: 'steady' },
+      { pillar: 'hydration', momentum: 'steady' },
+      { pillar: 'mental', momentum: 'steady' },
+    ],
+    weakest_pillar: focus,
+    strongest_pillar: 'sleep',
+    suggested_focus: focus,
+    confidence: (over.confidence ?? 'high') as PillarMomentumConfidence,
+    warnings: [],
+  };
+}
+
+function ctxWith(decisionContext: unknown, lang = 'en'): NextActionSourceContext {
+  return {
+    userId: 'u1',
+    tenantId: 't1',
+    lang,
+    nowIso: '2026-05-18T08:00:00Z',
+    decisionContext,
+    supabase: fakeSupabase(),
+  };
+}
+
+describe('vitana-index-pillar pure helpers', () => {
+  test('extractPillarMomentum is defensive', () => {
+    expect(extractPillarMomentum(null)).toBeNull();
+    expect(extractPillarMomentum({})).toBeNull();
+    expect(extractPillarMomentum({ pillar_momentum: null })).toBeNull();
+    expect(extractPillarMomentum({ pillar_momentum: 'oops' })).toBeNull();
+    const pm = makePm();
+    expect(extractPillarMomentum({ pillar_momentum: pm })).toEqual(pm);
+  });
+
+  test('renderLine — EN+DE per pillar', () => {
+    expect(renderLine('sleep', 'en')).toContain('sleep pillar');
+    expect(renderLine('sleep', 'de')).toContain('Schlaf');
+    expect(renderLine('mental', 'en')).toMatch(/mental.*weighing on you/);
+    expect(renderLine('mental', 'de')).toContain('Mental');
+  });
+});
+
+describe('produceVitanaIndexPillar source', () => {
+  test('no decision context → no_data', async () => {
+    const r = await produceVitanaIndexPillar(ctxWith(null));
+    expect(r.skippedReason).toBe('no_data');
+  });
+
+  test('decision context missing pillar_momentum → no_data', async () => {
+    const r = await produceVitanaIndexPillar(ctxWith({ some_other_field: true }));
+    expect(r.skippedReason).toBe('no_data');
+  });
+
+  test('low confidence → low_confidence', async () => {
+    const r = await produceVitanaIndexPillar(
+      ctxWith({ pillar_momentum: makePm({ confidence: 'low' }) }),
+    );
+    expect(r.skippedReason).toBe('low_confidence');
+  });
+
+  test('suggested_focus null → no_eligible_record', async () => {
+    const pm = makePm();
+    (pm as { suggested_focus: PillarKey | null }).suggested_focus = null;
+    const r = await produceVitanaIndexPillar(ctxWith({ pillar_momentum: pm }));
+    expect(r.skippedReason).toBe('no_eligible_record');
+  });
+
+  test('focus pillar steady/improving → no_eligible_record', async () => {
+    const r = await produceVitanaIndexPillar(
+      ctxWith({
+        pillar_momentum: makePm({
+          per_pillar: [
+            { pillar: 'sleep', momentum: 'steady' },
+            { pillar: 'nutrition', momentum: 'improving' },
+            { pillar: 'exercise', momentum: 'steady' },
+            { pillar: 'hydration', momentum: 'steady' },
+            { pillar: 'mental', momentum: 'steady' },
+          ],
+        }),
+      }),
+    );
+    expect(r.skippedReason).toBe('no_eligible_record');
+  });
+
+  test('slipping focus + high confidence → priority 68, dedupe by pillar', async () => {
+    const r = await produceVitanaIndexPillar(
+      ctxWith({ pillar_momentum: makePm({ confidence: 'high' }) }),
+    );
+    expect(r.candidate?.priority).toBe(68);
+    expect(r.candidate?.confidence).toBe('high');
+    expect(r.candidate?.userFacingLine.toLowerCase()).toContain('nutrition');
+    expect(r.candidate?.dedupeKey).toBe('vitana_index_pillar:nutrition');
+    expect(r.candidate?.cta?.type).toBe('navigate');
+  });
+
+  test('slipping focus + medium confidence → priority 58', async () => {
+    const r = await produceVitanaIndexPillar(
+      ctxWith({ pillar_momentum: makePm({ confidence: 'medium' }) }),
+    );
+    expect(r.candidate?.priority).toBe(58);
+  });
+
+  test('unknown momentum on suggested focus counts as eligible (gap-filling)', async () => {
+    const r = await produceVitanaIndexPillar(
+      ctxWith({
+        pillar_momentum: makePm({
+          per_pillar: [
+            { pillar: 'sleep', momentum: 'steady' },
+            { pillar: 'nutrition', momentum: 'unknown' },
+            { pillar: 'exercise', momentum: 'steady' },
+            { pillar: 'hydration', momentum: 'steady' },
+            { pillar: 'mental', momentum: 'steady' },
+          ],
+        }),
+      }),
+    );
+    expect(r.candidate).not.toBeNull();
+  });
+});


### PR DESCRIPTION
Third wave. Six sources now: reminders + calendar + autopilot + diary + life-compass + pillar.

**diary-missing-relevant**: queries user_diary_streak. Detects streak_at_risk (priority 78) when current ≥ 2 + yesterday gap, or streak_broken_restart (priority 58) when ≥3d ago + previous longest ≥3.

**vitana-index-pillar**: pillar_momentum reader (no re-query). Priority 68/58. Lowest band among real sources — fires only when nothing more concrete does. Subsumes the B0d-mini hardcoded path.

Tests: +26. 85 next-action tests + 713 orb tests green.

Acceptance: #1, #2, #4, #5, #6 ✅. #3 (match) → Xe. #7-8 (Command Hub + OASIS) → Xf.