### PR TITLE
feat(chat-groups): accept message_type + content_data on send (VTID-03089)

### DIFF
--- a/services/gateway/src/routes/chat-groups.ts
+++ b/services/gateway/src/routes/chat-groups.ts
@@ -5,8 +5,13 @@
  *   GET    /                       — List groups the caller belongs to
  *   GET    /:id                    — Group info + member list
  *   GET    /:id/messages           — Paginated group message history
- *   POST   /:id/send               — Send a message to the group;
- *                                    @vitana mentions trigger Vitana reply
+ *   POST   /:id/send               — Send a message to the group.
+ *                                    Body: { content?, message_type?: 'text'|'attachment'|'voice',
+ *                                    content_data? } — content_data persists in chat_messages.metadata
+ *                                    (e.g. { attachments: [{url, path, mime, filename, size}] }).
+ *                                    @vitana mentions in text trigger Vitana reply.
+ *                                    Reactions are written client-side via Supabase RLS on
+ *                                    message_reactions (polymorphic on chat_messages.id).
  *   POST   /:id/read               — Mark all group messages read up to "now"
  */
 
@@ -241,10 +246,29 @@ router.post('/:id/send', requireAuth, requireTenant, async (req: Request, res: R
   if (!identity) return res.status(401).json({ ok: false, error: 'unauthorized' });
 
   const { id: groupId } = req.params;
-  const { content } = req.body;
+  const { content, message_type, content_data } = req.body as {
+    content?: unknown;
+    message_type?: unknown;
+    content_data?: unknown;
+  };
 
-  if (!content || typeof content !== 'string' || content.trim().length === 0) {
-    return res.status(400).json({ ok: false, error: 'content is required' });
+  const msgType = typeof message_type === 'string' && message_type.length > 0 ? message_type : 'text';
+  const allowedTypes = new Set(['text', 'attachment', 'voice', 'voice_transcript']);
+  if (!allowedTypes.has(msgType)) {
+    return res.status(400).json({ ok: false, error: 'invalid_message_type' });
+  }
+
+  const rawContent = typeof content === 'string' ? content : '';
+  const trimmed = rawContent.trim();
+  const metadata = content_data && typeof content_data === 'object' ? (content_data as Record<string, unknown>) : {};
+  const attachments = Array.isArray((metadata as any).attachments) ? (metadata as any).attachments : [];
+
+  if (msgType === 'text') {
+    if (trimmed.length === 0) {
+      return res.status(400).json({ ok: false, error: 'content is required' });
+    }
+  } else if (trimmed.length === 0 && attachments.length === 0) {
+    return res.status(400).json({ ok: false, error: 'content_or_attachment_required' });
   }
 
   const supabase = getSupabase();
@@ -254,7 +278,6 @@ router.post('/:id/send', requireAuth, requireTenant, async (req: Request, res: R
     return res.status(403).json({ ok: false, error: 'not_a_member' });
   }
 
-  const trimmed = content.trim();
   const { data, error } = await supabase
     .from('chat_messages')
     .insert({
@@ -263,7 +286,8 @@ router.post('/:id/send', requireAuth, requireTenant, async (req: Request, res: R
       receiver_id: null,
       group_id: groupId,
       content: trimmed,
-      message_type: 'text',
+      message_type: msgType,
+      metadata,
     })
     .select()
     .single();
@@ -273,16 +297,28 @@ router.post('/:id/send', requireAuth, requireTenant, async (req: Request, res: R
     return res.status(500).json({ ok: false, error: error.message });
   }
 
+  const firstAttachmentName: string | null = attachments.length > 0
+    ? (attachments[0] as any)?.filename || (attachments[0] as any)?.name || null
+    : null;
+  let fanoutBody = trimmed;
+  if (trimmed.length === 0) {
+    if (msgType === 'attachment') {
+      fanoutBody = firstAttachmentName ? `📎 ${firstAttachmentName}` : '📎 Attachment';
+    } else if (msgType === 'voice' || msgType === 'voice_transcript') {
+      fanoutBody = '🎤 Voice message';
+    }
+  }
+
   fanoutGroupNotifications(
     supabase,
     groupId,
     identity.user_id,
     identity.tenant_id!,
-    trimmed,
+    fanoutBody,
     data.id,
   ).catch(err => console.warn('[ChatGroups] Fanout failed:', err.message));
 
-  if (VITANA_MENTION_RE.test(trimmed) && !isVitanaBot(identity.user_id)) {
+  if (trimmed.length > 0 && VITANA_MENTION_RE.test(trimmed) && !isVitanaBot(identity.user_id)) {
     handleVitanaGroupMention(
       supabase,
       groupId,


### PR DESCRIPTION
## Summary

- Extend `POST /api/v1/chat/groups/:id/send` to mirror the DM send contract: optional `message_type` (`'text' | 'attachment' | 'voice' | 'voice_transcript'`) and `content_data` (JSONB, stored in `chat_messages.metadata`).
- When the message is attachment- or voice-only, fan-out notifications use a sensible fallback body (`📎 <filename>` / `🎤 Voice message`) so lockscreen pushes still render. `@vitana` mention trigger only runs when text content is non-empty.
- No DB migration — `chat_messages.message_type` + `metadata` already exist (`20260315000000_chat_messages_type_metadata.sql`). Reactions stay client-side via Supabase RLS on the polymorphic `message_reactions` table.

Pairs with the frontend PR in `vitana-v1` (same branch name) which rebuilds the standalone `🎆 FIRST 100` group page to reuse the rich `MessageInput` + `MessageBubble` primitives.

## Test plan

- [ ] Pre-deploy: `grep -n "message_type" services/gateway/src/routes/chat-groups.ts` returns the new validation lines.
- [ ] `cd services/gateway && npx tsc --noEmit` passes (verified locally).
- [ ] Post-deploy curl:
  ```
  curl -s -o /dev/null -w "%{http_code} %{content_type}\n" \
    -X POST "$GATEWAY_URL/api/v1/chat/groups/<gid>/send" \
    -H "Content-Type: application/json" \
    -d '{"content":"","message_type":"attachment","content_data":{"attachments":[]}}'
  ```
  Expect `401 application/json` (route exists, auth required). HTML 404 = redeploy.
- [ ] Send a text message in FIRST 100 from the app → row persists with `message_type='text'`, `metadata={}`.
- [ ] Send an image attachment → row persists with `message_type='attachment'`, `metadata.attachments[0].url` set.
- [ ] Send a voice message → row persists with `message_type='voice'` (or `voice_transcript`).

https://claude.ai/code/session_01DpKHvbsfz696Gv6hiXeiko

---
_Generated by [Claude Code](https://claude.ai/code/session_01DpKHvbsfz696Gv6hiXeiko)_