### PR TITLE
fix(orb-widget): user X-close must not spawn a background session (VTID-03098, DEV-COMHU-03098)

### DIFF
--- a/services/gateway/scripts/orb-widget-stop-regression.mjs
+++ b/services/gateway/scripts/orb-widget-stop-regression.mjs
@@ -1,0 +1,126 @@
+#!/usr/bin/env node
+/**
+ * VTID-03098 regression: prove orb-widget.js cannot spawn a new session in
+ * the background after the user presses X.
+ *
+ * The bug we fixed: _sessionStop closed the SSE EventSource WITHOUT first
+ * detaching its onerror handler. On Android Appilix WebView, the manual
+ * close fired onerror with readyState === CLOSED, which called
+ * _announceDisconnect → started a 5s _recoveryWatchdog setInterval →
+ * health-probed the gateway → called _resetAndReconnect → _sessionStart →
+ * the user heard a brand-new wake-brief greeting "in the background" after
+ * the overlay was gone.
+ *
+ * The fix is layered:
+ *   1. _userInitiatedStop guard added to _s state, flipped true in
+ *      _sessionStop and false in _sessionStart.
+ *   2. _sessionStop now ALWAYS clears _recoveryWatchdog (the previous
+ *      cleanup was gated on _disconnectActive being true, which it usually
+ *      isn't during a healthy session).
+ *   3. _sessionStop detaches SSE onopen/onmessage/onerror BEFORE close().
+ *   4. _announceDisconnect short-circuits when _userInitiatedStop is set
+ *      OR when overlayVisible is false.
+ *   5. _resetAndReconnect short-circuits on the same conditions.
+ *
+ * This script greps the bundled widget source for each guard so a future
+ * refactor can't silently regress the cascade.
+ */
+import { readFileSync } from 'node:fs';
+import { dirname, resolve } from 'node:path';
+import { fileURLToPath } from 'node:url';
+
+const repoRoot = resolve(dirname(fileURLToPath(import.meta.url)), '..', '..', '..');
+const sourcePath = resolve(repoRoot, 'services/gateway/src/frontend/command-hub/orb-widget.js');
+const source = readFileSync(sourcePath, 'utf8');
+
+function assert(condition, message) {
+  if (!condition) {
+    console.error(`[orb-widget-stop-regression] FAIL: ${message}`);
+    process.exit(1);
+  }
+}
+
+function extractFunctionBody(signature) {
+  const sigIdx = source.indexOf(signature);
+  assert(sigIdx >= 0, `missing function signature: ${signature}`);
+  const openIdx = source.indexOf('{', sigIdx);
+  assert(openIdx >= 0, `missing function body open brace: ${signature}`);
+  let depth = 0;
+  for (let i = openIdx; i < source.length; i++) {
+    const c = source[i];
+    if (c === '{') depth++;
+    if (c === '}') depth--;
+    if (depth === 0) return source.slice(openIdx + 1, i);
+  }
+  throw new Error(`unclosed function body: ${signature}`);
+}
+
+// 1. _userInitiatedStop flag exists in _s state.
+assert(
+  /_userInitiatedStop\s*:\s*false/.test(source),
+  '_s must declare _userInitiatedStop: false so the stop guard can be flipped at runtime.',
+);
+
+const stopBody = extractFunctionBody('async function _sessionStop()');
+const startBody = extractFunctionBody('async function _sessionStart()');
+const announceBody = extractFunctionBody('function _announceDisconnect(reason)');
+const resetBody = extractFunctionBody('function _resetAndReconnect()');
+
+// 2. _sessionStop sets the flag.
+assert(
+  /_s\._userInitiatedStop\s*=\s*true/.test(stopBody),
+  '_sessionStop must set _s._userInitiatedStop = true before any teardown.',
+);
+
+// 3. _sessionStop unconditionally clears _recoveryWatchdog.
+const stopRecoveryClearIdx = stopBody.indexOf('clearInterval(_s._recoveryWatchdog)');
+assert(stopRecoveryClearIdx >= 0, '_sessionStop must clearInterval(_s._recoveryWatchdog).');
+// The unconditional clear must appear OUTSIDE the legacy `if (_s._disconnectActive)` block.
+// We check that there is at least one clearInterval call before the disconnect-active block
+// (which we identify by its assignment `_s._disconnectActive = false`).
+const disconnectActiveAssignIdx = stopBody.indexOf('_s._disconnectActive = false');
+assert(
+  disconnectActiveAssignIdx > 0 && stopRecoveryClearIdx < disconnectActiveAssignIdx,
+  '_sessionStop must clearInterval(_s._recoveryWatchdog) UNCONDITIONALLY, before the _disconnectActive cleanup block.',
+);
+
+// 4. _sessionStop detaches SSE handlers before close.
+assert(
+  /__es\.onerror\s*=\s*null/.test(stopBody),
+  '_sessionStop must null out eventSource.onerror BEFORE calling close() to suppress the auto-reconnect cascade.',
+);
+assert(
+  /__es\.onmessage\s*=\s*null/.test(stopBody),
+  '_sessionStop must null out eventSource.onmessage BEFORE calling close().',
+);
+const onerrorNullIdx = stopBody.indexOf('__es.onerror = null');
+const closeIdx = stopBody.indexOf('__es.close()');
+assert(
+  onerrorNullIdx >= 0 && closeIdx >= 0 && onerrorNullIdx < closeIdx,
+  '_sessionStop must null onerror BEFORE close() — order matters.',
+);
+
+// 5. _sessionStart clears the flag.
+assert(
+  /_s\._userInitiatedStop\s*=\s*false/.test(startBody),
+  '_sessionStart must reset _s._userInitiatedStop = false so the next session is allowed.',
+);
+
+// 6. _announceDisconnect short-circuits on _userInitiatedStop AND on !overlayVisible.
+assert(
+  /if\s*\(\s*_s\._userInitiatedStop\s*\)\s*return/.test(announceBody),
+  '_announceDisconnect must early-return when _userInitiatedStop is set.',
+);
+assert(
+  /if\s*\(\s*!_s\.overlayVisible\s*\)\s*return/.test(announceBody),
+  '_announceDisconnect must early-return when overlayVisible is false.',
+);
+
+// 7. _resetAndReconnect short-circuits on the same conditions.
+assert(
+  /_s\._userInitiatedStop\s*\|\|\s*!_s\.overlayVisible/.test(resetBody)
+    || (/_s\._userInitiatedStop/.test(resetBody) && /!_s\.overlayVisible/.test(resetBody)),
+  '_resetAndReconnect must early-return on _userInitiatedStop OR !overlayVisible.',
+);
+
+console.log('[orb-widget-stop-regression] OK: user X-close cannot spawn a background session.');

