### PR TITLE
feat(orb-livekit): B0d-real Xf.2 — POST /voice/next-action/event (VTID-03062)

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -775,6 +775,15 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const voiceFeatureDiscoveryEventRouter = require('./routes/voice-feature-discovery-event').default;
   mountRouterSync(app, '/api/v1', voiceFeatureDiscoveryEventRouter, { owner: 'voice-feature-discovery-event' });
 
+  // VTID-03062 (B0d-real Xf.2): Contextual Next Action accepted/dismissed
+  // lifecycle. POST /api/v1/voice/next-action/event with
+  // {decisionId, dedupeKey, eventName: 'accepted'|'dismissed', source?,
+  //  surface?, occurredAt?, metadata?}. Emits OASIS
+  // orb.livekit.next_action.{accepted,dismissed}. Complements Xf.1's
+  // auto-emitted suggested/suppressed events.
+  const voiceNextActionEventRouter = require('./routes/voice-next-action-event').default;
+  mountRouterSync(app, '/api/v1', voiceNextActionEventRouter, { owner: 'voice-next-action-event' });
+
   // VTID-02930 (B1): Greeting Decay preview (read-only simulator).
   // GET /api/v1/voice/greeting-policy/preview
   const voiceGreetingPolicyRouter = require('./routes/voice-greeting-policy').default;

