### PR TITLE
fix(teacher): never speak 'no personalized recommendations' — deflect to teaching offer (VTID-03110)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -3474,7 +3474,37 @@ async function executeLiveApiToolInner(
 
         if (results.length === 0) {
           console.log(`[VTID-01270A] get_recommendations: 0 results (type=${recType}), ${Date.now() - startTime}ms`);
-          return { success: true, result: 'No personalized recommendations available right now. Try checking back later, or ask me about events or community groups directly.' };
+          // VTID-03110: NEVER speak "no personalized recommendations".
+          // Vitana is the Teacher of the system — the catalog has 25+
+          // capabilities, each with a manual chapter. When the recommendation
+          // queries are empty, deflect into a teaching offer pulling the next
+          // pedagogically-ordered capability. Context-aware, data-driven —
+          // no hardcoded suggestion sequence.
+          let deflection = '';
+          try {
+            const sb = getSupabase();
+            if (sb && tenantId && userId) {
+              const { buildTeacherDeflectionForEmptyRecommendations } = await import(
+                '../services/assistant-continuation/providers/teacher/teacher-deflection'
+              );
+              deflection = await buildTeacherDeflectionForEmptyRecommendations({
+                supabase: sb,
+                tenantId,
+                userId,
+                lang: session.lang,
+                recType,
+              });
+            }
+          } catch (err) {
+            console.warn(`[VTID-03110] deflection helper failed (non-fatal): ${(err as Error).message}`);
+          }
+          if (!deflection) {
+            // Last-resort generic fallback — still NOT "no recommendations".
+            deflection = (session.lang || 'en').toLowerCase().startsWith('de')
+              ? 'Im Moment ist nichts Spezifisches vorgemerkt, aber in Vitanaland gibt es viel zu lernen. Wo möchtest du anfangen?'
+              : 'Nothing specific is queued up at the moment, but Vitanaland has lots to learn. What would you like to dive into?';
+          }
+          return { success: true, result: deflection };
         }
 
         const MAX_TOOL_RESPONSE_CHARS = 3000;

--- a/services/gateway/src/services/assistant-continuation/providers/teacher/teacher-deflection.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/teacher/teacher-deflection.ts
@@ -1,0 +1,173 @@
+/**
+ * VTID-03110 — "I have no personalized recommendations" must NEVER be the
+ * spoken answer.
+ *
+ * For the community education phase, Vitana is the Teacher of the system
+ * — there are 25+ capabilities seeded in `system_capabilities`, each with
+ * a manual chapter in `knowledge_docs`. Even when the recommendation
+ * queries return zero rows (no fresh community match, no daily ranked
+ * suggestion), there is ALWAYS something the Teacher can introduce.
+ *
+ * This module produces a context-aware tool-result string for the empty
+ * state of `get_recommendations` (both Vertex's voice tool handler in
+ * `routes/orb-live.ts` and the text-mode tool in `services/gemini-
+ * operator.ts`). It picks the next eligible capability using the same
+ * `pickCapability` ranker the Teacher provider uses, and returns a
+ * localized teaching-offer sentence Gemini will speak instead of the
+ * dismissive "no recommendations" line.
+ *
+ * Behavior:
+ *   - When pickCapability returns a row → "I don't have a specific
+ *     community match for you right now, but there's plenty to learn
+ *     in Vitanaland. Want me to introduce you to <display_name>?"
+ *   - When pickCapability returns null (all capabilities exhausted /
+ *     catalog empty / DB error) → fall back to a generic "lots to
+ *     explore — what would you like to dive into?" line. Still never
+ *     "no recommendations available".
+ *
+ * No hardcoded sequence. The capability suggested is whichever row the
+ * `pickCapability` sort selects (driven by `pedagogical_order` from the
+ * DB column).
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  pickCapability,
+  type CapabilityCatalogRow,
+  type AwarenessLedgerRow,
+} from './feature-discovery-teacher';
+
+export interface TeacherDeflectionInputs {
+  supabase: SupabaseClient;
+  tenantId: string;
+  userId: string;
+  /** ISO 639-1 lang code. Falls back to 'en'. */
+  lang?: string;
+  /** Which recommendation type was empty. Lets the deflection prefix
+   *  acknowledge what the user asked for ('match', 'community', 'all'). */
+  recType?: string;
+  /** Server-side now, injectable for tests. */
+  nowIso?: string;
+}
+
+/**
+ * Phrasings keyed by lang. Each entry has TWO clauses:
+ *   - `withCapability(displayName, recType)` — fires when pickCapability
+ *     returned a row. Mentions both the (lack of) recommendation AND
+ *     the teaching offer.
+ *   - `fallback(recType)` — when no capability is available either.
+ *     Should NEVER include the phrase "no personalized recommendations"
+ *     or any equivalent — the whole point of this module.
+ *
+ * The phrasings are intentionally short + warm. Gemini paraphrases
+ * tool-result strings, so brevity helps keep paraphrasing close to
+ * intent.
+ */
+type Phrasings = {
+  withCapability: (displayName: string, recType: string) => string;
+  fallback: (recType: string) => string;
+};
+
+const PHRASINGS: Record<string, Phrasings> = {
+  en: {
+    withCapability: (n, recType) =>
+      recType === 'match'
+        ? `I don't have a fresh community match lined up for you right now, but there's plenty in Vitanaland I can show you. Want me to introduce you to ${n}?`
+        : `I don't have a specific recommendation queued up right now, but there's plenty to learn in Vitanaland. Want me to introduce you to ${n}?`,
+    fallback: (recType) =>
+      recType === 'match'
+        ? `No fresh community match is queued up at the moment, but I can walk you through anything in Vitanaland. What would you like to explore?`
+        : `Nothing specific is queued up at the moment, but Vitanaland has lots to learn. What would you like to dive into?`,
+  },
+  de: {
+    withCapability: (n, recType) =>
+      recType === 'match'
+        ? `Aktuell habe ich kein frisches Community-Match für dich, aber in Vitanaland gibt es viel, was ich dir zeigen kann. Magst du, dass ich dir ${n} vorstelle?`
+        : `Aktuell ist nichts Spezifisches für dich vorgemerkt, aber in Vitanaland gibt es viel zu lernen. Magst du, dass ich dir ${n} vorstelle?`,
+    fallback: (recType) =>
+      recType === 'match'
+        ? `Im Moment ist kein neues Community-Match vorgemerkt, aber ich kann dich durch alles in Vitanaland führen. Was möchtest du entdecken?`
+        : `Im Moment ist nichts Spezifisches vorgemerkt, aber in Vitanaland gibt es viel zu lernen. Wo möchtest du anfangen?`,
+  },
+  fr: {
+    withCapability: (n, recType) =>
+      recType === 'match'
+        ? `Je n'ai pas de match communautaire frais pour toi en ce moment, mais Vitanaland a beaucoup à offrir. Veux-tu que je te présente ${n} ?`
+        : `Je n'ai pas de recommandation spécifique en file d'attente, mais il y a beaucoup à apprendre dans Vitanaland. Veux-tu que je te présente ${n} ?`,
+    fallback: (recType) =>
+      recType === 'match'
+        ? `Aucun match communautaire frais pour le moment, mais je peux te guider à travers tout Vitanaland. Que veux-tu explorer ?`
+        : `Rien de spécifique en file en ce moment, mais Vitanaland a beaucoup à apprendre. Par où veux-tu commencer ?`,
+  },
+  es: {
+    withCapability: (n, recType) =>
+      recType === 'match'
+        ? `Ahora mismo no tengo un match nuevo de la comunidad para ti, pero hay mucho que puedo mostrarte en Vitanaland. ¿Te presento ${n}?`
+        : `No tengo una recomendación específica en cola ahora mismo, pero hay mucho que aprender en Vitanaland. ¿Te presento ${n}?`,
+    fallback: (recType) =>
+      recType === 'match'
+        ? `No hay un match nuevo de la comunidad ahora mismo, pero puedo guiarte por todo Vitanaland. ¿Qué te gustaría explorar?`
+        : `Nada específico en cola ahora mismo, pero hay mucho que aprender en Vitanaland. ¿Por dónde empezamos?`,
+  },
+  sr: {
+    withCapability: (n, recType) =>
+      recType === 'match'
+        ? `Тренутно немам свежи community match за тебе, али у Vitanaland-у имам много шта да ти покажем. Желиш ли да ти представим ${n}?`
+        : `Тренутно немам специфичну препоруку, али у Vitanaland-у има много да се учи. Желиш ли да ти представим ${n}?`,
+    fallback: (recType) =>
+      recType === 'match'
+        ? `Тренутно нема новог community match-а, али могу да те водим кроз било шта у Vitanaland-у. Шта желиш да истражиш?`
+        : `Тренутно ништа специфично није на чекању, али Vitanaland има много да научиш. Где желиш да почнемо?`,
+  },
+};
+
+function langPhrasings(lang: string | undefined): Phrasings {
+  const k = (lang || 'en').toLowerCase();
+  return PHRASINGS[k] || PHRASINGS.en;
+}
+
+/**
+ * Build the deflection string. Returns a Promise — DB-side fetches for
+ * the catalog + ledger. Failures degrade to the fallback phrasing
+ * (still never says "no recommendations").
+ */
+export async function buildTeacherDeflectionForEmptyRecommendations(
+  inputs: TeacherDeflectionInputs,
+): Promise<string> {
+  const lang = (inputs.lang || 'en').toLowerCase();
+  const recType = inputs.recType || 'all';
+  const phr = langPhrasings(lang);
+
+  let catalog: CapabilityCatalogRow[] = [];
+  let ledger: AwarenessLedgerRow[] = [];
+  try {
+    const cap = await inputs.supabase
+      .from('system_capabilities')
+      .select('capability_key, display_name, description, manual_path, enabled, pedagogical_order')
+      .eq('enabled', true);
+    if (!cap.error && Array.isArray(cap.data)) {
+      catalog = cap.data as CapabilityCatalogRow[];
+    }
+    const led = await inputs.supabase
+      .from('user_capability_awareness')
+      .select('capability_key, awareness_state, dismiss_count, last_introduced_at')
+      .eq('tenant_id', inputs.tenantId)
+      .eq('user_id', inputs.userId);
+    if (!led.error && Array.isArray(led.data)) {
+      ledger = led.data as AwarenessLedgerRow[];
+    }
+  } catch {
+    // Fall through to fallback phrasing — never throw on this path.
+  }
+
+  if (catalog.length === 0) {
+    return phr.fallback(recType);
+  }
+
+  const nowIso = inputs.nowIso ?? new Date().toISOString();
+  const picked = pickCapability(catalog, ledger, nowIso);
+  if (!picked) {
+    return phr.fallback(recType);
+  }
+  return phr.withCapability(picked.row.display_name, recType);
+}

