### PR TITLE
chore(decision-contract): retire D42 bespoke Supabase clients (VTID-03144)

### DIFF
--- a/services/gateway/src/services/d42-context-fusion-engine.ts
+++ b/services/gateway/src/services/d42-context-fusion-engine.ts
@@ -30,9 +30,12 @@
  *   - Stable sorting for ties
  */
 
-import { createClient, SupabaseClient } from '@supabase/supabase-js';
 import { createHash } from 'crypto';
 import { emitOasisEvent } from './oasis-event-service';
+// VTID-03144 — fusion-audit write lives behind the decision-contract
+// boundary. d42 no longer imports `@supabase/supabase-js` directly;
+// the writer owns the table, the payload, and the auth-mode gate.
+import { storeFusionAudit as storeFusionAuditImpl } from './decision-contract/fusion-audit-writer';
 import {
   PriorityDomain,
   PriorityTag,
@@ -80,63 +83,6 @@ const DEV_IDENTITY = {
  * map, so behaviour is unchanged on a fresh deploy before migration.
  */
 import { getConflictPairResolver } from './decision-contract/conflict-pair-resolver';
-
-// =============================================================================
-// Environment Detection
-// =============================================================================
-
-function isDevSandbox(): boolean {
-  const env = (process.env.ENVIRONMENT || process.env.VITANA_ENV || '').toLowerCase();
-  return env === 'dev-sandbox' ||
-         env === 'dev' ||
-         env === 'development' ||
-         env === 'sandbox' ||
-         env.includes('dev') ||
-         env.includes('sandbox');
-}
-
-// =============================================================================
-// Supabase Client
-// =============================================================================
-
-function createServiceClient(): SupabaseClient | null {
-  const supabaseUrl = process.env.SUPABASE_URL;
-  const supabaseServiceKey = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
-
-  if (!supabaseUrl || !supabaseServiceKey) {
-    console.warn(`${LOG_PREFIX} Missing SUPABASE_URL or SUPABASE_SERVICE_ROLE_KEY`);
-    return null;
-  }
-
-  return createClient(supabaseUrl, supabaseServiceKey, {
-    auth: {
-      autoRefreshToken: false,
-      persistSession: false
-    }
-  });
-}
-
-function createUserClient(token: string): SupabaseClient | null {
-  const supabaseUrl = process.env.SUPABASE_URL;
-  const supabaseAnonKey = process.env.SUPABASE_ANON_KEY;
-
-  if (!supabaseUrl || !supabaseAnonKey) {
-    console.warn(`${LOG_PREFIX} Missing SUPABASE_URL or SUPABASE_ANON_KEY`);
-    return null;
-  }
-
-  return createClient(supabaseUrl, supabaseAnonKey, {
-    global: {
-      headers: {
-        Authorization: `Bearer ${token}`
-      }
-    },
-    auth: {
-      autoRefreshToken: false,
-      persistSession: false
-    }
-  });
-}
 
 // =============================================================================
 // Utility Functions
@@ -1329,55 +1275,18 @@ export async function isDomainActionAllowed(
 }
 
 /**
- * Store fusion audit entry
+ * Store fusion audit entry.
+ *
+ * VTID-03144: the actual DB write lives behind the decision-contract
+ * boundary. This export remains so external callers keep the same
+ * import surface; the call delegates to
+ * `services/decision-contract/fusion-audit-writer.ts`.
  */
 export async function storeFusionAudit(
   entry: FusionAuditEntry,
   authToken?: string
 ): Promise<boolean> {
-  try {
-    let supabase: SupabaseClient | null;
-
-    if (authToken) {
-      supabase = createUserClient(authToken);
-    } else if (isDevSandbox()) {
-      supabase = createServiceClient();
-    } else {
-      console.warn(`${LOG_PREFIX} Cannot store audit without auth`);
-      return false;
-    }
-
-    if (!supabase) {
-      return false;
-    }
-
-    const { error } = await supabase
-      .from('d42_fusion_audit')
-      .insert({
-        id: entry.id,
-        tenant_id: entry.tenant_id,
-        user_id: entry.user_id,
-        session_id: entry.session_id,
-        turn_id: entry.turn_id,
-        input_summary: entry.input_summary,
-        resolved_plan: entry.resolved_plan,
-        conflicts_count: entry.conflicts_count,
-        rules_applied: entry.rules_applied,
-        duration_ms: entry.duration_ms,
-        created_at: entry.created_at
-      });
-
-    if (error) {
-      console.warn(`${LOG_PREFIX} Failed to store audit:`, error.message);
-      return false;
-    }
-
-    return true;
-
-  } catch (error) {
-    console.error(`${LOG_PREFIX} Error storing audit:`, error);
-    return false;
-  }
+  return storeFusionAuditImpl(entry, authToken);
 }
 
 // =============================================================================

--- a/services/gateway/src/services/decision-contract/fusion-audit-writer.ts
+++ b/services/gateway/src/services/decision-contract/fusion-audit-writer.ts
@@ -1,0 +1,96 @@
+// VTID-03144 — D42 fusion audit writer.
+//
+// Boundary module for the `d42_fusion_audit` INSERT that previously
+// lived inside `d42-context-fusion-engine.ts`. With this module in
+// place, the D42 file no longer imports `@supabase/supabase-js`
+// directly: the writer terminates the Supabase boundary inside
+// `services/decision-contract/*` and routes through the two approved
+// helpers (`getSupabase()` for service-role writes,
+// `createUserSupabaseClient(token)` for user-token / RLS writes).
+//
+// Byte-identical behaviour vs the pre-VTID-03144 d42 path:
+//   - Same table: `d42_fusion_audit`.
+//   - Same payload columns and ordering as the original `.insert({...})`.
+//   - Same gate: user-token path if `authToken` is provided; otherwise
+//     service-role path only inside a dev/sandbox environment; otherwise
+//     refuse with a `Cannot store audit without auth` warning.
+//   - Same return shape: `Promise<boolean>` (`true` on insert success,
+//     `false` on any failure, including missing config).
+//   - Same log prefix `[D42-Fusion]` so existing log monitors keep
+//     matching.
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { getSupabase } from '../../lib/supabase';
+import { createUserSupabaseClient } from '../../lib/supabase-user';
+import type { FusionAuditEntry } from '../../types/context-fusion';
+
+const LOG_PREFIX = '[D42-Fusion]';
+
+/**
+ * Mirror of the pre-VTID-03144 `isDevSandbox()` predicate that the d42
+ * engine previously kept inline. Lifted here so the writer owns the
+ * full decision of whether a service-role write is permitted.
+ */
+function isDevSandbox(): boolean {
+  const env = (process.env.ENVIRONMENT || process.env.VITANA_ENV || '').toLowerCase();
+  return env === 'dev-sandbox' ||
+         env === 'dev' ||
+         env === 'development' ||
+         env === 'sandbox' ||
+         env.includes('dev') ||
+         env.includes('sandbox');
+}
+
+function resolveClient(authToken: string | undefined): SupabaseClient | null {
+  if (authToken) {
+    try {
+      return createUserSupabaseClient(authToken);
+    } catch (e: any) {
+      console.warn(`${LOG_PREFIX} ${e?.message ?? e}`);
+      return null;
+    }
+  }
+  if (isDevSandbox()) {
+    return getSupabase();
+  }
+  console.warn(`${LOG_PREFIX} Cannot store audit without auth`);
+  return null;
+}
+
+export async function storeFusionAudit(
+  entry: FusionAuditEntry,
+  authToken?: string,
+): Promise<boolean> {
+  try {
+    const supabase = resolveClient(authToken);
+    if (!supabase) {
+      return false;
+    }
+
+    const { error } = await supabase
+      .from('d42_fusion_audit')
+      .insert({
+        id: entry.id,
+        tenant_id: entry.tenant_id,
+        user_id: entry.user_id,
+        session_id: entry.session_id,
+        turn_id: entry.turn_id,
+        input_summary: entry.input_summary,
+        resolved_plan: entry.resolved_plan,
+        conflicts_count: entry.conflicts_count,
+        rules_applied: entry.rules_applied,
+        duration_ms: entry.duration_ms,
+        created_at: entry.created_at,
+      });
+
+    if (error) {
+      console.warn(`${LOG_PREFIX} Failed to store audit:`, error.message);
+      return false;
+    }
+
+    return true;
+  } catch (error) {
+    console.error(`${LOG_PREFIX} Error storing audit:`, error);
+    return false;
+  }
+}

--- a/services/gateway/test/services/decision-contract/fusion-audit-writer-structural.test.ts
+++ b/services/gateway/test/services/decision-contract/fusion-audit-writer-structural.test.ts
@@ -1,0 +1,103 @@
+// VTID-03144 — structural anti-regression for the D42 fusion-audit
+// Supabase boundary.
+//
+// Locks in the PR-1 boundary outcome: d42-context-fusion-engine.ts
+// must not reach Supabase directly; the only DB write site for
+// d42_fusion_audit is the new fusion-audit-writer module, which
+// terminates the boundary via the approved `getSupabase()` +
+// `createUserSupabaseClient(token)` helpers.
+//
+// If a future change reintroduces ANY of these patterns inside d42
+// (raw `@supabase/supabase-js` import, `createClient(`, `getSupabase(`,
+// `.from('d42_fusion_audit'`), this test fails — the leak has
+// returned and PR-1's contract is broken.
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const D42_PATH = path.resolve(
+  __dirname,
+  '../../../src/services/d42-context-fusion-engine.ts',
+);
+const WRITER_PATH = path.resolve(
+  __dirname,
+  '../../../src/services/decision-contract/fusion-audit-writer.ts',
+);
+
+// Read once at module load — these assertions are pure structural
+// checks on the source text. The d42 prose intentionally references
+// the boundary it just gave up (`@supabase/supabase-js`), but only
+// inside backtick-quoted code spans inside `//` comments, so the
+// regexes below (which require single or double quotes after `from`)
+// do not collide with comment text.
+const d42Code = fs.readFileSync(D42_PATH, 'utf8');
+const writerCode = fs.readFileSync(WRITER_PATH, 'utf8');
+
+describe('VTID-03144 D42 fusion-audit Supabase-boundary structural contract', () => {
+  describe('d42-context-fusion-engine.ts has no direct Supabase reach', () => {
+    it('does not import from @supabase/supabase-js', () => {
+      // No `from '@supabase/supabase-js'` and no `from "@supabase/supabase-js"`.
+      expect(d42Code).not.toMatch(/from\s+['"]@supabase\/supabase-js['"]/);
+      // Also: no `require('@supabase/supabase-js')`.
+      expect(d42Code).not.toMatch(/require\s*\(\s*['"]@supabase\/supabase-js['"]\s*\)/);
+    });
+
+    it('does not call createClient(', () => {
+      expect(d42Code).not.toMatch(/\bcreateClient\s*\(/);
+    });
+
+    it('does not call getSupabase(', () => {
+      // d42 must not reach even the approved boundary directly — the
+      // writer owns that call site.
+      expect(d42Code).not.toMatch(/\bgetSupabase\s*\(/);
+    });
+
+    it('does not write to d42_fusion_audit directly', () => {
+      // No `.from('d42_fusion_audit'` or `.from("d42_fusion_audit"`.
+      expect(d42Code).not.toMatch(/\.from\s*\(\s*['"]d42_fusion_audit['"]/);
+    });
+
+    it('does not reference SupabaseClient', () => {
+      // The type import disappeared with the client builders.
+      expect(d42Code).not.toMatch(/\bSupabaseClient\b/);
+    });
+
+    it('still exports storeFusionAudit (caller contract preserved)', () => {
+      expect(d42Code).toMatch(/export\s+async\s+function\s+storeFusionAudit\s*\(/);
+    });
+
+    it('delegates to the decision-contract writer', () => {
+      expect(d42Code).toMatch(
+        /from\s+['"]\.\/decision-contract\/fusion-audit-writer['"]/,
+      );
+    });
+  });
+
+  describe('decision-contract/fusion-audit-writer.ts is the single DB write site', () => {
+    it('owns the .from("d42_fusion_audit") insert', () => {
+      expect(writerCode).toMatch(/\.from\s*\(\s*['"]d42_fusion_audit['"]/);
+    });
+
+    it('uses the approved getSupabase() helper for service-role writes', () => {
+      expect(writerCode).toMatch(/from\s+['"]\.\.\/\.\.\/lib\/supabase['"]/);
+      expect(writerCode).toMatch(/\bgetSupabase\s*\(/);
+    });
+
+    it('uses the approved createUserSupabaseClient helper for user-token writes', () => {
+      expect(writerCode).toMatch(/from\s+['"]\.\.\/\.\.\/lib\/supabase-user['"]/);
+      expect(writerCode).toMatch(/\bcreateUserSupabaseClient\s*\(/);
+    });
+
+    it('does not call createClient( directly (must go via helpers)', () => {
+      expect(writerCode).not.toMatch(/\bcreateClient\s*\(/);
+    });
+
+    it('exports storeFusionAudit with the documented signature', () => {
+      // `(entry: FusionAuditEntry, authToken?: string): Promise<boolean>`
+      expect(writerCode).toMatch(
+        /export\s+async\s+function\s+storeFusionAudit\s*\(/,
+      );
+      expect(writerCode).toMatch(/Promise<boolean>/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

PR 1 of the **Decision-Contract Supabase Boundary Hardening** sequence (from the audit dated 2026-05-22). Closes findings **D42-1** and **D42-2**.

- Move the `d42_fusion_audit` INSERT out of `d42-context-fusion-engine.ts` and behind the decision-contract boundary into `services/gateway/src/services/decision-contract/fusion-audit-writer.ts`.
- The writer terminates the Supabase boundary via the two approved helpers: `getSupabase()` (service-role) and `createUserSupabaseClient(token)` (user-token / RLS).
- `d42-context-fusion-engine.ts` no longer imports `@supabase/supabase-js`, no `createClient`, no `SupabaseClient` type, no direct `getSupabase()` call, no `.from('d42_fusion_audit')`. The bespoke `createServiceClient` / `createUserClient` helpers and the inline `isDevSandbox` predicate are gone; `isDevSandbox` lives with the writer since only the writer's service-role branch uses it.
- External `storeFusionAudit` export on `d42-context-fusion-engine.ts` is preserved as a one-line delegator so future callers keep the same import surface. (No caller in tree today.)

## Byte-identical behaviour

- Same table: `d42_fusion_audit`.
- Same insert payload - same column set, same column ordering.
- Same gate: user-token if provided; service-role only in dev/sandbox; otherwise refuse with `[D42-Fusion] Cannot store audit without auth`.
- Same `Promise<boolean>` contract: `true` on insert success; `false` on any failure including missing config.
- Same `[D42-Fusion]` log prefix so existing log monitors keep matching.

## Anti-regression contract

New `test/services/decision-contract/fusion-audit-writer-structural.test.ts` locks the boundary with 12 structural assertions:

- d42 has no `@supabase/supabase-js` import, no `createClient(`, no `getSupabase(`, no `SupabaseClient` type, no `.from('d42_fusion_audit')`.
- d42 still exports `storeFusionAudit` and imports from `./decision-contract/fusion-audit-writer`.
- Writer owns the `.from('d42_fusion_audit')` INSERT and uses `getSupabase()` + `createUserSupabaseClient` (both from approved boundary helpers); does not call `createClient(` directly.

If a future PR reintroduces any of the above patterns in d42, this test fails.

## Net diff

`d42-context-fusion-engine.ts`: -91 LoC (1406 -> 1315).
New module: 96 LoC. New test: 102 LoC.

## Out of scope

- ContextPackBuilder Supabase leaks (CPB-1 through CPB-9) - covered by PRs 2-5 in the audit's sequence; do not start until this PR is merged + deployed + verified.
- D39, D28/D38/D47/D48, onboarding templates, compatibility matrices.

## Test plan

- [x] `npm run build` clean.
- [x] `npx jest --testPathPattern="decision-contract"` - 14/14 suites, 202/202 tests green.
- [ ] Post-deploy: verify the gateway boots; `/alive` returns 200; sample `[D42-Fusion]` log line (if any audit fires) preserves the existing prefix shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)