### PR TITLE
fix(orb-live): Teacher-aware reconnect recovery — pick up where Teacher left off (VTID-03128)

### DIFF
--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -6796,6 +6796,86 @@ function sendReconnectRecoveryPromptToLiveAPI(ws: WebSocket, session: GeminiLive
   const stage = ((session as any).reconnectStage as string) || 'idle';
   const reconnectCount = ((session as any)._reconnectCount || 0);
 
+  // VTID-03128: Teacher-aware recovery. When session.teacherModeContent
+  // is set, the generic "what were you asking?" prompt below makes
+  // Vitana lose the Teacher thread — user complained that after a
+  // disconnect during "Want me to show you Autopilot?", Vitana came
+  // back saying "Sorry, what were you asking?" instead of continuing
+  // the Teacher flow. The Teacher Mode block stays in system_instruction
+  // across the reconnect (because session.teacherModeContent is
+  // preserved on attemptTransparentReconnect); the recovery prompt was
+  // the only thing fighting against it. This branch tells Gemini to
+  // resume the Teacher flow explicitly: acknowledge the blip briefly,
+  // then continue from where the Teacher Mode block + transcript
+  // history place the conversation.
+  const teacherMode = (session as any).teacherModeContent as
+    | {
+        active_capability_key: string;
+        active_display_name: string;
+        active_teacher_intro_script: string | null;
+      }
+    | undefined;
+  if (teacherMode && teacherMode.active_capability_key) {
+    const ackByLang: Record<string, string> = {
+      en: 'Sorry, the connection blipped for a moment.',
+      de: 'Entschuldige, die Verbindung war kurz weg.',
+      fr: 'Désolé, la connexion a sauté un instant.',
+      es: 'Perdón, se cortó la conexión un momento.',
+      sr: 'Извини, веза је на тренутак отпала.',
+    };
+    const ack = ackByLang[lang] || ackByLang.en;
+
+    const teacherRecoveryPrompt = [
+      'You are recovering from a brief connection blip in the middle of a Teacher Mode session.',
+      '',
+      `The active capability is "${teacherMode.active_display_name}" (key: ${teacherMode.active_capability_key}).`,
+      'Your Teacher Mode block + the conversation history are in your system instruction. Read them to know exactly where the conversation was when the connection dropped.',
+      '',
+      'Recovery shape — speak exactly ONE acknowledgment sentence first, then RESUME the Teacher flow from where you left off:',
+      '',
+      `1. Open with: "${ack}"`,
+      '',
+      '2. Then look at what was happening BEFORE the disconnect (in the conversation history):',
+      `   - If you had JUST OFFERED the capability ("Want me to show you ${teacherMode.active_display_name}?") and the user had not yet responded → briefly re-offer in a slightly different wording, e.g. "Sind wir noch in der Frage, ob ich dir ${teacherMode.active_display_name} vorstellen darf?" / "Are we still on whether to walk through ${teacherMode.active_display_name}?"`,
+      `   - If you were IN THE MIDDLE OF the intro for ${teacherMode.active_display_name} → continue from where you stopped, picking up the unfinished sentence. Do NOT start the intro over.`,
+      `   - If you had JUST FINISHED the intro and were about to ask the user's next preference → ask the named-next question now ("Möchtest du noch mehr dazu wissen, oder soll ich dir ${teacherMode.active_display_name} jetzt im Detail zeigen?").`,
+      `   - If the user was responding when the connection dropped → paraphrase what they were saying (from history) in 3-6 words and invite them to continue ("Du warst gerade bei <kurz paraphrasieren> — sprich ruhig weiter.").`,
+      '',
+      'CRITICAL RULES:',
+      '- Do NOT say "Hello" / "Hi" / "Welcome back" / the user\'s name — this is a recovery, not a fresh start.',
+      '- Do NOT ask generic "What would you like to talk about?" — you ALREADY KNOW you were in Teacher Mode for ' + teacherMode.active_display_name + '.',
+      '- Do NOT restart the offer or the intro from scratch — continue.',
+      '- Do NOT use the word "Internet" / "network" / "Wi-Fi" — say "connection" / "Verbindung".',
+      '- Speak in the user\'s language (set in your system instruction).',
+      '- Use "Sorry" / equivalent ONCE only.',
+      '- Speak immediately when this prompt arrives.',
+      '- The Teacher Mode behavior rules (3-4 sentence intros, named-next, awareness-event tool calls) ALL still apply once you have resumed.',
+    ].join('\n');
+
+    const message = {
+      client_content: {
+        turns: [{ role: 'user', parts: [{ text: teacherRecoveryPrompt }] }],
+        turn_complete: true,
+      },
+    };
+    ws.send(JSON.stringify(message));
+    session.greetingSent = true;
+    session.greetingTurnIndex = session.turn_count;
+    console.log(
+      `[VTID-03128] Teacher-aware recovery sent — capability=${teacherMode.active_capability_key} lang=${lang} stage=${stage} reconnectCount=${reconnectCount} transcriptTurns=${session.transcriptTurns?.length || 0}`,
+    );
+    emitDiag(session, 'recovery_prompt_sent', {
+      lang,
+      stage,
+      reconnect_count: reconnectCount,
+      transcript_turns: session.transcriptTurns?.length || 0,
+      recovery_mode: 'teacher_resume',
+      capability_key: teacherMode.active_capability_key,
+    });
+    startResponseWatchdog(session, getGreetingResponseTimeoutMs(), 'recovery_timeout');
+    return true;
+  }
+
   // VTID-02715 — neutral disconnect copy.
   //  - Words "internet" / "network" never appear: the user's Wi-Fi is fine,
   //    the drop is on the upstream WS side and we don't shift blame.

--- a/services/gateway/test/orb/live/characterization/vertex-teacher-recovery.characterization.test.ts
+++ b/services/gateway/test/orb/live/characterization/vertex-teacher-recovery.characterization.test.ts
@@ -1,0 +1,106 @@
+/**
+ * VTID-03128 — Teacher-aware reconnect recovery.
+ *
+ * Without this branch, sendReconnectRecoveryPromptToLiveAPI sends the
+ * generic VTID-02020 recovery prompt ("Sorry, we got disconnected. What
+ * were you asking?"). That prompt is fine for a freeform chat session
+ * but disastrous for a Teacher Mode session: Vitana was halfway through
+ * offering / introducing a capability when the connection blipped, and
+ * the generic prompt makes her lose the thread entirely.
+ *
+ * This file locks the structural contract of the new branch so a future
+ * refactor cannot silently remove the Teacher-aware path:
+ *   - Reads session.teacherModeContent
+ *   - Branches BEFORE the generic recovery prompt is built
+ *   - References the active_capability_key + active_display_name in the
+ *     prompt so Gemini knows what was being taught
+ *   - Tells Gemini to resume the Teacher flow, not restart it
+ *   - Emits the [VTID-03128] diagnostic log so production grep can
+ *     confirm the right branch fired
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const ORB_LIVE_PATH = path.resolve(__dirname, '../../../../src/routes/orb-live.ts');
+
+let orbLiveSource: string;
+
+beforeAll(() => {
+  orbLiveSource = fs.readFileSync(ORB_LIVE_PATH, 'utf8');
+});
+
+function extractRecoveryFn(): string {
+  const startIdx = orbLiveSource.indexOf(
+    'function sendReconnectRecoveryPromptToLiveAPI(',
+  );
+  if (startIdx === -1) {
+    throw new Error('sendReconnectRecoveryPromptToLiveAPI not found in orb-live.ts');
+  }
+  const afterStart = orbLiveSource.slice(startIdx + 1);
+  const nextFnRel = afterStart.search(/\nfunction\s+\w/);
+  return nextFnRel === -1
+    ? orbLiveSource.slice(startIdx)
+    : orbLiveSource.slice(startIdx, startIdx + 1 + nextFnRel);
+}
+
+describe('VTID-03128: Teacher-aware reconnect recovery branch', () => {
+  let fn: string;
+  beforeAll(() => {
+    fn = extractRecoveryFn();
+  });
+
+  it('reads session.teacherModeContent before composing the recovery prompt', () => {
+    expect(fn).toMatch(/session as any\)\.teacherModeContent/);
+  });
+
+  it('Teacher branch references the active capability by display name AND key', () => {
+    // Both name + key must appear so production logs / Gemini's prompt
+    // have a clear identifier of what was being taught.
+    expect(fn).toMatch(/teacherMode\.active_display_name/);
+    expect(fn).toMatch(/teacherMode\.active_capability_key/);
+  });
+
+  it('Teacher branch tells Gemini to RESUME, not restart', () => {
+    // Capture only the teacher branch (between the teacherMode guard
+    // and the next `}` block boundary).
+    const branchStart = fn.indexOf('teacherMode && teacherMode.active_capability_key');
+    expect(branchStart).toBeGreaterThan(-1);
+    const window = fn.slice(branchStart, branchStart + 4500);
+    // Resume language present.
+    expect(window).toMatch(/RESUME the Teacher flow/i);
+    expect(window).toMatch(/Do NOT start the intro over/);
+    // Don't-greet rules.
+    expect(window).toMatch(/Do NOT say "Hello"/);
+    expect(window).toMatch(/Do NOT restart/);
+    // No generic "what would you like to talk about" trap.
+    expect(window).toMatch(/Do NOT ask generic "What would you like to talk about\?"/);
+  });
+
+  it('Teacher branch emits the VTID-03128 diagnostic log + diag event', () => {
+    expect(fn).toMatch(/\[VTID-03128\] Teacher-aware recovery sent/);
+    expect(fn).toMatch(/recovery_mode: 'teacher_resume'/);
+  });
+
+  it('Teacher branch returns before the legacy generic recovery code runs', () => {
+    // The branch must end with `return true;` so the legacy prompt
+    // builder below cannot also fire and double-send.
+    const branchMatch = fn.match(
+      /if\s*\(teacherMode\s*&&\s*teacherMode\.active_capability_key\)\s*\{[\s\S]+?return true;\s*\n\s\s\}/,
+    );
+    expect(branchMatch).not.toBeNull();
+  });
+
+  it('Teacher branch sets greetingSent so stall-recovery does not re-send', () => {
+    const branchStart = fn.indexOf('teacherMode && teacherMode.active_capability_key');
+    const window = fn.slice(branchStart, branchStart + 4500);
+    expect(window).toMatch(/session\.greetingSent\s*=\s*true/);
+  });
+
+  it('legacy VTID-02020 recovery path still exists for non-Teacher sessions', () => {
+    // The generic recovery prompt MUST still be intact further down so
+    // freeform chat reconnects (anonymous, non-Teacher) keep working.
+    expect(fn).toMatch(/VTID-02715/);
+    expect(fn).toMatch(/RECONNECT_STAGE = /);
+  });
+});


### PR DESCRIPTION
## Why
User report: \"Vertex disconnects frequently. When it reconnects, Vitana says 'Sorry, we got disconnected. What were you asking?' — losing the Teacher thread. She must pick up from where she left off.\"

## Root cause
`session.teacherModeContent` IS preserved across reconnects (session object survives `attemptTransparentReconnect`; only the upstream WS is replaced). The Teacher Mode block IS re-injected into system_instruction by buildOrbVertexSetupEnvelope. The ONLY thing fighting this was the generic VTID-02020 recovery prompt sent by `sendReconnectRecoveryPromptToLiveAPI` — it told Gemini to answer \"What were you asking?\" / \"What would you like to talk about?\" regardless of Teacher state. Gemini obediently abandoned the Teacher thread.

## What changed
New branch at the top of `sendReconnectRecoveryPromptToLiveAPI`: when `session.teacherModeContent` is set, build a Teacher-aware recovery prompt instead of the generic one. The prompt:
1. Opens with ONE localized acknowledgment (\"Entschuldige, die Verbindung war kurz weg\" / equivalents in EN/FR/ES/SR).
2. References the active capability by display_name + key so Gemini knows what was being taught.
3. Tells Gemini to read the conversation history and resume per situation:
   - Just-offered, no response yet → re-offer in slightly different wording.
   - Mid-intro → continue from the unfinished sentence.
   - Intro just finished → ask the named-next question now.
   - User was responding → paraphrase what they were saying.
4. Strict NEVERs: no \"Hello / Welcome back\", no generic \"What would you like to talk about?\", no restart, no \"Internet/network\" blame.

Legacy VTID-02020 generic recovery is intact for non-Teacher sessions. Pure additive branch.

## Test plan
- [x] 7 new structural tests in `vertex-teacher-recovery.characterization.test.ts`.
- [x] 828 tests pass across 50 suites in `test/orb`.
- [x] `npm run build` clean.
- [ ] **Runtime test on vitanaland**: simulate a disconnect mid-Teacher-session (toggle WiFi while she's offering Autopilot). Reconnect. She should resume the same capability — \"Sorry, the connection blipped. Are we still on whether to walk through Autopilot?\" — not \"What were you asking?\".

🤖 Generated with [Claude Code](https://claude.com/claude-code)