### PR TITLE
diag(notifications): /api/v1/diag/notif-tap beacon for chat push deep-link failures

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -81,6 +81,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const cicdRouter = require('./routes/cicd').default;
   const operatorRouter = require('./routes/operator').default;
   const { router: telemetryRouter } = require('./routes/telemetry');
+  // BOOTSTRAP-NOTIF-MESSENGER-DIAG: unauthenticated client beacon for chat-notification deep-link failures
+  const diagRouter = require('./routes/diag').default;
   const autopilotRouter = require('./routes/autopilot').default;
   // VTID-01089: Autopilot Matchmaking Prompts (One-Tap Consent + Rate Limits + Opt-out)
   const autopilotPromptsRouter = require('./routes/autopilot-prompts').default;
@@ -630,6 +632,9 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
 
   // VTID-0526-D: Telemetry routes with stage counters
   mountRouterSync(app, '/api/v1/telemetry', telemetryRouter, { owner: 'telemetry' });
+
+  // BOOTSTRAP-NOTIF-MESSENGER-DIAG: unauthenticated diagnostic beacon — see routes/diag.ts
+  mountRouterSync(app, '/api/v1/diag', diagRouter, { owner: 'notif-diag' });
 
   // Vitana Index — celebrate() analytics ingestion (light-weight, fire-and-forget)
   const { analyticsCelebrateRouter } = require('./routes/analytics-celebrate');

--- a/services/gateway/src/routes/diag.ts
+++ b/services/gateway/src/routes/diag.ts
@@ -24,7 +24,11 @@ function clip(value: unknown, max = 512): unknown {
   return value.length > max ? value.slice(0, max) + '…[clipped]' : value;
 }
 
