### PR TITLE
feat(chat): group chat + auto-enrollment + @vitana mentions (VTID-03089)

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -304,6 +304,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const notificationsRouter = require('./routes/notifications').default;
   // Chat — User-to-user direct messaging
   const chatRouter = require('./routes/chat').default;
+  // Group chat — VTID-03089
+  const chatGroupsRouter = require('./routes/chat-groups').default;
   // VTID-01967: Vitana ID — voice resolver, admin lookup, onboarding pick
   const usersResolveRouter = require('./routes/users-resolve').default;
   const adminUsersLookupRouter = require('./routes/admin-users-lookup').default;
@@ -974,6 +976,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
 
   // Chat — User-to-user direct messaging
   mountRouterSync(app, '/api/v1/chat', chatRouter, { owner: 'chat' });
+  // Group chat — VTID-03089. Mounted under /api/v1/chat/groups (sibling of DM endpoints).
+  mountRouterSync(app, '/api/v1/chat/groups', chatGroupsRouter, { owner: 'chat-groups' });
 
   // VTID-01967: Vitana ID resolver + onboarding pick + admin lookup.
   // Mounted under /api/v1/users so /resolve and /me/vitana-id/* are siblings;

--- a/services/gateway/src/routes/auth.ts
+++ b/services/gateway/src/routes/auth.ts
@@ -21,6 +21,7 @@ import { getSupabase } from '../lib/supabase';
 import { notifyUserAsync } from '../services/notification-service';
 import { generatePersonalRecommendations } from '../services/recommendation-engine';
 import { sendWelcomeChatMessages } from '../services/welcome-chat-service';
+import { addUserToSystemGroups } from '../services/community-group-enrollment';
 
 const router = Router();
 
@@ -274,6 +275,19 @@ router.post('/login', async (req: Request, res: Response) => {
           })
           .catch(err => {
             console.warn(`[WelcomeChat] First-login failed for ${uid.slice(0, 8)}: ${err.message}`);
+          });
+
+        // VTID-03089: auto-add to system groups (currently "🎆 FIRST 100", cap 100).
+        // Idempotent on chat_group_members PK.
+        addUserToSystemGroups(uid, tid, supabase as any)
+          .then(result => {
+            console.log(
+              `[GroupEnrollment] First-login for ${uid.slice(0, 8)}: ` +
+              `added=${result.added.length}, skipped=${result.skipped.length}`
+            );
+          })
+          .catch(err => {
+            console.warn(`[GroupEnrollment] First-login failed for ${uid.slice(0, 8)}: ${err.message}`);
           });
       }
     }

