### PR TITLE
fix(reminders): respect user language + deep-link push to action modal

### DIFF
--- a/services/gateway/src/i18n/server-locale.ts
+++ b/services/gateway/src/i18n/server-locale.ts
@@ -1,9 +1,13 @@
 // getUserLocale — resolves a user's preferred locale from server-side state.
 //
 // Sources, in priority order:
-//   1. app_users.locale (canonical, set by /settings/Preferences profile updates)
-//   2. memory_facts where fact_key='preferred_language' (assistant-inferred)
-//   3. GATEWAY_DEFAULT_LOCALE ('de')
+//   1. app_users.locale (canonical profile column — rarely populated today)
+//   2. user_preferences.stt_language (the field the frontend Language picker
+//      actually writes, e.g. 'en-US' — this is the live source for most users)
+//   3. memory_facts where fact_key='preferred_language' (assistant-inferred)
+//   4. GATEWAY_DEFAULT_LOCALE ('de')
+//
+// normalizeLocale() collapses 'en-US' → 'en', 'de-DE' → 'de', etc.
 //
 // Results are cached in-process for 5 minutes per user to avoid hammering
 // Supabase from cron jobs that fan out over thousands of users.
@@ -34,17 +38,30 @@ export async function getUserLocale(
     if (raw) {
       resolved = normalizeLocale(raw);
     } else {
-      // Fallback: check memory_facts
-      const { data: factRow } = await supa
-        .from('memory_facts')
-        .select('fact_value')
+      // Fallback 1: user_preferences.stt_language — the column the frontend
+      // Language picker writes (e.g. 'en-US'). This is what's actually
+      // populated for most users today.
+      const { data: prefRow } = await supa
+        .from('user_preferences')
+        .select('stt_language')
         .eq('user_id', userId)
-        .eq('fact_key', 'preferred_language')
-        .order('created_at', { ascending: false })
-        .limit(1)
         .maybeSingle();
-      const factValue = (factRow as { fact_value?: string | null } | null)?.fact_value ?? null;
-      if (factValue) resolved = normalizeLocale(factValue);
+      const stt = (prefRow as { stt_language?: string | null } | null)?.stt_language ?? null;
+      if (stt) {
+        resolved = normalizeLocale(stt);
+      } else {
+        // Fallback 2: memory_facts (assistant-inferred)
+        const { data: factRow } = await supa
+          .from('memory_facts')
+          .select('fact_value')
+          .eq('user_id', userId)
+          .eq('fact_key', 'preferred_language')
+          .order('created_at', { ascending: false })
+          .limit(1)
+          .maybeSingle();
+        const factValue = (factRow as { fact_value?: string | null } | null)?.fact_value ?? null;
+        if (factValue) resolved = normalizeLocale(factValue);
+      }
     }
   } catch (e) {
     // Never block notifications on locale lookup
@@ -74,20 +91,44 @@ export async function bulkGetUserLocales(
   if (missing.length === 0) return out;
 
   try {
+    // Pass 1: app_users.locale (only counts when non-null).
     const { data } = await supa
       .from('app_users')
       .select('user_id, locale')
       .in('user_id', missing);
     const rows = (data ?? []) as Array<{ user_id: string; locale: string | null }>;
-    const seen = new Set<string>();
+    const resolvedIds = new Set<string>();
     for (const row of rows) {
-      const lc = normalizeLocale(row.locale);
-      out.set(row.user_id, lc);
-      cache.set(row.user_id, { locale: lc, expires_at: now + TTL_MS });
-      seen.add(row.user_id);
+      if (row.locale) {
+        const lc = normalizeLocale(row.locale);
+        out.set(row.user_id, lc);
+        cache.set(row.user_id, { locale: lc, expires_at: now + TTL_MS });
+        resolvedIds.add(row.user_id);
+      }
     }
+
+    // Pass 2: user_preferences.stt_language for everyone still unresolved —
+    // this is the column the frontend Language picker actually writes.
+    const stillMissing = missing.filter((uid) => !resolvedIds.has(uid));
+    if (stillMissing.length > 0) {
+      const { data: prefData } = await supa
+        .from('user_preferences')
+        .select('user_id, stt_language')
+        .in('user_id', stillMissing);
+      const prefRows = (prefData ?? []) as Array<{ user_id: string; stt_language: string | null }>;
+      for (const row of prefRows) {
+        if (row.stt_language) {
+          const lc = normalizeLocale(row.stt_language);
+          out.set(row.user_id, lc);
+          cache.set(row.user_id, { locale: lc, expires_at: now + TTL_MS });
+          resolvedIds.add(row.user_id);
+        }
+      }
+    }
+
+    // Anyone still unresolved → default.
     for (const uid of missing) {
-      if (!seen.has(uid)) {
+      if (!resolvedIds.has(uid)) {
         out.set(uid, GATEWAY_DEFAULT_LOCALE);
         cache.set(uid, { locale: GATEWAY_DEFAULT_LOCALE, expires_at: now + TTL_MS });
       }

--- a/services/gateway/src/routes/scheduled-notifications.ts
+++ b/services/gateway/src/routes/scheduled-notifications.ts
@@ -1081,7 +1081,11 @@ async function scheduleReminderFcmPush(
     data: {
       type: 'reminder.fire',
       reminder_id: row.id,
-      url: '/reminders',
+      // Deep-link to the reminder action overlay (Mark done / Snooze /
+      // Dismiss) rather than the bare list — the frontend opens
+      // ReminderInterruptOverlay when ?fire=<id> is present, matching the
+      // in-app SSE behaviour on a push click.
+      url: `/reminders?fire=${row.id}`,
       spoken_message: row.spoken_message || '',
     },
   };


### PR DESCRIPTION
## Summary

Two follow-ups from live testing of the reminder push (companion to the frontend PR in `exafyltd/vitana-v1`).

### 1. Reminder push arrived in German for an English user

`getUserLocale` resolved `app_users.locale` (rarely populated) → `memory_facts.preferred_language` → `'de'` default. The frontend Language picker actually persists the choice to **`user_preferences.stt_language`** (`en-US`, `de-DE`, …), which the gateway never read — so English users hit the German default on the localized push title (`🔔 Erinnerung`).

Fix: add `user_preferences.stt_language` as the **second** resolution source (after `app_users.locale`, before `memory_facts`) in both `getUserLocale` and `bulkGetUserLocales`. `normalizeLocale` already collapses `en-US` → `en`. This fixes **every existing user** with no frontend deploy and no DB backfill, since `stt_language` is already populated.

### 2. Push click landed on the bare list, not the action modal

The reminder push `data.url` was `/reminders`. Changed to **`/reminders?fire=<id>`** so a push click opens the same Mark-done / Snooze / Dismiss overlay as the in-app SSE path (the frontend PR handles the `?fire=` param).

## Test plan

- [ ] After deploy: set a reminder as an English user → push title reads `🔔 Reminder`, not `🔔 Erinnerung`; German user still gets `🔔 Erinnerung`.
- [ ] Gateway logs `[reminders-tick] FCM push for <id>` and the push `url` is `/reminders?fire=<id>`.
- [ ] Tapping the push opens the reminder action modal (see paired vitana-v1 PR).
- [ ] Cron fan-outs (morning briefing etc.) still resolve locale correctly via `bulkGetUserLocales` pass-2.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xjx8cwuphmFBKT1n16eSEw)_