### PR TITLE
feat(decision-contract): Phase D.3 — Live API voices via PolicyResolver + fallback telemetry (VTID-03126)

### DIFF
--- a/services/gateway/src/orb/live/voice/live-api-voice.ts
+++ b/services/gateway/src/orb/live/voice/live-api-voice.ts
@@ -1,0 +1,70 @@
+// Phase D.3 (decision-contract refactor) — VTID-03126.
+//
+// Live API voice resolver. Externalizes the `LIVE_API_VOICES` Record
+// that previously lived inline in `routes/orb-live.ts:1341`. Each
+// language's policy row carries `{voice_name, fallback_lang}` so the
+// accessor can emit telemetry when the selected voice is NOT native to
+// the requested language. This closes the audit's "silent
+// Arabic → English Aoede" finding — the fallback is still served (so
+// behaviour is byte-identical at rollout) but it's now visible in logs.
+//
+// Future: when a native voice ships for ar/zh/ru/sr, update the DB row
+// to `fallback_lang: null` and the warning stops firing automatically.
+
+import { getPolicyResolver } from '../../../services/decision-contract/policy-resolver';
+
+interface LiveApiVoiceConfig {
+  voice_name: string;
+  fallback_lang: string | null;
+}
+
+// Byte-identical to the LIVE_API_VOICES Record at the time of writing.
+// Used as the cache-cold safety net by the accessor; production source
+// of truth is the seeded `decision_policy` rows.
+const LIVE_API_VOICE_FALLBACKS: Record<string, LiveApiVoiceConfig> = {
+  en: { voice_name: 'Aoede', fallback_lang: null },
+  de: { voice_name: 'Kore', fallback_lang: null },
+  fr: { voice_name: 'Charon', fallback_lang: null },
+  es: { voice_name: 'Fenrir', fallback_lang: null },
+  ar: { voice_name: 'Aoede', fallback_lang: 'en' },
+  zh: { voice_name: 'Kore', fallback_lang: 'de' },
+  ru: { voice_name: 'Aoede', fallback_lang: 'en' },
+  sr: { voice_name: 'Aoede', fallback_lang: 'en' },
+};
+
+// Dedup log lines so a hot per-session loop doesn't spam the logger.
+// One emission per (lang, fallback_lang) pair per process lifetime.
+const loggedFallbacks = new Set<string>();
+
+function livePolicyKeyForVoice(lang: string): string {
+  return `voice.live_api.voice.${lang}`;
+}
+
+function logFallbackOnce(lang: string, cfg: LiveApiVoiceConfig): void {
+  if (!cfg.fallback_lang) return;
+  const tag = `${lang}:${cfg.fallback_lang}:${cfg.voice_name}`;
+  if (loggedFallbacks.has(tag)) return;
+  loggedFallbacks.add(tag);
+  // eslint-disable-next-line no-console
+  console.warn(
+    `[voice-fallback] live_api: lang="${lang}" using "${cfg.fallback_lang}" voice "${cfg.voice_name}" — native voice not yet shipped for "${lang}"`,
+  );
+}
+
+export function getLiveApiVoice(lang: string): string {
+  const safeLang = typeof lang === 'string' && lang.length > 0 ? lang : 'en';
+  const fallback = LIVE_API_VOICE_FALLBACKS[safeLang] ?? LIVE_API_VOICE_FALLBACKS['en'];
+  const cfg = getPolicyResolver().getValue<LiveApiVoiceConfig | null>(
+    livePolicyKeyForVoice(safeLang),
+    { defaultValue: fallback },
+  );
+  const resolved = cfg ?? fallback;
+  logFallbackOnce(safeLang, resolved);
+  return resolved.voice_name;
+}
+
+// ---- test support ------------------------------------------------------
+// Tests can reset the dedup set so each test sees a fresh log state.
+export function __resetLiveApiVoiceFallbackLogForTests(): void {
+  loggedFallbacks.clear();
+}

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -1175,6 +1175,9 @@ import {
 // / resolve) via onSetupComplete + isSetupComplete callbacks, and forwards
 // every orb-live.ts-local helper through the deps bag.
 import { createUpstreamLiveMessageHandler } from '../orb/live/session/upstream-message-handler';
+// VTID-03126 (Phase D.3): Live API voice resolver — externalizes the
+// LIVE_API_VOICES Record + adds telemetry on silent fallbacks.
+import { getLiveApiVoice } from '../orb/live/voice/live-api-voice';
 // A8.3b.1 (VTID-02971): connectToLiveAPI now uses the A7 UpstreamLiveClient
 // boundary via VertexLiveClient. The orb-specific persona/tools/context
 // envelope is supplied through the new `customSetupMessage` option so the
@@ -1334,20 +1337,12 @@ async function getAccessToken(): Promise<string> {
   return tokenResponse.token;
 }
 
-/**
- * VTID-01219: Live API voice names (Vertex AI voices)
- * These are different from Cloud TTS voices
- */
-const LIVE_API_VOICES: Record<string, string> = {
-  'en': 'Aoede',    // English - warm, clear
-  'de': 'Kore',     // German
-  'fr': 'Charon',   // French
-  'es': 'Fenrir',   // Spanish
-  'ar': 'Aoede',    // Arabic - fallback to English voice
-  'zh': 'Kore',     // Chinese - fallback
-  'ru': 'Aoede',    // Russian - fallback
-  'sr': 'Aoede'     // Serbian - fallback
-};
+// VTID-03126 (Phase D.3): LIVE_API_VOICES Record moved out of this file
+// into a `decision_policy`-backed accessor at
+// services/gateway/src/orb/live/voice/live-api-voice.ts. Each row now
+// carries `{voice_name, fallback_lang}` so a non-native fallback emits
+// telemetry on first use per (lang, fallback_lang) — closes the
+// previously-silent "Arabic → English Aoede" audit finding.
 
 // VTID-02651: persona voice IDs and greetings are now data-driven from
 // agent_personas (loaded by services/persona-registry.ts). Adding a new
@@ -2730,7 +2725,7 @@ async function executeLiveApiToolInner(
             type: 'persona_swap',
             from: currentPersona,
             to: target,
-            voice_id: (session as any).personaVoiceOverride || (LIVE_API_VOICES[session.lang || 'en'] || 'Aoede'),
+            voice_id: (session as any).personaVoiceOverride || getLiveApiVoice(session.lang || 'en'),
             display_name: target.charAt(0).toUpperCase() + target.slice(1),
             navigation_only: true,
           };
@@ -5696,7 +5691,7 @@ async function connectToLiveAPI(
           console.warn(`[VTID-02651] persona registry lookup failed for ${_persona}:`, e);
         }
       }
