### PR TITLE
feat(decision-contract): Phase D.1 — voice thresholds externalized via PolicyResolver (VTID-03124)

### DIFF
--- a/services/gateway/src/orb/live/session/live-session-controller.ts
+++ b/services/gateway/src/orb/live/session/live-session-controller.ts
@@ -43,9 +43,10 @@ import type { ContextPack } from '../../../types/conversation';
 import { SESSION_TIMEOUT_MS, VERTEX_PROJECT_ID } from '../config';
 import { VERTEX_LIVE_MODEL } from '../protocol';
 import {
-  VAD_SILENCE_DURATION_MS_DEFAULT,
-  POST_TURN_COOLDOWN_MS,
-  FORWARDING_ACK_TIMEOUT_MS,
+  // VTID-03124 (Phase D.1): voice thresholds now resolved via PolicyResolver.
+  getVadSilenceDurationMs,
+  getPostTurnCooldownMs,
+  getForwardingAckTimeoutMs,
 } from '../../upstream/constants';
 import { destroySessionBuffer } from '../../../services/session-memory-buffer';
 import {
@@ -725,7 +726,7 @@ export async function handleLiveSessionStart(
     lastAudioForwardedTime: Date.now(),
     lastTelemetryEmitTime: 0,
     vadSilenceMs: (body as any).vad_silence_ms && (body as any).vad_silence_ms >= 500 && (body as any).vad_silence_ms <= 3000
-      ? (body as any).vad_silence_ms : VAD_SILENCE_DURATION_MS_DEFAULT,
+      ? (body as any).vad_silence_ms : getVadSilenceDurationMs(),
     greetingDeferred: false,
     lastSessionInfo,
     consecutiveModelTurns: 0,
@@ -1375,7 +1376,7 @@ export async function handleLiveStreamSend(
       }
 
       // VTID-ECHO-COOLDOWN: Post-turn cooldown drops mic for N ms.
-      if (session.turnCompleteAt > 0 && (Date.now() - session.turnCompleteAt) < POST_TURN_COOLDOWN_MS) {
+      if (session.turnCompleteAt > 0 && (Date.now() - session.turnCompleteAt) < getPostTurnCooldownMs()) {
         session.audioInChunks++;
         return res.json({ ok: true, dropped: true, reason: 'post_turn_cooldown' });
       }
@@ -1413,7 +1414,7 @@ export async function handleLiveStreamSend(
               const canSlide = !session.responseWatchdogTimer
                 || session.responseWatchdogReason === 'forwarding_no_ack';
               if (canSlide) {
-                deps.startResponseWatchdog(session, FORWARDING_ACK_TIMEOUT_MS, 'forwarding_no_ack');
+                deps.startResponseWatchdog(session, getForwardingAckTimeoutMs(), 'forwarding_no_ack');
               }
             }
           }

--- a/services/gateway/src/orb/live/session/upstream-message-handler.ts
+++ b/services/gateway/src/orb/live/session/upstream-message-handler.ts
@@ -38,13 +38,14 @@ import type { GeminiLiveSession } from '../../../routes/orb-live';
 import type { MemoryIdentity } from '../../../services/orb-memory-bridge';
 import { writeSseEvent } from '../transport/sse-handler';
 import {
-  POST_TURN_COOLDOWN_MS,
-  MAX_CONSECUTIVE_MODEL_TURNS,
-  MAX_CONSECUTIVE_TOOL_CALLS,
-  TURN_RESPONSE_TIMEOUT_MS,
+  // VTID-03124 (Phase D.1): voice thresholds now resolved via PolicyResolver.
+  getPostTurnCooldownMs,
+  getMaxConsecutiveModelTurns,
+  getMaxConsecutiveToolCalls,
+  getTurnResponseTimeoutMs,
+  getSilenceIdleThresholdMs,
+  getSilenceKeepaliveIntervalMs,
   SILENCE_AUDIO_B64,
-  SILENCE_IDLE_THRESHOLD_MS,
-  SILENCE_KEEPALIVE_INTERVAL_MS,
 } from '../../upstream/constants';
 import { emitOasisEvent } from '../../../services/oasis-event-service';
 import { handleIdentityIntent } from '../../../services/identity-intent-handler';
@@ -174,7 +175,7 @@ export function createUpstreamLiveMessageHandler(
             // Vertex VAD to briefly process the input, creating audible glitches.
             if (session.isModelSpeaking) return;
             const idleMs = Date.now() - session.lastAudioForwardedTime;
-            if (idleMs >= SILENCE_IDLE_THRESHOLD_MS) {
+            if (idleMs >= getSilenceIdleThresholdMs()) {
               try {
                 ctx.deps.sendAudioToLiveAPI(ws, SILENCE_AUDIO_B64, 'audio/pcm;rate=16000');
                 // Don't update lastAudioForwardedTime — silence doesn't count as real audio
@@ -182,7 +183,7 @@ export function createUpstreamLiveMessageHandler(
                 // WS may be closing — ignore
               }
             }
-          }, SILENCE_KEEPALIVE_INTERVAL_MS);
+          }, getSilenceKeepaliveIntervalMs());
 
           // setup-complete handshake completed via ctx.onSetupComplete() above
           return;
@@ -227,10 +228,10 @@ export function createUpstreamLiveMessageHandler(
             // VTID-VOICE-INIT: Model finished speaking — ungate mic audio
             session.isModelSpeaking = false;
             // VTID-ECHO-COOLDOWN: Record turn completion time for post-turn mic cooldown.
-            // Client playback queue may still be draining — gate mic for POST_TURN_COOLDOWN_MS
+            // Client playback queue may still be draining — gate mic for getPostTurnCooldownMs()
             // to prevent speaker echo from being picked up and triggering phantom responses.
             session.turnCompleteAt = Date.now();
-            console.log(`[VTID-VOICE-INIT] Model stopped speaking for session ${session.sessionId} — mic audio ungated (cooldown ${POST_TURN_COOLDOWN_MS}ms)`);
+            console.log(`[VTID-VOICE-INIT] Model stopped speaking for session ${session.sessionId} — mic audio ungated (cooldown ${getPostTurnCooldownMs()}ms)`);
             ctx.deps.emitDiag(session, 'turn_complete');
 
             // VTID-02047 voice channel-swap: if a persona swap was queued by
@@ -330,7 +331,7 @@ export function createUpstreamLiveMessageHandler(
 
             // VTID-LOOPGUARD: If the model has responded too many times without user input,
             // pause the silence keepalive so Vertex's idle timeout stops the loop naturally.
-            if (session.consecutiveModelTurns > MAX_CONSECUTIVE_MODEL_TURNS && !isGreetingTurn) {
+            if (session.consecutiveModelTurns > getMaxConsecutiveModelTurns() && !isGreetingTurn) {
               console.warn(`[VTID-LOOPGUARD] Response loop detected for session ${session.sessionId}: ${session.consecutiveModelTurns} consecutive model turns without user speech — pausing silence keepalive`);
               if (session.silenceKeepaliveInterval) {
                 clearInterval(session.silenceKeepaliveInterval);
@@ -827,7 +828,7 @@ export function createUpstreamLiveMessageHandler(
                 }
                 // VTID-WATCHDOG: Model is sending audio — restart watchdog.
                 // If audio stops mid-stream (no turn_complete), watchdog fires.
-                ctx.deps.startResponseWatchdog(session, TURN_RESPONSE_TIMEOUT_MS, 'audio_stall');
+                ctx.deps.startResponseWatchdog(session, getTurnResponseTimeoutMs(), 'audio_stall');
                 session.audioOutChunks++;
                 const audioB64 = inlineData.data;
                 // VTID-STREAM-KEEPALIVE: Only log every 50th audio chunk to reduce log volume
@@ -846,7 +847,7 @@ export function createUpstreamLiveMessageHandler(
               if (part.text) {
                 // VTID-WATCHDOG: Model is responding with text — restart watchdog.
                 // If text stops mid-stream (no turn_complete), watchdog fires.
-                ctx.deps.startResponseWatchdog(session, TURN_RESPONSE_TIMEOUT_MS, 'text_stall');
+                ctx.deps.startResponseWatchdog(session, getTurnResponseTimeoutMs(), 'text_stall');
                 console.log(`[VTID-01219] Received text: ${part.text.substring(0, 100)}`);
                 ctx.callbacks.onTextResponse(part.text);
               }
@@ -898,18 +899,18 @@ export function createUpstreamLiveMessageHandler(
                   if (!session.upstreamWs || session.upstreamWs.readyState !== WebSocket.OPEN || !session.active) return;
                   if (session.isModelSpeaking) return;
                   const idleMs = Date.now() - session.lastAudioForwardedTime;
-                  if (idleMs >= SILENCE_IDLE_THRESHOLD_MS) {
+                  if (idleMs >= getSilenceIdleThresholdMs()) {
                     try {
                       ctx.deps.sendAudioToLiveAPI(session.upstreamWs, SILENCE_AUDIO_B64, 'audio/pcm;rate=16000');
                     } catch (_e) { /* WS closing */ }
                   }
-                }, SILENCE_KEEPALIVE_INTERVAL_MS);
+                }, getSilenceKeepaliveIntervalMs());
               }
 
               // VTID-WATCHDOG: User spoke — start watchdog waiting for model response.
               // Restart on each transcript fragment to give the model time from the
               // LAST user speech, not the first (user may still be speaking).
-              ctx.deps.startResponseWatchdog(session, TURN_RESPONSE_TIMEOUT_MS, 'response_timeout');
+              ctx.deps.startResponseWatchdog(session, getTurnResponseTimeoutMs(), 'response_timeout');
 
               // VTID-THINKING: Notify client that model is processing (user spoke, waiting for response).
               // Client uses this to show "Thinking..." state instead of staying on "Listening...".
@@ -946,7 +947,7 @@ export function createUpstreamLiveMessageHandler(
         if (toolCall) {
           const toolNames = (toolCall.function_calls || toolCall.functionCalls || []).map((fc: any) => fc.name);
           session.consecutiveToolCalls++;
-          console.log(`[VTID-01224] Tool call received for session ${session.sessionId} (consecutive: ${session.consecutiveToolCalls}/${MAX_CONSECUTIVE_TOOL_CALLS}):`, JSON.stringify(toolCall).substring(0, 500));
+          console.log(`[VTID-01224] Tool call received for session ${session.sessionId} (consecutive: ${session.consecutiveToolCalls}/${getMaxConsecutiveToolCalls()}):`, JSON.stringify(toolCall).substring(0, 500));
           ctx.deps.emitDiag(session, 'tool_call', { tools: toolNames, consecutive: session.consecutiveToolCalls });
 
           // VTID-THINKING: Notify client that model is processing a tool call.
@@ -971,8 +972,8 @@ export function createUpstreamLiveMessageHandler(
           // `watchdog_fired` with reason `forwarding_no_ack`. Sending a
           // synthetic response keeps the Live API protocol intact while still
           // forcing the model out of the tool-call loop.
-          if (session.consecutiveToolCalls > MAX_CONSECUTIVE_TOOL_CALLS) {
-            console.warn(`[VTID-TOOLGUARD] Tool call loop detected for session ${session.sessionId}: ${session.consecutiveToolCalls} consecutive calls (limit: ${MAX_CONSECUTIVE_TOOL_CALLS}). Sending synthetic loop-break response.`);
+          if (session.consecutiveToolCalls > getMaxConsecutiveToolCalls()) {
+            console.warn(`[VTID-TOOLGUARD] Tool call loop detected for session ${session.sessionId}: ${session.consecutiveToolCalls} consecutive calls (limit: ${getMaxConsecutiveToolCalls()}). Sending synthetic loop-break response.`);
             ctx.deps.emitDiag(session, 'tool_loop_guard', { consecutive: session.consecutiveToolCalls, dropped_tools: toolNames });
             ctx.deps.emitLiveSessionEvent('orb.live.tool_loop_guard_activated', {
               session_id: session.sessionId,

--- a/services/gateway/src/orb/upstream/constants.ts
+++ b/services/gateway/src/orb/upstream/constants.ts
@@ -1,10 +1,22 @@
 /**
- * BOOTSTRAP-ORB-MOVE: Phase 2 (move-only) — protocol + watchdog + keepalive
- * constants that were previously inline in routes/orb-live.ts.
+ * Voice-pipeline thresholds + protocol constants.
  *
- * All values are preserved byte-for-byte. No behaviour change.
+ * Phase D.1 (VTID-03124) moved the tunable thresholds out of `export
+ * const` literals and behind accessor functions that read from
+ * `PolicyResolver`. The literal values that previously lived here are
+ * kept as `*_FALLBACK` constants — they are the safety-net `defaultValue`
+ * the accessor passes to `getValue`, so behaviour is byte-identical when
+ * the resolver cache is cold (boot warm-up race) or when the
+ * `decision_policy` row is missing.
  *
- * Categories:
+ * Connection-issue messages (8 languages) remain as a literal Record for
+ * now — Phase D.2 migrates them to `policy_render_block`.
+ *
+ * The protocol-derived constants (`SILENCE_PCM_BYTES`,
+ * `SILENCE_AUDIO_B64`) stay as literals because they encode the on-wire
+ * sample-rate format (16 kHz mono 16-bit) — not a tuning knob.
+ *
+ * Original BOOTSTRAP-ORB-MOVE phase 2 move-only history:
  *   - VAD / end-of-speech detection
  *   - Post-turn mic cooldown (echo prevention)
  *   - Silence keepalive (anti-idle-timeout)
@@ -14,116 +26,138 @@
  *   - User-facing connection-issue messages
  */
 
-// =============================================================================
-// VTID-RESPONSE-DELAY: VAD silence threshold for end-of-speech detection
-// =============================================================================
-// How long Vertex waits after user stops speaking before triggering a response.
-// Default Vertex VAD is ~100ms which is too aggressive — the model starts
-// responding while users are still mid-thought or pausing between sentences.
-//
-// Tuning history:
-//   100ms   (Vertex default)  — too aggressive, cut off the user mid-thought
-//   1_200ms (VTID-RESPONSE-DELAY)  — safe, but felt sluggish
-//   850ms   (VTID-03019)            — current; trims ~350ms off end-of-turn
-//                                     latency while still tolerating short
-//                                     conversational pauses (sub-sentence
-//                                     breaths, "uh", "let me think…").
-//                                     Watch for false turn-takes when users
-//                                     pause >850ms between thoughts; if seen,
-//                                     bump back toward 1_000ms.
-export const VAD_SILENCE_DURATION_MS_DEFAULT = 850;
+import { getPolicyResolver } from '../../services/decision-contract/policy-resolver';
+import { POLICY_KEYS } from '../../services/decision-contract/policy-keys';
 
-// =============================================================================
-// VTID-ECHO-COOLDOWN: Post-turn mic audio cooldown
-// =============================================================================
-// After Vertex sends turn_complete, the server unsets isModelSpeaking
-// immediately. But the client is still draining its audio playback queue
-// (Web Audio API scheduled sources). During this window, speaker output gets
-// picked up by the mic and forwarded to Vertex as new user speech, causing
-// phantom responses. Mobile AEC is weak — diagnostics show ghost responses
-// triggered on 2 chunks (~170ms) within 740ms of turn_complete. 2000ms covers
-// realistic mobile playback drain without killing responsiveness.
-export const POST_TURN_COOLDOWN_MS = 2_000;
+// ---------------------------------------------------------------------------
+// Safety-net fallback values. Match the Phase D.1 seed rows byte-for-byte.
+// Used by the accessor functions below when the resolver cache is cold or
+// when no row is seeded for the key. Production source of truth is the
+// `decision_policy` table.
+// ---------------------------------------------------------------------------
 
-// =============================================================================
-// VTID-STREAM-SILENCE: Silence audio keepalive for Vertex Live API
-// =============================================================================
-// Vertex closes the stream with code 1000 after ~25-30s of no audio.
-// Periodic 250ms silence frames keep it alive during user pauses.
-export const SILENCE_KEEPALIVE_INTERVAL_MS = 3_000; // Check every 3s
-export const SILENCE_IDLE_THRESHOLD_MS = 3_000;     // Send silence after 3s idle
-export const SILENCE_PCM_BYTES = 8_000;             // 250ms at 16kHz, 16-bit mono
+// VTID-RESPONSE-DELAY / VTID-03019: 1_200 → 850 ms trims ~350ms off
+// end-of-turn latency vs the original Vertex VAD default of 100 ms (too
+// aggressive — cut users off mid-thought).
+const VAD_SILENCE_DURATION_MS_FALLBACK = 850;
+
+// VTID-ECHO-COOLDOWN: gates mic for 2s after turn_complete so the
+// client's draining playback queue doesn't leak into the upstream WS
+// as new user speech (mobile AEC is weak; ghost-response repro under
+// PR #743).
+const POST_TURN_COOLDOWN_MS_FALLBACK = 2_000;
+
+// VTID-STREAM-SILENCE: Vertex closes the stream after ~25-30s of no
+// audio. A 250ms silence frame every 3s keeps it open during pauses.
+const SILENCE_KEEPALIVE_INTERVAL_MS_FALLBACK = 3_000;
+const SILENCE_IDLE_THRESHOLD_MS_FALLBACK = 3_000;
+
+// VTID-WATCHDOG: stall detection windows. 8s greeting / 10s turn — short
+// enough to recover from a true Vertex stall, long enough to tolerate a
+// healthy 5-7s first-turn inference.
+const GREETING_RESPONSE_TIMEOUT_MS_FALLBACK = 8_000;
+const TURN_RESPONSE_TIMEOUT_MS_FALLBACK = 10_000;
+
+// VTID-FORWARDING-WATCHDOG (latest = VTID-01984): 45s tolerance for
+// genuine first-turn before any sign of life. With ~15K-char system
+// instruction + 16 tools, Vertex's first-turn inference can take 8-12s;
+// shorter windows fire inside the compute window and destroy the
+// utterance. Once Vertex has shown ANY sign of life (transcription,
+// start_speaking, audio chunk), the arm site skips this watchdog
+// entirely — see the call site in live-session-controller.ts.
+const FORWARDING_ACK_TIMEOUT_MS_FALLBACK = 45_000;
+
+// VTID-LOOPGUARD: pause silence keepalive after 3 model turns without
+// user speech so Vertex's idle timeout breaks the loop.
+const MAX_CONSECUTIVE_MODEL_TURNS_FALLBACK = 3;
+
+// VTID-TOOLGUARD: 5 consecutive tool calls without audio output → inject
+// a synthetic function_response so the model answers from data gathered
+// so far. See PR #743 for the non-destructive injection pattern.
+const MAX_CONSECUTIVE_TOOL_CALLS_FALLBACK = 5;
+
+// ---------------------------------------------------------------------------
+// Accessor functions — call these instead of importing the old `const`.
+// ---------------------------------------------------------------------------
+
+export function getVadSilenceDurationMs(): number {
+  return getPolicyResolver().getValue<number>(
+    POLICY_KEYS.VOICE_VAD_SILENCE_DURATION_MS,
+    { defaultValue: VAD_SILENCE_DURATION_MS_FALLBACK },
+  );
+}
+
+export function getPostTurnCooldownMs(): number {
+  return getPolicyResolver().getValue<number>(
+    POLICY_KEYS.VOICE_POST_TURN_COOLDOWN_MS,
+    { defaultValue: POST_TURN_COOLDOWN_MS_FALLBACK },
+  );
+}
+
+export function getSilenceKeepaliveIntervalMs(): number {
+  return getPolicyResolver().getValue<number>(
+    POLICY_KEYS.VOICE_SILENCE_KEEPALIVE_INTERVAL_MS,
+    { defaultValue: SILENCE_KEEPALIVE_INTERVAL_MS_FALLBACK },
+  );
+}
+
+export function getSilenceIdleThresholdMs(): number {
+  return getPolicyResolver().getValue<number>(
+    POLICY_KEYS.VOICE_SILENCE_KEEPALIVE_IDLE_THRESHOLD_MS,
+    { defaultValue: SILENCE_IDLE_THRESHOLD_MS_FALLBACK },
+  );
+}
+
+export function getGreetingResponseTimeoutMs(): number {
+  return getPolicyResolver().getValue<number>(
+    POLICY_KEYS.VOICE_WATCHDOG_GREETING_TIMEOUT_MS,
+    { defaultValue: GREETING_RESPONSE_TIMEOUT_MS_FALLBACK },
+  );
+}
+
+export function getTurnResponseTimeoutMs(): number {
+  return getPolicyResolver().getValue<number>(
+    POLICY_KEYS.VOICE_WATCHDOG_TURN_RESPONSE_TIMEOUT_MS,
+    { defaultValue: TURN_RESPONSE_TIMEOUT_MS_FALLBACK },
+  );
+}
+
+export function getForwardingAckTimeoutMs(): number {
+  return getPolicyResolver().getValue<number>(
+    POLICY_KEYS.VOICE_WATCHDOG_FORWARDING_ACK_TIMEOUT_MS,
+    { defaultValue: FORWARDING_ACK_TIMEOUT_MS_FALLBACK },
+  );
+}
+
+export function getMaxConsecutiveModelTurns(): number {
+  return getPolicyResolver().getValue<number>(
+    POLICY_KEYS.VOICE_LOOP_GUARD_MAX_CONSECUTIVE_MODEL_TURNS,
+    { defaultValue: MAX_CONSECUTIVE_MODEL_TURNS_FALLBACK },
+  );
+}
+
+export function getMaxConsecutiveToolCalls(): number {
+  return getPolicyResolver().getValue<number>(
+    POLICY_KEYS.VOICE_LOOP_GUARD_MAX_CONSECUTIVE_TOOL_CALLS,
+    { defaultValue: MAX_CONSECUTIVE_TOOL_CALLS_FALLBACK },
+  );
+}
+
+// ---------------------------------------------------------------------------
+// Protocol-derived constants (NOT tuning knobs — stay literal).
+// ---------------------------------------------------------------------------
+// 250ms at 16kHz mono 16-bit = 16000 * 0.25 * 2 = 8000 bytes. This encodes
+// the on-wire audio format the upstream expects; changing it would mean
+// a different frame size, not a different policy.
+export const SILENCE_PCM_BYTES = 8_000;
 export const SILENCE_AUDIO_B64 = Buffer.alloc(SILENCE_PCM_BYTES, 0).toString('base64');
-
-// =============================================================================
-// VTID-WATCHDOG: Response watchdog — stall detection across failure modes
-// =============================================================================
-// Monitors whether Gemini produces ANY output (audio/text) within N seconds
-// after greeting prompt or user speech. Catches Vertex stalls, tool-call
-// cascade failures, network drops, post-function-response hangs, etc.
-export const GREETING_RESPONSE_TIMEOUT_MS = 8_000;  // 8s for greeting to arrive
-export const TURN_RESPONSE_TIMEOUT_MS = 10_000;     // 10s after user speech
-
-// =============================================================================
-// VTID-FORWARDING-WATCHDOG: Detect zombie upstream WebSocket connections
-// =============================================================================
-// Armed when user audio is forwarded but no watchdog is running and model is
-// not speaking — catches the case where the upstream WS is OPEN but silently
-// not processing anything. If Vertex doesn't acknowledge within this window
-// (via input_transcription or model response), stall recovery force-closes
-// the WS to trigger a transparent reconnect.
-//
-// History:
-//   R2 (#769): 15 s → 6 s. Mistaken as "Vertex responds in 2-4 s" — actually
-//     Vertex's VAD needs 1.2 s silence before input_transcription, so Vertex
-//     legitimately sends NOTHING during an ongoing utterance. 6 s tripped
-//     mid-sentence on any utterance longer than ~5 s. Reverted.
-//   #772 compromise: 10 s. Still too aggressive with our 15 K-char system
-//     instruction + 16 tools; first-turn inference alone takes 8-9 s.
-//   R3 (this change): back to the pre-regression 15 s. Users were having
-//     their 2nd/3rd questions cut off. A proper follow-up makes the watchdog
-//     SLIDING — reset on each inbound audio chunk — so any timeout becomes
-//     safe because "N seconds without Vertex response" then means "N seconds
-//     after last audio with Vertex still silent" which is the real stall
-//     condition. Until that ships, 15 s is the safest known-good value.
-//   R5 (VTID-01984): production data (24h, 14/20 sessions BAD, 1 session
-//     53s of speech with 0 turns) showed 15 s was still destroying healthy
-//     sessions during legitimate first-turn inference. With 15K-char system
-//     instruction + 16 tools, Vertex first-turn latency is 8-12 s; add
-//     1.2 s VAD trigger time + audio chunking; 15 s is right on the edge
-//     and frequently fires inside Vertex's compute window — destroying the
-//     in-flight utterance via reconnect. Two changes:
-//       (1) The arm site now skips this watchdog entirely once Vertex has
-//           shown ANY sign of life this session (input_transcription /
-//           model_start_speaking / audio_out chunk). Native WS handlers
-//           still close on real connection failures; we don't need a 15 s
-//           heuristic to "detect" a Vertex pause between turns when the
-//           WS itself is healthy.
-//       (2) For genuine first-turn (vertexHasShownLife=false), bump from
-//           15 s to 45 s. Real Vertex stalls before any life signal are
-//           rare and 45 s won't make them invisible — but it will stop
-//           the false positives that were truncating greetings.
-export const FORWARDING_ACK_TIMEOUT_MS = 45_000;
-
-// =============================================================================
-// VTID-LOOPGUARD: Response loop prevention
-// =============================================================================
-// Gemini Live can enter a generative loop where the model keeps responding to
-// its own turn_complete without user input. After MAX_CONSECUTIVE_MODEL_TURNS
-// model turns without user speech, silence keepalive is paused so Vertex's
-// idle timeout stops the loop.
-export const MAX_CONSECUTIVE_MODEL_TURNS = 3;
-
-// VTID-TOOLGUARD: Hard limit on consecutive tool calls without audio output.
-// Gemini can spiral calling tools indefinitely (search_memory + search_events
-// + search_memory + ...). After this many consecutive calls, a synthetic
-// function_response is sent instructing the model to answer with data
-// already gathered. See PR #743 for the fix that made this non-destructive.
-export const MAX_CONSECUTIVE_TOOL_CALLS = 5;
 
 // =============================================================================
 // User-facing connection-issue messages (per language)
 // =============================================================================
+// Phase D.2 (next slice) will migrate these to `policy_render_block` so
+// translations + edits don't require a code deploy. Kept inline for now
+// so this PR stays bounded.
 export const connectionIssueMessages: Record<string, string> = {
   'en': "I'm sorry, I seem to be having connection issues right now. Please try starting a new conversation.",
   'de': 'Es tut mir leid, ich habe gerade Verbindungsprobleme. Bitte versuchen Sie, ein neues Gespräch zu starten.',

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -242,17 +242,22 @@ import { parse as parseUrl } from 'url';
 // BOOTSTRAP-ORB-MOVE: Phase 2 (move-only) extracted constants + helpers.
 // Definitions previously inline in this file now live in the orb/ tree.
 import {
-  VAD_SILENCE_DURATION_MS_DEFAULT,
-  POST_TURN_COOLDOWN_MS,
-  SILENCE_KEEPALIVE_INTERVAL_MS,
-  SILENCE_IDLE_THRESHOLD_MS,
+  // VTID-03124 (Phase D.1): voice thresholds now resolved via PolicyResolver.
+  // The literal `*_DEFAULT` / uppercase exports were retired; accessors
+  // delegate to decision_policy rows with the same byte-identical values
+  // as the previous literals (preserved as defaultValue for cache-cold
+  // safety).
+  getVadSilenceDurationMs,
+  getPostTurnCooldownMs,
+  getSilenceKeepaliveIntervalMs,
+  getSilenceIdleThresholdMs,
   SILENCE_PCM_BYTES,
   SILENCE_AUDIO_B64,
-  GREETING_RESPONSE_TIMEOUT_MS,
-  TURN_RESPONSE_TIMEOUT_MS,
-  FORWARDING_ACK_TIMEOUT_MS,
-  MAX_CONSECUTIVE_MODEL_TURNS,
-  MAX_CONSECUTIVE_TOOL_CALLS,
+  getGreetingResponseTimeoutMs,
+  getTurnResponseTimeoutMs,
+  getForwardingAckTimeoutMs,
+  getMaxConsecutiveModelTurns,
+  getMaxConsecutiveToolCalls,
   connectionIssueMessages,
 } from '../orb/upstream/constants';
 import {
@@ -856,7 +861,7 @@ export interface GeminiLiveSession {
   // being picked up by the mic and causing overlapping response streams.
   isModelSpeaking: boolean;
   // VTID-ECHO-COOLDOWN: Timestamp when turn_complete was received.
-  // Mic audio is gated for POST_TURN_COOLDOWN_MS after this to let client-side
+  // Mic audio is gated for getPostTurnCooldownMs() after this to let client-side
   // audio playback finish draining — prevents speaker echo being picked up as input.
   turnCompleteAt: number;
   // VTID-01225-THROTTLE: Timestamp of last successful fact extraction.
@@ -882,7 +887,7 @@ export interface GeminiLiveSession {
   // 10-second windows instead of per-N-chunks, reducing Supabase HTTP calls.
   lastTelemetryEmitTime: number;
   // VTID-RESPONSE-DELAY: Per-session VAD silence threshold (ms).
-  // Defaults to VAD_SILENCE_DURATION_MS_DEFAULT; can be overridden by client.
+  // Defaults to getVadSilenceDurationMs(); can be overridden by client.
   vadSilenceMs: number;
   // VTID-AUDIO-READY: Whether greeting is deferred until client sends audio_ready.
   // Used by WebSocket (mobile) path to avoid greeting truncation from race condition.
@@ -910,7 +915,7 @@ export interface GeminiLiveSession {
   consecutiveModelTurns: number;
   // VTID-TOOLGUARD: Consecutive tool calls without audio output.
   // Gemini can enter an infinite loop calling tools without producing audio.
-  // After MAX_CONSECUTIVE_TOOL_CALLS, we stop sending function_responses
+  // After getMaxConsecutiveToolCalls(), we stop sending function_responses
   // to force the model to generate an audio response.
   consecutiveToolCalls: number;
   // VTID-ANON: Whether this is an anonymous/unauthenticated session (landing page)
@@ -6553,7 +6558,7 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
       wake_opener: 'override_v2',
       decision_id: wakeBriefDecision?.decisionId || null,
     });
-    startResponseWatchdog(session, GREETING_RESPONSE_TIMEOUT_MS, 'greeting_timeout');
+    startResponseWatchdog(session, getGreetingResponseTimeoutMs(), 'greeting_timeout');
     return true;
   }
 
@@ -6750,7 +6755,7 @@ function sendGreetingPromptToLiveAPI(ws: WebSocket, session: GeminiLiveSession):
   emitDiag(session, 'greeting_sent', { lang, prompt_len: message.client_content?.turns?.[0]?.parts?.[0]?.text?.length || 0 });
 
   // VTID-WATCHDOG: Start watchdog — if greeting response doesn't arrive, notify user
-  startResponseWatchdog(session, GREETING_RESPONSE_TIMEOUT_MS, 'greeting_timeout');
+  startResponseWatchdog(session, getGreetingResponseTimeoutMs(), 'greeting_timeout');
 
   return true;
 }
@@ -6889,7 +6894,7 @@ function sendReconnectRecoveryPromptToLiveAPI(ws: WebSocket, session: GeminiLive
 
   // Watchdog so a missing recovery response surfaces as a recoverable diag,
   // matching the greeting path's behavior.
-  startResponseWatchdog(session, GREETING_RESPONSE_TIMEOUT_MS, 'recovery_prompt_timeout');
+  startResponseWatchdog(session, getGreetingResponseTimeoutMs(), 'recovery_prompt_timeout');
 
   return true;
 }
@@ -11856,7 +11861,7 @@ async function handleWsStartMessage(clientSession: WsClientSession, message: WsC
     lastTelemetryEmitTime: 0,
     // VTID-RESPONSE-DELAY: Per-session VAD from client or default
     vadSilenceMs: message.vad_silence_ms && message.vad_silence_ms >= 500 && message.vad_silence_ms <= 3000
-      ? message.vad_silence_ms : VAD_SILENCE_DURATION_MS_DEFAULT,
+      ? message.vad_silence_ms : getVadSilenceDurationMs(),
     // VTID-AUDIO-READY: WebSocket path defers greeting until client sends audio_ready
     greetingDeferred: true,
     // VTID-STREAM-RECONNECT: Store client WS reference for transparent reconnection notifications
@@ -12131,7 +12136,7 @@ async function handleWsAudioMessage(clientSession: WsClientSession, message: WsC
 
   // VTID-ECHO-COOLDOWN: Post-turn cooldown — gate mic audio for N ms after
   // turn_complete to let client-side audio playback finish draining.
-  if (liveSession.turnCompleteAt > 0 && (Date.now() - liveSession.turnCompleteAt) < POST_TURN_COOLDOWN_MS) {
+  if (liveSession.turnCompleteAt > 0 && (Date.now() - liveSession.turnCompleteAt) < getPostTurnCooldownMs()) {
     liveSession.audioInChunks++;
     liveSession.lastActivity = new Date();
     return;
@@ -12179,7 +12184,7 @@ async function handleWsAudioMessage(clientSession: WsClientSession, message: WsC
           const canSlide = !liveSession.responseWatchdogTimer
             || liveSession.responseWatchdogReason === 'forwarding_no_ack';
           if (canSlide) {
-            startResponseWatchdog(liveSession, FORWARDING_ACK_TIMEOUT_MS, 'forwarding_no_ack');
+            startResponseWatchdog(liveSession, getForwardingAckTimeoutMs(), 'forwarding_no_ack');
           }
         }
       }

--- a/services/gateway/src/services/decision-contract/policy-keys.ts
+++ b/services/gateway/src/services/decision-contract/policy-keys.ts
@@ -28,6 +28,30 @@ export const POLICY_KEYS = {
     'session.recency_bucket.today_max_hours',
   SESSION_RECENCY_WEEK_MAX_DAYS:
     'session.recency_bucket.week_max_days',
+
+  // ---- voice.* (Phase D.1, VTID-03124) --------------------------
+  // Thresholds that previously lived as `export const` in
+  // services/gateway/src/orb/upstream/constants.ts. Consumed by the
+  // live-session-controller, upstream-message-handler, and orb-live.ts
+  // route handlers. Seeded by the Phase D.1 migration with the same
+  // byte-identical values; the constants.ts file still carries the
+  // literal as the safety-net `defaultValue` when the cache is cold.
+  VOICE_VAD_SILENCE_DURATION_MS: 'voice.vad.silence_duration_ms',
+  VOICE_POST_TURN_COOLDOWN_MS: 'voice.post_turn.cooldown_ms',
+  VOICE_SILENCE_KEEPALIVE_INTERVAL_MS:
+    'voice.silence_keepalive.interval_ms',
+  VOICE_SILENCE_KEEPALIVE_IDLE_THRESHOLD_MS:
+    'voice.silence_keepalive.idle_threshold_ms',
+  VOICE_WATCHDOG_GREETING_TIMEOUT_MS:
+    'voice.watchdog.greeting_timeout_ms',
+  VOICE_WATCHDOG_TURN_RESPONSE_TIMEOUT_MS:
+    'voice.watchdog.turn_response_timeout_ms',
+  VOICE_WATCHDOG_FORWARDING_ACK_TIMEOUT_MS:
+    'voice.watchdog.forwarding_ack_timeout_ms',
+  VOICE_LOOP_GUARD_MAX_CONSECUTIVE_MODEL_TURNS:
+    'voice.loop_guard.max_consecutive_model_turns',
+  VOICE_LOOP_GUARD_MAX_CONSECUTIVE_TOOL_CALLS:
+    'voice.loop_guard.max_consecutive_tool_calls',
 } as const;
 
 export type PolicyKey = (typeof POLICY_KEYS)[keyof typeof POLICY_KEYS];

--- a/services/gateway/test/orb/upstream/voice-thresholds-policy.test.ts
+++ b/services/gateway/test/orb/upstream/voice-thresholds-policy.test.ts
@@ -1,0 +1,183 @@
+// VTID-03124 — Phase D.1 of the decision-contract refactor.
+//
+// Locks the wire-up that makes `orb/upstream/constants.ts` accessors
+// resolve through PolicyResolver while preserving byte-identical
+// behaviour vs the previous literal `export const` exports when the
+// resolver is unseeded.
+
+import {
+  getVadSilenceDurationMs,
+  getPostTurnCooldownMs,
+  getSilenceKeepaliveIntervalMs,
+  getSilenceIdleThresholdMs,
+  getGreetingResponseTimeoutMs,
+  getTurnResponseTimeoutMs,
+  getForwardingAckTimeoutMs,
+  getMaxConsecutiveModelTurns,
+  getMaxConsecutiveToolCalls,
+  SILENCE_PCM_BYTES,
+} from '../../../src/orb/upstream/constants';
+import {
+  configurePolicyResolverForTests,
+  __resetPolicyResolverForTests,
+} from '../../../src/services/decision-contract/policy-resolver';
+
+const NOW_ISO = new Date().toISOString();
+const FUTURE_ISO = new Date(Date.now() + 86_400_000).toISOString();
+
+function seedPolicy(key: string, value: number) {
+  configurePolicyResolverForTests({
+    decisionPolicy: [
+      {
+        policy_key: key,
+        tenant_id: null,
+        version: 1,
+        value_json: value,
+        effective_from: NOW_ISO,
+        effective_until: null,
+      },
+    ],
+  });
+}
+
+describe('VTID-03124 Phase D.1 voice-threshold accessors', () => {
+  afterEach(() => {
+    __resetPolicyResolverForTests();
+  });
+
+  describe('fallback path — no resolver cache (cold boot)', () => {
+    beforeEach(() => {
+      __resetPolicyResolverForTests();
+    });
+
+    it('VAD silence duration falls back to byte-identical 850 ms', () => {
+      expect(getVadSilenceDurationMs()).toBe(850);
+    });
+
+    it('post-turn cooldown falls back to byte-identical 2000 ms', () => {
+      expect(getPostTurnCooldownMs()).toBe(2000);
+    });
+
+    it('silence keepalive interval falls back to byte-identical 3000 ms', () => {
+      expect(getSilenceKeepaliveIntervalMs()).toBe(3000);
+    });
+
+    it('silence idle threshold falls back to byte-identical 3000 ms', () => {
+      expect(getSilenceIdleThresholdMs()).toBe(3000);
+    });
+
+    it('greeting response timeout falls back to byte-identical 8000 ms', () => {
+      expect(getGreetingResponseTimeoutMs()).toBe(8000);
+    });
+
+    it('turn response timeout falls back to byte-identical 10000 ms', () => {
+      expect(getTurnResponseTimeoutMs()).toBe(10000);
+    });
+
+    it('forwarding ack timeout falls back to byte-identical 45000 ms', () => {
+      expect(getForwardingAckTimeoutMs()).toBe(45000);
+    });
+
+    it('max consecutive model turns falls back to byte-identical 3', () => {
+      expect(getMaxConsecutiveModelTurns()).toBe(3);
+    });
+
+    it('max consecutive tool calls falls back to byte-identical 5', () => {
+      expect(getMaxConsecutiveToolCalls()).toBe(5);
+    });
+  });
+
+  describe('resolver-seeded path — DB row wins over fallback', () => {
+    it('VAD silence reads the seeded policy value', () => {
+      seedPolicy('voice.vad.silence_duration_ms', 1100);
+      expect(getVadSilenceDurationMs()).toBe(1100);
+    });
+
+    it('post-turn cooldown reads the seeded policy value', () => {
+      seedPolicy('voice.post_turn.cooldown_ms', 1500);
+      expect(getPostTurnCooldownMs()).toBe(1500);
+    });
+
+    it('greeting watchdog reads the seeded policy value', () => {
+      seedPolicy('voice.watchdog.greeting_timeout_ms', 12_000);
+      expect(getGreetingResponseTimeoutMs()).toBe(12_000);
+    });
+
+    it('forwarding watchdog reads the seeded policy value', () => {
+      seedPolicy('voice.watchdog.forwarding_ack_timeout_ms', 30_000);
+      expect(getForwardingAckTimeoutMs()).toBe(30_000);
+    });
+
+    it('max tool calls reads the seeded policy value', () => {
+      seedPolicy('voice.loop_guard.max_consecutive_tool_calls', 7);
+      expect(getMaxConsecutiveToolCalls()).toBe(7);
+    });
+  });
+
+  describe('expired rows do not override the fallback', () => {
+    it('expired row is ignored; accessor returns fallback', () => {
+      const yesterday = new Date(Date.now() - 86_400_000).toISOString();
+      configurePolicyResolverForTests({
+        decisionPolicy: [
+          {
+            policy_key: 'voice.vad.silence_duration_ms',
+            tenant_id: null,
+            version: 1,
+            value_json: 9999,
+            effective_from: '2020-01-01T00:00:00.000Z',
+            effective_until: yesterday, // expired
+          },
+        ],
+      });
+      expect(getVadSilenceDurationMs()).toBe(850);
+    });
+
+    it('future-dated row is ignored until effective_from', () => {
+      configurePolicyResolverForTests({
+        decisionPolicy: [
+          {
+            policy_key: 'voice.vad.silence_duration_ms',
+            tenant_id: null,
+            version: 1,
+            value_json: 9999,
+            effective_from: FUTURE_ISO,
+            effective_until: null,
+          },
+        ],
+      });
+      expect(getVadSilenceDurationMs()).toBe(850);
+    });
+  });
+
+  describe('higher version wins over lower', () => {
+    it('returns value from highest-version effective row', () => {
+      configurePolicyResolverForTests({
+        decisionPolicy: [
+          {
+            policy_key: 'voice.vad.silence_duration_ms',
+            tenant_id: null,
+            version: 1,
+            value_json: 700,
+            effective_from: NOW_ISO,
+            effective_until: null,
+          },
+          {
+            policy_key: 'voice.vad.silence_duration_ms',
+            tenant_id: null,
+            version: 2,
+            value_json: 950,
+            effective_from: NOW_ISO,
+            effective_until: null,
+          },
+        ],
+      });
+      expect(getVadSilenceDurationMs()).toBe(950);
+    });
+  });
+
+  describe('protocol-derived constants stay literal', () => {
+    it('SILENCE_PCM_BYTES is the 250ms @ 16kHz mono 16-bit constant — not a policy knob', () => {
+      expect(SILENCE_PCM_BYTES).toBe(8000);
+    });
+  });
+});

--- a/supabase/migrations/20260528000000_VTID_03124_voice_thresholds_seeds.sql
+++ b/supabase/migrations/20260528000000_VTID_03124_voice_thresholds_seeds.sql
@@ -1,0 +1,95 @@
+-- Phase D.1 (decision-contract refactor) — voice-pipeline threshold seeds.
+--
+-- VTID-03124. Externalizes the 9 numeric thresholds currently hard-coded
+-- in `services/gateway/src/orb/upstream/constants.ts` into the
+-- `decision_policy` table seeded by Phase B.1.
+--
+-- Idempotent: each INSERT is guarded by WHERE NOT EXISTS against the same
+-- (key, tenant, version). Safe to re-run.
+--
+-- Values are BYTE-IDENTICAL to the constants exported by
+-- `orb/upstream/constants.ts` at the time of writing. Tuning history is
+-- captured in `notes`; the constants.ts file still carries the literal
+-- as `*_FALLBACK` for the safety-net path when the resolver cache is
+-- cold (e.g. boot before warm-up completes).
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.vad.silence_duration_ms', NULL, 1, '850'::jsonb, 'seed',
+       'orb/upstream/constants.ts:34 (VTID-03019 tuning: trims ~350ms off end-of-turn latency vs 1200ms predecessor)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM decision_policy
+  WHERE policy_key = 'voice.vad.silence_duration_ms'
+    AND tenant_id IS NULL AND version = 1
+);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.post_turn.cooldown_ms', NULL, 1, '2000'::jsonb, 'seed',
+       'orb/upstream/constants.ts:46 (VTID-ECHO-COOLDOWN: gates mic for 2s after turn_complete to prevent speaker echo on mobile)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM decision_policy
+  WHERE policy_key = 'voice.post_turn.cooldown_ms'
+    AND tenant_id IS NULL AND version = 1
+);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.silence_keepalive.interval_ms', NULL, 1, '3000'::jsonb, 'seed',
+       'orb/upstream/constants.ts:53 (VTID-STREAM-SILENCE: check every 3s whether to send a 250ms silence frame to prevent Vertex idle-timeout)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM decision_policy
+  WHERE policy_key = 'voice.silence_keepalive.interval_ms'
+    AND tenant_id IS NULL AND version = 1
+);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.silence_keepalive.idle_threshold_ms', NULL, 1, '3000'::jsonb, 'seed',
+       'orb/upstream/constants.ts:54 (VTID-STREAM-SILENCE: send silence frame after 3s of inbound idle)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM decision_policy
+  WHERE policy_key = 'voice.silence_keepalive.idle_threshold_ms'
+    AND tenant_id IS NULL AND version = 1
+);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.watchdog.greeting_timeout_ms', NULL, 1, '8000'::jsonb, 'seed',
+       'orb/upstream/constants.ts:64 (VTID-WATCHDOG: stall recovery if no greeting bytes within 8s)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM decision_policy
+  WHERE policy_key = 'voice.watchdog.greeting_timeout_ms'
+    AND tenant_id IS NULL AND version = 1
+);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.watchdog.turn_response_timeout_ms', NULL, 1, '10000'::jsonb, 'seed',
+       'orb/upstream/constants.ts:65 (VTID-WATCHDOG: stall recovery if no model response within 10s after user speech)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM decision_policy
+  WHERE policy_key = 'voice.watchdog.turn_response_timeout_ms'
+    AND tenant_id IS NULL AND version = 1
+);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.watchdog.forwarding_ack_timeout_ms', NULL, 1, '45000'::jsonb, 'seed',
+       'orb/upstream/constants.ts:106 (VTID-FORWARDING-WATCHDOG: tuned via VTID-01984 to 45s for genuine first-turn cold-start tolerance)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM decision_policy
+  WHERE policy_key = 'voice.watchdog.forwarding_ack_timeout_ms'
+    AND tenant_id IS NULL AND version = 1
+);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.loop_guard.max_consecutive_model_turns', NULL, 1, '3'::jsonb, 'seed',
+       'orb/upstream/constants.ts:115 (VTID-LOOPGUARD: after 3 model turns without user speech, pause silence keepalive so Vertex idles out the loop)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM decision_policy
+  WHERE policy_key = 'voice.loop_guard.max_consecutive_model_turns'
+    AND tenant_id IS NULL AND version = 1
+);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.loop_guard.max_consecutive_tool_calls', NULL, 1, '5'::jsonb, 'seed',
+       'orb/upstream/constants.ts:122 (VTID-TOOLGUARD: after 5 consecutive tool calls, inject synthetic function_response so the model answers from gathered data)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM decision_policy
+  WHERE policy_key = 'voice.loop_guard.max_consecutive_tool_calls'
+    AND tenant_id IS NULL AND version = 1
+);


### PR DESCRIPTION
## Summary
**Phase D.1** of the contextual-intelligence refactor. First of four D slices per the original audit roadmap. Externalizes 9 numeric voice-pipeline thresholds (VAD, cooldowns, watchdogs, loop guards) from `services/gateway/src/orb/upstream/constants.ts` into the `decision_policy` table — same byte-identical values, now tunable without a deploy.

## Why
Audit found ~140 hard-coded constants. Phase B externalized greeting policy (prompt block + bucket thresholds). Phase D.1 takes the next-most-touched category: voice timing. A wrong VAD silence value cuts users off mid-sentence; a wrong watchdog kills sessions during legitimate first-turn inference. Both have already triggered production incidents (VTID-RESPONSE-DELAY, VTID-01984). Putting them in DB lets ops change them without a Cloud Run roll.

## Changes
- **Migration** `20260528000000_VTID_03124_voice_thresholds_seeds.sql` — 9 idempotent inserts under `voice.*` policy keys.
- **`orb/upstream/constants.ts`** — `export const X = N` → `export function getX(): number` that calls `getPolicyResolver().getValue<number>(POLICY_KEYS.VOICE_X, { defaultValue: N })`. Literal `*_FALLBACK` constants kept as the cache-cold safety net.
- **`POLICY_KEYS`** — 9 new `VOICE_*` entries (typed const; stringly-typed keys forbidden by the Phase B brief).
- **3 consumer files updated** — 17 call sites in `live-session-controller.ts`, `upstream-message-handler.ts`, `orb-live.ts`. Old uppercase constants no longer imported.

`SILENCE_PCM_BYTES` and `connectionIssueMessages` stay literal — the former is protocol-derived (250ms @ 16kHz mono 16-bit = 8000 bytes, changing it means a different wire format); the latter is Phase D.2 scope.

## Test plan
- [x] 18 new VTID-03124 tests cover: 9 cold-cache fallback parity assertions, 5 resolver-seeded reads, expired-row + future-dated-row guards, version precedence, `SILENCE_PCM_BYTES` literal contract.
- [x] Full orb suite stays green: 792/792 tests across 47/47 suites.
- [x] `npm run build` clean.
- [ ] CI: gateway build + tests stay green.
- [ ] RUN-MIGRATION: 9 row inserts logged.
- [ ] Post-deploy: `/alive` returns 200 JSON.
- [ ] Post-deploy: voice path behaviour unchanged (seeds = previous literals; no user-visible change).

🤖 Generated with [Claude Code](https://claude.com/claude-code)