### PR TITLE
fix(orb-livekit): B0d-real P0 mitigation - pause turn-end + unregister match source (VTID-03075)

### DIFF
--- a/services/gateway/src/routes/voice-next-action-turn-end.ts
+++ b/services/gateway/src/routes/voice-next-action-turn-end.ts
@@ -30,7 +30,10 @@
  * suppress_reason. The agent NEVER blocks the user's turn on this call.
  */
 
+import { randomUUID } from 'crypto';
 import { Router, Response } from 'express';
+import { emitOasisEvent } from '../services/oasis-event-service';
+import { NEXT_ACTION_SUPPRESSED } from '../services/assistant-continuation/telemetry';
 import {
   requireAuthWithTenant,
   AuthenticatedRequest,
@@ -82,76 +85,59 @@ router.post(
         });
       }
 
-      const sb = getSupabase();
-      if (!sb) {
-        return res
-          .status(503)
-          .json({ ok: false, error: 'DB_UNAVAILABLE', vtid: VTID });
-      }
-
-      const body = (req.body ?? {}) as Record<string, unknown>;
-      const lang =
-        typeof body.lang === 'string' && body.lang
-          ? body.lang.toLowerCase().slice(0, 5)
-          : 'en';
-      const decisionContext =
-        body.decisionContext && typeof body.decisionContext === 'object'
-          ? body.decisionContext
-          : null;
-
-      // Run the framework decision on the turn_end surface. We only
-      // populate ctx.extra.nextAction — voice-wake-brief lacks turn-end
-      // inputs and returns `skipped` here. The contextual_next_action
-      // provider serves both surfaces (orb_wake + orb_turn_end).
-      const decision = await decideContinuation({
-        surface: 'orb_turn_end',
-        context: {
-          sessionId: undefined,
-          userId,
-          tenantId,
-          extra: {
-            [NEXT_ACTION_EXTRA_KEY]: {
-              supabase: sb,
-              decisionContext,
-            },
-          },
+      // VTID-03075 (B0d-real P0 mitigation): turn-end next-actions are
+      // PAUSED. Live German testing showed the agent interrupting
+      // active support flows with proactive turn-end nudges that the
+      // LLM had no memory of (spoken with add_to_chat_ctx=False in
+      // orb-agent/session.py) — so when the user said "ja" the agent
+      // answered nonsense. We return a typed suppression here so the
+      // Inspector still sees the request and the lifecycle stays
+      // intact; no candidate is computed and no line is spoken.
+      //
+      // Re-enable ONLY after:
+      //   1. activeContinuation state lands in the LiveKit agent so
+      //      spoken proactive lines join chat context and short-reply
+      //      acceptance ("ja" / "yes" / "okay") is intercepted.
+      //   2. Turn-end suppression rules land (support flow, awaiting
+      //      question, topic mismatch, lang mismatch).
+      //   3. Match-source copy is tightened to suppress on thin
+      //      context instead of firing a generic "frisches Match".
+      const nowIso = new Date().toISOString();
+      const pausedDecisionId = randomUUID();
+      // Emit the suppression to OASIS so the Inspector still sees
+      // turn-end requests during the mitigation window. Fire-and-
+      // forget — mitigation MUST NOT fail because telemetry hiccups.
+      void emitOasisEvent({
+        vtid: VTID,
+        type: NEXT_ACTION_SUPPRESSED as never,
+        source: 'b0d-real-next-action-turn-end',
+        status: 'info',
+        message: 'turn_end_paused_pending_p0',
+        payload: {
+          tenant_id: tenantId,
+          user_id: userId,
+          decision_id: pausedDecisionId,
+          surface: 'orb_turn_end',
+          suppress_reason: 'turn_end_paused_pending_p0',
         },
+        actor_id: userId,
+        actor_role: 'user',
+        surface: 'orb',
+      }).catch(() => {
+        // swallow — mitigation is the contract; telemetry is best-effort.
       });
-
-      // Fire-and-forget OASIS emit (suggested / suppressed). Mirrors
-      // the wake-brief auto-emit so the Inspector sees turn-end events.
-      emitNextActionDecisionTelemetry({
-        decision,
-        userId,
-        tenantId,
-        surface: 'orb_turn_end',
-      });
-
-      const chosen = decision.selectedContinuation;
-      const continuation = chosen
-        ? {
-            user_facing_line: chosen.userFacingLine,
-            kind: chosen.kind,
-            dedupe_key: chosen.dedupeKey,
-            priority: chosen.priority,
-            cta: chosen.cta,
-            evidence: chosen.evidence,
-            privacy_mode: chosen.privacyMode,
-          }
-        : null;
-
       return res.status(200).json({
         ok: true,
         vtid: VTID,
         surface: 'orb_turn_end',
         decision: {
-          decision_id: decision.decisionId,
-          selected_kind: chosen?.kind ?? 'none_with_reason',
-          suppress_reason: decision.suppressionReason ?? null,
-          decision_started_at: decision.decisionStartedAt,
-          decision_finished_at: decision.decisionFinishedAt,
+          decision_id: pausedDecisionId,
+          selected_kind: 'none_with_reason',
+          suppress_reason: 'turn_end_paused_pending_p0',
+          decision_started_at: nowIso,
+          decision_finished_at: nowIso,
         },
-        continuation,
+        continuation: null,
       });
     } catch (err) {
       console.error(`[${VTID}] turn-end route error: ${(err as Error).message}`);

--- a/services/gateway/src/services/assistant-continuation/providers/next-action/register-default-sources.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/next-action/register-default-sources.ts
@@ -64,7 +64,21 @@ export function ensureDefaultNextActionSourcesRegistered(): void {
   // Default behavior (row absent) keeps every source live.
   defaultNextActionComposer.register(withFlagGate(makeReminderDueSource()));
   defaultNextActionComposer.register(withFlagGate(makeCalendarUpcomingSource()));
-  defaultNextActionComposer.register(withFlagGate(makeMatchActivityPlanSource()));
+  // VTID-03075 (B0d-real P0 mitigation): match source temporarily
+  // unregistered. Live German testing showed it interrupting active
+  // support flows with vague match nudges ("Es gibt ein frisches
+  // Match...") and the agent had no way to act on user acceptance
+  // because the spoken line was emitted with add_to_chat_ctx=False
+  // in session.py — the LLM had no record of the offer, so "ja"
+  // produced unrelated answers. Re-register only after:
+  //   1. activeContinuation state lands in the LiveKit agent
+  //      (orb-agent/session.py) so spoken proactive lines join chat
+  //      context and short-reply acceptance is intercepted.
+  //   2. Turn-end suppression rules land in the gateway (support flow,
+  //      awaiting question, topic mismatch, lang mismatch).
+  //   3. Match-source copy is tightened so generic "frisches Match"
+  //      suppresses instead of firing on thin context.
+  // defaultNextActionComposer.register(withFlagGate(makeMatchActivityPlanSource()));
   defaultNextActionComposer.register(withFlagGate(makeAutopilotRecommendationSource()));
   defaultNextActionComposer.register(withFlagGate(makeContinuityPromiseOwedSource()));
   defaultNextActionComposer.register(withFlagGate(makeDiaryMissingRelevantSource()));

--- a/services/gateway/test/routes/voice-next-action-turn-end.test.ts
+++ b/services/gateway/test/routes/voice-next-action-turn-end.test.ts
@@ -68,7 +68,7 @@ describe('VTID-03064 — POST /api/v1/voice/next-action/turn-end', () => {
     currentIdentity = FIXED_IDENTITY;
   });
 
-  it('returns 200 + continuation:null when no source qualifies (all empty)', async () => {
+  it('VTID-03075 mitigation: returns suppress_reason=turn_end_paused_pending_p0 unconditionally', async () => {
     const app = buildApp();
     const res = await request(app)
       .post('/api/v1/voice/next-action/turn-end')
@@ -78,8 +78,8 @@ describe('VTID-03064 — POST /api/v1/voice/next-action/turn-end', () => {
     expect(res.body.surface).toBe('orb_turn_end');
     expect(res.body.continuation).toBeNull();
     expect(res.body.decision.selected_kind).toBe('none_with_reason');
-    // Composer suppressed because all sources returned empty.
-    expect(res.body.decision.suppress_reason).toBeTruthy();
+    expect(res.body.decision.suppress_reason).toBe('turn_end_paused_pending_p0');
+    expect(typeof res.body.decision.decision_id).toBe('string');
   });
 
   it('returns 401 when identity is missing', async () => {
@@ -100,18 +100,17 @@ describe('VTID-03064 — POST /api/v1/voice/next-action/turn-end', () => {
     expect(res.status).toBe(200);
   });
 
-  it('emits OASIS suppressed when the composer suppresses', async () => {
+  it('VTID-03075 mitigation: emits orb.livekit.next_action.suppressed with paused reason', async () => {
     const app = buildApp();
     await request(app)
       .post('/api/v1/voice/next-action/turn-end')
       .send({ lang: 'en' });
     // Best-effort + microtask-flushed.
     return Promise.resolve().then(() => {
-      const topics = emitMock.mock.calls.map((c) => (c[0] as { type?: string })?.type);
-      // At least one of next_action.* fires; suppressed when no source.
-      expect(
-        topics.some((t) => typeof t === 'string' && t.startsWith('orb.livekit.next_action.')),
-      ).toBe(true);
+      const calls = emitMock.mock.calls.map((c) => c[0] as { type?: string; message?: string });
+      const suppressed = calls.find((c) => c?.type === 'orb.livekit.next_action.suppressed');
+      expect(suppressed).toBeDefined();
+      expect(suppressed?.message).toBe('turn_end_paused_pending_p0');
     });
   });
 });


### PR DESCRIPTION
## Summary — STOP THE BLEEDING

Live German testing exposed two failure modes that the earlier lang/copy fix (PR #2220) did NOT solve:

1. **Turn-end nudges fire during active support flows.** The user was troubleshooting; the agent injected "fresh match" mid-conversation.
2. **Proactive lines are spoken with `add_to_chat_ctx=False`** in `orb-agent/session.py` so the LLM has no memory of having said them. When the user replies "ja", the LLM falls back on whatever is in `system_instruction` (Vitanaland in our case) and produces an unrelated answer. The user then asks "what did you just say?" and the agent denies saying it.

The root-cause work lands in follow-up slices. **This PR is the mitigation that stops the bleeding.**

## Changes

| File | Effect |
|---|---|
| `register-default-sources.ts` | `makeMatchActivityPlanSource` commented out (not deleted). One-line uncomment to re-enable. |
| `voice-next-action-turn-end.ts` | `POST /voice/next-action/turn-end` short-circuits to `suppress_reason='turn_end_paused_pending_p0'`. Emits `orb.livekit.next_action.suppressed` to OASIS so the Inspector keeps visibility. |

## What still fires

- Wake-brief at `orb_wake` for the 7 remaining sources (reminder / calendar / autopilot / promise / diary / thread / life-compass / pillar). This was the original B0d-mini behavior and not the source of the chaos.

## P0 follow-ups (NOT this PR)

| Slice | Repo | Scope |
|---|---|---|
| Suppression rules | gateway | support-flow / awaiting-answer / tool-failure / topic-mismatch / lang-mismatch gates before any next-action |
| Match copy tightening | gateway | suppress on thin context instead of generic "frisches Match" |
| activeContinuation state | orb-agent (Python) | join chat ctx; intercept "ja"/"yes"/"okay"; answer "was hast du gerade gesagt?" from state |

## Hold the line

- Do not tune priorities.
- Do not expand canary.
- Do not continue behavior validation until P0 fixes land.

## Test plan
- [x] New mitigation test asserts `suppress_reason='turn_end_paused_pending_p0'` + OASIS event
- [x] 24 turn-end + match-source tests green
- [x] Full gateway build green
- [ ] Post-deploy verification: replay the George Michael transcript → no match nudge, no English in DE session

🤖 Generated with [Claude Code](https://claude.com/claude-code)