### PR TITLE
fix(teacher): LiveKit also injects wake-brief override block (VTID-03100)

### DIFF
--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -423,7 +423,7 @@ export async function handleLiveStreamEndTurn(
 export const VERTEX_WAKE_BRIEF_OVERRIDE_MARKER =
   '<<VERTEX_WAKE_BRIEF_OVERRIDE_ACTIVE>>';
 
-function buildVertexWakeBriefBlock(
+export function buildVertexWakeBriefBlock(
   line: string,
   _lang: string,
   dedupeKey: string | null,

--- a/services/gateway/src/routes/orb-livekit.ts
+++ b/services/gateway/src/routes/orb-livekit.ts
@@ -1545,6 +1545,62 @@ router.get(
       }
     }
 
+    // VTID-03100: re-render systemInstruction with the wake-brief
+    // override block when a candidate has a non-empty userFacingLine.
+    // The earlier buildLiveSystemInstruction call (line ~1431) ran
+    // BEFORE wakeBriefDecision was computed, so the override block
+    // had nowhere to go. Now we know the picked line (Teacher's
+    // two-clause greeting or voice_wake_brief's policy line), so we
+    // build the block, prepend the sentinel marker to bootstrapContext,
+    // and re-call buildLiveSystemInstruction. The strip helper in
+    // live-system-instruction.ts detects the marker and removes the
+    // competing vitana-brain opener sections so the override actually
+    // owns the first turn.
+    try {
+      const picked = wakeBriefDecision?.selectedContinuation ?? null;
+      const line = picked?.userFacingLine?.trim();
+      if (picked && line && line.length > 0 && !isReconnect) {
+        const { buildVertexWakeBriefBlock } = await import(
+          '../orb/live/session/live-session-controller'
+        );
+        const overrideBlock = buildVertexWakeBriefBlock(
+          line,
+          lang,
+          picked.dedupeKey ?? null,
+        );
+        const vitanaBehavioralRule = buildPersonaBehavioralRule('vitana');
+        const augmentedContext =
+          (bootstrapContext ? `${bootstrapContext}\n\n` : '') +
+          `${vitanaBehavioralRule}` +
+          overrideBlock;
+        const voiceStyle =
+          (voiceConfig as { voice_style?: string } | null)?.voice_style?.trim() ||
+          'friendly, calm, empathetic';
+        systemInstruction = buildLiveSystemInstruction(
+          lang,
+          voiceStyle,
+          augmentedContext,
+          role,
+          undefined,
+          undefined,
+          isReconnect,
+          null,
+          null,
+          null,
+          envContext ?? undefined,
+          req.identity?.vitana_id ?? null,
+          true,
+        );
+        console.log(
+          `[${VTID}/VTID-03100] systemInstruction re-rendered with wake-brief override (kind=${picked.kind}, decision_id=${wakeBriefDecision?.decisionId}, lang=${lang})`,
+        );
+      }
+    } catch (exc) {
+      console.warn(
+        `[${VTID}/VTID-03100] override re-render failed (non-fatal — falls back to pre-override system_instruction): ${(exc as Error).message}`,
+      );
+    }
+
     const responsePayload: Record<string, unknown> = {
       ok: true,
       vtid: VTID,


### PR DESCRIPTION
## Why

Live probe showed the LiveKit bootstrap returns `wake_brief_decision.user_facing_line` correctly (Teacher line populated) but the rendered `system_instruction` still contains the vitana-brain opener sections and lacks the override block:

```
Contains override marker:             False
Contains OPENING SHAPE MATRIX:        True   ← still there
Contains PROACTIVE OPENER CANDIDATE:  True   ← still there
Contains REQUIRED VERBATIM marker:    False
```

Structural cause: orb-livekit.ts called `buildLiveSystemInstruction` BEFORE `wakeBriefDecision` was computed. The override block had no input data when the prompt was rendered.

Vertex was always fine (per-turn re-render via orb-live.ts:5641 always sees the latest `session.contextInstruction`); LiveKit's bootstrap is one-shot at the top of the route.

## Fix

After `wakeBriefDecision` is computed, if a candidate with a non-empty `userFacingLine` was picked, re-call `buildLiveSystemInstruction` with the augmented bootstrap context. The override block contains the `<<VERTEX_WAKE_BRIEF_OVERRIDE_ACTIVE>>` sentinel marker that `stripBrainOpenerSections` (VTID-03098) keys off — so the brain's opener sections are stripped from the rendered prompt and the override's `REQUIRED VERBATIM` instruction is the only opener left.

Also: exports `buildVertexWakeBriefBlock` from live-session-controller so the LiveKit route can share it. No behavior change in Vertex.

## Test plan
- [x] 90 tests green (8 strip-brain + 17 wake-brief-wiring + 56 controller + 9 livekit parity)
- [x] Gateway build green
- [ ] Real-mic LiveKit Test Bench: should hear Teacher line
- [ ] Real-mic Vertex Android: should also hear Teacher line (Vertex always shared the same flow per turn)

🤖 Generated with [Claude Code](https://claude.com/claude-code)