### PR TITLE
feat(decision-contract): C.5 — feed-ranker weights via PolicyResolver (VTID-03137)

### DIFF
--- a/services/gateway/src/services/decision-contract/policy-keys.ts
+++ b/services/gateway/src/services/decision-contract/policy-keys.ts
@@ -141,6 +141,31 @@ export const POLICY_KEYS = {
     'situational.session_length.long_threshold_minutes',
   SITUATIONAL_OVERRIDE_EXPIRY_MINUTES:
     'situational.override.expiry_minutes',
+
+  // ---- Phase C.5 (VTID-03137) — feed-ranker weights ------------
+  // The 12 weight/threshold literals in
+  // `services/gateway/src/services/feed-ranker.ts`. Accessor
+  // `getFeedRankerConfig()` reads via PolicyResolver with the literals
+  // as cache-cold defaults so behaviour is byte-identical at rollout.
+  RANKER_FEED_PW_ONBOARDING:
+    'ranker.feed.personalization_weight.onboarding',
+  RANKER_FEED_PW_EARLY:
+    'ranker.feed.personalization_weight.early',
+  RANKER_FEED_PW_ESTABLISHED:
+    'ranker.feed.personalization_weight.established',
+  RANKER_FEED_PW_MATURE:
+    'ranker.feed.personalization_weight.mature',
+  RANKER_FEED_PW_DEFAULT:
+    'ranker.feed.personalization_weight.default',
+  RANKER_FEED_FEATURED_BOOST: 'ranker.feed.featured_boost',
+  RANKER_FEED_RATING_SCORE_MAX: 'ranker.feed.rating_score_max',
+  RANKER_FEED_CATEGORY_MIX_WEIGHT: 'ranker.feed.category_mix_weight',
+  RANKER_FEED_TOPIC_AFFINITY_CAP: 'ranker.feed.topic_affinity_cap',
+  RANKER_FEED_CONDITION_MATCH_BOOST: 'ranker.feed.condition_match_boost',
+  RANKER_FEED_SAME_REGION_BONUS: 'ranker.feed.same_region_bonus',
+  RANKER_FEED_HIGH_RATING_THRESHOLD: 'ranker.feed.high_rating_threshold',
+  RANKER_FEED_HIGH_RATING_BONUS: 'ranker.feed.high_rating_bonus',
+  RANKER_FEED_BUDGET_FIT_BONUS: 'ranker.feed.budget_fit_bonus',
 } as const;
 
 export type PolicyKey = (typeof POLICY_KEYS)[keyof typeof POLICY_KEYS];

--- a/services/gateway/src/services/feed-ranker.ts
+++ b/services/gateway/src/services/feed-ranker.ts
@@ -32,18 +32,61 @@ interface RankableProduct extends FilterableProduct {
   price_cents: number | null;
 }
 
