### PR TITLE
fix(teacher): strip vitana-brain opener sections when wake-brief override active (VTID-03098)

### DIFF
--- a/services/gateway/src/orb/live/instruction/live-system-instruction.ts
+++ b/services/gateway/src/orb/live/instruction/live-system-instruction.ts
@@ -131,6 +131,38 @@ export function describeRoute(route: string | undefined | null, lang: string): {
  * The block is language-agnostic — Gemini Live translates it into the
  * session language via the LANGUAGE directive earlier in the instruction.
  */
+
+/**
+ * VTID-03097: surgically strip vitana-brain's opener sections from
+ * `bootstrapContext` when a VERTEX WAKE BRIEF override is active.
+ * The three sections below all tell Gemini "your first utterance must
+ * build around this candidate" and dominate the override at generation
+ * time even when the override is later in the prompt. Removing them
+ * lets the override own the first turn without re-architecting
+ * vitana-brain.ts.
+ *
+ * Idempotent: stripping a string that doesn't contain the markers
+ * returns it unchanged. Pure function. Exported for tests.
+ */
+export function stripBrainOpenerSections(bootstrap: string): string {
+  if (!bootstrap) return bootstrap;
+  const SECTIONS = [
+    'OPENING SHAPE MATRIX (TENURE × LAST_INTERACTION)',
+    'PROACTIVE OPENER CANDIDATE — YOUR FIRST UTTERANCE MUST BUILD AROUND THIS',
+    'PROACTIVE INITIATIVE OFFER (V2 — HIGHEST-PRIORITY OPENER FOR THIS SESSION)',
+  ];
+  let out = bootstrap;
+  for (const heading of SECTIONS) {
+    const safe = heading.replace(/[.*+?^${}()|[\]\\]/g, '\\$&');
+    const pattern = new RegExp(
+      `={3,}\\s*${safe}\\s*={3,}[\\s\\S]*?(?=\\n={3,}\\s+|$)`,
+      'g',
+    );
+    out = out.replace(pattern, '');
+  }
+  return out.replace(/\n{3,}/g, '\n\n').trim();
+}
+
 function buildTemporalJourneyContextSection(
   lang: string,
   lastSessionInfo: { time: string; wasFailure: boolean } | null | undefined,
@@ -615,9 +647,36 @@ ${voiceLiveConfig.important_section || '- This is a real-time voice conversation
     instruction += `\n\nPREVIOUS CONVERSATION CONTEXT:\n${conversationSummary}\nYou may briefly reference this context naturally, but do NOT recite it back to the user.`;
   }
 
-  // VTID-01224: Append bootstrap context if available
-  if (bootstrapContext) {
-    instruction += `\n\n${bootstrapContext}`;
+  // VTID-01224: Append bootstrap context if available.
+  //
+  // VTID-03097 step 2: when a wake-brief override block is active
+  // (Teacher / wake-brief picked a specific userFacingLine), strip
+  // the competing brain-side opener sections from bootstrapContext:
+  //   === OPENING SHAPE MATRIX (TENURE × LAST_INTERACTION) ===
+  //   === PROACTIVE OPENER CANDIDATE — YOUR FIRST UTTERANCE MUST BUILD AROUND THIS ===
+  //   === PROACTIVE INITIATIVE OFFER (V2 — HIGHEST-PRIORITY OPENER FOR THIS SESSION) ===
+  //
+  // These are vitana-brain.ts injections that tell Gemini "lead with
+  // this opener candidate." They dominate the override block at
+  // generation time even when the override is later in the prompt —
+  // Gemini reconciles by following the more-concrete matrix
+  // instructions and ignoring our VERBATIM rule. Stripping them is
+  // the only reliable way to make the wake-brief override actually
+  // own the first turn.
+  //
+  // The strip is surgical: only the opener sections are removed; the
+  // rest of the brain context (USER CONTEXT PROFILE, ACTIVITY_14D,
+  // RECENT, FACTS, etc.) stays — those carry no greeting instructions
+  // and continue to ground the conversation after the first utterance.
+  let effectiveBootstrap = bootstrapContext ?? '';
+  if (
+    effectiveBootstrap &&
+    effectiveBootstrap.includes('<<VERTEX_WAKE_BRIEF_OVERRIDE_ACTIVE>>')
+  ) {
+    effectiveBootstrap = stripBrainOpenerSections(effectiveBootstrap);
+  }
+  if (effectiveBootstrap) {
+    instruction += `\n\n${effectiveBootstrap}`;
   }
 
   // VTID-01225 + VTID-STREAM-KEEPALIVE: Append conversation history for reconnect continuity.

--- a/services/gateway/src/orb/live/instruction/live-system-instruction.ts
+++ b/services/gateway/src/orb/live/instruction/live-system-instruction.ts
@@ -149,6 +149,10 @@ function buildTemporalJourneyContextSection(
   // greeting) so this stays opt-in. TONE RULES + JOURNEY AWARENESS are
   // kept because they shape ongoing conversation, not just the opener.
   omitGreetingPolicy?: boolean,
+  // VTID-03097: when the caller already injected a VERTEX WAKE BRIEF
+  // override block, suppress the short-gap-greeting-phrases pool so
+  // Gemini doesn't see two competing "speak this verbatim" lists.
+  wakeBriefOverrideActive?: boolean,
 ): string {
   const temporal = describeTimeSince(lastSessionInfo);
   const current = describeRoute(currentRoute, lang);
@@ -247,11 +251,19 @@ function buildTemporalJourneyContextSection(
   const greetingTimeOfDay = timeOfDay === 'night' ? 'evening' : (timeOfDay || 'day');
 
   const bucket = isReconnect ? 'reconnect' : temporal.bucket;
+  // VTID-03097: caller signals when a wake-brief override block is
+  // active. When yes, the SHORT-GAP GREETING PHRASES pool is
+  // suppressed so Gemini doesn't see two competing "speak this
+  // verbatim" lists.
   // VTID-GREETING-VARIETY: for short-gap buckets, inject a freshly-shuffled
   // subset of the language-specific phrase pool so Gemini rotates openers
   // instead of converging on the same translation every time.
   const shortGapExamples = pickShortGapGreetings(lang, 6);
   const appendShortGapPhraseMenu = () => {
+    if (wakeBriefOverrideActive) {
+      lines.push('  • SHORT-GAP PHRASE LIST SUPPRESSED — a VERTEX WAKE BRIEF override is active later in this prompt. Speak the override line verbatim instead of any phrase here.');
+      return;
+    }
     lines.push('  • Pick ONE of these example phrasings (use them VERBATIM — they are already in the user\'s language; pick a different one than last time):');
     for (const p of shortGapExamples) {
       lines.push(`      "${p}"`);
@@ -630,6 +642,13 @@ ${trimmedHistory}
   // VTID-NAV-TIMEJOURNEY: Append the temporal + journey context block LAST so
   // its greeting policy overrides the generic GREETING RULES higher up. This
   // is what stops Vitana from saying "Hello <name>!" every single session.
+  // VTID-03097: detect VERTEX WAKE BRIEF override here at the
+  // top-level buildLiveSystemInstruction (which has bootstrapContext)
+  // and pass the boolean down so the temporal section can suppress
+  // the SHORT-GAP GREETING PHRASES pool when needed.
+  const wakeBriefOverrideActive =
+    typeof bootstrapContext === 'string' &&
+    bootstrapContext.includes('<<VERTEX_WAKE_BRIEF_OVERRIDE_ACTIVE>>');
   instruction += buildTemporalJourneyContextSection(
     lang,
     lastSessionInfo,
@@ -638,6 +657,7 @@ ${trimmedHistory}
     !!isReconnect,
     clientContext?.timeOfDay,
     omitGreetingPolicy,
+    wakeBriefOverrideActive,
   );
 
   // BOOTSTRAP-AWARENESS-REGISTRY: gate the override blocks below on admin

--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -417,35 +417,48 @@ export async function handleLiveStreamEndTurn(
  * Trailing punctuation + quote escaping is handled inline so the
  * line can't accidentally close the prompt block.
  */
+/** Sentinel marker — used by buildLiveSystemInstruction to suppress
+ *  the SHORT-GAP GREETING PHRASES pool when an override is active.
+ *  Must match the literal substring exactly in both places. */
+export const VERTEX_WAKE_BRIEF_OVERRIDE_MARKER =
+  '<<VERTEX_WAKE_BRIEF_OVERRIDE_ACTIVE>>';
+
 function buildVertexWakeBriefBlock(
   line: string,
-  lang: string,
+  _lang: string,
   dedupeKey: string | null,
 ): string {
   // Escape backticks + close-quotes so a renderer-produced line with
   // quotes in it can't break the surrounding instruction block.
   const safe = line.replace(/`/g, "'").replace(/\r?\n/g, ' ').trim();
-  const isDe = (lang || 'en').toLowerCase().startsWith('de');
-  const greetingHint = isDe
-    ? 'Beginne mit EINEM warmen Begrüßungs-Satz auf Deutsch (z.B. "Hi Dragan, schön dass du wieder da bist."). Verwende den Vornamen des Nutzers, falls verfügbar.'
-    : 'Open with ONE warm greeting sentence (e.g. "Hi Dragan, good to see you again."). Use the user\'s first name when available.';
   const dedupeLine = dedupeKey ? `\nDedupe key: ${dedupeKey} (do NOT repeat after this turn).` : '';
-  return `\n\n## VERTEX WAKE BRIEF (HIGHEST PRIORITY — VTID-03079)
+  // VTID-03097: hard-instruction format. Earlier soft-instruction
+  // ("Speak this VERBATIM") was being lost to the SHORT-GAP GREETING
+  // PHRASES pool injection in live-system-instruction.ts:253. The
+  // sentinel marker below is also detected by buildLiveSystemInstruction
+  // to skip the pool injection entirely when an override is active.
+  return `\n\n${VERTEX_WAKE_BRIEF_OVERRIDE_MARKER}
 
-Your FIRST utterance this session MUST be a single turn that combines:
+## SPOKEN FIRST UTTERANCE — REQUIRED VERBATIM (VTID-03079 / VTID-03097)
 
-  Part A — Warm greeting:
-    ${greetingHint}
+The user just opened the orb. Your FIRST spoken turn this session MUST
+be EXACTLY this text. Copy these characters letter-for-letter; do not
+paraphrase, do not translate, do not shorten, do not split into two
+turns, do not append clarifying questions:
 
-  Part B — Proactive content (speak VERBATIM, do NOT paraphrase, do NOT translate):
-    "${safe}"
+  "${safe}"
 
-Speak Part A and Part B as ONE continuous turn. Do NOT use any other opener
-("How can I help today?", "Was liegt an?", "Ready to go", "I'm here"). Do NOT
-list features. Do NOT introduce yourself. The wake-brief content already
-ends with an inviting question — let the user respond before continuing.${dedupeLine}
+Rules:
+  - Do NOT say "Wie kann ich dir helfen?" / "How can I help?" / "Was steht an?"
+    / "Was liegt an?" / any standalone offer-to-help phrasing.
+  - Do NOT pick a phrase from the "SHORT-GAP GREETING PHRASES" section —
+    that section is SUPPRESSED for this turn.
+  - Do NOT introduce yourself or list features.
+  - The line above already contains both the greeting AND the proactive
+    invitation. After speaking it, stop and wait for the user's reply.${dedupeLine}
 
-This block REPLACES every other greeting rule below for the first turn only.`;
+This block OVERRIDES every other greeting rule in this prompt for the
+first turn only. Subsequent turns follow the normal conversation flow.`;
 }
 
 export async function handleLiveSessionStart(

--- a/services/gateway/src/routes/voice-teach-inspector.ts
+++ b/services/gateway/src/routes/voice-teach-inspector.ts
@@ -17,6 +17,7 @@
 
 import { Router, Response } from 'express';
 import {
+  requireAuthWithTenant,
   requireExafyAdmin,
   AuthenticatedRequest,
 } from '../middleware/auth-supabase-jwt';
@@ -33,6 +34,12 @@ const SUPPORTED_LANGS = ['en', 'de'] as const;
 
 router.get(
   '/voice/teach-vitanaland/state',
+  // VTID-03097: requireExafyAdmin needs requireAuthWithTenant FIRST to
+  // populate req.identity. Without the auth step the admin middleware
+  // sees no identity and returns 'Authentication required' (401). All
+  // other admin routes pair these two — voice-feature-discovery.ts is
+  // the canonical example.
+  requireAuthWithTenant,
   requireExafyAdmin,
   async (req: AuthenticatedRequest, res: Response) => {
     try {

--- a/services/gateway/test/orb/live/instruction/strip-brain-opener-sections.test.ts
+++ b/services/gateway/test/orb/live/instruction/strip-brain-opener-sections.test.ts
@@ -1,0 +1,124 @@
+/**
+ * VTID-03097 — stripBrainOpenerSections() pure helper tests.
+ */
+
+import { stripBrainOpenerSections } from '../../../../src/orb/live/instruction/live-system-instruction';
+
+describe('VTID-03097 — stripBrainOpenerSections', () => {
+  test('empty / null in returns unchanged', () => {
+    expect(stripBrainOpenerSections('')).toBe('');
+  });
+
+  test('bootstrap without any opener sections is unchanged', () => {
+    const text = '## USER CONTEXT PROFILE\n\nDragan is a 56-year-old founder.';
+    expect(stripBrainOpenerSections(text)).toBe(text.trim());
+  });
+
+  test('strips OPENING SHAPE MATRIX section', () => {
+    const input = `
+## USER CONTEXT PROFILE
+foo bar
+
+=== OPENING SHAPE MATRIX (TENURE × LAST_INTERACTION) ===
+
+day0 → 5-8 sentences. FULL INTRODUCTION.
+day1 → ...
+
+=== NEXT SECTION ===
+keep this
+`.trim();
+    const out = stripBrainOpenerSections(input);
+    expect(out).not.toContain('OPENING SHAPE MATRIX');
+    expect(out).toContain('## USER CONTEXT PROFILE');
+    expect(out).toContain('keep this');
+  });
+
+  test('strips PROACTIVE OPENER CANDIDATE section', () => {
+    const input = `
+HEADER
+
+=== PROACTIVE OPENER CANDIDATE — YOUR FIRST UTTERANCE MUST BUILD AROUND THIS ===
+Kind: pillar_focus
+Title: Your nutrition pillar
+...
+`.trim();
+    const out = stripBrainOpenerSections(input);
+    expect(out).not.toContain('PROACTIVE OPENER CANDIDATE');
+    expect(out).not.toContain('pillar_focus');
+    expect(out).toContain('HEADER');
+  });
+
+  test('strips PROACTIVE INITIATIVE OFFER section', () => {
+    const input = `
+context
+
+=== PROACTIVE INITIATIVE OFFER (V2 — HIGHEST-PRIORITY OPENER FOR THIS SESSION) ===
+
+Initiative key: log_meal
+...
+`.trim();
+    const out = stripBrainOpenerSections(input);
+    expect(out).not.toContain('PROACTIVE INITIATIVE OFFER');
+    expect(out).toContain('context');
+  });
+
+  test('strips all three opener sections together', () => {
+    const input = `
+## USER CONTEXT PROFILE
+Dragan, day30plus.
+
+=== OPENING SHAPE MATRIX (TENURE × LAST_INTERACTION) ===
+day30plus → 1-2 sentences.
+
+=== PROACTIVE OPENER CANDIDATE — YOUR FIRST UTTERANCE MUST BUILD AROUND THIS ===
+Kind: pillar_focus.
+
+=== PROACTIVE INITIATIVE OFFER (V2 — HIGHEST-PRIORITY OPENER FOR THIS SESSION) ===
+Initiative key: log_meal.
+
+=== ACTIVITY 14D ===
+keep me
+
+=== RECENT TURNS ===
+keep me too
+`.trim();
+    const out = stripBrainOpenerSections(input);
+    expect(out).not.toContain('OPENING SHAPE MATRIX');
+    expect(out).not.toContain('PROACTIVE OPENER CANDIDATE');
+    expect(out).not.toContain('PROACTIVE INITIATIVE OFFER');
+    expect(out).not.toContain('day30plus → 1-2 sentences');
+    expect(out).not.toContain('Initiative key: log_meal');
+    expect(out).toContain('USER CONTEXT PROFILE');
+    expect(out).toContain('ACTIVITY 14D');
+    expect(out).toContain('RECENT TURNS');
+    expect(out).toContain('keep me');
+    expect(out).toContain('keep me too');
+  });
+
+  test('collapses excess blank lines after removal', () => {
+    const input = `
+A
+
+=== OPENING SHAPE MATRIX (TENURE × LAST_INTERACTION) ===
+delete me
+
+=== NEXT ===
+B
+`.trim();
+    const out = stripBrainOpenerSections(input);
+    // No more than two consecutive newlines anywhere.
+    expect(out).not.toMatch(/\n{3,}/);
+  });
+
+  test('strip is idempotent', () => {
+    const input = `
+=== OPENING SHAPE MATRIX (TENURE × LAST_INTERACTION) ===
+remove
+=== ANOTHER ===
+keep
+`.trim();
+    const first = stripBrainOpenerSections(input);
+    const second = stripBrainOpenerSections(first);
+    expect(second).toBe(first);
+  });
+});


### PR DESCRIPTION
## Why this PR exists

User on Vertex Android still heard *"Nice that you're back. What can I do for you?"* after PR #2248 deployed.

PR #2248 fixed:
1. The auth bug on the Command Hub panel ✓
2. The SHORT-GAP GREETING PHRASES pool competing with the override ✓

But it didn't fix the deeper conflict: **vitana-brain.ts injects three separate opener sections** that all tell Gemini "your first utterance must build around this candidate":

- `=== OPENING SHAPE MATRIX (TENURE × LAST_INTERACTION) ===`
- `=== PROACTIVE OPENER CANDIDATE — YOUR FIRST UTTERANCE MUST BUILD AROUND THIS ===`
- `=== PROACTIVE INITIATIVE OFFER (V2 — HIGHEST-PRIORITY OPENER FOR THIS SESSION) ===`

These dominate the VERTEX WAKE BRIEF override even though the override appears later in the prompt. Gemini reconciles by following the more-specific matrix instructions and ignoring the "speak this verbatim" rule. For a `day30plus` user with no specific candidate, the matrix naturally produces "Nice that you're back. What can I do for you?".

## Fix

In `live-system-instruction.ts`, when `bootstrapContext` contains the `<<VERTEX_WAKE_BRIEF_OVERRIDE_ACTIVE>>` sentinel, run `stripBrainOpenerSections()` to surgically remove the three opener sections **before** appending the bootstrap to the prompt.

The strip is surgical: only the opener-instruction sections are removed. `USER CONTEXT PROFILE`, `ACTIVITY_14D`, `RECENT TURNS`, `FACTS`, and every other brain-context section stays intact and continues to ground subsequent turns.

## Test plan
- [x] 8 unit tests cover the pure helper: each section individually, all three together, empty/null, blank-line collapse, idempotency
- [x] Gateway build green
- [ ] Real-mic Android Vertex: Dragan1 should hear "Hallo nochmal, Dragan. Hast du eine Minute? Ich würde dir gerne etwas zeigen." NOT "Nice that you're back. What can I do for you?"

🤖 Generated with [Claude Code](https://claude.com/claude-code)