### PR TITLE
feat(orb-livekit): B0d-real P0-C activeContinuation voice state (VTID-03076)

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/continuation_intent.py
+++ b/services/agents/orb-agent/src/orb_agent/continuation_intent.py
@@ -1,0 +1,106 @@
+"""VTID-03076 (P0-C) — short-reply intent classifier for activeContinuation.
+
+When the agent speaks a proactive wake-brief and the user replies with a
+short answer ("ja" / "yes" / "okay" / "nein" / "no"), this module decides
+whether to fire `accepted` or `dismissed` to /api/v1/voice/next-action/event.
+
+Lives as its own module (not a closure inside session.py) so it can be
+unit-tested without spinning up the full LiveKit AgentSession.
+
+Hard rules baked into the classifier:
+  - Long replies (>60 chars OR >6 words) are NOT short replies.
+    They're treated as topic shifts; the caller clears
+    active_continuation on that signal.
+  - Match is exact OR leading/trailing token so "ja bitte" and
+    "klar gerne" still hit.
+  - Trailing punctuation is stripped before comparison.
+  - German + English coverage. Other supported_languages (fr/es/etc.)
+    can extend the sets if/when ORB validation runs in those locales.
+"""
+from __future__ import annotations
+
+
+# German acceptance — short replies that mean "do it" / "tell me more".
+ACCEPT_PATTERNS_DE: frozenset[str] = frozenset({
+    "ja", "ja bitte", "ja gerne", "okay", "ok", "klar", "klar gerne",
+    "mach das", "zeig es mir", "zeig mir", "erklär es", "erklaer es",
+    "erklär mir", "erzähl mir", "erzaehl mir", "gerne", "bitte",
+})
+
+ACCEPT_PATTERNS_EN: frozenset[str] = frozenset({
+    "yes", "yes please", "ok", "okay", "sure", "go ahead",
+    "show me", "tell me", "tell me more", "explain", "please do",
+    "do it",
+})
+
+DISMISS_PATTERNS_DE: frozenset[str] = frozenset({
+    "nein", "nein danke", "nicht jetzt", "später", "spaeter",
+    "lass mal", "nee", "ne", "danke nein",
+})
+
+DISMISS_PATTERNS_EN: frozenset[str] = frozenset({
+    "no", "no thanks", "not now", "later", "skip", "no thank you",
+    "nope",
+})
+
+_MAX_CHARS_FOR_SHORT_REPLY = 60
+_MAX_WORDS_FOR_SHORT_REPLY = 6
+
+
+def classify_short_reply(text: str | None) -> str | None:
+    """Return 'accept' / 'dismiss' / None for a user reply.
+
+    None means "not a short accept/dismiss" — caller should NOT fire any
+    continuation event. Long topical replies fall here too; the caller
+    can use the `is_topic_shift` helper below to decide whether to also
+    clear active_continuation state.
+    """
+    if not isinstance(text, str):
+        return None
+    t = text.strip().lower()
+    if not t:
+        return None
+    if len(t) > _MAX_CHARS_FOR_SHORT_REPLY:
+        return None
+    if len(t.split()) > _MAX_WORDS_FOR_SHORT_REPLY:
+        return None
+    # Strip trailing punctuation for matching.
+    t_norm = t.rstrip(".!?,;:")
+    accept = ACCEPT_PATTERNS_DE | ACCEPT_PATTERNS_EN
+    dismiss = DISMISS_PATTERNS_DE | DISMISS_PATTERNS_EN
+    if t_norm in accept:
+        return "accept"
+    if t_norm in dismiss:
+        return "dismiss"
+    # Prefix / suffix match for compound replies ("ja, zeig mal").
+    for p in accept:
+        if (
+            t_norm.startswith(p + " ")
+            or t_norm.startswith(p + ",")
+            or t_norm.endswith(" " + p)
+        ):
+            return "accept"
+    for p in dismiss:
+        if (
+            t_norm.startswith(p + " ")
+            or t_norm.startswith(p + ",")
+            or t_norm.endswith(" " + p)
+        ):
+            return "dismiss"
+    return None
+
+
+def is_topic_shift(text: str | None) -> bool:
+    """True when the user reply is long enough to qualify as a topic
+    change — caller uses this to clear active_continuation state so a
+    later 'ja' on a different topic doesn't fire the old acceptance.
+    """
+    if not isinstance(text, str):
+        return False
+    t = text.strip()
+    if not t:
+        return False
+    return (
+        len(t) > _MAX_CHARS_FOR_SHORT_REPLY
+        or len(t.split()) > _MAX_WORDS_FOR_SHORT_REPLY
+    )

