### PR TITLE
feat(decision-contract): C.3.b — per-feedback-path provenance (VTID-03141)

### DIFF
--- a/services/gateway/src/services/decision-contract/strategies/pillar-weighter.ts
+++ b/services/gateway/src/services/decision-contract/strategies/pillar-weighter.ts
@@ -25,6 +25,7 @@ import {
   scoreRec,
   rankBatch,
   DEFAULT_RANKER_CONFIG,
+  type FeedbackBreakdown,
   type RankerConfig,
   type RankerContext,
   type RankInputRec,
@@ -38,7 +39,76 @@ import type {
 } from '../strategy';
 
 export const PILLAR_WEIGHTER_STRATEGY_ID = 'pillar_weighter_v1';
-export const PILLAR_WEIGHTER_STRATEGY_VERSION = 1;
+// Phase C.3.b (VTID-03141): bumped from 1 → 2. feedback_mult composite
+// component is replaced by per-path `feedback_completion` /
+// `feedback_plan` / `feedback_reinforcement` / `feedback_rejection`
+// components. Historical v1 traces remain valid and interpretable.
+export const PILLAR_WEIGHTER_STRATEGY_VERSION = 2;
+
+/**
+ * Build the per-feedback-path provenance components for one ranked rec.
+ * Each path that fired in `scoreRec` (encoded in `r.feedback_breakdown`)
+ * becomes one top-level component using one of the 4 new union arms.
+ * Paths that did not fire emit nothing.
+ *
+ * VTID-03141 (C.3.b): replaces the single fused `feedback_mult`
+ * multiplier the v1 strategy emitted.
+ */
+function buildFeedbackComponents<T extends RankInputRec>(
+  rec: T,
+  ctx: RankerContext,
+  cfg: RankerConfig,
+  bd: FeedbackBreakdown,
+): RankProvenanceComponent[] {
+  const out: RankProvenanceComponent[] = [];
+  if (bd.completion !== undefined) {
+    out.push({
+      kind: 'feedback_completion',
+      weight_key: POLICY_KEYS.RANKER_PILLAR_COMPLETION_DAMPENER,
+      weight_value: cfg.completion_dampener,
+      contribution_multiplier: bd.completion,
+    });
+  }
+  if (bd.plan !== undefined) {
+    out.push({
+      kind: 'feedback_plan',
+      weight_key: POLICY_KEYS.RANKER_PILLAR_PLAN_DAMPENER,
+      weight_value: cfg.plan_dampener,
+      contribution_multiplier: bd.plan,
+    });
+  }
+  if (bd.community !== undefined) {
+    out.push({
+      kind: 'feedback_reinforcement',
+      path: 'community',
+      weight_key: POLICY_KEYS.RANKER_PILLAR_COMMUNITY_MOMENTUM_BOOST,
+      weight_value: cfg.community_momentum_boost,
+      contribution_multiplier: bd.community,
+    });
+  }
+  if (bd.streak !== undefined) {
+    out.push({
+      kind: 'feedback_reinforcement',
+      path: 'streak',
+      weight_key: POLICY_KEYS.RANKER_PILLAR_STREAK_REINFORCEMENT,
+      weight_value: cfg.streak_reinforcement,
+      contribution_multiplier: bd.streak,
+    });
+  }
+  if (bd.rejection !== undefined) {
+    const rate = rec.domain
+      ? ctx.rejection_rate_by_domain[rec.domain] ?? 0
+      : 0;
+    out.push({
+      kind: 'feedback_rejection',
+      weight_key: POLICY_KEYS.RANKER_PILLAR_REJECTION_DAMPENER_ALPHA,
+      weight_value: cfg.rejection_dampener_alpha,
+      rejection_rate: rate,
+      contribution_multiplier: bd.rejection,
+    });
+  }
+  return out;
+}
 
 /**
  * Build a `RankerConfig` populated from PolicyResolver, with the
@@ -110,16 +180,6 @@ export function scoreRecWithProvenance<T extends RankInputRec>(
   const journeyComplement = 1 - ranked.journey_mode;
   const pillarAdditive = cfg.alpha_pillar * ranked.pillar_boost * journeyComplement;
 
-  // feedback_mult — recovered as a single multiplier from the
-  // post-formula identity rank_score = base × (1 + α·pb·(1−jm))
-  //                                       × compass × econ × feedback_mult
-  const denom =
-    base *
-    (1 + pillarAdditive) *
-    ranked.compass_boost *
-    ranked.economic_boost;
-  const feedback_mult = denom > 0 ? ranked.rank_score / denom : 1;
-
   const components: RankProvenanceComponent[] = [
     { kind: 'base', value: base },
     {
@@ -149,16 +209,11 @@ export function scoreRecWithProvenance<T extends RankInputRec>(
       applied: ranked.economic_boost > 1,
       contribution_multiplier: ranked.economic_boost,
     },
-    {
-      kind: 'multiplier',
-      name: 'feedback_mult',
-      // Composite of completion / plan / community / streak dampeners + rejection
-      // suppression. C.3.b will break this into per-path components.
-      weight_key: 'ranker.pillar_weighter.feedback_composite',
-      weight_value: feedback_mult,
-      applied: feedback_mult !== 1,
-      contribution_multiplier: feedback_mult,
-    },
+    // Phase C.3.b (VTID-03141): per-path feedback components. Each path
+    // that fired in scoreRec emits one component using the 4 new union
+    // arms (feedback_completion / feedback_plan / feedback_reinforcement
+    // / feedback_rejection). Paths that did not fire emit nothing.
+    ...buildFeedbackComponents(rec, ctx, cfg, ranked.feedback_breakdown),
   ];
 
   const provenance: RankProvenance = {
@@ -192,8 +247,6 @@ export function rankBatchWithProvenance<T extends RankInputRec>(
     const base = Number(r.rec.impact_score ?? 5);
     const journeyComplement = 1 - r.journey_mode;
     const pillarAdditive = cfg.alpha_pillar * r.pillar_boost * journeyComplement;
-    const denom = base * (1 + pillarAdditive) * r.compass_boost * r.economic_boost;
-    const feedback_mult = denom > 0 ? r.rank_score / denom : 1;
     const components: RankProvenanceComponent[] = [
       { kind: 'base', value: base },
       {
@@ -220,14 +273,8 @@ export function rankBatchWithProvenance<T extends RankInputRec>(
         applied: r.economic_boost > 1,
         contribution_multiplier: r.economic_boost,
       },
-      {
-        kind: 'multiplier',
-        name: 'feedback_mult',
-        weight_key: 'ranker.pillar_weighter.feedback_composite',
-        weight_value: feedback_mult,
-        applied: feedback_mult !== 1,
-        contribution_multiplier: feedback_mult,
-      },
+      // Phase C.3.b (VTID-03141): per-path feedback components.
+      ...buildFeedbackComponents(r.rec, ctx, cfg, r.feedback_breakdown),
     ];
     const provenance: RankProvenance = {
       strategy_id: PILLAR_WEIGHTER_STRATEGY_ID,

--- a/services/gateway/src/services/decision-contract/strategy.ts
+++ b/services/gateway/src/services/decision-contract/strategy.ts
@@ -50,6 +50,39 @@ export type RankProvenanceComponent =
       readonly before: number;
       readonly after: number;
       readonly reason: string;
+    }
+  // Phase C.3.b (VTID-03141): four new flat kinds covering the feedback
+  // paths previously fused into a single `feedback_mult` multiplier.
+  // Composite_decomposition is explicitly NOT used — each path that fires
+  // emits its own top-level component. `feedback_reinforcement` carries a
+  // `path` field that distinguishes the two positive-reinforcement
+  // sub-paths (community-momentum + start_streak) which share the
+  // `completions_7d ≥ 3` trigger.
+  | {
+      readonly kind: 'feedback_completion';
+      readonly weight_key: string;
+      readonly weight_value: number;
+      readonly contribution_multiplier: number;
+    }
+  | {
+      readonly kind: 'feedback_plan';
+      readonly weight_key: string;
+      readonly weight_value: number;
+      readonly contribution_multiplier: number;
+    }
+  | {
+      readonly kind: 'feedback_reinforcement';
+      readonly path: 'community' | 'streak';
+      readonly weight_key: string;
+      readonly weight_value: number;
+      readonly contribution_multiplier: number;
+    }
+  | {
+      readonly kind: 'feedback_rejection';
+      readonly weight_key: string;
+      readonly weight_value: number;
+      readonly rejection_rate: number;
+      readonly contribution_multiplier: number;
     };
 
 export interface RankProvenance {

--- a/services/gateway/src/services/recommendation-engine/ranking/index-pillar-weighter.ts
+++ b/services/gateway/src/services/recommendation-engine/ranking/index-pillar-weighter.ts
@@ -57,6 +57,21 @@ export interface RankInputRec {
   economic_axis?: EconomicAxis | string | null;
 }
 
+// Phase C.3.b (VTID-03141): structured per-path breakdown of the
+// `feedback_mult` composite. Each field is the multiplicative factor
+// the path contributed (e.g. 0.3 for a fired completion dampener, 1.2
+// for a fired community-momentum boost). A field is `undefined` when
+// the path did not fire. Used by PillarWeighterStrategy to emit one
+// `feedback_*` provenance component per fired path instead of a single
+// fused `feedback_mult` multiplier.
+export interface FeedbackBreakdown {
+  completion?: number;
+  plan?: number;
+  community?: number;
+  streak?: number;
+  rejection?: number;
+}
+
 export interface RankedRec<T extends RankInputRec = RankInputRec> {
   rec: T;
   rank_score: number;
@@ -64,6 +79,7 @@ export interface RankedRec<T extends RankInputRec = RankInputRec> {
   compass_boost: number;
   economic_boost: number;
   journey_mode: number;
+  feedback_breakdown: FeedbackBreakdown;
   explanation: string;
 }
 
@@ -411,22 +427,29 @@ export function scoreRec<T extends RankInputRec>(
   const primary = primaryPillar(rec);
   let feedback_mult = 1.0;
   let feedback_reason = '';
+  // VTID-03141 (C.3.b): per-path breakdown to feed provenance components.
+  // Only populated for paths that actually fire on this row.
+  const feedback_breakdown: FeedbackBreakdown = {};
   if (primary && ctx.recent_activity[primary]) {
     const act = ctx.recent_activity[primary]!;
     if (act.completions_24h > 0) {
       feedback_mult *= cfg.completion_dampener;
+      feedback_breakdown.completion = cfg.completion_dampener;
       feedback_reason += ' completion_dampened';
     } else if (act.plan_events_24h > 0) {
       feedback_mult *= cfg.plan_dampener;
+      feedback_breakdown.plan = cfg.plan_dampener;
       feedback_reason += ' voice_plan_dampened';
     }
     if (act.completions_7d >= 3 && primary === 'mental') {
       feedback_mult *= cfg.community_momentum_boost;
+      feedback_breakdown.community = cfg.community_momentum_boost;
       feedback_reason += ' community_momentum';
     }
     // Streak reinforcement — rec that encourages continuing the streak
     if (act.completions_7d >= 3 && rec.source_ref === 'start_streak') {
       feedback_mult *= cfg.streak_reinforcement;
+      feedback_breakdown.streak = cfg.streak_reinforcement;
       feedback_reason += ' streak_reinforcement';
     }
   }
@@ -434,7 +457,12 @@ export function scoreRec<T extends RankInputRec>(
   if (rec.domain) {
     const rate = ctx.rejection_rate_by_domain[rec.domain] ?? 0;
     if (rate > 0) {
-      feedback_mult *= Math.max(0.2, 1 - cfg.rejection_dampener_alpha * rate);
+      const rejectionFactor = Math.max(
+        0.2,
+        1 - cfg.rejection_dampener_alpha * rate,
+      );
+      feedback_mult *= rejectionFactor;
+      feedback_breakdown.rejection = rejectionFactor;
       feedback_reason += ` rej_rate_${rate.toFixed(2)}`;
     }
   }
@@ -449,6 +477,7 @@ export function scoreRec<T extends RankInputRec>(
     compass_boost,
     economic_boost,
     journey_mode,
+    feedback_breakdown,
     explanation: `base=${base.toFixed(1)} × (1 + ${cfg.alpha_pillar}·pillarBoost=${pillar_boost.toFixed(2)}·(1−jm=${journey_mode.toFixed(2)})) × compass=${compass_boost.toFixed(2)} × econ=${economic_boost.toFixed(2)} × fb=${feedback_mult.toFixed(2)}${feedback_reason} = ${rank_score.toFixed(2)}`,
   };
 }

--- a/services/gateway/test/services/decision-contract/feedback-path-provenance.test.ts
+++ b/services/gateway/test/services/decision-contract/feedback-path-provenance.test.ts
@@ -1,0 +1,279 @@
+// VTID-03141 — Phase C.3.b of the decision-contract refactor.
+//
+// Locks the contract for per-feedback-path provenance: the single fused
+// `feedback_mult` multiplier from C.3 (v1) is gone, replaced by up to
+// 5 per-path components emitted via 4 new union arms:
+//
+//   - feedback_completion          (kind:'feedback_completion')
+//   - feedback_plan                (kind:'feedback_plan')
+//   - feedback_reinforcement       (kind:'feedback_reinforcement', path:'community')
+//   - feedback_reinforcement       (kind:'feedback_reinforcement', path:'streak')
+//   - feedback_rejection           (kind:'feedback_rejection')
+//
+// strategy_version bumped to 2 (v1 traces remain interpretable).
+
+import {
+  scoreRecWithProvenance,
+  rankBatchWithProvenance,
+  PILLAR_WEIGHTER_STRATEGY_VERSION,
+} from '../../../src/services/decision-contract';
+import {
+  type RankerContext,
+  type RankInputRec,
+  DEFAULT_RANKER_CONFIG,
+} from '../../../src/services/recommendation-engine/ranking/index-pillar-weighter';
+import { __resetPolicyResolverForTests } from '../../../src/services/decision-contract/policy-resolver';
+import type { RankProvenanceComponent } from '../../../src/services/decision-contract/strategy';
+
+function makeCtx(overrides: Partial<RankerContext> = {}): RankerContext {
+  return {
+    pillars: {
+      nutrition: 100, hydration: 100, exercise: 100, sleep: 100, mental: 100,
+    },
+    balance_factor: 1.0,
+    weakest_pillar: null,
+    active_goal_category: null,
+    has_baseline: true,
+    has_recent_completions: false,
+    days_since_start: 14,
+    recent_activity: {},
+    rejection_rate_by_domain: {},
+    ...overrides,
+  };
+}
+
+function makeRec(overrides: Partial<RankInputRec> = {}): RankInputRec {
+  return {
+    id: 'rec-1',
+    impact_score: 7,
+    contribution_vector: { nutrition: 0, hydration: 0, exercise: 0, sleep: 0, mental: 1 },
+    source_ref: 'morning_walk',
+    domain: 'lifestyle',
+    ...overrides,
+  };
+}
+
+function feedbackComponents(
+  components: ReadonlyArray<RankProvenanceComponent>,
+): RankProvenanceComponent[] {
+  return components.filter((c) => c.kind.startsWith('feedback_')) as RankProvenanceComponent[];
+}
+
+describe('VTID-03141 C.3.b — per-feedback-path provenance', () => {
+  beforeEach(() => __resetPolicyResolverForTests());
+
+  it('strategy_version is 2', () => {
+    expect(PILLAR_WEIGHTER_STRATEGY_VERSION).toBe(2);
+    const out = scoreRecWithProvenance(makeRec(), makeCtx());
+    expect(out.provenance.strategy_version).toBe(2);
+  });
+
+  it('no fb path fires → no feedback_* components in the trail', () => {
+    const out = scoreRecWithProvenance(makeRec(), makeCtx());
+    expect(feedbackComponents(out.provenance.components)).toHaveLength(0);
+  });
+
+  it('completions_24h>0 → emits feedback_completion ONLY (mutex with plan)', () => {
+    const ctx = makeCtx({
+      recent_activity: {
+        mental: {
+          last_completed_at: null,
+          completions_24h: 1,
+          completions_7d: 1,
+          plan_events_24h: 99, // would have triggered plan, but completion wins
+        },
+      },
+    });
+    const out = scoreRecWithProvenance(makeRec(), ctx);
+    const fb = feedbackComponents(out.provenance.components);
+    expect(fb).toHaveLength(1);
+    expect(fb[0].kind).toBe('feedback_completion');
+    if (fb[0].kind === 'feedback_completion') {
+      expect(fb[0].weight_key).toBe('ranker.pillar_weighter.completion_dampener');
+      expect(fb[0].weight_value).toBe(DEFAULT_RANKER_CONFIG.completion_dampener);
+      expect(fb[0].contribution_multiplier).toBe(DEFAULT_RANKER_CONFIG.completion_dampener);
+    }
+  });
+
+  it('plan_events_24h>0 with no completions_24h → emits feedback_plan ONLY', () => {
+    const ctx = makeCtx({
+      recent_activity: {
+        mental: {
+          last_completed_at: null,
+          completions_24h: 0,
+          completions_7d: 0,
+          plan_events_24h: 1,
+        },
+      },
+    });
+    const out = scoreRecWithProvenance(makeRec(), ctx);
+    const fb = feedbackComponents(out.provenance.components);
+    expect(fb).toHaveLength(1);
+    expect(fb[0].kind).toBe('feedback_plan');
+    if (fb[0].kind === 'feedback_plan') {
+      expect(fb[0].weight_key).toBe('ranker.pillar_weighter.plan_dampener');
+      expect(fb[0].weight_value).toBe(DEFAULT_RANKER_CONFIG.plan_dampener);
+    }
+  });
+
+  it('completions_7d>=3 + mental pillar → emits feedback_reinforcement(community)', () => {
+    const ctx = makeCtx({
+      recent_activity: {
+        mental: {
+          last_completed_at: null,
+          completions_24h: 0,
+          completions_7d: 5,
+          plan_events_24h: 0,
+        },
+      },
+    });
+    const out = scoreRecWithProvenance(makeRec(), ctx);
+    const fb = feedbackComponents(out.provenance.components);
+    expect(fb).toHaveLength(1);
+    expect(fb[0].kind).toBe('feedback_reinforcement');
+    if (fb[0].kind === 'feedback_reinforcement') {
+      expect(fb[0].path).toBe('community');
+      expect(fb[0].weight_key).toBe('ranker.pillar_weighter.community_momentum_boost');
+      expect(fb[0].weight_value).toBe(DEFAULT_RANKER_CONFIG.community_momentum_boost);
+    }
+  });
+
+  it('start_streak rec with completions_7d>=3 → emits BOTH community and streak reinforcement', () => {
+    // primary pillar = mental + completions_7d>=3 satisfies both
+    // community-momentum (primary===mental) and streak (source_ref===start_streak).
+    const ctx = makeCtx({
+      recent_activity: {
+        mental: {
+          last_completed_at: null,
+          completions_24h: 0,
+          completions_7d: 5,
+          plan_events_24h: 0,
+        },
+      },
+    });
+    const out = scoreRecWithProvenance(makeRec({ source_ref: 'start_streak' }), ctx);
+    const fb = feedbackComponents(out.provenance.components);
+    expect(fb).toHaveLength(2);
+    const paths = fb
+      .filter((c) => c.kind === 'feedback_reinforcement')
+      .map((c) => (c as { path: string }).path);
+    expect(paths.sort()).toEqual(['community', 'streak']);
+  });
+
+  it('rejection_rate_by_domain set → emits feedback_rejection with rate captured', () => {
+    const ctx = makeCtx({
+      rejection_rate_by_domain: { lifestyle: 0.4 },
+    });
+    const out = scoreRecWithProvenance(makeRec(), ctx);
+    const fb = feedbackComponents(out.provenance.components);
+    expect(fb).toHaveLength(1);
+    expect(fb[0].kind).toBe('feedback_rejection');
+    if (fb[0].kind === 'feedback_rejection') {
+      expect(fb[0].weight_key).toBe('ranker.pillar_weighter.rejection_dampener_alpha');
+      expect(fb[0].rejection_rate).toBe(0.4);
+      // contribution_multiplier = max(0.2, 1 - 0.5 × 0.4) = max(0.2, 0.8) = 0.8
+      expect(fb[0].contribution_multiplier).toBeCloseTo(0.8, 5);
+    }
+  });
+
+  it('rejection_rate clamps at 0.2 floor for extreme dismissal', () => {
+    const ctx = makeCtx({
+      rejection_rate_by_domain: { lifestyle: 5.0 }, // 1 - 0.5 × 5 = -1.5 → clamp 0.2
+    });
+    const out = scoreRecWithProvenance(makeRec(), ctx);
+    const fb = feedbackComponents(out.provenance.components);
+    expect(fb).toHaveLength(1);
+    if (fb[0].kind === 'feedback_rejection') {
+      expect(fb[0].contribution_multiplier).toBeCloseTo(0.2, 5);
+    }
+  });
+
+  it('multiple paths can co-fire and each gets its own component', () => {
+    const ctx = makeCtx({
+      recent_activity: {
+        mental: {
+          last_completed_at: null,
+          completions_24h: 1,
+          completions_7d: 5,
+          plan_events_24h: 0,
+        },
+      },
+      rejection_rate_by_domain: { lifestyle: 0.3 },
+    });
+    const out = scoreRecWithProvenance(makeRec({ source_ref: 'start_streak' }), ctx);
+    const fb = feedbackComponents(out.provenance.components);
+    // Expected paths:
+    //   - feedback_completion (completions_24h>0)
+    //   - feedback_reinforcement community (completions_7d>=3 + mental)
+    //   - feedback_reinforcement streak (completions_7d>=3 + start_streak)
+    //   - feedback_rejection (lifestyle rate 0.3)
+    expect(fb).toHaveLength(4);
+    const kinds = fb.map((c) => c.kind).sort();
+    expect(kinds).toEqual([
+      'feedback_completion',
+      'feedback_reinforcement',
+      'feedback_reinforcement',
+      'feedback_rejection',
+    ]);
+  });
+
+  it('byte-identical final_score: per-path components reconstruct the score', () => {
+    // The product of all multipliers should match the legacy single
+    // feedback_mult value, so rank_score must equal the v1 result.
+    const ctx = makeCtx({
+      recent_activity: {
+        mental: {
+          last_completed_at: null,
+          completions_24h: 0,
+          completions_7d: 5,
+          plan_events_24h: 0,
+        },
+      },
+      rejection_rate_by_domain: { lifestyle: 0.2 },
+    });
+    const rec = makeRec({ source_ref: 'start_streak' });
+    const out = scoreRecWithProvenance(rec, ctx);
+    expect(Number.isFinite(out.score)).toBe(true);
+    expect(out.provenance.final_score).toBe(out.score);
+    // Manually replay the fb_mult product from the new components.
+    const fb = feedbackComponents(out.provenance.components);
+    const product = fb.reduce((acc, c) => {
+      if (
+        c.kind === 'feedback_completion' ||
+        c.kind === 'feedback_plan' ||
+        c.kind === 'feedback_reinforcement' ||
+        c.kind === 'feedback_rejection'
+      ) {
+        return acc * c.contribution_multiplier;
+      }
+      return acc;
+    }, 1);
+    // Expected: community (1.2) × streak (1.3) × rejection (1 - 0.5 × 0.2 = 0.9)
+    expect(product).toBeCloseTo(1.2 * 1.3 * 0.9, 5);
+  });
+
+  it('batch path emits per-path components per row', () => {
+    const ctx = makeCtx({
+      recent_activity: {
+        mental: {
+          last_completed_at: null,
+          completions_24h: 1,
+          completions_7d: 0,
+          plan_events_24h: 0,
+        },
+      },
+    });
+    const recs = [
+      makeRec({ id: 'a' }),
+      makeRec({ id: 'b', domain: 'health' }),
+    ];
+    const out = rankBatchWithProvenance(recs, ctx);
+    expect(out).toHaveLength(2);
+    for (const r of out) {
+      const fb = feedbackComponents(r.provenance.components);
+      // Each row's primary pillar is mental + completions_24h>0 ⇒ completion fires
+      expect(fb).toHaveLength(1);
+      expect(fb[0].kind).toBe('feedback_completion');
+    }
+  });
+});

--- a/services/gateway/test/services/decision-contract/pillar-weighter-strategy.test.ts
+++ b/services/gateway/test/services/decision-contract/pillar-weighter-strategy.test.ts
@@ -236,14 +236,19 @@ describe('VTID-03132 Phase C.3 PillarWeighterStrategy', () => {
     it('emits strategy_id and version', () => {
       const out = scoreRecWithProvenance(makeRec(), makeCtx());
       expect(out.provenance.strategy_id).toBe(PILLAR_WEIGHTER_STRATEGY_ID);
+      // VTID-03141 (C.3.b) bumped version from 1 → 2.
       expect(out.provenance.strategy_version).toBe(PILLAR_WEIGHTER_STRATEGY_VERSION);
+      expect(PILLAR_WEIGHTER_STRATEGY_VERSION).toBe(2);
       expect(out.provenance.strategy_id).toBe('pillar_weighter_v1');
     });
 
-    it('emits the 5 canonical components: base + 1 additive + 3 multipliers', () => {
+    it('with no feedback path firing, emits 4 components: base + 1 additive + 2 multipliers', () => {
+      // VTID-03141 (C.3.b): the single fused `feedback_mult` multiplier
+      // is gone. When no feedback path fires for a row, the provenance
+      // trail does not carry a feedback component at all.
       const out = scoreRecWithProvenance(makeRec(), makeCtx());
       const kinds = out.provenance.components.map((c) => c.kind);
-      expect(kinds).toEqual(['base', 'additive', 'multiplier', 'multiplier', 'multiplier']);
+      expect(kinds).toEqual(['base', 'additive', 'multiplier', 'multiplier']);
       const names = out.provenance.components.map((c) =>
         c.kind === 'base' ? 'base' : (c as { name: string }).name,
       );
@@ -252,7 +257,6 @@ describe('VTID-03132 Phase C.3 PillarWeighterStrategy', () => {
         'pillar_boost',
         'compass_boost',
         'economic_boost',
-        'feedback_mult',
       ]);
     });
 


### PR DESCRIPTION
## Summary

Phase C.3.b of the decision-contract refactor. Replaces the single fused `feedback_mult` multiplier component (C.3, v1) with up to 5 per-path components emitted via **4 new flat union arms** on `RankProvenanceComponent`. Composite-decomposition was explicitly rejected — each path that fires emits its own top-level component.

## Why

The v1 trail collapsed completion / plan / community / streak / rejection into one scalar recovered by post-formula division. Per-path provenance lets us answer "which feedback signal moved this rec where" without re-running scoring or guessing from the explanation string.

## What changed

**`RankProvenanceComponent` discriminated union** — 4 new arms:
- `feedback_completion` (completion_dampener)
- `feedback_plan` (plan_dampener)
- `feedback_reinforcement` with `path: 'community' | 'streak'` (covers both completions_7d≥3 sub-paths under one kind)
- `feedback_rejection` (carries `rejection_rate`)

**`RankedRec`** — new `feedback_breakdown: FeedbackBreakdown` field. `scoreRec` populates per-path factors as each path fires (undefined when not fired). Existing rank_score math is unchanged — `feedback_mult` is still the product of fired paths, byte-identical to v1.

**`PillarWeighterStrategy`** — `PILLAR_WEIGHTER_STRATEGY_VERSION` bumped `1 → 2`. New helper `buildFeedbackComponents()` iterates `feedback_breakdown` and emits one component per fired path. Both `scoreRecWithProvenance` and `rankBatchWithProvenance` use it.

## Tests

- 11 new in `test/services/decision-contract/feedback-path-provenance.test.ts` covering: version=2, no-fire trail shape, completion vs plan mutex, community vs streak co-fire, rejection rate captured + 0.2 clamp, multi-path co-fire, byte-identical rank_score, batch parity.
- Existing `pillar-weighter-strategy.test.ts` updated: the no-fire baseline ctx now emits **4 components** (base + pillar_boost + compass_boost + economic_boost) instead of 5 (the fused feedback_mult is gone).

**139/139 decision-contract suite green.**

## No migration

The provenance JSONB column accepts the new arms without DDL change. `strategy_version=2` is the only discriminator; v1 historical traces remain interpretable.

## Test plan

- [x] `npm run build` clean
- [x] `npx jest test/services/decision-contract/` 139 pass
- [ ] Auto-deploy + `/alive` 200 JSON
- [ ] Autopilot live smoke confirms new per-path components appear in `provenance.components` for any rec where a feedback path fired

🤖 Generated with [Claude Code](https://claude.com/claude-code)