### PR TITLE
feat(teacher): highlights-first curriculum + locked intro scripts (VTID-03120)

### DIFF
--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -992,6 +992,10 @@ export async function handleLiveSessionStart(
               tenantId: orbIdentity.tenant_id,
               userId: orbIdentity.user_id,
               activeCapabilityKey,
+              // VTID-03120: pass user lang so the resolver picks the
+              // right teacher_intro_de / _en script for the deterministic
+              // Say-exactly intro pattern.
+              lang,
             });
             if (teacherContent) {
               (session as any).teacherModeContent = teacherContent;

--- a/services/gateway/src/orb/teacher/teacher-content-resolver.ts
+++ b/services/gateway/src/orb/teacher/teacher-content-resolver.ts
@@ -44,6 +44,16 @@ export interface TeacherModeContent {
    *  injection into system_instruction stays bounded. May be empty
    *  string when the knowledge_docs row isn't found. */
   active_manual_content: string;
+  /** VTID-03120: locked 3-4 sentence script in the user's language —
+   *  hand-written in `system_capabilities.teacher_intro_*` so the
+   *  Teacher prompt can use the deterministic "Say exactly:" pattern
+   *  the wake-brief opener uses. Null when the row isn't seeded for
+   *  this capability/lang; the prompt then falls back to manual-based
+   *  generation. The fallback is intentional — capabilities without a
+   *  seeded script still teach, they just rely on LLM judgment for
+   *  length and phrasing. Operators add scripts to new capabilities
+   *  via the system_capabilities table without a code deploy. */
+  active_teacher_intro_script: string | null;
   /** Up to 5 remaining capabilities in pedagogical order so the LLM
    *  can chain to the next one without an extra fetch. Each entry has
    *  the display name + a one-line description (no manual content —
@@ -61,6 +71,9 @@ export interface TeacherContentResolverInputs {
   tenantId: string;
   userId: string;
   activeCapabilityKey: string;
+  /** VTID-03120: user's language. Picks teacher_intro_de or
+   *  teacher_intro_en. Defaults to 'en' when absent. */
+  lang?: string;
   nowIso?: string;
 }
 
@@ -86,16 +99,32 @@ export async function resolveTeacherModeContent(
 ): Promise<TeacherModeContent | null> {
   let catalog: CapabilityCatalogRow[] = [];
   let activeRow: CapabilityCatalogRow | null = null;
+  // VTID-03120: keep the raw row (including the teacher_intro_* columns)
+  // so we can resolve the locked script for the active capability + lang
+  // BEFORE the pickCapability ranker discards everything except the
+  // catalog-shape fields.
+  let activeRawRow: Record<string, unknown> | null = null;
   try {
     const cap = await inputs.supabase
       .from('system_capabilities')
-      .select('capability_key, display_name, description, manual_path, enabled, pedagogical_order')
+      .select('capability_key, display_name, description, manual_path, enabled, pedagogical_order, teacher_intro_de, teacher_intro_en')
       .eq('enabled', true);
     if (cap.error || !Array.isArray(cap.data)) {
       return null;
     }
-    catalog = cap.data as CapabilityCatalogRow[];
+    catalog = (cap.data as Array<Record<string, unknown>>).map((r) => ({
+      capability_key: r.capability_key as string,
+      display_name: r.display_name as string,
+      description: r.description as string,
+      manual_path: (r.manual_path as string | null) ?? null,
+      enabled: r.enabled as boolean,
+      pedagogical_order: (r.pedagogical_order as number | null) ?? null,
+    }));
     activeRow = catalog.find((r) => r.capability_key === inputs.activeCapabilityKey) ?? null;
+    activeRawRow =
+      (cap.data as Array<Record<string, unknown>>).find(
+        (r) => r.capability_key === inputs.activeCapabilityKey,
+      ) ?? null;
   } catch {
     return null;
   }
@@ -196,12 +225,34 @@ export async function resolveTeacherModeContent(
     });
   }
 