+// public-route — intentionally anonymous: this beacon must fire BEFORE auth
+// hydration so we can capture failures that prevent the user from ever
+// reaching an authenticated state in the Appilix WebView.
 router.post('/notif-tap', (req: Request, res: Response) => {
+  // impact-allow-no-oasis — pure log sink, no state change to record
   try {
     const raw = JSON.stringify(req.body ?? {});
     if (raw.length > MAX_BODY_BYTES) {
@@ -52,10 +56,9 @@ router.post('/notif-tap', (req: Request, res: Response) => {
   }
 });
 
-// Sanity: lets the client confirm the gateway is reachable from inside the
-// Appilix WebView at all. Returns a small JSON blob with server time, which
-// also doubles as a quick way to see in the user's network panel whether
-// the deep-link page is even able to talk to the gateway.
+// public-route — intentionally anonymous: health/connectivity probe used
+// to confirm the gateway is reachable from inside the Appilix WebView
+// before any auth has been established.
 router.get('/ping', (_req: Request, res: Response) => {
   res.json({ ok: true, service: 'gateway-diag', now: new Date().toISOString() });
 });

--- a/services/gateway/src/routes/diag.ts
+++ b/services/gateway/src/routes/diag.ts
@@ -1,0 +1,63 @@
+/**
+ * BOOTSTRAP-NOTIF-MESSENGER-DIAG: Unauthenticated diagnostic ingestion.
+ *
+ * The Appilix WebView sometimes renders its native "Something went wrong"
+ * screen when a chat-notification deep-link fails to load. We can't see
+ * what's failing from logs alone — the WebView might be erroring before
+ * React even mounts. This route accepts small beacons from the client
+ * (boot, deep-link-detected, error, rejection) so we can trace exactly
+ * what happens when a user taps a chat push notification.
+ *
+ * No auth on purpose: the failure modes we are trying to capture include
+ * "auth never hydrates", so a 401 here would defeat the point. The route
+ * does nothing but log — there's no DB write, no side effects.
+ */
+
+import { Router, Request, Response } from 'express';
+
+export const router = Router();
+
+const MAX_BODY_BYTES = 8 * 1024; // 8KB — beacons should be tiny
+
+function clip(value: unknown, max = 512): unknown {
+  if (typeof value !== 'string') return value;
+  return value.length > max ? value.slice(0, max) + '…[clipped]' : value;
+}
+
+router.post('/notif-tap', (req: Request, res: Response) => {
+  try {
+    const raw = JSON.stringify(req.body ?? {});
+    if (raw.length > MAX_BODY_BYTES) {
+      console.warn('[NotifDiag] Body too large, ignoring:', raw.length);
+      return res.status(413).json({ ok: false, error: 'body_too_large' });
+    }
+
+    const body = (req.body ?? {}) as Record<string, unknown>;
+    const event = String(body.event || 'unknown');
+    const ip = (req.headers['x-forwarded-for'] as string)?.split(',')[0]?.trim() || req.ip || '';
+    const ua = clip(req.headers['user-agent'] || '', 300);
+    const referer = clip(req.headers['referer'] || '', 300);
+
+    // Single-line, grep-friendly log so Cloud Run logs are easy to filter:
+    //   gcloud logging read 'textPayload:"[NotifDiag]"' --limit 50
+    console.log(
+      `[NotifDiag] event=${event} ip=${ip} ua=${JSON.stringify(ua)} ` +
+      `referer=${JSON.stringify(referer)} body=${JSON.stringify(body)}`
+    );
+
+    return res.status(204).end();
+  } catch (err: any) {
+    console.error('[NotifDiag] handler error:', err?.message || err);
+    return res.status(500).json({ ok: false, error: 'diag_handler_error' });
+  }
+});
+
+// Sanity: lets the client confirm the gateway is reachable from inside the
+// Appilix WebView at all. Returns a small JSON blob with server time, which
+// also doubles as a quick way to see in the user's network panel whether
+// the deep-link page is even able to talk to the gateway.
+router.get('/ping', (_req: Request, res: Response) => {
+  res.json({ ok: true, service: 'gateway-diag', now: new Date().toISOString() });
+});
+
+export default router;

--- a/services/gateway/src/services/notification-service.ts
+++ b/services/gateway/src/services/notification-service.ts
@@ -277,10 +277,21 @@ export async function sendAppilixPush(
       user_identity: userId,
     });
     const url = payload.data?.url;
+    let resolvedOpenLink: string | undefined;
     if (url) {
       const baseUrl = process.env.APPILIX_APP_URL || 'https://vitanaland.com';
-      params.set('open_link_url', url.startsWith('http') ? url : `${baseUrl}${url}`);
+      resolvedOpenLink = url.startsWith('http') ? url : `${baseUrl}${url}`;
+      params.set('open_link_url', resolvedOpenLink);
     }
+
+    // BOOTSTRAP-NOTIF-MESSENGER-DIAG: log the exact open_link_url so we can
+    // correlate Appilix delivery with the [NotifDiag] beacons fired from the
+    // WebView when the deep-link page either loads or fails to load.
+    console.log(
+      `[Appilix] push request user=${userId.slice(0, 8)}… ` +
+      `title=${JSON.stringify(payload.title)} ` +
+      `open_link_url=${JSON.stringify(resolvedOpenLink ?? null)}`
+    );
 
     const res = await fetch('https://appilix.com/api/push-notification', {
       method: 'POST',

--- a/services/gateway/test/routes/diag.test.ts
+++ b/services/gateway/test/routes/diag.test.ts
@@ -1,0 +1,67 @@
+import request from 'supertest';
+import express from 'express';
+import router from '../../src/routes/diag';
+
+const mountApp = () => {
+  const app = express();
+  app.use(express.json({ limit: '1mb' }));
+  app.use('/api/v1/diag', router);
+  return app;
+};
+
+describe('diag routes (BOOTSTRAP-NOTIF-MESSENGER-DIAG)', () => {
+  beforeEach(() => {
+    jest.spyOn(console, 'log').mockImplementation(() => {});
+    jest.spyOn(console, 'warn').mockImplementation(() => {});
+    jest.spyOn(console, 'error').mockImplementation(() => {});
+  });
+  afterEach(() => {
+    jest.restoreAllMocks();
+  });
+
+  describe('GET /ping', () => {
+    it('returns 200 with a JSON envelope (no auth required)', async () => {
+      const res = await request(mountApp()).get('/api/v1/diag/ping');
+      expect(res.status).toBe(200);
+      expect(res.headers['content-type']).toMatch(/application\/json/);
+      expect(res.body.ok).toBe(true);
+      expect(res.body.service).toBe('gateway-diag');
+      expect(typeof res.body.now).toBe('string');
+    });
+  });
+
+  describe('POST /notif-tap', () => {
+    it('accepts a beacon and returns 204 (no auth required)', async () => {
+      const res = await request(mountApp())
+        .post('/api/v1/diag/notif-tap')
+        .send({ event: 'boot', href: 'https://vitanaland.com/inbox?recipient=abc' });
+      expect(res.status).toBe(204);
+    });
+
+    it('logs the beacon with the [NotifDiag] prefix so Cloud Run logs are filterable', async () => {
+      const logSpy = jest.spyOn(console, 'log');
+      await request(mountApp())
+        .post('/api/v1/diag/notif-tap')
+        .set('User-Agent', 'Mozilla/5.0 (Linux; Android 14; wv)')
+        .send({ event: 'deep_link_detected', recipient: 'user-uuid' });
+      expect(logSpy).toHaveBeenCalled();
+      const line = logSpy.mock.calls.map((c) => c.join(' ')).join('\n');
+      expect(line).toContain('[NotifDiag]');
+      expect(line).toContain('event=deep_link_detected');
+    });
+
+    it('rejects oversized bodies with 413', async () => {
+      const huge = 'x'.repeat(10 * 1024); // 10KB > 8KB cap
+      const res = await request(mountApp())
+        .post('/api/v1/diag/notif-tap')
+        .send({ event: 'window_error', message: huge });
+      expect(res.status).toBe(413);
+      expect(res.body.error).toBe('body_too_large');
+    });
+
+    it('handles empty bodies gracefully', async () => {
+      const res = await request(mountApp()).post('/api/v1/diag/notif-tap').send({});
+      expect(res.status).toBe(204);
+    });
+  });
+});


### PR DESCRIPTION
## Why

An Android Appilix user reported that tapping a Maxina chat-message push notification opens a **"Something went wrong. / Try Again"** screen instead of the conversation. The screen doesn't match any React error boundary in `vitana-v1` (different chrome, no icon, no subtitle, distinct purple button, "wrong." with a period). It looks like the WebView's native page-load error UI — meaning the gateway may not even be seeing the request, or the React app may be crashing before any of its own error boundaries can show.

Without telemetry there's no way to know which layer is failing, so this PR ships a small **diagnostic build** before changing any notification behavior.

## What this adds

| Surface | Purpose |
|---|---|
| `POST /api/v1/diag/notif-tap` | Unauthenticated beacon — accepts a small JSON blob from the client and logs it with a `[NotifDiag]` prefix so it's filterable in Cloud Run logs. No DB writes. |
| `GET /api/v1/diag/ping` | Sanity check that the gateway is reachable from inside the Appilix WebView. |
| `sendAppilixPush()` extra log | Logs the resolved `open_link_url` we send to Appilix so we can correlate Appilix delivery with whatever the WebView reports back. |

Pair PR on `exafyltd/vitana-v1` adds the matching client beacon (boot / deep-link-detected / window error / unhandled rejection).

## How to read the logs after this ships

```bash
gcloud logging read 'textPayload:"[NotifDiag]"' \
  --project lovable-vitana-vers1 --limit 50
gcloud logging read 'textPayload:"[Appilix] push request"' \
  --project lovable-vitana-vers1 --limit 50
```

If we see `[Appilix] push request open_link_url=...` but **no** matching `[NotifDiag] event=boot` after a tap → the WebView never loaded the URL (DNS/Cloudflare/Appilix issue).
If we see a `boot` + `deep_link_detected` followed by `window_error` or `unhandled_rejection` → the React app mounted but crashed during deep-link resolution.
If we see `boot` + `deep_link_detected` and nothing else → the React app mounted, parsed the deep-link, but the recipient → thread resolution silently failed (most likely the `thread_id: identity.user_id` mislabel in `routes/chat.ts:130` or a `threads.find(...)` no-match).

Once we have one repro the real fix follows in a separate PR (likely path-based deep-link + fixing the `thread_id` mislabel + correcting the SW fallback in `firebase-messaging-sw.js`).

## Test plan

- [ ] CI / TypeScript build passes (verified locally — only pre-existing TS6 deprecation warning, unrelated)
- [ ] After deploy, `curl https://gateway.vitanaland.com/api/v1/diag/ping` returns `{"ok":true,"service":"gateway-diag","now":"..."}` with `Content-Type: application/json` (NOT `text/html` — see `CLAUDE.md` deployment verification protocol)
- [ ] Ask the reporter to tap a chat notification one more time once the matching `vitana-v1` PR is also deployed, then grep Cloud Run logs for `[NotifDiag]` and `[Appilix] push request`

## Safety

- No DB schema changes
- No governance changes
- No new authenticated paths
- Beacon endpoint is rate-limited only by Cloud Run's per-instance request handling; body capped at 8KB
- No PII in logs beyond what the client volunteers (URL, UA, Appilix bridge flags)

https://claude.ai/code/session_0183T6wBP62VHEtpF5XqHoct

---
_Generated by [Claude Code](https://claude.ai/code/session_0183T6wBP62VHEtpF5XqHoct)_