### PR TITLE
feat(teacher): Feature Discovery Coach provider (VTID-03093)

### DIFF
--- a/services/gateway/src/services/assistant-continuation/providers/teacher/feature-discovery-teacher.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/teacher/feature-discovery-teacher.ts
@@ -1,0 +1,448 @@
+/**
+ * VTID-03093 (Teacher PR 3) — Feature Discovery Coach ("the Teacher").
+ *
+ * The Teacher is a separate role from the Guide (next-action composer).
+ *
+ *   Guide  → picks the user's ONE most-actionable next move (reminder,
+ *            calendar, autopilot, match, ...). Wins when there is real
+ *            actionable data.
+ *
+ *   Teacher → picks ONE unexplored Vitanaland / Maxina capability and
+ *            asks permission to introduce it. Wins when the Guide has
+ *            nothing concrete AND the user has unexplored capabilities
+ *            AND cadence allows.
+ *
+ *   Default → silence (when both above suppress).
+ *
+ * The Teacher renders its spoken first turn as TWO clauses concatenated:
+ *
+ *   [greeting clause]  +  [invitation clause]
+ *
+ * The greeting clause is name-aware ("Schön, dich wieder zu hören,
+ * Dragan."). The invitation clause asks permission ("Darf ich dir den
+ * Life Compass vorstellen?"). Both clauses are picked from pure pools
+ * in `teacher-greeting-pool.ts` + `teacher-invitation-pool.ts`.
+ *
+ * Hard rules (carried forward from the user's spec):
+ *   - NEVER list features. ONE capability at a time.
+ *   - NEVER hardcode "How can I help you?" / "Wie kann ich dir helfen?".
+ *   - NEVER paste manual content into the prompt. The intro line is in
+ *     the catalog; the agent navigates the user to `manual_path` on
+ *     accept.
+ *   - Suppress when greetingPolicy === 'skip' (B1 cadence wins).
+ *   - Suppress when there are no unexplored capabilities left
+ *     (all_capabilities_mastered).
+ *   - Selection is READ-ONLY. State advancement (introduced / dismissed)
+ *     lives in PR 4 via `advance_capability_awareness` RPC.
+ */
+
+import { randomUUID } from 'crypto';
+import type { SupabaseClient } from '@supabase/supabase-js';
+import type {
+  AssistantContinuation,
+  ContinuationProvider,
+  ContinuationDecisionContext,
+  ProviderResult,
+} from '../../types';
+import type { GreetingPolicy } from '../../../../orb/live/instruction/greeting-policy';
+import {
+  pickTeacherGreeting,
+  listTeacherGreetings,
+} from './teacher-greeting-pool';
+import {
+  pickTeacherInvitation,
+  listTeacherInvitations,
+} from './teacher-invitation-pool';
+
+// ---------------------------------------------------------------------------
+// Inputs — caller forwards via ctx.extra.teacher
+// ---------------------------------------------------------------------------
+
+export const TEACHER_EXTRA_KEY = 'teacher' as const;
+export const TEACHER_PROVIDER_KEY = 'feature_discovery_teacher' as const;
+
+// Priority 75 — sits between voice_wake_brief (80) and the lowest band
+// of next-action sources (~50). Guide picks above-50 candidates first;
+// when Guide has nothing, Teacher's offer beats the bare wake-brief
+// fallback. Wake-brief at 80 still wins ONLY when the renderer
+// produces a non-empty line AND we explicitly chose the wake-brief
+// path (e.g. pillar-momentum proactive variant). The composer keeps
+// the Teacher candidate as a co-equal fallback if voice_wake_brief
+// returns the generic policy line — they have different `kind`s
+// (`wake_brief` vs `feature_discovery`) and different dedupeKeys.
+const DEFAULT_PRIORITY = 75;
+
+const DEFAULT_LOOKBACK_INTRODUCED_DAYS = 7;
+const MAX_DISMISS_BEFORE_PERMANENT = 3;
+
+export interface TeacherInputs {
+  /** Supabase service-role client. Required — DB-backed selection. */
+  supabase: SupabaseClient;
+  /** Tenant + user identity. Anonymous sessions can't run the Teacher. */
+  tenantId: string;
+  userId: string;
+  /** Resolved language for the spoken line. Falls back to 'en'. */
+  lang: string;
+  /** User's first name when known (from identity facts). */
+  firstName?: string | null;
+  /** B1 greeting policy. When 'skip', Teacher also suppresses. */
+  greetingPolicy: GreetingPolicy;
+  /** ISO 8601 server-side now. Used for the introduced-within-N-days
+   *  filter so a candidate isn't re-introduced too soon. */
+  nowIso?: string;
+}
+
+// ---------------------------------------------------------------------------
+// Pure helpers — exported for tests
+// ---------------------------------------------------------------------------
+
+export interface CapabilityCatalogRow {
+  capability_key: string;
+  display_name: string;
+  description: string;
+  manual_path: string | null;
+  enabled: boolean;
+}
+
+export interface AwarenessLedgerRow {
+  capability_key: string;
+  awareness_state: string;
+  dismiss_count: number;
+  last_introduced_at: string | null;
+}
+
+export interface PickedCapability {
+  row: CapabilityCatalogRow;
+  /** Current awareness state from the ledger, or 'unknown' when no row exists. */
+  awarenessState: string;
+}
+
+/**
+ * Filter + rank rule (deterministic, pure):
+ *   1. Drop disabled rows.
+ *   2. Drop rows whose ledger state ∈ {tried, completed, mastered, dismissed}
+ *      UNLESS the dismiss_count is exactly 1 AND the row hasn't been
+ *      reintroduced in 30 days (gentle re-offer after long absence).
+ *   3. Drop rows that have been introduced within the last
+ *      DEFAULT_LOOKBACK_INTRODUCED_DAYS days (avoid back-to-back
+ *      repetition).
+ *   4. Drop rows with dismiss_count >= MAX_DISMISS_BEFORE_PERMANENT
+ *      (3 strikes — permanent for this user).
+ *   5. Sort eligibles by:
+ *      a) Never-introduced first (awareness_state === 'unknown')
+ *      b) Then oldest last_introduced_at first
+ *      c) Then dismiss_count ascending (lower is preferred)
+ *      d) Then capability_key alphabetical (deterministic tie-break)
+ *   6. Pick top 1.
+ */
+export function pickCapability(
+  catalog: CapabilityCatalogRow[],
+  ledger: AwarenessLedgerRow[],
+  nowIso: string,
+): PickedCapability | null {
+  const nowMs = Date.parse(nowIso);
+  if (!Number.isFinite(nowMs)) return null;
+  const lookbackMs = nowMs - DEFAULT_LOOKBACK_INTRODUCED_DAYS * 24 * 60 * 60 * 1000;
+  const reintroduceAfterMs = nowMs - 30 * 24 * 60 * 60 * 1000;
+
+  const ledgerByKey = new Map<string, AwarenessLedgerRow>();
+  for (const row of ledger) ledgerByKey.set(row.capability_key, row);
+
+  const eligible: PickedCapability[] = [];
+  for (const cap of catalog) {
+    if (!cap.enabled) continue;
+    const lr = ledgerByKey.get(cap.capability_key);
+    const state = lr?.awareness_state ?? 'unknown';
+    const dismissCount = lr?.dismiss_count ?? 0;
+    const lastIntroducedAt = lr?.last_introduced_at
+      ? Date.parse(lr.last_introduced_at)
+      : null;
+
+    // 4. Permanent strike-out
+    if (dismissCount >= MAX_DISMISS_BEFORE_PERMANENT) continue;
+
+    // 2. Terminal / progressed states
+    if (state === 'tried' || state === 'completed' || state === 'mastered') {
+      continue;
+    }
+    if (state === 'dismissed') {
+      // Gentle re-offer after 30 days iff this is the only dismissal
+      if (dismissCount !== 1) continue;
+      if (lastIntroducedAt === null) continue;
+      if (lastIntroducedAt > reintroduceAfterMs) continue;
+    }
+
+    // 3. Recent-introduction guard
+    if (
+      lastIntroducedAt !== null &&
+      Number.isFinite(lastIntroducedAt) &&
+      lastIntroducedAt > lookbackMs
+    ) {
+      continue;
+    }
+
+    eligible.push({ row: cap, awarenessState: state });
+  }
+
+  if (eligible.length === 0) return null;
+
+  eligible.sort((a, b) => {
+    // 5a. Never-introduced first
+    const aNever = a.awarenessState === 'unknown' ? 0 : 1;
+    const bNever = b.awarenessState === 'unknown' ? 0 : 1;
+    if (aNever !== bNever) return aNever - bNever;
+
+    // 5b. Oldest last_introduced_at first
+    const al = ledgerByKey.get(a.row.capability_key)?.last_introduced_at ?? null;
+    const bl = ledgerByKey.get(b.row.capability_key)?.last_introduced_at ?? null;
+    const aMs = al ? Date.parse(al) : -Infinity;
+    const bMs = bl ? Date.parse(bl) : -Infinity;
+    if (aMs !== bMs) return aMs - bMs;
+
+    // 5c. Lower dismiss_count
+    const ad = ledgerByKey.get(a.row.capability_key)?.dismiss_count ?? 0;
+    const bd = ledgerByKey.get(b.row.capability_key)?.dismiss_count ?? 0;
+    if (ad !== bd) return ad - bd;
+
+    // 5d. Alphabetical tie-break
+    return a.row.capability_key.localeCompare(b.row.capability_key);
+  });
+
+  return eligible[0];
+}
+
+/**
+ * Render the full two-clause first utterance from a picked capability.
+ * Pure function — caller supplies RNG so tests can pin the output.
+ */
+export function renderTeacherLine(args: {
+  greeting: string;
+  invitation: string;
+}): string {
+  // Trim every clause, join with a single space. Greeting ends in `.`
+  // (enforced by the pool), invitation has a `?` somewhere.
+  return `${args.greeting.trim()} ${args.invitation.trim()}`;
+}
+
+// ---------------------------------------------------------------------------
+// Provider factory
+// ---------------------------------------------------------------------------
+
+export interface TeacherProviderOptions {
+  /** Override priority. Default 75. */
+  priority?: number;
+  /** Deterministic id generator for tests. */
+  newId?: () => string;
+  /** Deterministic clock for tests. */
+  now?: () => number;
+  /** Deterministic RNG for pool picks (greeting + invitation). */
+  rng?: () => number;
+}
+
+/**
+ * Build the Teacher provider. Factory pattern matches voice-wake-brief
+ * for consistency: production wiring registers ONE instance; tests
+ * build their own with deterministic deps.
+ */
+export function makeFeatureDiscoveryTeacherProvider(
+  opts: TeacherProviderOptions = {},
+): ContinuationProvider {
+  const newId = opts.newId ?? randomUUID;
+  const now = opts.now ?? (() => Date.now());
+  const priority = opts.priority ?? DEFAULT_PRIORITY;
+  const rng = opts.rng ?? Math.random;
+
+  return {
+    key: TEACHER_PROVIDER_KEY,
+    surfaces: ['orb_wake'],
+    async produce(ctx: ContinuationDecisionContext): Promise<ProviderResult> {
+      const t0 = now();
+      const inputs = readInputs(ctx);
+      if (!inputs) {
+        return {
+          providerKey: TEACHER_PROVIDER_KEY,
+          status: 'skipped',
+          latencyMs: Math.max(0, now() - t0),
+          reason: 'no_teacher_inputs',
+        };
+      }
+
+      // Cadence wall: when B1 says skip, the Teacher MUST stay silent.
+      if (inputs.greetingPolicy === 'skip') {
+        return {
+          providerKey: TEACHER_PROVIDER_KEY,
+          status: 'suppressed',
+          latencyMs: Math.max(0, now() - t0),
+          reason: 'greeting_policy_skip',
+        };
+      }
+
+      // ---- DB fetch: catalog + ledger ----
+      let catalog: CapabilityCatalogRow[];
+      let ledger: AwarenessLedgerRow[];
+      try {
+        const cap = await inputs.supabase
+          .from('system_capabilities')
+          .select('capability_key, display_name, description, manual_path, enabled')
+          .eq('enabled', true);
+        if (cap.error) {
+          return {
+            providerKey: TEACHER_PROVIDER_KEY,
+            status: 'errored',
+            latencyMs: Math.max(0, now() - t0),
+            reason: `catalog_fetch_failed: ${cap.error.message}`,
+          };
+        }
+        catalog = (cap.data || []) as CapabilityCatalogRow[];
+
+        const led = await inputs.supabase
+          .from('user_capability_awareness')
+          .select('capability_key, awareness_state, dismiss_count, last_introduced_at')
+          .eq('tenant_id', inputs.tenantId)
+          .eq('user_id', inputs.userId);
+        if (led.error) {
+          // Ledger fetch failures degrade to empty ledger — every capability
+          // is treated as 'unknown'. Better than silencing the Teacher.
+          ledger = [];
+        } else {
+          ledger = (led.data || []) as AwarenessLedgerRow[];
+        }
+      } catch (err) {
+        return {
+          providerKey: TEACHER_PROVIDER_KEY,
+          status: 'errored',
+          latencyMs: Math.max(0, now() - t0),
+          reason: err instanceof Error ? err.message : String(err),
+        };
+      }
+
+      if (catalog.length === 0) {
+        // Catalog empty — migrations not applied, or every row disabled.
+        // Treat as "nothing to teach right now"; Guide / wake-brief decide.
+        return {
+          providerKey: TEACHER_PROVIDER_KEY,
+          status: 'suppressed',
+          latencyMs: Math.max(0, now() - t0),
+          reason: 'empty_catalog',
+        };
+      }
+
+      const nowIso = inputs.nowIso ?? new Date().toISOString();
+      const picked = pickCapability(catalog, ledger, nowIso);
+      if (!picked) {
+        return {
+          providerKey: TEACHER_PROVIDER_KEY,
+          status: 'suppressed',
+          latencyMs: Math.max(0, now() - t0),
+          reason: 'all_capabilities_known_or_dismissed',
+        };
+      }
+
+      // ---- Render the two-clause line ----
+      const greeting = pickTeacherGreeting({
+        lang: inputs.lang,
+        firstName: inputs.firstName ?? null,
+        rng,
+      });
+      // For the FIRST introduction we keep the invitation abstract
+      // (no featureLabel) — Vitana asks "may I show you something?"
+      // and only names the capability AFTER the user accepts. This
+      // matches the user's spec ("Darf ich dir kurz etwas zeigen?").
+      // A future tuning slice can flip this rule per-capability.
+      const invitation = pickTeacherInvitation({
+        lang: inputs.lang,
+        featureLabel: null,
+        rng,
+      });
+      const userFacingLine = renderTeacherLine({ greeting, invitation });
+
+      const candidate: AssistantContinuation = {
+        id: `teacher-${newId()}`,
+        surface: 'orb_wake',
+        kind: 'feature_discovery',
+        priority,
+        userFacingLine,
+        cta: {
+          type: 'offer_demo',
+          payload: {
+            capability_key: picked.row.capability_key,
+            manual_path: picked.row.manual_path ?? null,
+            display_name: picked.row.display_name,
+          },
+        },
+        evidence: [
+          {
+            kind: 'capability:eligible',
+            detail: picked.row.capability_key,
+          },
+          {
+            kind: 'awareness_state',
+            detail: picked.awarenessState,
+          },
+          {
+            kind: 'catalog_size',
+            detail: String(catalog.length),
+          },
+        ],
+        dedupeKey: `teacher:${picked.row.capability_key}`,
+        privacyMode: 'safe_to_speak',
+      };
+
+      return {
+        providerKey: TEACHER_PROVIDER_KEY,
+        status: 'returned',
+        latencyMs: Math.max(0, now() - t0),
+        candidate,
+      };
+    },
+  };
+}
+
+function readInputs(ctx: ContinuationDecisionContext): TeacherInputs | null {
+  const extra = ctx.extra;
+  if (!extra || typeof extra !== 'object') return null;
+  const raw = (extra as Record<string, unknown>)[TEACHER_EXTRA_KEY];
+  if (!raw || typeof raw !== 'object') return null;
+  const obj = raw as Record<string, unknown>;
+  const supabase = obj.supabase;
+  if (
+    !supabase ||
+    typeof supabase !== 'object' ||
+    typeof (supabase as Record<string, unknown>).from !== 'function'
+  ) {
+    return null;
+  }
+  if (typeof obj.tenantId !== 'string' || !obj.tenantId) return null;
+  if (typeof obj.userId !== 'string' || !obj.userId) return null;
+  const gp = obj.greetingPolicy;
+  if (
+    gp !== 'skip' &&
+    gp !== 'brief_resume' &&
+    gp !== 'warm_return' &&
+    gp !== 'fresh_intro'
+  ) {
+    return null;
+  }
+  return {
+    supabase: supabase as SupabaseClient,
+    tenantId: obj.tenantId,
+    userId: obj.userId,
+    lang: typeof obj.lang === 'string' && obj.lang ? obj.lang : 'en',
+    firstName:
+      typeof obj.firstName === 'string' && obj.firstName.trim().length > 0
+        ? obj.firstName
+        : null,
+    greetingPolicy: gp,
+    nowIso: typeof obj.nowIso === 'string' && obj.nowIso ? obj.nowIso : undefined,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// Re-exports for the Command Hub "Teach Vitanaland" panel (PR 5)
+// ---------------------------------------------------------------------------
+export {
+  listTeacherGreetings,
+  listTeacherInvitations,
+  pickTeacherGreeting,
+  pickTeacherInvitation,
+};

--- a/services/gateway/src/services/assistant-continuation/providers/teacher/teacher-greeting-pool.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/teacher/teacher-greeting-pool.ts
@@ -1,0 +1,108 @@
+/**
+ * VTID-03092 (Teacher PR 2) — name-aware greeting pool for the Teacher
+ * (Feature Discovery Coach).
+ *
+ * The Teacher's spoken first turn is built as TWO clauses concatenated:
+ *
+ *   [greeting clause]  +  [invitation clause]
+ *
+ * This module owns the GREETING clause only. It picks one warm,
+ * service-grade phrase that acknowledges the user's return (using
+ * their first name when known). The invitation clause comes from
+ * `teacher-invitation-pool.ts` and asks permission to introduce ONE
+ * unexplored Vitanaland feature.
+ *
+ * Hard rules baked into this pool:
+ *   - No dismissive openers ("Yes?", "Ja bitte?", "What's up?").
+ *   - Every phrase ends in a period — the invitation appends after.
+ *   - Phrases with `{firstName}` substitute the user's first name when
+ *     available; phrases without it are the no-name fallback set.
+ *   - All phrases use the user's language. Unsupported langs fall back
+ *     to English.
+ *
+ * Pool size target: ~20 per language (mix of with-name + no-name
+ * variants) so Gemini's recency bias is broken across sessions.
+ */
+
+const GREETING_PHRASES: Record<string, string[]> = {
+  en: [
+    'Welcome back, {firstName}.',
+    'Hi again, {firstName}.',
+    'Good to see you again, {firstName}.',
+    'Glad you are back, {firstName}.',
+    'Nice to hear you, {firstName}.',
+    'Welcome back.',
+    'Hi again.',
+    'Good to have you back.',
+    'It is good to hear from you, {firstName}.',
+    'Welcome, {firstName}.',
+    'Lovely to see you again, {firstName}.',
+    'Hello again, {firstName}.',
+    'Hi, {firstName}. Good to have you back.',
+    'It is great that you are here, {firstName}.',
+    'Welcome back to Vitanaland, {firstName}.',
+    'I am happy you are here, {firstName}.',
+    'Good to have you with us again, {firstName}.',
+    'Hi, {firstName}. Glad you stopped by.',
+    'Welcome back. It is good to hear you.',
+    'Hello again. Nice to hear you.',
+  ],
+  de: [
+    'Willkommen zurück, {firstName}.',
+    'Schön, dich wieder zu hören, {firstName}.',
+    'Hallo {firstName}, schön, dass du wieder da bist.',
+    'Schön, dass du wieder hier bist, {firstName}.',
+    'Hi {firstName}, schön dich zu sehen.',
+    'Willkommen zurück.',
+    'Schön, dich wieder zu hören.',
+    'Schön, dass du wieder da bist.',
+    'Schön, von dir zu hören, {firstName}.',
+    'Hallo nochmal, {firstName}.',
+    'Schön, dich zu sehen, {firstName}.',
+    'Ich freue mich, dass du wieder da bist, {firstName}.',
+    'Hi {firstName}, willkommen zurück.',
+    'Toll, dass du wieder hier bist, {firstName}.',
+    'Willkommen zurück in Vitanaland, {firstName}.',
+    'Ich freue mich, dich wieder zu hören, {firstName}.',
+    'Schön, dass du da bist, {firstName}.',
+    'Gut, dich wieder zu hören, {firstName}.',
+    'Willkommen zurück. Schön, dich zu hören.',
+    'Hallo nochmal. Schön, von dir zu hören.',
+  ],
+};
+
+/**
+ * Pick one greeting phrase, substituting `{firstName}` when supplied.
+ *
+ * When no name is available, the function filters the pool to entries
+ * that don't reference `{firstName}` so we never speak the literal
+ * placeholder. When the name IS available we keep the full pool.
+ *
+ * Pure function. Caller supplies the random source (defaults to
+ * Math.random) so tests can pin the choice deterministically.
+ */
+export function pickTeacherGreeting(args: {
+  lang: string;
+  firstName?: string | null;
+  rng?: () => number;
+}): string {
+  const lang = (args.lang || 'en').toLowerCase();
+  const pool = GREETING_PHRASES[lang] || GREETING_PHRASES.en;
+  const hasName = !!(args.firstName && args.firstName.trim().length > 0);
+  const eligible = hasName ? pool : pool.filter((p) => !p.includes('{firstName}'));
+  // Defensive: if a lang lacks no-name phrases, fall back to en's no-name set.
+  const finalPool =
+    eligible.length > 0 ? eligible : GREETING_PHRASES.en.filter((p) => !p.includes('{firstName}'));
+  const rng = args.rng ?? Math.random;
+  const idx = Math.floor(rng() * finalPool.length) % finalPool.length;
+  const raw = finalPool[idx];
+  return hasName ? raw.replace('{firstName}', args.firstName!.trim()) : raw;
+}
+
+/**
+ * Exported for the Command Hub "Teach Vitanaland" panel — operators
+ * inspect the full pool in the read-only "Phrase Pools" section.
+ */
+export function listTeacherGreetings(lang: string): string[] {
+  return GREETING_PHRASES[(lang || 'en').toLowerCase()] || GREETING_PHRASES.en;
+}

--- a/services/gateway/src/services/assistant-continuation/providers/teacher/teacher-invitation-pool.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/teacher/teacher-invitation-pool.ts
@@ -1,0 +1,111 @@
+/**
+ * VTID-03092 (Teacher PR 2) — invitation pool for the Teacher
+ * (Feature Discovery Coach).
+ *
+ * The Teacher's spoken first turn is built as TWO clauses concatenated:
+ *
+ *   [greeting clause]  +  [invitation clause]
+ *
+ * This module owns the INVITATION clause only — the permission-asking
+ * second sentence that offers to introduce ONE unexplored Vitanaland
+ * feature. The greeting clause comes from `teacher-greeting-pool.ts`.
+ *
+ * Hard rules baked into this pool:
+ *   - Every phrase asks PERMISSION ("Darf ich…?", "Hast du kurz Zeit?",
+ *     "Magst du…?") — Vitana never assumes the user wants to be taught.
+ *   - No "How can I help you?" / "Wie kann ich dir helfen?" — the
+ *     Teacher's contract is "I want to introduce something to you",
+ *     not "tell me what you want". The user has been clear about this.
+ *   - No feature name is hardcoded here. The picked capability's
+ *     display_name is substituted via `{featureLabel}` at render time —
+ *     a few phrases name the feature, others stay abstract ("etwas
+ *     Neues", "something I want to show you") so we can rotate without
+ *     forcing the user to hear the capability name twice.
+ *   - All phrases end in a question mark (permission-asking).
+ *
+ * Pool size target: ~20 per language so Gemini's recency bias doesn't
+ * lock onto a single phrasing across the user's first 20+ sessions.
+ */
+
+const INVITATION_PHRASES: Record<string, string[]> = {
+  en: [
+    'May I show you something?',
+    'Do you have a moment? I would like to introduce something to you.',
+    'Would you like to see {featureLabel}?',
+    'May I introduce you to {featureLabel}?',
+    'Got a minute? I would love to show you something.',
+    'Is now a good time to show you something new?',
+    'May I take a minute to introduce something?',
+    'Would you like a quick tour of {featureLabel}?',
+    'I have something I would love to show you — interested?',
+    'Got a minute for a small discovery?',
+    'May I introduce one of our community features to you?',
+    'Would you like to learn about {featureLabel}?',
+    'Could I quickly walk you through {featureLabel}?',
+    'Do you have a couple of minutes for something new?',
+    'May I show you what {featureLabel} can do?',
+    'Got time for a 30-second introduction?',
+    'Would you like me to show you around {featureLabel}?',
+    'I would like to introduce you to {featureLabel} — okay?',
+    'May I share something about our community with you?',
+    'Want to discover something new in Vitanaland?',
+  ],
+  de: [
+    'Darf ich dir kurz etwas zeigen?',
+    'Hast du einen Moment? Ich möchte dir etwas vorstellen.',
+    'Magst du, dass ich dir {featureLabel} zeige?',
+    'Darf ich dir {featureLabel} vorstellen?',
+    'Hast du eine Minute? Ich würde dir gerne etwas zeigen.',
+    'Passt es dir gerade, wenn ich dir etwas Neues zeige?',
+    'Darf ich dir kurz {featureLabel} näherbringen?',
+    'Magst du eine kleine Tour durch {featureLabel}?',
+    'Ich habe etwas, das ich dir gerne zeigen würde — interessiert?',
+    'Hast du Lust auf eine kleine Entdeckung?',
+    'Darf ich dir eine unserer Community-Funktionen vorstellen?',
+    'Magst du mehr über {featureLabel} erfahren?',
+    'Soll ich dich kurz durch {featureLabel} führen?',
+    'Hast du ein paar Minuten für etwas Neues?',
+    'Darf ich dir zeigen, was {featureLabel} dir bringt?',
+    'Hast du Zeit für eine 30-Sekunden-Einführung?',
+    'Magst du, dass ich dich durch {featureLabel} führe?',
+    'Ich würde dir gerne {featureLabel} vorstellen — passt das?',
+    'Darf ich dir etwas aus unserer Community zeigen?',
+    'Magst du etwas Neues in Vitanaland entdecken?',
+  ],
+};
+
+/**
+ * Pick one invitation phrase, substituting `{featureLabel}` when supplied.
+ *
+ * When no feature label is given (e.g. the first call when the Teacher
+ * just wants to ask "may I introduce something" without naming what),
+ * the function filters the pool to entries that don't reference
+ * `{featureLabel}`.
+ *
+ * Pure function. Caller supplies the random source for deterministic tests.
+ */
+export function pickTeacherInvitation(args: {
+  lang: string;
+  featureLabel?: string | null;
+  rng?: () => number;
+}): string {
+  const lang = (args.lang || 'en').toLowerCase();
+  const pool = INVITATION_PHRASES[lang] || INVITATION_PHRASES.en;
+  const hasLabel = !!(args.featureLabel && args.featureLabel.trim().length > 0);
+  const eligible = hasLabel ? pool : pool.filter((p) => !p.includes('{featureLabel}'));
+  // Defensive: every lang has phrases without `{featureLabel}`; fall back
+  // to en's no-label subset if the lang somehow lacks them.
+  const finalPool =
+    eligible.length > 0
+      ? eligible
+      : INVITATION_PHRASES.en.filter((p) => !p.includes('{featureLabel}'));
+  const rng = args.rng ?? Math.random;
+  const idx = Math.floor(rng() * finalPool.length) % finalPool.length;
+  const raw = finalPool[idx];
+  return hasLabel ? raw.replace('{featureLabel}', args.featureLabel!.trim()) : raw;
+}
+
+/** Exported for the Command Hub "Teach Vitanaland" panel. */
+export function listTeacherInvitations(lang: string): string[] {
+  return INVITATION_PHRASES[(lang || 'en').toLowerCase()] || INVITATION_PHRASES.en;
+}

--- a/services/gateway/src/services/wake-brief-wiring.ts
+++ b/services/gateway/src/services/wake-brief-wiring.ts
@@ -44,6 +44,14 @@ import {
   NEXT_ACTION_PROVIDER_KEY,
 } from './assistant-continuation/providers/next-action';
 import './assistant-continuation/providers/next-action/register-default-sources';
+// VTID-03093 (Teacher PR 3): the Feature Discovery Coach. Sits at
+// priority 75 — beats the bare wake-brief fallback when the user has
+// unexplored capabilities, loses to next-action candidates above 50.
+import {
+  makeFeatureDiscoveryTeacherProvider,
+  TEACHER_EXTRA_KEY,
+  TEACHER_PROVIDER_KEY,
+} from './assistant-continuation/providers/teacher/feature-discovery-teacher';
 // VTID-03061 (B0d-real Xf.1): auto-emit OASIS next_action.suggested/
 // .suppressed events when a wake-brief decision lands. Fire-and-forget;
 // never blocks the voice path.
@@ -83,6 +91,13 @@ export function ensureWakeBriefProviderRegistered(): void {
   // framework's decideContinuation picks voice-wake-brief instead.
   if (!defaultProviderRegistry.get(NEXT_ACTION_PROVIDER_KEY)) {
     defaultProviderRegistry.register(makeNextActionProvider());
+  }
+  // VTID-03093: Teacher (Feature Discovery Coach). Priority 75 — wins
+  // when next-action has nothing and the user has an unexplored
+  // capability. Requires the system_capabilities + user_capability_awareness
+  // tables; degrades to `suppressed:empty_catalog` when missing.
+  if (!defaultProviderRegistry.get(TEACHER_PROVIDER_KEY)) {
+    defaultProviderRegistry.register(makeFeatureDiscoveryTeacherProvider());
   }
   _registered = true;
 }
@@ -168,6 +183,13 @@ export interface DecideWakeBriefArgs {
    * for tests; production callers set it true.
    */
   recordEmission?: boolean;
+  /**
+   * VTID-03093 (Teacher PR 3): user's first name (when known) so the
+   * Teacher greeting clause can address them by name. Pulled from
+   * identity_facts at the caller side. Anonymous sessions pass null /
+   * absent and the Teacher's pool falls back to no-name phrases.
+   */
+  firstName?: string | null;
 }
 
 // ---------------------------------------------------------------------------
@@ -263,6 +285,18 @@ export async function decideWakeBriefForSession(
       decisionContext: args.decisionContext ?? null,
       lang: args.lang,
     };
+    // VTID-03093 (Teacher PR 3): forward Teacher inputs when identity is
+    // known. Anonymous sessions are skipped at the provider level.
+    if (args.tenantId && args.userId) {
+      extra[TEACHER_EXTRA_KEY] = {
+        supabase: args.supabase,
+        tenantId: args.tenantId,
+        userId: args.userId,
+        lang: args.lang,
+        firstName: args.firstName ?? null,
+        greetingPolicy,
+      };
+    }
   }
 
   const t0 = now();

--- a/services/gateway/test/services/assistant-continuation/providers/teacher/feature-discovery-teacher.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/teacher/feature-discovery-teacher.test.ts
@@ -1,0 +1,370 @@
+/**
+ * VTID-03093 (Teacher PR 3) — Feature Discovery Coach provider tests.
+ */
+
+import {
+  makeFeatureDiscoveryTeacherProvider,
+  pickCapability,
+  renderTeacherLine,
+  TEACHER_EXTRA_KEY,
+  TEACHER_PROVIDER_KEY,
+  type CapabilityCatalogRow,
+  type AwarenessLedgerRow,
+} from '../../../../../src/services/assistant-continuation/providers/teacher/feature-discovery-teacher';
+import type { ContinuationDecisionContext } from '../../../../../src/services/assistant-continuation/types';
+
+const NOW_ISO = '2026-05-19T08:00:00Z';
+const NOW_MS = Date.parse(NOW_ISO);
+const DAY_MS = 24 * 60 * 60 * 1000;
+
+function cat(over: Partial<CapabilityCatalogRow> = {}): CapabilityCatalogRow {
+  return {
+    capability_key: 'life_compass',
+    display_name: 'Life Compass',
+    description: 'desc',
+    manual_path: '/manuals/maxina/00-concepts/life-compass',
+    enabled: true,
+    ...over,
+  };
+}
+
+function lr(over: Partial<AwarenessLedgerRow> = {}): AwarenessLedgerRow {
+  return {
+    capability_key: 'life_compass',
+    awareness_state: 'unknown',
+    dismiss_count: 0,
+    last_introduced_at: null,
+    ...over,
+  };
+}
+
+// ---------------------------------------------------------------------------
+// pickCapability — pure ranker
+// ---------------------------------------------------------------------------
+
+describe('VTID-03093 — pickCapability', () => {
+  test('empty catalog → null', () => {
+    expect(pickCapability([], [], NOW_ISO)).toBeNull();
+  });
+
+  test('all-disabled catalog → null', () => {
+    expect(pickCapability([cat({ enabled: false })], [], NOW_ISO)).toBeNull();
+  });
+
+  test('never-introduced wins over recently-introduced', () => {
+    const catalog: CapabilityCatalogRow[] = [
+      cat({ capability_key: 'a' }),
+      cat({ capability_key: 'b' }),
+    ];
+    const ledger: AwarenessLedgerRow[] = [
+      lr({
+        capability_key: 'a',
+        awareness_state: 'introduced',
+        last_introduced_at: new Date(NOW_MS - 60 * DAY_MS).toISOString(),
+      }),
+    ];
+    const picked = pickCapability(catalog, ledger, NOW_ISO);
+    expect(picked?.row.capability_key).toBe('b'); // never-introduced wins
+  });
+
+  test('recently-introduced (within 7 days) is filtered out', () => {
+    const catalog: CapabilityCatalogRow[] = [cat({ capability_key: 'a' })];
+    const ledger: AwarenessLedgerRow[] = [
+      lr({
+        capability_key: 'a',
+        awareness_state: 'introduced',
+        last_introduced_at: new Date(NOW_MS - 3 * DAY_MS).toISOString(), // 3 days ago
+      }),
+    ];
+    expect(pickCapability(catalog, ledger, NOW_ISO)).toBeNull();
+  });
+
+  test('terminal states (tried/completed/mastered) are filtered out', () => {
+    const catalog: CapabilityCatalogRow[] = [
+      cat({ capability_key: 'a' }),
+      cat({ capability_key: 'b' }),
+      cat({ capability_key: 'c' }),
+    ];
+    const ledger: AwarenessLedgerRow[] = [
+      lr({ capability_key: 'a', awareness_state: 'tried' }),
+      lr({ capability_key: 'b', awareness_state: 'completed' }),
+      lr({ capability_key: 'c', awareness_state: 'mastered' }),
+    ];
+    expect(pickCapability(catalog, ledger, NOW_ISO)).toBeNull();
+  });
+
+  test('dismissed once + last introduced > 30 days ago → gentle re-offer eligible', () => {
+    const catalog: CapabilityCatalogRow[] = [cat({ capability_key: 'a' })];
+    const ledger: AwarenessLedgerRow[] = [
+      lr({
+        capability_key: 'a',
+        awareness_state: 'dismissed',
+        dismiss_count: 1,
+        last_introduced_at: new Date(NOW_MS - 45 * DAY_MS).toISOString(),
+      }),
+    ];
+    expect(pickCapability(catalog, ledger, NOW_ISO)?.row.capability_key).toBe('a');
+  });
+
+  test('dismissed twice (or more) → permanently filtered', () => {
+    const catalog: CapabilityCatalogRow[] = [cat({ capability_key: 'a' })];
+    const ledger: AwarenessLedgerRow[] = [
+      lr({
+        capability_key: 'a',
+        awareness_state: 'dismissed',
+        dismiss_count: 2,
+        last_introduced_at: new Date(NOW_MS - 90 * DAY_MS).toISOString(),
+      }),
+    ];
+    expect(pickCapability(catalog, ledger, NOW_ISO)).toBeNull();
+  });
+
+  test('alphabetical tie-break on equal-priority entries', () => {
+    const catalog: CapabilityCatalogRow[] = [
+      cat({ capability_key: 'zebra' }),
+      cat({ capability_key: 'apple' }),
+      cat({ capability_key: 'mango' }),
+    ];
+    const picked = pickCapability(catalog, [], NOW_ISO);
+    expect(picked?.row.capability_key).toBe('apple');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// renderTeacherLine
+// ---------------------------------------------------------------------------
+
+describe('VTID-03093 — renderTeacherLine', () => {
+  test('concatenates greeting + invitation with single space', () => {
+    expect(
+      renderTeacherLine({
+        greeting: 'Willkommen zurück, Dragan.',
+        invitation: 'Darf ich dir kurz etwas zeigen?',
+      }),
+    ).toBe('Willkommen zurück, Dragan. Darf ich dir kurz etwas zeigen?');
+  });
+
+  test('trims excess whitespace', () => {
+    expect(
+      renderTeacherLine({
+        greeting: '  Hi.  ',
+        invitation: '  May I?  ',
+      }),
+    ).toBe('Hi. May I?');
+  });
+});
+
+// ---------------------------------------------------------------------------
+// Provider — produce()
+// ---------------------------------------------------------------------------
+
+function fakeSb(opts: {
+  catalog?: CapabilityCatalogRow[];
+  ledger?: AwarenessLedgerRow[];
+  catalogError?: { message: string } | null;
+  ledgerError?: { message: string } | null;
+  catalogThrows?: boolean;
+}): import('@supabase/supabase-js').SupabaseClient {
+  return {
+    from: (table: string) => ({
+      select: () => ({
+        eq: () => {
+          if (table === 'system_capabilities') {
+            if (opts.catalogThrows) throw new Error('boom');
+            return Promise.resolve({
+              data: opts.catalog ?? [],
+              error: opts.catalogError ?? null,
+            });
+          }
+          // user_capability_awareness chain: .eq().eq()
+          return {
+            eq: () =>
+              Promise.resolve({
+                data: opts.ledger ?? [],
+                error: opts.ledgerError ?? null,
+              }),
+          };
+        },
+      }),
+    }),
+    rpc: async () => ({ data: null, error: null }),
+  } as unknown as import('@supabase/supabase-js').SupabaseClient;
+}
+
+function ctxWith(extra: Record<string, unknown>): ContinuationDecisionContext {
+  return {
+    surface: 'orb_wake',
+    sessionId: 's1',
+    userId: 'u1',
+    tenantId: 't1',
+    extra,
+  };
+}
+
+describe('VTID-03093 — provider produce()', () => {
+  test('missing inputs → skipped', async () => {
+    const provider = makeFeatureDiscoveryTeacherProvider();
+    const r = await provider.produce(ctxWith({}));
+    expect(r.status).toBe('skipped');
+    if (r.status === 'skipped') expect(r.reason).toBe('no_teacher_inputs');
+  });
+
+  test('greetingPolicy=skip → suppressed', async () => {
+    const provider = makeFeatureDiscoveryTeacherProvider({ rng: () => 0 });
+    const r = await provider.produce(
+      ctxWith({
+        [TEACHER_EXTRA_KEY]: {
+          supabase: fakeSb({ catalog: [cat()] }),
+          tenantId: 't1',
+          userId: 'u1',
+          lang: 'de',
+          greetingPolicy: 'skip',
+        },
+      }),
+    );
+    expect(r.status).toBe('suppressed');
+    if (r.status === 'suppressed') expect(r.reason).toBe('greeting_policy_skip');
+  });
+
+  test('empty catalog → suppressed:empty_catalog', async () => {
+    const provider = makeFeatureDiscoveryTeacherProvider({ rng: () => 0 });
+    const r = await provider.produce(
+      ctxWith({
+        [TEACHER_EXTRA_KEY]: {
+          supabase: fakeSb({ catalog: [] }),
+          tenantId: 't1',
+          userId: 'u1',
+          lang: 'de',
+          greetingPolicy: 'fresh_intro',
+        },
+      }),
+    );
+    expect(r.status).toBe('suppressed');
+    if (r.status === 'suppressed') expect(r.reason).toBe('empty_catalog');
+  });
+
+  test('catalog error → errored', async () => {
+    const provider = makeFeatureDiscoveryTeacherProvider({ rng: () => 0 });
+    const r = await provider.produce(
+      ctxWith({
+        [TEACHER_EXTRA_KEY]: {
+          supabase: fakeSb({ catalogError: { message: 'rls denied' } }),
+          tenantId: 't1',
+          userId: 'u1',
+          lang: 'de',
+          greetingPolicy: 'fresh_intro',
+        },
+      }),
+    );
+    expect(r.status).toBe('errored');
+    if (r.status === 'errored') expect(r.reason).toMatch(/catalog_fetch_failed/);
+  });
+
+  test('returns a candidate when catalog has rows + ledger empty', async () => {
+    const provider = makeFeatureDiscoveryTeacherProvider({
+      newId: () => 'fixed-id',
+      now: () => 1_700_000_000_000,
+      rng: () => 0,
+    });
+    const r = await provider.produce(
+      ctxWith({
+        [TEACHER_EXTRA_KEY]: {
+          supabase: fakeSb({
+            catalog: [
+              cat({ capability_key: 'life_compass', display_name: 'Life Compass' }),
+              cat({ capability_key: 'vitana_index', display_name: 'Vitana Index' }),
+            ],
+            ledger: [],
+          }),
+          tenantId: 't1',
+          userId: 'u1',
+          lang: 'de',
+          firstName: 'Dragan',
+          greetingPolicy: 'fresh_intro',
+          nowIso: NOW_ISO,
+        },
+      }),
+    );
+    expect(r.status).toBe('returned');
+    if (r.status !== 'returned') return;
+    expect(r.candidate.id).toBe('teacher-fixed-id');
+    expect(r.candidate.kind).toBe('feature_discovery');
+    expect(r.candidate.priority).toBe(75);
+    expect(r.candidate.userFacingLine).toContain('Dragan');
+    expect(r.candidate.userFacingLine).toMatch(/\?/);
+    // CTA carries capability_key + manual_path
+    expect((r.candidate.cta as { type: string }).type).toBe('offer_demo');
+    const payload = (r.candidate.cta as { payload: { capability_key: string } }).payload;
+    // alphabetical tie-break: life_compass < vitana_index → life_compass wins
+    expect(payload.capability_key).toBe('life_compass');
+    expect(r.candidate.dedupeKey).toBe('teacher:life_compass');
+  });
+
+  test('all capabilities mastered → suppressed:all_known_or_dismissed', async () => {
+    const provider = makeFeatureDiscoveryTeacherProvider({ rng: () => 0 });
+    const r = await provider.produce(
+      ctxWith({
+        [TEACHER_EXTRA_KEY]: {
+          supabase: fakeSb({
+            catalog: [cat({ capability_key: 'a' })],
+            ledger: [lr({ capability_key: 'a', awareness_state: 'mastered' })],
+          }),
+          tenantId: 't1',
+          userId: 'u1',
+          lang: 'de',
+          greetingPolicy: 'fresh_intro',
+          nowIso: NOW_ISO,
+        },
+      }),
+    );
+    expect(r.status).toBe('suppressed');
+    if (r.status === 'suppressed') {
+      expect(r.reason).toBe('all_capabilities_known_or_dismissed');
+    }
+  });
+
+  test('provider key + extra key are stable', () => {
+    expect(TEACHER_PROVIDER_KEY).toBe('feature_discovery_teacher');
+    expect(TEACHER_EXTRA_KEY).toBe('teacher');
+  });
+
+  test('NO "Wie kann ich dir helfen" in produced line', async () => {
+    const provider = makeFeatureDiscoveryTeacherProvider({
+      newId: () => 'fixed',
+      now: () => 1_700_000_000_000,
+      // Sweep enough rng values to hit every invitation phrase.
+    });
+    for (let i = 0; i < 30; i++) {
+      const rng = ((): (() => number) => {
+        let v = i / 30;
+        return () => {
+          const out = v;
+          v = (v + 1e-9) % 1;
+          return out;
+        };
+      })();
+      const provider2 = makeFeatureDiscoveryTeacherProvider({
+        newId: () => 'fixed',
+        now: () => 1_700_000_000_000,
+        rng,
+      });
+      const r = await provider2.produce(
+        ctxWith({
+          [TEACHER_EXTRA_KEY]: {
+            supabase: fakeSb({ catalog: [cat()], ledger: [] }),
+            tenantId: 't1',
+            userId: 'u1',
+            lang: 'de',
+            firstName: 'Dragan',
+            greetingPolicy: 'fresh_intro',
+            nowIso: NOW_ISO,
+          },
+        }),
+      );
+      if (r.status === 'returned') {
+        expect(r.candidate.userFacingLine.toLowerCase()).not.toContain('wie kann ich dir helfen');
+        expect(r.candidate.userFacingLine.toLowerCase()).not.toContain('how can i help');
+      }
+    }
+  });
+});

--- a/services/gateway/test/services/assistant-continuation/providers/teacher/teacher-pools.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/teacher/teacher-pools.test.ts
@@ -1,0 +1,170 @@
+/**
+ * VTID-03092 (Teacher PR 2) — pure tests for the greeting + invitation pools.
+ */
+
+import {
+  pickTeacherGreeting,
+  listTeacherGreetings,
+} from '../../../../../src/services/assistant-continuation/providers/teacher/teacher-greeting-pool';
+import {
+  pickTeacherInvitation,
+  listTeacherInvitations,
+} from '../../../../../src/services/assistant-continuation/providers/teacher/teacher-invitation-pool';
+
+// Deterministic RNG factory — produces 0, then increments by step,
+// wrapping at 1. Lets a test sweep through every index of the pool.
+function rngSeq(start: number) {
+  let v = start;
+  return () => {
+    const out = v;
+    v = (v + 1e-9) % 1;
+    return out;
+  };
+}
+
+describe('VTID-03092 — teacher-greeting-pool', () => {
+  test('substitutes firstName when provided', () => {
+    // Pick index 0 — the de pool starts with "Willkommen zurück, {firstName}."
+    const out = pickTeacherGreeting({
+      lang: 'de',
+      firstName: 'Dragan',
+      rng: () => 0,
+    });
+    expect(out).toBe('Willkommen zurück, Dragan.');
+  });
+
+  test('falls back to no-name phrases when firstName missing', () => {
+    // Sweep many indices; the result must NEVER contain "{firstName}".
+    for (let i = 0; i < 50; i++) {
+      const r = (i / 50) % 1;
+      const out = pickTeacherGreeting({ lang: 'de', firstName: null, rng: () => r });
+      expect(out).not.toContain('{firstName}');
+      expect(out.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('every named entry contains exactly one firstName slot', () => {
+    for (const lang of ['en', 'de']) {
+      for (const phrase of listTeacherGreetings(lang)) {
+        const matches = phrase.match(/\{firstName\}/g) ?? [];
+        expect(matches.length).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+
+  test('no dismissive openers leak in (banned-phrase guard)', () => {
+    const banned = [
+      /\byes\?/i,
+      /\bja bitte\b/i,
+      /\bwas gibt's neues\b/i,
+      /\bgo ahead\b/i,
+      /\bworum geht\b/i,
+      /\bbereit\./i,
+      /\bja\?/i,
+    ];
+    for (const lang of ['en', 'de']) {
+      for (const phrase of listTeacherGreetings(lang)) {
+        for (const re of banned) {
+          expect(phrase).not.toMatch(re);
+        }
+      }
+    }
+  });
+
+  test('unknown language falls back to English pool', () => {
+    const out = pickTeacherGreeting({ lang: 'xx', firstName: 'Alice', rng: () => 0 });
+    expect(out).toBe('Welcome back, Alice.');
+  });
+
+  test('variety floor: at least 16 phrases per supported lang', () => {
+    for (const lang of ['en', 'de']) {
+      expect(listTeacherGreetings(lang).length).toBeGreaterThanOrEqual(16);
+    }
+  });
+});
+
+describe('VTID-03092 — teacher-invitation-pool', () => {
+  test('substitutes featureLabel when provided', () => {
+    // de pool index 2: "Magst du, dass ich dir {featureLabel} zeige?"
+    const out = pickTeacherInvitation({
+      lang: 'de',
+      featureLabel: 'den Life Compass',
+      rng: () => 2 / 20,
+    });
+    expect(out).toContain('den Life Compass');
+    expect(out).not.toContain('{featureLabel}');
+  });
+
+  test('falls back to no-label phrases when label missing', () => {
+    for (let i = 0; i < 50; i++) {
+      const r = (i / 50) % 1;
+      const out = pickTeacherInvitation({ lang: 'de', featureLabel: null, rng: () => r });
+      expect(out).not.toContain('{featureLabel}');
+      expect(out.length).toBeGreaterThan(0);
+    }
+  });
+
+  test('NO "Wie kann ich dir helfen" / "How can I help" anywhere', () => {
+    // Hard rule from the user: the Teacher must NEVER ask
+    // "how can I help you" as a standalone phrase. It only invites.
+    const banned = [/wie kann ich dir helfen/i, /how can i help/i];
+    for (const lang of ['en', 'de']) {
+      for (const phrase of listTeacherInvitations(lang)) {
+        for (const re of banned) {
+          expect(phrase).not.toMatch(re);
+        }
+      }
+    }
+  });
+
+  test('every phrase contains a question mark (permission-asking)', () => {
+    // Phrases may have a question + explanatory follow-up
+    // ("Do you have a moment? I would like to introduce something."),
+    // so we only require AT LEAST one '?' in the phrase, not that it
+    // ends with one.
+    for (const lang of ['en', 'de']) {
+      for (const phrase of listTeacherInvitations(lang)) {
+        expect(phrase.includes('?')).toBe(true);
+      }
+    }
+  });
+
+  test('every featureLabel slot appears at most once per phrase', () => {
+    for (const lang of ['en', 'de']) {
+      for (const phrase of listTeacherInvitations(lang)) {
+        const matches = phrase.match(/\{featureLabel\}/g) ?? [];
+        expect(matches.length).toBeLessThanOrEqual(1);
+      }
+    }
+  });
+
+  test('unknown language falls back to English pool', () => {
+    const out = pickTeacherInvitation({ lang: 'xx', featureLabel: null, rng: () => 0 });
+    expect(out.length).toBeGreaterThan(0);
+    // First English no-label entry is "May I show you something?"
+    expect(out).toBe('May I show you something?');
+  });
+
+  test('variety floor: at least 16 phrases per supported lang', () => {
+    for (const lang of ['en', 'de']) {
+      expect(listTeacherInvitations(lang).length).toBeGreaterThanOrEqual(16);
+    }
+  });
+});
+
+describe('VTID-03092 — combined greeting + invitation render', () => {
+  test('concatenation produces a clean two-sentence utterance', () => {
+    const greeting = pickTeacherGreeting({
+      lang: 'de',
+      firstName: 'Dragan',
+      rng: () => 0,
+    });
+    const invitation = pickTeacherInvitation({
+      lang: 'de',
+      featureLabel: null,
+      rng: () => 0,
+    });
+    const full = `${greeting} ${invitation}`;
+    expect(full).toBe('Willkommen zurück, Dragan. Darf ich dir kurz etwas zeigen?');
+  });
+});


### PR DESCRIPTION
## Teacher PR 3 of 5 — the provider

Registers a new ContinuationProvider at priority **75** that picks ONE unexplored Vitanaland capability and asks permission to introduce it.

Sits between `voice_wake_brief` (80) and the lowest band of next-action sources (~50). Selection is **read-only** — state advancement lives in PR 4 via `advance_capability_awareness` RPC.

## Selection rules (deterministic, pure-function `pickCapability`)

1. Drop disabled rows.
2. Drop rows whose ledger state is `tried` / `completed` / `mastered`.
3. Drop rows dismissed ≥ 3 times (permanent strike-out).
4. Dismissed-once rows are eligible only after 30 days (gentle re-offer).
5. Drop rows introduced within the last 7 days (no back-to-back repeat).
6. Sort: never-introduced first → oldest `last_introduced_at` → lowest `dismiss_count` → alphabetical tie-break.

## Suppression paths

| Reason | When |
|---|---|
| `greeting_policy_skip` | B1 cadence says skip |
| `empty_catalog` | system_capabilities empty (migration not applied) |
| `all_capabilities_known_or_dismissed` | no eligible rows after filter |
| `catalog_fetch_failed` (errored) | catalog DB error |

Ledger DB error degrades to empty-ledger (every cap treated as `unknown`).

## Two-clause render

```
[greeting]  +  [invitation]
"Willkommen zurück, Dragan."  +  "Darf ich dir kurz etwas zeigen?"
```

Both pools come from PR 2 (`teacher-greeting-pool.ts` + `teacher-invitation-pool.ts`).

## Inputs wired

`decideWakeBriefForSession()` now forwards a `TEACHER_EXTRA_KEY` entry alongside the existing next-action extras. `firstName` is a new optional arg; when present the greeting addresses the user by name.

## Test plan
- [x] 32 tests green (provider + pure helpers)
- [x] 16 existing wake-brief-wiring tests still green
- [x] Banned-phrase guard swept 30 rng values: no "Wie kann ich dir helfen" / "How can I help" anywhere in produced lines
- [x] Gateway build green

## What's NOT in this PR

- PR 4 → `confirm_teach_feature` tool + OASIS events + ledger writes via RPC
- PR 5 → Command Hub "Teach Vitanaland" sub-tab

Note: this branch cherry-picks PR 2's commit `c7f159c1` for the pool files (PR 2 hasn't merged yet). When PR 2 lands first, this PR rebases cleanly. When this lands first, PR 2's PR auto-resolves the duplicate.

🤖 Generated with [Claude Code](https://claude.com/claude-code)