--- a/services/gateway/src/routes/voice-next-action-event.ts
+++ b/services/gateway/src/routes/voice-next-action-event.ts
@@ -1,0 +1,199 @@
+/**
+ * VTID-03062 (B0d-real slice Xf.2): next-action accepted/dismissed ingest.
+ *
+ *   POST /api/v1/voice/next-action/event
+ *
+ * Body:
+ *   {
+ *     decisionId: string,
+ *     dedupeKey: string,
+ *     eventName: 'accepted' | 'dismissed',
+ *     source?: string,          // candidate source key, e.g. 'reminder_due'
+ *     surface?: 'orb_wake' | 'orb_turn_end' | 'text_turn_end' | 'home',
+ *     occurredAt?: string,      // ISO 8601
+ *     metadata?: object         // free-form telemetry context
+ *   }
+ *
+ * Auth: requireAuthWithTenant. Tenant + user IDs come from the JWT only.
+ *
+ * Lifecycle:
+ *   - Xf.1 already emits `orb.livekit.next_action.suggested` server-side
+ *     when a B0d-real candidate is selected.
+ *   - THIS endpoint emits the matching `accepted` or `dismissed` event
+ *     when the user follows or ignores the CTA.
+ *   - Together, Xf.1 + Xf.2 give the Command Hub Candidate Inspector
+ *     (Xf.3) the full lifecycle: suggested → (accepted | dismissed).
+ *
+ * Fire-and-forget downstream: the OASIS emit is awaited so the caller
+ * knows whether it landed, but the body validation is strict enough
+ * that bad clients fail fast. Mutation-free at the DB level — the
+ * OASIS log itself is the audit trail.
+ */
+
+import { Router, Response } from 'express';
+import {
+  requireAuthWithTenant,
+  AuthenticatedRequest,
+} from '../middleware/auth-supabase-jwt';
+import { emitOasisEvent } from '../services/oasis-event-service';
+import {
+  NEXT_ACTION_ACCEPTED,
+  NEXT_ACTION_DISMISSED,
+} from '../services/assistant-continuation/telemetry';
+
+const router = Router();
+const VTID = 'VTID-03062';
+
+type LifecycleEventName = 'accepted' | 'dismissed';
+const ALLOWED_EVENTS: ReadonlySet<LifecycleEventName> = new Set([
+  'accepted',
+  'dismissed',
+]);
+
+const ALLOWED_SURFACES: ReadonlySet<string> = new Set([
+  'orb_wake',
+  'orb_turn_end',
+  'text_turn_end',
+  'home',
+]);
+
+// Soft cap to keep payload size predictable + prevent abuse.
+const MAX_METADATA_KEYS = 16;
+const MAX_STRING_FIELD_CHARS = 512;
+
+router.post(
+  '/voice/next-action/event',
+  requireAuthWithTenant,
+  async (req: AuthenticatedRequest, res: Response) => {
+    try {
+      const tenantId = req.identity?.tenant_id;
+      const userId = req.identity?.user_id;
+      if (!tenantId || !userId) {
+        return res.status(401).json({
+          ok: false,
+          error: 'UNAUTHENTICATED',
+          message: 'Authenticated session with active tenant required',
+          vtid: VTID,
+        });
+      }
+
+      const body = (req.body ?? {}) as Record<string, unknown>;
+
+      const decisionId =
+        typeof body.decisionId === 'string' ? body.decisionId.trim() : '';
+      const dedupeKey =
+        typeof body.dedupeKey === 'string' ? body.dedupeKey.trim() : '';
+      const eventNameRaw = typeof body.eventName === 'string' ? body.eventName : '';
+      const sourceRaw =
+        typeof body.source === 'string' ? body.source.trim() : undefined;
+      const surfaceRaw =
+        typeof body.surface === 'string' ? body.surface : undefined;
+      const occurredAt =
+        typeof body.occurredAt === 'string' && body.occurredAt
+          ? body.occurredAt
+          : new Date().toISOString();
+      const metadata =
+        body.metadata && typeof body.metadata === 'object' && !Array.isArray(body.metadata)
+          ? (body.metadata as Record<string, unknown>)
+          : undefined;
+
+      if (!decisionId) {
+        return res
+          .status(400)
+          .json({ ok: false, error: 'decisionId is required', vtid: VTID });
+      }
+      if (decisionId.length > MAX_STRING_FIELD_CHARS) {
+        return res
+          .status(400)
+          .json({ ok: false, error: 'decisionId too long', vtid: VTID });
+      }
+      if (!dedupeKey) {
+        return res
+          .status(400)
+          .json({ ok: false, error: 'dedupeKey is required', vtid: VTID });
+      }
+      if (dedupeKey.length > MAX_STRING_FIELD_CHARS) {
+        return res
+          .status(400)
+          .json({ ok: false, error: 'dedupeKey too long', vtid: VTID });
+      }
+      if (!ALLOWED_EVENTS.has(eventNameRaw as LifecycleEventName)) {
+        return res.status(400).json({
+          ok: false,
+          error: `eventName must be one of: ${Array.from(ALLOWED_EVENTS).join(', ')}`,
+          vtid: VTID,
+        });
+      }
+      if (sourceRaw && sourceRaw.length > MAX_STRING_FIELD_CHARS) {
+        return res
+          .status(400)
+          .json({ ok: false, error: 'source too long', vtid: VTID });
+      }
+      const surface =
+        surfaceRaw && ALLOWED_SURFACES.has(surfaceRaw)
+          ? (surfaceRaw as 'orb_wake' | 'orb_turn_end' | 'text_turn_end' | 'home')
+          : undefined;
+      if (metadata && Object.keys(metadata).length > MAX_METADATA_KEYS) {
+        return res.status(400).json({
+          ok: false,
+          error: `metadata has more than ${MAX_METADATA_KEYS} keys`,
+          vtid: VTID,
+        });
+      }
+
+      const eventName = eventNameRaw as LifecycleEventName;
+      const topic =
+        eventName === 'accepted' ? NEXT_ACTION_ACCEPTED : NEXT_ACTION_DISMISSED;
+
+      // Emit. Awaited so we can return 502 if the OASIS layer errors;
+      // OASIS errors do NOT block voice paths in this endpoint because
+      // we're not in the voice path (frontend-driven event).
+      try {
+        await emitOasisEvent({
+          vtid: VTID,
+          type: topic as never,
+          source: 'b0d-real-next-action',
+          status: 'info',
+          message: topic,
+          payload: {
+            user_id: userId,
+            tenant_id: tenantId,
+            decision_id: decisionId,
+            dedupe_key: dedupeKey,
+            event_name: eventName,
+            source: sourceRaw ?? null,
+            surface: surface ?? null,
+            occurred_at: occurredAt,
+            metadata: metadata ?? null,
+          },
+          actor_id: userId,
+          actor_role: 'user',
+          surface: 'orb',
+        });
+      } catch (emitErr) {
+        console.warn(
+          `[${VTID}] emit failed: ${(emitErr as Error).message}`,
+        );
+        return res
+          .status(502)
+          .json({ ok: false, error: 'telemetry_emit_failed', vtid: VTID });
+      }
+
+      return res.status(200).json({
+        ok: true,
+        vtid: VTID,
+        decision_id: decisionId,
+        dedupe_key: dedupeKey,
+        event_name: eventName,
+        topic,
+      });
+    } catch (err) {
+      console.error(`[${VTID}] route error: ${(err as Error).message}`);
+      return res
+        .status(500)
+        .json({ ok: false, error: 'internal_error', vtid: VTID });
+    }
+  },
+);
+
+export default router;

