### PR TITLE
fix(notifications): path-based chat deep-link so Appilix WebView can open it

### DIFF
--- a/services/gateway/src/routes/chat.ts
+++ b/services/gateway/src/routes/chat.ts
@@ -128,7 +128,12 @@ router.post('/send', requireAuth, requireTenant, async (req: Request, res: Respo
           sender_name: senderName,
           message_id: data.id,
           thread_id: identity.user_id,
-          url: `/inbox?recipient=${identity.user_id}&context=global`,
+          // Path-based deep-link — query-string form (?recipient=…&context=global)
+          // silently fails in Appilix's Android in-app browser when launched from
+          // a notification tap (confirmed via BOOTSTRAP-NOTIF-MESSENGER-DIAG:
+          // diagnostic beacon never fired, no Cloud Run hit recorded). Path form
+          // launches cleanly because the URL has no special characters.
+          url: `/inbox/u/${identity.user_id}`,
         },
       },
       supabase,


### PR DESCRIPTION
## Why

Follow-up to the diagnostic PR (#2219). The diagnostic build proved that Appilix's Android in-app browser **silently fails to launch URLs with query strings** when triggered from a notification tap:

| Surface | Result |
|---|---|
| `https://vitanaland.com/inbox?recipient=<uuid>&context=global` opened in mobile Chrome | ✅ Inbox loads, conversation renders correctly |
| Same URL via Appilix push tap | ❌ "Something went wrong / Try Again" — Appilix's own native error screen |
| `[NotifDiag] event=boot` beacons in Cloud Run logs after tap | ❌ Zero |
| `[Appilix] push request open_link_url=…` in Cloud Run logs | ✅ Confirms the gateway sent the correct URL — failure is downstream of delivery, in Appilix's launcher itself |

So the failure is pre-network in Appilix's URL launcher, not in the React app, the gateway, the WebView's network stack, or Cloudflare.

## What this does

Switch the `new_chat_message` push payload from
```
url: /inbox?recipient=<user_id>&context=global
```
to
```
url: /inbox/u/<user_id>
```

The `&context=global` was redundant — `global` is the default in `Messages.tsx` — and the path-based form is what Appilix's launcher can actually open.

The pair PR `exafyltd/vitana-v1` adds the matching `/inbox/u/:recipientId` (and `/inbox/t/:threadId`) routes and keeps the existing `?thread=` / `?recipient=` parsing so older notifications still resolve.

## Files touched

- `services/gateway/src/routes/chat.ts:131` — one URL string

## Test plan

- [x] `tsc --noEmit -p services/gateway` passes
- [x] Existing `test/routes/diag.test.ts` still passes (`5 passed`)
- [ ] After deploy + reporter taps a fresh chat notification:
  - `[Appilix] push request open_link_url="https://vitanaland.com/inbox/u/<uuid>"` shows in gateway logs
  - `[NotifDiag] event=boot` and `event=deep_link_detected` should now fire (confirming the WebView actually loaded the page)
  - The conversation opens instead of the "Something went wrong" screen

## Safety

- Single-line URL change; no schema, no governance, no auth changes
- Legacy bookmarks / older queued notifications keep working because the v1 PR keeps `?recipient=` / `?thread=` parsing intact

https://claude.ai/code/session_0183T6wBP62VHEtpF5XqHoct

---
_Generated by [Claude Code](https://claude.ai/code/session_0183T6wBP62VHEtpF5XqHoct)_