### PR TITLE
fix(orb): pass user transcript to forwarding gate — Vertex parity (VTID-03099)

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/tools.py
+++ b/services/agents/orb-agent/src/orb_agent/tools.py
@@ -324,9 +324,67 @@ async def report_to_specialist(
     orb_session_id = getattr(gw, "orb_session_id", None) or ""
     user_id = getattr(gw, "user_id", None) or ""
 
+    # VTID-03099: extract the user's last 3 RAW transcript turns and ship
+    # them with the tool call. The gateway feeds these into the two-gate
+    # forwarding RPC as gate_input — same logic Vertex uses (orb-live.ts:
+    # buildGateInputFromTranscript). Without this, the gate only sees the
+    # LLM-curated `summary` (compressed business language) which rarely
+    # contains the forward_request_phrases the RPC looks for ("verbinde
+    # mich", "mit dem support sprechen", "fehler melden", etc.) — Gate A
+    # returns answer_inline and the handoff is silently vetoed even after
+    # the user explicitly consented. Defensive: best-effort, never raises
+    # — empty list falls through to the summary fallback on the gateway
+    # side, exactly matching Vertex's behaviour when transcriptTurns is
+    # empty.
+    recent_user_turns: list[str] = []
+    try:
+        session_obj = (
+            getattr(context, "session", None)
+            or getattr(getattr(context, "agent", None), "session", None)
+        )
+        chat_ctx = getattr(session_obj, "chat_ctx", None) if session_obj else None
+        # livekit-agents 1.x stores items on chat_ctx.items; older 0.x
+        # used .messages. Support both without importing the type.
+        items = getattr(chat_ctx, "items", None) or getattr(chat_ctx, "messages", None) or []
+        for item in reversed(list(items)):
+            role = getattr(item, "role", None)
+            if role != "user":
+                continue
+            content = (
+                getattr(item, "content", None)
+                or getattr(item, "text_content", None)
+            )
+            if content is None:
+                continue
+            if isinstance(content, str):
+                text = content.strip()
+            else:
+                # ChatMessage.content can be list[str | ContentBlock]; join
+                # whatever stringifies meaningfully and ignore the rest.
+                try:
+                    text = " ".join(
+                        str(c) for c in content if c is not None
+                    ).strip()
+                except Exception:  # noqa: BLE001
+                    text = ""
+            if text:
+                recent_user_turns.append(text)
+                if len(recent_user_turns) >= 3:
+                    break
+        recent_user_turns.reverse()
+    except Exception as exc:  # noqa: BLE001
+        logger.warning(
+            "report_to_specialist: chat_ctx read failed (gate falls back "
+            "to summary): %s",
+            exc,
+        )
+        recent_user_turns = []
+
     args: dict[str, Any] = {"kind": kind, "summary": summary}
     if specialist_hint:
         args["specialist_hint"] = specialist_hint
+    if recent_user_turns:
+        args["recent_user_turns"] = recent_user_turns
 
     # --- BEFORE DISPATCH ---------------------------------------------------
     summary_chars = len(summary or "")
@@ -352,6 +410,7 @@ async def report_to_specialist(
                     "summary_chars": summary_chars,
                     "summary_words": summary_word_count,
                     "specialist_hint": specialist_hint,
+                    "recent_user_turns_count": len(recent_user_turns),
                 },
                 vtid="VTID-03033",
             )

