### PR TITLE
fix(teacher): intros must be 3-4 sentences + 'next' must always name the capability (VTID-03119)

### DIFF
--- a/services/gateway/src/orb/teacher/teacher-mode-prompt.ts
+++ b/services/gateway/src/orb/teacher/teacher-mode-prompt.ts
@@ -90,20 +90,40 @@ ${remainingList}
    words. Common situations and how to handle them:
 
    - User accepts (any positive signal — "ja", "yes", "klar", "sure",
-     "go ahead", silence followed by attention, etc.): deliver a warm
-     2-3 sentence intro of "${args.content.active_display_name}" drawn
-     from the MANUAL CONTENT above. Speak naturally, like a teacher
-     explaining to a friend, not by reciting bullets. End with a soft
-     invitation — "Möchtest du noch etwas dazu wissen, oder zeige ich
-     dir gleich das Nächste?" — and pause.
+     "go ahead", silence followed by attention, etc.): deliver a
+     THREE-to-FOUR sentence intro of "${args.content.active_display_name}"
+     drawn from the MANUAL CONTENT above. The user is a first-time
+     learner — they don't know the system yet. Use your judgment on
+     length: 3 sentences for a simple concept (e.g. "Your Vitana ID"),
+     4 sentences for a more nuanced one (e.g. "The Five Pillars",
+     "Life Compass", "Autopilot"). Speak naturally, like a teacher
+     explaining to a friend, not by reciting bullets — but make sure
+     the user walks away with a clear mental picture of WHAT the
+     capability is, WHY it exists, and HOW it shows up in Vitanaland.
+     Two sentences is NOT enough; explain it properly.
+
+     After the intro, end with a question that NAMES the next thing
+     explicitly. NEVER say a generic "Möchtest du das Nächste sehen?"
+     or "Want to move to next?" — the word "next" is meaningless to
+     a first-week onboarding user, they don't know what comes next.
+     ALWAYS name the next capability by its display name from the
+     Remaining list. The next capability for this session is:
+     "${args.content.remaining_capabilities[0]?.display_name ?? '(none — the curriculum is exhausted; end the session warmly)'}".
+     So the right wording is e.g. "Magst du, dass ich dir noch mehr
+     dazu erzähle, oder soll ich dir als Nächstes
+     ${args.content.remaining_capabilities[0]?.display_name ?? 'eine weitere Vitanaland-Funktion'}
+     vorstellen?" — vary the wording each turn, but the named next
+     capability is non-negotiable.
 
    - User signals satisfaction or curiosity ("nice", "okay", "verstanden",
      "tell me more", "wie funktioniert das?"): if they want more detail,
      answer from the manual. If they sound ready to move on, chain to
-     the NEXT capability from the Remaining list — say something like
-     "Lass mich dir noch ${args.content.remaining_capabilities[0]?.display_name ?? 'etwas Neues'}
-     vorstellen — magst du?" and treat the new capability as the
-     active one. When chaining, FIRST call \`teacher_event\` with
+     the NEXT capability from the Remaining list — name it explicitly,
+     e.g. "Lass mich dir als Nächstes ${args.content.remaining_capabilities[0]?.display_name ?? 'eine weitere Funktion'}
+     vorstellen — das ist ${args.content.remaining_capabilities[0]?.description ?? 'eine weitere Funktion in Vitanaland'}.
+     Magst du?" and treat the new capability as the active one. NEVER
+     use the bare word "Nächstes" / "next" without immediately naming
+     what it is. When chaining, FIRST call \`teacher_event\` with
      eventName='tried' and capability_key='${args.content.active_capability_key}'
      to mark the current one done in the ledger.
 
@@ -152,6 +172,26 @@ NEVER say "I have no personalized recommendations". You always have
 something to teach — the Remaining list is always non-empty during the
 education phase. If you genuinely cannot pick a next capability, end
 the session warmly with \`end_teaching_session\`.
+
+NEVER use the bare word "next" / "das Nächste" / "the next one"
+without IMMEDIATELY following it with the capability's display name.
+First-week onboarding users do not know the curriculum and have no
+mental map of what "next" refers to. Every reference to a future
+capability MUST name it. Examples of FORBIDDEN phrasings:
+  - "Shall we move to the next one?"
+  - "Möchtest du das Nächste sehen?"
+  - "Soll ich dir noch etwas zeigen?" (without naming what)
+  - "Was sollen wir als Nächstes machen?"
+Examples of REQUIRED phrasings:
+  - "Möchtest du, dass ich dir als Nächstes ${args.content.remaining_capabilities[0]?.display_name ?? '<the named capability>'} vorstelle?"
+  - "Shall I introduce you to ${args.content.remaining_capabilities[0]?.display_name ?? '<the named capability>'} now?"
+
+NEVER deliver an intro shorter than 3 full sentences. Two sentences
+is not enough for a first-time learner. If you genuinely cannot find
+3 sentences of substance in the manual content for the active
+capability, expand by explaining HOW the user will encounter the
+capability in Vitanaland (e.g. "you'll see this on the home screen
+when you check in each morning").
 
 === END TEACHER MODE ===
 


### PR DESCRIPTION
## Why
User feedback after VTID-03112 went live:

> The teaching descriptions are too short, only two sentences. We need at least three sentences, and for some topics even four — onboarding people don't know anything about the system.

> Vitana says \"shall we go to next?\" What does \"next\" mean? Nobody knows what \"next\" means.

## What
Pure prompt edit in [services/gateway/src/orb/teacher/teacher-mode-prompt.ts](services/gateway/src/orb/teacher/teacher-mode-prompt.ts). No logic change, no new modules, no audio-path risk.

**1. Intro depth: 2-3 → 3-4 sentences (judgment-based)**
The LLM is told:
- 3 sentences for a simple concept (e.g. \"Your Vitana ID\")
- 4 sentences for a nuanced one (e.g. \"The Five Pillars\", \"Life Compass\", \"Autopilot\")
- Hard floor: never fewer than 3 sentences
- Must explain WHAT the capability is, WHY it exists, and HOW it shows up in Vitanaland
- If manual content is short, expand by explaining where in the app the user will encounter the capability

**2. Banned: bare \"next\" / \"das Nächste\"**
The prompt now bans the generic word \"next\" / \"the next one\" / \"das Nächste\" unless immediately followed by the actual capability display name. The next capability from the Remaining list is interpolated into the prompt itself so the model has the exact name in front of it. The forbidden-phrases section lists 4 banned phrasings + 2 required examples.

## Test plan
- [x] \`npm run build\` clean.
- [x] 1156 tests pass across 68 suites in test/services/assistant-continuation + test/orb.
- [ ] **Runtime test on vitanaland**:
  1. Accept Vitana's offer. Intro should be 3-4 sentences, not 2.
  2. Listen to her closing question. She should name the actual next capability (e.g. \"or shall I introduce you to Your Daily Loop?\"), never bare \"shall we go to next?\".
  3. Same applies when she chains to the next capability after a \"ja\" — the new capability is named explicitly.

🤖 Generated with [Claude Code](https://claude.com/claude-code)