### PR TITLE
feat(orb-livekit): B0d-real Xg — turn-end activation (VTID-03064)

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -1276,6 +1276,97 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
         logger.debug("could not hook conversation_item_added: %s", exc)
 
     # ------------------------------------------------------------------
+    # VTID-03064 (B0d-real Xg): turn-end next-action wiring.
+    #
+    # Every time the assistant finishes saying something substantial,
+    # ask the gateway for a structured continuation (the highest-priority
+    # B0d-real candidate for surface=orb_turn_end). If one comes back,
+    # speak it as a brief closing doorway after a small gap.
+    #
+    # Guards (kept tight to avoid feeling spammy):
+    #   1. Only fire on role='assistant' items with text_len > 30 — skip
+    #      tool acks + very short responses that don't end a turn.
+    #   2. Skip when the assistant text ends with '?' — they already
+    #      asked the user something.
+    #   3. Per-session dedupe via a small set; same dedupe_key in the
+    #      last 3 turns suppresses the speak.
+    #   4. Fire-and-forget; gateway/network errors never block voice.
+    # ------------------------------------------------------------------
+    _turn_end_recent_dedupe: list[str] = []
+    _TURN_END_DEDUPE_HISTORY = 3
+    _TURN_END_MIN_TEXT_LEN = 30
+    _TURN_END_GAP_SECONDS = 1.5
+
+    async def _turn_end_fetch_and_speak(assistant_text: str) -> None:
+        try:
+            body = await gw.post(
+                "/api/v1/voice/next-action/turn-end",
+                {"lang": identity.lang or "en"},
+            )
+            if not isinstance(body, dict) or body.get("ok") is not True:
+                return
+            cont = body.get("continuation")
+            if not isinstance(cont, dict):
+                return
+            line = cont.get("user_facing_line")
+            dedupe_key = cont.get("dedupe_key")
+            if not isinstance(line, str) or not line.strip():
+                return
+            if isinstance(dedupe_key, str) and dedupe_key in _turn_end_recent_dedupe:
+                return
+
+            # Pause briefly so the doorway doesn't bleed into the just-
+            # spoken response. session.say() blocks until audio queues;
+            # the sleep keeps the boundary audible.
+            await asyncio.sleep(_TURN_END_GAP_SECONDS)
+            try:
+                await session.say(line.strip(), add_to_chat_ctx=False)
+            except Exception as say_err:  # noqa: BLE001
+                logger.warning(
+                    "VTID-03064: turn-end session.say failed: %s", say_err,
+                )
+                return
+
+            if isinstance(dedupe_key, str):
+                _turn_end_recent_dedupe.append(dedupe_key)
+                if len(_turn_end_recent_dedupe) > _TURN_END_DEDUPE_HISTORY:
+                    del _turn_end_recent_dedupe[0]
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("VTID-03064: turn-end fetch failed: %s", exc)
+
+    def _on_turn_end_candidate(ev: Any = None) -> None:
+        try:
+            item = getattr(ev, "item", None) or ev
+            role = getattr(item, "role", None) or (
+                item.get("role") if isinstance(item, dict) else None
+            )
+            if role != "assistant":
+                return
+            text = (
+                getattr(item, "text_content", None)
+                or getattr(item, "text", None)
+                or (item.get("text_content") if isinstance(item, dict) else None)
+                or (item.get("text") if isinstance(item, dict) else None)
+                or ""
+            )
+            if not isinstance(text, str):
+                return
+            stripped = text.strip()
+            if len(stripped) < _TURN_END_MIN_TEXT_LEN:
+                return
+            if stripped.endswith("?") or stripped.endswith("?"):
+                # Already a question; don't tack on another doorway.
+                return
+            asyncio.create_task(_turn_end_fetch_and_speak(stripped))
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("VTID-03064: turn-end hook setup failed: %s", exc)
+
+    try:
+        session.on("conversation_item_added")(_on_turn_end_candidate)  # type: ignore[misc]
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("could not hook turn-end conversation_item_added: %s", exc)
+
+    # ------------------------------------------------------------------
     # VTID-03050: STT FAILURE OBSERVABILITY (DIAGNOSTIC — no behavior
     # change). Three listeners that surface what was previously invisible:
     #

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -791,6 +791,13 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const voiceNextActionInspectorRouter = require('./routes/voice-next-action-inspector').default;
   mountRouterSync(app, '/api/v1', voiceNextActionInspectorRouter, { owner: 'voice-next-action-inspector' });
 
