### PR TITLE
feat(reminders): wire reminder cron + always-push-to-mobile delivery

### DIFF
--- a/scripts/setup-cloud-scheduler.sh
+++ b/scripts/setup-cloud-scheduler.sh
@@ -105,3 +105,57 @@ done
 
 echo ""
 echo "Done. ${#JOBS[@]} scheduler jobs processed."
+
+# ──────────────────────────────────────────────────────────────
+# Direct-URL Scheduler Jobs (VTID-02601 — reminder tick/sweeper)
+#
+# These don't follow the AP-XXXX automation registry pattern — they
+# hit gateway routes directly. They're tenant-agnostic (the endpoints
+# scan all due reminders across every tenant) so no tenant_id needed.
+# ──────────────────────────────────────────────────────────────
+
+# Format: NAME|SCHEDULE|TIMEZONE|PATH
+DIRECT_JOBS=(
+  "reminders-tick|* * * * *|UTC|/api/v1/scheduled-notifications/reminders-tick"
+  "reminders-sweeper|*/5 * * * *|UTC|/api/v1/scheduled-notifications/reminders-sweeper"
+)
+
+for JOB in "${DIRECT_JOBS[@]}"; do
+  IFS='|' read -r NAME SCHEDULE TIMEZONE PATH_ <<< "$JOB"
+  JOB_NAME="gateway-${NAME}"
+  TARGET_URL="${GATEWAY_URL}${PATH_}"
+
+  if $DELETE; then
+    echo "Deleting: $JOB_NAME"
+    if ! $DRY_RUN; then
+      gcloud scheduler jobs delete "$JOB_NAME" \
+        --project="$PROJECT" \
+        --location="$REGION" \
+        --quiet 2>/dev/null || echo "  (not found, skipping)"
+    fi
+  else
+    echo "Creating: $JOB_NAME → $PATH_ ($SCHEDULE $TIMEZONE)"
+    if ! $DRY_RUN; then
+      gcloud scheduler jobs delete "$JOB_NAME" \
+        --project="$PROJECT" \
+        --location="$REGION" \
+        --quiet 2>/dev/null || true
+
+      gcloud scheduler jobs create http "$JOB_NAME" \
+        --project="$PROJECT" \
+        --location="$REGION" \
+        --schedule="$SCHEDULE" \
+        --time-zone="$TIMEZONE" \
+        --uri="$TARGET_URL" \
+        --http-method=POST \
+        --headers="Content-Type=application/json" \
+        --message-body="{}" \
+        --attempt-deadline=120s \
+        --max-retry-attempts=1 \
+        --description="Gateway direct cron: $NAME"
+    fi
+  fi
+done
+
+echo ""
+echo "Done. ${#DIRECT_JOBS[@]} direct-URL scheduler jobs processed."

--- a/services/gateway/src/i18n/catalog.ts
+++ b/services/gateway/src/i18n/catalog.ts
@@ -35,6 +35,7 @@ export type GatewayI18nKey =
   | 'notif.recommendation_expiring.body'
   | 'notif.signal_expired.title'
   | 'notif.signal_expired.body'
+  | 'notif.reminder.title'
   | 'notif.fallback_app_name'
   // Notification-category labels surfaced on Settings → Notifications page.
   // Mapped from notification_categories.slug (display_name + description).
