### PR TITLE
fix(wake-brief): replace dismissive copy with service-grade warmth (VTID-03083)

### DIFF
--- a/services/gateway/src/services/assistant-continuation/providers/voice-wake-brief.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/voice-wake-brief.ts
@@ -88,20 +88,24 @@ export interface VoiceWakeBriefRenderer {
   render(inputs: VoiceWakeBriefInputs, ctx: ContinuationDecisionContext): string;
 }
 
+// VTID-03083: warmer, service-grade copy. "Back already?" / "Schon
+// zurück?" reads as dismissive — a service assistant greets a returning
+// user warmly, never with a confronting question. Same rule for every
+// policy.
 const DEFAULT_LINES: Record<GreetingPolicy, Record<string, string>> = {
   // Suppressed at provider boundary; never reaches the renderer.
   skip: { en: '', de: '' },
   brief_resume: {
-    en: 'Back already? What did you want to follow up on?',
-    de: 'Schon zurück? Worauf wolltest du zurückkommen?',
+    en: 'Welcome back. What would you like to pick up on?',
+    de: 'Schön, dich wieder zu hören. Womit kann ich dir helfen?',
   },
   warm_return: {
     en: 'Welcome back. What is on your mind?',
-    de: 'Schön, dass du wieder da bist. Was steht an?',
+    de: 'Schön, dass du wieder da bist. Womit kann ich dir helfen?',
   },
   fresh_intro: {
     en: 'Hello! How can I help today?',
-    de: 'Hallo! Wie kann ich heute helfen?',
+    de: 'Hallo! Wie kann ich dir heute helfen?',
   },
 };
 

--- a/services/gateway/test/services/assistant-continuation/providers/voice-wake-brief-pillar-momentum.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/voice-wake-brief-pillar-momentum.test.ts
@@ -197,7 +197,8 @@ describe('VTID-03053 — defaultVoiceWakeBriefRenderer emits pillar-specific lin
       { greetingPolicy: 'brief_resume', lang: 'en', pillarMomentum: makePm() },
       makeCtx({ greetingPolicy: 'brief_resume', lang: 'en' }),
     );
-    expect(line).toBe('Back already? What did you want to follow up on?');
+    // VTID-03083: warmer copy — never confronting questions.
+    expect(line).toBe('Welcome back. What would you like to pick up on?');
   });
 });
 

--- a/services/gateway/test/services/assistant-continuation/providers/voice-wake-brief.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/voice-wake-brief.test.ts
@@ -167,7 +167,7 @@ describe('B0d.2 — Voice Wake Brief provider', () => {
       const result = (await provider.produce(
         makeCtx({ greetingPolicy: 'fresh_intro', lang: 'de' }),
       )) as ProviderResult;
-      expect(result.candidate?.userFacingLine).toBe('Hallo! Wie kann ich heute helfen?');
+      expect(result.candidate?.userFacingLine).toBe('Hallo! Wie kann ich dir heute helfen?');
     });
 
     it('falls back to English for an unknown lang', async () => {

--- a/services/gateway/test/services/wake-brief-wiring.test.ts
+++ b/services/gateway/test/services/wake-brief-wiring.test.ts
@@ -129,7 +129,7 @@ describe('B0d.4 — wake-brief-wiring', () => {
         },
         { recorder },
       );
-      expect(decision.selectedContinuation?.userFacingLine).toBe('Hallo! Wie kann ich heute helfen?');
+      expect(decision.selectedContinuation?.userFacingLine).toBe('Hallo! Wie kann ich dir heute helfen?');
     });
   });
 
@@ -333,7 +333,7 @@ describe('B0d.4 — wake-brief-wiring', () => {
         { recorder },
       );
       // bucket=long → default fresh_intro, but 4 sessions today drops to brief_resume.
-      expect(decision.selectedContinuation?.userFacingLine).toMatch(/Back already\?/);
+      expect(decision.selectedContinuation?.userFacingLine).toMatch(/Welcome back/i);
     });
 
     it('cadence: same greeting style twice in a row downgrades one tier', async () => {


### PR DESCRIPTION
## Why this PR exists

User feedback (German native speaker, blunt): the brief_resume DE line *"Schon zurück? Worauf wolltest du zurückkommen?"* reads as confronting / street-trash, never how a service assistant greets a returning user. Same dismissive tone on the English side: *"Back already? What did you want to follow up on?"*

This PR replaces those lines with warm welcome-back phrasing.

## Replacements

| Policy | Lang | OLD | NEW |
|---|---|---|---|
| brief_resume | EN | Back already? What did you want to follow up on? | Welcome back. What would you like to pick up on? |
| brief_resume | DE | Schon zurück? Worauf wolltest du zurückkommen? | Schön, dich wieder zu hören. Womit kann ich dir helfen? |
| warm_return | DE | Schön, dass du wieder da bist. Was steht an? | Schön, dass du wieder da bist. Womit kann ich dir helfen? |
| fresh_intro | DE | Hallo! Wie kann ich heute helfen? | Hallo! Wie kann ich dir heute helfen? |

EN warm_return + fresh_intro kept (already friendly).

## Tests
- [x] 57 wake-brief tests updated + green
- [x] Gateway build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)