### PR TITLE
feat(decision-contract): D.3.b-e — voice mapping tables via PolicyResolver (VTID-03134)

### DIFF
--- a/services/gateway/src/orb/live/voice/voice-mapping.ts
+++ b/services/gateway/src/orb/live/voice/voice-mapping.ts
@@ -1,0 +1,108 @@
+// Phase D.3.b-e (decision-contract refactor) — VTID-03134.
+//
+// Voice mapping table resolvers. Externalizes the remaining 4 Records
+// that previously lived inline in `routes/orb-live.ts`:
+//   - LIVE_LANGUAGE_VOICES       → getLiveLanguageVoice(lang)
+//   - GEMINI_TTS_VOICES          → getGeminiTtsVoice(lang)
+//   - NEURAL2_TTS_VOICES         → getNeural2TtsVoice(lang)
+//   - NEURAL2_ENABLED_LANGUAGES  → getNeural2EnabledLanguages() + isNeural2EnabledFor(lang)
+//
+// Behaviour preserved byte-for-byte at cache-cold. The literal Records
+// below are the safety nets that match the Phase D.3.b-e seed values
+// in the corresponding `decision_policy` rows.
+
+import { getPolicyResolver } from '../../../services/decision-contract/policy-resolver';
+import { POLICY_KEYS } from '../../../services/decision-contract/policy-keys';
+
+export interface TtsVoiceConfig {
+  name: string;
+  languageCode: string;
+}
+
+// =============================================================================
+// Cache-cold safety-net Records
+// =============================================================================
+
+const LIVE_LANGUAGE_VOICE_FALLBACKS: Record<string, string> = {
+  en: 'Callirrhoe',
+  de: 'Achernar',
+  fr: 'Leda',
+  es: 'Aoede',
+  ar: 'Sulafat',
+  zh: 'Laomedeia',
+  sr: 'Vindemiatrix',
+  ru: 'Gacrux',
+};
+
+const GEMINI_TTS_VOICE_FALLBACKS: Record<string, TtsVoiceConfig> = {
+  en: { name: 'Kore', languageCode: 'en-US' },
+  de: { name: 'Kore', languageCode: 'de-DE' },
+  fr: { name: 'Kore', languageCode: 'fr-FR' },
+  es: { name: 'Kore', languageCode: 'es-ES' },
+  ar: { name: 'Kore', languageCode: 'ar-XA' },
+  zh: { name: 'Kore', languageCode: 'cmn-CN' },
+  sr: { name: 'Kore', languageCode: 'sr-RS' },
+  ru: { name: 'Kore', languageCode: 'ru-RU' },
+};
+
+const NEURAL2_TTS_VOICE_FALLBACKS: Record<string, TtsVoiceConfig> = {
+  de: { name: 'de-DE-Neural2-G', languageCode: 'de-DE' },
+  en: { name: 'en-US-Neural2-H', languageCode: 'en-US' },
+  fr: { name: 'fr-FR-Neural2-A', languageCode: 'fr-FR' },
+  es: { name: 'es-ES-Neural2-A', languageCode: 'es-ES' },
+  ar: { name: 'ar-XA-Wavenet-D', languageCode: 'ar-XA' },
+  zh: { name: 'cmn-CN-Wavenet-A', languageCode: 'cmn-CN' },
+  ru: { name: 'ru-RU-Wavenet-A', languageCode: 'ru-RU' },
+  sr: { name: 'sr-RS-Standard-A', languageCode: 'sr-RS' },
+};
+
+const NEURAL2_ENABLED_LANGUAGES_FALLBACK: ReadonlyArray<string> = [
+  'en', 'de', 'fr', 'es', 'ar', 'zh', 'ru', 'sr',
+];
+
+// =============================================================================
+// Accessors
+// =============================================================================
+
+export function getLiveLanguageVoice(lang: string): string {
+  const safeLang = typeof lang === 'string' && lang.length > 0 ? lang : 'en';
+  const fallback = LIVE_LANGUAGE_VOICE_FALLBACKS[safeLang] ?? LIVE_LANGUAGE_VOICE_FALLBACKS['en'];
+  return getPolicyResolver().getValue<string>(
+    `voice.live_language.${safeLang}`,
+    { defaultValue: fallback },
+  );
+}
+
+export function getGeminiTtsVoice(lang: string): TtsVoiceConfig {
+  const safeLang = typeof lang === 'string' && lang.length > 0 ? lang : 'en';
+  const fallback =
+    GEMINI_TTS_VOICE_FALLBACKS[safeLang] ?? GEMINI_TTS_VOICE_FALLBACKS['en'];
+  return getPolicyResolver().getValue<TtsVoiceConfig>(
+    `voice.gemini_tts.${safeLang}`,
+    { defaultValue: fallback },
+  );
+}
+
+export function getNeural2TtsVoice(lang: string): TtsVoiceConfig {
+  const safeLang = typeof lang === 'string' && lang.length > 0 ? lang : 'en';
+  const fallback =
+    NEURAL2_TTS_VOICE_FALLBACKS[safeLang] ?? NEURAL2_TTS_VOICE_FALLBACKS['en'];
+  return getPolicyResolver().getValue<TtsVoiceConfig>(
+    `voice.neural2_tts.${safeLang}`,
+    { defaultValue: fallback },
+  );
+}
+
+export function getNeural2EnabledLanguages(): ReadonlyArray<string> {
+  const out = getPolicyResolver().getValue<ReadonlyArray<string>>(
+    POLICY_KEYS.VOICE_NEURAL2_ENABLED_LANGUAGES,
+    { defaultValue: NEURAL2_ENABLED_LANGUAGES_FALLBACK },
+  );
+  // Defensive guard: if a malformed DB row sneaks through, return the
+  // safety net rather than risk an `includes` call on a non-array.
+  return Array.isArray(out) ? out : NEURAL2_ENABLED_LANGUAGES_FALLBACK;
+}
+
+export function isNeural2EnabledFor(lang: string): boolean {
+  return getNeural2EnabledLanguages().includes(lang);
+}

