### PR TITLE
fix(orb-live): greeting trigger no longer overrides wake-brief override (VTID-03102)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -6343,6 +6343,104 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
   }
 
   const lang = session.lang;
+
+  // VTID-WAKE-OPENER: branch on wake-brief state BEFORE the legacy bucket-driven
+  // menu prompt is built. The legacy prompt (below) is a user-turn that tells
+  // Gemini to "Pick ONE of: 'How can I help?' / 'I am listening.' / ...". Since
+  // it's sent AFTER setup_complete, it is the most recent input Gemini sees and
+  // it wins over the system_instruction's SPOKEN FIRST UTTERANCE override block
+  // (live-session-controller.ts buildVertexWakeBriefBlock). VTID-03101 fixed the
+  // race that wiped the override block from contextInstruction; this fixes the
+  // separate race where the trigger prompt itself contradicts the override.
+  //
+  // Two distinct wake-brief states matter here:
+  //   (a) decision produced a userFacingLine → block exists on the session:
+  //       send a minimal trigger that defers to the system_instruction. NO menu.
+  //   (b) decision exists but was suppressed (none_with_reason — B1 cadence
+  //       skip, greeted-recently, heavy-day dampening, etc.): the policy says
+  //       "do not greet". Do NOT send the legacy menu (that would force
+  //       Gemini to speak generic fallback). Skip the trigger entirely; the
+  //       user opens with audio and the model responds to that.
+  //
+  // Both branches mark greetingSent=true so the stall-recovery re-send path
+  // does not re-fire the legacy menu later. The watchdog only starts when
+  // we actually send a trigger (case a) — case b is silence-by-design.
+  const wakeBriefOverrideBlock: string | undefined = (session as any).wakeBriefOverrideBlock;
+  const wakeBriefDecision: { selectedContinuation?: { kind?: string; userFacingLine?: string; suppressReason?: string | null } | null; suppressionReason?: string | null; decisionId?: string } | null =
+    (session as any).wakeBriefDecision || null;
+  const overrideActive =
+    typeof wakeBriefOverrideBlock === 'string' && wakeBriefOverrideBlock.length > 0;
+  const wakeBriefSuppressed =
+    !overrideActive
+    && !!wakeBriefDecision
+    && (wakeBriefDecision.selectedContinuation?.kind === 'none_with_reason'
+        || !wakeBriefDecision.selectedContinuation
+        || !wakeBriefDecision.selectedContinuation.userFacingLine
+        || wakeBriefDecision.selectedContinuation.userFacingLine.trim().length === 0);
+
+  if (overrideActive) {
+    const triggerPromptsByLang: Record<string, string> = {
+      'en': 'Begin your first turn now. The SPOKEN FIRST UTTERANCE block in your system instruction contains the exact line you must speak. Use that line verbatim — copy it letter-for-letter — then stop and wait for the user. Do NOT pick a phrase from any other section. Do NOT add a greeting before it. Do NOT add a question after it.',
+      'de': 'Beginne jetzt deinen ersten Sprechturn. Der Abschnitt "SPOKEN FIRST UTTERANCE" in deiner Systemanweisung enthält den exakten Satz, den du sprechen musst. Verwende diesen Satz wörtlich — Zeichen für Zeichen — und warte dann auf den Nutzer. Wähle KEINE Phrase aus einem anderen Abschnitt. Stelle KEINE Begrüßung davor. Hänge KEINE Frage hinten an.',
+      'fr': 'Commence ton premier tour maintenant. Le bloc "SPOKEN FIRST UTTERANCE" dans tes instructions système contient la phrase exacte que tu dois prononcer. Utilise cette phrase verbatim — caractère par caractère — puis attends l\'utilisateur. Ne choisis AUCUNE phrase d\'une autre section. N\'ajoute AUCUNE salutation avant. N\'ajoute AUCUNE question après.',
+      'es': 'Comienza ahora tu primer turno. El bloque "SPOKEN FIRST UTTERANCE" en tu instrucción del sistema contiene la frase exacta que debes decir. Usa esa frase textualmente — letra por letra — y luego espera al usuario. NO elijas una frase de ninguna otra sección. NO añadas saludo antes. NO añadas pregunta después.',
+      'ar': 'ابدأ دورك الأول الآن. يحتوي قسم "SPOKEN FIRST UTTERANCE" في تعليمات النظام على الجملة الدقيقة التي يجب أن تنطق بها. استخدم تلك الجملة حرفياً — حرفاً بحرف — ثم انتظر المستخدم. لا تختر عبارة من أي قسم آخر.',
+      'zh': '现在开始你的第一个对话回合。你的系统指令中的"SPOKEN FIRST UTTERANCE"部分包含你必须说的确切句子。逐字使用那句话，然后停下来等待用户。不要从任何其他部分选择短语。',
+      'ru': 'Начни свой первый ход прямо сейчас. Блок "SPOKEN FIRST UTTERANCE" в твоих системных инструкциях содержит точную фразу, которую ты должен произнести. Используй её дословно — буква в букву — затем остановись и жди пользователя. НЕ выбирай фразу из других разделов.',
+      'sr': 'Започни сада свој први потез. Блок "SPOKEN FIRST UTTERANCE" у твојим системским упутствима садржи тачну реченицу коју мораш изговорити. Користи ту реченицу дословно — слово по слово — затим стани и сачекај корисника. НЕ бирај фразу из друге секције.',
+    };
+    const triggerPrompt = triggerPromptsByLang[lang] || triggerPromptsByLang['en'];
+    const triggerMessage = {
+      client_content: {
+        turns: [{
+          role: 'user',
+          parts: [{ text: triggerPrompt }]
+        }],
+        turn_complete: true
+      }
+    };
+    const selectedLine = wakeBriefDecision?.selectedContinuation?.userFacingLine?.trim() || '<missing>';
+    const previewLine = selectedLine.length > 160 ? selectedLine.slice(0, 160) + '...' : selectedLine;
+    const promptPreview = triggerPrompt.length > 120 ? triggerPrompt.slice(0, 120) + '...' : triggerPrompt;
+    console.log(`[VTID-WAKE-OPENER] path=vertex override_active=true lang=${lang} decision_id=${wakeBriefDecision?.decisionId || '<none>'}`);
+    console.log(`[VTID-WAKE-OPENER] selected_line="${previewLine}"`);
+    console.log(`[VTID-WAKE-OPENER] prompt_sent="${promptPreview}"`);
+    ws.send(JSON.stringify(triggerMessage));
+    session.greetingSent = true;
+    session.greetingTurnIndex = session.turn_count;
+    emitDiag(session, 'greeting_sent', {
+      lang,
+      prompt_len: triggerPrompt.length,
+      wake_opener: 'override_trigger',
+      decision_id: wakeBriefDecision?.decisionId || null,
+    });
+    startResponseWatchdog(session, GREETING_RESPONSE_TIMEOUT_MS, 'greeting_timeout');
+    return true;
+  }
+
+  if (wakeBriefSuppressed) {
+    // Wake-brief policy said "do not greet". Do NOT send a competing trigger.
+    // Mark greetingSent=true so stall-recovery doesn't later substitute the
+    // legacy menu. No watchdog: case is silence-by-design and the next turn
+    // is gated on user audio (mic input → Gemini realtime VAD).
+    const suppressionReason =
+      wakeBriefDecision?.selectedContinuation?.suppressReason
+      || wakeBriefDecision?.suppressionReason
+      || 'unknown';
+    console.log(`[VTID-WAKE-OPENER] path=vertex override_active=false suppressed=true lang=${lang} suppression_reason=${suppressionReason} decision_id=${wakeBriefDecision?.decisionId || '<none>'}`);
+    console.log(`[VTID-WAKE-OPENER] selected_line=<none>`);
+    console.log(`[VTID-WAKE-OPENER] prompt_sent=<skipped>`);
+    session.greetingSent = true;
+    session.greetingTurnIndex = session.turn_count;
+    emitDiag(session, 'greeting_sent', {
+      lang,
+      prompt_len: 0,
+      wake_opener: 'suppressed_no_trigger',
+      suppression_reason: suppressionReason,
+      decision_id: wakeBriefDecision?.decisionId || null,
+    });
+    return true;
+  }
   // VTID-NAV-TIMEJOURNEY (warmth fix): The default greeting prompt for
   // AUTHENTICATED sessions must be WARM, POLITE, and KIND — never cold,
   // never curt. The previous iteration fixed "Hello Dragan!" but made