-      _personaVoice = _personaVoice || LIVE_API_VOICES[session.lang] || LIVE_API_VOICES['en'];
+      _personaVoice = _personaVoice || getLiveApiVoice(session.lang);
       console.log(`[VTID-02047] Setup voice for session ${session.sessionId}: persona=${_persona} voice=${_personaVoice}`);
 
       const setupMessage = {
@@ -10692,7 +10687,7 @@ router.get('/live/stream', optionalAuth, async (req: AuthenticatedRequest, res: 
     meta: {
       model: VERTEX_LIVE_MODEL,
       lang: session.lang,
-      voice: LIVE_API_VOICES[session.lang] || LIVE_API_VOICES['en'] || getVoiceForLang(session.lang),
+      voice: getLiveApiVoice(session.lang) || getVoiceForLang(session.lang),
       audio_out_rate: 24000,
       audio_in_rate: 16000,
     },
@@ -11919,7 +11914,7 @@ async function handleWsStartMessage(clientSession: WsClientSession, message: WsC
       message: 'Session created but Live API not available (missing credentials)',
       meta: {
         lang,
-        voice: LIVE_API_VOICES[lang] || LIVE_API_VOICES['en'],
+        voice: getLiveApiVoice(lang),
         model: VERTEX_LIVE_MODEL
       }
     });
@@ -12001,7 +11996,7 @@ async function handleWsStartMessage(clientSession: WsClientSession, message: WsC
     emitLiveSessionEvent('vtid.live.session.start', {
       session_id: sessionId,
       lang,
-      voice: LIVE_API_VOICES[lang] || LIVE_API_VOICES['en'],
+      voice: getLiveApiVoice(lang),
       response_modalities: responseModalities,
       transport: 'websocket',
       // VTID-01224: Include context bootstrap info
@@ -12039,7 +12034,7 @@ async function handleWsStartMessage(clientSession: WsClientSession, message: WsC
       },
       meta: {
         lang,
-        voice: LIVE_API_VOICES[lang] || LIVE_API_VOICES['en'],
+        voice: getLiveApiVoice(lang),
         model: VERTEX_LIVE_MODEL,
         audio_in_rate: 16000,
         audio_out_rate: 24000,
@@ -12087,7 +12082,7 @@ async function handleWsStartMessage(clientSession: WsClientSession, message: WsC
       error: err.message,
       meta: {
         lang,
-        voice: LIVE_API_VOICES[lang] || LIVE_API_VOICES['en'],
+        voice: getLiveApiVoice(lang),
         model: VERTEX_LIVE_MODEL
       }
     });

--- a/services/gateway/test/orb/live/voice/live-api-voice.test.ts
+++ b/services/gateway/test/orb/live/voice/live-api-voice.test.ts
@@ -1,0 +1,223 @@
+// VTID-03126 — Phase D.3 of the decision-contract refactor.
+//
+// Locks the wire-up that migrates `LIVE_API_VOICES` from inline Record
+// in routes/orb-live.ts to `decision_policy`-backed accessor with
+// explicit fallback telemetry.
+
+import {
+  getLiveApiVoice,
+  __resetLiveApiVoiceFallbackLogForTests,
+} from '../../../../src/orb/live/voice/live-api-voice';
+import {
+  configurePolicyResolverForTests,
+  __resetPolicyResolverForTests,
+} from '../../../../src/services/decision-contract/policy-resolver';
+
+const NOW_ISO = new Date().toISOString();
+
+function seedVoice(lang: string, voiceName: string, fallbackLang: string | null) {
+  configurePolicyResolverForTests({
+    decisionPolicy: [
+      {
+        policy_key: `voice.live_api.voice.${lang}`,
+        tenant_id: null,
+        version: 1,
+        value_json: { voice_name: voiceName, fallback_lang: fallbackLang },
+        effective_from: NOW_ISO,
+        effective_until: null,
+      },
+    ],
+  });
+}
+
+describe('VTID-03126 Phase D.3 Live API voice accessor', () => {
+  let warnSpy: jest.SpyInstance;
+
+  beforeEach(() => {
+    __resetLiveApiVoiceFallbackLogForTests();
+    warnSpy = jest.spyOn(console, 'warn').mockImplementation(() => {});
+  });
+
+  afterEach(() => {
+    __resetPolicyResolverForTests();
+    __resetLiveApiVoiceFallbackLogForTests();
+    warnSpy.mockRestore();
+  });
+
+  describe('cold-cache fallback path (byte-identical to pre-D.3 Record)', () => {
+    beforeEach(() => {
+      __resetPolicyResolverForTests();
+    });
+
+    it('en → Aoede (native, no warning)', () => {
+      expect(getLiveApiVoice('en')).toBe('Aoede');
+      // PolicyResolver may emit its own "policy.miss" warnings when the
+      // cache has no row for a key — those are unrelated to the
+      // voice-fallback contract. Assert that no [voice-fallback] line was
+      // emitted.
+      const voiceFallbackCalls = warnSpy.mock.calls.filter((args) =>
+        typeof args[0] === 'string' && args[0].startsWith('[voice-fallback]'),
+      );
+      expect(voiceFallbackCalls).toHaveLength(0);
+    });
+
+    it('de → Kore (native, no warning)', () => {
+      expect(getLiveApiVoice('de')).toBe('Kore');
+      // PolicyResolver may emit its own "policy.miss" warnings when the
+      // cache has no row for a key — those are unrelated to the
+      // voice-fallback contract. Assert that no [voice-fallback] line was
+      // emitted.
+      const voiceFallbackCalls = warnSpy.mock.calls.filter((args) =>
+        typeof args[0] === 'string' && args[0].startsWith('[voice-fallback]'),
+      );
+      expect(voiceFallbackCalls).toHaveLength(0);
+    });
+
+    it('fr → Charon (native, no warning)', () => {
+      expect(getLiveApiVoice('fr')).toBe('Charon');
+      // PolicyResolver may emit its own "policy.miss" warnings when the
+      // cache has no row for a key — those are unrelated to the
+      // voice-fallback contract. Assert that no [voice-fallback] line was
+      // emitted.
+      const voiceFallbackCalls = warnSpy.mock.calls.filter((args) =>
+        typeof args[0] === 'string' && args[0].startsWith('[voice-fallback]'),
+      );
+      expect(voiceFallbackCalls).toHaveLength(0);
+    });
+
+    it('es → Fenrir (native, no warning)', () => {
+      expect(getLiveApiVoice('es')).toBe('Fenrir');
+      // PolicyResolver may emit its own "policy.miss" warnings when the
+      // cache has no row for a key — those are unrelated to the
+      // voice-fallback contract. Assert that no [voice-fallback] line was
+      // emitted.
+      const voiceFallbackCalls = warnSpy.mock.calls.filter((args) =>
+        typeof args[0] === 'string' && args[0].startsWith('[voice-fallback]'),
+      );
+      expect(voiceFallbackCalls).toHaveLength(0);
+    });
+
+    it('ar → Aoede (English fallback) and emits a warning', () => {
+      expect(getLiveApiVoice('ar')).toBe('Aoede');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/lang="ar".*using "en" voice "Aoede"/),
+      );
+    });
+
+    it('zh → Kore (German fallback) and emits a warning', () => {
+      expect(getLiveApiVoice('zh')).toBe('Kore');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/lang="zh".*using "de" voice "Kore"/),
+      );
+    });
+
+    it('ru → Aoede (English fallback) and emits a warning', () => {
+      expect(getLiveApiVoice('ru')).toBe('Aoede');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/lang="ru".*using "en" voice "Aoede"/),
+      );
+    });
+
+    it('sr → Aoede (English fallback) and emits a warning', () => {
+      expect(getLiveApiVoice('sr')).toBe('Aoede');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/lang="sr".*using "en" voice "Aoede"/),
+      );
+    });
+  });
+
+  describe('telemetry de-duplication', () => {
+    beforeEach(() => {
+      __resetPolicyResolverForTests();
+    });
+
+    it('emits the fallback warning at most once per (lang, fallback_lang) pair', () => {
+      for (let i = 0; i < 5; i++) {
+        getLiveApiVoice('ar');
+      }
+      // 5 calls, but the (ar, en) pair logs only once across the process
+      // lifetime — high-cardinality voice sessions cannot spam the logger.
+      const voiceFallbackCalls = warnSpy.mock.calls.filter((args) =>
+        typeof args[0] === 'string' && args[0].startsWith('[voice-fallback]'),
+      );
+      expect(voiceFallbackCalls).toHaveLength(1);
+    });
+
+    it('different fallback langs each get their own one-time warning', () => {
+      getLiveApiVoice('ar'); // (ar, en)
+      getLiveApiVoice('zh'); // (zh, de)
+      getLiveApiVoice('ru'); // (ru, en)
+      getLiveApiVoice('sr'); // (sr, en)
+      const voiceFallbackCalls = warnSpy.mock.calls.filter((args) =>
+        typeof args[0] === 'string' && args[0].startsWith('[voice-fallback]'),
+      );
+      expect(voiceFallbackCalls).toHaveLength(4);
+    });
+  });
+
+  describe('resolver-seeded path — DB row wins over fallback', () => {
+    it('returns the seeded voice_name', () => {
+      seedVoice('ar', 'NewArabicVoice', null);
+      expect(getLiveApiVoice('ar')).toBe('NewArabicVoice');
+    });
+
+    it('clearing fallback_lang in DB silences the telemetry', () => {
+      // Operational dream: ship a native Arabic voice → edit the DB row
+      // → no code change, no deploy, no warning.
+      seedVoice('ar', 'NativeArabic', null);
+      getLiveApiVoice('ar');
+      getLiveApiVoice('ar');
+      // PolicyResolver may emit its own "policy.miss" warnings when the
+      // cache has no row for a key — those are unrelated to the
+      // voice-fallback contract. Assert that no [voice-fallback] line was
+      // emitted.
+      const voiceFallbackCalls = warnSpy.mock.calls.filter((args) =>
+        typeof args[0] === 'string' && args[0].startsWith('[voice-fallback]'),
+      );
+      expect(voiceFallbackCalls).toHaveLength(0);
+    });
+
+    it('setting fallback_lang in DB on a previously-native lang surfaces a warning', () => {
+      // The reverse of the above: tagging a voice as fallback (e.g. a
+      // regression where we have to temporarily route fr to en) makes
+      // the silent voice routing visible.
+      seedVoice('fr', 'Aoede', 'en');
+      getLiveApiVoice('fr');
+      expect(warnSpy).toHaveBeenCalledWith(
+        expect.stringMatching(/lang="fr".*using "en" voice "Aoede"/),
+      );
+    });
+  });
+
+  describe('input sanitization', () => {
+    beforeEach(() => {
+      __resetPolicyResolverForTests();
+    });
+
+    it('empty string lang → English default, no warning', () => {
+      expect(getLiveApiVoice('')).toBe('Aoede');
+      // PolicyResolver may emit its own "policy.miss" warnings when the
+      // cache has no row for a key — those are unrelated to the
+      // voice-fallback contract. Assert that no [voice-fallback] line was
+      // emitted.
+      const voiceFallbackCalls = warnSpy.mock.calls.filter((args) =>
+        typeof args[0] === 'string' && args[0].startsWith('[voice-fallback]'),
+      );
+      expect(voiceFallbackCalls).toHaveLength(0);
+    });
+
+    it('unknown lang → English fallback voice (Aoede), no warning (no DB row at all)', () => {
+      // No DB row for "jp"; no entry in LIVE_API_VOICE_FALLBACKS either.
+      // The accessor's safety-net is the English row, which is native.
+      expect(getLiveApiVoice('jp')).toBe('Aoede');
+      // PolicyResolver may emit its own "policy.miss" warnings when the
+      // cache has no row for a key — those are unrelated to the
+      // voice-fallback contract. Assert that no [voice-fallback] line was
+      // emitted.
+      const voiceFallbackCalls = warnSpy.mock.calls.filter((args) =>
+        typeof args[0] === 'string' && args[0].startsWith('[voice-fallback]'),
+      );
+      expect(voiceFallbackCalls).toHaveLength(0);
+    });
+  });
+});

