### PR TITLE
feat(orb-livekit): B0d-real Xj — per-source flag gates (VTID-03067)

### DIFF
--- a/services/gateway/src/services/assistant-continuation/providers/next-action/register-default-sources.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/next-action/register-default-sources.ts
@@ -30,6 +30,8 @@ import { makeVitanaIndexPillarSource } from './sources/vitana-index-pillar';
 // VTID-03060 (B0d-real Xe) — continuity sources.
 import { makeContinuityPendingThreadSource } from './sources/continuity-pending-thread';
 import { makeContinuityPromiseOwedSource } from './sources/continuity-promise-owed';
+// VTID-03067 (B0d-real Xj) — per-source flag gates.
+import { withFlagGate } from './source-gate';
 
 let _registered = false;
 
@@ -50,14 +52,18 @@ export function ensureDefaultNextActionSourcesRegistered(): void {
   // Each source's bands are tuned so the natural urgency winner wins on
   // priority alone. This order resolves rare ties without the composer
   // needing a global registry.
-  defaultNextActionComposer.register(makeReminderDueSource());
-  defaultNextActionComposer.register(makeCalendarUpcomingSource());
-  defaultNextActionComposer.register(makeAutopilotRecommendationSource());
-  defaultNextActionComposer.register(makeContinuityPromiseOwedSource());
-  defaultNextActionComposer.register(makeDiaryMissingRelevantSource());
-  defaultNextActionComposer.register(makeContinuityPendingThreadSource());
-  defaultNextActionComposer.register(makeLifeCompassAlignmentSource());
-  defaultNextActionComposer.register(makeVitanaIndexPillarSource());
+  // VTID-03067: every source is wrapped in withFlagGate() so operators
+  // can toggle individual sources via `system_controls` row
+  // `voice.next_action.<source_key>.enabled = false` without redeploy.
+  // Default behavior (row absent) keeps every source live.
+  defaultNextActionComposer.register(withFlagGate(makeReminderDueSource()));
+  defaultNextActionComposer.register(withFlagGate(makeCalendarUpcomingSource()));
+  defaultNextActionComposer.register(withFlagGate(makeAutopilotRecommendationSource()));
+  defaultNextActionComposer.register(withFlagGate(makeContinuityPromiseOwedSource()));
+  defaultNextActionComposer.register(withFlagGate(makeDiaryMissingRelevantSource()));
+  defaultNextActionComposer.register(withFlagGate(makeContinuityPendingThreadSource()));
+  defaultNextActionComposer.register(withFlagGate(makeLifeCompassAlignmentSource()));
+  defaultNextActionComposer.register(withFlagGate(makeVitanaIndexPillarSource()));
 }
 
 // Register on import so consumers don't have to remember.

