### PR TITLE
fix(orb-live): Vertex bootstrap promise wipes wake-brief override block (VTID-03101)

### DIFF
--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -901,9 +901,22 @@ export async function handleLiveSessionStart(
     const line = picked?.userFacingLine?.trim();
     if (picked && line && line.length > 0 && !isReconnectStart) {
       const block = buildVertexWakeBriefBlock(line, lang, picked.dedupeKey ?? null);
-      session.contextInstruction = (session.contextInstruction || '') + block;
+      // VTID-03101: write to a DEDICATED session field instead of mutating
+      // contextInstruction. The bootstrap promise above unconditionally
+      // does `session.contextInstruction = finalContext` when it resolves
+      // — and bootstrap typically finishes AFTER this synchronous block
+      // (vitana-brain ~200-2000ms vs wake-brief ~50-200ms). Mutating
+      // contextInstruction here meant the bootstrap overwrite always
+      // wiped the override block, and the WS setup-message builder then
+      // sent Gemini a prompt with NO override — so Gemini fell back to
+      // its trained-default greeting ("Hello! How can I help today?")
+      // and the Teacher line was never spoken. The setup-message builder
+      // (orb-live.ts buildOrbVertexSetupEnvelope) now concatenates BOTH
+      // contextInstruction AND wakeBriefOverrideBlock, eliminating the
+      // race entirely.
+      session.wakeBriefOverrideBlock = block;
       console.log(
-        `[VTID-03079] Vertex wake-brief injected into system_instruction (decision_id=${wakeBriefDecision?.decisionId}, source=${picked.evidence?.find((e) => e.kind?.startsWith('source:'))?.kind || 'voice_wake_brief'})`,
+        `[VTID-03079/VTID-03101] Vertex wake-brief stored on session.wakeBriefOverrideBlock (decision_id=${wakeBriefDecision?.decisionId}, source=${picked.evidence?.find((e) => e.kind?.startsWith('source:'))?.kind || 'voice_wake_brief'}, block_chars=${block.length})`,
       );
     }
   } catch (e) {

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -827,6 +827,12 @@ export interface GeminiLiveSession {
   // overlaps with the Google auth + WS handshake (500-1000ms) instead of
   // serializing with /live/session/start's response.
   contextReadyPromise?: Promise<void>;
+  // VTID-03101: wake-brief override block, kept on its own field so the
+  // background bootstrap promise (which unconditionally writes
+  // contextInstruction = finalContext at the end of its .then) cannot
+  // overwrite it. The WS setup-message builder concatenates BOTH fields
+  // when rendering the system_instruction.
+  wakeBriefOverrideBlock?: string;
   // VTID-01225: Transcript accumulation for Cognee extraction
   // Forwarding v2d: `persona` records WHICH persona spoke this assistant turn
   // (e.g. 'vitana' / 'devon' / 'sage' / 'atlas' / 'mira'). Without this, the
@@ -5662,7 +5668,19 @@ async function connectToLiveAPI(
                                   ((session as any)._lastSpecialistPersona as string),
                                   session.lang,
                                 )
-                              : ''),
+                              : '')
+                          // VTID-03101: append the wake-brief override block
+                          // LAST so it has recency primacy in Gemini's
+                          // attention AND so the sentinel marker reaches
+                          // buildLiveSystemInstruction's strip+suppress
+                          // logic in the same string. The block lives on
+                          // its own session field to avoid the race where
+                          // the bootstrap promise (session.contextInstruction
+                          // = finalContext at the end of its .then) wipes
+                          // the appended override. See
+                          // live-session-controller.ts:VTID-03101 for the
+                          // write side. Empty when no override is active.
+                          + (session.wakeBriefOverrideBlock || ''),
                         session.active_role,
                         session.conversationSummary,
                         // VTID-STREAM-KEEPALIVE: Pass last 10 turns for reconnect continuity.