+  // VTID-03064 (B0d-real Xg): turn-end activation endpoint. The LiveKit
+  // agent calls this after each generate_reply to fetch the next-action
+  // continuation it should speak as a closing doorway.
+  // POST /api/v1/voice/next-action/turn-end.
+  const voiceNextActionTurnEndRouter = require('./routes/voice-next-action-turn-end').default;
+  mountRouterSync(app, '/api/v1', voiceNextActionTurnEndRouter, { owner: 'voice-next-action-turn-end' });
+
   // VTID-02930 (B1): Greeting Decay preview (read-only simulator).
   // GET /api/v1/voice/greeting-policy/preview
   const voiceGreetingPolicyRouter = require('./routes/voice-greeting-policy').default;

--- a/services/gateway/src/routes/voice-next-action-turn-end.ts
+++ b/services/gateway/src/routes/voice-next-action-turn-end.ts
@@ -1,0 +1,168 @@
+/**
+ * VTID-03064 (B0d-real slice Xg): turn-end next-action endpoint.
+ *
+ *   POST /api/v1/voice/next-action/turn-end
+ *
+ * Called by the LiveKit agent (orb-agent/session.py) at the end of each
+ * generated assistant reply. Returns ONE next-best action the agent
+ * should speak as a closing doorway — or an empty result when the
+ * composer suppressed.
+ *
+ * Body:
+ *   {
+ *     decisionContext?: object,   // optional spine signals if cached agent-side
+ *     lang?: string,              // ISO 639-1; defaults to req.identity.lang
+ *     dedupeKeyHistory?: string[] // recent decisions in this session (Xg-future)
+ *   }
+ *
+ * Auth: requireAuthWithTenant. Tenant + user from JWT only.
+ *
+ * Response:
+ *   {
+ *     ok: true,
+ *     vtid: 'VTID-03064',
+ *     surface: 'orb_turn_end',
+ *     decision: { decision_id, selected_kind, suppress_reason, ... },
+ *     continuation: { user_facing_line, kind, dedupe_key, ... } | null
+ *   }
+ *
+ * Best-effort: framework errors degrade to `continuation: null` + a
+ * suppress_reason. The agent NEVER blocks the user's turn on this call.
+ */
+
+import { Router, Response } from 'express';
+import {
+  requireAuthWithTenant,
+  AuthenticatedRequest,
+} from '../middleware/auth-supabase-jwt';
+import { getSupabase } from '../lib/supabase';
+import { decideContinuation } from '../services/assistant-continuation/decide-continuation';
+import {
+  NEXT_ACTION_EXTRA_KEY,
+} from '../services/assistant-continuation/providers/next-action';
+import {
+  makeNextActionProvider,
+  NEXT_ACTION_PROVIDER_KEY,
+} from '../services/assistant-continuation/providers/next-action';
+import { defaultProviderRegistry } from '../services/assistant-continuation/provider-registry';
+// Side-effect import: ensure the 8 default sources are registered with
+// the module-level composer before the endpoint serves its first call.
+import '../services/assistant-continuation/providers/next-action/register-default-sources';
+import { emitNextActionDecisionTelemetry } from '../services/assistant-continuation/providers/next-action/emit-telemetry';
+
+const router = Router();
+const VTID = 'VTID-03064';
+
+// Idempotent provider registration. The wake-brief wiring registers the
+// next-action provider on import too — this is belt-and-braces in case
+// the turn-end route is invoked first.
+let _registered = false;
+function ensureNextActionProviderRegistered(): void {
+  if (_registered) return;
+  if (!defaultProviderRegistry.get(NEXT_ACTION_PROVIDER_KEY)) {
+    defaultProviderRegistry.register(makeNextActionProvider());
+  }
+  _registered = true;
+}
+ensureNextActionProviderRegistered();
+
+router.post(
+  '/voice/next-action/turn-end',
+  requireAuthWithTenant,
+  async (req: AuthenticatedRequest, res: Response) => {
+    try {
+      const tenantId = req.identity?.tenant_id;
+      const userId = req.identity?.user_id;
+      if (!tenantId || !userId) {
+        return res.status(401).json({
+          ok: false,
+          error: 'UNAUTHENTICATED',
+          message: 'Authenticated session with active tenant required',
+          vtid: VTID,
+        });
+      }
+
+      const sb = getSupabase();
+      if (!sb) {
+        return res
+          .status(503)
+          .json({ ok: false, error: 'DB_UNAVAILABLE', vtid: VTID });
+      }
+
+      const body = (req.body ?? {}) as Record<string, unknown>;
+      const lang =
+        typeof body.lang === 'string' && body.lang
+          ? body.lang.toLowerCase().slice(0, 5)
+          : 'en';
+      const decisionContext =
+        body.decisionContext && typeof body.decisionContext === 'object'
+          ? body.decisionContext
+          : null;
+
+      // Run the framework decision on the turn_end surface. We only
+      // populate ctx.extra.nextAction — voice-wake-brief lacks turn-end
+      // inputs and returns `skipped` here. The contextual_next_action
+      // provider serves both surfaces (orb_wake + orb_turn_end).
+      const decision = await decideContinuation({
+        surface: 'orb_turn_end',
+        context: {
+          sessionId: undefined,
+          userId,
+          tenantId,
+          extra: {
+            [NEXT_ACTION_EXTRA_KEY]: {
+              supabase: sb,
+              decisionContext,
+            },
+          },
+        },
+      });
+
+      // Fire-and-forget OASIS emit (suggested / suppressed). Mirrors
+      // the wake-brief auto-emit so the Inspector sees turn-end events.
+      emitNextActionDecisionTelemetry({
+        decision,
+        userId,
+        tenantId,
+        surface: 'orb_turn_end',
+      });
+
+      const chosen = decision.selectedContinuation;
+      const continuation = chosen
+        ? {
+            user_facing_line: chosen.userFacingLine,
+            kind: chosen.kind,
+            dedupe_key: chosen.dedupeKey,
+            priority: chosen.priority,
+            cta: chosen.cta,
+            evidence: chosen.evidence,
+            privacy_mode: chosen.privacyMode,
+          }
+        : null;
+
+      return res.status(200).json({
+        ok: true,
+        vtid: VTID,
+        surface: 'orb_turn_end',
+        decision: {
+          decision_id: decision.decisionId,
+          selected_kind: chosen?.kind ?? 'none_with_reason',
+          suppress_reason: decision.suppressionReason ?? null,
+          decision_started_at: decision.decisionStartedAt,
+          decision_finished_at: decision.decisionFinishedAt,
+        },
+        continuation,
+      });
+    } catch (err) {
+      console.error(`[${VTID}] turn-end route error: ${(err as Error).message}`);
+      return res.status(500).json({
+        ok: false,
+        error: 'internal_error',
+        message: (err as Error).message,
+        vtid: VTID,
+      });
+    }
+  },
+);
+
+export default router;