@@ -84,6 +85,7 @@ const DE: LocaleCatalog = {
   'notif.recommendation_expiring.body': '"{title}" läuft bald ab. Jetzt handeln!',
   'notif.signal_expired.title': 'Signal abgelaufen',
   'notif.signal_expired.body': 'Ein prädiktives Signal ist abgelaufen.',
+  'notif.reminder.title': '🔔 Erinnerung',
   'notif.fallback_app_name': 'Vitana',
   // Notification-category labels (Settings → Benachrichtigungen)
   'notif.category.chat.direct_messages.label': 'Direktnachrichten',
@@ -131,6 +133,7 @@ const EN: LocaleCatalog = {
   'notif.recommendation_expiring.body': '"{title}" expires soon. Act now!',
   'notif.signal_expired.title': 'Signal Expired',
   'notif.signal_expired.body': 'A predictive signal has expired.',
+  'notif.reminder.title': '🔔 Reminder',
   'notif.fallback_app_name': 'Vitana',
   // Notification-category labels (Settings → Notifications)
   'notif.category.chat.direct_messages.label': 'Direct Messages',

--- a/services/gateway/src/routes/scheduled-notifications.ts
+++ b/services/gateway/src/routes/scheduled-notifications.ts
@@ -972,13 +972,12 @@ router.post('/reminders-tick', async (_req: Request, res: Response) => {
           });
         } catch {}
 
-        // VTID-02601 FCM fallback: 5s after fire, if SSE didn't ack the row,
-        // send an OS-level push notification so the user gets the reminder
-        // even if the app is closed / phone locked / WebView suspended.
-        // SSE wins for active clients (it acks within ~3s); FCM catches the
-        // rest. Best-effort, fully detached — does not block the tick.
-        scheduleReminderFcmFallback(supa, row).catch((e) =>
-          console.warn(`[reminders-tick] FCM fallback schedule failed for ${row.id}:`, e?.message),
+        // VTID-02601 / BOOTSTRAP-REMINDERS-CRON: 5s after fire, always send an
+        // OS-level push (FCM + Appilix) so the reminder reaches the lock screen
+        // regardless of whether the in-app SSE banner already showed on web.
+        // Best-effort, fully detached — does not block the tick.
+        scheduleReminderFcmPush(supa, row).catch((e) =>
+          console.warn(`[reminders-tick] FCM push schedule failed for ${row.id}:`, e?.message),
         );
 
         fired++;
@@ -1051,40 +1050,33 @@ router.post('/reminders-sweeper', async (_req: Request, res: Response) => {
 });
 
 // =============================================================================
-// VTID-02601 — scheduleReminderFcmFallback
+// VTID-02601 — scheduleReminderFcmPush
 //
-// 5 seconds after a reminder is marked 'fired', re-check `acked_at`. If the
-// SSE listener already acked the row (because the app is open and the user
-// got the chime + voice + banner), skip — the user has been notified. If
-// not, send an FCM web push so the OS surfaces a notification. Also try
-// Appilix native push for the Maxina installed app (currently 522 per memory,
-// but worth retrying — fails silently if API is down).
+// 5 seconds after a reminder is marked 'fired', send the mobile/web push
+// (FCM + Appilix native). Always fires regardless of SSE ack — product
+// decision (BOOTSTRAP-REMINDERS-CRON): a reminder should always reach the
+// lock screen even if the user already saw the in-app banner on web, because
+// they may dismiss the web banner, walk away, and rely on the phone. The web
+// overlay's seen-set dedups so a user with both surfaces open never sees the
+// same fire rendered twice.
 //
-// Detached from the request handler — Cloud Run keeps the function instance
-// alive long enough for the 5-second timer because the gateway has CPU
-// always-on (set in EXEC-DEPLOY). Worst case (instance scales to zero),
-// the FCM is dropped and the next tick poll picks it up via the existing
-// fired+unacked SSE flow.
+// The 5-second delay stays as a small grace window (lets the SSE banner land
+// first when the app is open) and to keep the Cloud Run instance warm. Worst
+// case (instance scales to zero) the push is dropped and the next tick poll
+// re-picks it via the fired+unacked SSE flow.
+//
+// Title is localized (CLAUDE.md §13b) so German users don't see English on
+// the lock screen; the body is the user's own reminder text (not translated).
 // =============================================================================
-async function scheduleReminderFcmFallback(
+async function scheduleReminderFcmPush(
   supa: any,
   row: { id: string; user_id: string; tenant_id: string; action_text: string; spoken_message: string | null }
 ): Promise<void> {
   await new Promise((r) => setTimeout(r, 5000));
 
-  // Re-check acked_at — SSE may have already delivered + the user dismissed.
-  const { data: fresh } = await supa
-    .from('reminders')
-    .select('id, acked_at, delivery_via')
-    .eq('id', row.id)
-    .maybeSingle();
-  if (fresh?.acked_at) {
-    console.log(`[reminders-tick] FCM skip — already acked via ${fresh.delivery_via} (${row.id})`);
-    return;
-  }
-
+  const locale = await getUserLocale(supa, row.user_id);
   const payload = {
-    title: '🔔 Reminder',
+    title: tt('notif.reminder.title', locale),
     body: row.action_text,
     data: {
       type: 'reminder.fire',
@@ -1097,7 +1089,7 @@ async function scheduleReminderFcmFallback(
   try {
     const fcmSent = await sendPushToUser(row.user_id, row.tenant_id, payload, supa);
     const appilixSent = await sendAppilixPush(row.user_id, payload);
-    console.log(`[reminders-tick] FCM fallback for ${row.id}: fcm=${fcmSent} appilix=${appilixSent}`);
+    console.log(`[reminders-tick] FCM push for ${row.id}: fcm=${fcmSent} appilix=${appilixSent}`);
 
     // Mark delivery_via=fcm if we sent at least one push and the row is still
     // unacked. The SSE flow may still race-deliver later — that's fine, the


### PR DESCRIPTION
## Summary

Two related fixes that make the user-facing reminders feature (VTID-02601) actually deliver end-to-end. Verified live in dev: a voice reminder ("remind me to take my medicine") now writes a row, the cron picks it up, and it delivers to web (SSE) and — after this PR — mobile lock screen too.

### 1. Wire the reminder cron jobs (`scripts/setup-cloud-scheduler.sh`)

The reminders system shipped full CRUD + dispatch infra but **no Cloud Scheduler job ever called `/reminders-tick`**, so nothing fired. New `DIRECT_JOBS` array adds:
- `gateway-reminders-tick` — `* * * * *` UTC → `/api/v1/scheduled-notifications/reminders-tick` (Cloud Scheduler min interval is 1 min; the "30s" in the source comment needs Cloud Tasks, out of scope)
- `gateway-reminders-sweeper` — `*/5 * * * *` UTC → `/api/v1/scheduled-notifications/reminders-sweeper` (recovers rows stuck in `dispatching`)

### 2. Always push reminders to mobile (`scheduled-notifications.ts`, `i18n/catalog.ts`)

Product decision: a reminder must always reach the lock screen even if the in-app web banner already showed. Previously `scheduleReminderFcmFallback` skipped the FCM/Appilix push whenever the row was acked within 5s — which the web overlay does automatically when the app is open — so a user active on desktop never got the mobile push.

- Removed the `acked_at` early-return; renamed `scheduleReminderFcmFallback` → `scheduleReminderFcmPush` (it's now the primary mobile path, not a fallback). The web overlay's seen-set already dedups, so a user with both surfaces open won't see the same fire twice.
- Localized the push title via the i18n catalog (CLAUDE.md §13b): new `notif.reminder.title` (DE `🔔 Erinnerung`, EN `🔔 Reminder`). Body is the user's own reminder text, untranslated. Fixes English "Reminder" on German lock screens.
- Kept the 5s grace delay (SSE banner lands first; keeps Cloud Run warm).

## Deploy note

Part 2 changes gateway code → needs EXEC-DEPLOY after merge. Part 1 is a Cloud Shell script (no deploy); the two scheduler jobs were already registered manually in dev and confirmed firing.

## Test plan

- [ ] After merge + EXEC-DEPLOY: set a reminder via ORB voice while the web app is **open**. Confirm BOTH the web banner AND a mobile lock-screen push arrive (previously only the banner).
- [ ] Confirm German user sees `🔔 Erinnerung` not `🔔 Reminder`.
- [ ] `gcloud logging` shows `[reminders-tick] FCM push for <id>: fcm=N appilix=...` with no `FCM skip — already acked` lines.
- [ ] Re-run `bash scripts/setup-cloud-scheduler.sh` from Cloud Shell; confirm `gateway-reminders-tick` + `gateway-reminders-sweeper` present.