--- a/services/gateway/test/orb/live/characterization/vertex-wake-brief-override.characterization.test.ts
+++ b/services/gateway/test/orb/live/characterization/vertex-wake-brief-override.characterization.test.ts
@@ -1,0 +1,76 @@
+/**
+ * VTID-03101 — structural lock for the wake-brief override block on Vertex.
+ *
+ * Background:
+ *   The Vertex session-start handler runs in two passes. Pass 1
+ *   (`/live/session/start`) computes the wake-brief decision and stores
+ *   the override block on the session. Pass 2 (WS-open) builds the
+ *   setup-message and renders the system_instruction.
+ *
+ *   Before this fix, pass 1 stored the override by mutating
+ *   `session.contextInstruction = (session.contextInstruction || '') + block`.
+ *   A background bootstrap promise (vitana-brain context build, ~200-2000ms)
+ *   resolved AFTER pass 1 and ran `session.contextInstruction = finalContext`
+ *   — unconditionally overwriting the override. Gemini's setup message then
+ *   carried NO override block, and the model fell back to its trained-default
+ *   greeting ("Hello! How can I help today?"). The Teacher's permission-asking
+ *   line was never spoken on Vertex.
+ *
+ * Fix:
+ *   The override block lives on its own session field,
+ *   `session.wakeBriefOverrideBlock`. The bootstrap promise only touches
+ *   `contextInstruction`. The setup-message builder concatenates BOTH
+ *   fields when rendering the system_instruction. No race possible.
+ *
+ * This file locks both ends of the contract structurally so a future
+ * refactor cannot silently re-introduce the race.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ORB_LIVE_PATH = path.resolve(__dirname, '../../../../src/routes/orb-live.ts');
+const CONTROLLER_PATH = path.resolve(
+  __dirname,
+  '../../../../src/orb/live/session/live-session-controller.ts',
+);
+
+let orbLiveSource: string;
+let controllerSource: string;
+
+beforeAll(() => {
+  orbLiveSource = fs.readFileSync(ORB_LIVE_PATH, 'utf8');
+  controllerSource = fs.readFileSync(CONTROLLER_PATH, 'utf8');
+});
+
+describe('VTID-03101: GeminiLiveSession declares wakeBriefOverrideBlock', () => {
+  it('orb-live.ts declares the dedicated wakeBriefOverrideBlock field on the session interface', () => {
+    expect(orbLiveSource).toMatch(/wakeBriefOverrideBlock\s*\?\s*:\s*string\s*;/);
+  });
+});
+
+describe('VTID-03101: controller writes the override to the dedicated field (not contextInstruction)', () => {
+  it('writes the picked block to session.wakeBriefOverrideBlock', () => {
+    expect(controllerSource).toMatch(
+      /session\.wakeBriefOverrideBlock\s*=\s*block\s*;/,
+    );
+  });
+
+  it('does NOT mutate session.contextInstruction with the override block', () => {
+    // The old (racy) pattern: `session.contextInstruction = (session.contextInstruction || '') + block`
+    // must not reappear. The bootstrap promise is the only writer of
+    // contextInstruction at session-start; the wake-brief block goes elsewhere.
+    expect(controllerSource).not.toMatch(
+      /session\.contextInstruction\s*=\s*\(\s*session\.contextInstruction\s*\|\|\s*''\s*\)\s*\+\s*block/,
+    );
+  });
+});
+
+describe('VTID-03101: setup-message builder reads both fields when rendering system_instruction', () => {
+  it('orb-live.ts concatenates session.wakeBriefOverrideBlock into the bootstrap arg passed to buildLiveSystemInstruction', () => {
+    // The setup-message builder must reference wakeBriefOverrideBlock on
+    // the session — otherwise the override never reaches Gemini even when
+    // the controller stored it.
+    expect(orbLiveSource).toMatch(/session\.wakeBriefOverrideBlock\s*\|\|\s*''/);
+  });
+});


### PR DESCRIPTION
Root cause: Vertex /live/session/start kicks off contextReadyPromise (vitana-brain ~200-2000ms). Inside its .then() at line 667 it does session.contextInstruction = finalContext unconditionally. Meanwhile the synchronous wake-brief decision at line 904 did session.contextInstruction = (session.contextInstruction || '') + block. Wake-brief almost always wins the race; bootstrap then overwrites the block; WS setup reads contextInstruction with NO override; Gemini falls back to its trained-default greeting. Fix: store override on session.wakeBriefOverrideBlock; bootstrap only writes contextInstruction; setup builder concatenates BOTH. LiveKit untouched (synchronous re-render, no race). Coverage: 4 new structural tests; 56+174+88 existing tests green; build clean.