### PR TITLE
feat(orb-agent + test-bench): silent-stall detection + reconnect banner + audio chime (VTID-03075)

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/oasis.py
+++ b/services/agents/orb-agent/src/orb_agent/oasis.py
@@ -162,3 +162,13 @@ TOPIC_AGENT_TURN_MEASURED = "orb.livekit.agent.turn.measured"
 TOPIC_STT_ERROR = "livekit.stt.error"                           # SDK ErrorEvent from STT/LLM/TTS, source-typed
 TOPIC_STT_AVAILABILITY_CHANGED = "livekit.stt.availability_changed"  # FallbackAdapter swap or recovery
 TOPIC_STT_METRICS = "livekit.stt.metrics"                       # metrics_collected from STT subsystem
+
+# VTID-03075: agent-level silent-stall detection. Fires when VAD reports
+# user_state_changed → "speaking" but no `user_input_transcribed` event
+# appears within SILENT_STALL_THRESHOLD_S seconds. The cascade
+# FallbackAdapter can't help — it swaps on errors only, and the silent-buffer
+# failure produces none. Pairs with a `client.alert.show` data message
+# published into the LiveKit room so the Test Bench frontend can render a
+# "Hold on, reconnecting…" banner + an audio chime mirroring Vertex's
+# INSTANT-FEEDBACK behavior.
+TOPIC_STT_SILENT_STALL = "livekit.stt.silent_stall"

--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -53,6 +53,7 @@ from .oasis import (
     TOPIC_STT_AVAILABILITY_CHANGED,
     TOPIC_STT_ERROR,
     TOPIC_STT_METRICS,
+    TOPIC_STT_SILENT_STALL,
     OasisEmitter,
 )
 from .providers import build_cascade
@@ -766,41 +767,19 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     if vad_instance is None and not SILERO_AVAILABLE:
         logger.warning("livekit-plugins-silero not installed, no VAD")
 
-    # VTID-03074: turn-handling config. SDK defaults leave
-    # `user_turn_limit.max_duration=None`, which means there is NO hard
-    # wall-clock cap on how long a user turn can stay open. The 2026-05-18
-    # 10:07-10:10 UTC session showed Google STT holding a single user turn
-    # open for 170 seconds — VAD never said "speech ended" so the agent
-    # stayed in `listening`, the model never ran, and from the user's seat
-    # the conversation was dead. (Confirmed by VTID-03050 observability:
-    # one `livekit.stt.metrics` event with audio_duration=170s and zero
-    # `livekit.stt.error` / `availability_changed` events — STT was
-    # "working", just buffering forever.)
-    #
-    # Setting max_duration=20s forces the framework to finalize the turn
-    # after 20 wall-clock seconds regardless of VAD state. Worst case for
-    # a long user utterance: it splits into 20-second chunks, each
-    # processed in order. Far better than 170-second silence.
-    #
-    # Endpointing values are the SDK documented defaults — set explicitly
-    # here so the values are visible in code review rather than implicit
-    # from an upstream library version.
+    # VTID-03075: the `turn_handling.user_turn_limit.max_duration=20.0` cap
+    # shipped in VTID-03074 was a no-op for the 170-second STT-buffer bug.
+    # Per livekit-agents source (audio_recognition.py _check_user_turn_limit,
+    # called only on FINAL transcripts), the cap only triggers AFTER a
+    # transcript event arrives — which means it cannot fire DURING the
+    # silent-buffer window. Removed; real detection lives in the
+    # silent-stall watchdog wired further down in this file.
     session_kwargs: dict[str, Any] = {
         "stt": cascade.stt,
         "llm": cascade.llm,
         "tts": cascade.tts,
         "userdata": gw,
         "max_tool_steps": MAX_TOOL_STEPS,
-        "turn_handling": {
-            "endpointing": {
-                "mode": "fixed",
-                "min_delay": 0.5,
-                "max_delay": 3.0,
-            },
-            "user_turn_limit": {
-                "max_duration": 20.0,
-            },
-        },
     }
     if vad_instance is not None:
         session_kwargs["vad"] = vad_instance
@@ -1258,10 +1237,9 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     except Exception as exc:  # noqa: BLE001
         logger.debug("could not hook agent_state_changed: %s", exc)
 