--- a/supabase/migrations/20260528020000_VTID_03126_live_api_voice_seeds.sql
+++ b/supabase/migrations/20260528020000_VTID_03126_live_api_voice_seeds.sql
@@ -1,0 +1,100 @@
+-- Phase D.3 (decision-contract refactor) — Live API voice mapping seeds.
+--
+-- VTID-03126. Externalizes `LIVE_API_VOICES` from
+-- `services/gateway/src/routes/orb-live.ts:1341` into the
+-- `decision_policy` table. Each row carries `{voice_name, fallback_lang}`
+-- so the accessor can emit telemetry when a non-native fallback voice
+-- is selected — closes the silent "Arabic → English Aoede" audit finding.
+--
+-- Idempotent: each INSERT is guarded by WHERE NOT EXISTS against the
+-- same (key, tenant, version). Safe to re-run.
+--
+-- Values are BYTE-IDENTICAL to the LIVE_API_VOICES Record. The
+-- `fallback_lang` field is "en" for languages currently using an English
+-- voice as fallback; null for native-voice rows.
+
+-- Native voices (no fallback)
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.live_api.voice.en', NULL, 1,
+       '{"voice_name":"Aoede","fallback_lang":null}'::jsonb,
+       'seed',
+       'orb-live.ts:1342 (LIVE_API_VOICES.en — native English voice)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM decision_policy
+  WHERE policy_key = 'voice.live_api.voice.en' AND tenant_id IS NULL AND version = 1
+);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.live_api.voice.de', NULL, 1,
+       '{"voice_name":"Kore","fallback_lang":null}'::jsonb,
+       'seed',
+       'orb-live.ts:1343 (LIVE_API_VOICES.de — native German voice)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM decision_policy
+  WHERE policy_key = 'voice.live_api.voice.de' AND tenant_id IS NULL AND version = 1
+);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.live_api.voice.fr', NULL, 1,
+       '{"voice_name":"Charon","fallback_lang":null}'::jsonb,
+       'seed',
+       'orb-live.ts:1344 (LIVE_API_VOICES.fr — native French voice)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM decision_policy
+  WHERE policy_key = 'voice.live_api.voice.fr' AND tenant_id IS NULL AND version = 1
+);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.live_api.voice.es', NULL, 1,
+       '{"voice_name":"Fenrir","fallback_lang":null}'::jsonb,
+       'seed',
+       'orb-live.ts:1345 (LIVE_API_VOICES.es — native Spanish voice)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM decision_policy
+  WHERE policy_key = 'voice.live_api.voice.es' AND tenant_id IS NULL AND version = 1
+);
+
+-- Languages currently using an English voice as fallback. The
+-- fallback_lang field marks them so the accessor can emit telemetry
+-- whenever they are read. Once a native voice ships for these
+-- languages, replace the row with `fallback_lang: null` and a new
+-- voice_name.
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.live_api.voice.ar', NULL, 1,
+       '{"voice_name":"Aoede","fallback_lang":"en"}'::jsonb,
+       'seed',
+       'orb-live.ts:1346 (LIVE_API_VOICES.ar — silent English-voice fallback; telemetry will fire on each read until a native Arabic voice is shipped)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM decision_policy
+  WHERE policy_key = 'voice.live_api.voice.ar' AND tenant_id IS NULL AND version = 1
+);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.live_api.voice.zh', NULL, 1,
+       '{"voice_name":"Kore","fallback_lang":"de"}'::jsonb,
+       'seed',
+       'orb-live.ts:1347 (LIVE_API_VOICES.zh — silent fallback to German "Kore"; telemetry will fire on each read until a native Chinese voice is shipped)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM decision_policy
+  WHERE policy_key = 'voice.live_api.voice.zh' AND tenant_id IS NULL AND version = 1
+);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.live_api.voice.ru', NULL, 1,
+       '{"voice_name":"Aoede","fallback_lang":"en"}'::jsonb,
+       'seed',
+       'orb-live.ts:1348 (LIVE_API_VOICES.ru — silent English-voice fallback; telemetry will fire on each read)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM decision_policy
+  WHERE policy_key = 'voice.live_api.voice.ru' AND tenant_id IS NULL AND version = 1
+);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.live_api.voice.sr', NULL, 1,
+       '{"voice_name":"Aoede","fallback_lang":"en"}'::jsonb,
+       'seed',
+       'orb-live.ts:1349 (LIVE_API_VOICES.sr — silent English-voice fallback; telemetry will fire on each read)'
+WHERE NOT EXISTS (
+  SELECT 1 FROM decision_policy
+  WHERE policy_key = 'voice.live_api.voice.sr' AND tenant_id IS NULL AND version = 1
+);