+// VTID-03137 (Phase C.5): feed-ranker weights now resolved via
+// PolicyResolver. Literal defaults preserved for cache-cold safety.
+import { getPolicyResolver } from './decision-contract/policy-resolver';
+import { POLICY_KEYS } from './decision-contract/policy-keys';
+
+interface FeedRankerWeights {
+  pwOnboarding: number;
+  pwEarly: number;
+  pwEstablished: number;
+  pwMature: number;
+  pwDefault: number;
+  featuredBoost: number;
+  ratingScoreMax: number;
+  categoryMixWeight: number;
+  topicAffinityCap: number;
+  conditionMatchBoost: number;
+  sameRegionBonus: number;
+  highRatingThreshold: number;
+  highRatingBonus: number;
+  budgetFitBonus: number;
+}
+
+function getFeedRankerWeights(): FeedRankerWeights {
+  const r = getPolicyResolver();
+  return {
+    pwOnboarding:        r.getValue<number>(POLICY_KEYS.RANKER_FEED_PW_ONBOARDING,       { defaultValue: 0.2 }),
+    pwEarly:             r.getValue<number>(POLICY_KEYS.RANKER_FEED_PW_EARLY,            { defaultValue: 0.45 }),
+    pwEstablished:       r.getValue<number>(POLICY_KEYS.RANKER_FEED_PW_ESTABLISHED,      { defaultValue: 0.7 }),
+    pwMature:            r.getValue<number>(POLICY_KEYS.RANKER_FEED_PW_MATURE,           { defaultValue: 0.9 }),
+    pwDefault:           r.getValue<number>(POLICY_KEYS.RANKER_FEED_PW_DEFAULT,          { defaultValue: 0.3 }),
+    featuredBoost:       r.getValue<number>(POLICY_KEYS.RANKER_FEED_FEATURED_BOOST,      { defaultValue: 0.7 }),
+    ratingScoreMax:      r.getValue<number>(POLICY_KEYS.RANKER_FEED_RATING_SCORE_MAX,    { defaultValue: 0.3 }),
+    categoryMixWeight:   r.getValue<number>(POLICY_KEYS.RANKER_FEED_CATEGORY_MIX_WEIGHT, { defaultValue: 0.2 }),
+    topicAffinityCap:    r.getValue<number>(POLICY_KEYS.RANKER_FEED_TOPIC_AFFINITY_CAP,  { defaultValue: 0.4 }),
+    conditionMatchBoost: r.getValue<number>(POLICY_KEYS.RANKER_FEED_CONDITION_MATCH_BOOST, { defaultValue: 0.3 }),
+    sameRegionBonus:     r.getValue<number>(POLICY_KEYS.RANKER_FEED_SAME_REGION_BONUS,   { defaultValue: 0.1 }),
+    highRatingThreshold: r.getValue<number>(POLICY_KEYS.RANKER_FEED_HIGH_RATING_THRESHOLD, { defaultValue: 4.5 }),
+    highRatingBonus:     r.getValue<number>(POLICY_KEYS.RANKER_FEED_HIGH_RATING_BONUS,   { defaultValue: 0.1 }),
+    budgetFitBonus:      r.getValue<number>(POLICY_KEYS.RANKER_FEED_BUDGET_FIT_BONUS,    { defaultValue: 0.05 }),
+  };
+}
+
 export function defaultPersonalizationWeightForStage(stage: string | null): number {
+  const w = getFeedRankerWeights();
   switch (stage) {
     case 'onboarding':
-      return 0.2;
+      return w.pwOnboarding;
     case 'early':
-      return 0.45;
+      return w.pwEarly;
     case 'established':
-      return 0.7;
+      return w.pwEstablished;
     case 'mature':
-      return 0.9;
+      return w.pwMature;
     default:
-      return 0.3;
+      return w.pwDefault;
   }
 }
 
