### PR TITLE
feat(teacher): greeting + invitation phrase pools (VTID-03092)

### DIFF
--- a/services/gateway/src/services/assistant-continuation/providers/teacher/teacher-greeting-pool.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/teacher/teacher-greeting-pool.ts
@@ -1,0 +1,108 @@
+/**
+ * VTID-03092 (Teacher PR 2) — name-aware greeting pool for the Teacher
+ * (Feature Discovery Coach).
+ *
+ * The Teacher's spoken first turn is built as TWO clauses concatenated:
+ *
+ *   [greeting clause]  +  [invitation clause]
+ *
+ * This module owns the GREETING clause only. It picks one warm,
+ * service-grade phrase that acknowledges the user's return (using
+ * their first name when known). The invitation clause comes from
+ * `teacher-invitation-pool.ts` and asks permission to introduce ONE
+ * unexplored Vitanaland feature.
+ *
+ * Hard rules baked into this pool:
+ *   - No dismissive openers ("Yes?", "Ja bitte?", "What's up?").
+ *   - Every phrase ends in a period — the invitation appends after.
+ *   - Phrases with `{firstName}` substitute the user's first name when
+ *     available; phrases without it are the no-name fallback set.
+ *   - All phrases use the user's language. Unsupported langs fall back
+ *     to English.
+ *
+ * Pool size target: ~20 per language (mix of with-name + no-name
+ * variants) so Gemini's recency bias is broken across sessions.
+ */
+
+const GREETING_PHRASES: Record<string, string[]> = {
+  en: [
+    'Welcome back, {firstName}.',
+    'Hi again, {firstName}.',
+    'Good to see you again, {firstName}.',
+    'Glad you are back, {firstName}.',
+    'Nice to hear you, {firstName}.',
+    'Welcome back.',
+    'Hi again.',
+    'Good to have you back.',
+    'It is good to hear from you, {firstName}.',
+    'Welcome, {firstName}.',
+    'Lovely to see you again, {firstName}.',
+    'Hello again, {firstName}.',
+    'Hi, {firstName}. Good to have you back.',
+    'It is great that you are here, {firstName}.',
+    'Welcome back to Vitanaland, {firstName}.',
+    'I am happy you are here, {firstName}.',
+    'Good to have you with us again, {firstName}.',
+    'Hi, {firstName}. Glad you stopped by.',
+    'Welcome back. It is good to hear you.',
+    'Hello again. Nice to hear you.',
+  ],
+  de: [
+    'Willkommen zurück, {firstName}.',
+    'Schön, dich wieder zu hören, {firstName}.',
+    'Hallo {firstName}, schön, dass du wieder da bist.',
+    'Schön, dass du wieder hier bist, {firstName}.',
+    'Hi {firstName}, schön dich zu sehen.',
+    'Willkommen zurück.',
+    'Schön, dich wieder zu hören.',
+    'Schön, dass du wieder da bist.',
+    'Schön, von dir zu hören, {firstName}.',
+    'Hallo nochmal, {firstName}.',
+    'Schön, dich zu sehen, {firstName}.',
+    'Ich freue mich, dass du wieder da bist, {firstName}.',
+    'Hi {firstName}, willkommen zurück.',
+    'Toll, dass du wieder hier bist, {firstName}.',
+    'Willkommen zurück in Vitanaland, {firstName}.',
+    'Ich freue mich, dich wieder zu hören, {firstName}.',
+    'Schön, dass du da bist, {firstName}.',
+    'Gut, dich wieder zu hören, {firstName}.',
+    'Willkommen zurück. Schön, dich zu hören.',
+    'Hallo nochmal. Schön, von dir zu hören.',
+  ],
+};
+
+/**
+ * Pick one greeting phrase, substituting `{firstName}` when supplied.
+ *
+ * When no name is available, the function filters the pool to entries
+ * that don't reference `{firstName}` so we never speak the literal
+ * placeholder. When the name IS available we keep the full pool.
+ *
+ * Pure function. Caller supplies the random source (defaults to
+ * Math.random) so tests can pin the choice deterministically.
+ */
+export function pickTeacherGreeting(args: {
+  lang: string;
+  firstName?: string | null;
+  rng?: () => number;
+}): string {
+  const lang = (args.lang || 'en').toLowerCase();
+  const pool = GREETING_PHRASES[lang] || GREETING_PHRASES.en;
+  const hasName = !!(args.firstName && args.firstName.trim().length > 0);
+  const eligible = hasName ? pool : pool.filter((p) => !p.includes('{firstName}'));
+  // Defensive: if a lang lacks no-name phrases, fall back to en's no-name set.
+  const finalPool =
+    eligible.length > 0 ? eligible : GREETING_PHRASES.en.filter((p) => !p.includes('{firstName}'));
+  const rng = args.rng ?? Math.random;
+  const idx = Math.floor(rng() * finalPool.length) % finalPool.length;
+  const raw = finalPool[idx];
+  return hasName ? raw.replace('{firstName}', args.firstName!.trim()) : raw;
+}
+
+/**
+ * Exported for the Command Hub "Teach Vitanaland" panel — operators
+ * inspect the full pool in the read-only "Phrase Pools" section.
+ */
+export function listTeacherGreetings(lang: string): string[] {
+  return GREETING_PHRASES[(lang || 'en').toLowerCase()] || GREETING_PHRASES.en;
+}