--- a/services/gateway/src/routes/orb-live.ts
+++ b/services/gateway/src/routes/orb-live.ts
@@ -745,20 +745,12 @@ const orbTranscripts = new Map<string, OrbSessionTranscript>();
 // VTID-01155: Gemini Live Multimodal Session Types & Stores
 // =============================================================================
 
-/**
- * VTID-01155: Supported languages for Live sessions and TTS
- * Voice map uses female voices per spec
- */
-const LIVE_LANGUAGE_VOICES: Record<string, string> = {
-  'en': 'Callirrhoe',
-  'de': 'Achernar',
-  'fr': 'Leda',
-  'es': 'Aoede',
-  'ar': 'Sulafat',
-  'zh': 'Laomedeia',
-  'sr': 'Vindemiatrix',
-  'ru': 'Gacrux'
-};
+// VTID-03134 (Phase D.3.b-e): LIVE_LANGUAGE_VOICES Record moved out of
+// this file. See `services/gateway/src/orb/live/voice/voice-mapping.ts`
+// for the PolicyResolver-backed accessor (`getLiveLanguageVoice`).
+// Seeded rows live under `voice.live_language.<lang>` in
+// `decision_policy`; byte-identical literal kept in voice-mapping.ts
+// as the cache-cold safety net.
 
 // A2 (orb-live-refactor): SUPPORTED_LIVE_LANGUAGES lifted to orb/live/config.ts.
 import { SUPPORTED_LIVE_LANGUAGES } from '../orb/live/config';
@@ -1178,6 +1170,14 @@ import { createUpstreamLiveMessageHandler } from '../orb/live/session/upstream-m
 // VTID-03126 (Phase D.3): Live API voice resolver — externalizes the
 // LIVE_API_VOICES Record + adds telemetry on silent fallbacks.
 import { getLiveApiVoice } from '../orb/live/voice/live-api-voice';
+// VTID-03134 (Phase D.3.b-e): voice mapping table accessors.
+import {
+  getLiveLanguageVoice,
+  getGeminiTtsVoice,
+  getNeural2TtsVoice,
+  getNeural2EnabledLanguages,
+  isNeural2EnabledFor,
+} from '../orb/live/voice/voice-mapping';
 // A8.3b.1 (VTID-02971): connectToLiveAPI now uses the A7 UpstreamLiveClient
 // boundary via VertexLiveClient. The orb-specific persona/tools/context
 // envelope is supplied through the new `customSetupMessage` option so the
@@ -1247,39 +1247,12 @@ try {
 }
 
 // VTID-01155: Gemini TTS voice mapping for each language
