### PR TITLE
fix(orb-agent): tighten silent_stall predicate — kill false positives that fired mid-sentence (VTID-03079)

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -1727,6 +1727,20 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     # of "dead for 3 minutes."
     # ------------------------------------------------------------------
     SILENT_STALL_THRESHOLD_S = 3.0
+    # VTID-03079: combined predicate. The old single-condition watchdog
+    # (just `speaking_for >= 3s`) fired during NORMAL 5-8s utterances
+    # because Google STT often takes that long to finalize a turn — and
+    # the user heard the recovery chime mid-sentence with no logic. The
+    # 2026-05-18 18:43-18:46 session showed the issue exactly:
+    #   stall #1: since_last_transcript=80.14s  ← real bug, recover
+    #   stall #2: since_last_transcript=3.37s   ← FALSE POSITIVE
+    #   stall #3: since_last_transcript=33.14s  ← maybe real
+    # Adding `since_last_transcript_s >= MIN_TRANSCRIPT_AGE_S` as a
+    # second required condition makes the predicate
+    #   VAD says speaking for ≥3s  AND  no transcript for ≥15s
+    # which is the signature of an actual stall (the 80s and 33s cases),
+    # not normal STT latency.
+    SILENT_STALL_MIN_TRANSCRIPT_AGE_S = 15.0
     SILENT_STALL_REPEAT_S = 8.0  # rate-limit: one alert per window
 
     stall_state: dict[str, Any] = {
@@ -1812,7 +1826,14 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
     # LiveKit transport problem, not STT. Kill switch:
     # ORB_STT_RECOVERY_ENABLED=false reverts to detection-only behavior.
     # ------------------------------------------------------------------
-    STT_RECOVERY_MAX_ATTEMPTS = 3
+    # VTID-03079: bumped from 3 → 5. The previous cap was burned by
+    # false-positive triggers (see SILENT_STALL_MIN_TRANSCRIPT_AGE_S
+    # comment above); after VTID-03079's tighter predicate every fired
+    # attempt should be a real stall, and a longer session may
+    # legitimately need 4-5 recoveries. Each attempt is bounded to ~3s
+    # by the activity-swap wait, so 5 attempts cost at most ~15s of
+    # total session disruption — still well under any user's patience.
+    STT_RECOVERY_MAX_ATTEMPTS = 5
 
     def _stt_recovery_enabled() -> bool:
         return os.environ.get("ORB_STT_RECOVERY_ENABLED", "true").lower() not in (
@@ -1948,6 +1969,14 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
                 now = time.monotonic()
                 speaking_for = now - started
                 if speaking_for < SILENT_STALL_THRESHOLD_S:
+                    continue
+                # VTID-03079: second predicate. Without this we fire on
+                # every normal user utterance whose STT happens to take
+                # >3s to finalize. Require ≥15s since the last successful
+                # transcript before declaring stall.
+                last_transcript_at = stall_state.get("last_transcript_at") or now
+                since_last_transcript = now - last_transcript_at
+                if since_last_transcript < SILENT_STALL_MIN_TRANSCRIPT_AGE_S:
                     continue
                 last_alert = stall_state.get("last_alert_at") or 0.0
                 if (now - last_alert) < SILENT_STALL_REPEAT_S:

--- a/services/agents/orb-agent/tests/test_silent_stall_predicate.py
+++ b/services/agents/orb-agent/tests/test_silent_stall_predicate.py
@@ -1,0 +1,77 @@
+"""VTID-03079: silent_stall predicate must check BOTH conditions.
+
+The 2026-05-18 18:43-18:46 UTC session showed the original VTID-03075
+single-condition watchdog firing during normal speech:
+
+  stall #1: speaking_for=3.48s  since_last_transcript=80.14s  ← real
+  stall #2: speaking_for=3.23s  since_last_transcript=3.37s   ← FALSE POSITIVE
+  stall #3: speaking_for=3.68s  since_last_transcript=33.14s  ← maybe real
+
+The chime/banner fired mid-sentence because Google STT was just slow to
+finalize a normal 6-second utterance. This regression test pins the
+new combined predicate so a future PR can't accidentally drop the
+second condition and reintroduce mid-sentence false-positive chimes.
+"""
+from __future__ import annotations
+
+import pathlib
+
+
+def _session_src() -> str:
+    return (
+        pathlib.Path(__file__).resolve().parent.parent
+        / "src" / "orb_agent" / "session.py"
+    ).read_text(encoding="utf-8")
+
+
+def test_min_transcript_age_constant_exists_with_15s() -> None:
+    """15s is the floor for declaring a stall. Anything lower
+    (especially the original 3s) re-introduces false positives during
+    normal STT finalization latency."""
+    src = _session_src()
+    assert "SILENT_STALL_MIN_TRANSCRIPT_AGE_S = 15.0" in src, (
+        "VTID-03079 regression: SILENT_STALL_MIN_TRANSCRIPT_AGE_S must be 15.0"
+    )
+
+
+def test_predicate_uses_both_conditions() -> None:
+    """The watchdog tick MUST gate on speaking_for AND since_last_transcript.
+    Either condition alone is wrong:
+      - speaking_for only → fires during normal STT latency (the bug we're fixing)
+      - since_last_transcript only → fires during ordinary silence between turns
+    """
+    src = _session_src()
+    # Find the watchdog tick body
+    watchdog_start = src.find("async def _silent_stall_watchdog")
+    assert watchdog_start != -1
+    body = src[watchdog_start : watchdog_start + 3500]
+    # Both predicates must appear in the tick
+    assert "speaking_for < SILENT_STALL_THRESHOLD_S" in body, (
+        "VTID-03079 regression: lost the VAD speaking-time predicate"
+    )
+    assert "since_last_transcript < SILENT_STALL_MIN_TRANSCRIPT_AGE_S" in body, (
+        "VTID-03079 regression: lost the transcript-age predicate; "
+        "watchdog will re-introduce mid-sentence false positives"
+    )
+
+
+def test_predicate_returns_early_on_each_failure() -> None:
+    """Both predicates are early-return checks: if EITHER condition is
+    not met, the tick skips alert/recovery entirely. The 18:45:30 false
+    positive happened with since_last_transcript=3.37s — that condition
+    alone must be enough to skip even when speaking_for is high."""
+    src = _session_src()
+    watchdog_start = src.find("async def _silent_stall_watchdog")
+    body = src[watchdog_start : watchdog_start + 3500]
+    # Both should be followed by `continue` (loop skip).
+    # Find the `< SILENT_STALL_MIN_TRANSCRIPT_AGE_S` check and check
+    # the next line is a continue.
+    import re
+    match = re.search(
+        r"if\s+since_last_transcript\s*<\s*SILENT_STALL_MIN_TRANSCRIPT_AGE_S\s*:\s*\n\s+continue",
+        body,
+    )
+    assert match, (
+        "VTID-03079 regression: the transcript-age check must `continue` on miss "
+        "(skip this tick), not fall through to fire the alert"
+    )

--- a/services/agents/orb-agent/tests/test_stt_recovery.py
+++ b/services/agents/orb-agent/tests/test_stt_recovery.py
@@ -58,13 +58,16 @@ def test_recovery_kill_switch_off_variants(monkeypatch) -> None:  # type: ignore
         assert val in ("false", "0", "no", "off"), v
 
 
-def test_max_attempts_constant_pinned_at_three() -> None:
-    """3 swaps per session. Anything higher risks churning Google STT
-    + Deepgram connections on a chronic upstream problem; anything lower
-    means we give up before the user does. Pin literal."""
+def test_max_attempts_constant_pinned_at_five() -> None:
+    """VTID-03079 bumped 3 → 5 once the tighter predicate started
+    rejecting false positives. 5 attempts cost at most ~15s of swap
+    activity (each bounded by the 5s activity-swap wait); a longer
+    session may legitimately need 4-5 recoveries. Anything higher risks
+    churning Google STT / Deepgram connections on a chronic problem;
+    anything lower means we give up before the user does."""
     src = _session_src()
-    assert "STT_RECOVERY_MAX_ATTEMPTS = 3" in src, (
-        "VTID-03078 regression: STT_RECOVERY_MAX_ATTEMPTS must be 3"
+    assert "STT_RECOVERY_MAX_ATTEMPTS = 5" in src, (
+        "VTID-03079 regression: STT_RECOVERY_MAX_ATTEMPTS must be 5"
     )
 
 


### PR DESCRIPTION
## Summary
VTID-03075's single-condition watchdog (`speaking_for >= 3s`) over-fired during normal 5-8s utterances because Google STT often takes that long to finalize. The chime/banner fired mid-sentence with no logic. Adding `since_last_transcript_s >= 15s` as a second required predicate eliminates false positives without losing real-stall detection.

## Diagnostic (from VTID-03075 telemetry, 2026-05-18 18:43-18:46 session)
```
stall #1: speaking_for=3.48s  since_last_transcript=80.14s  ← real (80s gap)
stall #2: speaking_for=3.23s  since_last_transcript=3.37s   ← FALSE POSITIVE (mid-sentence)
stall #3: speaking_for=3.68s  since_last_transcript=33.14s  ← maybe real (33s)
```
Real-stall signature is tens-of-seconds. The 3.37s gap was burning recovery slots on healthy speech.

## Changes
- `SILENT_STALL_MIN_TRANSCRIPT_AGE_S = 15.0` (NEW). Both predicates now required.
- `STT_RECOVERY_MAX_ATTEMPTS` bumped 3 → 5 (false positives no longer steal slots).

## Tests
24/24 green (3 new in test_silent_stall_predicate.py + existing 21).

🤖 Generated with [Claude Code](https://claude.com/claude-code)