### PR TITLE
feat(teacher): continuous Teaching Loop — context-aware Teacher Mode prompt + 2 tools (VTID-03112, DEV-COMHU-03115)

### DIFF
--- a/services/gateway/src/frontend/command-hub/orb-widget.js
+++ b/services/gateway/src/frontend/command-hub/orb-widget.js
@@ -1726,7 +1726,7 @@
             }, 300);
           })();
         } else if (msg.directive === 'end_teaching_session') {
-          // VTID-03112 (T2): the LLM called `end_teaching_session` after
+          // VTID-03112 (T2 / DEV-COMHU-03115): the LLM called `end_teaching_session` after
           // delivering its farewell line. Close the overlay gracefully —
           // give the audio queue a moment to finish playing the farewell
           // before the SSE/WS tear down. Mirrors the navigate directive's

--- a/services/gateway/src/frontend/command-hub/orb-widget.js
+++ b/services/gateway/src/frontend/command-hub/orb-widget.js
@@ -1725,6 +1725,29 @@
               }, 200);
             }, 300);
           })();
+        } else if (msg.directive === 'end_teaching_session') {
+          // VTID-03112 (T2): the LLM called `end_teaching_session` after
+          // delivering its farewell line. Close the overlay gracefully —
+          // give the audio queue a moment to finish playing the farewell
+          // before the SSE/WS tear down. Mirrors the navigate directive's
+          // teardown pattern so the closing chime + state cleanup behave
+          // identically.
+          console.log('[VTOrb] orb_directive end_teaching_session (reason=' + (msg.reason || '<none>') + ')');
+          try {
+            // Stop accepting new audio chunks but let the queued farewell
+            // finish playing — _hide() is invoked after a short delay.
+            _s.audioPlaying = false;
+            setTimeout(function() {
+              try { _hide(); }
+              catch (e) { console.error('[VTOrb] _hide on end_teaching_session failed:', e); }
+            }, 500);
+            if (typeof _cfg.onTeachingSessionEnd === 'function') {
+              try { _cfg.onTeachingSessionEnd(msg.reason || null); }
+              catch (e) { console.error('[VTOrb] onTeachingSessionEnd handler failed:', e); }
+            }
+          } catch (e) {
+            console.error('[VTOrb] end_teaching_session handling error:', e);
+          }
         } else {
           console.warn('[VTOrb] Unknown orb_directive: ' + msg.directive);
         }

--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -965,6 +965,48 @@ export async function handleLiveSessionStart(
       console.log(
         `[VTID-03079/VTID-03101] Vertex wake-brief stored on session.wakeBriefOverrideBlock (decision_id=${wakeBriefDecision?.decisionId}, source=${picked.evidence?.find((e) => e.kind?.startsWith('source:'))?.kind || 'voice_wake_brief'}, block_chars=${block.length})`,
       );
+
+      // VTID-03112 (T1): when the wake-brief winner is the Teacher
+      // (feature_discovery kind), fetch the manual content + the next
+      // curriculum entries so the system_instruction can run Teacher
+      // Mode for the WHOLE session — not just turn 1. The model
+      // interprets every subsequent user reply IN CONTEXT (no regex,
+      // no keyword tables) and decides what to do next. Best-effort
+      // — any failure leaves teacherModeContent null and the session
+      // degrades to the legacy one-shot Teacher behavior.
+      const winnerEvidence = picked.evidence ?? [];
+      const sourceKind = winnerEvidence.find((e) => e.kind?.startsWith('source:'))?.kind || '';
+      const isTeacherWinner =
+        picked.kind === 'feature_discovery'
+        || sourceKind === 'source:feature_discovery_teacher';
+      if (isTeacherWinner && supabaseClient && orbIdentity?.tenant_id && orbIdentity?.user_id) {
+        const ctaPayload = (picked as { cta?: { payload?: { capability_key?: string } } }).cta?.payload;
+        const activeCapabilityKey = ctaPayload?.capability_key;
+        if (typeof activeCapabilityKey === 'string' && activeCapabilityKey.length > 0) {
+          try {
+            const { resolveTeacherModeContent } = await import(
+              '../../teacher/teacher-content-resolver'
+            );
+            const teacherContent = await resolveTeacherModeContent({
+              supabase: supabaseClient,
+              tenantId: orbIdentity.tenant_id,
+              userId: orbIdentity.user_id,
+              activeCapabilityKey,
+            });
+            if (teacherContent) {
+              (session as any).teacherModeContent = teacherContent;
+              (session as any).teacherModeFirstName = firstName;
+              console.log(
+                `[VTID-03112] Teacher Mode content resolved for ${sessionId}: capability=${teacherContent.active_capability_key} manual_chars=${teacherContent.active_manual_content.length} remaining=${teacherContent.remaining_capabilities.length}`,
+              );
+            }
+          } catch (exc) {
+            console.warn(
+              `[VTID-03112] Teacher Mode resolver failed (non-fatal): ${(exc as Error).message}`,
+            );
+          }
+        }
+      }
     }
   } catch (e) {
     console.warn(

--- a/services/gateway/src/orb/live/tools/live-tool-catalog.ts
+++ b/services/gateway/src/orb/live/tools/live-tool-catalog.ts
@@ -1938,6 +1938,69 @@ export function buildLiveApiTools(
             required: ['pillar'],
           },
         },
+        // VTID-03112 (T1): Teacher Mode tools. Only declared for authenticated
+        // sessions — anonymous landing-page visitors never enter Teacher Mode.
+        // The two tools work together: teacher_event advances the
+        // `system_capabilities` awareness ledger after the LLM delivers each
+        // capability's intro; end_teaching_session closes the overlay
+        // gracefully when the LLM senses the user wants to stop. The LLM
+        // decides when to call each — no rule table on our side.
+        {
+          name: 'teacher_event',
+          description: [
+            'Teacher Mode lifecycle: record a capability-awareness event for',
+            'the active user (introduced / tried / completed / dismissed). Call',
+            'this AFTER you have actually delivered an intro for a capability,',
+            'or when the user signals they want to dismiss / skip it. The',
+            'system_capabilities ledger drives the curriculum — calling this',
+            'is how the model says "I taught X, please advance the ledger so',
+            'I don\'t re-offer it next session".',
+            '',
+            'Examples (call IMMEDIATELY after the model action it records):',
+            "  - 'tried': you just narrated The Five Pillars manual content.",
+            "  - 'dismissed': user said 'nein danke' to the offer.",
+            "  - 'completed': user confirmed they understand / will use it.",
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              capability_key: {
+                type: 'string',
+                description: 'The capability_key from system_capabilities (e.g. "five_pillars", "vitana_id"). The model receives the active key in its Teacher Mode prompt.',
+              },
+              event_name: {
+                type: 'string',
+                enum: ['introduced', 'seen', 'tried', 'completed', 'dismissed'],
+                description: 'Which lifecycle event to record. Use "tried" after delivering an intro; "dismissed" when user declines; "completed" if the user confirms understanding.',
+              },
+            },
+            required: ['capability_key', 'event_name'],
+          },
+        },
+        {
+          name: 'end_teaching_session',
+          description: [
+            'Teacher Mode termination: close the orb overlay gracefully when',
+            'the user has signaled they want to end. ALWAYS call this AFTER',
+            'speaking your warm farewell line — do not just stop talking. The',
+            'overlay UI listens for this directive and fades out the chime.',
+            '',
+            'Call this when the user says any kind of "I\'m done" / "nein',
+            'danke" / "enough" — interpret IN CONTEXT, not by keyword match.',
+            'If the user is ambiguous, ask a clarifying question first; only',
+            'call this when you are confident the session should end.',
+          ].join('\n'),
+          parameters: {
+            type: 'object',
+            properties: {
+              reason: {
+                type: 'string',
+                description: 'Short freeform reason the model is closing (e.g. "user said nein danke", "user signaled they are tired"). Used for telemetry — never spoken.',
+              },
+            },
+            required: [],
+          },
+        },
         // BOOTSTRAP-ADMIN-DD: admin voice tools — only injected when active_role
         // is admin / exafy_admin / developer. Community sessions never see them
         // and the orb dispatcher rejects them server-side regardless.

