### PR TITLE
feat(decision-contract): Phase B.2 seeds — bucket thresholds + greeting templates (VTID-03114)

### DIFF
--- a/DATABASE_SCHEMA.md
+++ b/DATABASE_SCHEMA.md
@@ -405,6 +405,7 @@ CREATE TABLE my_new_table (
 | 2026-04-28 | Added `pillar` + `contribution_vector` columns to `calendar_events` for typed Vitana Index linkage (replaces `pillar:*` wellness_tag heuristic on the frontend) | Claude | claude/vitana-index-navigation-VdSEQ |
 | 2026-05-12 | Added `cover_url`, `cover_generated_at`, `cover_source` to `user_intents` for the Find-a-Match cover-photo flow (user upload OR server-side OpenAI Images generation OR curated fallback). Idx on `(requester_user_id, cover_generated_at)` for per-user rate-limit. | Claude | BOOTSTRAP-INTENT-COVER-GEN |
 | 2026-05-20 | Added `decision_policy` + `policy_render_block` (Phase B.1 of decision-contract refactor). Versioned, tenant-aware, time-bounded externalized policy values + localized render fragments. Schema only — no consumer reads yet (lands in Phase B.4). | Claude | VTID-03113 |
+| 2026-05-20 | Seeded Phase B vertical-proof rows: 5 `decision_policy` rows (session-recency bucket thresholds) + 64 `policy_render_block` rows (8 greeting buckets × 8 languages). English content authoritative; non-`en` rows carry `notes='seeded from en; awaiting translation'`. Still no consumer reads yet — that's Phase B.4. | Claude | VTID-03114 |
 
 ---
 

--- a/supabase/migrations/20260527020000_VTID_03114_policy_seeds.sql
+++ b/supabase/migrations/20260527020000_VTID_03114_policy_seeds.sql
@@ -1,0 +1,228 @@
+-- Phase B.2 (decision-contract refactor) — seed values for B.1 tables.
+--
+-- VTID-03114. Populates `decision_policy` + `policy_render_block`
+-- with the global defaults that the Phase B.4 vertical proof
+-- (greeting block in live-system-instruction.ts) will consume.
+--
+-- Phase B.2 ships data only. No app code reads these rows yet —
+-- the resolver lands in Phase B.3 and the consumer in Phase B.4.
+--
+-- Idempotent: every INSERT is guarded by `WHERE NOT EXISTS` against
+-- the same (key, tenant, version, language). Safe to re-run.
+--
+-- Seed values are byte-identical to the constants currently emitted
+-- by `services/gateway/src/orb/live/instruction/live-system-instruction.ts`
+-- at the time of writing (post-PR #2273, pre-resolver). Two embedded
+-- placeholder tokens survive into the seeded text:
+--
+--   {{greeting_time_of_day}}   -- replaced by 'morning' | 'afternoon'
+--                                 | 'evening' | 'day' at render time
+--   {{short_gap_phrase_menu}}  -- replaced by the locale-specific
+--                                 short-gap phrase block at render time
+--
+-- B.4 owns the substitution. B.2 only stores the template strings.
+-- Non-English render-block rows are seeded with the English template
+-- and `notes='seeded from en; awaiting translation'` per the Phase B
+-- brief (`docs/decision-contract/phase-b-brief.md`). Translations
+-- graduate through a later content-only PR.
+
+-- ===========================================================
+-- decision_policy seeds (5 rows, global defaults, version=1)
+-- ===========================================================
+-- All five describe the session-recency bucket thresholds that
+-- `describeTimeSince()` uses today. Sources cited in `notes`.
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'session.recency_bucket.reconnect_max_seconds', NULL, 1, '120'::jsonb, 'seed',
+       'live-system-instruction.ts:72 (diffSec < 120 → reconnect bucket)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM decision_policy
+  WHERE policy_key = 'session.recency_bucket.reconnect_max_seconds'
+    AND tenant_id IS NULL AND version = 1
+);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'session.recency_bucket.recent_max_minutes', NULL, 1, '15'::jsonb, 'seed',
+       'live-system-instruction.ts:75 (diffMin < 15 → recent bucket)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM decision_policy
+  WHERE policy_key = 'session.recency_bucket.recent_max_minutes'
+    AND tenant_id IS NULL AND version = 1
+);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'session.recency_bucket.same_day_max_hours', NULL, 1, '8'::jsonb, 'seed',
+       'live-system-instruction.ts:78 (diffHour < 8 → same_day bucket)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM decision_policy
+  WHERE policy_key = 'session.recency_bucket.same_day_max_hours'
+    AND tenant_id IS NULL AND version = 1
+);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'session.recency_bucket.today_max_hours', NULL, 1, '24'::jsonb, 'seed',
+       'live-system-instruction.ts:85 (diffHour < 24 → today bucket)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM decision_policy
+  WHERE policy_key = 'session.recency_bucket.today_max_hours'
+    AND tenant_id IS NULL AND version = 1
+);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'session.recency_bucket.week_max_days', NULL, 1, '7'::jsonb, 'seed',
+       'live-system-instruction.ts:91 (diffDay < 7 → week bucket; >= 7 → long)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM decision_policy
+  WHERE policy_key = 'session.recency_bucket.week_max_days'
+    AND tenant_id IS NULL AND version = 1
+);
+
+-- ===========================================================
+-- policy_render_block seeds (64 rows = 8 buckets × 8 languages)
+-- ===========================================================
+-- Templates first (English authoritative). Then a single fan-out
+-- INSERT multiplies by language, attaching the translation-pending
+-- note for every non-`en` row.
+
+WITH bucket_templates AS (
+  SELECT * FROM (VALUES
+    -- bucket=reconnect (no interpolations — verbatim text)
+    ('greeting.bucket.reconnect',
+$$- BUCKET = reconnect (transparent server-side resume — the user did NOT perceive any pause).
+  • DO NOT speak. DO NOT greet. DO NOT acknowledge any "interruption", "reconnection", "resume", "where were we", "I'm back", "I'm listening", "picking up", or anything similar. Saying any of these creates a perceived apology that the user reads as a bug.
+  • Wait for the user to speak. Your next message must be a direct response to the user's next utterance — nothing else.
+  • If the user says nothing, you say nothing. Silence is correct here.$$),
+
+    -- bucket=recent (short-gap menu placeholder)
+    ('greeting.bucket.recent',
+$$- BUCKET = recent (2–15 min since last session).
+  • Do NOT use a formal greeting. NO "Hello <name>!", NO "Hi there!", NO self-introduction. NO user name.
+  • Open with ONE single short phrase. NEVER use two-part sentences joined by dashes or commas.
+{{short_gap_phrase_menu}}
+  • Max ONE short phrase. Warm but direct.$$),
+
+    -- bucket=same_day (short-gap menu placeholder)
+    ('greeting.bucket.same_day',
+$$- BUCKET = same_day (15 min – 8 h since last session).
+  • Light re-engagement. NOT a formal greeting. No user name. NEVER "Hello <name>!" as if you've never met.
+  • Open with ONE single short phrase. NEVER use two-part sentences joined by dashes or commas.
+{{short_gap_phrase_menu}}
+  • Max ONE short phrase. Warm and direct.$$),
+
+    -- bucket=today (greeting_time_of_day placeholder)
+    ('greeting.bucket.today',
+$$- BUCKET = today (8–24 h since last session — this is a NEW-DAY greeting).
+  • ALWAYS open with "Good {{greeting_time_of_day}}, [Name]." using the user's name from memory context.
+  • If no name is available in memory, just say "Good {{greeting_time_of_day}}."
+  • LEGACY-FALLBACK ONLY (use the brain context's candidate when available).
+  • Example follow-up if no candidate exists (pick ONE or skip):
+      "What's on your mind today?"
+      "Where would you like to focus today?"
+  • Max TWO short sentences total: the time-of-day greeting + optionally one question.$$),
+
+    -- bucket=yesterday (greeting_time_of_day placeholder)
+    ('greeting.bucket.yesterday',
+$$- BUCKET = yesterday (this is a NEW-DAY greeting).
+  • ALWAYS open with "Good {{greeting_time_of_day}}, [Name]." using the user's name from memory context.
+  • If no name is available in memory, just say "Good {{greeting_time_of_day}}."
+  • LEGACY-FALLBACK ONLY (use the brain context's candidate when available).
+  • Example follow-up if no candidate exists (pick ONE or skip):
+      "What would you like to explore today?"
+      "Picking up where we left off?"
+  • Max TWO short sentences total: the time-of-day greeting + optionally one question.$$),
+
+    -- bucket=week (greeting_time_of_day placeholder)
+    ('greeting.bucket.week',
+$$- BUCKET = week (2–7 days since last session — this is a NEW-DAY greeting).
+  • ALWAYS open with "Good {{greeting_time_of_day}}, [Name]." using the user's name from memory context.
+  • If no name is available in memory, just say "Good {{greeting_time_of_day}}."
+  • LEGACY-FALLBACK ONLY (use the brain context's candidate when available).
+  • Example follow-up if no candidate exists (pick ONE or skip):
+      "Good to hear from you again — what's been on your mind?"
+      "What would you like to explore today?"
+  • Max TWO short sentences total: the time-of-day greeting + optionally one question.$$),
+
+    -- bucket=long (greeting_time_of_day placeholder)
+    ('greeting.bucket.long',
+$$- BUCKET = long (> 7 days since last session — this is a NEW-DAY greeting).
+  • ALWAYS open with "Good {{greeting_time_of_day}}, [Name]." using the user's name from memory context.
+  • If no name is available in memory, just say "Good {{greeting_time_of_day}}."
+  • LEGACY-FALLBACK ONLY (use the brain context's candidate when available — for >7-day absences the candidate should explicitly acknowledge the gap).
+  • Example follow-up if no candidate exists (pick ONE or skip):
+      "It's been a few days — happy you're back. What's been on your mind?"
+      "What would you like to focus on today?"
+  • Max TWO short sentences total: the time-of-day greeting + optionally one question.$$),
+
+    -- bucket=first (greeting_time_of_day placeholder)
+    ('greeting.bucket.first',
+$$- BUCKET = first (telemetry lookup found no prior session — usually treat as RETURNING with NEW-DAY greeting).
+  • ALWAYS open with "Good {{greeting_time_of_day}}, [Name]." using the user's name from memory context.
+  • If no name is available in memory, just say "Good {{greeting_time_of_day}}."
+  • EXCEPTION: when the brain context's USER AWARENESS shows tenure.stage="day0", the user is genuinely new. Use the FULL INTRODUCTION shape from the brain context's OPENING SHAPE MATRIX — that overrides this fallback.
+  • LEGACY-FALLBACK ONLY (use the brain context's candidate when available).
+  • Example follow-up if no candidate exists (pick ONE or skip):
+      "What's on your mind today?"
+      "Where would you like to focus today?"
+  • Max TWO short sentences total: the time-of-day greeting + optionally one question.$$)
+  ) AS t(block_key, content)
+),
+languages AS (
+  SELECT * FROM (VALUES
+    ('en'), ('de'), ('fr'), ('es'), ('ar'), ('zh'), ('ru'), ('sr')
+  ) AS l(language)
+),
+seed_rows AS (
+  SELECT
+    bt.block_key,
+    l.language,
+    bt.content,
+    CASE
+      WHEN l.language = 'en' THEN 'live-system-instruction.ts switch(bucket) at lines ~226-312'
+      ELSE 'seeded from en; awaiting translation'
+    END AS notes
+  FROM bucket_templates bt
+  CROSS JOIN languages l
+)
+INSERT INTO policy_render_block (block_key, language, tenant_id, version, content, source, notes)
+SELECT
+  s.block_key,
+  s.language,
+  NULL,
+  1,
+  s.content,
+  'seed',
+  s.notes
+FROM seed_rows s
+WHERE NOT EXISTS (
+  SELECT 1 FROM policy_render_block p
+  WHERE p.block_key = s.block_key
+    AND p.language = s.language
+    AND p.tenant_id IS NULL
+    AND p.version = 1
+);
+
+-- ===========================================================
+-- Sanity post-conditions (logged, not enforced)
+-- ===========================================================
+-- A psql interactive run will see these via NOTICE. CI does too.
+
+DO $$
+DECLARE
+  policy_count INTEGER;
+  block_count INTEGER;
+BEGIN
+  SELECT COUNT(*) INTO policy_count
+    FROM decision_policy
+    WHERE source = 'seed' AND tenant_id IS NULL;
+  SELECT COUNT(*) INTO block_count
+    FROM policy_render_block
+    WHERE source = 'seed' AND tenant_id IS NULL;
+  RAISE NOTICE 'VTID-03114 seed counts: decision_policy=%, policy_render_block=%',
+    policy_count, block_count;
+  IF policy_count < 5 THEN
+    RAISE WARNING 'decision_policy seed count below expected 5: %', policy_count;
+  END IF;
+  IF block_count < 64 THEN
+    RAISE WARNING 'policy_render_block seed count below expected 64: %', block_count;
+  END IF;
+END $$;


### PR DESCRIPTION
## Summary

Phase B.2 of the decision-contract refactor. Populates the B.1 tables with the global defaults the Phase B.4 vertical proof will consume.

**Data-only PR — no app code reads these rows yet.** Resolver lands in B.3; consumer (the greeting block in `live-system-instruction.ts`) lands in B.4.

### What lands

**`decision_policy`** — 5 rows, `tenant_id IS NULL`, `version=1`:

| `policy_key` | `value_json` | Source |
|---|---:|---|
| `session.recency_bucket.reconnect_max_seconds` | `120` | `live-system-instruction.ts:72` |
| `session.recency_bucket.recent_max_minutes` | `15` | `live-system-instruction.ts:75` |
| `session.recency_bucket.same_day_max_hours` | `8` | `live-system-instruction.ts:78` |
| `session.recency_bucket.today_max_hours` | `24` | `live-system-instruction.ts:85` |
| `session.recency_bucket.week_max_days` | `7` | `live-system-instruction.ts:91` |

Values are **byte-identical** to the literals currently in `describeTimeSince()`. The brief calls this out as the byte-identical bar.

**`policy_render_block`** — 64 rows = 8 buckets × 8 languages, `tenant_id IS NULL`, `version=1`:

- Buckets: `reconnect | recent | same_day | today | yesterday | week | long | first`
- Languages: `en | de | fr | es | ar | zh | ru | sr` (matches `SUPPORTED_LANGUAGES` in `types.ts`)

English content authoritative — copied verbatim from the switch body at `live-system-instruction.ts:305-392`. Non-`en` rows are seeded with the English template and `notes='seeded from en; awaiting translation'` per the Phase B brief. Translations graduate through a later content-only PR (out of scope here).

### Embedded placeholder tokens

Two tokens survive into the seeded text and are substituted by the Phase B.4 consumer (NOT this PR):

- `{{greeting_time_of_day}}` → `morning | afternoon | evening | day` (today's `greetingTimeOfDay` computation)
- `{{short_gap_phrase_menu}}` → the locale-specific short-gap phrase menu block (today's `appendShortGapPhraseMenu()`)

These survive byte-identical output of the existing switch case after substitution. The brief permits this because the dynamic substitution is the consumer's job, not the seed's.

### Idempotency

Every INSERT is guarded by `WHERE NOT EXISTS` against the same `(key, tenant_id, version[, language])`. Safe to re-run.

A `DO $$ ... $$` block at the bottom logs final seed counts via `RAISE NOTICE` and emits `RAISE WARNING` if counts fall below 5 + 64 (defense in depth, not a hard fail).

### Files

- `supabase/migrations/20260527020000_VTID_03114_policy_seeds.sql` — single seed migration, dependency-ordered after B.1's two schema migrations.
- `DATABASE_SCHEMA.md` — change-log row.

## Test plan

- [ ] PR CI green.
- [ ] `RUN-MIGRATION.yml` applies the seed migration cleanly on `lovable-vitana-vers1`.
- [ ] Post-migration sanity (psql or `execute_sql`):
  - `SELECT COUNT(*) FROM decision_policy WHERE source='seed' AND tenant_id IS NULL;` returns `5`.
  - `SELECT COUNT(*) FROM policy_render_block WHERE source='seed' AND tenant_id IS NULL;` returns `64`.
  - `SELECT block_key, COUNT(*) FROM policy_render_block GROUP BY 1 ORDER BY 1;` returns 8 rows of 8 each.
  - Spot-check `SELECT content FROM policy_render_block WHERE block_key='greeting.bucket.reconnect' AND language='en';` matches the verbatim switch case.
- [ ] No regression in `/orb/chat` (no consumer reads these rows yet, so this is a noop).

🤖 Generated with [Claude Code](https://claude.com/claude-code)