--- a/services/gateway/src/services/assistant-continuation/providers/teacher/teacher-invitation-pool.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/teacher/teacher-invitation-pool.ts
@@ -1,0 +1,111 @@
+/**
+ * VTID-03092 (Teacher PR 2) — invitation pool for the Teacher
+ * (Feature Discovery Coach).
+ *
+ * The Teacher's spoken first turn is built as TWO clauses concatenated:
+ *
+ *   [greeting clause]  +  [invitation clause]
+ *
+ * This module owns the INVITATION clause only — the permission-asking
+ * second sentence that offers to introduce ONE unexplored Vitanaland
+ * feature. The greeting clause comes from `teacher-greeting-pool.ts`.
+ *
+ * Hard rules baked into this pool:
+ *   - Every phrase asks PERMISSION ("Darf ich…?", "Hast du kurz Zeit?",
+ *     "Magst du…?") — Vitana never assumes the user wants to be taught.
+ *   - No "How can I help you?" / "Wie kann ich dir helfen?" — the
+ *     Teacher's contract is "I want to introduce something to you",
+ *     not "tell me what you want". The user has been clear about this.
+ *   - No feature name is hardcoded here. The picked capability's
+ *     display_name is substituted via `{featureLabel}` at render time —
+ *     a few phrases name the feature, others stay abstract ("etwas
+ *     Neues", "something I want to show you") so we can rotate without
+ *     forcing the user to hear the capability name twice.
+ *   - All phrases end in a question mark (permission-asking).
+ *
+ * Pool size target: ~20 per language so Gemini's recency bias doesn't
+ * lock onto a single phrasing across the user's first 20+ sessions.
+ */
+
+const INVITATION_PHRASES: Record<string, string[]> = {
+  en: [
+    'May I show you something?',
+    'Do you have a moment? I would like to introduce something to you.',
+    'Would you like to see {featureLabel}?',
+    'May I introduce you to {featureLabel}?',
+    'Got a minute? I would love to show you something.',
+    'Is now a good time to show you something new?',
+    'May I take a minute to introduce something?',
+    'Would you like a quick tour of {featureLabel}?',
+    'I have something I would love to show you — interested?',
+    'Got a minute for a small discovery?',
+    'May I introduce one of our community features to you?',
+    'Would you like to learn about {featureLabel}?',
+    'Could I quickly walk you through {featureLabel}?',
+    'Do you have a couple of minutes for something new?',
+    'May I show you what {featureLabel} can do?',
+    'Got time for a 30-second introduction?',
+    'Would you like me to show you around {featureLabel}?',
+    'I would like to introduce you to {featureLabel} — okay?',
+    'May I share something about our community with you?',
+    'Want to discover something new in Vitanaland?',
+  ],
+  de: [
+    'Darf ich dir kurz etwas zeigen?',
+    'Hast du einen Moment? Ich möchte dir etwas vorstellen.',
+    'Magst du, dass ich dir {featureLabel} zeige?',
+    'Darf ich dir {featureLabel} vorstellen?',
+    'Hast du eine Minute? Ich würde dir gerne etwas zeigen.',
+    'Passt es dir gerade, wenn ich dir etwas Neues zeige?',
+    'Darf ich dir kurz {featureLabel} näherbringen?',
+    'Magst du eine kleine Tour durch {featureLabel}?',
+    'Ich habe etwas, das ich dir gerne zeigen würde — interessiert?',
+    'Hast du Lust auf eine kleine Entdeckung?',
+    'Darf ich dir eine unserer Community-Funktionen vorstellen?',
+    'Magst du mehr über {featureLabel} erfahren?',
+    'Soll ich dich kurz durch {featureLabel} führen?',
+    'Hast du ein paar Minuten für etwas Neues?',
+    'Darf ich dir zeigen, was {featureLabel} dir bringt?',
+    'Hast du Zeit für eine 30-Sekunden-Einführung?',
+    'Magst du, dass ich dich durch {featureLabel} führe?',
+    'Ich würde dir gerne {featureLabel} vorstellen — passt das?',
+    'Darf ich dir etwas aus unserer Community zeigen?',
+    'Magst du etwas Neues in Vitanaland entdecken?',
+  ],
+};
+
+/**
+ * Pick one invitation phrase, substituting `{featureLabel}` when supplied.
+ *
+ * When no feature label is given (e.g. the first call when the Teacher
+ * just wants to ask "may I introduce something" without naming what),
+ * the function filters the pool to entries that don't reference
+ * `{featureLabel}`.
+ *
+ * Pure function. Caller supplies the random source for deterministic tests.
+ */
+export function pickTeacherInvitation(args: {
+  lang: string;
+  featureLabel?: string | null;
+  rng?: () => number;
+}): string {
+  const lang = (args.lang || 'en').toLowerCase();
+  const pool = INVITATION_PHRASES[lang] || INVITATION_PHRASES.en;
+  const hasLabel = !!(args.featureLabel && args.featureLabel.trim().length > 0);
+  const eligible = hasLabel ? pool : pool.filter((p) => !p.includes('{featureLabel}'));
+  // Defensive: every lang has phrases without `{featureLabel}`; fall back
+  // to en's no-label subset if the lang somehow lacks them.
+  const finalPool =
+    eligible.length > 0
+      ? eligible
+      : INVITATION_PHRASES.en.filter((p) => !p.includes('{featureLabel}'));
+  const rng = args.rng ?? Math.random;
+  const idx = Math.floor(rng() * finalPool.length) % finalPool.length;
+  const raw = finalPool[idx];
+  return hasLabel ? raw.replace('{featureLabel}', args.featureLabel!.trim()) : raw;
+}
+
+/** Exported for the Command Hub "Teach Vitanaland" panel. */
+export function listTeacherInvitations(lang: string): string[] {
+  return INVITATION_PHRASES[(lang || 'en').toLowerCase()] || INVITATION_PHRASES.en;
+}