-    try:
-        session.on("user_state_changed")(lambda _ev=None: stall.feed())  # type: ignore[misc]
-    except Exception as exc:  # noqa: BLE001
-        logger.debug("could not hook user_state_changed: %s", exc)
+    # VTID-03075: the user_state_changed handler is wired below by
+    # _record_user_state (does what this lambda did + records VAD
+    # speaking-start timestamp for the silent-stall watchdog).
 
     # VTID-03001: conversation_item_added fires whenever something is
     # appended to chat_ctx — LLM responses, tool calls, etc. If we see
@@ -1551,12 +1529,151 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     except Exception as exc:  # noqa: BLE001
         logger.debug("could not hook stt_availability_changed: %s", exc)
 
+    # ------------------------------------------------------------------
+    # VTID-03075: SILENT-STALL WATCHDOG. Cascade FallbackAdapter only
+    # advances on STT errors. Production telemetry (2026-05-18 10:07-10:10
+    # UTC: livekit.stt.metrics with audio_duration=170s, zero error/
+    # availability events) proved Google STT can silently buffer minutes
+    # of audio without raising. From the user's seat: agent in `listening`
+    # forever, no response, dead conversation, 5-10s tolerance.
+    #
+    # This watchdog watches for: user_state_changed → "speaking" without
+    # a `user_input_transcribed` event for SILENT_STALL_THRESHOLD_S. On
+    # detection:
+    #   (a) emit `livekit.stt.silent_stall` oasis (telemetry)
+    #   (b) publish a `client.alert.show` data message into the LiveKit
+    #       room so the frontend can paint a "Hold on, reconnecting…"
+    #       banner + audio chime (Vertex INSTANT-FEEDBACK parity).
+    #
+    # ACTUAL STT recovery (forcing FallbackAdapter to swap) is NOT in
+    # this PR — needs telemetry from this watchdog firing in real sessions
+    # before picking the recovery primitive (custom FallbackAdapter
+    # subclass with stream-idle detection, or AgentSession restart).
+    # Today's value: user immediately sees "we know it's broken" instead
+    # of "dead for 3 minutes."
+    # ------------------------------------------------------------------
+    SILENT_STALL_THRESHOLD_S = 3.0
+    SILENT_STALL_REPEAT_S = 8.0  # rate-limit: one alert per window
+
+    stall_state: dict[str, Any] = {
+        "user_speaking_since": None,   # monotonic when VAD → speaking, None when transcript fires or VAD → listening
+        "last_transcript_at": time.monotonic(),
+        "last_alert_at": 0.0,
+    }
+
+    async def _publish_client_alert(reason: str, detail: str | None = None) -> None:
+        """Send a JSON data-message to the LiveKit room so the frontend
+        can paint a banner + play a chime. Best-effort; agent must not
+        crash if publish_data isn't available on this SDK version."""
+        try:
+            room = getattr(ctx, "room", None)
+            lp = getattr(room, "local_participant", None) if room is not None else None
+            if lp is None:
+                return
+            payload = json.dumps({
+                "type": "client.alert.show",
+                "reason": reason,
+                "detail": detail,
+                "timestamp_ms": int(time.time() * 1000),
+            }).encode("utf-8")
+            pub = getattr(lp, "publish_data", None)
+            if callable(pub):
+                res = pub(payload, topic="orb_alert")
+                if asyncio.iscoroutine(res):
+                    await res
+        except Exception as exc:  # noqa: BLE001
+            logger.debug("publish_client_alert(%s) failed: %s", reason, exc)
+
+    def _record_user_state(ev: Any = None) -> None:
+        """Replaces the old `user_state_changed` lambda. Feeds the stall
+        watchdog (preserves VTID-02854 behavior) AND records VAD
+        speaking-start so the silent-stall checker can measure
+        VAD-speech-without-transcript wall-clock time."""
+        stall.feed()
+        try:
+            new_state = getattr(ev, "new_state", None)
+        except Exception:  # noqa: BLE001
+            new_state = None
+        if new_state == "speaking":
+            stall_state["user_speaking_since"] = time.monotonic()
+        elif new_state in ("listening", "away", None):
+            stall_state["user_speaking_since"] = None
+
+    try:
+        session.on("user_state_changed")(_record_user_state)  # type: ignore[misc]
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("could not hook user_state_changed for silent-stall: %s", exc)
+
+    def _on_transcript_for_stall(_ev: Any = None) -> None:
+        stall_state["last_transcript_at"] = time.monotonic()
+        stall_state["user_speaking_since"] = None  # turn closed cleanly
+
+    try:
+        session.on("user_input_transcribed")(_on_transcript_for_stall)  # type: ignore[misc]
+    except Exception as exc:  # noqa: BLE001
+        logger.debug("could not hook user_input_transcribed for stall-state: %s", exc)
+
+    async def _silent_stall_watchdog() -> None:
+        """Poll every 1s. If user has been in `speaking` for
+        ≥SILENT_STALL_THRESHOLD_S without a transcript, fire the alert.
+        Rate-limited by SILENT_STALL_REPEAT_S so one long stall doesn't
+        spam the client."""
+        while True:
+            try:
+                await asyncio.sleep(1.0)
+                started = stall_state.get("user_speaking_since")
+                if started is None:
+                    continue
+                now = time.monotonic()
+                speaking_for = now - started
+                if speaking_for < SILENT_STALL_THRESHOLD_S:
+                    continue
+                last_alert = stall_state.get("last_alert_at") or 0.0
+                if (now - last_alert) < SILENT_STALL_REPEAT_S:
+                    continue
+                stall_state["last_alert_at"] = now
+                asyncio.create_task(
+                    oasis.emit(
+                        topic=TOPIC_STT_SILENT_STALL,
+                        payload={
+                            "user_id": identity.user_id,
+                            "orb_session_id": orb_session_id,
+                            "speaking_for_s": round(speaking_for, 2),
+                            "since_last_transcript_s": round(
+                                now - (stall_state.get("last_transcript_at") or now), 2
+                            ),
+                            "threshold_s": SILENT_STALL_THRESHOLD_S,
+                        },
+                    )
+                )
+                await _publish_client_alert(
+                    reason="stt_silent_stall",
+                    detail=f"speaking_for={round(speaking_for, 1)}s",
+                )
+            except asyncio.CancelledError:
+                raise
+            except Exception as exc:  # noqa: BLE001
+                logger.debug("silent_stall_watchdog tick error: %s", exc)
+
+    _silent_stall_task: asyncio.Task[None] | None = None
+    try:
+        _silent_stall_task = asyncio.create_task(_silent_stall_watchdog())
+    except Exception as exc:  # noqa: BLE001
+        logger.warning("could not start silent-stall watchdog: %s", exc)
+
     # Stop the watchdog when the room disconnects so we don't leak the task.
     async def _stop_stall_on_shutdown() -> None:
         try:
             await stall.stop()
         except Exception:  # noqa: BLE001
             pass
