### PR TITLE
feat(decision-contract): Phase B.4 vertical proof — greeting block reads via PolicyResolver (VTID-03118)

### DIFF
--- a/services/gateway/src/orb/live/instruction/live-system-instruction.ts
+++ b/services/gateway/src/orb/live/instruction/live-system-instruction.ts
@@ -28,6 +28,17 @@ import {
   lookupByRoute as lookupNavByRoute,
 } from '../../../lib/navigation-catalog';
 import { pickShortGapGreetings } from '../../instruction/greeting-pools';
+// VTID-03118 (Phase B.4): bucket thresholds + greeting-bucket prompt
+// fragments come from PolicyResolver instead of inline literals/switch-case
+// lines. Resolver returns byte-identical content for the seeded defaults
+// (Phase B.2 / VTID-03114); the consumer below substitutes
+// {{greeting_time_of_day}} and {{short_gap_phrase_menu}} tokens to
+// reproduce the pre-B.4 output exactly.
+import {
+  getPolicyResolver,
+  POLICY_KEYS,
+  RENDER_BLOCK_KEYS,
+} from '../../../services/decision-contract';
 // A3: buildNavigatorPolicySection stays in orb-live.ts (still consumed by
 // the route handler too); the instruction builder calls it back across the
 // boundary. The function is pure (lang → string), so the round-trip is
@@ -43,6 +54,112 @@ import { buildNavigatorPolicySection } from '../../../routes/orb-live';
 import { renderAvailableToolsSection } from '../tools/live-tool-catalog';
 
 type TemporalBucket = 'reconnect' | 'recent' | 'same_day' | 'today' | 'yesterday' | 'week' | 'long' | 'first';