--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -809,6 +809,103 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     model_turns_counter = {"n": 0}
     stall_count = {"n": 0}
 
+    # VTID-03076 (P0-C): activeContinuation voice state.
+    #
+    # When the agent speaks a wake-brief (proactive opener at orb_wake),
+    # the LLM has historically not remembered it because session.say()
+    # ran with add_to_chat_ctx=False — the line was TTS-output only,
+    # never appended to chat_ctx. The user replying "ja" then triggered
+    # the LLM with NO record of an offer; the model fell back on
+    # system_instruction content (Vitanaland, Vitana Index, ...) and
+    # produced unrelated answers. The user then asked "was hast du
+    # gerade gesagt?" and the agent denied saying it.
+    #
+    # This dict carries the spoken offer's identity AND a TTL so:
+    #   1. on user "ja" / "yes" / "okay" / "mach das", we POST
+    #      /api/v1/voice/next-action/event (accepted) for OASIS.
+    #   2. on user "nein" / "no" / "not now", we POST (dismissed).
+    #   3. on TTL expiry / session end / topic-shift, we clear state.
+    # The wake-brief say() now adds to chat_ctx so the LLM can answer
+    # "was hast du gerade gesagt?" naturally — no special intercept
+    # needed for the repeat case.
+    #
+    # Shape mirrors the wake_brief_decision payload + a wall-clock
+    # deadline. None = no active offer.
+    active_continuation: dict[str, Any] = {}
+    # 3 minutes: long enough that "ja" after a 30s pause still works,
+    # short enough that a stale offer doesn't claim "yes" said much
+    # later about an unrelated topic.
+    _CONTINUATION_TTL_SECONDS = 180.0
+
+    def _continuation_is_active() -> bool:
+        if not active_continuation:
+            return False
+        deadline = active_continuation.get("expires_at_monotonic")
+        if not isinstance(deadline, (int, float)):
+            return False
+        return time.monotonic() < deadline
+
+    def _clear_continuation(reason: str) -> None:
+        if active_continuation:
+            logger.info(
+                "VTID-03076: clearing activeContinuation (reason=%s, decision_id=%s)",
+                reason,
+                active_continuation.get("decision_id"),
+            )
+            active_continuation.clear()
+
+    # VTID-03076: short-reply patterns live in continuation_intent.py
+    # so they can be unit-tested without spinning up an AgentSession.
+    # `classify_short_reply` returns 'accept' / 'dismiss' / None.
+    # `is_topic_shift` returns True when the reply is long enough to
+    # clear active_continuation as a precaution.
+    from orb_agent.continuation_intent import (
+        classify_short_reply as _short_reply_intent,
+        is_topic_shift as _is_topic_shift,
+    )
+
+    async def _post_continuation_event(event_name: str) -> None:
+        """Fire-and-forget POST to /api/v1/voice/next-action/event.
+
+        event_name: 'accepted' | 'dismissed'. Reads from active_continuation
+        snapshot taken at call time so a concurrent clear doesn't race.
+        """
+        snapshot = dict(active_continuation)
+        decision_id = snapshot.get("decision_id")
+        dedupe_key = snapshot.get("dedupe_key")
+        if not isinstance(decision_id, str) or not isinstance(dedupe_key, str):
+            logger.warning(
+                "VTID-03076: skip continuation event (missing decision_id or dedupe_key)",
+            )
+            return
+        body = {
+            "decisionId": decision_id,
+            "dedupeKey": dedupe_key,
+            "eventName": event_name,
+            "surface": snapshot.get("surface") or "orb_wake",
+        }
+        src = snapshot.get("source_key")
+        if isinstance(src, str) and src:
+            body["source"] = src
+        try:
+            res = await gw.post("/api/v1/voice/next-action/event", body)
+            ok = isinstance(res, dict) and res.get("ok") is True
+            if ok:
+                logger.info(
+                    "VTID-03076: continuation %s emitted (decision_id=%s)",
+                    event_name, decision_id,
+                )
+            else:
+                logger.warning(
+                    "VTID-03076: continuation %s emit failed: %s",
+                    event_name, res,
+                )
+        except Exception as exc:  # noqa: BLE001
+            logger.warning(
+                "VTID-03076: continuation %s POST exception: %s",
+                event_name, exc,
+            )
+
     # VTID-03046: per-turn latency state. user_input_transcribed sets
     # `user_done_at` and `user_text_len`; the next speech_created reads them,
     # computes the wait gap, and emits orb.livekit.agent.turn.measured. We
