### PR TITLE
feat(orb-livekit): plumb lastSessionInfo + journey-trail into system instruction (VTID-03122)

### DIFF
--- a/services/gateway/src/routes/orb-livekit.ts
+++ b/services/gateway/src/routes/orb-livekit.ts
@@ -795,6 +795,33 @@ router.get(
       }
     }
 
+    // VTID-03122 (Phase E): accept optional journey-trail hints from the
+    // client so the LiveKit-rendered system instruction can populate the
+    // current-screen + journey trail in the TEMPORAL+JOURNEY block. Older
+    // callers (Test Bench) don't send these; new callers can supply them
+    // to close the parity gap with Vertex without forcing any frontend
+    // change today. Always optional, null-safe, capped at 10 entries.
+    const currentRoute =
+      typeof req.query.current_route === 'string' && req.query.current_route
+        ? String(req.query.current_route)
+        : null;
+    const recentRoutes: string[] | null = (() => {
+      const raw = req.query.recent_routes;
+      if (Array.isArray(raw)) {
+        return raw
+          .filter((r): r is string => typeof r === 'string' && r.length > 0)
+          .slice(0, 10);
+      }
+      if (typeof raw === 'string' && raw) {
+        return raw
+          .split(',')
+          .map((s) => s.trim())
+          .filter((s) => s.length > 0)
+          .slice(0, 10);
+      }
+      return null;
+    })();
+
     // VTID-03035 + VTID-03036: two-layer cache hit short-circuit.
     //  - L1 in-memory (per Cloud Run instance) — ~0ms when hit
     //  - L2 Supabase `bootstrap_cache` (shared across instances) — ~30-80ms
@@ -1409,6 +1436,23 @@ router.get(
         console.warn(`[VTID-03047] persona prompt fetch failed for ${agentId}: ${(exc as Error).message}`);
       }
     }
