### PR TITLE
fix(news): exclude Fight Aging! source from longevity feed

### DIFF
--- a/services/gateway/src/routes/longevity-news.ts
+++ b/services/gateway/src/routes/longevity-news.ts
@@ -11,6 +11,11 @@ import { runFetchCycle } from '../services/longevity-news-fetcher';
 const router = Router();
 const VTID = 'VTID-01900';
 
+// Sources hidden from the feed (e.g. feeds that never supply cover images,
+// leaving ugly placeholder cards). Applied at serve time so existing rows
+// are hidden too, not just newly-fetched ones.
+const EXCLUDED_SOURCES = ['Fight Aging!'];
+
 const SUPABASE_URL = process.env.SUPABASE_URL;
 const SUPABASE_SERVICE_ROLE = process.env.SUPABASE_SERVICE_ROLE;
 
@@ -49,7 +54,7 @@ async function supabaseQuery(
 router.get('/', async (_req: Request, res: Response) => {
   try {
     const { count, error } = await supabaseQuery('news_items', { select: 'id', limit: '0' });
-    res.json({ ok: true, vtid: VTID, service: 'longevity-news', total_items: count ?? 0, feeds_configured: 28, error: error || undefined });
+    res.json({ ok: true, vtid: VTID, service: 'longevity-news', total_items: count ?? 0, feeds_configured: 27, error: error || undefined });
   } catch (err: any) {
     res.status(500).json({ ok: false, error: err.message });
   }
@@ -75,7 +80,16 @@ router.get('/items', async (req: Request, res: Response) => {
     };
 
     if (tag) params['tags'] = `cs.{${tag}}`;
-    if (source) params['source_name'] = `eq.${source}`;
+    if (source) {
+      // Requested source is excluded -> nothing to show.
+      if (EXCLUDED_SOURCES.includes(source)) {
+        res.json({ ok: true, items: [], total: 0, page, limit, has_more: false });
+        return;
+      }
+      params['source_name'] = `eq.${source}`;
+    } else if (EXCLUDED_SOURCES.length > 0) {
+      params['source_name'] = `not.in.(${EXCLUDED_SOURCES.map((s) => `"${s}"`).join(',')})`;
+    }
     if (language) params['language'] = `eq.${language}`;
 
     if (from) params['published_at'] = `gte.${from}`;
@@ -105,7 +119,10 @@ router.get('/sources', async (_req: Request, res: Response) => {
     const { data, error } = await supabaseQuery('news_items', { select: 'source_name', order: 'source_name' });
     if (error) { res.status(500).json({ ok: false, error }); return; }
     const sourceCounts: Record<string, number> = {};
-    for (const row of (data || [])) { sourceCounts[row.source_name] = (sourceCounts[row.source_name] || 0) + 1; }
+    for (const row of (data || [])) {
+      if (EXCLUDED_SOURCES.includes(row.source_name)) continue;
+      sourceCounts[row.source_name] = (sourceCounts[row.source_name] || 0) + 1;
+    }
     const sources = Object.entries(sourceCounts).map(([name, count]) => ({ source_name: name, item_count: count }));
     res.json({ ok: true, sources });
   } catch (err: any) {

--- a/services/gateway/src/services/longevity-news-fetcher.ts
+++ b/services/gateway/src/services/longevity-news-fetcher.ts
@@ -32,8 +32,8 @@ let cycleInFlight = false;
 interface FeedSource { name: string; url: string; language: string; }
 
 const FEEDS: FeedSource[] = [
-  // ── English (15) ──
-  { name: 'Fight Aging!', url: 'https://www.fightaging.org/feed/', language: 'en' },
+  // ── English (14) ──
+  // 'Fight Aging!' excluded: feed never supplies cover images, leaving ugly placeholder cards.
   { name: 'Lifespan.io', url: 'https://www.lifespan.io/feed/', language: 'en' },
   { name: 'Longevity.Technology', url: 'https://longevity.technology/feed/', language: 'en' },
   { name: 'Novos Labs', url: 'https://novoslabs.com/feed/', language: 'en' },


### PR DESCRIPTION
## Summary

The **Fight Aging!** RSS feed never supplies a cover image (no enclosure / `media:*` tags, no `og:image` on its article pages), so its cards rendered with the blank placeholder background and looked broken next to other sources. Per request, this excludes the source entirely.

## Changes

- **`services/gateway/src/services/longevity-news-fetcher.ts`** — removed `Fight Aging!` from the `FEEDS` list so no new articles are ingested.
- **`services/gateway/src/routes/longevity-news.ts`** — added an `EXCLUDED_SOURCES` list and applied it at serve time:
  - `/items` now filters out excluded sources (`source_name=not.in.(...)`), so **existing** Fight Aging! rows are hidden immediately, not just future fetches. A request explicitly filtering by an excluded source returns an empty page.
  - `/sources` omits excluded sources from the source list.
  - summary `feeds_configured` count updated 28 → 27.

No DB rows were deleted — the exclusion is applied at read time, so it's fully reversible and the frontend needs no changes (it just consumes the gateway API).

## Test plan

- [ ] `GET /api/v1/longevity-news/items` no longer returns any `Fight Aging!` items
- [ ] `GET /api/v1/longevity-news/items?source=Fight Aging!` returns an empty page
- [ ] `GET /api/v1/longevity-news/sources` does not list `Fight Aging!`
- [ ] Other sources still appear normally in the feed
- [ ] Gateway typechecks/builds clean

https://claude.ai/code/session_01MXpHsY64A9ZWXhqSKsh6xd

---
_Generated by [Claude Code](https://claude.ai/code/session_01MXpHsY64A9ZWXhqSKsh6xd)_