@@ -1206,6 +1303,72 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
         session.on("user_input_transcribed")(_on_user_transcribed)  # type: ignore[misc]
     except Exception as exc:  # noqa: BLE001
         logger.debug("could not hook user_input_transcribed: %s", exc)
+
+    # VTID-03076 (P0-C): activeContinuation accept/dismiss intercept.
+    #
+    # Runs alongside the watchdog/counter handler above. When the user
+    # replies "ja"/"yes"/"okay"/"nein"/"no" AND we have an unexpired
+    # active_continuation, fire the accepted/dismissed event so OASIS
+    # closes the suggested → accepted lifecycle with the same
+    # decision_id. We do NOT silence the LLM — the wake-brief is in
+    # chat_ctx, so the LLM will see the prior assistant turn and the
+    # "ja" reply together and produce a coherent next response. This
+    # handler is purely additive telemetry + clear-state.
+    def _on_user_transcribed_for_continuation(_ev: Any = None) -> None:
+        try:
+            if not _continuation_is_active():
+                if active_continuation:
+                    # Stale offer — sweep it now.
+                    _clear_continuation("ttl_expired")
+                return
+            transcript = ""
+            try:
+                t = (
+                    getattr(_ev, "transcript", None)
+                    or getattr(_ev, "text", None)
+                    or ""
+                )
+                if isinstance(t, str):
+                    transcript = t
+            except Exception:  # noqa: BLE001
+                return
+            intent = _short_reply_intent(transcript)
+            if intent == "accept":
+                # Fire-and-forget. POST runs on the event loop; we clear
+                # state immediately so a duplicate transcript event
+                # can't double-fire.
+                logger.info(
+                    "VTID-03076: short-reply ACCEPT for decision_id=%s",
+                    active_continuation.get("decision_id"),
+                )
+                asyncio.create_task(_post_continuation_event("accepted"))
+                _clear_continuation("accepted")
+            elif intent == "dismiss":
+                logger.info(
+                    "VTID-03076: short-reply DISMISS for decision_id=%s",
+                    active_continuation.get("decision_id"),
+                )
+                asyncio.create_task(_post_continuation_event("dismissed"))
+                _clear_continuation("dismissed")
+            else:
+                # Long / topical reply → treat as topic shift. The user
+                # changed subject; the offer is no longer the live
+                # context. Clear so a later "ja" on a different topic
+                # doesn't accidentally accept the old offer.
+                if _is_topic_shift(transcript):
+                    _clear_continuation("topic_shift")
+        except Exception as exc:  # noqa: BLE001
+            logger.debug(
+                "VTID-03076: continuation intercept handler failed: %s", exc,
+            )
+
+    try:
+        session.on("user_input_transcribed")(_on_user_transcribed_for_continuation)  # type: ignore[misc]
+    except Exception as exc:  # noqa: BLE001
+        logger.debug(
+            "VTID-03076: could not hook user_input_transcribed for continuation: %s",
+            exc,
+        )
 
     # VTID-03001: trace agent_state_changed so we can see the agent
     # transition idle → thinking → speaking. If `speaking` never fires
@@ -1699,6 +1862,19 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
         # the orb.
         wake_brief = getattr(bootstrap, "wake_brief_decision", None) or {}
         wake_line = wake_brief.get("user_facing_line") if isinstance(wake_brief, dict) else None
+        # VTID-03076 (P0-C): is this a real proactive offer (wake_brief
+        # kind=wake_brief OR next_step) we should remember? The agent
+        # only persists state for offers that have a decision_id +
+        # dedupe_key so the user's "ja"/"nein" can be POSTed back to
+        # /voice/next-action/event for OASIS lifecycle. A generic
+        # localized greeting (no decision) gets NO active_continuation.
+        is_proactive_offer = (
+            isinstance(wake_line, str)
+            and wake_line.strip()
+            and isinstance(wake_brief, dict)
+            and isinstance(wake_brief.get("decision_id"), str)
+            and isinstance(wake_brief.get("dedupe_key"), str)
+        )
         if isinstance(wake_line, str) and wake_line.strip():
             greeting_text = wake_line.strip()
             logger.info(
@@ -1706,21 +1882,51 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
                 wake_brief.get("selected_kind") if isinstance(wake_brief, dict) else None,
                 wake_brief.get("decision_id") if isinstance(wake_brief, dict) else None,
             )
