### PR TITLE
feat(orb-livekit): B0d-real Xf.3 — Candidate Inspector endpoint (VTID-03063)

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -784,6 +784,13 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const voiceNextActionEventRouter = require('./routes/voice-next-action-event').default;
   mountRouterSync(app, '/api/v1', voiceNextActionEventRouter, { owner: 'voice-next-action-event' });
 
+  // VTID-03063 (B0d-real Xf.3): Candidate Inspector — read-only operator
+  // surface that groups recent B0d-real OASIS events by decision_id.
+  // GET /api/v1/voice/next-action/inspector?user_id=<uuid>&hours=24.
+  // Auth: requireExafyAdmin (exposes operator-grade decision metadata).
+  const voiceNextActionInspectorRouter = require('./routes/voice-next-action-inspector').default;
+  mountRouterSync(app, '/api/v1', voiceNextActionInspectorRouter, { owner: 'voice-next-action-inspector' });
+
   // VTID-02930 (B1): Greeting Decay preview (read-only simulator).
   // GET /api/v1/voice/greeting-policy/preview
   const voiceGreetingPolicyRouter = require('./routes/voice-greeting-policy').default;

--- a/services/gateway/src/routes/voice-next-action-inspector.ts
+++ b/services/gateway/src/routes/voice-next-action-inspector.ts
@@ -1,0 +1,235 @@
+/**
+ * VTID-03063 (B0d-real slice Xf.3): Candidate Inspector read-only endpoint.
+ *
+ *   GET /api/v1/voice/next-action/inspector?user_id=<uuid>&hours=24
+ *
+ * Returns the recent B0d-real lifecycle events for a single user,
+ * grouped by decision_id. Used by the Command Hub Candidate Inspector
+ * panel to answer "what did Vitana suggest, what did the user do?".
+ *
+ * Auth: requireExafyAdmin. The inspector exposes raw OASIS metadata
+ * (source evidence + reasons + dedupe keys) so it's an operator surface,
+ * not a per-user one.
+ *
+ * Response shape:
+ *   {
+ *     ok: true,
+ *     vtid: 'VTID-03063',
+ *     window_hours: 24,
+ *     user_id: '<uuid>',
+ *     decisions: [
+ *       {
+ *         decision_id: 'd-...',
+ *         suggested_at?: string,       // when the candidate was offered
+ *         suggested?: {                // payload of the suggested event
+ *           dedupe_key, priority, source_evidence, reason_evidence, …
+ *         },
+ *         suppressed_at?: string,
+ *         suppressed?: { provider_status, suppress_reason, … },
+ *         outcome?: 'accepted' | 'dismissed' | null,
+ *         outcome_at?: string,
+ *         outcome_payload?: { source, surface, metadata, … },
+ *       },
+ *     ],
+ *     totals: {
+ *       suggested: number,
+ *       accepted: number,
+ *       dismissed: number,
+ *       suppressed: number,
+ *     },
+ *   }
+ *
+ * Read-only. Never mutates anything. Caps result to 200 decisions.
+ */
+
+import { Router, Response } from 'express';
+import {
+  requireExafyAdmin,
+  AuthenticatedRequest,
+} from '../middleware/auth-supabase-jwt';
+import { getSupabase } from '../lib/supabase';
+import {
+  NEXT_ACTION_SUGGESTED,
+  NEXT_ACTION_ACCEPTED,
+  NEXT_ACTION_DISMISSED,
+  NEXT_ACTION_SUPPRESSED,
+  NEXT_ACTION_CANDIDATE,
+} from '../services/assistant-continuation/telemetry';
+
+const router = Router();
+const VTID = 'VTID-03063';
+
+const TOPICS = [
+  NEXT_ACTION_SUGGESTED,
+  NEXT_ACTION_ACCEPTED,
+  NEXT_ACTION_DISMISSED,
+  NEXT_ACTION_SUPPRESSED,
+  NEXT_ACTION_CANDIDATE,
+] as const;
+
+const MAX_DECISIONS = 200;
+const MAX_HOURS = 24 * 14; // two weeks
+
+router.get(
+  '/voice/next-action/inspector',
+  requireExafyAdmin,
+  async (req: AuthenticatedRequest, res: Response) => {
+    try {
+      const userId = String(req.query.user_id ?? '').trim();
+      const hours = Math.max(
+        1,
+        Math.min(MAX_HOURS, Number(req.query.hours ?? 24) || 24),
+      );
+
+      // VTID-03063: UUID-ish gate to keep the SQL injection surface narrow.
+      // Same pattern the rest of the routes use for query-param IDs.
+      if (!userId || !/^[0-9a-f-]{8,}$/i.test(userId)) {
+        return res
+          .status(400)
+          .json({ ok: false, error: 'user_id is required (uuid)', vtid: VTID });
+      }
+
+      const sb = getSupabase();
+      if (!sb) {
+        return res
+          .status(503)
+          .json({ ok: false, error: 'DB_UNAVAILABLE', vtid: VTID });
+      }
+
+      const sinceIso = new Date(Date.now() - hours * 3_600_000).toISOString();
+      const { data, error } = await sb
+        .from('oasis_events')
+        .select('id, topic, created_at, payload, actor_id')
+        .in('topic', TOPICS as unknown as string[])
+        .eq('actor_id', userId)
+        .gte('created_at', sinceIso)
+        .order('created_at', { ascending: false })
+        .limit(800); // 4 topic types × 200 decisions cap
+
+      if (error) {
+        return res
+          .status(500)
+          .json({ ok: false, error: error.message, vtid: VTID });
+      }
+
+      const rows = (data || []) as OasisRowLike[];
+      const decisions = groupByDecision(rows, MAX_DECISIONS);
+      const totals = countTotals(rows);
+
+      return res.json({
+        ok: true,
+        vtid: VTID,
+        window_hours: hours,
+        user_id: userId,
+        decisions,
+        totals,
+      });
+    } catch (err) {
+      console.error(`[${VTID}] inspector error: ${(err as Error).message}`);
+      return res
+        .status(500)
+        .json({ ok: false, error: 'internal_error', vtid: VTID });
+    }
+  },
+);
+
+export default router;
+
+// ---------------------------------------------------------------------------
+// Pure helpers — exported for tests
+// ---------------------------------------------------------------------------
+
+export interface OasisRowLike {
+  id: string;
+  topic: string;
+  created_at: string;
+  payload: Record<string, unknown> | null;
+  actor_id: string | null;
+}
+
+export interface InspectorDecision {
+  decision_id: string;
+  suggested_at: string | null;
+  suggested: Record<string, unknown> | null;
+  suppressed_at: string | null;
+  suppressed: Record<string, unknown> | null;
+  outcome: 'accepted' | 'dismissed' | null;
+  outcome_at: string | null;
+  outcome_payload: Record<string, unknown> | null;
+}
+
+export interface InspectorTotals {
+  suggested: number;
+  accepted: number;
+  dismissed: number;
+  suppressed: number;
+}
+
+/**
+ * Group OASIS rows by decision_id (from payload). Newest-first by
+ * suggested_at when present, else by suppressed_at. Caps the output.
+ */
+export function groupByDecision(
+  rows: ReadonlyArray<OasisRowLike>,
+  cap: number,
+): InspectorDecision[] {
+  const byId = new Map<string, InspectorDecision>();
+  for (const r of rows) {
+    const did = r.payload && typeof r.payload.decision_id === 'string'
+      ? (r.payload.decision_id as string)
+      : null;
+    if (!did) continue;
+    const existing = byId.get(did) ?? blankDecision(did);
+    if (r.topic === NEXT_ACTION_SUGGESTED) {
+      existing.suggested_at = r.created_at;
+      existing.suggested = r.payload;
+    } else if (r.topic === NEXT_ACTION_SUPPRESSED) {
+      existing.suppressed_at = r.created_at;
+      existing.suppressed = r.payload;
+    } else if (r.topic === NEXT_ACTION_ACCEPTED) {
+      existing.outcome = 'accepted';
+      existing.outcome_at = r.created_at;
+      existing.outcome_payload = r.payload;
+    } else if (r.topic === NEXT_ACTION_DISMISSED) {
+      existing.outcome = 'dismissed';
+      existing.outcome_at = r.created_at;
+      existing.outcome_payload = r.payload;
+    }
+    byId.set(did, existing);
+  }
+  const out = Array.from(byId.values()).sort((a, b) => {
+    const aKey = a.suggested_at ?? a.suppressed_at ?? '';
+    const bKey = b.suggested_at ?? b.suppressed_at ?? '';
+    return bKey.localeCompare(aKey);
+  });
+  return out.slice(0, cap);
+}
+
+export function countTotals(rows: ReadonlyArray<OasisRowLike>): InspectorTotals {
+  const totals: InspectorTotals = {
+    suggested: 0,
+    accepted: 0,
+    dismissed: 0,
+    suppressed: 0,
+  };
+  for (const r of rows) {
+    if (r.topic === NEXT_ACTION_SUGGESTED) totals.suggested += 1;
+    else if (r.topic === NEXT_ACTION_ACCEPTED) totals.accepted += 1;
+    else if (r.topic === NEXT_ACTION_DISMISSED) totals.dismissed += 1;
+    else if (r.topic === NEXT_ACTION_SUPPRESSED) totals.suppressed += 1;
+  }
+  return totals;
+}
+
+function blankDecision(decisionId: string): InspectorDecision {
+  return {
+    decision_id: decisionId,
+    suggested_at: null,
+    suggested: null,
+    suppressed_at: null,
+    suppressed: null,
+    outcome: null,
+    outcome_at: null,
+    outcome_payload: null,
+  };
+}

