### PR TITLE
feat(teacher): lifecycle endpoint POST /voice/teacher/event (VTID-03094)

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -791,6 +791,14 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   const voiceNextActionEventRouter = require('./routes/voice-next-action-event').default;
   mountRouterSync(app, '/api/v1', voiceNextActionEventRouter, { owner: 'voice-next-action-event' });
 
+  // VTID-03094 (Teacher PR 4): Teacher lifecycle endpoint —
+  // POST /api/v1/voice/teacher/event. Calls the advance_capability_awareness
+  // RPC, emits capability.awareness.* OASIS events from the central
+  // registry, returns a navigate directive on 'introduced' events when
+  // the chosen capability has a manual_path.
+  const voiceTeacherEventRouter = require('./routes/voice-teacher-event').default;
+  mountRouterSync(app, '/api/v1', voiceTeacherEventRouter, { owner: 'voice-teacher-event' });
+
   // VTID-03063 (B0d-real Xf.3): Candidate Inspector — read-only operator
   // surface that groups recent B0d-real OASIS events by decision_id.
   // GET /api/v1/voice/next-action/inspector?user_id=<uuid>&hours=24.

--- a/services/gateway/src/routes/voice-teacher-event.ts
+++ b/services/gateway/src/routes/voice-teacher-event.ts
@@ -1,0 +1,276 @@
+/**
+ * VTID-03094 (Teacher PR 4) — Teacher lifecycle endpoint.
+ *
+ *   POST /api/v1/voice/teacher/event
+ *
+ * Body:
+ *   {
+ *     capabilityKey: string,                            // required, ∈ system_capabilities
+ *     eventName: 'introduced'|'seen'|'tried'|'completed'|'dismissed',
+ *     idempotencyKey: string,                           // required (client-generated UUID)
+ *     decisionId?: string,                              // from wake_brief_decision
+ *     sourceSurface?: 'orb_wake'|'orb_turn_end'|'text_turn_end'|'home',
+ *     occurredAt?: string,                              // ISO 8601
+ *     metadata?: Record<string, unknown>                // <=16 keys
+ *   }
+ *
+ * Auth: requireAuthWithTenant. Tenant + user IDs come from the JWT only.
+ *
+ * Flow:
+ *   1. Validate body.
+ *   2. Call `advance_capability_awareness` RPC (atomic, idempotent,
+ *      state-machine enforced — see VTID-02924 migration).
+ *   3. Emit OASIS event using the AWARENESS_EVENT_TO_TOPIC map (NEVER
+ *      construct topic strings inline).
+ *   4. When eventName is 'introduced' AND the chosen capability has a
+ *      manual_path, return a `navigate` directive so the frontend can
+ *      open the page.
+ *
+ * The RPC's idempotency key means re-posting the same event with the
+ * same idempotency_key is a no-op — caller can safely retry.
+ */
+
+import { Router, Response } from 'express';
+import {
+  requireAuthWithTenant,
+  AuthenticatedRequest,
+} from '../middleware/auth-supabase-jwt';
+import { getSupabase } from '../lib/supabase';
+import { emitOasisEvent } from '../services/oasis-event-service';
+import {
+  AWARENESS_EVENT_TO_TOPIC,
+  type CapabilityAwarenessEventName,
+} from '../services/assistant-continuation/telemetry';
+
+const router = Router();
+const VTID = 'VTID-03094';
+
+const ALLOWED_EVENTS: ReadonlySet<CapabilityAwarenessEventName> = new Set([
+  'introduced',
+  'seen',
+  'tried',
+  'completed',
+  'dismissed',
+] as CapabilityAwarenessEventName[]);
+
+const ALLOWED_SURFACES: ReadonlySet<string> = new Set([
+  'orb_wake',
+  'orb_turn_end',
+  'text_turn_end',
+  'home',
+]);
+
+const MAX_METADATA_KEYS = 16;
+const MAX_STRING_FIELD_CHARS = 512;
+
+router.post(
+  '/voice/teacher/event',
+  requireAuthWithTenant,
+  async (req: AuthenticatedRequest, res: Response) => {
+    try {
+      const tenantId = req.identity?.tenant_id;
+      const userId = req.identity?.user_id;
+      if (!tenantId || !userId) {
+        return res.status(401).json({
+          ok: false,
+          error: 'UNAUTHENTICATED',
+          message: 'Authenticated session with active tenant required',
+          vtid: VTID,
+        });
+      }
+
+      const body = (req.body ?? {}) as Record<string, unknown>;
+
+      const capabilityKey =
+        typeof body.capabilityKey === 'string' ? body.capabilityKey.trim() : '';
+      const eventNameRaw =
+        typeof body.eventName === 'string' ? body.eventName : '';
+      const idempotencyKey =
+        typeof body.idempotencyKey === 'string' ? body.idempotencyKey.trim() : '';
+      const decisionId =
+        typeof body.decisionId === 'string' ? body.decisionId.trim() : null;
+      const surfaceRaw =
+        typeof body.sourceSurface === 'string' ? body.sourceSurface : undefined;
+      const occurredAt =
+        typeof body.occurredAt === 'string' && body.occurredAt
+          ? body.occurredAt
+          : new Date().toISOString();
+      const metadata =
+        body.metadata && typeof body.metadata === 'object' && !Array.isArray(body.metadata)
+          ? (body.metadata as Record<string, unknown>)
+          : undefined;
+
+      // ---- Validation ----
+      if (!capabilityKey) {
+        return res
+          .status(400)
+          .json({ ok: false, error: 'capabilityKey is required', vtid: VTID });
+      }
+      if (capabilityKey.length > MAX_STRING_FIELD_CHARS) {
+        return res
+          .status(400)
+          .json({ ok: false, error: 'capabilityKey too long', vtid: VTID });
+      }
+      if (!ALLOWED_EVENTS.has(eventNameRaw as CapabilityAwarenessEventName)) {
+        return res.status(400).json({
+          ok: false,
+          error: `eventName must be one of: ${Array.from(ALLOWED_EVENTS).join(', ')}`,
+          vtid: VTID,
+        });
+      }
+      if (!idempotencyKey) {
+        return res
+          .status(400)
+          .json({ ok: false, error: 'idempotencyKey is required', vtid: VTID });
+      }
+      if (idempotencyKey.length > MAX_STRING_FIELD_CHARS) {
+        return res
+          .status(400)
+          .json({ ok: false, error: 'idempotencyKey too long', vtid: VTID });
+      }
+      if (decisionId && decisionId.length > MAX_STRING_FIELD_CHARS) {
+        return res
+          .status(400)
+          .json({ ok: false, error: 'decisionId too long', vtid: VTID });
+      }
+      const sourceSurface =
+        surfaceRaw && ALLOWED_SURFACES.has(surfaceRaw) ? surfaceRaw : null;
+      if (metadata && Object.keys(metadata).length > MAX_METADATA_KEYS) {
+        return res.status(400).json({
+          ok: false,
+          error: `metadata has more than ${MAX_METADATA_KEYS} keys`,
+          vtid: VTID,
+        });
+      }
+
+      const eventName = eventNameRaw as CapabilityAwarenessEventName;
+
+      // ---- RPC ----
+      const sb = getSupabase();
+      if (!sb) {
+        return res
+          .status(503)
+          .json({ ok: false, error: 'DB_UNAVAILABLE', vtid: VTID });
+      }
+      const { data: rpcResult, error: rpcError } = await sb.rpc(
+        'advance_capability_awareness',
+        {
+          p_tenant_id: tenantId,
+          p_user_id: userId,
+          p_capability_key: capabilityKey,
+          p_event_name: eventName,
+          p_idempotency_key: idempotencyKey,
+          p_decision_id: decisionId,
+          p_source_surface: sourceSurface,
+          p_occurred_at: occurredAt,
+          p_metadata: metadata ?? null,
+        },
+      );
+      if (rpcError) {
+        console.warn(`[${VTID}] advance_capability_awareness failed: ${rpcError.message}`);
+        return res.status(502).json({
+          ok: false,
+          error: 'rpc_failed',
+          message: rpcError.message,
+          vtid: VTID,
+        });
+      }
+      const result =
+        rpcResult && typeof rpcResult === 'object'
+          ? (rpcResult as Record<string, unknown>)
+          : {};
+      if (result.ok === false) {
+        return res.status(409).json({
+          ok: false,
+          error: 'transition_rejected',
+          rpc_reason: result.reason,
+          previous_state: result.previous_state,
+          attempted_event: result.attempted_event ?? eventName,
+          vtid: VTID,
+        });
+      }
+
+      // ---- OASIS emit ----
+      const topic = AWARENESS_EVENT_TO_TOPIC[eventName];
+      try {
+        await emitOasisEvent({
+          vtid: VTID,
+          type: topic as never,
+          source: 'teacher-feature-discovery',
+          status: 'info',
+          message: topic,
+          payload: {
+            user_id: userId,
+            tenant_id: tenantId,
+            capability_key: capabilityKey,
+            event_name: eventName,
+            decision_id: decisionId,
+            source_surface: sourceSurface,
+            occurred_at: occurredAt,
+            idempotent: result.idempotent === true,
+            previous_state: result.previous_state ?? null,
+            next_state: result.next_state ?? null,
+            metadata: metadata ?? null,
+          },
+          actor_id: userId,
+          actor_role: 'user',
+          surface: 'orb',
+        });
+      } catch (emitErr) {
+        // Telemetry MUST NOT fail the lifecycle write. The RPC has
+        // already advanced state; emit is best-effort.
+        console.warn(
+          `[${VTID}] OASIS emit failed (non-fatal): ${(emitErr as Error).message}`,
+        );
+      }
+
+      // ---- Navigation directive (introduced events with manual_path) ----
+      let directive: Record<string, unknown> | null = null;
+      if (eventName === 'introduced') {
+        try {
+          const { data: cap } = await sb
+            .from('system_capabilities')
+            .select('manual_path, display_name')
+            .eq('capability_key', capabilityKey)
+            .maybeSingle();
+          if (cap && typeof cap === 'object') {
+            const manualPath = (cap as { manual_path?: string | null }).manual_path;
+            if (typeof manualPath === 'string' && manualPath.trim().length > 0) {
+              directive = {
+                type: 'orb_directive',
+                directive: 'navigate',
+                screen_id: 'MANUALS.PAGE',
+                route: manualPath,
+                title: (cap as { display_name?: string }).display_name ?? null,
+                reason: 'teacher_introduced',
+                vtid: VTID,
+              };
+            }
+          }
+        } catch {
+          // manual_path lookup is best-effort.
+        }
+      }
+
+      return res.status(200).json({
+        ok: true,
+        vtid: VTID,
+        capability_key: capabilityKey,
+        event_name: eventName,
+        topic,
+        idempotent: result.idempotent === true,
+        previous_state: result.previous_state ?? null,
+        next_state: result.next_state ?? null,
+        event_id: result.event_id ?? null,
+        directive,
+      });
+    } catch (err) {
+      console.error(`[${VTID}] route error: ${(err as Error).message}`);
+      return res
+        .status(500)
+        .json({ ok: false, error: 'internal_error', vtid: VTID });
+    }
+  },
+);
+
+export default router;

