### PR TITLE
fix(orb-livekit): honor ?lang query + stored preference on /orb/context-bootstrap (VTID-03084)

### DIFF
--- a/services/gateway/src/routes/orb-livekit.ts
+++ b/services/gateway/src/routes/orb-livekit.ts
@@ -748,9 +748,52 @@ router.get(
     const userId = req.identity?.user_id ?? null;
     const tenantId = req.identity?.tenant_id ?? null;
     const role = req.identity?.role ?? 'community';
-    const lang = String(req.headers['accept-language'] || 'en')
+    // VTID-03084 (Lane 2): LiveKit lang resolution priority MUST match Vertex.
+    //   1. Client-supplied `?lang=...` query param (UI dropdown — most explicit).
+    //   2. Stored preference in `memory_facts` (fact_key=preferred_language).
+    //   3. Accept-Language header (browser default).
+    //   4. 'en' fallback.
+    //
+    // Before this fix the route ONLY read Accept-Language, so a German user
+    // who picked DE in the Test Bench dropdown would still get English
+    // wake-brief lines + English system_instruction whenever the browser
+    // sent en-US in the header. That's how the user got
+    // "Welcome back. What would you like to pick up on?" on a ?lang=de
+    // request.
+    const queryLang = typeof req.query.lang === 'string' && req.query.lang
+      ? String(req.query.lang).split(',')[0].split('-')[0].toLowerCase()
+      : null;
+    const headerLang = String(req.headers['accept-language'] || 'en')
       .split(',')[0]
-      .split('-')[0];
+      .split('-')[0]
+      .toLowerCase();
+    let lang = queryLang || headerLang || 'en';
+    // Stored preference only fills the gap when no explicit query param.
+    // (We don't override an explicit ?lang=en with a stored DE preference —
+    // the user just told us what they want for this session.)
+    if (!queryLang && userId && tenantId) {
+      try {
+        const { getCurrentFacts } = await import('../services/memory-facts-service');
+        const result = await getCurrentFacts({
+          tenant_id: tenantId,
+          user_id: userId,
+          fact_keys: ['preferred_language'],
+        });
+        if (result.ok && result.facts.length > 0) {
+          const stored = result.facts[0].fact_value.toLowerCase();
+          const nameToCode: Record<string, string> = {
+            english: 'en', german: 'de', french: 'fr', spanish: 'es',
+            arabic: 'ar', chinese: 'zh', russian: 'ru', serbian: 'sr',
+          };
+          const resolved = nameToCode[stored] || stored;
+          if (['en','de','fr','es','ar','zh','ru','sr'].includes(resolved)) {
+            lang = resolved;
+          }
+        }
+      } catch {
+        // Fail-open: keep header-derived lang.
+      }
+    }
 
     // VTID-03035 + VTID-03036: two-layer cache hit short-circuit.
     //  - L1 in-memory (per Cloud Run instance) — ~0ms when hit

--- a/services/gateway/test/orb/routes/livekit-context-parity.test.ts
+++ b/services/gateway/test/orb/routes/livekit-context-parity.test.ts
@@ -84,4 +84,23 @@ describe('VTID-03036 LiveKit context parity wire-up', () => {
     // unaffected by anything inside this best-effort closure.
     expect(source).toMatch(/buildBootstrapContextPack failed:/);
   });
+
+  // VTID-03084 (Lane 2) — LiveKit lang resolution priority.
+  it('VTID-03084: reads ?lang query param first (most explicit)', () => {
+    // The route must look at req.query.lang BEFORE the Accept-Language
+    // header so a Test Bench / mobile UI dropdown choice always wins
+    // over the browser's default language.
+    expect(source).toMatch(/req\.query\.lang/);
+    expect(source).toMatch(/queryLang\b/);
+  });
+
+  it('VTID-03084: still falls back to Accept-Language header', () => {
+    expect(source).toMatch(/req\.headers\[['"]accept-language['"]\]/);
+    expect(source).toMatch(/headerLang\b/);
+  });
+
+  it('VTID-03084: consults stored preferred_language fact when no explicit query param', () => {
+    expect(source).toMatch(/preferred_language/);
+    expect(source).toMatch(/getCurrentFacts/);
+  });
 });


### PR DESCRIPTION
## Lane 2 — LiveKit user-facing correctness

Before this fix the LiveKit `/orb/context-bootstrap` route resolved `lang` from the `Accept-Language` header ONLY. A Test Bench or mobile UI dropdown choice (e.g. "Deutsch") was silently dropped, so a German user got English wake_brief copy + English system_instruction whenever the browser sent `en-US` in the header.

Vertex already does this correctly in `live-session-controller.ts`. LiveKit was the outlier.

## New priority (matches Vertex)

1. `?lang=` query param (UI dropdown — most explicit)
2. Stored `preferred_language` fact (per-user preference)
3. `Accept-Language` header (browser default)
4. `'en'` fallback

Stored preference only fills the gap when no explicit query param — an explicit `?lang=en` MUST NOT be overridden by a stored DE preference. The user just told us what they want for this session.

## Test plan
- [x] 10 livekit-context-parity tests green (4 new assertions for query/header/stored lang lookup)
- [x] Gateway build green
- [ ] Real-mic LiveKit Test Bench German: `?lang=de` → German wake_brief

🤖 Generated with [Claude Code](https://claude.com/claude-code)