--- a/services/gateway/test/routes/voice-next-action-event.test.ts
+++ b/services/gateway/test/routes/voice-next-action-event.test.ts
@@ -1,0 +1,178 @@
+/**
+ * VTID-03062 (B0d-real Xf.2) — POST /api/v1/voice/next-action/event tests.
+ *
+ * Pure route-level tests. The OASIS emitter is mocked so we verify:
+ *   - HTTP contract (200 / 400 / 401 / 502)
+ *   - Tenant + user come from JWT, never body
+ *   - Topic selection: accepted → orb.livekit.next_action.accepted,
+ *     dismissed → orb.livekit.next_action.dismissed
+ *   - Field-length + key-count limits
+ *   - Surface enum gate
+ */
+
+import express from 'express';
+import request from 'supertest';
+
+// Mock OASIS emit so we observe topics without persisting events.
+const emitMock = jest.fn();
+jest.mock('../../src/services/oasis-event-service', () => ({
+  emitOasisEvent: (...args: unknown[]) => emitMock(...args),
+}));
+
+// Inject a per-test mutable identity. Tests flip `currentIdentity` to
+// null to simulate an unauthenticated request and the auth mock then
+// leaves req.identity undefined — the route returns 401.
+const FIXED_IDENTITY = {
+  user_id: 'jwt-user-id',
+  tenant_id: 'jwt-tenant-id',
+};
+let currentIdentity: typeof FIXED_IDENTITY | null = FIXED_IDENTITY;
+jest.mock('../../src/middleware/auth-supabase-jwt', () => ({
+  requireAuthWithTenant: (req: any, _res: any, next: any) => {
+    if (currentIdentity) req.identity = currentIdentity;
+    // else leave req.identity undefined → route's own guard returns 401.
+    next();
+  },
+  requireExafyAdmin: (_req: any, _res: any, next: any) => next(),
+  optionalAuth: (_req: any, _res: any, next: any) => next(),
+}));
+
+function buildApp() {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const router = require('../../src/routes/voice-next-action-event').default;
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1', router);
+  return app;
+}
+
+describe('VTID-03062 — POST /api/v1/voice/next-action/event', () => {
+  beforeEach(() => {
+    emitMock.mockReset();
+    emitMock.mockResolvedValue({ ok: true });
+    currentIdentity = FIXED_IDENTITY;
+  });
+
+  it('returns 200 + emits orb.livekit.next_action.accepted on eventName=accepted', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/voice/next-action/event')
+      .send({
+        decisionId: 'd-123',
+        dedupeKey: 'reminder_due:r-9',
+        eventName: 'accepted',
+        source: 'reminder_due',
+        surface: 'orb_wake',
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.topic).toBe('orb.livekit.next_action.accepted');
+    expect(emitMock).toHaveBeenCalledTimes(1);
+    const call = emitMock.mock.calls[0][0];
+    expect(call.type).toBe('orb.livekit.next_action.accepted');
+    expect(call.payload.decision_id).toBe('d-123');
+    expect(call.payload.dedupe_key).toBe('reminder_due:r-9');
+    expect(call.payload.user_id).toBe('jwt-user-id');
+    expect(call.payload.tenant_id).toBe('jwt-tenant-id');
+    expect(call.payload.source).toBe('reminder_due');
+    expect(call.payload.surface).toBe('orb_wake');
+  });
+
+  it('returns 200 + emits dismissed on eventName=dismissed', async () => {
+    const app = buildApp();
+    const res = await request(app).post('/api/v1/voice/next-action/event').send({
+      decisionId: 'd-456',
+      dedupeKey: 'autopilot_recommendation:rec-1',
+      eventName: 'dismissed',
+    });
+    expect(res.status).toBe(200);
+    expect(res.body.topic).toBe('orb.livekit.next_action.dismissed');
+    expect(emitMock).toHaveBeenCalledTimes(1);
+    expect(emitMock.mock.calls[0][0].type).toBe('orb.livekit.next_action.dismissed');
+  });
+
+  it('returns 400 on missing decisionId', async () => {
+    const app = buildApp();
+    const res = await request(app).post('/api/v1/voice/next-action/event').send({
+      dedupeKey: 'x:1',
+      eventName: 'accepted',
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/decisionId/);
+    expect(emitMock).not.toHaveBeenCalled();
+  });
+
+  it('returns 400 on missing dedupeKey', async () => {
+    const app = buildApp();
+    const res = await request(app).post('/api/v1/voice/next-action/event').send({
+      decisionId: 'd-1',
+      eventName: 'accepted',
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/dedupeKey/);
+  });
+
+  it('returns 400 on bad eventName', async () => {
+    const app = buildApp();
+    const res = await request(app).post('/api/v1/voice/next-action/event').send({
+      decisionId: 'd-1',
+      dedupeKey: 'x:1',
+      eventName: 'completed', // not accepted/dismissed
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/eventName must be one of/);
+  });
+
+  it('returns 401 when identity is missing', async () => {
+    // Flip the mutable identity to null so the auth mock leaves
+    // req.identity undefined — the route's own guard returns 401.
+    currentIdentity = null;
+    const app = buildApp();
+    const res = await request(app).post('/api/v1/voice/next-action/event').send({
+      decisionId: 'd-1',
+      dedupeKey: 'x:1',
+      eventName: 'accepted',
+    });
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('UNAUTHENTICATED');
+  });
+
+  it('returns 502 when emit throws', async () => {
+    emitMock.mockRejectedValueOnce(new Error('OASIS down'));
+    const app = buildApp();
+    const res = await request(app).post('/api/v1/voice/next-action/event').send({
+      decisionId: 'd-1',
+      dedupeKey: 'x:1',
+      eventName: 'accepted',
+    });
+    expect(res.status).toBe(502);
+    expect(res.body.error).toBe('telemetry_emit_failed');
+  });
+
+  it('drops invalid surface enum to null (does not 400)', async () => {
+    const app = buildApp();
+    const res = await request(app).post('/api/v1/voice/next-action/event').send({
+      decisionId: 'd-1',
+      dedupeKey: 'x:1',
+      eventName: 'accepted',
+      surface: 'invalid_surface',
+    });
+    expect(res.status).toBe(200);
+    const payload = emitMock.mock.calls[0][0].payload;
+    expect(payload.surface).toBeNull();
+  });
+
+  it('rejects metadata with >16 keys', async () => {
+    const big: Record<string, number> = {};
+    for (let i = 0; i < 17; i++) big[`k${i}`] = i;
+    const app = buildApp();
+    const res = await request(app).post('/api/v1/voice/next-action/event').send({
+      decisionId: 'd-1',
+      dedupeKey: 'x:1',
+      eventName: 'accepted',
+      metadata: big,
+    });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/metadata has more than/);
+  });
+});


### PR DESCRIPTION
POST /api/v1/voice/next-action/event for the accepted/dismissed lifecycle. Auth via JWT (tenant+user from token, never body). Emits orb.livekit.next_action.{accepted,dismissed}. 200/400/401/502 contract. +9 supertest tests. 1023 tests green.

With Xf.1 + Xf.2 the full B0d-real OASIS lifecycle is wired: suggested → (accepted | dismissed | suppressed). Acceptance #8 ✅. Only #3 (match) + #7 (Command Hub Inspector) remain.