### PR TITLE
feat: VTID-03152 journey foundation — persistence + unified API + landing-route

### DIFF
--- a/services/gateway/src/index.ts
+++ b/services/gateway/src/index.ts
@@ -95,6 +95,9 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   // same OASIS pipeline the gateway uses.
   const oasisEmitRouter = require('./routes/oasis-emit').default;
   const vitanaIndexRouter = require('./routes/vitana-index').default;
+  // VTID-03152 Slice B + J: unified my-journey payload + landing-route resolver.
+  const myJourneyRouter = require('./routes/my-journey').default;
+  const landingRouteRouter = require('./routes/landing-route').default;
   const orbToolRouter = require('./routes/orb-tool').default;
   const orbAgentTraceRouter = require('./routes/orb-agent-trace').default;
   const awarenessConfigRouter = require('./routes/awareness-config').default;
@@ -698,6 +701,10 @@ if (process.env.K_SERVICE === 'vitana-dev-gateway') {
   // (get_vitana_index, get_index_improvement_suggestions). Lifted from the
   // inline case bodies in orb-live.ts so both pipelines share the helper layer.
   mountRouterSync(app, '/api/v1/vitana-index', vitanaIndexRouter, { owner: 'vitana-index' });
+
+  // VTID-03152: journey-foundation endpoints.
+  mountRouterSync(app, '/api/v1/my-journey', myJourneyRouter, { owner: 'my-journey' });
+  mountRouterSync(app, '/api/v1/landing-route', landingRouteRouter, { owner: 'landing-route' });
 
   // VTID-LIVEKIT-TOOLS: dispatcher endpoint that wraps every tool whose Vertex
   // implementation is inline-only in orb-live.ts. Single POST /api/v1/orb/tool

--- a/services/gateway/src/routes/landing-route.ts
+++ b/services/gateway/src/routes/landing-route.ts
@@ -1,0 +1,167 @@
+/**
+ * VTID-03152 — Slice J: GET /api/v1/landing-route resolver.
+ *
+ * Backend resolver for the post-login default route. Returns:
+ *   { route: string, reason: string, feature_flag_enabled: boolean }
+ *
+ * Today's behaviour: post-login lands on Events & Meetups.
+ * Target behaviour (when the feature flag is on): community users in
+ * the active-journey window land on /my-journey.
+ *
+ * The frontend reads this endpoint on the login redirect and routes
+ * accordingly. While the feature flag is OFF (default), the resolver
+ * always returns the legacy route — so deploying this code is safe
+ * and doesn't change user-visible behaviour until the flag flips.
+ *
+ * Carve-outs (encoded here, not in the frontend):
+ *   - Non-community roles (admin / professional / developer) → unchanged
+ *     role-specific landing.
+ *   - Journey complete (is_past_total_days and not renewed) → legacy
+ *     route until the completion-flow slice ships.
+ *   - Journey paused → /my-journey (so the user sees the resume affordance).
+ *   - Active community journey → /my-journey.
+ *
+ * Deep-link override is the FRONTEND's responsibility: when a URL or
+ * notification deep-links to a specific surface, the frontend must
+ * respect the link and skip the resolver entirely. The resolver only
+ * decides the *default* destination when no deep-link is present.
+ */
+
+import { Router, Response } from 'express';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { requireAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
+import { getJourneyState } from '../services/journey/user-journey-service';
+
+const router = Router();
+
+const VTID = 'VTID-03152';
+const LEGACY_ROUTE = '/events';
+const JOURNEY_ROUTE = '/my-journey';
+
+function getServiceClient(): SupabaseClient | null {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+  if (!url || !key) return null;
+  return createClient(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+function flagEnabled(): boolean {
+  const raw = (process.env.LANDING_ROUTE_TO_MY_JOURNEY_ENABLED ?? '').toLowerCase();
+  return raw === '1' || raw === 'true' || raw === 'yes';
+}
+
+async function getActiveRole(client: SupabaseClient, userId: string): Promise<string | null> {
+  try {
+    const { data } = await client
+      .from('user_tenants')
+      .select('active_role, is_primary')
+      .eq('user_id', userId)
+      .order('is_primary', { ascending: false })
+      .limit(1)
+      .maybeSingle();
+    return (data?.active_role as string | undefined) ?? null;
+  } catch {
+    return null;
+  }
+}
+
+/**
+ * GET /api/v1/landing-route
+ *
+ * Auth: requires user JWT. Returns the post-login default route for the
+ * authenticated user, with a `reason` explaining the decision.
+ */
+router.get('/', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const userId = req.identity?.user_id;
+  if (!userId) {
+    return res.status(401).json({ ok: false, error: 'unauthenticated', vtid: VTID });
+  }
+
+  const flag = flagEnabled();
+
+  // When the flag is off, never change behaviour — always return legacy.
+  if (!flag) {
+    return res.status(200).json({
+      ok: true,
+      vtid: VTID,
+      route: LEGACY_ROUTE,
+      reason: 'feature_flag_off',
+      feature_flag_enabled: false,
+    });
+  }
+
+  const client = getServiceClient();
+  if (!client) {
+    return res.status(200).json({
+      ok: true,
+      vtid: VTID,
+      route: LEGACY_ROUTE,
+      reason: 'supabase_unavailable_fallback',
+      feature_flag_enabled: true,
+    });
+  }
+
+  try {
+    const role = await getActiveRole(client, userId);
+
+    // Non-community roles keep their existing landing.
+    if (role && role !== 'community') {
+      return res.status(200).json({
+        ok: true,
+        vtid: VTID,
+        route: LEGACY_ROUTE,
+        reason: `role_not_community:${role}`,
+        feature_flag_enabled: true,
+      });
+    }
+
+    const journey = await getJourneyState(client, userId);
+
+    // No journey state at all (very rare — backfill + ensure should cover
+    // everyone). Conservative fallback to legacy.
+    if (!journey) {
+      return res.status(200).json({
+        ok: true,
+        vtid: VTID,
+        route: LEGACY_ROUTE,
+        reason: 'no_journey_state',
+        feature_flag_enabled: true,
+      });
+    }
+
+    // Journey complete and not renewed — legacy until the completion flow
+    // ships.
+    if (journey.status === 'complete' || journey.is_past_total_days) {
+      return res.status(200).json({
+        ok: true,
+        vtid: VTID,
+        route: LEGACY_ROUTE,
+        reason: 'journey_past_total_days_or_complete',
+        feature_flag_enabled: true,
+      });
+    }
+
+    // Active or paused journey in the window → My Journey.
+    return res.status(200).json({
+      ok: true,
+      vtid: VTID,
+      route: JOURNEY_ROUTE,
+      reason: `journey_${journey.status}`,
+      feature_flag_enabled: true,
+    });
+  } catch (err: any) {
+    console.error('[VTID-03152] GET /landing-route unexpected:', err.message);
+    return res.status(200).json({
+      ok: true,
+      vtid: VTID,
+      route: LEGACY_ROUTE,
+      reason: 'resolver_error_fallback',
+      feature_flag_enabled: true,
+      error: err.message,
+    });
+  }
+});
+
+export default router;

--- a/services/gateway/src/routes/me.ts
+++ b/services/gateway/src/routes/me.ts
@@ -185,6 +185,21 @@ router.get('/', async (req: Request, res: Response) => {
           })
           .catch(err => console.warn(`[Calendar] Journey init failed (non-fatal): ${err.message}`));
       }).catch(err => console.error('[Calendar] Module import failed:', err.message));
+
+      // VTID-03152 Slice A: idempotently create the persistent user_journey
+      // row alongside the calendar init. Fire-and-forget; failures are
+      // non-fatal (getJourneyState() falls back to math).
+      const { getSupabase } = require('../lib/supabase');
+      const supa = getSupabase();
+      if (supa) {
+        import('../services/journey/user-journey-service').then(({ ensureUserJourneyRow }) => {
+          ensureUserJourneyRow(supa, meCtx.user_id!, { tenant_id: meCtx.tenant_id ?? null })
+            .then((created) => {
+              if (created) console.log(`[VTID-03152] user_journey row created for ${meCtx.user_id!.slice(0, 8)}`);
+            })
+            .catch((err: any) => console.warn(`[VTID-03152] ensureUserJourneyRow failed (non-fatal): ${err.message}`));
+        }).catch(err => console.error('[VTID-03152] Module import failed:', err.message));
+      }
     }
 
     return res.status(200).json({

--- a/services/gateway/src/routes/my-journey.ts
+++ b/services/gateway/src/routes/my-journey.ts
@@ -1,0 +1,130 @@
+/**
+ * VTID-03152 — Slice B: GET /api/v1/my-journey.
+ *
+ * Unified payload for the My Journey screen and the conversational
+ * decision-contract spine. One call returns everything the Slice C
+ * one-time welcome, the Slice D daily morning greeting, and the
+ * forthcoming Slice F screen need:
+ *
+ *   {
+ *     day_in_journey, total_days, days_left, plan_type, plan_summary,
+ *     status, is_first_session, last_session_date,
+ *     current_phase: { id, name, day_range, day_in_phase, days_to_next_milestone },
+ *     life_compass: { active_goal_text, pillar_focus, set_at } | null,
+ *     vitana_index: { today, tier, trend_7d } | null,
+ *   }
+ *
+ * Never breaks: every sub-fetch falls back to null on error so the
+ * payload is best-effort. The screen and the greeting renderer both
+ * handle missing fields gracefully (greeting falls back to phase-based
+ * purpose when life_compass.active_goal_text is null).
+ */
+
+import { Router, Response } from 'express';
+import { createClient, SupabaseClient } from '@supabase/supabase-js';
+import { requireAuth, AuthenticatedRequest } from '../middleware/auth-supabase-jwt';
+import { fetchVitanaIndexForProfiler, fetchLifeCompass } from '../services/user-context-profiler';
+import { getJourneyState } from '../services/journey/user-journey-service';
+
+const router = Router();
+
+const VTID = 'VTID-03152';
+
+function getServiceClient(): SupabaseClient | null {
+  const url = process.env.SUPABASE_URL;
+  const key = process.env.SUPABASE_SERVICE_ROLE_KEY || process.env.SUPABASE_SERVICE_ROLE;
+  if (!url || !key) return null;
+  return createClient(url, key, {
+    auth: { autoRefreshToken: false, persistSession: false },
+  });
+}
+
+/**
+ * GET /api/v1/my-journey
+ *
+ * Auth: requires user JWT. Returns the unified journey payload for the
+ * authenticated user.
+ */
+router.get('/', requireAuth, async (req: AuthenticatedRequest, res: Response) => {
+  const userId = req.identity?.user_id;
+  if (!userId) {
+    return res.status(401).json({ ok: false, error: 'unauthenticated', vtid: VTID });
+  }
+
+  const client = getServiceClient();
+  if (!client) {
+    return res.status(503).json({ ok: false, error: 'supabase_unavailable', vtid: VTID });
+  }
+
+  try {
+    // Run journey/index/life-compass in parallel; all are independent.
+    const [journey, indexSnapshot, lifeCompass] = await Promise.all([
+      getJourneyState(client, userId),
+      fetchVitanaIndexForProfiler(client, userId).catch(() => null),
+      fetchLifeCompass(client, userId).catch(() => null),
+    ]);
+
+    if (!journey) {
+      // Service couldn't fetch and couldn't fall back. Return a shape
+      // the frontend can render with sensible "no journey yet" copy.
+      return res.status(200).json({
+        ok: true,
+        vtid: VTID,
+        journey: null,
+        life_compass: null,
+        vitana_index: null,
+      });
+    }
+
+    const phase = journey.current_wave
+      ? {
+          id: journey.current_wave.id,
+          name: journey.current_wave.name,
+          description: journey.current_wave.description,
+          day_range: [journey.current_wave.start_day, journey.current_wave.end_day] as [number, number],
+          day_in_phase: Math.max(0, journey.day_in_journey - journey.current_wave.start_day),
+          days_to_next_milestone: Math.max(0, journey.current_wave.end_day - journey.day_in_journey),
+        }
+      : null;
+
+    return res.status(200).json({
+      ok: true,
+      vtid: VTID,
+      journey: {
+        day_in_journey: journey.day_in_journey,
+        total_days: journey.total_days,
+        days_left: journey.days_left,
+        plan_type: journey.plan_type,
+        plan_summary: journey.plan_summary,
+        status: journey.status,
+        is_first_session: journey.is_first_session,
+        last_session_date: journey.last_session_date,
+        is_past_total_days: journey.is_past_total_days,
+        current_phase: phase,
+        fallback_used: journey.fallback_used,
+      },
+      life_compass: lifeCompass
+        ? {
+            active_goal_text: lifeCompass.primary_goal,
+            pillar_focus: lifeCompass.category,
+            confidence_score: lifeCompass.confidence_score ?? null,
+          }
+        : null,
+      vitana_index: indexSnapshot
+        ? {
+            today: indexSnapshot.total,
+            tier: indexSnapshot.tier,
+            tier_framing: indexSnapshot.tier_framing,
+            trend_7d: indexSnapshot.trend_7d,
+            weakest_pillar: indexSnapshot.weakest_pillar,
+            balance_label: indexSnapshot.balance_label,
+          }
+        : null,
+    });
+  } catch (err: any) {
+    console.error('[VTID-03152] GET /my-journey unexpected:', err.message);
+    return res.status(500).json({ ok: false, error: err.message, vtid: VTID });
+  }
+});
+
+export default router;

--- a/services/gateway/src/services/journey/user-journey-service.ts
+++ b/services/gateway/src/services/journey/user-journey-service.ts
@@ -1,0 +1,276 @@
+/**
+ * VTID-03152 — Slice A: user_journey persistence layer.
+ *
+ * Source of truth for a user's journey state. Replaces the live-math
+ * `buildJourney(daysSinceSignup)` path in awareness-context.ts as the
+ * canonical reader; that math survives only as a fallback for users
+ * whose row was missed by the backfill (transition window).
+ *
+ * Slice B (GET /api/v1/my-journey) and the forthcoming conversational
+ * slices (D daily morning greeting, C one-time welcome, G milestones,
+ * H gap recovery) all consume `getJourneyState()`.
+ */
+
+import type { SupabaseClient } from '@supabase/supabase-js';
+import { DEFAULT_WAVE_CONFIG, type WaveDefinition } from '../wave-defaults';
+
+const JOURNEY_TOTAL_DAYS_DEFAULT = 90;
+const GREETING_OPENINGS_MAX = 5;
+
+export type JourneyPlanType = 'default' | 'personalized';
+export type JourneyStatus = 'active' | 'paused' | 'complete' | 'restarted';
+
+/** Persisted row (mirrors public.user_journey). */
+export interface UserJourneyRow {
+  user_id: string;
+  tenant_id: string | null;
+  started_at: string;
+  total_days: number;
+  plan_type: JourneyPlanType;
+  plan_summary: string | null;
+  current_wave_id: string | null;
+  current_milestone_id: string | null;
+  status: JourneyStatus;
+  completed_milestone_ids: string[];
+  is_first_session: boolean;
+  last_session_date: string | null;
+  last_acknowledged_day: number | null;
+  recent_greeting_openings: string[];
+  plan_negotiated_at: string | null;
+  created_at: string;
+  updated_at: string;
+}
+
+/** Computed view returned to callers. Combines the row with derived day_in_journey, current_wave, days_left. */
+export interface JourneyState {
+  user_id: string;
+  tenant_id: string | null;
+  started_at: string;
+  total_days: number;
+  plan_type: JourneyPlanType;
+  plan_summary: string | null;
+  status: JourneyStatus;
+  is_first_session: boolean;
+  last_session_date: string | null;
+  recent_greeting_openings: string[];
+  completed_milestone_ids: string[];
+  last_acknowledged_day: number | null;
+
+  // Derived:
+  day_in_journey: number;
+  days_left: number;
+  is_past_total_days: boolean;
+  current_wave: { id: string; name: string; description: string; start_day: number; end_day: number } | null;
+  /** When true the row was missing and the state was computed from the math fallback. */
+  fallback_used: boolean;
+}
+
+/** Compute day_in_journey from started_at. Floor to whole days. */
+export function computeDayInJourney(startedAt: string | Date, now: Date = new Date()): number {
+  const start = typeof startedAt === 'string' ? new Date(startedAt) : startedAt;
+  const ms = now.getTime() - start.getTime();
+  return Math.max(0, Math.floor(ms / 86_400_000));
+}
+
+/**
+ * Resolve the wave the user is in for a given day. NULL when past the
+ * configured waves.
+ *
+ * Picks the wave with the **earliest end_day** — i.e. "the phase the
+ * user is about to graduate from". This matches the existing
+ * `buildJourney` behavior in awareness-context.ts so both readers
+ * agree on which wave is "current" for the same day.
+ */
+export function resolveCurrentWave(dayInJourney: number): WaveDefinition | null {
+  const enabled = DEFAULT_WAVE_CONFIG.filter((w) => w.enabled);
+  const matching = enabled.filter(
+    (w) => dayInJourney >= w.timeline.start_day && dayInJourney <= w.timeline.end_day,
+  );
+  if (matching.length === 0) return null;
+  const sorted = [...matching].sort((a, b) => a.timeline.end_day - b.timeline.end_day);
+  return sorted[0];
+}
+
+function toState(row: UserJourneyRow, fallbackUsed = false): JourneyState {
+  const day = computeDayInJourney(row.started_at);
+  const wave = resolveCurrentWave(day);
+  const daysLeft = Math.max(0, row.total_days - day);
+  return {
+    user_id: row.user_id,
+    tenant_id: row.tenant_id,
+    started_at: row.started_at,
+    total_days: row.total_days,
+    plan_type: row.plan_type,
+    plan_summary: row.plan_summary,
+    status: row.status,
+    is_first_session: row.is_first_session,
+    last_session_date: row.last_session_date,
+    recent_greeting_openings: row.recent_greeting_openings ?? [],
+    completed_milestone_ids: row.completed_milestone_ids ?? [],
+    last_acknowledged_day: row.last_acknowledged_day,
+    day_in_journey: day,
+    days_left: daysLeft,
+    is_past_total_days: day >= row.total_days,
+    current_wave: wave
+      ? {
+          id: wave.id,
+          name: wave.name,
+          description: wave.description,
+          start_day: wave.timeline.start_day,
+          end_day: wave.timeline.end_day,
+        }
+      : null,
+    fallback_used: fallbackUsed,
+  };
+}
+
+/**
+ * Read the user_journey row, computing derived fields. When the row is
+ * missing (user predates backfill or backfill was skipped), fall back
+ * to math against app_users.created_at and return is_first_session=false.
+ *
+ * Never throws. On DB error returns null.
+ */
+export async function getJourneyState(
+  client: SupabaseClient,
+  userId: string,
+): Promise<JourneyState | null> {
+  try {
+    const { data, error } = await client
+      .from('user_journey')
+      .select(
+        'user_id, tenant_id, started_at, total_days, plan_type, plan_summary, current_wave_id, ' +
+          'current_milestone_id, status, completed_milestone_ids, is_first_session, last_session_date, ' +
+          'last_acknowledged_day, recent_greeting_openings, plan_negotiated_at, created_at, updated_at',
+      )
+      .eq('user_id', userId)
+      .maybeSingle();
+
+    if (error) {
+      console.warn(`[journey-service] getJourneyState DB error for ${userId.slice(0, 8)}:`, error.message);
+      return null;
+    }
+
+    if (data) return toState(data as unknown as UserJourneyRow);
+
+    // Fallback: synthesize from app_users.created_at.
+    const { data: userRow, error: userErr } = await client
+      .from('app_users')
+      .select('user_id, created_at')
+      .eq('user_id', userId)
+      .maybeSingle();
+    if (userErr || !userRow) return null;
+    const synth: UserJourneyRow = {
+      user_id: userRow.user_id,
+      tenant_id: null,
+      started_at: userRow.created_at,
+      total_days: JOURNEY_TOTAL_DAYS_DEFAULT,
+      plan_type: 'default',
+      plan_summary: null,
+      current_wave_id: null,
+      current_milestone_id: null,
+      status: 'active',
+      completed_milestone_ids: [],
+      is_first_session: false,
+      last_session_date: null,
+      last_acknowledged_day: null,
+      recent_greeting_openings: [],
+      plan_negotiated_at: null,
+      created_at: userRow.created_at,
+      updated_at: userRow.created_at,
+    };
+    return toState(synth, true);
+  } catch (err: any) {
+    console.warn(`[journey-service] getJourneyState unexpected for ${userId.slice(0, 8)}:`, err.message);
+    return null;
+  }
+}
+
+/**
+ * Idempotently create a user_journey row if one doesn't exist. Called on
+ * /me to seed new users. Returns true when a row was created, false when
+ * it already existed or creation was skipped.
+ */
+export async function ensureUserJourneyRow(
+  client: SupabaseClient,
+  userId: string,
+  opts: { tenant_id?: string | null; started_at?: string | Date } = {},
+): Promise<boolean> {
+  try {
+    const startedAtIso =
+      opts.started_at instanceof Date
+        ? opts.started_at.toISOString()
+        : opts.started_at ?? new Date().toISOString();
+    const { data, error } = await client
+      .from('user_journey')
+      .insert({
+        user_id: userId,
+        tenant_id: opts.tenant_id ?? null,
+        started_at: startedAtIso,
+        is_first_session: true,
+      })
+      .select('user_id')
+      .maybeSingle();
+    if (error) {
+      // 23505 = unique_violation = row already exists. Idempotent path.
+      if ((error as any).code === '23505') return false;
+      console.warn(`[journey-service] ensureUserJourneyRow error for ${userId.slice(0, 8)}:`, error.message);
+      return false;
+    }
+    return !!data;
+  } catch (err: any) {
+    console.warn(`[journey-service] ensureUserJourneyRow unexpected:`, err.message);
+    return false;
+  }
+}
+
+/**
+ * Mark the session end and update the trigger fields the conversational
+ * slices read on the next session:
+ *   - last_session_date (advances when current login is a new calendar
+ *     day in user TZ — caller passes the date string YYYY-MM-DD)
+ *   - is_first_session → false after the first session ends
+ *   - recent_greeting_openings push (capped at GREETING_OPENINGS_MAX)
+ *   - last_acknowledged_day (when caller explicitly acknowledges a milestone)
+ *
+ * All fields are optional. Never throws.
+ */
+export async function updateSessionEndState(
+  client: SupabaseClient,
+  userId: string,
+  patch: {
+    last_session_date?: string;
+    clear_first_session?: boolean;
+    pushed_greeting_opening?: string;
+    last_acknowledged_day?: number;
+  },
+): Promise<void> {
+  try {
+    const update: Record<string, unknown> = {};
+    if (patch.last_session_date) update.last_session_date = patch.last_session_date;
+    if (patch.clear_first_session) update.is_first_session = false;
+    if (typeof patch.last_acknowledged_day === 'number')
+      update.last_acknowledged_day = patch.last_acknowledged_day;
+
+    if (patch.pushed_greeting_opening) {
+      const { data: existing } = await client
+        .from('user_journey')
+        .select('recent_greeting_openings')
+        .eq('user_id', userId)
+        .maybeSingle();
+      const current: string[] =
+        (existing?.recent_greeting_openings as string[] | undefined) ?? [];
+      const next = [patch.pushed_greeting_opening, ...current].slice(0, GREETING_OPENINGS_MAX);
+      update.recent_greeting_openings = next;
+    }
+
+    if (Object.keys(update).length === 0) return;
+
+    const { error } = await client.from('user_journey').update(update).eq('user_id', userId);
+    if (error) {
+      console.warn(`[journey-service] updateSessionEndState error for ${userId.slice(0, 8)}:`, error.message);
+    }
+  } catch (err: any) {
+    console.warn(`[journey-service] updateSessionEndState unexpected:`, err.message);
+  }
+}

--- a/services/gateway/test/services/journey/user-journey-service.test.ts
+++ b/services/gateway/test/services/journey/user-journey-service.test.ts
@@ -1,0 +1,237 @@
+/**
+ * VTID-03152 — Slice A: user_journey persistence layer tests.
+ *
+ * Covers:
+ *   - computeDayInJourney pure math
+ *   - resolveCurrentWave picks the latest-start matching enabled wave
+ *   - getJourneyState happy path, missing row falls back to app_users math, DB error returns null
+ *   - ensureUserJourneyRow inserts when missing, returns false on unique_violation, returns false on other errors
+ *   - updateSessionEndState no-ops when patch is empty, pushes greeting opening capped at 5
+ */
+
+import {
+  computeDayInJourney,
+  resolveCurrentWave,
+  getJourneyState,
+  ensureUserJourneyRow,
+  updateSessionEndState,
+} from '../../../src/services/journey/user-journey-service';
+
+const FIXED_NOW = new Date('2026-06-01T12:00:00.000Z');
+
+describe('VTID-03152 user-journey-service', () => {
+  describe('computeDayInJourney', () => {
+    it('returns 0 on the same day as start', () => {
+      expect(computeDayInJourney('2026-06-01T08:00:00.000Z', FIXED_NOW)).toBe(0);
+    });
+    it('returns floor of elapsed days', () => {
+      // 14 days minus a few hours -> floor 13
+      expect(computeDayInJourney('2026-05-19T18:00:00.000Z', FIXED_NOW)).toBe(12);
+    });
+    it('returns 0 for future started_at (clamped)', () => {
+      expect(computeDayInJourney('2026-07-01T00:00:00.000Z', FIXED_NOW)).toBe(0);
+    });
+    it('handles 90+ days past start', () => {
+      // 100 days before FIXED_NOW
+      const start = new Date(FIXED_NOW.getTime() - 100 * 86_400_000).toISOString();
+      expect(computeDayInJourney(start, FIXED_NOW)).toBe(100);
+    });
+  });
+
+  describe('resolveCurrentWave', () => {
+    it('returns the earliest-ending matching wave (matches existing buildJourney behavior)', () => {
+      // Day 0: wave-1 (ends 7) is the only match → wave-1.
+      expect(resolveCurrentWave(0)?.id).toBe('wave-1');
+      // Day 5: wave-1 (0-7) AND wave-2 (1-14) match. wave-1 ends earlier → wave-1.
+      expect(resolveCurrentWave(5)?.id).toBe('wave-1');
+      // Day 14: wave-2 (1-14), wave-3 (7-30), wave-4 (14-60) match. wave-2 ends earliest → wave-2.
+      expect(resolveCurrentWave(14)?.id).toBe('wave-2');
+    });
+    it('returns null past all enabled waves', () => {
+      expect(resolveCurrentWave(120)).toBeNull();
+    });
+  });
+
+  describe('getJourneyState', () => {
+    function makeClient(opts: {
+      journeyRow?: any;
+      journeyError?: any;
+      appUserRow?: any;
+      appUserError?: any;
+    }) {
+      return {
+        from(table: string) {
+          const builder: any = {
+            select() { return builder; },
+            eq() { return builder; },
+            order() { return builder; },
+            limit() { return builder; },
+            async maybeSingle() {
+              if (table === 'user_journey') {
+                return { data: opts.journeyRow ?? null, error: opts.journeyError ?? null };
+              }
+              if (table === 'app_users') {
+                return { data: opts.appUserRow ?? null, error: opts.appUserError ?? null };
+              }
+              return { data: null, error: null };
+            },
+          };
+          return builder;
+        },
+      } as any;
+    }
+
+    it('returns derived state for a present row', async () => {
+      const start = new Date(FIXED_NOW.getTime() - 14 * 86_400_000).toISOString();
+      jest.useFakeTimers().setSystemTime(FIXED_NOW);
+      const client = makeClient({
+        journeyRow: {
+          user_id: 'u1', tenant_id: 't1', started_at: start, total_days: 90,
+          plan_type: 'default', plan_summary: null, current_wave_id: null,
+          current_milestone_id: null, status: 'active', completed_milestone_ids: [],
+          is_first_session: false, last_session_date: null, last_acknowledged_day: null,
+          recent_greeting_openings: [], plan_negotiated_at: null,
+          created_at: start, updated_at: start,
+        },
+      });
+      const state = await getJourneyState(client, 'u1');
+      expect(state).not.toBeNull();
+      expect(state!.day_in_journey).toBe(14);
+      expect(state!.days_left).toBe(76);
+      expect(state!.current_wave?.id).toBe('wave-2'); // Daily Anchors (ends 14) at day 14, matching buildJourney's earliest-end policy
+      expect(state!.fallback_used).toBe(false);
+      jest.useRealTimers();
+    });
+
+    it('falls back to app_users.created_at when journey row missing', async () => {
+      const start = new Date(FIXED_NOW.getTime() - 5 * 86_400_000).toISOString();
+      jest.useFakeTimers().setSystemTime(FIXED_NOW);
+      const client = makeClient({
+        journeyRow: null,
+        appUserRow: { user_id: 'u2', created_at: start },
+      });
+      const state = await getJourneyState(client, 'u2');
+      expect(state).not.toBeNull();
+      expect(state!.day_in_journey).toBe(5);
+      expect(state!.is_first_session).toBe(false);
+      expect(state!.fallback_used).toBe(true);
+      expect(state!.current_wave?.id).toBe('wave-1'); // day 5 → Getting Started (ends 7, earliest)
+      jest.useRealTimers();
+    });
+
+    it('returns null on DB error', async () => {
+      const client = makeClient({ journeyError: { message: 'boom' } });
+      const state = await getJourneyState(client, 'u3');
+      expect(state).toBeNull();
+    });
+
+    it('returns null when neither row is present', async () => {
+      const client = makeClient({});
+      const state = await getJourneyState(client, 'u4');
+      expect(state).toBeNull();
+    });
+  });
+
+  describe('ensureUserJourneyRow', () => {
+    it('returns true when insert succeeds', async () => {
+      const client = {
+        from(_t: string) {
+          return {
+            insert() { return this; },
+            select() { return this; },
+            async maybeSingle() { return { data: { user_id: 'u5' }, error: null }; },
+          } as any;
+        },
+      } as any;
+      const created = await ensureUserJourneyRow(client, 'u5', { tenant_id: 't1' });
+      expect(created).toBe(true);
+    });
+
+    it('returns false when insert hits unique_violation (idempotent path)', async () => {
+      const client = {
+        from(_t: string) {
+          return {
+            insert() { return this; },
+            select() { return this; },
+            async maybeSingle() {
+              return { data: null, error: { code: '23505', message: 'duplicate' } };
+            },
+          } as any;
+        },
+      } as any;
+      const created = await ensureUserJourneyRow(client, 'u6');
+      expect(created).toBe(false);
+    });
+
+    it('returns false on other DB errors', async () => {
+      const client = {
+        from(_t: string) {
+          return {
+            insert() { return this; },
+            select() { return this; },
+            async maybeSingle() {
+              return { data: null, error: { code: '42P01', message: 'no table' } };
+            },
+          } as any;
+        },
+      } as any;
+      const created = await ensureUserJourneyRow(client, 'u7');
+      expect(created).toBe(false);
+    });
+  });
+
+  describe('updateSessionEndState', () => {
+    it('does nothing on empty patch', async () => {
+      let updateCalled = false;
+      const client = {
+        from(_t: string) {
+          return {
+            update() { updateCalled = true; return this; },
+            eq() { return Promise.resolve({ error: null }); },
+          } as any;
+        },
+      } as any;
+      await updateSessionEndState(client, 'u8', {});
+      expect(updateCalled).toBe(false);
+    });
+
+    it('pushes greeting opening capped at 5', async () => {
+      const captured: Record<string, unknown> = {};
+      const client = {
+        from(_t: string) {
+          return {
+            select() { return this; },
+            eq() { return this; },
+            async maybeSingle() {
+              return { data: { recent_greeting_openings: ['o1', 'o2', 'o3', 'o4', 'o5'] }, error: null };
+            },
+            update(patch: Record<string, unknown>) {
+              Object.assign(captured, patch);
+              return { eq: () => Promise.resolve({ error: null }) };
+            },
+          } as any;
+        },
+      } as any;
+      await updateSessionEndState(client, 'u9', { pushed_greeting_opening: 'o6' });
+      expect((captured.recent_greeting_openings as string[]).length).toBe(5);
+      expect((captured.recent_greeting_openings as string[])[0]).toBe('o6');
+      expect((captured.recent_greeting_openings as string[])).not.toContain('o5');
+    });
+
+    it('clear_first_session writes is_first_session=false', async () => {
+      const captured: Record<string, unknown> = {};
+      const client = {
+        from(_t: string) {
+          return {
+            update(patch: Record<string, unknown>) {
+              Object.assign(captured, patch);
+              return { eq: () => Promise.resolve({ error: null }) };
+            },
+          } as any;
+        },
+      } as any;
+      await updateSessionEndState(client, 'u10', { clear_first_session: true });
+      expect(captured.is_first_session).toBe(false);
+    });
+  });
+});

--- a/supabase/migrations/20260603000000_VTID_03152_user_journey_table.sql
+++ b/supabase/migrations/20260603000000_VTID_03152_user_journey_table.sql
@@ -1,0 +1,115 @@
+-- VTID-03152 — Slice A: persistent user_journey table.
+--
+-- Today, journey state (current_wave, day_in_journey, is_past_90_day) is
+-- computed live in services/gateway/src/services/guide/awareness-context.ts
+-- (buildJourney) from app_users.created_at math every request. There is
+-- no persistent representation, no plan_type, no milestone progress, no
+-- anti-repetition memory for greetings, no "have we said hello today"
+-- gate, and no place to mark the journey paused / restarted / complete.
+--
+-- This migration introduces `user_journey` as the canonical source of
+-- truth for a user's journey. Slice B (GET /api/v1/my-journey) and the
+-- forthcoming conversational slices (D daily morning greeting, C one-
+-- time welcome, G milestones, H gap recovery) all read from here.
+--
+-- Design notes:
+--   - One row per user (PK = user_id). No tenant FK on the row — we read
+--     tenant via user_tenants.active_role at query time.
+--   - Schema is additive. The legacy buildJourney() math still works as
+--     a fallback in the service layer if a row is missing (transition
+--     period for any user the backfill misses).
+--   - Backfill seeds is_first_session=false for all existing users
+--     (they've already had sessions; the one-time welcome should not
+--     fire retroactively). Slice C will only fire for users whose
+--     first /me call happens AFTER this migration.
+
+BEGIN;
+
+CREATE TABLE IF NOT EXISTS public.user_journey (
+  user_id                  UUID PRIMARY KEY REFERENCES public.app_users(user_id) ON DELETE CASCADE,
+  tenant_id                UUID,
+  started_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+  total_days               INT NOT NULL DEFAULT 90,
+  plan_type                TEXT NOT NULL DEFAULT 'default'
+                             CHECK (plan_type IN ('default','personalized')),
+  plan_summary             TEXT,
+  current_wave_id          TEXT,
+  current_milestone_id     TEXT,
+  status                   TEXT NOT NULL DEFAULT 'active'
+                             CHECK (status IN ('active','paused','complete','restarted')),
+  completed_milestone_ids  TEXT[] NOT NULL DEFAULT '{}',
+  is_first_session         BOOLEAN NOT NULL DEFAULT true,
+  last_session_date        DATE,
+  last_acknowledged_day    INT,
+  recent_greeting_openings TEXT[] NOT NULL DEFAULT '{}',
+  plan_negotiated_at       TIMESTAMPTZ,
+  created_at               TIMESTAMPTZ NOT NULL DEFAULT now(),
+  updated_at               TIMESTAMPTZ NOT NULL DEFAULT now()
+);
+
+COMMENT ON TABLE  public.user_journey IS
+  'VTID-03152: persistent journey state. One row per user. Slice A of the journey-as-spine plan.';
+COMMENT ON COLUMN public.user_journey.plan_type IS
+  'default = 90-day plan Vitana prepared; personalized = user negotiated a custom plan with Vitana (Slice E).';
+COMMENT ON COLUMN public.user_journey.plan_summary IS
+  '2-sentence summary stored by Slice E plan negotiation. NULL for default plans.';
+COMMENT ON COLUMN public.user_journey.is_first_session IS
+  'Trigger gate for the one-time first-session welcome (Slice C). Cleared at end of first session.';
+COMMENT ON COLUMN public.user_journey.last_session_date IS
+  'Date (in user TZ) of last completed session. Triggers daily morning greeting (Slice D) when current login date > this.';
+COMMENT ON COLUMN public.user_journey.recent_greeting_openings IS
+  'Anti-repetition memory for daily greetings. Capped at 5 entries by the service layer.';
+
+CREATE INDEX IF NOT EXISTS user_journey_status_active_idx
+  ON public.user_journey(status) WHERE status = 'active';
+CREATE INDEX IF NOT EXISTS user_journey_tenant_idx
+  ON public.user_journey(tenant_id) WHERE tenant_id IS NOT NULL;
+CREATE INDEX IF NOT EXISTS user_journey_last_session_idx
+  ON public.user_journey(last_session_date) WHERE last_session_date IS NOT NULL;
+
+CREATE OR REPLACE FUNCTION public.user_journey_touch_updated_at()
+  RETURNS TRIGGER AS $$
+BEGIN
+  NEW.updated_at = now();
+  RETURN NEW;
+END;
+$$ LANGUAGE plpgsql;
+
+DROP TRIGGER IF EXISTS user_journey_updated_at_trigger ON public.user_journey;
+CREATE TRIGGER user_journey_updated_at_trigger
+  BEFORE UPDATE ON public.user_journey
+  FOR EACH ROW
+  EXECUTE FUNCTION public.user_journey_touch_updated_at();
+
+ALTER TABLE public.user_journey ENABLE ROW LEVEL SECURITY;
+
+DROP POLICY IF EXISTS user_journey_select_own ON public.user_journey;
+CREATE POLICY user_journey_select_own ON public.user_journey
+  FOR SELECT TO authenticated USING (user_id = auth.uid());
+
+DROP POLICY IF EXISTS user_journey_update_own ON public.user_journey;
+CREATE POLICY user_journey_update_own ON public.user_journey
+  FOR UPDATE TO authenticated USING (user_id = auth.uid()) WITH CHECK (user_id = auth.uid());
+
+-- service_role bypasses RLS; the gateway writes via service_role.
+
+-- ============================================================
+-- Backfill existing users.
+-- is_first_session = false so the one-time welcome (Slice C) does NOT
+-- fire retroactively for users who have already used the platform.
+-- ============================================================
+INSERT INTO public.user_journey (user_id, tenant_id, started_at, is_first_session)
+SELECT
+  u.user_id,
+  ut.tenant_id,
+  COALESCE(u.created_at, now()),
+  false
+FROM public.app_users u
+LEFT JOIN LATERAL (
+  SELECT tenant_id FROM public.user_tenants
+   WHERE user_id = u.user_id AND is_primary = true
+   ORDER BY created_at ASC LIMIT 1
+) ut ON true
+ON CONFLICT (user_id) DO NOTHING;
+
+COMMIT;


### PR DESCRIPTION
## Summary

Foundation PR for the "My Journey as engagement spine" plan. Three slices shipped together because B and J both depend on A; the conversational slices (C / D / E / G / H / I) and the screen (F) all consume what's built here.

### Slice A — Journey persistence layer
- New `public.user_journey` table (one row per user) with `started_at`, `total_days` (default 90), `plan_type`, `plan_summary`, `current_wave_id`, `status`, `completed_milestone_ids[]`, `is_first_session`, `last_session_date`, `last_acknowledged_day`, `recent_greeting_openings[]` (capped at 5).
- Backfill seeds `is_first_session=false` for all existing users so the forthcoming Slice C one-time welcome does NOT fire retroactively.
- New `services/gateway/src/services/journey/user-journey-service.ts`:
  - `getJourneyState` — reads the row, computes derived fields (`day_in_journey`, `days_left`, `current_wave`), and falls back to `app_users.created_at` math if the row is missing. Never throws.
  - `ensureUserJourneyRow` — idempotent insert (handles unique_violation `23505`).
  - `updateSessionEndState` — advances `last_session_date`, clears `is_first_session`, pushes a greeting opening capped at 5.
- `resolveCurrentWave` matches the existing `buildJourney` semantics (earliest-end wave = "the phase the user is about to graduate from") so both readers agree on the same day.
- `/me` hook: idempotent `ensureUserJourneyRow` call alongside the existing `initializeJourneyCalendar`. Fire-and-forget; failures are non-fatal.

### Slice B — Unified `GET /api/v1/my-journey`
Single payload powering the My Journey screen and the conversational decision-contract spine. Returns:
```
{
  journey: { day_in_journey, total_days, days_left, plan_type, plan_summary,
             status, is_first_session, last_session_date, is_past_total_days,
             current_phase: { id, name, description, day_range,
                              day_in_phase, days_to_next_milestone },
             fallback_used },
  life_compass: { active_goal_text, pillar_focus, confidence_score } | null,
  vitana_index: { today, tier, tier_framing, trend_7d, weakest_pillar, balance_label } | null
}
```
Parallel sub-fetches; per-fetch errors return null fields rather than failing the whole payload.

### Slice J — `GET /api/v1/landing-route` resolver (feature-flagged OFF)
- Returns `{ route, reason, feature_flag_enabled }`.
- Default behavior = legacy `/events` until env `LANDING_ROUTE_TO_MY_JOURNEY_ENABLED=true` flips behavior. **Deploying this PR does NOT change user-visible routing**; it ships the resolver behind the flag.
- Carve-outs encoded server-side: non-community roles unchanged; journey complete / past `total_days` → legacy; active or paused community journey → `/my-journey`. Deep-link override is the frontend's responsibility.

## Test plan

- [x] `npm run build` clean
- [x] 16 new unit tests in `test/services/journey/user-journey-service.test.ts` — all green
- [x] 78 regression tests across `test/orb/teacher/` + `test/services/journey-stage/` — all green
- [ ] Apply migration via RUN-MIGRATION.yml before merge
- [ ] EXEC-DEPLOY green
- [ ] Post-deploy smoke: `curl /api/v1/my-journey` (with test user JWT) → JSON shape; `curl /api/v1/landing-route` → `{ route: "/events", reason: "feature_flag_off" }` until flag flips

## What this does NOT do (deferred)

- Slice C (one-time welcome wiring) — system-instruction contract block.
- Slice D (daily morning greeting + `journey_position` decision-contract provider).
- Slice E (personalization / custom plan negotiation).
- Slice F (My Journey screen visuals) — separate session per founder's request.
- Slice G/H (milestone celebration / gap recovery).
- Slice I (phase-scoped Teacher Mode).

Generated with [Claude Code](https://claude.com/claude-code)