### PR TITLE
fix(auth): enroll into system groups on every login, not only first (VTID-03089)

### DIFF
--- a/services/gateway/src/routes/auth.ts
+++ b/services/gateway/src/routes/auth.ts
@@ -277,19 +277,27 @@ router.post('/login', async (req: Request, res: Response) => {
             console.warn(`[WelcomeChat] First-login failed for ${uid.slice(0, 8)}: ${err.message}`);
           });
 
-        // VTID-03089: auto-add to system groups (currently "🎆 FIRST 100", cap 100).
-        // Idempotent on chat_group_members PK.
-        addUserToSystemGroups(uid, tid, supabase as any)
-          .then(result => {
+      }
+
+      // VTID-03089: auto-add to system groups (currently "🎆 FIRST 100",
+      // cap 100). Run on EVERY login, not just first-login: users who
+      // signed up before VTID-03089 shipped already received the welcome
+      // notification, so the `count === 0` gate above would never re-fire
+      // for them and they'd never be enrolled. The function is idempotent
+      // (chat_group_members PK + silent cap_reached skip), so re-running
+      // on every login is safe and cheap.
+      addUserToSystemGroups(uid, tid, supabase as any)
+        .then(result => {
+          if (result.added.length > 0) {
             console.log(
-              `[GroupEnrollment] First-login for ${uid.slice(0, 8)}: ` +
+              `[GroupEnrollment] Login for ${uid.slice(0, 8)}: ` +
               `added=${result.added.length}, skipped=${result.skipped.length}`
             );
-          })
-          .catch(err => {
-            console.warn(`[GroupEnrollment] First-login failed for ${uid.slice(0, 8)}: ${err.message}`);
-          });
-      }
+          }
+        })
+        .catch(err => {
+          console.warn(`[GroupEnrollment] Login enroll failed for ${uid.slice(0, 8)}: ${err.message}`);
+        });
     }
 
     return res.status(200).json({


### PR DESCRIPTION
## Summary

🎆 FIRST 100 was stuck at the initial 69 seeded members. Root cause: `addUserToSystemGroups` lives inside the welcome-notification gate (`if (count === 0)` on line 239 of `auth.ts`). Users who signed up before VTID-03089 shipped already received `welcome_to_vitana`, so on every subsequent login the entire block (including enrollment) is skipped — they never get added to the group.

**Fix:** move the enrollment call **outside** the welcome-notification gate. The function is already idempotent:
- `(group_id, user_id)` PK on `chat_group_members` silently rejects duplicates.
- The `cap_reached` branch short-circuits without writing.

So running it on every login is safe and cheap (3 small queries). Logging tightened to only emit when something was actually added.

## Test plan

- [ ] Type-check passes (verified).
- [ ] Pre-deploy: `grep -n "addUserToSystemGroups" services/gateway/src/routes/auth.ts` shows the call OUTSIDE the `if (count === 0)` block.
- [ ] After deploy: existing users (who never got enrolled) get added on their next login — confirm via `SELECT COUNT(*) FROM chat_group_members WHERE group_id = '76964efd-ad16-4c6d-b9ea-96138758a066'` climbing past 69 once people log in.
- [ ] New signups continue to be enrolled on first login.
- [ ] Enrollment stops once the 100 cap is reached.

## Follow-up

A one-time SQL backfill should be applied via Studio to add the remaining eligible tenant users immediately rather than waiting for each to log in. I'll paste the SQL after this merges.

https://claude.ai/code/session_01DpKHvbsfz696Gv6hiXeiko

---
_Generated by [Claude Code](https://claude.ai/code/session_01DpKHvbsfz696Gv6hiXeiko)_