@@ -6460,13 +6558,22 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
     }
   };
 
+  // VTID-WAKE-OPENER: legacy path log — fires when no wake-brief decision was
+  // made (anonymous session, decider threw, pre-VTID-03052 callers, etc.).
+  // Always paired with the override + suppressed logs above so we can prove
+  // in production which branch actually fired for a given session.
+  const promptPreview = prompt.length > 120 ? prompt.slice(0, 120) + '...' : prompt;
+  console.log(`[VTID-WAKE-OPENER] path=vertex override_active=false suppressed=false lang=${lang} decision_id=<none>`);
+  console.log(`[VTID-WAKE-OPENER] selected_line=<none> (legacy menu path)`);
+  console.log(`[VTID-WAKE-OPENER] prompt_sent="${promptPreview}"`);
+
   ws.send(JSON.stringify(message));
 
   // Mark greeting as sent and record turn index for filtering
   session.greetingSent = true;
   session.greetingTurnIndex = session.turn_count;
   console.log(`[VTID-VOICE-INIT] Greeting prompt sent for lang=${lang}, turnIndex=${session.turn_count}`);
-  emitDiag(session, 'greeting_sent', { lang, prompt_len: message.client_content?.turns?.[0]?.parts?.[0]?.text?.length || 0 });
+  emitDiag(session, 'greeting_sent', { lang, prompt_len: message.client_content?.turns?.[0]?.parts?.[0]?.text?.length || 0, wake_opener: 'legacy' });
 
   // VTID-WATCHDOG: Start watchdog — if greeting response doesn't arrive, notify user
   startResponseWatchdog(session, GREETING_RESPONSE_TIMEOUT_MS, 'greeting_timeout');