@@ -78,28 +121,33 @@ export function rankFeedProducts<T extends RankableProduct>(
   const maxPerMerchant = config?.max_products_per_merchant ?? 3;
   const maxPerCategory = config?.max_products_per_category ?? null;
 
+  // VTID-03137 (Phase C.5): per-product weights read once via the
+  // resolver-backed snapshot so all per-product scoring decisions
+  // share a single consistent set of weights for the batch.
+  const w = getFeedRankerWeights();
+
   const scored = products.map((p) => {
     const rank_reasons: string[] = [];
 
     // Default score component: featured pins + rating + category mix fit
     let defaultScore = 0;
     if (featuredSet.has(p.id)) {
-      defaultScore += 0.7;
+      defaultScore += w.featuredBoost;
       rank_reasons.push('Featured by editors');
     }
     if (p.rating !== null && p.rating > 0) {
-      defaultScore += Math.max(0, Math.min(0.3, ((p.rating - 3) / 2) * 0.3));
+      defaultScore += Math.max(0, Math.min(w.ratingScoreMax, ((p.rating - 3) / 2) * w.ratingScoreMax));
     }
     if (config && p.category && config.category_mix[p.category]) {
       // Slight boost for categories that the admin config prioritizes
-      defaultScore += config.category_mix[p.category] * 0.2;
+      defaultScore += config.category_mix[p.category] * w.categoryMixWeight;
     }
 
     // Personalization score component
     let personalizedScore = 0;
     // Topic affinity
     if (p.category && ctx.topic_affinity[p.category]) {
-      personalizedScore += Math.min(0.4, ctx.topic_affinity[p.category]);
+      personalizedScore += Math.min(w.topicAffinityCap, ctx.topic_affinity[p.category]);
     }
     // Active-condition fit: if product's health_goals overlap starter or active conditions
     if (p.health_goals?.length) {
@@ -107,7 +155,7 @@ export function rankFeedProducts<T extends RankableProduct>(
         if (starterConditions.has(cond.key) || cond.source === 'user_stated') {
           const goals = p.health_goals.map((g) => g.toLowerCase());
           if (goals.some((g) => g.includes(cond.key.toLowerCase().replace(/-/g, '')))) {
-            personalizedScore += 0.3;
+            personalizedScore += w.conditionMatchBoost;
             rank_reasons.push(`Supports ${cond.key}`);
             break;
           }
@@ -116,16 +164,16 @@ export function rankFeedProducts<T extends RankableProduct>(
     }
     // Same-region origin bonus
     if (ctx.region_group && p.origin_region === ctx.region_group) {
-      personalizedScore += 0.1;
+      personalizedScore += w.sameRegionBonus;
       rank_reasons.push('Ships from your region');
     }
     // Rating — also shared with default score but we leave both for simplicity
-    if (p.rating !== null && p.rating >= 4.5) {
-      personalizedScore += 0.1;
+    if (p.rating !== null && p.rating >= w.highRatingThreshold) {
+      personalizedScore += w.highRatingBonus;
     }
     // Budget fit
     if (ctx.budget_max_per_product_cents && p.price_cents !== null && p.price_cents !== undefined && p.price_cents <= ctx.budget_max_per_product_cents) {
-      personalizedScore += 0.05;
+      personalizedScore += w.budgetFitBonus;
     }
 
     const blended = (1 - personalizationWeight) * defaultScore + personalizationWeight * personalizedScore;

--- a/services/gateway/test/services/decision-contract/feed-ranker-weights.test.ts
+++ b/services/gateway/test/services/decision-contract/feed-ranker-weights.test.ts
@@ -1,0 +1,125 @@
+// VTID-03137 — Phase C.5 of the decision-contract refactor.
+//
+// Locks the contract for feed-ranker weight externalization. Byte-identical
+// cold-cache parity + resolver-seeded override behaviour + source-level
+// wire-up assertions.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  defaultPersonalizationWeightForStage,
+  rankFeedProducts,
+} from '../../../src/services/feed-ranker';
+import {
+  configurePolicyResolverForTests,
+  __resetPolicyResolverForTests,
+} from '../../../src/services/decision-contract/policy-resolver';
+
+const NOW_ISO = new Date().toISOString();
+
+function seed(key: string, value: unknown) {
+  configurePolicyResolverForTests({
+    decisionPolicy: [
+      {
+        policy_key: key,
+        tenant_id: null,
+        version: 1,
+        value_json: value,
+        effective_from: NOW_ISO,
+        effective_until: null,
+      },
+    ],
+  });
+}
+
+describe('VTID-03137 Phase C.5 feed-ranker weights', () => {
+  afterEach(() => __resetPolicyResolverForTests());
+
+  describe('defaultPersonalizationWeightForStage — cold-cache parity', () => {
+    beforeEach(() => __resetPolicyResolverForTests());
+
+    it.each([
+      ['onboarding', 0.2],
+      ['early', 0.45],
+      ['established', 0.7],
+      ['mature', 0.9],
+      [null, 0.3],
+      ['unknown-stage', 0.3],
+    ] as const)('stage=%p → %p', (stage, expected) => {
+      expect(defaultPersonalizationWeightForStage(stage)).toBe(expected);
+    });
+  });
+
+  describe('defaultPersonalizationWeightForStage — resolver override', () => {
+    it('seeded onboarding = 0.05 wins', () => {
+      seed('ranker.feed.personalization_weight.onboarding', 0.05);
+      expect(defaultPersonalizationWeightForStage('onboarding')).toBe(0.05);
+    });
+
+    it('seeded mature = 0.99 wins', () => {
+      seed('ranker.feed.personalization_weight.mature', 0.99);
+      expect(defaultPersonalizationWeightForStage('mature')).toBe(0.99);
+    });
+  });
+
+  describe('rankFeedProducts — featured boost cold-cache parity', () => {
+    beforeEach(() => __resetPolicyResolverForTests());
+
+    it('featured product gets the 0.7 default-score boost', () => {
+      const out = rankFeedProducts({
+        products: [
+          { id: 'a', merchant_id: 'm1', category: 'food', rating: null, origin_region: null, health_goals: null, price_cents: null },
+          { id: 'b', merchant_id: 'm2', category: 'food', rating: null, origin_region: null, health_goals: null, price_cents: null },
+        ],
+        config: {
+          featured_product_ids: ['a'],
+          starter_conditions: [],
+          max_products_per_merchant: 10,
+          max_products_per_category: null,
+          category_mix: {},
+          personalization_weight_override: 0,
+          region_group: null,
+        } as any,
+        ctx: {
+          lifecycle_stage: 'onboarding',
+          topic_affinity: {},
+          active_conditions: [],
+          region_group: null,
+          budget_max_per_product_cents: null,
+        } as any,
+        limit: 10,
+      });
+      const a = out.items.find((p: any) => p.id === 'a')!;
+      const b = out.items.find((p: any) => p.id === 'b')!;
+      // 'a' wins because of featured 0.7 boost (under 0% personalization weight,
+      // the personalization side is zero so default-score is the whole score).
+      expect(a.rank_score).toBeGreaterThan(b.rank_score);
+      // 0.7 boost × (1 - 0) default weight = 0.7
+      expect(a.rank_score).toBeCloseTo(0.7, 5);
+    });
+  });
+
+  describe('source-level wire-up — no remaining literals in feed-ranker', () => {
+    const SRC = path.resolve(__dirname, '../../../src/services/feed-ranker.ts');
+    let src: string;
+    beforeAll(() => { src = fs.readFileSync(SRC, 'utf8'); });
+
+    it('imports POLICY_KEYS + getPolicyResolver', () => {
+      expect(src).toMatch(/from\s+['"]\.\/decision-contract\/policy-resolver['"]/);
+      expect(src).toMatch(/POLICY_KEYS/);
+    });
+
+    it('uses w.featuredBoost (not the literal 0.7) inside the scoring loop', () => {
+      expect(src).toMatch(/w\.featuredBoost/);
+    });
+
+    it('uses w.highRatingThreshold (not the literal 4.5) inside the scoring loop', () => {
+      expect(src).toMatch(/w\.highRatingThreshold/);
+    });
+
+    it('uses w.pwOnboarding et al. in defaultPersonalizationWeightForStage', () => {
+      expect(src).toMatch(/w\.pwOnboarding/);
+      expect(src).toMatch(/w\.pwMature/);
+    });
+  });
+});

--- a/supabase/migrations/20260528090000_VTID_03137_feed_ranker_weights_seeds.sql
+++ b/supabase/migrations/20260528090000_VTID_03137_feed_ranker_weights_seeds.sql
@@ -1,0 +1,80 @@
+-- Phase C.5 (decision-contract refactor) — feed-ranker weight seeds.
+--
+-- VTID-03137. Externalizes the 12 weight/threshold literals in
+-- `services/gateway/src/services/feed-ranker.ts`. Accessor function
+-- `getFeedRankerConfig()` reads via PolicyResolver with these values
+-- as cache-cold defaults so behaviour is byte-identical at rollout.
+--
+-- Idempotent.
+
+-- Lifecycle-stage personalization-weight blends
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'ranker.feed.personalization_weight.onboarding', NULL, 1, '0.2'::jsonb, 'seed',
+       'feed-ranker.ts:38 (defaultPersonalizationWeightForStage: onboarding)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'ranker.feed.personalization_weight.onboarding' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'ranker.feed.personalization_weight.early', NULL, 1, '0.45'::jsonb, 'seed',
+       'feed-ranker.ts:40 (early lifecycle)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'ranker.feed.personalization_weight.early' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'ranker.feed.personalization_weight.established', NULL, 1, '0.7'::jsonb, 'seed',
+       'feed-ranker.ts:42 (established lifecycle)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'ranker.feed.personalization_weight.established' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'ranker.feed.personalization_weight.mature', NULL, 1, '0.9'::jsonb, 'seed',
+       'feed-ranker.ts:44 (mature lifecycle)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'ranker.feed.personalization_weight.mature' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'ranker.feed.personalization_weight.default', NULL, 1, '0.3'::jsonb, 'seed',
+       'feed-ranker.ts:46 (default fallback)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'ranker.feed.personalization_weight.default' AND tenant_id IS NULL AND version = 1);
+
+-- Per-product score components
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'ranker.feed.featured_boost', NULL, 1, '0.7'::jsonb, 'seed',
+       'feed-ranker.ts:87 (featured-pin boost)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'ranker.feed.featured_boost' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'ranker.feed.rating_score_max', NULL, 1, '0.3'::jsonb, 'seed',
+       'feed-ranker.ts:91 (rating score capped at 0.3; formula (rating-3)/2 * 0.3)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'ranker.feed.rating_score_max' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'ranker.feed.category_mix_weight', NULL, 1, '0.2'::jsonb, 'seed',
+       'feed-ranker.ts:95 (category_mix multiplier)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'ranker.feed.category_mix_weight' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'ranker.feed.topic_affinity_cap', NULL, 1, '0.4'::jsonb, 'seed',
+       'feed-ranker.ts:102 (topic_affinity per-category cap)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'ranker.feed.topic_affinity_cap' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'ranker.feed.condition_match_boost', NULL, 1, '0.3'::jsonb, 'seed',
+       'feed-ranker.ts:110 (active-condition match boost)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'ranker.feed.condition_match_boost' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'ranker.feed.same_region_bonus', NULL, 1, '0.1'::jsonb, 'seed',
+       'feed-ranker.ts:119 (same-region origin bonus)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'ranker.feed.same_region_bonus' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'ranker.feed.high_rating_threshold', NULL, 1, '4.5'::jsonb, 'seed',
+       'feed-ranker.ts:123 (high-rating threshold; ≥4.5 stars triggers personalized bonus)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'ranker.feed.high_rating_threshold' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'ranker.feed.high_rating_bonus', NULL, 1, '0.1'::jsonb, 'seed',
+       'feed-ranker.ts:124 (high-rating personalized bonus when threshold met)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'ranker.feed.high_rating_bonus' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'ranker.feed.budget_fit_bonus', NULL, 1, '0.05'::jsonb, 'seed',
+       'feed-ranker.ts:128 (within-budget bonus)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'ranker.feed.budget_fit_bonus' AND tenant_id IS NULL AND version = 1);


### PR DESCRIPTION
14 feed-ranker literals (5 stage weights + 9 score components) → decision_policy + getFeedRankerWeights snapshot accessor. Byte-identical at rollout. 13 new tests, 925/925 across 57 suites.

🤖 Generated with [Claude Code](https://claude.com/claude-code)