### PR TITLE
fix(orb-live): suppress duplicate model turns (Vitana repeating same intro twice/thrice) (VTID-03143)

### DIFF
--- a/services/gateway/src/orb/live/session/upstream-message-handler.ts
+++ b/services/gateway/src/orb/live/session/upstream-message-handler.ts
@@ -271,6 +271,33 @@ export function createUpstreamLiveMessageHandler(
             const isGreetingTurn = session.greetingSent && session.turn_count === (session.greetingTurnIndex ?? 0) + 1;
             console.log(`[VTID-01219] Turn complete for session ${session.sessionId} (turn ${session.turn_count}, isGreeting=${isGreetingTurn}, consecutiveModelTurns=${session.consecutiveModelTurns})`);
 
+            // VTID-03143: snapshot the just-completed assistant transcript
+            // into the recent-turns ring buffer (capped at 3) so the NEXT
+            // turn can detect and suppress duplication. Skip the snapshot
+            // when the audio was suppressed (we don't want to keep a
+            // suppressed duplicate as a comparison anchor — that would
+            // re-trigger suppression on every retry forever). Snapshot
+            // also skipped on too-short transcripts (less signal).
+            const completedTranscript = (session.outputTranscriptBuffer || '').trim();
+            const wasSuppressed = (session as any).suppressCurrentTurnAudio === true;
+            const droppedChunks = (session as any).currentTurnAudioChunksDropped || 0;
+            if (wasSuppressed) {
+              console.log(
+                `[VTID-03143] Turn complete with suppression — session ${session.sessionId}, dropped ${droppedChunks} duplicate chunks. transcript_chars=${completedTranscript.length}`,
+              );
+              ctx.deps.emitDiag(session, 'duplicate_turn_suppressed_at_complete', {
+                dropped_chunks: droppedChunks,
+                transcript_chars: completedTranscript.length,
+              });
+            } else if (completedTranscript.length >= 30) {
+              const recent: string[] = ((session as any).recentAssistantTexts as string[]) || [];
+              recent.push(completedTranscript);
+              while (recent.length > 3) recent.shift();
+              (session as any).recentAssistantTexts = recent;
+            }
+            (session as any).suppressCurrentTurnAudio = false;
+            (session as any).currentTurnAudioChunksDropped = 0;
+
             // VTID-ANON-SIGNUP-INTENT + VTID-ANON-NUDGE: Detect signup intent and enforce turn limits.
             // CRITICAL: No client_content injections — those cause double responses.
             // All nudging is done via the system instruction (see buildAnonymousSystemInstruction).
@@ -835,7 +862,31 @@ export function createUpstreamLiveMessageHandler(
                 if (session.audioOutChunks % 50 === 1) {
                   console.log(`[VTID-01219] Audio chunk ${session.audioOutChunks}, size: ${audioB64.length}`);
                 }
-                ctx.callbacks.onAudioResponse(audioB64);
+                // VTID-03143: duplicate-turn suppression. Gemini Live
+                // occasionally re-emits the same response after a long
+                // Say-exactly directive — the user hears the same intro
+                // twice or three times. The duplication is detected by
+                // comparing the new turn's early output transcript
+                // prefix to the last 3 completed assistant turns
+                // (recentAssistantTexts). On match, suppressCurrentTurnAudio
+                // is set and all REMAINING audio chunks for this turn
+                // are dropped. The first ~30-60 chars before detection
+                // still reach the user — better than nothing-suppressed.
+                // The model continues generating; we just stop forwarding.
+                if ((session as any).suppressCurrentTurnAudio === true) {
+                  (session as any).currentTurnAudioChunksDropped =
+                    ((session as any).currentTurnAudioChunksDropped || 0) + 1;
+                  // Log every 25th dropped chunk so we don't spam the log
+                  // for a long duplicated turn.
+                  if ((session as any).currentTurnAudioChunksDropped % 25 === 1) {
+                    console.warn(
+                      `[VTID-03143] Suppressing duplicate-turn audio chunk for session ${session.sessionId} (dropped=${(session as any).currentTurnAudioChunksDropped} so far this turn)`,
+                    );
+                  }
+                  // Don't forward to client.
+                } else {
+                  ctx.callbacks.onAudioResponse(audioB64);
+                }
 
                 // VTID-STREAM-KEEPALIVE: Removed per-chunk OASIS event emission.
                 // emitLiveSessionEvent fires an HTTP call to Supabase on every audio chunk
@@ -938,6 +989,39 @@ export function createUpstreamLiveMessageHandler(
               }
               // VTID-01225: Accumulate output transcription chunks in buffer (will be written on turnComplete)
               session.outputTranscriptBuffer += outputTranscription;
+
+              // VTID-03143: duplicate-turn detection. Once we have ~30
+              // chars of output transcript for this turn, compare its
+              // early prefix to the last few completed assistant turns.
+              // If the new turn STARTS with the same content as a
+              // recent one, Gemini is repeating — flip the audio
+              // suppression flag so subsequent chunks are dropped.
+              // Pure string comparison after normalization; no LLM call.
+              const SUPPRESS_PREFIX_CHARS = 30;
+              const recent: string[] = ((session as any).recentAssistantTexts as string[]) || [];
+              if (
+                !(session as any).suppressCurrentTurnAudio
+                && session.outputTranscriptBuffer.length >= SUPPRESS_PREFIX_CHARS
+                && recent.length > 0
+              ) {
+                const norm = (s: string) =>
+                  s.toLowerCase().replace(/[^\p{L}\p{N} ]+/gu, ' ').replace(/\s+/g, ' ').trim();
+                const currentPrefix = norm(session.outputTranscriptBuffer).slice(0, SUPPRESS_PREFIX_CHARS);
+                for (const prevText of recent) {
+                  const prevPrefix = norm(prevText).slice(0, SUPPRESS_PREFIX_CHARS);
+                  if (prevPrefix.length >= 20 && prevPrefix === currentPrefix) {
+                    (session as any).suppressCurrentTurnAudio = true;
+                    console.warn(
+                      `[VTID-03143] Duplicate turn detected for session ${session.sessionId} — suppressing audio for the rest of this turn. matched_prefix="${currentPrefix.slice(0, 60)}"`,
+                    );
+                    ctx.deps.emitDiag(session, 'duplicate_turn_detected', {
+                      matched_prefix_chars: currentPrefix.length,
+                      buffer_len: session.outputTranscriptBuffer.length,
+                    });
+                    break;
+                  }
+                }
+              }
             }
           }
         }