+  // VTID-03120: resolve the locked intro script for the user's lang.
+  // Falls back to the other language if the requested one is empty
+  // (better to speak the locked script in the wrong language than to
+  // collapse to manual-based generation and risk the 2-sentence issue).
+  // Falls back to null only when BOTH language columns are empty —
+  // then the prompt uses the manual-based fallback path.
+  const lang = (inputs.lang || 'en').toLowerCase();
+  let teacherIntroScript: string | null = null;
+  if (activeRawRow) {
+    const de = typeof activeRawRow.teacher_intro_de === 'string'
+      ? activeRawRow.teacher_intro_de.trim()
+      : '';
+    const en = typeof activeRawRow.teacher_intro_en === 'string'
+      ? activeRawRow.teacher_intro_en.trim()
+      : '';
+    if (lang.startsWith('de') && de) teacherIntroScript = de;
+    else if (lang.startsWith('en') && en) teacherIntroScript = en;
+    else if (en) teacherIntroScript = en;
+    else if (de) teacherIntroScript = de;
+  }
+
   return {
     active_capability_key: activeRow.capability_key,
     active_display_name: activeRow.display_name,
     active_description: activeRow.description,
     active_manual_path: activeRow.manual_path,
     active_manual_content: manualContent,
+    active_teacher_intro_script: teacherIntroScript,
     remaining_capabilities: remaining,
   };
 }

--- a/services/gateway/src/orb/teacher/teacher-mode-prompt.ts
+++ b/services/gateway/src/orb/teacher/teacher-mode-prompt.ts
@@ -90,17 +90,36 @@ ${remainingList}
    words. Common situations and how to handle them:
 
    - User accepts (any positive signal — "ja", "yes", "klar", "sure",
-     "go ahead", silence followed by attention, etc.): deliver a
-     THREE-to-FOUR sentence intro of "${args.content.active_display_name}"
-     drawn from the MANUAL CONTENT above. The user is a first-time
-     learner — they don't know the system yet. Use your judgment on
-     length: 3 sentences for a simple concept (e.g. "Your Vitana ID"),
-     4 sentences for a more nuanced one (e.g. "The Five Pillars",
-     "Life Compass", "Autopilot"). Speak naturally, like a teacher
-     explaining to a friend, not by reciting bullets — but make sure
-     the user walks away with a clear mental picture of WHAT the
-     capability is, WHY it exists, and HOW it shows up in Vitanaland.
-     Two sentences is NOT enough; explain it properly.
+     "go ahead", silence followed by attention, etc.): deliver the
+     intro for "${args.content.active_display_name}" using the
+     INTRO SCRIPT path below.${args.content.active_teacher_intro_script
+       ? `
+
+     ===== INTRO SCRIPT — SPEAK VERBATIM =====
+     This is the locked 3-4 sentence intro hand-written for
+     "${args.content.active_display_name}". Speak it WORD FOR WORD —
+     do NOT shorten it, do NOT paraphrase it, do NOT collapse it into
+     a 2-sentence summary. Two sentences is NOT enough for a first-time
+     learner. The script:
+
+     "${args.content.active_teacher_intro_script.replace(/"/g, '\\"')}"
+
+     Read every sentence. Pause briefly at the end of the script for
+     the user to react. Treat the script as the FIRST DELIVERY of this
+     capability — the user is hearing about it for the first time.
+     ===== END INTRO SCRIPT =====
+`
+       : `
+
+     The active capability has no locked intro script seeded in the
+     catalog. Use your judgment to compose a THREE-to-FOUR sentence
+     intro from the MANUAL CONTENT above. The user is a first-time
+     learner — they don't know the system yet. Three sentences for a
+     simple concept (e.g. "Your Vitana ID"), four for a nuanced one.
+     Make sure the user walks away with a clear mental picture of
+     WHAT the capability is, WHY it exists, and HOW it shows up in
+     Vitanaland. Two sentences is NOT enough; explain it properly.
+`}
 
      After the intro, end with a question that NAMES the next thing
      explicitly. NEVER say a generic "Möchtest du das Nächste sehen?"

