### PR TITLE
fix(orb-agent): suppressed wake_brief must not fall back to localized greeting (VTID-03103)

### DIFF
--- a/services/agents/orb-agent/src/orb_agent/session.py
+++ b/services/agents/orb-agent/src/orb_agent/session.py
@@ -2149,8 +2149,25 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
         # behavior. Fully reversible — empty/missing decision falls back to
         # _localized_greeting() so a degraded bootstrap path never silences
         # the orb.
-        wake_brief = getattr(bootstrap, "wake_brief_decision", None) or {}
-        wake_line = wake_brief.get("user_facing_line") if isinstance(wake_brief, dict) else None
+        #
+        # VTID-WAKE-OPENER: trust the decider. When the gateway returned a
+        # decision (`wake_brief_decision` is a dict) but no `user_facing_line`,
+        # that is a deliberate policy decision — B1 cadence skip, greeted-
+        # recently, heavy-day dampening, etc. Falling back to
+        # _localized_greeting() in that case is exactly the bug: the user
+        # hears "Hallo, wie kann ich helfen?" three minutes after they last
+        # heard "Hallo, wie kann ich helfen?". The only legitimate fallback
+        # is when the decision is absent (degraded bootstrap, pre-VTID-03052
+        # gateway) — then localized greeting is correct so the orb never
+        # silently fails to greet.
+        raw_wake_brief = getattr(bootstrap, "wake_brief_decision", None)
+        decision_present = isinstance(raw_wake_brief, dict)
+        wake_brief = raw_wake_brief if decision_present else {}
+        wake_line = wake_brief.get("user_facing_line") if decision_present else None
+        selected_kind = wake_brief.get("selected_kind") if decision_present else None
+        suppression_reason = (
+            wake_brief.get("suppression_reason") if decision_present else None
+        )
         # VTID-03076 (P0-C): is this a real proactive offer (wake_brief
         # kind=wake_brief OR next_step) we should remember? The agent
         # only persists state for offers that have a decision_id +
@@ -2160,7 +2177,7 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
         is_proactive_offer = (
             isinstance(wake_line, str)
             and wake_line.strip()
-            and isinstance(wake_brief, dict)
+            and decision_present
             and isinstance(wake_brief.get("decision_id"), str)
             and isinstance(wake_brief.get("dedupe_key"), str)
         )
@@ -2168,8 +2185,20 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
             greeting_text = wake_line.strip()
             logger.info(
                 "VTID-03054: speaking wake_brief user_facing_line (kind=%s, decision_id=%s)",
-                wake_brief.get("selected_kind") if isinstance(wake_brief, dict) else None,
-                wake_brief.get("decision_id") if isinstance(wake_brief, dict) else None,
+                selected_kind,
+                wake_brief.get("decision_id"),
+            )
+            # VTID-WAKE-OPENER: parallel log to the Vertex side
+            # (orb-live.ts sendGreetingPromptToLiveAPI) so a single grep
+            # across logs covers both providers.
+            line_preview = greeting_text[:160] + ("..." if len(greeting_text) > 160 else "")
+            logger.info(
+                '[VTID-WAKE-OPENER] path=livekit override_active=true lang=%s '
+                'decision_id=%s selected_line="%s" said="%s"',
+                identity.lang or "en",
+                wake_brief.get("decision_id") or "<none>",
+                line_preview,
+                line_preview,
             )
             # VTID-03076: persist activeContinuation BEFORE the speak so
             # a race with the next user turn finds the state populated.
@@ -2191,45 +2220,85 @@ async def agent_entrypoint(ctx: "JobContext") -> None:
                     active_continuation.get("source_key"),
                     _CONTINUATION_TTL_SECONDS,
                 )
+        elif decision_present:
+            # VTID-WAKE-OPENER: decision was made AND policy suppressed the
+            # spoken opener. Do NOT fall back to the localized-greeting
+            # helper — the decider already considered (and rejected) speaking
+            # on this wake. Silence is the correct outcome; the next turn is
+            # gated on user audio.
+            greeting_text = None
+            is_proactive_offer = False
+            logger.info(
+                "[VTID-WAKE-OPENER] path=livekit override_active=false suppressed=true "
+                "lang=%s decision_id=%s selected_kind=%s suppression_reason=%s "
+                'user_facing_line=<empty> said=<skipped>',
+                identity.lang or "en",
+                wake_brief.get("decision_id") or "<none>",
+                selected_kind or "<none>",
+                suppression_reason or "<unknown>",
+            )
         else:
+            # No decision at all — degraded bootstrap, pre-VTID-03052 gateway,
+            # or wake_brief_decision absent for any other reason. Localized
+            # fallback so the orb never silently fails to greet.
             greeting_text = _localized_greeting(
                 identity.lang,
                 first_name=first_name,
                 vitana_handle=vid,
             )
             is_proactive_offer = False
