### PR TITLE
feat(decision-contract): C.6 — signal→impact maps via PolicyResolver (VTID-03140)

### DIFF
--- a/services/gateway/src/services/decision-contract/policy-keys.ts
+++ b/services/gateway/src/services/decision-contract/policy-keys.ts
@@ -202,6 +202,23 @@ export const POLICY_KEYS = {
     'analyzer.community.onboarding_stage.day14_after_days',
   ANALYZER_COMMUNITY_STAGE_DAY30PLUS_AFTER_DAYS:
     'analyzer.community.onboarding_stage.day30plus_after_days',
+
+  // ---- Phase C.6 (VTID-03140) — signal→impact maps -------------
+  // Per-signal-type impact catalogues from `recommendation-generator.ts`.
+  // One JSONB row per signal_type. Shape:
+  //   { version: 1, impacts: { <signal_key>: { impact, weight, rationale } } }
+  // The `weight` field is reserved (currently 1 for every entry) — leaves
+  // room to introduce per-key fan-in weighting without another schema bump.
+  // Codebase/OASIS/health are categorical maps; LLM/marketplace/wearable
+  // encode the existing 3-tier ladders as named keys ('high'/'mid'/'low').
+  RECOMMENDATION_SIGNAL_IMPACT_CODEBASE: 'recommendation.signal_impact.codebase',
+  RECOMMENDATION_SIGNAL_IMPACT_OASIS: 'recommendation.signal_impact.oasis',
+  RECOMMENDATION_SIGNAL_IMPACT_HEALTH: 'recommendation.signal_impact.health',
+  RECOMMENDATION_SIGNAL_IMPACT_LLM: 'recommendation.signal_impact.llm',
+  RECOMMENDATION_SIGNAL_IMPACT_MARKETPLACE:
+    'recommendation.signal_impact.marketplace',
+  RECOMMENDATION_SIGNAL_IMPACT_WEARABLE:
+    'recommendation.signal_impact.wearable',
 } as const;
 
 export type PolicyKey = (typeof POLICY_KEYS)[keyof typeof POLICY_KEYS];

--- a/services/gateway/src/services/recommendation-engine/recommendation-generator.ts
+++ b/services/gateway/src/services/recommendation-engine/recommendation-generator.ts
@@ -65,6 +65,16 @@ import {
   WearableSignal,
   generateWearableFingerprint,
 } from './analyzers/wearable-analyzer';
+// VTID-03140 (Phase C.6): per-signal-type impact maps live in
+// `decision_policy` now; this module owns the typed lookups.
+import {
+  getCodebaseSignalImpact,
+  getOasisSignalImpact,
+  getHealthSignalImpact,
+  getLLMSignalImpact,
+  getMarketplaceSignalImpact,
+  getWearableSignalImpact,
+} from './signal-impact';
 
 const LOG_PREFIX = '[VTID-01185:Generator]';
 
@@ -172,14 +182,8 @@ function convertCodebaseSignal(signal: CodebaseSignal): GeneratedRecommendation 
     missing_docs: 'dev',
   };
 