--- a/services/gateway/test/orb/teacher/teacher-content-resolver.test.ts
+++ b/services/gateway/test/orb/teacher/teacher-content-resolver.test.ts
@@ -65,6 +65,8 @@ const FIVE_PILLARS: FakeRow = {
   manual_path: '/manuals/maxina/00-concepts/five-pillars',
   enabled: true,
   pedagogical_order: 10,
+  teacher_intro_de: null,
+  teacher_intro_en: null,
 };
 
 const VITANA_ID: FakeRow = {
@@ -74,6 +76,8 @@ const VITANA_ID: FakeRow = {
   manual_path: '/manuals/maxina/00-concepts/vitana-id',
   enabled: true,
   pedagogical_order: 30,
+  teacher_intro_de: null,
+  teacher_intro_en: null,
 };
 
 const ACTIVITY_MATCH: FakeRow = {
@@ -83,6 +87,8 @@ const ACTIVITY_MATCH: FakeRow = {
   manual_path: '/manuals/maxina/03-community/activity-match',
   enabled: true,
   pedagogical_order: 140,
+  teacher_intro_de: 'Activity Match auf Deutsch — vier Sätze hier. Zweiter Satz. Dritter Satz. Vierter Satz.',
+  teacher_intro_en: 'Activity Match in English — four sentences here. Second sentence. Third sentence. Fourth sentence.',
 };
 
 describe('VTID-03112 — resolveTeacherModeContent', () => {
@@ -208,6 +214,88 @@ describe('VTID-03112 — resolveTeacherModeContent', () => {
     expect(keys).toContain('activity_match'); // still eligible
   });
 
+  // VTID-03120: locked intro script resolution tests.
+  test('returns the German teacher_intro when lang=de', async () => {
+    const sb = fakeSb({
+      catalog: [ACTIVITY_MATCH],
+      ledger: [],
+      doc: { content: '# manual' },
+    });
+    const out = await resolveTeacherModeContent({
+      supabase: sb,
+      tenantId: 't1',
+      userId: 'u1',
+      activeCapabilityKey: 'activity_match',
+      lang: 'de',
+      nowIso: NOW_ISO,
+    });
+    expect(out).not.toBeNull();
+    expect(out!.active_teacher_intro_script).toBeTruthy();
+    expect(out!.active_teacher_intro_script).toContain('Activity Match auf Deutsch');
+  });
+
+  test('returns the English teacher_intro when lang=en', async () => {
+    const sb = fakeSb({
+      catalog: [ACTIVITY_MATCH],
+      ledger: [],
+      doc: { content: '# manual' },
+    });
+    const out = await resolveTeacherModeContent({
+      supabase: sb,
+      tenantId: 't1',
+      userId: 'u1',
+      activeCapabilityKey: 'activity_match',
+      lang: 'en',
+      nowIso: NOW_ISO,
+    });
+    expect(out).not.toBeNull();
+    expect(out!.active_teacher_intro_script).toContain('Activity Match in English');
+  });
+
+  test('falls back across languages when requested lang is empty', async () => {
+    // De-only capability — caller asks for English. Resolver falls
+    // back to the German script rather than collapse to null. Speaking
+    // the locked script in the wrong language is preferable to letting
+    // Gemini freelance a 2-sentence summary.
+    const DE_ONLY: FakeRow = {
+      ...ACTIVITY_MATCH,
+      teacher_intro_en: null,
+    };
+    const sb = fakeSb({
+      catalog: [DE_ONLY],
+      ledger: [],
+      doc: { content: '# manual' },
+    });
+    const out = await resolveTeacherModeContent({
+      supabase: sb,
+      tenantId: 't1',
+      userId: 'u1',
+      activeCapabilityKey: 'activity_match',
+      lang: 'en',
+      nowIso: NOW_ISO,
+    });
+    expect(out).not.toBeNull();
+    expect(out!.active_teacher_intro_script).toContain('Activity Match auf Deutsch');
+  });
+
+  test('active_teacher_intro_script is null when both columns empty (fallback to manual-based)', async () => {
+    const sb = fakeSb({
+      catalog: [FIVE_PILLARS],
+      ledger: [],
+      doc: { content: '# manual' },
+    });
+    const out = await resolveTeacherModeContent({
+      supabase: sb,
+      tenantId: 't1',
+      userId: 'u1',
+      activeCapabilityKey: 'five_pillars',
+      lang: 'en',
+      nowIso: NOW_ISO,
+    });
+    expect(out).not.toBeNull();
+    expect(out!.active_teacher_intro_script).toBeNull();
+  });
+
   test('remaining list capped at 5 entries even with a large catalog', async () => {
     const catalog: FakeRow[] = [
       FIVE_PILLARS,
@@ -218,6 +306,8 @@ describe('VTID-03112 — resolveTeacherModeContent', () => {
         manual_path: null,
         enabled: true,
         pedagogical_order: 20 + i,
+        teacher_intro_de: null,
+        teacher_intro_en: null,
       })),
     ];
     const sb = fakeSb({

--- a/supabase/migrations/20260527000000_VTID_03120_teacher_highlights_intros.sql
+++ b/supabase/migrations/20260527000000_VTID_03120_teacher_highlights_intros.sql
@@ -1,0 +1,130 @@
+-- VTID-03120 — Teacher highlights curriculum + locked intro scripts.
+--
+-- User feedback: the pedagogical curriculum order from VTID-03108 led
+-- with foundational CONCEPTS (Five Pillars, Daily Loop, Vitana ID,
+-- Did-You-Know). For first-week onboarding users those are abstract
+-- and dry. The actual HIGHLIGHTS that get people engaged are the
+-- POWERFUL capabilities — Life Compass setup, Vitana Index, Autopilot,
+-- Daily Diary, Activity Match. Those need to come FIRST.
+--
+-- On top of that, the model has been ignoring the "3-4 sentence intro"
+-- judgment rule in the system_instruction. Soft rules get lost in long
+-- prompts. The same fix that worked for the wake-brief opener
+-- (VTID-03104's `Say exactly:` deterministic pattern) is the answer
+-- for intros too: store a hand-written, locked 3-4 sentence script
+-- per capability in the DB, and the prompt tells the model to speak
+-- it verbatim. Operators tune the scripts in the DB without a code
+-- deploy. Capabilities without a populated script fall back to the
+-- existing manual-based generation (with the soft 3-4 sentence rule
+-- still in the prompt).
+--
+-- This migration:
+--   1. Adds `teacher_intro_de TEXT` + `teacher_intro_en TEXT` columns.
+--   2. Reorders `pedagogical_order` to put highlights first.
+--   3. Seeds 3-4 sentence intros for the top 5 highlights in DE + EN.
+
+ALTER TABLE system_capabilities
+  ADD COLUMN IF NOT EXISTS teacher_intro_de TEXT;
+ALTER TABLE system_capabilities
+  ADD COLUMN IF NOT EXISTS teacher_intro_en TEXT;
+
+COMMENT ON COLUMN system_capabilities.teacher_intro_de IS
+  'VTID-03120: hand-written 3-4 sentence German intro the Teacher speaks verbatim via the Say-exactly pattern. NULL = fall back to manual-based generation in the Teacher Mode prompt.';
+COMMENT ON COLUMN system_capabilities.teacher_intro_en IS
+  'VTID-03120: hand-written 3-4 sentence English intro the Teacher speaks verbatim. NULL = fall back to manual-based generation.';
+
+-- ============================================================
+-- Step 1: reorder pedagogical_order
+-- ============================================================
+-- Highlights tier (10-50):
+--   life_compass         — the ACTIONABLE setup that personalizes the system
+--   vitana_index         — the daily measurement layer the user will see most
+--   autopilot            — the agentic power the system has
+--   diary_entry          — the daily capture habit that makes everything work
+--   activity_match       — the community-matching power that turns it social
+--
+-- Voice highlight (60):
+--   community_intent     — \"post an intent to find help / collaborate\"
+--   community_post       — community share
+--
+-- Foundation tier (70-100):
+--   five_pillars, journey_daily_loop, vitana_id, did_you_know, biomarkers
+--
+-- Advanced (110-200):
+--   reminders, calendar_connect, scheduling, memory_garden, live_room,
+--   invite_contact, events, marketplace
+--
+-- Capabilities without an explicit value here keep whatever they had.
+
+UPDATE system_capabilities SET pedagogical_order = 10  WHERE capability_key = 'life_compass';
+UPDATE system_capabilities SET pedagogical_order = 20  WHERE capability_key = 'vitana_index';
+UPDATE system_capabilities SET pedagogical_order = 30  WHERE capability_key = 'autopilot';
+UPDATE system_capabilities SET pedagogical_order = 40  WHERE capability_key = 'diary_entry';
+UPDATE system_capabilities SET pedagogical_order = 50  WHERE capability_key = 'activity_match';
+
+UPDATE system_capabilities SET pedagogical_order = 60  WHERE capability_key = 'community_intent';
+UPDATE system_capabilities SET pedagogical_order = 70  WHERE capability_key = 'community_post';
+
+UPDATE system_capabilities SET pedagogical_order = 80  WHERE capability_key = 'five_pillars';
+UPDATE system_capabilities SET pedagogical_order = 90  WHERE capability_key = 'journey_daily_loop';
+UPDATE system_capabilities SET pedagogical_order = 100 WHERE capability_key = 'vitana_id';
+UPDATE system_capabilities SET pedagogical_order = 110 WHERE capability_key = 'did_you_know';
+UPDATE system_capabilities SET pedagogical_order = 120 WHERE capability_key = 'biomarkers';
+
+UPDATE system_capabilities SET pedagogical_order = 130 WHERE capability_key = 'reminders';
+UPDATE system_capabilities SET pedagogical_order = 140 WHERE capability_key = 'calendar_connect';
+UPDATE system_capabilities SET pedagogical_order = 150 WHERE capability_key = 'scheduling';
+UPDATE system_capabilities SET pedagogical_order = 160 WHERE capability_key = 'memory_garden';
+
+UPDATE system_capabilities SET pedagogical_order = 170 WHERE capability_key = 'events';
+UPDATE system_capabilities SET pedagogical_order = 180 WHERE capability_key = 'live_room';
+UPDATE system_capabilities SET pedagogical_order = 190 WHERE capability_key = 'invite_contact';
+UPDATE system_capabilities SET pedagogical_order = 200 WHERE capability_key = 'marketplace';
+
+-- ============================================================
+-- Step 2: seed locked teacher_intro_* scripts for the top highlights
+-- ============================================================
+-- Voice + length notes:
+--   - 3-4 spoken sentences per language
+--   - Names the capability explicitly
+--   - Explains WHAT, WHY (value to the user), HOW (where it shows up)
+--   - For action-oriented capabilities (life_compass), invites the user to
+--     SET IT UP together instead of just listening to an explanation
+--   - Where appropriate, weaves in a trust / privacy reassurance — the
+--     user has been explicit that this matters in onboarding
+--   - Closes with a CTA the model can name the next capability after
+
+-- life_compass — joint-setup framing. The first thing a new user should
+-- do because everything else personalizes around it.
+UPDATE system_capabilities
+SET teacher_intro_de = 'Lass uns gleich gemeinsam deinen Life Compass einrichten — das ist das wichtigste Werkzeug, damit Vitana dich wirklich versteht. Du sagst mir kurz, was dir gerade im Leben am wichtigsten ist — zum Beispiel Gesundheit, Energie, eine bestimmte Beziehung oder ein Projekt — und ich verknüpfe das mit deinen Säulen, sodass jede spätere Empfehlung darauf abgestimmt ist. Wenn du dich später anders ausrichten möchtest, ändern wir das jederzeit — du bestimmst, ich folge. Magst du, dass wir das jetzt zusammen einrichten?',
+    teacher_intro_en = 'Let''s set up your Life Compass together right now — it''s the single most important tool for Vitana to actually understand you. You tell me briefly what matters most to you in life right now — health, energy, a relationship, a project — and I tie that to your pillars so every later recommendation is tuned around it. Whenever you want to point in a different direction, we change it — you decide, I follow. Want to do it together now?'
+WHERE capability_key = 'life_compass';
+
+-- vitana_index — the daily measurement / dashboard layer
+UPDATE system_capabilities
+SET teacher_intro_de = 'Dein Vitana Index ist die tägliche Punktzahl, die zeigt, wie ausgewogen deine fünf Säulen gerade laufen — Ernährung, Hydration, Bewegung, Schlaf und Mentales. Du siehst ihn auf deinem Home-Screen, jeden Tag aktualisiert, und Vitana erklärt dir bei jedem Wert, welche Säule gerade trägt und welche ein wenig Aufmerksamkeit braucht. Alle Werte bleiben privat in deinem persönlichen Bereich — niemand sonst hat darauf Zugriff, und du entscheidest, was geteilt wird. Soll ich dir gleich zeigen, wie dein Index gerade aussieht?',
+    teacher_intro_en = 'Your Vitana Index is the daily score that shows how balanced your five pillars are running — Nutrition, Hydration, Exercise, Sleep, and Mental. You see it on your home screen, updated every day, and Vitana explains at every reading which pillar is carrying you and which one needs a little attention. All values stay private in your personal space — no one else can see them, and you decide what gets shared. Want me to show you what your Index looks like right now?'
+WHERE capability_key = 'vitana_index';
+
+-- autopilot — agentic power, with a trust angle
+UPDATE system_capabilities
+SET teacher_intro_de = 'Der Autopilot ist das, was Vitana von einer App zu einem echten Partner macht — ich kann eigenständig Aufgaben für dich erledigen: Termine in deinen Kalender eintragen, Erinnerungen setzen, dir passende Menschen aus der Community vorschlagen, oder dir morgens ein kurzes Briefing zusammenstellen. Du gibst vor, was ich tun darf und was nicht — alles läuft mit deiner Zustimmung, und du siehst jeden Schritt im Verlauf. Nichts passiert hinter deinem Rücken, und du kannst den Autopiloten jederzeit anhalten oder anpassen. Magst du, dass ich dir zeige, wie du den Autopiloten startest?',
+    teacher_intro_en = 'Autopilot is what turns Vitana from an app into an actual partner — I can take tasks off your shoulders: put events into your calendar, set reminders, suggest the right people from the community, or assemble a short morning briefing for you. You decide what I''m allowed to do and what stays off-limits — everything runs with your consent, and every step is visible in your history. Nothing happens behind your back, and you can pause or adjust Autopilot anytime. Want me to show you how to start it?'
+WHERE capability_key = 'autopilot';
+
+-- diary_entry — daily capture habit
+UPDATE system_capabilities
+SET teacher_intro_de = 'Dein Tagebuch ist der Ort, an dem du jeden Tag ganz kurz festhältst, wie es dir geht — was gut lief, was schwer war, was du gegessen, geschlafen oder gespürt hast. Vitana liest mit dir mit und zieht daraus die Muster, die deinen Index und deine Empfehlungen prägen — du musst nichts auswendig lernen, ich erinnere mich für dich. Deine Einträge gehören dir allein, sind verschlüsselt gespeichert, und nur du entscheidest, ob ein Auszug in eine Empfehlung einfließt. Soll ich dir gleich helfen, deinen ersten Eintrag von heute zu machen?',
+    teacher_intro_en = 'Your Diary is where you briefly capture each day how you''re doing — what went well, what was hard, what you ate, slept, or felt. Vitana reads along with you and extracts the patterns that shape your Index and your recommendations — you don''t have to memorize anything, I remember for you. Your entries belong to you alone, are stored encrypted, and only you decide whether an excerpt flows into a recommendation. Want me to help you make your first entry for today right now?'
+WHERE capability_key = 'diary_entry';
+
+-- activity_match — community matching
+UPDATE system_capabilities
+SET teacher_intro_de = 'Activity Match ist Vitanas Weg, dich mit Menschen aus der Community zusammenzubringen, die gerade dasselbe vorhaben wie du — gemeinsam laufen, kochen, meditieren, einen Skill lernen, oder einfach reden. Du sagst mir, was du suchst, und ich gleiche es mit den offenen Absichten in der Community ab — du bekommst echte Vorschläge, keine zufällige Liste. Du entscheidest, ob und wann ein Match zu einem Kontakt wird — solange du nicht "Ja" sagst, bleibt deine Identität geschützt. Soll ich dir zeigen, wer gerade zu deinen Interessen passt?',
+    teacher_intro_en = 'Activity Match is Vitana''s way of connecting you with people in the community who are up for the same thing as you right now — running together, cooking, meditating, learning a skill, or just talking. You tell me what you''re looking for, and I match it against the open intents in the community — you get real suggestions, not a random list. You decide whether and when a match turns into a contact — until you say yes, your identity stays protected. Want me to show you who matches your interests right now?'
+WHERE capability_key = 'activity_match';
+
+-- Index for the system_capabilities lookup. The teacher_intro_*
+-- columns are read per-session by teacher-content-resolver.ts; no
+-- index is needed (PK on capability_key already covers the lookup).


### PR DESCRIPTION
## Why
After VTID-03119, the 3-4 sentence rule was still being ignored by Gemini (soft rules get lost in long system_instructions), and the curriculum ordering was wrong — foundational concepts like \"Five Pillars\" / \"Daily Loop\" / \"Vitana ID\" came before the actual onboarding highlights that get users engaged.

User explicitly listed the right highlights:
- find a match (activity_match)
- vitana index
- autopilot
- daily diary
- life compass (setup together)
- with privacy/trust posture woven in

## What
Two structural fixes in one slice:

**1. Curriculum reorder (data-driven via pedagogical_order):**
Migration `20260527000000_VTID_03120_teacher_highlights_intros.sql` updates `pedagogical_order`:
- `10 life_compass` (joint setup — the first thing every new user should do)
- `20 vitana_index` (the daily measurement dashboard)
- `30 autopilot` (agentic power)
- `40 diary_entry` (daily capture habit)
- `50 activity_match` (community matching)
- `60-70 community_*`
- `80+` foundation tier (five_pillars, daily_loop, vitana_id, …)
- `130+` utility tier (reminders, calendar, …)

Operators tune live in the DB without a deploy.

**2. Locked intro scripts via the proven Say-exactly pattern:**
Two new columns `teacher_intro_de TEXT` + `teacher_intro_en TEXT` on `system_capabilities`. Seeded with hand-written 3-4 sentence scripts in DE + EN for the top 5 highlights. Each script names the capability, explains WHAT / WHY / HOW, weaves in privacy/trust posture where appropriate, and for `life_compass` uses joint-action framing (\"let's set this up together right now\") instead of \"may I introduce\".

The Teacher Mode prompt branches: when `active_teacher_intro_script` is set, INJECT it as a verbatim \"Say it word-for-word\" block (same deterministic Say-exactly pattern as VTID-03104's wake-brief override, which has been stable in production since 2026-05-19). When the column is null, falls back to the existing manual-based generation with the soft 3-4 sentence rule — no regression for non-highlight capabilities.

Cross-language fallback: if `teacher_intro_de` is empty but `teacher_intro_en` is set, the resolver returns the EN script (and vice-versa). Speaking the locked script in the wrong language is preferable to letting Gemini freelance a 2-sentence summary.

## Test plan
- [x] 5 new resolver tests + 7 existing updated (cross-lang fallback, both-null returns null, returns DE when lang=de, EN when lang=en, oversized manual truncation still works).
- [x] **915 tests pass** across 54 suites.
- [x] `npm run build` clean.
- [ ] **Migration must apply BEFORE deploy**: the new gateway code SELECTs `teacher_intro_de, teacher_intro_en` columns. If gateway deploys first, the SELECT errors and the Teacher resolver silently falls back to null (legacy path) — not catastrophic but defeats the purpose. Apply migration first via RUN-MIGRATION.yml.
- [ ] **Runtime test on vitanaland**: tap orb on a fresh community user.
  1. The FIRST capability offered should be \"Life Compass\" (pedagogical_order=10), with joint-setup framing: \"Lass uns gleich gemeinsam deinen Life Compass einrichten — …\" (DE) or \"Let's set up your Life Compass together right now — …\" (EN).
  2. The intro should be **3-4 full sentences**, verbatim from the locked DB script — NOT a 2-sentence summary.
  3. The closing question should NAME the actual next capability (\"Vitana Index\", from pedagogical_order=20).
  4. When you say \"ja\", the next capability offered should be \"Vitana Index\" — with its own locked 3-4 sentence intro.

🤖 Generated with [Claude Code](https://claude.com/claude-code)