### PR TITLE
fix(orb-live): plumb AssistantDecisionContext spine into Vertex wake-brief (VTID-03085)

### DIFF
--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -789,6 +789,34 @@ export async function handleLiveSessionStart(
   // signals into decideGreetingPolicy(). Now we read them from
   // user_assistant_state, pass them through, and record after fire.
   let wakeBriefDecision: Awaited<ReturnType<typeof decideWakeBriefForSession>> | null = null;
+  // VTID-03085 (Lane 1): compile the AssistantDecisionContext on Vertex
+  // so the 4 spine-dependent next-action sources can compete here too.
+  // Before this fix Vertex passed `decisionContext: null` so:
+  //   - life_compass_alignment            → skipped:no_decision_context
+  //   - vitana_index_pillar               → skipped:no_decision_context
+  //   - continuity_pending_thread         → skipped:no_decision_context
+  //   - continuity_promise_owed           → skipped:no_decision_context
+  // Only reminder / calendar / autopilot could fire on Vertex. LiveKit
+  // already compiles the spine — this brings Vertex to parity.
+  let decisionContextVertex: import('../../../orb/context/types').AssistantDecisionContext | null = null;
+  if (orbIdentity?.tenant_id && orbIdentity?.user_id) {
+    try {
+      const { compileAssistantDecisionContext } = await import(
+        '../../../orb/context/compile-assistant-decision-context'
+      );
+      decisionContextVertex = await compileAssistantDecisionContext({
+        userId: orbIdentity.user_id,
+        tenantId: orbIdentity.tenant_id,
+      });
+    } catch (exc) {
+      // Fail-open: degraded behavior is "old Vertex" — never blocks session start.
+      console.warn(
+        `[VTID-03085] compileAssistantDecisionContext failed (non-fatal): ${(exc as Error).message}`,
+      );
+    }
+  }
+  (session as any).decisionContext = decisionContextVertex;
+
   try {
     const temporal = deps.describeTimeSince(session.lastSessionInfo);
     const { getSupabase } = await import('../../../lib/supabase');
@@ -816,7 +844,14 @@ export async function handleLiveSessionStart(
       isReconnect: isReconnectStart,
       lang,
       supabase: supabaseClient,
-      decisionContext: null,
+      // VTID-03085 (Lane 1): pass the compiled spine — unlocks
+      // life_compass_alignment, vitana_index_pillar,
+      // continuity_pending_thread, continuity_promise_owed on Vertex.
+      decisionContext: decisionContextVertex,
+      // Forward distilled pillar_momentum so the voice-wake-brief
+      // renderer can fold in the slipping-pillar proactive variant on
+      // Vertex (LiveKit already does this).
+      pillarMomentum: decisionContextVertex?.pillar_momentum ?? null,
       cadenceSignals,
       // wake_origin is not yet plumbed from the client envelope on
       // Vertex; default 'unknown' so the B1 policy doesn't fire the


### PR DESCRIPTION
## Lane 1 — Vertex production parity

Before this fix Vertex's call to `decideWakeBriefForSession` passed `decisionContext: null`. The 4 spine-dependent next-action sources returned `skipped:no_decision_context` on **every Vertex session**:

- `life_compass_alignment`
- `vitana_index_pillar`
- `continuity_pending_thread`
- `continuity_promise_owed`

Only `reminder_due` / `calendar_upcoming` / `autopilot_recommendation` could fire on Vertex. LiveKit already compiles the spine (see `orb-livekit.ts` ~line 1285); Vertex was the outlier and silently swallowed half the proactive intelligence.

## Changes (Vertex only — LiveKit untouched per Lane isolation)

- Dynamically import `compileAssistantDecisionContext`.
- Compile `decisionContext` at Vertex session-start (best-effort — failure degrades to old behavior, never blocks).
- Pass the compiled context into `decideWakeBriefForSession` alongside already-wired `supabase` + `cadenceSignals`.
- Also forward distilled `pillar_momentum` so the voice-wake-brief renderer can produce the slipping-pillar proactive variant on Vertex (it already does on LiveKit).
- Attach `(session as any).decisionContext` so downstream callers can consume it.

## Acceptance

- Vertex session-start now produces `wake_brief` decision with non-null `decisionContext`.
- The 4 spine-dependent sources are eligible on Vertex.
- LiveKit code path unchanged.
- Vertex production smoke must still work after deploy.

## Test plan
- [x] 72 controller + wake-brief-wiring tests green
- [x] Gateway build green
- [ ] Real-mic Vertex Android German: cold session shows reminder/calendar/autopilot OR pillar/continuity content (no more bare fresh_intro)

🤖 Generated with [Claude Code](https://claude.com/claude-code)