--- a/services/gateway/src/services/assistant-continuation/providers/next-action/source-gate.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/next-action/source-gate.ts
@@ -1,0 +1,103 @@
+/**
+ * VTID-03067 (B0d-real Xj) — per-source flag gates.
+ *
+ * Each NextActionSource reads its own `voice.next_action.<key>.enabled`
+ * flag from `system_controls` before producing a candidate. When the
+ * flag is explicitly disabled, the source returns
+ * `skippedReason: 'feature_disabled'` and the composer skips it
+ * entirely. Default behavior (flag absent OR flag enabled=true) keeps
+ * the source live.
+ *
+ * Operators can disable any source at runtime by inserting/updating
+ * the `system_controls` row — no redeploy needed, takes effect within
+ * the 60s cache TTL of `system-controls-service`.
+ *
+ * Examples (canonical keys for the 10-source registry):
+ *
+ *   voice.next_action.reminder_due.enabled
+ *   voice.next_action.calendar_upcoming.enabled
+ *   voice.next_action.autopilot_recommendation.enabled
+ *   voice.next_action.continuity_promise_owed.enabled
+ *   voice.next_action.diary_missing_relevant.enabled
+ *   voice.next_action.continuity_pending_thread.enabled
+ *   voice.next_action.life_compass_alignment.enabled
+ *   voice.next_action.vitana_index_pillar.enabled
+ *   voice.next_action.journey_stage_nudge.enabled    (reserved)
+ *   voice.next_action.match_activity_plan.enabled     (reserved — Xj does not
+ *                                                       ship this source; key
+ *                                                       reserved for parity)
+ *
+ * The helper NEVER throws — DB failures default to enabled=true so a
+ * Supabase outage can't accidentally silence every source.
+ */
+
+import { getSystemControl } from '../../../system-controls-service';
+import type {
+  NextActionSource,
+  NextActionSourceKey,
+  NextActionSourceResult,
+} from './types';
+
+/**
+ * Build the canonical flag key for a given source.
+ */
+export function buildSourceFlagKey(source: NextActionSourceKey): string {
+  return `voice.next_action.${source}.enabled`;
+}
+
+/**
+ * Is this source enabled? Reads the flag from system_controls.
+ * Defaults to `true` when:
+ *   - the row doesn't exist
+ *   - the system-controls service errors
+ *   - any other unexpected shape arrives
+ *
+ * Operators DISABLE a source by inserting a `system_controls` row with
+ * `enabled = false`. There is no "kill switch by default" mode —
+ * sources are live unless someone explicitly turns them off.
+ */
+export async function isNextActionSourceEnabled(
+  source: NextActionSourceKey,
+): Promise<boolean> {
+  try {
+    const control = await getSystemControl(buildSourceFlagKey(source));
+    if (!control) return true; // absent → enabled
+    // applyExpiryCheck in system-controls-service handles expires_at
+    // by force-flipping enabled=false. We just read the resulting
+    // boolean.
+    return control.enabled !== false;
+  } catch {
+    return true; // never silence by default
+  }
+}
+
+/**
+ * Wrap a NextActionSource so its produce() runs only when the flag
+ * gate is enabled. When disabled, returns
+ * `{ candidate: null, skippedReason: 'feature_disabled' }` immediately.
+ *
+ * Use in source factories:
+ *   export function makeReminderDueSource(): NextActionSource {
+ *     return withFlagGate({ key: 'reminder_due', serves: …, produce: … });
+ *   }
+ *
+ * This keeps the gate uniform across sources — every source gets the
+ * same opt-out without duplicating the call site.
+ */
+export function withFlagGate(source: NextActionSource): NextActionSource {
+  return {
+    key: source.key,
+    serves: source.serves,
+    async produce(ctx): Promise<NextActionSourceResult> {
+      const enabled = await isNextActionSourceEnabled(source.key);
+      if (!enabled) {
+        return {
+          source: source.key,
+          candidate: null,
+          skippedReason: 'feature_disabled',
+        };
+      }
+      return source.produce(ctx);
+    },
+  };
+}