--- a/services/gateway/src/orb/teacher/teacher-content-resolver.ts
+++ b/services/gateway/src/orb/teacher/teacher-content-resolver.ts
@@ -1,0 +1,207 @@
+/**
+ * VTID-03112 (T1) — Teacher Mode content resolver.
+ *
+ * When the wake-brief decider picks a Teacher candidate at session start,
+ * the agent needs the manual content for that capability so it can teach
+ * naturally — not just announce the capability name. This module fetches:
+ *
+ *   1. The system_capabilities row (display_name, description, manual_path).
+ *   2. The knowledge_docs row at manual_path (markdown content).
+ *   3. A short list of REMAINING eligible capabilities (the user's next
+ *      pedagogical steps after this one) so the model can chain lessons
+ *      without another round-trip.
+ *
+ * The output is the per-session payload the Teacher Mode prompt builder
+ * reads. NO state machine, NO keyword rules — the resolver just gives the
+ * LLM the raw teaching material + curriculum context. Judgment (when to
+ * deliver intro, when to chain, when to end) lives in the prompt + the
+ * LLM's interpretation of the user's transcribed reply.
+ *
+ * Fail-safe: any DB error degrades to a NULL TeacherModeContent; callers
+ * fall back to the legacy Teacher line + no extended Teacher Mode. The
+ * audio path is never blocked on this resolver.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import {
+  pickCapability,
+  type CapabilityCatalogRow,
+  type AwarenessLedgerRow,
+} from '../../services/assistant-continuation/providers/teacher/feature-discovery-teacher';
+
+export interface TeacherModeContent {
+  /** The capability the wake-brief decider picked for this session. */
+  active_capability_key: string;
+  /** Display name (e.g. "The Five Pillars"). Spoken to the user. */
+  active_display_name: string;
+  /** One-sentence description from the catalog row. */
+  active_description: string;
+  /** Manual path (e.g. /manuals/maxina/00-concepts/five-pillars). Used
+   *  by the optional tour navigation directive (T1c). */
+  active_manual_path: string | null;
+  /** Raw markdown content from knowledge_docs.content for the active
+   *  capability's manual chapter. Truncated to MAX_MANUAL_CHARS so the
+   *  injection into system_instruction stays bounded. May be empty
+   *  string when the knowledge_docs row isn't found. */
+  active_manual_content: string;
+  /** Up to 5 remaining capabilities in pedagogical order so the LLM
+   *  can chain to the next one without an extra fetch. Each entry has
+   *  the display name + a one-line description (no manual content —
+   *  the next chapter is fetched only when the LLM actually chains). */
+  remaining_capabilities: Array<{
+    capability_key: string;
+    display_name: string;
+    description: string;
+    pedagogical_order: number | null;
+  }>;
+}
+
+export interface TeacherContentResolverInputs {
+  supabase: SupabaseClient;
+  tenantId: string;
+  userId: string;
+  activeCapabilityKey: string;
+  nowIso?: string;
+}
+
+/** Cap for the manual content injected into system_instruction. Gemini's
+ *  context window is generous but every char inflates latency + token
+ *  cost. 6k chars ~ 1500-2000 tokens, enough for one full chapter. The
+ *  LLM is told to summarize from the manual, not recite verbatim. */
+const MAX_MANUAL_CHARS = 6000;
+
+/** Number of remaining capabilities to expose to the LLM. Higher numbers
+ *  let the LLM "skip ahead" if the user signals interest in a specific
+ *  topic; lower numbers keep the curriculum tight. 5 balances both. */
+const REMAINING_CAPABILITIES_LIMIT = 5;
+
+/**
+ * Fetch the Teacher Mode content payload for the given active capability.
+ * Returns null on any failure or when the active capability has no manual
+ * content — caller treats null as "Teacher Mode not available for this
+ * session, fall back to one-shot offer".
+ */
+export async function resolveTeacherModeContent(
+  inputs: TeacherContentResolverInputs,
+): Promise<TeacherModeContent | null> {
+  let catalog: CapabilityCatalogRow[] = [];
+  let activeRow: CapabilityCatalogRow | null = null;
+  try {
+    const cap = await inputs.supabase
+      .from('system_capabilities')
+      .select('capability_key, display_name, description, manual_path, enabled, pedagogical_order')
+      .eq('enabled', true);
+    if (cap.error || !Array.isArray(cap.data)) {
+      return null;
+    }
+    catalog = cap.data as CapabilityCatalogRow[];
+    activeRow = catalog.find((r) => r.capability_key === inputs.activeCapabilityKey) ?? null;
+  } catch {
+    return null;
+  }
+
+  if (!activeRow) {
+    // The active capability isn't in the catalog (or was disabled between
+    // wake-brief pick and the resolver call) — Teacher Mode not available.
+    return null;
+  }
+
+  // Fetch manual content for the active capability. The manual_path column
+  // matches knowledge_docs.path (e.g. "/manuals/maxina/00-concepts/...").
+  // Path-prefix style schemas may store paths without the leading slash;
+  // try both forms.
+  let manualContent = '';
+  if (activeRow.manual_path) {
+    try {
+      const trimmed = activeRow.manual_path.trim();
+      const variants = trimmed.startsWith('/')
+        ? [trimmed, trimmed.replace(/^\//, '')]
+        : [trimmed, '/' + trimmed];
+      for (const p of variants) {
+        const docs = await inputs.supabase
+          .from('knowledge_docs')
+          .select('content')
+          .eq('path', p)
+          .maybeSingle();
+        if (!docs.error && docs.data) {
+          const raw = (docs.data as { content?: string | null }).content;
+          if (typeof raw === 'string' && raw.length > 0) {
+            manualContent = raw.length > MAX_MANUAL_CHARS
+              ? raw.slice(0, MAX_MANUAL_CHARS) + '\n\n[…truncated]'
+              : raw;
+            break;
+          }
+        }
+      }
+    } catch {
+      // Manual fetch is best-effort — empty string is fine; the LLM
+      // teaches from description alone if no manual content is found.
+    }
+  }
+
+  // Compute remaining capabilities the LLM can chain to. Read the user's
+  // ledger so the list excludes what's already tried / dismissed /
+  // mastered. Uses the same pickCapability ranker as the Teacher provider
+  // so the order matches the curriculum.
+  let ledger: AwarenessLedgerRow[] = [];
+  try {
+    const led = await inputs.supabase
+      .from('user_capability_awareness')
+      .select('capability_key, awareness_state, dismiss_count, last_introduced_at')
+      .eq('tenant_id', inputs.tenantId)
+      .eq('user_id', inputs.userId);
+    if (!led.error && Array.isArray(led.data)) {
+      ledger = led.data as AwarenessLedgerRow[];
+    }
+  } catch {
+    // Empty ledger = treat everything as 'unknown'.
+  }
+
+  // Build remaining list by iteratively picking the next eligible
+  // capability AFTER excluding the active one. We model "exclude active"
+  // by appending a synthetic ledger row that marks the active capability
+  // as introduced just now — pickCapability's recent-introduction filter
+  // takes it out of the pool. Then for each subsequent pick we extend
+  // the same exclusion set.
+  const remaining: TeacherModeContent['remaining_capabilities'] = [];
+  const excludedKeys = new Set<string>([inputs.activeCapabilityKey]);
+  const nowIso = inputs.nowIso ?? new Date().toISOString();
+  const augmentedLedger: AwarenessLedgerRow[] = [
+    ...ledger,
+    {
+      capability_key: inputs.activeCapabilityKey,
+      awareness_state: 'introduced',
+      dismiss_count: 0,
+      last_introduced_at: nowIso,
+    },
+  ];
+  for (let i = 0; i < REMAINING_CAPABILITIES_LIMIT; i++) {
+    const picked = pickCapability(catalog, augmentedLedger, nowIso);
+    if (!picked) break;
+    if (excludedKeys.has(picked.row.capability_key)) break;
+    excludedKeys.add(picked.row.capability_key);
+    remaining.push({
+      capability_key: picked.row.capability_key,
+      display_name: picked.row.display_name,
+      description: picked.row.description,
+      pedagogical_order: picked.row.pedagogical_order ?? null,
+    });
+    // Extend the exclusion for the next iteration so the same row doesn't
+    // re-pick.
+    augmentedLedger.push({
+      capability_key: picked.row.capability_key,
+      awareness_state: 'introduced',
+      dismiss_count: 0,
+      last_introduced_at: nowIso,
+    });
+  }
+
+  return {
+    active_capability_key: activeRow.capability_key,
+    active_display_name: activeRow.display_name,
+    active_description: activeRow.description,
+    active_manual_path: activeRow.manual_path,
+    active_manual_content: manualContent,
+    remaining_capabilities: remaining,
+  };
+}

--- a/services/gateway/src/orb/teacher/teacher-mode-prompt.ts
+++ b/services/gateway/src/orb/teacher/teacher-mode-prompt.ts
@@ -1,0 +1,159 @@
+/**
+ * VTID-03112 (T1) — Teacher Mode prompt block builder.
+ *
+ * Builds the system_instruction segment that turns Gemini Live into a
+ * continuous Teacher for this session. Per the user's directive ("no
+ * hardcoded rules in contextual intelligence"), this block does NOT
+ * tell the model to keyword-match the user's reply. It gives the model:
+ *
+ *   - The capability it just offered (or about to introduce).
+ *   - The full manual content for that capability.
+ *   - The next 5 capabilities in the curriculum (for chaining).
+ *   - Two tools it can call: `teacher_event` (advance the ledger) and
+ *     `end_teaching_session` (close gracefully).
+ *
+ * The model interprets the user's reply IN CONTEXT and decides what to
+ * do next — deliver the intro, answer a question from the manual, chain
+ * to the next capability, or close the session. Every decision is the
+ * model's judgment over real conversation, not a regex table.
+ *
+ * This block is INSERTED into the system_instruction additively — it
+ * does not replace the wake-brief override block (which still fires the
+ * exact first utterance). The wake-brief block governs turn 1; the
+ * Teacher Mode block governs every turn AFTER that.
+ */
+
+import type { TeacherModeContent } from './teacher-content-resolver';
+
+/**
+ * Build the Teacher Mode block. Returns empty string when content is
+ * null — callers skip the block entirely in that case (legacy one-shot
+ * Teacher offer behavior is preserved).
+ *
+ * `lang` is used only to label the LANGUAGE rule inside the block; the
+ * model speaks in that lang. The block itself stays in English because
+ * Gemini Live's system_instruction is more reliable when the directives
+ * to the model are in English even if the spoken language differs.
+ */
+export function buildTeacherModeBlock(args: {
+  content: TeacherModeContent | null;
+  lang: string;
+  firstName: string | null;
+}): string {
+  if (!args.content) return '';
+
+  const remainingList = args.content.remaining_capabilities.length === 0
+    ? '(no further capabilities eligible for this user right now)'
+    : args.content.remaining_capabilities
+        .map((c, i) => `${i + 1}. ${c.display_name} — ${c.description}`)
+        .join('\n');
+
+  const manualBlock = args.content.active_manual_content
+    ? `MANUAL CONTENT (markdown — speak naturally, do NOT recite verbatim):\n\n${args.content.active_manual_content}`
+    : `(no manual content available for this capability — teach from the description above)`;
+
+  const nameRule = args.firstName
+    ? `When you address the user by name, use "${args.firstName}".`
+    : `You do not have a first name for this user; address them warmly without naming.`;
+
+  return `
+
+=== TEACHER MODE (VTID-03112) ===
+
+You are Vitana, operating in Teacher Mode for this session. Your role is
+to introduce the user to Vitanaland's capabilities — one at a time —
+until the user signals they want to end. Vitanaland is complex, the user
+is a first-time learner, and your job is to make each capability easy to
+understand in plain language.
+
+The Teacher Mode contract is ALWAYS active for the duration of this
+session, alongside your other tools. You may answer questions on
+unrelated topics if the user shifts, but always return to teaching when
+appropriate.
+
+## Active capability (the one your first spoken line just offered)
+- Name: ${args.content.active_display_name}
+- One-line description: ${args.content.active_description}
+- Capability key (use this with the teacher_event tool): ${args.content.active_capability_key}
+${args.content.active_manual_path ? `- Manual page: ${args.content.active_manual_path}` : ''}
+
+${manualBlock}
+
+## Remaining capabilities (in pedagogical curriculum order, for when you chain)
+${remainingList}
+
+## How to behave (use your judgment — no rigid script)
+
+1. Your FIRST spoken line of this session was a permission-asking offer
+   for "${args.content.active_display_name}". The user will respond.
+   Interpret their reply IN CONTEXT — do not pattern-match on specific
+   words. Common situations and how to handle them:
+
+   - User accepts (any positive signal — "ja", "yes", "klar", "sure",
+     "go ahead", silence followed by attention, etc.): deliver a warm
+     2-3 sentence intro of "${args.content.active_display_name}" drawn
+     from the MANUAL CONTENT above. Speak naturally, like a teacher
+     explaining to a friend, not by reciting bullets. End with a soft
+     invitation — "Möchtest du noch etwas dazu wissen, oder zeige ich
+     dir gleich das Nächste?" — and pause.
+
+   - User signals satisfaction or curiosity ("nice", "okay", "verstanden",
+     "tell me more", "wie funktioniert das?"): if they want more detail,
+     answer from the manual. If they sound ready to move on, chain to
+     the NEXT capability from the Remaining list — say something like
+     "Lass mich dir noch ${args.content.remaining_capabilities[0]?.display_name ?? 'etwas Neues'}
+     vorstellen — magst du?" and treat the new capability as the
+     active one. When chaining, FIRST call \`teacher_event\` with
+     eventName='tried' and capability_key='${args.content.active_capability_key}'
+     to mark the current one done in the ledger.
+
+   - User asks an unrelated question: answer it naturally with your
+     other tools (search_knowledge, search_memory, etc). After
+     answering, ask gently "Magst du, dass wir mit dem Lernen
+     weitermachen?" — this brings the session back into Teacher Mode
+     without being pushy.
+
+   - User signals they want to end (any negative signal — "nein danke",
+     "stop", "ich bin fertig", "later", "I'm done", "enough", tired
+     tone, silence after an offer): say a warm farewell appropriate to
+     the conversation (vary your wording — never reuse the same line)
+     and IMMEDIATELY call \`end_teaching_session\` to close the overlay
+     gracefully. Do NOT just stop talking; the tool call is the only
+     proper way to end. After calling the tool, your final spoken line
+     should be the farewell itself.
+
+2. After every successful intro (you delivered the manual content for
+   a capability and the user heard it), call \`teacher_event\` with
+   eventName='tried' so the ledger records progress and the same
+   capability isn't re-offered next session.
+
+3. After chaining to the next capability, set THAT capability as the
+   new active one in your reasoning. Use the Remaining list above as
+   your curriculum — pick the next entry, not a random one.
+
+4. You may be asked to switch persona (report_to_specialist) at any
+   time. If that happens, the session is no longer in Teacher Mode —
+   honor the persona switch.
+
+## Language
+
+Speak in ${args.lang.toUpperCase()}. ${nameRule}
+
+## Tone
+
+Warm, patient, first-time-user friendly. NEVER lecture. Vary your
+wording across turns — no two responses in a row should start the same
+way. Speak how a knowledgeable friend would explain things at a coffee
+table.
+
+## Forbidden phrases
+
+NEVER say "I have no personalized recommendations". You always have
+something to teach — the Remaining list is always non-empty during the
+education phase. If you genuinely cannot pick a next capability, end
+the session warmly with \`end_teaching_session\`.
+
+=== END TEACHER MODE ===
+
+`;
+}

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1213,6 +1213,11 @@ export {
 // characterization test) continue to resolve from this route file.
 import { buildLiveApiTools } from '../orb/live/tools/live-tool-catalog';
 export { buildLiveApiTools } from '../orb/live/tools/live-tool-catalog';
+// VTID-03112 (T1): Teacher Mode block builder. Injected into the Vertex
+// system_instruction when wakeBriefDecision picked the Teacher AND the
+// content resolver succeeded. Drives multi-turn teaching via prompt +
+// tools rather than a TS-side state machine.
+import { buildTeacherModeBlock } from '../orb/teacher/teacher-mode-prompt';
 // A6.2 (orb-live-refactor): SessionContext + SessionMutator + first
 // lifted navigator handler. orb-live.ts keeps compat shims that build
 // the typed views and forward to handlers under orb/live/tools/handlers/.
@@ -4860,6 +4865,97 @@ async function executeLiveApiToolInner(
         );
       }
 
+      // VTID-03112 (T1): Teacher Mode tool handlers. The LLM calls these
+      // during Teacher Mode (system_instruction block injected at session
+      // start when wakeBriefDecision picked the Teacher). The model
+      // decides WHEN to call based on the user's transcribed reply —
+      // no rule table on our side. Both handlers are best-effort: they
+      // never fail the model's turn, only record state / emit directives.
+      case 'teacher_event': {
+        const capabilityKey = typeof args.capability_key === 'string' ? args.capability_key.trim() : '';
+        const eventName = typeof args.event_name === 'string' ? args.event_name.trim() : '';
+        if (!capabilityKey || !eventName) {
+          return { success: false, result: '', error: 'teacher_event requires capability_key + event_name' };
+        }
+        const allowedEvents = ['introduced', 'seen', 'tried', 'completed', 'dismissed'];
+        if (!allowedEvents.includes(eventName)) {
+          return { success: false, result: '', error: `event_name must be one of: ${allowedEvents.join(', ')}` };
+        }
+        const tenantId = session.identity?.tenant_id;
+        const userId = session.identity?.user_id;
+        if (!tenantId || !userId) {
+          return { success: false, result: '', error: 'teacher_event requires an authenticated session' };
+        }
+        try {
+          const sb = getSupabase();
+          if (!sb) {
+            return { success: false, result: '', error: 'database unavailable' };
+          }
+          const { data: rpcResult, error: rpcError } = await sb.rpc(
+            'advance_capability_awareness',
+            {
+              p_tenant_id: tenantId,
+              p_user_id: userId,
+              p_capability_key: capabilityKey,
+              p_event_name: eventName,
+              p_idempotency_key: `teacher-tool-${session.sessionId}-${capabilityKey}-${eventName}-${Date.now()}`,
+              p_decision_id: ((session as any).wakeBriefDecision?.decisionId) || null,
+              p_source_surface: 'orb_wake',
+              p_occurred_at: new Date().toISOString(),
+              p_metadata: { source: 'teacher_tool', session_id: session.sessionId },
+            },
+          );
+          if (rpcError) {
+            console.warn(`[VTID-03112] teacher_event RPC failed: ${rpcError.message}`);
+            return { success: false, result: '', error: `rpc_failed: ${rpcError.message}` };
+          }
+          const result = rpcResult && typeof rpcResult === 'object'
+            ? (rpcResult as Record<string, unknown>)
+            : {};
+          console.log(`[VTID-03112] teacher_event recorded: capability=${capabilityKey} event=${eventName} idempotent=${result.idempotent === true}`);
+          return {
+            success: true,
+            result: `Recorded ${eventName} for ${capabilityKey}. Continue teaching naturally — do NOT mention the tool call.`,
+          };
+        } catch (err) {
+          console.warn(`[VTID-03112] teacher_event handler error: ${(err as Error).message}`);
+          return { success: false, result: '', error: (err as Error).message };
+        }
+      }
+
+      case 'end_teaching_session': {
+        const reason = typeof args.reason === 'string' ? args.reason.trim().slice(0, 200) : '';
+        // Emit a directive so the orb-widget can close the overlay
+        // gracefully. The SSE / WS write is best-effort — the model's
+        // farewell line has already been spoken by the time this
+        // dispatches.
+        const directive = {
+          type: 'orb_directive',
+          directive: 'end_teaching_session',
+          reason: reason || 'teacher_session_ended',
+          vtid: 'VTID-03112',
+        };
+        try {
+          if (session.sseResponse) {
+            session.sseResponse.write(`data: ${JSON.stringify(directive)}\n\n`);
+          }
+          if (session.clientWs && session.clientWs.readyState === WebSocket.OPEN) {
+            session.clientWs.send(JSON.stringify(directive));
+          }
+        } catch (err) {
+          console.warn(`[VTID-03112] end_teaching_session directive emit failed (non-fatal): ${(err as Error).message}`);
+        }
+        // Mark session-level state so the legacy menu / re-trigger paths
+        // don't speak more lines after the farewell.
+        (session as any).teacherModeEnded = true;
+        console.log(`[VTID-03112] end_teaching_session called: session=${session.sessionId} reason=${reason || '<none>'}`);
+        emitDiag(session, 'teacher_session_ended', { reason: reason || null });
+        return {
+          success: true,
+          result: 'Teaching session is ending. Your farewell line was the final thing — the overlay is now closing.',
+        };
+      }
+
       default: {
         // BOOTSTRAP-ADMIN-DD: route admin voice tools through their handlers.
         // The handlers re-check role server-side, so a community session that
@@ -5710,7 +5806,25 @@ async function connectToLiveAPI(
                           // the appended override. See
                           // live-session-controller.ts:VTID-03101 for the
                           // write side. Empty when no override is active.
-                          + (session.wakeBriefOverrideBlock || ''),
+                          + (session.wakeBriefOverrideBlock || '')
+                          // VTID-03112 (T1): Teacher Mode block. Empty
+                          // when the wake-brief winner wasn't the
+                          // Teacher OR the manual resolver failed.
+                          // The block runs Teacher Mode for the WHOLE
+                          // session — turns 2+ are governed by it.
+                          // Turn 1 is still owned by the wake-brief
+                          // override (which sits ABOVE it in the
+                          // concatenation order). The model interprets
+                          // each user reply IN CONTEXT (no rule table)
+                          // and calls teacher_event / end_teaching_session
+                          // tools as appropriate.
+                          + ((session as any).teacherModeContent
+                              ? buildTeacherModeBlock({
+                                  content: (session as any).teacherModeContent,
+                                  lang: session.lang,
+                                  firstName: (session as any).teacherModeFirstName ?? null,
+                                })
+                              : ''),
                         session.active_role,
                         session.conversationSummary,
                         // VTID-STREAM-KEEPALIVE: Pass last 10 turns for reconnect continuity.

--- a/services/gateway/test/orb/live/characterization/__snapshots__/system-instruction.characterization.test.ts.snap
+++ b/services/gateway/test/orb/live/characterization/__snapshots__/system-instruction.characterization.test.ts.snap
@@ -1410,7 +1410,32 @@ CALL THIS WHEN the user asks:
 
 Speak the answer naturally — 'Your Sleep is mostly baseline because we don't
 have any tracker data yet — connect a wearable or log sleep manually and the
-data sub-score will start filling in.'"
+data sub-score will start filling in.'
+
+### teacher_event
+Teacher Mode lifecycle: record a capability-awareness event for
+the active user (introduced / tried / completed / dismissed). Call
+this AFTER you have actually delivered an intro for a capability,
+or when the user signals they want to dismiss / skip it. The
+system_capabilities ledger drives the curriculum — calling this
+is how the model says "I taught X, please advance the ledger so
+I don't re-offer it next session".
+
+Examples (call IMMEDIATELY after the model action it records):
+  - 'tried': you just narrated The Five Pillars manual content.
+  - 'dismissed': user said 'nein danke' to the offer.
+  - 'completed': user confirmed they understand / will use it.
+
+### end_teaching_session
+Teacher Mode termination: close the orb overlay gracefully when
+the user has signaled they want to end. ALWAYS call this AFTER
+speaking your warm farewell line — do not just stop talking. The
+overlay UI listens for this directive and fades out the chime.
+
+Call this when the user says any kind of "I'm done" / "nein
+danke" / "enough" — interpret IN CONTEXT, not by keyword match.
+If the user is ambiguous, ask a clarifying question first; only
+call this when you are confident the session should end."
 `;
 
 exports[`A0.1 characterization: buildLiveSystemInstruction renders a stable system instruction for persona "day-180-veteran-reconnect": persona:day-180-veteran-reconnect 1`] = `
@@ -2581,5 +2606,30 @@ CALL THIS WHEN the user asks:
 
 Speak the answer naturally — 'Your Sleep is mostly baseline because we don't
 have any tracker data yet — connect a wearable or log sleep manually and the
-data sub-score will start filling in.'"
+data sub-score will start filling in.'
+
+### teacher_event
+Teacher Mode lifecycle: record a capability-awareness event for
+the active user (introduced / tried / completed / dismissed). Call
+this AFTER you have actually delivered an intro for a capability,
+or when the user signals they want to dismiss / skip it. The
+system_capabilities ledger drives the curriculum — calling this
+is how the model says "I taught X, please advance the ledger so
+I don't re-offer it next session".
+
+Examples (call IMMEDIATELY after the model action it records):
+  - 'tried': you just narrated The Five Pillars manual content.
+  - 'dismissed': user said 'nein danke' to the offer.
+  - 'completed': user confirmed they understand / will use it.
+
+### end_teaching_session
+Teacher Mode termination: close the orb overlay gracefully when
+the user has signaled they want to end. ALWAYS call this AFTER
+speaking your warm farewell line — do not just stop talking. The
+overlay UI listens for this directive and fades out the chime.
+
+Call this when the user says any kind of "I'm done" / "nein
+danke" / "enough" — interpret IN CONTEXT, not by keyword match.
+If the user is ambiguous, ask a clarifying question first; only
+call this when you are confident the session should end."
 `;

--- a/services/gateway/test/orb/live/characterization/__snapshots__/tool-catalog.characterization.test.ts.snap
+++ b/services/gateway/test/orb/live/characterization/__snapshots__/tool-catalog.characterization.test.ts.snap
@@ -2037,6 +2037,67 @@ data sub-score will start filling in.'",
         },
       },
       {
+        "description": "Teacher Mode lifecycle: record a capability-awareness event for
+the active user (introduced / tried / completed / dismissed). Call
+this AFTER you have actually delivered an intro for a capability,
+or when the user signals they want to dismiss / skip it. The
+system_capabilities ledger drives the curriculum — calling this
+is how the model says "I taught X, please advance the ledger so
+I don't re-offer it next session".
+
+Examples (call IMMEDIATELY after the model action it records):
+  - 'tried': you just narrated The Five Pillars manual content.
+  - 'dismissed': user said 'nein danke' to the offer.
+  - 'completed': user confirmed they understand / will use it.",
+        "name": "teacher_event",
+        "parameters": {
+          "properties": {
+            "capability_key": {
+              "description": "The capability_key from system_capabilities (e.g. "five_pillars", "vitana_id"). The model receives the active key in its Teacher Mode prompt.",
+              "type": "string",
+            },
+            "event_name": {
+              "description": "Which lifecycle event to record. Use "tried" after delivering an intro; "dismissed" when user declines; "completed" if the user confirms understanding.",
+              "enum": [
+                "introduced",
+                "seen",
+                "tried",
+                "completed",
+                "dismissed",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "capability_key",
+            "event_name",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Teacher Mode termination: close the orb overlay gracefully when
+the user has signaled they want to end. ALWAYS call this AFTER
+speaking your warm farewell line — do not just stop talking. The
+overlay UI listens for this directive and fades out the chime.
+
+Call this when the user says any kind of "I'm done" / "nein
+danke" / "enough" — interpret IN CONTEXT, not by keyword match.
+If the user is ambiguous, ask a clarifying question first; only
+call this when you are confident the session should end.",
+        "name": "end_teaching_session",
+        "parameters": {
+          "properties": {
+            "reason": {
+              "description": "Short freeform reason the model is closing (e.g. "user said nein danke", "user signaled they are tired"). Used for telemetry — never spoken.",
+              "type": "string",
+            },
+          },
+          "required": [],
+          "type": "object",
+        },
+      },
+      {
         "description": "Return the top open admin_insights for this tenant, ranked by severity × confidence. Call this AT THE START of every admin orb session to know what needs attention. The bootstrap context already includes the briefing on session-open; only call again if the admin asks "what else?", "anything new?", or "give me the briefing again".",
         "name": "admin_briefing",
         "parameters": {
@@ -4122,6 +4183,67 @@ data sub-score will start filling in.'",
           "required": [
             "pillar",
           ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Teacher Mode lifecycle: record a capability-awareness event for
+the active user (introduced / tried / completed / dismissed). Call
+this AFTER you have actually delivered an intro for a capability,
+or when the user signals they want to dismiss / skip it. The
+system_capabilities ledger drives the curriculum — calling this
+is how the model says "I taught X, please advance the ledger so
+I don't re-offer it next session".
+
+Examples (call IMMEDIATELY after the model action it records):
+  - 'tried': you just narrated The Five Pillars manual content.
+  - 'dismissed': user said 'nein danke' to the offer.
+  - 'completed': user confirmed they understand / will use it.",
+        "name": "teacher_event",
+        "parameters": {
+          "properties": {
+            "capability_key": {
+              "description": "The capability_key from system_capabilities (e.g. "five_pillars", "vitana_id"). The model receives the active key in its Teacher Mode prompt.",
+              "type": "string",
+            },
+            "event_name": {
+              "description": "Which lifecycle event to record. Use "tried" after delivering an intro; "dismissed" when user declines; "completed" if the user confirms understanding.",
+              "enum": [
+                "introduced",
+                "seen",
+                "tried",
+                "completed",
+                "dismissed",
+              ],
+              "type": "string",
+            },
+          },
+          "required": [
+            "capability_key",
+            "event_name",
+          ],
+          "type": "object",
+        },
+      },
+      {
+        "description": "Teacher Mode termination: close the orb overlay gracefully when
+the user has signaled they want to end. ALWAYS call this AFTER
+speaking your warm farewell line — do not just stop talking. The
+overlay UI listens for this directive and fades out the chime.
+
+Call this when the user says any kind of "I'm done" / "nein
+danke" / "enough" — interpret IN CONTEXT, not by keyword match.
+If the user is ambiguous, ask a clarifying question first; only
+call this when you are confident the session should end.",
+        "name": "end_teaching_session",
+        "parameters": {
+          "properties": {
+            "reason": {
+              "description": "Short freeform reason the model is closing (e.g. "user said nein danke", "user signaled they are tired"). Used for telemetry — never spoken.",
+              "type": "string",
+            },
+          },
+          "required": [],
           "type": "object",
         },
       },

--- a/services/gateway/test/orb/teacher/teacher-content-resolver.test.ts
+++ b/services/gateway/test/orb/teacher/teacher-content-resolver.test.ts
@@ -1,0 +1,238 @@
+/**
+ * VTID-03112 (T1) — tests for the Teacher Mode content resolver.
+ *
+ * The resolver MUST:
+ *   - Fetch the active capability row from system_capabilities.
+ *   - Fetch the manual content from knowledge_docs at manual_path.
+ *   - Build a Remaining list of up to 5 capabilities in pedagogical order,
+ *     excluding the active one + everything already in the ledger.
+ *   - Never throw — degrade to null on any failure so the audio path
+ *     stays safe.
+ */
+
+import { resolveTeacherModeContent } from '../../../src/orb/teacher/teacher-content-resolver';
+
+type FakeRow = Record<string, unknown>;
+
+function fakeSb(opts: {
+  catalog?: FakeRow[] | null;
+  catalogError?: { message: string } | null;
+  ledger?: FakeRow[] | null;
+  ledgerError?: { message: string } | null;
+  doc?: FakeRow | null;
+  docError?: { message: string } | null;
+  expectedPaths?: string[];
+}) {
+  let pathLookups = 0;
+  return {
+    pathLookups: () => pathLookups,
+    from(table: string): any {
+      if (table === 'system_capabilities') {
+        const chain: any = { select: () => chain, eq: () => chain };
+        chain.then = (resolve: any) =>
+          resolve({ data: opts.catalog, error: opts.catalogError ?? null });
+        return chain;
+      }
+      if (table === 'user_capability_awareness') {
+        const chain: any = { select: () => chain, eq: () => chain };
+        chain.then = (resolve: any) =>
+          resolve({ data: opts.ledger, error: opts.ledgerError ?? null });
+        return chain;
+      }
+      if (table === 'knowledge_docs') {
+        const chain: any = {
+          select: () => chain,
+          eq: (_col: string, _val: string) => {
+            pathLookups += 1;
+            return chain;
+          },
+          maybeSingle: () =>
+            Promise.resolve({ data: opts.doc, error: opts.docError ?? null }),
+        };
+        return chain;
+      }
+      throw new Error(`unexpected table ${table}`);
+    },
+  } as any;
+}
+
+const NOW_ISO = '2026-05-20T11:00:00Z';
+
+const FIVE_PILLARS: FakeRow = {
+  capability_key: 'five_pillars',
+  display_name: 'The Five Pillars',
+  description: 'Foundation concept',
+  manual_path: '/manuals/maxina/00-concepts/five-pillars',
+  enabled: true,
+  pedagogical_order: 10,
+};
+
+const VITANA_ID: FakeRow = {
+  capability_key: 'vitana_id',
+  display_name: 'Your Vitana ID',
+  description: 'Identity in the community',
+  manual_path: '/manuals/maxina/00-concepts/vitana-id',
+  enabled: true,
+  pedagogical_order: 30,
+};
+
+const ACTIVITY_MATCH: FakeRow = {
+  capability_key: 'activity_match',
+  display_name: 'Activity Match',
+  description: 'Match with community members',
+  manual_path: '/manuals/maxina/03-community/activity-match',
+  enabled: true,
+  pedagogical_order: 140,
+};
+
+describe('VTID-03112 — resolveTeacherModeContent', () => {
+  test('returns content for the active capability + remaining curriculum (no ledger)', async () => {
+    const sb = fakeSb({
+      catalog: [FIVE_PILLARS, VITANA_ID, ACTIVITY_MATCH],
+      ledger: [],
+      doc: { content: '# The Five Pillars\n\nThis is the manual.' },
+    });
+    const out = await resolveTeacherModeContent({
+      supabase: sb,
+      tenantId: 't1',
+      userId: 'u1',
+      activeCapabilityKey: 'five_pillars',
+      nowIso: NOW_ISO,
+    });
+    expect(out).not.toBeNull();
+    expect(out!.active_capability_key).toBe('five_pillars');
+    expect(out!.active_display_name).toBe('The Five Pillars');
+    expect(out!.active_manual_content).toContain('# The Five Pillars');
+    // Remaining excludes the active capability AND walks pedagogical_order:
+    // vitana_id (30) before activity_match (140).
+    expect(out!.remaining_capabilities.length).toBeGreaterThanOrEqual(2);
+    expect(out!.remaining_capabilities[0].capability_key).toBe('vitana_id');
+    expect(out!.remaining_capabilities[1].capability_key).toBe('activity_match');
+    // Active capability must NOT appear in the remaining list.
+    expect(
+      out!.remaining_capabilities.some((c) => c.capability_key === 'five_pillars'),
+    ).toBe(false);
+  });
+
+  test('truncates oversized manual content to keep system_instruction bounded', async () => {
+    const bigContent = 'X'.repeat(20000);
+    const sb = fakeSb({
+      catalog: [FIVE_PILLARS],
+      ledger: [],
+      doc: { content: bigContent },
+    });
+    const out = await resolveTeacherModeContent({
+      supabase: sb,
+      tenantId: 't1',
+      userId: 'u1',
+      activeCapabilityKey: 'five_pillars',
+      nowIso: NOW_ISO,
+    });
+    expect(out).not.toBeNull();
+    expect(out!.active_manual_content.length).toBeLessThan(7000);
+    expect(out!.active_manual_content).toContain('[…truncated]');
+  });
+
+  test('missing knowledge_docs row degrades to empty manual content (still returns)', async () => {
+    const sb = fakeSb({
+      catalog: [FIVE_PILLARS],
+      ledger: [],
+      doc: null,
+    });
+    const out = await resolveTeacherModeContent({
+      supabase: sb,
+      tenantId: 't1',
+      userId: 'u1',
+      activeCapabilityKey: 'five_pillars',
+      nowIso: NOW_ISO,
+    });
+    expect(out).not.toBeNull();
+    expect(out!.active_manual_content).toBe('');
+    expect(out!.active_display_name).toBe('The Five Pillars');
+  });
+
+  test('catalog error returns null (never throws)', async () => {
+    const sb = fakeSb({
+      catalog: null,
+      catalogError: { message: 'simulated db outage' },
+    });
+    const out = await resolveTeacherModeContent({
+      supabase: sb,
+      tenantId: 't1',
+      userId: 'u1',
+      activeCapabilityKey: 'five_pillars',
+      nowIso: NOW_ISO,
+    });
+    expect(out).toBeNull();
+  });
+
+  test('active capability not in catalog returns null', async () => {
+    const sb = fakeSb({
+      catalog: [VITANA_ID],
+      ledger: [],
+    });
+    const out = await resolveTeacherModeContent({
+      supabase: sb,
+      tenantId: 't1',
+      userId: 'u1',
+      activeCapabilityKey: 'capability_does_not_exist',
+      nowIso: NOW_ISO,
+    });
+    expect(out).toBeNull();
+  });
+
+  test('ledger filters out already-tried capabilities from remaining', async () => {
+    const sb = fakeSb({
+      catalog: [FIVE_PILLARS, VITANA_ID, ACTIVITY_MATCH],
+      ledger: [
+        // vitana_id already tried — excluded from remaining.
+        {
+          capability_key: 'vitana_id',
+          awareness_state: 'tried',
+          dismiss_count: 0,
+          last_introduced_at: null,
+        },
+      ],
+      doc: { content: '# manual' },
+    });
+    const out = await resolveTeacherModeContent({
+      supabase: sb,
+      tenantId: 't1',
+      userId: 'u1',
+      activeCapabilityKey: 'five_pillars',
+      nowIso: NOW_ISO,
+    });
+    expect(out).not.toBeNull();
+    const keys = out!.remaining_capabilities.map((c) => c.capability_key);
+    expect(keys).not.toContain('vitana_id'); // filtered by ledger state
+    expect(keys).toContain('activity_match'); // still eligible
+  });
+
+  test('remaining list capped at 5 entries even with a large catalog', async () => {
+    const catalog: FakeRow[] = [
+      FIVE_PILLARS,
+      ...Array.from({ length: 10 }, (_, i) => ({
+        capability_key: `cap_${i}`,
+        display_name: `Capability ${i}`,
+        description: 'desc',
+        manual_path: null,
+        enabled: true,
+        pedagogical_order: 20 + i,
+      })),
+    ];
+    const sb = fakeSb({
+      catalog,
+      ledger: [],
+      doc: { content: '# manual' },
+    });
+    const out = await resolveTeacherModeContent({
+      supabase: sb,
+      tenantId: 't1',
+      userId: 'u1',
+      activeCapabilityKey: 'five_pillars',
+      nowIso: NOW_ISO,
+    });
+    expect(out).not.toBeNull();
+    expect(out!.remaining_capabilities.length).toBeLessThanOrEqual(5);
+  });
+});


### PR DESCRIPTION
## What
Implements the **continuous Teacher Loop**: once Vitana enters Teacher Mode at session start, she keeps teaching capabilities one after the other — chain → check-in → next capability — until the user signals they want to end OR closes the overlay. The user's requirement: **\"no hardcoded rules in contextual intelligence\"** — the state machine is **NOT** in TypeScript. It's in the LLM, driven by an injected system_instruction block + two new tools the LLM calls when its judgment says so.

## How
1. New module \`teacher-content-resolver.ts\` — when wake-brief picks the Teacher at \`/live/session/start\`, fetches:
   - The active capability row (display name, description, manual_path).
   - Markdown content from \`knowledge_docs\` at \`manual_path\` (capped at 6k chars).
   - Up to 5 Remaining capabilities in \`pedagogical_order\`, filtered against the user's ledger.
2. New module \`teacher-mode-prompt.ts\` — builds a system_instruction block that describes **situations and judgment** (not regex / keyword tables) for how the model should react to user replies, plus the two tools it can call.
3. Controller wiring: when the Teacher wins, store \`session.teacherModeContent\` + \`session.teacherModeFirstName\`.
4. Vertex setup envelope: appends \`buildTeacherModeBlock(...)\` to the system_instruction (AFTER the wake-brief override block — turn 1 still spoken by the override, turn 2+ governed by Teacher Mode).
5. Two new tools in the Live API tool catalog:
   - \`teacher_event(capability_key, event_name)\` — calls \`advance_capability_awareness\` RPC (introduced / seen / tried / completed / dismissed).
   - \`end_teaching_session(reason?)\` — emits SSE / WS \`orb_directive: 'end_teaching_session'\` so the overlay closes after the model's farewell.
6. Dispatcher handlers for both tools in orb-live.ts.
7. orb-widget.js handles the new directive — stops accepting audio, lets the farewell play out (~500ms), calls \`_hide()\`. Optional \`onTeachingSessionEnd\` callback for embedders.

## Why this design
The user pushed back hard against any rule table for intent. The LLM sees the raw manual + the curriculum + behavioral guidance (\"if the user signals satisfaction or curiosity, deliver more detail OR chain to next — use your judgment\") and decides. The TS side is just the data pipe + tool handlers.

## Audio safety (lessons from VTID-03102 / VTID-03103)
- System_instruction additive — does NOT displace the wake-brief override (turn 1 still works via VTID-03104 \`Say exactly:\` shape).
- \`end_teaching_session\` fires AFTER the model speaks; the directive triggers UI close, not Gemini silence.
- Tool handlers tolerate DB errors and return messages the model can speak briefly — no silent dead end.
- Teacher Mode block is bounded (6k chars manual + 5 remaining capabilities) so no cognitive-load delay risk.

## Tests
- [x] 7 new tests in \`test/orb/teacher/teacher-content-resolver.test.ts\` lock: catalog fetch, ledger filtering, remaining cap at 5, manual truncation, db-error → null, missing capability → null.
- [x] 4 snapshot updates: tool-catalog picks up the 2 new tools; system_instruction picks up the Teacher Mode block.
- [x] **892 tests pass** across 52 suites.
- [x] \`npm run build\` clean.

## Test plan
- [ ] **Runtime test on vitanaland**:
  1. Tap orb on a fresh user. Vitana should offer a foundation capability (\"The Five Pillars\" or similar).
  2. Say \"ja\" or \"yes\". Vitana should deliver a 2-3 sentence intro from the manual, then ask if you want to learn more.
  3. Say \"nice\" / \"ja\" again. Vitana should chain to the next capability in curriculum order (Daily Loop → Vitana ID → Vitana Index → Life Compass → …).
  4. Say \"nein danke\" / \"I'm done\" / similar. Vitana should speak a warm farewell, then the orb overlay closes automatically.
  5. Open Cloud Run gateway logs and grep \`[VTID-03112]\` to confirm the resolver fired, the Teacher block was injected, and \`teacher_event\` + \`end_teaching_session\` tool calls landed.

## Open follow-ups (NOT in this PR)
- vitana-v1 mobile orb hook for the new directive (LiveKit + the React v1 chain). Mobile is on Vertex via Appilix WebView so the gateway-served orb-widget.js handles them; native React orb (vitana-v1) is a separate slice.
- LiveKit session.py: same system_instruction block injection on the LiveKit path. Today canary is off, so Vertex is what matters.

🤖 Generated with [Claude Code](https://claude.com/claude-code)