--- a/services/gateway/src/routes/chat-groups.ts
+++ b/services/gateway/src/routes/chat-groups.ts
@@ -1,0 +1,442 @@
+/**
+ * Group Chat API Routes — VTID-03089
+ *
+ * Endpoints (mounted at /api/v1/chat/groups):
+ *   GET    /                       — List groups the caller belongs to
+ *   GET    /:id                    — Group info + member list
+ *   GET    /:id/messages           — Paginated group message history
+ *   POST   /:id/send               — Send a message to the group;
+ *                                    @vitana mentions trigger Vitana reply
+ *   POST   /:id/read               — Mark all group messages read up to "now"
+ */
+
+import { Router, Request, Response } from 'express';
+import {
+  requireAuth,
+  requireTenant,
+  AuthenticatedRequest,
+} from '../middleware/auth-supabase-jwt';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { notifyUserAsync } from '../services/notification-service';
+import { VITANA_BOT_USER_ID, isVitanaBot } from '../lib/vitana-bot';
+import { processConversationTurn } from '../services/conversation-client';
+
+const router = Router();
+
+function getSupabase(): SupabaseClient {
+  return createClient(
+    process.env.SUPABASE_URL!,
+    process.env.SUPABASE_SERVICE_ROLE!,
+  );
+}
+
+const VITANA_MENTION_RE = /(^|\s)@vitana\b/i;
+
+// ── GET / — Groups the caller belongs to ──────────────────────
+
+router.get('/', requireAuth, requireTenant, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const supabase = getSupabase();
+  const { data: memberships, error } = await supabase
+    .from('chat_group_members')
+    .select('group_id, last_read_at, role, joined_at')
+    .eq('user_id', identity.user_id)
+    .eq('tenant_id', identity.tenant_id);
+
+  if (error) {
+    console.error('[ChatGroups] List memberships error:', error);
+    return res.status(500).json({ ok: false, error: error.message });
+  }
+
+  if (!memberships || memberships.length === 0) {
+    return res.json({ ok: true, data: [] });
+  }
+
+  const groupIds = memberships.map(m => m.group_id);
+
+  const { data: groups, error: groupsErr } = await supabase
+    .from('chat_groups')
+    .select('id, name, description, is_system, metadata, created_at')
+    .in('id', groupIds);
+
+  if (groupsErr) {
+    console.error('[ChatGroups] Fetch groups error:', groupsErr);
+    return res.status(500).json({ ok: false, error: groupsErr.message });
+  }
+
+  const { data: lastMessages, error: lastErr } = await supabase
+    .from('chat_messages')
+    .select('id, group_id, sender_id, content, created_at, message_type, metadata')
+    .in('group_id', groupIds)
+    .order('created_at', { ascending: false })
+    .limit(500);
+
+  if (lastErr) {
+    console.warn('[ChatGroups] Fetch last messages failed:', lastErr.message);
+  }
+
+  const lastByGroup = new Map<string, any>();
+  for (const msg of lastMessages || []) {
+    if (!lastByGroup.has(msg.group_id)) {
+      lastByGroup.set(msg.group_id, msg);
+    }
+  }
+
+  const membershipByGroup = new Map(memberships.map(m => [m.group_id, m]));
+
+  const unreadCounts = await Promise.all(groupIds.map(async gid => {
+    const m = membershipByGroup.get(gid);
+    const since = m?.last_read_at;
+    let q = supabase
+      .from('chat_messages')
+      .select('id', { count: 'exact', head: true })
+      .eq('group_id', gid)
+      .neq('sender_id', identity.user_id);
+    if (since) q = q.gt('created_at', since);
+    const { count } = await q;
+    return { group_id: gid, count: count || 0 };
+  }));
+  const unreadByGroup = new Map(unreadCounts.map(u => [u.group_id, u.count]));
+
+  const data = (groups || []).map(g => ({
+    id: g.id,
+    name: g.name,
+    description: g.description,
+    is_system: g.is_system,
+    metadata: g.metadata,
+    created_at: g.created_at,
+    role: membershipByGroup.get(g.id)?.role || 'member',
+    joined_at: membershipByGroup.get(g.id)?.joined_at,
+    last_read_at: membershipByGroup.get(g.id)?.last_read_at,
+    last_message: lastByGroup.get(g.id) || null,
+    unread_count: unreadByGroup.get(g.id) || 0,
+  }));
+
+  data.sort((a, b) => {
+    const ta = a.last_message?.created_at || a.created_at;
+    const tb = b.last_message?.created_at || b.created_at;
+    return tb.localeCompare(ta);
+  });
+
+  return res.json({ ok: true, data });
+});
+
+// ── GET /:id — Group info + members ───────────────────────────
+
+router.get('/:id', requireAuth, requireTenant, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const { id: groupId } = req.params;
+  const supabase = getSupabase();
+
+  const membership = await requireMembership(supabase, groupId, identity.user_id);
+  if (!membership) {
+    return res.status(403).json({ ok: false, error: 'not_a_member' });
+  }
+
+  const [{ data: group, error: groupErr }, { data: members, error: membersErr }] = await Promise.all([
+    supabase.from('chat_groups').select('*').eq('id', groupId).maybeSingle(),
+    supabase.from('chat_group_members').select('user_id, role, joined_at').eq('group_id', groupId),
+  ]);
+
+  if (groupErr || !group) {
+    return res.status(404).json({ ok: false, error: 'group_not_found' });
+  }
+  if (membersErr) {
+    console.error('[ChatGroups] Members fetch error:', membersErr);
+    return res.status(500).json({ ok: false, error: membersErr.message });
+  }
+
+  const memberIds = (members || []).map(m => m.user_id);
+  let profiles: Array<{ user_id: string; display_name: string | null; avatar_url: string | null }> = [];
+  if (memberIds.length > 0) {
+    const { data: profileRows } = await supabase
+      .from('app_users')
+      .select('user_id, display_name, avatar_url')
+      .in('user_id', memberIds);
+    profiles = profileRows || [];
+  }
+  const profileById = new Map(profiles.map(p => [p.user_id, p]));
+
+  const enrichedMembers = (members || []).map(m => ({
+    user_id: m.user_id,
+    role: m.role,
+    joined_at: m.joined_at,
+    display_name: profileById.get(m.user_id)?.display_name || null,
+    avatar_url: profileById.get(m.user_id)?.avatar_url || null,
+    is_bot: isVitanaBot(m.user_id),
+  }));
+
+  return res.json({
+    ok: true,
+    data: {
+      ...group,
+      member_count: enrichedMembers.length,
+      members: enrichedMembers,
+    },
+  });
+});
+
+// ── GET /:id/messages — Paginated history ─────────────────────
+
+router.get('/:id/messages', requireAuth, requireTenant, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const { id: groupId } = req.params;
+  const limit = Math.min(Number(req.query.limit) || 50, 100);
+  const before = req.query.before as string | undefined;
+
+  const supabase = getSupabase();
+
+  const membership = await requireMembership(supabase, groupId, identity.user_id);
+  if (!membership) {
+    return res.status(403).json({ ok: false, error: 'not_a_member' });
+  }
+
+  let query = supabase
+    .from('chat_messages')
+    .select('*')
+    .eq('group_id', groupId)
+    .order('created_at', { ascending: false })
+    .limit(limit);
+
+  if (before) query = query.lt('created_at', before);
+
+  const { data, error } = await query;
+  if (error) {
+    console.error('[ChatGroups] Messages fetch error:', error);
+    return res.status(500).json({ ok: false, error: error.message });
+  }
+
+  return res.json({ ok: true, data });
+});
+
+// ── POST /:id/send — Send group message ───────────────────────
+
+router.post('/:id/send', requireAuth, requireTenant, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const { id: groupId } = req.params;
+  const { content } = req.body;
+
+  if (!content || typeof content !== 'string' || content.trim().length === 0) {
+    return res.status(400).json({ ok: false, error: 'content is required' });
+  }
+
+  const supabase = getSupabase();
+
+  const membership = await requireMembership(supabase, groupId, identity.user_id);
+  if (!membership) {
+    return res.status(403).json({ ok: false, error: 'not_a_member' });
+  }
+
+  const trimmed = content.trim();
+  const { data, error } = await supabase
+    .from('chat_messages')
+    .insert({
+      tenant_id: identity.tenant_id,
+      sender_id: identity.user_id,
+      receiver_id: null,
+      group_id: groupId,
+      content: trimmed,
+      message_type: 'text',
+    })
+    .select()
+    .single();
+
+  if (error) {
+    console.error('[ChatGroups] Send error:', error);
+    return res.status(500).json({ ok: false, error: error.message });
+  }
+
+  fanoutGroupNotifications(
+    supabase,
+    groupId,
+    identity.user_id,
+    identity.tenant_id!,
+    trimmed,
+    data.id,
+  ).catch(err => console.warn('[ChatGroups] Fanout failed:', err.message));
+
+  if (VITANA_MENTION_RE.test(trimmed) && !isVitanaBot(identity.user_id)) {
+    handleVitanaGroupMention(
+      supabase,
+      groupId,
+      identity.user_id,
+      identity.tenant_id!,
+      trimmed,
+    ).catch(err => console.warn('[ChatGroups] @vitana reply failed:', err.message));
+  }
+
+  return res.status(201).json({ ok: true, data });
+});
+
+// ── POST /:id/read — Mark group read up to now ────────────────
+
+router.post('/:id/read', requireAuth, requireTenant, async (req: Request, res: Response) => {
+  const { identity } = req as AuthenticatedRequest;
+  if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
+
+  const { id: groupId } = req.params;
+  const supabase = getSupabase();
+
+  const membership = await requireMembership(supabase, groupId, identity.user_id);
+  if (!membership) {
+    return res.status(403).json({ ok: false, error: 'not_a_member' });
+  }
+
+  const { error } = await supabase
+    .from('chat_group_members')
+    .update({ last_read_at: new Date().toISOString() })
+    .eq('group_id', groupId)
+    .eq('user_id', identity.user_id);
+
+  if (error) {
+    console.error('[ChatGroups] Mark read error:', error);
+    return res.status(500).json({ ok: false, error: error.message });
+  }
+
+  return res.json({ ok: true });
+});
+
+// ── helpers ───────────────────────────────────────────────────
+
+async function requireMembership(
+  supabase: SupabaseClient,
+  groupId: string,
+  userId: string,
+): Promise<{ role: string } | null> {
+  const { data, error } = await supabase
+    .from('chat_group_members')
+    .select('role')
+    .eq('group_id', groupId)
+    .eq('user_id', userId)
+    .maybeSingle();
+  if (error || !data) return null;
+  return { role: (data as any).role };
+}
+
+async function fanoutGroupNotifications(
+  supabase: SupabaseClient,
+  groupId: string,
+  senderId: string,
+  tenantId: string,
+  content: string,
+  messageId: string,
+): Promise<void> {
+  const [{ data: group }, { data: members }, { data: senderProfile }] = await Promise.all([
+    supabase.from('chat_groups').select('name').eq('id', groupId).maybeSingle(),
+    supabase.from('chat_group_members').select('user_id').eq('group_id', groupId),
+    supabase.from('app_users').select('display_name, email').eq('user_id', senderId).maybeSingle(),
+  ]);
+
+  const groupName = (group as any)?.name || 'Group chat';
+  const senderName = (senderProfile as any)?.display_name
+    || ((senderProfile as any)?.email ? (senderProfile as any).email.split('@')[0] : 'Someone');
+
+  const body = content.length > 100 ? content.slice(0, 97) + '...' : content;
+
+  for (const m of (members || []) as Array<{ user_id: string }>) {
+    if (m.user_id === senderId) continue;
+    if (isVitanaBot(m.user_id)) continue;
+    notifyUserAsync(
+      m.user_id,
+      tenantId,
+      'new_chat_message',
+      {
+        title: groupName,
+        body: `${senderName}: ${body}`,
+        data: {
+          type: 'new_group_message',
+          group_id: groupId,
+          sender_id: senderId,
+          sender_name: senderName,
+          message_id: messageId,
+          url: `/inbox/g/${groupId}`,
+        },
+      },
+      supabase,
+    );
+  }
+}
+
+async function handleVitanaGroupMention(
+  supabase: SupabaseClient,
+  groupId: string,
+  askerUserId: string,
+  tenantId: string,
+  content: string,
+): Promise<void> {
+  const startTime = Date.now();
+  const question = content.replace(VITANA_MENTION_RE, ' ').trim() || content;
+
+  try {
+    const { isVitanaBrainEnabled } = await import('../services/system-controls-service');
+    const useBrain = await isVitanaBrainEnabled();
+
+    let result: { ok: boolean; reply: string; error?: string; thread_id: string; turn_number: number; meta: { model_used: string; latency_ms: number } };
+
+    if (useBrain) {
+      const { processBrainTurn } = await import('../services/vitana-brain');
+      result = await processBrainTurn({
+        channel: 'orb',
+        tenant_id: tenantId,
+        user_id: askerUserId,
+        role: 'user',
+        message: question,
+        message_type: 'text',
+        vtid: 'VTID-03089',
+      });
+    } else {
+      result = await processConversationTurn({
+        channel: 'orb',
+        tenant_id: tenantId,
+        user_id: askerUserId,
+        role: 'user',
+        message: question,
+        message_type: 'text',
+        vtid: 'VTID-03089',
+      });
+    }
+
+    if (!result.ok || !result.reply) {
+      console.warn(`[ChatGroups] @vitana reply failed: ${result.error || 'empty reply'}`);
+      return;
+    }
+
+    const { error } = await supabase
+      .from('chat_messages')
+      .insert({
+        tenant_id: tenantId,
+        sender_id: VITANA_BOT_USER_ID,
+        receiver_id: null,
+        group_id: groupId,
+        content: result.reply,
+        message_type: 'text',
+        metadata: {
+          source: useBrain ? 'brain_group_mention' : 'group_mention',
+          model_used: result.meta.model_used,
+          latency_ms: result.meta.latency_ms,
+          thread_id: result.thread_id,
+          turn_number: result.turn_number,
+          brain_enabled: useBrain,
+          asked_by: askerUserId,
+        },
+      });
+
+    if (error) {
+      console.warn(`[ChatGroups] Vitana group reply write failed: ${error.message}`);
+    } else {
+      console.log(`[ChatGroups] @vitana reply written for group ${groupId} (${Date.now() - startTime}ms)`);
+    }
+  } catch (err: any) {
+    console.error(`[ChatGroups] @vitana handler error: ${err.message}`);
+  }
+}
+
+export default router;