+        # VTID-03075: also tear down the silent-stall watchdog.
+        if _silent_stall_task is not None and not _silent_stall_task.done():
+            _silent_stall_task.cancel()
+            try:
+                await _silent_stall_task
+            except (asyncio.CancelledError, Exception):  # noqa: BLE001
+                pass
 
     ctx.add_shutdown_callback(_stop_stall_on_shutdown)
 

--- a/services/agents/orb-agent/tests/test_silent_stall_watchdog.py
+++ b/services/agents/orb-agent/tests/test_silent_stall_watchdog.py
@@ -1,0 +1,87 @@
+"""VTID-03075: silent-stall watchdog structural + constant tests.
+
+The runtime behavior of the watchdog (asyncio.Task polling
+stall_state every 1s, firing oasis emit + publish_data on a
+3-second threshold) is hard to unit-test hermetically without
+booting a real LiveKit room. These tests pin the OBSERVABLE
+contract instead:
+
+  1. The new oasis topic exists with the exact gateway-allowlisted
+     string `livekit.stt.silent_stall`.
+  2. session.py imports the topic + registers the user_state_changed
+     handler + creates the watchdog asyncio.Task + tears it down.
+  3. The 3-second threshold constant is set to 3.0s (the user said
+     5-10s is their tolerance; 3s leaves recovery budget under that).
+
+Behavior smoke tests live in real LiveKit sessions; pull from
+`oasis_events` after a real conversation.
+"""
+from __future__ import annotations
+
+import pathlib
+
+
+def _session_src() -> str:
+    return (
+        pathlib.Path(__file__).resolve().parent.parent
+        / "src" / "orb_agent" / "session.py"
+    ).read_text(encoding="utf-8")
+
+
+def test_silent_stall_topic_exact_string() -> None:
+    """The gateway oasis-emit allowlist accepts `livekit.` prefix.
+    The CicdEventType union expects this exact string. Pin it."""
+    from src.orb_agent.oasis import TOPIC_STT_SILENT_STALL
+    assert TOPIC_STT_SILENT_STALL == "livekit.stt.silent_stall"
+
+
+def test_session_imports_silent_stall_topic() -> None:
+    """session.py must import TOPIC_STT_SILENT_STALL from oasis or the
+    watchdog can't emit. Structural — small fast guard against a stray
+    refactor stripping the import."""
+    src = _session_src()
+    assert "TOPIC_STT_SILENT_STALL" in src, (
+        "session.py is no longer importing TOPIC_STT_SILENT_STALL — the "
+        "silent-stall watchdog can't emit telemetry without it"
+    )
+
+
+def test_threshold_set_to_3_seconds() -> None:
+    """3s detection window. The user said: 'all of that happens within
+    the time frame of maybe 5 seconds, maximum 10'. Detection at 3s
+    leaves 7s of remaining budget for the agent to recover before the
+    user gives up and disconnects."""
+    src = _session_src()
+    assert "SILENT_STALL_THRESHOLD_S = 3.0" in src, (
+        "silent-stall detection threshold drifted from 3.0s — that breaks "
+        "the user-tolerance budget (5-10s before they disconnect)"
+    )
+
+
+def test_record_user_state_replaces_lambda() -> None:
+    """The old `user_state_changed`-feeds-stall lambda was replaced by
+    `_record_user_state` so we ALSO record the VAD-speaking-start
+    timestamp. If someone reverts to the lambda the watchdog can never
+    fire (no speaking_since recorded)."""
+    src = _session_src()
+    assert "_record_user_state" in src
+    # The lambda form must NOT exist anymore.
+    assert "lambda _ev=None: stall.feed())" not in src, (
+        "lambda form of user_state_changed re-introduced — the watchdog "
+        "loses its 'user is currently speaking' input"
+    )
+
+
+def test_publish_client_alert_publishes_orb_alert_topic() -> None:
+    """Publish path uses `topic='orb_alert'` so the Test Bench frontend
+    can disambiguate it from orb_directive / transcript messages."""
+    src = _session_src()
+    assert "topic=\"orb_alert\"" in src or "topic='orb_alert'" in src
+
+
+def test_watchdog_task_torn_down_on_shutdown() -> None:
+    """The asyncio.Task must be cancelled in the shutdown callback so a
+    long-running agent process doesn't leak tasks across sessions."""
+    src = _session_src()
+    assert "_silent_stall_task" in src
+    assert "_silent_stall_task.cancel()" in src

