### PR TITLE
fix(teacher): Command Hub auth + Teacher line actually spoken on Vertex (VTID-03097)

### DIFF
--- a/services/gateway/src/orb/live/instruction/live-system-instruction.ts
+++ b/services/gateway/src/orb/live/instruction/live-system-instruction.ts
@@ -149,6 +149,10 @@ function buildTemporalJourneyContextSection(
   // greeting) so this stays opt-in. TONE RULES + JOURNEY AWARENESS are
   // kept because they shape ongoing conversation, not just the opener.
   omitGreetingPolicy?: boolean,
+  // VTID-03097: when the caller already injected a VERTEX WAKE BRIEF
+  // override block, suppress the short-gap-greeting-phrases pool so
+  // Gemini doesn't see two competing "speak this verbatim" lists.
+  wakeBriefOverrideActive?: boolean,
 ): string {
   const temporal = describeTimeSince(lastSessionInfo);
   const current = describeRoute(currentRoute, lang);
@@ -247,11 +251,19 @@ function buildTemporalJourneyContextSection(
   const greetingTimeOfDay = timeOfDay === 'night' ? 'evening' : (timeOfDay || 'day');
 
   const bucket = isReconnect ? 'reconnect' : temporal.bucket;
+  // VTID-03097: caller signals when a wake-brief override block is
+  // active. When yes, the SHORT-GAP GREETING PHRASES pool is
+  // suppressed so Gemini doesn't see two competing "speak this
+  // verbatim" lists.
   // VTID-GREETING-VARIETY: for short-gap buckets, inject a freshly-shuffled
   // subset of the language-specific phrase pool so Gemini rotates openers
   // instead of converging on the same translation every time.
   const shortGapExamples = pickShortGapGreetings(lang, 6);
   const appendShortGapPhraseMenu = () => {
+    if (wakeBriefOverrideActive) {
+      lines.push('  • SHORT-GAP PHRASE LIST SUPPRESSED — a VERTEX WAKE BRIEF override is active later in this prompt. Speak the override line verbatim instead of any phrase here.');
+      return;
+    }
     lines.push('  • Pick ONE of these example phrasings (use them VERBATIM — they are already in the user\'s language; pick a different one than last time):');
     for (const p of shortGapExamples) {
       lines.push(`      "${p}"`);
@@ -630,6 +642,13 @@ ${trimmedHistory}
   // VTID-NAV-TIMEJOURNEY: Append the temporal + journey context block LAST so
   // its greeting policy overrides the generic GREETING RULES higher up. This
   // is what stops Vitana from saying "Hello <name>!" every single session.
+  // VTID-03097: detect VERTEX WAKE BRIEF override here at the
+  // top-level buildLiveSystemInstruction (which has bootstrapContext)
+  // and pass the boolean down so the temporal section can suppress
+  // the SHORT-GAP GREETING PHRASES pool when needed.
+  const wakeBriefOverrideActive =
+    typeof bootstrapContext === 'string' &&
+    bootstrapContext.includes('<<VERTEX_WAKE_BRIEF_OVERRIDE_ACTIVE>>');
   instruction += buildTemporalJourneyContextSection(
     lang,
     lastSessionInfo,
@@ -638,6 +657,7 @@ ${trimmedHistory}
     !!isReconnect,
     clientContext?.timeOfDay,
     omitGreetingPolicy,
+    wakeBriefOverrideActive,
   );
 
   // BOOTSTRAP-AWARENESS-REGISTRY: gate the override blocks below on admin

--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -417,35 +417,48 @@ export async function handleLiveStreamEndTurn(
  * Trailing punctuation + quote escaping is handled inline so the
  * line can't accidentally close the prompt block.
  */
+/** Sentinel marker — used by buildLiveSystemInstruction to suppress
+ *  the SHORT-GAP GREETING PHRASES pool when an override is active.
+ *  Must match the literal substring exactly in both places. */
+export const VERTEX_WAKE_BRIEF_OVERRIDE_MARKER =
+  '<<VERTEX_WAKE_BRIEF_OVERRIDE_ACTIVE>>';
+
 function buildVertexWakeBriefBlock(
   line: string,
-  lang: string,
+  _lang: string,
   dedupeKey: string | null,
 ): string {
   // Escape backticks + close-quotes so a renderer-produced line with
   // quotes in it can't break the surrounding instruction block.
   const safe = line.replace(/`/g, "'").replace(/\r?\n/g, ' ').trim();
-  const isDe = (lang || 'en').toLowerCase().startsWith('de');
-  const greetingHint = isDe
-    ? 'Beginne mit EINEM warmen Begrüßungs-Satz auf Deutsch (z.B. "Hi Dragan, schön dass du wieder da bist."). Verwende den Vornamen des Nutzers, falls verfügbar.'
-    : 'Open with ONE warm greeting sentence (e.g. "Hi Dragan, good to see you again."). Use the user\'s first name when available.';
   const dedupeLine = dedupeKey ? `\nDedupe key: ${dedupeKey} (do NOT repeat after this turn).` : '';
-  return `\n\n## VERTEX WAKE BRIEF (HIGHEST PRIORITY — VTID-03079)
+  // VTID-03097: hard-instruction format. Earlier soft-instruction
+  // ("Speak this VERBATIM") was being lost to the SHORT-GAP GREETING
+  // PHRASES pool injection in live-system-instruction.ts:253. The
+  // sentinel marker below is also detected by buildLiveSystemInstruction
+  // to skip the pool injection entirely when an override is active.
+  return `\n\n${VERTEX_WAKE_BRIEF_OVERRIDE_MARKER}
 
-Your FIRST utterance this session MUST be a single turn that combines:
+## SPOKEN FIRST UTTERANCE — REQUIRED VERBATIM (VTID-03079 / VTID-03097)
 
-  Part A — Warm greeting:
-    ${greetingHint}
+The user just opened the orb. Your FIRST spoken turn this session MUST
+be EXACTLY this text. Copy these characters letter-for-letter; do not
+paraphrase, do not translate, do not shorten, do not split into two
+turns, do not append clarifying questions:
 
-  Part B — Proactive content (speak VERBATIM, do NOT paraphrase, do NOT translate):
-    "${safe}"
+  "${safe}"
 
-Speak Part A and Part B as ONE continuous turn. Do NOT use any other opener
-("How can I help today?", "Was liegt an?", "Ready to go", "I'm here"). Do NOT
-list features. Do NOT introduce yourself. The wake-brief content already
-ends with an inviting question — let the user respond before continuing.${dedupeLine}
+Rules:
+  - Do NOT say "Wie kann ich dir helfen?" / "How can I help?" / "Was steht an?"
+    / "Was liegt an?" / any standalone offer-to-help phrasing.
+  - Do NOT pick a phrase from the "SHORT-GAP GREETING PHRASES" section —
+    that section is SUPPRESSED for this turn.
+  - Do NOT introduce yourself or list features.
+  - The line above already contains both the greeting AND the proactive
+    invitation. After speaking it, stop and wait for the user's reply.${dedupeLine}
 
-This block REPLACES every other greeting rule below for the first turn only.`;
+This block OVERRIDES every other greeting rule in this prompt for the
+first turn only. Subsequent turns follow the normal conversation flow.`;
 }
 
 export async function handleLiveSessionStart(

--- a/services/gateway/src/routes/voice-teach-inspector.ts
+++ b/services/gateway/src/routes/voice-teach-inspector.ts
@@ -17,6 +17,7 @@
 
 import { Router, Response } from 'express';
 import {
+  requireAuthWithTenant,
   requireExafyAdmin,
   AuthenticatedRequest,
 } from '../middleware/auth-supabase-jwt';
@@ -33,6 +34,12 @@ const SUPPORTED_LANGS = ['en', 'de'] as const;
 
 router.get(
   '/voice/teach-vitanaland/state',
+  // VTID-03097: requireExafyAdmin needs requireAuthWithTenant FIRST to
+  // populate req.identity. Without the auth step the admin middleware
+  // sees no identity and returns 'Authentication required' (401). All
+  // other admin routes pair these two — voice-feature-discovery.ts is
+  // the canonical example.
+  requireAuthWithTenant,
   requireExafyAdmin,
   async (req: AuthenticatedRequest, res: Response) => {
     try {


### PR DESCRIPTION
## Two real bugs the user hit on production

### Problem 1 — "Authentication required" on Teach Vitanaland panel
Route used `requireExafyAdmin` alone; that middleware needs `requireAuthWithTenant` FIRST to populate `req.identity`. All other admin routes pair them.

**Fix:** added `requireAuthWithTenant` before `requireExafyAdmin` on `/voice/teach-vitanaland/state`.

### Problem 2 — Teacher's line never reaches audio; bare wake-brief wins
User on Vertex heard "Hallo nochmal, wie kann ich dir helfen" — NOT the Teacher's two-clause line. Two competing "speak this verbatim" instructions:

1. `SHORT-GAP GREETING PHRASES` section (live-system-instruction.ts:253) — pool of 6-8 example phrasings.
2. `VERTEX WAKE BRIEF` override block — Teacher's picked line.

Gemini Live biased toward the pool list and ignored the override.

**Fix (two layers):**

A. **Tightened override block:** wrapped in sentinel marker `<<VERTEX_WAKE_BRIEF_OVERRIDE_ACTIVE>>`, changed from "Speak this VERBATIM" soft instruction to "REQUIRED VERBATIM" with explicit "do not paraphrase, do not translate, do not shorten, do not pick from SHORT-GAP GREETING PHRASES — that section is SUPPRESSED for this turn."

B. **Suppression at the source:** `buildLiveSystemInstruction` detects the marker in `bootstrapContext` and threads `wakeBriefOverrideActive=true` down. When set, the SHORT-GAP GREETING PHRASES menu is replaced with a single line saying it's suppressed — no pool entries flow to Gemini.

The two systems no longer compete — the override is now hierarchically dominant by construction, not by recency bias.

## Test plan
- [x] 121 tests green (teacher / controller / greeting-pools characterization)
- [x] Gateway build green
- [ ] Real-mic verification post-deploy: Dragan1 / Dragan3 should hear the warm two-clause Teacher line, not the bare wake-brief
- [ ] Command Hub panel loads (no more 401)

🤖 Generated with [Claude Code](https://claude.com/claude-code)