### PR TITLE
feat(decision-contract): Phase C.4 — wire PillarWeighterStrategy into recommendation-generator + persist provenance (VTID-03133)

### DIFF
--- a/services/gateway/src/services/recommendation-engine/recommendation-generator.ts
+++ b/services/gateway/src/services/recommendation-engine/recommendation-generator.ts
@@ -44,6 +44,16 @@ import {
 import { analyzeLifeCompass } from './analyzers/life-compass-analyzer';
 import { analyzeIndexGaps } from './analyzers/index-gap-analyzer';
 import { buildRankerContext, rankBatch } from './ranking/index-pillar-weighter';
+// VTID-03133 (Phase C.4): replace direct `rankBatch` with the
+// PolicyResolver-backed strategy so each recommendation gets a
+// RankProvenance trail persisted to autopilot_recommendations.provenance.
+// The legacy `rankBatch` import stays for the fallback path inside the
+// try/catch below — if the strategy bombs, we silently fall back to the
+// pre-C.4 scoring path so production keeps working.
+import {
+  rankBatchWithProvenance,
+  type RankProvenance,
+} from '../decision-contract';
 import { deriveEconomicAxis } from './economic-axis';
 import {
   analyzeMarketplace,
@@ -844,6 +854,11 @@ export async function generatePersonalRecommendations(
     // G4: re-rank by pillar-gap + compass + journey_mode BEFORE fingerprint
     // dedup so the highest-rank_score candidates survive when they collide.
     // rankBatch also applies the G6 per-pillar quota + balance guard.
+    // VTID-03133 (Phase C.4): use `rankBatchWithProvenance` so each
+    // ranked rec carries a `RankProvenance` trail. We key the trail by
+    // the rec's index-id and persist it after the corresponding row is
+    // inserted in autopilot_recommendations.
+    const provenanceByIndex = new Map<string, RankProvenance>();
     try {
       const rankerInputs = recommendations.map((r, idx) => ({
         id: String(idx),
@@ -852,13 +867,46 @@ export async function generatePersonalRecommendations(
         contribution_vector: (r as any).contribution_vector ?? null,
         economic_axis: deriveEconomicAxis(r.source_type, r.source_ref),
       }));
-      const ranked = rankBatch(rankerInputs, rankerCtx);
+      let rankedOrder: Array<{ rec: { id?: string } }>;
+      try {
+        const rankedWithProv = rankBatchWithProvenance(rankerInputs, rankerCtx);
+        for (const r of rankedWithProv) {
+          const idxId = (r.ranked.rec as { id?: string }).id;
+          if (idxId) provenanceByIndex.set(idxId, r.provenance);
+        }
+        rankedOrder = rankedWithProv.map((r) => ({ rec: r.ranked.rec }));
+      } catch (stratErr: any) {
+        // Strategy bombed → fall back to the pre-C.4 scoring path so
+        // production isn't blocked by a Phase C wiring bug. Provenance
+        // is auxiliary; rank order is critical.
+        console.warn(
+          `${LOG_PREFIX} rankBatchWithProvenance failed — falling back to legacy rankBatch (non-fatal): ${stratErr?.message}`,
+        );
+        rankedOrder = rankBatch(rankerInputs, rankerCtx).map((r) => ({ rec: r.rec }));
+      }
       // Apply rank order back onto recommendations[].
       const indexById = new Map<string, GeneratedRecommendation>(
         recommendations.map((r, idx) => [String(idx), r]),
       );
-      recommendations = ranked
-        .map(r => indexById.get((r.rec as any).id as string))
+      // VTID-03133: stash the new ranker index back onto each rec so we
+      // can recover its provenance in the insert loop below. Map's key
+      // is `rec` reference for stability across the re-ordering.
+      const recToProvenance = new Map<GeneratedRecommendation, RankProvenance>();
+      for (const r of rankedOrder) {
+        const idxId = (r.rec as { id?: string }).id;
+        if (!idxId) continue;
+        const matched = indexById.get(idxId);
+        const prov = provenanceByIndex.get(idxId);
+        if (matched && prov) recToProvenance.set(matched, prov);
+      }
+      // Stamp provenance onto the rec object (untyped — picked up below
+      // in the insert loop). Done before `recommendations` is rewritten
+      // by the .filter so references survive.
+      for (const [rec, prov] of recToProvenance) {
+        (rec as unknown as { __rank_provenance?: RankProvenance }).__rank_provenance = prov;
+      }
+      recommendations = rankedOrder
+        .map(r => indexById.get((r.rec as { id?: string }).id as string))
         .filter((r): r is GeneratedRecommendation => !!r);
     } catch (rankErr: any) {
       console.warn(`${LOG_PREFIX} rankBatch failed (non-fatal):`, rankErr?.message);
@@ -895,7 +943,7 @@ export async function generatePersonalRecommendations(
         continue;
       }
 
-      const insertResult = await callRpc<{ duplicate?: boolean }>('insert_autopilot_recommendation', {
+      const insertResult = await callRpc<{ duplicate?: boolean; id?: string }>('insert_autopilot_recommendation', {
         p_title: rec.title,
         p_summary: rec.summary,
         p_domain: rec.domain,
@@ -920,6 +968,45 @@ export async function generatePersonalRecommendations(
           duplicatesSkipped++;
         } else {
           generated++;
+          // VTID-03133 (Phase C.4): persist the RankProvenance trail to
+          // the autopilot_recommendations row created by the RPC above.
+          // Best-effort: UPDATE failure NEVER blocks generation (the row
+          // already exists; provenance is auxiliary). Without an
+          // id-returning RPC, we'd have to update by fingerprint —
+          // luckily the RPC's JSONB return includes `id` when not a
+          // duplicate.
+          const insertedId = insertResult.data?.id;
+          const prov = (rec as unknown as { __rank_provenance?: RankProvenance }).__rank_provenance;
+          if (insertedId && prov) {
+            try {
+              const supabaseUrl = process.env.SUPABASE_URL;
+              const supabaseKey = process.env.SUPABASE_SERVICE_ROLE;
+              if (supabaseUrl && supabaseKey) {
+                const upd = await fetch(
+                  `${supabaseUrl}/rest/v1/autopilot_recommendations?id=eq.${insertedId}`,
+                  {
+                    method: 'PATCH',
+                    headers: {
+                      'Content-Type': 'application/json',
+                      apikey: supabaseKey,
+                      Authorization: `Bearer ${supabaseKey}`,
+                      Prefer: 'return=minimal',
+                    },
+                    body: JSON.stringify({ provenance: prov }),
+                  },
+                );
+                if (!upd.ok) {
+                  console.warn(
+                    `${LOG_PREFIX} provenance UPDATE failed (non-fatal): ${upd.status} for id=${insertedId.slice(0, 8)}`,
+                  );
+                }
+              }
+            } catch (provErr: any) {
+              console.warn(
+                `${LOG_PREFIX} provenance UPDATE threw (non-fatal): ${provErr?.message}`,
+              );
+            }
+          }
         }
       } else {
         errors.push({ source: 'community', error: insertResult.error || 'Insert failed' });

--- a/services/gateway/test/services/recommendation-engine/recommendation-generator-provenance-wireup.test.ts
+++ b/services/gateway/test/services/recommendation-engine/recommendation-generator-provenance-wireup.test.ts
@@ -1,0 +1,84 @@
+// VTID-03133 — Phase C.4 of the decision-contract refactor.
+//
+// Source-level wire-up assertions confirming `recommendation-generator.ts`
+// calls `rankBatchWithProvenance` and persists the resulting trail to
+// `autopilot_recommendations.provenance` via a follow-up PATCH.
+//
+// We assert at the source level (matching the Phase E / VTID-03036
+// pattern) because the integration scaffolding for the full
+// recommendation pipeline is heavy and the wire-up is the load-bearing
+// contract — the behaviour (the call to the strategy, the PATCH on the
+// row id) is exactly what production must do.
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const SOURCE_PATH = path.resolve(
+  __dirname,
+  '../../../src/services/recommendation-engine/recommendation-generator.ts',
+);
+
+let source: string;
+
+beforeAll(() => {
+  source = fs.readFileSync(SOURCE_PATH, 'utf8');
+});
+
+describe('VTID-03133 Phase C.4 — rankBatchWithProvenance + provenance persistence', () => {
+  it('imports rankBatchWithProvenance + RankProvenance from the decision-contract barrel', () => {
+    expect(source).toMatch(/import\s*{[\s\S]*?\brankBatchWithProvenance\b[\s\S]*?\bRankProvenance\b[\s\S]*?}\s*from\s*['"]\.\.\/decision-contract['"]/);
+  });
+
+  it('keeps the legacy `rankBatch` import for the fallback path', () => {
+    // Critical: if `rankBatchWithProvenance` throws (e.g. resolver bug),
+    // we MUST fall back to the pre-C.4 scoring path so production isn''t
+    // blocked. The legacy import must survive.
+    expect(source).toMatch(/import\s*{[^}]*\bbuildRankerContext\b[^}]*\brankBatch\b[^}]*}\s*from\s*['"]\.\/ranking\/index-pillar-weighter['"]/);
+  });
+
+  it('invokes rankBatchWithProvenance inside the rank block', () => {
+    expect(source).toMatch(/const\s+rankedWithProv\s*=\s*rankBatchWithProvenance\(\s*rankerInputs\s*,\s*rankerCtx\s*\)/);
+  });
+
+  it('keys the provenance trail by the rec index id', () => {
+    expect(source).toMatch(/provenanceByIndex\.set\(\s*idxId\s*,\s*r\.provenance\s*\)/);
+  });
+
+  it('falls back to legacy rankBatch on strategy exception (non-fatal)', () => {
+    expect(source).toMatch(/rankBatchWithProvenance failed[\s\S]{0,200}falling back to legacy rankBatch/);
+    // The fallback path must actually call rankBatch, not just log:
+    expect(source).toMatch(/rankBatch\(rankerInputs,\s*rankerCtx\)\.map/);
+  });
+
+  it('captures the inserted row id from the insert RPC return', () => {
+    // The RPC's JSONB return shape is `{ ok, duplicate, id }`. We extend
+    // the TS type so `insertResult.data?.id` is type-safe.
+    expect(source).toMatch(/callRpc<\{\s*duplicate\?\s*:\s*boolean;\s*id\?\s*:\s*string\s*\}>/);
+    expect(source).toMatch(/const\s+insertedId\s*=\s*insertResult\.data\?\.id/);
+  });
+
+  it('PATCHes autopilot_recommendations to set provenance on the inserted row', () => {
+    // Direct REST UPDATE keyed on the row id. PATCH (not the RPC) so
+    // the existing function signature stays untouched.
+    expect(source).toMatch(/autopilot_recommendations\?id=eq\.\$\{insertedId\}/);
+    expect(source).toMatch(/method:\s*['"]PATCH['"]/);
+    expect(source).toMatch(/JSON\.stringify\(\{\s*provenance:\s*prov\s*\}\)/);
+  });
+
+  it('provenance PATCH failure is non-fatal (never throws upstream)', () => {
+    // The PATCH lives inside its own try/catch so a network blip cannot
+    // surface as a generation error. The row already exists; provenance
+    // is auxiliary.
+    expect(source).toMatch(/provenance UPDATE failed[\s\S]{0,200}non-fatal/);
+    expect(source).toMatch(/provenance UPDATE threw[\s\S]{0,200}non-fatal/);
+  });
+
+  it('only persists provenance on non-duplicate inserts (no UPDATE on dup rows)', () => {
+    // The provenance write is inside the `else` branch of
+    // `if (insertResult.data?.duplicate)` so duplicate skips never fire
+    // an UPDATE on a row that may belong to a different run.
+    expect(source).toMatch(
+      /if\s*\(\s*insertResult\.data\?\.duplicate\s*\)\s*\{[\s\S]{0,200}duplicatesSkipped\+\+;[\s\S]*?\}\s*else\s*\{[\s\S]*?provenance/,
+    );
+  });
+});


### PR DESCRIPTION
## Summary
**Phase C.4 — final slice of Phase C.** Wires the C.3 `PillarWeighterStrategy` into the autopilot recommendation pipeline and persists each rec's `RankProvenance` to `autopilot_recommendations.provenance`.

After this PR, every recommendation produced by `recommendation-generator.ts` carries a structured trail naming which signals contributed, which `decision_policy` rows fed in their weights, and how each component contributed to the final score. Auditable rank decisions.

## Changes
- **`recommendation-generator.ts`** — `rankBatch(...)` → `rankBatchWithProvenance(...)`. Strategy exception falls back to legacy `rankBatch` (rank order critical; provenance auxiliary). Each non-duplicate insert is followed by a best-effort PATCH on `autopilot_recommendations?id=eq.<id>` writing `{ provenance }`.
- **9 new VTID-03133 wire-up tests**.

## Defensive contract
- Strategy bombs → legacy rankBatch keeps the rank order intact.
- PATCH bombs → row stays with `provenance: NULL`; generation continues.
- Duplicate skips → no PATCH fires (would risk touching a row owned by a different run).

## Test plan
- [x] 9 new VTID-03133 tests + full suite 901/901 across 56/56 (decision-contract + recommendation-engine + orb).
- [x] `npm run build` clean.
- [ ] CI green.
- [ ] No new migration — the column already exists (C.1) and the keys are seeded (C.2).
- [ ] Post-deploy: next autopilot generation cycle produces rows with non-null `provenance`. Smoke: `SELECT id, provenance->>'strategy_id' FROM autopilot_recommendations WHERE created_at > now() - interval '1 hour' AND provenance IS NOT NULL LIMIT 5;` (visual inspection after a generation run).

## Phase C complete
- C.1 (VTID-03130 PR #2294): schema + types
- C.2 (VTID-03131 PR #2296): 21 ranker policy seeds
- C.3 (VTID-03132 PR #2298): strategy + cfg-threaded ranker + 17 parity tests
- C.4 (this PR): wire + persist

🤖 Generated with [Claude Code](https://claude.com/claude-code)