--- a/services/agents/orb-agent/tests/test_turn_handling.py
+++ b/services/agents/orb-agent/tests/test_turn_handling.py
@@ -1,20 +1,14 @@
-"""VTID-03074: turn-handling config locked in session_kwargs.
+"""VTID-03075: VTID-03074's turn_handling/max_duration block was a no-op.
 
-Structural test — asserts the literal config values are present in
-session.py's AgentSession construction. We need this locked because:
+Per livekit-agents source (voice/audio_recognition.py
+_check_user_turn_limit), the SDK only checks max_duration AFTER a final
+transcript arrives. That cannot help when STT silently buffers audio
+without producing transcripts — exactly the 170-second bug VTID-03074
+claimed to fix.
 
-- SDK default `user_turn_limit.max_duration=None` is "disabled" — production
-  was running with no hard turn cap and Google STT held a turn open for
-  170 seconds on 2026-05-18, killing the conversation.
-- `max_duration=20.0` is the wall-clock force-finalize threshold. If
-  someone bumps this back to None or removes turn_handling entirely,
-  the regression returns.
-
-Why structural and not hermetic-mock: AgentSession is constructed deep
-inside the 1500-line agent_entrypoint with ~30 dependencies (oasis,
-gateway client, identity resolver, VAD, etc.). Mocking all of those to
-just observe the kwargs would be more fragile than reading the source
-literally. The values that matter are constants; pin them.
+The actual detection now lives in the silent-stall watchdog (see
+test_silent_stall_watchdog.py). These structural assertions just lock
+in the REMOVAL of the dead config so it doesn't sneak back in.
 """
 from __future__ import annotations
 
@@ -28,51 +22,24 @@ def _session_src() -> str:
     ).read_text(encoding="utf-8")
 
 
-def test_session_kwargs_includes_turn_handling_block() -> None:
-    """The literal `"turn_handling": {` dict-key MUST appear inside the
-    session_kwargs construction. Without it the SDK defaults take over
-    (which leave user_turn_limit.max_duration=None — the bug)."""
+def test_turn_handling_block_removed_from_session_kwargs() -> None:
+    """`turn_handling` MUST NOT appear inside session_kwargs. The block
+    we shipped in VTID-03074 was a no-op. If it comes back, reviewers
+    should reject the PR."""
     src = _session_src()
-    assert "\"turn_handling\":" in src or "'turn_handling':" in src, (
-        "session_kwargs lost its turn_handling block — SDK defaults "
-        "would re-enable the 170-second user-turn buffering bug"
+    assert "\"turn_handling\":" not in src, (
+        "turn_handling block re-introduced — VTID-03074 was a no-op for "
+        "silent-buffer bugs (SDK checks max_duration only after a final "
+        "transcript event, which never arrives during the bug). Detection "
+        "lives in the silent-stall watchdog instead."
     )
 
 
-def test_max_duration_explicitly_set_to_20s() -> None:
-    """The 20-second hard cap is the actual fix. Anything else (None,
-    0, a much higher number) re-introduces the conversation-death mode."""
+def test_max_duration_dict_literal_not_present_in_session_kwargs() -> None:
+    """No `"max_duration": 20.0` (the VTID-03074 dead value). It would
+    only resurface inside a fresh turn_handling block — the test above
+    catches that case too, but pin the literal explicitly so the failure
+    message points at the right thing."""
     src = _session_src()
-    assert "\"max_duration\": 20.0" in src or "'max_duration': 20.0" in src, (
-        "max_duration override missing or changed — must be 20.0s "
-        "to prevent the 170-second-turn regression from VTID-03050 telemetry"
-    )
-
-
-def test_endpointing_block_present_with_documented_defaults() -> None:
-    """We pass min_delay=0.5 and max_delay=3.0 explicitly so the values
-    are visible in code review. They match the SDK documented defaults
-    (livekit-agents voice/turn.py:69-74). If the SDK ever changes its
-    defaults, our agent stays on the values it was tested against."""
-    src = _session_src()
-    assert "\"min_delay\": 0.5" in src or "'min_delay': 0.5" in src
-    assert "\"max_delay\": 3.0" in src or "'max_delay': 3.0" in src
-    assert "\"mode\": \"fixed\"" in src or "'mode': 'fixed'" in src
-
-
-def test_turn_handling_lives_in_agentsession_kwargs_not_update_options() -> None:
-    """Sanity: the config has to land at AgentSession construction time.
-    If someone moves it to a post-start update_options() call we lose the
-    config for the first turn (the one most likely to wedge). Keep it
-    inline with session_kwargs."""
-    src = _session_src()
-    # Find the AgentSession(**session_kwargs) line and assert the
-    # turn_handling block appears BEFORE it in the file.
-    idx_construction = src.find("AgentSession(**session_kwargs)")
-    idx_turn_handling = src.find("\"turn_handling\":")
-    assert idx_construction != -1, "AgentSession(**session_kwargs) line missing"
-    assert idx_turn_handling != -1, "turn_handling key not found in session.py"
-    assert idx_turn_handling < idx_construction, (
-        "turn_handling block must be defined BEFORE the AgentSession() call "
-        "so it lands at construction time, not via update_options() later"
-    )
+    assert "\"max_duration\": 20.0" not in src
+    assert "'max_duration': 20.0" not in src

--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -35524,6 +35524,18 @@ function renderLivekitTestView() {
         + '<div><span style="color:#94a3b8;font-size:11px;">AGENT SPEAKING</span><br><span class="lkt-speaking" style="color:#facc15;font-weight:bold;">no</span></div>';
     container.appendChild(statusPanel);
 
+    // VTID-03075: reconnect banner. Painted when the agent publishes a
+    // `client.alert.show` data message on the `orb_alert` topic — fired
+    // today by the silent-stall watchdog when VAD says user-speaking but
+    // no transcript arrives within 3s. Mirrors Vertex's connection_alert
+    // path; without this the user sees a frozen UI for minutes while STT
+    // silently buffers.
+    var reconnectBanner = document.createElement('div');
+    reconnectBanner.className = 'lkt-reconnect-banner';
+    reconnectBanner.style.cssText = 'display:none;padding:10px 14px;background:#7c2d12;color:#fff;border-radius:6px;margin-bottom:12px;font-size:13px;font-weight:bold;border:1px solid #f97316;';
+    reconnectBanner.textContent = '⏳ Hold on a second, reconnecting…';
+    container.appendChild(reconnectBanner);
+
     // VTID-02996: live mic level meter + audio-autoplay-block recovery +
     // mic-permission banner. The page used to show "MIC: on" the moment
     // setMicrophoneEnabled resolved, even if the OS-level permission was
@@ -36836,12 +36848,83 @@ function renderLivekitTestView() {
                 });
             }
 
+            // VTID-03075: reconnect chime — C5 → E5 ascending two-tone, 400ms
+            // total. Same notes / duration / envelope as Vertex's INSTANT-FEEDBACK
+            // PCM chime (orb-live.ts:1342-1396) so the audio cue feels identical
+            // across providers. Generated on demand via WebAudio API — no MP3
+            // asset, no server PCM publishing.
+            function playReconnectChime() {
+                try {
+                    var AC = window.AudioContext || window.webkitAudioContext;
+                    if (!AC) return;
+                    if (!window._lktChimeCtx) window._lktChimeCtx = new AC();
+                    var ctx = window._lktChimeCtx;
+                    if (ctx.state === 'suspended') { try { ctx.resume(); } catch (_) {} }
+                    var now = ctx.currentTime;
+                    // Tone 1: C5 (523.25Hz) 0-150ms, fade in/out.
+                    var o1 = ctx.createOscillator();
+                    var g1 = ctx.createGain();
+                    o1.frequency.value = 523.25;
+                    g1.gain.setValueAtTime(0, now);
+                    g1.gain.linearRampToValueAtTime(0.18, now + 0.02);
+                    g1.gain.linearRampToValueAtTime(0.18, now + 0.08);
+                    g1.gain.linearRampToValueAtTime(0, now + 0.15);
+                    o1.connect(g1).connect(ctx.destination);
+                    o1.start(now); o1.stop(now + 0.16);
+                    // Tone 2: E5 (659.25Hz) 150-400ms, fade in/out.
+                    var o2 = ctx.createOscillator();
+                    var g2 = ctx.createGain();
+                    o2.frequency.value = 659.25;
+                    g2.gain.setValueAtTime(0, now + 0.15);
+                    g2.gain.linearRampToValueAtTime(0.18, now + 0.17);
+                    g2.gain.linearRampToValueAtTime(0.18, now + 0.25);
+                    g2.gain.linearRampToValueAtTime(0, now + 0.40);
+                    o2.connect(g2).connect(ctx.destination);
+                    o2.start(now + 0.15); o2.stop(now + 0.41);
+                } catch (e) { log('warn', 'playReconnectChime failed', { error: String(e) }); }
+            }
+
+            // VTID-03075: banner show/hide. Auto-hides after 6s OR when the
+            // next transcript arrives (sign of recovery).
+            var _bannerHideTimer = null;
+            function showReconnectBanner(reason, detail) {
+                try {
+                    if (reconnectBanner) {
+                        reconnectBanner.textContent = '⏳ Hold on a second, reconnecting…' + (detail ? ' (' + detail + ')' : '');
+                        reconnectBanner.style.display = 'block';
+                    }
+                    playReconnectChime();
+                    if (_bannerHideTimer) clearTimeout(_bannerHideTimer);
+                    _bannerHideTimer = setTimeout(function () {
+                        if (reconnectBanner) reconnectBanner.style.display = 'none';
+                        _bannerHideTimer = null;
+                    }, 6000);
+                } catch (e) { log('warn', 'showReconnectBanner failed', { error: String(e) }); }
+            }
+            function hideReconnectBanner() {
+                if (reconnectBanner) reconnectBanner.style.display = 'none';
+                if (_bannerHideTimer) { clearTimeout(_bannerHideTimer); _bannerHideTimer = null; }
+            }
+
             room.on(LivekitClient.RoomEvent.DataReceived, function (payload, _participant, _kind, topic) {
                 try {
                     var msg = JSON.parse(new TextDecoder().decode(payload));
                     log('event', 'DataReceived', msg);
-                    if (msg.type === 'transcript') appendTranscript(msg.is_user ? 'user' : 'agent', String(msg.text || ''));
+                    if (msg.type === 'transcript') {
+                        appendTranscript(msg.is_user ? 'user' : 'agent', String(msg.text || ''));
+                        // VTID-03075: any transcript = STT recovered (or never stuck). Drop the banner.
+                        hideReconnectBanner();
+                    }
                     if (msg.type === 'tool_call') log('event', 'tool_call', msg);
+                    // VTID-03075: agent-published client alert on the `orb_alert` topic.
+                    // Today's reason: stt_silent_stall. Future reasons (connection_recovering,
+                    // etc.) ride the same channel.
+                    if (msg.type === 'client.alert.show' && (topic === 'orb_alert' || !topic)) {
+                        showReconnectBanner(msg.reason, msg.detail);
+                    }
+                    if (msg.type === 'client.alert.hide') {
+                        hideReconnectBanner();
+                    }
                     // PR 1.B-0 — orb_directive: the agent publishes structured payloads on
                     // the data channel (topic='orb_directive') so the page can react out-of-band
                     // the same way the SSE/WS branch does on Vertex. Currently 2 directive

--- a/services/gateway/src/types/cicd.ts
+++ b/services/gateway/src/types/cicd.ts
@@ -579,6 +579,12 @@ export type CicdEventType =
   | 'livekit.stt.error'
   | 'livekit.stt.availability_changed'
   | 'livekit.stt.metrics'
+  // VTID-03075: silent-stall detection. Fires when VAD reports
+  // user_state_changed → "speaking" but no user_input_transcribed
+  // arrives within 3 seconds. Pairs with a `client.alert.show` data
+  // message published to the LiveKit room so the Test Bench shows
+  // "Hold on, reconnecting…" + plays a chime.
+  | 'livekit.stt.silent_stall'
   // VTID-DIAG: Pipeline diagnostics
   | 'orb.live.diag'
   // VTID-FALLBACK: Chat-TTS fallback events


### PR DESCRIPTION
## Replaces VTID-03074

VTID-03074 was a no-op. The SDK's max_duration only triggers AFTER a final transcript arrives — it cannot fire during the silent-buffer window. This PR removes the dead config and ships the actual detection + immediate user feedback.

## What's new

**Agent (session.py + oasis.py)**
- Silent-stall watchdog: listens to user_state_changed → speaking, polls every 1s, fires if 3s elapse without user_input_transcribed
- On detection: emits livekit.stt.silent_stall oasis event + publishes a client.alert.show data message on the orb_alert topic
- Rate-limited (1 alert per 8s window)
- Task cancelled on shutdown

**Test Bench (app.js)**
- New reconnect banner: '⏳ Hold on a second, reconnecting…' below the status panel
- WebAudio chime (C5 → E5, 400ms) matching Vertex's INSTANT-FEEDBACK PCM chime
- DataReceived handler renders banner + plays chime on client.alert.show
- Banner auto-hides after 6s OR on next transcript

**Gateway types (cicd.ts)**
- Adds livekit.stt.silent_stall to CicdEventType (type hygiene; runtime allowlist already accepts livekit.* prefix)

## What this does NOT do
Forcing the FallbackAdapter to actually swap to mirror/Deepgram is a separate problem (needs custom adapter subclass or AgentSession restart). This PR is the detection + user-feedback layer. We pick the recovery primitive after we have telemetry showing the watchdog firing on real failures.

## User-tolerance math
User stated 5-10s before they disconnect. Detection at 3s = 7s remaining budget. Banner + chime within those 3s = user sees 'we know it's broken' instead of 'frozen for 3 minutes'.

## Tests (23/23 green)
- test_turn_handling.py rewritten: pins the REMOVAL of VTID-03074 dead config
- test_silent_stall_watchdog.py NEW: 6 tests pin topic string, threshold, publish-topic, wiring, shutdown
- test_stt_observability.py (4/4) + test_stt_fallback.py (11/11) unchanged

🤖 Generated with [Claude Code](https://claude.com/claude-code)