### PR TITLE
feat(decision-contract): Phase C.3 — PillarWeighterStrategy + cfg-threaded ranker (VTID-03132)

### DIFF
--- a/services/gateway/src/services/decision-contract/index.ts
+++ b/services/gateway/src/services/decision-contract/index.ts
@@ -72,3 +72,16 @@ export type {
   RecommendationStrategyScoreResult,
   RecommendationStrategy,
 } from './strategy';
+
+// Phase C.3 (VTID-03132) — PillarWeighterStrategy implementation.
+// Vertical proof: reads 21 ranker policy keys via PolicyResolver,
+// calls the existing scoreRec/rankBatch, emits RankProvenance.
+// Byte-identical to the pre-C.3 path when defaults are seeded.
+export {
+  PILLAR_WEIGHTER_STRATEGY_ID,
+  PILLAR_WEIGHTER_STRATEGY_VERSION,
+  buildPillarWeighterConfig,
+  scoreRecWithProvenance,
+  rankBatchWithProvenance,
+  type PillarWeighterStrategyResult,
+} from './strategies/pillar-weighter';

--- a/services/gateway/src/services/decision-contract/strategies/pillar-weighter.ts
+++ b/services/gateway/src/services/decision-contract/strategies/pillar-weighter.ts
@@ -1,0 +1,242 @@
+// Phase C.3 (decision-contract refactor) — VTID-03132.
+//
+// PillarWeighterStrategy — the vertical proof for Phase C. Reads the 21
+// ranker policy keys via PolicyResolver, builds a RankerConfig matching
+// the byte-identical defaults, calls the existing scoreRec/rankBatch,
+// and emits a RankProvenance trail naming each major scoring component.
+//
+// Scope-bounded per the brief:
+//   - Ships ONE strategy (this one) reading externalized weights.
+//   - Algorithm-swap (runtime formula interpretation) is deferred to a
+//     Phase C follow-up.
+//   - Provenance is "major component" granularity (base, pillar_boost,
+//     compass_boost, economic_boost, journey_mode, feedback_mult).
+//     Per-feedback-path expansion (which dampener fired specifically)
+//     is a C.3.b follow-up.
+//
+// Discipline:
+//   - Every literal that previously lived inline in scoreRec /
+//     computeJourneyMode / rankBatch reaches this strategy via
+//     `getValue<number>(POLICY_KEYS.RANKER_PILLAR_*, { defaultValue })`.
+//   - Defaults match `DEFAULT_RANKER_CONFIG` so the cache-cold path is
+//     byte-identical to today's behaviour.
+
+import {
+  scoreRec,
+  rankBatch,
+  DEFAULT_RANKER_CONFIG,
+  type RankerConfig,
+  type RankerContext,
+  type RankInputRec,
+  type RankedRec,
+} from '../../recommendation-engine/ranking/index-pillar-weighter';
+import { POLICY_KEYS } from '../policy-keys';
+import { getPolicyResolver, type PolicyResolver } from '../policy-resolver';
+import type {
+  RankProvenance,
+  RankProvenanceComponent,
+} from '../strategy';
+
+export const PILLAR_WEIGHTER_STRATEGY_ID = 'pillar_weighter_v1';
+export const PILLAR_WEIGHTER_STRATEGY_VERSION = 1;
+
+/**
+ * Build a `RankerConfig` populated from PolicyResolver, with the
+ * literals previously hard-coded in `index-pillar-weighter.ts` as
+ * cache-cold defaults. Result: when the policy table is unreachable
+ * or empty, scoring is byte-identical to the pre-C.3 path.
+ */
+export function buildPillarWeighterConfig(
+  resolver: PolicyResolver = getPolicyResolver(),
+  tenantId: string | null = null,
+): RankerConfig {
+  const get = (key: string, defaultValue: number): number =>
+    resolver.getValue<number>(key, { tenantId, defaultValue });
+  return {
+    alpha_pillar:               get(POLICY_KEYS.RANKER_PILLAR_ALPHA_PILLAR,               DEFAULT_RANKER_CONFIG.alpha_pillar),
+    alpha_wave:                 get(POLICY_KEYS.RANKER_PILLAR_ALPHA_WAVE,                 DEFAULT_RANKER_CONFIG.alpha_wave),
+    compass_boost:              get(POLICY_KEYS.RANKER_PILLAR_COMPASS_BOOST,              DEFAULT_RANKER_CONFIG.compass_boost),
+    economic_boost:             DEFAULT_RANKER_CONFIG.economic_boost, // not yet keyed; C.3 follow-up
+    pillar_quota_max:           get(POLICY_KEYS.RANKER_PILLAR_QUOTA_MAX,                  DEFAULT_RANKER_CONFIG.pillar_quota_max),
+    weakest_quota_max:          get(POLICY_KEYS.RANKER_PILLAR_WEAKEST_QUOTA_MAX,          DEFAULT_RANKER_CONFIG.weakest_quota_max),
+    completion_dampener:        get(POLICY_KEYS.RANKER_PILLAR_COMPLETION_DAMPENER,        DEFAULT_RANKER_CONFIG.completion_dampener),
+    plan_dampener:              get(POLICY_KEYS.RANKER_PILLAR_PLAN_DAMPENER,              DEFAULT_RANKER_CONFIG.plan_dampener),
+    rejection_dampener_alpha:   get(POLICY_KEYS.RANKER_PILLAR_REJECTION_DAMPENER_ALPHA,   DEFAULT_RANKER_CONFIG.rejection_dampener_alpha),
+    streak_reinforcement:       get(POLICY_KEYS.RANKER_PILLAR_STREAK_REINFORCEMENT,       DEFAULT_RANKER_CONFIG.streak_reinforcement),
+    community_momentum_boost:   get(POLICY_KEYS.RANKER_PILLAR_COMMUNITY_MOMENTUM_BOOST,   DEFAULT_RANKER_CONFIG.community_momentum_boost),
+    balance_unbalanced_at:      get(POLICY_KEYS.RANKER_PILLAR_BALANCE_UNBALANCED_AT,      DEFAULT_RANKER_CONFIG.balance_unbalanced_at),
+    balance_amplify_at:         get(POLICY_KEYS.RANKER_PILLAR_BALANCE_AMPLIFY_AT,         DEFAULT_RANKER_CONFIG.balance_amplify_at),
+    balance_amplify_factor:     get(POLICY_KEYS.RANKER_PILLAR_BALANCE_AMPLIFY_FACTOR,     DEFAULT_RANKER_CONFIG.balance_amplify_factor),
+    journey_mode_day_break_1:   get(POLICY_KEYS.RANKER_PILLAR_JOURNEY_MODE_DAY_BREAK_1,   DEFAULT_RANKER_CONFIG.journey_mode_day_break_1),
+    journey_mode_day_break_2:   get(POLICY_KEYS.RANKER_PILLAR_JOURNEY_MODE_DAY_BREAK_2,   DEFAULT_RANKER_CONFIG.journey_mode_day_break_2),
+    journey_mode_day_break_3:   get(POLICY_KEYS.RANKER_PILLAR_JOURNEY_MODE_DAY_BREAK_3,   DEFAULT_RANKER_CONFIG.journey_mode_day_break_3),
+    journey_mode_decay_1to2:    get(POLICY_KEYS.RANKER_PILLAR_JOURNEY_MODE_DECAY_1TO2,    DEFAULT_RANKER_CONFIG.journey_mode_decay_1to2),
+    journey_mode_decay_2to3:    get(POLICY_KEYS.RANKER_PILLAR_JOURNEY_MODE_DECAY_2TO3,    DEFAULT_RANKER_CONFIG.journey_mode_decay_2to3),
+    journey_mode_terminal:      get(POLICY_KEYS.RANKER_PILLAR_JOURNEY_MODE_TERMINAL,      DEFAULT_RANKER_CONFIG.journey_mode_terminal),
+    compass_decay_subtract:     get(POLICY_KEYS.RANKER_PILLAR_COMPASS_DECAY_SUBTRACT,     DEFAULT_RANKER_CONFIG.compass_decay_subtract),
+    pillar_score_cap:           get(POLICY_KEYS.RANKER_PILLAR_SCORE_CAP,                  DEFAULT_RANKER_CONFIG.pillar_score_cap),
+  };
+}
+
+export interface PillarWeighterStrategyResult<
+  T extends RankInputRec = RankInputRec,
+> {
+  readonly score: number;
+  readonly provenance: RankProvenance;
+  readonly ranked: RankedRec<T>;
+}
+
+/**
+ * Score a single recommendation under the pillar-weighter strategy and
+ * emit a `RankProvenance` trail. The trail captures the same components
+ * scoreRec uses in its scalar formula:
+ *   rank_score = base
+ *     × (1 + alpha_pillar × pillar_boost × (1 − journey_mode))
+ *     × compass_boost × economic_boost × feedback_mult
+ */
+export function scoreRecWithProvenance<T extends RankInputRec>(
+  rec: T,
+  ctx: RankerContext,
+  resolver: PolicyResolver = getPolicyResolver(),
+  tenantId: string | null = null,
+): PillarWeighterStrategyResult<T> {
+  const cfg = buildPillarWeighterConfig(resolver, tenantId);
+  const ranked = scoreRec(rec, ctx, cfg);
+  const base = Number(rec.impact_score ?? 5);
+
+  // pillar contribution: (1 + alpha_pillar × pillar_boost × (1 − journey_mode))
+  // Surface the alpha_pillar weight + pillar_boost signal + (1 − journey_mode)
+  // as a single additive component on the "multiplier-1" side.
+  const journeyComplement = 1 - ranked.journey_mode;
+  const pillarAdditive = cfg.alpha_pillar * ranked.pillar_boost * journeyComplement;
+
+  // feedback_mult — recovered as a single multiplier from the
+  // post-formula identity rank_score = base × (1 + α·pb·(1−jm))
+  //                                       × compass × econ × feedback_mult
+  const denom =
+    base *
+    (1 + pillarAdditive) *
+    ranked.compass_boost *
+    ranked.economic_boost;
+  const feedback_mult = denom > 0 ? ranked.rank_score / denom : 1;
+
+  const components: RankProvenanceComponent[] = [
+    { kind: 'base', value: base },
+    {
+      kind: 'additive',
+      name: 'pillar_boost',
+      weight_key: POLICY_KEYS.RANKER_PILLAR_ALPHA_PILLAR,
+      weight_value: cfg.alpha_pillar,
+      signal: ranked.pillar_boost * journeyComplement,
+      contribution: pillarAdditive,
+    },
+    {
+      kind: 'multiplier',
+      name: 'compass_boost',
+      weight_key: POLICY_KEYS.RANKER_PILLAR_COMPASS_BOOST,
+      weight_value: cfg.compass_boost,
+      applied: ranked.compass_boost > 1,
+      contribution_multiplier: ranked.compass_boost,
+    },
+    {
+      kind: 'multiplier',
+      name: 'economic_boost',
+      // Not yet a `POLICY_KEYS` entry — this lands when economic_boost
+      // gets its own seed key in a Phase C follow-up. Track the literal
+      // here so the provenance row still has a stable key string.
+      weight_key: 'ranker.pillar_weighter.economic_boost',
+      weight_value: cfg.economic_boost,
+      applied: ranked.economic_boost > 1,
+      contribution_multiplier: ranked.economic_boost,
+    },
+    {
+      kind: 'multiplier',
+      name: 'feedback_mult',
+      // Composite of completion / plan / community / streak dampeners + rejection
+      // suppression. C.3.b will break this into per-path components.
+      weight_key: 'ranker.pillar_weighter.feedback_composite',
+      weight_value: feedback_mult,
+      applied: feedback_mult !== 1,
+      contribution_multiplier: feedback_mult,
+    },
+  ];
+
+  const provenance: RankProvenance = {
+    strategy_id: PILLAR_WEIGHTER_STRATEGY_ID,
+    strategy_version: PILLAR_WEIGHTER_STRATEGY_VERSION,
+    computed_at: new Date().toISOString(),
+    tenant_id: tenantId,
+    components,
+    final_score: ranked.rank_score,
+  };
+
+  return { score: ranked.rank_score, provenance, ranked };
+}
+
+/**
+ * Batch variant: builds the resolver-driven config once, scores all recs,
+ * runs the standard quota pass, returns ranked recs paired with provenance.
+ */
+export function rankBatchWithProvenance<T extends RankInputRec>(
+  recs: T[],
+  ctx: RankerContext,
+  resolver: PolicyResolver = getPolicyResolver(),
+  tenantId: string | null = null,
+): Array<PillarWeighterStrategyResult<T>> {
+  const cfg = buildPillarWeighterConfig(resolver, tenantId);
+  // Reuse the existing rankBatch for the quota pass, then attach
+  // provenance per ranked rec. The two passes are decoupled so
+  // provenance generation stays additive (no rank-order change).
+  const ranked = rankBatch(recs, ctx, cfg);
+  return ranked.map((r) => {
+    const base = Number(r.rec.impact_score ?? 5);
+    const journeyComplement = 1 - r.journey_mode;
+    const pillarAdditive = cfg.alpha_pillar * r.pillar_boost * journeyComplement;
+    const denom = base * (1 + pillarAdditive) * r.compass_boost * r.economic_boost;
+    const feedback_mult = denom > 0 ? r.rank_score / denom : 1;
+    const components: RankProvenanceComponent[] = [
+      { kind: 'base', value: base },
+      {
+        kind: 'additive',
+        name: 'pillar_boost',
+        weight_key: POLICY_KEYS.RANKER_PILLAR_ALPHA_PILLAR,
+        weight_value: cfg.alpha_pillar,
+        signal: r.pillar_boost * journeyComplement,
+        contribution: pillarAdditive,
+      },
+      {
+        kind: 'multiplier',
+        name: 'compass_boost',
+        weight_key: POLICY_KEYS.RANKER_PILLAR_COMPASS_BOOST,
+        weight_value: cfg.compass_boost,
+        applied: r.compass_boost > 1,
+        contribution_multiplier: r.compass_boost,
+      },
+      {
+        kind: 'multiplier',
+        name: 'economic_boost',
+        weight_key: 'ranker.pillar_weighter.economic_boost',
+        weight_value: cfg.economic_boost,
+        applied: r.economic_boost > 1,
+        contribution_multiplier: r.economic_boost,
+      },
+      {
+        kind: 'multiplier',
+        name: 'feedback_mult',
+        weight_key: 'ranker.pillar_weighter.feedback_composite',
+        weight_value: feedback_mult,
+        applied: feedback_mult !== 1,
+        contribution_multiplier: feedback_mult,
+      },
+    ];
+    const provenance: RankProvenance = {
+      strategy_id: PILLAR_WEIGHTER_STRATEGY_ID,
+      strategy_version: PILLAR_WEIGHTER_STRATEGY_VERSION,
+      computed_at: new Date().toISOString(),
+      tenant_id: tenantId,
+      components,
+      final_score: r.rank_score,
+    };
+    return { score: r.rank_score, provenance, ranked: r };
+  });
+}