--- a/services/gateway/test/orb/live/characterization/upstream-duplicate-turn-suppression.characterization.test.ts
+++ b/services/gateway/test/orb/live/characterization/upstream-duplicate-turn-suppression.characterization.test.ts
@@ -1,0 +1,95 @@
+/**
+ * VTID-03143 — duplicate-turn audio suppression.
+ *
+ * User report: Gemini Live sometimes repeats the same response twice
+ * (occasionally three times) — especially when given a long Say-exactly
+ * directive like our locked teacher_intro_de/en scripts. The user hears
+ * the same intro multiple times before the conversation can move on.
+ *
+ * This file locks the structural contract of the anti-duplicate filter
+ * in services/gateway/src/orb/live/session/upstream-message-handler.ts:
+ *
+ *   - On every output_transcription chunk, accumulate into the session
+ *     buffer. Once we have >= 30 chars, compare the normalized prefix
+ *     to the last few completed assistant transcripts
+ *     (session.recentAssistantTexts, capped at 3).
+ *   - If the prefix matches any recent turn's prefix → flip
+ *     session.suppressCurrentTurnAudio = true.
+ *   - All subsequent audio chunks for this turn are DROPPED (the early
+ *     ~30 chars already reached the client; the rest of the duplicate
+ *     does not).
+ *   - At turn_complete: the just-completed transcript is pushed onto
+ *     recentAssistantTexts (ring buffer of 3) IFF the turn was NOT
+ *     suppressed (otherwise we'd keep a suppressed duplicate as a
+ *     comparison anchor and feedback-loop the suppression). Flag +
+ *     counter reset.
+ */
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const HANDLER_PATH = path.resolve(
+  __dirname,
+  '../../../../src/orb/live/session/upstream-message-handler.ts',
+);
+
+let src: string;
+
+beforeAll(() => {
+  src = fs.readFileSync(HANDLER_PATH, 'utf8');
+});
+
+describe('VTID-03143: duplicate-turn audio suppression', () => {
+  it('audio-chunk path checks session.suppressCurrentTurnAudio BEFORE forwarding', () => {
+    // The suppression check must be in the same block that calls
+    // onAudioResponse — otherwise a duplicate would still reach the
+    // client through onAudioResponse.
+    expect(src).toMatch(/suppressCurrentTurnAudio === true/);
+    expect(src).toMatch(/currentTurnAudioChunksDropped/);
+    // The "else { ctx.callbacks.onAudioResponse(audioB64); }" branch
+    // proves we only forward when suppression is off.
+    expect(src).toMatch(/\}\s*else\s*\{\s*ctx\.callbacks\.onAudioResponse\(audioB64\);\s*\}/);
+  });
+
+  it('output_transcription handler compares prefix to session.recentAssistantTexts', () => {
+    expect(src).toMatch(/recentAssistantTexts/);
+    expect(src).toMatch(/SUPPRESS_PREFIX_CHARS\s*=\s*30/);
+    // Prefix normalization: lowercase, strip non-letter/digit/space,
+    // collapse whitespace, trim. Locks the canonical comparison so a
+    // refactor can't accidentally weaken it.
+    expect(src).toMatch(/toLowerCase\(\)\.replace\(\/\[\^\\p\{L\}\\p\{N\} \]\+\/gu, ' '\)\.replace\(\/\\s\+\/g, ' '\)\.trim\(\)/);
+  });
+
+  it('detection emits [VTID-03143] log + diag event', () => {
+    expect(src).toMatch(/\[VTID-03143\] Duplicate turn detected/);
+    expect(src).toMatch(/duplicate_turn_detected/);
+  });
+
+  it('turn_complete snapshots the transcript into recentAssistantTexts ring buffer (capped at 3)', () => {
+    // Snapshot only happens when the turn was NOT suppressed (otherwise
+    // we'd feedback-loop the suppression flag forever).
+    expect(src).toMatch(/recent\.push\(completedTranscript\)/);
+    // Ring-buffer cap.
+    expect(src).toMatch(/while\s*\(recent\.length\s*>\s*3\)\s*recent\.shift\(\)/);
+  });
+
+  it('turn_complete does NOT snapshot a suppressed (duplicate) turn', () => {
+    // The snapshot line `recent.push(completedTranscript)` must live in
+    // the `else if (completedTranscript.length >= 30)` branch — i.e.
+    // AFTER the `if (wasSuppressed)` guard returns / logs only.
+    const block = src.match(/const wasSuppressed[\s\S]+?suppressCurrentTurnAudio\s*=\s*false;\s*\n\s+\(session as any\)\.currentTurnAudioChunksDropped\s*=\s*0;/);
+    expect(block).not.toBeNull();
+    expect(block![0]).toMatch(/if\s*\(wasSuppressed\)/);
+    expect(block![0]).toMatch(/else if\s*\(completedTranscript\.length\s*>=\s*30\)/);
+  });
+
+  it('turn_complete resets suppressCurrentTurnAudio + chunk counter', () => {
+    expect(src).toMatch(/suppressCurrentTurnAudio\s*=\s*false;/);
+    expect(src).toMatch(/currentTurnAudioChunksDropped\s*=\s*0;/);
+  });
+
+  it('suppression diag emitted at turn_complete when it fired', () => {
+    expect(src).toMatch(/duplicate_turn_suppressed_at_complete/);
+    expect(src).toMatch(/dropped_chunks/);
+  });
+});