-// Uses Google Cloud TTS with Gemini model
-const GEMINI_TTS_VOICES: Record<string, { name: string; languageCode: string }> = {
-  'en': { name: 'Kore', languageCode: 'en-US' },
-  'de': { name: 'Kore', languageCode: 'de-DE' },
-  'fr': { name: 'Kore', languageCode: 'fr-FR' },
-  'es': { name: 'Kore', languageCode: 'es-ES' },
-  'ar': { name: 'Kore', languageCode: 'ar-XA' },
-  'zh': { name: 'Kore', languageCode: 'cmn-CN' },
-  'sr': { name: 'Kore', languageCode: 'sr-RS' },
-  'ru': { name: 'Kore', languageCode: 'ru-RU' }
-};
-
-// VTID-01219: TTS voices for ALL languages
-// Neural2 voices provide lower latency and more natural speech synthesis
-// Gemini TTS "Kore" voice DOES NOT WORK due to @google-cloud/text-to-speech
-// library stripping modelName field during protobuf serialization.
-// Female voices selected per specification
-// Neural2 available: de, en, fr, es
-// WaveNet fallback: ar, zh, ru (Neural2 not available)
-// Standard fallback: sr (neither Neural2 nor WaveNet available)
-const NEURAL2_TTS_VOICES: Record<string, { name: string; languageCode: string }> = {
-  'de': { name: 'de-DE-Neural2-G', languageCode: 'de-DE' },  // Female German - Neural2
-  'en': { name: 'en-US-Neural2-H', languageCode: 'en-US' },  // Female English - Neural2
-  'fr': { name: 'fr-FR-Neural2-A', languageCode: 'fr-FR' },  // Female French - Neural2
-  'es': { name: 'es-ES-Neural2-A', languageCode: 'es-ES' },  // Female Spanish - Neural2
-  'ar': { name: 'ar-XA-Wavenet-D', languageCode: 'ar-XA' },  // Female Arabic - WaveNet (Neural2 N/A)
-  'zh': { name: 'cmn-CN-Wavenet-A', languageCode: 'cmn-CN' }, // Female Chinese - WaveNet (Neural2 N/A)
-  'ru': { name: 'ru-RU-Wavenet-A', languageCode: 'ru-RU' },  // Female Russian - WaveNet (Neural2 N/A)
-  'sr': { name: 'sr-RS-Standard-A', languageCode: 'sr-RS' }, // Female Serbian - Standard (Neural2/WaveNet N/A)
-};
-
-// ALL languages use best available voice (Neural2 > WaveNet > Standard)
-const NEURAL2_ENABLED_LANGUAGES = ['en', 'de', 'fr', 'es', 'ar', 'zh', 'ru', 'sr'];
+// VTID-03134 (Phase D.3.b-e): GEMINI_TTS_VOICES + NEURAL2_TTS_VOICES +
+// NEURAL2_ENABLED_LANGUAGES moved to
+// `services/gateway/src/orb/live/voice/voice-mapping.ts`. Per-lang rows
+// seeded under `voice.gemini_tts.<lang>`, `voice.neural2_tts.<lang>`,
+// `voice.neural2.enabled_languages`. Byte-identical fallbacks retained
+// in the accessor module for cache-cold safety.
 
 // =============================================================================
 // VTID-01219: Gemini Live API WebSocket Implementation