--- a/services/gateway/test/routes/voice-next-action-turn-end.test.ts
+++ b/services/gateway/test/routes/voice-next-action-turn-end.test.ts
@@ -1,0 +1,117 @@
+/**
+ * VTID-03064 (B0d-real Xg) — POST /voice/next-action/turn-end tests.
+ *
+ * Covers the happy + error paths of the turn-end endpoint. Uses the
+ * real composer wired with stub sources so the composer/decideContinuation
+ * loop is exercised end-to-end.
+ */
+
+import express from 'express';
+import request from 'supertest';
+
+// Mock the OASIS emit so we observe topics without persisting events.
+const emitMock = jest.fn().mockResolvedValue({ ok: true });
+jest.mock('../../src/services/oasis-event-service', () => ({
+  emitOasisEvent: (...args: unknown[]) => emitMock(...args),
+}));
+
+// Inject a fixed JWT identity.
+const FIXED_IDENTITY = {
+  user_id: 'jwt-user-id',
+  tenant_id: 'jwt-tenant-id',
+};
+let currentIdentity: typeof FIXED_IDENTITY | null = FIXED_IDENTITY;
+jest.mock('../../src/middleware/auth-supabase-jwt', () => ({
+  requireAuthWithTenant: (req: any, _res: any, next: any) => {
+    if (currentIdentity) req.identity = currentIdentity;
+    next();
+  },
+  requireExafyAdmin: (_req: any, _res: any, next: any) => next(),
+  optionalAuth: (_req: any, _res: any, next: any) => next(),
+}));
+
+// Supabase fake — every source query returns no rows. The composer
+// then has nothing to fire and we expect a suppressed result. That's
+// fine for the route-level test; per-source happy paths are covered
+// in the dedicated source test files.
+function fakeSupabase(): any {
+  const chain: any = {};
+  chain.eq = () => chain;
+  chain.in = () => chain;
+  chain.neq = () => chain;
+  chain.gte = () => chain;
+  chain.lte = () => chain;
+  chain.order = () => chain;
+  chain.limit = () => Promise.resolve({ data: [], error: null });
+  chain.maybeSingle = () => Promise.resolve({ data: null, error: null });
+  return {
+    from: () => ({ select: () => chain }),
+    rpc: async () => ({ data: null, error: null }),
+  };
+}
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: () => fakeSupabase(),
+}));
+
+function buildApp() {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const router = require('../../src/routes/voice-next-action-turn-end').default;
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1', router);
+  return app;
+}
+
+describe('VTID-03064 — POST /api/v1/voice/next-action/turn-end', () => {
+  beforeEach(() => {
+    emitMock.mockClear();
+    currentIdentity = FIXED_IDENTITY;
+  });
+
+  it('returns 200 + continuation:null when no source qualifies (all empty)', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/voice/next-action/turn-end')
+      .send({ lang: 'en' });
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.surface).toBe('orb_turn_end');
+    expect(res.body.continuation).toBeNull();
+    expect(res.body.decision.selected_kind).toBe('none_with_reason');
+    // Composer suppressed because all sources returned empty.
+    expect(res.body.decision.suppress_reason).toBeTruthy();
+  });
+
+  it('returns 401 when identity is missing', async () => {
+    currentIdentity = null;
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/voice/next-action/turn-end')
+      .send({ lang: 'en' });
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('UNAUTHENTICATED');
+  });
+
+  it('accepts no body and defaults lang to en', async () => {
+    const app = buildApp();
+    const res = await request(app)
+      .post('/api/v1/voice/next-action/turn-end')
+      .send({});
+    expect(res.status).toBe(200);
+  });
+
+  it('emits OASIS suppressed when the composer suppresses', async () => {
+    const app = buildApp();
+    await request(app)
+      .post('/api/v1/voice/next-action/turn-end')
+      .send({ lang: 'en' });
+    // Best-effort + microtask-flushed.
+    return Promise.resolve().then(() => {
+      const topics = emitMock.mock.calls.map((c) => (c[0] as { type?: string })?.type);
+      // At least one of next_action.* fires; suppressed when no source.
+      expect(
+        topics.some((t) => typeof t === 'string' && t.startsWith('orb.livekit.next_action.')),
+      ).toBe(true);
+    });
+  });
+});


### PR DESCRIPTION
Closes the second surface from the original B0d-real scope: every assistant turn now ends with at most ONE structured continuation from the same 8-source composer.

**Gateway**: POST /api/v1/voice/next-action/turn-end. Auth via JWT. Returns continuation + decision; null when no source qualifies.

**Agent**: new conversation_item_added hook on role=assistant items with text_len>30, not already a question. Calls gateway, waits 1.5s, session.say(line). Per-session dedupe via recent-3 keyed on dedupe_key. Fire-and-forget — gateway failures never block voice.

+4 endpoint tests. Both surfaces (orb_wake + orb_turn_end) now share the same 8-source composer.

**Reminder**: this triggers DEPLOY-ORB-AGENT path-triggered auto-deploy in addition to the gateway EXEC-DEPLOY because session.py changed.