### PR TITLE
fix(notifications): encode title/body in Appilix form body

### DIFF
--- a/services/gateway/src/services/notification-service.ts
+++ b/services/gateway/src/services/notification-service.ts
@@ -269,14 +269,18 @@ export async function sendAppilixPush(
   if (!appKey || !apiKey) return false;
 
   try {
-    // IMPORTANT: Appilix API does NOT decode URL-encoded values.
-    // We must NOT use URLSearchParams (which auto-encodes) — instead
-    // build the body string manually so open_link_url is passed raw.
+    // Appilix API does NOT decode open_link_url (confirmed by their support),
+    // so that field must be sent raw. However, notification_title and
+    // notification_body CAN contain user input with &, =, + etc. which would
+    // corrupt the form body. Encode those fields to keep the body well-formed;
+    // Appilix decodes standard display fields normally for the push text.
+    const safeTitle = encodeURIComponent(payload.title);
+    const safeBody = encodeURIComponent(payload.body);
     const bodyParts = [
       `app_key=${appKey}`,
       `api_key=${apiKey}`,
-      `notification_title=${payload.title}`,
-      `notification_body=${payload.body}`,
+      `notification_title=${safeTitle}`,
+      `notification_body=${safeBody}`,
       `user_identity=${userId}`,
     ];
     const url = payload.data?.url;
@@ -287,12 +291,10 @@ export async function sendAppilixPush(
       bodyParts.push(`open_link_url=${resolvedOpenLink}`);
     }
 
-    // BOOTSTRAP-NOTIF-MESSENGER-DIAG: log the exact open_link_url so we can
-    // correlate Appilix delivery with the [NotifDiag] beacons fired from the
-    // WebView when the deep-link page either loads or fails to load.
     console.log(
-      `[Appilix] push request user=${userId.slice(0, 8)}… ` +
+      `[Appilix] push user=${userId.slice(0, 8)}… ` +
       `title=${JSON.stringify(payload.title)} ` +
+      `body_len=${payload.body.length} ` +
       `open_link_url=${JSON.stringify(resolvedOpenLink ?? null)}`
     );
 


### PR DESCRIPTION
## Summary

- Encode `notification_title` and `notification_body` with `encodeURIComponent` in the Appilix push request body
- Keep `open_link_url` raw (unencoded) per Appilix support guidance
- Fixes intermittent "Something went wrong" black screen on notification tap

## Root cause

The manual `bodyParts.join('&')` form body doesn't escape user input. When a sender's name or message text contains `&`, `=`, or `+`, the form body splits prematurely, corrupting `open_link_url`. This explains why deep-links work for some users but fail for others — it depends on the message content.

## Test plan

- [ ] Send a chat message containing `&` (e.g. "Hi & how are you?") and tap the notification — should deep-link correctly
- [ ] Send a normal message and tap — should still work
- [ ] Verify notification text displays correctly (not URL-encoded) on the lock screen

https://claude.ai/code/session_01XGFwQaxGMc3L971fMdT1vT

---
_Generated by [Claude Code](https://claude.ai/code/session_01XGFwQaxGMc3L971fMdT1vT)_