### PR TITLE
fix(orb-livekit): B0d-real next-action lang plumbing + match-source duplicate-word bug (VTID-03073)

### DIFF
--- a/services/gateway/src/services/assistant-continuation/providers/next-action/index.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/next-action/index.ts
@@ -69,6 +69,14 @@ import { emitPerSourceCandidates } from './emit-telemetry';
 export interface NextActionInputs {
   supabase: SupabaseClient;
   decisionContext: unknown;
+  /**
+   * VTID-03073: language for the wake-brief / turn-end line. Forwarded
+   * by wake-brief-wiring.ts so every source's `renderLine(... lang)`
+   * picks the user's actual locale. Before this fix the provider
+   * defaulted to 'en' regardless of caller, so German users got
+   * English next-action lines for a week.
+   */
+  lang?: string;
 }
 
 export const NEXT_ACTION_EXTRA_KEY = 'nextAction' as const;
@@ -143,7 +151,7 @@ export function makeNextActionProvider(
         result = await composer.compose(surface, {
           userId: ctx.userId,
           tenantId: ctx.tenantId,
-          lang: 'lang' in (inputs as object) ? (inputs as { lang?: string }).lang ?? 'en' : 'en',
+          lang: inputs.lang ?? 'en',
           nowIso: new Date().toISOString(),
           decisionContext: inputs.decisionContext,
           supabase: inputs.supabase,
@@ -216,6 +224,7 @@ function readInputs(ctx: ContinuationDecisionContext): NextActionInputs | null {
   return {
     supabase: supabase as SupabaseClient,
     decisionContext: obj.decisionContext,
+    lang: typeof obj.lang === 'string' ? obj.lang : undefined,
   };
 }
 

--- a/services/gateway/src/services/assistant-continuation/providers/next-action/sources/match-activity-plan.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/next-action/sources/match-activity-plan.ts
@@ -245,14 +245,14 @@ function reasonKindFor(stage: MatchStage): string {
 
 /**
  * Map a kind_pairing string ("buddy_seek::buddy_seek", "hike::hike",
- * "commercial_buy::product") to a short user-facing label without
- * leaking the full enum. The label is intentionally generic — the
- * voice line never claims "hiking match" if the kind pairing is
- * something we don't have a friendly word for; it falls back to
- * "match" so we never invent or misclassify the activity.
+ * "commercial_buy::product") to a short user-facing label, or null when
+ * the kind is unknown / absent. NULL signals "no friendly label" — the
+ * renderer then picks a generic sentence template instead of trying to
+ * inject the word "match" into a sentence that already contains
+ * "match" (the original Xm bug: "You have a fresh match match.").
  */
-export function renderKindLabel(kindPairing: string | null): string {
-  if (!kindPairing) return 'match';
+export function renderKindLabel(kindPairing: string | null): string | null {
+  if (!kindPairing) return null;
   const left = String(kindPairing).split('::')[0] || '';
   const known: Record<string, string> = {
     hike: 'hike',
@@ -266,26 +266,42 @@ export function renderKindLabel(kindPairing: string | null): string {
     commercial_buy: 'purchase',
     commercial_sell: 'offer',
   };
-  return known[left] ?? 'match';
+  return known[left] ?? null;
 }
 
 export function renderLine(
   stage: MatchStage,
-  kindLabel: string,
+  kindLabel: string | null,
   lang: string,
 ): string {
   const isDe = (lang || 'en').toLowerCase().startsWith('de');
   if (stage === 'pending_user_decision') {
+    if (kindLabel) {
+      return isDe
+        ? `Es gibt eine Antwort auf deine ${kindLabel}-Anfrage. Willst du entscheiden, wie es weitergeht?`
+        : `Someone has responded to your ${kindLabel} request. Want to decide what's next?`;
+    }
     return isDe
-      ? `Es gibt eine Antwort auf deine ${kindLabel}-Anfrage. Willst du entscheiden, wie es weitergeht?`
-      : `Someone has responded to your ${kindLabel} request. Want to decide what's next?`;
+      ? `Jemand hat auf deine Anfrage geantwortet. Willst du entscheiden, wie es weitergeht?`
+      : `Someone has responded to your request. Want to decide what's next?`;
   }
   if (stage === 'mutual_interest') {
+    if (kindLabel) {
+      return isDe
+        ? `Du hast ein neues gegenseitiges Match auf ${kindLabel}. Sollen wir das Gespräch eröffnen?`
+        : `You have a new mutual ${kindLabel} match. Want to open the conversation?`;
+    }
     return isDe
-      ? `Du hast ein neues gegenseitiges Match auf ${kindLabel}. Sollen wir das Gespräch eröffnen?`
-      : `You have a new mutual ${kindLabel} match. Want to open the conversation?`;
+      ? `Du hast ein neues gegenseitiges Match. Sollen wir das Gespräch eröffnen?`
+      : `You have a new mutual match. Want to open the conversation?`;
+  }
+  // stage === 'new'
+  if (kindLabel) {
+    return isDe
+      ? `Es gibt ein frisches ${kindLabel}-Match für dich. Soll ich es dir vorstellen?`
+      : `You have a fresh ${kindLabel} match. Want me to walk you through it?`;
   }
   return isDe
-    ? `Es gibt ein frisches ${kindLabel}-Match für dich. Soll ich es dir vorstellen?`
-    : `You have a fresh ${kindLabel} match. Want me to walk you through it?`;
+    ? `Es gibt ein frisches Match für dich. Soll ich es dir vorstellen?`
+    : `You have a fresh match. Want me to walk you through it?`;
 }

--- a/services/gateway/src/services/wake-brief-wiring.ts
+++ b/services/gateway/src/services/wake-brief-wiring.ts
@@ -200,9 +200,17 @@ export async function decideWakeBriefForSession(
     [VOICE_WAKE_BRIEF_EXTRA_KEY]: wakeBriefInputs,
   };
   if (args.supabase) {
+    // VTID-03073: forward `lang` so next-action sources render in the
+    // user's language. Before this fix the next-action provider always
+    // received the default 'en' — every source rendered English to
+    // German users since slice Xb. The bug was invisible until the
+    // match source's fallback label collided with its own sentence
+    // template ("fresh match match"), making the English line stick
+    // out next to an otherwise German conversation.
     extra[NEXT_ACTION_EXTRA_KEY] = {
       supabase: args.supabase,
       decisionContext: args.decisionContext ?? null,
+      lang: args.lang,
     };
   }
 

--- a/services/gateway/test/services/assistant-continuation/providers/next-action/match-activity-plan.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/next-action/match-activity-plan.test.ts
@@ -94,24 +94,48 @@ function ctxWith(
 // ---------------------------------------------------------------------------
 
 describe('match-activity-plan pure helpers', () => {
-  test('renderKindLabel — known kinds get a friendly label, unknown stays generic', () => {
+  test('renderKindLabel — known kinds get a friendly label, unknown returns null', () => {
     expect(renderKindLabel('hike::hike')).toBe('hike');
     expect(renderKindLabel('chess::chess')).toBe('chess');
     expect(renderKindLabel('language_exchange::language_exchange')).toBe('language exchange');
     expect(renderKindLabel('buddy_seek::buddy_seek')).toBe('buddy');
     expect(renderKindLabel('commercial_buy::product')).toBe('purchase');
-    expect(renderKindLabel('mystery_kind::other')).toBe('match'); // safe fallback
-    expect(renderKindLabel(null)).toBe('match');
-    expect(renderKindLabel('')).toBe('match');
+    // VTID-03073: unknown / null kinds return null so the renderer can
+    // pick a generic sentence instead of producing "fresh match match".
+    expect(renderKindLabel('mystery_kind::other')).toBeNull();
+    expect(renderKindLabel(null)).toBeNull();
+    expect(renderKindLabel('')).toBeNull();
   });
 
-  test('renderLine — EN + DE for all three stages', () => {
+  test('renderLine — EN + DE for all three stages with a known kind', () => {
     expect(renderLine('pending_user_decision', 'hike', 'en')).toMatch(/responded.+hike/i);
     expect(renderLine('pending_user_decision', 'hike', 'de')).toMatch(/Antwort.+hike/);
     expect(renderLine('mutual_interest', 'chess', 'en')).toMatch(/mutual.+chess/i);
     expect(renderLine('mutual_interest', 'chess', 'de')).toMatch(/gegenseitiges.+chess/);
-    expect(renderLine('new', 'match', 'en')).toMatch(/fresh match/i);
-    expect(renderLine('new', 'match', 'de')).toMatch(/frisches match/i);
+    expect(renderLine('new', 'hike', 'en')).toMatch(/fresh hike match/i);
+    expect(renderLine('new', 'hike', 'de')).toMatch(/frisches hike-Match/i);
+  });
+
+  test('renderLine — generic sentence when kindLabel is null (no "match match" duplication)', () => {
+    // VTID-03073 regression guard: the Xm "match match" bug. When the
+    // kind is unknown the sentence MUST NOT inject the word "match"
+    // twice in any language.
+    const newEn = renderLine('new', null, 'en');
+    const newDe = renderLine('new', null, 'de');
+    const mutEn = renderLine('mutual_interest', null, 'en');
+    const mutDe = renderLine('mutual_interest', null, 'de');
+    const penEn = renderLine('pending_user_decision', null, 'en');
+    const penDe = renderLine('pending_user_decision', null, 'de');
+    for (const line of [newEn, newDe, mutEn, mutDe, penEn, penDe]) {
+      expect(line).not.toMatch(/match match/i);
+      expect(line).not.toMatch(/Match-Match/);
+    }
+    expect(newEn).toMatch(/fresh match/i);
+    expect(newDe).toMatch(/frisches Match/);
+    expect(mutEn).toMatch(/mutual match/i);
+    expect(mutDe).toMatch(/gegenseitiges Match/);
+    expect(penEn).toMatch(/responded to your request/i);
+    expect(penDe).toMatch(/auf deine Anfrage geantwortet/);
   });
 
   test('bandForStage — priority + confidence', () => {

--- a/services/gateway/test/services/assistant-continuation/providers/next-action/skeleton.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/next-action/skeleton.test.ts
@@ -364,4 +364,40 @@ describe('VTID-03056 (Xa) — makeNextActionProvider()', () => {
     expect(NEXT_ACTION_PROVIDER_KEY).toBe('contextual_next_action');
     expect(NEXT_ACTION_EXTRA_KEY).toBe('nextAction');
   });
+
+  // VTID-03073 regression guard: every source's `renderLine` reads
+  // `ctx.lang` to pick EN vs DE. Before this fix the provider's
+  // composer call hardcoded `'en'` because the extras object never
+  // carried `lang` — every wake-brief rendered English to German users
+  // for a week. This test fails fast if the wiring breaks again.
+  test('VTID-03073: ctx.lang is forwarded from extras.lang into composer ctx', async () => {
+    const {
+      defaultNextActionComposer,
+    } = require('../../../../../src/services/assistant-continuation/providers/next-action/composer');
+    defaultNextActionComposer.reset();
+    let observedLang: string | null = null;
+    defaultNextActionComposer.register({
+      key: 'reminder_due',
+      serves: () => true,
+      produce: async (ctx: { lang: string }) => {
+        observedLang = ctx.lang;
+        return { source: 'reminder_due', candidate: null, skippedReason: 'no_data' };
+      },
+    });
+    const provider = makeNextActionProvider({ newId: () => 'fixed-id' });
+    await provider.produce({
+      surface: 'orb_wake',
+      sessionId: 's1',
+      userId: 'u1',
+      tenantId: 't1',
+      extra: {
+        [NEXT_ACTION_EXTRA_KEY]: {
+          supabase: fakeSupabase(),
+          decisionContext: null,
+          lang: 'de',
+        },
+      },
+    });
+    expect(observedLang).toBe('de');
+  });
 });


### PR DESCRIPTION
## Summary

Two bugs surfaced in live German voice testing this morning. The agent said the following to a German-speaking user:

> agent: **You have a fresh match match. Want me to walk you through it?**
> user: i don't understand
> agent: Ich verstehe, Dragan. Was genau verstehst du nicht? […]

Both bugs are mine and both ship in one PR.

## Bug 1 — wrong language (all 9 sources affected, since slice Xb)

The provider's `readInputs` helper in `next-action/index.ts` stripped any `lang` field off the extras object, and the composer call then defaulted to `'en'` for every caller. This has been silently shipping since VTID-03057 (a week ago). The bug was invisible until the match-source landed because the prior fluent English sentences read as a choice, not a defect.

Fix:
- `NextActionInputs` gains `lang?: string`.
- `readInputs` reads `obj.lang` instead of silently dropping it.
- `composer.compose(...)` passes `inputs.lang ?? 'en'` so the fallback is intentional, not accidental.
- `wake-brief-wiring.ts` adds `lang: args.lang` to the NEXT_ACTION extras object.

Regression guard: new `skeleton.test.ts` test asserts the provider forwards `extras.lang` to the composer ctx. If a future refactor strips `lang` again the test fails fast.

## Bug 2 — "match match" duplication (Xm only)

The match-source's `renderKindLabel` returned the literal string `'match'` as the fallback for unknown `kind_pairing` values. `renderLine` then injected it into a sentence template that already contained "match", producing "You have a fresh match match."

Fix:
- `renderKindLabel` now returns `string | null` (null when the kind is unknown or absent).
- `renderLine` branches on `kindLabel === null` and uses a generic sentence template ("a fresh match", "ein frisches Match", etc.) that does NOT inject the word "match" twice.
- New regression-guard test loops every (stage × lang) combo with `kindLabel=null` and asserts the rendered line never contains "match match" or "Match-Match".

## Test plan
- [x] 168 next-action + wake-brief tests green (was 167 + 1 new regression guard + 1 modified pure-helper test)
- [x] `npm run build` green
- [ ] Real-mic re-validation in German after deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)