+            # VTID-03076: persist activeContinuation BEFORE the speak so
+            # a race with the next user turn finds the state populated.
+            if is_proactive_offer:
+                active_continuation.update({
+                    "decision_id": wake_brief.get("decision_id"),
+                    "dedupe_key": wake_brief.get("dedupe_key"),
+                    "source_key": wake_brief.get("source_key"),
+                    "selected_kind": wake_brief.get("selected_kind"),
+                    "user_facing_line": greeting_text,
+                    "lang": identity.lang or "en",
+                    "surface": "orb_wake",
+                    "created_at_monotonic": time.monotonic(),
+                    "expires_at_monotonic": time.monotonic() + _CONTINUATION_TTL_SECONDS,
+                })
+                logger.info(
+                    "VTID-03076: activeContinuation set (decision_id=%s, source_key=%s, ttl=%.0fs)",
+                    active_continuation.get("decision_id"),
+                    active_continuation.get("source_key"),
+                    _CONTINUATION_TTL_SECONDS,
+                )
         else:
             greeting_text = _localized_greeting(
                 identity.lang,
                 first_name=first_name,
                 vitana_handle=vid,
             )
+            is_proactive_offer = False
     else:
         greeting_text = _localized_anonymous_greeting(identity.lang)
+        is_proactive_offer = False
     try:
         # VTID-03017: add_to_chat_ctx=False — the greeting is a deterministic
         # template, not an LLM turn, so it shouldn't pollute chat_ctx as if
         # the model authored it. The LLM still knows the user is freshly
         # greeted via the placeholder system prompt + (after hydration) the
         # rendered system_instruction.