--- a/services/gateway/src/services/community-group-enrollment.ts
+++ b/services/gateway/src/services/community-group-enrollment.ts
@@ -1,0 +1,91 @@
+/**
+ * Community Group Enrollment — VTID-03089
+ *
+ * Auto-adds new users to system chat groups in their tenant. Currently the
+ * only system group is "🎆 FIRST 100", capped at 100 members. Idempotent:
+ * silently skips if the user is already a member or the cap is reached.
+ * Fire-and-forget — never blocks login.
+ */
+
+import { SupabaseClient } from '@supabase/supabase-js';
+
+const FIRST_100_CAP = 100;
+
+export async function addUserToSystemGroups(
+  userId: string,
+  tenantId: string,
+  supabase: SupabaseClient,
+): Promise<{ added: string[]; skipped: Array<{ group_id: string; reason: string }> }> {
+  const added: string[] = [];
+  const skipped: Array<{ group_id: string; reason: string }> = [];
+  const tag = '[GroupEnrollment]';
+
+  try {
+    const { data: groups, error: groupsErr } = await supabase
+      .from('chat_groups')
+      .select('id, name')
+      .eq('tenant_id', tenantId)
+      .eq('is_system', true);
+
+    if (groupsErr) {
+      console.warn(`${tag} List system groups failed: ${groupsErr.message}`);
+      return { added, skipped };
+    }
+    if (!groups || groups.length === 0) {
+      return { added, skipped };
+    }
+
+    for (const group of groups as Array<{ id: string; name: string }>) {
+      const { data: existing } = await supabase
+        .from('chat_group_members')
+        .select('user_id')
+        .eq('group_id', group.id)
+        .eq('user_id', userId)
+        .maybeSingle();
+
+      if (existing) {
+        skipped.push({ group_id: group.id, reason: 'already_member' });
+        continue;
+      }
+
+      const { count, error: countErr } = await supabase
+        .from('chat_group_members')
+        .select('user_id', { count: 'exact', head: true })
+        .eq('group_id', group.id);
+
+      if (countErr) {
+        console.warn(`${tag} Count members for ${group.id} failed: ${countErr.message}`);
+        skipped.push({ group_id: group.id, reason: 'count_failed' });
+        continue;
+      }
+
+      if ((count || 0) >= FIRST_100_CAP) {
+        skipped.push({ group_id: group.id, reason: 'cap_reached' });
+        continue;
+      }
+
+      const { error: insertErr } = await supabase
+        .from('chat_group_members')
+        .insert({
+          group_id: group.id,
+          user_id: userId,
+          tenant_id: tenantId,
+          role: 'member',
+        });
+
+      if (insertErr) {
+        console.warn(`${tag} Insert membership for ${group.name} failed: ${insertErr.message}`);
+        skipped.push({ group_id: group.id, reason: insertErr.message });
+        continue;
+      }
+
+      added.push(group.id);
+      console.log(`${tag} Added ${userId.slice(0, 8)} to ${group.name} (${group.id})`);
+    }
+
+    return { added, skipped };
+  } catch (err: any) {
+    console.error(`${tag} Unexpected error: ${err.message}`);
+    return { added, skipped };
+  }
+}

