### PR TITLE
feat(context-pack): route DIARY + NETWORK through memory-broker (VTID-03145)

### DIFF
--- a/services/gateway/src/services/context-pack-builder.ts
+++ b/services/gateway/src/services/context-pack-builder.ts
@@ -42,6 +42,10 @@ import {
 import { searchKnowledge, KnowledgeSearchRequest } from './knowledge-hub';
 import { getCurrentFacts } from './memory-facts-service';
 import { generateEmbedding } from './embedding-service';
+// VTID-03145 (PR 2): DIARY + NETWORK blocks now route through the
+// memory-broker boundary instead of raw Supabase fetches. See
+// fetchDiaryHits / fetchRelationshipContext below.
+import { getMemoryContext, type DiaryBlock, type NetworkBlock } from './memory-broker';
 import { ContextLens } from '../types/context-lens';
 // VTID-01230: Session buffer for Tier 0 short-term memory
 import { formatSessionBufferForLLM, getSessionContext } from './session-memory-buffer';
@@ -580,9 +584,11 @@ async function fetchMemoryFacts(
 }
 
 /**
- * VTID-01224-FIX: Fetch diary entries from memory_diary_entries and diary_entries tables.
- * Diary data lives in separate tables (not memory_items), so without this function
- * the search_memory tool cannot find diary content during live ORB sessions.
+ * VTID-01224-FIX: Fetch diary entries to surface in the LLM context pack.
+ *
+ * VTID-03145 (PR 2): now routed through the memory-broker boundary.
+ * The broker owns the canonical DIARY stream (`memory_diary_entries`).
+ *
  * Results are returned as MemoryHit[] to merge with other memory hits.
  */
 async function fetchDiaryHits(
@@ -593,105 +599,54 @@ async function fetchDiaryHits(
   const startTime = Date.now();
 
   try {
-    const SUPABASE_URL = process.env.SUPABASE_URL;
-    const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
-
-    if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
-      return { hits: [], latency_ms: Date.now() - startTime };
-    }
-
     if (!lens.tenant_id || !lens.user_id) {
       return { hits: [], latency_ms: Date.now() - startTime };
     }
 
-    const headers = {
-      'Content-Type': 'application/json',
-      apikey: SUPABASE_SERVICE_ROLE,
-      Authorization: `Bearer ${SUPABASE_SERVICE_ROLE}`,
-    };
+    // VTID-03145 (PR 2): DIARY now routed through the memory-broker
+    // boundary. The broker reads `memory_diary_entries` via the
+    // approved `getSupabase()` helper. The legacy `diary_entries`
+    // table read is dropped here — context-pack alignment with the
+    // broker's canonical-table decision (audit 2026-05-22, CPB-4).
+    // Voice-saved diary entries written via tool_save_diary_entry
+    // into `diary_entries` remain readable through orb-memory-bridge;
+    // they no longer surface in the LLM context pack until the write
+    // path is migrated to `memory_diary_entries`.
+    const pack = await getMemoryContext({
+      tenant_id: lens.tenant_id,
+      user_id: lens.user_id,
+      intent: 'recall_history',
+      required_blocks: ['DIARY'],
+      query: query || undefined,
+    });
 
-    // Fetch from both diary tables in parallel with timeout
-    const timeout = fetchWithTimeout();
-    try {
-      const diaryUrl = `${SUPABASE_URL}/rest/v1/memory_diary_entries?select=id,raw_text,tags,entry_date,created_at,entry_type&tenant_id=eq.${lens.tenant_id}&user_id=eq.${lens.user_id}&order=created_at.desc&limit=${limit}`;
-      const lovableUrl = `${SUPABASE_URL}/rest/v1/diary_entries?select=id,text,source,tags,created_at&user_id=eq.${lens.user_id}&order=created_at.desc&limit=${limit}`;
-
-      const [diaryResp, lovableResp] = await Promise.all([
-        fetch(diaryUrl, { method: 'GET', headers, signal: timeout.signal }),
-        fetch(lovableUrl, { method: 'GET', headers, signal: timeout.signal }).catch(() => null),
-      ]);
-
-      const hits: MemoryHit[] = [];
-
-      // Process memory_diary_entries
-      if (diaryResp.ok) {
-        const diaryData = await diaryResp.json() as Array<{
-          id: string;
-          raw_text: string;
-          tags: string[];
-          entry_date: string;
-          created_at: string;
-          entry_type: string;
-        }>;
-
-        for (const d of diaryData) {
-          const content = d.raw_text || '';
-          hits.push({
-            id: d.id,
-            category_key: d.tags?.[0]?.replace(/-/g, '_') || 'diary',
-            content: content.substring(0, CONTEXT_PACK_CONFIG.MAX_CONTENT_LENGTH),
-            importance: 60,
-            occurred_at: d.entry_date ? new Date(d.entry_date).toISOString() : d.created_at,
-            source: 'diary',
-            relevance_score: computeRelevanceScore(
-              { importance: 60, occurred_at: d.entry_date || d.created_at, content },
-              query, hits.length
-            ),
-          });
-        }
-      }
-
-      // Process diary_entries (Lovable) — table may not exist
-      if (lovableResp && lovableResp.ok) {
-        const lovableData = await lovableResp.json() as Array<{
-          id: string;
-          text: string;
-          source: string;
-          tags: string[];
-          created_at: string;
-        }>;
-
-        // Deduplicate by ID (in case same entry exists in both tables)
-        const seenIds = new Set(hits.map(h => h.id));
-        for (const d of lovableData) {
-          if (seenIds.has(d.id)) continue;
-          const content = d.text || '';
-          hits.push({
-            id: d.id,
-            category_key: d.tags?.[0]?.replace(/-/g, '_') || 'diary',
-            content: content.substring(0, CONTEXT_PACK_CONFIG.MAX_CONTENT_LENGTH),
-            importance: 60,
-            occurred_at: d.created_at,
-            source: d.source || 'diary',
-            relevance_score: computeRelevanceScore(
-              { importance: 60, occurred_at: d.created_at, content },
-              query, hits.length
-            ),
-          });
-        }
-      }
-
-      // Sort by relevance and cap
-      hits.sort((a, b) => b.relevance_score - a.relevance_score);
-      console.log(`[VTID-01224-FIX] fetchDiaryHits: ${hits.length} diary entries found`);
-
+    const diaryBlock = pack.blocks.DIARY as DiaryBlock | undefined;
+    const entries = diaryBlock?.entries ?? [];
+    const hits: MemoryHit[] = entries.map((e, idx) => {
+      const content = e.content ?? '';
       return {
-        hits: hits.slice(0, limit),
-        latency_ms: Date.now() - startTime,
+        id: e.id,
+        category_key: e.category_key || 'diary',
+        content: content.substring(0, CONTEXT_PACK_CONFIG.MAX_CONTENT_LENGTH),
+        importance: 60,
+        occurred_at: e.occurred_at,
+        source: 'diary',
+        relevance_score: computeRelevanceScore(
+          { importance: 60, occurred_at: e.occurred_at, content },
+          query,
+          idx,
+        ),
       };
-    } finally {
-      timeout.clear();
-    }
+    });
+
+    // Sort by relevance and cap (same as legacy behaviour).
+    hits.sort((a, b) => b.relevance_score - a.relevance_score);
+    console.log(`[VTID-01224-FIX] fetchDiaryHits: ${hits.length} diary entries found`);
+
+    return {
+      hits: hits.slice(0, limit),
+      latency_ms: Date.now() - startTime,
+    };
   } catch (error: any) {
     console.error(`[VTID-01224-FIX] diary retrieval error: ${error.message}`);
     return { hits: [], latency_ms: Date.now() - startTime };
@@ -699,8 +654,17 @@ async function fetchDiaryHits(
 }
 
 /**
- * Fetch relationship graph context from relationship_nodes and relationship_edges tables
- * (written by cognee extraction pipeline). Returns human-readable relationship strings.
+ * Fetch relationship graph context. Returns human-readable strings
+ * describing the user's closest connections.
+ *
+ * VTID-03145 (PR 2): NETWORK now routed through the memory-broker
+ * boundary. The broker reads `mem_graph_edges` + `relationship_nodes`
+ * via the approved `getSupabase()` helper. The legacy
+ * `relationship_edges` direct read is dropped: `mem_graph_edges` is
+ * the canonical Phase 5/6 schema for relationship traversal (audit
+ * 2026-05-22, CPB-5). The output array shape (string[]) is unchanged;
+ * each string is now centred on the user-vs-other-side of an edge
+ * (the broker resolves the "other side" already).
  */
 async function fetchRelationshipContext(
   lens: ContextLens,
@@ -709,74 +673,26 @@ async function fetchRelationshipContext(
   const startTime = Date.now();
 
   try {
-    const SUPABASE_URL = process.env.SUPABASE_URL;
-    const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
-
-    if (!SUPABASE_URL || !SUPABASE_SERVICE_ROLE) {
-      return { context: [], latency_ms: Date.now() - startTime };
-    }
-
     if (!lens.tenant_id || !lens.user_id) {
       return { context: [], latency_ms: Date.now() - startTime };
     }
 
-    const headers = {
-      'Content-Type': 'application/json',
-      apikey: SUPABASE_SERVICE_ROLE,
-      Authorization: `Bearer ${SUPABASE_SERVICE_ROLE}`,
-    };
+    const pack = await getMemoryContext({
+      tenant_id: lens.tenant_id,
+      user_id: lens.user_id,
+      intent: 'social_query',
+      required_blocks: ['NETWORK'],
+    });
 
-    // Fetch nodes and edges in parallel
-    const nodesUrl = `${SUPABASE_URL}/rest/v1/relationship_nodes?select=id,title,node_type,domain,metadata&tenant_id=eq.${lens.tenant_id}&order=created_at.desc&limit=${limit}`;
-    const edgesUrl = `${SUPABASE_URL}/rest/v1/relationship_edges?select=from_node_id,to_node_id,relationship_type,strength&tenant_id=eq.${lens.tenant_id}&user_id=eq.${lens.user_id}&order=strength.desc&limit=20`;
+    const networkBlock = pack.blocks.NETWORK as NetworkBlock | undefined;
+    const people = networkBlock?.people ?? [];
+    const context: string[] = people.slice(0, limit).map(p => {
+      const edge = p.edge_type || 'connected to';
+      const name = p.display_name || p.node_id;
+      return `User ${edge}: ${name} (${p.node_type})`;
+    });
 
-    // VTID-01224-FIX: Add timeout to relationship graph fetch
-    const relTimeout = fetchWithTimeout();
-    const [nodesResponse, edgesResponse] = await Promise.all([
-      fetch(nodesUrl, { method: 'GET', headers, signal: relTimeout.signal }),
-      fetch(edgesUrl, { method: 'GET', headers, signal: relTimeout.signal }),
-    ]);
-
-    if (!nodesResponse.ok || !edgesResponse.ok) {
-      console.warn(`[VTID-01216] relationship retrieval failed: nodes=${nodesResponse.status}, edges=${edgesResponse.status}`);
-      return { context: [], latency_ms: Date.now() - startTime };
-    }
-
-    const nodes = await nodesResponse.json() as Array<{
-      id: string;
-      title: string;
-      node_type: string;
-      domain: string;
-      metadata: Record<string, unknown>;
-    }>;
-
-    const edges = await edgesResponse.json() as Array<{
-      from_node_id: string;
-      to_node_id: string;
-      relationship_type: string;
-      strength: number;
-    }>;
-
-    // Build node lookup map
-    const nodeMap = new Map<string, { title: string; node_type: string }>();
-    for (const node of nodes) {
-      nodeMap.set(node.id, { title: node.title, node_type: node.node_type });
-    }
-
-    // Map edges to human-readable strings
-    const context: string[] = edges
-      .map((edge) => {
-        const fromNode = nodeMap.get(edge.from_node_id);
-        const toNode = nodeMap.get(edge.to_node_id);
-        if (!fromNode || !toNode) return null;
-
-        return `${fromNode.node_type}: ${fromNode.title} (${edge.relationship_type}) → connected to → ${toNode.title} (${toNode.node_type})`;
-      })
-      .filter((s): s is string => s !== null);
-
-    console.log(`[VTID-01216] relationship graph returned ${context.length} connections from ${nodes.length} nodes`);
-
-    relTimeout.clear();
+    console.log(`[VTID-01216] relationship graph returned ${context.length} connections (NETWORK block)`);
     return {
       context,
       latency_ms: Date.now() - startTime,

--- a/services/gateway/test/services/decision-contract/context-pack-diary-network-structural.test.ts
+++ b/services/gateway/test/services/decision-contract/context-pack-diary-network-structural.test.ts
@@ -1,0 +1,104 @@
+// VTID-03145 (PR 2) — structural anti-regression for the
+// context-pack-builder DIARY + NETWORK Supabase boundary.
+//
+// PR 2 of the Decision-Contract Supabase Boundary Hardening sequence
+// routes the DIARY and NETWORK reads through `getMemoryContext` instead
+// of raw REST fetches. This test locks the outcome: the four table
+// names (memory_diary_entries, diary_entries, relationship_nodes,
+// relationship_edges) must no longer appear as table references inside
+// context-pack-builder.ts source code. Comment references are allowed
+// (they document why the rewrite happened); raw fetch URLs and
+// `.from('<table>')` SDK calls are not.
+//
+// If a future change reintroduces ANY of the four tables as a direct
+// read inside context-pack-builder.ts, this test fails.
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const CPB_PATH = path.resolve(
+  __dirname,
+  '../../../src/services/context-pack-builder.ts',
+);
+
+const cpbSrc = fs.readFileSync(CPB_PATH, 'utf8');
+
+// Strip ONLY line comments (`// ...`) and block comments (`/* ... */`),
+// being careful not to chew real code:
+//   - Block comments are matched lazily (`/\*[\s\S]*?\*\//`) so we don't
+//     eat across the file.
+//   - Line comments are anchored to the start-of-line or preceded by
+//     whitespace (`(^|\s)//[^\n]*`) so `://` inside URL string literals
+//     (`https://...`) and forward slashes inside import paths
+//     (`../../lib/x`) are NOT consumed.
+function stripCommentsSafely(src: string): string {
+  return src
+    .replace(/\/\*[\s\S]*?\*\//g, '')
+    .replace(/(^|\s)\/\/[^\n]*/g, '$1');
+}
+
+const cpbCode = stripCommentsSafely(cpbSrc);
+
+describe('VTID-03145 PR 2 ContextPackBuilder DIARY + NETWORK boundary', () => {
+  describe('context-pack-builder.ts has no direct reads to the four migrated tables', () => {
+    it('does not fetch from /rest/v1/memory_diary_entries', () => {
+      // Catches both `${SUPABASE_URL}/rest/v1/memory_diary_entries?...`
+      // and any `rest/v1/memory_diary_entries` variant.
+      expect(cpbCode).not.toMatch(/rest\/v1\/memory_diary_entries/);
+    });
+
+    it('does not fetch from /rest/v1/diary_entries', () => {
+      // Word-boundary-anchored so `memory_diary_entries` doesn't match.
+      expect(cpbCode).not.toMatch(/rest\/v1\/diary_entries\b/);
+    });
+
+    it('does not fetch from /rest/v1/relationship_nodes', () => {
+      expect(cpbCode).not.toMatch(/rest\/v1\/relationship_nodes/);
+    });
+
+    it('does not fetch from /rest/v1/relationship_edges', () => {
+      expect(cpbCode).not.toMatch(/rest\/v1\/relationship_edges/);
+    });
+
+    it('does not call .from("memory_diary_entries")', () => {
+      expect(cpbCode).not.toMatch(/\.from\s*\(\s*['"]memory_diary_entries['"]/);
+    });
+
+    it('does not call .from("diary_entries")', () => {
+      // Distinct from memory_diary_entries.
+      expect(cpbCode).not.toMatch(/\.from\s*\(\s*['"]diary_entries['"]/);
+    });
+
+    it('does not call .from("relationship_nodes")', () => {
+      expect(cpbCode).not.toMatch(/\.from\s*\(\s*['"]relationship_nodes['"]/);
+    });
+
+    it('does not call .from("relationship_edges")', () => {
+      expect(cpbCode).not.toMatch(/\.from\s*\(\s*['"]relationship_edges['"]/);
+    });
+  });
+
+  describe('context-pack-builder.ts routes DIARY + NETWORK through memory-broker', () => {
+    it('imports getMemoryContext from memory-broker', () => {
+      // Either the existing dynamic import inside fetchMemoryHitsViaBroker
+      // OR the new top-level import — at least one must be present.
+      expect(cpbCode).toMatch(
+        /(import\s*\{[^}]*\bgetMemoryContext\b[^}]*\}\s*from\s*['"]\.\/memory-broker['"]|await\s+import\s*\(\s*['"]\.\/memory-broker['"]\s*\))/,
+      );
+    });
+
+    it('passes required_blocks: [\'DIARY\'] for the diary fetcher', () => {
+      // The broker is the only diary source after PR 2.
+      expect(cpbCode).toMatch(/required_blocks:\s*\[\s*['"]DIARY['"]\s*\]/);
+    });
+
+    it('passes required_blocks: [\'NETWORK\'] for the relationship fetcher', () => {
+      expect(cpbCode).toMatch(/required_blocks:\s*\[\s*['"]NETWORK['"]\s*\]/);
+    });
+
+    it('fetchDiaryHits + fetchRelationshipContext are still exported under the same names', () => {
+      expect(cpbCode).toMatch(/async\s+function\s+fetchDiaryHits\s*\(/);
+      expect(cpbCode).toMatch(/async\s+function\s+fetchRelationshipContext\s*\(/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

PR 2 of the **Decision-Contract Supabase Boundary Hardening** sequence (audit 2026-05-22). Closes findings **CPB-4** and **CPB-5**.

- Move the diary + relationship-graph reads in `services/gateway/src/services/context-pack-builder.ts` from raw `${SUPABASE_URL}/rest/v1/<table>` fetches to the approved memory-broker boundary via `getMemoryContext({ required_blocks: ['DIARY' | 'NETWORK'] })`.
- After this PR, `context-pack-builder.ts` contains zero direct references to the four migrated tables (`memory_diary_entries`, `diary_entries`, `relationship_nodes`, `relationship_edges`).

## Tables migrated

| Block | Old (raw REST in CPB) | New (broker, behind `getSupabase()`) |
|---|---|---|
| DIARY | `memory_diary_entries` | `memory-broker.ts:fetchDiaryBlock` |
| DIARY | `diary_entries` (legacy) | **dropped** (see below) |
| NETWORK | `relationship_nodes` | `memory-broker.ts:fetchNetworkBlock` |
| NETWORK | `relationship_edges` | replaced by `mem_graph_edges` (canonical Phase 5/6 schema) |

## Behaviour

- `ContextPack` shape unchanged: `memory_hits` still merges structured facts + diary hits; `relationship_context` is still a `string[] | undefined`.
- `fetchDiaryHits` and `fetchRelationshipContext` signatures and sort/cap semantics preserved; `computeRelevanceScore` still drives ordering for diary hits.
- Relationship strings now read `User <edge>: <name> (<node_type>)` instead of the legacy edge-traversal `<from> → connected to → <to>`. This is the downstream-equivalent representation centred on the user (the broker resolves the "other side" of each edge). The LLM consumes these as opaque bullets in the `<relationship_graph>` section.

## Visible side-effect: legacy `diary_entries` fallback dropped

Per the audit's explicit recommendation (CPB-4) and per the PR 2 spec ("Drop the legacy `diary_entries` fallback unless a test proves it is still required"):

- No test covers the read path. Drop is safe by the contract.
- `tool_save_diary_entry` (ORB voice tool) still writes voice diaries to `diary_entries`. Those entries remain readable through `orb-memory-bridge` and the diary-streak view.
- **They no longer surface in the LLM context pack** until the write path is migrated to `memory_diary_entries`. Surface this in your head before merging if voice-diary context to the LLM matters short-term.

## Anti-regression contract

New `test/services/decision-contract/context-pack-diary-network-structural.test.ts` (12 assertions):

- `context-pack-builder.ts` contains no `rest/v1/<table>` or `.from('<table>')` references to the four migrated tables.
- The file imports `getMemoryContext` from `./memory-broker`.
- The two fetcher functions route through `getMemoryContext({ required_blocks: ['DIARY' | 'NETWORK'] })`.

If a future PR reintroduces any of the four tables as a direct read inside context-pack-builder, this test fails.

## Net diff

`context-pack-builder.ts`: -118 LoC (1837 → 1719). New test: 102 LoC.

## Out of scope

- Memory facts, episodic memory fallback, OASIS, VTID ledger reads (PRs 3-5).
- D39, D28/D38/D47/D48, onboarding templates, compatibility matrices.
- Voice-diary write-path migration (`tool_save_diary_entry` → `memory_diary_entries`) — separate concern.

## Test plan

- [x] `npm run build` clean (gateway).
- [x] `npx jest --testPathPattern="(decision-contract|context-pack|memory-broker)"` — 15/15 suites, 214/214 tests green.
- [ ] Post-deploy: gateway `/alive` returns 200 application/json. (Pure refactor; no new routes.)

🤖 Generated with [Claude Code](https://claude.com/claude-code)