+            preview = (greeting_text or "")[:160]
+            logger.info(
+                "[VTID-WAKE-OPENER] path=livekit override_active=false suppressed=false "
+                'lang=%s decision_id=<missing> said="%s"',
+                identity.lang or "en",
+                preview,
+            )
     else:
         greeting_text = _localized_anonymous_greeting(identity.lang)
         is_proactive_offer = False
-    try:
-        # VTID-03017: add_to_chat_ctx=False — the greeting is a deterministic
-        # template, not an LLM turn, so it shouldn't pollute chat_ctx as if
-        # the model authored it. The LLM still knows the user is freshly
-        # greeted via the placeholder system prompt + (after hydration) the
-        # rendered system_instruction.
-        #
-        # VTID-03076 (P0-C) exception: a REAL proactive offer (wake_brief
-        # with decision_id + dedupe_key) MUST go into chat_ctx so the LLM
-        # remembers having said it. Otherwise the user's "ja" hits the
-        # model with no context and produces a tangential answer
-        # (Vitanaland explanation when a match was offered). Localized
-        # greetings stay out of chat_ctx — those are decoration, not
-        # offers the user can act on.
-        await session.say(greeting_text, add_to_chat_ctx=bool(is_proactive_offer))
-    except Exception as exc:  # noqa: BLE001
-        logger.warning("initial greeting session.say failed: %s", exc)
-        asyncio.create_task(
-            _early_trace_heartbeat(
-                cfg.gateway_url,
-                {
-                    "user_id": identity.user_id or "unknown",
-                    "code_version": CODE_VERSION,
-                    "phase": "greeting_failed",
-                    "orb_session_id": orb_session_id,
-                    "error": str(exc)[:500],
-                },
-            )
+        preview = (greeting_text or "")[:160]
+        logger.info(
+            "[VTID-WAKE-OPENER] path=livekit override_active=false suppressed=false "
+            'lang=%s anonymous=true said="%s"',
+            identity.lang or "en",
+            preview,
         )
+    if greeting_text is None:
+        # VTID-WAKE-OPENER: suppressed-by-policy branch. Skip session.say
+        # entirely; do NOT emit a greeting_failed heartbeat (this is not a
+        # failure, it is the intended behavior).
+        pass
+    else:
+        try:
+            # VTID-03017: add_to_chat_ctx=False — the greeting is a deterministic
+            # template, not an LLM turn, so it shouldn't pollute chat_ctx as if
+            # the model authored it. The LLM still knows the user is freshly
+            # greeted via the placeholder system prompt + (after hydration) the
+            # rendered system_instruction.
+            #
+            # VTID-03076 (P0-C) exception: a REAL proactive offer (wake_brief
+            # with decision_id + dedupe_key) MUST go into chat_ctx so the LLM
+            # remembers having said it. Otherwise the user's "ja" hits the
+            # model with no context and produces a tangential answer
+            # (Vitanaland explanation when a match was offered). Localized
+            # greetings stay out of chat_ctx — those are decoration, not
+            # offers the user can act on.
+            await session.say(greeting_text, add_to_chat_ctx=bool(is_proactive_offer))
+        except Exception as exc:  # noqa: BLE001
+            logger.warning("initial greeting session.say failed: %s", exc)
+            asyncio.create_task(
+                _early_trace_heartbeat(
+                    cfg.gateway_url,
+                    {
+                        "user_id": identity.user_id or "unknown",
+                        "code_version": CODE_VERSION,
+                        "phase": "greeting_failed",
+                        "orb_session_id": orb_session_id,
+                        "error": str(exc)[:500],
+                    },
+                )
+            )
 
     # VTID-03021: NO background hydration. The full system_instruction is
     # already bound to Agent(instructions=sys_prompt) at construction time

--- a/services/agents/orb-agent/tests/test_wake_brief_suppressed_no_fallback.py
+++ b/services/agents/orb-agent/tests/test_wake_brief_suppressed_no_fallback.py
@@ -1,0 +1,164 @@
+"""VTID-WAKE-OPENER: suppressed wake_brief must not fall back to
+_localized_greeting().
+
+Background
+----------
+VTID-03054 wired session.py to speak `wake_brief.user_facing_line` when
+the gateway returns a non-empty proactive opener. But the `else` branch
+was a single bucket covering BOTH:
+  (a) gateway returned no wake_brief_decision (degraded / pre-VTID-03052
+      gateway)
+  (b) gateway returned a decision but the decider deliberately produced
+      no line (B1 cadence skip, greeted-recently, heavy-day dampening,
+      etc.)
+
+In case (b) the policy says "do not greet again". Falling back to
+`_localized_greeting()` was exactly the bug the user reported on the
+LiveKit Test Bench: three minutes after hearing "Hallo, wie kann ich
+helfen?", they heard the identical line again. Wake-brief had decided
+NOT to greet; session.py overrode that decision.
+
+Fix structure (session.py)
+--------------------------
+1. `decision_present` is computed first (raw_wake_brief is dict).
+2. Branch order:
+     - wake_line non-empty             → speak it
+     - decision_present, no wake_line  → greeting_text = None; SKIP say
+     - else                            → _localized_greeting() fallback
+3. session.say() is only called when greeting_text is not None.
+4. Three [VTID-WAKE-OPENER] log lines (override / suppressed / legacy)
+   so production can grep which branch fired.
+
+These tests are structural — they lock the branch shape so a future
+refactor cannot silently re-merge the (a) and (b) cases.
+"""
+from __future__ import annotations
+
+import pathlib
+
+
+def _session_src() -> str:
+    return (
+        pathlib.Path(__file__).resolve().parent.parent
+        / 'src' / 'orb_agent' / 'session.py'
+    ).read_text(encoding='utf-8')
+
+
+def test_session_py_distinguishes_decision_present_from_decision_absent() -> None:
+    """The two cases — `wake_brief_decision is a dict` vs `is None` — must
+    be branched on separately. A single `else` clause covering both is
+    the bug this PR fixes."""
+    src = _session_src()
+    assert 'decision_present' in src, (
+        "session.py is missing the decision_present guard — the suppressed "
+        "(case b) and absent (case a) paths must be distinguishable."
+    )
+    # The guard is defined as isinstance(raw_wake_brief, dict). Look for
+    # the exact pattern so a future refactor that loses the dict check
+    # (e.g. just `bool(raw_wake_brief)` — which is False for empty dicts)
+    # fails this assertion.
+    assert 'isinstance(raw_wake_brief, dict)' in src
+
+
+def test_session_py_skips_say_when_decision_suppressed() -> None:
+    """When wake_brief_decision exists but has no user_facing_line, the
+    code must set greeting_text=None and skip session.say() — NOT fall
+    back to _localized_greeting()."""
+    src = _session_src()
+
+    # The suppressed branch must be present as a distinct elif.
+    assert 'elif decision_present:' in src, (
+        'session.py must branch on `elif decision_present:` between '
+        'the speak-line path and the localized-fallback path.'
+    )
+
+    # Capture ONLY the elif body — stop at the next `else:` (the
+    # absent-decision branch) so the absent-branch fallback call doesn't
+    # bleed into the assertion.
+    suppressed_marker_idx = src.index('elif decision_present:')
+    next_else_rel = src[suppressed_marker_idx:].index('\n        else:')
+    window = src[suppressed_marker_idx:suppressed_marker_idx + next_else_rel]
+
+    assert 'greeting_text = None' in window, (
+        'suppressed branch must set greeting_text = None — sentinel for '
+        'skipping session.say().'
+    )
+    # The suppressed branch must NOT call _localized_greeting.
+    # (Comment mentions of the helper that include the literal `(` would
+    # also fail this check — keep prose without parens in this branch.)
+    assert '_localized_greeting(' not in window, (
+        'suppressed branch must not call _localized_greeting() — that is '
+        'the exact regression this PR closes.'
+    )
+
+
+def test_session_py_say_is_guarded_on_greeting_text_not_none() -> None:
+    """session.say() must be wrapped in an `if greeting_text is None / else`
+    so the suppressed branch's None sentinel actually short-circuits the
+    speak path."""
+    src = _session_src()
+    assert 'if greeting_text is None:' in src, (
+        'session.py must guard session.say() on greeting_text not being None.'
+    )
+    # session.say must still be in the file — we did not remove the speak
+    # path, only guarded it.
+    assert 'await session.say(greeting_text' in src
+
+
+def test_session_py_falls_back_only_when_decision_absent() -> None:
+    """When wake_brief_decision is MISSING (degraded bootstrap / pre-
+    VTID-03052 gateway), _localized_greeting() is still the right
+    fallback so the orb never silently fails to greet."""
+    src = _session_src()
+    # The _localized_greeting() call must live INSIDE the `else:` branch
+    # that follows `elif decision_present:` — i.e. only fires when the
+    # decision is absent, not when it's suppressed.
+    suppressed_idx = src.index('elif decision_present:')
+    # The next `else:` after `elif decision_present:` is the absent-decision branch.
+    absent_branch_start = src.index('\n        else:', suppressed_idx)
+    absent_window = src[absent_branch_start:absent_branch_start + 800]
+    assert '_localized_greeting(' in absent_window, (
+        'absent-decision branch must still call _localized_greeting() so '
+        'a degraded bootstrap path does not silence the orb.'
+    )
+
+
+def test_session_py_emits_vtid_wake_opener_logs() -> None:
+    """Three [VTID-WAKE-OPENER] log lines must fire so production logs can
+    prove which branch handled the wake — override / suppressed / legacy."""
+    src = _session_src()
+    assert 'path=livekit override_active=true' in src, (
+        '[VTID-WAKE-OPENER] override branch log line missing.'
+    )
+    assert 'path=livekit override_active=false suppressed=true' in src, (
+        '[VTID-WAKE-OPENER] suppressed branch log line missing.'
+    )
+    assert 'path=livekit override_active=false suppressed=false' in src, (
+        '[VTID-WAKE-OPENER] legacy / absent-decision branch log line missing.'
+    )
+    # The suppressed log must include suppression_reason so we can later
+    # tell B1-cadence from heavy-day from greeted-recently in production.
+    sup_idx = src.index('path=livekit override_active=false suppressed=true')
+    sup_window = src[sup_idx:sup_idx + 600]
+    assert 'suppression_reason' in sup_window, (
+        'suppressed log must include suppression_reason field.'
+    )
+    # Three branches each log selected_kind / user_facing_line OR said=.
+    assert 'said=<skipped>' in src, (
+        'suppressed branch log must mark said=<skipped> for grep parity.'
+    )
+
+
+def test_session_py_anonymous_path_unaffected() -> None:
+    """The is_anonymous branch is still wired to _localized_anonymous_greeting.
+    Wake-brief decisions never apply to anonymous sessions (no user_id at the
+    gateway), so the anonymous path should be untouched by this PR."""
+    src = _session_src()
+    assert '_localized_anonymous_greeting(' in src
+    # Anonymous branch must NOT consult wake_brief_decision.
+    anon_idx = src.index('_localized_anonymous_greeting(')
+    # The 200 chars BEFORE the anonymous call must not reference wake_brief.
+    pre_anon = src[max(0, anon_idx - 200):anon_idx]
+    assert 'wake_brief' not in pre_anon, (
+        'anonymous branch must not consult wake_brief_decision.'
+    )


### PR DESCRIPTION
## Summary
- LiveKit Test Bench user heard generic localized greeting after wake-brief decided to suppress (B1 cadence, greeted-recently, heavy-day dampening) — the policy says "don't greet again" but session.py overrode that decision with `_localized_greeting()`.
- `session.py` now distinguishes three cases instead of two:
  - `wake_line` present → speak it verbatim (existing VTID-03054 path).
  - `decision_present` but no line → `greeting_text = None`; skip `session.say()` entirely. Silence is correct; next turn is gated on user audio.
  - `decision_present` is False (degraded bootstrap / pre-VTID-03052) → `_localized_greeting()` fallback so the orb never silently fails to greet.
- `session.say()` now lives behind `if greeting_text is None: pass / else: await session.say(...)`.
- Three `[VTID-WAKE-OPENER]` log lines parallel to the Vertex side (`path=livekit override_active=... suppressed=... lang=... decision_id=... selected_kind=... suppression_reason=... said="..." | said=<skipped>`).

## Test plan
- [x] `pytest tests/test_wake_brief_suppressed_no_fallback.py tests/test_wake_brief_greeting_consumption.py` — 11/11 green.
- [x] 22 pre-existing failures in `test_smoke.py` / `test_recipient_resolution_observability.py` / `test_report_to_specialist_observability.py` confirmed identical on clean `origin/main` (unrelated).
- [ ] **Runtime verification on LiveKit Test Bench**: connect, confirm first spoken line is the Teacher line. Agent log must show `[VTID-WAKE-OPENER] path=livekit override_active=true selected_line="..."`.
- [ ] **B1 suppression path**: reconnect within suppression window → agent log shows `path=livekit override_active=false suppressed=true suppression_reason=...`, orb is silent.
- [ ] **Degraded bootstrap path**: agent log shows `decision_id=<missing>`, localized greeting still speaks.

## Notes
- **Lang issue NOT addressed here**. The new `[VTID-WAKE-OPENER]` log line records `identity.lang` on every branch so the next Test Bench session produces evidence; a follow-up PR will fix lang resolution once we know the path (env vs Accept-Language vs stored preference).
- VTID-03103 allocated via `POST /api/v1/vtid/allocate` 2026-05-19.
- Paired with VTID-03102 (Vertex-side trigger override fix) — see separate PR.

🤖 Generated with [Claude Code](https://claude.com/claude-code)