-        await session.say(greeting_text, add_to_chat_ctx=False)
+        #
+        # VTID-03076 (P0-C) exception: a REAL proactive offer (wake_brief
+        # with decision_id + dedupe_key) MUST go into chat_ctx so the LLM
+        # remembers having said it. Otherwise the user's "ja" hits the
+        # model with no context and produces a tangential answer
+        # (Vitanaland explanation when a match was offered). Localized
+        # greetings stay out of chat_ctx — those are decoration, not
+        # offers the user can act on.
+        await session.say(greeting_text, add_to_chat_ctx=bool(is_proactive_offer))
     except Exception as exc:  # noqa: BLE001
         logger.warning("initial greeting session.say failed: %s", exc)
         asyncio.create_task(

--- a/services/agents/orb-agent/tests/test_continuation_intent.py
+++ b/services/agents/orb-agent/tests/test_continuation_intent.py
@@ -1,0 +1,182 @@
+"""VTID-03076 (P0-C) — continuation_intent tests.
+
+Pure-function tests for the short-reply classifier. No LiveKit, no
+network, no AgentSession. Run with `pytest tests/test_continuation_intent.py`.
+
+These tests are the regression guard for the live German bug:
+  agent: "Es gibt ein frisches Match für dich. Soll ich es dir vorstellen?"
+  user:  "ja"
+  agent: <Vitanaland explanation>   ← wrong, should have fired accepted
+
+Acceptance #3 from the user's spec: User says "ja" after match
+continuation → continuation accepted (not Vitanaland explanation).
+"""
+from __future__ import annotations
+
+import pytest
+
+from src.orb_agent.continuation_intent import (
+    classify_short_reply,
+    is_topic_shift,
+)
+
+
+# ---------------------------------------------------------------------------
+# Accept patterns
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("text", [
+    "ja",
+    "Ja",
+    "JA",
+    "ja.",
+    "ja!",
+    "ja bitte",
+    "ja gerne",
+    "okay",
+    "ok",
+    "klar",
+    "klar gerne",
+    "mach das",
+    "zeig es mir",
+    "zeig mir",
+    "erklär es",
+    "erklär mir",
+    "erzähl mir",
+    "gerne",
+    "bitte",
+])
+def test_classify_accepts_german_short_reply(text: str) -> None:
+    assert classify_short_reply(text) == "accept"
+
+
+@pytest.mark.parametrize("text", [
+    "yes",
+    "Yes",
+    "yes please",
+    "ok",
+    "okay",
+    "sure",
+    "go ahead",
+    "show me",
+    "tell me",
+    "tell me more",
+    "explain",
+    "please do",
+    "do it",
+])
+def test_classify_accepts_english_short_reply(text: str) -> None:
+    assert classify_short_reply(text) == "accept"
+
+
+# ---------------------------------------------------------------------------
+# Dismiss patterns
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("text", [
+    "nein",
+    "Nein",
+    "nein danke",
+    "nicht jetzt",
+    "später",
+    "lass mal",
+    "nee",
+    "ne",
+])
+def test_classify_dismisses_german_short_reply(text: str) -> None:
+    assert classify_short_reply(text) == "dismiss"
+
+
+@pytest.mark.parametrize("text", [
+    "no",
+    "No",
+    "no thanks",
+    "not now",
+    "later",
+    "skip",
+    "nope",
+])
+def test_classify_dismisses_english_short_reply(text: str) -> None:
+    assert classify_short_reply(text) == "dismiss"
+
+
+# ---------------------------------------------------------------------------
+# Compound replies ("ja, zeig mal", "yes, go ahead")
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("text", [
+    "ja, zeig mal",
+    "ja zeig mal",
+    "yes, go ahead",
+    "okay, do it",
+])
+def test_classify_handles_compound_accept(text: str) -> None:
+    assert classify_short_reply(text) == "accept"
+
+
+@pytest.mark.parametrize("text", [
+    "nein, danke",
+    "no, thanks",
+    "later, please",
+])
+def test_classify_handles_compound_dismiss(text: str) -> None:
+    assert classify_short_reply(text) == "dismiss"
+
+
+# ---------------------------------------------------------------------------
+# Non-matches: empty, long, off-topic
+# ---------------------------------------------------------------------------
+
+@pytest.mark.parametrize("text", [
+    "",
+    "   ",
+    None,
+])
+def test_classify_returns_none_for_empty(text) -> None:
+    assert classify_short_reply(text) is None
+
+
+def test_classify_returns_none_for_long_reply() -> None:
+    # >60 chars → topic shift, not a short reply.
+    long_text = "I'd like to know what the weather is going to be tomorrow evening in Berlin around six"
+    assert classify_short_reply(long_text) is None
+    assert is_topic_shift(long_text) is True
+
+
+def test_classify_returns_none_for_many_words() -> None:
+    # >6 words → topic shift even if short character count.
+    many_words = "yes but tell me later about something"
+    assert classify_short_reply(many_words) is None
+    assert is_topic_shift(many_words) is True
+
+
+@pytest.mark.parametrize("text", [
+    "hello",
+    "ich verstehe nicht",  # "I don't understand" — NOT acceptance
+    "was hast du gesagt",  # NOT acceptance — this is the "what did you say" repeat case
+    "actually",
+])
+def test_classify_returns_none_for_unrelated_short_text(text: str) -> None:
+    assert classify_short_reply(text) is None
+
+
+# ---------------------------------------------------------------------------
+# Topic-shift helper
+# ---------------------------------------------------------------------------
+
+def test_is_topic_shift_short_reply_is_not_a_shift() -> None:
+    assert is_topic_shift("ja") is False
+    assert is_topic_shift("yes") is False
+
+
+def test_is_topic_shift_empty_is_not_a_shift() -> None:
+    assert is_topic_shift("") is False
+    assert is_topic_shift(None) is False
+
+
+def test_is_topic_shift_long_reply_is_a_shift() -> None:
+    # The exact George Michael bug scenario: user replies with a long
+    # support/troubleshooting sentence; we must NOT carry an old
+    # active_continuation past this.
+    long_text = "I'm having trouble with my account login can you help me reset my password"
+    assert is_topic_shift(long_text) is True

--- a/services/gateway/src/routes/orb-livekit.ts
+++ b/services/gateway/src/routes/orb-livekit.ts
@@ -1530,6 +1530,19 @@ router.get(
             selected_kind: wakeBriefDecision.selectedContinuation?.kind ?? 'none_with_reason',
             suppression_reason: wakeBriefDecision.suppressionReason ?? null,
             user_facing_line: wakeBriefDecision.selectedContinuation?.userFacingLine ?? null,
+            // VTID-03076 (P0-C): expose dedupe_key + source_key on the
+            // bootstrap response so the LiveKit agent can POST
+            // accepted/dismissed events to /voice/next-action/event
+            // when the user replies "ja"/"yes"/"nein"/"no" to a spoken
+            // wake-brief. Without these two fields the agent has no way
+            // to close the suggested → accepted lifecycle (event
+            // endpoint validates dedupeKey as required).
+            dedupe_key: wakeBriefDecision.selectedContinuation?.dedupeKey ?? null,
+            source_key:
+              wakeBriefDecision.selectedContinuation?.evidence
+                .map((e) => e.kind)
+                .find((k) => k.startsWith('source:'))
+                ?.replace('source:', '') ?? null,
             decision_started_at: wakeBriefDecision.decisionStartedAt,
             decision_finished_at: wakeBriefDecision.decisionFinishedAt,
             provider_results: wakeBriefDecision.sourceProviderResults.map((r) => ({


### PR DESCRIPTION
## Summary — close the "ja → Vitanaland" root cause

The mitigation (PR #2222) stopped the bleeding by pausing turn-end + unregistering match. This PR fixes the underlying architectural gap that made wake-brief unactionable:

> agent: "Es gibt ein frisches Match für dich. Soll ich es dir vorstellen?"
> user:  "ja"
> agent: \<unrelated Vitanaland explanation\>
> user:  "was hast du gerade gesagt?"
> agent: "ich kann mich nicht erinnern..."

Root cause: the LiveKit agent spoke proactive wake-brief lines with `session.say(..., add_to_chat_ctx=False)`. From the LLM's point of view the line never happened. "Ja" hit the model with no record of an offer → fallback to system_instruction content. "Was hast du gesagt?" → no chat_ctx → denial.

## Changes

### orb-agent/session.py
- New session-scope `active_continuation` dict (TTL 3 min) populated whenever a real proactive wake-brief speaks. Stores decision_id, dedupe_key, source_key, user-facing line, lang, surface, expires_at_monotonic.
- Wake-brief `session.say()` now runs with `add_to_chat_ctx=True` when (and only when) the offer is a real proactive candidate with decision_id + dedupe_key. Localized fallback greetings still go to chat_ctx=False because they aren't actionable offers.
- New `user_input_transcribed` listener:
  - "ja" / "yes" / "okay" / "mach das" / "zeig es mir" / ... → fire-and-forget POST to `/api/v1/voice/next-action/event` with `eventName=accepted`, then clear state.
  - "nein" / "no" / "nicht jetzt" / ... → POST dismissed, clear.
  - Long / topical reply (>60 chars OR >6 words) → topic shift, clear state.
  - TTL-expired offer swept on any subsequent transcript.
- "Was hast du gerade gesagt?" needs no special handling — with the proactive line in chat_ctx, the LLM sees the prior assistant turn and answers naturally.

### orb-agent/continuation_intent.py (NEW)
Pure module exporting `classify_short_reply(text)` and `is_topic_shift(text)`. Lifted out of the session.py closure so unit tests don't need a LiveKit AgentSession.

### gateway/orb-livekit.ts
`wake_brief_decision` response payload gains `dedupe_key` and `source_key`. Required so the agent has the values the `/voice/next-action/event` endpoint validates as required fields. `source_key` is parsed from the chosen continuation's evidence (entries with `kind: 'source:<key>'`).

### tests
- 66 new pytest cases for the classifier: DE + EN accept/dismiss patterns, compound replies, case/punctuation tolerance, empty/long inputs, topic-shift heuristic.
- 5 existing wake-brief greeting tests still pass.

## What does NOT change

- Turn-end next-actions: still paused at the gateway route level (VTID-03075 mitigation). This PR does NOT re-enable turn-end.
- Match source: still unregistered. This PR does NOT re-enable match — that waits on Slice B (copy tightening + suppression rules).

## Acceptance

1. Wake brief in German is remembered (chat_ctx). ✓
2. "Ja" after wake brief fires `/voice/next-action/event` accepted with the same decision_id from the bootstrap.
3. "Was hast du gerade gesagt?" answered from chat_ctx context.
4. OASIS lifecycle: suggested → accepted/dismissed shares decision_id.
5. No turn-end nudges return.

## Test plan
- [x] 66 pytest cases for the pure classifier
- [x] Existing wake-brief greeting consumption tests still pass (5/5)
- [x] Python syntax check on session.py + continuation_intent.py
- [x] Gateway `npm run build` green
- [ ] Real-mic German session: ORB tap → wake brief speaks → user says "ja" → OASIS shows `orb.livekit.next_action.accepted` with the wake-brief decision_id

🤖 Generated with [Claude Code](https://claude.com/claude-code)