### PR TITLE
feat(decision-contract): Phase B.3 PolicyResolver service + cache warm-up (VTID-03116)

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -1484,6 +1484,18 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
         console.warn('⚠️ AI Personality cache warm failed (non-fatal, using defaults):', error);
       }
 
+      // VTID-03116 (Phase B.3): pre-warm the PolicyResolver cache so the
+      // first inbound request can sync-read from `decision_policy` /
+      // `policy_render_block`. Warm failure is non-fatal — the resolver
+      // falls back to caller-supplied defaultValue, never crashes.
+      try {
+        const { warmPolicyResolverCache } = require('./services/decision-contract');
+        await warmPolicyResolverCache();
+        console.log('📜 PolicyResolver cache pre-warmed (decision-contract Phase B.3)');
+      } catch (error) {
+        console.warn('⚠️ PolicyResolver cache warm failed (non-fatal, using defaults):', error);
+      }
+
       // VTID-NAV-02: Pre-warm Navigator catalog DB cache + start periodic refresh
       try {
         warmNavCatalogCache();

--- a/services/gateway/src/services/decision-contract/index.ts
+++ b/services/gateway/src/services/decision-contract/index.ts
@@ -41,3 +41,22 @@ export {
   renderSystemInstructionFromContext,
   type RenderOptions,
 } from './renderer';
+
+// VTID-03116 (Phase B.3) — PolicyResolver service: sync gets after a 15s
+// cache warm-up. Both consumers and tests import from here, never from
+// the implementation files directly, so the boundary is grep-auditable.
+export {
+  POLICY_KEYS,
+  RENDER_BLOCK_KEYS,
+  type PolicyKey,
+  type RenderBlockKey,
+} from './policy-keys';
+
+export {
+  getPolicyResolver,
+  warmPolicyResolverCache,
+  configurePolicyResolverForTests,
+  __resetPolicyResolverForTests,
+  type PolicyResolver,
+  type PolicyResolverTestSeed,
+} from './policy-resolver';

--- a/services/gateway/src/services/decision-contract/policy-keys.ts
+++ b/services/gateway/src/services/decision-contract/policy-keys.ts
@@ -1,0 +1,52 @@
+// Phase B.3 (decision-contract refactor) — typed catalog of policy keys.
+//
+// VTID-03116. Every consumer of `PolicyResolver` imports its key from this
+// file. Stringly-typed keys scattered across the codebase are explicitly
+// forbidden by the Phase B brief (`docs/decision-contract/phase-b-brief.md`,
+// section "What to keep saying NO to").
+//
+// Adding a new key:
+//   1. Add it to the `POLICY_KEYS` const below.
+//   2. Add a seed row to a new migration so the resolver returns something
+//      sane on a fresh deploy. The resolver's last-resort fallback is the
+//      hard-coded `defaultValue` callers pass — that exists for safety, not
+//      as the production source of truth.
+//   3. Wire the consumer to call `getValue(POLICY_KEYS.<key>, { defaultValue: ... })`.
+
+export const POLICY_KEYS = {
+  // ---- session.recency_bucket.* ---------------------------------
+  // Thresholds that drive `describeTimeSince()` in
+  // services/gateway/src/orb/live/instruction/live-system-instruction.ts.
+  // Seeded by Phase B.2 (VTID-03114).
+  SESSION_RECENCY_RECONNECT_MAX_SECONDS:
+    'session.recency_bucket.reconnect_max_seconds',
+  SESSION_RECENCY_RECENT_MAX_MINUTES:
+    'session.recency_bucket.recent_max_minutes',
+  SESSION_RECENCY_SAME_DAY_MAX_HOURS:
+    'session.recency_bucket.same_day_max_hours',
+  SESSION_RECENCY_TODAY_MAX_HOURS:
+    'session.recency_bucket.today_max_hours',
+  SESSION_RECENCY_WEEK_MAX_DAYS:
+    'session.recency_bucket.week_max_days',
+} as const;
+
+export type PolicyKey = (typeof POLICY_KEYS)[keyof typeof POLICY_KEYS];
+
+// ---- policy_render_block keys -----------------------------------
+// Greeting bucket prompt fragments. 8 buckets, 8 languages each.
+// Seeded by Phase B.2 (VTID-03114). Consumed by the Phase B.4 vertical
+// proof (greeting block in live-system-instruction.ts).
+
+export const RENDER_BLOCK_KEYS = {
+  GREETING_BUCKET_RECONNECT: 'greeting.bucket.reconnect',
+  GREETING_BUCKET_RECENT: 'greeting.bucket.recent',
+  GREETING_BUCKET_SAME_DAY: 'greeting.bucket.same_day',
+  GREETING_BUCKET_TODAY: 'greeting.bucket.today',
+  GREETING_BUCKET_YESTERDAY: 'greeting.bucket.yesterday',
+  GREETING_BUCKET_WEEK: 'greeting.bucket.week',
+  GREETING_BUCKET_LONG: 'greeting.bucket.long',
+  GREETING_BUCKET_FIRST: 'greeting.bucket.first',
+} as const;
+
+export type RenderBlockKey =
+  (typeof RENDER_BLOCK_KEYS)[keyof typeof RENDER_BLOCK_KEYS];

--- a/services/gateway/src/services/decision-contract/policy-resolver.ts
+++ b/services/gateway/src/services/decision-contract/policy-resolver.ts
@@ -1,0 +1,341 @@
+// Phase B.3 (decision-contract refactor) — PolicyResolver service.
+//
+// VTID-03116. Sync-cached, never-throws resolver for the two Phase B tables:
+//   - decision_policy        (numeric / enum / small-JSON policy values)
+//   - policy_render_block    (localized prompt fragments)
+//
+// Resolution rules (identical for both tables):
+//   For a given (key, [language,] tenant_id, now), pick the highest
+//   `version` row where:
+//     effective_from <= now
+//     AND (effective_until IS NULL OR effective_until > now)
+//   A tenant-specific row wins over `tenant_id IS NULL` (global default).
+//
+// Discipline (per `docs/decision-contract/phase-b-brief.md`):
+//   - Cache TTL: 15s (matches `livekit-canary-config`).
+//   - Never throws on resolution miss — falls back to `tenant_id IS NULL`
+//     first, then to the caller-provided `defaultValue` (logged once at
+//     boot when used). A miss must NOT crash a voice session.
+//   - `getValue` returns the unwrapped JSONB value via TypeScript generics.
+//   - Telemetry: structured console.warn on every fallback fire under the
+//     `[PolicyResolver][decision_contract.policy.miss]` prefix. Routing to
+//     OASIS is a Phase B follow-up (requires extending CicdEventType, which
+//     is out of B.3 scope).
+//
+// API surface mirrors the brief:
+//   getValue<T>(key, opts?) -> T
+//   getRenderBlock(key, language, opts?) -> string
+//   refresh() -> Promise<void>
+//   warmPolicyResolverCache() -> Promise<void>   (boot hook)
+//   getPolicyResolver() -> PolicyResolver         (singleton)
+//   configurePolicyResolverForTests(seed) -> void
+//   __resetPolicyResolverForTests() -> void
+
+import { getSupabase } from '../../lib/supabase';
+
+const CACHE_TTL_MS = 15_000;
+const TELEMETRY_PREFIX = '[PolicyResolver][decision_contract.policy.miss]';
+
+interface DecisionPolicyRow {
+  policy_key: string;
+  tenant_id: string | null;
+  version: number;
+  value_json: unknown;
+  effective_from: string; // ISO timestamp
+  effective_until: string | null;
+}
+
+interface PolicyRenderBlockRow {
+  block_key: string;
+  language: string;
+  tenant_id: string | null;
+  version: number;
+  content: string;
+  effective_from: string;
+  effective_until: string | null;
+}
+
+// Cache shape: maps keyed by (key[, language]) → all rows for that key
+// (both global and per-tenant). Resolution walks the candidate list to
+// pick the winner for a given (tenant_id, now).
+type DecisionPolicyCache = Map<string, DecisionPolicyRow[]>;
+type PolicyRenderBlockCache = Map<string, PolicyRenderBlockRow[]>;
+
+interface CacheSnapshot {
+  decisionPolicy: DecisionPolicyCache;
+  policyRenderBlock: PolicyRenderBlockCache;
+  warmedAt: number;
+}
+
+let cache: CacheSnapshot | null = null;
+let refreshInflight: Promise<void> | null = null;
+let refreshTimer: NodeJS.Timeout | null = null;
+// Track which (key, defaultUsed) pairs have already logged a miss, so a
+// hot loop doesn't spam the logger.
+const loggedMisses = new Set<string>();
+
+export interface PolicyResolver {
+  getValue<T>(
+    key: string,
+    opts?: { tenantId?: string | null; defaultValue?: T },
+  ): T;
+  getRenderBlock(
+    key: string,
+    language: string,
+    opts?: { tenantId?: string | null; defaultValue?: string },
+  ): string;
+  refresh(): Promise<void>;
+}
+
+function blockMapKey(blockKey: string, language: string): string {
+  return `${blockKey}${language}`;
+}
+
+function isEffective(
+  row: { effective_from: string; effective_until: string | null },
+  nowMs: number,
+): boolean {
+  const fromMs = Date.parse(row.effective_from);
+  if (Number.isFinite(fromMs) && fromMs > nowMs) return false;
+  if (row.effective_until == null) return true;
+  const untilMs = Date.parse(row.effective_until);
+  return Number.isFinite(untilMs) ? untilMs > nowMs : true;
+}
+
+// Pick the winner across candidate rows: prefer tenant-specific over
+// global, then highest `version`. Caller guarantees `candidates` are all
+// for the same logical key (e.g. same `policy_key`).
+function pickWinner<
+  R extends {
+    tenant_id: string | null;
+    version: number;
+    effective_from: string;
+    effective_until: string | null;
+  },
+>(
+  candidates: R[],
+  tenantId: string | null | undefined,
+  nowMs: number,
+): R | null {
+  let bestTenant: R | null = null;
+  let bestGlobal: R | null = null;
+  for (const row of candidates) {
+    if (!isEffective(row, nowMs)) continue;
+    if (tenantId && row.tenant_id === tenantId) {
+      if (!bestTenant || row.version > bestTenant.version) bestTenant = row;
+    } else if (row.tenant_id === null) {
+      if (!bestGlobal || row.version > bestGlobal.version) bestGlobal = row;
+    }
+  }
+  return bestTenant ?? bestGlobal;
+}
+
+function logMissOnce(tag: string, message: string): void {
+  if (loggedMisses.has(tag)) return;
+  loggedMisses.add(tag);
+  console.warn(`${TELEMETRY_PREFIX} ${message}`);
+}
+
+function getValueImpl<T>(
+  key: string,
+  opts?: { tenantId?: string | null; defaultValue?: T },
+): T {
+  const tenantId = opts?.tenantId ?? null;
+  const fallback = opts?.defaultValue;
+  const nowMs = Date.now();
+  const rows = cache?.decisionPolicy.get(key);
+  if (!rows || rows.length === 0) {
+    logMissOnce(
+      `value:${key}:${tenantId ?? 'GLOBAL'}:no-cache`,
+      `no cached rows for policy_key="${key}" tenant_id="${tenantId ?? 'GLOBAL'}" — using defaultValue`,
+    );
+    return fallback as T;
+  }
+  const winner = pickWinner(rows, tenantId, nowMs);
+  if (!winner) {
+    logMissOnce(
+      `value:${key}:${tenantId ?? 'GLOBAL'}:no-effective`,
+      `no effective row for policy_key="${key}" tenant_id="${tenantId ?? 'GLOBAL'}" — using defaultValue`,
+    );
+    return fallback as T;
+  }
+  return winner.value_json as T;
+}
+
+function getRenderBlockImpl(
+  key: string,
+  language: string,
+  opts?: { tenantId?: string | null; defaultValue?: string },
+): string {
+  const tenantId = opts?.tenantId ?? null;
+  const fallback = opts?.defaultValue ?? '';
+  const nowMs = Date.now();
+  // Try (key, language) first; fall back to (key, 'en') if requested
+  // language has no rows so the consumer still gets a sensible string.
+  const primary = cache?.policyRenderBlock.get(blockMapKey(key, language));
+  const winner = primary ? pickWinner(primary, tenantId, nowMs) : null;
+  if (winner) return winner.content;
+
+  if (language !== 'en') {
+    const enRows = cache?.policyRenderBlock.get(blockMapKey(key, 'en'));
+    const enWinner = enRows ? pickWinner(enRows, tenantId, nowMs) : null;
+    if (enWinner) {
+      logMissOnce(
+        `block:${key}:${language}:${tenantId ?? 'GLOBAL'}:fallback-en`,
+        `no row for block_key="${key}" language="${language}" — falling back to en`,
+      );
+      return enWinner.content;
+    }
+  }
+  logMissOnce(
+    `block:${key}:${language}:${tenantId ?? 'GLOBAL'}:no-cache`,
+    `no cached row for block_key="${key}" language="${language}" tenant_id="${tenantId ?? 'GLOBAL'}" — using defaultValue`,
+  );
+  return fallback;
+}
+
+async function fetchAll(): Promise<CacheSnapshot> {
+  const supa = getSupabase();
+  const snap: CacheSnapshot = {
+    decisionPolicy: new Map(),
+    policyRenderBlock: new Map(),
+    warmedAt: Date.now(),
+  };
+  if (!supa) {
+    return snap;
+  }
+  try {
+    const { data: pol, error: polErr } = await supa
+      .from('decision_policy')
+      .select('policy_key, tenant_id, version, value_json, effective_from, effective_until');
+    if (polErr) {
+      // Table missing pre-migration is normal in early environments; treat
+      // any error as "no rows" so the resolver degrades to defaults rather
+      // than throwing.
+      if (!/relation .*decision_policy.* does not exist/i.test(polErr.message)) {
+        console.warn(`${TELEMETRY_PREFIX} decision_policy fetch failed: ${polErr.message}`);
+      }
+    } else if (Array.isArray(pol)) {
+      for (const row of pol as DecisionPolicyRow[]) {
+        const list = snap.decisionPolicy.get(row.policy_key);
+        if (list) list.push(row);
+        else snap.decisionPolicy.set(row.policy_key, [row]);
+      }
+    }
+  } catch (e: any) {
+    console.warn(`${TELEMETRY_PREFIX} decision_policy fetch threw: ${e?.message ?? e}`);
+  }
+  try {
+    const { data: blk, error: blkErr } = await supa
+      .from('policy_render_block')
+      .select('block_key, language, tenant_id, version, content, effective_from, effective_until');
+    if (blkErr) {
+      if (!/relation .*policy_render_block.* does not exist/i.test(blkErr.message)) {
+        console.warn(`${TELEMETRY_PREFIX} policy_render_block fetch failed: ${blkErr.message}`);
+      }
+    } else if (Array.isArray(blk)) {
+      for (const row of blk as PolicyRenderBlockRow[]) {
+        const k = blockMapKey(row.block_key, row.language);
+        const list = snap.policyRenderBlock.get(k);
+        if (list) list.push(row);
+        else snap.policyRenderBlock.set(k, [row]);
+      }
+    }
+  } catch (e: any) {
+    console.warn(`${TELEMETRY_PREFIX} policy_render_block fetch threw: ${e?.message ?? e}`);
+  }
+  return snap;
+}
+
+async function refreshImpl(): Promise<void> {
+  if (refreshInflight) return refreshInflight;
+  refreshInflight = (async () => {
+    try {
+      const next = await fetchAll();
+      cache = next;
+    } finally {
+      refreshInflight = null;
+    }
+  })();
+  return refreshInflight;
+}
+
+/**
+ * Block at boot until the first fetch resolves so the first inbound
+ * request sees populated caches. Never throws.
+ *
+ * Also starts a 15s background refresh timer if not already running.
+ */
+export async function warmPolicyResolverCache(): Promise<void> {
+  await refreshImpl();
+  if (!refreshTimer) {
+    refreshTimer = setInterval(() => {
+      // Fire-and-forget background refresh; any error is logged inside.
+      void refreshImpl();
+    }, CACHE_TTL_MS);
+    // Don't keep the event loop alive solely for this timer (matches the
+    // "non-fatal background warmers" pattern used elsewhere in index.ts).
+    if (typeof refreshTimer.unref === 'function') refreshTimer.unref();
+  }
+}
+
+const resolverSingleton: PolicyResolver = {
+  getValue<T>(
+    key: string,
+    opts?: { tenantId?: string | null; defaultValue?: T },
+  ): T {
+    return getValueImpl<T>(key, opts);
+  },
+  getRenderBlock(
+    key: string,
+    language: string,
+    opts?: { tenantId?: string | null; defaultValue?: string },
+  ): string {
+    return getRenderBlockImpl(key, language, opts);
+  },
+  refresh: refreshImpl,
+};
+
+export function getPolicyResolver(): PolicyResolver {
+  return resolverSingleton;
+}
+
+// ---- test support ------------------------------------------------------
+// Tests can prime the cache directly so they don't have to spin up
+// Supabase. The shape matches what `fetchAll` would produce.
+
+export interface PolicyResolverTestSeed {
+  decisionPolicy?: DecisionPolicyRow[];
+  policyRenderBlock?: PolicyRenderBlockRow[];
+}
+
+export function configurePolicyResolverForTests(seed: PolicyResolverTestSeed): void {
+  const snap: CacheSnapshot = {
+    decisionPolicy: new Map(),
+    policyRenderBlock: new Map(),
+    warmedAt: Date.now(),
+  };
+  for (const row of seed.decisionPolicy ?? []) {
+    const list = snap.decisionPolicy.get(row.policy_key);
+    if (list) list.push(row);
+    else snap.decisionPolicy.set(row.policy_key, [row]);
+  }
+  for (const row of seed.policyRenderBlock ?? []) {
+    const k = blockMapKey(row.block_key, row.language);
+    const list = snap.policyRenderBlock.get(k);
+    if (list) list.push(row);
+    else snap.policyRenderBlock.set(k, [row]);
+  }
+  cache = snap;
+  loggedMisses.clear();
+}
+
+export function __resetPolicyResolverForTests(): void {
+  cache = null;
+  refreshInflight = null;
+  loggedMisses.clear();
+  if (refreshTimer) {
+    clearInterval(refreshTimer);
+    refreshTimer = null;
+  }
+}

--- a/services/gateway/test/services/decision-contract/policy-resolver.test.ts
+++ b/services/gateway/test/services/decision-contract/policy-resolver.test.ts
@@ -1,0 +1,322 @@
+// VTID-03116 (Phase B.3) — PolicyResolver tests.
+//
+// The resolver itself is the unit under test. Tests prime the in-memory
+// cache via `configurePolicyResolverForTests` so no Supabase or network
+// roundtrip is involved — the cache shape is the contract.
+
+import {
+  POLICY_KEYS,
+  RENDER_BLOCK_KEYS,
+  configurePolicyResolverForTests,
+  __resetPolicyResolverForTests,
+  getPolicyResolver,
+} from '../../../src/services/decision-contract';
+
+const TENANT_A = '00000000-0000-0000-0000-000000000aaa';
+const TENANT_B = '00000000-0000-0000-0000-000000000bbb';
+
+const RECENT_PAST = new Date(Date.now() - 60_000).toISOString();
+const FAR_PAST = new Date(Date.now() - 86_400_000).toISOString();
+const FAR_FUTURE = new Date(Date.now() + 86_400_000).toISOString();
+const RECENT_FUTURE = new Date(Date.now() + 60_000).toISOString();
+
+beforeEach(() => {
+  __resetPolicyResolverForTests();
+});
+
+afterAll(() => {
+  __resetPolicyResolverForTests();
+});
+
+describe('PolicyResolver — getValue', () => {
+  it('returns the unwrapped value when one effective row exists', () => {
+    configurePolicyResolverForTests({
+      decisionPolicy: [
+        {
+          policy_key: POLICY_KEYS.SESSION_RECENCY_RECONNECT_MAX_SECONDS,
+          tenant_id: null,
+          version: 1,
+          value_json: 120,
+          effective_from: RECENT_PAST,
+          effective_until: null,
+        },
+      ],
+    });
+    const v = getPolicyResolver().getValue<number>(
+      POLICY_KEYS.SESSION_RECENCY_RECONNECT_MAX_SECONDS,
+    );
+    expect(v).toBe(120);
+  });
+
+  it('picks the highest version among effective candidates', () => {
+    configurePolicyResolverForTests({
+      decisionPolicy: [
+        {
+          policy_key: POLICY_KEYS.SESSION_RECENCY_RECENT_MAX_MINUTES,
+          tenant_id: null,
+          version: 1,
+          value_json: 15,
+          effective_from: FAR_PAST,
+          effective_until: null,
+        },
+        {
+          policy_key: POLICY_KEYS.SESSION_RECENCY_RECENT_MAX_MINUTES,
+          tenant_id: null,
+          version: 2,
+          value_json: 20,
+          effective_from: RECENT_PAST,
+          effective_until: null,
+        },
+      ],
+    });
+    expect(
+      getPolicyResolver().getValue<number>(
+        POLICY_KEYS.SESSION_RECENCY_RECENT_MAX_MINUTES,
+      ),
+    ).toBe(20);
+  });
+
+  it('skips rows whose effective_from is in the future', () => {
+    configurePolicyResolverForTests({
+      decisionPolicy: [
+        {
+          policy_key: POLICY_KEYS.SESSION_RECENCY_RECENT_MAX_MINUTES,
+          tenant_id: null,
+          version: 1,
+          value_json: 15,
+          effective_from: RECENT_PAST,
+          effective_until: null,
+        },
+        {
+          policy_key: POLICY_KEYS.SESSION_RECENCY_RECENT_MAX_MINUTES,
+          tenant_id: null,
+          version: 2,
+          value_json: 99,
+          effective_from: RECENT_FUTURE,
+          effective_until: null,
+        },
+      ],
+    });
+    expect(
+      getPolicyResolver().getValue<number>(
+        POLICY_KEYS.SESSION_RECENCY_RECENT_MAX_MINUTES,
+      ),
+    ).toBe(15);
+  });
+
+  it('skips rows whose effective_until has passed', () => {
+    configurePolicyResolverForTests({
+      decisionPolicy: [
+        {
+          policy_key: POLICY_KEYS.SESSION_RECENCY_RECENT_MAX_MINUTES,
+          tenant_id: null,
+          version: 2,
+          value_json: 99,
+          effective_from: FAR_PAST,
+          effective_until: RECENT_PAST,
+        },
+        {
+          policy_key: POLICY_KEYS.SESSION_RECENCY_RECENT_MAX_MINUTES,
+          tenant_id: null,
+          version: 1,
+          value_json: 15,
+          effective_from: FAR_PAST,
+          effective_until: null,
+        },
+      ],
+    });
+    expect(
+      getPolicyResolver().getValue<number>(
+        POLICY_KEYS.SESSION_RECENCY_RECENT_MAX_MINUTES,
+      ),
+    ).toBe(15);
+  });
+
+  it('prefers a tenant-specific row over a global default', () => {
+    configurePolicyResolverForTests({
+      decisionPolicy: [
+        {
+          policy_key: POLICY_KEYS.SESSION_RECENCY_TODAY_MAX_HOURS,
+          tenant_id: null,
+          version: 1,
+          value_json: 24,
+          effective_from: RECENT_PAST,
+          effective_until: null,
+        },
+        {
+          policy_key: POLICY_KEYS.SESSION_RECENCY_TODAY_MAX_HOURS,
+          tenant_id: TENANT_A,
+          version: 1,
+          value_json: 12,
+          effective_from: RECENT_PAST,
+          effective_until: null,
+        },
+      ],
+    });
+    expect(
+      getPolicyResolver().getValue<number>(
+        POLICY_KEYS.SESSION_RECENCY_TODAY_MAX_HOURS,
+        { tenantId: TENANT_A },
+      ),
+    ).toBe(12);
+    // No tenant filter still returns the global default.
+    expect(
+      getPolicyResolver().getValue<number>(
+        POLICY_KEYS.SESSION_RECENCY_TODAY_MAX_HOURS,
+      ),
+    ).toBe(24);
+    // Caller for a different tenant gets the global default.
+    expect(
+      getPolicyResolver().getValue<number>(
+        POLICY_KEYS.SESSION_RECENCY_TODAY_MAX_HOURS,
+        { tenantId: TENANT_B },
+      ),
+    ).toBe(24);
+  });
+
+  it('returns the supplied defaultValue on cache miss (never throws)', () => {
+    configurePolicyResolverForTests({});
+    expect(
+      getPolicyResolver().getValue<number>('session.never_seeded', {
+        defaultValue: 7,
+      }),
+    ).toBe(7);
+  });
+
+  it('returns the supplied defaultValue when all candidates are expired', () => {
+    configurePolicyResolverForTests({
+      decisionPolicy: [
+        {
+          policy_key: 'session.expired',
+          tenant_id: null,
+          version: 1,
+          value_json: 42,
+          effective_from: FAR_PAST,
+          effective_until: RECENT_PAST,
+        },
+      ],
+    });
+    expect(
+      getPolicyResolver().getValue<number>('session.expired', {
+        defaultValue: -1,
+      }),
+    ).toBe(-1);
+  });
+});
+
+describe('PolicyResolver — getRenderBlock', () => {
+  it('returns the content for a matching (block_key, language) row', () => {
+    configurePolicyResolverForTests({
+      policyRenderBlock: [
+        {
+          block_key: RENDER_BLOCK_KEYS.GREETING_BUCKET_RECONNECT,
+          language: 'en',
+          tenant_id: null,
+          version: 1,
+          content: 'EN content',
+          effective_from: RECENT_PAST,
+          effective_until: null,
+        },
+      ],
+    });
+    expect(
+      getPolicyResolver().getRenderBlock(
+        RENDER_BLOCK_KEYS.GREETING_BUCKET_RECONNECT,
+        'en',
+      ),
+    ).toBe('EN content');
+  });
+
+  it('falls back to en when the requested language has no row', () => {
+    configurePolicyResolverForTests({
+      policyRenderBlock: [
+        {
+          block_key: RENDER_BLOCK_KEYS.GREETING_BUCKET_RECENT,
+          language: 'en',
+          tenant_id: null,
+          version: 1,
+          content: 'EN fallback',
+          effective_from: RECENT_PAST,
+          effective_until: null,
+        },
+      ],
+    });
+    expect(
+      getPolicyResolver().getRenderBlock(
+        RENDER_BLOCK_KEYS.GREETING_BUCKET_RECENT,
+        'de',
+      ),
+    ).toBe('EN fallback');
+  });
+
+  it('returns defaultValue when neither requested language nor en exists', () => {
+    configurePolicyResolverForTests({});
+    expect(
+      getPolicyResolver().getRenderBlock(
+        RENDER_BLOCK_KEYS.GREETING_BUCKET_LONG,
+        'fr',
+        { defaultValue: 'safe-default' },
+      ),
+    ).toBe('safe-default');
+  });
+
+  it('prefers a tenant-specific row over global for the same (block_key, language)', () => {
+    configurePolicyResolverForTests({
+      policyRenderBlock: [
+        {
+          block_key: RENDER_BLOCK_KEYS.GREETING_BUCKET_TODAY,
+          language: 'en',
+          tenant_id: null,
+          version: 1,
+          content: 'GLOBAL',
+          effective_from: RECENT_PAST,
+          effective_until: null,
+        },
+        {
+          block_key: RENDER_BLOCK_KEYS.GREETING_BUCKET_TODAY,
+          language: 'en',
+          tenant_id: TENANT_A,
+          version: 1,
+          content: 'TENANT_A',
+          effective_from: RECENT_PAST,
+          effective_until: null,
+        },
+      ],
+    });
+    expect(
+      getPolicyResolver().getRenderBlock(
+        RENDER_BLOCK_KEYS.GREETING_BUCKET_TODAY,
+        'en',
+        { tenantId: TENANT_A },
+      ),
+    ).toBe('TENANT_A');
+    expect(
+      getPolicyResolver().getRenderBlock(
+        RENDER_BLOCK_KEYS.GREETING_BUCKET_TODAY,
+        'en',
+      ),
+    ).toBe('GLOBAL');
+  });
+});
+
+describe('PolicyResolver — resilience', () => {
+  it('never throws when the cache is empty', () => {
+    __resetPolicyResolverForTests();
+    expect(() =>
+      getPolicyResolver().getValue<number>('any.key', { defaultValue: 0 }),
+    ).not.toThrow();
+    expect(() =>
+      getPolicyResolver().getRenderBlock('any.block', 'en', {
+        defaultValue: '',
+      }),
+    ).not.toThrow();
+  });
+
+  it('warm-up against a missing Supabase env is non-fatal', async () => {
+    // Tests are run without SUPABASE_URL, so getSupabase() returns null
+    // (see services/gateway/src/lib/supabase.ts). `refresh()` should
+    // resolve with empty caches and not throw.
+    __resetPolicyResolverForTests();
+    await expect(getPolicyResolver().refresh()).resolves.toBeUndefined();
+  });
+});


### PR DESCRIPTION
## Summary

Phase B.3 of the decision-contract refactor. Ships the sync-cached, never-throws resolver that reads `decision_policy` + `policy_render_block` (created in B.1, seeded in B.2). Boot-wired so the first inbound request can sync-read; **no consumer reads from the resolver yet** — Phase B.4 wires the greeting block.

### What lands

- **`services/gateway/src/services/decision-contract/policy-keys.ts`** — typed `POLICY_KEYS` + `RENDER_BLOCK_KEYS` constants. Every consumer of the resolver imports its key from here (stringly-typed keys scattered across the codebase are forbidden by the brief).
- **`services/gateway/src/services/decision-contract/policy-resolver.ts`** — singleton resolver:
  - 15s in-memory cache + 15s background-refresh timer (timer is `unref()`'d so it doesn't keep the loop alive).
  - Sync `getValue<T>(key, opts?)` and `getRenderBlock(key, language, opts?)`.
  - Resolution rules: highest `version` among effective rows; tenant-specific beats `tenant_id IS NULL`; expired `effective_until` skipped; future `effective_from` skipped.
  - **Never throws.** On miss, returns caller-supplied `defaultValue`; logs once per `(key, tenant, reason)` under `[PolicyResolver][decision_contract.policy.miss]`.
  - `getRenderBlock` falls back to `language='en'` before `defaultValue` so a missing translation still produces a sensible string.
  - Test override: `configurePolicyResolverForTests({ seed })` + `__resetPolicyResolverForTests()`.
- **`services/gateway/src/services/decision-contract/index.ts`** — barrel exports the new surface so the boundary is grep-auditable.
- **`services/gateway/src/index.ts`** — boot hook calls `warmPolicyResolverCache()` alongside the AI Personality warm. Warm failure is non-fatal (log + continue).
- **`services/gateway/test/services/decision-contract/policy-resolver.test.ts`** — 13 tests, all green locally.

### Tests (13/13 ✅)

```
PolicyResolver — getValue
  ✓ returns the unwrapped value when one effective row exists
  ✓ picks the highest version among effective candidates
  ✓ skips rows whose effective_from is in the future
  ✓ skips rows whose effective_until has passed
  ✓ prefers a tenant-specific row over a global default
  ✓ returns the supplied defaultValue on cache miss (never throws)
  ✓ returns the supplied defaultValue when all candidates are expired
PolicyResolver — getRenderBlock
  ✓ returns the content for a matching (block_key, language) row
  ✓ falls back to en when the requested language has no row
  ✓ returns defaultValue when neither requested language nor en exists
  ✓ prefers a tenant-specific row over global for the same (block_key, language)
PolicyResolver — resilience
  ✓ never throws when the cache is empty
  ✓ warm-up against a missing Supabase env is non-fatal
```

`npm run build` clean locally.

### Telemetry note

The brief calls for emitting `decision_contract.policy.miss` as an OASIS event. That requires extending the strict `CicdEventType` union, which is outside B.3 scope. B.3 logs structured warnings under the canonical prefix; routing to OASIS is a follow-up that can land without touching the resolver call sites.

### Phase plan (still standing)

1. ✅ **B.1** — schema migrations (PR #2276, merged).
2. ✅ **B.2** — seed migration (PR #2278, merged + migration applied).
3. ➡️ **B.3** — this PR.
4. **B.4** — vertical proof: migrate the `live-system-instruction.ts` greeting block to read via the resolver. Snapshot tests prove byte-identical prompt output.

## Test plan

- [ ] PR CI green (unit suite picks up the new test file).
- [ ] EXEC-DEPLOY after merge (touches `services/gateway/**`, so Auto Deploy should dispatch).
- [ ] Post-deploy: `/alive` → 200 JSON.
- [ ] Boot log line `📜 PolicyResolver cache pre-warmed (decision-contract Phase B.3)` present in the new revision's startup logs.
- [ ] One smoke `/orb/chat` to confirm no regression (no consumer reads the resolver yet, so this is a noop in practice).

🤖 Generated with [Claude Code](https://claude.com/claude-code)