--- a/services/gateway/test/routes/voice-teacher-event.test.ts
+++ b/services/gateway/test/routes/voice-teacher-event.test.ts
@@ -1,0 +1,243 @@
+/**
+ * VTID-03094 (Teacher PR 4) — POST /api/v1/voice/teacher/event tests.
+ */
+
+import express from 'express';
+import request from 'supertest';
+
+const emitMock = jest.fn().mockResolvedValue({ ok: true });
+jest.mock('../../src/services/oasis-event-service', () => ({
+  emitOasisEvent: (...args: unknown[]) => emitMock(...args),
+}));
+
+const FIXED_IDENTITY = {
+  user_id: 'jwt-user-id',
+  tenant_id: 'jwt-tenant-id',
+};
+let currentIdentity: typeof FIXED_IDENTITY | null = FIXED_IDENTITY;
+jest.mock('../../src/middleware/auth-supabase-jwt', () => ({
+  requireAuthWithTenant: (req: any, _res: any, next: any) => {
+    if (currentIdentity) req.identity = currentIdentity;
+    next();
+  },
+  requireExafyAdmin: (_req: any, _res: any, next: any) => next(),
+  optionalAuth: (_req: any, _res: any, next: any) => next(),
+}));
+
+interface FakeOpts {
+  rpcResult?: unknown;
+  rpcError?: { message: string } | null;
+  capRow?: { manual_path: string | null; display_name: string } | null;
+}
+
+let fakeOpts: FakeOpts = {};
+jest.mock('../../src/lib/supabase', () => ({
+  getSupabase: () => ({
+    from: (_t: string) => ({
+      select: () => ({
+        eq: () => ({
+          maybeSingle: () => Promise.resolve({ data: fakeOpts.capRow ?? null, error: null }),
+        }),
+      }),
+    }),
+    rpc: async (_fn: string, _args: unknown) => ({
+      data: fakeOpts.rpcResult ?? null,
+      error: fakeOpts.rpcError ?? null,
+    }),
+  }),
+}));
+
+function buildApp() {
+  // eslint-disable-next-line @typescript-eslint/no-var-requires
+  const router = require('../../src/routes/voice-teacher-event').default;
+  const app = express();
+  app.use(express.json());
+  app.use('/api/v1', router);
+  return app;
+}
+
+describe('VTID-03094 — POST /api/v1/voice/teacher/event', () => {
+  beforeEach(() => {
+    emitMock.mockClear();
+    currentIdentity = FIXED_IDENTITY;
+    fakeOpts = {};
+  });
+
+  test('401 when identity missing', async () => {
+    currentIdentity = null;
+    const res = await request(buildApp())
+      .post('/api/v1/voice/teacher/event')
+      .send({
+        capabilityKey: 'life_compass',
+        eventName: 'introduced',
+        idempotencyKey: 'k-1',
+      });
+    expect(res.status).toBe(401);
+    expect(res.body.error).toBe('UNAUTHENTICATED');
+  });
+
+  test('400 when capabilityKey missing', async () => {
+    const res = await request(buildApp())
+      .post('/api/v1/voice/teacher/event')
+      .send({ eventName: 'introduced', idempotencyKey: 'k-1' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/capabilityKey/);
+  });
+
+  test('400 when eventName not allowed', async () => {
+    const res = await request(buildApp())
+      .post('/api/v1/voice/teacher/event')
+      .send({
+        capabilityKey: 'life_compass',
+        eventName: 'mastered', // mastered is not allowed via this endpoint
+        idempotencyKey: 'k-1',
+      });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/eventName must be one of/);
+  });
+
+  test('400 when idempotencyKey missing', async () => {
+    const res = await request(buildApp())
+      .post('/api/v1/voice/teacher/event')
+      .send({ capabilityKey: 'life_compass', eventName: 'introduced' });
+    expect(res.status).toBe(400);
+    expect(res.body.error).toMatch(/idempotencyKey/);
+  });
+
+  test('happy path: introduced → returns directive + emits OASIS', async () => {
+    fakeOpts = {
+      rpcResult: {
+        ok: true,
+        idempotent: false,
+        previous_state: 'unknown',
+        next_state: 'introduced',
+        event_id: 'evt-1',
+      },
+      capRow: { manual_path: '/manuals/maxina/00-concepts/life-compass', display_name: 'Life Compass' },
+    };
+    const res = await request(buildApp())
+      .post('/api/v1/voice/teacher/event')
+      .send({
+        capabilityKey: 'life_compass',
+        eventName: 'introduced',
+        idempotencyKey: 'k-1',
+        sourceSurface: 'orb_wake',
+        decisionId: 'dec-1',
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+    expect(res.body.capability_key).toBe('life_compass');
+    expect(res.body.event_name).toBe('introduced');
+    expect(res.body.topic).toBe('capability.awareness.introduced');
+    expect(res.body.directive).toBeTruthy();
+    expect(res.body.directive.route).toBe('/manuals/maxina/00-concepts/life-compass');
+    expect(res.body.directive.directive).toBe('navigate');
+    // OASIS event fired with the topic from the central registry
+    const calls = emitMock.mock.calls.map((c) => c[0] as { type?: string; message?: string });
+    const emitted = calls.find((c) => c.type === 'capability.awareness.introduced');
+    expect(emitted).toBeDefined();
+  });
+
+  test('dismissed: no directive (we do not navigate on dismiss)', async () => {
+    fakeOpts = {
+      rpcResult: {
+        ok: true,
+        idempotent: false,
+        previous_state: 'introduced',
+        next_state: 'dismissed',
+        event_id: 'evt-2',
+      },
+      capRow: { manual_path: '/manuals/...', display_name: 'X' },
+    };
+    const res = await request(buildApp())
+      .post('/api/v1/voice/teacher/event')
+      .send({
+        capabilityKey: 'life_compass',
+        eventName: 'dismissed',
+        idempotencyKey: 'k-2',
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.directive).toBeNull();
+    expect(res.body.topic).toBe('capability.awareness.dismissed');
+  });
+
+  test('idempotent replay: returns idempotent:true from RPC', async () => {
+    fakeOpts = {
+      rpcResult: {
+        ok: true,
+        idempotent: true,
+        previous_state: 'unknown',
+        next_state: 'introduced',
+        event_id: 'evt-existing',
+      },
+      capRow: { manual_path: '/m', display_name: 'X' },
+    };
+    const res = await request(buildApp())
+      .post('/api/v1/voice/teacher/event')
+      .send({
+        capabilityKey: 'life_compass',
+        eventName: 'introduced',
+        idempotencyKey: 'same-key',
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.idempotent).toBe(true);
+  });
+
+  test('RPC transition rejected → 409', async () => {
+    fakeOpts = {
+      rpcResult: {
+        ok: false,
+        reason: 'transition_not_allowed',
+        previous_state: 'mastered',
+        attempted_event: 'introduced',
+      },
+    };
+    const res = await request(buildApp())
+      .post('/api/v1/voice/teacher/event')
+      .send({
+        capabilityKey: 'life_compass',
+        eventName: 'introduced',
+        idempotencyKey: 'k-3',
+      });
+    expect(res.status).toBe(409);
+    expect(res.body.rpc_reason).toBe('transition_not_allowed');
+  });
+
+  test('RPC error → 502', async () => {
+    fakeOpts = {
+      rpcError: { message: 'connection lost' },
+    };
+    const res = await request(buildApp())
+      .post('/api/v1/voice/teacher/event')
+      .send({
+        capabilityKey: 'life_compass',
+        eventName: 'introduced',
+        idempotencyKey: 'k-4',
+      });
+    expect(res.status).toBe(502);
+    expect(res.body.error).toBe('rpc_failed');
+  });
+
+  test('OASIS emit failure does NOT fail the request', async () => {
+    fakeOpts = {
+      rpcResult: {
+        ok: true,
+        idempotent: false,
+        previous_state: 'unknown',
+        next_state: 'introduced',
+        event_id: 'evt-5',
+      },
+      capRow: { manual_path: '/m', display_name: 'X' },
+    };
+    emitMock.mockRejectedValueOnce(new Error('OASIS down'));
+    const res = await request(buildApp())
+      .post('/api/v1/voice/teacher/event')
+      .send({
+        capabilityKey: 'life_compass',
+        eventName: 'introduced',
+        idempotencyKey: 'k-5',
+      });
+    expect(res.status).toBe(200);
+    expect(res.body.ok).toBe(true);
+  });
+});


### PR DESCRIPTION
## Teacher PR 4 of 5 — lifecycle endpoint

Wires the Teacher's accept/dismiss lifecycle into the existing `capability_awareness` state machine (VTID-02924 migration).

## Endpoint

```
POST /api/v1/voice/teacher/event

body: {
  capabilityKey: string,
  eventName: 'introduced'|'seen'|'tried'|'completed'|'dismissed',
  idempotencyKey: string,
  decisionId?: string,
  sourceSurface?: 'orb_wake'|'orb_turn_end'|'text_turn_end'|'home',
  occurredAt?: string,
  metadata?: Record<string, unknown>
}

Auth: requireAuthWithTenant
```

## Flow

1. Validate body (length caps, allowed enums).
2. Call `advance_capability_awareness()` RPC (atomic, idempotent on `idempotencyKey`, state-machine enforced).
3. Emit OASIS event using `AWARENESS_EVENT_TO_TOPIC` from the central registry — NEVER constructed inline.
4. On `'introduced'` events with a `manual_path`, return a `navigate` directive so the frontend opens the manual page.

## Hard rules carried forward

- `mastered` is NOT accepted via this endpoint — graduation lives in a future automated rule.
- OASIS emit failures do NOT fail the request (telemetry is best-effort; RPC has already written state).
- `idempotencyKey` is required — RPC's UNIQUE constraint makes retried calls no-ops with `idempotent:true` returned.
- Transition violations return **409** with the RPC's reason.

## Test plan
- [x] 10 tests green (401, 400×3, happy path, dismissed, idempotent, 409 transition, 502 RPC error, emit failure resilience)
- [x] Gateway build green

## NOT in this PR

- vitana-v1 frontend hook (separate cross-repo PR)
- `feature.discovery.suggested` auto-emit when Teacher candidate wins (small follow-up)

🤖 Generated with [Claude Code](https://claude.com/claude-code)