### PR TITLE
fix(orb-agent): cap user-turn duration at 20s — STT was holding turns open for 170s (VTID-03074)

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -766,12 +766,41 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     if vad_instance is None and not SILERO_AVAILABLE:
         logger.warning("livekit-plugins-silero not installed, no VAD")
 
+    # VTID-03074: turn-handling config. SDK defaults leave
+    # `user_turn_limit.max_duration=None`, which means there is NO hard
+    # wall-clock cap on how long a user turn can stay open. The 2026-05-18
+    # 10:07-10:10 UTC session showed Google STT holding a single user turn
+    # open for 170 seconds — VAD never said "speech ended" so the agent
+    # stayed in `listening`, the model never ran, and from the user's seat
+    # the conversation was dead. (Confirmed by VTID-03050 observability:
+    # one `livekit.stt.metrics` event with audio_duration=170s and zero
+    # `livekit.stt.error` / `availability_changed` events — STT was
+    # "working", just buffering forever.)
+    #
+    # Setting max_duration=20s forces the framework to finalize the turn
+    # after 20 wall-clock seconds regardless of VAD state. Worst case for
+    # a long user utterance: it splits into 20-second chunks, each
+    # processed in order. Far better than 170-second silence.
+    #
+    # Endpointing values are the SDK documented defaults — set explicitly
+    # here so the values are visible in code review rather than implicit
+    # from an upstream library version.
     session_kwargs: dict[str, Any] = {
         "stt": cascade.stt,
         "llm": cascade.llm,
         "tts": cascade.tts,
         "userdata": gw,
         "max_tool_steps": MAX_TOOL_STEPS,
+        "turn_handling": {
+            "endpointing": {
+                "mode": "fixed",
+                "min_delay": 0.5,
+                "max_delay": 3.0,
+            },
+            "user_turn_limit": {
+                "max_duration": 20.0,
+            },
+        },
     }
     if vad_instance is not None:
         session_kwargs["vad"] = vad_instance

--- a/services/agents/orb-agent/tests/test_turn_handling.py
+++ b/services/agents/orb-agent/tests/test_turn_handling.py
@@ -1,0 +1,78 @@
+"""VTID-03074: turn-handling config locked in session_kwargs.
+
+Structural test — asserts the literal config values are present in
+session.py's AgentSession construction. We need this locked because:
+
+- SDK default `user_turn_limit.max_duration=None` is "disabled" — production
+  was running with no hard turn cap and Google STT held a turn open for
+  170 seconds on 2026-05-18, killing the conversation.
+- `max_duration=20.0` is the wall-clock force-finalize threshold. If
+  someone bumps this back to None or removes turn_handling entirely,
+  the regression returns.
+
+Why structural and not hermetic-mock: AgentSession is constructed deep
+inside the 1500-line agent_entrypoint with ~30 dependencies (oasis,
+gateway client, identity resolver, VAD, etc.). Mocking all of those to
+just observe the kwargs would be more fragile than reading the source
+literally. The values that matter are constants; pin them.
+"""
+from __future__ import annotations
+
+import pathlib
+
+
+def _session_src() -> str:
+    return (
+        pathlib.Path(__file__).resolve().parent.parent
+        / "src" / "orb_agent" / "session.py"
+    ).read_text(encoding="utf-8")
+
+
+def test_session_kwargs_includes_turn_handling_block() -> None:
+    """The literal `"turn_handling": {` dict-key MUST appear inside the
+    session_kwargs construction. Without it the SDK defaults take over
+    (which leave user_turn_limit.max_duration=None — the bug)."""
+    src = _session_src()
+    assert "\"turn_handling\":" in src or "'turn_handling':" in src, (
+        "session_kwargs lost its turn_handling block — SDK defaults "
+        "would re-enable the 170-second user-turn buffering bug"
+    )
+
+
+def test_max_duration_explicitly_set_to_20s() -> None:
+    """The 20-second hard cap is the actual fix. Anything else (None,
+    0, a much higher number) re-introduces the conversation-death mode."""
+    src = _session_src()
+    assert "\"max_duration\": 20.0" in src or "'max_duration': 20.0" in src, (
+        "max_duration override missing or changed — must be 20.0s "
+        "to prevent the 170-second-turn regression from VTID-03050 telemetry"
+    )
+
+
+def test_endpointing_block_present_with_documented_defaults() -> None:
+    """We pass min_delay=0.5 and max_delay=3.0 explicitly so the values
+    are visible in code review. They match the SDK documented defaults
+    (livekit-agents voice/turn.py:69-74). If the SDK ever changes its
+    defaults, our agent stays on the values it was tested against."""
+    src = _session_src()
+    assert "\"min_delay\": 0.5" in src or "'min_delay': 0.5" in src
+    assert "\"max_delay\": 3.0" in src or "'max_delay': 3.0" in src
+    assert "\"mode\": \"fixed\"" in src or "'mode': 'fixed'" in src
+
+
+def test_turn_handling_lives_in_agentsession_kwargs_not_update_options() -> None:
+    """Sanity: the config has to land at AgentSession construction time.
+    If someone moves it to a post-start update_options() call we lose the
+    config for the first turn (the one most likely to wedge). Keep it
+    inline with session_kwargs."""
+    src = _session_src()
+    # Find the AgentSession(**session_kwargs) line and assert the
+    # turn_handling block appears BEFORE it in the file.
+    idx_construction = src.find("AgentSession(**session_kwargs)")
+    idx_turn_handling = src.find("\"turn_handling\":")
+    assert idx_construction != -1, "AgentSession(**session_kwargs) line missing"
+    assert idx_turn_handling != -1, "turn_handling key not found in session.py"
+    assert idx_turn_handling < idx_construction, (
+        "turn_handling block must be defined BEFORE the AgentSession() call "
+        "so it lands at construction time, not via update_options() later"
+    )


### PR DESCRIPTION
## The smoking gun

The VTID-03050 STT observability finally landed and immediately gave us this from session 0adc6ff6 at 10:07-10:10 UTC today:

```
livekit.stt.metrics  audio_duration=99s   duration=0s
livekit.stt.metrics  audio_duration=170s  duration=0s
```

Zero livekit.stt.error events. Zero livekit.stt.availability_changed events. **Google STT wasn't failing — it was holding a SINGLE user turn open for 170 wall-clock seconds.** VAD never said 'speech ended', the framework never finalized the turn, the agent stayed in listening, the model never ran. From the user's seat: 2:50 of dead air.

## Root cause

SDK `UserTurnLimitOptions` defaults to `max_duration=None` — **no hard wall-clock cap on user-turn duration**. Combine with a VAD that misclassifies ambient noise + long thinking pauses as 'still speech' and you get unbounded turn buffering.

## Fix

Pass `turn_handling` to AgentSession with `user_turn_limit.max_duration=20.0`. Worst case for genuinely long utterances: they split into 20-second chunks.

## Tests
- 4 new structural tests pin the constants
- 15 existing tests still green

## What this does NOT fix
- The 'fresh match match' cross-talk in your 10:11 transcript — separate proactive-nudge bug, follow-up VTID once we have data
- STT silent-stall at chain level — still possible, but bounded by 20s now

🤖 Generated with [Claude Code](https://claude.com/claude-code)