### PR TITLE
feat(decision-contract): Phase B.1 schema — decision_policy + policy_render_block (VTID-03113)

### DIFF
--- a/DATABASE_SCHEMA.md
+++ b/DATABASE_SCHEMA.md
@@ -404,6 +404,7 @@ CREATE TABLE my_new_table (
 | 2026-04-27 | Added routines + routine_runs tables for daily Claude Code remote-agent catalog and run history | Claude | VTID-01981 |
 | 2026-04-28 | Added `pillar` + `contribution_vector` columns to `calendar_events` for typed Vitana Index linkage (replaces `pillar:*` wellness_tag heuristic on the frontend) | Claude | claude/vitana-index-navigation-VdSEQ |
 | 2026-05-12 | Added `cover_url`, `cover_generated_at`, `cover_source` to `user_intents` for the Find-a-Match cover-photo flow (user upload OR server-side OpenAI Images generation OR curated fallback). Idx on `(requester_user_id, cover_generated_at)` for per-user rate-limit. | Claude | BOOTSTRAP-INTENT-COVER-GEN |
+| 2026-05-20 | Added `decision_policy` + `policy_render_block` (Phase B.1 of decision-contract refactor). Versioned, tenant-aware, time-bounded externalized policy values + localized render fragments. Schema only — no consumer reads yet (lands in Phase B.4). | Claude | VTID-03113 |
 
 ---
 
@@ -792,6 +793,81 @@ CREATE INDEX idx_routine_runs_status          ON routine_runs(status);
 ```
 
 **Auth model:** GET endpoints reuse Command Hub auth. POST/PATCH require `X-Routine-Token: $ROUTINE_INGEST_TOKEN` (shared secret env var on the gateway), so a remote sandbox routine can authenticate without a user JWT.
+
+---
+
+## VTID-03113 — Decision-Contract Phase B (externalized policy)
+
+These two tables externalize the ~140 hard-coded constants and ~30 hard-coded ladders the May 2026 contextual-intelligence audit found scattered across the renderer, ranker, fusion engine, and voice layers. Phase B.1 introduces the **schema only** — no code reads from these tables yet. Reads land in Phase B.4 (vertical proof on the temporal-bucket greeting block in `services/gateway/src/orb/live/instruction/live-system-instruction.ts`).
+
+### decision_policy
+**Purpose:** Versioned, tenant-aware, time-bounded numeric/enum/JSON policy values. One row per `(policy_key, tenant_id, version)`. Replaces hard-coded literals across decision-producing code paths.
+**Used by:** `services/gateway/src/services/decision-contract/policy-resolver.ts` (lands in Phase B.3; nothing today).
+**Migration:** `supabase/migrations/20260527000000_VTID_03113_decision_policy.sql`
+
+**Resolver contract:** for a given `(policy_key, tenant_id, now)`, pick the highest `version` row where `effective_from <= now AND (effective_until IS NULL OR effective_until > now)`. Tenant-specific row wins over `tenant_id IS NULL`.
+
+**Schema:**
+```sql
+CREATE TABLE decision_policy (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  policy_key      TEXT NOT NULL,         -- e.g. session.recency_bucket.reconnect_max_seconds
+  tenant_id       UUID,                  -- NULL = global default
+  version         INTEGER NOT NULL,
+  value_json      JSONB NOT NULL,
+  effective_from  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  effective_until TIMESTAMPTZ,
+  source          TEXT NOT NULL DEFAULT 'seed'
+    CHECK (source IN ('seed','admin_ui','autopilot','experiment')),
+  notes           TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_by      TEXT,
+  UNIQUE (policy_key, tenant_id, version)
+);
+CREATE INDEX decision_policy_lookup_idx
+  ON decision_policy (policy_key, tenant_id, effective_from DESC);
+```
+
+**Auth model:** RLS enabled. `service_role` bypasses RLS (Supabase default) — the resolver runs as service. Authenticated app role has `SELECT` only, scoped to global defaults (`tenant_id IS NULL`) plus rows whose `tenant_id` is in `user_tenants` for the caller. No INSERT/UPDATE/DELETE policy for authenticated.
+
+### policy_render_block
+**Purpose:** Versioned, tenant-aware, localized prompt fragments. Sibling of `decision_policy`: carries verbatim text the renderer concatenates or the model echoes (greeting lines, instruction blocks).
+**Used by:** Same as `decision_policy` (Phase B.3 resolver; nothing today).
+**Migration:** `supabase/migrations/20260527010000_VTID_03113_policy_render_block.sql`
+
+**Resolver contract:** identical to `decision_policy`, keyed by `(block_key, language, tenant_id, now)`.
+
+**Schema:**
+```sql
+CREATE TABLE policy_render_block (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  block_key       TEXT NOT NULL,         -- e.g. greeting.bucket.today
+  language        TEXT NOT NULL,         -- en, de, fr, es, ar, zh, ru, sr
+  tenant_id       UUID,                  -- NULL = global default
+  version         INTEGER NOT NULL,
+  content         TEXT NOT NULL,
+  effective_from  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  effective_until TIMESTAMPTZ,
+  source          TEXT NOT NULL DEFAULT 'seed'
+    CHECK (source IN ('seed','admin_ui','autopilot','experiment')),
+  notes           TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_by      TEXT,
+  UNIQUE (block_key, language, tenant_id, version)
+);
+CREATE INDEX policy_render_block_lookup_idx
+  ON policy_render_block (block_key, language, tenant_id, effective_from DESC);
+```
+
+**Auth model:** Same as `decision_policy` (RLS-on, `service_role` bypass, authenticated SELECT only).
+
+**Phase plan (each its own VTID + PR):**
+1. B.1 — schema (this VTID, VTID-03113).
+2. B.2 — seed migration (5 `decision_policy` rows + 64 `policy_render_block` rows = 8 buckets × 8 languages).
+3. B.3 — `PolicyResolver` service, cache warm-up, telemetry, `policy-keys.ts`.
+4. B.4 — vertical proof: migrate `live-system-instruction.ts` greeting block to read via the resolver.
+
+See `docs/decision-contract/phase-b-brief.md` for the full plan.
 
 ---
 

--- a/supabase/migrations/20260527000000_VTID_03113_decision_policy.sql
+++ b/supabase/migrations/20260527000000_VTID_03113_decision_policy.sql
@@ -1,0 +1,88 @@
+-- Phase B.1 (decision-contract refactor) — decision_policy table.
+--
+-- VTID-03113. Versioned, tenant-aware, time-bounded numeric/enum
+-- policy values. One row per (policy_key, tenant_id, version) triple.
+-- Replaces hard-coded constants scattered across the renderer,
+-- ranker, fusion engine and voice layers (~140 of them, per the
+-- May 2026 contextual-intelligence audit).
+--
+-- Phase B introduces the schema only. No code reads from this table
+-- yet — that lands in Phase B.4 (vertical proof on the
+-- live-system-instruction.ts greeting block).
+--
+-- Resolver contract (see services/gateway/src/services/decision-contract/
+-- policy-resolver.ts, landing in Phase B.3):
+--   For a given (policy_key, tenant_id, now) pick the highest
+--   `version` row where:
+--     effective_from <= now
+--     AND (effective_until IS NULL OR effective_until > now)
+--   A tenant-specific row wins over `tenant_id IS NULL`.
+--
+-- RLS:
+--   - service_role bypasses RLS (Supabase default). The resolver
+--     runs as service.
+--   - authenticated app role: SELECT only, scoped to global defaults
+--     (`tenant_id IS NULL`) plus rows for tenants the user belongs
+--     to (via user_tenants, same pattern as B0c / B2).
+--   - No INSERT/UPDATE/DELETE policy for authenticated → effectively
+--     read-only for non-service callers.
+
+CREATE TABLE IF NOT EXISTS decision_policy (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- Stable, dotted, namespaced key. Examples:
+  --   session.recency_bucket.reconnect_max_seconds
+  --   session.recency_bucket.recent_max_minutes
+  -- Exact key strings are owned by `policy-keys.ts` (Phase B.3).
+  policy_key      TEXT NOT NULL,
+  -- NULL = global default. Non-NULL = tenant-specific override.
+  tenant_id       UUID,
+  -- Monotonic per (policy_key, tenant_id). Newer versions never
+  -- delete older ones — they supersede via effective_from / until.
+  version         INTEGER NOT NULL,
+  -- The unwrapped value. JSONB so a single column carries numbers,
+  -- strings, arrays, or small objects (the resolver returns the
+  -- value typed by the caller via generics, never raw JSON).
+  value_json      JSONB NOT NULL,
+  effective_from  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  -- NULL = open-ended (the row is current until a newer version
+  -- explicitly closes it, or another non-NULL `effective_until`
+  -- expires).
+  effective_until TIMESTAMPTZ,
+  -- Where the row came from. 'seed' for migrations, other values
+  -- reserved for future admin UI / autopilot / experiment writers.
+  source          TEXT NOT NULL DEFAULT 'seed'
+    CHECK (source IN ('seed', 'admin_ui', 'autopilot', 'experiment')),
+  notes           TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_by      TEXT,
+  UNIQUE (policy_key, tenant_id, version)
+);
+
+-- Resolver hot-path query: filter by (policy_key, tenant_id) and
+-- pick the most recent row that is currently effective. Ordering
+-- `effective_from DESC` puts candidates first.
+CREATE INDEX IF NOT EXISTS decision_policy_lookup_idx
+  ON decision_policy (policy_key, tenant_id, effective_from DESC);
+
+ALTER TABLE decision_policy ENABLE ROW LEVEL SECURITY;
+
+-- Read-only policy for app callers. Service-role bypasses RLS
+-- entirely, so seeds and admin writes work without explicit
+-- INSERT/UPDATE/DELETE policies here.
+DROP POLICY IF EXISTS decision_policy_tenant_read ON decision_policy;
+CREATE POLICY decision_policy_tenant_read
+  ON decision_policy
+  FOR SELECT
+  TO authenticated
+  USING (
+    tenant_id IS NULL
+    OR tenant_id IN (
+      SELECT tenant_id FROM user_tenants WHERE user_id = auth.uid()
+    )
+  );
+
+COMMENT ON TABLE decision_policy IS
+  'Phase B.1 (decision-contract refactor): versioned, tenant-aware, '
+  'time-bounded numeric/enum policy values. Resolver picks the highest '
+  'version row that is currently effective; tenant-specific wins over '
+  'NULL tenant_id. Service-role writes; authenticated reads only.';

--- a/supabase/migrations/20260527010000_VTID_03113_policy_render_block.sql
+++ b/supabase/migrations/20260527010000_VTID_03113_policy_render_block.sql
@@ -1,0 +1,74 @@
+-- Phase B.1 (decision-contract refactor) — policy_render_block table.
+--
+-- VTID-03113. Versioned, tenant-aware, localized prompt fragments.
+-- Sibling table to decision_policy: where decision_policy carries
+-- numbers / enums / small JSON values, policy_render_block carries
+-- the rendered text the model echoes or the renderer concatenates
+-- verbatim (e.g. greeting lines, instruction blocks).
+--
+-- Phase B introduces the schema only. No code reads from this table
+-- yet — that lands in Phase B.4 (vertical proof on the
+-- live-system-instruction.ts greeting block, 8 buckets × 8 languages).
+--
+-- Resolver contract (see services/gateway/src/services/decision-contract/
+-- policy-resolver.ts, landing in Phase B.3):
+--   For a given (block_key, language, tenant_id, now) pick the
+--   highest `version` row where:
+--     effective_from <= now
+--     AND (effective_until IS NULL OR effective_until > now)
+--   A tenant-specific row wins over `tenant_id IS NULL`.
+--
+-- RLS: same shape as decision_policy. Service-role bypass for writes,
+-- authenticated SELECT scoped to global defaults plus the user's own
+-- tenants.
+
+CREATE TABLE IF NOT EXISTS policy_render_block (
+  id              UUID PRIMARY KEY DEFAULT gen_random_uuid(),
+  -- Stable, dotted, namespaced key (e.g. `greeting.bucket.today`).
+  -- Exact key strings are owned by `policy-keys.ts` (Phase B.3).
+  block_key       TEXT NOT NULL,
+  -- BCP-47-ish short code. Allowed values match SUPPORTED_LANGUAGES
+  -- in services/gateway/src/services/decision-contract/types.ts at
+  -- the time Phase B.1 lands: en, de, fr, es, ar, zh, ru, sr.
+  -- Stored as TEXT (no enum) so adding a language in a future phase
+  -- is a seed change, not a schema change.
+  language        TEXT NOT NULL,
+  -- NULL = global default. Non-NULL = tenant-specific override.
+  tenant_id       UUID,
+  version         INTEGER NOT NULL,
+  -- The rendered fragment, single-line or multi-line. Seeded
+  -- verbatim from the current source-of-truth in
+  -- live-system-instruction.ts during Phase B.2.
+  content         TEXT NOT NULL,
+  effective_from  TIMESTAMPTZ NOT NULL DEFAULT now(),
+  effective_until TIMESTAMPTZ,
+  source          TEXT NOT NULL DEFAULT 'seed'
+    CHECK (source IN ('seed', 'admin_ui', 'autopilot', 'experiment')),
+  notes           TEXT,
+  created_at      TIMESTAMPTZ NOT NULL DEFAULT now(),
+  created_by      TEXT,
+  UNIQUE (block_key, language, tenant_id, version)
+);
+
+CREATE INDEX IF NOT EXISTS policy_render_block_lookup_idx
+  ON policy_render_block (block_key, language, tenant_id, effective_from DESC);
+
+ALTER TABLE policy_render_block ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS policy_render_block_tenant_read ON policy_render_block;
+CREATE POLICY policy_render_block_tenant_read
+  ON policy_render_block
+  FOR SELECT
+  TO authenticated
+  USING (
+    tenant_id IS NULL
+    OR tenant_id IN (
+      SELECT tenant_id FROM user_tenants WHERE user_id = auth.uid()
+    )
+  );
+
+COMMENT ON TABLE policy_render_block IS
+  'Phase B.1 (decision-contract refactor): versioned, tenant-aware, '
+  'localized prompt fragments. Sibling of decision_policy; carries '
+  'verbatim text the renderer concatenates or the model echoes. '
+  'Service-role writes; authenticated reads only.';


### PR DESCRIPTION
## Summary

Phase B.1 of the decision-contract refactor. Introduces the two versioned, tenant-aware, time-bounded tables that will hold the ~140 hard-coded constants and ~30 hard-coded ladders the May 2026 contextual-intelligence audit found scattered across the renderer, ranker, fusion engine, and voice layers.

**Schema-only PR — no code reads from these tables yet.** Reads land in B.4 (vertical proof on the `live-system-instruction.ts` greeting block). See `docs/decision-contract/phase-b-brief.md`.

### Tables

- **`decision_policy`** — numeric / enum / small-JSON policy values. One row per `(policy_key, tenant_id, version)`; resolver picks the highest version with `effective_from <= now < effective_until`. Tenant-specific row beats `tenant_id IS NULL`.
- **`policy_render_block`** — localized prompt fragments. Sibling shape, keyed by `(block_key, language, tenant_id, version)`.

Both tables ship with a `(key, tenant_id, effective_from DESC)` index sized for the hot-path resolver query.

### Auth

RLS enabled on both. `service_role` bypasses RLS (Supabase default) — the Phase B.3 resolver runs as service. `authenticated` has **`SELECT` only**, scoped to global defaults (`tenant_id IS NULL`) plus rows for tenants the caller belongs to via `user_tenants` — same pattern as B0c / B2 / continuity tables. No `INSERT/UPDATE/DELETE` policy for `authenticated`.

### Files

- `supabase/migrations/20260527000000_VTID_03113_decision_policy.sql` — table + index + RLS.
- `supabase/migrations/20260527010000_VTID_03113_policy_render_block.sql` — table + index + RLS.
- `DATABASE_SCHEMA.md` — full schema documentation block + change-log entry (per CLAUDE.md non-negotiable).

### Phase plan (each its own VTID + PR)

1. **B.1** — schema (this PR, VTID-03113).
2. **B.2** — seed migration (5 `decision_policy` rows + 64 `policy_render_block` rows = 8 buckets × 8 languages, byte-identical to the current code constants).
3. **B.3** — `PolicyResolver` service + cache warm-up + telemetry + `policy-keys.ts`.
4. **B.4** — vertical proof: migrate `live-system-instruction.ts` greeting block to read via the resolver. Snapshot tests prove byte-identical prompt output before/after.

## Test plan

- [ ] EXEC-DEPLOY succeeds for the gateway after merge (doc-only path may not auto-dispatch — verify, dispatch manually if needed).
- [ ] `RUN-MIGRATION.yml` runs cleanly and applies both migrations on `lovable-vitana-vers1`.
- [ ] Post-migration sanity: `SELECT COUNT(*) FROM decision_policy;` and `SELECT COUNT(*) FROM policy_render_block;` each return 0 (no seeds yet — that's B.2).
- [ ] Spot-check `\d+ decision_policy` shows: RLS enabled, unique constraint on `(policy_key, tenant_id, version)`, index on `(policy_key, tenant_id, effective_from DESC)`.
- [ ] Same for `policy_render_block` with `(block_key, language, tenant_id, version)`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)