--- a/services/gateway/src/services/gemini-operator.ts
+++ b/services/gateway/src/services/gemini-operator.ts
@@ -2374,7 +2374,36 @@ async function executeCommunityGetRecommendations(
 
   if (results.length === 0) {
     console.log(`[VTID-01270A] get_recommendations (text): 0 results (type=${recType})`);
-    return { ok: true, data: { result: 'No personalized recommendations available right now. Try checking back later, or ask me about events or community groups directly.' } };
+    // VTID-03110: never say "no personalized recommendations". Deflect
+    // into a teaching offer using the next pedagogically-ordered
+    // capability from the Teacher catalog. Same helper as the voice
+    // path in orb-live.ts so behavior is consistent across modalities.
+    let deflection = '';
+    try {
+      const { getSupabase } = await import('../lib/supabase');
+      const sb = getSupabase();
+      if (sb) {
+        const { buildTeacherDeflectionForEmptyRecommendations } = await import(
+          './assistant-continuation/providers/teacher/teacher-deflection'
+        );
+        // Text path doesn't carry a session lang; default to 'en'. A
+        // future slice can lookup app_users.preferred_language if
+        // needed — voice path (orb-live.ts) uses session.lang.
+        deflection = await buildTeacherDeflectionForEmptyRecommendations({
+          supabase: sb,
+          tenantId: identity.tenant_id,
+          userId: identity.user_id,
+          lang: 'en',
+          recType,
+        });
+      }
+    } catch (err) {
+      console.warn(`[VTID-03110] deflection helper failed (non-fatal): ${(err as Error).message}`);
+    }
+    if (!deflection) {
+      deflection = 'Nothing specific is queued up at the moment, but Vitanaland has lots to learn. What would you like to dive into?';
+    }
+    return { ok: true, data: { result: deflection } };
   }
 
   const formatted = results.join('\n');

--- a/services/gateway/test/services/assistant-continuation/providers/teacher/teacher-deflection.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/teacher/teacher-deflection.test.ts
@@ -1,0 +1,208 @@
+/**
+ * VTID-03110 — tests for buildTeacherDeflectionForEmptyRecommendations.
+ *
+ * Hard requirement: the empty-state response of `get_recommendations`
+ * must NEVER speak the phrase "no personalized recommendations" (or
+ * any close variant). It must instead pivot to a teaching offer.
+ *
+ * These tests fake the Supabase client so we can pin catalog + ledger
+ * shapes deterministically.
+ */
+
+import { buildTeacherDeflectionForEmptyRecommendations } from '../../../../../src/services/assistant-continuation/providers/teacher/teacher-deflection';
+
+function fakeSb(opts: {
+  catalog?: any[] | null;
+  ledger?: any[] | null;
+  catalogError?: { message: string } | null;
+  ledgerError?: { message: string } | null;
+}) {
+  const catalog = opts.catalog;
+  const ledger = opts.ledger;
+  return {
+    from(table: string) {
+      const isLedger = table === 'user_capability_awareness';
+      const chain: any = {
+        select: () => chain,
+        eq: () => chain,
+      };
+      const data = isLedger ? ledger : catalog;
+      const error = isLedger ? (opts.ledgerError ?? null) : (opts.catalogError ?? null);
+      // The orchestrator awaits the final eq() chain. We make the chain
+      // thenable so `await sb.from(...).select(...).eq(...)` resolves
+      // with `{ data, error }`.
+      (chain as any).then = (resolve: any) => resolve({ data, error });
+      return chain;
+    },
+  } as any;
+}
+
+const NOW_ISO = '2026-05-20T09:00:00Z';
+
+const FIVE_PILLARS = {
+  capability_key: 'five_pillars',
+  display_name: 'The Five Pillars',
+  description: 'Foundation concept',
+  manual_path: '/manuals/maxina/00-concepts/five-pillars',
+  enabled: true,
+  pedagogical_order: 10,
+};
+
+const ACTIVITY_MATCH = {
+  capability_key: 'activity_match',
+  display_name: 'Activity Match',
+  description: 'Community matching',
+  manual_path: '/manuals/maxina/03-community/activity-match',
+  enabled: true,
+  pedagogical_order: 140,
+};
+
+const NO_REC_FORBIDDEN_PHRASES = [
+  'no personalized recommendations',
+  'no recommendations available',
+  'check back later',
+  'keine personalisierten',
+  'keine Empfehlungen verfügbar',
+];
+
+function assertNoForbiddenPhrase(text: string): void {
+  const lower = text.toLowerCase();
+  for (const phrase of NO_REC_FORBIDDEN_PHRASES) {
+    expect(lower).not.toContain(phrase.toLowerCase());
+  }
+}
+
+describe('VTID-03110 — buildTeacherDeflectionForEmptyRecommendations', () => {
+  test('NEVER speaks "no personalized recommendations" — picks next teaching capability instead (en)', async () => {
+    const out = await buildTeacherDeflectionForEmptyRecommendations({
+      supabase: fakeSb({ catalog: [FIVE_PILLARS, ACTIVITY_MATCH], ledger: [] }),
+      tenantId: 't1',
+      userId: 'u1',
+      lang: 'en',
+      recType: 'all',
+      nowIso: NOW_ISO,
+    });
+    assertNoForbiddenPhrase(out);
+    expect(out).toContain('The Five Pillars'); // pedagogical_order=10 wins over 140
+  });
+
+  test('NEVER speaks "no recommendations" — DE variant uses German teaching offer', async () => {
+    const out = await buildTeacherDeflectionForEmptyRecommendations({
+      supabase: fakeSb({ catalog: [FIVE_PILLARS, ACTIVITY_MATCH], ledger: [] }),
+      tenantId: 't1',
+      userId: 'u1',
+      lang: 'de',
+      recType: 'all',
+      nowIso: NOW_ISO,
+    });
+    assertNoForbiddenPhrase(out);
+    expect(out).toContain('The Five Pillars');
+    // German body markers
+    expect(out.toLowerCase()).toMatch(/vitanaland|magst du/);
+  });
+
+  test('recType=match acknowledges the match miss explicitly without dismissing', async () => {
+    const out = await buildTeacherDeflectionForEmptyRecommendations({
+      supabase: fakeSb({ catalog: [FIVE_PILLARS], ledger: [] }),
+      tenantId: 't1',
+      userId: 'u1',
+      lang: 'en',
+      recType: 'match',
+      nowIso: NOW_ISO,
+    });
+    assertNoForbiddenPhrase(out);
+    // recType=match acknowledges the community-match miss but pivots
+    // to teaching.
+    expect(out.toLowerCase()).toMatch(/community match|fresh.*match/);
+    expect(out).toContain('The Five Pillars');
+  });
+
+  test('empty catalog → fallback phrasing still does NOT say "no recommendations"', async () => {
+    const out = await buildTeacherDeflectionForEmptyRecommendations({
+      supabase: fakeSb({ catalog: [], ledger: [] }),
+      tenantId: 't1',
+      userId: 'u1',
+      lang: 'en',
+      recType: 'all',
+      nowIso: NOW_ISO,
+    });
+    assertNoForbiddenPhrase(out);
+    expect(out.toLowerCase()).toMatch(/vitanaland/);
+  });
+
+  test('catalog fetch error → fallback phrasing (never throws upward)', async () => {
+    const out = await buildTeacherDeflectionForEmptyRecommendations({
+      supabase: fakeSb({
+        catalog: null,
+        ledger: null,
+        catalogError: { message: 'simulated db outage' },
+      }),
+      tenantId: 't1',
+      userId: 'u1',
+      lang: 'en',
+      recType: 'all',
+      nowIso: NOW_ISO,
+    });
+    assertNoForbiddenPhrase(out);
+    // Still produces SOMETHING speakable — never a thrown error reaching
+    // the tool result.
+    expect(out.length).toBeGreaterThan(20);
+  });
+
+  test('all-capabilities-introduced → fallback (no eligible pick)', async () => {
+    const introducedRecently = new Date(Date.parse(NOW_ISO) - 60 * 60 * 1000).toISOString();
+    const out = await buildTeacherDeflectionForEmptyRecommendations({
+      supabase: fakeSb({
+        catalog: [FIVE_PILLARS],
+        ledger: [
+          {
+            capability_key: 'five_pillars',
+            awareness_state: 'introduced',
+            dismiss_count: 0,
+            last_introduced_at: introducedRecently, // within 7-day filter
+          },
+        ],
+      }),
+      tenantId: 't1',
+      userId: 'u1',
+      lang: 'en',
+      recType: 'all',
+      nowIso: NOW_ISO,
+    });
+    assertNoForbiddenPhrase(out);
+    expect(out.toLowerCase()).toMatch(/vitanaland/);
+  });
+
+  test('pedagogical_order drives the pick — first-time user gets foundations, NOT alphabetical', async () => {
+    // Even though "activity_match" is alphabetically first, "five_pillars"
+    // has pedagogical_order=10 vs 140. Curriculum order wins.
+    const out = await buildTeacherDeflectionForEmptyRecommendations({
+      supabase: fakeSb({
+        catalog: [ACTIVITY_MATCH, FIVE_PILLARS],
+        ledger: [],
+      }),
+      tenantId: 't1',
+      userId: 'u1',
+      lang: 'en',
+      recType: 'all',
+      nowIso: NOW_ISO,
+    });
+    expect(out).toContain('The Five Pillars');
+    expect(out).not.toContain('Activity Match');
+  });
+
+  test('unknown lang falls back to English phrasing', async () => {
+    const out = await buildTeacherDeflectionForEmptyRecommendations({
+      supabase: fakeSb({ catalog: [FIVE_PILLARS], ledger: [] }),
+      tenantId: 't1',
+      userId: 'u1',
+      lang: 'xx-unknown',
+      recType: 'all',
+      nowIso: NOW_ISO,
+    });
+    assertNoForbiddenPhrase(out);
+    expect(out).toContain('The Five Pillars');
+    // English markers
+    expect(out.toLowerCase()).toMatch(/vitanaland|introduce|learn/);
+  });
+});


### PR DESCRIPTION
## Why
User reported across multiple voice sessions: Vitana repeatedly spoke
**\"I have no personalized recommendations for you\"** (and the German paraphrase). For the community education phase that answer is unforgivable — the catalog has 25+ capabilities, the manuals have ~1000 chapters; there's ALWAYS something to teach.

Two empty-state code paths produced that string and Gemini dutifully spoke it:
- [services/gateway/src/routes/orb-live.ts:3477](services/gateway/src/routes/orb-live.ts#L3477) (voice, Vertex)
- [services/gateway/src/services/gemini-operator.ts:2377](services/gateway/src/services/gemini-operator.ts#L2377) (text)

## What changed
New helper [`teacher-deflection.ts`](services/gateway/src/services/assistant-continuation/providers/teacher/teacher-deflection.ts):
- Fetches the user's `user_capability_awareness` ledger + the `system_capabilities` catalog (with the `pedagogical_order` column added in VTID-03108).
- Calls the same `pickCapability` ranker the Teacher provider uses — so the deflection picks whichever capability is NEXT in the curriculum for THIS specific user.
- Returns a localized teaching-offer sentence in en / de / fr / es / sr that mentions the capability by `display_name`. Example:
  > \"I don't have a specific recommendation queued up right now, but there's plenty to learn in Vitanaland. Want me to introduce you to The Five Pillars?\"
- When `pickCapability` returns null (catalog empty, all capabilities exhausted, DB outage) → generic \"lots to learn in Vitanaland — where do you want to start?\" fallback. Still **never** \"no recommendations\".

Both empty-state paths now call this helper. Happy path (recommendations exist) is unchanged.

## No-hardcoding guarantee
The suggested capability is picked by `pedagogical_order ASC` (then alphabetical), driven by the DB column added in VTID-03108. Operators tune the order in the DB — same data-driven curriculum the Teacher provider uses. No fixed sequence anywhere in TS.

## Test plan
- [x] **8 new tests** in `teacher-deflection.test.ts` lock the behavior:
  - Forbidden-phrase scan: every branch's output must NOT contain \"no personalized recommendations\", \"no recommendations available\", \"check back later\", \"keine personalisierten\", \"keine Empfehlungen verfügbar\".
  - Foundation capabilities (pedagogical_order=10) win over alphabetically-first community capabilities (order=140).
  - recType=match acknowledges the community-match miss without being dismissive.
  - Catalog fetch error degrades to fallback phrasing, never throws.
  - DE phrasing renders the German teaching offer.
- [x] **892 tests pass** across 52 suites in test/services/assistant-continuation + test/orb/live (was 884; +8).
- [x] \`npm run build\` clean.
- [ ] **Runtime test on vitanaland**: ask Vitana \"do you have any recommendations for me?\" (DE: \"hast du Empfehlungen für mich?\"). Confirm she pivots to a teaching offer, never says \"no recommendations\".

## Notes
- VTID-03110 allocated via the gateway VTID allocator.
- This unblocks T1-T6 (continuous teaching loop) — once it's live the next slice can build on the assumption that the empty-state deflection IS the teaching pivot.

🤖 Generated with [Claude Code](https://claude.com/claude-code)