-  const impactMap: Record<string, number> = {
-    todo: 5,
-    large_file: 6,
-    missing_tests: 7,
-    dead_code: 4,
-    duplication: 5,
-    missing_docs: 3,
-  };
+  // VTID-03140 (Phase C.6): impactMap moved to decision_policy
+  // (`recommendation.signal_impact.codebase`).
 
   const effortMap: Record<string, number> = {
     todo: 3,
@@ -200,7 +204,7 @@ function convertCodebaseSignal(signal: CodebaseSignal): GeneratedRecommendation 
     title: signal.suggested_action.substring(0, 100),
     summary: signal.message,
     domain: domainMap[signal.type] || 'dev',
-    impact_score: impactMap[signal.type] || 5,
+    impact_score: getCodebaseSignalImpact(signal.type),
     effort_score: effortMap[signal.type] || 5,
     risk_level: severityToRisk[signal.severity] || 'low',
     source_type: 'codebase',
@@ -221,19 +225,14 @@ function convertOasisSignal(signal: OasisSignal): GeneratedRecommendation {
     underused_feature: 'Review underused feature',
   };
 
-  const impactMap: Record<string, number> = {
-    error_pattern: 8,
-    slow_endpoint: 7,
-    failed_deploy: 9,
-    anomaly: 6,
-    underused_feature: 4,
-  };
+  // VTID-03140 (Phase C.6): impactMap moved to decision_policy
+  // (`recommendation.signal_impact.oasis`).
 
   return {
     title: `${typeToTitle[signal.type] || 'Address issue'}: ${signal.source.substring(0, 50)}`,
     summary: signal.message,
     domain: signal.type === 'failed_deploy' ? 'infra' : 'dev',
-    impact_score: impactMap[signal.type] || 6,
+    impact_score: getOasisSignalImpact(signal.type),
     effort_score: signal.type === 'slow_endpoint' ? 6 : 5,
     risk_level: signal.severity === 'critical' ? 'critical' : signal.severity as 'low' | 'medium' | 'high',
     source_type: 'oasis',
@@ -254,19 +253,14 @@ function convertHealthSignal(signal: HealthSignal): GeneratedRecommendation {
     stale_migration: 'Apply pending migration',
   };
 
-  const impactMap: Record<string, number> = {
-    missing_index: 7,
-    large_table: 6,
-    missing_rls: 9,
-    env_gap: 8,
-    stale_migration: 5,
-  };
+  // VTID-03140 (Phase C.6): impactMap moved to decision_policy
+  // (`recommendation.signal_impact.health`).
 
   return {
     title: `${typeToTitle[signal.type] || 'Fix issue'}: ${signal.resource}`,
     summary: signal.message,
     domain: signal.type === 'missing_rls' ? 'security' : 'infra',
-    impact_score: impactMap[signal.type] || 6,
+    impact_score: getHealthSignalImpact(signal.type),
     effort_score: signal.type === 'large_table' ? 8 : 4,
     risk_level: signal.severity === 'critical' ? 'critical' : signal.severity as 'low' | 'medium' | 'high',
     source_type: 'health',
@@ -300,7 +294,9 @@ function convertLLMSignal(signal: LLMSignal): GeneratedRecommendation {
     title: signal.title.substring(0, 100),
     summary: signal.message,
     domain: signal.type === 'security' ? 'security' : signal.type === 'architecture' ? 'infra' : 'dev',
-    impact_score: signal.confidence > 0.8 ? 8 : signal.confidence > 0.5 ? 6 : 4,
+    // VTID-03140 (Phase C.6): confidence ladder moved to decision_policy
+    // (`recommendation.signal_impact.llm`).
+    impact_score: getLLMSignalImpact(signal.confidence),
     effort_score: signal.type === 'architecture' ? 7 : 5,
     risk_level: signal.severity,
     source_type: 'llm',
@@ -313,7 +309,9 @@ function convertLLMSignal(signal: LLMSignal): GeneratedRecommendation {
 }
 
 function convertWearableSignal(signal: WearableSignal): GeneratedRecommendation {
-  const impact = signal.severity === 'high' ? 8 : signal.severity === 'medium' ? 6 : 4;
+  // VTID-03140 (Phase C.6): severity ladder moved to decision_policy
+  // (`recommendation.signal_impact.wearable`).
+  const impact = getWearableSignalImpact(signal.severity);
   return {
     title: signal.summary.substring(0, 100),
     summary: signal.summary,
@@ -345,7 +343,9 @@ function convertMarketplaceSignal(signal: MarketplaceSignal): GeneratedRecommend
     title: `Try: ${signal.product_title}${priceText}`.substring(0, 100),
     summary: `Recommended${conditionText}. ${reasonsText}`,
     domain: 'marketplace',
-    impact_score: signal.match_score > 0.7 ? 8 : signal.match_score > 0.5 ? 6 : 4,
+    // VTID-03140 (Phase C.6): match_score ladder moved to decision_policy
+    // (`recommendation.signal_impact.marketplace`).
+    impact_score: getMarketplaceSignalImpact(signal.match_score),
     effort_score: 2, // easy to act on — just review + click
     risk_level: signal.severity,
     source_type: 'marketplace',

--- a/services/gateway/src/services/recommendation-engine/signal-impact.ts
+++ b/services/gateway/src/services/recommendation-engine/signal-impact.ts
@@ -1,0 +1,194 @@
+// Phase C.6 (decision-contract refactor) — signal→impact accessor.
+//
+// VTID-03140. Per-signal-type impact catalogues are stored as one JSONB
+// row per signal_type in `decision_policy`. This module is the only place
+// that knows the JSONB shape; consumers go through the typed accessors
+// below and never touch the raw policy value.
+//
+// Why one row per signal_type (not (signal_type, signal_key) rows):
+//   - This is still a bounded map of constants. The user explicitly chose
+//     the JSONB shape as the right level of abstraction for "catalogue of
+//     facts". Per-key rows are reserved for the user-editable recommendation
+//     graph in a later phase.
+//   - Cache-coldness is byte-identical to the old literal maps because the
+//     fallback below mirrors the seed verbatim.
+
+import { getPolicyResolver } from '../decision-contract/policy-resolver';
+import { POLICY_KEYS } from '../decision-contract/policy-keys';
+
+// ---------------------------------------------------------------------------
+// JSONB shape
+// ---------------------------------------------------------------------------
+
+export interface SignalImpactEntry {
+  impact: number;
+  weight: number;
+  rationale: string;
+}
+
+export interface SignalImpactMap {
+  version: 1;
+  impacts: Record<string, SignalImpactEntry>;
+}
+
+// ---------------------------------------------------------------------------
+// Cold-cache fallback maps — byte-identical to the seed migration values.
+// These exist so that if PolicyResolver returns no rows (e.g. fresh
+// deploy before RUN-MIGRATION lands), behaviour matches the pre-refactor
+// literals exactly.
+// ---------------------------------------------------------------------------
+
+const CODEBASE_FALLBACK: SignalImpactMap = {
+  version: 1,
+  impacts: {
+    todo:          { impact: 5, weight: 1, rationale: 'Inline TODO — small but real follow-up' },
+    large_file:    { impact: 6, weight: 1, rationale: 'Refactor candidate — affects readability + diffability' },
+    missing_tests: { impact: 7, weight: 1, rationale: 'Quality + regression risk' },
+    dead_code:     { impact: 4, weight: 1, rationale: 'Cleanup, no functional gain' },
+    duplication:   { impact: 5, weight: 1, rationale: 'Maintenance + drift risk' },
+    missing_docs:  { impact: 3, weight: 1, rationale: 'Onboarding friction; lowest ranked' },
+  },
+};
+
+const OASIS_FALLBACK: SignalImpactMap = {
+  version: 1,
+  impacts: {
+    error_pattern:     { impact: 8, weight: 1, rationale: 'Recurring error — high user impact' },
+    slow_endpoint:     { impact: 7, weight: 1, rationale: 'Latency degrades UX' },
+    failed_deploy:     { impact: 9, weight: 1, rationale: 'Pipeline broken — blocks delivery' },
+    anomaly:           { impact: 6, weight: 1, rationale: 'Unexpected behaviour, investigate' },
+    underused_feature: { impact: 4, weight: 1, rationale: 'Adoption signal, not urgent' },
+  },
+};
+
+const HEALTH_FALLBACK: SignalImpactMap = {
+  version: 1,
+  impacts: {
+    missing_index:   { impact: 7, weight: 1, rationale: 'Performance hot-spot at scale' },
+    large_table:     { impact: 6, weight: 1, rationale: 'Archival/retention candidate' },
+    missing_rls:     { impact: 9, weight: 1, rationale: 'Security — tenant isolation gap' },
+    env_gap:         { impact: 8, weight: 1, rationale: 'Configuration drift, breaks features' },
+    stale_migration: { impact: 5, weight: 1, rationale: 'Schema lag, low blast radius' },
+  },
+};
+
+const LLM_FALLBACK: SignalImpactMap = {
+  version: 1,
+  impacts: {
+    high: { impact: 8, weight: 1, rationale: 'confidence > 0.8 — strong LLM judgement' },
+    mid:  { impact: 6, weight: 1, rationale: '0.5 < confidence ≤ 0.8 — qualified' },
+    low:  { impact: 4, weight: 1, rationale: 'confidence ≤ 0.5 — speculative' },
+  },
+};
+
+const MARKETPLACE_FALLBACK: SignalImpactMap = {
+  version: 1,
+  impacts: {
+    high: { impact: 8, weight: 1, rationale: 'match_score > 0.7 — strong fit' },
+    mid:  { impact: 6, weight: 1, rationale: '0.5 < match_score ≤ 0.7 — qualified' },
+    low:  { impact: 4, weight: 1, rationale: 'match_score ≤ 0.5 — exploratory' },
+  },
+};
+
+const WEARABLE_FALLBACK: SignalImpactMap = {
+  version: 1,
+  impacts: {
+    high:   { impact: 8, weight: 1, rationale: 'Clinical concern — flag prominently' },
+    medium: { impact: 6, weight: 1, rationale: 'Notable variance — surface' },
+    low:    { impact: 4, weight: 1, rationale: 'Routine trend information' },
+  },
+};
+
+// ---------------------------------------------------------------------------
+// Resolver
+// ---------------------------------------------------------------------------
+
+type SignalType =
+  | 'codebase'
+  | 'oasis'
+  | 'health'
+  | 'llm'
+  | 'marketplace'
+  | 'wearable';
+
+const POLICY_KEY_BY_SIGNAL_TYPE: Record<SignalType, string> = {
+  codebase:    POLICY_KEYS.RECOMMENDATION_SIGNAL_IMPACT_CODEBASE,
+  oasis:       POLICY_KEYS.RECOMMENDATION_SIGNAL_IMPACT_OASIS,
+  health:      POLICY_KEYS.RECOMMENDATION_SIGNAL_IMPACT_HEALTH,
+  llm:         POLICY_KEYS.RECOMMENDATION_SIGNAL_IMPACT_LLM,
+  marketplace: POLICY_KEYS.RECOMMENDATION_SIGNAL_IMPACT_MARKETPLACE,
+  wearable:    POLICY_KEYS.RECOMMENDATION_SIGNAL_IMPACT_WEARABLE,
+};
+
+const FALLBACK_BY_SIGNAL_TYPE: Record<SignalType, SignalImpactMap> = {
+  codebase:    CODEBASE_FALLBACK,
+  oasis:       OASIS_FALLBACK,
+  health:      HEALTH_FALLBACK,
+  llm:         LLM_FALLBACK,
+  marketplace: MARKETPLACE_FALLBACK,
+  wearable:    WEARABLE_FALLBACK,
+};
+
+function getSignalImpactMap(signalType: SignalType): SignalImpactMap {
+  const fallback = FALLBACK_BY_SIGNAL_TYPE[signalType];
+  const fromPolicy = getPolicyResolver().getValue<SignalImpactMap>(
+    POLICY_KEY_BY_SIGNAL_TYPE[signalType],
+    { defaultValue: fallback },
+  );
+  // Light shape guard: if the row is missing impacts or wrong version,
+  // fall back. This is cheap and prevents a malformed override from
+  // crashing recommendation generation.
+  if (
+    !fromPolicy ||
+    fromPolicy.version !== 1 ||
+    !fromPolicy.impacts ||
+    typeof fromPolicy.impacts !== 'object'
+  ) {
+    return fallback;
+  }
+  return fromPolicy;
+}
+
+function lookupImpact(
+  map: SignalImpactMap,
+  key: string,
+  defaultImpact: number,
+): number {
+  const entry = map.impacts[key];
+  if (entry && typeof entry.impact === 'number') return entry.impact;
+  return defaultImpact;
+}
+
+// ---------------------------------------------------------------------------
+// Per-signal-type accessors (called by recommendation-generator.ts)
+// ---------------------------------------------------------------------------
+
+export function getCodebaseSignalImpact(type: string): number {
+  return lookupImpact(getSignalImpactMap('codebase'), type, 5);
+}
+
+export function getOasisSignalImpact(type: string): number {
+  return lookupImpact(getSignalImpactMap('oasis'), type, 6);
+}
+
+export function getHealthSignalImpact(type: string): number {
+  return lookupImpact(getSignalImpactMap('health'), type, 6);
+}
+
+export function getLLMSignalImpact(confidence: number): number {
+  const map = getSignalImpactMap('llm');
+  const tier = confidence > 0.8 ? 'high' : confidence > 0.5 ? 'mid' : 'low';
+  return lookupImpact(map, tier, 4);
+}
+
+export function getMarketplaceSignalImpact(matchScore: number): number {
+  const map = getSignalImpactMap('marketplace');
+  const tier = matchScore > 0.7 ? 'high' : matchScore > 0.5 ? 'mid' : 'low';
+  return lookupImpact(map, tier, 4);
+}
+
+export function getWearableSignalImpact(
+  severity: 'high' | 'medium' | 'low',
+): number {
+  return lookupImpact(getSignalImpactMap('wearable'), severity, 4);
+}

--- a/services/gateway/test/services/decision-contract/signal-impact.test.ts
+++ b/services/gateway/test/services/decision-contract/signal-impact.test.ts
@@ -1,0 +1,202 @@
+// VTID-03140 — Phase C.6 of the decision-contract refactor.
+//
+// Locks the contract for the 6 per-signal-type impact catalogues.
+// Behavioural fallback (cold cache) + resolver override (seeded row).
+
+import {
+  configurePolicyResolverForTests,
+  __resetPolicyResolverForTests,
+} from '../../../src/services/decision-contract/policy-resolver';
+import {
+  getCodebaseSignalImpact,
+  getOasisSignalImpact,
+  getHealthSignalImpact,
+  getLLMSignalImpact,
+  getMarketplaceSignalImpact,
+  getWearableSignalImpact,
+} from '../../../src/services/recommendation-engine/signal-impact';
+
+const NOW_ISO = new Date().toISOString();
+
+function seedSignalImpact(key: string, payload: unknown) {
+  configurePolicyResolverForTests({
+    decisionPolicy: [
+      {
+        policy_key: key,
+        tenant_id: null,
+        version: 1,
+        value_json: payload,
+        effective_from: NOW_ISO,
+        effective_until: null,
+      },
+    ],
+  });
+}
+
+describe('VTID-03140 Phase C.6 signal-impact accessors', () => {
+  afterEach(() => __resetPolicyResolverForTests());
+
+  // -----------------------------------------------------------------
+  // Cold-cache fallback parity — every value must match the literal it
+  // replaces. If any of these change, callers will see different scores.
+  // -----------------------------------------------------------------
+  describe('cold-cache fallback parity', () => {
+    beforeEach(() => __resetPolicyResolverForTests());
+
+    it('codebase impacts match pre-refactor literals', () => {
+      expect(getCodebaseSignalImpact('todo')).toBe(5);
+      expect(getCodebaseSignalImpact('large_file')).toBe(6);
+      expect(getCodebaseSignalImpact('missing_tests')).toBe(7);
+      expect(getCodebaseSignalImpact('dead_code')).toBe(4);
+      expect(getCodebaseSignalImpact('duplication')).toBe(5);
+      expect(getCodebaseSignalImpact('missing_docs')).toBe(3);
+    });
+
+    it('codebase unknown key → fallback 5', () => {
+      expect(getCodebaseSignalImpact('totally-new-kind')).toBe(5);
+    });
+
+    it('oasis impacts match pre-refactor literals', () => {
+      expect(getOasisSignalImpact('error_pattern')).toBe(8);
+      expect(getOasisSignalImpact('slow_endpoint')).toBe(7);
+      expect(getOasisSignalImpact('failed_deploy')).toBe(9);
+      expect(getOasisSignalImpact('anomaly')).toBe(6);
+      expect(getOasisSignalImpact('underused_feature')).toBe(4);
+    });
+
+    it('oasis unknown key → fallback 6', () => {
+      expect(getOasisSignalImpact('totally-new-kind')).toBe(6);
+    });
+
+    it('health impacts match pre-refactor literals', () => {
+      expect(getHealthSignalImpact('missing_index')).toBe(7);
+      expect(getHealthSignalImpact('large_table')).toBe(6);
+      expect(getHealthSignalImpact('missing_rls')).toBe(9);
+      expect(getHealthSignalImpact('env_gap')).toBe(8);
+      expect(getHealthSignalImpact('stale_migration')).toBe(5);
+    });
+
+    it('health unknown key → fallback 6', () => {
+      expect(getHealthSignalImpact('totally-new-kind')).toBe(6);
+    });
+
+    it('LLM ladder boundaries match `>0.8 ? 8 : >0.5 ? 6 : 4`', () => {
+      expect(getLLMSignalImpact(0.9)).toBe(8);
+      expect(getLLMSignalImpact(0.81)).toBe(8);
+      expect(getLLMSignalImpact(0.8)).toBe(6); // strictly greater
+      expect(getLLMSignalImpact(0.6)).toBe(6);
+      expect(getLLMSignalImpact(0.51)).toBe(6);
+      expect(getLLMSignalImpact(0.5)).toBe(4); // strictly greater
+      expect(getLLMSignalImpact(0.3)).toBe(4);
+      expect(getLLMSignalImpact(0)).toBe(4);
+    });
+
+    it('marketplace ladder boundaries match `>0.7 ? 8 : >0.5 ? 6 : 4`', () => {
+      expect(getMarketplaceSignalImpact(0.9)).toBe(8);
+      expect(getMarketplaceSignalImpact(0.71)).toBe(8);
+      expect(getMarketplaceSignalImpact(0.7)).toBe(6);
+      expect(getMarketplaceSignalImpact(0.6)).toBe(6);
+      expect(getMarketplaceSignalImpact(0.51)).toBe(6);
+      expect(getMarketplaceSignalImpact(0.5)).toBe(4);
+      expect(getMarketplaceSignalImpact(0.1)).toBe(4);
+    });
+
+    it('wearable severity ladder matches `high→8, medium→6, low→4`', () => {
+      expect(getWearableSignalImpact('high')).toBe(8);
+      expect(getWearableSignalImpact('medium')).toBe(6);
+      expect(getWearableSignalImpact('low')).toBe(4);
+    });
+  });
+
+  // -----------------------------------------------------------------
+  // Resolver overrides — seed a row, value flows through.
+  // -----------------------------------------------------------------
+  describe('resolver override', () => {
+    it('seeded codebase row overrides built-in fallback', () => {
+      seedSignalImpact('recommendation.signal_impact.codebase', {
+        version: 1,
+        impacts: {
+          todo: { impact: 99, weight: 1, rationale: 'test bump' },
+          missing_docs: { impact: 9, weight: 1, rationale: 'test bump' },
+        },
+      });
+      expect(getCodebaseSignalImpact('todo')).toBe(99);
+      expect(getCodebaseSignalImpact('missing_docs')).toBe(9);
+      // Missing keys fall through to the per-key default (5 for codebase)
+      // because the override row's `impacts` is sparse.
+      expect(getCodebaseSignalImpact('missing_tests')).toBe(5);
+    });
+
+    it('seeded LLM ladder overrides built-in tiers', () => {
+      seedSignalImpact('recommendation.signal_impact.llm', {
+        version: 1,
+        impacts: {
+          high: { impact: 10, weight: 1, rationale: 'test' },
+          mid:  { impact: 7,  weight: 1, rationale: 'test' },
+          low:  { impact: 1,  weight: 1, rationale: 'test' },
+        },
+      });
+      expect(getLLMSignalImpact(0.9)).toBe(10);
+      expect(getLLMSignalImpact(0.6)).toBe(7);
+      expect(getLLMSignalImpact(0.2)).toBe(1);
+    });
+
+    it('seeded marketplace ladder overrides built-in tiers', () => {
+      seedSignalImpact('recommendation.signal_impact.marketplace', {
+        version: 1,
+        impacts: {
+          high: { impact: 10, weight: 1, rationale: 'test' },
+          mid:  { impact: 5,  weight: 1, rationale: 'test' },
+          low:  { impact: 1,  weight: 1, rationale: 'test' },
+        },
+      });
+      expect(getMarketplaceSignalImpact(0.9)).toBe(10);
+      expect(getMarketplaceSignalImpact(0.6)).toBe(5);
+      expect(getMarketplaceSignalImpact(0.2)).toBe(1);
+    });
+
+    it('seeded wearable ladder overrides built-in tiers', () => {
+      seedSignalImpact('recommendation.signal_impact.wearable', {
+        version: 1,
+        impacts: {
+          high:   { impact: 10, weight: 1, rationale: 'test' },
+          medium: { impact: 5,  weight: 1, rationale: 'test' },
+          low:    { impact: 1,  weight: 1, rationale: 'test' },
+        },
+      });
+      expect(getWearableSignalImpact('high')).toBe(10);
+      expect(getWearableSignalImpact('medium')).toBe(5);
+      expect(getWearableSignalImpact('low')).toBe(1);
+    });
+  });
+
+  // -----------------------------------------------------------------
+  // Defensive shape guards — a malformed override must not crash
+  // recommendation generation. Fall back to literals instead.
+  // -----------------------------------------------------------------
+  describe('malformed-policy defensive guard', () => {
+    it('row missing impacts → falls back', () => {
+      seedSignalImpact('recommendation.signal_impact.codebase', {
+        version: 1,
+      });
+      expect(getCodebaseSignalImpact('missing_tests')).toBe(7);
+    });
+
+    it('row with wrong version → falls back', () => {
+      seedSignalImpact('recommendation.signal_impact.codebase', {
+        version: 2,
+        impacts: { missing_tests: { impact: 99, weight: 1, rationale: 'x' } },
+      });
+      expect(getCodebaseSignalImpact('missing_tests')).toBe(7);
+    });
+
+    it('row with impacts entry missing impact field → per-key default', () => {
+      seedSignalImpact('recommendation.signal_impact.health', {
+        version: 1,
+        impacts: { missing_index: { rationale: 'broken' } as never },
+      });
+      // missing_index entry exists but has no `impact` number → fallback default (6)
+      expect(getHealthSignalImpact('missing_index')).toBe(6);
+    });
+  });
+});

--- a/supabase/migrations/20260528110000_VTID_03140_signal_impact_maps_seeds.sql
+++ b/supabase/migrations/20260528110000_VTID_03140_signal_impact_maps_seeds.sql
@@ -1,0 +1,128 @@
+-- Phase C.6 (decision-contract refactor) — signal→impact maps.
+--
+-- VTID-03140. Externalizes the 6 hardcoded impactMap tables (codebase,
+-- OASIS, health, LLM, marketplace, wearable) in
+-- `services/gateway/src/services/recommendation-engine/recommendation-generator.ts`.
+--
+-- One JSONB row per signal_type. The user-approved schema is:
+--   {
+--     "version": 1,
+--     "impacts": {
+--       "<signal_key>": { "impact": <int>, "weight": <int>, "rationale": "..." }
+--     }
+--   }
+--
+-- Categorical maps (codebase / OASIS / health) use the raw signal.type as
+-- the key. Ladder maps (LLM / marketplace / wearable) encode the existing
+-- 3-tier ladder as named keys 'high' / 'mid' / 'low'; the runtime accessor
+-- picks the right bucket. Values byte-identical to the literals they
+-- replace. Idempotent.
+
+-- =========================================================================
+-- C.6.a — codebase signal impact map
+-- =========================================================================
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'recommendation.signal_impact.codebase', NULL, 1,
+       '{
+         "version": 1,
+         "impacts": {
+           "todo":          { "impact": 5, "weight": 1, "rationale": "Inline TODO — small but real follow-up" },
+           "large_file":    { "impact": 6, "weight": 1, "rationale": "Refactor candidate — affects readability + diffability" },
+           "missing_tests": { "impact": 7, "weight": 1, "rationale": "Quality + regression risk" },
+           "dead_code":     { "impact": 4, "weight": 1, "rationale": "Cleanup, no functional gain" },
+           "duplication":   { "impact": 5, "weight": 1, "rationale": "Maintenance + drift risk" },
+           "missing_docs":  { "impact": 3, "weight": 1, "rationale": "Onboarding friction; lowest ranked" }
+         }
+       }'::jsonb,
+       'seed', 'recommendation-generator.ts:175-182 (convertCodebaseSignal impactMap)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'recommendation.signal_impact.codebase' AND tenant_id IS NULL AND version = 1);
+
+-- =========================================================================
+-- C.6.b — OASIS signal impact map
+-- =========================================================================
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'recommendation.signal_impact.oasis', NULL, 1,
+       '{
+         "version": 1,
+         "impacts": {
+           "error_pattern":      { "impact": 8, "weight": 1, "rationale": "Recurring error — high user impact" },
+           "slow_endpoint":      { "impact": 7, "weight": 1, "rationale": "Latency degrades UX" },
+           "failed_deploy":      { "impact": 9, "weight": 1, "rationale": "Pipeline broken — blocks delivery" },
+           "anomaly":            { "impact": 6, "weight": 1, "rationale": "Unexpected behaviour, investigate" },
+           "underused_feature":  { "impact": 4, "weight": 1, "rationale": "Adoption signal, not urgent" }
+         }
+       }'::jsonb,
+       'seed', 'recommendation-generator.ts:224-230 (convertOasisSignal impactMap)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'recommendation.signal_impact.oasis' AND tenant_id IS NULL AND version = 1);
+
+-- =========================================================================
+-- C.6.c — health signal impact map
+-- =========================================================================
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'recommendation.signal_impact.health', NULL, 1,
+       '{
+         "version": 1,
+         "impacts": {
+           "missing_index":   { "impact": 7, "weight": 1, "rationale": "Performance hot-spot at scale" },
+           "large_table":     { "impact": 6, "weight": 1, "rationale": "Archival/retention candidate" },
+           "missing_rls":     { "impact": 9, "weight": 1, "rationale": "Security — tenant isolation gap" },
+           "env_gap":         { "impact": 8, "weight": 1, "rationale": "Configuration drift, breaks features" },
+           "stale_migration": { "impact": 5, "weight": 1, "rationale": "Schema lag, low blast radius" }
+         }
+       }'::jsonb,
+       'seed', 'recommendation-generator.ts:257-263 (convertHealthSignal impactMap)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'recommendation.signal_impact.health' AND tenant_id IS NULL AND version = 1);
+
+-- =========================================================================
+-- C.6.d — LLM signal impact ladder (confidence-tiered)
+-- Source code: `signal.confidence > 0.8 ? 8 : signal.confidence > 0.5 ? 6 : 4`
+-- Keys: high (>0.8) / mid (>0.5) / low (else)
+-- =========================================================================
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'recommendation.signal_impact.llm', NULL, 1,
+       '{
+         "version": 1,
+         "impacts": {
+           "high": { "impact": 8, "weight": 1, "rationale": "confidence > 0.8 — strong LLM judgement" },
+           "mid":  { "impact": 6, "weight": 1, "rationale": "0.5 < confidence ≤ 0.8 — qualified" },
+           "low":  { "impact": 4, "weight": 1, "rationale": "confidence ≤ 0.5 — speculative" }
+         }
+       }'::jsonb,
+       'seed', 'recommendation-generator.ts:303 (convertLLMSignal confidence ladder)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'recommendation.signal_impact.llm' AND tenant_id IS NULL AND version = 1);
+
+-- =========================================================================
+-- C.6.e — marketplace signal impact ladder (match_score-tiered)
+-- Source code: `signal.match_score > 0.7 ? 8 : signal.match_score > 0.5 ? 6 : 4`
+-- Keys: high (>0.7) / mid (>0.5) / low (else)
+-- =========================================================================
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'recommendation.signal_impact.marketplace', NULL, 1,
+       '{
+         "version": 1,
+         "impacts": {
+           "high": { "impact": 8, "weight": 1, "rationale": "match_score > 0.7 — strong fit" },
+           "mid":  { "impact": 6, "weight": 1, "rationale": "0.5 < match_score ≤ 0.7 — qualified" },
+           "low":  { "impact": 4, "weight": 1, "rationale": "match_score ≤ 0.5 — exploratory" }
+         }
+       }'::jsonb,
+       'seed', 'recommendation-generator.ts:348 (convertMarketplaceSignal match_score ladder)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'recommendation.signal_impact.marketplace' AND tenant_id IS NULL AND version = 1);
+
+-- =========================================================================
+-- C.6.f — wearable signal impact ladder (severity-tiered)
+-- Source code: `severity === 'high' ? 8 : severity === 'medium' ? 6 : 4`
+-- Keys map directly to severity strings.
+-- =========================================================================
+INSERT INTO decision_policy (policy_key, tenant_id, version, value_json, source, notes)
+SELECT 'recommendation.signal_impact.wearable', NULL, 1,
+       '{
+         "version": 1,
+         "impacts": {
+           "high":   { "impact": 8, "weight": 1, "rationale": "Clinical concern — flag prominently" },
+           "medium": { "impact": 6, "weight": 1, "rationale": "Notable variance — surface" },
+           "low":    { "impact": 4, "weight": 1, "rationale": "Routine trend information" }
+         }
+       }'::jsonb,
+       'seed', 'recommendation-generator.ts:316 (convertWearableSignal severity ladder)'
+WHERE NOT EXISTS (SELECT 1 FROM decision_policy WHERE policy_key = 'recommendation.signal_impact.wearable' AND tenant_id IS NULL AND version = 1);