--- a/services/gateway/src/services/orb-tools-shared.ts
+++ b/services/gateway/src/services/orb-tools-shared.ts
@@ -338,10 +338,32 @@ export async function tool_report_to_specialist(
   sb: SupabaseClient,
 ): Promise<OrbToolResult> {
   const { executeReportToSpecialist } = await import('./report-to-specialist-core');
+
+  // VTID-03099: build gate_input from the user's recent RAW transcript
+  // turns so the two-gate RPC matches forward_request_phrases against
+  // what the user actually said — Vertex parity (see orb-live.ts:2872
+  // buildGateInputFromTranscript). Without this, the LLM-curated summary
+  // (compressed business language) rarely matches phrases like
+  // "verbinde mich" / "mit dem support sprechen" / "fehler melden", so
+  // Gate A returns answer_inline and the handoff is vetoed even after
+  // the user explicitly consented. 2026-05-19 user-reported regression.
+  const recentTurnsRaw = Array.isArray(args.recent_user_turns)
+    ? (args.recent_user_turns as unknown[])
+    : [];
+  const recentTurns: string[] = recentTurnsRaw
+    .map((t) => (typeof t === 'string' ? t.trim() : ''))
+    .filter((t) => t.length > 0);
+  const summaryStr =
+    typeof args.summary === 'string' ? args.summary : undefined;
+  const gateInput =
+    recentTurns.length > 0
+      ? recentTurns.slice(-3).join(' \n ')
+      : summaryStr;
+
   const result = await executeReportToSpecialist(
     {
       kind: typeof args.kind === 'string' ? args.kind : undefined,
-      summary: typeof args.summary === 'string' ? args.summary : undefined,
+      summary: summaryStr,
       specialist_hint:
         typeof args.specialist_hint === 'string' ? args.specialist_hint : undefined,
     },
@@ -353,6 +375,7 @@ export async function tool_report_to_specialist(
     },
     sb,
     {
+      gate_input: gateInput,
       source: 'orb-livekit-tool',
       screen_path: '/orb/livekit-voice',
     },


### PR DESCRIPTION
## Summary

LiveKit handover to Devon **failed silently** on 2026-05-19: Vitana proposed Devon, user said yes, but the two-gate forwarding RPC returned `status=stay_inline, rpc_gate=forward_request` and Vitana was forced to refuse the handoff she'd just promised.

**Trace** (oasis):
```
report_to_specialist.called:  kind=bug, summary_words=19, specialist_hint=None
report_to_specialist.result:  status=stay_inline, rpc_gate=forward_request, persona=None
```

## Root cause

Vertex passes the user's RAW transcript turns to the gate via `buildGateInputFromTranscript` (orb-live.ts:2872) — the gate matches on phrases like "verbinde mich", "mit dem support sprechen", "fehler melden" against what the user ACTUALLY said.

LiveKit's `tool_report_to_specialist` did NOT pass `gate_input`, so the helper fell back to the LLM-curated `summary`. The LLM compresses "Ich will einen Fehler melden, das Live-Kit funktioniert nicht" into business language like "User reports issue with LiveKit test page on desktop" — which doesn't match the `forward_request_phrases` list. Gate A returns `answer_inline` and the legitimate handoff is vetoed.

## Fix — Vertex parity, two layers

**A) `services/agents/orb-agent/src/orb_agent/tools.py`** — `report_to_specialist` wrapper reads the last 3 user turns from `chat_ctx` (supports both livekit-agents 1.x `chat_ctx.items` and 0.x `.messages`) and ships them as `args.recent_user_turns`. Defensive: any access failure falls through to empty list (gateway then uses summary, exactly like Vertex's fallback). Adds `recent_user_turns_count` to the `.called` OASIS event for diagnostics.

**B) `services/gateway/src/services/orb-tools-shared.ts`** — `tool_report_to_specialist` joins the last 3 received turns with `' \n '` (same separator Vertex uses at `buildGateInputFromTranscript`) and passes as `gate_input` to `executeReportToSpecialist`. Empty array → falls back to summary, identical to Vertex.

## Why not just trust the LLM and bypass Gate A?

Considered. Rejected because the user's directive was "mirror Vertex". Vertex deliberately uses the raw transcript because the LLM's classification is too easy to game (silent intent drift). The right fix is parity, not divergence.

## Test plan

- [ ] **After merge + deploy:** re-run the German bug-report flow. Expected oasis trace:
      `.called` payload carries `recent_user_turns_count >= 1`,
      `.result` returns `status=handoff_created, persona=devon, handoff_signaled=true` instead of `stay_inline`.
- [ ] Spot-check: when the user is *vague* AND has no forwarding language ("hey, just exploring") Vitana correctly stays inline (Gate A still does its job).

## Deploy chain

1. Merge → Auto Deploy → Exec Deploy (gateway).
2. DEPLOY-ORB-AGENT auto-fires on the `services/agents/orb-agent/**` path change.
3. Both must land before re-test (the agent needs to send the new arg AND the gateway needs to read it).

🤖 Generated with [Claude Code](https://claude.com/claude-code)