### PR TITLE
test(context-pack): anti-regression for CPB-4/5 broker boundary (VTID-03153)

### DIFF
--- a/services/gateway/src/services/context-pack-builder.ts
+++ b/services/gateway/src/services/context-pack-builder.ts
@@ -586,8 +586,13 @@ async function fetchMemoryFacts(
 /**
  * VTID-01224-FIX: Fetch diary entries to surface in the LLM context pack.
  *
- * VTID-03145 (PR 2): now routed through the memory-broker boundary.
- * The broker owns the canonical DIARY stream (`memory_diary_entries`).
+ * VTID-03145 (PR 2): routed through the memory-broker DIARY block —
+ * raw table reads no longer live in this file. The broker owns the
+ * canonical diary stream.
+ *
+ * VTID-03153 (CPB-4 anti-regression): forbidden table names are
+ * intentionally absent from this file. Reintroducing them is caught
+ * by `test/services/context-pack-broker-boundary.test.ts`.
  *
  * Results are returned as MemoryHit[] to merge with other memory hits.
  */
@@ -603,15 +608,11 @@ async function fetchDiaryHits(
       return { hits: [], latency_ms: Date.now() - startTime };
     }
 
-    // VTID-03145 (PR 2): DIARY now routed through the memory-broker
-    // boundary. The broker reads `memory_diary_entries` via the
-    // approved `getSupabase()` helper. The legacy `diary_entries`
-    // table read is dropped here — context-pack alignment with the
-    // broker's canonical-table decision (audit 2026-05-22, CPB-4).
-    // Voice-saved diary entries written via tool_save_diary_entry
-    // into `diary_entries` remain readable through orb-memory-bridge;
-    // they no longer surface in the LLM context pack until the write
-    // path is migrated to `memory_diary_entries`.
+    // VTID-03145 (PR 2): DIARY routed through the memory-broker. The
+    // broker owns the canonical diary store. The legacy alternative
+    // diary store (voice tool_save_diary_entry write path) is no
+    // longer mirrored into the context pack here; that bridge moves
+    // when the write path is unified upstream.
     const pack = await getMemoryContext({
       tenant_id: lens.tenant_id,
       user_id: lens.user_id,
@@ -657,14 +658,16 @@ async function fetchDiaryHits(
  * Fetch relationship graph context. Returns human-readable strings
  * describing the user's closest connections.
  *
- * VTID-03145 (PR 2): NETWORK now routed through the memory-broker
- * boundary. The broker reads `mem_graph_edges` + `relationship_nodes`
- * via the approved `getSupabase()` helper. The legacy
- * `relationship_edges` direct read is dropped: `mem_graph_edges` is
- * the canonical Phase 5/6 schema for relationship traversal (audit
- * 2026-05-22, CPB-5). The output array shape (string[]) is unchanged;
- * each string is now centred on the user-vs-other-side of an edge
- * (the broker resolves the "other side" already).
+ * VTID-03145 (PR 2): NETWORK routed through the memory-broker NETWORK
+ * block. The broker owns the canonical graph traversal; this file
+ * does not name graph tables anymore. The output array shape
+ * (string[]) is unchanged; each string is now centred on the user-
+ * vs-other-side of an edge (the broker resolves the "other side"
+ * already).
+ *
+ * VTID-03153 (CPB-5 anti-regression): forbidden table names are
+ * intentionally absent from this file; see
+ * `test/services/context-pack-broker-boundary.test.ts`.
  */
 async function fetchRelationshipContext(
   lens: ContextLens,

--- a/services/gateway/test/services/context-pack-broker-boundary.test.ts
+++ b/services/gateway/test/services/context-pack-broker-boundary.test.ts
@@ -1,0 +1,74 @@
+// VTID-03153 — anti-regression closeout for VTID-03145 (PR #2313),
+// which routed the DIARY and NETWORK blocks in context-pack-builder.ts
+// through the memory-broker boundary instead of raw Supabase fetches.
+//
+// This test asserts the structural contract for CPB-4 + CPB-5:
+// `context-pack-builder.ts` may not name the four canonical broker-
+// owned tables anywhere in its source (code OR comments). Even in
+// comments, those strings are a tripwire for someone copy-pasting an
+// old direct-read block back in. Adding them must be an explicit
+// audit decision, not an accident.
+//
+// Forbidden substrings:
+//   - memory_diary_entries
+//   - diary_entries
+//   - relationship_nodes
+//   - relationship_edges
+//
+// Companion positive contract: the file must continue to use
+// `getMemoryContext({ required_blocks: ['DIARY' | 'NETWORK'] })` for
+// these blocks. That import + call shape is the broker boundary.
+
+import * as fs from 'fs';
+import * as path from 'path';
+
+const CPB_PATH = path.resolve(
+  __dirname,
+  '../../src/services/context-pack-builder.ts',
+);
+
+describe('VTID-03153 CPB-4/5 broker boundary — anti-regression', () => {
+  let src: string;
+  beforeAll(() => {
+    src = fs.readFileSync(CPB_PATH, 'utf8');
+  });
+
+  describe('no direct references to broker-owned tables', () => {
+    // These are the four substrings the audit (2026-05-22) flagged.
+    // Re-introducing any of them in context-pack-builder.ts means the
+    // file is reading a table the memory-broker owns — i.e. the
+    // boundary has been re-broken.
+    const FORBIDDEN: string[] = [
+      'memory_diary_entries',
+      'diary_entries',
+      'relationship_nodes',
+      'relationship_edges',
+    ];
+
+    for (const term of FORBIDDEN) {
+      it(`does not mention "${term}"`, () => {
+        expect(src).not.toMatch(new RegExp(term));
+      });
+    }
+  });
+
+  describe('positive contract — DIARY and NETWORK go through getMemoryContext', () => {
+    it('imports getMemoryContext from memory-broker', () => {
+      expect(src).toMatch(/from\s+['"]\.\/memory-broker['"]/);
+      expect(src).toMatch(/getMemoryContext/);
+    });
+
+    it('requests the DIARY block via required_blocks', () => {
+      expect(src).toMatch(/required_blocks\s*:\s*\[\s*['"]DIARY['"]\s*\]/);
+    });
+
+    it('requests the NETWORK block via required_blocks', () => {
+      expect(src).toMatch(/required_blocks\s*:\s*\[\s*['"]NETWORK['"]\s*\]/);
+    });
+
+    it('imports DiaryBlock and NetworkBlock types', () => {
+      expect(src).toMatch(/DiaryBlock/);
+      expect(src).toMatch(/NetworkBlock/);
+    });
+  });
+});


### PR DESCRIPTION
## Summary

Closeout for VTID-03145 (PR #2313, "feat(context-pack): route DIARY + NETWORK through memory-broker"), which shipped the routing logic but did not add the structural anti-regression test the audit called for and did not strip residual references to the four broker-owned table names from comments.

## What this PR does

1. **Removes the four forbidden table-name substrings from comments** in `context-pack-builder.ts`. The behavioural / explanatory intent is preserved; only the tripwire substrings are gone.
2. **Adds `test/services/context-pack-broker-boundary.test.ts`** with two contracts:
   - **negative**: `context-pack-builder.ts` must not name any of `memory_diary_entries`, `diary_entries`, `relationship_nodes`, `relationship_edges` anywhere in the source. Re-introducing any of them = the boundary is broken (copy-pasted direct read).
   - **positive**: the file continues to import `getMemoryContext` from `./memory-broker`, requests `required_blocks: ['DIARY']` and `['NETWORK']`, and imports `DiaryBlock` + `NetworkBlock` types.

## Why an anti-regression test

Direct table reads are easy to bring back by accident (copy-paste from another file, rebase against a stale branch, etc). The DIARY + NETWORK boundaries are documented invariants — this test makes them executable.

## Scope discipline

Per the PR-2 brief: touched only `context-pack-builder.ts` + a new test file. Did **not** touch memory_facts, episodic-memory fallback, OASIS / VTID ledger, D39, onboarding templates, D28/D38/D47/D48, or the wider boundary cleanup.

ContextPack shape and fallback behaviour unchanged — no runtime code in CPB changed in this PR (the routing logic already lives on main from #2313).

## Test plan

- [x] `npm run build` clean
- [x] `npx jest test/services/context-pack-broker-boundary.test.ts` 8/8 pass
- [ ] Auto-deploy + `/alive` 200 JSON

🤖 Generated with [Claude Code](https://claude.com/claude-code)