--- a/services/gateway/src/frontend/command-hub/orb-widget.js
+++ b/services/gateway/src/frontend/command-hub/orb-widget.js
@@ -199,6 +199,13 @@
     _isReconnecting: false,
     _recoveryWatchdog: null,         // VTID-01987: setInterval handle for the 5s health probe
     _disconnectStuck: false,
+    // VTID-03098: user-initiated stop guard. Set true at the top of
+    // _sessionStop (X button / VitanaOrb.hide() / signup-close), cleared at
+    // the top of _sessionStart. While true, _announceDisconnect and
+    // _resetAndReconnect both short-circuit so a spurious onerror from the
+    // manually-closed EventSource (Android WebView fires it; spec is murky)
+    // never spawns a fresh session in the background.
+    _userInitiatedStop: false,
     // VTID-02020: contextual recovery state. _preDisconnectStage captures what
     // the user was doing when the network dropped (idle / listening_user_speaking
     // / thinking / speaking) so the backend's recovery prompt can decide
@@ -653,6 +660,13 @@
   }
 
   function _announceDisconnect(reason) {
+    // VTID-03098: never announce a disconnect during user-initiated teardown
+    // or when the overlay is already closed. Either condition means the
+    // session is supposed to be ending; treating the close as a network
+    // disconnect arms _recoveryWatchdog and spawns a fresh session in the
+    // background ~5s after the X press.
+    if (_s._userInitiatedStop) return;
+    if (!_s.overlayVisible) return;
     if (_s._disconnectActive) return; // debounce
     _s._disconnectActive = true;
     _s._disconnectReason = reason;
@@ -786,6 +800,17 @@
   // by the orb-tap handler when the user taps an orb that's stuck on the
   // disconnect display, and by the 60s watchdog as a last-resort recovery.
   function _resetAndReconnect() {
+    // VTID-03098: refuse to reconnect when the user has closed the overlay
+    // or when _sessionStop has been initiated. This is the last line of
+    // defense — both the SSE-handler detach in _sessionStop and the
+    // _userInitiatedStop guard in _announceDisconnect should prevent us
+    // from getting here, but if any future code path manages to call this
+    // function after the user pressed X, fail closed instead of spawning a
+    // background session.
+    if (_s._userInitiatedStop || !_s.overlayVisible) {
+      console.log('[VTOrb] _resetAndReconnect: skipped — overlay closed or stop in progress');
+      return;
+    }
     console.log('[VTOrb] _resetAndReconnect: forcing full session restart');
     _stopWatchdog();
     if (_s.captureStream) {
@@ -942,6 +967,11 @@
     if (_s.active) return;
     console.log('[VTOrb] Starting Gemini Live session...');
 
+    // VTID-03098: clear the user-initiated-stop flag at the start of every
+    // session so a fresh tap on the orb can connect normally. The flag is
+    // only meant to guard the teardown window between _sessionStop and the
+    // next intentional _sessionStart.
+    _s._userInitiatedStop = false;
     _s.greetingAudioReceived = false;
     // VTID-01988: greetingComplete gates the post-greeting _startAudioCapture()
     // call. It used to only get reset in _sessionStop (full session teardown),
@@ -1131,8 +1161,22 @@
 
   async function _sessionStop() {
     console.log('[VTOrb] Stopping session...');
+    // VTID-03098: mark this as a user-initiated stop BEFORE any teardown.
+    // Anything that fires synchronously as a result of the teardown (SSE
+    // onerror on Android WebView, residual disconnect-recovery probes,
+    // setTimeout reconnect callbacks) must see this flag and bail.
+    _s._userInitiatedStop = true;
     _stopWatchdog();
     clearTimeout(_s._listeningIdleTimer);
+
+    // VTID-03098: always cancel the disconnect-recovery probe, even when
+    // _disconnectActive is false. The probe is a 5s setInterval started by
+    // _announceDisconnect; if any earlier onerror (manual close on Android,
+    // half-open socket race) armed it without flipping _disconnectActive
+    // back into the alert state we still observe, leaving it running would
+    // wake a brand-new session in the background after the user pressed X.
+    clearInterval(_s._recoveryWatchdog);
+    _s._recoveryWatchdog = null;
 
     // Cancel any pending disconnect alert silently — session is ending, so no
     // "we're back" phrase. (Alert clips are short BufferSources that finish
@@ -1143,8 +1187,6 @@
       _s._preDisconnectVoiceState = null;
       _s._disconnectStuck = false;
       _s._isReconnecting = false;
-      clearInterval(_s._recoveryWatchdog);
-      _s._recoveryWatchdog = null;
     }
 
     // Stop mic
@@ -1168,8 +1210,21 @@
     _s.greetingAudioReceived = false;
     _s.lastScheduledEnd = 0;
 
-    // Close SSE
-    if (_s.eventSource) { _s.eventSource.close(); _s.eventSource = null; }
+    // Close SSE — VTID-03098: detach handlers FIRST so the manual close
+    // cannot trip the auto-reconnect cascade through es.onerror. The
+    // EventSource spec does not require onerror to fire on close(), but
+    // Android Appilix WebView observably does fire it, and the handler
+    // bound below calls _announceDisconnect → _recoveryWatchdog (5s
+    // health probe) → _resetAndReconnect → _sessionStart, which is
+    // exactly the "background greeting after the X" symptom this fixes.
+    if (_s.eventSource) {
+      var __es = _s.eventSource;
+      _s.eventSource = null;
+      try { __es.onopen = null; } catch (e) { /* noop */ }
+      try { __es.onmessage = null; } catch (e) { /* noop */ }
+      try { __es.onerror = null; } catch (e) { /* noop */ }
+      try { __es.close(); } catch (e) { /* noop */ }
+    }
 
     // Stop backend session
     if (_s.sessionId) {


### PR DESCRIPTION
## Summary

After pressing X in the unified orb overlay on Android Appilix WebView, the orb started a brand-new greeting ~5 seconds later — "in the background", with the overlay already gone. Two MAXINA accounts (Dragan1 + Dragan3) reproduced.

The vanilla-JS \`orb-widget.js\` served by the gateway is what mobile actually runs (the React \`VitanaAudioOverlay\` from PR vitana-v1#477 is dead code on this surface). The widget closed its SSE \`EventSource\` without detaching \`onerror\` first — Android WebView fires \`onerror\` with \`readyState === CLOSED\` on a manual close, the handler ran \`_announceDisconnect\` → armed the 5s \`_recoveryWatchdog\` → health-probed the gateway → called \`_resetAndReconnect\` → \`_sessionStart\` → fresh wake-brief spoken into nothing.

## Fix (layered)

1. New \`_s._userInitiatedStop\` flag, set in \`_sessionStop\`, cleared in \`_sessionStart\`.
2. \`_sessionStop\` now ALWAYS clears \`_recoveryWatchdog\` (the previous code only cleared it inside an \`if (_s._disconnectActive)\` branch — which is normally false on a healthy session).
3. \`_sessionStop\` detaches \`onopen\` / \`onmessage\` / \`onerror\` BEFORE \`EventSource.close()\`.
4. \`_announceDisconnect\` short-circuits on \`_userInitiatedStop\` OR \`!overlayVisible\`.
5. \`_resetAndReconnect\` short-circuits on the same conditions as a last line of defense.

## Sibling PR

[vitana-v1#477](https://github.com/exafyltd/vitana-v1/pull/477) (VTID-03086) shipped the same shape of fix for \`OrbVoiceClient.stop()\` on the React side. That code is not mounted on the WebView the user actually sees, so this PR is the one that lands on mobile.

## Test plan

- [x] \`node services/gateway/scripts/orb-widget-stop-regression.mjs\` — new script greps the widget source for every guard, plus the ordering invariant that \`onerror = null\` precedes \`close()\`. Run as part of the pre-merge sanity loop.
- [x] \`new Function(src)\` parse check — widget JS is syntactically valid.
- [ ] After AUTO-DEPLOY: Android Appilix WebView, two accounts, press X mid-greeting, confirm no second greeting fires 5–10s later (force-stop the app to drop any stale runtime; the gateway already serves \`orb-widget.js\` with \`cache-control: no-store\`).
- [ ] Desktop /command-hub smoke — open orb, talk to Vitana, press X mid-response, confirm no auto-reconnect after close.

🤖 Generated with [Claude Code](https://claude.com/claude-code)