--- a/services/gateway/test/routes/voice-next-action-inspector.test.ts
+++ b/services/gateway/test/routes/voice-next-action-inspector.test.ts
@@ -1,0 +1,208 @@
+/**
+ * VTID-03063 (B0d-real Xf.3) — Candidate Inspector route tests.
+ *
+ * Covers:
+ *   - Pure helpers (groupByDecision, countTotals)
+ *   - HTTP contract: 400 on missing user_id, 503 on missing DB,
+ *     200 happy-path with grouped decisions + totals
+ *   - admin-only auth (the mock injects admin identity)
+ */
+
+import express from 'express';
+import request from 'supertest';
+import {
+  groupByDecision,
+  countTotals,
+  type OasisRowLike,
+} from '../../src/routes/voice-next-action-inspector';
+
+// Mock auth — admin pass-through.
+jest.mock('../../src/middleware/auth-supabase-jwt', () => ({
+  requireExafyAdmin: (_req: any, _res: any, next: any) => next(),
+  requireAuthWithTenant: (req: any, _res: any, next: any) => {
+    req.identity = { user_id: 'admin', tenant_id: 'admin' };
+    next();
+  },
+  optionalAuth: (_req: any, _res: any, next: any) => next(),
+}));
+
+// Mock the supabase factory so we can inject query results.
+const supabaseMock = jest.fn();
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: () => supabaseMock(),
+}));
+
+function fakeSb(rows: unknown[] | null, err: { message: string } | null = null) {
+  const chain = {
+    in: () => chain,
+    eq: () => chain,
+    gte: () => chain,
+    order: () => chain,
+    limit: () => Promise.resolve(err ? { data: null, error: err } : { data: rows, error: null }),
+  };
+  return {
+    from: () => ({ select: () => chain }),
+  };
+}
+
+function buildApp() {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const router = require('../../src/routes/voice-next-action-inspector').default;
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1', router);
+  return app;
+}
+
+describe('VTID-03063 — pure helpers', () => {
+  test('groupByDecision groups rows by decision_id and merges topics', () => {
+    const rows: OasisRowLike[] = [
+      {
+        id: '1',
+        topic: 'orb.livekit.next_action.suggested',
+        created_at: '2026-05-18T08:00:00Z',
+        payload: { decision_id: 'd-1', dedupe_key: 'k-1', priority: 90 },
+        actor_id: 'u1',
+      },
+      {
+        id: '2',
+        topic: 'orb.livekit.next_action.accepted',
+        created_at: '2026-05-18T08:01:00Z',
+        payload: { decision_id: 'd-1', source: 'reminder_due' },
+        actor_id: 'u1',
+      },
+      {
+        id: '3',
+        topic: 'orb.livekit.next_action.suppressed',
+        created_at: '2026-05-18T08:05:00Z',
+        payload: { decision_id: 'd-2', suppress_reason: 'tied_below_threshold' },
+        actor_id: 'u1',
+      },
+    ];
+    const groups = groupByDecision(rows, 10);
+    expect(groups).toHaveLength(2);
+    const d1 = groups.find((g) => g.decision_id === 'd-1')!;
+    expect(d1.suggested_at).toBe('2026-05-18T08:00:00Z');
+    expect(d1.outcome).toBe('accepted');
+    expect(d1.outcome_at).toBe('2026-05-18T08:01:00Z');
+    const d2 = groups.find((g) => g.decision_id === 'd-2')!;
+    expect(d2.suppressed_at).toBe('2026-05-18T08:05:00Z');
+    expect(d2.suppressed?.suppress_reason).toBe('tied_below_threshold');
+  });
+
+  test('groupByDecision drops rows without decision_id in payload', () => {
+    const groups = groupByDecision(
+      [
+        {
+          id: '1',
+          topic: 'orb.livekit.next_action.suggested',
+          created_at: '2026-05-18T08:00:00Z',
+          payload: { /* no decision_id */ priority: 90 },
+          actor_id: 'u1',
+        },
+      ],
+      10,
+    );
+    expect(groups).toHaveLength(0);
+  });
+
+  test('groupByDecision respects the cap', () => {
+    const rows: OasisRowLike[] = [];
+    for (let i = 0; i < 5; i++) {
+      rows.push({
+        id: String(i),
+        topic: 'orb.livekit.next_action.suggested',
+        created_at: `2026-05-18T08:0${i}:00Z`,
+        payload: { decision_id: `d-${i}` },
+        actor_id: 'u1',
+      });
+    }
+    const groups = groupByDecision(rows, 3);
+    expect(groups).toHaveLength(3);
+  });
+
+  test('countTotals counts every topic', () => {
+    const t = countTotals([
+      { id: '1', topic: 'orb.livekit.next_action.suggested', created_at: '', payload: {}, actor_id: 'u1' },
+      { id: '2', topic: 'orb.livekit.next_action.suggested', created_at: '', payload: {}, actor_id: 'u1' },
+      { id: '3', topic: 'orb.livekit.next_action.accepted', created_at: '', payload: {}, actor_id: 'u1' },
+      { id: '4', topic: 'orb.livekit.next_action.dismissed', created_at: '', payload: {}, actor_id: 'u1' },
+      { id: '5', topic: 'orb.livekit.next_action.suppressed', created_at: '', payload: {}, actor_id: 'u1' },
+    ]);
+    expect(t).toEqual({ suggested: 2, accepted: 1, dismissed: 1, suppressed: 1 });
+  });
+});
+
+describe('VTID-03063 — HTTP contract', () => {
+  beforeEach(() => {
+    supabaseMock.mockReset();
+  });
+
+  it('400 on missing user_id', async () => {
+    const app = buildApp();
+    const res = await request(app).get('/api/v1/voice/next-action/inspector');
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/user_id/);
+  });
+
+  it('400 on invalid user_id', async () => {
+    const app = buildApp();
+    const res = await request(app).get('/api/v1/voice/next-action/inspector?user_id=not-uuid!');
+    expect(res.status).toBe(400);
+  });
+
+  it('503 on missing DB', async () => {
+    supabaseMock.mockReturnValue(null);
+    const app = buildApp();
+    const res = await request(app).get(
+      '/api/v1/voice/next-action/inspector?user_id=c5a4daf9-190a-4a9e-9638-d6b32f85244a',
+    );
+    expect(res.status).toBe(503);
+  });
+
+  it('200 happy path returns grouped decisions + totals', async () => {
+    supabaseMock.mockReturnValue(
+      fakeSb([
+        {
+          id: '1',
+          topic: 'orb.livekit.next_action.suggested',
+          created_at: '2026-05-18T08:00:00Z',
+          payload: { decision_id: 'd-1', priority: 95 },
+          actor_id: 'c5a4daf9-190a-4a9e-9638-d6b32f85244a',
+        },
+        {
+          id: '2',
+          topic: 'orb.livekit.next_action.accepted',
+          created_at: '2026-05-18T08:01:00Z',
+          payload: { decision_id: 'd-1' },
+          actor_id: 'c5a4daf9-190a-4a9e-9638-d6b32f85244a',
+        },
+      ]),
+    );
+    const app = buildApp();
+    const res = await request(app).get(
+      '/api/v1/voice/next-action/inspector?user_id=c5a4daf9-190a-4a9e-9638-d6b32f85244a&hours=12',
+    );
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.window_hours).toBe(12);
+    expect(res.body.decisions).toHaveLength(1);
+    expect(res.body.decisions[0].decision_id).toBe('d-1');
+    expect(res.body.decisions[0].outcome).toBe('accepted');
+    expect(res.body.totals).toEqual({
+      suggested: 1,
+      accepted: 1,
+      dismissed: 0,
+      suppressed: 0,
+    });
+  });
+
+  it('500 when supabase query errors', async () => {
+    supabaseMock.mockReturnValue(fakeSb(null, { message: 'rls denied' }));
+    const app = buildApp();
+    const res = await request(app).get(
+      '/api/v1/voice/next-action/inspector?user_id=c5a4daf9-190a-4a9e-9638-d6b32f85244a',
+    );
+    expect(res.status).toBe(500);
+  });
+});


### PR DESCRIPTION
GET /api/v1/voice/next-action/inspector?user_id=...&hours=24 — admin-only read-only surface that groups recent B0d-real OASIS events by decision_id. Powers the Command Hub Candidate Inspector. +9 hermetic tests.

**B0d-real has reached 7/8 acceptance criteria:**
- [x] #1 Autopilot recommendation can win
- [x] #2 reminder/calendar due soon can win
- [x] #4 Life Compass + weak pillar can win
- [x] #5 diary missing relevant can win
- [x] #6 pillar momentum is ONE candidate
- [x] continuity pending thread/promise can win
- [x] #7 Command Hub data layer ready (frontend panel = follow-up)
- [x] #8 OASIS records suggested/accepted/dismissed/suppressed
- [ ] #3 match/activity plan (deferred — match-journey is a parallel-session deliverable per VTID-03028 memory)

The B0d-real foundation is shipped: 8 sources, composer with stable tie-break, structured AssistantContinuation winners, OASIS lifecycle telemetry end-to-end, admin-readable Inspector endpoint.