### PR TITLE
fix(orb-live): wake-brief override speaks Teacher line via `Say exactly:` shape (VTID-03104)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -6343,6 +6343,75 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
   }
 
   const lang = session.lang;
+
+  // VTID-03104 (Teacher opener v2): when the wake-brief decider produced
+  // a user_facing_line on /live/session/start, replace the legacy menu
+  // prompt with the SAME `Say exactly: "..."` shape the wasFailure bucket
+  // (~line 6413) already uses successfully in production. The line itself
+  // is embedded in the user-turn — Gemini does not need to scan the
+  // system_instruction to find the SPOKEN FIRST UTTERANCE block, and the
+  // prompt stays compact (~150-300 chars) so it does not delay the first
+  // audio chunk past the AudioContext suspend window.
+  //
+  // History:
+  //   VTID-03101 (PR #2258) — added wake-brief override block to system_instruction.
+  //                            Legacy menu user-turn still won (recency primacy).
+  //   VTID-03102 (PR #2262) — replaced legacy menu with a long meta-instruction
+  //                            trigger that pointed Gemini at the system prompt's
+  //                            override block. Reverted in PR #2265 because
+  //                            Gemini Live either shifted response modality to
+  //                            text-only or delayed first audio past iOS
+  //                            AudioContext auto-suspend — UI flipped to
+  //                            "speaking" but no audio reached the user.
+  //   VTID-03104 (this fix)  — minimal, field-tested prompt shape; line is
+  //                            quoted directly so the model has nothing to
+  //                            look up.
+  //
+  // The suppressed-by-cadence branch deliberately falls through to the
+  // legacy bucket dispatch below — that path has shipped for months and
+  // is known to keep audio flowing. B1 cadence is a separate slice.
+  const wakeBriefDecision: { selectedContinuation?: { userFacingLine?: string } | null; decisionId?: string } | null =
+    (session as any).wakeBriefDecision || null;
+  const wakeOverrideLine = wakeBriefDecision?.selectedContinuation?.userFacingLine?.trim();
+  if (wakeOverrideLine && wakeOverrideLine.length > 0 && !session.isAnonymous) {
+    // Escape double-quotes so the line cannot terminate the wrapper early.
+    const safe = wakeOverrideLine.replace(/"/g, '\\"');
+    const wakeTriggerByLang: Record<string, string> = {
+      en: `Say exactly: "${safe}" — ONE short utterance only. Do NOT add a greeting before. Do NOT add a question after. Do NOT paraphrase.`,
+      de: `Sage genau Folgendes: "${safe}" — NUR EINE kurze Aussage. KEINE Begrüßung davor. KEINE Frage danach. NICHT umformulieren.`,
+      fr: `Dis exactement : "${safe}" — UNE seule courte phrase. PAS de salutation avant. PAS de question après. NE PAS reformuler.`,
+      es: `Di exactamente: "${safe}" — UNA sola frase corta. NO añadas saludo antes. NO añadas pregunta después. NO parafrasees.`,
+      ar: `قل بالضبط: "${safe}" — جملة قصيرة واحدة فقط. لا تحية قبلها. لا سؤال بعدها. لا تعيد صياغتها.`,
+      zh: `请准确地说："${safe}" —— 只说一句话。前面不要加问候。后面不要加问题。不要改述。`,
+      ru: `Скажи ровно: "${safe}" — ОДНА короткая фраза. БЕЗ приветствия перед. БЕЗ вопроса после. НЕ перефразируй.`,
+      sr: `Реци тачно: "${safe}" — ЈЕДНА кратка реченица. БЕЗ поздрава пре. БЕЗ питања после. НЕ преформулиши.`,
+    };
+    const wakePrompt = wakeTriggerByLang[lang] || wakeTriggerByLang.en;
+    const linePreview = safe.length > 160 ? safe.slice(0, 160) + '...' : safe;
+    const promptPreview = wakePrompt.length > 200 ? wakePrompt.slice(0, 200) + '...' : wakePrompt;
+    console.log(
+      `[VTID-WAKE-OPENER] path=vertex override_active=true lang=${lang} decision_id=${wakeBriefDecision?.decisionId || '<none>'} prompt_len=${wakePrompt.length}`,
+    );
+    console.log(`[VTID-WAKE-OPENER] selected_line="${linePreview}"`);
+    console.log(`[VTID-WAKE-OPENER] prompt_sent="${promptPreview}"`);
+    const wakeMessage = {
+      client_content: {
+        turns: [{ role: 'user', parts: [{ text: wakePrompt }] }],
+        turn_complete: true,
+      },
+    };
+    ws.send(JSON.stringify(wakeMessage));
+    session.greetingSent = true;
+    session.greetingTurnIndex = session.turn_count;
+    emitDiag(session, 'greeting_sent', {
+      lang,
+      prompt_len: wakePrompt.length,
+      wake_opener: 'override_v2',
+      decision_id: wakeBriefDecision?.decisionId || null,
+    });
+    startResponseWatchdog(session, GREETING_RESPONSE_TIMEOUT_MS, 'greeting_timeout');
+    return true;
+  }
   // VTID-NAV-TIMEJOURNEY (warmth fix): The default greeting prompt for
   // AUTHENTICATED sessions must be WARM, POLITE, and KIND — never cold,
   // never curt. The previous iteration fixed "Hello Dragan!" but made

--- a/services/gateway/test/orb/live/characterization/vertex-wake-opener-v2.characterization.test.ts
+++ b/services/gateway/test/orb/live/characterization/vertex-wake-opener-v2.characterization.test.ts
@@ -1,0 +1,157 @@
+/**
+ * VTID-03104 — structural lock for the Teacher-opener v2 trigger.
+ *
+ * Background
+ * ----------
+ * VTID-03102 (PR #2262, reverted by #2265) replaced the legacy menu user-turn
+ * with a long meta-instruction trigger:
+ *
+ *   "Begin your first turn now. The SPOKEN FIRST UTTERANCE block in your
+ *    system instruction contains the exact line you must speak. Use that
+ *    line verbatim — copy it letter-for-letter — then stop and wait for
+ *    the user. Do NOT pick a phrase from any other section."
+ *
+ * Gemini Live either (a) interpreted the text-mode-sounding phrasing as a
+ * text-only response cue, or (b) took long enough to start synthesis that
+ * the AudioContext suspended. Either way: UI flipped to "Vitana speaking"
+ * (chunks arrived) but no TTS audio was heard. Reverted ~25 min after
+ * deploy.
+ *
+ * VTID-03104 takes a different shape: mirror the EXACT format the
+ * temporal.wasFailure bucket already uses successfully in production
+ * (`Say exactly: "Sorry about that. How can I help?" ONE short phrase
+ * only. Do NOT say "Hello" or the user's name.`). The wake-brief line is
+ * embedded in the user-turn directly so Gemini does not need to scan the
+ * system_instruction for the SPOKEN FIRST UTTERANCE block.
+ *
+ * Hazards this file locks against:
+ *   - Re-introducing the v1 long meta-instruction phrasing
+ *   - Triggers that exceed the wasFailure pattern's working length
+ *   - Trigger lines that include "verbatim", "letter-for-letter", or
+ *     "stop and wait for the user" (the candidate audio-killers from v1)
+ *   - Removing the line embedding so the model has to look it up again
+ *   - Losing the three [VTID-WAKE-OPENER] diagnostic logs
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ORB_LIVE_PATH = path.resolve(__dirname, '../../../../src/routes/orb-live.ts');
+
+let orbLiveSource: string;
+
+beforeAll(() => {
+  orbLiveSource = fs.readFileSync(ORB_LIVE_PATH, 'utf8');
+});
+
+function extractSendGreetingFn(): string {
+  const startIdx = orbLiveSource.indexOf('function sendGreetingPromptToLiveAPI(');
+  if (startIdx === -1) {
+    throw new Error('sendGreetingPromptToLiveAPI not found in orb-live.ts');
+  }
+  const afterStart = orbLiveSource.slice(startIdx + 1);
+  const nextFnRel = afterStart.search(/\nfunction\s+\w/);
+  return nextFnRel === -1
+    ? orbLiveSource.slice(startIdx)
+    : orbLiveSource.slice(startIdx, startIdx + 1 + nextFnRel);
+}
+
+describe('VTID-03104: Teacher-opener v2 in sendGreetingPromptToLiveAPI', () => {
+  let fn: string;
+
+  beforeAll(() => {
+    fn = extractSendGreetingFn();
+  });
+
+  it('reads session.wakeBriefDecision.selectedContinuation.userFacingLine', () => {
+    expect(fn).toMatch(/session as any\)\.wakeBriefDecision/);
+    expect(fn).toMatch(/selectedContinuation\?\.userFacingLine\?\.trim\(\)/);
+  });
+
+  it('only fires the override branch when the line is non-empty AND session is NOT anonymous', () => {
+    // Anonymous sessions have their own intro speech (anonPrompts above);
+    // wake-brief should never short-circuit that.
+    expect(fn).toMatch(
+      /wakeOverrideLine[\s\S]{0,200}length\s*>\s*0[\s\S]{0,200}!session\.isAnonymous/,
+    );
+  });
+
+  it('embeds the line directly in the user-turn via `Say exactly: "..."` (the proven wasFailure pattern)', () => {
+    // English form — line is interpolated as ${safe} inside double quotes.
+    expect(fn).toMatch(/Say exactly: "\$\{safe\}"/);
+    // German form — same idea, localized.
+    expect(fn).toMatch(/Sage genau Folgendes: "\$\{safe\}"/);
+    // Escape pass so embedded quotes in the line can't terminate the wrapper.
+    expect(fn).toMatch(/wakeOverrideLine\.replace\(\/"\/g, '\\\\"'\)/);
+  });
+
+  it('does NOT re-introduce any v1 (VTID-03102) phrasing that broke audio', () => {
+    // The exact phrases from the reverted trigger.
+    expect(fn).not.toMatch(/Use that line verbatim/);
+    expect(fn).not.toMatch(/copy it letter-for-letter/);
+    expect(fn).not.toMatch(/stop and wait for the user/);
+    expect(fn).not.toMatch(/Begin your first turn now/);
+    // The v1 prompt referenced the SPOKEN FIRST UTTERANCE block in the
+    // user-turn so the model would scan the system_instruction for it.
+    // v2 inlines the line, so the user-turn must not reference the block.
+    const overrideBranchMatch = fn.match(
+      /if\s*\(wakeOverrideLine[\s\S]+?return true;\s*\n\s\s\}/,
+    );
+    expect(overrideBranchMatch).not.toBeNull();
+    const overrideBranch = overrideBranchMatch![0];
+    expect(overrideBranch).not.toMatch(/SPOKEN FIRST UTTERANCE/);
+  });
+
+  it('keeps the override trigger compact — no per-lang trigger exceeds the wasFailure-template length budget', () => {
+    // wasFailure prompt is ~155 chars + line. v2 lang prompts wrap an
+    // 80-150 char line in <200 chars of localized instruction text.
+    // We cap the localized template text at 300 chars per lang to keep
+    // the total trigger near the working-pattern length.
+    const triggerObjMatch = fn.match(/wakeTriggerByLang:[\s\S]*?Record<string,\s*string>\s*=\s*\{([\s\S]*?)\n\s\s\s\s\};/);
+    expect(triggerObjMatch).not.toBeNull();
+    const triggerBody = triggerObjMatch![1];
+    // Each lang entry: `lang: \`...\`,`  We measure the template string only.
+    const langTemplates = triggerBody.match(/`[^`]*`/g) || [];
+    expect(langTemplates.length).toBeGreaterThanOrEqual(8);
+    for (const tpl of langTemplates) {
+      expect(tpl.length).toBeLessThan(300);
+    }
+  });
+
+  it('does NOT fall through to the legacy menu when an override line is present (line is in user-turn AND triggers return true)', () => {
+    const overrideBranchMatch = fn.match(
+      /if\s*\(wakeOverrideLine[\s\S]+?return true;\s*\n\s\s\}/,
+    );
+    expect(overrideBranchMatch).not.toBeNull();
+    const overrideBranch = overrideBranchMatch![0];
+    // The override branch must end with `return true;` so the legacy
+    // bucket dispatch below it cannot execute and send a competing menu.
+    expect(overrideBranch).toMatch(/return true;\s*\n\s\s\}\s*$/);
+    // ws.send must fire inside the branch — otherwise the watchdog
+    // arms but Gemini never receives the trigger.
+    expect(overrideBranch).toMatch(/ws\.send\(JSON\.stringify\(wakeMessage\)\)/);
+    // greetingSent must be set so stall-recovery does not re-send the
+    // legacy menu later.
+    expect(overrideBranch).toMatch(/session\.greetingSent\s*=\s*true/);
+    // Watchdog must still arm — we ARE waiting on the model.
+    expect(overrideBranch).toMatch(/startResponseWatchdog\(/);
+  });
+
+  it('legacy menu path remains intact for sessions without a wake-brief override', () => {
+    expect(fn).toMatch(/pick ONE of: "How can I help\?"/);
+    expect(fn).toMatch(/ws\.send\(JSON\.stringify\(message\)\)/);
+  });
+
+  it('emits the three [VTID-WAKE-OPENER] diagnostic logs in the override branch', () => {
+    const logLines = fn.match(/\[VTID-WAKE-OPENER\]/g) || [];
+    expect(logLines.length).toBeGreaterThanOrEqual(3);
+    expect(fn).toMatch(/path=vertex override_active=true/);
+    expect(fn).toMatch(/selected_line=/);
+    expect(fn).toMatch(/prompt_sent=/);
+  });
+
+  it('emits a greeting_sent diag event with wake_opener=override_v2 + decision_id', () => {
+    expect(fn).toMatch(/wake_opener:\s*'override_v2'/);
+    expect(fn).toMatch(/decision_id:\s*wakeBriefDecision\?\.decisionId/);
+  });
+});


### PR DESCRIPTION
## Summary
**v2 of the VTID-03102 attempt** that was reverted in PR #2265 (TTS audio regression).

Key difference: instead of pointing Gemini at the system_instruction with a long meta-instruction trigger, this v2 quotes the wake-brief line DIRECTLY in the user-turn using the same `Say exactly: "..."` shape the `temporal.wasFailure` bucket prompt has been using successfully in production for months. Gemini doesn't have to scan the system prompt to find the override block — the line is right there in the user turn.

## Why v1 broke audio
Suspected: Gemini Live interpreted phrases like "Use that line verbatim — copy it letter-for-letter — then stop and wait for the user" as text-mode cues OR took too long to begin synthesis, pushing the first audio chunk past the iOS AudioContext auto-suspend window. Either way: UI flipped to "Vitana speaking" but no audio reached the user.

## Why v2 should not break audio
- Trigger shape (`Say exactly: "<line>" — ONE short utterance only. Do NOT add a greeting before. Do NOT add a question after. Do NOT paraphrase.`) mirrors the existing `wasFailure` prompt (`Say exactly: "Sorry about that. How can I help?" ONE short phrase only. Do NOT say "Hello" or the user's name.`) which is currently in production.
- Per-lang template capped under 300 chars — same length budget as the working `wasFailure` prompt.
- Line embedded directly so the model never has to scan the system_instruction for a "verbatim" target.
- Override branch ONLY runs when wake-brief produced a line AND session is not anonymous. All other cases (no decision, suppressed decision, anonymous) fall through to the existing legacy menu — no silent branch.

## Test plan
- [x] `npm run build` (gateway) — clean.
- [x] `npx jest test/orb/live` — 480 tests, 28 suites, all green.
- [x] 9 new structural assertions in vertex-wake-opener-v2.characterization.test.ts — including an explicit `not.toMatch` for every v1 audio-killer phrase (verbatim / letter-for-letter / stop and wait / Begin your first turn).
- [ ] **Runtime on vitanaland desktop**: tap orb, confirm (a) audio is heard, (b) first spoken line is the Teacher/proactive line, not generic.
- [ ] **Runtime on vitanaland Android**: same.
- [ ] **Sanity** (anonymous session): tap orb on landing page, confirm anonymous intro still speaks.

## Notes
- VTID-03104 allocated via `POST /api/v1/vtid/allocate` 2026-05-19.
- LiveKit side (VTID-03103) remains reverted in PR #2266; the original LiveKit Test Bench "English when user prefers German" complaint is a lang-resolution issue, separate slice.

🤖 Generated with [Claude Code](https://claude.com/claude-code)