### PR TITLE
feat(decision-contract): C.7 + C.8 — marketplace + community analyzers via PolicyResolver (VTID-03138)

### DIFF
--- a/services/gateway/src/services/decision-contract/policy-keys.ts
+++ b/services/gateway/src/services/decision-contract/policy-keys.ts
@@ -166,6 +166,42 @@ export const POLICY_KEYS = {
   RANKER_FEED_HIGH_RATING_THRESHOLD: 'ranker.feed.high_rating_threshold',
   RANKER_FEED_HIGH_RATING_BONUS: 'ranker.feed.high_rating_bonus',
   RANKER_FEED_BUDGET_FIT_BONUS: 'ranker.feed.budget_fit_bonus',
+
+  // ---- Phase C.7 (VTID-03138) — marketplace-analyzer -----------
+  RANKER_MARKETPLACE_TOP_PICKS_PER_USER:
+    'ranker.marketplace.top_picks_per_user',
+  RANKER_MARKETPLACE_PRODUCT_CANDIDATE_LIMIT:
+    'ranker.marketplace.product_candidate_limit',
+  RANKER_MARKETPLACE_INGREDIENT_RANK_BASE:
+    'ranker.marketplace.ingredient_rank_base',
+  RANKER_MARKETPLACE_INGREDIENT_RANK_DECAY:
+    'ranker.marketplace.ingredient_rank_decay',
+  RANKER_MARKETPLACE_EVIDENCE_MULTIPLIERS:
+    'ranker.marketplace.evidence_multipliers',
+  RANKER_MARKETPLACE_GOAL_MATCH_BOOST:
+    'ranker.marketplace.goal_match_boost',
+  RANKER_MARKETPLACE_SAME_REGION_BONUS:
+    'ranker.marketplace.same_region_bonus',
+  RANKER_MARKETPLACE_RATING_BOOST_CAP:
+    'ranker.marketplace.rating_boost_cap',
+  RANKER_MARKETPLACE_PAST_PURCHASE_PENALTY:
+    'ranker.marketplace.past_purchase_penalty',
+
+  // ---- Phase C.8 (VTID-03138) — community-user-analyzer --------
+  ANALYZER_COMMUNITY_PILLAR_WEAKNESS_THRESHOLD:
+    'analyzer.community.pillar_weakness_threshold',
+  ANALYZER_COMMUNITY_DECLINE_TREND_DROP_POINTS:
+    'analyzer.community.decline_trend_drop_points',
+  ANALYZER_COMMUNITY_STAGE_DAY1_AFTER_DAYS:
+    'analyzer.community.onboarding_stage.day1_after_days',
+  ANALYZER_COMMUNITY_STAGE_DAY3_AFTER_DAYS:
+    'analyzer.community.onboarding_stage.day3_after_days',
+  ANALYZER_COMMUNITY_STAGE_DAY7_AFTER_DAYS:
+    'analyzer.community.onboarding_stage.day7_after_days',
+  ANALYZER_COMMUNITY_STAGE_DAY14_AFTER_DAYS:
+    'analyzer.community.onboarding_stage.day14_after_days',
+  ANALYZER_COMMUNITY_STAGE_DAY30PLUS_AFTER_DAYS:
+    'analyzer.community.onboarding_stage.day30plus_after_days',
 } as const;
 
 export type PolicyKey = (typeof POLICY_KEYS)[keyof typeof POLICY_KEYS];

--- a/services/gateway/src/services/recommendation-engine/analyzers/community-user-analyzer.ts
+++ b/services/gateway/src/services/recommendation-engine/analyzers/community-user-analyzer.ts
@@ -47,10 +47,32 @@ export type CanonicalWeakness =
   | 'sleep_low'
   | 'mental_low';
 