### PR DESCRIPTION
## Summary
**Phase D.3** of the contextual-intelligence refactor. Closes the audit's "silent Arabic → English Aoede" finding by migrating the `LIVE_API_VOICES` Record from inline in `orb-live.ts:1341` to `decision_policy`-backed `getLiveApiVoice(lang)` with explicit fallback telemetry.

## Why
Audit identified 4 languages (ar, zh, ru, sr) silently using non-native voices via the inline Record. No log, no metric, no way for ops to know German users were getting a German voice but Arabic users were getting English. Phase D.3 makes that visible — the fallback is still served (byte-identical at rollout) but a deduped `[voice-fallback]` warning fires per (lang, fallback_lang) pair so log aggregation surfaces the gap.

## Changes
- **Migration** `20260528020000_VTID_03126_live_api_voice_seeds.sql` — 8 idempotent inserts under `voice.live_api.voice.<lang>`. Each row stores `{voice_name, fallback_lang}` JSON; `fallback_lang` is `null` for native voices, set to the borrowed-from language otherwise.
- **New module** `orb/live/voice/live-api-voice.ts` — `getLiveApiVoice(lang)` accessor with cache-cold literal safety net + per-(lang, fallback_lang) dedup'd telemetry.
- **`orb-live.ts`** — 7 call sites + import migrated. `LIVE_API_VOICES` declaration removed (replaced with a one-line VTID-03126 reference comment).