--- a/supabase/migrations/20260525000000_VTID_03089_chat_groups.sql
+++ b/supabase/migrations/20260525000000_VTID_03089_chat_groups.sql
@@ -1,0 +1,146 @@
+-- =============================================================================
+-- VTID-03089: Group chat — chat_groups + chat_group_members + chat_messages.group_id
+-- =============================================================================
+--
+-- Adds many-to-many group chat on top of the existing 1-to-1 chat_messages
+-- model. A chat_messages row is either a DM (receiver_id set, group_id null)
+-- or a group message (group_id set, receiver_id null) — enforced by a check
+-- constraint. The first system group is "🎆 FIRST 100" populated by the
+-- community-group-enrollment service.
+-- =============================================================================
+
+CREATE TABLE IF NOT EXISTS public.chat_groups (
+  id UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id UUID NOT NULL,
+  name TEXT NOT NULL,
+  description TEXT,
+  created_by UUID,
+  is_system BOOLEAN NOT NULL DEFAULT false,
+  metadata JSONB NOT NULL DEFAULT '{}'::jsonb,
+  created_at TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_chat_groups_tenant
+  ON public.chat_groups (tenant_id, created_at DESC);
+
+CREATE TABLE IF NOT EXISTS public.chat_group_members (
+  group_id UUID NOT NULL REFERENCES public.chat_groups(id) ON DELETE CASCADE,
+  user_id UUID NOT NULL,
+  tenant_id UUID NOT NULL,
+  role TEXT NOT NULL DEFAULT 'member' CHECK (role IN ('member', 'admin', 'bot')),
+  joined_at TIMESTAMPTZ NOT NULL DEFAULT now(),
+  last_read_at TIMESTAMPTZ,
+  PRIMARY KEY (group_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_chat_group_members_user
+  ON public.chat_group_members (user_id);
+
+-- Allow group messages: receiver_id may be null when group_id is set.
+ALTER TABLE public.chat_messages ALTER COLUMN receiver_id DROP NOT NULL;
+
+ALTER TABLE public.chat_messages
+  ADD COLUMN IF NOT EXISTS group_id UUID NULL REFERENCES public.chat_groups(id) ON DELETE SET NULL;
+
+-- Exactly one of (receiver_id, group_id) must be set.
+ALTER TABLE public.chat_messages
+  DROP CONSTRAINT IF EXISTS chat_messages_target_xor;
+ALTER TABLE public.chat_messages
+  ADD CONSTRAINT chat_messages_target_xor CHECK (
+    (receiver_id IS NOT NULL AND group_id IS NULL) OR
+    (receiver_id IS NULL     AND group_id IS NOT NULL)
+  );
+
+CREATE INDEX IF NOT EXISTS idx_chat_messages_group_recent
+  ON public.chat_messages (group_id, created_at DESC)
+  WHERE group_id IS NOT NULL;
+
+-- =============================================================================
+-- RLS
+-- =============================================================================
+
+ALTER TABLE public.chat_groups        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.chat_group_members ENABLE ROW LEVEL SECURITY;
+
+-- Members see their group's row.
+DROP POLICY IF EXISTS chat_groups_member_read ON public.chat_groups;
+CREATE POLICY chat_groups_member_read
+  ON public.chat_groups FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.chat_group_members m
+      WHERE m.group_id = chat_groups.id
+        AND m.user_id = auth.uid()
+    )
+  );
+
+-- Service role manages groups (gateway).
+DROP POLICY IF EXISTS chat_groups_service_role ON public.chat_groups;
+CREATE POLICY chat_groups_service_role
+  ON public.chat_groups FOR ALL
+  USING (true) WITH CHECK (true);
+
+-- Members see the member list of groups they belong to.
+DROP POLICY IF EXISTS chat_group_members_read ON public.chat_group_members;
+CREATE POLICY chat_group_members_read
+  ON public.chat_group_members FOR SELECT
+  USING (
+    EXISTS (
+      SELECT 1 FROM public.chat_group_members m2
+      WHERE m2.group_id = chat_group_members.group_id
+        AND m2.user_id = auth.uid()
+    )
+  );
+
+-- Service role manages membership.
+DROP POLICY IF EXISTS chat_group_members_service_role ON public.chat_group_members;
+CREATE POLICY chat_group_members_service_role
+  ON public.chat_group_members FOR ALL
+  USING (true) WITH CHECK (true);
+
+-- Extend chat_messages RLS for group messages.
+-- (The DM policies users_read_own_messages / users_send_messages /
+--  service_role_manage_chat from the original migration still apply for DMs.)
+DROP POLICY IF EXISTS users_read_group_messages ON public.chat_messages;
+CREATE POLICY users_read_group_messages
+  ON public.chat_messages FOR SELECT
+  USING (
+    group_id IS NOT NULL AND EXISTS (
+      SELECT 1 FROM public.chat_group_members m
+      WHERE m.group_id = chat_messages.group_id
+        AND m.user_id = auth.uid()
+    )
+  );
+
+DROP POLICY IF EXISTS users_send_group_messages ON public.chat_messages;
+CREATE POLICY users_send_group_messages
+  ON public.chat_messages FOR INSERT
+  WITH CHECK (
+    group_id IS NOT NULL
+    AND auth.uid() = sender_id
+    AND EXISTS (
+      SELECT 1 FROM public.chat_group_members m
+      WHERE m.group_id = chat_messages.group_id
+        AND m.user_id = auth.uid()
+    )
+  );
+
+-- =============================================================================
+-- Realtime publication
+-- =============================================================================
+
+DO $$
+BEGIN
+  BEGIN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.chat_groups;
+  EXCEPTION WHEN duplicate_object THEN NULL;
+  END;
+  BEGIN
+    ALTER PUBLICATION supabase_realtime ADD TABLE public.chat_group_members;
+  EXCEPTION WHEN duplicate_object THEN NULL;
+  END;
+END$$;
+
+COMMENT ON TABLE  public.chat_groups        IS 'Group chats (e.g. "🎆 FIRST 100"). 1-to-1 DMs continue using chat_messages.receiver_id.';
+COMMENT ON TABLE  public.chat_group_members IS 'Group membership and per-user last_read_at for unread counts.';
+COMMENT ON COLUMN public.chat_messages.group_id IS 'When set, this message is a group message; receiver_id is NULL. Mutex enforced by chat_messages_target_xor.';


### PR DESCRIPTION
## Summary

Phase 1 of the "🎆 FIRST 100" feature: backend foundation for group chat with auto-enrollment and `@vitana` mentions.

## What ships

**Migration (`20260525000000_VTID_03089_chat_groups.sql`)**
- `chat_groups` + `chat_group_members`
- `chat_messages.group_id UUID NULL` + `chat_messages_target_xor` check (DM xor group)
- RLS for member-only read/send, service role unrestricted
- Realtime publication on new tables

**Endpoints** mounted at `/api/v1/chat/groups`
| Method | Path | Purpose |
|---|---|---|
| GET | `/` | List groups the caller is in (with last_message + unread_count) |
| GET | `/:id` | Group info + member list (display_name, avatar_url, is_bot) |
| GET | `/:id/messages` | Paginated history (`?limit`, `?before`) |
| POST | `/:id/send` | Send a message; @vitana mentions trigger a Vitana reply |
| POST | `/:id/read` | Bump `chat_group_members.last_read_at` |

**`@vitana` auto-response** — on every group `send`, server detects `/@vitana\b/i`, asks the Vitana Brain (or legacy `processConversationTurn` when brain flag is off) for a reply, writes it back to the group as a message from the bot. Identical pattern to the existing DM Vitana bridge.

**Auto-enrollment** (`addUserToSystemGroups`) — on first login, the user is added to every `is_system=true` group in their tenant, capped at 100 members per group. Idempotent (skips already-member + cap-reached). Fire-and-forget alongside `sendWelcomeChatMessages`.

## Out of scope (Phase 2 / Phase 3)

- vitana-v1 community UI for groups — separate PR in the community frontend repo.
- Final SQL batch: create "🎆 FIRST 100" + add all current members + Vitana's German welcome + 1,876 individual-hello backfill. Runs after Phase 2 is live.

## Test plan

- [x] Gateway `npm run build` green (confirmed locally before push)
- [ ] RUN-MIGRATION.yml applies cleanly (new tables + column + RLS)
- [ ] EXEC-DEPLOY succeeds
- [ ] Post-deploy curl smoke: `GET /api/v1/chat/groups` returns `{ok:true, data:[]}` for a user not in any group
- [ ] Post-deploy auth smoke: `/auth/login` still returns 200 + welcome chat continues to fire (no regression from VTID-03082)

🤖 Generated with [Claude Code](https://claude.com/claude-code)