--- a/services/gateway/src/services/recommendation-engine/ranking/index-pillar-weighter.ts
+++ b/services/gateway/src/services/recommendation-engine/ranking/index-pillar-weighter.ts
@@ -102,6 +102,20 @@ export interface RankerConfig {
   rejection_dampener_alpha: number; // 0.5 — impact × (1 - alpha × dismiss_rate)
   streak_reinforcement: number;    // 1.3 — when streak ≥ 3 days
   community_momentum_boost: number; // 1.2 — when ≥ 3 community completions/7d
+  // VTID-03132 (Phase C.3): the 11 thresholds that previously lived as
+  // inline literals in scoreRec/rankBatch/computeJourneyMode. Externalized
+  // so PillarWeighterStrategy can override them via PolicyResolver.
+  balance_unbalanced_at: number;       // 0.7 — rankBatch quota flip threshold
+  balance_amplify_at: number;          // 0.9 — scoreRec weakest-pillar amplify threshold
+  balance_amplify_factor: number;      // 1.2 — scoreRec weakest-pillar weight when amplified
+  journey_mode_day_break_1: number;    // 7   — computeJourneyMode onramp ceiling
+  journey_mode_day_break_2: number;    // 30  — computeJourneyMode mid-mode ceiling
+  journey_mode_day_break_3: number;    // 90  — computeJourneyMode terminal-mode start
+  journey_mode_decay_1to2: number;     // 0.5 — mode decay from 1.0 → 0.5 between breaks 1 and 2
+  journey_mode_decay_2to3: number;     // 0.3 — mode decay from 0.5 → 0.2 between breaks 2 and 3
+  journey_mode_terminal: number;       // 0.2 — mode after break 3 (Index-led)
+  compass_decay_subtract: number;      // 0.1 — active_goal_category bonus subtraction
+  pillar_score_cap: number;            // 200 — Vitana Index per-pillar cap (gap normalizer)
 }
 
 export const DEFAULT_RANKER_CONFIG: RankerConfig = {
@@ -116,6 +130,18 @@ export const DEFAULT_RANKER_CONFIG: RankerConfig = {
   rejection_dampener_alpha: 0.5,
   streak_reinforcement: 1.3,
   community_momentum_boost: 1.2,
+  // VTID-03132 (Phase C.3) — byte-identical to previous inline literals.
+  balance_unbalanced_at: 0.7,
+  balance_amplify_at: 0.9,
+  balance_amplify_factor: 1.2,
+  journey_mode_day_break_1: 7,
+  journey_mode_day_break_2: 30,
+  journey_mode_day_break_3: 90,
+  journey_mode_decay_1to2: 0.5,
+  journey_mode_decay_2to3: 0.3,
+  journey_mode_terminal: 0.2,
+  compass_decay_subtract: 0.1,
+  pillar_score_cap: 200,
 };
 
 /**
@@ -269,21 +295,40 @@ export async function buildRankerContext(
  * Index-led ongoing practice. Data-coverage gate pins at 1.0 until the user
  * has taken the baseline AND completed at least one action in 14 days.
  */
-export function computeJourneyMode(ctx: RankerContext): number {
+export function computeJourneyMode(
+  ctx: RankerContext,
+  cfg: RankerConfig = DEFAULT_RANKER_CONFIG,
+): number {
   // Data-coverage gate: no baseline OR no recent completions → onramp.
   if (!ctx.has_baseline || !ctx.has_recent_completions) return 1.0;
 
   const d = ctx.days_since_start;
   if (d === null) return 1.0;
 
-  let mode: number;
-  if (d <= 7)          mode = 1.0;
-  else if (d <= 30)    mode = 1.0 - ((d - 7) / 23) * 0.5;     // 1.0 → 0.5
-  else if (d <= 90)    mode = 0.5 - ((d - 30) / 60) * 0.3;    // 0.5 → 0.2
-  else                 mode = 0.2;
+  // VTID-03132 (Phase C.3): break-points + decay factors now sourced
+  // from cfg so PolicyResolver-backed callers can tune the curve
+  // without a redeploy. Pre-C.3 inline literals: 7, 30, 90, 0.5, 0.3, 0.2.
+  const break1 = cfg.journey_mode_day_break_1;
+  const break2 = cfg.journey_mode_day_break_2;
+  const break3 = cfg.journey_mode_day_break_3;
 
-  // Compass override: goal-directed users ramp faster (−0.1, clamped).
-  if (ctx.active_goal_category) mode = Math.max(0.1, mode - 0.1);
+  let mode: number;
+  if (d <= break1) {
+    mode = 1.0;
+  } else if (d <= break2) {
+    mode = 1.0 - ((d - break1) / (break2 - break1)) * cfg.journey_mode_decay_1to2;
+  } else if (d <= break3) {
+    mode = (1.0 - cfg.journey_mode_decay_1to2)
+         - ((d - break2) / (break3 - break2)) * cfg.journey_mode_decay_2to3;
+  } else {
+    mode = cfg.journey_mode_terminal;
+  }
+
+  // Compass override: goal-directed users ramp faster (subtraction
+  // clamped to 0.1 floor — preserves the pre-C.3 max(0.1, …) clamp).
+  if (ctx.active_goal_category) {
+    mode = Math.max(0.1, mode - cfg.compass_decay_subtract);
+  }
   return mode;
 }
 
@@ -304,11 +349,19 @@ export function scoreRec<T extends RankInputRec>(
     let maxSum = 0;
     for (const p of PILLAR_KEYS) {
       const cv = Number((rec.contribution_vector as any)[p] ?? 0);
-      const gap = Math.max(0, Math.min(1, (200 - ctx.pillars[p]) / 200));
+      // VTID-03132 (Phase C.3): pillar score cap (default 200, Vitana
+      // Index per-pillar) now sourced from cfg.
+      const cap = cfg.pillar_score_cap;
+      const gap = Math.max(0, Math.min(1, (cap - ctx.pillars[p]) / cap));
       let weight = 1.0;
-      // G6 balance guard: when unbalanced, amplify contribution to the weakest pillar.
-      if (ctx.balance_factor !== null && ctx.balance_factor <= 0.9 && p === ctx.weakest_pillar) {
-        weight = 1.2;
+      // G6 balance guard: when unbalanced, amplify contribution to the
+      // weakest pillar. Threshold + factor now sourced from cfg.
+      if (
+        ctx.balance_factor !== null &&
+        ctx.balance_factor <= cfg.balance_amplify_at &&
+        p === ctx.weakest_pillar
+      ) {
+        weight = cfg.balance_amplify_factor;
       }
       boostSum += cv * gap * weight;
       maxSum += cv;
@@ -339,7 +392,9 @@ export function scoreRec<T extends RankInputRec>(
   }
 
   // Journey mode — decays over 90 days, gated on data coverage.
-  const journey_mode = computeJourneyMode(ctx);
+  // VTID-03132 (Phase C.3): cfg threaded through so the decay curve is
+  // tunable via PolicyResolver.
+  const journey_mode = computeJourneyMode(ctx, cfg);
 
   // G7 — feedback-loop multipliers.
   // 1. Completion dampener: if the primary pillar of this rec has a recent
@@ -430,7 +485,11 @@ export function rankBatch<T extends RankInputRec>(
 
   const pillarQuota = Math.max(1, Math.floor(total * cfg.pillar_quota_max));
   const weakestQuota = Math.max(1, Math.floor(total * cfg.weakest_quota_max));
-  const unbalanced = ctx.balance_factor !== null && ctx.balance_factor <= 0.7 && ctx.weakest_pillar !== null;
+  // VTID-03132 (Phase C.3): balance threshold now sourced from cfg.
+  const unbalanced =
+    ctx.balance_factor !== null &&
+    ctx.balance_factor <= cfg.balance_unbalanced_at &&
+    ctx.weakest_pillar !== null;
 
   const counts: Record<PillarKey, number> = { nutrition: 0, hydration: 0, exercise: 0, sleep: 0, mental: 0 };
   const kept: RankedRec<T>[] = [];

--- a/services/gateway/test/services/decision-contract/pillar-weighter-strategy.test.ts
+++ b/services/gateway/test/services/decision-contract/pillar-weighter-strategy.test.ts
@@ -1,0 +1,295 @@
+// VTID-03132 — Phase C.3 of the decision-contract refactor.
+//
+// Locks two contracts:
+//   1. Byte-identical parity: PillarWeighterStrategy + cold-cache resolver
+//      MUST produce the same rank_score as the pre-C.3 `scoreRec` /
+//      `rankBatch` path running on DEFAULT_RANKER_CONFIG.
+//   2. Provenance shape: every score is paired with a `RankProvenance`
+//      trail whose components reconstruct the scoring formula.
+
+import {
+  scoreRec,
+  rankBatch,
+  computeJourneyMode,
+  DEFAULT_RANKER_CONFIG,
+  type RankerConfig,
+  type RankerContext,
+  type RankInputRec,
+} from '../../../src/services/recommendation-engine/ranking/index-pillar-weighter';
+import {
+  buildPillarWeighterConfig,
+  scoreRecWithProvenance,
+  rankBatchWithProvenance,
+  PILLAR_WEIGHTER_STRATEGY_ID,
+  PILLAR_WEIGHTER_STRATEGY_VERSION,
+} from '../../../src/services/decision-contract';
+import {
+  configurePolicyResolverForTests,
+  __resetPolicyResolverForTests,
+  getPolicyResolver,
+} from '../../../src/services/decision-contract/policy-resolver';
+
+const NOW_ISO = new Date().toISOString();
+
+function makeCtx(overrides: Partial<RankerContext> = {}): RankerContext {
+  return {
+    pillars: {
+      nutrition: 120,
+      hydration: 80,
+      exercise: 140,
+      sleep: 100,
+      mental: 90,
+    },
+    balance_factor: 0.85,
+    weakest_pillar: 'hydration',
+    active_goal_category: null,
+    has_baseline: true,
+    has_recent_completions: true,
+    days_since_start: 14,
+    recent_activity: {},
+    rejection_rate_by_domain: {},
+    ...overrides,
+  };
+}
+
+function makeRec(overrides: Partial<RankInputRec> = {}): RankInputRec {
+  return {
+    id: 'rec-1',
+    impact_score: 7,
+    contribution_vector: { nutrition: 0, hydration: 1, exercise: 0, sleep: 0, mental: 0 },
+    source_ref: 'morning_walk',
+    domain: 'lifestyle',
+    ...overrides,
+  };
+}
+
+function seedAllRankerPolicies(cfgOverrides: Partial<RankerConfig> = {}) {
+  const cfg: RankerConfig = { ...DEFAULT_RANKER_CONFIG, ...cfgOverrides };
+  const rows = [
+    ['ranker.pillar_weighter.alpha_pillar', cfg.alpha_pillar],
+    ['ranker.pillar_weighter.alpha_wave', cfg.alpha_wave],
+    ['ranker.pillar_weighter.compass_boost', cfg.compass_boost],
+    ['ranker.pillar_weighter.pillar_quota_max', cfg.pillar_quota_max],
+    ['ranker.pillar_weighter.weakest_quota_max', cfg.weakest_quota_max],
+    ['ranker.pillar_weighter.completion_dampener', cfg.completion_dampener],
+    ['ranker.pillar_weighter.plan_dampener', cfg.plan_dampener],
+    ['ranker.pillar_weighter.rejection_dampener_alpha', cfg.rejection_dampener_alpha],
+    ['ranker.pillar_weighter.streak_reinforcement', cfg.streak_reinforcement],
+    ['ranker.pillar_weighter.community_momentum_boost', cfg.community_momentum_boost],
+    ['ranker.pillar_weighter.balance_unbalanced_at', cfg.balance_unbalanced_at],
+    ['ranker.pillar_weighter.balance_amplify_at', cfg.balance_amplify_at],
+    ['ranker.pillar_weighter.balance_amplify_factor', cfg.balance_amplify_factor],
+    ['ranker.pillar_weighter.journey_mode_day_break_1', cfg.journey_mode_day_break_1],
+    ['ranker.pillar_weighter.journey_mode_day_break_2', cfg.journey_mode_day_break_2],
+    ['ranker.pillar_weighter.journey_mode_day_break_3', cfg.journey_mode_day_break_3],
+    ['ranker.pillar_weighter.journey_mode_decay_1to2', cfg.journey_mode_decay_1to2],
+    ['ranker.pillar_weighter.journey_mode_decay_2to3', cfg.journey_mode_decay_2to3],
+    ['ranker.pillar_weighter.journey_mode_terminal', cfg.journey_mode_terminal],
+    ['ranker.pillar_weighter.compass_decay_subtract', cfg.compass_decay_subtract],
+    ['ranker.pillar_weighter.pillar_score_cap', cfg.pillar_score_cap],
+  ] as const;
+  configurePolicyResolverForTests({
+    decisionPolicy: rows.map(([policy_key, value]) => ({
+      policy_key,
+      tenant_id: null,
+      version: 1,
+      value_json: value as unknown,
+      effective_from: NOW_ISO,
+      effective_until: null,
+    })),
+  });
+}
+
+describe('VTID-03132 Phase C.3 PillarWeighterStrategy', () => {
+  afterEach(() => {
+    __resetPolicyResolverForTests();
+  });
+
+  describe('cold-cache fallback path — byte-identical to DEFAULT_RANKER_CONFIG', () => {
+    beforeEach(() => {
+      __resetPolicyResolverForTests();
+    });
+
+    it('buildPillarWeighterConfig returns DEFAULT_RANKER_CONFIG when no rows seeded', () => {
+      const cfg = buildPillarWeighterConfig();
+      // Every numeric field must match the default. Spot-check a couple
+      // critical ones; the parity tests below will exercise the rest.
+      expect(cfg.alpha_pillar).toBe(DEFAULT_RANKER_CONFIG.alpha_pillar);
+      expect(cfg.compass_boost).toBe(DEFAULT_RANKER_CONFIG.compass_boost);
+      expect(cfg.pillar_score_cap).toBe(DEFAULT_RANKER_CONFIG.pillar_score_cap);
+      expect(cfg.journey_mode_day_break_1).toBe(7);
+      expect(cfg.balance_amplify_factor).toBe(1.2);
+    });
+
+    it.each([
+      ['nutrition'],
+      ['hydration'],
+      ['exercise'],
+      ['sleep'],
+      ['mental'],
+    ] as const)(
+      'parity (%s pillar): cold-cache strategy score matches DEFAULT_RANKER_CONFIG scoreRec',
+      (pillar) => {
+        const rec = makeRec({
+          contribution_vector: {
+            nutrition: pillar === 'nutrition' ? 1 : 0,
+            hydration: pillar === 'hydration' ? 1 : 0,
+            exercise: pillar === 'exercise' ? 1 : 0,
+            sleep: pillar === 'sleep' ? 1 : 0,
+            mental: pillar === 'mental' ? 1 : 0,
+          },
+          id: `rec-${pillar}`,
+        });
+        const ctx = makeCtx({ weakest_pillar: pillar });
+        const reference = scoreRec(rec, ctx);
+        const out = scoreRecWithProvenance(rec, ctx);
+        expect(out.score).toBeCloseTo(reference.rank_score, 10);
+        expect(out.ranked.rank_score).toBeCloseTo(reference.rank_score, 10);
+        expect(out.provenance.final_score).toBeCloseTo(reference.rank_score, 10);
+      },
+    );
+
+    it('parity with active compass goal + streak signal + completion dampener', () => {
+      const rec = makeRec({
+        contribution_vector: { nutrition: 0, hydration: 1, exercise: 0, sleep: 0, mental: 0 },
+        source_ref: 'start_streak',
+      });
+      const ctx = makeCtx({
+        active_goal_category: 'health_baseline',
+        recent_activity: {
+          hydration: {
+            last_completed_at: '2026-05-21T00:00:00.000Z',
+            completions_24h: 0,
+            completions_7d: 4,
+            plan_events_24h: 0,
+          },
+        },
+      });
+      const reference = scoreRec(rec, ctx);
+      const out = scoreRecWithProvenance(rec, ctx);
+      expect(out.score).toBeCloseTo(reference.rank_score, 10);
+    });
+
+    it('parity with dismissal rate suppression', () => {
+      const rec = makeRec({ domain: 'lifestyle' });
+      const ctx = makeCtx({ rejection_rate_by_domain: { lifestyle: 0.6 } });
+      const reference = scoreRec(rec, ctx);
+      const out = scoreRecWithProvenance(rec, ctx);
+      expect(out.score).toBeCloseTo(reference.rank_score, 10);
+    });
+
+    it('parity for the rankBatch path with quota enforcement', () => {
+      const recs: RankInputRec[] = [
+        makeRec({ id: 'r1', impact_score: 9, contribution_vector: { nutrition: 1, hydration: 0, exercise: 0, sleep: 0, mental: 0 } }),
+        makeRec({ id: 'r2', impact_score: 8, contribution_vector: { nutrition: 0, hydration: 1, exercise: 0, sleep: 0, mental: 0 } }),
+        makeRec({ id: 'r3', impact_score: 8, contribution_vector: { nutrition: 0, hydration: 0, exercise: 1, sleep: 0, mental: 0 } }),
+        makeRec({ id: 'r4', impact_score: 7, contribution_vector: { nutrition: 0, hydration: 0, exercise: 0, sleep: 1, mental: 0 } }),
+        makeRec({ id: 'r5', impact_score: 6, contribution_vector: { nutrition: 0, hydration: 0, exercise: 0, sleep: 0, mental: 1 } }),
+      ];
+      const ctx = makeCtx();
+      const reference = rankBatch(recs, ctx);
+      const out = rankBatchWithProvenance(recs, ctx);
+      // Same ranking order
+      expect(out.map((o) => o.ranked.rec.id)).toEqual(reference.map((r) => r.rec.id));
+      // Same scores
+      out.forEach((o, i) => {
+        expect(o.score).toBeCloseTo(reference[i].rank_score, 10);
+        expect(o.provenance.final_score).toBeCloseTo(reference[i].rank_score, 10);
+      });
+    });
+  });
+
+  describe('resolver-seeded path — DB row wins over fallback', () => {
+    it('seeded alpha_pillar override changes the score', () => {
+      seedAllRankerPolicies({ alpha_pillar: 1.0 }); // double the default 0.5
+      const rec = makeRec({
+        contribution_vector: { nutrition: 0, hydration: 1, exercise: 0, sleep: 0, mental: 0 },
+      });
+      const ctx = makeCtx();
+      const reference = scoreRec(rec, ctx); // uses DEFAULT_RANKER_CONFIG
+      const out = scoreRecWithProvenance(rec, ctx);
+      // alpha_pillar doubled → the strategy's score should be > reference
+      // (so long as the rec actually has any pillar_boost).
+      expect(out.ranked.pillar_boost).toBeGreaterThan(0);
+      expect(out.score).toBeGreaterThan(reference.rank_score);
+    });
+
+    it('seeded journey_mode_terminal changes computeJourneyMode tail', () => {
+      seedAllRankerPolicies({ journey_mode_terminal: 0.4 });
+      const cfg = buildPillarWeighterConfig();
+      // computeJourneyMode at day 200 should return the seeded value
+      // (no compass override).
+      const ctx = makeCtx({
+        days_since_start: 200,
+        active_goal_category: null,
+      });
+      const m = computeJourneyMode(ctx, cfg);
+      expect(m).toBe(0.4);
+    });
+  });
+
+  describe('provenance shape', () => {
+    beforeEach(() => {
+      __resetPolicyResolverForTests();
+    });
+
+    it('emits strategy_id and version', () => {
+      const out = scoreRecWithProvenance(makeRec(), makeCtx());
+      expect(out.provenance.strategy_id).toBe(PILLAR_WEIGHTER_STRATEGY_ID);
+      expect(out.provenance.strategy_version).toBe(PILLAR_WEIGHTER_STRATEGY_VERSION);
+      expect(out.provenance.strategy_id).toBe('pillar_weighter_v1');
+    });
+
+    it('emits the 5 canonical components: base + 1 additive + 3 multipliers', () => {
+      const out = scoreRecWithProvenance(makeRec(), makeCtx());
+      const kinds = out.provenance.components.map((c) => c.kind);
+      expect(kinds).toEqual(['base', 'additive', 'multiplier', 'multiplier', 'multiplier']);
+      const names = out.provenance.components.map((c) =>
+        c.kind === 'base' ? 'base' : (c as { name: string }).name,
+      );
+      expect(names).toEqual([
+        'base',
+        'pillar_boost',
+        'compass_boost',
+        'economic_boost',
+        'feedback_mult',
+      ]);
+    });
+
+    it('component weight_keys cite POLICY_KEYS strings for grep-back', () => {
+      const out = scoreRecWithProvenance(makeRec(), makeCtx());
+      const c = out.provenance.components;
+      // pillar_boost cites alpha_pillar
+      expect(c[1].kind).toBe('additive');
+      if (c[1].kind === 'additive') {
+        expect(c[1].weight_key).toBe('ranker.pillar_weighter.alpha_pillar');
+      }
+      // compass_boost cites compass_boost key
+      expect(c[2].kind).toBe('multiplier');
+      if (c[2].kind === 'multiplier') {
+        expect(c[2].weight_key).toBe('ranker.pillar_weighter.compass_boost');
+      }
+    });
+
+    it('final_score on provenance matches the score field exactly', () => {
+      const out = scoreRecWithProvenance(makeRec(), makeCtx());
+      expect(out.provenance.final_score).toBe(out.score);
+    });
+
+    it('computed_at is a parseable ISO-8601 timestamp', () => {
+      const out = scoreRecWithProvenance(makeRec(), makeCtx());
+      expect(Number.isFinite(Date.parse(out.provenance.computed_at))).toBe(true);
+    });
+  });
+
+  describe('singleton resolver wiring', () => {
+    it('buildPillarWeighterConfig defaults to getPolicyResolver()', () => {
+      // No resolver passed → must not throw.
+      __resetPolicyResolverForTests();
+      const cfg = buildPillarWeighterConfig();
+      expect(cfg).toBeDefined();
+      expect(cfg.alpha_pillar).toBeGreaterThan(0);
+      expect(getPolicyResolver).toBeDefined();
+    });
+  });
+});


### PR DESCRIPTION
## Summary
**Phase C.3 — vertical proof.** Implements `PillarWeighterStrategy` reading all 21 ranker policy keys via `PolicyResolver`, threads them through the existing `scoreRec` / `rankBatch` via an extended `RankerConfig`, and emits a `RankProvenance` trail per scored rec.

**Behaviour is byte-identical** to the pre-C.3 path when the resolver cache is cold or the policy table is empty — the Phase C.2 seed values match `DEFAULT_RANKER_CONFIG` so the cache-cold path scores the same numbers.

## Changes
- **`index-pillar-weighter.ts`** — `RankerConfig` + `DEFAULT_RANKER_CONFIG` extended with 11 new fields (balance thresholds, journey-mode breakpoints/decays, compass decay, pillar score cap). `computeJourneyMode`, `scoreRec`, `rankBatch` all read from cfg instead of inline literals.
- **`strategies/pillar-weighter.ts`** (new) — `buildPillarWeighterConfig(resolver, tenantId)`, `scoreRecWithProvenance(...)`, `rankBatchWithProvenance(...)`. Strategy id `pillar_weighter_v1` v1. Emits 5 canonical components: base + pillar_boost (additive) + compass_boost / economic_boost / feedback_mult (multipliers).
- **Barrel re-exports** through `services/decision-contract`.
- **17 new VTID-03132 tests**: 9 parity tests vs `DEFAULT_RANKER_CONFIG`-driven scoreRec/rankBatch (5 pillars + 3 narrative scenarios + batch), 2 resolver-seeded override tests, 5 provenance-shape tests, 1 singleton wiring.

## Test plan
- [x] 17 new tests green.
- [x] Full suite: **892/892 across 55/55 suites** (decision-contract + recommendation-engine + orb).
- [x] `npm run build` clean.
- [ ] CI green.
- [ ] No new migration in C.3 (the keys were seeded in C.2). Just EXEC-DEPLOY.
- [ ] Post-deploy `/alive` 200 JSON.

## Scope
- **In scope:** the strategy + provenance + cfg refactor + parity tests. **No call sites changed yet** — existing `rankBatch` consumers continue to use `DEFAULT_RANKER_CONFIG` and produce the same scores. Phase C.4 wires the strategy into the recommendation pipeline + persists `provenance` to the DB column added in C.1.
- **Deferred:**
  - Per-feedback-path provenance expansion (which dampener fired specifically) → C.3.b
  - `economic_boost` seed key (literal still in DEFAULT_RANKER_CONFIG) → later slice
  - Other ranker files (feed-ranker, recommendation-generator, marketplace-analyzer) → C.5+

🤖 Generated with [Claude Code](https://claude.com/claude-code)