### PR TITLE
feat(decision-contract): Phase D.2 — connection-issue render blocks via PolicyResolver (VTID-03125)

### DIFF
--- a/services/gateway/src/orb/upstream/constants.ts
+++ b/services/gateway/src/orb/upstream/constants.ts
@@ -27,7 +27,10 @@
  */
 
 import { getPolicyResolver } from '../../services/decision-contract/policy-resolver';
-import { POLICY_KEYS } from '../../services/decision-contract/policy-keys';
+import {
+  POLICY_KEYS,
+  RENDER_BLOCK_KEYS,
+} from '../../services/decision-contract/policy-keys';
 
 // ---------------------------------------------------------------------------
 // Safety-net fallback values. Match the Phase D.1 seed rows byte-for-byte.
@@ -155,10 +158,12 @@ export const SILENCE_AUDIO_B64 = Buffer.alloc(SILENCE_PCM_BYTES, 0).toString('ba
 // =============================================================================
 // User-facing connection-issue messages (per language)
 // =============================================================================
-// Phase D.2 (next slice) will migrate these to `policy_render_block` so
-// translations + edits don't require a code deploy. Kept inline for now
-// so this PR stays bounded.
-export const connectionIssueMessages: Record<string, string> = {
+// Phase D.2 (VTID-03125): localized strings now live in `policy_render_block`
+// rows seeded with byte-identical content. `getConnectionIssueMessage` reads
+// via PolicyResolver; the resolver automatically falls back to 'en' if the
+// requested language has no row. The fallback Record below is the
+// cache-cold safety net — same strings as the seeded rows.
+const CONNECTION_ISSUE_FALLBACKS: Record<string, string> = {
   'en': "I'm sorry, I seem to be having connection issues right now. Please try starting a new conversation.",
   'de': 'Es tut mir leid, ich habe gerade Verbindungsprobleme. Bitte versuchen Sie, ein neues Gespräch zu starten.',
   'fr': "Je suis désolé, j'ai des problèmes de connexion. Veuillez réessayer une nouvelle conversation.",
@@ -168,3 +173,12 @@ export const connectionIssueMessages: Record<string, string> = {
   'ru': 'Извините, у меня проблемы с подключением. Пожалуйста, попробуйте начать новый разговор.',
   'sr': 'Извините, изгледа да имам проблеме са везом. Молимо покушајте поново.',
 };
+
+export function getConnectionIssueMessage(lang: string): string {
+  const fallback = CONNECTION_ISSUE_FALLBACKS[lang] ?? CONNECTION_ISSUE_FALLBACKS['en'];
+  return getPolicyResolver().getRenderBlock(
+    RENDER_BLOCK_KEYS.VOICE_CONNECTION_ISSUE,
+    lang,
+    { defaultValue: fallback },
+  );
+}

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -258,7 +258,9 @@ import {
   getForwardingAckTimeoutMs,
   getMaxConsecutiveModelTurns,
   getMaxConsecutiveToolCalls,
-  connectionIssueMessages,
+  // VTID-03125 (Phase D.2): connection-issue apologies now resolve via
+  // PolicyResolver render-block lookup with English fallback baked in.
+  getConnectionIssueMessage,
 } from '../orb/upstream/constants';
 import {
   SHORT_GAP_GREETING_PHRASES,
@@ -5990,7 +5992,7 @@ async function connectToLiveAPI(
         const issueEvent = {
           type: 'connection_issue',
           reason: 'upstream_error',
-          message: connectionIssueMessages[lang] || connectionIssueMessages['en'],
+          message: getConnectionIssueMessage(lang),
           should_close: true,
         };
         if (session.sseResponse) {
@@ -6097,7 +6099,7 @@ async function connectToLiveAPI(
             const issueEvent = {
               type: 'connection_issue',
               reason: 'upstream_disconnected',
-              message: connectionIssueMessages[lang] || connectionIssueMessages['en'],
+              message: getConnectionIssueMessage(lang),
               should_close: true,
             };
             // VTID-02637: dedupe — only emit if we haven't already.
@@ -6152,7 +6154,7 @@ async function connectToLiveAPI(
         const issueEvent = {
           type: 'connection_issue',
           reason: 'upstream_disconnected',
-          message: connectionIssueMessages[lang] || connectionIssueMessages['en'],
+          message: getConnectionIssueMessage(lang),
           should_close: true,
         };
         // VTID-02637: dedupe — error handler may already have emitted.
@@ -6415,7 +6417,7 @@ function startResponseWatchdog(
     if (!session.active) return;
 
     const lang = session.lang || 'en';
-    const message = connectionIssueMessages[lang] || connectionIssueMessages['en'];
+    const message = getConnectionIssueMessage(lang);
 
     console.warn(`[VTID-WATCHDOG] Response watchdog fired for session ${session.sessionId}: ${reason} (${timeoutMs}ms)`);
     emitDiag(session, 'watchdog_fired', { reason, timeout_ms: timeoutMs });

--- a/services/gateway/src/services/decision-contract/policy-keys.ts
+++ b/services/gateway/src/services/decision-contract/policy-keys.ts
@@ -70,6 +70,12 @@ export const RENDER_BLOCK_KEYS = {
   GREETING_BUCKET_WEEK: 'greeting.bucket.week',
   GREETING_BUCKET_LONG: 'greeting.bucket.long',
   GREETING_BUCKET_FIRST: 'greeting.bucket.first',
+
+  // Phase D.2 (VTID-03125) — user-facing connection-issue apology when
+  // the upstream WS is unrecoverable. Localized; renderer falls back to
+  // 'en' if the requested language has no row. Consumed by orb-live.ts
+  // (4 call sites at the time of writing).
+  VOICE_CONNECTION_ISSUE: 'voice.connection_issue',
 } as const;
 
 export type RenderBlockKey =

--- a/services/gateway/test/orb/upstream/connection-issue-policy.test.ts
+++ b/services/gateway/test/orb/upstream/connection-issue-policy.test.ts
@@ -1,0 +1,148 @@
+// VTID-03125 — Phase D.2 of the decision-contract refactor.
+//
+// Locks the wire-up that migrates `connectionIssueMessages` from an
+// inline 8-language Record export to a `policy_render_block`-backed
+// accessor. The literal Record stays in code as the cache-cold safety
+// net; production source of truth is the seeded DB rows.
+
+import { getConnectionIssueMessage } from '../../../src/orb/upstream/constants';
+import {
+  configurePolicyResolverForTests,
+  __resetPolicyResolverForTests,
+} from '../../../src/services/decision-contract/policy-resolver';
+
+const NOW_ISO = new Date().toISOString();
+
+function seedBlock(language: string, content: string) {
+  configurePolicyResolverForTests({
+    policyRenderBlock: [
+      {
+        block_key: 'voice.connection_issue',
+        language,
+        tenant_id: null,
+        version: 1,
+        content,
+        effective_from: NOW_ISO,
+        effective_until: null,
+      },
+    ],
+  });
+}
+
+describe('VTID-03125 Phase D.2 connection-issue accessor', () => {
+  afterEach(() => {
+    __resetPolicyResolverForTests();
+  });
+
+  describe('cold-cache fallback path (byte-identical to pre-D.2 Record)', () => {
+    beforeEach(() => {
+      __resetPolicyResolverForTests();
+    });
+
+    it('en falls back to the literal English string', () => {
+      expect(getConnectionIssueMessage('en')).toBe(
+        "I'm sorry, I seem to be having connection issues right now. Please try starting a new conversation.",
+      );
+    });
+
+    it('de falls back to the literal German string', () => {
+      expect(getConnectionIssueMessage('de')).toBe(
+        'Es tut mir leid, ich habe gerade Verbindungsprobleme. Bitte versuchen Sie, ein neues Gespräch zu starten.',
+      );
+    });
+
+    it('fr falls back to the literal French string', () => {
+      expect(getConnectionIssueMessage('fr')).toBe(
+        "Je suis désolé, j'ai des problèmes de connexion. Veuillez réessayer une nouvelle conversation.",
+      );
+    });
+
+    it('es / ar / zh / ru / sr all have non-empty literal fallbacks', () => {
+      // Spot-check: each must return a non-empty, non-English string
+      // (Latin / non-Latin scripts both supported).
+      for (const lang of ['es', 'ar', 'zh', 'ru', 'sr']) {
+        const out = getConnectionIssueMessage(lang);
+        expect(out.length).toBeGreaterThan(0);
+        // Spot-check by alphabet — none of these should be the English text.
+        expect(out).not.toContain('connection issues right now');
+      }
+    });
+
+    it('unknown language falls back to the English string (not empty)', () => {
+      expect(getConnectionIssueMessage('jp')).toBe(
+        "I'm sorry, I seem to be having connection issues right now. Please try starting a new conversation.",
+      );
+    });
+  });
+
+  describe('resolver-seeded path — DB row wins over fallback', () => {
+    it('returns the seeded value when language matches', () => {
+      seedBlock('de', 'Verbindungsfehler — bitte erneut versuchen.');
+      expect(getConnectionIssueMessage('de')).toBe(
+        'Verbindungsfehler — bitte erneut versuchen.',
+      );
+    });
+
+    it('seeded English row is returned for en', () => {
+      seedBlock('en', 'Connection trouble — please restart.');
+      expect(getConnectionIssueMessage('en')).toBe(
+        'Connection trouble — please restart.',
+      );
+    });
+
+    it('resolver English-fallback path: requested fr, only en seeded → returns seeded en', () => {
+      seedBlock('en', 'Reseeded English.');
+      // No 'fr' row seeded — resolver falls back to 'en' before the
+      // hard-coded literal.
+      expect(getConnectionIssueMessage('fr')).toBe('Reseeded English.');
+    });
+
+    it('multiple languages seeded — each returns its own row', () => {
+      configurePolicyResolverForTests({
+        policyRenderBlock: [
+          {
+            block_key: 'voice.connection_issue',
+            language: 'en',
+            tenant_id: null,
+            version: 1,
+            content: 'EN seed',
+            effective_from: NOW_ISO,
+            effective_until: null,
+          },
+          {
+            block_key: 'voice.connection_issue',
+            language: 'de',
+            tenant_id: null,
+            version: 1,
+            content: 'DE seed',
+            effective_from: NOW_ISO,
+            effective_until: null,
+          },
+        ],
+      });
+      expect(getConnectionIssueMessage('en')).toBe('EN seed');
+      expect(getConnectionIssueMessage('de')).toBe('DE seed');
+    });
+  });
+
+  describe('expired rows do not override the fallback', () => {
+    it('expired German row → falls back to literal German', () => {
+      configurePolicyResolverForTests({
+        policyRenderBlock: [
+          {
+            block_key: 'voice.connection_issue',
+            language: 'de',
+            tenant_id: null,
+            version: 1,
+            content: 'EXPIRED CONTENT',
+            effective_from: '2020-01-01T00:00:00.000Z',
+            effective_until: '2020-12-31T23:59:59.000Z',
+          },
+        ],
+      });
+      expect(getConnectionIssueMessage('de')).toBe(
+        'Es tut mir leid, ich habe gerade Verbindungsprobleme. Bitte versuchen Sie, ein neues Gespräch zu starten.',
+      );
+    });
+  });
+});

--- a/supabase/migrations/20260528010000_VTID_03125_voice_connection_issue_seeds.sql
+++ b/supabase/migrations/20260528010000_VTID_03125_voice_connection_issue_seeds.sql
@@ -1,0 +1,93 @@
+-- Phase D.2 (decision-contract refactor) — connection-issue render blocks.
+--
+-- VTID-03125. Externalizes the 8-language `connectionIssueMessages`
+-- Record currently exported by `services/gateway/src/orb/upstream/constants.ts`
+-- into the `policy_render_block` table seeded by Phase B.1.
+--
+-- Idempotent: each INSERT is guarded by WHERE NOT EXISTS against the
+-- same (block_key, language, tenant_id, version). Safe to re-run.
+--
+-- Content is BYTE-IDENTICAL to the Record entries at the time of
+-- writing. The constants.ts file keeps the same strings as the
+-- `defaultValue` arg for cache-cold safety; this migration is the
+-- production source of truth.
+
+INSERT INTO policy_render_block (block_key, language, tenant_id, version, content, source, notes)
+SELECT 'voice.connection_issue', 'en', NULL, 1,
+       'I''m sorry, I seem to be having connection issues right now. Please try starting a new conversation.',
+       'seed', 'orb/upstream/constants.ts:163 (connectionIssueMessages.en)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM policy_render_block
+  WHERE block_key = 'voice.connection_issue' AND language = 'en'
+    AND tenant_id IS NULL AND version = 1
+);
+
+INSERT INTO policy_render_block (block_key, language, tenant_id, version, content, source, notes)
+SELECT 'voice.connection_issue', 'de', NULL, 1,
+       'Es tut mir leid, ich habe gerade Verbindungsprobleme. Bitte versuchen Sie, ein neues Gespräch zu starten.',
+       'seed', 'orb/upstream/constants.ts:164 (connectionIssueMessages.de)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM policy_render_block
+  WHERE block_key = 'voice.connection_issue' AND language = 'de'
+    AND tenant_id IS NULL AND version = 1
+);
+
+INSERT INTO policy_render_block (block_key, language, tenant_id, version, content, source, notes)
+SELECT 'voice.connection_issue', 'fr', NULL, 1,
+       'Je suis désolé, j''ai des problèmes de connexion. Veuillez réessayer une nouvelle conversation.',
+       'seed', 'orb/upstream/constants.ts:165 (connectionIssueMessages.fr)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM policy_render_block
+  WHERE block_key = 'voice.connection_issue' AND language = 'fr'
+    AND tenant_id IS NULL AND version = 1
+);
+
+INSERT INTO policy_render_block (block_key, language, tenant_id, version, content, source, notes)
+SELECT 'voice.connection_issue', 'es', NULL, 1,
+       'Lo siento, parece que tengo problemas de conexión. Por favor, intenta iniciar una nueva conversación.',
+       'seed', 'orb/upstream/constants.ts:166 (connectionIssueMessages.es)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM policy_render_block
+  WHERE block_key = 'voice.connection_issue' AND language = 'es'
+    AND tenant_id IS NULL AND version = 1
+);
+
+INSERT INTO policy_render_block (block_key, language, tenant_id, version, content, source, notes)
+SELECT 'voice.connection_issue', 'ar', NULL, 1,
+       'عذراً، يبدو أنني أواجه مشاكل في الاتصال. يرجى محاولة بدء محادثة جديدة.',
+       'seed', 'orb/upstream/constants.ts:167 (connectionIssueMessages.ar)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM policy_render_block
+  WHERE block_key = 'voice.connection_issue' AND language = 'ar'
+    AND tenant_id IS NULL AND version = 1
+);
+
+INSERT INTO policy_render_block (block_key, language, tenant_id, version, content, source, notes)
+SELECT 'voice.connection_issue', 'zh', NULL, 1,
+       '抱歉，我目前似乎遇到了连接问题。请尝试重新开始对话。',
+       'seed', 'orb/upstream/constants.ts:168 (connectionIssueMessages.zh)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM policy_render_block
+  WHERE block_key = 'voice.connection_issue' AND language = 'zh'
+    AND tenant_id IS NULL AND version = 1
+);
+
+INSERT INTO policy_render_block (block_key, language, tenant_id, version, content, source, notes)
+SELECT 'voice.connection_issue', 'ru', NULL, 1,
+       'Извините, у меня проблемы с подключением. Пожалуйста, попробуйте начать новый разговор.',
+       'seed', 'orb/upstream/constants.ts:169 (connectionIssueMessages.ru)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM policy_render_block
+  WHERE block_key = 'voice.connection_issue' AND language = 'ru'
+    AND tenant_id IS NULL AND version = 1
+);
+
+INSERT INTO policy_render_block (block_key, language, tenant_id, version, content, source, notes)
+SELECT 'voice.connection_issue', 'sr', NULL, 1,
+       'Извините, изгледа да имам проблеме са везом. Молимо покушајте поново.',
+       'seed', 'orb/upstream/constants.ts:170 (connectionIssueMessages.sr)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM policy_render_block
+  WHERE block_key = 'voice.connection_issue' AND language = 'sr'
+    AND tenant_id IS NULL AND version = 1
+);


### PR DESCRIPTION
## Summary
**Phase D.2** of the contextual-intelligence refactor. Migrates the 8-language `connectionIssueMessages` Record from `orb/upstream/constants.ts` to `policy_render_block` rows backed by `getConnectionIssueMessage(lang)` — preserving byte-identical strings while making the translations editable without a Cloud Run deploy.

## Changes
- **Migration** `20260528010000_VTID_03125_voice_connection_issue_seeds.sql` — 8 idempotent inserts under `block_key='voice.connection_issue'`.
- **`orb/upstream/constants.ts`** — Record export replaced with `getConnectionIssueMessage(lang)`; literal `CONNECTION_ISSUE_FALLBACKS` kept as the cache-cold safety net.
- **`RENDER_BLOCK_KEYS`** — new `VOICE_CONNECTION_ISSUE` entry.
- **`orb-live.ts`** — 4 call sites + import migrated. The `|| connectionIssueMessages['en']` pattern at each site is now dead weight — the resolver's English-fallback handles it.

## Test plan
- [x] 10 new VTID-03125 cases (cold-cache parity for 5 langs + unknown-lang, resolver-seeded reads, multi-language seed, English-fallback for unseeded language, expired-row guard).
- [x] Full orb suite: 802/802 green across 48/48 suites.
- [x] `npm run build` clean.
- [ ] CI green.
- [ ] RUN-MIGRATION: 8 row inserts logged.
- [ ] Post-deploy `/alive` 200 JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)