--- a/services/gateway/test/orb/live/characterization/vertex-wake-opener-trigger.characterization.test.ts
+++ b/services/gateway/test/orb/live/characterization/vertex-wake-opener-trigger.characterization.test.ts
@@ -1,0 +1,138 @@
+/**
+ * VTID-WAKE-OPENER — structural lock for the Vertex greeting-trigger fix.
+ *
+ * Background:
+ *   VTID-03101 fixed the race that wiped the wake-brief override block out
+ *   of the system_instruction. After that fix the system prompt correctly
+ *   contained the SPOKEN FIRST UTTERANCE block. But Gemini still spoke a
+ *   generic "How can I help?" / "Hallo, wie kann ich helfen?" greeting on
+ *   Vertex Android + desktop because `sendGreetingPromptToLiveAPI` then
+ *   sent a SECOND, contradictory instruction as a `client_content` user
+ *   turn AFTER setup_complete. That trigger prompt told Gemini to pick a
+ *   menu entry — and being the most recent input it won over the system
+ *   instruction. The Teacher line was authored into the prompt but never
+ *   spoken.
+ *
+ *   This fix branches sendGreetingPromptToLiveAPI on the wake-brief state
+ *   carried on the session:
+ *     1. wakeBriefOverrideBlock set → minimal trigger that defers to the
+ *        system_instruction. No menuList. No bucket switch.
+ *     2. Decision exists but suppressed (B1 cadence, greeted-recently, …)
+ *        → do NOT send any trigger prompt; mark greetingSent=true so the
+ *        stall-recovery re-send path does not later inject the menu.
+ *     3. No decision at all → legacy menu path (unchanged).
+ *
+ *   Three diagnostic logs (`[VTID-WAKE-OPENER]`) prove which branch fired
+ *   in production: override_active, selected_line, prompt_sent.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ORB_LIVE_PATH = path.resolve(__dirname, '../../../../src/routes/orb-live.ts');
+
+let orbLiveSource: string;
+
+beforeAll(() => {
+  orbLiveSource = fs.readFileSync(ORB_LIVE_PATH, 'utf8');
+});
+
+function extractSendGreetingFn(): string {
+  // Capture from the function signature through to the next top-level
+  // `function ` declaration so assertions are scoped only to
+  // sendGreetingPromptToLiveAPI and not to other helpers in the file.
+  const startIdx = orbLiveSource.indexOf(
+    'function sendGreetingPromptToLiveAPI(',
+  );
+  if (startIdx === -1) {
+    throw new Error('sendGreetingPromptToLiveAPI not found in orb-live.ts');
+  }
+  const afterStart = orbLiveSource.slice(startIdx + 1);
+  const nextFnRel = afterStart.search(/\nfunction\s+\w/);
+  return nextFnRel === -1
+    ? orbLiveSource.slice(startIdx)
+    : orbLiveSource.slice(startIdx, startIdx + 1 + nextFnRel);
+}
+
+describe('VTID-WAKE-OPENER: sendGreetingPromptToLiveAPI branches on wake-brief state', () => {
+  let fn: string;
+
+  beforeAll(() => {
+    fn = extractSendGreetingFn();
+  });
+
+  it('reads session.wakeBriefOverrideBlock and session.wakeBriefDecision', () => {
+    expect(fn).toMatch(/session as any\)\.wakeBriefOverrideBlock/);
+    expect(fn).toMatch(/session as any\)\.wakeBriefDecision/);
+  });
+
+  it('defines an overrideActive guard derived from the block being a non-empty string', () => {
+    expect(fn).toMatch(/overrideActive\s*=[\s\S]{0,200}wakeBriefOverrideBlock[\s\S]{0,200}length\s*>\s*0/);
+  });
+
+  it('defines a wakeBriefSuppressed guard distinct from overrideActive', () => {
+    expect(fn).toMatch(/wakeBriefSuppressed\s*=/);
+    // The suppressed branch must require !overrideActive so the two branches
+    // are mutually exclusive — both being true would be a logic error.
+    expect(fn).toMatch(/wakeBriefSuppressed\s*=[\s\S]{0,400}!overrideActive/);
+  });
+
+  it('override branch sends a minimal trigger and does NOT contain any menuList interpolation', () => {
+    const overrideBranchMatch = fn.match(/if\s*\(\s*overrideActive\s*\)\s*\{[\s\S]*?\n\s\s\}/);
+    expect(overrideBranchMatch).not.toBeNull();
+    const overrideBranch = overrideBranchMatch![0];
+    // Trigger must reference SPOKEN FIRST UTTERANCE so Gemini knows where to look.
+    expect(overrideBranch).toMatch(/SPOKEN FIRST UTTERANCE/);
+    // Trigger must NOT include the legacy menu phrasings.
+    expect(overrideBranch).not.toMatch(/How can I help\?/);
+    expect(overrideBranch).not.toMatch(/I am listening\./);
+    expect(overrideBranch).not.toMatch(/What's on your mind\?/);
+    expect(overrideBranch).not.toMatch(/Womit kann ich helfen\?/);
+    expect(overrideBranch).not.toMatch(/Ich höre dir zu\./);
+    // Trigger must NOT reference the bucket / menuList / OPENING SHAPE MATRIX
+    // dispatch — those are the legacy paths whose output contradicts the override.
+    expect(overrideBranch).not.toMatch(/menuList/);
+    expect(overrideBranch).not.toMatch(/OPENING SHAPE MATRIX/);
+    // greetingSent must be set so stall-recovery does not later re-send a legacy menu.
+    expect(overrideBranch).toMatch(/session\.greetingSent\s*=\s*true/);
+    // Watchdog should still arm in the override branch — we ARE waiting on the model.
+    expect(overrideBranch).toMatch(/startResponseWatchdog\(/);
+  });
+
+  it('suppressed branch does NOT send any client_content prompt and does NOT arm the watchdog', () => {
+    const suppressedMatch = fn.match(
+      /if\s*\(\s*wakeBriefSuppressed\s*\)\s*\{[\s\S]*?\n\s\s\}/,
+    );
+    expect(suppressedMatch).not.toBeNull();
+    const suppressedBranch = suppressedMatch![0];
+    // No outgoing message in the suppressed branch.
+    expect(suppressedBranch).not.toMatch(/ws\.send\(/);
+    // No watchdog arming — case is silence-by-design.
+    expect(suppressedBranch).not.toMatch(/startResponseWatchdog\(/);
+    // Must still mark greeting as handled so it isn't re-injected later.
+    expect(suppressedBranch).toMatch(/session\.greetingSent\s*=\s*true/);
+    // Must log a suppression_reason so production logs prove the branch fired.
+    expect(suppressedBranch).toMatch(/suppression_reason/);
+  });
+
+  it('legacy menu path remains intact when no wake-brief decision is present', () => {
+    // The legacy menu must still be wired so anonymous + pre-VTID-03052
+    // callers continue to receive a greeting trigger. We assert that the
+    // existing prompts table is still defined inside the function.
+    expect(fn).toMatch(/pick ONE of: "How can I help\?"/);
+    // The legacy ws.send call site must still exist.
+    expect(fn).toMatch(/ws\.send\(JSON\.stringify\(message\)\)/);
+  });
+
+  it('emits the three diagnostic [VTID-WAKE-OPENER] logs in every branch', () => {
+    const logLines = fn.match(/\[VTID-WAKE-OPENER\]/g) || [];
+    // Three lines per branch × three branches = 9 occurrences.
+    expect(logLines.length).toBeGreaterThanOrEqual(9);
+    // Each log triplet must appear: override + suppressed + selected_line + prompt_sent.
+    expect(fn).toMatch(/path=vertex override_active=true/);
+    expect(fn).toMatch(/path=vertex override_active=false suppressed=true/);
+    expect(fn).toMatch(/path=vertex override_active=false suppressed=false/);
+    expect(fn).toMatch(/prompt_sent="?\$\{?promptPreview/);
+    expect(fn).toMatch(/prompt_sent=<skipped>/);
+  });
+});


### PR DESCRIPTION
## Summary
- Vertex Android + desktop still spoke generic "Hello, how can I help?" after VTID-03101 because `sendGreetingPromptToLiveAPI` sent a *second* user-turn telling Gemini to "Pick ONE of: 'How can I help?' / 'I am listening.' / ..." — recency primacy beat the system_instruction's SPOKEN FIRST UTTERANCE block.
- `sendGreetingPromptToLiveAPI` now branches on `session.wakeBriefOverrideBlock` + `session.wakeBriefDecision`:
  - Override present → minimal trigger that defers to the system_instruction. No menu, no bucket dispatch, no OPENING SHAPE MATRIX.
  - Decision present but suppressed (B1 cadence / greeted-recently / heavy-day dampening) → NO trigger sent, NO watchdog armed, `greetingSent=true` so stall-recovery can't substitute the legacy menu.
  - No decision → legacy menu path (unchanged) tagged `wake_opener='legacy'` on the diag event.
- Three `[VTID-WAKE-OPENER]` log lines on every branch — `override_active`, `selected_line`, `prompt_sent` — so the **actual audio path** is observable in production, not just the rendered prompt.
- New structural test (`vertex-wake-opener-trigger.characterization.test.ts`) locks all three branches.

## Test plan
- [x] `npm run build` (gateway) — clean.
- [x] `npx jest test/orb/live` — 478 tests, 28 suites, all green.
- [ ] **Runtime verification on Vertex Android**: tap orb, confirm first spoken line is the Teacher/proactive line. Cloud Run gateway log must show `[VTID-WAKE-OPENER] path=vertex override_active=true selected_line="..."` for the session.
- [ ] **Runtime verification on Vertex desktop**: same.
- [ ] **B1 cadence path**: reopen within suppression window → log shows `path=vertex override_active=false suppressed=true suppression_reason=...`, orb is silent.
- [ ] **Legacy path** (anonymous): log shows `path=vertex ... legacy menu path`, generic prompt still works.

## Notes
- VTID-03102 allocated via `POST /api/v1/vtid/allocate` 2026-05-19.
- Paired with VTID-03103 (LiveKit-side suppression fix) — see separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)