+
+// VTID-03118 (Phase B.4): map TemporalBucket → policy_render_block key so
+// the consumer below can fetch the seeded template by enum.
+const BUCKET_TO_BLOCK_KEY: Record<TemporalBucket, string> = {
+  reconnect: RENDER_BLOCK_KEYS.GREETING_BUCKET_RECONNECT,
+  recent: RENDER_BLOCK_KEYS.GREETING_BUCKET_RECENT,
+  same_day: RENDER_BLOCK_KEYS.GREETING_BUCKET_SAME_DAY,
+  today: RENDER_BLOCK_KEYS.GREETING_BUCKET_TODAY,
+  yesterday: RENDER_BLOCK_KEYS.GREETING_BUCKET_YESTERDAY,
+  week: RENDER_BLOCK_KEYS.GREETING_BUCKET_WEEK,
+  long: RENDER_BLOCK_KEYS.GREETING_BUCKET_LONG,
+  first: RENDER_BLOCK_KEYS.GREETING_BUCKET_FIRST,
+};
+
+// VTID-03118 (Phase B.4): safety-net fallbacks. Byte-identical to the
+// Phase B.2 seed content. The resolver returns the DB row in production;
+// these defaults activate only when the seed migration hasn't been run
+// (e.g. early boot in a fresh environment). Placeholder tokens match the
+// seed migration (see supabase/migrations/20260527020000_...).
+const BUCKET_DEFAULT_TEMPLATES: Record<TemporalBucket, string> = {
+  reconnect:
+`- BUCKET = reconnect (transparent server-side resume — the user did NOT perceive any pause).
+  • DO NOT speak. DO NOT greet. DO NOT acknowledge any "interruption", "reconnection", "resume", "where were we", "I'm back", "I'm listening", "picking up", or anything similar. Saying any of these creates a perceived apology that the user reads as a bug.
+  • Wait for the user to speak. Your next message must be a direct response to the user's next utterance — nothing else.
+  • If the user says nothing, you say nothing. Silence is correct here.`,
+  recent:
+`- BUCKET = recent (2–15 min since last session).
+  • Do NOT use a formal greeting. NO "Hello <name>!", NO "Hi there!", NO self-introduction. NO user name.
+  • Open with ONE single short phrase. NEVER use two-part sentences joined by dashes or commas.
+{{short_gap_phrase_menu}}
+  • Max ONE short phrase. Warm but direct.`,
+  same_day:
+`- BUCKET = same_day (15 min – 8 h since last session).
+  • Light re-engagement. NOT a formal greeting. No user name. NEVER "Hello <name>!" as if you've never met.
+  • Open with ONE single short phrase. NEVER use two-part sentences joined by dashes or commas.
+{{short_gap_phrase_menu}}
+  • Max ONE short phrase. Warm and direct.`,
+  today:
+`- BUCKET = today (8–24 h since last session — this is a NEW-DAY greeting).
+  • ALWAYS open with "Good {{greeting_time_of_day}}, [Name]." using the user's name from memory context.
+  • If no name is available in memory, just say "Good {{greeting_time_of_day}}."
+  • LEGACY-FALLBACK ONLY (use the brain context's candidate when available).
+  • Example follow-up if no candidate exists (pick ONE or skip):
+      "What's on your mind today?"
+      "Where would you like to focus today?"
+  • Max TWO short sentences total: the time-of-day greeting + optionally one question.`,
+  yesterday:
+`- BUCKET = yesterday (this is a NEW-DAY greeting).
+  • ALWAYS open with "Good {{greeting_time_of_day}}, [Name]." using the user's name from memory context.
+  • If no name is available in memory, just say "Good {{greeting_time_of_day}}."
+  • LEGACY-FALLBACK ONLY (use the brain context's candidate when available).
+  • Example follow-up if no candidate exists (pick ONE or skip):
+      "What would you like to explore today?"
+      "Picking up where we left off?"
+  • Max TWO short sentences total: the time-of-day greeting + optionally one question.`,
+  week:
+`- BUCKET = week (2–7 days since last session — this is a NEW-DAY greeting).
+  • ALWAYS open with "Good {{greeting_time_of_day}}, [Name]." using the user's name from memory context.
+  • If no name is available in memory, just say "Good {{greeting_time_of_day}}."
+  • LEGACY-FALLBACK ONLY (use the brain context's candidate when available).
+  • Example follow-up if no candidate exists (pick ONE or skip):
+      "Good to hear from you again — what's been on your mind?"
+      "What would you like to explore today?"
+  • Max TWO short sentences total: the time-of-day greeting + optionally one question.`,
+  long:
+`- BUCKET = long (> 7 days since last session — this is a NEW-DAY greeting).
+  • ALWAYS open with "Good {{greeting_time_of_day}}, [Name]." using the user's name from memory context.
+  • If no name is available in memory, just say "Good {{greeting_time_of_day}}."
+  • LEGACY-FALLBACK ONLY (use the brain context's candidate when available — for >7-day absences the candidate should explicitly acknowledge the gap).
+  • Example follow-up if no candidate exists (pick ONE or skip):
+      "It's been a few days — happy you're back. What's been on your mind?"
+      "What would you like to focus on today?"
+  • Max TWO short sentences total: the time-of-day greeting + optionally one question.`,
+  first:
+`- BUCKET = first (telemetry lookup found no prior session — usually treat as RETURNING with NEW-DAY greeting).
+  • ALWAYS open with "Good {{greeting_time_of_day}}, [Name]." using the user's name from memory context.
+  • If no name is available in memory, just say "Good {{greeting_time_of_day}}."
+  • EXCEPTION: when the brain context's USER AWARENESS shows tenure.stage="day0", the user is genuinely new. Use the FULL INTRODUCTION shape from the brain context's OPENING SHAPE MATRIX — that overrides this fallback.
+  • LEGACY-FALLBACK ONLY (use the brain context's candidate when available).
+  • Example follow-up if no candidate exists (pick ONE or skip):
+      "What's on your mind today?"
+      "Where would you like to focus today?"
+  • Max TWO short sentences total: the time-of-day greeting + optionally one question.`,
+};
+
+// VTID-03118 (Phase B.4): the `{{short_gap_phrase_menu}}` placeholder
+// inside the `recent` and `same_day` templates expands to this multi-line
+// block. Identical line-for-line to the pre-B.4 `appendShortGapPhraseMenu`
+// closure that used to live inside `buildTemporalJourneyContextSection`.
+function expandShortGapPhraseMenu(
+  lang: string,
+  wakeBriefOverrideActive?: boolean,
+): string {
+  if (wakeBriefOverrideActive) {
+    return '  • SHORT-GAP PHRASE LIST SUPPRESSED — a VERTEX WAKE BRIEF override is active later in this prompt. Speak the override line verbatim instead of any phrase here.';
+  }
+  const examples = pickShortGapGreetings(lang, 6);
+  const out: string[] = [
+    '  • Pick ONE of these example phrasings (use them VERBATIM — they are already in the user\'s language; pick a different one than last time):',
+  ];
+  for (const p of examples) {
+    out.push(`      "${p}"`);
+  }
+  out.push('  • Rotate across sessions — the user notices repetition. If the previous session used one of these, pick a different one.');
+  return out.join('\n');
+}
 
 // Exported for characterization testing (A0.2, orb-live-refactor).
 // No behavior change — same function, externally addressable so the refactor