--- a/services/gateway/test/services/assistant-continuation/providers/teacher/teacher-pools.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/teacher/teacher-pools.test.ts
@@ -1,0 +1,170 @@
+/**
+ * VTID-03092 (Teacher PR 2) — pure tests for the greeting + invitation pools.
+ */
+
+import {
+  pickTeacherGreeting,
+  listTeacherGreetings,
+} from '../../../../../src/services/assistant-continuation/providers/teacher/teacher-greeting-pool';
+import {
+  pickTeacherInvitation,
+  listTeacherInvitations,
+} from '../../../../../src/services/assistant-continuation/providers/teacher/teacher-invitation-pool';
+
+// Deterministic RNG factory — produces 0, then increments by step,
+// wrapping at 1. Lets a test sweep through every index of the pool.
+function rngSeq(start: number) {
+  let v = start;
+  return () => {
+    const out = v;
+    v = (v + 1e-9) % 1;
+    return out;
+  };
+}
+
+describe('VTID-03092 — teacher-greeting-pool', () => {
+  test('substitutes firstName when provided', () => {
+    // Pick index 0 — the de pool starts with "Willkommen zurück, {firstName}."
+    const out = pickTeacherGreeting({
+      lang: 'de',
+      firstName: 'Dragan',
+      rng: () => 0,
+    });
+    expect(out).toBe('Willkommen zurück, Dragan.');
+  });
+
+  test('falls back to no-name phrases when firstName missing', () => {
+    // Sweep many indices; the result must NEVER contain "{firstName}".
+    for (let i = 0; i < 50; i++) {
+      const r = (i / 50) % 1;
+      const out = pickTeacherGreeting({ lang: 'de', firstName: null, rng: () => r });
+      expect(out).not.toContain('{firstName}');
+      expect(out.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('every named entry contains exactly one firstName slot', () => {
+    for (const lang of ['en', 'de']) {
+      for (const phrase of listTeacherGreetings(lang)) {
+        const matches = phrase.match(/\{firstName\}/g) ?? [];
+        expect(matches.length).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+
+  test('no dismissive openers leak in (banned-phrase guard)', () => {
+    const banned = [
+      /\byes\?/i,
+      /\bja bitte\b/i,
+      /\bwas gibt's neues\b/i,
+      /\bgo ahead\b/i,
+      /\bworum geht\b/i,
+      /\bbereit\./i,
+      /\bja\?/i,
+    ];
+    for (const lang of ['en', 'de']) {
+      for (const phrase of listTeacherGreetings(lang)) {
+        for (const re of banned) {
+          expect(phrase).not.toMatch(re);
+        }
+      }
+    }
+  });
+
+  test('unknown language falls back to English pool', () => {
+    const out = pickTeacherGreeting({ lang: 'xx', firstName: 'Alice', rng: () => 0 });
+    expect(out).toBe('Welcome back, Alice.');
+  });
+
+  test('variety floor: at least 16 phrases per supported lang', () => {
+    for (const lang of ['en', 'de']) {
+      expect(listTeacherGreetings(lang).length).toBeGreaterThanOrEqual(16);
+    }
+  });
+});
+
+describe('VTID-03092 — teacher-invitation-pool', () => {
+  test('substitutes featureLabel when provided', () => {
+    // de pool index 2: "Magst du, dass ich dir {featureLabel} zeige?"
+    const out = pickTeacherInvitation({
+      lang: 'de',
+      featureLabel: 'den Life Compass',
+      rng: () => 2 / 20,
+    });
+    expect(out).toContain('den Life Compass');
+    expect(out).not.toContain('{featureLabel}');
+  });
+
+  test('falls back to no-label phrases when label missing', () => {
+    for (let i = 0; i < 50; i++) {
+      const r = (i / 50) % 1;
+      const out = pickTeacherInvitation({ lang: 'de', featureLabel: null, rng: () => r });
+      expect(out).not.toContain('{featureLabel}');
+      expect(out.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('NO "Wie kann ich dir helfen" / "How can I help" anywhere', () => {
+    // Hard rule from the user: the Teacher must NEVER ask
+    // "how can I help you" as a standalone phrase. It only invites.
+    const banned = [/wie kann ich dir helfen/i, /how can i help/i];
+    for (const lang of ['en', 'de']) {
+      for (const phrase of listTeacherInvitations(lang)) {
+        for (const re of banned) {
+          expect(phrase).not.toMatch(re);
+        }
+      }
+    }
+  });
+
+  test('every phrase contains a question mark (permission-asking)', () => {
+    // Phrases may have a question + explanatory follow-up
+    // ("Do you have a moment? I would like to introduce something."),
+    // so we only require AT LEAST one '?' in the phrase, not that it
+    // ends with one.
+    for (const lang of ['en', 'de']) {
+      for (const phrase of listTeacherInvitations(lang)) {
+        expect(phrase.includes('?')).toBe(true);
+      }
+    }
+  });
+
+  test('every featureLabel slot appears at most once per phrase', () => {
+    for (const lang of ['en', 'de']) {
+      for (const phrase of listTeacherInvitations(lang)) {
+        const matches = phrase.match(/\{featureLabel\}/g) ?? [];
+        expect(matches.length).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+
+  test('unknown language falls back to English pool', () => {
+    const out = pickTeacherInvitation({ lang: 'xx', featureLabel: null, rng: () => 0 });
+    expect(out.length).toBeGreaterThan(0);
+    // First English no-label entry is "May I show you something?"
+    expect(out).toBe('May I show you something?');
+  });
+
+  test('variety floor: at least 16 phrases per supported lang', () => {
+    for (const lang of ['en', 'de']) {
+      expect(listTeacherInvitations(lang).length).toBeGreaterThanOrEqual(16);
+    }
+  });
+});
+
+describe('VTID-03092 — combined greeting + invitation render', () => {
+  test('concatenation produces a clean two-sentence utterance', () => {
+    const greeting = pickTeacherGreeting({
+      lang: 'de',
+      firstName: 'Dragan',
+      rng: () => 0,
+    });
+    const invitation = pickTeacherInvitation({
+      lang: 'de',
+      featureLabel: null,
+      rng: () => 0,
+    });
+    const full = `${greeting} ${invitation}`;
+    expect(full).toBe('Willkommen zurück, Dragan. Darf ich dir kurz etwas zeigen?');
+  });
+});


### PR DESCRIPTION
## Teacher PR 2 of 5 — phrase pools

Two pure modules. No DB, no fetch, no provider hooks. The Teacher renders its spoken first turn as TWO clauses concatenated: `[greeting]  +  [invitation]`.

### `teacher-greeting-pool.ts`
- 20 warm greetings per language (DE + EN)
- `{firstName}` substitution; no-name fallback set when name absent
- Banned-phrase guard: no `Yes?` / `Ja bitte?` / `Was gibt's Neues?` / `Go ahead` / `Worum geht's?` / `Bereit.`

### `teacher-invitation-pool.ts`
- 20 permission-asking invitations per language (DE + EN)
- `{featureLabel}` substitution; abstract phrases when no label
- **Hard rule baked in:** NO `How can I help you?` / `Wie kann ich dir helfen?` anywhere. The Teacher's contract is "may I introduce something to you?", never "tell me what you need".

### Test plan
- [x] 14 tests green
- [x] Banned-phrase guards for both pools
- [x] Combined render test confirms clean two-sentence output: `"Willkommen zurück, Dragan. Darf ich dir kurz etwas zeigen?"`
- [x] Gateway build green

🤖 Generated with [Claude Code](https://claude.com/claude-code)