+    // VTID-03122 (Phase E): hoist fetchLastSessionInfo so the TEMPORAL+JOURNEY
+    // block in buildLiveSystemInstruction has real "Time since last ORB session"
+    // data instead of "UNKNOWN recency". The same call already runs inside the
+    // wake-brief block below — hoisting here lets both code paths share a
+    // single fetch. Best-effort: any error returns null and the temporal block
+    // degrades to UNKNOWN, never blocks the bootstrap.
+    let lastSessionInfo: { time: string; wasFailure: boolean } | null = null;
+    if (userId) {
+      try {
+        lastSessionInfo = await fetchLastSessionInfo(userId);
+      } catch (exc) {
+        console.warn(
+          `[${VTID}/VTID-03122] fetchLastSessionInfo failed (non-fatal, temporal block falls back to UNKNOWN): ${(exc as Error).message}`,
+        );
+      }
+    }
+
     // Vitana path: full 65KB system instruction with IDENTITY LOCK etc.
     try {
       if (systemInstruction === null) {
@@ -1436,9 +1480,9 @@ router.get(
         undefined,           // conversationSummary — not surfaced through bootstrap yet
         undefined,           // conversationHistory — agent reconnect path will populate later
         isReconnect,
-        null,                // lastSessionInfo — not surfaced through bootstrap yet
-        null,                // currentRoute — LiveKit path doesn't carry the React route
-        null,                // recentRoutes
+        lastSessionInfo,     // VTID-03122 (Phase E) — drives "Time since last ORB session" + wasFailure marker in the TEMPORAL+JOURNEY block
+        currentRoute,        // VTID-03122 (Phase E) — drives "Current screen" line when client supplies ?current_route=…
+        recentRoutes,        // VTID-03122 (Phase E) — drives journey trail when client supplies ?recent_routes=…
         envContext ?? undefined,
         req.identity?.vitana_id ?? null,
         true,                // VTID-03046 step 2 — LiveKit's session.say()
@@ -1472,7 +1516,10 @@ router.get(
         // continuation_decision_* events that fire from
         // decideWakeBriefForSession for THIS call.
         const wakeBriefSessionId = `livekit-bootstrap-${randomUUID()}`;
-        const lastSessionInfo = await fetchLastSessionInfo(userId);
+        // VTID-03122 (Phase E): reuse the lastSessionInfo hoisted at the top
+        // of the handler instead of re-fetching here. Single fetch per
+        // bootstrap, same value reaches both buildLiveSystemInstruction call
+        // sites and the wake-brief decision.
         const temporal = describeTimeSince(lastSessionInfo);
         // VTID-03081 (B1 wiring): read cadence signals from
         // user_assistant_state so decideGreetingPolicy() can apply the
@@ -1584,9 +1631,9 @@ router.get(
           undefined,
           undefined,
           isReconnect,
-          null,
-          null,
-          null,
+          lastSessionInfo,     // VTID-03122 (Phase E)
+          currentRoute,        // VTID-03122 (Phase E)
+          recentRoutes,        // VTID-03122 (Phase E)
           envContext ?? undefined,
           req.identity?.vitana_id ?? null,
           true,
@@ -1617,9 +1664,13 @@ router.get(
       active_role: role,
       conversation_summary: null,
       last_turns: null,
-      last_session_info: null,
-      current_route: null,
-      recent_routes: [],
+      // VTID-03122 (Phase E): echo the populated fields back so the client
+      // can verify what was applied. lastSessionInfo flows in from the
+      // hoisted fetch; currentRoute / recentRoutes echo the query-param
+      // input (null/[] when unset).
+      last_session_info: lastSessionInfo,
+      current_route: currentRoute,
+      recent_routes: recentRoutes ?? [],
       client_context: envContext ?? { user_agent: req.headers['user-agent'] ?? null },
       vitana_id: req.identity?.vitana_id ?? null,
       // VTID-LIVEKIT-IDENTITY-NAME: surface the user's name + verified facts as

--- a/services/gateway/test/orb/routes/livekit-context-parity.test.ts
+++ b/services/gateway/test/orb/routes/livekit-context-parity.test.ts
@@ -104,3 +104,62 @@ describe('VTID-03036 LiveKit context parity wire-up', () => {
     expect(source).toMatch(/getCurrentFacts/);
   });
 });
+
+describe('VTID-03122 Phase E LiveKit context parity — lastSessionInfo + journey trail', () => {
+  it('extracts current_route from the query string', () => {
+    expect(source).toMatch(/req\.query\.current_route/);
+    expect(source).toMatch(/const\s+currentRoute\s*=/);
+  });
+
+  it('extracts recent_routes as array or comma-separated string', () => {
+    expect(source).toMatch(/req\.query\.recent_routes/);
+    expect(source).toMatch(/Array\.isArray\(raw\)/);
+    expect(source).toMatch(/split\(['"`],['"`]\)/);
+  });
+
+  it('caps recent_routes at 10 entries to bound prompt size', () => {
+    expect(source).toMatch(/\.slice\(0,\s*10\)/);
+  });
+
+  it('hoists fetchLastSessionInfo so both buildLiveSystemInstruction call sites share one fetch', () => {
+    expect(source).toMatch(
+      /let\s+lastSessionInfo:\s*\{\s*time:\s*string;\s*wasFailure:\s*boolean\s*\}\s*\|\s*null\s*=\s*null/,
+    );
+    expect(source).toMatch(/lastSessionInfo\s*=\s*await\s+fetchLastSessionInfo\(userId\)/);
+  });
+
+  it('threads lastSessionInfo / currentRoute / recentRoutes into both buildLiveSystemInstruction call sites', () => {
+    // Both calls must reference the variables; the original `null` literals
+    // for these positional args were the parity leak.
+    const callRegex = /buildLiveSystemInstruction\([\s\S]*?\);/g;
+    const calls = source.match(callRegex) ?? [];
+    const vitanaCalls = calls.filter((c) => c.includes('vitanaContextInstruction') || c.includes('augmentedContext'));
+    expect(vitanaCalls.length).toBeGreaterThanOrEqual(2);
+    for (const call of vitanaCalls) {
+      expect(call).toMatch(/\blastSessionInfo\b/);
+      expect(call).toMatch(/\bcurrentRoute\b/);
+      expect(call).toMatch(/\brecentRoutes\b/);
+    }
+  });
+
+  it('does not re-fetch lastSessionInfo inside the wake-brief block (single fetch only)', () => {
+    // One single occurrence of `await fetchLastSessionInfo` is the hoist.
+    // A duplicate inside the wake-brief block would mean the route fetches
+    // twice per request.
+    const matches = source.match(/await\s+fetchLastSessionInfo\(/g) ?? [];
+    expect(matches.length).toBe(1);
+  });
+
+  it('echoes lastSessionInfo / currentRoute / recentRoutes back in the bootstrap response payload', () => {
+    expect(source).toMatch(/last_session_info:\s*lastSessionInfo/);
+    expect(source).toMatch(/current_route:\s*currentRoute/);
+    expect(source).toMatch(/recent_routes:\s*recentRoutes\s*\?\?\s*\[\]/);
+  });
+
+  it('degrades silently when fetchLastSessionInfo throws (best-effort, no rethrow)', () => {
+    // Must wrap the hoisted fetch in try/catch so a temporal-bucket lookup
+    // failure cannot block the bootstrap response. The Vertex orb-live.ts
+    // path is unaffected.
+    expect(source).toMatch(/fetchLastSessionInfo failed[\s\S]{0,200}falls back to UNKNOWN/);
+  });
+});


### PR DESCRIPTION
## Summary
**Phase E** of the contextual-intelligence refactor (per `docs/decision-contract/phase-b-brief.md` roadmap). Closes the parity gap in `orb-livekit.ts` where `null` was passed for `lastSessionInfo` / `currentRoute` / `recentRoutes` when calling `buildLiveSystemInstruction` — leaving the TEMPORAL+JOURNEY block reporting "UNKNOWN recency" + "(no prior screens reported this session)" on every LiveKit bootstrap.

## Why
Audit identified five missing fields. Three of them (`memoryContext.formatted_context`, `recentTurnsBlock`, `profileBlock`) were already closed by VTID-03036 via `historyContextPack.contextInstruction` inlining into `bootstrap_context`. `conversationHistory` is session-lifecycle state and doesn't apply to a one-shot bootstrap HTTP request. **`lastSessionInfo` was the real remaining gap** + the journey-trail (`currentRoute` / `recentRoutes`) needed a client-driven plumbing seam.

## Changes (`services/gateway/src/routes/orb-livekit.ts`)
1. **Hoist `fetchLastSessionInfo(userId)`** to the top of the handler. Single fetch reaches both `buildLiveSystemInstruction` call sites + the wake-brief decision. Best-effort — fetch failure degrades to UNKNOWN, never blocks the bootstrap.
2. **Accept optional `?current_route=` and `?recent_routes=` query params** (array or comma-separated, capped at 10 entries). Older callers unchanged; new callers can close the journey-trail gap without forcing a frontend change today.
3. **Echo back the three fields** in the bootstrap response so callers verify what was applied.

## Tests
8 new VTID-03122 source-level wire-up assertions in `test/orb/routes/livekit-context-parity.test.ts` (matches the existing VTID-03036 pattern):
- query-param extraction for `current_route` and `recent_routes`
- 10-entry cap on `recent_routes`
- single-fetch `fetchLastSessionInfo` hoist
- both `buildLiveSystemInstruction` call sites receive the three threaded variables
- no re-fetch inside the wake-brief block
- response payload echoes the three fields
- best-effort try/catch around the hoisted fetch

Full orb suite: **770/770 tests passing, 46/46 suites green**.

## Test plan
- [ ] CI: gateway build + orb tests stay green
- [ ] Post-deploy: `/alive` returns 200 JSON
- [ ] Post-deploy: `GET /api/v1/orb/context-bootstrap?agent_id=vitana&current_route=/wallet&recent_routes=/home,/insights` returns a JSON response whose `current_route` and `recent_routes` echo the query input (or 401 with `application/json` for an unauthenticated probe — both confirm the route exists and the new params are wired)
- [ ] LiveKit canary still gated OFF (`voice.livekit_agent_enabled=false`) — change runs on the LiveKit code path only, no user-facing behavior change on Vertex

🤖 Generated with [Claude Code](https://claude.com/claude-code)