### PR DESCRIPTION
## Summary

Phase C.6 of the decision-contract refactor. Externalizes the 6 hardcoded `impactMap` tables in `recommendation-generator.ts` (codebase, OASIS, health, LLM, marketplace, wearable) into versioned, tenant-aware `decision_policy` rows.

## Schema (user-approved)

One JSONB row per signal_type, shape:

```jsonc
{
  "version": 1,
  "impacts": {
    "<signal_key>": { "impact": <int>, "weight": <int>, "rationale": "…" }
  }
}
```

Why one row per signal_type (not per `(signal_type, signal_key)`): this is still a bounded catalogue of constants. JSONB is the right granularity for a fact catalogue; per-key rows are reserved for the future user-editable recommendation graph.

## What landed

- 6 new keys in `POLICY_KEYS` (`recommendation.signal_impact.<type>`)
- New `services/gateway/src/services/recommendation-engine/signal-impact.ts`: typed `SignalImpactMap` shape, 6 accessors, per-type cold-cache fallbacks byte-identical to seed values, plus a defensive shape guard (missing impacts, wrong version, missing impact field → fallback)
- `recommendation-generator.ts`: 6 call sites swap inline impactMap / confidence/match-score/severity ladders for accessor calls. Effort + domain maps stay inline (not in C.6 scope)
- Categorical maps (codebase / OASIS / health) use `signal.type` as the key
- Ladder maps (LLM / marketplace / wearable) encode the existing 3-tier ladder as named keys `high` / `mid` / `low`

## Migration

`supabase/migrations/20260528110000_VTID_03140_signal_impact_maps_seeds.sql` — 6 idempotent `WHERE NOT EXISTS` inserts, `tenant_id` NULL, `version` 1, values byte-identical to the pre-refactor literals.

## Tests

16 new in `test/services/decision-contract/signal-impact.test.ts`. 128/128 decision-contract suite green.

## Test plan

- [x] `npm run build` clean
- [x] `npx jest test/services/decision-contract/` 128 pass
- [ ] RUN-MIGRATION applies 20260528110000_VTID_03140 idempotently
- [ ] EXEC-DEPLOY green + `/alive` 200 JSON
- [ ] Autopilot live smoke confirms `impact_score` flows from the seeded catalogue

🤖 Generated with [Claude Code](https://claude.com/claude-code)