### PR TITLE
feat(orb-livekit): B0d-real Xm - match / activity-plan next-action source (VTID-03070)

### DIFF
--- a/services/gateway/src/services/assistant-continuation/providers/next-action/register-default-sources.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/next-action/register-default-sources.ts
@@ -30,6 +30,8 @@ import { makeVitanaIndexPillarSource } from './sources/vitana-index-pillar';
 // VTID-03060 (B0d-real Xe) — continuity sources.
 import { makeContinuityPendingThreadSource } from './sources/continuity-pending-thread';
 import { makeContinuityPromiseOwedSource } from './sources/continuity-promise-owed';
+// VTID-03070 (B0d-real Xm) — match / activity-plan source.
+import { makeMatchActivityPlanSource } from './sources/match-activity-plan';
 // VTID-03067 (B0d-real Xj) — per-source flag gates.
 import { withFlagGate } from './source-gate';
 
@@ -42,12 +44,16 @@ export function ensureDefaultNextActionSourcesRegistered(): void {
   // Pick (urgency-first):
   //   1. reminders                — time-bound, beats coaching
   //   2. calendar                 — time-bound, slightly weaker than reminders
-  //   3. autopilot                — coaching with confidence signal
-  //   4. continuity_promise_owed  — relationship trust (overdue promises sit high)
-  //   5. diary_missing_relevant   — streak preservation
-  //   6. continuity_pending_thread— pick up the thread we left
-  //   7. life-compass-alignment   — goal-anchored coaching
-  //   8. vitana-index-pillar      — weakest signal, last resort
+  //   3. match_activity_plan      — time-bound social decisions sit between
+  //                                 calendar and autopilot (a pending match
+  //                                 response is more urgent than a coaching
+  //                                 rec, less urgent than a calendar event)
+  //   4. autopilot                — coaching with confidence signal
+  //   5. continuity_promise_owed  — relationship trust (overdue promises sit high)
+  //   6. diary_missing_relevant   — streak preservation
+  //   7. continuity_pending_thread— pick up the thread we left
+  //   8. life-compass-alignment   — goal-anchored coaching
+  //   9. vitana-index-pillar      — weakest signal, last resort
   //
   // Each source's bands are tuned so the natural urgency winner wins on
   // priority alone. This order resolves rare ties without the composer
@@ -58,6 +64,7 @@ export function ensureDefaultNextActionSourcesRegistered(): void {
   // Default behavior (row absent) keeps every source live.
   defaultNextActionComposer.register(withFlagGate(makeReminderDueSource()));
   defaultNextActionComposer.register(withFlagGate(makeCalendarUpcomingSource()));
+  defaultNextActionComposer.register(withFlagGate(makeMatchActivityPlanSource()));
   defaultNextActionComposer.register(withFlagGate(makeAutopilotRecommendationSource()));
   defaultNextActionComposer.register(withFlagGate(makeContinuityPromiseOwedSource()));
   defaultNextActionComposer.register(withFlagGate(makeDiaryMissingRelevantSource()));

--- a/services/gateway/src/services/assistant-continuation/providers/next-action/sources/match-activity-plan.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/next-action/sources/match-activity-plan.ts
@@ -1,0 +1,291 @@
+/**
+ * VTID-03070 (B0d-real slice Xm) — Match / activity-plan NextActionSource.
+ *
+ * Closes acceptance #3 from the B0d-real spec ("match/activity plan
+ * opportunity can win"). Surfaces the user's most-actionable
+ * intent_matches row as a next-action candidate so the orb can offer:
+ *
+ *   - "Someone matched you on <kind>. Want to open the conversation?"
+ *     when state === 'mutual_interest' (both sides engaged).
+ *   - "Your match on <kind> is waiting for your response."
+ *     when the other side has responded and this user has not.
+ *   - "You have a fresh match on <kind>. Want me to walk you through it?"
+ *     when state === 'new'.
+ *
+ * Priority bands (mapped from state, parallel to other sources):
+ *   - pending_user_decision (other side responded, our turn) → 85
+ *   - mutual_interest                                        → 78
+ *   - new (fresh, not yet acted on)                          → 65
+ *
+ * Confidence:
+ *   - pending_user_decision / mutual_interest → high
+ *   - new                                     → medium
+ *
+ * Privacy contract (B0d-real Xm — hard rules):
+ *   - NEVER include raw chat text, profile payloads, intent titles, or
+ *     match-row JSON. Only kind_pairing (a category enum) + state +
+ *     match_id leave this file.
+ *   - Counterparty vitana_id is NOT exposed in the spoken line — the
+ *     redact-on-pre-reveal logic in intent-mutual-reveal.ts is the
+ *     authoritative gate; the wake-brief surface stays vitana-id-free.
+ *   - If the table is missing or the read fails, suppress with
+ *     skippedReason: 'source_unavailable' so a DB outage cannot leak.
+ *
+ * Schema contract this source assumes (from intent-matcher.ts +
+ * intent-mutual-reveal.ts):
+ *   intent_matches(match_id, intent_a_id, intent_b_id, kind_pairing,
+ *                  state, mutual_reveal_unlocked_at, score, ...)
+ *   user_intents(intent_id, requester_user_id)
+ *
+ * State enum used in this source (mirroring orb-tools-shared.ts
+ * respond_to_match):
+ *   'new' | 'responded_by_a' | 'responded_by_b' | 'mutual_interest' |
+ *   'declined'
+ */
+
+import type {
+  NextActionSource,
+  NextActionSourceContext,
+  NextActionSourceResult,
+  ScoredCandidate,
+} from '../types';
+
+const KEY = 'match_activity_plan' as const;
+
+/** Max user_intents to fan out across when discovering matches. The
+ *  orb only ever surfaces one candidate; this cap exists so a user
+ *  with a long intent history doesn't pull a giant batch. */
+const MAX_INTENTS_PER_USER = 20;
+
+/** Max intent_matches rows to consider once we have intent ids. The
+ *  ranker only picks the top stage; we never read more than this. */
+const MAX_MATCHES_PER_SOURCE = 20;
+
+/** State buckets in priority order. 'mutual_interest' beats fresh, but
+ *  is itself beaten by "pending response from this user" — because a
+ *  decision waiting on the user is more time-sensitive than an open
+ *  conversation. */
+type MatchStage = 'pending_user_decision' | 'mutual_interest' | 'new';
+
+export function makeMatchActivityPlanSource(): NextActionSource {
+  return {
+    key: KEY,
+    serves: () => true,
+    produce: produceMatchActivityPlan,
+  };
+}
+
+export async function produceMatchActivityPlan(
+  ctx: NextActionSourceContext,
+): Promise<NextActionSourceResult> {
+  let userIntentIds: string[];
+  try {
+    const { data, error } = await ctx.supabase
+      .from('user_intents')
+      .select('intent_id')
+      .eq('requester_user_id', ctx.userId)
+      .order('created_at', { ascending: false })
+      .limit(MAX_INTENTS_PER_USER);
+    if (error) {
+      return { source: KEY, candidate: null, skippedReason: 'source_unavailable' };
+    }
+    userIntentIds = (data || [])
+      .map((r) => (r as { intent_id: string }).intent_id)
+      .filter(Boolean);
+  } catch {
+    return { source: KEY, candidate: null, skippedReason: 'errored' };
+  }
+
+  if (userIntentIds.length === 0) {
+    return { source: KEY, candidate: null, skippedReason: 'no_eligible_record' };
+  }
+
+  let matches: MatchRow[];
+  try {
+    // We have to query "intent_a_id in (ids) OR intent_b_id in (ids)".
+    // Supabase REST does that via .or('intent_a_id.in.(...),intent_b_id.in.(...)').
+    const idList = userIntentIds.map((s) => `"${s}"`).join(',');
+    const { data, error } = await ctx.supabase
+      .from('intent_matches')
+      .select('match_id, intent_a_id, intent_b_id, kind_pairing, state, mutual_reveal_unlocked_at')
+      .or(`intent_a_id.in.(${idList}),intent_b_id.in.(${idList})`)
+      .in('state', ['new', 'responded_by_a', 'responded_by_b', 'mutual_interest'])
+      .order('match_id', { ascending: true })
+      .limit(MAX_MATCHES_PER_SOURCE);
+    if (error) {
+      return { source: KEY, candidate: null, skippedReason: 'source_unavailable' };
+    }
+    matches = (data || []) as MatchRow[];
+  } catch {
+    return { source: KEY, candidate: null, skippedReason: 'errored' };
+  }
+
+  if (matches.length === 0) {
+    return { source: KEY, candidate: null, skippedReason: 'no_eligible_record' };
+  }
+
+  const intentIdSet = new Set(userIntentIds);
+  const ranked = rankMatches(matches, intentIdSet);
+  const top = ranked[0];
+  if (!top) {
+    return { source: KEY, candidate: null, skippedReason: 'no_eligible_record' };
+  }
+
+  const { priority, confidence } = bandForStage(top.stage);
+  const kindLabel = renderKindLabel(top.row.kind_pairing);
+  const userFacingLine = renderLine(top.stage, kindLabel, ctx.lang);
+
+  const candidate: ScoredCandidate = {
+    source: KEY,
+    priority,
+    confidence,
+    userFacingLine,
+    reasons: [
+      {
+        kind: reasonKindFor(top.stage),
+        detail: `match=${top.row.match_id} kind=${top.row.kind_pairing} state=${top.row.state}`,
+      },
+    ],
+    dedupeKey: `match_activity_plan:${top.row.match_id}:${top.stage}`,
+    cta: {
+      type: 'ask_permission',
+      payload: { match_id: top.row.match_id, stage: top.stage },
+    },
+  };
+  return { source: KEY, candidate };
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers — exported for tests
+// ---------------------------------------------------------------------------
+
+export interface MatchRow {
+  match_id: string;
+  intent_a_id: string;
+  intent_b_id: string | null;
+  kind_pairing: string | null;
+  state: string;
+  mutual_reveal_unlocked_at: string | null;
+}
+
+interface RankedMatch {
+  row: MatchRow;
+  stage: MatchStage;
+}
+
+export function rankMatches(
+  rows: MatchRow[],
+  userIntentIdSet: Set<string>,
+): RankedMatch[] {
+  const stages: RankedMatch[] = [];
+  for (const row of rows) {
+    const stage = classifyStage(row, userIntentIdSet);
+    if (stage) stages.push({ row, stage });
+  }
+  // Sort by stage priority (pending > mutual > new) then by match_id for
+  // deterministic tie-break.
+  stages.sort((a, b) => {
+    const pa = stageRank(a.stage);
+    const pb = stageRank(b.stage);
+    if (pa !== pb) return pb - pa;
+    return a.row.match_id.localeCompare(b.row.match_id);
+  });
+  return stages;
+}
+
+export function classifyStage(
+  row: MatchRow,
+  userIntentIdSet: Set<string>,
+): MatchStage | null {
+  if (row.state === 'mutual_interest') return 'mutual_interest';
+  if (row.state === 'new') return 'new';
+  const userOwnsA = userIntentIdSet.has(row.intent_a_id);
+  const userOwnsB = row.intent_b_id ? userIntentIdSet.has(row.intent_b_id) : false;
+  // The other side responded. If the user owns A and B responded, the
+  // user (A) owes the decision. Same mirrored for the B side.
+  if (row.state === 'responded_by_b' && userOwnsA) return 'pending_user_decision';
+  if (row.state === 'responded_by_a' && userOwnsB) return 'pending_user_decision';
+  return null;
+}
+
+function stageRank(stage: MatchStage): number {
+  switch (stage) {
+    case 'pending_user_decision':
+      return 3;
+    case 'mutual_interest':
+      return 2;
+    case 'new':
+      return 1;
+  }
+}
+
+export function bandForStage(
+  stage: MatchStage,
+): { priority: number; confidence: ScoredCandidate['confidence'] } {
+  switch (stage) {
+    case 'pending_user_decision':
+      return { priority: 85, confidence: 'high' };
+    case 'mutual_interest':
+      return { priority: 78, confidence: 'high' };
+    case 'new':
+      return { priority: 65, confidence: 'medium' };
+  }
+}
+
+function reasonKindFor(stage: MatchStage): string {
+  switch (stage) {
+    case 'pending_user_decision':
+      return 'match_awaiting_user_response';
+    case 'mutual_interest':
+      return 'match_mutual_interest_open_conversation';
+    case 'new':
+      return 'match_new_unseen';
+  }
+}
+
+/**
+ * Map a kind_pairing string ("buddy_seek::buddy_seek", "hike::hike",
+ * "commercial_buy::product") to a short user-facing label without
+ * leaking the full enum. The label is intentionally generic — the
+ * voice line never claims "hiking match" if the kind pairing is
+ * something we don't have a friendly word for; it falls back to
+ * "match" so we never invent or misclassify the activity.
+ */
+export function renderKindLabel(kindPairing: string | null): string {
+  if (!kindPairing) return 'match';
+  const left = String(kindPairing).split('::')[0] || '';
+  const known: Record<string, string> = {
+    hike: 'hike',
+    run: 'run',
+    chess: 'chess',
+    language_exchange: 'language exchange',
+    coffee: 'coffee',
+    buddy_seek: 'buddy',
+    partner_seek: 'partner',
+    activity_seek: 'activity',
+    commercial_buy: 'purchase',
+    commercial_sell: 'offer',
+  };
+  return known[left] ?? 'match';
+}
+
+export function renderLine(
+  stage: MatchStage,
+  kindLabel: string,
+  lang: string,
+): string {
+  const isDe = (lang || 'en').toLowerCase().startsWith('de');
+  if (stage === 'pending_user_decision') {
+    return isDe
+      ? `Es gibt eine Antwort auf deine ${kindLabel}-Anfrage. Willst du entscheiden, wie es weitergeht?`
+      : `Someone has responded to your ${kindLabel} request. Want to decide what's next?`;
+  }
+  if (stage === 'mutual_interest') {
+    return isDe
+      ? `Du hast ein neues gegenseitiges Match auf ${kindLabel}. Sollen wir das Gespräch eröffnen?`
+      : `You have a new mutual ${kindLabel} match. Want to open the conversation?`;
+  }
+  return isDe
+    ? `Es gibt ein frisches ${kindLabel}-Match für dich. Soll ich es dir vorstellen?`
+    : `You have a fresh ${kindLabel} match. Want me to walk you through it?`;
+}

--- a/services/gateway/test/services/assistant-continuation/providers/next-action/match-activity-plan.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/next-action/match-activity-plan.test.ts
@@ -1,0 +1,404 @@
+/**
+ * VTID-03070 (B0d-real Xm) — match / activity-plan source tests.
+ *
+ * Covers:
+ *   - Pure helpers: classifyStage, rankMatches, bandForStage,
+ *     renderKindLabel, renderLine
+ *   - produceMatchActivityPlan:
+ *     * No user_intents → no_eligible_record
+ *     * user_intents query error → source_unavailable
+ *     * user_intents throws → errored
+ *     * intent_matches query error → source_unavailable
+ *     * intent_matches throws → errored
+ *     * No matching rows → no_eligible_record
+ *     * mutual_interest row → priority 78, confidence high
+ *     * pending_user_decision wins over mutual_interest when both present
+ *     * fresh 'new' row → priority 65
+ *     * Privacy: spoken line never includes raw match_id or kind_pairing enum
+ */
+
+import {
+  produceMatchActivityPlan,
+  classifyStage,
+  rankMatches,
+  bandForStage,
+  renderKindLabel,
+  renderLine,
+} from '../../../../../src/services/assistant-continuation/providers/next-action/sources/match-activity-plan';
+import type { MatchRow } from '../../../../../src/services/assistant-continuation/providers/next-action/sources/match-activity-plan';
+import type { NextActionSourceContext } from '../../../../../src/services/assistant-continuation/providers/next-action/types';
+
+interface FakeOpts {
+  intentRows?: unknown[] | null;
+  intentError?: { message: string } | null;
+  intentThrows?: boolean;
+  matchRows?: unknown[] | null;
+  matchError?: { message: string } | null;
+  matchThrows?: boolean;
+}
+
+function fakeSupabase(opts: FakeOpts): import('@supabase/supabase-js').SupabaseClient {
+  let table = '';
+  const intentChain: any = {
+    eq: () => intentChain,
+    order: () => intentChain,
+    limit: () =>
+      opts.intentThrows
+        ? Promise.reject(new Error('boom-intents'))
+        : Promise.resolve(
+            opts.intentError
+              ? { data: null, error: opts.intentError }
+              : { data: opts.intentRows ?? null, error: null },
+          ),
+  };
+  const matchChain: any = {
+    or: () => matchChain,
+    in: () => matchChain,
+    order: () => matchChain,
+    limit: () =>
+      opts.matchThrows
+        ? Promise.reject(new Error('boom-matches'))
+        : Promise.resolve(
+            opts.matchError
+              ? { data: null, error: opts.matchError }
+              : { data: opts.matchRows ?? null, error: null },
+          ),
+  };
+  return {
+    from: (t: string) => {
+      table = t;
+      return {
+        select: () => (table === 'user_intents' ? intentChain : matchChain),
+      };
+    },
+    rpc: async () => ({ data: null, error: null }),
+  } as unknown as import('@supabase/supabase-js').SupabaseClient;
+}
+
+function ctxWith(
+  sb: import('@supabase/supabase-js').SupabaseClient,
+  lang = 'en',
+): NextActionSourceContext {
+  return {
+    userId: 'u1',
+    tenantId: 't1',
+    lang,
+    nowIso: '2026-05-18T08:00:00Z',
+    decisionContext: null,
+    supabase: sb,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers
+// ---------------------------------------------------------------------------
+
+describe('match-activity-plan pure helpers', () => {
+  test('renderKindLabel — known kinds get a friendly label, unknown stays generic', () => {
+    expect(renderKindLabel('hike::hike')).toBe('hike');
+    expect(renderKindLabel('chess::chess')).toBe('chess');
+    expect(renderKindLabel('language_exchange::language_exchange')).toBe('language exchange');
+    expect(renderKindLabel('buddy_seek::buddy_seek')).toBe('buddy');
+    expect(renderKindLabel('commercial_buy::product')).toBe('purchase');
+    expect(renderKindLabel('mystery_kind::other')).toBe('match'); // safe fallback
+    expect(renderKindLabel(null)).toBe('match');
+    expect(renderKindLabel('')).toBe('match');
+  });
+
+  test('renderLine — EN + DE for all three stages', () => {
+    expect(renderLine('pending_user_decision', 'hike', 'en')).toMatch(/responded.+hike/i);
+    expect(renderLine('pending_user_decision', 'hike', 'de')).toMatch(/Antwort.+hike/);
+    expect(renderLine('mutual_interest', 'chess', 'en')).toMatch(/mutual.+chess/i);
+    expect(renderLine('mutual_interest', 'chess', 'de')).toMatch(/gegenseitiges.+chess/);
+    expect(renderLine('new', 'match', 'en')).toMatch(/fresh match/i);
+    expect(renderLine('new', 'match', 'de')).toMatch(/frisches match/i);
+  });
+
+  test('bandForStage — priority + confidence', () => {
+    expect(bandForStage('pending_user_decision')).toEqual({ priority: 85, confidence: 'high' });
+    expect(bandForStage('mutual_interest')).toEqual({ priority: 78, confidence: 'high' });
+    expect(bandForStage('new')).toEqual({ priority: 65, confidence: 'medium' });
+  });
+
+  test('classifyStage — mutual_interest always wins regardless of intent ownership', () => {
+    const row: MatchRow = {
+      match_id: 'm1',
+      intent_a_id: 'i-a',
+      intent_b_id: 'i-b',
+      kind_pairing: 'hike::hike',
+      state: 'mutual_interest',
+      mutual_reveal_unlocked_at: null,
+    };
+    expect(classifyStage(row, new Set(['i-a']))).toBe('mutual_interest');
+    expect(classifyStage(row, new Set(['i-b']))).toBe('mutual_interest');
+  });
+
+  test('classifyStage — pending_user_decision when other side responded', () => {
+    const row: MatchRow = {
+      match_id: 'm2',
+      intent_a_id: 'i-a',
+      intent_b_id: 'i-b',
+      kind_pairing: 'chess::chess',
+      state: 'responded_by_b',
+      mutual_reveal_unlocked_at: null,
+    };
+    // User owns A — B responded, so A (user) owes the decision.
+    expect(classifyStage(row, new Set(['i-a']))).toBe('pending_user_decision');
+    // User owns B — B already responded, so it's not pending on user.
+    expect(classifyStage(row, new Set(['i-b']))).toBeNull();
+  });
+
+  test('classifyStage — new fresh match', () => {
+    const row: MatchRow = {
+      match_id: 'm3',
+      intent_a_id: 'i-a',
+      intent_b_id: null,
+      kind_pairing: 'commercial_buy::product',
+      state: 'new',
+      mutual_reveal_unlocked_at: null,
+    };
+    expect(classifyStage(row, new Set(['i-a']))).toBe('new');
+  });
+
+  test('classifyStage — declined or unrelated → null', () => {
+    const row: MatchRow = {
+      match_id: 'm4',
+      intent_a_id: 'i-a',
+      intent_b_id: 'i-b',
+      kind_pairing: 'hike::hike',
+      state: 'declined',
+      mutual_reveal_unlocked_at: null,
+    };
+    expect(classifyStage(row, new Set(['i-a']))).toBeNull();
+  });
+
+  test('rankMatches — pending beats mutual beats new, stable by match_id', () => {
+    const userIntents = new Set(['i-a']);
+    const rows: MatchRow[] = [
+      {
+        match_id: 'b-new',
+        intent_a_id: 'i-a',
+        intent_b_id: null,
+        kind_pairing: 'hike::hike',
+        state: 'new',
+        mutual_reveal_unlocked_at: null,
+      },
+      {
+        match_id: 'a-mutual',
+        intent_a_id: 'i-a',
+        intent_b_id: 'i-other',
+        kind_pairing: 'hike::hike',
+        state: 'mutual_interest',
+        mutual_reveal_unlocked_at: null,
+      },
+      {
+        match_id: 'c-pending',
+        intent_a_id: 'i-a',
+        intent_b_id: 'i-other',
+        kind_pairing: 'hike::hike',
+        state: 'responded_by_b',
+        mutual_reveal_unlocked_at: null,
+      },
+    ];
+    const ranked = rankMatches(rows, userIntents);
+    expect(ranked.map((r) => r.row.match_id)).toEqual(['c-pending', 'a-mutual', 'b-new']);
+  });
+});
+
+// ---------------------------------------------------------------------------
+// produceMatchActivityPlan
+// ---------------------------------------------------------------------------
+
+describe('produceMatchActivityPlan source', () => {
+  test('no user_intents → no_eligible_record', async () => {
+    const r = await produceMatchActivityPlan(ctxWith(fakeSupabase({ intentRows: [] })));
+    expect(r.candidate).toBeNull();
+    expect(r.skippedReason).toBe('no_eligible_record');
+  });
+
+  test('user_intents query error → source_unavailable', async () => {
+    const r = await produceMatchActivityPlan(
+      ctxWith(fakeSupabase({ intentError: { message: 'rls denied' } })),
+    );
+    expect(r.candidate).toBeNull();
+    expect(r.skippedReason).toBe('source_unavailable');
+  });
+
+  test('user_intents throws → errored', async () => {
+    const r = await produceMatchActivityPlan(
+      ctxWith(fakeSupabase({ intentThrows: true })),
+    );
+    expect(r.candidate).toBeNull();
+    expect(r.skippedReason).toBe('errored');
+  });
+
+  test('intent_matches query error → source_unavailable', async () => {
+    const r = await produceMatchActivityPlan(
+      ctxWith(
+        fakeSupabase({
+          intentRows: [{ intent_id: 'i-a' }],
+          matchError: { message: 'rls denied' },
+        }),
+      ),
+    );
+    expect(r.candidate).toBeNull();
+    expect(r.skippedReason).toBe('source_unavailable');
+  });
+
+  test('intent_matches throws → errored', async () => {
+    const r = await produceMatchActivityPlan(
+      ctxWith(
+        fakeSupabase({
+          intentRows: [{ intent_id: 'i-a' }],
+          matchThrows: true,
+        }),
+      ),
+    );
+    expect(r.candidate).toBeNull();
+    expect(r.skippedReason).toBe('errored');
+  });
+
+  test('no matching rows → no_eligible_record', async () => {
+    const r = await produceMatchActivityPlan(
+      ctxWith(
+        fakeSupabase({
+          intentRows: [{ intent_id: 'i-a' }],
+          matchRows: [],
+        }),
+      ),
+    );
+    expect(r.candidate).toBeNull();
+    expect(r.skippedReason).toBe('no_eligible_record');
+  });
+
+  test('mutual_interest row → priority 78, confidence high', async () => {
+    const r = await produceMatchActivityPlan(
+      ctxWith(
+        fakeSupabase({
+          intentRows: [{ intent_id: 'i-a' }],
+          matchRows: [
+            {
+              match_id: 'm-100',
+              intent_a_id: 'i-a',
+              intent_b_id: 'i-other',
+              kind_pairing: 'hike::hike',
+              state: 'mutual_interest',
+              mutual_reveal_unlocked_at: null,
+            },
+          ],
+        }),
+      ),
+    );
+    expect(r.candidate).not.toBeNull();
+    if (!r.candidate) return;
+    expect(r.candidate.priority).toBe(78);
+    expect(r.candidate.confidence).toBe('high');
+    expect(r.candidate.dedupeKey).toBe('match_activity_plan:m-100:mutual_interest');
+    expect(r.candidate.userFacingLine).toMatch(/hike/i);
+    expect(r.candidate.cta?.type).toBe('ask_permission');
+    expect(r.candidate.reasons[0].kind).toBe('match_mutual_interest_open_conversation');
+  });
+
+  test('pending_user_decision wins over mutual_interest when both present', async () => {
+    const r = await produceMatchActivityPlan(
+      ctxWith(
+        fakeSupabase({
+          intentRows: [{ intent_id: 'i-a' }],
+          matchRows: [
+            {
+              match_id: 'a-mutual',
+              intent_a_id: 'i-a',
+              intent_b_id: 'i-other',
+              kind_pairing: 'chess::chess',
+              state: 'mutual_interest',
+              mutual_reveal_unlocked_at: null,
+            },
+            {
+              match_id: 'b-pending',
+              intent_a_id: 'i-a',
+              intent_b_id: 'i-other',
+              kind_pairing: 'hike::hike',
+              state: 'responded_by_b',
+              mutual_reveal_unlocked_at: null,
+            },
+          ],
+        }),
+      ),
+    );
+    expect(r.candidate?.priority).toBe(85);
+    expect(r.candidate?.dedupeKey).toBe('match_activity_plan:b-pending:pending_user_decision');
+    expect(r.candidate?.userFacingLine).toMatch(/hike/);
+  });
+
+  test("fresh 'new' row → priority 65, confidence medium", async () => {
+    const r = await produceMatchActivityPlan(
+      ctxWith(
+        fakeSupabase({
+          intentRows: [{ intent_id: 'i-a' }],
+          matchRows: [
+            {
+              match_id: 'm-new-1',
+              intent_a_id: 'i-a',
+              intent_b_id: null,
+              kind_pairing: 'commercial_buy::product',
+              state: 'new',
+              mutual_reveal_unlocked_at: null,
+            },
+          ],
+        }),
+      ),
+    );
+    expect(r.candidate?.priority).toBe(65);
+    expect(r.candidate?.confidence).toBe('medium');
+    expect(r.candidate?.userFacingLine).toMatch(/fresh/i);
+    expect(r.candidate?.userFacingLine).toMatch(/purchase/i);
+  });
+
+  test('privacy: spoken line never includes match_id or raw kind_pairing enum', async () => {
+    const r = await produceMatchActivityPlan(
+      ctxWith(
+        fakeSupabase({
+          intentRows: [{ intent_id: 'i-a' }],
+          matchRows: [
+            {
+              match_id: 'PRIVATE-MATCH-UUID-1234567890',
+              intent_a_id: 'i-a',
+              intent_b_id: 'i-other',
+              kind_pairing: 'commercial_sell::product',
+              state: 'mutual_interest',
+              mutual_reveal_unlocked_at: null,
+            },
+          ],
+        }),
+      ),
+    );
+    expect(r.candidate).not.toBeNull();
+    if (!r.candidate) return;
+    expect(r.candidate.userFacingLine).not.toContain('PRIVATE-MATCH-UUID-1234567890');
+    expect(r.candidate.userFacingLine).not.toContain('commercial_sell::product');
+    expect(r.candidate.userFacingLine).not.toContain('::');
+  });
+
+  test('unrelated intent ownership (declined or responded by user) → no_eligible_record', async () => {
+    const r = await produceMatchActivityPlan(
+      ctxWith(
+        fakeSupabase({
+          intentRows: [{ intent_id: 'i-a' }],
+          matchRows: [
+            // User is A; A already responded → not pending on user.
+            {
+              match_id: 'm-already-responded',
+              intent_a_id: 'i-a',
+              intent_b_id: 'i-other',
+              kind_pairing: 'hike::hike',
+              state: 'responded_by_a',
+              mutual_reveal_unlocked_at: null,
+            },
+          ],
+        }),
+      ),
+    );
+    expect(r.candidate).toBeNull();
+    expect(r.skippedReason).toBe('no_eligible_record');
+  });
+});


### PR DESCRIPTION
## Summary

Adds the 9th source to the next-action composer (closes acceptance #3 from the B0d-real spec). New file `sources/match-activity-plan.ts` produces a candidate when the user has an actionable `intent_matches` row. Wired via `withFlagGate()` between `calendar_upcoming` and `autopilot_recommendation` so the time-bound social decision sits where it belongs in the tie-break.

## Behavior

Stages mapped from `intent_matches.state`:
- `pending_user_decision` (other side responded, our turn) → priority 85, confidence high
- `mutual_interest` (both sides engaged) → priority 78, confidence high
- `new` (fresh, not yet acted on) → priority 65, confidence medium

Reads via two queries: `user_intents → intent_ids`, then `intent_matches.or(intent_a_id.in.(..), intent_b_id.in.(..))`. Caps at 20 intents + 20 matches.

Dedupe key: `match_activity_plan:<match_id>:<stage>` so different stages of the same match don't collide. EN + DE copy.

## Privacy contract (hard rules)

- NEVER includes raw chat text, profile payloads, intent titles, or match-row JSON.
- Only `kind_pairing` (a category enum) maps to a short friendly label ("hike", "chess", "buddy", "purchase", ...) with a safe "match" fallback.
- Counterparty `vitana_id` is NOT exposed in the spoken line — the redact-on-pre-reveal logic stays at the route layer.
- DB failure → `skippedReason='source_unavailable'` (fail-closed for privacy).

## Validation order

Per the B0d-real plan, behavior tuning (priority bands, dedupe windows, copy) is deferred until real-mic validation. The next slice is frontend ACT/DISMISS hooks in vitana-v1.

## Test plan
- [x] 19 new unit tests (pure helpers + produce() across 8 paths)
- [x] Privacy assertion: spoken line never contains raw `match_id` or `::` enum strings
- [x] 155 next-action tests green
- [x] Full gateway build green
- [ ] Real-mic validation (deferred per plan)

🤖 Generated with [Claude Code](https://claude.com/claude-code)