@@ -67,28 +184,55 @@ export function describeTimeSince(lastSessionInfo: { time: string; wasFailure: b
   const diffHour = Math.floor(diffMin / 60);
   const diffDay = Math.floor(diffHour / 24);
 
+  // VTID-03118 (Phase B.4): thresholds resolved through PolicyResolver.
+  // Defaults match the pre-B.4 literal values (live-system-instruction.ts
+  // lines 72-91 before this PR) so behavior is byte-identical when the
+  // seeds from Phase B.2 are present; defaults take over if the cache is
+  // cold (e.g. early boot, Supabase outage).
+  const resolver = getPolicyResolver();
+  const reconnectMaxSec = resolver.getValue<number>(
+    POLICY_KEYS.SESSION_RECENCY_RECONNECT_MAX_SECONDS,
+    { defaultValue: 120 },
+  );
+  const recentMaxMin = resolver.getValue<number>(
+    POLICY_KEYS.SESSION_RECENCY_RECENT_MAX_MINUTES,
+    { defaultValue: 15 },
+  );
+  const sameDayMaxHour = resolver.getValue<number>(
+    POLICY_KEYS.SESSION_RECENCY_SAME_DAY_MAX_HOURS,
+    { defaultValue: 8 },
+  );
+  const todayMaxHour = resolver.getValue<number>(
+    POLICY_KEYS.SESSION_RECENCY_TODAY_MAX_HOURS,
+    { defaultValue: 24 },
+  );
+  const weekMaxDay = resolver.getValue<number>(
+    POLICY_KEYS.SESSION_RECENCY_WEEK_MAX_DAYS,
+    { defaultValue: 7 },
+  );
+
   let bucket: TemporalBucket;
   let timeAgo: string;
-  if (diffSec < 120) {
+  if (diffSec < reconnectMaxSec) {
     bucket = 'reconnect';
     timeAgo = diffSec < 30 ? 'a few seconds ago' : `about ${diffSec} seconds ago`;
-  } else if (diffMin < 15) {
+  } else if (diffMin < recentMaxMin) {
     bucket = 'recent';
     timeAgo = `${diffMin} minute${diffMin === 1 ? '' : 's'} ago`;
-  } else if (diffHour < 8) {
+  } else if (diffHour < sameDayMaxHour) {
     bucket = 'same_day';
     if (diffMin < 60) {
       timeAgo = `${diffMin} minutes ago`;
     } else {
       timeAgo = `about ${diffHour} hour${diffHour === 1 ? '' : 's'} ago`;
     }
-  } else if (diffHour < 24) {
+  } else if (diffHour < todayMaxHour) {
     bucket = 'today';
     timeAgo = `earlier today (about ${diffHour} hours ago)`;
   } else if (diffDay === 1) {
     bucket = 'yesterday';
     timeAgo = 'yesterday';
-  } else if (diffDay < 7) {
+  } else if (diffDay < weekMaxDay) {
     bucket = 'week';
     timeAgo = `${diffDay} days ago`;
   } else {
@@ -290,105 +434,35 @@ function buildTemporalJourneyContextSection(
   // VTID-GREETING-VARIETY: for short-gap buckets, inject a freshly-shuffled
   // subset of the language-specific phrase pool so Gemini rotates openers
   // instead of converging on the same translation every time.
-  const shortGapExamples = pickShortGapGreetings(lang, 6);
-  const appendShortGapPhraseMenu = () => {
-    if (wakeBriefOverrideActive) {
-      lines.push('  • SHORT-GAP PHRASE LIST SUPPRESSED — a VERTEX WAKE BRIEF override is active later in this prompt. Speak the override line verbatim instead of any phrase here.');
-      return;
-    }
-    lines.push('  • Pick ONE of these example phrasings (use them VERBATIM — they are already in the user\'s language; pick a different one than last time):');
-    for (const p of shortGapExamples) {
-      lines.push(`      "${p}"`);
-    }
-    lines.push('  • Rotate across sessions — the user notices repetition. If the previous session used one of these, pick a different one.');
-  };
-  switch (bucket) {
-    case 'reconnect':
-      // VTID-02637: This is a transparent server-side reconnect (Vertex 5-min
-      // session limit, network blip, or stall recovery). The user did NOT
-      // perceive any pause — they may still be mid-thought or already speaking.
-      // Speaking ANY proactive phrase here ("Picking up where we left off?",
-      // "I'm listening", "Where were we?") creates the apology-loop bug: every
-      // reconnect prompts a new spoken interjection that the user reads as
-      // "Vitana keeps apologizing for connection issues". Stay silent. Wait.
-      lines.push('- BUCKET = reconnect (transparent server-side resume — the user did NOT perceive any pause).');
-      lines.push('  • DO NOT speak. DO NOT greet. DO NOT acknowledge any "interruption", "reconnection", "resume", "where were we", "I\'m back", "I\'m listening", "picking up", or anything similar. Saying any of these creates a perceived apology that the user reads as a bug.');
-      lines.push('  • Wait for the user to speak. Your next message must be a direct response to the user\'s next utterance — nothing else.');
-      lines.push('  • If the user says nothing, you say nothing. Silence is correct here.');
-      break;
-    case 'recent':
-      lines.push('- BUCKET = recent (2–15 min since last session).');
-      lines.push('  • Do NOT use a formal greeting. NO "Hello <name>!", NO "Hi there!", NO self-introduction. NO user name.');
-      lines.push('  • Open with ONE single short phrase. NEVER use two-part sentences joined by dashes or commas.');
-      appendShortGapPhraseMenu();
-      lines.push('  • Max ONE short phrase. Warm but direct.');
-      break;
-    case 'same_day':
-      lines.push('- BUCKET = same_day (15 min – 8 h since last session).');
-      lines.push('  • Light re-engagement. NOT a formal greeting. No user name. NEVER "Hello <name>!" as if you\'ve never met.');
-      lines.push('  • Open with ONE single short phrase. NEVER use two-part sentences joined by dashes or commas.');
-      appendShortGapPhraseMenu();
-      lines.push('  • Max ONE short phrase. Warm and direct.');
-      break;
-    case 'today':
-      lines.push('- BUCKET = today (8–24 h since last session — this is a NEW-DAY greeting).');
-      lines.push(`  • ALWAYS open with "Good ${greetingTimeOfDay}, [Name]." using the user's name from memory context.`);
-      lines.push('  • If no name is available in memory, just say "Good ' + greetingTimeOfDay + '."');
-      lines.push('  • LEGACY-FALLBACK ONLY (use the brain context\'s candidate when available).');
-      lines.push('  • Example follow-up if no candidate exists (pick ONE or skip):');
-      lines.push('      "What\'s on your mind today?"');
-      lines.push('      "Where would you like to focus today?"');
-      lines.push('  • Max TWO short sentences total: the time-of-day greeting + optionally one question.');
-      break;
-    case 'yesterday':
-      lines.push('- BUCKET = yesterday (this is a NEW-DAY greeting).');
-      lines.push(`  • ALWAYS open with "Good ${greetingTimeOfDay}, [Name]." using the user's name from memory context.`);
-      lines.push('  • If no name is available in memory, just say "Good ' + greetingTimeOfDay + '."');
-      lines.push('  • LEGACY-FALLBACK ONLY (use the brain context\'s candidate when available).');
-      lines.push('  • Example follow-up if no candidate exists (pick ONE or skip):');
-      lines.push('      "What would you like to explore today?"');
-      lines.push('      "Picking up where we left off?"');
-      lines.push('  • Max TWO short sentences total: the time-of-day greeting + optionally one question.');
-      break;
-    case 'week':
-      lines.push('- BUCKET = week (2–7 days since last session — this is a NEW-DAY greeting).');
-      lines.push(`  • ALWAYS open with "Good ${greetingTimeOfDay}, [Name]." using the user's name from memory context.`);
-      lines.push('  • If no name is available in memory, just say "Good ' + greetingTimeOfDay + '."');
-      lines.push('  • LEGACY-FALLBACK ONLY (use the brain context\'s candidate when available).');
-      lines.push('  • Example follow-up if no candidate exists (pick ONE or skip):');
-      lines.push('      "Good to hear from you again — what\'s been on your mind?"');
-      lines.push('      "What would you like to explore today?"');
-      lines.push('  • Max TWO short sentences total: the time-of-day greeting + optionally one question.');
-      break;
-    case 'long':
-      lines.push('- BUCKET = long (> 7 days since last session — this is a NEW-DAY greeting).');
-      lines.push(`  • ALWAYS open with "Good ${greetingTimeOfDay}, [Name]." using the user's name from memory context.`);
-      lines.push('  • If no name is available in memory, just say "Good ' + greetingTimeOfDay + '."');
-      lines.push('  • LEGACY-FALLBACK ONLY (use the brain context\'s candidate when available — for >7-day absences the candidate should explicitly acknowledge the gap).');
-      lines.push('  • Example follow-up if no candidate exists (pick ONE or skip):');
-      lines.push('      "It\'s been a few days — happy you\'re back. What\'s been on your mind?"');
-      lines.push('      "What would you like to focus on today?"');
-      lines.push('  • Max TWO short sentences total: the time-of-day greeting + optionally one question.');
-      break;
-    case 'first':
-    default:
-      // VTID-NAV-TIMEJOURNEY: 'first' here is the "no telemetry found"
-      // fallback, NOT a genuine first meeting. For authenticated users
-      // (everyone who reaches this code path) we treat it as a returning
-      // user with unknown recency — treat as new-day greeting.
-      // VTID-01927/VTID-01929: when the brain context shows tenure.stage='day0',
-      // the user IS truly new and gets the FULL INTRODUCTION shape (handled
-      // by the OPENING SHAPE MATRIX in the brain block, not this fallback).
-      lines.push('- BUCKET = first (telemetry lookup found no prior session — usually treat as RETURNING with NEW-DAY greeting).');
-      lines.push(`  • ALWAYS open with "Good ${greetingTimeOfDay}, [Name]." using the user's name from memory context.`);
-      lines.push('  • If no name is available in memory, just say "Good ' + greetingTimeOfDay + '."');
-      lines.push('  • EXCEPTION: when the brain context\'s USER AWARENESS shows tenure.stage="day0", the user is genuinely new. Use the FULL INTRODUCTION shape from the brain context\'s OPENING SHAPE MATRIX — that overrides this fallback.');
-      lines.push('  • LEGACY-FALLBACK ONLY (use the brain context\'s candidate when available).');
-      lines.push('  • Example follow-up if no candidate exists (pick ONE or skip):');
-      lines.push('      "What\'s on your mind today?"');
-      lines.push('      "Where would you like to focus today?"');
-      lines.push('  • Max TWO short sentences total: the time-of-day greeting + optionally one question.');
-      break;
+  // VTID-03118 (Phase B.4): the bucket-to-prompt mapping (8 templates × 8
+  // languages) is the policy_render_block table seeded in Phase B.2. The
+  // resolver returns each bucket's full multi-line template; the consumer
+  // here substitutes the two dynamic tokens that survive into seed text:
+  //
+  //   {{greeting_time_of_day}}  -> the local `greetingTimeOfDay` value
+  //                                (morning | afternoon | evening | day).
+  //   {{short_gap_phrase_menu}} -> the locale-specific menu produced by
+  //                                `expandShortGapPhraseMenu()` below
+  //                                (1 line under wake-brief override,
+  //                                multiple lines otherwise).
+  //
+  // BUCKET_DEFAULT_TEMPLATES below is byte-identical to the seed content
+  // — it exists ONLY as a safety net for the "resolver cold + cache miss"
+  // case. In production, the resolver returns the DB row.
+  const shortGapPhraseMenu = expandShortGapPhraseMenu(
+    lang,
+    wakeBriefOverrideActive,
+  );
+  const template = getPolicyResolver().getRenderBlock(
+    BUCKET_TO_BLOCK_KEY[bucket],
+    lang,
+    { defaultValue: BUCKET_DEFAULT_TEMPLATES[bucket] },
+  );
+  const rendered = template
+    .replace(/\{\{greeting_time_of_day\}\}/g, greetingTimeOfDay)
+    .replace(/\{\{short_gap_phrase_menu\}\}/g, shortGapPhraseMenu);
+  for (const line of rendered.split('\n')) {
+    lines.push(line);
   }
 
   // VTID-02637: wasFailure means the PREVIOUS session ended with no audio

--- a/services/gateway/test/orb/live/characterization/greeting-block-resolver.test.ts
+++ b/services/gateway/test/orb/live/characterization/greeting-block-resolver.test.ts
@@ -1,0 +1,267 @@
+/**
+ * VTID-03118 (Phase B.4) — byte-identical proof for the resolver-backed
+ * greeting block.
+ *
+ * The Phase B.4 PR removes the inline `switch (bucket)` body that used to
+ * push per-bucket greeting policy lines and replaces it with a single
+ * `PolicyResolver.getRenderBlock()` call plus two token substitutions.
+ *
+ * This test locks the invariant: the output of `buildLiveSystemInstruction`
+ * is **byte-identical** whether the resolver returns its seeded content or
+ * the consumer falls back to BUCKET_DEFAULT_TEMPLATES. Both code paths must
+ * produce the same prompt — that is the whole point of the vertical proof.
+ */
+
+// pickShortGapGreetings shuffles its return value, which would make the
+// byte-identical comparison flap. Pin it to a fixed sequence so the two
+// invocations (defaults path vs resolver path) emit the same menu lines.
+jest.mock('../../../../src/orb/instruction/greeting-pools', () => ({
+  pickShortGapGreetings: (_lang: string, _n: number) => [
+    'fixed phrase 1',
+    'fixed phrase 2',
+    'fixed phrase 3',
+    'fixed phrase 4',
+    'fixed phrase 5',
+    'fixed phrase 6',
+  ],
+}));
+
+import { buildLiveSystemInstruction } from '../../../../src/orb/live/instruction/live-system-instruction';
+import {
+  configurePolicyResolverForTests,
+  __resetPolicyResolverForTests,
+  POLICY_KEYS,
+  RENDER_BLOCK_KEYS,
+} from '../../../../src/services/decision-contract';
+
+// Same template strings the consumer falls back to when the cache is cold
+// (see BUCKET_DEFAULT_TEMPLATES in live-system-instruction.ts). Duplicating
+// them here is the test contract: if the consumer ever diverges from these,
+// the byte-identical claim fails.
+const TEMPLATES = {
+  reconnect:
+`- BUCKET = reconnect (transparent server-side resume — the user did NOT perceive any pause).
+  • DO NOT speak. DO NOT greet. DO NOT acknowledge any "interruption", "reconnection", "resume", "where were we", "I'm back", "I'm listening", "picking up", or anything similar. Saying any of these creates a perceived apology that the user reads as a bug.
+  • Wait for the user to speak. Your next message must be a direct response to the user's next utterance — nothing else.
+  • If the user says nothing, you say nothing. Silence is correct here.`,
+  recent:
+`- BUCKET = recent (2–15 min since last session).
+  • Do NOT use a formal greeting. NO "Hello <name>!", NO "Hi there!", NO self-introduction. NO user name.
+  • Open with ONE single short phrase. NEVER use two-part sentences joined by dashes or commas.
+{{short_gap_phrase_menu}}
+  • Max ONE short phrase. Warm but direct.`,
+  same_day:
+`- BUCKET = same_day (15 min – 8 h since last session).
+  • Light re-engagement. NOT a formal greeting. No user name. NEVER "Hello <name>!" as if you've never met.
+  • Open with ONE single short phrase. NEVER use two-part sentences joined by dashes or commas.
+{{short_gap_phrase_menu}}
+  • Max ONE short phrase. Warm and direct.`,
+  today:
+`- BUCKET = today (8–24 h since last session — this is a NEW-DAY greeting).
+  • ALWAYS open with "Good {{greeting_time_of_day}}, [Name]." using the user's name from memory context.
+  • If no name is available in memory, just say "Good {{greeting_time_of_day}}."
+  • LEGACY-FALLBACK ONLY (use the brain context's candidate when available).
+  • Example follow-up if no candidate exists (pick ONE or skip):
+      "What's on your mind today?"
+      "Where would you like to focus today?"
+  • Max TWO short sentences total: the time-of-day greeting + optionally one question.`,
+  yesterday:
+`- BUCKET = yesterday (this is a NEW-DAY greeting).
+  • ALWAYS open with "Good {{greeting_time_of_day}}, [Name]." using the user's name from memory context.
+  • If no name is available in memory, just say "Good {{greeting_time_of_day}}."
+  • LEGACY-FALLBACK ONLY (use the brain context's candidate when available).
+  • Example follow-up if no candidate exists (pick ONE or skip):
+      "What would you like to explore today?"
+      "Picking up where we left off?"
+  • Max TWO short sentences total: the time-of-day greeting + optionally one question.`,
+  week:
+`- BUCKET = week (2–7 days since last session — this is a NEW-DAY greeting).
+  • ALWAYS open with "Good {{greeting_time_of_day}}, [Name]." using the user's name from memory context.
+  • If no name is available in memory, just say "Good {{greeting_time_of_day}}."
+  • LEGACY-FALLBACK ONLY (use the brain context's candidate when available).
+  • Example follow-up if no candidate exists (pick ONE or skip):
+      "Good to hear from you again — what's been on your mind?"
+      "What would you like to explore today?"
+  • Max TWO short sentences total: the time-of-day greeting + optionally one question.`,
+  long:
+`- BUCKET = long (> 7 days since last session — this is a NEW-DAY greeting).
+  • ALWAYS open with "Good {{greeting_time_of_day}}, [Name]." using the user's name from memory context.
+  • If no name is available in memory, just say "Good {{greeting_time_of_day}}."
+  • LEGACY-FALLBACK ONLY (use the brain context's candidate when available — for >7-day absences the candidate should explicitly acknowledge the gap).
+  • Example follow-up if no candidate exists (pick ONE or skip):
+      "It's been a few days — happy you're back. What's been on your mind?"
+      "What would you like to focus on today?"
+  • Max TWO short sentences total: the time-of-day greeting + optionally one question.`,
+  first:
+`- BUCKET = first (telemetry lookup found no prior session — usually treat as RETURNING with NEW-DAY greeting).
+  • ALWAYS open with "Good {{greeting_time_of_day}}, [Name]." using the user's name from memory context.
+  • If no name is available in memory, just say "Good {{greeting_time_of_day}}."
+  • EXCEPTION: when the brain context's USER AWARENESS shows tenure.stage="day0", the user is genuinely new. Use the FULL INTRODUCTION shape from the brain context's OPENING SHAPE MATRIX — that overrides this fallback.
+  • LEGACY-FALLBACK ONLY (use the brain context's candidate when available).
+  • Example follow-up if no candidate exists (pick ONE or skip):
+      "What's on your mind today?"
+      "Where would you like to focus today?"
+  • Max TWO short sentences total: the time-of-day greeting + optionally one question.`,
+};
+
+const RECENT_PAST = new Date(Date.now() - 60_000).toISOString();
+
+type BucketName = 'reconnect' | 'recent' | 'same_day' | 'today' | 'yesterday' | 'week' | 'long' | 'first';
+
+// Map each bucket to a lastSessionInfo timestamp that classifies into that
+// bucket via describeTimeSince().
+function timestampFor(bucket: BucketName): string {
+  const now = Date.now();
+  switch (bucket) {
+    case 'reconnect': return new Date(now - 30000).toISOString();           // < 120s
+    case 'recent':    return new Date(now - 5 * 60000).toISOString();        // 2-15 min
+    case 'same_day':  return new Date(now - 2 * 3600000).toISOString();      // 15 min - 8 h
+    case 'today':     return new Date(now - 10 * 3600000).toISOString();     // 8-24 h
+    case 'yesterday': return new Date(now - 25 * 3600000).toISOString();     // ~1 day
+    case 'week':      return new Date(now - 3 * 86400000).toISOString();    // 2-7 days
+    case 'long':      return new Date(now - 14 * 86400000).toISOString();   // > 7 days
+    case 'first':     return '';                                              // empty → 'first'
+  }
+}
+
+function withResolverFromTable(): void {
+  configurePolicyResolverForTests({
+    decisionPolicy: [
+      {
+        policy_key: POLICY_KEYS.SESSION_RECENCY_RECONNECT_MAX_SECONDS,
+        tenant_id: null, version: 1, value_json: 120,
+        effective_from: RECENT_PAST, effective_until: null,
+      },
+      {
+        policy_key: POLICY_KEYS.SESSION_RECENCY_RECENT_MAX_MINUTES,
+        tenant_id: null, version: 1, value_json: 15,
+        effective_from: RECENT_PAST, effective_until: null,
+      },
+      {
+        policy_key: POLICY_KEYS.SESSION_RECENCY_SAME_DAY_MAX_HOURS,
+        tenant_id: null, version: 1, value_json: 8,
+        effective_from: RECENT_PAST, effective_until: null,
+      },
+      {
+        policy_key: POLICY_KEYS.SESSION_RECENCY_TODAY_MAX_HOURS,
+        tenant_id: null, version: 1, value_json: 24,
+        effective_from: RECENT_PAST, effective_until: null,
+      },
+      {
+        policy_key: POLICY_KEYS.SESSION_RECENCY_WEEK_MAX_DAYS,
+        tenant_id: null, version: 1, value_json: 7,
+        effective_from: RECENT_PAST, effective_until: null,
+      },
+    ],
+    policyRenderBlock: [
+      ['reconnect', RENDER_BLOCK_KEYS.GREETING_BUCKET_RECONNECT],
+      ['recent', RENDER_BLOCK_KEYS.GREETING_BUCKET_RECENT],
+      ['same_day', RENDER_BLOCK_KEYS.GREETING_BUCKET_SAME_DAY],
+      ['today', RENDER_BLOCK_KEYS.GREETING_BUCKET_TODAY],
+      ['yesterday', RENDER_BLOCK_KEYS.GREETING_BUCKET_YESTERDAY],
+      ['week', RENDER_BLOCK_KEYS.GREETING_BUCKET_WEEK],
+      ['long', RENDER_BLOCK_KEYS.GREETING_BUCKET_LONG],
+      ['first', RENDER_BLOCK_KEYS.GREETING_BUCKET_FIRST],
+    ].map(([bucket, blockKey]) => ({
+      block_key: blockKey,
+      language: 'en',
+      tenant_id: null,
+      version: 1,
+      content: TEMPLATES[bucket as keyof typeof TEMPLATES],
+      effective_from: RECENT_PAST,
+      effective_until: null,
+    })),
+  });
+}
+
+function callBuilder(timestamp: string): string {
+  return buildLiveSystemInstruction(
+    'en',                       // lang
+    'verbose',                  // voiceStyle
+    undefined,                  // bootstrapContext (no wake-brief override marker)
+    'community',                // activeRole
+    undefined,                  // conversationSummary
+    undefined,                  // conversationHistory
+    false,                      // isReconnect
+    timestamp ? { time: timestamp, wasFailure: false } : null,
+    null,                       // currentRoute
+    null,                       // recentRoutes
+    { timeOfDay: 'evening' } as any, // clientContext — carries timeOfDay
+    null,                       // vitanaId
+    false,                      // omitGreetingPolicy
+  );
+}
+
+beforeEach(() => {
+  __resetPolicyResolverForTests();
+});
+
+afterAll(() => {
+  __resetPolicyResolverForTests();
+});
+
+describe('VTID-03118 — resolver-backed greeting block parity', () => {
+  const buckets: BucketName[] = [
+    'reconnect', 'recent', 'same_day', 'today',
+    'yesterday', 'week', 'long', 'first',
+  ];
+
+  for (const bucket of buckets) {
+    it(`bucket="${bucket}" produces byte-identical output via defaults vs resolver`, () => {
+      const ts = timestampFor(bucket);
+
+      // Path 1: cache empty → defaults.
+      __resetPolicyResolverForTests();
+      const fromDefaults = callBuilder(ts);
+
+      // Path 2: cache primed with the same templates the seed migration loaded.
+      withResolverFromTable();
+      const fromResolver = callBuilder(ts);
+
+      expect(fromResolver).toBe(fromDefaults);
+    });
+  }
+
+  it('today bucket output contains the expected verbatim line for greetingTimeOfDay="evening"', () => {
+    const out = callBuilder(timestampFor('today'));
+    expect(out).toContain(
+      '  • ALWAYS open with "Good evening, [Name]." using the user\'s name from memory context.',
+    );
+    expect(out).toContain('  • If no name is available in memory, just say "Good evening."');
+    // Sanity: the placeholder must NOT survive into the rendered prompt.
+    expect(out).not.toContain('{{greeting_time_of_day}}');
+  });
+
+  it('reconnect bucket output contains the "do not speak" guardrail verbatim', () => {
+    const out = callBuilder(timestampFor('reconnect'));
+    expect(out).toContain(
+      '- BUCKET = reconnect (transparent server-side resume — the user did NOT perceive any pause).',
+    );
+    expect(out).not.toContain('{{short_gap_phrase_menu}}');
+  });
+
+  it('recent bucket expands the short-gap phrase menu (non-wake-brief path)', () => {
+    const out = callBuilder(timestampFor('recent'));
+    expect(out).toContain('  • Pick ONE of these example phrasings (use them VERBATIM');
+    expect(out).toContain(
+      '  • Rotate across sessions — the user notices repetition. If the previous session used one of these, pick a different one.',
+    );
+    expect(out).toContain('  • Max ONE short phrase. Warm but direct.');
+    // Placeholder must be fully substituted.
+    expect(out).not.toContain('{{short_gap_phrase_menu}}');
+  });
+
+  it('describeTimeSince still classifies via the resolver-supplied thresholds', () => {
+    // Prime the cache with the same constants the pre-PR literals used and
+    // verify each timestamp lands in the expected bucket via output markers.
+    withResolverFromTable();
+    expect(callBuilder(timestampFor('reconnect'))).toContain('BUCKET = reconnect');
+    expect(callBuilder(timestampFor('recent'))).toContain('BUCKET = recent');
+    expect(callBuilder(timestampFor('same_day'))).toContain('BUCKET = same_day');
+    expect(callBuilder(timestampFor('today'))).toContain('BUCKET = today');
+    expect(callBuilder(timestampFor('yesterday'))).toContain('BUCKET = yesterday');
+    expect(callBuilder(timestampFor('week'))).toContain('BUCKET = week');
+    expect(callBuilder(timestampFor('long'))).toContain('BUCKET = long');
+    expect(callBuilder(timestampFor('first'))).toContain('BUCKET = first');
+  });
+});


### PR DESCRIPTION
## Summary

Phase B.4 of the decision-contract refactor — the **keystone vertical proof**.

The temporal-bucket greeting block in [`live-system-instruction.ts`](services/gateway/src/orb/live/instruction/live-system-instruction.ts) — the loudest decision leak in the May 2026 audit, every "Hello [Name]!" complaint lives here — now reads its values through `PolicyResolver` instead of inlining literals and switch-case lines.

This PR exercises **both** new tables (`decision_policy` for thresholds, `policy_render_block` for bucket prompts), exercises tenant-aware / version-aware / language-aware resolution, and stays **byte-identical** to the pre-B.4 output. That is the bar the brief set.

### Changes

**`services/gateway/src/orb/live/instruction/live-system-instruction.ts`**

- `describeTimeSince()`: five hard-coded threshold literals (`120`, `15`, `8`, `24`, `7`) now go through `PolicyResolver.getValue()` with the same constants baked in as `defaultValue`. Behavior is identical when the cache is primed; defaults take over when it isn't.
- `buildTemporalJourneyContextSection()`: the ~90-line `switch (bucket)` body that pushed per-bucket greeting policy lines now collapses to **one** `getRenderBlock()` lookup plus token substitution:
  - `{{greeting_time_of_day}}` → the local `greetingTimeOfDay` (`morning | afternoon | evening | day`).
  - `{{short_gap_phrase_menu}}` → the locale-specific menu the previous `appendShortGapPhraseMenu` closure used to push inline.
- New `BUCKET_TO_BLOCK_KEY` (`TemporalBucket` → `policy_render_block` key) and `BUCKET_DEFAULT_TEMPLATES` (last-resort fallback content, byte-identical to the Phase B.2 seeds). The defaults exist **only** for "resolver cold + DB unavailable" — the brief permits this form of last-resort fallback explicitly.

**`services/gateway/test/orb/live/characterization/greeting-block-resolver.test.ts`** — new file, 12 tests:

- **8 byte-identical parity checks**, one per bucket. For each, invoke `buildLiveSystemInstruction()` once with the resolver cache empty (defaults path) and once with it primed via `configurePolicyResolverForTests` (resolver path); assert the two outputs are strictly equal. This is the byte-identical contract the brief specifies.
- **4 content sanity checks**: substituted placeholders, short-gap menu expansion, every bucket landing in the right `describeTimeSince` classification under resolver-supplied thresholds.
- `pickShortGapGreetings` is `jest.mock`'d to a fixed sequence so the menu-shuffle randomness doesn't make the parity comparison flap.

### Test results

```
PASS test/orb/live/characterization/greeting-block-resolver.test.ts (12/12)
PASS test/orb/live/characterization/time-since.characterization.test.ts
PASS test/orb/live/characterization/greeting-policy.characterization.test.ts
PASS test/orb/live/characterization/system-instruction.characterization.test.ts
51 pre-existing characterization tests still green.
```

`npm run build` clean.

### Phase plan status

| Slice | PR | Status |
|---|---|---|
| B.1 schema | [#2276](https://github.com/exafyltd/vitana-platform/pull/2276) | ✅ merged + migrations applied |
| B.2 seeds | [#2278](https://github.com/exafyltd/vitana-platform/pull/2278) | ✅ merged + migration applied |
| B.3 PolicyResolver | [#2279](https://github.com/exafyltd/vitana-platform/pull/2279) | ✅ merged (EXEC-DEPLOY in flight) |
| **B.4 vertical proof** | **this PR** | ➡️ opening |

After B.4 lands and a production session shows the greeting block behaves unchanged, **Phase B's vertical proof is complete**. The brief's follow-up slices (temporal-bucket.ts cooling thresholds, D32 time-of-day windows, D33 readiness thresholds, etc.) are out of scope here — each is its own VTID + PR per the brief.

## Test plan

- [ ] PR CI green (new test file picked up).
- [ ] EXEC-DEPLOY after merge dispatches (touches `services/gateway/**`).
- [ ] Post-deploy: `/alive` returns 200 JSON.
- [ ] One smoke `/orb/chat` call returns successfully. The temporal greeting block in the rendered prompt should match the relevant bucket's seeded text for the user's `(recency, language)`.
- [ ] Production sanity: pull a sample LiveKit/Vertex transcript from the new revision and confirm greetings still classify correctly (recent → no "Hello X!"; today → "Good morning, X.", etc.).

🤖 Generated with [Claude Code](https://claude.com/claude-code)