### PR TITLE
fix(reminders): stop double push (FCM + Appilix) on reminder fire

### DIFF
--- a/services/gateway/src/routes/scheduled-notifications.ts
+++ b/services/gateway/src/routes/scheduled-notifications.ts
@@ -1092,8 +1092,28 @@ async function scheduleReminderFcmPush(
 
   try {
     const fcmSent = await sendPushToUser(row.user_id, row.tenant_id, payload, supa);
-    const appilixSent = await sendAppilixPush(row.user_id, payload);
-    console.log(`[reminders-tick] FCM push for ${row.id}: fcm=${fcmSent} appilix=${appilixSent}`);
+
+    // Avoid double-notifying. Mirrors notifyUser()'s FCM/Appilix coexistence
+    // rule: if the user has an Appilix-wrapped native token (device_label
+    // 'Appilix %'), FCM-direct already delivered to the installed app, so
+    // sending Appilix too would surface a second identical lock-screen
+    // notification. Only fire Appilix when there's no native token, or as a
+    // last resort when FCM reached zero devices (e.g. web-only token that
+    // opens the browser, not the app).
+    let appilixSent = false;
+    const { count: nativeMobileCount } = await supa
+      .from('user_device_tokens')
+      .select('*', { count: 'exact', head: true })
+      .eq('user_id', row.user_id)
+      .eq('tenant_id', row.tenant_id)
+      .like('device_label', 'Appilix %');
+    if (!nativeMobileCount) {
+      appilixSent = await sendAppilixPush(row.user_id, payload);
+    }
+    if (fcmSent === 0 && !appilixSent) {
+      appilixSent = await sendAppilixPush(row.user_id, payload);
+    }
+    console.log(`[reminders-tick] FCM push for ${row.id}: fcm=${fcmSent} appilix=${appilixSent} nativeTokens=${nativeMobileCount || 0}`);
 
     // Mark delivery_via=fcm if we sent at least one push and the row is still
     // unacked. The SSE flow may still race-deliver later — that's fine, the


### PR DESCRIPTION
## Summary

You got **two identical** lock-screen reminders ("🔔 Reminder — take medicine" ×2). Not a duplicate fire — a duplicate **delivery path**.

`scheduleReminderFcmPush` (the reminder dispatch) called **both** `sendPushToUser` (FCM-direct) **and** `sendAppilixPush` unconditionally. Your device has an Appilix-wrapped native FCM token, so FCM-direct delivered to the installed app **and** Appilix delivered to the same app → two notifications.

The central `notifyUser` dispatcher already guards against this (the BOOTSTRAP-FCM-APPILIX-COEXIST rule), but the reminder path didn't. This applies the same gate.

## Change

`scheduled-notifications.ts` → `scheduleReminderFcmPush`: only fire Appilix when the user has **no** native (`device_label 'Appilix %'`) token, or as a last resort when FCM reached zero devices (e.g. web-only token that opens the browser, not the app). Native-token users now get a single FCM-direct push.

## Verification

- ✅ `tsc` clean
- ⚠️ Live push delivery needs the gateway deploy to confirm — after deploy, fire a reminder and check you get exactly one notification; logs show `fcm=N appilix=false nativeTokens=M`.

## Test plan

- [ ] Fire a reminder on a device with the native app → **one** lock-screen notification (not two).
- [ ] Logs: `[reminders-tick] FCM push for <id>: fcm=N appilix=false nativeTokens=M` (appilix suppressed when native token present).
- [ ] A web-only user (no native token) still gets the Appilix fallback so the app is notified.


---
_Generated by [Claude Code](https://claude.ai/code/session_01Xjx8cwuphmFBKT1n16eSEw)_