### PR TITLE
fix(orb-agent): tune Silero VAD — catch natural pauses + cap continuous speech at 8s (VTID-03086)

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -100,6 +100,33 @@ except ImportError:
 # instance to every subsequent agent_entrypoint.
 _SHARED_VAD: Any = None
 
+# VTID-03086: Silero VAD tuning. The 2026-05-18 20:56-21:03 UTC session
+# diagnosed the root cause behind the silent-stall thrash — STT recognition
+# cycles were consuming 79-86 SECONDS of audio per cycle because Silero's
+# defaults treat natural German speech (with comma-pauses + breathing)
+# as one continuous "speech" state. Both Google STT and Deepgram are
+# working correctly; they're just being handed one-minute audio streams
+# and finalizing one giant transcript at the end.
+#
+# Three tuned parameters:
+#   * min_silence_duration 0.55 → 0.25
+#     Catches the natural comma-pauses in conversational German that
+#     don't cross the half-second silence threshold of the default.
+#   * activation_threshold 0.5 → 0.6
+#     Slightly less sensitive to breathing / ambient noise being
+#     classified as ongoing speech (especially during a long pause).
+#   * max_buffered_speech 60.0 → 8.0
+#     Hard ceiling. Regardless of silence-detection, Silero will declare
+#     end-of-speech after 8 seconds of continuous "speech" state. This
+#     is the safety net: STT cycles can NEVER again hit the 79-86s
+#     batches we saw. Worst case for a single user utterance: it splits
+#     into 8-second chunks, each transcribed in order, LLM responds per
+#     chunk. Better than 80 seconds of dead air.
+_VAD_MIN_SILENCE_DURATION_S = 0.25
+_VAD_ACTIVATION_THRESHOLD = 0.6
+_VAD_MAX_BUFFERED_SPEECH_S = 8.0
+
+
 def _get_vad() -> Any:
     global _SHARED_VAD
     if _SHARED_VAD is not None:
@@ -107,10 +134,20 @@ def _get_vad() -> Any:
     if not SILERO_AVAILABLE:
         return None
     try:
-        _SHARED_VAD = silero.VAD.load()  # type: ignore[union-attr]
-        logger.info("VTID-03012: module-level Silero VAD loaded (reused across sessions)")
+        _SHARED_VAD = silero.VAD.load(  # type: ignore[union-attr]
+            min_silence_duration=_VAD_MIN_SILENCE_DURATION_S,
+            activation_threshold=_VAD_ACTIVATION_THRESHOLD,
+            max_buffered_speech=_VAD_MAX_BUFFERED_SPEECH_S,
+        )
+        logger.info(
+            "VTID-03086: module-level Silero VAD loaded "
+            "(min_silence=%.2fs, activation=%.2f, max_buffered_speech=%.1fs)",
+            _VAD_MIN_SILENCE_DURATION_S,
+            _VAD_ACTIVATION_THRESHOLD,
+            _VAD_MAX_BUFFERED_SPEECH_S,
+        )
     except Exception as exc:  # noqa: BLE001
-        logger.warning("VTID-03012: silero.VAD.load() failed: %s", exc)
+        logger.warning("VTID-03086: silero.VAD.load() failed: %s", exc)
     return _SHARED_VAD
 
 

