### PR TITLE
fix(chat-groups): show real member names instead of "Member"

### DIFF
--- a/services/gateway/src/routes/chat-groups.ts
+++ b/services/gateway/src/routes/chat-groups.ts
@@ -152,24 +152,42 @@ router.get('/:id', requireAuth, requireTenant, async (req: Request, res: Respons
   }
 
   const memberIds = (members || []).map(m => m.user_id);
-  let profiles: Array<{ user_id: string; display_name: string | null; avatar_url: string | null }> = [];
+  let profileRows: Array<{ user_id: string; display_name: string | null; full_name: string | null; avatar_url: string | null }> = [];
+  let appUserRows: Array<{ user_id: string; display_name: string | null; email: string | null }> = [];
   if (memberIds.length > 0) {
-    const { data: profileRows } = await supabase
-      .from('app_users')
-      .select('user_id, display_name, avatar_url')
-      .in('user_id', memberIds);
-    profiles = profileRows || [];
+    const [profilesResp, appUsersResp] = await Promise.all([
+      supabase
+        .from('profiles')
+        .select('user_id, display_name, full_name, avatar_url')
+        .in('user_id', memberIds),
+      supabase
+        .from('app_users')
+        .select('user_id, display_name, email')
+        .in('user_id', memberIds),
+    ]);
+    profileRows = (profilesResp.data as typeof profileRows) || [];
+    appUserRows = (appUsersResp.data as typeof appUserRows) || [];
   }
-  const profileById = new Map(profiles.map(p => [p.user_id, p]));
+  const profileById = new Map(profileRows.map(p => [p.user_id, p]));
+  const appUserById = new Map(appUserRows.map(u => [u.user_id, u]));
 
-  const enrichedMembers = (members || []).map(m => ({
-    user_id: m.user_id,
-    role: m.role,
-    joined_at: m.joined_at,
-    display_name: profileById.get(m.user_id)?.display_name || null,
-    avatar_url: profileById.get(m.user_id)?.avatar_url || null,
-    is_bot: isVitanaBot(m.user_id),
-  }));
+  const enrichedMembers = (members || []).map(m => {
+    const profile = profileById.get(m.user_id);
+    const appUser = appUserById.get(m.user_id);
+    const displayName =
+      profile?.display_name ||
+      profile?.full_name ||
+      appUser?.display_name ||
+      (appUser?.email ? appUser.email.split('@')[0] : null);
+    return {
+      user_id: m.user_id,
+      role: m.role,
+      joined_at: m.joined_at,
+      display_name: displayName,
+      avatar_url: profile?.avatar_url || null,
+      is_bot: isVitanaBot(m.user_id),
+    };
+  });
 
   return res.json({
     ok: true,
@@ -330,15 +348,19 @@ async function fanoutGroupNotifications(
   content: string,
   messageId: string,
 ): Promise<void> {
-  const [{ data: group }, { data: members }, { data: senderProfile }] = await Promise.all([
+  const [{ data: group }, { data: members }, { data: senderAppUser }, { data: senderProfile }] = await Promise.all([
     supabase.from('chat_groups').select('name').eq('id', groupId).maybeSingle(),
     supabase.from('chat_group_members').select('user_id').eq('group_id', groupId),
     supabase.from('app_users').select('display_name, email').eq('user_id', senderId).maybeSingle(),
+    supabase.from('profiles').select('display_name, full_name').eq('user_id', senderId).maybeSingle(),
   ]);
 
   const groupName = (group as any)?.name || 'Group chat';
-  const senderName = (senderProfile as any)?.display_name
-    || ((senderProfile as any)?.email ? (senderProfile as any).email.split('@')[0] : 'Someone');
+  const senderName =
+    (senderProfile as any)?.display_name
+    || (senderProfile as any)?.full_name
+    || (senderAppUser as any)?.display_name
+    || ((senderAppUser as any)?.email ? (senderAppUser as any).email.split('@')[0] : 'Someone');
 
   const body = content.length > 100 ? content.slice(0, 97) + '...' : content;
 


### PR DESCRIPTION
## Summary

In group chats (e.g. the FIRST 100 group), every participant was rendered as
"Member" instead of their actual name. Root cause: the gateway endpoint
`GET /api/v1/chat/groups/:id` was reading `display_name` only from the thin
`app_users` registry, where `display_name` is frequently null. The rich names
(`display_name`, `full_name`) live in the `profiles` table.

## Changes

- `GET /api/v1/chat/groups/:id` now joins both `profiles` and `app_users` and
  resolves each member's `display_name` using a fallback chain:
  `profiles.display_name → profiles.full_name → app_users.display_name →
  email-local of app_users.email → null`.
- `fanoutGroupNotifications` uses the same chain so push notifications show
  the sender's real name (e.g. `"Alice: Hi!"`) instead of `"Someone: Hi!"`.

## Test plan

- [ ] Open a group with multiple members; verify each row shows the user's
      real name instead of "Member".
- [ ] Send a group message; verify recipients receive a push titled with the
      sender's real name (not "Someone").
- [ ] Confirm the Vitana bot row still renders as "Vitana" (handled
      separately on the client via `isVitanaBot`).


---
_Generated by [Claude Code](https://claude.ai/code/session_01D3LC3yjQBsP9XM2xMosMLs)_