### PR TITLE
fix(teacher): cadence-aware greeting + LLM-picked awareness events (VTID-03123)

### DIFF
--- a/services/gateway/src/orb/teacher/teacher-mode-prompt.ts
+++ b/services/gateway/src/orb/teacher/teacher-mode-prompt.ts
@@ -161,16 +161,59 @@ ${remainingList}
      proper way to end. After calling the tool, your final spoken line
      should be the farewell itself.
 
-2. After every successful intro (you delivered the manual content for
-   a capability and the user heard it), call \`teacher_event\` with
-   eventName='tried' so the ledger records progress and the same
-   capability isn't re-offered next session.
+2. The awareness ledger (system_capabilities + user_capability_awareness)
+   has FIVE event names — \`introduced\`, \`seen\`, \`tried\`, \`completed\`,
+   \`dismissed\`. After every meaningful interaction with a capability,
+   call \`teacher_event\` with the event that ACTUALLY describes what
+   happened in conversation. Do NOT default-call 'tried' for every
+   intro — pick by context:
 
-3. After chaining to the next capability, set THAT capability as the
+   - \`introduced\`: you spoke the intro and the user heard it BUT did
+     not take any action with the capability. They said "okay, what's
+     next" or signaled satisfaction and moved on. Use this for the
+     common case of "I told them about X, they moved on" — this is the
+     RIGHT event for most chain transitions because the user has
+     LEARNED about the capability but the capability itself is not yet
+     in use. The ledger gives a 7-day soft skip; the capability can
+     resurface later when relevant.
+
+   - \`seen\`: the user actively acknowledged understanding (asked a
+     follow-up, summarized back to you) but did not act. Stronger
+     than introduced but still no action. Same 7-day soft skip.
+
+   - \`tried\`: the user actually USED the capability in this session.
+     For Life Compass: they completed a step of the setup with you.
+     For Diary: they made an entry. For Activity Match: they
+     started a match. This is a TERMINAL state — the capability is
+     not re-offered. Use ONLY when the user has actually done the
+     action, not just heard about it.
+
+   - \`completed\`: the user finished a complete cycle of the
+     capability (set up the Life Compass fully; built their first
+     match; completed a diary entry meaningfully). Stronger than
+     tried.
+
+   - \`dismissed\`: the user politely declined ("nicht jetzt", "not
+     interested", "skip that") without anger. Resurfaces gently
+     after 30 days.
+
+   For the most common chain transition (intro spoken → user satisfied
+   → moving on), use \`introduced\`. Reserve \`tried\` / \`completed\`
+   for sessions where the user actually exercised the capability.
+
+3. The Remaining Capabilities list above ALREADY excludes everything
+   the user has \`tried\` / \`completed\` / \`mastered\`. If the user
+   directly asks about a capability NOT in the Remaining list
+   (i.e. they've already done it), do NOT re-teach from scratch.
+   Acknowledge they have it, and offer to modify, recall details
+   they may have forgotten, or check progress. The user's first
+   instinct will be that you remember them, not that you reset.
+
+4. After chaining to the next capability, set THAT capability as the
    new active one in your reasoning. Use the Remaining list above as
    your curriculum — pick the next entry, not a random one.
 
-4. You may be asked to switch persona (report_to_specialist) at any
+5. You may be asked to switch persona (report_to_specialist) at any
    time. If that happens, the session is no longer in Teacher Mode —
    honor the persona switch.
 

--- a/services/gateway/src/services/assistant-continuation/providers/teacher/feature-discovery-teacher.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/teacher/feature-discovery-teacher.ts
@@ -251,9 +251,12 @@ export function renderTeacherLine(args: {
   greeting: string;
   invitation: string;
 }): string {
-  // Trim every clause, join with a single space. Greeting ends in `.`
-  // (enforced by the pool), invitation has a `?` somewhere.
-  return `${args.greeting.trim()} ${args.invitation.trim()}`;
+  // VTID-03123: greeting may be empty (cadence-class skip — rapid re-tap).
+  // In that case the rendered line is just the invitation, no leading
+  // space or stale "Welcome back".
+  const g = args.greeting.trim();
+  const inv = args.invitation.trim();
+  return g.length > 0 ? `${g} ${inv}` : inv;
 }
 
 // ---------------------------------------------------------------------------
@@ -392,10 +395,16 @@ export function makeFeatureDiscoveryTeacherProvider(
       }
 
       // ---- Render the two-clause line ----
+      // VTID-03123: pass the B1 greetingPolicy so the greeting clause is
+      // SUPPRESSED on cadence-class skips (rapid re-tap, greet-once
+      // window). The invitation always fires — the Teacher's offer is
+      // its purpose — but a 5-second re-tap should not produce
+      // "Welcome back, Dragan."
       const greetingPick = pickTeacherGreetingMeta({
         lang: inputs.lang,
         firstName: inputs.firstName ?? null,
         rng,
+        greetingPolicy: inputs.greetingPolicy,
       });
       // For the FIRST introduction we keep the invitation abstract
       // (no featureLabel) — Vitana asks "may I show you something?"

--- a/services/gateway/src/services/assistant-continuation/providers/teacher/teacher-greeting-pool.ts
+++ b/services/gateway/src/services/assistant-continuation/providers/teacher/teacher-greeting-pool.ts
@@ -87,11 +87,41 @@ export interface TeacherGreetingPick {
   poolSize: number;
 }
 
+/**
+ * VTID-03123: pickTeacherGreetingMeta now reads the B1 `greetingPolicy`
+ * the existing decideGreetingPolicy* produces and skips the greeting
+ * clause entirely when policy is 'skip'. That's the case for rapid
+ * re-taps (under 60s since last turn) and the greet-once-per-15-min
+ * window — the user's instinct ("if I've been there a few seconds ago
+ * it should greet in a simple way, knowing I have been there a few
+ * seconds ago") translates to: no warm "Welcome back, Dragan", just
+ * the invitation clause that's about to follow. The greeting POOL
+ * itself stays untouched (it's content, picked from when applicable);
+ * the change is in WHEN to pick from it.
+ *
+ * Returns `{ text: '', rawTemplate: '', idx: -1, poolSize: 0 }` on skip
+ * — the caller's renderTeacherLine drops the empty prefix and the
+ * Teacher's userFacingLine becomes just the invitation.
+ *
+ * Other policy values still draw from the full pool — `brief_resume`,
+ * `warm_return`, and `fresh_intro` all currently use the same pool.
+ * Future slices can tier the pool further by warmth (e.g. "Hi again."
+ * for brief_resume vs "Welcome back, Dragan." for fresh_intro) — that
+ * is a content-tuning slice, not a logic change here.
+ */
 export function pickTeacherGreetingMeta(args: {
   lang: string;
   firstName?: string | null;
   rng?: () => number;
+  /** VTID-03123: B1 greeting policy from decideGreetingPolicy. When
+   *  'skip' the greeting clause is suppressed entirely (rapid re-tap
+   *  / cadence-class skip). Optional — when absent the function
+   *  behaves as before (full-pool pick). */
+  greetingPolicy?: 'skip' | 'brief_resume' | 'warm_return' | 'fresh_intro';
 }): TeacherGreetingPick {
+  if (args.greetingPolicy === 'skip') {
+    return { text: '', rawTemplate: '', idx: -1, poolSize: 0 };
+  }
   const lang = (args.lang || 'en').toLowerCase();
   const pool = GREETING_PHRASES[lang] || GREETING_PHRASES.en;
   const hasName = !!(args.firstName && args.firstName.trim().length > 0);
@@ -120,6 +150,7 @@ export function pickTeacherGreeting(args: {
   lang: string;
   firstName?: string | null;
   rng?: () => number;
+  greetingPolicy?: 'skip' | 'brief_resume' | 'warm_return' | 'fresh_intro';
 }): string {
   return pickTeacherGreetingMeta(args).text;
 }

--- a/services/gateway/test/services/assistant-continuation/providers/teacher/feature-discovery-teacher.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/teacher/feature-discovery-teacher.test.ts
@@ -188,6 +188,27 @@ describe('VTID-03093 — renderTeacherLine', () => {
       }),
     ).toBe('Hi. May I?');
   });
+
+  // VTID-03123: when cadence-class skip suppressed the greeting, the
+  // renderer returns just the invitation — no leading space, no stale
+  // "Welcome back". The user's 5-second-re-tap complaint.
+  test('VTID-03123: empty greeting drops the leading space', () => {
+    expect(
+      renderTeacherLine({
+        greeting: '',
+        invitation: 'Magst du, dass ich dir Life Compass vorstelle?',
+      }),
+    ).toBe('Magst du, dass ich dir Life Compass vorstelle?');
+  });
+
+  test('VTID-03123: whitespace-only greeting also drops cleanly', () => {
+    expect(
+      renderTeacherLine({
+        greeting: '   ',
+        invitation: 'Want me to show you?',
+      }),
+    ).toBe('Want me to show you?');
+  });
 });
 
 // ---------------------------------------------------------------------------

--- a/services/gateway/test/services/assistant-continuation/providers/teacher/teacher-pools-meta.test.ts
+++ b/services/gateway/test/services/assistant-continuation/providers/teacher/teacher-pools-meta.test.ts
@@ -77,6 +77,58 @@ describe('VTID-03105 — pickTeacherGreetingMeta', () => {
     });
     expect(plain).toBe(meta.text);
   });
+
+  // VTID-03123: cadence-class skip drops the greeting clause.
+  test('greetingPolicy=skip returns empty text + idx=-1', () => {
+    const meta = pickTeacherGreetingMeta({
+      lang: 'de',
+      firstName: 'Dragan',
+      rng: () => 0,
+      greetingPolicy: 'skip',
+    });
+    expect(meta.text).toBe('');
+    expect(meta.rawTemplate).toBe('');
+    expect(meta.idx).toBe(-1);
+    expect(meta.poolSize).toBe(0);
+  });
+
+  test('greetingPolicy=skip wrapper returns empty string', () => {
+    const out = pickTeacherGreeting({
+      lang: 'de',
+      firstName: 'Dragan',
+      rng: () => 0,
+      greetingPolicy: 'skip',
+    });
+    expect(out).toBe('');
+  });
+
+  test('non-skip policies still draw from the full pool', () => {
+    for (const policy of ['brief_resume', 'warm_return', 'fresh_intro'] as const) {
+      const meta = pickTeacherGreetingMeta({
+        lang: 'de',
+        firstName: 'Dragan',
+        rng: () => 0,
+        greetingPolicy: policy,
+      });
+      expect(meta.text.length).toBeGreaterThan(0);
+      expect(meta.idx).toBeGreaterThanOrEqual(0);
+      expect(meta.poolSize).toBeGreaterThan(0);
+    }
+  });
+
+  test('greetingPolicy absent (undefined) behaves like pre-VTID-03123 (full pool)', () => {
+    // Backward-compat guard: callers that don't pass greetingPolicy
+    // still get the full pool. Existing wake-brief code paths that
+    // haven't been updated to forward policy don't suddenly silence
+    // greetings.
+    const meta = pickTeacherGreetingMeta({
+      lang: 'de',
+      firstName: 'Dragan',
+      rng: () => 0,
+    });
+    expect(meta.text.length).toBeGreaterThan(0);
+    expect(meta.poolSize).toBeGreaterThan(0);
+  });
 });
 
 describe('VTID-03105 — pickTeacherInvitationMeta', () => {


### PR DESCRIPTION
## Why
Two user complaints, both about hardcoded behavior the LLM should own:

1. **Rapid re-tap still gets the full warm greeting.** \"If I come back after 5 seconds it still says 'Hello Dragan, nice you're back'.\" The greeting-policy already returns `'skip'` for rapid re-taps (`recent_turn_continues_thread`, `greeted_recently_within_window`). The Teacher just wasn't reading the signal — `pickTeacherGreeting` always drew from the full pool.

2. **Awareness event hardcoded to `'tried'`** after every intro. \"`tried`\" is TERMINAL in the 5-event state machine, so calling it for \"user heard the intro and said next\" permanently locked the capability out of re-offering even though the user hadn't used it. The user explicitly demanded no hardcoded rules.

## What changed
**Fix 1 — Cadence-aware greeting:**
`pickTeacherGreetingMeta` now accepts `greetingPolicy`. On `'skip'` it returns an empty clause; `renderTeacherLine` drops the leading space; the Teacher's `userFacingLine` becomes just the invitation (e.g. *\"Magst du, dass ich dir Life Compass vorstelle?\"*) without the stale *\"Welcome back, Dragan.\"* prefix. Non-skip policies (`brief_resume` / `warm_return` / `fresh_intro`) still draw from the full pool.

**Fix 2 — LLM picks the right awareness event:**
Removed the hardcoded `eventName='tried'` directive from the Teacher Mode prompt. Replaced with a description of all 5 events:
- `introduced`: spoke intro, user moved on (no action) — 7-day soft skip
- `seen`: user acknowledged understanding (no action) — 7-day soft skip
- `tried`: user actually USED the capability this session — TERMINAL
- `completed`: full setup cycle done — TERMINAL
- `dismissed`: polite decline — resurfaces after 30 days

The LLM picks based on what actually happened in conversation. For the common chain transition (intro spoken → user satisfied → next), the right event is `introduced` — the capability stays in the curriculum for relevant resurfacing later.

**Bonus:** new section in the prompt for the case where the user directly asks about a capability they've already completed: don't re-teach — offer modification / recall / progress check.

## Test plan
- [x] 4 new tests in `teacher-pools-meta.test.ts` covering all greetingPolicy values + backward-compat (undefined → full pool).
- [x] 2 new tests in `feature-discovery-teacher.test.ts` for renderTeacherLine handling empty / whitespace-only greeting cleanly.
- [x] **835 tests pass** across 50 suites.
- [x] `npm run build` clean.
- [ ] **Runtime test on vitanaland**: re-tap the orb within ~10 seconds of closing it. The new opening should be just the invitation, no \"Welcome back, Dragan.\". And after the intro, when you say \"next\", the next session should NOT skip the same capability — Gemini should now pick `introduced` (soft skip) rather than `tried` (permanent).

🤖 Generated with [Claude Code](https://claude.com/claude-code)