+// VTID-03138 (Phase C.8): pillar weakness threshold + decline gate now
+// resolved via PolicyResolver. Literal defaults below are the cache-cold
+// safety net.
+import { getPolicyResolver } from '../../decision-contract/policy-resolver';
+import { POLICY_KEYS } from '../../decision-contract/policy-keys';
+
 /** Threshold below which a pillar is considered weak and a weakness
  *  recommendation is emitted. Each pillar scale: 0..200; threshold 80 =
- *  below the "Building" floor for that pillar. */
+ *  below the "Building" floor for that pillar.
+ *  Legacy const kept for inspection; hot path uses
+ *  `getPillarWeaknessThreshold()`. */
 const PILLAR_WEAKNESS_THRESHOLD = 80;
+
+function getPillarWeaknessThreshold(): number {
+  return getPolicyResolver().getValue<number>(
+    POLICY_KEYS.ANALYZER_COMMUNITY_PILLAR_WEAKNESS_THRESHOLD,
+    { defaultValue: 80 },
+  );
+}
+
+function getDeclineTrendDropPoints(): number {
+  return getPolicyResolver().getValue<number>(
+    POLICY_KEYS.ANALYZER_COMMUNITY_DECLINE_TREND_DROP_POINTS,
+    { defaultValue: 10 },
+  );
+}
 
 /**
  * Pure deterministic weakness detection from canonical 5-pillar scores.
@@ -62,17 +84,19 @@ export function detectCanonicalWeaknesses(
 ): CanonicalWeakness[] {
   if (!scores) return [];
   const out: CanonicalWeakness[] = [];
+  const weaknessThreshold = getPillarWeaknessThreshold();
+  const declineDropPoints = getDeclineTrendDropPoints();
   for (const p of PILLAR_KEYS) {
     const current = Number(scores[p] ?? 0);
-    if (current < PILLAR_WEAKNESS_THRESHOLD) {
+    if (current < weaknessThreshold) {
       out.push(`${p}_low` as CanonicalWeakness);
       continue;
     }
-    // Optional trend check: if pillar dropped by >= 10 points from previous
-    // snapshot, flag it as declining even if still above threshold.
+    // Optional trend check: if pillar dropped by ≥ declineDropPoints from
+    // previous snapshot, flag it as declining even if still above threshold.
     if (previous) {
       const prev = Number(previous[p] ?? 0);
-      if (prev - current >= 10) {
+      if (prev - current >= declineDropPoints) {
         out.push(`${p}_low` as CanonicalWeakness);
       }
     }
@@ -502,11 +526,19 @@ export interface CommunityUserAnalysisResult {
 export function detectOnboardingStage(createdAt: Date): OnboardingStage {
   const daysSinceCreation = Math.floor((Date.now() - createdAt.getTime()) / 86400000);
 
-  if (daysSinceCreation < 1) return 'day0';
-  if (daysSinceCreation < 3) return 'day1';
-  if (daysSinceCreation < 7) return 'day3';
-  if (daysSinceCreation < 14) return 'day7';
-  if (daysSinceCreation < 30) return 'day14';
+  // VTID-03138 (Phase C.8): 5 stage boundaries now policy-driven.
+  const r = getPolicyResolver();
+  const d1 = r.getValue<number>(POLICY_KEYS.ANALYZER_COMMUNITY_STAGE_DAY1_AFTER_DAYS, { defaultValue: 1 });
+  const d3 = r.getValue<number>(POLICY_KEYS.ANALYZER_COMMUNITY_STAGE_DAY3_AFTER_DAYS, { defaultValue: 3 });
+  const d7 = r.getValue<number>(POLICY_KEYS.ANALYZER_COMMUNITY_STAGE_DAY7_AFTER_DAYS, { defaultValue: 7 });
+  const d14 = r.getValue<number>(POLICY_KEYS.ANALYZER_COMMUNITY_STAGE_DAY14_AFTER_DAYS, { defaultValue: 14 });
+  const d30 = r.getValue<number>(POLICY_KEYS.ANALYZER_COMMUNITY_STAGE_DAY30PLUS_AFTER_DAYS, { defaultValue: 30 });
+
+  if (daysSinceCreation < d1) return 'day0';
+  if (daysSinceCreation < d3) return 'day1';
+  if (daysSinceCreation < d7) return 'day3';
+  if (daysSinceCreation < d14) return 'day7';
+  if (daysSinceCreation < d30) return 'day14';
   return 'day30plus';
 }
 

--- a/services/gateway/src/services/recommendation-engine/analyzers/marketplace-analyzer.ts
+++ b/services/gateway/src/services/recommendation-engine/analyzers/marketplace-analyzer.ts
@@ -71,6 +71,44 @@ interface ProductRow extends FilterableProduct {
   ingredients_primary: string[];
 }
 
+// VTID-03138 (Phase C.7): marketplace weights resolved via PolicyResolver.
+// Literals below are the cache-cold safety net; production source of
+// truth is `decision_policy` rows under `ranker.marketplace.*`.
+import { getPolicyResolver } from '../../decision-contract/policy-resolver';
+import { POLICY_KEYS } from '../../decision-contract/policy-keys';
+
+interface MarketplaceWeights {
+  topPicksPerUser: number;
+  productCandidateLimit: number;
+  ingredientRankBase: number;
+  ingredientRankDecay: number;
+  evidenceMultipliers: { strong: number; moderate: number; weak: number };
+  goalMatchBoost: number;
+  sameRegionBonus: number;
+  ratingBoostCap: number;
+  pastPurchasePenalty: number;
+}
+
+function getMarketplaceWeights(): MarketplaceWeights {
+  const r = getPolicyResolver();
+  return {
+    topPicksPerUser:       r.getValue<number>(POLICY_KEYS.RANKER_MARKETPLACE_TOP_PICKS_PER_USER,       { defaultValue: 5 }),
+    productCandidateLimit: r.getValue<number>(POLICY_KEYS.RANKER_MARKETPLACE_PRODUCT_CANDIDATE_LIMIT, { defaultValue: 100 }),
+    ingredientRankBase:    r.getValue<number>(POLICY_KEYS.RANKER_MARKETPLACE_INGREDIENT_RANK_BASE,    { defaultValue: 0.5 }),
+    ingredientRankDecay:   r.getValue<number>(POLICY_KEYS.RANKER_MARKETPLACE_INGREDIENT_RANK_DECAY,   { defaultValue: 0.08 }),
+    evidenceMultipliers:   r.getValue<{ strong: number; moderate: number; weak: number }>(
+      POLICY_KEYS.RANKER_MARKETPLACE_EVIDENCE_MULTIPLIERS,
+      { defaultValue: { strong: 1.0, moderate: 0.8, weak: 0.5 } },
+    ),
+    goalMatchBoost:        r.getValue<number>(POLICY_KEYS.RANKER_MARKETPLACE_GOAL_MATCH_BOOST,        { defaultValue: 0.2 }),
+    sameRegionBonus:       r.getValue<number>(POLICY_KEYS.RANKER_MARKETPLACE_SAME_REGION_BONUS,      { defaultValue: 0.15 }),
+    ratingBoostCap:        r.getValue<number>(POLICY_KEYS.RANKER_MARKETPLACE_RATING_BOOST_CAP,       { defaultValue: 0.1 }),
+    pastPurchasePenalty:   r.getValue<number>(POLICY_KEYS.RANKER_MARKETPLACE_PAST_PURCHASE_PENALTY,   { defaultValue: -1.0 }),
+  };
+}
+
+// Legacy const exports preserved for any tests/inspectors that read them.
+// The hot path uses `getMarketplaceWeights()` via the resolver-backed snapshot.
 const TOP_PICKS_PER_USER = 5;
 const PRODUCT_CANDIDATE_LIMIT = 100;
 
@@ -109,7 +147,7 @@ async function fetchCandidateProducts(
       'id, title, merchant_id, price_cents, currency, rating, origin_country, origin_region, health_goals, ingredients_primary, dietary_tags, contains_allergens, contraindicated_with_conditions, contraindicated_with_medications, ships_to_countries, ships_to_regions, excluded_from_regions'
     )
     .eq('is_active', true)
-    .limit(PRODUCT_CANDIDATE_LIMIT);
+    .limit(getMarketplaceWeights().productCandidateLimit);
 
   // Narrow by mapping ingredients if available — via GIN-indexed ingredients_primary
   if (mapping?.recommended_ingredients.length) {
@@ -141,14 +179,19 @@ function scoreProduct(
 ): { score: number; reasons: Array<{ kind: string; text: string }> } {
   const reasons: Array<{ kind: string; text: string }> = [];
   let score = 0;
+  // VTID-03138 (Phase C.7): per-scoring-call snapshot.
+  const w = getMarketplaceWeights();
 
   // Ingredient-fit (0..0.5) — highest-rank-match wins
   if (mapping?.recommended_ingredients.length) {
     const productIngs = new Set(p.ingredients_primary.map((x) => x.toLowerCase()));
     for (const rec of mapping.recommended_ingredients) {
       if (productIngs.has(rec.ingredient.toLowerCase())) {
-        const rankBoost = Math.max(0, 0.5 - (rec.rank - 1) * 0.08);
-        const evidenceBoost = rec.evidence === 'strong' ? 1.0 : rec.evidence === 'moderate' ? 0.8 : 0.5;
+        const rankBoost = Math.max(0, w.ingredientRankBase - (rec.rank - 1) * w.ingredientRankDecay);
+        const evidenceBoost =
+          rec.evidence === 'strong' ? w.evidenceMultipliers.strong
+          : rec.evidence === 'moderate' ? w.evidenceMultipliers.moderate
+          : w.evidenceMultipliers.weak;
         score += rankBoost * evidenceBoost;
         reasons.push({
           kind: 'condition',
@@ -164,20 +207,20 @@ function scoreProduct(
     const hg = new Set(p.health_goals.map((g) => g.toLowerCase()));
     const match = mapping.recommended_health_goals.find((g) => hg.has(g.toLowerCase()));
     if (match) {
-      score += 0.2;
+      score += w.goalMatchBoost;
       reasons.push({ kind: 'goal', text: `Supports ${match}` });
     }
   }
 
   // Origin-proximity (0..0.15) — same-region gets the full boost
   if (userRegion && p.origin_region === userRegion) {
-    score += 0.15;
+    score += w.sameRegionBonus;
     reasons.push({ kind: 'origin', text: `Ships from ${p.origin_country ?? 'your region'}` });
   }
 
   // Rating (0..0.1)
   if (p.rating !== null && p.rating > 0) {
-    const ratingBoost = Math.max(0, Math.min(0.1, ((p.rating - 3) / 2) * 0.1));
+    const ratingBoost = Math.max(0, Math.min(w.ratingBoostCap, ((p.rating - 3) / 2) * w.ratingBoostCap));
     if (ratingBoost > 0.02) {
       score += ratingBoost;
       reasons.push({ kind: 'rating', text: `Rated ${p.rating.toFixed(1)}/5` });
@@ -186,7 +229,7 @@ function scoreProduct(
 
   // Penalty: past purchase (don't re-recommend)
   if (pastPurchaseIds.has(p.id)) {
-    score -= 1.0;
+    score += w.pastPurchasePenalty;
   }
 
   return { score: Math.max(0, Math.min(1, score)), reasons };
@@ -228,7 +271,7 @@ export async function analyzeMarketplaceForUser(
     })
     .filter((s) => s.score > 0.15)
     .sort((a, b) => b.score - a.score)
-    .slice(0, TOP_PICKS_PER_USER);
+    .slice(0, getMarketplaceWeights().topPicksPerUser);
 
   return scored.map((s) => ({
     user_id,
@@ -298,7 +341,7 @@ export async function analyzeMarketplace(opts: {
     summary: {
       users_analyzed: userIds.length,
       products_scored: productsScored,
-      top_picks_per_user: TOP_PICKS_PER_USER,
+      top_picks_per_user: getMarketplaceWeights().topPicksPerUser,
       duration_ms: duration,
     },
   };

--- a/services/gateway/test/services/decision-contract/marketplace-community-policies.test.ts
+++ b/services/gateway/test/services/decision-contract/marketplace-community-policies.test.ts
@@ -1,0 +1,136 @@
+// VTID-03138 — Phase C.7 + C.8 of the decision-contract refactor.
+//
+// Locks the contract for marketplace-analyzer + community-user-analyzer
+// threshold externalization. Source-level wire-up + behavioural
+// fallback/override tests for the most user-visible knobs.
+
+import * as fs from 'fs';
+import * as path from 'path';
+import {
+  detectCanonicalWeaknesses,
+  detectOnboardingStage,
+} from '../../../src/services/recommendation-engine/analyzers/community-user-analyzer';
+import {
+  configurePolicyResolverForTests,
+  __resetPolicyResolverForTests,
+} from '../../../src/services/decision-contract/policy-resolver';
+
+const NOW_ISO = new Date().toISOString();
+
+function seed(key: string, value: unknown) {
+  configurePolicyResolverForTests({
+    decisionPolicy: [
+      {
+        policy_key: key,
+        tenant_id: null,
+        version: 1,
+        value_json: value,
+        effective_from: NOW_ISO,
+        effective_until: null,
+      },
+    ],
+  });
+}
+
+describe('VTID-03138 Phase C.8 community-user-analyzer', () => {
+  afterEach(() => __resetPolicyResolverForTests());
+
+  describe('detectCanonicalWeaknesses — cold-cache fallback (threshold=80)', () => {
+    beforeEach(() => __resetPolicyResolverForTests());
+
+    it('pillar < 80 → flagged as weakness', () => {
+      const w = detectCanonicalWeaknesses({
+        nutrition: 75, hydration: 100, exercise: 100, sleep: 100, mental: 100,
+      } as any);
+      expect(w).toContain('nutrition_low');
+      expect(w).not.toContain('hydration_low');
+    });
+
+    it('pillar ≥ 80 + previous-drop ≥ 10 → flagged as declining', () => {
+      const w = detectCanonicalWeaknesses(
+        { nutrition: 85, hydration: 100, exercise: 100, sleep: 100, mental: 100 } as any,
+        { nutrition: 100, hydration: 100, exercise: 100, sleep: 100, mental: 100 } as any,
+      );
+      // 100 - 85 = 15 ≥ 10 → declining
+      expect(w).toContain('nutrition_low');
+    });
+
+    it('pillar ≥ 80 + previous-drop < 10 → not flagged', () => {
+      const w = detectCanonicalWeaknesses(
+        { nutrition: 95, hydration: 100, exercise: 100, sleep: 100, mental: 100 } as any,
+        { nutrition: 100, hydration: 100, exercise: 100, sleep: 100, mental: 100 } as any,
+      );
+      expect(w).not.toContain('nutrition_low');
+    });
+  });
+
+  describe('detectCanonicalWeaknesses — resolver override', () => {
+    it('seeded threshold=90 catches pillars 85-89 that fallback (80) would miss', () => {
+      seed('analyzer.community.pillar_weakness_threshold', 90);
+      const w = detectCanonicalWeaknesses({
+        nutrition: 85, hydration: 100, exercise: 100, sleep: 100, mental: 100,
+      } as any);
+      expect(w).toContain('nutrition_low');
+    });
+
+    it('seeded decline-drop=5 makes 5-point declines count', () => {
+      seed('analyzer.community.decline_trend_drop_points', 5);
+      const w = detectCanonicalWeaknesses(
+        { nutrition: 95, hydration: 100, exercise: 100, sleep: 100, mental: 100 } as any,
+        { nutrition: 100, hydration: 100, exercise: 100, sleep: 100, mental: 100 } as any,
+      );
+      expect(w).toContain('nutrition_low');
+    });
+  });
+
+  describe('detectOnboardingStage — cold-cache parity', () => {
+    beforeEach(() => __resetPolicyResolverForTests());
+
+    function dateAgo(days: number): Date {
+      return new Date(Date.now() - days * 86400000);
+    }
+
+    it('day0 / day1 / day3 / day7 / day14 / day30plus boundaries', () => {
+      expect(detectOnboardingStage(dateAgo(0))).toBe('day0');
+      expect(detectOnboardingStage(dateAgo(2))).toBe('day1');
+      expect(detectOnboardingStage(dateAgo(5))).toBe('day3');
+      expect(detectOnboardingStage(dateAgo(10))).toBe('day7');
+      expect(detectOnboardingStage(dateAgo(20))).toBe('day14');
+      expect(detectOnboardingStage(dateAgo(45))).toBe('day30plus');
+    });
+
+    it('seeded day14_after_days=21 stretches the day7 window', () => {
+      seed('analyzer.community.onboarding_stage.day14_after_days', 21);
+      expect(detectOnboardingStage(dateAgo(20))).toBe('day7'); // would be day14 under default
+    });
+  });
+});
+
+describe('VTID-03138 Phase C.7 marketplace-analyzer — source-level wire-up', () => {
+  const SRC = path.resolve(
+    __dirname,
+    '../../../src/services/recommendation-engine/analyzers/marketplace-analyzer.ts',
+  );
+  let src: string;
+  beforeAll(() => { src = fs.readFileSync(SRC, 'utf8'); });
+
+  it('imports POLICY_KEYS + getPolicyResolver', () => {
+    expect(src).toMatch(/getPolicyResolver/);
+    expect(src).toMatch(/POLICY_KEYS\./);
+  });
+
+  it('hot path uses getMarketplaceWeights() snapshot', () => {
+    expect(src).toMatch(/getMarketplaceWeights\(\)/);
+  });
+
+  it('scoring loop uses w.ingredientRankBase / w.evidenceMultipliers / w.goalMatchBoost', () => {
+    expect(src).toMatch(/w\.ingredientRankBase/);
+    expect(src).toMatch(/w\.evidenceMultipliers/);
+    expect(src).toMatch(/w\.goalMatchBoost/);
+  });
+
+  it('TOP_PICKS_PER_USER and PRODUCT_CANDIDATE_LIMIT call sites use accessor', () => {
+    expect(src).toMatch(/getMarketplaceWeights\(\)\.topPicksPerUser/);
+    expect(src).toMatch(/getMarketplaceWeights\(\)\.productCandidateLimit/);
+  });
+});

--- a/supabase/migrations/20260528100000_VTID_03138_marketplace_community_seeds.sql
+++ b/supabase/migrations/20260528100000_VTID_03138_marketplace_community_seeds.sql
@@ -1,0 +1,99 @@
+-- Phase C.7 + C.8 (decision-contract refactor) — marketplace + community analyzer seeds.
+--
+-- VTID-03138. Externalizes 16 literals across two ranker files:
+--   - marketplace-analyzer.ts: 9 weights (TOP_PICKS_PER_USER,
+--     PRODUCT_CANDIDATE_LIMIT, ingredient rank decay, evidence
+--     multipliers, goal-fit boost, region boost, rating boost cap,
+--     past-purchase penalty, confidence base)
+--   - community-user-analyzer.ts: 7 thresholds (PILLAR_WEAKNESS_THRESHOLD,
+--     decline-trend gate, 5 onboarding-stage day boundaries)
+--
+-- Idempotent. Values byte-identical to literals.
+
+-- =========================================================================
+-- C.7 marketplace-analyzer
+-- =========================================================================
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'ranker.marketplace.top_picks_per_user', NULL, 1, '5'::jsonb, 'seed',
+       'marketplace-analyzer.ts:74 (TOP_PICKS_PER_USER)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'ranker.marketplace.top_picks_per_user' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'ranker.marketplace.product_candidate_limit', NULL, 1, '100'::jsonb, 'seed',
+       'marketplace-analyzer.ts:75 (PRODUCT_CANDIDATE_LIMIT)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'ranker.marketplace.product_candidate_limit' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'ranker.marketplace.ingredient_rank_base', NULL, 1, '0.5'::jsonb, 'seed',
+       'marketplace-analyzer.ts:150 (rank-1 ingredient boost; formula 0.5 - (rank-1)*0.08)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'ranker.marketplace.ingredient_rank_base' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'ranker.marketplace.ingredient_rank_decay', NULL, 1, '0.08'::jsonb, 'seed',
+       'marketplace-analyzer.ts:150 (per-rank decay step)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'ranker.marketplace.ingredient_rank_decay' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'ranker.marketplace.evidence_multipliers', NULL, 1, '{"strong":1.0,"moderate":0.8,"weak":0.5}'::jsonb, 'seed',
+       'marketplace-analyzer.ts:151 (evidence band → multiplier)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'ranker.marketplace.evidence_multipliers' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'ranker.marketplace.goal_match_boost', NULL, 1, '0.2'::jsonb, 'seed',
+       'marketplace-analyzer.ts:167 (goal-fit boost)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'ranker.marketplace.goal_match_boost' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'ranker.marketplace.same_region_bonus', NULL, 1, '0.15'::jsonb, 'seed',
+       'marketplace-analyzer.ts:174 (same-region origin proximity)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'ranker.marketplace.same_region_bonus' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'ranker.marketplace.rating_boost_cap', NULL, 1, '0.1'::jsonb, 'seed',
+       'marketplace-analyzer.ts:180 (rating boost cap; formula (rating-3)/2 * 0.1)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'ranker.marketplace.rating_boost_cap' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'ranker.marketplace.past_purchase_penalty', NULL, 1, '-1.0'::jsonb, 'seed',
+       'marketplace-analyzer.ts:189 (don''t re-recommend past purchases)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'ranker.marketplace.past_purchase_penalty' AND tenant_id IS NULL AND version = 1);
+
+-- =========================================================================
+-- C.8 community-user-analyzer
+-- =========================================================================
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'analyzer.community.pillar_weakness_threshold', NULL, 1, '80'::jsonb, 'seed',
+       'community-user-analyzer.ts:53 (PILLAR_WEAKNESS_THRESHOLD — pillar < 80 → weakness flagged)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'analyzer.community.pillar_weakness_threshold' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'analyzer.community.decline_trend_drop_points', NULL, 1, '10'::jsonb, 'seed',
+       'community-user-analyzer.ts:71 (pillar dropped ≥10 points vs previous → declining)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'analyzer.community.decline_trend_drop_points' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'analyzer.community.onboarding_stage.day1_after_days', NULL, 1, '1'::jsonb, 'seed',
+       'community-user-analyzer.ts:505 (daysSinceCreation < 1 → day0)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'analyzer.community.onboarding_stage.day1_after_days' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'analyzer.community.onboarding_stage.day3_after_days', NULL, 1, '3'::jsonb, 'seed',
+       'community-user-analyzer.ts:506 (daysSinceCreation < 3 → day1)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'analyzer.community.onboarding_stage.day3_after_days' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'analyzer.community.onboarding_stage.day7_after_days', NULL, 1, '7'::jsonb, 'seed',
+       'community-user-analyzer.ts:507 (daysSinceCreation < 7 → day3)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'analyzer.community.onboarding_stage.day7_after_days' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'analyzer.community.onboarding_stage.day14_after_days', NULL, 1, '14'::jsonb, 'seed',
+       'community-user-analyzer.ts:508 (daysSinceCreation < 14 → day7)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'analyzer.community.onboarding_stage.day14_after_days' AND tenant_id IS NULL AND version = 1);
+
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'analyzer.community.onboarding_stage.day30plus_after_days', NULL, 1, '30'::jsonb, 'seed',
+       'community-user-analyzer.ts:509 (daysSinceCreation < 30 → day14; else day30plus)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'analyzer.community.onboarding_stage.day30plus_after_days' AND tenant_id IS NULL AND version = 1);


### PR DESCRIPTION
Batched C.7 (9 marketplace-analyzer keys) + C.8 (7 community-user-analyzer keys). 16-row seed migration; byte-identical fallbacks. 11 new tests across the two analyzers. 960/960 across 59 suites green.

🤖 Generated with [Claude Code](https://claude.com/claude-code)