### PR TITLE
fix(teacher): bump priority 75 → 85 so the Teacher owns the first turn (VTID-03096)

### DIFF
--- a/services/gateway/src/services/assistant-continuation/providers/teacher/feature-discovery-teacher.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/teacher/feature-discovery-teacher.ts
@@ -61,16 +61,17 @@ import {
 export const TEACHER_EXTRA_KEY = 'teacher' as const;
 export const TEACHER_PROVIDER_KEY = 'feature_discovery_teacher' as const;
 
-// Priority 75 — sits between voice_wake_brief (80) and the lowest band
-// of next-action sources (~50). Guide picks above-50 candidates first;
-// when Guide has nothing, Teacher's offer beats the bare wake-brief
-// fallback. Wake-brief at 80 still wins ONLY when the renderer
-// produces a non-empty line AND we explicitly chose the wake-brief
-// path (e.g. pillar-momentum proactive variant). The composer keeps
-// the Teacher candidate as a co-equal fallback if voice_wake_brief
-// returns the generic policy line — they have different `kind`s
-// (`wake_brief` vs `feature_discovery`) and different dedupeKeys.
-const DEFAULT_PRIORITY = 75;
+// VTID-03096 (Teacher priority bump): Teacher → 85, voice_wake_brief
+// stays at 80. The Teacher OWNS the spoken first turn whenever there
+// is an unexplored capability for this user. voice_wake_brief becomes
+// the pure fallback for the all-mastered / catalog-empty / suppressed
+// case.
+//
+// Lower than the urgent next-action bands (95+ reminder) so a
+// time-sensitive reminder still pre-empts the Teacher. Above the
+// generic wake-brief greeting because the user's product philosophy
+// is: teach first, greet-only when there is nothing to teach.
+const DEFAULT_PRIORITY = 85;
 
 const DEFAULT_LOOKBACK_INTRODUCED_DAYS = 7;
 const MAX_DISMISS_BEFORE_PERMANENT = 3;

--- a/services/gateway/test/services/assistant-continuation/providers/teacher/feature-discovery-teacher.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/teacher/feature-discovery-teacher.test.ts
@@ -289,7 +289,7 @@ describe('VTID-03093 — provider produce()', () => {
     if (r.status !== 'returned') return;
     expect(r.candidate.id).toBe('teacher-fixed-id');
     expect(r.candidate.kind).toBe('feature_discovery');
-    expect(r.candidate.priority).toBe(75);
+    expect(r.candidate.priority).toBe(85);
     expect(r.candidate.userFacingLine).toContain('Dragan');
     expect(r.candidate.userFacingLine).toMatch(/\?/);
     // CTA carries capability_key + manual_path


### PR DESCRIPTION
## Why

End-to-end probe after Teacher PRs 1-5 deployed showed `voice_wake_brief` (80) always winning over the Teacher (75). Every session returned the generic `"Hallo! Wie kann ich dir heute helfen?"` instead of the warm greeting + permission ask the Teacher was built to emit.

The user's product philosophy: **teach first, greet-only when nothing to teach**. Priority 75 had this backwards.

## Fix

- Teacher → **85**
- voice_wake_brief stays at 80

Teacher OWNS the first turn whenever there's an unexplored capability. voice_wake_brief is the fallback for all-mastered / catalog-empty / suppressed cases.

Still below urgent next-action bands (95+ reminder) so a time-sensitive reminder pre-empts the Teacher. Cadence (B1) still applies on top — a recent greeting still suppresses both.

## Test plan
- [x] 32 teacher tests green (one expectation flipped 75 → 85)
- [x] Gateway build green
- [ ] Real-mic verification post-deploy

🤖 Generated with [Claude Code](https://claude.com/claude-code)