### PR TITLE
feat(billing): subscription + credits launch (VTID-03107 / DEV-COMHU-03107) — full slice

### DIFF
--- a/docs/business-model/BUSINESS-MODEL.md
+++ b/docs/business-model/BUSINESS-MODEL.md
@@ -4,7 +4,7 @@
 >
 > **VTID:** VTID-03107
 > **Status:** Spec for launch (v1). Numbers tuneable post-launch via DB config; mechanism changes require new VTID.
-> **Last updated:** 2026-05-20
+> **Last updated:** 2026-05-26 (rolling-window Free quotas + auto-grant for existing users)
 
 ---
 
@@ -70,16 +70,35 @@ The Subscriptions screen leads with **Free vs Premium** as the binary headline c
 
 ## 3. The most-valued features (paywall surface)
 
-Six metered features. v1 actively enforces paywalls on the two **cost drivers** (rows 1–2). Rows 3–6 ship as visible tier quotas (soft counters) so users see the upgrade value, but the routes do not yet return 402 — they will be flipped on after 30–60 days of usage data justify it.
+Six metered features. v1 enforces **hard cuts on all six** on Free. Existing onboarded users are protected from those walls by the launch auto-grant (§9). Paid plans see only the monthly cap. Free sees three rolling windows so the user always has a near-term recovery option (Claude / ChatGPT pattern).
 
-| # | Feature | Free | Premium | Host | Community | PAYG rate | Enforcement |
-|---|---|---|---|---|---|---|---|
-| 1 | **Live AI voice** (Gemini Live) | 15 min/mo · 5 min/day cap · D36-gated | 30 min/mo | 150 min/mo (5×) | 600 min/mo (20×) | 5 credits/min | **Hard: degrade to standard voice OR PAYG** |
-| 2 | **Live Rooms hosting** (Daily.co) | 40 min/mo · 1 session | 5 hrs/mo | 25 hrs/mo (5×) | 100 hrs/mo (20×) | 1 credit/min | **Hard: 5-min warn → graceful end OR PAYG** |
-| 3 | **Find-a-Match posts** | 3/mo | 20/mo | 100/mo | 400/mo | 50 credits/post | Soft (UI counter, no 402) |
-| 4 | **Find-a-Match reveals** | 5/wk | 50/mo | 250/mo | 1,000/mo | 10 credits/reveal | Soft (UI counter, no 402) |
-| 5 | **Lab analysis** (OCR + LLM) | 1/mo | 5/mo | 25/mo | 100/mo | 50 credits/lab | Soft (UI counter, no 402) |
-| 6 | **Photo uploads** | 5/mo | 50/mo | 250/mo | 1,000/mo | 1 credit/photo | Soft (UI counter, no 402) |
+### Free tier — three rolling windows
+
+The Free user gets two short-window caps (5h + weekly) AND a monthly soft ceiling. **The weekly cap is almost always the binding limit.** The 5h cap stops burst use and refreshes ~4×/day. The monthly is set above weekly×4.3 so it acts as a safety ceiling, not the day-to-day pain point.
+
+| # | Feature | 5h window | Weekly cap | Monthly ceiling | Enforcement |
+|---|---|---|---|---|---|
+| 1 | **Live AI voice** (Gemini Live) | 5 min | 20 min/wk | 80 min/mo | Hard: degrade to standard voice OR PAYG |
+| 2 | **Live Rooms hosting** (Daily.co) | 20 min | 60 min/wk | 240 min/mo | Hard: graceful end OR PAYG |
+| 3 | **Find-a-Match posts** | 2 | 5/wk | 20/mo | Hard: 402 OR PAYG |
+| 4 | **Find-a-Match reveals** | 3 | 10/wk | 40/mo | Hard: 402 OR PAYG |
+| 5 | **Lab analysis** (OCR + LLM) | 1 | 3/wk | 12/mo | Hard: 402 OR PAYG |
+| 6 | **Photo uploads** | 5 | 15/wk | 60/mo | Hard: 402 OR PAYG |
+
+When the user hits ANY of the three caps, the in-context message shows the sooner reset (always the 5h window during active use, the weekly cap otherwise). The Usage drawer shows both bars side-by-side.
+
+### Paid tiers — monthly only
+
+| # | Feature | Premium | Host | Community | PAYG rate |
+|---|---|---|---|---|---|
+| 1 | Live AI voice | 30 min/mo | 150 min/mo (5×) | 600 min/mo (20×) | 5 credits/min |
+| 2 | Live Rooms hosting | 5 hrs/mo | 25 hrs/mo (5×) | 100 hrs/mo (20×) | 1 credit/min |
+| 3 | Find-a-Match posts | 20/mo | 100/mo | 400/mo | 50 credits/post |
+| 4 | Find-a-Match reveals | 50/mo | 250/mo | 1,000/mo | 10 credits/reveal |
+| 5 | Lab analysis | 5/mo | 25/mo | 100/mo | 50 credits/lab |
+| 6 | Photo uploads | 50/mo | 250/mo | 1,000/mo | 1 credit/photo |
+
+Paid plans have `window_5h_quota` and `weekly_quota` NULL — only the monthly cap is checked. PAYG credits work across all plans for overage.
 
 ### Storage included in every plan
 
@@ -262,7 +281,32 @@ No fake transparency under any circumstances. If neither mode is achievable, the
 
 ---
 
-## 9. Not in launch scope (intentional — not promised anywhere)
+## 9. Launch auto-grant for existing onboarded users
+
+Locked decision (2026-05-26): every user who was onboarded BEFORE the billing v1 deploy automatically receives a **12-month Premium subscription** — no codes, no clicks, no email. The grant runs once during deploy via migration `20260526110000_VTID_03107_launch_auto_grant.sql`.
+
+**What it does:**
+- Iterates every `user_tenants.is_primary = true` membership where `app_users.created_at < now() - 24h`
+- Skips any user with an active/trialing/past_due subscription (auto-grant is a floor, not an override)
+- Writes a `user_subscriptions` row: `plan_key='premium'`, `status='active'`, `current_period_end=now()+365d`, `price_key=NULL` (no Stripe binding)
+- Tags with `metadata.source='launch_auto_grant_2026'`, `metadata.no_friction=true`, `metadata.granted_at`, `metadata.grant_duration_days=365`
+
+**What the user sees** on next app open (no push, no email):
+- Settings → Subscription shows their plan as **Premium** with subtitle "auto-granted at launch · ends YYYY-MM-DD"
+- A one-time welcome banner above the plan card: "🎁 Welcome from us — you've received 12 months of Vitana Premium on us. Active until {date}. No action needed. Enjoy."
+- Banner is dismissible (`localStorage` keyed by user id). The plan-card subtitle stays so the user can always check the source.
+
+**End of grant (day 350):**
+- One pre-end nudge: "Your Vitana Premium grant ends in 15 days. Continue for €9.99/mo or stay on the Free plan." (push + in-app banner, no email)
+- At day 365: cron flips status to `canceled` and plan back to `free`. Same UX as any expired paid sub.
+
+**Cashflow note:** foregone-revenue worst case ≈ user_count × €9.99 × 12 months. At ~2,000 users that's ~€240k foregone. Real cash spent is bounded by Premium quotas (30 min voice + 5h rooms + small features per month) ≈ €10/user/mo ≈ ~€240k infra worst case. Acceptable: existing users are the highest-value cohort we have, and the alternative — telling onboarded users to "redeem a code" — is poor UX.
+
+This grant supersedes the test-cohort codes for already-onboarded users. The test-cohort + Founding code campaigns (§6) remain active for NEW signups who arrive after the deploy.
+
+---
+
+## 10. Not in launch scope (intentional — not promised anywhere)
 
 - ❌ Match-reveal / Match-post / Memory / Autopilot active 402 paywalls (soft UI badges only in v1)
 - ❌ Family plan / multi-seat subscription
@@ -286,7 +330,7 @@ Each of these is a separate scoped project with its own cashflow analysis when p
 
 ---
 
-## 10. Cross-references
+## 11. Cross-references
 
 | Customer-facing copy | Engineering implementation |
 |---|---|

--- a/docs/business-model/BUSINESS-MODEL.md
+++ b/docs/business-model/BUSINESS-MODEL.md
@@ -1,0 +1,297 @@
+# Vitana Business Model
+
+> Canonical quantified spec for the billing v1 launch. Engineering reads this; customer-facing copy lives in the i18n shards and KB chapters (cross-referenced below). All numbers in this document are config — single SQL UPDATE retunes any value without a deploy.
+>
+> **VTID:** VTID-03107
+> **Status:** Spec for launch (v1). Numbers tuneable post-launch via DB config; mechanism changes require new VTID.
+> **Last updated:** 2026-05-20
+
+---
+
+## 1. The four privacy + trust promises (lead with these)
+
+Anchored on the Subscriptions screen, the Trust Center, and every Premium upsell. These are the brand promises — every screen, every email, every push notification stays compatible with them.
+
+1. **You own what you share.** Memory, profile, recommendations — all visible, exportable, deletable.
+2. **We never sell your data to advertisers, brokers, or partners.** Enforced in code (D36 + monetization-attempts ledger).
+3. **Your experience, expertise, and recommendations can earn for you.** When your recommendation closes a sale through Sell and Earn or when you host a paid Live Room, you get the income — transparently disclosed.
+4. **You decide what Sell and Earn does for you.** Three switches plus per-channel autonomy plus per-category exclusions, visible in the Connect screen.
+
+**Things never said in customer copy** (enforced by the forbidden-strings i18n test in PR-3):
+- "Your data is your asset" / "monetize your data" / "data licensing" — too close to a regulatory product we don't ship in v1
+- "Premium 5×" / "Premium 20×" / "PAYG" / "VAEA" / "managed AI" / "BYO" — engineering terms
+- "Unlimited" for any variable-cost feature — use "generous fair use" or an explicit number
+- "Quota" / "throttle" / "burn" / "consume" — internal jargon
+- "Tier" — use "plan"
+
+---
+
+## 2. Plans (4 tiers + 6 price variants + 3 credit packs)
+
+### Internal naming vs customer-facing
+
+| Internal `plan_key` | Customer-facing label (i18n) | Quota multiplier vs Premium |
+|---|---|---|
+| `free` | **Free** | — |
+| `premium` | **Premium** | 1× |
+| `premium_5x` | **Host** | 5× |
+| `premium_20x` | **Community** | 20× |
+
+Internal keys carry the multiplier semantics for reasoning + telemetry. Customer-facing names lead with outcomes ("Host" = "you can host bigger rooms" / "Community" = "you can run a community").
+
+### Pricing
+
+| Plan | Monthly | Annual | Best for |
+|---|---|---|---|
+| **Free** | €0 | — | Trying out, casual use |
+| **Premium** | **€9.99/mo** | **€89/yr** (save ~26%) | Daily wellness use |
+| **Host** | **€99/mo** | **€890/yr** (save ~25%) | Power user, family, regular host |
+| **Community** | **€199/mo** | **€1990/yr** (save ~17%) | Coach, practitioner, community lead |
+
+All paid tiers include a **14-day free trial** on first subscription (Duolingo-equivalent). Trial converts to paid automatically unless cancelled.
+
+EUR-only at launch. EU VAT handled by Stripe Tax. USD/global price lists post-launch via additional `subscription_plan_prices` rows.
+
+### Customer-facing presentation
+
+The Subscriptions screen leads with **Free vs Premium** as the binary headline choice. Host and Community are surfaced behind a **"Need more live time or hosting?"** disclosure for power users only. The "Add extra minutes" tile (credit packs) sits **outside** the plan grid as an action, not a fourth tier.
+
+### Credit packs (one-shot purchases — works on any plan)
+
+| Internal SKU | Customer label (i18n) | Price | Credits | Bonus |
+|---|---|---|---|---|
+| `starter` | "10 hours of standard voice OR 100 live minutes" | €4.99 | 500 | — |
+| `boost` | "Most popular — 7 hours of live voice" | €19.99 | 2,200 | +10% bonus |
+| `power` | "Heavy use — 40 hours of live voice" | €99 | 12,000 | +20% bonus |
+
+**1 credit = €0.01** baseline. Bonus credits are volume incentive — they live in the same `purchased_credits` bucket and have the same purchasing power.
+
+---
+
+## 3. The most-valued features (paywall surface)
+
+Six metered features. v1 actively enforces paywalls on the two **cost drivers** (rows 1–2). Rows 3–6 ship as visible tier quotas (soft counters) so users see the upgrade value, but the routes do not yet return 402 — they will be flipped on after 30–60 days of usage data justify it.
+
+| # | Feature | Free | Premium | Host | Community | PAYG rate | Enforcement |
+|---|---|---|---|---|---|---|---|
+| 1 | **Live AI voice** (Gemini Live) | 15 min/mo · 5 min/day cap · D36-gated | 30 min/mo | 150 min/mo (5×) | 600 min/mo (20×) | 5 credits/min | **Hard: degrade to standard voice OR PAYG** |
+| 2 | **Live Rooms hosting** (Daily.co) | 40 min/mo · 1 session | 5 hrs/mo | 25 hrs/mo (5×) | 100 hrs/mo (20×) | 1 credit/min | **Hard: 5-min warn → graceful end OR PAYG** |
+| 3 | **Find-a-Match posts** | 3/mo | 20/mo | 100/mo | 400/mo | 50 credits/post | Soft (UI counter, no 402) |
+| 4 | **Find-a-Match reveals** | 5/wk | 50/mo | 250/mo | 1,000/mo | 10 credits/reveal | Soft (UI counter, no 402) |
+| 5 | **Lab analysis** (OCR + LLM) | 1/mo | 5/mo | 25/mo | 100/mo | 50 credits/lab | Soft (UI counter, no 402) |
+| 6 | **Photo uploads** | 5/mo | 50/mo | 250/mo | 1,000/mo | 1 credit/photo | Soft (UI counter, no 402) |
+
+### Storage included in every plan
+
+| Plan | Vitana Storage |
+|---|---|
+| Free | 100 MB |
+| Premium | 5 GB |
+| Host | 25 GB |
+| Community | 100 GB |
+| Overage | 50 credits = 1 GB / month (PAYG) |
+
+Metering scope: upload size (storage_objects trigger) + transformed-image bandwidth + daily egress check.
+
+### Other features (free for everyone, no metering)
+
+Calendar, Knowledge Hub, basic diary, group memberships, wellness lists, direct messages — all free at launch, same on every plan. Premium plans get **feature-flag perks** with no per-action metering:
+- `auto_schedule_calendar` (Premium+)
+- `premium_priority_practitioner` (Premium+)
+- `ai_digest_cadence: daily` (Premium+) vs `weekly` (Free)
+
+### Live Rooms participant guardrail (internal)
+
+Customer copy: "fair-use participant limits apply."
+Internal cap: 60,000 participant-minutes/month per host on Community plan (100h × avg 10 ppl). Beyond → contact for custom tier. Bounds Daily.co cost at the most expensive plan's worst case.
+
+---
+
+## 4. Wallet — three buckets, one ledger
+
+The single most important cashflow guardrail in v1: **separation by source AND by burn path**.
+
+| Bucket | Source | Burn paths in v1 |
+|---|---|---|
+| `purchased_credits` | Stripe credit-pack top-ups · ENTER-code grants · refunds · transfers | **Any feature** (default) — Live AI overage, Room overage, lab, photo, match |
+| `reward_credits` | Diary streaks · milestones · referrals · hosted workshops · wellness-list rewards · group-creation rewards | **Cheap features only** — match reveal · photo · lab. **NEVER** Live AI minutes, Room minutes, or subscription discount. |
+| `cash_balance` | Sell-and-Earn commissions held by Vitana · Stripe Connect hosting payouts · workshop revenue | **Withdrawable to bank** via Stripe Connect Express. Not in-app spend. |
+
+Implementation: 3 columns on `wallet_balances`. The legacy `balance` column stays as the sum across buckets for backward compatibility.
+
+**Rules** (enforced by `feature_entitlements.allowed_burn_buckets`):
+- `consumeCredits(userId, feature, amount)` checks the feature's `allowed_burn_buckets` config
+- Burn order when both allowed: **rewards first** (drain the lower-utility bucket first; preserves cash-equivalent purchased credits)
+- UI: Wallet page shows up to three rows (Credits / Rewards / Cash earnings). Subscriptions/checkout flows show only `Credits`.
+
+---
+
+## 5. Sell and Earn — recommendation income, with flat platform rules
+
+The customer-facing name for the VAEA service. Phase 0+1.5 already shipped (observe-mode, shadow drafts, no posting). v1 commercial framing locks the platform's revenue rules:
+
+### Two flat commission rules (NOT tier-scaled)
+
+| Income type | User keeps | Vitana keeps | Already wired? |
+|---|---|---|---|
+| **Vitana-processed sale** (Live Room ticket · workshop · service via Stripe Connect) | **90%** | 10% | YES — VTID-01231 Stripe Connect Express |
+| **External affiliate** (catalog tier = `affiliate_network`) | **What the network pays** (typically 3–10%) | **0%** (we don't intermediate the cash) | YES — vaea_referral_catalog.affiliate_url |
+
+**Why flat:** tier-scaled splits require commission-attribution + payout-routing code we haven't built. Flat rules align with what's actually live. Tier rises buy *capability* (more catalog items, more channels, higher autonomy), not a better payout percentage.
+
+### Sell-and-Earn capability ladder per plan
+
+| | Free | Premium | Host | Community |
+|---|---|---|---|---|
+| Catalog size | 5 items | 25 items | 100 items | 1,000 items |
+| Daily draft limit | 1 | 5 | 25 | 200 |
+| Channels listened | 1 (community) | 3 | 10 | 50 |
+| Autonomy ceiling | `draft_to_user` | `draft_to_user` | `one_tap_approve` | `one_tap_approve` |
+| Voice/persona cloning | Off | Off | Off | Off *(deferred from v1 launch)* |
+| Detected-questions visibility | Last 7 days | Last 30 days | Last 90 days | Lifetime |
+
+`auto_post` autonomy is feature-flagged off platform-wide in v1.
+
+### "Your Earnings" widget (Subscriptions screen)
+
+Honest, read-only. Only renders for users with non-zero `cash_balance` history. For Free / new users: hidden — **no projected-earnings copy, no "Premium users typically earn…" claims**.
+
+```
+YOUR EARNINGS (this year)
+  Live Room hosting payouts:    €280.50
+  Sell and Earn commissions:     €54.00
+  ────────────────────────────────
+  Total in your wallet:         €334.50
+                                          [Withdraw]
+```
+
+---
+
+## 6. Trial structure + launch giveaway campaigns
+
+Four layered paths to free Premium access, each with its own cap and cashflow ceiling:
+
+| Path | Who gets it | Length | Mechanism | Launch state |
+|---|---|---|---|---|
+| **Standard trial** | Every new Premium signup | 14 days | Stripe Checkout `subscription_data.trial_period_days: 14` | ACTIVE |
+| **Test cohort codes** ("ENTER codes") | First 100 inner-circle users (admin-issued) | **12 months** | 100 unique codes (`VITANA-TEST-A4F2-9KX1`), `max_uses=1` each, generated via Command Hub admin section in PR-5 | ACTIVE (PR-5 generates) |
+| **Founding Member promo** | First 500 public signups via marketing code | **3 months** | One shared `FOUNDING` code, `max_uses=500`, `is_active=true` | ACTIVE (seeded migration 6) |
+| **Referral bonus** | New user via someone's referral link | 30 days for the new user (one-sided) | `referral_redemptions` audit, max 5,000 grants total | **PAUSED** at launch (`is_active=false`); flipped on after PR-6 telemetry confirms safe |
+
+### Launch-day cashflow ceiling
+
+| Campaign | Users | Duration | Infrastructure cost worst-case | Foregone revenue |
+|---|---|---|---|---|
+| Test cohort | 100 | 12 months | ~€11,000 | ~€12,000 |
+| Founding 500 | 500 | 3 months | ~€16,500 | ~€15,000 |
+| Referral 5,000 | 5,000 | 1 month | ~€55,000 | ~€50,000 (PAUSED) |
+| 14-day trials | scales | 14 days | ~€5/user | proportional |
+
+**Launch-day combined ceiling (with referral paused): ~€27.5k foregone revenue + ~€27.5k infrastructure = ≤€55k total commitment worst-case.**
+
+### Hard money cap at redemption time
+
+Beyond per-code `max_uses`, `fn_redeem_code` checks AND decrements `tenant_settings.feature_flags.marketing_budget_eur_remaining_cents` BEFORE granting. Counter decrements by `grant_duration_days × monthly_subscription_cents / 30` per grant. When the counter hits zero, redemptions return `BUDGET_EXHAUSTED` until ops tops it up. Real money cap, independent of code-count caps.
+
+Ops seeds the launch-day budget at €55k. Daily OASIS alert if budget drops more than 10% in 24h.
+
+### Lifecycle messaging (Duolingo loss-aversion adapted)
+
+Via existing `notification-service.ts`:
+
+| Day | Trigger | Message |
+|---|---|---|
+| Day 0 | Trial start | Welcome + 3 personalized starter tiles |
+| Day 7 | Trial midpoint | Usage stats so far + "Keep going at €9.99/mo" |
+| Day 12 | Trial end-2 | "Your trial ends in 2 days. Want to keep [top-used feature]?" |
+| Day 13 | Trial end-1 | "Tomorrow your trial ends. Add a payment method or stay on Free." |
+| Day 14 | Trial expires | Silent — Stripe converts or user has cancelled |
+| Day 15 (if cancelled) | Post-cancel | "Your memory garden and streak stay. Come back anytime." |
+| Day 30 (if cancelled, no return) | Win-back one-shot | Personalized network nudge + 7-day free grant if click-through |
+
+Founding Member uses the same template at 90 / 80 / 88 / 89.
+
+---
+
+## 7. Trust Center — honest privacy transparency
+
+New surface at `/settings/trust-center` (PR-3). Three explicit zones:
+
+```
+📱 ON YOUR DEVICE
+   Biometric key                 Stays here, never sent
+   PIN                           Stays here, never sent
+   Photo originals (cache)       Cleared after 30 days
+   Draft text                    Stays here until you save
+
+🏠 ON VITANA SERVERS (EU region, encrypted at rest)
+   Health profile, Memory Garden, Sell-and-Earn catalog, Wallet ledger
+   Voice transcripts only when you opt in
+
+🌐 SENT TO YOUR AI PROVIDER (Vitana-managed Gemini)
+   Each chat turn: your message + tool results
+   Voice audio: streams during live calls, not retained
+   Your profile: never sent directly, summarized on our side first
+
+   [View AI call history] · [Export everything] · [Delete my account]
+```
+
+### Honesty hard gate (PR-3 acceptance criterion)
+
+Today `ai_usage_log` is only written by the ORB delegation path — not every AI surface. PR-3 cannot ship the Trust Center page in its full form until this is resolved. Two acceptance modes — PR-3 must pick one:
+
+- **Mode A — Full wiring**: instrument every AI provider call site (LLM, TTS, STT, embeddings, image-gen) to write to `ai_usage_log`. Then the panel can claim "all AI activity is visible here."
+- **Mode B — Narrowed honest panel**: ship the page with a tighter copy: "Showing N of M tracked AI surfaces. Other providers (TTS, embeddings, …) are not yet audited." List which surfaces ARE in the log, with last-call timestamp.
+
+No fake transparency under any circumstances. If neither mode is achievable, the link is hidden from Settings and the page does not ship in v1.
+
+---
+
+## 8. Cashflow Guardrails (canonical — every PR must honor these)
+
+1. **No "unlimited" anywhere** in copy or schema. Every metered feature has a monthly quota, even on the €199 tier. Marketing language: "generous fair use" or explicit numbers.
+2. **Three separate financial paths, never mixed in v1**: subscriptions fund tier access · purchased credits fund overage · earned rewards drive retention.
+3. **Voice and Live Room overage is paid only by purchased credits or hard-degrade.** Never by reward credits, never by extending the monthly tier quota.
+4. **Two-column wallet** enforces #3 at the schema level — `feature_entitlements.allowed_burn_buckets` config determines which buckets can pay; `fn_consume_credits` checks before debit.
+5. **D36 vulnerability deferral** → degrade to standard voice / offer PAYG credits / wait, but **never gift expensive minutes**. Deferral itself is metered: max 3 defer-grants per user per month (configurable).
+6. **All discount/multiplier mechanisms are out of launch scope** — no code, no flag, no promise. Specifically: 2× earn multiplier, subscription offset, Earn-Your-Month milestone, reward→subscription conversion are NOT in v1.
+7. **All caps are config**, not code — `subscription_plans.features_json`, `feature_entitlements.quota`, `redemption_codes.max_uses`, `tenant_settings.feature_flags.marketing_budget_eur_remaining_cents`. Single SQL UPDATE retunes any value.
+8. **Credit reservation pattern**: any future "credits at checkout" flow must reserve credits BEFORE Stripe checkout and release on Stripe failure (prevents double-spend race). Not in v1 scope.
+9. **Marketing-budget cap is a hard money guard**: `fn_redeem_code` and `fn_grant_referral` decrement the cap at redemption time and return `BUDGET_EXHAUSTED` when zero.
+10. **Feature flags can instantly reopen any gate** — `tenant_settings.feature_flags.billing_v1_*` rows control every paywall surface; tier quotas live in DB, never in TypeScript constants.
+
+---
+
+## 9. Not in launch scope (intentional — not promised anywhere)
+
+- ❌ Match-reveal / Match-post / Memory / Autopilot active 402 paywalls (soft UI badges only in v1)
+- ❌ Family plan / multi-seat subscription
+- ❌ Education / NGO discount portal
+- ❌ Annual gift card flow
+- ❌ Streak-save trial-extension flow
+- ❌ Per-conversation AI audit detail screen
+- ❌ Voice-transcript opt-in UI controls
+- ❌ Tier-scaled Sell-and-Earn commission percentages (flat rules only)
+- ❌ "100% to user on own products" promise (contradicts existing 90/10 Stripe Connect)
+- ❌ Data licensing / anonymized data marketplace
+- ❌ Sell-and-Earn auto-posting / mesh broker / voice cloning
+- ❌ BYO AI key (OpenAI/Anthropic/Gemini) credit-back
+- ❌ BYO cloud Drive (Google/iCloud/Dropbox/OneDrive) credit-back
+- ❌ 2× Premium earn multiplier
+- ❌ 50% subscription offset at checkout
+- ❌ "Earn Your Month" 5,000-credit milestone
+- ❌ Bilateral referral bonus (both sides get free time)
+
+Each of these is a separate scoped project with its own cashflow analysis when proposed. Nothing here is committed in this plan.
+
+---
+
+## 10. Cross-references
+
+| Customer-facing copy | Engineering implementation |
+|---|---|
+| KB chapter [`docs/knowledge-base/en/18-wallet/04-subscriptions.md`](../knowledge-base/en/18-wallet/04-subscriptions.md) | This file + i18n shards in `vitana-v1/src/i18n/de/subscriptions.json` (PR-3) |
+| KB chapter [`docs/knowledge-base/en/06-financial-longevity/03-credits-cash-and-vtn.md`](../knowledge-base/en/06-financial-longevity/03-credits-cash-and-vtn.md) | §4 (wallet buckets) above |
+| KB chapter [`docs/knowledge-base/en/07-maxina-experience/03-ethical-ai-and-privacy.md`](../knowledge-base/en/07-maxina-experience/03-ethical-ai-and-privacy.md) | §7 (Trust Center) above |
+
+Plan source of truth: `.claude/plans/the-plan-should-also-humming-stonebraker.md` (engineering plan, with full §A–§T sections).

--- a/docs/knowledge-base/en/18-wallet/04-subscriptions.md
+++ b/docs/knowledge-base/en/18-wallet/04-subscriptions.md
@@ -6,7 +6,7 @@ tags: ["subscriptions", "plans", "premium", "billing", "membership"]
 lang: "en"
 tenant: "all"
 status: "live"
-last_updated: "2026-02-25"
+last_updated: "2026-05-20"
 related: ["kb-en-18-01", "kb-en-18-02"]
 ---
 
@@ -39,19 +39,52 @@ Premium subscriptions go deeper. They are designed for members who want more pre
 
 **Exclusive content and programs.** Certain educational content, specialized programs, and expert-led courses are available only to premium members. These are not generic wellness guides. They are deep, evidence-based resources created by longevity professionals.
 
-**Expanded credit earning.** Premium members earn credits at an accelerated rate for the same activities. This means your healthy behaviors generate more tangible value, which you can reinvest in your journey through marketplace purchases, service bookings, and event access.
+**Earn while you participate.** Your healthy behaviors and your community contributions generate reward credits as you go. Those credits unlock community extras like additional match reveals or extra photo uploads in the Memory Garden. Earned rewards stay earned -- they accumulate without expiring as long as you remain active.
 
 **Premium community features.** Access to premium-only live events, intimate group sessions with limited attendance, and exclusive community spaces designed for deeper engagement and more focused discussion.
 
+## Our four promises
+
+Before plans, before pricing, here is what stays true on every plan -- free or paid:
+
+1. **You own what you share.** Your memory, your profile, your recommendations are visible to you, exportable on request, and deletable at any time.
+2. **We never sell your data to advertisers, brokers, or partners.** We never have. The system enforces this in code.
+3. **Your experience and your recommendations can earn for you.** When your trusted recommendation closes a sale through Sell and Earn, or when you host a paid Live Room, you receive the income directly. Every cent is shown to you.
+4. **You decide what Sell and Earn does for you.** Three switches in your Connect settings give you full control over whether your assistant receives, gives, or earns from recommendations -- and which channels it listens to.
+
+The Trust Center in your settings shows exactly what stays on your device, what lives on Vitana servers, and what is sent to the AI provider when you talk to me. No hidden profiling. No surprises.
+
 ## Available Plans
 
-Vitanaland offers subscription tiers designed to match different levels of engagement:
+Most members choose between Free and Premium. Two larger plans exist for hosts, coaches, and community leaders who use Live Rooms heavily or build their work around the platform.
 
 **Free.** Full access to core features. No cost, no commitment, no expiration. This is your permanent foundation inside Vitanaland.
 
-**Premium Monthly.** Full premium access billed monthly. This is the most flexible option -- you can subscribe, use the premium features, and cancel anytime without a long-term commitment. Ideal if you want to try premium before committing to a longer plan.
+**Premium.** Daily wellness use. Live conversations with me, room hosting time, and storage scaled for an engaged member. **€9.99 per month**, or **€89 per year** -- the annual plan saves about a quarter of the monthly cost because we want to reward long-term commitment, just like longevity rewards consistency.
 
-**Premium Annual.** Full premium access billed annually at a discounted rate. If you know you are committed to your longevity journey for the long haul, the annual plan gives you the best value. The discount is meaningful because we want to reward long-term commitment -- just like longevity itself rewards consistency.
+**Host.** Five times the Premium quotas, designed for power users, families, and anyone hosting regular Live Rooms or working with multiple recommendations. **€99 per month** or **€890 per year**.
+
+**Community.** Twenty times the Premium quotas, designed for coaches, practitioners, and community leads who run their work through the platform. **€199 per month** or **€1990 per year**.
+
+Every paid plan includes a **14-day free trial** on first subscription. You can cancel anytime during the trial without being charged.
+
+## What's included at each plan
+
+| | Free | Premium | Host | Community |
+|---|---|---|---|---|
+| **Live conversations with ORB** | 15 min/month (with a 5-minute daily limit) | 30 min/month | 150 min/month | 600 min/month |
+| **Standard voice conversations** | Generous fair use | Generous fair use | Generous fair use | Generous fair use |
+| **Live Rooms hosting time** | 40 minutes per month | 5 hours per month | 25 hours per month | 100 hours per month |
+| **Find-a-Match posts** | 3 per month | 20 per month | 100 per month | 400 per month |
+| **Find-a-Match reveals** | 5 per week | 50 per month | 250 per month | 1,000 per month |
+| **Lab analysis** | 1 per month | 5 per month | 25 per month | 100 per month |
+| **Photo uploads** | 5 per month | 50 per month | 250 per month | 1,000 per month |
+| **Secure storage** | 100 MB | 5 GB | 25 GB | 100 GB |
+| **AI-generated digests** | Weekly | Daily | Daily, plus on-demand | Daily, on-demand, custom |
+| **Sell and Earn catalog** | 5 items | 25 items | 100 items | 1,000 items |
+| **Priority practitioner access** | -- | Yes | Yes | Yes |
+
+If you exhaust a quota and want a little more, you can add extra credits any time. One credit equals one cent of value. Five credits buys one extra minute of live voice; one credit buys one extra minute of room hosting; ten credits unlocks one extra Find-a-Match reveal.
 
 ## How to Subscribe
 

--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -1,5 +1,6 @@
 // Vitana Dev Frontend Spec v2 Implementation - Task 3
 // AUTODEPLOY-TRIGGER: 2025-12-20T14:00:00Z
+// DEV-COMHU-03107: Billing v1 — admin Billing Codes + Billing Dashboard tabs
 
 // VTID-0539: Operator Console Chat Experience Improvements
 // DEV-COMHU-2025-0012: Task Management v1 - Persisted Specs + Lifecycle + Approvals

--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -2715,7 +2715,8 @@ const NAVIGATION_CONFIG = [
             { "key": "identity-access", "path": "/command-hub/admin/identity-access/" },
             { "key": "marketplace-shops", "path": "/command-hub/admin/marketplace-shops/" },
             { "key": "marketplace-review", "path": "/command-hub/admin/marketplace-review/" },
-            { "key": "analytics", "path": "/command-hub/admin/analytics/" }
+            { "key": "analytics", "path": "/command-hub/admin/analytics/" },
+            { "key": "billing-codes", "label": "Billing Codes", "path": "/command-hub/admin/billing-codes/" }
         ]
     },
     {
@@ -6256,6 +6257,9 @@ function renderModuleContent(moduleKey, tab) {
     } else if (moduleKey === 'admin' && tab === 'marketplace-review') {
         // VTID-02000: Admin Marketplace Review Queue - approve/reject flagged products
         container.appendChild(renderAdminMarketplaceReviewView());
+    } else if (moduleKey === 'admin' && tab === 'billing-codes') {
+        // VTID-03107: Billing v1 admin — redemption code generation + listing
+        container.appendChild(renderAdminBillingCodesView());
     } else if (moduleKey === 'agents' && tab === 'registered-agents') {
         // VTID-01173: Agents Control Plane v1 - Registered Agents (Worker Orchestrator)
         container.appendChild(renderRegisteredAgentsView());
@@ -11428,6 +11432,261 @@ async function triggerMarketplaceSync(network) {
         console.error('[VTID-02000] sync failed:', err);
         showToast('Sync failed: ' + err.message, 'error');
     }
+}
+
+// =============================================================================
+// VTID-03107 · Billing v1 — admin redemption-code management
+// =============================================================================
+// Operator tab at /command-hub/admin/billing-codes/.
+//
+// Lets ops:
+//   - Bulk-generate unique-per-user codes for a campaign (test cohort pattern,
+//     365-day default). Downloads CSV for distribution.
+//   - View existing codes per campaign with usage stats.
+//   - Deactivate a code instantly (leak response).
+//
+// Reads/writes via the routes shipped in PR-2 (routes/billing.ts):
+//   POST /api/v1/billing/admin/redemption-codes/generate
+//   GET  /api/v1/billing/admin/redemption-codes
+//   PATCH /api/v1/billing/admin/redemption-codes/:code
+// =============================================================================
+
+async function fetchAdminBillingCodes(campaign) {
+    state.adminBillingCodesLoading = true;
+    try {
+        var url = '/api/v1/billing/admin/redemption-codes?include_codes=true' +
+            (campaign ? '&campaign=' + encodeURIComponent(campaign) : '') +
+            '&limit=200';
+        var resp = await fetch(url, { method: 'GET', headers: buildContextHeaders() });
+        var json = await resp.json();
+        if (!resp.ok || !json.ok) throw new Error(json.error || ('HTTP ' + resp.status));
+        state.adminBillingCodes = json.codes || [];
+        state.adminBillingCodesError = null;
+    } catch (err) {
+        console.error('[VTID-03107] fetch billing codes failed:', err);
+        state.adminBillingCodes = [];
+        state.adminBillingCodesError = String(err && err.message ? err.message : err);
+    } finally {
+        state.adminBillingCodesLoading = false;
+        renderApp();
+    }
+}
+
+async function generateAdminBillingCodes(payload) {
+    try {
+        var resp = await fetch('/api/v1/billing/admin/redemption-codes/generate', {
+            method: 'POST',
+            headers: Object.assign({ 'Content-Type': 'application/json' }, buildContextHeaders()),
+            body: JSON.stringify(payload),
+        });
+        var json = await resp.json();
+        if (!resp.ok || !json.ok) throw new Error(json.error || ('HTTP ' + resp.status));
+        state.adminBillingLastBatch = json;
+        await fetchAdminBillingCodes(null);
+        return json;
+    } catch (err) {
+        console.error('[VTID-03107] generate codes failed:', err);
+        state.adminBillingError = String(err && err.message ? err.message : err);
+        renderApp();
+        throw err;
+    }
+}
+
+async function deactivateAdminBillingCode(code) {
+    try {
+        var resp = await fetch('/api/v1/billing/admin/redemption-codes/' + encodeURIComponent(code), {
+            method: 'PATCH',
+            headers: Object.assign({ 'Content-Type': 'application/json' }, buildContextHeaders()),
+            body: JSON.stringify({ is_active: false }),
+        });
+        var json = await resp.json();
+        if (!resp.ok || !json.ok) throw new Error(json.error || ('HTTP ' + resp.status));
+        await fetchAdminBillingCodes(null);
+    } catch (err) {
+        console.error('[VTID-03107] deactivate code failed:', err);
+        alert('Deactivate failed: ' + err.message);
+    }
+}
+
+function downloadCodesAsCsv(codes, campaign) {
+    var header = 'code,campaign,grants_plan,grant_duration_days,deep_link\n';
+    var origin = (window.location.origin || '').replace(/\/$/, '');
+    var rows = codes.map(function (c) {
+        var code = (c.code || '').replace(/"/g, '""');
+        var deepLink = origin + '/redeem?code=' + encodeURIComponent(c.code);
+        return [
+            '"' + code + '"',
+            '"' + (campaign || '') + '"',
+            '"' + (c.grants_plan || 'premium') + '"',
+            (c.grant_duration_days || 365),
+            '"' + deepLink + '"',
+        ].join(',');
+    }).join('\n');
+    var blob = new Blob([header + rows], { type: 'text/csv;charset=utf-8' });
+    var url = URL.createObjectURL(blob);
+    var a = document.createElement('a');
+    a.href = url;
+    a.download = 'vitana-codes-' + (campaign || 'batch') + '-' + Date.now() + '.csv';
+    document.body.appendChild(a);
+    a.click();
+    document.body.removeChild(a);
+    setTimeout(function () { URL.revokeObjectURL(url); }, 1000);
+}
+
+function renderAdminBillingCodesView() {
+    var container = document.createElement('div');
+    container.className = 'admin-screen-container';
+
+    if (!state.adminBillingCodes && !state.adminBillingCodesLoading) {
+        fetchAdminBillingCodes(null);
+    }
+
+    var header = document.createElement('div');
+    header.className = 'admin-screen-header';
+    header.innerHTML = '<h2>Billing Codes (VTID-03107)</h2>' +
+        '<p class="admin-screen-subtitle">Generate redemption codes for test cohorts and special campaigns. ' +
+        'The public FOUNDING code is managed via SQL (see migration 6). All grants decrement the marketing budget cap.</p>';
+    container.appendChild(header);
+
+    // ── Generation form ────────────────────────────────────────────────────
+    var formCard = document.createElement('div');
+    formCard.className = 'admin-form-card';
+    formCard.style.cssText = 'background:#1e293b;border:1px solid #334155;border-radius:8px;padding:1rem;margin-bottom:1rem;';
+    formCard.innerHTML =
+        '<h3 style="margin:0 0 0.75rem;font-size:14px;">Generate codes</h3>' +
+        '<div style="display:grid;grid-template-columns:1fr 1fr 1fr 1fr auto;gap:0.5rem;align-items:end;">' +
+        '  <div><label style="display:block;font-size:11px;color:#94a3b8;margin-bottom:0.25rem;">Campaign name</label>' +
+        '    <input id="vtid-03107-campaign" type="text" placeholder="test_cohort_2026Q2" ' +
+        '      style="width:100%;padding:0.4rem;background:#0f172a;border:1px solid #475569;border-radius:4px;color:#e2e8f0;" /></div>' +
+        '  <div><label style="display:block;font-size:11px;color:#94a3b8;margin-bottom:0.25rem;">Count</label>' +
+        '    <input id="vtid-03107-count" type="number" min="1" max="1000" value="100" ' +
+        '      style="width:100%;padding:0.4rem;background:#0f172a;border:1px solid #475569;border-radius:4px;color:#e2e8f0;" /></div>' +
+        '  <div><label style="display:block;font-size:11px;color:#94a3b8;margin-bottom:0.25rem;">Days granted</label>' +
+        '    <input id="vtid-03107-days" type="number" min="1" max="730" value="365" ' +
+        '      style="width:100%;padding:0.4rem;background:#0f172a;border:1px solid #475569;border-radius:4px;color:#e2e8f0;" /></div>' +
+        '  <div><label style="display:block;font-size:11px;color:#94a3b8;margin-bottom:0.25rem;">Plan</label>' +
+        '    <select id="vtid-03107-plan" style="width:100%;padding:0.4rem;background:#0f172a;border:1px solid #475569;border-radius:4px;color:#e2e8f0;">' +
+        '      <option value="premium">premium</option>' +
+        '      <option value="premium_5x">premium_5x (Host)</option>' +
+        '      <option value="premium_20x">premium_20x (Community)</option>' +
+        '    </select></div>' +
+        '  <button id="vtid-03107-generate" class="primary-btn" style="padding:0.5rem 1rem;background:#10b981;color:#0f172a;border:none;border-radius:4px;font-weight:600;cursor:pointer;">Generate</button>' +
+        '</div>' +
+        '<p style="margin:0.5rem 0 0;font-size:11px;color:#64748b;">Codes are unique-per-user (max_uses=1). For shared marketing codes, edit redemption_codes directly via SQL.</p>';
+    container.appendChild(formCard);
+
+    formCard.querySelector('#vtid-03107-generate').addEventListener('click', async function () {
+        var campaign = formCard.querySelector('#vtid-03107-campaign').value.trim();
+        var count = parseInt(formCard.querySelector('#vtid-03107-count').value, 10) || 0;
+        var days = parseInt(formCard.querySelector('#vtid-03107-days').value, 10) || 365;
+        var plan = formCard.querySelector('#vtid-03107-plan').value;
+        if (!campaign) { alert('Campaign name required'); return; }
+        if (count < 1 || count > 1000) { alert('Count must be 1–1000'); return; }
+        try {
+            var result = await generateAdminBillingCodes({
+                campaign: campaign, count: count, grant_duration_days: days, grants_plan: plan,
+            });
+            downloadCodesAsCsv(result.codes || [], campaign);
+            alert('Generated ' + (result.generated || 0) + ' codes for campaign "' + campaign + '". CSV downloaded.');
+        } catch (e) { /* error already alerted via state */ }
+    });
+
+    // ── Last-batch quick view ──────────────────────────────────────────────
+    if (state.adminBillingLastBatch) {
+        var batch = state.adminBillingLastBatch;
+        var batchCard = document.createElement('div');
+        batchCard.style.cssText = 'background:#064e3b;border:1px solid #10b981;border-radius:8px;padding:1rem;margin-bottom:1rem;color:#d1fae5;';
+        batchCard.innerHTML = '<strong>Last batch:</strong> ' + (batch.generated || 0) +
+            ' codes generated for campaign "' + escapeHtml(batch.campaign || '') + '" ' +
+            '(plan=' + escapeHtml(batch.grants_plan || '') + ', ' + (batch.grant_duration_days || '?') + ' days each). ' +
+            'CSV downloaded. Distribute to recipients individually.';
+        container.appendChild(batchCard);
+    }
+
+    // ── Existing codes table ───────────────────────────────────────────────
+    var listCard = document.createElement('div');
+    listCard.className = 'admin-list-container';
+    listCard.style.cssText = 'background:#1e293b;border:1px solid #334155;border-radius:8px;padding:1rem;';
+
+    var listHeader = document.createElement('div');
+    listHeader.style.cssText = 'display:flex;justify-content:space-between;align-items:center;margin-bottom:0.75rem;';
+    listHeader.innerHTML = '<h3 style="margin:0;font-size:14px;">Recent codes (latest 200)</h3>' +
+        '<button id="vtid-03107-refresh" style="padding:0.25rem 0.75rem;background:#334155;color:#e2e8f0;border:1px solid #475569;border-radius:4px;cursor:pointer;font-size:12px;">↻ Refresh</button>';
+    listCard.appendChild(listHeader);
+    listHeader.querySelector('#vtid-03107-refresh').addEventListener('click', function () {
+        state.adminBillingCodes = null;
+        state.adminBillingCodesError = null;
+        fetchAdminBillingCodes(null);
+    });
+
+    if (state.adminBillingCodesLoading) {
+        var loading = document.createElement('p');
+        loading.textContent = 'Loading…';
+        loading.style.color = '#94a3b8';
+        listCard.appendChild(loading);
+    } else if (state.adminBillingCodesError) {
+        var errEl = document.createElement('p');
+        errEl.textContent = 'Error: ' + state.adminBillingCodesError;
+        errEl.style.color = '#ef4444';
+        listCard.appendChild(errEl);
+    } else if (!state.adminBillingCodes || state.adminBillingCodes.length === 0) {
+        var empty = document.createElement('p');
+        empty.textContent = 'No codes generated yet. Use the form above.';
+        empty.style.color = '#94a3b8';
+        listCard.appendChild(empty);
+    } else {
+        var table = document.createElement('table');
+        table.className = 'list-table';
+        table.style.cssText = 'width:100%;border-collapse:collapse;font-size:12px;';
+        table.innerHTML =
+            '<thead><tr style="border-bottom:1px solid #334155;">' +
+            '<th style="text-align:left;padding:0.5rem;">Code</th>' +
+            '<th style="text-align:left;padding:0.5rem;">Campaign</th>' +
+            '<th style="text-align:left;padding:0.5rem;">Plan</th>' +
+            '<th style="text-align:right;padding:0.5rem;">Days</th>' +
+            '<th style="text-align:right;padding:0.5rem;">Used</th>' +
+            '<th style="text-align:center;padding:0.5rem;">Active</th>' +
+            '<th style="text-align:left;padding:0.5rem;">Created</th>' +
+            '<th></th>' +
+            '</tr></thead>';
+        var tbody = document.createElement('tbody');
+        state.adminBillingCodes.forEach(function (c) {
+            var tr = document.createElement('tr');
+            tr.style.cssText = 'border-bottom:1px solid #1e293b;';
+            var usagePct = c.max_uses > 0 ? Math.round((c.uses_count / c.max_uses) * 100) : 0;
+            var usedColor = usagePct >= 100 ? '#ef4444' : usagePct >= 80 ? '#f59e0b' : '#10b981';
+            tr.innerHTML =
+                '<td style="padding:0.5rem;font-family:monospace;">' + escapeHtml(c.code) + '</td>' +
+                '<td style="padding:0.5rem;">' + escapeHtml(c.campaign) + '</td>' +
+                '<td style="padding:0.5rem;">' + escapeHtml(c.grants_plan) + '</td>' +
+                '<td style="padding:0.5rem;text-align:right;">' + (c.grant_duration_days || '?') + '</td>' +
+                '<td style="padding:0.5rem;text-align:right;color:' + usedColor + ';">' +
+                  (c.uses_count || 0) + ' / ' + (c.max_uses || 0) + '</td>' +
+                '<td style="padding:0.5rem;text-align:center;">' + (c.is_active ? '✓' : '✗') + '</td>' +
+                '<td style="padding:0.5rem;color:#94a3b8;">' +
+                  (c.created_at ? new Date(c.created_at).toISOString().slice(0, 10) : '') + '</td>' +
+                '<td style="padding:0.5rem;text-align:right;">' +
+                  (c.is_active ? '<button class="deactivate-btn" data-code="' + escapeHtml(c.code) +
+                    '" style="padding:0.25rem 0.5rem;background:#7f1d1d;color:#fecaca;border:none;border-radius:4px;cursor:pointer;font-size:11px;">Deactivate</button>' : '') +
+                '</td>';
+            tbody.appendChild(tr);
+        });
+        table.appendChild(tbody);
+        listCard.appendChild(table);
+
+        // Wire deactivate buttons
+        listCard.querySelectorAll('.deactivate-btn').forEach(function (btn) {
+            btn.addEventListener('click', function () {
+                var code = btn.getAttribute('data-code');
+                if (confirm('Deactivate code "' + code + '"? This is reversible via SQL.')) {
+                    deactivateAdminBillingCode(code);
+                }
+            });
+        });
+    }
+    container.appendChild(listCard);
+
+    return container;
 }
 
 function renderAdminMarketplaceShopsView() {

--- a/services/gateway/src/frontend/command-hub/app.js
+++ b/services/gateway/src/frontend/command-hub/app.js
@@ -2716,6 +2716,7 @@ const NAVIGATION_CONFIG = [
             { "key": "marketplace-shops", "path": "/command-hub/admin/marketplace-shops/" },
             { "key": "marketplace-review", "path": "/command-hub/admin/marketplace-review/" },
             { "key": "analytics", "path": "/command-hub/admin/analytics/" },
+            { "key": "billing-dashboard", "label": "Billing", "path": "/command-hub/admin/billing-dashboard/" },
             { "key": "billing-codes", "label": "Billing Codes", "path": "/command-hub/admin/billing-codes/" }
         ]
     },
@@ -6257,6 +6258,9 @@ function renderModuleContent(moduleKey, tab) {
     } else if (moduleKey === 'admin' && tab === 'marketplace-review') {
         // VTID-02000: Admin Marketplace Review Queue - approve/reject flagged products
         container.appendChild(renderAdminMarketplaceReviewView());
+    } else if (moduleKey === 'admin' && tab === 'billing-dashboard') {
+        // VTID-03107: Billing v1 operator dashboard — MRR / paywall funnel / code redemptions / voice degrade
+        container.appendChild(renderAdminBillingDashboardView());
     } else if (moduleKey === 'admin' && tab === 'billing-codes') {
         // VTID-03107: Billing v1 admin — redemption code generation + listing
         container.appendChild(renderAdminBillingCodesView());
@@ -11432,6 +11436,203 @@ async function triggerMarketplaceSync(network) {
         console.error('[VTID-02000] sync failed:', err);
         showToast('Sync failed: ' + err.message, 'error');
     }
+}
+
+// =============================================================================
+// VTID-03107 · Billing v1 — operator dashboard
+// =============================================================================
+// Operator tab at /command-hub/admin/billing-dashboard/.
+//
+// Renders KPIs from GET /api/v1/billing/admin/metrics:
+//   - MRR / ARR (€ from active + trialing subs)
+//   - Subscription counts by plan
+//   - Paywall funnel (30d): shown / upgraded / credit_paid /
+//     deferred_for_vulnerability / degraded
+//   - Code redemptions by campaign (30d)
+//   - Voice degrade events (7d)
+//   - Marketing budget remaining (cents)
+//
+// Read-only. All numbers from the live schema; no caching beyond the
+// 60-second auto-refresh.
+// =============================================================================
+
+async function fetchAdminBillingMetrics() {
+    state.adminBillingMetricsLoading = true;
+    try {
+        var resp = await fetch('/api/v1/billing/admin/metrics', {
+            method: 'GET', headers: buildContextHeaders(),
+        });
+        var json = await resp.json();
+        if (!resp.ok || !json.ok) throw new Error(json.error || ('HTTP ' + resp.status));
+        state.adminBillingMetrics = json;
+        state.adminBillingMetricsError = null;
+    } catch (err) {
+        console.error('[VTID-03107] fetch metrics failed:', err);
+        state.adminBillingMetrics = null;
+        state.adminBillingMetricsError = String(err && err.message ? err.message : err);
+    } finally {
+        state.adminBillingMetricsLoading = false;
+        renderApp();
+    }
+}
+
+function formatEur(cents) {
+    if (typeof cents !== 'number') return '–';
+    return '€' + (cents / 100).toLocaleString('en-US', { minimumFractionDigits: 2, maximumFractionDigits: 2 });
+}
+
+function renderAdminBillingDashboardView() {
+    var container = document.createElement('div');
+    container.className = 'admin-screen-container';
+
+    if (!state.adminBillingMetrics && !state.adminBillingMetricsLoading) {
+        fetchAdminBillingMetrics();
+    }
+
+    var header = document.createElement('div');
+    header.className = 'admin-screen-header';
+    header.innerHTML = '<h2>Billing Dashboard (VTID-03107)</h2>' +
+        '<p class="admin-screen-subtitle">Live KPIs from user_subscriptions + paywall_events + redemption_redemptions. ' +
+        'Refreshes manually via the button.</p>';
+    container.appendChild(header);
+
+    var refreshBar = document.createElement('div');
+    refreshBar.style.cssText = 'margin-bottom:1rem;';
+    refreshBar.innerHTML = '<button id="vtid-03107-metrics-refresh" style="padding:0.5rem 1rem;background:#334155;color:#e2e8f0;border:1px solid #475569;border-radius:4px;cursor:pointer;font-size:13px;">↻ Refresh</button>';
+    container.appendChild(refreshBar);
+    refreshBar.querySelector('#vtid-03107-metrics-refresh').addEventListener('click', function () {
+        state.adminBillingMetrics = null;
+        state.adminBillingMetricsError = null;
+        fetchAdminBillingMetrics();
+    });
+
+    if (state.adminBillingMetricsLoading) {
+        var loading = document.createElement('p');
+        loading.textContent = 'Loading metrics…';
+        loading.style.color = '#94a3b8';
+        container.appendChild(loading);
+        return container;
+    }
+
+    if (state.adminBillingMetricsError) {
+        var errEl = document.createElement('p');
+        errEl.textContent = 'Error: ' + state.adminBillingMetricsError;
+        errEl.style.color = '#ef4444';
+        container.appendChild(errEl);
+        return container;
+    }
+
+    var m = state.adminBillingMetrics;
+    if (!m) {
+        var emptyEl = document.createElement('p');
+        emptyEl.textContent = 'No metrics yet.';
+        emptyEl.style.color = '#94a3b8';
+        container.appendChild(emptyEl);
+        return container;
+    }
+
+    // ── KPI card grid ──────────────────────────────────────────────────────
+    var grid = document.createElement('div');
+    grid.style.cssText = 'display:grid;grid-template-columns:repeat(auto-fill,minmax(220px,1fr));gap:1rem;margin-bottom:1.5rem;';
+
+    function kpiCard(label, value, accent) {
+        var card = document.createElement('div');
+        card.style.cssText = 'background:#1e293b;border:1px solid #334155;border-left:4px solid ' + (accent || '#475569') +
+            ';border-radius:6px;padding:1rem;';
+        card.innerHTML = '<div style="font-size:11px;color:#94a3b8;text-transform:uppercase;letter-spacing:0.05em;margin-bottom:0.25rem;">' +
+            escapeHtml(label) + '</div>' +
+            '<div style="font-size:24px;font-weight:600;color:#e2e8f0;">' + escapeHtml(String(value)) + '</div>';
+        return card;
+    }
+
+    grid.appendChild(kpiCard('MRR', formatEur(m.revenue.mrr_cents), '#10b981'));
+    grid.appendChild(kpiCard('ARR', formatEur(m.revenue.arr_cents), '#10b981'));
+    grid.appendChild(kpiCard('Active + Trialing', m.subscriptions.total_active_or_trialing, '#3b82f6'));
+    grid.appendChild(kpiCard('Voice Degrades (7d)', m.voice_degrade_count_7d, '#f59e0b'));
+    grid.appendChild(kpiCard('Marketing Budget Left',
+        m.marketing_budget_remaining_cents !== null ? formatEur(m.marketing_budget_remaining_cents) : 'not set',
+        '#a855f7'));
+
+    container.appendChild(grid);
+
+    // ── Subs by plan ───────────────────────────────────────────────────────
+    var planCard = document.createElement('div');
+    planCard.style.cssText = 'background:#1e293b;border:1px solid #334155;border-radius:8px;padding:1rem;margin-bottom:1rem;';
+    var planHtml = '<h3 style="margin:0 0 0.5rem;font-size:14px;">Subscriptions by plan</h3>';
+    var planRows = '<table style="width:100%;border-collapse:collapse;font-size:13px;">' +
+        '<thead><tr style="border-bottom:1px solid #334155;"><th style="text-align:left;padding:0.5rem;">Plan</th>' +
+        '<th style="text-align:right;padding:0.5rem;">Total</th>' +
+        '<th style="text-align:right;padding:0.5rem;">Trialing</th></tr></thead><tbody>';
+    var planKeys = Object.keys(m.subscriptions.by_plan || {});
+    if (planKeys.length === 0) {
+        planRows += '<tr><td colspan="3" style="padding:0.5rem;color:#64748b;">No subscriptions yet.</td></tr>';
+    } else {
+        planKeys.forEach(function (k) {
+            planRows += '<tr style="border-bottom:1px solid #1e293b;">' +
+                '<td style="padding:0.5rem;font-family:monospace;">' + escapeHtml(k) + '</td>' +
+                '<td style="padding:0.5rem;text-align:right;">' + (m.subscriptions.by_plan[k] || 0) + '</td>' +
+                '<td style="padding:0.5rem;text-align:right;color:#94a3b8;">' + (m.subscriptions.trialing_by_plan[k] || 0) + '</td>' +
+                '</tr>';
+        });
+    }
+    planRows += '</tbody></table>';
+    planCard.innerHTML = planHtml + planRows;
+    container.appendChild(planCard);
+
+    // ── Paywall funnel (30d) ───────────────────────────────────────────────
+    var funnelCard = document.createElement('div');
+    funnelCard.style.cssText = 'background:#1e293b;border:1px solid #334155;border-radius:8px;padding:1rem;margin-bottom:1rem;';
+    funnelCard.innerHTML = '<h3 style="margin:0 0 0.5rem;font-size:14px;">Paywall funnel (last 30 days)</h3>';
+    var funnel = m.paywall_funnel_30d || {};
+    var funnelKeys = ['shown', 'upgraded', 'credit_paid', 'deferred_for_vulnerability', 'degraded', 'redeemed', 'rejected', 'soft_counter_reached'];
+    var funnelGrid = document.createElement('div');
+    funnelGrid.style.cssText = 'display:grid;grid-template-columns:repeat(auto-fill,minmax(160px,1fr));gap:0.5rem;';
+    funnelKeys.forEach(function (k) {
+        if ((funnel[k] || 0) === 0) return; // hide empty
+        var stage = document.createElement('div');
+        stage.style.cssText = 'background:#0f172a;padding:0.5rem;border-radius:4px;border-top:3px solid ' +
+            (k === 'upgraded' || k === 'credit_paid' ? '#10b981' :
+             k === 'deferred_for_vulnerability' ? '#a855f7' :
+             k === 'degraded' ? '#f59e0b' :
+             k === 'rejected' ? '#ef4444' : '#475569') + ';';
+        stage.innerHTML = '<div style="font-size:10px;color:#94a3b8;text-transform:uppercase;">' + k + '</div>' +
+            '<div style="font-size:20px;font-weight:600;">' + (funnel[k] || 0) + '</div>';
+        funnelGrid.appendChild(stage);
+    });
+    funnelCard.appendChild(funnelGrid);
+    container.appendChild(funnelCard);
+
+    // ── Redemptions by campaign (30d) ──────────────────────────────────────
+    var redemptions = m.redemptions_30d || {};
+    var campaignKeys = Object.keys(redemptions);
+    if (campaignKeys.length > 0) {
+        var rdCard = document.createElement('div');
+        rdCard.style.cssText = 'background:#1e293b;border:1px solid #334155;border-radius:8px;padding:1rem;';
+        var rdHtml = '<h3 style="margin:0 0 0.5rem;font-size:14px;">Code redemptions (last 30 days)</h3>' +
+            '<table style="width:100%;border-collapse:collapse;font-size:13px;">' +
+            '<thead><tr style="border-bottom:1px solid #334155;">' +
+            '<th style="text-align:left;padding:0.5rem;">Campaign</th>' +
+            '<th style="text-align:right;padding:0.5rem;">Redemptions</th>' +
+            '<th style="text-align:right;padding:0.5rem;">Foregone revenue</th>' +
+            '</tr></thead><tbody>';
+        campaignKeys.forEach(function (c) {
+            rdHtml += '<tr style="border-bottom:1px solid #1e293b;">' +
+                '<td style="padding:0.5rem;font-family:monospace;">' + escapeHtml(c) + '</td>' +
+                '<td style="padding:0.5rem;text-align:right;">' + redemptions[c].count + '</td>' +
+                '<td style="padding:0.5rem;text-align:right;color:#a855f7;">' + formatEur(redemptions[c].grant_value_cents) + '</td>' +
+                '</tr>';
+        });
+        rdHtml += '</tbody></table>';
+        rdCard.innerHTML = rdHtml;
+        container.appendChild(rdCard);
+    }
+
+    var footer = document.createElement('p');
+    footer.style.cssText = 'margin-top:1rem;font-size:11px;color:#64748b;';
+    footer.textContent = 'Generated at ' + (m.generated_at || '?');
+    container.appendChild(footer);
+
+    return container;
 }
 
 // =============================================================================

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -1354,6 +1354,15 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
         console.warn('⚠️ Autopilot heartbeat loop initialization failed (non-fatal):', error);
       }
 
+      // VTID-03107: Billing v1 — trial lifecycle notification worker.
+      // Polls lifecycle_notification_state every 5min, fans out via notifyUserAsync.
+      try {
+        const { startLifecycleNotificationWorker } = require('./services/lifecycle-notification-worker');
+        startLifecycleNotificationWorker();
+      } catch (error) {
+        console.warn('⚠️ Lifecycle notification worker startup failed (non-fatal):', error);
+      }
+
       // VTID-01185: Initialize recommendation scheduler (autonomous self-improvement)
       try {
         const { startScheduler } = require('./services/recommendation-engine/scheduler');

--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -300,6 +300,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   // VTID-01231: Stripe Connect Express Backend
   const creatorsRouter = require('./routes/creators').default;
   const stripeConnectWebhookRouter = require('./routes/stripe-connect-webhook').default;
+  // VTID-03107: Billing v1 — customer-side Stripe subscriptions + credit packs + redemption
+  const billingRouter = require('./routes/billing').default;
   // Notification System — FCM push + in-app notification history
   const notificationsRouter = require('./routes/notifications').default;
   // Chat — User-to-user direct messaging
@@ -414,8 +416,10 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   setupCors(app);
   app.use(sseHeaders);
 
-  // VTID-01230: Raw body parser for Stripe webhooks (MUST come BEFORE express.json())
+  // VTID-01230: Raw body parser for Stripe Connect webhooks (MUST come BEFORE express.json())
   app.use('/api/v1/stripe/webhook', express.raw({ type: 'application/json' }));
+  // VTID-03107: Raw body parser for customer-side Stripe billing webhook (separate signing secret)
+  app.use('/api/v1/billing/webhooks/stripe', express.raw({ type: 'application/json' }));
 
   // Middleware - IMPORTANT: JSON body parser must come before route handlers
   app.use(express.json({ limit: '2mb' }));
@@ -985,6 +989,8 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   // VTID-01231: Stripe Connect Express Backend
   mountRouterSync(app, '/api/v1/creators', creatorsRouter, { owner: 'creators' });
   mountRouterSync(app, '/api/v1/stripe', stripeConnectWebhookRouter, { owner: 'stripe-connect-webhook' });
+  // VTID-03107: Billing v1 — customer-side Stripe + redemption codes + admin code mgmt
+  mountRouterSync(app, '/api/v1/billing', billingRouter, { owner: 'billing' });
 
   // Notification System — FCM push notifications + in-app history
   mountRouterSync(app, '/api/v1/notifications', notificationsRouter, { owner: 'notifications' });

--- a/services/gateway/src/middleware/paywall.ts
+++ b/services/gateway/src/middleware/paywall.ts
@@ -150,6 +150,8 @@ export function requireEntitlement(
         used: 0,
         remaining: -1,
         reset_at: null,
+        windows: [],
+        binding_window: 'monthly',
         credit_cost_per_unit: 0,
         user_credit_balance: 0,
         allowed_burn_buckets: ['purchased_credits'] as WalletBucket[],

--- a/services/gateway/src/middleware/paywall.ts
+++ b/services/gateway/src/middleware/paywall.ts
@@ -1,0 +1,216 @@
+/**
+ * VTID-03107 · Billing v1 — Paywall middleware
+ *
+ * Express middleware factory used by every gated route to short-circuit
+ * with HTTP 402 when the user has no remaining entitlement.
+ *
+ * Usage in a route file:
+ *
+ *   import { requireEntitlement } from '../middleware/paywall';
+ *
+ *   router.post('/intents',
+ *     requireAuth,
+ *     requireEntitlement('match_posts'),
+ *     async (req, res) => {
+ *       // handler runs only if req.entitlement.paywall_action ∈ {allow, soft_counter, deferred, degrade}
+ *       const handlerResult = await createIntent(...);
+ *       // for the 'allow' / 'soft_counter' / 'degrade' / 'deferred' paths,
+ *       // call recordUsage AFTER the handler succeeds:
+ *       if (req.entitlement.paywall_action !== 'deferred') {
+ *         await recordUsage(...);
+ *       }
+ *       res.json({ ok: true, ... });
+ *     }
+ *   );
+ *
+ * Response shape on 402 (paywall / hard_block):
+ *
+ *   {
+ *     "error": "payment_required",
+ *     "paywall": {
+ *       "feature": "voice_live_minutes",
+ *       "tier": "free",
+ *       "quota": 15,
+ *       "used": 15,
+ *       "remaining": 0,
+ *       "reset_at": "2026-06-25T00:00:00Z",
+ *       "credit_cost_per_unit": 5,
+ *       "user_credit_balance": 250,
+ *       "allowed_burn_buckets": ["purchased_credits"],
+ *       "credit_option": {
+ *         "cost_per_unit": 5,
+ *         "balance": 250,
+ *         "balance_sufficient_for_one_unit": true,
+ *         "endpoint": "/api/v1/billing/credits/spend"
+ *       } | null,
+ *       "upgrade_url": "/api/v1/billing/checkout/subscription",
+ *       "deferred_for_vulnerability": false
+ *     }
+ *   }
+ *
+ * D36-aware: when checkEntitlement returns paywall_action='deferred', this
+ * middleware silently sets `req.entitlement` and calls next(). The handler
+ * MUST treat deferred as "allowed but do not increment usage and do not show
+ * a paywall to the user."
+ */
+
+import type { Response, NextFunction } from 'express';
+import type { AuthenticatedRequest } from './auth-supabase-jwt';
+import {
+  checkEntitlement,
+  type CheckResult,
+  type WalletBucket,
+} from '../services/entitlement-service';
+
+// Augment AuthenticatedRequest with the entitlement result. Handlers can read
+// req.entitlement.quota / .used / .remaining / .paywall_action to render the
+// progress indicator + decide whether to degrade.
+
+declare module 'express' {
+  // eslint-disable-next-line @typescript-eslint/no-empty-interface
+  interface Request {
+    entitlement?: CheckResult;
+  }
+}
+
+const VTID = 'VTID-03107';
+const LOG_PREFIX = '[paywall-middleware]';
+
+const SUBSCRIPTION_UPGRADE_URL = '/api/v1/billing/checkout/subscription';
+const CREDIT_SPEND_URL          = '/api/v1/billing/credits/spend';
+
+export interface RequireEntitlementOpts {
+  /**
+   * Requested amount (default 1). For `unit='minutes'` features the caller
+   * may pass a non-1 value (e.g. start-of-session reserves 1 minute up front).
+   */
+  amount?: number;
+
+  /**
+   * Skip D36 deferral hook — for admin/system flows that should NEVER be
+   * deferred. Default false.
+   */
+  skipD36?: boolean;
+
+  /**
+   * Custom session_id for D36 history tracking. If absent, the middleware
+   * uses req.sessionId (which various existing routes set) or undefined.
+   */
+  sessionIdGetter?: (req: AuthenticatedRequest) => string | undefined;
+}
+
+export function requireEntitlement(
+  feature: string,
+  opts: RequireEntitlementOpts = {}
+) {
+  return async function paywallGate(
+    req: AuthenticatedRequest,
+    res: Response,
+    next: NextFunction
+  ): Promise<void> {
+    const identity = req.identity;
+    if (!identity?.user_id || !identity?.tenant_id) {
+      // Auth middleware should have already enforced this; defense in depth.
+      res.status(401).json({ ok: false, error: 'UNAUTHENTICATED', feature, vtid: VTID });
+      return;
+    }
+
+    // Extract bearer token for D36 (it needs the user JWT to read their
+    // personal monetization signals under RLS).
+    const authHeader = req.headers.authorization || '';
+    const authToken = authHeader.startsWith('Bearer ')
+      ? authHeader.slice(7)
+      : undefined;
+
+    const sessionId =
+      opts.sessionIdGetter?.(req) ??
+      (req as any).sessionId ??
+      (req.headers['x-session-id'] as string | undefined);
+
+    let result: CheckResult;
+    try {
+      result = await checkEntitlement(identity.user_id, identity.tenant_id, feature, {
+        amount: opts.amount,
+        sessionId,
+        authToken,
+        skipD36: opts.skipD36,
+      });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`${LOG_PREFIX} checkEntitlement crash for user=${identity.user_id} feature=${feature}: ${message}`);
+      // Fail open to a soft path — return 200 with a degraded entitlement
+      // marker. We never block the request on infrastructure failure (users
+      // get a worse experience than 402-paywall when we have a bug).
+      req.entitlement = {
+        allowed: true,
+        paywall_action: 'allow',
+        feature,
+        tier: 'unknown',
+        quota: -1,
+        used: 0,
+        remaining: -1,
+        reset_at: null,
+        credit_cost_per_unit: 0,
+        user_credit_balance: 0,
+        allowed_burn_buckets: ['purchased_credits'] as WalletBucket[],
+        deferred_for_vulnerability: false,
+      };
+      next();
+      return;
+    }
+
+    // Attach result to req so handlers can read quota/used/remaining + branch
+    // on paywall_action='degrade' to switch behavior.
+    req.entitlement = result;
+
+    // allow / soft_counter / degrade / deferred → handler runs
+    if (
+      result.paywall_action === 'allow' ||
+      result.paywall_action === 'soft_counter' ||
+      result.paywall_action === 'degrade' ||
+      result.paywall_action === 'deferred'
+    ) {
+      next();
+      return;
+    }
+
+    // paywall / hard_block → 402 with structured body
+    const isHardBlock = result.paywall_action === 'hard_block';
+    const canPayWithCredits =
+      !isHardBlock &&
+      result.credit_cost_per_unit > 0 &&
+      result.allowed_burn_buckets.length > 0;
+    const creditOption = canPayWithCredits
+      ? {
+          cost_per_unit: result.credit_cost_per_unit,
+          balance: result.user_credit_balance,
+          balance_sufficient_for_one_unit:
+            result.user_credit_balance >= result.credit_cost_per_unit,
+          endpoint: CREDIT_SPEND_URL,
+        }
+      : null;
+
+    res.status(402).json({
+      ok: false,
+      error: 'payment_required',
+      paywall: {
+        feature: result.feature,
+        tier: result.tier,
+        quota: result.quota,
+        used: result.used,
+        remaining: result.remaining,
+        reset_at: result.reset_at,
+        credit_cost_per_unit: result.credit_cost_per_unit,
+        user_credit_balance: result.user_credit_balance,
+        allowed_burn_buckets: result.allowed_burn_buckets,
+        credit_option: creditOption,
+        upgrade_url: SUBSCRIPTION_UPGRADE_URL,
+        deferred_for_vulnerability: false, // never true here (deferred bypasses 402)
+        paywall_action: result.paywall_action,
+      },
+      vtid: VTID,
+    });
+  };
+}
+
+export const _VTID = VTID;

--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -48,9 +48,18 @@ import {
   FORWARDING_ACK_TIMEOUT_MS,
 } from '../../upstream/constants';
 import { destroySessionBuffer } from '../../../services/session-memory-buffer';
-// VTID-03107: Live AI voice quota check at session start.
-import { reserveVoiceQuotaAtSessionStart } from '../../../services/voice-quota-guard';
+// VTID-03107: Live AI voice quota check at session start + per-minute meter.
+import {
+  reserveVoiceQuotaAtSessionStart,
+  recordVoiceMinute,
+  triggerDowngrade,
+} from '../../../services/voice-quota-guard';
 import { recordPaywallEvent } from '../../../services/entitlement-service';
+
+// VTID-03107: per-session voice-meter intervals. Keyed by session_id so cleanup
+// in handleLiveSessionStop can tear down without touching GeminiLiveSession's type.
+const voiceMeterIntervals: Map<string, NodeJS.Timeout> = new Map();
+const VOICE_METER_INTERVAL_MS = 60_000; // 1 minute
 import {
   deduplicatedExtract,
   clearExtractionState,
@@ -832,6 +841,70 @@ export async function handleLiveSessionStart(
   // Store session
   liveSessions.set(sessionId, session);
 
+  // VTID-03107: arm the per-minute voice meter for authenticated sessions
+  // whose quota gate is in 'allow' or 'degrade' state. 'deferred' sessions
+  // do NOT advance the meter (D36 protection). Anonymous sessions skip
+  // (no user to bill).
+  if (
+    voiceQuotaReservation &&
+    req.identity?.user_id &&
+    req.identity?.tenant_id &&
+    voiceQuotaReservation.paywall_action !== 'deferred' &&
+    voiceQuotaReservation.paywall_action !== 'hard_block' &&
+    voiceQuotaReservation.paywall_action !== 'paywall'
+  ) {
+    const meterUserId = req.identity.user_id;
+    const meterTenantId = req.identity.tenant_id;
+    const startedRemaining = voiceQuotaReservation.remaining;
+    let degradeAlreadyFired = voiceQuotaReservation.paywall_action === 'degrade';
+    const timer = setInterval(async () => {
+      const currentSession = liveSessions.get(sessionId);
+      if (!currentSession || !currentSession.active) {
+        // Session already ended; tear down ourselves as a belt-and-suspenders cleanup
+        const handle = voiceMeterIntervals.get(sessionId);
+        if (handle) {
+          clearInterval(handle);
+          voiceMeterIntervals.delete(sessionId);
+        }
+        return;
+      }
+      try {
+        const newUsed = await recordVoiceMinute(meterUserId, meterTenantId, false);
+        if (newUsed === null) return;
+        // If we've now exceeded the start-of-session remaining, the user has
+        // burned through their daily Live quota mid-call. Emit the dedicated
+        // downgrade SSE event ONCE. The frontend's OrbDegradeBanner +
+        // OrbTierBadge will flip on their own.
+        const consumed = Math.max(0, newUsed - (voiceQuotaReservation!.used));
+        if (!degradeAlreadyFired && consumed >= startedRemaining) {
+          degradeAlreadyFired = true;
+          const sseWriter = (_eventName: string, dataJson: string) => {
+            const sseResponse = liveSessions.get(sessionId)?.sseResponse;
+            if (sseResponse) {
+              try {
+                sseResponse.write(`data: ${dataJson}\n\n`);
+              } catch {
+                // SSE may have closed; non-blocking.
+              }
+            }
+          };
+          try {
+            await triggerDowngrade(meterUserId, meterTenantId, sseWriter, 'session_quota');
+          } catch (err) {
+            console.warn(
+              `[VTID-03107] triggerDowngrade failed for session ${sessionId}: ${err instanceof Error ? err.message : String(err)}`
+            );
+          }
+        }
+      } catch (err) {
+        console.warn(
+          `[VTID-03107] voice-meter tick failed for session ${sessionId}: ${err instanceof Error ? err.message : String(err)}`
+        );
+      }
+    }, VOICE_METER_INTERVAL_MS);
+    voiceMeterIntervals.set(sessionId, timer);
+  }
+
   // VTID-02917 (B0d.3): wake-timeline session_start_received event
   try {
     defaultWakeTimelineRecorder.startSession({
@@ -1132,6 +1205,13 @@ export async function handleLiveSessionStop(
   }
 
   session.active = false;
+
+  // VTID-03107: tear down the per-minute voice meter
+  const voiceMeterHandle = voiceMeterIntervals.get(session_id);
+  if (voiceMeterHandle) {
+    clearInterval(voiceMeterHandle);
+    voiceMeterIntervals.delete(session_id);
+  }
 
   // VTID-STREAM-KEEPALIVE: Clear upstream ping interval on session stop
   if (session.upstreamPingInterval) {

--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -48,6 +48,9 @@ import {
   FORWARDING_ACK_TIMEOUT_MS,
 } from '../../upstream/constants';
 import { destroySessionBuffer } from '../../../services/session-memory-buffer';
+// VTID-03107: Live AI voice quota check at session start.
+import { reserveVoiceQuotaAtSessionStart } from '../../../services/voice-quota-guard';
+import { recordPaywallEvent } from '../../../services/entitlement-service';
 import {
   deduplicatedExtract,
   clearExtractionState,
@@ -488,6 +491,70 @@ export async function handleLiveSessionStart(
       error: 'AUTH_TOKEN_INVALID',
       message: 'Session expired or invalid — please re-authenticate',
     });
+  }
+
+  // VTID-03107: Live AI voice quota gate (authenticated sessions only).
+  // Anonymous sessions skip the gate (no user to bill). For authenticated
+  // users we reserve quota up front; if exhausted with degrade behavior, we
+  // allow the session to start but mark `voice_quota_exhausted` in the
+  // response meta so the frontend can flip to Standard tier mode.
+  //
+  // Failures inside the guard never block a legitimate session — they log
+  // and fall through to normal start. The cashflow guardrail is best-effort;
+  // never trade availability for metering accuracy.
+  const _earlyAuthHeader = req.headers.authorization;
+  const _earlyAuthToken =
+    _earlyAuthHeader && _earlyAuthHeader.startsWith('Bearer ')
+      ? _earlyAuthHeader.slice(7)
+      : undefined;
+  let voiceQuotaReservation: Awaited<ReturnType<typeof reserveVoiceQuotaAtSessionStart>> | null = null;
+  if (req.identity?.user_id && req.identity?.tenant_id) {
+    try {
+      voiceQuotaReservation = await reserveVoiceQuotaAtSessionStart(
+        req.identity.user_id,
+        req.identity.tenant_id,
+        { authToken: _earlyAuthToken }
+      );
+    } catch (err: unknown) {
+      console.warn(
+        `[VTID-03107] voice quota reservation failed (failing open): ${err instanceof Error ? err.message : String(err)}`
+      );
+    }
+
+    if (
+      voiceQuotaReservation &&
+      (voiceQuotaReservation.paywall_action === 'paywall' ||
+        voiceQuotaReservation.paywall_action === 'hard_block')
+    ) {
+      // Quota exhausted AND the user's plan configures this feature as hard_block
+      // (no PAYG path open at all). Record event + return 402 with paywall body.
+      recordPaywallEvent(
+        req.identity.user_id,
+        req.identity.tenant_id,
+        'voice_live_minutes',
+        'shown',
+        { context: 'session_start_blocked', vtid: 'VTID-03107' }
+      ).catch(() => {});
+      return res.status(402).json({
+        ok: false,
+        error: 'payment_required',
+        paywall: {
+          feature: 'voice_live_minutes',
+          tier: 'unknown',
+          quota: voiceQuotaReservation.quota,
+          used: voiceQuotaReservation.used,
+          remaining: voiceQuotaReservation.remaining,
+          reset_at: voiceQuotaReservation.reset_at,
+          credit_cost_per_unit: 0,
+          user_credit_balance: 0,
+          allowed_burn_buckets: ['purchased_credits'],
+          credit_option: null,
+          upgrade_url: '/api/v1/billing/checkout/subscription',
+          paywall_action: voiceQuotaReservation.paywall_action,
+        },
+        vtid: 'VTID-03107',
+      });
+    }
   }
 
   const body = req.body as LiveSessionStartRequest;
@@ -954,6 +1021,20 @@ export async function handleLiveSessionStart(
       voice: deps.getVoiceForLang(lang),
       modalities: responseModalities,
       model: VERTEX_LIVE_MODEL,
+      // VTID-03107: voice quota snapshot at session start. Frontend reads
+      // this to know whether to display the Standard-tier badge from the
+      // get-go (start_on_standard_tier=true) and how much quota remains.
+      voice_quota: voiceQuotaReservation
+        ? {
+            tier: voiceQuotaReservation.start_on_standard_tier ? 'standard' : 'live',
+            quota: voiceQuotaReservation.quota,
+            used: voiceQuotaReservation.used,
+            remaining: voiceQuotaReservation.remaining,
+            reset_at: voiceQuotaReservation.reset_at,
+            deferred_for_vulnerability: voiceQuotaReservation.deferred_for_vulnerability,
+            paywall_action: voiceQuotaReservation.paywall_action,
+          }
+        : null,
       context_bootstrap: {
         latency_ms: contextBootstrapLatencyMs ?? null,
         context_chars: null,

--- a/services/gateway/src/routes/billing.ts
+++ b/services/gateway/src/routes/billing.ts
@@ -1,0 +1,1032 @@
+/**
+ * VTID-03107 · Billing v1 — Customer-side Stripe routes + redemption
+ *
+ * Mounted at /api/v1/billing
+ *
+ *   GET  /me                            current plan + usage + credits + earnings
+ *   POST /checkout/subscription         Stripe Checkout (subscription mode)
+ *   POST /checkout/credits              Stripe Checkout (payment mode for credit pack)
+ *   POST /portal                        Stripe Customer Portal (manage / cancel)
+ *   POST /credits/spend                 idempotent credit burn for a feature
+ *   POST /redeem                        redemption code → grants Premium (no Stripe)
+ *   POST /webhooks/stripe               customer-side webhook (separate secret from Connect)
+ *
+ * Admin endpoints (require exafy_admin):
+ *   POST /admin/redemption-codes/generate    bulk-generate unique codes for a campaign
+ *   GET  /admin/redemption-codes             list codes + usage per campaign
+ *   PATCH /admin/redemption-codes/:code      deactivate/reactivate a code
+ *
+ * Separation from Stripe Connect
+ *   This file handles the CUSTOMER side (users paying Vitana for plans +
+ *   credit packs). Stripe Connect (creators receiving payouts from Live
+ *   Rooms) lives in routes/creators.ts + routes/stripe-connect-webhook.ts
+ *   and is untouched by PR-2.
+ *
+ * Webhook signing
+ *   The customer-side webhook uses STRIPE_BILLING_WEBHOOK_SECRET, a
+ *   DIFFERENT env var from the Connect webhook's STRIPE_CONNECT_WEBHOOK_SECRET.
+ *   This lets the two webhooks be rotated independently.
+ */
+
+import { Router, type Request, type Response } from 'express';
+import Stripe from 'stripe';
+import { randomUUID } from 'crypto';
+
+import { getSupabase } from '../lib/supabase';
+import {
+  requireAuth,
+  requireExafyAdmin,
+  type AuthenticatedRequest,
+} from '../middleware/auth-supabase-jwt';
+import {
+  checkEntitlement,
+  recordUsage,
+  consumeCredits,
+  getUserPlan,
+  recordPaywallEvent,
+  type WalletBucket,
+} from '../services/entitlement-service';
+
+const VTID = 'VTID-03107';
+const LOG_PREFIX = '[billing]';
+
+const FRONTEND_URL = process.env.FRONTEND_URL || 'https://community-app.vitanaland.com';
+const STRIPE_BILLING_WEBHOOK_SECRET = process.env.STRIPE_BILLING_WEBHOOK_SECRET || '';
+
+const router = Router();
+
+// =============================================================================
+// Lazy Stripe init (mirrors routes/creators.ts pattern)
+// =============================================================================
+
+let _stripe: Stripe | null = null;
+function getStripe(): Stripe {
+  if (!_stripe) {
+    const key = process.env.STRIPE_SECRET_KEY;
+    if (!key) {
+      throw new Error('STRIPE_SECRET_KEY is not configured');
+    }
+    _stripe = new Stripe(key);
+  }
+  return _stripe;
+}
+
+function sb() {
+  const client = getSupabase();
+  if (!client) {
+    throw new Error('Supabase service client unavailable');
+  }
+  return client;
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+interface PriceRow {
+  price_key: string;
+  plan_key: string;
+  billing_interval: 'month' | 'year';
+  price_cents: number;
+  currency: string;
+  stripe_price_id: string | null;
+}
+
+interface PackRow {
+  pack_key: string;
+  display_name: string;
+  credits: number;
+  bonus_credits: number;
+  price_cents: number;
+  currency: string;
+  stripe_price_id: string | null;
+}
+
+interface UserSubscriptionRow {
+  id: string;
+  tenant_id: string;
+  user_id: string;
+  plan_key: string;
+  price_key: string | null;
+  status: string;
+  stripe_customer_id: string | null;
+  stripe_subscription_id: string | null;
+  current_period_start: string | null;
+  current_period_end: string | null;
+  cancel_at_period_end: boolean;
+  trial_end: string | null;
+  last_payment_error: string | null;
+  metadata: Record<string, unknown>;
+}
+
+async function readPriceByKey(priceKey: string): Promise<PriceRow | null> {
+  const { data, error } = await sb()
+    .from('subscription_plan_prices')
+    .select('price_key, plan_key, billing_interval, price_cents, currency, stripe_price_id')
+    .eq('price_key', priceKey)
+    .eq('is_active', true)
+    .maybeSingle();
+  if (error) {
+    console.error(`${LOG_PREFIX} readPriceByKey error: ${error.message}`);
+    return null;
+  }
+  return (data as PriceRow) || null;
+}
+
+async function readPackByKey(packKey: string): Promise<PackRow | null> {
+  const { data, error } = await sb()
+    .from('credit_packs')
+    .select('pack_key, display_name, credits, bonus_credits, price_cents, currency, stripe_price_id')
+    .eq('pack_key', packKey)
+    .eq('is_active', true)
+    .maybeSingle();
+  if (error) {
+    console.error(`${LOG_PREFIX} readPackByKey error: ${error.message}`);
+    return null;
+  }
+  return (data as PackRow) || null;
+}
+
+async function readUserSubscription(
+  tenantId: string,
+  userId: string
+): Promise<UserSubscriptionRow | null> {
+  const { data, error } = await sb()
+    .from('user_subscriptions')
+    .select('*')
+    .eq('tenant_id', tenantId)
+    .eq('user_id', userId)
+    .maybeSingle();
+  if (error) {
+    console.error(`${LOG_PREFIX} readUserSubscription error: ${error.message}`);
+    return null;
+  }
+  return (data as UserSubscriptionRow) || null;
+}
+
+async function ensureStripeCustomer(
+  tenantId: string,
+  userId: string,
+  email: string | null
+): Promise<string> {
+  const sub = await readUserSubscription(tenantId, userId);
+  if (sub?.stripe_customer_id) {
+    return sub.stripe_customer_id;
+  }
+  // Create a new Stripe Customer with our user_id + tenant_id in metadata
+  const customer = await getStripe().customers.create({
+    email: email ?? undefined,
+    metadata: {
+      vitana_user_id: userId,
+      vitana_tenant_id: tenantId,
+      vtid: VTID,
+    },
+  });
+
+  // Upsert user_subscriptions to remember the customer_id even before they
+  // actually subscribe to anything. plan_key='free' / status='free' as default.
+  await sb()
+    .from('user_subscriptions')
+    .upsert(
+      {
+        tenant_id: tenantId,
+        user_id: userId,
+        plan_key: sub?.plan_key ?? 'free',
+        status: sub?.status ?? 'free',
+        stripe_customer_id: customer.id,
+        metadata: { ...(sub?.metadata ?? {}), source: sub?.metadata?.source ?? 'free_default' },
+      },
+      { onConflict: 'tenant_id,user_id' }
+    );
+  return customer.id;
+}
+
+// =============================================================================
+// GET /me  — single endpoint that powers the Subscriptions screen
+// =============================================================================
+
+router.get('/me', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const identity = req.identity;
+  if (!identity?.user_id || !identity?.tenant_id) {
+    return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+  }
+  try {
+    const [plan, sub] = await Promise.all([
+      getUserPlan(identity.user_id, identity.tenant_id),
+      readUserSubscription(identity.tenant_id, identity.user_id),
+    ]);
+
+    // Wallet snapshot (post-§M three-bucket schema)
+    const { data: wallet } = await sb()
+      .from('wallet_balances')
+      .select('purchased_credits, reward_credits, cash_balance, balance')
+      .eq('tenant_id', identity.tenant_id)
+      .eq('user_id', identity.user_id)
+      .maybeSingle();
+
+    // Usage rollup for the 6 metered features (only for current plan)
+    const { data: entitlementRows } = await sb()
+      .from('feature_entitlements')
+      .select('feature_key, quota, window_seconds, unit, behavior_on_exceed')
+      .eq('plan_key', plan.plan_key);
+
+    const usage: Record<string, { used: number; quota: number; reset_at: string | null; unit: string; behavior: string }> = {};
+    if (entitlementRows) {
+      for (const row of entitlementRows as Array<{ feature_key: string; quota: number; window_seconds: number; unit: string; behavior_on_exceed: string }>) {
+        const { data: u } = await sb().rpc('fn_get_feature_usage', {
+          p_tenant_id: identity.tenant_id,
+          p_user_id: identity.user_id,
+          p_feature_key: row.feature_key,
+          p_window_seconds: row.window_seconds,
+        });
+        const used = (u as { used?: number })?.used ?? 0;
+        const resetAt = (u as { window_end?: string })?.window_end ?? null;
+        usage[row.feature_key] = {
+          used,
+          quota: row.quota,
+          reset_at: resetAt,
+          unit: row.unit,
+          behavior: row.behavior_on_exceed,
+        };
+      }
+    }
+
+    // Earnings rollup (read-only; no commission attribution code in PR-2)
+    const yearStart = new Date();
+    yearStart.setUTCMonth(0, 1);
+    yearStart.setUTCHours(0, 0, 0, 0);
+    const { data: earnTx } = await sb()
+      .from('wallet_transactions')
+      .select('amount, created_at')
+      .eq('tenant_id', identity.tenant_id)
+      .eq('user_id', identity.user_id)
+      .eq('type', 'earning')
+      .gte('created_at', yearStart.toISOString());
+    const yearEarnedCents = ((earnTx as Array<{ amount: number }>) ?? []).reduce(
+      (sum, t) => sum + (t.amount > 0 ? t.amount : 0),
+      0
+    );
+
+    return res.json({
+      ok: true,
+      vtid: VTID,
+      plan: {
+        plan_key: plan.plan_key,
+        status: plan.status,
+        current_period_end: plan.current_period_end,
+        cancel_at_period_end: plan.cancel_at_period_end,
+        trial_end: plan.trial_end,
+        price_key: sub?.price_key ?? null,
+        source: (plan.metadata?.source as string | undefined) ?? null,
+      },
+      wallet: {
+        purchased_credits: wallet?.purchased_credits ?? 0,
+        reward_credits: wallet?.reward_credits ?? 0,
+        cash_balance: wallet?.cash_balance ?? 0,
+        balance_total: wallet?.balance ?? 0,
+      },
+      usage,
+      earnings: {
+        year_in_cents: yearEarnedCents,
+      },
+      stripe: {
+        has_customer: !!sub?.stripe_customer_id,
+        has_paid_subscription: !!sub?.stripe_subscription_id,
+      },
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`${LOG_PREFIX} /me crash: ${message}`);
+    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR', vtid: VTID });
+  }
+});
+
+// =============================================================================
+// POST /checkout/subscription  — start a Stripe Checkout session for a plan
+// =============================================================================
+
+router.post('/checkout/subscription', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const identity = req.identity;
+  if (!identity?.user_id || !identity?.tenant_id) {
+    return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+  }
+
+  const priceKey: string | undefined = req.body?.price_key;
+  if (!priceKey || typeof priceKey !== 'string') {
+    return res.status(400).json({ ok: false, error: 'MISSING_PRICE_KEY' });
+  }
+
+  const price = await readPriceByKey(priceKey);
+  if (!price) {
+    return res.status(400).json({ ok: false, error: 'PRICE_NOT_FOUND', price_key: priceKey });
+  }
+  if (!price.stripe_price_id) {
+    return res.status(503).json({
+      ok: false,
+      error: 'STRIPE_PRICE_NOT_CONFIGURED',
+      message: 'Ops has not yet populated stripe_price_id for this plan. Contact admin.',
+      price_key: priceKey,
+    });
+  }
+
+  // Block if user already has an active Stripe sub on this customer
+  const existingSub = await readUserSubscription(identity.tenant_id, identity.user_id);
+  if (existingSub?.stripe_subscription_id && ['active', 'trialing', 'past_due'].includes(existingSub.status)) {
+    return res.status(409).json({
+      ok: false,
+      error: 'ALREADY_SUBSCRIBED',
+      current_plan: existingSub.plan_key,
+      message: 'Manage your subscription via the customer portal.',
+    });
+  }
+
+  try {
+    const customerId = await ensureStripeCustomer(identity.tenant_id, identity.user_id, identity.email);
+
+    // Look up trial_days from the plan
+    const { data: planRow } = await sb()
+      .from('subscription_plans')
+      .select('trial_days')
+      .eq('plan_key', price.plan_key)
+      .maybeSingle();
+    const trialDays = (planRow as { trial_days?: number })?.trial_days ?? 0;
+
+    const session = await getStripe().checkout.sessions.create({
+      mode: 'subscription',
+      customer: customerId,
+      client_reference_id: identity.user_id,
+      line_items: [
+        {
+          price: price.stripe_price_id,
+          quantity: 1,
+        },
+      ],
+      subscription_data:
+        trialDays > 0
+          ? {
+              trial_period_days: trialDays,
+              metadata: {
+                vitana_user_id: identity.user_id,
+                vitana_tenant_id: identity.tenant_id,
+                vitana_plan_key: price.plan_key,
+                vitana_price_key: price.price_key,
+              },
+            }
+          : {
+              metadata: {
+                vitana_user_id: identity.user_id,
+                vitana_tenant_id: identity.tenant_id,
+                vitana_plan_key: price.plan_key,
+                vitana_price_key: price.price_key,
+              },
+            },
+      success_url: `${FRONTEND_URL}/wallet/subscriptions?checkout=success&session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${FRONTEND_URL}/wallet/subscriptions?checkout=cancelled`,
+      metadata: {
+        vitana_user_id: identity.user_id,
+        vitana_tenant_id: identity.tenant_id,
+        vitana_kind: 'subscription',
+        vitana_plan_key: price.plan_key,
+        vitana_price_key: price.price_key,
+      },
+    });
+
+    return res.json({ ok: true, url: session.url, session_id: session.id, vtid: VTID });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`${LOG_PREFIX} /checkout/subscription crash: ${message}`);
+    return res.status(500).json({ ok: false, error: 'STRIPE_CHECKOUT_FAILED', message, vtid: VTID });
+  }
+});
+
+// =============================================================================
+// POST /checkout/credits  — Stripe Checkout for a credit pack (one-shot)
+// =============================================================================
+
+router.post('/checkout/credits', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const identity = req.identity;
+  if (!identity?.user_id || !identity?.tenant_id) {
+    return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+  }
+
+  const packKey: string | undefined = req.body?.pack_key;
+  if (!packKey || typeof packKey !== 'string') {
+    return res.status(400).json({ ok: false, error: 'MISSING_PACK_KEY' });
+  }
+
+  const pack = await readPackByKey(packKey);
+  if (!pack) {
+    return res.status(400).json({ ok: false, error: 'PACK_NOT_FOUND', pack_key: packKey });
+  }
+  if (!pack.stripe_price_id) {
+    return res.status(503).json({
+      ok: false,
+      error: 'STRIPE_PRICE_NOT_CONFIGURED',
+      message: 'Ops has not yet populated stripe_price_id for this credit pack.',
+      pack_key: packKey,
+    });
+  }
+
+  try {
+    const customerId = await ensureStripeCustomer(identity.tenant_id, identity.user_id, identity.email);
+    const totalCredits = pack.credits + (pack.bonus_credits || 0);
+    const session = await getStripe().checkout.sessions.create({
+      mode: 'payment',
+      customer: customerId,
+      client_reference_id: identity.user_id,
+      line_items: [{ price: pack.stripe_price_id, quantity: 1 }],
+      success_url: `${FRONTEND_URL}/wallet?credits_purchased=true&session_id={CHECKOUT_SESSION_ID}`,
+      cancel_url: `${FRONTEND_URL}/wallet/subscriptions?checkout=cancelled`,
+      metadata: {
+        vitana_user_id: identity.user_id,
+        vitana_tenant_id: identity.tenant_id,
+        vitana_kind: 'credit_pack',
+        vitana_pack_key: pack.pack_key,
+        vitana_credits: String(totalCredits),
+      },
+    });
+    return res.json({ ok: true, url: session.url, session_id: session.id, vtid: VTID });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`${LOG_PREFIX} /checkout/credits crash: ${message}`);
+    return res.status(500).json({ ok: false, error: 'STRIPE_CHECKOUT_FAILED', message, vtid: VTID });
+  }
+});
+
+// =============================================================================
+// POST /portal  — Stripe Customer Portal redirect
+// =============================================================================
+
+router.post('/portal', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const identity = req.identity;
+  if (!identity?.user_id || !identity?.tenant_id) {
+    return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+  }
+  const sub = await readUserSubscription(identity.tenant_id, identity.user_id);
+  if (!sub?.stripe_customer_id) {
+    return res.status(400).json({ ok: false, error: 'NO_STRIPE_CUSTOMER', message: 'Subscribe first before using the portal.' });
+  }
+  try {
+    const session = await getStripe().billingPortal.sessions.create({
+      customer: sub.stripe_customer_id,
+      return_url: `${FRONTEND_URL}/wallet/subscriptions`,
+    });
+    return res.json({ ok: true, url: session.url, vtid: VTID });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`${LOG_PREFIX} /portal crash: ${message}`);
+    return res.status(500).json({ ok: false, error: 'STRIPE_PORTAL_FAILED', message, vtid: VTID });
+  }
+});
+
+// =============================================================================
+// POST /credits/spend  — idempotent credit burn for a feature
+// =============================================================================
+
+router.post('/credits/spend', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const identity = req.identity;
+  if (!identity?.user_id || !identity?.tenant_id) {
+    return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+  }
+
+  const feature: string | undefined = req.body?.feature;
+  const unitsRaw = req.body?.units;
+  const units = typeof unitsRaw === 'number' && unitsRaw > 0 ? Math.floor(unitsRaw) : 1;
+  const preferredBucket: WalletBucket | undefined =
+    req.body?.bucket && typeof req.body.bucket === 'string' ? req.body.bucket : undefined;
+
+  if (!feature || typeof feature !== 'string') {
+    return res.status(400).json({ ok: false, error: 'MISSING_FEATURE' });
+  }
+
+  const idempotencyKey =
+    (req.headers['idempotency-key'] as string | undefined) ||
+    (req.body?.idempotency_key as string | undefined) ||
+    `pawall-credit:${identity.user_id}:${feature}:${randomUUID()}`;
+
+  const result = await consumeCredits(
+    identity.user_id,
+    identity.tenant_id,
+    feature,
+    units,
+    idempotencyKey,
+    preferredBucket
+  );
+
+  if (!result.ok) {
+    return res.status(400).json({ ...result, ok: false, error: result.error, vtid: VTID });
+  }
+
+  // Advance the feature usage meter so the entitlement engine sees the spend
+  // as "consumed" — the PAYG credits paid for the units.
+  const { data: cfg } = await sb()
+    .from('feature_entitlements')
+    .select('window_seconds')
+    .eq('plan_key', (await getUserPlan(identity.user_id, identity.tenant_id)).plan_key)
+    .eq('feature_key', feature)
+    .maybeSingle();
+  const windowSeconds = (cfg as { window_seconds?: number })?.window_seconds ?? 2592000;
+  await recordUsage(identity.user_id, identity.tenant_id, feature, units, windowSeconds);
+
+  return res.json({ ...result, ok: true, units_purchased: units, vtid: VTID });
+});
+
+// =============================================================================
+// POST /redeem  — code redemption (calls fn_redeem_code RPC)
+// =============================================================================
+
+router.post('/redeem', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const identity = req.identity;
+  if (!identity?.user_id || !identity?.tenant_id) {
+    return res.status(401).json({ ok: false, error: 'UNAUTHENTICATED' });
+  }
+  const code: string | undefined = req.body?.code;
+  if (!code || typeof code !== 'string' || code.trim().length < 3) {
+    return res.status(400).json({ ok: false, error: 'INVALID_CODE' });
+  }
+
+  try {
+    const { data, error } = await sb().rpc('fn_redeem_code', {
+      p_tenant_id: identity.tenant_id,
+      p_user_id: identity.user_id,
+      p_code: code.trim(),
+    });
+    if (error) {
+      console.error(`${LOG_PREFIX} fn_redeem_code error: ${error.message}`);
+      return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR', message: error.message });
+    }
+    const result = data as Record<string, unknown>;
+    if ((result.ok as boolean) === true) {
+      return res.json({ ok: true, ...result, vtid: VTID });
+    }
+    // Map the RPC error to HTTP status
+    const errCode = (result.error as string) || 'UNKNOWN';
+    const status =
+      errCode === 'INVALID_CODE' ? 404 :
+      errCode === 'EXPIRED' || errCode === 'EXPIRED_OR_INACTIVE' ? 410 :
+      errCode === 'MAX_USES_REACHED' ? 410 :
+      errCode === 'ALREADY_REDEEMED' ? 409 :
+      errCode === 'STRIPE_SUB_ACTIVE' ? 409 :
+      errCode === 'BUDGET_EXHAUSTED' ? 503 :
+      400;
+    return res.status(status).json({ ...result, ok: false, vtid: VTID });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`${LOG_PREFIX} /redeem crash: ${message}`);
+    return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR', message, vtid: VTID });
+  }
+});
+
+// =============================================================================
+// POST /webhooks/stripe  — customer-side webhook
+// =============================================================================
+//
+// IMPORTANT: index.ts must register express.raw({type:'application/json'})
+// for this path BEFORE express.json() global parser. Pattern mirrors
+// '/api/v1/stripe/webhook' for Connect.
+// =============================================================================
+
+router.post('/webhooks/stripe', async (req: Request, res: Response) => {
+  const sig = req.headers['stripe-signature'];
+  if (!sig) {
+    return res.status(400).json({ error: 'Missing signature' });
+  }
+  if (!STRIPE_BILLING_WEBHOOK_SECRET) {
+    console.error(`${LOG_PREFIX} STRIPE_BILLING_WEBHOOK_SECRET not configured`);
+    return res.status(500).json({ error: 'Webhook not configured' });
+  }
+
+  let event: Stripe.Event;
+  try {
+    event = getStripe().webhooks.constructEvent(
+      req.body as Buffer,
+      sig,
+      STRIPE_BILLING_WEBHOOK_SECRET
+    );
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`${LOG_PREFIX} Webhook signature verification failed: ${message}`);
+    return res.status(400).json({ error: `Webhook Error: ${message}` });
+  }
+
+  // Idempotency: insert event.id into processed_stripe_events; PK conflict = already handled
+  const { error: idemErr } = await sb()
+    .from('processed_stripe_events')
+    .insert({ event_id: event.id, event_type: event.type });
+  if (idemErr) {
+    // PK collision: this event was already processed. Acknowledge and skip.
+    if (idemErr.code === '23505' || /duplicate key/i.test(idemErr.message)) {
+      console.log(`${LOG_PREFIX} Webhook ${event.id} already processed — idempotent skip`);
+      return res.json({ received: true, duplicate: true });
+    }
+    console.error(`${LOG_PREFIX} processed_stripe_events insert error: ${idemErr.message}`);
+    return res.status(500).json({ error: 'Idempotency log failed' });
+  }
+
+  console.log(`${LOG_PREFIX} Webhook event: ${event.type} (id=${event.id})`);
+
+  try {
+    switch (event.type) {
+      case 'checkout.session.completed':
+        await handleCheckoutCompleted(event.data.object as Stripe.Checkout.Session);
+        break;
+      case 'customer.subscription.created':
+      case 'customer.subscription.updated':
+        await handleSubscriptionUpserted(event.data.object as Stripe.Subscription);
+        break;
+      case 'customer.subscription.deleted':
+        await handleSubscriptionDeleted(event.data.object as Stripe.Subscription);
+        break;
+      case 'invoice.paid':
+        await handleInvoicePaid(event.data.object as Stripe.Invoice);
+        break;
+      case 'invoice.payment_failed':
+        await handleInvoiceFailed(event.data.object as Stripe.Invoice);
+        break;
+      default:
+        console.log(`${LOG_PREFIX} Unhandled event type: ${event.type}`);
+    }
+    return res.json({ received: true });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.error(`${LOG_PREFIX} Webhook processing crash: ${message}`);
+    // We've already inserted the event_id; Stripe will retry on 5xx. Allowing
+    // retry is safer than leaving processed_stripe_events stale.
+    await sb().from('processed_stripe_events').delete().eq('event_id', event.id);
+    return res.status(500).json({ error: 'Webhook processing failed' });
+  }
+});
+
+// -----------------------------------------------------------------------------
+// Webhook handlers
+// -----------------------------------------------------------------------------
+
+async function handleCheckoutCompleted(session: Stripe.Checkout.Session): Promise<void> {
+  const kind = session.metadata?.vitana_kind;
+  const userId = session.metadata?.vitana_user_id || session.client_reference_id || undefined;
+  const tenantId = session.metadata?.vitana_tenant_id;
+  if (!userId || !tenantId) {
+    console.warn(`${LOG_PREFIX} checkout.session.completed missing user/tenant metadata; session=${session.id}`);
+    return;
+  }
+
+  if (kind === 'subscription') {
+    // For subscription mode, the subscription object will fire its own
+    // customer.subscription.created event. We just record the paywall event.
+    await recordPaywallEvent(userId, tenantId, 'subscription', 'upgraded', {
+      stripe_session_id: session.id,
+      stripe_subscription_id: session.subscription as string | null,
+      plan_key: session.metadata?.vitana_plan_key,
+      price_key: session.metadata?.vitana_price_key,
+    });
+    return;
+  }
+
+  if (kind === 'credit_pack') {
+    const packKey = session.metadata?.vitana_pack_key;
+    const creditsStr = session.metadata?.vitana_credits;
+    const credits = creditsStr ? parseInt(creditsStr, 10) : 0;
+    if (!packKey || credits <= 0) {
+      console.warn(`${LOG_PREFIX} credit_pack checkout missing metadata; session=${session.id}`);
+      return;
+    }
+
+    // Idempotent credit via the existing credit_wallet RPC. source_event_id =
+    // session.id so re-delivery never double-credits.
+    const { error } = await sb().rpc('credit_wallet', {
+      p_tenant_id: tenantId,
+      p_user_id: userId,
+      p_amount: credits,
+      p_type: 'purchase',
+      p_source: `credit_pack:${packKey}`,
+      p_source_event_id: session.id,
+      p_description: `Stripe credit pack purchase: ${packKey} (${credits} credits)`,
+    });
+    if (error) {
+      console.error(`${LOG_PREFIX} credit_wallet RPC failed: ${error.message}`);
+      throw new Error(`credit_wallet failed: ${error.message}`);
+    }
+    await recordPaywallEvent(userId, tenantId, 'credit_pack', 'credit_paid', {
+      stripe_session_id: session.id,
+      pack_key: packKey,
+      credits,
+    });
+    return;
+  }
+
+  console.log(`${LOG_PREFIX} checkout.session.completed unknown kind: ${kind}`);
+}
+
+async function handleSubscriptionUpserted(stripeSub: Stripe.Subscription): Promise<void> {
+  const userId = stripeSub.metadata?.vitana_user_id;
+  const tenantId = stripeSub.metadata?.vitana_tenant_id;
+  if (!userId || !tenantId) {
+    console.warn(`${LOG_PREFIX} subscription.${stripeSub.status} missing user/tenant metadata; sub=${stripeSub.id}`);
+    return;
+  }
+
+  // Resolve plan_key from the Stripe Price ID
+  const stripePriceId = stripeSub.items.data[0]?.price.id;
+  let planKey = stripeSub.metadata?.vitana_plan_key ?? 'free';
+  let priceKey = stripeSub.metadata?.vitana_price_key ?? null;
+  if (stripePriceId) {
+    const { data } = await sb()
+      .from('subscription_plan_prices')
+      .select('plan_key, price_key')
+      .eq('stripe_price_id', stripePriceId)
+      .maybeSingle();
+    if (data) {
+      planKey = (data.plan_key as string) || planKey;
+      priceKey = (data.price_key as string) || priceKey;
+    }
+  }
+
+  // Stripe SDK v18+ moved current_period_start / current_period_end onto the
+  // SubscriptionItem (subscription.items.data[N]). Fall back to the legacy
+  // top-level fields if present, for older API versions.
+  const item = stripeSub.items.data[0] as
+    | (Stripe.SubscriptionItem & { current_period_start?: number; current_period_end?: number })
+    | undefined;
+  const legacySub = stripeSub as Stripe.Subscription & {
+    current_period_start?: number;
+    current_period_end?: number;
+  };
+  const periodStartUnix = item?.current_period_start ?? legacySub.current_period_start ?? null;
+  const periodEndUnix = item?.current_period_end ?? legacySub.current_period_end ?? null;
+  const periodStart = periodStartUnix ? new Date(periodStartUnix * 1000).toISOString() : null;
+  const periodEnd = periodEndUnix ? new Date(periodEndUnix * 1000).toISOString() : null;
+  const trialEnd = stripeSub.trial_end ? new Date(stripeSub.trial_end * 1000).toISOString() : null;
+
+  await sb()
+    .from('user_subscriptions')
+    .upsert(
+      {
+        tenant_id: tenantId,
+        user_id: userId,
+        plan_key: planKey,
+        price_key: priceKey,
+        status: stripeSub.status,
+        stripe_customer_id: stripeSub.customer as string,
+        stripe_subscription_id: stripeSub.id,
+        current_period_start: periodStart,
+        current_period_end: periodEnd,
+        cancel_at_period_end: stripeSub.cancel_at_period_end,
+        trial_end: trialEnd,
+        last_payment_error: null,
+        metadata: { source: 'stripe' },
+      },
+      { onConflict: 'tenant_id,user_id' }
+    );
+}
+
+async function handleSubscriptionDeleted(stripeSub: Stripe.Subscription): Promise<void> {
+  const userId = stripeSub.metadata?.vitana_user_id;
+  const tenantId = stripeSub.metadata?.vitana_tenant_id;
+  if (!userId || !tenantId) return;
+  await sb()
+    .from('user_subscriptions')
+    .update({
+      status: 'canceled',
+      plan_key: 'free',
+      price_key: null,
+      cancel_at_period_end: false,
+      metadata: { source: 'stripe', last_event: 'subscription.deleted' },
+    })
+    .eq('tenant_id', tenantId)
+    .eq('user_id', userId);
+}
+
+// Helper: pull (user_id, tenant_id) out of an invoice. Stripe SDK v18 changed
+// the surface but invoice.lines.data[0].metadata still carries
+// subscription_data.metadata propagated from the Checkout session. As a
+// belt-and-braces fallback, retrieve the subscription explicitly.
+async function resolveInvoiceIdentity(
+  invoice: Stripe.Invoice
+): Promise<{ userId: string | null; tenantId: string | null }> {
+  const lineMetadata = invoice.lines.data[0]?.metadata as Record<string, string> | undefined;
+  let userId = lineMetadata?.vitana_user_id ?? null;
+  let tenantId = lineMetadata?.vitana_tenant_id ?? null;
+
+  // Cast for SDK-version-tolerant access to legacy subscription_details
+  const inv = invoice as Stripe.Invoice & {
+    subscription_details?: { metadata?: Record<string, string> };
+    subscription?: string | Stripe.Subscription | null;
+  };
+  if (!userId || !tenantId) {
+    userId = userId ?? inv.subscription_details?.metadata?.vitana_user_id ?? null;
+    tenantId = tenantId ?? inv.subscription_details?.metadata?.vitana_tenant_id ?? null;
+  }
+
+  if ((!userId || !tenantId) && inv.subscription) {
+    try {
+      const subId = typeof inv.subscription === 'string' ? inv.subscription : inv.subscription.id;
+      const sub = await getStripe().subscriptions.retrieve(subId);
+      userId = userId ?? (sub.metadata?.vitana_user_id as string | undefined) ?? null;
+      tenantId = tenantId ?? (sub.metadata?.vitana_tenant_id as string | undefined) ?? null;
+    } catch (err) {
+      console.warn(`${LOG_PREFIX} resolveInvoiceIdentity: subscription retrieve failed: ${err instanceof Error ? err.message : String(err)}`);
+    }
+  }
+
+  return { userId, tenantId };
+}
+
+async function handleInvoicePaid(invoice: Stripe.Invoice): Promise<void> {
+  const { userId, tenantId } = await resolveInvoiceIdentity(invoice);
+  if (!userId || !tenantId) return;
+  await sb()
+    .from('user_subscriptions')
+    .update({ status: 'active', last_payment_error: null })
+    .eq('tenant_id', tenantId)
+    .eq('user_id', userId);
+}
+
+async function handleInvoiceFailed(invoice: Stripe.Invoice): Promise<void> {
+  const { userId, tenantId } = await resolveInvoiceIdentity(invoice);
+  if (!userId || !tenantId) return;
+  const inv = invoice as Stripe.Invoice & { last_finalization_error?: { message?: string } };
+  const lastError = inv.last_finalization_error?.message ?? 'Payment failed';
+  await sb()
+    .from('user_subscriptions')
+    .update({ status: 'past_due', last_payment_error: lastError })
+    .eq('tenant_id', tenantId)
+    .eq('user_id', userId);
+}
+
+// =============================================================================
+// Admin: redemption codes management
+// =============================================================================
+
+/**
+ * POST /admin/redemption-codes/generate
+ *   Body: { campaign: string, count: number, grant_duration_days?: number,
+ *           grants_plan?: string, prefix?: string, expires_at?: string }
+ *
+ *   Generates `count` unique codes of pattern PREFIX-CAMPAIGN-XXXX-XXXX
+ *   (base32-ish alphabet, no ambiguous chars). Default grant_duration_days=365
+ *   (test-cohort default), grants_plan='premium'.
+ *
+ *   Returns the generated codes; admin downloads CSV and hand-delivers.
+ */
+router.post(
+  '/admin/redemption-codes/generate',
+  requireAuth,
+  requireExafyAdmin,
+  async (req: AuthenticatedRequest, res: Response) => {
+    const identity = req.identity!;
+    const body = req.body || {};
+    const campaign: string | undefined = body.campaign;
+    const count = Math.min(1000, Math.max(1, parseInt(String(body.count ?? '0'), 10) || 0));
+    const grantDurationDays = Math.min(730, Math.max(1, parseInt(String(body.grant_duration_days ?? '365'), 10) || 365));
+    const grantsPlan: string = typeof body.grants_plan === 'string' ? body.grants_plan : 'premium';
+    const prefix: string = typeof body.prefix === 'string' ? body.prefix.toUpperCase().replace(/[^A-Z]/g, '').slice(0, 12) || 'VITANA' : 'VITANA';
+    const expiresAt: string | null = typeof body.expires_at === 'string' ? body.expires_at : null;
+
+    if (!campaign || typeof campaign !== 'string' || campaign.length < 2) {
+      return res.status(400).json({ ok: false, error: 'MISSING_CAMPAIGN' });
+    }
+    if (count < 1) {
+      return res.status(400).json({ ok: false, error: 'INVALID_COUNT' });
+    }
+
+    // Validate plan exists
+    const { data: planRow } = await sb()
+      .from('subscription_plans')
+      .select('plan_key')
+      .eq('plan_key', grantsPlan)
+      .maybeSingle();
+    if (!planRow) {
+      return res.status(400).json({ ok: false, error: 'PLAN_NOT_FOUND', plan_key: grantsPlan });
+    }
+
+    const ALPHABET = 'ABCDEFGHJKLMNPQRSTUVWXYZ23456789'; // Crockford-ish base32 (no 0/O/1/I)
+    function gen4(): string {
+      let out = '';
+      const buf = require('crypto').randomBytes(4);
+      for (let i = 0; i < 4; i++) {
+        out += ALPHABET[buf[i] % ALPHABET.length];
+      }
+      return out;
+    }
+
+    const campaignToken = campaign.toUpperCase().replace(/[^A-Z0-9]/g, '').slice(0, 16);
+    const generated: Array<{ code: string }> = [];
+    const inserts: Array<Record<string, unknown>> = [];
+    for (let i = 0; i < count; i++) {
+      const code = `${prefix}-${campaignToken}-${gen4()}-${gen4()}`;
+      generated.push({ code });
+      inserts.push({
+        code,
+        campaign,
+        grants_plan: grantsPlan,
+        grant_duration_days: grantDurationDays,
+        max_uses: 1,
+        uses_count: 0,
+        expires_at: expiresAt,
+        created_by: identity.user_id,
+        is_active: true,
+        metadata: { issued_by_admin: identity.user_id, prefix },
+      });
+    }
+
+    const { error } = await sb().from('redemption_codes').insert(inserts);
+    if (error) {
+      console.error(`${LOG_PREFIX} admin generate codes failed: ${error.message}`);
+      return res.status(500).json({ ok: false, error: 'INSERT_FAILED', message: error.message });
+    }
+
+    return res.json({
+      ok: true,
+      generated: generated.length,
+      campaign,
+      grants_plan: grantsPlan,
+      grant_duration_days: grantDurationDays,
+      codes: generated,
+      vtid: VTID,
+    });
+  }
+);
+
+/**
+ * GET /admin/redemption-codes
+ *   Query: ?campaign=...&limit=...&offset=...&include_codes=false
+ *
+ *   Lists codes per campaign with usage stats. By default `include_codes=false`
+ *   so unredeemed codes are not exposed beyond the admin who generated them
+ *   (screenshot-leak protection). Set ?include_codes=true to see full code values.
+ */
+router.get(
+  '/admin/redemption-codes',
+  requireAuth,
+  requireExafyAdmin,
+  async (req: AuthenticatedRequest, res: Response) => {
+    const campaign = (req.query.campaign as string | undefined) || null;
+    const limit = Math.min(500, Math.max(1, parseInt((req.query.limit as string) || '100', 10) || 100));
+    const offset = Math.max(0, parseInt((req.query.offset as string) || '0', 10) || 0);
+    const includeCodes = String(req.query.include_codes ?? 'false') === 'true';
+
+    let query = sb()
+      .from('redemption_codes')
+      .select('code, campaign, grants_plan, grant_duration_days, max_uses, uses_count, expires_at, is_active, created_at, created_by, metadata')
+      .order('created_at', { ascending: false })
+      .range(offset, offset + limit - 1);
+    if (campaign) {
+      query = query.eq('campaign', campaign);
+    }
+    const { data, error } = await query;
+    if (error) {
+      return res.status(500).json({ ok: false, error: 'QUERY_FAILED', message: error.message });
+    }
+
+    const rows = (data || []).map((row) => {
+      if (!includeCodes) {
+        // Redact the code; show only a hash-prefix so the admin can match to CSV
+        const r = row as Record<string, unknown>;
+        const codeStr = String(r.code || '');
+        const masked = codeStr.length > 8 ? `${codeStr.slice(0, 7)}…${codeStr.slice(-2)}` : codeStr;
+        return { ...row, code: masked };
+      }
+      return row;
+    });
+
+    return res.json({ ok: true, count: rows.length, codes: rows, vtid: VTID });
+  }
+);
+
+/**
+ * PATCH /admin/redemption-codes/:code
+ *   Body: { is_active: boolean }
+ *
+ *   Activate or deactivate a single code (e.g., on leak detection).
+ */
+router.patch(
+  '/admin/redemption-codes/:code',
+  requireAuth,
+  requireExafyAdmin,
+  async (req: AuthenticatedRequest, res: Response) => {
+    const codeParam = req.params.code;
+    const isActive = typeof req.body?.is_active === 'boolean' ? req.body.is_active : null;
+    if (isActive === null) {
+      return res.status(400).json({ ok: false, error: 'MISSING_IS_ACTIVE' });
+    }
+    const { data, error } = await sb()
+      .from('redemption_codes')
+      .update({ is_active: isActive })
+      .eq('code', codeParam)
+      .select('code, is_active')
+      .maybeSingle();
+    if (error) {
+      return res.status(500).json({ ok: false, error: 'UPDATE_FAILED', message: error.message });
+    }
+    if (!data) {
+      return res.status(404).json({ ok: false, error: 'CODE_NOT_FOUND', code: codeParam });
+    }
+    return res.json({ ok: true, code: (data as { code: string }).code, is_active: (data as { is_active: boolean }).is_active, vtid: VTID });
+  }
+);
+
+// =============================================================================
+// VTID marker for grep
+// =============================================================================
+export const _VTID = VTID;
+export default router;

--- a/services/gateway/src/routes/billing.ts
+++ b/services/gateway/src/routes/billing.ts
@@ -578,6 +578,67 @@ router.post('/redeem', requireAuth, async (req: AuthenticatedRequest, res: Respo
 });
 
 // =============================================================================
+// GET /founding-status  — public Founding-campaign progress for the launch banner
+// =============================================================================
+//
+// Returns the active Founding campaign's uses_count + max_uses + code so the
+// frontend marketing banner can render real-time scarcity ("X of N spots
+// remaining"). Public — no auth required. Returns the code ONLY when the
+// campaign is still public (is_active=true AND has_spots).
+//
+// When the campaign is exhausted or deactivated, we still return shape but
+// `code` is null so the frontend banner can hide cleanly.
+// =============================================================================
+
+router.get('/founding-status', async (_req: Request, res: Response) => {
+  try {
+    const { data, error } = await sb()
+      .from('redemption_codes')
+      .select('code, max_uses, uses_count, is_active, expires_at, campaign, metadata')
+      .eq('campaign', 'founding_500')
+      .order('created_at', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+
+    if (error) {
+      console.warn(`${LOG_PREFIX} /founding-status query error: ${error.message}`);
+      return res.json({ ok: true, active: false, vtid: VTID });
+    }
+    if (!data) {
+      return res.json({ ok: true, active: false, vtid: VTID });
+    }
+
+    const row = data as {
+      code: string;
+      max_uses: number;
+      uses_count: number;
+      is_active: boolean;
+      expires_at: string | null;
+      campaign: string;
+      metadata: Record<string, unknown> | null;
+    };
+    const expired = row.expires_at ? new Date(row.expires_at).getTime() < Date.now() : false;
+    const hasSpots = row.uses_count < row.max_uses;
+    const active = row.is_active && hasSpots && !expired;
+
+    return res.json({
+      ok: true,
+      active,
+      uses_count: row.uses_count,
+      max_uses: row.max_uses,
+      remaining: Math.max(0, row.max_uses - row.uses_count),
+      code: active ? row.code : null,
+      campaign: row.campaign,
+      vtid: VTID,
+    });
+  } catch (err: unknown) {
+    const message = err instanceof Error ? err.message : String(err);
+    console.warn(`${LOG_PREFIX} /founding-status crash: ${message}`);
+    return res.json({ ok: true, active: false, vtid: VTID });
+  }
+});
+
+// =============================================================================
 // POST /webhooks/stripe  — customer-side webhook
 // =============================================================================
 //

--- a/services/gateway/src/routes/billing.ts
+++ b/services/gateway/src/routes/billing.ts
@@ -1087,6 +1087,142 @@ router.patch(
 );
 
 // =============================================================================
+// GET /admin/billing/metrics  — operator dashboard KPIs (PR-6)
+// =============================================================================
+// Aggregates over the v1 schema for the Command Hub billing dashboard:
+//   - MRR / ARR derived from active subscriptions × their monthly price
+//   - Subs by plan_key (active + trialing)
+//   - Paywall funnel counts (shown / upgraded / credit_paid /
+//     deferred_for_vulnerability / degraded) over the last 30 days
+//   - Code redemptions by campaign over the last 30 days
+//   - Voice degrade events over the last 7 days
+//   - Marketing budget remaining (cents) from tenant_settings.feature_flags
+//
+// No new tables. All reads. Admin-only.
+// =============================================================================
+
+router.get(
+  '/admin/metrics',
+  requireAuth,
+  requireExafyAdmin,
+  async (_req: AuthenticatedRequest, res: Response) => {
+    try {
+      const supabase = sb();
+      const since30d = new Date(Date.now() - 30 * 24 * 60 * 60 * 1000).toISOString();
+      const since7d = new Date(Date.now() - 7 * 24 * 60 * 60 * 1000).toISOString();
+
+      // 1. Active subscriptions joined with their monthly price for MRR/ARR
+      const { data: activeSubs } = await supabase
+        .from('user_subscriptions')
+        .select('plan_key, price_key, status')
+        .in('status', ['active', 'trialing', 'past_due']);
+
+      const planCounts: Record<string, number> = {};
+      const trialingCount: Record<string, number> = {};
+      const planKeys = new Set<string>();
+      ((activeSubs as Array<{ plan_key: string; price_key: string | null; status: string }>) || []).forEach(
+        (row) => {
+          planCounts[row.plan_key] = (planCounts[row.plan_key] || 0) + 1;
+          if (row.status === 'trialing') {
+            trialingCount[row.plan_key] = (trialingCount[row.plan_key] || 0) + 1;
+          }
+          planKeys.add(row.plan_key);
+        }
+      );
+
+      // Read monthly prices per plan to compute MRR
+      const { data: prices } = await supabase
+        .from('subscription_plan_prices')
+        .select('plan_key, billing_interval, price_cents')
+        .eq('billing_interval', 'month')
+        .eq('is_active', true);
+      const monthlyPriceCents: Record<string, number> = {};
+      ((prices as Array<{ plan_key: string; billing_interval: string; price_cents: number }>) || []).forEach(
+        (p) => {
+          monthlyPriceCents[p.plan_key] = p.price_cents;
+        }
+      );
+      let mrrCents = 0;
+      Object.entries(planCounts).forEach(([plan, count]) => {
+        const trialing = trialingCount[plan] || 0;
+        const paying = count - trialing;
+        mrrCents += paying * (monthlyPriceCents[plan] || 0);
+      });
+
+      // 2. Paywall funnel (last 30d)
+      const { data: paywallEvents } = await supabase
+        .from('paywall_events')
+        .select('action')
+        .gte('created_at', since30d);
+      const funnel: Record<string, number> = {};
+      ((paywallEvents as Array<{ action: string }>) || []).forEach((row) => {
+        funnel[row.action] = (funnel[row.action] || 0) + 1;
+      });
+
+      // 3. Code redemptions by campaign (last 30d)
+      const { data: redemptions } = await supabase
+        .from('redemption_redemptions')
+        .select('campaign, grant_value_cents')
+        .gte('redeemed_at', since30d);
+      const redemptionsByCampaign: Record<string, { count: number; grant_value_cents: number }> = {};
+      ((redemptions as Array<{ campaign: string; grant_value_cents: number }>) || []).forEach((row) => {
+        const c = redemptionsByCampaign[row.campaign] || { count: 0, grant_value_cents: 0 };
+        c.count += 1;
+        c.grant_value_cents += row.grant_value_cents || 0;
+        redemptionsByCampaign[row.campaign] = c;
+      });
+
+      // 4. Voice degrade events (last 7d)
+      const { data: degradeEvents } = await supabase
+        .from('paywall_events')
+        .select('id')
+        .eq('action', 'degraded')
+        .eq('feature_key', 'voice_live_minutes')
+        .gte('created_at', since7d);
+      const voiceDegradeCount7d = (degradeEvents as Array<unknown>)?.length ?? 0;
+
+      // 5. Marketing budget remaining
+      let budgetRemainingCents: number | null = null;
+      try {
+        const { data: budgetRow } = await supabase
+          .from('tenant_settings')
+          .select('feature_flags')
+          .maybeSingle();
+        const flags = (budgetRow as { feature_flags?: Record<string, unknown> } | null)?.feature_flags;
+        const val = flags?.marketing_budget_eur_remaining_cents;
+        if (typeof val === 'number') budgetRemainingCents = val;
+      } catch (err) {
+        console.warn(`${LOG_PREFIX} budget query error: ${err instanceof Error ? err.message : String(err)}`);
+      }
+
+      return res.json({
+        ok: true,
+        generated_at: new Date().toISOString(),
+        revenue: {
+          mrr_cents: mrrCents,
+          arr_cents: mrrCents * 12,
+          currency: 'eur',
+        },
+        subscriptions: {
+          total_active_or_trialing: Object.values(planCounts).reduce((a, b) => a + b, 0),
+          by_plan: planCounts,
+          trialing_by_plan: trialingCount,
+        },
+        paywall_funnel_30d: funnel,
+        redemptions_30d: redemptionsByCampaign,
+        voice_degrade_count_7d: voiceDegradeCount7d,
+        marketing_budget_remaining_cents: budgetRemainingCents,
+        vtid: VTID,
+      });
+    } catch (err: unknown) {
+      const message = err instanceof Error ? err.message : String(err);
+      console.error(`${LOG_PREFIX} /admin/metrics crash: ${message}`);
+      return res.status(500).json({ ok: false, error: 'INTERNAL_ERROR', message, vtid: VTID });
+    }
+  }
+);
+
+// =============================================================================
 // VTID marker for grep
 // =============================================================================
 export const _VTID = VTID;

--- a/services/gateway/src/routes/billing.ts
+++ b/services/gateway/src/routes/billing.ts
@@ -224,29 +224,115 @@ router.get('/me', requireAuth, async (req: AuthenticatedRequest, res: Response) 
       .eq('user_id', identity.user_id)
       .maybeSingle();
 
-    // Usage rollup for the 6 metered features (only for current plan)
+    // Usage rollup for the 6 metered features (only for current plan).
+    // Post rolling-windows migration (20260526100000), Free tier carries
+    // window_5h_quota + weekly_quota in addition to monthly. Paid tiers keep
+    // monthly-only (other columns NULL). We surface all configured windows so
+    // the UI shows "5h resets in 2h" + "Weekly resets Mon" side-by-side
+    // (Codex/Claude pattern).
     const { data: entitlementRows } = await sb()
       .from('feature_entitlements')
-      .select('feature_key, quota, window_seconds, unit, behavior_on_exceed')
+      .select('feature_key, quota, window_seconds, window_5h_quota, weekly_quota, unit, behavior_on_exceed')
       .eq('plan_key', plan.plan_key);
 
-    const usage: Record<string, { used: number; quota: number; reset_at: string | null; unit: string; behavior: string }> = {};
+    type EntitlementRow = {
+      feature_key: string;
+      quota: number;
+      window_seconds: number;
+      window_5h_quota: number | null;
+      weekly_quota: number | null;
+      unit: string;
+      behavior_on_exceed: string;
+    };
+
+    type WindowSnapshot = {
+      name: 'window_5h' | 'weekly' | 'monthly';
+      used: number;
+      limit: number;
+      reset_at: string | null;
+    };
+
+    const SECONDS_5H = 5 * 60 * 60;
+    const SECONDS_WEEK = 7 * 24 * 60 * 60;
+
+    const usage: Record<string, {
+      used: number;
+      quota: number;
+      reset_at: string | null;
+      unit: string;
+      behavior: string;
+      windows: WindowSnapshot[];
+      binding_window: 'window_5h' | 'weekly' | 'monthly';
+    }> = {};
+
     if (entitlementRows) {
-      for (const row of entitlementRows as Array<{ feature_key: string; quota: number; window_seconds: number; unit: string; behavior_on_exceed: string }>) {
-        const { data: u } = await sb().rpc('fn_get_feature_usage', {
+      for (const row of entitlementRows as EntitlementRow[]) {
+        const windows: WindowSnapshot[] = [];
+
+        if (row.window_5h_quota != null) {
+          const { data: w } = await sb().rpc('fn_get_feature_usage_in_window', {
+            p_tenant_id: identity.tenant_id,
+            p_user_id: identity.user_id,
+            p_feature_key: row.feature_key,
+            p_window_seconds: SECONDS_5H,
+          });
+          windows.push({
+            name: 'window_5h',
+            used: (w as { used?: number })?.used ?? 0,
+            limit: row.window_5h_quota,
+            reset_at: (w as { reset_at?: string })?.reset_at ?? null,
+          });
+        }
+
+        if (row.weekly_quota != null) {
+          const { data: w } = await sb().rpc('fn_get_feature_usage_in_window', {
+            p_tenant_id: identity.tenant_id,
+            p_user_id: identity.user_id,
+            p_feature_key: row.feature_key,
+            p_window_seconds: SECONDS_WEEK,
+          });
+          windows.push({
+            name: 'weekly',
+            used: (w as { used?: number })?.used ?? 0,
+            limit: row.weekly_quota,
+            reset_at: (w as { reset_at?: string })?.reset_at ?? null,
+          });
+        }
+
+        // Monthly always present
+        const { data: m } = await sb().rpc('fn_get_feature_usage', {
           p_tenant_id: identity.tenant_id,
           p_user_id: identity.user_id,
           p_feature_key: row.feature_key,
           p_window_seconds: row.window_seconds,
         });
-        const used = (u as { used?: number })?.used ?? 0;
-        const resetAt = (u as { window_end?: string })?.window_end ?? null;
+        windows.push({
+          name: 'monthly',
+          used: (m as { used?: number })?.used ?? 0,
+          limit: row.quota,
+          reset_at: (m as { window_end?: string })?.window_end ?? null,
+        });
+
+        // Pick binding window (least remaining; ties go to shortest window)
+        let bindingIdx = 0;
+        let bestRemaining = windows[0].limit - windows[0].used;
+        for (let i = 1; i < windows.length; i++) {
+          const remaining = windows[i].limit - windows[i].used;
+          if (remaining < bestRemaining) {
+            bestRemaining = remaining;
+            bindingIdx = i;
+          }
+        }
+        const binding = windows[bindingIdx];
+
         usage[row.feature_key] = {
-          used,
-          quota: row.quota,
-          reset_at: resetAt,
+          used: binding.used,
+          quota: binding.limit,
+          reset_at: binding.reset_at,
           unit: row.unit,
           behavior: row.behavior_on_exceed,
+          windows,
+          binding_window: binding.name,
         };
       }
     }
@@ -518,15 +604,10 @@ router.post('/credits/spend', requireAuth, async (req: AuthenticatedRequest, res
   }
 
   // Advance the feature usage meter so the entitlement engine sees the spend
-  // as "consumed" — the PAYG credits paid for the units.
-  const { data: cfg } = await sb()
-    .from('feature_entitlements')
-    .select('window_seconds')
-    .eq('plan_key', (await getUserPlan(identity.user_id, identity.tenant_id)).plan_key)
-    .eq('feature_key', feature)
-    .maybeSingle();
-  const windowSeconds = (cfg as { window_seconds?: number })?.window_seconds ?? 2592000;
-  await recordUsage(identity.user_id, identity.tenant_id, feature, units, windowSeconds);
+  // as "consumed" — the PAYG credits paid for the units. Per-minute event
+  // granularity (post rolling-windows migration) — entitlement-service handles
+  // window aggregation downstream.
+  await recordUsage(identity.user_id, identity.tenant_id, feature, units);
 
   return res.json({ ...result, ok: true, units_purchased: units, vtid: VTID });
 });

--- a/services/gateway/src/routes/live.ts
+++ b/services/gateway/src/routes/live.ts
@@ -28,6 +28,13 @@ import { z } from 'zod';
 import { randomUUID } from 'crypto';
 import { emitOasisEvent } from '../services/oasis-event-service';
 import { DailyClient } from '../services/daily-client';
+// VTID-03107: Live Room hosting quota enforcement
+import { verifyAndExtractIdentity } from '../middleware/auth-supabase-jwt';
+import {
+  checkEntitlement,
+  recordUsage,
+  recordPaywallEvent,
+} from '../services/entitlement-service';
 import { RoomSessionManager } from '../services/room-session-manager';
 import Stripe from 'stripe';
 import rateLimit from 'express-rate-limit';
@@ -400,6 +407,70 @@ router.post('/rooms/:id/start', async (req: Request, res: Response) => {
     return res.status(400).json({ ok: false, error: 'Invalid room ID format' });
   }
 
+  // VTID-03107: Live Room hosting quota check (BEFORE the live_room_start RPC).
+  // Fails open on any internal error — never block a legitimate room start
+  // because the entitlement service had a hiccup.
+  let liveRoomEntitlement: Awaited<ReturnType<typeof checkEntitlement>> | null = null;
+  try {
+    const verified = await verifyAndExtractIdentity(token);
+    const identity = verified?.identity;
+    if (identity?.user_id && identity?.tenant_id) {
+      liveRoomEntitlement = await checkEntitlement(
+        identity.user_id,
+        identity.tenant_id,
+        'live_room_minutes',
+        { amount: 1, authToken: token }
+      );
+
+      // Hard block when host has zero remaining minutes (free user past quota
+      // or any tier whose live_room_minutes hit `behavior_on_exceed='hard_block'`).
+      // D36 deferral has already been applied inside checkEntitlement.
+      if (
+        liveRoomEntitlement.paywall_action === 'hard_block' ||
+        liveRoomEntitlement.paywall_action === 'paywall'
+      ) {
+        await recordPaywallEvent(identity.user_id, identity.tenant_id, 'live_room_minutes', 'shown', {
+          context: 'room_start_blocked',
+          remaining: liveRoomEntitlement.remaining,
+          vtid: 'VTID-03107',
+        });
+        return res.status(402).json({
+          ok: false,
+          error: 'payment_required',
+          paywall: {
+            feature: 'live_room_minutes',
+            tier: liveRoomEntitlement.tier,
+            quota: liveRoomEntitlement.quota,
+            used: liveRoomEntitlement.used,
+            remaining: liveRoomEntitlement.remaining,
+            reset_at: liveRoomEntitlement.reset_at,
+            credit_cost_per_unit: liveRoomEntitlement.credit_cost_per_unit,
+            user_credit_balance: liveRoomEntitlement.user_credit_balance,
+            allowed_burn_buckets: liveRoomEntitlement.allowed_burn_buckets,
+            credit_option:
+              liveRoomEntitlement.credit_cost_per_unit > 0
+                ? {
+                    cost_per_unit: liveRoomEntitlement.credit_cost_per_unit,
+                    balance: liveRoomEntitlement.user_credit_balance,
+                    balance_sufficient_for_one_unit:
+                      liveRoomEntitlement.user_credit_balance >=
+                      liveRoomEntitlement.credit_cost_per_unit,
+                    endpoint: '/api/v1/billing/credits/spend',
+                  }
+                : null,
+            upgrade_url: '/api/v1/billing/checkout/subscription',
+            paywall_action: liveRoomEntitlement.paywall_action,
+          },
+          vtid: 'VTID-03107',
+        });
+      }
+    }
+  } catch (err: unknown) {
+    console.warn(
+      `[VTID-03107] live_room_minutes entitlement check failed (failing open): ${err instanceof Error ? err.message : String(err)}`
+    );
+  }
+
   const result = await callRpc(token, 'live_room_start', {
     p_live_room_id: roomId
   });
@@ -445,11 +516,23 @@ router.post('/rooms/:id/start', async (req: Request, res: Response) => {
 
   console.log(`[VTID-01090] Live room started: ${roomId}`);
 
+  // VTID-03107: Surface session budget so the frontend SessionTimer can
+  // count down from minutes_allowed = remaining quota.
   return res.status(200).json({
     ok: true,
     live_room_id: roomId,
     status: 'live',
-    started_at: result.data?.started_at
+    started_at: result.data?.started_at,
+    session_budget: liveRoomEntitlement
+      ? {
+          minutes_allowed: liveRoomEntitlement.remaining,
+          tier: liveRoomEntitlement.tier,
+          quota: liveRoomEntitlement.quota,
+          used: liveRoomEntitlement.used,
+          reset_at: liveRoomEntitlement.reset_at,
+          deferred_for_vulnerability: liveRoomEntitlement.deferred_for_vulnerability,
+        }
+      : null,
   });
 });
 
@@ -482,6 +565,36 @@ router.post('/rooms/:id/end', async (req: Request, res: Response) => {
       result.error?.includes('ROOM_NOT_FOUND') ? 404 :
       result.error?.includes('INVALID_STATE') ? 409 : 502;
     return res.status(statusCode).json({ ok: false, error: result.error });
+  }
+
+  // VTID-03107: Record actual hosting minutes consumed. Best-effort — never
+  // block the room-end response on a metering error.
+  try {
+    const startedAtIso = result.data?.started_at as string | undefined;
+    const endedAtIso = result.data?.ended_at as string | undefined;
+    if (startedAtIso && endedAtIso) {
+      const elapsedMs = new Date(endedAtIso).getTime() - new Date(startedAtIso).getTime();
+      const elapsedMinutes = Math.max(0, Math.ceil(elapsedMs / 60_000));
+      if (elapsedMinutes > 0) {
+        const verified = await verifyAndExtractIdentity(token);
+        if (verified?.identity?.user_id && verified.identity.tenant_id) {
+          await recordUsage(
+            verified.identity.user_id,
+            verified.identity.tenant_id,
+            'live_room_minutes',
+            elapsedMinutes,
+            2592000
+          );
+          console.log(
+            `[VTID-03107] recorded ${elapsedMinutes} live_room_minutes for user=${verified.identity.user_id}`
+          );
+        }
+      }
+    }
+  } catch (err: unknown) {
+    console.warn(
+      `[VTID-03107] live_room_minutes usage record failed (non-blocking): ${err instanceof Error ? err.message : String(err)}`
+    );
   }
 
   // Sync to community_live_streams (so LiveRooms listing reflects ended state)

--- a/services/gateway/src/routes/live.ts
+++ b/services/gateway/src/routes/live.ts
@@ -582,8 +582,7 @@ router.post('/rooms/:id/end', async (req: Request, res: Response) => {
             verified.identity.user_id,
             verified.identity.tenant_id,
             'live_room_minutes',
-            elapsedMinutes,
-            2592000
+            elapsedMinutes
           );
           console.log(
             `[VTID-03107] recorded ${elapsedMinutes} live_room_minutes for user=${verified.identity.user_id}`

--- a/services/gateway/src/services/entitlement-service.ts
+++ b/services/gateway/src/services/entitlement-service.ts
@@ -1,0 +1,578 @@
+/**
+ * VTID-03107 · Billing v1 — Entitlement service
+ *
+ * Single source of truth for "can this user use this feature right now?"
+ *
+ * Public API:
+ *   checkEntitlement(userId, tenantId, feature, opts?) → CheckResult
+ *   recordUsage(userId, tenantId, feature, amount=1)   → void
+ *   consumeCredits(userId, tenantId, feature, units,
+ *                  idempotencyKey, bucket?)            → ConsumeResult
+ *   getUserPlan(userId, tenantId)                      → PlanSnapshot
+ *   recordPaywallEvent(userId, tenantId, feature,
+ *                      action, context?)               → void
+ *
+ * D36 hook
+ *   Before returning a `paywall` or `hard_block` outcome, this service calls
+ *   the D36 monetization-readiness engine. If D36 says NOT allow_paid
+ *   (emotional vulnerability, recent rejection, cooldown), the outcome is
+ *   downgraded to `deferred` and a paywall_events row with
+ *   action='deferred_for_vulnerability' is written. Callers should treat
+ *   `deferred` as "allow, but do not increment usage and do not show paywall."
+ *
+ * Cashflow guardrails
+ *   - `allowed_burn_buckets` config on feature_entitlements controls which
+ *     wallet buckets can fund overage. Voice/Rooms default to
+ *     {purchased_credits} only. Cash_balance is NEVER spendable.
+ *   - Reward credits cannot pay for voice or rooms by default (enforced via
+ *     the seed config in migration 8).
+ *
+ * No new tables — only reads/writes existing v1 schema (subscription_plans,
+ * user_subscriptions, feature_entitlements, feature_usage, paywall_events,
+ * wallet_balances + RPCs fn_increment_feature_usage / fn_get_feature_usage /
+ * fn_consume_credits).
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabase } from '../lib/supabase';
+import { computeMonetizationContext } from './d36-financial-monetization-engine';
+
+const VTID = 'VTID-03107';
+const LOG_PREFIX = '[entitlement-service]';
+
+// =============================================================================
+// Types
+// =============================================================================
+
+export type BehaviorOnExceed =
+  | 'paywall'
+  | 'degrade'
+  | 'hard_block'
+  | 'soft_counter';
+
+export type PaywallAction =
+  | 'allow'           // quota available; caller proceeds normally
+  | 'soft_counter'    // quota exhausted but behavior=soft_counter — caller proceeds and shows UI badge
+  | 'paywall'         // quota exhausted, caller returns 402 with structured body
+  | 'degrade'         // quota exhausted, caller switches to fallback (voice → Standard)
+  | 'hard_block'      // quota exhausted, caller returns 402 without PAYG option
+  | 'deferred';       // D36 protection — caller proceeds without increment, no UI paywall
+
+export type WalletBucket = 'purchased_credits' | 'reward_credits' | 'cash_balance';
+
+export interface EntitlementConfig {
+  plan_key: string;
+  feature_key: string;
+  quota: number;
+  window_seconds: number;
+  unit: 'count' | 'minutes' | 'bytes';
+  behavior_on_exceed: BehaviorOnExceed;
+  credit_cost_per_unit: number;
+  allowed_burn_buckets: WalletBucket[];
+}
+
+export interface PlanSnapshot {
+  plan_key: string;
+  status: string;
+  current_period_end: string | null;
+  cancel_at_period_end: boolean;
+  trial_end: string | null;
+  metadata: Record<string, unknown>;
+}
+
+export interface CheckResult {
+  allowed: boolean;
+  paywall_action: PaywallAction;
+  feature: string;
+  tier: string;
+  quota: number;
+  used: number;
+  remaining: number;
+  reset_at: string | null;
+  credit_cost_per_unit: number;
+  user_credit_balance: number;
+  allowed_burn_buckets: WalletBucket[];
+  deferred_for_vulnerability: boolean;
+}
+
+export interface ConsumeResult {
+  ok: boolean;
+  error?: string;
+  bucket?: string;
+  bucket_balance?: number;
+  duplicate?: boolean;
+}
+
+export interface CheckEntitlementOpts {
+  amount?: number;          // requested amount (default 1) — for unit='minutes' could be a chunk size
+  sessionId?: string;       // for D36 history tracking
+  authToken?: string;       // user JWT (for D36 to read their personal monetization-signals)
+  skipD36?: boolean;        // bypass D36 for admin/system flows (default false)
+}
+
+// =============================================================================
+// Helpers
+// =============================================================================
+
+function client(): SupabaseClient {
+  const sb = getSupabase();
+  if (!sb) {
+    throw new Error(`${LOG_PREFIX} Supabase service client unavailable — check SUPABASE_URL + SUPABASE_SERVICE_ROLE env`);
+  }
+  return sb;
+}
+
+function isAllowedPaywallAction(action: PaywallAction): boolean {
+  return action === 'allow' || action === 'soft_counter' || action === 'deferred' || action === 'degrade';
+}
+
+/**
+ * Default behavior when no feature_entitlements row exists. Fail closed to
+ * paywall — we never silently allow an unknown feature.
+ */
+const DEFAULT_FAIL_CLOSED: BehaviorOnExceed = 'paywall';
+
+// =============================================================================
+// Public API — getUserPlan
+// =============================================================================
+
+/**
+ * Read the user's current subscription state. Defaults to 'free' if no row.
+ */
+export async function getUserPlan(userId: string, tenantId: string): Promise<PlanSnapshot> {
+  const sb = client();
+  const { data, error } = await sb
+    .from('user_subscriptions')
+    .select('plan_key, status, current_period_end, cancel_at_period_end, trial_end, metadata')
+    .eq('tenant_id', tenantId)
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (error) {
+    console.error(`${LOG_PREFIX} getUserPlan error for user=${userId}: ${error.message}`);
+    return {
+      plan_key: 'free',
+      status: 'free',
+      current_period_end: null,
+      cancel_at_period_end: false,
+      trial_end: null,
+      metadata: {},
+    };
+  }
+
+  if (!data) {
+    return {
+      plan_key: 'free',
+      status: 'free',
+      current_period_end: null,
+      cancel_at_period_end: false,
+      trial_end: null,
+      metadata: {},
+    };
+  }
+
+  return {
+    plan_key: data.plan_key,
+    status: data.status,
+    current_period_end: data.current_period_end,
+    cancel_at_period_end: !!data.cancel_at_period_end,
+    trial_end: data.trial_end,
+    metadata: (data.metadata as Record<string, unknown>) || {},
+  };
+}
+
+// =============================================================================
+// Internal — readEntitlementConfig
+// =============================================================================
+
+async function readEntitlementConfig(
+  planKey: string,
+  feature: string
+): Promise<EntitlementConfig | null> {
+  const sb = client();
+  const { data, error } = await sb
+    .from('feature_entitlements')
+    .select('plan_key, feature_key, quota, window_seconds, unit, behavior_on_exceed, credit_cost_per_unit, allowed_burn_buckets')
+    .eq('plan_key', planKey)
+    .eq('feature_key', feature)
+    .maybeSingle();
+
+  if (error) {
+    console.error(`${LOG_PREFIX} readEntitlementConfig(${planKey},${feature}) error: ${error.message}`);
+    return null;
+  }
+  if (!data) return null;
+
+  return {
+    plan_key: data.plan_key,
+    feature_key: data.feature_key,
+    quota: data.quota,
+    window_seconds: data.window_seconds,
+    unit: data.unit as 'count' | 'minutes' | 'bytes',
+    behavior_on_exceed: data.behavior_on_exceed as BehaviorOnExceed,
+    credit_cost_per_unit: data.credit_cost_per_unit,
+    allowed_burn_buckets: (data.allowed_burn_buckets as WalletBucket[]) || ['purchased_credits'],
+  };
+}
+
+// =============================================================================
+// Internal — readUsageInCurrentWindow
+// =============================================================================
+
+interface UsageSnapshot {
+  used: number;
+  window_end: string | null;
+}
+
+async function readUsageInCurrentWindow(
+  tenantId: string,
+  userId: string,
+  feature: string,
+  windowSeconds: number
+): Promise<UsageSnapshot> {
+  const sb = client();
+  const { data, error } = await sb.rpc('fn_get_feature_usage', {
+    p_tenant_id: tenantId,
+    p_user_id: userId,
+    p_feature_key: feature,
+    p_window_seconds: windowSeconds,
+  });
+
+  if (error || !data) {
+    console.error(`${LOG_PREFIX} fn_get_feature_usage error: ${error?.message}`);
+    return { used: 0, window_end: null };
+  }
+
+  const result = data as Record<string, unknown>;
+  return {
+    used: (result.used as number) || 0,
+    window_end: (result.window_end as string) || null,
+  };
+}
+
+// =============================================================================
+// Internal — readWalletBuckets
+// =============================================================================
+
+interface WalletBucketsSnapshot {
+  purchased_credits: number;
+  reward_credits: number;
+  cash_balance: number;
+}
+
+async function readWalletBuckets(
+  tenantId: string,
+  userId: string
+): Promise<WalletBucketsSnapshot> {
+  const sb = client();
+  const { data, error } = await sb
+    .from('wallet_balances')
+    .select('purchased_credits, reward_credits, cash_balance')
+    .eq('tenant_id', tenantId)
+    .eq('user_id', userId)
+    .maybeSingle();
+
+  if (error || !data) {
+    return { purchased_credits: 0, reward_credits: 0, cash_balance: 0 };
+  }
+  return {
+    purchased_credits: data.purchased_credits || 0,
+    reward_credits: data.reward_credits || 0,
+    cash_balance: data.cash_balance || 0,
+  };
+}
+
+/**
+ * Returns the credit balance available to fund overage for a given feature,
+ * respecting `allowed_burn_buckets` config.
+ */
+function bucketsToBalance(
+  buckets: WalletBucketsSnapshot,
+  allowed: WalletBucket[]
+): number {
+  return allowed.reduce((sum, b) => sum + (buckets[b] || 0), 0);
+}
+
+// =============================================================================
+// Public API — checkEntitlement
+// =============================================================================
+
+export async function checkEntitlement(
+  userId: string,
+  tenantId: string,
+  feature: string,
+  opts: CheckEntitlementOpts = {}
+): Promise<CheckResult> {
+  const amount = Math.max(1, opts.amount ?? 1);
+
+  // 1. Resolve plan
+  const plan = await getUserPlan(userId, tenantId);
+  const planKey = plan.plan_key || 'free';
+
+  // 2. Resolve entitlement config (fail closed if missing)
+  const config = await readEntitlementConfig(planKey, feature);
+  if (!config) {
+    console.warn(`${LOG_PREFIX} No entitlement config for (${planKey}, ${feature}) — failing closed to paywall`);
+    return {
+      allowed: false,
+      paywall_action: DEFAULT_FAIL_CLOSED,
+      feature,
+      tier: planKey,
+      quota: 0,
+      used: 0,
+      remaining: 0,
+      reset_at: null,
+      credit_cost_per_unit: 0,
+      user_credit_balance: 0,
+      allowed_burn_buckets: ['purchased_credits'],
+      deferred_for_vulnerability: false,
+    };
+  }
+
+  // 3. Read current usage in the current rolling window
+  const usage = await readUsageInCurrentWindow(tenantId, userId, feature, config.window_seconds);
+  const remaining = config.quota - usage.used;
+
+  // 4. Read wallet buckets relevant to this feature's allowed_burn_buckets
+  const buckets = await readWalletBuckets(tenantId, userId);
+  const userCreditBalance = bucketsToBalance(buckets, config.allowed_burn_buckets);
+
+  // 5. Decide outcome
+  // If the request fits within remaining quota → allow
+  if (remaining >= amount) {
+    return {
+      allowed: true,
+      paywall_action: 'allow',
+      feature,
+      tier: planKey,
+      quota: config.quota,
+      used: usage.used,
+      remaining,
+      reset_at: usage.window_end,
+      credit_cost_per_unit: config.credit_cost_per_unit,
+      user_credit_balance: userCreditBalance,
+      allowed_burn_buckets: config.allowed_burn_buckets,
+      deferred_for_vulnerability: false,
+    };
+  }
+
+  // Quota exhausted. Translate behavior_on_exceed to a paywall_action.
+  let action: PaywallAction;
+  switch (config.behavior_on_exceed) {
+    case 'soft_counter':
+      action = 'soft_counter';
+      break;
+    case 'degrade':
+      action = 'degrade';
+      break;
+    case 'hard_block':
+      action = 'hard_block';
+      break;
+    case 'paywall':
+    default:
+      action = 'paywall';
+      break;
+  }
+
+  // 6. D36 deferral hook — only for outcomes that would BLOCK the user
+  // (hard_block, paywall). Degrade is graceful and doesn't need deferral.
+  // soft_counter doesn't block, no deferral needed.
+  let deferredForVulnerability = false;
+  if (!opts.skipD36 && (action === 'paywall' || action === 'hard_block')) {
+    try {
+      const d36 = await computeMonetizationContext(undefined, opts.sessionId, opts.authToken);
+      if (d36.ok && d36.envelope && !d36.envelope.allow_paid) {
+        deferredForVulnerability = true;
+        action = 'deferred';
+        // Audit: write a paywall_events row noting the deferral
+        await recordPaywallEvent(userId, tenantId, feature, 'deferred_for_vulnerability', {
+          original_action: config.behavior_on_exceed,
+          reason: d36.envelope.reason || 'D36 envelope.allow_paid=false',
+          tags: d36.envelope.tags || [],
+          plan: planKey,
+        });
+      }
+    } catch (err) {
+      // D36 failure should not BLOCK monetization (fail open to the configured behavior)
+      console.error(`${LOG_PREFIX} D36 check failed for user=${userId} feature=${feature}: ${err}`);
+    }
+  }
+
+  return {
+    allowed: isAllowedPaywallAction(action),
+    paywall_action: action,
+    feature,
+    tier: planKey,
+    quota: config.quota,
+    used: usage.used,
+    remaining: Math.max(0, remaining),
+    reset_at: usage.window_end,
+    credit_cost_per_unit: config.credit_cost_per_unit,
+    user_credit_balance: userCreditBalance,
+    allowed_burn_buckets: config.allowed_burn_buckets,
+    deferred_for_vulnerability: deferredForVulnerability,
+  };
+}
+
+// =============================================================================
+// Public API — recordUsage
+// =============================================================================
+
+/**
+ * Atomic increment of the user's feature_usage counter in the current
+ * rolling window. Call AFTER the user action has been allowed.
+ *
+ * @returns the new `used` value after increment, or null on error
+ */
+export async function recordUsage(
+  userId: string,
+  tenantId: string,
+  feature: string,
+  amount: number = 1,
+  windowSeconds: number = 2592000
+): Promise<number | null> {
+  const sb = client();
+  const { data, error } = await sb.rpc('fn_increment_feature_usage', {
+    p_tenant_id: tenantId,
+    p_user_id: userId,
+    p_feature_key: feature,
+    p_amount: amount,
+    p_window_seconds: windowSeconds,
+  });
+
+  if (error || !data) {
+    console.error(`${LOG_PREFIX} fn_increment_feature_usage error: ${error?.message}`);
+    return null;
+  }
+  const result = data as Record<string, unknown>;
+  return (result.used as number) ?? null;
+}
+
+// =============================================================================
+// Public API — consumeCredits
+// =============================================================================
+
+/**
+ * Debit the user's wallet to fund overage for a feature. Uses the existing
+ * fn_consume_credits RPC which maps bucket → wallet_transactions.type and
+ * lets the §M trigger route correctly. Idempotent on idempotencyKey.
+ *
+ * When `bucket` is omitted, picks the first allowed bucket from the feature's
+ * config (rewards first if allowed, else purchased) to drain lower-utility
+ * credits first.
+ */
+export async function consumeCredits(
+  userId: string,
+  tenantId: string,
+  feature: string,
+  units: number,
+  idempotencyKey: string,
+  preferredBucket?: WalletBucket
+): Promise<ConsumeResult> {
+  if (units <= 0) {
+    return { ok: false, error: 'INVALID_AMOUNT' };
+  }
+
+  // Resolve the feature's allowed buckets + cost-per-unit
+  const planSnapshot = await getUserPlan(userId, tenantId);
+  const config = await readEntitlementConfig(planSnapshot.plan_key, feature);
+  if (!config || config.credit_cost_per_unit <= 0) {
+    return { ok: false, error: 'PAYG_NOT_AVAILABLE_FOR_FEATURE' };
+  }
+
+  const creditsToDebit = units * config.credit_cost_per_unit;
+  const buckets = await readWalletBuckets(tenantId, userId);
+
+  // Pick bucket: preferred if explicitly given AND allowed, else "rewards
+  // first if allowed and has sufficient balance, else purchased"
+  let bucket: WalletBucket;
+  if (preferredBucket && config.allowed_burn_buckets.includes(preferredBucket)) {
+    bucket = preferredBucket;
+  } else if (
+    config.allowed_burn_buckets.includes('reward_credits') &&
+    buckets.reward_credits >= creditsToDebit
+  ) {
+    bucket = 'reward_credits';
+  } else {
+    bucket = 'purchased_credits';
+  }
+
+  const sb = client();
+  const { data, error } = await sb.rpc('fn_consume_credits', {
+    p_tenant_id: tenantId,
+    p_user_id: userId,
+    p_credits: creditsToDebit,
+    p_bucket: bucket,
+    p_feature_key: feature,
+    p_idempotency_key: idempotencyKey,
+  });
+
+  if (error || !data) {
+    console.error(`${LOG_PREFIX} fn_consume_credits error: ${error?.message}`);
+    return { ok: false, error: 'INTERNAL_ERROR' };
+  }
+
+  const result = data as Record<string, unknown>;
+  if ((result.ok as boolean) === true) {
+    // Audit
+    await recordPaywallEvent(userId, tenantId, feature, 'credit_paid', {
+      bucket,
+      credits_debited: creditsToDebit,
+      units,
+      idempotency_key: idempotencyKey,
+      duplicate: result.duplicate === true,
+    });
+    return {
+      ok: true,
+      bucket: result.bucket as string,
+      bucket_balance: result.bucket_balance as number,
+      duplicate: result.duplicate === true,
+    };
+  }
+
+  return {
+    ok: false,
+    error: (result.error as string) || 'UNKNOWN',
+    bucket: result.bucket as string,
+    bucket_balance: result.bucket_balance as number,
+  };
+}
+
+// =============================================================================
+// Public API — recordPaywallEvent
+// =============================================================================
+
+export type PaywallEventAction =
+  | 'shown'
+  | 'upgraded'
+  | 'rejected'
+  | 'credit_paid'
+  | 'deferred_for_vulnerability'
+  | 'degraded'
+  | 'redeemed'
+  | 'soft_counter_reached';
+
+export async function recordPaywallEvent(
+  userId: string,
+  tenantId: string,
+  feature: string,
+  action: PaywallEventAction,
+  context: Record<string, unknown> = {}
+): Promise<void> {
+  const sb = client();
+  const { error } = await sb.from('paywall_events').insert({
+    tenant_id: tenantId,
+    user_id: userId,
+    feature_key: feature,
+    action,
+    context,
+  });
+  if (error) {
+    console.error(`${LOG_PREFIX} recordPaywallEvent(${action}) error: ${error.message}`);
+  }
+}
+
+// =============================================================================
+// VTID marker for grep
+// =============================================================================
+export const _VTID = VTID;

--- a/services/gateway/src/services/entitlement-service.ts
+++ b/services/gateway/src/services/entitlement-service.ts
@@ -63,13 +63,25 @@ export type WalletBucket = 'purchased_credits' | 'reward_credits' | 'cash_balanc
 export interface EntitlementConfig {
   plan_key: string;
   feature_key: string;
-  quota: number;
-  window_seconds: number;
+  quota: number;              // monthly cap (always set)
+  window_seconds: number;     // monthly window (default 30 days)
+  window_5h_quota: number | null;   // optional rolling 5h cap (Free tier only)
+  weekly_quota: number | null;      // optional rolling 7d cap (Free tier only)
   unit: 'count' | 'minutes' | 'bytes';
   behavior_on_exceed: BehaviorOnExceed;
   credit_cost_per_unit: number;
   allowed_burn_buckets: WalletBucket[];
 }
+
+/** Per-window snapshot exposed on /billing/me + paywall responses. */
+export interface UsageWindow {
+  name: 'window_5h' | 'weekly' | 'monthly';
+  used: number;
+  limit: number;
+  reset_at: string | null;
+}
+
+export type BindingWindow = 'window_5h' | 'weekly' | 'monthly';
 
 export interface PlanSnapshot {
   plan_key: string;
@@ -85,10 +97,16 @@ export interface CheckResult {
   paywall_action: PaywallAction;
   feature: string;
   tier: string;
+  // Legacy single-window fields kept for backwards compat with existing callers.
+  // These mirror the BINDING window (most restrictive of the three).
   quota: number;
   used: number;
   remaining: number;
   reset_at: string | null;
+  // Multi-window detail — surfaced to the UI so the user sees both
+  // "5h resets in 2h 14m" and "Weekly resets Mon 1 Jun".
+  windows: UsageWindow[];
+  binding_window: BindingWindow;
   credit_cost_per_unit: number;
   user_credit_balance: number;
   allowed_burn_buckets: WalletBucket[];
@@ -192,7 +210,7 @@ async function readEntitlementConfig(
   const sb = client();
   const { data, error } = await sb
     .from('feature_entitlements')
-    .select('plan_key, feature_key, quota, window_seconds, unit, behavior_on_exceed, credit_cost_per_unit, allowed_burn_buckets')
+    .select('plan_key, feature_key, quota, window_seconds, window_5h_quota, weekly_quota, unit, behavior_on_exceed, credit_cost_per_unit, allowed_burn_buckets')
     .eq('plan_key', planKey)
     .eq('feature_key', feature)
     .maybeSingle();
@@ -208,6 +226,8 @@ async function readEntitlementConfig(
     feature_key: data.feature_key,
     quota: data.quota,
     window_seconds: data.window_seconds,
+    window_5h_quota: (data as { window_5h_quota?: number | null }).window_5h_quota ?? null,
+    weekly_quota: (data as { weekly_quota?: number | null }).weekly_quota ?? null,
     unit: data.unit as 'count' | 'minutes' | 'bytes',
     behavior_on_exceed: data.behavior_on_exceed as BehaviorOnExceed,
     credit_cost_per_unit: data.credit_cost_per_unit,
@@ -221,9 +241,13 @@ async function readEntitlementConfig(
 
 interface UsageSnapshot {
   used: number;
-  window_end: string | null;
+  reset_at: string | null;
 }
 
+/**
+ * Calendar-aligned bucket read (used for the monthly window). This is the
+ * historical fn_get_feature_usage RPC — kept for backwards compat.
+ */
 async function readUsageInCurrentWindow(
   tenantId: string,
   userId: string,
@@ -240,14 +264,108 @@ async function readUsageInCurrentWindow(
 
   if (error || !data) {
     console.error(`${LOG_PREFIX} fn_get_feature_usage error: ${error?.message}`);
-    return { used: 0, window_end: null };
+    return { used: 0, reset_at: null };
   }
 
   const result = data as Record<string, unknown>;
   return {
     used: (result.used as number) || 0,
-    window_end: (result.window_end as string) || null,
+    reset_at: (result.window_end as string) || null,
   };
+}
+
+/**
+ * Sliding-window aggregation (used for 5h + weekly Free-tier rolling caps).
+ * Shipped in migration 20260526100000. Returns SUM(used) over events in the
+ * last `windowSeconds` plus the effective reset_at (= oldest event ages out).
+ */
+async function readUsageInSlidingWindow(
+  tenantId: string,
+  userId: string,
+  feature: string,
+  windowSeconds: number
+): Promise<UsageSnapshot> {
+  const sb = client();
+  const { data, error } = await sb.rpc('fn_get_feature_usage_in_window', {
+    p_tenant_id: tenantId,
+    p_user_id: userId,
+    p_feature_key: feature,
+    p_window_seconds: windowSeconds,
+  });
+
+  if (error || !data) {
+    console.error(`${LOG_PREFIX} fn_get_feature_usage_in_window error: ${error?.message}`);
+    return { used: 0, reset_at: null };
+  }
+
+  const result = data as Record<string, unknown>;
+  return {
+    used: (result.used as number) || 0,
+    reset_at: (result.reset_at as string) || null,
+  };
+}
+
+const SECONDS_PER_5H = 5 * 60 * 60;
+const SECONDS_PER_WEEK = 7 * 24 * 60 * 60;
+
+/**
+ * Build the per-feature usage windows array. Includes only the windows that
+ * are configured (window_5h/weekly are optional; monthly is always present).
+ */
+async function readAllWindows(
+  tenantId: string,
+  userId: string,
+  config: EntitlementConfig
+): Promise<UsageWindow[]> {
+  const windows: UsageWindow[] = [];
+
+  if (config.window_5h_quota !== null && config.window_5h_quota !== undefined) {
+    const u = await readUsageInSlidingWindow(tenantId, userId, config.feature_key, SECONDS_PER_5H);
+    windows.push({
+      name: 'window_5h',
+      used: u.used,
+      limit: config.window_5h_quota,
+      reset_at: u.reset_at,
+    });
+  }
+
+  if (config.weekly_quota !== null && config.weekly_quota !== undefined) {
+    const u = await readUsageInSlidingWindow(tenantId, userId, config.feature_key, SECONDS_PER_WEEK);
+    windows.push({
+      name: 'weekly',
+      used: u.used,
+      limit: config.weekly_quota,
+      reset_at: u.reset_at,
+    });
+  }
+
+  const monthly = await readUsageInCurrentWindow(tenantId, userId, config.feature_key, config.window_seconds);
+  windows.push({
+    name: 'monthly',
+    used: monthly.used,
+    limit: config.quota,
+    reset_at: monthly.reset_at,
+  });
+
+  return windows;
+}
+
+/**
+ * Pick the binding window: the one with the LEAST remaining (or already
+ * over-quota). Ties broken by shortest reset time (window_5h before weekly
+ * before monthly).
+ */
+function pickBindingWindow(windows: UsageWindow[]): { window: UsageWindow; index: number } {
+  let bestIdx = 0;
+  let bestRemaining = windows[0].limit - windows[0].used;
+  for (let i = 1; i < windows.length; i++) {
+    const remaining = windows[i].limit - windows[i].used;
+    if (remaining < bestRemaining) {
+      bestRemaining = remaining;
+      bestIdx = i;
+    }
+  }
+  return { window: windows[bestIdx], index: bestIdx };
 }
 
 // =============================================================================
@@ -322,6 +440,8 @@ export async function checkEntitlement(
       used: 0,
       remaining: 0,
       reset_at: null,
+      windows: [],
+      binding_window: 'monthly',
       credit_cost_per_unit: 0,
       user_credit_balance: 0,
       allowed_burn_buckets: ['purchased_credits'],
@@ -329,26 +449,30 @@ export async function checkEntitlement(
     };
   }
 
-  // 3. Read current usage in the current rolling window
-  const usage = await readUsageInCurrentWindow(tenantId, userId, feature, config.window_seconds);
-  const remaining = config.quota - usage.used;
+  // 3. Read usage in every configured window (5h / weekly / monthly).
+  //    Paid tiers only have monthly; Free has all three.
+  const windows = await readAllWindows(tenantId, userId, config);
+  const binding = pickBindingWindow(windows);
+  const remaining = binding.window.limit - binding.window.used;
 
   // 4. Read wallet buckets relevant to this feature's allowed_burn_buckets
   const buckets = await readWalletBuckets(tenantId, userId);
   const userCreditBalance = bucketsToBalance(buckets, config.allowed_burn_buckets);
 
   // 5. Decide outcome
-  // If the request fits within remaining quota → allow
+  // If the request fits within the BINDING window's remaining quota → allow
   if (remaining >= amount) {
     return {
       allowed: true,
       paywall_action: 'allow',
       feature,
       tier: planKey,
-      quota: config.quota,
-      used: usage.used,
+      quota: binding.window.limit,
+      used: binding.window.used,
       remaining,
-      reset_at: usage.window_end,
+      reset_at: binding.window.reset_at,
+      windows,
+      binding_window: binding.window.name,
       credit_cost_per_unit: config.credit_cost_per_unit,
       user_credit_balance: userCreditBalance,
       allowed_burn_buckets: config.allowed_burn_buckets,
@@ -403,10 +527,12 @@ export async function checkEntitlement(
     paywall_action: action,
     feature,
     tier: planKey,
-    quota: config.quota,
-    used: usage.used,
+    quota: binding.window.limit,
+    used: binding.window.used,
     remaining: Math.max(0, remaining),
-    reset_at: usage.window_end,
+    reset_at: binding.window.reset_at,
+    windows,
+    binding_window: binding.window.name,
     credit_cost_per_unit: config.credit_cost_per_unit,
     user_credit_balance: userCreditBalance,
     allowed_burn_buckets: config.allowed_burn_buckets,
@@ -419,25 +545,36 @@ export async function checkEntitlement(
 // =============================================================================
 
 /**
- * Atomic increment of the user's feature_usage counter in the current
- * rolling window. Call AFTER the user action has been allowed.
+ * Atomic increment of the user's feature_usage counter. Call AFTER the user
+ * action has been allowed.
  *
- * @returns the new `used` value after increment, or null on error
+ * Writes a per-minute event row so sliding-window aggregation (5h, weekly)
+ * works correctly. Same-minute increments fold into the same row via the
+ * existing ON CONFLICT (user_id, feature_key, window_start).
+ *
+ * Sliding aggregation reads via fn_get_feature_usage_in_window (SUM over
+ * recent minute rows). Monthly aggregation (calendar-aligned) is computed
+ * client-side over the same minute rows by passing 30d to the same RPC, OR
+ * the legacy fn_get_feature_usage if the caller wants epoch-aligned buckets.
+ *
+ * @returns the new `used` value after increment in the minute-bucket, or
+ *          null on error. (Callers usually care about the aggregate, not
+ *          the per-minute total.)
  */
 export async function recordUsage(
   userId: string,
   tenantId: string,
   feature: string,
-  amount: number = 1,
-  windowSeconds: number = 2592000
+  amount: number = 1
 ): Promise<number | null> {
   const sb = client();
+  // Always write at minute granularity so sliding-window SUM works.
   const { data, error } = await sb.rpc('fn_increment_feature_usage', {
     p_tenant_id: tenantId,
     p_user_id: userId,
     p_feature_key: feature,
     p_amount: amount,
-    p_window_seconds: windowSeconds,
+    p_window_seconds: 60,
   });
 
   if (error || !data) {

--- a/services/gateway/src/services/lifecycle-notification-worker.ts
+++ b/services/gateway/src/services/lifecycle-notification-worker.ts
@@ -1,0 +1,177 @@
+/**
+ * VTID-03107 · Gateway worker: trial lifecycle notifications.
+ *
+ * Polls lifecycle_notification_state for rows fired in the last 2 hours
+ * whose notified_at is NULL, fans out via notifyUserAsync, marks notified_at.
+ *
+ * The SQL processor (fn_process_lifecycle_notifications, hourly pg_cron)
+ * does the milestone detection + idempotency PK; this worker only does
+ * the notification dispatch.
+ *
+ * i18n bodies for each kind live inline below as English placeholders. A
+ * follow-up will move them to src/i18n/ shards via the existing gateway
+ * server-side i18n catalog (services/gateway/src/i18n/catalog.ts) per the
+ * PR-#2269 server-side i18n hard rule. For v1 launch the English shape is
+ * what ops can preview; localized strings are a fast follow.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabase } from '../lib/supabase';
+import { notifyUserAsync } from './notification-service';
+
+const VTID = 'VTID-03107';
+const LOG_PREFIX = '[lifecycle-notification-worker]';
+const POLL_INTERVAL_MS = 5 * 60 * 1000; // 5 minutes
+const LOOK_BACK_HOURS = 2;
+
+interface LifecycleStateRow {
+  user_id: string;
+  tenant_id: string;
+  lifecycle_kind: string;
+  subscription_id: string | null;
+  metadata: Record<string, unknown> | null;
+  fired_at: string;
+}
+
+/**
+ * Inline copy per lifecycle kind. Placeholder English; i18n is a follow-up.
+ * Each entry is the notification body the user sees on lock screen + in-app.
+ * Keys not present here = unknown kind, worker logs warn + marks row processed.
+ */
+const COPY: Record<string, { title: string; body: string }> = {
+  trial_welcome: {
+    title: 'Welcome to Premium',
+    body: 'Your free trial has started. Take a look around — your full access is active.',
+  },
+  trial_midpoint: {
+    title: "You're halfway through your trial",
+    body: 'A week of Premium gone — keep going at €9.99/mo or stay on Free with the limits.',
+  },
+  trial_ending_2d: {
+    title: 'Your trial ends in 2 days',
+    body: "Want to keep what you've been using? Add a payment method anytime.",
+  },
+  trial_ending_1d: {
+    title: 'Your trial ends tomorrow',
+    body: 'Add a payment method to keep Premium, or stay on Free with the limits.',
+  },
+  trial_cancelled_winback: {
+    title: 'Your memory garden and streak stay',
+    body: 'Premium is no longer active. Come back anytime — your data is waiting.',
+  },
+  trial_winback_one_shot: {
+    title: 'Your community is still here',
+    body: 'Want to give Premium another week, on us? Tap to see what changed.',
+  },
+  founding_midpoint: {
+    title: "You're halfway through your Founding Member period",
+    body: '45 days of Premium gone, 45 to go. Enjoy.',
+  },
+  founding_ending_2d: {
+    title: 'Founding Member period ends in 2 days',
+    body: 'Want to keep Premium past day 90? Add a payment method anytime.',
+  },
+  founding_ending_1d: {
+    title: 'Founding Member period ends tomorrow',
+    body: 'Add a payment method to keep Premium, or stay on Free with the limits.',
+  },
+};
+
+let pollerHandle: NodeJS.Timeout | null = null;
+let inFlight = false;
+
+async function processBatch(): Promise<void> {
+  if (inFlight) return;
+  inFlight = true;
+  try {
+    const sb = getSupabase();
+    if (!sb) {
+      console.warn(`${LOG_PREFIX} Supabase unavailable — skipping cycle`);
+      return;
+    }
+
+    const sinceIso = new Date(Date.now() - LOOK_BACK_HOURS * 3600_000).toISOString();
+    const { data, error } = await sb
+      .from('lifecycle_notification_state')
+      .select('user_id, tenant_id, lifecycle_kind, subscription_id, metadata, fired_at')
+      .gte('fired_at', sinceIso)
+      .is('notified_at', null)
+      .limit(500);
+
+    if (error) {
+      if (/notified_at/i.test(error.message) || /column .* does not exist/i.test(error.message)) {
+        // Migration not applied — soft-fail until ops applies it.
+        return;
+      }
+      console.warn(`${LOG_PREFIX} query failed: ${error.message}`);
+      return;
+    }
+
+    const rows = (data || []) as LifecycleStateRow[];
+    if (!rows.length) return;
+    console.log(`${LOG_PREFIX} processing ${rows.length} lifecycle event(s)`);
+
+    for (const row of rows) {
+      const copy = COPY[row.lifecycle_kind];
+      if (!copy) {
+        console.warn(`${LOG_PREFIX} unknown lifecycle_kind: ${row.lifecycle_kind}`);
+      } else {
+        try {
+          notifyUserAsync(
+            row.user_id,
+            row.tenant_id,
+            row.lifecycle_kind,
+            {
+              title: copy.title,
+              body: copy.body,
+              data: {
+                lifecycle_kind: row.lifecycle_kind,
+                vtid: VTID,
+              },
+            },
+            sb as SupabaseClient<any, any, any>,
+          );
+        } catch (err) {
+          console.warn(
+            `${LOG_PREFIX} notifyUserAsync failed for ${row.user_id} ${row.lifecycle_kind}: ${err instanceof Error ? err.message : String(err)}`
+          );
+        }
+      }
+
+      const { error: updErr } = await sb
+        .from('lifecycle_notification_state')
+        .update({ notified_at: new Date().toISOString() })
+        .eq('user_id', row.user_id)
+        .eq('lifecycle_kind', row.lifecycle_kind);
+      if (updErr) {
+        console.warn(
+          `${LOG_PREFIX} mark-notified failed for ${row.user_id} ${row.lifecycle_kind}: ${updErr.message}`
+        );
+      }
+    }
+  } catch (err) {
+    console.warn(
+      `${LOG_PREFIX} unexpected error: ${err instanceof Error ? err.message : String(err)}`
+    );
+  } finally {
+    inFlight = false;
+  }
+}
+
+export function startLifecycleNotificationWorker(): void {
+  if (pollerHandle) return;
+  console.log(`${LOG_PREFIX} starting (poll interval ${POLL_INTERVAL_MS}ms)`);
+  processBatch().catch(() => {});
+  pollerHandle = setInterval(() => {
+    processBatch().catch(() => {});
+  }, POLL_INTERVAL_MS);
+}
+
+export function stopLifecycleNotificationWorker(): void {
+  if (pollerHandle) {
+    clearInterval(pollerHandle);
+    pollerHandle = null;
+  }
+}
+
+export const _VTID = VTID;

--- a/services/gateway/src/services/notification-service.ts
+++ b/services/gateway/src/services/notification-service.ts
@@ -137,6 +137,16 @@ const TYPE_META: Record<string, TypeMeta> = {
   // Admin Companion (BOOTSTRAP-ADMIN-EE)
   admin_insight_urgent:        { channel: 'push_and_inapp', priority: 'p0', category: 'system' },
   admin_insight_action_needed: { channel: 'inapp',          priority: 'p1', category: 'system' },
+  // Billing lifecycle (VTID-03107) — Duolingo-style trial / cancel / win-back
+  trial_welcome:               { channel: 'push_and_inapp', priority: 'p1', category: 'system' },
+  trial_midpoint:              { channel: 'inapp',          priority: 'p2', category: 'system' },
+  trial_ending_2d:             { channel: 'push_and_inapp', priority: 'p1', category: 'system' },
+  trial_ending_1d:             { channel: 'push_and_inapp', priority: 'p1', category: 'system' },
+  trial_cancelled_winback:     { channel: 'inapp',          priority: 'p2', category: 'system' },
+  trial_winback_one_shot:      { channel: 'inapp',          priority: 'p3', category: 'system' },
+  founding_midpoint:           { channel: 'inapp',          priority: 'p2', category: 'system' },
+  founding_ending_2d:          { channel: 'push_and_inapp', priority: 'p1', category: 'system' },
+  founding_ending_1d:          { channel: 'push_and_inapp', priority: 'p1', category: 'system' },
   // Wallet & Business (VTID-01250)
   wallet_credits_earned:       { channel: 'push_and_inapp', priority: 'p1', category: 'offer' },
   wallet_payout_received:      { channel: 'push_and_inapp', priority: 'p1', category: 'offer' },

--- a/services/gateway/src/services/voice-quota-guard.ts
+++ b/services/gateway/src/services/voice-quota-guard.ts
@@ -109,7 +109,7 @@ export async function recordVoiceMinute(
   isDeferred: boolean = false
 ): Promise<number | null> {
   if (isDeferred) return null;
-  return recordUsage(userId, tenantId, FEATURE_VOICE_LIVE_MINUTES, 1, 2592000);
+  return recordUsage(userId, tenantId, FEATURE_VOICE_LIVE_MINUTES, 1);
 }
 
 /**

--- a/services/gateway/src/services/voice-quota-guard.ts
+++ b/services/gateway/src/services/voice-quota-guard.ts
@@ -1,0 +1,164 @@
+/**
+ * VTID-03107 · Voice quota guard service.
+ *
+ * Helper that orb-live.ts will call (in a follow-up surgical PR) to enforce
+ * the Live AI voice (`voice_live_minutes`) quota during a session.
+ *
+ * Shipped in this PR as a typed, side-effect-free helper. Integration into
+ * the orb-live.ts hot path (the WebSocket session handler that runs Gemini
+ * Live, per A8.3a.2 upstream-message-handler) is intentionally deferred — the
+ * memory rules around orb-live.ts call out the renderApp / voice teardown
+ * order / "no degraded flag in voice tool responses" patterns, and any
+ * touch there needs explicit review.
+ *
+ * Three operations the eventual integration will use:
+ *
+ *   reserveVoiceQuotaAtSessionStart(userId, tenantId, authToken?)
+ *     Called from /orb/live/session/start route. Returns the entitlement
+ *     snapshot so the session state can stash quota + decide whether to
+ *     start on the Live tier vs. immediately route to Standard.
+ *
+ *   recordVoiceMinute(userId, tenantId)
+ *     Called once per minute of Live audio from the per-turn handler.
+ *     Atomically increments feature_usage; returns the new `used` value so
+ *     the caller can compare against the entitlement's `quota`.
+ *
+ *   triggerDowngrade(userId, tenantId, sseWriter, reason)
+ *     Called when remaining hits 0. Writes a paywall_events row and emits
+ *     the dedicated `orb.tier.downgraded` SSE event over the existing
+ *     client stream (NOT inside any tool-response payload — Gemini reads
+ *     `degraded:true` as failure; see memory rule from 2026-05-04).
+ *
+ * D36 deferral
+ *   reserveVoiceQuotaAtSessionStart goes through checkEntitlement, which
+ *   already calls D36 before any 'paywall' / 'hard_block' outcome. If the
+ *   user is vulnerable, the outcome is 'deferred' and the caller treats
+ *   that as "allow normally, do not increment usage."
+ */
+
+import {
+  checkEntitlement,
+  recordUsage,
+  recordPaywallEvent,
+  type CheckResult,
+} from './entitlement-service';
+
+const VTID = 'VTID-03107';
+const LOG_PREFIX = '[voice-quota-guard]';
+
+const FEATURE_VOICE_LIVE_MINUTES = 'voice_live_minutes';
+
+export interface VoiceQuotaReservation {
+  feature: typeof FEATURE_VOICE_LIVE_MINUTES;
+  paywall_action: CheckResult['paywall_action'];
+  quota: number;
+  used: number;
+  remaining: number;
+  reset_at: string | null;
+  start_on_standard_tier: boolean;
+  deferred_for_vulnerability: boolean;
+}
+
+/**
+ * Called at the start of a Live voice session. Returns whether the user has
+ * any Live minutes left, and what tier the session should START on.
+ *
+ *   - allow: start on Live (the usual path)
+ *   - degrade: start on Standard (Cartesia + Flash); quota already exhausted
+ *   - deferred (D36): start on Live but don't burn the meter — user is
+ *                     in a vulnerable state and we extend silently
+ *   - paywall / hard_block: caller should 402 the session-start request
+ */
+export async function reserveVoiceQuotaAtSessionStart(
+  userId: string,
+  tenantId: string,
+  opts: { sessionId?: string; authToken?: string } = {}
+): Promise<VoiceQuotaReservation> {
+  const result = await checkEntitlement(userId, tenantId, FEATURE_VOICE_LIVE_MINUTES, {
+    amount: 1,
+    sessionId: opts.sessionId,
+    authToken: opts.authToken,
+  });
+
+  return {
+    feature: FEATURE_VOICE_LIVE_MINUTES,
+    paywall_action: result.paywall_action,
+    quota: result.quota,
+    used: result.used,
+    remaining: result.remaining,
+    reset_at: result.reset_at,
+    start_on_standard_tier:
+      result.paywall_action === 'degrade' ||
+      result.paywall_action === 'paywall' ||
+      result.paywall_action === 'hard_block',
+    deferred_for_vulnerability: result.deferred_for_vulnerability,
+  };
+}
+
+/**
+ * Atomic per-minute meter increment. Call once per minute of Live audio.
+ * Returns the new `used` value so caller can decide whether to flip the
+ * session to Standard mode mid-call.
+ *
+ * No-op (returns null) for sessions in deferred mode — D36 protection means
+ * we never advance the meter for a vulnerable user.
+ */
+export async function recordVoiceMinute(
+  userId: string,
+  tenantId: string,
+  isDeferred: boolean = false
+): Promise<number | null> {
+  if (isDeferred) return null;
+  return recordUsage(userId, tenantId, FEATURE_VOICE_LIVE_MINUTES, 1, 2592000);
+}
+
+/**
+ * Wire-format for the dedicated SSE event the frontend listens for.
+ * This is a DEDICATED event channel — never inside a tool-response payload.
+ * See memory rule (2026-05-04 / "No degraded/partial flags in voice-tool
+ * responses"): Gemini Live reads `degraded:true` inside its tool envelope
+ * as a tool-call failure and apologizes to the user even when ok:true.
+ */
+export interface OrbTierDowngradedEvent {
+  type: 'orb.tier.downgraded';
+  new_tier: 'standard';
+  reason: 'daily_quota' | 'session_quota' | 'plan_exhausted';
+  feature: typeof FEATURE_VOICE_LIVE_MINUTES;
+}
+
+/**
+ * SSE writer signature this guard accepts. The caller (orb-live.ts) passes a
+ * thin wrapper around its existing `writeSseEvent` (A9.2 SSE transport
+ * boundary). We don't import that directly to avoid an import cycle.
+ */
+export type SseWriter = (eventName: string, dataJson: string) => void;
+
+/**
+ * Mark a session as degraded. Writes the audit row (paywall_events.action=
+ * 'degraded') and emits the SSE event the frontend's OrbVoiceClient listens
+ * for (`vitana:orb-tier-downgraded` window event).
+ */
+export async function triggerDowngrade(
+  userId: string,
+  tenantId: string,
+  writeSse: SseWriter,
+  reason: OrbTierDowngradedEvent['reason'] = 'daily_quota'
+): Promise<void> {
+  const event: OrbTierDowngradedEvent = {
+    type: 'orb.tier.downgraded',
+    new_tier: 'standard',
+    reason,
+    feature: FEATURE_VOICE_LIVE_MINUTES,
+  };
+  try {
+    writeSse('message', JSON.stringify(event));
+  } catch (err) {
+    console.error(`${LOG_PREFIX} Failed to write SSE downgrade event: ${err instanceof Error ? err.message : String(err)}`);
+  }
+  await recordPaywallEvent(userId, tenantId, FEATURE_VOICE_LIVE_MINUTES, 'degraded', {
+    reason,
+    vtid: VTID,
+  });
+}
+
+export const _VTID = VTID;

--- a/services/gateway/test/orb/live/session/live-session-controller.test.ts
+++ b/services/gateway/test/orb/live/session/live-session-controller.test.ts
@@ -13,7 +13,28 @@
  *   - `configureLiveSessionController` is required before any handler fires.
  *   - Double-configure throws (catches mis-wired tests / boot loudly).
  *   - `__resetLiveSessionControllerForTests` clears state for clean tests.
+ *
+ * VTID-03107: mock voice-quota-guard so the new entitlement gate in
+ * handleLiveSessionStart does not query a (test-mode) Supabase that has no
+ * feature_entitlements seeded. Default mock returns `paywall_action='allow'`
+ * so every pre-existing authenticated test keeps passing. Quota-exhausted
+ * behavior gets its own focused test below.
  */
+
+jest.mock('../../../../src/services/voice-quota-guard', () => ({
+  reserveVoiceQuotaAtSessionStart: jest.fn(async () => ({
+    feature: 'voice_live_minutes',
+    paywall_action: 'allow',
+    quota: 600,
+    used: 0,
+    remaining: 600,
+    reset_at: null,
+    start_on_standard_tier: false,
+    deferred_for_vulnerability: false,
+  })),
+  recordVoiceMinute: jest.fn(async () => 0),
+  triggerDowngrade: jest.fn(async () => undefined),
+}));
 
 import {
   configureLiveSessionController,
@@ -659,6 +680,94 @@ describe('A8.2.1: handleLiveSessionStart', () => {
     const payload = (res.json.mock.calls[0][0]) as any;
     // wake_brief MAY be non-null even for anonymous sessions; just assert the field exists.
     expect(payload.meta).toHaveProperty('wake_brief');
+  });
+
+  // VTID-03107: voice-quota gate behavior
+  describe('VTID-03107: voice-quota gate', () => {
+    let reserveMock: jest.Mock;
+
+    beforeEach(() => {
+      // Pull a typed handle on the mocked module so each test can override
+      // the per-call return without re-mocking the module.
+      const voiceQuotaModule = require('../../../../src/services/voice-quota-guard');
+      reserveMock = voiceQuotaModule.reserveVoiceQuotaAtSessionStart as jest.Mock;
+      reserveMock.mockClear();
+      // Reset to the default `allow` shape between tests
+      reserveMock.mockResolvedValue({
+        feature: 'voice_live_minutes',
+        paywall_action: 'allow',
+        quota: 600,
+        used: 0,
+        remaining: 600,
+        reset_at: null,
+        start_on_standard_tier: false,
+        deferred_for_vulnerability: false,
+      });
+    });
+
+    it('returns 402 with structured paywall body when quota is exhausted (hard_block)', async () => {
+      configureLiveSessionController(
+        baseDeps({
+          resolveOrbIdentity: async () => ({
+            user_id: 'real-user-uuid',
+            tenant_id: 'tenant-uuid',
+          }) as any,
+        }),
+      );
+      reserveMock.mockResolvedValueOnce({
+        feature: 'voice_live_minutes',
+        paywall_action: 'hard_block',
+        quota: 15,
+        used: 15,
+        remaining: 0,
+        reset_at: '2026-06-01T00:00:00Z',
+        start_on_standard_tier: true,
+        deferred_for_vulnerability: false,
+      });
+      const req = makeReq({
+        identity: { user_id: 'real-user-uuid', tenant_id: 'tenant-uuid' },
+      });
+      const res = makeRes();
+      await handleLiveSessionStart(req, res);
+      expect(res.status).toHaveBeenCalledWith(402);
+      const payload = (res.json.mock.calls[0][0]) as any;
+      expect(payload.ok).toBe(false);
+      expect(payload.error).toBe('payment_required');
+      expect(payload.paywall.feature).toBe('voice_live_minutes');
+      expect(payload.paywall.paywall_action).toBe('hard_block');
+      expect(payload.paywall.upgrade_url).toBe('/api/v1/billing/checkout/subscription');
+    });
+
+    it('allows the session to start normally when quota is available', async () => {
+      configureLiveSessionController(
+        baseDeps({
+          resolveOrbIdentity: async () => ({
+            user_id: 'real-user-uuid',
+            tenant_id: 'tenant-uuid',
+          }) as any,
+        }),
+      );
+      const req = makeReq({
+        identity: { user_id: 'real-user-uuid', tenant_id: 'tenant-uuid' },
+      });
+      const res = makeRes();
+      await handleLiveSessionStart(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(reserveMock).toHaveBeenCalledWith(
+        'real-user-uuid',
+        'tenant-uuid',
+        expect.objectContaining({ authToken: undefined }),
+      );
+    });
+
+    it('skips the quota check entirely for anonymous sessions (no identity)', async () => {
+      configureLiveSessionController(baseDeps());
+      const req = makeReq();
+      const res = makeRes();
+      await handleLiveSessionStart(req, res);
+      expect(res.status).toHaveBeenCalledWith(200);
+      expect(reserveMock).not.toHaveBeenCalled();
+    });
   });
 });
 

--- a/supabase/migrations/20260526000000_VTID_03107_wallet_reconciliation.sql
+++ b/supabase/migrations/20260526000000_VTID_03107_wallet_reconciliation.sql
@@ -1,0 +1,377 @@
+-- =============================================================================
+-- VTID-03107 · Billing v1 — Wallet reconciliation (HARD BLOCKER for PR-1)
+-- =============================================================================
+-- Purpose
+--   Split the existing single `wallet_balances.balance` ledger into three
+--   semantically-distinct buckets so that earned, purchased, and cash-earning
+--   credits cannot be silently converted into expensive features:
+--
+--     purchased_credits  cash-equivalent (Stripe top-ups, ENTER-code grants,
+--                                        refunds, transfers, vtn_convert)
+--     reward_credits     engagement reward (diary streaks, milestones,
+--                                          referrals); limited burn paths
+--     cash_balance       VAEA/hosting payouts (Stripe Connect earnings),
+--                                          withdrawable in cents
+--
+--   `balance` (legacy column) continues to track the SUM of all three buckets
+--   so existing read paths keep working without code change.
+--
+-- Why both `credit_wallet()` RPC AND `update_wallet_balance()` trigger
+--   The trigger fires AFTER INSERT on `wallet_transactions`. Direct inserts
+--   (bypassing the RPC) must also route to the correct bucket. Replacing only
+--   the RPC leaves a real gap.
+--
+-- Backwards-compatibility
+--   `balance` continues to be a valid running total. No existing reader is
+--   broken. The new bucket columns default to 0 and are filled forward;
+--   one-time backfill assigns the historical `balance` to `purchased_credits`
+--   (safest default — most pre-launch state is from Stripe-equivalent flows).
+--
+-- Verification (embedded at end of file)
+--   Synthetic test inserts a reward-typed `wallet_transactions` row WITHOUT
+--   going through `credit_wallet()`, then asserts the trigger routed the
+--   amount to `reward_credits` (and NOT to `purchased_credits`).
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- 1. Schema: add the three bucket columns to wallet_balances
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE public.wallet_balances
+  ADD COLUMN IF NOT EXISTS purchased_credits integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS reward_credits    integer NOT NULL DEFAULT 0,
+  ADD COLUMN IF NOT EXISTS cash_balance      integer NOT NULL DEFAULT 0;
+
+COMMENT ON COLUMN public.wallet_balances.purchased_credits IS
+  'VTID-03107: cash-equivalent credits from Stripe top-ups, ENTER-code grants, refunds, transfers. Can burn against any feature.';
+COMMENT ON COLUMN public.wallet_balances.reward_credits IS
+  'VTID-03107: engagement-earned credits from diary streaks / milestones / referrals. CANNOT burn against Live AI minutes, Room hosting, or subscriptions (cashflow guardrail).';
+COMMENT ON COLUMN public.wallet_balances.cash_balance IS
+  'VTID-03107: cents-denominated cash earnings (Sell-and-Earn affiliate commissions held by Vitana + Stripe Connect hosting payouts). Withdrawable to bank via Stripe Connect Express.';
+COMMENT ON COLUMN public.wallet_balances.balance IS
+  'Legacy sum of purchased_credits + reward_credits + cash_balance. Kept for backward compatibility with existing readers; new code should read the specific bucket column.';
+
+-- -----------------------------------------------------------------------------
+-- 2. One-time backfill: existing balance → purchased_credits
+-- -----------------------------------------------------------------------------
+-- All historical balance is treated as purchased (safe default — pre-launch
+-- the system has near-zero reward and zero earning rows; routing test pre-prod
+-- balances into the most-flexible bucket avoids accidentally restricting
+-- legitimate spend paths).
+--
+-- Idempotent: if migration is re-run (column already 0), no double-credit.
+-- The condition `purchased_credits = 0 AND balance > 0` ensures backfill is
+-- a one-time operation; subsequent runs are no-ops.
+
+UPDATE public.wallet_balances
+SET purchased_credits = balance
+WHERE purchased_credits = 0
+  AND balance > 0;
+
+-- -----------------------------------------------------------------------------
+-- 3. Replace update_wallet_balance() trigger function
+-- -----------------------------------------------------------------------------
+-- Routes NEW.amount to the bucket determined by NEW.type:
+--
+--   'reward'                       → reward_credits
+--   'earning'                      → cash_balance (NEW type for VTID-03107)
+--   'purchase' / 'transfer' /
+--   'refund'   / 'vtn_convert' /
+--   NULL / unknown                  → purchased_credits (safest default)
+--
+-- `balance` continues to be the SUM across buckets (legacy read path).
+-- `total_earned` / `total_spent` continue to track gross flow regardless of
+-- bucket (their existing semantics).
+
+CREATE OR REPLACE FUNCTION public.update_wallet_balance()
+RETURNS trigger AS $$
+DECLARE
+  v_to_purchased integer := 0;
+  v_to_reward    integer := 0;
+  v_to_cash      integer := 0;
+BEGIN
+  -- Route the amount to exactly one bucket
+  IF NEW.type = 'reward' THEN
+    v_to_reward := NEW.amount;
+  ELSIF NEW.type = 'earning' THEN
+    v_to_cash := NEW.amount;
+  ELSE
+    -- purchase, transfer, refund, vtn_convert, NULL, or anything else
+    v_to_purchased := NEW.amount;
+  END IF;
+
+  INSERT INTO public.wallet_balances (
+    tenant_id,
+    user_id,
+    balance,
+    total_earned,
+    total_spent,
+    purchased_credits,
+    reward_credits,
+    cash_balance,
+    updated_at
+  )
+  VALUES (
+    NEW.tenant_id,
+    NEW.user_id,
+    NEW.amount,
+    GREATEST(NEW.amount, 0),
+    GREATEST(-NEW.amount, 0),
+    v_to_purchased,
+    v_to_reward,
+    v_to_cash,
+    now()
+  )
+  ON CONFLICT (tenant_id, user_id) DO UPDATE SET
+    balance           = public.wallet_balances.balance           + NEW.amount,
+    total_earned      = public.wallet_balances.total_earned      + GREATEST(NEW.amount, 0),
+    total_spent       = public.wallet_balances.total_spent       + GREATEST(-NEW.amount, 0),
+    purchased_credits = public.wallet_balances.purchased_credits + v_to_purchased,
+    reward_credits    = public.wallet_balances.reward_credits    + v_to_reward,
+    cash_balance      = public.wallet_balances.cash_balance      + v_to_cash,
+    updated_at        = now();
+
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+COMMENT ON FUNCTION public.update_wallet_balance() IS
+  'VTID-03107: routes wallet_transactions inserts to the correct bucket (purchased_credits / reward_credits / cash_balance) by NEW.type. Maintains `balance` as the legacy total across buckets.';
+
+-- Trigger already exists (trg_wallet_balance_update from 20260318...).
+-- The CREATE OR REPLACE FUNCTION above is enough — no need to re-CREATE the
+-- trigger itself.
+
+-- -----------------------------------------------------------------------------
+-- 4. Replace credit_wallet() RPC
+-- -----------------------------------------------------------------------------
+-- Now handles 'earning' type. Returns the bucket-specific balance in addition
+-- to the legacy 'balance' total so callers can render per-bucket without a
+-- second query.
+--
+-- Insufficient-balance check is per-bucket: a debit of reward_credits cannot
+-- pull from purchased_credits, and vice versa. (Debits to a non-existent row
+-- still fail with INSUFFICIENT_BALANCE.)
+
+CREATE OR REPLACE FUNCTION public.credit_wallet(
+  p_tenant_id        uuid,
+  p_user_id          uuid,
+  p_amount           integer,
+  p_type             text,
+  p_source           text,
+  p_source_event_id  text,
+  p_description      text DEFAULT NULL
+)
+RETURNS jsonb AS $$
+DECLARE
+  v_row              public.wallet_balances%ROWTYPE;
+  v_bucket_name      text;
+  v_current_bucket   integer;
+  v_new_bucket       integer;
+  v_current_total    integer;
+  v_new_total        integer;
+  v_tx_id            uuid;
+BEGIN
+  -- Determine which bucket this transaction targets
+  IF p_type = 'reward' THEN
+    v_bucket_name := 'reward_credits';
+  ELSIF p_type = 'earning' THEN
+    v_bucket_name := 'cash_balance';
+  ELSE
+    v_bucket_name := 'purchased_credits';
+  END IF;
+
+  -- Read the user's current row (may not exist yet)
+  SELECT * INTO v_row
+  FROM public.wallet_balances
+  WHERE tenant_id = p_tenant_id AND user_id = p_user_id;
+
+  -- Current bucket value (0 if no row exists)
+  IF v_row IS NULL THEN
+    v_current_bucket := 0;
+    v_current_total  := 0;
+  ELSE
+    v_current_bucket := CASE v_bucket_name
+                          WHEN 'reward_credits'    THEN v_row.reward_credits
+                          WHEN 'cash_balance'      THEN v_row.cash_balance
+                          ELSE                          v_row.purchased_credits
+                        END;
+    v_current_total  := v_row.balance;
+  END IF;
+
+  v_new_bucket := v_current_bucket + p_amount;
+  v_new_total  := v_current_total  + p_amount;
+
+  -- Prevent negative bucket balance for debits (per-bucket isolation)
+  IF v_new_bucket < 0 THEN
+    RETURN jsonb_build_object(
+      'ok', false,
+      'error', 'INSUFFICIENT_BALANCE',
+      'bucket', v_bucket_name,
+      'bucket_balance', v_current_bucket
+    );
+  END IF;
+
+  -- Insert transaction (idempotent via unique index on source_event_id).
+  -- Trigger handles wallet_balances UPSERT.
+  INSERT INTO public.wallet_transactions (
+    tenant_id, user_id, amount, type, source, source_event_id, description, balance_after
+  )
+  VALUES (
+    p_tenant_id, p_user_id, p_amount, p_type, p_source, p_source_event_id, p_description, v_new_total
+  )
+  ON CONFLICT (tenant_id, user_id, source_event_id) WHERE source_event_id IS NOT NULL
+  DO NOTHING
+  RETURNING id INTO v_tx_id;
+
+  IF v_tx_id IS NULL THEN
+    -- Already credited (idempotent replay)
+    RETURN jsonb_build_object(
+      'ok', true,
+      'duplicate', true,
+      'balance', v_current_total,
+      'bucket', v_bucket_name,
+      'bucket_balance', v_current_bucket
+    );
+  END IF;
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'transaction_id', v_tx_id,
+    'balance', v_new_total,
+    'bucket', v_bucket_name,
+    'bucket_balance', v_new_bucket,
+    'amount', p_amount
+  );
+END;
+$$ LANGUAGE plpgsql SECURITY DEFINER;
+
+COMMENT ON FUNCTION public.credit_wallet IS
+  'VTID-03107: idempotent wallet credit/debit. Routes by p_type into purchased_credits / reward_credits / cash_balance. Returns bucket_name + bucket_balance alongside the legacy balance total.';
+
+-- -----------------------------------------------------------------------------
+-- 5. Embedded verification: trigger correctness for direct INSERTs
+-- -----------------------------------------------------------------------------
+-- This block runs at migration time on staging. It inserts a synthetic
+-- wallet_transactions row of type='reward' for a sentinel user (deterministic
+-- UUID), then asserts the trigger routed the amount to reward_credits and NOT
+-- to purchased_credits. The row is rolled back at the end so production state
+-- is unchanged.
+--
+-- Sentinel UUIDs (all-zero except final byte) avoid collision with real users.
+
+DO $$
+DECLARE
+  v_tenant uuid := '00000000-0000-0000-0000-000000000001';
+  v_user   uuid := '00000000-0000-0000-0000-00000000FEED';
+  v_event  text := 'vtid-03107-migration-verify-' || gen_random_uuid()::text;
+  v_row    public.wallet_balances%ROWTYPE;
+BEGIN
+  -- Direct insert bypassing credit_wallet() RPC — this is the gap §M called out
+  INSERT INTO public.wallet_transactions (
+    tenant_id, user_id, amount, type, source, source_event_id, balance_after
+  ) VALUES (
+    v_tenant, v_user, 100, 'reward', 'vtid-03107-verify', v_event, 100
+  );
+
+  -- Trigger should have UPSERTed wallet_balances. Read it back.
+  SELECT * INTO v_row
+  FROM public.wallet_balances
+  WHERE tenant_id = v_tenant AND user_id = v_user;
+
+  IF v_row IS NULL THEN
+    RAISE EXCEPTION 'VTID-03107 verify: trigger did not insert wallet_balances row';
+  END IF;
+
+  IF v_row.reward_credits <> 100 THEN
+    RAISE EXCEPTION 'VTID-03107 verify: reward_credits is %, expected 100', v_row.reward_credits;
+  END IF;
+
+  IF v_row.purchased_credits <> 0 THEN
+    RAISE EXCEPTION 'VTID-03107 verify: purchased_credits is %, expected 0 (type=reward must not touch this bucket)', v_row.purchased_credits;
+  END IF;
+
+  IF v_row.cash_balance <> 0 THEN
+    RAISE EXCEPTION 'VTID-03107 verify: cash_balance is %, expected 0', v_row.cash_balance;
+  END IF;
+
+  IF v_row.balance <> 100 THEN
+    RAISE EXCEPTION 'VTID-03107 verify: balance (legacy sum) is %, expected 100', v_row.balance;
+  END IF;
+
+  -- Clean up the sentinel row + transaction
+  DELETE FROM public.wallet_transactions
+   WHERE tenant_id = v_tenant AND user_id = v_user AND source_event_id = v_event;
+  DELETE FROM public.wallet_balances
+   WHERE tenant_id = v_tenant AND user_id = v_user;
+
+  RAISE NOTICE 'VTID-03107 wallet reconciliation: trigger routes reward → reward_credits ✓';
+END $$;
+
+-- Second verification: 'earning' routes to cash_balance
+DO $$
+DECLARE
+  v_tenant uuid := '00000000-0000-0000-0000-000000000001';
+  v_user   uuid := '00000000-0000-0000-0000-00000000CA5E';
+  v_event  text := 'vtid-03107-migration-verify-earning-' || gen_random_uuid()::text;
+  v_row    public.wallet_balances%ROWTYPE;
+BEGIN
+  INSERT INTO public.wallet_transactions (
+    tenant_id, user_id, amount, type, source, source_event_id, balance_after
+  ) VALUES (
+    v_tenant, v_user, 500, 'earning', 'vtid-03107-verify', v_event, 500
+  );
+
+  SELECT * INTO v_row
+  FROM public.wallet_balances
+  WHERE tenant_id = v_tenant AND user_id = v_user;
+
+  IF v_row.cash_balance <> 500 OR v_row.purchased_credits <> 0 OR v_row.reward_credits <> 0 THEN
+    RAISE EXCEPTION 'VTID-03107 verify: earning routing wrong (cash=%, purchased=%, reward=%)',
+      v_row.cash_balance, v_row.purchased_credits, v_row.reward_credits;
+  END IF;
+
+  DELETE FROM public.wallet_transactions
+   WHERE tenant_id = v_tenant AND user_id = v_user AND source_event_id = v_event;
+  DELETE FROM public.wallet_balances
+   WHERE tenant_id = v_tenant AND user_id = v_user;
+
+  RAISE NOTICE 'VTID-03107 wallet reconciliation: trigger routes earning → cash_balance ✓';
+END $$;
+
+-- Third verification: 'purchase' (default path) routes to purchased_credits
+DO $$
+DECLARE
+  v_tenant uuid := '00000000-0000-0000-0000-000000000001';
+  v_user   uuid := '00000000-0000-0000-0000-00000000BABE';
+  v_event  text := 'vtid-03107-migration-verify-purchase-' || gen_random_uuid()::text;
+  v_row    public.wallet_balances%ROWTYPE;
+BEGIN
+  INSERT INTO public.wallet_transactions (
+    tenant_id, user_id, amount, type, source, source_event_id, balance_after
+  ) VALUES (
+    v_tenant, v_user, 250, 'purchase', 'vtid-03107-verify', v_event, 250
+  );
+
+  SELECT * INTO v_row
+  FROM public.wallet_balances
+  WHERE tenant_id = v_tenant AND user_id = v_user;
+
+  IF v_row.purchased_credits <> 250 OR v_row.reward_credits <> 0 OR v_row.cash_balance <> 0 THEN
+    RAISE EXCEPTION 'VTID-03107 verify: purchase routing wrong (purchased=%, reward=%, cash=%)',
+      v_row.purchased_credits, v_row.reward_credits, v_row.cash_balance;
+  END IF;
+
+  DELETE FROM public.wallet_transactions
+   WHERE tenant_id = v_tenant AND user_id = v_user AND source_event_id = v_event;
+  DELETE FROM public.wallet_balances
+   WHERE tenant_id = v_tenant AND user_id = v_user;
+
+  RAISE NOTICE 'VTID-03107 wallet reconciliation: trigger routes purchase → purchased_credits ✓';
+END $$;
+
+-- Final guard: if any of the above blocks raised an exception, the entire
+-- migration aborts and the schema is rolled back. Confirming success here.
+DO $$ BEGIN
+  RAISE NOTICE 'VTID-03107 wallet reconciliation: all three routing paths verified — migration complete.';
+END $$;

--- a/supabase/migrations/20260526010000_VTID_03107_subscription_core.sql
+++ b/supabase/migrations/20260526010000_VTID_03107_subscription_core.sql
@@ -1,0 +1,400 @@
+-- =============================================================================
+-- VTID-03107 · Billing v1 — Subscription core schema
+-- =============================================================================
+-- Six tables that together form the billing v1 state model:
+--
+--   subscription_plans     config · one row per published plan (Free / Premium /
+--                                   Host / Community), one source of truth for
+--                                   price + Stripe IDs + capability JSON
+--   user_subscriptions     state  · per-user current sub (plan_key, status,
+--                                   Stripe customer/sub IDs, period bounds)
+--   feature_entitlements   config · per (plan, feature) → quota + window +
+--                                   behavior_on_exceed + allowed burn buckets
+--   feature_usage          state  · per (user, feature, window) → counter
+--   credit_packs           config · one-shot Stripe Checkout SKUs
+--   paywall_events         analytics · funnel events for telemetry dashboard
+--
+-- Naming
+--   Internal plan_keys: 'free', 'premium', 'premium_5x', 'premium_20x'
+--   Customer-facing names ('Premium', 'Host', 'Community') live in i18n
+--   shards and the §O copy table — never in the DB.
+--
+-- RLS
+--   subscription_plans / feature_entitlements / credit_packs → world-readable
+--     (config tables, not user data)
+--   user_subscriptions / feature_usage / paywall_events → user reads own only
+--   All tables → service_role full access
+--
+-- Compatibility
+--   This migration adds no foreign key to wallet_balances; the entitlement
+--   service joins by tenant_id + user_id at query time. See §M wallet
+--   reconciliation (20260526000000) — that lands first as the hard blocker.
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- 1. subscription_plans  (one row per tier)
+-- -----------------------------------------------------------------------------
+-- Four tiers: free, premium, premium_5x, premium_20x. Price + Stripe Price IDs
+-- are NOT here — they live in subscription_plan_prices (2 prices per paid tier).
+-- This separation lets the entitlement engine key off plan_key (tier) without
+-- duplicating quota rows for monthly vs annual.
+
+CREATE TABLE IF NOT EXISTS public.subscription_plans (
+  plan_key             text PRIMARY KEY,
+  display_name         text NOT NULL,                  -- internal label; user-facing label is i18n-driven
+  stripe_product_id    text,                            -- Stripe Product (one per tier)
+  trial_days           integer NOT NULL DEFAULT 0,      -- 14 for paid tiers, 0 for free
+  features_json        jsonb NOT NULL DEFAULT '{}'::jsonb,  -- storage_mb, sell_and_earn_*, etc. (see migration 8)
+  sort_order           integer NOT NULL DEFAULT 0,
+  is_active            boolean NOT NULL DEFAULT true,
+  created_at           timestamptz NOT NULL DEFAULT now(),
+  updated_at           timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.subscription_plans IS
+  'VTID-03107: catalog of subscription tiers (free / premium / premium_5x / premium_20x). plan_key is the canonical internal identifier; display_name + i18n strings provide customer-facing labels. Pricing variants live in subscription_plan_prices.';
+COMMENT ON COLUMN public.subscription_plans.features_json IS
+  'Per-tier capability config (storage_mb, sell_and_earn_catalog_size, etc.). Seeded by migration 20260526070000.';
+
+-- -----------------------------------------------------------------------------
+-- 1b. subscription_plan_prices  (one row per (tier, interval) variant)
+-- -----------------------------------------------------------------------------
+-- 6 rows expected: premium×{month, year}, premium_5x×{month, year}, premium_20x×{month, year}.
+-- Free has no price row (the application defaults to "free" with no Stripe binding).
+-- Adding a quarterly tier or a regional price later is just an INSERT here.
+
+CREATE TABLE IF NOT EXISTS public.subscription_plan_prices (
+  price_key            text PRIMARY KEY,                              -- e.g. 'premium_monthly', 'premium_annual'
+  plan_key             text NOT NULL REFERENCES public.subscription_plans(plan_key) ON DELETE CASCADE,
+  billing_interval     text NOT NULL CHECK (billing_interval IN ('month','year')),
+  price_cents          integer NOT NULL CHECK (price_cents > 0),
+  currency             text NOT NULL DEFAULT 'eur',
+  stripe_price_id      text UNIQUE,                                   -- filled by ops via SQL UPDATE
+  is_active            boolean NOT NULL DEFAULT true,
+  sort_order           integer NOT NULL DEFAULT 0,
+  created_at           timestamptz NOT NULL DEFAULT now(),
+  updated_at           timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (plan_key, billing_interval)
+);
+
+CREATE INDEX IF NOT EXISTS idx_subscription_plan_prices_plan
+  ON public.subscription_plan_prices (plan_key);
+
+COMMENT ON TABLE public.subscription_plan_prices IS
+  'VTID-03107: Stripe Price variants per plan tier (monthly + annual). One Stripe Price ID per row. Filled by ops via SQL UPDATE after Dashboard creation.';
+
+-- -----------------------------------------------------------------------------
+-- 2. user_subscriptions
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.user_subscriptions (
+  id                      uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id               uuid NOT NULL,
+  user_id                 uuid NOT NULL,
+  plan_key                text NOT NULL REFERENCES public.subscription_plans(plan_key),         -- tier
+  price_key               text REFERENCES public.subscription_plan_prices(price_key),           -- variant (NULL for grants)
+  status                  text NOT NULL CHECK (status IN (
+                            'trialing',
+                            'active',
+                            'past_due',
+                            'unpaid',
+                            'canceled',
+                            'incomplete',
+                            'incomplete_expired',
+                            'paused',
+                            'free'
+                          )),
+  stripe_customer_id      text,
+  stripe_subscription_id  text UNIQUE,
+  current_period_start    timestamptz,
+  current_period_end      timestamptz,
+  cancel_at_period_end    boolean NOT NULL DEFAULT false,
+  trial_end               timestamptz,
+  last_payment_error      text,
+  metadata                jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at              timestamptz NOT NULL DEFAULT now(),
+  updated_at              timestamptz NOT NULL DEFAULT now(),
+  UNIQUE (tenant_id, user_id)
+);
+
+CREATE INDEX IF NOT EXISTS idx_user_subscriptions_status
+  ON public.user_subscriptions (status);
+CREATE INDEX IF NOT EXISTS idx_user_subscriptions_period_end
+  ON public.user_subscriptions (current_period_end)
+  WHERE status IN ('active','trialing','past_due');
+CREATE INDEX IF NOT EXISTS idx_user_subscriptions_stripe_customer
+  ON public.user_subscriptions (stripe_customer_id)
+  WHERE stripe_customer_id IS NOT NULL;
+
+COMMENT ON TABLE public.user_subscriptions IS
+  'VTID-03107: per-user subscription state. metadata.source ∈ {stripe, redemption, earned} distinguishes Stripe-paid from grant-based subs.';
+COMMENT ON COLUMN public.user_subscriptions.stripe_subscription_id IS
+  'NULL for grant-based subs (ENTER codes, Founding promo, future referral). Only Stripe-paid subs have a real Stripe sub ID.';
+
+-- -----------------------------------------------------------------------------
+-- 3. feature_entitlements
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.feature_entitlements (
+  plan_key             text NOT NULL REFERENCES public.subscription_plans(plan_key) ON DELETE CASCADE,
+  feature_key          text NOT NULL,
+  quota                integer NOT NULL,                          -- finite number; no -1, no "unlimited"
+  window_seconds       integer NOT NULL DEFAULT 2592000,          -- default 30 days
+  unit                 text NOT NULL DEFAULT 'count'              -- 'count' | 'minutes' | 'bytes'
+                         CHECK (unit IN ('count','minutes','bytes')),
+  behavior_on_exceed   text NOT NULL DEFAULT 'paywall'
+                         CHECK (behavior_on_exceed IN ('paywall','degrade','hard_block','soft_counter')),
+  credit_cost_per_unit integer NOT NULL DEFAULT 0,                -- PAYG burn rate; 0 = pay-with-credits not allowed
+  allowed_burn_buckets text[] NOT NULL DEFAULT ARRAY['purchased_credits']::text[],
+                                                                  -- which wallet buckets can fund overage
+  PRIMARY KEY (plan_key, feature_key)
+);
+
+COMMENT ON TABLE public.feature_entitlements IS
+  'VTID-03107: per-plan, per-feature quotas + behavior on exceed. Single SQL UPDATE retunes any value without a deploy.';
+COMMENT ON COLUMN public.feature_entitlements.quota IS
+  'Finite number, e.g. 15 (Free voice min/month) or 1200 (Community voice min/month). Cashflow guardrail §N #1 forbids -1/unlimited.';
+COMMENT ON COLUMN public.feature_entitlements.behavior_on_exceed IS
+  'paywall: return 402 · degrade: handler chooses fallback (voice → Standard mode) · hard_block: 402 with no PAYG · soft_counter: UI shows counter but route returns 200.';
+COMMENT ON COLUMN public.feature_entitlements.allowed_burn_buckets IS
+  'Wallet bucket(s) that can pay PAYG overage. Voice/Rooms: {purchased_credits} only. Match/photo/lab: {purchased_credits, reward_credits}. Subscription discount: never (out of launch scope).';
+
+-- -----------------------------------------------------------------------------
+-- 4. feature_usage
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.feature_usage (
+  tenant_id     uuid NOT NULL,
+  user_id       uuid NOT NULL,
+  feature_key   text NOT NULL,
+  window_start  timestamptz NOT NULL,
+  window_end    timestamptz NOT NULL,
+  used          integer NOT NULL DEFAULT 0,
+  metadata      jsonb NOT NULL DEFAULT '{}'::jsonb,
+  updated_at    timestamptz NOT NULL DEFAULT now(),
+  PRIMARY KEY (user_id, feature_key, window_start)
+);
+
+CREATE INDEX IF NOT EXISTS idx_feature_usage_window_end
+  ON public.feature_usage (window_end);
+CREATE INDEX IF NOT EXISTS idx_feature_usage_tenant
+  ON public.feature_usage (tenant_id);
+
+COMMENT ON TABLE public.feature_usage IS
+  'VTID-03107: per-user, per-feature, per-window usage counter. window_start is the rolling window anchor; fn_increment_feature_usage (migration 20260526040000) does the atomic UPSERT.';
+
+-- -----------------------------------------------------------------------------
+-- 5. credit_packs
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.credit_packs (
+  pack_key         text PRIMARY KEY,
+  display_name     text NOT NULL,
+  credits          integer NOT NULL CHECK (credits > 0),
+  bonus_credits    integer NOT NULL DEFAULT 0 CHECK (bonus_credits >= 0),
+  price_cents      integer NOT NULL CHECK (price_cents > 0),
+  currency         text NOT NULL DEFAULT 'eur',
+  stripe_product_id text,
+  stripe_price_id  text UNIQUE,
+  is_active        boolean NOT NULL DEFAULT true,
+  sort_order       integer NOT NULL DEFAULT 0,
+  created_at       timestamptz NOT NULL DEFAULT now(),
+  updated_at       timestamptz NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE public.credit_packs IS
+  'VTID-03107: one-shot credit pack SKUs sold via Stripe Checkout payment mode. Inserted credits land in wallet_balances.purchased_credits.';
+
+-- -----------------------------------------------------------------------------
+-- 6. paywall_events
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.paywall_events (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id     uuid NOT NULL,
+  user_id       uuid NOT NULL,
+  feature_key   text NOT NULL,
+  action        text NOT NULL CHECK (action IN (
+                  'shown',
+                  'upgraded',
+                  'rejected',
+                  'credit_paid',
+                  'deferred_for_vulnerability',
+                  'degraded',
+                  'redeemed',
+                  'soft_counter_reached'
+                )),
+  current_plan  text,
+  context       jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at    timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_paywall_events_user_time
+  ON public.paywall_events (user_id, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_paywall_events_feature_time
+  ON public.paywall_events (feature_key, created_at DESC);
+CREATE INDEX IF NOT EXISTS idx_paywall_events_action
+  ON public.paywall_events (action, created_at DESC);
+
+COMMENT ON TABLE public.paywall_events IS
+  'VTID-03107: funnel analytics for the Command Hub billing dashboard. Each paywall touch (shown, upgraded, credit_paid, deferred, etc.) writes one row.';
+
+-- -----------------------------------------------------------------------------
+-- 7. processed_stripe_events (webhook idempotency)
+-- -----------------------------------------------------------------------------
+-- Mirrors the existing Connect-webhook idempotency pattern. PR-2's customer-side
+-- Stripe webhook inserts the event.id before processing; PK conflict = skip.
+
+CREATE TABLE IF NOT EXISTS public.processed_stripe_events (
+  event_id     text PRIMARY KEY,                         -- Stripe's event.id (evt_xxx)
+  event_type   text NOT NULL,
+  processed_at timestamptz NOT NULL DEFAULT now()
+);
+
+CREATE INDEX IF NOT EXISTS idx_processed_stripe_events_type_time
+  ON public.processed_stripe_events (event_type, processed_at DESC);
+
+COMMENT ON TABLE public.processed_stripe_events IS
+  'VTID-03107: Stripe webhook idempotency log. Insert event.id before processing; PK conflict = already handled, skip.';
+
+-- =============================================================================
+-- updated_at triggers (shared helper)
+-- =============================================================================
+
+CREATE OR REPLACE FUNCTION public.billing_bump_updated_at()
+RETURNS trigger LANGUAGE plpgsql AS $$
+BEGIN
+  NEW.updated_at := now();
+  RETURN NEW;
+END;
+$$;
+
+DROP TRIGGER IF EXISTS trg_subscription_plans_updated        ON public.subscription_plans;
+DROP TRIGGER IF EXISTS trg_subscription_plan_prices_updated  ON public.subscription_plan_prices;
+DROP TRIGGER IF EXISTS trg_user_subscriptions_updated        ON public.user_subscriptions;
+DROP TRIGGER IF EXISTS trg_credit_packs_updated              ON public.credit_packs;
+DROP TRIGGER IF EXISTS trg_feature_usage_updated             ON public.feature_usage;
+
+CREATE TRIGGER trg_subscription_plans_updated
+  BEFORE UPDATE ON public.subscription_plans
+  FOR EACH ROW EXECUTE FUNCTION public.billing_bump_updated_at();
+
+CREATE TRIGGER trg_subscription_plan_prices_updated
+  BEFORE UPDATE ON public.subscription_plan_prices
+  FOR EACH ROW EXECUTE FUNCTION public.billing_bump_updated_at();
+
+CREATE TRIGGER trg_user_subscriptions_updated
+  BEFORE UPDATE ON public.user_subscriptions
+  FOR EACH ROW EXECUTE FUNCTION public.billing_bump_updated_at();
+
+CREATE TRIGGER trg_credit_packs_updated
+  BEFORE UPDATE ON public.credit_packs
+  FOR EACH ROW EXECUTE FUNCTION public.billing_bump_updated_at();
+
+CREATE TRIGGER trg_feature_usage_updated
+  BEFORE UPDATE ON public.feature_usage
+  FOR EACH ROW EXECUTE FUNCTION public.billing_bump_updated_at();
+
+-- =============================================================================
+-- Row-Level Security
+-- =============================================================================
+
+-- subscription_plans: world-readable config (no user PII), service_role writes
+ALTER TABLE public.subscription_plans ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS subscription_plans_read_all   ON public.subscription_plans;
+DROP POLICY IF EXISTS subscription_plans_svc_full   ON public.subscription_plans;
+CREATE POLICY subscription_plans_read_all ON public.subscription_plans
+  FOR SELECT TO authenticated, anon
+  USING (is_active = true);
+CREATE POLICY subscription_plans_svc_full ON public.subscription_plans
+  FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+-- subscription_plan_prices: world-readable active variants, service_role writes
+ALTER TABLE public.subscription_plan_prices ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS subscription_plan_prices_read_all ON public.subscription_plan_prices;
+DROP POLICY IF EXISTS subscription_plan_prices_svc_full ON public.subscription_plan_prices;
+CREATE POLICY subscription_plan_prices_read_all ON public.subscription_plan_prices
+  FOR SELECT TO authenticated, anon
+  USING (is_active = true);
+CREATE POLICY subscription_plan_prices_svc_full ON public.subscription_plan_prices
+  FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+-- feature_entitlements: world-readable, service_role writes
+ALTER TABLE public.feature_entitlements ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS feature_entitlements_read_all ON public.feature_entitlements;
+DROP POLICY IF EXISTS feature_entitlements_svc_full ON public.feature_entitlements;
+CREATE POLICY feature_entitlements_read_all ON public.feature_entitlements
+  FOR SELECT TO authenticated, anon
+  USING (true);
+CREATE POLICY feature_entitlements_svc_full ON public.feature_entitlements
+  FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+-- credit_packs: world-readable (active SKUs only), service_role writes
+ALTER TABLE public.credit_packs ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS credit_packs_read_active ON public.credit_packs;
+DROP POLICY IF EXISTS credit_packs_svc_full    ON public.credit_packs;
+CREATE POLICY credit_packs_read_active ON public.credit_packs
+  FOR SELECT TO authenticated, anon
+  USING (is_active = true);
+CREATE POLICY credit_packs_svc_full ON public.credit_packs
+  FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+-- user_subscriptions: user reads own only, service_role writes
+ALTER TABLE public.user_subscriptions ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS user_subscriptions_read_own ON public.user_subscriptions;
+DROP POLICY IF EXISTS user_subscriptions_svc_full ON public.user_subscriptions;
+CREATE POLICY user_subscriptions_read_own ON public.user_subscriptions
+  FOR SELECT TO authenticated
+  USING (auth.uid() = user_id);
+CREATE POLICY user_subscriptions_svc_full ON public.user_subscriptions
+  FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+-- feature_usage: user reads own only, service_role writes
+ALTER TABLE public.feature_usage ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS feature_usage_read_own ON public.feature_usage;
+DROP POLICY IF EXISTS feature_usage_svc_full ON public.feature_usage;
+CREATE POLICY feature_usage_read_own ON public.feature_usage
+  FOR SELECT TO authenticated
+  USING (auth.uid() = user_id);
+CREATE POLICY feature_usage_svc_full ON public.feature_usage
+  FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+-- paywall_events: user reads own (for transparency), service_role writes
+ALTER TABLE public.paywall_events ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS paywall_events_read_own ON public.paywall_events;
+DROP POLICY IF EXISTS paywall_events_svc_full ON public.paywall_events;
+CREATE POLICY paywall_events_read_own ON public.paywall_events
+  FOR SELECT TO authenticated
+  USING (auth.uid() = user_id);
+CREATE POLICY paywall_events_svc_full ON public.paywall_events
+  FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+-- processed_stripe_events: service_role only (internal log)
+ALTER TABLE public.processed_stripe_events ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS processed_stripe_events_svc_full ON public.processed_stripe_events;
+CREATE POLICY processed_stripe_events_svc_full ON public.processed_stripe_events
+  FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+-- =============================================================================
+-- Grants
+-- =============================================================================
+
+GRANT SELECT ON public.subscription_plans         TO authenticated, anon;
+GRANT SELECT ON public.subscription_plan_prices   TO authenticated, anon;
+GRANT SELECT ON public.feature_entitlements       TO authenticated, anon;
+GRANT SELECT ON public.credit_packs               TO authenticated, anon;
+GRANT SELECT ON public.user_subscriptions    TO authenticated;
+GRANT SELECT ON public.feature_usage         TO authenticated;
+GRANT SELECT ON public.paywall_events        TO authenticated;
+
+-- Service role gets full access via RLS bypass (default); no explicit grant
+-- needed but listed here for documentation:
+--   GRANT ALL ON public.* TO service_role;

--- a/supabase/migrations/20260526020000_VTID_03107_openclaw_compat.sql
+++ b/supabase/migrations/20260526020000_VTID_03107_openclaw_compat.sql
@@ -1,0 +1,46 @@
+-- =============================================================================
+-- VTID-03107 · Billing v1 — OpenClaw compatibility view
+-- =============================================================================
+-- Purpose
+--   The OpenClaw skill at services/openclaw-bridge/src/skills/vitana-stripe.ts
+--   queries a `stripe_subscriptions` table that doesn't exist:
+--
+--     .from('stripe_subscriptions')
+--     .select('id, tenant_id, status, last_payment_error')
+--     .in('status', ['past_due', 'unpaid'])
+--
+--   A real table by that name would duplicate user_subscriptions. Instead we
+--   ship a view that exposes the same column shape, sourced from the canonical
+--   user_subscriptions table. OpenClaw heartbeats continue to work with zero
+--   code change.
+--
+--   The view is filtered to subscriptions that have a real Stripe sub ID —
+--   redemption-grant rows (where stripe_subscription_id is NULL) are excluded
+--   so OpenClaw never tries to retry-charge a grant.
+-- =============================================================================
+
+DROP VIEW IF EXISTS public.stripe_subscriptions;
+
+CREATE VIEW public.stripe_subscriptions AS
+SELECT
+  stripe_subscription_id  AS id,            -- OpenClaw expects 'id' (Stripe sub id)
+  tenant_id,
+  status,
+  last_payment_error,
+  user_id,
+  plan_key,
+  current_period_start,
+  current_period_end,
+  cancel_at_period_end,
+  trial_end,
+  stripe_customer_id,
+  metadata,
+  created_at,
+  updated_at
+FROM public.user_subscriptions
+WHERE stripe_subscription_id IS NOT NULL;
+
+COMMENT ON VIEW public.stripe_subscriptions IS
+  'VTID-03107: compatibility view for the OpenClaw vitana-stripe skill and any other consumer expecting a `stripe_subscriptions` table. Sourced from user_subscriptions; excludes grant-based rows (no stripe_subscription_id).';
+
+GRANT SELECT ON public.stripe_subscriptions TO authenticated, service_role, anon;

--- a/supabase/migrations/20260526030000_VTID_03107_seed_plans.sql
+++ b/supabase/migrations/20260526030000_VTID_03107_seed_plans.sql
@@ -1,0 +1,237 @@
+-- =============================================================================
+-- VTID-03107 · Billing v1 — Seed plans, prices, credit packs, entitlements
+-- =============================================================================
+-- Populates the four core config tables with the launch-day catalog:
+--
+--   subscription_plans          4 rows (free, premium, premium_5x, premium_20x)
+--   subscription_plan_prices    6 rows (3 paid tiers × 2 intervals)
+--   credit_packs                3 rows (starter, boost, power)
+--   feature_entitlements        24 rows (4 plans × 6 metered features)
+--
+-- All Stripe Price IDs left NULL — ops fills them via SQL UPDATE after the
+-- Stripe Dashboard sweep:
+--   1. Create 4 Stripe Products (Premium, Host, Community, Credit-Pack)
+--   2. Create 9 Stripe Prices (Premium m+y, Host m+y, Community m+y, 3 credit packs)
+--   3. UPDATE subscription_plans SET stripe_product_id='prod_…' WHERE plan_key='…';
+--   4. UPDATE subscription_plan_prices SET stripe_price_id='price_…' WHERE price_key='…';
+--   5. UPDATE credit_packs SET stripe_price_id='price_…', stripe_product_id='prod_…' WHERE pack_key='…';
+--
+-- Naming
+--   plan_key  → internal engineering identifier (free, premium, premium_5x, premium_20x)
+--   display_name → engineer-readable label (NOT shown in UI; UI uses i18n)
+--   i18n customer-facing names map per §O: Free, Premium, Host, Community
+--
+-- Cashflow guardrail
+--   Every quota is a finite integer — no -1, no "unlimited" semantics.
+--   Premium 5× / Premium 20× quotas are 5×/20× the Premium baseline.
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- 1. subscription_plans — 4 tier rows
+-- -----------------------------------------------------------------------------
+
+INSERT INTO public.subscription_plans (
+  plan_key, display_name, stripe_product_id, trial_days, features_json, sort_order, is_active
+) VALUES
+  ('free',         'Free',                     NULL,  0,  '{}'::jsonb, 10, true),
+  ('premium',      'Premium',                  NULL, 14,  '{}'::jsonb, 20, true),
+  ('premium_5x',   'Premium 5x (Host)',        NULL, 14,  '{}'::jsonb, 30, true),
+  ('premium_20x',  'Premium 20x (Community)',  NULL, 14,  '{}'::jsonb, 40, true)
+ON CONFLICT (plan_key) DO UPDATE SET
+  display_name = EXCLUDED.display_name,
+  trial_days   = EXCLUDED.trial_days,
+  sort_order   = EXCLUDED.sort_order,
+  is_active    = EXCLUDED.is_active,
+  updated_at   = now();
+
+-- features_json is intentionally empty here. Migration 8 (20260526070000)
+-- seeds storage_mb + Sell-and-Earn capability config per tier.
+
+-- -----------------------------------------------------------------------------
+-- 2. subscription_plan_prices — 6 variant rows (3 paid tiers × 2 intervals)
+-- -----------------------------------------------------------------------------
+
+INSERT INTO public.subscription_plan_prices (
+  price_key, plan_key, billing_interval, price_cents, currency, stripe_price_id, is_active, sort_order
+) VALUES
+  -- Premium: €9.99/mo · €89/yr (save ~26%)
+  ('premium_monthly',     'premium',      'month',    999, 'eur', NULL, true, 10),
+  ('premium_annual',      'premium',      'year',    8900, 'eur', NULL, true, 20),
+
+  -- Premium 5× / Host: €99/mo · €890/yr (save ~25%) — 10× the Premium price for 5× the quota
+  ('premium_5x_monthly',  'premium_5x',   'month',   9900, 'eur', NULL, true, 30),
+  ('premium_5x_annual',   'premium_5x',   'year',   89000, 'eur', NULL, true, 40),
+
+  -- Premium 20× / Community: €199/mo · €1990/yr (save ~17%) — 20× price for 20× quota
+  ('premium_20x_monthly', 'premium_20x',  'month',  19900, 'eur', NULL, true, 50),
+  ('premium_20x_annual',  'premium_20x',  'year',  199000, 'eur', NULL, true, 60)
+ON CONFLICT (price_key) DO UPDATE SET
+  plan_key         = EXCLUDED.plan_key,
+  billing_interval = EXCLUDED.billing_interval,
+  price_cents      = EXCLUDED.price_cents,
+  currency         = EXCLUDED.currency,
+  is_active        = EXCLUDED.is_active,
+  sort_order       = EXCLUDED.sort_order,
+  updated_at       = now();
+
+-- -----------------------------------------------------------------------------
+-- 3. credit_packs — 3 one-shot SKUs
+-- -----------------------------------------------------------------------------
+
+INSERT INTO public.credit_packs (
+  pack_key, display_name, credits, bonus_credits, price_cents, currency,
+  stripe_product_id, stripe_price_id, is_active, sort_order
+) VALUES
+  ('starter', 'Starter',  500,    0,  499, 'eur', NULL, NULL, true, 10),
+  ('boost',   'Boost',   2000,  200, 1999, 'eur', NULL, NULL, true, 20),  -- +10% bonus
+  ('power',   'Power',  10000, 2000, 9900, 'eur', NULL, NULL, true, 30)   -- +20% bonus
+ON CONFLICT (pack_key) DO UPDATE SET
+  display_name  = EXCLUDED.display_name,
+  credits       = EXCLUDED.credits,
+  bonus_credits = EXCLUDED.bonus_credits,
+  price_cents   = EXCLUDED.price_cents,
+  currency      = EXCLUDED.currency,
+  is_active     = EXCLUDED.is_active,
+  sort_order    = EXCLUDED.sort_order,
+  updated_at    = now();
+
+-- Customer-facing labels in i18n (PR-3) lead with what the credits buy, not the
+-- raw count:
+--   starter: "10 hours of standard voice OR 100 live minutes"
+--   boost:   "Most popular — 7 hours of live voice"
+--   power:   "Heavy use — 40 hours of live voice"
+
+-- -----------------------------------------------------------------------------
+-- 4. feature_entitlements — 24 rows (4 plans × 6 metered features)
+-- -----------------------------------------------------------------------------
+-- Feature quotas locked per §A of the plan. All numbers finite (no -1).
+--
+-- Six features metered in v1:
+--   voice_live_minutes  (ORB Gemini Live)         — HARD: degrade
+--   live_room_minutes   (Daily.co hosting)        — HARD: graceful disconnect
+--   match_posts         (Find-a-Match post count) — SOFT counter (no 402)
+--   match_reveals       (Find-a-Match reveals)    — SOFT counter (no 402)
+--   lab_analyses        (OCR + LLM lab readings)  — SOFT counter (no 402)
+--   photo_uploads       (storage-bound)           — SOFT counter (no 402)
+--
+-- allowed_burn_buckets governs which wallet bucket can fund PAYG overage:
+--   purchased_credits only           — voice + rooms (expensive, cashflow-critical)
+--   purchased_credits + reward_credits — match/lab/photo (cheap, engagement-friendly)
+--
+-- credit_cost_per_unit is the PAYG burn rate per additional unit beyond quota.
+
+INSERT INTO public.feature_entitlements (
+  plan_key, feature_key, quota, window_seconds, unit, behavior_on_exceed,
+  credit_cost_per_unit, allowed_burn_buckets
+) VALUES
+  -- ─── voice_live_minutes (Gemini Live · €0.20/min raw cost) ─────────────────
+  -- 30-day window. Behavior: degrade to standard voice (Cartesia + Flash).
+  -- PAYG rate: 5 credits/min = €0.05/min covers cost + margin.
+  ('free',         'voice_live_minutes',   15, 2592000, 'minutes', 'degrade',     5, ARRAY['purchased_credits']),
+  ('premium',      'voice_live_minutes',   30, 2592000, 'minutes', 'degrade',     5, ARRAY['purchased_credits']),
+  ('premium_5x',   'voice_live_minutes',  150, 2592000, 'minutes', 'degrade',     5, ARRAY['purchased_credits']),
+  ('premium_20x',  'voice_live_minutes',  600, 2592000, 'minutes', 'degrade',     5, ARRAY['purchased_credits']),
+
+  -- ─── live_room_minutes (Daily.co hosting · €0.004/p-min) ───────────────────
+  -- 30-day window. Behavior: 5-min warning → 1-min warning → graceful disconnect.
+  -- PAYG rate: 1 credit/min = €0.01/min.
+  -- Free: 40 min/month total (≈ one 40-min session). Per-session 40-min cap is
+  -- enforced in the route handler, not the entitlement.
+  ('free',         'live_room_minutes',    40, 2592000, 'minutes', 'hard_block',  1, ARRAY['purchased_credits']),
+  ('premium',      'live_room_minutes',   300, 2592000, 'minutes', 'hard_block',  1, ARRAY['purchased_credits']),
+  ('premium_5x',   'live_room_minutes',  1500, 2592000, 'minutes', 'hard_block',  1, ARRAY['purchased_credits']),
+  ('premium_20x',  'live_room_minutes',  6000, 2592000, 'minutes', 'hard_block',  1, ARRAY['purchased_credits']),
+
+  -- ─── match_posts (Find-a-Match post creation) ──────────────────────────────
+  -- 30-day window. Behavior: soft_counter — UI badge, route returns 200.
+  -- PAYG rate: 50 credits/post = €0.50.
+  ('free',         'match_posts',           3, 2592000, 'count',   'soft_counter', 50, ARRAY['purchased_credits','reward_credits']),
+  ('premium',      'match_posts',          20, 2592000, 'count',   'soft_counter', 50, ARRAY['purchased_credits','reward_credits']),
+  ('premium_5x',   'match_posts',         100, 2592000, 'count',   'soft_counter', 50, ARRAY['purchased_credits','reward_credits']),
+  ('premium_20x',  'match_posts',         400, 2592000, 'count',   'soft_counter', 50, ARRAY['purchased_credits','reward_credits']),
+
+  -- ─── match_reveals (Find-a-Match counterparty reveal) ──────────────────────
+  -- 7-day rolling window. Behavior: soft_counter in v1.
+  -- PAYG rate: 10 credits/reveal = €0.10.
+  ('free',         'match_reveals',         5,  604800, 'count',   'soft_counter', 10, ARRAY['purchased_credits','reward_credits']),
+  ('premium',      'match_reveals',        50, 2592000, 'count',   'soft_counter', 10, ARRAY['purchased_credits','reward_credits']),
+  ('premium_5x',   'match_reveals',       250, 2592000, 'count',   'soft_counter', 10, ARRAY['purchased_credits','reward_credits']),
+  ('premium_20x',  'match_reveals',      1000, 2592000, 'count',   'soft_counter', 10, ARRAY['purchased_credits','reward_credits']),
+
+  -- ─── lab_analyses (OCR + Gemini multimodal · ~€0.10/lab raw) ───────────────
+  -- 30-day window. Behavior: soft_counter in v1.
+  -- PAYG rate: 50 credits/lab = €0.50.
+  ('free',         'lab_analyses',          1, 2592000, 'count',   'soft_counter', 50, ARRAY['purchased_credits','reward_credits']),
+  ('premium',      'lab_analyses',          5, 2592000, 'count',   'soft_counter', 50, ARRAY['purchased_credits','reward_credits']),
+  ('premium_5x',   'lab_analyses',         25, 2592000, 'count',   'soft_counter', 50, ARRAY['purchased_credits','reward_credits']),
+  ('premium_20x',  'lab_analyses',        100, 2592000, 'count',   'soft_counter', 50, ARRAY['purchased_credits','reward_credits']),
+
+  -- ─── photo_uploads (Supabase Storage · ~$0.021/GB-month + egress) ──────────
+  -- 30-day window. Behavior: soft_counter in v1.
+  -- PAYG rate: 1 credit/photo = €0.01.
+  -- Storage GB quotas are separate (subscription_plans.features_json.storage_mb,
+  -- seeded in migration 8) and metered by a different code path.
+  ('free',         'photo_uploads',         5, 2592000, 'count',   'soft_counter',  1, ARRAY['purchased_credits','reward_credits']),
+  ('premium',      'photo_uploads',        50, 2592000, 'count',   'soft_counter',  1, ARRAY['purchased_credits','reward_credits']),
+  ('premium_5x',   'photo_uploads',       250, 2592000, 'count',   'soft_counter',  1, ARRAY['purchased_credits','reward_credits']),
+  ('premium_20x',  'photo_uploads',      1000, 2592000, 'count',   'soft_counter',  1, ARRAY['purchased_credits','reward_credits'])
+
+ON CONFLICT (plan_key, feature_key) DO UPDATE SET
+  quota                = EXCLUDED.quota,
+  window_seconds       = EXCLUDED.window_seconds,
+  unit                 = EXCLUDED.unit,
+  behavior_on_exceed   = EXCLUDED.behavior_on_exceed,
+  credit_cost_per_unit = EXCLUDED.credit_cost_per_unit,
+  allowed_burn_buckets = EXCLUDED.allowed_burn_buckets;
+
+-- -----------------------------------------------------------------------------
+-- 5. Verification: row counts
+-- -----------------------------------------------------------------------------
+
+DO $$
+DECLARE
+  v_plans     integer;
+  v_prices    integer;
+  v_packs     integer;
+  v_entitle   integer;
+BEGIN
+  SELECT COUNT(*) INTO v_plans   FROM public.subscription_plans       WHERE is_active = true;
+  SELECT COUNT(*) INTO v_prices  FROM public.subscription_plan_prices WHERE is_active = true;
+  SELECT COUNT(*) INTO v_packs   FROM public.credit_packs             WHERE is_active = true;
+  SELECT COUNT(*) INTO v_entitle FROM public.feature_entitlements;
+
+  IF v_plans   <> 4  THEN RAISE EXCEPTION 'VTID-03107 seed: expected 4 plans, found %', v_plans; END IF;
+  IF v_prices  <> 6  THEN RAISE EXCEPTION 'VTID-03107 seed: expected 6 prices, found %', v_prices; END IF;
+  IF v_packs   <> 3  THEN RAISE EXCEPTION 'VTID-03107 seed: expected 3 credit packs, found %', v_packs; END IF;
+  IF v_entitle <> 24 THEN RAISE EXCEPTION 'VTID-03107 seed: expected 24 entitlement rows, found %', v_entitle; END IF;
+
+  RAISE NOTICE 'VTID-03107 seed: 4 plans, 6 prices, 3 credit packs, 24 entitlements ✓';
+END $$;
+
+-- -----------------------------------------------------------------------------
+-- 6. Verification: the 5×/20× quota multipliers are exact
+-- -----------------------------------------------------------------------------
+
+DO $$
+DECLARE
+  v_premium_voice   integer;
+  v_5x_voice        integer;
+  v_20x_voice       integer;
+BEGIN
+  SELECT quota INTO v_premium_voice FROM public.feature_entitlements
+    WHERE plan_key = 'premium'      AND feature_key = 'voice_live_minutes';
+  SELECT quota INTO v_5x_voice      FROM public.feature_entitlements
+    WHERE plan_key = 'premium_5x'   AND feature_key = 'voice_live_minutes';
+  SELECT quota INTO v_20x_voice     FROM public.feature_entitlements
+    WHERE plan_key = 'premium_20x'  AND feature_key = 'voice_live_minutes';
+
+  IF v_5x_voice  <> v_premium_voice * 5  THEN
+    RAISE EXCEPTION 'VTID-03107 seed: Premium 5x voice quota is %, expected %', v_5x_voice, v_premium_voice * 5;
+  END IF;
+  IF v_20x_voice <> v_premium_voice * 20 THEN
+    RAISE EXCEPTION 'VTID-03107 seed: Premium 20x voice quota is %, expected %', v_20x_voice, v_premium_voice * 20;
+  END IF;
+
+  RAISE NOTICE 'VTID-03107 seed: 5×/20× quota multipliers verified ✓ (% / % / % min)',
+    v_premium_voice, v_5x_voice, v_20x_voice;
+END $$;

--- a/supabase/migrations/20260526040000_VTID_03107_usage_helpers.sql
+++ b/supabase/migrations/20260526040000_VTID_03107_usage_helpers.sql
@@ -1,0 +1,298 @@
+-- =============================================================================
+-- VTID-03107 · Billing v1 — Usage-window + credit-burn helper RPCs
+-- =============================================================================
+-- Two atomic RPCs used by entitlement-service.ts (shipped in PR-2):
+--
+--   fn_increment_feature_usage   Atomic UPSERT into feature_usage; computes
+--                                the current rolling window and bumps `used`.
+--                                Returns new `used` + `window_end`.
+--
+--   fn_consume_credits           Wrapper around credit_wallet() that debits a
+--                                specific bucket (purchased_credits or
+--                                reward_credits) for paywall PAYG overage.
+--                                Maps p_bucket → p_type so the existing
+--                                trigger does the routing.
+--
+-- Both are SECURITY DEFINER so the entitlement service (running as
+-- service_role) can call them without RLS friction; the policies on the
+-- underlying tables already restrict direct access.
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- 1. fn_increment_feature_usage
+-- -----------------------------------------------------------------------------
+-- Window alignment: calendar / epoch-bucket. For a 30-day (2592000s) window
+-- this groups all users into the same window boundaries so the window_end is
+-- predictable ("resets on this future timestamp"). Better than per-user-anchored
+-- because the entitlement engine can cache window_end across users.
+--
+-- Atomicity: single INSERT … ON CONFLICT … RETURNING ensures concurrent calls
+-- against the same (user, feature, window) increment correctly without races.
+
+CREATE OR REPLACE FUNCTION public.fn_increment_feature_usage(
+  p_tenant_id      uuid,
+  p_user_id        uuid,
+  p_feature_key    text,
+  p_amount         integer DEFAULT 1,
+  p_window_seconds integer DEFAULT 2592000  -- 30 days
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_now             timestamptz := now();
+  v_window_start    timestamptz;
+  v_window_end      timestamptz;
+  v_used            integer;
+BEGIN
+  IF p_window_seconds < 1 THEN
+    RAISE EXCEPTION 'fn_increment_feature_usage: p_window_seconds must be >= 1';
+  END IF;
+
+  -- Epoch-bucket alignment: floor to nearest window_seconds boundary
+  v_window_start := to_timestamp(
+    floor(extract(epoch FROM v_now)::bigint / p_window_seconds) * p_window_seconds
+  );
+  v_window_end := v_window_start + make_interval(secs => p_window_seconds);
+
+  INSERT INTO public.feature_usage AS fu (
+    tenant_id, user_id, feature_key, window_start, window_end, used, updated_at
+  ) VALUES (
+    p_tenant_id, p_user_id, p_feature_key, v_window_start, v_window_end, p_amount, v_now
+  )
+  ON CONFLICT (user_id, feature_key, window_start)
+  DO UPDATE SET
+    used       = fu.used + p_amount,
+    updated_at = v_now
+  RETURNING used INTO v_used;
+
+  RETURN jsonb_build_object(
+    'ok',           true,
+    'used',         v_used,
+    'window_start', v_window_start,
+    'window_end',   v_window_end
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.fn_increment_feature_usage IS
+  'VTID-03107: atomic feature usage increment. Calendar-aligned rolling window. Returns the post-increment `used` value + window_end.';
+
+GRANT EXECUTE ON FUNCTION public.fn_increment_feature_usage TO service_role, authenticated;
+
+-- -----------------------------------------------------------------------------
+-- 2. fn_get_feature_usage  (read-only helper for the entitlement service)
+-- -----------------------------------------------------------------------------
+-- Returns the user's current `used` value in the current window without
+-- incrementing. Used by checkEntitlement() before deciding whether to allow,
+-- defer (D36), or paywall.
+
+CREATE OR REPLACE FUNCTION public.fn_get_feature_usage(
+  p_tenant_id      uuid,
+  p_user_id        uuid,
+  p_feature_key    text,
+  p_window_seconds integer DEFAULT 2592000
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_now            timestamptz := now();
+  v_window_start   timestamptz;
+  v_window_end     timestamptz;
+  v_used           integer;
+BEGIN
+  v_window_start := to_timestamp(
+    floor(extract(epoch FROM v_now)::bigint / p_window_seconds) * p_window_seconds
+  );
+  v_window_end := v_window_start + make_interval(secs => p_window_seconds);
+
+  SELECT used INTO v_used
+  FROM public.feature_usage
+  WHERE user_id = p_user_id
+    AND feature_key = p_feature_key
+    AND window_start = v_window_start;
+
+  RETURN jsonb_build_object(
+    'ok',           true,
+    'used',         COALESCE(v_used, 0),
+    'window_start', v_window_start,
+    'window_end',   v_window_end
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.fn_get_feature_usage IS
+  'VTID-03107: read-only feature usage query. Returns the user current `used` in the current rolling window; 0 if no row exists yet.';
+
+GRANT EXECUTE ON FUNCTION public.fn_get_feature_usage TO service_role, authenticated;
+
+-- -----------------------------------------------------------------------------
+-- 3. fn_consume_credits
+-- -----------------------------------------------------------------------------
+-- Debits the specified bucket for paywall PAYG overage. Wraps the existing
+-- credit_wallet() RPC (which routes by p_type → bucket).
+--
+-- Bucket mapping (mirrors the §M wallet-split semantics):
+--   'purchased_credits' → p_type='purchase'   (default; used for voice/rooms/sub overage)
+--   'reward_credits'    → p_type='reward'     (allowed for match/lab/photo overage only)
+--   'cash_balance'      → REJECTED in v1     (cash earnings are withdrawable to bank
+--                                              via Stripe Connect Express, not in-app spend)
+--
+-- Idempotency via the existing wallet_transactions unique index on
+-- (tenant_id, user_id, source_event_id). Replays return ok=true, duplicate=true.
+
+CREATE OR REPLACE FUNCTION public.fn_consume_credits(
+  p_tenant_id        uuid,
+  p_user_id          uuid,
+  p_credits          integer,           -- positive units to debit
+  p_bucket           text,              -- 'purchased_credits' | 'reward_credits'
+  p_feature_key      text,              -- for audit + source field
+  p_idempotency_key  text               -- source_event_id (entitlement-service generates UUID)
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_type        text;
+  v_source      text;
+  v_description text;
+  v_result      jsonb;
+BEGIN
+  IF p_credits <= 0 THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'INVALID_AMOUNT', 'credits', p_credits);
+  END IF;
+
+  -- Map bucket → wallet_transactions.type (used by credit_wallet + trigger to route)
+  IF p_bucket = 'purchased_credits' THEN
+    v_type := 'purchase';
+  ELSIF p_bucket = 'reward_credits' THEN
+    v_type := 'reward';
+  ELSIF p_bucket = 'cash_balance' THEN
+    RETURN jsonb_build_object(
+      'ok', false,
+      'error', 'BUCKET_NOT_SPENDABLE',
+      'message', 'cash_balance is withdrawable to bank via Stripe Connect, not in-app spend (§M)'
+    );
+  ELSE
+    RETURN jsonb_build_object(
+      'ok', false,
+      'error', 'INVALID_BUCKET',
+      'bucket', p_bucket
+    );
+  END IF;
+
+  v_source      := 'paywall:' || p_feature_key;
+  v_description := 'PAYG overage debit for ' || p_feature_key || ' from ' || p_bucket;
+
+  -- credit_wallet() handles per-bucket insufficient-balance check + idempotency
+  v_result := public.credit_wallet(
+    p_tenant_id       => p_tenant_id,
+    p_user_id         => p_user_id,
+    p_amount          => -p_credits,    -- NEGATIVE for debit
+    p_type            => v_type,
+    p_source          => v_source,
+    p_source_event_id => p_idempotency_key,
+    p_description     => v_description
+  );
+
+  -- Pass-through credit_wallet's response (ok / duplicate / INSUFFICIENT_BALANCE)
+  RETURN v_result;
+END;
+$$;
+
+COMMENT ON FUNCTION public.fn_consume_credits IS
+  'VTID-03107: idempotent paywall PAYG debit. Maps p_bucket → wallet_transactions.type so the existing trigger routes the debit to the right column. Rejects cash_balance spends (withdrawable only).';
+
+GRANT EXECUTE ON FUNCTION public.fn_consume_credits TO service_role, authenticated;
+
+-- -----------------------------------------------------------------------------
+-- 4. Verification: fn_increment_feature_usage routes to correct window
+-- -----------------------------------------------------------------------------
+
+DO $$
+DECLARE
+  v_tenant uuid := '00000000-0000-0000-0000-000003107010';
+  v_user   uuid := '00000000-0000-0000-0000-000003107011';
+  v_result jsonb;
+  v_used   integer;
+BEGIN
+  -- First call: should create the row with used=1
+  v_result := public.fn_increment_feature_usage(v_tenant, v_user, 'verify_voice_min', 1, 2592000);
+  v_used := (v_result->>'used')::integer;
+  IF v_used <> 1 THEN
+    RAISE EXCEPTION 'VTID-03107 fn_increment_feature_usage verify: first call returned used=%, expected 1', v_used;
+  END IF;
+
+  -- Second call in same window: should increment to used=6
+  v_result := public.fn_increment_feature_usage(v_tenant, v_user, 'verify_voice_min', 5, 2592000);
+  v_used := (v_result->>'used')::integer;
+  IF v_used <> 6 THEN
+    RAISE EXCEPTION 'VTID-03107 fn_increment_feature_usage verify: second call returned used=%, expected 6', v_used;
+  END IF;
+
+  -- fn_get_feature_usage should return 6 without incrementing
+  v_result := public.fn_get_feature_usage(v_tenant, v_user, 'verify_voice_min', 2592000);
+  v_used := (v_result->>'used')::integer;
+  IF v_used <> 6 THEN
+    RAISE EXCEPTION 'VTID-03107 fn_get_feature_usage verify: returned used=%, expected 6', v_used;
+  END IF;
+
+  -- Cleanup
+  DELETE FROM public.feature_usage
+   WHERE tenant_id = v_tenant AND user_id = v_user AND feature_key = 'verify_voice_min';
+
+  RAISE NOTICE 'VTID-03107 fn_increment_feature_usage + fn_get_feature_usage: verified ✓';
+END $$;
+
+-- -----------------------------------------------------------------------------
+-- 5. Verification: fn_consume_credits rejects cash_balance + invalid bucket
+-- -----------------------------------------------------------------------------
+
+DO $$
+DECLARE
+  v_tenant uuid := '00000000-0000-0000-0000-000003107020';
+  v_user   uuid := '00000000-0000-0000-0000-000003107021';
+  v_result jsonb;
+BEGIN
+  -- Cash bucket should be rejected
+  v_result := public.fn_consume_credits(
+    v_tenant, v_user, 10, 'cash_balance', 'verify_voice', 'vtid-03107-verify-' || gen_random_uuid()::text
+  );
+  IF (v_result->>'ok')::boolean OR (v_result->>'error') <> 'BUCKET_NOT_SPENDABLE' THEN
+    RAISE EXCEPTION 'VTID-03107 fn_consume_credits verify: cash_balance should be rejected, got %', v_result;
+  END IF;
+
+  -- Invalid bucket should be rejected
+  v_result := public.fn_consume_credits(
+    v_tenant, v_user, 10, 'invalid_bucket', 'verify_voice', 'vtid-03107-verify-' || gen_random_uuid()::text
+  );
+  IF (v_result->>'ok')::boolean OR (v_result->>'error') <> 'INVALID_BUCKET' THEN
+    RAISE EXCEPTION 'VTID-03107 fn_consume_credits verify: invalid_bucket should be rejected, got %', v_result;
+  END IF;
+
+  -- Zero/negative amount should be rejected
+  v_result := public.fn_consume_credits(
+    v_tenant, v_user, 0, 'purchased_credits', 'verify_voice', 'vtid-03107-verify-' || gen_random_uuid()::text
+  );
+  IF (v_result->>'ok')::boolean OR (v_result->>'error') <> 'INVALID_AMOUNT' THEN
+    RAISE EXCEPTION 'VTID-03107 fn_consume_credits verify: zero amount should be rejected, got %', v_result;
+  END IF;
+
+  -- Insufficient balance: user has 0 purchased_credits, asking to debit 100
+  v_result := public.fn_consume_credits(
+    v_tenant, v_user, 100, 'purchased_credits', 'verify_voice', 'vtid-03107-verify-' || gen_random_uuid()::text
+  );
+  IF (v_result->>'ok')::boolean OR (v_result->>'error') <> 'INSUFFICIENT_BALANCE' THEN
+    RAISE EXCEPTION 'VTID-03107 fn_consume_credits verify: insufficient balance check failed, got %', v_result;
+  END IF;
+
+  RAISE NOTICE 'VTID-03107 fn_consume_credits: cash-rejection + invalid-bucket + zero-amount + insufficient-balance all verified ✓';
+END $$;

--- a/supabase/migrations/20260526050000_VTID_03107_cron_cleanup.sql
+++ b/supabase/migrations/20260526050000_VTID_03107_cron_cleanup.sql
@@ -1,0 +1,192 @@
+-- =============================================================================
+-- VTID-03107 · Billing v1 — pg_cron cleanup + redemption-grant reconciliation
+-- =============================================================================
+-- Two daily jobs that keep the billing state tidy:
+--
+--   billing_feature_usage_prune     Daily 03:00 UTC — deletes feature_usage rows
+--                                   older than 7 days past window_end. Keeps the
+--                                   table small while preserving recent windows
+--                                   for analytics.
+--
+--   billing_reconcile_grants        Daily 03:10 UTC — flips redemption-grant
+--                                   subscriptions whose period has expired back
+--                                   to plan_key='free', status='free'. Stripe-
+--                                   paid subs are NOT touched here (Stripe
+--                                   webhooks own that lifecycle).
+--
+-- pg_cron schema: cron.schedule(job_name, schedule, command).
+-- Idempotency: cron.unschedule is called first to allow re-runs.
+-- =============================================================================
+
+-- pg_cron is already installed across the platform (see prior VAEA cron usage).
+-- This migration creates schema/extension if absent for safety.
+
+CREATE EXTENSION IF NOT EXISTS pg_cron WITH SCHEMA extensions;
+
+-- -----------------------------------------------------------------------------
+-- 1. Cleanup function: feature_usage rows older than 7 days past window_end
+-- -----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.fn_prune_feature_usage()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_deleted bigint;
+BEGIN
+  DELETE FROM public.feature_usage
+   WHERE window_end < now() - interval '7 days';
+
+  GET DIAGNOSTICS v_deleted = ROW_COUNT;
+  RETURN jsonb_build_object('ok', true, 'deleted_rows', v_deleted, 'ran_at', now());
+END;
+$$;
+
+COMMENT ON FUNCTION public.fn_prune_feature_usage IS
+  'VTID-03107: daily prune of feature_usage rows older than 7 days past window_end. Keeps the table size bounded while preserving recent history for analytics.';
+
+GRANT EXECUTE ON FUNCTION public.fn_prune_feature_usage TO service_role;
+
+-- -----------------------------------------------------------------------------
+-- 2. Reconciliation function: expired redemption grants → free
+-- -----------------------------------------------------------------------------
+-- A redemption-grant sub is identified by metadata.source ∈ {'redemption',
+-- 'earned'} AND stripe_subscription_id IS NULL. When current_period_end <
+-- now(), the user's premium time has elapsed; flip them to free.
+--
+-- Stripe-paid subs (stripe_subscription_id IS NOT NULL) are never touched by
+-- this job — Stripe webhooks own that lifecycle. Mixing the two paths here
+-- would risk double-cancellation races.
+
+CREATE OR REPLACE FUNCTION public.fn_reconcile_redemption_grants()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_updated bigint;
+BEGIN
+  UPDATE public.user_subscriptions
+     SET plan_key             = 'free',
+         status               = 'free',
+         price_key            = NULL,
+         current_period_start = NULL,
+         current_period_end   = NULL,
+         cancel_at_period_end = false,
+         trial_end            = NULL,
+         metadata             = COALESCE(metadata, '{}'::jsonb) ||
+                                jsonb_build_object(
+                                  'reconciled_from', plan_key,
+                                  'reconciled_at',   now()
+                                ),
+         updated_at           = now()
+   WHERE stripe_subscription_id IS NULL
+     AND current_period_end IS NOT NULL
+     AND current_period_end < now()
+     AND plan_key <> 'free'
+     AND status <> 'free'
+     AND (metadata ? 'source')
+     AND (metadata->>'source') IN ('redemption', 'earned');
+
+  GET DIAGNOSTICS v_updated = ROW_COUNT;
+
+  -- Audit: write one paywall_events row per reconciled user
+  IF v_updated > 0 THEN
+    INSERT INTO public.paywall_events (tenant_id, user_id, feature_key, action, current_plan, context)
+    SELECT
+      tenant_id,
+      user_id,
+      'subscription',
+      'rejected',                    -- closest existing action enum value (period ended)
+      'free',
+      jsonb_build_object(
+        'reason', 'redemption_grant_expired',
+        'previous_plan', metadata->>'reconciled_from',
+        'reconciled_at', metadata->>'reconciled_at'
+      )
+    FROM public.user_subscriptions
+    WHERE (metadata->>'reconciled_at')::timestamptz > now() - interval '1 hour';
+  END IF;
+
+  RETURN jsonb_build_object('ok', true, 'reconciled_rows', v_updated, 'ran_at', now());
+END;
+$$;
+
+COMMENT ON FUNCTION public.fn_reconcile_redemption_grants IS
+  'VTID-03107: daily reconciliation that flips expired redemption-grant subs (metadata.source ∈ {redemption, earned}) back to free. Never touches Stripe-paid subs.';
+
+GRANT EXECUTE ON FUNCTION public.fn_reconcile_redemption_grants TO service_role;
+
+-- -----------------------------------------------------------------------------
+-- 3. Schedule the cron jobs (idempotent — unschedule first)
+-- -----------------------------------------------------------------------------
+
+DO $$
+DECLARE
+  v_jobid bigint;
+BEGIN
+  -- Unschedule existing jobs with same names (no-op if absent)
+  FOR v_jobid IN
+    SELECT jobid FROM cron.job
+     WHERE jobname IN ('billing_feature_usage_prune', 'billing_reconcile_grants')
+  LOOP
+    PERFORM cron.unschedule(v_jobid);
+  END LOOP;
+END $$;
+
+SELECT cron.schedule(
+  'billing_feature_usage_prune',
+  '0 3 * * *',                         -- daily 03:00 UTC
+  $cron_prune$SELECT public.fn_prune_feature_usage();$cron_prune$
+);
+
+SELECT cron.schedule(
+  'billing_reconcile_grants',
+  '10 3 * * *',                        -- daily 03:10 UTC (10 minutes after prune)
+  $cron_recon$SELECT public.fn_reconcile_redemption_grants();$cron_recon$
+);
+
+-- -----------------------------------------------------------------------------
+-- 4. Verification: both cron jobs registered
+-- -----------------------------------------------------------------------------
+
+DO $$
+DECLARE
+  v_count integer;
+BEGIN
+  SELECT COUNT(*) INTO v_count
+  FROM cron.job
+  WHERE jobname IN ('billing_feature_usage_prune', 'billing_reconcile_grants');
+
+  IF v_count <> 2 THEN
+    RAISE EXCEPTION 'VTID-03107 cron: expected 2 jobs registered, found %', v_count;
+  END IF;
+
+  RAISE NOTICE 'VTID-03107 cron: feature_usage prune + redemption grants reconciliation scheduled ✓';
+END $$;
+
+-- -----------------------------------------------------------------------------
+-- 5. Verification: functions execute on empty data without error
+-- -----------------------------------------------------------------------------
+
+DO $$
+DECLARE
+  v_prune  jsonb;
+  v_recon  jsonb;
+BEGIN
+  v_prune := public.fn_prune_feature_usage();
+  IF NOT (v_prune->>'ok')::boolean THEN
+    RAISE EXCEPTION 'VTID-03107: fn_prune_feature_usage returned %', v_prune;
+  END IF;
+
+  v_recon := public.fn_reconcile_redemption_grants();
+  IF NOT (v_recon->>'ok')::boolean THEN
+    RAISE EXCEPTION 'VTID-03107: fn_reconcile_redemption_grants returned %', v_recon;
+  END IF;
+
+  RAISE NOTICE 'VTID-03107 cron functions: both executable on empty data ✓ (pruned=%, reconciled=%)',
+    v_prune->>'deleted_rows', v_recon->>'reconciled_rows';
+END $$;

--- a/supabase/migrations/20260526060000_VTID_03107_redemption_codes.sql
+++ b/supabase/migrations/20260526060000_VTID_03107_redemption_codes.sql
@@ -1,0 +1,405 @@
+-- =============================================================================
+-- VTID-03107 · Billing v1 — Redemption codes + fn_redeem_code
+-- =============================================================================
+-- Two new tables + one atomic RPC that powers all three giveaway paths from §S:
+--
+--   redemption_codes          One row per code. max_uses=1 for unique-per-user
+--                              test-cohort codes (VITANA-TEST-*); max_uses=N
+--                              for shared marketing codes (FOUNDING).
+--   redemption_redemptions    Per-user audit of each successful redemption.
+--                              Enforces one-shot per (user, code).
+--
+--   fn_redeem_code            Atomic redeem with all guards (validity, single-
+--                              use, Stripe-sub conflict, marketing-budget cap,
+--                              extension stacking for existing Premium).
+--                              Idempotent on retry (returns ALREADY_REDEEMED).
+--
+-- Marketing-budget guard (§S cashflow hardening)
+--   Beyond per-code max_uses, fn_redeem_code checks AND decrements
+--   `tenant_settings.feature_flags.marketing_budget_eur_remaining_cents`
+--   before granting. Computes grant_value_cents from the plan's monthly
+--   Stripe price (pro-rated by grant_duration_days). When the budget hits 0
+--   the next redemption returns BUDGET_EXHAUSTED. Ops tops up the counter via
+--   a single SQL UPDATE.
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- 1. redemption_codes
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.redemption_codes (
+  code                  text PRIMARY KEY,
+  campaign              text NOT NULL,                       -- 'test_cohort_2026Q2' | 'founding_500' | 'launch_podcast' | …
+  grants_plan           text NOT NULL REFERENCES public.subscription_plans(plan_key),
+  grant_duration_days   integer NOT NULL DEFAULT 90 CHECK (grant_duration_days > 0 AND grant_duration_days <= 730),
+  max_uses              integer NOT NULL DEFAULT 1 CHECK (max_uses > 0),
+  uses_count            integer NOT NULL DEFAULT 0 CHECK (uses_count >= 0),
+  expires_at            timestamptz,                          -- NULL = no expiry
+  created_by            uuid,                                 -- admin user_id (NULL if seeded via SQL)
+  is_active             boolean NOT NULL DEFAULT true,
+  metadata              jsonb NOT NULL DEFAULT '{}'::jsonb,
+  created_at            timestamptz NOT NULL DEFAULT now(),
+  updated_at            timestamptz NOT NULL DEFAULT now(),
+  CHECK (uses_count <= max_uses)
+);
+
+CREATE INDEX IF NOT EXISTS idx_redemption_codes_campaign ON public.redemption_codes (campaign);
+CREATE INDEX IF NOT EXISTS idx_redemption_codes_active   ON public.redemption_codes (is_active) WHERE is_active = true;
+
+COMMENT ON TABLE public.redemption_codes IS
+  'VTID-03107: campaign codes (test cohort + Founding shared promo + referral). max_uses distinguishes unique-per-user (max_uses=1) from shared-with-cap (max_uses=N).';
+COMMENT ON COLUMN public.redemption_codes.grant_duration_days IS
+  'Length of the Premium grant in days. 365 for test cohort, 90 for Founding, 30 for referral.';
+
+DROP TRIGGER IF EXISTS trg_redemption_codes_updated ON public.redemption_codes;
+CREATE TRIGGER trg_redemption_codes_updated
+  BEFORE UPDATE ON public.redemption_codes
+  FOR EACH ROW EXECUTE FUNCTION public.billing_bump_updated_at();
+
+-- -----------------------------------------------------------------------------
+-- 2. redemption_redemptions  (per-user audit)
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.redemption_redemptions (
+  id            uuid PRIMARY KEY DEFAULT gen_random_uuid(),
+  tenant_id     uuid NOT NULL,
+  user_id       uuid NOT NULL,
+  code          text NOT NULL REFERENCES public.redemption_codes(code),
+  campaign      text NOT NULL,
+  granted_plan  text NOT NULL,
+  granted_until timestamptz NOT NULL,
+  grant_value_cents integer NOT NULL,                        -- foregone-revenue value at redemption time
+  redeemed_at   timestamptz NOT NULL DEFAULT now(),
+  metadata      jsonb NOT NULL DEFAULT '{}'::jsonb,
+  UNIQUE (user_id, code)                                      -- one redemption of each code per user
+);
+
+CREATE INDEX IF NOT EXISTS idx_redemption_redemptions_user      ON public.redemption_redemptions (user_id);
+CREATE INDEX IF NOT EXISTS idx_redemption_redemptions_campaign  ON public.redemption_redemptions (campaign, redeemed_at DESC);
+CREATE INDEX IF NOT EXISTS idx_redemption_redemptions_code      ON public.redemption_redemptions (code);
+
+COMMENT ON TABLE public.redemption_redemptions IS
+  'VTID-03107: audit of each successful code redemption. grant_value_cents captures the foregone-revenue at redemption time for cashflow telemetry.';
+
+-- -----------------------------------------------------------------------------
+-- 3. RLS
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE public.redemption_codes        ENABLE ROW LEVEL SECURITY;
+ALTER TABLE public.redemption_redemptions  ENABLE ROW LEVEL SECURITY;
+
+-- redemption_codes: admins manage; authenticated can read active codes via the
+-- RPC (the RPC is SECURITY DEFINER so the policy below is defense-in-depth)
+DROP POLICY IF EXISTS redemption_codes_svc_full ON public.redemption_codes;
+CREATE POLICY redemption_codes_svc_full ON public.redemption_codes
+  FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+-- redemption_redemptions: users see own; service_role full
+DROP POLICY IF EXISTS redemption_redemptions_read_own ON public.redemption_redemptions;
+DROP POLICY IF EXISTS redemption_redemptions_svc_full ON public.redemption_redemptions;
+CREATE POLICY redemption_redemptions_read_own ON public.redemption_redemptions
+  FOR SELECT TO authenticated
+  USING (auth.uid() = user_id);
+CREATE POLICY redemption_redemptions_svc_full ON public.redemption_redemptions
+  FOR ALL TO service_role
+  USING (true) WITH CHECK (true);
+
+GRANT SELECT ON public.redemption_redemptions TO authenticated;
+
+-- -----------------------------------------------------------------------------
+-- 4. fn_normalize_code  (helper: uppercase, strip whitespace + dashes)
+-- -----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.fn_normalize_code(p_code text)
+RETURNS text
+LANGUAGE sql
+IMMUTABLE
+AS $$
+  SELECT upper(regexp_replace(COALESCE(p_code, ''), '[^A-Za-z0-9]', '', 'g'));
+$$;
+
+COMMENT ON FUNCTION public.fn_normalize_code IS
+  'VTID-03107: normalize a redemption code (uppercase, strip whitespace + dashes). VITANA-test-A4F2-9KX1 → VITANATESTA4F29KX1';
+
+-- However: codes are STORED in dashed form (VITANA-TEST-A4F2-9KX1) for human
+-- readability. The lookup logic uses regexp_replace on the stored code so both
+-- normalized and dashed inputs match.
+
+-- -----------------------------------------------------------------------------
+-- 5. fn_redeem_code  (atomic redemption with all guards)
+-- -----------------------------------------------------------------------------
+
+CREATE OR REPLACE FUNCTION public.fn_redeem_code(
+  p_tenant_id  uuid,
+  p_user_id    uuid,
+  p_code       text
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_code_row              public.redemption_codes%ROWTYPE;
+  v_normalized            text;
+  v_existing_redemption   uuid;
+  v_existing_sub          public.user_subscriptions%ROWTYPE;
+  v_granted_until         timestamptz;
+  v_monthly_price_cents   integer;
+  v_grant_value_cents     integer;
+  v_budget_remaining      integer;
+  v_redemption_id         uuid;
+  v_settings_row_id       uuid;
+BEGIN
+  -- 1. Validate inputs
+  IF p_user_id IS NULL OR p_tenant_id IS NULL THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'MISSING_IDENTITY');
+  END IF;
+
+  v_normalized := public.fn_normalize_code(p_code);
+  IF v_normalized = '' OR length(v_normalized) < 4 THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'INVALID_CODE');
+  END IF;
+
+  -- 2. Lookup code row (FOR UPDATE locks against concurrent redeems on same code)
+  --    Match against the stored code with non-alphanumerics stripped, so
+  --    both VITANATESTA4F29KX1 and VITANA-TEST-A4F2-9KX1 hit the same row.
+  SELECT * INTO v_code_row
+  FROM public.redemption_codes
+  WHERE upper(regexp_replace(code, '[^A-Za-z0-9]', '', 'g')) = v_normalized
+  FOR UPDATE;
+
+  IF v_code_row.code IS NULL THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'INVALID_CODE');
+  END IF;
+
+  IF NOT v_code_row.is_active THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'EXPIRED_OR_INACTIVE', 'code', v_code_row.code);
+  END IF;
+
+  IF v_code_row.expires_at IS NOT NULL AND v_code_row.expires_at < now() THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'EXPIRED', 'expired_at', v_code_row.expires_at);
+  END IF;
+
+  IF v_code_row.uses_count >= v_code_row.max_uses THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'MAX_USES_REACHED', 'max_uses', v_code_row.max_uses);
+  END IF;
+
+  -- 3. Per-user single-use check
+  SELECT id INTO v_existing_redemption
+  FROM public.redemption_redemptions
+  WHERE user_id = p_user_id AND code = v_code_row.code;
+
+  IF v_existing_redemption IS NOT NULL THEN
+    RETURN jsonb_build_object('ok', false, 'error', 'ALREADY_REDEEMED', 'redemption_id', v_existing_redemption);
+  END IF;
+
+  -- 4. Stripe-sub conflict: if user has an active Stripe-paid sub, refuse the
+  --    grant to avoid double-pay. Grant-on-grant (extension) is allowed.
+  SELECT * INTO v_existing_sub
+  FROM public.user_subscriptions
+  WHERE tenant_id = p_tenant_id AND user_id = p_user_id
+  FOR UPDATE;
+
+  IF v_existing_sub.user_id IS NOT NULL
+     AND v_existing_sub.stripe_subscription_id IS NOT NULL
+     AND v_existing_sub.status IN ('active','trialing','past_due') THEN
+    RETURN jsonb_build_object(
+      'ok', false,
+      'error', 'STRIPE_SUB_ACTIVE',
+      'message', 'You already have a paid subscription. Save this code for later.',
+      'current_plan', v_existing_sub.plan_key
+    );
+  END IF;
+
+  -- 5. Compute granted_until (stacking: extend existing period if any)
+  IF v_existing_sub.current_period_end IS NOT NULL AND v_existing_sub.current_period_end > now() THEN
+    v_granted_until := v_existing_sub.current_period_end + make_interval(days => v_code_row.grant_duration_days);
+  ELSE
+    v_granted_until := now() + make_interval(days => v_code_row.grant_duration_days);
+  END IF;
+
+  -- 6. Marketing-budget guard — compute grant value from monthly Stripe price
+  --    pro-rated by grant_duration_days.
+  SELECT price_cents INTO v_monthly_price_cents
+  FROM public.subscription_plan_prices
+  WHERE plan_key = v_code_row.grants_plan
+    AND billing_interval = 'month'
+    AND is_active = true
+  ORDER BY created_at ASC
+  LIMIT 1;
+
+  IF v_monthly_price_cents IS NULL THEN
+    -- No monthly price configured for the granted plan (e.g. free). Skip budget guard.
+    v_grant_value_cents := 0;
+  ELSE
+    v_grant_value_cents := (v_monthly_price_cents::numeric * v_code_row.grant_duration_days / 30.0)::integer;
+  END IF;
+
+  -- Read + decrement tenant_settings.feature_flags.marketing_budget_eur_remaining_cents.
+  -- If the flag doesn't exist, we don't gate (interpret missing flag as "no
+  -- budget configured" = no cap). Once ops seeds the flag, the guard activates.
+  IF v_grant_value_cents > 0 THEN
+    SELECT id, COALESCE((feature_flags->>'marketing_budget_eur_remaining_cents')::integer, NULL)
+      INTO v_settings_row_id, v_budget_remaining
+    FROM public.tenant_settings
+    WHERE tenant_id = p_tenant_id
+    FOR UPDATE;
+
+    IF v_settings_row_id IS NOT NULL AND v_budget_remaining IS NOT NULL THEN
+      IF v_budget_remaining < v_grant_value_cents THEN
+        RETURN jsonb_build_object(
+          'ok', false,
+          'error', 'BUDGET_EXHAUSTED',
+          'budget_remaining_cents', v_budget_remaining,
+          'grant_value_cents', v_grant_value_cents
+        );
+      END IF;
+
+      UPDATE public.tenant_settings
+         SET feature_flags = jsonb_set(
+               feature_flags,
+               '{marketing_budget_eur_remaining_cents}',
+               to_jsonb(v_budget_remaining - v_grant_value_cents)
+             )
+       WHERE id = v_settings_row_id;
+    END IF;
+  END IF;
+
+  -- 7. UPSERT user_subscriptions (status='active' for grants)
+  INSERT INTO public.user_subscriptions (
+    tenant_id, user_id, plan_key, status,
+    current_period_start, current_period_end,
+    metadata
+  ) VALUES (
+    p_tenant_id, p_user_id, v_code_row.grants_plan, 'active',
+    COALESCE(v_existing_sub.current_period_start, now()),
+    v_granted_until,
+    jsonb_build_object(
+      'source',   'redemption',
+      'code',     v_code_row.code,
+      'campaign', v_code_row.campaign
+    )
+  )
+  ON CONFLICT (tenant_id, user_id) DO UPDATE SET
+    plan_key             = EXCLUDED.plan_key,
+    status               = EXCLUDED.status,
+    current_period_end   = EXCLUDED.current_period_end,
+    cancel_at_period_end = false,
+    metadata             = public.user_subscriptions.metadata ||
+                           jsonb_build_object(
+                             'source',   'redemption',
+                             'code',     v_code_row.code,
+                             'campaign', v_code_row.campaign
+                           ),
+    updated_at           = now();
+
+  -- 8. Increment code uses_count
+  UPDATE public.redemption_codes
+     SET uses_count = uses_count + 1
+   WHERE code = v_code_row.code;
+
+  -- 9. Record redemption audit
+  INSERT INTO public.redemption_redemptions (
+    tenant_id, user_id, code, campaign, granted_plan, granted_until, grant_value_cents
+  ) VALUES (
+    p_tenant_id, p_user_id, v_code_row.code, v_code_row.campaign,
+    v_code_row.grants_plan, v_granted_until, v_grant_value_cents
+  )
+  RETURNING id INTO v_redemption_id;
+
+  -- 10. paywall_events audit
+  INSERT INTO public.paywall_events (tenant_id, user_id, feature_key, action, current_plan, context)
+  VALUES (
+    p_tenant_id, p_user_id, 'subscription', 'redeemed', v_code_row.grants_plan,
+    jsonb_build_object(
+      'code', v_code_row.code,
+      'campaign', v_code_row.campaign,
+      'granted_until', v_granted_until,
+      'grant_value_cents', v_grant_value_cents
+    )
+  );
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'redemption_id', v_redemption_id,
+    'granted_plan', v_code_row.grants_plan,
+    'granted_until', v_granted_until,
+    'grant_value_cents', v_grant_value_cents,
+    'uses_count', v_code_row.uses_count + 1,
+    'max_uses', v_code_row.max_uses,
+    'campaign', v_code_row.campaign
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.fn_redeem_code IS
+  'VTID-03107: atomic code redemption. Validates code → checks per-user single-use → rejects on active Stripe sub → checks + decrements marketing-budget cap → UPSERTs user_subscriptions with metadata.source=redemption → increments uses_count → audits to redemption_redemptions + paywall_events.';
+
+GRANT EXECUTE ON FUNCTION public.fn_redeem_code TO service_role, authenticated;
+
+-- -----------------------------------------------------------------------------
+-- 6. Seed Founding 500 launch campaign code  (per §S launch-day SQL)
+-- -----------------------------------------------------------------------------
+-- One shared marketing code. max_uses=500, grant_duration_days=90.
+-- Test-cohort codes (100 unique VITANA-TEST-* codes) are generated by ops via
+-- the Command Hub admin form in PR-5 — they are not seeded here.
+
+INSERT INTO public.redemption_codes (
+  code, campaign, grants_plan, grant_duration_days, max_uses, is_active, metadata
+) VALUES (
+  'FOUNDING', 'founding_500', 'premium', 90, 500, true,
+  jsonb_build_object(
+    'description', 'Launch Founding Member promo — first 500 users get 3 months Premium free',
+    'visibility', 'public',
+    'launch_date', '2026-05-20'
+  )
+)
+ON CONFLICT (code) DO UPDATE SET
+  max_uses            = EXCLUDED.max_uses,
+  grant_duration_days = EXCLUDED.grant_duration_days,
+  is_active           = EXCLUDED.is_active,
+  metadata            = EXCLUDED.metadata,
+  updated_at          = now();
+
+-- -----------------------------------------------------------------------------
+-- 7. Verification: code seeded + reused-redemption rejected
+-- -----------------------------------------------------------------------------
+
+DO $$
+DECLARE
+  v_row    public.redemption_codes%ROWTYPE;
+  v_result jsonb;
+BEGIN
+  SELECT * INTO v_row FROM public.redemption_codes WHERE code = 'FOUNDING';
+  IF v_row.code IS NULL THEN
+    RAISE EXCEPTION 'VTID-03107: FOUNDING code not seeded';
+  END IF;
+  IF v_row.max_uses <> 500 OR v_row.grant_duration_days <> 90 THEN
+    RAISE EXCEPTION 'VTID-03107: FOUNDING seeded with wrong values (max_uses=%, days=%)',
+      v_row.max_uses, v_row.grant_duration_days;
+  END IF;
+
+  -- Invalid code should be rejected
+  v_result := public.fn_redeem_code(
+    '00000000-0000-0000-0000-000003107030'::uuid,
+    '00000000-0000-0000-0000-000003107031'::uuid,
+    'NONEXISTENT-XXXX-XXXX'
+  );
+  IF (v_result->>'ok')::boolean OR (v_result->>'error') <> 'INVALID_CODE' THEN
+    RAISE EXCEPTION 'VTID-03107: invalid code should return INVALID_CODE, got %', v_result;
+  END IF;
+
+  -- Empty code should be rejected
+  v_result := public.fn_redeem_code(
+    '00000000-0000-0000-0000-000003107030'::uuid,
+    '00000000-0000-0000-0000-000003107031'::uuid,
+    '   '
+  );
+  IF (v_result->>'ok')::boolean OR (v_result->>'error') <> 'INVALID_CODE' THEN
+    RAISE EXCEPTION 'VTID-03107: empty code should return INVALID_CODE, got %', v_result;
+  END IF;
+
+  RAISE NOTICE 'VTID-03107 fn_redeem_code: FOUNDING seeded + invalid-code rejection verified ✓';
+END $$;

--- a/supabase/migrations/20260526070000_VTID_03107_features_json_seed.sql
+++ b/supabase/migrations/20260526070000_VTID_03107_features_json_seed.sql
@@ -1,0 +1,179 @@
+-- =============================================================================
+-- VTID-03107 · Billing v1 — subscription_plans.features_json seed
+-- =============================================================================
+-- Populates the per-tier capability config that lives alongside the metered
+-- feature_entitlements rows. These are CAPABILITY flags (boolean-ish / scalar)
+-- that don't fit the quota model:
+--
+--   storage_mb                       Storage quota (separate metering path
+--                                    using Supabase Storage upload sizes)
+--   sell_and_earn_catalog_size       Max items in the user's referral catalog
+--   sell_and_earn_daily_drafts       Per-day cap on Sell-and-Earn shadow drafts
+--   sell_and_earn_channels           Max listener channels
+--   sell_and_earn_autonomy_ceiling   Highest autonomy level user can set
+--                                    ('silent' | 'draft_to_user' | 'one_tap_approve' | 'auto_post')
+--                                    In v1: highest available is 'one_tap_approve'
+--                                    (auto_post is feature-flagged off platform-wide)
+--   sell_and_earn_voice_cloning      Voice/persona cloning (false in v1 launch)
+--   premium_priority_practitioner    Premium users surface first in practitioner queues
+--   ai_digest_cadence                'weekly' (Free) | 'daily' (paid) — feature flag
+--   auto_schedule_calendar           Premium-only calendar auto-schedule capability
+--
+-- Engineering naming
+--   These keys live in features_json (jsonb) on subscription_plans. The
+--   entitlement service reads them via:
+--     SELECT features_json->>'storage_mb' FROM subscription_plans WHERE plan_key = $1
+-- =============================================================================
+
+UPDATE public.subscription_plans
+SET features_json = jsonb_build_object(
+  -- Storage
+  'storage_mb',                       100,
+
+  -- Sell and Earn (capability ladder per §R)
+  'sell_and_earn_catalog_size',       5,
+  'sell_and_earn_daily_drafts',       1,
+  'sell_and_earn_channels',           1,
+  'sell_and_earn_autonomy_ceiling',   'draft_to_user',
+  'sell_and_earn_voice_cloning',      false,
+  'sell_and_earn_detected_window_days', 7,
+
+  -- AI / personalization
+  'ai_digest_cadence',                'weekly',
+  'auto_schedule_calendar',           false,
+
+  -- Practitioner / marketplace
+  'premium_priority_practitioner',    false
+)
+WHERE plan_key = 'free';
+
+UPDATE public.subscription_plans
+SET features_json = jsonb_build_object(
+  -- Storage
+  'storage_mb',                       5000,            -- 5 GB
+
+  -- Sell and Earn
+  'sell_and_earn_catalog_size',       25,
+  'sell_and_earn_daily_drafts',       5,
+  'sell_and_earn_channels',           3,
+  'sell_and_earn_autonomy_ceiling',   'draft_to_user',
+  'sell_and_earn_voice_cloning',      false,
+  'sell_and_earn_detected_window_days', 30,
+
+  -- AI / personalization
+  'ai_digest_cadence',                'daily',
+  'auto_schedule_calendar',           true,
+
+  -- Practitioner / marketplace
+  'premium_priority_practitioner',    true
+)
+WHERE plan_key = 'premium';
+
+UPDATE public.subscription_plans
+SET features_json = jsonb_build_object(
+  -- Storage
+  'storage_mb',                       25000,           -- 25 GB
+
+  -- Sell and Earn
+  'sell_and_earn_catalog_size',       100,
+  'sell_and_earn_daily_drafts',       25,
+  'sell_and_earn_channels',           10,
+  'sell_and_earn_autonomy_ceiling',   'one_tap_approve',
+  'sell_and_earn_voice_cloning',      false,
+  'sell_and_earn_detected_window_days', 90,
+
+  -- AI / personalization
+  'ai_digest_cadence',                'daily',
+  'auto_schedule_calendar',           true,
+
+  -- Practitioner / marketplace
+  'premium_priority_practitioner',    true
+)
+WHERE plan_key = 'premium_5x';
+
+UPDATE public.subscription_plans
+SET features_json = jsonb_build_object(
+  -- Storage
+  'storage_mb',                       100000,          -- 100 GB
+
+  -- Sell and Earn (fair-use ceilings; finite per cashflow guardrail §N #1)
+  'sell_and_earn_catalog_size',       1000,
+  'sell_and_earn_daily_drafts',       200,
+  'sell_and_earn_channels',           50,
+  'sell_and_earn_autonomy_ceiling',   'one_tap_approve',
+  'sell_and_earn_voice_cloning',      false,
+  'sell_and_earn_detected_window_days', -1,             -- lifetime (this is the ONE place we use -1; not a paywall quota)
+
+  -- AI / personalization
+  'ai_digest_cadence',                'daily',
+  'auto_schedule_calendar',           true,
+
+  -- Practitioner / marketplace
+  'premium_priority_practitioner',    true,
+
+  -- Live Rooms participant guardrail (internal cap to bound Daily.co cost)
+  'live_room_participant_minute_cap', 60000             -- 100h × avg 10 ppl = 60k p-min/mo
+)
+WHERE plan_key = 'premium_20x';
+
+-- -----------------------------------------------------------------------------
+-- Verification: every plan has a non-empty features_json with storage_mb
+-- -----------------------------------------------------------------------------
+
+DO $$
+DECLARE
+  v_count             integer;
+  v_free_storage      integer;
+  v_premium_storage   integer;
+  v_5x_storage        integer;
+  v_20x_storage       integer;
+BEGIN
+  SELECT COUNT(*) INTO v_count
+  FROM public.subscription_plans
+  WHERE features_json ? 'storage_mb';
+
+  IF v_count <> 4 THEN
+    RAISE EXCEPTION 'VTID-03107 features_json: expected 4 plans with storage_mb, found %', v_count;
+  END IF;
+
+  SELECT (features_json->>'storage_mb')::integer INTO v_free_storage    FROM public.subscription_plans WHERE plan_key = 'free';
+  SELECT (features_json->>'storage_mb')::integer INTO v_premium_storage FROM public.subscription_plans WHERE plan_key = 'premium';
+  SELECT (features_json->>'storage_mb')::integer INTO v_5x_storage      FROM public.subscription_plans WHERE plan_key = 'premium_5x';
+  SELECT (features_json->>'storage_mb')::integer INTO v_20x_storage     FROM public.subscription_plans WHERE plan_key = 'premium_20x';
+
+  IF v_free_storage    <> 100    THEN RAISE EXCEPTION 'free storage_mb = %, expected 100', v_free_storage; END IF;
+  IF v_premium_storage <> 5000   THEN RAISE EXCEPTION 'premium storage_mb = %, expected 5000', v_premium_storage; END IF;
+  IF v_5x_storage      <> 25000  THEN RAISE EXCEPTION 'premium_5x storage_mb = %, expected 25000', v_5x_storage; END IF;
+  IF v_20x_storage     <> 100000 THEN RAISE EXCEPTION 'premium_20x storage_mb = %, expected 100000', v_20x_storage; END IF;
+
+  RAISE NOTICE 'VTID-03107 features_json: storage_mb seeded per plan ✓ (100MB / 5GB / 25GB / 100GB)';
+END $$;
+
+DO $$
+DECLARE
+  v_premium_catalog integer;
+  v_5x_catalog      integer;
+  v_20x_catalog     integer;
+  v_free_ceiling    text;
+BEGIN
+  SELECT (features_json->>'sell_and_earn_catalog_size')::integer INTO v_premium_catalog
+   FROM public.subscription_plans WHERE plan_key = 'premium';
+  SELECT (features_json->>'sell_and_earn_catalog_size')::integer INTO v_5x_catalog
+   FROM public.subscription_plans WHERE plan_key = 'premium_5x';
+  SELECT (features_json->>'sell_and_earn_catalog_size')::integer INTO v_20x_catalog
+   FROM public.subscription_plans WHERE plan_key = 'premium_20x';
+  SELECT features_json->>'sell_and_earn_autonomy_ceiling' INTO v_free_ceiling
+   FROM public.subscription_plans WHERE plan_key = 'free';
+
+  IF v_premium_catalog <> 25 OR v_5x_catalog <> 100 OR v_20x_catalog <> 1000 THEN
+    RAISE EXCEPTION 'Sell-and-Earn catalog ladder broken: premium=%, 5x=%, 20x=%',
+      v_premium_catalog, v_5x_catalog, v_20x_catalog;
+  END IF;
+
+  IF v_free_ceiling <> 'draft_to_user' THEN
+    RAISE EXCEPTION 'Free Sell-and-Earn autonomy ceiling = %, expected draft_to_user', v_free_ceiling;
+  END IF;
+
+  RAISE NOTICE 'VTID-03107 features_json: Sell-and-Earn capability ladder verified ✓ (catalogs % / % / %)',
+    v_premium_catalog, v_5x_catalog, v_20x_catalog;
+END $$;

--- a/supabase/migrations/20260526080000_VTID_03107_lifecycle_notifications.sql
+++ b/supabase/migrations/20260526080000_VTID_03107_lifecycle_notifications.sql
@@ -1,0 +1,301 @@
+-- =============================================================================
+-- VTID-03107 · Billing v1 — Trial lifecycle notifications (Duolingo-style)
+-- =============================================================================
+-- Drives the 5-milestone lifecycle email/push sequence per §S of the plan:
+--
+--   day_0       trial_welcome              — fired on subscription creation
+--   day_7       trial_midpoint             — halfway-through usage stats
+--   day_12      trial_ending_2d            — "2 days left"
+--   day_13      trial_ending_1d            — "ends tomorrow"
+--   day_15      trial_cancelled_winback    — only if user cancelled
+--   day_30      trial_winback_one_shot     — only if cancelled + no return
+--
+-- Founding Member grants use the same shape with proportional timestamps
+-- (90 / 80 / 88 / 89 days).
+--
+-- Mechanism
+--   * lifecycle_notification_state — per-user audit of what was fired when.
+--     PK (user_id, lifecycle_kind) enforces single-fire per milestone.
+--   * fn_process_lifecycle_notifications() — SQL function that scans
+--     user_subscriptions for users at each milestone and emits an OASIS
+--     event (notify.lifecycle.<kind>). The gateway listens for this event
+--     class and calls notifyUser() to fan out push+inapp.
+--   * pg_cron job billing_lifecycle_notifications — hourly fire.
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- 1. State table
+-- -----------------------------------------------------------------------------
+
+CREATE TABLE IF NOT EXISTS public.lifecycle_notification_state (
+  user_id          uuid NOT NULL,
+  tenant_id        uuid NOT NULL,
+  lifecycle_kind   text NOT NULL CHECK (lifecycle_kind IN (
+    'trial_welcome',
+    'trial_midpoint',
+    'trial_ending_2d',
+    'trial_ending_1d',
+    'trial_cancelled_winback',
+    'trial_winback_one_shot',
+    'founding_midpoint',
+    'founding_ending_2d',
+    'founding_ending_1d'
+  )),
+  fired_at         timestamptz NOT NULL DEFAULT now(),
+  subscription_id  uuid REFERENCES public.user_subscriptions(id) ON DELETE CASCADE,
+  metadata         jsonb NOT NULL DEFAULT '{}'::jsonb,
+  PRIMARY KEY (user_id, lifecycle_kind)
+);
+
+CREATE INDEX IF NOT EXISTS idx_lifecycle_notification_state_fired_at
+  ON public.lifecycle_notification_state (fired_at DESC);
+
+COMMENT ON TABLE public.lifecycle_notification_state IS
+  'VTID-03107: per-user audit of lifecycle notification fires. PK enforces single-fire per milestone (idempotency for the hourly cron).';
+
+ALTER TABLE public.lifecycle_notification_state ENABLE ROW LEVEL SECURITY;
+DROP POLICY IF EXISTS lifecycle_state_svc_full ON public.lifecycle_notification_state;
+CREATE POLICY lifecycle_state_svc_full ON public.lifecycle_notification_state
+  FOR ALL TO service_role USING (true) WITH CHECK (true);
+DROP POLICY IF EXISTS lifecycle_state_read_own ON public.lifecycle_notification_state;
+CREATE POLICY lifecycle_state_read_own ON public.lifecycle_notification_state
+  FOR SELECT TO authenticated USING (user_id = auth.uid());
+GRANT SELECT ON public.lifecycle_notification_state TO authenticated;
+
+-- -----------------------------------------------------------------------------
+-- 2. Processor function
+-- -----------------------------------------------------------------------------
+-- Scans active subs + recently-cancelled subs and emits OASIS events for any
+-- user that has crossed a milestone without an existing fire row. Each emit
+-- writes its own lifecycle_notification_state row in the SAME transaction so
+-- a partial run doesn't re-fire on retry.
+--
+-- OASIS event topic: 'billing.lifecycle.<kind>' with payload:
+--   { user_id, tenant_id, subscription_id, plan_key, days_since_start,
+--     trial_end, source }
+-- A gateway worker subscribes to this topic and translates into notifyUser()
+-- with the appropriate notification type (e.g. trial_midpoint).
+
+CREATE OR REPLACE FUNCTION public.fn_process_lifecycle_notifications()
+RETURNS jsonb
+LANGUAGE plpgsql
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_row record;
+  v_fires_total integer := 0;
+  v_kind_counts jsonb := '{}'::jsonb;
+
+  -- Helper: emit one fire (insert state + return)
+  -- Inlined as a CTE pattern below.
+BEGIN
+  -- ── Trial midpoint (day 7) ──────────────────────────────────────────────
+  FOR v_row IN
+    SELECT s.id, s.user_id, s.tenant_id, s.plan_key, s.trial_end, s.current_period_start
+    FROM public.user_subscriptions s
+    LEFT JOIN public.lifecycle_notification_state st
+      ON st.user_id = s.user_id AND st.lifecycle_kind = 'trial_midpoint'
+    WHERE s.status = 'trialing'
+      AND s.trial_end IS NOT NULL
+      AND s.trial_end > now()
+      AND s.trial_end - now() <= interval '8 days'
+      AND s.trial_end - now() >  interval '6 days'
+      AND st.user_id IS NULL
+  LOOP
+    INSERT INTO public.lifecycle_notification_state (user_id, tenant_id, lifecycle_kind, subscription_id, metadata)
+    VALUES (v_row.user_id, v_row.tenant_id, 'trial_midpoint', v_row.id,
+            jsonb_build_object('plan_key', v_row.plan_key, 'trial_end', v_row.trial_end))
+    ON CONFLICT (user_id, lifecycle_kind) DO NOTHING;
+
+    -- Best-effort OASIS event emit (table-write only; the gateway worker
+    -- subscribes and translates to notifyUser at the application layer).
+    BEGIN
+      INSERT INTO public.oasis_events (vtid, topic, source, status, message, payload)
+      VALUES ('VTID-03107', 'billing.lifecycle.trial_midpoint', 'fn_process_lifecycle_notifications',
+              'success', 'Trial midpoint reached',
+              jsonb_build_object(
+                'user_id', v_row.user_id,
+                'tenant_id', v_row.tenant_id,
+                'subscription_id', v_row.id,
+                'plan_key', v_row.plan_key,
+                'trial_end', v_row.trial_end
+              ));
+    EXCEPTION WHEN OTHERS THEN
+      -- oasis_events may not exist on every environment; non-blocking.
+      NULL;
+    END;
+    v_fires_total := v_fires_total + 1;
+  END LOOP;
+
+  -- ── Trial ending in 2 days ──────────────────────────────────────────────
+  FOR v_row IN
+    SELECT s.id, s.user_id, s.tenant_id, s.plan_key, s.trial_end
+    FROM public.user_subscriptions s
+    LEFT JOIN public.lifecycle_notification_state st
+      ON st.user_id = s.user_id AND st.lifecycle_kind = 'trial_ending_2d'
+    WHERE s.status = 'trialing'
+      AND s.trial_end IS NOT NULL
+      AND s.trial_end > now()
+      AND s.trial_end - now() <= interval '2 days 1 hour'
+      AND s.trial_end - now() >  interval '1 days 23 hours'
+      AND st.user_id IS NULL
+  LOOP
+    INSERT INTO public.lifecycle_notification_state (user_id, tenant_id, lifecycle_kind, subscription_id, metadata)
+    VALUES (v_row.user_id, v_row.tenant_id, 'trial_ending_2d', v_row.id,
+            jsonb_build_object('plan_key', v_row.plan_key, 'trial_end', v_row.trial_end))
+    ON CONFLICT (user_id, lifecycle_kind) DO NOTHING;
+    BEGIN
+      INSERT INTO public.oasis_events (vtid, topic, source, status, message, payload)
+      VALUES ('VTID-03107', 'billing.lifecycle.trial_ending_2d', 'fn_process_lifecycle_notifications',
+              'success', 'Trial ending in 2 days',
+              jsonb_build_object('user_id', v_row.user_id, 'tenant_id', v_row.tenant_id,
+                                 'subscription_id', v_row.id, 'plan_key', v_row.plan_key,
+                                 'trial_end', v_row.trial_end));
+    EXCEPTION WHEN OTHERS THEN NULL;
+    END;
+    v_fires_total := v_fires_total + 1;
+  END LOOP;
+
+  -- ── Trial ending in 1 day ───────────────────────────────────────────────
+  FOR v_row IN
+    SELECT s.id, s.user_id, s.tenant_id, s.plan_key, s.trial_end
+    FROM public.user_subscriptions s
+    LEFT JOIN public.lifecycle_notification_state st
+      ON st.user_id = s.user_id AND st.lifecycle_kind = 'trial_ending_1d'
+    WHERE s.status = 'trialing'
+      AND s.trial_end IS NOT NULL
+      AND s.trial_end > now()
+      AND s.trial_end - now() <= interval '1 day 1 hour'
+      AND s.trial_end - now() >  interval '23 hours'
+      AND st.user_id IS NULL
+  LOOP
+    INSERT INTO public.lifecycle_notification_state (user_id, tenant_id, lifecycle_kind, subscription_id, metadata)
+    VALUES (v_row.user_id, v_row.tenant_id, 'trial_ending_1d', v_row.id,
+            jsonb_build_object('plan_key', v_row.plan_key, 'trial_end', v_row.trial_end))
+    ON CONFLICT (user_id, lifecycle_kind) DO NOTHING;
+    BEGIN
+      INSERT INTO public.oasis_events (vtid, topic, source, status, message, payload)
+      VALUES ('VTID-03107', 'billing.lifecycle.trial_ending_1d', 'fn_process_lifecycle_notifications',
+              'success', 'Trial ending tomorrow',
+              jsonb_build_object('user_id', v_row.user_id, 'tenant_id', v_row.tenant_id,
+                                 'subscription_id', v_row.id, 'plan_key', v_row.plan_key,
+                                 'trial_end', v_row.trial_end));
+    EXCEPTION WHEN OTHERS THEN NULL;
+    END;
+    v_fires_total := v_fires_total + 1;
+  END LOOP;
+
+  -- ── Cancelled win-back (day 15 — 1 day after period end if cancelled) ───
+  FOR v_row IN
+    SELECT s.id, s.user_id, s.tenant_id, s.plan_key, s.current_period_end
+    FROM public.user_subscriptions s
+    LEFT JOIN public.lifecycle_notification_state st
+      ON st.user_id = s.user_id AND st.lifecycle_kind = 'trial_cancelled_winback'
+    WHERE s.status = 'canceled'
+      AND s.current_period_end IS NOT NULL
+      AND now() - s.current_period_end >= interval '23 hours'
+      AND now() - s.current_period_end <  interval '25 hours'
+      AND st.user_id IS NULL
+  LOOP
+    INSERT INTO public.lifecycle_notification_state (user_id, tenant_id, lifecycle_kind, subscription_id, metadata)
+    VALUES (v_row.user_id, v_row.tenant_id, 'trial_cancelled_winback', v_row.id,
+            jsonb_build_object('plan_key', v_row.plan_key, 'period_end', v_row.current_period_end))
+    ON CONFLICT (user_id, lifecycle_kind) DO NOTHING;
+    BEGIN
+      INSERT INTO public.oasis_events (vtid, topic, source, status, message, payload)
+      VALUES ('VTID-03107', 'billing.lifecycle.trial_cancelled_winback', 'fn_process_lifecycle_notifications',
+              'success', 'Cancelled trial — soft win-back',
+              jsonb_build_object('user_id', v_row.user_id, 'tenant_id', v_row.tenant_id,
+                                 'subscription_id', v_row.id, 'plan_key', v_row.plan_key,
+                                 'period_end', v_row.current_period_end));
+    EXCEPTION WHEN OTHERS THEN NULL;
+    END;
+    v_fires_total := v_fires_total + 1;
+  END LOOP;
+
+  -- ── Day-30 one-shot win-back (cancelled, no return, 30 days later) ──────
+  FOR v_row IN
+    SELECT s.id, s.user_id, s.tenant_id, s.plan_key, s.current_period_end
+    FROM public.user_subscriptions s
+    LEFT JOIN public.lifecycle_notification_state st
+      ON st.user_id = s.user_id AND st.lifecycle_kind = 'trial_winback_one_shot'
+    WHERE s.status = 'canceled'
+      AND s.current_period_end IS NOT NULL
+      AND now() - s.current_period_end >= interval '29 days 23 hours'
+      AND now() - s.current_period_end <  interval '30 days 1 hour'
+      AND st.user_id IS NULL
+  LOOP
+    INSERT INTO public.lifecycle_notification_state (user_id, tenant_id, lifecycle_kind, subscription_id, metadata)
+    VALUES (v_row.user_id, v_row.tenant_id, 'trial_winback_one_shot', v_row.id,
+            jsonb_build_object('plan_key', v_row.plan_key, 'period_end', v_row.current_period_end))
+    ON CONFLICT (user_id, lifecycle_kind) DO NOTHING;
+    BEGIN
+      INSERT INTO public.oasis_events (vtid, topic, source, status, message, payload)
+      VALUES ('VTID-03107', 'billing.lifecycle.trial_winback_one_shot', 'fn_process_lifecycle_notifications',
+              'success', 'Cancelled trial — day 30 one-shot',
+              jsonb_build_object('user_id', v_row.user_id, 'tenant_id', v_row.tenant_id,
+                                 'subscription_id', v_row.id, 'plan_key', v_row.plan_key,
+                                 'period_end', v_row.current_period_end));
+    EXCEPTION WHEN OTHERS THEN NULL;
+    END;
+    v_fires_total := v_fires_total + 1;
+  END LOOP;
+
+  -- Counts per kind for the telemetry dashboard
+  SELECT jsonb_object_agg(lifecycle_kind, c) INTO v_kind_counts
+  FROM (
+    SELECT lifecycle_kind, count(*) AS c
+    FROM public.lifecycle_notification_state
+    WHERE fired_at > now() - interval '24 hours'
+    GROUP BY lifecycle_kind
+  ) t;
+
+  RETURN jsonb_build_object(
+    'ok', true,
+    'fires_this_run', v_fires_total,
+    'fires_last_24h', COALESCE(v_kind_counts, '{}'::jsonb),
+    'ran_at', now()
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.fn_process_lifecycle_notifications IS
+  'VTID-03107: hourly lifecycle-milestone processor. Scans user_subscriptions for users at trial day 7/12/13 + cancelled day 15/30 milestones, fires OASIS events for the gateway worker to translate into notifyUser() push+inapp.';
+
+GRANT EXECUTE ON FUNCTION public.fn_process_lifecycle_notifications TO service_role;
+
+-- -----------------------------------------------------------------------------
+-- 3. Schedule pg_cron — hourly
+-- -----------------------------------------------------------------------------
+
+DO $$
+DECLARE v_jobid bigint;
+BEGIN
+  FOR v_jobid IN
+    SELECT jobid FROM cron.job WHERE jobname = 'billing_lifecycle_notifications'
+  LOOP
+    PERFORM cron.unschedule(v_jobid);
+  END LOOP;
+END $$;
+
+SELECT cron.schedule(
+  'billing_lifecycle_notifications',
+  '15 * * * *',                          -- hourly at :15 past the hour
+  $cron_lifecycle$SELECT public.fn_process_lifecycle_notifications();$cron_lifecycle$
+);
+
+-- -----------------------------------------------------------------------------
+-- 4. Verification: function executable on empty data
+-- -----------------------------------------------------------------------------
+
+DO $$
+DECLARE v_result jsonb;
+BEGIN
+  v_result := public.fn_process_lifecycle_notifications();
+  IF NOT (v_result->>'ok')::boolean THEN
+    RAISE EXCEPTION 'fn_process_lifecycle_notifications returned: %', v_result;
+  END IF;
+  RAISE NOTICE 'VTID-03107 lifecycle notifications: function + cron registered. First-run fires=%',
+    v_result->>'fires_this_run';
+END $$;

--- a/supabase/migrations/20260526090000_VTID_03107_lifecycle_notified_at.sql
+++ b/supabase/migrations/20260526090000_VTID_03107_lifecycle_notified_at.sql
@@ -1,0 +1,19 @@
+-- =============================================================================
+-- VTID-03107 · Billing v1 — lifecycle_notification_state.notified_at column
+-- =============================================================================
+-- Adds the column the gateway lifecycle-notification-worker reads to find
+-- un-dispatched rows. NULL = pending notification; non-null = worker
+-- already fanned out via notifyUserAsync.
+--
+-- Idempotent: ADD COLUMN IF NOT EXISTS lets the migration re-run safely.
+-- =============================================================================
+
+ALTER TABLE public.lifecycle_notification_state
+  ADD COLUMN IF NOT EXISTS notified_at timestamptz;
+
+CREATE INDEX IF NOT EXISTS idx_lifecycle_notification_state_pending
+  ON public.lifecycle_notification_state (fired_at DESC)
+  WHERE notified_at IS NULL;
+
+COMMENT ON COLUMN public.lifecycle_notification_state.notified_at IS
+  'VTID-03107: when the gateway lifecycle-notification-worker fanned this row out via notifyUserAsync. NULL = pending. Index supports the worker''s polling query.';

--- a/supabase/migrations/20260526100000_VTID_03107_rolling_windows.sql
+++ b/supabase/migrations/20260526100000_VTID_03107_rolling_windows.sql
@@ -1,0 +1,233 @@
+-- =============================================================================
+-- VTID-03107 · Billing v1 — Rolling 5h + weekly window quotas
+-- =============================================================================
+-- Adds Claude / ChatGPT-style two-tier reset windows so Free users hit walls
+-- that recover within hours instead of needing to wait 30 days.
+--
+-- Pattern (matches Codex menu UX):
+--   • 5h sliding window — caps burst usage, refreshes ~4x/day
+--   • Weekly sliding window — caps total per week, refreshes Monday 00:00 CET
+--   • Monthly window — kept as a higher ceiling so weekly is always the binding
+--     cap on Free; paid tiers keep monthly-only (no 5h/weekly limit)
+--
+-- Schema changes
+--   ALTER TABLE feature_entitlements
+--     ADD window_5h_quota   INTEGER NULL   -- if set, enforced as sliding 5h
+--     ADD weekly_quota      INTEGER NULL   -- if set, enforced as sliding 7d
+--
+-- NULL semantics: when a window column is NULL, that window is not enforced
+-- for this (plan, feature) row. Paid tiers keep both columns NULL → only the
+-- existing monthly `quota` is checked. Free uses all three.
+--
+-- New RPC
+--   fn_get_feature_usage_in_window(tenant, user, feature, seconds)
+--     Sliding aggregation: SUM(used) over feature_usage rows whose
+--     window_start is within the last `seconds` interval. Returns the
+--     accumulated usage plus the time when the OLDEST tallied event ages
+--     out of the window (= effective reset time the UI shows).
+--
+--   This sits alongside the existing fn_get_feature_usage (point lookup
+--   for calendar-aligned windows) — unchanged for backwards compat.
+--
+-- Cashflow guardrail
+--   Free worst case bumps from €3 → €16/user-month if every window is maxed
+--   every cycle. Real typical use is far lower (windows refresh but human
+--   attention doesn't). Every number below is one SQL UPDATE away from
+--   retuning if telemetry shows abuse.
+-- =============================================================================
+
+-- -----------------------------------------------------------------------------
+-- 1. Add columns
+-- -----------------------------------------------------------------------------
+
+ALTER TABLE public.feature_entitlements
+  ADD COLUMN IF NOT EXISTS window_5h_quota   INTEGER NULL,
+  ADD COLUMN IF NOT EXISTS weekly_quota      INTEGER NULL;
+
+COMMENT ON COLUMN public.feature_entitlements.window_5h_quota IS
+  'VTID-03107: optional rolling 5-hour cap. NULL = not enforced. When set, takes precedence over monthly if more restrictive.';
+COMMENT ON COLUMN public.feature_entitlements.weekly_quota IS
+  'VTID-03107: optional rolling 7-day cap. NULL = not enforced. Typically binds before monthly on Free tier.';
+
+-- -----------------------------------------------------------------------------
+-- 2. fn_get_feature_usage_in_window — sliding aggregation
+-- -----------------------------------------------------------------------------
+-- Returns SUM(used) over the last `p_window_seconds` of events plus the
+-- effective reset_at (when the oldest tallied event ages out).
+--
+-- Storage assumption: callers write per-action event rows via
+-- fn_increment_feature_usage with p_window_seconds=60 (minute-granularity),
+-- producing one row per minute of activity. Same-minute increments fold via
+-- the existing ON CONFLICT.
+--
+-- This means the EXISTING fn_increment_feature_usage stays usable for both
+-- modes — entitlement-service v2 just always passes p_window_seconds=60 so
+-- the rows are fine-grained enough for sliding aggregation.
+
+CREATE OR REPLACE FUNCTION public.fn_get_feature_usage_in_window(
+  p_tenant_id      uuid,
+  p_user_id        uuid,
+  p_feature_key    text,
+  p_window_seconds integer
+)
+RETURNS jsonb
+LANGUAGE plpgsql
+STABLE
+SECURITY DEFINER
+SET search_path = public
+AS $$
+DECLARE
+  v_now            timestamptz := now();
+  v_cutoff         timestamptz;
+  v_used           integer;
+  v_oldest         timestamptz;
+  v_reset_at       timestamptz;
+BEGIN
+  IF p_window_seconds < 1 THEN
+    RAISE EXCEPTION 'fn_get_feature_usage_in_window: p_window_seconds must be >= 1';
+  END IF;
+
+  v_cutoff := v_now - make_interval(secs => p_window_seconds);
+
+  SELECT COALESCE(SUM(used), 0), MIN(window_start)
+    INTO v_used, v_oldest
+  FROM public.feature_usage
+  WHERE user_id = p_user_id
+    AND feature_key = p_feature_key
+    AND window_start >= v_cutoff;
+
+  -- reset_at = oldest tallied event + window length (when it ages out).
+  -- If no events in window, reset_at is null (no usage to recover).
+  IF v_oldest IS NOT NULL THEN
+    v_reset_at := v_oldest + make_interval(secs => p_window_seconds);
+  ELSE
+    v_reset_at := NULL;
+  END IF;
+
+  RETURN jsonb_build_object(
+    'ok',         true,
+    'used',       v_used,
+    'window_seconds', p_window_seconds,
+    'reset_at',   v_reset_at,
+    'oldest_event_at', v_oldest
+  );
+END;
+$$;
+
+COMMENT ON FUNCTION public.fn_get_feature_usage_in_window IS
+  'VTID-03107: sliding-window usage aggregation. Returns SUM(used) over the last p_window_seconds + effective reset_at (oldest event + window length). Caller writes per-minute event rows via fn_increment_feature_usage(p_window_seconds=60).';
+
+GRANT EXECUTE ON FUNCTION public.fn_get_feature_usage_in_window TO service_role, authenticated;
+
+-- -----------------------------------------------------------------------------
+-- 3. Update Free tier with 5h + weekly + monthly
+-- -----------------------------------------------------------------------------
+-- Free tier gets the three-window treatment so the user always has a near-term
+-- recovery option. Monthly is bumped above weekly×4.3 so weekly is the binding
+-- cap (the rolling 5h binds first during active use; weekly binds for the week).
+
+UPDATE public.feature_entitlements SET
+  window_5h_quota = 5,           -- 5 min per 5h
+  weekly_quota    = 20,          -- 20 min per week
+  quota           = 80           -- monthly soft ceiling; weekly always binds first
+WHERE plan_key = 'free' AND feature_key = 'voice_live_minutes';
+
+UPDATE public.feature_entitlements SET
+  window_5h_quota = 20,          -- 20 min per 5h
+  weekly_quota    = 60,          -- 1 hr per week
+  quota           = 240          -- monthly soft ceiling
+WHERE plan_key = 'free' AND feature_key = 'live_room_minutes';
+
+UPDATE public.feature_entitlements SET
+  window_5h_quota = 2,           -- 2 posts per 5h
+  weekly_quota    = 5,           -- 5 posts per week
+  quota           = 20           -- monthly soft ceiling
+WHERE plan_key = 'free' AND feature_key = 'match_posts';
+
+UPDATE public.feature_entitlements SET
+  window_5h_quota = 3,           -- 3 reveals per 5h
+  weekly_quota    = 10,          -- 10 reveals per week
+  quota           = 40           -- monthly soft ceiling
+WHERE plan_key = 'free' AND feature_key = 'match_reveals';
+
+UPDATE public.feature_entitlements SET
+  window_5h_quota = 1,           -- 1 lab per 5h
+  weekly_quota    = 3,           -- 3 labs per week
+  quota           = 12           -- monthly soft ceiling
+WHERE plan_key = 'free' AND feature_key = 'lab_analyses';
+
+UPDATE public.feature_entitlements SET
+  window_5h_quota = 5,           -- 5 photos per 5h
+  weekly_quota    = 15,          -- 15 photos per week
+  quota           = 60           -- monthly soft ceiling
+WHERE plan_key = 'free' AND feature_key = 'photo_uploads';
+
+-- -----------------------------------------------------------------------------
+-- 4. Paid tiers — leave window_5h_quota + weekly_quota NULL (monthly only)
+-- -----------------------------------------------------------------------------
+-- Premium / Host / Community keep the existing monthly quotas. window_5h and
+-- weekly stay NULL → entitlement service skips those checks for these tiers.
+--
+-- No-op UPDATEs included for clarity that this is intentional.
+
+-- (intentionally no UPDATEs for premium/premium_5x/premium_20x rows — NULL is correct)
+
+-- -----------------------------------------------------------------------------
+-- 5. Flip Free tier behavior_on_exceed from soft_counter → paywall
+-- -----------------------------------------------------------------------------
+-- Per cashflow review 2026-05-26: hard cuts on all 8 metered features at launch.
+-- The auto-grant migration (20260526110000) ensures every onboarded user is on
+-- Premium for 12 months, so no existing user hits a Free hard cut. Only new
+-- signups after the Founding cap (500) face Free walls — and they always have
+-- PAYG credits + Upgrade CTAs.
+
+UPDATE public.feature_entitlements
+  SET behavior_on_exceed = 'paywall'
+WHERE plan_key = 'free'
+  AND behavior_on_exceed = 'soft_counter';
+
+-- -----------------------------------------------------------------------------
+-- 6. Verification: Free tier has all three windows populated
+-- -----------------------------------------------------------------------------
+
+DO $$
+DECLARE
+  v_free_with_5h   integer;
+  v_free_with_wk   integer;
+  v_paid_with_5h   integer;
+  v_voice_5h       integer;
+  v_voice_wk       integer;
+BEGIN
+  SELECT COUNT(*) INTO v_free_with_5h
+    FROM public.feature_entitlements
+    WHERE plan_key = 'free' AND window_5h_quota IS NOT NULL;
+
+  SELECT COUNT(*) INTO v_free_with_wk
+    FROM public.feature_entitlements
+    WHERE plan_key = 'free' AND weekly_quota IS NOT NULL;
+
+  SELECT COUNT(*) INTO v_paid_with_5h
+    FROM public.feature_entitlements
+    WHERE plan_key IN ('premium','premium_5x','premium_20x')
+      AND window_5h_quota IS NOT NULL;
+
+  SELECT window_5h_quota, weekly_quota
+    INTO v_voice_5h, v_voice_wk
+    FROM public.feature_entitlements
+    WHERE plan_key = 'free' AND feature_key = 'voice_live_minutes';
+
+  IF v_free_with_5h <> 6 THEN
+    RAISE EXCEPTION 'VTID-03107 rolling_windows: expected 6 Free rows with 5h quota, found %', v_free_with_5h;
+  END IF;
+  IF v_free_with_wk <> 6 THEN
+    RAISE EXCEPTION 'VTID-03107 rolling_windows: expected 6 Free rows with weekly quota, found %', v_free_with_wk;
+  END IF;
+  IF v_paid_with_5h <> 0 THEN
+    RAISE EXCEPTION 'VTID-03107 rolling_windows: paid tiers should have NO 5h windows, found %', v_paid_with_5h;
+  END IF;
+  IF v_voice_5h <> 5 OR v_voice_wk <> 20 THEN
+    RAISE EXCEPTION 'VTID-03107 rolling_windows: voice limits wrong (5h=%, weekly=%) expected 5/20', v_voice_5h, v_voice_wk;
+  END IF;
+
+  RAISE NOTICE 'VTID-03107 rolling_windows: Free rows have all 3 windows, paid stays monthly-only ✓';
+END $$;

--- a/supabase/migrations/20260526110000_VTID_03107_launch_auto_grant.sql
+++ b/supabase/migrations/20260526110000_VTID_03107_launch_auto_grant.sql
@@ -1,0 +1,181 @@
+-- =============================================================================
+-- VTID-03107 · Billing v1 — Launch auto-grant for existing onboarded users
+-- =============================================================================
+-- One-time idempotent grant: every user who was onboarded BEFORE this migration
+-- runs gets a 12-month Premium subscription automatically — no codes, no clicks,
+-- no email. They open the app on next launch and see they have Premium until
+-- {now + 365d}.
+--
+-- Rationale (locked with operator 2026-05-26):
+--   "We cannot go back to existing users and tell them: hey, now you have a
+--    hard cut, unlock with a code. Too complicated. Everyone already onboarded
+--    receives a 12-month free subscription automatically."
+--
+-- Source-of-truth for "who is onboarded"
+--   user_tenants → app_users (canonical, since the Phase A bootstrap migration
+--   20251231000000_vtid_01101). One row per (user_id, tenant_id) membership.
+--   Filtering by is_primary=true picks the user's primary tenant so multi-
+--   tenant accounts get exactly one grant.
+--
+-- Boundary
+--   app_users.created_at < (now() - 24h)  →  "already onboarded"
+--   Newer signups go through the normal trial flow. The 24h skirt avoids
+--   racing a fresh signup that's happening at migration time.
+--
+-- Idempotency
+--   Skip any user who already has an active/trialing/past_due subscription
+--   (Stripe-paid, redemption-coded, or otherwise). The auto-grant is a
+--   floor, not an override.
+--
+-- Tagging
+--   metadata.source = 'launch_auto_grant_2026'
+--   metadata.granted_at = <timestamp>
+--   metadata.no_friction = true
+--   metadata.grant_duration_days = 365
+--
+--   The frontend reads metadata.source to render the one-time welcome banner
+--   on Settings → Subscription. Once dismissed (localStorage) it never appears
+--   again, but the plan card subtitle keeps showing "auto-granted at launch"
+--   for the full 12 months so the user can always check why.
+--
+-- Cashflow note
+--   Foregone-revenue worst case: <onboarded_count> × €9.99 × 12 months.
+--   Real cost is infra (voice + storage). At ~2,000 users on Premium quotas
+--   (30 min voice/mo + 5h rooms/mo + small features) ≈ €10/user/mo worst case
+--   ≈ €240k infra worst case over 12 months. Acceptable: existing users are
+--   the highest-value cohort we have.
+-- =============================================================================
+
+DO $$
+DECLARE
+  v_inserted       integer;
+  v_skipped_active integer;
+  v_total_eligible integer;
+  v_total_users    integer;
+  v_granted_until  timestamptz := now() + interval '365 days';
+  v_source         text := 'launch_auto_grant_2026';
+BEGIN
+  -- Count total app_users (sanity check for empty environments)
+  SELECT COUNT(*) INTO v_total_users FROM public.app_users;
+
+  -- Count eligible: primary-tenant memberships of users onboarded >24h ago
+  -- who don't already have an active sub
+  SELECT COUNT(*) INTO v_total_eligible
+  FROM public.user_tenants ut
+  JOIN public.app_users au ON au.user_id = ut.user_id
+  WHERE ut.is_primary = true
+    AND au.created_at < (now() - interval '24 hours')
+    AND NOT EXISTS (
+      SELECT 1 FROM public.user_subscriptions us
+      WHERE us.user_id = ut.user_id
+        AND us.status IN ('trialing','active','past_due')
+    );
+
+  -- Count already-protected (active sub) — these get skipped
+  SELECT COUNT(*) INTO v_skipped_active
+  FROM public.user_tenants ut
+  JOIN public.app_users au ON au.user_id = ut.user_id
+  JOIN public.user_subscriptions us ON us.user_id = ut.user_id
+  WHERE ut.is_primary = true
+    AND au.created_at < (now() - interval '24 hours')
+    AND us.status IN ('trialing','active','past_due');
+
+  -- Do the grant
+  INSERT INTO public.user_subscriptions (
+    tenant_id,
+    user_id,
+    plan_key,
+    price_key,
+    status,
+    current_period_start,
+    current_period_end,
+    cancel_at_period_end,
+    trial_end,
+    metadata
+  )
+  SELECT
+    ut.tenant_id,
+    ut.user_id,
+    'premium',
+    NULL,                                 -- grant has no Stripe Price binding
+    'active',
+    now(),
+    v_granted_until,
+    false,
+    NULL,                                 -- grant ≠ trial
+    jsonb_build_object(
+      'source',              v_source,
+      'granted_at',          now(),
+      'no_friction',         true,
+      'grant_duration_days', 365,
+      'reason',              'launch_auto_grant_existing_onboarded_users'
+    )
+  FROM public.user_tenants ut
+  JOIN public.app_users au ON au.user_id = ut.user_id
+  WHERE ut.is_primary = true
+    AND au.created_at < (now() - interval '24 hours')
+    AND NOT EXISTS (
+      SELECT 1 FROM public.user_subscriptions us
+      WHERE us.user_id = ut.user_id
+        AND us.status IN ('trialing','active','past_due')
+    )
+  ON CONFLICT (tenant_id, user_id) DO NOTHING;
+
+  GET DIAGNOSTICS v_inserted = ROW_COUNT;
+
+  -- Audit: write a paywall_events row per grant so the Command Hub dashboard
+  -- can see the launch event in the funnel telemetry.
+  INSERT INTO public.paywall_events (tenant_id, user_id, feature_key, action, current_plan, context)
+  SELECT
+    us.tenant_id,
+    us.user_id,
+    'subscription_grant',
+    'redeemed',
+    'premium',
+    jsonb_build_object(
+      'source', v_source,
+      'granted_until', v_granted_until,
+      'campaign', 'launch_auto_grant_2026'
+    )
+  FROM public.user_subscriptions us
+  WHERE us.metadata->>'source' = v_source
+    AND us.created_at > (now() - interval '5 minutes');
+
+  RAISE NOTICE 'VTID-03107 launch_auto_grant_2026:';
+  RAISE NOTICE '  total app_users in tenant:            %', v_total_users;
+  RAISE NOTICE '  eligible (onboarded, no active sub):  %', v_total_eligible;
+  RAISE NOTICE '  granted now:                          %', v_inserted;
+  RAISE NOTICE '  skipped (already on a sub):           %', v_skipped_active;
+  RAISE NOTICE '  current_period_end:                   %', v_granted_until;
+END $$;
+
+-- -----------------------------------------------------------------------------
+-- Verification: if there are eligible users, at least one row was written
+-- (empty-environment / fresh-DB case: this is a no-op)
+-- -----------------------------------------------------------------------------
+
+DO $$
+DECLARE
+  v_count          integer;
+  v_eligible_count integer;
+BEGIN
+  SELECT COUNT(*) INTO v_eligible_count
+  FROM public.user_tenants ut
+  JOIN public.app_users au ON au.user_id = ut.user_id
+  WHERE ut.is_primary = true
+    AND au.created_at < (now() - interval '24 hours');
+
+  SELECT COUNT(*) INTO v_count
+  FROM public.user_subscriptions
+  WHERE metadata->>'source' = 'launch_auto_grant_2026';
+
+  IF v_eligible_count > 0 AND v_count = 0 THEN
+    RAISE EXCEPTION 'VTID-03107 launch_auto_grant: % eligible memberships but 0 grants written', v_eligible_count;
+  END IF;
+
+  IF v_eligible_count = 0 THEN
+    RAISE NOTICE 'VTID-03107 launch_auto_grant: no eligible memberships (empty env / fresh DB) — skipping ✓';
+  ELSE
+    RAISE NOTICE 'VTID-03107 launch_auto_grant: % subscriptions tagged source=launch_auto_grant_2026 ✓', v_count;
+  END IF;
+END $$;


### PR DESCRIPTION
## PR-1+PR-2 of 6 — Subscription + Credits Billing v1 Launch

**Status: PR-1 + PR-2 complete and pushed.** Schema foundation + runtime entitlement layer. **Zero behavior change in prod** — no feature is gated yet, no Stripe is called automatically, no frontend route changes. Follow-up PRs layer frontend (PR-3) + per-feature gates (PR-4) + ops integration (PR-5) + telemetry (PR-6) on top.

VTID-03107 allocated via the global VTID allocator (id `a440f147-ae7f-484b-86dc-972afedbc0f9`).

Plan source of truth: `.claude/plans/the-plan-should-also-humming-stonebraker.md`

---

## What's in this PR (so far)

| Commit | Scope | Lines |
|---|---|---|
| `ff05f600` | PR-1: wallet reconciliation + subscription core + OpenClaw compat view (3 migrations) | +823 |
| `a7cf3d3d` | PR-1: seed plans + helpers + cron + redemption codes + features_json (5 migrations) | +1,311 |
| `b96ee2a8` | PR-1: BUSINESS-MODEL.md + KB chapter 18-04 update | +335 / -5 |
| `ed065853` | **PR-2**: entitlement service + paywall middleware + Stripe routes | +1,833 / -1 |
| **Total** | | **+4,302 / -6** |

### PR-1 schema (8 migrations, see commits above) — unchanged from prior PR description

### PR-2 runtime (new commit `ed065853`)

**`services/gateway/src/services/entitlement-service.ts`** (578 lines) — single source of truth for "can this user use this feature right now?"
- `checkEntitlement` reads plan + entitlement config + usage + wallet, computes `paywall_action ∈ {allow, soft_counter, paywall, degrade, hard_block, deferred}`
- **D36 hook**: before returning paywall/hard_block, calls `computeMonetizationContext`; if `envelope.allow_paid === false`, downgrades outcome to `deferred` and writes `paywall_events.action='deferred_for_vulnerability'`. The caller treats `deferred` as "allowed, but do not increment usage, do not show paywall."
- `recordUsage` — atomic increment via `fn_increment_feature_usage` RPC
- `consumeCredits` — wraps `fn_consume_credits` + picks bucket (rewards-first drain if allowed by feature config), advances usage meter post-debit
- `recordPaywallEvent` — audit helper
- **Fails closed**: missing entitlement config returns paywall (never silently allows an unknown feature)

**`services/gateway/src/middleware/paywall.ts`** (216 lines) — `requireEntitlement(feature, opts?)` Express middleware factory
- allow / soft_counter / degrade / deferred → handler runs with `req.entitlement` set
- paywall / hard_block → HTTP 402 with structured body containing `feature`, `tier`, `quota`, `used`, `remaining`, `reset_at`, `credit_option` (or null), `upgrade_url`
- Fails open on infrastructure errors (never blocks the user on entitlement-check bugs)
- Augments Express `Request` type with `req.entitlement`

**`services/gateway/src/routes/billing.ts`** (1,032 lines) — customer-side Stripe + redemption, separate from Stripe Connect:

| Endpoint | Behavior |
|---|---|
| `GET  /billing/me` | Plan + wallet (3 buckets) + per-feature usage rollup + earnings YTD — single call powers the entire Subscriptions screen |
| `POST /billing/checkout/subscription` | Stripe Checkout (subscription mode); `ensureStripeCustomer` creates customer on first call; metadata propagates `user_id` / `tenant_id` / `plan_key` / `price_key`. 14-day trial applied per plan config. |
| `POST /billing/checkout/credits` | Stripe Checkout (payment mode) for credit pack |
| `POST /billing/portal` | Stripe Billing Portal redirect |
| `POST /billing/credits/spend` | Idempotent credit burn (Idempotency-Key header or body field). Advances usage meter post-debit. |
| `POST /billing/redeem` | Code redemption (calls `fn_redeem_code` RPC). Maps RPC errors to HTTP status codes (404 / 410 / 409 / 503). |
| `POST /billing/webhooks/stripe` | Customer-side webhook with **separate** signing secret (`STRIPE_BILLING_WEBHOOK_SECRET`); idempotency via `processed_stripe_events`; handles `checkout.session.completed` (sub + credit pack via `credit_wallet` RPC), `customer.subscription.{created,updated,deleted}`, `invoice.{paid,payment_failed}` |
| `POST /admin/redemption-codes/generate` | Admin-only bulk-generate unique codes for a campaign (default 365-day grants for test cohort pattern). Returns CSV-ready code list. |
| `GET  /admin/redemption-codes` | Admin-only code listing; default masks unredeemed code values (`?include_codes=true` shows). |
| `PATCH /admin/redemption-codes/:code` | Admin-only activate/deactivate single code (e.g., on leak). |

**`services/gateway/src/index.ts`** (edited, +7/-1) — registers `billingRouter` and the raw-body parser for `/api/v1/billing/webhooks/stripe` BEFORE the `express.json()` global parser (mirrors the existing Connect webhook pattern at line 418).

### Cashflow guardrails honored in PR-2

- `consumeCredits` rejects `cash_balance` spends (withdrawable-only per §M)
- `consumeCredits` picks `reward_credits` first when both buckets are allowed (drains lower-utility bucket first; preserves cash-equivalent purchased credits)
- Webhook idempotency via `processed_stripe_events` PK conflict — Stripe retries never double-credit
- Admin code listing masks unredeemed code values by default (screenshot-leak protection)

### Build verification

`npm run build` on the gateway passes clean (full `tsc` + frontend copy + data copy, zero TypeScript errors).

---

## What's still coming on this branch before review

- [ ] PR-3: Frontend (`/wallet/subscriptions` rewrite + PaywallProvider + Trust Center + Wallet rewire + i18n shards)
- [ ] PR-4: Per-feature gates (ORB Live degrade + Live Rooms timer + soft Find-a-Match counters)
- [ ] PR-5: Command Hub admin section for code generation + lifecycle email cron + /redeem rewire
- [ ] PR-6: Command Hub billing dashboard + flag flip + final unit/integration tests

Tests for PR-2 (entitlement-service unit tests + paywall middleware tests + billing route integration tests) will land as a follow-up commit on this branch alongside the PR-3 work.

---

## Pre-merge ops checklist

1. Apply all 8 migrations to staging in order; confirm all RAISE NOTICE blocks fire, no EXCEPTION
2. Verify routing tests (reward → reward_credits, earning → cash_balance, purchase → purchased_credits)
3. Stripe Dashboard: create 4 Products + 9 Prices, fill `subscription_plans.stripe_product_id` + `subscription_plan_prices.stripe_price_id` + `credit_packs.stripe_price_id` via SQL UPDATE
4. Seed `tenant_settings.feature_flags.marketing_budget_eur_remaining_cents` at €55,000 worth of cents (5500000)
5. Set new env var `STRIPE_BILLING_WEBHOOK_SECRET` (separate from `STRIPE_CONNECT_WEBHOOK_SECRET`) — create webhook endpoint in Stripe Dashboard for `customer.subscription.*`, `invoice.paid`, `invoice.payment_failed`, `checkout.session.completed`
6. Generate 100 test-cohort codes via the admin endpoint once PR-5 frontend Command Hub UI lands

## PR URL

https://github.com/exafyltd/exafyltd/pull/2270

🤖 Generated with [Claude Code](https://claude.com/claude-code)