### PR TITLE
fix(auth): decouple welcome-chat from welcome-notification gate (VTID-03082)

### DIFF
--- a/services/gateway/src/routes/auth.ts
+++ b/services/gateway/src/routes/auth.ts
@@ -260,19 +260,21 @@ router.post('/login', async (req: Request, res: Response) => {
             .catch(err => {
               console.warn(`[VTID-01185] First-login recommendations failed for ${uid.slice(0, 8)}: ${err.message}`);
             });
-
-          // Send welcome chat messages from new user to all community members (fire-and-forget)
-          sendWelcomeChatMessages(uid, tid, profile.display_name, supabase as any)
-            .then(result => {
-              console.log(
-                `[WelcomeChat] First-login for ${uid.slice(0, 8)}: ` +
-                `sent=${result.sent}, skipped=${result.skipped}${result.reason ? `, reason=${result.reason}` : ''}`
-              );
-            })
-            .catch(err => {
-              console.warn(`[WelcomeChat] First-login failed for ${uid.slice(0, 8)}: ${err.message}`);
-            });
         }
+
+        // Welcome chat: gated independently on app_users.welcome_chat_sent inside the
+        // service. An admin invite can pre-create a welcome_to_vitana notification,
+        // which must not suppress the community greeting.
+        sendWelcomeChatMessages(uid, tid, profile.display_name, supabase as any)
+          .then(result => {
+            console.log(
+              `[WelcomeChat] First-login for ${uid.slice(0, 8)}: ` +
+              `sent=${result.sent}, skipped=${result.skipped}${result.reason ? `, reason=${result.reason}` : ''}`
+            );
+          })
+          .catch(err => {
+            console.warn(`[WelcomeChat] First-login failed for ${uid.slice(0, 8)}: ${err.message}`);
+          });
       }
     }
 


### PR DESCRIPTION
## Summary

- New users were registering but never sending the community-greeting auto-DM ("Hello, I'm new to this community...").
- Root cause: `sendWelcomeChatMessages(...)` lived inside the `if (count === 0)` block in `POST /auth/login` that's gated on the user having zero `welcome_to_vitana` notifications. The admin `POST /admin/signups/:id/invite` endpoint also fires `welcome_to_vitana`, so any admin-invited user arrived at first login already gated out — and the greeting was silently skipped.
- Fix: move the call out of that block. The service's existing `app_users.welcome_chat_sent` idempotency flag already prevents duplicates.

## What changed

`services/gateway/src/routes/auth.ts` — `sendWelcomeChatMessages(...)` moved from inside `if (count === 0)` to immediately after it, still inside `if (tid)`. Welcome notification, profile prompt, and autopilot recs keep their gate (those *should* be once-per-user). 14 insertions / 12 deletions.

## Test plan

- [ ] Gateway `npm run build` green (confirmed locally before push)
- [ ] EXEC-DEPLOY runs cleanly
- [ ] Post-deploy: register a fresh test community user and confirm `chat_messages` rows inserted with `sender_id = newUser`, `metadata.source = 'welcome_chat'`
- [ ] Post-deploy regression case: invite a pending signup via `POST /admin/signups/:id/invite`, then complete signup + login — confirm the greeting still fires
- [ ] Confirm `app_users.welcome_chat_sent` flips to `true` and a second login does NOT re-send

## Out of scope

- One-shot backfill for users from past N weeks who missed the greeting — flagged as a product call.
- OAuth/magic-link path possibly bypassing `/auth/login` — unverified; secondary risk if it surfaces.

🤖 Generated with [Claude Code](https://claude.com/claude-code)