--- a/services/agents/orb-agent/tests/test_silero_vad_tune.py
+++ b/services/agents/orb-agent/tests/test_silero_vad_tune.py
@@ -1,0 +1,76 @@
+"""VTID-03086: Silero VAD parameter regression tests.
+
+The defaults were the root cause for the 2026-05-18 20:56-21:03 UTC
+silent-stall thrash. STT recognition cycles consumed 79-86 SECONDS of
+audio per cycle because Silero's `min_silence_duration=0.55s` default
+didn't catch natural comma-pauses, so the agent's STT stream stayed
+open for over a minute on a single "speech" state.
+
+These tests pin the three tuned values so a future PR can't silently
+revert to defaults and bring the marathon-batch failure mode back.
+"""
+from __future__ import annotations
+
+import pathlib
+
+
+def _session_src() -> str:
+    return (
+        pathlib.Path(__file__).resolve().parent.parent
+        / "src" / "orb_agent" / "session.py"
+    ).read_text(encoding="utf-8")
+
+
+def test_min_silence_duration_pinned() -> None:
+    """0.25s is the bar to catch natural German comma-pauses. The
+    upstream default (0.55s) was too long — speakers blew past it
+    without VAD ever declaring speech_end."""
+    src = _session_src()
+    assert "_VAD_MIN_SILENCE_DURATION_S = 0.25" in src, (
+        "VTID-03086 regression: VAD min_silence_duration must be 0.25s"
+    )
+
+
+def test_activation_threshold_pinned() -> None:
+    """0.6 is slightly above the Silero default (0.5) — less sensitive
+    to breathing / ambient noise being misclassified as ongoing speech.
+    Critical for the "no pause is ever long enough for VAD" failure mode."""
+    src = _session_src()
+    assert "_VAD_ACTIVATION_THRESHOLD = 0.6" in src, (
+        "VTID-03086 regression: VAD activation_threshold must be 0.6"
+    )
+
+
+def test_max_buffered_speech_pinned() -> None:
+    """8.0 is the hard ceiling. The upstream default (60.0) lets a single
+    "speech" state run for a full minute; production telemetry showed
+    cycles reaching 79-86s. This cap is the structural guarantee that
+    STT can never again receive a marathon batch — Silero force-declares
+    end-of-speech at 8s of continuous detection regardless of silence
+    threshold."""
+    src = _session_src()
+    assert "_VAD_MAX_BUFFERED_SPEECH_S = 8.0" in src, (
+        "VTID-03086 regression: VAD max_buffered_speech must be 8.0s "
+        "(hard ceiling against marathon-batch STT cycles)"
+    )
+
+
+def test_get_vad_passes_all_three_to_load() -> None:
+    """The constants only matter if `_get_vad()` actually forwards them
+    to `silero.VAD.load()`. Pin the call shape so a future PR can't
+    quietly drop a kwarg and revert to the upstream default."""
+    src = _session_src()
+    # Find _get_vad body
+    fn_start = src.find("def _get_vad")
+    assert fn_start != -1
+    body = src[fn_start : fn_start + 2000]
+    assert "silero.VAD.load(" in body, "VTID-03086 regression: _get_vad lost silero.VAD.load() call"
+    assert "min_silence_duration=_VAD_MIN_SILENCE_DURATION_S" in body, (
+        "VTID-03086 regression: _get_vad must pass min_silence_duration to silero.VAD.load"
+    )
+    assert "activation_threshold=_VAD_ACTIVATION_THRESHOLD" in body, (
+        "VTID-03086 regression: _get_vad must pass activation_threshold to silero.VAD.load"
+    )
+    assert "max_buffered_speech=_VAD_MAX_BUFFERED_SPEECH_S" in body, (
+        "VTID-03086 regression: _get_vad must pass max_buffered_speech to silero.VAD.load"
+    )


### PR DESCRIPTION
## Root cause (from yesterday's diagnostic)
STT recognition cycles consumed 79-86 SECONDS of audio in single cycles because Silero defaults (`min_silence_duration=0.55s`, `max_buffered_speech=60s`) treat natural German speech with comma-pauses as one continuous "speech" state.

NOT a Google bug. NOT a Deepgram bug. NOT a cascade architecture bug. A VAD config bug. Verified: every fresh cascade built by recovery showed identical batching.

## Three tuned parameters
- `min_silence_duration` 0.55s → **0.25s** — catches comma-pauses
- `activation_threshold` 0.5 → **0.6** — less sensitive to breathing/ambient
- `max_buffered_speech` 60.0s → **8.0s** — hard ceiling on continuous "speech" state

The 8s ceiling is the structural guarantee: STT cycles can NEVER again hit 79+s.

## Tests
14/14 green (4 new in tests/test_silero_vad_tune.py + 10 existing).

🤖 Generated with [Claude Code](https://claude.com/claude-code)