### PR TITLE
feat(orb-livekit): B0d-real Xk — cross-session dedupe (VTID-03068)

### DIFF
--- a/services/gateway/src/services/assistant-continuation/providers/next-action/composer.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/next-action/composer.ts
@@ -26,6 +26,12 @@ import type {
   NextActionSourceResult,
   ScoredCandidate,
 } from './types';
+// VTID-03068 (B0d-real Xk) — cross-session dedupe via user_assistant_state.
+import {
+  isSeenRecently,
+  recordDedupeSighting,
+  DEFAULT_DEDUPE_WINDOW_MS,
+} from './dedupe-store';
 
 class CompositeNextActionComposer implements NextActionComposer {
   /**
@@ -69,18 +75,84 @@ class CompositeNextActionComposer implements NextActionComposer {
     }
 
     const t0 = Date.now();
-    const results = await Promise.all(
+    const rawResults = await Promise.all(
       eligible.map((source) => invokeSourceSafely(source, ctx, t0)),
     );
+
+    // VTID-03068: cross-session dedupe gate. For every candidate that
+    // came back, check whether its dedupe_key was already shown to this
+    // user within the last 4 hours. If yes, downgrade the result to
+    // skippedReason='dedup_window' BEFORE ranking, so a fresh sibling
+    // candidate (different source, different dedupe_key) can still win.
+    //
+    // The check runs in parallel with itself; each check NEVER throws —
+    // failures default to "not seen" so a DB outage cannot silence the
+    // orb. Best-effort: composer continues even if every check errors.
+    const results = await applyDedupeGate(rawResults, ctx);
     const composeFinishedAt = new Date().toISOString();
 
+    const ranked = rank(results);
+
+    // VTID-03068: record the winner's dedupe_key sighting (fire-and-
+    // forget). When the orb actually speaks the line, recording here
+    // captures it as "shown" — subsequent wakes within the window will
+    // see it via isSeenRecently and skip.
+    if (ranked.chosen && ranked.chosen.dedupeKey) {
+      void recordDedupeSighting({
+        supabase: ctx.supabase,
+        tenantId: ctx.tenantId,
+        userId: ctx.userId,
+        dedupeKey: ranked.chosen.dedupeKey,
+        source: ranked.chosen.source,
+        surface,
+      });
+    }
+
     return {
-      ...rank(results),
+      ...ranked,
       candidates: results,
       composeStartedAt,
       composeFinishedAt,
     };
   }
+}
+
+/**
+ * For each result that has a candidate, check the dedupe store. When the
+ * dedupe_key was seen within the default window, downgrade the row to
+ * skippedReason='dedup_window'. Never throws upward — fail-open by
+ * design (DB outage MUST NOT silence the orb).
+ */
+async function applyDedupeGate(
+  rawResults: ReadonlyArray<NextActionSourceResult>,
+  ctx: NextActionSourceContext,
+): Promise<NextActionSourceResult[]> {
+  const checks = rawResults.map(async (row) => {
+    if (!row.candidate) return row;
+    try {
+      const seen = await isSeenRecently({
+        supabase: ctx.supabase,
+        tenantId: ctx.tenantId,
+        userId: ctx.userId,
+        dedupeKey: row.candidate.dedupeKey,
+        nowIso: ctx.nowIso,
+        windowMs: DEFAULT_DEDUPE_WINDOW_MS,
+      });
+      if (seen) {
+        return {
+          source: row.source,
+          candidate: null,
+          skippedReason: 'dedup_window' as const,
+          latencyMs: row.latencyMs,
+        };
+      }
+      return row;
+    } catch {
+      // Fail-open — never let the dedupe gate silence the orb.
+      return row;
+    }
+  });
+  return Promise.all(checks);
 }
 
 async function invokeSourceSafely(

--- a/services/gateway/src/services/assistant-continuation/providers/next-action/dedupe-store.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/next-action/dedupe-store.ts
@@ -1,0 +1,114 @@
+/**
+ * VTID-03068 (B0d-real Xk) — Cross-session dedupe via user_assistant_state.
+ *
+ * The agent-side in-process dedupe (session.py recent-3 set, VTID-03064)
+ * only protects against re-firing within a single LiveKit session. The
+ * REAL nag is "every time I tap ORB I hear the same reminder again
+ * because the reminder is still pending." That's a cross-session
+ * problem — the dedupe state has to live in the DB.
+ *
+ * Strategy: one `user_assistant_state` row per dedupe-key sighting.
+ *   signal_name: `next_action_dedupe:<dedupe_key>`
+ *   value:       { source, surface, shown_at }
+ *   last_seen_at: NOW() on each sighting
+ *
+ * A candidate is `seen recently` when a matching row exists with
+ * last_seen_at >= NOW() - <window>. The default window is 4 hours —
+ * long enough to span a "morning + evening orb tap" pattern, short
+ * enough to let the candidate fire again the next day.
+ *
+ * Failure mode: a DB outage MUST NOT silence the orb. Read failures
+ * default to "not seen recently" (fail-open). Write failures are
+ * fire-and-forget. The user-visible behavior degrades to per-session
+ * dedupe only — never to silence.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+
+/** Default look-back window. Keep at 4h so a morning + evening orb
+ *  tap doesn't get the same nudge twice, but the next day is fresh. */
+export const DEFAULT_DEDUPE_WINDOW_MS = 4 * 60 * 60 * 1000;
+
+/** Signal-name prefix for the dedupe rows. */
+export const DEDUPE_SIGNAL_PREFIX = 'next_action_dedupe:';
+
+export function buildDedupeSignalName(dedupeKey: string): string {
+  return DEDUPE_SIGNAL_PREFIX + dedupeKey;
+}
+
+export interface DedupeStoreInputs {
+  supabase: SupabaseClient;
+  tenantId: string;
+  userId: string;
+}
+
+export interface RecordDedupeInputs extends DedupeStoreInputs {
+  dedupeKey: string;
+  source: string;
+  surface: 'orb_wake' | 'orb_turn_end';
+}
+
+export interface IsSeenRecentlyInputs extends DedupeStoreInputs {
+  dedupeKey: string;
+  windowMs?: number;
+  nowIso?: string;
+}
+
+/**
+ * Check whether this dedupe_key was already shown to this user within
+ * the look-back window. Returns false on any failure (fail-open —
+ * never silence the orb).
+ */
+export async function isSeenRecently(inputs: IsSeenRecentlyInputs): Promise<boolean> {
+  const windowMs = inputs.windowMs ?? DEFAULT_DEDUPE_WINDOW_MS;
+  const nowIso = inputs.nowIso ?? new Date().toISOString();
+  const cutoffIso = new Date(Date.parse(nowIso) - windowMs).toISOString();
+  try {
+    const { data, error } = await inputs.supabase
+      .from('user_assistant_state')
+      .select('last_seen_at')
+      .eq('tenant_id', inputs.tenantId)
+      .eq('user_id', inputs.userId)
+      .eq('signal_name', buildDedupeSignalName(inputs.dedupeKey))
+      .gte('last_seen_at', cutoffIso)
+      .limit(1);
+    if (error) return false;
+    return Array.isArray(data) && data.length > 0;
+  } catch {
+    return false;
+  }
+}
+
+/**
+ * Record a dedupe-key sighting. Upserts the row (same key → bump
+ * last_seen_at + increment count). Fire-and-forget — caller does not
+ * await for the voice path.
+ */
+export async function recordDedupeSighting(
+  inputs: RecordDedupeInputs,
+): Promise<{ ok: boolean; reason?: string }> {
+  try {
+    const nowIso = new Date().toISOString();
+    const row = {
+      tenant_id: inputs.tenantId,
+      user_id: inputs.userId,
+      signal_name: buildDedupeSignalName(inputs.dedupeKey),
+      value: {
+        source: inputs.source,
+        surface: inputs.surface,
+        shown_at: nowIso,
+      },
+      // count + last_seen_at are managed via the update trigger when
+      // present, but supabase's upsert needs us to set them explicitly
+      // so the row reflects "seen N times, most recently at <iso>".
+      last_seen_at: nowIso,
+    };
+    const { error } = await inputs.supabase
+      .from('user_assistant_state')
+      .upsert(row, { onConflict: 'tenant_id,user_id,signal_name' });
+    if (error) return { ok: false, reason: error.message };
+    return { ok: true };
+  } catch (e) {
+    return { ok: false, reason: e instanceof Error ? e.message : String(e) };
+  }
+}

--- a/services/gateway/test/services/assistant-continuation/providers/next-action/dedupe-store.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/next-action/dedupe-store.test.ts
@@ -1,0 +1,181 @@
+/**
+ * VTID-03068 (B0d-real Xk) — Cross-session dedupe store tests.
+ *
+ * Covers:
+ *   - buildDedupeSignalName format
+ *   - isSeenRecently: hit, miss, error fail-open, default window
+ *   - recordDedupeSighting: upsert payload shape, error path
+ */
+
+import {
+  buildDedupeSignalName,
+  isSeenRecently,
+  recordDedupeSighting,
+  DEFAULT_DEDUPE_WINDOW_MS,
+  DEDUPE_SIGNAL_PREFIX,
+} from '../../../../../src/services/assistant-continuation/providers/next-action/dedupe-store';
+
+function fakeSb(opts: {
+  selectRows?: unknown[] | null;
+  selectError?: { message: string } | null;
+  selectThrows?: boolean;
+  upsertError?: { message: string } | null;
+  upsertThrows?: boolean;
+  captureUpsert?: (row: unknown) => void;
+}): { sb: import('@supabase/supabase-js').SupabaseClient; selectFilters: Record<string, unknown>[] } {
+  const selectFilters: Record<string, unknown>[] = [];
+  // The store calls:
+  //   sb.from('user_assistant_state').select('last_seen_at').eq().eq().eq().gte().limit()
+  // and
+  //   sb.from('user_assistant_state').upsert(row, { onConflict })
+  // Two different paths off `from`.
+  const fakeChain: any = {
+    eq: function (col: string, val: unknown) {
+      selectFilters.push({ [col]: val });
+      return fakeChain;
+    },
+    gte: function (col: string, val: unknown) {
+      selectFilters.push({ [col + '_gte']: val });
+      return fakeChain;
+    },
+    limit: function () {
+      if (opts.selectThrows) return Promise.reject(new Error('boom'));
+      return Promise.resolve(
+        opts.selectError
+          ? { data: null, error: opts.selectError }
+          : { data: opts.selectRows ?? null, error: null },
+      );
+    },
+  };
+  const from = () => ({
+    select: () => fakeChain,
+    upsert: function (row: unknown, _opts: unknown) {
+      if (opts.captureUpsert) opts.captureUpsert(row);
+      if (opts.upsertThrows) return Promise.reject(new Error('boom'));
+      return Promise.resolve(
+        opts.upsertError ? { error: opts.upsertError } : { error: null },
+      );
+    },
+  });
+  return {
+    sb: { from } as unknown as import('@supabase/supabase-js').SupabaseClient,
+    selectFilters,
+  };
+}
+
+const baseInputs = {
+  tenantId: 't1',
+  userId: 'u1',
+  dedupeKey: 'reminder_due:r-1',
+};
+
+describe('VTID-03068 — buildDedupeSignalName', () => {
+  test('prepends prefix', () => {
+    expect(buildDedupeSignalName('reminder_due:r-1')).toBe(
+      DEDUPE_SIGNAL_PREFIX + 'reminder_due:r-1',
+    );
+  });
+});
+
+describe('VTID-03068 — isSeenRecently', () => {
+  test('returns true when supabase returns a row within window', async () => {
+    const { sb } = fakeSb({
+      selectRows: [{ last_seen_at: '2026-05-18T07:00:00Z' }],
+    });
+    expect(
+      await isSeenRecently({ ...baseInputs, supabase: sb, nowIso: '2026-05-18T08:00:00Z' }),
+    ).toBe(true);
+  });
+
+  test('returns false when supabase returns empty', async () => {
+    const { sb } = fakeSb({ selectRows: [] });
+    expect(await isSeenRecently({ ...baseInputs, supabase: sb })).toBe(false);
+  });
+
+  test('returns false on supabase error (fail-open)', async () => {
+    const { sb } = fakeSb({ selectError: { message: 'rls denied' } });
+    expect(await isSeenRecently({ ...baseInputs, supabase: sb })).toBe(false);
+  });
+
+  test('returns false on exception (fail-open)', async () => {
+    const { sb } = fakeSb({ selectThrows: true });
+    expect(await isSeenRecently({ ...baseInputs, supabase: sb })).toBe(false);
+  });
+
+  test('passes the right filters to supabase', async () => {
+    const { sb, selectFilters } = fakeSb({ selectRows: [] });
+    await isSeenRecently({
+      ...baseInputs,
+      supabase: sb,
+      nowIso: '2026-05-18T08:00:00Z',
+    });
+    // Expect 3 .eq filters (tenant + user + signal_name) and 1 .gte
+    // (last_seen_at >= cutoff).
+    expect(selectFilters.some((f) => f.tenant_id === 't1')).toBe(true);
+    expect(selectFilters.some((f) => f.user_id === 'u1')).toBe(true);
+    expect(
+      selectFilters.some((f) => f.signal_name === buildDedupeSignalName(baseInputs.dedupeKey)),
+    ).toBe(true);
+    expect(selectFilters.some((f) => f.last_seen_at_gte != null)).toBe(true);
+  });
+
+  test('uses DEFAULT_DEDUPE_WINDOW_MS when windowMs is not supplied', async () => {
+    const { sb, selectFilters } = fakeSb({ selectRows: [] });
+    const nowIso = '2026-05-18T08:00:00Z';
+    await isSeenRecently({ ...baseInputs, supabase: sb, nowIso });
+    const gteFilter = selectFilters.find((f) => f.last_seen_at_gte != null);
+    expect(gteFilter).toBeDefined();
+    const cutoffMs = Date.parse(String(gteFilter!.last_seen_at_gte));
+    const expected = Date.parse(nowIso) - DEFAULT_DEDUPE_WINDOW_MS;
+    expect(cutoffMs).toBe(expected);
+  });
+});
+
+describe('VTID-03068 — recordDedupeSighting', () => {
+  test('upserts a well-formed row', async () => {
+    let captured: unknown = null;
+    const { sb } = fakeSb({ captureUpsert: (r) => (captured = r) });
+    const out = await recordDedupeSighting({
+      ...baseInputs,
+      supabase: sb,
+      source: 'reminder_due',
+      surface: 'orb_wake',
+    });
+    expect(out.ok).toBe(true);
+    expect(captured).not.toBeNull();
+    const row = captured as Record<string, unknown>;
+    expect(row.tenant_id).toBe('t1');
+    expect(row.user_id).toBe('u1');
+    expect(row.signal_name).toBe(buildDedupeSignalName('reminder_due:r-1'));
+    expect(row.value).toEqual({
+      source: 'reminder_due',
+      surface: 'orb_wake',
+      shown_at: expect.any(String),
+    });
+    expect(typeof row.last_seen_at).toBe('string');
+  });
+
+  test('returns {ok:false, reason} on supabase error', async () => {
+    const { sb } = fakeSb({ upsertError: { message: 'rls denied' } });
+    const out = await recordDedupeSighting({
+      ...baseInputs,
+      supabase: sb,
+      source: 'reminder_due',
+      surface: 'orb_wake',
+    });
+    expect(out.ok).toBe(false);
+    expect(out.reason).toBe('rls denied');
+  });
+
+  test('returns {ok:false, reason} on exception', async () => {
+    const { sb } = fakeSb({ upsertThrows: true });
+    const out = await recordDedupeSighting({
+      ...baseInputs,
+      supabase: sb,
+      source: 'reminder_due',
+      surface: 'orb_wake',
+    });
+    expect(out.ok).toBe(false);
+    expect(out.reason).toBe('boom');
+  });
+});


### PR DESCRIPTION
Cross-session dedupe via user_assistant_state. Stops 'same reminder fires every wake' nagging. Read fail-open, write fire-and-forget — DB outage can NEVER silence the orb. Default 4h window. Composer applies dedupe gate before ranking + records winner sighting after pick. +13 tests. 136 next-action tests green.