### PR DESCRIPTION
## Why
> Why does the recommendation get repeated twice — sometimes three times? Why haven't you built something that suppresses that?

Gemini Live, when given a long Say-exactly directive (like our locked `teacher_intro_de/en` scripts from VTID-03120), occasionally re-emits the response in a follow-up model turn without the user having spoken in between. The system already counted `consecutiveModelTurns` but never used it to **suppress** the duplicated audio.

## What changed
Defensive duplicate-turn detector + audio suppression in `services/gateway/src/orb/live/session/upstream-message-handler.ts`:

1. **Session ring buffer** `recentAssistantTexts` (capped at 3), populated at `turn_complete` with the just-completed transcript.
2. **Detection** on each `output_transcription` chunk: once we have ≥ 30 chars, normalize (lowercase, strip non-alphanum, collapse whitespace) and compare prefix to the ring buffer entries. Match → flip `suppressCurrentTurnAudio = true`.
3. **Audio gate**: chunk handler checks the flag BEFORE calling `onAudioResponse`. Suppressed → drop chunk + bump dropped-counter.
4. **Reset at turn_complete**: push transcript onto ring buffer ONLY if turn was NOT suppressed (snapshotting a suppressed duplicate would feedback-loop forever). Then reset flag + counter.

Trade-off: the first ~30-60 chars of a duplicate still reach the user before detection trips. Much better than hearing the entire duplicate. Simple defense ships first; tuning the threshold or sending an upstream interrupt comes in a follow-up if the simple version doesn't catch enough.

## Observability
- `[VTID-03143] Duplicate turn detected` on detection
- `[VTID-03143] Suppressing duplicate-turn audio chunk` (every 25th dropped chunk)
- `[VTID-03143] Turn complete with suppression` at turn end
- OASIS diag events `duplicate_turn_detected` + `duplicate_turn_suppressed_at_complete`

## Test plan
- [x] 7 new structural tests in `upstream-duplicate-turn-suppression.characterization.test.ts` lock the contract.
- [x] 531 existing `test/orb/live` tests still pass.
- [x] `npm run build` clean.
- [ ] **Runtime test on vitanaland**: tap orb, listen to Vitana's intro. If she's about to repeat the locked Teacher script, the second emission should be cut off after ~half a sentence. In Cloud Run logs grep `[VTID-03143]` to confirm the detector caught it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)