## How to silence a fallback warning
Once a native voice ships for a language, the operational fix is a single DB update — **no code change, no deploy**:
```sql
UPDATE decision_policy
   SET value_json = '{"voice_name":"NewNativeArabicVoice","fallback_lang":null}'::jsonb,
       version = 2
 WHERE policy_key = 'voice.live_api.voice.ar' AND tenant_id IS NULL;
```

## Test plan
- [x] 15 new VTID-03126 cases (4 native silent + 4 fallback warning, dedup behavior, seeded-row reads, input sanitization).
- [x] Full orb suite: 817/817 green across 49/49 suites.
- [x] `npm run build` clean.
- [ ] CI green.
- [ ] RUN-MIGRATION: 8 row inserts logged.
- [ ] Post-deploy `/alive` 200 JSON.

## Out of scope (deferred to D.3.b-e)
- `GEMINI_TTS_VOICES` (8 Cloud TTS Gemini "Kore" voices)
- `NEURAL2_TTS_VOICES` (8 Neural2/WaveNet voices)
- `NEURAL2_ENABLED_LANGUAGES` (8-lang array)
- `LIVE_LANGUAGE_VOICES` (Gemini Live voice names per lang)

Each is its own VTID + PR after D.4 lands. This PR ships the highest-value piece (the silent-fallback fix) without bulk-migrating 4 voice tables in one go.

🤖 Generated with [Claude Code](https://claude.com/claude-code)