@@ -10127,7 +10100,7 @@ router.get('/debug/tts', async (req: Request, res: Response) => {
 
   const testText = (req.query.text as string) || 'Hello, this is a TTS test.';
   const lang = normalizeLang((req.query.lang as string) || 'en');
-  const voiceConfig = GEMINI_TTS_VOICES[lang] || GEMINI_TTS_VOICES['en'];
+  const voiceConfig = getGeminiTtsVoice(lang);
 
   const debugResult: Record<string, unknown> = {
     timestamp: new Date().toISOString(),
@@ -10514,7 +10487,7 @@ function normalizeLang(lang: string): string {
  */
 function getVoiceForLang(lang: string): string {
   const normalized = normalizeLang(lang);
-  return LIVE_LANGUAGE_VOICES[normalized] || LIVE_LANGUAGE_VOICES['en'];
+  return getLiveLanguageVoice(normalized);
 }
 
 /**
@@ -11058,10 +11031,11 @@ router.post('/tts', optionalAuth, async (req: AuthenticatedRequest, res: Respons
   const lang = normalizeLang(body.lang || 'en');
 
   // VTID-01219: Use Neural2 voices for German and English, Gemini for others
-  const useNeural2 = NEURAL2_ENABLED_LANGUAGES.includes(lang);
+  // VTID-03134 (Phase D.3.b-e): both branches now read through accessors.
+  const useNeural2 = isNeural2EnabledFor(lang);
   const voiceConfig = useNeural2
-    ? (NEURAL2_TTS_VOICES[lang] || GEMINI_TTS_VOICES['en'])
-    : (GEMINI_TTS_VOICES[lang] || GEMINI_TTS_VOICES['en']);
+    ? getNeural2TtsVoice(lang)
+    : getGeminiTtsVoice(lang);
   const voiceType = useNeural2 ? 'Neural2' : 'Gemini';
 
   // Emit request event
@@ -11273,10 +11247,10 @@ router.post('/live/chat-tts', optionalAuth, async (req: AuthenticatedRequest, re
     let audioB64 = '';
     let audioMime = '';
     if (ttsClient) {
-      const useNeural2 = NEURAL2_ENABLED_LANGUAGES.includes(lang);
+      const useNeural2 = isNeural2EnabledFor(lang);
       const voiceConfig = useNeural2
-        ? (NEURAL2_TTS_VOICES[lang] || NEURAL2_TTS_VOICES['en'])
-        : (GEMINI_TTS_VOICES[lang] || GEMINI_TTS_VOICES['en']);
+        ? (getNeural2TtsVoice(lang))
+        : (getGeminiTtsVoice(lang));
 
       const voiceParams: any = {
         languageCode: voiceConfig.languageCode,
@@ -11400,19 +11374,20 @@ router.get('/health', (_req: Request, res: Response) => {
       video_format: 'JPEG 768x768 @ 1 FPS'
     },
     // VTID-01219: Neural2 TTS voice configuration (ALL languages)
+    // VTID-03134 (Phase D.3.b-e): now reads via accessors.
     neural2_tts: {
       enabled: true,
       vtid: 'VTID-01219',
-      enabled_languages: NEURAL2_ENABLED_LANGUAGES,
+      enabled_languages: getNeural2EnabledLanguages(),
       voices: {
-        de: NEURAL2_TTS_VOICES['de']?.name,
-        en: NEURAL2_TTS_VOICES['en']?.name,
-        fr: NEURAL2_TTS_VOICES['fr']?.name,
-        es: NEURAL2_TTS_VOICES['es']?.name,
-        ar: NEURAL2_TTS_VOICES['ar']?.name,
-        zh: NEURAL2_TTS_VOICES['zh']?.name,
-        ru: NEURAL2_TTS_VOICES['ru']?.name,
-        sr: NEURAL2_TTS_VOICES['sr']?.name
+        de: getNeural2TtsVoice('de')?.name,
+        en: getNeural2TtsVoice('en')?.name,
+        fr: getNeural2TtsVoice('fr')?.name,
+        es: getNeural2TtsVoice('es')?.name,
+        ar: getNeural2TtsVoice('ar')?.name,
+        zh: getNeural2TtsVoice('zh')?.name,
+        ru: getNeural2TtsVoice('ru')?.name,
+        sr: getNeural2TtsVoice('sr')?.name
       },
       note: 'Gemini TTS disabled - modelName stripped by protobuf serialization'
     },

--- a/services/gateway/src/services/decision-contract/policy-keys.ts
+++ b/services/gateway/src/services/decision-contract/policy-keys.ts
@@ -87,6 +87,16 @@ export const POLICY_KEYS = {
   RANKER_PILLAR_JOURNEY_MODE_TERMINAL: 'ranker.pillar_weighter.journey_mode_terminal',
   RANKER_PILLAR_COMPASS_DECAY_SUBTRACT: 'ranker.pillar_weighter.compass_decay_subtract',
   RANKER_PILLAR_SCORE_CAP: 'ranker.pillar_weighter.pillar_score_cap',
+
+  // ---- Phase D.3.b-e (VTID-03134) — voice mapping tables -------
+  // The remaining 4 voice-mapping Records from orb-live.ts:
+  //   - LIVE_LANGUAGE_VOICES  → voice.live_language.<lang>   (string)
+  //   - GEMINI_TTS_VOICES     → voice.gemini_tts.<lang>      ({name, languageCode})
+  //   - NEURAL2_TTS_VOICES    → voice.neural2_tts.<lang>     ({name, languageCode})
+  //   - NEURAL2_ENABLED_LANGUAGES → voice.neural2.enabled_languages (string[])
+  // Per-lang keys are looked up via helper builders in voice-mapping.ts;
+  // only the array key needs a direct POLICY_KEYS entry.
+  VOICE_NEURAL2_ENABLED_LANGUAGES: 'voice.neural2.enabled_languages',
 } as const;
 
 export type PolicyKey = (typeof POLICY_KEYS)[keyof typeof POLICY_KEYS];

--- a/services/gateway/test/orb/live/voice/voice-mapping.test.ts
+++ b/services/gateway/test/orb/live/voice/voice-mapping.test.ts
@@ -1,0 +1,131 @@
+// VTID-03134 — Phase D.3.b-e of the decision-contract refactor.
+//
+// Locks the contract for the 4 voice-mapping accessors that replaced
+// the inline Records in orb-live.ts. Byte-identical fallback parity
+// + resolver-seeded overrides + protocol shape for the Neural2-enabled
+// array case.
+
+import {
+  getLiveLanguageVoice,
+  getGeminiTtsVoice,
+  getNeural2TtsVoice,
+  getNeural2EnabledLanguages,
+  isNeural2EnabledFor,
+} from '../../../../src/orb/live/voice/voice-mapping';
+import {
+  configurePolicyResolverForTests,
+  __resetPolicyResolverForTests,
+} from '../../../../src/services/decision-contract/policy-resolver';
+
+const NOW_ISO = new Date().toISOString();
+
+function seed(key: string, value: unknown) {
+  configurePolicyResolverForTests({
+    decisionPolicy: [
+      {
+        policy_key: key,
+        tenant_id: null,
+        version: 1,
+        value_json: value,
+        effective_from: NOW_ISO,
+        effective_until: null,
+      },
+    ],
+  });
+}
+
+describe('VTID-03134 Phase D.3.b-e voice mapping accessors', () => {
+  afterEach(() => {
+    __resetPolicyResolverForTests();
+  });
+
+  describe('cold-cache fallback parity (byte-identical to pre-D.3.b-e Records)', () => {
+    beforeEach(() => {
+      __resetPolicyResolverForTests();
+    });
+
+    it('LIVE_LANGUAGE_VOICES — getLiveLanguageVoice across 8 langs', () => {
+      expect(getLiveLanguageVoice('en')).toBe('Callirrhoe');
+      expect(getLiveLanguageVoice('de')).toBe('Achernar');
+      expect(getLiveLanguageVoice('fr')).toBe('Leda');
+      expect(getLiveLanguageVoice('es')).toBe('Aoede');
+      expect(getLiveLanguageVoice('ar')).toBe('Sulafat');
+      expect(getLiveLanguageVoice('zh')).toBe('Laomedeia');
+      expect(getLiveLanguageVoice('sr')).toBe('Vindemiatrix');
+      expect(getLiveLanguageVoice('ru')).toBe('Gacrux');
+    });
+
+    it('GEMINI_TTS_VOICES — getGeminiTtsVoice returns {name, languageCode}', () => {
+      expect(getGeminiTtsVoice('en')).toEqual({ name: 'Kore', languageCode: 'en-US' });
+      expect(getGeminiTtsVoice('de')).toEqual({ name: 'Kore', languageCode: 'de-DE' });
+      expect(getGeminiTtsVoice('fr')).toEqual({ name: 'Kore', languageCode: 'fr-FR' });
+      expect(getGeminiTtsVoice('es')).toEqual({ name: 'Kore', languageCode: 'es-ES' });
+      expect(getGeminiTtsVoice('ar')).toEqual({ name: 'Kore', languageCode: 'ar-XA' });
+      expect(getGeminiTtsVoice('zh')).toEqual({ name: 'Kore', languageCode: 'cmn-CN' });
+      expect(getGeminiTtsVoice('sr')).toEqual({ name: 'Kore', languageCode: 'sr-RS' });
+      expect(getGeminiTtsVoice('ru')).toEqual({ name: 'Kore', languageCode: 'ru-RU' });
+    });
+
+    it('NEURAL2_TTS_VOICES — Neural2/WaveNet/Standard fallback chain preserved', () => {
+      expect(getNeural2TtsVoice('de').name).toBe('de-DE-Neural2-G');
+      expect(getNeural2TtsVoice('en').name).toBe('en-US-Neural2-H');
+      expect(getNeural2TtsVoice('fr').name).toBe('fr-FR-Neural2-A');
+      expect(getNeural2TtsVoice('es').name).toBe('es-ES-Neural2-A');
+      expect(getNeural2TtsVoice('ar').name).toBe('ar-XA-Wavenet-D');
+      expect(getNeural2TtsVoice('zh').name).toBe('cmn-CN-Wavenet-A');
+      expect(getNeural2TtsVoice('ru').name).toBe('ru-RU-Wavenet-A');
+      expect(getNeural2TtsVoice('sr').name).toBe('sr-RS-Standard-A');
+    });
+
+    it('NEURAL2_ENABLED_LANGUAGES — 8 supported langs', () => {
+      const langs = getNeural2EnabledLanguages();
+      expect(langs).toEqual(['en', 'de', 'fr', 'es', 'ar', 'zh', 'ru', 'sr']);
+    });
+
+    it('isNeural2EnabledFor returns true for all 8 supported, false otherwise', () => {
+      for (const l of ['en', 'de', 'fr', 'es', 'ar', 'zh', 'ru', 'sr']) {
+        expect(isNeural2EnabledFor(l)).toBe(true);
+      }
+      expect(isNeural2EnabledFor('jp')).toBe(false);
+      expect(isNeural2EnabledFor('')).toBe(false);
+    });
+
+    it('unknown lang defaults to en safely (no throw)', () => {
+      expect(getLiveLanguageVoice('jp')).toBe('Callirrhoe');
+      expect(getGeminiTtsVoice('jp').name).toBe('Kore');
+      expect(getNeural2TtsVoice('jp').name).toBe('en-US-Neural2-H');
+    });
+  });
+
+  describe('resolver-seeded path — DB row wins', () => {
+    it('seeded voice.live_language.<lang> overrides fallback', () => {
+      seed('voice.live_language.de', 'NewGermanVoice');
+      expect(getLiveLanguageVoice('de')).toBe('NewGermanVoice');
+    });
+
+    it('seeded voice.gemini_tts.<lang> overrides fallback (JSON shape)', () => {
+      seed('voice.gemini_tts.en', { name: 'Aoede', languageCode: 'en-GB' });
+      expect(getGeminiTtsVoice('en')).toEqual({ name: 'Aoede', languageCode: 'en-GB' });
+    });
+
+    it('seeded voice.neural2_tts.<lang> overrides fallback', () => {
+      seed('voice.neural2_tts.fr', { name: 'fr-FR-Studio-A', languageCode: 'fr-FR' });
+      expect(getNeural2TtsVoice('fr').name).toBe('fr-FR-Studio-A');
+    });
+
+    it('seeded voice.neural2.enabled_languages array overrides fallback', () => {
+      seed('voice.neural2.enabled_languages', ['en', 'de']);
+      expect(getNeural2EnabledLanguages()).toEqual(['en', 'de']);
+      expect(isNeural2EnabledFor('en')).toBe(true);
+      expect(isNeural2EnabledFor('fr')).toBe(false);
+    });
+  });
+
+  describe('defensive', () => {
+    it('malformed enabled_languages row (not an array) falls back to literal', () => {
+      seed('voice.neural2.enabled_languages', 'oops_not_an_array' as unknown);
+      // Defensive guard returns the safety net.
+      expect(getNeural2EnabledLanguages()).toEqual(['en', 'de', 'fr', 'es', 'ar', 'zh', 'ru', 'sr']);
+    });
+  });
+});

--- a/supabase/migrations/20260528060000_VTID_03134_voice_mapping_tables_seeds.sql
+++ b/supabase/migrations/20260528060000_VTID_03134_voice_mapping_tables_seeds.sql
@@ -1,0 +1,153 @@
+-- Phase D.3.b-e (decision-contract refactor) — voice mapping table seeds.
+--
+-- VTID-03134. Externalizes the remaining 4 voice-mapping Records from
+-- `services/gateway/src/routes/orb-live.ts`:
+--   - LIVE_LANGUAGE_VOICES   → voice.live_language.<lang>   (8 rows)
+--   - GEMINI_TTS_VOICES      → voice.gemini_tts.<lang>      (8 rows)
+--   - NEURAL2_TTS_VOICES     → voice.neural2_tts.<lang>     (8 rows)
+--   - NEURAL2_ENABLED_LANGUAGES → voice.neural2.enabled_languages (1 row)
+--
+-- Idempotent. Values are BYTE-IDENTICAL to the Record entries at the
+-- time of writing. Accessor functions in
+-- `services/gateway/src/orb/live/voice/voice-mapping.ts` use the same
+-- literals as cache-cold safety nets so a missing row falls back to
+-- today's behaviour silently.
+
+-- =========================================================================
+-- LIVE_LANGUAGE_VOICES (Gemini Live voice names per lang)
+-- =========================================================================
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.live_language.en', NULL, 1, '"Callirrhoe"'::jsonb, 'seed',
+       'orb-live.ts:753 (LIVE_LANGUAGE_VOICES.en — female Gemini Live voice)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'voice.live_language.en' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.live_language.de', NULL, 1, '"Achernar"'::jsonb, 'seed',
+       'orb-live.ts:754 (LIVE_LANGUAGE_VOICES.de)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'voice.live_language.de' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.live_language.fr', NULL, 1, '"Leda"'::jsonb, 'seed',
+       'orb-live.ts:755 (LIVE_LANGUAGE_VOICES.fr)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'voice.live_language.fr' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.live_language.es', NULL, 1, '"Aoede"'::jsonb, 'seed',
+       'orb-live.ts:756 (LIVE_LANGUAGE_VOICES.es)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'voice.live_language.es' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.live_language.ar', NULL, 1, '"Sulafat"'::jsonb, 'seed',
+       'orb-live.ts:757 (LIVE_LANGUAGE_VOICES.ar)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'voice.live_language.ar' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.live_language.zh', NULL, 1, '"Laomedeia"'::jsonb, 'seed',
+       'orb-live.ts:758 (LIVE_LANGUAGE_VOICES.zh)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'voice.live_language.zh' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.live_language.sr', NULL, 1, '"Vindemiatrix"'::jsonb, 'seed',
+       'orb-live.ts:759 (LIVE_LANGUAGE_VOICES.sr)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'voice.live_language.sr' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.live_language.ru', NULL, 1, '"Gacrux"'::jsonb, 'seed',
+       'orb-live.ts:760 (LIVE_LANGUAGE_VOICES.ru)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'voice.live_language.ru' AND tenant_id IS NULL AND version = 1);
+
+-- =========================================================================
+-- GEMINI_TTS_VOICES (Cloud TTS Gemini-model voices per lang)
+-- =========================================================================
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.gemini_tts.en', NULL, 1, '{"name":"Kore","languageCode":"en-US"}'::jsonb, 'seed',
+       'orb-live.ts:1252 (GEMINI_TTS_VOICES.en)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'voice.gemini_tts.en' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.gemini_tts.de', NULL, 1, '{"name":"Kore","languageCode":"de-DE"}'::jsonb, 'seed',
+       'orb-live.ts:1253 (GEMINI_TTS_VOICES.de)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'voice.gemini_tts.de' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.gemini_tts.fr', NULL, 1, '{"name":"Kore","languageCode":"fr-FR"}'::jsonb, 'seed',
+       'orb-live.ts:1254 (GEMINI_TTS_VOICES.fr)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'voice.gemini_tts.fr' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.gemini_tts.es', NULL, 1, '{"name":"Kore","languageCode":"es-ES"}'::jsonb, 'seed',
+       'orb-live.ts:1255 (GEMINI_TTS_VOICES.es)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'voice.gemini_tts.es' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.gemini_tts.ar', NULL, 1, '{"name":"Kore","languageCode":"ar-XA"}'::jsonb, 'seed',
+       'orb-live.ts:1256 (GEMINI_TTS_VOICES.ar)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'voice.gemini_tts.ar' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.gemini_tts.zh', NULL, 1, '{"name":"Kore","languageCode":"cmn-CN"}'::jsonb, 'seed',
+       'orb-live.ts:1257 (GEMINI_TTS_VOICES.zh)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'voice.gemini_tts.zh' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.gemini_tts.sr', NULL, 1, '{"name":"Kore","languageCode":"sr-RS"}'::jsonb, 'seed',
+       'orb-live.ts:1258 (GEMINI_TTS_VOICES.sr)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'voice.gemini_tts.sr' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.gemini_tts.ru', NULL, 1, '{"name":"Kore","languageCode":"ru-RU"}'::jsonb, 'seed',
+       'orb-live.ts:1259 (GEMINI_TTS_VOICES.ru)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'voice.gemini_tts.ru' AND tenant_id IS NULL AND version = 1);
+
+-- =========================================================================
+-- NEURAL2_TTS_VOICES (Cloud TTS Neural2/WaveNet/Standard fallback chain)
+-- =========================================================================
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.neural2_tts.de', NULL, 1, '{"name":"de-DE-Neural2-G","languageCode":"de-DE"}'::jsonb, 'seed',
+       'orb-live.ts:1271 (Neural2 female German)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'voice.neural2_tts.de' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.neural2_tts.en', NULL, 1, '{"name":"en-US-Neural2-H","languageCode":"en-US"}'::jsonb, 'seed',
+       'orb-live.ts:1272 (Neural2 female English)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'voice.neural2_tts.en' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.neural2_tts.fr', NULL, 1, '{"name":"fr-FR-Neural2-A","languageCode":"fr-FR"}'::jsonb, 'seed',
+       'orb-live.ts:1273 (Neural2 female French)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'voice.neural2_tts.fr' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.neural2_tts.es', NULL, 1, '{"name":"es-ES-Neural2-A","languageCode":"es-ES"}'::jsonb, 'seed',
+       'orb-live.ts:1274 (Neural2 female Spanish)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'voice.neural2_tts.es' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.neural2_tts.ar', NULL, 1, '{"name":"ar-XA-Wavenet-D","languageCode":"ar-XA"}'::jsonb, 'seed',
+       'orb-live.ts:1275 (WaveNet female Arabic — Neural2 not available)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'voice.neural2_tts.ar' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.neural2_tts.zh', NULL, 1, '{"name":"cmn-CN-Wavenet-A","languageCode":"cmn-CN"}'::jsonb, 'seed',
+       'orb-live.ts:1276 (WaveNet female Chinese — Neural2 not available)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'voice.neural2_tts.zh' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.neural2_tts.ru', NULL, 1, '{"name":"ru-RU-Wavenet-A","languageCode":"ru-RU"}'::jsonb, 'seed',
+       'orb-live.ts:1277 (WaveNet female Russian — Neural2 not available)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'voice.neural2_tts.ru' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.neural2_tts.sr', NULL, 1, '{"name":"sr-RS-Standard-A","languageCode":"sr-RS"}'::jsonb, 'seed',
+       'orb-live.ts:1278 (Standard female Serbian — Neural2/WaveNet not available)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'voice.neural2_tts.sr' AND tenant_id IS NULL AND version = 1);
+
+-- =========================================================================
+-- NEURAL2_ENABLED_LANGUAGES (array — which langs prefer Neural2 over Gemini TTS)
+-- =========================================================================
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'voice.neural2.enabled_languages', NULL, 1,
+       '["en","de","fr","es","ar","zh","ru","sr"]'::jsonb,
+       'seed',
+       'orb-live.ts:1282 (NEURAL2_ENABLED_LANGUAGES — all 8 supported langs use best-available TTS chain)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'voice.neural2.enabled_languages' AND tenant_id IS NULL AND version = 1);


### PR DESCRIPTION
## Summary
Batched D.3.b through D.3.e — migrates the 4 remaining voice-mapping Records from inline in `routes/orb-live.ts` to `decision_policy` + accessor functions. 25 seeded rows; byte-identical fallback path. Completes the LIVE_API_VOICES + 4-table voice externalization arc from the original audit.

## Changes
- **Migration** `20260528060000_VTID_03134_voice_mapping_tables_seeds.sql` — 25 idempotent inserts.
- **New module** `orb/live/voice/voice-mapping.ts` — `getLiveLanguageVoice`, `getGeminiTtsVoice`, `getNeural2TtsVoice`, `getNeural2EnabledLanguages`, `isNeural2EnabledFor`.
- **`orb-live.ts`** — 4 inline declarations removed, ~12 call sites updated to use accessors.
- **POLICY_KEYS** — `VOICE_NEURAL2_ENABLED_LANGUAGES` entry added (per-lang keys are dynamic).
- **11 new tests** covering: 8-lang fallback parity, JSON shape preservation, array seed override, malformed-row defensive guard.

## Test plan
- [x] 11 new tests green. Full orb suite 839/839 across 50 suites.
- [x] `npm run build` clean.
- [ ] CI green.
- [ ] RUN-MIGRATION: 25 row inserts.
- [ ] Post-deploy `/alive` 200 JSON.

🤖 Generated with [Claude Code](https://claude.com/claude-code)