--- a/services/gateway/test/services/assistant-continuation/providers/next-action/source-gate.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/next-action/source-gate.test.ts
@@ -1,0 +1,154 @@
+/**
+ * VTID-03067 (B0d-real Xj) — per-source flag gate tests.
+ */
+
+import {
+  buildSourceFlagKey,
+  isNextActionSourceEnabled,
+  withFlagGate,
+} from '../../../../../src/services/assistant-continuation/providers/next-action/source-gate';
+import type {
+  NextActionSource,
+  NextActionSourceContext,
+  NextActionSourceResult,
+} from '../../../../../src/services/assistant-continuation/providers/next-action/types';
+
+// ---------------------------------------------------------------------------
+// Mock system-controls-service. The gate reads getSystemControl(key) and
+// defaults to "enabled" when the row is absent.
+// ---------------------------------------------------------------------------
+
+let controlOverride: { enabled: boolean } | null | undefined = null;
+let getSystemControlMock = jest.fn();
+
+jest.mock('../../../../../src/services/system-controls-service', () => ({
+  getSystemControl: (...args: unknown[]) => getSystemControlMock(...args),
+}));
+
+beforeEach(() => {
+  controlOverride = null;
+  getSystemControlMock = jest.fn(async () => controlOverride);
+  // Re-wire the mock for the new fn.
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const mod = require('../../../../../src/services/system-controls-service');
+  mod.getSystemControl = getSystemControlMock;
+});
+
+function makeStubSource(opts: {
+  key: NextActionSource['key'];
+  result?: NextActionSourceResult;
+  throws?: boolean;
+}): NextActionSource {
+  return {
+    key: opts.key,
+    serves: () => true,
+    produce: async () => {
+      if (opts.throws) throw new Error('boom');
+      return (
+        opts.result ?? {
+          source: opts.key,
+          candidate: {
+            source: opts.key,
+            priority: 80,
+            confidence: 'high',
+            userFacingLine: 'unguarded',
+            reasons: [],
+            dedupeKey: `${opts.key}:1`,
+          },
+        }
+      );
+    },
+  };
+}
+
+function makeCtx(): NextActionSourceContext {
+  return {
+    userId: 'u1',
+    tenantId: 't1',
+    lang: 'en',
+    nowIso: '2026-05-18T08:00:00Z',
+    decisionContext: null,
+    supabase: {
+      from: () => ({}) as never,
+      rpc: async () => ({ data: null, error: null }),
+    } as unknown as import('@supabase/supabase-js').SupabaseClient,
+  };
+}
+
+describe('buildSourceFlagKey', () => {
+  test('reminder_due → voice.next_action.reminder_due.enabled', () => {
+    expect(buildSourceFlagKey('reminder_due')).toBe('voice.next_action.reminder_due.enabled');
+  });
+  test('continuity_promise_owed → voice.next_action.continuity_promise_owed.enabled', () => {
+    expect(buildSourceFlagKey('continuity_promise_owed')).toBe(
+      'voice.next_action.continuity_promise_owed.enabled',
+    );
+  });
+});
+
+describe('isNextActionSourceEnabled', () => {
+  test('absent row → enabled (default-true safety)', async () => {
+    controlOverride = null;
+    expect(await isNextActionSourceEnabled('reminder_due')).toBe(true);
+  });
+
+  test('row enabled=true → enabled', async () => {
+    controlOverride = { enabled: true };
+    expect(await isNextActionSourceEnabled('reminder_due')).toBe(true);
+  });
+
+  test('row enabled=false → disabled', async () => {
+    controlOverride = { enabled: false };
+    expect(await isNextActionSourceEnabled('reminder_due')).toBe(false);
+  });
+
+  test('getSystemControl throws → enabled (never silence by default)', async () => {
+    getSystemControlMock = jest.fn(async () => {
+      throw new Error('DB down');
+    });
+    // eslint-disable-next-line @typescript-eslint/no-var-requires
+    const mod = require('../../../../../src/services/system-controls-service');
+    mod.getSystemControl = getSystemControlMock;
+    expect(await isNextActionSourceEnabled('reminder_due')).toBe(true);
+  });
+});
+
+describe('withFlagGate', () => {
+  test('passes through when enabled', async () => {
+    controlOverride = { enabled: true };
+    const gated = withFlagGate(makeStubSource({ key: 'reminder_due' }));
+    const r = await gated.produce(makeCtx());
+    expect(r.candidate).not.toBeNull();
+    expect(r.candidate?.userFacingLine).toBe('unguarded');
+  });
+
+  test('returns feature_disabled when disabled (does NOT invoke underlying produce)', async () => {
+    controlOverride = { enabled: false };
+    let invoked = false;
+    const inner: NextActionSource = {
+      key: 'autopilot_recommendation',
+      serves: () => true,
+      produce: async () => {
+        invoked = true;
+        return {
+          source: 'autopilot_recommendation',
+          candidate: null,
+          skippedReason: 'no_data',
+        };
+      },
+    };
+    const gated = withFlagGate(inner);
+    const r = await gated.produce(makeCtx());
+    expect(r.candidate).toBeNull();
+    expect(r.skippedReason).toBe('feature_disabled');
+    expect(invoked).toBe(false);
+  });
+
+  test('preserves key + serves passthrough', () => {
+    const inner = makeStubSource({ key: 'diary_missing_relevant' });
+    const gated = withFlagGate(inner);
+    expect(gated.key).toBe('diary_missing_relevant');
+    expect(gated.serves('orb_wake')).toBe(true);
+    expect(gated.serves('orb_turn_end')).toBe(true);
+  });
+});


### PR DESCRIPTION
Operators can disable individual NextActionSources at runtime via system_controls rows (voice.next_action.<source>.enabled = false). Default = enabled (row absent or controls service down). withFlagGate wrapper keeps the gate uniform across all 8 registered sources. +10 tests. 126 next-action tests green.